### PR TITLE
fix(consensus): retry NotLeader in cluster test proposes

### DIFF
--- a/crates/vibesql-consensus/src/cluster.rs
+++ b/crates/vibesql-consensus/src/cluster.rs
@@ -217,28 +217,40 @@ impl TestCluster {
         .await;
     }
 
-    /// Propose on whoever currently leads, re-resolving leadership if a
-    /// spurious election deposed the previous leader mid-call.
+    /// Propose on whoever currently leads, re-resolving leadership —
+    /// preferring a `NotLeader` rejection's leader hint — if a spurious
+    /// election deposed the previous leader mid-call. Returns the accepting
+    /// leader and the entry's index.
     ///
     /// The durable nodes fsync inline on their core task (see
     /// `crate::durable`), so when the whole test suite runs in parallel an
     /// fsync stall can exceed the 200ms election timeout and trigger a
-    /// re-election a cached leader id would not survive. Committed results
-    /// are identical either way — only the door the write goes through
-    /// moves — so tests that don't specifically assert *which* node leads
-    /// propose through this helper. Bounded like every other wait.
-    async fn propose_on_leader(&self, value: &str) -> LogIndex {
+    /// re-election a cached leader id would not survive; release-mode
+    /// timing also compresses the window between the leadership observation
+    /// and the propose (#5385). The typed rejection means the entry was
+    /// **not** committed, so retrying is safe: committed results are
+    /// identical either way — only the door the write goes through moves —
+    /// so every propose that doesn't specifically assert a *rejection* goes
+    /// through this helper. Bounded like every other wait.
+    async fn propose_on_leader(&self, value: &str) -> (u64, LogIndex) {
         let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+        let mut hint: Option<u64> = None;
         loop {
-            let leader = self.wait_for_leader().await;
+            let live = self.live_ids();
+            let leader = match hint.take().filter(|id| live.contains(id)) {
+                Some(hinted) => hinted,
+                None => self.wait_for_leader().await,
+            };
             match self.node(leader).propose(value.to_string()).await {
-                Ok(idx) => return idx,
-                Err(ConsensusError::NotLeader { .. }) => {
+                Ok(idx) => return (leader, idx),
+                Err(ConsensusError::NotLeader { leader_hint }) => {
                     assert!(
                         tokio::time::Instant::now() < deadline,
                         "timed out after {WAIT_TIMEOUT:?} proposing {value:?}: leadership \
                          never settled"
                     );
+                    hint = leader_hint;
+                    tokio::time::sleep(POLL_INTERVAL).await;
                 }
                 Err(other) => panic!("propose of {value:?} failed: {other:?}"),
             }
@@ -281,9 +293,8 @@ fn follower_of(cluster: &TestCluster, leader: u64) -> u64 {
 #[tokio::test]
 async fn boot_elects_leader_and_replicates_to_all() {
     let cluster = TestCluster::new(3).await;
-    let leader = cluster.wait_for_leader().await;
 
-    let idx = cluster.node(leader).propose("write-1".to_string()).await.unwrap();
+    let (_, idx) = cluster.propose_on_leader("write-1").await;
     assert_eq!(idx, 1, "first application entry gets the first dense index");
 
     for id in 1..=3 {
@@ -296,9 +307,18 @@ async fn boot_elects_leader_and_replicates_to_all() {
     }
 
     // With replication settled and heartbeats healthy, leadership is
-    // unique: exactly the elected node reports `Role::Leader`.
-    let leaders: Vec<u64> = (1..=3).filter(|id| cluster.node(*id).role() == Role::Leader).collect();
-    assert_eq!(leaders, vec![leader]);
+    // unique: exactly one node reports `Role::Leader` and everyone
+    // acknowledges it. A bounded wait, not a one-shot snapshot — sampling
+    // roles non-atomically can catch an election in flight (#5385).
+    cluster
+        .wait_until("leadership to settle on a unique acknowledged leader", || {
+            let leaders: Vec<u64> =
+                (1..=3).filter(|id| cluster.node(*id).role() == Role::Leader).collect();
+            let [only] = leaders.as_slice() else { return None };
+            let only = *only;
+            (1..=3).all(|id| cluster.node(id).current_leader() == Some(only)).then_some(())
+        })
+        .await;
 }
 
 /// Kill the leader: the two survivors elect a new leader and writes resume,
@@ -306,9 +326,9 @@ async fn boot_elects_leader_and_replicates_to_all() {
 #[tokio::test]
 async fn killing_the_leader_elects_a_new_one_and_writes_resume() {
     let mut cluster = TestCluster::new(3).await;
-    let leader = cluster.wait_for_leader().await;
 
-    let idx = cluster.node(leader).propose("before-failover".to_string()).await.unwrap();
+    // The accepting leader is by construction the leader at write time.
+    let (leader, idx) = cluster.propose_on_leader("before-failover").await;
     for id in cluster.live_ids() {
         cluster.wait_for_apply(id, idx).await;
     }
@@ -318,7 +338,7 @@ async fn killing_the_leader_elects_a_new_one_and_writes_resume() {
     let new_leader = cluster.wait_for_leader().await;
     assert_ne!(new_leader, leader, "the killed node cannot be the new leader");
 
-    let idx2 = cluster.node(new_leader).propose("after-failover".to_string()).await.unwrap();
+    let (_, idx2) = cluster.propose_on_leader("after-failover").await;
     assert_eq!(idx2, 2, "application indices stay dense across the failover");
 
     for id in cluster.live_ids() {
@@ -334,11 +354,12 @@ async fn killing_the_leader_elects_a_new_one_and_writes_resume() {
 #[tokio::test]
 async fn restored_follower_catches_up_via_log_replication() {
     let mut cluster = TestCluster::new(3).await;
-    let leader = cluster.wait_for_leader().await;
 
+    let mut leader = cluster.wait_for_leader().await;
     for i in 1..=5u64 {
-        let idx = cluster.node(leader).propose(format!("entry-{i}")).await.unwrap();
+        let (l, idx) = cluster.propose_on_leader(&format!("entry-{i}")).await;
         assert_eq!(idx, i);
+        leader = l;
     }
     let follower = follower_of(&cluster, leader);
     cluster.wait_for_apply(follower, 5).await;
@@ -347,7 +368,7 @@ async fn restored_follower_catches_up_via_log_replication() {
 
     // The two survivors are still a majority: writes keep committing.
     for i in 6..=10u64 {
-        let idx = cluster.node(leader).propose(format!("entry-{i}")).await.unwrap();
+        let (_, idx) = cluster.propose_on_leader(&format!("entry-{i}")).await;
         assert_eq!(idx, i);
     }
 
@@ -398,15 +419,16 @@ async fn propose_on_follower_surfaces_not_leader_with_hint() {
 #[tokio::test]
 async fn durable_node_recovers_from_disk_and_rejoins() {
     let mut cluster = TestCluster::new_durable(3).await;
-    let leader = cluster.wait_for_leader().await;
 
     // Proposes go through `propose_on_leader`: with inline fsyncs on every
     // node, parallel-suite disk stalls can trigger spurious re-elections
     // this test does not care about (it asserts durability + catch-up, not
     // leadership stability).
+    let mut leader = cluster.wait_for_leader().await;
     for i in 1..=3u64 {
-        let idx = cluster.propose_on_leader(&format!("entry-{i}")).await;
+        let (l, idx) = cluster.propose_on_leader(&format!("entry-{i}")).await;
         assert_eq!(idx, i);
+        leader = l;
     }
     let follower = follower_of(&cluster, leader);
     cluster.wait_for_apply(follower, 3).await;
@@ -414,7 +436,7 @@ async fn durable_node_recovers_from_disk_and_rejoins() {
     cluster.kill(follower).await;
 
     for i in 4..=5u64 {
-        let idx = cluster.propose_on_leader(&format!("entry-{i}")).await;
+        let (_, idx) = cluster.propose_on_leader(&format!("entry-{i}")).await;
         assert_eq!(idx, i);
     }
 

--- a/crates/vibesql-consensus/tests/tcp_cluster.rs
+++ b/crates/vibesql-consensus/tests/tcp_cluster.rs
@@ -33,7 +33,11 @@
 //!
 //! All synchronization is bounded polling ([`TcpTestCluster::wait_until`],
 //! 10s deadline) — no bare sleeps; every wait fails loudly instead of
-//! hanging (PR 1's convention).
+//! hanging (PR 1's convention). Writes that don't specifically assert a
+//! rejection go through [`TcpTestCluster::propose_on_leader`], which
+//! retries the typed `NotLeader` rejection under the same deadline —
+//! release timing lets an election depose a just-observed leader between
+//! `wait_for_leader` and the propose (#5385).
 
 use std::collections::BTreeMap;
 use std::net::TcpListener as StdTcpListener;
@@ -350,6 +354,47 @@ impl TcpTestCluster {
         .await
     }
 
+    /// Propose on whoever currently leads, re-resolving leadership when a
+    /// [`ConsensusError::NotLeader`] rejection arrives (preferring its
+    /// leader hint). Returns the accepting leader and the entry's index.
+    ///
+    /// Release-mode timing compresses the gap between the leadership
+    /// observation in [`wait_for_leader_among`](Self::wait_for_leader_among)
+    /// and the propose enough that a parallel-suite election can depose the
+    /// observed leader mid-call (#5385); the typed rejection means the
+    /// entry was **not** committed, so retrying against the new leader is
+    /// safe. Bounded like every other wait. Tests asserting that a write is
+    /// *rejected* keep calling `propose` directly.
+    async fn propose_on_leader(&self, value: &str) -> (u64, LogIndex) {
+        self.propose_on_leader_among(&self.live_ids(), value).await
+    }
+
+    /// [`propose_on_leader`](Self::propose_on_leader) restricted to `ids`
+    /// (e.g. the majority side of a partition).
+    async fn propose_on_leader_among(&self, ids: &[u64], value: &str) -> (u64, LogIndex) {
+        let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+        let mut hint: Option<u64> = None;
+        loop {
+            let leader = match hint.take().filter(|id| ids.contains(id)) {
+                Some(hinted) => hinted,
+                None => self.wait_for_leader_among(ids).await,
+            };
+            match self.node(leader).propose(value.to_string()).await {
+                Ok(idx) => return (leader, idx),
+                Err(ConsensusError::NotLeader { leader_hint }) => {
+                    assert!(
+                        tokio::time::Instant::now() < deadline,
+                        "timed out after {WAIT_TIMEOUT:?} proposing {value:?}: leadership \
+                         never settled"
+                    );
+                    hint = leader_hint;
+                    tokio::time::sleep(POLL_INTERVAL).await;
+                }
+                Err(other) => panic!("propose of {value:?} failed: {other:?}"),
+            }
+        }
+    }
+
     /// Wait (bounded) until node `id` has applied the application log entry
     /// at `idx`.
     async fn wait_for_apply(&self, id: u64, idx: LogIndex) {
@@ -395,9 +440,8 @@ fn follower_of(cluster: &TcpTestCluster, leader: u64) -> u64 {
 #[tokio::test]
 async fn boots_elects_and_replicates_over_tcp() {
     let cluster = TcpTestCluster::boot(3).await;
-    let leader = cluster.wait_for_leader().await;
 
-    let idx = cluster.node(leader).propose("write-1".to_string()).await.unwrap();
+    let (_, idx) = cluster.propose_on_leader("write-1").await;
     assert_eq!(idx, 1, "first application entry gets the first dense index");
 
     for id in 1..=3 {
@@ -409,8 +453,18 @@ async fn boots_elects_and_replicates_over_tcp() {
         );
     }
 
-    let leaders: Vec<u64> = (1..=3).filter(|id| cluster.node(*id).role() == Role::Leader).collect();
-    assert_eq!(leaders, vec![leader], "leadership must be unique once settled");
+    // Leadership is unique once settled — asserted as a bounded wait, not
+    // a one-shot snapshot: sampling roles non-atomically can catch an
+    // election in flight and see zero or two claimants (#5385).
+    cluster
+        .wait_until("leadership to settle on a unique acknowledged leader", || {
+            let leaders: Vec<u64> =
+                (1..=3).filter(|id| cluster.node(*id).role() == Role::Leader).collect();
+            let [only] = leaders.as_slice() else { return None };
+            let only = *only;
+            (1..=3).all(|id| cluster.node(id).current_leader() == Some(only)).then_some(())
+        })
+        .await;
 }
 
 /// Kill the leader — its listener and every socket it owns die, like a
@@ -419,9 +473,9 @@ async fn boots_elects_and_replicates_over_tcp() {
 #[tokio::test]
 async fn killing_the_leader_severs_its_sockets_and_a_new_leader_emerges() {
     let mut cluster = TcpTestCluster::boot(3).await;
-    let leader = cluster.wait_for_leader().await;
 
-    let idx = cluster.node(leader).propose("before-failover".to_string()).await.unwrap();
+    // The accepting leader is by construction the leader at write time.
+    let (leader, idx) = cluster.propose_on_leader("before-failover").await;
     for id in cluster.live_ids() {
         cluster.wait_for_apply(id, idx).await;
     }
@@ -431,7 +485,7 @@ async fn killing_the_leader_severs_its_sockets_and_a_new_leader_emerges() {
     let new_leader = cluster.wait_for_leader().await;
     assert_ne!(new_leader, leader, "the killed node cannot be the new leader");
 
-    let idx2 = cluster.node(new_leader).propose("after-failover".to_string()).await.unwrap();
+    let (_, idx2) = cluster.propose_on_leader("after-failover").await;
     assert_eq!(idx2, 2, "application indices stay dense across the failover");
 
     for id in cluster.live_ids() {
@@ -446,11 +500,12 @@ async fn killing_the_leader_severs_its_sockets_and_a_new_leader_emerges() {
 #[tokio::test]
 async fn restarted_node_rebinds_reconnects_and_catches_up() {
     let mut cluster = TcpTestCluster::boot(3).await;
-    let leader = cluster.wait_for_leader().await;
 
+    let mut leader = cluster.wait_for_leader().await;
     for i in 1..=3u64 {
-        let idx = cluster.node(leader).propose(format!("entry-{i}")).await.unwrap();
+        let (l, idx) = cluster.propose_on_leader(&format!("entry-{i}")).await;
         assert_eq!(idx, i);
+        leader = l;
     }
     let follower = follower_of(&cluster, leader);
     cluster.wait_for_apply(follower, 3).await;
@@ -459,7 +514,7 @@ async fn restarted_node_rebinds_reconnects_and_catches_up() {
 
     // The two survivors are still a majority: writes keep committing.
     for i in 4..=6u64 {
-        let idx = cluster.node(leader).propose(format!("entry-{i}")).await.unwrap();
+        let (_, idx) = cluster.propose_on_leader(&format!("entry-{i}")).await;
         assert_eq!(idx, i);
     }
 
@@ -489,9 +544,8 @@ async fn restarted_node_rebinds_reconnects_and_catches_up() {
 #[tokio::test]
 async fn minority_partition_rejects_writes_while_the_majority_continues() {
     let cluster = TcpTestCluster::boot_partitionable(3).await;
-    let old_leader = cluster.wait_for_leader().await;
 
-    let idx = cluster.node(old_leader).propose("before-partition".to_string()).await.unwrap();
+    let (old_leader, idx) = cluster.propose_on_leader("before-partition").await;
     for id in 1..=3 {
         cluster.wait_for_apply(id, idx).await;
     }
@@ -508,8 +562,7 @@ async fn minority_partition_rejects_writes_while_the_majority_continues() {
 
     // Majority side: a new leader emerges and writes keep committing.
     let majority: Vec<u64> = (1..=3).filter(|id| *id != old_leader).collect();
-    let new_leader = cluster.wait_for_leader_among(&majority).await;
-    let idx2 = cluster.node(new_leader).propose("majority-write".to_string()).await.unwrap();
+    let (new_leader, idx2) = cluster.propose_on_leader_among(&majority, "majority-write").await;
     assert_eq!(idx2, 2, "the minority write must not have consumed an index");
     for id in &majority {
         cluster.wait_for_apply(*id, idx2).await;
@@ -574,9 +627,8 @@ async fn assert_connection_closed(mut stream: TcpStream) {
 #[tokio::test]
 async fn garbage_frames_drop_the_connection_without_disrupting_the_cluster() {
     let cluster = TcpTestCluster::boot(3).await;
-    let leader = cluster.wait_for_leader().await;
 
-    let idx = cluster.node(leader).propose("before-garbage".to_string()).await.unwrap();
+    let (leader, idx) = cluster.propose_on_leader("before-garbage").await;
     for id in 1..=3 {
         cluster.wait_for_apply(id, idx).await;
     }
@@ -603,7 +655,7 @@ async fn garbage_frames_drop_the_connection_without_disrupting_the_cluster() {
     drop(stream);
 
     // The cluster keeps replicating as if nothing happened.
-    let idx2 = cluster.node(leader).propose("after-garbage".to_string()).await.unwrap();
+    let (_, idx2) = cluster.propose_on_leader("after-garbage").await;
     for id in 1..=3 {
         cluster.wait_for_apply(id, idx2).await;
         assert_eq!(cluster.node(id).read_committed(idx2).await.unwrap(), "after-garbage");
@@ -639,24 +691,26 @@ async fn rejoin_lagging_follower_via_snapshot(
     entries: u64,
     payload_bytes: usize,
     convergence_timeout: Duration,
-) -> (TcpTestCluster, u64, u64) {
+) -> (TcpTestCluster, u64) {
     let value = {
         let payload = "x".repeat(payload_bytes);
         move |i: u64| format!("entry-{i}-{payload}")
     };
 
     let mut cluster = TcpTestCluster::boot_tuned(3, tuning).await;
-    let leader = cluster.wait_for_leader().await;
 
+    let mut leader = cluster.wait_for_leader().await;
     for i in 1..=3u64 {
-        cluster.node(leader).propose(value(i)).await.unwrap();
+        let (l, _) = cluster.propose_on_leader(&value(i)).await;
+        leader = l;
     }
     let follower = follower_of(&cluster, leader);
     cluster.wait_for_apply(follower, 3).await;
     cluster.kill(follower).await;
 
     for i in 4..=entries {
-        cluster.node(leader).propose(value(i)).await.unwrap();
+        let (l, _) = cluster.propose_on_leader(&value(i)).await;
+        leader = l;
     }
     cluster
         .wait_until("the leader's policy purge to pass the dead follower's position", || {
@@ -694,7 +748,7 @@ async fn rejoin_lagging_follower_via_snapshot(
         cluster.node(follower).snapshot_log_index()
     );
 
-    (cluster, leader, follower)
+    (cluster, follower)
 }
 
 /// The A4 rejoin acceptance criterion plus the #5369 judge's PR 2 liveness
@@ -705,13 +759,13 @@ async fn rejoin_lagging_follower_via_snapshot(
 /// comes back cleanly and stays current.
 #[tokio::test]
 async fn lagging_follower_rejoins_via_snapshot_and_survives_restart() {
-    let (mut cluster, leader, follower) =
+    let (mut cluster, follower) =
         rejoin_lagging_follower_via_snapshot(aggressive_purge_tuning(), 30, 16, WAIT_TIMEOUT).await;
 
     cluster.kill(follower).await;
     cluster.restore(follower).await;
 
-    let idx = cluster.node(leader).propose("after-second-restart".to_string()).await.unwrap();
+    let (_, idx) = cluster.propose_on_leader("after-second-restart").await;
     assert_eq!(idx, 31, "application indices stay dense across install + restart");
     cluster.wait_for_apply(follower, idx).await;
     assert_eq!(cluster.node(follower).read_committed(idx).await.unwrap(), "after-second-restart");


### PR DESCRIPTION
Closes #5385

## Summary

- The pre-existing echo-backend cluster tests called `propose(...).await.unwrap()` right after `wait_for_leader()`; under release timing an election can depose the just-observed leader inside that window, so the typed `NotLeader` rejection panicked the test — an intermittent CI red (CI's `test` job runs `cargo test --release --test '*'`, and `make test-cluster` is release mode too).
- Adds `TcpTestCluster::propose_on_leader` / `propose_on_leader_among` (the latter for the majority side of a partition), mirroring the MVCC tests' `execute_on_mvcc_leader`: on `ConsensusError::NotLeader { leader_hint }`, re-resolve leadership — preferring the hint when it points at a usable node — and retry under the existing 10s `wait_until` deadline. Returns `(accepting_leader, idx)` so tests that need "the leader at write time" (kill/failover, partition, follower selection) use the node that actually accepted the write.
- Routes every leader-dependent propose in `tests/tcp_cluster.rs` through the helper, and extends the channel-network harness's existing `src/cluster.rs::propose_on_leader` the same way (hint-following + accepting-leader return), using it at that file's remaining raw `propose().unwrap()` sites.
- Replaces the two "leadership must be unique once settled" one-shot role snapshots (same race: roles sampled non-atomically across an in-flight election) with bounded waits for exactly one `Role::Leader` claimant acknowledged by every node.
- No assertions weakened: dense-index checks (`idx == i`), value convergence on every replica, snapshot-install evidence, and the intentional rejection tests (`unwrap_err` on follower/deposed-leader proposes, the pending minority write) are all unchanged — rejection-asserting sites still call `propose` directly.

## Flake verification (release, Apple Silicon, same machine/conditions as the #5384 judge repro)

| | suite runs | failed |
|---|---|---|
| pre-fix (`ee6681c1f`, merged #5384 base) | 10 | **3** — all `NotLeader` unwrap panics (`snapshot_transfer_spans_many_chunks` x2, `garbage_frames_drop_the_connection_without_disrupting_the_cluster` x1; hints `Some(1)`, `Some(2)`, `None`) |
| post-fix | 24 | **0** (216/216 tests; ~11 of the runs under concurrent `cargo build --release --workspace` / `-p vibesql` load — per-run wall time 11–13s loaded vs ~8s idle) |
| post-fix lib `cluster::` tests (channel network) | 10 | **0** (50/50 tests) |

## Test plan

- [x] `cargo test --release -p vibesql-consensus --test tcp_cluster` x24 (loaded + idle) — all green
- [x] `cargo test --release -p vibesql-consensus --lib cluster::` x10 — all green
- [x] rustfmt clean on both touched files (no repo-wide fmt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)