### PR TITLE
fix(parser): match CASE...END nesting in trigger-body splitter

### DIFF
--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -106,6 +106,7 @@ mod quantified_comparison_tests;
 mod query_timeout_tests;
 mod raise_trigger_tests;
 mod recursive_cte_tests;
+mod trigger_case_body_tests;
 mod rowid_tests;
 mod scalar_subquery_basic_tests;
 mod scalar_subquery_caching_tests;

--- a/crates/vibesql-executor/src/tests/trigger_case_body_tests.rs
+++ b/crates/vibesql-executor/src/tests/trigger_case_body_tests.rs
@@ -1,0 +1,235 @@
+//! Execution tests for `CASE ... END` expressions inside trigger bodies (#5439).
+//!
+//! Regression for the trigger-body statement splitter / token collector: the
+//! `END` of a `CASE ... END` expression inside a body statement was treated as
+//! the trigger-body terminator, truncating the body so that statements after a
+//! CASE-bearing statement were silently dropped (and create-time parsing failed
+//! with `incomplete input`).
+//!
+//! Behavior verified against sqlite3 3.51.0:
+//! - `BEGIN UPDATE ... CASE ... END; INSERT INTO log ...; END` fires BOTH
+//!   statements (the CASE...END does not truncate the body).
+//! - Multiple CASE expressions across statements, nested CASE, and CASE in a
+//!   WHERE clause all leave the trailing statements intact.
+//! - `INSTEAD OF INSERT` with `SELECT CASE WHEN ... THEN raise(IGNORE) END`
+//!   followed by an `INSERT INTO base` skips the matching row but still runs the
+//!   base write for non-matching rows.
+
+use vibesql_ast::Statement;
+use vibesql_parser::Parser;
+use vibesql_types::SqlValue;
+
+use super::super::*;
+
+/// Execute setup SQL that is expected to succeed.
+fn exec_ok(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt =
+        Parser::parse_sql(sql).unwrap_or_else(|e| panic!("Failed to parse {:?}: {:?}", sql, e));
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+        }
+        Statement::CreateTrigger(s) => {
+            crate::advanced_objects::execute_create_trigger(&s, db).expect("CREATE TRIGGER failed");
+        }
+        Statement::CreateView(s) => {
+            crate::advanced_objects::execute_create_view(&s, db).expect("CREATE VIEW failed");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT failed");
+        }
+        Statement::Update(s) => {
+            UpdateExecutor::execute(&s, db).expect("UPDATE failed");
+        }
+        Statement::Delete(s) => {
+            DeleteExecutor::execute(&s, db).expect("DELETE failed");
+        }
+        other => panic!("Unsupported setup statement: {:?}", other),
+    }
+}
+
+/// Read column `col` of every row in `table`, ordered by physical position.
+fn column_values(db: &vibesql_storage::Database, table: &str, col: &str) -> Vec<SqlValue> {
+    let schema = db.catalog.get_table(table).expect("table exists");
+    let idx = schema.columns.iter().position(|c| c.name == col).expect("column exists");
+    db.get_table(table)
+        .expect("table exists")
+        .scan()
+        .iter()
+        .map(|row| row.values[idx].clone())
+        .collect()
+}
+
+fn strings(db: &vibesql_storage::Database, table: &str, col: &str) -> Vec<String> {
+    column_values(db, table, col)
+        .into_iter()
+        .map(|v| match v {
+            SqlValue::Varchar(s) | SqlValue::Character(s) => s.to_string(),
+            other => panic!("expected text, got {:?}", other),
+        })
+        .collect()
+}
+
+fn ints(db: &vibesql_storage::Database, table: &str, col: &str) -> Vec<i64> {
+    column_values(db, table, col)
+        .into_iter()
+        .map(|v| match v {
+            SqlValue::Integer(i) => i,
+            SqlValue::Bigint(i) => i,
+            other => panic!("expected integer, got {:?}", other),
+        })
+        .collect()
+}
+
+#[test]
+fn case_end_then_insert_fires_both_statements() {
+    // sqlite3 3.51.0: both the UPDATE (with CASE...END) and the trailing INSERT
+    // fire — the CASE's END does not terminate the body.
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE t (id INTEGER, v INTEGER)");
+    exec_ok(&mut db, "CREATE TABLE log (msg VARCHAR(16))");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER tr AFTER INSERT ON t BEGIN \
+         UPDATE t SET v = CASE WHEN NEW.v > 0 THEN 1 ELSE 0 END; \
+         INSERT INTO log VALUES ('x'); \
+         END",
+    );
+
+    exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (1, 5)");
+
+    // Trailing INSERT ran: log has one row.
+    assert_eq!(strings(&db, "log", "msg"), vec!["x".to_string()]);
+    // The CASE-driven UPDATE ran: v became 1.
+    assert_eq!(ints(&db, "t", "v"), vec![1]);
+}
+
+#[test]
+fn multiple_case_expressions_across_statements() {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE t (id INTEGER, v INTEGER)");
+    exec_ok(&mut db, "CREATE TABLE log (msg VARCHAR(16))");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER tr AFTER INSERT ON t BEGIN \
+         UPDATE t SET v = CASE WHEN NEW.v > 0 THEN 1 ELSE 0 END; \
+         INSERT INTO log VALUES (CASE WHEN NEW.v > 0 THEN 'pos' ELSE 'neg' END); \
+         END",
+    );
+
+    exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (1, 5)");
+
+    assert_eq!(ints(&db, "t", "v"), vec![1]);
+    assert_eq!(strings(&db, "log", "msg"), vec!["pos".to_string()]);
+}
+
+#[test]
+fn nested_case_end_does_not_truncate_body() {
+    // sqlite3 3.51.0: a nested CASE...END (inner CASE in the THEN of the outer)
+    // closes both blocks before the body terminator; trailing INSERT fires.
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE t (id INTEGER, v INTEGER)");
+    exec_ok(&mut db, "CREATE TABLE log (msg VARCHAR(16))");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER tr AFTER INSERT ON t BEGIN \
+         UPDATE t SET v = CASE WHEN NEW.v > 0 \
+           THEN CASE WHEN NEW.v > 10 THEN 99 ELSE 5 END \
+           ELSE 0 END; \
+         INSERT INTO log VALUES ('done'); \
+         END",
+    );
+
+    exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (1, 20)");
+
+    assert_eq!(ints(&db, "t", "v"), vec![99]);
+    assert_eq!(strings(&db, "log", "msg"), vec!["done".to_string()]);
+}
+
+#[test]
+fn case_in_where_clause_does_not_truncate_body() {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE t (id INTEGER, v INTEGER)");
+    exec_ok(&mut db, "CREATE TABLE log (msg VARCHAR(16))");
+    exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (1, 0)");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER tr AFTER UPDATE ON t BEGIN \
+         UPDATE t SET v = 7 WHERE id = CASE WHEN NEW.id > 0 THEN NEW.id ELSE -1 END; \
+         INSERT INTO log VALUES ('w'); \
+         END",
+    );
+
+    // Fire the AFTER UPDATE trigger. Recursion is prevented by SQLite/VibeSQL so
+    // the inner UPDATE does not re-fire infinitely.
+    exec_ok(&mut db, "UPDATE t SET v = 1 WHERE id = 1");
+
+    assert_eq!(strings(&db, "log", "msg"), vec!["w".to_string()]);
+}
+
+#[test]
+fn instead_of_insert_case_raise_ignore_body_parses_at_create_time() {
+    // #5439 (filed by the #5436 judge): the direct repro. Before the fix this
+    // CREATE TRIGGER failed with `incomplete input` because the CASE's `END`
+    // was treated as the body terminator, dropping the trailing base INSERT.
+    // The trigger must now CREATE successfully with the full body retained.
+    //
+    // NOTE: This is a *create-time* assertion. Actually *firing* this trigger
+    // additionally requires resolving `NEW.id` inside a from-less
+    // `SELECT CASE WHEN NEW.id = 1 THEN raise(IGNORE) END` — a separate
+    // executor limitation ("Column reference requires FROM clause") that PR
+    // #5436 worked around and that is out of scope for #5439. See the filed
+    // follow-on.
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE base (id INTEGER, v INTEGER)");
+    exec_ok(&mut db, "CREATE VIEW vw AS SELECT id, v FROM base");
+
+    let sql = "CREATE TRIGGER trg INSTEAD OF INSERT ON vw BEGIN \
+               SELECT CASE WHEN NEW.id = 1 THEN raise(IGNORE) END; \
+               INSERT INTO base (id, v) VALUES (NEW.id, NEW.v); \
+               END";
+    let stmt = Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("CREATE TRIGGER with CASE...END must parse (#5439): {:?}", e));
+    match stmt {
+        Statement::CreateTrigger(s) => {
+            // Body retains BOTH the CASE-bearing SELECT and the trailing INSERT.
+            let vibesql_ast::TriggerAction::RawSql(body) = &s.triggered_action;
+            let up = body.to_uppercase();
+            assert!(up.contains("CASE"), "body lost the CASE expression: {}", body);
+            assert!(
+                up.contains("INSERT INTO BASE"),
+                "body truncated before the trailing INSERT (the #5439 bug): {}",
+                body
+            );
+            crate::advanced_objects::execute_create_trigger(&s, &mut db)
+                .expect("CREATE TRIGGER should succeed");
+        }
+        other => panic!("expected CreateTrigger, got {:?}", other),
+    }
+}
+
+#[test]
+fn instead_of_insert_case_then_base_write_fires_both() {
+    // End-to-end INSTEAD OF variant that avoids the from-less `NEW` resolution
+    // limitation: the CASE...END lives in the INSERT's VALUES (which carries the
+    // NEW row context), so both the conditional column and the base write run.
+    // sqlite3 3.51.0: base receives one row with v = 'pos' (NEW.v = 10 > 0).
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE base (id INTEGER, label VARCHAR(8))");
+    exec_ok(&mut db, "CREATE TABLE log (msg VARCHAR(8))");
+    exec_ok(&mut db, "CREATE VIEW vw AS SELECT id, label FROM base");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg INSTEAD OF INSERT ON vw BEGIN \
+         INSERT INTO base (id, label) VALUES (NEW.id, CASE WHEN NEW.id > 0 THEN 'pos' ELSE 'neg' END); \
+         INSERT INTO log VALUES ('fired'); \
+         END",
+    );
+
+    exec_ok(&mut db, "INSERT INTO vw (id, label) VALUES (10, 'ignored')");
+
+    assert_eq!(ints(&db, "base", "id"), vec![10]);
+    assert_eq!(strings(&db, "base", "label"), vec!["pos".to_string()]);
+    // The statement after the CASE-bearing INSERT also fired.
+    assert_eq!(strings(&db, "log", "msg"), vec!["fired".to_string()]);
+}

--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -171,13 +171,25 @@ impl Parser {
         self.expect_keyword(Keyword::Begin)?;
 
         let mut sql_parts = vec!["BEGIN".to_string()];
-        let mut depth = 1; // Track BEGIN/END nesting
+        // Track block nesting. Both `BEGIN ... END` and `CASE ... END` open a
+        // block that `END` closes. The trigger body's terminating `END` is the
+        // one that brings the depth back to 0; a `CASE ... END` *expression*
+        // inside a body statement (e.g.
+        // `SELECT CASE WHEN NEW.id = 1 THEN raise(IGNORE) END;`) must not be
+        // mistaken for it, or the body is truncated at the CASE's `END`.
+        let mut depth = 1;
 
-        // Collect tokens until matching END
+        // Collect tokens until the matching body-terminator END.
         loop {
             match self.peek() {
                 Token::Keyword { keyword: Keyword::Begin, .. } => {
                     sql_parts.push("BEGIN".to_string());
+                    depth += 1;
+                    self.advance();
+                }
+                Token::Keyword { keyword: Keyword::Case, .. } => {
+                    // A CASE expression opens a block its own END closes.
+                    sql_parts.push("CASE".to_string());
                     depth += 1;
                     self.advance();
                 }

--- a/crates/vibesql-parser/src/tests/trigger.rs
+++ b/crates/vibesql-parser/src/tests/trigger.rs
@@ -532,3 +532,126 @@ fn test_create_trigger_empty_body_parses() {
     let result = Parser::parse_sql("CREATE TRIGGER tr5 AFTER INSERT ON t1 BEGIN END;");
     assert!(result.is_ok(), "empty trigger body should parse: {:?}", result.err());
 }
+
+// --- CASE...END nesting in trigger bodies (#5439) ---
+//
+// The trigger-body token collector and statement splitter must track block
+// nesting: a `CASE ... END` *expression* inside a body statement opens a block
+// that its own `END` closes. The body's terminating `END` is the one at
+// nesting depth 0 — so a body statement containing `CASE ... END` followed by
+// another statement must not be truncated at the CASE's `END`.
+
+#[test]
+fn test_create_trigger_body_case_end_not_treated_as_body_terminator() {
+    // Direct repro from #5439: a CASE ... END inside the first body statement
+    // must not truncate the body — the trailing INSERT must be preserved.
+    use vibesql_ast::TriggerAction;
+
+    let sql = "CREATE TRIGGER trg INSTEAD OF INSERT ON vw BEGIN \
+               SELECT CASE WHEN NEW.id = 1 THEN raise(IGNORE) END; \
+               INSERT INTO base(id, v) VALUES(NEW.id, NEW.v); \
+               END;";
+    let result = Parser::parse_sql(sql);
+    assert!(
+        result.is_ok(),
+        "trigger body with CASE...END must not be truncated: {:?}",
+        result.err()
+    );
+
+    match result.unwrap() {
+        Statement::CreateTrigger(trigger) => match &trigger.triggered_action {
+            TriggerAction::RawSql(body) => {
+                let up = body.to_uppercase();
+                // Both the CASE expression and the trailing INSERT survive.
+                assert!(up.contains("CASE"), "Body should retain the CASE expression. Got: {}", body);
+                assert!(
+                    up.contains("INSERT INTO BASE"),
+                    "Body should retain the statement after the CASE...END. Got: {}",
+                    body
+                );
+                // The body terminator END must be present (not consumed by CASE).
+                assert!(up.trim_end().ends_with("END"), "Body should end with END. Got: {}", body);
+            }
+        },
+        other => panic!("Expected CreateTrigger, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_trigger_body_multiple_case_expressions() {
+    // Two separate body statements each containing a CASE...END.
+    let sql = "CREATE TRIGGER trg AFTER INSERT ON t BEGIN \
+               UPDATE t SET v = CASE WHEN NEW.v > 0 THEN 'pos' ELSE 'neg' END; \
+               INSERT INTO log VALUES(CASE WHEN NEW.v > 0 THEN 'a' ELSE 'b' END); \
+               END;";
+    let result = Parser::parse_sql(sql);
+    assert!(
+        result.is_ok(),
+        "trigger body with multiple CASE...END must parse: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_create_trigger_body_nested_case_expressions() {
+    // A nested CASE...END (CASE inside the THEN of an outer CASE) must close
+    // both blocks before the body terminator.
+    use vibesql_ast::TriggerAction;
+
+    let sql = "CREATE TRIGGER trg AFTER INSERT ON t BEGIN \
+               UPDATE t SET v = CASE WHEN NEW.v > 0 \
+                 THEN CASE WHEN NEW.v > 10 THEN 'big' ELSE 'small' END \
+                 ELSE 'neg' END; \
+               INSERT INTO log VALUES('done'); \
+               END;";
+    let result = Parser::parse_sql(sql);
+    assert!(
+        result.is_ok(),
+        "trigger body with nested CASE...END must parse: {:?}",
+        result.err()
+    );
+
+    match result.unwrap() {
+        Statement::CreateTrigger(trigger) => match &trigger.triggered_action {
+            TriggerAction::RawSql(body) => {
+                let up = body.to_uppercase();
+                assert!(
+                    up.contains("INSERT INTO LOG"),
+                    "Body after nested CASE...END must be preserved. Got: {}",
+                    body
+                );
+            }
+        },
+        other => panic!("Expected CreateTrigger, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_trigger_body_case_in_where_clause() {
+    // CASE...END in a WHERE clause (different statement position).
+    let sql = "CREATE TRIGGER trg AFTER UPDATE ON t BEGIN \
+               UPDATE t SET v = 1 WHERE id = CASE WHEN NEW.id > 0 THEN NEW.id ELSE 0 END; \
+               INSERT INTO log VALUES('w'); \
+               END;";
+    let result = Parser::parse_sql(sql);
+    assert!(
+        result.is_ok(),
+        "trigger body with CASE...END in WHERE must parse: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_create_trigger_body_case_as_last_statement_no_trailing_semicolon() {
+    // A CASE...END in the final body statement (no trailing `;`) must not have
+    // its END mistaken for the body terminator nor leave the body unterminated.
+    let sql = "CREATE TRIGGER trg AFTER INSERT ON t BEGIN \
+               SELECT CASE WHEN NEW.v > 0 THEN 1 ELSE 0 END \
+               END;";
+    let result = Parser::parse_sql(sql);
+    assert!(
+        result.is_ok(),
+        "trigger body ending with CASE...END (no trailing ;) must parse: {:?}",
+        result.err()
+    );
+}

--- a/crates/vibesql-parser/src/trigger_body.rs
+++ b/crates/vibesql-parser/src/trigger_body.rs
@@ -197,6 +197,45 @@ mod tests {
     }
 
     #[test]
+    fn case_end_inside_statement_does_not_split_or_truncate_body() {
+        // #5439: the END of a CASE...END expression must not be treated as the
+        // body terminator. Both body statements must come through whole.
+        let body = "BEGIN \
+                    SELECT CASE WHEN NEW.id = 1 THEN raise(IGNORE) END; \
+                    INSERT INTO base(id, v) VALUES(NEW.id, NEW.v); \
+                    END";
+        let stmts = split_trigger_body_statements(body);
+        assert_eq!(
+            stmts,
+            vec![
+                "SELECT CASE WHEN NEW.id = 1 THEN raise(IGNORE) END",
+                "INSERT INTO base(id, v) VALUES(NEW.id, NEW.v)"
+            ]
+        );
+    }
+
+    #[test]
+    fn nested_case_end_does_not_truncate_body() {
+        let body = "BEGIN \
+                    UPDATE t SET v = CASE WHEN NEW.v > 0 \
+                      THEN CASE WHEN NEW.v > 10 THEN 'big' ELSE 'small' END \
+                      ELSE 'neg' END; \
+                    INSERT INTO log VALUES('done'); \
+                    END";
+        let stmts = split_trigger_body_statements(body);
+        assert_eq!(stmts.len(), 2, "got: {:?}", stmts);
+        assert!(stmts[0].to_uppercase().starts_with("UPDATE T"));
+        assert_eq!(stmts[1], "INSERT INTO log VALUES('done')");
+    }
+
+    #[test]
+    fn case_end_as_last_statement_without_trailing_semicolon() {
+        let body = "BEGIN SELECT CASE WHEN NEW.v > 0 THEN 1 ELSE 0 END END";
+        let stmts = split_trigger_body_statements(body);
+        assert_eq!(stmts, vec!["SELECT CASE WHEN NEW.v > 0 THEN 1 ELSE 0 END"]);
+    }
+
+    #[test]
     fn does_not_strip_begin_inside_identifier() {
         // A body that does not start with the BEGIN keyword should be left as
         // is (defensive: callers always pass a wrapped body, but guard anyway).


### PR DESCRIPTION
## Summary

Fixes #5439: the trigger-body token collector (`parse_trigger_action` in `crates/vibesql-parser/src/parser/trigger.rs`) treated the `END` of a `CASE ... END` expression inside a body statement as the trigger-body terminator. The body was truncated at the first CASE's `END`, so any statement after a CASE-bearing statement was silently dropped and `CREATE TRIGGER` failed with `incomplete input`.

## Approach: token-depth block nesting

Both `BEGIN ... END` and `CASE ... END` open a block that `END` closes. The collector already tracked `BEGIN`/`END` depth; this PR also increments depth on `Token::Keyword { Keyword::Case }`. The trigger body's terminating `END` is the one that brings nesting depth back to 0 — a `CASE ... END` *expression* (whose own `END` returns depth to 1, not 0) is no longer mistaken for it.

For the SQLite trigger-body grammar, `CASE` is the only additional END-pairing construct (nested `BEGIN` was already handled); routine-only forms like `IF ... END` are not valid in SQLite trigger bodies. The lexer-aware semicolon splitter (`split_trigger_body_statements`, #5408/#5412) needed no logic change — CASE expressions contain no top-level semicolons — but gains regression tests.

## Verified against sqlite3 3.51.0

| Case | sqlite3 result | VibeSQL result |
|------|----------------|----------------|
| `BEGIN UPDATE ... = CASE ... END; INSERT INTO log ...; END` | both fire (`v=1`, log row) | both fire |
| Multiple CASE expressions across statements | both fire | both fire |
| Nested CASE (`CASE ... THEN CASE ... END ... END`) | both fire (`v=99`, log row) | both fire |
| CASE in WHERE clause + trailing INSERT | trailing fires | trailing fires |
| INSTEAD OF INSERT with CASE in VALUES + trailing INSERT | base + log written | base + log written |
| Direct #5439 repro (`SELECT CASE WHEN NEW.id=1 THEN raise(IGNORE) END; INSERT INTO base...`) | accepted | now parses at create time (body retained) |

## Tests

Parser (`crates/vibesql-parser/src/tests/trigger.rs`, `trigger_body.rs`):
- CASE...END not treated as body terminator; multiple CASE; nested CASE; CASE in WHERE; CASE as last statement without trailing `;`
- Splitter unit tests for the same, plus existing #5408/#5412 string-literal/`;` tests still pass

Executor (`crates/vibesql-executor/src/tests/trigger_case_body_tests.rs`, new): end-to-end create + fire for each sqlite3-verified case above.

Results:
- `cargo test -p vibesql-parser`: 1411 + 8 doctests, 0 failed
- `cargo test -p vibesql-executor`: 4246 passed, 0 failed
- `cargo build --release`: clean

## Out of scope / follow-on

The direct #5439 repro uses a from-less `SELECT CASE WHEN NEW.id = 1 THEN raise(IGNORE) END`, which at *fire time* additionally requires resolving `NEW.id` in a `SELECT` with no `FROM` — a separate executor limitation (`Column reference requires FROM clause`) that PR #5436 already worked around. This PR fixes the create-time truncation (#5439) and verifies fire-time CASE behavior via the VALUES/WHERE positions that carry the NEW row context. The from-less `NEW.x` resolution will be filed as a follow-on.

## Test plan
- [x] `cargo test -p vibesql-parser` green
- [x] `cargo test -p vibesql-executor` green
- [x] sqlite3 3.51.0 parity for each case
- [x] `cargo build --release` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #5439