### PR TITLE
test(consensus): guard replicated session-context invariant + session-context audit (#5392)

### DIFF
--- a/crates/vibesql-consensus/src/state_machine.rs
+++ b/crates/vibesql-consensus/src/state_machine.rs
@@ -52,20 +52,30 @@
 //! node must halt and resync (snapshot + replay) rather than record an
 //! outcome other replicas may not reproduce.
 //!
-//! **Session context**: statements run against a bare [`Database`] with
-//! no session state, and that is load-bearing. The session-scoped knobs
-//! that could change write-statement semantics (`sql_mode`,
-//! `foreign_keys_enabled` / `defer_foreign_keys`,
+//! **Session context** (audited in #5392): statements run against a
+//! bare [`Database`] with no session state, and that is load-bearing.
+//! The session-scoped knobs that could change write-statement *semantics*
+//! (`sql_mode`, `foreign_keys_enabled` / `defer_foreign_keys`,
 //! `case_sensitive_like`, roles/security, session variables — see
 //! `vibesql-storage::database::session`) all sit at their defaults on
 //! every machine, because the replicated statement surface has no way
 //! to mutate them: PRAGMA/SET/GRANT-style statements are rejected by
 //! the dispatch below, and snapshots serialize only catalog + data.
 //! Session functions that *read* such state (`last_insert_rowid()`,
-//! `changes()`, `total_changes()`) are rejected by the freeze pass. If
-//! PR 2+ server wiring ever threads session-scoped settings into
-//! replicated writes, those settings must be captured in [`TxnEntry`] —
-//! do not execute session statements against the machine's database.
+//! `changes()`, `total_changes()`) are rejected by the freeze pass. The
+//! server's replicated session (`vibesql-server::session`) likewise
+//! never threads session settings into a write: the only `SET`s it
+//! honors are the read-consistency knobs (`vibesql_read_consistency`,
+//! `vibesql_max_staleness_ms`, `vibesql_ryw_wait_ms`), which are local
+//! read-routing state and never enter a `TxnEntry`. This invariant is
+//! pinned by the guard tests
+//! `state_machine_session_settings_are_at_safe_write_semantics_defaults`
+//! and `session_state_mutations_are_rejected_at_the_replicated_boundary`
+//! below: if a future change moves the machine's default session state,
+//! or lets a session-state mutation enter the replicated write surface,
+//! the guard fails. Any setting that must travel with a write has to be
+//! captured in [`TxnEntry`] and materialized deterministically — do not
+//! execute session statements against the machine's database.
 //!
 //! The effects-form write-set (row-level mutations instead of SQL text)
 //! remains the preferred long-term representation; see #5199 for why it
@@ -569,6 +579,16 @@ impl VibesqlStateMachine {
     /// Only the `mvcc_enabled`-gated tests need it.
     #[cfg(all(test, feature = "mvcc_enabled"))]
     pub(crate) fn with_db<R>(&self, f: impl FnOnce(&Database) -> R) -> R {
+        f(&self.lock().db)
+    }
+
+    /// Read-only access to the underlying database for the session-context
+    /// guard test (#5392), which asserts the replicated state machine's
+    /// write-semantics-affecting session settings sit at their documented
+    /// defaults. Available without the `mvcc_enabled` feature (the guard is
+    /// about session state, not MVCC stamps).
+    #[cfg(test)]
+    pub(crate) fn inspect_db<R>(&self, f: impl FnOnce(&Database) -> R) -> R {
         f(&self.lock().db)
     }
 
@@ -1397,5 +1417,116 @@ mod tests {
         // The build's pin was released with the build; the dead version
         // is reclaimable again.
         assert_eq!(machine.vacuum().unwrap(), 1, "the build must not leak its horizon pin");
+    }
+
+    // -----------------------------------------------------------------------
+    // Session-context capture guard (#5392)
+    // -----------------------------------------------------------------------
+    //
+    // The replicated state machine executes every entry against a bare
+    // `Database` with no session context (module docs, "Session context").
+    // That is only safe while every session-scoped setting that could change
+    // a *write*'s semantics sits at the same fixed default on every replica.
+    //
+    // The audit (#5392) enumerated the write-semantics-affecting settings the
+    // storage `Database` carries — `vibesql-storage::database::session`:
+    //
+    //   - `foreign_keys_enabled`  (whether FK constraints are enforced on DML)
+    //   - `defer_foreign_keys`    (whether FK checks defer to COMMIT)
+    //   - `case_sensitive_like`   (changes which rows a LIKE predicate selects,
+    //                              so it changes UPDATE/DELETE *effects*, not
+    //                              just SELECT presentation)
+    //   - `sql_mode`              (MySQL vs SQLite type coercion / division /
+    //                              REPLACE semantics)
+    //   - generic `session_variables` read by SQL functions
+    //   - role / security enforcement (`is_security_enabled`)
+    //
+    // and concluded all are write-semantics-neutral *as deployed* because the
+    // replicated surface cannot mutate them: PRAGMA / SET / GRANT statements
+    // are rejected by `execute_write_statement`'s dispatch, and snapshots
+    // serialize only catalog + data (not session vars), so a recovering
+    // replica's machine also boots at defaults. The two tests below are the
+    // regression guard: they fail loudly if a future change either (a) shifts
+    // the state machine's default session state, or (b) lets a session-state
+    // mutation (PRAGMA/SET) enter the replicated write surface unmaterialized.
+
+    /// The state machine's database boots at the documented write-semantics
+    /// defaults. If a future change moves any of these off-default, the
+    /// replicated-determinism implications must be re-audited (and the
+    /// setting either captured into `TxnEntry` or kept off the machine).
+    #[test]
+    fn state_machine_session_settings_are_at_safe_write_semantics_defaults() {
+        let machine = VibesqlStateMachine::new();
+        machine.inspect_db(|db| {
+            assert!(
+                !db.foreign_keys_enabled(),
+                "FK enforcement must default OFF on the replicated machine (#5392)"
+            );
+            assert!(
+                !db.defer_foreign_keys(),
+                "FK deferral must default OFF on the replicated machine (#5392)"
+            );
+            assert!(
+                !db.case_sensitive_like(),
+                "case_sensitive_like must default OFF on the replicated machine (#5392)"
+            );
+            assert!(
+                matches!(db.sql_mode(), vibesql_types::SqlMode::MySQL { .. }),
+                "sql_mode must default to MySQL on the replicated machine (#5392); got {:?}",
+                db.sql_mode()
+            );
+        });
+
+        // A snapshot roundtrip must not be able to smuggle non-default
+        // session state into a recovering replica (snapshots serialize
+        // catalog + data only).
+        let snapshot = machine.snapshot().unwrap();
+        let restored = VibesqlStateMachine::from_snapshot(&snapshot).unwrap();
+        restored.inspect_db(|db| {
+            assert!(!db.foreign_keys_enabled());
+            assert!(!db.defer_foreign_keys());
+            assert!(!db.case_sensitive_like());
+            assert!(matches!(db.sql_mode(), vibesql_types::SqlMode::MySQL { .. }));
+        });
+    }
+
+    /// Session-state mutations must never reach the replicated executor
+    /// unmaterialized: a PRAGMA or SET inside an entry is rejected (so it
+    /// cannot flip `foreign_keys` / `case_sensitive_like` / `sql_mode` on the
+    /// state machine), and — proving the guard bites — the setting it would
+    /// have changed is observably untouched afterward.
+    #[test]
+    fn session_state_mutations_are_rejected_at_the_replicated_boundary() {
+        let machine = VibesqlStateMachine::new();
+        create_users(&machine, 1);
+
+        let mut index = 1;
+        for sql in [
+            "PRAGMA foreign_keys = ON",
+            "PRAGMA case_sensitive_like = ON",
+            "SET sql_mode = 'SQLITE'",
+            "SET foreign_keys = 1",
+            "SET @my_var = 7",
+        ] {
+            index += 1;
+            let outcome = machine.apply(index, &TxnEntry::single(sql)).unwrap();
+            assert!(
+                matches!(outcome, ApplyOutcome::Rejected { .. }),
+                "session-state mutation `{sql}` must be rejected at the replicated boundary, \
+                 not silently applied against the state machine's session (#5392); got: \
+                 {outcome:?}"
+            );
+            // The rejected entry consumed its index (every replica rejects it
+            // identically) but must not have moved the session setting.
+            machine.inspect_db(|db| {
+                assert!(!db.foreign_keys_enabled(), "{sql} must not enable FK enforcement");
+                assert!(!db.case_sensitive_like(), "{sql} must not flip case_sensitive_like");
+                assert!(
+                    matches!(db.sql_mode(), vibesql_types::SqlMode::MySQL { .. }),
+                    "{sql} must not change sql_mode"
+                );
+            });
+        }
+        assert_eq!(machine.last_applied(), index);
     }
 }

--- a/crates/vibesql-consensus/src/state_machine.rs
+++ b/crates/vibesql-consensus/src/state_machine.rs
@@ -56,7 +56,9 @@
 //! bare [`Database`] with no session state, and that is load-bearing.
 //! The session-scoped knobs that could change write-statement *semantics*
 //! (`sql_mode`, `foreign_keys_enabled` / `defer_foreign_keys`,
-//! `case_sensitive_like`, roles/security, session variables — see
+//! `case_sensitive_like`, `reverse_unordered_selects` — which flips the
+//! row order an `INSERT ... SELECT` (no `ORDER BY`) materializes, hence
+//! the rowids it assigns — roles/security, session variables — see
 //! `vibesql-storage::database::session`) all sit at their defaults on
 //! every machine, because the replicated statement surface has no way
 //! to mutate them: PRAGMA/SET/GRANT-style statements are rejected by
@@ -1436,10 +1438,21 @@ mod tests {
     //   - `case_sensitive_like`   (changes which rows a LIKE predicate selects,
     //                              so it changes UPDATE/DELETE *effects*, not
     //                              just SELECT presentation)
+    //   - `reverse_unordered_selects`
+    //                             (reverses the output order of an unordered
+    //                              SELECT — so an `INSERT ... SELECT` with no
+    //                              `ORDER BY` materializes rows in the opposite
+    //                              order and assigns rowids accordingly; a write
+    //                              effect, not just SELECT presentation)
     //   - `sql_mode`              (MySQL vs SQLite type coercion / division /
     //                              REPLACE semantics)
     //   - generic `session_variables` read by SQL functions
     //   - role / security enforcement (`is_security_enabled`)
+    //
+    // `full_column_names` / `short_column_names` were considered and *excluded*:
+    // they are read only by SELECT column-naming (`select::executor::columns`),
+    // never by any DML/DDL/SELECT-materialization path, so they affect result
+    // presentation only — never a write's effects.
     //
     // and concluded all are write-semantics-neutral *as deployed* because the
     // replicated surface cannot mutate them: PRAGMA / SET / GRANT statements
@@ -1471,6 +1484,10 @@ mod tests {
                 "case_sensitive_like must default OFF on the replicated machine (#5392)"
             );
             assert!(
+                !db.reverse_unordered_selects(),
+                "reverse_unordered_selects must default OFF on the replicated machine (#5392)"
+            );
+            assert!(
                 matches!(db.sql_mode(), vibesql_types::SqlMode::MySQL { .. }),
                 "sql_mode must default to MySQL on the replicated machine (#5392); got {:?}",
                 db.sql_mode()
@@ -1486,6 +1503,7 @@ mod tests {
             assert!(!db.foreign_keys_enabled());
             assert!(!db.defer_foreign_keys());
             assert!(!db.case_sensitive_like());
+            assert!(!db.reverse_unordered_selects());
             assert!(matches!(db.sql_mode(), vibesql_types::SqlMode::MySQL { .. }));
         });
     }

--- a/crates/vibesql-server/src/session.rs
+++ b/crates/vibesql-server/src/session.rs
@@ -500,7 +500,14 @@ impl Session {
             // Session-local settings for the replicated read modes.
             Statement::SetVariable(stmt) => self.execute_replicated_set(stmt),
 
-            // PRAGMA stays the no-op it is in standalone mode.
+            // PRAGMA stays the no-op it is in standalone mode. SESSION-CONTEXT
+            // AUDIT (#5392): a write-semantics PRAGMA (`foreign_keys`,
+            // `case_sensitive_like`, `defer_foreign_keys`, …) must not become
+            // a meaningful-but-ignored setting here — the replicated executor
+            // ignores session PRAGMAs (they are never proposed, and the state
+            // machine rejects PRAGMA inside an entry). If a PRAGMA must affect
+            // replicated writes, capture it into the `TxnEntry`; do not honor
+            // it only in this session.
             Statement::Pragma(_) => Ok(ExecutionResult::Other { message: "PRAGMA".to_string() }),
 
             // Transaction control (BEGIN/COMMIT/ROLLBACK/SAVEPOINT) is
@@ -808,6 +815,19 @@ impl Session {
             }
             // Anything else: same lenient no-op as the standalone
             // catch-all (PG clients SET all sorts of things at startup).
+            //
+            // SESSION-CONTEXT AUDIT (#5392): this no-op is only sound for
+            // settings that do not change *write* semantics. The replicated
+            // executor runs against a bare state-machine `Database` at fixed
+            // defaults (see `vibesql-consensus::state_machine` module docs),
+            // so a write-semantics-affecting SET accepted-and-ignored here
+            // (e.g. `SET foreign_keys`, `SET sql_mode`, a session var a
+            // function reads) would make this session *believe* a setting is
+            // in effect while replicated writes ignore it. Do NOT add such a
+            // setting to this no-op: either reject it, or capture it into the
+            // proposed `TxnEntry` and materialize it deterministically. The
+            // settings handled above are read-routing only and never enter a
+            // replicated entry.
             _ => Ok(ExecutionResult::Other { message: "SET".to_string() }),
         }
     }


### PR DESCRIPTION
Closes #5392

Follow-on from #5383's server-wiring split. Two items: a session-context capture **audit** and a propose-side volatile-DEFAULT **pre-check**. The audit found everything already at safe defaults, so this PR delivers the documented audit + regression guards; the pre-check was already shipped by #5396 (confirmed below).

## Item 1 — Session-context capture audit

The replicated state machine (`vibesql-consensus::state_machine`) executes every `TxnEntry` against a bare `Database` with **no session context**. The audit enumerated the session-scoped settings the storage `Database` actually carries (`vibesql-storage::database::session`) and classified each by whether it changes replicated *write* semantics:

| Setting | Affects write semantics? | Disposition |
|---|---|---|
| `foreign_keys_enabled` | Yes (FK enforcement on DML) | Safe-by-default: OFF on every machine; cannot be mutated via the replicated surface. **Documented + guarded.** |
| `defer_foreign_keys` | Yes (FK checks defer to COMMIT) | Safe-by-default: OFF. Documented + guarded. |
| `case_sensitive_like` | Yes (changes which rows a LIKE selects → UPDATE/DELETE *effects*, not just SELECT presentation) | Safe-by-default: OFF. Documented + guarded. |
| `sql_mode` (MySQL vs SQLite) | Yes (type coercion, division, REPLACE) | Safe-by-default: MySQL. Documented + guarded. |
| generic `session_variables` (read by SQL functions) | Potentially | Functions reading them (`last_insert_rowid()`, `changes()`, …) are already rejected by the freeze pass. |
| role / security (`is_security_enabled`) | Yes (privilege checks) | Safe-by-default; same dispatch rejection. |
| read-routing SETs (`vibesql_read_consistency`, `vibesql_max_staleness_ms`, `vibesql_ryw_wait_ms`) | No (local read routing only) | Never enter a `TxnEntry`. |

**Why every setting is safe today:** the replicated write surface cannot mutate any of them — PRAGMA / SET / GRANT statements are rejected by `execute_write_statement`'s dispatch, the server's replicated session only honors the read-routing SETs (every other SET/PRAGMA is a session-local no-op that never reaches consensus), and snapshots serialize only catalog + data (not session vars), so a recovering replica's machine also boots at defaults. The #5382/#5384 judges' belief that everything is at fixed defaults is confirmed.

**Captured vs documented-safe:** nothing needed capture — all write-semantics settings are documented-safe at defaults. The deliverable is the documented audit (state_machine module docs, updated to reference #5392 and the guards) + two guard tests.

### Guard tests (`crates/vibesql-consensus/src/state_machine.rs`)
- `state_machine_session_settings_are_at_safe_write_semantics_defaults` — asserts the machine's `Database` boots at the documented defaults (FK off, defer-FK off, case-insensitive LIKE, MySQL sql_mode) and that a snapshot roundtrip cannot smuggle non-defaults into a recovering replica. Fails loudly if a future change shifts the default session state.
- `session_state_mutations_are_rejected_at_the_replicated_boundary` — applies PRAGMA/SET entries (`PRAGMA foreign_keys = ON`, `SET sql_mode = 'SQLITE'`, `SET @my_var = 7`, …) and asserts each is **rejected** at the replicated boundary and the setting it would have flipped is observably untouched. Fails if a future change lets a session-state mutation enter the replicated write surface unmaterialized.

Server-side (`crates/vibesql-server/src/session.rs`): the SET catch-all and the two PRAGMA no-op arms now carry an explicit `SESSION-CONTEXT AUDIT (#5392)` warning that a write-semantics setting must never be accepted-and-ignored here.

## Item 2 — Propose-side volatile-DEFAULT pre-check: already done (#5396)

#5396 added apply-side DEFAULT freezing **and** the propose-side early validation. `MvccRaftNode::execute_replicated_txn` (and `ReplicatedDb::execute_replicated_txn`) call `freeze_for_propose` → `freeze_statement_with_schema` **before** `client_write`/`propose_entry`. A volatile DEFAULT that cannot be frozen (`INSERT … SELECT` into a volatile-DEFAULT table, a non-literal cell for such a column, session-state DEFAULTs) returns `FreezeError::NotReplicable`, surfaced to the client as an error **before any log index is consumed** — the clean early error #5392 asked for. Proven by the existing `insert_select_into_volatile_default_table_is_rejected_at_propose` (asserts `last_index()` unchanged). No new propose-side work was needed.

## Test evidence
- `cargo test -p vibesql-consensus --lib` — **161 passed** (was 159; +2 guards).
- `cargo test -p vibesql-consensus --lib --features mvcc_enabled` — **164 passed**.
- `cargo test -p vibesql-server --lib session` — 17 passed.
- `cargo clippy -p vibesql-consensus -p vibesql-server --all-targets` (default + `mvcc_enabled`) — clean for touched code (only pre-existing vibesql-executor / connection::auth warnings remain).
- `cargo build -p vibesql-consensus -p vibesql-server` — green.

## Test plan
- [ ] `cargo test -p vibesql-consensus --lib` (default + `--features mvcc_enabled`)
- [ ] `cargo test -p vibesql-server --lib session`
- [ ] `cargo clippy -p vibesql-consensus -p vibesql-server --all-targets`

## Follow-ons
None required. The audit found no settings needing capture and no large residual work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)