### PR TITLE
feat(consensus): mount MVCC state machine into openraft — multi-node replication (phase B1, PR 2/2)

### DIFF
--- a/crates/vibesql-consensus/src/lib.rs
+++ b/crates/vibesql-consensus/src/lib.rs
@@ -94,14 +94,32 @@
 //!
 //! The generic byte-echo configurations above remain unchanged (and keep
 //! their conformance suite); the MVCC machine is a new configuration on
-//! top of them. PR 2 of #5199 mounts [`VibesqlStateMachine`] behind
-//! openraft's `RaftStateMachine` for multi-node replication with
-//! leader-only writes.
+//! top of them.
 //!
-//! Deliberately **not** here yet (later Raft phases): multi-node MVCC
-//! replication and leader-only write enforcement (Phase B1 PR 2), TLS
-//! on the consensus port, production wiring into `vibesql-server`, and
-//! membership changes.
+//! Phase B1, PR 2, mounts that machine **inside** openraft (the
+//! `mvcc_raft` module):
+//!
+//! - [`MvccRaftNode`]: one voter of a multi-node cluster whose state
+//!   machine is the MVCC database — apply happens in the engine's
+//!   state-machine worker on every voter, with commit_ts = dense log
+//!   index surviving leader changes (protocol entries consume no dense
+//!   index).
+//! - **Leader-only writes**: proposals anywhere but the leader fail
+//!   fast with [`ConsensusError::NotLeader`] + leader hint;
+//!   freeze-at-propose (#5377) always runs on the leader.
+//! - **Fatal apply = node halt**: a possibly-node-local apply failure
+//!   surfaces as a storage error to openraft, which shuts the node down
+//!   *without* acknowledging the entry — `last_applied` never advances
+//!   past it (the [`ConsensusError::FatalApply`] obligation).
+//! - **MVCC snapshots across the network**: chunked install of the
+//!   binary database payload heals followers that fell behind a purge,
+//!   with the Phase A4 durability order (persist before acknowledge).
+//!
+//! Deliberately **not** here yet (later Raft phases): TLS on the
+//! consensus port, production wiring into `vibesql-server` (PostgreSQL
+//! sessions do not yet route writes through [`MvccRaftNode`]; surfacing
+//! `NotLeader` as a SQL error is follow-on work), and membership
+//! changes.
 //!
 //! Note on retention: the Raft log purge gated above is orthogonal to the
 //! pre-existing data-WAL checkpoint/truncation in `vibesql-storage::wal`
@@ -119,6 +137,7 @@ mod cluster_config;
 mod conformance;
 mod durable;
 mod freeze;
+mod mvcc_raft;
 #[cfg(test)]
 mod network;
 mod openraft_backend;
@@ -131,6 +150,7 @@ mod tcp;
 pub use backend::{ConsensusBackend, ConsensusError, LogIndex, Result, Role, Snapshot};
 pub use cluster_config::{ClusterConfig, DEFAULT_CONSENSUS_PORT};
 pub use freeze::{freeze_statement, FreezeError, FrozenValue, SubstituteError};
+pub use mvcc_raft::MvccRaftNode;
 pub use openraft_backend::{OpenraftBackend, RaftTuning};
 pub use replicated::ReplicatedDb;
 pub use single_node::SingleNodeBackend;

--- a/crates/vibesql-consensus/src/mvcc_raft.rs
+++ b/crates/vibesql-consensus/src/mvcc_raft.rs
@@ -1,0 +1,1521 @@
+//! The MVCC state machine mounted inside openraft, plus [`MvccRaftNode`]:
+//! a cluster member whose replicated writes apply to a real database
+//! (Raft Phase B1, #5199, PR 2 of 2).
+//!
+//! PR 1 built [`VibesqlStateMachine`] — apply, idempotence, commit_ts =
+//! log index, the MVCC snapshot codec, and the vacuum-horizon pin — and
+//! drove it *outside* the engine through `ReplicatedDb::catch_up_to`.
+//! This module mounts that machine **inside** openraft as a real
+//! [`RaftStateMachine`], so apply happens in the engine's state-machine
+//! worker on every voter: a leader's `client_write` resolves only after
+//! the entry is committed on a quorum and applied locally, and followers
+//! apply the same entries in the same order without any external
+//! catch-up loop.
+//!
+//! # Index mapping
+//!
+//! openraft's raw log interleaves application entries with protocol
+//! entries (membership, new-leader blanks). [`VibesqlStateMachine`]
+//! numbers **application entries only** (dense, 1-based — the indices
+//! its commit timestamps are derived from), so [`MvccStateMachine`]
+//! tracks both: the raw raft `last_applied` (what openraft resumes
+//! from) and the machine's dense index (computed as
+//! `machine.last_applied() + 1` for each `Normal` entry). Protocol
+//! entries advance only the raw cursor, never the dense one — which is
+//! exactly why dense indices (and therefore MVCC `xmin` stamps) are
+//! identical on every replica even across leader changes.
+//!
+//! # Fatal apply = node halt
+//!
+//! [`ConsensusError::FatalApply`] documents the PR 2 obligation: a
+//! possibly-node-local apply failure (resource exhaustion, storage
+//! failure, frozen-entry version skew — see `crate::state_machine`)
+//! must **halt the node**; recording it as a rejection would silently
+//! diverge replicas, and acknowledging it would let openraft advance
+//! `last_applied` past an entry whose effects this node does not have.
+//! The mount discharges that obligation by returning a [`StorageError`]
+//! from [`RaftStateMachine::apply`]: openraft treats storage errors as
+//! fatal — the core shuts down without acknowledging the entry, so
+//! neither the engine's `last_applied` nor the machine's advances. The
+//! reason is retained on the node ([`MvccRaftNode::fatal_reason`]) and
+//! embedded in the error openraft logs and returns to in-flight
+//! writes. Recovery is operational: restart the node and let it resync
+//! via snapshot install + log replay (or fix the version skew the
+//! fatal error reported).
+//!
+//! # Leader-only writes
+//!
+//! Proposals are accepted only on the leader. A follower (or candidate)
+//! fails fast with [`ConsensusError::NotLeader`] carrying its best
+//! guess at the leader id, *before* evaluating any nondeterministic
+//! expression; even without the fast path, openraft's `client_write`
+//! rejects non-leader writes with `ForwardToLeader`, which maps to the
+//! same error. Freeze-at-propose (#5377) therefore always runs on the
+//! leader: [`MvccRaftNode::execute_replicated_txn`] freezes volatile
+//! call sites into the entry before `client_write`, and every replica
+//! applies the identical frozen entry.
+//!
+//! # Snapshots
+//!
+//! The engine-level snapshot payload is an 8-byte LE **dense index
+//! header** followed by the machine's binary database snapshot (the
+//! vbsql codec from PR 1). The header carries the dense application
+//! index across the wire because openraft's `SnapshotMeta` only knows
+//! raw raft log ids; install seeds the machine's dense cursor from it.
+//! Builds pin the MVCC vacuum horizon for their whole duration
+//! (`VibesqlStateMachine::horizon_pin` → `Database::pin_gc_horizon`),
+//! and on durable configurations the blob is persisted via the Phase A4
+//! [`SnapshotStore`] **before** it is registered or acknowledged — the
+//! same crash-safety order as the echo machine, including the deferred
+//! post-install log purge (`DurableLogStore::purge_compacted`).
+//!
+//! Out of scope here (deliberately): server/CLI wiring of replicated
+//! writes (PostgreSQL-protocol sessions still execute against the local
+//! engine; surfacing `NotLeader` as a SQL error with redirect info is
+//! follow-on work) and leases/follower reads (B2, #5200).
+//!
+//! [`RaftStateMachine`]: openraft::storage::RaftStateMachine
+//! [`StorageError`]: openraft::StorageError
+
+#[cfg(test)]
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::io::Cursor;
+use std::path::Path;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
+
+use openraft::error::{ClientWriteError, RaftError};
+use openraft::storage::{RaftLogStorage, RaftStateMachine};
+#[cfg(test)]
+use openraft::ServerState;
+use openraft::{
+    BasicNode, Entry, EntryPayload, LogId, Raft, RaftSnapshotBuilder, SnapshotMeta, StorageError,
+    StorageIOError, StoredMembership,
+};
+
+use crate::snapshot::SnapshotHorizonPin as _;
+
+use crate::backend::{ConsensusError, LogIndex, Result, Role, Snapshot};
+use crate::cluster_config::ClusterConfig;
+use crate::durable::DurableLogStore;
+use crate::freeze;
+use crate::openraft_backend::{
+    current_timestamp_ms, initialize_membership, role_from_state, AppResponse, Bootstrap,
+    InMemoryLogStore, RaftTuning, RecoveredDurable, TypeConfig,
+};
+use crate::snapshot::SnapshotStore;
+use crate::state_machine::{deserialize_database, ApplyOutcome, TxnEntry, VibesqlStateMachine};
+
+// ---------------------------------------------------------------------------
+// Snapshot payload framing: dense index header + vbsql database blob
+// ---------------------------------------------------------------------------
+
+/// Frame the machine's snapshot for the engine: 8-byte LE dense
+/// application index, then the binary database payload.
+fn encode_mvcc_snapshot(last_included_index: LogIndex, db_payload: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(8 + db_payload.len());
+    buf.extend_from_slice(&last_included_index.to_le_bytes());
+    buf.extend_from_slice(db_payload);
+    buf
+}
+
+/// Split an engine-level snapshot payload back into `(dense index,
+/// database payload)`. The database payload itself is validated by the
+/// machine's decoder before anything mutates.
+fn decode_mvcc_snapshot(data: &[u8]) -> std::result::Result<(LogIndex, &[u8]), String> {
+    if data.len() < 8 {
+        return Err(format!(
+            "MVCC snapshot payload is {} bytes — smaller than its 8-byte dense-index header",
+            data.len()
+        ));
+    }
+    let dense = LogIndex::from_le_bytes(data[..8].try_into().expect("8-byte slice"));
+    Ok((dense, &data[8..]))
+}
+
+// ---------------------------------------------------------------------------
+// The mounted state machine
+// ---------------------------------------------------------------------------
+
+/// A registered engine-level snapshot (framed payload + raft meta).
+#[derive(Debug, Clone)]
+struct StoredMvccSnapshot {
+    meta: SnapshotMeta<u64, BasicNode>,
+    /// Framed payload (dense-index header + vbsql blob).
+    data: Vec<u8>,
+}
+
+/// Raft-level bookkeeping the engine needs alongside the database state.
+#[derive(Debug, Default)]
+struct MvccSmInner {
+    /// Raw raft log id of the last applied entry (protocol entries
+    /// included) — what [`RaftStateMachine::applied_state`] reports.
+    last_applied: Option<LogId<u64>>,
+    last_membership: StoredMembership<u64, BasicNode>,
+    /// Monotonic snapshot counter (uniquified with a timestamp in the
+    /// snapshot id, since this counter restarts with the process).
+    snapshot_seq: u64,
+    current_snapshot: Option<StoredMvccSnapshot>,
+}
+
+/// [`VibesqlStateMachine`] mounted as openraft's [`RaftStateMachine`]
+/// (+ [`RaftSnapshotBuilder`]). See the module docs for the index
+/// mapping, the fatal-apply halt, and the snapshot framing.
+///
+/// Cloning shares the underlying state (it is a handle), as openraft
+/// expects from `get_snapshot_builder`. The `inner` mutex is held across
+/// each whole apply batch *and* the snapshot capture, so a concurrently
+/// built snapshot can never observe a raft meta / database pair from two
+/// different instants (lock order is always `inner` → machine; nothing
+/// takes them in the reverse order).
+#[derive(Debug, Clone)]
+pub(crate) struct MvccStateMachine {
+    machine: VibesqlStateMachine,
+    inner: Arc<Mutex<MvccSmInner>>,
+    /// Durable persistence for built/installed snapshots (`None` for
+    /// in-memory configurations).
+    store: Option<Arc<SnapshotStore>>,
+    /// Durable raft log, for the deferred post-install purge record
+    /// (see `DurableLogStore::purge_compacted`).
+    log_store: Option<DurableLogStore>,
+    /// The reason this node halted (a fatal apply), if it did. Never
+    /// cleared: a halted node must be restarted to resync.
+    fatal: Arc<Mutex<Option<String>>>,
+    /// Test-only failure injection: the next apply of the entry at this
+    /// **dense** index fails fatally (as if the executor had hit a
+    /// node-local resource error), exercising the halt path on one node
+    /// without poisoning the replicated log for its peers.
+    #[cfg(test)]
+    inject_fatal_at: Arc<Mutex<Option<LogIndex>>>,
+}
+
+impl MvccStateMachine {
+    /// A fresh machine over an empty in-memory database, with in-memory
+    /// snapshots.
+    fn volatile() -> Self {
+        Self {
+            machine: VibesqlStateMachine::new(),
+            inner: Arc::default(),
+            store: None,
+            log_store: None,
+            fatal: Arc::default(),
+            #[cfg(test)]
+            inject_fatal_at: Arc::default(),
+        }
+    }
+
+    /// A fresh machine that persists built/installed snapshots through
+    /// `store` and records deferred install purges in `log_store`.
+    fn durable(store: Arc<SnapshotStore>, log_store: DurableLogStore) -> Self {
+        Self { store: Some(store), log_store: Some(log_store), ..Self::volatile() }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, MvccSmInner> {
+        self.inner.lock().expect("mvcc raft state machine mutex poisoned")
+    }
+
+    /// Seed this (fresh) machine from a durable snapshot recovered off
+    /// disk, before the Raft core starts: database state, dense index,
+    /// raw `last_applied`, and membership all resume from the snapshot,
+    /// and openraft then replays only the log suffix above
+    /// `meta.last_log_id`.
+    fn seed_from_loaded(&self, meta: SnapshotMeta<u64, BasicNode>, data: Vec<u8>) -> Result<()> {
+        let (dense, db_payload) =
+            decode_mvcc_snapshot(&data).map_err(ConsensusError::SnapshotCodec)?;
+        let db = deserialize_database(db_payload)?;
+        let mut inner = self.lock();
+        self.machine.install_decoded(db, dense)?;
+        inner.last_applied = meta.last_log_id;
+        inner.last_membership = meta.last_membership.clone();
+        inner.current_snapshot = Some(StoredMvccSnapshot { meta, data });
+        Ok(())
+    }
+
+    /// Record the fatal reason and build the [`StorageError`] that halts
+    /// the node: openraft treats a storage error from `apply` as fatal —
+    /// the core shuts down *without* acknowledging the entry, so
+    /// `last_applied` (engine and machine alike) never advances past it.
+    /// The reason survives on the handle for operators/tests
+    /// ([`MvccRaftNode::fatal_reason`]) and rides inside the error the
+    /// engine logs and returns to in-flight `client_write`s.
+    fn halt(&self, log_id: LogId<u64>, reason: String) -> StorageError<u64> {
+        let reason = format!(
+            "halting this node: fatal apply at raft log id {log_id} — {reason} (restart the \
+             node to resync via snapshot install + log replay; recording this as a rejection \
+             would silently diverge replicas)"
+        );
+        let mut fatal = self.fatal.lock().expect("fatal reason mutex poisoned");
+        if fatal.is_none() {
+            *fatal = Some(reason.clone());
+        }
+        StorageError::IO { source: StorageIOError::apply(log_id, &std::io::Error::other(reason)) }
+    }
+
+    fn fatal_reason(&self) -> Option<String> {
+        self.fatal.lock().expect("fatal reason mutex poisoned").clone()
+    }
+}
+
+impl RaftSnapshotBuilder<TypeConfig> for MvccStateMachine {
+    async fn build_snapshot(
+        &mut self,
+    ) -> std::result::Result<openraft::Snapshot<TypeConfig>, StorageError<u64>> {
+        // Pin the MVCC vacuum horizon for the whole build — acquired
+        // before any state is read, released (guard drop) only after the
+        // blob is built, persisted, and registered, so `vacuum_mvcc`
+        // cannot reclaim row versions out from under it. (The machine's
+        // own `snapshot()` briefly takes a nested pin too; pins stack.)
+        let _horizon_pin = self.machine.horizon_pin().acquire();
+
+        // Capture the raft meta and the database state atomically: the
+        // `inner` lock is held across both (apply also holds it across
+        // each batch), so the dense index inside `data` always matches
+        // `meta.last_log_id`.
+        let (meta, data) = {
+            let mut inner = self.lock();
+            let snapshot = self.machine.snapshot().map_err(|e| StorageError::IO {
+                source: StorageIOError::write_state_machine(&std::io::Error::other(e.to_string())),
+            })?;
+            let data = encode_mvcc_snapshot(snapshot.last_included_index, &snapshot.data);
+            inner.snapshot_seq += 1;
+            let meta = SnapshotMeta {
+                last_log_id: inner.last_applied,
+                last_membership: inner.last_membership.clone(),
+                snapshot_id: format!(
+                    "mvcc-{}-{}-{}",
+                    inner.last_applied.map_or(0, |id| id.index),
+                    inner.snapshot_seq,
+                    current_timestamp_ms(),
+                ),
+            };
+            (meta, data)
+        };
+
+        // Persist BEFORE registering: openraft must never see (and purge
+        // against) a snapshot that is not yet durable.
+        if let Some(store) = &self.store {
+            store.save(&meta, &data).map_err(|e| StorageError::IO {
+                source: StorageIOError::write_snapshot(Some(meta.signature()), &e),
+            })?;
+        }
+
+        self.lock().current_snapshot =
+            Some(StoredMvccSnapshot { meta: meta.clone(), data: data.clone() });
+
+        Ok(openraft::Snapshot { meta, snapshot: Box::new(Cursor::new(data)) })
+        // `_horizon_pin` drops here: the horizon was held across read,
+        // persistence, and registration.
+    }
+}
+
+impl RaftStateMachine<TypeConfig> for MvccStateMachine {
+    type SnapshotBuilder = Self;
+
+    async fn applied_state(
+        &mut self,
+    ) -> std::result::Result<
+        (Option<LogId<u64>>, StoredMembership<u64, BasicNode>),
+        StorageError<u64>,
+    > {
+        let inner = self.lock();
+        Ok((inner.last_applied, inner.last_membership.clone()))
+    }
+
+    async fn apply<I>(
+        &mut self,
+        entries: I,
+    ) -> std::result::Result<Vec<AppResponse>, StorageError<u64>>
+    where
+        I: IntoIterator<Item = Entry<TypeConfig>> + Send,
+        I::IntoIter: Send,
+    {
+        // Held across the whole batch so a concurrent snapshot build
+        // never sees raft meta and database state from two different
+        // instants. No `.await` happens under the guard.
+        let mut inner = self.lock();
+        let mut responses = Vec::new();
+        for entry in entries {
+            let response = match entry.payload {
+                // Protocol entries advance only the raw cursor: they do
+                // not consume a dense application index, which is what
+                // keeps dense indices (= MVCC commit timestamps)
+                // identical on every replica across leader changes.
+                EntryPayload::Blank => {
+                    inner.last_applied = Some(entry.log_id);
+                    AppResponse::Protocol
+                }
+                EntryPayload::Membership(membership) => {
+                    inner.last_applied = Some(entry.log_id);
+                    inner.last_membership = StoredMembership::new(Some(entry.log_id), membership);
+                    AppResponse::Protocol
+                }
+                EntryPayload::Normal(data) => {
+                    let txn: TxnEntry = match serde_json::from_slice(&data) {
+                        Ok(txn) => txn,
+                        // Undecodable payloads indicate proposer/applier
+                        // version skew, the same class as a frozen-site
+                        // mismatch: halt rather than guess (halting
+                        // everywhere is an outage; guessing wrong is
+                        // divergence).
+                        Err(e) => {
+                            return Err(self.halt(
+                                entry.log_id,
+                                format!("replicated entry payload failed to decode: {e}"),
+                            ))
+                        }
+                    };
+                    let dense = self.machine.last_applied() + 1;
+
+                    #[cfg(test)]
+                    {
+                        let mut inject =
+                            self.inject_fatal_at.lock().expect("fatal injection mutex poisoned");
+                        if *inject == Some(dense) {
+                            *inject = None;
+                            return Err(self.halt(
+                                entry.log_id,
+                                format!(
+                                    "injected node-local apply failure at dense index {dense} \
+                                     (test hook)"
+                                ),
+                            ));
+                        }
+                    }
+
+                    match self.machine.apply(dense, &txn) {
+                        Ok(outcome) => {
+                            inner.last_applied = Some(entry.log_id);
+                            AppResponse::Mvcc { index: dense, outcome }
+                        }
+                        // FatalApply (possibly node-local failure) and
+                        // Backend (gap/protocol violation) alike: the
+                        // machine did not consume the index, and neither
+                        // may openraft — halt.
+                        Err(e) => {
+                            return Err(self.halt(entry.log_id, format!("dense index {dense}: {e}")))
+                        }
+                    }
+                }
+            };
+            responses.push(response);
+        }
+        Ok(responses)
+    }
+
+    async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
+        self.clone()
+    }
+
+    async fn begin_receiving_snapshot(
+        &mut self,
+    ) -> std::result::Result<Box<Cursor<Vec<u8>>>, StorageError<u64>> {
+        Ok(Box::new(Cursor::new(Vec::new())))
+    }
+
+    /// Replace this node's database from a received snapshot. The whole
+    /// payload is decoded and validated **before** anything is persisted
+    /// or mutated (a corrupt stream must neither half-install nor leave
+    /// a corrupt durable file), and on durable configurations the blob
+    /// is persisted — and the deferred post-install log purge recorded —
+    /// **before** the install is acknowledged, exactly like the echo
+    /// machine (Phase A4 crash-safety order).
+    async fn install_snapshot(
+        &mut self,
+        meta: &SnapshotMeta<u64, BasicNode>,
+        snapshot: Box<Cursor<Vec<u8>>>,
+    ) -> std::result::Result<(), StorageError<u64>> {
+        let data = snapshot.into_inner();
+        let codec_err = |e: String| StorageError::IO {
+            source: StorageIOError::write_snapshot(
+                Some(meta.signature()),
+                &std::io::Error::new(std::io::ErrorKind::InvalidData, e),
+            ),
+        };
+        let (dense, db_payload) = decode_mvcc_snapshot(&data).map_err(codec_err)?;
+        let db = deserialize_database(db_payload).map_err(|e| codec_err(e.to_string()))?;
+
+        if let Some(store) = &self.store {
+            store.save(meta, &data).map_err(|e| StorageError::IO {
+                source: StorageIOError::write_snapshot(Some(meta.signature()), &e),
+            })?;
+            // Record the log purge openraft issued before this snapshot
+            // was durable (deferred by the log store; see the echo
+            // machine's install for the full rationale and the
+            // crash-window repair in `RecoveredDurable::open`).
+            if let (Some(log_store), Some(last)) = (&self.log_store, meta.last_log_id) {
+                log_store.purge_compacted(last).map_err(|e| StorageError::IO {
+                    source: StorageIOError::write_snapshot(Some(meta.signature()), &e),
+                })?;
+            }
+        }
+
+        let mut inner = self.lock();
+        self.machine.install_decoded(db, dense).map_err(|e| codec_err(e.to_string()))?;
+        inner.last_applied = meta.last_log_id;
+        inner.last_membership = meta.last_membership.clone();
+        inner.current_snapshot = Some(StoredMvccSnapshot { meta: meta.clone(), data });
+        Ok(())
+    }
+
+    async fn get_current_snapshot(
+        &mut self,
+    ) -> std::result::Result<Option<openraft::Snapshot<TypeConfig>>, StorageError<u64>> {
+        let inner = self.lock();
+        Ok(inner.current_snapshot.as_ref().map(|s| openraft::Snapshot {
+            meta: s.meta.clone(),
+            snapshot: Box::new(Cursor::new(s.data.clone())),
+        }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The node
+// ---------------------------------------------------------------------------
+
+/// One voter of a Raft cluster whose state machine is a real MVCC
+/// database: replicated writes flow leader → quorum → apply-on-every-
+/// voter, with commit_ts = dense log index (Raft Phase B1, #5199, PR 2).
+///
+/// Writes ([`execute_replicated`](Self::execute_replicated) /
+/// [`execute_replicated_txn`](Self::execute_replicated_txn)) are
+/// accepted only on the leader — anywhere else they fail fast with
+/// [`ConsensusError::NotLeader`] and a leader hint — and resolve only
+/// after the entry is committed and applied locally, so a session can
+/// read its own write. Reads ([`query`](Self::query)) are local
+/// (leader-lease/follower-read semantics are B2, #5200).
+///
+/// This is the multi-node successor of the PR 1 harness
+/// (`ReplicatedDb`): same entry type, same freeze-at-propose, same
+/// machine — but apply happens inside openraft's state-machine worker
+/// instead of an external catch-up loop. Server/CLI wiring is follow-on
+/// work (see the module docs).
+pub struct MvccRaftNode {
+    raft: Raft<TypeConfig>,
+    sm: MvccStateMachine,
+    metrics: tokio::sync::watch::Receiver<openraft::RaftMetrics<u64, BasicNode>>,
+    /// Accept-loop task of the TCP transport (`None` for channel-network
+    /// configurations). Aborted on shutdown and on drop.
+    listener_task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl Drop for MvccRaftNode {
+    fn drop(&mut self) {
+        if let Some(task) = &self.listener_task {
+            task.abort();
+        }
+    }
+}
+
+impl Debug for MvccRaftNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MvccRaftNode")
+            .field("role", &self.role())
+            .field("last_applied", &self.last_applied())
+            .finish_non_exhaustive()
+    }
+}
+
+impl MvccRaftNode {
+    /// Boot one voter of a **TCP-connected MVCC cluster** with an
+    /// in-memory Raft log. Prefer
+    /// [`join_tcp_cluster_with_data_dir`](Self::join_tcp_cluster_with_data_dir)
+    /// anywhere a restart must not forget the log or vote.
+    ///
+    /// Like the echo backend's cluster constructors, this does **not**
+    /// wait for an election: the caller awaits leadership (e.g. by
+    /// polling [`role`](Self::role) / [`current_leader`](Self::current_leader)
+    /// with a bounded timeout). Must be called from within a tokio
+    /// runtime.
+    pub async fn join_tcp_cluster(node_id: u64, config: &ClusterConfig) -> Result<Self> {
+        Self::join_tcp(
+            node_id,
+            config,
+            InMemoryLogStore::default(),
+            MvccStateMachine::volatile(),
+            Bootstrap::Initialize,
+            RaftTuning::default(),
+        )
+        .await
+    }
+
+    /// Like [`join_tcp_cluster`](Self::join_tcp_cluster), but the node's
+    /// Raft log, vote, and snapshots are persisted under `dir` (created
+    /// if absent) and recovered on restart — snapshot first, then log
+    /// replay, with the same loss/tampering cross-checks as the echo
+    /// backend.
+    pub async fn join_tcp_cluster_with_data_dir(
+        node_id: u64,
+        config: &ClusterConfig,
+        dir: impl AsRef<Path>,
+    ) -> Result<Self> {
+        Self::join_tcp_cluster_with_data_dir_tuned(node_id, config, dir, RaftTuning::default())
+            .await
+    }
+
+    /// Like
+    /// [`join_tcp_cluster_with_data_dir`](Self::join_tcp_cluster_with_data_dir),
+    /// with explicit snapshot/retention/transfer tuning — see
+    /// [`RaftTuning`].
+    pub async fn join_tcp_cluster_with_data_dir_tuned(
+        node_id: u64,
+        config: &ClusterConfig,
+        dir: impl AsRef<Path>,
+        tuning: RaftTuning,
+    ) -> Result<Self> {
+        let (log_store, sm, bootstrap) = Self::open_durable(dir.as_ref())?;
+        Self::join_tcp(node_id, config, log_store, sm, bootstrap, tuning).await
+    }
+
+    /// Open (or create) the durable artifacts under `dir` and seed a
+    /// state machine from the latest durable snapshot, if any.
+    fn open_durable(dir: &Path) -> Result<(DurableLogStore, MvccStateMachine, Bootstrap)> {
+        let raw = RecoveredDurable::open(dir)?;
+        let sm = MvccStateMachine::durable(Arc::clone(&raw.snapshot_store), raw.log_store.clone());
+        if let Some(loaded) = raw.loaded {
+            sm.seed_from_loaded(loaded.meta, loaded.data).map_err(|e| {
+                ConsensusError::Backend(format!(
+                    "failed to recover durable MVCC snapshot in {}: {e}",
+                    dir.display()
+                ))
+            })?;
+        }
+        // Cluster members do not wait for local replay: convergence is a
+        // cluster-level outcome the caller awaits.
+        let bootstrap = if raw.log_has_state {
+            Bootstrap::Recover { last_log_index: None }
+        } else {
+            Bootstrap::Initialize
+        };
+        Ok((raw.log_store, sm, bootstrap))
+    }
+
+    async fn join_tcp<LS>(
+        node_id: u64,
+        config: &ClusterConfig,
+        log_store: LS,
+        sm: MvccStateMachine,
+        bootstrap: Bootstrap,
+        tuning: RaftTuning,
+    ) -> Result<Self>
+    where
+        LS: RaftLogStorage<TypeConfig>,
+    {
+        let listen_addr = config.addr(node_id).ok_or_else(|| {
+            ConsensusError::Config(format!("node {node_id} is not in the cluster config"))
+        })?;
+        // Bind before booting the core so a peer that initialized first
+        // can reach this node as soon as its Raft exists.
+        let listener = crate::tcp::bind_listener(listen_addr).await.map_err(|e| {
+            ConsensusError::Backend(format!(
+                "failed to bind consensus listener on {listen_addr}: {e}"
+            ))
+        })?;
+
+        let network = crate::tcp::TcpNetworkFactory::new(config);
+        let mut node = Self::boot(node_id, network, log_store, sm, tuning).await?;
+        node.listener_task = Some(crate::tcp::spawn_listener(node.raft.clone(), listener));
+
+        initialize_membership(&node.raft, config.membership(), bootstrap).await?;
+        Ok(node)
+    }
+
+    /// Spawn the Raft core over `sm`: storage + state machine + network,
+    /// no membership yet.
+    async fn boot<LS, NF>(
+        node_id: u64,
+        network: NF,
+        log_store: LS,
+        sm: MvccStateMachine,
+        tuning: RaftTuning,
+    ) -> Result<Self>
+    where
+        LS: RaftLogStorage<TypeConfig>,
+        NF: openraft::RaftNetworkFactory<TypeConfig>,
+    {
+        let config = Arc::new(tuning.raft_config()?);
+        let raft = Raft::new(node_id, config, network, log_store, sm.clone())
+            .await
+            .map_err(|e| ConsensusError::Backend(format!("failed to start raft core: {e}")))?;
+        let metrics = raft.metrics();
+        Ok(Self { raft, sm, metrics, listener_task: None })
+    }
+
+    /// Execute one autocommit write statement through consensus. See
+    /// [`execute_replicated_txn`](Self::execute_replicated_txn).
+    pub async fn execute_replicated(&self, sql: &str) -> Result<(LogIndex, ApplyOutcome)> {
+        self.execute_replicated_txn(&[sql]).await
+    }
+
+    /// Execute a multi-statement transaction through consensus: the
+    /// whole batch is proposed as **one** [`TxnEntry`] (one log entry
+    /// per committed transaction) and applied atomically on every voter
+    /// with commit_ts = the entry's dense log index.
+    ///
+    /// Non-deterministic expressions are **frozen here, at propose
+    /// time, on the leader** (#5377); statements whose nondeterminism
+    /// cannot be frozen fail before consuming a log index. On a
+    /// non-leader this fails fast with [`ConsensusError::NotLeader`]
+    /// (leader hint attached when known) before evaluating anything.
+    ///
+    /// Resolves once the entry is committed on a quorum **and applied
+    /// locally** — the caller can immediately read its own write. A
+    /// rejected entry (failed statement, rolled back identically on
+    /// every replica) is an `Ok` with [`ApplyOutcome::Rejected`].
+    pub async fn execute_replicated_txn(
+        &self,
+        statements: &[&str],
+    ) -> Result<(LogIndex, ApplyOutcome)> {
+        // Fast-path leader check: don't evaluate volatile expressions
+        // (freeze draws random values / reads the clock) on a node whose
+        // proposal is going to be refused anyway. Races are harmless —
+        // `client_write` itself enforces leadership authoritatively.
+        if self.role() != Role::Leader {
+            return Err(ConsensusError::NotLeader { leader_hint: self.current_leader() });
+        }
+        let mut frozen = Vec::with_capacity(statements.len());
+        for sql in statements {
+            frozen.push(freeze::freeze_statement(sql).map_err(|e| {
+                ConsensusError::Backend(format!("statement cannot be replicated: {e}"))
+            })?);
+        }
+        let entry =
+            TxnEntry::frozen_batch(statements.iter().map(|s| s.to_string()).collect(), frozen);
+        self.propose_entry(entry).await
+    }
+
+    /// Propose a pre-built entry. Internal: the public surface freezes
+    /// statements first (tests use this to exercise the apply-side
+    /// defenses with hand-crafted entries).
+    async fn propose_entry(&self, entry: TxnEntry) -> Result<(LogIndex, ApplyOutcome)> {
+        let payload =
+            serde_json::to_vec(&entry).map_err(|e| ConsensusError::Backend(e.to_string()))?;
+        let response =
+            self.raft.client_write(payload).await.map_err(|e| self.map_write_error(e))?;
+        match response.data {
+            AppResponse::Mvcc { index, outcome } => Ok((index, outcome)),
+            other => Err(ConsensusError::Backend(format!(
+                "client write resolved with an unexpected apply response: {other:?}"
+            ))),
+        }
+    }
+
+    fn map_write_error(
+        &self,
+        e: RaftError<u64, ClientWriteError<u64, BasicNode>>,
+    ) -> ConsensusError {
+        match e {
+            RaftError::APIError(ClientWriteError::ForwardToLeader(forward)) => {
+                ConsensusError::NotLeader { leader_hint: forward.leader_id }
+            }
+            other => {
+                // A halted node surfaces its fatal reason instead of the
+                // engine's shutdown noise: the write failed because this
+                // node must not apply anything further.
+                if let Some(reason) = self.fatal_reason() {
+                    ConsensusError::FatalApply(reason)
+                } else {
+                    ConsensusError::Backend(other.to_string())
+                }
+            }
+        }
+    }
+
+    /// Run a read-only SELECT against the locally applied state (reads
+    /// are local, not replicated — see [`VibesqlStateMachine::query`]).
+    pub fn query(&self, sql: &str) -> Result<Vec<Vec<vibesql_types::SqlValue>>> {
+        self.sm.machine.query(sql)
+    }
+
+    /// This node's current role in the consensus group.
+    pub fn role(&self) -> Role {
+        role_from_state(self.metrics.borrow().state)
+    }
+
+    /// The node this one currently believes leads the cluster (`None`
+    /// until it has heard from — or become — a leader).
+    pub fn current_leader(&self) -> Option<u64> {
+        self.metrics.borrow().current_leader
+    }
+
+    /// Dense application index of the last entry applied to the local
+    /// database (`0` if none) — also the MVCC commit timestamp of the
+    /// most recent committed transaction.
+    pub fn last_applied(&self) -> LogIndex {
+        self.sm.machine.last_applied()
+    }
+
+    /// The reason this node halted on a fatal apply, if it did. A halted
+    /// node acknowledges nothing further; restart it to resync via
+    /// snapshot install + log replay.
+    pub fn fatal_reason(&self) -> Option<String> {
+        self.sm.fatal_reason()
+    }
+
+    /// Raw raft index of the last snapshot this node knows of (built
+    /// locally or installed from the leader); `None` until one exists.
+    pub fn snapshot_log_index(&self) -> Option<u64> {
+        self.metrics.borrow().snapshot.map(|id| id.index)
+    }
+
+    /// Raw raft index through which this node's log has been purged
+    /// (`None` until the first purge). Never exceeds the durable
+    /// snapshot.
+    pub fn purged_log_index(&self) -> Option<u64> {
+        self.metrics.borrow().purged.map(|id| id.index)
+    }
+
+    /// Capture a snapshot through the engine's real pipeline (trigger →
+    /// builder → registration), returning the database-level artifact:
+    /// `last_included_index` is the **dense** application index and
+    /// `data` the machine's binary database payload — the same shape
+    /// [`VibesqlStateMachine::snapshot`] produces, so
+    /// [`VibesqlStateMachine::from_snapshot`] can restore it.
+    pub async fn snapshot(&self) -> Result<Snapshot> {
+        let Some(target) = self.metrics.borrow().last_applied else {
+            // Nothing applied (not even membership): nothing for the
+            // engine to build at. Unreachable through the public
+            // constructors once the cluster has initialized.
+            return self.sm.machine.snapshot();
+        };
+
+        self.raft
+            .trigger()
+            .snapshot()
+            .await
+            .map_err(|e| ConsensusError::Backend(format!("failed to trigger snapshot: {e}")))?;
+        self.raft
+            .wait(Some(Duration::from_secs(10)))
+            .metrics(move |m| m.snapshot >= Some(target), "snapshot build")
+            .await
+            .map_err(|e| ConsensusError::Backend(format!("snapshot build did not settle: {e}")))?;
+
+        let inner = self.sm.lock();
+        let stored = inner.current_snapshot.as_ref().ok_or_else(|| {
+            ConsensusError::Backend(
+                "snapshot build settled but no snapshot is registered".to_string(),
+            )
+        })?;
+        let (dense, db_payload) =
+            decode_mvcc_snapshot(&stored.data).map_err(ConsensusError::SnapshotCodec)?;
+        Ok(Snapshot { last_included_index: dense, data: db_payload.to_vec() })
+    }
+
+    /// Gracefully shut down the Raft core (and, for a TCP-clustered
+    /// node, its listener and inbound connections).
+    pub async fn shutdown(&self) -> Result<()> {
+        if let Some(task) = &self.listener_task {
+            task.abort();
+        }
+        self.raft.shutdown().await.map_err(|e| ConsensusError::Backend(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+impl MvccRaftNode {
+    /// Boot one member of an in-process channel-network cluster
+    /// (mirrors `OpenraftBackend::join_channel_cluster`).
+    pub(crate) async fn join_channel_cluster<LS>(
+        node_id: u64,
+        members: &BTreeMap<u64, BasicNode>,
+        router: &crate::network::ChannelRouter,
+        log_store: LS,
+        sm: MvccStateMachine,
+        bootstrap: Bootstrap,
+        tuning: RaftTuning,
+    ) -> Result<Self>
+    where
+        LS: RaftLogStorage<TypeConfig>,
+    {
+        let network = crate::network::ChannelNetworkFactory::new(router.clone());
+        let node = Self::boot(node_id, network, log_store, sm, tuning).await?;
+        // Register the inbound RPC loop *before* initializing, so peers
+        // that initialized first can already reach this node.
+        router.register(node_id, node.raft.clone());
+        initialize_membership(&node.raft, members.clone(), bootstrap).await?;
+        Ok(node)
+    }
+
+    /// A single-voter node with everything in memory, elected leader
+    /// before this returns — the cheapest way to exercise the mount
+    /// itself (apply plumbing, outcome surfacing, snapshot artifact).
+    pub(crate) async fn single_node() -> Result<Self> {
+        let node = Self::boot(
+            1,
+            crate::openraft_backend::NoopNetworkFactory,
+            InMemoryLogStore::default(),
+            MvccStateMachine::volatile(),
+            RaftTuning::default(),
+        )
+        .await?;
+        let members = BTreeMap::from([(1, BasicNode::default())]);
+        initialize_membership(&node.raft, members, Bootstrap::Initialize).await?;
+        node.raft
+            .wait(Some(Duration::from_secs(10)))
+            .state(ServerState::Leader, "single-node leader election")
+            .await
+            .map_err(|e| ConsensusError::Backend(format!("leader election did not settle: {e}")))?;
+        Ok(node)
+    }
+
+    /// The underlying MVCC machine, for storage-level assertions (only
+    /// the `mvcc_enabled`-gated tests inspect MVCC stamps).
+    #[cfg(feature = "mvcc_enabled")]
+    pub(crate) fn machine(&self) -> &VibesqlStateMachine {
+        &self.sm.machine
+    }
+
+    /// Arm the test-only fatal injection: the apply of the entry at this
+    /// **dense** index fails as if a node-local resource error occurred.
+    pub(crate) fn inject_fatal_at(&self, dense_index: LogIndex) {
+        *self.sm.inject_fatal_at.lock().expect("fatal injection mutex poisoned") =
+            Some(dense_index);
+    }
+
+    /// Raw raft index of the last applied entry per the **state
+    /// machine's own** bookkeeping (not the metrics channel) — what the
+    /// engine would resume from.
+    pub(crate) fn sm_raft_last_applied(&self) -> Option<u64> {
+        self.sm.lock().last_applied.map(|id| id.index)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: the Phase B1 PR 2 multi-node acceptance scenarios
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::freeze::FrozenValue;
+    use crate::network::ChannelRouter;
+    use vibesql_types::SqlValue;
+
+    /// Upper bound for any single cluster-level wait (election, catch-up,
+    /// purge). Bounded polls only — every wait fails loudly, never hangs.
+    const WAIT_TIMEOUT: Duration = Duration::from_secs(10);
+    const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+    /// Where a node keeps its Raft log + vote (and, when durable, its
+    /// snapshots) between `kill` and `restore`.
+    enum NodeStorage {
+        /// Shared handle to the killed node's in-memory store — models a
+        /// process that lost its (volatile) database but kept its log.
+        InMemory(InMemoryLogStore),
+        /// Data directory reopened on restore (durable log + snapshots).
+        Durable(TempDir),
+    }
+
+    struct TestNode {
+        /// `None` while the node is killed.
+        node: Option<MvccRaftNode>,
+        storage: NodeStorage,
+    }
+
+    /// An in-process MVCC Raft cluster wired by the channel transport.
+    struct MvccCluster {
+        router: ChannelRouter,
+        members: BTreeMap<u64, BasicNode>,
+        nodes: BTreeMap<u64, TestNode>,
+        tuning: RaftTuning,
+    }
+
+    impl MvccCluster {
+        /// Boot `n` voters with in-memory logs and fresh databases.
+        async fn new(n: u64) -> Self {
+            Self::build(n, false, RaftTuning::default()).await
+        }
+
+        /// Boot `n` voters each persisting log + snapshots in a tempdir.
+        async fn new_durable(n: u64, tuning: RaftTuning) -> Self {
+            Self::build(n, true, tuning).await
+        }
+
+        async fn build(n: u64, durable: bool, tuning: RaftTuning) -> Self {
+            let router = ChannelRouter::default();
+            let members: BTreeMap<u64, BasicNode> =
+                (1..=n).map(|id| (id, BasicNode::default())).collect();
+
+            let mut nodes = BTreeMap::new();
+            for id in 1..=n {
+                let node = if durable {
+                    let dir = TempDir::new().expect("create tempdir for durable node");
+                    let (log_store, sm, bootstrap) =
+                        MvccRaftNode::open_durable(dir.path()).expect("open durable storage");
+                    let node = MvccRaftNode::join_channel_cluster(
+                        id, &members, &router, log_store, sm, bootstrap, tuning,
+                    )
+                    .await
+                    .expect("boot durable mvcc node");
+                    TestNode { node: Some(node), storage: NodeStorage::Durable(dir) }
+                } else {
+                    let store = InMemoryLogStore::default();
+                    let node = MvccRaftNode::join_channel_cluster(
+                        id,
+                        &members,
+                        &router,
+                        store.clone(),
+                        MvccStateMachine::volatile(),
+                        Bootstrap::Initialize,
+                        tuning,
+                    )
+                    .await
+                    .expect("boot mvcc node");
+                    TestNode { node: Some(node), storage: NodeStorage::InMemory(store) }
+                };
+                nodes.insert(id, node);
+            }
+
+            Self { router, members, nodes, tuning }
+        }
+
+        fn node(&self, id: u64) -> &MvccRaftNode {
+            self.nodes
+                .get(&id)
+                .and_then(|n| n.node.as_ref())
+                .unwrap_or_else(|| panic!("node {id} is killed or unknown"))
+        }
+
+        fn live_ids(&self) -> Vec<u64> {
+            self.nodes.iter().filter(|(_, n)| n.node.is_some()).map(|(id, _)| *id).collect()
+        }
+
+        /// "Crash" a node: cut it off from the network and stop its core.
+        /// Shutdown errors are tolerated — a node that already halted on a
+        /// fatal apply has a dead core by design.
+        async fn kill(&mut self, id: u64) {
+            self.router.deregister(id);
+            let node = self
+                .nodes
+                .get_mut(&id)
+                .and_then(|n| n.node.take())
+                .unwrap_or_else(|| panic!("node {id} is already killed or unknown"));
+            let _ = node.shutdown().await;
+        }
+
+        /// Restart a killed node from its retained storage with a **fresh
+        /// database**: in-memory nodes replay the kept log from scratch;
+        /// durable nodes recover snapshot-first then replay the suffix.
+        async fn restore(&mut self, id: u64) {
+            let entry = self.nodes.get_mut(&id).expect("unknown node");
+            assert!(entry.node.is_none(), "node {id} is not killed");
+            let node = match &entry.storage {
+                NodeStorage::InMemory(store) => {
+                    MvccRaftNode::join_channel_cluster(
+                        id,
+                        &self.members,
+                        &self.router,
+                        store.clone(),
+                        MvccStateMachine::volatile(),
+                        Bootstrap::Recover { last_log_index: None },
+                        self.tuning,
+                    )
+                    .await
+                }
+                NodeStorage::Durable(dir) => {
+                    let (log_store, sm, bootstrap) =
+                        MvccRaftNode::open_durable(dir.path()).expect("reopen durable storage");
+                    MvccRaftNode::join_channel_cluster(
+                        id,
+                        &self.members,
+                        &self.router,
+                        log_store,
+                        sm,
+                        bootstrap,
+                        self.tuning,
+                    )
+                    .await
+                }
+            };
+            entry.node = Some(node.expect("restore killed node"));
+        }
+
+        async fn wait_for_leader(&self) -> u64 {
+            self.wait_until("a leader to be elected", || {
+                self.live_ids().into_iter().find(|id| self.node(*id).role() == Role::Leader)
+            })
+            .await
+        }
+
+        /// Wait until node `id` has applied the **dense** index `idx`.
+        async fn wait_for_apply(&self, id: u64, idx: LogIndex) {
+            self.wait_until(&format!("node {id} to apply dense index {idx}"), || {
+                (self.node(id).last_applied() >= idx).then_some(())
+            })
+            .await;
+        }
+
+        /// Execute on whoever currently leads, re-resolving leadership if
+        /// an election moved it mid-call.
+        async fn execute_on_leader(&self, sql: &str) -> (LogIndex, ApplyOutcome) {
+            let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+            loop {
+                let leader = self.wait_for_leader().await;
+                match self.node(leader).execute_replicated(sql).await {
+                    Ok(result) => return result,
+                    Err(ConsensusError::NotLeader { .. }) => {
+                        assert!(
+                            tokio::time::Instant::now() < deadline,
+                            "timed out executing {sql:?}: leadership never settled"
+                        );
+                    }
+                    Err(other) => panic!("execute of {sql:?} failed: {other:?}"),
+                }
+            }
+        }
+
+        /// Assert every live node returns identical rows for `sql`.
+        fn assert_converged(&self, sql: &str) -> Vec<Vec<SqlValue>> {
+            let ids = self.live_ids();
+            let reference = self.node(ids[0]).query(sql).expect("query reference node");
+            for id in &ids[1..] {
+                assert_eq!(
+                    self.node(*id).query(sql).expect("query node"),
+                    reference,
+                    "node {id} diverged from node {} on {sql:?}",
+                    ids[0]
+                );
+            }
+            reference
+        }
+
+        async fn wait_until<T>(&self, what: &str, mut probe: impl FnMut() -> Option<T>) -> T {
+            let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+            loop {
+                if let Some(value) = probe() {
+                    return value;
+                }
+                assert!(
+                    tokio::time::Instant::now() < deadline,
+                    "timed out after {WAIT_TIMEOUT:?} waiting for {what}"
+                );
+                tokio::time::sleep(POLL_INTERVAL).await;
+            }
+        }
+    }
+
+    fn follower_of(cluster: &MvccCluster, leader: u64) -> u64 {
+        cluster
+            .live_ids()
+            .into_iter()
+            .find(|id| *id != leader)
+            .expect("cluster has at least one follower")
+    }
+
+    /// The mount itself, on a single voter: writes flow client_write →
+    /// commit → apply-inside-the-engine; outcomes (incl. deterministic
+    /// rejection) surface through the response; the snapshot artifact is
+    /// the machine's own codec.
+    #[tokio::test]
+    async fn single_node_mount_applies_rejects_and_snapshots() {
+        let node = MvccRaftNode::single_node().await.unwrap();
+
+        let (idx, outcome) = node
+            .execute_replicated("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+            .await
+            .unwrap();
+        assert_eq!((idx, outcome), (1, ApplyOutcome::Applied { rows_affected: 0 }));
+
+        let (idx, outcome) =
+            node.execute_replicated("INSERT INTO users VALUES (1, 'alice')").await.unwrap();
+        assert_eq!((idx, outcome), (2, ApplyOutcome::Applied { rows_affected: 1 }));
+
+        // The session reads its own write immediately after the propose.
+        assert_eq!(
+            node.query("SELECT name FROM users").unwrap(),
+            vec![vec![SqlValue::Varchar("alice".into())]]
+        );
+
+        // A deterministic failure is a *rejected entry*, not an error: it
+        // consumed dense index 3 and surfaced through the apply response.
+        let (idx, outcome) =
+            node.execute_replicated("INSERT INTO users VALUES (1, 'dupe')").await.unwrap();
+        assert_eq!(idx, 3);
+        assert!(matches!(outcome, ApplyOutcome::Rejected { .. }), "got: {outcome:?}");
+        assert_eq!(node.last_applied(), 3);
+
+        node.execute_replicated("INSERT INTO users VALUES (2, 'bob')").await.unwrap();
+
+        // The engine-built snapshot artifact restores into a standalone
+        // machine byte-identically.
+        let snapshot = node.snapshot().await.unwrap();
+        assert_eq!(snapshot.last_included_index, 4);
+        let restored = VibesqlStateMachine::from_snapshot(&snapshot).unwrap();
+        assert_eq!(
+            restored.query("SELECT id, name FROM users ORDER BY id").unwrap(),
+            node.query("SELECT id, name FROM users ORDER BY id").unwrap()
+        );
+        assert_eq!(restored.last_applied(), 4);
+    }
+
+    /// 3-node acceptance: leader INSERT/UPDATE/DELETE replicate to every
+    /// voter — same rows, and (with MVCC on) the same `xmin` stamps,
+    /// because commit_ts = dense log index on every replica.
+    #[tokio::test]
+    async fn three_node_dml_converges_with_identical_commit_timestamps() {
+        let cluster = MvccCluster::new(3).await;
+
+        for (expected_idx, sql) in [
+            (1, "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)"),
+            (2, "INSERT INTO users VALUES (1, 'alice')"),
+            (3, "INSERT INTO users VALUES (2, 'bob')"),
+            (4, "UPDATE users SET name = 'bobby' WHERE id = 2"),
+            (5, "DELETE FROM users WHERE id = 1"),
+        ] {
+            let (idx, outcome) = cluster.execute_on_leader(sql).await;
+            assert_eq!(idx, expected_idx, "{sql}");
+            assert!(matches!(outcome, ApplyOutcome::Applied { .. }), "{sql}: {outcome:?}");
+        }
+
+        for id in 1..=3 {
+            cluster.wait_for_apply(id, 5).await;
+        }
+        let rows = cluster.assert_converged("SELECT id, name FROM users ORDER BY id");
+        assert_eq!(rows, vec![vec![SqlValue::Integer(2), SqlValue::Varchar("bobby".into())]]);
+
+        // commit_ts = dense log index, identical on every node: bobby's
+        // live version was written by entry 4 everywhere.
+        #[cfg(feature = "mvcc_enabled")]
+        for id in 1..=3 {
+            cluster.node(id).machine().with_db(|db| {
+                let table = db.get_table("users").unwrap();
+                let bobby = table
+                    .scan()
+                    .iter()
+                    .find(|r| r.values[0] == SqlValue::Integer(2) && r.xmax.is_none())
+                    .expect("bobby's live version")
+                    .xmin;
+                assert_eq!(bobby, 4, "node {id}: xmin must equal the entry's dense log index");
+            });
+        }
+    }
+
+    /// Freeze determinism multi-node (#5377 end-to-end): volatile
+    /// expressions are evaluated once on the leader and every voter
+    /// stores the identical drawn values.
+    #[tokio::test]
+    async fn nondeterministic_sql_converges_identically_on_all_nodes() {
+        let cluster = MvccCluster::new(3).await;
+
+        cluster
+            .execute_on_leader(
+                "CREATE TABLE t (id INTEGER PRIMARY KEY, r INTEGER, b BLOB, ts TIMESTAMP, d DATE)",
+            )
+            .await;
+        let (_, outcome) = cluster
+            .execute_on_leader(
+                "INSERT INTO t VALUES (1, random(), randomblob(8), CURRENT_TIMESTAMP, curdate())",
+            )
+            .await;
+        assert_eq!(outcome, ApplyOutcome::Applied { rows_affected: 1 });
+        let (idx, outcome) =
+            cluster.execute_on_leader("INSERT INTO t (id, ts) VALUES (2, datetime('now'))").await;
+        assert_eq!(outcome, ApplyOutcome::Applied { rows_affected: 1 });
+
+        for id in 1..=3 {
+            cluster.wait_for_apply(id, idx).await;
+        }
+        let rows = cluster.assert_converged("SELECT id, r, b, ts, d FROM t ORDER BY id");
+        assert_eq!(rows.len(), 2);
+        assert_ne!(rows[0][1], SqlValue::Null, "random() must have been frozen to a value");
+        assert_ne!(rows[0][3], SqlValue::Null, "CURRENT_TIMESTAMP must have been frozen");
+    }
+
+    /// A deterministic statement failure (constraint violation) is a
+    /// *rejected entry*: it consumes its dense index on every voter, the
+    /// rejection is identical everywhere, and the cluster keeps going.
+    #[tokio::test]
+    async fn deterministic_rejection_is_identical_on_every_node() {
+        let cluster = MvccCluster::new(3).await;
+        cluster.execute_on_leader("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)").await;
+        cluster.execute_on_leader("INSERT INTO users VALUES (1, 'alice')").await;
+
+        let (idx, outcome) =
+            cluster.execute_on_leader("INSERT INTO users VALUES (1, 'dupe')").await;
+        assert_eq!(idx, 3);
+        assert!(matches!(outcome, ApplyOutcome::Rejected { .. }), "got: {outcome:?}");
+
+        // Every voter consumed the rejected entry's index...
+        for id in 1..=3 {
+            cluster.wait_for_apply(id, 3).await;
+        }
+        // ...and the log keeps numbering past it.
+        let (idx, outcome) =
+            cluster.execute_on_leader("INSERT INTO users VALUES (2, 'carol')").await;
+        assert_eq!(idx, 4);
+        assert_eq!(outcome, ApplyOutcome::Applied { rows_affected: 1 });
+
+        for id in 1..=3 {
+            cluster.wait_for_apply(id, 4).await;
+            assert_eq!(cluster.node(id).last_applied(), 4, "node {id}");
+        }
+        let rows = cluster.assert_converged("SELECT id, name FROM users ORDER BY id");
+        assert_eq!(rows.len(), 2, "the rejected entry must have applied nothing anywhere");
+    }
+
+    /// Kill the leader mid-stream: the survivors elect a new leader and
+    /// writes continue (dense indices stay contiguous — the new leader's
+    /// blank protocol entry consumes no dense index, so commit timestamps
+    /// stay aligned across replicas); the killed node restores and
+    /// converges via log replay.
+    #[tokio::test]
+    async fn killing_the_leader_keeps_writes_flowing_and_restored_node_converges() {
+        let mut cluster = MvccCluster::new(3).await;
+        let leader = cluster.wait_for_leader().await;
+
+        cluster.execute_on_leader("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)").await;
+        cluster.execute_on_leader("INSERT INTO users VALUES (1, 'alice')").await;
+        for id in 1..=3 {
+            cluster.wait_for_apply(id, 2).await;
+        }
+
+        cluster.kill(leader).await;
+        let new_leader = cluster.wait_for_leader().await;
+        assert_ne!(new_leader, leader, "the killed node cannot lead");
+
+        let (idx, _) = cluster.execute_on_leader("INSERT INTO users VALUES (2, 'bob')").await;
+        assert_eq!(idx, 3, "dense indices stay contiguous across the failover");
+        let (idx, _) = cluster.execute_on_leader("INSERT INTO users VALUES (3, 'carol')").await;
+        assert_eq!(idx, 4);
+
+        cluster.restore(leader).await;
+        cluster.wait_for_apply(leader, 4).await;
+        let rows = cluster.assert_converged("SELECT id, name FROM users ORDER BY id");
+        assert_eq!(rows.len(), 3);
+
+        // The restored node replayed the full log into a fresh database:
+        // its commit timestamps match everyone else's.
+        #[cfg(feature = "mvcc_enabled")]
+        cluster.node(leader).machine().with_db(|db| {
+            let table = db.get_table("users").unwrap();
+            let carol = table
+                .scan()
+                .iter()
+                .find(|r| r.values[0] == SqlValue::Integer(3) && r.xmax.is_none())
+                .expect("carol's live version")
+                .xmin;
+            assert_eq!(carol, 4, "replayed write keeps commit_ts = dense log index");
+        });
+    }
+
+    /// Leader-only writes: a follower fails fast with `NotLeader` and a
+    /// hint at who leads, before consuming any log index (and before
+    /// evaluating any volatile expression).
+    #[tokio::test]
+    async fn follower_writes_are_rejected_with_a_leader_hint() {
+        let cluster = MvccCluster::new(3).await;
+        let leader = cluster.wait_for_leader().await;
+        let follower = follower_of(&cluster, leader);
+
+        // Wait until the follower has heard from the leader, so the hint
+        // is deterministic rather than `None`.
+        cluster
+            .wait_until("the follower to learn who leads", || {
+                (cluster.node(follower).current_leader() == Some(leader)).then_some(())
+            })
+            .await;
+
+        let err = cluster
+            .node(follower)
+            .execute_replicated("INSERT INTO nowhere VALUES (random())")
+            .await
+            .unwrap_err();
+        match err {
+            ConsensusError::NotLeader { leader_hint } => assert_eq!(leader_hint, Some(leader)),
+            other => panic!("expected NotLeader with a hint, got: {other:?}"),
+        }
+        for id in 1..=3 {
+            assert_eq!(cluster.node(id).last_applied(), 0, "no log index may be consumed");
+        }
+    }
+
+    /// The FatalApply → halt obligation, end-to-end through the real
+    /// fatal path: an entry with a frozen-site/value count mismatch
+    /// (proposer/applier version skew) halts every node that applies it
+    /// — openraft never advances `last_applied` past it, nothing is
+    /// recorded as a rejection, and the fatal reason is retained.
+    #[tokio::test]
+    async fn poisoned_entry_halts_nodes_without_consuming_the_index() {
+        let cluster = MvccCluster::new(3).await;
+        cluster.execute_on_leader("CREATE TABLE t (id INTEGER PRIMARY KEY, r INTEGER)").await;
+        for id in 1..=3 {
+            cluster.wait_for_apply(id, 1).await;
+        }
+        let leader = cluster.wait_for_leader().await;
+        let raft_before = cluster.node(leader).sm_raft_last_applied();
+
+        // Version-skewed entry: one volatile site, two frozen values.
+        let poisoned = TxnEntry::frozen_batch(
+            vec!["INSERT INTO t VALUES (1, random())".to_string()],
+            vec![vec![FrozenValue::Integer(7), FrozenValue::Integer(8)]],
+        );
+        let err = cluster.node(leader).propose_entry(poisoned).await.unwrap_err();
+        assert!(
+            matches!(err, ConsensusError::FatalApply(_)),
+            "the write must surface the halt, got: {err:?}"
+        );
+
+        // The leader halted at apply; the surviving followers commit the
+        // entry (it reached a quorum), elect a new leader among
+        // themselves, and halt the same way when *they* apply it. The
+        // whole cluster stops — an outage, never divergence.
+        for id in 1..=3 {
+            cluster
+                .wait_until(&format!("node {id} to halt on the poisoned entry"), || {
+                    cluster.node(id).fatal_reason().map(|_| ())
+                })
+                .await;
+        }
+        for id in 1..=3 {
+            assert_eq!(
+                cluster.node(id).last_applied(),
+                1,
+                "node {id}: a fatal apply must not consume the dense index"
+            );
+            let reason = cluster.node(id).fatal_reason().unwrap();
+            assert!(reason.contains("halting this node"), "node {id}: {reason}");
+        }
+        assert_eq!(
+            cluster.node(leader).sm_raft_last_applied(),
+            raft_before,
+            "openraft must not advance last_applied past the fatal entry"
+        );
+
+        // A halted node acknowledges nothing further.
+        let err = cluster
+            .node(leader)
+            .execute_replicated("INSERT INTO t VALUES (2, 2)")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, ConsensusError::FatalApply(_) | ConsensusError::NotLeader { .. }),
+            "writes after the halt must fail, got: {err:?}"
+        );
+    }
+
+    /// A *node-local* fatal failure (injected) halts only the node that
+    /// hit it; the quorum keeps committing. Restarting the halted node
+    /// resyncs it via log replay — the documented recovery path.
+    #[tokio::test]
+    async fn injected_fatal_halts_one_node_and_restart_resyncs_it() {
+        let mut cluster = MvccCluster::new(3).await;
+        cluster.execute_on_leader("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)").await;
+        for id in 1..=3 {
+            cluster.wait_for_apply(id, 1).await;
+        }
+        let leader = cluster.wait_for_leader().await;
+        let victim = follower_of(&cluster, leader);
+        cluster.node(victim).inject_fatal_at(2);
+
+        // The quorum (leader + the other follower) applies fine.
+        let (idx, outcome) = cluster.execute_on_leader("INSERT INTO t VALUES (1, 'alive')").await;
+        assert_eq!(idx, 2);
+        assert_eq!(outcome, ApplyOutcome::Applied { rows_affected: 1 });
+
+        cluster
+            .wait_until("the victim to halt on the injected failure", || {
+                cluster.node(victim).fatal_reason().map(|_| ())
+            })
+            .await;
+        assert_eq!(
+            cluster.node(victim).last_applied(),
+            1,
+            "the halted node must not have applied past the fatal entry"
+        );
+
+        // Writes keep flowing on the healthy majority.
+        let (idx, _) = cluster.execute_on_leader("INSERT INTO t VALUES (2, 'still alive')").await;
+        assert_eq!(idx, 3);
+
+        // Restart the halted node: fresh database, kept log → full
+        // replay → convergence (snapshot+replay is exercised separately).
+        cluster.kill(victim).await;
+        cluster.restore(victim).await;
+        cluster.wait_for_apply(victim, 3).await;
+        assert!(cluster.node(victim).fatal_reason().is_none(), "restarted node is healthy");
+        let rows = cluster.assert_converged("SELECT id, v FROM t ORDER BY id");
+        assert_eq!(rows.len(), 2);
+    }
+
+    /// The snapshot path end-to-end on durable nodes: policy-driven MVCC
+    /// snapshots + log purge run past a dead follower; the restored
+    /// follower heals via chunked MVCC snapshot install (its gap is
+    /// purged, so log replay alone cannot), converges, and a subsequent
+    /// restart recovers cleanly from its own durable snapshot.
+    #[tokio::test]
+    async fn purged_follower_heals_via_mvcc_snapshot_install_and_restarts_cleanly() {
+        let tuning =
+            RaftTuning { snapshot_after_entries: 4, keep_in_log: 1, ..RaftTuning::default() };
+        let mut cluster = MvccCluster::new_durable(3, tuning).await;
+
+        cluster.execute_on_leader("CREATE TABLE kv (id INTEGER PRIMARY KEY, v TEXT)").await;
+        cluster.execute_on_leader("INSERT INTO kv VALUES (1, 'one')").await;
+        for id in 1..=3 {
+            cluster.wait_for_apply(id, 2).await;
+        }
+
+        let leader = cluster.wait_for_leader().await;
+        let follower = follower_of(&cluster, leader);
+        let follower_raw =
+            cluster.node(follower).sm_raft_last_applied().expect("follower applied something");
+        cluster.kill(follower).await;
+
+        // Push enough writes for the snapshot/purge policy to discard the
+        // dead follower's catch-up gap.
+        let mut last_dense = 0;
+        for i in 2..=12u64 {
+            let (idx, outcome) =
+                cluster.execute_on_leader(&format!("INSERT INTO kv VALUES ({i}, 'v{i}')")).await;
+            assert!(matches!(outcome, ApplyOutcome::Applied { .. }));
+            last_dense = idx;
+        }
+        cluster
+            .wait_until("the leader to purge past the dead follower", || {
+                let leader = cluster
+                    .live_ids()
+                    .into_iter()
+                    .find(|id| cluster.node(*id).role() == Role::Leader)?;
+                cluster
+                    .node(leader)
+                    .purged_log_index()
+                    .is_some_and(|purged| purged > follower_raw)
+                    .then_some(())
+            })
+            .await;
+
+        // The restored follower cannot be backfilled by log replay (its
+        // gap is purged): it must heal via MVCC snapshot install.
+        cluster.restore(follower).await;
+        cluster.wait_for_apply(follower, last_dense).await;
+        assert!(
+            cluster.node(follower).snapshot_log_index().is_some_and(|snap| snap > follower_raw),
+            "the follower must have installed a snapshot covering its purged gap"
+        );
+        cluster.assert_converged("SELECT id, v FROM kv ORDER BY id");
+
+        // Post-install writes keep the commit_ts mapping on the healed
+        // node (snapshot install seeded the dense cursor + allocator).
+        let (idx, _) = cluster.execute_on_leader("INSERT INTO kv VALUES (99, 'post')").await;
+        cluster.wait_for_apply(follower, idx).await;
+        #[cfg(feature = "mvcc_enabled")]
+        cluster.node(follower).machine().with_db(|db| {
+            let table = db.get_table("kv").unwrap();
+            let post = table
+                .scan()
+                .iter()
+                .find(|r| r.values[0] == SqlValue::Integer(99))
+                .expect("post-install row")
+                .xmin;
+            assert_eq!(post, idx, "post-install applies keep commit_ts = dense log index");
+        });
+
+        // Subsequent restart is clean: the follower recovers from its own
+        // durable snapshot + log suffix and converges again.
+        cluster.kill(follower).await;
+        cluster.restore(follower).await;
+        cluster.wait_for_apply(follower, idx).await;
+        cluster.assert_converged("SELECT id, v FROM kv ORDER BY id");
+    }
+}

--- a/crates/vibesql-consensus/src/openraft_backend.rs
+++ b/crates/vibesql-consensus/src/openraft_backend.rs
@@ -97,12 +97,35 @@ openraft::declare_raft_types!(
     /// The application payload (`D`) is an opaque byte buffer: the
     /// [`ConsensusBackend`] entry type is serialized at the adapter boundary
     /// so openraft types never leak to consumers (ADR-0004). The response
-    /// (`R`) is the dense application log index assigned by the state
-    /// machine (`0` for protocol entries, which carry no app payload).
+    /// (`R`) is [`AppResponse`]: the dense application log index assigned
+    /// by the state machine, plus — for the MVCC machine (Raft Phase B1,
+    /// PR 2 of #5199, `crate::mvcc_raft`) — the apply outcome.
     pub(crate) TypeConfig:
         D = Vec<u8>,
-        R = u64,
+        R = AppResponse,
 );
+
+/// The engine-level apply response (`R` of [`TypeConfig`]), produced by a
+/// state machine for each applied entry and handed back to `client_write`
+/// callers. Never sent between nodes (client writes are not forwarded), but
+/// serde-capable because openraft's type config requires it.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) enum AppResponse {
+    /// A protocol entry (membership / new-leader blank): no application
+    /// payload, no dense application index consumed.
+    Protocol,
+    /// Echo state machine: the dense application index the entry was
+    /// applied at.
+    Index(u64),
+    /// MVCC state machine (`crate::mvcc_raft`): the dense application
+    /// index (= MVCC commit_ts) and the transaction's apply outcome.
+    Mvcc {
+        /// Dense application index the entry consumed.
+        index: u64,
+        /// Applied or (deterministically) rejected.
+        outcome: crate::state_machine::ApplyOutcome,
+    },
+}
 
 /// The fixed node id of the single-voter cluster.
 const NODE_ID: u64 = 1;
@@ -158,7 +181,7 @@ impl Default for RaftTuning {
 
 impl RaftTuning {
     /// Validate and translate into the engine's [`Config`].
-    fn raft_config(&self) -> Result<Config> {
+    pub(crate) fn raft_config(&self) -> Result<Config> {
         if self.snapshot_chunk_bytes == 0
             || self.snapshot_chunk_bytes > crate::tcp::MAX_SNAPSHOT_CHUNK_BYTES
         {
@@ -466,7 +489,47 @@ impl InMemoryStateMachine {
     }
 }
 
-fn current_timestamp_ms() -> u64 {
+/// Tolerant cluster initialization, shared by every multi-node constructor
+/// (echo and MVCC): with [`Bootstrap::Initialize`], write the static
+/// membership into the fresh log; with [`Bootstrap::Recover`] do nothing
+/// (the membership entry and vote are already in the recovered log, and
+/// re-running `initialize` would be rejected).
+///
+/// openraft documents that multiple nodes initializing with the *same*
+/// membership is safe; a node that already voted for (or received the
+/// membership entry from) a faster peer rejects its own initialize with
+/// `NotAllowed`. Both paths converge on the same membership, so that
+/// rejection is tolerated.
+pub(crate) async fn initialize_membership(
+    raft: &Raft<TypeConfig>,
+    members: BTreeMap<u64, BasicNode>,
+    bootstrap: Bootstrap,
+) -> Result<()> {
+    if !matches!(bootstrap, Bootstrap::Initialize) {
+        return Ok(());
+    }
+    match raft.initialize(members).await {
+        Ok(()) | Err(RaftError::APIError(openraft::error::InitializeError::NotAllowed(_))) => {
+            Ok(())
+        }
+        Err(e) => Err(ConsensusError::Backend(format!("failed to initialize cluster: {e}"))),
+    }
+}
+
+/// Map the engine's server state onto the adapter [`Role`]. Shared by the
+/// echo backend and the MVCC node (`crate::mvcc_raft`).
+pub(crate) fn role_from_state(state: ServerState) -> Role {
+    match state {
+        ServerState::Leader => Role::Leader,
+        ServerState::Candidate => Role::Candidate,
+        // `Learner` (non-voting) and `Shutdown` have no Role equivalent
+        // yet; report Follower, the closest "not sequencing writes"
+        // state. Revisit if consumers need the distinction.
+        ServerState::Follower | ServerState::Learner | ServerState::Shutdown => Role::Follower,
+    }
+}
+
+pub(crate) fn current_timestamp_ms() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis() as u64).unwrap_or(0)
 }
@@ -533,7 +596,10 @@ impl RaftStateMachine<TypeConfig> for InMemoryStateMachine {
         Ok((inner.last_applied, inner.last_membership.clone()))
     }
 
-    async fn apply<I>(&mut self, entries: I) -> std::result::Result<Vec<u64>, StorageError<u64>>
+    async fn apply<I>(
+        &mut self,
+        entries: I,
+    ) -> std::result::Result<Vec<AppResponse>, StorageError<u64>>
     where
         I: IntoIterator<Item = Entry<TypeConfig>> + Send,
         I::IntoIter: Send,
@@ -545,14 +611,14 @@ impl RaftStateMachine<TypeConfig> for InMemoryStateMachine {
             let response = match entry.payload {
                 // Protocol entries carry no application payload; they do not
                 // consume an application log index.
-                EntryPayload::Blank => 0,
+                EntryPayload::Blank => AppResponse::Protocol,
                 EntryPayload::Membership(membership) => {
                     inner.last_membership = StoredMembership::new(Some(entry.log_id), membership);
-                    0
+                    AppResponse::Protocol
                 }
                 EntryPayload::Normal(data) => {
                     inner.entries.push(data);
-                    inner.entries.len() as u64
+                    AppResponse::Index(inner.entries.len() as u64)
                 }
             };
             responses.push(response);
@@ -640,7 +706,7 @@ impl RaftStateMachine<TypeConfig> for InMemoryStateMachine {
 /// transport instead: the in-process channel network in `crate::network`
 /// (Phase A3, PR 1; test-only), with TCP following in PR 2.
 #[derive(Debug, Default)]
-struct NoopNetwork;
+pub(crate) struct NoopNetwork;
 
 fn unreachable_rpc<E: std::error::Error>() -> RPCError<u64, BasicNode, E> {
     RPCError::Unreachable(Unreachable::new(&std::io::Error::other(
@@ -679,7 +745,7 @@ impl openraft::RaftNetwork<TypeConfig> for NoopNetwork {
 }
 
 #[derive(Debug, Default)]
-struct NoopNetworkFactory;
+pub(crate) struct NoopNetworkFactory;
 
 impl openraft::RaftNetworkFactory<TypeConfig> for NoopNetworkFactory {
     type Network = NoopNetwork;
@@ -710,28 +776,36 @@ pub(crate) enum Bootstrap {
     Recover { last_log_index: Option<u64> },
 }
 
-/// Everything recovered from a data directory: the durable log store, plus a
-/// state machine already seeded from the latest durable snapshot (Raft Phase
-/// A4, PR 1 of #5198). Recovery order is **snapshot first, then log
-/// replay**: the state machine resumes at the snapshot's `last_applied`, and
-/// openraft re-applies only the log suffix above it.
-struct DurableStorage {
-    log_store: DurableLogStore,
-    state_machine: InMemoryStateMachine,
+/// The durable artifacts recovered from a data directory — log store,
+/// snapshot store, and (if present) the latest durable snapshot — after the
+/// loss/tampering cross-checks between them have passed. State-machine
+/// seeding is the caller's job: the echo machine ([`DurableStorage`]) and
+/// the MVCC machine (`crate::mvcc_raft`) decode the snapshot payload
+/// differently but share everything up to that point.
+pub(crate) struct RecoveredDurable {
+    pub(crate) log_store: DurableLogStore,
+    pub(crate) snapshot_store: Arc<SnapshotStore>,
+    /// The latest durable snapshot, already integrity-checked at the file
+    /// level (CRC + framing); the payload is decoded by the state machine
+    /// that installs it.
+    pub(crate) loaded: Option<crate::snapshot::LoadedSnapshot>,
     /// The raft *log* holds prior state (vote / entries / purge watermark).
     /// Drives the initialize-vs-recover decision: only a membership entry in
     /// the log makes re-running `Raft::initialize` illegal.
-    log_has_state: bool,
-    /// Any prior state at all, including a durable snapshot. Drives the
-    /// "cannot restore a snapshot into a stateful directory" rejection.
-    has_any_state: bool,
+    pub(crate) log_has_state: bool,
     /// Last raw raft log index (entries or purge watermark), for the
     /// single-node recovery-replay wait.
-    last_log_index: Option<u64>,
+    pub(crate) last_log_index: Option<u64>,
 }
 
-impl DurableStorage {
-    fn open(dir: &Path) -> Result<Self> {
+impl RecoveredDurable {
+    /// Any prior state at all, including a durable snapshot. Drives the
+    /// "cannot restore a snapshot into a stateful directory" rejection.
+    pub(crate) fn has_any_state(&self) -> bool {
+        self.log_has_state || self.loaded.is_some()
+    }
+
+    pub(crate) fn open(dir: &Path) -> Result<Self> {
         let (snapshot_store, loaded) = SnapshotStore::open(dir).map_err(|e| {
             ConsensusError::Backend(format!(
                 "failed to open durable raft snapshot in {}: {e}",
@@ -800,20 +874,48 @@ impl DurableStorage {
             }
         }
 
-        let state_machine = InMemoryStateMachine::durable(Arc::clone(&snapshot_store))
-            .with_log_store(log_store.clone());
-        let mut has_any_state = log_has_state;
-        if let Some(loaded) = loaded {
+        Ok(Self { log_store, snapshot_store, loaded, log_has_state, last_log_index })
+    }
+}
+
+/// Everything recovered from a data directory: the durable log store, plus a
+/// state machine already seeded from the latest durable snapshot (Raft Phase
+/// A4, PR 1 of #5198). Recovery order is **snapshot first, then log
+/// replay**: the state machine resumes at the snapshot's `last_applied`, and
+/// openraft re-applies only the log suffix above it.
+struct DurableStorage {
+    log_store: DurableLogStore,
+    state_machine: InMemoryStateMachine,
+    /// See [`RecoveredDurable::log_has_state`].
+    log_has_state: bool,
+    /// See [`RecoveredDurable::has_any_state`].
+    has_any_state: bool,
+    /// See [`RecoveredDurable::last_log_index`].
+    last_log_index: Option<u64>,
+}
+
+impl DurableStorage {
+    fn open(dir: &Path) -> Result<Self> {
+        let raw = RecoveredDurable::open(dir)?;
+        let has_any_state = raw.has_any_state();
+        let state_machine = InMemoryStateMachine::durable(Arc::clone(&raw.snapshot_store))
+            .with_log_store(raw.log_store.clone());
+        if let Some(loaded) = raw.loaded {
             state_machine.seed_from_snapshot(loaded.meta, loaded.data).map_err(|e| {
                 ConsensusError::Backend(format!(
                     "failed to recover durable raft snapshot in {}: {e}",
                     dir.display()
                 ))
             })?;
-            has_any_state = true;
         }
 
-        Ok(Self { log_store, state_machine, log_has_state, has_any_state, last_log_index })
+        Ok(Self {
+            log_store: raw.log_store,
+            state_machine,
+            log_has_state: raw.log_has_state,
+            has_any_state,
+            last_log_index: raw.last_log_index,
+        })
     }
 }
 
@@ -946,14 +1048,7 @@ impl<E> OpenraftBackend<E> {
     }
 
     fn current_role(&self) -> Role {
-        match self.metrics.borrow().state {
-            ServerState::Leader => Role::Leader,
-            ServerState::Candidate => Role::Candidate,
-            // `Learner` (non-voting) and `Shutdown` have no Role equivalent
-            // yet; report Follower, the closest "not sequencing writes"
-            // state. Revisit if consumers need the distinction.
-            ServerState::Follower | ServerState::Learner | ServerState::Shutdown => Role::Follower,
-        }
+        role_from_state(self.metrics.borrow().state)
     }
 
     #[cfg(test)]
@@ -1039,15 +1134,7 @@ impl<E> OpenraftBackend<E> {
         members: BTreeMap<u64, BasicNode>,
         bootstrap: Bootstrap,
     ) -> Result<()> {
-        if !matches!(bootstrap, Bootstrap::Initialize) {
-            return Ok(());
-        }
-        match self.raft.initialize(members).await {
-            Ok(()) | Err(RaftError::APIError(openraft::error::InitializeError::NotAllowed(_))) => {
-                Ok(())
-            }
-            Err(e) => Err(ConsensusError::Backend(format!("failed to initialize cluster: {e}"))),
-        }
+        initialize_membership(&self.raft, members, bootstrap).await
     }
 
     /// Boot one voter of a **TCP-connected cluster** with an in-memory Raft
@@ -1327,11 +1414,15 @@ where
             other => ConsensusError::Backend(other.to_string()),
         })?;
 
-        // `data` is the dense application index assigned by the state
-        // machine; 0 would mean a protocol entry, which client_write never
-        // produces.
-        debug_assert!(response.data > 0, "client write applied as a protocol entry");
-        Ok(response.data)
+        // The response carries the dense application index assigned by the
+        // state machine; protocol/MVCC responses cannot come back from a
+        // client write on the echo machine.
+        match response.data {
+            AppResponse::Index(idx) => Ok(idx),
+            other => Err(ConsensusError::Backend(format!(
+                "client write resolved with an unexpected apply response: {other:?}"
+            ))),
+        }
     }
 
     async fn read_committed(&self, idx: LogIndex) -> Result<E> {

--- a/crates/vibesql-consensus/src/state_machine.rs
+++ b/crates/vibesql-consensus/src/state_machine.rs
@@ -178,7 +178,13 @@ impl TxnEntry {
 }
 
 /// Result of applying one [`TxnEntry`] to the state machine.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// Serializable because the openraft mount (PR 2 of #5199,
+/// `crate::mvcc_raft`) returns it as the engine-level apply response
+/// (`R` of the raft type config), which openraft requires to be serde-
+/// capable. It never travels between nodes — `client_write` responses
+/// are local.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ApplyOutcome {
     /// The entry's transaction committed; `rows_affected` sums the DML
     /// row counts across its statements.
@@ -217,7 +223,8 @@ struct MachineInner {
 /// convention of the other state machines in this crate. PR 1 drives it
 /// through [`ReplicatedDb`](crate::ReplicatedDb) over
 /// [`SingleNodeBackend`](crate::SingleNodeBackend); PR 2 mounts it
-/// behind openraft's `RaftStateMachine` for multi-node replication.
+/// behind openraft's `RaftStateMachine` for multi-node replication —
+/// see `crate::mvcc_raft` ([`MvccRaftNode`](crate::MvccRaftNode)).
 #[derive(Debug, Clone)]
 pub struct VibesqlStateMachine {
     inner: Arc<Mutex<MachineInner>>,
@@ -418,12 +425,26 @@ impl VibesqlStateMachine {
     /// `<= last_included_index`) is correct and the next applied entry
     /// keeps the commit_ts = log index mapping.
     pub fn install_snapshot(&self, snapshot: &Snapshot) -> Result<()> {
-        let mut db = deserialize_database(&snapshot.data)?;
-        db.set_next_txn_id(snapshot.last_included_index + 1)
+        let db = deserialize_database(&snapshot.data)?;
+        self.install_decoded(db, snapshot.last_included_index)
+    }
+
+    /// Install an already-decoded database as this machine's state, with
+    /// `last_applied` resuming at `last_included_index`. The openraft
+    /// mount (`crate::mvcc_raft`) uses this split so a received snapshot
+    /// can be fully validated (decoded) **before** it is durably
+    /// persisted, and persisted before the machine mutates — a corrupt
+    /// stream must neither half-install nor leave a corrupt file behind.
+    pub(crate) fn install_decoded(
+        &self,
+        mut db: Database,
+        last_included_index: LogIndex,
+    ) -> Result<()> {
+        db.set_next_txn_id(last_included_index + 1)
             .map_err(|e| ConsensusError::SnapshotCodec(format!("failed to seed commit_ts: {e}")))?;
         let mut inner = self.lock();
         inner.db = db;
-        inner.last_applied = snapshot.last_included_index;
+        inner.last_applied = last_included_index;
         Ok(())
     }
 
@@ -521,7 +542,7 @@ fn serialize_database(db: &Database) -> Result<Vec<u8>> {
 
 /// Decode a snapshot payload back into a database. Fails loudly (and
 /// without side effects) on a corrupt payload.
-fn deserialize_database(data: &[u8]) -> Result<Database> {
+pub(crate) fn deserialize_database(data: &[u8]) -> Result<Database> {
     let codec = |e: vibesql_storage::StorageError| ConsensusError::SnapshotCodec(e.to_string());
     let mut reader = data;
     let version = read_header(&mut reader).map_err(codec)?;

--- a/crates/vibesql-consensus/tests/tcp_cluster.rs
+++ b/crates/vibesql-consensus/tests/tcp_cluster.rs
@@ -47,7 +47,8 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::task::JoinHandle;
 
 use vibesql_consensus::{
-    ClusterConfig, ConsensusBackend, ConsensusError, LogIndex, OpenraftBackend, RaftTuning, Role,
+    ClusterConfig, ConsensusBackend, ConsensusError, LogIndex, MvccRaftNode, OpenraftBackend,
+    RaftTuning, Role,
 };
 
 /// Upper bound for any single cluster-level wait (election, catch-up).
@@ -757,4 +758,129 @@ async fn large_snapshot_transfer_stress() {
         Duration::from_secs(300),
     )
     .await;
+}
+
+// ---------------------------------------------------------------------------
+// Raft Phase B1, PR 2 (#5199): the MVCC state machine over real sockets
+// ---------------------------------------------------------------------------
+
+/// Bounded poll shared by the MVCC test below (the `TcpTestCluster`
+/// methods are bound to the echo backend).
+async fn wait_for<T>(what: &str, mut probe: impl FnMut() -> Option<T>) -> T {
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    loop {
+        if let Some(value) = probe() {
+            return value;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out after {WAIT_TIMEOUT:?} waiting for {what}"
+        );
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Drive one write through whoever currently leads the MVCC cluster,
+/// tolerating elections mid-test.
+async fn execute_on_mvcc_leader(
+    nodes: &BTreeMap<u64, MvccRaftNode>,
+    sql: &str,
+) -> (LogIndex, vibesql_consensus::ApplyOutcome) {
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    loop {
+        let leader = wait_for("a leader to be elected", || {
+            nodes.iter().find(|(_, n)| n.role() == Role::Leader).map(|(id, _)| *id)
+        })
+        .await;
+        match nodes[&leader].execute_replicated(sql).await {
+            Ok(result) => return result,
+            Err(ConsensusError::NotLeader { .. }) => {
+                assert!(
+                    tokio::time::Instant::now() < deadline,
+                    "timed out executing {sql:?}: leadership never settled"
+                );
+            }
+            Err(other) => panic!("execute of {sql:?} failed: {other:?}"),
+        }
+    }
+}
+
+/// A 3-voter **MVCC** cluster over the TCP transport: replicated DML —
+/// including nondeterministic SQL frozen at propose — converges on every
+/// node; a follower write fails fast with `NotLeader` + leader hint.
+/// (The full failure-injection matrix for the MVCC machine runs on the
+/// in-process channel transport in `src/mvcc_raft.rs`; this proves the
+/// mount end-to-end over real sockets.)
+#[tokio::test]
+async fn mvcc_three_node_cluster_replicates_over_tcp() {
+    let addrs = free_localhost_addrs(3);
+    let config = ClusterConfig::new(addrs).expect("valid cluster config");
+
+    let mut nodes: BTreeMap<u64, MvccRaftNode> = BTreeMap::new();
+    for id in 1..=3 {
+        nodes.insert(
+            id,
+            MvccRaftNode::join_tcp_cluster(id, &config).await.expect("boot mvcc tcp node"),
+        );
+    }
+
+    let statements = [
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT, r INTEGER, d DATE)",
+        "INSERT INTO t VALUES (1, 'one', random(), curdate())",
+        "INSERT INTO t VALUES (2, 'two', random(), curdate())",
+        "UPDATE t SET v = 'TWO' WHERE id = 2",
+        "DELETE FROM t WHERE id = 1",
+    ];
+    let mut last_dense = 0;
+    for (i, sql) in statements.iter().enumerate() {
+        let (idx, outcome) = execute_on_mvcc_leader(&nodes, sql).await;
+        assert_eq!(idx, (i + 1) as LogIndex, "{sql}");
+        assert!(
+            matches!(outcome, vibesql_consensus::ApplyOutcome::Applied { .. }),
+            "{sql}: {outcome:?}"
+        );
+        last_dense = idx;
+    }
+
+    // Every voter applies the same log — identical rows everywhere,
+    // including the frozen random()/curdate() values.
+    for (id, node) in &nodes {
+        let id = *id;
+        wait_for(&format!("node {id} to apply dense index {last_dense}"), || {
+            (node.last_applied() >= last_dense).then_some(())
+        })
+        .await;
+    }
+    let reference = nodes[&1].query("SELECT id, v, r, d FROM t ORDER BY id").unwrap();
+    assert_eq!(reference.len(), 1, "one live row after the DELETE");
+    for id in 2..=3 {
+        assert_eq!(
+            nodes[&id].query("SELECT id, v, r, d FROM t ORDER BY id").unwrap(),
+            reference,
+            "node {id} diverged"
+        );
+    }
+
+    // Leader-only writes: a follower fails fast with a leader hint.
+    let leader = wait_for("a settled leader", || {
+        nodes.iter().find(|(_, n)| n.role() == Role::Leader).map(|(id, _)| *id)
+    })
+    .await;
+    let follower = (1..=3).find(|id| *id != leader).expect("a follower exists");
+    wait_for("the follower to learn who leads", || {
+        (nodes[&follower].current_leader() == Some(leader)).then_some(())
+    })
+    .await;
+    let err = nodes[&follower]
+        .execute_replicated("INSERT INTO t VALUES (3, 'nope', random(), curdate())")
+        .await
+        .unwrap_err();
+    match err {
+        ConsensusError::NotLeader { leader_hint } => assert_eq!(leader_hint, Some(leader)),
+        other => panic!("expected NotLeader with a hint, got: {other:?}"),
+    }
+
+    for node in nodes.values() {
+        node.shutdown().await.expect("clean shutdown");
+    }
 }


### PR DESCRIPTION
Closes #5199

PR 2 of 2 for Phase B1 (PR 1: #5378; determinism prerequisite: #5382/#5377). The MVCC state machine now runs **inside** openraft, and the multi-node acceptance scenarios from the curator re-scope are proven end-to-end.

## What's here

### 1. The mount (`crates/vibesql-consensus/src/mvcc_raft.rs`)
- `MvccStateMachine`: openraft 0.9.24 `RaftStateMachine` + `RaftSnapshotBuilder` over PR 1's `VibesqlStateMachine`. Mounting, not reimplementing — apply/idempotence/commit_ts/vacuum-pin logic is reused verbatim.
- **Index mapping**: openraft's raw log interleaves protocol entries (membership, leader blanks) with app entries; the wrapper tracks the raw cursor for the engine and computes the machine's dense index (`machine.last_applied() + 1`) per `Normal` entry. Protocol entries consume no dense index, so dense indices — and therefore MVCC `xmin` stamps — are identical on every replica **across leader changes** (asserted in tests).
- **Atomic capture**: the wrapper's mutex is held across each apply batch *and* the snapshot meta+state capture (lock order always wrapper → machine, no `.await` under the guard), so a concurrent build can never pair raft meta and database state from two instants.
- The shared raft type config's response `R` grew from `u64` to an `AppResponse` enum so the MVCC machine can return `(dense index, ApplyOutcome)` through `client_write`; the echo machine and its conformance suite are otherwise untouched.

### 2. FatalApply → node halt (the #5378 judge's PR 2 obligation)
A fatal apply (frozen-site mismatch, undecodable payload, resource-class executor error per #5377's split, gap) returns a `StorageError` from `RaftStateMachine::apply`: openraft treats storage errors as fatal — the core shuts down **without acknowledging the entry**, so neither the engine's `last_applied` nor the machine's advances past it. The reason is retained (`MvccRaftNode::fatal_reason`) and surfaces on in-flight writes as `ConsensusError::FatalApply`. Recovery = restart + resync (snapshot install + log replay), tested.

### 3. Leader-only writes
`execute_replicated_txn` fails fast with `NotLeader { leader_hint }` on non-leaders **before** evaluating any volatile expression; openraft's `ForwardToLeader` maps to the same error as the authoritative backstop. Freeze-at-propose therefore always runs on the leader (the propose path used multi-node is exactly the freezing one).

### 4. MVCC snapshots across the network
Engine snapshot payload = 8-byte LE dense-index header + the PR 1 vbsql blob. Builds pin the vacuum horizon for their whole duration; durable configs persist via the A4 `SnapshotStore` **before** registering/acknowledging, including the deferred post-install purge record. Received payloads are fully decoded before anything persists or mutates. `DurableStorage`'s open/cross-check logic was factored into `RecoveredDurable` and shared (echo behavior unchanged).

## Multi-node tests

Channel network (`src/mvcc_raft.rs`), all bounded polls, no bare sleeps:
- `three_node_dml_converges_with_identical_commit_timestamps` — INSERT/UPDATE/DELETE converge; `xmin` = dense index on all 3 nodes (mvcc_enabled)
- `nondeterministic_sql_converges_identically_on_all_nodes` — `random()`, `randomblob()`, `CURRENT_TIMESTAMP`, `curdate()`, `datetime('now')` → identical rows everywhere
- `deterministic_rejection_is_identical_on_every_node` — constraint violation rejected identically, index consumed everywhere, cluster continues
- `killing_the_leader_keeps_writes_flowing_and_restored_node_converges` — failover; dense indices stay contiguous; killed node replays to convergence (incl. xmin)
- `follower_writes_are_rejected_with_a_leader_hint` — NotLeader + hint, no index consumed
- `poisoned_entry_halts_nodes_without_consuming_the_index` — real fatal path (frozen mismatch): every node that applies it halts; openraft never advances past it; outage, not divergence
- `injected_fatal_halts_one_node_and_restart_resyncs_it` — node-local fatal (test hook) halts only the victim; quorum continues; restart resyncs
- `purged_follower_heals_via_mvcc_snapshot_install_and_restarts_cleanly` — policy snapshot+purge past a dead follower → restore heals via MVCC snapshot install → post-install commit_ts mapping intact → second restart clean from its own durable snapshot
- `single_node_mount_applies_rejects_and_snapshots` — mount plumbing + outcome surfacing + engine-built artifact restores standalone

TCP (`tests/tcp_cluster.rs`, runs under `make test-cluster`):
- `mvcc_three_node_cluster_replicates_over_tcp` — 3 voters over real sockets: DML + frozen `random()`/`curdate()` converge; follower NotLeader + hint

## Verification

- `cargo test -p vibesql-consensus`: **136** lib + **9** tcp_cluster green (default); **139** + **9** green (`--features mvcc_enabled`)
- `cargo clippy -p vibesql-consensus --all-targets`: zero warnings in this crate's code, both feature states
- `cargo build --workspace`: green
- `make test-cluster` (release): 9/9 green
- **Flake checks**: mvcc_raft lib suite 15/15 (default) and 15/15 (mvcc_enabled); tcp_cluster suite 17 consecutive runs green (debug) + release run; full combined suite 5/5 green under mvcc_enabled. One early tcp_cluster failure was observed while a full workspace build ran concurrently on the same machine and never reproduced across the 22 subsequent runs.
- Diff is vibesql-consensus only; no formatting churn in untouched lines (`replicated.rs` byte-identical to main)

## Acceptance criteria / scope notes

- Curator criteria "3-node leader write visible in follower reads", "follower write → NOT_LEADER with hint", "kill-leader-mid-txn never half-applied" — covered above (half-application is impossible by construction: one entry per committed transaction; atomicity additionally asserted by the rejection tests).
- **Deferred**: server/CLI wiring (PostgreSQL sessions routing writes through `MvccRaftNode`, NOT_LEADER as SQL error with redirect, propose-side DEFAULT pre-check) → filed as #5383 with the full curator context. A disposition comment goes on #5199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)