### PR TITLE
feat(explain): suppress ORDER BY temp B-tree for rowid-alias natural-order scans

### DIFF
--- a/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
@@ -635,9 +635,101 @@ pub(crate) fn needs_temp_btree_for_order_by_eqp(
     let Some(table) = database.get_table(table_name) else {
         return true;
     };
-    let _ = &table.schema; // table-only check (avoid unused warning on schema)
+
+    // #5375: ORDER BY led by the table's INTEGER PRIMARY KEY (the rowid
+    // alias) over a plain sequential scan. The executor guarantees that a
+    // sequential scan of a rowid-alias table delivers rows in rowid order
+    // (`sort_rows_by_integer_primary_key`, #4926), so the requested order —
+    // or its exact reverse, for DESC — IS the scan's natural output order
+    // and the runtime ORDER BY sort is order-equivalent to the natural
+    // traversal. sqlite3 3.51.0 shows a bare `SCAN t` with no temp line here
+    // (its table B-tree is keyed by rowid); suppressing the line falls under
+    // the same permissive EQP convention as the index stabilization-sort
+    // suppression below. Trailing ORDER BY terms are ignored: the rowid is
+    // unique, so they can never affect the order (verified live: sqlite3
+    // suppresses for `ORDER BY id, y` and `ORDER BY id ASC, y DESC`).
+    //
+    // This only applies when the planner picks NO index for the scan: if the
+    // WHERE clause rides an index (SEARCH/skip-scan), rows arrive in index
+    // order, not rowid order, and the sort is real. It also does NOT apply
+    // to the bare `rowid` pseudo-column on tables WITHOUT an INTEGER PRIMARY
+    // KEY: their sequential scan yields physical insertion order, which
+    // explicit-rowid INSERTs and `UPDATE ... SET rowid = ...` can decouple
+    // from rowid order, so that temp line stays truthful (documented
+    // divergence from sqlite3).
+    if order_by_leads_with_rowid_alias(&table.schema, table_name, order_by)
+        && cost_based_index_selection(table_name, where_clause, Some(order_by), database).is_none()
+        && !has_skip_scan_plan(table_name, where_clause, database)
+    {
+        return false;
+    }
 
     eqp_ordering_index(table_name, where_clause, order_by, database, false).is_none()
+}
+
+/// True when the planner would choose a skip-scan for this table + WHERE
+/// (mirrors the skip-scan fallback in `ExplainExecutor::explain_table_scan`).
+fn has_skip_scan_plan(
+    table_name: &str,
+    where_clause: Option<&Expression>,
+    database: &Database,
+) -> bool {
+    let Some(where_expr) = where_clause else {
+        return false;
+    };
+    IndexPlanner::new(database).plan_skip_scan(table_name, where_expr).is_some()
+}
+
+/// EQP-only (#5375): true when the FIRST ORDER BY term is a column reference
+/// to the table's INTEGER PRIMARY KEY rowid alias — either by the declared
+/// column name, or via the `rowid`/`_rowid_`/`oid` pseudo-column keywords
+/// (which resolve to the alias column; real columns shadow the keywords, and
+/// WITHOUT ROWID tables have no rowid pseudo-column, #4953).
+///
+/// Direction is ignored: ASC is the scan's natural rowid order and DESC its
+/// exact reverse (the same reverse-traversal convention as index DESC
+/// suppression; sqlite3 shows a bare `SCAN t` for both). Trailing terms are
+/// ignored because the rowid is unique.
+fn order_by_leads_with_rowid_alias(
+    schema: &TableSchema,
+    table_name: &str,
+    order_by: &[vibesql_ast::OrderByItem],
+) -> bool {
+    let Some(ipk_idx) = schema.rowid_alias_column else {
+        return false;
+    };
+    let Some(ipk_col) = schema.columns.get(ipk_idx) else {
+        return false;
+    };
+    let Some(first) = order_by.first() else {
+        return false;
+    };
+    let Expression::ColumnRef(col_id) = &first.expr else {
+        return false;
+    };
+    // Schema-qualified references are out of scope; a table qualifier must
+    // match the scanned table.
+    if col_id.schema_canonical().is_some() {
+        return false;
+    }
+    if let Some(qualifier) = col_id.table_canonical() {
+        if !qualifier.eq_ignore_ascii_case(table_name) {
+            return false;
+        }
+    }
+
+    let col_name = col_id.column_canonical();
+    if col_name.eq_ignore_ascii_case(&ipk_col.name) {
+        return true;
+    }
+
+    // rowid/_rowid_/oid keywords: only when no real column shadows the
+    // keyword (real columns take precedence, matching the evaluator) and the
+    // table is not WITHOUT ROWID (no rowid pseudo-column there).
+    let is_rowid_keyword = col_name.eq_ignore_ascii_case("rowid")
+        || col_name.eq_ignore_ascii_case("_rowid_")
+        || col_name.eq_ignore_ascii_case("oid");
+    is_rowid_keyword && !schema.without_rowid && schema.get_column_index(col_name).is_none()
 }
 
 /// EQP-only: the index whose natural traversal delivers `order_by` for a

--- a/crates/vibesql-executor/tests/explain_temp_btree_annotation_tests.rs
+++ b/crates/vibesql-executor/tests/explain_temp_btree_annotation_tests.rs
@@ -993,16 +993,46 @@ fn test_order_by_mixed_directions_keeps_bare_scan_and_temp_line() {
     );
 }
 
-// ORDER BY rowid: sqlite3's table B-tree traversal natively delivers rowid
-// order, so it shows a bare scan and NO temp line:
-//   `--SCAN t1
-// VibeSQL's runtime performs a real sort pass on the rowid pseudo-column
-// after the scan (rowid matches no index column, so no ordering index
-// applies), so the temp line truthfully describes execution. Suppressing it
-// when the storage scan provably yields rowid order is tracked as a
-// follow-on (#5375).
+// ---------------------------------------------------------------------------
+// ORDER BY rowid / INTEGER PRIMARY KEY alias (#5375)
+// ---------------------------------------------------------------------------
+// sqlite3 3.51.0 shows a bare `SCAN t` with NO temp line for ORDER BY on the
+// rowid (or its INTEGER PRIMARY KEY alias): its table B-tree is keyed by
+// rowid, so traversal natively delivers rowid order (DESC via reverse
+// traversal). Verified live for: bare rowid/_rowid_/oid ASC and DESC, the
+// IPK alias column ASC and DESC, qualified `t.id`, trailing terms after the
+// unique first key (`ORDER BY id, y`, `ORDER BY id ASC, y DESC` — never
+// evaluated, fully suppressed), and a non-indexed WHERE filter.
+//
+// VibeSQL splits on the storage scan-order guarantee (#5375 investigation):
+//
+// - Tables WITH a rowid alias (INTEGER PRIMARY KEY): the executor sorts
+//   every sequential scan's output by the IPK column (#4926,
+//   `sort_rows_by_integer_primary_key`), so rowid order IS the scan's
+//   guaranteed natural output order and the runtime ORDER BY sort is
+//   order-equivalent to it (its exact reverse for DESC — same convention as
+//   index reverse-traversal suppression). The temp line is suppressed,
+//   matching sqlite3 (`needs_temp_btree_for_order_by_eqp`).
+//
+// - Plain tables (NO rowid alias): the sequential scan yields physical
+//   insertion order, which `INSERT INTO t(rowid, ...)` with out-of-order
+//   values and `UPDATE t SET rowid = ...` (both supported, verified by
+//   probe) decouple from rowid order. The ORDER BY sort genuinely reorders
+//   rows, so the temp line stays — a documented divergence from sqlite3's
+//   bare `SCAN t`.
+
+/// r1(id INTEGER PRIMARY KEY, y TEXT) — rowid-alias table, no other indexes.
+fn setup_rowid_alias_db() -> Database {
+    let mut db = Database::new();
+    run_ddl(&mut db, "CREATE TABLE r1(id INTEGER PRIMARY KEY, y TEXT)");
+    db
+}
+
+// Plain table, ORDER BY rowid. sqlite3: `--SCAN t1 (no temp line).
+// DIVERGENCE (documented above): VibeSQL's plain-table scan order is
+// insertion order, not rowid order, so the sort is real and the line stays.
 #[test]
-fn test_order_by_rowid_emits_temp_btree() {
+fn test_order_by_rowid_plain_table_emits_temp_btree() {
     let db = setup_db();
     let output = eqp(&db, "SELECT * FROM t1 ORDER BY rowid");
 
@@ -1010,6 +1040,235 @@ fn test_order_by_rowid_emits_temp_btree() {
         output,
         "QUERY PLAN\n\
          |--SCAN t1\n\
+         `--USE TEMP B-TREE FOR ORDER BY\n"
+    );
+}
+
+// Plain table, ORDER BY rowid DESC. sqlite3: `--SCAN t1 (no temp line,
+// reverse traversal). DIVERGENCE: same scan-order reasoning as ASC.
+#[test]
+fn test_order_by_rowid_desc_plain_table_emits_temp_btree() {
+    let db = setup_db();
+    let output = eqp(&db, "SELECT * FROM t1 ORDER BY rowid DESC");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SCAN t1\n\
+         `--USE TEMP B-TREE FOR ORDER BY\n"
+    );
+}
+
+// Plain table, _rowid_ / oid keyword spellings. sqlite3: `--SCAN t1 for
+// both (no temp line). DIVERGENCE: same scan-order reasoning.
+#[test]
+fn test_order_by_rowid_keyword_spellings_plain_table_emit_temp_btree() {
+    let db = setup_db();
+    for sql in ["SELECT * FROM t1 ORDER BY _rowid_", "SELECT * FROM t1 ORDER BY oid"] {
+        let output = eqp(&db, sql);
+        assert_eq!(
+            output,
+            "QUERY PLAN\n\
+             |--SCAN t1\n\
+             `--USE TEMP B-TREE FOR ORDER BY\n",
+            "query: {}",
+            sql
+        );
+    }
+}
+
+// A real column named `rowid` shadows the pseudo-column (the evaluator
+// checks real columns first). sqlite3 — identical (verified live):
+//   |--SCAN t8
+//   `--USE TEMP B-TREE FOR ORDER BY
+#[test]
+fn test_order_by_shadowed_rowid_column_emits_temp_btree() {
+    let mut db = Database::new();
+    run_ddl(&mut db, "CREATE TABLE t8(rowid INT, y TEXT)");
+    let output = eqp(&db, "SELECT * FROM t8 ORDER BY rowid");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SCAN t8\n\
+         `--USE TEMP B-TREE FOR ORDER BY\n"
+    );
+}
+
+// IPK alias, ORDER BY id. sqlite3 — identical: `--SCAN r1 (no temp line).
+// The #4926 scan sort guarantees rowid order, so the suppression is the
+// stabilization-sort convention, not a fabrication.
+#[test]
+fn test_order_by_ipk_alias_suppresses_temp_btree() {
+    let db = setup_rowid_alias_db();
+    let output = eqp(&db, "SELECT * FROM r1 ORDER BY id");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         `--SCAN r1\n"
+    );
+}
+
+// IPK alias, ORDER BY id DESC. sqlite3 — identical (reverse traversal).
+#[test]
+fn test_order_by_ipk_alias_desc_suppresses_temp_btree() {
+    let db = setup_rowid_alias_db();
+    let output = eqp(&db, "SELECT * FROM r1 ORDER BY id DESC");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         `--SCAN r1\n"
+    );
+}
+
+// IPK alias via the rowid keyword spellings (rowid/_rowid_/oid resolve to
+// the alias column), ASC and DESC. sqlite3 — identical for all.
+#[test]
+fn test_order_by_rowid_keywords_on_ipk_table_suppress_temp_btree() {
+    let db = setup_rowid_alias_db();
+    for sql in [
+        "SELECT * FROM r1 ORDER BY rowid",
+        "SELECT * FROM r1 ORDER BY rowid DESC",
+        "SELECT * FROM r1 ORDER BY _rowid_",
+        "SELECT * FROM r1 ORDER BY oid",
+    ] {
+        let output = eqp(&db, sql);
+        assert_eq!(
+            output,
+            "QUERY PLAN\n\
+             `--SCAN r1\n",
+            "query: {}",
+            sql
+        );
+    }
+}
+
+// Trailing terms after the unique IPK first key are never evaluated, so
+// sqlite3 fully suppresses (verified live for `ORDER BY id, y` and
+// `ORDER BY id ASC, y DESC`) — identical here.
+#[test]
+fn test_order_by_ipk_with_trailing_terms_suppresses_temp_btree() {
+    let db = setup_rowid_alias_db();
+    for sql in ["SELECT * FROM r1 ORDER BY id, y", "SELECT * FROM r1 ORDER BY id ASC, y DESC"] {
+        let output = eqp(&db, sql);
+        assert_eq!(
+            output,
+            "QUERY PLAN\n\
+             `--SCAN r1\n",
+            "query: {}",
+            sql
+        );
+    }
+}
+
+// IPK NOT first: `ORDER BY y, id` needs a real sort. sqlite3 — identical:
+//   |--SCAN r1
+//   `--USE TEMP B-TREE FOR ORDER BY
+#[test]
+fn test_order_by_ipk_not_first_emits_temp_btree() {
+    let db = setup_rowid_alias_db();
+    let output = eqp(&db, "SELECT * FROM r1 ORDER BY y, id");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SCAN r1\n\
+         `--USE TEMP B-TREE FOR ORDER BY\n"
+    );
+}
+
+// Table-qualified reference to the IPK alias. sqlite3 — identical.
+#[test]
+fn test_order_by_qualified_ipk_alias_suppresses_temp_btree() {
+    let db = setup_rowid_alias_db();
+    let output = eqp(&db, "SELECT * FROM r1 ORDER BY r1.id");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         `--SCAN r1\n"
+    );
+}
+
+// Non-indexed WHERE + ORDER BY id: the filter preserves the scan's rowid
+// order. sqlite3 — identical: `--SCAN r1 (no temp line).
+#[test]
+fn test_where_filter_order_by_ipk_suppresses_temp_btree() {
+    let db = setup_rowid_alias_db();
+    let output = eqp(&db, "SELECT * FROM r1 WHERE y > 'a' ORDER BY id");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         `--SCAN r1\n"
+    );
+}
+
+// Expression over the IPK (`id+0`) is not the column itself. sqlite3 —
+// identical (verified live: `ORDER BY rowid+0` / `ORDER BY id+0` keep the
+// temp line):
+//   |--SCAN r1
+//   `--USE TEMP B-TREE FOR ORDER BY
+#[test]
+fn test_order_by_ipk_expression_emits_temp_btree() {
+    let db = setup_rowid_alias_db();
+    let output = eqp(&db, "SELECT * FROM r1 ORDER BY id+0");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SCAN r1\n\
+         `--USE TEMP B-TREE FOR ORDER BY\n"
+    );
+}
+
+// When the WHERE clause rides an index, rows arrive in INDEX order, not
+// rowid order, so the suppression does not apply and the temp line stays.
+// sqlite3 (verified live) suppresses even here:
+//   `--SEARCH r2 USING COVERING INDEX r2y (y=?)
+// because its index entries are (key, rowid) pairs — within an equality
+// group, traversal is rowid-ordered. VibeSQL's index buckets carry no such
+// guarantee and the runtime genuinely re-sorts, so the temp line is the
+// truthful rendering. DIVERGENCE (documented).
+#[test]
+fn test_indexed_where_order_by_ipk_keeps_temp_btree() {
+    let mut db = Database::new();
+    run_ddl(&mut db, "CREATE TABLE r2(id INTEGER PRIMARY KEY, y TEXT)");
+    run_ddl(&mut db, "CREATE INDEX r2y ON r2(y)");
+    let output = eqp(&db, "SELECT * FROM r2 WHERE y='a' ORDER BY id");
+
+    assert_eq!(
+        output,
+        "QUERY PLAN\n\
+         |--SEARCH r2 USING INDEX r2y (y=?)\n\
+         `--USE TEMP B-TREE FOR ORDER BY\n"
+    );
+}
+
+// WITHOUT ROWID with a single-column exact-INTEGER PRIMARY KEY: VibeSQL
+// still records the rowid-alias column and the #4926 scan sort applies, so
+// ORDER BY on the PK is the scan's natural order. sqlite3 — identical
+// (verified live; its WITHOUT ROWID B-tree is keyed by the PK):
+//   `--SCAN r3
+// The rowid KEYWORD spelling does not get the exemption on WITHOUT ROWID
+// tables (no rowid pseudo-column there, #4953), so that spelling keeps the
+// temp line.
+#[test]
+fn test_without_rowid_order_by_pk_suppresses_temp_btree() {
+    let mut db = Database::new();
+    run_ddl(&mut db, "CREATE TABLE r3(a INTEGER PRIMARY KEY, b TEXT) WITHOUT ROWID");
+
+    assert_eq!(
+        eqp(&db, "SELECT * FROM r3 ORDER BY a"),
+        "QUERY PLAN\n\
+         `--SCAN r3\n"
+    );
+    assert_eq!(
+        eqp(&db, "SELECT * FROM r3 ORDER BY rowid"),
+        "QUERY PLAN\n\
+         |--SCAN r3\n\
          `--USE TEMP B-TREE FOR ORDER BY\n"
     );
 }


### PR DESCRIPTION
Closes #5375

## Summary

For `SELECT * FROM t ORDER BY rowid`, sqlite3 3.51.0 shows a bare `SCAN t` with no temp line (its table B-tree is keyed by rowid; DESC via reverse traversal). VibeSQL emitted `USE TEMP B-TREE FOR ORDER BY` for every rowid ORDER BY. Per the issue, this PR first investigated the storage scan-order guarantee, then implemented suppression only where it holds.

## The scan-order-guarantee finding (the crux)

- **Tables WITH an INTEGER PRIMARY KEY rowid alias** (`rowid_alias_column`, #4536): the executor sorts every sequential scan's output by the IPK column (`sort_rows_by_integer_primary_key`, #4926 — `SELECT *` returns rowid order even after out-of-order inserts). Rowid order **is** the scan's guaranteed natural output order, so the runtime ORDER BY sort is order-equivalent to the natural traversal (its exact reverse for DESC — the same convention as the existing index reverse-traversal suppression). Suppressing the temp line falls under the established permissive EQP convention (#5367/#5370).
- **Plain tables (no alias)**: the sequential scan yields **physical insertion order**, NOT rowid order. Verified by runtime probe: after `INSERT INTO t1(rowid, x) VALUES (10, 1)` then `(5, 2)`, `SELECT rowid FROM t1` returns `[10, 5, 3]` while `ORDER BY rowid` returns `[3, 5, 10]`; in-place `UPDATE t SET rowid = ...` also decouples the orders. The sort genuinely reorders rows, so the temp line stays — a documented truthful divergence (#5360/#5366/#5370/#5372/#5376 precedent).

## Implementation

`needs_temp_btree_for_order_by_eqp` (selection.rs, EQP-only — sole caller is `ExplainExecutor`) now returns false when:
- the table has a rowid alias column, AND
- the FIRST ORDER BY term is a column reference to it — by name, `t.name`-qualified, or via `rowid`/`_rowid_`/`oid` (real columns shadow the keywords; WITHOUT ROWID tables get no keyword exemption, #4953), any direction, trailing terms ignored (the rowid is unique, verified live), AND
- the planner picks **no** index/skip-scan for the WHERE clause (index delivery order is not rowid order).

## Per-case outcomes (all verified against sqlite3 3.51.0 live)

| Case | sqlite3 | VibeSQL now | |
|---|---|---|---|
| IPK `ORDER BY id` / `id DESC` | bare SCAN | bare SCAN | suppressed, matches |
| IPK `ORDER BY rowid`/`_rowid_`/`oid` (+DESC) | bare SCAN | bare SCAN | suppressed, matches |
| IPK `ORDER BY id, y` / `id ASC, y DESC` | bare SCAN | bare SCAN | suppressed, matches (unique first key) |
| IPK `ORDER BY t.id` qualified | bare SCAN | bare SCAN | suppressed, matches |
| IPK non-indexed WHERE + `ORDER BY id` | bare SCAN | bare SCAN | suppressed, matches |
| WITHOUT ROWID `ORDER BY pk` | bare SCAN | bare SCAN | suppressed, matches |
| IPK `ORDER BY y, id` | temp line | temp line | matches |
| IPK `ORDER BY id+0` (expression) | temp line | temp line | matches |
| real column named `rowid` (shadowing) | temp line | temp line | matches |
| plain table `ORDER BY rowid` (+DESC, `_rowid_`, `oid`) | bare SCAN | temp line | **documented divergence** (no scan-order guarantee) |
| IPK indexed-equality WHERE + `ORDER BY id` | SEARCH, no temp line | SEARCH + temp line | **documented divergence** (sqlite's index entries are rowid-ordered within an equality group; VibeSQL's buckets carry no such guarantee) |

## Test plan

- [x] `cargo test -p vibesql-executor` — 4197 passed, 0 failed (clean run after rebase onto d8bd152cf)
- [x] `explain_temp_btree_annotation_tests.rs`: 54 → 67 tests (13 new, all sqlite3-verified expected strings; divergences documented in comments)
- [x] TCL vs clean base, zero new failures: eqp 5/0, distinct 38/0, distinct2 41 passed + same 3 pre-existing (120, 5020, 5030), select6 86/0, windowpushd 29/29, window9 38/0, orderby1 37 + pre-existing 5.1, orderby2 7/0, orderby3 15/0, orderby4 6/0, orderby5 8 + same 7 pre-existing (1.1–1.6), orderby6 116/0, orderby9 1 + same 2 pre-existing (1.0, 1.1) — baseline failures confirmed identical by stash-and-rebuild on the clean base
- [x] rustfmt: identical pre-existing hunk set on clean base and branch — no new violations, no repo-wide fmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)