### PR TITLE
feat(parser): reject RAISE() outside trigger programs at parse time

### DIFF
--- a/crates/vibesql-executor/src/trigger_execution.rs
+++ b/crates/vibesql-executor/src/trigger_execution.rs
@@ -394,7 +394,12 @@ impl TriggerFirer {
         // BEGIN/END wrapper and drops empty / comment-only fragments.
         let mut statements = Vec::new();
         for stmt_sql in vibesql_parser::split_trigger_body_statements(sql) {
-            match vibesql_parser::Parser::parse_sql(&stmt_sql) {
+            // Parse each body statement as a trigger-program statement so
+            // `RAISE()` is admitted at fire time. SQLite only permits RAISE()
+            // within a trigger-program, so the general `parse_sql` entry point
+            // rejects it at parse time; a trigger body legitimately contains
+            // it (see `Parser::parse_sql_in_trigger_body`).
+            match vibesql_parser::Parser::parse_sql_in_trigger_body(&stmt_sql) {
                 Ok(stmt) => statements.push(stmt),
                 Err(e) => {
                     return Err(ExecutorError::UnsupportedExpression(format!(

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -450,6 +450,17 @@ impl Parser {
     ) -> Result<vibesql_ast::Expression, ParseError> {
         use vibesql_ast::RaiseAction;
 
+        // SQLite only permits RAISE() inside a trigger-program (a
+        // `CREATE TRIGGER` body) and rejects it at prepare/parse time
+        // everywhere else, e.g. `SELECT raise(ABORT, 'x')` ->
+        // `RAISE() may only be used within a trigger-program`. Match that:
+        // reject at parse time unless we are parsing a trigger body.
+        if !self.in_trigger_body {
+            return Err(ParseError {
+                message: "RAISE() may only be used within a trigger-program".to_string(),
+            });
+        }
+
         // First argument: one of the conflict-resolution keywords.
         let action = match self.peek() {
             Token::Keyword { keyword: Keyword::Abort, .. } => RaiseAction::Abort,

--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -51,12 +51,19 @@ pub struct Parser {
     /// Counter for placeholder parameters (?)
     /// Incremented each time a placeholder is parsed, providing 0-indexed parameter positions
     placeholder_count: usize,
+    /// Whether the parser is currently inside a `CREATE TRIGGER` body
+    /// (a trigger-program). SQLite only permits the `RAISE()` expression
+    /// within a trigger-program and rejects it at prepare/parse time
+    /// elsewhere; this flag lets [`Parser::parse_raise_expression`] accept
+    /// `RAISE()` inside a trigger body and reject it everywhere else,
+    /// matching sqlite3 (`RAISE() may only be used within a trigger-program`).
+    in_trigger_body: bool,
 }
 
 impl Parser {
     /// Create a new parser from tokens
     pub fn new(tokens: Vec<Token>) -> Self {
-        Parser { tokens, position: 0, placeholder_count: 0 }
+        Parser { tokens, position: 0, placeholder_count: 0, in_trigger_body: false }
     }
 
     /// Parse a comma-separated list of items using a provided parser function
@@ -105,6 +112,29 @@ impl Parser {
             lexer.tokenize().map_err(|e| ParseError { message: format!("Lexer error: {}", e) })?;
 
         let mut parser = Parser::new(tokens);
+        parser.parse_statement()
+    }
+
+    /// Parse a single SQL statement that originates from a `CREATE TRIGGER`
+    /// body (a trigger-program).
+    ///
+    /// This is identical to [`Parser::parse_sql`] except that the parser is
+    /// marked as being inside a trigger body, so the `RAISE()` expression is
+    /// accepted (SQLite only permits `RAISE()` within a trigger-program and
+    /// rejects it at parse time everywhere else). Both the create-time
+    /// validation pass ([`Parser::validate_trigger_body`]) and the executor's
+    /// fire-time re-parse (`TriggerFirer::parse_trigger_sql`) must use this
+    /// entry point so a trigger body containing `RAISE()` is admitted on both
+    /// paths.
+    pub fn parse_sql_in_trigger_body(
+        input: &str,
+    ) -> Result<vibesql_ast::Statement, ParseError> {
+        let mut lexer = Lexer::new(input);
+        let tokens =
+            lexer.tokenize().map_err(|e| ParseError { message: format!("Lexer error: {}", e) })?;
+
+        let mut parser = Parser::new(tokens);
+        parser.in_trigger_body = true;
         parser.parse_statement()
     }
 

--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -124,7 +124,15 @@ impl Parser {
             } else {
                 false
             };
-            let expr = self.parse_expression()?;
+            // The WHEN condition is part of the trigger-program, so SQLite
+            // permits RAISE() there too. Mark the parser as inside a trigger
+            // body for the duration of the WHEN expression so RAISE() is
+            // admitted (it is rejected at parse time everywhere else).
+            let prev_in_trigger_body = self.in_trigger_body;
+            self.in_trigger_body = true;
+            let expr_result = self.parse_expression();
+            self.in_trigger_body = prev_in_trigger_body;
+            let expr = expr_result?;
             if has_paren {
                 self.expect_token(Token::RParen)?;
             }
@@ -241,7 +249,11 @@ impl Parser {
     /// (but SQLite accepts at create time) are preserved as before.
     fn validate_trigger_body(raw_sql: &str) -> Result<(), ParseError> {
         for stmt_sql in crate::split_trigger_body_statements(raw_sql) {
-            if let Err(e) = Self::parse_sql(&stmt_sql) {
+            // Parse each body statement as a trigger-program statement so
+            // `RAISE()` is admitted (SQLite only permits RAISE() within a
+            // trigger-program; `parse_sql` rejects it at parse time, but a
+            // trigger body legitimately contains it).
+            if let Err(e) = Self::parse_sql_in_trigger_body(&stmt_sql) {
                 if Self::is_create_time_rejection(&e) {
                     // Propagate verbatim so the message (e.g.
                     // `unsupported use of NULLS FIRST`) matches the

--- a/crates/vibesql-parser/src/tests/raise.rs
+++ b/crates/vibesql-parser/src/tests/raise.rs
@@ -1,4 +1,6 @@
-//! Tests for parsing the SQLite `RAISE()` trigger-program expression (#5409).
+//! Tests for parsing the SQLite `RAISE()` trigger-program expression
+//! (#5409 added RAISE; #5416 made it a parse-time error outside a
+//! trigger-program).
 //!
 //! SQLite accepts four forms inside a trigger body:
 //! - `RAISE(ABORT, error-message)`
@@ -6,17 +8,24 @@
 //! - `RAISE(ROLLBACK, error-message)`
 //! - `RAISE(IGNORE)` (no message)
 //!
-//! VibeSQL parses `RAISE()` as a general expression (the trigger-context gate
-//! is enforced at evaluation time), so we can exercise it through a standalone
-//! `SELECT raise(...)`.
+//! SQLite only permits `RAISE()` *within a trigger-program* (a
+//! `CREATE TRIGGER` body / WHEN condition) and rejects it at prepare/parse
+//! time everywhere else with `RAISE() may only be used within a
+//! trigger-program`. VibeSQL matches this: `RAISE()` parses inside a trigger
+//! body but is a parse error in any other context. These tests therefore
+//! exercise the four forms via [`Parser::parse_sql_in_trigger_body`] (the same
+//! entry point the create-time validation and fire-time re-parse use) and
+//! separately assert that `RAISE()` outside a trigger is rejected.
 
 use vibesql_ast::{Expression, RaiseAction, SelectItem, Statement};
 
 use crate::Parser;
 
-/// Parse `SELECT <expr>` and return the single projected expression.
-fn parse_select_expr(sql: &str) -> Expression {
-    let stmt = Parser::parse_sql(sql)
+/// Parse `SELECT <expr>` as a trigger-body statement and return the single
+/// projected expression. RAISE() is only legal inside a trigger-program, so
+/// the trigger-body entry point must be used.
+fn parse_trigger_body_select_expr(sql: &str) -> Expression {
+    let stmt = Parser::parse_sql_in_trigger_body(sql)
         .unwrap_or_else(|e| panic!("Failed to parse {:?}: {:?}", sql, e));
     let select = match stmt {
         Statement::Select(s) => s,
@@ -31,7 +40,7 @@ fn parse_select_expr(sql: &str) -> Expression {
 
 #[test]
 fn parses_raise_abort_with_message() {
-    let expr = parse_select_expr("SELECT raise(ABORT, 'boom')");
+    let expr = parse_trigger_body_select_expr("SELECT raise(ABORT, 'boom')");
     match expr {
         Expression::Raise { action, error_message } => {
             assert_eq!(action, RaiseAction::Abort);
@@ -48,7 +57,7 @@ fn parses_raise_abort_with_message() {
 
 #[test]
 fn parses_raise_fail_with_message() {
-    let expr = parse_select_expr("SELECT raise(FAIL, 'nope')");
+    let expr = parse_trigger_body_select_expr("SELECT raise(FAIL, 'nope')");
     match expr {
         Expression::Raise { action, error_message } => {
             assert_eq!(action, RaiseAction::Fail);
@@ -60,7 +69,7 @@ fn parses_raise_fail_with_message() {
 
 #[test]
 fn parses_raise_rollback_with_message() {
-    let expr = parse_select_expr("SELECT raise(ROLLBACK, 'undo all')");
+    let expr = parse_trigger_body_select_expr("SELECT raise(ROLLBACK, 'undo all')");
     match expr {
         Expression::Raise { action, error_message } => {
             assert_eq!(action, RaiseAction::Rollback);
@@ -72,7 +81,7 @@ fn parses_raise_rollback_with_message() {
 
 #[test]
 fn parses_raise_ignore_without_message() {
-    let expr = parse_select_expr("SELECT raise(IGNORE)");
+    let expr = parse_trigger_body_select_expr("SELECT raise(IGNORE)");
     match expr {
         Expression::Raise { action, error_message } => {
             assert_eq!(action, RaiseAction::Ignore);
@@ -85,7 +94,7 @@ fn parses_raise_ignore_without_message() {
 #[test]
 fn raise_is_case_insensitive() {
     // The RAISE keyword and the action keyword are both case-insensitive.
-    let expr = parse_select_expr("SELECT RaIsE(aBoRt, 'x')");
+    let expr = parse_trigger_body_select_expr("SELECT RaIsE(aBoRt, 'x')");
     assert!(matches!(
         expr,
         Expression::Raise { action: RaiseAction::Abort, error_message: Some(_) }
@@ -96,7 +105,7 @@ fn raise_is_case_insensitive() {
 fn raise_message_can_be_an_expression() {
     // SQLite allows any expression as the message, e.g. concatenation with a
     // pseudo-variable inside a trigger.
-    let expr = parse_select_expr("SELECT raise(ABORT, 'bad: ' || NEW.v)");
+    let expr = parse_trigger_body_select_expr("SELECT raise(ABORT, 'bad: ' || NEW.v)");
     match expr {
         Expression::Raise { action, error_message } => {
             assert_eq!(action, RaiseAction::Abort);
@@ -112,22 +121,31 @@ fn raise_message_can_be_an_expression() {
 }
 
 #[test]
+fn raise_in_subquery_inside_trigger_body_parses() {
+    // RAISE() nested in a subquery is still inside the trigger-program, so it
+    // is admitted (sqlite3 accepts `SELECT (SELECT raise(ABORT,'sub'))` in a
+    // trigger body).
+    let stmt = Parser::parse_sql_in_trigger_body("SELECT (SELECT raise(ABORT, 'sub'))");
+    assert!(stmt.is_ok(), "RAISE in a subquery inside a trigger body must parse: {:?}", stmt.err());
+}
+
+#[test]
 fn raise_ignore_with_message_is_rejected() {
     // SQLite reports a `near ","` syntax error for RAISE(IGNORE, ...).
-    let result = Parser::parse_sql("SELECT raise(IGNORE, 'msg')");
+    let result = Parser::parse_sql_in_trigger_body("SELECT raise(IGNORE, 'msg')");
     assert!(result.is_err(), "RAISE(IGNORE, ...) must be a parse error");
 }
 
 #[test]
 fn raise_abort_without_message_is_rejected() {
     // SQLite reports a `near ")"` syntax error for RAISE(ABORT).
-    let result = Parser::parse_sql("SELECT raise(ABORT)");
+    let result = Parser::parse_sql_in_trigger_body("SELECT raise(ABORT)");
     assert!(result.is_err(), "RAISE(ABORT) without a message must be a parse error");
 }
 
 #[test]
 fn raise_with_unknown_action_is_rejected() {
-    let result = Parser::parse_sql("SELECT raise(SOMETHING, 'x')");
+    let result = Parser::parse_sql_in_trigger_body("SELECT raise(SOMETHING, 'x')");
     assert!(result.is_err(), "RAISE with a non-action keyword must be a parse error");
 }
 
@@ -141,4 +159,50 @@ fn raise_inside_trigger_body_parses() {
     let result = Parser::parse_sql(sql);
     assert!(result.is_ok(), "trigger with RAISE body failed to parse: {:?}", result.err());
     assert!(matches!(result.unwrap(), Statement::CreateTrigger(_)));
+}
+
+#[test]
+fn raise_in_when_condition_parses() {
+    // The WHEN condition is part of the trigger-program, so SQLite permits
+    // RAISE() there too (sqlite3 accepts this at CREATE TRIGGER time).
+    let sql = "CREATE TRIGGER t BEFORE INSERT ON tbl WHEN raise(IGNORE) \
+               BEGIN SELECT 1; END";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "trigger with RAISE in WHEN failed to parse: {:?}", result.err());
+}
+
+// --- #5416: RAISE() outside a trigger-program is a parse-time error ---
+
+/// SQLite's exact error (sans the shell's `in prepare,` prefix).
+const RAISE_OUTSIDE_TRIGGER_MSG: &str = "RAISE() may only be used within a trigger-program";
+
+#[test]
+fn raise_outside_trigger_is_parse_error() {
+    // sqlite3 3.51.x: `SELECT raise(ABORT, 'x')` ->
+    // `in prepare, RAISE() may only be used within a trigger-program`.
+    let err = Parser::parse_sql("SELECT raise(ABORT, 'x')")
+        .expect_err("RAISE() outside a trigger must be a parse error");
+    assert_eq!(err.message, RAISE_OUTSIDE_TRIGGER_MSG);
+}
+
+#[test]
+fn raise_ignore_outside_trigger_is_parse_error() {
+    let err = Parser::parse_sql("SELECT raise(IGNORE)")
+        .expect_err("RAISE(IGNORE) outside a trigger must be a parse error");
+    assert_eq!(err.message, RAISE_OUTSIDE_TRIGGER_MSG);
+}
+
+#[test]
+fn raise_in_subquery_outside_trigger_is_parse_error() {
+    // sqlite3 rejects RAISE in a subquery outside a trigger at prepare time.
+    let err = Parser::parse_sql("SELECT (SELECT raise(ABORT, 'sub'))")
+        .expect_err("RAISE() in a subquery outside a trigger must be a parse error");
+    assert_eq!(err.message, RAISE_OUTSIDE_TRIGGER_MSG);
+}
+
+#[test]
+fn raise_in_where_outside_trigger_is_parse_error() {
+    let err = Parser::parse_sql("SELECT * FROM t WHERE raise(IGNORE)")
+        .expect_err("RAISE() in a WHERE outside a trigger must be a parse error");
+    assert_eq!(err.message, RAISE_OUTSIDE_TRIGGER_MSG);
 }

--- a/crates/vibesql-parser/src/tests/trigger.rs
+++ b/crates/vibesql-parser/src/tests/trigger.rs
@@ -471,10 +471,12 @@ fn test_create_trigger_body_nulls_in_conflict_target_rejected() {
 #[test]
 fn test_create_trigger_body_unparseable_construct_tolerated() {
     // VibeSQL's parser does not yet support every construct valid inside a
-    // SQLite trigger body (e.g. `RAISE(ABORT, …)`), and SQLite accepts those
-    // at CREATE TRIGGER time. Create-time validation must NOT hard-reject a
-    // body it merely cannot parse — the body is preserved as RawSql and
-    // re-parsed at fire time, exactly as before this validation existed.
+    // SQLite trigger body, and SQLite accepts those at CREATE TRIGGER time.
+    // Create-time validation must NOT hard-reject a body it merely cannot
+    // parse — the body is preserved as RawSql and re-parsed at fire time,
+    // exactly as before this validation existed. RAISE() (shown here) is now
+    // parseable in a trigger body (#5409/#5416), so this also guards that the
+    // create-time validation accepts a RAISE-bearing body.
     // (Regression guard for upsert1-1300, whose trigger body uses RAISE.)
     let sql = "CREATE TRIGGER tr2 BEFORE UPDATE ON t1 BEGIN \
                SELECT raise(ABORT, 'boom') WHERE old.y != new.y; \


### PR DESCRIPTION
## Summary
Match sqlite3 3.51.x: `RAISE()` is only legal inside a trigger-program and is rejected at parse time everywhere else. #5415 parsed `RAISE()` generally and surfaced the error at *evaluation* time; this moves the rejection to parse time with sqlite3's exact message.

## sqlite3 3.51.0 verified message
```
sqlite> SELECT raise(ABORT, 'x');
Error: in prepare, RAISE() may only be used within a trigger-program
```
The same `RAISE() may only be used within a trigger-program` is emitted for `SELECT raise(IGNORE)`, RAISE in a subquery (`SELECT (SELECT raise(...))`), and RAISE in a `WHERE`. VibeSQL now returns that exact core message (the shell's `in prepare,` prefix is sqlite's, not part of the prepare error text). RAISE inside a trigger body / `WHEN` is still accepted by sqlite3 and by VibeSQL.

## How trigger-body context is threaded to the parser
- New `Parser::in_trigger_body: bool` flag (default `false`).
- New `Parser::parse_sql_in_trigger_body(input)` entry point: identical to `parse_sql` but sets the flag.
- `parse_raise_expression` rejects `RAISE()` at parse time with `RAISE() may only be used within a trigger-program` unless `in_trigger_body` is set.
- Both trigger-body parse paths now use the new entry point so RAISE bodies stay admitted:
  - create-time validation `Parser::validate_trigger_body`
  - fire-time re-parse `TriggerFirer::parse_trigger_sql` (vibesql-executor)
- The `CREATE TRIGGER ... WHEN <expr>` condition is parsed with the flag temporarily set (sqlite permits RAISE in WHEN as part of the trigger-program).

No executor eval-path change: `RAISE` expressions can now only originate inside a trigger body, so the existing eval-time `Raise`/`RaiseIgnore` handling remains correct for in-trigger firing.

## Test evidence
- `cargo test -p vibesql-parser` — 1403 passed, 0 failed (incl. new `raise_outside_trigger_is_parse_error`, `raise_ignore_outside_trigger_is_parse_error`, `raise_in_subquery_outside_trigger_is_parse_error`, `raise_in_where_outside_trigger_is_parse_error`, all asserting the exact sqlite3 message; the four #5415 forms re-exercised via the trigger-body entry point; `raise_in_subquery_inside_trigger_body_parses`, `raise_in_when_condition_parses`).
- `cargo test -p vibesql-executor` — green, incl. all `raise_trigger_tests` (ABORT/FAIL/ROLLBACK abort, IGNORE row-skip across INSERT/UPDATE/DELETE) — the #5415 trigger regression suite still passes.
- `cargo test -p vibesql-consensus freeze` — green, incl. `raise_trigger_body_is_admitted` and `raise_message_with_volatile_call_is_rejected` (RAISE trigger bodies still admitted by the freeze validator).

## Test plan
- [x] RAISE outside a trigger rejected at parse with sqlite3's message
- [x] RAISE inside a trigger body still parses, validates at create time, and fires at eval time
- [x] RAISE in a subquery / WHEN inside a trigger admitted
- [x] vibesql-parser + vibesql-executor test suites green
- [x] consensus freeze tests green

Closes #5416

🤖 Generated with [Claude Code](https://claude.com/claude-code)