### PR TITLE
test(explain): document partial-prefix ordering-index EQP divergences

### DIFF
--- a/crates/vibesql-executor/src/explain.rs
+++ b/crates/vibesql-executor/src/explain.rs
@@ -938,6 +938,18 @@ impl ExplainExecutor {
         //   ride an ordering index exactly when the ORDER BY temp-line
         //   suppression fires, so non-suppressed shapes keep their
         //   pre-existing rendering.
+        //
+        // The scan rendering and the suppression stay COUPLED on purpose
+        // (#5373, investigated): sqlite3 also rides an index satisfying only
+        // a partial prefix of the key while keeping the temp line (partial
+        // GROUP BY/DISTINCT keys, mixed ASC/DESC — it then renames the sort
+        // line `USE TEMP B-TREE FOR LAST TERM OF ORDER BY`), but VibeSQL's
+        // runtime never does: `cost_based_index_selection` accepts an index
+        // for ordering only on a full direction-uniform match, and the
+        // aggregation path passes no ordering hint to the scan at all. In
+        // every partial case the runtime seq-scans, so an uncoupled
+        // `SCAN t USING INDEX i` would misstate the access path — documented
+        // divergence (explain_temp_btree_annotation_tests.rs, #5373 section).
         let window_scan_key = Self::distinct_window_keys(stmt).pop();
         let (scan_order_by, prefer_ordering_scan): (Option<Vec<vibesql_ast::OrderByItem>>, bool) =
             if window_scan_key.is_some() {

--- a/crates/vibesql-executor/tests/explain_temp_btree_annotation_tests.rs
+++ b/crates/vibesql-executor/tests/explain_temp_btree_annotation_tests.rs
@@ -32,6 +32,18 @@
 //!   `MERGE (<OP>)` block with per-branch ORDER BY lines (sorted branches
 //!   merged at read time, verified live) — a documented divergence, since
 //!   rendering MERGE would fabricate a plan VibeSQL never executes (#5371).
+//! - Partial-prefix shapes (#5373): when an index satisfies only a PREFIX
+//!   of the ordering work (partial GROUP BY/DISTINCT/ORDER BY key, mixed
+//!   ASC/DESC directions), sqlite3 still rides the index on the scan line —
+//!   its sorter benefits from partial order — and keeps the temp line
+//!   (`USE TEMP B-TREE FOR LAST TERM OF ORDER BY` for sorts). VibeSQL's
+//!   runtime gains nothing from partial order: the scan layer
+//!   (`cost_based_index_selection`) only accepts a full direction-uniform
+//!   structural match and otherwise seq-scans, and the GROUP BY/DISTINCT
+//!   paths pass no ordering hint to the scan at all. The bare `SCAN t` +
+//!   temp line is therefore the truthful rendering — a documented
+//!   divergence (see the #5373 section below); revisit if the runtime
+//!   learns to exploit partial index order.
 
 use vibesql_ast::Statement;
 use vibesql_executor::ExplainExecutor;
@@ -147,11 +159,14 @@ fn test_group_by_indexed_non_covering_scan_line() {
 // GROUP BY on two columns when the index only covers the first. sqlite3:
 //   |--SCAN t1 USING INDEX i1a        [scan-line divergence: SCAN t1]
 //   `--USE TEMP B-TREE FOR GROUP BY
-// Scan-line divergence (documented, #5371): sqlite3 still rides i1a for
-// the partial prefix of the group key so its sorter benefits from partial
-// order; VibeSQL's runtime seq-scans and hash-groups, and the #5371 scan
-// rendering only fires when the temp-line suppression fires, so the bare
-// `SCAN t1` is the truthful rendering here.
+// Scan-line divergence (documented, #5371/#5373): sqlite3 still rides i1a
+// for the partial prefix of the group key so its sorter benefits from
+// partial order; VibeSQL's runtime seq-scans and hash-groups, and the
+// #5371 scan rendering only fires when the temp-line suppression fires, so
+// the bare `SCAN t1` is the truthful rendering here. #5373 confirmed the
+// access path: the aggregation path passes no ordering hint to the scan
+// (executor/aggregation/mod.rs `execute_from_with_where(..., None, ...)`),
+// so the runtime never traverses i1a for this query.
 #[test]
 fn test_group_by_partially_indexed_emits_temp_btree() {
     let db = setup_db();
@@ -891,6 +906,105 @@ fn test_group_by_order_by_indexed_covering_scan_line() {
 fn test_unindexed_order_by_keeps_bare_scan() {
     let db = setup_db();
     let output = eqp(&db, "SELECT b FROM t1 ORDER BY b");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SCAN t1\n\
+         `--USE TEMP B-TREE FOR ORDER BY\n"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Partial-prefix ordering-index divergences (#5373) — documented
+// ---------------------------------------------------------------------------
+// sqlite3 3.51.0 rides an index whose columns satisfy only a PREFIX of the
+// ordering work and still emits the temp line: its external sorter exploits
+// partial input order. VibeSQL's runtime cannot — the scan layer
+// (`cost_based_index_selection`, select/scan/index_scan/selection.rs)
+// accepts an index for ordering only on a full direction-uniform structural
+// match (`can_use_index_for_order_by_with_pinned`: partial prefixes fail the
+// length check, mixed ASC/DESC fail the all-match/all-reversed check), the
+// aggregation path passes no ordering hint to the scan at all
+// (executor/aggregation/mod.rs), and DISTINCT hash-dedups over whatever the
+// scan returns (select/helpers.rs `apply_distinct`). In every shape below
+// the runtime performs a bare sequential scan, so rendering
+// `SCAN t USING INDEX i` would misstate the access path; the bare scan +
+// temp line is the truthful rendering. Each sqlite3 shape verified live.
+
+// DISTINCT over a SELECT list whose first column is indexed but whose
+// second is not. sqlite3:
+//   |--SCAN t1 USING INDEX i1a        [scan-line divergence: SCAN t1]
+//   `--USE TEMP B-TREE FOR DISTINCT
+// Runtime: non-aggregate SELECT passes only the statement ORDER BY (none
+// here) as the scan's ordering hint, so the scan is sequential and the
+// dedup is a hash structure — `SCAN t1` is what executes.
+#[test]
+fn test_distinct_partial_prefix_keeps_bare_scan_and_temp_line() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT DISTINCT a, c FROM t1");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SCAN t1\n\
+         `--USE TEMP B-TREE FOR DISTINCT\n"
+    );
+}
+
+// ORDER BY extending past the index columns (i1a covers `a` only). sqlite3
+// rides the prefix AND renames the temp line for the unsatisfied suffix:
+//   |--SCAN t1 USING INDEX i1a        [scan-line divergence: SCAN t1]
+//   `--USE TEMP B-TREE FOR LAST TERM OF ORDER BY   [line-text divergence]
+// Runtime: `can_use_index_for_order_by_with_pinned` rejects (a, b) against
+// index (a) — more ORDER BY terms than index columns — so the scan is
+// sequential and ONE full sort pass runs (`apply_order_by`); the plain
+// `USE TEMP B-TREE FOR ORDER BY` line truthfully describes that single
+// full sort (no LAST TERM partial-sort pass exists to describe).
+#[test]
+fn test_order_by_partial_prefix_keeps_bare_scan_and_temp_line() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT * FROM t1 ORDER BY a, b");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SCAN t1\n\
+         `--USE TEMP B-TREE FOR ORDER BY\n"
+    );
+}
+
+// Mixed-direction ORDER BY over the composite index (a, b). sqlite3 rides
+// iab for the leading term and sorts within each prefix group:
+//   |--SCAN tab USING INDEX iab       [scan-line divergence: SCAN tab]
+//   `--USE TEMP B-TREE FOR LAST TERM OF ORDER BY   [line-text divergence]
+// Runtime: mixed ASC/DESC fails the all-match/all-reversed direction check,
+// so the scan is sequential and one full sort pass runs.
+#[test]
+fn test_order_by_mixed_directions_keeps_bare_scan_and_temp_line() {
+    let db = setup_composite_db();
+    let output = eqp(&db, "SELECT * FROM tab ORDER BY a ASC, b DESC");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SCAN tab\n\
+         `--USE TEMP B-TREE FOR ORDER BY\n"
+    );
+}
+
+// ORDER BY rowid: sqlite3's table B-tree traversal natively delivers rowid
+// order, so it shows a bare scan and NO temp line:
+//   `--SCAN t1
+// VibeSQL's runtime performs a real sort pass on the rowid pseudo-column
+// after the scan (rowid matches no index column, so no ordering index
+// applies), so the temp line truthfully describes execution. Suppressing it
+// when the storage scan provably yields rowid order is tracked as a
+// follow-on (#5375).
+#[test]
+fn test_order_by_rowid_emits_temp_btree() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT * FROM t1 ORDER BY rowid");
 
     assert_eq!(
         output,


### PR DESCRIPTION
Closes #5373

## Summary

#5373 asked whether the #5371/#5372 coupling — the ordering-index scan line fires exactly when the temp-line suppression fires — should be decoupled so VibeSQL mirrors sqlite3's partial-prefix shapes (`SCAN t USING INDEX i` + temp line). Per the truthfulness precedent (#5355/#5360/#5366/#5370/#5372), the deciding question is what the runtime scan actually does. **Investigated: in every known instance the runtime performs a bare sequential scan, so rendering `USING INDEX` would misstate the access path. Resolved as documented divergence** — the coupling stays, each shape is pinned by a test with the verified sqlite3 3.51.0 output in comments.

## Per-instance findings (runtime access path)

| Shape | sqlite3 3.51.0 | VibeSQL EQP (unchanged) | Runtime access path |
|---|---|---|---|
| `SELECT DISTINCT a, c` with index `(a)` | `SCAN t1 USING INDEX i1a` + `USE TEMP B-TREE FOR DISTINCT` | bare `SCAN t1` + temp line | Non-aggregate SELECT passes only the statement ORDER BY (none here) as the scan ordering hint → seq scan; `apply_distinct` hash-dedups (select/helpers.rs) |
| `GROUP BY a, b` with index `(a)` | `SCAN t1 USING INDEX i1a` + `USE TEMP B-TREE FOR GROUP BY` | bare `SCAN t1` + temp line | Aggregation path passes `order_by: None` to the scan (executor/aggregation/mod.rs) → the runtime never traverses an ordering index for grouped queries |
| `ORDER BY a, b` with index `(a)` | `SCAN t1 USING INDEX i1a` + `USE TEMP B-TREE FOR LAST TERM OF ORDER BY` | bare `SCAN t1` + plain ORDER BY temp line | `can_use_index_for_order_by_with_pinned` rejects: more ORDER BY terms than index columns → seq scan + ONE full sort pass (no partial-sort pass exists for a LAST TERM line to describe) |
| `ORDER BY a ASC, b DESC` with index `(a, b)` | `SCAN tab USING INDEX iab` + `USE TEMP B-TREE FOR LAST TERM OF ORDER BY` | bare `SCAN tab` + plain ORDER BY temp line | Mixed directions fail the all-match/all-reversed check → seq scan + one full sort |
| `ORDER BY rowid` | bare `SCAN t1`, **no** temp line | bare `SCAN t1` + temp line | rowid matches no index column → seq scan + a real sort pass on the rowid pseudo-column, so the temp line truthfully describes execution. Natural-order suppression filed as follow-on #5375 |

Key code fact: `cost_based_index_selection` (select/scan/index_scan/selection.rs) accepts an index for ordering only on a full, direction-uniform structural match — sqlite3's "ride the prefix, sort the rest" plan has no VibeSQL analog, and its hash-group/hash-dedup gains nothing from partial input order.

## Changes

- `crates/vibesql-executor/tests/explain_temp_btree_annotation_tests.rs`: new "Partial-prefix ordering-index divergences (#5373)" section with 4 tests pinning the shapes above (50 → 54 tests); header bullet + updated `test_group_by_partially_indexed_emits_temp_btree` comment recording the access-path investigation.
- `crates/vibesql-executor/src/explain.rs`: comment on the `scan_order_by`/`prefer_ordering_scan` block documenting why the scan rendering stays coupled to the suppression (no production behavior change).

## Test evidence

- `cargo test -p vibesql-executor` — green (explain_temp_btree_annotation_tests 54/54; full suite 0 failures).
- Every sqlite3 shape verified live against sqlite3 3.51.0 (`.eqp on`).
- TCL vs main (zero new failures): eqp 5/0, distinct 38/0, distinct2 41 passed with the same 3 pre-existing failures (120, 5020, 5030), select6 86/0, windowpushd 29/0 (29/29), window9 38/0.
- Formatting: local nightly rustfmt reports the identical pre-existing hunk set on the clean base and this branch — no new violations; no repo-wide fmt run.

## Follow-on

- #5375 — suppress `USE TEMP B-TREE FOR ORDER BY` for rowid natural-order scans if storage scan order guarantees hold (would match sqlite3 under the existing permissive stabilization-sort convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)