### PR TITLE
feat(server): buffer prepared EXECUTE inside a replicated transaction

### DIFF
--- a/crates/vibesql-server/src/session.rs
+++ b/crates/vibesql-server/src/session.rs
@@ -698,18 +698,33 @@ impl Session {
         &mut self,
         execute_stmt: &vibesql_ast::ExecuteStmt,
     ) -> Result<ExecutionResult> {
-        let name = execute_stmt.name.clone();
+        let sql = self.substitute_execute_sql(execute_stmt)?;
+        // Box the recursive dispatch: `execute` → `execute_replicated` →
+        // here → `execute` would otherwise be an infinitely sized future.
+        Box::pin(self.execute(&sql)).await
+    }
+
+    /// Resolve an `EXECUTE <name>(args...)` to the substituted SQL *text*.
+    ///
+    /// Looks up the named prepared statement, evaluates the EXECUTE arguments
+    /// to literal values, validates the count, and renders them back into the
+    /// prepared statement's SQL text by replacing the `?` / `$N` placeholders
+    /// in order — the same text-substitution contract the extended wire
+    /// protocol's Bind path uses to route parameterized writes through
+    /// consensus. Shared by the autocommit EXECUTE path (`replicated_execute`)
+    /// and the open-transaction EXECUTE path (`execute_in_open_txn`), so a
+    /// prepared write buffers into the open transaction exactly as if the
+    /// substituted SQL had been issued directly.
+    fn substitute_execute_sql(
+        &self,
+        execute_stmt: &vibesql_ast::ExecuteStmt,
+    ) -> Result<String> {
+        let name = &execute_stmt.name;
         let prepared = self
             .named_statements
-            .get(&name)
-            .ok_or_else(|| anyhow::anyhow!("Prepared statement '{}' not found", name))?
-            .clone();
+            .get(name)
+            .ok_or_else(|| anyhow::anyhow!("Prepared statement '{}' not found", name))?;
 
-        // Evaluate the EXECUTE arguments to literal values, then render them
-        // back into the prepared statement's SQL text by replacing the `?`
-        // / `$N` placeholders in order — the same text-substitution contract
-        // the extended wire protocol's Bind path already uses to route
-        // parameterized writes through consensus.
         let params: Vec<SqlValue> =
             execute_stmt.params.iter().map(evaluate_expression).collect::<Result<Vec<_>>>()?;
 
@@ -722,10 +737,7 @@ impl Session {
             ));
         }
 
-        let sql = substitute_named_params(prepared.sql(), &params);
-        // Box the recursive dispatch: `execute` → `execute_replicated` →
-        // here → `execute` would otherwise be an infinitely sized future.
-        Box::pin(self.execute(&sql)).await
+        Ok(substitute_named_params(prepared.sql(), &params))
     }
 
     /// Roll back an open replicated transaction (#5391): discard the
@@ -931,20 +943,32 @@ impl Session {
             Statement::Pragma(_) => Ok(ExecutionResult::Other { message: "PRAGMA".to_string() }),
 
             // PREPARE/DEALLOCATE are session-local and harmless inside a
-            // transaction. EXECUTE of a prepared *write* inside a
-            // transaction is refused: `execute_in_open_txn` is synchronous
-            // (it cannot re-enter the async replicated dispatch to buffer the
-            // substituted SQL), and silently dropping it would be unsound.
-            // Use the substituted SQL directly inside the transaction, or
-            // run the prepared statement outside one (full prepared-EXECUTE
-            // inside replicated transactions is the scoped follow-on #5401).
+            // transaction.
             Statement::Prepare(stmt) => self.replicated_prepare(stmt),
             Statement::Deallocate(stmt) => self.execute_deallocate(stmt),
-            Statement::Execute(_) => Err(SqlError::not_supported(
-                "EXECUTE of a prepared statement inside a replicated transaction",
-                "#5401",
-            )
-            .into()),
+
+            // EXECUTE inside an open replicated transaction (#5414):
+            // substitute the prepared statement's literal parameters back into
+            // its SQL *text* (the same contract the autocommit EXECUTE path
+            // uses), re-parse the result, and dispatch it through this same
+            // open-transaction path. A prepared INSERT therefore freezes and
+            // buffers into the open transaction exactly as if its substituted
+            // SQL had been issued directly — it joins the atomic COMMIT batch,
+            // a mid-transaction read sees it via the speculative replay (full
+            // read-your-own-writes), and ROLLBACK discards it. Substitution +
+            // re-parse are synchronous, so no async re-entry is needed.
+            Statement::Execute(execute_stmt) => {
+                let substituted = self.substitute_execute_sql(execute_stmt)?;
+                // Parse + cache the substituted text, cloning the AST out so
+                // we can re-dispatch against `&mut self` without holding the
+                // cache borrow.
+                let prepared = self
+                    .stmt_cache
+                    .get_or_prepare(&substituted)
+                    .map_err(|e| anyhow::anyhow!("{}", e))?;
+                let statement = prepared.statement().clone();
+                self.execute_in_open_txn(&substituted, &statement)
+            }
             Statement::DeclareCursor(_)
             | Statement::OpenCursor(_)
             | Statement::Fetch(_)

--- a/crates/vibesql-server/tests/replication_tests.rs
+++ b/crates/vibesql-server/tests/replication_tests.rs
@@ -881,6 +881,194 @@ async fn replicated_txn_savepoint_survivors_replicate_to_followers() {
 }
 
 // ---------------------------------------------------------------------------
+// Session-level: EXECUTE of a prepared statement inside a transaction (#5414)
+// ---------------------------------------------------------------------------
+
+/// A PREPARE'd INSERT EXECUTE'd inside an open replicated transaction buffers
+/// into the batch exactly like a simple-query write: the read-your-own-writes
+/// path sees it mid-transaction, nothing is proposed until COMMIT, and the
+/// whole transaction lands as a **single** consensus entry.
+#[tokio::test]
+async fn replicated_txn_prepared_execute_buffers_into_batch() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let mut session = replicated_session(&handles[0]);
+
+    session.execute("CREATE TABLE users (id INT, name VARCHAR(100))").await.unwrap();
+    session.execute("PREPARE ins FROM 'INSERT INTO users VALUES (?, ?)'").await.unwrap();
+    let applied_before = handles[0].node().last_applied();
+
+    session.execute("BEGIN").await.unwrap();
+    // A prepared EXECUTE inside the txn acks optimistically (rows = 0) and
+    // buffers like a plain INSERT — it is not refused.
+    let r = session.execute("EXECUTE ins (1, 'Alice')").await.unwrap();
+    assert!(matches!(r, ExecutionResult::Insert { rows_affected: 0 }), "{r:?}");
+    let r = session.execute("EXECUTE ins USING 2, 'Bob'").await.unwrap();
+    assert!(matches!(r, ExecutionResult::Insert { rows_affected: 0 }), "{r:?}");
+
+    // Nothing applied yet: the buffer is not proposed until COMMIT.
+    assert_eq!(handles[0].node().last_applied(), applied_before, "buffer must not apply early");
+
+    // Read-your-own-writes: the buffered prepared INSERTs are visible mid-txn,
+    // with the quoted string preserved (no quote-escaping breakage).
+    let rows = select_rows(session.execute("SELECT id, name FROM users ORDER BY id").await.unwrap());
+    assert_eq!(rows.len(), 2, "read-your-own-writes: buffered prepared INSERTs visible");
+    assert_eq!(rows[1].values[1].to_string(), "Bob");
+
+    session.execute("COMMIT").await.unwrap();
+    // The whole transaction — both prepared writes — committed as one entry.
+    assert_eq!(
+        handles[0].node().last_applied(),
+        applied_before + 1,
+        "the transaction must be a single log entry"
+    );
+    let rows = handles[0].node().query("SELECT id, name FROM users ORDER BY id").unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[1][1].to_string(), "Bob");
+}
+
+/// ROLLBACK discards a prepared EXECUTE buffered inside the transaction: no
+/// log index is consumed and the prepared write never lands. The named
+/// statement survives (PREPARE is session-local), so a later autocommit
+/// EXECUTE still works.
+#[tokio::test]
+async fn replicated_txn_prepared_execute_rolled_back_discards_write() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let mut session = replicated_session(&handles[0]);
+
+    session.execute("CREATE TABLE t (id INT)").await.unwrap();
+    session.execute("PREPARE ins FROM 'INSERT INTO t VALUES (?)'").await.unwrap();
+    let applied_before = handles[0].node().last_applied();
+
+    session.execute("BEGIN").await.unwrap();
+    session.execute("EXECUTE ins (1)").await.unwrap();
+    assert!(matches!(session.execute("ROLLBACK").await.unwrap(), ExecutionResult::Rollback));
+
+    // No entry consumed, no row landed.
+    assert_eq!(handles[0].node().last_applied(), applied_before, "rollback must not propose");
+    let rows = select_rows(session.execute("SELECT id FROM t").await.unwrap());
+    assert!(rows.is_empty(), "rolled-back prepared write must not be visible");
+
+    // The named statement survived; an autocommit EXECUTE proposes immediately.
+    let r = session.execute("EXECUTE ins (2)").await.unwrap();
+    assert!(matches!(r, ExecutionResult::Insert { rows_affected: 1 }), "{r:?}");
+    assert_eq!(handles[0].node().last_applied(), applied_before + 1);
+}
+
+/// A prepared INSERT of a volatile value (`random()`) EXECUTE'd inside a
+/// transaction freezes once at buffer time: the mid-transaction read and the
+/// committed row carry the same value — same freeze-at-buffer contract as a
+/// simple-query volatile write.
+#[tokio::test]
+async fn replicated_txn_prepared_execute_volatile_value_is_frozen() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let mut session = replicated_session(&handles[0]);
+
+    session.execute("CREATE TABLE t (id INT, r INT)").await.unwrap();
+    // The volatile call lives in the prepared text; only `id` is a parameter.
+    session.execute("PREPARE ins FROM 'INSERT INTO t VALUES (?, abs(random()))'").await.unwrap();
+
+    session.execute("BEGIN").await.unwrap();
+    session.execute("EXECUTE ins (1)").await.unwrap();
+    let rows = select_rows(session.execute("SELECT r FROM t WHERE id = 1").await.unwrap());
+    assert_eq!(rows.len(), 1);
+    let mid_txn_value = rows[0].values[0].clone();
+
+    session.execute("COMMIT").await.unwrap();
+    let rows = select_rows(session.execute("SELECT r FROM t WHERE id = 1").await.unwrap());
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].values[0], mid_txn_value,
+        "a prepared volatile write must freeze once: committed value == mid-txn value"
+    );
+}
+
+/// A prepared EXECUTE buffered inside a transaction replicates atomically with
+/// the rest of the batch: after COMMIT on the leader, every follower converges
+/// to **all** of the transaction's rows (the prepared write is part of the one
+/// all-or-nothing entry).
+#[tokio::test]
+async fn replicated_txn_prepared_execute_replicates_atomically_to_followers() {
+    let (handles, _dir) = boot_cluster(3).await;
+    let leader = wait_for_leader(&handles).await;
+    let mut session = replicated_session(&handles[leader]);
+
+    session.execute("CREATE TABLE kv (id INT, v INT)").await.unwrap();
+    session.execute("PREPARE ins FROM 'INSERT INTO kv VALUES (?, ?)'").await.unwrap();
+    session.execute("BEGIN").await.unwrap();
+    // Mix a prepared EXECUTE with a simple-query write in the same batch.
+    session.execute("EXECUTE ins (1, 10)").await.unwrap();
+    session.execute("INSERT INTO kv VALUES (2, 20)").await.unwrap();
+    session.execute("EXECUTE ins (3, 30)").await.unwrap();
+    session.execute("COMMIT").await.unwrap();
+
+    // Every follower converges to all three rows (never a partial 1 or 2).
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    for (i, h) in handles.iter().enumerate() {
+        if i == leader {
+            continue;
+        }
+        loop {
+            let count = h
+                .node()
+                .query("SELECT COUNT(*) FROM kv")
+                .ok()
+                .and_then(|r| r.first().and_then(|row| row.first()).map(ToString::to_string));
+            if count.as_deref() == Some("3") {
+                break;
+            }
+            assert!(
+                matches!(count.as_deref(), None | Some("0") | Some("3")),
+                "follower {i} saw a non-atomic count: {count:?}"
+            );
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "follower {i} did not converge to 3 rows (saw {count:?})"
+            );
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+}
+
+/// A prepared EXECUTE buffered inside a transaction on a follower fails fast
+/// with SQLSTATE 25006 (the leader-redirect contract): freezing a buffered
+/// write is leader-only, so the prepared path is not a bypass. The
+/// transaction stays open (nothing buffered) and ROLLBACK cleanly closes it.
+#[tokio::test]
+async fn replicated_txn_prepared_execute_on_follower_redirects() {
+    let (handles, _dir) = boot_cluster(3).await;
+    let leader = wait_for_leader(&handles).await;
+
+    replicated_session(&handles[leader]).execute("CREATE TABLE t (id INT)").await.unwrap();
+
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    let follower = loop {
+        if let Some(i) = handles
+            .iter()
+            .position(|h| h.role() == Role::Follower && h.node().current_leader().is_some())
+        {
+            break i;
+        }
+        assert!(tokio::time::Instant::now() < deadline, "timed out waiting for a follower");
+        tokio::time::sleep(POLL_INTERVAL).await;
+    };
+
+    let mut session = replicated_session(&handles[follower]);
+    session.execute("PREPARE ins FROM 'INSERT INTO t VALUES (?)'").await.unwrap();
+
+    // BEGIN succeeds (session-local), but the buffered prepared write fails
+    // fast: freezing is leader-only, so the follower surfaces 25006.
+    session.execute("BEGIN").await.unwrap();
+    let err = session.execute("EXECUTE ins (1)").await.unwrap_err();
+    assert_eq!(sql_error(&err).code, "25006", "buffered prepared write must redirect like a write");
+
+    // The transaction is still open (nothing buffered); ROLLBACK closes it.
+    assert!(matches!(session.execute("ROLLBACK").await.unwrap(), ExecutionResult::Rollback));
+}
+
+// ---------------------------------------------------------------------------
 // Wire-level: full server in replicated mode, driven by tokio-postgres
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Lifts the `0A000` refusal on `EXECUTE <prepared>` inside an open replicated transaction (the last remaining refusal after #5401/#5413). A prepared write now buffers into the open transaction exactly like a plain INSERT.

- `execute_in_open_txn`'s `Statement::Execute(_)` arm no longer refuses. It substitutes the prepared statement's literal params back into its SQL text (via the new shared `substitute_execute_sql` helper, the same `substitute_named_params` + `ToSql` quote-safe contract the autocommit EXECUTE path uses), re-parses the result, and re-dispatches it through `execute_in_open_txn`.
- Substitution + re-parse are synchronous, so the originally-cited "blocked on making the open-txn buffering path async" concern does not apply — no async re-entry is needed. `replicated_execute` (autocommit) is refactored to share the same helper.
- The prepared write therefore freezes-at-buffer-time, joins the single atomic COMMIT `TxnEntry`, is visible mid-txn through the speculative read-your-own-writes path (#5401), and is discarded by ROLLBACK. On a follower it still surfaces `25006` (freezing is leader-only), so the prepared path is not a leader bypass.

## Why it was refused

`execute_in_open_txn` is synchronous and the EXECUTE path went `execute` -> `execute_replicated` -> `replicated_execute` -> `Box::pin(self.execute(&sql)).await` (async). The fix observes the substitution itself is sync; we substitute and re-dispatch synchronously into the buffering path instead of round-tripping through the async dispatch.

## Test evidence

Added to `crates/vibesql-server/tests/replication_tests.rs`:
- `replicated_txn_prepared_execute_buffers_into_batch` — buffers (rows=0), RYW sees it mid-txn, one entry at COMMIT
- `replicated_txn_prepared_execute_rolled_back_discards_write` — ROLLBACK consumes no index, named stmt survives
- `replicated_txn_prepared_execute_volatile_value_is_frozen` — `random()` mid-txn value == committed value
- `replicated_txn_prepared_execute_replicates_atomically_to_followers` — 3-node, mixed prepared + simple writes, all-or-nothing convergence
- `replicated_txn_prepared_execute_on_follower_redirects` — 25006 on a follower, txn stays open, ROLLBACK closes it

Results:
- New tests: 5/5 pass
- `cargo test -p vibesql-server`: all suites green (417 lib + integration tests, 0 failures), standalone transaction/prepared regressions included
- Flake-check: multi-node tests 12/12 green
- `cargo clippy -p vibesql-server --tests`: no new lints (only pre-existing unrelated `Rng`/`compare_values` warnings in other crates)

## Test plan
- [x] EXECUTE-in-txn buffers + RYW
- [x] ROLLBACK discards prepared write
- [x] freeze-at-buffer consistency for volatile prepared write
- [x] multi-node atomic replication
- [x] follower redirect 25006
- [x] standalone regression green
- [x] flake-check 12x

Closes #5414

🤖 Generated with [Claude Code](https://claude.com/claude-code)