### PR TITLE
fix(executor): thread trigger NEW/OLD context into IPK value evaluation

### DIFF
--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -545,15 +545,36 @@ fn execute_insert_internal(
                     }
                 }
                 _ => {
-                    // For complex expressions (CASE, functions, subqueries, etc.),
-                    // evaluate them to get the resulting value
-                    // Create a dummy schema/row for evaluation since rowid expressions
-                    // don't reference columns from a current row
+                    // For complex expressions (CASE, functions, subqueries, trigger
+                    // pseudo-variables, procedural variables, etc.), evaluate them to get
+                    // the resulting value.
+                    //
+                    // When inserting into an INTEGER PRIMARY KEY column, the column's value
+                    // is treated as the rowid and routed through this expression-evaluation
+                    // path. If the INSERT runs inside a trigger body, the expression may
+                    // reference NEW.x / OLD.x pseudo-variables (e.g.
+                    // `INSERT INTO audit(id, ...) VALUES (NEW.id, ...)` where audit.id is an
+                    // INTEGER PRIMARY KEY). We must thread the trigger / procedural context
+                    // into the evaluator so those references resolve, matching the non-IPK
+                    // column path in `evaluate_insert_expression_with_trigger_context`
+                    // (issue #5397).
+                    //
+                    // rowid expressions don't reference columns from a current row, so a
+                    // dummy row is sufficient.
                     let dummy_schema =
                         vibesql_catalog::TableSchema::new("__rowid_expr__".to_string(), vec![]);
                     let dummy_row = vibesql_storage::Row::new(vec![]);
-                    let mut evaluator =
-                        crate::ExpressionEvaluator::with_database(&dummy_schema, db);
+                    let mut evaluator = if let Some(ctx) = trigger_context {
+                        crate::ExpressionEvaluator::with_trigger_context(
+                            ctx.table_schema,
+                            db,
+                            ctx,
+                        )
+                    } else if let Some(ctx) = procedural_context {
+                        crate::ExpressionEvaluator::with_procedural_context(&dummy_schema, db, ctx)
+                    } else {
+                        crate::ExpressionEvaluator::with_database(&dummy_schema, db)
+                    };
                     if let Some(ref ctes) = cte_results {
                         evaluator = evaluator.with_cte_context(ctes);
                     }

--- a/crates/vibesql-executor/src/tests/triggers/pseudo_vars.rs
+++ b/crates/vibesql-executor/src/tests/triggers/pseudo_vars.rs
@@ -224,3 +224,118 @@ fn test_old_in_delete_trigger() {
         vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("Alice"))
     );
 }
+
+/// Execute a single statement parsed from SQL (helper for IPK trigger tests).
+fn exec(db: &mut Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Failed to parse {:?}: {:?}", sql, e));
+    match stmt {
+        vibesql_ast::Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).unwrap();
+        }
+        vibesql_ast::Statement::CreateTrigger(s) => {
+            crate::advanced_objects::execute_create_trigger(&s, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).unwrap();
+        }
+        vibesql_ast::Statement::Update(s) => {
+            UpdateExecutor::execute(&s, db).unwrap();
+        }
+        vibesql_ast::Statement::Delete(s) => {
+            DeleteExecutor::execute(&s, db).unwrap();
+        }
+        other => panic!("Unsupported statement in test helper: {:?}", other),
+    }
+}
+
+/// Read all rows of `SELECT id, v, rowid FROM audit ORDER BY id` as (id, v, rowid).
+fn audit_rows(db: &Database) -> Vec<(i64, i64, i64)> {
+    let stmt =
+        vibesql_parser::Parser::parse_sql("SELECT id, v, rowid FROM audit ORDER BY id;").unwrap();
+    let result = match stmt {
+        vibesql_ast::Statement::Select(s) => {
+            SelectExecutor::new(db).execute_with_columns(&s).unwrap()
+        }
+        _ => panic!("Expected Select"),
+    };
+    result
+        .rows
+        .iter()
+        .map(|r| {
+            let as_i64 = |v: &vibesql_types::SqlValue| match v {
+                vibesql_types::SqlValue::Integer(i) => *i,
+                vibesql_types::SqlValue::Bigint(i) => *i,
+                other => panic!("expected integer, got {:?}", other),
+            };
+            (as_i64(&r.values[0]), as_i64(&r.values[1]), as_i64(&r.values[2]))
+        })
+        .collect()
+}
+
+/// Regression for #5397: a parsed trigger body inserting NEW.col into an
+/// INTEGER PRIMARY KEY column must resolve the pseudo-variable. Previously the
+/// IPK value-evaluation path used a bare evaluator without trigger context and
+/// failed with "Pseudo-variable NEW.id is only valid within trigger bodies".
+///
+/// Verified against sqlite3 3.51.0: NEW.id lands as both the audit.id value and
+/// the audit rowid.
+#[test]
+fn test_new_into_ipk_column_in_insert_trigger() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER);");
+    exec(&mut db, "CREATE TABLE audit (id INTEGER PRIMARY KEY, v INTEGER);");
+    exec(
+        &mut db,
+        "CREATE TRIGGER trg AFTER INSERT ON t \
+         BEGIN INSERT INTO audit (id, v) VALUES (NEW.id, NEW.v); END;",
+    );
+
+    exec(&mut db, "INSERT INTO t VALUES (1, 42);");
+    exec(&mut db, "INSERT INTO t VALUES (7, 99);");
+
+    // NEW.id is the IPK value AND the rowid (matches sqlite3 3.51.0).
+    assert_eq!(audit_rows(&db), vec![(1, 42, 1), (7, 99, 7)]);
+}
+
+/// Regression for #5397: OLD.col into an INTEGER PRIMARY KEY column from a
+/// DELETE trigger body. Verified against sqlite3 3.51.0.
+#[test]
+fn test_old_into_ipk_column_in_delete_trigger() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER);");
+    exec(&mut db, "CREATE TABLE audit (id INTEGER PRIMARY KEY, v INTEGER);");
+    exec(
+        &mut db,
+        "CREATE TRIGGER trg_del AFTER DELETE ON t \
+         BEGIN INSERT INTO audit (id, v) VALUES (OLD.id, OLD.v); END;",
+    );
+
+    exec(&mut db, "INSERT INTO t VALUES (5, 500);");
+    exec(&mut db, "INSERT INTO t VALUES (8, 800);");
+    exec(&mut db, "DELETE FROM t WHERE id = 5;");
+
+    // OLD.id is the IPK value AND the rowid (matches sqlite3 3.51.0).
+    assert_eq!(audit_rows(&db), vec![(5, 500, 5)]);
+}
+
+/// Regression for #5397: OLD.col / NEW.col into an INTEGER PRIMARY KEY column
+/// from an UPDATE trigger body. Verified against sqlite3 3.51.0.
+#[test]
+fn test_old_and_new_into_ipk_column_in_update_trigger() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER);");
+    // audit.id is INTEGER PRIMARY KEY and receives NEW.v as its rowid.
+    exec(&mut db, "CREATE TABLE audit (id INTEGER PRIMARY KEY, v INTEGER);");
+    exec(
+        &mut db,
+        "CREATE TRIGGER trg_upd AFTER UPDATE ON t \
+         BEGIN INSERT INTO audit (id, v) VALUES (NEW.v, OLD.v); END;",
+    );
+
+    exec(&mut db, "INSERT INTO t VALUES (1, 100);");
+    exec(&mut db, "UPDATE t SET v = 200 WHERE id = 1;");
+
+    // NEW.v (200) becomes the audit IPK/rowid; OLD.v (100) is the value column.
+    assert_eq!(audit_rows(&db), vec![(200, 100, 200)]);
+}


### PR DESCRIPTION
## Summary

Fixes a pre-existing executor correctness bug: a parsed trigger body that inserts a pseudo-variable (`NEW.col` / `OLD.col`) into an **INTEGER PRIMARY KEY** column failed at fire time with `Pseudo-variable NEW.id is only valid within trigger bodies`.

This is a standalone executor fidelity bug (orthogonal to replication — it fails identically everywhere). Fixing it helps both standalone and replicated execution.

## Root cause

When inserting into an INTEGER PRIMARY KEY column, the column's value is treated as the rowid and routed through the rowid expression-evaluation path in `crates/vibesql-executor/src/insert/execution.rs`. The complex-expression (`_`) arm of that path built a bare `ExpressionEvaluator::with_database(...)` that carried **no trigger context**, so `Expression::PseudoVariable` (NEW/OLD) hit the "only valid within trigger bodies" arm in the evaluator.

The non-IPK column path (`evaluate_insert_expression_with_trigger_context` in `insert/defaults.rs`) already threads trigger context and resolves pseudo-variables correctly — the IPK path simply diverged from it.

## The fix

In the rowid complex-expression arm, build the evaluator with the trigger context (`with_trigger_context`) when one is present, falling back to the procedural context, then to plain database context — mirroring the non-IPK path. Pseudo-variables now resolve and the value lands as the actual rowid.

`crates/vibesql-executor/src/insert/execution.rs` (~line 547).

## Test evidence

New regression tests in `crates/vibesql-executor/src/tests/triggers/pseudo_vars.rs`, all verified against sqlite3 3.51.0:

- `test_new_into_ipk_column_in_insert_trigger` — `NEW.id`/`NEW.v` into IPK; value lands as rowid (`audit` rows `(1,42,1)`, `(7,99,7)`).
- `test_old_into_ipk_column_in_delete_trigger` — `OLD.id` into IPK from a DELETE trigger (`(5,500,5)`).
- `test_old_and_new_into_ipk_column_in_update_trigger` — `NEW.v`/`OLD.v` into IPK from an UPDATE trigger; NEW value becomes the rowid (`(200,100,200)`).

sqlite3 3.51.0 reference output confirmed: `NEW.id`/`OLD.id` inserted into an IPK column become both the value and the rowid.

## Regression results

- `cargo test -p vibesql-executor --lib`: **2653 passed, 0 failed** (includes all existing trigger, insert, and IPK/rowid tests).
- `cargo test -p vibesql-executor` (full, incl. integration binaries): all green.
- Trigger TCL files (`trigger1/2/3.test`) run clean (no new failures/panics).

Scope kept tight to `insert/execution.rs` + the trigger test file so queued trigger work (#5399) won't conflict heavily.

Closes #5397

🤖 Generated with [Claude Code](https://claude.com/claude-code)