### PR TITLE
fix: resolve real column names in replicated SELECT results

### DIFF
--- a/crates/vibesql-consensus/src/lib.rs
+++ b/crates/vibesql-consensus/src/lib.rs
@@ -171,4 +171,4 @@ pub use mvcc_raft::MvccRaftNode;
 pub use openraft_backend::{OpenraftBackend, RaftTuning};
 pub use replicated::ReplicatedDb;
 pub use single_node::SingleNodeBackend;
-pub use state_machine::{ApplyOutcome, TxnEntry, VibesqlStateMachine};
+pub use state_machine::{ApplyOutcome, QueryResult, TxnEntry, VibesqlStateMachine};

--- a/crates/vibesql-consensus/src/mvcc_raft.rs
+++ b/crates/vibesql-consensus/src/mvcc_raft.rs
@@ -231,7 +231,9 @@ use crate::openraft_backend::{
     InMemoryLogStore, RaftTuning, RecoveredDurable, TypeConfig,
 };
 use crate::snapshot::SnapshotStore;
-use crate::state_machine::{deserialize_database, ApplyOutcome, TxnEntry, VibesqlStateMachine};
+use crate::state_machine::{
+    deserialize_database, ApplyOutcome, QueryResult, TxnEntry, VibesqlStateMachine,
+};
 
 // ---------------------------------------------------------------------------
 // Snapshot payload framing: dense index header + vbsql database blob
@@ -936,7 +938,7 @@ impl MvccRaftNode {
         &self,
         entry: &TxnEntry,
         select_sql: &str,
-    ) -> Result<Vec<Vec<vibesql_types::SqlValue>>> {
+    ) -> Result<QueryResult> {
         if self.role() != Role::Leader {
             return Err(ConsensusError::NotLeader { leader_hint: self.current_leader() });
         }
@@ -1006,7 +1008,7 @@ impl MvccRaftNode {
     /// trail the cluster's committed state arbitrarily. For reads that
     /// must observe every committed write, use
     /// [`query_linearizable`](Self::query_linearizable).
-    pub fn query(&self, sql: &str) -> Result<Vec<Vec<vibesql_types::SqlValue>>> {
+    pub fn query(&self, sql: &str) -> Result<QueryResult> {
         self.sm.machine.query(sql)
     }
 
@@ -1028,7 +1030,7 @@ impl MvccRaftNode {
     ///   could not confirm a quorum (e.g. partitioned into a minority) —
     ///   its own view is exactly what could not be confirmed, so hinting
     ///   at itself would route callers back to a possibly-stale node.
-    pub async fn query_linearizable(&self, sql: &str) -> Result<Vec<Vec<vibesql_types::SqlValue>>> {
+    pub async fn query_linearizable(&self, sql: &str) -> Result<QueryResult> {
         self.raft.ensure_linearizable().await.map_err(|e| self.map_read_error(e))?;
         self.sm.machine.query(sql)
     }
@@ -1086,7 +1088,7 @@ impl MvccRaftNode {
         min_index: LogIndex,
         sql: &str,
         wait: Duration,
-    ) -> Result<Vec<Vec<vibesql_types::SqlValue>>> {
+    ) -> Result<QueryResult> {
         let mut rx = self.sm.applied.subscribe();
         // A closed channel (the inner `Err`) cannot happen while `self`
         // is alive — the sender lives on `self.sm` — so it folds into
@@ -1143,7 +1145,7 @@ impl MvccRaftNode {
         &self,
         max_staleness: Duration,
         sql: &str,
-    ) -> Result<Vec<Vec<vibesql_types::SqlValue>>> {
+    ) -> Result<QueryResult> {
         if max_staleness.is_zero() {
             return self.query_linearizable(sql).await;
         }
@@ -1557,7 +1559,7 @@ mod tests {
                     ids[0]
                 );
             }
-            reference
+            reference.rows
         }
 
         async fn wait_until<T>(&self, what: &str, mut probe: impl FnMut() -> Option<T>) -> T {
@@ -1603,7 +1605,7 @@ mod tests {
 
         // The session reads its own write immediately after the propose.
         assert_eq!(
-            node.query("SELECT name FROM users").unwrap(),
+            node.query("SELECT name FROM users").unwrap().rows,
             vec![vec![SqlValue::Varchar("alice".into())]]
         );
 
@@ -2014,7 +2016,7 @@ mod tests {
         node.execute_replicated("INSERT INTO t VALUES (1, 'one')").await.unwrap();
 
         let rows = node.query_linearizable("SELECT id, v FROM t").await.unwrap();
-        assert_eq!(rows, vec![vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())]]);
+        assert_eq!(rows.rows, vec![vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())]]);
         assert_eq!(rows, node.query("SELECT id, v FROM t").unwrap());
     }
 
@@ -2045,7 +2047,7 @@ mod tests {
         // The stale-allowed local read stays available on the follower.
         cluster.wait_for_apply(follower, idx).await;
         assert_eq!(
-            cluster.node(follower).query("SELECT id FROM t").unwrap(),
+            cluster.node(follower).query("SELECT id FROM t").unwrap().rows,
             Vec::<Vec<SqlValue>>::new()
         );
 
@@ -2077,7 +2079,7 @@ mod tests {
                 .query_at_least(token, "SELECT id, v FROM t", WAIT_TIMEOUT)
                 .await
                 .unwrap_or_else(|e| panic!("node {id} must serve the token read: {e:?}"));
-            assert_eq!(rows, vec![vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())]]);
+            assert_eq!(rows.rows, vec![vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())]]);
         }
     }
 
@@ -2142,7 +2144,7 @@ mod tests {
         node.execute_replicated("INSERT INTO t VALUES (7)").await.unwrap();
 
         let rows = node.query_bounded_staleness(Duration::ZERO, "SELECT id FROM t").await.unwrap();
-        assert_eq!(rows, vec![vec![SqlValue::Integer(7)]]);
+        assert_eq!(rows.rows, vec![vec![SqlValue::Integer(7)]]);
     }
 
     /// Pre-#5200 (unstamped) entries through the real mount: the dense
@@ -2229,7 +2231,7 @@ mod tests {
             .query_at_least(token, "SELECT id FROM t", WAIT_TIMEOUT)
             .await
             .unwrap();
-        assert_eq!(rows, vec![vec![SqlValue::Integer(1)]]);
+        assert_eq!(rows.rows, vec![vec![SqlValue::Integer(1)]]);
     }
 
     /// The opt-in staleness beacon keeps an IDLE cluster's bounded reads
@@ -2259,7 +2261,7 @@ mod tests {
         loop {
             match cluster.node(follower).query_bounded_staleness(bound, "SELECT id FROM t").await {
                 Ok(rows) => {
-                    assert_eq!(rows, vec![vec![SqlValue::Integer(1)]]);
+                    assert_eq!(rows.rows, vec![vec![SqlValue::Integer(1)]]);
                     break;
                 }
                 Err(ConsensusError::StalenessExceeded { .. }) => {} // beacon not landed yet

--- a/crates/vibesql-consensus/src/replicated.rs
+++ b/crates/vibesql-consensus/src/replicated.rs
@@ -18,11 +18,10 @@
 //! voter; the harness's catch-up loop then becomes the recovery/replay
 //! path only.
 
-use vibesql_types::SqlValue;
 
 use crate::{
     backend::{ConsensusBackend, ConsensusError, LogIndex, Result, Snapshot},
-    state_machine::{ApplyOutcome, TxnEntry, VibesqlStateMachine},
+    state_machine::{ApplyOutcome, QueryResult, TxnEntry, VibesqlStateMachine},
 };
 
 /// A database whose writes flow through a consensus backend.
@@ -130,7 +129,7 @@ where
 
     /// Run a read-only SELECT against the applied state (reads are
     /// local, not replicated).
-    pub fn query(&self, sql: &str) -> Result<Vec<Vec<SqlValue>>> {
+    pub fn query(&self, sql: &str) -> Result<QueryResult> {
         self.machine.query(sql)
     }
 
@@ -146,6 +145,7 @@ where
 mod tests {
     use super::*;
     use crate::single_node::SingleNodeBackend;
+    use vibesql_types::SqlValue;
     use crate::ConsensusError;
 
     fn replicated() -> ReplicatedDb<SingleNodeBackend<TxnEntry>> {
@@ -164,6 +164,7 @@ mod tests {
     fn names(db: &ReplicatedDb<SingleNodeBackend<TxnEntry>>) -> Vec<String> {
         db.query("SELECT name FROM users ORDER BY id")
             .unwrap()
+            .rows
             .into_iter()
             .map(|row| row[0].to_string())
             .collect()
@@ -351,7 +352,7 @@ mod tests {
             "curdate, curtime, age, CAST(TIME AS TIMESTAMP) must all freeze"
         );
         let rows = db.query("SELECT d, t, a, c FROM clk WHERE id = 1").unwrap();
-        for (got, frozen) in rows[0].iter().zip(&alias_entry.frozen[0]) {
+        for (got, frozen) in rows.rows[0].iter().zip(&alias_entry.frozen[0]) {
             assert_eq!(
                 *got,
                 SqlValue::from(frozen.clone()),
@@ -366,8 +367,8 @@ mod tests {
         assert_eq!(entry.frozen.len(), 1);
         assert_eq!(entry.frozen[0].len(), 3, "random, randomblob, CURRENT_TIMESTAMP");
         let rows = db.query("SELECT r, b FROM t WHERE id = 1").unwrap();
-        assert_eq!(rows[0][0], SqlValue::from(entry.frozen[0][0].clone()));
-        assert_eq!(rows[0][1], SqlValue::from(entry.frozen[0][1].clone()));
+        assert_eq!(rows.rows[0][0], SqlValue::from(entry.frozen[0][0].clone()));
+        assert_eq!(rows.rows[0][1], SqlValue::from(entry.frozen[0][1].clone()));
 
         // A second machine replaying the same log converges exactly.
         let recovered = ReplicatedDb::new(clone_log(&db).await);
@@ -515,7 +516,7 @@ mod tests {
         // WHERE + ORDER BY
         let rows = db.query("SELECT a, b FROM t1 WHERE b >= 20 ORDER BY b DESC").unwrap();
         assert_eq!(
-            rows,
+            rows.rows,
             vec![
                 vec![SqlValue::Integer(4), SqlValue::Integer(41)],
                 vec![SqlValue::Integer(3), SqlValue::Integer(31)],
@@ -525,7 +526,7 @@ mod tests {
 
         // Aggregates
         let rows = db.query("SELECT count(*), sum(b) FROM t1").unwrap();
-        assert_eq!(rows, vec![vec![SqlValue::Integer(3), SqlValue::Integer(92)]]);
+        assert_eq!(rows.rows, vec![vec![SqlValue::Integer(3), SqlValue::Integer(92)]]);
 
         // JOIN
         let rows = db
@@ -667,7 +668,7 @@ mod tests {
         let entry = db.backend().read_committed(index).await.unwrap();
         assert_eq!(entry.frozen_defaults[0].len(), 1, "the SET = DEFAULT site freezes one value");
         assert_eq!(
-            db.query("SELECT ts FROM events WHERE id = 1").unwrap(),
+            db.query("SELECT ts FROM events WHERE id = 1").unwrap().rows,
             vec![vec![SqlValue::from(entry.frozen_defaults[0][0].clone())]]
         );
 
@@ -774,7 +775,7 @@ mod tests {
         let (_, outcome) = db.execute_replicated("INSERT INTO t VALUES (1, 42)").await.unwrap();
         assert_eq!(outcome, ApplyOutcome::Applied { rows_affected: 1 });
         assert_eq!(
-            db.query("SELECT k, v FROM audit ORDER BY k").unwrap(),
+            db.query("SELECT k, v FROM audit ORDER BY k").unwrap().rows,
             vec![vec![SqlValue::Integer(1), SqlValue::Integer(42)]],
             "the trigger body fired and wrote the audit row from NEW"
         );

--- a/crates/vibesql-consensus/src/state_machine.rs
+++ b/crates/vibesql-consensus/src/state_machine.rs
@@ -306,6 +306,78 @@ pub struct VibesqlStateMachine {
     inner: Arc<Mutex<MachineInner>>,
 }
 
+/// Result of a replicated read-only SELECT: the resolved column names
+/// plus the row values (#5427).
+///
+/// Reads against the replicated state machine used to return only the
+/// `Vec<Vec<SqlValue>>` rows, forcing the server to label result columns
+/// with `col0`, `col1`, … placeholders. Carrying the executor's resolved
+/// `columns` up through the consensus query API lets the wire
+/// `RowDescription` and HTTP JSON keys use the real column names —
+/// matching standalone behavior exactly.
+#[derive(Debug, Clone, PartialEq)]
+pub struct QueryResult {
+    /// Column names as resolved by the executor (same as standalone:
+    /// real names, aliases, derived expression names, `*`-expansion).
+    pub columns: Vec<String>,
+    /// Result rows.
+    pub rows: Vec<Vec<SqlValue>>,
+}
+
+impl QueryResult {
+    /// Number of result rows.
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Whether the result has no rows.
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    /// Iterate the result rows (column names are read via `columns`).
+    pub fn iter(&self) -> std::slice::Iter<'_, Vec<SqlValue>> {
+        self.rows.iter()
+    }
+
+    /// The first result row, if any.
+    pub fn first(&self) -> Option<&Vec<SqlValue>> {
+        self.rows.first()
+    }
+}
+
+impl std::ops::Index<usize> for QueryResult {
+    type Output = Vec<SqlValue>;
+    fn index(&self, i: usize) -> &Self::Output {
+        &self.rows[i]
+    }
+}
+
+impl IntoIterator for QueryResult {
+    type Item = Vec<SqlValue>;
+    type IntoIter = std::vec::IntoIter<Vec<SqlValue>>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.rows.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a QueryResult {
+    type Item = &'a Vec<SqlValue>;
+    type IntoIter = std::slice::Iter<'a, Vec<SqlValue>>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.rows.iter()
+    }
+}
+
+impl From<vibesql_executor::SelectResult> for QueryResult {
+    fn from(result: vibesql_executor::SelectResult) -> Self {
+        QueryResult {
+            columns: result.columns,
+            rows: result.rows.into_iter().map(|r| r.values.to_vec()).collect(),
+        }
+    }
+}
+
 impl Default for VibesqlStateMachine {
     fn default() -> Self {
         Self::new()
@@ -485,10 +557,20 @@ impl VibesqlStateMachine {
         freeze::freeze_statement_with_schema(sql, schema.as_ref())
     }
 
-    /// Run a read-only SELECT against the applied state, returning row
-    /// values. Reads are local (not replicated); this is the query
-    /// surface the PR 1 tests assert convergence with.
-    pub fn query(&self, sql: &str) -> Result<Vec<Vec<SqlValue>>> {
+    // (QueryResult is defined at module scope, below the impl block.)
+
+    /// Run a read-only SELECT against the applied state, returning the
+    /// resolved column names alongside the row values (#5427). Reads are
+    /// local (not replicated); this is the query surface the PR 1 tests
+    /// assert convergence with.
+    ///
+    /// Column names are resolved by the executor exactly as in standalone
+    /// mode (`SelectExecutor::execute_with_columns`), so a replicated
+    /// SELECT labels its columns identically to the standalone path —
+    /// real names for `a`, aliases for `b AS x`, derived names for
+    /// expressions, and schema-expanded names for `SELECT *` — instead of
+    /// the `col0`, `col1`, … placeholders the row-only path forced.
+    pub fn query(&self, sql: &str) -> Result<QueryResult> {
         let inner = self.lock();
         let statement = vibesql_parser::parse_with_arena_fallback(sql)
             .map_err(|e| ConsensusError::Backend(format!("parse error: {e}")))?;
@@ -497,10 +579,10 @@ impl VibesqlStateMachine {
                 "query() only accepts SELECT statements, got: {sql}"
             )));
         };
-        let rows = vibesql_executor::SelectExecutor::new(&inner.db)
-            .execute(&select)
+        let result = vibesql_executor::SelectExecutor::new(&inner.db)
+            .execute_with_columns(&select)
             .map_err(|e| ConsensusError::Backend(format!("query failed: {e}")))?;
-        Ok(rows.into_iter().map(|r| r.values.to_vec()).collect())
+        Ok(QueryResult::from(result))
     }
 
     /// Speculatively read inside an open replicated transaction so the
@@ -534,7 +616,7 @@ impl VibesqlStateMachine {
         &self,
         entry: &TxnEntry,
         select_sql: &str,
-    ) -> Result<Vec<Vec<SqlValue>>> {
+    ) -> Result<QueryResult> {
         let select = match vibesql_parser::parse_with_arena_fallback(select_sql)
             .map_err(|e| ConsensusError::Backend(format!("parse error: {e}")))?
         {
@@ -579,8 +661,8 @@ impl VibesqlStateMachine {
                 )?;
             }
             vibesql_executor::SelectExecutor::new(&inner.db)
-                .execute(&select)
-                .map(|rows| rows.into_iter().map(|r| r.values.to_vec()).collect::<Vec<_>>())
+                .execute_with_columns(&select)
+                .map(QueryResult::from)
                 .map_err(|e| {
                     ConsensusError::Backend(format!("speculative query failed: {e}"))
                 })
@@ -1037,6 +1119,7 @@ mod tests {
         machine
             .query("SELECT name FROM users ORDER BY id")
             .unwrap()
+            .rows
             .into_iter()
             .map(|row| row[0].to_string())
             .collect()
@@ -1352,7 +1435,7 @@ mod tests {
                 assert_eq!(outcome, ApplyOutcome::Applied { rows_affected: 1 });
             }
         }
-        assert_eq!(a.query("SELECT r FROM t").unwrap(), vec![vec![SqlValue::Integer(30)]]);
+        assert_eq!(a.query("SELECT r FROM t").unwrap().rows, vec![vec![SqlValue::Integer(30)]]);
     }
 
     /// A frozen-value/site-count mismatch indicates proposer/applier
@@ -1380,7 +1463,7 @@ mod tests {
         let frozen = TxnEntry::frozen_batch(statements, vec![vec![FrozenValue::Integer(7)]]);
         assert_eq!(machine.apply(2, &frozen).unwrap(), ApplyOutcome::Applied { rows_affected: 1 });
         assert_eq!(
-            machine.query("SELECT r FROM t WHERE id = 1").unwrap(),
+            machine.query("SELECT r FROM t WHERE id = 1").unwrap().rows,
             vec![vec![SqlValue::Integer(7)]]
         );
     }

--- a/crates/vibesql-consensus/tests/follower_reads.rs
+++ b/crates/vibesql-consensus/tests/follower_reads.rs
@@ -315,7 +315,7 @@ async fn read_your_writes_token_serves_on_any_node() {
             .query_at_least(token, "SELECT id, v FROM accounts", WAIT_TIMEOUT)
             .await
             .unwrap_or_else(|e| panic!("node {id} must serve the token read: {e:?}"));
-        assert_eq!(rows, expected, "node {id}");
+        assert_eq!(rows.rows, expected, "node {id}");
     }
 
     // Token 0 degenerates to a plain local read.
@@ -325,7 +325,7 @@ async fn read_your_writes_token_serves_on_any_node() {
         .query_at_least(0, "SELECT id, v FROM accounts", WAIT_TIMEOUT)
         .await
         .unwrap();
-    assert_eq!(rows, expected);
+    assert_eq!(rows.rows, expected);
 
     // A token beyond anything committed must NOT serve — typed timeout.
     let err = cluster
@@ -392,7 +392,7 @@ async fn token_read_on_lagging_follower_blocks_until_catch_up() {
         .query_at_least(token, "SELECT id, v FROM t", WAIT_TIMEOUT)
         .await
         .expect("the healed follower must catch up and serve the token read");
-    assert_eq!(rows, vec![vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())]]);
+    assert_eq!(rows.rows, vec![vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())]]);
 
     cluster.shutdown().await;
 }
@@ -425,7 +425,7 @@ async fn fresh_follower_serves_bounded_reads_and_zero_redirects() {
         .query_bounded_staleness(Duration::from_secs(10), "SELECT id, v FROM t")
         .await
         .expect("a freshly-applied follower must serve within a 10s bound");
-    assert_eq!(rows, expected);
+    assert_eq!(rows.rows, expected);
 
     // staleness = 0 on a follower: redirect to the leader.
     match cluster.node(follower).query_bounded_staleness(Duration::ZERO, "SELECT id FROM t").await {
@@ -439,7 +439,7 @@ async fn fresh_follower_serves_bounded_reads_and_zero_redirects() {
         .query_bounded_staleness(Duration::ZERO, "SELECT id, v FROM t")
         .await
         .expect("the leader serves staleness=0 through the linearizable path");
-    assert_eq!(rows, expected);
+    assert_eq!(rows.rows, expected);
 
     cluster.shutdown().await;
 }
@@ -485,7 +485,7 @@ async fn partitioned_follower_refuses_bounded_reads_once_the_bound_elapses() {
         {
             Ok(rows) => {
                 assert_eq!(
-                    rows, seeded,
+                    rows.rows, seeded,
                     "a bounded read served inside the bound must be the pre-partition prefix"
                 );
             }
@@ -525,7 +525,7 @@ async fn partitioned_follower_refuses_bounded_reads_once_the_bound_elapses() {
         .query_at_least(majority_idx, "SELECT id, v FROM t ORDER BY id", WAIT_TIMEOUT)
         .await
         .expect("the healed follower must catch up to the majority write");
-    assert_eq!(rows, both);
+    assert_eq!(rows.rows, both);
     let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
     loop {
         match cluster
@@ -534,7 +534,7 @@ async fn partitioned_follower_refuses_bounded_reads_once_the_bound_elapses() {
             .await
         {
             Ok(rows) => {
-                assert_eq!(rows, both);
+                assert_eq!(rows.rows, both);
                 break;
             }
             Err(ConsensusError::StalenessExceeded { .. }) => {} // beacon not landed yet

--- a/crates/vibesql-consensus/tests/leader_reads.rs
+++ b/crates/vibesql-consensus/tests/leader_reads.rs
@@ -34,7 +34,7 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::task::JoinHandle;
 
 use vibesql_consensus::{
-    ApplyOutcome, ClusterConfig, ConsensusError, LogIndex, MvccRaftNode, Role,
+    ApplyOutcome, ClusterConfig, ConsensusError, LogIndex, MvccRaftNode, QueryResult, Role,
 };
 use vibesql_types::SqlValue;
 
@@ -297,7 +297,7 @@ async fn linearizable(
     cluster: &MvccTcpCluster,
     id: u64,
     sql: &str,
-) -> Result<Vec<Vec<SqlValue>>, ConsensusError> {
+) -> Result<QueryResult, ConsensusError> {
     tokio::time::timeout(WAIT_TIMEOUT, cluster.node(id).query_linearizable(sql))
         .await
         .expect("query_linearizable must resolve within the bounded wait")
@@ -329,7 +329,7 @@ async fn leader_serves_linearizable_reads_and_followers_redirect() {
     let rows = linearizable(&cluster, leader, "SELECT id, v FROM accounts")
         .await
         .expect("the node that just acknowledged the write must serve a linearizable read");
-    assert_eq!(rows, vec![vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())]]);
+    assert_eq!(rows.rows, vec![vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())]]);
 
     // A follower that knows who leads redirects with that hint.
     let follower = all.iter().copied().find(|id| *id != leader).expect("a follower exists");
@@ -375,7 +375,7 @@ async fn partitioned_stale_leader_is_fenced_from_linearizable_reads() {
     // Pre-partition sanity: the leader serves linearizable reads.
     let seeded = vec![vec![SqlValue::Integer(1), SqlValue::Varchar("one".into())]];
     assert_eq!(
-        linearizable(&cluster, old_leader, "SELECT id, v FROM t ORDER BY id").await.unwrap(),
+        linearizable(&cluster, old_leader, "SELECT id, v FROM t ORDER BY id").await.unwrap().rows,
         seeded
     );
 
@@ -396,7 +396,7 @@ async fn partitioned_stale_leader_is_fenced_from_linearizable_reads() {
 
     // ...while its plain local read stays available (stale-allowed).
     assert_eq!(
-        cluster.node(old_leader).query("SELECT id, v FROM t ORDER BY id").unwrap(),
+        cluster.node(old_leader).query("SELECT id, v FROM t ORDER BY id").unwrap().rows,
         seeded,
         "the minority leader's local read must keep serving the stale prefix"
     );
@@ -417,14 +417,14 @@ async fn partitioned_stale_leader_is_fenced_from_linearizable_reads() {
         vec![SqlValue::Integer(2), SqlValue::Varchar("two".into())],
     ];
     assert_eq!(
-        linearizable(&cluster, new_leader, "SELECT id, v FROM t ORDER BY id").await.unwrap(),
+        linearizable(&cluster, new_leader, "SELECT id, v FROM t ORDER BY id").await.unwrap().rows,
         both
     );
 
     // The minority leader is provably stale now (it cannot have applied
     // the majority write) — its local read still shows only the prefix,
     // and the linearizable path still refuses to serve it.
-    assert_eq!(cluster.node(old_leader).query("SELECT id, v FROM t ORDER BY id").unwrap(), seeded);
+    assert_eq!(cluster.node(old_leader).query("SELECT id, v FROM t ORDER BY id").unwrap().rows, seeded);
     assert!(
         matches!(
             linearizable(&cluster, old_leader, "SELECT id, v FROM t").await,
@@ -454,12 +454,12 @@ async fn partitioned_stale_leader_is_fenced_from_linearizable_reads() {
 
     // ...the leader serves them, and everyone's local state converged.
     assert_eq!(
-        linearizable(&cluster, new_leader, "SELECT id, v FROM t ORDER BY id").await.unwrap(),
+        linearizable(&cluster, new_leader, "SELECT id, v FROM t ORDER BY id").await.unwrap().rows,
         both
     );
     for id in &all {
         assert_eq!(
-            cluster.node(*id).query("SELECT id, v FROM t ORDER BY id").unwrap(),
+            cluster.node(*id).query("SELECT id, v FROM t ORDER BY id").unwrap().rows,
             both,
             "node {id} diverged after the heal"
         );

--- a/crates/vibesql-server/src/replication.rs
+++ b/crates/vibesql-server/src/replication.rs
@@ -44,7 +44,8 @@ use std::{sync::Arc, time::Duration};
 
 use anyhow::Result;
 use vibesql_consensus::{
-    ApplyOutcome, ClusterConfig, ConsensusError, LogIndex, MvccRaftNode, RaftTuning, Role, TxnEntry,
+    ApplyOutcome, ClusterConfig, ConsensusError, LogIndex, MvccRaftNode, QueryResult, RaftTuning,
+    Role, TxnEntry,
 };
 
 use crate::config::ReplicationConfig;
@@ -269,7 +270,7 @@ impl ReplicationHandle {
         &self,
         entry: &TxnEntry,
         select_sql: &str,
-    ) -> Result<Vec<Vec<vibesql_types::SqlValue>>, SqlError> {
+    ) -> Result<QueryResult, SqlError> {
         self.node.speculative_query(entry, select_sql).map_err(|e| self.sql_error("the query", e))
     }
 
@@ -285,7 +286,7 @@ impl ReplicationHandle {
     }
 
     /// Local, stale-allowed read (the default read mode).
-    pub fn query_local(&self, sql: &str) -> Result<Vec<Vec<vibesql_types::SqlValue>>, SqlError> {
+    pub fn query_local(&self, sql: &str) -> Result<QueryResult, SqlError> {
         self.node.query(sql).map_err(|e| self.sql_error("the query", e))
     }
 
@@ -293,7 +294,7 @@ impl ReplicationHandle {
     pub async fn query_linearizable(
         &self,
         sql: &str,
-    ) -> Result<Vec<Vec<vibesql_types::SqlValue>>, SqlError> {
+    ) -> Result<QueryResult, SqlError> {
         self.node.query_linearizable(sql).await.map_err(|e| self.sql_error("the query", e))
     }
 
@@ -302,7 +303,7 @@ impl ReplicationHandle {
         &self,
         max_staleness: Duration,
         sql: &str,
-    ) -> Result<Vec<Vec<vibesql_types::SqlValue>>, SqlError> {
+    ) -> Result<QueryResult, SqlError> {
         self.node
             .query_bounded_staleness(max_staleness, sql)
             .await
@@ -315,7 +316,7 @@ impl ReplicationHandle {
         min_index: LogIndex,
         sql: &str,
         wait: Duration,
-    ) -> Result<Vec<Vec<vibesql_types::SqlValue>>, SqlError> {
+    ) -> Result<QueryResult, SqlError> {
         self.node
             .query_at_least(min_index, sql, wait)
             .await

--- a/crates/vibesql-server/src/session.rs
+++ b/crates/vibesql-server/src/session.rs
@@ -5,7 +5,7 @@ use vibesql_executor::{
     CursorExecutor, CursorStore, FetchResult as CursorFetchResult, PreparedStatement,
     PreparedStatementCache, PreparedStatementCacheStats,
 };
-use vibesql_consensus::TxnEntry;
+use vibesql_consensus::{QueryResult, TxnEntry};
 use vibesql_types::SqlValue;
 
 use crate::{
@@ -252,6 +252,18 @@ pub struct Row {
     pub values: Vec<vibesql_types::SqlValue>,
 }
 
+/// Map a replicated-read [`QueryResult`] onto an [`ExecutionResult::Select`],
+/// carrying the executor-resolved column names through to the wire
+/// `RowDescription` and HTTP JSON keys (#5427). The consensus query path
+/// resolves names exactly as standalone does, so a replicated SELECT
+/// labels its columns identically — real names, aliases, derived
+/// expression names, `*`-expansion — instead of `col0`/`col1` placeholders.
+fn select_result(result: QueryResult) -> ExecutionResult {
+    let columns = result.columns.into_iter().map(|name| Column { name }).collect();
+    let rows = result.rows.into_iter().map(|values| Row { values }).collect();
+    ExecutionResult::Select { rows, columns }
+}
+
 impl Session {
     /// Create a new session with a shared database
     ///
@@ -461,7 +473,7 @@ impl Session {
             // Reads: dispatch on the session's read-consistency mode.
             Statement::Select(_) => {
                 let handle = Arc::clone(&state.handle);
-                let rows = match state.read_consistency {
+                let result = match state.read_consistency {
                     ReadConsistency::Local => handle.query_local(sql)?,
                     ReadConsistency::Linearizable => handle.query_linearizable(sql).await?,
                     ReadConsistency::BoundedStaleness => {
@@ -482,15 +494,7 @@ impl Session {
                             .await?
                     }
                 };
-                // Placeholder column names, matching the standalone
-                // SELECT path (which also does not resolve real names
-                // yet — see the TODO there).
-                let columns = rows
-                    .first()
-                    .map(|r| (0..r.len()).map(|i| Column { name: format!("col{i}") }).collect())
-                    .unwrap_or_default();
-                let rows = rows.into_iter().map(|values| Row { values }).collect();
-                Ok(ExecutionResult::Select { rows, columns })
+                Ok(select_result(result))
             }
 
             // Writes: one autocommit statement = one replicated entry.
@@ -860,7 +864,7 @@ impl Session {
                 let handle = Arc::clone(
                     &self.replication.as_ref().expect("execute_in_open_txn without state").handle,
                 );
-                let rows = if buffer_has_writes {
+                let result = if buffer_has_writes {
                     // Read-your-own-writes: replay the frozen buffer into a
                     // discardable leader-local scratch transaction, then read.
                     let entry = self
@@ -874,12 +878,7 @@ impl Session {
                     // No buffered writes yet: serve against committed state.
                     handle.query_local(sql)?
                 };
-                let columns = rows
-                    .first()
-                    .map(|r| (0..r.len()).map(|i| Column { name: format!("col{i}") }).collect())
-                    .unwrap_or_default();
-                let rows = rows.into_iter().map(|values| Row { values }).collect();
-                Ok(ExecutionResult::Select { rows, columns })
+                Ok(select_result(result))
             }
 
             // Writes: freeze + buffer for the COMMIT batch, ack optimistically.
@@ -1042,20 +1041,23 @@ impl Session {
             Statement::Select(select_stmt) => {
                 let db = self.db.read().await;
                 let executor = vibesql_executor::SelectExecutor::new(&db);
-                let rows = executor.execute(select_stmt)?;
+                // Resolve real column names from the SELECT list (aliases,
+                // derived expression names, schema-expanded `*`), matching
+                // the executor's standalone behavior, instead of `col{i}`
+                // placeholders (#5427). The replicated read path resolves
+                // the same way, keeping the two label-for-label identical.
+                let select_result = executor.execute_with_columns(select_stmt)?;
 
-                // Convert to our result format
-                let result_rows: Vec<Row> =
-                    rows.iter().map(|r| Row { values: r.values.to_vec() }).collect();
-
-                // TODO: Get actual column names from select statement
-                let columns = if !rows.is_empty() {
-                    (0..rows[0].values.len())
-                        .map(|i| Column { name: format!("col{}", i) })
-                        .collect()
-                } else {
-                    Vec::new()
-                };
+                let result_rows: Vec<Row> = select_result
+                    .rows
+                    .into_iter()
+                    .map(|r| Row { values: r.values.to_vec() })
+                    .collect();
+                let columns = select_result
+                    .columns
+                    .into_iter()
+                    .map(|name| Column { name })
+                    .collect();
 
                 Ok(ExecutionResult::Select { rows: result_rows, columns })
             }

--- a/crates/vibesql-server/tests/replication_tests.rs
+++ b/crates/vibesql-server/tests/replication_tests.rs
@@ -125,6 +125,16 @@ fn select_rows(result: ExecutionResult) -> Vec<vibesql_server::Row> {
     }
 }
 
+/// The resolved column names of a SELECT result (#5427 parity checks).
+fn select_columns(result: ExecutionResult) -> Vec<String> {
+    match result {
+        ExecutionResult::Select { columns, .. } => {
+            columns.into_iter().map(|c| c.name).collect()
+        }
+        other => panic!("expected Select result, got {other:?}"),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Session-level: single node
 // ---------------------------------------------------------------------------
@@ -166,6 +176,84 @@ async fn replicated_session_writes_and_read_modes() {
     // (the entry was rejected identically on every replica).
     let err = session.execute("INSERT INTO no_such_table VALUES (1)").await.unwrap_err();
     assert!(err.downcast_ref::<SqlError>().is_none(), "rejection keeps the executor error: {err}");
+}
+
+/// Replicated SELECT results carry the **real** column names — the same
+/// labels the standalone executor produces — not the `col0`, `col1`, …
+/// placeholders the consensus read path used to force (#5427). Standalone
+/// is the correctness oracle: the replicated read must label its columns
+/// identically for simple columns, aliases, expressions, `SELECT *`,
+/// aggregates, and joins.
+#[tokio::test]
+async fn replicated_select_column_names_match_standalone() {
+    // Schema + data, applied to both a standalone session and a
+    // replicated single-node leader so the two answer the same queries.
+    let setup = [
+        "CREATE TABLE t (a INT, b INT)",
+        "CREATE TABLE u (a INT, c VARCHAR(10))",
+        "INSERT INTO t VALUES (1, 10)",
+        "INSERT INTO t VALUES (2, 20)",
+        "INSERT INTO u VALUES (1, 'one')",
+        "INSERT INTO u VALUES (2, 'two')",
+    ];
+
+    // The SELECTs whose column labels must match. Each exercises a
+    // different name-resolution path.
+    let selects = [
+        "SELECT a, b FROM t ORDER BY a",            // simple columns
+        "SELECT a AS x, b AS y FROM t ORDER BY a",  // aliases
+        "SELECT a + 1, b * 2 FROM t ORDER BY a",    // expressions
+        "SELECT * FROM t ORDER BY a",               // wildcard expansion
+        "SELECT count(*), sum(b) FROM t",           // aggregates
+        "SELECT count(*) AS n FROM t",              // aggregate + alias
+        "SELECT t.a, u.c FROM t JOIN u ON t.a = u.a ORDER BY t.a", // join
+    ];
+
+    // Standalone session is the oracle.
+    let mut standalone =
+        Session::new("testdb".to_string(), "testuser".to_string(), SharedDatabase::new(Database::new()));
+    for sql in setup {
+        standalone.execute(sql).await.expect("standalone setup");
+    }
+
+    // Replicated leader session.
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let mut replicated = replicated_session(&handles[0]);
+    for sql in setup {
+        replicated.execute(sql).await.expect("replicated setup");
+    }
+
+    for sql in selects {
+        let standalone_cols =
+            select_columns(standalone.execute(sql).await.expect("standalone select"));
+        let replicated_cols =
+            select_columns(replicated.execute(sql).await.expect("replicated select"));
+
+        // The placeholders the bug produced must be gone.
+        assert!(
+            !replicated_cols.iter().any(|name| name.starts_with("col")),
+            "{sql}: replicated columns must not be col0/col1 placeholders, got {replicated_cols:?}",
+        );
+        // And the replicated labels must match the standalone oracle.
+        assert_eq!(
+            replicated_cols, standalone_cols,
+            "{sql}: replicated column names must match standalone",
+        );
+    }
+
+    // Spot-check the resolved names so a regression in BOTH paths cannot
+    // pass silently by agreeing on placeholders.
+    let aliased = select_columns(
+        replicated
+            .execute("SELECT a AS x, b AS y FROM t ORDER BY a")
+            .await
+            .expect("replicated aliased select"),
+    );
+    assert_eq!(aliased, vec!["x".to_string(), "y".to_string()]);
+    let star =
+        select_columns(replicated.execute("SELECT * FROM t ORDER BY a").await.expect("star select"));
+    assert_eq!(star, vec!["a".to_string(), "b".to_string()]);
 }
 
 /// Unsupported features fail with SQLSTATE 0A000 and a follow-on
@@ -905,6 +993,12 @@ async fn wire_protocol_replicated_end_to_end() {
     assert_eq!(rows[0].get(0), Some("1"));
     assert_eq!(rows[0].get(1), Some("Alice"));
 
+    // The wire RowDescription carries the real column names, not the
+    // col0/col1 placeholders the replicated read path used to force
+    // (#5427).
+    let col_names: Vec<&str> = rows[0].columns().iter().map(|c| c.name()).collect();
+    assert_eq!(col_names, vec!["id", "name"]);
+
     // The replicated write is in the consensus state machine.
     assert_eq!(
         handles[0].node().query("SELECT COUNT(*) FROM wire_test").unwrap()[0][0].to_string(),
@@ -1185,6 +1279,25 @@ async fn http_query_writes_route_through_consensus() {
     assert_eq!(resp.status(), reqwest::StatusCode::OK);
     let body: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
     assert_eq!(body["row_count"], 1, "the replicated read must see the row");
+
+    // The JSON response carries the real column names, not col0/col1
+    // placeholders — a REST/JSON consumer keys on `id`/`name` (#5427).
+    assert_eq!(
+        body["columns"],
+        serde_json::json!(["id", "name"]),
+        "replicated HTTP SELECT must return real column names, got {body}",
+    );
+    // An aliased + expression SELECT resolves the same labels standalone
+    // would (alias wins; the expression gets its derived name).
+    let resp = post_sql("SELECT id AS pk, id + 1 FROM http_t").await;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+    let cols = body["columns"].as_array().expect("columns array");
+    assert_eq!(cols[0], "pk", "alias must be the JSON key, got {body}");
+    assert!(
+        !cols[1].as_str().unwrap().starts_with("col"),
+        "expression column must not be a col1 placeholder, got {body}",
+    );
 }
 
 /// A deterministic SQL rejection over `/api/query` in replicated mode (one


### PR DESCRIPTION
## Summary

Replicated SELECT results returned placeholder column names (`col0`, `col1`, ...) instead of the real ones. This degraded every replicated read: the wire `RowDescription` and the HTTP `/api/query` JSON keys (wired in #5423) used synthetic labels even though the row data was correct. For REST/JSON consumers a response keyed on `col0`/`col1` is a real usability gap.

## Where the names were lost + how threaded through

The consensus query API returned only rows (`Vec<Vec<SqlValue>>`). `VibesqlStateMachine::query` / `speculative_query` ran `SelectExecutor::execute` (rows only), so the server session fell back to `format!("col{i}")`. The executor already resolves real names via `SelectExecutor::execute_with_columns` (the standalone oracle).

- Added `vibesql_consensus::QueryResult { columns, rows }`; the state machine now resolves names with `execute_with_columns`.
- Threaded `QueryResult` through every read entry point: `MvccRaftNode::{query, query_linearizable, query_at_least, query_bounded_staleness, speculative_query}`, the `ReplicationHandle` wrappers, and `ReplicatedDb::query`.
- The server session maps `QueryResult` → `ExecutionResult::Select`, so the read entry points that consume `ExecutionResult::Select.columns` all get real names.

## Read entry points fixed

- Simple-query wire SELECT (`send_query_result` `RowDescription`).
- Open-transaction read-your-writes / speculative-query SELECT.
- HTTP `POST /api/query` SELECT and CRUD list (`columns` JSON array + per-row JSON keys).
- The standalone simple-query SELECT path was aligned to the same `execute_with_columns` resolution so standalone and replicated label columns identically (standalone is the correctness oracle).

Out of scope (separate, pre-existing path): the extended-protocol `Describe` builds `RowDescription` from a static AST helper (`extract_select_columns`) that returns `None` for `SELECT *`/`table.*` in both standalone and replicated mode — not the `col{i}` bug this issue targets. Filed as a follow-on.

## Replicated-vs-standalone parity result

New test `replicated_select_column_names_match_standalone` runs identical setup on a standalone session and a replicated leader, then asserts the resolved column-name vectors are equal (and contain no `col*` placeholders) for: simple columns, aliases, expressions, `SELECT *`, aggregates, aggregate+alias, and joins. Spot-checks confirm `SELECT a AS x, b AS y` → `[x, y]` and `SELECT *` → `[a, b]`.

## Test plan

- [x] `cargo test -p vibesql-consensus` — 169 + 4 + 2 + 9 green
- [x] `cargo test -p vibesql-server` — all suites green incl. replication_tests (33)
- [x] New parity test (replicated vs standalone) green
- [x] Wire `RowDescription` column names asserted (`wire_protocol_replicated_end_to_end`)
- [x] HTTP `/api/query` JSON `columns` keys asserted (`http_query_writes_route_through_consensus`)
- [x] Builds with default and `--no-default-features` for both crates
- [x] No new clippy warnings in changed files

Closes #5427

🤖 Generated with [Claude Code](https://claude.com/claude-code)