### PR TITLE
fix(executor): resolve NEW/OLD in from-less SELECT inside trigger body

### DIFF
--- a/crates/vibesql-executor/src/select/executor/nonagg/without_from.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/without_from.rs
@@ -85,9 +85,18 @@ impl SelectExecutor<'_> {
         // resolve to a select-list alias, so evaluate the select list first and
         // bind the aliases for the WHERE evaluation.
         if let Some(where_clause) = &stmt.where_clause {
+            // #5445: inside a trigger body the WHERE can reference NEW/OLD
+            // pseudo-variables, which resolve from the firing row rather than a
+            // select-list alias; only divert non-pseudo column references to the
+            // alias-binding path.
+            let references_alias_candidate = if self.trigger_context.is_some() {
+                self.expression_references_non_pseudo_column(where_clause)
+            } else {
+                self.expression_references_column(where_clause)
+            };
             if !has_outer_context
                 && !has_window_functions(&stmt.select_list)
-                && self.expression_references_column(where_clause)
+                && references_alias_candidate
             {
                 return self.execute_select_without_from_alias_where(stmt, where_clause, cte_ctx);
             }
@@ -111,9 +120,17 @@ impl SelectExecutor<'_> {
                 }
                 evaluator.eval(where_clause, outer_row)?
             } else {
+                // No outer context - thread the trigger NEW/OLD context (#5445)
+                // so a WHERE over NEW/OLD inside a trigger-body SELECT resolves.
                 let empty_schema = vibesql_catalog::TableSchema::new("".to_string(), vec![]);
-                let mut evaluator =
-                    ExpressionEvaluator::with_database(&empty_schema, self.database);
+                let mut evaluator = match self.trigger_context {
+                    Some(trigger_ctx) => ExpressionEvaluator::with_trigger_context(
+                        &empty_schema,
+                        self.database,
+                        trigger_ctx,
+                    ),
+                    None => ExpressionEvaluator::with_database(&empty_schema, self.database),
+                };
                 if let Some(cte) = cte_ctx {
                     evaluator = evaluator.with_cte_context(cte);
                 }
@@ -161,8 +178,19 @@ impl SelectExecutor<'_> {
                 vibesql_ast::SelectItem::Expression { expr, .. } => {
                     // Check if expression references a column
                     // FIX for select1-18.1: Only error if we don't have outer context
-                    // When outer context exists, columns can be resolved from outer scope
-                    if !has_outer_context && self.expression_references_column(expr) {
+                    // When outer context exists, columns can be resolved from outer scope.
+                    //
+                    // #5445: when this from-less SELECT runs inside a trigger body
+                    // (self.trigger_context is set), NEW/OLD pseudo-variables are
+                    // resolvable from the firing row's context, so they must not be
+                    // rejected here. A plain (non-pseudo) column reference still
+                    // requires a FROM clause — it has nothing to bind to.
+                    let column_check_fails = if self.trigger_context.is_some() {
+                        self.expression_references_non_pseudo_column(expr)
+                    } else {
+                        self.expression_references_column(expr)
+                    };
+                    if !has_outer_context && column_check_fails {
                         return Err(ExecutorError::UnsupportedFeature(
                             "Column reference requires FROM clause".to_string(),
                         ));
@@ -188,11 +216,18 @@ impl SelectExecutor<'_> {
                         }
                         evaluator.eval(expr, outer_row)?
                     } else {
-                        // No outer context - use simple evaluation
+                        // No outer context - use simple evaluation, threading the
+                        // trigger NEW/OLD context (#5445) so pseudo-variables resolve.
                         let empty_schema =
                             vibesql_catalog::TableSchema::new("".to_string(), vec![]);
-                        let mut evaluator =
-                            ExpressionEvaluator::with_database(&empty_schema, self.database);
+                        let mut evaluator = match self.trigger_context {
+                            Some(trigger_ctx) => ExpressionEvaluator::with_trigger_context(
+                                &empty_schema,
+                                self.database,
+                                trigger_ctx,
+                            ),
+                            None => ExpressionEvaluator::with_database(&empty_schema, self.database),
+                        };
                         if let Some(cte) = cte_ctx {
                             evaluator = evaluator.with_cte_context(cte);
                         }

--- a/crates/vibesql-executor/src/select/executor/utils.rs
+++ b/crates/vibesql-executor/src/select/executor/utils.rs
@@ -2,12 +2,19 @@
 
 use super::builder::SelectExecutor;
 
-/// Check if an expression references a column (which requires FROM clause)
-fn expression_references_column(expr: &vibesql_ast::Expression) -> bool {
+/// Check if an expression references a column (which requires FROM clause).
+///
+/// `count_pseudo` controls whether NEW/OLD pseudo-variables (`NEW.x`, `OLD.x`)
+/// count as column references. They do for a plain from-less SELECT (which has
+/// no row to resolve them from), but inside a trigger body (#5445) the firing
+/// row's NEW/OLD context resolves them, so callers there pass `false`.
+fn expression_references_column_inner(expr: &vibesql_ast::Expression, count_pseudo: bool) -> bool {
+    let expression_references_column =
+        |e: &vibesql_ast::Expression| expression_references_column_inner(e, count_pseudo);
     match expr {
         vibesql_ast::Expression::ColumnRef(_) => true,
-        vibesql_ast::Expression::PseudoVariable { .. } => true, /* Pseudo-variables reference */
-        // columns (OLD.x, NEW.x)
+        vibesql_ast::Expression::PseudoVariable { .. } => count_pseudo, /* Pseudo-variables */
+        // reference columns (OLD.x, NEW.x)
         vibesql_ast::Expression::Default => false, // DEFAULT doesn't reference columns
         vibesql_ast::Expression::DuplicateKeyValue { .. } => false, /* DuplicateKeyValue doesn't */
         // reference columns
@@ -144,9 +151,24 @@ fn expression_references_column(expr: &vibesql_ast::Expression) -> bool {
 }
 
 impl SelectExecutor<'_> {
-    /// Check if an expression references a column (which requires FROM clause)
+    /// Check if an expression references a column (which requires FROM clause).
+    ///
+    /// NEW/OLD pseudo-variables count as column references here.
     pub(super) fn expression_references_column(&self, expr: &vibesql_ast::Expression) -> bool {
-        expression_references_column(expr)
+        expression_references_column_inner(expr, true)
+    }
+
+    /// Check if an expression references a *non-pseudo* column (i.e. a real
+    /// `ColumnRef` that requires a FROM clause), ignoring NEW/OLD pseudo-variables.
+    ///
+    /// Used by the from-less SELECT path inside a trigger body (#5445): there the
+    /// firing row's NEW/OLD context resolves pseudo-variables, so only a real
+    /// column reference (which has nothing to bind to) still requires a FROM clause.
+    pub(super) fn expression_references_non_pseudo_column(
+        &self,
+        expr: &vibesql_ast::Expression,
+    ) -> bool {
+        expression_references_column_inner(expr, false)
     }
 
     /// Evaluate a LIMIT or OFFSET expression and convert to usize

--- a/crates/vibesql-executor/src/tests/trigger_case_body_tests.rs
+++ b/crates/vibesql-executor/src/tests/trigger_case_body_tests.rs
@@ -168,18 +168,21 @@ fn case_in_where_clause_does_not_truncate_body() {
 }
 
 #[test]
-fn instead_of_insert_case_raise_ignore_body_parses_at_create_time() {
-    // #5439 (filed by the #5436 judge): the direct repro. Before the fix this
-    // CREATE TRIGGER failed with `incomplete input` because the CASE's `END`
-    // was treated as the body terminator, dropping the trailing base INSERT.
-    // The trigger must now CREATE successfully with the full body retained.
+fn instead_of_insert_case_raise_ignore_body_fires_and_resolves_new() {
+    // #5439 (parse) + #5445 (fire): the direct repro, now asserted end-to-end.
     //
-    // NOTE: This is a *create-time* assertion. Actually *firing* this trigger
-    // additionally requires resolving `NEW.id` inside a from-less
-    // `SELECT CASE WHEN NEW.id = 1 THEN raise(IGNORE) END` — a separate
-    // executor limitation ("Column reference requires FROM clause") that PR
-    // #5436 worked around and that is out of scope for #5439. See the filed
-    // follow-on.
+    // Parse side (#5439/#5444): before the fix the CREATE TRIGGER failed with
+    // `incomplete input` because the CASE's `END` was treated as the body
+    // terminator, dropping the trailing base INSERT. The body must retain BOTH
+    // statements.
+    //
+    // Fire side (#5445): firing additionally requires resolving `NEW.id` inside
+    // a from-less `SELECT CASE WHEN NEW.id = 1 THEN raise(IGNORE) END`. Before
+    // #5445 this failed at fire time with "Column reference requires FROM clause"
+    // (the from-less SELECT path did not receive the trigger's NEW/OLD context).
+    //
+    // sqlite3 3.51.0: inserting (1, 100) is skipped by raise(IGNORE); inserting
+    // (2, 200) reaches the base table.
     let mut db = vibesql_storage::Database::new();
     exec_ok(&mut db, "CREATE TABLE base (id INTEGER, v INTEGER)");
     exec_ok(&mut db, "CREATE VIEW vw AS SELECT id, v FROM base");
@@ -206,6 +209,84 @@ fn instead_of_insert_case_raise_ignore_body_parses_at_create_time() {
         }
         other => panic!("expected CreateTrigger, got {:?}", other),
     }
+
+    // Fire the INSTEAD OF INSERT trigger for both rows.
+    exec_ok(&mut db, "INSERT INTO vw (id, v) VALUES (1, 100)");
+    exec_ok(&mut db, "INSERT INTO vw (id, v) VALUES (2, 200)");
+
+    // raise(IGNORE) skipped the NEW.id = 1 row; only the NEW.id = 2 row reached base.
+    assert_eq!(ints(&db, "base", "id"), vec![2]);
+    assert_eq!(ints(&db, "base", "v"), vec![200]);
+}
+
+#[test]
+fn from_less_select_new_resolves_in_trigger_body() {
+    // #5445: a standalone from-less `SELECT NEW.col` body statement (no CASE)
+    // resolves the firing row's NEW context and runs without error. sqlite3
+    // 3.51.0 accepts this; the trailing INSERT logs NEW.v + 1.
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE t (id INTEGER, v INTEGER)");
+    exec_ok(&mut db, "CREATE TABLE log (val INTEGER)");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER tr AFTER INSERT ON t BEGIN \
+         SELECT NEW.id; \
+         INSERT INTO log VALUES (NEW.v + 1); \
+         END",
+    );
+
+    exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (5, 99)");
+
+    assert_eq!(ints(&db, "log", "val"), vec![100]);
+}
+
+#[test]
+fn from_less_select_old_raise_ignore_in_delete_trigger() {
+    // #5445: OLD pseudo-variable in a from-less SELECT CASE inside an AFTER
+    // DELETE trigger. sqlite3 3.51.0: raise(IGNORE) abandons the trigger program
+    // for the OLD.id = 1 row (so it is not logged) but does not undo the delete;
+    // the OLD.id = 2 row is logged.
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE d (id INTEGER, v INTEGER)");
+    exec_ok(&mut db, "CREATE TABLE dlog (val INTEGER)");
+    exec_ok(&mut db, "INSERT INTO d (id, v) VALUES (1, 10)");
+    exec_ok(&mut db, "INSERT INTO d (id, v) VALUES (2, 20)");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trd AFTER DELETE ON d BEGIN \
+         SELECT CASE WHEN OLD.id = 1 THEN raise(IGNORE) END; \
+         INSERT INTO dlog VALUES (OLD.v); \
+         END",
+    );
+
+    exec_ok(&mut db, "DELETE FROM d");
+
+    // Only the OLD.id = 2 row was logged; both rows were still deleted.
+    assert_eq!(ints(&db, "dlog", "val"), vec![20]);
+    assert!(column_values(&db, "d", "id").is_empty(), "all rows should be deleted");
+}
+
+#[test]
+fn from_less_select_expression_over_new_and_old() {
+    // #5445: an expression combining NEW and OLD in a from-less SELECT CASE
+    // inside an AFTER UPDATE trigger. sqlite3 3.51.0: when NEW.v - OLD.v > 5 the
+    // row is ignored (not logged); otherwise NEW.v is logged.
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE t (id INTEGER, v INTEGER)");
+    exec_ok(&mut db, "CREATE TABLE log (val INTEGER)");
+    exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (1, 10)");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER tr AFTER UPDATE ON t BEGIN \
+         SELECT CASE WHEN NEW.v - OLD.v > 5 THEN raise(IGNORE) END; \
+         INSERT INTO log VALUES (NEW.v); \
+         END",
+    );
+
+    exec_ok(&mut db, "UPDATE t SET v = 12 WHERE id = 1"); // delta 2, not ignored
+    exec_ok(&mut db, "UPDATE t SET v = 100 WHERE id = 1"); // delta 88, ignored
+
+    assert_eq!(ints(&db, "log", "val"), vec![12]);
 }
 
 #[test]

--- a/crates/vibesql-executor/src/trigger_execution.rs
+++ b/crates/vibesql-executor/src/trigger_execution.rs
@@ -468,10 +468,21 @@ impl TriggerFirer {
                 Ok(())
             }
             Statement::Select(select_stmt) => {
-                // Execute SELECT but ignore results (useful for side effects)
-                // Note: SELECT doesn't need special trigger context handling since
-                // it can reference OLD/NEW through normal expression evaluation
-                let executor = crate::SelectExecutor::new(db);
+                // Execute SELECT but ignore results (useful for side effects, e.g.
+                // a body statement of the form `SELECT CASE WHEN NEW.x ... THEN
+                // raise(IGNORE) END`).
+                //
+                // The SELECT must be evaluated with the trigger's NEW/OLD
+                // pseudo-row context (#5445): a from-less SELECT that references
+                // NEW/OLD has no FROM clause to resolve them from, so the
+                // evaluator needs the firing row's context — exactly as the WHEN
+                // clause and the body's DML statements already receive it. Before
+                // this, the SELECT was executed with a plain `SelectExecutor::new`
+                // and a body like `SELECT CASE WHEN NEW.id = 1 THEN raise(IGNORE)
+                // END` failed at fire time with "Column reference requires FROM
+                // clause".
+                let executor =
+                    crate::SelectExecutor::new_with_trigger_context(db, trigger_context);
                 executor.execute_with_columns(select_stmt)?;
                 Ok(())
             }


### PR DESCRIPTION
## Summary

Closes #5445

A trigger body statement of the form `SELECT CASE WHEN NEW.id = 1 THEN raise(IGNORE) END;` (a from-less `SELECT` referencing a `NEW`/`OLD` pseudo-column) failed at fire time with:

```
UnsupportedFeature("Column reference requires FROM clause")
```

### Where the trigger context was missing

Two gaps in the from-less SELECT path:

1. `crates/vibesql-executor/src/trigger_execution.rs` executed trigger-body `SELECT` statements with a plain `SelectExecutor::new(db)`, dropping the trigger's `NEW`/`OLD` context (an outdated comment claimed SELECT needed no special handling).
2. `crates/vibesql-executor/src/select/executor/nonagg/without_from.rs` built its `ExpressionEvaluator` without `trigger_context` and rejected any pseudo-variable reference up front via `expression_references_column`.

### How it was threaded

- `trigger_execution.rs`: the body `SELECT` now uses `SelectExecutor::new_with_trigger_context(db, trigger_context)` (the field already existed on `SelectExecutor`).
- `without_from.rs`: the no-outer-context branches (select-list and WHERE) now build the evaluator with `ExpressionEvaluator::with_trigger_context` when `self.trigger_context` is set, mirroring how the WHEN clause and body DML already resolve `NEW`/`OLD`.
- `utils.rs`: added `expression_references_non_pseudo_column` (a `count_pseudo=false` variant of the existing check). Inside a trigger body, `NEW`/`OLD` pseudo-variables resolve from the firing row, so they no longer trip the "requires FROM clause" rejection — a real, non-pseudo column reference still does.

Diff is confined to `without_from.rs` + its evaluator wiring (`utils.rs`, `trigger_execution.rs`) and tests, to stay disjoint from the other queued executor trigger issues.

## sqlite3 3.51.0 verified

All new test cases were cross-checked against sqlite3 3.51.0:

- `INSTEAD OF INSERT` with `SELECT CASE WHEN NEW.id = 1 THEN raise(IGNORE) END;` then `INSERT INTO base ...`: row `NEW.id = 1` skipped, `NEW.id = 2` reaches base (`base` ends with `(2, 200)`).
- Standalone `SELECT NEW.id;` body statement resolves and runs; trailing `INSERT INTO log VALUES (NEW.v + 1)` logs `100`.
- `OLD` in a from-less `SELECT CASE` in an `AFTER DELETE` trigger: `raise(IGNORE)` abandons the trigger program for `OLD.id = 1` (not logged) but does not undo the delete; `OLD.id = 2` logged.
- Expression over `NEW`/`OLD` (`NEW.v - OLD.v > 5`) in an `AFTER UPDATE` trigger: delta 2 logs `12`, delta 88 ignored.

## Deferred #5444 test re-enabled

`crates/vibesql-executor/src/tests/trigger_case_body_tests.rs::instead_of_insert_case_raise_ignore_body_parses_at_create_time` was a create-time-only assertion with a NOTE pointing at this issue. It is now `instead_of_insert_case_raise_ignore_body_fires_and_resolves_new`, asserting the full end-to-end fire behavior.

## Test plan

- [x] `cargo test -p vibesql-executor` green (2697 passed, 0 failed, 2 pre-existing ignored)
- [x] New `trigger_case_body_tests` (4 added) pass; existing trigger tests no regression
- [x] `cargo clippy -p vibesql-executor` no new warnings on touched files
- [x] Trigger TCL suite: no regression (the trigger*.test files extract 0 tests under the current shim both before and after this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)