### PR TITLE
feat(consensus): bounded-staleness follower reads + read-your-writes tokens (phase B2, PR 2/2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,10 +302,12 @@ test-tcl-status:
 # Boots 3-voter clusters on localhost (ephemeral ports, durable Raft logs)
 # wired by the TCP transport and exercises election, replication, leader
 # kill -> re-election, restart -> catch-up, a 2-1 minority partition, and
-# garbage frames on the wire — plus the Raft Phase B2 (#5200) linearizable
-# leader-read / stale-leader fencing scenarios. Exits nonzero on any failure.
+# garbage frames on the wire — plus the Raft Phase B2 (#5200) read-path
+# scenarios: linearizable leader reads / stale-leader fencing, and the
+# follower-read suite (read-your-writes tokens, bounded staleness on
+# partitioned followers). Exits nonzero on any failure.
 test-cluster:
-	cargo test --release -p vibesql-consensus --test tcp_cluster --test leader_reads -- --nocapture
+	cargo test --release -p vibesql-consensus --test tcp_cluster --test leader_reads --test follower_reads -- --nocapture
 
 #
 # Fuzzing Targets

--- a/crates/vibesql-consensus/src/backend.rs
+++ b/crates/vibesql-consensus/src/backend.rs
@@ -48,6 +48,54 @@ pub enum ConsensusError {
     /// The requested log index has not been committed (or never existed).
     #[error("log index {0} is not committed")]
     NotCommitted(LogIndex),
+    /// A read-your-writes read (Raft Phase B2, #5200, PR 2:
+    /// `MvccRaftNode::query_at_least`) gave up waiting: this node's
+    /// applied state had not reached the session token within the
+    /// caller's bound. The local state is intact — the caller may retry
+    /// here later, or route the read to the leader (`leader_hint`, when
+    /// known), which by construction has applied every index it ever
+    /// returned from a propose.
+    #[error(
+        "read-your-writes wait expired: this node has applied index {applied}, the session \
+         token requires {required} (leader hint: {leader_hint:?})"
+    )]
+    ReadTimeout {
+        /// The session token: the dense application index the read must
+        /// observe (as returned by the write's propose).
+        required: LogIndex,
+        /// The dense application index this node had reached when the
+        /// wait expired.
+        applied: LogIndex,
+        /// Best-effort identifier of the current leader, if known.
+        leader_hint: Option<u64>,
+    },
+    /// A bounded-staleness read (Raft Phase B2, #5200, PR 2:
+    /// `MvccRaftNode::query_bounded_staleness`) was refused because this
+    /// node could not prove its applied state is no staler than the
+    /// caller's bound. Route the read to the leader (`leader_hint`, when
+    /// known) or retry with a larger bound.
+    #[error(
+        "bounded-staleness read refused: observed staleness {observed_ms:?}ms exceeds the \
+         {max_staleness_ms}ms bound (None = unknown — no leader-stamped entry applied yet; \
+         leader hint: {leader_hint:?})"
+    )]
+    StalenessExceeded {
+        /// Milliseconds elapsed (per this node's clock) since the
+        /// leader-clock stamp of the last stamped entry this node
+        /// applied; `None` when no stamped entry has been applied yet
+        /// (fresh node, pre-#5200 log prefix, or just after a snapshot
+        /// install on a fresh node) — unknown staleness is treated as
+        /// unbounded.
+        observed_ms: Option<u64>,
+        /// The caller's staleness bound, in milliseconds.
+        max_staleness_ms: u64,
+        /// Best-effort identifier of the current leader, if known.
+        /// Deliberately `None` when the refusing node itself believes it
+        /// leads: stale stamps on a "leader" suggest it has been deposed
+        /// or partitioned, and hinting at itself would route callers
+        /// straight back.
+        leader_hint: Option<u64>,
+    },
     /// Snapshot serialization or deserialization failed.
     #[error("snapshot encode/decode failed: {0}")]
     SnapshotCodec(String),

--- a/crates/vibesql-consensus/src/lib.rs
+++ b/crates/vibesql-consensus/src/lib.rs
@@ -115,11 +115,28 @@
 //!   binary database payload heals followers that fell behind a purge,
 //!   with the Phase A4 durability order (persist before acknowledge).
 //!
+//! Phase B2 (#5200) adds the **read paths** on [`MvccRaftNode`] (see the
+//! `mvcc_raft` module docs' read-path sections for the full contracts):
+//!
+//! - PR 1: `query_linearizable` — openraft's ReadIndex protocol
+//!   (clock-free quorum confirmation), with stale-leader fencing and
+//!   no-self-hint discipline; plain `query` stays local/stale-allowed.
+//! - PR 2: `query_at_least` — clock-free **read-your-writes** via the
+//!   dense application index a propose returns, served on any node once
+//!   it catches up; and `query_bounded_staleness` — follower reads
+//!   bounded by the leader wall-clock stamp piggybacked on every
+//!   proposed entry ([`TxnEntry::leader_time_ms`], serde-compatible both
+//!   ways), refusing whenever the bound cannot be proven. Idle clusters
+//!   either age out of bounded reads (default) or stay fresh via the
+//!   opt-in staleness beacon ([`RaftTuning::staleness_beacon_ms`]).
+//!
 //! Deliberately **not** here yet (later Raft phases): TLS on the
 //! consensus port, production wiring into `vibesql-server` (PostgreSQL
 //! sessions do not yet route writes through [`MvccRaftNode`]; surfacing
-//! `NotLeader` as a SQL error is follow-on work), and membership
-//! changes.
+//! `NotLeader` as a SQL error and mapping the `max_staleness_ms` PG
+//! option onto `query_bounded_staleness` is follow-on work, #5383), the
+//! lease fast path for linearizable reads (needs openraft 0.10's
+//! `ReadPolicy::LeaseRead`), and membership changes.
 //!
 //! Note on retention: the Raft log purge gated above is orthogonal to the
 //! pre-existing data-WAL checkpoint/truncation in `vibesql-storage::wal`

--- a/crates/vibesql-consensus/src/mvcc_raft.rs
+++ b/crates/vibesql-consensus/src/mvcc_raft.rs
@@ -69,9 +69,9 @@
 //! same crash-safety order as the echo machine, including the deferred
 //! post-install log purge (`DurableLogStore::purge_compacted`).
 //!
-//! # Read paths (Raft Phase B2, #5200, PR 1 of 2)
+//! # Read paths (Raft Phase B2, #5200)
 //!
-//! Two read modes, one guarantee each:
+//! Four read modes, one guarantee each:
 //!
 //! - [`MvccRaftNode::query`] — **local, stale-allowed**: runs against
 //!   whatever this node has applied, with no leadership check or network
@@ -90,6 +90,59 @@
 //!   [`ConsensusError::NotLeader`] carrying **no** hint — its own view
 //!   is exactly what could not be confirmed, so hinting at itself would
 //!   route callers straight back to a possibly-stale node.
+//! - [`MvccRaftNode::query_at_least`] — **read-your-writes** (PR 2 of 2,
+//!   clock-free): a session carries the **dense application index** its
+//!   last write's propose returned as a token; any node — leader or
+//!   follower — serves the read once its locally applied dense index
+//!   reaches the token (waiting up to the caller's bound, then failing
+//!   with [`ConsensusError::ReadTimeout`]). Dense indices are identical
+//!   on every replica (see *Index mapping* above) and
+//!   [`execute_replicated`](MvccRaftNode::execute_replicated) returns
+//!   exactly the dense index its entry consumed, so a token minted by a
+//!   leader propose compares like-with-like against any follower's
+//!   applied cursor. Exact, no clocks involved.
+//! - [`MvccRaftNode::query_bounded_staleness`] — **bounded staleness**
+//!   (PR 2 of 2): serves locally iff this node can prove its applied
+//!   state is no staler than the caller's bound, refusing otherwise
+//!   with [`ConsensusError::StalenessExceeded`] (route to the leader or
+//!   retry with a larger bound). A bound of **zero** delegates to
+//!   [`query_linearizable`](MvccRaftNode::query_linearizable) — on a
+//!   follower that is exactly the "staleness 0 redirects to the leader"
+//!   contract.
+//!
+//! ## Bounded staleness: the leader wall-clock piggyback (PR 2 of 2)
+//!
+//! openraft 0.9.24's heartbeats are engine-internal empty AppendEntries
+//! frames with no application payload, so the leader's clock cannot
+//! ride on them without forking the engine. The carrier is therefore
+//! the **log itself**: every entry [`MvccRaftNode`] proposes is stamped
+//! with the leader's wall clock at propose time
+//! ([`TxnEntry::leader_time_ms`] — serde-compatible both ways: pre-#5200
+//! entries decode as unstamped, unstamped entries keep the pre-#5200
+//! byte encoding). Each replica records the stamp of the freshest
+//! stamped entry it has applied, and a bounded read with bound `S` is
+//! served iff `now - last_stamp <= S` on the serving node's own clock.
+//! The stamp is taken at *propose* time — before replication and apply —
+//! so the observed staleness already over-counts replication latency:
+//! the sound direction. A node that has never applied a stamped entry
+//! (fresh boot, pre-#5200 log prefix, or a snapshot installed onto a
+//! fresh node — engine snapshots carry no stamps) treats its staleness
+//! as **unknown** and refuses bounded reads until a stamped entry
+//! arrives; an unstamped entry advances the applied cursor but retains
+//! the previous (older) stamp, which only weakens the freshness claim —
+//! also sound.
+//!
+//! **Idle clusters**: with no writes, the last stamp simply ages, and a
+//! perfectly healthy idle follower ends up refusing bounded reads. Two
+//! supported answers, chosen per deployment: (a) leave it — bounded
+//! reads refuse and callers fall back to leader reads (the default;
+//! zero overhead, zero log noise); or (b) enable the app-level
+//! **staleness beacon** ([`RaftTuning::staleness_beacon_ms`], off by
+//! default): the leader proposes an empty, stamped no-op transaction
+//! entry whenever no stamped entry has been applied within the window,
+//! keeping idle followers fresh at the cost of one tiny log entry per
+//! window (which consumes a dense index / commit_ts like any entry — a
+//! no-op transaction, no rows touched).
 //!
 //! ## Clock skew: what it can and cannot affect
 //!
@@ -113,16 +166,38 @@
 //! *rate* drift — so the fast path is deferred to an openraft upgrade
 //! (or a follow-on) rather than approximated here. When it lands, the
 //! standard requirements apply: lease duration < election timeout minus
-//! a safety margin, monotonic clock only, warn on NTP step. Follower
-//! reads with bounded staleness (leader wall-clock piggyback, sensitive
-//! to leader↔follower skew within a documented bound, plus a clock-free
-//! index-based read-your-writes session token) are PR 2 of #5200.
+//! a safety margin, monotonic clock only, warn on NTP step.
+//!
+//! Of the PR 2 read modes, [`query_at_least`](MvccRaftNode::query_at_least)
+//! is fully clock-free (pure index comparison — skew-immune like the
+//! ReadIndex path). [`query_bounded_staleness`](MvccRaftNode::query_bounded_staleness)
+//! is the one read mode whose *bound* — not its data integrity, which
+//! MVCC snapshots at the applied index guarantee regardless — depends on
+//! wall clocks: staleness is measured as `follower_now - leader_stamp`,
+//! so leader↔follower clock skew adds (or subtracts) directly. Honest
+//! accounting of the real bound a caller gets: **true staleness ≤
+//! max_staleness + skew**, where `skew` is how far the follower's clock
+//! runs *behind* the leader's (a follower running behind under-measures
+//! staleness; one running ahead over-measures and refuses early — only
+//! the behind direction weakens the guarantee). Deployments relying on
+//! tight bounds therefore assume NTP-disciplined clocks and should
+//! budget the expected sync error (and the beacon/heartbeat interval)
+//! into `max_staleness`; an NTP step on the *leader* makes stamps jump,
+//! which at worst makes followers refuse (backward step ages stamps) or
+//! briefly under-measure by the step size (forward step). This is
+//! exactly the documented-skew-term bound from the curator's
+//! acceptance criteria — bounded, never silently unbounded.
 //!
 //! Out of scope here (deliberately): server/CLI wiring of replicated
-//! writes and reads (PostgreSQL-protocol sessions still execute against
+//! writes and reads — PostgreSQL-protocol sessions still execute against
 //! the local engine; surfacing `NotLeader` as a SQL error with redirect
-//! info is follow-on work, #5383) and follower reads / staleness bounds
-//! (PR 2 of #5200).
+//! info, and mapping a per-connection/per-statement `max_staleness_ms`
+//! PG option onto
+//! [`query_bounded_staleness`](MvccRaftNode::query_bounded_staleness)
+//! (plus propose-returned tokens onto
+//! [`query_at_least`](MvccRaftNode::query_at_least) for session-level
+//! read-your-writes), is follow-on work in #5383
+//! (`crates/vibesql-server/src/session.rs`).
 //!
 //! [`RaftStateMachine`]: openraft::storage::RaftStateMachine
 //! [`StorageError`]: openraft::StorageError
@@ -144,6 +219,7 @@ use openraft::{
     BasicNode, Entry, EntryPayload, LogId, Raft, RaftSnapshotBuilder, SnapshotMeta, StorageError,
     StorageIOError, StoredMembership,
 };
+use tokio::sync::watch;
 
 use crate::snapshot::SnapshotHorizonPin as _;
 
@@ -197,6 +273,23 @@ struct StoredMvccSnapshot {
     data: Vec<u8>,
 }
 
+/// The applied-state stamp broadcast by the mounted machine after every
+/// apply and snapshot install (Raft Phase B2, #5200, PR 2 bookkeeping):
+/// what the staleness-bounded and read-your-writes read paths watch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct AppliedStamp {
+    /// Dense application index of the last applied entry (mirrors
+    /// [`VibesqlStateMachine::last_applied`]; `0` = nothing applied).
+    dense: LogIndex,
+    /// Leader wall clock (ms since the UNIX epoch, taken at propose
+    /// time) of the freshest *stamped* entry applied. `None` until one
+    /// arrives — fresh node, pre-#5200 log prefix, or a snapshot
+    /// installed onto a fresh node (engine snapshots carry no stamps).
+    /// Unstamped entries advance `dense` but retain the previous stamp:
+    /// a weaker (older) freshness claim is always sound.
+    leader_time_ms: Option<u64>,
+}
+
 /// Raft-level bookkeeping the engine needs alongside the database state.
 #[derive(Debug, Default)]
 struct MvccSmInner {
@@ -224,6 +317,12 @@ struct MvccSmInner {
 pub(crate) struct MvccStateMachine {
     machine: VibesqlStateMachine,
     inner: Arc<Mutex<MvccSmInner>>,
+    /// Broadcasts the applied dense index + freshest leader-clock stamp
+    /// after every apply / install, so the PR 2 read paths
+    /// (`query_at_least`, `query_bounded_staleness`) can wait/decide
+    /// without polling the machine. Updated under the `inner` lock,
+    /// which serializes applies — values are monotone in `dense`.
+    applied: Arc<watch::Sender<AppliedStamp>>,
     /// Durable persistence for built/installed snapshots (`None` for
     /// in-memory configurations).
     store: Option<Arc<SnapshotStore>>,
@@ -248,6 +347,7 @@ impl MvccStateMachine {
         Self {
             machine: VibesqlStateMachine::new(),
             inner: Arc::default(),
+            applied: Arc::new(watch::Sender::new(AppliedStamp::default())),
             store: None,
             log_store: None,
             fatal: Arc::default(),
@@ -280,6 +380,10 @@ impl MvccStateMachine {
         inner.last_applied = meta.last_log_id;
         inner.last_membership = meta.last_membership.clone();
         inner.current_snapshot = Some(StoredMvccSnapshot { meta, data });
+        // Snapshots carry no leader-clock stamp: the dense cursor jumps,
+        // the previous stamp (typically none — this runs on a fresh
+        // machine) is retained as a sound lower bound on freshness.
+        self.applied.send_modify(|s| s.dense = dense);
         Ok(())
     }
 
@@ -437,6 +541,20 @@ impl RaftStateMachine<TypeConfig> for MvccStateMachine {
                     match self.machine.apply(dense, &txn) {
                         Ok(outcome) => {
                             inner.last_applied = Some(entry.log_id);
+                            // Broadcast for the PR 2 read paths: the new
+                            // dense cursor, plus the entry's leader-clock
+                            // stamp when it has one (an unstamped entry
+                            // retains the previous, older stamp — a
+                            // weaker freshness claim, always sound). A
+                            // rejected entry counts too: it consumed its
+                            // index on every replica, proving this
+                            // node's state is exactly as fresh.
+                            self.applied.send_modify(|s| {
+                                s.dense = dense;
+                                if txn.leader_time_ms.is_some() {
+                                    s.leader_time_ms = txn.leader_time_ms;
+                                }
+                            });
                             AppResponse::Mvcc { index: dense, outcome }
                         }
                         // FatalApply (possibly node-local failure) and
@@ -506,6 +624,11 @@ impl RaftStateMachine<TypeConfig> for MvccStateMachine {
         inner.last_applied = meta.last_log_id;
         inner.last_membership = meta.last_membership.clone();
         inner.current_snapshot = Some(StoredMvccSnapshot { meta: meta.clone(), data });
+        // As in `seed_from_loaded`: dense cursor jumps, no new stamp —
+        // staleness stays unknown (or keeps its older lower bound) until
+        // the next stamped entry applies. Bounded reads refuse until
+        // then; `query_at_least` waiters see the jump immediately.
+        self.applied.send_modify(|s| s.dense = dense);
         Ok(())
     }
 
@@ -550,11 +673,18 @@ pub struct MvccRaftNode {
     /// Accept-loop task of the TCP transport (`None` for channel-network
     /// configurations). Aborted on shutdown and on drop.
     listener_task: Option<tokio::task::JoinHandle<()>>,
+    /// App-level staleness-beacon task (`None` unless
+    /// [`RaftTuning::staleness_beacon_ms`] is non-zero) — see the module
+    /// docs' bounded-staleness section. Aborted on shutdown and on drop.
+    beacon_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl Drop for MvccRaftNode {
     fn drop(&mut self) {
         if let Some(task) = &self.listener_task {
+            task.abort();
+        }
+        if let Some(task) = &self.beacon_task {
             task.abort();
         }
     }
@@ -581,13 +711,24 @@ impl MvccRaftNode {
     /// with a bounded timeout). Must be called from within a tokio
     /// runtime.
     pub async fn join_tcp_cluster(node_id: u64, config: &ClusterConfig) -> Result<Self> {
+        Self::join_tcp_cluster_tuned(node_id, config, RaftTuning::default()).await
+    }
+
+    /// Like [`join_tcp_cluster`](Self::join_tcp_cluster), with explicit
+    /// [`RaftTuning`] (snapshot/retention/transfer knobs and the Phase
+    /// B2 staleness beacon).
+    pub async fn join_tcp_cluster_tuned(
+        node_id: u64,
+        config: &ClusterConfig,
+        tuning: RaftTuning,
+    ) -> Result<Self> {
         Self::join_tcp(
             node_id,
             config,
             InMemoryLogStore::default(),
             MvccStateMachine::volatile(),
             Bootstrap::Initialize,
-            RaftTuning::default(),
+            tuning,
         )
         .await
     }
@@ -691,7 +832,15 @@ impl MvccRaftNode {
             .await
             .map_err(|e| ConsensusError::Backend(format!("failed to start raft core: {e}")))?;
         let metrics = raft.metrics();
-        Ok(Self { raft, sm, metrics, listener_task: None })
+        let beacon_task = (tuning.staleness_beacon_ms > 0).then(|| {
+            spawn_staleness_beacon(
+                raft.clone(),
+                metrics.clone(),
+                Arc::clone(&sm.applied),
+                tuning.staleness_beacon_ms,
+            )
+        });
+        Ok(Self { raft, sm, metrics, listener_task: None, beacon_task })
     }
 
     /// Execute one autocommit write statement through consensus. See
@@ -739,8 +888,12 @@ impl MvccRaftNode {
 
     /// Propose a pre-built entry. Internal: the public surface freezes
     /// statements first (tests use this to exercise the apply-side
-    /// defenses with hand-crafted entries).
+    /// defenses with hand-crafted entries). Every entry proposed here is
+    /// stamped with this node's wall clock — the leader-clock piggyback
+    /// the bounded-staleness read path measures against (Raft Phase B2,
+    /// #5200, PR 2; see [`TxnEntry::leader_time_ms`]).
     async fn propose_entry(&self, entry: TxnEntry) -> Result<(LogIndex, ApplyOutcome)> {
+        let entry = entry.stamp_leader_time(current_timestamp_ms());
         let payload =
             serde_json::to_vec(&entry).map_err(|e| ConsensusError::Backend(e.to_string()))?;
         let response =
@@ -839,6 +992,106 @@ impl MvccRaftNode {
         }
     }
 
+    /// Run a read-only SELECT with **read-your-writes** semantics (Raft
+    /// Phase B2, #5200, PR 2): wait — up to `wait` — until this node's
+    /// locally applied **dense application index** reaches `min_index`,
+    /// then read locally. Clock-free and exact: the token is the dense
+    /// index a write's propose returned
+    /// ([`execute_replicated`](Self::execute_replicated) /
+    /// [`execute_replicated_txn`](Self::execute_replicated_txn)), and
+    /// dense indices are identical on every replica (see the module
+    /// docs' index-mapping section), so *write on the leader → carry the
+    /// returned index → read on ANY node with the token* always observes
+    /// the write. Works on leaders and followers alike; `min_index = 0`
+    /// degenerates to a plain local [`query`](Self::query).
+    ///
+    /// Fails with [`ConsensusError::ReadTimeout`] (carrying this node's
+    /// applied index and a best-effort leader hint) if the node does not
+    /// catch up within `wait` — e.g. a partitioned or badly lagging
+    /// follower. The session can then retry here, or route the read to
+    /// the leader, which has applied every index it ever returned.
+    pub async fn query_at_least(
+        &self,
+        min_index: LogIndex,
+        sql: &str,
+        wait: Duration,
+    ) -> Result<Vec<Vec<vibesql_types::SqlValue>>> {
+        let mut rx = self.sm.applied.subscribe();
+        // A closed channel (the inner `Err`) cannot happen while `self`
+        // is alive — the sender lives on `self.sm` — so it folds into
+        // the timeout arm rather than inventing an unreachable error.
+        let caught_up = matches!(
+            tokio::time::timeout(wait, rx.wait_for(|s| s.dense >= min_index)).await,
+            Ok(Ok(_))
+        );
+        if caught_up {
+            self.sm.machine.query(sql)
+        } else {
+            Err(ConsensusError::ReadTimeout {
+                required: min_index,
+                applied: self.sm.applied.borrow().dense,
+                leader_hint: self.current_leader(),
+            })
+        }
+    }
+
+    /// Run a read-only SELECT with **bounded staleness** (Raft Phase B2,
+    /// #5200, PR 2): serve locally iff this node can prove its applied
+    /// state is no staler than `max_staleness` — i.e. the leader-clock
+    /// stamp of the freshest stamped entry it has applied is within the
+    /// bound of this node's current wall clock (see the module docs'
+    /// bounded-staleness section for the carrier design, and the
+    /// clock-skew section for the honest bound: true staleness ≤
+    /// `max_staleness` + leader↔follower skew). Works on any node; a
+    /// leader gets no special treatment — a deposed or partitioned
+    /// ex-leader's stamps age exactly like a follower's, so it refuses
+    /// rather than serve provably-stale data.
+    ///
+    /// A bound of **zero** delegates to
+    /// [`query_linearizable`](Self::query_linearizable): the leader
+    /// serves it linearizably, a follower fails with
+    /// [`ConsensusError::NotLeader`] and a leader hint — the
+    /// "staleness 0 redirects to the leader" contract.
+    ///
+    /// Otherwise fails with [`ConsensusError::StalenessExceeded`] when
+    /// the bound cannot be proven: the observed staleness exceeds it, or
+    /// no stamped entry has been applied yet (`observed_ms: None` —
+    /// fresh node, pre-#5200 log prefix, snapshot install onto a fresh
+    /// node, or an idle cluster without the
+    /// [`RaftTuning::staleness_beacon_ms`] beacon). The error carries a
+    /// leader hint for redirect routing — except when this node itself
+    /// believes it leads, since stale stamps on a "leader" are evidence
+    /// it may be deposed, and hinting at itself would route callers
+    /// straight back (the same discipline as
+    /// [`query_linearizable`](Self::query_linearizable)'s quorum-failure
+    /// arm).
+    ///
+    /// The server's per-connection / per-statement `max_staleness_ms` PG
+    /// option (#5383) maps directly onto this method's `max_staleness`.
+    pub async fn query_bounded_staleness(
+        &self,
+        max_staleness: Duration,
+        sql: &str,
+    ) -> Result<Vec<Vec<vibesql_types::SqlValue>>> {
+        if max_staleness.is_zero() {
+            return self.query_linearizable(sql).await;
+        }
+        let max_staleness_ms = u64::try_from(max_staleness.as_millis()).unwrap_or(u64::MAX);
+        let stamp = self.sm.applied.borrow().leader_time_ms;
+        let observed_ms = stamp.map(|t| current_timestamp_ms().saturating_sub(t));
+        match observed_ms {
+            Some(observed) if observed <= max_staleness_ms => self.sm.machine.query(sql),
+            _ => Err(ConsensusError::StalenessExceeded {
+                observed_ms,
+                max_staleness_ms,
+                leader_hint: match self.role() {
+                    Role::Leader => None,
+                    _ => self.current_leader(),
+                },
+            }),
+        }
+    }
+
     /// This node's current role in the consensus group.
     pub fn role(&self) -> Role {
         role_from_state(self.metrics.borrow().state)
@@ -919,8 +1172,51 @@ impl MvccRaftNode {
         if let Some(task) = &self.listener_task {
             task.abort();
         }
+        if let Some(task) = &self.beacon_task {
+            task.abort();
+        }
         self.raft.shutdown().await.map_err(|e| ConsensusError::Backend(e.to_string()))
     }
+}
+
+/// The app-level staleness beacon (Raft Phase B2, #5200, PR 2 — see the
+/// module docs' bounded-staleness section, idle-cluster paragraph):
+/// every `interval_ms`, a node that believes it leads checks whether any
+/// stamped entry was applied within the window and, if not, proposes an
+/// empty no-op [`TxnEntry`] stamped with its wall clock. On a healthy
+/// idle cluster a follower therefore sees a fresh stamp at least every
+/// ~2×`interval_ms` (one window to notice + one to land).
+///
+/// Deliberately fire-and-forget: a `NotLeader` race (deposed between the
+/// role check and the propose), an engine shutdown, or any other write
+/// failure is a non-event — the beacon retries next tick, and bounded
+/// reads simply refuse in the meantime, which is the safe direction.
+fn spawn_staleness_beacon(
+    raft: Raft<TypeConfig>,
+    metrics: tokio::sync::watch::Receiver<openraft::RaftMetrics<u64, BasicNode>>,
+    applied: Arc<watch::Sender<AppliedStamp>>,
+    interval_ms: u64,
+) -> tokio::task::JoinHandle<()> {
+    tokio::task::spawn(async move {
+        let interval = Duration::from_millis(interval_ms);
+        loop {
+            tokio::time::sleep(interval).await;
+            if role_from_state(metrics.borrow().state) != Role::Leader {
+                continue;
+            }
+            let fresh_enough = applied
+                .borrow()
+                .leader_time_ms
+                .is_some_and(|t| current_timestamp_ms().saturating_sub(t) < interval_ms);
+            if fresh_enough {
+                continue;
+            }
+            let entry =
+                TxnEntry::batch(Vec::<String>::new()).stamp_leader_time(current_timestamp_ms());
+            let Ok(payload) = serde_json::to_vec(&entry) else { continue };
+            let _ = raft.client_write(payload).await;
+        }
+    })
 }
 
 #[cfg(test)]
@@ -1685,5 +1981,231 @@ mod tests {
         // And the leader serves the linearizable read it just confirmed.
         let rows = cluster.node(leader).query_linearizable("SELECT id FROM t").await.unwrap();
         assert!(rows.is_empty(), "no rows inserted yet, got: {rows:?}");
+    }
+
+    // -----------------------------------------------------------------
+    // Raft Phase B2, PR 2 (#5200): read-your-writes tokens +
+    // bounded-staleness follower reads (the partition scenarios run
+    // over real sockets in tests/follower_reads.rs; these cover the
+    // plumbing and the mixed-version / idle-cluster contracts)
+    // -----------------------------------------------------------------
+
+    /// The read-your-writes contract, clock-free: write on the leader,
+    /// carry the returned dense index as the session token, and
+    /// `query_at_least` on ANY node observes the write — no manual
+    /// apply-waiting by the caller.
+    #[tokio::test]
+    async fn read_your_writes_token_serves_on_every_node() {
+        let cluster = MvccCluster::new(3).await;
+        cluster.execute_on_leader("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)").await;
+        let (token, _) = cluster.execute_on_leader("INSERT INTO t VALUES (1, 'one')").await;
+
+        for id in 1..=3 {
+            let rows = cluster
+                .node(id)
+                .query_at_least(token, "SELECT id, v FROM t", WAIT_TIMEOUT)
+                .await
+                .unwrap_or_else(|e| panic!("node {id} must serve the token read: {e:?}"));
+            assert_eq!(rows, vec![vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())]]);
+        }
+    }
+
+    /// A token this node cannot reach within the caller's bound is a
+    /// typed, loud timeout — applied cursor and leader hint attached —
+    /// never a hang and never a stale serve.
+    #[tokio::test]
+    async fn query_at_least_times_out_with_a_typed_error() {
+        let cluster = MvccCluster::new(3).await;
+        let (token, _) = cluster.execute_on_leader("CREATE TABLE t (id INTEGER PRIMARY KEY)").await;
+        let leader = cluster.wait_for_leader().await;
+        let follower = follower_of(&cluster, leader);
+        cluster.wait_for_apply(follower, token).await;
+
+        let err = cluster
+            .node(follower)
+            .query_at_least(token + 100, "SELECT id FROM t", Duration::from_millis(100))
+            .await
+            .unwrap_err();
+        match err {
+            ConsensusError::ReadTimeout { required, applied, .. } => {
+                assert_eq!(required, token + 100);
+                assert!(applied < required, "applied {applied} must trail the token");
+            }
+            other => panic!("expected ReadTimeout, got: {other:?}"),
+        }
+    }
+
+    /// Unknown staleness refuses: a fresh node (only protocol entries
+    /// applied — no stamped entry yet) must not serve bounded reads, and
+    /// a node that itself believes it leads must not hint at itself. The
+    /// first stamped write then makes bounded reads serviceable.
+    #[tokio::test]
+    async fn bounded_staleness_refuses_until_a_stamped_entry_applies() {
+        let node = MvccRaftNode::single_node().await.unwrap();
+
+        let err =
+            node.query_bounded_staleness(Duration::from_secs(10), "SELECT 1").await.unwrap_err();
+        match err {
+            ConsensusError::StalenessExceeded { observed_ms, leader_hint, .. } => {
+                assert_eq!(observed_ms, None, "no stamped entry applied → unknown staleness");
+                assert_eq!(leader_hint, None, "a leader must not hint at itself");
+            }
+            other => panic!("expected StalenessExceeded, got: {other:?}"),
+        }
+
+        node.execute_replicated("CREATE TABLE t (id INTEGER PRIMARY KEY)").await.unwrap();
+        let rows = node
+            .query_bounded_staleness(Duration::from_secs(10), "SELECT id FROM t")
+            .await
+            .expect("a just-stamped node serves bounded reads");
+        assert!(rows.is_empty());
+    }
+
+    /// A zero bound is the linearizable path: the leader serves it (with
+    /// full ReadIndex confirmation), so `max_staleness = 0` never serves
+    /// from an unconfirmed local state.
+    #[tokio::test]
+    async fn bounded_staleness_zero_is_linearizable_on_the_leader() {
+        let node = MvccRaftNode::single_node().await.unwrap();
+        node.execute_replicated("CREATE TABLE t (id INTEGER PRIMARY KEY)").await.unwrap();
+        node.execute_replicated("INSERT INTO t VALUES (7)").await.unwrap();
+
+        let rows = node.query_bounded_staleness(Duration::ZERO, "SELECT id FROM t").await.unwrap();
+        assert_eq!(rows, vec![vec![SqlValue::Integer(7)]]);
+    }
+
+    /// Pre-#5200 (unstamped) entries through the real mount: the dense
+    /// cursor advances — read-your-writes tokens keep working — but
+    /// staleness stays unknown, so bounded reads refuse until the first
+    /// stamped entry arrives (the documented mixed-version behavior).
+    #[tokio::test]
+    async fn unstamped_entry_advances_tokens_but_not_staleness() {
+        let node = MvccRaftNode::single_node().await.unwrap();
+
+        // Bypass the (stamping) propose path: an old proposer's entry.
+        let old_format =
+            serde_json::to_vec(&TxnEntry::single("CREATE TABLE t (id INTEGER PRIMARY KEY)"))
+                .unwrap();
+        node.raft.client_write(old_format).await.unwrap();
+
+        // Token reads work — clock-free, index-based.
+        let rows = node.query_at_least(1, "SELECT id FROM t", WAIT_TIMEOUT).await.unwrap();
+        assert!(rows.is_empty());
+
+        // Bounded reads refuse — staleness unknown.
+        let err = node
+            .query_bounded_staleness(Duration::from_secs(10), "SELECT id FROM t")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, ConsensusError::StalenessExceeded { observed_ms: None, .. }),
+            "got: {err:?}"
+        );
+
+        // A stamped entry restores bounded-read service.
+        node.execute_replicated("INSERT INTO t VALUES (1)").await.unwrap();
+        node.query_bounded_staleness(Duration::from_secs(10), "SELECT id FROM t")
+            .await
+            .expect("a stamped entry restores bounded reads");
+    }
+
+    /// Idle aging without the beacon (the default): once the last stamp
+    /// is older than the caller's bound, a healthy but idle follower
+    /// refuses bounded reads — with a leader hint for redirect routing —
+    /// while its token/local reads keep serving (those are clock-free).
+    #[tokio::test]
+    async fn idle_cluster_without_beacon_ages_out_of_bounded_reads() {
+        let cluster = MvccCluster::new(3).await;
+        cluster.execute_on_leader("CREATE TABLE t (id INTEGER PRIMARY KEY)").await;
+        let (token, _) = cluster.execute_on_leader("INSERT INTO t VALUES (1)").await;
+        let leader = cluster.wait_for_leader().await;
+        let follower = follower_of(&cluster, leader);
+        cluster.wait_for_apply(follower, token).await;
+        cluster
+            .wait_until("the follower to learn who leads", || {
+                (cluster.node(follower).current_leader() == Some(leader)).then_some(())
+            })
+            .await;
+
+        // No writes from here on: the stamp can only age. Poll until the
+        // 150ms bound is exceeded (bounded — fails loudly, never hangs).
+        let bound = Duration::from_millis(150);
+        let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+        loop {
+            match cluster.node(follower).query_bounded_staleness(bound, "SELECT id FROM t").await {
+                Err(ConsensusError::StalenessExceeded {
+                    observed_ms: Some(observed),
+                    max_staleness_ms,
+                    leader_hint,
+                }) => {
+                    assert!(observed > max_staleness_ms, "{observed} vs {max_staleness_ms}");
+                    assert_eq!(leader_hint, Some(leader), "refusals must carry the redirect");
+                    break;
+                }
+                Ok(_) => {} // still within the bound — keep aging
+                Err(other) => panic!("expected StalenessExceeded, got: {other:?}"),
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for the idle follower to age out of the bound"
+            );
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+
+        // The clock-free paths are unaffected by idleness.
+        let rows = cluster
+            .node(follower)
+            .query_at_least(token, "SELECT id FROM t", WAIT_TIMEOUT)
+            .await
+            .unwrap();
+        assert_eq!(rows, vec![vec![SqlValue::Integer(1)]]);
+    }
+
+    /// The opt-in staleness beacon keeps an IDLE cluster's bounded reads
+    /// alive: with no application writes for many beacon windows, a
+    /// follower still proves freshness within a 200ms bound, because the
+    /// leader keeps proposing stamped no-op entries (which consume dense
+    /// indices like any entry).
+    #[tokio::test]
+    async fn staleness_beacon_keeps_idle_cluster_bounded_reads_fresh() {
+        let tuning = RaftTuning { staleness_beacon_ms: 50, ..RaftTuning::default() };
+        let cluster = MvccCluster::build(3, false, tuning).await;
+        cluster.execute_on_leader("CREATE TABLE t (id INTEGER PRIMARY KEY)").await;
+        let (token, _) = cluster.execute_on_leader("INSERT INTO t VALUES (1)").await;
+        let leader = cluster.wait_for_leader().await;
+        let follower = follower_of(&cluster, leader);
+        cluster.wait_for_apply(follower, token).await;
+
+        // Go idle for far longer than the 200ms bound the last real
+        // write's stamp could cover on its own.
+        tokio::time::sleep(Duration::from_millis(400)).await;
+
+        // Poll (bounded) until a bounded read succeeds: without the
+        // beacon the stamp could only age further, so success here
+        // proves a beacon-refreshed stamp reached the follower.
+        let bound = Duration::from_millis(200);
+        let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+        loop {
+            match cluster.node(follower).query_bounded_staleness(bound, "SELECT id FROM t").await {
+                Ok(rows) => {
+                    assert_eq!(rows, vec![vec![SqlValue::Integer(1)]]);
+                    break;
+                }
+                Err(ConsensusError::StalenessExceeded { .. }) => {} // beacon not landed yet
+                Err(other) => panic!("expected rows or StalenessExceeded, got: {other:?}"),
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for the beacon to refresh the idle follower"
+            );
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+
+        // Beacons are real (no-op) entries: the dense cursor moved past
+        // the last application write on every replica identically.
+        assert!(
+            cluster.node(follower).last_applied() > token,
+            "beacon entries must have consumed dense indices"
+        );
     }
 }

--- a/crates/vibesql-consensus/src/openraft_backend.rs
+++ b/crates/vibesql-consensus/src/openraft_backend.rs
@@ -169,13 +169,38 @@ pub struct RaftTuning {
     /// expansion; values outside `1..=MAX` are a typed
     /// [`ConsensusError::Config`] at construction.
     pub snapshot_chunk_bytes: u64,
+    /// App-level **staleness beacon** for bounded-staleness follower
+    /// reads (Raft Phase B2, #5200, PR 2 — only meaningful on
+    /// [`MvccRaftNode`](crate::MvccRaftNode)): when non-zero, a node
+    /// that believes it leads proposes an empty no-op transaction
+    /// entry — stamped with its wall clock, consuming a dense
+    /// application index like any other entry — whenever no stamped
+    /// entry has been applied within this many milliseconds. An *idle*
+    /// cluster then keeps refreshing follower staleness, so
+    /// `query_bounded_staleness` stays serviceable without writes; a
+    /// healthy idle follower sees a fresh stamp at least every
+    /// ~2×`staleness_beacon_ms`, so set this to at most half the
+    /// smallest staleness bound you intend to serve (minus a margin for
+    /// replication latency and clock skew).
+    ///
+    /// `0` (the default) disables the beacon: an idle cluster's last
+    /// stamp simply ages, and bounded-staleness reads refuse once it
+    /// exceeds the caller's bound (falling back to
+    /// linearizable/leader reads) until the next write arrives.
+    pub staleness_beacon_ms: u64,
 }
 
 impl Default for RaftTuning {
     /// openraft's own defaults: snapshot every 5000 entries, keep a
-    /// 1000-entry catch-up tail, 3 MiB transfer chunks.
+    /// 1000-entry catch-up tail, 3 MiB transfer chunks. The staleness
+    /// beacon is off.
     fn default() -> Self {
-        Self { snapshot_after_entries: 5000, keep_in_log: 1000, snapshot_chunk_bytes: 3 << 20 }
+        Self {
+            snapshot_after_entries: 5000,
+            keep_in_log: 1000,
+            snapshot_chunk_bytes: 3 << 20,
+            staleness_beacon_ms: 0,
+        }
     }
 }
 

--- a/crates/vibesql-consensus/src/state_machine.rs
+++ b/crates/vibesql-consensus/src/state_machine.rs
@@ -150,6 +150,20 @@ pub struct TxnEntry {
     /// statement found to contain one.
     #[serde(default)]
     pub frozen: Vec<Vec<FrozenValue>>,
+    /// The proposing leader's wall clock at propose time, in
+    /// milliseconds since the UNIX epoch (Raft Phase B2, #5200, PR 2).
+    ///
+    /// **Bookkeeping only** — never consulted by the apply path's SQL
+    /// execution (it is not an HLC and assigns no visibility): replicas
+    /// record the stamp of the last applied stamped entry so a
+    /// bounded-staleness read can prove "my applied state is no staler
+    /// than `now - stamp`". Serde-compatible in both directions:
+    /// entries encoded before #5200 decode as `None` (unknown
+    /// staleness — bounded reads refuse until a stamped entry arrives),
+    /// and `None` skips serialization so unstamped entries keep the
+    /// pre-#5200 byte encoding.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub leader_time_ms: Option<u64>,
 }
 
 impl TxnEntry {
@@ -159,13 +173,17 @@ impl TxnEntry {
     /// (as [`ReplicatedDb`](crate::ReplicatedDb) does) to replicate
     /// non-deterministic SQL.
     pub fn single(sql: impl Into<String>) -> Self {
-        Self { statements: vec![sql.into()], frozen: Vec::new() }
+        Self { statements: vec![sql.into()], frozen: Vec::new(), leader_time_ms: None }
     }
 
     /// Entry for a multi-statement transaction (no frozen values — see
     /// [`single`](Self::single)).
     pub fn batch<S: Into<String>>(statements: impl IntoIterator<Item = S>) -> Self {
-        Self { statements: statements.into_iter().map(Into::into).collect(), frozen: Vec::new() }
+        Self {
+            statements: statements.into_iter().map(Into::into).collect(),
+            frozen: Vec::new(),
+            leader_time_ms: None,
+        }
     }
 
     /// Entry whose non-deterministic call sites were frozen at propose
@@ -173,7 +191,14 @@ impl TxnEntry {
     /// `statements[i]`.
     pub fn frozen_batch(statements: Vec<String>, frozen: Vec<Vec<FrozenValue>>) -> Self {
         debug_assert_eq!(statements.len(), frozen.len());
-        Self { statements, frozen }
+        Self { statements, frozen, leader_time_ms: None }
+    }
+
+    /// Stamp this entry with the proposing leader's wall clock (ms since
+    /// the UNIX epoch) — see [`leader_time_ms`](Self::leader_time_ms).
+    pub fn stamp_leader_time(mut self, ms: u64) -> Self {
+        self.leader_time_ms = Some(ms);
+        self
     }
 }
 
@@ -770,15 +795,35 @@ mod tests {
         );
         let bytes = serde_json::to_vec(&entry).unwrap();
         assert_eq!(serde_json::from_slice::<TxnEntry>(&bytes).unwrap(), entry);
+
+        let entry = TxnEntry::single("INSERT INTO t VALUES (1)").stamp_leader_time(1_700_000_000);
+        let bytes = serde_json::to_vec(&entry).unwrap();
+        assert_eq!(serde_json::from_slice::<TxnEntry>(&bytes).unwrap(), entry);
     }
 
-    /// Entries encoded before #5377 (no `frozen` field) still decode.
+    /// Entries encoded before #5377 (no `frozen` field) / #5200 (no
+    /// `leader_time_ms` field) still decode: unknown staleness, no
+    /// frozen sites.
     #[test]
     fn entry_decode_without_frozen_field_is_backward_compatible() {
         let json = br#"{"statements":["INSERT INTO t VALUES (1)"]}"#;
         let entry: TxnEntry = serde_json::from_slice(json).unwrap();
         assert_eq!(entry.statements.len(), 1);
         assert!(entry.frozen.is_empty());
+        assert_eq!(entry.leader_time_ms, None);
+    }
+
+    /// An unstamped entry keeps the pre-#5200 byte encoding (the stamp
+    /// field is skipped, not serialized as null), so proposers that do
+    /// not stamp emit entries old appliers decode unchanged.
+    #[test]
+    fn unstamped_entry_keeps_pre_5200_encoding() {
+        let entry = TxnEntry::single("INSERT INTO t VALUES (1)");
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(
+            !json.contains("leader_time_ms"),
+            "unstamped entries must not mention the stamp field, got: {json}"
+        );
     }
 
     #[test]
@@ -834,10 +879,7 @@ mod tests {
         let machine = VibesqlStateMachine::new();
         create_users(&machine, 1);
         let entry = TxnEntry::single("INSERT INTO users VALUES (1, 'alice')");
-        assert_eq!(
-            machine.apply(2, &entry).unwrap(),
-            ApplyOutcome::Applied { rows_affected: 1 }
-        );
+        assert_eq!(machine.apply(2, &entry).unwrap(), ApplyOutcome::Applied { rows_affected: 1 });
 
         // Re-applying the same index must not duplicate effects — this is
         // what makes snapshot+log-replay overlap safe.
@@ -1138,8 +1180,7 @@ mod tests {
         #[cfg(feature = "mvcc_enabled")]
         restored.with_db(|db| {
             let table = db.get_table("users").unwrap();
-            let carol =
-                table.scan().iter().find(|r| r.values[0] == SqlValue::Integer(3)).unwrap();
+            let carol = table.scan().iter().find(|r| r.values[0] == SqlValue::Integer(3)).unwrap();
             assert_eq!(carol.xmin, 4, "post-install applies keep commit_ts = log index");
         });
     }

--- a/crates/vibesql-consensus/tests/follower_reads.rs
+++ b/crates/vibesql-consensus/tests/follower_reads.rs
@@ -1,0 +1,551 @@
+//! Follower reads over real sockets (Raft Phase B2, #5200, PR 2 of 2):
+//! read-your-writes session tokens + bounded-staleness reads.
+//!
+//! Boots 3-voter [`MvccRaftNode`] clusters whose Raft RPCs travel over the
+//! TCP transport, with every directed edge optionally behind a severable
+//! TCP proxy (the partition machinery from #5197/#5200 PR 1), and proves
+//! the B2 PR 2 read-path contract end-to-end:
+//!
+//! - **read-your-writes**: write on the leader, carry the returned dense
+//!   index as the session token — `query_at_least` on ANY node observes
+//!   the write, and a partitioned (lagging) follower blocks until the
+//!   heal lets it catch up rather than serving early;
+//! - **bounded staleness**: a fresh follower serves within the bound; a
+//!   `max_staleness = 0` read on a follower redirects to the leader; a
+//!   PARTITIONED follower refuses once its last leader-clock stamp ages
+//!   past the bound — provably stale data is never served within the
+//!   claimed bound — and resumes service after the heal.
+//!
+//! The `Proxy` here intentionally duplicates the one in
+//! `tests/tcp_cluster.rs` / `tests/leader_reads.rs`: integration-test
+//! binaries are separate crates, and keeping each file self-contained
+//! keeps them conflict-free under parallel work.
+//!
+//! All synchronization is bounded polling (10s deadline) — no bare
+//! sleeps on the critical path; every wait fails loudly instead of
+//! hanging.
+
+use std::collections::BTreeMap;
+use std::net::TcpListener as StdTcpListener;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinHandle;
+
+use vibesql_consensus::{
+    ApplyOutcome, ClusterConfig, ConsensusError, LogIndex, MvccRaftNode, RaftTuning, Role,
+};
+use vibesql_types::SqlValue;
+
+/// Upper bound for any single cluster-level wait (election, catch-up,
+/// staleness aging).
+const WAIT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Poll interval inside bounded waits.
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Reserve `n` distinct localhost addresses with OS-assigned ephemeral
+/// ports, keyed by node id `1..=n` (same strategy as tcp_cluster.rs).
+fn free_localhost_addrs(n: u64) -> BTreeMap<u64, String> {
+    let listeners: Vec<(u64, StdTcpListener)> = (1..=n)
+        .map(|id| (id, StdTcpListener::bind("127.0.0.1:0").expect("reserve ephemeral port")))
+        .collect();
+    listeners
+        .iter()
+        .map(|(id, listener)| {
+            (*id, listener.local_addr().expect("reserved port address").to_string())
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Per-edge TCP proxy (partition injection) — see tests/tcp_cluster.rs
+// ---------------------------------------------------------------------------
+
+/// A severable TCP forwarder for one directed cluster edge.
+struct Proxy {
+    /// Address the source node dials instead of the target's real address.
+    addr: String,
+    enabled: Arc<AtomicBool>,
+    /// Live forwarder tasks; aborted (sockets dropped) on sever.
+    conns: Arc<Mutex<Vec<JoinHandle<()>>>>,
+    accept_task: JoinHandle<()>,
+}
+
+impl Proxy {
+    async fn spawn(target: String) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind proxy listener");
+        let addr = listener.local_addr().expect("proxy address").to_string();
+        let enabled = Arc::new(AtomicBool::new(true));
+        let conns: Arc<Mutex<Vec<JoinHandle<()>>>> = Arc::default();
+
+        let accept_task = tokio::spawn({
+            let enabled = Arc::clone(&enabled);
+            let conns = Arc::clone(&conns);
+            async move {
+                loop {
+                    let Ok((mut inbound, _)) = listener.accept().await else {
+                        tokio::time::sleep(POLL_INTERVAL).await;
+                        continue;
+                    };
+                    if !enabled.load(Ordering::SeqCst) {
+                        continue; // dropping `inbound` hangs up on the dialer
+                    }
+                    let target = target.clone();
+                    let forwarder = tokio::spawn(async move {
+                        let Ok(mut outbound) = TcpStream::connect(&target).await else { return };
+                        let _ = tokio::io::copy_bidirectional(&mut inbound, &mut outbound).await;
+                    });
+                    let mut conns = conns.lock().expect("proxy connection list poisoned");
+                    conns.retain(|handle| !handle.is_finished());
+                    conns.push(forwarder);
+                }
+            }
+        });
+
+        Self { addr, enabled, conns, accept_task }
+    }
+
+    /// Cut the edge: live connections die, new ones are accepted and
+    /// immediately dropped.
+    fn sever(&self) {
+        self.enabled.store(false, Ordering::SeqCst);
+        let mut conns = self.conns.lock().expect("proxy connection list poisoned");
+        for handle in conns.drain(..) {
+            handle.abort();
+        }
+    }
+
+    /// Reconnect the edge for new connections.
+    fn reconnect(&self) {
+        self.enabled.store(true, Ordering::SeqCst);
+    }
+}
+
+impl Drop for Proxy {
+    fn drop(&mut self) {
+        self.accept_task.abort();
+        self.sever();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MVCC cluster harness
+// ---------------------------------------------------------------------------
+
+/// A 3-voter MVCC cluster over the TCP transport, optionally with every
+/// directed edge behind a severable [`Proxy`], and with explicit
+/// [`RaftTuning`] (the staleness-beacon tests need it).
+struct MvccTcpCluster {
+    nodes: BTreeMap<u64, MvccRaftNode>,
+    /// Directed-edge proxies; empty unless built partitionable.
+    proxies: BTreeMap<(u64, u64), Proxy>,
+}
+
+impl MvccTcpCluster {
+    /// Boot `n` voters (ids `1..=n`) dialing each other directly.
+    async fn boot(n: u64) -> Self {
+        Self::build(n, false, RaftTuning::default()).await
+    }
+
+    /// Like [`boot`](Self::boot), but every directed edge runs through a
+    /// severable [`Proxy`], enabling [`partition`](Self::partition).
+    async fn boot_partitionable(n: u64) -> Self {
+        Self::build(n, true, RaftTuning::default()).await
+    }
+
+    /// Partitionable cluster with explicit tuning (staleness beacon on).
+    async fn boot_partitionable_tuned(n: u64, tuning: RaftTuning) -> Self {
+        Self::build(n, true, tuning).await
+    }
+
+    async fn build(n: u64, with_proxies: bool, tuning: RaftTuning) -> Self {
+        let addrs = free_localhost_addrs(n);
+
+        let mut proxies = BTreeMap::new();
+        if with_proxies {
+            for a in 1..=n {
+                for b in 1..=n {
+                    if a != b {
+                        proxies.insert((a, b), Proxy::spawn(addrs[&b].clone()).await);
+                    }
+                }
+            }
+        }
+
+        let mut nodes = BTreeMap::new();
+        for id in 1..=n {
+            // Node `id`'s view: its own real address (it binds it), every
+            // peer behind this node's outgoing proxy when partitionable.
+            let view = (1..=n).map(|peer| {
+                let addr = if peer == id || !with_proxies {
+                    addrs[&peer].clone()
+                } else {
+                    proxies[&(id, peer)].addr.clone()
+                };
+                (peer, addr)
+            });
+            let config = ClusterConfig::new(view).expect("valid cluster config");
+            let node = MvccRaftNode::join_tcp_cluster_tuned(id, &config, tuning)
+                .await
+                .expect("boot mvcc tcp node");
+            nodes.insert(id, node);
+        }
+
+        Self { nodes, proxies }
+    }
+
+    fn node(&self, id: u64) -> &MvccRaftNode {
+        &self.nodes[&id]
+    }
+
+    fn ids(&self) -> Vec<u64> {
+        self.nodes.keys().copied().collect()
+    }
+
+    /// Sever every directed edge between `minority` and the rest of the
+    /// cluster, in both directions. Panics unless built partitionable.
+    fn partition(&self, minority: &[u64]) {
+        assert!(!self.proxies.is_empty(), "cluster was not built partitionable");
+        for (&(a, b), proxy) in &self.proxies {
+            if minority.contains(&a) != minority.contains(&b) {
+                proxy.sever();
+            }
+        }
+    }
+
+    /// Reconnect every severed edge.
+    fn heal(&self) {
+        for proxy in self.proxies.values() {
+            proxy.reconnect();
+        }
+    }
+
+    /// Wait (bounded) until one of `ids` reports itself leader **and**
+    /// every node in `ids` acknowledges it; returns the leader.
+    async fn wait_for_leader_among(&self, ids: &[u64]) -> u64 {
+        self.wait_until(&format!("an acknowledged leader among {ids:?}"), || {
+            let leader = ids.iter().copied().find(|id| self.node(*id).role() == Role::Leader)?;
+            ids.iter().all(|id| self.node(*id).current_leader() == Some(leader)).then_some(leader)
+        })
+        .await
+    }
+
+    /// Wait (bounded) until node `id` has applied the dense index `idx`.
+    async fn wait_for_apply(&self, id: u64, idx: LogIndex) {
+        self.wait_until(&format!("node {id} to apply dense index {idx}"), || {
+            (self.node(id).last_applied() >= idx).then_some(())
+        })
+        .await;
+    }
+
+    /// Execute one replicated write through whoever currently leads among
+    /// `ids`, re-resolving leadership if an election moves it mid-call.
+    async fn execute_on_leader_among(
+        &self,
+        ids: &[u64],
+        sql: &str,
+    ) -> (u64, LogIndex, ApplyOutcome) {
+        let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+        loop {
+            let leader = self.wait_for_leader_among(ids).await;
+            match self.node(leader).execute_replicated(sql).await {
+                Ok((idx, outcome)) => return (leader, idx, outcome),
+                Err(ConsensusError::NotLeader { .. }) => {
+                    assert!(
+                        tokio::time::Instant::now() < deadline,
+                        "timed out executing {sql:?}: leadership never settled"
+                    );
+                }
+                Err(other) => panic!("execute of {sql:?} failed: {other:?}"),
+            }
+        }
+    }
+
+    /// Poll `probe` until it yields a value, panicking after
+    /// [`WAIT_TIMEOUT`].
+    async fn wait_until<T>(&self, what: &str, mut probe: impl FnMut() -> Option<T>) -> T {
+        let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+        loop {
+            if let Some(value) = probe() {
+                return value;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out after {WAIT_TIMEOUT:?} waiting for {what}"
+            );
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+
+    async fn shutdown(self) {
+        for node in self.nodes.values() {
+            node.shutdown().await.expect("clean shutdown");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// B2 PR 2 scenarios
+// ---------------------------------------------------------------------------
+
+/// Read-your-writes via the session token, end-to-end over TCP: write on
+/// the leader, carry the returned dense index, and `query_at_least` on
+/// EVERY node — followers included — observes the write, with no manual
+/// apply-waiting by the caller. A `0` token serves immediately; a token
+/// from the future fails with a typed timeout rather than serving early.
+#[tokio::test]
+async fn read_your_writes_token_serves_on_any_node() {
+    let cluster = MvccTcpCluster::boot(3).await;
+    let all = cluster.ids();
+
+    cluster
+        .execute_on_leader_among(&all, "CREATE TABLE accounts (id INTEGER PRIMARY KEY, v TEXT)")
+        .await;
+    let (leader, token, outcome) =
+        cluster.execute_on_leader_among(&all, "INSERT INTO accounts VALUES (1, 'one')").await;
+    assert_eq!(outcome, ApplyOutcome::Applied { rows_affected: 1 });
+
+    let expected = vec![vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())]];
+    for id in &all {
+        let rows = cluster
+            .node(*id)
+            .query_at_least(token, "SELECT id, v FROM accounts", WAIT_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| panic!("node {id} must serve the token read: {e:?}"));
+        assert_eq!(rows, expected, "node {id}");
+    }
+
+    // Token 0 degenerates to a plain local read.
+    let follower = all.iter().copied().find(|id| *id != leader).expect("a follower exists");
+    let rows = cluster
+        .node(follower)
+        .query_at_least(0, "SELECT id, v FROM accounts", WAIT_TIMEOUT)
+        .await
+        .unwrap();
+    assert_eq!(rows, expected);
+
+    // A token beyond anything committed must NOT serve — typed timeout.
+    let err = cluster
+        .node(follower)
+        .query_at_least(token + 100, "SELECT id FROM accounts", Duration::from_millis(200))
+        .await
+        .unwrap_err();
+    match err {
+        ConsensusError::ReadTimeout { required, applied, .. } => {
+            assert_eq!(required, token + 100);
+            assert!(applied < required, "applied {applied} must trail the token");
+        }
+        other => panic!("expected ReadTimeout, got: {other:?}"),
+    }
+
+    cluster.shutdown().await;
+}
+
+/// A lagging (partitioned) follower holds a token read rather than
+/// serving early: the bounded wait fails with `ReadTimeout` while the
+/// partition lasts, and the SAME token read succeeds after the heal —
+/// observing the write it was a receipt for.
+#[tokio::test]
+async fn token_read_on_lagging_follower_blocks_until_catch_up() {
+    let cluster = MvccTcpCluster::boot_partitionable(3).await;
+    let all = cluster.ids();
+
+    let (_, idx, _) = cluster
+        .execute_on_leader_among(&all, "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+        .await;
+    for id in &all {
+        cluster.wait_for_apply(*id, idx).await;
+    }
+    let leader = cluster.wait_for_leader_among(&all).await;
+    let lagging = all.iter().copied().find(|id| *id != leader).expect("a follower exists");
+
+    // Cut the follower off, then commit a write it cannot see.
+    cluster.partition(&[lagging]);
+    let majority: Vec<u64> = all.iter().copied().filter(|id| *id != lagging).collect();
+    let (_, token, outcome) =
+        cluster.execute_on_leader_among(&majority, "INSERT INTO t VALUES (1, 'one')").await;
+    assert_eq!(outcome, ApplyOutcome::Applied { rows_affected: 1 });
+
+    // The partitioned follower must NOT serve the token read: it waits,
+    // then fails loudly with its applied cursor still short of the token.
+    let err = cluster
+        .node(lagging)
+        .query_at_least(token, "SELECT id, v FROM t", Duration::from_millis(500))
+        .await
+        .unwrap_err();
+    match err {
+        ConsensusError::ReadTimeout { required, applied, .. } => {
+            assert_eq!(required, token);
+            assert!(applied < token, "the partitioned follower cannot have applied the write");
+        }
+        other => panic!("expected ReadTimeout on the partitioned follower, got: {other:?}"),
+    }
+
+    // Heal: the same token read now blocks only until catch-up, then
+    // serves the write it was a receipt for.
+    cluster.heal();
+    let rows = cluster
+        .node(lagging)
+        .query_at_least(token, "SELECT id, v FROM t", WAIT_TIMEOUT)
+        .await
+        .expect("the healed follower must catch up and serve the token read");
+    assert_eq!(rows, vec![vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())]]);
+
+    cluster.shutdown().await;
+}
+
+/// Bounded staleness on a healthy cluster: a fresh follower serves
+/// within a generous bound; `max_staleness = 0` on a follower redirects
+/// to the leader (the curator's "staleness=0 → redirect" criterion)
+/// while the leader serves it linearizably.
+#[tokio::test]
+async fn fresh_follower_serves_bounded_reads_and_zero_redirects() {
+    let cluster = MvccTcpCluster::boot(3).await;
+    let all = cluster.ids();
+
+    cluster.execute_on_leader_among(&all, "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)").await;
+    let (leader, idx, _) =
+        cluster.execute_on_leader_among(&all, "INSERT INTO t VALUES (1, 'one')").await;
+    let follower = all.iter().copied().find(|id| *id != leader).expect("a follower exists");
+    cluster.wait_for_apply(follower, idx).await;
+    cluster
+        .wait_until("the follower to learn who leads", || {
+            (cluster.node(follower).current_leader() == Some(leader)).then_some(())
+        })
+        .await;
+
+    let expected = vec![vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())]];
+
+    // Fresh follower, generous bound: serves the local snapshot.
+    let rows = cluster
+        .node(follower)
+        .query_bounded_staleness(Duration::from_secs(10), "SELECT id, v FROM t")
+        .await
+        .expect("a freshly-applied follower must serve within a 10s bound");
+    assert_eq!(rows, expected);
+
+    // staleness = 0 on a follower: redirect to the leader.
+    match cluster.node(follower).query_bounded_staleness(Duration::ZERO, "SELECT id FROM t").await {
+        Err(ConsensusError::NotLeader { leader_hint }) => assert_eq!(leader_hint, Some(leader)),
+        other => panic!("staleness=0 on a follower must redirect, got: {other:?}"),
+    }
+
+    // staleness = 0 on the leader: served, linearizably.
+    let rows = cluster
+        .node(leader)
+        .query_bounded_staleness(Duration::ZERO, "SELECT id, v FROM t")
+        .await
+        .expect("the leader serves staleness=0 through the linearizable path");
+    assert_eq!(rows, expected);
+
+    cluster.shutdown().await;
+}
+
+/// The bounded-staleness acceptance on a PARTITIONED follower: its last
+/// leader-clock stamp ages, so once `max_staleness` elapses it refuses —
+/// and while it still serves (inside the bound), it serves only the
+/// pre-partition prefix, never claiming freshness it does not have. The
+/// staleness beacon keeps the healthy side fresh through the idle
+/// stretch and restores the follower's service after the heal.
+#[tokio::test]
+async fn partitioned_follower_refuses_bounded_reads_once_the_bound_elapses() {
+    let tuning = RaftTuning { staleness_beacon_ms: 100, ..RaftTuning::default() };
+    let cluster = MvccTcpCluster::boot_partitionable_tuned(3, tuning).await;
+    let all = cluster.ids();
+
+    cluster.execute_on_leader_among(&all, "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)").await;
+    let (leader, idx, _) =
+        cluster.execute_on_leader_among(&all, "INSERT INTO t VALUES (1, 'one')").await;
+    for id in &all {
+        cluster.wait_for_apply(*id, idx).await;
+    }
+    let follower = all.iter().copied().find(|id| *id != leader).expect("a follower exists");
+    let seeded = vec![vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())]];
+
+    // Cut the follower off, then commit a write it can never see.
+    cluster.partition(&[follower]);
+    let majority: Vec<u64> = all.iter().copied().filter(|id| *id != follower).collect();
+    let (_, majority_idx, _) =
+        cluster.execute_on_leader_among(&majority, "INSERT INTO t VALUES (2, 'two')").await;
+
+    // Poll the partitioned follower with a 750ms bound: any read it still
+    // serves must be the pre-partition prefix (it physically cannot have
+    // the majority write), and once its stamp ages past the bound it must
+    // refuse — provably stale data is never served within the bound.
+    let bound = Duration::from_millis(750);
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    loop {
+        match cluster
+            .node(follower)
+            .query_bounded_staleness(bound, "SELECT id, v FROM t ORDER BY id")
+            .await
+        {
+            Ok(rows) => {
+                assert_eq!(
+                    rows, seeded,
+                    "a bounded read served inside the bound must be the pre-partition prefix"
+                );
+            }
+            Err(ConsensusError::StalenessExceeded { observed_ms, max_staleness_ms, .. }) => {
+                let observed = observed_ms.expect("the follower applied stamped entries");
+                assert!(observed > max_staleness_ms, "{observed} vs {max_staleness_ms}");
+                break;
+            }
+            Err(other) => panic!("expected rows or StalenessExceeded, got: {other:?}"),
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for the partitioned follower to age out of the bound"
+        );
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+
+    // It stays refused for as long as the partition lasts.
+    assert!(
+        matches!(
+            cluster.node(follower).query_bounded_staleness(bound, "SELECT id FROM t").await,
+            Err(ConsensusError::StalenessExceeded { .. })
+        ),
+        "the partitioned follower must keep refusing"
+    );
+
+    // Heal: the follower catches up (read-your-writes token from the
+    // majority write proves it) and — thanks to the beacon — proves
+    // freshness again, now serving BOTH rows within the bound.
+    cluster.heal();
+    let both = vec![
+        vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())],
+        vec![SqlValue::Integer(2), SqlValue::Varchar("two".into())],
+    ];
+    let rows = cluster
+        .node(follower)
+        .query_at_least(majority_idx, "SELECT id, v FROM t ORDER BY id", WAIT_TIMEOUT)
+        .await
+        .expect("the healed follower must catch up to the majority write");
+    assert_eq!(rows, both);
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    loop {
+        match cluster
+            .node(follower)
+            .query_bounded_staleness(bound, "SELECT id, v FROM t ORDER BY id")
+            .await
+        {
+            Ok(rows) => {
+                assert_eq!(rows, both);
+                break;
+            }
+            Err(ConsensusError::StalenessExceeded { .. }) => {} // beacon not landed yet
+            Err(other) => panic!("expected rows or StalenessExceeded, got: {other:?}"),
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for the healed follower to prove freshness again"
+        );
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+
+    cluster.shutdown().await;
+}


### PR DESCRIPTION
Closes #5200

PR 2 of 2 for Raft Phase B2 (PR 1: #5387 — linearizable leader reads + stale-leader fencing). Implements the follower-read half of the curator re-scope (ADR-0004: no HLC), `vibesql-consensus` only.

## What's in here

### 1. Read-your-writes session tokens (clock-free, exact)

`MvccRaftNode::query_at_least(min_index, sql, wait)`: the **dense application index** returned by `execute_replicated[_txn]` is the session token — write on the leader, carry the returned index, and a read on ANY node (leader or follower) observes the write once that node's applied cursor reaches the token. Dense indices are identical on every replica (protocol entries consume none), so the token compares like-with-like against any follower's cursor; the wait rides a `tokio::watch` the state machine updates on every apply (no polling). A node that cannot catch up within the caller's bound fails with the new typed `ConsensusError::ReadTimeout { required, applied, leader_hint }` — never a hang, never an early stale serve.

### 2. Bounded-staleness follower reads (leader wall-clock piggyback)

openraft 0.9.24 heartbeats are engine-internal empty AppendEntries — no app payload can ride them without forking. The carrier is therefore the **log itself**: every entry `MvccRaftNode` proposes is stamped with the leader's wall clock at propose time (`TxnEntry::leader_time_ms`). `query_bounded_staleness(max_staleness, sql)` serves locally iff `now - last_applied_stamp <= bound`, refusing otherwise with `ConsensusError::StalenessExceeded { observed_ms, max_staleness_ms, leader_hint }`. Soundness details:

- Stamp taken at *propose* time → observed staleness over-counts replication latency (conservative direction).
- `max_staleness = 0` delegates to `query_linearizable` → followers redirect to the leader with a hint (the curator's staleness=0 criterion); the leader serves it with full ReadIndex confirmation.
- No leader special-case: a deposed/partitioned ex-leader's stamps age like anyone's, so it refuses rather than serve provably-stale data — and never hints at itself (PR 1's discipline).
- **Clock skew documented honestly** (module docs): true staleness ≤ `max_staleness` + leader→follower skew (only a follower running *behind* weakens the bound; running ahead refuses early). NTP assumptions and leader-step behavior spelled out. The token/ReadIndex paths remain fully clock-free.

### 3. Serde compatibility (log format)

`leader_time_ms: Option<u64>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`:
- pre-#5200 entries decode as unstamped → **unknown staleness** → bounded reads refuse until a stamped entry arrives (token reads unaffected);
- unstamped entries keep the byte-identical pre-#5200 encoding (test-asserted);
- unstamped entries advance the dense cursor but retain the previous (older) stamp — a weaker freshness claim, always sound;
- engine snapshots carry no stamps → after install, staleness stays unknown until the next stamped entry (documented).

### 4. Idle-cluster handling

With no writes the last stamp ages and a healthy idle follower would refuse. Both supported answers implemented, chosen per deployment:
- **Default (off)**: idle clusters age out of bounded reads; callers fall back to leader reads. Zero overhead, zero log noise.
- **Opt-in beacon** (`RaftTuning::staleness_beacon_ms`): the leader proposes an empty, stamped no-op entry whenever no stamped entry landed within the window (consumes a dense index like any entry; fire-and-forget, leadership-checked, race-tolerant). Healthy idle followers see a fresh stamp every ~2×window.

### 5. Misc

- `MvccRaftNode::join_tcp_cluster_tuned` (in-memory TCP constructor with tuning) for the beacon.
- `make test-cluster` now also runs `tests/follower_reads.rs`.
- Server mapping noted for #5383: the per-connection/per-statement `max_staleness_ms` PG option maps directly onto `query_bounded_staleness` (and propose tokens onto `query_at_least`).
- Lease fast path follow-on filed: #5389 (needs openraft 0.10 `ReadPolicy::LeaseRead`).

## Tests

`tests/follower_reads.rs` (TCP transport + severable per-edge proxies):
- `read_your_writes_token_serves_on_any_node` — token serves on every node with no manual apply-wait; token 0 degenerates to local; future token → typed `ReadTimeout`.
- `token_read_on_lagging_follower_blocks_until_catch_up` — partitioned follower refuses the token read (typed, bounded) while cut off; the SAME token read succeeds after the heal.
- `fresh_follower_serves_bounded_reads_and_zero_redirects` — fresh follower serves within bound; staleness=0 redirects to leader on a follower, serves linearizably on the leader.
- `partitioned_follower_refuses_bounded_reads_once_the_bound_elapses` — the acceptance: any read the partitioned follower still serves inside the bound is the pre-partition prefix; once `max_staleness` elapses it refuses (`observed > bound`) and stays refused; after the heal it catches up (token-proven) and the beacon restores bounded service with both rows.

Unit/channel tests (`mvcc_raft.rs`, `state_machine.rs`): tokens on every node, typed timeout, unknown-staleness refusal (no self-hint), zero-bound linearizable delegation, **pre-#5200 unstamped entry through the real mount** (tokens work, bounded reads refuse until a stamped entry), idle aging without beacon (refusal carries the leader hint; clock-free paths unaffected), beacon keeps an idle cluster fresh (and consumes dense indices), serde round-trip + byte-encoding compat.

## Verification

- `cargo test -p vibesql-consensus`: 146 unit + 15 integration, green
- `cargo test -p vibesql-consensus --features mvcc_enabled`: 149 unit + 15 integration, green
- `cargo clippy -p vibesql-consensus --all-targets` (both feature states): zero warnings
- `cargo build --workspace`: green (pre-existing warnings in other crates untouched)
- `make test-cluster`: 9 + 2 + 4 over real sockets, green
- Flake check: **15 consecutive runs** of the 4 new integration tests + 7 new unit tests — 30/30 result lines `0 failed`