### PR TITLE
feat(explain): ordering-index scan lines + compound ORDER BY shape

### DIFF
--- a/crates/vibesql-executor/src/explain.rs
+++ b/crates/vibesql-executor/src/explain.rs
@@ -67,6 +67,11 @@ pub struct PlanNode {
     pub scan_type: Option<ScanType>,
     /// Index name used (for SEARCH operations)
     pub index_name: Option<String>,
+    /// True when `index_name` covers every column the query reads from this
+    /// table (SELECT list + WHERE, with the rowid alias carried implicitly).
+    /// Ordering scans then render as SQLite's
+    /// `SCAN <table> USING COVERING INDEX <index>` (#5371).
+    pub index_covering: bool,
     /// Index predicates for SQLite EQP format (e.g., "w=?", "x>? AND x<?")
     pub index_predicates: Vec<IndexPredicate>,
     /// Whether this query requires a temp B-tree for ORDER BY
@@ -112,6 +117,7 @@ impl PlanNode {
             children: Vec::new(),
             scan_type: None,
             index_name: None,
+            index_covering: false,
             index_predicates: Vec::new(),
             needs_temp_btree_for_order_by: false,
             needs_temp_btree_for_group_by: false,
@@ -671,9 +677,16 @@ fn format_sqlite_eqp_node(node: &PlanNode) -> String {
 
     match node.scan_type.as_ref() {
         Some(ScanType::Scan) => {
-            // Check if we have an index for ordering (SCAN table USING INDEX idx)
+            // Check if we have an index for ordering (SCAN table USING INDEX idx).
+            // When the index also covers every column read, SQLite renders
+            // `SCAN <table> USING COVERING INDEX <index>` (verified live
+            // against sqlite3 3.51.0, #5371).
             if let Some(ref index_name) = node.index_name {
-                format!("SCAN {} USING INDEX {}", table_name, index_name)
+                if node.index_covering {
+                    format!("SCAN {} USING COVERING INDEX {}", table_name, index_name)
+                } else {
+                    format!("SCAN {} USING INDEX {}", table_name, index_name)
+                }
             } else {
                 format!("SCAN {}", table_name)
             }
@@ -846,22 +859,112 @@ impl ExplainExecutor {
         // Extract columns needed by the SELECT list for covering index detection
         let needed_columns = extract_select_columns(&stmt.select_list);
 
-        // Analyze FROM clause. When the SELECT list contains window
-        // functions, the base-table scan feeds the INNERMOST window sorting
-        // pass (SQLite's co-routine rewrite, see count_window_sorts), so the
-        // scan's effective ordering requirement is the last distinct window
-        // key — SQLite picks an index that delivers PARTITION BY/ORDER BY
-        // order even without any predicate (windowpushd.test 2.1.3.6).
+        // Temp-structure suppression keys (#5367), computed BEFORE the FROM
+        // analysis because the base scan's effective ordering requirement
+        // depends on which suppression (if any) fires (#5371): when an index
+        // delivers GROUP BY / DISTINCT order, sqlite3 shows the scan riding
+        // that index (`SCAN t USING [COVERING ]INDEX i`, verified live).
+        //
+        // The simple GROUP BY key (ordinals and output aliases resolved like
+        // SQLite) is also reused below to suppress the ORDER BY line when the
+        // statement-level ORDER BY matches the grouping output order.
+        let group_key: Option<Vec<&Expression>> =
+            stmt.group_by.as_ref().map(|g| g.as_simple()).and_then(|simple| {
+                simple.map(|exprs| {
+                    exprs
+                        .iter()
+                        .map(|e| Self::resolve_output_expr(e, &stmt.select_list))
+                        .collect()
+                })
+            });
+        // The index-delivered group order (as written or permuted into an
+        // index's column order); `Some` exactly when the GROUP BY temp line
+        // is suppressed.
+        let group_index_order: Option<Vec<vibesql_ast::OrderByItem>> = if stmt.group_by.is_some()
+        {
+            group_key.as_ref().and_then(|key| {
+                Self::group_key_index_order(
+                    stmt.from.as_ref(),
+                    stmt.where_clause.as_ref(),
+                    key,
+                    database,
+                )
+            })
+        } else {
+            None
+        };
+
+        // The DISTINCT key is the SELECT list. SQLite suppresses the line
+        // when an index delivers the SELECT-list order — but never when a
+        // GROUP BY intervenes (`SELECT DISTINCT a FROM t GROUP BY a` with an
+        // index on `a` still shows the DISTINCT line; verified live).
+        let distinct_key: Option<Vec<&Expression>> = if stmt.distinct {
+            Self::distinct_key_exprs(&stmt.select_list)
+        } else {
+            None
+        };
+        // The index-delivered SELECT-list order for DISTINCT; `Some` exactly
+        // when the DISTINCT temp line is suppressed.
+        let distinct_index_order: Option<Vec<vibesql_ast::OrderByItem>> =
+            if stmt.distinct && stmt.group_by.is_none() {
+                distinct_key.as_ref().and_then(|key| {
+                    let items = Self::exprs_as_asc_order_items(key);
+                    if Self::needs_temp_btree_for_order_by(
+                        stmt.from.as_ref(),
+                        stmt.where_clause.as_ref(),
+                        &items,
+                        database,
+                    ) {
+                        None
+                    } else {
+                        Some(items)
+                    }
+                })
+            } else {
+                None
+            };
+
+        // Analyze FROM clause. The base scan's effective ordering
+        // requirement follows SQLite's pipeline priority:
+        // - When the SELECT list contains window functions, the scan feeds
+        //   the INNERMOST window sorting pass (SQLite's co-routine rewrite,
+        //   see count_window_sorts) — SQLite picks an index that delivers
+        //   PARTITION BY/ORDER BY order even without any predicate
+        //   (windowpushd.test 2.1.3.6).
+        // - Otherwise the grouping/dedup pass consumes the scan's order:
+        //   when its suppression fired, the scan rides the delivering index
+        //   (#5371, sqlite3 3.51.0 verified live).
+        // - Otherwise the statement-level ORDER BY applies; the scan may
+        //   ride an ordering index exactly when the ORDER BY temp-line
+        //   suppression fires, so non-suppressed shapes keep their
+        //   pre-existing rendering.
         let window_scan_key = Self::distinct_window_keys(stmt).pop();
-        let order_from_window = window_scan_key.is_some();
-        let scan_order_by: Option<Vec<vibesql_ast::OrderByItem>> =
-            window_scan_key.or_else(|| stmt.order_by.clone());
+        let (scan_order_by, prefer_ordering_scan): (Option<Vec<vibesql_ast::OrderByItem>>, bool) =
+            if window_scan_key.is_some() {
+                (window_scan_key, true)
+            } else if group_index_order.is_some() {
+                (group_index_order.clone(), true)
+            } else if distinct_index_order.is_some() {
+                (distinct_index_order.clone(), true)
+            } else if stmt.group_by.is_none() && !stmt.distinct {
+                let order_by_suppressed = stmt.order_by.as_ref().is_some_and(|ob| {
+                    !Self::needs_temp_btree_for_order_by(
+                        stmt.from.as_ref(),
+                        stmt.where_clause.as_ref(),
+                        ob,
+                        database,
+                    )
+                });
+                (stmt.order_by.clone(), order_by_suppressed)
+            } else {
+                (stmt.order_by.clone(), false)
+            };
         if let Some(ref from_clause) = stmt.from {
             let scan_node = Self::explain_from_clause(
                 from_clause,
                 &stmt.where_clause,
                 &scan_order_by,
-                order_from_window,
+                prefer_ordering_scan,
                 &needed_columns,
                 database,
                 &ctes,
@@ -891,56 +994,17 @@ impl ExplainExecutor {
         // truthfully describe those temp structures; the index suppression
         // mirrors the established permissive EQP-level convention (see
         // `needs_temp_btree_for_order_by_eqp`).
-        //
-        // The simple GROUP BY key (ordinals and output aliases resolved like
-        // SQLite) is also reused below to suppress the ORDER BY line when the
-        // statement-level ORDER BY matches the grouping output order.
-        let group_key: Option<Vec<&Expression>> =
-            stmt.group_by.as_ref().map(|g| g.as_simple()).and_then(|simple| {
-                simple.map(|exprs| {
-                    exprs
-                        .iter()
-                        .map(|e| Self::resolve_output_expr(e, &stmt.select_list))
-                        .collect()
-                })
-            });
         if stmt.group_by.is_some() {
-            root.needs_temp_btree_for_group_by = match &group_key {
-                // ROLLUP/CUBE/GROUPING SETS always build temp structures.
-                None => true,
-                Some(key) => !Self::group_key_satisfied_by_index(
-                    stmt.from.as_ref(),
-                    stmt.where_clause.as_ref(),
-                    key,
-                    database,
-                ),
-            };
+            // ROLLUP/CUBE/GROUPING SETS (`group_key` is None) always build
+            // temp structures; a simple key suppresses exactly when an index
+            // delivers group order (`group_index_order`, computed above).
+            root.needs_temp_btree_for_group_by = group_index_order.is_none();
         }
-
-        // The DISTINCT key is the SELECT list. SQLite suppresses the line
-        // when an index delivers the SELECT-list order — but never when a
-        // GROUP BY intervenes (`SELECT DISTINCT a FROM t GROUP BY a` with an
-        // index on `a` still shows the DISTINCT line; verified live).
-        let distinct_key: Option<Vec<&Expression>> = if stmt.distinct {
-            Self::distinct_key_exprs(&stmt.select_list)
-        } else {
-            None
-        };
         if stmt.distinct {
-            root.needs_temp_btree_for_distinct = stmt.group_by.is_some()
-                || match &distinct_key {
-                    // Wildcard SELECT lists never suppress.
-                    None => true,
-                    Some(key) => {
-                        let items = Self::exprs_as_asc_order_items(key);
-                        Self::needs_temp_btree_for_order_by(
-                            stmt.from.as_ref(),
-                            stmt.where_clause.as_ref(),
-                            &items,
-                            database,
-                        )
-                    }
-                };
+            // Wildcard SELECT lists and grouped queries never suppress;
+            // `distinct_index_order` (computed above) is `Some` exactly when
+            // an index delivers the SELECT-list order.
+            root.needs_temp_btree_for_distinct = distinct_index_order.is_none();
         }
 
         // Check if we need a temp B-tree for ORDER BY
@@ -1122,6 +1186,21 @@ impl ExplainExecutor {
             // Continue to nested set operations
             current_set_op = set_op.right.set_operation.as_ref();
         }
+
+        // A compound's statement-level ORDER BY renders as a trailing
+        // `USE TEMP B-TREE FOR ORDER BY` line after the COMPOUND QUERY
+        // block. Truthful (#5371): the runtime materializes the combined
+        // result and sorts it in one pass (`sort_set_operation_results`,
+        // select/executor/execute.rs) for every operator, ALL or not.
+        //
+        // Documented divergence: sqlite3 3.51.0 instead renders a
+        // `MERGE (UNION)` / `MERGE (UNION ALL)` / ... block with per-branch
+        // `USE TEMP B-TREE FOR ORDER BY` lines (verified live) because its
+        // runtime sorts each branch and merges them. VibeSQL does not
+        // merge pre-sorted branches, so rendering MERGE would fabricate a
+        // plan shape that never executes (per the #5355/#5360/#5366
+        // truthfulness precedent).
+        root.needs_temp_btree_for_order_by = stmt.order_by.is_some();
 
         Ok(root)
     }
@@ -1412,28 +1491,31 @@ impl ExplainExecutor {
             })
     }
 
-    /// True when an index delivers the rows in GROUP BY order, suppressing
-    /// the `USE TEMP B-TREE FOR GROUP BY` line.
+    /// The ASC ORDER BY items under which an index delivers the rows in
+    /// GROUP BY order, if any — `Some` suppresses the
+    /// `USE TEMP B-TREE FOR GROUP BY` line, and the returned key becomes the
+    /// base scan's ordering requirement so the scan line shows the
+    /// delivering index like sqlite3 (#5371).
     ///
     /// Grouping is order-insensitive, so SQLite reorders the GROUP BY terms
     /// to match a candidate index (`GROUP BY b, a` with index `(a, b)`
     /// suppresses — verified live). We first try the key as written, then
     /// retry with the terms permuted into each index's column order.
-    fn group_key_satisfied_by_index(
+    fn group_key_index_order(
         from: Option<&vibesql_ast::FromClause>,
         where_clause: Option<&vibesql_ast::Expression>,
         group_key: &[&Expression],
         database: &Database,
-    ) -> bool {
+    ) -> Option<Vec<vibesql_ast::OrderByItem>> {
         let items = Self::exprs_as_asc_order_items(group_key);
         if !Self::needs_temp_btree_for_order_by(from, where_clause, &items, database) {
-            return true;
+            return Some(items);
         }
 
         // Order-insensitive retry: only bare column references can be
         // realigned to an index's column order.
         let Some(vibesql_ast::FromClause::Table { name, .. }) = from else {
-            return false;
+            return None;
         };
         let col_names: Option<Vec<&str>> = group_key
             .iter()
@@ -1442,9 +1524,7 @@ impl ExplainExecutor {
                 _ => None,
             })
             .collect();
-        let Some(col_names) = col_names else {
-            return false;
-        };
+        let col_names = col_names?;
 
         for index_name in database.list_indexes_for_table(name) {
             let Some(index) = database.get_index(&index_name) else { continue };
@@ -1470,11 +1550,11 @@ impl ExplainExecutor {
             let permuted_items = Self::exprs_as_asc_order_items(&permuted);
             if !Self::needs_temp_btree_for_order_by(from, where_clause, &permuted_items, database)
             {
-                return true;
+                return Some(permuted_items);
             }
         }
 
-        false
+        None
     }
 
     /// True when the SELECT list (or named WINDOW clause) of `stmt` contains
@@ -1537,14 +1617,16 @@ impl ExplainExecutor {
 
     /// Generate plan node for FROM clause
     ///
-    /// `order_from_window` is true when `order_by` is a window sort key
-    /// rather than the statement-level ORDER BY; the base scan then prefers
-    /// an index that delivers the window order even without predicates.
+    /// `prefer_ordering_scan` is true when `order_by` is an ordering
+    /// requirement the scan may ride an index for even without predicates —
+    /// a window sort key (windowpushd.test 2.1.3.6), an index-delivered
+    /// GROUP BY/DISTINCT key, or a statement-level ORDER BY whose temp-line
+    /// suppression fired (#5371).
     fn explain_from_clause(
         from: &vibesql_ast::FromClause,
         where_clause: &Option<vibesql_ast::Expression>,
         order_by: &Option<Vec<vibesql_ast::OrderByItem>>,
-        order_from_window: bool,
+        prefer_ordering_scan: bool,
         needed_columns: &HashSet<String>,
         database: &Database,
         ctes: &HashSet<String>,
@@ -1618,7 +1700,7 @@ impl ExplainExecutor {
                     alias.as_deref(),
                     where_clause,
                     order_by,
-                    order_from_window,
+                    prefer_ordering_scan,
                     needed_columns,
                     database,
                 )
@@ -1661,7 +1743,7 @@ impl ExplainExecutor {
                     left,
                     where_clause,
                     order_by,
-                    order_from_window,
+                    prefer_ordering_scan,
                     needed_columns,
                     database,
                     ctes,
@@ -1726,13 +1808,42 @@ impl ExplainExecutor {
         }
     }
 
+    /// True when `index_name` covers every column the query reads from
+    /// `table_name`: all SELECT-list and WHERE columns are index columns,
+    /// with the rowid-alias column carried implicitly (SQLite indexes always
+    /// store the rowid — windowpushd.test 1.4). An empty `needed_columns`
+    /// set means a wildcard SELECT, which can never be covering.
+    fn index_covers_scan(
+        table_name: &str,
+        index_name: &str,
+        where_clause: &Option<vibesql_ast::Expression>,
+        needed_columns: &HashSet<String>,
+        database: &Database,
+    ) -> bool {
+        if needed_columns.is_empty() {
+            return false;
+        }
+        let mut all_needed_columns = needed_columns.clone();
+        if let Some(where_expr) = where_clause {
+            collect_column_refs(where_expr, &mut all_needed_columns);
+        }
+        if let Some(table) = database.get_table(table_name) {
+            if let Some(rowid_idx) = table.schema.rowid_alias_column {
+                if let Some(col) = table.schema.columns.get(rowid_idx) {
+                    all_needed_columns.remove(&col.name.to_lowercase());
+                }
+            }
+        }
+        is_covering_index(index_name, &all_needed_columns, database)
+    }
+
     /// Generate plan node for table scan (sequential or index)
     fn explain_table_scan(
         table_name: &str,
         alias: Option<&str>,
         where_clause: &Option<vibesql_ast::Expression>,
         order_by: &Option<Vec<vibesql_ast::OrderByItem>>,
-        order_from_window: bool,
+        prefer_ordering_scan: bool,
         needed_columns: &HashSet<String>,
         database: &Database,
     ) -> Result<PlanNode, ExecutorError> {
@@ -1781,35 +1892,15 @@ impl ExplainExecutor {
 
             skip_node
         } else if let Some((index_name, sorted_cols)) = index_info {
-            // Check if this is a covering index (all needed columns are in the index)
-            // A covering index requires:
-            // 1. All SELECT columns are in the index
-            // 2. All WHERE clause columns are also in the index (or evaluable from index)
-            //
-            // NOTE: If needed_columns is empty, it means SELECT * was used (wildcard),
-            // which requires ALL table columns - this can never be a covering index
-            // unless the index literally contains all columns.
-            let is_covering = if needed_columns.is_empty() {
-                // Wildcard case: need all table columns, cannot be a covering index
-                false
-            } else {
-                let mut all_needed_columns = needed_columns.clone();
-                if let Some(where_expr) = where_clause {
-                    collect_column_refs(where_expr, &mut all_needed_columns);
-                }
-                // SQLite indexes implicitly carry the rowid, so an INTEGER
-                // PRIMARY KEY column (rowid alias) never disqualifies a
-                // covering index (windowpushd.test 1.4: index i1(grp_id)
-                // covers `SELECT grp_id, id` when id is the rowid alias).
-                if let Some(table) = database.get_table(table_name) {
-                    if let Some(rowid_idx) = table.schema.rowid_alias_column {
-                        if let Some(col) = table.schema.columns.get(rowid_idx) {
-                            all_needed_columns.remove(&col.name.to_lowercase());
-                        }
-                    }
-                }
-                is_covering_index(&index_name, &all_needed_columns, database)
-            };
+            // Check if this is a covering index (all needed columns are in
+            // the index) — see `index_covers_scan` for the rules.
+            let is_covering = Self::index_covers_scan(
+                table_name,
+                &index_name,
+                where_clause,
+                needed_columns,
+                database,
+            );
 
             // Check if we have any predicates on the index (determines SCAN vs SEARCH)
             let has_index_predicates = if let Some(where_expr) = where_clause {
@@ -1839,6 +1930,11 @@ impl ExplainExecutor {
                 .with_object(table_name)
                 .with_scan_type(scan_type.clone())
                 .with_index_name(&index_name);
+            // Pure ordering scans (no predicates) render `SCAN t USING
+            // COVERING INDEX i` when the index covers all read columns,
+            // matching sqlite3 (#5371). SEARCH paths carry covering via
+            // `ScanType::CoveringIndex` instead.
+            idx_node.index_covering = is_covering;
             idx_node.details.push(format!("USING INDEX {} ", index_name));
 
             // Extract predicates from WHERE clause for SQLite EQP format
@@ -1868,18 +1964,28 @@ impl ExplainExecutor {
 
             idx_node
         } else if let Some(ordering_index) =
-            order_by.as_deref().filter(|_| order_from_window).and_then(|items| {
+            order_by.as_deref().filter(|_| prefer_ordering_scan).and_then(|items| {
                 eqp_ordering_index(table_name, where_clause.as_ref(), items, database, true)
             })
         {
-            // No filtering index, but the scan feeds a window sorting pass
-            // whose key an index delivers: SQLite scans that index instead
-            // of sorting (windowpushd.test 2.1.3.6: `SCAN t1 USING INDEX
-            // i2` — i2 is chosen purely for PARTITION BY order).
-            PlanNode::new("Index Scan")
+            // No filtering index, but the scan feeds a pass whose key an
+            // index delivers — a window sorting pass (windowpushd.test
+            // 2.1.3.6: `SCAN t1 USING INDEX i2`, chosen purely for PARTITION
+            // BY order), or a GROUP BY/DISTINCT/ORDER BY whose temp-line
+            // suppression fired (#5371): SQLite scans that index instead of
+            // sorting, rendering COVERING when it covers all read columns.
+            let mut idx_node = PlanNode::new("Index Scan")
                 .with_object(table_name)
                 .with_scan_type(ScanType::Scan)
-                .with_index_name(&ordering_index)
+                .with_index_name(&ordering_index);
+            idx_node.index_covering = Self::index_covers_scan(
+                table_name,
+                &ordering_index,
+                where_clause,
+                needed_columns,
+                database,
+            );
+            idx_node
         } else {
             PlanNode::new("Seq Scan").with_object(table_name).with_scan_type(ScanType::Scan)
         };
@@ -2022,7 +2128,13 @@ fn extract_select_columns(select_list: &[SelectItem]) -> HashSet<String> {
 fn collect_column_refs(expr: &Expression, columns: &mut HashSet<String>) {
     match expr {
         Expression::ColumnRef(col_id) => {
-            columns.insert(col_id.column_canonical().to_lowercase());
+            // `count(*)` parses with a `*` pseudo-column argument; it reads
+            // no actual column and must not defeat covering-index detection
+            // (sqlite3 renders `SCAN t USING COVERING INDEX i` for
+            // `SELECT x, count(*) ... GROUP BY x`, verified live — #5371).
+            if col_id.column_canonical() != "*" {
+                columns.insert(col_id.column_canonical().to_lowercase());
+            }
         }
         Expression::BinaryOp { left, right, .. } => {
             collect_column_refs(left, columns);

--- a/crates/vibesql-executor/tests/explain_temp_btree_annotation_tests.rs
+++ b/crates/vibesql-executor/tests/explain_temp_btree_annotation_tests.rs
@@ -1,7 +1,9 @@
-//! Tests for EXPLAIN QUERY PLAN temp-structure annotations (#5367):
+//! Tests for EXPLAIN QUERY PLAN temp-structure annotations (#5367, #5371):
 //! `USE TEMP B-TREE FOR GROUP BY`, `USE TEMP B-TREE FOR DISTINCT`, the
-//! `<OP> USING TEMP B-TREE` compound dedup branch labels, and the
-//! `CO-ROUTINE <alias>` wrapper for non-flattenable derived tables.
+//! `<OP> USING TEMP B-TREE` compound dedup branch labels, the
+//! `CO-ROUTINE <alias>` wrapper for non-flattenable derived tables,
+//! ordering-index scan lines (`SCAN t USING [COVERING ]INDEX i`), and the
+//! compound + ORDER BY shape.
 //!
 //! Every expected shape below was verified live against sqlite3 3.51.0
 //! (`.eqp on`); divergences are noted per test. Truthfulness (per the
@@ -19,6 +21,17 @@
 //! - Compound dedup (UNION/INTERSECT/EXCEPT) executes via temp hash
 //!   structures (select/set_operations.rs), so `USING TEMP B-TREE` labels
 //!   are truthful.
+//! - Where a GROUP BY/DISTINCT/ORDER BY temp line is suppressed because an
+//!   index delivers the key order, the scan line shows that index like
+//!   sqlite3 (`SCAN t USING COVERING INDEX i` when it covers all read
+//!   columns) — the same permissive EQP-level convention (#5371).
+//! - A compound's statement-level ORDER BY renders as a trailing
+//!   `USE TEMP B-TREE FOR ORDER BY` line after the COMPOUND QUERY block:
+//!   the runtime materializes the combined result and sorts it in one pass
+//!   (`sort_set_operation_results`). sqlite3 3.51.0 instead renders a
+//!   `MERGE (<OP>)` block with per-branch ORDER BY lines (sorted branches
+//!   merged at read time, verified live) — a documented divergence, since
+//!   rendering MERGE would fabricate a plan VibeSQL never executes (#5371).
 
 use vibesql_ast::Statement;
 use vibesql_executor::ExplainExecutor;
@@ -99,30 +112,56 @@ fn test_group_by_unindexed_emits_temp_btree() {
 }
 
 // Indexed GROUP BY: the i1a index delivers group order, so the line is
-// suppressed (sqlite3 suppresses too: `SCAN t1 USING COVERING INDEX i1a`
-// alone). Scan-line divergence: VibeSQL's runtime hash-groups over a plain
-// scan, so the pre-existing base-scan rendering shows `SCAN t1` (#5355
-// notes); the suppression itself matches SQLite.
+// suppressed and the scan rides the index (#5371). The `count(*)`
+// pseudo-column reads nothing, so i1a covers the SELECT list. sqlite3 —
+// identical:
+//   `--SCAN t1 USING COVERING INDEX i1a
 #[test]
 fn test_group_by_indexed_suppresses_temp_btree() {
     let db = setup_db();
     let output = eqp(&db, "SELECT a, count(*) FROM t1 GROUP BY a");
 
-    assert!(!output.contains("USE TEMP B-TREE"), "indexed GROUP BY must suppress:\n{}", output);
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         `--SCAN t1 USING COVERING INDEX i1a\n"
+    );
+}
+
+// Indexed GROUP BY whose SELECT list reads a column outside the index: the
+// scan rides the ordering index without the COVERING tag. sqlite3 —
+// identical:
+//   `--SCAN t1 USING INDEX i1a
+#[test]
+fn test_group_by_indexed_non_covering_scan_line() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT a, c FROM t1 GROUP BY a");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         `--SCAN t1 USING INDEX i1a\n"
+    );
 }
 
 // GROUP BY on two columns when the index only covers the first. sqlite3:
 //   |--SCAN t1 USING INDEX i1a        [scan-line divergence: SCAN t1]
 //   `--USE TEMP B-TREE FOR GROUP BY
+// Scan-line divergence (documented, #5371): sqlite3 still rides i1a for
+// the partial prefix of the group key so its sorter benefits from partial
+// order; VibeSQL's runtime seq-scans and hash-groups, and the #5371 scan
+// rendering only fires when the temp-line suppression fires, so the bare
+// `SCAN t1` is the truthful rendering here.
 #[test]
 fn test_group_by_partially_indexed_emits_temp_btree() {
     let db = setup_db();
     let output = eqp(&db, "SELECT a, b, count(*) FROM t1 GROUP BY a, b");
 
-    assert!(
-        output.contains("USE TEMP B-TREE FOR GROUP BY"),
-        "partially indexed GROUP BY needs the temp structure:\n{}",
-        output
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SCAN t1\n\
+         `--USE TEMP B-TREE FOR GROUP BY\n"
     );
 }
 
@@ -139,18 +178,19 @@ fn test_group_by_pinned_by_where_suppresses_temp_btree() {
 }
 
 // Grouping is order-insensitive: SQLite reorders `GROUP BY b, a` to match
-// the (a, b) index and suppresses the line (verified live:
-// `SCAN tab USING COVERING INDEX iab` alone). VibeSQL retries the group key
-// permuted into each index's column order.
+// the (a, b) index, suppresses the line, and rides the covering index.
+// VibeSQL retries the group key permuted into each index's column order
+// and renders the matched index (#5371). sqlite3 — identical:
+//   `--SCAN tab USING COVERING INDEX iab
 #[test]
 fn test_group_by_order_insensitive_index_match_suppresses() {
     let db = setup_composite_db();
     let output = eqp(&db, "SELECT b, a, count(*) FROM tab GROUP BY b, a");
 
-    assert!(
-        !output.contains("USE TEMP B-TREE"),
-        "reordered GROUP BY matching the (a, b) index must suppress:\n{}",
-        output
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         `--SCAN tab USING COVERING INDEX iab\n"
     );
 }
 
@@ -170,7 +210,9 @@ fn test_group_by_rollup_emits_temp_btree() {
 }
 
 // Plain aggregate without GROUP BY: no temp-structure line. sqlite3 agrees
-// (`SCAN t1 USING COVERING INDEX i1a` for count(*) — scan-line divergence).
+// (`SCAN t1 USING COVERING INDEX i1a` for count(*) — scan-line divergence:
+// sqlite3 counts over the smallest index; VibeSQL's runtime seq-scans, and
+// with no grouping/dedup/ordering key there is no ordering index to ride).
 #[test]
 fn test_aggregate_without_group_by_no_temp_btree() {
     let db = setup_db();
@@ -315,14 +357,19 @@ fn test_distinct_unindexed_emits_temp_btree() {
 }
 
 // Indexed DISTINCT: rows arrive in SELECT-list order via i1a, so the line
-// is suppressed (sqlite3: `SCAN t1 USING COVERING INDEX i1a` alone —
-// scan-line divergence as usual).
+// is suppressed and the dedup rides the covering index (#5371). sqlite3 —
+// identical:
+//   `--SCAN t1 USING COVERING INDEX i1a
 #[test]
 fn test_distinct_indexed_suppresses_temp_btree() {
     let db = setup_db();
     let output = eqp(&db, "SELECT DISTINCT a FROM t1");
 
-    assert!(!output.contains("USE TEMP B-TREE"), "indexed DISTINCT must suppress:\n{}", output);
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         `--SCAN t1 USING COVERING INDEX i1a\n"
+    );
 }
 
 // DISTINCT + ORDER BY on the exact (all-ASC) SELECT list: the dedup
@@ -420,36 +467,37 @@ fn test_distinct_with_group_by_emits_both_in_order() {
 
 // With GROUP BY present the index never suppresses DISTINCT (the grouping
 // pass intervenes): sqlite3 keeps the DISTINCT line for
-// `SELECT DISTINCT a ... GROUP BY a` even with the index (verified live).
+// `SELECT DISTINCT a ... GROUP BY a` even with the index, while the
+// grouping itself rides the covering index (verified live, #5371) —
+// identical:
+//   |--SCAN t1 USING COVERING INDEX i1a
+//   `--USE TEMP B-TREE FOR DISTINCT
 #[test]
 fn test_distinct_not_suppressed_by_index_when_grouped() {
     let db = setup_db();
     let output = eqp(&db, "SELECT DISTINCT a FROM t1 GROUP BY a");
 
-    assert!(
-        !output.contains("USE TEMP B-TREE FOR GROUP BY"),
-        "indexed group key must suppress the GROUP BY line:\n{}",
-        output
-    );
-    assert!(
-        output.contains("USE TEMP B-TREE FOR DISTINCT"),
-        "DISTINCT after grouping still dedups:\n{}",
-        output
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SCAN t1 USING COVERING INDEX i1a\n\
+         `--USE TEMP B-TREE FOR DISTINCT\n"
     );
 }
 
 // Indexed DISTINCT + reverse ORDER BY: the dedup rides the index and the
-// reverse traversal satisfies the DESC order — no lines at all. sqlite3 —
-// no temp B-tree lines (verified live; scan-line divergence as usual).
+// reverse traversal satisfies the DESC order — no lines at all, and the
+// scan shows the covering index (#5371). sqlite3 — identical:
+//   `--SCAN t1 USING COVERING INDEX i1a
 #[test]
 fn test_distinct_indexed_order_by_desc_no_lines() {
     let db = setup_db();
     let output = eqp(&db, "SELECT DISTINCT a FROM t1 ORDER BY a DESC");
 
-    assert!(
-        !output.contains("USE TEMP B-TREE"),
-        "index-backed dedup + reversible order needs no temp lines:\n{}",
-        output
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         `--SCAN t1 USING COVERING INDEX i1a\n"
     );
 }
 
@@ -782,5 +830,190 @@ fn test_outer_order_by_over_group_by_view() {
          |  `--USE TEMP B-TREE FOR GROUP BY\n\
          |--SCAN gvu\n\
          `--USE TEMP B-TREE FOR ORDER BY\n"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Ordering-index scan lines (#5371)
+// ---------------------------------------------------------------------------
+// Where a temp-line suppression fires because an index delivers the key
+// order, the scan line shows that index like sqlite3. The runtime truthfully
+// hash-groups/dedups over its scan; the index rendering follows the same
+// permissive EQP-level convention as the suppression itself (#5367).
+
+// ORDER BY satisfied by a covering index. sqlite3 — identical:
+//   `--SCAN t1 USING COVERING INDEX i1a
+#[test]
+fn test_order_by_indexed_covering_scan_line() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT a FROM t1 ORDER BY a");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         `--SCAN t1 USING COVERING INDEX i1a\n"
+    );
+}
+
+// ORDER BY satisfied by a non-covering index (c is not in i1a). sqlite3 —
+// identical:
+//   `--SCAN t1 USING INDEX i1a
+#[test]
+fn test_order_by_indexed_non_covering_scan_line() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT a, c FROM t1 ORDER BY a");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         `--SCAN t1 USING INDEX i1a\n"
+    );
+}
+
+// GROUP BY + matching ORDER BY both ride the index: one covering scan, no
+// temp lines. sqlite3 — identical:
+//   `--SCAN t1 USING COVERING INDEX i1a
+#[test]
+fn test_group_by_order_by_indexed_covering_scan_line() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT a, count(*) FROM t1 GROUP BY a ORDER BY a");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         `--SCAN t1 USING COVERING INDEX i1a\n"
+    );
+}
+
+// Unindexed keys keep the bare scan: the #5371 rendering only fires with
+// the suppression. sqlite3 — identical (no index on b).
+#[test]
+fn test_unindexed_order_by_keeps_bare_scan() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT b FROM t1 ORDER BY b");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SCAN t1\n\
+         `--USE TEMP B-TREE FOR ORDER BY\n"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Compound + ORDER BY (#5371)
+// ---------------------------------------------------------------------------
+// The runtime materializes the combined result and sorts it in ONE pass
+// (`sort_set_operation_results`, select/executor/execute.rs) for every set
+// operator, so the truthful shape is the COMPOUND QUERY block plus a single
+// trailing `USE TEMP B-TREE FOR ORDER BY` line.
+//
+// Documented divergence: sqlite3 3.51.0 renders `MERGE (UNION)` /
+// `MERGE (UNION ALL)` / `MERGE (INTERSECT)` / `MERGE (EXCEPT)` with LEFT /
+// RIGHT branch blocks each carrying its own ORDER BY line (verified live):
+//   `--MERGE (UNION)
+//      |--LEFT
+//      |  |--SCAN u1
+//      |  `--USE TEMP B-TREE FOR ORDER BY
+//      `--RIGHT
+//         |--SCAN u2
+//         `--USE TEMP B-TREE FOR ORDER BY
+// because its runtime sorts each branch and merges the sorted streams.
+// VibeSQL never merges pre-sorted branches, so rendering MERGE would
+// fabricate a plan shape that never executes (#5355/#5360/#5366 precedent).
+
+// UNION + ORDER BY: dedup branch label plus one trailing sort line.
+#[test]
+fn test_union_order_by_trailing_temp_btree() {
+    let db = setup_compound_db();
+    let output = eqp(&db, "SELECT a FROM u1 UNION SELECT a FROM u2 ORDER BY 1");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--COMPOUND QUERY\n\
+         |  |--LEFT-MOST SUBQUERY\n\
+         |  |  `--SCAN u1\n\
+         |  `--UNION USING TEMP B-TREE\n\
+         |     `--SCAN u2\n\
+         `--USE TEMP B-TREE FOR ORDER BY\n"
+    );
+}
+
+// UNION ALL + ORDER BY: bare branch label, same trailing sort line (the
+// runtime sorts ALL-variants identically).
+#[test]
+fn test_union_all_order_by_trailing_temp_btree() {
+    let db = setup_compound_db();
+    let output = eqp(&db, "SELECT a FROM u1 UNION ALL SELECT a FROM u2 ORDER BY 1");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--COMPOUND QUERY\n\
+         |  |--LEFT-MOST SUBQUERY\n\
+         |  |  `--SCAN u1\n\
+         |  `--UNION ALL\n\
+         |     `--SCAN u2\n\
+         `--USE TEMP B-TREE FOR ORDER BY\n"
+    );
+}
+
+// INTERSECT and EXCEPT take the same trailing line; ORDER BY by name
+// resolves like ordinals.
+#[test]
+fn test_intersect_except_order_by_trailing_temp_btree() {
+    let db = setup_compound_db();
+
+    let intersect = eqp(&db, "SELECT a FROM u1 INTERSECT SELECT a FROM u2 ORDER BY a");
+    assert!(
+        intersect.ends_with("`--USE TEMP B-TREE FOR ORDER BY\n"),
+        "INTERSECT + ORDER BY needs the trailing sort line:\n{}",
+        intersect
+    );
+
+    let except = eqp(&db, "SELECT a FROM u1 EXCEPT SELECT a FROM u2 ORDER BY 1");
+    assert!(
+        except.ends_with("`--USE TEMP B-TREE FOR ORDER BY\n"),
+        "EXCEPT + ORDER BY needs the trailing sort line:\n{}",
+        except
+    );
+}
+
+// A compound WITHOUT ORDER BY keeps the bare COMPOUND QUERY shape (no
+// trailing line) — sqlite3 identical (no MERGE without an ORDER BY).
+#[test]
+fn test_compound_without_order_by_no_trailing_line() {
+    let db = setup_compound_db();
+    let output = eqp(&db, "SELECT a FROM u1 UNION SELECT a FROM u2");
+
+    assert!(
+        !output.contains("USE TEMP B-TREE FOR ORDER BY"),
+        "no ORDER BY, no sort line:\n{}",
+        output
+    );
+}
+
+// Dedup-compound derived table with an inner ORDER BY: the trailing sort
+// line renders INSIDE the CO-ROUTINE block (the body sorts before the
+// outer query reads it). sqlite3 nests its MERGE block in the co-routine
+// the same way (divergence as above).
+#[test]
+fn test_compound_order_by_inside_coroutine() {
+    let db = setup_compound_db();
+    let output =
+        eqp(&db, "SELECT * FROM (SELECT a FROM u1 UNION SELECT a FROM u2 ORDER BY 1) AS q");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--CO-ROUTINE q\n\
+         |  |--COMPOUND QUERY\n\
+         |  |  |--LEFT-MOST SUBQUERY\n\
+         |  |  |  `--SCAN u1\n\
+         |  |  `--UNION USING TEMP B-TREE\n\
+         |  |     `--SCAN u2\n\
+         |  `--USE TEMP B-TREE FOR ORDER BY\n\
+         `--SCAN q\n"
     );
 }

--- a/crates/vibesql-executor/tests/explain_view_expansion_tests.rs
+++ b/crates/vibesql-executor/tests/explain_view_expansion_tests.rs
@@ -356,9 +356,9 @@ fn test_outer_order_by_over_flattened_view_keeps_temp_btree() {
 //
 // Expected shapes verified against sqlite3 3.51.0 per category; divergences
 // are noted on each test:
-// - SQLite uses `SCAN t3 USING COVERING INDEX i3x` for covering-index-only
-//   bodies; VibeSQL's pre-existing base-scan rendering shows `SCAN t3`
-//   (same for bare bodies — unrelated to view expansion, see #5355 notes).
+// - Since #5371, bodies whose GROUP BY/DISTINCT/ORDER BY key rides the i3x
+//   index render the scan on that index (`SCAN t3 USING [COVERING ]INDEX
+//   i3x`) like sqlite3. Bodies with no usable ordering key keep `SCAN t3`.
 // - `USE TEMP B-TREE FOR GROUP BY` / `FOR DISTINCT` lines render like
 //   SQLite's since #5367 (suppressed here because the i3x index delivers
 //   x-order for the grouping/dedup keys below — sqlite3 suppresses too;
@@ -369,7 +369,8 @@ fn test_outer_order_by_over_flattened_view_keeps_temp_btree() {
 //   |  `--SEARCH t3 USING COVERING INDEX i3x (x=?)   [outer WHERE pushed]
 //   `--SCAN av
 // VibeSQL materializes the body and post-filters the outer WHERE, so the
-// inner plan truthfully shows the body's own scan (no fabricated probe).
+// inner plan truthfully shows the body's own scan (no fabricated probe) —
+// the body's GROUP BY x rides the covering i3x index (#5371).
 #[test]
 fn test_aggregate_group_by_view_renders_coroutine() {
     let db = setup_plain_view_db();
@@ -379,7 +380,7 @@ fn test_aggregate_group_by_view_renders_coroutine() {
         output,
         "QUERY PLAN\n\
          |--CO-ROUTINE av\n\
-         |  `--SCAN t3\n\
+         |  `--SCAN t3 USING COVERING INDEX i3x\n\
          `--SCAN av\n"
     );
 }
@@ -460,11 +461,14 @@ fn test_limit_offset_view_renders_coroutine() {
 
 // DISTINCT view. sqlite3 (with the index, dedup rides the covering index
 // and the `USE TEMP B-TREE FOR DISTINCT` line is suppressed — VibeSQL
-// suppresses too since #5367; the unindexed emitted case is covered in
+// suppresses too since #5367, and shows the dedup riding the covering
+// index since #5371; the unindexed emitted case is covered in
 // explain_temp_btree_annotation_tests.rs):
 //   |--CO-ROUTINE dv
 //   |  `--SEARCH t3 USING COVERING INDEX i3x (x=?)
 //   `--SCAN dv
+// Divergence: no fabricated outer-WHERE probe (the runtime materializes
+// the body and post-filters), so the body's own covering scan renders.
 #[test]
 fn test_distinct_view_renders_coroutine() {
     let db = setup_plain_view_db();
@@ -474,7 +478,7 @@ fn test_distinct_view_renders_coroutine() {
         output,
         "QUERY PLAN\n\
          |--CO-ROUTINE dv\n\
-         |  `--SCAN t3\n\
+         |  `--SCAN t3 USING COVERING INDEX i3x\n\
          `--SCAN dv\n"
     );
 }
@@ -569,8 +573,9 @@ fn test_with_view_renders_coroutine_divergence() {
 
 // A blocked body with its own ORDER BY: the body's temp B-tree line renders
 // INSIDE the CO-ROUTINE block, exactly once. No GROUP BY line: the i3x
-// index delivers GROUP BY x order (sqlite3 suppresses too), and ORDER BY c
-// does not match the group key, so the ORDER BY line renders. sqlite3:
+// index delivers GROUP BY x order (sqlite3 suppresses too, and the scan
+// rides the covering index since #5371), and ORDER BY c does not match the
+// group key, so the ORDER BY line renders. sqlite3 — identical:
 //   |--CO-ROUTINE aov
 //   |  |--SCAN t3 USING COVERING INDEX i3x
 //   |  `--USE TEMP B-TREE FOR ORDER BY
@@ -584,7 +589,7 @@ fn test_blocked_view_order_by_temp_btree_inside_coroutine_once() {
         output,
         "QUERY PLAN\n\
          |--CO-ROUTINE aov\n\
-         |  |--SCAN t3\n\
+         |  |--SCAN t3 USING COVERING INDEX i3x\n\
          |  `--USE TEMP B-TREE FOR ORDER BY\n\
          `--SCAN aov\n"
     );
@@ -592,9 +597,9 @@ fn test_blocked_view_order_by_temp_btree_inside_coroutine_once() {
 
 // Plain view over a blocked view: the outer view flattens away (#5355) and
 // the inner blocked view renders its CO-ROUTINE block. sqlite3 — identical
-// shape (modulo covering index):
+// shape:
 //   |--CO-ROUTINE av
-//   |  `--SCAN t3
+//   |  `--SCAN t3 USING COVERING INDEX i3x
 //   `--SCAN av
 #[test]
 fn test_plain_view_over_blocked_view() {
@@ -605,7 +610,7 @@ fn test_plain_view_over_blocked_view() {
         output,
         "QUERY PLAN\n\
          |--CO-ROUTINE av\n\
-         |  `--SCAN t3\n\
+         |  `--SCAN t3 USING COVERING INDEX i3x\n\
          `--SCAN av\n"
     );
     assert!(!output.contains("pav"), "outer plain view must flatten away:\n{}", output);
@@ -626,7 +631,7 @@ fn test_outer_order_by_over_blocked_view() {
         output,
         "QUERY PLAN\n\
          |--CO-ROUTINE av\n\
-         |  `--SCAN t3\n\
+         |  `--SCAN t3 USING COVERING INDEX i3x\n\
          |--SCAN av\n\
          `--USE TEMP B-TREE FOR ORDER BY\n"
     );


### PR DESCRIPTION
Closes #5371

Two EQP fidelity items deferred from #5367 / PR #5370. All expected strings verified live against sqlite3 3.51.0 (`.eqp on`).

## 1. Ordering-index scan lines (implemented)

Where a `USE TEMP B-TREE FOR GROUP BY` / `FOR DISTINCT` / `FOR ORDER BY` suppression fires because an index delivers the key order, the scan line now shows that index like sqlite3:

- `SELECT a, count(*) FROM t1 GROUP BY a` → `SCAN t1 USING COVERING INDEX i1a` (was bare `SCAN t1`)
- `SELECT a, c FROM t1 GROUP BY a` → `SCAN t1 USING INDEX i1a` (non-covering)
- `SELECT b, a, count(*) FROM tab GROUP BY b, a` → `SCAN tab USING COVERING INDEX iab` (permuted group key)
- `SELECT DISTINCT a FROM t1 [ORDER BY a DESC]` → `SCAN t1 USING COVERING INDEX i1a`
- `SELECT DISTINCT a FROM t1 GROUP BY a` → covering scan + `USE TEMP B-TREE FOR DISTINCT` (sqlite3-identical)
- `SELECT a FROM t1 ORDER BY a` → covering scan; `SELECT a, c ... ORDER BY a` → plain index scan

Mechanics: the suppression keys (group / distinct / order-by) are computed before FROM analysis and become the base scan's effective ordering requirement, extending the `eqp_ordering_index` machinery from the window path (#5354) via a generalized `prefer_ordering_scan` gate — it only fires when the corresponding suppression fires, so non-suppressed shapes keep their pre-existing rendering. New `index_covering` flag on `PlanNode` renders `SCAN t USING COVERING INDEX i`; the `count(*)` `*` pseudo-column no longer defeats covering detection.

Remaining documented divergence (kept truthful): sqlite3 also rides a partial-prefix index when the temp line still renders (e.g. `GROUP BY a, b` with index on `a` shows `SCAN t1 USING INDEX i1a` + temp line); VibeSQL's runtime seq-scans there, so the bare scan stays (noted in test comments).

## 2. Compound + ORDER BY: MERGE shape (documented divergence, truthful shape implemented)

**Runtime finding**: VibeSQL executes compound + ORDER BY as collect-then-sort, not a sorted-branch merge. `apply_set_operation` (select/set_operations.rs) materializes and hash-dedups both branches, then `sort_set_operation_results` (select/executor/execute.rs:792) sorts the combined result in one pass — for every operator, ALL or not.

sqlite3 3.51.0 renders `MERGE (UNION)` / `MERGE (UNION ALL)` / `MERGE (INTERSECT)` / `MERGE (EXCEPT)` with per-branch `USE TEMP B-TREE FOR ORDER BY` lines (verified live) because its runtime sorts each branch and merges the streams. Rendering MERGE would fabricate a plan VibeSQL never executes, so per the #5355/#5360/#5366 truthfulness precedent the truthful shape is implemented instead: the `COMPOUND QUERY` block plus one trailing `USE TEMP B-TREE FOR ORDER BY` line (previously the compound's ORDER BY emitted nothing at all). The divergence is documented in the test-file header and per-test comments.

## Test evidence

- `cargo test -p vibesql-executor`: all 55 test binaries green (2649 + suite tests, 0 failures)
- `explain_temp_btree_annotation_tests.rs`: 40 → 50 tests (new ordering-index scan-line section + compound ORDER BY section; existing tests tightened to exact sqlite3-verified shapes)
- `explain_view_expansion_tests.rs`: 5 expectations updated to the sqlite3-verified covering/index scan lines their comments already documented
- TCL vs origin/main baseline (built both binaries from this worktree, diffed failure lists):
  - `eqp.test`: 2 pattern mismatches **fixed** (1.3, 2.2.2), zero new
  - `distinct.test` 38/0, `select6.test` 86/0, `windowpushd.test` 29/0, `window9.test` 38/0 — identical to baseline
  - `distinct2.test` 41 passed / 3 failed — identical failure set to baseline (120, 5020, 5030; pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)