### PR TITLE
fix: split trigger body on top-level semicolons only

### DIFF
--- a/crates/vibesql-executor/src/tests/triggers/insert.rs
+++ b/crates/vibesql-executor/src/tests/triggers/insert.rs
@@ -6,7 +6,7 @@ use vibesql_ast::{
 use vibesql_storage::Database;
 
 use super::{count_audit_rows, create_audit_table, create_users_table};
-use crate::InsertExecutor;
+use crate::{InsertExecutor, SelectExecutor};
 
 #[test]
 fn test_after_insert_trigger_fires() {
@@ -158,4 +158,175 @@ fn test_before_insert_trigger_fires() {
 
     // Verify trigger fired
     assert_eq!(count_audit_rows(&db), 1);
+}
+
+/// Read the single `event` value from the audit_log (created by
+/// `create_audit_table`). Panics if there is not exactly one row.
+fn single_audit_event(db: &Database) -> String {
+    let stmt = vibesql_parser::Parser::parse_sql("SELECT event FROM audit_log;").unwrap();
+    let result = match stmt {
+        vibesql_ast::Statement::Select(stmt) => {
+            SelectExecutor::new(db).execute_with_columns(&stmt).unwrap()
+        }
+        _ => panic!("Expected Select"),
+    };
+    assert_eq!(result.rows.len(), 1, "expected exactly one audit row");
+    match &result.rows[0].values[0] {
+        vibesql_types::SqlValue::Varchar(s) => s.to_string(),
+        other => panic!("expected Varchar audit value, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_insert_trigger_body_semicolon_inside_string_literal_is_not_split() {
+    // Regression for #5408: when a trigger body statement contains a `;`
+    // inside a string literal, the fire-time splitter must NOT break it into
+    // two malformed fragments. The full string (including the embedded `;`)
+    // must be stored intact. Verified against sqlite3 3.51.x:
+    //   sqlite> CREATE TABLE x(id INT);
+    //   sqlite> CREATE TABLE audit_log(event TEXT);
+    //   sqlite> CREATE TRIGGER t AFTER INSERT ON x BEGIN
+    //             INSERT INTO audit_log(event) VALUES('a;b'); END;
+    //   sqlite> INSERT INTO x VALUES(1);
+    //   sqlite> SELECT event FROM audit_log;  -- => a;b
+    let mut db = Database::new();
+    create_users_table(&mut db);
+    create_audit_table(&mut db);
+
+    let trigger_stmt = CreateTriggerStmt {
+        trigger_name: "log_semicolon".to_string(),
+        timing: TriggerTiming::After,
+        event: TriggerEvent::Insert,
+        table_name: "USERS".to_string(),
+        granularity: TriggerGranularity::Row,
+        when_condition: None,
+        triggered_action: TriggerAction::RawSql(
+            "BEGIN INSERT INTO audit_log (event) VALUES ('a;b'); END".to_string(),
+        ),
+    };
+    crate::advanced_objects::execute_create_trigger(&trigger_stmt, &mut db)
+        .expect("Failed to create trigger");
+
+    let insert = vibesql_ast::InsertStmt {
+        with_clause: None,
+        schema_name: None,
+        schema_quoted: false,
+        table_quoted: false,
+        table_name: "USERS".to_string(),
+        columns: vec!["id".to_string(), "username".to_string()],
+        source: vibesql_ast::InsertSource::Values(vec![vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("alice"),
+            )),
+        ]]),
+        conflict_clause: None,
+        on_conflict: None,
+        on_duplicate_key_update: None,
+        returning: None,
+    };
+    InsertExecutor::execute(&mut db, &insert).expect("Failed to insert");
+
+    // Exactly one audit row, with the full string preserved (not truncated to
+    // "a" and not split into a second malformed statement).
+    assert_eq!(count_audit_rows(&db), 1);
+    assert_eq!(single_audit_event(&db), "a;b");
+}
+
+#[test]
+fn test_insert_trigger_body_escaped_quote_with_semicolon_is_intact() {
+    // #5408: SQLite escapes a single quote inside a string as `''`. A `;`
+    // after the escaped quote stays inside the literal. Verified against
+    // sqlite3 3.51.x: the stored value is `o'reilly;jr`.
+    let mut db = Database::new();
+    create_users_table(&mut db);
+    create_audit_table(&mut db);
+
+    let trigger_stmt = CreateTriggerStmt {
+        trigger_name: "log_escaped".to_string(),
+        timing: TriggerTiming::After,
+        event: TriggerEvent::Insert,
+        table_name: "USERS".to_string(),
+        granularity: TriggerGranularity::Row,
+        when_condition: None,
+        triggered_action: TriggerAction::RawSql(
+            "BEGIN INSERT INTO audit_log (event) VALUES ('o''reilly;jr'); END".to_string(),
+        ),
+    };
+    crate::advanced_objects::execute_create_trigger(&trigger_stmt, &mut db)
+        .expect("Failed to create trigger");
+
+    let insert = vibesql_ast::InsertStmt {
+        with_clause: None,
+        schema_name: None,
+        schema_quoted: false,
+        table_quoted: false,
+        table_name: "USERS".to_string(),
+        columns: vec!["id".to_string(), "username".to_string()],
+        source: vibesql_ast::InsertSource::Values(vec![vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("alice"),
+            )),
+        ]]),
+        conflict_clause: None,
+        on_conflict: None,
+        on_duplicate_key_update: None,
+        returning: None,
+    };
+    InsertExecutor::execute(&mut db, &insert).expect("Failed to insert");
+
+    assert_eq!(count_audit_rows(&db), 1);
+    assert_eq!(single_audit_event(&db), "o'reilly;jr");
+}
+
+#[test]
+fn test_insert_trigger_multi_statement_body_with_semicolon_string() {
+    // #5408: a multi-statement body where one statement has a `;` in a string
+    // must split into exactly the real statements. Both audit rows must be
+    // written, with the `;`-containing value preserved intact.
+    let mut db = Database::new();
+    create_users_table(&mut db);
+    create_audit_table(&mut db);
+
+    let trigger_stmt = CreateTriggerStmt {
+        trigger_name: "log_multi".to_string(),
+        timing: TriggerTiming::After,
+        event: TriggerEvent::Insert,
+        table_name: "USERS".to_string(),
+        granularity: TriggerGranularity::Row,
+        when_condition: None,
+        triggered_action: TriggerAction::RawSql(
+            "BEGIN \
+             INSERT INTO audit_log (event) VALUES ('a;b'); \
+             INSERT INTO audit_log (event) VALUES ('c'); \
+             END"
+                .to_string(),
+        ),
+    };
+    crate::advanced_objects::execute_create_trigger(&trigger_stmt, &mut db)
+        .expect("Failed to create trigger");
+
+    let insert = vibesql_ast::InsertStmt {
+        with_clause: None,
+        schema_name: None,
+        schema_quoted: false,
+        table_quoted: false,
+        table_name: "USERS".to_string(),
+        columns: vec!["id".to_string(), "username".to_string()],
+        source: vibesql_ast::InsertSource::Values(vec![vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("alice"),
+            )),
+        ]]),
+        conflict_clause: None,
+        on_conflict: None,
+        on_duplicate_key_update: None,
+        returning: None,
+    };
+    InsertExecutor::execute(&mut db, &insert).expect("Failed to insert");
+
+    // Both statements ran: two audit rows (not one truncated, not three split).
+    assert_eq!(count_audit_rows(&db), 2);
 }

--- a/crates/vibesql-executor/src/trigger_execution.rs
+++ b/crates/vibesql-executor/src/trigger_execution.rs
@@ -362,30 +362,16 @@ impl TriggerFirer {
     /// # Returns
     /// Vector of parsed statements
     pub fn parse_trigger_sql(sql: &str) -> Result<Vec<vibesql_ast::Statement>, ExecutorError> {
-        // Strip BEGIN/END wrapper if present
-        let sql = sql.trim();
-        let sql = if sql.to_uppercase().starts_with("BEGIN") {
-            // Remove BEGIN and END
-            let sql = sql[5..].trim();
-            if sql.to_uppercase().ends_with("END") {
-                &sql[..sql.len() - 3]
-            } else {
-                sql
-            }
-        } else {
-            sql
-        };
-
-        // Split by semicolons and parse each statement
+        // Split the BEGIN ... END body into statements with the shared,
+        // string-literal- and comment-aware splitter. This is the same
+        // splitter `Parser::validate_trigger_body` uses at create time, so the
+        // create-time and fire-time paths cannot drift, and a `;` inside a
+        // string literal (e.g. `INSERT INTO log VALUES('a;b')`) is no longer
+        // mistaken for a statement separator. The splitter strips the
+        // BEGIN/END wrapper and drops empty / comment-only fragments.
         let mut statements = Vec::new();
-        for stmt_sql in sql.split(';') {
-            let stmt_sql = stmt_sql.trim();
-            if stmt_sql.is_empty() || stmt_sql.starts_with("--") {
-                // Skip empty statements or comments
-                continue;
-            }
-
-            match vibesql_parser::Parser::parse_sql(stmt_sql) {
+        for stmt_sql in vibesql_parser::split_trigger_body_statements(sql) {
+            match vibesql_parser::Parser::parse_sql(&stmt_sql) {
                 Ok(stmt) => statements.push(stmt),
                 Err(e) => {
                     return Err(ExecutorError::UnsupportedExpression(format!(

--- a/crates/vibesql-parser/src/lib.rs
+++ b/crates/vibesql-parser/src/lib.rs
@@ -30,11 +30,13 @@ mod parser;
 #[cfg(test)]
 mod tests;
 mod token;
+mod trigger_body;
 
 pub use keywords::Keyword;
 pub use lexer::{Lexer, LexerError, Span};
 pub use parser::{ParseError, Parser};
 pub use token::Token;
+pub use trigger_body::split_trigger_body_statements;
 use vibesql_ast::Statement;
 
 /// Parse SQL using arena allocation where supported, falling back to standard parsing.

--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -229,31 +229,19 @@ impl Parser {
     /// Parse-and-validate each statement of a `BEGIN ... END` trigger body,
     /// surfacing the create-time validation errors SQLite enforces.
     ///
-    /// Strips the `BEGIN`/`END` wrapper, splits the body on `;`, and parses
-    /// each non-empty statement with [`Parser::parse_sql`] — mirroring
-    /// `TriggerFirer::parse_trigger_sql` in `vibesql-executor`, the parser
-    /// used when the trigger fires. A parse error is only propagated when it
-    /// is a create-time rejection class SQLite also enforces (see
+    /// Splits the body into statements with
+    /// [`crate::split_trigger_body_statements`] — the same string-literal- and
+    /// comment-aware splitter `TriggerFirer::parse_trigger_sql` in
+    /// `vibesql-executor` uses at fire time, so the two paths cannot drift and
+    /// neither mishandles a `;` inside a string literal — and parses each
+    /// statement with [`Parser::parse_sql`]. A parse error is only propagated
+    /// when it is a create-time rejection class SQLite also enforces (see
     /// [`Parser::is_create_time_rejection`]); other parse failures are
     /// tolerated so that bodies using constructs VibeSQL cannot yet parse
     /// (but SQLite accepts at create time) are preserved as before.
     fn validate_trigger_body(raw_sql: &str) -> Result<(), ParseError> {
-        // Strip the BEGIN/END wrapper (case-insensitive), mirroring the
-        // executor's fire-time stripping.
-        let body = raw_sql.trim();
-        let body = body.strip_prefix("BEGIN").map(str::trim).unwrap_or(body);
-        let body = if body.to_uppercase().ends_with("END") {
-            body[..body.len() - 3].trim()
-        } else {
-            body
-        };
-
-        for stmt_sql in body.split(';') {
-            let stmt_sql = stmt_sql.trim();
-            if stmt_sql.is_empty() || stmt_sql.starts_with("--") {
-                continue;
-            }
-            if let Err(e) = Self::parse_sql(stmt_sql) {
+        for stmt_sql in crate::split_trigger_body_statements(raw_sql) {
+            if let Err(e) = Self::parse_sql(&stmt_sql) {
                 if Self::is_create_time_rejection(&e) {
                     // Propagate verbatim so the message (e.g.
                     // `unsupported use of NULLS FIRST`) matches the

--- a/crates/vibesql-parser/src/tests/trigger.rs
+++ b/crates/vibesql-parser/src/tests/trigger.rs
@@ -311,6 +311,63 @@ fn test_create_trigger_body_with_string_literal() {
 }
 
 #[test]
+fn test_create_trigger_body_semicolon_inside_string_literal() {
+    // Regression for #5408: a `;` inside a string literal must not split the
+    // body into two malformed statements at create-time validation. SQLite
+    // accepts this body; VibeSQL must parse it successfully and preserve the
+    // full string (including the embedded `;`).
+    use vibesql_ast::TriggerAction;
+
+    let sql = "CREATE TRIGGER t AFTER INSERT ON x BEGIN \
+               INSERT INTO log VALUES ('a;b'); \
+               END;";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse body with ';' in string: {:?}", result.err());
+
+    match result.unwrap() {
+        Statement::CreateTrigger(trigger) => match &trigger.triggered_action {
+            TriggerAction::RawSql(body) => {
+                assert!(
+                    body.contains("'a;b'"),
+                    "Body should preserve the full string literal containing ';'. Got: {}",
+                    body
+                );
+            }
+        },
+        _ => panic!("Expected CreateTrigger statement"),
+    }
+}
+
+#[test]
+fn test_create_trigger_body_escaped_quote_and_semicolon_in_string() {
+    // #5408: SQLite escapes a single quote inside a string as `''`. A `;`
+    // appearing after an escaped quote is still inside the literal and must
+    // not split the statement.
+    let sql = "CREATE TRIGGER t AFTER INSERT ON x BEGIN \
+               INSERT INTO log VALUES ('o''reilly;jr'); \
+               END;";
+    let result = Parser::parse_sql(sql);
+    assert!(
+        result.is_ok(),
+        "Failed to parse body with escaped quote + ';' in string: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_create_trigger_multi_statement_body_with_semicolon_string() {
+    // #5408: a multi-statement body where one statement contains a ';' in a
+    // string must still split into exactly the real statements (the embedded
+    // ';' is not a separator), and each must parse.
+    let sql = "CREATE TRIGGER t AFTER INSERT ON x BEGIN \
+               INSERT INTO log VALUES ('a;b'); \
+               INSERT INTO log VALUES ('c'); \
+               END;";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse multi-statement body: {:?}", result.err());
+}
+
+#[test]
 fn test_create_temp_trigger_after_insert() {
     let sql = "CREATE TEMP TRIGGER tr2 AFTER INSERT ON t1 BEGIN UPDATE t1 SET b = 1; END;";
     let result = Parser::parse_sql(sql);

--- a/crates/vibesql-parser/src/trigger_body.rs
+++ b/crates/vibesql-parser/src/trigger_body.rs
@@ -1,0 +1,207 @@
+//! Statement splitting for `BEGIN ... END` trigger bodies.
+//!
+//! A SQLite trigger body is a sequence of statements separated by `;`. Both
+//! the create-time validator (`Parser::validate_trigger_body`) and the
+//! fire-time executor (`TriggerFirer::parse_trigger_sql`) need to break the
+//! body into its component statements before parsing each one.
+//!
+//! A naive `body.split(';')` is wrong: it splits on a `;` that appears inside
+//! a string literal (e.g. `INSERT INTO log VALUES('a;b')`), a quoted
+//! identifier (`"a;b"`, `[a;b]`, `` `a;b` ``), a blob literal, or a `--`
+//! comment — producing two malformed fragments where SQLite (and a correct
+//! parser) sees one statement.
+//!
+//! This module reuses the crate's lexer to find the *top-level* semicolons.
+//! The lexer already handles SQLite string-literal escaping (`''`), all of
+//! VibeSQL's quoted-identifier forms, blob literals, and `--` comments, so a
+//! `;` inside any of those is never tokenized as [`Token::Semicolon`]. We
+//! split the original source on the byte offsets of the top-level semicolon
+//! tokens, which preserves each statement's exact text.
+//!
+//! This is the single source of truth shared by the parser-side validator and
+//! the executor's fire-time path so the two cannot drift.
+
+use crate::lexer::Lexer;
+use crate::token::Token;
+
+/// Split a `BEGIN ... END` trigger body into its component statements.
+///
+/// `raw_sql` is the full triggered-action SQL as stored on the trigger,
+/// including the `BEGIN`/`END` wrapper (the wrapper is stripped here,
+/// case-insensitively). The returned statements are trimmed; empty fragments
+/// and `--` comment-only fragments are dropped, mirroring the prior behavior
+/// of both call sites.
+///
+/// Semicolons inside string literals, quoted identifiers, blob literals, and
+/// comments are not treated as statement separators. If the body cannot be
+/// tokenized (an unterminated string, an unexpected character, etc.), this
+/// falls back to the historical naive `split(';')` so we never reject a body
+/// that the lexer happens not to handle but the downstream parser might.
+pub fn split_trigger_body_statements(raw_sql: &str) -> Vec<String> {
+    let body = strip_begin_end(raw_sql);
+
+    let statements = match split_top_level_semicolons(body) {
+        Some(parts) => parts,
+        // Lexing failed: preserve the prior naive behavior rather than
+        // dropping the body entirely.
+        None => body.split(';').map(str::to_string).collect(),
+    };
+
+    statements
+        .into_iter()
+        .filter_map(|stmt| {
+            let trimmed = stmt.trim();
+            if trimmed.is_empty() || trimmed.starts_with("--") {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
+        .collect()
+}
+
+/// Strip the leading `BEGIN` keyword and trailing `END` keyword (case
+/// insensitive) from a trigger body, returning the inner statement list.
+///
+/// Mirrors the stripping both call sites previously did inline.
+fn strip_begin_end(raw_sql: &str) -> &str {
+    let body = raw_sql.trim();
+
+    // Strip a leading BEGIN only when it is the keyword (followed by
+    // whitespace or end-of-input), not merely a prefix of an identifier.
+    let body = match body.get(..5) {
+        Some(prefix) if prefix.eq_ignore_ascii_case("BEGIN") => {
+            let rest = &body[5..];
+            if rest.is_empty() || rest.starts_with(|c: char| c.is_whitespace()) {
+                rest.trim()
+            } else {
+                body
+            }
+        }
+        _ => body,
+    };
+
+    // Strip a trailing END keyword similarly.
+    let len = body.len();
+    if len >= 3 && body[len - 3..].eq_ignore_ascii_case("END") {
+        let before = &body[..len - 3];
+        if before.is_empty() || before.ends_with(|c: char| c.is_whitespace()) {
+            return before.trim();
+        }
+    }
+
+    body
+}
+
+/// Split `body` on top-level semicolons using the lexer to skip semicolons
+/// inside string/identifier/blob literals and comments.
+///
+/// Returns `None` if the body cannot be tokenized, so the caller can fall
+/// back to the naive split.
+fn split_top_level_semicolons(body: &str) -> Option<Vec<String>> {
+    let mut lexer = Lexer::new(body);
+    let tokens = lexer.tokenize_with_spans().ok()?;
+
+    let mut statements = Vec::new();
+    let mut stmt_start = 0usize;
+
+    for (token, span) in &tokens {
+        match token {
+            Token::Semicolon => {
+                // Statement is the source text up to (not including) the
+                // semicolon. Slicing the original source preserves the exact
+                // contents of any string literal that contained a `;`.
+                statements.push(body[stmt_start..span.start].to_string());
+                stmt_start = span.end;
+            }
+            // Trailing text after the last semicolon (no terminating `;`).
+            Token::Eof if stmt_start < span.start => {
+                statements.push(body[stmt_start..span.start].to_string());
+            }
+            _ => {}
+        }
+    }
+
+    Some(statements)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_simple_multi_statement_body() {
+        let body = "BEGIN INSERT INTO a VALUES (1); INSERT INTO b VALUES (2); END";
+        let stmts = split_trigger_body_statements(body);
+        assert_eq!(stmts, vec!["INSERT INTO a VALUES (1)", "INSERT INTO b VALUES (2)"]);
+    }
+
+    #[test]
+    fn does_not_split_on_semicolon_inside_string_literal() {
+        let body = "BEGIN INSERT INTO log VALUES ('a;b'); END";
+        let stmts = split_trigger_body_statements(body);
+        assert_eq!(stmts, vec!["INSERT INTO log VALUES ('a;b')"]);
+    }
+
+    #[test]
+    fn keeps_full_string_with_multiple_semicolons() {
+        let body = "BEGIN INSERT INTO log VALUES ('a;b;c;d'); INSERT INTO log VALUES ('x'); END";
+        let stmts = split_trigger_body_statements(body);
+        assert_eq!(
+            stmts,
+            vec!["INSERT INTO log VALUES ('a;b;c;d')", "INSERT INTO log VALUES ('x')"]
+        );
+    }
+
+    #[test]
+    fn handles_escaped_quote_inside_semicolon_string() {
+        // SQLite escaping: '' is an escaped single quote inside the string.
+        // The `;` after the escaped quote must stay inside the literal.
+        let body = "BEGIN INSERT INTO log VALUES ('o''reilly;jr'); END";
+        let stmts = split_trigger_body_statements(body);
+        assert_eq!(stmts, vec!["INSERT INTO log VALUES ('o''reilly;jr')"]);
+    }
+
+    #[test]
+    fn does_not_split_on_semicolon_inside_double_quoted_identifier() {
+        let body = "BEGIN INSERT INTO \"weird;col\" VALUES (1); END";
+        let stmts = split_trigger_body_statements(body);
+        assert_eq!(stmts, vec!["INSERT INTO \"weird;col\" VALUES (1)"]);
+    }
+
+    #[test]
+    fn does_not_split_on_semicolon_inside_bracket_identifier() {
+        let body = "BEGIN INSERT INTO [weird;col] VALUES (1); END";
+        let stmts = split_trigger_body_statements(body);
+        assert_eq!(stmts, vec!["INSERT INTO [weird;col] VALUES (1)"]);
+    }
+
+    #[test]
+    fn handles_body_without_trailing_semicolon() {
+        let body = "BEGIN INSERT INTO log VALUES ('a;b') END";
+        let stmts = split_trigger_body_statements(body);
+        assert_eq!(stmts, vec!["INSERT INTO log VALUES ('a;b')"]);
+    }
+
+    #[test]
+    fn drops_empty_and_comment_only_fragments() {
+        let body = "BEGIN INSERT INTO a VALUES (1); ; -- a comment\n END";
+        let stmts = split_trigger_body_statements(body);
+        assert_eq!(stmts, vec!["INSERT INTO a VALUES (1)"]);
+    }
+
+    #[test]
+    fn empty_body_yields_no_statements() {
+        assert!(split_trigger_body_statements("BEGIN END").is_empty());
+        assert!(split_trigger_body_statements("BEGIN  END").is_empty());
+    }
+
+    #[test]
+    fn does_not_strip_begin_inside_identifier() {
+        // A body that does not start with the BEGIN keyword should be left as
+        // is (defensive: callers always pass a wrapped body, but guard anyway).
+        let body = "INSERT INTO beginnings VALUES (1)";
+        let stmts = split_trigger_body_statements(body);
+        assert_eq!(stmts, vec!["INSERT INTO beginnings VALUES (1)"]);
+    }
+}


### PR DESCRIPTION
## Summary

The CREATE TRIGGER body splitter used a naive `body.split(';')`, which splits a body statement containing a `;` inside a string literal (e.g. `INSERT INTO log VALUES('a;b')`) into two malformed fragments. This was duplicated, drift-prone logic in both call sites:
- `Parser::validate_trigger_body` (create time, `crates/vibesql-parser/src/parser/trigger.rs`)
- `TriggerFirer::parse_trigger_sql` (fire time, `crates/vibesql-executor/src/trigger_execution.rs`)

## Fix

Added a single shared, string-literal- and comment-aware splitter `vibesql_parser::split_trigger_body_statements` (`crates/vibesql-parser/src/trigger_body.rs`) that **reuses the crate's lexer** to find *top-level* semicolons.

**Approach: lexer-reuse, not hand-rolled quote tracking.** The lexer (`tokenize_with_spans`) already correctly handles:
- SQLite `''`-escaped single quotes inside string literals
- all quoted-identifier forms: `"..."`, `[...]`, and backtick
- blob literals (`x'...'`)
- `--` line comments

so a `;` inside any of those is never tokenized as `Token::Semicolon`. We split the original source on the byte spans of the top-level semicolon tokens, preserving each statement's exact text. If the body fails to tokenize, we fall back to the historical naive `split(';')` so no previously-accepted body is rejected.

Both call sites now delegate to this one helper, so the create-time and fire-time paths cannot drift.

## sqlite3 3.51.0 verification

| Body | sqlite3 stored value | VibeSQL |
| --- | --- | --- |
| `VALUES('a;b')` | `a;b` | `a;b` |
| `VALUES('o''reilly;jr')` | `o'reilly;jr` | `o'reilly;jr` |
| two stmts, first `('a;b')` | 2 rows: `a;b,c` | 2 rows |

## Tests

- `crates/vibesql-parser/src/trigger_body.rs`: 8 unit tests for the splitter (string `;`, escaped quote + `;`, double-quote and bracket identifiers, no-trailing-`;`, comment/empty fragment drop, BEGIN/END stripping).
- `crates/vibesql-parser/src/tests/trigger.rs`: 3 create-time tests (`;`-in-string, escaped-quote + `;`, multi-statement).
- `crates/vibesql-executor/src/tests/triggers/insert.rs`: 3 fire-time end-to-end tests asserting the stored value is intact (`a;b`, `o'reilly;jr`) and multi-statement bodies write both rows.

`cargo test -p vibesql-parser -p vibesql-executor`: all green (2656 parser unit tests + full executor suite, 0 failures). `cargo clippy` clean for the new code. Trigger TCL files (`trigger2.test`, etc.) extract 0 tests under VibeSQL's harness both before and after this change — a pre-existing harness limitation, not a regression.

## Test plan

- [x] Splitter unit tests pass
- [x] Create-time + fire-time trigger tests pass
- [x] Full `vibesql-parser` + `vibesql-executor` suites green
- [x] Expected values cross-checked against sqlite3 3.51.0
- [x] clippy clean for new code

Closes #5408

🤖 Generated with [Claude Code](https://claude.com/claude-code)