### PR TITLE
feat(consensus): MVCC state machine — apply committed txns from the Raft log (phase B1, PR 1/2)

### DIFF
--- a/crates/vibesql-consensus/Cargo.toml
+++ b/crates/vibesql-consensus/Cargo.toml
@@ -13,7 +13,24 @@ categories = ["database"]
 # crates depend on the engine-agnostic `ConsensusBackend` trait and must
 # never see openraft types, so the consensus engine stays swappable.
 
+[features]
+# MVCC machinery toggle, forwarded to the storage/executor stack (see
+# `crates/vibesql-storage/Cargo.toml` for full documentation). Off by
+# default, matching the workspace. The replicated state machine works in
+# both states; commit-timestamp stamping (`xmin` = Raft log index) and the
+# vacuum-horizon interlock only have observable effects with this ON, so
+# the tests asserting them are gated on it.
+mvcc_enabled = ["vibesql-storage/mvcc_enabled", "vibesql-executor/mvcc_enabled"]
+
 [dependencies]
+# Raft Phase B1 (#5199): the replicated state machine applies committed
+# log entries to a real database. Dependency direction is consensus →
+# executor → storage (never the reverse), per ADR-0004's layering rule.
+vibesql-ast = { version = "0.1.4", path = "../vibesql-ast" }
+vibesql-executor = { version = "0.1.4", path = "../vibesql-executor" }
+vibesql-parser = { version = "0.1.4", path = "../vibesql-parser" }
+vibesql-storage = { version = "0.1.4", path = "../vibesql-storage" }
+vibesql-types = { version = "0.1.4", path = "../vibesql-types" }
 # `storage-v2` unseals the RaftLogStorage/RaftStateMachine traits (the v2
 # storage API) so this crate can implement them; `serde` because our log
 # entry payloads and vote state will be serialized for durability in PR 2.

--- a/crates/vibesql-consensus/src/lib.rs
+++ b/crates/vibesql-consensus/src/lib.rs
@@ -73,9 +73,35 @@
 //!   restarts cleanly (recovery repairs the log from the snapshot); a
 //!   snapshot next to a log with no state at all still fails loudly.
 //!
-//! Deliberately **not** here yet (later Raft phases): applying entries
-//! to VibeSQL storage (Phase B1), TLS on the consensus port, production
-//! wiring into `vibesql-server`, and membership changes.
+//! Phase B1 (#5199), PR 1, applies committed entries to **real storage**:
+//!
+//! - [`TxnEntry`]: the replicated entry type — one committed transaction
+//!   per log entry, as a deterministic SQL statement batch (see the
+//!   `state_machine` module docs for why the statement-batch form was
+//!   chosen over a row-level write-set in PR 1, and the tradeoff).
+//! - [`VibesqlStateMachine`]: applies committed entries to a real
+//!   `vibesql-storage` database with **commit_ts = log index** (the
+//!   transaction applying entry `N` is stamped `TxnId = N`, per
+//!   ADR-0004's "apply index = commit order"); apply is idempotent per
+//!   index, so snapshot-install + log-replay overlap is safe. Its
+//!   snapshots serialize the database state with the binary persistence
+//!   codec, and builds pin the MVCC vacuum horizon through the real
+//!   storage-layer holdback (`Database::pin_gc_horizon`) — the
+//!   `SnapshotHorizonPin` seam from Phase A4, no longer a no-op.
+//! - [`ReplicatedDb`]: the PR 1 propose path (test harness, not server
+//!   wiring) — whole transactions proposed through a
+//!   [`ConsensusBackend`] and applied on commit.
+//!
+//! The generic byte-echo configurations above remain unchanged (and keep
+//! their conformance suite); the MVCC machine is a new configuration on
+//! top of them. PR 2 of #5199 mounts [`VibesqlStateMachine`] behind
+//! openraft's `RaftStateMachine` for multi-node replication with
+//! leader-only writes.
+//!
+//! Deliberately **not** here yet (later Raft phases): multi-node MVCC
+//! replication and leader-only write enforcement (Phase B1 PR 2), TLS
+//! on the consensus port, production wiring into `vibesql-server`, and
+//! membership changes.
 //!
 //! Note on retention: the Raft log purge gated above is orthogonal to the
 //! pre-existing data-WAL checkpoint/truncation in `vibesql-storage::wal`
@@ -95,11 +121,15 @@ mod durable;
 #[cfg(test)]
 mod network;
 mod openraft_backend;
+mod replicated;
 mod single_node;
 mod snapshot;
+mod state_machine;
 mod tcp;
 
 pub use backend::{ConsensusBackend, ConsensusError, LogIndex, Result, Role, Snapshot};
 pub use cluster_config::{ClusterConfig, DEFAULT_CONSENSUS_PORT};
 pub use openraft_backend::{OpenraftBackend, RaftTuning};
+pub use replicated::ReplicatedDb;
 pub use single_node::SingleNodeBackend;
+pub use state_machine::{ApplyOutcome, TxnEntry, VibesqlStateMachine};

--- a/crates/vibesql-consensus/src/replicated.rs
+++ b/crates/vibesql-consensus/src/replicated.rs
@@ -1,0 +1,356 @@
+//! [`ReplicatedDb`]: the PR 1 propose path — run transactions through
+//! consensus on a single node (Raft Phase B1, #5199).
+//!
+//! This couples a [`ConsensusBackend`] whose entries are [`TxnEntry`]
+//! with a [`VibesqlStateMachine`]: writes are proposed as whole-
+//! transaction entries, and committed entries are applied — in dense log
+//! order — to the real database, with commit_ts = log index. Reads run
+//! locally against the applied state.
+//!
+//! This is a **test-facing harness**, not server wiring (deliberately:
+//! server/CLI integration is out of scope for PR 1). With
+//! [`SingleNodeBackend`](crate::SingleNodeBackend), `propose` commits
+//! immediately and the harness applies the committed entry before the
+//! write returns, so a session can read its own write — the same
+//! "propose resolves post-apply" contract the openraft state machine
+//! gives for free. PR 2 mounts [`VibesqlStateMachine`] behind openraft's
+//! `RaftStateMachine` so apply happens *inside* the backend on every
+//! voter; the harness's catch-up loop then becomes the recovery/replay
+//! path only.
+
+use vibesql_types::SqlValue;
+
+use crate::backend::{ConsensusBackend, LogIndex, Result, Snapshot};
+use crate::state_machine::{ApplyOutcome, TxnEntry, VibesqlStateMachine};
+
+/// A database whose writes flow through a consensus backend.
+///
+/// See the module docs for scope (PR 1 test harness). The interesting
+/// invariants all live in [`VibesqlStateMachine`]; this type contributes
+/// the propose → read-committed → apply plumbing and the catch-up loop.
+#[derive(Debug)]
+pub struct ReplicatedDb<B> {
+    backend: B,
+    machine: VibesqlStateMachine,
+}
+
+impl<B> ReplicatedDb<B>
+where
+    B: ConsensusBackend<Entry = TxnEntry>,
+{
+    /// Couple `backend` with a fresh (empty) state machine.
+    pub fn new(backend: B) -> Self {
+        Self { backend, machine: VibesqlStateMachine::new() }
+    }
+
+    /// Couple `backend` with an existing state machine — e.g. one
+    /// restored from a snapshot, after which [`catch_up_to`]
+    /// (or the next write) replays only the log suffix above the
+    /// snapshot (entries at or below it are skipped by the machine's
+    /// idempotence).
+    ///
+    /// [`catch_up_to`]: Self::catch_up_to
+    pub fn with_machine(backend: B, machine: VibesqlStateMachine) -> Self {
+        Self { backend, machine }
+    }
+
+    /// The state machine applying this node's committed entries.
+    pub fn machine(&self) -> &VibesqlStateMachine {
+        &self.machine
+    }
+
+    /// The consensus backend sequencing this node's writes.
+    pub fn backend(&self) -> &B {
+        &self.backend
+    }
+
+    /// Execute one autocommit write statement through consensus.
+    pub async fn execute_replicated(&self, sql: &str) -> Result<(LogIndex, ApplyOutcome)> {
+        self.execute_replicated_txn(&[sql]).await
+    }
+
+    /// Execute a multi-statement transaction through consensus: the
+    /// whole batch is proposed as **one** [`TxnEntry`] (one log entry
+    /// per committed transaction) and applied atomically with
+    /// commit_ts = the entry's log index.
+    ///
+    /// Returns the entry's log index and its apply outcome. A rejected
+    /// entry (failed statement, rolled back) is an `Ok` with
+    /// [`ApplyOutcome::Rejected`] — the rejection consumed a log index
+    /// and is part of the replicated history.
+    pub async fn execute_replicated_txn(
+        &self,
+        statements: &[&str],
+    ) -> Result<(LogIndex, ApplyOutcome)> {
+        let entry = TxnEntry::batch(statements.iter().copied());
+        let index = self.backend.propose(entry).await?;
+        let outcome = self.catch_up_to(index).await?;
+        Ok((index, outcome))
+    }
+
+    /// Apply every committed entry up to and including `index`, in dense
+    /// log order, returning the outcome at `index`. Entries the machine
+    /// has already applied (`<= last_applied`) are skipped by its
+    /// idempotence check, which is what makes this safe to run on top of
+    /// an installed snapshot that overlaps the log.
+    pub async fn catch_up_to(&self, index: LogIndex) -> Result<ApplyOutcome> {
+        let mut outcome = ApplyOutcome::AlreadyApplied;
+        let first_pending = self.machine.last_applied() + 1;
+        for idx in first_pending..=index {
+            let entry = self.backend.read_committed(idx).await?;
+            outcome = self.machine.apply(idx, &entry)?;
+        }
+        Ok(outcome)
+    }
+
+    /// Run a read-only SELECT against the applied state (reads are
+    /// local, not replicated).
+    pub fn query(&self, sql: &str) -> Result<Vec<Vec<SqlValue>>> {
+        self.machine.query(sql)
+    }
+
+    /// Snapshot the applied database state (binary persistence codec,
+    /// vacuum horizon pinned for the build) — see
+    /// [`VibesqlStateMachine::snapshot`].
+    pub fn snapshot(&self) -> Result<Snapshot> {
+        self.machine.snapshot()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::single_node::SingleNodeBackend;
+    use crate::ConsensusError;
+
+    fn replicated() -> ReplicatedDb<SingleNodeBackend<TxnEntry>> {
+        ReplicatedDb::new(SingleNodeBackend::new())
+    }
+
+    async fn seed_users(db: &ReplicatedDb<SingleNodeBackend<TxnEntry>>) {
+        let (index, outcome) = db
+            .execute_replicated("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+            .await
+            .unwrap();
+        assert_eq!(index, 1);
+        assert_eq!(outcome, ApplyOutcome::Applied { rows_affected: 0 });
+    }
+
+    fn names(db: &ReplicatedDb<SingleNodeBackend<TxnEntry>>) -> Vec<String> {
+        db.query("SELECT name FROM users ORDER BY id")
+            .unwrap()
+            .into_iter()
+            .map(|row| row[0].to_string())
+            .collect()
+    }
+
+    /// The PR 1 acceptance roundtrip: INSERT/UPDATE/DELETE through the
+    /// single-node backend, data visible afterwards, commit_ts = log
+    /// index (asserted at the MVCC level when the feature is on).
+    #[tokio::test]
+    async fn propose_apply_roundtrip_through_single_node_backend() {
+        let db = replicated();
+        seed_users(&db).await;
+
+        let (index, outcome) =
+            db.execute_replicated("INSERT INTO users VALUES (1, 'alice')").await.unwrap();
+        assert_eq!(index, 2);
+        assert_eq!(outcome, ApplyOutcome::Applied { rows_affected: 1 });
+
+        let (index, _) =
+            db.execute_replicated("INSERT INTO users VALUES (2, 'bob')").await.unwrap();
+        assert_eq!(index, 3);
+
+        let (index, outcome) = db
+            .execute_replicated("UPDATE users SET name = 'amelia' WHERE id = 1")
+            .await
+            .unwrap();
+        assert_eq!(index, 4);
+        assert_eq!(outcome, ApplyOutcome::Applied { rows_affected: 1 });
+
+        let (index, outcome) =
+            db.execute_replicated("DELETE FROM users WHERE id = 2").await.unwrap();
+        assert_eq!(index, 5);
+        assert_eq!(outcome, ApplyOutcome::Applied { rows_affected: 1 });
+
+        // The session reads its own writes immediately after propose.
+        assert_eq!(names(&db), vec!["amelia"]);
+        assert_eq!(db.machine().last_applied(), 5);
+
+        // commit_ts = log index, observable in the MVCC stamps.
+        #[cfg(feature = "mvcc_enabled")]
+        db.machine().with_db(|inner| {
+            let table = inner.get_table("users").unwrap();
+            let amelia = table
+                .scan()
+                .iter()
+                .find(|r| r.values[0] == SqlValue::Integer(1) && r.xmax.is_none())
+                .expect("amelia's live version");
+            assert_eq!(amelia.xmin, 4, "UPDATE's new version is stamped with its log index");
+        });
+    }
+
+    /// A whole transaction is one log entry; it applies all-or-nothing.
+    #[tokio::test]
+    async fn multi_statement_txn_is_one_entry_and_atomic() {
+        let db = replicated();
+        seed_users(&db).await;
+
+        let (index, outcome) = db
+            .execute_replicated_txn(&[
+                "INSERT INTO users VALUES (1, 'alice')",
+                "INSERT INTO users VALUES (2, 'bob')",
+            ])
+            .await
+            .unwrap();
+        assert_eq!(index, 2, "the whole batch consumed exactly one log index");
+        assert_eq!(outcome, ApplyOutcome::Applied { rows_affected: 2 });
+
+        // A failing batch rolls back entirely but still consumes its
+        // index; the history converges on every replica.
+        let (index, outcome) = db
+            .execute_replicated_txn(&[
+                "INSERT INTO users VALUES (3, 'carol')",
+                "INSERT INTO users VALUES (1, 'dupe')", // PK violation
+            ])
+            .await
+            .unwrap();
+        assert_eq!(index, 3);
+        assert!(matches!(outcome, ApplyOutcome::Rejected { .. }), "got: {outcome:?}");
+        assert_eq!(names(&db), vec!["alice", "bob"], "rejected entry must apply nothing");
+
+        let (index, _) =
+            db.execute_replicated("INSERT INTO users VALUES (4, 'dave')").await.unwrap();
+        assert_eq!(index, 4, "log numbering continues past the rejected entry");
+        assert_eq!(names(&db), vec!["alice", "bob", "dave"]);
+    }
+
+    /// Snapshot + log-replay overlap: a fresh machine restored from a
+    /// snapshot at index 3 replays the full log 1..=5; entries 1–3 are
+    /// skipped by idempotence, 4–5 apply, and the result is identical to
+    /// the original.
+    #[tokio::test]
+    async fn snapshot_install_plus_log_replay_overlap_converges() {
+        let db = replicated();
+        seed_users(&db).await;
+        db.execute_replicated("INSERT INTO users VALUES (1, 'alice')").await.unwrap();
+        db.execute_replicated("INSERT INTO users VALUES (2, 'bob')").await.unwrap();
+
+        let snapshot = db.snapshot().unwrap();
+        assert_eq!(snapshot.last_included_index, 3);
+
+        db.execute_replicated("UPDATE users SET name = 'bobby' WHERE id = 2").await.unwrap();
+        db.execute_replicated("INSERT INTO users VALUES (3, 'carol')").await.unwrap();
+
+        // "Recover" a second node: install the snapshot, then replay the
+        // whole committed log against the same backend log.
+        let machine = VibesqlStateMachine::from_snapshot(&snapshot).unwrap();
+        assert_eq!(machine.last_applied(), 3);
+        let recovered = ReplicatedDb::with_machine(clone_log(&db).await, machine);
+        recovered.catch_up_to(5).await.unwrap();
+
+        assert_eq!(recovered.machine().last_applied(), 5);
+        assert_eq!(names(&recovered), names(&db));
+        assert_eq!(names(&recovered), vec!["alice", "bobby", "carol"]);
+    }
+
+    /// Rebuild a `SingleNodeBackend` holding the same committed log (the
+    /// loopback backend is in-memory; a "second node" shares the log by
+    /// re-proposing the committed prefix).
+    async fn clone_log(
+        db: &ReplicatedDb<SingleNodeBackend<TxnEntry>>,
+    ) -> SingleNodeBackend<TxnEntry> {
+        let source = db.backend();
+        let target = SingleNodeBackend::new();
+        for idx in 1..=source.last_index() {
+            let entry = source.read_committed(idx).await.unwrap();
+            target.propose(entry).await.unwrap();
+        }
+        target
+    }
+
+    /// Replaying an already-applied prefix is harmless (idempotence at
+    /// the harness level): catch_up_to with a stale index does nothing.
+    #[tokio::test]
+    async fn catch_up_is_idempotent() {
+        let db = replicated();
+        seed_users(&db).await;
+        db.execute_replicated("INSERT INTO users VALUES (1, 'alice')").await.unwrap();
+
+        for _ in 0..3 {
+            let outcome = db.catch_up_to(2).await.unwrap();
+            assert_eq!(outcome, ApplyOutcome::AlreadyApplied);
+        }
+        assert_eq!(names(&db), vec!["alice"]);
+    }
+
+    /// Catching up to an uncommitted index is a NotCommitted error from
+    /// the backend, surfaced unchanged.
+    #[tokio::test]
+    async fn catch_up_beyond_committed_prefix_fails() {
+        let db = replicated();
+        seed_users(&db).await;
+        let err = db.catch_up_to(7).await.unwrap_err();
+        assert!(matches!(err, ConsensusError::NotCommitted(2)), "got: {err:?}");
+    }
+
+    /// TCL Priority-1-style smoke through the replicated path. The TCL
+    /// harness itself drives the CLI binary, which is not wired to
+    /// consensus in PR 1 (server/CLI integration is out of scope), so
+    /// this exercises a representative set of P1 statement shapes —
+    /// CREATE TABLE / INSERT / UPDATE with WHERE / DELETE with WHERE /
+    /// CREATE INDEX / aggregates / ORDER BY / JOIN — end-to-end through
+    /// propose + apply instead. The full `make test-tcl` baseline runs
+    /// against the unreplicated engine, which this PR leaves untouched.
+    #[tokio::test]
+    async fn tcl_p1_style_smoke_through_replication() {
+        let db = replicated();
+
+        db.execute_replicated("CREATE TABLE t1 (a INTEGER PRIMARY KEY, b INTEGER, c TEXT)")
+            .await
+            .unwrap();
+        for (a, b, c) in [(1, 10, "one"), (2, 20, "two"), (3, 30, "three"), (4, 40, "four")] {
+            let (_, outcome) = db
+                .execute_replicated(&format!("INSERT INTO t1 VALUES ({a}, {b}, '{c}')"))
+                .await
+                .unwrap();
+            assert_eq!(outcome, ApplyOutcome::Applied { rows_affected: 1 });
+        }
+        db.execute_replicated("CREATE INDEX i1 ON t1(b)").await.unwrap();
+        db.execute_replicated("UPDATE t1 SET b = b + 1 WHERE a > 2").await.unwrap();
+        db.execute_replicated("DELETE FROM t1 WHERE a = 1").await.unwrap();
+
+        db.execute_replicated("CREATE TABLE t2 (a INTEGER, d TEXT)").await.unwrap();
+        db.execute_replicated_txn(&[
+            "INSERT INTO t2 VALUES (2, 'zwei')",
+            "INSERT INTO t2 VALUES (3, 'drei')",
+        ])
+        .await
+        .unwrap();
+
+        // WHERE + ORDER BY
+        let rows = db.query("SELECT a, b FROM t1 WHERE b >= 20 ORDER BY b DESC").unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                vec![SqlValue::Integer(4), SqlValue::Integer(41)],
+                vec![SqlValue::Integer(3), SqlValue::Integer(31)],
+                vec![SqlValue::Integer(2), SqlValue::Integer(20)],
+            ]
+        );
+
+        // Aggregates
+        let rows = db.query("SELECT count(*), sum(b) FROM t1").unwrap();
+        assert_eq!(rows, vec![vec![SqlValue::Integer(3), SqlValue::Integer(92)]]);
+
+        // JOIN
+        let rows = db
+            .query("SELECT t1.c, t2.d FROM t1 JOIN t2 ON t1.a = t2.a ORDER BY t1.a")
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0][1].to_string(), "zwei");
+        assert_eq!(rows[1][1].to_string(), "drei");
+
+        assert_eq!(db.machine().last_applied(), db.backend().last_index());
+    }
+}

--- a/crates/vibesql-consensus/src/snapshot.rs
+++ b/crates/vibesql-consensus/src/snapshot.rs
@@ -88,14 +88,14 @@ const SNAPSHOT_HEADER_SIZE: usize = 8;
 // ---------------------------------------------------------------------------
 //
 // The snapshot *payload* is the serialized applied state of the state
-// machine. Until Phase B1 (#5199) wires the real MVCC-backed state machine,
-// that state is the echo machine's ordered list of applied entry payloads,
-// and serde_json is its (test-scale) encoding. B1 replaces this codec with a
-// streamed database-state encoding reusing the writers in
-// `vibesql-storage::persistence::binary` — those writers serialize *tables*,
-// which the echo machine does not have, so coupling to them now would be
-// premature (see the curator re-scope on #5198). Keeping the codec isolated
-// here means only this seam changes when B1 lands.
+// machine. For the generic echo machine (`openraft_backend`) that state is
+// the ordered list of applied entry payloads, and serde_json is its
+// (test-scale) encoding. Phase B1 (#5199) swapped this seam for the real
+// MVCC-backed machine: `crate::state_machine::VibesqlStateMachine` encodes
+// its snapshots with the binary database codec from
+// `vibesql-storage::persistence::binary` instead. The JSON codec below
+// remains for the generic byte-echo configurations (and their conformance
+// suite), which have no tables to serialize.
 
 /// Encode the state machine's applied entries into a snapshot payload blob.
 pub(crate) fn encode_payload(entries: &[Vec<u8>]) -> serde_json::Result<Vec<u8>> {
@@ -120,15 +120,18 @@ pub(crate) fn decode_payload(data: &[u8]) -> serde_json::Result<Vec<Vec<u8>>> {
 /// snapshot is built, durably persisted, and registered — dropping the guard
 /// is what releases the horizon.
 ///
-/// The state machine is not MVCC-wired until Phase B1 (#5199), so the only
-/// production implementation today is the no-op [`NoopHorizonPin`]. B1
-/// implements this by registering the snapshot build as (or alongside) an
-/// active read transaction in
-/// `vibesql-storage::database::transaction_api` — the existing
-/// `compute_gc_horizon` holdback for active transactions then covers the
-/// build with no new watermark type (see
-/// `vacuum_mvcc_horizon_held_back_by_active_transaction` in the storage
-/// crate's vacuum tests).
+/// Two implementations exist:
+///
+/// - [`NoopHorizonPin`] for the generic echo state machine (nothing to
+///   hold back: its state is an in-memory `Vec` read under the
+///   state-machine mutex).
+/// - `MvccHorizonPin` (`crate::state_machine`, Phase B1 of #5199): the
+///   real thing, registering the build alongside the active-transaction
+///   holdback in `vibesql-storage::database::transaction_api` via
+///   `Database::pin_gc_horizon` — while held, `compute_gc_horizon` (and
+///   therefore `vacuum_mvcc`) cannot advance past the build's view (see
+///   `vacuum_mvcc_held_back_by_gc_horizon_pin` in the storage crate's
+///   vacuum tests).
 ///
 /// [`RaftSnapshotBuilder::build_snapshot`]: openraft::RaftSnapshotBuilder::build_snapshot
 pub(crate) trait SnapshotHorizonPin: Send + Sync + Debug {

--- a/crates/vibesql-consensus/src/state_machine.rs
+++ b/crates/vibesql-consensus/src/state_machine.rs
@@ -1,0 +1,790 @@
+//! The MVCC-backed replicated state machine (Raft Phase B1, #5199, PR 1).
+//!
+//! This module is where the replication layer stops echoing bytes and
+//! starts applying real database transactions: [`TxnEntry`] is the log
+//! entry type replicated through a [`ConsensusBackend`], and
+//! [`VibesqlStateMachine`] applies committed entries to a real
+//! [`Database`] with MVCC commit timestamps derived from the log index.
+//!
+//! # Entry representation: deterministic statement batch
+//!
+//! A [`TxnEntry`] carries **one committed transaction** as an ordered
+//! batch of SQL write statements. One entry per transaction makes atomic
+//! apply trivial (the whole batch applies in a single storage
+//! transaction, all-or-nothing) and rules out half-applied transactions
+//! by construction — there is no `TxnBegin@10 / TxnCommit@12`
+//! interleaving in the Raft log.
+//!
+//! The curator re-scope on #5199 preferred a *write-set/effects* form (a
+//! batch of row-level mutations) over re-executing SQL text. That form
+//! is not implementable against today's storage layer without new
+//! machinery, so PR 1 ships the statement-batch form:
+//!
+//! - The crash-recovery WAL replay (`vibesql-storage::wal::recovery`)
+//!   that the issue proposed reusing as the apply function is a **stub**
+//!   for DML — `apply_op` counts Insert/Update/Delete entries but does
+//!   not apply them (it has no `table_id → table` resolution).
+//! - The only write-set the storage layer captures per transaction is
+//!   `TransactionChange` (kept for savepoint undo). It records DML only
+//!   — no DDL — and replaying it would bypass the executor's index and
+//!   constraint maintenance, which has no row-level "apply with index
+//!   upkeep" entry point today.
+//!
+//! **Tradeoff and follow-up**: statement batches are deterministic only
+//! if the statements are (no `random()`, `CURRENT_TIMESTAMP`, …). On a
+//! single node (this PR) every entry is applied exactly once by one
+//! machine, so nothing can diverge; for multi-node (PR 2) and beyond,
+//! either the proposer must freeze non-deterministic values into
+//! literals before proposing, or the storage layer must grow a real
+//! write-set capture + apply pair (effects form). That follow-up is
+//! filed as #5377.
+//!
+//! # commit_ts = log index
+//!
+//! ADR-0004 (single Raft group, no HLC): the MVCC commit timestamp is
+//! the Raft apply order. Concretely, the transaction that applies log
+//! entry `N` runs with `TxnId = N` — [`VibesqlStateMachine::apply`]
+//! calls [`Database::set_next_txn_id`]`(N)` immediately before `BEGIN`,
+//! so every `xmin`/`xmax` stamped by entry `N` equals `N`. The mapping
+//! survives snapshot install + log replay (the allocator is re-seeded
+//! from the entry index on every apply) and failed entries (a rolled-
+//! back entry's id is not left behind in any row).
+//!
+//! Indices here are the **dense application indices** of the
+//! [`ConsensusBackend`] contract (1-based, application entries only) —
+//! the same values `propose` resolves with.
+//!
+//! # Idempotent apply
+//!
+//! `apply(index, entry)` with `index <= last_applied` is a no-op
+//! returning [`ApplyOutcome::AlreadyApplied`]. This is what makes
+//! snapshot-install + log-replay overlap safe: a recovering node may
+//! replay log entries at or below its installed snapshot's index, and
+//! they must not double-apply. Gaps (`index > last_applied + 1`) are a
+//! protocol violation and fail loudly.
+//!
+//! # Snapshot codec
+//!
+//! Snapshots serialize the **database state** using the binary
+//! persistence format from `vibesql-storage::persistence::binary`
+//! (header + catalog + data sections, vbsql v7+, which carries per-row
+//! `xmin`/`xmax`) — this swaps the echo machine's JSON payload seam
+//! exactly where Phase A4 left it (`crate::snapshot`). Builds hold the
+//! MVCC vacuum horizon through the real [`SnapshotHorizonPin`]
+//! implementation ([`VibesqlStateMachine::horizon_pin`]), wired to
+//! [`Database::pin_gc_horizon`]'s holdback in the storage layer.
+//!
+//! [`ConsensusBackend`]: crate::ConsensusBackend
+//! [`Database`]: vibesql_storage::Database
+//! [`Database::set_next_txn_id`]: vibesql_storage::Database::set_next_txn_id
+//! [`Database::pin_gc_horizon`]: vibesql_storage::Database::pin_gc_horizon
+
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use serde::{Deserialize, Serialize};
+use vibesql_ast::Statement;
+use vibesql_storage::persistence::binary::{
+    read_catalog_v, read_data, read_header, write_catalog, write_data, write_header,
+};
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+use crate::backend::{ConsensusError, LogIndex, Result, Snapshot};
+use crate::snapshot::SnapshotHorizonPin;
+
+// ---------------------------------------------------------------------------
+// The replicated entry type
+// ---------------------------------------------------------------------------
+
+/// One committed transaction, replicated as a single Raft log entry.
+///
+/// See the module docs for the representation decision (deterministic
+/// statement batch) and its tradeoffs. The serde encoding (JSON at the
+/// adapter boundary, like every other entry type) is the payload behind
+/// the backend's opaque `Vec<u8>`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TxnEntry {
+    /// The transaction's write statements, in execution order. Applied
+    /// atomically: all statements commit together or none do.
+    pub statements: Vec<String>,
+}
+
+impl TxnEntry {
+    /// Entry for a single-statement (autocommit-style) transaction.
+    pub fn single(sql: impl Into<String>) -> Self {
+        Self { statements: vec![sql.into()] }
+    }
+
+    /// Entry for a multi-statement transaction.
+    pub fn batch<S: Into<String>>(statements: impl IntoIterator<Item = S>) -> Self {
+        Self { statements: statements.into_iter().map(Into::into).collect() }
+    }
+}
+
+/// Result of applying one [`TxnEntry`] to the state machine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApplyOutcome {
+    /// The entry's transaction committed; `rows_affected` sums the DML
+    /// row counts across its statements.
+    Applied {
+        /// Total rows affected by the entry's statements.
+        rows_affected: usize,
+    },
+    /// The entry's transaction was rolled back (a statement failed).
+    /// The entry still consumed its log index — every replica rejects
+    /// it identically, so the rejection is part of the state machine
+    /// history, not an apply error.
+    Rejected {
+        /// The failing statement's error message.
+        reason: String,
+    },
+    /// `index <= last_applied`: this entry's effects are already in the
+    /// state (snapshot-install + log-replay overlap). Nothing was done.
+    AlreadyApplied,
+}
+
+// ---------------------------------------------------------------------------
+// The state machine
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+struct MachineInner {
+    db: Database,
+    /// Dense application index of the last applied entry (`0` = none).
+    last_applied: LogIndex,
+}
+
+/// The replicated state machine: a real [`Database`] plus the apply-side
+/// bookkeeping (`last_applied`, idempotence, commit_ts derivation).
+///
+/// Cloning shares the underlying state (it is a handle), matching the
+/// convention of the other state machines in this crate. PR 1 drives it
+/// through [`ReplicatedDb`](crate::ReplicatedDb) over
+/// [`SingleNodeBackend`](crate::SingleNodeBackend); PR 2 mounts it
+/// behind openraft's `RaftStateMachine` for multi-node replication.
+#[derive(Debug, Clone)]
+pub struct VibesqlStateMachine {
+    inner: Arc<Mutex<MachineInner>>,
+}
+
+impl Default for VibesqlStateMachine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VibesqlStateMachine {
+    /// A fresh state machine over an empty in-memory database.
+    pub fn new() -> Self {
+        Self { inner: Arc::new(Mutex::new(MachineInner { db: Database::new(), last_applied: 0 })) }
+    }
+
+    /// Rebuild a state machine from a snapshot produced by
+    /// [`snapshot`](Self::snapshot): decodes the database state and
+    /// resumes `last_applied` at the snapshot's
+    /// [`last_included_index`](Snapshot::last_included_index).
+    pub fn from_snapshot(snapshot: &Snapshot) -> Result<Self> {
+        let machine = Self::new();
+        machine.install_snapshot(snapshot)?;
+        Ok(machine)
+    }
+
+    fn lock(&self) -> MutexGuard<'_, MachineInner> {
+        self.inner.lock().expect("replicated state machine mutex poisoned")
+    }
+
+    /// Dense application index of the last applied entry (`0` if none).
+    pub fn last_applied(&self) -> LogIndex {
+        self.lock().last_applied
+    }
+
+    /// Apply one committed log entry.
+    ///
+    /// - `index <= last_applied`: idempotent no-op
+    ///   ([`ApplyOutcome::AlreadyApplied`]).
+    /// - `index == last_applied + 1`: the entry's statements run in a
+    ///   single storage transaction whose `TxnId` — and therefore every
+    ///   MVCC stamp it writes — is `index` (commit_ts = log index). A
+    ///   statement failure rolls the whole transaction back
+    ///   ([`ApplyOutcome::Rejected`]); the entry still consumes its
+    ///   index, because every replica rejects it identically.
+    /// - `index > last_applied + 1`: a gap — protocol violation, loud
+    ///   error.
+    pub fn apply(&self, index: LogIndex, entry: &TxnEntry) -> Result<ApplyOutcome> {
+        let mut inner = self.lock();
+        if index == 0 {
+            return Err(ConsensusError::Backend(
+                "log index 0 is the 'nothing committed' sentinel; entries start at 1".to_string(),
+            ));
+        }
+        if index <= inner.last_applied {
+            return Ok(ApplyOutcome::AlreadyApplied);
+        }
+        if index != inner.last_applied + 1 {
+            return Err(ConsensusError::Backend(format!(
+                "apply gap: entry index {index} but last applied is {} (entries must apply in \
+                 dense log order)",
+                inner.last_applied
+            )));
+        }
+
+        // commit_ts = log index: the transaction applying entry N is
+        // stamped TxnId = N (ADR-0004's "apply index = commit order").
+        inner
+            .db
+            .set_next_txn_id(index)
+            .map_err(|e| ConsensusError::Backend(format!("failed to seed commit_ts: {e}")))?;
+        inner
+            .db
+            .begin_transaction()
+            .map_err(|e| ConsensusError::Backend(format!("failed to begin apply txn: {e}")))?;
+        debug_assert_eq!(
+            inner.db.transaction_id(),
+            Some(index),
+            "apply transaction id must equal the log index"
+        );
+
+        let mut rows_affected = 0usize;
+        let mut failure: Option<String> = None;
+        for sql in &entry.statements {
+            match execute_write_statement(&mut inner.db, sql) {
+                Ok(n) => rows_affected += n,
+                Err(reason) => {
+                    failure = Some(reason);
+                    break;
+                }
+            }
+        }
+
+        let outcome = match failure {
+            None => {
+                // COMMIT through the executor so deferred-FK re-validation
+                // (which can itself abort the transaction) behaves exactly
+                // as it would for a local session.
+                match vibesql_executor::CommitExecutor::execute(
+                    &vibesql_ast::CommitStmt,
+                    &mut inner.db,
+                ) {
+                    Ok(_) => ApplyOutcome::Applied { rows_affected },
+                    Err(e) => {
+                        // CommitExecutor rolls back on deferred-FK failure;
+                        // make sure no transaction is left open either way.
+                        if inner.db.in_transaction() {
+                            let _ = inner.db.rollback_transaction();
+                        }
+                        ApplyOutcome::Rejected { reason: e.to_string() }
+                    }
+                }
+            }
+            Some(reason) => {
+                inner.db.rollback_transaction().map_err(|e| {
+                    ConsensusError::Backend(format!("failed to roll back rejected entry: {e}"))
+                })?;
+                ApplyOutcome::Rejected { reason }
+            }
+        };
+
+        // The entry consumed its index regardless of outcome: a rejected
+        // entry is rejected identically on every replica.
+        inner.last_applied = index;
+        Ok(outcome)
+    }
+
+    /// Run a read-only SELECT against the applied state, returning row
+    /// values. Reads are local (not replicated); this is the query
+    /// surface the PR 1 tests assert convergence with.
+    pub fn query(&self, sql: &str) -> Result<Vec<Vec<SqlValue>>> {
+        let inner = self.lock();
+        let statement = vibesql_parser::parse_with_arena_fallback(sql)
+            .map_err(|e| ConsensusError::Backend(format!("parse error: {e}")))?;
+        let Statement::Select(select) = statement else {
+            return Err(ConsensusError::Backend(format!(
+                "query() only accepts SELECT statements, got: {sql}"
+            )));
+        };
+        let rows = vibesql_executor::SelectExecutor::new(&inner.db)
+            .execute(&select)
+            .map_err(|e| ConsensusError::Backend(format!("query failed: {e}")))?;
+        Ok(rows.into_iter().map(|r| r.values.to_vec()).collect())
+    }
+
+    /// Capture a snapshot of the applied state: the database serialized
+    /// with the binary persistence format, covering everything up to
+    /// [`last_applied`](Self::last_applied).
+    ///
+    /// The MVCC vacuum horizon is pinned (via
+    /// [`horizon_pin`](Self::horizon_pin) →
+    /// [`Database::pin_gc_horizon`]) before the state is read and
+    /// released only after the blob is built, so `vacuum_mvcc` cannot
+    /// reclaim row versions out from under the build.
+    ///
+    /// [`Database::pin_gc_horizon`]: vibesql_storage::Database::pin_gc_horizon
+    pub fn snapshot(&self) -> Result<Snapshot> {
+        // Acquire the pin through the same seam openraft's snapshot
+        // builder uses (Phase A4's SnapshotHorizonPin), now backed by the
+        // real storage-layer holdback.
+        let _horizon_pin = self.horizon_pin().acquire();
+
+        let inner = self.lock();
+        let data = serialize_database(&inner.db)?;
+        Ok(Snapshot { last_included_index: inner.last_applied, data })
+        // `_horizon_pin` drops here, releasing the vacuum horizon.
+    }
+
+    /// Replace this machine's state from a snapshot produced by
+    /// [`snapshot`](Self::snapshot).
+    ///
+    /// The payload is fully decoded **before** any mutation (a corrupt
+    /// snapshot must not half-install). After install, the transaction
+    /// id allocator resumes at `last_included_index + 1`, so MVCC
+    /// visibility for the restored rows (stamped with commit timestamps
+    /// `<= last_included_index`) is correct and the next applied entry
+    /// keeps the commit_ts = log index mapping.
+    pub fn install_snapshot(&self, snapshot: &Snapshot) -> Result<()> {
+        let mut db = deserialize_database(&snapshot.data)?;
+        db.set_next_txn_id(snapshot.last_included_index + 1)
+            .map_err(|e| ConsensusError::SnapshotCodec(format!("failed to seed commit_ts: {e}")))?;
+        let mut inner = self.lock();
+        inner.db = db;
+        inner.last_applied = snapshot.last_included_index;
+        Ok(())
+    }
+
+    /// MVCC vacuum on the applied state — see
+    /// [`Database::vacuum_mvcc`](vibesql_storage::Database::vacuum_mvcc).
+    /// Returns the number of row versions reclaimed.
+    pub fn vacuum(&self) -> Result<usize> {
+        let mut inner = self.lock();
+        inner.db.vacuum_mvcc().map_err(|e| ConsensusError::Backend(format!("vacuum failed: {e}")))
+    }
+
+    /// The [`SnapshotHorizonPin`] over this machine's database: acquiring
+    /// it holds the MVCC vacuum horizon (the active-transaction-holdback
+    /// generalization in `vibesql-storage`) until the guard drops. This
+    /// is the real implementation of the seam Phase A4 introduced with a
+    /// no-op; PR 2 hands it to the openraft snapshot builder.
+    pub(crate) fn horizon_pin(&self) -> MvccHorizonPin {
+        MvccHorizonPin { inner: Arc::clone(&self.inner) }
+    }
+
+    /// Direct read access to the underlying database, for tests that
+    /// assert storage-level invariants (MVCC stamps, table contents).
+    /// Only the `mvcc_enabled`-gated tests need it.
+    #[cfg(all(test, feature = "mvcc_enabled"))]
+    pub(crate) fn with_db<R>(&self, f: impl FnOnce(&Database) -> R) -> R {
+        f(&self.lock().db)
+    }
+
+    /// Direct mutable access to the underlying database — test
+    /// instrumentation only (e.g. hand-stamping tombstones the way the
+    /// storage crate's vacuum tests do, since the current write path
+    /// bitmap-deletes rather than deferring tombstones).
+    #[cfg(all(test, feature = "mvcc_enabled"))]
+    pub(crate) fn with_db_mut<R>(&self, f: impl FnOnce(&mut Database) -> R) -> R {
+        f(&mut self.lock().db)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The MVCC vacuum-horizon pin (the real SnapshotHorizonPin)
+// ---------------------------------------------------------------------------
+
+/// [`SnapshotHorizonPin`] backed by the storage layer's GC-horizon
+/// holdback ([`Database::pin_gc_horizon`]): the Phase B1 replacement for
+/// the echo machine's `NoopHorizonPin`. Acquiring registers the snapshot
+/// build alongside the active-transaction holdback in
+/// `vibesql-storage::database::transaction_api`; dropping the guard
+/// releases it.
+///
+/// [`Database::pin_gc_horizon`]: vibesql_storage::Database::pin_gc_horizon
+#[derive(Debug)]
+pub(crate) struct MvccHorizonPin {
+    inner: Arc<Mutex<MachineInner>>,
+}
+
+struct MvccHorizonGuard {
+    inner: Arc<Mutex<MachineInner>>,
+    pin_id: u64,
+}
+
+impl Drop for MvccHorizonGuard {
+    fn drop(&mut self) {
+        if let Ok(mut inner) = self.inner.lock() {
+            inner.db.release_gc_horizon(self.pin_id);
+        }
+    }
+}
+
+impl SnapshotHorizonPin for MvccHorizonPin {
+    fn acquire(&self) -> Box<dyn Send> {
+        let pin_id = {
+            let mut inner = self.inner.lock().expect("replicated state machine mutex poisoned");
+            inner.db.pin_gc_horizon()
+        };
+        Box::new(MvccHorizonGuard { inner: Arc::clone(&self.inner), pin_id })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot codec: the database state in the binary persistence format
+// ---------------------------------------------------------------------------
+
+/// Serialize the database with the binary persistence format
+/// (`vibesql-storage::persistence::binary`: header + catalog + data;
+/// vbsql v7+ carries per-row `xmin`/`xmax`, so MVCC stamps survive the
+/// roundtrip).
+fn serialize_database(db: &Database) -> Result<Vec<u8>> {
+    let codec = |e: vibesql_storage::StorageError| ConsensusError::SnapshotCodec(e.to_string());
+    let mut buf = Vec::new();
+    write_header(&mut buf).map_err(codec)?;
+    write_catalog(&mut buf, db).map_err(codec)?;
+    write_data(&mut buf, db).map_err(codec)?;
+    Ok(buf)
+}
+
+/// Decode a snapshot payload back into a database. Fails loudly (and
+/// without side effects) on a corrupt payload.
+fn deserialize_database(data: &[u8]) -> Result<Database> {
+    let codec = |e: vibesql_storage::StorageError| ConsensusError::SnapshotCodec(e.to_string());
+    let mut reader = data;
+    let version = read_header(&mut reader).map_err(codec)?;
+    let mut db = read_catalog_v(&mut reader, version).map_err(codec)?;
+    read_data(&mut reader, &mut db, version).map_err(codec)?;
+    Ok(db)
+}
+
+// ---------------------------------------------------------------------------
+// Statement dispatch
+// ---------------------------------------------------------------------------
+
+/// Parse and execute one write statement inside the apply transaction,
+/// returning its affected-row count.
+///
+/// The supported set covers the replicated write surface: DML
+/// (INSERT/UPDATE/DELETE) and the core DDL (CREATE/DROP TABLE,
+/// CREATE/DROP INDEX, CREATE/DROP VIEW). Reads are not replicated, and
+/// transaction control lives at the entry boundary (the whole entry IS
+/// the transaction), so SELECT/BEGIN/COMMIT/ROLLBACK inside an entry are
+/// rejected — deterministically, on every replica.
+fn execute_write_statement(
+    db: &mut Database,
+    sql: &str,
+) -> std::result::Result<usize, String> {
+    let statement = vibesql_parser::parse_with_arena_fallback(sql)
+        .map_err(|e| format!("parse error in replicated statement: {e}"))?;
+    match &statement {
+        Statement::Insert(stmt) => vibesql_executor::InsertExecutor::execute(db, stmt)
+            .map_err(|e| e.to_string()),
+        Statement::Update(stmt) => vibesql_executor::UpdateExecutor::execute(stmt, db)
+            .map_err(|e| e.to_string()),
+        Statement::Delete(stmt) => vibesql_executor::DeleteExecutor::execute(stmt, db)
+            .map_err(|e| e.to_string()),
+        Statement::CreateTable(stmt) => vibesql_executor::CreateTableExecutor::execute(stmt, db)
+            .map(|_| 0)
+            .map_err(|e| e.to_string()),
+        Statement::CreateIndex(stmt) => vibesql_executor::CreateIndexExecutor::execute(stmt, db)
+            .map(|_| 0)
+            .map_err(|e| e.to_string()),
+        Statement::CreateView(stmt) => {
+            vibesql_executor::advanced_objects::execute_create_view(stmt, db)
+                .map(|_| 0)
+                .map_err(|e| e.to_string())
+        }
+        Statement::DropTable(stmt) => vibesql_executor::DropTableExecutor::execute(stmt, db)
+            .map(|_| 0)
+            .map_err(|e| e.to_string()),
+        Statement::DropIndex(stmt) => vibesql_executor::DropIndexExecutor::execute(stmt, db)
+            .map(|_| 0)
+            .map_err(|e| e.to_string()),
+        Statement::DropView(stmt) => {
+            vibesql_executor::advanced_objects::execute_drop_view(stmt, db)
+                .map(|_| 0)
+                .map_err(|e| e.to_string())
+        }
+        Statement::BeginTransaction(_) | Statement::Commit(_) | Statement::Rollback(_) => {
+            Err("transaction control is not allowed inside a replicated entry: the entry itself \
+                 is the transaction (one entry per committed transaction)"
+                .to_string())
+        }
+        Statement::Select(_) => Err(
+            "SELECT is not allowed inside a replicated entry: reads are local, not replicated"
+                .to_string(),
+        ),
+        other => Err(format!(
+            "statement is not supported in a replicated entry (Raft Phase B1, PR 1): {other:?}"
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_users(machine: &VibesqlStateMachine, index: LogIndex) {
+        let outcome = machine
+            .apply(
+                index,
+                &TxnEntry::single("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)"),
+            )
+            .unwrap();
+        assert_eq!(outcome, ApplyOutcome::Applied { rows_affected: 0 });
+    }
+
+    fn names(machine: &VibesqlStateMachine) -> Vec<String> {
+        machine
+            .query("SELECT name FROM users ORDER BY id")
+            .unwrap()
+            .into_iter()
+            .map(|row| row[0].to_string())
+            .collect()
+    }
+
+    #[test]
+    fn entry_serde_roundtrips() {
+        let entry = TxnEntry::batch(["INSERT INTO t VALUES (1)", "UPDATE t SET x = 2"]);
+        let bytes = serde_json::to_vec(&entry).unwrap();
+        assert_eq!(serde_json::from_slice::<TxnEntry>(&bytes).unwrap(), entry);
+    }
+
+    #[test]
+    fn apply_insert_update_delete_roundtrip() {
+        let machine = VibesqlStateMachine::new();
+        create_users(&machine, 1);
+
+        let outcome = machine
+            .apply(
+                2,
+                &TxnEntry::batch([
+                    "INSERT INTO users VALUES (1, 'alice')",
+                    "INSERT INTO users VALUES (2, 'bob')",
+                    "INSERT INTO users VALUES (3, 'carol')",
+                ]),
+            )
+            .unwrap();
+        assert_eq!(outcome, ApplyOutcome::Applied { rows_affected: 3 });
+
+        let outcome = machine
+            .apply(3, &TxnEntry::single("UPDATE users SET name = 'bobby' WHERE id = 2"))
+            .unwrap();
+        assert_eq!(outcome, ApplyOutcome::Applied { rows_affected: 1 });
+
+        let outcome =
+            machine.apply(4, &TxnEntry::single("DELETE FROM users WHERE id = 1")).unwrap();
+        assert_eq!(outcome, ApplyOutcome::Applied { rows_affected: 1 });
+
+        assert_eq!(names(&machine), vec!["bobby", "carol"]);
+        assert_eq!(machine.last_applied(), 4);
+    }
+
+    /// commit_ts = log index: every MVCC stamp written by entry `N`
+    /// carries `xmin = N`. Only observable with the MVCC feature on
+    /// (stamping is compiled out otherwise).
+    #[cfg(feature = "mvcc_enabled")]
+    #[test]
+    fn apply_stamps_commit_ts_with_the_log_index() {
+        let machine = VibesqlStateMachine::new();
+        create_users(&machine, 1);
+        machine.apply(2, &TxnEntry::single("INSERT INTO users VALUES (1, 'alice')")).unwrap();
+        machine.apply(3, &TxnEntry::single("INSERT INTO users VALUES (2, 'bob')")).unwrap();
+
+        machine.with_db(|db| {
+            let table = db.get_table("users").unwrap();
+            let xmins: Vec<u64> = table.scan().iter().map(|row| row.xmin).collect();
+            assert_eq!(xmins, vec![2, 3], "xmin must equal the applying entry's log index");
+        });
+    }
+
+    #[test]
+    fn apply_is_idempotent_per_index() {
+        let machine = VibesqlStateMachine::new();
+        create_users(&machine, 1);
+        let entry = TxnEntry::single("INSERT INTO users VALUES (1, 'alice')");
+        assert_eq!(
+            machine.apply(2, &entry).unwrap(),
+            ApplyOutcome::Applied { rows_affected: 1 }
+        );
+
+        // Re-applying the same index must not duplicate effects — this is
+        // what makes snapshot+log-replay overlap safe.
+        assert_eq!(machine.apply(2, &entry).unwrap(), ApplyOutcome::AlreadyApplied);
+        assert_eq!(machine.apply(1, &entry).unwrap(), ApplyOutcome::AlreadyApplied);
+        assert_eq!(names(&machine), vec!["alice"]);
+        assert_eq!(machine.last_applied(), 2);
+    }
+
+    #[test]
+    fn apply_gap_is_a_loud_error() {
+        let machine = VibesqlStateMachine::new();
+        create_users(&machine, 1);
+        let err = machine
+            .apply(3, &TxnEntry::single("INSERT INTO users VALUES (1, 'alice')"))
+            .unwrap_err();
+        assert!(format!("{err}").contains("apply gap"), "unexpected error: {err}");
+        // Index 0 is the "nothing" sentinel.
+        machine.apply(0, &TxnEntry::single("INSERT INTO users VALUES (1, 'x')")).unwrap_err();
+        assert_eq!(machine.last_applied(), 1);
+    }
+
+    /// Multi-statement entries are atomic: a failing statement rolls the
+    /// whole entry back, but the entry still consumes its index (every
+    /// replica rejects it identically).
+    #[test]
+    fn rejected_entry_applies_nothing_and_still_consumes_its_index() {
+        let machine = VibesqlStateMachine::new();
+        create_users(&machine, 1);
+        machine.apply(2, &TxnEntry::single("INSERT INTO users VALUES (1, 'alice')")).unwrap();
+
+        let outcome = machine
+            .apply(
+                3,
+                &TxnEntry::batch([
+                    "INSERT INTO users VALUES (2, 'bob')",
+                    // Duplicate primary key: fails after the first insert
+                    // succeeded inside the txn.
+                    "INSERT INTO users VALUES (1, 'dupe')",
+                ]),
+            )
+            .unwrap();
+        assert!(
+            matches!(outcome, ApplyOutcome::Rejected { .. }),
+            "constraint violation must reject the entry, got: {outcome:?}"
+        );
+
+        // All-or-nothing: bob must not have survived the rollback.
+        assert_eq!(names(&machine), vec!["alice"]);
+        // The index is consumed; the next entry continues after it.
+        assert_eq!(machine.last_applied(), 3);
+        machine.apply(4, &TxnEntry::single("INSERT INTO users VALUES (3, 'carol')")).unwrap();
+        assert_eq!(names(&machine), vec!["alice", "carol"]);
+    }
+
+    #[test]
+    fn transaction_control_and_reads_inside_an_entry_are_rejected() {
+        let machine = VibesqlStateMachine::new();
+        create_users(&machine, 1);
+        for (index, sql) in [(2, "BEGIN"), (3, "COMMIT"), (4, "SELECT * FROM users")] {
+            let outcome = machine.apply(index, &TxnEntry::single(sql)).unwrap();
+            assert!(
+                matches!(outcome, ApplyOutcome::Rejected { .. }),
+                "{sql} inside an entry must be rejected, got: {outcome:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn snapshot_install_roundtrip_restores_state_and_index() {
+        let machine = VibesqlStateMachine::new();
+        create_users(&machine, 1);
+        machine.apply(2, &TxnEntry::single("INSERT INTO users VALUES (1, 'alice')")).unwrap();
+        machine.apply(3, &TxnEntry::single("INSERT INTO users VALUES (2, 'bob')")).unwrap();
+
+        let snapshot = machine.snapshot().unwrap();
+        assert_eq!(snapshot.last_included_index, 3);
+
+        let restored = VibesqlStateMachine::from_snapshot(&snapshot).unwrap();
+        assert_eq!(restored.last_applied(), 3);
+        assert_eq!(names(&restored), names(&machine));
+
+        // The restored machine continues the log where the snapshot left
+        // off — and keeps the commit_ts = log index mapping.
+        restored.apply(4, &TxnEntry::single("INSERT INTO users VALUES (3, 'carol')")).unwrap();
+        assert_eq!(names(&restored), vec!["alice", "bob", "carol"]);
+        #[cfg(feature = "mvcc_enabled")]
+        restored.with_db(|db| {
+            let table = db.get_table("users").unwrap();
+            let carol =
+                table.scan().iter().find(|r| r.values[0] == SqlValue::Integer(3)).unwrap();
+            assert_eq!(carol.xmin, 4, "post-install applies keep commit_ts = log index");
+        });
+    }
+
+    #[test]
+    fn corrupt_snapshot_is_rejected_without_mutation() {
+        let machine = VibesqlStateMachine::new();
+        create_users(&machine, 1);
+        machine.apply(2, &TxnEntry::single("INSERT INTO users VALUES (1, 'alice')")).unwrap();
+
+        let err = machine
+            .install_snapshot(&Snapshot {
+                last_included_index: 9,
+                data: b"definitely not a vbsql payload".to_vec(),
+            })
+            .unwrap_err();
+        assert!(matches!(err, ConsensusError::SnapshotCodec(_)), "unexpected error: {err}");
+
+        // The failed install must not have touched the state.
+        assert_eq!(machine.last_applied(), 2);
+        assert_eq!(names(&machine), vec!["alice"]);
+    }
+
+    /// Hand-stamp a committed tombstone (`xmax`) on a live row, the same
+    /// way the storage crate's vacuum tests do: today's executor DELETE
+    /// path bitmap-deletes immediately (and `gc_old_versions` skips
+    /// bitmap-deleted rows), so vacuum-reclaimable garbage must be
+    /// simulated via a deferred tombstone.
+    #[cfg(feature = "mvcc_enabled")]
+    fn tombstone_users_row(machine: &VibesqlStateMachine, row_idx: usize, xmax: u64) {
+        machine.with_db_mut(|db| {
+            db.get_table_mut("users").unwrap().stamp_row_xmax_inplace(row_idx, xmax);
+        });
+    }
+
+    /// The real SnapshotHorizonPin: while the pin a snapshot build
+    /// acquires is held, `vacuum_mvcc` cannot reclaim row versions the
+    /// build might still read; releasing it un-blocks reclamation. This
+    /// replaces Phase A4's recording-pin assertion with one against the
+    /// actual storage-layer holdback.
+    #[cfg(feature = "mvcc_enabled")]
+    #[test]
+    fn horizon_pin_holds_vacuum_back_until_released() {
+        let machine = VibesqlStateMachine::new();
+        create_users(&machine, 1);
+        machine.apply(2, &TxnEntry::single("INSERT INTO users VALUES (1, 'alice')")).unwrap();
+
+        // Acquire the pin exactly as `snapshot()` does (same code path).
+        // The horizon is pinned at 3 (= next commit_ts).
+        let pin = machine.horizon_pin().acquire();
+
+        // A "transaction" at commit_ts 3 tombstones alice's version, and
+        // a later entry advances the allocator watermark past it — so the
+        // version would be reclaimable if not for the pin.
+        tombstone_users_row(&machine, 0, 3);
+        machine.apply(3, &TxnEntry::single("INSERT INTO users VALUES (2, 'bob')")).unwrap();
+
+        assert_eq!(
+            machine.vacuum().unwrap(),
+            0,
+            "vacuum must reclaim nothing while the snapshot pin is held"
+        );
+
+        drop(pin);
+        assert_eq!(
+            machine.vacuum().unwrap(),
+            1,
+            "vacuum must reclaim the dead version once the pin is released"
+        );
+    }
+
+    /// `snapshot()` itself acquires and releases the pin: after a build
+    /// completes, vacuum proceeds normally (nothing leaks pinned).
+    #[cfg(feature = "mvcc_enabled")]
+    #[test]
+    fn snapshot_releases_the_horizon_pin_when_done() {
+        let machine = VibesqlStateMachine::new();
+        create_users(&machine, 1);
+        machine.apply(2, &TxnEntry::single("INSERT INTO users VALUES (1, 'alice')")).unwrap();
+        tombstone_users_row(&machine, 0, 3);
+        machine.apply(3, &TxnEntry::single("INSERT INTO users VALUES (2, 'bob')")).unwrap();
+
+        let snapshot = machine.snapshot().unwrap();
+        assert_eq!(snapshot.last_included_index, 3);
+
+        // The build's pin was released with the build; the dead version
+        // is reclaimable again.
+        assert_eq!(machine.vacuum().unwrap(), 1, "the build must not leak its horizon pin");
+    }
+}

--- a/crates/vibesql-storage/src/database/tests/vacuum.rs
+++ b/crates/vibesql-storage/src/database/tests/vacuum.rs
@@ -170,6 +170,140 @@ fn vacuum_mvcc_preserves_subsequent_query_correctness() {
     );
 }
 
+// ============================================================================
+// GC horizon pins (Raft Phase B1, #5199)
+// ============================================================================
+//
+// A horizon pin holds `compute_gc_horizon` back exactly like an active
+// transaction would, but without occupying the single-writer transaction
+// slot. The consensus layer acquires one for the duration of a Raft
+// snapshot build (see `vibesql-consensus`'s `SnapshotHorizonPin`).
+
+#[test]
+fn gc_horizon_pin_holds_horizon_and_release_restores_it() {
+    // Feature-independent: the pin operates on `compute_gc_horizon`
+    // arithmetic, which exists in both feature states.
+    let mut db = Database::new();
+    assert_eq!(db.compute_gc_horizon(), 1);
+
+    let pin = db.pin_gc_horizon();
+
+    // Advance the allocator watermark with two no-op transactions.
+    for _ in 0..2 {
+        db.begin_transaction().unwrap();
+        db.commit_transaction().unwrap();
+    }
+    // Unpinned, the horizon would now be next_transaction_id = 3; the
+    // pin holds it at the value captured at acquire time.
+    assert_eq!(db.compute_gc_horizon(), 1, "pin must hold the horizon back");
+
+    db.release_gc_horizon(pin);
+    assert_eq!(db.compute_gc_horizon(), 3, "release must let the horizon advance");
+
+    // Releasing an unknown pin is a no-op.
+    db.release_gc_horizon(9999);
+    assert_eq!(db.compute_gc_horizon(), 3);
+}
+
+#[test]
+fn gc_horizon_pins_combine_to_the_minimum() {
+    let mut db = Database::new();
+    let early_pin = db.pin_gc_horizon(); // pinned at 1
+
+    db.begin_transaction().unwrap();
+    db.commit_transaction().unwrap();
+    let late_pin = db.pin_gc_horizon(); // pinned at min(2, early pin 1) = 1
+
+    db.begin_transaction().unwrap();
+    db.commit_transaction().unwrap();
+    assert_eq!(db.compute_gc_horizon(), 1, "lowest pin wins");
+
+    db.release_gc_horizon(early_pin);
+    // The late pin captured the horizon *while the early pin was held*,
+    // so it pinned the still-held-back value.
+    assert_eq!(db.compute_gc_horizon(), 1);
+
+    db.release_gc_horizon(late_pin);
+    assert_eq!(db.compute_gc_horizon(), 3);
+}
+
+#[test]
+fn gc_horizon_pin_does_not_block_transactions() {
+    // Unlike an active transaction, a pin leaves the single-writer
+    // transaction slot free: begin/commit while pinned must work. This
+    // is the property that lets a Raft snapshot build coexist with
+    // applying committed log entries (Phase B1, #5199).
+    let mut db = Database::new();
+    make_users_table(&mut db);
+
+    let pin = db.pin_gc_horizon();
+    db.begin_transaction().unwrap();
+    db.insert_row("users", user_row(1, "Alice")).unwrap();
+    db.commit_transaction().unwrap();
+    db.release_gc_horizon(pin);
+
+    assert_eq!(db.get_table("users").unwrap().row_count(), 1);
+}
+
+#[cfg(feature = "mvcc_enabled")]
+#[test]
+fn vacuum_mvcc_held_back_by_gc_horizon_pin() {
+    // The end-to-end property the consensus layer relies on: while a
+    // pin is held, `vacuum_mvcc` must not reclaim row versions that
+    // were visible when the pin was acquired — even though the
+    // allocator watermark has advanced past their tombstones.
+    let mut db = Database::new();
+    make_users_table(&mut db);
+    db.insert_row("users", user_row(1, "Alice")).unwrap();
+    db.insert_row("users", user_row(2, "Bob")).unwrap();
+
+    // Tombstone row 0 with a committed xmax, as in
+    // `vacuum_mvcc_reclaims_committed_deletions`.
+    {
+        let table = db.get_table_mut("users").unwrap();
+        table.stamp_row_xmax_inplace(0, 1);
+    }
+
+    // Pin while the horizon is still 1 (nothing reclaimable yet).
+    let pin = db.pin_gc_horizon();
+
+    // Advance the watermark past the tombstone.
+    db.begin_transaction().unwrap();
+    db.commit_transaction().unwrap();
+
+    // Pinned: the sweep must reclaim nothing.
+    assert_eq!(db.vacuum_mvcc().unwrap(), 0, "pinned horizon must block reclamation");
+    assert_eq!(db.get_table("users").unwrap().row_count(), 2);
+
+    // Released: the tombstoned version becomes reclaimable.
+    db.release_gc_horizon(pin);
+    assert_eq!(db.vacuum_mvcc().unwrap(), 1, "released pin must allow reclamation");
+    assert_eq!(db.get_table("users").unwrap().row_count(), 1);
+}
+
+// ============================================================================
+// Replication txn-id override (Raft Phase B1, #5199)
+// ============================================================================
+
+#[test]
+fn set_next_txn_id_controls_allocation_and_rejects_active_txn() {
+    let mut db = Database::new();
+
+    db.set_next_txn_id(42).unwrap();
+    db.begin_transaction().unwrap();
+    assert_eq!(db.transaction_id(), Some(42), "next BEGIN must use the overridden id");
+
+    // The id of an in-flight transaction cannot change.
+    let err = db.set_next_txn_id(99).expect_err("must refuse inside a transaction");
+    assert!(format!("{err}").contains("set_next_txn_id"), "unexpected error: {err}");
+
+    db.commit_transaction().unwrap();
+    db.set_next_txn_id(99).unwrap();
+    db.begin_transaction().unwrap();
+    assert_eq!(db.transaction_id(), Some(99));
+    db.rollback_transaction().unwrap();
+}
+
 #[cfg(feature = "mvcc_enabled")]
 #[test]
 fn vacuum_mvcc_horizon_held_back_by_active_transaction() {

--- a/crates/vibesql-storage/src/database/transaction_api.rs
+++ b/crates/vibesql-storage/src/database/transaction_api.rs
@@ -143,6 +143,39 @@ impl Database {
         self.lifecycle.transaction_manager().compute_gc_horizon()
     }
 
+    /// Pin the MVCC GC horizon at its current value (Raft Phase B1, #5199).
+    ///
+    /// See [`TransactionManager::pin_gc_horizon`]: while the returned pin
+    /// is held, [`Self::vacuum_mvcc`] cannot reclaim row versions visible
+    /// at pin time. Used by `vibesql-consensus` to keep a Raft snapshot
+    /// build's view of the database stable without occupying the
+    /// single-writer transaction slot.
+    ///
+    /// [`TransactionManager::pin_gc_horizon`]: crate::database::transactions::TransactionManager::pin_gc_horizon
+    pub fn pin_gc_horizon(&mut self) -> u64 {
+        self.lifecycle.transaction_manager_mut().pin_gc_horizon()
+    }
+
+    /// Release a GC horizon pin acquired with [`Self::pin_gc_horizon`].
+    /// Releasing an unknown (or already-released) pin id is a no-op.
+    pub fn release_gc_horizon(&mut self, pin_id: u64) {
+        self.lifecycle.transaction_manager_mut().release_gc_horizon(pin_id);
+    }
+
+    /// Override the next transaction id (Raft Phase B1, #5199).
+    ///
+    /// Replication-apply use only — see
+    /// [`TransactionManager::set_next_txn_id`] for the full caller
+    /// contract (must be outside a transaction; must never move the
+    /// allocator backwards past stamped rows). This is how the
+    /// replicated state machine derives the MVCC commit timestamp from
+    /// the Raft log index.
+    ///
+    /// [`TransactionManager::set_next_txn_id`]: crate::database::transactions::TransactionManager::set_next_txn_id
+    pub fn set_next_txn_id(&mut self, id: crate::row::TxnId) -> Result<(), StorageError> {
+        self.lifecycle.transaction_manager_mut().set_next_txn_id(id)
+    }
+
     /// MVCC vacuum: reclaim space from row versions whose deletion is
     /// provably invisible to every active and future transaction.
     ///

--- a/crates/vibesql-storage/src/database/transactions.rs
+++ b/crates/vibesql-storage/src/database/transactions.rs
@@ -117,12 +117,36 @@ pub struct TransactionManager {
     transaction_state: TransactionState,
     /// Next transaction ID
     next_transaction_id: u64,
+    /// Externally-held GC horizon pins (Raft Phase B1, #5199).
+    ///
+    /// Each entry maps a pin id to the horizon value captured when the
+    /// pin was acquired. While any pin is held, [`compute_gc_horizon`]
+    /// never advances past the lowest pinned value, so a long-running
+    /// reader that is **not** a SQL transaction — concretely, a Raft
+    /// snapshot build serializing the database state — can prevent
+    /// `vacuum_mvcc` from reclaiming row versions it still needs.
+    ///
+    /// This is the same primitive as the active-transaction holdback
+    /// (an active txn pins the horizon at its snapshot's `xmin_active`),
+    /// generalized to non-transactional readers. A `BTreeMap` keeps the
+    /// "lowest pinned value" lookup simple; the map is tiny (one entry
+    /// per concurrent snapshot build).
+    ///
+    /// [`compute_gc_horizon`]: Self::compute_gc_horizon
+    horizon_pins: std::collections::BTreeMap<u64, TxnId>,
+    /// Next pin id to hand out from [`pin_gc_horizon`](Self::pin_gc_horizon).
+    next_pin_id: u64,
 }
 
 impl TransactionManager {
     /// Create a new transaction manager
     pub fn new() -> Self {
-        TransactionManager { transaction_state: TransactionState::None, next_transaction_id: 1 }
+        TransactionManager {
+            transaction_state: TransactionState::None,
+            next_transaction_id: 1,
+            horizon_pins: std::collections::BTreeMap::new(),
+            next_pin_id: 1,
+        }
     }
 
     /// Record a change in the current transaction (if any)
@@ -347,10 +371,76 @@ impl TransactionManager {
     /// [`Table::gc_old_versions`]: crate::Table::gc_old_versions
     /// [`crate::Database::vacuum_mvcc`]: crate::Database
     pub fn compute_gc_horizon(&self) -> TxnId {
-        match &self.transaction_state {
+        let base = match &self.transaction_state {
             TransactionState::Active { snapshot, .. } => snapshot.xmin_active,
             TransactionState::None => self.next_transaction_id,
+        };
+        // Raft Phase B1 (#5199): externally-held pins (snapshot builds)
+        // hold the horizon back exactly like an active transaction would.
+        match self.horizon_pins.values().min() {
+            Some(&pinned) => base.min(pinned),
+            None => base,
         }
+    }
+
+    /// Pin the GC horizon at its current value (Raft Phase B1, #5199).
+    ///
+    /// Returns a pin id that must be passed to
+    /// [`release_gc_horizon`](Self::release_gc_horizon) when the pinned
+    /// read completes. While the pin is held,
+    /// [`compute_gc_horizon`](Self::compute_gc_horizon) — and therefore
+    /// `vacuum_mvcc` — never advances past the value captured here, so
+    /// row versions visible at pin time cannot be physically reclaimed.
+    ///
+    /// This is how a Raft snapshot build registers itself "as (or
+    /// alongside) an active read transaction" per the Phase A4 design
+    /// (`vibesql-consensus`'s `SnapshotHorizonPin`): the build acquires
+    /// a pin before reading any state and releases it once the snapshot
+    /// blob is built and durable. Unlike `begin_transaction`, a pin does
+    /// not occupy the single-writer transaction slot, so applying
+    /// committed log entries can proceed while a snapshot is pinned.
+    pub fn pin_gc_horizon(&mut self) -> u64 {
+        let pin_id = self.next_pin_id;
+        self.next_pin_id += 1;
+        let horizon = self.compute_gc_horizon();
+        self.horizon_pins.insert(pin_id, horizon);
+        pin_id
+    }
+
+    /// Release a GC horizon pin acquired with
+    /// [`pin_gc_horizon`](Self::pin_gc_horizon). Releasing an unknown
+    /// (or already-released) pin id is a no-op.
+    pub fn release_gc_horizon(&mut self, pin_id: u64) {
+        self.horizon_pins.remove(&pin_id);
+    }
+
+    /// Override the next transaction id (Raft Phase B1, #5199).
+    ///
+    /// On a replicated node the MVCC commit timestamp is the Raft log
+    /// index ("apply index = commit order", ADR-0004): the state machine
+    /// calls this immediately before `begin_transaction` so the
+    /// transaction that applies log entry `N` is stamped with
+    /// `txn_id = N`. This keeps `xmin`/`xmax` stamps identical on every
+    /// replica and across snapshot-install + log-replay recovery, where
+    /// the local allocator's counter would otherwise restart from 1.
+    ///
+    /// # Caller contract
+    ///
+    /// Replication-apply use only. Must be called **outside** an active
+    /// transaction (the id of an in-flight transaction cannot change),
+    /// and `id` must be at least the highest id already stamped into
+    /// rows — moving the allocator backwards would let two different
+    /// transactions stamp the same id, corrupting MVCC visibility.
+    /// Single-node (non-replicated) databases never call this and keep
+    /// the sequential local allocator.
+    pub fn set_next_txn_id(&mut self, id: TxnId) -> Result<(), StorageError> {
+        if self.in_transaction() {
+            return Err(StorageError::TransactionError(
+                "set_next_txn_id cannot run while a transaction is active".to_string(),
+            ));
+        }
+        self.next_transaction_id = id;
+        Ok(())
     }
 
     /// Capture a fresh "commit-time" MVCC snapshot.


### PR DESCRIPTION
Part of #5199 (PR 1 of 2 — do not auto-close the issue; PR 2 adds leader-only enforcement + multi-node tests).

## Summary

Wires the real MVCC database in as the Raft replicated state machine, per the curator re-scope (ADR-0004: single group, no HLC, commit_ts = apply order).

- **`TxnEntry`** (`crates/vibesql-consensus/src/state_machine.rs`): one committed transaction per log entry as a **deterministic SQL statement batch**. The re-scope preferred a write-set/effects form, but it is not implementable against today's storage layer: the crash-recovery WAL replay (`wal/recovery.rs::apply_op`) is a DML stub (no `table_id -> table` resolution), and `TransactionChange` (savepoint undo) is DML-only with no row-level "apply with index/constraint upkeep" entry point. The determinism hazard (`random()`, `CURRENT_TIMESTAMP`) is documented in the module docs as a known limitation — harmless single-node (each entry applied exactly once by one machine), and filed as **#5377** before multi-node lands.
- **`VibesqlStateMachine`**: applies committed entries to a real `Database`. **commit_ts = log index** — `set_next_txn_id(N)` immediately before BEGIN, so every `xmin`/`xmax` stamped by entry `N` equals `N`; survives snapshot-install + log-replay. Apply is atomic per entry (whole batch in one storage transaction, COMMIT through `CommitExecutor` so deferred-FK re-validation behaves like a local session), **idempotent** (`index <= last_applied` is a no-op), and loud on gaps. A rejected entry rolls back fully but still consumes its index (identical rejection on every replica).
- **Snapshot codec seam (#5369)**: machine snapshots serialize the database with the binary persistence format (vbsql v7+, carries per-row `xmin`/`xmax`); corrupt payloads are rejected without mutation. The echo machine keeps its JSON codec and its conformance suite (unchanged, still green).
- **Real `SnapshotHorizonPin`**: `MvccHorizonPin` registers a snapshot build with the new storage-layer GC-horizon holdback, so `vacuum_mvcc` cannot reclaim row versions under a build. The Phase A4 seam is no longer a no-op.
- **`ReplicatedDb`** (`replicated.rs`): the PR 1 propose path (`execute_replicated` / `execute_replicated_txn`) — whole transactions proposed as one entry through a `ConsensusBackend`, applied on commit, session reads its own writes. Test harness, not server/CLI wiring (out of scope per the re-scope).
- **`vibesql-storage` (additive only)**: `pin_gc_horizon`/`release_gc_horizon` (pins hold `compute_gc_horizon` back like an active transaction, minimum-of-pins, without occupying the single-writer slot) and `set_next_txn_id` (refuses inside an active transaction). Dependency direction stays consensus → executor → storage.

## Tests

- `cargo test -p vibesql-consensus`: 96 lib tests + integration suites, green (99 with `--features mvcc_enabled`).
- `cargo test -p vibesql-storage`: 652+ green; new vacuum-pin tests also pass with `mvcc_enabled` (`vacuum_mvcc_held_back_by_gc_horizon_pin` etc.).
- New coverage: propose/apply roundtrip (INSERT/UPDATE/DELETE, `xmin` = log index asserted at the MVCC level); multi-statement atomicity (PK violation rolls whole entry back, index still consumed); idempotent re-apply; snapshot build → install → identical results, plus snapshot+log-replay overlap convergence; real vacuum-pin holds reclamation until released and `snapshot()` doesn't leak its pin; corrupt-snapshot rejection without mutation.
- **TCL P1 note**: the TCL harness drives the CLI binary, which is not wired to consensus in PR 1 (server/CLI wiring is PR 2+ scope), so the P1 baseline is covered by a Rust-level P1-style smoke through the replicated path (`tcl_p1_style_smoke_through_replication`: CREATE TABLE/INDEX, INSERT, UPDATE/DELETE with WHERE, aggregates, ORDER BY, JOIN). The full `make test-tcl` baseline runs against the unreplicated engine, untouched by this PR.
- Async tests flake-checked 12/12 green. `cargo build --workspace` green; clippy clean on touched files.

## Follow-ons

- #5377 — deterministic replication of nondeterministic SQL (freeze-at-propose or effects-form write-set) before multi-node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)