### PR TITLE
Raft: route HTTP GraphQL queries + mutations through consensus

### DIFF
--- a/crates/vibesql-consensus/src/mvcc_raft.rs
+++ b/crates/vibesql-consensus/src/mvcc_raft.rs
@@ -1023,6 +1023,18 @@ impl MvccRaftNode {
         self.sm.machine.primary_key_column(table_name)
     }
 
+    /// Snapshot every table's schema from the locally applied replicated
+    /// catalog (#5421), keyed by table name. Local read of the applied
+    /// catalog — no leadership check or network round — used by the HTTP
+    /// GraphQL surface to build its GraphQL type and relationship model in
+    /// replicated mode, where the schema lives in the state machine rather
+    /// than the (empty) local registry database.
+    pub fn schema_snapshot(
+        &self,
+    ) -> std::collections::HashMap<String, vibesql_catalog::TableSchema> {
+        self.sm.machine.schema_snapshot()
+    }
+
     /// Run a read-only SELECT with **linearizable** semantics (Raft
     /// Phase B2, #5200, PR 1): openraft's ReadIndex protocol
     /// ([`Raft::ensure_linearizable`]) first confirms this node's

--- a/crates/vibesql-consensus/src/state_machine.rs
+++ b/crates/vibesql-consensus/src/state_machine.rs
@@ -606,6 +606,27 @@ impl VibesqlStateMachine {
         }
     }
 
+    /// Snapshot every table's schema from the **applied replicated catalog**
+    /// (#5421), keyed by table name. This is the replicated-mode counterpart
+    /// of reading the local registry catalog: the HTTP GraphQL surface builds
+    /// its GraphQL type/relationship model (table types, columns, foreign-key
+    /// relationships) from these schemas, but in replicated mode the catalog
+    /// lives here in the state machine, not in the (empty) local registry
+    /// database. Like [`query`](Self::query) and
+    /// [`primary_key_column`](Self::primary_key_column) it is a local read of
+    /// the applied state — no leadership check or network round.
+    pub fn schema_snapshot(
+        &self,
+    ) -> std::collections::HashMap<String, vibesql_catalog::TableSchema> {
+        let inner = self.lock();
+        inner
+            .db
+            .list_tables()
+            .into_iter()
+            .filter_map(|name| inner.db.get_table(&name).map(|table| (name, table.schema.clone())))
+            .collect()
+    }
+
     /// Speculatively read inside an open replicated transaction so the
     /// session observes its **own** buffered (not-yet-committed) writes —
     /// full mid-transaction read-your-own-writes (#5401).

--- a/crates/vibesql-server/src/http/graphql/introspection.rs
+++ b/crates/vibesql-server/src/http/graphql/introspection.rs
@@ -1,33 +1,51 @@
 //! GraphQL schema introspection support
 //!
 //! Handles __schema and __type queries for GraphQL introspection.
+//!
+//! Introspection is driven by a schema map (table name → [`TableSchema`])
+//! rather than the live database handle, so the same code path serves both
+//! standalone mode (the map is built from the local registry catalog) and
+//! replicated mode (the map is built from the applied consensus catalog via
+//! [`ReplicationHandle::schema_snapshot`](crate::replication::ReplicationHandle::schema_snapshot)),
+//! #5421. Reading the catalog through the map keeps the GraphQL surface from
+//! ever introspecting the unreplicated local database on a replicated node.
 
-use std::sync::Arc;
+use std::collections::HashMap;
 
 use serde_json::{json, Value as JsonValue};
-use vibesql_storage::Database;
+use vibesql_catalog::TableSchema;
 
 /// Try to handle introspection queries (__schema, __type)
 /// Returns Some(result) if this was an introspection query, None otherwise
-pub fn try_introspection_query(db: &Arc<Database>, query: &str) -> Option<JsonValue> {
+pub fn try_introspection_query(
+    schemas: &HashMap<String, TableSchema>,
+    query: &str,
+) -> Option<JsonValue> {
     let query = query.trim();
 
     // Check for __schema query
     if query.contains("__schema") {
-        return try_schema_query(db, query);
+        return try_schema_query(schemas, query);
     }
 
     // Check for __type query
     if query.contains("__type") {
-        return try_type_query(db, query);
+        return try_type_query(schemas, query);
     }
 
     None
 }
 
+/// Look up a table schema in the map case-insensitively.
+fn find_schema<'a>(
+    schemas: &'a HashMap<String, TableSchema>,
+    table_name: &str,
+) -> Option<&'a TableSchema> {
+    schemas.iter().find(|(name, _)| name.eq_ignore_ascii_case(table_name)).map(|(_, schema)| schema)
+}
+
 /// Handle __schema introspection query
-fn try_schema_query(db: &Arc<Database>, _query: &str) -> Option<JsonValue> {
-    let table_names = db.list_tables();
+fn try_schema_query(schemas: &HashMap<String, TableSchema>, _query: &str) -> Option<JsonValue> {
     let mut types = Vec::new();
 
     // Add built-in scalar types
@@ -40,9 +58,11 @@ fn try_schema_query(db: &Arc<Database>, _query: &str) -> Option<JsonValue> {
         }));
     }
 
-    // Add table types
-    for table_name in &table_names {
-        let fields = get_table_fields(db, table_name);
+    // Add table types (sorted for deterministic output across runs).
+    let mut table_names: Vec<&String> = schemas.keys().collect();
+    table_names.sort();
+    for table_name in table_names {
+        let fields = get_table_fields(schemas, table_name);
         types.push(json!({
             "kind": "OBJECT",
             "name": table_name,
@@ -94,7 +114,7 @@ fn try_schema_query(db: &Arc<Database>, _query: &str) -> Option<JsonValue> {
 }
 
 /// Handle __type(name: "...") introspection query
-fn try_type_query(db: &Arc<Database>, query: &str) -> Option<JsonValue> {
+fn try_type_query(schemas: &HashMap<String, TableSchema>, query: &str) -> Option<JsonValue> {
     // Simple pattern matching for __type(name: "TypeName")
     let type_name = extract_type_name(query)?;
 
@@ -113,9 +133,8 @@ fn try_type_query(db: &Arc<Database>, query: &str) -> Option<JsonValue> {
     }
 
     // Check if it's a table
-    let table_names = db.list_tables();
-    if table_names.contains(&type_name) {
-        let fields = get_table_fields(db, &type_name);
+    if find_schema(schemas, &type_name).is_some() {
+        let fields = get_table_fields(schemas, &type_name);
         return Some(json!({
             "__type": {
                 "kind": "OBJECT",
@@ -145,33 +164,71 @@ pub fn extract_type_name(query: &str) -> Option<String> {
     Some(remaining[..closing_quote].to_string())
 }
 
-/// Get fields for a table (map SQLite columns to GraphQL fields)
-fn get_table_fields(db: &Arc<Database>, table_name: &str) -> Vec<JsonValue> {
-    let fields = Vec::new();
+/// Get fields for a table (map columns to GraphQL fields), driven by the
+/// resolved [`TableSchema`]. In replicated mode the schema comes from the
+/// applied consensus catalog, so the fields are no longer the empty list the
+/// pre-#5421 local-only path returned for an empty local database.
+fn get_table_fields(schemas: &HashMap<String, TableSchema>, table_name: &str) -> Vec<JsonValue> {
+    let Some(schema) = find_schema(schemas, table_name) else {
+        return Vec::new();
+    };
 
-    // Get table schema from database
-    let table_names = db.list_tables();
-    if !table_names.iter().any(|t| t == table_name) {
-        return fields;
+    schema
+        .columns
+        .iter()
+        .map(|col| {
+            json!({
+                "name": col.name,
+                "type": graphql_type_name(&col.data_type, col.nullable),
+            })
+        })
+        .collect()
+}
+
+/// Map a SQL [`DataType`](vibesql_types::DataType) onto a GraphQL scalar type
+/// name, appending `!` for NOT NULL columns (GraphQL non-null marker).
+fn graphql_type_name(data_type: &vibesql_types::DataType, nullable: bool) -> String {
+    use vibesql_types::DataType;
+    let base = match data_type {
+        DataType::Boolean => "Boolean",
+        DataType::Smallint | DataType::Integer | DataType::Bigint | DataType::Unsigned => "Int",
+        DataType::Real
+        | DataType::DoublePrecision
+        | DataType::Float { .. }
+        | DataType::Numeric { .. }
+        | DataType::Decimal { .. } => "Float",
+        _ => "String",
+    };
+    if nullable {
+        base.to_string()
+    } else {
+        format!("{base}!")
     }
-
-    // Try to get table schema from database metadata
-    // Use a basic introspection approach that queries the database
-    // to determine column names
-
-    // Note: Table introspection disabled for now - requires async context.
-    // In a real implementation, this should query the database catalog to get column information.
-    // For now, return generic fields based on table existence check above.
-    let _ = table_name; // Silence unused variable warning
-
-    // If we couldn't get fields from introspection, return an empty list
-    // This prevents errors when a table exists but has no schema info
-    fields
 }
 
 #[cfg(test)]
 mod tests {
+    use vibesql_catalog::ColumnSchema;
+    use vibesql_types::DataType;
+
     use super::*;
+
+    fn sample_schemas() -> HashMap<String, TableSchema> {
+        let mut schemas = HashMap::new();
+        let users = TableSchema::new(
+            "users".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new(
+                    "name".to_string(),
+                    DataType::Varchar { max_length: Some(255) },
+                    true,
+                ),
+            ],
+        );
+        schemas.insert("users".to_string(), users);
+        schemas
+    }
 
     #[test]
     fn test_extract_type_name() {
@@ -184,25 +241,51 @@ mod tests {
 
     #[test]
     fn test_schema_query_detection() {
-        let db = Arc::new(Database::new());
+        let schemas = HashMap::new();
         let query = "query { __schema { types { name } } }";
-        assert!(try_introspection_query(&db, query).is_some());
+        assert!(try_introspection_query(&schemas, query).is_some());
     }
 
     #[test]
     fn test_type_query_detection() {
-        let db = Arc::new(Database::new());
+        let schemas = HashMap::new();
         let query = r#"{ __type(name: "String") { kind } }"#;
-        assert!(try_introspection_query(&db, query).is_some());
+        assert!(try_introspection_query(&schemas, query).is_some());
     }
 
     #[test]
     fn test_builtin_scalar_type() {
-        let db = Arc::new(Database::new());
+        let schemas = HashMap::new();
         let query = r#"{ __type(name: "Int") { kind name fields } }"#;
-        let result = try_type_query(&db, query).unwrap();
+        let result = try_type_query(&schemas, query).unwrap();
         assert_eq!(result["__type"]["kind"], "SCALAR");
         assert_eq!(result["__type"]["name"], "Int");
         assert!(result["__type"]["fields"].is_null());
+    }
+
+    #[test]
+    fn test_table_type_fields_from_schema() {
+        let schemas = sample_schemas();
+        let query = r#"{ __type(name: "users") { kind name fields { name } } }"#;
+        let result = try_type_query(&schemas, query).unwrap();
+        assert_eq!(result["__type"]["kind"], "OBJECT");
+        assert_eq!(result["__type"]["name"], "users");
+        let fields = result["__type"]["fields"].as_array().expect("fields array");
+        // The schema's columns are reflected as GraphQL fields (no longer the
+        // empty list the local-only path returned).
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0]["name"], "id");
+        assert_eq!(fields[0]["type"], "Int!"); // NOT NULL → non-null marker
+        assert_eq!(fields[1]["name"], "name");
+        assert_eq!(fields[1]["type"], "String"); // nullable
+    }
+
+    #[test]
+    fn test_schema_query_includes_tables() {
+        let schemas = sample_schemas();
+        let query = "query { __schema { types { name } } }";
+        let result = try_schema_query(&schemas, query).unwrap();
+        let types = result["__schema"]["types"].as_array().unwrap();
+        assert!(types.iter().any(|t| t["name"] == "users"));
     }
 }

--- a/crates/vibesql-server/src/http/rest.rs
+++ b/crates/vibesql-server/src/http/rest.rs
@@ -78,12 +78,14 @@ pub struct HttpState {
     /// consensus (#5410 — the `/api/query` endpoint and the CRUD collection
     /// endpoints; #5420 — the CRUD by-id endpoints, which resolve the primary
     /// key from the replicated catalog via
-    /// [`ReplicationHandle::primary_key_column`]) build a **replicated** session
+    /// [`ReplicationHandle::primary_key_column`]; #5421 — the GraphQL endpoint,
+    /// which introspects the replicated catalog via
+    /// [`ReplicationHandle::schema_snapshot`]) build a **replicated** session
     /// via [`Self::session`], so writes propose through this handle (leader-only,
     /// freeze-at-propose) and reads run against the replicated state machine —
     /// never against the unreplicated local registry database. Surfaces that
-    /// still depend on local-database schema/state introspection (GraphQL,
-    /// subscriptions, blob storage) remain gated (see [`Self::replicated_gate`])
+    /// still depend on local-database change-feed/state introspection
+    /// (subscriptions, blob storage) remain gated (see [`Self::replicated_gate`])
     /// to a clear error rather than silently reading stale data or accepting a
     /// write that never replicates; those are tracked as follow-ons to #5410.
     /// `/health` uses the handle to report node role/writability.
@@ -120,6 +122,28 @@ impl HttpState {
                 StdArc::clone(handle),
             ),
             None => Session::new(db_name.to_string(), "http_user".to_string(), shared_db),
+        }
+    }
+
+    /// Resolve the GraphQL schema map (table name → [`TableSchema`]) for
+    /// `shared_db`, used to answer introspection queries and to drive nested
+    /// relationship resolution (#5421).
+    ///
+    /// In replicated mode the schema lives in the consensus state machine, not
+    /// the (empty) local registry database, so it is read from the **applied
+    /// replicated catalog** via [`ReplicationHandle::schema_snapshot`]. In
+    /// standalone mode it is built from the local registry database, exactly as
+    /// the pre-#5421 path did — keeping standalone GraphQL behavior unchanged.
+    pub(crate) async fn graphql_schema_map(
+        &self,
+        shared_db: &crate::registry::SharedDatabase,
+    ) -> std::collections::HashMap<String, vibesql_catalog::TableSchema> {
+        match &self.replication {
+            Some(handle) => handle.schema_snapshot(),
+            None => {
+                let db_guard = shared_db.read().await;
+                build_schema_map(&db_guard)
+            }
         }
     }
 
@@ -293,7 +317,22 @@ pub fn get_database_name(headers: &HeaderMap) -> String {
         .unwrap_or_else(|| DEFAULT_DATABASE_NAME.to_string())
 }
 
-/// GraphQL endpoint handler with relationship resolution support
+/// GraphQL endpoint handler with relationship resolution support.
+///
+/// In replicated mode the GraphQL surface is no longer gated (#5421): both
+/// queries and mutations route through consensus via the [`HttpState::session`]
+/// choke point — a GraphQL **query** lowers to a SELECT served from the
+/// replicated state machine, and a GraphQL **mutation** lowers to an
+/// INSERT/UPDATE/DELETE proposed through consensus (leader-only,
+/// freeze-at-propose). A mutation on a follower surfaces the NOT_LEADER refusal
+/// as a `421` with a leader hint (via [`execution_error_response`]) and is never
+/// executed against the follower's local database (the split-brain invariant).
+/// Schema/relationship introspection reads the **applied replicated catalog**
+/// (via [`ReplicationHandle::schema_snapshot`]) rather than the (empty) local
+/// registry database. The GraphQL→SQL lowering parameterizes every value arg
+/// (`graphql::graphql_to_sql`), so string args cannot inject SQL. In standalone
+/// mode every step is identical to before (the schema comes from the local
+/// catalog, the session is the local executor).
 async fn graphql_handler(
     State(state): State<HttpState>,
     headers: HeaderMap,
@@ -301,30 +340,25 @@ async fn graphql_handler(
 ) -> impl IntoResponse {
     debug!("Received GraphQL request: {}", req.query);
 
-    // The GraphQL surface executes against the local registry database,
-    // which receives no replicated writes — gate it in replicated mode
-    // (#5393).
-    if let Some((code, body)) = state.replicated_gate("the GraphQL API") {
-        return (code, body).into_response();
-    }
-
     // Get the database name from headers
     let db_name = get_database_name(&headers);
 
     // Get or create the shared database from the registry
     let shared_db = state.registry.get_or_create(&db_name).await;
 
-    // For introspection, we need a read lock on the database
-    {
-        let db_guard = shared_db.read().await;
-        let db_arc = std::sync::Arc::new((*db_guard).clone());
-        if let Some(introspection_result) = graphql::try_introspection_query(&db_arc, &req.query) {
-            return (
-                StatusCode::OK,
-                Json(graphql::GraphQLResponse { data: Some(introspection_result), errors: None }),
-            )
-                .into_response();
-        }
+    // Resolve the schema map (table → TableSchema) used for both introspection
+    // and relationship resolution. In replicated mode it comes from the applied
+    // consensus catalog; in standalone mode from the local registry database.
+    let schemas = state.graphql_schema_map(&shared_db).await;
+
+    // Introspection (__schema / __type) is answered directly from the schema
+    // map — no SQL executes.
+    if let Some(introspection_result) = graphql::try_introspection_query(&schemas, &req.query) {
+        return (
+            StatusCode::OK,
+            Json(graphql::GraphQLResponse { data: Some(introspection_result), errors: None }),
+        )
+            .into_response();
     }
 
     // Parse the GraphQL query
@@ -368,21 +402,26 @@ async fn graphql_handler(
         }
     };
 
+    // Inline the bound value params (`$1`, `$2`, …) into the SQL as escaped
+    // literals before execution (#5421). The GraphQL→SQL lowering parameterizes
+    // every value arg, but the replicated write path proposes a SQL *string*
+    // through consensus (it carries no param vector), and the replicated session
+    // rejects the prepared-statement path outright. Rendering the params with
+    // the same `ToSql` escaping the wire `Bind`/`EXECUTE` paths use keeps string
+    // args injection-safe (a quote in a value is doubled, never breaks out) while
+    // producing a self-contained statement that executes identically standalone
+    // and over consensus.
+    let sql = crate::session::substitute_named_params(&sql, &params);
+
     debug!("Generated SQL: {}", sql);
 
-    // Create a session with the shared database
-    let mut session = crate::session::Session::new(
-        db_name.clone(),
-        "graphql_user".to_string(),
-        shared_db.clone(),
-    );
+    // Build the session through the replicated choke point: in replicated mode
+    // queries read the state machine and mutations propose through consensus;
+    // in standalone mode it is the ordinary local-executor session (#5421).
+    let mut session = state.session(&db_name, shared_db.clone());
 
-    // Execute the main query
-    let result = if params.is_empty() {
-        session.execute(&sql).await
-    } else {
-        session.execute_with_params(&sql, &params).await
-    };
+    // Execute the main query (params are already inlined as literals above).
+    let result = session.execute(&sql).await;
 
     match result {
         Ok(exec_result) => {
@@ -406,17 +445,14 @@ async fn graphql_handler(
                         })
                         .collect();
 
-                    // If we have nested fields, resolve relationships
+                    // If we have nested fields, resolve relationships using the
+                    // schema map resolved above (replicated catalog in
+                    // replicated mode, local catalog in standalone mode).
                     if has_nested {
                         if let graphql::GraphQLQueryInfo::Query {
                             table_name, nested_fields, ..
                         } = &query_info
                         {
-                            // Build schema map from database
-                            let db_guard = shared_db.read().await;
-                            let schemas = build_schema_map(&db_guard);
-                            drop(db_guard);
-
                             if !schemas.is_empty() {
                                 let ctx = graphql::GraphQLExecutionContext::new(&schemas);
                                 let nested_queries =
@@ -496,19 +532,49 @@ async fn graphql_handler(
         }
         Err(e) => {
             error!("Query execution failed: {}", e);
-            (
-                StatusCode::BAD_REQUEST,
-                Json(graphql::GraphQLResponse {
-                    data: None,
-                    errors: Some(vec![graphql::GraphQLError::new(format!(
-                        "Query execution failed: {}",
-                        e
-                    ))]),
-                }),
-            )
-                .into_response()
+            // Map a consensus refusal of a GraphQL mutation/query onto the same
+            // HTTP semantics the SQL surfaces use (#5421): NOT_LEADER → 421 with
+            // the leader-hint header, staleness/FATAL → 503, any other consensus
+            // error → 500, and a deterministic SQL rejection → 400. The body is
+            // a GraphQL `errors` array either way, so a GraphQL client still
+            // parses the failure; the status code + leader hint give a smart
+            // client the redirect contract. In standalone mode every error is a
+            // plain executor error → 400, exactly as before.
+            graphql_execution_error_response(&e)
         }
     }
+}
+
+/// Map a GraphQL execution error onto an HTTP response with a GraphQL-shaped
+/// body. Reuses [`execution_error_response`]'s consensus→HTTP mapping (status
+/// code + `X-VibeSQL-Leader` header for NOT_LEADER) but replaces the
+/// `ErrorResponse` JSON body with a [`graphql::GraphQLResponse`] carrying the
+/// flattened message in its `errors` array, so the response is valid GraphQL
+/// regardless of the status code (#5421).
+fn graphql_execution_error_response(err: &anyhow::Error) -> axum::response::Response {
+    // Derive the status + headers from the shared consensus mapping.
+    let mut mapped = execution_error_response(err);
+    let status = mapped.status();
+    let leader_hint = mapped.headers_mut().remove(LEADER_HINT_HEADER);
+    let retry_after = mapped.headers_mut().remove("Retry-After");
+
+    let message = match err.downcast_ref::<SqlError>() {
+        Some(sql_error) => sql_error_message(sql_error),
+        None => format!("Query execution failed: {err}"),
+    };
+
+    let body = Json(graphql::GraphQLResponse {
+        data: None,
+        errors: Some(vec![graphql::GraphQLError::new(message)]),
+    });
+    let mut resp = (status, body).into_response();
+    if let Some(hint) = leader_hint {
+        resp.headers_mut().insert(LEADER_HINT_HEADER, hint);
+    }
+    if let Some(retry) = retry_after {
+        resp.headers_mut().insert("Retry-After", retry);
+    }
+    resp
 }
 
 /// Build a map of table schemas from the database

--- a/crates/vibesql-server/src/replication.rs
+++ b/crates/vibesql-server/src/replication.rs
@@ -303,6 +303,19 @@ impl ReplicationHandle {
         self.node.primary_key_column(table_name)
     }
 
+    /// Snapshot every table's schema from the applied replicated catalog
+    /// (#5421), keyed by table name. The HTTP GraphQL surface uses this to
+    /// build its GraphQL type and relationship model in replicated mode —
+    /// where the schema lives in the consensus state machine, not the
+    /// (empty) local registry database — exactly as it would read the local
+    /// catalog in standalone mode. Local read of the applied catalog: no
+    /// leadership check or network round.
+    pub fn schema_snapshot(
+        &self,
+    ) -> std::collections::HashMap<String, vibesql_catalog::TableSchema> {
+        self.node.schema_snapshot()
+    }
+
     /// Linearizable read (quorum-confirmed leadership).
     pub async fn query_linearizable(
         &self,

--- a/crates/vibesql-server/src/session.rs
+++ b/crates/vibesql-server/src/session.rs
@@ -1485,7 +1485,7 @@ fn set_value_ms(expr: &vibesql_ast::Expression, variable: &str) -> Result<u64> {
 /// [`vibesql_ast::ToSql`] (the same escaping the wire `Bind` path uses), so
 /// values containing quotes cannot break out of the statement. Placeholders
 /// inside string literals are not substituted.
-fn substitute_named_params(sql: &str, params: &[SqlValue]) -> String {
+pub(crate) fn substitute_named_params(sql: &str, params: &[SqlValue]) -> String {
     use vibesql_ast::pretty_print::ToSql;
 
     let mut out = String::with_capacity(sql.len());

--- a/crates/vibesql-server/tests/replication_tests.rs
+++ b/crates/vibesql-server/tests/replication_tests.rs
@@ -1870,28 +1870,19 @@ async fn http_write_replicates_to_followers() {
     }
 }
 
-/// In replicated mode the GraphQL, subscription, and blob-storage surfaces
-/// remain gated to a clear 503 (they depend on local-database schema/state
+/// In replicated mode the subscription and blob-storage surfaces remain gated
+/// to a clear 503 (they depend on local-database change-feed/state
 /// introspection that is not yet wired through consensus — follow-ons to
 /// #5410). They must never silently execute against the local database. The
-/// CRUD by-id endpoints are no longer gated (#5420 wired them through
-/// consensus); see `http_crud_by_id_*` below.
+/// CRUD by-id endpoints (#5420) and the GraphQL endpoint (#5421) are no longer
+/// gated — they route through consensus; see `http_crud_by_id_*` and
+/// `http_graphql_*` below.
 #[tokio::test]
 async fn http_unwired_surfaces_still_gated_in_replicated_mode() {
     let (handles, _dir) = boot_cluster(1).await;
     wait_for_leader(&handles).await;
     let (base, _tx) = start_http(Some(Arc::clone(&handles[0]))).await;
     let client = reqwest::Client::new();
-
-    // GraphQL.
-    let resp = client
-        .post(format!("{base}/api/graphql"))
-        .header("content-type", "application/json")
-        .body(r#"{"query":"{ __typename }"}"#)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
 
     // Subscriptions.
     let resp = client.get(format!("{base}/api/subscribe?query=SELECT%201")).send().await.unwrap();
@@ -1900,6 +1891,261 @@ async fn http_unwired_surfaces_still_gated_in_replicated_mode() {
     // Blob storage.
     let resp = client.get(format!("{base}/api/storage/anything")).send().await.unwrap();
     assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+
+    // GraphQL is no longer gated — an introspection query succeeds (200)
+    // against the replicated catalog rather than returning the old 503.
+    let resp = client
+        .post(format!("{base}/api/graphql"))
+        .header("content-type", "application/json")
+        .body(r#"{"query":"{ __schema { types { name } } }"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+}
+
+/// In replicated mode a GraphQL **mutation** routes through consensus and a
+/// GraphQL **query** reads it back from the replicated state machine (#5421):
+/// the inserted row lands in the consensus state machine (not the unreplicated
+/// local database) and a subsequent GraphQL query observes it.
+#[tokio::test]
+async fn http_graphql_mutation_and_query_route_through_consensus() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let (base, _tx) = start_http(Some(Arc::clone(&handles[0]))).await;
+    let client = reqwest::Client::new();
+
+    let post_graphql = |query: &str| {
+        let client = client.clone();
+        let base = base.clone();
+        let body = serde_json::json!({ "query": query }).to_string();
+        async move {
+            client
+                .post(format!("{base}/api/graphql"))
+                .header("content-type", "application/json")
+                .body(body)
+                .send()
+                .await
+                .unwrap()
+        }
+    };
+
+    // Create the table through the SQL surface (DDL has no GraphQL form).
+    let resp = client
+        .post(format!("{base}/api/query"))
+        .header("content-type", "application/json")
+        .body(r#"{"sql":"CREATE TABLE gql_t (id INT, name VARCHAR(100))"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+
+    // GraphQL INSERT mutation → proposes through consensus (200).
+    let resp = post_graphql(
+        r#"mutation { insertInto(table: "gql_t", values: {"id": 1, "name": "Alice"}) }"#,
+    )
+    .await;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    // The write is in the consensus state machine, not the local database.
+    assert_eq!(
+        handles[0].node().query("SELECT COUNT(*) FROM gql_t").unwrap()[0][0].to_string(),
+        "1",
+        "a GraphQL mutation must land in the replicated state machine"
+    );
+
+    // A GraphQL query reads it back through the replicated state machine.
+    let resp = post_graphql(r#"{ gql_t { id name } }"#).await;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+    let rows = body["data"]["data"].as_array().expect("data.data array");
+    assert_eq!(rows.len(), 1, "the replicated GraphQL query must see the row: {body}");
+    assert_eq!(rows[0]["name"], "Alice", "{body}");
+}
+
+/// A GraphQL mutation replicates to every node (#5421): after an INSERT on the
+/// leader's HTTP GraphQL port, every follower converges to the row.
+#[tokio::test]
+async fn http_graphql_mutation_replicates_to_followers() {
+    let (handles, _dir) = boot_cluster(3).await;
+    let leader = wait_for_leader(&handles).await;
+    let (base, _tx) = start_http(Some(Arc::clone(&handles[leader]))).await;
+    let client = reqwest::Client::new();
+
+    // Create + seed through the leader's SQL surface.
+    let resp = client
+        .post(format!("{base}/api/query"))
+        .header("content-type", "application/json")
+        .body(r#"{"sql":"CREATE TABLE gql_repl (id INT, name VARCHAR(100))"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+
+    // GraphQL INSERT mutation on the leader.
+    let resp = client
+        .post(format!("{base}/api/graphql"))
+        .header("content-type", "application/json")
+        .body(
+            serde_json::json!({
+                "query": r#"mutation { insertInto(table: "gql_repl", values: {"id": 7, "name": "Bob"}) }"#
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    // Every follower converges to the row.
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    for (i, h) in handles.iter().enumerate() {
+        if i == leader {
+            continue;
+        }
+        loop {
+            let n = h
+                .node()
+                .query("SELECT name FROM gql_repl WHERE id = 7")
+                .ok()
+                .and_then(|r| r.first().and_then(|row| row.first()).map(ToString::to_string));
+            if n.as_deref() == Some("Bob") {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "follower {i} did not converge to the GraphQL-inserted row (saw {n:?})"
+            );
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+}
+
+/// A GraphQL mutation on a **follower** is refused with `421 Misdirected
+/// Request` carrying the leader hint, and is never executed against the
+/// follower's local database (the split-brain invariant, #5421). The redirect
+/// contract matches the SQL surfaces; the body is a GraphQL `errors` array.
+#[tokio::test]
+async fn http_graphql_mutation_on_follower_redirects_with_leader_hint() {
+    let (handles, _dir) = boot_cluster(3).await;
+    let leader = wait_for_leader(&handles).await;
+
+    // Create + seed the table through the leader.
+    for sql in [
+        "CREATE TABLE gql_redir (id INT, name VARCHAR(100))",
+        "INSERT INTO gql_redir VALUES (1, 'Alice')",
+    ] {
+        replicated_session(&handles[leader]).execute(sql).await.unwrap();
+    }
+    let leader_id = handles[leader].node_id();
+
+    // Pick a follower that knows who leads (so the hint is populated) and that
+    // has applied the seed row (so introspection sees the table).
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    let follower = loop {
+        if let Some(i) = handles.iter().position(|h| {
+            h.role() == Role::Follower
+                && h.node().current_leader().is_some()
+                && h.schema_snapshot().contains_key("gql_redir")
+        }) {
+            break i;
+        }
+        assert!(tokio::time::Instant::now() < deadline, "timed out waiting for a follower");
+        tokio::time::sleep(POLL_INTERVAL).await;
+    };
+
+    let (base, _tx) = start_http(Some(Arc::clone(&handles[follower]))).await;
+    let client = reqwest::Client::new();
+
+    // GraphQL UPDATE mutation on the follower → 421 + leader hint header.
+    let resp = client
+        .post(format!("{base}/api/graphql"))
+        .header("content-type", "application/json")
+        .body(
+            serde_json::json!({
+                "query": r#"mutation { update(table: "gql_redir", values: {"name": "Bob"}, where: {"id": {"eq": 1}}) }"#
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::MISDIRECTED_REQUEST);
+    let leader_hint = resp
+        .headers()
+        .get("X-VibeSQL-Leader")
+        .expect("leader-hint header")
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(leader_hint.contains(&format!("node {leader_id}")), "{leader_hint}");
+
+    // The response body is a valid GraphQL error envelope.
+    let body: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+    assert!(body["errors"].is_array(), "expected a GraphQL errors array, got {body}");
+
+    // The follower's local state machine never executed the write.
+    assert_eq!(
+        handles[follower].node().query("SELECT name FROM gql_redir WHERE id = 1").unwrap()[0][0]
+            .to_string(),
+        "Alice",
+        "a GraphQL mutation on a follower must not mutate state outside consensus"
+    );
+}
+
+/// A GraphQL query string arg is parameterized, not interpolated, so a value
+/// crafted to break out of the SQL string cannot inject (#5421). The malicious
+/// value is bound as a literal and simply matches no row.
+#[tokio::test]
+async fn http_graphql_string_arg_is_injection_safe() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let (base, _tx) = start_http(Some(Arc::clone(&handles[0]))).await;
+    let client = reqwest::Client::new();
+
+    for sql in [
+        "CREATE TABLE gql_inj (id INT, name VARCHAR(100))",
+        "INSERT INTO gql_inj VALUES (1, 'Alice')",
+    ] {
+        let resp = client
+            .post(format!("{base}/api/query"))
+            .header("content-type", "application/json")
+            .body(serde_json::json!({ "sql": sql }).to_string())
+            .send()
+            .await
+            .unwrap();
+        assert!(resp.status().is_success(), "{sql}: {}", resp.status());
+    }
+
+    // A classic injection payload in a GraphQL `where` string equality arg.
+    // If naively interpolated this would become `WHERE name = '' OR '1'='1'`
+    // and return every row; parameterized, it matches the literal string and
+    // returns nothing.
+    let payload = "' OR '1'='1";
+    let query = serde_json::json!({
+        "query": format!(r#"{{ gql_inj(where: {{"name": {{"eq": "{payload}"}}}}) {{ id name }} }}"#)
+    })
+    .to_string();
+    let resp = client
+        .post(format!("{base}/api/graphql"))
+        .header("content-type", "application/json")
+        .body(query)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+    let rows = body["data"]["data"].as_array().expect("data.data array");
+    assert!(
+        rows.is_empty(),
+        "an injection payload must be bound as a literal (match nothing), got {body}"
+    );
+
+    // The table is untouched — the real row is still present and queryable.
+    assert_eq!(
+        handles[0].node().query("SELECT COUNT(*) FROM gql_inj").unwrap()[0][0].to_string(),
+        "1"
+    );
 }
 
 /// Standalone HTTP is unaffected: `/health` is 200 with no `replication`
@@ -1923,4 +2169,42 @@ async fn http_standalone_unaffected() {
         .await
         .unwrap();
     assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    // GraphQL is unchanged standalone (#5421): a mutation + query round-trip
+    // works against the local database (no consensus handle present).
+    let resp = client
+        .post(format!("{base}/api/query"))
+        .header("content-type", "application/json")
+        .body(r#"{"sql":"CREATE TABLE gql_std (id INT, name VARCHAR(100))"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+
+    let resp = client
+        .post(format!("{base}/api/graphql"))
+        .header("content-type", "application/json")
+        .body(
+            serde_json::json!({
+                "query": r#"mutation { insertInto(table: "gql_std", values: {"id": 1, "name": "Alice"}) }"#
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    let resp = client
+        .post(format!("{base}/api/graphql"))
+        .header("content-type", "application/json")
+        .body(r#"{"query":"{ gql_std { id name } }"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+    let rows = body["data"]["data"].as_array().expect("data.data array");
+    assert_eq!(rows.len(), 1, "standalone GraphQL query must still work: {body}");
+    assert_eq!(rows[0]["name"], "Alice", "{body}");
 }


### PR DESCRIPTION
## Summary

Routes the HTTP GraphQL endpoint (`POST /api/graphql`) through consensus in replicated mode, removing the 503 gate from #5410. Part of #5410 (umbrella stays open until #5422 is also done).

- **Schema/relationship introspection** now reads the **applied replicated catalog** via a new `schema_snapshot()` accessor on `VibesqlStateMachine` → `MvccRaftNode` → `ReplicationHandle`. `try_introspection_query` operates on a `HashMap<String, TableSchema>` (replicated catalog in replicated mode, local catalog standalone) instead of `&Arc<Database>`, so a replicated node never introspects the unreplicated local DB. As a bonus it now reflects real columns/types (the old local-only path returned an empty field list).
- **Queries + mutations** route through the `HttpState::session` choke point (#5423): a GraphQL query lowers to a SELECT served from the state machine; a GraphQL mutation lowers to an INSERT/UPDATE/DELETE proposed through consensus (leader-only, freeze-at-propose).
- **NotLeader / staleness / FATAL** are mapped via `execution_error_response`: a mutation on a follower → `421 Misdirected Request` + `X-VibeSQL-Leader` hint, staleness/FATAL → 503, deterministic SQL rejection → 400. The body stays a GraphQL `errors` envelope at every status.
- The GraphQL `replicated_gate` is removed; **only subscriptions and blob storage remain gated**.

### Scope

Full scope delivered: queries, mutations (insert/update/delete), introspection (`__schema`/`__type`), **and** nested relationship resolution — all over the replicated catalog. The single `schema_snapshot()` accessor powers both introspection and relationship maps, so no functionality was deferred. (Subscriptions/blob remain gated as before — out of scope for #5421.)

### Injection-safety

GraphQL value args are bound, not interpolated: `graphql_to_sql` parameterizes every value (`$N`) and structured-WHERE value, and identifiers go through `escape_identifier`. Because the consensus propose path replicates a SQL **string** (no param vector) and the replicated session rejects the prepared path, the `$N` SQL is inlined via the existing `substitute_named_params` — the same `vibesql_ast::ToSql` escaping the wire `Bind`/`EXECUTE` paths use, so a quote in a value is doubled and cannot break out.

### Split-brain invariant

A GraphQL mutation on a follower is refused with 421 before any local execution; a test asserts the follower's state machine still holds the original row.

## Test plan

New tests in `crates/vibesql-server/tests/replication_tests.rs` (+ introspection unit tests):

- [x] `http_graphql_mutation_and_query_route_through_consensus` — mutation lands in the state machine; query reads it back
- [x] `http_graphql_mutation_replicates_to_followers` — 3-node convergence
- [x] `http_graphql_mutation_on_follower_redirects_with_leader_hint` — 421 + leader hint, GraphQL errors body, not applied locally
- [x] `http_graphql_string_arg_is_injection_safe` — `' OR '1'='1` payload bound as a literal, matches nothing
- [x] `http_unwired_surfaces_still_gated_in_replicated_mode` — updated: GraphQL no longer gated (200); only subscriptions/blob remain 503
- [x] `http_standalone_unaffected` — extended with a standalone GraphQL mutation+query round-trip
- [x] introspection unit tests: real fields from schema, NOT NULL → `!`
- [x] full suites green: `vibesql-server` lib (419) + `replication_tests` (45), `vibesql-consensus` lib (172)

Kept to vibesql-server + minimal consensus accessors (disjoint from the parallel #5439/#5435 work).

Closes #5421