### PR TITLE
feat(consensus): linearizable leader reads + stale-leader fencing (phase B2, PR 1/2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,9 +302,10 @@ test-tcl-status:
 # Boots 3-voter clusters on localhost (ephemeral ports, durable Raft logs)
 # wired by the TCP transport and exercises election, replication, leader
 # kill -> re-election, restart -> catch-up, a 2-1 minority partition, and
-# garbage frames on the wire. Exits nonzero on any failure.
+# garbage frames on the wire — plus the Raft Phase B2 (#5200) linearizable
+# leader-read / stale-leader fencing scenarios. Exits nonzero on any failure.
 test-cluster:
-	cargo test --release -p vibesql-consensus --test tcp_cluster -- --nocapture
+	cargo test --release -p vibesql-consensus --test tcp_cluster --test leader_reads -- --nocapture
 
 #
 # Fuzzing Targets

--- a/crates/vibesql-consensus/Cargo.toml
+++ b/crates/vibesql-consensus/Cargo.toml
@@ -56,3 +56,8 @@ tempfile = "3.19"
 # `macros` for #[tokio::test]; everything else the tests need (rt, net,
 # io-util, time) is already enabled on the main dependency above.
 tokio = { version = "1.0", features = ["rt", "macros", "time"] }
+# Row-value assertions in the integration tests (tests/leader_reads.rs):
+# `MvccRaftNode::query*` returns `Vec<Vec<SqlValue>>`, and integration
+# test binaries only see dev-dependencies. Same crate the library itself
+# depends on above.
+vibesql-types = { version = "0.1.4", path = "../vibesql-types" }

--- a/crates/vibesql-consensus/src/mvcc_raft.rs
+++ b/crates/vibesql-consensus/src/mvcc_raft.rs
@@ -69,13 +69,64 @@
 //! same crash-safety order as the echo machine, including the deferred
 //! post-install log purge (`DurableLogStore::purge_compacted`).
 //!
+//! # Read paths (Raft Phase B2, #5200, PR 1 of 2)
+//!
+//! Two read modes, one guarantee each:
+//!
+//! - [`MvccRaftNode::query`] — **local, stale-allowed**: runs against
+//!   whatever this node has applied, with no leadership check or network
+//!   round. Available on every node — including a leader partitioned
+//!   into a minority — and may therefore trail the cluster's committed
+//!   state arbitrarily.
+//! - [`MvccRaftNode::query_linearizable`] — **linearizable**: confirms
+//!   this node's leadership through openraft's ReadIndex protocol
+//!   ([`Raft::ensure_linearizable`]: one empty-AppendEntries heartbeat
+//!   round acknowledged by a quorum, then a wait until the local state
+//!   machine reaches the confirmed read index) before running the same
+//!   local query. A node that knows it is not the leader fails with
+//!   [`ConsensusError::NotLeader`] and a leader hint; a node that still
+//!   believes it leads but cannot confirm a quorum (partitioned into a
+//!   minority, deposed but not yet aware) fails with
+//!   [`ConsensusError::NotLeader`] carrying **no** hint — its own view
+//!   is exactly what could not be confirmed, so hinting at itself would
+//!   route callers straight back to a possibly-stale node.
+//!
+//! ## Clock skew: what it can and cannot affect
+//!
+//! The ReadIndex path above is **clock-free**: its correctness rests
+//! solely on a quorum acknowledging the leader's term, never on
+//! wall-clock or monotonic time, so no amount of clock skew or NTP
+//! stepping can make `query_linearizable` return stale data. Clocks
+//! influence only *liveness* (heartbeat and election timeouts run on
+//! each node's local clock).
+//!
+//! The **lease fast path** — serving linearizable reads inside a
+//! quorum-acked time window without a per-read heartbeat round — is
+//! deliberately **not** implemented in this PR. openraft 0.9.24 keeps a
+//! leader lease internally, but only to suppress elections (its
+//! `docs::protocol::leader_lease`); it exposes no lease-based read
+//! policy — `ensure_linearizable` always runs the quorum round
+//! (`ReadPolicy::LeaseRead` arrives with openraft 0.10's
+//! `Raft::ensure_linearizable(read_policy)`). Hand-rolling lease timing
+//! outside the engine would re-introduce the classic lease failure
+//! mode — a deposed leader serving reads past lease expiry under clock
+//! *rate* drift — so the fast path is deferred to an openraft upgrade
+//! (or a follow-on) rather than approximated here. When it lands, the
+//! standard requirements apply: lease duration < election timeout minus
+//! a safety margin, monotonic clock only, warn on NTP step. Follower
+//! reads with bounded staleness (leader wall-clock piggyback, sensitive
+//! to leader↔follower skew within a documented bound, plus a clock-free
+//! index-based read-your-writes session token) are PR 2 of #5200.
+//!
 //! Out of scope here (deliberately): server/CLI wiring of replicated
-//! writes (PostgreSQL-protocol sessions still execute against the local
-//! engine; surfacing `NotLeader` as a SQL error with redirect info is
-//! follow-on work) and leases/follower reads (B2, #5200).
+//! writes and reads (PostgreSQL-protocol sessions still execute against
+//! the local engine; surfacing `NotLeader` as a SQL error with redirect
+//! info is follow-on work, #5383) and follower reads / staleness bounds
+//! (PR 2 of #5200).
 //!
 //! [`RaftStateMachine`]: openraft::storage::RaftStateMachine
 //! [`StorageError`]: openraft::StorageError
+//! [`ConsensusError::NotLeader`]: crate::backend::ConsensusError::NotLeader
 
 #[cfg(test)]
 use std::collections::BTreeMap;
@@ -85,7 +136,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
-use openraft::error::{ClientWriteError, RaftError};
+use openraft::error::{CheckIsLeaderError, ClientWriteError, RaftError};
 use openraft::storage::{RaftLogStorage, RaftStateMachine};
 #[cfg(test)]
 use openraft::ServerState;
@@ -482,8 +533,10 @@ impl RaftStateMachine<TypeConfig> for MvccStateMachine {
 /// accepted only on the leader — anywhere else they fail fast with
 /// [`ConsensusError::NotLeader`] and a leader hint — and resolve only
 /// after the entry is committed and applied locally, so a session can
-/// read its own write. Reads ([`query`](Self::query)) are local
-/// (leader-lease/follower-read semantics are B2, #5200).
+/// read its own write. Reads come in two modes (Raft Phase B2, #5200,
+/// PR 1): [`query`](Self::query) is local and stale-allowed;
+/// [`query_linearizable`](Self::query_linearizable) confirms leadership
+/// with a quorum first (see the module docs' read-path section).
 ///
 /// This is the multi-node successor of the PR 1 harness
 /// (`ReplicatedDb`): same entry type, same freeze-at-propose, same
@@ -721,10 +774,69 @@ impl MvccRaftNode {
         }
     }
 
-    /// Run a read-only SELECT against the locally applied state (reads
-    /// are local, not replicated — see [`VibesqlStateMachine::query`]).
+    /// Run a read-only SELECT against the locally applied state —
+    /// **local, stale-allowed** (see [`VibesqlStateMachine::query`]).
+    ///
+    /// No leadership check, no network round: this is available on every
+    /// node, including a leader partitioned into a minority, and may
+    /// trail the cluster's committed state arbitrarily. For reads that
+    /// must observe every committed write, use
+    /// [`query_linearizable`](Self::query_linearizable).
     pub fn query(&self, sql: &str) -> Result<Vec<Vec<vibesql_types::SqlValue>>> {
         self.sm.machine.query(sql)
+    }
+
+    /// Run a read-only SELECT with **linearizable** semantics (Raft
+    /// Phase B2, #5200, PR 1): openraft's ReadIndex protocol
+    /// ([`Raft::ensure_linearizable`]) first confirms this node's
+    /// leadership with a quorum heartbeat round and waits for the local
+    /// state machine to reach the confirmed read index; only then does
+    /// the query run locally. The whole path is clock-free — see the
+    /// module docs' read-path section, including why the lease fast path
+    /// is deferred. Costs one heartbeat round-trip per read (bounded by
+    /// the heartbeat-interval RPC TTL), which is still far cheaper than
+    /// the full log-append round a replicated write pays.
+    ///
+    /// Fails with [`ConsensusError::NotLeader`]:
+    /// - carrying a leader hint when this node knows it is not the
+    ///   leader (route the read there);
+    /// - carrying **no** hint when this node still believes it leads but
+    ///   could not confirm a quorum (e.g. partitioned into a minority) —
+    ///   its own view is exactly what could not be confirmed, so hinting
+    ///   at itself would route callers back to a possibly-stale node.
+    pub async fn query_linearizable(&self, sql: &str) -> Result<Vec<Vec<vibesql_types::SqlValue>>> {
+        self.raft.ensure_linearizable().await.map_err(|e| self.map_read_error(e))?;
+        self.sm.machine.query(sql)
+    }
+
+    /// Map a failed leadership confirmation onto the adapter error,
+    /// mirroring [`map_write_error`](Self::map_write_error).
+    fn map_read_error(
+        &self,
+        e: RaftError<u64, CheckIsLeaderError<u64, BasicNode>>,
+    ) -> ConsensusError {
+        match e {
+            RaftError::APIError(CheckIsLeaderError::ForwardToLeader(forward)) => {
+                ConsensusError::NotLeader { leader_hint: forward.leader_id }
+            }
+            // Still nominally the leader, but a quorum did not answer the
+            // confirmation heartbeat: serving the read could violate
+            // linearizability (a majority may have elected someone else).
+            // Deliberately no hint — this node's own leadership is what
+            // could not be confirmed.
+            RaftError::APIError(CheckIsLeaderError::QuorumNotEnough(_)) => {
+                ConsensusError::NotLeader { leader_hint: None }
+            }
+            other => {
+                // A halted node surfaces its fatal reason instead of the
+                // engine's shutdown noise (same as the write path).
+                if let Some(reason) = self.fatal_reason() {
+                    ConsensusError::FatalApply(reason)
+                } else {
+                    ConsensusError::Backend(other.to_string())
+                }
+            }
+        }
     }
 
     /// This node's current role in the consensus group.
@@ -1517,5 +1629,61 @@ mod tests {
         cluster.restore(follower).await;
         cluster.wait_for_apply(follower, idx).await;
         cluster.assert_converged("SELECT id, v FROM kv ORDER BY id");
+    }
+
+    // -----------------------------------------------------------------
+    // Raft Phase B2, PR 1 (#5200): linearizable leader reads
+    // (the partition/fencing acceptance runs over real sockets in
+    // tests/leader_reads.rs; these cover the read path's plumbing)
+    // -----------------------------------------------------------------
+
+    /// Read-your-writes through the linearizable path on a single voter
+    /// (quorum of one): a just-acknowledged write is visible, and the
+    /// linearizable result matches the local read exactly.
+    #[tokio::test]
+    async fn single_node_linearizable_read_sees_own_write() {
+        let node = MvccRaftNode::single_node().await.unwrap();
+        node.execute_replicated("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)").await.unwrap();
+        node.execute_replicated("INSERT INTO t VALUES (1, 'one')").await.unwrap();
+
+        let rows = node.query_linearizable("SELECT id, v FROM t").await.unwrap();
+        assert_eq!(rows, vec![vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())]]);
+        assert_eq!(rows, node.query("SELECT id, v FROM t").unwrap());
+    }
+
+    /// A follower never serves a linearizable read: it redirects with a
+    /// leader hint, while its plain local read keeps working
+    /// (stale-allowed by contract).
+    #[tokio::test]
+    async fn linearizable_read_on_follower_redirects_to_the_leader() {
+        let cluster = MvccCluster::new(3).await;
+        let (idx, _) = cluster.execute_on_leader("CREATE TABLE t (id INTEGER PRIMARY KEY)").await;
+
+        let leader = cluster.wait_for_leader().await;
+        let follower = follower_of(&cluster, leader);
+        // Wait until the follower has heard from the leader, so the hint
+        // is deterministic rather than `None`.
+        cluster
+            .wait_until("the follower to learn who leads", || {
+                (cluster.node(follower).current_leader() == Some(leader)).then_some(())
+            })
+            .await;
+
+        let err = cluster.node(follower).query_linearizable("SELECT id FROM t").await.unwrap_err();
+        match err {
+            ConsensusError::NotLeader { leader_hint } => assert_eq!(leader_hint, Some(leader)),
+            other => panic!("expected NotLeader with a hint, got: {other:?}"),
+        }
+
+        // The stale-allowed local read stays available on the follower.
+        cluster.wait_for_apply(follower, idx).await;
+        assert_eq!(
+            cluster.node(follower).query("SELECT id FROM t").unwrap(),
+            Vec::<Vec<SqlValue>>::new()
+        );
+
+        // And the leader serves the linearizable read it just confirmed.
+        let rows = cluster.node(leader).query_linearizable("SELECT id FROM t").await.unwrap();
+        assert!(rows.is_empty(), "no rows inserted yet, got: {rows:?}");
     }
 }

--- a/crates/vibesql-consensus/tests/leader_reads.rs
+++ b/crates/vibesql-consensus/tests/leader_reads.rs
@@ -1,0 +1,469 @@
+//! Linearizable leader reads over real sockets (Raft Phase B2, #5200,
+//! PR 1 of 2) — the stale-leader fencing acceptance.
+//!
+//! Boots 3-voter [`MvccRaftNode`] clusters whose Raft RPCs travel over the
+//! TCP transport, with every directed edge optionally behind a severable
+//! TCP proxy (the partition machinery introduced for #5197's minority-
+//! partition test), and proves the B2 PR 1 read-path contract end-to-end:
+//!
+//! - a leader serves `query_linearizable` and sees its own writes;
+//! - a follower redirects linearizable reads with a leader hint while its
+//!   plain `query` keeps serving (stale-allowed by contract);
+//! - **fencing**: a leader partitioned into the minority FAILS
+//!   `query_linearizable` (it cannot confirm a quorum) while the
+//!   majority's new leader serves both writes and linearizable reads; the
+//!   minority leader's plain local read stays available but stale; after
+//!   the heal the deposed leader steps down and redirects at the real
+//!   leader.
+//!
+//! The `Proxy` here intentionally duplicates the one in
+//! `tests/tcp_cluster.rs`: integration-test binaries are separate crates,
+//! and keeping this file self-contained also keeps it conflict-free with
+//! parallel work on the echo-cluster suite (#5385).
+//!
+//! All synchronization is bounded polling (10s deadline) — no bare
+//! sleeps; every wait fails loudly instead of hanging.
+
+use std::collections::BTreeMap;
+use std::net::TcpListener as StdTcpListener;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinHandle;
+
+use vibesql_consensus::{
+    ApplyOutcome, ClusterConfig, ConsensusError, LogIndex, MvccRaftNode, Role,
+};
+use vibesql_types::SqlValue;
+
+/// Upper bound for any single cluster-level wait (election, catch-up,
+/// fencing rejection).
+const WAIT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Poll interval inside bounded waits.
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Reserve `n` distinct localhost addresses with OS-assigned ephemeral
+/// ports, keyed by node id `1..=n` (same strategy as tcp_cluster.rs: all
+/// reservations held at once, released just before the nodes bind them).
+fn free_localhost_addrs(n: u64) -> BTreeMap<u64, String> {
+    let listeners: Vec<(u64, StdTcpListener)> = (1..=n)
+        .map(|id| (id, StdTcpListener::bind("127.0.0.1:0").expect("reserve ephemeral port")))
+        .collect();
+    listeners
+        .iter()
+        .map(|(id, listener)| {
+            (*id, listener.local_addr().expect("reserved port address").to_string())
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Per-edge TCP proxy (partition injection) — see tests/tcp_cluster.rs
+// ---------------------------------------------------------------------------
+
+/// A severable TCP forwarder for one directed cluster edge.
+///
+/// While connected, accepted connections are forwarded byte-for-byte to
+/// the target. [`sever`](Self::sever) kills every live forwarded
+/// connection (both endpoints see a dead socket) and makes the proxy
+/// accept-then-drop new ones, so dialers get a connection that dies on
+/// first use — openraft maps either to `Unreachable` and backs off,
+/// exactly like a real partition.
+struct Proxy {
+    /// Address the source node dials instead of the target's real address.
+    addr: String,
+    enabled: Arc<AtomicBool>,
+    /// Live forwarder tasks; aborted (sockets dropped) on sever.
+    conns: Arc<Mutex<Vec<JoinHandle<()>>>>,
+    accept_task: JoinHandle<()>,
+}
+
+impl Proxy {
+    async fn spawn(target: String) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind proxy listener");
+        let addr = listener.local_addr().expect("proxy address").to_string();
+        let enabled = Arc::new(AtomicBool::new(true));
+        let conns: Arc<Mutex<Vec<JoinHandle<()>>>> = Arc::default();
+
+        let accept_task = tokio::spawn({
+            let enabled = Arc::clone(&enabled);
+            let conns = Arc::clone(&conns);
+            async move {
+                loop {
+                    let Ok((mut inbound, _)) = listener.accept().await else {
+                        tokio::time::sleep(POLL_INTERVAL).await;
+                        continue;
+                    };
+                    if !enabled.load(Ordering::SeqCst) {
+                        continue; // dropping `inbound` hangs up on the dialer
+                    }
+                    let target = target.clone();
+                    let forwarder = tokio::spawn(async move {
+                        let Ok(mut outbound) = TcpStream::connect(&target).await else { return };
+                        let _ = tokio::io::copy_bidirectional(&mut inbound, &mut outbound).await;
+                    });
+                    let mut conns = conns.lock().expect("proxy connection list poisoned");
+                    conns.retain(|handle| !handle.is_finished());
+                    conns.push(forwarder);
+                }
+            }
+        });
+
+        Self { addr, enabled, conns, accept_task }
+    }
+
+    /// Cut the edge: live connections die, new ones are accepted and
+    /// immediately dropped.
+    fn sever(&self) {
+        self.enabled.store(false, Ordering::SeqCst);
+        let mut conns = self.conns.lock().expect("proxy connection list poisoned");
+        for handle in conns.drain(..) {
+            handle.abort();
+        }
+    }
+
+    /// Reconnect the edge for new connections.
+    fn reconnect(&self) {
+        self.enabled.store(true, Ordering::SeqCst);
+    }
+}
+
+impl Drop for Proxy {
+    fn drop(&mut self) {
+        self.accept_task.abort();
+        self.sever();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MVCC cluster harness
+// ---------------------------------------------------------------------------
+
+/// A 3-voter MVCC cluster over the TCP transport, optionally with every
+/// directed edge behind a severable [`Proxy`].
+struct MvccTcpCluster {
+    nodes: BTreeMap<u64, MvccRaftNode>,
+    /// Directed-edge proxies; empty unless built with
+    /// [`boot_partitionable`](Self::boot_partitionable).
+    proxies: BTreeMap<(u64, u64), Proxy>,
+}
+
+impl MvccTcpCluster {
+    /// Boot `n` voters (ids `1..=n`) dialing each other directly.
+    async fn boot(n: u64) -> Self {
+        Self::build(n, false).await
+    }
+
+    /// Like [`boot`](Self::boot), but every directed edge runs through a
+    /// severable [`Proxy`], enabling [`partition`](Self::partition).
+    async fn boot_partitionable(n: u64) -> Self {
+        Self::build(n, true).await
+    }
+
+    async fn build(n: u64, with_proxies: bool) -> Self {
+        let addrs = free_localhost_addrs(n);
+
+        let mut proxies = BTreeMap::new();
+        if with_proxies {
+            for a in 1..=n {
+                for b in 1..=n {
+                    if a != b {
+                        proxies.insert((a, b), Proxy::spawn(addrs[&b].clone()).await);
+                    }
+                }
+            }
+        }
+
+        let mut nodes = BTreeMap::new();
+        for id in 1..=n {
+            // Node `id`'s view: its own real address (it binds it), every
+            // peer behind this node's outgoing proxy when partitionable.
+            let view = (1..=n).map(|peer| {
+                let addr = if peer == id || !with_proxies {
+                    addrs[&peer].clone()
+                } else {
+                    proxies[&(id, peer)].addr.clone()
+                };
+                (peer, addr)
+            });
+            let config = ClusterConfig::new(view).expect("valid cluster config");
+            let node =
+                MvccRaftNode::join_tcp_cluster(id, &config).await.expect("boot mvcc tcp node");
+            nodes.insert(id, node);
+        }
+
+        Self { nodes, proxies }
+    }
+
+    fn node(&self, id: u64) -> &MvccRaftNode {
+        &self.nodes[&id]
+    }
+
+    fn ids(&self) -> Vec<u64> {
+        self.nodes.keys().copied().collect()
+    }
+
+    /// Sever every directed edge between `minority` and the rest of the
+    /// cluster, in both directions. Panics unless built partitionable.
+    fn partition(&self, minority: &[u64]) {
+        assert!(!self.proxies.is_empty(), "cluster was not built partitionable");
+        for (&(a, b), proxy) in &self.proxies {
+            if minority.contains(&a) != minority.contains(&b) {
+                proxy.sever();
+            }
+        }
+    }
+
+    /// Reconnect every severed edge.
+    fn heal(&self) {
+        for proxy in self.proxies.values() {
+            proxy.reconnect();
+        }
+    }
+
+    /// Wait (bounded) until one of `ids` reports itself leader **and**
+    /// every node in `ids` acknowledges it; returns the leader. Requiring
+    /// agreement matters over TCP — see tcp_cluster.rs for the rationale.
+    async fn wait_for_leader_among(&self, ids: &[u64]) -> u64 {
+        self.wait_until(&format!("an acknowledged leader among {ids:?}"), || {
+            let leader = ids.iter().copied().find(|id| self.node(*id).role() == Role::Leader)?;
+            ids.iter().all(|id| self.node(*id).current_leader() == Some(leader)).then_some(leader)
+        })
+        .await
+    }
+
+    /// Wait (bounded) until node `id` has applied the dense index `idx`.
+    async fn wait_for_apply(&self, id: u64, idx: LogIndex) {
+        self.wait_until(&format!("node {id} to apply dense index {idx}"), || {
+            (self.node(id).last_applied() >= idx).then_some(())
+        })
+        .await;
+    }
+
+    /// Execute one replicated write through whoever currently leads among
+    /// `ids`, re-resolving leadership if an election moves it mid-call.
+    /// Returns the node that committed the write plus the entry's dense
+    /// index and outcome.
+    async fn execute_on_leader_among(
+        &self,
+        ids: &[u64],
+        sql: &str,
+    ) -> (u64, LogIndex, ApplyOutcome) {
+        let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+        loop {
+            let leader = self.wait_for_leader_among(ids).await;
+            match self.node(leader).execute_replicated(sql).await {
+                Ok((idx, outcome)) => return (leader, idx, outcome),
+                Err(ConsensusError::NotLeader { .. }) => {
+                    assert!(
+                        tokio::time::Instant::now() < deadline,
+                        "timed out executing {sql:?}: leadership never settled"
+                    );
+                }
+                Err(other) => panic!("execute of {sql:?} failed: {other:?}"),
+            }
+        }
+    }
+
+    /// Poll `probe` until it yields a value, panicking after
+    /// [`WAIT_TIMEOUT`].
+    async fn wait_until<T>(&self, what: &str, mut probe: impl FnMut() -> Option<T>) -> T {
+        let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+        loop {
+            if let Some(value) = probe() {
+                return value;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out after {WAIT_TIMEOUT:?} waiting for {what}"
+            );
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+
+    async fn shutdown(self) {
+        for node in self.nodes.values() {
+            node.shutdown().await.expect("clean shutdown");
+        }
+    }
+}
+
+/// Run `query_linearizable` on node `id` with a loud bound: fencing and
+/// redirects must resolve within [`WAIT_TIMEOUT`], never hang.
+async fn linearizable(
+    cluster: &MvccTcpCluster,
+    id: u64,
+    sql: &str,
+) -> Result<Vec<Vec<SqlValue>>, ConsensusError> {
+    tokio::time::timeout(WAIT_TIMEOUT, cluster.node(id).query_linearizable(sql))
+        .await
+        .expect("query_linearizable must resolve within the bounded wait")
+}
+
+// ---------------------------------------------------------------------------
+// B2 PR 1 scenarios
+// ---------------------------------------------------------------------------
+
+/// Healthy-cluster contract: the leader's linearizable read sees its own
+/// just-acknowledged write; a follower redirects linearizable reads with
+/// a leader hint while its plain local read keeps serving (stale-allowed
+/// by contract).
+#[tokio::test]
+async fn leader_serves_linearizable_reads_and_followers_redirect() {
+    let cluster = MvccTcpCluster::boot(3).await;
+    let all = cluster.ids();
+
+    let (_, idx, outcome) = cluster
+        .execute_on_leader_among(&all, "CREATE TABLE accounts (id INTEGER PRIMARY KEY, v TEXT)")
+        .await;
+    assert_eq!((idx, outcome), (1, ApplyOutcome::Applied { rows_affected: 0 }));
+
+    // Read-your-writes: insert through the leader and immediately read
+    // linearizably on the same node — the row must be visible.
+    let (leader, idx, outcome) =
+        cluster.execute_on_leader_among(&all, "INSERT INTO accounts VALUES (1, 'one')").await;
+    assert_eq!((idx, outcome), (2, ApplyOutcome::Applied { rows_affected: 1 }));
+    let rows = linearizable(&cluster, leader, "SELECT id, v FROM accounts")
+        .await
+        .expect("the node that just acknowledged the write must serve a linearizable read");
+    assert_eq!(rows, vec![vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())]]);
+
+    // A follower that knows who leads redirects with that hint.
+    let follower = all.iter().copied().find(|id| *id != leader).expect("a follower exists");
+    cluster
+        .wait_until("the follower to learn who leads", || {
+            (cluster.node(follower).current_leader() == Some(leader)).then_some(())
+        })
+        .await;
+    match linearizable(&cluster, follower, "SELECT id, v FROM accounts").await {
+        Err(ConsensusError::NotLeader { leader_hint }) => assert_eq!(leader_hint, Some(leader)),
+        other => panic!("a follower must redirect linearizable reads, got: {other:?}"),
+    }
+
+    // ...while its plain local read keeps working once it has applied.
+    cluster.wait_for_apply(follower, idx).await;
+    assert_eq!(cluster.node(follower).query("SELECT id, v FROM accounts").unwrap(), rows);
+
+    cluster.shutdown().await;
+}
+
+/// The B2 PR 1 fencing acceptance (curator criterion on #5200): a leader
+/// partitioned into the minority must FAIL linearizable reads — it cannot
+/// confirm a quorum — while the majority's new leader serves both writes
+/// and linearizable reads. The minority leader's plain local read stays
+/// available but stale (documented stale-allowed). After the heal, the
+/// deposed leader steps down, converges, and redirects linearizable reads
+/// at the real leader.
+#[tokio::test]
+async fn partitioned_stale_leader_is_fenced_from_linearizable_reads() {
+    let cluster = MvccTcpCluster::boot_partitionable(3).await;
+    let all = cluster.ids();
+
+    // Seed history and pin down the pre-partition leader: the node that
+    // just committed a write is the (confirmed) leader.
+    cluster.execute_on_leader_among(&all, "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)").await;
+    let (old_leader, idx, outcome) =
+        cluster.execute_on_leader_among(&all, "INSERT INTO t VALUES (1, 'one')").await;
+    assert_eq!((idx, outcome), (2, ApplyOutcome::Applied { rows_affected: 1 }));
+    for id in &all {
+        cluster.wait_for_apply(*id, idx).await;
+    }
+
+    // Pre-partition sanity: the leader serves linearizable reads.
+    let seeded = vec![vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())]];
+    assert_eq!(
+        linearizable(&cluster, old_leader, "SELECT id, v FROM t ORDER BY id").await.unwrap(),
+        seeded
+    );
+
+    // 2-1 split with the leader alone on the minority side.
+    cluster.partition(&[old_leader]);
+
+    // FENCING: the partitioned leader cannot confirm a quorum, so the
+    // linearizable read fails — with no hint, because its own leadership
+    // is exactly what could not be confirmed (hinting at itself would
+    // route callers back to a stale node).
+    match linearizable(&cluster, old_leader, "SELECT id, v FROM t").await {
+        Err(ConsensusError::NotLeader { leader_hint }) => assert_eq!(
+            leader_hint, None,
+            "a quorum-less leader must not hint at anyone (least of all itself)"
+        ),
+        other => panic!("the partitioned leader must be fenced, got: {other:?}"),
+    }
+
+    // ...while its plain local read stays available (stale-allowed).
+    assert_eq!(
+        cluster.node(old_leader).query("SELECT id, v FROM t ORDER BY id").unwrap(),
+        seeded,
+        "the minority leader's local read must keep serving the stale prefix"
+    );
+
+    // Majority side: a new leader emerges and serves writes AND
+    // linearizable reads.
+    let majority: Vec<u64> = all.iter().copied().filter(|id| *id != old_leader).collect();
+    let (new_leader, idx2, outcome) =
+        cluster.execute_on_leader_among(&majority, "INSERT INTO t VALUES (2, 'two')").await;
+    assert_ne!(new_leader, old_leader);
+    assert_eq!(
+        (idx2, outcome),
+        (3, ApplyOutcome::Applied { rows_affected: 1 }),
+        "the fenced reads must not have consumed a log index"
+    );
+    let both = vec![
+        vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())],
+        vec![SqlValue::Integer(2), SqlValue::Varchar("two".into())],
+    ];
+    assert_eq!(
+        linearizable(&cluster, new_leader, "SELECT id, v FROM t ORDER BY id").await.unwrap(),
+        both
+    );
+
+    // The minority leader is provably stale now (it cannot have applied
+    // the majority write) — its local read still shows only the prefix,
+    // and the linearizable path still refuses to serve it.
+    assert_eq!(cluster.node(old_leader).query("SELECT id, v FROM t ORDER BY id").unwrap(), seeded);
+    assert!(
+        matches!(
+            linearizable(&cluster, old_leader, "SELECT id, v FROM t").await,
+            Err(ConsensusError::NotLeader { leader_hint: None })
+        ),
+        "the stale leader must stay fenced for as long as the partition lasts"
+    );
+
+    cluster.heal();
+
+    // The deposed leader steps down once the new leader's heartbeats
+    // reach it, learns who leads, and converges on the majority history.
+    cluster
+        .wait_until("the old leader to step down and learn who leads", || {
+            (cluster.node(old_leader).role() == Role::Follower
+                && cluster.node(old_leader).current_leader() == Some(new_leader))
+            .then_some(())
+        })
+        .await;
+    cluster.wait_for_apply(old_leader, idx2).await;
+
+    // Now it redirects linearizable reads at the real leader...
+    match linearizable(&cluster, old_leader, "SELECT id, v FROM t").await {
+        Err(ConsensusError::NotLeader { leader_hint }) => assert_eq!(leader_hint, Some(new_leader)),
+        other => panic!("the deposed leader must redirect, got: {other:?}"),
+    }
+
+    // ...the leader serves them, and everyone's local state converged.
+    assert_eq!(
+        linearizable(&cluster, new_leader, "SELECT id, v FROM t ORDER BY id").await.unwrap(),
+        both
+    );
+    for id in &all {
+        assert_eq!(
+            cluster.node(*id).query("SELECT id, v FROM t ORDER BY id").unwrap(),
+            both,
+            "node {id} diverged after the heal"
+        );
+    }
+
+    cluster.shutdown().await;
+}


### PR DESCRIPTION
Part of #5200 (PR 1 of 2 — leader read path; follower reads + `max_staleness` are PR 2).

## Summary

- **Linearizable leader reads**: new `MvccRaftNode::query_linearizable`, gated on openraft 0.9.24's `Raft::ensure_linearizable()` — the ReadIndex protocol (one empty-AppendEntries heartbeat round acknowledged by a quorum, then a wait until the local state machine reaches the confirmed read index) before the local MVCC query runs. Error surface:
  - follower / deposed-and-aware → `NotLeader` **with** leader hint;
  - nominal leader that cannot confirm a quorum (`QuorumNotEnough`, e.g. partitioned into the minority) → `NotLeader` with **no** hint — its own leadership is exactly what could not be confirmed, so hinting at itself would route callers back to a stale node.
- **Plain `query` stays local and is now explicitly documented as stale-allowed** (available even on a minority-partitioned leader).
- **Clock-skew documentation** (module docs in `mvcc_raft.rs`): the ReadIndex path is clock-free — no skew or NTP step can make it return stale data; clocks affect liveness only. The lease path's skew sensitivity (lease < election timeout minus margin, monotonic clock, NTP-step warning) is documented for when the fast path lands.

## Lease fast-path finding (openraft 0.9.24)

openraft 0.9.24 **does** maintain a leader lease internally, but only to suppress elections (`src/docs/protocol/leader_lease.md`); it exposes **no lease-based read policy** — `ensure_linearizable()` always runs the quorum heartbeat round (verified against the vendored 0.9.24 source: `handle_check_is_leader_request` spawns empty AppendEntries to all voters and waits for a quorum, bounded by the heartbeat-interval RPC TTL). `ReadPolicy::LeaseRead` arrives with openraft 0.10's `ensure_linearizable(read_policy)`. Per the curator's re-scope, the lease fast path is therefore **deferred** (openraft upgrade or follow-on) rather than hand-rolled — hand-rolled lease timing outside the engine is precisely the deposed-leader-serves-past-expiry failure mode the ADR warns about.

## Tests

New `tests/leader_reads.rs` (self-contained severable-proxy harness, deliberately separate from `tests/tcp_cluster.rs` to stay conflict-free with #5385):

- `leader_serves_linearizable_reads_and_followers_redirect` — read-your-writes on the leader (write → immediate linearizable read sees it); follower redirects with hint; follower's plain local read keeps serving.
- `partitioned_stale_leader_is_fenced_from_linearizable_reads` — **the named acceptance**: 3-node TCP cluster, per-edge severable proxies, 2-1 split with the leader in the minority. The old leader FAILS `query_linearizable` (NotLeader, no hint, bounded) for the whole partition while its plain `query` stays available (stale: still shows only the pre-partition prefix); the majority's new leader serves writes and linearizable reads (fenced reads consume no log index); heal → old leader steps down, converges, and redirects linearizable reads at the real leader.

Plus unit tests on the channel transport (`single_node_linearizable_read_sees_own_write`, `linearizable_read_on_follower_redirects_to_the_leader`).

`make test-cluster` now also runs the new suite.

## Verification

- `cargo test -p vibesql-consensus`: green (149 tests), both default and `--features mvcc_enabled` (152).
- `cargo clippy -p vibesql-consensus --all-targets`, both feature states: no warnings attributable to this crate.
- `cargo build --workspace`: green.
- `make test-cluster`: green.
- **Flake check**: 15/15 consecutive green runs of the new integration + unit tests.

### Pre-existing flake (not introduced here)

`tcp_cluster.rs::snapshot_transfer_spans_many_chunks` flakes intermittently in `--release` (`NotLeader { leader_hint: Some(2) }` from `propose` at tcp_cluster.rs:659 — a mid-test re-election while the harness keeps proposing to the leader it pinned at start). Reproduced on the **unmodified base** (ee6681c1f, changes stashed): 1 failure in 23 baseline release runs, identical panic/line. Untouched by this PR; will file a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)