### PR TITLE
feat(server): interactive transactions (BEGIN...COMMIT) in replicated sessions

### DIFF
--- a/crates/vibesql-server/src/replication.rs
+++ b/crates/vibesql-server/src/replication.rs
@@ -194,6 +194,22 @@ impl ReplicationHandle {
         self.node.execute_replicated(sql).await.map_err(|e| self.sql_error("the statement", e))
     }
 
+    /// Propose an interactive transaction's buffered write statements as
+    /// **one** consensus entry (#5391): the whole batch becomes a single
+    /// `TxnEntry`, applied atomically with `commit_ts` = its dense log
+    /// index. Freeze-at-propose runs once, on the leader, at COMMIT.
+    /// Returns the entry's log index (the session's read-your-writes
+    /// token) and the apply outcome.
+    pub async fn execute_txn(
+        &self,
+        statements: &[&str],
+    ) -> Result<(LogIndex, ApplyOutcome), SqlError> {
+        self.node
+            .execute_replicated_txn(statements)
+            .await
+            .map_err(|e| self.sql_error("the transaction", e))
+    }
+
     /// Local, stale-allowed read (the default read mode).
     pub fn query_local(&self, sql: &str) -> Result<Vec<Vec<vibesql_types::SqlValue>>, SqlError> {
         self.node.query(sql).map_err(|e| self.sql_error("the query", e))

--- a/crates/vibesql-server/src/session.rs
+++ b/crates/vibesql-server/src/session.rs
@@ -50,6 +50,20 @@ struct ReplicatedSessionState {
     /// Dense log index of this session's last replicated write (`0` =
     /// none) — the read-your-writes token `execute_replicated` returned.
     last_write_token: vibesql_consensus::LogIndex,
+    /// Open interactive transaction (#5391): `Some` between `BEGIN` and
+    /// `COMMIT`/`ROLLBACK`. Holds the buffered write statements (in
+    /// execution order) that are proposed as **one** `TxnEntry` at
+    /// `COMMIT` — the one-entry-per-committed-transaction design.
+    ///
+    /// During the open transaction the buffer is *not yet* proposed, so:
+    /// - write statements return an optimistic ack (`rows_affected = 0`);
+    ///   the authoritative row counts are knowable only after the atomic
+    ///   apply at `COMMIT`;
+    /// - reads are refused once the buffer is non-empty, because the
+    ///   buffered writes are not applied anywhere yet and a local read
+    ///   would silently miss the session's own writes (full mid-txn read
+    ///   fidelity is the scoped follow-on #5401).
+    open_txn: Option<Vec<String>>,
 }
 
 /// Session state for a database connection
@@ -235,6 +249,7 @@ impl Session {
             max_staleness_ms: 0,
             ryw_wait_ms: DEFAULT_RYW_WAIT_MS,
             last_write_token: 0,
+            open_txn: None,
         });
         session
     }
@@ -360,14 +375,46 @@ impl Session {
     ) -> Result<ExecutionResult> {
         use vibesql_ast::Statement;
 
-        let state = self.replication.as_ref().expect("execute_replicated without state");
-
-        // A halted node serves nothing further (fatal apply, see
-        // ConsensusError::FatalApply): every statement gets the retained
-        // reason instead of a stale read or a hung write.
-        if let Some(reason) = state.handle.fatal_reason() {
-            return Err(state.handle.halted_error(reason).into());
+        {
+            let state = self.replication.as_ref().expect("execute_replicated without state");
+            // A halted node serves nothing further (fatal apply, see
+            // ConsensusError::FatalApply): every statement gets the
+            // retained reason instead of a stale read or a hung write.
+            if let Some(reason) = state.handle.fatal_reason() {
+                return Err(state.handle.halted_error(reason).into());
+            }
         }
+
+        // Interactive transaction control (#5391): BEGIN opens a write
+        // buffer, COMMIT proposes it as one TxnEntry, ROLLBACK discards
+        // it. Handled before the per-statement dispatch so an open
+        // transaction can intercept buffered writes and gated reads.
+        match statement {
+            Statement::BeginTransaction(_) => return self.replicated_begin(),
+            Statement::Commit(_) => return self.replicated_commit().await,
+            Statement::Rollback(_) => return self.replicated_rollback(),
+            // Savepoints are out of scope (#5391); standalone sessions do
+            // not support them either. Refuse clearly.
+            Statement::Savepoint(_)
+            | Statement::RollbackToSavepoint(_)
+            | Statement::ReleaseSavepoint(_) => {
+                return Err(SqlError::not_supported(
+                    "savepoints in replicated transactions",
+                    "#5401",
+                )
+                .into())
+            }
+            _ => {}
+        }
+
+        // Inside an open transaction, writes are buffered (proposed as
+        // one entry at COMMIT) and reads are gated once the buffer is
+        // non-empty. Re-borrow `state` after this returns where needed.
+        if self.replication.as_ref().is_some_and(|s| s.open_txn.is_some()) {
+            return self.execute_in_open_txn(sql, statement);
+        }
+
+        let state = self.replication.as_ref().expect("execute_replicated without state");
 
         match statement {
             // Reads: dispatch on the session's read-consistency mode.
@@ -456,21 +503,8 @@ impl Session {
             // PRAGMA stays the no-op it is in standalone mode.
             Statement::Pragma(_) => Ok(ExecutionResult::Other { message: "PRAGMA".to_string() }),
 
-            // Interactive transactions are follow-on #5391: buffering the
-            // statements and proposing one TxnEntry at COMMIT needs its
-            // own design review (results during the open transaction,
-            // reads of buffered writes). Refusing is sound; guessing is
-            // not.
-            Statement::BeginTransaction(_)
-            | Statement::Commit(_)
-            | Statement::Rollback(_)
-            | Statement::Savepoint(_)
-            | Statement::RollbackToSavepoint(_)
-            | Statement::ReleaseSavepoint(_) => Err(SqlError::not_supported(
-                "interactive transaction control (BEGIN/COMMIT/ROLLBACK)",
-                "#5391",
-            )
-            .into()),
+            // Transaction control (BEGIN/COMMIT/ROLLBACK/SAVEPOINT) is
+            // intercepted above, before this autocommit dispatch.
 
             // Named prepared statements execute from a bound AST without
             // the SQL text the propose path replicates; cursors, EXPLAIN,
@@ -517,6 +551,220 @@ impl Session {
             // Unreachable from a fresh propose (idempotence replays only
             // overlap snapshot-install with log replay), but harmless.
             vibesql_consensus::ApplyOutcome::AlreadyApplied => Ok(0),
+        }
+    }
+
+    /// Open an interactive transaction in a replicated session (#5391):
+    /// installs an empty write buffer that subsequent DML/DDL append to
+    /// and that `COMMIT` proposes as one `TxnEntry`. `BEGIN` inside an
+    /// open transaction errors, matching the standalone behavior.
+    fn replicated_begin(&mut self) -> Result<ExecutionResult> {
+        let state = self.replication.as_mut().expect("replicated_begin without state");
+        if state.open_txn.is_some() {
+            return Err(anyhow::anyhow!("a transaction is already in progress"));
+        }
+        state.open_txn = Some(Vec::new());
+        Ok(ExecutionResult::Begin)
+    }
+
+    /// Commit an open replicated transaction (#5391): propose the whole
+    /// buffered write batch as **one** `TxnEntry` via
+    /// `execute_replicated_txn` (freeze-at-propose runs once, on the
+    /// leader, at COMMIT) and map the outcome:
+    ///
+    /// - `Applied` → the transaction committed atomically (`COMMIT`);
+    /// - `Rejected` → a deterministic statement failure rolled the whole
+    ///   batch back identically on every replica; the buffer is discarded
+    ///   and the executor error surfaced (no partial state);
+    /// - `NotLeader` / `FatalApply` → surfaced as the usual SQLSTATE; the
+    ///   buffer is discarded so a retry against the leader starts clean.
+    ///
+    /// An empty transaction (`BEGIN; COMMIT;` with no writes) consumes no
+    /// log index — there is nothing to replicate.
+    async fn replicated_commit(&mut self) -> Result<ExecutionResult> {
+        let buffered = {
+            let state = self.replication.as_mut().expect("replicated_commit without state");
+            match state.open_txn.take() {
+                Some(buf) => buf,
+                None => return Err(anyhow::anyhow!("no transaction is in progress")),
+            }
+        };
+
+        // Empty transaction: nothing to propose.
+        if buffered.is_empty() {
+            return Ok(ExecutionResult::Commit);
+        }
+
+        let state = self.replication.as_ref().expect("replicated_commit without state");
+        let handle = Arc::clone(&state.handle);
+        let statements: Vec<&str> = buffered.iter().map(String::as_str).collect();
+
+        // Propose the batch as one entry. `NotLeader`/`FatalApply`/etc.
+        // surface as a structured SqlError; the buffer is already cleared
+        // above so the session is back in autocommit on any error.
+        let (index, outcome) = handle.execute_txn(&statements).await?;
+
+        let state = self.replication.as_mut().expect("replicated_commit without state");
+        state.last_write_token = index;
+
+        match outcome {
+            vibesql_consensus::ApplyOutcome::Applied { .. } => Ok(ExecutionResult::Commit),
+            // Deterministic failure inside the batch: rolled back
+            // identically on every replica, no partial state committed.
+            vibesql_consensus::ApplyOutcome::Rejected { reason } => {
+                Err(anyhow::anyhow!("{}", reason))
+            }
+            // Not reachable from a fresh propose (see `replicated_write`).
+            vibesql_consensus::ApplyOutcome::AlreadyApplied => Ok(ExecutionResult::Commit),
+        }
+    }
+
+    /// Roll back an open replicated transaction (#5391): discard the
+    /// buffered writes without proposing anything — the batch never
+    /// reached consensus, so no log index is consumed.
+    fn replicated_rollback(&mut self) -> Result<ExecutionResult> {
+        let state = self.replication.as_mut().expect("replicated_rollback without state");
+        if state.open_txn.take().is_none() {
+            return Err(anyhow::anyhow!("no transaction is in progress"));
+        }
+        Ok(ExecutionResult::Rollback)
+    }
+
+    /// Execute one statement inside an open replicated transaction
+    /// (#5391). Writes are appended to the buffer and acknowledged
+    /// optimistically; reads are gated; unsupported features keep their
+    /// `0A000` refusal.
+    ///
+    /// Mid-transaction result semantics (documented contract):
+    /// - **Writes** return their command tag with `rows_affected = 0`.
+    ///   The buffer is not proposed until `COMMIT`, so the authoritative
+    ///   row count is not yet known; clients learn the outcome (success
+    ///   or a deterministic rejection) at `COMMIT`.
+    /// - **Reads** are refused with `0A000` once the buffer holds any
+    ///   writes: those writes are applied nowhere yet, so a local read
+    ///   would silently miss the session's own writes. A read before any
+    ///   buffered write (it observes committed state coherently) is
+    ///   allowed. Full read-your-own-writes inside the transaction is the
+    ///   scoped follow-on #5401.
+    fn execute_in_open_txn(
+        &mut self,
+        sql: &str,
+        statement: &vibesql_ast::Statement,
+    ) -> Result<ExecutionResult> {
+        use vibesql_ast::Statement;
+
+        // Whether the buffer already holds writes (read gating).
+        let buffer_has_writes = self
+            .replication
+            .as_ref()
+            .and_then(|s| s.open_txn.as_ref())
+            .is_some_and(|buf| !buf.is_empty());
+
+        // Append `sql` to the open transaction buffer.
+        let buffer = |this: &mut Self| {
+            this.replication
+                .as_mut()
+                .and_then(|s| s.open_txn.as_mut())
+                .expect("execute_in_open_txn without open transaction")
+                .push(sql.to_string());
+        };
+
+        match statement {
+            Statement::Select(_) => {
+                if buffer_has_writes {
+                    Err(SqlError::not_supported(
+                        "reads of a replicated transaction's own buffered writes",
+                        "#5401",
+                    )
+                    .into())
+                } else {
+                    // No buffered writes yet: serve against committed
+                    // state through the normal local read path.
+                    let handle = Arc::clone(
+                        &self
+                            .replication
+                            .as_ref()
+                            .expect("execute_in_open_txn without state")
+                            .handle,
+                    );
+                    let rows = handle.query_local(sql)?;
+                    let columns = rows
+                        .first()
+                        .map(|r| {
+                            (0..r.len()).map(|i| Column { name: format!("col{i}") }).collect()
+                        })
+                        .unwrap_or_default();
+                    let rows = rows.into_iter().map(|values| Row { values }).collect();
+                    Ok(ExecutionResult::Select { rows, columns })
+                }
+            }
+
+            // Writes: buffer for the COMMIT batch, ack optimistically.
+            Statement::Insert(stmt) => {
+                buffer(self);
+                self.stmt_cache.invalidate_table(&stmt.table_name);
+                Ok(ExecutionResult::Insert { rows_affected: 0 })
+            }
+            Statement::Update(stmt) => {
+                buffer(self);
+                self.stmt_cache.invalidate_table(&stmt.table_name);
+                Ok(ExecutionResult::Update { rows_affected: 0 })
+            }
+            Statement::Delete(stmt) => {
+                buffer(self);
+                self.stmt_cache.invalidate_table(&stmt.table_name);
+                Ok(ExecutionResult::Delete { rows_affected: 0 })
+            }
+            Statement::CreateTable(_) => {
+                buffer(self);
+                Ok(ExecutionResult::CreateTable)
+            }
+            Statement::CreateIndex(_) => {
+                buffer(self);
+                Ok(ExecutionResult::CreateIndex)
+            }
+            Statement::CreateView(_) => {
+                buffer(self);
+                Ok(ExecutionResult::CreateView)
+            }
+            Statement::DropTable(stmt) => {
+                buffer(self);
+                self.stmt_cache.invalidate_table(&stmt.table_name);
+                Ok(ExecutionResult::DropTable)
+            }
+            Statement::DropIndex(_) => {
+                buffer(self);
+                Ok(ExecutionResult::DropIndex)
+            }
+            Statement::DropView(_) => {
+                buffer(self);
+                Ok(ExecutionResult::DropView)
+            }
+
+            // SET adjusts session-local read settings; harmless inside a
+            // transaction and not part of the replicated batch.
+            Statement::SetVariable(stmt) => self.execute_replicated_set(stmt),
+
+            // PRAGMA stays the no-op it is in standalone mode.
+            Statement::Pragma(_) => Ok(ExecutionResult::Other { message: "PRAGMA".to_string() }),
+
+            // Everything else (PREPARE/EXECUTE, cursors, EXPLAIN, ANALYZE,
+            // VACUUM, ...) keeps its autocommit refusal inside the
+            // transaction too.
+            Statement::Prepare(_) | Statement::Execute(_) | Statement::Deallocate(_) => {
+                Err(SqlError::not_supported("PREPARE/EXECUTE statement syntax", "#5393").into())
+            }
+            Statement::DeclareCursor(_)
+            | Statement::OpenCursor(_)
+            | Statement::Fetch(_)
+            | Statement::CloseCursor(_) => {
+                Err(SqlError::not_supported("cursors", "#5393").into())
+            }
+            Statement::Explain(_) => Err(SqlError::not_supported("EXPLAIN", "#5393").into()),
+            Statement::Analyze(_) => Err(SqlError::not_supported("ANALYZE", "#5393").into()),
+            Statement::Vacuum(_) => Err(SqlError::not_supported("VACUUM", "#5393").into()),
+
+            _ => Err(SqlError::not_supported("this statement", "#5393").into()),
         }
     }
 

--- a/crates/vibesql-server/tests/replication_tests.rs
+++ b/crates/vibesql-server/tests/replication_tests.rs
@@ -174,10 +174,8 @@ async fn replicated_session_rejects_unsupported_features() {
     wait_for_leader(&handles).await;
     let mut session = replicated_session(&handles[0]);
 
-    let err = session.execute("BEGIN").await.unwrap_err();
-    let err = sql_error(&err);
-    assert_eq!(err.code, "0A000");
-    assert!(err.hint.as_deref().unwrap_or_default().contains("#5391"), "{err:?}");
+    // BEGIN/COMMIT/ROLLBACK are supported as of #5391 (see the dedicated
+    // interactive-transaction tests); they are no longer refused here.
 
     for (sql, follow_on) in [
         ("PREPARE p FROM 'SELECT 1'", "#5393"),
@@ -206,6 +204,154 @@ async fn replicated_session_rejects_unsupported_features() {
 
     // PRAGMA stays a no-op, as in standalone mode.
     session.execute("PRAGMA journal_mode = WAL").await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Session-level: interactive transactions (#5391)
+// ---------------------------------------------------------------------------
+
+/// BEGIN ... INSERT ... INSERT ... COMMIT replicates the whole batch as
+/// **one** consensus entry: a single log index is consumed and both rows
+/// are visible afterward.
+#[tokio::test]
+async fn replicated_txn_commits_batch_as_one_entry() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let mut session = replicated_session(&handles[0]);
+
+    session.execute("CREATE TABLE accounts (id INT, balance INT)").await.unwrap();
+    let applied_before = handles[0].node().last_applied();
+
+    // Open transaction: writes buffer and ack optimistically (rows = 0).
+    assert!(matches!(session.execute("BEGIN").await.unwrap(), ExecutionResult::Begin));
+    let r = session.execute("INSERT INTO accounts VALUES (1, 100)").await.unwrap();
+    assert!(matches!(r, ExecutionResult::Insert { rows_affected: 0 }), "{r:?}");
+    let r = session.execute("INSERT INTO accounts VALUES (2, 200)").await.unwrap();
+    assert!(matches!(r, ExecutionResult::Insert { rows_affected: 0 }), "{r:?}");
+
+    // Nothing is applied yet — the batch is not proposed until COMMIT.
+    assert_eq!(handles[0].node().last_applied(), applied_before, "buffer must not apply early");
+
+    assert!(matches!(session.execute("COMMIT").await.unwrap(), ExecutionResult::Commit));
+
+    // Exactly one entry was consumed for the whole transaction.
+    assert_eq!(
+        handles[0].node().last_applied(),
+        applied_before + 1,
+        "the transaction must be a single log entry"
+    );
+
+    // Both rows replicated atomically.
+    let rows = select_rows(session.execute("SELECT id, balance FROM accounts").await.unwrap());
+    assert_eq!(rows.len(), 2);
+}
+
+/// ROLLBACK discards the buffer without proposing anything: no log index
+/// is consumed and none of the buffered writes land.
+#[tokio::test]
+async fn replicated_txn_rollback_discards_buffer() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let mut session = replicated_session(&handles[0]);
+
+    session.execute("CREATE TABLE t (id INT)").await.unwrap();
+    let applied_before = handles[0].node().last_applied();
+
+    session.execute("BEGIN").await.unwrap();
+    session.execute("INSERT INTO t VALUES (1)").await.unwrap();
+    session.execute("INSERT INTO t VALUES (2)").await.unwrap();
+    assert!(matches!(session.execute("ROLLBACK").await.unwrap(), ExecutionResult::Rollback));
+
+    // No entry consumed, no rows landed.
+    assert_eq!(handles[0].node().last_applied(), applied_before, "rollback must not propose");
+    let rows = select_rows(session.execute("SELECT id FROM t").await.unwrap());
+    assert!(rows.is_empty(), "rolled-back writes must not be visible");
+
+    // The session is back in autocommit: a write proposes immediately.
+    let r = session.execute("INSERT INTO t VALUES (3)").await.unwrap();
+    assert!(matches!(r, ExecutionResult::Insert { rows_affected: 1 }), "{r:?}");
+    assert_eq!(handles[0].node().last_applied(), applied_before + 1);
+}
+
+/// A deterministic statement failure in the batch rejects the whole
+/// COMMIT — no partial state is committed.
+#[tokio::test]
+async fn replicated_txn_deterministic_failure_rejects_whole_batch() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let mut session = replicated_session(&handles[0]);
+
+    session.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)").await.unwrap();
+
+    session.execute("BEGIN").await.unwrap();
+    session.execute("INSERT INTO t VALUES (1)").await.unwrap();
+    // Duplicate primary key: deterministic rejection at apply.
+    session.execute("INSERT INTO t VALUES (1)").await.unwrap();
+
+    let err = session.execute("COMMIT").await.unwrap_err();
+    // A rejection surfaces the executor error, not a structured SqlError.
+    assert!(err.downcast_ref::<SqlError>().is_none(), "rejection keeps the executor error: {err}");
+
+    // No partial state: the first INSERT did not commit either.
+    let rows = select_rows(session.execute("SELECT id FROM t").await.unwrap());
+    assert!(rows.is_empty(), "a rejected batch must commit nothing: {rows:?}");
+}
+
+/// An empty transaction (BEGIN; COMMIT; with no writes) consumes no log
+/// index — there is nothing to replicate.
+#[tokio::test]
+async fn replicated_empty_txn_consumes_no_index() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let mut session = replicated_session(&handles[0]);
+
+    let applied_before = handles[0].node().last_applied();
+    session.execute("BEGIN").await.unwrap();
+    assert!(matches!(session.execute("COMMIT").await.unwrap(), ExecutionResult::Commit));
+    assert_eq!(handles[0].node().last_applied(), applied_before, "empty txn must not propose");
+}
+
+/// Reads inside a transaction are coherent before any buffered write
+/// (committed state) and refused once writes are buffered (the buffer is
+/// applied nowhere yet — full mid-txn read fidelity is #5401).
+#[tokio::test]
+async fn replicated_txn_read_gating() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let mut session = replicated_session(&handles[0]);
+
+    session.execute("CREATE TABLE t (id INT)").await.unwrap();
+    session.execute("INSERT INTO t VALUES (1)").await.unwrap();
+
+    session.execute("BEGIN").await.unwrap();
+    // No buffered writes yet: a read observes committed state.
+    let rows = select_rows(session.execute("SELECT id FROM t").await.unwrap());
+    assert_eq!(rows.len(), 1, "pre-write read sees committed state");
+
+    // After a buffered write, reads are refused with 0A000 → #5401.
+    session.execute("INSERT INTO t VALUES (2)").await.unwrap();
+    let err = session.execute("SELECT id FROM t").await.unwrap_err();
+    let err = sql_error(&err);
+    assert_eq!(err.code, "0A000");
+    assert!(err.hint.as_deref().unwrap_or_default().contains("#5401"), "{err:?}");
+
+    session.execute("ROLLBACK").await.unwrap();
+}
+
+/// Savepoints inside a replicated transaction are refused with 0A000 and
+/// a pointer to the scoped follow-on (#5401).
+#[tokio::test]
+async fn replicated_txn_savepoints_refused() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let mut session = replicated_session(&handles[0]);
+
+    session.execute("BEGIN").await.unwrap();
+    let err = session.execute("SAVEPOINT s1").await.unwrap_err();
+    let err = sql_error(&err);
+    assert_eq!(err.code, "0A000");
+    assert!(err.hint.as_deref().unwrap_or_default().contains("#5401"), "{err:?}");
+    session.execute("ROLLBACK").await.unwrap();
 }
 
 // ---------------------------------------------------------------------------
@@ -278,6 +424,91 @@ async fn follower_rejects_writes_with_redirect_hint() {
     // (token 0 degenerates to a local read) the read serves locally.
     session.execute("SET vibesql_read_consistency = 'read_your_writes'").await.unwrap();
     assert_not_redirected(session.execute("SELECT * FROM t").await, "token-0 read");
+}
+
+/// A transaction's COMMIT on a follower fails with SQLSTATE 25006 (the
+/// leader-redirect contract) and discards the buffer, so the follower is
+/// back in autocommit afterward.
+#[tokio::test]
+async fn replicated_txn_commit_on_follower_redirects_and_discards() {
+    let (handles, _dir) = boot_cluster(3).await;
+    let leader = wait_for_leader(&handles).await;
+
+    // Create the table through the leader.
+    replicated_session(&handles[leader]).execute("CREATE TABLE t (id INT)").await.unwrap();
+
+    // Pick a follower that knows who leads.
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    let follower = loop {
+        if let Some(i) = handles
+            .iter()
+            .position(|h| h.role() == Role::Follower && h.node().current_leader().is_some())
+        {
+            break i;
+        }
+        assert!(tokio::time::Instant::now() < deadline, "timed out waiting for a follower");
+        tokio::time::sleep(POLL_INTERVAL).await;
+    };
+
+    let mut session = replicated_session(&handles[follower]);
+
+    // BEGIN/INSERT buffer locally (no propose yet, so no error here).
+    session.execute("BEGIN").await.unwrap();
+    session.execute("INSERT INTO t VALUES (1)").await.unwrap();
+
+    // COMMIT proposes on the follower → 25006.
+    let err = session.execute("COMMIT").await.unwrap_err();
+    assert_eq!(sql_error(&err).code, "25006");
+
+    // The buffer was discarded: the session is back in autocommit, so a
+    // ROLLBACK now errors with "no transaction in progress".
+    let err = session.execute("ROLLBACK").await.unwrap_err();
+    assert!(err.downcast_ref::<SqlError>().is_none(), "buffer should be discarded: {err}");
+}
+
+/// A committed transaction replicates atomically to a second node: after
+/// COMMIT on the leader, a follower converges to **all** of the
+/// transaction's rows (one entry applies all or none).
+#[tokio::test]
+async fn replicated_txn_replicates_atomically_to_followers() {
+    let (handles, _dir) = boot_cluster(3).await;
+    let leader = wait_for_leader(&handles).await;
+    let mut session = replicated_session(&handles[leader]);
+
+    session.execute("CREATE TABLE kv (id INT, v INT)").await.unwrap();
+    session.execute("BEGIN").await.unwrap();
+    session.execute("INSERT INTO kv VALUES (1, 10)").await.unwrap();
+    session.execute("INSERT INTO kv VALUES (2, 20)").await.unwrap();
+    session.execute("INSERT INTO kv VALUES (3, 30)").await.unwrap();
+    session.execute("COMMIT").await.unwrap();
+
+    // Every follower converges to all three rows (never a partial 1 or 2).
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    for (i, h) in handles.iter().enumerate() {
+        if i == leader {
+            continue;
+        }
+        loop {
+            let count = h
+                .node()
+                .query("SELECT COUNT(*) FROM kv")
+                .ok()
+                .and_then(|r| r.first().and_then(|row| row.first()).map(ToString::to_string));
+            if count.as_deref() == Some("3") {
+                break;
+            }
+            // A partial count would mean the batch did not apply atomically.
+            assert!(
+                matches!(count.as_deref(), None | Some("0") | Some("3")),
+                "follower {i} saw a non-atomic count: {count:?}"
+            );
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "follower {i} did not converge to 3 rows (saw {count:?})"
+            );
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -400,10 +631,30 @@ async fn wire_protocol_replicated_end_to_end() {
         "1"
     );
 
-    // BEGIN is refused with feature_not_supported.
-    let err = client.simple_query("BEGIN").await.unwrap_err();
-    let db_err = err.as_db_error().expect("db error");
-    assert_eq!(db_err.code(), &SqlState::FEATURE_NOT_SUPPORTED);
+    // A wire-level interactive transaction commits atomically (#5391).
+    client.simple_query("BEGIN").await.unwrap();
+    client.simple_query("INSERT INTO wire_test VALUES (2, 'Bob')").await.unwrap();
+    client.simple_query("INSERT INTO wire_test VALUES (3, 'Carol')").await.unwrap();
+    client.simple_query("COMMIT").await.unwrap();
+    assert_eq!(
+        handles[0].node().query("SELECT COUNT(*) FROM wire_test").unwrap()[0][0].to_string(),
+        "3"
+    );
+
+    // ROLLBACK discards a buffered write.
+    client.simple_query("BEGIN").await.unwrap();
+    client.simple_query("INSERT INTO wire_test VALUES (4, 'Dan')").await.unwrap();
+    client.simple_query("ROLLBACK").await.unwrap();
+    assert_eq!(
+        handles[0].node().query("SELECT COUNT(*) FROM wire_test").unwrap()[0][0].to_string(),
+        "3"
+    );
+
+    // Savepoints remain feature_not_supported (#5401).
+    client.simple_query("BEGIN").await.unwrap();
+    let err = client.simple_query("SAVEPOINT s1").await.unwrap_err();
+    assert_eq!(err.as_db_error().expect("db error").code(), &SqlState::FEATURE_NOT_SUPPORTED);
+    client.simple_query("ROLLBACK").await.unwrap();
 }
 
 /// End to end on a follower: a write gets SQLSTATE 25006 with the


### PR DESCRIPTION
## Summary

Implements interactive transactions for replicated sessions (#5391), the deferred follow-on from #5383. A replicated session can now run `BEGIN ... <writes> ... COMMIT` / `ROLLBACK`, with the whole transaction becoming **one** `TxnEntry` in the consensus log.

- **Buffer-and-propose-at-COMMIT**: `BEGIN` opens a write buffer in the session's replicated state. DML/DDL append their SQL to the buffer. `COMMIT` proposes the whole batch via the new `ReplicationHandle::execute_txn` (wrapping the existing `MvccRaftNode::execute_replicated_txn`), so freeze-at-propose runs once on the leader and the batch applies atomically with `commit_ts = log index`. `ROLLBACK` discards the buffer with no propose (no index consumed).
- **COMMIT outcome mapping**: `Applied` -> commit ack; `Rejected` (deterministic statement failure, rolled back identically on every replica) -> buffer discarded + executor error surfaced, no partial state; `NotLeader`/`FatalApply` -> structured `SqlError` (25006/58000) + buffer discarded so a retry against the leader starts clean. Empty `BEGIN; COMMIT;` consumes no index.

## Mid-transaction result semantics (documented contract)

- **Writes** ack optimistically with `rows_affected = 0` — the entry is not proposed until COMMIT, so the authoritative count is not yet known; clients learn the outcome (success or deterministic rejection) at COMMIT.
- **Reads** observe committed state before any buffered write (coherent), and are **refused with `0A000`** once the buffer holds writes, because those writes are applied nowhere yet and a local read would silently miss the session's own writes. Full read-your-own-writes inside the transaction is the scoped follow-on #5401.

## Scope / disposition

- **Savepoints** (`SAVEPOINT`/`ROLLBACK TO`/`RELEASE`) remain `0A000` with a pointer to #5401 (filed). Standalone sessions don't fully support them either.
- **Standalone mode is unaffected** — it keeps its real local transactions.

## Changes

- `crates/vibesql-server/src/replication.rs`: add `ReplicationHandle::execute_txn` (propose a buffered batch as one entry).
- `crates/vibesql-server/src/session.rs`: `open_txn` buffer on the replicated session state; `replicated_begin`/`replicated_commit`/`replicated_rollback`; `execute_in_open_txn` (buffer writes, gate reads); transaction control intercepted before the autocommit dispatch.
- `crates/vibesql-server/tests/replication_tests.rs`: new session-level + multi-node + wire-level tests.

## Test plan

- [x] `cargo test -p vibesql-server` green (414+ lib tests + all integration suites, standalone transaction regression included)
- [x] New replicated-txn tests: atomic batch -> one log entry; both rows replicate to a 2nd/3rd node atomically; ROLLBACK discards; deterministic constraint violation rejects whole batch (no partial state); empty txn consumes no index; read gating; COMMIT on a follower -> 25006 + buffer discarded; wire-level BEGIN/INSERT/INSERT/COMMIT + ROLLBACK + savepoint refusal
- [x] Multi-node tests flake-checked 12x (stable)
- [x] `cargo clippy -p vibesql-server --all-targets` clean for touched files
- [x] `cargo build --workspace` green

Closes #5391

🤖 Generated with [Claude Code](https://claude.com/claude-code)