### PR TITLE
fix(storage): rebuild IVFFlat/HNSW vector indexes on table compaction

### DIFF
--- a/crates/vibesql-storage/src/database/indexes/hnsw.rs
+++ b/crates/vibesql-storage/src/database/indexes/hnsw.rs
@@ -166,6 +166,11 @@ impl HnswIndex {
         self.metric
     }
 
+    /// Get the number of dimensions of vectors in this index
+    pub fn dimensions(&self) -> usize {
+        self.dimensions
+    }
+
     /// Build the index from a set of vectors
     ///
     /// This inserts all vectors into the HNSW graph structure.

--- a/crates/vibesql-storage/src/database/indexes/index_maintenance/create.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance/create.rs
@@ -484,7 +484,7 @@ impl IndexManager {
     ///
     /// Note: SqlValue::Vector stores f32 for storage efficiency,
     /// but IVFFlat uses f64 for precision in k-means clustering.
-    fn extract_vector(value: &vibesql_types::SqlValue) -> Option<Vec<f64>> {
+    pub(crate) fn extract_vector(value: &vibesql_types::SqlValue) -> Option<Vec<f64>> {
         match value {
             vibesql_types::SqlValue::Vector(data) => {
                 // Convert f32 vector to f64 for IVFFlat processing

--- a/crates/vibesql-storage/src/database/indexes/index_maintenance/update.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance/update.rs
@@ -438,27 +438,112 @@ impl IndexManager {
                             }
                         }
                         IndexData::IVFFlat { index } => {
-                            // IVFFlat indexes need to be rebuilt via build()
-                            // This requires extracting vectors from the table
-                            log::debug!(
-                                "IVFFlat index rebuild not yet implemented. Index '{}' needs manual rebuild.",
-                                index_name
+                            // Rebuild the IVFFlat index from the post-compaction table
+                            // rows so its internal row_id references match the new
+                            // (renumbered) row positions. A full rebuild re-runs
+                            // k-means clustering; compaction is rare, so correctness
+                            // is preferred over incremental maintenance here.
+                            //
+                            // Vector indexes are in-memory and part of the COW
+                            // snapshot of `Operations` (#5419/#5425): a rebuild that
+                            // runs inside a transaction is restored on ROLLBACK by
+                            // the snapshot clone — no disk undo-log is involved.
+                            let col_idx = match table_schema
+                                .get_column_index(metadata.columns[0].expect_column_name())
+                            {
+                                Some(idx) => idx,
+                                None => {
+                                    log::warn!(
+                                        "IVFFlat index '{}' column not found during rebuild; skipping",
+                                        index_name
+                                    );
+                                    continue;
+                                }
+                            };
+
+                            let vectors = Self::extract_vectors_for_rebuild(table_rows, col_idx);
+
+                            // Preserve the configured parameters of the existing index.
+                            let mut rebuilt = crate::database::indexes::ivfflat::IVFFlatIndex::new(
+                                index.dimensions(),
+                                index.num_lists() as u32,
+                                index.metric(),
                             );
-                            let _ = index; // Suppress unused warning
+                            rebuilt.set_probes(index.probes());
+
+                            if let Err(e) = rebuilt.build(vectors) {
+                                log::warn!(
+                                    "Failed to rebuild IVFFlat index '{}': {}",
+                                    index_name,
+                                    e
+                                );
+                            } else {
+                                *index = rebuilt;
+                            }
                         }
                         IndexData::Hnsw { index } => {
-                            // HNSW indexes need to be rebuilt via build()
-                            // This requires extracting vectors from the table
-                            log::debug!(
-                                "HNSW index rebuild not yet implemented. Index '{}' needs manual rebuild.",
-                                index_name
+                            // Rebuild the HNSW graph from the post-compaction table
+                            // rows so its internal row_id references match the new
+                            // (renumbered) row positions. HNSW graph construction is
+                            // O(n log n); compaction is rare, so a full rebuild is
+                            // acceptable in exchange for correctness.
+                            //
+                            // Like IVFFlat, HNSW indexes are in-memory and part of
+                            // the COW snapshot of `Operations`, so an in-transaction
+                            // rebuild is reversed on ROLLBACK by the snapshot clone.
+                            let col_idx = match table_schema
+                                .get_column_index(metadata.columns[0].expect_column_name())
+                            {
+                                Some(idx) => idx,
+                                None => {
+                                    log::warn!(
+                                        "HNSW index '{}' column not found during rebuild; skipping",
+                                        index_name
+                                    );
+                                    continue;
+                                }
+                            };
+
+                            let vectors = Self::extract_vectors_for_rebuild(table_rows, col_idx);
+
+                            // Preserve the configured parameters of the existing index.
+                            let mut rebuilt = crate::database::indexes::hnsw::HnswIndex::new(
+                                index.dimensions(),
+                                index.m() as u32,
+                                index.ef_construction() as u32,
+                                index.metric(),
                             );
-                            let _ = index; // Suppress unused warning
+                            rebuilt.set_ef_search(index.ef_search());
+
+                            if let Err(e) = rebuilt.build(vectors) {
+                                log::warn!("Failed to rebuild HNSW index '{}': {}", index_name, e);
+                            } else {
+                                *index = rebuilt;
+                            }
                         }
                     }
                 }
             }
         }
+    }
+
+    /// Extract `(row_id, vector)` pairs from the given table rows for the vector
+    /// column at `col_idx`, for rebuilding an IVFFlat/HNSW index after compaction.
+    ///
+    /// `row_id` is the row's position in `table_rows` (the post-compaction
+    /// position), which is exactly what vector search must return so callers can
+    /// look the row back up in the compacted table. NULL / non-vector cells are
+    /// skipped, mirroring the create path.
+    fn extract_vectors_for_rebuild(table_rows: &[Row], col_idx: usize) -> Vec<(usize, Vec<f64>)> {
+        let mut vectors = Vec::new();
+        for (row_index, row) in table_rows.iter().enumerate() {
+            if col_idx < row.values.len() {
+                if let Some(vec_data) = IndexManager::extract_vector(&row.values[col_idx]) {
+                    vectors.push((row_index, vec_data));
+                }
+            }
+        }
+        vectors
     }
 
     // ============================================================================

--- a/crates/vibesql-storage/src/database/indexes/index_manager.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_manager.rs
@@ -1049,4 +1049,203 @@ mod tests {
         assert!(disk_lookup(&manager, "idx_t_id", 20).is_empty());
         assert!(disk_lookup(&manager, "idx_t_id", 30).is_empty());
     }
+
+    // ========================================================================
+    // Vector-index (IVFFlat / HNSW) rebuild after compaction (issue #5446)
+    // ========================================================================
+
+    use vibesql_ast::VectorDistanceMetric;
+
+    /// Schema for a table `v` with an id column and a 2-D vector column `vec`.
+    fn vector_schema() -> TableSchema {
+        TableSchema::new(
+            "v".to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new("vec".to_string(), DataType::Vector { dimensions: 2 }, true),
+            ],
+        )
+    }
+
+    /// Build a table row `(id, vec)` where `vec` is a 2-D vector.
+    fn vrow(id: i64, x: f32, y: f32) -> Row {
+        Row::new(vec![SqlValue::Integer(id), SqlValue::Vector(vec![x, y])])
+    }
+
+    /// `(row_id, vector)` pairs the create path expects, for the given table rows.
+    fn vectors_from(rows: &[Row]) -> Vec<(usize, Vec<f64>)> {
+        rows.iter()
+            .enumerate()
+            .map(|(i, r)| match &r.values[1] {
+                SqlValue::Vector(v) => (i, v.iter().map(|&f| f as f64).collect::<Vec<f64>>()),
+                other => panic!("expected vector, got {:?}", other),
+            })
+            .collect()
+    }
+
+    /// #5446: after a compacting DELETE renumbers rows, `rebuild_indexes` must
+    /// rebuild an IVFFlat index from the post-compaction rows so its row_id
+    /// references point at the *new* positions, not the stale pre-compaction
+    /// ones.
+    #[test]
+    fn ivfflat_index_rebuilt_after_compaction() {
+        let schema = vector_schema();
+        let mut manager = IndexManager::new();
+
+        // Pre-compaction table: 4 rows at positions 0..3.
+        let pre_rows =
+            vec![vrow(1, 0.0, 0.0), vrow(2, 10.0, 10.0), vrow(3, 0.1, 0.0), vrow(4, 10.0, 9.9)];
+
+        manager
+            .create_ivfflat_index_with_vectors(
+                "idx_vec".to_string(),
+                "v".to_string(),
+                "vec".to_string(),
+                2,
+                2,
+                VectorDistanceMetric::L2,
+                vectors_from(&pre_rows),
+            )
+            .unwrap();
+        manager.set_ivfflat_probes("idx_vec", 2).unwrap();
+
+        // Simulate a DELETE that compacts away the two "far" rows (old positions
+        // 1 and 3). The surviving rows (old ids 1 and 3) are renumbered to
+        // positions 0 and 1.
+        let post_rows = vec![vrow(1, 0.0, 0.0), vrow(3, 0.1, 0.0)];
+        manager.rebuild_indexes("v", &schema, &post_rows);
+
+        // Search near the origin: results must be the new positions {0, 1},
+        // never the stale pre-compaction positions {2, 3}.
+        let results = manager.search_ivfflat_index("idx_vec", &[0.05, 0.0], 2).unwrap();
+        let mut ids: Vec<usize> = results.iter().map(|(id, _)| *id).collect();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![0, 1], "IVFFlat rebuild must map to compacted positions");
+
+        // The index must hold exactly the two surviving vectors.
+        match manager.index_data.get("idx_vec").unwrap() {
+            IndexData::IVFFlat { index } => assert_eq!(index.len(), 2),
+            other => panic!("expected IVFFlat, got {:?}", other),
+        }
+    }
+
+    /// #5446: same as above for HNSW.
+    #[test]
+    fn hnsw_index_rebuilt_after_compaction() {
+        let schema = vector_schema();
+        let mut manager = IndexManager::new();
+
+        let pre_rows =
+            vec![vrow(1, 0.0, 0.0), vrow(2, 10.0, 10.0), vrow(3, 0.1, 0.0), vrow(4, 10.0, 9.9)];
+
+        manager
+            .create_hnsw_index_with_vectors(
+                "idx_vec".to_string(),
+                "v".to_string(),
+                "vec".to_string(),
+                2,
+                16,
+                64,
+                VectorDistanceMetric::L2,
+                vectors_from(&pre_rows),
+            )
+            .unwrap();
+
+        let post_rows = vec![vrow(1, 0.0, 0.0), vrow(3, 0.1, 0.0)];
+        manager.rebuild_indexes("v", &schema, &post_rows);
+
+        let results = manager.search_hnsw_index("idx_vec", &[0.05, 0.0], 2).unwrap();
+        let mut ids: Vec<usize> = results.iter().map(|(id, _)| *id).collect();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![0, 1], "HNSW rebuild must map to compacted positions");
+
+        match manager.index_data.get("idx_vec").unwrap() {
+            IndexData::Hnsw { index } => assert_eq!(index.len(), 2),
+            other => panic!("expected Hnsw, got {:?}", other),
+        }
+    }
+
+    /// #5446: vector indexes are in-memory and part of the COW snapshot of
+    /// `Operations` (#5419/#5425). A rebuild that runs inside a transaction and
+    /// then ROLLBACKs must restore the pre-rebuild index. This is modeled the
+    /// same way the in-memory leg of `mixed_in_memory_and_disk_backed_indexes_*`
+    /// is: clone the manager before the rebuild (the COW snapshot), then restore
+    /// the clone on ROLLBACK.
+    #[test]
+    fn ivfflat_rebuild_in_txn_rolls_back_via_snapshot() {
+        let schema = vector_schema();
+        let mut manager = IndexManager::new();
+
+        let pre_rows =
+            vec![vrow(1, 0.0, 0.0), vrow(2, 10.0, 10.0), vrow(3, 0.1, 0.0), vrow(4, 10.0, 9.9)];
+        manager
+            .create_ivfflat_index_with_vectors(
+                "idx_vec".to_string(),
+                "v".to_string(),
+                "vec".to_string(),
+                2,
+                2,
+                VectorDistanceMetric::L2,
+                vectors_from(&pre_rows),
+            )
+            .unwrap();
+        manager.set_ivfflat_probes("idx_vec", 2).unwrap();
+
+        // BEGIN: COW snapshot (deep clone of the whole manager, incl. the
+        // in-memory vector index).
+        let snapshot = manager.clone();
+
+        // A compacting DELETE rebuilds the index mid-transaction.
+        let post_rows = vec![vrow(1, 0.0, 0.0), vrow(3, 0.1, 0.0)];
+        manager.rebuild_indexes("v", &schema, &post_rows);
+        match manager.index_data.get("idx_vec").unwrap() {
+            IndexData::IVFFlat { index } => assert_eq!(index.len(), 2, "rebuilt mid-txn"),
+            other => panic!("expected IVFFlat, got {:?}", other),
+        }
+
+        // ROLLBACK: restore the snapshot clone.
+        manager = snapshot;
+        match manager.index_data.get("idx_vec").unwrap() {
+            IndexData::IVFFlat { index } => {
+                assert_eq!(index.len(), 4, "ROLLBACK restores the pre-rebuild vector index");
+            }
+            other => panic!("expected IVFFlat, got {:?}", other),
+        }
+    }
+
+    /// #5446: COMMIT of a transaction whose vector index was rebuilt persists the
+    /// rebuilt contents (the COW snapshot is simply dropped on COMMIT).
+    #[test]
+    fn ivfflat_rebuild_in_txn_commits() {
+        let schema = vector_schema();
+        let mut manager = IndexManager::new();
+
+        let pre_rows =
+            vec![vrow(1, 0.0, 0.0), vrow(2, 10.0, 10.0), vrow(3, 0.1, 0.0), vrow(4, 10.0, 9.9)];
+        manager
+            .create_ivfflat_index_with_vectors(
+                "idx_vec".to_string(),
+                "v".to_string(),
+                "vec".to_string(),
+                2,
+                2,
+                VectorDistanceMetric::L2,
+                vectors_from(&pre_rows),
+            )
+            .unwrap();
+
+        // BEGIN + rebuild; on COMMIT the snapshot is dropped (modeled by not
+        // restoring it).
+        let _snapshot = manager.clone();
+        let post_rows = vec![vrow(1, 0.0, 0.0), vrow(3, 0.1, 0.0)];
+        manager.rebuild_indexes("v", &schema, &post_rows);
+        drop(_snapshot);
+
+        match manager.index_data.get("idx_vec").unwrap() {
+            IndexData::IVFFlat { index } => {
+                assert_eq!(index.len(), 2, "COMMIT persists the rebuilt vector index");
+            }
+            other => panic!("expected IVFFlat, got {:?}", other),
+        }
+    }
 }

--- a/crates/vibesql-storage/src/database/indexes/ivfflat.rs
+++ b/crates/vibesql-storage/src/database/indexes/ivfflat.rs
@@ -90,6 +90,11 @@ impl IVFFlatIndex {
         self.inverted_lists.len()
     }
 
+    /// Get the number of dimensions of vectors in this index
+    pub fn dimensions(&self) -> usize {
+        self.dimensions
+    }
+
     /// Check if the index is trained
     pub fn is_trained(&self) -> bool {
         self.trained


### PR DESCRIPTION
## Summary

`IndexManager::rebuild_indexes` (`crates/vibesql-storage/src/database/indexes/index_maintenance/update.rs`) handled `InMemory` and `DiskBacked` (B+tree) index data but its `IVFFlat` and `Hnsw` arms were no-ops. After a compacting DELETE, vector indexes were left pointing at stale, pre-compaction row positions — corrupting the row_id mapping that vector search returns. This implements the analogous rebuild for both vector index types.

Closes #5446

## Reachability finding (real bug)

The gap is reachable on the transactional DML path and is **not feature-gated**:
- `Database::delete_row` (`index_ops.rs:1262`) calls `self.rebuild_indexes(table_name)` from the `delete_result.compacted` branch.
- `Table::delete_by_indices` sets `compacted = true` via `Table::should_compact` (`table/mod.rs:1248`): compaction triggers when `deleted_count > rows.len() / 2` (a DELETE removing >50% of rows).
- Compaction renumbers every surviving row's position, so any index for that table must be rebuilt.

Vector indexes are typically placed on large embedding tables; a >50% delete (e.g. purging stale embeddings) is realistic, after which a vector search would return positions that map to the wrong rows in the compacted table. This is a real correctness bug, not just latent.

## Rebuild implementation (full, both IVFFlat and HNSW)

Both arms now rebuild from the post-compaction table rows:
- Resolve the vector column index from the index's single column metadata.
- Extract `(post_compaction_position, vector)` pairs from the live rows (reusing the create path's `extract_vector`, now `pub(crate)`, via a shared `extract_vectors_for_rebuild` helper).
- Construct a fresh index preserving the existing parameters — IVFFlat: `dimensions`, `num_lists`, `metric`, `probes`; HNSW: `dimensions`, `m`, `ef_construction`, `metric`, `ef_search` — and `build()` it, then swap it in.

Full rebuilds are used (IVFFlat re-runs k-means; HNSW re-constructs the graph, O(n log n)). Compaction is rare, so correctness is preferred over incremental maintenance. Added `dimensions()` accessors to `IVFFlatIndex`/`HnswIndex`. No split was needed — reusing the existing `build()` construction made both straightforward.

## Transaction-rollback coverage finding

Vector indexes are **in-memory and never disk-backed/spillable** — they live in `IndexData::IVFFlat`/`Hnsw`, both `#[derive(Clone)]` with owned `Vec`/`HashMap` fields (deep clone). They are therefore fully covered by the copy-on-write `Operations` snapshot from #5419/#5425: the snapshot deep-clones the `IndexManager` (including vector index contents), so an in-transaction rebuild is reversed on ROLLBACK by restoring the snapshot clone, and persisted on COMMIT by dropping it. **No disk undo-log analog (#5435) is needed** — that mechanism exists only because disk-backed B+trees clone as shallow `Arc` bumps; vector indexes have no such sharing.

## Test plan / evidence

New tests in `index_manager.rs`:
- [x] `ivfflat_index_rebuilt_after_compaction` — DELETE >50% then search returns the new (compacted) positions {0,1}, never stale {2,3}; index len == surviving rows.
- [x] `hnsw_index_rebuilt_after_compaction` — same for HNSW.
- [x] `ivfflat_rebuild_in_txn_rolls_back_via_snapshot` — rebuild mid-txn, then restore the COW snapshot clone; pre-rebuild index restored (len 4).
- [x] `ivfflat_rebuild_in_txn_commits` — rebuild + drop snapshot; rebuilt contents persist (len 2).

Results:
- [x] `cargo test -p vibesql-storage` — green (677 lib + doc/integration tests pass).
- [x] `cargo test -p vibesql-storage --features mvcc_enabled` — green (686 lib pass).
- [x] No existing vector-index test regressions; `cargo clippy` clean on touched code.

## Follow-ons

- Incremental vector-index maintenance on `INSERT`/`UPDATE`/`DELETE` (currently no-ops in `insert.rs`/`update.rs`/`delete.rs` — the index relies on rebuild after bulk ops). Out of scope here; would avoid full rebuilds for small mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)