### PR TITLE
feat(executor): honor RAISE per-variant txn-scope (ABORT/FAIL/ROLLBACK)

### DIFF
--- a/crates/vibesql-consensus/src/state_machine.rs
+++ b/crates/vibesql-consensus/src/state_machine.rs
@@ -1198,6 +1198,69 @@ mod tests {
         assert_eq!(machine.last_applied(), 4);
     }
 
+    /// A `RAISE()` fired from a replicated trigger rejects the whole applied
+    /// entry deterministically (#5417): the per-variant abort scope is a pure
+    /// function of the entry + applied state, so every replica records the
+    /// same `Rejected` outcome and the same (rolled-back, empty) rows. The
+    /// replicated apply path applies a buffered batch as one storage
+    /// transaction and rolls the whole batch back on any rejected statement —
+    /// a coarser-but-equally-deterministic scope than the local
+    /// per-statement RAISE handling.
+    #[test]
+    fn raise_in_replicated_trigger_rejects_entry_deterministically() {
+        let build = || {
+            let machine = VibesqlStateMachine::new();
+            create_users(&machine, 1);
+            machine
+                .apply(
+                    2,
+                    &TxnEntry::single(
+                        "CREATE TRIGGER trg BEFORE INSERT ON users WHEN NEW.name = 'BAD' \
+                         BEGIN SELECT raise(ABORT, 'no bad names'); END",
+                    ),
+                )
+                .unwrap();
+            machine
+        };
+
+        // The offending entry inserts a good row then a row the trigger
+        // RAISEs on: the entry is rejected and nothing from it survives.
+        let raising_entry = || {
+            TxnEntry::batch([
+                "INSERT INTO users VALUES (1, 'alice')",
+                "INSERT INTO users VALUES (2, 'BAD')",
+            ])
+        };
+
+        let machine_a = build();
+        let outcome_a = machine_a.apply(3, &raising_entry()).unwrap();
+        assert!(
+            matches!(outcome_a, ApplyOutcome::Rejected { .. }),
+            "RAISE entry must be rejected, got {outcome_a:?}"
+        );
+        // Whole batch rolled back — not even the 'alice' row survives.
+        assert!(names(&machine_a).is_empty(), "rejected entry leaves no rows");
+        // Index is still consumed (rejected identically everywhere).
+        assert_eq!(machine_a.last_applied(), 3);
+
+        // A second, independent replica applying the same log produces the
+        // identical outcome and state — replication determinism.
+        let machine_b = build();
+        let outcome_b = machine_b.apply(3, &raising_entry()).unwrap();
+        assert_eq!(
+            format!("{outcome_a:?}"),
+            format!("{outcome_b:?}"),
+            "both replicas reject with the identical outcome"
+        );
+        assert!(names(&machine_b).is_empty());
+
+        // Re-applying the already-consumed index is idempotent.
+        assert_eq!(
+            machine_a.apply(3, &raising_entry()).unwrap(),
+            ApplyOutcome::AlreadyApplied
+        );
+    }
+
     /// Speculative reads (#5401) see the buffer's own writes but never
     /// commit them: after a `speculative_query`, the applied state is
     /// unchanged (no double-apply), and the entry can still be applied
@@ -1683,6 +1746,17 @@ mod tests {
             E::TableNotFound("t".to_string()),
             E::DivisionByZero,
             E::IntegerOverflow,
+            // RAISE(ABORT|FAIL|ROLLBACK) from a trigger (#5409/#5417): a pure
+            // function of the (replicated) statement + state, so it rejects the
+            // entry identically on every replica — never a node-local halt.
+            E::Raise {
+                action: vibesql_ast::RaiseAction::Abort,
+                message: "boom".to_string(),
+            },
+            E::Raise {
+                action: vibesql_ast::RaiseAction::Rollback,
+                message: "boom".to_string(),
+            },
         ];
         for e in &deterministic {
             assert!(

--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -95,7 +95,12 @@ impl DeleteExecutor {
     /// assert_eq!(count, 1);
     /// ```
     pub fn execute(stmt: &DeleteStmt, database: &mut Database) -> Result<usize, ExecutorError> {
-        Self::execute_internal(stmt, database, None, None).map(|(count, _)| count)
+        // SQLite per-variant RAISE scope handling for the top-level statement
+        // (#5417): see [`crate::raise_scope::run_top_level_dml`].
+        let may_fire = crate::raise_scope::table_may_fire_trigger(database, &stmt.table_name);
+        crate::raise_scope::run_top_level_dml(database, may_fire, |database| {
+            Self::execute_internal(stmt, database, None, None).map(|(count, _)| count)
+        })
     }
 
     /// Execute a DELETE statement, capturing RETURNING rows (SQLite 3.35.0+)

--- a/crates/vibesql-executor/src/insert/mod.rs
+++ b/crates/vibesql-executor/src/insert/mod.rs
@@ -23,7 +23,12 @@ impl InsertExecutor {
         db: &mut vibesql_storage::Database,
         stmt: &vibesql_ast::InsertStmt,
     ) -> Result<usize, ExecutorError> {
-        execution::execute_insert(db, stmt)
+        // Wrap the top-level statement in SQLite's per-variant RAISE scope
+        // handling (#5417): inside an explicit transaction, RAISE(ABORT) undoes
+        // just this statement, RAISE(FAIL) keeps its partial changes, and
+        // RAISE(ROLLBACK) rolls back the whole transaction.
+        let may_fire = crate::raise_scope::table_may_fire_trigger(db, &stmt.table_name);
+        crate::raise_scope::run_top_level_dml(db, may_fire, |db| execution::execute_insert(db, stmt))
     }
 
     /// Execute an INSERT statement, capturing RETURNING rows (SQLite 3.35.0+)

--- a/crates/vibesql-executor/src/lib.rs
+++ b/crates/vibesql-executor/src/lib.rs
@@ -35,6 +35,7 @@ pub mod persistence;
 pub mod pipeline;
 mod privilege_checker;
 pub mod procedural;
+mod raise_scope;
 pub mod profiling;
 mod revoke;
 mod role_ddl;

--- a/crates/vibesql-executor/src/raise_scope.rs
+++ b/crates/vibesql-executor/src/raise_scope.rs
@@ -1,0 +1,148 @@
+//! Per-variant transaction-scope handling for the SQLite `RAISE()`
+//! conflict-resolution actions (#5417).
+//!
+//! `RAISE(ABORT|FAIL|ROLLBACK, msg)` fired from a trigger reports `msg` (SQLite
+//! error code 19) but the three variants differ in *how much* they undo when
+//! they abort the firing statement inside an explicit multi-statement
+//! transaction. Verified against sqlite3 3.51.x:
+//!
+//! - **`RAISE(ABORT, msg)`** — roll back the current **statement** (undo the
+//!   partial changes it already applied), but keep the enclosing transaction
+//!   open: statements that ran *before* it in the same transaction survive.
+//!   This is also SQLite's default conflict behavior.
+//! - **`RAISE(FAIL, msg)`** — stop the statement at the failing row but do
+//!   **not** undo the changes it already applied to earlier rows; keep the
+//!   transaction open.
+//! - **`RAISE(ROLLBACK, msg)`** — roll back the **entire** enclosing
+//!   transaction.
+//! - `RAISE(IGNORE)` is handled earlier as a control-flow signal
+//!   ([`ExecutorError::RaiseIgnore`]) and never reaches this module.
+//!
+//! The distinction is only observable inside an explicit transaction: outside
+//! one, every statement is its own auto-commit unit, so all three variants
+//! leave identical state (the failing statement's changes vanish either way).
+//! See [`apply_raise_scope`] and [`run_top_level_dml`].
+//!
+//! ## Replication determinism
+//!
+//! The abort scope is a pure function of the `RaiseAction` carried in the
+//! error and the storage transaction state — both of which are identical on
+//! every replica that applies the same log entry — so the surviving rows are
+//! deterministic across nodes. (The replicated apply path additionally rolls
+//! back the *whole* buffered batch on any rejected statement, which is a
+//! strictly coarser, equally-deterministic scope; see
+//! `vibesql-consensus::state_machine`.)
+
+use vibesql_ast::RaiseAction;
+use vibesql_storage::Database;
+
+use crate::errors::ExecutorError;
+
+/// Cheap pre-check: does `table` carry any trigger that could fire a `RAISE`?
+///
+/// A `RAISE()` can only originate from a trigger body, so a table with no
+/// triggers can never need a statement savepoint. This lets the common
+/// (trigger-free) DML path skip the snapshot entirely.
+pub(crate) fn table_may_fire_trigger(db: &Database, table: &str) -> bool {
+    db.catalog.get_triggers_for_table(table, None).next().is_some()
+}
+
+/// Apply the transaction-scope rollback for a `RAISE(action, msg)` that
+/// aborted a top-level statement, then return the (unchanged) error so the
+/// caller can propagate it.
+///
+/// Assumes the executor armed an implicit statement savepoint via
+/// [`Database::arm_statement_savepoint`] before running the statement (when a
+/// transaction is active). The savepoint is consumed here regardless of which
+/// scope is chosen.
+///
+/// - `Abort` → roll back to the statement savepoint (undo this statement only).
+/// - `Fail` → keep the statement's partial changes; just release the savepoint.
+/// - `Rollback` → roll back the whole transaction.
+/// - `Ignore` → unreachable (handled as a control-flow signal upstream); kept
+///   as a no-op for totality.
+pub(crate) fn apply_raise_scope(
+    db: &mut Database,
+    action: RaiseAction,
+    message: String,
+) -> ExecutorError {
+    match action {
+        RaiseAction::Abort => {
+            // Undo just this statement's changes; the transaction stays open
+            // and earlier statements survive. No-op outside a transaction
+            // (nothing was armed) — the statement's changes are dropped by the
+            // caller's own per-statement rollback paths / auto-commit instead.
+            db.rollback_statement_savepoint();
+        }
+        RaiseAction::Fail => {
+            // Keep the partial changes the statement already applied; only
+            // discard the now-unneeded snapshot.
+            db.release_statement_savepoint();
+        }
+        RaiseAction::Rollback => {
+            // Roll back the entire enclosing transaction. Best-effort: if no
+            // transaction is active (RAISE(ROLLBACK) outside BEGIN), there is
+            // nothing to roll back beyond the statement itself.
+            db.release_statement_savepoint();
+            if db.in_transaction() {
+                let _ = db.rollback_transaction();
+            }
+        }
+        RaiseAction::Ignore => {
+            // Control-flow signal handled upstream; never reaches here.
+            db.release_statement_savepoint();
+        }
+    }
+    ExecutorError::Raise { action, message }
+}
+
+/// Run a top-level DML statement with SQLite per-variant `RAISE` scope
+/// handling.
+///
+/// When a transaction is active **and** `may_fire_trigger` is true (the only
+/// way a `RAISE()` can fire), this arms an implicit statement savepoint before
+/// running `f`, so a `RAISE(ABORT)` can undo just this statement. On a
+/// `RAISE(..)` error it applies the per-variant scope; on success or any other
+/// error it releases the savepoint (leaving the changes in place — non-RAISE
+/// errors keep their existing rollback behavior, unchanged by this wrapper).
+///
+/// When no transaction is active, or the table has no triggers, this is a
+/// thin pass-through with zero snapshot cost — preserving the hot path.
+pub(crate) fn run_top_level_dml<T, F>(
+    db: &mut Database,
+    may_fire_trigger: bool,
+    f: F,
+) -> Result<T, ExecutorError>
+where
+    F: FnOnce(&mut Database) -> Result<T, ExecutorError>,
+{
+    // Fast path: nothing can RAISE (no triggers) or there is no surrounding
+    // transaction whose earlier statements must survive — run directly.
+    let armed =
+        if may_fire_trigger && db.in_transaction() { db.arm_statement_savepoint() } else { false };
+
+    let result = f(db);
+
+    match result {
+        Ok(v) => {
+            if armed {
+                db.release_statement_savepoint();
+            }
+            Ok(v)
+        }
+        Err(ExecutorError::Raise { action, message }) => {
+            // Apply the per-variant scope. `apply_raise_scope` consumes the
+            // savepoint (armed or not) and returns the error to propagate.
+            Err(apply_raise_scope(db, action, message))
+        }
+        Err(other) => {
+            // Non-RAISE errors keep their pre-existing behavior. The DML
+            // executors already perform their own targeted rollback for these
+            // (e.g. constraint failures), so we just drop the snapshot.
+            if armed {
+                db.release_statement_savepoint();
+            }
+            Err(other)
+        }
+    }
+}

--- a/crates/vibesql-executor/src/tests/raise_trigger_tests.rs
+++ b/crates/vibesql-executor/src/tests/raise_trigger_tests.rs
@@ -6,12 +6,14 @@
 //!   surfaced verbatim.
 //! - `RAISE(IGNORE)` abandons just the current row and continues with no error.
 //!
-//! Because VibeSQL evaluates a statement's row set and *then* applies it (the
-//! BEFORE trigger loop runs before any mutation), a single aborting statement
-//! leaves the table unchanged for all of ABORT/FAIL/ROLLBACK — the distinction
-//! between their rollback scopes is exercised by the parser/AST layer and the
-//! per-variant error mapping; broader multi-statement transaction-scope
-//! differences are tracked as a follow-on.
+//! For a *single* aborting statement the three abort variants leave identical
+//! visible state (the failing statement's changes vanish either way). Their
+//! rollback-scope differences are only observable inside an explicit
+//! multi-statement transaction — those are covered by the
+//! "Multi-statement transaction scope (#5417)" section below, where ABORT
+//! rolls back just the statement, FAIL keeps the statement's partial changes,
+//! and ROLLBACK rolls back the whole transaction (all verified against
+//! sqlite3 3.51.0).
 
 use vibesql_ast::Statement;
 use vibesql_parser::Parser;
@@ -22,15 +24,14 @@ use crate::errors::ExecutorError;
 
 /// Execute setup SQL that is expected to succeed.
 fn exec_ok(db: &mut vibesql_storage::Database, sql: &str) {
-    let stmt = Parser::parse_sql(sql)
-        .unwrap_or_else(|e| panic!("Failed to parse {:?}: {:?}", sql, e));
+    let stmt =
+        Parser::parse_sql(sql).unwrap_or_else(|e| panic!("Failed to parse {:?}: {:?}", sql, e));
     match stmt {
         Statement::CreateTable(s) => {
             CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
         }
         Statement::CreateTrigger(s) => {
-            crate::advanced_objects::execute_create_trigger(&s, db)
-                .expect("CREATE TRIGGER failed");
+            crate::advanced_objects::execute_create_trigger(&s, db).expect("CREATE TRIGGER failed");
         }
         Statement::Insert(s) => {
             InsertExecutor::execute(db, &s).expect("INSERT failed");
@@ -47,12 +48,9 @@ fn exec_ok(db: &mut vibesql_storage::Database, sql: &str) {
 
 /// Execute a DML statement and return the Result so the caller can assert on a
 /// RAISE-driven error.
-fn exec_dml(
-    db: &mut vibesql_storage::Database,
-    sql: &str,
-) -> Result<usize, ExecutorError> {
-    let stmt = Parser::parse_sql(sql)
-        .unwrap_or_else(|e| panic!("Failed to parse {:?}: {:?}", sql, e));
+fn exec_dml(db: &mut vibesql_storage::Database, sql: &str) -> Result<usize, ExecutorError> {
+    let stmt =
+        Parser::parse_sql(sql).unwrap_or_else(|e| panic!("Failed to parse {:?}: {:?}", sql, e));
     match stmt {
         Statement::Insert(s) => InsertExecutor::execute(db, &s),
         Statement::Update(s) => UpdateExecutor::execute(&s, db),
@@ -62,11 +60,7 @@ fn exec_dml(
 }
 
 /// Read column `col` of every row in `table`, ordered by physical position.
-fn column_values(
-    db: &vibesql_storage::Database,
-    table: &str,
-    col: &str,
-) -> Vec<SqlValue> {
+fn column_values(db: &vibesql_storage::Database, table: &str, col: &str) -> Vec<SqlValue> {
     let schema = db.catalog.get_table(table).expect("table exists");
     let idx = schema.columns.iter().position(|c| c.name == col).expect("column exists");
     db.get_table(table)
@@ -197,11 +191,8 @@ fn raise_ignore_skips_only_the_matching_update_row() {
     );
 
     // Row 2 maps to 999 (ignored); rows 1 and 3 get +100. No error.
-    let affected = exec_dml(
-        &mut db,
-        "UPDATE t SET v = CASE WHEN id = 2 THEN 999 ELSE v + 100 END",
-    )
-    .expect("RAISE(IGNORE) must not error");
+    let affected = exec_dml(&mut db, "UPDATE t SET v = CASE WHEN id = 2 THEN 999 ELSE v + 100 END")
+        .expect("RAISE(IGNORE) must not error");
 
     // Rows 1 and 3 updated; row 2 unchanged at 20.
     assert_eq!(ints(&db, "t", "v"), vec![110, 20, 130]);
@@ -244,6 +235,189 @@ fn raise_ignore_skips_only_the_matching_delete_row() {
 
     assert_eq!(ints(&db, "t", "id"), vec![2]);
     assert_eq!(affected, 2, "only the non-ignored rows are deleted/counted");
+}
+
+// ===========================================================================
+// Multi-statement transaction scope (#5417)
+//
+// The per-variant rollback scope (ABORT vs FAIL vs ROLLBACK) is only
+// observable inside an explicit BEGIN...COMMIT. Each test below mirrors a
+// scenario verified against sqlite3 3.51.0:
+//
+//   CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+//   CREATE TRIGGER trg <BEFORE|AFTER> INSERT ON t WHEN NEW.v = 'BAD'
+//     BEGIN SELECT RAISE(<action>, 'boom'); END;
+//   BEGIN;
+//   INSERT INTO t VALUES (1,'before');         -- earlier statement
+//   INSERT INTO t VALUES (...);                -- offending statement (RAISEs)
+//   ...                                        -- (txn still open for ABORT/FAIL)
+//   COMMIT;
+//
+// sqlite3 reference results are documented inline per test.
+// ===========================================================================
+
+/// Build a db with table `t(id INTEGER PRIMARY KEY, v TEXT)` and a trigger.
+fn db_with_trigger(timing_event: &str, action: &str) -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)");
+    exec_ok(
+        &mut db,
+        &format!(
+            "CREATE TRIGGER trg {timing_event} ON t WHEN NEW.v = 'BAD' \
+             BEGIN SELECT raise({action}, 'boom'); END"
+        ),
+    );
+    db
+}
+
+fn texts(db: &vibesql_storage::Database, table: &str, col: &str) -> Vec<String> {
+    column_values(db, table, col)
+        .into_iter()
+        .map(|v| match v {
+            SqlValue::Varchar(s) => s.to_string(),
+            SqlValue::Null => "<null>".to_string(),
+            other => panic!("expected text, got {:?}", other),
+        })
+        .collect()
+}
+
+/// RAISE(ABORT): the offending statement is rolled back, but earlier and
+/// later statements in the same transaction survive, and the transaction
+/// stays open.
+///
+/// sqlite3 3.51.0 final rows for `{before}, {BAD}, {after}`: `{before, after}`.
+#[test]
+fn raise_abort_keeps_transaction_open_and_prior_statements_survive() {
+    let mut db = db_with_trigger("BEFORE INSERT", "ABORT");
+
+    db.begin_transaction().expect("BEGIN");
+
+    exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (1, 'before')").expect("stmt 1 ok");
+
+    // Offending statement: BEFORE trigger fires RAISE(ABORT).
+    match exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (2, 'BAD')") {
+        Err(ExecutorError::Raise { action, message }) => {
+            assert_eq!(action, vibesql_ast::RaiseAction::Abort);
+            assert_eq!(message, "boom");
+        }
+        other => panic!("expected RAISE(ABORT), got {:?}", other),
+    }
+
+    // Transaction is STILL OPEN (ABORT only rolls back the statement).
+    assert!(db.in_transaction(), "ABORT must keep the transaction open");
+
+    // A later statement still runs inside the same transaction.
+    exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (3, 'after')").expect("stmt 3 ok");
+
+    db.commit_transaction().expect("COMMIT");
+
+    // Row 1 (before) and row 3 (after) survive; row 2 (BAD) was aborted.
+    assert_eq!(ints(&db, "t", "id"), vec![1, 3]);
+    assert_eq!(texts(&db, "t", "v"), vec!["before".to_string(), "after".to_string()]);
+}
+
+/// RAISE(ROLLBACK): the entire transaction is rolled back and closed.
+///
+/// sqlite3 3.51.0: after the RAISE, `no transaction is active` — even the
+/// earlier `before` row is gone.
+#[test]
+fn raise_rollback_aborts_entire_transaction() {
+    let mut db = db_with_trigger("BEFORE INSERT", "ROLLBACK");
+
+    db.begin_transaction().expect("BEGIN");
+
+    exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (1, 'before')").expect("stmt 1 ok");
+    assert_eq!(ints(&db, "t", "id"), vec![1], "row 1 visible before the RAISE");
+
+    match exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (2, 'BAD')") {
+        Err(ExecutorError::Raise { action, message }) => {
+            assert_eq!(action, vibesql_ast::RaiseAction::Rollback);
+            assert_eq!(message, "boom");
+        }
+        other => panic!("expected RAISE(ROLLBACK), got {:?}", other),
+    }
+
+    // The WHOLE transaction was rolled back: no longer in a transaction, and
+    // even the earlier `before` row is gone.
+    assert!(!db.in_transaction(), "ROLLBACK must end the transaction");
+    assert!(db.get_table("t").unwrap().scan().is_empty(), "all rows rolled back");
+}
+
+/// RAISE(ABORT) vs RAISE(FAIL): with an AFTER trigger and a multi-row
+/// statement, the offending statement has already applied some rows when the
+/// trigger fires. ABORT undoes the whole statement; FAIL keeps the rows the
+/// statement already applied (including the offending row, inserted before the
+/// AFTER trigger ran).
+///
+/// Scenario: txn has row 1; statement inserts (2,'okA'),(3,'BAD'),(4,'okB').
+///   - ABORT  → final rows `{1}`            (whole statement undone)
+///   - FAIL   → final rows `{1, 2, 3}`      (rows applied so far kept; row 4
+///                                           never reached)
+/// Both verified against sqlite3 3.51.0.
+#[test]
+fn raise_abort_undoes_whole_statement_with_after_trigger() {
+    let mut db = db_with_trigger("AFTER INSERT", "ABORT");
+
+    db.begin_transaction().expect("BEGIN");
+    exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (1, 'before')").expect("stmt 1 ok");
+
+    match exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (2, 'okA'), (3, 'BAD'), (4, 'okB')") {
+        Err(ExecutorError::Raise { action, .. }) => {
+            assert_eq!(action, vibesql_ast::RaiseAction::Abort);
+        }
+        other => panic!("expected RAISE(ABORT), got {:?}", other),
+    }
+
+    assert!(db.in_transaction(), "ABORT keeps the transaction open");
+    db.commit_transaction().expect("COMMIT");
+
+    // ABORT undoes the entire offending statement — only row 1 survives.
+    assert_eq!(ints(&db, "t", "id"), vec![1]);
+}
+
+#[test]
+fn raise_fail_keeps_partial_statement_changes_with_after_trigger() {
+    let mut db = db_with_trigger("AFTER INSERT", "FAIL");
+
+    db.begin_transaction().expect("BEGIN");
+    exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (1, 'before')").expect("stmt 1 ok");
+
+    match exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (2, 'okA'), (3, 'BAD'), (4, 'okB')") {
+        Err(ExecutorError::Raise { action, .. }) => {
+            assert_eq!(action, vibesql_ast::RaiseAction::Fail);
+        }
+        other => panic!("expected RAISE(FAIL), got {:?}", other),
+    }
+
+    assert!(db.in_transaction(), "FAIL keeps the transaction open");
+    db.commit_transaction().expect("COMMIT");
+
+    // FAIL keeps the rows applied before the trigger fired: row 1 (earlier
+    // statement), row 2 ('okA'), and row 3 ('BAD' — inserted before its AFTER
+    // trigger raised). Row 4 ('okB') was never reached.
+    assert_eq!(ints(&db, "t", "id"), vec![1, 2, 3]);
+    assert_eq!(
+        texts(&db, "t", "v"),
+        vec!["before".to_string(), "okA".to_string(), "BAD".to_string()]
+    );
+}
+
+/// Outside an explicit transaction, all three variants behave identically:
+/// the offending statement leaves no trace (auto-commit unit) and no
+/// transaction is opened. Guards against the savepoint machinery leaking an
+/// implicit transaction.
+#[test]
+fn raise_outside_transaction_leaves_no_open_transaction() {
+    for action in ["ABORT", "FAIL", "ROLLBACK"] {
+        let mut db = db_with_trigger("BEFORE INSERT", action);
+        exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (1, 'ok')").expect("seed row");
+
+        let err = exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (2, 'BAD')").unwrap_err();
+        assert!(matches!(err, ExecutorError::Raise { .. }), "{action}: expected RAISE");
+        assert!(!db.in_transaction(), "{action}: must not leave a transaction open");
+        // Only the seeded row remains; the BAD insert never applied.
+        assert_eq!(ints(&db, "t", "id"), vec![1], "{action}");
+    }
 }
 
 #[test]

--- a/crates/vibesql-executor/src/update/mod.rs
+++ b/crates/vibesql-executor/src/update/mod.rs
@@ -136,7 +136,12 @@ impl UpdateExecutor {
     /// assert_eq!(count, 1);
     /// ```
     pub fn execute(stmt: &UpdateStmt, database: &mut Database) -> Result<usize, ExecutorError> {
-        executor::execute_internal(stmt, database, None, None, None).map(|(count, _)| count)
+        // SQLite per-variant RAISE scope handling for the top-level statement
+        // (#5417): see [`crate::raise_scope::run_top_level_dml`].
+        let may_fire = crate::raise_scope::table_may_fire_trigger(database, &stmt.table_name);
+        crate::raise_scope::run_top_level_dml(database, may_fire, |database| {
+            executor::execute_internal(stmt, database, None, None, None).map(|(count, _)| count)
+        })
     }
 
     /// Execute an UPDATE statement, capturing RETURNING rows (SQLite 3.35.0+)

--- a/crates/vibesql-storage/src/database/transaction_api.rs
+++ b/crates/vibesql-storage/src/database/transaction_api.rs
@@ -334,6 +334,67 @@ impl Database {
         self.lifecycle.transaction_manager_mut().release_savepoint(name)
     }
 
+    // ========================================================================
+    // Implicit statement-level savepoint (#5417 — RAISE(ABORT) scope)
+    // ========================================================================
+
+    /// Arm an implicit statement-level savepoint for the current statement.
+    ///
+    /// SQLite wraps every top-level statement in an implicit savepoint so a
+    /// `RAISE(ABORT)` (or ordinary constraint failure) can undo just that
+    /// statement's partial changes while keeping the enclosing transaction
+    /// open. The executor arms one of these before a top-level DML statement
+    /// that may fire a trigger, and on a `RAISE(ABORT)` calls
+    /// [`Self::rollback_statement_savepoint`].
+    ///
+    /// No-op (returns `false`) outside an explicit transaction: there is no
+    /// surrounding transaction whose earlier statements must survive, so the
+    /// auto-commit unit already provides the correct all-or-nothing scope.
+    ///
+    /// Snapshots catalog/tables/operations wholesale, so the subsequent
+    /// rollback correctly undoes INSERT/UPDATE/DELETE row data as well as any
+    /// PK/UNIQUE/spatial index key mutations the statement made.
+    pub fn arm_statement_savepoint(&mut self) -> bool {
+        let catalog = self.catalog.clone();
+        let tables = self.tables.clone();
+        let operations = self.operations.clone();
+        self.lifecycle.transaction_manager_mut().arm_statement_savepoint(
+            &catalog,
+            &tables,
+            &operations,
+        )
+    }
+
+    /// Roll back to the armed statement savepoint, undoing just the current
+    /// statement's changes (`RAISE(ABORT)` scope). The enclosing transaction
+    /// stays open. Returns `true` if a savepoint was armed and restored.
+    pub fn rollback_statement_savepoint(&mut self) -> bool {
+        let mut catalog = std::mem::take(&mut self.catalog);
+        let mut tables = std::mem::take(&mut self.tables);
+        let mut operations = std::mem::take(&mut self.operations);
+        let restored = self.lifecycle.transaction_manager_mut().rollback_statement_savepoint(
+            &mut catalog,
+            &mut tables,
+            &mut operations,
+        );
+        self.catalog = catalog;
+        self.tables = tables;
+        self.operations = operations;
+        restored
+    }
+
+    /// Disarm the statement savepoint without rolling back — the statement
+    /// succeeded, or a different rollback scope (`FAIL` keeps changes,
+    /// `ROLLBACK` already discarded the whole transaction) was chosen.
+    pub fn release_statement_savepoint(&mut self) {
+        self.lifecycle.transaction_manager_mut().release_statement_savepoint();
+    }
+
+    /// True when an implicit statement savepoint is currently armed.
+    pub fn has_statement_savepoint(&self) -> bool {
+        self.lifecycle.transaction_manager().has_statement_savepoint()
+    }
+
     // ============================================================================
     // Deferred FK Violation Queue (Phase C2 of #5085)
     // ============================================================================
@@ -361,5 +422,54 @@ impl Database {
     /// `sqlite3_db_status DBSTATUS_DEFERRED_FKS` PRAGMA bridge.
     pub fn deferred_fk_violations(&self) -> &[DeferredFkViolation] {
         self.lifecycle.transaction_manager().deferred_fk_violations()
+    }
+}
+
+#[cfg(test)]
+mod statement_savepoint_tests {
+    //! Contract tests for the implicit statement-level savepoint (#5417),
+    //! the primitive behind SQLite's `RAISE(ABORT)` statement-scope rollback.
+    //! End-to-end behavior (RAISE(ABORT) vs FAIL vs ROLLBACK survival rows) is
+    //! verified against sqlite3 3.51.0 in `vibesql-executor`'s
+    //! `raise_trigger_tests`.
+
+    use crate::Database;
+
+    #[test]
+    fn statement_savepoint_is_a_noop_outside_a_transaction() {
+        let mut db = Database::new();
+        // Outside a transaction nothing can be armed.
+        assert!(!db.arm_statement_savepoint(), "must not arm without a transaction");
+        assert!(!db.has_statement_savepoint());
+        // Rollback / release are harmless no-ops.
+        assert!(!db.rollback_statement_savepoint());
+        db.release_statement_savepoint();
+        assert!(!db.in_transaction(), "savepoint API must not open a transaction");
+    }
+
+    #[test]
+    fn arm_release_and_rollback_toggle_the_armed_flag() {
+        let mut db = Database::new();
+        db.begin_transaction().expect("BEGIN");
+
+        assert!(!db.has_statement_savepoint());
+        assert!(db.arm_statement_savepoint(), "arm inside a transaction succeeds");
+        assert!(db.has_statement_savepoint());
+
+        // Release disarms without ending the transaction.
+        db.release_statement_savepoint();
+        assert!(!db.has_statement_savepoint());
+        assert!(db.in_transaction());
+
+        // Re-arm, then roll back: consumes the savepoint, transaction stays open.
+        assert!(db.arm_statement_savepoint());
+        assert!(db.rollback_statement_savepoint(), "armed savepoint rolls back");
+        assert!(!db.has_statement_savepoint(), "rollback consumes the savepoint");
+        assert!(db.in_transaction(), "statement rollback keeps the transaction open");
+
+        // A second rollback with nothing armed is a no-op.
+        assert!(!db.rollback_statement_savepoint());
+
+        db.rollback_transaction().expect("ROLLBACK");
     }
 }

--- a/crates/vibesql-storage/src/database/transactions.rs
+++ b/crates/vibesql-storage/src/database/transactions.rs
@@ -67,6 +67,34 @@ pub struct Savepoint {
     pub deferred_fk_snapshot_index: usize,
 }
 
+/// An implicit statement-level savepoint (#5417).
+///
+/// SQLite wraps every top-level statement in an implicit savepoint so that
+/// `RAISE(ABORT)` (and ordinary constraint failures) can undo just that
+/// statement's partial changes while leaving earlier statements in the
+/// enclosing transaction intact. This struct captures the same wholesale
+/// catalog/tables/operations snapshot the transaction-start path uses, so a
+/// statement-level rollback is bit-for-bit equivalent to a full rollback
+/// scoped to the moment the statement began.
+///
+/// Boxed inside [`TransactionState::Active`] to keep the common (no
+/// statement savepoint armed) case cheap.
+#[derive(Debug, Clone)]
+pub struct StatementSavepoint {
+    /// Catalog snapshot taken at statement start.
+    catalog: vibesql_catalog::Catalog,
+    /// Table snapshots taken at statement start.
+    tables: HashMap<String, Table>,
+    /// Index/spatial-index (`Operations`) snapshot taken at statement start.
+    operations: Operations,
+    /// Length of the transaction's `changes` undo-log at statement start, so
+    /// the statement's own change-log entries can be truncated on rollback.
+    changes_len: usize,
+    /// Length of the deferred-FK queue at statement start, so violations
+    /// queued by the aborted statement are discarded on rollback.
+    deferred_fk_len: usize,
+}
+
 /// Transaction state
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
@@ -104,6 +132,19 @@ pub enum TransactionState {
         /// it is taken *before* the mutation is applied, preserving the
         /// exact restore semantics #5413 established.
         original_operations: Option<Operations>,
+        /// Implicit statement-level savepoint for SQLite `RAISE(ABORT)`
+        /// semantics (#5417). Captured at the start of a top-level DML
+        /// statement that *may* fire a trigger, and used to undo just that
+        /// statement's changes when a `RAISE(ABORT)` aborts it without
+        /// rolling back the enclosing transaction.
+        ///
+        /// `None` whenever no statement savepoint is currently armed (the
+        /// common case — most statements never arm one, and the no-trigger
+        /// fast path skips it entirely). It snapshots `catalog`, `tables`,
+        /// and `operations` wholesale, exactly like the transaction-start
+        /// snapshot above, so it correctly undoes INSERT/UPDATE/DELETE row
+        /// data *and* index/PK/UNIQUE key mutations made by the statement.
+        statement_savepoint: Option<Box<StatementSavepoint>>,
         /// Stack of savepoints (newest at end)
         savepoints: Vec<Savepoint>,
         /// All changes made since transaction start (for incremental undo)
@@ -269,6 +310,7 @@ impl TransactionManager {
                     original_catalog,
                     original_tables,
                     original_operations: None,
+                    statement_savepoint: None,
                     savepoints: Vec::new(),
                     changes: Vec::new(),
                     durability,
@@ -673,6 +715,90 @@ impl TransactionManager {
                 Ok(())
             }
         }
+    }
+
+    // ========================================================================
+    // Implicit statement-level savepoint (#5417 — RAISE(ABORT) scope)
+    // ========================================================================
+
+    /// Arm an implicit statement-level savepoint, snapshotting the current
+    /// catalog/tables/operations so a later [`Self::rollback_statement_savepoint`]
+    /// can undo just this statement's changes.
+    ///
+    /// No-op (returns `false`) when no transaction is active — outside an
+    /// explicit transaction every statement is its own auto-commit unit and
+    /// there is nothing to scope. Overwrites any previously-armed statement
+    /// savepoint (the caller arms exactly one per top-level statement and
+    /// releases it before the next).
+    pub fn arm_statement_savepoint(
+        &mut self,
+        catalog: &vibesql_catalog::Catalog,
+        tables: &HashMap<String, Table>,
+        operations: &Operations,
+    ) -> bool {
+        match &mut self.transaction_state {
+            TransactionState::None => false,
+            TransactionState::Active {
+                statement_savepoint, changes, deferred_fk_violations, ..
+            } => {
+                *statement_savepoint = Some(Box::new(StatementSavepoint {
+                    catalog: catalog.clone(),
+                    tables: tables.clone(),
+                    operations: operations.clone(),
+                    changes_len: changes.len(),
+                    deferred_fk_len: deferred_fk_violations.len(),
+                }));
+                true
+            }
+        }
+    }
+
+    /// Roll back to the armed statement savepoint, restoring the
+    /// catalog/tables/operations captured by [`Self::arm_statement_savepoint`]
+    /// and truncating the change / deferred-FK logs back to statement start.
+    /// Consumes (disarms) the savepoint.
+    ///
+    /// Returns `true` when a savepoint was armed and restored, `false`
+    /// otherwise (no active transaction or none armed).
+    pub fn rollback_statement_savepoint(
+        &mut self,
+        catalog: &mut vibesql_catalog::Catalog,
+        tables: &mut HashMap<String, Table>,
+        operations: &mut Operations,
+    ) -> bool {
+        match &mut self.transaction_state {
+            TransactionState::Active {
+                statement_savepoint, changes, deferred_fk_violations, ..
+            } => match statement_savepoint.take() {
+                Some(sp) => {
+                    *catalog = sp.catalog;
+                    *tables = sp.tables;
+                    *operations = sp.operations;
+                    changes.truncate(sp.changes_len);
+                    deferred_fk_violations.truncate(sp.deferred_fk_len);
+                    true
+                }
+                None => false,
+            },
+            TransactionState::None => false,
+        }
+    }
+
+    /// Disarm (release) the statement savepoint without rolling back —
+    /// the statement succeeded (or `RAISE(FAIL)`/`RAISE(ROLLBACK)` chose a
+    /// different scope). Cheap: just drops the snapshot.
+    pub fn release_statement_savepoint(&mut self) {
+        if let TransactionState::Active { statement_savepoint, .. } = &mut self.transaction_state {
+            *statement_savepoint = None;
+        }
+    }
+
+    /// True when an implicit statement savepoint is currently armed.
+    pub fn has_statement_savepoint(&self) -> bool {
+        matches!(
+            &self.transaction_state,
+            TransactionState::Active { statement_savepoint: Some(_), .. }
+        )
     }
 }
 


### PR DESCRIPTION
Closes #5417

## Summary

Implements SQLite's per-variant `RAISE()` rollback scope for multi-statement transactions, the follow-on from #5415. Previously, because a single aborting statement leaves the table unchanged for all three variants, ABORT/FAIL/ROLLBACK were indistinguishable. They differ only across an explicit `BEGIN...COMMIT`, and now do so correctly:

| Variant | Scope (verified against sqlite3 3.51.0) |
|---|---|
| `RAISE(ABORT, msg)` | Roll back the **current statement** only; transaction stays open, earlier statements survive. |
| `RAISE(FAIL, msg)` | Stop the statement **without** undoing rows it already applied; transaction stays open. |
| `RAISE(ROLLBACK, msg)` | Roll back the **entire** enclosing transaction. |
| `RAISE(IGNORE)` | Skip current row, continue (unchanged, from #5415). |

## Per-variant sqlite3-verified semantics

Reference scenario (txn already holds row 1; offending multi-row statement `INSERT (2,'okA'),(3,'BAD'),(4,'okB')` with an `AFTER INSERT` trigger that `RAISE`s on `'BAD'`):

- **ABORT** -> final rows `{1}` (whole statement undone), txn open.
- **FAIL** -> final rows `{1, 2, 3}` (rows applied before the trigger fired are kept, including the offending row 3 inserted before its AFTER trigger ran; row 4 never reached), txn open.
- **ROLLBACK** -> `{}` (whole transaction discarded), txn closed.

All confirmed byte-for-byte against `sqlite3 3.51.0`.

## Did statement-level rollback exist?

**Partly.** Full-transaction rollback (snapshot-restore of catalog/tables/operations) already existed, and named `SAVEPOINT`/`ROLLBACK TO` existed but only undo INSERT via the change-log (UPDATE/DELETE aren't recorded there). For robust statement-level ABORT across all DML, this PR **adds** an implicit statement-level savepoint in `vibesql-storage` (`arm`/`rollback`/`release_statement_savepoint`) that snapshots catalog/tables/operations wholesale — identical to the txn-start snapshot — so it correctly undoes INSERT/UPDATE/DELETE row data **and** PK/UNIQUE/spatial index key mutations.

## Implementation

- **Storage** (`transactions.rs`, `transaction_api.rs`): implicit statement savepoint stored on the active transaction state (boxed, `None` in the common case).
- **Executor** (`raise_scope.rs`): `run_top_level_dml` wraps the three top-level DML `execute` entry points. It arms the savepoint **only** when inside a transaction AND the target table has triggers (the only way a `RAISE` can fire), keeping the trigger-free hot path zero-cost. On `ExecutorError::Raise` it applies the per-variant scope. Nested trigger-body DML uses the `*_with_trigger_context` entries, so the outer statement remains the single savepoint boundary.

## Replication determinism

`ExecutorError::Raise` classifies as `Deterministic`, so a `RAISE` in a replicated trigger rejects the whole buffered batch identically on every node — a coarser, equally-deterministic scope than the local per-statement handling. Added a behavioral test confirming two independent replicas reach the identical `Rejected` outcome + empty state, and that re-apply is idempotent.

## Test plan

- [x] `cargo test -p vibesql-executor` — full suite green; 14 RAISE-trigger tests incl. 5 new multi-statement scope tests (ABORT keeps txn / prior stmts survive, ROLLBACK aborts whole txn, ABORT-vs-FAIL partial-statement distinction, outside-txn no-op).
- [x] `cargo test -p vibesql-storage` — green; 2 new statement-savepoint contract tests.
- [x] `cargo test -p vibesql-consensus` — green; replication-determinism test + RAISE added to deterministic-classification assertion.
- [x] `cargo clippy` on all three crates — no errors/new warnings.
- [x] `vibesql-server` builds (uses the unchanged public DML entry points).
- [x] Single-statement #5415 regressions still pass.

## Follow-ons

- Procedural-context and RETURNING DML entry points (`execute_with_procedural_context`, `execute_returning`) are not yet wrapped — only the bare `execute` entries (which cover all SQL DML traffic) are. Wrapping those is a small, mechanical follow-on if RAISE-in-procedures or RAISE-in-RETURNING-DML scoping is desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)