### PR TITLE
feat(consensus): snapshot builder + durable snapshots + purge safety (phase A4, PR 1/2)

### DIFF
--- a/crates/vibesql-consensus/src/cluster.rs
+++ b/crates/vibesql-consensus/src/cluster.rs
@@ -92,7 +92,13 @@ impl TestCluster {
         for id in 1..=n {
             let node = if durable {
                 let dir = TempDir::new().expect("create tempdir for durable raft log");
-                let store = DurableLogStore::open(dir.path()).expect("open durable raft log");
+                // Fresh (empty) snapshot watermark: these cluster tests
+                // exercise log replication, not snapshots, so no purge ever
+                // becomes legal — which is exactly the pre-snapshot state.
+                let watermark =
+                    std::sync::Arc::new(crate::snapshot::DurableSnapshotWatermark::default());
+                let store =
+                    DurableLogStore::open(dir.path(), watermark).expect("open durable raft log");
                 let backend = OpenraftBackend::join_channel_cluster(
                     id,
                     &members,
@@ -176,7 +182,10 @@ impl TestCluster {
                 .await
             }
             NodeStorage::Durable(dir) => {
-                let store = DurableLogStore::open(dir.path()).expect("reopen durable raft log");
+                let watermark =
+                    std::sync::Arc::new(crate::snapshot::DurableSnapshotWatermark::default());
+                let store =
+                    DurableLogStore::open(dir.path(), watermark).expect("reopen durable raft log");
                 OpenraftBackend::join_channel_cluster(
                     id,
                     &self.members,

--- a/crates/vibesql-consensus/src/durable.rs
+++ b/crates/vibesql-consensus/src/durable.rs
@@ -97,6 +97,7 @@ use openraft::{Entry, LogId, LogState, RaftLogReader, StorageError, StorageIOErr
 use serde::{Deserialize, Serialize};
 
 use crate::openraft_backend::TypeConfig;
+use crate::snapshot::DurableSnapshotWatermark;
 
 /// Name of the Raft log file inside the data directory.
 const RAFT_LOG_FILE_NAME: &str = "raft.log";
@@ -114,7 +115,9 @@ const RAFT_LOG_HEADER_SIZE: usize = 32;
 const RECORD_FRAME_SIZE: usize = 8;
 
 /// CRC-32 (IEEE polynomial), identical to `vibesql-storage::wal::writer`.
-fn crc32(data: &[u8]) -> u32 {
+/// Shared with the snapshot store (`crate::snapshot`), which mirrors the
+/// same framing conventions.
+pub(crate) fn crc32(data: &[u8]) -> u32 {
     const CRC32_TABLE: [u32; 256] = {
         let mut table = [0u32; 256];
         let mut i = 0;
@@ -436,15 +439,29 @@ struct DurableInner {
 #[derive(Debug, Clone)]
 pub(crate) struct DurableLogStore {
     inner: Arc<Mutex<DurableInner>>,
+    /// Raw index of the last snapshot that is durable on disk, shared with
+    /// the [`SnapshotStore`](crate::snapshot::SnapshotStore). [`purge`]
+    /// refuses to exceed it — the Phase A4 safety rule that log entries may
+    /// only be discarded once a durable snapshot covers them.
+    ///
+    /// [`purge`]: RaftLogStorage::purge
+    snapshot_watermark: Arc<DurableSnapshotWatermark>,
 }
 
 impl DurableLogStore {
     /// Open (or create) the Raft log under `dir`, replaying any existing
     /// state from disk.
-    pub(crate) fn open(dir: &Path) -> io::Result<Self> {
+    ///
+    /// `snapshot_watermark` is the durable-snapshot index this store's
+    /// `purge` is allowed to reach (shared with the snapshot store that
+    /// advances it).
+    pub(crate) fn open(
+        dir: &Path,
+        snapshot_watermark: Arc<DurableSnapshotWatermark>,
+    ) -> io::Result<Self> {
         std::fs::create_dir_all(dir)?;
         let (file, image) = RaftLogFile::open(&dir.join(RAFT_LOG_FILE_NAME))?;
-        Ok(Self { inner: Arc::new(Mutex::new(DurableInner { file, image })) })
+        Ok(Self { inner: Arc::new(Mutex::new(DurableInner { file, image })), snapshot_watermark })
     }
 
     fn lock(&self) -> MutexGuard<'_, DurableInner> {
@@ -456,6 +473,13 @@ impl DurableLogStore {
     pub(crate) fn recovery_summary(&self) -> (bool, Option<u64>) {
         let inner = self.lock();
         (inner.image.has_state(), inner.image.last_log_id().map(|id| id.index))
+    }
+
+    /// Raw index of the purge watermark recovered from disk, if any. The
+    /// backend cross-checks it against the durable snapshot on startup: a
+    /// log purged beyond the snapshot is unrecoverable and must fail loudly.
+    pub(crate) fn last_purged_index(&self) -> Option<u64> {
+        self.lock().image.last_purged.map(|id| id.index)
     }
 
     /// Durably append one record and apply it to the in-memory image.
@@ -559,6 +583,25 @@ impl RaftLogStorage<TypeConfig> for DurableLogStore {
     }
 
     async fn purge(&mut self, log_id: LogId<u64>) -> Result<(), StorageError<u64>> {
+        // Phase A4 safety rule: never purge above the last *durable*
+        // snapshot. openraft's own purge policy respects its in-memory view
+        // of the snapshot, but this storage-level check is the final
+        // defense: the watermark only advances after the snapshot file is
+        // fsynced and renamed, so a purge acknowledged here can never
+        // outrun what would survive a crash. (When to purge — the policy —
+        // is PR 2 of #5198; this PR only enforces legality.)
+        let durable = self.snapshot_watermark.get();
+        if durable.is_none_or(|covered| log_id.index > covered) {
+            let e = io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "refusing to purge raft log through index {}: the durable snapshot covers \
+                     only {durable:?}, and purging beyond it would make state unrecoverable",
+                    log_id.index
+                ),
+            );
+            return Err(StorageError::IO { source: StorageIOError::write_logs(&e) });
+        }
         self.append_and_apply(LogRecord::Purge(log_id))
             .map_err(|e| StorageError::IO { source: StorageIOError::write_logs(&e) })
     }
@@ -574,6 +617,16 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+
+    fn test_watermark() -> Arc<DurableSnapshotWatermark> {
+        Arc::new(DurableSnapshotWatermark::default())
+    }
+
+    /// Open a store with a fresh (empty) snapshot watermark — the state of
+    /// every node before its first durable snapshot.
+    fn open_store(dir: &TempDir) -> io::Result<DurableLogStore> {
+        DurableLogStore::open(dir.path(), test_watermark())
+    }
 
     fn entry(term: u64, index: u64, payload: &[u8]) -> Entry<TypeConfig> {
         Entry {
@@ -593,7 +646,7 @@ mod tests {
     #[test]
     fn fresh_store_is_empty() {
         let dir = TempDir::new().unwrap();
-        let store = DurableLogStore::open(dir.path()).unwrap();
+        let store = open_store(&dir).unwrap();
         assert_eq!(store.recovery_summary(), (false, None));
         assert!(entry_indices(&store).is_empty());
     }
@@ -602,7 +655,7 @@ mod tests {
     fn entries_survive_reopen() {
         let dir = TempDir::new().unwrap();
         {
-            let store = DurableLogStore::open(dir.path()).unwrap();
+            let store = open_store(&dir).unwrap();
             store
                 .append_entries(vec![
                     entry(1, 1, b"one"),
@@ -612,7 +665,7 @@ mod tests {
                 .unwrap();
         }
 
-        let store = DurableLogStore::open(dir.path()).unwrap();
+        let store = open_store(&dir).unwrap();
         assert_eq!(store.recovery_summary(), (true, Some(3)));
         assert_eq!(entry_indices(&store), vec![1, 2, 3]);
         let payload = match &store.lock().image.entries[&2].payload {
@@ -627,11 +680,11 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let vote = Vote::new(7, 1);
         {
-            let store = DurableLogStore::open(dir.path()).unwrap();
+            let store = open_store(&dir).unwrap();
             store.append_and_apply(LogRecord::Vote(vote)).unwrap();
         }
 
-        let store = DurableLogStore::open(dir.path()).unwrap();
+        let store = open_store(&dir).unwrap();
         assert_eq!(store.lock().image.vote, Some(vote));
         // A vote alone counts as prior state: recovery must not re-initialize.
         assert_eq!(store.recovery_summary(), (true, None));
@@ -642,12 +695,12 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let committed = Some(LogId::new(CommittedLeaderId::new(1, 1), 2));
         {
-            let store = DurableLogStore::open(dir.path()).unwrap();
+            let store = open_store(&dir).unwrap();
             store.append_entries(vec![entry(1, 1, b"a"), entry(1, 2, b"b")]).unwrap();
             store.append_and_apply(LogRecord::Committed(committed)).unwrap();
         }
 
-        let store = DurableLogStore::open(dir.path()).unwrap();
+        let store = open_store(&dir).unwrap();
         assert_eq!(store.lock().image.committed, committed);
     }
 
@@ -655,7 +708,7 @@ mod tests {
     fn truncate_survives_reopen() {
         let dir = TempDir::new().unwrap();
         {
-            let store = DurableLogStore::open(dir.path()).unwrap();
+            let store = open_store(&dir).unwrap();
             store.append_entries((1..=5).map(|i| entry(1, i, b"x")).collect()).unwrap();
             // Conflict rollback: drop entries >= 3...
             store.append_and_apply(LogRecord::Truncate(3)).unwrap();
@@ -663,7 +716,7 @@ mod tests {
             store.append_entries(vec![entry(2, 3, b"replacement")]).unwrap();
         }
 
-        let store = DurableLogStore::open(dir.path()).unwrap();
+        let store = open_store(&dir).unwrap();
         assert_eq!(entry_indices(&store), vec![1, 2, 3]);
         let replayed = store.lock().image.entries[&3].log_id;
         assert_eq!(replayed, LogId::new(CommittedLeaderId::new(2, 1), 3));
@@ -674,12 +727,12 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let purge_id = LogId::new(CommittedLeaderId::new(1, 1), 3);
         {
-            let store = DurableLogStore::open(dir.path()).unwrap();
+            let store = open_store(&dir).unwrap();
             store.append_entries((1..=5).map(|i| entry(1, i, b"x")).collect()).unwrap();
             store.append_and_apply(LogRecord::Purge(purge_id)).unwrap();
         }
 
-        let store = DurableLogStore::open(dir.path()).unwrap();
+        let store = open_store(&dir).unwrap();
         assert_eq!(entry_indices(&store), vec![4, 5]);
         assert_eq!(store.lock().image.last_purged, Some(purge_id));
         assert_eq!(store.recovery_summary(), (true, Some(5)));
@@ -690,21 +743,75 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let purge_id = LogId::new(CommittedLeaderId::new(1, 1), 2);
         {
-            let store = DurableLogStore::open(dir.path()).unwrap();
+            let store = open_store(&dir).unwrap();
             store.append_entries(vec![entry(1, 1, b"a"), entry(1, 2, b"b")]).unwrap();
             store.append_and_apply(LogRecord::Purge(purge_id)).unwrap();
         }
 
-        let store = DurableLogStore::open(dir.path()).unwrap();
+        let store = open_store(&dir).unwrap();
         assert!(entry_indices(&store).is_empty());
         assert_eq!(store.lock().image.last_log_id(), Some(purge_id));
+    }
+
+    // -----------------------------------------------------------------------
+    // Purge safety: never purge above the durable snapshot (Phase A4, PR 1)
+    // -----------------------------------------------------------------------
+
+    /// With no durable snapshot at all, every purge is illegal.
+    #[tokio::test]
+    async fn purge_without_durable_snapshot_is_rejected() {
+        let dir = TempDir::new().unwrap();
+        let mut store = open_store(&dir).unwrap();
+        store.append_entries((1..=5).map(|i| entry(1, i, b"x")).collect()).unwrap();
+
+        let err = RaftLogStorage::purge(&mut store, LogId::new(CommittedLeaderId::new(1, 1), 3))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("refusing to purge"), "unexpected error: {err}");
+
+        // The rejection wrote nothing: all entries survive a reopen.
+        drop(store);
+        let store = open_store(&dir).unwrap();
+        assert_eq!(entry_indices(&store), vec![1, 2, 3, 4, 5]);
+        assert_eq!(store.last_purged_index(), None);
+    }
+
+    /// Purging above the durable snapshot index is rejected; purging at or
+    /// below it succeeds and survives a reopen.
+    #[tokio::test]
+    async fn purge_is_clamped_to_the_durable_snapshot_index() {
+        let dir = TempDir::new().unwrap();
+        let watermark = test_watermark();
+        let mut store = DurableLogStore::open(dir.path(), Arc::clone(&watermark)).unwrap();
+        store.append_entries((1..=5).map(|i| entry(1, i, b"x")).collect()).unwrap();
+
+        // A durable snapshot covers entries up to index 3.
+        watermark.advance(3);
+
+        // Above the snapshot: rejected, nothing written.
+        let err = RaftLogStorage::purge(&mut store, LogId::new(CommittedLeaderId::new(1, 1), 4))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("durable snapshot covers only Some(3)"), "{err}");
+        assert_eq!(store.last_purged_index(), None);
+
+        // At the snapshot: legal.
+        RaftLogStorage::purge(&mut store, LogId::new(CommittedLeaderId::new(1, 1), 3))
+            .await
+            .unwrap();
+        assert_eq!(entry_indices(&store), vec![4, 5]);
+
+        drop(store);
+        let store = open_store(&dir).unwrap();
+        assert_eq!(entry_indices(&store), vec![4, 5]);
+        assert_eq!(store.last_purged_index(), Some(3));
     }
 
     #[test]
     fn torn_trailing_record_is_discarded() {
         let dir = TempDir::new().unwrap();
         {
-            let store = DurableLogStore::open(dir.path()).unwrap();
+            let store = open_store(&dir).unwrap();
             store
                 .append_entries(vec![
                     entry(1, 1, b"one"),
@@ -721,7 +828,7 @@ mod tests {
         file.set_len(len - 3).unwrap();
         drop(file);
 
-        let store = DurableLogStore::open(dir.path()).unwrap();
+        let store = open_store(&dir).unwrap();
         assert_eq!(entry_indices(&store), vec![1, 2]);
         assert_eq!(store.recovery_summary(), (true, Some(2)));
 
@@ -730,7 +837,7 @@ mod tests {
         store.append_entries(vec![entry(1, 3, b"retry")]).unwrap();
         drop(store);
 
-        let store = DurableLogStore::open(dir.path()).unwrap();
+        let store = open_store(&dir).unwrap();
         assert_eq!(entry_indices(&store), vec![1, 2, 3]);
     }
 
@@ -738,7 +845,7 @@ mod tests {
     fn torn_frame_header_is_discarded() {
         let dir = TempDir::new().unwrap();
         {
-            let store = DurableLogStore::open(dir.path()).unwrap();
+            let store = open_store(&dir).unwrap();
             store.append_entries(vec![entry(1, 1, b"one")]).unwrap();
         }
 
@@ -748,7 +855,7 @@ mod tests {
         file.write_all(&42u32.to_le_bytes()).unwrap();
         drop(file);
 
-        let store = DurableLogStore::open(dir.path()).unwrap();
+        let store = open_store(&dir).unwrap();
         assert_eq!(entry_indices(&store), vec![1]);
     }
 
@@ -763,7 +870,7 @@ mod tests {
     fn corrupt_checksum_truncates_the_tail() {
         let dir = TempDir::new().unwrap();
         {
-            let store = DurableLogStore::open(dir.path()).unwrap();
+            let store = open_store(&dir).unwrap();
             store.append_entries(vec![entry(1, 1, b"one"), entry(1, 2, b"two")]).unwrap();
         }
 
@@ -774,7 +881,7 @@ mod tests {
         buf[last] ^= 0xFF;
         std::fs::write(&path, &buf).unwrap();
 
-        let store = DurableLogStore::open(dir.path()).unwrap();
+        let store = open_store(&dir).unwrap();
         assert_eq!(entry_indices(&store), vec![1]);
     }
 
@@ -800,7 +907,7 @@ mod tests {
     fn mid_file_corruption_is_rejected_and_file_untouched() {
         let dir = TempDir::new().unwrap();
         {
-            let store = DurableLogStore::open(dir.path()).unwrap();
+            let store = open_store(&dir).unwrap();
             store.append_entries((1..=5).map(|i| entry(1, i, b"payload")).collect()).unwrap();
             store.append_and_apply(LogRecord::Vote(Vote::new(7, 1))).unwrap();
             store
@@ -819,14 +926,14 @@ mod tests {
         buf[frame2 + RECORD_FRAME_SIZE + 2] ^= 0xFF;
         std::fs::write(&path, &buf).unwrap();
 
-        let err = DurableLogStore::open(dir.path()).unwrap_err();
+        let err = open_store(&dir).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         assert!(err.to_string().contains("mid-file corruption"), "unexpected error: {err}");
         // The file was left byte-for-byte untouched: nothing truncated.
         assert_eq!(std::fs::metadata(&path).unwrap().len(), len_before);
 
         // The refusal is stable: a second open attempt fails the same way.
-        let err = DurableLogStore::open(dir.path()).unwrap_err();
+        let err = open_store(&dir).unwrap_err();
         assert!(err.to_string().contains("mid-file corruption"), "unexpected error: {err}");
     }
 
@@ -841,7 +948,7 @@ mod tests {
         for corrupt_len in [u32::MAX, 1u32] {
             let dir = TempDir::new().unwrap();
             {
-                let store = DurableLogStore::open(dir.path()).unwrap();
+                let store = open_store(&dir).unwrap();
                 store.append_entries((1..=5).map(|i| entry(1, i, b"payload")).collect()).unwrap();
             }
 
@@ -852,7 +959,7 @@ mod tests {
             buf[frame2..frame2 + 4].copy_from_slice(&corrupt_len.to_le_bytes());
             std::fs::write(&path, &buf).unwrap();
 
-            let err = DurableLogStore::open(dir.path()).unwrap_err();
+            let err = open_store(&dir).unwrap_err();
             assert!(
                 err.to_string().contains("mid-file corruption"),
                 "len={corrupt_len}: unexpected error: {err}"
@@ -868,12 +975,12 @@ mod tests {
         // Creation crashed mid-header: fewer than 32 bytes, no records.
         std::fs::write(log_file_path(&dir), b"VRFT\x01").unwrap();
 
-        let store = DurableLogStore::open(dir.path()).unwrap();
+        let store = open_store(&dir).unwrap();
         assert_eq!(store.recovery_summary(), (false, None));
         store.append_entries(vec![entry(1, 1, b"one")]).unwrap();
         drop(store);
 
-        let store = DurableLogStore::open(dir.path()).unwrap();
+        let store = open_store(&dir).unwrap();
         assert_eq!(entry_indices(&store), vec![1]);
     }
 
@@ -883,7 +990,7 @@ mod tests {
         std::fs::create_dir_all(dir.path()).unwrap();
         std::fs::write(log_file_path(&dir), [b'X'; 64]).unwrap();
 
-        let err = DurableLogStore::open(dir.path()).unwrap_err();
+        let err = open_store(&dir).unwrap_err();
         assert!(err.to_string().contains("expected magic"), "unexpected error: {err}");
     }
 
@@ -897,7 +1004,7 @@ mod tests {
         buf.extend_from_slice(&[0u8; 24]);
         std::fs::write(log_file_path(&dir), &buf).unwrap();
 
-        let err = DurableLogStore::open(dir.path()).unwrap_err();
+        let err = open_store(&dir).unwrap_err();
         assert!(
             err.to_string().contains("unsupported raft log version"),
             "unexpected error: {err}"

--- a/crates/vibesql-consensus/src/lib.rs
+++ b/crates/vibesql-consensus/src/lib.rs
@@ -41,11 +41,31 @@
 //!   election, failover, restart catch-up, minority partitions, and
 //!   torn/garbage frames over real sockets.
 //!
-//! Deliberately **not** here yet (later Raft phases): snapshot transfer and
-//! truncation *policy* (Phase A4; the storage-level truncate/purge hooks
-//! exist), applying entries to VibeSQL storage (Phase B1), TLS on the
-//! consensus port, production wiring into `vibesql-server`, and membership
-//! changes.
+//! Phase A4 (#5198), PR 1, makes snapshots real on a single node:
+//!
+//! - [`ConsensusBackend::snapshot`] on [`OpenraftBackend`] flows through
+//!   openraft's `RaftSnapshotBuilder` (the `snapshot` module holds the
+//!   payload codec and the durable [`SnapshotStore`](snapshot) machinery).
+//! - Durable configurations persist each built/installed snapshot to the
+//!   data directory (tmp/rename atomic, CRC-framed) and recover **snapshot
+//!   first, then log replay**; a corrupt snapshot file fails recovery
+//!   loudly rather than silently starting fresh.
+//! - Snapshot builds pin the MVCC vacuum horizon through a hook
+//!   (`SnapshotHorizonPin`) that is a no-op until Phase B1 wires the real
+//!   state machine.
+//! - Log purge is storage-enforced to never exceed the last durable
+//!   snapshot's index.
+//!
+//! Deliberately **not** here yet (later Raft phases): snapshot *transfer*
+//! between nodes and the purge *policy* (Phase A4 PR 2), applying entries
+//! to VibeSQL storage (Phase B1), TLS on the consensus port, production
+//! wiring into `vibesql-server`, and membership changes.
+//!
+//! Note on retention: the Raft log purge gated above is orthogonal to the
+//! pre-existing data-WAL checkpoint/truncation in `vibesql-storage::wal`
+//! (LSN-based, `DEFAULT_SAFETY_BUFFER`). On a replicated node the **Raft
+//! log is authoritative** (per the A2/B1 direction); the data WAL remains a
+//! local durability detail of the storage engine.
 //!
 //! [ADR-0004]: https://github.com/rjwalters/vibesql/blob/main/docs/decisions/0004-consensus-library.md
 
@@ -60,6 +80,7 @@ mod durable;
 mod network;
 mod openraft_backend;
 mod single_node;
+mod snapshot;
 mod tcp;
 
 pub use backend::{ConsensusBackend, ConsensusError, LogIndex, Result, Role, Snapshot};

--- a/crates/vibesql-consensus/src/openraft_backend.rs
+++ b/crates/vibesql-consensus/src/openraft_backend.rs
@@ -18,6 +18,15 @@
 //! factory, which is never exercised because a single-voter cluster sends
 //! no RPCs.
 //!
+//! Raft Phase A4 (PR 1 of #5198) replaces the snapshot stand-ins with the
+//! real pipeline: [`ConsensusBackend::snapshot`] flows through openraft's
+//! [`RaftSnapshotBuilder`], builds pin the MVCC vacuum horizon
+//! (`crate::snapshot::SnapshotHorizonPin`; a no-op until B1), durable
+//! configurations persist snapshots to the data directory and recover from
+//! them (snapshot first, then log replay), and log purge is storage-enforced
+//! to never exceed the durable snapshot. Network snapshot transfer and the
+//! purge *policy* are PR 2.
+//!
 //! ## Log index mapping
 //!
 //! openraft's raw log interleaves application entries with protocol entries
@@ -57,6 +66,9 @@ use serde::Serialize;
 use crate::backend::{ConsensusBackend, ConsensusError, LogIndex, Result, Role, Snapshot};
 use crate::cluster_config::ClusterConfig;
 use crate::durable::DurableLogStore;
+use crate::snapshot::{
+    decode_payload, encode_payload, NoopHorizonPin, SnapshotHorizonPin, SnapshotStore,
+};
 
 openraft::declare_raft_types!(
     /// Raft type configuration for VibeSQL consensus.
@@ -189,6 +201,11 @@ impl RaftLogStorage<TypeConfig> for InMemoryLogStore {
     }
 
     async fn purge(&mut self, log_id: LogId<u64>) -> std::result::Result<(), StorageError<u64>> {
+        // No durable-snapshot check here, unlike `DurableLogStore::purge`:
+        // this store is for tests/dev only, and its log is exactly as
+        // volatile as the in-memory snapshots that justify purging it — a
+        // restart loses both, so there is no acknowledged-durability gap for
+        // the Phase A4 safety rule to protect.
         let mut inner = self.lock();
         inner.last_purged_log_id = Some(log_id);
         inner.log = inner.log.split_off(&(log_id.index + 1));
@@ -205,6 +222,9 @@ impl RaftLogStorage<TypeConfig> for InMemoryLogStore {
 struct StoredSnapshot {
     meta: SnapshotMeta<u64, BasicNode>,
     data: Vec<u8>,
+    /// Number of application entries covered by `data` (the dense
+    /// [`LogIndex`] the [`ConsensusBackend::snapshot`] artifact reports).
+    app_index: u64,
 }
 
 #[derive(Debug, Default)]
@@ -214,7 +234,8 @@ struct StateMachineInner {
     /// Applied application entries (serialized payloads). Position `i`
     /// holds application log index `i + 1` (1-based, Raft convention).
     entries: Vec<Vec<u8>>,
-    /// Monotonic snapshot id counter.
+    /// Monotonic snapshot counter (uniquified with a timestamp in the
+    /// snapshot id, since this counter restarts with the process).
     snapshot_seq: u64,
     current_snapshot: Option<StoredSnapshot>,
 }
@@ -222,37 +243,158 @@ struct StateMachineInner {
 /// In-memory [`RaftStateMachine`] that records applied application entries.
 ///
 /// "State" here is simply the ordered list of applied payloads: VibeSQL's
-/// real state machine (applying write-sets to storage) is Phase B1 work.
+/// real state machine (applying write-sets to storage) is Phase B1 work
+/// (#5199), and the snapshot machinery below is deliberately generic over
+/// that state so B1 only swaps the payload codec and the horizon pin.
 /// Cloning shares the underlying state (it is a handle).
-#[derive(Debug, Clone, Default)]
+///
+/// With a [`SnapshotStore`] attached ([`durable`](Self::durable)), built and
+/// installed snapshots are persisted to the data directory **before** they
+/// are registered, so openraft never learns of — and purge can never run
+/// against — a snapshot that would not survive a crash.
+#[derive(Debug, Clone)]
 struct InMemoryStateMachine {
     inner: Arc<Mutex<StateMachineInner>>,
+    /// Durable persistence for built/installed snapshots (`None` for the
+    /// in-memory configurations, whose snapshots are exactly as volatile as
+    /// the rest of their state).
+    store: Option<Arc<SnapshotStore>>,
+    /// MVCC vacuum-horizon pin held across snapshot builds. A no-op until
+    /// Phase B1 (#5199) wires the MVCC state machine — see
+    /// [`SnapshotHorizonPin`].
+    pin: Arc<dyn SnapshotHorizonPin>,
+}
+
+impl Default for InMemoryStateMachine {
+    fn default() -> Self {
+        Self::volatile()
+    }
 }
 
 impl InMemoryStateMachine {
+    /// A state machine whose snapshots live (and die) in memory.
+    fn volatile() -> Self {
+        Self { inner: Arc::default(), store: None, pin: Arc::new(NoopHorizonPin) }
+    }
+
+    /// A state machine that persists its snapshots through `store`.
+    fn durable(store: Arc<SnapshotStore>) -> Self {
+        Self { inner: Arc::default(), store: Some(store), pin: Arc::new(NoopHorizonPin) }
+    }
+
     fn lock(&self) -> std::sync::MutexGuard<'_, StateMachineInner> {
         self.inner.lock().expect("raft state machine mutex poisoned")
     }
+
+    /// Seed this (fresh) machine from a snapshot recovered off disk, before
+    /// the Raft core starts: applied state, `last_applied`, and membership
+    /// all resume from the snapshot, and openraft then replays only the log
+    /// suffix above `meta.last_log_id`.
+    fn seed_from_snapshot(
+        &self,
+        meta: SnapshotMeta<u64, BasicNode>,
+        data: Vec<u8>,
+    ) -> std::io::Result<()> {
+        let entries = decode_payload(&data).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("durable raft snapshot payload failed to decode: {e}"),
+            )
+        })?;
+        let mut inner = self.lock();
+        inner.last_applied = meta.last_log_id;
+        inner.last_membership = meta.last_membership.clone();
+        inner.current_snapshot =
+            Some(StoredSnapshot { meta, app_index: entries.len() as u64, data });
+        inner.entries = entries;
+        Ok(())
+    }
+
+    /// Seed this (fresh) machine with entries restored from a
+    /// [`ConsensusBackend::snapshot`] artifact — the "restore a backup into
+    /// a NEW consensus group" path ([`OpenraftBackend::from_snapshot`]).
+    ///
+    /// Unlike [`install_snapshot`](RaftStateMachine::install_snapshot), the
+    /// artifact carries no raft meta (the new group starts its own log from
+    /// scratch), so `last_applied` stays `None` and the persisted seed
+    /// snapshot legalizes no log purge. With a durable store the seed is
+    /// persisted before this returns, so the restored state now survives
+    /// restarts of the restored node.
+    fn restore_seed(&self, entries: Vec<Vec<u8>>) -> std::io::Result<()> {
+        let data = encode_payload(&entries).map_err(std::io::Error::other)?;
+        let meta = SnapshotMeta {
+            last_log_id: None,
+            last_membership: StoredMembership::default(),
+            snapshot_id: format!("restore-{}", current_timestamp_ms()),
+        };
+        if let Some(store) = &self.store {
+            store.save(&meta, &data)?;
+        }
+        let mut inner = self.lock();
+        inner.current_snapshot =
+            Some(StoredSnapshot { meta, app_index: entries.len() as u64, data });
+        inner.entries = entries;
+        Ok(())
+    }
+
+    /// `(application index, payload blob)` of the current snapshot, for the
+    /// [`ConsensusBackend::snapshot`] artifact.
+    fn current_snapshot_artifact(&self) -> Option<(u64, Vec<u8>)> {
+        self.lock().current_snapshot.as_ref().map(|s| (s.app_index, s.data.clone()))
+    }
+}
+
+fn current_timestamp_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis() as u64).unwrap_or(0)
 }
 
 impl RaftSnapshotBuilder<TypeConfig> for InMemoryStateMachine {
     async fn build_snapshot(
         &mut self,
     ) -> std::result::Result<openraft::Snapshot<TypeConfig>, StorageError<u64>> {
-        let mut inner = self.lock();
-        let data = serde_json::to_vec(&inner.entries).map_err(|e| StorageError::IO {
-            source: openraft::StorageIOError::write_state_machine(&e),
-        })?;
+        // Pin the MVCC vacuum horizon for the whole build: the snapshot is a
+        // consistent view at `last_applied`, so versions visible at that
+        // index must not be reclaimed until the blob is built, durable, and
+        // registered. (No-op for the echo machine; #5199 connects this to
+        // the active-transaction holdback in vibesql-storage's
+        // transaction_api.)
+        let _horizon_pin = self.pin.acquire();
 
-        inner.snapshot_seq += 1;
-        let meta = SnapshotMeta {
-            last_log_id: inner.last_applied,
-            last_membership: inner.last_membership.clone(),
-            snapshot_id: format!("snapshot-{}", inner.snapshot_seq),
+        // Capture state and meta atomically under the state-machine lock.
+        let (meta, data, app_index) = {
+            let mut inner = self.lock();
+            let data = encode_payload(&inner.entries).map_err(|e| StorageError::IO {
+                source: openraft::StorageIOError::write_state_machine(&e),
+            })?;
+            inner.snapshot_seq += 1;
+            let meta = SnapshotMeta {
+                last_log_id: inner.last_applied,
+                last_membership: inner.last_membership.clone(),
+                snapshot_id: format!(
+                    "snapshot-{}-{}-{}",
+                    inner.last_applied.map_or(0, |id| id.index),
+                    inner.snapshot_seq,
+                    current_timestamp_ms(),
+                ),
+            };
+            (meta, data, inner.entries.len() as u64)
         };
-        inner.current_snapshot = Some(StoredSnapshot { meta: meta.clone(), data: data.clone() });
+
+        // Persist BEFORE registering: openraft must never see (and purge
+        // against) a snapshot that is not yet durable.
+        if let Some(store) = &self.store {
+            store.save(&meta, &data).map_err(|e| StorageError::IO {
+                source: openraft::StorageIOError::write_snapshot(Some(meta.signature()), &e),
+            })?;
+        }
+
+        self.lock().current_snapshot =
+            Some(StoredSnapshot { meta: meta.clone(), data: data.clone(), app_index });
 
         Ok(openraft::Snapshot { meta, snapshot: Box::new(Cursor::new(data)) })
+        // `_horizon_pin` drops here: the horizon was held across read,
+        // persistence, and registration.
     }
 }
 
@@ -306,21 +448,34 @@ impl RaftStateMachine<TypeConfig> for InMemoryStateMachine {
         Ok(Box::new(Cursor::new(Vec::new())))
     }
 
+    /// Replace the state machine's contents from a received snapshot:
+    /// applied state, `last_applied`, and membership all jump to the
+    /// snapshot's view. Decode is validated **before** any mutation (a
+    /// corrupt snapshot must not half-install), and with a durable store the
+    /// blob is persisted **before** the install is acknowledged (a follower
+    /// must not confirm an install it could forget across a crash).
     async fn install_snapshot(
         &mut self,
         meta: &SnapshotMeta<u64, BasicNode>,
         snapshot: Box<Cursor<Vec<u8>>>,
     ) -> std::result::Result<(), StorageError<u64>> {
         let data = snapshot.into_inner();
-        let entries: Vec<Vec<u8>> = serde_json::from_slice(&data).map_err(|e| {
-            StorageError::IO { source: openraft::StorageIOError::write_state_machine(&e) }
+        let entries = decode_payload(&data).map_err(|e| StorageError::IO {
+            source: openraft::StorageIOError::write_snapshot(Some(meta.signature()), &e),
         })?;
 
+        if let Some(store) = &self.store {
+            store.save(meta, &data).map_err(|e| StorageError::IO {
+                source: openraft::StorageIOError::write_snapshot(Some(meta.signature()), &e),
+            })?;
+        }
+
         let mut inner = self.lock();
-        inner.entries = entries;
         inner.last_applied = meta.last_log_id;
         inner.last_membership = meta.last_membership.clone();
-        inner.current_snapshot = Some(StoredSnapshot { meta: meta.clone(), data });
+        inner.current_snapshot =
+            Some(StoredSnapshot { meta: meta.clone(), app_index: entries.len() as u64, data });
+        inner.entries = entries;
         Ok(())
     }
 
@@ -417,6 +572,82 @@ pub(crate) enum Bootstrap {
     Recover { last_log_index: Option<u64> },
 }
 
+/// Everything recovered from a data directory: the durable log store, plus a
+/// state machine already seeded from the latest durable snapshot (Raft Phase
+/// A4, PR 1 of #5198). Recovery order is **snapshot first, then log
+/// replay**: the state machine resumes at the snapshot's `last_applied`, and
+/// openraft re-applies only the log suffix above it.
+struct DurableStorage {
+    log_store: DurableLogStore,
+    state_machine: InMemoryStateMachine,
+    /// The raft *log* holds prior state (vote / entries / purge watermark).
+    /// Drives the initialize-vs-recover decision: only a membership entry in
+    /// the log makes re-running `Raft::initialize` illegal.
+    log_has_state: bool,
+    /// Any prior state at all, including a durable snapshot. Drives the
+    /// "cannot restore a snapshot into a stateful directory" rejection.
+    has_any_state: bool,
+    /// Last raw raft log index (entries or purge watermark), for the
+    /// single-node recovery-replay wait.
+    last_log_index: Option<u64>,
+}
+
+impl DurableStorage {
+    fn open(dir: &Path) -> Result<Self> {
+        let (snapshot_store, loaded) = SnapshotStore::open(dir).map_err(|e| {
+            ConsensusError::Backend(format!(
+                "failed to open durable raft snapshot in {}: {e}",
+                dir.display()
+            ))
+        })?;
+        let log_store = DurableLogStore::open(dir, snapshot_store.watermark()).map_err(|e| {
+            ConsensusError::Backend(format!(
+                "failed to open durable raft log in {}: {e}",
+                dir.display()
+            ))
+        })?;
+        let (log_has_state, last_log_index) = log_store.recovery_summary();
+        let snapshot_index = loaded.as_ref().and_then(|s| s.meta.last_log_id).map(|id| id.index);
+
+        // Cross-checks between the two durable artifacts; both are loud
+        // errors because proceeding would silently lose acknowledged state.
+        if let Some(purged) = log_store.last_purged_index() {
+            if snapshot_index.is_none_or(|covered| covered < purged) {
+                return Err(ConsensusError::Backend(format!(
+                    "raft log in {} is purged through index {purged}, but the durable snapshot \
+                     covers only {snapshot_index:?}; entries below the purge point are \
+                     unrecoverable — refusing to start",
+                    dir.display()
+                )));
+            }
+        }
+        if let Some(snapshot_index) = snapshot_index {
+            if last_log_index.is_none_or(|last| last < snapshot_index) {
+                return Err(ConsensusError::Backend(format!(
+                    "durable snapshot in {} covers raft index {snapshot_index}, but the raft \
+                     log ends at {last_log_index:?}; the log has lost acknowledged state — \
+                     refusing to start",
+                    dir.display()
+                )));
+            }
+        }
+
+        let state_machine = InMemoryStateMachine::durable(Arc::clone(&snapshot_store));
+        let mut has_any_state = log_has_state;
+        if let Some(loaded) = loaded {
+            state_machine.seed_from_snapshot(loaded.meta, loaded.data).map_err(|e| {
+                ConsensusError::Backend(format!(
+                    "failed to recover durable raft snapshot in {}: {e}",
+                    dir.display()
+                ))
+            })?;
+            has_any_state = true;
+        }
+
+        Ok(Self { log_store, state_machine, log_has_state, has_any_state, last_log_index })
+    }
+}
+
 /// [`ConsensusBackend`] backed by `openraft` (ADR-0004), running a
 /// single-node configuration (Raft Phase A2).
 ///
@@ -470,7 +701,12 @@ impl<E> OpenraftBackend<E> {
     /// Must be called from within a tokio runtime (openraft spawns its core
     /// tasks on it).
     pub async fn new() -> Result<Self> {
-        Self::start(InMemoryLogStore::default(), Vec::new(), Bootstrap::Initialize).await
+        Self::start(
+            InMemoryLogStore::default(),
+            InMemoryStateMachine::volatile(),
+            Bootstrap::Initialize,
+        )
+        .await
     }
 
     /// Create a backend whose Raft log and vote are **persisted on disk**
@@ -537,25 +773,31 @@ impl<E> OpenraftBackend<E> {
     ///
     /// `restore` carries state-machine entries decoded from a snapshot; it
     /// must only be combined with a *fresh* data directory, since seeding a
-    /// snapshot next to recovered log state would produce two competing
-    /// histories.
+    /// snapshot next to recovered state would produce two competing
+    /// histories. The seed is persisted as a durable snapshot before the
+    /// node starts, so restored state survives later restarts.
     async fn start_durable(dir: &Path, restore: Option<Vec<Vec<u8>>>) -> Result<Self> {
-        let log_store = DurableLogStore::open(dir).map_err(|e| {
-            ConsensusError::Backend(format!(
-                "failed to open durable raft log in {}: {e}",
-                dir.display()
-            ))
-        })?;
-        let (has_state, last_log_index) = log_store.recovery_summary();
-        if has_state && restore.is_some() {
+        let storage = DurableStorage::open(dir)?;
+        if storage.has_any_state && restore.is_some() {
             return Err(ConsensusError::Backend(format!(
                 "cannot restore a snapshot into {}: it already contains raft state",
                 dir.display()
             )));
         }
-        let bootstrap =
-            if has_state { Bootstrap::Recover { last_log_index } } else { Bootstrap::Initialize };
-        Self::start(log_store, restore.unwrap_or_default(), bootstrap).await
+        if let Some(entries) = restore {
+            storage.state_machine.restore_seed(entries).map_err(|e| {
+                ConsensusError::Backend(format!(
+                    "failed to persist the restored snapshot in {}: {e}",
+                    dir.display()
+                ))
+            })?;
+        }
+        let bootstrap = if storage.log_has_state {
+            Bootstrap::Recover { last_log_index: storage.last_log_index }
+        } else {
+            Bootstrap::Initialize
+        };
+        Self::start(storage.log_store, storage.state_machine, bootstrap).await
     }
 
     /// Spawn the Raft core: storage + state machine + network, no membership
@@ -566,7 +808,7 @@ impl<E> OpenraftBackend<E> {
         node_id: u64,
         network: NF,
         log_store: LS,
-        entries: Vec<Vec<u8>>,
+        state_machine: InMemoryStateMachine,
     ) -> Result<Self>
     where
         LS: RaftLogStorage<TypeConfig>,
@@ -585,12 +827,9 @@ impl<E> OpenraftBackend<E> {
         let config =
             Arc::new(config.validate().map_err(|e| ConsensusError::Backend(e.to_string()))?);
 
-        let state_machine = InMemoryStateMachine::default();
-        // Seed the state machine before the Raft core starts so restored
-        // entries keep their application log indices and new proposals
-        // continue numbering after them.
-        state_machine.lock().entries = entries;
-
+        // The state machine arrives pre-seeded (from a durable snapshot or a
+        // restore artifact) so recovered entries keep their application log
+        // indices and new proposals continue numbering after them.
         let raft = Raft::new(node_id, config, network, log_store, state_machine.clone())
             .await
             .map_err(|e| ConsensusError::Backend(format!("failed to start raft core: {e}")))?;
@@ -639,7 +878,14 @@ impl<E> OpenraftBackend<E> {
     ///
     /// Must be called from within a tokio runtime.
     pub async fn join_tcp_cluster(node_id: u64, config: &ClusterConfig) -> Result<Self> {
-        Self::join_tcp(node_id, config, InMemoryLogStore::default(), Bootstrap::Initialize).await
+        Self::join_tcp(
+            node_id,
+            config,
+            InMemoryLogStore::default(),
+            InMemoryStateMachine::volatile(),
+            Bootstrap::Initialize,
+        )
+        .await
     }
 
     /// Like [`join_tcp_cluster`](Self::join_tcp_cluster), but the node's
@@ -653,27 +899,22 @@ impl<E> OpenraftBackend<E> {
         dir: impl AsRef<Path>,
     ) -> Result<Self> {
         let dir = dir.as_ref();
-        let log_store = DurableLogStore::open(dir).map_err(|e| {
-            ConsensusError::Backend(format!(
-                "failed to open durable raft log in {}: {e}",
-                dir.display()
-            ))
-        })?;
-        let (has_state, _) = log_store.recovery_summary();
+        let storage = DurableStorage::open(dir)?;
         // Cluster members do not wait for local replay (`last_log_index:
         // None`): convergence is a cluster-level outcome the caller awaits.
-        let bootstrap = if has_state {
+        let bootstrap = if storage.log_has_state {
             Bootstrap::Recover { last_log_index: None }
         } else {
             Bootstrap::Initialize
         };
-        Self::join_tcp(node_id, config, log_store, bootstrap).await
+        Self::join_tcp(node_id, config, storage.log_store, storage.state_machine, bootstrap).await
     }
 
     async fn join_tcp<LS>(
         node_id: u64,
         config: &ClusterConfig,
         log_store: LS,
+        state_machine: InMemoryStateMachine,
         bootstrap: Bootstrap,
     ) -> Result<Self>
     where
@@ -691,18 +932,22 @@ impl<E> OpenraftBackend<E> {
         })?;
 
         let network = crate::tcp::TcpNetworkFactory::new(config);
-        let mut backend = Self::boot(node_id, network, log_store, Vec::new()).await?;
+        let mut backend = Self::boot(node_id, network, log_store, state_machine).await?;
         backend.listener_task = Some(crate::tcp::spawn_listener(backend.raft.clone(), listener));
 
         backend.establish_membership(config.membership(), bootstrap).await?;
         Ok(backend)
     }
 
-    async fn start<LS>(log_store: LS, entries: Vec<Vec<u8>>, bootstrap: Bootstrap) -> Result<Self>
+    async fn start<LS>(
+        log_store: LS,
+        state_machine: InMemoryStateMachine,
+        bootstrap: Bootstrap,
+    ) -> Result<Self>
     where
         LS: RaftLogStorage<TypeConfig>,
     {
-        let backend = Self::boot(NODE_ID, NoopNetworkFactory, log_store, entries).await?;
+        let backend = Self::boot(NODE_ID, NoopNetworkFactory, log_store, state_machine).await?;
 
         if matches!(bootstrap, Bootstrap::Initialize) {
             let mut members = BTreeMap::new();
@@ -726,8 +971,8 @@ impl<E> OpenraftBackend<E> {
             .map_err(|e| ConsensusError::Backend(format!("leader election did not settle: {e}")))?;
 
         if let Bootstrap::Recover { last_log_index: Some(last) } = bootstrap {
-            // The state machine is in-memory (until Phase B1) and therefore
-            // starts empty on every boot; wait for the recovered log to be
+            // The state machine resumes from the durable snapshot (or empty,
+            // if none exists); wait for the recovered log suffix to be
             // re-applied so `read_committed` and `last_index` reflect
             // pre-restart state before the constructor returns.
             backend
@@ -773,7 +1018,8 @@ impl<E> OpenraftBackend<E> {
         LS: RaftLogStorage<TypeConfig>,
     {
         let network = crate::network::ChannelNetworkFactory::new(router.clone());
-        let backend = Self::boot(node_id, network, log_store, Vec::new()).await?;
+        let backend =
+            Self::boot(node_id, network, log_store, InMemoryStateMachine::volatile()).await?;
 
         // Register the inbound RPC loop *before* initializing, so peers that
         // initialized first can already send this node vote/append RPCs.
@@ -786,25 +1032,35 @@ impl<E> OpenraftBackend<E> {
 
 impl<E: DeserializeOwned> OpenraftBackend<E> {
     /// Rebuild a backend from a snapshot previously produced by
-    /// [`ConsensusBackend::snapshot`] on an `OpenraftBackend`.
+    /// [`ConsensusBackend::snapshot`] on an `OpenraftBackend` — restoring a
+    /// backup into a **new** consensus group with a fresh log.
     ///
-    /// Like [`SingleNodeBackend::from_snapshot`](crate::SingleNodeBackend::from_snapshot)
-    /// this is an inherent method: snapshot *installation* hooks join the
-    /// trait in later Raft phases. The restored entries seed the state
+    /// This is distinct from openraft's
+    /// [`install_snapshot`](RaftStateMachine::install_snapshot), which
+    /// replaces a *replica's* state within an existing group (carrying the
+    /// group's raft meta); both paths share the same payload codec and
+    /// state-machine seeding (`crate::snapshot`), so there is one snapshot
+    /// mechanism with two entry points. The restored entries seed the state
     /// machine; the Raft log itself starts fresh (and in-memory — see
     /// [`from_snapshot_with_data_dir`](Self::from_snapshot_with_data_dir)
     /// for a durable restore).
     pub async fn from_snapshot(snapshot: &Snapshot) -> Result<Self> {
         let entries = Self::decode_snapshot(snapshot)?;
-        Self::start(InMemoryLogStore::default(), entries, Bootstrap::Initialize).await
+        let state_machine = InMemoryStateMachine::volatile();
+        state_machine
+            .restore_seed(entries)
+            .map_err(|e| ConsensusError::SnapshotCodec(e.to_string()))?;
+        Self::start(InMemoryLogStore::default(), state_machine, Bootstrap::Initialize).await
     }
 
     /// Like [`from_snapshot`](Self::from_snapshot), but the restored node
-    /// persists its Raft log and vote under `dir` (Raft Phase A2, PR 2).
+    /// persists its Raft log and vote under `dir` (Raft Phase A2, PR 2) and,
+    /// since Phase A4, the restored entries themselves as a durable seed
+    /// snapshot — so the restored state also survives restarts.
     ///
-    /// `dir` must not already contain Raft state: a snapshot seeded next to a
-    /// recovered log would be two competing histories, so that case is
-    /// rejected.
+    /// `dir` must not already contain Raft state (log *or* snapshot): a
+    /// restore seeded next to recovered state would be two competing
+    /// histories, so that case is rejected.
     pub async fn from_snapshot_with_data_dir(
         snapshot: &Snapshot,
         dir: impl AsRef<Path>,
@@ -816,7 +1072,7 @@ impl<E: DeserializeOwned> OpenraftBackend<E> {
     /// Decode and validate a [`Snapshot`] produced by
     /// [`ConsensusBackend::snapshot`] into state-machine entries.
     fn decode_snapshot(snapshot: &Snapshot) -> Result<Vec<Vec<u8>>> {
-        let entries: Vec<Vec<u8>> = serde_json::from_slice(&snapshot.data)
+        let entries = decode_payload(&snapshot.data)
             .map_err(|e| ConsensusError::SnapshotCodec(e.to_string()))?;
         if entries.len() as LogIndex != snapshot.last_included_index {
             return Err(ConsensusError::SnapshotCodec(format!(
@@ -873,11 +1129,49 @@ where
         serde_json::from_slice(&payload).map_err(|e| ConsensusError::Backend(e.to_string()))
     }
 
+    /// Capture a snapshot through openraft's real snapshot pipeline (Raft
+    /// Phase A4): trigger a build, wait for the engine to run
+    /// [`RaftSnapshotBuilder::build_snapshot`] (which pins the vacuum
+    /// horizon and — on durable configurations — persists the blob before
+    /// registering it), then hand back the registered artifact. The Phase A2
+    /// shortcut that serialized the state machine directly, bypassing the
+    /// builder, is gone (judge follow-up from PR #5351).
     async fn snapshot(&self) -> Result<Snapshot> {
-        let inner = self.state_machine.lock();
-        let data = serde_json::to_vec(&inner.entries)
-            .map_err(|e| ConsensusError::SnapshotCodec(e.to_string()))?;
-        Ok(Snapshot { last_included_index: inner.entries.len() as LogIndex, data })
+        let Some(target) = self.metrics.borrow().last_applied else {
+            // Nothing applied yet (not even a membership entry): there is no
+            // log id for openraft to build a snapshot at, and nothing for
+            // the builder to capture. Unreachable through the public
+            // constructors, which all wait for membership to apply.
+            return Ok(Snapshot {
+                last_included_index: 0,
+                data: encode_payload(&[])
+                    .map_err(|e| ConsensusError::SnapshotCodec(e.to_string()))?,
+            });
+        };
+
+        self.raft
+            .trigger()
+            .snapshot()
+            .await
+            .map_err(|e| ConsensusError::Backend(format!("failed to trigger snapshot: {e}")))?;
+
+        // The trigger returns once accepted, not once built: wait until the
+        // engine reports a snapshot covering everything applied at the time
+        // of this call. (If such a snapshot already exists, the engine may
+        // skip the build; the artifact is identical either way.)
+        self.raft
+            .wait(Some(Duration::from_secs(10)))
+            .metrics(move |m| m.snapshot >= Some(target), "snapshot build")
+            .await
+            .map_err(|e| ConsensusError::Backend(format!("snapshot build did not settle: {e}")))?;
+
+        let (last_included_index, data) =
+            self.state_machine.current_snapshot_artifact().ok_or_else(|| {
+                ConsensusError::Backend(
+                    "snapshot build settled but no snapshot is registered".to_string(),
+                )
+            })?;
+        Ok(Snapshot { last_included_index, data })
     }
 
     fn role(&self) -> Role {
@@ -887,6 +1181,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    use openraft::CommittedLeaderId;
+    use tempfile::TempDir;
+
     use super::*;
 
     /// `shutdown` stops the Raft core cleanly: subsequent proposals fail
@@ -908,5 +1205,262 @@ mod tests {
         // Applied state is served from the state machine, not the core.
         assert_eq!(backend.read_committed(1).await.unwrap(), "before");
         assert_eq!(backend.last_index(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Raft Phase A4, PR 1 (#5198): snapshot builder, durable snapshots,
+    // vacuum-horizon pin, purge safety.
+    // -----------------------------------------------------------------------
+
+    /// [`SnapshotHorizonPin`] that records acquire/release ordering, and
+    /// (optionally) whether the snapshot file was already durable when the
+    /// pin was released — proving the pin is held across the whole build,
+    /// persistence included.
+    #[derive(Debug, Default)]
+    struct RecordingPin {
+        events: Arc<Mutex<Vec<String>>>,
+        expect_file: Option<std::path::PathBuf>,
+    }
+
+    struct RecordingGuard {
+        events: Arc<Mutex<Vec<String>>>,
+        expect_file: Option<std::path::PathBuf>,
+    }
+
+    impl Drop for RecordingGuard {
+        fn drop(&mut self) {
+            let event = match &self.expect_file {
+                None => "released",
+                Some(path) if path.exists() => "released-after-durable",
+                Some(_) => "released-before-durable",
+            };
+            self.events.lock().unwrap().push(event.to_string());
+        }
+    }
+
+    impl SnapshotHorizonPin for RecordingPin {
+        fn acquire(&self) -> Box<dyn Send> {
+            self.events.lock().unwrap().push("acquired".to_string());
+            Box::new(RecordingGuard {
+                events: Arc::clone(&self.events),
+                expect_file: self.expect_file.clone(),
+            })
+        }
+    }
+
+    fn events_of(events: &Arc<Mutex<Vec<String>>>) -> Vec<String> {
+        events.lock().unwrap().clone()
+    }
+
+    /// Build on one node, install into a fresh state machine: applied state,
+    /// `last_applied`, and membership all come out identical.
+    #[tokio::test]
+    async fn snapshot_build_install_roundtrip_restores_state_and_meta() {
+        let backend = OpenraftBackend::<String>::new().await.unwrap();
+        for i in 1..=3u64 {
+            backend.propose(format!("entry-{i}")).await.unwrap();
+        }
+        // Build + register through the engine's real snapshot pipeline.
+        backend.snapshot().await.unwrap();
+
+        let mut source = backend.state_machine.clone();
+        let built = source.get_current_snapshot().await.unwrap().expect("snapshot registered");
+
+        let mut target = InMemoryStateMachine::volatile();
+        target.install_snapshot(&built.meta, built.snapshot).await.unwrap();
+
+        let (source_applied, source_membership) = source.applied_state().await.unwrap();
+        let (target_applied, target_membership) = target.applied_state().await.unwrap();
+        assert!(source_applied.is_some(), "source has applied entries");
+        assert_eq!(source_applied, target_applied);
+        assert_eq!(source_membership, target_membership);
+        assert_eq!(source.lock().entries, target.lock().entries);
+        assert_eq!(target.lock().entries.len(), 3);
+    }
+
+    /// A corrupt snapshot must fail the install loudly and leave the state
+    /// machine untouched — never half-install.
+    #[tokio::test]
+    async fn install_of_a_corrupt_snapshot_is_rejected_without_mutation() {
+        let machine = InMemoryStateMachine::volatile();
+        machine.lock().entries = vec![b"keep me".to_vec()];
+
+        let meta = SnapshotMeta {
+            last_log_id: Some(LogId::new(CommittedLeaderId::new(1, 1), 9)),
+            last_membership: StoredMembership::default(),
+            snapshot_id: "bogus".to_string(),
+        };
+        let mut handle = machine.clone();
+        handle
+            .install_snapshot(&meta, Box::new(Cursor::new(b"not a payload".to_vec())))
+            .await
+            .unwrap_err();
+
+        let inner = machine.lock();
+        assert_eq!(inner.entries, vec![b"keep me".to_vec()]);
+        assert_eq!(inner.last_applied, None, "meta must not be applied either");
+    }
+
+    /// `ConsensusBackend::snapshot` no longer bypasses the snapshot builder
+    /// (judge follow-up from PR #5351): the builder runs, and with it the
+    /// vacuum-horizon pin, acquired before and released after the build.
+    #[tokio::test]
+    async fn trait_snapshot_runs_the_builder_and_pins_the_horizon() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut machine = InMemoryStateMachine::volatile();
+        machine.pin = Arc::new(RecordingPin { events: Arc::clone(&events), expect_file: None });
+
+        let backend = OpenraftBackend::<String>::start(
+            InMemoryLogStore::default(),
+            machine,
+            Bootstrap::Initialize,
+        )
+        .await
+        .unwrap();
+        backend.propose("entry-1".to_string()).await.unwrap();
+        assert!(events_of(&events).is_empty(), "no build before snapshot() is called");
+
+        let snapshot = backend.snapshot().await.unwrap();
+        assert_eq!(snapshot.last_included_index, 1);
+        assert_eq!(events_of(&events), vec!["acquired".to_string(), "released".to_string()]);
+    }
+
+    /// On a durable configuration, the pin is held until the snapshot file
+    /// is on disk: the guard observes the durable file at release time.
+    #[tokio::test]
+    async fn horizon_pin_is_held_until_the_snapshot_is_durable() {
+        let dir = TempDir::new().unwrap();
+        let (store, _) = SnapshotStore::open(dir.path()).unwrap();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let expect_file = dir.path().join("snapshot-3.bin");
+
+        let mut machine = InMemoryStateMachine::durable(store);
+        machine.pin = Arc::new(RecordingPin {
+            events: Arc::clone(&events),
+            expect_file: Some(expect_file.clone()),
+        });
+        {
+            let mut inner = machine.lock();
+            inner.entries = vec![b"a".to_vec(), b"b".to_vec()];
+            inner.last_applied = Some(LogId::new(CommittedLeaderId::new(1, 1), 3));
+        }
+
+        let built = machine.build_snapshot().await.unwrap();
+        assert_eq!(built.meta.last_log_id.unwrap().index, 3);
+        assert!(expect_file.exists(), "snapshot persisted to the data dir");
+        assert_eq!(
+            events_of(&events),
+            vec!["acquired".to_string(), "released-after-durable".to_string()]
+        );
+    }
+
+    /// The full Phase A4 PR 1 story on one durable node: build a snapshot,
+    /// purge the log up to it (legal — at the durable snapshot), write past
+    /// it, restart. Recovery loads the snapshot first, then replays the log
+    /// suffix; the purged prefix is only recoverable through the snapshot.
+    #[tokio::test]
+    async fn durable_recovery_loads_snapshot_then_replays_log() {
+        let dir = TempDir::new().unwrap();
+        {
+            let backend = OpenraftBackend::<String>::with_data_dir(dir.path()).await.unwrap();
+            for i in 1..=3u64 {
+                backend.propose(format!("entry-{i}")).await.unwrap();
+            }
+            let snapshot = backend.snapshot().await.unwrap();
+            assert_eq!(snapshot.last_included_index, 3);
+
+            // Purge the log up to the durable snapshot. (Triggering purge is
+            // manual here; *when* to purge — the policy — is PR 2.)
+            let snapshot_log_id = backend.metrics.borrow().snapshot.expect("snapshot built");
+            backend.raft.trigger().purge_log(snapshot_log_id.index).await.unwrap();
+            backend
+                .raft
+                .wait(Some(Duration::from_secs(10)))
+                .metrics(move |m| m.purged >= Some(snapshot_log_id), "log purged")
+                .await
+                .unwrap();
+
+            // Write past the purge point so recovery must stitch
+            // snapshot + log suffix.
+            for i in 4..=5u64 {
+                backend.propose(format!("entry-{i}")).await.unwrap();
+            }
+            backend.shutdown().await.unwrap();
+        }
+
+        let backend = OpenraftBackend::<String>::with_data_dir(dir.path()).await.unwrap();
+        assert_eq!(backend.last_index(), 5);
+        for i in 1..=5u64 {
+            assert_eq!(backend.read_committed(i).await.unwrap(), format!("entry-{i}"));
+        }
+        // Numbering continues after the stitched prefix.
+        assert_eq!(backend.propose("entry-6".to_string()).await.unwrap(), 6);
+    }
+
+    /// A corrupt durable snapshot fails recovery loudly — never a silent
+    /// fresh start (the log may be purged up to that snapshot).
+    #[tokio::test]
+    async fn corrupt_durable_snapshot_fails_recovery_loudly() {
+        let dir = TempDir::new().unwrap();
+        {
+            let backend = OpenraftBackend::<String>::with_data_dir(dir.path()).await.unwrap();
+            backend.propose("entry-1".to_string()).await.unwrap();
+            backend.snapshot().await.unwrap();
+            backend.shutdown().await.unwrap();
+        }
+
+        let snapshot_path = std::fs::read_dir(dir.path())
+            .unwrap()
+            .flatten()
+            .map(|e| e.path())
+            .find(|p| {
+                p.file_name().is_some_and(|n| {
+                    let n = n.to_string_lossy();
+                    n.starts_with("snapshot-") && n.ends_with(".bin")
+                })
+            })
+            .expect("a durable snapshot file exists");
+        let mut buf = std::fs::read(&snapshot_path).unwrap();
+        let last = buf.len() - 1;
+        buf[last] ^= 0xFF;
+        std::fs::write(&snapshot_path, &buf).unwrap();
+
+        let err = OpenraftBackend::<String>::with_data_dir(dir.path()).await.unwrap_err();
+        assert!(
+            matches!(err, ConsensusError::Backend(ref msg) if msg.contains("corrupt")),
+            "unexpected result: {err:?}"
+        );
+    }
+
+    /// Restoring a `ConsensusBackend::snapshot` artifact into a durable data
+    /// dir persists the restored state as a durable seed snapshot, so it now
+    /// survives restarts of the restored node (pre-A4 it lived only in
+    /// memory and a restart silently lost it).
+    #[tokio::test]
+    async fn restored_durable_backend_survives_restart() {
+        let snapshot = {
+            let source = OpenraftBackend::<String>::new().await.unwrap();
+            for i in 1..=3u64 {
+                source.propose(format!("entry-{i}")).await.unwrap();
+            }
+            source.snapshot().await.unwrap()
+        };
+
+        let dir = TempDir::new().unwrap();
+        {
+            let restored =
+                OpenraftBackend::<String>::from_snapshot_with_data_dir(&snapshot, dir.path())
+                    .await
+                    .unwrap();
+            assert_eq!(restored.last_index(), 3);
+            assert_eq!(restored.propose("entry-4".to_string()).await.unwrap(), 4);
+            restored.shutdown().await.unwrap();
+        }
+
+        let reopened = OpenraftBackend::<String>::with_data_dir(dir.path()).await.unwrap();
+        assert_eq!(reopened.last_index(), 4);
+        for i in 1..=4u64 {
+            assert_eq!(reopened.read_committed(i).await.unwrap(), format!("entry-{i}"));
+        }
     }
 }

--- a/crates/vibesql-consensus/src/snapshot.rs
+++ b/crates/vibesql-consensus/src/snapshot.rs
@@ -1,0 +1,625 @@
+//! Durable snapshot persistence, the snapshot payload codec, and the MVCC
+//! vacuum-horizon pin for [`OpenraftBackend`] (Raft Phase A4, PR 1 of issue
+//! #5198).
+//!
+//! Three concerns live here, all consumed by the state machine in
+//! `openraft_backend.rs`:
+//!
+//! 1. **Payload codec** ([`encode_payload`] / [`decode_payload`]): the byte
+//!    encoding of the state machine's applied state inside a snapshot.
+//! 2. **Durable persistence** ([`SnapshotStore`]): snapshot blobs written to
+//!    the data directory with tmp/rename atomicity, recovered on restart,
+//!    and rejected **loudly** when corrupt.
+//! 3. **GC interlock** ([`SnapshotHorizonPin`]): the hook through which an
+//!    in-progress snapshot build pins the MVCC vacuum horizon, plus the
+//!    no-op implementation for the current echo state machine.
+//!
+//! ## File format
+//!
+//! One file per snapshot, `snapshot-<raw raft index>.bin`, in the same data
+//! directory as `raft.log`. The framing mirrors the conventions of
+//! `crate::durable` (magic + version + CRC-32 over each frame):
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────┐
+//! │ Magic: "VSNP" (4 bytes)                     │
+//! │ Version: u32 LE                             │
+//! ├─────────────────────────────────────────────┤
+//! │ Meta frame:  [len:u32][crc:u32][meta JSON]  │  SnapshotMeta
+//! ├─────────────────────────────────────────────┤
+//! │ Data frame:  [len:u64][crc:u32][data bytes] │  payload blob
+//! └─────────────────────────────────────────────┘
+//! ```
+//!
+//! Writes go to `snapshot-<index>.bin.tmp`, are fsynced, then renamed over
+//! the final name (followed by a directory fsync), so a crash mid-write can
+//! never leave a torn *final* file — only a `.tmp` leftover, which was never
+//! acknowledged and is silently removed on the next open.
+//!
+//! ## Corruption handling
+//!
+//! A final `snapshot-<index>.bin` that fails validation (bad magic, bad
+//! version, CRC mismatch, truncation, trailing bytes, undecodable meta) is
+//! **real corruption**, not a crash artifact — the rename was atomic and the
+//! contents were fsynced first. Following the same philosophy as
+//! `crate::durable` (etcd's tail-only repair rule; see PR #5357): the open
+//! fails loudly with `InvalidData` and the file is left byte-for-byte
+//! untouched for inspection. There is **no silent fall back** to an older
+//! snapshot or to a fresh state machine, because the raft log may already be
+//! purged up to this snapshot's index — starting fresh would silently lose
+//! acknowledged state.
+//!
+//! ## Purge safety
+//!
+//! [`DurableSnapshotWatermark`] is the bridge between the snapshot store and
+//! the log store: it carries the raw raft index of the last snapshot that is
+//! **durable on disk**. `DurableLogStore::purge` refuses to purge above it
+//! (the Phase A4 safety rule: log entries may only be discarded once a
+//! durable snapshot covers them). The watermark only advances *after* the
+//! snapshot file is fsynced and renamed, so openraft can never be told about
+//! — and can never purge against — a snapshot that might not survive a
+//! crash.
+//!
+//! [`OpenraftBackend`]: crate::OpenraftBackend
+
+use std::fmt::Debug;
+use std::fs::File;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use openraft::{BasicNode, SnapshotMeta};
+
+use crate::durable::crc32;
+
+/// Current snapshot file format version.
+const SNAPSHOT_VERSION: u32 = 1;
+
+/// Magic number for snapshot files: "VSNP" (cf. the raft log's "VRFT").
+const SNAPSHOT_MAGIC: &[u8; 4] = b"VSNP";
+
+/// `magic + version`.
+const SNAPSHOT_HEADER_SIZE: usize = 8;
+
+// ---------------------------------------------------------------------------
+// Payload codec
+// ---------------------------------------------------------------------------
+//
+// The snapshot *payload* is the serialized applied state of the state
+// machine. Until Phase B1 (#5199) wires the real MVCC-backed state machine,
+// that state is the echo machine's ordered list of applied entry payloads,
+// and serde_json is its (test-scale) encoding. B1 replaces this codec with a
+// streamed database-state encoding reusing the writers in
+// `vibesql-storage::persistence::binary` — those writers serialize *tables*,
+// which the echo machine does not have, so coupling to them now would be
+// premature (see the curator re-scope on #5198). Keeping the codec isolated
+// here means only this seam changes when B1 lands.
+
+/// Encode the state machine's applied entries into a snapshot payload blob.
+pub(crate) fn encode_payload(entries: &[Vec<u8>]) -> serde_json::Result<Vec<u8>> {
+    serde_json::to_vec(entries)
+}
+
+/// Decode a snapshot payload blob back into applied entries.
+pub(crate) fn decode_payload(data: &[u8]) -> serde_json::Result<Vec<Vec<u8>>> {
+    serde_json::from_slice(data)
+}
+
+// ---------------------------------------------------------------------------
+// MVCC vacuum-horizon pin
+// ---------------------------------------------------------------------------
+
+/// Hook through which a snapshot build pins the MVCC vacuum horizon.
+///
+/// A snapshot is a consistent view of the state machine at a specific apply
+/// index; row versions visible at that index must not be reclaimed while the
+/// build reads them. [`RaftSnapshotBuilder::build_snapshot`] acquires a
+/// guard from this hook **before** reading any state and holds it until the
+/// snapshot is built, durably persisted, and registered — dropping the guard
+/// is what releases the horizon.
+///
+/// The state machine is not MVCC-wired until Phase B1 (#5199), so the only
+/// production implementation today is the no-op [`NoopHorizonPin`]. B1
+/// implements this by registering the snapshot build as (or alongside) an
+/// active read transaction in
+/// `vibesql-storage::database::transaction_api` — the existing
+/// `compute_gc_horizon` holdback for active transactions then covers the
+/// build with no new watermark type (see
+/// `vacuum_mvcc_horizon_held_back_by_active_transaction` in the storage
+/// crate's vacuum tests).
+///
+/// [`RaftSnapshotBuilder::build_snapshot`]: openraft::RaftSnapshotBuilder::build_snapshot
+pub(crate) trait SnapshotHorizonPin: Send + Sync + Debug {
+    /// Acquire the pin. The returned guard releases it on drop.
+    fn acquire(&self) -> Box<dyn Send>;
+}
+
+/// No-op pin for the pre-B1 echo state machine (nothing to hold back: its
+/// state is an in-memory `Vec` read under the state-machine mutex).
+#[derive(Debug, Default)]
+pub(crate) struct NoopHorizonPin;
+
+impl SnapshotHorizonPin for NoopHorizonPin {
+    fn acquire(&self) -> Box<dyn Send> {
+        Box::new(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Durable snapshot watermark
+// ---------------------------------------------------------------------------
+
+/// The raw raft index of the last snapshot that is **durable on disk**
+/// (`None` until one exists). Shared between [`SnapshotStore`] (which
+/// advances it) and `DurableLogStore` (whose `purge` refuses to exceed it).
+///
+/// `0` is the "no snapshot" sentinel: raw raft log indices are 1-based, so
+/// no real snapshot ever covers index 0 (a restore-seeded snapshot with no
+/// raft meta reports index 0 and deliberately legalizes no purge).
+#[derive(Debug, Default)]
+pub(crate) struct DurableSnapshotWatermark(AtomicU64);
+
+impl DurableSnapshotWatermark {
+    /// The last durably snapshotted raw index, if any.
+    pub(crate) fn get(&self) -> Option<u64> {
+        match self.0.load(Ordering::SeqCst) {
+            0 => None,
+            index => Some(index),
+        }
+    }
+
+    /// Monotonically advance the watermark (lower values are ignored).
+    pub(crate) fn advance(&self, index: u64) {
+        self.0.fetch_max(index, Ordering::SeqCst);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The durable snapshot store
+// ---------------------------------------------------------------------------
+
+/// A snapshot recovered from disk on open.
+#[derive(Debug)]
+pub(crate) struct LoadedSnapshot {
+    pub(crate) meta: SnapshotMeta<u64, BasicNode>,
+    pub(crate) data: Vec<u8>,
+}
+
+/// Durable snapshot persistence under a data directory (alongside
+/// `raft.log`). See the module docs for format, atomicity, and corruption
+/// rules.
+#[derive(Debug)]
+pub(crate) struct SnapshotStore {
+    dir: PathBuf,
+    watermark: Arc<DurableSnapshotWatermark>,
+}
+
+/// The raw raft index a snapshot file is named after (`0` for snapshots
+/// whose meta carries no log id, e.g. restore seeds).
+fn file_index(meta: &SnapshotMeta<u64, BasicNode>) -> u64 {
+    meta.last_log_id.map_or(0, |id| id.index)
+}
+
+fn snapshot_file_name(index: u64) -> String {
+    format!("snapshot-{index}.bin")
+}
+
+/// Parse `snapshot-<index>.bin` back into `<index>`; `None` for anything
+/// else (foreign files are ignored, never deleted).
+fn parse_snapshot_file_name(name: &str) -> Option<u64> {
+    name.strip_prefix("snapshot-")?.strip_suffix(".bin")?.parse().ok()
+}
+
+fn corrupt(path: &Path, detail: impl std::fmt::Display) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!(
+            "durable raft snapshot {} is corrupt: {detail}; refusing to start — the file has \
+             been left untouched for inspection (the raft log may be purged up to this \
+             snapshot, so silently ignoring it could lose acknowledged state)",
+            path.display()
+        ),
+    )
+}
+
+fn encode_snapshot_file(meta: &SnapshotMeta<u64, BasicNode>, data: &[u8]) -> io::Result<Vec<u8>> {
+    let meta_json = serde_json::to_vec(meta).map_err(io::Error::other)?;
+    let mut buf = Vec::with_capacity(SNAPSHOT_HEADER_SIZE + 8 + meta_json.len() + 12 + data.len());
+    buf.extend_from_slice(SNAPSHOT_MAGIC);
+    buf.extend_from_slice(&SNAPSHOT_VERSION.to_le_bytes());
+    buf.extend_from_slice(&(meta_json.len() as u32).to_le_bytes());
+    buf.extend_from_slice(&crc32(&meta_json).to_le_bytes());
+    buf.extend_from_slice(&meta_json);
+    buf.extend_from_slice(&(data.len() as u64).to_le_bytes());
+    buf.extend_from_slice(&crc32(data).to_le_bytes());
+    buf.extend_from_slice(data);
+    Ok(buf)
+}
+
+fn decode_snapshot_file(
+    path: &Path,
+    buf: &[u8],
+) -> io::Result<(SnapshotMeta<u64, BasicNode>, Vec<u8>)> {
+    if buf.len() < SNAPSHOT_HEADER_SIZE {
+        return Err(corrupt(path, "file is shorter than the 8-byte header"));
+    }
+    if &buf[0..4] != SNAPSHOT_MAGIC {
+        return Err(corrupt(
+            path,
+            format!("expected magic 'VSNP', got '{}'", String::from_utf8_lossy(&buf[0..4])),
+        ));
+    }
+    let version = u32::from_le_bytes(buf[4..8].try_into().expect("4-byte slice"));
+    if version > SNAPSHOT_VERSION {
+        return Err(corrupt(
+            path,
+            format!("unsupported snapshot version {version} (current: {SNAPSHOT_VERSION})"),
+        ));
+    }
+
+    // Meta frame.
+    let mut offset = SNAPSHOT_HEADER_SIZE;
+    if buf.len() - offset < 8 {
+        return Err(corrupt(path, "truncated meta frame header"));
+    }
+    let meta_len =
+        u32::from_le_bytes(buf[offset..offset + 4].try_into().expect("4-byte slice")) as usize;
+    let meta_crc =
+        u32::from_le_bytes(buf[offset + 4..offset + 8].try_into().expect("4-byte slice"));
+    offset += 8;
+    let Some(meta_end) = offset.checked_add(meta_len).filter(|&end| end <= buf.len()) else {
+        return Err(corrupt(path, "meta frame length exceeds the file"));
+    };
+    let meta_json = &buf[offset..meta_end];
+    if crc32(meta_json) != meta_crc {
+        return Err(corrupt(path, "meta frame checksum mismatch"));
+    }
+    let meta: SnapshotMeta<u64, BasicNode> = serde_json::from_slice(meta_json)
+        .map_err(|e| corrupt(path, format!("meta frame failed to decode: {e}")))?;
+    offset = meta_end;
+
+    // Data frame.
+    if buf.len() - offset < 12 {
+        return Err(corrupt(path, "truncated data frame header"));
+    }
+    let data_len =
+        u64::from_le_bytes(buf[offset..offset + 8].try_into().expect("8-byte slice")) as usize;
+    let data_crc =
+        u32::from_le_bytes(buf[offset + 8..offset + 12].try_into().expect("4-byte slice"));
+    offset += 12;
+    let Some(data_end) = offset.checked_add(data_len).filter(|&end| end <= buf.len()) else {
+        return Err(corrupt(path, "data frame length exceeds the file"));
+    };
+    let data = &buf[offset..data_end];
+    if crc32(data) != data_crc {
+        return Err(corrupt(path, "data frame checksum mismatch"));
+    }
+    if data_end != buf.len() {
+        return Err(corrupt(
+            path,
+            format!("{} trailing bytes after the data frame", buf.len() - data_end),
+        ));
+    }
+
+    Ok((meta, data.to_vec()))
+}
+
+/// fsync the directory containing `path` so renames/creations are durable.
+fn sync_dir(dir: &Path) -> io::Result<()> {
+    File::open(dir)?.sync_data()?;
+    Ok(())
+}
+
+impl SnapshotStore {
+    /// Open the snapshot store under `dir` (created if absent), recovering
+    /// the latest snapshot if one exists.
+    ///
+    /// Crash leftovers (`*.tmp`, never acknowledged) are removed silently. A
+    /// corrupt *final* snapshot file is a loud [`io::ErrorKind::InvalidData`]
+    /// error — see the module docs for why there is no silent fallback.
+    pub(crate) fn open(dir: &Path) -> io::Result<(Arc<Self>, Option<LoadedSnapshot>)> {
+        std::fs::create_dir_all(dir)?;
+
+        let mut latest: Option<(u64, PathBuf)> = None;
+        for entry in std::fs::read_dir(dir)? {
+            let entry = entry?;
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if name.starts_with("snapshot-") && name.ends_with(".tmp") {
+                // A tmp file is a crash mid-write: it was never renamed, so
+                // it was never acknowledged. Removing it is safe.
+                let _ = std::fs::remove_file(entry.path());
+                continue;
+            }
+            if let Some(index) = parse_snapshot_file_name(&name) {
+                if latest.as_ref().is_none_or(|(best, _)| index > *best) {
+                    latest = Some((index, entry.path()));
+                }
+            }
+        }
+
+        let watermark = Arc::new(DurableSnapshotWatermark::default());
+        let loaded = match latest {
+            None => None,
+            Some((index, path)) => {
+                let buf = std::fs::read(&path)?;
+                let (meta, data) = decode_snapshot_file(&path, &buf)?;
+                if file_index(&meta) != index {
+                    return Err(corrupt(
+                        &path,
+                        format!(
+                            "file is named for index {index} but its meta covers index {}",
+                            file_index(&meta)
+                        ),
+                    ));
+                }
+                watermark.advance(index);
+                Some(LoadedSnapshot { meta, data })
+            }
+        };
+
+        Ok((Arc::new(Self { dir: dir.to_path_buf(), watermark }), loaded))
+    }
+
+    /// Shared watermark handle for the log store's purge-safety check.
+    pub(crate) fn watermark(&self) -> Arc<DurableSnapshotWatermark> {
+        Arc::clone(&self.watermark)
+    }
+
+    /// Durably persist a snapshot: write to a tmp file, fsync, rename over
+    /// the final name, fsync the directory, **then** advance the watermark
+    /// (so purge can never get ahead of what is actually on disk). Older
+    /// snapshot files are removed best-effort afterwards.
+    pub(crate) fn save(&self, meta: &SnapshotMeta<u64, BasicNode>, data: &[u8]) -> io::Result<()> {
+        let index = file_index(meta);
+        let final_path = self.dir.join(snapshot_file_name(index));
+        let tmp_path = self.dir.join(format!("snapshot-{index}.bin.tmp"));
+
+        let buf = encode_snapshot_file(meta, data)?;
+        {
+            let mut file = File::create(&tmp_path)?;
+            file.write_all(&buf)?;
+            file.sync_data()?;
+        }
+        std::fs::rename(&tmp_path, &final_path)?;
+        sync_dir(&self.dir)?;
+
+        self.watermark.advance(index);
+
+        // Best-effort cleanup of superseded snapshots; failure leaves
+        // harmless extra files (open always picks the highest index).
+        if let Ok(entries) = std::fs::read_dir(&self.dir) {
+            for entry in entries.flatten() {
+                let name = entry.file_name().to_string_lossy().into_owned();
+                if let Some(old) = parse_snapshot_file_name(&name) {
+                    if old < index {
+                        let _ = std::fs::remove_file(entry.path());
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: format, atomicity, and corruption handling at the store level
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use openraft::{CommittedLeaderId, LogId, StoredMembership};
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn meta_at(index: u64) -> SnapshotMeta<u64, BasicNode> {
+        SnapshotMeta {
+            last_log_id: Some(LogId::new(CommittedLeaderId::new(1, 1), index)),
+            last_membership: StoredMembership::default(),
+            snapshot_id: format!("test-{index}"),
+        }
+    }
+
+    #[test]
+    fn watermark_starts_empty_and_advances_monotonically() {
+        let watermark = DurableSnapshotWatermark::default();
+        assert_eq!(watermark.get(), None);
+        watermark.advance(5);
+        assert_eq!(watermark.get(), Some(5));
+        watermark.advance(3); // lower values are ignored
+        assert_eq!(watermark.get(), Some(5));
+        watermark.advance(9);
+        assert_eq!(watermark.get(), Some(9));
+    }
+
+    #[test]
+    fn empty_dir_has_no_snapshot() {
+        let dir = TempDir::new().unwrap();
+        let (store, loaded) = SnapshotStore::open(dir.path()).unwrap();
+        assert!(loaded.is_none());
+        assert_eq!(store.watermark().get(), None);
+    }
+
+    #[test]
+    fn save_then_open_roundtrips_meta_and_data() {
+        let dir = TempDir::new().unwrap();
+        let meta = meta_at(7);
+        {
+            let (store, _) = SnapshotStore::open(dir.path()).unwrap();
+            store.save(&meta, b"payload bytes").unwrap();
+            assert_eq!(store.watermark().get(), Some(7));
+        }
+
+        let (store, loaded) = SnapshotStore::open(dir.path()).unwrap();
+        let loaded = loaded.expect("snapshot should be recovered");
+        assert_eq!(loaded.meta, meta);
+        assert_eq!(loaded.data, b"payload bytes");
+        assert_eq!(store.watermark().get(), Some(7));
+    }
+
+    #[test]
+    fn newer_snapshot_supersedes_older() {
+        let dir = TempDir::new().unwrap();
+        let (store, _) = SnapshotStore::open(dir.path()).unwrap();
+        store.save(&meta_at(3), b"old").unwrap();
+        store.save(&meta_at(8), b"new").unwrap();
+
+        // The superseded file is gone; only the latest remains.
+        assert!(!dir.path().join(snapshot_file_name(3)).exists());
+        assert!(dir.path().join(snapshot_file_name(8)).exists());
+
+        let (store, loaded) = SnapshotStore::open(dir.path()).unwrap();
+        assert_eq!(loaded.unwrap().data, b"new");
+        assert_eq!(store.watermark().get(), Some(8));
+    }
+
+    #[test]
+    fn restore_seed_snapshot_legalizes_no_purge() {
+        let dir = TempDir::new().unwrap();
+        // A restore-seeded snapshot has no raft log id: it covers no raft
+        // entries, so the durable watermark must remain "none".
+        let meta = SnapshotMeta {
+            last_log_id: None,
+            last_membership: StoredMembership::default(),
+            snapshot_id: "restore".to_string(),
+        };
+        let (store, _) = SnapshotStore::open(dir.path()).unwrap();
+        store.save(&meta, b"seed").unwrap();
+        assert_eq!(store.watermark().get(), None);
+
+        let (store, loaded) = SnapshotStore::open(dir.path()).unwrap();
+        assert_eq!(loaded.unwrap().data, b"seed");
+        assert_eq!(store.watermark().get(), None);
+    }
+
+    #[test]
+    fn crash_leftover_tmp_file_is_removed_silently() {
+        let dir = TempDir::new().unwrap();
+        {
+            let (store, _) = SnapshotStore::open(dir.path()).unwrap();
+            store.save(&meta_at(4), b"good").unwrap();
+        }
+        // Simulate a crash mid-write of the NEXT snapshot: a torn tmp file.
+        std::fs::write(dir.path().join("snapshot-9.bin.tmp"), b"torn garbage").unwrap();
+
+        let (store, loaded) = SnapshotStore::open(dir.path()).unwrap();
+        assert_eq!(loaded.unwrap().data, b"good");
+        assert_eq!(store.watermark().get(), Some(4));
+        assert!(!dir.path().join("snapshot-9.bin.tmp").exists());
+    }
+
+    /// Every corruption of a *final* snapshot file must fail the open loudly
+    /// and leave the file untouched — never silently fall back.
+    #[test]
+    fn corrupt_final_snapshot_is_rejected_loudly_and_left_untouched() {
+        let make = |mutate: &dyn Fn(&mut Vec<u8>)| {
+            let dir = TempDir::new().unwrap();
+            let (store, _) = SnapshotStore::open(dir.path()).unwrap();
+            store.save(&meta_at(5), b"snapshot payload").unwrap();
+            drop(store);
+            let path = dir.path().join(snapshot_file_name(5));
+            let mut buf = std::fs::read(&path).unwrap();
+            mutate(&mut buf);
+            std::fs::write(&path, &buf).unwrap();
+            (dir, path)
+        };
+
+        type Mutation = Box<dyn Fn(&mut Vec<u8>)>;
+        let cases: Vec<(&str, Mutation)> = vec![
+            (
+                "flipped data byte",
+                Box::new(|buf: &mut Vec<u8>| {
+                    let last = buf.len() - 1;
+                    buf[last] ^= 0xFF;
+                }),
+            ),
+            (
+                "flipped meta byte",
+                Box::new(|buf: &mut Vec<u8>| {
+                    buf[SNAPSHOT_HEADER_SIZE + 8] ^= 0xFF;
+                }),
+            ),
+            (
+                "truncated file",
+                Box::new(|buf: &mut Vec<u8>| {
+                    buf.truncate(buf.len() - 4);
+                }),
+            ),
+            (
+                "trailing garbage",
+                Box::new(|buf: &mut Vec<u8>| {
+                    buf.extend_from_slice(b"junk");
+                }),
+            ),
+            (
+                "wrong magic",
+                Box::new(|buf: &mut Vec<u8>| {
+                    buf[0..4].copy_from_slice(b"XXXX");
+                }),
+            ),
+            (
+                "future version",
+                Box::new(|buf: &mut Vec<u8>| {
+                    buf[4..8].copy_from_slice(&(SNAPSHOT_VERSION + 1).to_le_bytes());
+                }),
+            ),
+        ];
+
+        for (label, mutate) in cases {
+            let (dir, path) = make(&*mutate);
+            let len_before = std::fs::metadata(&path).unwrap().len();
+
+            let err = SnapshotStore::open(dir.path()).unwrap_err();
+            assert_eq!(err.kind(), io::ErrorKind::InvalidData, "{label}: wrong kind: {err}");
+            assert!(err.to_string().contains("corrupt"), "{label}: unexpected error: {err}");
+            // Left byte-for-byte untouched for inspection.
+            assert_eq!(std::fs::metadata(&path).unwrap().len(), len_before, "{label}");
+
+            // The refusal is stable across attempts.
+            let err = SnapshotStore::open(dir.path()).unwrap_err();
+            assert_eq!(err.kind(), io::ErrorKind::InvalidData, "{label}: second open: {err}");
+        }
+    }
+
+    #[test]
+    fn filename_and_meta_index_disagreement_is_rejected() {
+        let dir = TempDir::new().unwrap();
+        let (store, _) = SnapshotStore::open(dir.path()).unwrap();
+        store.save(&meta_at(5), b"payload").unwrap();
+        drop(store);
+        // Rename the file to claim a different index than its meta carries.
+        std::fs::rename(
+            dir.path().join(snapshot_file_name(5)),
+            dir.path().join(snapshot_file_name(9)),
+        )
+        .unwrap();
+
+        let err = SnapshotStore::open(dir.path()).unwrap_err();
+        assert!(err.to_string().contains("named for index 9"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn foreign_files_are_ignored() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path()).unwrap();
+        std::fs::write(dir.path().join("raft.log"), b"not a snapshot").unwrap();
+        std::fs::write(dir.path().join("snapshot-abc.bin"), b"unparsable name").unwrap();
+
+        let (store, loaded) = SnapshotStore::open(dir.path()).unwrap();
+        assert!(loaded.is_none());
+        assert_eq!(store.watermark().get(), None);
+        // Foreign files were not deleted.
+        assert!(dir.path().join("raft.log").exists());
+        assert!(dir.path().join("snapshot-abc.bin").exists());
+    }
+
+    #[test]
+    fn payload_codec_roundtrips() {
+        let entries = vec![b"one".to_vec(), b"two".to_vec()];
+        let blob = encode_payload(&entries).unwrap();
+        assert_eq!(decode_payload(&blob).unwrap(), entries);
+
+        assert!(decode_payload(b"not json").is_err());
+    }
+}


### PR DESCRIPTION
Part of #5198 (Raft Phase A4 — PR 1 of 2 per the curator re-scope).

## Summary

Replaces the Phase A2 snapshot stand-ins with openraft's real snapshot pipeline on a single node:

- **Real `RaftSnapshotBuilder`**: `ConsensusBackend::snapshot()` on `OpenraftBackend` now triggers a build through the engine (`Raft::trigger().snapshot()` + metrics wait) and returns the registered artifact — the Phase A2 shortcut that serialized the state machine directly, bypassing the builder (flagged by the #5351 judge as fine-until-A4), is gone.
- **Snapshot install**: `install_snapshot` validates the payload *before* mutating (no half-installs), restores `last_applied` + membership, and on durable configurations persists the blob *before* acknowledging. The `from_snapshot*` constructors share the same payload codec and state-machine seeding — one snapshot mechanism, two entry points (replica install with raft meta vs. restore-a-backup-into-a-new-group without).
- **Durable persistence** (`crate::snapshot::SnapshotStore`): `snapshot-<raw index>.bin` next to `raft.log`, written tmp → fsync → rename → dir fsync. Recovery loads the latest snapshot **first**, then replays the log suffix from the snapshot index. A corrupt final snapshot file fails recovery loudly (`InvalidData`, file left untouched) — never a silent fresh start, mirroring `durable.rs`'s tail-only-repair philosophy from PR #5357. `.tmp` leftovers (never acknowledged) are removed silently.
- **vacuum_mvcc horizon pin**: builds acquire a `SnapshotHorizonPin` guard before reading state and hold it until the blob is built, durable, and registered. It is a trait hook with a no-op for the current echo state machine; **#5199 (B1)** implements it by registering the build alongside an active read transaction in `vibesql-storage`'s `transaction_api`, so the existing `compute_gc_horizon` holdback covers it (no new watermark type). Tests prove the guard is held across the build, including persistence. No `vibesql-storage` changes in this PR.
- **Purge safety**: `DurableLogStore::purge` refuses to purge above the durable-snapshot watermark, which only advances after fsync+rename — openraft can never purge against a snapshot that would not survive a crash. Purge *policy* (when to trigger) is PR 2.
- **Bonus correctness fix**: `from_snapshot_with_data_dir` previously seeded restored entries only in memory, so a restart of the restored node silently lost them; the restore seed is now persisted as a durable snapshot (covered by a regression test).

## Two retention policies (per the curator note)

- **Raft log purge** (this PR): gated on the durable snapshot index, enforced at the storage layer; on a replicated node the **Raft log is authoritative** (A2/B1 direction).
- **Data-WAL checkpoint/truncation** (`vibesql-storage::wal`, LSN-based with `DEFAULT_SAFETY_BUFFER`): orthogonal, untouched — it remains a local durability detail of the storage engine. Documented in `lib.rs`.

## Not in this PR (PR 2)

- Network snapshot transfer (InstallSnapshot leg of the A3 transport, including the 64 MiB frame-cap issue flagged on #5368)
- Purge policy/triggering + rejoin-via-snapshot test + disk-reclamation assertion
- MVCC wiring (#5199)

## Tests

- Build → install roundtrip: state + `last_applied` + membership identical; corrupt install rejected without mutation
- Durable: build, purge to snapshot, write past it, restart → snapshot loaded then log replayed (entries below the purge point only recoverable via snapshot)
- Corrupt snapshot file → loud error on recovery (6 corruption variants at store level, plus end-to-end)
- Purge above durable snapshot rejected (incl. no-snapshot case); at/below allowed and survives reopen
- Horizon pin held across build (in-memory and durable; durable guard observes the on-disk file at release)
- Restored durable backend survives restart (regression for the pre-A4 data-loss gap)
- Conformance suite unchanged and green for all three harnesses (semantics preserved: dense app-index artifact, corrupt-snapshot rejection)

## Verification

- `cargo test -p vibesql-consensus`: 79/79 green
- New async tests flake-checked 12x, conformance + snapshot tests 10x — no flakes
- `cargo clippy -p vibesql-consensus --all-targets`: clean
- `cargo build --workspace`: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)