### PR TITLE
feat(explain): render blocked view bodies as CO-ROUTINE blocks in EQP

### DIFF
--- a/crates/vibesql-executor/src/explain.rs
+++ b/crates/vibesql-executor/src/explain.rs
@@ -192,15 +192,10 @@ impl ExplainResult {
         // Add "QUERY PLAN" header to match SQLite's EQP format
         writeln!(output, "QUERY PLAN").unwrap();
 
-        // Check if this is a compound query
-        if self.plan.is_compound_query {
-            format_compound_query_eqp(&self.plan, "", true, &mut output);
-        } else {
-            // Collect all EQP entries (scan nodes, CO-ROUTINE blocks, temp
-            // b-tree entries) and render the tree.
-            let entries = collect_eqp_entries(&self.plan);
-            write_eqp_entries(&entries, "", &mut output);
-        }
+        // Collect all EQP entries (scan nodes, CO-ROUTINE blocks, COMPOUND
+        // QUERY blocks, temp b-tree entries) and render the tree.
+        let entries = collect_eqp_entries(&self.plan);
+        write_eqp_entries(&entries, "", &mut output);
 
         output
     }
@@ -542,6 +537,19 @@ fn append_scan_entries(node: &PlanNode, entries: &mut Vec<EqpEntry>) {
         return;
     }
 
+    // Compound (UNION/INTERSECT/EXCEPT) roots render as a nested
+    // `COMPOUND QUERY` block. This both drives the top-level rendering in
+    // `to_sqlite_eqp` and lets compound view/subquery bodies nest inside
+    // `CO-ROUTINE` blocks (#5361), matching SQLite's shape:
+    //   |--CO-ROUTINE cv
+    //   |  `--COMPOUND QUERY
+    //   |     |--LEFT-MOST SUBQUERY
+    //   ...
+    if node.is_compound_query {
+        entries.push(compound_eqp_entry(node));
+        return;
+    }
+
     if node.scan_type.is_some() {
         entries.push(EqpEntry::leaf(format_sqlite_eqp_node(node)));
     }
@@ -549,6 +557,27 @@ fn append_scan_entries(node: &PlanNode, entries: &mut Vec<EqpEntry>) {
     for child in &node.children {
         append_scan_entries(child, entries);
     }
+}
+
+/// Build the `COMPOUND QUERY` entry tree for a compound-query plan root:
+/// a `LEFT-MOST SUBQUERY` child for the first branch, then one child per
+/// set operation (`UNION`, `UNION ALL`, `INTERSECT`, `EXCEPT`, ...), each
+/// containing that branch's scan entries.
+fn compound_eqp_entry(node: &PlanNode) -> EqpEntry {
+    let mut children = Vec::new();
+    for (i, branch) in node.children.iter().enumerate() {
+        let label = if i == 0 {
+            "LEFT-MOST SUBQUERY".to_string()
+        } else {
+            branch.set_operation_type.clone().unwrap_or_else(|| "UNION ALL".to_string())
+        };
+        let scans = collect_scan_nodes(branch)
+            .into_iter()
+            .map(|scan| EqpEntry::leaf(format_sqlite_eqp_node(scan)))
+            .collect();
+        children.push(EqpEntry { text: label, children: scans });
+    }
+    EqpEntry { text: "COMPOUND QUERY".to_string(), children }
 }
 
 /// True when any node in `node`'s subtree needs a temp B-tree for ORDER BY.
@@ -598,69 +627,12 @@ fn collect_eqp_entries(node: &PlanNode) -> Vec<EqpEntry> {
     entries
 }
 
-/// Format a compound query in SQLite EQP style
-fn format_compound_query_eqp(node: &PlanNode, indent: &str, is_last: bool, output: &mut String) {
-    let connector = if is_last { "`--" } else { "|--" };
-    let child_indent = if is_last { format!("{}   ", indent) } else { format!("{}|  ", indent) };
-
-    // Write COMPOUND QUERY header
-    writeln!(output, "{}{}COMPOUND QUERY", indent, connector).unwrap();
-
-    // Write compound query children
-    let child_count = node.children.len();
-    for (i, child) in node.children.iter().enumerate() {
-        let is_child_last = i == child_count - 1;
-        let child_connector = if is_child_last { "`--" } else { "|--" };
-        let grandchild_indent = if is_child_last {
-            format!("{}   ", child_indent)
-        } else {
-            format!("{}|  ", child_indent)
-        };
-
-        if i == 0 {
-            // First subquery
-            writeln!(output, "{}{}LEFT-MOST SUBQUERY", child_indent, child_connector).unwrap();
-            // Write scan nodes for this subquery
-            let scan_nodes = collect_scan_nodes(child);
-            for (j, scan_node) in scan_nodes.iter().enumerate() {
-                let is_scan_last = j == scan_nodes.len() - 1;
-                let scan_connector = if is_scan_last { "`--" } else { "|--" };
-                writeln!(
-                    output,
-                    "{}{}{}",
-                    grandchild_indent,
-                    scan_connector,
-                    format_sqlite_eqp_node(scan_node)
-                )
-                .unwrap();
-            }
-        } else {
-            // Subsequent parts with set operation label
-            let set_op = child.set_operation_type.as_deref().unwrap_or("UNION ALL");
-            writeln!(output, "{}{}{}", child_indent, child_connector, set_op).unwrap();
-            // Write scan nodes for this subquery
-            let scan_nodes = collect_scan_nodes(child);
-            for (j, scan_node) in scan_nodes.iter().enumerate() {
-                let is_scan_last = j == scan_nodes.len() - 1;
-                let scan_connector = if is_scan_last { "`--" } else { "|--" };
-                writeln!(
-                    output,
-                    "{}{}{}",
-                    grandchild_indent,
-                    scan_connector,
-                    format_sqlite_eqp_node(scan_node)
-                )
-                .unwrap();
-            }
-        }
-    }
-}
-
 /// Format a single node in SQLite EQP style
 fn format_sqlite_eqp_node(node: &PlanNode) -> String {
-    // Handle constant row scan (no FROM clause)
-    if node.operation == "SCAN CONSTANT ROW" {
-        return "SCAN CONSTANT ROW".to_string();
+    // Handle constant row scan (no FROM clause / VALUES), e.g.
+    // `SCAN CONSTANT ROW` or `SCAN 2 CONSTANT ROWS`.
+    if node.operation == "SCAN CONSTANT ROW" || node.operation.ends_with("CONSTANT ROWS") {
+        return node.operation.clone();
     }
 
     let table_name = node.object.as_deref().unwrap_or("?");
@@ -864,10 +836,16 @@ impl ExplainExecutor {
             )?;
             root.add_child(scan_node);
         } else {
-            // No FROM clause - this is a constant expression scan
+            // No FROM clause - this is a constant expression scan. Multi-row
+            // VALUES bodies render SQLite's plural `SCAN <n> CONSTANT ROWS`;
+            // a single row (or a plain FROM-less SELECT) keeps the singular
+            // `SCAN CONSTANT ROW` (verified against sqlite3 3.51.0, #5361).
             let mut constant_node = PlanNode::new("Constant Row");
             constant_node.scan_type = Some(ScanType::Scan);
-            constant_node.operation = "SCAN CONSTANT ROW".to_string();
+            constant_node.operation = match &stmt.values {
+                Some(rows) if rows.len() > 1 => format!("SCAN {} CONSTANT ROWS", rows.len()),
+                _ => "SCAN CONSTANT ROW".to_string(),
+            };
             root.add_child(constant_node);
         }
 
@@ -1211,11 +1189,10 @@ impl ExplainExecutor {
     ///
     /// Mirrors SQLite's query-flattener blocking conditions conservatively:
     /// aggregates, GROUP BY/HAVING, DISTINCT, LIMIT/OFFSET, compound bodies,
-    /// VALUES, and WITH clauses all keep the pre-existing opaque
-    /// `SCAN <view>` rendering (SQLite materializes/co-routines these;
-    /// VibeSQL keeps the conservative opaque line rather than guessing —
-    /// follow-on work can add CO-ROUTINE blocks case by case). Window
-    /// functions are handled separately by the CO-ROUTINE path (#5347).
+    /// VALUES, and WITH clauses all render as `CO-ROUTINE <view>` blocks
+    /// showing the body's inner plan (#5361) — truthful because the runtime
+    /// materializes every view body. Window functions take the same
+    /// CO-ROUTINE path (#5347).
     fn view_body_is_flattenable(stmt: &SelectStmt) -> bool {
         let select_list_has_aggregate = stmt.select_list.iter().any(|item| match item {
             SelectItem::Expression { expr, .. } => contains_aggregate_function(expr),
@@ -1253,9 +1230,17 @@ impl ExplainExecutor {
                 // `SCAN <view>`. CTE names shadow same-named views and are
                 // never expanded.
                 //
-                // - Window-function views (#5347): SQLite cannot flatten
+                // - Window-function views (#5347) and blocked bodies —
+                //   aggregates, GROUP BY/HAVING, DISTINCT, LIMIT/OFFSET,
+                //   compound, VALUES, WITH (#5361): SQLite cannot flatten
                 //   them, so the body's plan renders as a CO-ROUTINE block
-                //   plus a trailing `SCAN <name>` (windowpushd.test 2.1.3.6).
+                //   plus a trailing `SCAN <name>` (windowpushd.test 2.1.3.6;
+                //   sqlite3 3.51.0 verified per category). VibeSQL's runtime
+                //   materializes every view body, so the block + inner plan
+                //   is truthful even where SQLite manages to flatten a
+                //   specific shape (LIMIT-only bodies, UNION ALL bodies,
+                //   single-use plain CTEs — documented divergences in
+                //   explain_view_expansion_tests.rs).
                 // - Plain flattenable views (#5355): SQLite inlines the body
                 //   into the outer query and shows the underlying table
                 //   access with no mention of the view. VibeSQL's runtime
@@ -1266,25 +1251,24 @@ impl ExplainExecutor {
                 //   push-down (`SEARCH <table> (x=?)`) because no index
                 //   probe happens at runtime. Where no index applies the
                 //   output matches SQLite exactly (`SCAN <table>`).
-                // - Blocked bodies (aggregate/GROUP BY/DISTINCT/LIMIT/
-                //   compound/...) keep the opaque rendering.
                 if !ctes.contains(&name.to_ascii_lowercase()) {
                     if let Some(view) = database.catalog.get_view(name) {
-                        if Self::select_has_window_functions(&view.query) {
-                            let source = alias.as_deref().unwrap_or(name.as_str());
-                            let child = Self::explain_select(&view.query, database, ctes)?;
-                            let mut view_node = PlanNode::new("Subquery");
-                            view_node.object = Some(format!("AS {}", source));
-                            view_node.coroutine = Some(source.to_string());
-                            view_node.add_child(child);
-                            return Ok(view_node);
-                        }
+                        let source = alias.as_deref().unwrap_or(name.as_str());
+                        let child = Self::explain_select(&view.query, database, ctes)?;
+                        let mut view_node = PlanNode::new("Subquery");
+                        view_node.object = Some(format!("AS {}", source));
 
-                        if Self::view_body_is_flattenable(&view.query) {
-                            let source = alias.as_deref().unwrap_or(name.as_str());
-                            let child = Self::explain_select(&view.query, database, ctes)?;
-                            let mut view_node = PlanNode::new("Subquery");
-                            view_node.object = Some(format!("AS {}", source));
+                        if Self::select_has_window_functions(&view.query)
+                            || !Self::view_body_is_flattenable(&view.query)
+                        {
+                            // CO-ROUTINE block: the inner plan (including
+                            // the body's own temp B-tree entries) renders
+                            // inside the block via collect_eqp_entries, so
+                            // no flag hoisting — subtree_needs_order_by_
+                            // temp_btree skips co-routine subtrees to avoid
+                            // double emission.
+                            view_node.coroutine = Some(source.to_string());
+                        } else {
                             // The body's ORDER BY genuinely sorts at runtime
                             // (views are materialized), and SQLite's
                             // flattened plan keeps the body's `USE TEMP
@@ -1297,9 +1281,10 @@ impl ExplainExecutor {
                             // rendered (verified against sqlite3 3.51.0).
                             view_node.needs_temp_btree_for_order_by =
                                 subtree_needs_order_by_temp_btree(&child);
-                            view_node.add_child(child);
-                            return Ok(view_node);
                         }
+
+                        view_node.add_child(child);
+                        return Ok(view_node);
                     }
                 }
 

--- a/crates/vibesql-executor/tests/explain_view_expansion_tests.rs
+++ b/crates/vibesql-executor/tests/explain_view_expansion_tests.rs
@@ -192,6 +192,12 @@ fn setup_plain_view_db() -> Database {
     run_ddl(&mut db, "CREATE VIEW ov AS SELECT x, y FROM t3 ORDER BY y");
     run_ddl(&mut db, "CREATE VIEW ovx AS SELECT x, y FROM t3 ORDER BY x");
     run_ddl(&mut db, "CREATE VIEW ov2 AS SELECT x, y FROM ov");
+    run_ddl(&mut db, "CREATE VIEW lov AS SELECT x FROM t3 LIMIT 5 OFFSET 2");
+    run_ddl(&mut db, "CREATE VIEW uav AS SELECT x FROM t3 UNION ALL SELECT y FROM t3");
+    run_ddl(&mut db, "CREATE VIEW vv AS VALUES(1,2),(3,4)");
+    run_ddl(&mut db, "CREATE VIEW wv AS WITH c AS (SELECT x FROM t3) SELECT * FROM c");
+    run_ddl(&mut db, "CREATE VIEW aov AS SELECT x, count(*) AS c FROM t3 GROUP BY x ORDER BY c");
+    run_ddl(&mut db, "CREATE VIEW pav AS SELECT c FROM av");
     db
 }
 
@@ -340,55 +346,304 @@ fn test_outer_order_by_over_flattened_view_keeps_temp_btree() {
 }
 
 // ---------------------------------------------------------------------------
-// Blocked view bodies keep the opaque rendering (#5355)
+// Blocked view bodies render CO-ROUTINE blocks (#5361)
 // ---------------------------------------------------------------------------
-// SQLite renders all of these as `CO-ROUTINE <view>` blocks; VibeSQL
-// conservatively keeps the pre-existing opaque `SCAN <view>` line rather
-// than guessing (follow-on work can add the CO-ROUTINE shape per case).
+// View bodies that block flattening (aggregates, GROUP BY/HAVING, DISTINCT,
+// LIMIT/OFFSET, compound, VALUES, WITH) render as a `CO-ROUTINE <view>`
+// block containing the body's inner plan, followed by `SCAN <view>` of the
+// co-routine output. VibeSQL's runtime materializes every view body, so the
+// block + inner plan is the truthful access path for all of these.
+//
+// Expected shapes verified against sqlite3 3.51.0 per category; divergences
+// are noted on each test:
+// - SQLite uses `SCAN t3 USING COVERING INDEX i3x` for covering-index-only
+//   bodies; VibeSQL's pre-existing base-scan rendering shows `SCAN t3`
+//   (same for bare bodies — unrelated to view expansion, see #5355 notes).
+// - SQLite shows `USE TEMP B-TREE FOR GROUP BY` / `FOR DISTINCT` lines for
+//   unindexed grouping/dedup; VibeSQL's EQP has no GROUP BY/DISTINCT temp
+//   B-tree rendering anywhere yet (follow-on).
 
+// Aggregate + GROUP BY view. sqlite3:
+//   |--CO-ROUTINE av
+//   |  `--SEARCH t3 USING COVERING INDEX i3x (x=?)   [outer WHERE pushed]
+//   `--SCAN av
+// VibeSQL materializes the body and post-filters the outer WHERE, so the
+// inner plan truthfully shows the body's own scan (no fabricated probe).
 #[test]
-fn test_aggregate_group_by_view_not_flattened() {
+fn test_aggregate_group_by_view_renders_coroutine() {
     let db = setup_plain_view_db();
     let output = eqp(&db, "SELECT * FROM av WHERE x = 1");
 
-    assert!(output.contains("SCAN av"), "expected opaque view scan:\n{}", output);
-    assert!(!output.contains("SCAN t3"), "blocked body must not inline:\n{}", output);
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE av\n\
+         |  `--SCAN t3\n\
+         `--SCAN av\n"
+    );
 }
 
+// Scalar aggregate view (no GROUP BY). sqlite3 (modulo covering index):
+//   |--CO-ROUTINE sv
+//   |  `--SCAN t3
+//   `--SCAN sv
 #[test]
-fn test_scalar_aggregate_view_not_flattened() {
+fn test_scalar_aggregate_view_renders_coroutine() {
     let db = setup_plain_view_db();
     let output = eqp(&db, "SELECT * FROM sv");
 
-    assert!(output.contains("SCAN sv"), "expected opaque view scan:\n{}", output);
-    assert!(!output.contains("SCAN t3"), "blocked body must not inline:\n{}", output);
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE sv\n\
+         |  `--SCAN t3\n\
+         `--SCAN sv\n"
+    );
 }
 
+// LIMIT view under an outer WHERE. sqlite3 agrees (the outer WHERE blocks
+// its LIMIT-only flattening):
+//   |--CO-ROUTINE lv
+//   |  `--SCAN t3 USING COVERING INDEX i3x
+//   `--SCAN lv
 #[test]
-fn test_limit_view_not_flattened() {
+fn test_limit_view_renders_coroutine() {
     let db = setup_plain_view_db();
     let output = eqp(&db, "SELECT * FROM lv WHERE x = 1");
 
-    assert!(output.contains("SCAN lv"), "expected opaque view scan:\n{}", output);
-    assert!(!output.contains("SCAN t3"), "blocked body must not inline:\n{}", output);
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE lv\n\
+         |  `--SCAN t3\n\
+         `--SCAN lv\n"
+    );
 }
 
+// Bare LIMIT-only view: sqlite3 flattens this specific shape (`SCAN t3`,
+// no co-routine) when nothing else blocks. VibeSQL materializes the body
+// regardless, so the CO-ROUTINE block is the truthful rendering —
+// documented divergence (#5361, same precedent as the #5355 outer-WHERE
+// divergence).
 #[test]
-fn test_distinct_view_not_flattened() {
+fn test_bare_limit_view_renders_coroutine_divergence() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM lv");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE lv\n\
+         |  `--SCAN t3\n\
+         `--SCAN lv\n"
+    );
+}
+
+// LIMIT + OFFSET view. sqlite3 (modulo covering index):
+//   |--CO-ROUTINE lov
+//   |  `--SCAN t3
+//   `--SCAN lov
+#[test]
+fn test_limit_offset_view_renders_coroutine() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM lov");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE lov\n\
+         |  `--SCAN t3\n\
+         `--SCAN lov\n"
+    );
+}
+
+// DISTINCT view. sqlite3 (with the index, dedup rides the covering index;
+// without it, a `USE TEMP B-TREE FOR DISTINCT` line appears — VibeSQL has
+// no DISTINCT temp B-tree rendering yet, follow-on):
+//   |--CO-ROUTINE dv
+//   |  `--SEARCH t3 USING COVERING INDEX i3x (x=?)
+//   `--SCAN dv
+#[test]
+fn test_distinct_view_renders_coroutine() {
     let db = setup_plain_view_db();
     let output = eqp(&db, "SELECT * FROM dv WHERE x = 1");
 
-    assert!(output.contains("SCAN dv"), "expected opaque view scan:\n{}", output);
-    assert!(!output.contains("SCAN t3"), "blocked body must not inline:\n{}", output);
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE dv\n\
+         |  `--SCAN t3\n\
+         `--SCAN dv\n"
+    );
 }
 
+// Compound (UNION) view: the body's COMPOUND QUERY block nests inside the
+// CO-ROUTINE. sqlite3:
+//   |--CO-ROUTINE cv
+//   |  `--COMPOUND QUERY
+//   |     |--LEFT-MOST SUBQUERY
+//   |     |  `--SEARCH t3 USING COVERING INDEX i3x (x=?)
+//   |     `--UNION USING TEMP B-TREE
+//   |        `--SCAN t3
+//   `--SCAN cv
+// Divergences: no fabricated outer-WHERE probe (see above), and VibeSQL's
+// pre-existing compound rendering labels the dedup branch `UNION` rather
+// than `UNION USING TEMP B-TREE` (follow-on).
 #[test]
-fn test_compound_view_not_flattened() {
+fn test_compound_union_view_renders_coroutine() {
     let db = setup_plain_view_db();
     let output = eqp(&db, "SELECT * FROM cv WHERE x = 1");
 
-    assert!(output.contains("SCAN cv"), "expected opaque view scan:\n{}", output);
-    assert!(!output.contains("SCAN t3"), "blocked body must not inline:\n{}", output);
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE cv\n\
+         |  `--COMPOUND QUERY\n\
+         |     |--LEFT-MOST SUBQUERY\n\
+         |     |  `--SCAN t3\n\
+         |     `--UNION\n\
+         |        `--SCAN t3\n\
+         `--SCAN cv\n"
+    );
+}
+
+// UNION ALL view: sqlite3 flattens the branches into a top-level COMPOUND
+// QUERY (no co-routine, no view name). VibeSQL materializes the body, so
+// the CO-ROUTINE block around the COMPOUND QUERY is the truthful rendering
+// — documented divergence (#5361).
+#[test]
+fn test_union_all_view_renders_coroutine_divergence() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM uav");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE uav\n\
+         |  `--COMPOUND QUERY\n\
+         |     |--LEFT-MOST SUBQUERY\n\
+         |     |  `--SCAN t3\n\
+         |     `--UNION ALL\n\
+         |        `--SCAN t3\n\
+         `--SCAN uav\n"
+    );
+}
+
+// VALUES view. sqlite3 — identical shape:
+//   |--CO-ROUTINE vv
+//   |  `--SCAN 2 CONSTANT ROWS
+//   `--SCAN vv
+#[test]
+fn test_values_view_renders_coroutine() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM vv");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE vv\n\
+         |  `--SCAN 2 CONSTANT ROWS\n\
+         `--SCAN vv\n"
+    );
+}
+
+// WITH-bearing view: sqlite3 inlines a single-use plain CTE all the way
+// down (`SCAN t3`, no co-routine, no view or CTE name). VibeSQL
+// materializes the view body and renders its plan inside the CO-ROUTINE
+// block; the CTE keeps its pre-existing opaque `SCAN c` rendering inside
+// the body — documented divergence (#5361).
+#[test]
+fn test_with_view_renders_coroutine_divergence() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM wv");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE wv\n\
+         |  `--SCAN c\n\
+         `--SCAN wv\n"
+    );
+}
+
+// A blocked body with its own ORDER BY: the body's temp B-tree line renders
+// INSIDE the CO-ROUTINE block, exactly once. sqlite3 (the GROUP BY temp
+// B-tree line is the documented gap above):
+//   |--CO-ROUTINE aov
+//   |  |--SCAN t3 USING COVERING INDEX i3x
+//   |  `--USE TEMP B-TREE FOR ORDER BY
+//   `--SCAN aov
+#[test]
+fn test_blocked_view_order_by_temp_btree_inside_coroutine_once() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM aov");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE aov\n\
+         |  |--SCAN t3\n\
+         |  `--USE TEMP B-TREE FOR ORDER BY\n\
+         `--SCAN aov\n"
+    );
+}
+
+// Plain view over a blocked view: the outer view flattens away (#5355) and
+// the inner blocked view renders its CO-ROUTINE block. sqlite3 — identical
+// shape (modulo covering index):
+//   |--CO-ROUTINE av
+//   |  `--SCAN t3
+//   `--SCAN av
+#[test]
+fn test_plain_view_over_blocked_view() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM pav");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE av\n\
+         |  `--SCAN t3\n\
+         `--SCAN av\n"
+    );
+    assert!(!output.contains("pav"), "outer plain view must flatten away:\n{}", output);
+}
+
+// Outer ORDER BY over a blocked view: the outer sort's temp B-tree line
+// renders OUTSIDE the CO-ROUTINE block. sqlite3 — identical shape:
+//   |--CO-ROUTINE av
+//   |  `--SCAN t3 USING COVERING INDEX i3x
+//   |--SCAN av
+//   `--USE TEMP B-TREE FOR ORDER BY
+#[test]
+fn test_outer_order_by_over_blocked_view() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM av ORDER BY c");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE av\n\
+         |  `--SCAN t3\n\
+         |--SCAN av\n\
+         `--USE TEMP B-TREE FOR ORDER BY\n"
+    );
+}
+
+// A blocked view referenced twice: sqlite3 renders a single
+// `MATERIALIZE av` block plus `SCAN a1` / `SCAN a2`. VibeSQL's runtime
+// executes the view body once per reference (no sharing), so one
+// CO-ROUTINE block per reference is the truthful rendering — documented
+// divergence (#5361).
+#[test]
+fn test_blocked_view_referenced_twice_renders_two_coroutines() {
+    let db = setup_plain_view_db();
+    let output = eqp(&db, "SELECT * FROM av AS a1, av AS a2");
+
+    assert!(output.contains("CO-ROUTINE a1"), "missing first block:\n{}", output);
+    assert!(output.contains("CO-ROUTINE a2"), "missing second block:\n{}", output);
+    assert!(output.contains("SCAN a1"), "missing first outer scan:\n{}", output);
+    assert!(output.contains("SCAN a2"), "missing second outer scan:\n{}", output);
 }
 
 // A WITH-clause CTE shadows a same-named plain view: the view body must NOT
@@ -399,6 +654,27 @@ fn test_cte_shadowing_plain_view_not_flattened() {
     let output = eqp(&db, "WITH pv AS (SELECT 1 AS x, 2 AS y) SELECT * FROM pv WHERE x = 1");
 
     assert!(!output.contains("SCAN t3"), "view body must not be planned:\n{}", output);
+}
+
+// Window views are unaffected by the blocked-body CO-ROUTINE path (#5361):
+// exactly one CO-ROUTINE block, no double rendering.
+#[test]
+fn test_window_view_single_coroutine_block_unchanged() {
+    let db = setup_section1_db();
+    let output = eqp(&db, "SELECT * FROM lll WHERE grp_id = 2");
+
+    assert_eq!(
+        output.matches("CO-ROUTINE").count(),
+        1,
+        "window view must render exactly one CO-ROUTINE block:\n{}",
+        output
+    );
+    assert_eq!(
+        output.matches("SCAN lll").count(),
+        1,
+        "window view must render exactly one outer scan:\n{}",
+        output
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #5361

## Summary

Blocked view bodies (aggregates, GROUP BY/HAVING, DISTINCT, LIMIT/OFFSET, compound, VALUES, WITH) no longer render as an opaque `SCAN <view>` in EXPLAIN QUERY PLAN — they now render as a `CO-ROUTINE <view>` block containing the body's inner plan, followed by `SCAN <view>` of the co-routine output, reusing the existing #5347/#5354 window-view machinery (`PlanNode.coroutine`). VibeSQL's runtime materializes every view body, so the block + inner plan is the truthful access path for every category.

```
EXPLAIN QUERY PLAN SELECT * FROM av;   -- av = SELECT x, count(*) FROM t3 GROUP BY x
QUERY PLAN
|--CO-ROUTINE av
|  `--SCAN t3
`--SCAN av
```

### Changes

- `explain_from_clause`: the window-view and flattenable-view branches are unified — any view body with window functions OR failing `view_body_is_flattenable` gets the CO-ROUTINE rendering; plain flattenable views keep the #5360 flatten path (incl. temp-B-tree hoisting) byte-for-byte. The CTE-shadowing gate is unchanged (CTE-bound names never expand).
- Compound bodies inside CO-ROUTINE blocks: the string-writer `format_compound_query_eqp` is folded into the `EqpEntry` tree renderer (`compound_eqp_entry` + `append_scan_entries`), so a UNION view body nests its `COMPOUND QUERY` block inside the `CO-ROUTINE` entry exactly like SQLite. Top-level compound output is unchanged (same flat per-branch scan collection).
- Multi-row VALUES bodies render SQLite's plural `SCAN <n> CONSTANT ROWS` (single row keeps `SCAN CONSTANT ROW`).
- Temp-B-tree interaction verified: a blocked body's ORDER BY line renders exactly once, inside the block (`subtree_needs_order_by_temp_btree` already skips co-routine subtrees); an outer ORDER BY renders outside the block — both match sqlite3.

### Per-category sqlite3 3.51.0 findings (`.eqp on`, live)

| Category | sqlite3 shape | VibeSQL rendering |
|---|---|---|
| GROUP BY / bare aggregate / HAVING | CO-ROUTINE + inner plan | same (divergence: no `USE TEMP B-TREE FOR GROUP BY` line — VibeSQL EQP has no GROUP BY temp-B-tree rendering anywhere yet, follow-on #5367) |
| DISTINCT | CO-ROUTINE (+ `USE TEMP B-TREE FOR DISTINCT` when unindexed) | CO-ROUTINE (same DISTINCT-line gap, follow-on #5367) |
| LIMIT+OFFSET | CO-ROUTINE | same |
| LIMIT-only, nothing else blocking | flattened (`SCAN t3`) | CO-ROUTINE — truthful (runtime materializes), documented divergence; with an outer WHERE sqlite3 co-routines too and shapes agree |
| UNION (dedup) | CO-ROUTINE wrapping COMPOUND QUERY, branch labeled `UNION USING TEMP B-TREE` | same shape; branch labeled `UNION` (pre-existing compound labeling, follow-on #5367) |
| UNION ALL | flattened to top-level COMPOUND QUERY | CO-ROUTINE wrapping COMPOUND QUERY — truthful, documented divergence |
| VALUES | CO-ROUTINE + `SCAN 2 CONSTANT ROWS` | identical |
| WITH (single-use plain CTE) | fully inlined (`SCAN t3`) | CO-ROUTINE + opaque `SCAN <cte>` — truthful, documented divergence |
| Blocked view referenced twice | single `MATERIALIZE av` + `SCAN a1`/`SCAN a2` | one CO-ROUTINE per reference — truthful (runtime materializes per reference), documented divergence |
| Plain view over blocked view | outer flattens, inner CO-ROUTINE | identical shape |

## Test plan

- [x] `cargo test -p vibesql-executor` — 0 failures (2649 lib + all integration suites)
- [x] `explain_view_expansion_tests.rs` extended 22 → 32 tests: one per blocked category with full expected-output equality, bare-LIMIT/UNION ALL/WITH divergence tests, nested plain-over-blocked, ORDER-BY-inside-block (no double emission), outer ORDER BY outside block, double-reference, window view exactly-one-CO-ROUTINE regression
- [x] TCL: windowpushd 29/29, window9 38 pass/0 fail, eqp 5 pass/0 fail, view 24 pass/0 fail, select6 86 pass/0 fail — zero failures, so zero new vs main
- [x] `cargo clippy -p vibesql-executor` — no new warnings (remaining ones pre-exist in unrelated modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
