### PR TITLE
fix(storage): undo disk-backed (spilled) index mutations on ROLLBACK

### DIFF
--- a/crates/vibesql-storage/src/btree/node/btree_index/bulk_load.rs
+++ b/crates/vibesql-storage/src/btree/node/btree_index/bulk_load.rs
@@ -229,8 +229,15 @@ impl BTreeIndex {
         // 3. Root is the single remaining node
         let root_page_id = current_level[0];
 
-        let index =
-            BTreeIndex { root_page_id, key_schema, degree, height, page_manager, metadata_page_id };
+        let index = BTreeIndex {
+            root_page_id,
+            key_schema,
+            degree,
+            height,
+            page_manager,
+            metadata_page_id,
+            undo_log: None,
+        };
 
         // Save metadata without syncing (we'll sync once at the end)
         index.save_metadata_no_sync()?;

--- a/crates/vibesql-storage/src/btree/node/btree_index/delete.rs
+++ b/crates/vibesql-storage/src/btree/node/btree_index/delete.rs
@@ -66,11 +66,21 @@ impl BTreeIndex {
     /// 4. Propagate rebalancing up the tree if necessary
     /// 5. Collapse the root if it has only one child
     pub fn delete(&mut self, key: &Key) -> Result<bool, StorageError> {
+        // Transaction undo-logging (#5425): a full-key delete removes *all*
+        // row_ids for the key, so the inverse must re-insert every one of
+        // them. Capture them before mutating, but only when logging is active
+        // (the lookup is otherwise wasted work).
+        let undo_row_ids =
+            if self.undo_log.is_some() { Some(self.lookup(key)?) } else { None };
+
         // Handle single-level tree (root is leaf)
         if self.height == 1 {
             let mut root_leaf = self.read_leaf_node(self.root_page_id)?;
             let deleted = root_leaf.delete_all(key);
             if deleted {
+                if let Some(row_ids) = undo_row_ids {
+                    self.record_undo_reinsert(key.clone(), row_ids);
+                }
                 self.write_leaf_node(&root_leaf)?;
             }
             return Ok(deleted);
@@ -82,6 +92,10 @@ impl BTreeIndex {
         // Delete all row_ids for the key from leaf
         if !leaf.delete_all(key) {
             return Ok(false); // Key not found
+        }
+
+        if let Some(row_ids) = undo_row_ids {
+            self.record_undo_reinsert(key.clone(), row_ids);
         }
 
         // Write leaf back
@@ -134,6 +148,7 @@ impl BTreeIndex {
             let mut root_leaf = self.read_leaf_node(self.root_page_id)?;
             let deleted = root_leaf.delete(key, row_id);
             if deleted {
+                self.record_undo_reinsert(key.clone(), vec![row_id]);
                 self.write_leaf_node(&root_leaf)?;
             }
             return Ok(deleted);
@@ -146,6 +161,10 @@ impl BTreeIndex {
         if !leaf.delete(key, row_id) {
             return Ok(false); // Key or row_id not found
         }
+
+        // Transaction undo-logging (#5425): the row was removed, so its
+        // inverse is a re-insert of (key, row_id).
+        self.record_undo_reinsert(key.clone(), vec![row_id]);
 
         // Write leaf back
         self.write_leaf_node(&leaf)?;
@@ -216,6 +235,9 @@ impl BTreeIndex {
                 if root_leaf.delete(key, *row_id) {
                     deleted_count += 1;
                     modified = true;
+                    // Transaction undo-logging (#5425): inverse of a batch
+                    // delete is a re-insert of each removed (key, row_id).
+                    self.record_undo_reinsert(key.clone(), vec![*row_id]);
                 }
             }
 
@@ -268,6 +290,9 @@ impl BTreeIndex {
                 if current_leaf.delete(key, *row_id) {
                     deleted_count += 1;
                     leaf_modified = true;
+                    // Transaction undo-logging (#5425): record the re-insert
+                    // inverse for each removed (key, row_id) pair.
+                    self.record_undo_reinsert(key.clone(), vec![*row_id]);
                 }
                 entry_idx += 1;
             } else {

--- a/crates/vibesql-storage/src/btree/node/btree_index/insert.rs
+++ b/crates/vibesql-storage/src/btree/node/btree_index/insert.rs
@@ -79,6 +79,13 @@ impl BTreeIndex {
     /// 3. Handling splits that may propagate up the tree
     /// 4. Creating a new root if split reaches the original root
     pub fn insert(&mut self, key: Key, row_id: RowId) -> Result<(), StorageError> {
+        // Transaction undo-logging (#5425): record the inverse of this insert
+        // (a delete of the specific (key, row_id) pair) *before* mutating, so
+        // ROLLBACK can reverse it. Recorded only when logging is active.
+        if let Some(log) = self.undo_log.as_mut() {
+            log.push(super::DiskUndoOp::DeleteSpecific { key: key.clone(), row_id });
+        }
+
         // Special case: height 1 means root is a leaf
         if self.height == 1 {
             // Read root as leaf

--- a/crates/vibesql-storage/src/btree/node/btree_index/mod.rs
+++ b/crates/vibesql-storage/src/btree/node/btree_index/mod.rs
@@ -14,12 +14,29 @@ use vibesql_types::DataType;
 use super::{
     super::calculate_degree,
     datatype_serialization::{deserialize_datatype, serialize_datatype},
-    structure::{InternalNode, LeafNode},
+    structure::{InternalNode, Key, LeafNode, RowId},
 };
 use crate::{
     page::{PageId, PageManager},
     StorageError,
 };
+
+/// A single reversible mutation recorded while transaction undo-logging is
+/// enabled on a disk-backed B+ tree (issue #5425).
+///
+/// Each variant stores enough information to undo the mutation that produced
+/// it by applying its logical inverse:
+/// - an `insert(key, row_id)` is undone by `delete_specific(key, row_id)`;
+/// - a `delete_specific(key, row_id)` is undone by `insert(key, row_id)`;
+/// - a full-key `delete(key)` is undone by re-inserting every `row_id` that
+///   was present for that key at delete time.
+#[derive(Debug, Clone)]
+pub enum DiskUndoOp {
+    /// Undo an insert by deleting the specific (key, row_id) pair.
+    DeleteSpecific { key: Key, row_id: RowId },
+    /// Undo a delete by re-inserting the (key, row_id) pairs that were removed.
+    Reinsert { key: Key, row_ids: Vec<RowId> },
+}
 
 // Submodules
 mod bulk_load;
@@ -70,6 +87,22 @@ pub struct BTreeIndex {
     /// This field will be used when supporting multiple B+ trees with different metadata pages
     #[allow(dead_code)]
     pub(super) metadata_page_id: PageId,
+    /// Transaction undo-log (issue #5425).
+    ///
+    /// When `Some`, every mutating operation (`insert`, `delete`,
+    /// `delete_specific`, `delete_batch`) appends the logical inverse needed
+    /// to undo it. ROLLBACK replays the recorded inverses in reverse order to
+    /// restore the disk-backed index to its pre-transaction state; COMMIT
+    /// simply discards the log. When `None` (the default, and the non-
+    /// transactional fast path) no recording occurs and there is zero
+    /// overhead.
+    ///
+    /// This exists because `IndexData::DiskBacked` clones as a *shallow*
+    /// `Arc<Mutex<BTreeIndex>>` bump, so the copy-on-write `Operations`
+    /// rollback snapshot (#5413/#5419) shares the *same* live B+ tree as the
+    /// transaction. Restoring that shallow clone is a no-op for spilled
+    /// indexes, so mutations must instead be reversed via this undo-log.
+    pub(super) undo_log: Option<Vec<DiskUndoOp>>,
 }
 
 impl BTreeIndex {
@@ -81,6 +114,73 @@ impl BTreeIndex {
     /// coercion (issue #5337) without any disk I/O.
     pub fn key_schema(&self) -> &[DataType] {
         &self.key_schema
+    }
+
+    /// Begin recording a transaction undo-log on this disk-backed B+ tree
+    /// (issue #5425).
+    ///
+    /// After this call, every mutating operation records the inverse needed to
+    /// undo it (see [`DiskUndoOp`]). Idempotent: if logging is already active
+    /// the existing log is preserved (so a no-op second BEGIN-snapshot does not
+    /// discard already-recorded mutations). Call [`Self::rollback_undo_log`] to
+    /// reverse, or [`Self::clear_undo_log`] to commit/discard.
+    pub fn begin_undo_logging(&mut self) {
+        if self.undo_log.is_none() {
+            self.undo_log = Some(Vec::new());
+        }
+    }
+
+    /// Returns `true` if transaction undo-logging is currently active.
+    pub fn is_undo_logging(&self) -> bool {
+        self.undo_log.is_some()
+    }
+
+    /// Record a `Reinsert` undo entry (the inverse of a delete) when undo-
+    /// logging is active. No-op otherwise. Used by the delete paths.
+    pub(super) fn record_undo_reinsert(&mut self, key: Key, row_ids: Vec<RowId>) {
+        if row_ids.is_empty() {
+            return;
+        }
+        if let Some(log) = self.undo_log.as_mut() {
+            log.push(DiskUndoOp::Reinsert { key, row_ids });
+        }
+    }
+
+    /// Stop recording and discard the undo-log without reversing anything
+    /// (COMMIT path — mutations are already persisted in the B+ tree).
+    pub fn clear_undo_log(&mut self) {
+        self.undo_log = None;
+    }
+
+    /// Reverse all recorded mutations, restoring the B+ tree to the state it
+    /// had when [`Self::begin_undo_logging`] was called, then stop recording
+    /// (ROLLBACK path).
+    ///
+    /// Inverses are applied in reverse order (LIFO) so overlapping mutations
+    /// on the same key unwind correctly. The reversal itself is performed with
+    /// logging disabled so it does not record new entries.
+    pub fn rollback_undo_log(&mut self) -> Result<(), StorageError> {
+        // Take the log out and disable recording so the inverse operations
+        // below run on the non-logging fast path.
+        let log = match self.undo_log.take() {
+            Some(log) => log,
+            None => return Ok(()),
+        };
+
+        for op in log.into_iter().rev() {
+            match op {
+                DiskUndoOp::DeleteSpecific { key, row_id } => {
+                    self.delete_specific(&key, row_id)?;
+                }
+                DiskUndoOp::Reinsert { key, row_ids } => {
+                    for row_id in row_ids {
+                        self.insert(key.clone(), row_id)?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Create a new B+ tree index
@@ -126,6 +226,7 @@ impl BTreeIndex {
             height: 1,
             page_manager,
             metadata_page_id,
+            undo_log: None,
         };
 
         // Write empty root to disk
@@ -186,6 +287,7 @@ impl BTreeIndex {
             height,
             page_manager,
             metadata_page_id: 0,
+            undo_log: None,
         })
     }
 

--- a/crates/vibesql-storage/src/btree/node/tests.rs
+++ b/crates/vibesql-storage/src/btree/node/tests.rs
@@ -1378,3 +1378,182 @@ fn test_delete_batch_empty() {
     // Original entry should still exist
     assert_eq!(index.lookup(&vec![SqlValue::Integer(10)]).unwrap(), vec![1]);
 }
+
+// ============================================================================
+// Transaction undo-log (issue #5425)
+//
+// `IndexData::DiskBacked` clones as a shallow `Arc<Mutex<BTreeIndex>>` bump, so
+// the copy-on-write `Operations` rollback snapshot does not undo spilled-index
+// mutations. The undo-log records the inverse of each mutation so ROLLBACK can
+// reverse it; COMMIT discards it. These tests pin the reversibility of every
+// mutating B+ tree operation.
+// ============================================================================
+
+/// Build a fresh disk-backed B+ tree seeded with `(int_key, row_id)` entries.
+fn undo_test_index(seed: &[(i64, RowId)]) -> (BTreeIndex, tempfile::TempDir) {
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let storage = Arc::new(crate::NativeStorage::new(temp_dir.path()).unwrap());
+    let page_manager = Arc::new(PageManager::new("undo_test.db", storage).unwrap());
+
+    let mut index = BTreeIndex::new(page_manager, vec![DataType::Integer]).unwrap();
+    for (k, row_id) in seed {
+        index.insert(vec![SqlValue::Integer(*k)], *row_id).unwrap();
+    }
+    (index, temp_dir)
+}
+
+/// Capture every key's row_ids so two B+ tree states can be compared.
+fn snapshot_keys(index: &BTreeIndex, keys: &[i64]) -> Vec<(i64, Vec<RowId>)> {
+    keys.iter()
+        .map(|k| {
+            let mut rows = index.lookup(&vec![SqlValue::Integer(*k)]).unwrap();
+            rows.sort_unstable();
+            (*k, rows)
+        })
+        .collect()
+}
+
+#[test]
+fn undo_log_reverses_inserts_on_rollback() {
+    let (mut index, _dir) = undo_test_index(&[(10, 1), (20, 2)]);
+    let before = snapshot_keys(&index, &[10, 20, 30, 40]);
+
+    index.begin_undo_logging();
+    assert!(index.is_undo_logging());
+
+    // Mutate: insert a brand-new key and a duplicate row on an existing key.
+    index.insert(vec![SqlValue::Integer(30)], 3).unwrap();
+    index.insert(vec![SqlValue::Integer(40)], 4).unwrap();
+    index.insert(vec![SqlValue::Integer(10)], 5).unwrap();
+    assert_eq!(index.lookup(&vec![SqlValue::Integer(30)]).unwrap(), vec![3]);
+    assert_eq!(snapshot_keys(&index, &[10]), vec![(10, vec![1, 5])]);
+
+    index.rollback_undo_log().unwrap();
+    assert!(!index.is_undo_logging(), "rollback disables logging");
+
+    assert_eq!(
+        snapshot_keys(&index, &[10, 20, 30, 40]),
+        before,
+        "ROLLBACK must reverse all inserts, restoring the pre-transaction tree"
+    );
+}
+
+#[test]
+fn undo_log_reverses_delete_specific_on_rollback() {
+    // Non-unique key 10 holds two rows; delete one specifically.
+    let (mut index, _dir) = undo_test_index(&[(10, 1), (10, 2), (20, 3)]);
+    let before = snapshot_keys(&index, &[10, 20]);
+
+    index.begin_undo_logging();
+    assert!(index.delete_specific(&vec![SqlValue::Integer(10)], 1).unwrap());
+    assert_eq!(index.lookup(&vec![SqlValue::Integer(10)]).unwrap(), vec![2]);
+
+    index.rollback_undo_log().unwrap();
+    assert_eq!(
+        snapshot_keys(&index, &[10, 20]),
+        before,
+        "ROLLBACK must re-insert the specifically-deleted row"
+    );
+}
+
+#[test]
+fn undo_log_reverses_full_key_delete_on_rollback() {
+    // Full-key delete removes ALL rows for the key; undo must restore them all.
+    let (mut index, _dir) = undo_test_index(&[(10, 1), (10, 2), (10, 3), (20, 4)]);
+    let before = snapshot_keys(&index, &[10, 20]);
+
+    index.begin_undo_logging();
+    assert!(index.delete(&vec![SqlValue::Integer(10)]).unwrap());
+    assert!(index.lookup(&vec![SqlValue::Integer(10)]).unwrap().is_empty());
+
+    index.rollback_undo_log().unwrap();
+    assert_eq!(
+        snapshot_keys(&index, &[10, 20]),
+        before,
+        "ROLLBACK must re-insert every row removed by a full-key delete"
+    );
+}
+
+#[test]
+fn undo_log_reverses_delete_batch_on_rollback() {
+    let (mut index, _dir) = undo_test_index(&[(10, 1), (20, 2), (30, 3), (40, 4)]);
+    let before = snapshot_keys(&index, &[10, 20, 30, 40]);
+
+    index.begin_undo_logging();
+    let deleted = index
+        .delete_batch(&[
+            (vec![SqlValue::Integer(10)], 1),
+            (vec![SqlValue::Integer(30)], 3),
+        ])
+        .unwrap();
+    assert_eq!(deleted, 2);
+    assert!(index.lookup(&vec![SqlValue::Integer(10)]).unwrap().is_empty());
+
+    index.rollback_undo_log().unwrap();
+    assert_eq!(
+        snapshot_keys(&index, &[10, 20, 30, 40]),
+        before,
+        "ROLLBACK must reverse a batch delete"
+    );
+}
+
+#[test]
+fn undo_log_reverses_mixed_mutations_lifo() {
+    // Interleave inserts and deletes (including on the same key) and confirm
+    // the LIFO reversal restores the exact starting state.
+    let (mut index, _dir) = undo_test_index(&[(10, 1), (20, 2)]);
+    let before = snapshot_keys(&index, &[10, 20, 30]);
+
+    index.begin_undo_logging();
+    index.insert(vec![SqlValue::Integer(30)], 3).unwrap(); // add new key
+    index.delete(&vec![SqlValue::Integer(20)]).unwrap(); // remove existing key
+    index.insert(vec![SqlValue::Integer(20)], 9).unwrap(); // re-add with new row
+    index.delete_specific(&vec![SqlValue::Integer(10)], 1).unwrap();
+    index.insert(vec![SqlValue::Integer(10)], 7).unwrap();
+
+    index.rollback_undo_log().unwrap();
+    assert_eq!(
+        snapshot_keys(&index, &[10, 20, 30]),
+        before,
+        "interleaved mutations must unwind in LIFO order to the original tree"
+    );
+}
+
+#[test]
+fn clear_undo_log_keeps_committed_mutations() {
+    // COMMIT path: clearing the log must NOT reverse anything.
+    let (mut index, _dir) = undo_test_index(&[(10, 1)]);
+
+    index.begin_undo_logging();
+    index.insert(vec![SqlValue::Integer(20)], 2).unwrap();
+    index.delete_specific(&vec![SqlValue::Integer(10)], 1).unwrap();
+    index.clear_undo_log();
+    assert!(!index.is_undo_logging());
+
+    assert!(
+        index.lookup(&vec![SqlValue::Integer(10)]).unwrap().is_empty(),
+        "committed delete must persist"
+    );
+    assert_eq!(
+        index.lookup(&vec![SqlValue::Integer(20)]).unwrap(),
+        vec![2],
+        "committed insert must persist"
+    );
+
+    // A subsequent rollback (no active log) is a harmless no-op.
+    index.rollback_undo_log().unwrap();
+    assert_eq!(index.lookup(&vec![SqlValue::Integer(20)]).unwrap(), vec![2]);
+}
+
+#[test]
+fn no_undo_logging_has_no_overhead_and_no_reversal() {
+    // Without begin_undo_logging, mutations are not recorded and a stray
+    // rollback call does nothing.
+    let (mut index, _dir) = undo_test_index(&[(10, 1)]);
+    assert!(!index.is_undo_logging());
+    index.insert(vec![SqlValue::Integer(20)], 2).unwrap();
+    index.rollback_undo_log().unwrap(); // no log => no-op
+    assert_eq!(index.lookup(&vec![SqlValue::Integer(20)]).unwrap(), vec![2]);
+}

--- a/crates/vibesql-storage/src/database/core.rs
+++ b/crates/vibesql-storage/src/database/core.rs
@@ -152,7 +152,20 @@ impl Database {
     /// [`TransactionManager::ensure_operations_snapshot`]: crate::database::transactions::TransactionManager::ensure_operations_snapshot
     #[inline]
     pub(super) fn snapshot_operations_for_mutation(&mut self) {
+        let before = self.lifecycle.transaction_manager().operations_snapshot_clones();
         self.lifecycle.transaction_manager_mut().ensure_operations_snapshot(&self.operations);
+        let after = self.lifecycle.transaction_manager().operations_snapshot_clones();
+
+        // #5425: A *fresh* snapshot was just taken for this transaction (the
+        // clone counter advanced), meaning this is the first index mutation of
+        // the transaction. The copy-on-write snapshot restores in-memory index
+        // state on ROLLBACK, but it shares the *same* `Arc<Mutex<BTreeIndex>>`
+        // as any spilled (disk-backed) index, so shallow-clone restore is a
+        // no-op for those. Arm a per-tree undo-log now so ROLLBACK can reverse
+        // disk-backed mutations and COMMIT can discard the log.
+        if after != before {
+            self.operations.begin_disk_undo_logging();
+        }
     }
 
     // NOTE: Other method groups are defined in their respective modules:

--- a/crates/vibesql-storage/src/database/indexes/index_manager.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_manager.rs
@@ -142,6 +142,60 @@ impl IndexManager {
         self.resource_tracker = ResourceTracker::new();
     }
 
+    // ========================================================================
+    // Disk-backed index transaction undo-logging (issue #5425)
+    // ========================================================================
+    //
+    // `IndexData::DiskBacked` clones as a shallow `Arc<Mutex<BTreeIndex>>` bump,
+    // so the copy-on-write `Operations` rollback snapshot (#5413/#5419) shares
+    // the *same* live B+ tree as the transaction — restoring the shallow clone
+    // does not undo spilled-index mutations. Instead, when a mutating
+    // transaction begins we arm a per-tree undo-log; ROLLBACK reverses it and
+    // COMMIT discards it. Cost is proportional to the transaction's own
+    // mutations, not to the (by definition large) spilled index size.
+
+    /// Arm transaction undo-logging on every disk-backed B+ tree.
+    ///
+    /// Called at the copy-on-write snapshot chokepoint, just before the first
+    /// index mutation inside a transaction. In-memory / vector indexes are
+    /// unaffected (they are restored by the snapshot clone as before).
+    pub fn begin_disk_undo_logging(&mut self) {
+        for index_data in self.index_data.values_mut() {
+            if let IndexData::DiskBacked { btree, .. } = index_data {
+                if let Ok(mut guard) = acquire_btree_lock(btree) {
+                    guard.begin_undo_logging();
+                }
+            }
+        }
+    }
+
+    /// Reverse and disable the undo-log on every disk-backed B+ tree
+    /// (ROLLBACK path), restoring each spilled index to its pre-transaction
+    /// state.
+    pub fn rollback_disk_undo_logs(&mut self) {
+        for index_data in self.index_data.values_mut() {
+            if let IndexData::DiskBacked { btree, .. } = index_data {
+                if let Ok(mut guard) = acquire_btree_lock(btree) {
+                    if let Err(e) = guard.rollback_undo_log() {
+                        log::warn!("Failed to roll back disk-backed index undo-log: {:?}", e);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Disable and discard the undo-log on every disk-backed B+ tree
+    /// (COMMIT path — the mutations are already persisted in the trees).
+    pub fn clear_disk_undo_logs(&mut self) {
+        for index_data in self.index_data.values_mut() {
+            if let IndexData::DiskBacked { btree, .. } = index_data {
+                if let Ok(mut guard) = acquire_btree_lock(btree) {
+                    guard.clear_undo_log();
+                }
+            }
+        }
+    }
+
     /// Check if an index exists
     pub fn index_exists(&self, index_name: &str) -> bool {
         let normalized = normalize_index_name(index_name);
@@ -644,5 +698,248 @@ mod tests {
                 other => panic!("expected DiskBacked after spill, got {:?}", other),
             }
         }
+    }
+
+    // ========================================================================
+    // Spilled-index transaction rollback / commit (issue #5425)
+    // ========================================================================
+
+    use vibesql_catalog::{ColumnSchema, TableSchema};
+
+    use crate::database::indexes::index_operations::normalize_for_comparison;
+
+    /// Normalize an integer key the same way the insert/maintenance path does.
+    fn normalize_int(k: i64) -> SqlValue {
+        normalize_for_comparison(&SqlValue::Integer(k))
+    }
+
+    /// Build a manager holding a single-column integer index on table `t`,
+    /// seeded with `(key, row_id)` entries, then spill it to disk. Returns the
+    /// manager, the table schema, and the TempDir backing the index file.
+    fn spilled_index_manager(
+        index_name: &str,
+        seed: &[(i64, usize)],
+    ) -> (IndexManager, TableSchema, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = IndexManager::new();
+        manager.set_database_path(temp_dir.path().to_path_buf());
+
+        let schema = TableSchema::new(
+            "t".to_string(),
+            vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+        );
+
+        // Seed with normalized keys, matching how the real insert/maintenance
+        // path stores them (integers normalize to Double — see
+        // `normalize_for_comparison`). This keeps the seeded B+ tree, its
+        // inferred key schema, and the maintenance-path mutations consistent.
+        let mut data: BTreeMap<Vec<SqlValue>, Vec<usize>> = BTreeMap::new();
+        for (k, row_id) in seed {
+            data.entry(vec![normalize_int(*k)]).or_default().push(*row_id);
+        }
+
+        manager.indexes.insert(
+            index_name.to_string(),
+            IndexMetadata {
+                index_name: index_name.to_string(),
+                table_name: "t".to_string(),
+                unique: false,
+                columns: vec![vibesql_ast::IndexColumn::new_column(
+                    "id".to_string(),
+                    vibesql_ast::OrderDirection::Asc,
+                )],
+                where_clause: None,
+            },
+        );
+        manager
+            .index_data
+            .insert(index_name.to_string(), IndexData::InMemory { data, pending_deletions: vec![] });
+
+        manager.spill_index_to_disk(index_name).unwrap();
+        match manager.index_data.get(index_name).unwrap() {
+            IndexData::DiskBacked { .. } => {}
+            other => panic!("expected DiskBacked after spill, got {:?}", other),
+        }
+
+        (manager, schema, temp_dir)
+    }
+
+    /// Read the row_ids stored under `key` in a disk-backed index.
+    fn disk_lookup(manager: &IndexManager, index_name: &str, key: i64) -> Vec<usize> {
+        match manager.index_data.get(index_name).unwrap() {
+            IndexData::DiskBacked { btree, .. } => {
+                let guard = acquire_btree_lock(btree).unwrap();
+                let mut rows = guard.lookup(&vec![normalize_int(key)]).unwrap();
+                rows.sort_unstable();
+                rows
+            }
+            other => panic!("expected DiskBacked, got {:?}", other),
+        }
+    }
+
+    fn row(id: i64) -> Row {
+        Row::new(vec![SqlValue::Integer(id)])
+    }
+
+    /// #5425 core: a transaction that mutates a *spilled* (disk-backed) index
+    /// and then ROLLBACKs must leave the index identical to its pre-transaction
+    /// state. Before the undo-log fix the shallow `Arc<Mutex<BTreeIndex>>` clone
+    /// meant rollback was a no-op for spilled indexes and these mutations
+    /// survived.
+    #[test]
+    fn spilled_index_rollback_restores_state() {
+        let (mut manager, schema, _dir) =
+            spilled_index_manager("idx_t_id", &[(10, 0), (20, 1)]);
+
+        // Begin the (simulated) transaction: arm undo-logging on disk-backed
+        // indexes — exactly what the COW snapshot chokepoint does on the first
+        // index mutation.
+        manager.begin_disk_undo_logging();
+
+        // Mutate the spilled index through the real maintenance entry points.
+        manager.add_to_indexes_for_insert("t", &schema, &row(30), 2);
+        manager.add_to_indexes_for_insert("t", &schema, &row(10), 3); // duplicate key
+        manager.update_indexes_for_delete_with_values(
+            "t",
+            &schema,
+            &[SqlValue::Integer(20)],
+            1,
+        );
+
+        // Sanity: mutations are visible mid-transaction.
+        assert_eq!(disk_lookup(&manager, "idx_t_id", 30), vec![2]);
+        assert_eq!(disk_lookup(&manager, "idx_t_id", 10), vec![0, 3]);
+        assert!(disk_lookup(&manager, "idx_t_id", 20).is_empty());
+
+        // ROLLBACK.
+        manager.rollback_disk_undo_logs();
+
+        assert!(
+            disk_lookup(&manager, "idx_t_id", 30).is_empty(),
+            "inserted key must be undone on ROLLBACK"
+        );
+        assert_eq!(
+            disk_lookup(&manager, "idx_t_id", 10),
+            vec![0],
+            "duplicate row inserted in txn must be undone, original preserved"
+        );
+        assert_eq!(
+            disk_lookup(&manager, "idx_t_id", 20),
+            vec![1],
+            "deleted key must be restored on ROLLBACK"
+        );
+    }
+
+    /// #5425: COMMIT of a spilled-index transaction must persist the mutations
+    /// (clearing the undo-log must not reverse anything).
+    #[test]
+    fn spilled_index_commit_persists_state() {
+        let (mut manager, schema, _dir) =
+            spilled_index_manager("idx_t_id", &[(10, 0), (20, 1)]);
+
+        manager.begin_disk_undo_logging();
+        manager.add_to_indexes_for_insert("t", &schema, &row(30), 2);
+        manager.update_indexes_for_delete_with_values(
+            "t",
+            &schema,
+            &[SqlValue::Integer(20)],
+            1,
+        );
+
+        // COMMIT: discard the undo-log without reversing.
+        manager.clear_disk_undo_logs();
+
+        assert_eq!(
+            disk_lookup(&manager, "idx_t_id", 30),
+            vec![2],
+            "committed insert must persist on a spilled index"
+        );
+        assert!(
+            disk_lookup(&manager, "idx_t_id", 20).is_empty(),
+            "committed delete must persist on a spilled index"
+        );
+        assert_eq!(disk_lookup(&manager, "idx_t_id", 10), vec![0]);
+    }
+
+    /// #5425 + #5413/#5419: a transaction that mutates BOTH an in-memory index
+    /// and a spilled (disk-backed) index on the same table must restore both on
+    /// ROLLBACK. The in-memory index is restored by the copy-on-write snapshot
+    /// clone (modeled here by cloning before mutating and restoring after);
+    /// the disk-backed index is restored by the undo-log. This mirrors the
+    /// `rollback_transaction` sequence (reverse disk undo-log, then restore the
+    /// snapshot clone).
+    #[test]
+    fn mixed_in_memory_and_disk_backed_indexes_both_roll_back() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = IndexManager::new();
+        manager.set_database_path(temp_dir.path().to_path_buf());
+
+        let schema = TableSchema::new(
+            "t".to_string(),
+            vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+        );
+
+        let mk_meta = |name: &str| IndexMetadata {
+            index_name: name.to_string(),
+            table_name: "t".to_string(),
+            unique: false,
+            columns: vec![vibesql_ast::IndexColumn::new_column(
+                "id".to_string(),
+                vibesql_ast::OrderDirection::Asc,
+            )],
+            where_clause: None,
+        };
+
+        // In-memory index (normalized keys, matching the maintenance path).
+        let mut mem_data: BTreeMap<Vec<SqlValue>, Vec<usize>> = BTreeMap::new();
+        mem_data.entry(vec![normalize_int(10)]).or_default().push(0);
+        manager.indexes.insert("idx_mem".to_string(), mk_meta("idx_mem"));
+        manager
+            .index_data
+            .insert("idx_mem".to_string(), IndexData::InMemory { data: mem_data, pending_deletions: vec![] });
+
+        // Disk-backed (spilled) index.
+        let mut disk_data: BTreeMap<Vec<SqlValue>, Vec<usize>> = BTreeMap::new();
+        disk_data.entry(vec![normalize_int(10)]).or_default().push(0);
+        manager.indexes.insert("idx_disk".to_string(), mk_meta("idx_disk"));
+        manager
+            .index_data
+            .insert("idx_disk".to_string(), IndexData::InMemory { data: disk_data, pending_deletions: vec![] });
+        manager.spill_index_to_disk("idx_disk").unwrap();
+
+        // BEGIN: copy-on-write snapshot of the whole manager (restores in-memory
+        // indexes), and arm undo-logging on disk-backed indexes.
+        let snapshot = manager.clone();
+        manager.begin_disk_undo_logging();
+
+        // Mutate both indexes (one insert hits every matching index for the table).
+        manager.add_to_indexes_for_insert("t", &schema, &row(30), 1);
+
+        // Mid-txn both are mutated.
+        match manager.index_data.get("idx_mem").unwrap() {
+            IndexData::InMemory { data, .. } => {
+                assert!(data.contains_key(&vec![normalize_int(30)]), "in-memory mutated");
+            }
+            other => panic!("expected InMemory, got {:?}", other),
+        }
+        assert_eq!(disk_lookup(&manager, "idx_disk", 30), vec![1], "disk-backed mutated");
+
+        // ROLLBACK: reverse the disk-backed undo-log first, then restore the
+        // snapshot clone (this is exactly what `rollback_transaction` does).
+        manager.rollback_disk_undo_logs();
+        manager = snapshot;
+
+        // In-memory index restored by the snapshot clone.
+        match manager.index_data.get("idx_mem").unwrap() {
+            IndexData::InMemory { data, .. } => {
+                assert!(!data.contains_key(&vec![normalize_int(30)]), "in-memory rolled back");
+                assert!(data.contains_key(&vec![normalize_int(10)]));
+            }
+            other => panic!("expected InMemory, got {:?}", other),
+        }
+        // Disk-backed index restored by the undo-log (the snapshot clone shares
+        // the same now-reverted B+ tree Arc).
+        assert!(disk_lookup(&manager, "idx_disk", 30).is_empty(), "disk-backed rolled back");
+        assert_eq!(disk_lookup(&manager, "idx_disk", 10), vec![0]);
     }
 }

--- a/crates/vibesql-storage/src/database/indexes/index_metadata.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_metadata.rs
@@ -118,22 +118,32 @@ pub enum IndexData {
     /// Note: The B+ tree stores (key, row_id) pairs. For non-unique indexes,
     /// we serialize Vec<usize> as the row_id value to support multiple rows per key.
     ///
-    /// **Transaction-rollback gap (#5419, follow-on of #5413):** `Clone`
+    /// **Transaction rollback (#5425, follow-on of #5413/#5419):** `Clone`
     /// for this variant is a *shallow* `Arc` bump — the cloned snapshot and
     /// the live index share the same `Arc<Mutex<BTreeIndex>>`. The #5413 /
-    /// #5419 rollback snapshot of `Operations` therefore does **not** undo
-    /// mutations made to a spilled (disk-backed) index inside a transaction:
-    /// restoring the shallow clone restores a handle to the *same, already-
-    /// mutated* B+ tree. This is the same class of leak #5413 closed for the
-    /// in-memory index, but for spilled indexes.
+    /// #5419 copy-on-write rollback snapshot of `Operations` therefore cannot
+    /// undo mutations to a spilled index by restoring the shallow clone alone
+    /// (it would just re-point at the *same, already-mutated* B+ tree).
     ///
-    /// This is **not reachable in replicated mode** today: the state machine
-    /// builds the database via `Database::new()` (no `database_path`), so
-    /// index spilling — which requires a path — never triggers there. It is
-    /// a latent gap only for standalone-with-path databases that spill an
-    /// index and then ROLLBACK. Tracked as a focused follow-on; the
-    /// copy-on-write change in #5419 deliberately preserves the existing
-    /// #5413 behavior here rather than expanding scope.
+    /// To fix this, disk-backed mutations are undone via a per-tree **undo-log**
+    /// (#5425): when a transaction's first index mutation arms the COW snapshot,
+    /// [`BTreeIndex::begin_undo_logging`] is also called on every disk-backed
+    /// tree (see [`IndexManager::begin_disk_undo_logging`]). ROLLBACK reverses
+    /// the log ([`IndexManager::rollback_disk_undo_logs`]); COMMIT discards it
+    /// ([`IndexManager::clear_disk_undo_logs`]). The cost is proportional to the
+    /// transaction's own mutations, not the (by definition large) spilled index
+    /// size, which would defeat the purpose of spilling. Note: this covers
+    /// full-transaction ROLLBACK; savepoint-scoped rollback of disk-backed
+    /// mutations is tracked as a separate follow-on.
+    ///
+    /// This path is **not reachable in replicated mode**: the state machine
+    /// builds the database via `Database::new()` (no `database_path`), so index
+    /// spilling — which requires a path — never triggers there. It applies to
+    /// standalone-with-path databases that spill an index and then ROLLBACK.
+    ///
+    /// [`IndexManager::begin_disk_undo_logging`]: super::IndexManager::begin_disk_undo_logging
+    /// [`IndexManager::rollback_disk_undo_logs`]: super::IndexManager::rollback_disk_undo_logs
+    /// [`IndexManager::clear_disk_undo_logs`]: super::IndexManager::clear_disk_undo_logs
     DiskBacked { btree: Arc<Mutex<BTreeIndex>>, page_manager: Arc<PageManager> },
     /// IVFFlat index for approximate nearest neighbor search on vectors
     IVFFlat { index: IVFFlatIndex },

--- a/crates/vibesql-storage/src/database/operations.rs
+++ b/crates/vibesql-storage/src/database/operations.rs
@@ -1515,6 +1515,31 @@ impl Operations {
         }
     }
 
+    // ========================================================================
+    // Disk-backed index transaction undo-logging (issue #5425)
+    // ========================================================================
+
+    /// Arm transaction undo-logging on all disk-backed (spilled) indexes.
+    ///
+    /// Disk-backed indexes are not undone by the copy-on-write `Operations`
+    /// rollback snapshot (the snapshot shares the same `Arc<Mutex<BTreeIndex>>`),
+    /// so a per-tree undo-log is recorded for the duration of a mutating
+    /// transaction. See [`super::indexes::IndexManager::begin_disk_undo_logging`].
+    pub fn begin_disk_undo_logging(&mut self) {
+        self.index_manager.begin_disk_undo_logging();
+    }
+
+    /// Reverse the disk-backed index undo-logs (ROLLBACK path), restoring each
+    /// spilled index to its pre-transaction state.
+    pub fn rollback_disk_undo_logs(&mut self) {
+        self.index_manager.rollback_disk_undo_logs();
+    }
+
+    /// Discard the disk-backed index undo-logs (COMMIT path — already persisted).
+    pub fn clear_disk_undo_logs(&mut self) {
+        self.index_manager.clear_disk_undo_logs();
+    }
+
     /// Reset the operations manager to empty state (clears all indexes).
     ///
     /// Clears all index data but preserves configuration (database path, storage backend, config).

--- a/crates/vibesql-storage/src/database/transaction_api.rs
+++ b/crates/vibesql-storage/src/database/transaction_api.rs
@@ -57,6 +57,12 @@ impl Database {
 
         self.lifecycle.transaction_manager_mut().commit_transaction()?;
 
+        // #5425: Discard the disk-backed index undo-logs armed during this
+        // transaction. The spilled-index mutations are already persisted in
+        // their B+ trees, so COMMIT simply stops recording and drops the log.
+        // No-op when nothing spilled or the transaction never mutated an index.
+        self.operations.clear_disk_undo_logs();
+
         // SQLite: PRAGMA defer_foreign_keys is automatically reset to OFF at
         // every COMMIT (R-21752-26913, fkey6-1.10.1). This is a session-level
         // flag, so reset it here regardless of FK enforcement state.

--- a/crates/vibesql-storage/src/database/transactions.rs
+++ b/crates/vibesql-storage/src/database/transactions.rs
@@ -418,6 +418,19 @@ impl TransactionManager {
                 // keys inserted during the transaction must be undone,
                 // otherwise a later legitimate write spuriously fails the
                 // uniqueness check against a stale, rolled-back key (#5413).
+                // #5425: Reverse any disk-backed (spilled) index mutations
+                // *before* swapping in the snapshot. The copy-on-write snapshot
+                // shares the same `Arc<Mutex<BTreeIndex>>` as the live spilled
+                // index, so restoring the shallow clone alone is a no-op for
+                // disk-backed indexes — their mutations must be undone via the
+                // per-tree undo-log armed at the first mutation. Reversing on
+                // the live `operations` reverts the shared B+ tree; the
+                // subsequent snapshot restore then re-points at the reverted
+                // tree (and drops any index that only began spilling mid-txn,
+                // which is correct for rollback). When no snapshot was taken
+                // (read-only txn) no undo-log was armed, so this is a no-op.
+                operations.rollback_disk_undo_logs();
+
                 if let Some(snapshot) = original_operations {
                     *operations = snapshot.clone();
                 }


### PR DESCRIPTION
## Summary

Closes #5425.

`IndexData::DiskBacked { btree: Arc<Mutex<BTreeIndex>>, .. }` derives `Clone` as a **shallow `Arc` bump**, so the copy-on-write `Operations` rollback snapshot (#5413/#5419) shares the *same* live B+ tree as the transaction. Restoring that shallow clone is a no-op for spilled indexes, so a standalone-with-path database that **spills an index and then ROLLBACKs** kept the transaction's index mutations — the same class of leak #5413 closed for in-memory indexes, but for spilled ones. (Not reachable in replicated mode: the state machine uses `Database::new()` with no path, so spilling never triggers.)

## Chosen approach: undo-log (option b)

Considered:
- **(a) deep-clone the spilled B+ tree per txn** — correct but defeats the purpose of spilling (a spilled index is large by definition).
- **(c) page-level COW** — `BTreeIndex`/`PageManager` expose no page-COW primitives; large change.
- **(b) undo-log** — chosen. The BTreeIndex API is cleanly invertible (`insert` ⟺ `delete_specific`), so recording each mutation's inverse and reversing it on ROLLBACK costs **O(txn mutations)**, not O(index size).

### How it works
- `BTreeIndex` gains an optional `undo_log`. When armed, `insert` / `delete` / `delete_specific` / `delete_batch` push their logical inverse (`DeleteSpecific` for an insert; `Reinsert` of the removed row_ids for a delete). Recording happens at the **B+ tree boundary**, so all ~15 scattered disk-backed mutation sites are covered uniformly with zero changes to those call sites.
- Transaction lifecycle wiring:
  - **BEGIN (first index mutation):** `snapshot_operations_for_mutation` (the #5419 COW chokepoint) detects a freshly-taken snapshot and arms `begin_disk_undo_logging()` on every disk-backed tree.
  - **ROLLBACK:** `rollback_transaction` reverses the undo-logs on the *live* (shared) trees **before** restoring the snapshot clone — so the shared `Arc` is reverted and the clone re-points at the corrected tree (LIFO reversal handles overlapping mutations on a key).
  - **COMMIT:** `clear_disk_undo_logs()` discards the log (mutations already persisted).
- When no snapshot is taken (read-only txn) no log is armed → zero overhead, preserving the #5419 lazy-clone property.

Scope: this fixes **full-transaction ROLLBACK** (the issue's acceptance). Savepoint-scoped rollback of disk-backed mutations needs nested undo markers and is filed as a follow-on.

## Forcing spilling in tests

In test builds `DISK_BACKED_THRESHOLD == usize::MAX`, so the Database API never spills. Tests instead force a real spill via the directly-callable `IndexManager::spill_index_to_disk` (the pattern existing spill tests use), then drive the real maintenance entry points (`add_to_indexes_for_insert`, `update_indexes_for_delete_with_values`) and the real lifecycle helpers. Seed/probe keys are normalized (`Integer` → `Double`) to match the production insert path.

## Test evidence

New tests (all green):
- `btree::node::tests` — 7 undo-log unit tests: inserts, `delete_specific`, full-key `delete`, `delete_batch`, interleaved-LIFO all reverse on rollback; `clear_undo_log` keeps committed mutations; no-logging path is a no-op.
- `database::indexes::index_manager::tests`:
  - `spilled_index_rollback_restores_state` — **core**: spilled index mutated in a txn is bit-for-bit restored on ROLLBACK.
  - `spilled_index_commit_persists_state` — COMMIT persists spilled-index mutations.
  - `mixed_in_memory_and_disk_backed_indexes_both_roll_back` — one txn mutating both index kinds rolls both back (in-memory via snapshot clone, disk-backed via undo-log).

Regression: the #5413/#5419 in-memory rollback tests (`rollback_restores_index_manager_state`, `commit_keeps_index_manager_state`, `read_only_transaction_does_not_clone_operations_snapshot`, `mutating_transaction_clones_operations_snapshot_once_and_rolls_back`) still pass.

- `cargo test -p vibesql-storage` — green (default features): 670 + 16 + 13 + 15 passed.
- `cargo test -p vibesql-storage --features in-memory-indexes` — green: 670 + 16 + 13 + 15 passed.
- `cargo build --workspace` — clean.
- `cargo clippy -p vibesql-storage --lib` — no new lints in changed code.

## Follow-ons
- Savepoint-scoped (`SAVEPOINT`/`ROLLBACK TO`) and statement-savepoint rollback of disk-backed mutations (needs nested undo markers).
- `rebuild_indexes` / bulk-load full-tree replacement is outside the per-row DML undo path; if a rebuild ever runs mid-transaction it would not be undone (currently not on the transactional DML path).

## Test plan
- [x] Spilled-index ROLLBACK restores pre-txn state
- [x] Spilled-index COMMIT persists
- [x] In-memory #5413/#5419 regressions still pass
- [x] Mixed in-memory + disk-backed txn both roll back
- [x] `cargo test -p vibesql-storage` green (both feature states)
- [x] `cargo build --workspace`

Generated with [Claude Code](https://claude.com/claude-code)