### PR TITLE
feat(parser): support RAISE() in trigger bodies

### DIFF
--- a/crates/vibesql-ast/src/expression.rs
+++ b/crates/vibesql-ast/src/expression.rs
@@ -365,6 +365,52 @@ pub enum Expression {
         expr: Box<Expression>,
         collation: String,
     },
+
+    /// RAISE() trigger-program error/abort expression (SQLite).
+    ///
+    /// Only meaningful inside a trigger body, where it aborts the firing
+    /// statement / transaction (or abandons the current row) with the given
+    /// message. SQLite parses it only within a trigger-program and reports
+    /// `RAISE() may only be used within a trigger-program` otherwise.
+    ///
+    /// Syntax:
+    /// - `RAISE(ABORT, error-message)`
+    /// - `RAISE(FAIL, error-message)`
+    /// - `RAISE(ROLLBACK, error-message)`
+    /// - `RAISE(IGNORE)` (no message)
+    ///
+    /// The error message may be any expression (commonly a string literal or
+    /// `'msg: ' || NEW.col`). It is `None` for `RAISE(IGNORE)` and always
+    /// `Some(..)` for the other three actions.
+    Raise {
+        action: RaiseAction,
+        error_message: Option<Box<Expression>>,
+    },
+}
+
+/// The conflict-resolution action of a `RAISE()` expression.
+///
+/// Mirrors SQLite's RAISE behavior:
+/// - `Ignore` abandons just the current row's processing and continues
+///   (no error is reported).
+/// - `Abort` rolls back the changes made by the current statement, but
+///   preserves earlier statements in the transaction.
+/// - `Fail` stops the current statement without undoing changes it already
+///   made to earlier rows in that statement.
+/// - `Rollback` rolls back the entire enclosing transaction.
+///
+/// `Abort`, `Fail`, and `Rollback` report the error message (SQLite error
+/// code 19, `SQLITE_CONSTRAINT`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RaiseAction {
+    /// RAISE(IGNORE) — abandon the current row, continue, no error.
+    Ignore,
+    /// RAISE(ABORT, msg) — roll back the current statement.
+    Abort,
+    /// RAISE(FAIL, msg) — stop the statement, keep prior in-statement changes.
+    Fail,
+    /// RAISE(ROLLBACK, msg) — roll back the whole transaction.
+    Rollback,
 }
 
 /// Full-text search mode specification

--- a/crates/vibesql-ast/src/lib.rs
+++ b/crates/vibesql-ast/src/lib.rs
@@ -187,7 +187,7 @@ pub use dml::{
 };
 pub use expression::{
     CaseWhen, CharacterUnit, Expression, FrameBound, FrameExclude, FrameUnit, FulltextMode,
-    IntervalUnit, PseudoTable, Quantifier, TrimPosition, TruthValue, WindowFrame,
+    IntervalUnit, PseudoTable, Quantifier, RaiseAction, TrimPosition, TruthValue, WindowFrame,
     WindowFunctionSpec, WindowSpec,
 };
 pub use grant::{GrantStmt, ObjectType, PrivilegeType};

--- a/crates/vibesql-ast/src/pretty_print.rs
+++ b/crates/vibesql-ast/src/pretty_print.rs
@@ -23,8 +23,8 @@ use vibesql_types::{DataType, SqlValue};
 use crate::{
     expression::{
         CaseWhen, CharacterUnit, Expression, FrameBound, FrameExclude, FrameUnit, FulltextMode,
-        IntervalUnit, PseudoTable, Quantifier, TrimPosition, WindowFrame, WindowFunctionSpec,
-        WindowSpec,
+        IntervalUnit, PseudoTable, Quantifier, RaiseAction, TrimPosition, WindowFrame,
+        WindowFunctionSpec, WindowSpec,
     },
     operators::{BinaryOperator, UnaryOperator},
     select::{
@@ -598,6 +598,11 @@ impl ToSql for Expression {
             Expression::Collate { expr, collation } => {
                 format!("{} COLLATE {}", expr.to_sql(), collation)
             }
+
+            Expression::Raise { action, error_message } => match error_message {
+                Some(msg) => format!("RAISE({}, {})", action.to_sql(), msg.to_sql()),
+                None => format!("RAISE({})", action.to_sql()),
+            },
         }
     }
 }
@@ -684,6 +689,17 @@ impl ToSql for CharacterUnit {
         match self {
             CharacterUnit::Characters => "CHARACTERS".to_string(),
             CharacterUnit::Octets => "OCTETS".to_string(),
+        }
+    }
+}
+
+impl ToSql for RaiseAction {
+    fn to_sql(&self) -> String {
+        match self {
+            RaiseAction::Ignore => "IGNORE".to_string(),
+            RaiseAction::Abort => "ABORT".to_string(),
+            RaiseAction::Fail => "FAIL".to_string(),
+            RaiseAction::Rollback => "ROLLBACK".to_string(),
         }
     }
 }

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -454,6 +454,18 @@ pub fn walk_expression<V: ExpressionVisitor>(visitor: &mut V, expr: &Expression)
         }
 
         Expression::Collate { expr: inner, .. } => walk_expression(visitor, inner),
+
+        // Descend into the RAISE error-message expression so any nested
+        // function call (e.g. a volatile call inside the message) is still
+        // visited by detectors such as the replication freeze pass. RAISE
+        // itself is non-volatile.
+        Expression::Raise { error_message, .. } => {
+            if let Some(msg) = error_message {
+                walk_expression(visitor, msg)
+            } else {
+                VisitResult::Continue
+            }
+        }
     };
 
     if result.should_stop() {
@@ -753,6 +765,12 @@ pub fn transform_expression<V: ExpressionMutVisitor>(
         Expression::Collate { expr: inner, collation } => {
             Expression::Collate { expr: Box::new(transform_expression(visitor, *inner)), collation }
         }
+
+        Expression::Raise { action, error_message } => Expression::Raise {
+            action,
+            error_message: error_message
+                .map(|msg| Box::new(transform_expression(visitor, *msg))),
+        },
     };
 
     // Post-order transform

--- a/crates/vibesql-catalog/src/table.rs
+++ b/crates/vibesql-catalog/src/table.rs
@@ -664,6 +664,10 @@ impl TableSchema {
             vibesql_ast::Expression::Collate { expr, .. } => {
                 Self::expression_references_column(expr, column_name)
             }
+
+            vibesql_ast::Expression::Raise { error_message, .. } => error_message
+                .as_ref()
+                .is_some_and(|msg| Self::expression_references_column(msg, column_name)),
         }
     }
 }

--- a/crates/vibesql-consensus/src/freeze.rs
+++ b/crates/vibesql-consensus/src/freeze.rs
@@ -2684,4 +2684,42 @@ mod tests {
             assert!(validate_statement(&parse(sql)).is_err(), "{sql} must be rejected");
         }
     }
+
+    #[test]
+    fn raise_trigger_body_is_admitted() {
+        // RAISE() is deterministic (no clock / RNG / session state), so a
+        // RAISE-bearing trigger body must pass the replication volatility
+        // validator and replicate verbatim (#5409). The abort is identical on
+        // every replica.
+        for sql in [
+            "CREATE TRIGGER trg BEFORE UPDATE ON t WHEN NEW.v > 100 \
+             BEGIN SELECT raise(ABORT, 'value too big'); END",
+            "CREATE TRIGGER trg BEFORE INSERT ON t WHEN NEW.v < 0 \
+             BEGIN SELECT raise(FAIL, 'no negatives'); END",
+            "CREATE TRIGGER trg BEFORE DELETE ON t WHEN OLD.v = 0 \
+             BEGIN SELECT raise(ROLLBACK, 'protected'); END",
+            "CREATE TRIGGER trg BEFORE UPDATE ON t WHEN NEW.v = 0 \
+             BEGIN SELECT raise(IGNORE); END",
+            // Message built from a non-volatile expression over NEW is still
+            // deterministic.
+            "CREATE TRIGGER trg BEFORE UPDATE ON t \
+             BEGIN SELECT raise(ABORT, 'bad: ' || NEW.v); END",
+        ] {
+            validate_statement(&parse(sql))
+                .unwrap_or_else(|e| panic!("RAISE trigger body must be admitted: {sql}: {e}"));
+        }
+    }
+
+    #[test]
+    fn raise_message_with_volatile_call_is_rejected() {
+        // A volatile call *inside* the RAISE message must still be caught by
+        // the walker (RAISE itself is non-volatile, but its message subtree is
+        // validated like any other expression).
+        let sql = "CREATE TRIGGER trg BEFORE UPDATE ON t \
+                   BEGIN SELECT raise(ABORT, 'r=' || random()); END";
+        assert!(
+            validate_statement(&parse(sql)).is_err(),
+            "RAISE with a volatile message must be rejected"
+        );
+    }
 }

--- a/crates/vibesql-executor/src/cache/parameterized.rs
+++ b/crates/vibesql-executor/src/cache/parameterized.rs
@@ -361,6 +361,12 @@ impl LiteralExtractor {
                 Self::extract_from_expression(expr, literals);
             }
 
+            Expression::Raise { error_message, .. } => {
+                if let Some(msg) = error_message {
+                    Self::extract_from_expression(msg, literals);
+                }
+            }
+
             Expression::UnaryOp { expr, .. } => {
                 Self::extract_from_expression(expr, literals);
             }

--- a/crates/vibesql-executor/src/cache/prepared_statement/bind/mutation.rs
+++ b/crates/vibesql-executor/src/cache/prepared_statement/bind/mutation.rs
@@ -279,6 +279,12 @@ fn bind_expression_mut(expr: &mut Expression, params: &[SqlValue]) {
             bind_expression_mut(expr, params);
         }
 
+        Expression::Raise { error_message, .. } => {
+            if let Some(msg) = error_message {
+                bind_expression_mut(msg, params);
+            }
+        }
+
         Expression::UnaryOp { expr: inner, .. } => {
             bind_expression_mut(inner, params);
         }
@@ -661,6 +667,12 @@ fn bind_expression_named_mut(expr: &mut Expression, params: &HashMap<String, Sql
 
         Expression::Collate { expr, .. } => {
             bind_expression_named_mut(expr, params);
+        }
+
+        Expression::Raise { error_message, .. } => {
+            if let Some(msg) = error_message {
+                bind_expression_named_mut(msg, params);
+            }
         }
 
         Expression::UnaryOp { expr: inner, .. } => {

--- a/crates/vibesql-executor/src/cache/query_signature.rs
+++ b/crates/vibesql-executor/src/cache/query_signature.rs
@@ -616,6 +616,14 @@ impl QuerySignature {
                 Self::hash_expression(expr, hasher);
                 collation.hash(hasher);
             }
+
+            Expression::Raise { action, error_message } => {
+                "RAISE".hash(hasher);
+                std::mem::discriminant(action).hash(hasher);
+                if let Some(msg) = error_message {
+                    Self::hash_expression(msg, hasher);
+                }
+            }
         }
     }
 

--- a/crates/vibesql-executor/src/cache/table_extractor.rs
+++ b/crates/vibesql-executor/src/cache/table_extractor.rs
@@ -186,6 +186,12 @@ fn extract_from_expression(expr: &vibesql_ast::Expression, tables: &mut HashSet<
             extract_from_expression(expr, tables);
         }
 
+        vibesql_ast::Expression::Raise { error_message, .. } => {
+            if let Some(msg) = error_message {
+                extract_from_expression(msg, tables);
+            }
+        }
+
         // Leaf expressions - no tables to extract
         vibesql_ast::Expression::Literal(_)
         | vibesql_ast::Expression::Placeholder(_)

--- a/crates/vibesql-executor/src/correlation.rs
+++ b/crates/vibesql-executor/src/correlation.rs
@@ -439,6 +439,10 @@ fn is_expression_correlated(
             is_expression_correlated(expr, outer_schema, subquery_tables)
         }
 
+        Expression::Raise { error_message, .. } => error_message
+            .as_ref()
+            .is_some_and(|msg| is_expression_correlated(msg, outer_schema, subquery_tables)),
+
         Expression::PseudoVariable { .. }
         | Expression::SessionVariable { .. }
         | Expression::DuplicateKeyValue { .. }

--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -460,17 +460,24 @@ impl DeleteExecutor {
             )?;
         }
 
-        // Step 3: Fire BEFORE DELETE ROW triggers only if triggers exist
+        // Step 3: Fire BEFORE DELETE ROW triggers only if triggers exist.
+        // A RAISE(IGNORE) in a BEFORE DELETE trigger abandons that row: drop it
+        // from the batch so it is neither deleted nor counted (SQLite).
         if has_delete_triggers {
-            for (_, row) in &rows_and_indices_to_delete {
-                crate::TriggerFirer::execute_before_triggers(
+            let mut keep = Vec::with_capacity(rows_and_indices_to_delete.len());
+            for (idx, row) in rows_and_indices_to_delete {
+                let outcome = crate::TriggerFirer::execute_before_triggers(
                     database,
                     table_name,
                     vibesql_ast::TriggerEvent::Delete,
-                    Some(row),
+                    Some(&row),
                     None,
                 )?;
+                if outcome != crate::TriggerOutcome::SkipRow {
+                    keep.push((idx, row));
+                }
             }
+            rows_and_indices_to_delete = keep;
         }
 
         // Step 4: Handle referential integrity for each row to be deleted

--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -145,6 +145,25 @@ pub enum ExecutorError {
         to: String,
     },
     ConstraintViolation(String),
+    /// A `RAISE(ABORT|FAIL|ROLLBACK, msg)` expression fired inside a trigger
+    /// body (SQLite RAISE). Carries the conflict-resolution action so the
+    /// trigger / DML / transaction layer can apply the correct rollback scope:
+    /// - `Abort` rolls back the current statement (default),
+    /// - `Fail` stops the statement but keeps its already-applied row changes,
+    /// - `Rollback` rolls back the whole enclosing transaction.
+    ///
+    /// `RAISE(IGNORE)` is *not* represented here: it is a control-flow signal
+    /// (abandon the current row, no error) and uses [`ExecutorError::RaiseIgnore`].
+    Raise {
+        action: vibesql_ast::RaiseAction,
+        message: String,
+    },
+    /// A `RAISE(IGNORE)` expression fired inside a trigger body. This is a
+    /// control-flow signal, not a user-visible error: the enclosing trigger /
+    /// row-processing loop catches it, abandons the current row, and continues
+    /// without reporting an error. If it ever escapes to a user (RAISE(IGNORE)
+    /// outside any trigger), it is surfaced as a benign no-op-style message.
+    RaiseIgnore,
     /// FOREIGN KEY references a parent column set that is not covered by a
     /// PRIMARY KEY, UNIQUE constraint, or non-partial UNIQUE INDEX in the
     /// parent table (SQLite-compatible error). Format:
@@ -749,6 +768,16 @@ impl std::fmt::Display for ExecutorError {
             }
             ExecutorError::ConstraintViolation(msg) => {
                 write!(f, "{}", vibe_msg!("executor-constraint-violation", message = msg.as_str()))
+            }
+            ExecutorError::Raise { message, .. } => {
+                // SQLite reports the RAISE() message verbatim (error code 19,
+                // SQLITE_CONSTRAINT). e.g. `Runtime error: value too big`.
+                write!(f, "{}", message)
+            }
+            ExecutorError::RaiseIgnore => {
+                // Should normally be intercepted before reaching a user. If it
+                // escapes (RAISE(IGNORE) outside a trigger), describe it plainly.
+                write!(f, "RAISE(IGNORE) used outside of a trigger body")
             }
             ExecutorError::ForeignKeyMismatch { child, parent } => {
                 // SQLite-compatible error format from fkey.c::sqlite3FkLocateIndex.

--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -1256,8 +1256,39 @@ impl CombinedExpressionEvaluator<'_> {
                 }
             }
 
+            // RAISE() trigger-program error/abort expression (SQLite).
+            vibesql_ast::Expression::Raise { action, error_message } => {
+                self.eval_raise(*action, error_message.as_deref(), row)
+            }
+
             // Unsupported expressions
             _ => Err(ExecutorError::UnsupportedExpression(format!("{:?}", expr))),
+        }
+    }
+
+    /// Evaluate a `RAISE(...)` trigger-program expression.
+    ///
+    /// `RAISE(IGNORE)` yields [`ExecutorError::RaiseIgnore`] (a control-flow
+    /// signal the trigger loop intercepts to skip the current row).
+    /// `RAISE(ABORT|FAIL|ROLLBACK, msg)` evaluates the message expression and
+    /// yields [`ExecutorError::Raise`] carrying the action and rendered message.
+    fn eval_raise(
+        &self,
+        action: vibesql_ast::RaiseAction,
+        error_message: Option<&vibesql_ast::Expression>,
+        row: &vibesql_storage::Row,
+    ) -> Result<SqlValue, ExecutorError> {
+        match action {
+            vibesql_ast::RaiseAction::Ignore => Err(ExecutorError::RaiseIgnore),
+            _ => {
+                let message = match error_message {
+                    Some(expr) => crate::evaluator::raise::render_raise_message(
+                        self.eval(expr, row)?,
+                    ),
+                    None => String::new(),
+                };
+                Err(ExecutorError::Raise { action, message })
+            }
         }
     }
 

--- a/crates/vibesql-executor/src/evaluator/expression_hash.rs
+++ b/crates/vibesql-executor/src/evaluator/expression_hash.rs
@@ -220,6 +220,11 @@ impl ExpressionHasher {
                 Self::is_deterministic_impl(expr, allow_column_refs)
             }
 
+            // RAISE() aborts evaluation by raising an error. It must never be
+            // cached or used as an index expression, so treat it as
+            // non-deterministic.
+            vibesql_ast::Expression::Raise { .. } => false,
+
             // MATCH AGAINST is deterministic if the search term is constant
             vibesql_ast::Expression::MatchAgainst { .. } => {
                 // MATCH AGAINST always operates on columns, which are non-deterministic
@@ -473,6 +478,14 @@ impl ExpressionHasher {
                 "COLLATE".hash(hasher);
                 Self::hash_expression(expr, hasher);
                 collation.hash(hasher);
+            }
+
+            vibesql_ast::Expression::Raise { action, error_message } => {
+                "RAISE".hash(hasher);
+                std::mem::discriminant(action).hash(hasher);
+                if let Some(msg) = error_message {
+                    Self::hash_expression(msg, hasher);
+                }
             }
         }
     }

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -970,6 +970,22 @@ impl ExpressionEvaluator<'_> {
             // COLLATE expression - evaluate inner expression (collation affects string comparison)
             // TODO: Full collation support - for now just evaluate the inner expression
             vibesql_ast::Expression::Collate { expr, .. } => self.eval(expr, row),
+
+            // RAISE() trigger-program error/abort expression (SQLite).
+            // RAISE(IGNORE) is a control-flow signal (skip the current row);
+            // RAISE(ABORT|FAIL|ROLLBACK, msg) aborts with the rendered message.
+            vibesql_ast::Expression::Raise { action, error_message } => match action {
+                vibesql_ast::RaiseAction::Ignore => Err(ExecutorError::RaiseIgnore),
+                _ => {
+                    let message = match error_message {
+                        Some(expr) => crate::evaluator::raise::render_raise_message(
+                            self.eval(expr, row)?,
+                        ),
+                        None => String::new(),
+                    };
+                    Err(ExecutorError::Raise { action: *action, message })
+                }
+            },
         }
     }
 

--- a/crates/vibesql-executor/src/evaluator/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod parallel;
 #[cfg(not(feature = "parallel"))]
 mod parallel;
 pub(crate) mod pattern;
+pub(crate) mod raise;
 mod schema_context;
 mod single;
 mod subqueries_shared;

--- a/crates/vibesql-executor/src/evaluator/raise.rs
+++ b/crates/vibesql-executor/src/evaluator/raise.rs
@@ -1,0 +1,46 @@
+//! Helpers for the `RAISE()` trigger-program expression (SQLite).
+//!
+//! `RAISE(ABORT|FAIL|ROLLBACK, msg)` reports `msg` coerced to text. SQLite's
+//! text coercion of the message differs from VibeSQL's default `Display` in
+//! one place that matters for compatibility: a `NULL` message is rendered as
+//! the empty string (SQLite shows `Runtime error:  (19)` for
+//! `RAISE(ABORT, NULL)`), whereas `SqlValue`'s `Display` renders `NULL` as the
+//! literal text `NULL`. Every other storage class uses the standard display
+//! form, matching SQLite (e.g. an integer `42` becomes `"42"`).
+
+use vibesql_types::SqlValue;
+
+/// Render a `RAISE()` error-message value as SQLite would.
+///
+/// `NULL` becomes the empty string; all other values use their normal text
+/// representation.
+pub(crate) fn render_raise_message(value: SqlValue) -> String {
+    match value {
+        SqlValue::Null => String::new(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_string_message_verbatim() {
+        assert_eq!(
+            render_raise_message(SqlValue::Varchar("value too big".into())),
+            "value too big"
+        );
+    }
+
+    #[test]
+    fn coerces_integer_message_to_text() {
+        assert_eq!(render_raise_message(SqlValue::Integer(42)), "42");
+    }
+
+    #[test]
+    fn renders_null_message_as_empty_string() {
+        // SQLite shows an empty message for RAISE(ABORT, NULL).
+        assert_eq!(render_raise_message(SqlValue::Null), "");
+    }
+}

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -1129,13 +1129,18 @@ fn execute_insert_internal(
             // Fire BEFORE INSERT triggers only if triggers exist
             let row_to_insert = make_row((full_row_values.clone(), explicit_rowid));
             if has_insert_triggers {
-                crate::TriggerFirer::execute_before_triggers(
+                // RAISE(IGNORE) in a BEFORE INSERT trigger abandons this row:
+                // skip the insert and continue with the next row (SQLite).
+                if crate::TriggerFirer::execute_before_triggers(
                     db,
                     table_name,
                     vibesql_ast::TriggerEvent::Insert,
                     None,
                     Some(&row_to_insert),
-                )?;
+                )? == crate::trigger_execution::TriggerOutcome::SkipRow
+                {
+                    continue;
+                }
             }
 
             // Get physical row count before insert to enable rollback and rowid calculation

--- a/crates/vibesql-executor/src/lib.rs
+++ b/crates/vibesql-executor/src/lib.rs
@@ -109,7 +109,7 @@ pub use transaction::{
     ReleaseSavepointExecutor, RollbackExecutor, RollbackToSavepointExecutor, SavepointExecutor,
 };
 pub use trigger_ddl::TriggerExecutor;
-pub use trigger_execution::TriggerFirer;
+pub use trigger_execution::{TriggerFirer, TriggerOutcome};
 pub use truncate_table::TruncateTableExecutor;
 pub use type_ddl::TypeExecutor;
 pub use update::UpdateExecutor;

--- a/crates/vibesql-executor/src/optimizer/column_pruning.rs
+++ b/crates/vibesql-executor/src/optimizer/column_pruning.rs
@@ -371,6 +371,12 @@ pub fn collect_columns_from_expr(expr: &Expression, columns: &mut HashSet<Column
             collect_columns_from_expr(expr, columns);
         }
 
+        Expression::Raise { error_message, .. } => {
+            if let Some(msg) = error_message {
+                collect_columns_from_expr(msg, columns);
+            }
+        }
+
         // Expressions that don't reference columns
         Expression::Literal(_)
         | Expression::Placeholder(_)

--- a/crates/vibesql-executor/src/optimizer/expressions.rs
+++ b/crates/vibesql-executor/src/optimizer/expressions.rs
@@ -446,6 +446,10 @@ pub fn optimize_expression(
             let optimized_expr = optimize_expression(expr, evaluator)?;
             Ok(Expression::Collate { expr: Box::new(optimized_expr), collation: collation.clone() })
         }
+
+        // RAISE() aborts at evaluation; never constant-fold it (it must run,
+        // not be precomputed away). Leave it untouched.
+        Expression::Raise { .. } => Ok(expr.clone()),
     }
 }
 

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/correlation.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/correlation.rs
@@ -225,6 +225,10 @@ pub(crate) fn has_external_column_refs(expr: &Expression, subquery: &SelectStmt)
 
         Expression::Collate { expr, .. } => has_external_column_refs(expr, subquery),
 
+        Expression::Raise { error_message, .. } => {
+            error_message.as_ref().is_some_and(|msg| has_external_column_refs(msg, subquery))
+        }
+
         // Literals and special expressions don't reference columns
         Expression::Literal(_)
         | Expression::Wildcard

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/expression.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/expression.rs
@@ -462,6 +462,13 @@ pub(super) fn rewrite_expression_with_context(
             collation: collation.clone(),
         },
 
+        Expression::Raise { action, error_message } => Expression::Raise {
+            action: *action,
+            error_message: error_message.as_ref().map(|msg| {
+                Box::new(rewrite_expression_with_context(msg, rewrite_subquery_fn, outer_tables))
+            }),
+        },
+
         // Literals, column refs, and special expressions don't need rewriting
         Expression::Literal(_)
         | Expression::ColumnRef(_)

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
@@ -148,6 +148,12 @@ impl SelectExecutor<'_> {
             vibesql_ast::Expression::Collate { .. } => {
                 simple::evaluate(self, expr, group_rows, group_key, evaluator)
             }
+
+            // RAISE() has no aggregate semantics; evaluating it surfaces the
+            // trigger abort/error via the normal evaluator.
+            vibesql_ast::Expression::Raise { .. } => {
+                simple::evaluate(self, expr, group_rows, group_key, evaluator)
+            }
         }
     }
 

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
@@ -687,6 +687,9 @@ fn expression_has_rowid(expr: &vibesql_ast::Expression) -> bool {
             exprs.iter().any(expression_has_rowid)
         }
         vibesql_ast::Expression::Collate { expr, .. } => expression_has_rowid(expr),
+        vibesql_ast::Expression::Raise { error_message, .. } => {
+            error_message.as_ref().is_some_and(|msg| expression_has_rowid(msg))
+        }
         // These variants don't contain column references that could be ROWID
         vibesql_ast::Expression::Literal(_)
         | vibesql_ast::Expression::Placeholder(_)

--- a/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
@@ -694,5 +694,12 @@ fn validate_expression_column_refs(
         Expression::Collate { expr, .. } => {
             validate_expression_column_refs(expr, schema, outer_schema, allowed_aliases)
         }
+
+        Expression::Raise { error_message, .. } => {
+            if let Some(msg) = error_message {
+                validate_expression_column_refs(msg, schema, outer_schema, allowed_aliases)?;
+            }
+            Ok(())
+        }
     }
 }

--- a/crates/vibesql-executor/src/select/executor/utils.rs
+++ b/crates/vibesql-executor/src/select/executor/utils.rs
@@ -136,6 +136,10 @@ fn expression_references_column(expr: &vibesql_ast::Expression) -> bool {
         }
 
         vibesql_ast::Expression::Collate { expr, .. } => expression_references_column(expr),
+
+        vibesql_ast::Expression::Raise { error_message, .. } => {
+            error_message.as_ref().is_some_and(|msg| expression_references_column(msg))
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
@@ -136,6 +136,9 @@ fn walk_first<T>(expr: &Expression, f: &impl Fn(&Expression) -> WalkAction<T>) -
         Expression::MatchAgainst { search_modifier, .. } => walk_first(search_modifier, f),
         Expression::RowValueConstructor(children) => children.iter().find_map(|c| walk_first(c, f)),
         Expression::Collate { expr, .. } => walk_first(expr, f),
+        Expression::Raise { error_message, .. } => {
+            error_message.as_deref().and_then(|msg| walk_first(msg, f))
+        }
         // Leaf-like or scope-closing expressions. ScalarSubquery / Exists
         // intentionally terminate the walk — most callers want subqueries
         // treated as their own scope. Callers that need to recurse must

--- a/crates/vibesql-executor/src/select/executor/validation/column_refs.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/column_refs.rs
@@ -162,6 +162,12 @@ pub fn extract_column_refs(expr: &Expression, refs: &mut Vec<ColumnReference>) {
             extract_column_refs(expr, refs);
         }
 
+        Expression::Raise { error_message, .. } => {
+            if let Some(msg) = error_message {
+                extract_column_refs(msg, refs);
+            }
+        }
+
         // Terminals with no column references
         Expression::Literal(_)
         | Expression::Wildcard

--- a/crates/vibesql-executor/src/select/join/expression_mapper.rs
+++ b/crates/vibesql-executor/src/select/join/expression_mapper.rs
@@ -312,6 +312,12 @@ impl ExpressionMapper {
             Expression::Collate { expr, .. } => {
                 self.walk_expression(expr, tables, columns, resolvable);
             }
+
+            Expression::Raise { error_message, .. } => {
+                if let Some(msg) = error_message {
+                    self.walk_expression(msg, tables, columns, resolvable);
+                }
+            }
         }
     }
 }

--- a/crates/vibesql-executor/src/select/order/resolution.rs
+++ b/crates/vibesql-executor/src/select/order/resolution.rs
@@ -1416,6 +1416,14 @@ fn resolve_where_expression_with_schema(
             }
         }
 
+        // RAISE: resolve aliases inside the error-message expression.
+        Expression::Raise { action, error_message } => Expression::Raise {
+            action: *action,
+            error_message: error_message.as_ref().map(|msg| {
+                Box::new(resolve_where_expression_with_schema(msg, select_list, table_columns))
+            }),
+        },
+
         // Expressions that don't need alias resolution (pass through)
         Expression::Literal(_)
         | Expression::Wildcard
@@ -1732,6 +1740,11 @@ fn collect_aggregates_from_expr(
         }
         Expression::Collate { expr: inner, .. } => {
             collect_aggregates_from_expr(inner, aggregates);
+        }
+        Expression::Raise { error_message, .. } => {
+            if let Some(msg) = error_message {
+                collect_aggregates_from_expr(msg, aggregates);
+            }
         }
         Expression::MatchAgainst { .. } => {}
     }

--- a/crates/vibesql-executor/src/select/window/order_by.rs
+++ b/crates/vibesql-executor/src/select/window/order_by.rs
@@ -148,6 +148,12 @@ fn collect_window_functions_from_expression(
         Expression::Collate { expr, .. } => {
             collect_window_functions_from_expression(expr, window_functions);
         }
+
+        Expression::Raise { error_message, .. } => {
+            if let Some(msg) = error_message {
+                collect_window_functions_from_expression(msg, window_functions);
+            }
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -104,6 +104,7 @@ mod privilege_checker_tests;
 mod procedures;
 mod quantified_comparison_tests;
 mod query_timeout_tests;
+mod raise_trigger_tests;
 mod recursive_cte_tests;
 mod rowid_tests;
 mod scalar_subquery_basic_tests;

--- a/crates/vibesql-executor/src/tests/raise_trigger_tests.rs
+++ b/crates/vibesql-executor/src/tests/raise_trigger_tests.rs
@@ -1,0 +1,268 @@
+//! Execution tests for the SQLite `RAISE()` trigger-program expression (#5409).
+//!
+//! Verified against sqlite3 3.51.x:
+//! - `RAISE(ABORT, msg)` / `RAISE(FAIL, msg)` / `RAISE(ROLLBACK, msg)` abort the
+//!   firing statement and report `msg` (SQLite error code 19); the message is
+//!   surfaced verbatim.
+//! - `RAISE(IGNORE)` abandons just the current row and continues with no error.
+//!
+//! Because VibeSQL evaluates a statement's row set and *then* applies it (the
+//! BEFORE trigger loop runs before any mutation), a single aborting statement
+//! leaves the table unchanged for all of ABORT/FAIL/ROLLBACK — the distinction
+//! between their rollback scopes is exercised by the parser/AST layer and the
+//! per-variant error mapping; broader multi-statement transaction-scope
+//! differences are tracked as a follow-on.
+
+use vibesql_ast::Statement;
+use vibesql_parser::Parser;
+use vibesql_types::SqlValue;
+
+use super::super::*;
+use crate::errors::ExecutorError;
+
+/// Execute setup SQL that is expected to succeed.
+fn exec_ok(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Failed to parse {:?}: {:?}", sql, e));
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+        }
+        Statement::CreateTrigger(s) => {
+            crate::advanced_objects::execute_create_trigger(&s, db)
+                .expect("CREATE TRIGGER failed");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT failed");
+        }
+        Statement::Update(s) => {
+            UpdateExecutor::execute(&s, db).expect("UPDATE failed");
+        }
+        Statement::Delete(s) => {
+            DeleteExecutor::execute(&s, db).expect("DELETE failed");
+        }
+        other => panic!("Unsupported setup statement: {:?}", other),
+    }
+}
+
+/// Execute a DML statement and return the Result so the caller can assert on a
+/// RAISE-driven error.
+fn exec_dml(
+    db: &mut vibesql_storage::Database,
+    sql: &str,
+) -> Result<usize, ExecutorError> {
+    let stmt = Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Failed to parse {:?}: {:?}", sql, e));
+    match stmt {
+        Statement::Insert(s) => InsertExecutor::execute(db, &s),
+        Statement::Update(s) => UpdateExecutor::execute(&s, db),
+        Statement::Delete(s) => DeleteExecutor::execute(&s, db),
+        other => panic!("Expected DML, got {:?}", other),
+    }
+}
+
+/// Read column `col` of every row in `table`, ordered by physical position.
+fn column_values(
+    db: &vibesql_storage::Database,
+    table: &str,
+    col: &str,
+) -> Vec<SqlValue> {
+    let schema = db.catalog.get_table(table).expect("table exists");
+    let idx = schema.columns.iter().position(|c| c.name == col).expect("column exists");
+    db.get_table(table)
+        .expect("table exists")
+        .scan()
+        .iter()
+        .map(|row| row.values[idx].clone())
+        .collect()
+}
+
+fn ints(db: &vibesql_storage::Database, table: &str, col: &str) -> Vec<i64> {
+    column_values(db, table, col)
+        .into_iter()
+        .map(|v| match v {
+            SqlValue::Integer(i) => i,
+            SqlValue::Bigint(i) => i,
+            other => panic!("expected integer, got {:?}", other),
+        })
+        .collect()
+}
+
+fn new_db_with_table() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)");
+    exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (1, 10)");
+    exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (2, 20)");
+    exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (3, 30)");
+    db
+}
+
+#[test]
+fn raise_abort_aborts_update_with_message() {
+    let mut db = new_db_with_table();
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg BEFORE UPDATE ON t WHEN NEW.v > 100 \
+         BEGIN SELECT raise(ABORT, 'value too big'); END",
+    );
+
+    let result = exec_dml(&mut db, "UPDATE t SET v = 200 WHERE id = 2");
+    match result {
+        Err(ExecutorError::Raise { action, message }) => {
+            assert_eq!(action, vibesql_ast::RaiseAction::Abort);
+            assert_eq!(message, "value too big");
+        }
+        other => panic!("expected RAISE(ABORT) error, got {:?}", other),
+    }
+
+    // The aborted statement made no change: row 2 keeps v=20.
+    assert_eq!(ints(&db, "t", "v"), vec![10, 20, 30]);
+}
+
+#[test]
+fn raise_abort_message_is_surfaced_verbatim() {
+    // SQLite reports the message text directly (no "constraint" prefix).
+    let mut db = new_db_with_table();
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg BEFORE UPDATE ON t \
+         BEGIN SELECT raise(ABORT, 'custom error text'); END",
+    );
+
+    let err = exec_dml(&mut db, "UPDATE t SET v = 99 WHERE id = 1").unwrap_err();
+    // Display should be exactly the rendered message.
+    assert_eq!(err.to_string(), "custom error text");
+}
+
+#[test]
+fn raise_abort_coerces_non_string_message_to_text() {
+    // SQLite coerces the message to text (integer 42 -> "42").
+    let mut db = new_db_with_table();
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg BEFORE UPDATE ON t \
+         BEGIN SELECT raise(ABORT, 42); END",
+    );
+
+    let err = exec_dml(&mut db, "UPDATE t SET v = 99 WHERE id = 1").unwrap_err();
+    assert_eq!(err.to_string(), "42");
+}
+
+#[test]
+fn raise_fail_aborts_with_message() {
+    let mut db = new_db_with_table();
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg BEFORE UPDATE ON t WHEN NEW.v > 100 \
+         BEGIN SELECT raise(FAIL, 'fail msg'); END",
+    );
+
+    match exec_dml(&mut db, "UPDATE t SET v = 200 WHERE id = 2") {
+        Err(ExecutorError::Raise { action, message }) => {
+            assert_eq!(action, vibesql_ast::RaiseAction::Fail);
+            assert_eq!(message, "fail msg");
+        }
+        other => panic!("expected RAISE(FAIL) error, got {:?}", other),
+    }
+}
+
+#[test]
+fn raise_rollback_aborts_with_message() {
+    let mut db = new_db_with_table();
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg BEFORE UPDATE ON t WHEN NEW.v > 100 \
+         BEGIN SELECT raise(ROLLBACK, 'undo all'); END",
+    );
+
+    match exec_dml(&mut db, "UPDATE t SET v = 200 WHERE id = 2") {
+        Err(ExecutorError::Raise { action, message }) => {
+            assert_eq!(action, vibesql_ast::RaiseAction::Rollback);
+            assert_eq!(message, "undo all");
+        }
+        other => panic!("expected RAISE(ROLLBACK) error, got {:?}", other),
+    }
+    // No row changed.
+    assert_eq!(ints(&db, "t", "v"), vec![10, 20, 30]);
+}
+
+#[test]
+fn raise_ignore_skips_only_the_matching_update_row() {
+    let mut db = new_db_with_table();
+    // Skip the row whose NEW value would be the sentinel 999, update the rest.
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg BEFORE UPDATE ON t WHEN NEW.v = 999 \
+         BEGIN SELECT raise(IGNORE); END",
+    );
+
+    // Row 2 maps to 999 (ignored); rows 1 and 3 get +100. No error.
+    let affected = exec_dml(
+        &mut db,
+        "UPDATE t SET v = CASE WHEN id = 2 THEN 999 ELSE v + 100 END",
+    )
+    .expect("RAISE(IGNORE) must not error");
+
+    // Rows 1 and 3 updated; row 2 unchanged at 20.
+    assert_eq!(ints(&db, "t", "v"), vec![110, 20, 130]);
+    // The ignored row is not counted as affected.
+    assert_eq!(affected, 2, "ignored row must not be counted as updated");
+}
+
+#[test]
+fn raise_ignore_skips_only_the_matching_insert_row() {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg BEFORE INSERT ON t WHEN NEW.v = 999 \
+         BEGIN SELECT raise(IGNORE); END",
+    );
+
+    exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (1, 10)");
+    // This insert is ignored by the trigger.
+    exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (2, 999)")
+        .expect("RAISE(IGNORE) must not error");
+    exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (3, 30)");
+
+    // Only rows 1 and 3 made it in.
+    assert_eq!(ints(&db, "t", "id"), vec![1, 3]);
+    assert_eq!(ints(&db, "t", "v"), vec![10, 30]);
+}
+
+#[test]
+fn raise_ignore_skips_only_the_matching_delete_row() {
+    let mut db = new_db_with_table();
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg BEFORE DELETE ON t WHEN OLD.v = 20 \
+         BEGIN SELECT raise(IGNORE); END",
+    );
+
+    // Attempt to delete everything; row 2 (v=20) is protected by IGNORE.
+    let affected = exec_dml(&mut db, "DELETE FROM t").expect("RAISE(IGNORE) must not error");
+
+    assert_eq!(ints(&db, "t", "id"), vec![2]);
+    assert_eq!(affected, 2, "only the non-ignored rows are deleted/counted");
+}
+
+#[test]
+fn raise_abort_in_insert_trigger_aborts() {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg BEFORE INSERT ON t WHEN NEW.v < 0 \
+         BEGIN SELECT raise(ABORT, 'no negatives'); END",
+    );
+
+    match exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (1, -5)") {
+        Err(ExecutorError::Raise { action, message }) => {
+            assert_eq!(action, vibesql_ast::RaiseAction::Abort);
+            assert_eq!(message, "no negatives");
+        }
+        other => panic!("expected RAISE(ABORT), got {:?}", other),
+    }
+    // Nothing inserted.
+    assert!(db.get_table("t").unwrap().scan().is_empty());
+}

--- a/crates/vibesql-executor/src/trigger_execution.rs
+++ b/crates/vibesql-executor/src/trigger_execution.rs
@@ -114,6 +114,24 @@ impl<'a> TriggerContext<'a> {
     }
 }
 
+/// Outcome of firing a trigger (or set of triggers) for a row.
+///
+/// `RAISE(IGNORE)` inside a trigger body asks SQLite to abandon the current
+/// row's DML operation without raising an error and continue with the rest of
+/// the statement. The trigger firing functions translate the internal
+/// [`ExecutorError::RaiseIgnore`] signal into [`TriggerOutcome::SkipRow`] so the
+/// DML caller can drop that row; every other (real) error still propagates via
+/// `Err`. `RAISE(ABORT|FAIL|ROLLBACK, ..)` are *not* represented here — they are
+/// genuine aborts and propagate as [`ExecutorError::Raise`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TriggerOutcome {
+    /// Triggers completed normally; the DML operation should proceed.
+    Proceed,
+    /// A `RAISE(IGNORE)` fired; the current row should be skipped, and the
+    /// surrounding statement should continue with the next row.
+    SkipRow,
+}
+
 /// Helper struct for trigger firing (execution during DML operations)
 pub struct TriggerFirer;
 
@@ -198,7 +216,7 @@ impl TriggerFirer {
         trigger: &TriggerDefinition,
         old_row: Option<&Row>,
         new_row: Option<&Row>,
-    ) -> Result<(), ExecutorError> {
+    ) -> Result<TriggerOutcome, ExecutorError> {
         // 1. Evaluate WHEN condition (if present)
         if let Some(when_expr) = &trigger.when_condition {
             let condition_result = Self::evaluate_when_condition(
@@ -211,14 +229,12 @@ impl TriggerFirer {
 
             // Skip trigger execution if WHEN condition is false
             if !condition_result {
-                return Ok(());
+                return Ok(TriggerOutcome::Proceed);
             }
         }
 
         // 2. Execute trigger action
-        Self::execute_trigger_action(db, trigger, old_row, new_row)?;
-
-        Ok(())
+        Self::execute_trigger_action(db, trigger, old_row, new_row)
     }
 
     /// Evaluate WHEN condition for a trigger
@@ -286,7 +302,7 @@ impl TriggerFirer {
         trigger: &TriggerDefinition,
         old_row: Option<&Row>,
         new_row: Option<&Row>,
-    ) -> Result<(), ExecutorError> {
+    ) -> Result<TriggerOutcome, ExecutorError> {
         // Extract SQL from trigger action
         let sql = match &trigger.triggered_action {
             vibesql_ast::TriggerAction::RawSql(sql) => sql.clone(),
@@ -309,12 +325,19 @@ impl TriggerFirer {
         // Create trigger context for OLD/NEW pseudo-variable resolution
         let trigger_context = TriggerContext { old_row, new_row, table_schema: &schema };
 
-        // Execute each statement in the trigger body with trigger context
+        // Execute each statement in the trigger body with trigger context.
+        // A RAISE(IGNORE) inside any statement abandons the rest of this
+        // trigger's action for the current row and asks the caller to skip the
+        // row (SQLite semantics), without raising a user-visible error.
         for statement in statements {
-            Self::execute_statement(db, &statement, &trigger_context)?;
+            match Self::execute_statement(db, &statement, &trigger_context) {
+                Ok(()) => {}
+                Err(ExecutorError::RaiseIgnore) => return Ok(TriggerOutcome::SkipRow),
+                Err(e) => return Err(e),
+            }
         }
 
-        Ok(())
+        Ok(TriggerOutcome::Proceed)
     }
 
     /// Build a pseudo TableSchema from a view definition for trigger OLD/NEW column resolution
@@ -463,7 +486,7 @@ impl TriggerFirer {
         event: TriggerEvent,
         old_row: Option<&Row>,
         new_row: Option<&Row>,
-    ) -> Result<(), ExecutorError> {
+    ) -> Result<TriggerOutcome, ExecutorError> {
         // Check recursion depth before executing any triggers
         let _guard = RecursionGuard::new()?;
 
@@ -486,11 +509,16 @@ impl TriggerFirer {
                     }
                 }
 
-                Self::execute_trigger(db, &trigger, old_row, new_row)?;
+                // A RAISE(IGNORE) in any trigger abandons the current row.
+                if Self::execute_trigger(db, &trigger, old_row, new_row)?
+                    == TriggerOutcome::SkipRow
+                {
+                    return Ok(TriggerOutcome::SkipRow);
+                }
             }
         }
 
-        Ok(())
+        Ok(TriggerOutcome::Proceed)
     }
 
     /// Execute all BEFORE STATEMENT-level triggers for an operation
@@ -506,7 +534,7 @@ impl TriggerFirer {
         db: &mut Database,
         table_name: &str,
         event: TriggerEvent,
-    ) -> Result<(), ExecutorError> {
+    ) -> Result<TriggerOutcome, ExecutorError> {
         // Check recursion depth before executing any triggers
         let _guard = RecursionGuard::new()?;
 
@@ -516,11 +544,13 @@ impl TriggerFirer {
             // Only execute STATEMENT-level triggers in this method
             if trigger.granularity == TriggerGranularity::Statement {
                 // Statement-level triggers don't have OLD/NEW row access
-                Self::execute_trigger(db, &trigger, None, None)?;
+                if Self::execute_trigger(db, &trigger, None, None)? == TriggerOutcome::SkipRow {
+                    return Ok(TriggerOutcome::SkipRow);
+                }
             }
         }
 
-        Ok(())
+        Ok(TriggerOutcome::Proceed)
     }
 
     /// Execute all AFTER ROW-level triggers for an operation
@@ -540,7 +570,7 @@ impl TriggerFirer {
         event: TriggerEvent,
         old_row: Option<&Row>,
         new_row: Option<&Row>,
-    ) -> Result<(), ExecutorError> {
+    ) -> Result<TriggerOutcome, ExecutorError> {
         // Check recursion depth before executing any triggers
         let _guard = RecursionGuard::new()?;
 
@@ -563,11 +593,15 @@ impl TriggerFirer {
                     }
                 }
 
-                Self::execute_trigger(db, &trigger, old_row, new_row)?;
+                if Self::execute_trigger(db, &trigger, old_row, new_row)?
+                    == TriggerOutcome::SkipRow
+                {
+                    return Ok(TriggerOutcome::SkipRow);
+                }
             }
         }
 
-        Ok(())
+        Ok(TriggerOutcome::Proceed)
     }
 
     /// Execute all AFTER STATEMENT-level triggers for an operation
@@ -583,7 +617,7 @@ impl TriggerFirer {
         db: &mut Database,
         table_name: &str,
         event: TriggerEvent,
-    ) -> Result<(), ExecutorError> {
+    ) -> Result<TriggerOutcome, ExecutorError> {
         // Check recursion depth before executing any triggers
         let _guard = RecursionGuard::new()?;
 
@@ -593,10 +627,12 @@ impl TriggerFirer {
             // Only execute STATEMENT-level triggers in this method
             if trigger.granularity == TriggerGranularity::Statement {
                 // Statement-level triggers don't have OLD/NEW row access
-                Self::execute_trigger(db, &trigger, None, None)?;
+                if Self::execute_trigger(db, &trigger, None, None)? == TriggerOutcome::SkipRow {
+                    return Ok(TriggerOutcome::SkipRow);
+                }
             }
         }
 
-        Ok(())
+        Ok(TriggerOutcome::Proceed)
     }
 }

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -588,17 +588,24 @@ pub(super) fn execute_internal(
         }
     }
 
-    // Fire BEFORE UPDATE triggers for all rows (before database mutation)
+    // Fire BEFORE UPDATE triggers for all rows (before database mutation).
+    // A RAISE(IGNORE) in a BEFORE UPDATE trigger abandons that row: drop it
+    // from the batch so it is neither updated nor counted (SQLite semantics).
     if has_triggers {
-        for u in &updates {
-            crate::TriggerFirer::execute_before_triggers(
+        let mut keep = Vec::with_capacity(updates.len());
+        for u in updates {
+            let outcome = crate::TriggerFirer::execute_before_triggers(
                 database,
                 table_name,
                 vibesql_ast::TriggerEvent::Update(None),
                 Some(&u.old_row),
                 Some(&u.new_row),
             )?;
+            if outcome != crate::TriggerOutcome::SkipRow {
+                keep.push(u);
+            }
         }
+        updates = keep;
     }
 
     // Step 8: Apply all updates (after evaluation phase completes)
@@ -910,6 +917,14 @@ fn validate_expression(
 
         // Collate
         Expression::Collate { expr, .. } => validate_expression(expr, schema, database),
+
+        // RAISE: validate the error-message expression if present
+        Expression::Raise { error_message, .. } => {
+            if let Some(msg) = error_message {
+                validate_expression(msg, schema, database)?;
+            }
+            Ok(())
+        }
 
         // POSITION
         Expression::Position { substring, string, .. } => {

--- a/crates/vibesql-executor/src/update/from_clause.rs
+++ b/crates/vibesql-executor/src/update/from_clause.rs
@@ -601,6 +601,13 @@ fn substitute_pseudo_vars(
             expr: Box::new(substitute_pseudo_vars(inner, trigger_context)?),
             collation: collation.clone(),
         },
+        Expression::Raise { action, error_message } => Expression::Raise {
+            action: *action,
+            error_message: match error_message {
+                Some(msg) => Some(Box::new(substitute_pseudo_vars(msg, trigger_context)?)),
+                None => None,
+            },
+        },
     })
 }
 

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -81,6 +81,14 @@ impl Parser {
         self.advance(); // consume '('
         let first = function_name;
 
+        // Special case for RAISE(ABORT|FAIL|ROLLBACK, msg) and RAISE(IGNORE).
+        // SQLite's trigger-program error/abort expression. The first argument is
+        // one of the conflict-resolution keywords (not a normal expression), so
+        // it cannot go through the generic argument loop.
+        if first.to_uppercase() == "RAISE" {
+            return Ok(Some(self.parse_raise_expression()?));
+        }
+
         // Special case for VALUES(column) - MySQL ON DUPLICATE KEY UPDATE
         // Returns the value that would have been inserted
         if first.to_uppercase() == "VALUES" {
@@ -423,5 +431,54 @@ impl Parser {
             }
             Ok(Some(vibesql_ast::Expression::Function { name: func_id, args, character_unit }))
         }
+    }
+
+    /// Parse a `RAISE(...)` trigger-program expression.
+    ///
+    /// The opening `RAISE` identifier and the `(` have already been consumed.
+    /// Accepts SQLite's four forms:
+    /// - `RAISE(ABORT, error-message)`
+    /// - `RAISE(FAIL, error-message)`
+    /// - `RAISE(ROLLBACK, error-message)`
+    /// - `RAISE(IGNORE)`
+    ///
+    /// The error-message is required for ABORT/FAIL/ROLLBACK and forbidden for
+    /// IGNORE (matching SQLite, which reports a `near ","`/`near ")"` syntax
+    /// error for the mismatched forms).
+    fn parse_raise_expression(
+        &mut self,
+    ) -> Result<vibesql_ast::Expression, ParseError> {
+        use vibesql_ast::RaiseAction;
+
+        // First argument: one of the conflict-resolution keywords.
+        let action = match self.peek() {
+            Token::Keyword { keyword: Keyword::Abort, .. } => RaiseAction::Abort,
+            Token::Keyword { keyword: Keyword::Fail, .. } => RaiseAction::Fail,
+            Token::Keyword { keyword: Keyword::Rollback, .. } => RaiseAction::Rollback,
+            Token::Keyword { keyword: Keyword::Ignore, .. } => RaiseAction::Ignore,
+            other => {
+                return Err(ParseError {
+                    message: format!(
+                        "near \"{}\": syntax error (expected ABORT, FAIL, ROLLBACK, or IGNORE in RAISE())",
+                        other
+                    ),
+                });
+            }
+        };
+        self.advance(); // consume the action keyword
+
+        let error_message = if matches!(action, RaiseAction::Ignore) {
+            // RAISE(IGNORE) takes no message.
+            self.expect_token(Token::RParen)?;
+            None
+        } else {
+            // RAISE(ABORT|FAIL|ROLLBACK, error-message) requires a message.
+            self.expect_token(Token::Comma)?;
+            let message = self.parse_expression()?;
+            self.expect_token(Token::RParen)?;
+            Some(Box::new(message))
+        };
+
+        Ok(vibesql_ast::Expression::Raise { action, error_message })
     }
 }

--- a/crates/vibesql-parser/src/tests/mod.rs
+++ b/crates/vibesql-parser/src/tests/mod.rs
@@ -35,6 +35,7 @@ mod pragma;
 mod predicates;
 mod prepared;
 mod quantified;
+mod raise;
 mod revoke;
 mod role;
 mod routines;

--- a/crates/vibesql-parser/src/tests/raise.rs
+++ b/crates/vibesql-parser/src/tests/raise.rs
@@ -1,0 +1,144 @@
+//! Tests for parsing the SQLite `RAISE()` trigger-program expression (#5409).
+//!
+//! SQLite accepts four forms inside a trigger body:
+//! - `RAISE(ABORT, error-message)`
+//! - `RAISE(FAIL, error-message)`
+//! - `RAISE(ROLLBACK, error-message)`
+//! - `RAISE(IGNORE)` (no message)
+//!
+//! VibeSQL parses `RAISE()` as a general expression (the trigger-context gate
+//! is enforced at evaluation time), so we can exercise it through a standalone
+//! `SELECT raise(...)`.
+
+use vibesql_ast::{Expression, RaiseAction, SelectItem, Statement};
+
+use crate::Parser;
+
+/// Parse `SELECT <expr>` and return the single projected expression.
+fn parse_select_expr(sql: &str) -> Expression {
+    let stmt = Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Failed to parse {:?}: {:?}", sql, e));
+    let select = match stmt {
+        Statement::Select(s) => s,
+        other => panic!("Expected SELECT, got {:?}", other),
+    };
+    assert_eq!(select.select_list.len(), 1, "expected a single projection");
+    match &select.select_list[0] {
+        SelectItem::Expression { expr, .. } => expr.clone(),
+        other => panic!("Expected a projected expression, got {:?}", other),
+    }
+}
+
+#[test]
+fn parses_raise_abort_with_message() {
+    let expr = parse_select_expr("SELECT raise(ABORT, 'boom')");
+    match expr {
+        Expression::Raise { action, error_message } => {
+            assert_eq!(action, RaiseAction::Abort);
+            let msg = error_message.expect("ABORT requires a message");
+            assert!(
+                matches!(*msg, Expression::Literal(_)),
+                "expected literal message, got {:?}",
+                msg
+            );
+        }
+        other => panic!("Expected Raise, got {:?}", other),
+    }
+}
+
+#[test]
+fn parses_raise_fail_with_message() {
+    let expr = parse_select_expr("SELECT raise(FAIL, 'nope')");
+    match expr {
+        Expression::Raise { action, error_message } => {
+            assert_eq!(action, RaiseAction::Fail);
+            assert!(error_message.is_some());
+        }
+        other => panic!("Expected Raise, got {:?}", other),
+    }
+}
+
+#[test]
+fn parses_raise_rollback_with_message() {
+    let expr = parse_select_expr("SELECT raise(ROLLBACK, 'undo all')");
+    match expr {
+        Expression::Raise { action, error_message } => {
+            assert_eq!(action, RaiseAction::Rollback);
+            assert!(error_message.is_some());
+        }
+        other => panic!("Expected Raise, got {:?}", other),
+    }
+}
+
+#[test]
+fn parses_raise_ignore_without_message() {
+    let expr = parse_select_expr("SELECT raise(IGNORE)");
+    match expr {
+        Expression::Raise { action, error_message } => {
+            assert_eq!(action, RaiseAction::Ignore);
+            assert!(error_message.is_none(), "IGNORE takes no message");
+        }
+        other => panic!("Expected Raise, got {:?}", other),
+    }
+}
+
+#[test]
+fn raise_is_case_insensitive() {
+    // The RAISE keyword and the action keyword are both case-insensitive.
+    let expr = parse_select_expr("SELECT RaIsE(aBoRt, 'x')");
+    assert!(matches!(
+        expr,
+        Expression::Raise { action: RaiseAction::Abort, error_message: Some(_) }
+    ));
+}
+
+#[test]
+fn raise_message_can_be_an_expression() {
+    // SQLite allows any expression as the message, e.g. concatenation with a
+    // pseudo-variable inside a trigger.
+    let expr = parse_select_expr("SELECT raise(ABORT, 'bad: ' || NEW.v)");
+    match expr {
+        Expression::Raise { action, error_message } => {
+            assert_eq!(action, RaiseAction::Abort);
+            let msg = error_message.expect("message present");
+            assert!(
+                matches!(*msg, Expression::BinaryOp { .. }),
+                "expected a binary (concat) message, got {:?}",
+                msg
+            );
+        }
+        other => panic!("Expected Raise, got {:?}", other),
+    }
+}
+
+#[test]
+fn raise_ignore_with_message_is_rejected() {
+    // SQLite reports a `near ","` syntax error for RAISE(IGNORE, ...).
+    let result = Parser::parse_sql("SELECT raise(IGNORE, 'msg')");
+    assert!(result.is_err(), "RAISE(IGNORE, ...) must be a parse error");
+}
+
+#[test]
+fn raise_abort_without_message_is_rejected() {
+    // SQLite reports a `near ")"` syntax error for RAISE(ABORT).
+    let result = Parser::parse_sql("SELECT raise(ABORT)");
+    assert!(result.is_err(), "RAISE(ABORT) without a message must be a parse error");
+}
+
+#[test]
+fn raise_with_unknown_action_is_rejected() {
+    let result = Parser::parse_sql("SELECT raise(SOMETHING, 'x')");
+    assert!(result.is_err(), "RAISE with a non-action keyword must be a parse error");
+}
+
+#[test]
+fn raise_inside_trigger_body_parses() {
+    // The whole point of #5409: a trigger whose body uses RAISE must parse
+    // (previously failed with `near "ABORT": syntax error`). The body is
+    // stored as RawSql, so just assert the CREATE TRIGGER parses.
+    let sql = "CREATE TRIGGER t BEFORE UPDATE ON tbl WHEN NEW.v > 100 \
+               BEGIN SELECT raise(ABORT, 'value too big'); END";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "trigger with RAISE body failed to parse: {:?}", result.err());
+    assert!(matches!(result.unwrap(), Statement::CreateTrigger(_)));
+}

--- a/crates/vibesql-storage/src/persistence/binary/expression/mod.rs
+++ b/crates/vibesql-storage/src/persistence/binary/expression/mod.rs
@@ -78,6 +78,7 @@ enum ExprTag {
     RowValueConstructor = 0x23,
     Collate = 0x24,
     Glob = 0x25,
+    Raise = 0x26,
 }
 
 impl ExprTag {
@@ -121,6 +122,7 @@ impl ExprTag {
             0x23 => Ok(ExprTag::RowValueConstructor),
             0x24 => Ok(ExprTag::Collate),
             0x25 => Ok(ExprTag::Glob),
+            0x26 => Ok(ExprTag::Raise),
             _ => {
                 Err(StorageError::NotImplemented(format!("Unknown expression tag: 0x{:02X}", tag)))
             }
@@ -448,6 +450,22 @@ pub fn write_expression<W: Write>(writer: &mut W, expr: &Expression) -> Result<(
             write_expression(writer, expr)?;
             write_string(writer, collation)?;
         }
+        Expression::Raise { action, error_message } => {
+            write_tag!(writer, ExprTag::Raise);
+            write_u8(
+                writer,
+                match action {
+                    vibesql_ast::RaiseAction::Ignore => 0,
+                    vibesql_ast::RaiseAction::Abort => 1,
+                    vibesql_ast::RaiseAction::Fail => 2,
+                    vibesql_ast::RaiseAction::Rollback => 3,
+                },
+            )?;
+            write_bool(writer, error_message.is_some())?;
+            if let Some(msg) = error_message {
+                write_expression(writer, msg)?;
+            }
+        }
     }
     Ok(())
 }
@@ -733,6 +751,24 @@ pub fn read_expression<R: Read>(reader: &mut R) -> Result<Expression, StorageErr
             let collation = read_string(reader)?;
             Ok(Expression::Collate { expr: Box::new(expr), collation })
         }
+        ExprTag::Raise => {
+            let action = match read_u8(reader)? {
+                0 => vibesql_ast::RaiseAction::Ignore,
+                1 => vibesql_ast::RaiseAction::Abort,
+                2 => vibesql_ast::RaiseAction::Fail,
+                3 => vibesql_ast::RaiseAction::Rollback,
+                other => {
+                    return Err(StorageError::NotImplemented(format!(
+                        "Unknown RAISE action tag: {}",
+                        other
+                    )))
+                }
+            };
+            let has_message = read_bool(reader)?;
+            let error_message =
+                if has_message { Some(Box::new(read_expression(reader)?)) } else { None };
+            Ok(Expression::Raise { action, error_message })
+        }
     }
 }
 
@@ -806,6 +842,36 @@ mod tests {
                 result: Expression::Literal(SqlValue::Integer(1)),
             }],
             else_result: Some(Box::new(Expression::Literal(SqlValue::Integer(0)))),
+        };
+        let mut buf = Vec::new();
+        write_expression(&mut buf, &expr).unwrap();
+
+        let mut reader = &buf[..];
+        let result = read_expression(&mut reader).unwrap();
+        assert_eq!(result, expr);
+    }
+
+    #[test]
+    fn test_raise_with_message_roundtrip() {
+        let expr = Expression::Raise {
+            action: vibesql_ast::RaiseAction::Abort,
+            error_message: Some(Box::new(Expression::Literal(SqlValue::Varchar(
+                arcstr::ArcStr::from("boom"),
+            )))),
+        };
+        let mut buf = Vec::new();
+        write_expression(&mut buf, &expr).unwrap();
+
+        let mut reader = &buf[..];
+        let result = read_expression(&mut reader).unwrap();
+        assert_eq!(result, expr);
+    }
+
+    #[test]
+    fn test_raise_ignore_roundtrip() {
+        let expr = Expression::Raise {
+            action: vibesql_ast::RaiseAction::Ignore,
+            error_message: None,
         };
         let mut buf = Vec::new();
         write_expression(&mut buf, &expr).unwrap();


### PR DESCRIPTION
## Summary

Adds SQLite's `RAISE()` trigger-program expression, which VibeSQL's parser previously rejected with `near "ABORT": syntax error`. Because of that gap, the #5407 create-time trigger validation had to stay scoped to NULLS-only (a blanket parse-gate would have wrongly rejected valid RAISE-bearing triggers).

Closes #5409

## AST / parse approach

- New `Expression::Raise { action: RaiseAction, error_message: Option<Box<Expression>> }` variant in `vibesql-ast` (with `RaiseAction = Ignore | Abort | Fail | Rollback`).
- Parsed via a `RAISE(...)` special case in the standard function-call parser (`crates/vibesql-parser/src/parser/expressions/functions/mod.rs`), since the first argument is a conflict-resolution keyword, not a normal expression. The message is **required** for ABORT/FAIL/ROLLBACK and **forbidden** for IGNORE — matching sqlite3 3.51.x, which reports a `near ","` / `near ")"` syntax error for the mismatched forms.
- RAISE is parsed generally and gated at evaluation (accept-and-error), the approach the issue sanctioned. sqlite3 instead parse-errors RAISE outside a trigger (`RAISE() may only be used within a trigger-program`); VibeSQL surfaces it at eval time instead. (Documented divergence; follow-on below.)

## Per-variant rollback-scope semantics (verified vs sqlite3 3.51.0)

| Variant | sqlite3 behavior | VibeSQL mapping |
|---|---|---|
| `RAISE(ABORT, msg)` | Rolls back the current **statement**; prior statements in the txn persist. Error 19, message verbatim. | `ExecutorError::Raise{Abort, msg}`. BEFORE-trigger fires before the batch apply, so the aborting statement makes no change. |
| `RAISE(FAIL, msg)` | Stops the statement but **keeps** changes already made to earlier rows in that statement. Error 19. | `ExecutorError::Raise{Fail, msg}`. |
| `RAISE(ROLLBACK, msg)` | Rolls back the **whole transaction**. Error 19. | `ExecutorError::Raise{Rollback, msg}`. |
| `RAISE(IGNORE)` | Abandons just the **current row**, continues, **no error**. | `ExecutorError::RaiseIgnore` -> `TriggerOutcome::SkipRow`; INSERT/UPDATE/DELETE row loops drop just that row and continue. |

Message coercion matches sqlite3: integer `42` -> `"42"`, `NULL` -> `""`.

Note on ABORT vs FAIL distinction at statement scope: VibeSQL evaluates a statement's row set and then applies it (BEFORE triggers fire before any mutation), so a single aborting statement leaves the table unchanged for all of ABORT/FAIL/ROLLBACK. The per-variant *multi-statement transaction-scope* differences are tracked as a follow-on; the action is carried precisely through the AST and error so the distinction can be honored once statement/txn rollback is threaded.

## Replication determinism

RAISE reads no clock / RNG / session state, so it is non-volatile by construction (it is its own AST variant, not a `Function`). A RAISE-bearing trigger body passes the #5396/#5381 volatility validator and replicates verbatim; the abort is deterministic on every node. The expression walker still descends into the RAISE message, so a volatile call *inside* the message (e.g. `'r=' || random()`) is rejected. RAISE is also marked non-deterministic-for-cache, so it is never CSE-cached, constant-folded, or used as an index expression.

## Interaction with #5407

Not broadening the #5407 create-time gate in this PR (deferred per the #5407 judge's note) — filed as a follow-on.

## Test plan

- [x] Parser: all four RAISE forms parse; case-insensitivity; `RAISE(IGNORE, msg)` / `RAISE(ABORT)` / unknown-action are parse errors; trigger body with RAISE parses (`crates/vibesql-parser/src/tests/raise.rs`).
- [x] Executor: ABORT/FAIL/ROLLBACK abort with the verbatim message; non-string message coerced to text; IGNORE skips only the matching row across INSERT/UPDATE/DELETE and is excluded from affected-row counts (`crates/vibesql-executor/src/tests/raise_trigger_tests.rs`).
- [x] Consensus freeze: RAISE trigger bodies admitted; volatile RAISE message rejected (`crates/vibesql-consensus/src/freeze.rs`).
- [x] Storage: RAISE expression binary roundtrip.
- [x] `cargo test -p vibesql-ast -p vibesql-parser -p vibesql-executor` green; `-p vibesql-consensus -p vibesql-storage -p vibesql-catalog` green; clippy clean on touched crates.
- TCL: `trigger1.test` / `triggerC.test` contain RAISE cases that now parse (full TCL run not exercised here).

## Follow-ons

1. Match sqlite3's parse-time rejection of RAISE outside a trigger-program (currently errors at eval time).
2. Honor per-variant transaction-scope differences (ABORT vs FAIL vs ROLLBACK) for multi-statement transactions.
3. Resolve `OLD.`/`NEW.` pseudo-vars inside a trigger-body `SELECT` (so a RAISE message like `'bad: ' || NEW.v` works at fire time; currently only WHEN clauses resolve them).
4. Broaden the #5407 create-time validation gate now that RAISE parses.
5. Wire `TriggerOutcome::SkipRow` through the CASCADE / INSTEAD-OF trigger paths (`update/triggers.rs`, the direct `execute_trigger` call sites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)