### PR TITLE
feat(explain): emit temp B-tree annotations for GROUP BY/DISTINCT/compound

### DIFF
--- a/crates/vibesql-executor/src/explain.rs
+++ b/crates/vibesql-executor/src/explain.rs
@@ -71,6 +71,22 @@ pub struct PlanNode {
     pub index_predicates: Vec<IndexPredicate>,
     /// Whether this query requires a temp B-tree for ORDER BY
     pub needs_temp_btree_for_order_by: bool,
+    /// Whether this query requires a temp structure for GROUP BY — rendered
+    /// as SQLite's `USE TEMP B-TREE FOR GROUP BY`. VibeSQL's runtime always
+    /// groups via a hash table and then sorts the groups by key
+    /// (select/grouping/hash.rs), so the line truthfully describes the temp
+    /// grouping structure; it is suppressed when an index delivers group
+    /// order, mirroring SQLite's EQP (same permissive EQP-level convention
+    /// as the ORDER BY stabilization-sort suppression in
+    /// `needs_temp_btree_for_order_by_eqp`).
+    pub needs_temp_btree_for_group_by: bool,
+    /// Whether this query requires a temp structure for DISTINCT — rendered
+    /// as SQLite's `USE TEMP B-TREE FOR DISTINCT`. VibeSQL's runtime dedups
+    /// via a hash set preserving input order (select/helpers.rs
+    /// `apply_distinct`); the line truthfully describes the temp dedup
+    /// structure and is suppressed when an index delivers the SELECT-list
+    /// order, mirroring SQLite's EQP.
+    pub needs_temp_btree_for_distinct: bool,
     /// Number of distinct window-function sorting passes (PARTITION BY +
     /// ORDER BY keys) not satisfied by an index. Each contributes one
     /// `USE TEMP B-TREE FOR ORDER BY` entry in EQP output.
@@ -98,6 +114,8 @@ impl PlanNode {
             index_name: None,
             index_predicates: Vec::new(),
             needs_temp_btree_for_order_by: false,
+            needs_temp_btree_for_group_by: false,
+            needs_temp_btree_for_distinct: false,
             window_sort_count: 0,
             set_operation_type: None,
             is_compound_query: false,
@@ -561,8 +579,10 @@ fn append_scan_entries(node: &PlanNode, entries: &mut Vec<EqpEntry>) {
 
 /// Build the `COMPOUND QUERY` entry tree for a compound-query plan root:
 /// a `LEFT-MOST SUBQUERY` child for the first branch, then one child per
-/// set operation (`UNION`, `UNION ALL`, `INTERSECT`, `EXCEPT`, ...), each
-/// containing that branch's scan entries.
+/// set operation (`UNION USING TEMP B-TREE`, `UNION ALL`, ...), each
+/// containing that branch's full EQP entries — including the branch's own
+/// `USE TEMP B-TREE FOR GROUP BY` / `FOR DISTINCT` lines, which sqlite3
+/// renders inside the branch block (verified live).
 fn compound_eqp_entry(node: &PlanNode) -> EqpEntry {
     let mut children = Vec::new();
     for (i, branch) in node.children.iter().enumerate() {
@@ -571,11 +591,7 @@ fn compound_eqp_entry(node: &PlanNode) -> EqpEntry {
         } else {
             branch.set_operation_type.clone().unwrap_or_else(|| "UNION ALL".to_string())
         };
-        let scans = collect_scan_nodes(branch)
-            .into_iter()
-            .map(|scan| EqpEntry::leaf(format_sqlite_eqp_node(scan)))
-            .collect();
-        children.push(EqpEntry { text: label, children: scans });
+        children.push(EqpEntry { text: label, children: collect_eqp_entries(branch) });
     }
     EqpEntry { text: "COMPOUND QUERY".to_string(), children }
 }
@@ -597,11 +613,22 @@ fn subtree_needs_order_by_temp_btree(node: &PlanNode) -> bool {
 }
 
 /// Collect all EQP entries from the plan tree, including TEMP B-TREE entries
+///
+/// Line order matches sqlite3 3.51.0: scans, then `... FOR GROUP BY`, then
+/// window sorting passes, then `... FOR DISTINCT`, then `... FOR ORDER BY`
+/// (GROUP BY-before-DISTINCT and DISTINCT/GROUP BY-before-ORDER BY verified
+/// live; windows restructure SQLite's plan entirely, so their relative slot
+/// follows the grouping-before-dedup pipeline order).
 fn collect_eqp_entries(node: &PlanNode) -> Vec<EqpEntry> {
     let mut entries = Vec::new();
 
     // Collect scan entries first (co-routine blocks nest their inner plan)
     append_scan_entries(node, &mut entries);
+
+    // Add TEMP B-TREE entry if needed for GROUP BY
+    if node.needs_temp_btree_for_group_by {
+        entries.push(EqpEntry::leaf("USE TEMP B-TREE FOR GROUP BY".to_string()));
+    }
 
     // Add one TEMP B-TREE entry per distinct window sort key not satisfied
     // by an index. Window sorting passes run before the statement-level
@@ -609,6 +636,11 @@ fn collect_eqp_entries(node: &PlanNode) -> Vec<EqpEntry> {
     // separate passes.
     for _ in 0..node.window_sort_count {
         entries.push(EqpEntry::leaf("USE TEMP B-TREE FOR ORDER BY".to_string()));
+    }
+
+    // Add TEMP B-TREE entry if needed for DISTINCT
+    if node.needs_temp_btree_for_distinct {
+        entries.push(EqpEntry::leaf("USE TEMP B-TREE FOR DISTINCT".to_string()));
     }
 
     // Add TEMP B-TREE entry if needed for ORDER BY
@@ -849,6 +881,68 @@ impl ExplainExecutor {
             root.add_child(constant_node);
         }
 
+        // Temp-structure annotations for GROUP BY and DISTINCT (#5367).
+        //
+        // SQLite emits `USE TEMP B-TREE FOR GROUP BY` / `FOR DISTINCT` when
+        // grouping/dedup is not satisfied by the scan's delivery order, and
+        // suppresses the line when an index delivers it (verified against
+        // sqlite3 3.51.0). VibeSQL's runtime always hash-groups then sorts
+        // groups by key, and always hash-dedups DISTINCT — the emitted lines
+        // truthfully describe those temp structures; the index suppression
+        // mirrors the established permissive EQP-level convention (see
+        // `needs_temp_btree_for_order_by_eqp`).
+        //
+        // The simple GROUP BY key (ordinals and output aliases resolved like
+        // SQLite) is also reused below to suppress the ORDER BY line when the
+        // statement-level ORDER BY matches the grouping output order.
+        let group_key: Option<Vec<&Expression>> =
+            stmt.group_by.as_ref().map(|g| g.as_simple()).and_then(|simple| {
+                simple.map(|exprs| {
+                    exprs
+                        .iter()
+                        .map(|e| Self::resolve_output_expr(e, &stmt.select_list))
+                        .collect()
+                })
+            });
+        if stmt.group_by.is_some() {
+            root.needs_temp_btree_for_group_by = match &group_key {
+                // ROLLUP/CUBE/GROUPING SETS always build temp structures.
+                None => true,
+                Some(key) => !Self::group_key_satisfied_by_index(
+                    stmt.from.as_ref(),
+                    stmt.where_clause.as_ref(),
+                    key,
+                    database,
+                ),
+            };
+        }
+
+        // The DISTINCT key is the SELECT list. SQLite suppresses the line
+        // when an index delivers the SELECT-list order — but never when a
+        // GROUP BY intervenes (`SELECT DISTINCT a FROM t GROUP BY a` with an
+        // index on `a` still shows the DISTINCT line; verified live).
+        let distinct_key: Option<Vec<&Expression>> = if stmt.distinct {
+            Self::distinct_key_exprs(&stmt.select_list)
+        } else {
+            None
+        };
+        if stmt.distinct {
+            root.needs_temp_btree_for_distinct = stmt.group_by.is_some()
+                || match &distinct_key {
+                    // Wildcard SELECT lists never suppress.
+                    None => true,
+                    Some(key) => {
+                        let items = Self::exprs_as_asc_order_items(key);
+                        Self::needs_temp_btree_for_order_by(
+                            stmt.from.as_ref(),
+                            stmt.where_clause.as_ref(),
+                            &items,
+                            database,
+                        )
+                    }
+                };
+        }
+
         // Check if we need a temp B-tree for ORDER BY
         // This happens when ORDER BY cannot be satisfied by an index. The WHERE
         // clause is passed through so the planner can pin leading index columns
@@ -863,6 +957,16 @@ impl ExplainExecutor {
         // B-tree (verified against sqlite3 3.51.0). An empty key (`OVER ()`)
         // never suppresses; extensions, direction/COLLATE mismatches, and
         // matches against later windows do not suppress.
+        //
+        // With GROUP BY, the grouping pass replaces the scan as the order
+        // source: SQLite suppresses the ORDER BY line exactly when the ORDER
+        // BY terms equal the GROUP BY terms — same expressions, same
+        // sequence, same length, directions ignored (the group structure is
+        // traversed in either direction); a bare prefix does NOT suppress
+        // (all verified against sqlite3 3.51.0). With DISTINCT, the dedup
+        // structure delivers SELECT-list order: an exact all-ASC match
+        // suppresses; otherwise the line renders unless the dedup itself
+        // rode an index (in which case the index check applies as usual).
         if let Some(ref order_by) = stmt.order_by {
             let satisfied_by_window_sort =
                 Self::first_window_combined_key(stmt).is_some_and(|key| {
@@ -870,13 +974,51 @@ impl ExplainExecutor {
                         && order_by.len() <= key.len()
                         && key[..order_by.len()] == order_by[..]
                 });
-            root.needs_temp_btree_for_order_by = !satisfied_by_window_sort
-                && Self::needs_temp_btree_for_order_by(
+            root.needs_temp_btree_for_order_by = if satisfied_by_window_sort {
+                false
+            } else if stmt.group_by.is_some() {
+                match &group_key {
+                    Some(key) => !Self::order_by_matches_exprs(
+                        order_by,
+                        key,
+                        &stmt.select_list,
+                        false, // directions ignored
+                    ),
+                    // ROLLUP/CUBE/GROUPING SETS output order is unspecified.
+                    None => true,
+                }
+            } else if stmt.distinct {
+                let matches_distinct = distinct_key.as_ref().is_some_and(|key| {
+                    Self::order_by_matches_exprs(
+                        order_by,
+                        key,
+                        &stmt.select_list,
+                        true, // exact ASC match required (verified live)
+                    )
+                });
+                if matches_distinct {
+                    false
+                } else if root.needs_temp_btree_for_distinct {
+                    // Hash/b-tree dedup does not deliver the requested order.
+                    true
+                } else {
+                    // Dedup rode the index; the scan's delivery order may
+                    // still satisfy the ORDER BY (e.g. reverse traversal).
+                    Self::needs_temp_btree_for_order_by(
+                        stmt.from.as_ref(),
+                        stmt.where_clause.as_ref(),
+                        order_by,
+                        database,
+                    )
+                }
+            } else {
+                Self::needs_temp_btree_for_order_by(
                     stmt.from.as_ref(),
                     stmt.where_clause.as_ref(),
                     order_by,
                     database,
-                );
+                )
+            };
         }
 
         // Count window-function sorting passes for EQP output. SQLite emits
@@ -940,13 +1082,19 @@ impl ExplainExecutor {
         // Add subsequent set operations
         let mut current_set_op = stmt.set_operation.as_ref();
         while let Some(set_op) = current_set_op {
+            // Dedup branches are labeled `<OP> USING TEMP B-TREE` like
+            // sqlite3 3.51.0 (verified live for UNION/INTERSECT/EXCEPT).
+            // Truthful: the runtime dedups via temp hash structures
+            // (select/set_operations.rs). `ALL` variants stay bare; the
+            // non-standard INTERSECT ALL / EXCEPT ALL have no SQLite
+            // reference output and keep their bare labels.
             let op_label = match (&set_op.op, set_op.all) {
                 (vibesql_ast::SetOperator::Union, true) => "UNION ALL",
-                (vibesql_ast::SetOperator::Union, false) => "UNION",
+                (vibesql_ast::SetOperator::Union, false) => "UNION USING TEMP B-TREE",
                 (vibesql_ast::SetOperator::Intersect, true) => "INTERSECT ALL",
-                (vibesql_ast::SetOperator::Intersect, false) => "INTERSECT",
+                (vibesql_ast::SetOperator::Intersect, false) => "INTERSECT USING TEMP B-TREE",
                 (vibesql_ast::SetOperator::Except, true) => "EXCEPT ALL",
-                (vibesql_ast::SetOperator::Except, false) => "EXCEPT",
+                (vibesql_ast::SetOperator::Except, false) => "EXCEPT USING TEMP B-TREE",
             };
 
             // Create plan for right side of set operation
@@ -1172,6 +1320,163 @@ impl ExplainExecutor {
         needs_temp_btree_for_order_by_eqp(table_name, where_clause, order_by, database)
     }
 
+    /// Resolve an ORDER BY / GROUP BY term against the SELECT list the way
+    /// SQLite does for EQP purposes: an integer literal is a 1-based output
+    /// ordinal, and a bare (unqualified) column reference matching an output
+    /// alias resolves to that output expression. Anything else (including
+    /// out-of-range ordinals) is returned unchanged. Verified live:
+    /// `GROUP BY b ORDER BY 1` and `SELECT b AS z ... GROUP BY b ORDER BY z`
+    /// both suppress the ORDER BY temp B-tree line.
+    fn resolve_output_expr<'a>(
+        expr: &'a Expression,
+        select_list: &'a [SelectItem],
+    ) -> &'a Expression {
+        use vibesql_types::SqlValue;
+
+        let ordinal = match expr {
+            Expression::Literal(SqlValue::Integer(n)) | Expression::Literal(SqlValue::Bigint(n)) => {
+                Some(*n)
+            }
+            Expression::Literal(SqlValue::Smallint(n)) => Some(i64::from(*n)),
+            _ => None,
+        };
+        if let Some(n) = ordinal {
+            if n >= 1 && (n as usize) <= select_list.len() {
+                if let SelectItem::Expression { expr: target, .. } = &select_list[n as usize - 1] {
+                    return target;
+                }
+            }
+            return expr;
+        }
+
+        if let Expression::ColumnRef(col_id) = expr {
+            if col_id.schema_canonical().is_none() && col_id.table_canonical().is_none() {
+                for item in select_list {
+                    if let SelectItem::Expression { expr: target, alias: Some(alias), .. } = item {
+                        if alias.eq_ignore_ascii_case(col_id.column_canonical()) {
+                            return target;
+                        }
+                    }
+                }
+            }
+        }
+
+        expr
+    }
+
+    /// The DISTINCT key: the SELECT-list expressions in order, or `None`
+    /// when the list contains wildcards (which never suppress the DISTINCT
+    /// temp-structure line).
+    fn distinct_key_exprs(select_list: &[SelectItem]) -> Option<Vec<&Expression>> {
+        select_list
+            .iter()
+            .map(|item| match item {
+                SelectItem::Expression { expr, .. } => Some(expr),
+                SelectItem::Wildcard { .. } | SelectItem::QualifiedWildcard { .. } => None,
+            })
+            .collect()
+    }
+
+    /// Wrap key expressions as ASC ORDER BY items for the index-delivery
+    /// checks (grouping and dedup keys have no inherent direction).
+    fn exprs_as_asc_order_items(exprs: &[&Expression]) -> Vec<vibesql_ast::OrderByItem> {
+        exprs
+            .iter()
+            .map(|e| vibesql_ast::OrderByItem {
+                expr: (*e).clone(),
+                direction: vibesql_ast::OrderDirection::Asc,
+                nulls_order: None,
+            })
+            .collect()
+    }
+
+    /// True when the statement-level ORDER BY matches `exprs` exactly: same
+    /// expressions (output ordinals/aliases resolved), same sequence, same
+    /// length, no explicit NULLS ordering. With `require_asc`, every term
+    /// must also be ASC (the DISTINCT rule); otherwise directions are
+    /// ignored (the GROUP BY rule — sqlite3 suppresses for DESC and even
+    /// mixed-direction matches, verified live). Bare prefixes and
+    /// permutations never match (verified live).
+    fn order_by_matches_exprs(
+        order_by: &[vibesql_ast::OrderByItem],
+        exprs: &[&Expression],
+        select_list: &[SelectItem],
+        require_asc: bool,
+    ) -> bool {
+        order_by.len() == exprs.len()
+            && order_by.iter().zip(exprs).all(|(item, expr)| {
+                item.nulls_order.is_none()
+                    && (!require_asc
+                        || item.direction == vibesql_ast::OrderDirection::Asc)
+                    && Self::resolve_output_expr(&item.expr, select_list) == *expr
+            })
+    }
+
+    /// True when an index delivers the rows in GROUP BY order, suppressing
+    /// the `USE TEMP B-TREE FOR GROUP BY` line.
+    ///
+    /// Grouping is order-insensitive, so SQLite reorders the GROUP BY terms
+    /// to match a candidate index (`GROUP BY b, a` with index `(a, b)`
+    /// suppresses — verified live). We first try the key as written, then
+    /// retry with the terms permuted into each index's column order.
+    fn group_key_satisfied_by_index(
+        from: Option<&vibesql_ast::FromClause>,
+        where_clause: Option<&vibesql_ast::Expression>,
+        group_key: &[&Expression],
+        database: &Database,
+    ) -> bool {
+        let items = Self::exprs_as_asc_order_items(group_key);
+        if !Self::needs_temp_btree_for_order_by(from, where_clause, &items, database) {
+            return true;
+        }
+
+        // Order-insensitive retry: only bare column references can be
+        // realigned to an index's column order.
+        let Some(vibesql_ast::FromClause::Table { name, .. }) = from else {
+            return false;
+        };
+        let col_names: Option<Vec<&str>> = group_key
+            .iter()
+            .map(|e| match e {
+                Expression::ColumnRef(col_id) => Some(col_id.column_canonical()),
+                _ => None,
+            })
+            .collect();
+        let Some(col_names) = col_names else {
+            return false;
+        };
+
+        for index_name in database.list_indexes_for_table(name) {
+            let Some(index) = database.get_index(&index_name) else { continue };
+            // Permute the group terms into this index's column order; every
+            // term must appear as an index column for the realignment to be
+            // meaningful.
+            let positions: Option<Vec<usize>> = col_names
+                .iter()
+                .map(|col| {
+                    index.columns.iter().position(|ic| {
+                        ic.column_name().is_some_and(|n| n.eq_ignore_ascii_case(col))
+                    })
+                })
+                .collect();
+            let Some(positions) = positions else { continue };
+
+            let mut order: Vec<usize> = (0..group_key.len()).collect();
+            order.sort_by_key(|&i| positions[i]);
+            if order.iter().zip(0..group_key.len()).all(|(&a, b)| a == b) {
+                continue; // Same as the as-written key already checked.
+            }
+            let permuted: Vec<&Expression> = order.iter().map(|&i| group_key[i]).collect();
+            let permuted_items = Self::exprs_as_asc_order_items(&permuted);
+            if !Self::needs_temp_btree_for_order_by(from, where_clause, &permuted_items, database)
+            {
+                return true;
+            }
+        }
+
+        false
+    }
+
     /// True when the SELECT list (or named WINDOW clause) of `stmt` contains
     /// window functions — such subqueries/views render as CO-ROUTINE blocks
     /// in EQP output because SQLite cannot flatten them.
@@ -1194,10 +1499,7 @@ impl ExplainExecutor {
     /// materializes every view body. Window functions take the same
     /// CO-ROUTINE path (#5347).
     fn view_body_is_flattenable(stmt: &SelectStmt) -> bool {
-        let select_list_has_aggregate = stmt.select_list.iter().any(|item| match item {
-            SelectItem::Expression { expr, .. } => contains_aggregate_function(expr),
-            SelectItem::Wildcard { .. } | SelectItem::QualifiedWildcard { .. } => false,
-        });
+        let select_list_has_aggregate = Self::select_list_has_aggregate(stmt);
 
         stmt.set_operation.is_none()
             && !stmt.distinct
@@ -1208,6 +1510,29 @@ impl ExplainExecutor {
             && stmt.values.is_none()
             && stmt.with_clause.is_none()
             && !select_list_has_aggregate
+    }
+
+    /// True when any SELECT-list expression contains an aggregate function.
+    fn select_list_has_aggregate(stmt: &SelectStmt) -> bool {
+        stmt.select_list.iter().any(|item| match item {
+            SelectItem::Expression { expr, .. } => contains_aggregate_function(expr),
+            SelectItem::Wildcard { .. } | SelectItem::QualifiedWildcard { .. } => false,
+        })
+    }
+
+    /// True when a compound body contains any deduplicating set operation
+    /// (UNION/INTERSECT/EXCEPT without ALL). SQLite cannot flatten such
+    /// derived tables and renders them as CO-ROUTINE blocks; UNION-ALL-only
+    /// chains flatten into a top-level COMPOUND QUERY (verified live).
+    fn compound_has_dedup(stmt: &SelectStmt) -> bool {
+        let mut set_op = stmt.set_operation.as_ref();
+        while let Some(op) = set_op {
+            if !op.all {
+                return true;
+            }
+            set_op = op.right.set_operation.as_ref();
+        }
+        false
     }
 
     /// Generate plan node for FROM clause
@@ -1362,12 +1687,22 @@ impl ExplainExecutor {
                 let mut subquery_node = PlanNode::new("Subquery");
                 subquery_node.object = Some(format!("AS {}", alias));
 
-                // Window-function subqueries cannot be flattened; SQLite
-                // runs them as co-routines and EQP nests the inner plan
-                // under a `CO-ROUTINE <alias>` entry (#5347). Plain derived
-                // tables keep the existing flat rendering, matching
-                // SQLite's query flattening.
-                if Self::select_has_window_functions(query) {
+                // Derived tables SQLite cannot flatten render as a
+                // `CO-ROUTINE <alias>` block: window functions (#5347),
+                // aggregates, GROUP BY/HAVING, DISTINCT, and compounds with
+                // a deduplicating set operation (#5367 — sqlite3 3.51.0
+                // shows `CO-ROUTINE q` around the COMPOUND QUERY for dedup
+                // UNION/INTERSECT/EXCEPT bodies, verified live). Truthful:
+                // the runtime materializes derived tables. UNION-ALL-only
+                // compounds, LIMIT-only, and plain bodies keep the existing
+                // flat rendering, matching SQLite's flattener exactly.
+                if Self::select_has_window_functions(query)
+                    || query.group_by.is_some()
+                    || query.distinct
+                    || query.having.is_some()
+                    || Self::select_list_has_aggregate(query)
+                    || Self::compound_has_dedup(query)
+                {
                     subquery_node.coroutine = Some(alias.clone());
                 }
 

--- a/crates/vibesql-executor/tests/explain_temp_btree_annotation_tests.rs
+++ b/crates/vibesql-executor/tests/explain_temp_btree_annotation_tests.rs
@@ -1,0 +1,786 @@
+//! Tests for EXPLAIN QUERY PLAN temp-structure annotations (#5367):
+//! `USE TEMP B-TREE FOR GROUP BY`, `USE TEMP B-TREE FOR DISTINCT`, the
+//! `<OP> USING TEMP B-TREE` compound dedup branch labels, and the
+//! `CO-ROUTINE <alias>` wrapper for non-flattenable derived tables.
+//!
+//! Every expected shape below was verified live against sqlite3 3.51.0
+//! (`.eqp on`); divergences are noted per test. Truthfulness (per the
+//! #5355/#5360/#5366 precedent):
+//! - GROUP BY always executes as hash aggregation followed by a sort of the
+//!   groups by key (select/grouping/hash.rs), so the GROUP BY line
+//!   truthfully describes the temp grouping structure. Its suppression when
+//!   an index delivers group order mirrors SQLite's EQP — the same
+//!   permissive EQP-level convention as the existing ORDER BY
+//!   stabilization-sort suppression (`needs_temp_btree_for_order_by_eqp`).
+//! - DISTINCT always executes as a hash dedup preserving input order
+//!   (select/helpers.rs `apply_distinct`); the DISTINCT line truthfully
+//!   describes that temp structure, suppressed like SQLite when an index
+//!   delivers SELECT-list order.
+//! - Compound dedup (UNION/INTERSECT/EXCEPT) executes via temp hash
+//!   structures (select/set_operations.rs), so `USING TEMP B-TREE` labels
+//!   are truthful.
+
+use vibesql_ast::Statement;
+use vibesql_executor::ExplainExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+fn run_ddl(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse failed");
+    match stmt {
+        Statement::CreateTable(s) => {
+            vibesql_executor::CreateTableExecutor::execute(&s, db).unwrap();
+        }
+        Statement::CreateIndex(s) => {
+            vibesql_executor::CreateIndexExecutor::execute(&s, db).unwrap();
+        }
+        Statement::CreateView(s) => {
+            vibesql_executor::advanced_objects::execute_create_view(&s, db).unwrap();
+        }
+        other => panic!("unsupported DDL in test: {:?}", other),
+    }
+}
+
+/// Run EXPLAIN QUERY PLAN and return the SQLite-style EQP output.
+fn eqp(db: &Database, sql: &str) -> String {
+    let explain_sql = format!("EXPLAIN QUERY PLAN {}", sql);
+    let stmt = Parser::parse_sql(&explain_sql).expect("Failed to parse SQL");
+
+    if let Statement::Explain(explain_stmt) = stmt {
+        let result = ExplainExecutor::execute(&explain_stmt, db).expect("EXPLAIN failed");
+        result.to_sqlite_eqp()
+    } else {
+        panic!("Expected EXPLAIN statement");
+    }
+}
+
+/// t1(a, b, c) with a single-column index on `a`.
+fn setup_db() -> Database {
+    let mut db = Database::new();
+    run_ddl(&mut db, "CREATE TABLE t1(a INTEGER, b INTEGER, c INTEGER)");
+    run_ddl(&mut db, "CREATE INDEX i1a ON t1(a)");
+    db
+}
+
+/// tab(a, b, c) with a composite index on (a, b).
+fn setup_composite_db() -> Database {
+    let mut db = Database::new();
+    run_ddl(&mut db, "CREATE TABLE tab(a INTEGER, b INTEGER, c INTEGER)");
+    run_ddl(&mut db, "CREATE INDEX iab ON tab(a, b)");
+    db
+}
+
+/// Two plain (unindexed) tables for compound-query shapes.
+fn setup_compound_db() -> Database {
+    let mut db = Database::new();
+    run_ddl(&mut db, "CREATE TABLE u1(a INTEGER, b INTEGER)");
+    run_ddl(&mut db, "CREATE TABLE u2(a INTEGER, b INTEGER)");
+    db
+}
+
+// ---------------------------------------------------------------------------
+// GROUP BY
+// ---------------------------------------------------------------------------
+
+// Unindexed GROUP BY. sqlite3 — identical:
+//   |--SCAN t1
+//   `--USE TEMP B-TREE FOR GROUP BY
+#[test]
+fn test_group_by_unindexed_emits_temp_btree() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT b, count(*) FROM t1 GROUP BY b");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SCAN t1\n\
+         `--USE TEMP B-TREE FOR GROUP BY\n"
+    );
+}
+
+// Indexed GROUP BY: the i1a index delivers group order, so the line is
+// suppressed (sqlite3 suppresses too: `SCAN t1 USING COVERING INDEX i1a`
+// alone). Scan-line divergence: VibeSQL's runtime hash-groups over a plain
+// scan, so the pre-existing base-scan rendering shows `SCAN t1` (#5355
+// notes); the suppression itself matches SQLite.
+#[test]
+fn test_group_by_indexed_suppresses_temp_btree() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT a, count(*) FROM t1 GROUP BY a");
+
+    assert!(!output.contains("USE TEMP B-TREE"), "indexed GROUP BY must suppress:\n{}", output);
+}
+
+// GROUP BY on two columns when the index only covers the first. sqlite3:
+//   |--SCAN t1 USING INDEX i1a        [scan-line divergence: SCAN t1]
+//   `--USE TEMP B-TREE FOR GROUP BY
+#[test]
+fn test_group_by_partially_indexed_emits_temp_btree() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT a, b, count(*) FROM t1 GROUP BY a, b");
+
+    assert!(
+        output.contains("USE TEMP B-TREE FOR GROUP BY"),
+        "partially indexed GROUP BY needs the temp structure:\n{}",
+        output
+    );
+}
+
+// Equality-pinned GROUP BY column: the index search delivers a single
+// group, so no temp structure line. sqlite3 — identical shape:
+//   `--SEARCH t1 USING COVERING INDEX i1a (a=?)
+#[test]
+fn test_group_by_pinned_by_where_suppresses_temp_btree() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT a, count(*) FROM t1 WHERE a = 5 GROUP BY a");
+
+    assert!(output.contains("SEARCH t1"), "expected index search:\n{}", output);
+    assert!(!output.contains("USE TEMP B-TREE"), "pinned GROUP BY must suppress:\n{}", output);
+}
+
+// Grouping is order-insensitive: SQLite reorders `GROUP BY b, a` to match
+// the (a, b) index and suppresses the line (verified live:
+// `SCAN tab USING COVERING INDEX iab` alone). VibeSQL retries the group key
+// permuted into each index's column order.
+#[test]
+fn test_group_by_order_insensitive_index_match_suppresses() {
+    let db = setup_composite_db();
+    let output = eqp(&db, "SELECT b, a, count(*) FROM tab GROUP BY b, a");
+
+    assert!(
+        !output.contains("USE TEMP B-TREE"),
+        "reordered GROUP BY matching the (a, b) index must suppress:\n{}",
+        output
+    );
+}
+
+// ROLLUP (and other grouping-set forms) always build temp structures.
+// (Non-standard in SQLite — no reference output; the line is the truthful
+// rendering of the runtime's grouping-sets execution.)
+#[test]
+fn test_group_by_rollup_emits_temp_btree() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT a, b, count(*) FROM t1 GROUP BY ROLLUP(a, b)");
+
+    assert!(
+        output.contains("USE TEMP B-TREE FOR GROUP BY"),
+        "ROLLUP grouping needs the temp structure:\n{}",
+        output
+    );
+}
+
+// Plain aggregate without GROUP BY: no temp-structure line. sqlite3 agrees
+// (`SCAN t1 USING COVERING INDEX i1a` for count(*) — scan-line divergence).
+#[test]
+fn test_aggregate_without_group_by_no_temp_btree() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT count(*) FROM t1");
+
+    assert!(!output.contains("USE TEMP B-TREE"), "plain aggregate needs no line:\n{}", output);
+}
+
+// ---------------------------------------------------------------------------
+// GROUP BY + ORDER BY interaction
+// ---------------------------------------------------------------------------
+
+// ORDER BY matching the GROUP BY key exactly is satisfied by the grouping
+// output (the runtime sorts groups by key). sqlite3 — identical:
+//   |--SCAN t1
+//   `--USE TEMP B-TREE FOR GROUP BY
+#[test]
+fn test_order_by_matching_group_key_suppressed() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT b, count(*) FROM t1 GROUP BY b ORDER BY b");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SCAN t1\n\
+         `--USE TEMP B-TREE FOR GROUP BY\n"
+    );
+}
+
+// ORDER BY on a non-group expression needs its own sorting pass. sqlite3 —
+// identical:
+//   |--SCAN t1
+//   |--USE TEMP B-TREE FOR GROUP BY
+//   `--USE TEMP B-TREE FOR ORDER BY
+#[test]
+fn test_order_by_not_matching_group_key_emits_both() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT b, count(*) FROM t1 GROUP BY b ORDER BY count(*)");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SCAN t1\n\
+         |--USE TEMP B-TREE FOR GROUP BY\n\
+         `--USE TEMP B-TREE FOR ORDER BY\n"
+    );
+}
+
+// Directions are ignored in the GROUP BY match: sqlite3 suppresses the
+// ORDER BY line even for mixed ASC/DESC over the exact group key (verified
+// live: only the GROUP BY line renders).
+#[test]
+fn test_order_by_group_key_mixed_directions_suppressed() {
+    let db = setup_db();
+    let output =
+        eqp(&db, "SELECT b, c, count(*) FROM t1 GROUP BY b, c ORDER BY b ASC, c DESC");
+
+    assert!(output.contains("USE TEMP B-TREE FOR GROUP BY"), "missing GROUP BY:\n{}", output);
+    assert!(
+        !output.contains("USE TEMP B-TREE FOR ORDER BY"),
+        "exact-key ORDER BY (directions ignored) must suppress:\n{}",
+        output
+    );
+}
+
+// A bare prefix of the group key does NOT suppress (verified live: sqlite3
+// emits both lines for `GROUP BY b, c ORDER BY b`).
+#[test]
+fn test_order_by_group_key_prefix_not_suppressed() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT b, c, count(*) FROM t1 GROUP BY b, c ORDER BY b");
+
+    assert!(output.contains("USE TEMP B-TREE FOR GROUP BY"), "missing GROUP BY:\n{}", output);
+    assert!(
+        output.contains("USE TEMP B-TREE FOR ORDER BY"),
+        "prefix-only ORDER BY needs its own pass:\n{}",
+        output
+    );
+}
+
+// A permutation of the group key does NOT suppress either (verified live).
+#[test]
+fn test_order_by_group_key_permutation_not_suppressed() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT b, c, count(*) FROM t1 GROUP BY b, c ORDER BY c, b");
+
+    assert!(
+        output.contains("USE TEMP B-TREE FOR ORDER BY"),
+        "permuted ORDER BY needs its own pass:\n{}",
+        output
+    );
+}
+
+// Output ordinals resolve before the match: `ORDER BY 1` is `ORDER BY b`
+// here. sqlite3 — only the GROUP BY line (verified live).
+#[test]
+fn test_order_by_ordinal_resolves_against_group_key() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT b, count(*) FROM t1 GROUP BY b ORDER BY 1");
+
+    assert!(output.contains("USE TEMP B-TREE FOR GROUP BY"), "missing GROUP BY:\n{}", output);
+    assert!(
+        !output.contains("USE TEMP B-TREE FOR ORDER BY"),
+        "ordinal ORDER BY over the group key must suppress:\n{}",
+        output
+    );
+}
+
+// Output aliases resolve too: `ORDER BY z` where `b AS z`. sqlite3 — only
+// the GROUP BY line (verified live).
+#[test]
+fn test_order_by_alias_resolves_against_group_key() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT b AS z, count(*) FROM t1 GROUP BY b ORDER BY z");
+
+    assert!(output.contains("USE TEMP B-TREE FOR GROUP BY"), "missing GROUP BY:\n{}", output);
+    assert!(
+        !output.contains("USE TEMP B-TREE FOR ORDER BY"),
+        "alias ORDER BY over the group key must suppress:\n{}",
+        output
+    );
+}
+
+// ---------------------------------------------------------------------------
+// DISTINCT
+// ---------------------------------------------------------------------------
+
+// Unindexed DISTINCT. sqlite3 — identical:
+//   |--SCAN t1
+//   `--USE TEMP B-TREE FOR DISTINCT
+#[test]
+fn test_distinct_unindexed_emits_temp_btree() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT DISTINCT b FROM t1");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SCAN t1\n\
+         `--USE TEMP B-TREE FOR DISTINCT\n"
+    );
+}
+
+// Indexed DISTINCT: rows arrive in SELECT-list order via i1a, so the line
+// is suppressed (sqlite3: `SCAN t1 USING COVERING INDEX i1a` alone —
+// scan-line divergence as usual).
+#[test]
+fn test_distinct_indexed_suppresses_temp_btree() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT DISTINCT a FROM t1");
+
+    assert!(!output.contains("USE TEMP B-TREE"), "indexed DISTINCT must suppress:\n{}", output);
+}
+
+// DISTINCT + ORDER BY on the exact (all-ASC) SELECT list: the dedup
+// structure delivers the order; one line only. sqlite3 — identical:
+//   |--SCAN t1
+//   `--USE TEMP B-TREE FOR DISTINCT
+#[test]
+fn test_distinct_order_by_exact_asc_one_line() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT DISTINCT b FROM t1 ORDER BY b");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SCAN t1\n\
+         `--USE TEMP B-TREE FOR DISTINCT\n"
+    );
+}
+
+// DESC breaks the DISTINCT match (unlike the GROUP BY rule — verified
+// live): sqlite3 emits both lines.
+//   |--SCAN t1
+//   |--USE TEMP B-TREE FOR DISTINCT
+//   `--USE TEMP B-TREE FOR ORDER BY
+#[test]
+fn test_distinct_order_by_desc_two_lines() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT DISTINCT b FROM t1 ORDER BY b DESC");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SCAN t1\n\
+         |--USE TEMP B-TREE FOR DISTINCT\n\
+         `--USE TEMP B-TREE FOR ORDER BY\n"
+    );
+}
+
+// A bare prefix of the SELECT list does not suppress the ORDER BY line
+// (verified live), but the full list does.
+#[test]
+fn test_distinct_order_by_prefix_vs_full_list() {
+    let db = setup_db();
+
+    let prefix = eqp(&db, "SELECT DISTINCT b, c FROM t1 ORDER BY b");
+    assert!(prefix.contains("USE TEMP B-TREE FOR DISTINCT"), "missing DISTINCT:\n{}", prefix);
+    assert!(
+        prefix.contains("USE TEMP B-TREE FOR ORDER BY"),
+        "prefix-only ORDER BY needs its own pass:\n{}",
+        prefix
+    );
+
+    let full = eqp(&db, "SELECT DISTINCT b, c FROM t1 ORDER BY b, c");
+    assert!(full.contains("USE TEMP B-TREE FOR DISTINCT"), "missing DISTINCT:\n{}", full);
+    assert!(
+        !full.contains("USE TEMP B-TREE FOR ORDER BY"),
+        "full-list ASC ORDER BY must suppress:\n{}",
+        full
+    );
+}
+
+// Ordinals resolve in the DISTINCT match too: `ORDER BY 1` is `ORDER BY b`
+// (verified live: only the DISTINCT line renders).
+#[test]
+fn test_distinct_order_by_ordinal_suppressed() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT DISTINCT b FROM t1 ORDER BY 1");
+
+    assert!(output.contains("USE TEMP B-TREE FOR DISTINCT"), "missing DISTINCT:\n{}", output);
+    assert!(
+        !output.contains("USE TEMP B-TREE FOR ORDER BY"),
+        "ordinal ORDER BY over the SELECT list must suppress:\n{}",
+        output
+    );
+}
+
+// DISTINCT + GROUP BY emit both lines, GROUP BY first. sqlite3 — identical
+// (it does not prove distinctness from the grouping):
+//   |--SCAN t1
+//   |--USE TEMP B-TREE FOR GROUP BY
+//   `--USE TEMP B-TREE FOR DISTINCT
+#[test]
+fn test_distinct_with_group_by_emits_both_in_order() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT DISTINCT b, count(*) FROM t1 GROUP BY b");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SCAN t1\n\
+         |--USE TEMP B-TREE FOR GROUP BY\n\
+         `--USE TEMP B-TREE FOR DISTINCT\n"
+    );
+}
+
+// With GROUP BY present the index never suppresses DISTINCT (the grouping
+// pass intervenes): sqlite3 keeps the DISTINCT line for
+// `SELECT DISTINCT a ... GROUP BY a` even with the index (verified live).
+#[test]
+fn test_distinct_not_suppressed_by_index_when_grouped() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT DISTINCT a FROM t1 GROUP BY a");
+
+    assert!(
+        !output.contains("USE TEMP B-TREE FOR GROUP BY"),
+        "indexed group key must suppress the GROUP BY line:\n{}",
+        output
+    );
+    assert!(
+        output.contains("USE TEMP B-TREE FOR DISTINCT"),
+        "DISTINCT after grouping still dedups:\n{}",
+        output
+    );
+}
+
+// Indexed DISTINCT + reverse ORDER BY: the dedup rides the index and the
+// reverse traversal satisfies the DESC order — no lines at all. sqlite3 —
+// no temp B-tree lines (verified live; scan-line divergence as usual).
+#[test]
+fn test_distinct_indexed_order_by_desc_no_lines() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT DISTINCT a FROM t1 ORDER BY a DESC");
+
+    assert!(
+        !output.contains("USE TEMP B-TREE"),
+        "index-backed dedup + reversible order needs no temp lines:\n{}",
+        output
+    );
+}
+
+// Constant SELECT lists never suppress (verified live: sqlite3 keeps the
+// DISTINCT line).
+#[test]
+fn test_distinct_literal_emits_temp_btree() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT DISTINCT 1 FROM t1");
+
+    assert!(output.contains("USE TEMP B-TREE FOR DISTINCT"), "missing DISTINCT:\n{}", output);
+}
+
+// Wildcard SELECT lists never suppress either.
+#[test]
+fn test_distinct_wildcard_emits_temp_btree() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT DISTINCT * FROM t1");
+
+    assert!(output.contains("USE TEMP B-TREE FOR DISTINCT"), "missing DISTINCT:\n{}", output);
+}
+
+// ---------------------------------------------------------------------------
+// Compound dedup branch labels
+// ---------------------------------------------------------------------------
+
+// UNION dedups through a temp structure. sqlite3 — identical:
+//   `--COMPOUND QUERY
+//      |--LEFT-MOST SUBQUERY
+//      |  `--SCAN u1
+//      `--UNION USING TEMP B-TREE
+//         `--SCAN u2
+#[test]
+fn test_union_branch_labeled_using_temp_btree() {
+    let db = setup_compound_db();
+    let output = eqp(&db, "SELECT a FROM u1 UNION SELECT a FROM u2");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         `--COMPOUND QUERY\n   \
+            |--LEFT-MOST SUBQUERY\n   \
+            |  `--SCAN u1\n   \
+            `--UNION USING TEMP B-TREE\n      \
+               `--SCAN u2\n"
+    );
+}
+
+// UNION ALL stays bare. sqlite3 — identical.
+#[test]
+fn test_union_all_branch_stays_bare() {
+    let db = setup_compound_db();
+    let output = eqp(&db, "SELECT a FROM u1 UNION ALL SELECT a FROM u2");
+
+    assert!(output.contains("`--UNION ALL\n"), "UNION ALL must stay bare:\n{}", output);
+    assert!(!output.contains("USING TEMP B-TREE"), "no dedup structure:\n{}", output);
+}
+
+// INTERSECT and EXCEPT take the same suffix. sqlite3 — identical labels.
+#[test]
+fn test_intersect_and_except_labels() {
+    let db = setup_compound_db();
+
+    let intersect = eqp(&db, "SELECT a FROM u1 INTERSECT SELECT a FROM u2");
+    assert!(
+        intersect.contains("INTERSECT USING TEMP B-TREE"),
+        "missing INTERSECT label:\n{}",
+        intersect
+    );
+
+    let except = eqp(&db, "SELECT a FROM u1 EXCEPT SELECT a FROM u2");
+    assert!(
+        except.contains("EXCEPT USING TEMP B-TREE"),
+        "missing EXCEPT label:\n{}",
+        except
+    );
+}
+
+// Mixed chains label each branch independently. sqlite3 — identical:
+//   `--COMPOUND QUERY
+//      |--LEFT-MOST SUBQUERY
+//      |  `--SCAN u1
+//      |--UNION ALL
+//      |  `--SCAN u2
+//      `--UNION USING TEMP B-TREE
+//         `--SCAN u1
+#[test]
+fn test_mixed_compound_chain_labels() {
+    let db = setup_compound_db();
+    let output =
+        eqp(&db, "SELECT a FROM u1 UNION ALL SELECT a FROM u2 UNION SELECT b FROM u1");
+
+    assert!(output.contains("|--UNION ALL\n"), "missing bare UNION ALL branch:\n{}", output);
+    assert!(
+        output.contains("`--UNION USING TEMP B-TREE\n"),
+        "missing dedup UNION branch:\n{}",
+        output
+    );
+}
+
+// Branch-level GROUP BY/DISTINCT lines render INSIDE the branch block.
+// sqlite3 — identical:
+//   `--COMPOUND QUERY
+//      |--LEFT-MOST SUBQUERY
+//      |  |--SCAN u1
+//      |  `--USE TEMP B-TREE FOR GROUP BY
+//      `--UNION ALL
+//         `--SCAN u2
+#[test]
+fn test_compound_branch_group_by_line_inside_branch() {
+    let db = setup_compound_db();
+    let output =
+        eqp(&db, "SELECT a, count(*) FROM u1 GROUP BY a UNION ALL SELECT a, b FROM u2");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         `--COMPOUND QUERY\n   \
+            |--LEFT-MOST SUBQUERY\n   \
+            |  |--SCAN u1\n   \
+            |  `--USE TEMP B-TREE FOR GROUP BY\n   \
+            `--UNION ALL\n      \
+               `--SCAN u2\n"
+    );
+}
+
+// sqlite3 — identical shape for a DISTINCT left branch.
+#[test]
+fn test_compound_branch_distinct_line_inside_branch() {
+    let db = setup_compound_db();
+    let output = eqp(&db, "SELECT DISTINCT a FROM u1 UNION ALL SELECT a FROM u2");
+
+    assert!(
+        output.contains("|  `--USE TEMP B-TREE FOR DISTINCT\n"),
+        "DISTINCT line must render inside the branch block:\n{}",
+        output
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CO-ROUTINE wrapper for non-flattenable derived tables
+// ---------------------------------------------------------------------------
+
+// Dedup-compound derived tables cannot be flattened; sqlite3 wraps the
+// COMPOUND QUERY in a CO-ROUTINE (verified live) — identical:
+//   |--CO-ROUTINE q
+//   |  `--COMPOUND QUERY
+//   |     |--LEFT-MOST SUBQUERY
+//   |     |  `--SCAN u1
+//   |     `--UNION USING TEMP B-TREE
+//   |        `--SCAN u2
+//   `--SCAN q
+#[test]
+fn test_dedup_compound_derived_table_wrapped_in_coroutine() {
+    let db = setup_compound_db();
+    let output =
+        eqp(&db, "SELECT * FROM (SELECT a FROM u1 UNION SELECT a FROM u2) AS q");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE q\n\
+         |  `--COMPOUND QUERY\n\
+         |     |--LEFT-MOST SUBQUERY\n\
+         |     |  `--SCAN u1\n\
+         |     `--UNION USING TEMP B-TREE\n\
+         |        `--SCAN u2\n\
+         `--SCAN q\n"
+    );
+}
+
+// UNION-ALL-only derived tables flatten (sqlite3 shows the bare COMPOUND
+// QUERY with no co-routine and no alias — verified live) — identical.
+#[test]
+fn test_union_all_derived_table_not_wrapped() {
+    let db = setup_compound_db();
+    let output =
+        eqp(&db, "SELECT * FROM (SELECT a FROM u1 UNION ALL SELECT a FROM u2) AS q");
+
+    assert!(!output.contains("CO-ROUTINE"), "UNION ALL derived must flatten:\n{}", output);
+    assert!(output.contains("COMPOUND QUERY"), "missing compound block:\n{}", output);
+}
+
+// GROUP BY derived tables wrap, with the grouping line inside the block.
+// sqlite3 — identical:
+//   |--CO-ROUTINE g
+//   |  |--SCAN t1
+//   |  `--USE TEMP B-TREE FOR GROUP BY
+//   `--SCAN g
+#[test]
+fn test_group_by_derived_table_wrapped_in_coroutine() {
+    let db = setup_db();
+    let output =
+        eqp(&db, "SELECT * FROM (SELECT b, count(*) AS c FROM t1 GROUP BY b) AS g");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE g\n\
+         |  |--SCAN t1\n\
+         |  `--USE TEMP B-TREE FOR GROUP BY\n\
+         `--SCAN g\n"
+    );
+}
+
+// DISTINCT derived tables wrap too. sqlite3 — identical:
+//   |--CO-ROUTINE d
+//   |  |--SCAN t1
+//   |  `--USE TEMP B-TREE FOR DISTINCT
+//   `--SCAN d
+#[test]
+fn test_distinct_derived_table_wrapped_in_coroutine() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT * FROM (SELECT DISTINCT b FROM t1) AS d");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE d\n\
+         |  |--SCAN t1\n\
+         |  `--USE TEMP B-TREE FOR DISTINCT\n\
+         `--SCAN d\n"
+    );
+}
+
+// Scalar-aggregate derived tables wrap (sqlite3: `CO-ROUTINE d` — verified
+// live) — identical.
+#[test]
+fn test_aggregate_derived_table_wrapped_in_coroutine() {
+    let db = setup_compound_db();
+    let output = eqp(&db, "SELECT * FROM (SELECT count(*) AS n FROM u2) AS d");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE d\n\
+         |  `--SCAN u2\n\
+         `--SCAN d\n"
+    );
+}
+
+// LIMIT-only derived tables flatten in sqlite3 (verified live: `SCAN u1`
+// alone); VibeSQL keeps the pre-existing flat rendering — identical.
+#[test]
+fn test_limit_derived_table_not_wrapped() {
+    let db = setup_compound_db();
+    let output = eqp(&db, "SELECT * FROM (SELECT a FROM u1 LIMIT 5) AS l");
+
+    assert!(!output.contains("CO-ROUTINE"), "LIMIT-only derived must flatten:\n{}", output);
+    assert!(output.contains("SCAN u1"), "missing flattened scan:\n{}", output);
+}
+
+// ---------------------------------------------------------------------------
+// GROUP BY / DISTINCT views inside CO-ROUTINE blocks
+// ---------------------------------------------------------------------------
+
+// Unindexed GROUP BY view: the grouping line renders INSIDE the CO-ROUTINE
+// block, exactly once. sqlite3 — identical:
+//   |--CO-ROUTINE gvu
+//   |  |--SCAN t1
+//   |  `--USE TEMP B-TREE FOR GROUP BY
+//   `--SCAN gvu
+#[test]
+fn test_group_by_view_temp_btree_inside_coroutine_once() {
+    let mut db = setup_db();
+    run_ddl(&mut db, "CREATE VIEW gvu AS SELECT b, count(*) AS c FROM t1 GROUP BY b");
+    let output = eqp(&db, "SELECT * FROM gvu");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE gvu\n\
+         |  |--SCAN t1\n\
+         |  `--USE TEMP B-TREE FOR GROUP BY\n\
+         `--SCAN gvu\n"
+    );
+    assert_eq!(
+        output.matches("USE TEMP B-TREE FOR GROUP BY").count(),
+        1,
+        "no double emission:\n{}",
+        output
+    );
+}
+
+// Unindexed DISTINCT view. sqlite3 — identical:
+//   |--CO-ROUTINE dvu
+//   |  |--SCAN t1
+//   |  `--USE TEMP B-TREE FOR DISTINCT
+//   `--SCAN dvu
+#[test]
+fn test_distinct_view_temp_btree_inside_coroutine_once() {
+    let mut db = setup_db();
+    run_ddl(&mut db, "CREATE VIEW dvu AS SELECT DISTINCT b FROM t1");
+    let output = eqp(&db, "SELECT * FROM dvu");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE dvu\n\
+         |  |--SCAN t1\n\
+         |  `--USE TEMP B-TREE FOR DISTINCT\n\
+         `--SCAN dvu\n"
+    );
+    assert_eq!(
+        output.matches("USE TEMP B-TREE FOR DISTINCT").count(),
+        1,
+        "no double emission:\n{}",
+        output
+    );
+}
+
+// Outer ORDER BY over a GROUP BY view: the view's grouping line stays
+// inside the block; the outer sort renders outside. sqlite3 — identical:
+//   |--CO-ROUTINE gvu
+//   |  |--SCAN t1
+//   |  `--USE TEMP B-TREE FOR GROUP BY
+//   |--SCAN gvu
+//   `--USE TEMP B-TREE FOR ORDER BY
+#[test]
+fn test_outer_order_by_over_group_by_view() {
+    let mut db = setup_db();
+    run_ddl(&mut db, "CREATE VIEW gvu AS SELECT b, count(*) AS c FROM t1 GROUP BY b");
+    let output = eqp(&db, "SELECT * FROM gvu ORDER BY c");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE gvu\n\
+         |  |--SCAN t1\n\
+         |  `--USE TEMP B-TREE FOR GROUP BY\n\
+         |--SCAN gvu\n\
+         `--USE TEMP B-TREE FOR ORDER BY\n"
+    );
+}

--- a/crates/vibesql-executor/tests/explain_view_expansion_tests.rs
+++ b/crates/vibesql-executor/tests/explain_view_expansion_tests.rs
@@ -359,9 +359,10 @@ fn test_outer_order_by_over_flattened_view_keeps_temp_btree() {
 // - SQLite uses `SCAN t3 USING COVERING INDEX i3x` for covering-index-only
 //   bodies; VibeSQL's pre-existing base-scan rendering shows `SCAN t3`
 //   (same for bare bodies — unrelated to view expansion, see #5355 notes).
-// - SQLite shows `USE TEMP B-TREE FOR GROUP BY` / `FOR DISTINCT` lines for
-//   unindexed grouping/dedup; VibeSQL's EQP has no GROUP BY/DISTINCT temp
-//   B-tree rendering anywhere yet (follow-on).
+// - `USE TEMP B-TREE FOR GROUP BY` / `FOR DISTINCT` lines render like
+//   SQLite's since #5367 (suppressed here because the i3x index delivers
+//   x-order for the grouping/dedup keys below — sqlite3 suppresses too;
+//   see explain_temp_btree_annotation_tests.rs for the emitted cases).
 
 // Aggregate + GROUP BY view. sqlite3:
 //   |--CO-ROUTINE av
@@ -457,9 +458,10 @@ fn test_limit_offset_view_renders_coroutine() {
     );
 }
 
-// DISTINCT view. sqlite3 (with the index, dedup rides the covering index;
-// without it, a `USE TEMP B-TREE FOR DISTINCT` line appears — VibeSQL has
-// no DISTINCT temp B-tree rendering yet, follow-on):
+// DISTINCT view. sqlite3 (with the index, dedup rides the covering index
+// and the `USE TEMP B-TREE FOR DISTINCT` line is suppressed — VibeSQL
+// suppresses too since #5367; the unindexed emitted case is covered in
+// explain_temp_btree_annotation_tests.rs):
 //   |--CO-ROUTINE dv
 //   |  `--SEARCH t3 USING COVERING INDEX i3x (x=?)
 //   `--SCAN dv
@@ -478,7 +480,8 @@ fn test_distinct_view_renders_coroutine() {
 }
 
 // Compound (UNION) view: the body's COMPOUND QUERY block nests inside the
-// CO-ROUTINE. sqlite3:
+// CO-ROUTINE, and the dedup branch is labeled `UNION USING TEMP B-TREE`
+// (#5367 — truthful: the runtime dedups via a temp hash structure). sqlite3:
 //   |--CO-ROUTINE cv
 //   |  `--COMPOUND QUERY
 //   |     |--LEFT-MOST SUBQUERY
@@ -486,9 +489,7 @@ fn test_distinct_view_renders_coroutine() {
 //   |     `--UNION USING TEMP B-TREE
 //   |        `--SCAN t3
 //   `--SCAN cv
-// Divergences: no fabricated outer-WHERE probe (see above), and VibeSQL's
-// pre-existing compound rendering labels the dedup branch `UNION` rather
-// than `UNION USING TEMP B-TREE` (follow-on).
+// Divergence: no fabricated outer-WHERE probe (see above).
 #[test]
 fn test_compound_union_view_renders_coroutine() {
     let db = setup_plain_view_db();
@@ -501,7 +502,7 @@ fn test_compound_union_view_renders_coroutine() {
          |  `--COMPOUND QUERY\n\
          |     |--LEFT-MOST SUBQUERY\n\
          |     |  `--SCAN t3\n\
-         |     `--UNION\n\
+         |     `--UNION USING TEMP B-TREE\n\
          |        `--SCAN t3\n\
          `--SCAN cv\n"
     );
@@ -567,8 +568,9 @@ fn test_with_view_renders_coroutine_divergence() {
 }
 
 // A blocked body with its own ORDER BY: the body's temp B-tree line renders
-// INSIDE the CO-ROUTINE block, exactly once. sqlite3 (the GROUP BY temp
-// B-tree line is the documented gap above):
+// INSIDE the CO-ROUTINE block, exactly once. No GROUP BY line: the i3x
+// index delivers GROUP BY x order (sqlite3 suppresses too), and ORDER BY c
+// does not match the group key, so the ORDER BY line renders. sqlite3:
 //   |--CO-ROUTINE aov
 //   |  |--SCAN t3 USING COVERING INDEX i3x
 //   |  `--USE TEMP B-TREE FOR ORDER BY


### PR DESCRIPTION
Closes #5367

## Summary

EXPLAIN QUERY PLAN now emits the temp-structure lines sqlite3 produces, with **every expected shape verified live against sqlite3 3.51.0** (`.eqp on`):

- **`USE TEMP B-TREE FOR GROUP BY`** — emitted when no index delivers group order; suppressed when one does. Suppression handles equality-pinned leading columns (`WHERE a=5 GROUP BY b` with index `(a,b)`) and is **order-insensitive** (`GROUP BY b, a` matches index `(a, b)` — sqlite3 reorders group terms, verified live). ROLLUP/CUBE/GROUPING SETS always emit.
- **`USE TEMP B-TREE FOR DISTINCT`** — emitted when no index delivers SELECT-list order; never suppressed when a GROUP BY intervenes (`SELECT DISTINCT a ... GROUP BY a` keeps the line even with an index — verified live, sqlite3 agrees).
- **ORDER BY interaction** (all rules verified live):
  - GROUP BY: ORDER BY suppressed iff it equals the group key — same exprs, same sequence, same length, *directions ignored* (even `ORDER BY b ASC, c DESC` over `GROUP BY b, c` suppresses); bare prefixes and permutations do NOT suppress. Output ordinals (`ORDER BY 1`) and aliases (`ORDER BY z` for `b AS z`) resolve first.
  - DISTINCT: suppressed iff exact all-ASC match of the SELECT list (`ORDER BY b DESC` emits both lines); when the dedup itself rides an index, the usual index check applies (`SELECT DISTINCT a ... ORDER BY a DESC` with index → no lines, matching sqlite3's reverse traversal).
  - Line order matches sqlite3: GROUP BY → DISTINCT → ORDER BY.
- **Compound dedup branch labels** — `UNION USING TEMP B-TREE`, `INTERSECT USING TEMP B-TREE`, `EXCEPT USING TEMP B-TREE`; `UNION ALL` stays bare. Branch-level GROUP BY/DISTINCT lines now render *inside* the branch block (sqlite3-identical), via switching `compound_eqp_entry` from flat scan collection to full per-branch entry collection.
- **CO-ROUTINE wrapper for non-flattenable derived tables** (the #5366 judge's note, folded in): GROUP BY / DISTINCT / aggregate / dedup-compound derived tables now wrap in `CO-ROUTINE <alias>` blocks exactly like sqlite3; UNION-ALL-only and LIMIT-only derived tables keep flattening (sqlite3 flattens those — verified live, so no currently-matching shape regresses).

## Runtime truthfulness (per the #5355/#5360/#5366 precedent)

Investigated how these actually execute:
- **GROUP BY**: always hash aggregation (`AHashMap` in `crates/vibesql-executor/src/select/grouping/hash.rs`) followed by `result.sort_by` on the group keys — a temp grouping structure is genuinely built whenever GROUP BY runs, so the line is truthful. The index suppression mirrors sqlite3 and follows the repo's established permissive EQP convention (`needs_temp_btree_for_order_by_eqp` already suppresses despite runtime stabilization sorts).
- **DISTINCT**: always hash dedup preserving input order (`apply_distinct` in `crates/vibesql-executor/src/select/helpers.rs`, `IndexSet`) — temp structure truthful; suppression mirrors sqlite3.
- **Compound dedup**: `HashSet`/`HashMap` based dedup + sort (`crates/vibesql-executor/src/select/set_operations.rs`) — `USING TEMP B-TREE` labels truthful.

Documented divergence (pre-existing, unchanged): when an index delivers group/dedup order, sqlite3 also renders the scan as `SCAN t USING COVERING INDEX i`; VibeSQL's base-scan rendering shows `SCAN t` (the runtime genuinely seq-scans + hash-groups). The temp-line suppression itself matches sqlite3.

## Tests

- New suite `crates/vibesql-executor/tests/explain_temp_btree_annotation_tests.rs`: **40 tests**, each annotated with its sqlite3-verified expected shape — bare/indexed/pinned/reordered GROUP BY, ROLLUP, all GROUP BY×ORDER BY rules (exact/DESC/mixed/prefix/permutation/ordinal/alias), bare/indexed DISTINCT, DISTINCT×ORDER BY rules, DISTINCT+GROUP BY ordering, compound labels (UNION/UNION ALL/INTERSECT/EXCEPT/mixed chains), branch-level lines, derived-table wrapping (wrapped: dedup-compound/GROUP BY/DISTINCT/aggregate; flat: UNION ALL/LIMIT), GROUP BY/DISTINCT views inside CO-ROUTINE blocks with single emission, outer ORDER BY over a GROUP BY view.
- `explain_view_expansion_tests.rs`: 32/32 pass (one expectation updated to the now-correct `UNION USING TEMP B-TREE` label; stale gap comments refreshed).
- Full `cargo test -p vibesql-executor`: green (60 test binaries, zero failures).
- TCL vs main baseline (origin/main c41f5d26, same 7 files, native tclsh): **identical results, zero new failures** — eqp 5/5, windowpushd 29/29, window9 38/38, view 24/24, select6 86/86, distinct 38/38, distinct2 41/44 (3 pre-existing failures on main too: 120/5020/5030, result-ordering/column-resolution issues unrelated to EQP).

## Notes

- Pre-existing clippy failure on main: `clippy::approx_constant` in `crates/vibesql-executor/src/evaluator/expressions/operators.rs:339` (unit test asserting `-3.14`) — untouched by this PR.
- Follow-on candidates (not scope-crept): sqlite3 renders compound + ORDER BY as a `MERGE (UNION)` plan shape (VibeSQL keeps COMPOUND QUERY); ordering-index scan lines (`SCAN t USING COVERING INDEX i`) for grouping/dedup-driven index choices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)