### PR TITLE
Wire RAISE(IGNORE) SkipRow through REPLACE / UPDATE-FROM / INSTEAD-OF trigger paths

### DIFF
--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -458,7 +458,10 @@ impl DeleteExecutor {
         // Fire BEFORE STATEMENT triggers only if triggers exist AND we're not inside a trigger
         // context (Statement-level triggers don't fire for deletes within trigger bodies)
         if has_delete_triggers && trigger_context.is_none() {
-            crate::TriggerFirer::execute_before_statement_triggers(
+            // Statement-level RAISE(IGNORE) has no sqlite3 analog (SQLite
+            // triggers are always FOR EACH ROW); drop the must-use outcome and
+            // keep the pre-#5418 proceed behavior (#5418).
+            let _stmt_outcome = crate::TriggerFirer::execute_before_statement_triggers(
                 database,
                 table_name,
                 vibesql_ast::TriggerEvent::Delete,
@@ -575,10 +578,13 @@ impl DeleteExecutor {
             database.invalidate_columnar_cache(table_name);
         }
 
-        // Step 6: Fire AFTER DELETE ROW triggers only if triggers exist
+        // Step 6: Fire AFTER DELETE ROW triggers only if triggers exist.
+        // AFTER triggers run once the row is already deleted; a RAISE(IGNORE)
+        // here cannot un-delete it (sqlite3 3.51 keeps the row deleted), so
+        // SkipRow is a no-op — drop the must-use outcome (#5418).
         if has_delete_triggers {
             for (_, row) in &rows_and_indices_to_delete {
-                crate::TriggerFirer::execute_after_triggers(
+                let _after_outcome = crate::TriggerFirer::execute_after_triggers(
                     database,
                     table_name,
                     vibesql_ast::TriggerEvent::Delete,
@@ -591,7 +597,9 @@ impl DeleteExecutor {
         // Fire AFTER STATEMENT triggers only if triggers exist AND we're not inside a trigger
         // context (Statement-level triggers don't fire for deletes within trigger bodies)
         if has_delete_triggers && trigger_context.is_none() {
-            crate::TriggerFirer::execute_after_statement_triggers(
+            // Statement-level RAISE(IGNORE) has no sqlite3 analog; drop the
+            // must-use outcome (#5418).
+            let _stmt_outcome = crate::TriggerFirer::execute_after_statement_triggers(
                 database,
                 table_name,
                 vibesql_ast::TriggerEvent::Delete,
@@ -1048,11 +1056,23 @@ fn execute_delete_on_view(
         collected_rows
     }; // evaluator dropped here
 
-    // Now fire triggers (database can be mutably borrowed)
+    // Now fire triggers (database can be mutably borrowed).
+    //
+    // RAISE(IGNORE) inside an INSTEAD OF DELETE trigger abandons the view
+    // operation for that row (#5418): the trigger body stops at the RAISE
+    // (`execute_trigger` returns SkipRow) and we move on to the next row. On
+    // SkipRow we `break` out of this row's remaining INSTEAD OF triggers,
+    // following the first-SkipRow-wins convention of the primary DML loops
+    // (#5415). The common single-trigger case matches sqlite3 3.51 exactly —
+    // the row's operation is skipped.
     let rows_processed = rows_to_delete.len();
     for old_row in &rows_to_delete {
         for trigger in &triggers {
-            crate::TriggerFirer::execute_trigger(database, trigger, Some(old_row), None)?;
+            if crate::TriggerFirer::execute_trigger(database, trigger, Some(old_row), None)?
+                == crate::TriggerOutcome::SkipRow
+            {
+                break;
+            }
         }
     }
 

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -817,7 +817,10 @@ fn execute_insert_internal(
     // Fire BEFORE STATEMENT triggers only if triggers exist AND we're not inside a trigger context
     // (Statement-level triggers don't fire for inserts within trigger bodies)
     if has_insert_triggers && trigger_context.is_none() {
-        crate::TriggerFirer::execute_before_statement_triggers(
+        // Statement-level RAISE(IGNORE) has no sqlite3 analog (SQLite triggers
+        // are always FOR EACH ROW); drop the must-use outcome and keep the
+        // pre-#5418 proceed behavior (#5418).
+        let _stmt_outcome = crate::TriggerFirer::execute_before_statement_triggers(
             db,
             table_name,
             vibesql_ast::TriggerEvent::Insert,
@@ -1279,7 +1282,9 @@ fn execute_insert_internal(
     // Fire AFTER STATEMENT triggers only if triggers exist AND we're not inside a trigger context
     // (Statement-level triggers don't fire for inserts within trigger bodies)
     if has_insert_triggers && trigger_context.is_none() {
-        crate::TriggerFirer::execute_after_statement_triggers(
+        // Statement-level RAISE(IGNORE) has no sqlite3 analog; drop the
+        // must-use outcome (#5418).
+        let _stmt_outcome = crate::TriggerFirer::execute_after_statement_triggers(
             db,
             table_name,
             vibesql_ast::TriggerEvent::Insert,
@@ -1677,11 +1682,23 @@ fn execute_insert_on_view(
         None
     };
 
-    // Now fire triggers (database can be mutably borrowed)
+    // Now fire triggers (database can be mutably borrowed).
+    //
+    // RAISE(IGNORE) inside an INSTEAD OF INSERT trigger abandons the view
+    // operation for that row (#5418): the trigger body stops at the RAISE
+    // (`execute_trigger` returns SkipRow) and we move on to the next row. On
+    // SkipRow we `break` out of this row's remaining INSTEAD OF triggers,
+    // following the first-SkipRow-wins convention of the primary DML loops
+    // (#5415). Verified against sqlite3 3.51: a RAISE(IGNORE) before the body's
+    // `INSERT INTO base` skips that base insert while later rows proceed.
     let rows_processed = new_rows.len();
     for row in new_rows {
         for trigger in &triggers {
-            crate::TriggerFirer::execute_trigger(db, trigger, None, Some(&row))?;
+            if crate::TriggerFirer::execute_trigger(db, trigger, None, Some(&row))?
+                == crate::trigger_execution::TriggerOutcome::SkipRow
+            {
+                break;
+            }
         }
     }
 

--- a/crates/vibesql-executor/src/insert/replace.rs
+++ b/crates/vibesql-executor/src/insert/replace.rs
@@ -56,6 +56,8 @@ pub fn handle_replace_conflicts(
         .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
 
     let mut rows_to_delete: Vec<(usize, vibesql_storage::Row)> = Vec::new();
+    // (Re-bound below after BEFORE DELETE triggers run; rows whose delete a
+    // RAISE(IGNORE) abandons are dropped from this vector — #5418.)
 
     // Use scan_live() to skip deleted rows and get correct physical indices
     for (row_index, row) in table.scan_live() {
@@ -160,15 +162,36 @@ pub fn handle_replace_conflicts(
     // This must happen BEFORE actual deletion (SQLite semantics)
     // The reserved rowid is active during this phase, so trigger INSERTs that try
     // to allocate the same rowid will fail.
+    //
+    // RAISE(IGNORE) in a BEFORE DELETE trigger abandons the delete of that
+    // conflicting row (#5418). We drop the row from `rows_to_delete` so it is
+    // NOT deleted; the conflicting row then survives. Because the REPLACE
+    // caller re-validates PK/UNIQUE constraints after this function returns,
+    // a surviving conflict surfaces as a UNIQUE/PK error — matching sqlite3
+    // 3.51 with `recursive_triggers=ON`, where a BEFORE DELETE RAISE(IGNORE)
+    // during REPLACE leaves the row in place and the subsequent insert fails
+    // with "UNIQUE constraint failed".
     if has_delete_triggers {
-        for (_, row) in &rows_to_delete {
-            TriggerFirer::execute_before_triggers(
+        let mut kept = Vec::with_capacity(rows_to_delete.len());
+        for (idx, row) in rows_to_delete {
+            let outcome = TriggerFirer::execute_before_triggers(
                 db,
                 table_name,
                 vibesql_ast::TriggerEvent::Delete,
-                Some(row),
+                Some(&row),
                 None,
             )?;
+            if outcome != crate::trigger_execution::TriggerOutcome::SkipRow {
+                kept.push((idx, row));
+            }
+        }
+        rows_to_delete = kept;
+
+        // Every conflicting row's delete was skipped by RAISE(IGNORE); there is
+        // nothing to delete. Return early so the caller's constraint
+        // re-validation runs against the still-conflicting table state.
+        if rows_to_delete.is_empty() {
+            return Ok(());
         }
     }
 
@@ -252,7 +275,10 @@ pub fn handle_replace_conflicts(
     // This must happen AFTER actual deletion (SQLite semantics)
     if has_delete_triggers {
         for (_, row) in &rows_to_delete {
-            TriggerFirer::execute_after_triggers(
+            // AFTER DELETE fires once the row is already gone. A RAISE(IGNORE)
+            // here cannot un-delete it (sqlite3 3.51 leaves the row deleted),
+            // so SkipRow is a no-op — explicitly drop the must-use outcome.
+            let _after_outcome = TriggerFirer::execute_after_triggers(
                 db,
                 table_name,
                 vibesql_ast::TriggerEvent::Delete,

--- a/crates/vibesql-executor/src/tests/raise_trigger_tests.rs
+++ b/crates/vibesql-executor/src/tests/raise_trigger_tests.rs
@@ -33,6 +33,9 @@ fn exec_ok(db: &mut vibesql_storage::Database, sql: &str) {
         Statement::CreateTrigger(s) => {
             crate::advanced_objects::execute_create_trigger(&s, db).expect("CREATE TRIGGER failed");
         }
+        Statement::CreateView(s) => {
+            crate::advanced_objects::execute_create_view(&s, db).expect("CREATE VIEW failed");
+        }
         Statement::Insert(s) => {
             InsertExecutor::execute(db, &s).expect("INSERT failed");
         }
@@ -439,4 +442,258 @@ fn raise_abort_in_insert_trigger_aborts() {
     }
     // Nothing inserted.
     assert!(db.get_table("t").unwrap().scan().is_empty());
+}
+
+// ===========================================================================
+// RAISE(IGNORE) in secondary trigger paths (#5418)
+//
+// PR #5415 wired RAISE(IGNORE) -> TriggerOutcome::SkipRow through the primary
+// INSERT/UPDATE/DELETE row loops. #5418 extends it to the REPLACE
+// conflict-resolution path, the UPDATE ... FROM secondary-update path, and the
+// INSTEAD OF (view) trigger paths. Each test below mirrors a scenario verified
+// against sqlite3 3.51.0.
+// ===========================================================================
+
+/// REPLACE / INSERT OR REPLACE: a BEFORE DELETE trigger that RAISE(IGNORE)s the
+/// conflicting row's delete leaves the row in place, so the REPLACE's insert
+/// then fails with a UNIQUE constraint error and the table is unchanged.
+///
+/// sqlite3 3.51.0 (PRAGMA recursive_triggers=ON):
+///   CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+///   INSERT INTO t VALUES(1,'a'),(2,'b');
+///   CREATE TRIGGER trg BEFORE DELETE ON t BEGIN SELECT RAISE(IGNORE); END;
+///   REPLACE INTO t VALUES(1,'NEW');  -- Error: UNIQUE constraint failed: t.id
+///   -- table unchanged: 1|a, 2|b
+#[test]
+fn raise_ignore_in_before_delete_blocks_replace_conflict() {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)");
+    exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (1, 10)");
+    exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (2, 20)");
+    // BEFORE DELETE always ignores: the conflicting row can never be deleted.
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg BEFORE DELETE ON t \
+         BEGIN SELECT raise(IGNORE); END",
+    );
+
+    // REPLACE on id=1 must resolve the conflict by deleting the old row, but
+    // the BEFORE DELETE trigger IGNOREs that delete. The surviving row then
+    // collides with the new row on the PK -> UNIQUE constraint error.
+    let result = exec_dml(&mut db, "INSERT OR REPLACE INTO t (id, v) VALUES (1, 99)");
+    assert!(
+        result.is_err(),
+        "REPLACE must fail: the IGNORE'd conflicting row still collides on the PK"
+    );
+
+    // Table unchanged: the old row survives, the new row was not inserted.
+    assert_eq!(ints(&db, "t", "id"), vec![1, 2]);
+    assert_eq!(ints(&db, "t", "v"), vec![10, 20]);
+}
+
+// NOTE: a companion test for "REPLACE where the BEFORE DELETE trigger IGNOREs
+// only SOME conflicts (the unguarded conflict still resolves)" was intentionally
+// omitted: VibeSQL has a pre-existing bug where REPLACE with ANY BEFORE DELETE
+// trigger present (even a non-firing / always-Proceed one) leaves a duplicate
+// row instead of deleting the conflicting one. That defect is independent of
+// SkipRow plumbing (it reproduces with a trigger that never raises) and is
+// tracked as a separate follow-on. The `blocks_replace_conflict` test above
+// still exercises the SkipRow wiring because every conflicting delete is
+// IGNORE'd, which correctly surfaces the UNIQUE error.
+
+/// UPDATE ... FROM (secondary-update path): a BEFORE UPDATE trigger that
+/// RAISE(IGNORE)s one matched row skips just that row; the rest update.
+///
+/// sqlite3 3.51.0:
+///   UPDATE t SET v=d.nv FROM d WHERE t.id=d.id;  -- d maps id 2 -> 999
+///   -- trigger ignores NEW.v=999, so row 2 keeps its old value, 1 and 3 update.
+#[test]
+fn raise_ignore_skips_only_matching_row_in_update_from() {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)");
+    exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (1, 10)");
+    exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (2, 20)");
+    exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (3, 30)");
+    exec_ok(&mut db, "CREATE TABLE d (id INTEGER PRIMARY KEY, nv INTEGER)");
+    exec_ok(&mut db, "INSERT INTO d (id, nv) VALUES (1, 111)");
+    exec_ok(&mut db, "INSERT INTO d (id, nv) VALUES (2, 999)");
+    exec_ok(&mut db, "INSERT INTO d (id, nv) VALUES (3, 333)");
+    // The sentinel 999 is ignored.
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg BEFORE UPDATE ON t WHEN NEW.v = 999 \
+         BEGIN SELECT raise(IGNORE); END",
+    );
+
+    let affected = exec_dml(&mut db, "UPDATE t SET v = d.nv FROM d WHERE t.id = d.id")
+        .expect("RAISE(IGNORE) must not error");
+
+    // Rows 1 and 3 updated; row 2 unchanged at 20 (its NEW value 999 ignored).
+    assert_eq!(ints(&db, "t", "v"), vec![111, 20, 333]);
+    assert_eq!(affected, 2, "the ignored row must not be counted as updated");
+}
+
+// INSTEAD OF (view) trigger tests.
+//
+// These use the trigger-level WHEN guard plus an unconditional `SELECT
+// raise(IGNORE)` placed BEFORE the base-table write, rather than an in-body
+// `CASE WHEN ... THEN raise(IGNORE) END`. VibeSQL's trigger-body statement
+// splitter currently treats the `END` of a `CASE ... END` as the trigger-body
+// terminator (a pre-existing splitter limitation, separate from #5418), so a
+// `CASE` inside a trigger body fails to parse. The WHEN-guard form exercises
+// the same INSTEAD OF SkipRow plumbing without tripping that limitation.
+//
+// SkipRow semantics for INSTEAD OF (verified against sqlite3 3.51.0): a
+// `SELECT raise(IGNORE)` aborts the rest of the current trigger's program for
+// that row — so a base-table write placed after the RAISE does not run — while
+// other rows proceed normally.
+
+/// INSTEAD OF INSERT: when the trigger fires and RAISE(IGNORE)s before its base
+/// insert, the base table is not written for that view row.
+#[test]
+fn raise_ignore_in_instead_of_insert_skips_base_write() {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE base (id INTEGER, v INTEGER)");
+    exec_ok(&mut db, "CREATE VIEW vw AS SELECT id, v FROM base");
+    // The IGNORE comes before the base insert, so the base insert is abandoned.
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg INSTEAD OF INSERT ON vw \
+         BEGIN \
+           SELECT raise(IGNORE); \
+           INSERT INTO base (id, v) VALUES (NEW.id, NEW.v); \
+         END",
+    );
+
+    exec_dml(&mut db, "INSERT INTO vw (id, v) VALUES (1, 10)")
+        .expect("RAISE(IGNORE) must not error");
+
+    // The view insert was abandoned: nothing reached the base table.
+    assert!(db.get_table("base").unwrap().scan().is_empty());
+}
+
+/// Control: the same INSTEAD OF INSERT trigger WITHOUT the RAISE writes the base
+/// table normally (confirms the path applies the operation when not skipped).
+#[test]
+fn instead_of_insert_without_ignore_writes_base() {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE base (id INTEGER, v INTEGER)");
+    exec_ok(&mut db, "CREATE VIEW vw AS SELECT id, v FROM base");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg INSTEAD OF INSERT ON vw \
+         BEGIN \
+           INSERT INTO base (id, v) VALUES (NEW.id, NEW.v); \
+         END",
+    );
+
+    exec_dml(&mut db, "INSERT INTO vw (id, v) VALUES (1, 10)").expect("view insert must succeed");
+
+    assert_eq!(ints(&db, "base", "id"), vec![1]);
+    assert_eq!(ints(&db, "base", "v"), vec![10]);
+}
+
+// NOTE: the INSTEAD OF UPDATE/DELETE tests below use a single, *unconditional*
+// trigger (no trigger-level WHEN clause). VibeSQL has a pre-existing limitation
+// where an INSTEAD OF trigger's WHEN condition cannot be evaluated on a view —
+// `evaluate_when_condition` resolves the schema via `catalog.get_table`, which
+// returns None for a view, yielding `TableNotFound`. That gap is independent of
+// #5418 (SkipRow plumbing) and is tracked as a separate follow-on. The
+// unconditional form still exercises the INSTEAD OF SkipRow path: a
+// `SELECT raise(IGNORE)` placed before the base write abandons the operation.
+
+/// INSTEAD OF UPDATE: RAISE(IGNORE) before the base UPDATE abandons the view
+/// update, so the base table is not written.
+#[test]
+fn raise_ignore_in_instead_of_update_abandons_row() {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE base (id INTEGER, v INTEGER)");
+    exec_ok(&mut db, "INSERT INTO base (id, v) VALUES (1, 10)");
+    exec_ok(&mut db, "INSERT INTO base (id, v) VALUES (2, 20)");
+    exec_ok(&mut db, "CREATE VIEW vw AS SELECT id, v FROM base");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg INSTEAD OF UPDATE ON vw \
+         BEGIN \
+           SELECT raise(IGNORE); \
+           UPDATE base SET v = NEW.v WHERE id = OLD.id; \
+         END",
+    );
+
+    exec_dml(&mut db, "UPDATE vw SET v = 999")
+        .expect("RAISE(IGNORE) in INSTEAD OF UPDATE must not error");
+
+    // Base unchanged: every row's view update was abandoned.
+    assert_eq!(ints(&db, "base", "id"), vec![1, 2]);
+    assert_eq!(ints(&db, "base", "v"), vec![10, 20]);
+}
+
+/// Control: the same INSTEAD OF UPDATE trigger WITHOUT the RAISE writes the base
+/// table for every matched view row.
+#[test]
+fn instead_of_update_without_ignore_writes_base() {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE base (id INTEGER, v INTEGER)");
+    exec_ok(&mut db, "INSERT INTO base (id, v) VALUES (1, 10)");
+    exec_ok(&mut db, "INSERT INTO base (id, v) VALUES (2, 20)");
+    exec_ok(&mut db, "CREATE VIEW vw AS SELECT id, v FROM base");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg INSTEAD OF UPDATE ON vw \
+         BEGIN \
+           UPDATE base SET v = NEW.v WHERE id = OLD.id; \
+         END",
+    );
+
+    exec_dml(&mut db, "UPDATE vw SET v = 999").expect("INSTEAD OF UPDATE must succeed");
+
+    assert_eq!(ints(&db, "base", "v"), vec![999, 999]);
+}
+
+/// INSTEAD OF DELETE: RAISE(IGNORE) before the base DELETE abandons the view
+/// delete, so no base rows are removed.
+#[test]
+fn raise_ignore_in_instead_of_delete_abandons_row() {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE base (id INTEGER, v INTEGER)");
+    exec_ok(&mut db, "INSERT INTO base (id, v) VALUES (1, 10)");
+    exec_ok(&mut db, "INSERT INTO base (id, v) VALUES (2, 20)");
+    exec_ok(&mut db, "CREATE VIEW vw AS SELECT id, v FROM base");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg INSTEAD OF DELETE ON vw \
+         BEGIN \
+           SELECT raise(IGNORE); \
+           DELETE FROM base WHERE id = OLD.id; \
+         END",
+    );
+
+    exec_dml(&mut db, "DELETE FROM vw")
+        .expect("RAISE(IGNORE) in INSTEAD OF DELETE must not error");
+
+    // Base unchanged: every row's view delete was abandoned.
+    assert_eq!(ints(&db, "base", "id"), vec![1, 2]);
+    assert_eq!(ints(&db, "base", "v"), vec![10, 20]);
+}
+
+/// Control: the same INSTEAD OF DELETE trigger WITHOUT the RAISE deletes the
+/// base rows.
+#[test]
+fn instead_of_delete_without_ignore_deletes_base() {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE base (id INTEGER, v INTEGER)");
+    exec_ok(&mut db, "INSERT INTO base (id, v) VALUES (1, 10)");
+    exec_ok(&mut db, "INSERT INTO base (id, v) VALUES (2, 20)");
+    exec_ok(&mut db, "CREATE VIEW vw AS SELECT id, v FROM base");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg INSTEAD OF DELETE ON vw \
+         BEGIN \
+           DELETE FROM base WHERE id = OLD.id; \
+         END",
+    );
+
+    exec_dml(&mut db, "DELETE FROM vw").expect("INSTEAD OF DELETE must succeed");
+
+    assert!(db.get_table("base").unwrap().scan().is_empty());
 }

--- a/crates/vibesql-executor/src/trigger_execution.rs
+++ b/crates/vibesql-executor/src/trigger_execution.rs
@@ -123,6 +123,14 @@ impl<'a> TriggerContext<'a> {
 /// DML caller can drop that row; every other (real) error still propagates via
 /// `Err`. `RAISE(ABORT|FAIL|ROLLBACK, ..)` are *not* represented here — they are
 /// genuine aborts and propagate as [`ExecutorError::Raise`].
+///
+/// Marked `#[must_use]` (#5418): the trigger-firing helpers return this so the
+/// DML caller can drop the current row on [`TriggerOutcome::SkipRow`]. A call
+/// site that writes `fire(..)?;` and discards the value would silently swallow
+/// a `RAISE(IGNORE)` and apply the row anyway. The attribute turns every such
+/// drop into a compile-time warning so new call sites must decide explicitly
+/// what to do with `SkipRow`.
+#[must_use = "a TriggerOutcome::SkipRow must be honored (skip the row); discarding it silently applies a RAISE(IGNORE)'d row"]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TriggerOutcome {
     /// Triggers completed normally; the DML operation should proceed.

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -122,9 +122,14 @@ pub(super) fn execute_internal(
         }
     }
 
-    // Fire BEFORE STATEMENT triggers only if triggers exist
+    // Fire BEFORE STATEMENT triggers only if triggers exist.
+    // Statement-level triggers are a VibeSQL extension with no sqlite3 analog
+    // (SQLite triggers are always FOR EACH ROW), so a RAISE(IGNORE) at
+    // statement granularity has no defined "skip the row" semantics. We keep
+    // the pre-#5418 behavior (proceed) and explicitly drop the must-use
+    // outcome rather than guessing.
     if has_triggers {
-        crate::TriggerFirer::execute_before_statement_triggers(
+        let _stmt_outcome = crate::TriggerFirer::execute_before_statement_triggers(
             database,
             table_name,
             vibesql_ast::TriggerEvent::Update(None),
@@ -645,10 +650,13 @@ pub(super) fn execute_internal(
         ));
     }
 
-    // Fire AFTER UPDATE triggers for all updated rows
+    // Fire AFTER UPDATE triggers for all updated rows.
+    // AFTER triggers run once the row is already updated; a RAISE(IGNORE) here
+    // cannot revert it (sqlite3 3.51 keeps the modified row), so SkipRow is a
+    // no-op — explicitly drop the must-use outcome (#5418).
     if has_triggers {
         for (_index, old_row, new_row, _changed_columns) in &index_updates {
-            crate::TriggerFirer::execute_after_triggers(
+            let _after_outcome = crate::TriggerFirer::execute_after_triggers(
                 database,
                 table_name,
                 vibesql_ast::TriggerEvent::Update(None),
@@ -694,7 +702,9 @@ pub(super) fn execute_internal(
 
     // Fire AFTER STATEMENT triggers only if triggers exist
     if has_triggers {
-        crate::TriggerFirer::execute_after_statement_triggers(
+        // Statement-level RAISE(IGNORE) has no sqlite3 analog (see BEFORE
+        // STATEMENT note above); drop the must-use outcome (#5418).
+        let _stmt_outcome = crate::TriggerFirer::execute_after_statement_triggers(
             database,
             table_name,
             vibesql_ast::TriggerEvent::Update(None),
@@ -1262,7 +1272,9 @@ fn execute_update_from(
 
     // Fire BEFORE STATEMENT triggers if needed
     if has_triggers {
-        crate::TriggerFirer::execute_before_statement_triggers(
+        // Statement-level RAISE(IGNORE) has no sqlite3 analog; drop the
+        // must-use outcome (#5418).
+        let _stmt_outcome = crate::TriggerFirer::execute_before_statement_triggers(
             database,
             table_name,
             vibesql_ast::TriggerEvent::Update(None),
@@ -1283,7 +1295,9 @@ fn execute_update_from(
     if updates.is_empty() {
         // Fire AFTER STATEMENT triggers even when no rows matched
         if has_triggers {
-            crate::TriggerFirer::execute_after_statement_triggers(
+            // Statement-level RAISE(IGNORE) has no sqlite3 analog; drop the
+            // must-use outcome (#5418).
+            let _stmt_outcome = crate::TriggerFirer::execute_after_statement_triggers(
                 database,
                 table_name,
                 vibesql_ast::TriggerEvent::Update(None),
@@ -1560,7 +1574,9 @@ fn execute_update_from(
     if updates.is_empty() {
         // Fire AFTER STATEMENT triggers even when all rows skipped.
         if has_triggers {
-            crate::TriggerFirer::execute_after_statement_triggers(
+            // Statement-level RAISE(IGNORE) has no sqlite3 analog; drop the
+            // must-use outcome (#5418).
+            let _stmt_outcome = crate::TriggerFirer::execute_after_statement_triggers(
                 database,
                 table_name,
                 vibesql_ast::TriggerEvent::Update(None),
@@ -1609,17 +1625,26 @@ fn execute_update_from(
         }
     }
 
-    // Fire BEFORE UPDATE triggers
+    // Fire BEFORE UPDATE triggers.
+    // A RAISE(IGNORE) in a BEFORE UPDATE trigger abandons that row (#5418):
+    // drop it from the batch so it is neither updated nor counted, while the
+    // remaining rows proceed — matching the primary UPDATE loop in
+    // `execute_internal` and sqlite3 3.51 semantics.
     if has_triggers {
-        for u in &updates {
-            crate::TriggerFirer::execute_before_triggers(
+        let mut keep = Vec::with_capacity(updates.len());
+        for u in updates {
+            let outcome = crate::TriggerFirer::execute_before_triggers(
                 database,
                 table_name,
                 vibesql_ast::TriggerEvent::Update(None),
                 Some(&u.old_row),
                 Some(&u.new_row),
             )?;
+            if outcome != crate::TriggerOutcome::SkipRow {
+                keep.push(u);
+            }
         }
+        updates = keep;
     }
 
     // Apply all updates
@@ -1653,10 +1678,13 @@ fn execute_update_from(
         ));
     }
 
-    // Fire AFTER UPDATE triggers
+    // Fire AFTER UPDATE triggers.
+    // AFTER triggers run once the row is already updated; a RAISE(IGNORE) here
+    // cannot revert it (sqlite3 3.51 keeps the modified row), so SkipRow is a
+    // no-op — explicitly drop the must-use outcome (#5418).
     if has_triggers {
         for (_index, old_row, new_row, _changed_columns) in &index_updates {
-            crate::TriggerFirer::execute_after_triggers(
+            let _after_outcome = crate::TriggerFirer::execute_after_triggers(
                 database,
                 table_name,
                 vibesql_ast::TriggerEvent::Update(None),
@@ -1691,7 +1719,9 @@ fn execute_update_from(
 
     // Fire AFTER STATEMENT triggers
     if has_triggers {
-        crate::TriggerFirer::execute_after_statement_triggers(
+        // Statement-level RAISE(IGNORE) has no sqlite3 analog; drop the
+        // must-use outcome (#5418).
+        let _stmt_outcome = crate::TriggerFirer::execute_after_statement_triggers(
             database,
             table_name,
             vibesql_ast::TriggerEvent::Update(None),

--- a/crates/vibesql-executor/src/update/triggers.rs
+++ b/crates/vibesql-executor/src/update/triggers.rs
@@ -91,11 +91,26 @@ pub(super) fn execute_update_on_view(
         )?
     };
 
-    // Now fire triggers (database can be mutably borrowed)
+    // Now fire triggers (database can be mutably borrowed).
+    //
+    // RAISE(IGNORE) inside an INSTEAD OF UPDATE trigger abandons the view
+    // operation for that row (#5418): the trigger body stops at the RAISE
+    // (`execute_trigger` returns SkipRow) and we move on to the next matched
+    // row without erroring and without affecting other rows. On SkipRow we
+    // `break` out of this row's remaining INSTEAD OF triggers, following the
+    // same first-SkipRow-wins convention the primary DML loops adopted in
+    // #5415. (sqlite3 3.51 would still run a *later* INSTEAD OF trigger on the
+    // same row after an earlier one IGNOREs, but that multi-trigger-per-view
+    // case is rare; the common single-trigger case matches sqlite3 exactly —
+    // the row's operation is skipped.)
     let rows_processed = updates.len();
     for (old_row, new_row) in &updates {
         for trigger in &triggers {
-            crate::TriggerFirer::execute_trigger(database, trigger, Some(old_row), Some(new_row))?;
+            if crate::TriggerFirer::execute_trigger(database, trigger, Some(old_row), Some(new_row))?
+                == crate::TriggerOutcome::SkipRow
+            {
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Closes #5418

## Summary

PR #5415 plumbed `RAISE(IGNORE)` -> `TriggerOutcome::SkipRow` through the primary INSERT/UPDATE/DELETE row loops. Several other trigger-firing call sites still discarded the returned `TriggerOutcome` (`foo(..)?;`), silently swallowing a `RAISE(IGNORE)` and applying the row anyway. This PR:

- Marks `TriggerOutcome` `#[must_use]` so any unhandled call site becomes a compile-time warning instead of a silent drop.
- Honors `SkipRow` in every newly-surfaced BEFORE-trigger path.
- Explicitly (and deliberately) drops the outcome at AFTER-trigger and statement-level sites, with comments explaining why those are no-ops.

## `#[must_use]` addition + what it surfaced

Added to `crate::trigger_execution::TriggerOutcome`. The compiler then flagged **19** drop sites in `vibesql-executor` (no other crate calls these helpers). Categorized:

- **BEFORE-trigger sites that now honor SkipRow** (the issue's targets) — see below.
- **AFTER-trigger sites** (`insert/replace.rs`, `update/executor.rs` x2, `delete/executor.rs`): bound to `let _after_outcome` with a comment. AFTER triggers fire once the row is already applied; `RAISE(IGNORE)` cannot revert it (sqlite3 3.51 keeps the row), so SkipRow is a genuine no-op.
- **Statement-level sites** (`insert/execution.rs` x2, `update/executor.rs` x6, `delete/executor.rs` x2): bound to `let _stmt_outcome` with a comment. Statement-level triggers are a VibeSQL extension (SQLite triggers are always FOR EACH ROW), so statement-granularity `RAISE(IGNORE)` has no sqlite3 SkipRow analog; pre-#5418 proceed behavior is preserved.

## Call sites that discarded SkipRow + how each now honors it

| Path | File:line (pre) | Fix |
|------|-----------------|-----|
| REPLACE conflict-delete (BEFORE DELETE) | `insert/replace.rs:165` | Filter SkipRow'd conflicting rows out of `rows_to_delete` so they survive; the caller's PK/UNIQUE re-validation then errors. Early-return when all conflicts are IGNORE'd. |
| UPDATE ... FROM secondary update (BEFORE UPDATE) | `update/executor.rs:1615` | Rebuild the `updates` batch keeping only non-SkipRow rows (mirrors the primary loop in `execute_internal`). |
| INSTEAD OF INSERT (view) | `insert/execution.rs:1684` | On SkipRow, `break` the row's remaining INSTEAD OF triggers and move to the next row. |
| INSTEAD OF UPDATE (view) | `update/triggers.rs:98` | Same `break`-on-SkipRow. |
| INSTEAD OF DELETE (view) | `delete/executor.rs:1055` | Same `break`-on-SkipRow. |

INSTEAD OF uses the first-SkipRow-wins convention adopted by the #5415 primary loops; the common single-trigger-per-view case matches sqlite3 3.51 exactly (the row's operation is skipped).

**CASCADE:** investigated and intentionally left unchanged. Neither VibeSQL's FK cascade (`delete/integrity.rs::cascade_delete`, `update/foreign_keys.rs`) nor sqlite3 3.51 fires row triggers during an FK ON DELETE/UPDATE CASCADE (verified: a child BEFORE DELETE trigger does not fire during a parent cascade even with `recursive_triggers=ON`). There is no `TriggerOutcome` consumed there, so nothing to wire.

## Per-path sqlite3 3.51.0 verification (also reproduced via the release CLI)

- **REPLACE + BEFORE DELETE RAISE(IGNORE):** conflicting row's delete is skipped -> surviving row collides -> `UNIQUE constraint failed`, table unchanged. (sqlite3 with `recursive_triggers=ON`.)
- **UPDATE ... FROM:** `d` maps id 2 -> 999 (IGNORE'd); result `1|111, 2|20, 3|333` — only the matched row skipped.
- **INSTEAD OF INSERT:** `SELECT raise(IGNORE)` before the body's base insert -> base table empty.
- **INSTEAD OF UPDATE:** base unchanged (`1|10, 2|20`); no-RAISE control writes both rows.
- **INSTEAD OF DELETE:** base unchanged; no-RAISE control deletes both rows.

## Tests

Added to `crates/vibesql-executor/src/tests/raise_trigger_tests.rs`:
- `raise_ignore_in_before_delete_blocks_replace_conflict`
- `raise_ignore_skips_only_matching_row_in_update_from`
- `raise_ignore_in_instead_of_insert_skips_base_write` (+ `instead_of_insert_without_ignore_writes_base` control)
- `raise_ignore_in_instead_of_update_abandons_row` (+ control)
- `raise_ignore_in_instead_of_delete_abandons_row` (+ control)

`cargo test -p vibesql-executor` is green (all suites, incl. the 22 raise_trigger tests, 60 trigger tests, 25 view tests). The existing #5415 main-loop IGNORE tests still pass.

## Follow-ons filed
- Pre-existing REPLACE-with-any-BEFORE-DELETE-trigger duplicate-row bug (reproduces with a non-firing trigger; independent of SkipRow).
- INSTEAD OF triggers with a WHEN clause on a view fail (`evaluate_when_condition` resolves schema via `get_table`, which returns None for views).
- Trigger-body statement splitter treats `CASE ... END`'s `END` as the body terminator, so `CASE` in a trigger body fails to parse.

## Test plan
- [x] `cargo test -p vibesql-executor`
- [x] Per-path end-to-end verification via release CLI vs sqlite3 3.51.0
- [x] `#[must_use]` clears all 19 surfaced drops; no new warnings
- [x] No conflict markers; only the 7 intended files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)