### PR TITLE
feat(server): route HTTP /api/query + CRUD-create writes through consensus

### DIFF
--- a/crates/vibesql-server/src/http/crud.rs
+++ b/crates/vibesql-server/src/http/crud.rs
@@ -48,7 +48,7 @@ use serde_json::{json, Value as JsonValue};
 use tracing::{debug, error};
 
 use super::{
-    rest::{get_database_name, HttpState},
+    rest::{execution_error_response, get_database_name, HttpState},
     types::*,
 };
 use crate::registry::SharedDatabase;
@@ -395,20 +395,17 @@ pub async fn list_rows(
 ) -> impl IntoResponse {
     debug!("CRUD: GET /api/tables/{}/rows with params: {:?}", table_name, params);
 
-    // The CRUD surface executes against the local registry database, which
-    // receives no replicated writes — gate it in replicated mode (#5393).
-    if let Some((code, body)) = state.replicated_gate("the CRUD API") {
-        return (code, body).into_response();
-    }
-
     // Get the database name from headers
     let db_name = get_database_name(&headers);
 
     // Get or create the shared database from the registry
     let shared_db = state.registry.get_or_create(&db_name).await;
 
-    // Check if table exists
-    {
+    // Table-existence pre-check reads the local registry schema, which is only
+    // populated in standalone mode. In replicated mode the schema lives in the
+    // consensus state machine, so skip the local check and let the read against
+    // the state machine report a missing table (#5410).
+    if !state.is_replicated() {
         let db = shared_db.read().await;
         let table_names = db.list_tables();
         if !table_names.iter().any(|t| t.eq_ignore_ascii_case(&table_name)) {
@@ -424,8 +421,9 @@ pub async fn list_rows(
     let sql = build_select_sql(&table_name, &params);
     debug!("CRUD: Executing SQL: {}", sql);
 
-    let mut session =
-        crate::session::Session::new(db_name.clone(), "http_user".to_string(), shared_db);
+    // Replicated session in replicated mode (read runs against the state
+    // machine per the session's read-consistency mode); local otherwise.
+    let mut session = state.session(&db_name, shared_db);
 
     match session.execute(&sql).await {
         Ok(crate::session::ExecutionResult::Select { rows, columns }) => {
@@ -444,8 +442,7 @@ pub async fn list_rows(
             .into_response(),
         Err(e) => {
             error!("Query execution failed: {}", e);
-            (StatusCode::BAD_REQUEST, Json(ErrorResponse::new(format!("Query failed: {}", e))))
-                .into_response()
+            execution_error_response(&e)
         }
     }
 }
@@ -459,7 +456,7 @@ pub async fn get_row(
 ) -> impl IntoResponse {
     debug!("CRUD: GET /api/tables/{}/rows/{}", table_name, id);
 
-    if let Some((code, body)) = state.replicated_gate("the CRUD API") {
+    if let Some((code, body)) = state.replicated_gate("the CRUD by-id API (resolving the primary key needs schema introspection through consensus)") {
         return (code, body).into_response();
     }
 
@@ -531,10 +528,6 @@ pub async fn create_row(
 ) -> impl IntoResponse {
     debug!("CRUD: POST /api/tables/{}/rows with body: {:?}", table_name, body);
 
-    if let Some((code, gate_body)) = state.replicated_gate("the CRUD API") {
-        return (code, gate_body).into_response();
-    }
-
     if body.values.is_empty() {
         return (
             StatusCode::BAD_REQUEST,
@@ -549,8 +542,11 @@ pub async fn create_row(
     // Get or create the shared database from the registry
     let shared_db = state.registry.get_or_create(&db_name).await;
 
-    // Check if table exists
-    {
+    // The table-existence pre-check reads the local registry schema (only
+    // populated in standalone mode). In replicated mode the schema lives in
+    // the consensus state machine, so skip it and let the consensus INSERT
+    // report a missing table deterministically (#5410).
+    if !state.is_replicated() {
         let db = shared_db.read().await;
         let table_names = db.list_tables();
         if !table_names.iter().any(|t| t.eq_ignore_ascii_case(&table_name)) {
@@ -566,8 +562,10 @@ pub async fn create_row(
     let sql = build_insert_sql(&table_name, &body.values);
     debug!("CRUD: Executing SQL: {}", sql);
 
-    let mut session =
-        crate::session::Session::new(db_name.clone(), "http_user".to_string(), shared_db);
+    // Replicated session in replicated mode: the INSERT proposes through
+    // consensus (leader-only); a write on a follower surfaces as 421 with a
+    // leader hint. Local session otherwise.
+    let mut session = state.session(&db_name, shared_db);
 
     match session.execute(&sql).await {
         Ok(crate::session::ExecutionResult::Insert { rows_affected }) => {
@@ -580,8 +578,7 @@ pub async fn create_row(
             .into_response(),
         Err(e) => {
             error!("Insert failed: {}", e);
-            (StatusCode::BAD_REQUEST, Json(ErrorResponse::new(format!("Insert failed: {}", e))))
-                .into_response()
+            execution_error_response(&e)
         }
     }
 }
@@ -595,7 +592,7 @@ pub async fn update_row(
 ) -> impl IntoResponse {
     debug!("CRUD: PUT /api/tables/{}/rows/{} with body: {:?}", table_name, id, body);
 
-    if let Some((code, gate_body)) = state.replicated_gate("the CRUD API") {
+    if let Some((code, gate_body)) = state.replicated_gate("the CRUD by-id API (resolving the primary key needs schema introspection through consensus)") {
         return (code, gate_body).into_response();
     }
 
@@ -669,7 +666,7 @@ pub async fn patch_row(
 ) -> impl IntoResponse {
     debug!("CRUD: PATCH /api/tables/{}/rows/{} with body: {:?}", table_name, id, body);
 
-    if let Some((code, gate_body)) = state.replicated_gate("the CRUD API") {
+    if let Some((code, gate_body)) = state.replicated_gate("the CRUD by-id API (resolving the primary key needs schema introspection through consensus)") {
         return (code, gate_body).into_response();
     }
 
@@ -742,7 +739,7 @@ pub async fn delete_row(
 ) -> impl IntoResponse {
     debug!("CRUD: DELETE /api/tables/{}/rows/{}", table_name, id);
 
-    if let Some((code, body)) = state.replicated_gate("the CRUD API") {
+    if let Some((code, body)) = state.replicated_gate("the CRUD by-id API (resolving the primary key needs schema introspection through consensus)") {
         return (code, body).into_response();
     }
 

--- a/crates/vibesql-server/src/http/rest.rs
+++ b/crates/vibesql-server/src/http/rest.rs
@@ -19,11 +19,18 @@ use super::{graphql, types::*};
 use crate::{
     observability::ServerMetrics,
     registry::DatabaseRegistry,
-    replication::{role_str, ReplicationHandle},
+    replication::{
+        role_str, ReplicationHandle, SqlError, SQLSTATE_FATAL, SQLSTATE_NOT_LEADER, SQLSTATE_RETRY,
+    },
+    session::Session,
     subscription::{
         detect_pk_columns_from_stmt, SelectiveColumnConfig, SubscriptionManager, SubscriptionUpdate,
     },
 };
+
+/// Response header carrying the leader hint on a `421 Misdirected Request`
+/// (the HTTP equivalent of the wire path's NOT_LEADER redirect, #5410).
+pub const LEADER_HINT_HEADER: &str = "X-VibeSQL-Leader";
 
 /// Pagination configuration
 #[derive(Debug, Clone)]
@@ -67,18 +74,53 @@ pub struct HttpState {
     pub metrics: Option<ServerMetrics>,
     /// Consensus handle when the server runs in replicated mode (#5393).
     ///
-    /// Present only in replicated mode. The HTTP REST/GraphQL/subscription
-    /// surface executes against the local registry database, which does NOT
-    /// receive replicated writes — so in replicated mode those paths are
-    /// gated (see [`replicated_gate`]) to refuse with a clear error rather
-    /// than silently read stale data or accept a write that never
-    /// replicates. `/health` uses it to report node role/writability. Full
-    /// routing of HTTP writes/subscriptions through consensus is follow-on
-    /// #5410.
+    /// Present only in replicated mode. Surfaces that have been wired through
+    /// consensus (#5410 — the `/api/query` endpoint and the CRUD collection
+    /// endpoints) build a **replicated** session via [`Self::session`], so
+    /// writes propose through this handle (leader-only, freeze-at-propose)
+    /// and reads run against the replicated state machine — never against the
+    /// unreplicated local registry database. Surfaces that still depend on
+    /// local-database schema/state introspection (CRUD by-id, GraphQL,
+    /// subscriptions, blob storage) remain gated (see [`Self::replicated_gate`])
+    /// to a clear error rather than silently reading stale data or accepting a
+    /// write that never replicates; those are tracked as follow-ons to #5410.
+    /// `/health` uses the handle to report node role/writability.
     pub replication: Option<StdArc<ReplicationHandle>>,
 }
 
 impl HttpState {
+    /// Whether this server runs in replicated mode.
+    pub(crate) fn is_replicated(&self) -> bool {
+        self.replication.is_some()
+    }
+
+    /// Build the session for an HTTP request against `db_name`.
+    ///
+    /// In replicated mode this returns a **replicated** session
+    /// ([`Session::new_replicated`]): writes propose through consensus
+    /// (leader-only, freeze-at-propose) and reads run against the replicated
+    /// state machine per the session's read-consistency mode — the local
+    /// `shared_db` is retained only for API compatibility and is never
+    /// executed against. In standalone mode it returns the ordinary
+    /// local-executor session, leaving standalone behavior untouched. This is
+    /// the single choke point that keeps every replicated HTTP write going
+    /// through consensus (the split-brain invariant, #5410).
+    pub(crate) fn session(
+        &self,
+        db_name: &str,
+        shared_db: crate::registry::SharedDatabase,
+    ) -> Session {
+        match &self.replication {
+            Some(handle) => Session::new_replicated(
+                db_name.to_string(),
+                "http_user".to_string(),
+                shared_db,
+                StdArc::clone(handle),
+            ),
+            None => Session::new(db_name.to_string(), "http_user".to_string(), shared_db),
+        }
+    }
+
     /// `Some(error_response)` when this request hits a surface that is not
     /// yet coherent in replicated mode and must be refused; `None` in
     /// standalone mode (where every path is sound). Returning a `503` with
@@ -102,6 +144,78 @@ impl HttpState {
             )
         })
     }
+}
+
+/// Map an execution error to an HTTP response, translating a structured
+/// consensus [`SqlError`] (the replicated-write path's NOT_LEADER / staleness
+/// / FATAL surface) onto idiomatic HTTP semantics (#5410). The mapping mirrors
+/// the wire path's SQLSTATEs:
+///
+/// - **NotLeader** (`25006`) → **421 Misdirected Request** with the leader hint
+///   in the [`LEADER_HINT_HEADER`] response header (and the detail/hint in the
+///   body). 421 is the HTTP "you reached the wrong node, retarget" status — the
+///   HTTP-shaped equivalent of the wire redirect contract. The leader address
+///   lets a client redirect without re-probing the cluster.
+/// - **StalenessExceeded / ReadTimeout** (`57P03`) → **503 Service Unavailable**
+///   with `Retry-After: 1` — a retryable "can't serve this right now".
+/// - **FatalApply** (`58000`) → **503 Service Unavailable** — this node halted
+///   and must be restarted to resync.
+/// - **Any other structured SqlError** → **500 Internal Server Error**.
+/// - **A plain (non-structured) executor error** — e.g. a deterministic
+///   constraint/SQL rejection, identical on every replica — → **400 Bad
+///   Request** with the SQL error message, the same status standalone uses.
+pub(crate) fn execution_error_response(err: &anyhow::Error) -> axum::response::Response {
+    use axum::http::HeaderValue;
+
+    let Some(sql_error) = err.downcast_ref::<SqlError>() else {
+        // Not a consensus refusal: a deterministic SQL/constraint error (or
+        // any standalone executor error). 400, exactly like standalone.
+        return (StatusCode::BAD_REQUEST, Json(ErrorResponse::new(err.to_string())))
+            .into_response();
+    };
+
+    let body = Json(ErrorResponse {
+        error: sql_error_message(sql_error),
+        code: Some(sql_error.code.to_string()),
+    });
+
+    match sql_error.code {
+        SQLSTATE_NOT_LEADER => {
+            // 421 Misdirected Request: wrong node, retarget to the leader.
+            let mut resp = (StatusCode::MISDIRECTED_REQUEST, body).into_response();
+            if let Some(detail) = &sql_error.detail {
+                if let Ok(value) = HeaderValue::from_str(detail) {
+                    resp.headers_mut().insert(LEADER_HINT_HEADER, value);
+                }
+            }
+            resp
+        }
+        // Retryable: staleness/RYW timeout or a halted node.
+        SQLSTATE_RETRY | SQLSTATE_FATAL => {
+            let mut resp = (StatusCode::SERVICE_UNAVAILABLE, body).into_response();
+            resp.headers_mut().insert("Retry-After", HeaderValue::from_static("1"));
+            resp
+        }
+        // Any other structured error (internal_error catch-all, etc.).
+        _ => (StatusCode::INTERNAL_SERVER_ERROR, body).into_response(),
+    }
+}
+
+/// Flatten a [`SqlError`]'s message + detail + hint into one human-readable
+/// string for the JSON error body (HTTP has no separate DETAIL/HINT fields
+/// the way the PostgreSQL wire protocol does).
+fn sql_error_message(e: &SqlError) -> String {
+    let mut msg = e.message.clone();
+    if let Some(detail) = &e.detail {
+        msg.push_str(" — ");
+        msg.push_str(detail);
+    }
+    if let Some(hint) = &e.hint {
+        msg.push_str(" (");
+        msg.push_str(hint);
+        msg.push(')');
+    }
+    msg
 }
 
 /// Create the HTTP API router
@@ -549,13 +663,11 @@ async fn execute_query(
 ) -> impl IntoResponse {
     debug!("Executing query: {} (limit: {:?}, offset: {:?})", req.sql, req.limit, req.offset);
 
-    // The /api/query surface executes against the local registry database,
-    // which receives no replicated writes — a write would never replicate
-    // and a read would silently return stale/empty data. Gate it in
-    // replicated mode and point clients at the wire protocol (#5393).
-    if let Some((code, body)) = state.replicated_gate("the /api/query endpoint") {
-        return (code, body).into_response();
-    }
+    // In replicated mode this builds a replicated session (#5410): writes
+    // propose through consensus (leader-only, freeze-at-propose), reads run
+    // against the replicated state machine, and a write on a follower surfaces
+    // as 421 with a leader hint — never executed against the unreplicated
+    // local database. In standalone mode it is the ordinary local session.
 
     // Convert JSON parameters to SqlValue
     let params = match req.to_sql_values() {
@@ -576,9 +688,8 @@ async fn execute_query(
     // Get or create the shared database from the registry
     let shared_db = state.registry.get_or_create(&db_name).await;
 
-    // Create a session with the shared database
-    let mut session =
-        crate::session::Session::new(db_name.clone(), "http_user".to_string(), shared_db);
+    // Create a session — replicated when the server is in replicated mode.
+    let mut session = state.session(&db_name, shared_db);
 
     // Execute the query
     let result = if params.is_empty() {
@@ -636,11 +747,10 @@ async fn execute_query(
         }
         Err(e) => {
             error!("Query execution failed: {}", e);
-            (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse::new(format!("Query execution failed: {}", e))),
-            )
-                .into_response()
+            // Map a consensus refusal (NotLeader → 421 + leader hint, staleness
+            // / FATAL → 503) or a deterministic SQL rejection (→ 400) to the
+            // right HTTP status (#5410).
+            execution_error_response(&e)
         }
     }
 }

--- a/crates/vibesql-server/tests/replication_tests.rs
+++ b/crates/vibesql-server/tests/replication_tests.rs
@@ -1140,33 +1140,248 @@ async fn http_health_reports_leader_and_follower() {
     assert_eq!(body["replication"]["leader_id"], handles[leader].node_id());
 }
 
-/// In replicated mode the HTTP query/CRUD/subscription surface is gated to
-/// a clear 503 (it would otherwise execute against the unreplicated local
-/// database) — never silent wrong behavior.
+/// In replicated mode the HTTP `/api/query` endpoint routes writes through
+/// consensus (#5410): a `POST /api/query` INSERT on the leader lands in the
+/// consensus state machine and a subsequent SELECT reads it back from there
+/// (not the unreplicated local database).
 #[tokio::test]
-async fn http_query_surface_gated_in_replicated_mode() {
+async fn http_query_writes_route_through_consensus() {
     let (handles, _dir) = boot_cluster(1).await;
     wait_for_leader(&handles).await;
     let (base, _tx) = start_http(Some(Arc::clone(&handles[0]))).await;
-
     let client = reqwest::Client::new();
+
+    let post_sql = |sql: &str| {
+        let client = client.clone();
+        let base = base.clone();
+        let body = serde_json::json!({ "sql": sql }).to_string();
+        async move {
+            client
+                .post(format!("{base}/api/query"))
+                .header("content-type", "application/json")
+                .body(body)
+                .send()
+                .await
+                .unwrap()
+        }
+    };
+
+    // DDL + DML route through consensus.
+    assert!(post_sql("CREATE TABLE http_t (id INT, name VARCHAR(100))")
+        .await
+        .status()
+        .is_success());
+    let resp = post_sql("INSERT INTO http_t VALUES (1, 'Alice')").await;
+    assert_eq!(resp.status(), reqwest::StatusCode::CREATED);
+
+    // The write is in the consensus state machine, not the local database.
+    assert_eq!(
+        handles[0].node().query("SELECT COUNT(*) FROM http_t").unwrap()[0][0].to_string(),
+        "1"
+    );
+
+    // A SELECT reads it back through the replicated state machine.
+    let resp = post_sql("SELECT id, name FROM http_t").await;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+    assert_eq!(body["row_count"], 1, "the replicated read must see the row");
+}
+
+/// A deterministic SQL rejection over `/api/query` in replicated mode (one
+/// that every replica rejects identically, e.g. inserting into a missing
+/// table) surfaces as HTTP 400 — not a 503/421 consensus refusal (#5410).
+#[tokio::test]
+async fn http_query_deterministic_rejection_is_400() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let (base, _tx) = start_http(Some(Arc::clone(&handles[0]))).await;
+    let client = reqwest::Client::new();
+
     let resp = client
         .post(format!("{base}/api/query"))
         .header("content-type", "application/json")
-        .body(r#"{"sql":"SELECT 1"}"#)
+        .body(r#"{"sql":"INSERT INTO no_such_table VALUES (1)"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::BAD_REQUEST);
+}
+
+/// A CRUD collection write (`POST /api/tables/{t}/rows`) routes through
+/// consensus in replicated mode (#5410): the row lands in the state machine.
+#[tokio::test]
+async fn http_crud_create_routes_through_consensus() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let (base, _tx) = start_http(Some(Arc::clone(&handles[0]))).await;
+    let client = reqwest::Client::new();
+
+    // Schema via /api/query (also replicated).
+    let resp = client
+        .post(format!("{base}/api/query"))
+        .header("content-type", "application/json")
+        .body(r#"{"sql":"CREATE TABLE crud_t (id INT, name VARCHAR(100))"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+
+    // CRUD create proposes through consensus.
+    let resp = client
+        .post(format!("{base}/api/tables/crud_t/rows"))
+        .header("content-type", "application/json")
+        .body(r#"{"id":7,"name":"Carol"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::CREATED);
+
+    // The row is in the consensus state machine.
+    assert_eq!(
+        handles[0].node().query("SELECT name FROM crud_t WHERE id = 7").unwrap()[0][0].to_string(),
+        "Carol"
+    );
+}
+
+/// An HTTP write on a **follower** is refused with `421 Misdirected Request`
+/// carrying the leader hint in the `X-VibeSQL-Leader` header — the HTTP
+/// equivalent of the wire path's NOT_LEADER redirect (#5410). It must never
+/// be executed against the follower's local database.
+#[tokio::test]
+async fn http_write_on_follower_redirects_with_leader_hint() {
+    let (handles, _dir) = boot_cluster(3).await;
+    let leader = wait_for_leader(&handles).await;
+
+    // Create the table through the leader.
+    replicated_session(&handles[leader]).execute("CREATE TABLE redir (id INT)").await.unwrap();
+    let leader_id = handles[leader].node_id();
+
+    // Pick a follower that knows who leads (so the hint is populated).
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    let follower = loop {
+        if let Some(i) = handles
+            .iter()
+            .position(|h| h.role() == Role::Follower && h.node().current_leader().is_some())
+        {
+            break i;
+        }
+        assert!(tokio::time::Instant::now() < deadline, "timed out waiting for a follower");
+        tokio::time::sleep(POLL_INTERVAL).await;
+    };
+
+    let (base, _tx) = start_http(Some(Arc::clone(&handles[follower]))).await;
+    let client = reqwest::Client::new();
+
+    // /api/query write on the follower → 421 + leader hint header.
+    let resp = client
+        .post(format!("{base}/api/query"))
+        .header("content-type", "application/json")
+        .body(r#"{"sql":"INSERT INTO redir VALUES (1)"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::MISDIRECTED_REQUEST);
+    let leader_hint = resp
+        .headers()
+        .get("X-VibeSQL-Leader")
+        .expect("leader-hint header")
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(leader_hint.contains(&format!("node {leader_id}")), "{leader_hint}");
+    let body: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+    assert_eq!(body["code"], "25006", "the body carries the NOT_LEADER SQLSTATE");
+
+    // CRUD create on the follower → same 421 contract.
+    let resp = client
+        .post(format!("{base}/api/tables/redir/rows"))
+        .header("content-type", "application/json")
+        .body(r#"{"id":2}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::MISDIRECTED_REQUEST);
+}
+
+/// An HTTP write replicates to a second node (#5410): after a `POST /api/query`
+/// INSERT on the leader's HTTP port, every follower converges to the row.
+#[tokio::test]
+async fn http_write_replicates_to_followers() {
+    let (handles, _dir) = boot_cluster(3).await;
+    let leader = wait_for_leader(&handles).await;
+    let (base, _tx) = start_http(Some(Arc::clone(&handles[leader]))).await;
+    let client = reqwest::Client::new();
+
+    for sql in [
+        "CREATE TABLE repl_http (id INT)",
+        "INSERT INTO repl_http VALUES (1)",
+        "INSERT INTO repl_http VALUES (2)",
+    ] {
+        let resp = client
+            .post(format!("{base}/api/query"))
+            .header("content-type", "application/json")
+            .body(serde_json::json!({ "sql": sql }).to_string())
+            .send()
+            .await
+            .unwrap();
+        assert!(resp.status().is_success(), "{sql}: {}", resp.status());
+    }
+
+    // Every follower converges to both rows.
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    for (i, h) in handles.iter().enumerate() {
+        if i == leader {
+            continue;
+        }
+        loop {
+            let count = h
+                .node()
+                .query("SELECT COUNT(*) FROM repl_http")
+                .ok()
+                .and_then(|r| r.first().and_then(|row| row.first()).map(ToString::to_string));
+            if count.as_deref() == Some("2") {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "follower {i} did not converge to 2 rows (saw {count:?})"
+            );
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+}
+
+/// In replicated mode the CRUD by-id, GraphQL, subscription, and blob-storage
+/// surfaces remain gated to a clear 503 (they depend on local-database schema
+/// /state introspection that is not yet wired through consensus — follow-ons
+/// to #5410). They must never silently execute against the local database.
+#[tokio::test]
+async fn http_unwired_surfaces_still_gated_in_replicated_mode() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let (base, _tx) = start_http(Some(Arc::clone(&handles[0]))).await;
+    let client = reqwest::Client::new();
+
+    // CRUD by-id (needs primary-key schema introspection).
+    let resp = client.get(format!("{base}/api/tables/t/rows/1")).send().await.unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+
+    // GraphQL.
+    let resp = client
+        .post(format!("{base}/api/graphql"))
+        .header("content-type", "application/json")
+        .body(r#"{"query":"{ __typename }"}"#)
         .send()
         .await
         .unwrap();
     assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
 
-    // CRUD writes are gated too.
-    let resp = client
-        .post(format!("{base}/api/tables/t/rows"))
-        .header("content-type", "application/json")
-        .body(r#"{"id":1}"#)
-        .send()
-        .await
-        .unwrap();
+    // Subscriptions.
+    let resp = client.get(format!("{base}/api/subscribe?query=SELECT%201")).send().await.unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+
+    // Blob storage.
+    let resp = client.get(format!("{base}/api/storage/anything")).send().await.unwrap();
     assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
 }
 


### PR DESCRIPTION
Part of #5410.

## Summary

Removes the replicated-mode 503 gate from the HTTP write paths that can be routed soundly today and wires them through consensus, mapping consensus refusals onto idiomatic HTTP. Surfaces that depend on local-database schema/state introspection stay gated with clear errors and dedicated follow-ons.

**Wired through consensus (gate removed):**
- `POST /api/query` — INSERT/UPDATE/DELETE/DDL propose through consensus; SELECT reads the replicated state machine per the session read-consistency mode.
- `GET /api/tables/{t}/rows` (CRUD list) and `POST /api/tables/{t}/rows` (CRUD create).

**Still gated (follow-ons):**
- CRUD by-id GET/PUT/PATCH/DELETE → #5420 (needs PK schema introspection through consensus).
- GraphQL → #5421 (schema/relationship introspection).
- SSE subscriptions + blob storage → #5422 (change feed from applied consensus entries; the hardest part).

## Design / split-brain invariant

A single choke point, `HttpState::session(db_name, shared_db)`, returns a **replicated** session (`Session::new_replicated`) in replicated mode and the ordinary local session in standalone mode. A replicated session never executes against the local registry DB — writes propose through the `ReplicationHandle` (leader-only, freeze-at-propose) and reads run against the consensus state machine, exactly mirroring the wire-session path. No HTTP write can execute locally on a replicated node outside consensus. Standalone mode is entirely unchanged (all routing is behind `Option<ReplicationHandle>`).

## HTTP status mapping for consensus errors

| Consensus error | SQLSTATE | HTTP |
|---|---|---|
| `NotLeader` | 25006 | **421 Misdirected Request** + `X-VibeSQL-Leader` hint header (+ body code/detail) |
| `StalenessExceeded` / `ReadTimeout` | 57P03 | **503** + `Retry-After: 1` (retryable) |
| `FatalApply` | 58000 | **503** |
| other structured `SqlError` | XX000 | **500** |
| deterministic SQL/constraint rejection (non-structured) | — | **400** (as standalone) |

421 is the HTTP-shaped equivalent of the wire path's NOT_LEADER redirect — "wrong node, retarget to the leader" — carrying the leader address so a client redirects without re-probing the cluster.

## Reads / consistency

Replicated HTTP reads run through the replicated session, which defaults to local (stale-allowed) reads. Per-request read-consistency selection over HTTP (mirroring the `vibesql_read_consistency` session setting, #5200) is not added here; reads remain local-by-default and documented. Note: the replicated SELECT path returns placeholder column names (`col0`, `col1`, ...) — the same limitation the wire SELECT path has today (the state machine does not yet resolve column names); data is correct.

## Test plan / evidence

`cargo test -p vibesql-server` — all suites green (417 lib + integration suites; `replication_tests` 32 passed). New tests in `replication_tests.rs`:

- [x] `http_query_writes_route_through_consensus` — `/api/query` INSERT lands in the state machine; SELECT reads it back.
- [x] `http_crud_create_routes_through_consensus` — CRUD POST lands in the state machine.
- [x] `http_write_replicates_to_followers` — multi-node: HTTP INSERT on the leader converges on every follower.
- [x] `http_write_on_follower_redirects_with_leader_hint` — follower write → 421 + `X-VibeSQL-Leader` + body code 25006 (both `/api/query` and CRUD).
- [x] `http_query_deterministic_rejection_is_400` — INSERT into a missing table → 400 (not a consensus refusal).
- [x] `http_unwired_surfaces_still_gated_in_replicated_mode` — CRUD by-id / GraphQL / subscribe / storage still 503.
- [x] `http_standalone_unaffected` (existing guard) — standalone HTTP unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)