### PR TITLE
feat(server): route HTTP CRUD by-id endpoints through consensus

### DIFF
--- a/crates/vibesql-consensus/src/mvcc_raft.rs
+++ b/crates/vibesql-consensus/src/mvcc_raft.rs
@@ -1012,6 +1012,17 @@ impl MvccRaftNode {
         self.sm.machine.query(sql)
     }
 
+    /// Resolve the single-column primary key of `table_name` against the
+    /// locally applied replicated catalog (#5420). Local read of the
+    /// applied schema — no leadership check or network round — used by the
+    /// HTTP CRUD by-id endpoints to build their `WHERE pk = {id}` SQL in
+    /// replicated mode, where the schema lives in the state machine rather
+    /// than the (empty) local registry database. Returns `None` for an
+    /// unknown table, no primary key, or a composite primary key.
+    pub fn primary_key_column(&self, table_name: &str) -> Option<String> {
+        self.sm.machine.primary_key_column(table_name)
+    }
+
     /// Run a read-only SELECT with **linearizable** semantics (Raft
     /// Phase B2, #5200, PR 1): openraft's ReadIndex protocol
     /// ([`Raft::ensure_linearizable`]) first confirms this node's

--- a/crates/vibesql-consensus/src/state_machine.rs
+++ b/crates/vibesql-consensus/src/state_machine.rs
@@ -585,6 +585,27 @@ impl VibesqlStateMachine {
         Ok(QueryResult::from(result))
     }
 
+    /// Resolve the (single-column) primary-key column of `table_name`
+    /// against the **applied replicated catalog** (#5420). This is the
+    /// replicated-mode counterpart of reading the local registry schema:
+    /// the HTTP CRUD by-id endpoints need the PK column to build their
+    /// `WHERE pk = {id}` SQL, but in replicated mode the schema lives here
+    /// in the state machine, not in the (empty) local registry database.
+    ///
+    /// Returns `None` if the table is unknown, has no declared primary
+    /// key, or has a composite primary key (the by-id endpoints only
+    /// support a single-column key, matching the standalone path).
+    pub fn primary_key_column(&self, table_name: &str) -> Option<String> {
+        let inner = self.lock();
+        let schema = lookup_table_schema(&inner.db, None, table_name)?;
+        let pk = schema.primary_key.as_ref()?;
+        // Single-column primary keys only (same restriction as standalone).
+        match pk.as_slice() {
+            [single] => Some(single.clone()),
+            _ => None,
+        }
+    }
+
     /// Speculatively read inside an open replicated transaction so the
     /// session observes its **own** buffered (not-yet-committed) writes —
     /// full mid-transaction read-your-own-writes (#5401).
@@ -1123,6 +1144,29 @@ mod tests {
             .into_iter()
             .map(|row| row[0].to_string())
             .collect()
+    }
+
+    #[test]
+    fn primary_key_column_resolves_from_applied_catalog() {
+        let machine = VibesqlStateMachine::new();
+        create_users(&machine, 1);
+
+        // Single-column PK resolves (the HTTP CRUD by-id path, #5420).
+        assert_eq!(machine.primary_key_column("users").as_deref(), Some("id"));
+
+        // Unknown table → None.
+        assert_eq!(machine.primary_key_column("missing"), None);
+
+        // No declared primary key → None.
+        machine.apply(2, &TxnEntry::single("CREATE TABLE nopk (a INT, b INT)")).unwrap();
+        assert_eq!(machine.primary_key_column("nopk"), None);
+
+        // Composite primary key → None (by-id endpoints support single-column
+        // keys only, matching the standalone path).
+        machine
+            .apply(3, &TxnEntry::single("CREATE TABLE composite (a INT, b INT, PRIMARY KEY (a, b))"))
+            .unwrap();
+        assert_eq!(machine.primary_key_column("composite"), None);
     }
 
     #[test]

--- a/crates/vibesql-server/src/http/crud.rs
+++ b/crates/vibesql-server/src/http/crud.rs
@@ -364,13 +364,39 @@ fn json_to_sql_literal(val: &JsonValue) -> String {
     }
 }
 
-/// Get the primary key column name for a table using shared database
+/// Get the primary key column name for a table from the local registry
+/// database schema (single-column keys only). Used in standalone mode.
 async fn get_primary_key_column(shared_db: &SharedDatabase, table_name: &str) -> Option<String> {
     let db = shared_db.read().await;
     let table = db.get_table(table_name)?;
     let pk = table.schema.primary_key.as_ref()?;
-    // For now, support single-column primary keys
-    pk.first().cloned()
+    // Single-column primary keys only.
+    match pk.as_slice() {
+        [single] => Some(single.clone()),
+        _ => None,
+    }
+}
+
+/// Resolve the primary-key column for the CRUD by-id endpoints, from the
+/// right catalog for the server's mode (#5420):
+///
+/// - **Replicated mode**: the schema lives in the consensus state machine, not
+///   the (empty) local registry database, so resolve it through the
+///   replication handle's catalog accessor.
+/// - **Standalone mode**: read the local registry database schema as before.
+///
+/// Returns `None` when the table is unknown, has no primary key, or has a
+/// composite primary key (the by-id endpoints support single-column keys only,
+/// identically in both modes).
+async fn resolve_pk_column(
+    state: &HttpState,
+    shared_db: &SharedDatabase,
+    table_name: &str,
+) -> Option<String> {
+    match &state.replication {
+        Some(handle) => handle.primary_key_column(table_name),
+        None => get_primary_key_column(shared_db, table_name).await,
+    }
 }
 
 /// Convert execution result rows to JSON objects
@@ -456,18 +482,16 @@ pub async fn get_row(
 ) -> impl IntoResponse {
     debug!("CRUD: GET /api/tables/{}/rows/{}", table_name, id);
 
-    if let Some((code, body)) = state.replicated_gate("the CRUD by-id API (resolving the primary key needs schema introspection through consensus)") {
-        return (code, body).into_response();
-    }
-
     // Get the database name from headers
     let db_name = get_database_name(&headers);
 
     // Get or create the shared database from the registry
     let shared_db = state.registry.get_or_create(&db_name).await;
 
-    // Get primary key column
-    let pk_column = match get_primary_key_column(&shared_db, &table_name).await {
+    // Resolve the primary key column. In replicated mode this reads the
+    // schema from the consensus state machine (the local registry DB is
+    // empty); in standalone mode it reads the local registry schema (#5420).
+    let pk_column = match resolve_pk_column(&state, &shared_db, &table_name).await {
         Some(pk) => pk,
         None => {
             return (
@@ -485,8 +509,9 @@ pub async fn get_row(
     let sql = build_select_by_pk_sql(&table_name, &pk_column, &id, params.select.as_deref());
     debug!("CRUD: Executing SQL: {}", sql);
 
-    let mut session =
-        crate::session::Session::new(db_name.clone(), "http_user".to_string(), shared_db);
+    // Replicated session in replicated mode (the SELECT runs against the
+    // state machine per the session's read-consistency mode); local otherwise.
+    let mut session = state.session(&db_name, shared_db);
 
     match session.execute(&sql).await {
         Ok(crate::session::ExecutionResult::Select { rows, columns }) => {
@@ -513,8 +538,7 @@ pub async fn get_row(
             .into_response(),
         Err(e) => {
             error!("Query execution failed: {}", e);
-            (StatusCode::BAD_REQUEST, Json(ErrorResponse::new(format!("Query failed: {}", e))))
-                .into_response()
+            execution_error_response(&e)
         }
     }
 }
@@ -592,10 +616,6 @@ pub async fn update_row(
 ) -> impl IntoResponse {
     debug!("CRUD: PUT /api/tables/{}/rows/{} with body: {:?}", table_name, id, body);
 
-    if let Some((code, gate_body)) = state.replicated_gate("the CRUD by-id API (resolving the primary key needs schema introspection through consensus)") {
-        return (code, gate_body).into_response();
-    }
-
     if body.values.is_empty() {
         return (
             StatusCode::BAD_REQUEST,
@@ -610,8 +630,9 @@ pub async fn update_row(
     // Get or create the shared database from the registry
     let shared_db = state.registry.get_or_create(&db_name).await;
 
-    // Get primary key column
-    let pk_column = match get_primary_key_column(&shared_db, &table_name).await {
+    // Resolve the primary key column (replicated catalog in replicated mode,
+    // local registry schema otherwise) (#5420).
+    let pk_column = match resolve_pk_column(&state, &shared_db, &table_name).await {
         Some(pk) => pk,
         None => {
             return (
@@ -629,8 +650,10 @@ pub async fn update_row(
     let sql = build_update_sql(&table_name, &pk_column, &id, &body.values);
     debug!("CRUD: Executing SQL: {}", sql);
 
-    let mut session =
-        crate::session::Session::new(db_name.clone(), "http_user".to_string(), shared_db);
+    // Replicated session in replicated mode: the UPDATE proposes through
+    // consensus (leader-only); a write on a follower surfaces as 421 with a
+    // leader hint. Local session otherwise.
+    let mut session = state.session(&db_name, shared_db);
 
     match session.execute(&sql).await {
         Ok(crate::session::ExecutionResult::Update { rows_affected }) => {
@@ -651,8 +674,7 @@ pub async fn update_row(
             .into_response(),
         Err(e) => {
             error!("Update failed: {}", e);
-            (StatusCode::BAD_REQUEST, Json(ErrorResponse::new(format!("Update failed: {}", e))))
-                .into_response()
+            execution_error_response(&e)
         }
     }
 }
@@ -665,10 +687,6 @@ pub async fn patch_row(
     Json(body): Json<PatchRequest>,
 ) -> impl IntoResponse {
     debug!("CRUD: PATCH /api/tables/{}/rows/{} with body: {:?}", table_name, id, body);
-
-    if let Some((code, gate_body)) = state.replicated_gate("the CRUD by-id API (resolving the primary key needs schema introspection through consensus)") {
-        return (code, gate_body).into_response();
-    }
 
     if body.values.is_empty() {
         return (
@@ -684,8 +702,9 @@ pub async fn patch_row(
     // Get or create the shared database from the registry
     let shared_db = state.registry.get_or_create(&db_name).await;
 
-    // Get primary key column
-    let pk_column = match get_primary_key_column(&shared_db, &table_name).await {
+    // Resolve the primary key column (replicated catalog in replicated mode,
+    // local registry schema otherwise) (#5420).
+    let pk_column = match resolve_pk_column(&state, &shared_db, &table_name).await {
         Some(pk) => pk,
         None => {
             return (
@@ -703,8 +722,10 @@ pub async fn patch_row(
     let sql = build_update_sql(&table_name, &pk_column, &id, &body.values);
     debug!("CRUD: Executing SQL: {}", sql);
 
-    let mut session =
-        crate::session::Session::new(db_name.clone(), "http_user".to_string(), shared_db);
+    // Replicated session in replicated mode: the UPDATE proposes through
+    // consensus (leader-only); a write on a follower surfaces as 421 with a
+    // leader hint. Local session otherwise.
+    let mut session = state.session(&db_name, shared_db);
 
     match session.execute(&sql).await {
         Ok(crate::session::ExecutionResult::Update { rows_affected }) => {
@@ -725,8 +746,7 @@ pub async fn patch_row(
             .into_response(),
         Err(e) => {
             error!("Patch failed: {}", e);
-            (StatusCode::BAD_REQUEST, Json(ErrorResponse::new(format!("Patch failed: {}", e))))
-                .into_response()
+            execution_error_response(&e)
         }
     }
 }
@@ -739,18 +759,15 @@ pub async fn delete_row(
 ) -> impl IntoResponse {
     debug!("CRUD: DELETE /api/tables/{}/rows/{}", table_name, id);
 
-    if let Some((code, body)) = state.replicated_gate("the CRUD by-id API (resolving the primary key needs schema introspection through consensus)") {
-        return (code, body).into_response();
-    }
-
     // Get the database name from headers
     let db_name = get_database_name(&headers);
 
     // Get or create the shared database from the registry
     let shared_db = state.registry.get_or_create(&db_name).await;
 
-    // Get primary key column
-    let pk_column = match get_primary_key_column(&shared_db, &table_name).await {
+    // Resolve the primary key column (replicated catalog in replicated mode,
+    // local registry schema otherwise) (#5420).
+    let pk_column = match resolve_pk_column(&state, &shared_db, &table_name).await {
         Some(pk) => pk,
         None => {
             return (
@@ -768,8 +785,10 @@ pub async fn delete_row(
     let sql = build_delete_sql(&table_name, &pk_column, &id);
     debug!("CRUD: Executing SQL: {}", sql);
 
-    let mut session =
-        crate::session::Session::new(db_name.clone(), "http_user".to_string(), shared_db);
+    // Replicated session in replicated mode: the DELETE proposes through
+    // consensus (leader-only); a write on a follower surfaces as 421 with a
+    // leader hint. Local session otherwise.
+    let mut session = state.session(&db_name, shared_db);
 
     match session.execute(&sql).await {
         Ok(crate::session::ExecutionResult::Delete { rows_affected }) => {
@@ -790,8 +809,7 @@ pub async fn delete_row(
             .into_response(),
         Err(e) => {
             error!("Delete failed: {}", e);
-            (StatusCode::BAD_REQUEST, Json(ErrorResponse::new(format!("Delete failed: {}", e))))
-                .into_response()
+            execution_error_response(&e)
         }
     }
 }

--- a/crates/vibesql-server/src/http/rest.rs
+++ b/crates/vibesql-server/src/http/rest.rs
@@ -76,11 +76,13 @@ pub struct HttpState {
     ///
     /// Present only in replicated mode. Surfaces that have been wired through
     /// consensus (#5410 — the `/api/query` endpoint and the CRUD collection
-    /// endpoints) build a **replicated** session via [`Self::session`], so
-    /// writes propose through this handle (leader-only, freeze-at-propose)
-    /// and reads run against the replicated state machine — never against the
-    /// unreplicated local registry database. Surfaces that still depend on
-    /// local-database schema/state introspection (CRUD by-id, GraphQL,
+    /// endpoints; #5420 — the CRUD by-id endpoints, which resolve the primary
+    /// key from the replicated catalog via
+    /// [`ReplicationHandle::primary_key_column`]) build a **replicated** session
+    /// via [`Self::session`], so writes propose through this handle (leader-only,
+    /// freeze-at-propose) and reads run against the replicated state machine —
+    /// never against the unreplicated local registry database. Surfaces that
+    /// still depend on local-database schema/state introspection (GraphQL,
     /// subscriptions, blob storage) remain gated (see [`Self::replicated_gate`])
     /// to a clear error rather than silently reading stale data or accepting a
     /// write that never replicates; those are tracked as follow-ons to #5410.

--- a/crates/vibesql-server/src/replication.rs
+++ b/crates/vibesql-server/src/replication.rs
@@ -290,6 +290,19 @@ impl ReplicationHandle {
         self.node.query(sql).map_err(|e| self.sql_error("the query", e))
     }
 
+    /// Resolve the single-column primary key of `table_name` from the
+    /// applied replicated catalog (#5420). The HTTP CRUD by-id endpoints
+    /// use this to introspect the PK in replicated mode — where the schema
+    /// lives in the consensus state machine, not the (empty) local registry
+    /// database — then build their `WHERE pk = {id}` SQL and route it
+    /// through the replicated session like the collection endpoints.
+    /// Returns `None` for an unknown table, no primary key, or a composite
+    /// primary key (the by-id endpoints support single-column keys only,
+    /// matching the standalone path).
+    pub fn primary_key_column(&self, table_name: &str) -> Option<String> {
+        self.node.primary_key_column(table_name)
+    }
+
     /// Linearizable read (quorum-confirmed leadership).
     pub async fn query_linearizable(
         &self,

--- a/crates/vibesql-server/tests/replication_tests.rs
+++ b/crates/vibesql-server/tests/replication_tests.rs
@@ -1604,6 +1604,224 @@ async fn http_write_on_follower_redirects_with_leader_hint() {
     assert_eq!(resp.status(), reqwest::StatusCode::MISDIRECTED_REQUEST);
 }
 
+/// The CRUD by-id endpoints (GET/PUT/PATCH/DELETE one row) work in replicated
+/// mode (#5420): the primary key is resolved from the consensus state machine's
+/// catalog (the local registry DB is empty), reads run against the replicated
+/// state machine, and writes propose through consensus. A by-id GET returns the
+/// row with its real column names (post-#5428).
+#[tokio::test]
+async fn http_crud_by_id_routes_through_consensus() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let (base, _tx) = start_http(Some(Arc::clone(&handles[0]))).await;
+    let client = reqwest::Client::new();
+
+    // Schema + seed row via the (already replicated) /api/query endpoint.
+    for sql in [
+        "CREATE TABLE byid (id INTEGER PRIMARY KEY, name VARCHAR(100))",
+        "INSERT INTO byid VALUES (1, 'Alice')",
+    ] {
+        let resp = client
+            .post(format!("{base}/api/query"))
+            .header("content-type", "application/json")
+            .body(serde_json::json!({ "sql": sql }).to_string())
+            .send()
+            .await
+            .unwrap();
+        assert!(resp.status().is_success(), "{sql}: {}", resp.status());
+    }
+
+    // GET by id resolves the PK through consensus and reads the row back from
+    // the replicated state machine, with real column names (#5428).
+    let resp = client.get(format!("{base}/api/tables/byid/rows/1")).send().await.unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+    assert_eq!(body["data"]["id"], 1, "by-id GET must read the replicated row, got {body}");
+    assert_eq!(body["data"]["name"], "Alice", "real column name (post-#5428), got {body}");
+
+    // GET a missing id → 404.
+    let resp = client.get(format!("{base}/api/tables/byid/rows/999")).send().await.unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+
+    // PUT by id proposes an UPDATE through consensus.
+    let resp = client
+        .put(format!("{base}/api/tables/byid/rows/1"))
+        .header("content-type", "application/json")
+        .body(r#"{"name":"Alicia"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        handles[0].node().query("SELECT name FROM byid WHERE id = 1").unwrap()[0][0].to_string(),
+        "Alicia",
+        "the PUT must land in the consensus state machine"
+    );
+
+    // PUT a missing id → 404 (zero rows affected).
+    let resp = client
+        .put(format!("{base}/api/tables/byid/rows/999"))
+        .header("content-type", "application/json")
+        .body(r#"{"name":"Nobody"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+
+    // PATCH by id proposes a partial UPDATE through consensus.
+    let resp = client
+        .patch(format!("{base}/api/tables/byid/rows/1"))
+        .header("content-type", "application/json")
+        .body(r#"{"name":"Allie"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        handles[0].node().query("SELECT name FROM byid WHERE id = 1").unwrap()[0][0].to_string(),
+        "Allie",
+        "the PATCH must land in the consensus state machine"
+    );
+
+    // DELETE by id proposes a DELETE through consensus.
+    let resp = client.delete(format!("{base}/api/tables/byid/rows/1")).send().await.unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        handles[0].node().query("SELECT COUNT(*) FROM byid").unwrap()[0][0].to_string(),
+        "0",
+        "the DELETE must land in the consensus state machine"
+    );
+
+    // DELETE a missing id → 404.
+    let resp = client.delete(format!("{base}/api/tables/byid/rows/1")).send().await.unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+}
+
+/// A CRUD by-id write replicates to followers (#5420): PUT/PATCH/DELETE on the
+/// leader's HTTP port converge on a second node.
+#[tokio::test]
+async fn http_crud_by_id_writes_replicate_to_followers() {
+    let (handles, _dir) = boot_cluster(3).await;
+    let leader = wait_for_leader(&handles).await;
+    let (base, _tx) = start_http(Some(Arc::clone(&handles[leader]))).await;
+    let client = reqwest::Client::new();
+
+    for sql in [
+        "CREATE TABLE byid_repl (id INTEGER PRIMARY KEY, n INT)",
+        "INSERT INTO byid_repl VALUES (1, 10)",
+    ] {
+        let resp = client
+            .post(format!("{base}/api/query"))
+            .header("content-type", "application/json")
+            .body(serde_json::json!({ "sql": sql }).to_string())
+            .send()
+            .await
+            .unwrap();
+        assert!(resp.status().is_success(), "{sql}: {}", resp.status());
+    }
+
+    // PATCH the row by id on the leader's HTTP port.
+    let resp = client
+        .patch(format!("{base}/api/tables/byid_repl/rows/1"))
+        .header("content-type", "application/json")
+        .body(r#"{"n":42}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    // Every follower converges to the updated value.
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    for (i, h) in handles.iter().enumerate() {
+        if i == leader {
+            continue;
+        }
+        loop {
+            let n = h
+                .node()
+                .query("SELECT n FROM byid_repl WHERE id = 1")
+                .ok()
+                .and_then(|r| r.first().and_then(|row| row.first()).map(ToString::to_string));
+            if n.as_deref() == Some("42") {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "follower {i} did not converge to n=42 (saw {n:?})"
+            );
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+}
+
+/// A CRUD by-id write on a **follower** is refused with `421 Misdirected
+/// Request` carrying the leader hint — the same redirect contract as the
+/// collection endpoints (#5420). It must never execute against the follower's
+/// local database (the split-brain invariant).
+#[tokio::test]
+async fn http_crud_by_id_write_on_follower_redirects_with_leader_hint() {
+    let (handles, _dir) = boot_cluster(3).await;
+    let leader = wait_for_leader(&handles).await;
+
+    // Create + seed the table through the leader.
+    for sql in [
+        "CREATE TABLE byid_redir (id INTEGER PRIMARY KEY, name VARCHAR(100))",
+        "INSERT INTO byid_redir VALUES (1, 'Alice')",
+    ] {
+        replicated_session(&handles[leader]).execute(sql).await.unwrap();
+    }
+    let leader_id = handles[leader].node_id();
+
+    // Pick a follower that knows who leads (so the hint is populated) and that
+    // has applied the seed row (so the resolution sees the table).
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    let follower = loop {
+        if let Some(i) = handles.iter().position(|h| {
+            h.role() == Role::Follower
+                && h.node().current_leader().is_some()
+                && h.primary_key_column("byid_redir").as_deref() == Some("id")
+        }) {
+            break i;
+        }
+        assert!(tokio::time::Instant::now() < deadline, "timed out waiting for a follower");
+        tokio::time::sleep(POLL_INTERVAL).await;
+    };
+
+    let (base, _tx) = start_http(Some(Arc::clone(&handles[follower]))).await;
+    let client = reqwest::Client::new();
+
+    // PUT by id on the follower → 421 + leader hint header (NOT_LEADER).
+    let resp = client
+        .put(format!("{base}/api/tables/byid_redir/rows/1"))
+        .header("content-type", "application/json")
+        .body(r#"{"name":"Bob"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::MISDIRECTED_REQUEST);
+    let leader_hint = resp
+        .headers()
+        .get("X-VibeSQL-Leader")
+        .expect("leader-hint header")
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(leader_hint.contains(&format!("node {leader_id}")), "{leader_hint}");
+
+    // DELETE by id on the follower → same 421 contract.
+    let resp = client.delete(format!("{base}/api/tables/byid_redir/rows/1")).send().await.unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::MISDIRECTED_REQUEST);
+
+    // The follower's local database never executed the write: the row is
+    // untouched in the replicated state machine.
+    assert_eq!(
+        handles[follower].node().query("SELECT name FROM byid_redir WHERE id = 1").unwrap()[0][0]
+            .to_string(),
+        "Alice",
+        "a by-id write on a follower must not mutate state outside consensus"
+    );
+}
+
 /// An HTTP write replicates to a second node (#5410): after a `POST /api/query`
 /// INSERT on the leader's HTTP port, every follower converges to the row.
 #[tokio::test]
@@ -1652,20 +1870,18 @@ async fn http_write_replicates_to_followers() {
     }
 }
 
-/// In replicated mode the CRUD by-id, GraphQL, subscription, and blob-storage
-/// surfaces remain gated to a clear 503 (they depend on local-database schema
-/// /state introspection that is not yet wired through consensus — follow-ons
-/// to #5410). They must never silently execute against the local database.
+/// In replicated mode the GraphQL, subscription, and blob-storage surfaces
+/// remain gated to a clear 503 (they depend on local-database schema/state
+/// introspection that is not yet wired through consensus — follow-ons to
+/// #5410). They must never silently execute against the local database. The
+/// CRUD by-id endpoints are no longer gated (#5420 wired them through
+/// consensus); see `http_crud_by_id_*` below.
 #[tokio::test]
 async fn http_unwired_surfaces_still_gated_in_replicated_mode() {
     let (handles, _dir) = boot_cluster(1).await;
     wait_for_leader(&handles).await;
     let (base, _tx) = start_http(Some(Arc::clone(&handles[0]))).await;
     let client = reqwest::Client::new();
-
-    // CRUD by-id (needs primary-key schema introspection).
-    let resp = client.get(format!("{base}/api/tables/t/rows/1")).send().await.unwrap();
-    assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
 
     // GraphQL.
     let resp = client


### PR DESCRIPTION
## Summary

Ungates the HTTP CRUD by-id endpoints (`GET`/`PUT`/`PATCH`/`DELETE /api/tables/{t}/rows/{id}`) in replicated mode (#5420, part of #5410). They were gated to a 503 because they resolve the table's primary key from the **local registry database schema**, which is empty when replicated — the schema lives in the consensus state machine.

- **PK resolution in replicated mode**: new `primary_key_column(table)` accessor resolves the single-column primary key from the applied replicated catalog — `VibesqlStateMachine::primary_key_column` → `MvccRaftNode::primary_key_column` → `ReplicationHandle::primary_key_column`. (PRAGMA is a no-op and the replicated read path only accepts `SELECT`, so a direct catalog accessor is used rather than schema-introspection SQL.) Standalone mode keeps reading the local registry schema.
- **Routing**: the by-id handlers now build their `WHERE pk = {id}` SQL and route it through the `HttpState::session` choke point established in #5410 — reads run against the replicated state machine (with real column names, post-#5428), writes propose through consensus (leader-only). The by-id `replicated_gate` is removed.
- **Error mapping**: errors flow through `execution_error_response` like the collection endpoints — `NotLeader → 421` with the `X-VibeSQL-Leader` hint, staleness/FATAL → 503, deterministic rejection → 400. `404` when the row doesn't exist (read returns no rows / write affects 0 rows). Composite or missing primary key → a clear 400, matching the standalone path.
- **Split-brain invariant**: a by-id write on a follower is refused with 421 and never executes against the follower's local database (asserted in tests).

## Test plan

- [x] `http_crud_by_id_routes_through_consensus` — single-node GET/PUT/PATCH/DELETE replicate/read correctly; GET returns real column names; missing id → 404 for GET/PUT/DELETE.
- [x] `http_crud_by_id_writes_replicate_to_followers` — by-id PATCH on the leader converges on every follower (3-node).
- [x] `http_crud_by_id_write_on_follower_redirects_with_leader_hint` — by-id PUT/DELETE on a follower → 421 + leader hint; follower's state untouched (split-brain invariant).
- [x] `http_unwired_surfaces_still_gated_in_replicated_mode` updated: by-id no longer gated; only GraphQL / subscriptions / blob storage remain gated.
- [x] `http_standalone_unaffected` and full `replication_tests` suite (41 tests) green.
- [x] `primary_key_column_resolves_from_applied_catalog` unit test (single / unknown / no-PK / composite).
- [x] `cargo build` + `cargo clippy` clean on `vibesql-server`/`vibesql-consensus` (no new warnings in touched files).

## Follow-ons

- Composite / non-integer primary keys are not supported by the by-id endpoints (single-column only, matching standalone). Composite-PK by-id support would be a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)