### PR TITLE
feat(consensus): TCP transport + cluster config + make test-cluster (phase A3, PR 2/2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # VibeSQL Makefile
 # Convenience targets for common development tasks
 
-.PHONY: all all-bg logs status build build-all build-wasm build-python test test-unit test-workspace test-sqllogictest test-sqllogictest-halting test-tcl test-tcl-all test-tcl-file test-tcl-status fuzz fuzz-parser fuzz-expr fuzz-type-convert fuzz-query fuzz-type-coercion fuzz-differential fuzz-list benchmark benchmark-quick benchmark-smoke benchmark-all benchmark-all-bg benchmark-logs benchmark-status benchmark-embedded-all benchmark-server-all benchmark-tpch benchmark-tpch-quick benchmark-tpch-profile benchmark-tpch-server benchmark-tpcc benchmark-tpcc-server benchmark-tpcds benchmark-sysbench benchmark-sysbench-server benchmark-vibesql benchmark-sqlite benchmark-duckdb benchmark-cli benchmark-cli-prep benchmark-cli-quick fmt fmt-check clean help analyze-tests analyze-benchmarks analyze profile-tpch profile-tpcc profile-sysbench profile-select profile-query bench-storage bench-executor bench-types website mysql-start mysql-stop mysql-status strip-quarantine
+.PHONY: all all-bg logs status build build-all build-wasm build-python test test-unit test-workspace test-sqllogictest test-sqllogictest-halting test-tcl test-tcl-all test-tcl-file test-tcl-status test-cluster fuzz fuzz-parser fuzz-expr fuzz-type-convert fuzz-query fuzz-type-coercion fuzz-differential fuzz-list benchmark benchmark-quick benchmark-smoke benchmark-all benchmark-all-bg benchmark-logs benchmark-status benchmark-embedded-all benchmark-server-all benchmark-tpch benchmark-tpch-quick benchmark-tpch-profile benchmark-tpch-server benchmark-tpcc benchmark-tpcc-server benchmark-tpcds benchmark-sysbench benchmark-sysbench-server benchmark-vibesql benchmark-sqlite benchmark-duckdb benchmark-cli benchmark-cli-prep benchmark-cli-quick fmt fmt-check clean help analyze-tests analyze-benchmarks analyze profile-tpch profile-tpcc profile-sysbench profile-select profile-query bench-storage bench-executor bench-types website mysql-start mysql-stop mysql-status strip-quarantine
 
 # Default target: show help
 .DEFAULT_GOAL := help
@@ -109,6 +109,7 @@ help:
 	@echo "  make test-tcl-all       - Run all SQLite TCL tests (1174 files)"
 	@echo "  make test-tcl-file FILE=X - Run specific TCL test file"
 	@echo "  make test-tcl-status    - Show TCL test status"
+	@echo "  make test-cluster       - Run 3-node TCP consensus cluster smoke tests"
 	@echo ""
 	@echo "Fuzzing targets:"
 	@echo "  make fuzz               - Run all fuzz targets (5 min each)"
@@ -296,6 +297,14 @@ test-tcl-file:
 # Show TCL test status
 test-tcl-status:
 	./scripts/tcltest status
+
+# Run the multi-node consensus cluster smoke tests (Raft Phase A3, #5197).
+# Boots 3-voter clusters on localhost (ephemeral ports, durable Raft logs)
+# wired by the TCP transport and exercises election, replication, leader
+# kill -> re-election, restart -> catch-up, a 2-1 minority partition, and
+# garbage frames on the wire. Exits nonzero on any failure.
+test-cluster:
+	cargo test --release -p vibesql-consensus --test tcp_cluster -- --nocapture
 
 #
 # Fuzzing Targets

--- a/crates/vibesql-consensus/Cargo.toml
+++ b/crates/vibesql-consensus/Cargo.toml
@@ -21,11 +21,17 @@ openraft = { version = "0.9.24", features = ["serde", "storage-v2"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
-tokio = { version = "1.0", features = ["sync"] }
+# `rt`/`net`/`io-util` power the TCP transport (Phase A3, PR 2): the
+# per-node listener task and length-prefix framed connections. `time` bounds
+# each outbound RPC by openraft's hard TTL. `sync` predates this (metrics
+# watch channel, oneshots).
+tokio = { version = "1.0", features = ["sync", "rt", "net", "io-util", "time"] }
+# Static `cluster.toml` membership parsing (Phase A3, PR 2). Same version
+# the server crate already uses for its config file.
+toml = "1.1"
 
 [dev-dependencies]
 tempfile = "3.19"
-# `rt` also unlocks `tokio::spawn` for the in-process channel network's
-# per-node server loops (Phase A3, PR 1); `time` provides the bounded waits
-# in the multi-node cluster tests.
+# `macros` for #[tokio::test]; everything else the tests need (rt, net,
+# io-util, time) is already enabled on the main dependency above.
 tokio = { version = "1.0", features = ["rt", "macros", "time"] }

--- a/crates/vibesql-consensus/src/backend.rs
+++ b/crates/vibesql-consensus/src/backend.rs
@@ -51,6 +51,9 @@ pub enum ConsensusError {
     /// Snapshot serialization or deserialization failed.
     #[error("snapshot encode/decode failed: {0}")]
     SnapshotCodec(String),
+    /// The cluster configuration is invalid or could not be loaded.
+    #[error("cluster configuration error: {0}")]
+    Config(String),
     /// Catch-all for backend-internal failures.
     #[error("consensus backend error: {0}")]
     Backend(String),

--- a/crates/vibesql-consensus/src/cluster.rs
+++ b/crates/vibesql-consensus/src/cluster.rs
@@ -20,8 +20,13 @@
 //!
 //! Deliberately out of scope here (matching the issue): snapshot-based
 //! catch-up (Phase A4, #5198 — these tests stay far below any log-purge
-//! threshold so catch-up always happens via plain AppendEntries backfill),
-//! TCP transport and process-level clusters (PR 2), and dynamic membership.
+//! threshold so catch-up always happens via plain AppendEntries backfill)
+//! and dynamic membership. **Network partitions** are also not testable
+//! with this harness: the shared router only gates a node's *inbound*
+//! queue, so a live "partitioned" node's outbound RPCs would still reach
+//! peers — true partition needs per-edge severing, which the TCP cluster
+//! tests provide (`tests/tcp_cluster.rs`, via per-edge proxies; Phase A3,
+//! PR 2). The TCP transport itself lives in `crate::tcp`.
 
 use std::collections::BTreeMap;
 use std::time::Duration;

--- a/crates/vibesql-consensus/src/cluster_config.rs
+++ b/crates/vibesql-consensus/src/cluster_config.rs
@@ -1,0 +1,238 @@
+//! Static cluster membership configuration (`cluster.toml`) for the TCP
+//! transport (Raft Phase A3, PR 2 of issue #5197).
+//!
+//! A [`ClusterConfig`] maps node ids to `host:port` consensus addresses. It
+//! is loaded once at startup ([`ClusterConfig::load`]) and handed to
+//! [`OpenraftBackend::join_tcp_cluster`]; membership is **static** — adding
+//! or removing nodes is a separate later issue (openraft supports it via
+//! `change_membership`, so there is no design debt in starting static).
+//!
+//! ```toml
+//! # cluster.toml — one [[node]] table per cluster member.
+//! [[node]]
+//! id = 1
+//! addr = "10.0.0.1"        # no port ⇒ the default consensus port, 5433
+//!
+//! [[node]]
+//! id = 2
+//! addr = "10.0.0.2:5433"
+//!
+//! [[node]]
+//! id = 3
+//! addr = "raft-3.internal:6000"
+//! ```
+//!
+//! ## Addresses are the local node's *view*
+//!
+//! The addresses in this config are used for two things on the node that
+//! loaded it: binding its own listener (its own entry) and dialing peers
+//! (every other entry). They are deliberately **not** written into the
+//! replicated Raft membership (`BasicNode` stays empty): replicated
+//! membership must be identical on every node, while dial addresses are
+//! legitimately per-node (NAT, split-horizon DNS, and the per-edge proxies
+//! the partition tests use). Two nodes may therefore reach the same peer
+//! through different addresses without corrupting shared state.
+//!
+//! The consensus port (default [`DEFAULT_CONSENSUS_PORT`], 5433) is distinct
+//! from the SQL port on purpose. Note the port-defaulting rule keys on the
+//! absence of `:` in the address, so IPv6 literals must always carry an
+//! explicit port (`[::1]:5433`).
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use openraft::BasicNode;
+use serde::Deserialize;
+
+use crate::backend::{ConsensusError, Result};
+
+/// Default TCP port for consensus traffic, distinct from the SQL port.
+pub const DEFAULT_CONSENSUS_PORT: u16 = 5433;
+
+/// Static membership of a consensus cluster: node id → `host:port`.
+///
+/// See the [module docs](self) for the `cluster.toml` format and the
+/// per-node-view addressing rationale.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClusterConfig {
+    nodes: BTreeMap<u64, String>,
+}
+
+/// serde mirror of the `cluster.toml` file.
+#[derive(Deserialize)]
+struct ConfigFile {
+    #[serde(default)]
+    node: Vec<NodeEntry>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NodeEntry {
+    id: u64,
+    addr: String,
+}
+
+impl ClusterConfig {
+    /// Build a config from `(node_id, addr)` pairs. An `addr` without a
+    /// port gets [`DEFAULT_CONSENSUS_PORT`] appended.
+    ///
+    /// Fails on an empty member list, duplicate ids, or empty addresses.
+    pub fn new(nodes: impl IntoIterator<Item = (u64, String)>) -> Result<Self> {
+        let mut map = BTreeMap::new();
+        for (id, addr) in nodes {
+            if addr.trim().is_empty() {
+                return Err(ConsensusError::Config(format!("node {id} has an empty address")));
+            }
+            let addr =
+                if addr.contains(':') { addr } else { format!("{addr}:{DEFAULT_CONSENSUS_PORT}") };
+            if map.insert(id, addr).is_some() {
+                return Err(ConsensusError::Config(format!("duplicate node id {id}")));
+            }
+        }
+        if map.is_empty() {
+            return Err(ConsensusError::Config("cluster config has no nodes".to_string()));
+        }
+        Ok(Self { nodes: map })
+    }
+
+    /// Parse a config from `cluster.toml` text.
+    pub fn from_toml_str(text: &str) -> Result<Self> {
+        let file: ConfigFile = toml::from_str(text)
+            .map_err(|e| ConsensusError::Config(format!("invalid cluster.toml: {e}")))?;
+        Self::new(file.node.into_iter().map(|n| (n.id, n.addr)))
+    }
+
+    /// Load a config from a `cluster.toml` file on disk.
+    pub fn load(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let text = std::fs::read_to_string(path).map_err(|e| {
+            ConsensusError::Config(format!("failed to read {}: {e}", path.display()))
+        })?;
+        Self::from_toml_str(&text)
+    }
+
+    /// The `host:port` address of `node_id`, if it is a member.
+    pub fn addr(&self, node_id: u64) -> Option<&str> {
+        self.nodes.get(&node_id).map(String::as_str)
+    }
+
+    /// Ids of all cluster members, ascending.
+    pub fn node_ids(&self) -> impl Iterator<Item = u64> + '_ {
+        self.nodes.keys().copied()
+    }
+
+    /// Number of cluster members.
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Always `false` (construction rejects empty configs); provided for
+    /// `len`/`is_empty` convention completeness.
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    /// The replicated openraft membership derived from this config: ids
+    /// only, with empty [`BasicNode`]s — dial addresses stay local (see the
+    /// module docs).
+    pub(crate) fn membership(&self) -> BTreeMap<u64, BasicNode> {
+        self.nodes.keys().map(|id| (*id, BasicNode::default())).collect()
+    }
+
+    /// Dial-address map handed to the TCP network factory.
+    pub(crate) fn dial_addrs(&self) -> BTreeMap<u64, String> {
+        self.nodes.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact example from the module docs parses, with the default port
+    /// applied to the entry that omits one.
+    #[test]
+    fn parses_the_documented_example() {
+        let config = ClusterConfig::from_toml_str(
+            r#"
+            [[node]]
+            id = 1
+            addr = "10.0.0.1"
+
+            [[node]]
+            id = 2
+            addr = "10.0.0.2:5433"
+
+            [[node]]
+            id = 3
+            addr = "raft-3.internal:6000"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(config.len(), 3);
+        assert_eq!(config.addr(1), Some("10.0.0.1:5433"));
+        assert_eq!(config.addr(2), Some("10.0.0.2:5433"));
+        assert_eq!(config.addr(3), Some("raft-3.internal:6000"));
+        assert_eq!(config.node_ids().collect::<Vec<_>>(), vec![1, 2, 3]);
+        assert_eq!(config.addr(4), None);
+    }
+
+    #[test]
+    fn rejects_duplicate_node_ids() {
+        let err = ClusterConfig::from_toml_str(
+            r#"
+            [[node]]
+            id = 1
+            addr = "a:1"
+
+            [[node]]
+            id = 1
+            addr = "b:2"
+            "#,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ConsensusError::Config(ref m) if m.contains("duplicate")), "{err}");
+    }
+
+    #[test]
+    fn rejects_empty_configs_and_empty_addresses() {
+        assert!(matches!(ClusterConfig::from_toml_str("").unwrap_err(), ConsensusError::Config(_)));
+        assert!(matches!(
+            ClusterConfig::new([(1, String::new())]).unwrap_err(),
+            ConsensusError::Config(_)
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_fields_and_malformed_toml() {
+        let err = ClusterConfig::from_toml_str(
+            r#"
+            [[node]]
+            id = 1
+            addr = "a:1"
+            sql_port = 5432
+            "#,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ConsensusError::Config(_)), "{err}");
+
+        assert!(matches!(
+            ClusterConfig::from_toml_str("not toml at all [").unwrap_err(),
+            ConsensusError::Config(_)
+        ));
+    }
+
+    #[test]
+    fn loads_from_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cluster.toml");
+        std::fs::write(&path, "[[node]]\nid = 1\naddr = \"127.0.0.1\"\n").unwrap();
+
+        let config = ClusterConfig::load(&path).unwrap();
+        assert_eq!(config.addr(1), Some("127.0.0.1:5433"));
+
+        let err = ClusterConfig::load(dir.path().join("missing.toml")).unwrap_err();
+        assert!(matches!(err, ConsensusError::Config(_)), "{err}");
+    }
+}

--- a/crates/vibesql-consensus/src/lib.rs
+++ b/crates/vibesql-consensus/src/lib.rs
@@ -26,16 +26,25 @@
 //! (the `conformance` test module), so consumers written against the trait
 //! behave identically on any of them.
 //!
-//! Phase A3 (PR 1 of #5197) adds **in-process multi-node replication for
-//! tests**: a channel-based implementation of openraft's network traits
-//! (the `network` module) plus a cluster harness with kill/restore failure
-//! injection (the `cluster` module). Both are test-only; nothing about them
-//! is public API.
+//! Phase A3 (#5197) adds **multi-node replication**:
 //!
-//! Deliberately **not** here yet (later Raft phases): a real TCP transport
-//! and process-level clusters (Phase A3, PR 2), snapshot transfer and
+//! - PR 1: a channel-based implementation of openraft's network traits (the
+//!   `network` module) plus an in-process cluster harness with kill/restore
+//!   failure injection (the `cluster` module). Both are test-only.
+//! - PR 2: the **TCP transport** (the `tcp` module — length-prefixed frames
+//!   on a dedicated consensus port, default [`DEFAULT_CONSENSUS_PORT`]),
+//!   static membership via [`ClusterConfig`] (`cluster.toml`), and the
+//!   cluster-level constructors
+//!   [`OpenraftBackend::join_tcp_cluster`] /
+//!   [`OpenraftBackend::join_tcp_cluster_with_data_dir`]. The
+//!   `tcp_cluster` integration test (run by `make test-cluster`) exercises
+//!   election, failover, restart catch-up, minority partitions, and
+//!   torn/garbage frames over real sockets.
+//!
+//! Deliberately **not** here yet (later Raft phases): snapshot transfer and
 //! truncation *policy* (Phase A4; the storage-level truncate/purge hooks
-//! exist), applying entries to VibeSQL storage (Phase B1), and membership
+//! exist), applying entries to VibeSQL storage (Phase B1), TLS on the
+//! consensus port, production wiring into `vibesql-server`, and membership
 //! changes.
 //!
 //! [ADR-0004]: https://github.com/rjwalters/vibesql/blob/main/docs/decisions/0004-consensus-library.md
@@ -43,6 +52,7 @@
 mod backend;
 #[cfg(test)]
 mod cluster;
+mod cluster_config;
 #[cfg(test)]
 mod conformance;
 mod durable;
@@ -50,7 +60,9 @@ mod durable;
 mod network;
 mod openraft_backend;
 mod single_node;
+mod tcp;
 
 pub use backend::{ConsensusBackend, ConsensusError, LogIndex, Result, Role, Snapshot};
+pub use cluster_config::{ClusterConfig, DEFAULT_CONSENSUS_PORT};
 pub use openraft_backend::OpenraftBackend;
 pub use single_node::SingleNodeBackend;

--- a/crates/vibesql-consensus/src/openraft_backend.rs
+++ b/crates/vibesql-consensus/src/openraft_backend.rs
@@ -9,10 +9,14 @@
 //!
 //! Raft Phase A3 (PR 1 of #5197) adds `join_channel_cluster` (test-only):
 //! the same backend booted as one voter of an in-process multi-node cluster
-//! whose RPCs travel over the channel transport in `crate::network`. The
-//! TCP transport is PR 2. The single-node constructors keep the no-op
-//! network factory, which is never exercised because a single-voter cluster
-//! sends no RPCs.
+//! whose RPCs travel over the channel transport in `crate::network`. PR 2
+//! adds the production-shaped equivalents over real sockets —
+//! [`join_tcp_cluster`](OpenraftBackend::join_tcp_cluster) /
+//! [`join_tcp_cluster_with_data_dir`](OpenraftBackend::join_tcp_cluster_with_data_dir)
+//! — wiring the TCP transport in `crate::tcp` to a static
+//! [`ClusterConfig`]. The single-node constructors keep the no-op network
+//! factory, which is never exercised because a single-voter cluster sends
+//! no RPCs.
 //!
 //! ## Log index mapping
 //!
@@ -51,6 +55,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use crate::backend::{ConsensusBackend, ConsensusError, LogIndex, Result, Role, Snapshot};
+use crate::cluster_config::ClusterConfig;
 use crate::durable::DurableLogStore;
 
 openraft::declare_raft_types!(
@@ -428,9 +433,25 @@ pub struct OpenraftBackend<E> {
     raft: Raft<TypeConfig>,
     state_machine: InMemoryStateMachine,
     metrics: tokio::sync::watch::Receiver<openraft::RaftMetrics<u64, BasicNode>>,
+    /// Accept-loop task of the TCP transport (`None` for the single-node
+    /// and channel-network configurations). Aborted on [`shutdown`] and on
+    /// drop; the loop owns its accepted connections through a `JoinSet`, so
+    /// aborting it also severs every inbound socket — a dropped backend
+    /// looks like a crashed process to its peers.
+    ///
+    /// [`shutdown`]: Self::shutdown
+    listener_task: Option<tokio::task::JoinHandle<()>>,
     /// `fn() -> E` keeps the backend `Send + Sync` independent of `E` while
     /// still tying the entry type to the instance.
     _entry: PhantomData<fn() -> E>,
+}
+
+impl<E> Drop for OpenraftBackend<E> {
+    fn drop(&mut self) {
+        if let Some(task) = &self.listener_task {
+            task.abort();
+        }
+    }
 }
 
 impl<E> Debug for OpenraftBackend<E> {
@@ -475,9 +496,25 @@ impl<E> OpenraftBackend<E> {
         self.state_machine.lock().entries.len() as LogIndex
     }
 
-    /// Gracefully shut down the underlying Raft core tasks.
+    /// Gracefully shut down the underlying Raft core tasks (and, for a
+    /// TCP-clustered node, its listener and every inbound connection).
     pub async fn shutdown(&self) -> Result<()> {
+        // Abort the listener first so no new inbound RPC is dispatched into
+        // a core that is going down; peers see dead sockets and retry.
+        if let Some(task) = &self.listener_task {
+            task.abort();
+        }
         self.raft.shutdown().await.map_err(|e| ConsensusError::Backend(e.to_string()))
+    }
+
+    /// The node this backend currently believes leads the cluster, per its
+    /// metrics (`None` until it has heard from — or become — a leader).
+    ///
+    /// Callers that get [`ConsensusError::NotLeader`] without a hint can
+    /// poll this to discover where to retry; B2 (#5200) builds leader-aware
+    /// routing on it.
+    pub fn current_leader(&self) -> Option<u64> {
+        self.metrics.borrow().current_leader
     }
 
     fn current_role(&self) -> Role {
@@ -559,7 +596,106 @@ impl<E> OpenraftBackend<E> {
             .map_err(|e| ConsensusError::Backend(format!("failed to start raft core: {e}")))?;
 
         let metrics = raft.metrics();
-        Ok(Self { raft, state_machine, metrics, _entry: PhantomData })
+        Ok(Self { raft, state_machine, metrics, listener_task: None, _entry: PhantomData })
+    }
+
+    /// With [`Bootstrap::Initialize`], write the static membership into the
+    /// fresh log ([`Raft::initialize`]); with [`Bootstrap::Recover`] do
+    /// nothing (the membership entry and vote are already in the recovered
+    /// log, and re-running `initialize` would be rejected).
+    ///
+    /// openraft documents that multiple nodes initializing with the *same*
+    /// membership is safe; a node that already voted for (or received the
+    /// membership entry from) a faster peer rejects its own initialize with
+    /// `NotAllowed`. Both paths converge on the same membership, so that
+    /// rejection is tolerated.
+    async fn establish_membership(
+        &self,
+        members: BTreeMap<u64, BasicNode>,
+        bootstrap: Bootstrap,
+    ) -> Result<()> {
+        if !matches!(bootstrap, Bootstrap::Initialize) {
+            return Ok(());
+        }
+        match self.raft.initialize(members).await {
+            Ok(()) | Err(RaftError::APIError(openraft::error::InitializeError::NotAllowed(_))) => {
+                Ok(())
+            }
+            Err(e) => Err(ConsensusError::Backend(format!("failed to initialize cluster: {e}"))),
+        }
+    }
+
+    /// Boot one voter of a **TCP-connected cluster** with an in-memory Raft
+    /// log (Raft Phase A3, PR 2 of #5197). Prefer
+    /// [`join_tcp_cluster_with_data_dir`](Self::join_tcp_cluster_with_data_dir)
+    /// anywhere a restart must not forget the log or vote.
+    ///
+    /// Binds this node's listener at its own `config` address (consensus
+    /// port convention: [`crate::DEFAULT_CONSENSUS_PORT`]) and dials peers
+    /// at theirs. Like `join_channel_cluster`, this does **not** wait for an
+    /// election: which node wins is a cluster-level outcome the caller
+    /// awaits (e.g. by polling [`role`](ConsensusBackend::role) /
+    /// [`current_leader`](Self::current_leader) with a bounded timeout).
+    ///
+    /// Must be called from within a tokio runtime.
+    pub async fn join_tcp_cluster(node_id: u64, config: &ClusterConfig) -> Result<Self> {
+        Self::join_tcp(node_id, config, InMemoryLogStore::default(), Bootstrap::Initialize).await
+    }
+
+    /// Like [`join_tcp_cluster`](Self::join_tcp_cluster), but the node's
+    /// Raft log and vote are persisted under `dir` (created if absent) and
+    /// recovered on restart — a restarted node rebinds its address, rejoins
+    /// the cluster with its pre-crash log and vote, and catches up via log
+    /// replication.
+    pub async fn join_tcp_cluster_with_data_dir(
+        node_id: u64,
+        config: &ClusterConfig,
+        dir: impl AsRef<Path>,
+    ) -> Result<Self> {
+        let dir = dir.as_ref();
+        let log_store = DurableLogStore::open(dir).map_err(|e| {
+            ConsensusError::Backend(format!(
+                "failed to open durable raft log in {}: {e}",
+                dir.display()
+            ))
+        })?;
+        let (has_state, _) = log_store.recovery_summary();
+        // Cluster members do not wait for local replay (`last_log_index:
+        // None`): convergence is a cluster-level outcome the caller awaits.
+        let bootstrap = if has_state {
+            Bootstrap::Recover { last_log_index: None }
+        } else {
+            Bootstrap::Initialize
+        };
+        Self::join_tcp(node_id, config, log_store, bootstrap).await
+    }
+
+    async fn join_tcp<LS>(
+        node_id: u64,
+        config: &ClusterConfig,
+        log_store: LS,
+        bootstrap: Bootstrap,
+    ) -> Result<Self>
+    where
+        LS: RaftLogStorage<TypeConfig>,
+    {
+        let listen_addr = config.addr(node_id).ok_or_else(|| {
+            ConsensusError::Config(format!("node {node_id} is not in the cluster config"))
+        })?;
+        // Bind before booting the core so a peer that initialized first can
+        // reach this node as soon as its Raft exists.
+        let listener = crate::tcp::bind_listener(listen_addr).await.map_err(|e| {
+            ConsensusError::Backend(format!(
+                "failed to bind consensus listener on {listen_addr}: {e}"
+            ))
+        })?;
+
+        let network = crate::tcp::TcpNetworkFactory::new(config);
+        let mut backend = Self::boot(node_id, network, log_store, Vec::new()).await?;
+        backend.listener_task = Some(crate::tcp::spawn_listener(backend.raft.clone(), listener));
+
+        backend.establish_membership(config.membership(), bootstrap).await?;
+        Ok(backend)
     }
 
     async fn start<LS>(log_store: LS, entries: Vec<Vec<u8>>, bootstrap: Bootstrap) -> Result<Self>
@@ -643,29 +779,8 @@ impl<E> OpenraftBackend<E> {
         // initialized first can already send this node vote/append RPCs.
         router.register(node_id, backend.raft.clone());
 
-        if matches!(bootstrap, Bootstrap::Initialize) {
-            match backend.raft.initialize(members.clone()).await {
-                Ok(()) => {}
-                // openraft documents that multiple nodes initializing with
-                // the *same* membership is safe; a node that already voted
-                // for (or received the membership entry from) a faster peer
-                // rejects its own initialize with `NotAllowed`. Both paths
-                // converge on the same membership, so tolerate it.
-                Err(RaftError::APIError(openraft::error::InitializeError::NotAllowed(_))) => {}
-                Err(e) => {
-                    return Err(ConsensusError::Backend(format!(
-                        "failed to initialize cluster: {e}"
-                    )))
-                }
-            }
-        }
-
+        backend.establish_membership(members.clone(), bootstrap).await?;
         Ok(backend)
-    }
-
-    /// The node this backend currently believes is leader, per its metrics.
-    pub(crate) fn current_leader(&self) -> Option<u64> {
-        self.metrics.borrow().current_leader
     }
 }
 

--- a/crates/vibesql-consensus/src/tcp.rs
+++ b/crates/vibesql-consensus/src/tcp.rs
@@ -1,0 +1,431 @@
+//! TCP transport for multi-node openraft clusters
+//! (Raft Phase A3, PR 2 of issue #5197).
+//!
+//! This is the socket implementation of openraft 0.9's pluggable network
+//! layer — the same [`RaftNetwork`] / [`RaftNetworkFactory`] traits the
+//! in-process channel transport (`crate::network`, PR 1) implements, so a
+//! cluster of real processes behaves exactly like the deterministic test
+//! cluster, RPC for RPC.
+//!
+//! ## Wire format
+//!
+//! Length-prefixed frames, mirroring the durable Raft log's framing
+//! convention (`crate::durable`) minus the CRC — TCP already checksums the
+//! stream:
+//!
+//! ```text
+//! ┌──────────────────────────────┐
+//! │ [len: u32 LE][payload bytes] │
+//! └──────────────────────────────┘
+//! ```
+//!
+//! The payload is a `serde_json`-encoded [`TcpRequest`] (client → server)
+//! or [`TcpResponse`] (server → client). JSON keeps this crate's existing
+//! codec convention (entries, snapshots, and the durable log all serialize
+//! through serde_json) and adds no dependency; the framing is
+//! codec-agnostic, so swapping in a binary codec later only changes the
+//! payload encoder. A frame longer than [`MAX_FRAME_LEN`] is rejected
+//! before allocation, so a torn or malicious length prefix cannot OOM the
+//! process.
+//!
+//! ## Connection model
+//!
+//! Client side: one lazily-established outbound connection per
+//! [`TcpNetwork`] instance, i.e. per (source, target) replication stream —
+//! openraft awaits each RPC on a stream before issuing the next (verified
+//! against the vendored 0.9.24 in PR 1), so a strict request/response
+//! lockstep per connection is sufficient; no pipelining or correlation ids.
+//! Any failure — connect refused, IO error, decode error, or openraft's
+//! hard TTL expiring — tears the connection down and surfaces
+//! [`Unreachable`]; openraft backs off and retries, and the next RPC dials
+//! fresh. That *is* the reconnect-on-failure story: reconnection needs no
+//! bookkeeping because every RPC re-establishes on demand. The connection
+//! is taken out of `self` for the duration of an exchange and only put back
+//! after a complete round-trip, so a cancelled (timed-out) RPC can never
+//! leave a half-written frame on a reused stream.
+//!
+//! Dial addresses come from the node's **local** [`ClusterConfig`], not
+//! from the replicated membership — see `crate::cluster_config` for why.
+//!
+//! Server side: [`spawn_listener`] accepts connections and serves each on
+//! its own task, dispatching inbound RPCs into the local [`Raft`] exactly
+//! like the channel transport's serve loop (`Raft::append_entries` /
+//! `Raft::vote` / `Raft::install_snapshot`), sequentially per connection. A
+//! malformed or torn inbound frame drops that connection (the peer
+//! reconnects); it never panics the node. The accept loop owns the
+//! per-connection tasks through a [`JoinSet`], so aborting the listener
+//! task — which [`OpenraftBackend::shutdown`] and `Drop` do — also severs
+//! every accepted connection, making a dropped backend look like a crashed
+//! process to its peers.
+//!
+//! [`ClusterConfig`]: crate::cluster_config::ClusterConfig
+//! [`OpenraftBackend::shutdown`]: crate::OpenraftBackend::shutdown
+
+use std::collections::BTreeMap;
+use std::io;
+use std::sync::Arc;
+use std::time::Duration;
+
+use openraft::error::{InstallSnapshotError, RPCError, RaftError, RemoteError, Unreachable};
+use openraft::network::RPCOption;
+use openraft::raft::{
+    AppendEntriesRequest, AppendEntriesResponse, InstallSnapshotRequest, InstallSnapshotResponse,
+    VoteRequest, VoteResponse,
+};
+use openraft::{BasicNode, Raft, RaftNetwork, RaftNetworkFactory};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpSocket, TcpStream};
+use tokio::task::{JoinHandle, JoinSet};
+
+use crate::cluster_config::ClusterConfig;
+use crate::openraft_backend::TypeConfig;
+
+/// Upper bound on a single frame's payload. Far above any AppendEntries
+/// batch this phase produces (snapshot *streaming* is Phase A4, #5198), but
+/// small enough that a garbage length prefix cannot trigger a huge
+/// allocation.
+const MAX_FRAME_LEN: u32 = 64 * 1024 * 1024;
+
+/// Backoff after a failed `accept` (e.g. EMFILE) before trying again.
+const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(50);
+
+// ---------------------------------------------------------------------------
+// Wire messages
+// ---------------------------------------------------------------------------
+
+/// A Raft RPC traveling client → server. One frame each.
+#[derive(Serialize, Deserialize)]
+enum TcpRequest {
+    AppendEntries(AppendEntriesRequest<TypeConfig>),
+    Vote(VoteRequest<u64>),
+    InstallSnapshot(InstallSnapshotRequest<TypeConfig>),
+}
+
+/// The matching response traveling server → client: the local `Raft`'s
+/// verbatim result, including its error — mirroring how the channel
+/// transport ships `Result<_, RaftError>` back over its oneshot.
+#[derive(Serialize, Deserialize)]
+enum TcpResponse {
+    AppendEntries(Result<AppendEntriesResponse<u64>, RaftError<u64>>),
+    Vote(Result<VoteResponse<u64>, RaftError<u64>>),
+    InstallSnapshot(Result<InstallSnapshotResponse<u64>, RaftError<u64, InstallSnapshotError>>),
+}
+
+// ---------------------------------------------------------------------------
+// Framing
+// ---------------------------------------------------------------------------
+
+/// Write one `[len:u32 LE][payload]` frame.
+async fn write_frame<W>(writer: &mut W, payload: &[u8]) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let len =
+        u32::try_from(payload.len()).ok().filter(|len| *len <= MAX_FRAME_LEN).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("frame of {} bytes exceeds the {MAX_FRAME_LEN}-byte limit", payload.len()),
+            )
+        })?;
+    writer.write_all(&len.to_le_bytes()).await?;
+    writer.write_all(payload).await?;
+    writer.flush().await
+}
+
+/// Read one `[len:u32 LE][payload]` frame, rejecting oversized lengths
+/// before allocating.
+async fn read_frame<R>(reader: &mut R) -> io::Result<Vec<u8>>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut len = [0u8; 4];
+    reader.read_exact(&mut len).await?;
+    let len = u32::from_le_bytes(len);
+    if len > MAX_FRAME_LEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("frame length {len} exceeds the {MAX_FRAME_LEN}-byte limit"),
+        ));
+    }
+    let mut payload = vec![0u8; len as usize];
+    reader.read_exact(&mut payload).await?;
+    Ok(payload)
+}
+
+// ---------------------------------------------------------------------------
+// Server side
+// ---------------------------------------------------------------------------
+
+/// Bind the consensus listener for `addr` (`host:port`, resolved if it is a
+/// hostname), with `SO_REUSEADDR` so a restarted node can rebind its port
+/// while connections from its previous life linger in TIME_WAIT.
+pub(crate) async fn bind_listener(addr: &str) -> io::Result<TcpListener> {
+    let resolved = tokio::net::lookup_host(addr)
+        .await?
+        .next()
+        .ok_or_else(|| io::Error::other(format!("{addr} resolved to no addresses")))?;
+    let socket = if resolved.is_ipv4() { TcpSocket::new_v4() } else { TcpSocket::new_v6() }?;
+    socket.set_reuseaddr(true)?;
+    socket.bind(resolved)?;
+    socket.listen(1024)
+}
+
+/// Spawn the accept loop feeding inbound RPCs into the local `Raft`.
+///
+/// Aborting the returned handle ends the loop **and** every accepted
+/// connection (the loop owns them via a [`JoinSet`]), so peers see dead
+/// sockets — the crash semantics the failover tests rely on.
+pub(crate) fn spawn_listener(raft: Raft<TypeConfig>, listener: TcpListener) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut connections = JoinSet::new();
+        loop {
+            tokio::select! {
+                accepted = listener.accept() => match accepted {
+                    Ok((stream, _peer)) => {
+                        let _ = stream.set_nodelay(true);
+                        connections.spawn(serve_connection(raft.clone(), stream));
+                    }
+                    // Transient accept failure (e.g. fd exhaustion): back
+                    // off briefly instead of spinning.
+                    Err(_) => tokio::time::sleep(ACCEPT_RETRY_DELAY).await,
+                },
+                // Reap finished connection tasks so the set stays small.
+                Some(_) = connections.join_next(), if !connections.is_empty() => {}
+            }
+        }
+    })
+}
+
+/// Serve one inbound connection: read a request frame, dispatch it into the
+/// local `Raft`, write the response frame; repeat. Any framing, decode, or
+/// IO problem ends the connection (the peer reconnects) — never a panic.
+async fn serve_connection(raft: Raft<TypeConfig>, mut stream: TcpStream) {
+    loop {
+        let Ok(payload) = read_frame(&mut stream).await else { return };
+        let Ok(request) = serde_json::from_slice::<TcpRequest>(&payload) else { return };
+
+        let response = match request {
+            TcpRequest::AppendEntries(rpc) => {
+                TcpResponse::AppendEntries(raft.append_entries(rpc).await)
+            }
+            TcpRequest::Vote(rpc) => TcpResponse::Vote(raft.vote(rpc).await),
+            TcpRequest::InstallSnapshot(rpc) => {
+                TcpResponse::InstallSnapshot(raft.install_snapshot(rpc).await)
+            }
+        };
+
+        let Ok(bytes) = serde_json::to_vec(&response) else { return };
+        if write_frame(&mut stream, &bytes).await.is_err() {
+            return;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Client side
+// ---------------------------------------------------------------------------
+
+/// Factory handed to `Raft::new`; produces one [`TcpNetwork`] per
+/// (source, target) replication stream, dialing by the **local** cluster
+/// config's view of each peer.
+pub(crate) struct TcpNetworkFactory {
+    dial_addrs: Arc<BTreeMap<u64, String>>,
+}
+
+impl TcpNetworkFactory {
+    pub(crate) fn new(config: &ClusterConfig) -> Self {
+        Self { dial_addrs: Arc::new(config.dial_addrs()) }
+    }
+}
+
+impl RaftNetworkFactory<TypeConfig> for TcpNetworkFactory {
+    type Network = TcpNetwork;
+
+    async fn new_client(&mut self, target: u64, _node: &BasicNode) -> Self::Network {
+        TcpNetwork { target, addr: self.dial_addrs.get(&target).cloned(), stream: None }
+    }
+}
+
+/// Client half of the TCP transport: sends RPCs to one target node over a
+/// lazily-(re)established connection.
+pub(crate) struct TcpNetwork {
+    target: u64,
+    /// Dial address from the local cluster config; `None` if the target is
+    /// not in it (every RPC then fails as unreachable).
+    addr: Option<String>,
+    /// The live connection, if the previous exchange completed cleanly.
+    stream: Option<TcpStream>,
+}
+
+/// The transport-level error openraft treats as "back off and retry".
+fn unreachable<E: std::error::Error>(message: String) -> RPCError<u64, BasicNode, E> {
+    RPCError::Unreachable(Unreachable::new(&io::Error::other(message)))
+}
+
+impl TcpNetwork {
+    /// One framed request/response round-trip, bounded by openraft's hard
+    /// TTL for the RPC. Every failure mode (connect, IO, decode, timeout)
+    /// drops the connection and maps to [`Unreachable`].
+    async fn exchange<E>(
+        &mut self,
+        request: &TcpRequest,
+        option: RPCOption,
+    ) -> Result<TcpResponse, RPCError<u64, BasicNode, E>>
+    where
+        E: std::error::Error,
+    {
+        let target = self.target;
+        match tokio::time::timeout(option.hard_ttl(), self.round_trip(request)).await {
+            Ok(Ok(response)) => Ok(response),
+            Ok(Err(e)) => Err(unreachable(format!("rpc to node {target} failed: {e}"))),
+            Err(_) => Err(unreachable(format!(
+                "rpc to node {target} exceeded its {:?} ttl",
+                option.hard_ttl()
+            ))),
+        }
+    }
+
+    /// Connect if needed, write the request frame, read the response frame.
+    ///
+    /// The stream is **taken out** of `self` for the duration and only put
+    /// back after a complete round-trip, so cancellation (the TTL above, or
+    /// openraft dropping the future) cannot leave a desynchronized
+    /// connection behind — the next RPC simply dials fresh.
+    async fn round_trip(&mut self, request: &TcpRequest) -> io::Result<TcpResponse> {
+        let payload = serde_json::to_vec(request).map_err(io::Error::other)?;
+
+        let mut stream = match self.stream.take() {
+            Some(stream) => stream,
+            None => {
+                let addr = self.addr.as_deref().ok_or_else(|| {
+                    io::Error::other(format!(
+                        "node {} is not in the local cluster config",
+                        self.target
+                    ))
+                })?;
+                let stream = TcpStream::connect(addr).await?;
+                let _ = stream.set_nodelay(true);
+                stream
+            }
+        };
+
+        write_frame(&mut stream, &payload).await?;
+        let response = read_frame(&mut stream).await?;
+        let response = serde_json::from_slice(&response)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        self.stream = Some(stream);
+        Ok(response)
+    }
+
+    /// The server answered with the wrong response variant: a protocol bug,
+    /// not a transient fault — but dropping the connection and letting
+    /// openraft retry is still the safest reaction.
+    fn wrong_variant<E: std::error::Error>(
+        &mut self,
+        expected: &str,
+    ) -> RPCError<u64, BasicNode, E> {
+        self.stream = None;
+        unreachable(format!(
+            "node {} answered an {expected} rpc with a different variant",
+            self.target
+        ))
+    }
+}
+
+impl RaftNetwork<TypeConfig> for TcpNetwork {
+    async fn append_entries(
+        &mut self,
+        rpc: AppendEntriesRequest<TypeConfig>,
+        option: RPCOption,
+    ) -> Result<AppendEntriesResponse<u64>, RPCError<u64, BasicNode, RaftError<u64>>> {
+        match self.exchange(&TcpRequest::AppendEntries(rpc), option).await? {
+            TcpResponse::AppendEntries(result) => {
+                result.map_err(|e| RPCError::RemoteError(RemoteError::new(self.target, e)))
+            }
+            _ => Err(self.wrong_variant("append-entries")),
+        }
+    }
+
+    async fn install_snapshot(
+        &mut self,
+        rpc: InstallSnapshotRequest<TypeConfig>,
+        option: RPCOption,
+    ) -> Result<
+        InstallSnapshotResponse<u64>,
+        RPCError<u64, BasicNode, RaftError<u64, InstallSnapshotError>>,
+    > {
+        match self.exchange(&TcpRequest::InstallSnapshot(rpc), option).await? {
+            TcpResponse::InstallSnapshot(result) => {
+                result.map_err(|e| RPCError::RemoteError(RemoteError::new(self.target, e)))
+            }
+            _ => Err(self.wrong_variant("install-snapshot")),
+        }
+    }
+
+    async fn vote(
+        &mut self,
+        rpc: VoteRequest<u64>,
+        option: RPCOption,
+    ) -> Result<VoteResponse<u64>, RPCError<u64, BasicNode, RaftError<u64>>> {
+        match self.exchange(&TcpRequest::Vote(rpc), option).await? {
+            TcpResponse::Vote(result) => {
+                result.map_err(|e| RPCError::RemoteError(RemoteError::new(self.target, e)))
+            }
+            _ => Err(self.wrong_variant("vote")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Frames round-trip bytes exactly, back to back.
+    #[tokio::test]
+    async fn frames_round_trip() {
+        let (mut a, mut b) = tokio::io::duplex(1024);
+
+        write_frame(&mut a, b"hello").await.unwrap();
+        write_frame(&mut a, b"").await.unwrap();
+        write_frame(&mut a, &[0u8, 1, 2, 255]).await.unwrap();
+
+        assert_eq!(read_frame(&mut b).await.unwrap(), b"hello");
+        assert_eq!(read_frame(&mut b).await.unwrap(), b"");
+        assert_eq!(read_frame(&mut b).await.unwrap(), &[0u8, 1, 2, 255]);
+    }
+
+    /// A length prefix beyond the limit is rejected before any allocation,
+    /// as `InvalidData` rather than a panic or OOM.
+    #[tokio::test]
+    async fn read_frame_rejects_oversized_lengths() {
+        let (mut a, mut b) = tokio::io::duplex(64);
+        a.write_all(&u32::MAX.to_le_bytes()).await.unwrap();
+
+        let err = read_frame(&mut b).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// The writer enforces the same limit symmetrically.
+    #[tokio::test]
+    async fn write_frame_rejects_oversized_payloads() {
+        let (mut a, _b) = tokio::io::duplex(64);
+        let oversized = vec![0u8; MAX_FRAME_LEN as usize + 1];
+
+        let err = write_frame(&mut a, &oversized).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// A torn frame (length promises more bytes than ever arrive) surfaces
+    /// as an IO error once the stream ends.
+    #[tokio::test]
+    async fn read_frame_errors_on_torn_payload() {
+        let (mut a, mut b) = tokio::io::duplex(64);
+        a.write_all(&100u32.to_le_bytes()).await.unwrap();
+        a.write_all(b"only ten b").await.unwrap();
+        drop(a); // EOF before the promised 100 bytes
+
+        assert!(read_frame(&mut b).await.is_err());
+    }
+}

--- a/crates/vibesql-consensus/tests/tcp_cluster.rs
+++ b/crates/vibesql-consensus/tests/tcp_cluster.rs
@@ -1,0 +1,589 @@
+//! Process-level TCP cluster tests (Raft Phase A3, PR 2 of issue #5197) —
+//! the suite behind `make test-cluster`.
+//!
+//! Boots 3-voter [`OpenraftBackend`] clusters whose Raft RPCs travel over
+//! the real TCP transport (`crate::tcp` — length-prefixed frames), with
+//! each node persisting its Raft log in its own tempdir, and exercises the
+//! A3 acceptance scenarios end-to-end: election, replication, leader kill →
+//! re-election, restart → rebind + catch-up, minority partition, and
+//! garbage on the wire.
+//!
+//! ## Port strategy
+//!
+//! Nothing here hardcodes the 5433 port convention: every cluster binds OS-
+//! assigned ephemeral ports (`127.0.0.1:0`, all reservations held
+//! simultaneously, then released just before the nodes rebind them), so
+//! parallel tests and busy CI runners cannot collide. Ephemeral allocation
+//! is cyclic, so a just-released port is not handed out again within a test
+//! run, and the consensus listener binds with `SO_REUSEADDR`, so a
+//! restarted node can rebind its own port immediately.
+//!
+//! ## Partitions
+//!
+//! True partitions need per-edge severing — a live node's outbound traffic
+//! must die too, which neither killing the node nor the channel network's
+//! inbound-queue gating models (see `src/cluster.rs`). Here every directed
+//! edge runs through a tiny TCP [`Proxy`], and each node's *local*
+//! [`ClusterConfig`] dials peers through its own outgoing proxies (local
+//! dial addresses are exactly why the transport does not put addresses in
+//! the replicated membership). Severing a proxy kills its live connections
+//! and refuses new ones.
+//!
+//! All synchronization is bounded polling ([`TcpTestCluster::wait_until`],
+//! 10s deadline) — no bare sleeps; every wait fails loudly instead of
+//! hanging (PR 1's convention).
+
+use std::collections::BTreeMap;
+use std::net::TcpListener as StdTcpListener;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinHandle;
+
+use vibesql_consensus::{
+    ClusterConfig, ConsensusBackend, ConsensusError, LogIndex, OpenraftBackend, Role,
+};
+
+/// Upper bound for any single cluster-level wait (election, catch-up).
+const WAIT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Poll interval inside bounded waits.
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Reserve `n` distinct localhost addresses with OS-assigned ephemeral
+/// ports, keyed by node id `1..=n`. All reservations are held at once (so
+/// they are guaranteed distinct) and released on return, just before the
+/// cluster's nodes bind them for real.
+fn free_localhost_addrs(n: u64) -> BTreeMap<u64, String> {
+    let listeners: Vec<(u64, StdTcpListener)> = (1..=n)
+        .map(|id| (id, StdTcpListener::bind("127.0.0.1:0").expect("reserve ephemeral port")))
+        .collect();
+    listeners
+        .iter()
+        .map(|(id, listener)| {
+            (*id, listener.local_addr().expect("reserved port address").to_string())
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Per-edge TCP proxy (partition injection)
+// ---------------------------------------------------------------------------
+
+/// A severable TCP forwarder for one directed cluster edge.
+///
+/// While connected, accepted connections are forwarded byte-for-byte to the
+/// target. [`sever`](Self::sever) kills every live forwarded connection
+/// (both endpoints see a dead socket) and makes the proxy accept-then-drop
+/// new ones, so dialers get a connection that dies on first use — openraft
+/// maps either to `Unreachable` and backs off, exactly like a real
+/// partition.
+struct Proxy {
+    /// Address the source node dials instead of the target's real address.
+    addr: String,
+    enabled: Arc<AtomicBool>,
+    /// Live forwarder tasks; aborted (sockets dropped) on sever.
+    conns: Arc<Mutex<Vec<JoinHandle<()>>>>,
+    accept_task: JoinHandle<()>,
+}
+
+impl Proxy {
+    async fn spawn(target: String) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind proxy listener");
+        let addr = listener.local_addr().expect("proxy address").to_string();
+        let enabled = Arc::new(AtomicBool::new(true));
+        let conns: Arc<Mutex<Vec<JoinHandle<()>>>> = Arc::default();
+
+        let accept_task = tokio::spawn({
+            let enabled = Arc::clone(&enabled);
+            let conns = Arc::clone(&conns);
+            async move {
+                loop {
+                    let Ok((mut inbound, _)) = listener.accept().await else {
+                        tokio::time::sleep(POLL_INTERVAL).await;
+                        continue;
+                    };
+                    if !enabled.load(Ordering::SeqCst) {
+                        continue; // dropping `inbound` hangs up on the dialer
+                    }
+                    let target = target.clone();
+                    let forwarder = tokio::spawn(async move {
+                        let Ok(mut outbound) = TcpStream::connect(&target).await else { return };
+                        let _ = tokio::io::copy_bidirectional(&mut inbound, &mut outbound).await;
+                    });
+                    let mut conns = conns.lock().expect("proxy connection list poisoned");
+                    conns.retain(|handle| !handle.is_finished());
+                    conns.push(forwarder);
+                }
+            }
+        });
+
+        Self { addr, enabled, conns, accept_task }
+    }
+
+    /// Cut the edge: live connections die, new ones are accepted and
+    /// immediately dropped.
+    fn sever(&self) {
+        self.enabled.store(false, Ordering::SeqCst);
+        let mut conns = self.conns.lock().expect("proxy connection list poisoned");
+        for handle in conns.drain(..) {
+            handle.abort();
+        }
+    }
+
+    /// Reconnect the edge for new connections.
+    fn reconnect(&self) {
+        self.enabled.store(true, Ordering::SeqCst);
+    }
+}
+
+impl Drop for Proxy {
+    fn drop(&mut self) {
+        self.accept_task.abort();
+        self.sever();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cluster harness
+// ---------------------------------------------------------------------------
+
+struct TestNode {
+    /// `None` while the node is killed. `Arc` so a test can hold the
+    /// backend across `&mut self` harness calls (e.g. await a pending
+    /// propose on a partitioned node).
+    backend: Option<Arc<OpenraftBackend<String>>>,
+    /// This node's local view of the cluster (its own real address, peers
+    /// possibly behind per-edge proxies).
+    config: ClusterConfig,
+    /// Data directory holding the node's durable Raft log across restarts.
+    dir: TempDir,
+    /// The node's real listen address (where raw-socket tests dial it).
+    listen_addr: String,
+}
+
+/// A 3-voter TCP cluster on localhost ephemeral ports, every node with a
+/// durable Raft log in its own tempdir.
+struct TcpTestCluster {
+    nodes: BTreeMap<u64, TestNode>,
+    /// Directed-edge proxies; empty unless built with
+    /// [`boot_partitionable`](Self::boot_partitionable).
+    proxies: BTreeMap<(u64, u64), Proxy>,
+}
+
+impl TcpTestCluster {
+    /// Boot `n` voters (ids `1..=n`) dialing each other directly.
+    async fn boot(n: u64) -> Self {
+        Self::build(n, false).await
+    }
+
+    /// Like [`boot`](Self::boot), but every directed edge runs through a
+    /// severable [`Proxy`], enabling [`partition`](Self::partition).
+    async fn boot_partitionable(n: u64) -> Self {
+        Self::build(n, true).await
+    }
+
+    async fn build(n: u64, with_proxies: bool) -> Self {
+        let addrs = free_localhost_addrs(n);
+
+        let mut proxies = BTreeMap::new();
+        if with_proxies {
+            for a in 1..=n {
+                for b in 1..=n {
+                    if a != b {
+                        proxies.insert((a, b), Proxy::spawn(addrs[&b].clone()).await);
+                    }
+                }
+            }
+        }
+
+        let mut nodes = BTreeMap::new();
+        for id in 1..=n {
+            // Node `id`'s view: its own real address (it binds it), every
+            // peer behind this node's outgoing proxy when partitionable.
+            let view = (1..=n).map(|peer| {
+                let addr = if peer == id || !with_proxies {
+                    addrs[&peer].clone()
+                } else {
+                    proxies[&(id, peer)].addr.clone()
+                };
+                (peer, addr)
+            });
+            let config = ClusterConfig::new(view).expect("valid cluster config");
+            let dir = TempDir::new().expect("create node data directory");
+            let backend = OpenraftBackend::join_tcp_cluster_with_data_dir(id, &config, dir.path())
+                .await
+                .expect("boot tcp cluster node");
+            nodes.insert(
+                id,
+                TestNode {
+                    backend: Some(Arc::new(backend)),
+                    config,
+                    dir,
+                    listen_addr: addrs[&id].clone(),
+                },
+            );
+        }
+
+        Self { nodes, proxies }
+    }
+
+    /// The backend of a live node. Panics if `id` is killed or unknown.
+    fn node(&self, id: u64) -> &Arc<OpenraftBackend<String>> {
+        self.nodes
+            .get(&id)
+            .and_then(|n| n.backend.as_ref())
+            .unwrap_or_else(|| panic!("node {id} is killed or unknown"))
+    }
+
+    /// The real listen address of node `id`.
+    fn listen_addr(&self, id: u64) -> &str {
+        &self.nodes[&id].listen_addr
+    }
+
+    /// Ids of nodes that are currently alive.
+    fn live_ids(&self) -> Vec<u64> {
+        self.nodes.iter().filter(|(_, n)| n.backend.is_some()).map(|(id, _)| *id).collect()
+    }
+
+    /// "Crash" a node: stop its Raft core and abort its listener, so every
+    /// socket it owns — inbound and outbound — dies, exactly like a killed
+    /// process. Its data directory survives for [`restore`](Self::restore).
+    async fn kill(&mut self, id: u64) {
+        let backend = self
+            .nodes
+            .get_mut(&id)
+            .and_then(|n| n.backend.take())
+            .unwrap_or_else(|| panic!("node {id} is already killed or unknown"));
+        backend.shutdown().await.expect("shut down killed node's raft core");
+        // Dropping the (last) Arc also aborts the listener task via Drop,
+        // tearing down all of the node's accepted connections.
+    }
+
+    /// Restart a killed node: reopen its durable Raft log and rebind its
+    /// address. Bind is retried briefly because the killed node's listener
+    /// task is aborted asynchronously by the runtime.
+    async fn restore(&mut self, id: u64) {
+        let node = self.nodes.get_mut(&id).expect("unknown node");
+        assert!(node.backend.is_none(), "node {id} is not killed");
+
+        let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+        let backend = loop {
+            match OpenraftBackend::join_tcp_cluster_with_data_dir(id, &node.config, node.dir.path())
+                .await
+            {
+                Ok(backend) => break backend,
+                Err(e) => {
+                    assert!(
+                        tokio::time::Instant::now() < deadline,
+                        "timed out restoring node {id}: {e}"
+                    );
+                    tokio::time::sleep(POLL_INTERVAL).await;
+                }
+            }
+        };
+        node.backend = Some(Arc::new(backend));
+    }
+
+    /// Sever every directed edge between `minority` and the rest of the
+    /// cluster, in both directions. Panics unless built partitionable.
+    fn partition(&self, minority: &[u64]) {
+        assert!(!self.proxies.is_empty(), "cluster was not built partitionable");
+        for (&(a, b), proxy) in &self.proxies {
+            if minority.contains(&a) != minority.contains(&b) {
+                proxy.sever();
+            }
+        }
+    }
+
+    /// Reconnect every severed edge.
+    fn heal(&self) {
+        for proxy in self.proxies.values() {
+            proxy.reconnect();
+        }
+    }
+
+    /// Wait (bounded) until some live node reports itself leader.
+    async fn wait_for_leader(&self) -> u64 {
+        self.wait_for_leader_among(&self.live_ids()).await
+    }
+
+    /// Wait (bounded) until one of `ids` reports itself leader **and**
+    /// every node in `ids` acknowledges it; returns the leader.
+    ///
+    /// Requiring agreement (not just a `Role::Leader` claim) matters over
+    /// TCP: nodes boot staggered enough that early elections can be
+    /// superseded, leaving a node briefly claiming a leadership it already
+    /// lost. Once every polled node has heard from the same leader,
+    /// heartbeats are flowing and the claim is settled.
+    async fn wait_for_leader_among(&self, ids: &[u64]) -> u64 {
+        self.wait_until(&format!("an acknowledged leader among {ids:?}"), || {
+            let leader = ids.iter().copied().find(|id| self.node(*id).role() == Role::Leader)?;
+            ids.iter().all(|id| self.node(*id).current_leader() == Some(leader)).then_some(leader)
+        })
+        .await
+    }
+
+    /// Wait (bounded) until node `id` has applied the application log entry
+    /// at `idx`.
+    async fn wait_for_apply(&self, id: u64, idx: LogIndex) {
+        self.wait_until(&format!("node {id} to apply log index {idx}"), || {
+            (self.node(id).last_index() >= idx).then_some(())
+        })
+        .await;
+    }
+
+    /// Poll `probe` until it yields a value, panicking after
+    /// [`WAIT_TIMEOUT`]. The single bounded-wait primitive every
+    /// cluster-level synchronization goes through.
+    async fn wait_until<T>(&self, what: &str, mut probe: impl FnMut() -> Option<T>) -> T {
+        let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+        loop {
+            if let Some(value) = probe() {
+                return value;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out after {WAIT_TIMEOUT:?} waiting for {what}"
+            );
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+}
+
+/// Pick a live node that is not `leader`.
+fn follower_of(cluster: &TcpTestCluster, leader: u64) -> u64 {
+    cluster
+        .live_ids()
+        .into_iter()
+        .find(|id| *id != leader)
+        .expect("cluster has at least one follower")
+}
+
+// ---------------------------------------------------------------------------
+// A3 acceptance scenarios (process-level / PR 2)
+// ---------------------------------------------------------------------------
+
+/// Cold start over real sockets: three voters elect exactly one leader, a
+/// proposal commits, and all three state machines apply it identically.
+#[tokio::test]
+async fn boots_elects_and_replicates_over_tcp() {
+    let cluster = TcpTestCluster::boot(3).await;
+    let leader = cluster.wait_for_leader().await;
+
+    let idx = cluster.node(leader).propose("write-1".to_string()).await.unwrap();
+    assert_eq!(idx, 1, "first application entry gets the first dense index");
+
+    for id in 1..=3 {
+        cluster.wait_for_apply(id, idx).await;
+        assert_eq!(
+            cluster.node(id).read_committed(idx).await.unwrap(),
+            "write-1",
+            "node {id} applied a different value"
+        );
+    }
+
+    let leaders: Vec<u64> = (1..=3).filter(|id| cluster.node(*id).role() == Role::Leader).collect();
+    assert_eq!(leaders, vec![leader], "leadership must be unique once settled");
+}
+
+/// Kill the leader — its listener and every socket it owns die, like a
+/// crashed process — and the two survivors elect a new leader; writes
+/// resume on the remaining majority.
+#[tokio::test]
+async fn killing_the_leader_severs_its_sockets_and_a_new_leader_emerges() {
+    let mut cluster = TcpTestCluster::boot(3).await;
+    let leader = cluster.wait_for_leader().await;
+
+    let idx = cluster.node(leader).propose("before-failover".to_string()).await.unwrap();
+    for id in cluster.live_ids() {
+        cluster.wait_for_apply(id, idx).await;
+    }
+
+    cluster.kill(leader).await;
+
+    let new_leader = cluster.wait_for_leader().await;
+    assert_ne!(new_leader, leader, "the killed node cannot be the new leader");
+
+    let idx2 = cluster.node(new_leader).propose("after-failover".to_string()).await.unwrap();
+    assert_eq!(idx2, 2, "application indices stay dense across the failover");
+
+    for id in cluster.live_ids() {
+        cluster.wait_for_apply(id, idx2).await;
+        assert_eq!(cluster.node(id).read_committed(idx2).await.unwrap(), "after-failover");
+    }
+}
+
+/// A killed follower misses writes, then restarts: it reopens its durable
+/// Raft log, rebinds its address (`SO_REUSEADDR`), reconnects, and catches
+/// up via AppendEntries backfill to the full history.
+#[tokio::test]
+async fn restarted_node_rebinds_reconnects_and_catches_up() {
+    let mut cluster = TcpTestCluster::boot(3).await;
+    let leader = cluster.wait_for_leader().await;
+
+    for i in 1..=3u64 {
+        let idx = cluster.node(leader).propose(format!("entry-{i}")).await.unwrap();
+        assert_eq!(idx, i);
+    }
+    let follower = follower_of(&cluster, leader);
+    cluster.wait_for_apply(follower, 3).await;
+
+    cluster.kill(follower).await;
+
+    // The two survivors are still a majority: writes keep committing.
+    for i in 4..=6u64 {
+        let idx = cluster.node(leader).propose(format!("entry-{i}")).await.unwrap();
+        assert_eq!(idx, i);
+    }
+
+    cluster.restore(follower).await;
+    cluster.wait_for_apply(follower, 6).await;
+
+    for i in 1..=6u64 {
+        assert_eq!(
+            cluster.node(follower).read_committed(i).await.unwrap(),
+            format!("entry-{i}"),
+            "restored follower diverged at index {i}"
+        );
+    }
+}
+
+/// The minority-partition acceptance criterion from #5197, 2-1 split with
+/// the leader on the minority side:
+///
+/// - the majority elects a new leader and keeps committing writes;
+/// - a write proposed on the partitioned old leader can never commit, and
+///   surfaces as the **typed** [`ConsensusError::NotLeader`] (with the new
+///   leader as hint) once the heal lets the old leader learn it was
+///   deposed — openraft fails the pending proposal when the new leader's
+///   log truncates the uncommitted entry;
+/// - after the heal, everyone converges on the majority history and the
+///   rejected write appears nowhere.
+#[tokio::test]
+async fn minority_partition_rejects_writes_while_the_majority_continues() {
+    let cluster = TcpTestCluster::boot_partitionable(3).await;
+    let old_leader = cluster.wait_for_leader().await;
+
+    let idx = cluster.node(old_leader).propose("before-partition".to_string()).await.unwrap();
+    for id in 1..=3 {
+        cluster.wait_for_apply(id, idx).await;
+    }
+
+    // 2-1 split: the leader alone on the minority side, both directions
+    // severed.
+    cluster.partition(&[old_leader]);
+
+    // A write proposed on the minority leader cannot reach quorum; it stays
+    // pending until the node learns it was deposed (openraft has no
+    // check-quorum step-down, so the rejection arrives at heal time).
+    let minority = Arc::clone(cluster.node(old_leader));
+    let pending = tokio::spawn(async move { minority.propose("minority-write".to_string()).await });
+
+    // Majority side: a new leader emerges and writes keep committing.
+    let majority: Vec<u64> = (1..=3).filter(|id| *id != old_leader).collect();
+    let new_leader = cluster.wait_for_leader_among(&majority).await;
+    let idx2 = cluster.node(new_leader).propose("majority-write".to_string()).await.unwrap();
+    assert_eq!(idx2, 2, "the minority write must not have consumed an index");
+    for id in &majority {
+        cluster.wait_for_apply(*id, idx2).await;
+        assert_eq!(cluster.node(*id).read_committed(idx2).await.unwrap(), "majority-write");
+    }
+
+    cluster.heal();
+
+    // The deposed leader truncates its uncommitted entry when the new
+    // leader's log reaches it; the pending write surfaces NotLeader with
+    // the new leader as hint.
+    let result = tokio::time::timeout(WAIT_TIMEOUT, pending)
+        .await
+        .expect("the minority write should resolve after the partition heals")
+        .expect("the propose task must not panic");
+    match result {
+        Err(ConsensusError::NotLeader { leader_hint }) => assert_eq!(
+            leader_hint,
+            Some(new_leader),
+            "the rejection should point at the leader that deposed the entry"
+        ),
+        other => panic!("minority write must surface NotLeader, got: {other:?}"),
+    }
+
+    // Everyone converges on the majority history; the rejected write
+    // appears nowhere.
+    cluster.wait_for_apply(old_leader, idx2).await;
+    for id in 1..=3 {
+        assert_eq!(cluster.node(id).read_committed(idx).await.unwrap(), "before-partition");
+        assert_eq!(cluster.node(id).read_committed(idx2).await.unwrap(), "majority-write");
+    }
+
+    // And the stepped-down old leader now rejects writes outright, hinting
+    // at the new leader.
+    cluster
+        .wait_until("the old leader to step down and learn who leads", || {
+            (cluster.node(old_leader).role() == Role::Follower
+                && cluster.node(old_leader).current_leader() == Some(new_leader))
+            .then_some(())
+        })
+        .await;
+    let err = cluster.node(old_leader).propose("still rejected".to_string()).await.unwrap_err();
+    match err {
+        ConsensusError::NotLeader { leader_hint } => assert_eq!(leader_hint, Some(new_leader)),
+        other => panic!("expected NotLeader from the deposed leader, got: {other:?}"),
+    }
+}
+
+/// Read until the server hangs up; panics if it answers or stays open.
+async fn assert_connection_closed(mut stream: TcpStream) {
+    let mut buf = [0u8; 16];
+    match tokio::time::timeout(WAIT_TIMEOUT, stream.read(&mut buf)).await {
+        Ok(Ok(0)) | Ok(Err(_)) => {} // clean close or reset — both fine
+        Ok(Ok(n)) => panic!("server answered {n} bytes instead of dropping the connection"),
+        Err(_) => panic!("server kept the connection open after a malformed frame"),
+    }
+}
+
+/// Garbage on the wire — an undecodable payload, an absurd length prefix,
+/// and a torn frame — gets the offending connection dropped (no panic, no
+/// allocation blow-up) while the cluster keeps replicating.
+#[tokio::test]
+async fn garbage_frames_drop_the_connection_without_disrupting_the_cluster() {
+    let cluster = TcpTestCluster::boot(3).await;
+    let leader = cluster.wait_for_leader().await;
+
+    let idx = cluster.node(leader).propose("before-garbage".to_string()).await.unwrap();
+    for id in 1..=3 {
+        cluster.wait_for_apply(id, idx).await;
+    }
+
+    let victim = follower_of(&cluster, leader);
+    let addr = cluster.listen_addr(victim).to_string();
+
+    // Well-framed garbage payload: decode fails, connection dropped.
+    let mut stream = TcpStream::connect(&addr).await.unwrap();
+    stream.write_all(&7u32.to_le_bytes()).await.unwrap();
+    stream.write_all(b"garbage").await.unwrap();
+    assert_connection_closed(stream).await;
+
+    // Absurd length prefix: rejected before allocation, connection dropped.
+    let mut stream = TcpStream::connect(&addr).await.unwrap();
+    stream.write_all(&u32::MAX.to_le_bytes()).await.unwrap();
+    assert_connection_closed(stream).await;
+
+    // Torn frame: promise 100 bytes, deliver 10, hang up. The server's
+    // read fails and the connection just ends.
+    let mut stream = TcpStream::connect(&addr).await.unwrap();
+    stream.write_all(&100u32.to_le_bytes()).await.unwrap();
+    stream.write_all(b"only ten b").await.unwrap();
+    drop(stream);
+
+    // The cluster keeps replicating as if nothing happened.
+    let idx2 = cluster.node(leader).propose("after-garbage".to_string()).await.unwrap();
+    for id in 1..=3 {
+        cluster.wait_for_apply(id, idx2).await;
+        assert_eq!(cluster.node(id).read_committed(idx2).await.unwrap(), "after-garbage");
+    }
+}


### PR DESCRIPTION
Closes #5197

PR 2 of 2 for Raft Phase A3 (curator re-scope per ADR-0004). PR 1 (#5364) delivered the in-process channel network and deterministic `TestCluster`; this PR delivers the socket half: real TCP transport, static `cluster.toml` membership, and `make test-cluster`.

## What's here

**TCP transport (`src/tcp.rs`)** — implements the same openraft 0.9.24 `RaftNetwork`/`RaftNetworkFactory` traits as PR 1, over sockets:
- Length-prefixed frames `[len:u32 LE][payload]`, mirroring the durable-log framing convention (`src/durable.rs`) minus the CRC (TCP already checksums). Payload is a serde_json-encoded request/response enum (AppendEntries/Vote/InstallSnapshot + verbatim `Result<_, RaftError>` responses) — JSON keeps the crate's existing codec convention and adds zero deps; the framing is codec-agnostic if we want binary later.
- One lazy outbound connection per (source, target) replication stream, strict request/response lockstep (openraft awaits each RPC per stream — verified in PR 1 review — so no pipelining/correlation ids). Every failure (connect, IO, decode, hard-TTL timeout) tears the connection down and surfaces `Unreachable`; openraft backs off and the next RPC redials — that is the reconnect story, with no bookkeeping. The stream is taken out of `self` during an exchange and only restored after a full round-trip, so a cancelled RPC can never leave a desynchronized connection behind.
- Server side: one listener task per node dispatching inbound RPCs into the local `Raft` (same dispatch shape as the channel transport's serve loop), sequential per connection. A 64 MiB frame cap rejects garbage length prefixes before allocation; malformed/torn frames drop that connection — never a panic. The accept loop owns connections via a `JoinSet`, so aborting it (shutdown/Drop) severs every socket — a dropped backend looks like a crashed process.

**Static membership (`src/cluster_config.rs`)** — `ClusterConfig` (node id → `host:port`) loadable from `cluster.toml` (`toml = "1.1"`, same crate/version vibesql-server already uses). Default consensus port **5433**, distinct from the SQL port; an addr without a port gets it appended. Design note: dial addresses stay **node-local** and are not written into replicated membership (`BasicNode` stays empty) — replicated state must be identical on every node while dial addresses are legitimately per-node (NAT, split-horizon, and the per-edge partition proxies below).

**Backend constructors** — `OpenraftBackend::join_tcp_cluster` / `join_tcp_cluster_with_data_dir` (durable log+vote, recovery auto-detected, rebind with `SO_REUSEADDR`). `current_leader()` promoted to public (B2 leader-aware routing will need it). The initialize-tolerating-`NotAllowed` logic is now shared (`establish_membership`) between the channel and TCP joins.

**`make test-cluster`** — runs `cargo test --release -p vibesql-consensus --test tcp_cluster`; exits nonzero on failure. CI's Phase-3 integration runner picks the suite up automatically as well.

## Minority-partition criterion (deferred from PR 1 — now implemented)

The PR 1 judge flagged that the "minority partition rejects writes" AC was deferred and undocumented. It is **implemented** here, not deferred: every directed edge of the partitionable cluster runs through a tiny severable TCP proxy (possible precisely because dial addresses are node-local). The test does a 2-1 split with the leader on the minority side:
- majority elects a new leader and keeps committing;
- a write proposed on the partitioned old leader never commits, and surfaces as typed `ConsensusError::NotLeader { leader_hint: Some(new_leader) }` once the heal lets the new leader's log truncate the uncommitted entry (openraft has no check-quorum step-down, so the rejection arrives at heal time — verified against vendored 0.9.24 `raft_core.rs` `Command::DeleteConflictLog`, which fails pending client writes with `ForwardToLeader`);
- after heal everyone converges on the majority history, the rejected write appears nowhere, and a direct propose on the deposed leader returns `NotLeader` hinting at the new leader.

`src/cluster.rs` docs now also state explicitly why the channel harness cannot express partitions (inbound-only gating) and where they are covered.

## Tests

New: 5 process-level scenarios in `tests/tcp_cluster.rs` (boot/elect/replicate; kill leader → sockets die → re-election; restart → rebind + durable recovery + catch-up; minority partition; garbage frames: undecodable payload, `u32::MAX` length prefix, torn frame — connection dropped, cluster unaffected) + frame-codec unit tests + `ClusterConfig` parsing tests. **No test hardcodes port 5433**: clusters bind OS-assigned ephemeral ports (all reservations held simultaneously, released just before nodes rebind), so parallel CI runs cannot collide. All waits are bounded polls (10s deadline / 20ms poll, PR 1's convention). One TCP-specific hardening: `wait_for_leader` requires the leader to be *acknowledged by all polled nodes*, because staggered TCP boots can leave a node briefly claiming a superseded leadership.

## Verification

- `cargo test -p vibesql-consensus`: 55 lib + 5 integration, all green (also green with `--test-threads=1`)
- Flake resistance: 25 sequential runs of `tcp_cluster` (1.6–2.2s each) + 5 runs under 8-way CPU load (`yes` hogs) — zero failures, stable timing
- `make test-cluster` (release): 5/5 in 2.2s
- `cargo clippy -p vibesql-consensus --all-targets`: clean; rustfmt clean
- `cargo build --workspace`: green (the 3 vibesql-executor warnings pre-exist on main)

## Not in scope (per issue)

TLS, dynamic membership, snapshot streaming (#5198), production wiring into vibesql-server (B2, #5200).