### PR TITLE
fix(storage): make full-tree index rebuild reversible mid-transaction

### DIFF
--- a/crates/vibesql-storage/src/btree/node/btree_index/mod.rs
+++ b/crates/vibesql-storage/src/btree/node/btree_index/mod.rs
@@ -183,6 +183,81 @@ impl BTreeIndex {
         Ok(())
     }
 
+    /// Collect every `(key, row_ids)` entry currently stored in the tree, in
+    /// key order, by walking the leaf chain from the leftmost leaf.
+    ///
+    /// Used by [`Self::rebuild_in_place_logged`] to capture the pre-rebuild
+    /// contents so a full-tree rebuild can be expressed as logged per-key
+    /// deletes (issue #5435). O(n) in the number of entries.
+    pub(crate) fn collect_all_entries(&self) -> Result<Vec<(Key, Vec<RowId>)>, StorageError> {
+        let mut entries: Vec<(Key, Vec<RowId>)> = Vec::new();
+
+        // Empty tree (height 0) has nothing to collect.
+        if self.height == 0 {
+            return Ok(entries);
+        }
+
+        let mut current_leaf = self.find_leftmost_leaf()?;
+        loop {
+            for (key, row_ids) in &current_leaf.entries {
+                entries.push((key.clone(), row_ids.clone()));
+            }
+            if current_leaf.next_leaf == super::super::NULL_PAGE_ID {
+                break;
+            }
+            current_leaf = self.read_leaf_node(current_leaf.next_leaf)?;
+        }
+
+        Ok(entries)
+    }
+
+    /// Rebuild this tree's contents in place to exactly `new_entries`, recording
+    /// every mutation in the transaction undo-log (issue #5435).
+    ///
+    /// A full-tree rebuild / bulk-load normally swaps in a freshly built
+    /// `BTreeIndex` (see `IndexManager::rebuild_indexes`). For a spilled
+    /// (disk-backed) index that swap discards the armed undo-log and replaces
+    /// the live tree wholesale, so a rebuild that runs *inside* a transaction
+    /// would not be reversed on ROLLBACK. This method instead mutates the
+    /// *same* tree object through the logged `delete`/`insert` paths so the
+    /// inverse of the rebuild is captured in the undo-log and ROLLBACK restores
+    /// the exact pre-rebuild contents.
+    ///
+    /// Must only be called when [`Self::is_undo_logging`] is `true`; outside a
+    /// transaction the wholesale `bulk_load` swap is preferred (it is faster
+    /// and avoids growing an undo-log that would never be replayed).
+    ///
+    /// `new_entries` are `(key, row_id)` pairs (duplicates allowed for non-
+    /// unique indexes). Cost is O(existing + new) entries, paid once per
+    /// in-transaction rebuild (rebuilds are rare — they only fire when a single
+    /// DELETE compacts away >50% of a table's rows).
+    pub(crate) fn rebuild_in_place_logged(
+        &mut self,
+        new_entries: Vec<(Key, RowId)>,
+    ) -> Result<(), StorageError> {
+        debug_assert!(
+            self.is_undo_logging(),
+            "rebuild_in_place_logged must only be used while undo-logging is armed; \
+             the non-transactional path should use bulk_load + swap",
+        );
+
+        // Delete every existing key via the logged delete path. `delete`
+        // removes all row_ids for a key and records a `Reinsert` undo entry,
+        // so the prior contents are fully recoverable on ROLLBACK.
+        let existing = self.collect_all_entries()?;
+        for (key, _row_ids) in existing {
+            self.delete(&key)?;
+        }
+
+        // Insert the new contents via the logged insert path. Each insert
+        // records a `DeleteSpecific` undo entry.
+        for (key, row_id) in new_entries {
+            self.insert(key, row_id)?;
+        }
+
+        Ok(())
+    }
+
     /// Create a new B+ tree index
     ///
     /// Creates a new disk-backed B+ tree index that supports both unique and

--- a/crates/vibesql-storage/src/database/indexes/index_maintenance/update.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance/update.rs
@@ -380,20 +380,60 @@ impl IndexManager {
                                 })
                                 .collect();
 
-                            // Use bulk_load to create new B+tree
-                            if let Ok(new_btree) = BTreeIndex::bulk_load(
-                                sorted_entries,
-                                key_schema,
-                                page_manager.clone(),
-                            ) {
-                                // Safely acquire lock and replace old btree with new one
-                                match acquire_btree_lock(btree) {
-                                    Ok(mut guard) => {
-                                        *guard = new_btree;
+                            // Acquire the lock once and decide on the rebuild
+                            // strategy based on whether a transaction undo-log
+                            // is armed (issue #5435).
+                            //
+                            // A wholesale `bulk_load` + `*guard = new_btree`
+                            // swap is the fast path, but it replaces the live
+                            // tree object and discards any armed undo-log — so a
+                            // rebuild that runs *inside* a transaction (e.g. a
+                            // DELETE that compacts away >50% of a table's rows,
+                            // see `Database::delete_row`'s
+                            // `delete_result.compacted` branch) would not be
+                            // reversed on ROLLBACK. When undo-logging is armed
+                            // we instead rebuild the *same* tree in place
+                            // through the logged delete/insert paths, so the
+                            // inverse of the rebuild is captured and ROLLBACK
+                            // restores the exact pre-rebuild contents (matching
+                            // the #5425 soundness bar). Outside a transaction
+                            // the undo-log is `None` and we keep the fast swap.
+                            match acquire_btree_lock(btree) {
+                                Ok(mut guard) => {
+                                    if guard.is_undo_logging() {
+                                        if let Err(e) =
+                                            guard.rebuild_in_place_logged(sorted_entries)
+                                        {
+                                            log::warn!(
+                                                "Logged in-place rebuild failed for index '{}': {}",
+                                                index_name,
+                                                e
+                                            );
+                                        }
+                                    } else {
+                                        match BTreeIndex::bulk_load(
+                                            sorted_entries,
+                                            key_schema,
+                                            page_manager.clone(),
+                                        ) {
+                                            Ok(new_btree) => {
+                                                *guard = new_btree;
+                                            }
+                                            Err(e) => {
+                                                log::warn!(
+                                                    "bulk_load failed for index '{}': {}",
+                                                    index_name,
+                                                    e
+                                                );
+                                            }
+                                        }
                                     }
-                                    Err(e) => {
-                                        log::warn!("BTreeIndex lock acquisition failed in rebuild_indexes: {}", e);
-                                    }
+                                }
+                                Err(e) => {
+                                    log::warn!(
+                                        "BTreeIndex lock acquisition failed in rebuild_indexes: {}",
+                                        e
+                                    );
                                 }
                             }
                         }

--- a/crates/vibesql-storage/src/database/indexes/index_manager.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_manager.rs
@@ -751,9 +751,10 @@ mod tests {
                 where_clause: None,
             },
         );
-        manager
-            .index_data
-            .insert(index_name.to_string(), IndexData::InMemory { data, pending_deletions: vec![] });
+        manager.index_data.insert(
+            index_name.to_string(),
+            IndexData::InMemory { data, pending_deletions: vec![] },
+        );
 
         manager.spill_index_to_disk(index_name).unwrap();
         match manager.index_data.get(index_name).unwrap() {
@@ -788,8 +789,7 @@ mod tests {
     /// survived.
     #[test]
     fn spilled_index_rollback_restores_state() {
-        let (mut manager, schema, _dir) =
-            spilled_index_manager("idx_t_id", &[(10, 0), (20, 1)]);
+        let (mut manager, schema, _dir) = spilled_index_manager("idx_t_id", &[(10, 0), (20, 1)]);
 
         // Begin the (simulated) transaction: arm undo-logging on disk-backed
         // indexes — exactly what the COW snapshot chokepoint does on the first
@@ -799,12 +799,7 @@ mod tests {
         // Mutate the spilled index through the real maintenance entry points.
         manager.add_to_indexes_for_insert("t", &schema, &row(30), 2);
         manager.add_to_indexes_for_insert("t", &schema, &row(10), 3); // duplicate key
-        manager.update_indexes_for_delete_with_values(
-            "t",
-            &schema,
-            &[SqlValue::Integer(20)],
-            1,
-        );
+        manager.update_indexes_for_delete_with_values("t", &schema, &[SqlValue::Integer(20)], 1);
 
         // Sanity: mutations are visible mid-transaction.
         assert_eq!(disk_lookup(&manager, "idx_t_id", 30), vec![2]);
@@ -834,17 +829,11 @@ mod tests {
     /// (clearing the undo-log must not reverse anything).
     #[test]
     fn spilled_index_commit_persists_state() {
-        let (mut manager, schema, _dir) =
-            spilled_index_manager("idx_t_id", &[(10, 0), (20, 1)]);
+        let (mut manager, schema, _dir) = spilled_index_manager("idx_t_id", &[(10, 0), (20, 1)]);
 
         manager.begin_disk_undo_logging();
         manager.add_to_indexes_for_insert("t", &schema, &row(30), 2);
-        manager.update_indexes_for_delete_with_values(
-            "t",
-            &schema,
-            &[SqlValue::Integer(20)],
-            1,
-        );
+        manager.update_indexes_for_delete_with_values("t", &schema, &[SqlValue::Integer(20)], 1);
 
         // COMMIT: discard the undo-log without reversing.
         manager.clear_disk_undo_logs();
@@ -894,17 +883,19 @@ mod tests {
         let mut mem_data: BTreeMap<Vec<SqlValue>, Vec<usize>> = BTreeMap::new();
         mem_data.entry(vec![normalize_int(10)]).or_default().push(0);
         manager.indexes.insert("idx_mem".to_string(), mk_meta("idx_mem"));
-        manager
-            .index_data
-            .insert("idx_mem".to_string(), IndexData::InMemory { data: mem_data, pending_deletions: vec![] });
+        manager.index_data.insert(
+            "idx_mem".to_string(),
+            IndexData::InMemory { data: mem_data, pending_deletions: vec![] },
+        );
 
         // Disk-backed (spilled) index.
         let mut disk_data: BTreeMap<Vec<SqlValue>, Vec<usize>> = BTreeMap::new();
         disk_data.entry(vec![normalize_int(10)]).or_default().push(0);
         manager.indexes.insert("idx_disk".to_string(), mk_meta("idx_disk"));
-        manager
-            .index_data
-            .insert("idx_disk".to_string(), IndexData::InMemory { data: disk_data, pending_deletions: vec![] });
+        manager.index_data.insert(
+            "idx_disk".to_string(),
+            IndexData::InMemory { data: disk_data, pending_deletions: vec![] },
+        );
         manager.spill_index_to_disk("idx_disk").unwrap();
 
         // BEGIN: copy-on-write snapshot of the whole manager (restores in-memory
@@ -941,5 +932,121 @@ mod tests {
         // the same now-reverted B+ tree Arc).
         assert!(disk_lookup(&manager, "idx_disk", 30).is_empty(), "disk-backed rolled back");
         assert_eq!(disk_lookup(&manager, "idx_disk", 10), vec![0]);
+    }
+
+    // ========================================================================
+    // Spilled-index full-tree rebuild rollback (issue #5435)
+    // ========================================================================
+
+    /// #5435: a full-tree `rebuild_indexes` on a *spilled* (disk-backed) index
+    /// that runs *inside* a transaction must be reversible. This is reachable
+    /// today: a DELETE that compacts away >50% of a table's rows triggers
+    /// `Database::delete_row`'s `delete_result.compacted` branch, which calls
+    /// `rebuild_indexes` while the disk undo-log is armed.
+    ///
+    /// Before this fix the rebuild swapped in a freshly `bulk_load`ed tree
+    /// (`*guard = new_btree`), discarding the armed undo-log and replacing the
+    /// live tree wholesale, so ROLLBACK could not restore the pre-rebuild
+    /// contents. The fix rebuilds the same tree in place via logged
+    /// delete/insert when undo-logging is armed.
+    #[test]
+    fn spilled_index_rebuild_in_txn_rolls_back() {
+        // Seed: keys 10,20,30 at row positions 0,1,2.
+        let (mut manager, schema, _dir) =
+            spilled_index_manager("idx_t_id", &[(10, 0), (20, 1), (30, 2)]);
+
+        // BEGIN: arm undo-logging (what the COW snapshot chokepoint does on the
+        // first index mutation of a transaction).
+        manager.begin_disk_undo_logging();
+
+        // Simulate a DELETE that compacts the table: rows 20 and 30 were
+        // deleted, so the live table now holds only key 10 — and compaction
+        // shifted its position to row 0. `rebuild_indexes` rebuilds the index
+        // from the post-compaction table rows.
+        let post_compaction_rows = vec![row(10)];
+        manager.rebuild_indexes("t", &schema, &post_compaction_rows);
+
+        // Mid-transaction: the index reflects the rebuilt (post-compaction)
+        // contents.
+        assert_eq!(disk_lookup(&manager, "idx_t_id", 10), vec![0]);
+        assert!(
+            disk_lookup(&manager, "idx_t_id", 20).is_empty(),
+            "rebuilt index drops the deleted key mid-txn"
+        );
+        assert!(
+            disk_lookup(&manager, "idx_t_id", 30).is_empty(),
+            "rebuilt index drops the deleted key mid-txn"
+        );
+
+        // ROLLBACK: the in-place logged rebuild must be fully reversed.
+        manager.rollback_disk_undo_logs();
+
+        assert_eq!(
+            disk_lookup(&manager, "idx_t_id", 10),
+            vec![0],
+            "key 10 restored to its pre-rebuild position"
+        );
+        assert_eq!(
+            disk_lookup(&manager, "idx_t_id", 20),
+            vec![1],
+            "key 20 dropped by the rebuild must be restored on ROLLBACK"
+        );
+        assert_eq!(
+            disk_lookup(&manager, "idx_t_id", 30),
+            vec![2],
+            "key 30 dropped by the rebuild must be restored on ROLLBACK"
+        );
+    }
+
+    /// #5435: COMMIT of a transaction whose spilled index was rebuilt must
+    /// persist the rebuilt contents (clearing the undo-log must not reverse the
+    /// rebuild).
+    #[test]
+    fn spilled_index_rebuild_in_txn_commits() {
+        let (mut manager, schema, _dir) =
+            spilled_index_manager("idx_t_id", &[(10, 0), (20, 1), (30, 2)]);
+
+        manager.begin_disk_undo_logging();
+
+        let post_compaction_rows = vec![row(10), row(30)];
+        manager.rebuild_indexes("t", &schema, &post_compaction_rows);
+
+        // COMMIT: discard the undo-log without reversing.
+        manager.clear_disk_undo_logs();
+
+        assert_eq!(disk_lookup(&manager, "idx_t_id", 10), vec![0]);
+        assert!(
+            disk_lookup(&manager, "idx_t_id", 20).is_empty(),
+            "committed rebuild must persist the dropped key"
+        );
+        assert_eq!(
+            disk_lookup(&manager, "idx_t_id", 30),
+            vec![1],
+            "committed rebuild must persist the new row position"
+        );
+    }
+
+    /// #5435: outside a transaction (no undo-log armed) the rebuild still uses
+    /// the fast wholesale `bulk_load` swap and produces correct contents.
+    #[test]
+    fn spilled_index_rebuild_without_txn_uses_fast_path() {
+        let (mut manager, schema, _dir) =
+            spilled_index_manager("idx_t_id", &[(10, 0), (20, 1), (30, 2)]);
+
+        // No begin_disk_undo_logging(): the index is not undo-logging.
+        match manager.index_data.get("idx_t_id").unwrap() {
+            IndexData::DiskBacked { btree, .. } => {
+                assert!(!acquire_btree_lock(btree).unwrap().is_undo_logging());
+            }
+            other => panic!("expected DiskBacked, got {:?}", other),
+        }
+
+        let new_rows = vec![row(10), row(40)];
+        manager.rebuild_indexes("t", &schema, &new_rows);
+
+        assert_eq!(disk_lookup(&manager, "idx_t_id", 10), vec![0]);
+        assert_eq!(disk_lookup(&manager, "idx_t_id", 40), vec![1]);
+        assert!(disk_lookup(&manager, "idx_t_id", 20).is_empty());
+        assert!(disk_lookup(&manager, "idx_t_id", 30).is_empty());
     }
 }


### PR DESCRIPTION
Closes #5435

## Reachability finding (key result)

The #5433 judge filed this as **latent — "not on the transactional DML path today."** Investigation shows it **is reachable today**:

- `Database::delete_row` (`crates/vibesql-storage/src/database/index_ops.rs:1262`) calls `rebuild_indexes` from its `if delete_result.compacted` branch.
- Compaction fires when a single DELETE removes >50% of a table's rows (`Table::should_compact`, `crates/vibesql-storage/src/table/mod.rs:1246`).
- DELETE runs inside transactions, and `rebuild_indexes` itself arms the disk undo-log via `snapshot_operations_for_mutation` (`core.rs:167`).

So a spilled (disk-backed) index **can** be wholesale-rebuilt while the undo-log is armed. The old `DiskBacked` rebuild arm did `*guard = new_btree` (a fresh `bulk_load` tree with `undo_log: None`), which discarded the armed log and replaced the live tree — leaving nothing for `rollback_disk_undo_logs` to reverse. ROLLBACK would silently keep the rebuilt index and lose the pre-rebuild state.

`vacuum_mvcc` (the other in-txn-looking `rebuild_indexes` caller) is already guarded by an `in_transaction()` error, so it is not a concern.

## Chosen approach: in-place logged rebuild (undo, not guard)

Because the path **is** reachable on legitimate DELETE-heavy transactions, a guard/error would break real workloads. Instead, ROLLBACK is made sound:

- New `BTreeIndex::rebuild_in_place_logged` + `collect_all_entries` (`btree/node/btree_index/mod.rs`): when undo-logging is armed, rebuild the **same** tree object by deleting every existing key and inserting the new contents through the **logged** `delete`/`insert` paths. The undo-log captures the full inverse, so ROLLBACK restores the exact pre-rebuild tree and COMMIT discards the log.
- `IndexManager::rebuild_indexes` (`indexes/index_maintenance/update.rs`) branches on `guard.is_undo_logging()`: logged in-place rebuild inside a txn, fast wholesale `bulk_load` swap otherwise.

Cost is O(existing + new) entries, paid once per in-txn rebuild (rare — only on >50%-compacting DELETEs). This matches the #5425 soundness bar without snapshotting the whole tree (so spill is preserved).

## Test evidence

New tests in `index_manager.rs`:
- `spilled_index_rebuild_in_txn_rolls_back` — rebuild mid-txn, then ROLLBACK restores all pre-rebuild keys/positions.
- `spilled_index_rebuild_in_txn_commits` — COMMIT persists the rebuilt contents.
- `spilled_index_rebuild_without_txn_uses_fast_path` — outside a txn the fast bulk_load swap still yields correct contents.

Results:
- `cargo test -p vibesql-storage` (default): all pass (the only flake, `test_sql_dump_large_dataset`, is a pre-existing wall-clock `< 10s` assertion that fails only under heavy parallel-build load; passes in isolation at 0.08s).
- `cargo test -p vibesql-storage --features mvcc_enabled --lib`: 682 passed, 0 failed.
- #5425/#5433 regressions (`spilled_index_rollback_restores_state`, `spilled_index_commit_persists_state`) still pass.
- No new clippy warnings in the changed files.

## Test plan
- [ ] Review the in-place logged rebuild for soundness vs. the per-row undo-log inverses
- [ ] Confirm the fast-path (non-txn) rebuild is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)