### PR TITLE
perf(storage): copy-on-write Operations snapshot for txn rollback

### DIFF
--- a/crates/vibesql-consensus/src/state_machine.rs
+++ b/crates/vibesql-consensus/src/state_machine.rs
@@ -1234,6 +1234,40 @@ mod tests {
         assert_eq!(machine.last_applied(), 1);
     }
 
+    /// #5419: a speculative read whose buffer contains no index-mutating
+    /// statements must NOT deep-clone the `Operations` (IndexManager)
+    /// rollback snapshot. Before #5419 the snapshot was eager, so the
+    /// scratch transaction every `speculative_query` opens cloned the
+    /// entire index manager per read — O(index-keys) per mid-txn read on a
+    /// replicated session. With copy-on-write the read-only scratch txn
+    /// triggers zero clones. Asserted deterministically via the clone
+    /// counter (no timing).
+    #[test]
+    fn read_only_speculative_query_does_not_clone_operations_snapshot() {
+        let machine = VibesqlStateMachine::new();
+        // Seed a committed row so the index manager is non-empty (an eager
+        // clone would be observable work).
+        create_users(&machine, 1);
+        machine.apply(2, &TxnEntry::single("INSERT INTO users VALUES (1, 'alice')")).unwrap();
+
+        let before = machine.inspect_db(|db| db.operations_snapshot_clones());
+
+        // Empty buffer => the scratch transaction only reads; it never
+        // mutates an index, so the COW snapshot is never taken.
+        let empty: [&str; 0] = [];
+        let rows = machine
+            .speculative_query(&TxnEntry::batch(empty), "SELECT name FROM users ORDER BY id")
+            .unwrap();
+        let seen: Vec<String> = rows.into_iter().map(|r| r[0].to_string()).collect();
+        assert_eq!(seen, vec!["alice"], "read-only speculative read sees committed state");
+
+        let after = machine.inspect_db(|db| db.operations_snapshot_clones());
+        assert_eq!(
+            after, before,
+            "a read-only speculative query must not deep-clone the Operations snapshot (#5419)"
+        );
+    }
+
     /// commit_ts = log index: every MVCC stamp written by entry `N`
     /// carries `xmin = N`. Only observable with the MVCC feature on
     /// (stamping is compiled out otherwise).

--- a/crates/vibesql-storage/src/database/core.rs
+++ b/crates/vibesql-storage/src/database/core.rs
@@ -132,6 +132,29 @@ impl Database {
         self.metadata.clear_routine_cache();
     }
 
+    /// Capture the copy-on-write `Operations` rollback snapshot before a
+    /// mutation, if a transaction is active (#5419).
+    ///
+    /// This is the **single chokepoint** for index/spatial-index mutation:
+    /// every code path that mutates `self.operations` must call this first
+    /// (it is invoked implicitly by [`Self::operations_mut`]). The lazy
+    /// `Operations` rollback snapshot (see
+    /// [`TransactionManager::ensure_operations_snapshot`]) is taken before
+    /// the *first* mutation inside a transaction, so it captures committed,
+    /// pre-mutation state and ROLLBACK restores it exactly — preserving the
+    /// #5413 correctness fix while skipping the clone entirely for
+    /// read-only transactions. Outside a transaction it is a cheap no-op.
+    ///
+    /// `ensure_operations_snapshot` borrows `self.operations` immutably and
+    /// `self.lifecycle` mutably; these are disjoint fields, so the call
+    /// compiles even though both are reached through `self`.
+    ///
+    /// [`TransactionManager::ensure_operations_snapshot`]: crate::database::transactions::TransactionManager::ensure_operations_snapshot
+    #[inline]
+    pub(super) fn snapshot_operations_for_mutation(&mut self) {
+        self.lifecycle.transaction_manager_mut().ensure_operations_snapshot(&self.operations);
+    }
+
     // NOTE: Other method groups are defined in their respective modules:
     // - Transaction methods: transaction_api.rs
     // - Table methods: table_api.rs

--- a/crates/vibesql-storage/src/database/index_ops.rs
+++ b/crates/vibesql-storage/src/database/index_ops.rs
@@ -139,6 +139,7 @@ impl Database {
         unique: bool,
         columns: Vec<IndexColumn>,
     ) -> Result<(), StorageError> {
+        self.snapshot_operations_for_mutation();
         self.operations.create_index(
             &self.catalog,
             &self.tables,
@@ -169,6 +170,7 @@ impl Database {
         where_clause: Box<vibesql_ast::Expression>,
         included_row_indices: &std::collections::HashSet<usize>,
     ) -> Result<(), StorageError> {
+        self.snapshot_operations_for_mutation();
         self.operations.create_index(
             &self.catalog,
             &self.tables,
@@ -201,6 +203,7 @@ impl Database {
         columns: Vec<IndexColumn>,
         keys: Vec<(Vec<vibesql_types::SqlValue>, usize)>,
     ) -> Result<(), StorageError> {
+        self.snapshot_operations_for_mutation();
         self.operations.create_index_with_keys(
             &self.catalog,
             index_name,
@@ -243,6 +246,7 @@ impl Database {
         row_index: usize,
         changed_columns: Option<&std::collections::HashSet<usize>>,
     ) {
+        self.snapshot_operations_for_mutation();
         self.operations.update_indexes_for_update(
             &self.catalog,
             table_name,
@@ -255,6 +259,7 @@ impl Database {
 
     /// Update user-defined indexes for delete operation
     pub fn update_indexes_for_delete(&mut self, table_name: &str, row: &Row, row_index: usize) {
+        self.snapshot_operations_for_mutation();
         self.operations.update_indexes_for_delete(&self.catalog, table_name, row, row_index);
     }
 
@@ -267,11 +272,13 @@ impl Database {
         table_name: &str,
         rows_to_delete: &[(usize, &Row)],
     ) {
+        self.snapshot_operations_for_mutation();
         self.operations.batch_update_indexes_for_delete(&self.catalog, table_name, rows_to_delete);
     }
 
     /// Rebuild user-defined indexes after bulk operations that change row indices
     pub fn rebuild_indexes(&mut self, table_name: &str) {
+        self.snapshot_operations_for_mutation();
         self.operations.rebuild_indexes(&self.catalog, &self.tables, table_name);
     }
 
@@ -284,11 +291,13 @@ impl Database {
     /// * `table_name` - Name of the table whose indexes need adjustment
     /// * `deleted_indices` - Sorted list of deleted row indices (ascending order)
     pub fn adjust_indexes_after_delete(&mut self, table_name: &str, deleted_indices: &[usize]) {
+        self.snapshot_operations_for_mutation();
         self.operations.adjust_indexes_after_delete(table_name, deleted_indices);
     }
 
     /// Drop an index
     pub fn drop_index(&mut self, index_name: &str) -> Result<(), StorageError> {
+        self.snapshot_operations_for_mutation();
         self.operations.drop_index(index_name)
     }
 
@@ -301,6 +310,7 @@ impl Database {
         index_name: &str,
         where_clause: Option<Box<vibesql_ast::Expression>>,
     ) -> bool {
+        self.snapshot_operations_for_mutation();
         self.operations.set_index_where_clause(index_name, where_clause)
     }
 
@@ -339,6 +349,7 @@ impl Database {
         row_index: usize,
         included_partial_indexes: &std::collections::HashSet<String>,
     ) {
+        self.snapshot_operations_for_mutation();
         self.operations.add_to_partial_indexes_for_insert(
             &self.catalog,
             table_name,
@@ -358,6 +369,7 @@ impl Database {
         old_included: &std::collections::HashSet<String>,
         new_included: &std::collections::HashSet<String>,
     ) {
+        self.snapshot_operations_for_mutation();
         self.operations.update_partial_indexes_for_update(
             &self.catalog,
             table_name,
@@ -377,6 +389,7 @@ impl Database {
         row_index: usize,
         included_partial_indexes: &std::collections::HashSet<String>,
     ) {
+        self.snapshot_operations_for_mutation();
         self.operations.update_partial_indexes_for_delete_with_values(
             &self.catalog,
             table_name,
@@ -426,6 +439,7 @@ impl Database {
         row_index: usize,
         expression_keys: &std::collections::HashMap<String, Vec<vibesql_types::SqlValue>>,
     ) {
+        self.snapshot_operations_for_mutation();
         self.operations.add_to_expression_indexes_for_insert(
             table_name,
             row_index,
@@ -441,6 +455,7 @@ impl Database {
         old_expression_keys: &std::collections::HashMap<String, Vec<vibesql_types::SqlValue>>,
         new_expression_keys: &std::collections::HashMap<String, Vec<vibesql_types::SqlValue>>,
     ) {
+        self.snapshot_operations_for_mutation();
         self.operations.update_expression_indexes_for_update(
             table_name,
             row_index,
@@ -456,6 +471,7 @@ impl Database {
         row_index: usize,
         expression_keys: &std::collections::HashMap<String, Vec<vibesql_types::SqlValue>>,
     ) {
+        self.snapshot_operations_for_mutation();
         self.operations.update_expression_indexes_for_delete(
             table_name,
             row_index,
@@ -481,6 +497,7 @@ impl Database {
 
     /// Clear expression index data for a table (for rebuilding after compaction)
     pub fn clear_expression_index_data(&mut self, table_name: &str) {
+        self.snapshot_operations_for_mutation();
         self.operations.clear_expression_index_data(table_name);
     }
 
@@ -492,6 +509,7 @@ impl Database {
     /// partial index's WHERE predicate against the post-compaction rows and
     /// repopulates the body via `add_to_partial_indexes_for_insert`.
     pub fn clear_partial_index_data(&mut self, table_name: &str) {
+        self.snapshot_operations_for_mutation();
         self.operations.clear_partial_index_data(table_name);
     }
 
@@ -505,6 +523,7 @@ impl Database {
         metadata: SpatialIndexMetadata,
         spatial_index: crate::index::SpatialIndex,
     ) -> Result<(), StorageError> {
+        self.snapshot_operations_for_mutation();
         self.operations.create_spatial_index(metadata, spatial_index)
     }
 
@@ -532,6 +551,7 @@ impl Database {
         lists: usize,
         metric: vibesql_ast::VectorDistanceMetric,
     ) -> Result<(), StorageError> {
+        self.snapshot_operations_for_mutation();
         self.operations.create_ivfflat_index(
             &self.catalog,
             &self.tables,
@@ -578,6 +598,7 @@ impl Database {
         index_name: &str,
         probes: usize,
     ) -> Result<(), StorageError> {
+        self.snapshot_operations_for_mutation();
         self.operations.set_ivfflat_probes(index_name, probes)
     }
 
@@ -611,6 +632,7 @@ impl Database {
         ef_construction: u32,
         metric: vibesql_ast::VectorDistanceMetric,
     ) -> Result<(), StorageError> {
+        self.snapshot_operations_for_mutation();
         self.operations.create_hnsw_index(
             &self.catalog,
             &self.tables,
@@ -658,6 +680,7 @@ impl Database {
         index_name: &str,
         ef_search: usize,
     ) -> Result<(), StorageError> {
+        self.snapshot_operations_for_mutation();
         self.operations.set_hnsw_ef_search(index_name, ef_search)
     }
 
@@ -677,10 +700,15 @@ impl Database {
     }
 
     /// Get spatial index (mutable)
+    ///
+    /// Returns a mutable borrow that a caller can use to mutate the spatial
+    /// index out of band, so the copy-on-write rollback snapshot (#5419)
+    /// must be captured here before the borrow escapes.
     pub fn get_spatial_index_mut(
         &mut self,
         index_name: &str,
     ) -> Option<&mut crate::index::SpatialIndex> {
+        self.snapshot_operations_for_mutation();
         self.operations.get_spatial_index_mut(index_name)
     }
 
@@ -693,20 +721,26 @@ impl Database {
     }
 
     /// Get all spatial indexes for a specific table (mutable)
+    ///
+    /// Returns mutable borrows usable for out-of-band mutation, so the
+    /// copy-on-write rollback snapshot (#5419) must be captured here.
     pub fn get_spatial_indexes_for_table_mut(
         &mut self,
         table_name: &str,
     ) -> Vec<(&SpatialIndexMetadata, &mut crate::index::SpatialIndex)> {
+        self.snapshot_operations_for_mutation();
         self.operations.get_spatial_indexes_for_table_mut(table_name)
     }
 
     /// Drop a spatial index
     pub fn drop_spatial_index(&mut self, index_name: &str) -> Result<(), StorageError> {
+        self.snapshot_operations_for_mutation();
         self.operations.drop_spatial_index(index_name)
     }
 
     /// Drop all spatial indexes associated with a table (CASCADE behavior)
     pub fn drop_spatial_indexes_for_table(&mut self, table_name: &str) -> Vec<String> {
+        self.snapshot_operations_for_mutation();
         self.operations.drop_spatial_indexes_for_table(table_name)
     }
 
@@ -1179,6 +1213,7 @@ impl Database {
         // Update user-defined indexes first (using reference to values)
         // This must happen before we move ownership of values to WAL
         let phase_start = start.map(|_| Instant::now());
+        self.snapshot_operations_for_mutation();
         self.operations.update_indexes_for_delete_with_values(
             &self.catalog,
             table_name,

--- a/crates/vibesql-storage/src/database/indexes/index_metadata.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_metadata.rs
@@ -117,6 +117,23 @@ pub enum IndexData {
     /// Disk-backed B+ tree (for large indexes or persistence)
     /// Note: The B+ tree stores (key, row_id) pairs. For non-unique indexes,
     /// we serialize Vec<usize> as the row_id value to support multiple rows per key.
+    ///
+    /// **Transaction-rollback gap (#5419, follow-on of #5413):** `Clone`
+    /// for this variant is a *shallow* `Arc` bump — the cloned snapshot and
+    /// the live index share the same `Arc<Mutex<BTreeIndex>>`. The #5413 /
+    /// #5419 rollback snapshot of `Operations` therefore does **not** undo
+    /// mutations made to a spilled (disk-backed) index inside a transaction:
+    /// restoring the shallow clone restores a handle to the *same, already-
+    /// mutated* B+ tree. This is the same class of leak #5413 closed for the
+    /// in-memory index, but for spilled indexes.
+    ///
+    /// This is **not reachable in replicated mode** today: the state machine
+    /// builds the database via `Database::new()` (no `database_path`), so
+    /// index spilling — which requires a path — never triggers there. It is
+    /// a latent gap only for standalone-with-path databases that spill an
+    /// index and then ROLLBACK. Tracked as a focused follow-on; the
+    /// copy-on-write change in #5419 deliberately preserves the existing
+    /// #5413 behavior here rather than expanding scope.
     DiskBacked { btree: Arc<Mutex<BTreeIndex>>, page_manager: Arc<PageManager> },
     /// IVFFlat index for approximate nearest neighbor search on vectors
     IVFFlat { index: IVFFlatIndex },

--- a/crates/vibesql-storage/src/database/table_api.rs
+++ b/crates/vibesql-storage/src/database/table_api.rs
@@ -326,6 +326,7 @@ impl Database {
 
         // Invalidate columnar cache before dropping
         self.columnar_cache.invalidate(name);
+        self.snapshot_operations_for_mutation();
         self.operations.drop_table(&mut self.catalog, &mut self.tables, name)
     }
 
@@ -346,6 +347,7 @@ impl Database {
         let txn_id = self.transaction_id();
         crate::mvcc::stamp_xmin_for_write(&mut row, txn_id);
 
+        self.snapshot_operations_for_mutation();
         let row_index =
             self.operations.insert_row(&self.catalog, &mut self.tables, table_name, row.clone())?;
 
@@ -426,6 +428,7 @@ impl Database {
             crate::mvcc::stamp_xmin_for_write(row, txn_id);
         }
 
+        self.snapshot_operations_for_mutation();
         let row_indices = self.operations.insert_rows_batch(
             &self.catalog,
             &mut self.tables,
@@ -623,6 +626,7 @@ impl Database {
         table_mut.update_row_selective(row_index, new_row.clone(), &changed_columns)?;
 
         // Update user-defined indexes (pass changed_columns to skip unaffected indexes)
+        self.snapshot_operations_for_mutation();
         self.operations.update_indexes_for_update(
             &self.catalog,
             &resolved_name,

--- a/crates/vibesql-storage/src/database/tests/core_tests.rs
+++ b/crates/vibesql-storage/src/database/tests/core_tests.rs
@@ -854,3 +854,118 @@ fn commit_keeps_index_manager_state() {
 
     assert!(db.index_exists("idx_t_id"), "COMMIT must keep the index created in the txn");
 }
+
+// ============================================================================
+// Copy-on-write Operations snapshot (#5419)
+// ============================================================================
+
+/// #5419: a read-only transaction must NOT deep-clone the `Operations`
+/// (IndexManager + spatial indexes) at BEGIN. Before #5419 the snapshot was
+/// eager, so every BEGIN — including the per-read scratch txn used by
+/// replicated read-your-own-writes — paid an O(index-keys) clone. With the
+/// copy-on-write snapshot, a transaction that only reads triggers zero
+/// clones. Asserted deterministically via the clone counter (no timing).
+#[test]
+fn read_only_transaction_does_not_clone_operations_snapshot() {
+    use vibesql_ast::IndexColumn;
+    use vibesql_catalog::{ColumnSchema, TableSchema};
+    use vibesql_types::DataType;
+
+    let mut db = Database::new();
+    let schema = TableSchema::new(
+        "t".to_string(),
+        vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+    );
+    db.create_table(schema).unwrap();
+
+    // Build a non-trivial index so an eager clone would be observable work.
+    db.create_index(
+        "idx_t_id".to_string(),
+        "t".to_string(),
+        false,
+        vec![IndexColumn::new_column("id".to_string(), vibesql_ast::OrderDirection::Asc)],
+    )
+    .unwrap();
+    for i in 0..256 {
+        db.insert_row("t", crate::Row::new(vec![SqlValue::Integer(i)])).unwrap();
+    }
+
+    let before = db.operations_snapshot_clones();
+
+    // A purely read-only transaction: BEGIN, observe index state, ROLLBACK.
+    db.begin_transaction().unwrap();
+    assert!(db.index_exists("idx_t_id"), "index visible inside the read-only txn");
+    let _ = db.list_indexes();
+    db.rollback_transaction().unwrap();
+
+    assert_eq!(
+        db.operations_snapshot_clones(),
+        before,
+        "a read-only transaction must not deep-clone the Operations snapshot (#5419)"
+    );
+}
+
+/// #5419: a transaction that DOES mutate an index lazily clones the
+/// `Operations` snapshot exactly once (on the first mutation), and that
+/// snapshot still fully restores index state on ROLLBACK — i.e. the #5413
+/// correctness fix is preserved, just deferred. Also verifies the clone is
+/// taken once even across multiple index mutations.
+#[test]
+fn mutating_transaction_clones_operations_snapshot_once_and_rolls_back() {
+    use vibesql_ast::IndexColumn;
+    use vibesql_catalog::{ColumnSchema, TableSchema};
+    use vibesql_types::DataType;
+
+    let mut db = Database::new();
+    let schema = TableSchema::new(
+        "t".to_string(),
+        vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+    );
+    db.create_table(schema).unwrap();
+    db.create_index(
+        "idx_t_id".to_string(),
+        "t".to_string(),
+        false,
+        vec![IndexColumn::new_column("id".to_string(), vibesql_ast::OrderDirection::Asc)],
+    )
+    .unwrap();
+
+    let before = db.operations_snapshot_clones();
+
+    db.begin_transaction().unwrap();
+    // First index mutation triggers exactly one lazy clone.
+    db.insert_row("t", crate::Row::new(vec![SqlValue::Integer(1)])).unwrap();
+    assert_eq!(
+        db.operations_snapshot_clones(),
+        before + 1,
+        "first index mutation must take exactly one snapshot clone"
+    );
+    // Further mutations do not re-clone.
+    db.insert_row("t", crate::Row::new(vec![SqlValue::Integer(2)])).unwrap();
+    db.create_index(
+        "idx_t_id2".to_string(),
+        "t".to_string(),
+        false,
+        vec![IndexColumn::new_column("id".to_string(), vibesql_ast::OrderDirection::Asc)],
+    )
+    .unwrap();
+    assert_eq!(
+        db.operations_snapshot_clones(),
+        before + 1,
+        "subsequent mutations must reuse the existing snapshot, not re-clone"
+    );
+
+    db.rollback_transaction().unwrap();
+
+    // The lazily-captured snapshot must fully restore index state: the
+    // index created in the txn is gone, and the pre-existing index survives.
+    assert!(
+        !db.index_exists("idx_t_id2"),
+        "ROLLBACK must restore Operations: index created in the txn is removed (#5413 preserved)"
+    );
+    assert!(
+        db.index_exists("idx_t_id"),
+        "the pre-transaction index must survive ROLLBACK"
+    );
+    assert_eq!(db.get_table("t").map(|t| t.row_count()), Some(0), "rolled-back rows are gone");
+}

--- a/crates/vibesql-storage/src/database/transaction_api.rs
+++ b/crates/vibesql-storage/src/database/transaction_api.rs
@@ -38,7 +38,6 @@ impl Database {
         self.lifecycle.transaction_manager_mut().begin_transaction_with_durability(
             catalog,
             &self.tables,
-            &self.operations,
             durability,
         )?;
 
@@ -111,6 +110,22 @@ impl Database {
     /// Check if we're currently in a transaction
     pub fn in_transaction(&self) -> bool {
         self.lifecycle.transaction_manager().in_transaction()
+    }
+
+    /// Number of `Operations` (IndexManager) deep-clones taken for
+    /// transaction rollback snapshots since this database was created
+    /// (copy-on-write instrumentation, #5419).
+    ///
+    /// Read-only transactions — including the per-read scratch transaction
+    /// used by replicated read-your-own-writes — never mutate the index
+    /// manager, so they never trigger the lazy clone and leave this counter
+    /// unchanged. A transaction that mutates an index increments it exactly
+    /// once. Exposed so tests can assert deterministically (no timing) that
+    /// the read-only path avoids the deep clone.
+    ///
+    /// See [`crate::database::transactions::TransactionManager::ensure_operations_snapshot`].
+    pub fn operations_snapshot_clones(&self) -> u64 {
+        self.lifecycle.transaction_manager().operations_snapshot_clones()
     }
 
     /// Get current transaction ID (for debugging)

--- a/crates/vibesql-storage/src/database/transactions.rs
+++ b/crates/vibesql-storage/src/database/transactions.rs
@@ -81,7 +81,7 @@ pub enum TransactionState {
         original_catalog: vibesql_catalog::Catalog,
         /// Original table snapshots for full rollback
         original_tables: HashMap<String, Table>,
-        /// Original index/spatial-index snapshot for full rollback.
+        /// Lazily-captured index/spatial-index snapshot for full rollback.
         ///
         /// The B-tree `IndexManager` and spatial indexes live in
         /// [`Operations`], which is *not* part of the `catalog`/`tables`
@@ -90,10 +90,20 @@ pub enum TransactionState {
         /// otherwise a rolled-back key survives in the unique index and a
         /// later legitimate write spuriously fails the uniqueness check
         /// (the row itself is hidden by MVCC visibility, masking the leak
-        /// from `SELECT`). Snapshotting `Operations` at BEGIN and
-        /// restoring it on ROLLBACK keeps all indexes bit-for-bit
-        /// identical to their pre-transaction state.
-        original_operations: Operations,
+        /// from `SELECT`). Restoring this snapshot on ROLLBACK keeps all
+        /// indexes bit-for-bit identical to their pre-transaction state
+        /// (the #5413 fix).
+        ///
+        /// **Copy-on-write (#5419):** this is `None` until the first time
+        /// the transaction takes a *mutable* borrow of `Operations`
+        /// (see [`Self::ensure_operations_snapshot`]). A read-only
+        /// transaction — including the per-read scratch transaction used
+        /// by replicated read-your-own-writes — never mutates the index
+        /// manager, so it never pays the deep clone. The clone, when it
+        /// does happen, captures committed (pre-transaction) state because
+        /// it is taken *before* the mutation is applied, preserving the
+        /// exact restore semantics #5413 established.
+        original_operations: Option<Operations>,
         /// Stack of savepoints (newest at end)
         savepoints: Vec<Savepoint>,
         /// All changes made since transaction start (for incremental undo)
@@ -150,6 +160,16 @@ pub struct TransactionManager {
     horizon_pins: std::collections::BTreeMap<u64, TxnId>,
     /// Next pin id to hand out from [`pin_gc_horizon`](Self::pin_gc_horizon).
     next_pin_id: u64,
+    /// Number of times an `Operations` snapshot has been deep-cloned for a
+    /// transaction (copy-on-write instrumentation, #5419).
+    ///
+    /// Incremented exactly once per transaction that mutates the index
+    /// manager — the first mutable borrow of `Operations` triggers the
+    /// lazy clone. A read-only transaction leaves this counter untouched.
+    /// Exposed via [`Self::operations_snapshot_clones`] so tests can
+    /// assert deterministically that the read-only / speculative-read
+    /// path does not pay the deep clone, without relying on timing.
+    operations_snapshot_clones: u64,
 }
 
 impl TransactionManager {
@@ -160,6 +180,7 @@ impl TransactionManager {
             next_transaction_id: 1,
             horizon_pins: std::collections::BTreeMap::new(),
             next_pin_id: 1,
+            operations_snapshot_clones: 0,
         }
     }
 
@@ -175,14 +196,40 @@ impl TransactionManager {
         &mut self,
         catalog: &vibesql_catalog::Catalog,
         tables: &HashMap<String, Table>,
-        operations: &Operations,
     ) -> Result<(), StorageError> {
-        self.begin_transaction_with_durability(
-            catalog,
-            tables,
-            operations,
-            TransactionDurability::Default,
-        )
+        self.begin_transaction_with_durability(catalog, tables, TransactionDurability::Default)
+    }
+
+    /// Ensure the `Operations` rollback snapshot has been captured for the
+    /// active transaction (copy-on-write, #5419).
+    ///
+    /// Called by the [`Database`](crate::Database) just *before* it takes a
+    /// mutable borrow of `Operations` to perform an index/table mutation.
+    /// The first such call inside a transaction deep-clones `operations`
+    /// (capturing committed, pre-mutation state) and stashes it for
+    /// ROLLBACK; subsequent calls are no-ops. Outside a transaction this
+    /// is a no-op.
+    ///
+    /// This preserves the exact restore semantics of the #5413 eager
+    /// snapshot — the only change is *when* the clone happens. Read-only
+    /// transactions never call a mutating `Operations` method, so they
+    /// never trigger the clone.
+    ///
+    /// [`Database`]: crate::Database
+    pub fn ensure_operations_snapshot(&mut self, operations: &Operations) {
+        if let TransactionState::Active { original_operations, .. } = &mut self.transaction_state {
+            if original_operations.is_none() {
+                *original_operations = Some(operations.clone());
+                self.operations_snapshot_clones += 1;
+            }
+        }
+    }
+
+    /// Number of `Operations` deep-clones taken for transaction rollback
+    /// snapshots since this manager was created (copy-on-write
+    /// instrumentation, #5419). See [`Self::ensure_operations_snapshot`].
+    pub fn operations_snapshot_clones(&self) -> u64 {
+        self.operations_snapshot_clones
     }
 
     /// Begin a new transaction with a specific durability hint
@@ -190,17 +237,19 @@ impl TransactionManager {
         &mut self,
         catalog: &vibesql_catalog::Catalog,
         tables: &HashMap<String, Table>,
-        operations: &Operations,
         durability: TransactionDurability,
     ) -> Result<(), StorageError> {
         match self.transaction_state {
             TransactionState::None => {
-                // Create snapshots of catalog, all current tables, and the
+                // Snapshot catalog and all current tables eagerly. The
                 // index/spatial-index state (which lives in `Operations`,
-                // outside the catalog/tables snapshot).
+                // outside the catalog/tables snapshot) is captured lazily
+                // on the first mutation — see `ensure_operations_snapshot`
+                // and `original_operations` (#5419). A read-only / mid-txn
+                // speculative-read transaction therefore never pays the
+                // index-manager deep clone.
                 let original_catalog = catalog.clone();
                 let original_tables = tables.clone();
-                let original_operations = operations.clone();
 
                 let transaction_id = self.next_transaction_id;
                 self.next_transaction_id += 1;
@@ -219,7 +268,7 @@ impl TransactionManager {
                     id: transaction_id,
                     original_catalog,
                     original_tables,
-                    original_operations,
+                    original_operations: None,
                     savepoints: Vec::new(),
                     changes: Vec::new(),
                     durability,
@@ -312,15 +361,24 @@ impl TransactionManager {
                 original_operations,
                 ..
             } => {
-                // Restore catalog, all tables, AND the index/spatial-index
-                // state from snapshots. Restoring `operations` is required
-                // for correctness: PK/UNIQUE index keys inserted during the
-                // transaction must be undone, otherwise a later legitimate
-                // write spuriously fails the uniqueness check against a
-                // stale, rolled-back key.
+                // Restore catalog and all tables from their snapshots.
                 *catalog = original_catalog.clone();
                 *tables = original_tables.clone();
-                *operations = original_operations.clone();
+
+                // Restore the index/spatial-index state *only if* a snapshot
+                // was taken (#5419 copy-on-write). The snapshot is captured
+                // lazily on the first mutating borrow of `Operations`
+                // (`ensure_operations_snapshot`); if the transaction never
+                // mutated an index — e.g. a read-only / speculative-read
+                // scratch txn — there is nothing to restore and `operations`
+                // is already in its committed state. When a snapshot exists,
+                // restoring it is required for correctness: PK/UNIQUE index
+                // keys inserted during the transaction must be undone,
+                // otherwise a later legitimate write spuriously fails the
+                // uniqueness check against a stale, rolled-back key (#5413).
+                if let Some(snapshot) = original_operations {
+                    *operations = snapshot.clone();
+                }
                 self.transaction_state = TransactionState::None;
                 Ok(())
             }
@@ -648,7 +706,7 @@ mod snapshot_capture_tests {
         //   - xmin_active = 2 (one past self)
         let (catalog, tables) = empty_catalog_and_tables();
         let mut mgr = TransactionManager::new();
-        mgr.begin_transaction(&catalog, &tables, &Operations::new()).unwrap();
+        mgr.begin_transaction(&catalog, &tables).unwrap();
 
         let snap = mgr.current_snapshot().expect("snapshot present after BEGIN");
         assert_eq!(snap.xmin_active, 2);
@@ -663,10 +721,10 @@ mod snapshot_capture_tests {
         let (catalog, tables) = empty_catalog_and_tables();
         let mut mgr = TransactionManager::new();
 
-        mgr.begin_transaction(&catalog, &tables, &Operations::new()).unwrap();
+        mgr.begin_transaction(&catalog, &tables).unwrap();
         mgr.commit_transaction().unwrap();
 
-        mgr.begin_transaction(&catalog, &tables, &Operations::new()).unwrap();
+        mgr.begin_transaction(&catalog, &tables).unwrap();
         let snap = mgr.current_snapshot().expect("second snapshot present");
         // #5207: xmax_committed = self (= 2), xmin_active = self + 1 (= 3)
         assert_eq!(snap.xmin_active, 3);
@@ -680,7 +738,7 @@ mod snapshot_capture_tests {
         // return the same data. This is the snapshot-isolation contract.
         let (catalog, tables) = empty_catalog_and_tables();
         let mut mgr = TransactionManager::new();
-        mgr.begin_transaction(&catalog, &tables, &Operations::new()).unwrap();
+        mgr.begin_transaction(&catalog, &tables).unwrap();
 
         let snap1 = mgr.current_snapshot().cloned().unwrap();
         let snap2 = mgr.current_snapshot().cloned().unwrap();
@@ -710,10 +768,10 @@ mod snapshot_capture_tests {
         let (mut catalog, mut tables) = empty_catalog_and_tables();
         let mut mgr = TransactionManager::new();
 
-        mgr.begin_transaction(&catalog, &tables, &Operations::new()).unwrap();
+        mgr.begin_transaction(&catalog, &tables).unwrap();
         mgr.rollback_transaction(&mut catalog, &mut tables, &mut Operations::new()).unwrap();
 
-        mgr.begin_transaction(&catalog, &tables, &Operations::new()).unwrap();
+        mgr.begin_transaction(&catalog, &tables).unwrap();
         let snap = mgr.current_snapshot().unwrap();
         // First txn id was 1 (rolled back). Second txn id is 2.
         // #5207: xmax_committed = self (= 2), xmin_active = self + 1 (= 3).
@@ -729,7 +787,7 @@ mod snapshot_capture_tests {
         // "see-your-own-writes" invariant.
         let (catalog, tables) = empty_catalog_and_tables();
         let mut mgr = TransactionManager::new();
-        mgr.begin_transaction(&catalog, &tables, &Operations::new()).unwrap();
+        mgr.begin_transaction(&catalog, &tables).unwrap();
         let my_id = mgr.transaction_id().unwrap();
         let snap = mgr.current_snapshot().unwrap();
 
@@ -764,7 +822,7 @@ mod snapshot_capture_tests {
         // safe to reclaim. Horizon = 2.
         let (catalog, tables) = empty_catalog_and_tables();
         let mut mgr = TransactionManager::new();
-        mgr.begin_transaction(&catalog, &tables, &Operations::new()).unwrap();
+        mgr.begin_transaction(&catalog, &tables).unwrap();
         mgr.commit_transaction().unwrap();
         assert_eq!(mgr.compute_gc_horizon(), 2);
     }
@@ -777,7 +835,7 @@ mod snapshot_capture_tests {
         // Single-writer: snapshot.xmin_active = txn_id + 1 = 2.
         let (catalog, tables) = empty_catalog_and_tables();
         let mut mgr = TransactionManager::new();
-        mgr.begin_transaction(&catalog, &tables, &Operations::new()).unwrap();
+        mgr.begin_transaction(&catalog, &tables).unwrap();
         let horizon = mgr.compute_gc_horizon();
         let snap = mgr.current_snapshot().unwrap();
         assert_eq!(horizon, snap.xmin_active);
@@ -790,7 +848,7 @@ mod snapshot_capture_tests {
         let (catalog, tables) = empty_catalog_and_tables();
         let mut mgr = TransactionManager::new();
         for _ in 0..2 {
-            mgr.begin_transaction(&catalog, &tables, &Operations::new()).unwrap();
+            mgr.begin_transaction(&catalog, &tables).unwrap();
             mgr.commit_transaction().unwrap();
         }
         assert_eq!(mgr.compute_gc_horizon(), 3);
@@ -803,11 +861,11 @@ mod snapshot_capture_tests {
         let (catalog, tables) = empty_catalog_and_tables();
         let mut mgr = TransactionManager::new();
         for _ in 0..2 {
-            mgr.begin_transaction(&catalog, &tables, &Operations::new()).unwrap();
+            mgr.begin_transaction(&catalog, &tables).unwrap();
             mgr.commit_transaction().unwrap();
         }
         // Third txn begins (txn_id = 3), and stays active.
-        mgr.begin_transaction(&catalog, &tables, &Operations::new()).unwrap();
+        mgr.begin_transaction(&catalog, &tables).unwrap();
         let horizon = mgr.compute_gc_horizon();
         // Snapshot's xmin_active = txn_id + 1 = 4 under single-writer
         // self-write widening (#5207).


### PR DESCRIPTION
Closes #5419

## Summary

PR #5413 fixed an index-rollback correctness leak by snapshotting `Operations` (the whole `IndexManager` + spatial indexes, which live outside the catalog/tables snapshot) at BEGIN and restoring it on ROLLBACK. Correct, but it **deep-cloned `Operations` at every BEGIN** — including the per-speculative-read scratch transaction replicated sessions open for read-your-own-writes — so every mid-txn read paid an O(index-keys) clone.

This PR replaces the eager clone with a **copy-on-write (lazy) snapshot**.

## Chosen approach: lazy copy-on-write — and why

Evaluated the three options in the issue:

- **(a) lazy COW (chosen)** — keep no snapshot until the first index mutation; clone lazily only when the txn actually mutates an index.
- (b) undo-log — record per-key index mutations, reverse on rollback.
- (c) snapshot only on first mutation — this *is* lazy COW.

Lazy COW wins on the **correctness/complexity tradeoff**:

- It **removes the clone entirely for read-only transactions** (the deterministically-testable hot path), making read-only BEGIN/ROLLBACK O(1).
- It preserves the **exact** #5413 deep-snapshot/restore semantics — the only change is *when* the clone happens (deferred to the first mutation, where it still captures committed, pre-mutation state). This is the lowest-risk way to keep the four #5413 regressions passing.
- An undo-log would be materially more code threaded through ~30 mutation entry points across InMemory + DiskBacked + spatial + IVFFlat + HNSW indexes, with high risk of a missed path = a silent re-introduction of the exact bug class #5413 fixed.

### Implementation

- `TransactionState::Active.original_operations` is now `Option<Operations>` (was `Operations`), `None` until the first mutation.
- New `TransactionManager::ensure_operations_snapshot(&Operations)` deep-clones once on the first call inside a txn; subsequent calls are no-ops.
- A **single chokepoint** `Database::snapshot_operations_for_mutation()` is invoked at the top of every method that takes a mutable borrow of `self.operations` (index create/drop, insert/update/delete index maintenance, partial/expression/spatial/IVFFlat/HNSW mutations, and the `_mut` spatial accessors). `self.operations` is `pub(super)`, so these are the only mutation entry points.
- ROLLBACK restores `operations` **only if** a snapshot was taken.

### How speculative reads avoid the clone now

`speculative_query` opens a scratch txn, replays the buffer, reads, and rolls back. A speculative read whose buffer does not mutate an index (e.g. a pure read) now triggers **zero** `Operations` clones — the read-only scratch txn never calls a mutating `Operations` method. (A buffer that does write still clones once, on its first write — same as #5413, no regression.)

## DiskBacked disposition

`IndexData::DiskBacked` clones as a shallow `Arc<Mutex<BTreeIndex>>` bump, so a spilled-index rollback would not undo mutations. This PR **preserves the existing #5413 behavior** (no regression — lazy COW just defers the same clone), documents the gap on the `DiskBacked` variant, and files a focused follow-on: **#5425**. Not reachable in replicated mode (state machine uses `Database::new()`, no path, so spilling never triggers).

## #5413 regressions still pass

All four:
- `rollback_restores_index_manager_state` (storage) ✅
- `commit_keeps_index_manager_state` (storage) ✅
- `speculative_query_leaves_pk_index_clean_for_later_apply` (consensus) ✅
- `two_speculative_reads_of_one_buffered_pk_are_idempotent` (consensus) ✅

## New tests (deterministic, no timing flakes — assert via clone counter)

- `read_only_transaction_does_not_clone_operations_snapshot` (storage): read-only BEGIN/ROLLBACK over a 256-key index ⇒ 0 clones.
- `mutating_transaction_clones_operations_snapshot_once_and_rolls_back` (storage): exactly 1 clone across multiple mutations; ROLLBACK fully restores index + row state.
- `read_only_speculative_query_does_not_clone_operations_snapshot` (consensus): a read-only `speculative_query` ⇒ 0 clones.

New `Database::operations_snapshot_clones()` instrumentation backs these assertions.

## Test plan
- [x] `cargo test -p vibesql-storage` (default + `mvcc_enabled`) green
- [x] `cargo test -p vibesql-consensus` (default + `mvcc_enabled`) green
- [x] `cargo test -p vibesql-server` (default; crate has no `mvcc_enabled` feature) green
- [x] `cargo build --workspace` green
- [x] clippy clean on edited files

🤖 Generated with [Claude Code](https://claude.com/claude-code)