### PR TITLE
feat(server): replicated operational surface — prepared-stmt writes, /health role, HTTP gating

### DIFF
--- a/crates/vibesql-server/src/http/crud.rs
+++ b/crates/vibesql-server/src/http/crud.rs
@@ -395,6 +395,12 @@ pub async fn list_rows(
 ) -> impl IntoResponse {
     debug!("CRUD: GET /api/tables/{}/rows with params: {:?}", table_name, params);
 
+    // The CRUD surface executes against the local registry database, which
+    // receives no replicated writes — gate it in replicated mode (#5393).
+    if let Some((code, body)) = state.replicated_gate("the CRUD API") {
+        return (code, body).into_response();
+    }
+
     // Get the database name from headers
     let db_name = get_database_name(&headers);
 
@@ -452,6 +458,10 @@ pub async fn get_row(
     Query(params): Query<CrudQueryParams>,
 ) -> impl IntoResponse {
     debug!("CRUD: GET /api/tables/{}/rows/{}", table_name, id);
+
+    if let Some((code, body)) = state.replicated_gate("the CRUD API") {
+        return (code, body).into_response();
+    }
 
     // Get the database name from headers
     let db_name = get_database_name(&headers);
@@ -521,6 +531,10 @@ pub async fn create_row(
 ) -> impl IntoResponse {
     debug!("CRUD: POST /api/tables/{}/rows with body: {:?}", table_name, body);
 
+    if let Some((code, gate_body)) = state.replicated_gate("the CRUD API") {
+        return (code, gate_body).into_response();
+    }
+
     if body.values.is_empty() {
         return (
             StatusCode::BAD_REQUEST,
@@ -580,6 +594,10 @@ pub async fn update_row(
     Json(body): Json<UpdateRequest>,
 ) -> impl IntoResponse {
     debug!("CRUD: PUT /api/tables/{}/rows/{} with body: {:?}", table_name, id, body);
+
+    if let Some((code, gate_body)) = state.replicated_gate("the CRUD API") {
+        return (code, gate_body).into_response();
+    }
 
     if body.values.is_empty() {
         return (
@@ -651,6 +669,10 @@ pub async fn patch_row(
 ) -> impl IntoResponse {
     debug!("CRUD: PATCH /api/tables/{}/rows/{} with body: {:?}", table_name, id, body);
 
+    if let Some((code, gate_body)) = state.replicated_gate("the CRUD API") {
+        return (code, gate_body).into_response();
+    }
+
     if body.values.is_empty() {
         return (
             StatusCode::BAD_REQUEST,
@@ -719,6 +741,10 @@ pub async fn delete_row(
     Path((table_name, id)): Path<(String, String)>,
 ) -> impl IntoResponse {
     debug!("CRUD: DELETE /api/tables/{}/rows/{}", table_name, id);
+
+    if let Some((code, body)) = state.replicated_gate("the CRUD API") {
+        return (code, body).into_response();
+    }
 
     // Get the database name from headers
     let db_name = get_database_name(&headers);

--- a/crates/vibesql-server/src/http/rest.rs
+++ b/crates/vibesql-server/src/http/rest.rs
@@ -1,6 +1,6 @@
 //! REST API endpoints for VibeSQL HTTP interface
 
-use std::sync::Arc;
+use std::sync::{Arc, Arc as StdArc};
 
 use axum::{
     extract::{Path, Query, State},
@@ -19,6 +19,7 @@ use super::{graphql, types::*};
 use crate::{
     observability::ServerMetrics,
     registry::DatabaseRegistry,
+    replication::{role_str, ReplicationHandle},
     subscription::{
         detect_pk_columns_from_stmt, SelectiveColumnConfig, SubscriptionManager, SubscriptionUpdate,
     },
@@ -64,6 +65,43 @@ pub struct HttpState {
     pub subscription_manager: Arc<SubscriptionManager>,
     /// Optional server metrics for observability
     pub metrics: Option<ServerMetrics>,
+    /// Consensus handle when the server runs in replicated mode (#5393).
+    ///
+    /// Present only in replicated mode. The HTTP REST/GraphQL/subscription
+    /// surface executes against the local registry database, which does NOT
+    /// receive replicated writes — so in replicated mode those paths are
+    /// gated (see [`replicated_gate`]) to refuse with a clear error rather
+    /// than silently read stale data or accept a write that never
+    /// replicates. `/health` uses it to report node role/writability. Full
+    /// routing of HTTP writes/subscriptions through consensus is follow-on
+    /// #5410.
+    pub replication: Option<StdArc<ReplicationHandle>>,
+}
+
+impl HttpState {
+    /// `Some(error_response)` when this request hits a surface that is not
+    /// yet coherent in replicated mode and must be refused; `None` in
+    /// standalone mode (where every path is sound). Returning a `503` with
+    /// a `Retry-After`-style hint matches how a non-leader PostgreSQL
+    /// session refuses writes — the caller should route to the dedicated
+    /// PostgreSQL wire port, which is fully replicated.
+    pub(crate) fn replicated_gate(
+        &self,
+        feature: &str,
+    ) -> Option<(StatusCode, Json<ErrorResponse>)> {
+        self.replication.as_ref().map(|_| {
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ErrorResponse::with_code(
+                    format!(
+                        "{feature} is not available over the HTTP API in replicated mode; use the \
+                         PostgreSQL wire protocol port (writes route through consensus there)"
+                    ),
+                    "58000",
+                )),
+            )
+        })
+    }
 }
 
 /// Create the HTTP API router
@@ -78,13 +116,16 @@ pub fn create_http_router(
     registry: DatabaseRegistry,
     subscription_manager: Arc<SubscriptionManager>,
     metrics: Option<ServerMetrics>,
+    replication: Option<StdArc<ReplicationHandle>>,
 ) -> Router {
     let state = HttpState {
         registry: registry.clone(),
         db: db.clone(),
         subscription_manager: subscription_manager.clone(),
         metrics,
+        replication,
     };
+    let is_replicated = state.replication.is_some();
 
     // Create main router with state
     let main_router = Router::new()
@@ -106,11 +147,25 @@ pub fn create_http_router(
         .route("/stats/subscriptions/efficiency", get(get_efficiency_stats))
         .with_state(state);
 
-    // Create storage sub-router with its own state
-    // We nest it after the main router is state-resolved
-    let storage_router = super::storage::create_storage_router(db, registry);
-
-    main_router.nest("/api/storage", storage_router)
+    // Create storage sub-router with its own state. The blob storage API
+    // also writes to the local registry database, so in replicated mode it
+    // is gated to a uniform 503 rather than nested (#5393).
+    if is_replicated {
+        let gated = Router::new().fallback(|| async {
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ErrorResponse::with_code(
+                    "the blob storage API is not available over HTTP in replicated mode; use the \
+                     PostgreSQL wire protocol port",
+                    "58000",
+                )),
+            )
+        });
+        main_router.nest("/api/storage", gated)
+    } else {
+        let storage_router = super::storage::create_storage_router(db, registry);
+        main_router.nest("/api/storage", storage_router)
+    }
 }
 
 /// Extract database name from request headers, falling back to default
@@ -129,6 +184,13 @@ async fn graphql_handler(
     Json(req): Json<graphql::GraphQLRequest>,
 ) -> impl IntoResponse {
     debug!("Received GraphQL request: {}", req.query);
+
+    // The GraphQL surface executes against the local registry database,
+    // which receives no replicated writes — gate it in replicated mode
+    // (#5393).
+    if let Some((code, body)) = state.replicated_gate("the GraphQL API") {
+        return (code, body).into_response();
+    }
 
     // Get the database name from headers
     let db_name = get_database_name(&headers);
@@ -425,12 +487,47 @@ async fn execute_nested_query(
     Ok(())
 }
 
-/// Health check endpoint
-async fn health_check() -> impl IntoResponse {
-    Json(HealthResponse {
-        status: "ok".to_string(),
-        version: env!("CARGO_PKG_VERSION").to_string(),
-    })
+/// Health check endpoint.
+///
+/// Standalone mode: always `200 {"status":"ok"}`. Replicated mode (#5393):
+/// reports the node's consensus role, writability, applied index, and any
+/// fatal-halt reason, and returns `503` (with the same JSON body) whenever
+/// the node cannot currently serve writes — so a load balancer routes
+/// writes to the leader and routes around halted/lagging nodes even with a
+/// status-code-only health check.
+async fn health_check(State(state): State<HttpState>) -> impl IntoResponse {
+    let version = env!("CARGO_PKG_VERSION").to_string();
+
+    match &state.replication {
+        None => (
+            StatusCode::OK,
+            Json(HealthResponse { status: "ok".to_string(), version, replication: None }),
+        ),
+        Some(handle) => {
+            let snap = handle.health_snapshot();
+            let status = if snap.can_serve_writes { "ok" } else { "unavailable" };
+            let code = if snap.can_serve_writes {
+                StatusCode::OK
+            } else {
+                StatusCode::SERVICE_UNAVAILABLE
+            };
+            (
+                code,
+                Json(HealthResponse {
+                    status: status.to_string(),
+                    version,
+                    replication: Some(ReplicationStatus {
+                        node_id: snap.node_id,
+                        role: role_str(snap.role).to_string(),
+                        can_serve_writes: snap.can_serve_writes,
+                        applied_index: snap.applied_index,
+                        leader_id: snap.leader_id,
+                        fatal_reason: snap.fatal_reason,
+                    }),
+                }),
+            )
+        }
+    }
 }
 
 /// Get subscription partial update efficiency statistics
@@ -451,6 +548,14 @@ async fn execute_query(
     Json(req): Json<QueryRequest>,
 ) -> impl IntoResponse {
     debug!("Executing query: {} (limit: {:?}, offset: {:?})", req.sql, req.limit, req.offset);
+
+    // The /api/query surface executes against the local registry database,
+    // which receives no replicated writes — a write would never replicate
+    // and a read would silently return stale/empty data. Gate it in
+    // replicated mode and point clients at the wire protocol (#5393).
+    if let Some((code, body)) = state.replicated_gate("the /api/query endpoint") {
+        return (code, body).into_response();
+    }
 
     // Convert JSON parameters to SqlValue
     let params = match req.to_sql_values() {
@@ -663,6 +768,14 @@ async fn subscribe_stream(
     use axum::response::sse::{Event, KeepAlive, Sse};
 
     debug!("SSE subscription requested for query: {}", params.query);
+
+    // Subscriptions are fed by change events from the local registry
+    // database, which receives no replicated writes — gate them in
+    // replicated mode (feeding subscriptions from applied consensus entries
+    // is follow-on #5410).
+    if let Some((code, body)) = state.replicated_gate("subscriptions") {
+        return (code, body).into_response();
+    }
 
     // Get the database name from headers
     let db_name = get_database_name(&headers);

--- a/crates/vibesql-server/src/http/types.rs
+++ b/crates/vibesql-server/src/http/types.rs
@@ -96,11 +96,46 @@ impl ErrorResponse {
     }
 }
 
-/// Health check response
+/// Health check response.
+///
+/// In standalone mode `replication` is omitted and `status` is always
+/// `"ok"`. In replicated mode the endpoint reports the node's consensus
+/// role and writability so load balancers / orchestration can route writes
+/// to the leader and route around halted or lagging nodes (#5393). The
+/// handler also returns HTTP 503 (instead of 200) whenever the node is not
+/// currently able to serve writes, so a plain TCP/HTTP health check (no
+/// body parsing) already avoids non-leader and halted nodes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HealthResponse {
+    /// `"ok"` when this node can serve writes; `"unavailable"` otherwise.
     pub status: String,
     pub version: String,
+    /// Replicated-mode consensus status; absent in standalone mode.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replication: Option<ReplicationStatus>,
+}
+
+/// Consensus-node status surfaced by `/health` in replicated mode (#5393).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReplicationStatus {
+    /// This node's id within the cluster.
+    pub node_id: u64,
+    /// Consensus role: `"leader"`, `"follower"`, or `"candidate"`.
+    pub role: String,
+    /// Whether this node can currently accept writes (true only on a
+    /// healthy leader — false on followers/candidates and on a halted node).
+    pub can_serve_writes: bool,
+    /// Dense application index of the last entry applied locally — a
+    /// monotonic progress marker for observing replication lag against the
+    /// leader's `applied_index`.
+    pub applied_index: u64,
+    /// The node this one currently believes leads the cluster, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub leader_id: Option<u64>,
+    /// Set when this node has halted on a fatal apply and must be
+    /// restarted to resync; carries the retained reason.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fatal_reason: Option<String>,
 }
 
 /// Convert SqlValue to JSON

--- a/crates/vibesql-server/src/main.rs
+++ b/crates/vibesql-server/src/main.rs
@@ -161,12 +161,14 @@ async fn main() -> Result<()> {
         let registry_for_http = database_registry.clone();
 
         let metrics_for_http = observability.metrics().cloned();
+        let replication_for_http = replication.clone();
         tokio::spawn(async move {
             let app = create_http_router(
                 db_for_http,
                 registry_for_http,
                 subscription_manager_for_http,
                 metrics_for_http,
+                replication_for_http,
             );
             let listener = tokio::net::TcpListener::bind(&http_addr)
                 .await

--- a/crates/vibesql-server/src/replication.rs
+++ b/crates/vibesql-server/src/replication.rs
@@ -11,41 +11,36 @@
 //! Consensus refusals surface as PostgreSQL errors with deliberately
 //! chosen SQLSTATEs (see [`SqlError`]):
 //!
-//! - [`ConsensusError::NotLeader`] → **`25006`** (`read_only_sql_transaction`).
-//!   This is exactly what real PostgreSQL returns when a write reaches a
-//!   hot-standby replica ("cannot execute INSERT in a read-only
-//!   transaction"), so PG-aware clients and poolers that already handle
-//!   primary/replica routing (libpq `target_session_attrs=read-write`,
-//!   JDBC `targetServerType=primary`, pgpool) treat it as "wrong node,
-//!   find the primary". The error's DETAIL carries the leader hint (node
-//!   id + consensus address from this node's `cluster.toml` view) so a
-//!   client can redirect without re-probing the whole cluster.
-//! - [`ConsensusError::StalenessExceeded`] / [`ConsensusError::ReadTimeout`]
-//!   → **`57P03`** (`cannot_connect_now`): the node cannot serve this
-//!   read *right now* — the same retryable class PostgreSQL uses while a
-//!   standby is catching up ("the database system is starting up").
-//!   DETAIL carries the observed staleness / applied-vs-required indices
-//!   and the leader hint.
-//! - [`ConsensusError::FatalApply`] → **`58000`** (`system_error`): this
-//!   node halted on a fatal apply and must be restarted to resync; every
-//!   statement on the halted node fails with the retained reason rather
-//!   than silently serving stale reads. (Failing health checks / refusing
-//!   new sessions is follow-on #5393.)
-//! - Anything else → **`XX000`** (`internal_error`), matching the
-//!   server's existing catch-all.
+//! - [`ConsensusError::NotLeader`] → **`25006`** (`read_only_sql_transaction`). This is exactly
+//!   what real PostgreSQL returns when a write reaches a hot-standby replica ("cannot execute
+//!   INSERT in a read-only transaction"), so PG-aware clients and poolers that already handle
+//!   primary/replica routing (libpq `target_session_attrs=read-write`, JDBC
+//!   `targetServerType=primary`, pgpool) treat it as "wrong node, find the primary". The error's
+//!   DETAIL carries the leader hint (node id + consensus address from this node's `cluster.toml`
+//!   view) so a client can redirect without re-probing the whole cluster.
+//! - [`ConsensusError::StalenessExceeded`] / [`ConsensusError::ReadTimeout`] → **`57P03`**
+//!   (`cannot_connect_now`): the node cannot serve this read *right now* — the same retryable class
+//!   PostgreSQL uses while a standby is catching up ("the database system is starting up"). DETAIL
+//!   carries the observed staleness / applied-vs-required indices and the leader hint.
+//! - [`ConsensusError::FatalApply`] → **`58000`** (`system_error`): this node halted on a fatal
+//!   apply and must be restarted to resync; every statement on the halted node fails with the
+//!   retained reason rather than silently serving stale reads. The node also reports
+//!   `can_serve_writes = false` from [`ReplicationHandle::health_snapshot`] so the `/health`
+//!   endpoint returns 503 and load balancers route around it (#5393).
+//! - Anything else → **`XX000`** (`internal_error`), matching the server's existing catch-all.
 //!
 //! Features a replicated session does not support yet return **`0A000`**
 //! (`feature_not_supported`) with a pointer to the follow-on issue:
-//! interactive transactions (#5391), `PREPARE`/`EXECUTE`-syntax writes,
-//! cursors, `EXPLAIN`, `ANALYZE`, `VACUUM` (#5393).
+//! cursors, `EXPLAIN`, `ANALYZE`, `VACUUM` (#5393). `PREPARE`/`EXECUTE`
+//! statement syntax is supported (the EXECUTE substitutes its literals into
+//! the prepared SQL text and routes through the consensus propose path).
 //!
 //! [`ConsensusError::NotLeader`]: vibesql_consensus::ConsensusError::NotLeader
 //! [`ConsensusError::StalenessExceeded`]: vibesql_consensus::ConsensusError::StalenessExceeded
 //! [`ConsensusError::ReadTimeout`]: vibesql_consensus::ConsensusError::ReadTimeout
 //! [`ConsensusError::FatalApply`]: vibesql_consensus::ConsensusError::FatalApply
 
-use std::sync::Arc;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use anyhow::Result;
 use vibesql_consensus::{
@@ -107,6 +102,33 @@ impl SqlError {
             detail: None,
             hint: Some(format!("tracked in {follow_on}")),
         }
+    }
+}
+
+/// A point-in-time view of a node's consensus health, produced by
+/// [`ReplicationHandle::health_snapshot`] for the `/health` endpoint.
+#[derive(Debug, Clone)]
+pub struct HealthSnapshot {
+    /// This node's id within the cluster.
+    pub node_id: u64,
+    /// This node's current consensus role.
+    pub role: Role,
+    /// Whether this node can currently accept writes (a healthy leader).
+    pub can_serve_writes: bool,
+    /// Dense application index of the last locally applied entry.
+    pub applied_index: LogIndex,
+    /// The node this one currently believes leads the cluster, if known.
+    pub leader_id: Option<u64>,
+    /// The fatal-apply reason if this node has halted, else `None`.
+    pub fatal_reason: Option<String>,
+}
+
+/// Lower-case string name of a consensus [`Role`], for JSON/observability.
+pub fn role_str(role: Role) -> &'static str {
+    match role {
+        Role::Leader => "leader",
+        Role::Follower => "follower",
+        Role::Candidate => "candidate",
     }
 }
 
@@ -185,6 +207,25 @@ impl ReplicationHandle {
     /// The reason this node halted on a fatal apply, if it did.
     pub fn fatal_reason(&self) -> Option<String> {
         self.node.fatal_reason()
+    }
+
+    /// A point-in-time snapshot of this node's consensus health, for the
+    /// `/health` endpoint (#5393). `can_serve_writes` is true only on a
+    /// healthy leader (a halted leader cannot serve writes); load balancers
+    /// route writes to a node reporting `can_serve_writes = true`, and route
+    /// around any node that has a `fatal_reason`.
+    pub fn health_snapshot(&self) -> HealthSnapshot {
+        let fatal_reason = self.node.fatal_reason();
+        let role = self.node.role();
+        HealthSnapshot {
+            node_id: self.node_id,
+            role,
+            // A halted node serves nothing further, even if it was leader.
+            can_serve_writes: role == Role::Leader && fatal_reason.is_none(),
+            applied_index: self.node.last_applied(),
+            leader_id: self.node.current_leader(),
+            fatal_reason,
+        }
     }
 
     /// Execute one autocommit write statement through consensus,

--- a/crates/vibesql-server/src/session.rs
+++ b/crates/vibesql-server/src/session.rs
@@ -56,13 +56,11 @@ struct ReplicatedSessionState {
     /// `COMMIT` — the one-entry-per-committed-transaction design.
     ///
     /// During the open transaction the buffer is *not yet* proposed, so:
-    /// - write statements return an optimistic ack (`rows_affected = 0`);
-    ///   the authoritative row counts are knowable only after the atomic
-    ///   apply at `COMMIT`;
-    /// - reads are refused once the buffer is non-empty, because the
-    ///   buffered writes are not applied anywhere yet and a local read
-    ///   would silently miss the session's own writes (full mid-txn read
-    ///   fidelity is the scoped follow-on #5401).
+    /// - write statements return an optimistic ack (`rows_affected = 0`); the authoritative row
+    ///   counts are knowable only after the atomic apply at `COMMIT`;
+    /// - reads are refused once the buffer is non-empty, because the buffered writes are not
+    ///   applied anywhere yet and a local read would silently miss the session's own writes (full
+    ///   mid-txn read fidelity is the scoped follow-on #5401).
     open_txn: Option<Vec<String>>,
 }
 
@@ -513,23 +511,24 @@ impl Session {
             // Transaction control (BEGIN/COMMIT/ROLLBACK/SAVEPOINT) is
             // intercepted above, before this autocommit dispatch.
 
-            // Named prepared statements execute from a bound AST without
-            // the SQL text the propose path replicates; cursors, EXPLAIN,
-            // ANALYZE, and VACUUM would all run against the local (empty)
-            // database. Refuse clearly rather than mislead (#5393).
-            Statement::Prepare(_) | Statement::Execute(_) | Statement::Deallocate(_) => {
-                Err(SqlError::not_supported(
-                    "PREPARE/EXECUTE statement syntax",
-                    "#5393",
-                )
-                .into())
-            }
+            // Named prepared-statement syntax (#5393): PREPARE captures the
+            // SQL *text* (not a bound AST), EXECUTE substitutes its literal
+            // parameters back into that text and re-routes through this same
+            // replicated dispatch — so a PREPARE'd INSERT proposes through
+            // consensus with freeze-at-propose exactly like the simple path,
+            // and a PREPARE'd SELECT honors the session read-consistency mode.
+            // DEALLOCATE drops the named statement. None of these execute
+            // against the local (empty) database.
+            Statement::Prepare(stmt) => self.replicated_prepare(stmt),
+            Statement::Execute(stmt) => self.replicated_execute(stmt).await,
+            Statement::Deallocate(stmt) => self.execute_deallocate(stmt),
+
+            // Cursors, EXPLAIN, ANALYZE, and VACUUM would all run against the
+            // local (empty) database. Refuse clearly rather than mislead.
             Statement::DeclareCursor(_)
             | Statement::OpenCursor(_)
             | Statement::Fetch(_)
-            | Statement::CloseCursor(_) => {
-                Err(SqlError::not_supported("cursors", "#5393").into())
-            }
+            | Statement::CloseCursor(_) => Err(SqlError::not_supported("cursors", "#5393").into()),
             Statement::Explain(_) => Err(SqlError::not_supported("EXPLAIN", "#5393").into()),
             Statement::Analyze(_) => Err(SqlError::not_supported("ANALYZE", "#5393").into()),
             Statement::Vacuum(_) => Err(SqlError::not_supported("VACUUM", "#5393").into()),
@@ -580,11 +579,10 @@ impl Session {
     /// leader, at COMMIT) and map the outcome:
     ///
     /// - `Applied` → the transaction committed atomically (`COMMIT`);
-    /// - `Rejected` → a deterministic statement failure rolled the whole
-    ///   batch back identically on every replica; the buffer is discarded
-    ///   and the executor error surfaced (no partial state);
-    /// - `NotLeader` / `FatalApply` → surfaced as the usual SQLSTATE; the
-    ///   buffer is discarded so a retry against the leader starts clean.
+    /// - `Rejected` → a deterministic statement failure rolled the whole batch back identically on
+    ///   every replica; the buffer is discarded and the executor error surfaced (no partial state);
+    /// - `NotLeader` / `FatalApply` → surfaced as the usual SQLSTATE; the buffer is discarded so a
+    ///   retry against the leader starts clean.
     ///
     /// An empty transaction (`BEGIN; COMMIT;` with no writes) consumes no
     /// log index — there is nothing to replicate.
@@ -626,6 +624,61 @@ impl Session {
         }
     }
 
+    /// PREPARE in a replicated session (#5393): store the statement's SQL
+    /// *text* under its name. EXECUTE substitutes literal parameters back
+    /// into that text and routes it through the normal replicated dispatch,
+    /// so a PREPARE'd write proposes through consensus (freeze-at-propose)
+    /// exactly like the simple-query path. Shares the `named_statements`
+    /// registry with standalone mode; only the EXECUTE path differs.
+    fn replicated_prepare(
+        &mut self,
+        prepare_stmt: &vibesql_ast::PrepareStmt,
+    ) -> Result<ExecutionResult> {
+        // Reuse the standalone PREPARE machinery: it parses + caches the
+        // SQL and retains the original text (PreparedStatement::sql()),
+        // which is exactly what the consensus propose path needs.
+        self.execute_prepare(prepare_stmt)
+    }
+
+    /// EXECUTE in a replicated session (#5393): bind the statement's literal
+    /// parameters into the prepared SQL *text* and re-route the result
+    /// through `execute` (→ `execute_replicated`). Writes therefore propose
+    /// through consensus and reads honor the session read-consistency mode,
+    /// identically to issuing the substituted SQL directly.
+    async fn replicated_execute(
+        &mut self,
+        execute_stmt: &vibesql_ast::ExecuteStmt,
+    ) -> Result<ExecutionResult> {
+        let name = execute_stmt.name.clone();
+        let prepared = self
+            .named_statements
+            .get(&name)
+            .ok_or_else(|| anyhow::anyhow!("Prepared statement '{}' not found", name))?
+            .clone();
+
+        // Evaluate the EXECUTE arguments to literal values, then render them
+        // back into the prepared statement's SQL text by replacing the `?`
+        // / `$N` placeholders in order — the same text-substitution contract
+        // the extended wire protocol's Bind path already uses to route
+        // parameterized writes through consensus.
+        let params: Vec<SqlValue> =
+            execute_stmt.params.iter().map(evaluate_expression).collect::<Result<Vec<_>>>()?;
+
+        if params.len() != prepared.param_count() {
+            return Err(anyhow::anyhow!(
+                "EXECUTE for '{}' expected {} parameter(s), got {}",
+                name,
+                prepared.param_count(),
+                params.len()
+            ));
+        }
+
+        let sql = substitute_named_params(prepared.sql(), &params);
+        // Box the recursive dispatch: `execute` → `execute_replicated` →
+        // here → `execute` would otherwise be an infinitely sized future.
+        Box::pin(self.execute(&sql)).await
+    }
+
     /// Roll back an open replicated transaction (#5391): discard the
     /// buffered writes without proposing anything — the batch never
     /// reached consensus, so no log index is consumed.
@@ -643,16 +696,13 @@ impl Session {
     /// `0A000` refusal.
     ///
     /// Mid-transaction result semantics (documented contract):
-    /// - **Writes** return their command tag with `rows_affected = 0`.
-    ///   The buffer is not proposed until `COMMIT`, so the authoritative
-    ///   row count is not yet known; clients learn the outcome (success
-    ///   or a deterministic rejection) at `COMMIT`.
-    /// - **Reads** are refused with `0A000` once the buffer holds any
-    ///   writes: those writes are applied nowhere yet, so a local read
-    ///   would silently miss the session's own writes. A read before any
-    ///   buffered write (it observes committed state coherently) is
-    ///   allowed. Full read-your-own-writes inside the transaction is the
-    ///   scoped follow-on #5401.
+    /// - **Writes** return their command tag with `rows_affected = 0`. The buffer is not proposed
+    ///   until `COMMIT`, so the authoritative row count is not yet known; clients learn the outcome
+    ///   (success or a deterministic rejection) at `COMMIT`.
+    /// - **Reads** are refused with `0A000` once the buffer holds any writes: those writes are
+    ///   applied nowhere yet, so a local read would silently miss the session's own writes. A read
+    ///   before any buffered write (it observes committed state coherently) is allowed. Full
+    ///   read-your-own-writes inside the transaction is the scoped follow-on #5401.
     fn execute_in_open_txn(
         &mut self,
         sql: &str,
@@ -697,9 +747,7 @@ impl Session {
                     let rows = handle.query_local(sql)?;
                     let columns = rows
                         .first()
-                        .map(|r| {
-                            (0..r.len()).map(|i| Column { name: format!("col{i}") }).collect()
-                        })
+                        .map(|r| (0..r.len()).map(|i| Column { name: format!("col{i}") }).collect())
                         .unwrap_or_default();
                     let rows = rows.into_iter().map(|values| Row { values }).collect();
                     Ok(ExecutionResult::Select { rows, columns })
@@ -755,18 +803,25 @@ impl Session {
             // PRAGMA stays the no-op it is in standalone mode.
             Statement::Pragma(_) => Ok(ExecutionResult::Other { message: "PRAGMA".to_string() }),
 
-            // Everything else (PREPARE/EXECUTE, cursors, EXPLAIN, ANALYZE,
-            // VACUUM, ...) keeps its autocommit refusal inside the
-            // transaction too.
-            Statement::Prepare(_) | Statement::Execute(_) | Statement::Deallocate(_) => {
-                Err(SqlError::not_supported("PREPARE/EXECUTE statement syntax", "#5393").into())
-            }
+            // PREPARE/DEALLOCATE are session-local and harmless inside a
+            // transaction. EXECUTE of a prepared *write* inside a
+            // transaction is refused: `execute_in_open_txn` is synchronous
+            // (it cannot re-enter the async replicated dispatch to buffer the
+            // substituted SQL), and silently dropping it would be unsound.
+            // Use the substituted SQL directly inside the transaction, or
+            // run the prepared statement outside one (full prepared-EXECUTE
+            // inside replicated transactions is the scoped follow-on #5401).
+            Statement::Prepare(stmt) => self.replicated_prepare(stmt),
+            Statement::Deallocate(stmt) => self.execute_deallocate(stmt),
+            Statement::Execute(_) => Err(SqlError::not_supported(
+                "EXECUTE of a prepared statement inside a replicated transaction",
+                "#5401",
+            )
+            .into()),
             Statement::DeclareCursor(_)
             | Statement::OpenCursor(_)
             | Statement::Fetch(_)
-            | Statement::CloseCursor(_) => {
-                Err(SqlError::not_supported("cursors", "#5393").into())
-            }
+            | Statement::CloseCursor(_) => Err(SqlError::not_supported("cursors", "#5393").into()),
             Statement::Explain(_) => Err(SqlError::not_supported("EXPLAIN", "#5393").into()),
             Statement::Analyze(_) => Err(SqlError::not_supported("ANALYZE", "#5393").into()),
             Statement::Vacuum(_) => Err(SqlError::not_supported("VACUUM", "#5393").into()),
@@ -1267,6 +1322,63 @@ fn set_value_ms(expr: &vibesql_ast::Expression, variable: &str) -> Result<u64> {
     })
 }
 
+/// Substitute a prepared statement's positional (`?`) and numbered (`$N`)
+/// placeholders with rendered SQL literals, for routing a replicated
+/// `EXECUTE` through the SQL-text propose path (#5393).
+///
+/// `?` placeholders are consumed left to right; `$N` placeholders refer to
+/// `params[N - 1]`. String/quote-bearing literals are rendered safely via
+/// [`vibesql_ast::ToSql`] (the same escaping the wire `Bind` path uses), so
+/// values containing quotes cannot break out of the statement. Placeholders
+/// inside string literals are not substituted.
+fn substitute_named_params(sql: &str, params: &[SqlValue]) -> String {
+    use vibesql_ast::pretty_print::ToSql;
+
+    let mut out = String::with_capacity(sql.len());
+    let mut chars = sql.chars().peekable();
+    let mut positional = 0usize;
+    // Track whether we are inside a single- or double-quoted string literal
+    // so placeholders in literal text are left untouched.
+    let mut in_single = false;
+    let mut in_double = false;
+
+    while let Some(c) = chars.next() {
+        match c {
+            '\'' if !in_double => {
+                in_single = !in_single;
+                out.push(c);
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+                out.push(c);
+            }
+            '?' if !in_single && !in_double => {
+                match params.get(positional) {
+                    Some(v) => out.push_str(&v.to_sql()),
+                    None => out.push('?'),
+                }
+                positional += 1;
+            }
+            '$' if !in_single && !in_double && chars.peek().is_some_and(char::is_ascii_digit) => {
+                let mut digits = String::new();
+                while chars.peek().is_some_and(char::is_ascii_digit) {
+                    digits.push(chars.next().unwrap());
+                }
+                let idx: usize = digits.parse().unwrap_or(0);
+                match idx.checked_sub(1).and_then(|i| params.get(i)) {
+                    Some(v) => out.push_str(&v.to_sql()),
+                    None => {
+                        out.push('$');
+                        out.push_str(&digits);
+                    }
+                }
+            }
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
 /// Evaluate an expression to a SqlValue (for EXECUTE parameters)
 fn evaluate_expression(expr: &vibesql_ast::Expression) -> Result<SqlValue> {
     use vibesql_ast::Expression;
@@ -1608,6 +1720,48 @@ mod tests {
             }
             other => panic!("Expected Explain result, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_substitute_named_params_positional_and_numbered() {
+        // Positional `?` consumed in order.
+        assert_eq!(
+            substitute_named_params(
+                "INSERT INTO t VALUES (?, ?)",
+                &[SqlValue::Integer(1), SqlValue::Varchar("Alice".into())]
+            ),
+            "INSERT INTO t VALUES (1, 'Alice')"
+        );
+        // Numbered `$N` indexes into params; reuse is allowed.
+        assert_eq!(
+            substitute_named_params(
+                "SELECT $1, $2, $1",
+                &[SqlValue::Integer(7), SqlValue::Integer(8)]
+            ),
+            "SELECT 7, 8, 7"
+        );
+    }
+
+    #[test]
+    fn test_substitute_named_params_escapes_quotes() {
+        // A value containing a single quote is escaped (no statement
+        // break-out): `O'Brien` -> `'O''Brien'`.
+        assert_eq!(
+            substitute_named_params(
+                "INSERT INTO t VALUES (?)",
+                &[SqlValue::Varchar("O'Brien".into())]
+            ),
+            "INSERT INTO t VALUES ('O''Brien')"
+        );
+    }
+
+    #[test]
+    fn test_substitute_named_params_ignores_placeholders_in_string_literals() {
+        // A `?` / `$1` already inside a quoted literal is left untouched.
+        assert_eq!(
+            substitute_named_params("SELECT '? and $1', ?", &[SqlValue::Integer(5)]),
+            "SELECT '? and $1', 5"
+        );
     }
 
     #[test]

--- a/crates/vibesql-server/tests/common/mod.rs
+++ b/crates/vibesql-server/tests/common/mod.rs
@@ -142,6 +142,7 @@ pub async fn start_test_server_with_config(mut config: Config) -> TestServer {
                 registry_for_http,
                 subscription_manager_for_http,
                 metrics_for_http,
+                None,
             );
             axum::serve(http_listener, app).await.expect("HTTP server error");
         });
@@ -344,6 +345,7 @@ pub async fn start_test_server_with_metrics(mut config: Config) -> TestServerWit
                 registry_for_http,
                 subscription_manager_for_http,
                 metrics_for_http,
+                None,
             );
             axum::serve(http_listener, app).await.expect("HTTP server error");
         });

--- a/crates/vibesql-server/tests/replication_tests.rs
+++ b/crates/vibesql-server/tests/replication_tests.rs
@@ -4,21 +4,22 @@
 //! SQLSTATE surface.
 //!
 //! Two layers are exercised:
-//! - **Session-level**: `Session::new_replicated` against real consensus
-//!   nodes (single-node and 3-node TCP clusters on ephemeral ports).
-//! - **Wire-level**: a full `ConnectionHandler` server in replicated
-//!   mode, driven by `tokio-postgres`, asserting the SQLSTATEs and
-//!   redirect fields real clients see.
+//! - **Session-level**: `Session::new_replicated` against real consensus nodes (single-node and
+//!   3-node TCP clusters on ephemeral ports).
+//! - **Wire-level**: a full `ConnectionHandler` server in replicated mode, driven by
+//!   `tokio-postgres`, asserting the SQLSTATEs and redirect fields real clients see.
 
-use std::net::TcpListener as StdTcpListener;
-use std::sync::{atomic::AtomicUsize, Arc};
-use std::time::Duration;
+use std::{
+    net::TcpListener as StdTcpListener,
+    sync::{atomic::AtomicUsize, Arc},
+    time::Duration,
+};
 
-use tokio::net::TcpListener as TokioTcpListener;
-use tokio::sync::{broadcast, oneshot};
-use tokio_postgres::error::SqlState;
-use tokio_postgres::NoTls;
-
+use tokio::{
+    net::TcpListener as TokioTcpListener,
+    sync::{broadcast, oneshot},
+};
+use tokio_postgres::{error::SqlState, NoTls};
 use vibesql_consensus::Role;
 use vibesql_server::{
     config::{Config, ReplicationConfig},
@@ -175,10 +176,11 @@ async fn replicated_session_rejects_unsupported_features() {
     let mut session = replicated_session(&handles[0]);
 
     // BEGIN/COMMIT/ROLLBACK are supported as of #5391 (see the dedicated
-    // interactive-transaction tests); they are no longer refused here.
+    // interactive-transaction tests); PREPARE/EXECUTE syntax is supported
+    // as of #5393 (see the dedicated prepared-statement tests). Neither is
+    // refused here any longer.
 
     for (sql, follow_on) in [
-        ("PREPARE p FROM 'SELECT 1'", "#5393"),
         ("DECLARE c CURSOR FOR SELECT 1", "#5393"),
         ("EXPLAIN SELECT 1", "#5393"),
         ("ANALYZE", "#5393"),
@@ -204,6 +206,130 @@ async fn replicated_session_rejects_unsupported_features() {
 
     // PRAGMA stays a no-op, as in standalone mode.
     session.execute("PRAGMA journal_mode = WAL").await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Session-level: PREPARE/EXECUTE statement syntax (#5393)
+// ---------------------------------------------------------------------------
+
+/// A PREPARE'd INSERT routes its EXECUTE through consensus (one log entry
+/// per EXECUTE), exactly like the simple-query write path: the rows land in
+/// the replicated state machine and the row count comes back from the apply.
+#[tokio::test]
+async fn replicated_prepared_insert_routes_through_consensus() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let mut session = replicated_session(&handles[0]);
+
+    session.execute("CREATE TABLE users (id INT, name VARCHAR(100))").await.unwrap();
+
+    // PREPARE captures the SQL text; EXECUTE substitutes the literals and
+    // proposes through consensus.
+    session.execute("PREPARE ins FROM 'INSERT INTO users VALUES (?, ?)'").await.unwrap();
+    let applied_before = handles[0].node().last_applied();
+
+    let r = session.execute("EXECUTE ins (1, 'Alice')").await.unwrap();
+    assert!(matches!(r, ExecutionResult::Insert { rows_affected: 1 }), "{r:?}");
+    let r = session.execute("EXECUTE ins USING 2, 'Bob'").await.unwrap();
+    assert!(matches!(r, ExecutionResult::Insert { rows_affected: 1 }), "{r:?}");
+
+    // Each EXECUTE was its own replicated entry.
+    assert_eq!(handles[0].node().last_applied(), applied_before + 2);
+
+    // Both rows are in the consensus state machine, with the quoted string
+    // preserved (no SQL injection / quote-escaping breakage).
+    let rows = handles[0].node().query("SELECT id, name FROM users ORDER BY id").unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[1][1].to_string(), "Bob");
+
+    // DEALLOCATE drops the named statement; a later EXECUTE errors.
+    session.execute("DEALLOCATE ins").await.unwrap();
+    assert!(session.execute("EXECUTE ins (3, 'Carol')").await.is_err());
+}
+
+/// A PREPARE'd SELECT honors the session's read-consistency mode and reads
+/// from the replicated state machine (not the empty local database).
+#[tokio::test]
+async fn replicated_prepared_select_reads_state_machine() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let mut session = replicated_session(&handles[0]);
+
+    session.execute("CREATE TABLE t (id INT)").await.unwrap();
+    session.execute("INSERT INTO t VALUES (1)").await.unwrap();
+    session.execute("INSERT INTO t VALUES (2)").await.unwrap();
+
+    session.execute("PREPARE sel FROM 'SELECT id FROM t WHERE id = ?'").await.unwrap();
+    session.execute("SET vibesql_read_consistency = 'linearizable'").await.unwrap();
+
+    let rows = select_rows(session.execute("EXECUTE sel (2)").await.unwrap());
+    assert_eq!(rows.len(), 1, "prepared SELECT must read the replicated data");
+    assert_eq!(rows[0].values[0].to_string(), "2");
+}
+
+/// A PREPARE'd write on a follower is refused with the same NOT_LEADER
+/// surface (SQLSTATE 25006 + redirect hint) as a simple-query write — the
+/// prepared path is not a bypass.
+#[tokio::test]
+async fn replicated_prepared_write_on_follower_redirects() {
+    let (handles, _dir) = boot_cluster(3).await;
+    let leader = wait_for_leader(&handles).await;
+
+    let mut leader_session = replicated_session(&handles[leader]);
+    leader_session.execute("CREATE TABLE t (id INT)").await.unwrap();
+
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    let follower = loop {
+        if let Some(i) = handles
+            .iter()
+            .position(|h| h.role() == Role::Follower && h.node().current_leader().is_some())
+        {
+            break i;
+        }
+        assert!(tokio::time::Instant::now() < deadline, "timed out waiting for a follower");
+        tokio::time::sleep(POLL_INTERVAL).await;
+    };
+
+    let mut follower_session = replicated_session(&handles[follower]);
+    // The follower may not have applied the leader's CREATE TABLE yet; the
+    // propose itself is refused before any local execution regardless.
+    follower_session.execute("PREPARE ins FROM 'INSERT INTO t VALUES (?)'").await.unwrap();
+    let err = follower_session.execute("EXECUTE ins (1)").await.unwrap_err();
+    assert_eq!(sql_error(&err).code, "25006", "prepared write must redirect like a simple write");
+}
+
+// ---------------------------------------------------------------------------
+// Session-level: health snapshot (#5393)
+// ---------------------------------------------------------------------------
+
+/// The leader reports writable; a follower reports not-writable with the
+/// leader's id; both expose a monotonic applied index.
+#[tokio::test]
+async fn health_snapshot_reports_role_and_writability() {
+    let (handles, _dir) = boot_cluster(3).await;
+    let leader = wait_for_leader(&handles).await;
+
+    let leader_snap = handles[leader].health_snapshot();
+    assert_eq!(leader_snap.role, Role::Leader);
+    assert!(leader_snap.can_serve_writes, "a healthy leader must be writable");
+    assert!(leader_snap.fatal_reason.is_none());
+
+    // Wait for a follower that knows the leader, then check its snapshot.
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    let follower = loop {
+        if let Some(i) = handles
+            .iter()
+            .position(|h| h.role() == Role::Follower && h.node().current_leader().is_some())
+        {
+            break i;
+        }
+        assert!(tokio::time::Instant::now() < deadline, "timed out waiting for a follower");
+        tokio::time::sleep(POLL_INTERVAL).await;
+    };
+    let follower_snap = handles[follower].health_snapshot();
+    assert_eq!(follower_snap.role, Role::Follower);
+    assert!(!follower_snap.can_serve_writes, "a follower must not be writable");
+    assert_eq!(follower_snap.leader_id, Some(handles[leader].node_id()));
 }
 
 // ---------------------------------------------------------------------------
@@ -373,9 +499,10 @@ async fn follower_rejects_writes_with_redirect_hint() {
     // hint is populated deterministically).
     let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
     let follower = loop {
-        if let Some(i) = handles.iter().position(|h| {
-            h.role() == Role::Follower && h.node().current_leader().is_some()
-        }) {
+        if let Some(i) = handles
+            .iter()
+            .position(|h| h.role() == Role::Follower && h.node().current_leader().is_some())
+        {
             break i;
         }
         assert!(tokio::time::Instant::now() < deadline, "timed out waiting for a follower");
@@ -523,8 +650,7 @@ struct TestServer {
 
 impl TestServer {
     async fn start(replication: Option<Arc<ReplicationHandle>>) -> Self {
-        let listener =
-            TokioTcpListener::bind("127.0.0.1:0").await.expect("bind test server port");
+        let listener = TokioTcpListener::bind("127.0.0.1:0").await.expect("bind test server port");
         let port = listener.local_addr().expect("server port").port();
         let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
 
@@ -672,9 +798,10 @@ async fn wire_protocol_follower_write_redirects() {
     // Wait for a follower that knows the leader.
     let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
     let follower = loop {
-        if let Some(i) = handles.iter().position(|h| {
-            h.role() == Role::Follower && h.node().current_leader().is_some()
-        }) {
+        if let Some(i) = handles
+            .iter()
+            .position(|h| h.role() == Role::Follower && h.node().current_leader().is_some())
+        {
             break i;
         }
         assert!(tokio::time::Instant::now() < deadline, "timed out waiting for a follower");
@@ -706,9 +833,193 @@ async fn wire_protocol_standalone_unaffected() {
     client.simple_query("COMMIT").await.unwrap();
 
     let messages = client.simple_query("SELECT * FROM standalone_test").await.unwrap();
-    let rows = messages
-        .iter()
-        .filter(|m| matches!(m, tokio_postgres::SimpleQueryMessage::Row(_)))
-        .count();
+    let rows =
+        messages.iter().filter(|m| matches!(m, tokio_postgres::SimpleQueryMessage::Row(_))).count();
     assert_eq!(rows, 1);
+}
+
+/// The PostgreSQL **extended** query protocol (Parse/Bind/Execute, used by
+/// `tokio_postgres::Client::execute`/`query`) routes a write through
+/// consensus in replicated mode: `handle_execute` runs the bound query via
+/// `Session::execute`, which dispatches through the replicated path exactly
+/// like the simple-query path. This guards the contract that the extended
+/// protocol is not a write bypass (#5393).
+///
+/// (Bound `$N` parameters are exercised by the simple-query and
+/// session-level PREPARE/EXECUTE tests; VibeSQL's extended-protocol
+/// Describe does not infer parameter OIDs, so this test drives the
+/// Parse/Bind/Execute path the same param-free way the other
+/// extended-protocol integration tests do.)
+#[tokio::test]
+async fn wire_protocol_extended_write_replicates() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let server = TestServer::start(Some(Arc::clone(&handles[0]))).await;
+    let client = connect(&server).await;
+
+    // `execute`/`query` drive Parse/Bind/Execute (not the simple-query
+    // protocol). The write must land in the consensus state machine.
+    client.execute("CREATE TABLE ext (id INT, name VARCHAR(100))", &[]).await.unwrap();
+    let affected = client.execute("INSERT INTO ext VALUES (1, 'Alice')", &[]).await.unwrap();
+    assert_eq!(affected, 1);
+    assert_eq!(handles[0].node().query("SELECT COUNT(*) FROM ext").unwrap()[0][0].to_string(), "1");
+
+    // A read over the extended protocol reads it back from the state machine.
+    let rows = client.query("SELECT name FROM ext WHERE id = 1", &[]).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    let name: &str = rows[0].get(0);
+    assert_eq!(name, "Alice");
+}
+
+/// An extended-protocol write on a follower is refused with SQLSTATE 25006,
+/// exactly like the simple-query path — the extended path is not a bypass.
+#[tokio::test]
+async fn wire_protocol_extended_write_on_follower_redirects() {
+    let (handles, _dir) = boot_cluster(3).await;
+    let leader = wait_for_leader(&handles).await;
+
+    let mut leader_session = replicated_session(&handles[leader]);
+    leader_session.execute("CREATE TABLE ext_redirect (id INT)").await.unwrap();
+
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    let follower = loop {
+        if let Some(i) = handles
+            .iter()
+            .position(|h| h.role() == Role::Follower && h.node().current_leader().is_some())
+        {
+            break i;
+        }
+        assert!(tokio::time::Instant::now() < deadline, "timed out waiting for a follower");
+        tokio::time::sleep(POLL_INTERVAL).await;
+    };
+
+    let server = TestServer::start(Some(Arc::clone(&handles[follower]))).await;
+    let client = connect(&server).await;
+
+    let err = client.execute("INSERT INTO ext_redirect VALUES (1)", &[]).await.unwrap_err();
+    assert_eq!(err.as_db_error().expect("db error").code(), &SqlState::READ_ONLY_SQL_TRANSACTION);
+}
+
+// ---------------------------------------------------------------------------
+// HTTP /health endpoint in replicated mode (#5393)
+// ---------------------------------------------------------------------------
+
+/// Bind the HTTP router (in replicated mode against `handle`) to an
+/// ephemeral port and return its base URL plus a shutdown sender.
+async fn start_http(handle: Option<Arc<ReplicationHandle>>) -> (String, oneshot::Sender<()>) {
+    use vibesql_server::{http::create_http_router, registry::DatabaseRegistry};
+    use vibesql_storage::Database;
+
+    let listener = TokioTcpListener::bind("127.0.0.1:0").await.expect("bind http");
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = oneshot::channel::<()>();
+
+    let db = Arc::new(Database::new());
+    let registry = DatabaseRegistry::new();
+    let subs = Arc::new(SubscriptionManager::new());
+    let app = create_http_router(db, registry, subs, None, handle);
+
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = rx.await;
+            })
+            .await
+            .ok();
+    });
+
+    (format!("http://{addr}"), tx)
+}
+
+/// `/health` on the leader is 200 `ok` with role `"leader"` and
+/// `can_serve_writes: true`; on a follower it is 503 `unavailable` with
+/// role `"follower"` and the leader's id — the load-balancer routing
+/// contract.
+#[tokio::test]
+async fn http_health_reports_leader_and_follower() {
+    let (handles, _dir) = boot_cluster(3).await;
+    let leader = wait_for_leader(&handles).await;
+
+    // Leader: 200 OK, writable.
+    let (base, _tx) = start_http(Some(Arc::clone(&handles[leader]))).await;
+    let resp = reqwest::get(format!("{base}/health")).await.unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+    assert_eq!(body["status"], "ok");
+    assert_eq!(body["replication"]["role"], "leader");
+    assert_eq!(body["replication"]["can_serve_writes"], true);
+
+    // Follower: 503, not writable, leader id present.
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    let follower = loop {
+        if let Some(i) = handles
+            .iter()
+            .position(|h| h.role() == Role::Follower && h.node().current_leader().is_some())
+        {
+            break i;
+        }
+        assert!(tokio::time::Instant::now() < deadline, "timed out waiting for a follower");
+        tokio::time::sleep(POLL_INTERVAL).await;
+    };
+    let (base, _tx2) = start_http(Some(Arc::clone(&handles[follower]))).await;
+    let resp = reqwest::get(format!("{base}/health")).await.unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+    let body: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+    assert_eq!(body["status"], "unavailable");
+    assert_eq!(body["replication"]["role"], "follower");
+    assert_eq!(body["replication"]["can_serve_writes"], false);
+    assert_eq!(body["replication"]["leader_id"], handles[leader].node_id());
+}
+
+/// In replicated mode the HTTP query/CRUD/subscription surface is gated to
+/// a clear 503 (it would otherwise execute against the unreplicated local
+/// database) — never silent wrong behavior.
+#[tokio::test]
+async fn http_query_surface_gated_in_replicated_mode() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let (base, _tx) = start_http(Some(Arc::clone(&handles[0]))).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base}/api/query"))
+        .header("content-type", "application/json")
+        .body(r#"{"sql":"SELECT 1"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+
+    // CRUD writes are gated too.
+    let resp = client
+        .post(format!("{base}/api/tables/t/rows"))
+        .header("content-type", "application/json")
+        .body(r#"{"id":1}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+}
+
+/// Standalone HTTP is unaffected: `/health` is 200 with no `replication`
+/// block and the query surface works (regression guard for the optional
+/// wiring).
+#[tokio::test]
+async fn http_standalone_unaffected() {
+    let (base, _tx) = start_http(None).await;
+    let resp = reqwest::get(format!("{base}/health")).await.unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+    assert_eq!(body["status"], "ok");
+    assert!(body.get("replication").is_none() || body["replication"].is_null());
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base}/api/query"))
+        .header("content-type", "application/json")
+        .body(r#"{"sql":"SELECT 1"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
 }


### PR DESCRIPTION
## Summary

Wires the operational surfaces deferred from the core replicated-session wiring (#5383, #5395) — the three items #5393 calls out:

1. **Prepared-statement / `PREPARE`/`EXECUTE` writes** (correctness gap, fixed)
2. **Health / role endpoint** (`/health`, implemented)
3. **HTTP API + subscriptions** in replicated mode (audited; **gated** with a clear error, full routing deferred to #5410)

Standalone mode is behavior-unchanged — everything here is opt-in behind the replication handle.

### 1. Prepared-statement writes

**Finding on the extended wire protocol: already correct, no gap.** `connection/extended.rs::handle_execute` runs the bound portal via `Session::execute(&portal.bound_query)`; Bind substitutes `$N` params into SQL text, so a parameterized write routes through `execute_replicated` (freeze-at-propose) with the same `NotLeader`/SQLSTATE handling as the simple path. Added regression tests (`wire_protocol_extended_write_replicates`, `..._on_follower_redirects`) guarding it is not a bypass.

**`PREPARE`/`EXECUTE` *statement syntax*: was the real gap (refused `0A000`), now fixed.** `PREPARE name FROM 'sql'` stores the SQL text; `EXECUTE name (...)` evaluates the literal args, substitutes them back into the prepared text (quote-safe via `ToSql` — `O'Brien` → `'O''Brien'`, placeholders inside string literals left untouched), and re-routes through `execute` → `execute_replicated`. So a PREPARE'd INSERT proposes one consensus entry per EXECUTE, a PREPARE'd SELECT honors the session read-consistency mode, and a PREPARE'd write on a follower returns `25006` with a leader hint. `DEALLOCATE` drops the named statement. Inside an interactive transaction, PREPARE/DEALLOCATE are allowed; EXECUTE of a prepared write is refused (`0A000` → #5401) because the in-txn dispatch is synchronous.

### 2. Health / role endpoint

`/health` now reports, in replicated mode, the node's consensus role, `can_serve_writes`, `applied_index` (replication-lag marker), `leader_id`, and any `fatal_reason`, and returns **503** whenever the node cannot serve writes (follower / candidate / fatally halted). A status-code-only health check therefore lets a load balancer route writes to the leader and route around halted/lagging nodes. Standalone `/health` is unchanged (200, no `replication` block). Backed by `ReplicationHandle::health_snapshot`.

### 3. HTTP API + subscriptions

The HTTP REST/GraphQL/CRUD/subscription/blob-storage handlers execute against the local registry database, which receives no replicated writes — a write would never replicate and a read would silently return stale/empty data. In replicated mode each is **gated to a clear 503** (SQLSTATE `58000`) pointing clients at the PostgreSQL wire port (fully replicated). Never silent wrong behavior. Full routing of HTTP writes/subscriptions through consensus is filed as follow-on **#5410**.

## Scope decision

Split, keeping #5393 open (`Part of #5393`): prepared-statement writes + `/health` delivered solidly; HTTP/subscriptions audited and gated with a clear error; full HTTP consensus routing deferred to #5410. A sound partial over a sprawling whole.

## Test plan / evidence

`cargo test -p vibesql-server` — **all green**:
- [x] 417 lib unit tests (incl. new `substitute_named_params` quote-escaping / placeholder-in-literal tests)
- [x] 23 replication integration tests, including:
  - `replicated_prepared_insert_routes_through_consensus` (one entry per EXECUTE; quoted string preserved; DEALLOCATE)
  - `replicated_prepared_select_reads_state_machine` (linearizable read of replicated data)
  - `replicated_prepared_write_on_follower_redirects` (`25006`)
  - `wire_protocol_extended_write_replicates` / `..._on_follower_redirects` (extended protocol is not a bypass)
  - `health_snapshot_reports_role_and_writability` + `http_health_reports_leader_and_follower` (leader 200/writable, follower 503/not-writable with leader id)
  - `http_query_surface_gated_in_replicated_mode` (query + CRUD → 503)
  - `http_standalone_unaffected` (regression: standalone /health 200, query works)
- [x] standalone regression suites (transaction_tests, extended_protocol_tests, session_tests, etc.) unchanged and green

Multi-node + wire-level conventions follow `tests/replication_tests.rs` (bounded waits, NotLeader retry, real ephemeral-port clusters).

Closes nothing; **Part of #5393**. Follow-on: #5410.