### PR TITLE
Raft: feed HTTP SSE subscriptions from applied consensus entries

### DIFF
--- a/crates/vibesql-consensus/src/mvcc_raft.rs
+++ b/crates/vibesql-consensus/src/mvcc_raft.rs
@@ -1012,6 +1012,28 @@ impl MvccRaftNode {
         self.sm.machine.query(sql)
     }
 
+    /// Subscribe to this node's apply-path change feed (#5422): a
+    /// [`ChangeEventReceiver`](vibesql_storage::ChangeEventReceiver) yielding a
+    /// [`ChangeEvent`](vibesql_storage::ChangeEvent) per row mutated by the
+    /// state machine's [`apply`](VibesqlStateMachine::apply), in apply (commit)
+    /// order. Available on **every** node — leader or follower — because apply
+    /// runs on all replicas; this is what lets a subscriber connected to a
+    /// follower observe committed changes as that follower applies them. The
+    /// receiver carries no historical backlog (see
+    /// [`VibesqlStateMachine::subscribe_changes`]).
+    pub fn subscribe_changes(&self) -> Option<vibesql_storage::ChangeEventReceiver> {
+        self.sm.machine.subscribe_changes()
+    }
+
+    /// Run a closure against the locally applied database under the state
+    /// machine lock (#5422). The replicated subscription loop uses this to
+    /// re-execute a subscription's SELECT against the **committed** state when a
+    /// change event fires. The closure must not block or `.await` — it holds
+    /// the apply mutex, serializing with [`apply`](VibesqlStateMachine::apply).
+    pub fn with_applied_db<R>(&self, f: impl FnOnce(&vibesql_storage::Database) -> R) -> R {
+        self.sm.machine.with_applied_db(f)
+    }
+
     /// Resolve the single-column primary key of `table_name` against the
     /// locally applied replicated catalog (#5420). Local read of the
     /// applied schema — no leadership check or network round — used by the

--- a/crates/vibesql-consensus/src/state_machine.rs
+++ b/crates/vibesql-consensus/src/state_machine.rs
@@ -384,10 +384,54 @@ impl Default for VibesqlStateMachine {
     }
 }
 
+/// Buffer size for the apply-path change-event channel (#5422). The state
+/// machine's database broadcasts a [`ChangeEvent`](vibesql_storage::ChangeEvent)
+/// for every row mutated by [`apply`](VibesqlStateMachine::apply); a subscriber
+/// (the server's replicated subscription loop) drains them and re-runs its
+/// SELECTs against the applied state. A ring this size tolerates large bursts
+/// of applied rows between drains; lagging only forces a conservative
+/// full-table re-check, never incorrect results.
+const APPLY_CHANGE_BUFFER: usize = 4096;
+
 impl VibesqlStateMachine {
     /// A fresh state machine over an empty in-memory database.
+    ///
+    /// Change-event broadcasting is enabled on the underlying database so the
+    /// apply path emits a [`ChangeEvent`](vibesql_storage::ChangeEvent) per
+    /// mutated row (#5422). This is what lets HTTP SSE subscriptions on any
+    /// node — leader or follower — observe **committed/applied** changes: a
+    /// subscriber taps this feed via [`subscribe_changes`](Self::subscribe_changes)
+    /// and re-queries the applied state. It is harmless in the non-subscription
+    /// paths (the events are simply buffered and dropped when no receiver
+    /// exists).
     pub fn new() -> Self {
-        Self { inner: Arc::new(Mutex::new(MachineInner { db: Database::new(), last_applied: 0 })) }
+        let mut db = Database::new();
+        db.enable_change_events(APPLY_CHANGE_BUFFER);
+        Self { inner: Arc::new(Mutex::new(MachineInner { db, last_applied: 0 })) }
+    }
+
+    /// Subscribe to the apply-path change feed (#5422): a
+    /// [`ChangeEventReceiver`](vibesql_storage::ChangeEventReceiver) that
+    /// yields a [`ChangeEvent`](vibesql_storage::ChangeEvent) for every row the
+    /// [`apply`](Self::apply) path mutates, in apply (commit) order. Returns
+    /// `None` only if change events were never enabled (they always are for a
+    /// machine built via [`new`](Self::new) / [`from_snapshot`](Self::from_snapshot)).
+    ///
+    /// The receiver starts at the current position (no historical backlog): a
+    /// fresh subscriber observes changes applied *after* it subscribes, having
+    /// taken its own initial snapshot via a query against the applied state —
+    /// exactly the standalone subscription contract.
+    pub fn subscribe_changes(&self) -> Option<vibesql_storage::ChangeEventReceiver> {
+        self.lock().db.subscribe_changes()
+    }
+
+    /// Run a closure against the applied database under the machine lock
+    /// (#5422). The replicated subscription loop uses this to execute a
+    /// subscription's SELECT against the **committed** state when a change
+    /// event fires. The closure must not block or `.await` — it runs while the
+    /// apply mutex is held, serializing with [`apply`](Self::apply).
+    pub fn with_applied_db<R>(&self, f: impl FnOnce(&Database) -> R) -> R {
+        f(&self.lock().db)
     }
 
     /// Rebuild a state machine from a snapshot produced by
@@ -773,6 +817,13 @@ impl VibesqlStateMachine {
     ) -> Result<()> {
         db.set_next_txn_id(last_included_index + 1)
             .map_err(|e| ConsensusError::SnapshotCodec(format!("failed to seed commit_ts: {e}")))?;
+        // Re-arm the apply-path change feed on the freshly decoded database
+        // (#5422): the deserialized database has no change sender, so without
+        // this a post-snapshot apply would emit no events. Replacing the
+        // database closes the previous sender, so any subscriber tapping the
+        // old feed observes a closed channel and must re-subscribe + re-snapshot
+        // — the correct response to the applied state jumping forward.
+        db.enable_change_events(APPLY_CHANGE_BUFFER);
         let mut inner = self.lock();
         inner.db = db;
         inner.last_applied = last_included_index;

--- a/crates/vibesql-consensus/tests/apply_change_feed.rs
+++ b/crates/vibesql-consensus/tests/apply_change_feed.rs
@@ -1,0 +1,219 @@
+//! Apply-path change feed over a real TCP cluster (#5422).
+//!
+//! These tests prove the foundation of consensus-coherent HTTP SSE
+//! subscriptions: every node — leader **and** follower — emits a
+//! [`ChangeEvent`](vibesql_storage::ChangeEvent) as it applies a committed
+//! entry, so a subscriber tapping a node's apply-path feed
+//! ([`MvccRaftNode::subscribe_changes`]) observes committed changes regardless
+//! of which node it is connected to. This is the channel the server's
+//! replicated subscription loop drains; testing it here at the consensus level
+//! exercises the cross-node "write on leader A, observed on follower B" path
+//! without an HTTP streaming client (the SSE wiring is covered in
+//! `vibesql-server`).
+
+use std::collections::BTreeMap;
+use std::net::TcpListener as StdTcpListener;
+use std::time::Duration;
+
+use vibesql_consensus::{ClusterConfig, ConsensusError, LogIndex, MvccRaftNode, RaftTuning, Role};
+use vibesql_storage::{change_events::RecvError, ChangeEventReceiver};
+use vibesql_types::SqlValue;
+
+const WAIT_TIMEOUT: Duration = Duration::from_secs(10);
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+fn free_localhost_addrs(n: u64) -> BTreeMap<u64, String> {
+    let listeners: Vec<(u64, StdTcpListener)> = (1..=n)
+        .map(|id| (id, StdTcpListener::bind("127.0.0.1:0").expect("reserve ephemeral port")))
+        .collect();
+    listeners
+        .iter()
+        .map(|(id, listener)| {
+            (*id, listener.local_addr().expect("reserved port address").to_string())
+        })
+        .collect()
+}
+
+/// A minimal `n`-voter MVCC cluster over TCP (no partition proxies).
+struct Cluster {
+    nodes: BTreeMap<u64, MvccRaftNode>,
+}
+
+impl Cluster {
+    async fn boot(n: u64) -> Self {
+        let addrs = free_localhost_addrs(n);
+        let mut nodes = BTreeMap::new();
+        for id in 1..=n {
+            let view = (1..=n).map(|peer| (peer, addrs[&peer].clone()));
+            let config = ClusterConfig::new(view).expect("valid cluster config");
+            let node = MvccRaftNode::join_tcp_cluster_tuned(id, &config, RaftTuning::default())
+                .await
+                .expect("boot mvcc tcp node");
+            nodes.insert(id, node);
+        }
+        Self { nodes }
+    }
+
+    fn node(&self, id: u64) -> &MvccRaftNode {
+        &self.nodes[&id]
+    }
+
+    fn ids(&self) -> Vec<u64> {
+        self.nodes.keys().copied().collect()
+    }
+
+    async fn wait_for_leader(&self) -> u64 {
+        self.wait_until("an acknowledged leader", || {
+            let ids = self.ids();
+            let leader = ids.iter().copied().find(|id| self.node(*id).role() == Role::Leader)?;
+            ids.iter().all(|id| self.node(*id).current_leader() == Some(leader)).then_some(leader)
+        })
+        .await
+    }
+
+    async fn wait_for_apply(&self, id: u64, idx: LogIndex) {
+        self.wait_until(&format!("node {id} to apply dense index {idx}"), || {
+            (self.node(id).last_applied() >= idx).then_some(())
+        })
+        .await;
+    }
+
+    /// Execute one replicated write through whoever currently leads.
+    async fn execute(&self, sql: &str) -> (u64, LogIndex) {
+        let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+        loop {
+            let leader = self.wait_for_leader().await;
+            match self.node(leader).execute_replicated(sql).await {
+                Ok((idx, _outcome)) => return (leader, idx),
+                Err(ConsensusError::NotLeader { .. }) => {
+                    assert!(
+                        tokio::time::Instant::now() < deadline,
+                        "timed out executing {sql:?}: leadership never settled"
+                    );
+                }
+                Err(other) => panic!("execute of {sql:?} failed: {other:?}"),
+            }
+        }
+    }
+
+    async fn wait_until<T>(&self, what: &str, mut probe: impl FnMut() -> Option<T>) -> T {
+        let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+        loop {
+            if let Some(value) = probe() {
+                return value;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out after {WAIT_TIMEOUT:?} waiting for {what}"
+            );
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+
+    async fn shutdown(self) {
+        for node in self.nodes.values() {
+            node.shutdown().await.expect("clean shutdown");
+        }
+    }
+}
+
+/// Drain a change feed (bounded) until it yields an event mentioning `table`,
+/// returning the matching event. Panics on timeout or a closed feed.
+async fn wait_for_table_change(rx: &mut ChangeEventReceiver, table: &str) {
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    loop {
+        match rx.try_recv() {
+            Ok(event) => {
+                if event.table_name().eq_ignore_ascii_case(table) {
+                    return;
+                }
+            }
+            Err(RecvError::Empty) => {}
+            Err(RecvError::Lagged(_)) => {
+                // Lagging is acceptable; keep draining toward the latest.
+            }
+            Err(RecvError::Closed) => panic!("apply-path change feed closed unexpectedly"),
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for a change event on table {table:?}"
+        );
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// The core cross-node subscription contract: a subscriber tapping a
+/// **follower's** apply-path feed observes a change committed by a write on the
+/// **leader**, and the follower's applied state reflects that write. This is
+/// the consensus-level equivalent of "an SSE subscriber on node B sees a change
+/// committed via a write on leader A".
+#[tokio::test]
+async fn follower_apply_feed_observes_leader_write() {
+    let cluster = Cluster::boot(3).await;
+
+    let (_, idx) =
+        cluster.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)").await;
+    for id in cluster.ids() {
+        cluster.wait_for_apply(id, idx).await;
+    }
+
+    let leader = cluster.wait_for_leader().await;
+    let follower = cluster.ids().into_iter().find(|id| *id != leader).expect("a follower exists");
+
+    // Subscribe to the follower's apply-path feed BEFORE the write (the feed
+    // carries no backlog, mirroring the standalone subscription contract).
+    let mut feed = cluster
+        .node(follower)
+        .subscribe_changes()
+        .expect("apply-path change feed must be available on a follower");
+
+    // Write on the leader; the follower applies it via replication.
+    let (write_leader, write_idx) =
+        cluster.execute("INSERT INTO users VALUES (1, 'alice')").await;
+    assert_eq!(write_leader, leader, "leadership should not have moved");
+    cluster.wait_for_apply(follower, write_idx).await;
+
+    // The follower's feed fired for the table as it applied the entry.
+    wait_for_table_change(&mut feed, "users").await;
+
+    // And re-querying the follower's applied state (what the subscription loop
+    // does) returns the committed row.
+    let rows = cluster.node(follower).query("SELECT id, name FROM users").expect("local read");
+    assert_eq!(
+        rows.rows,
+        vec![vec![SqlValue::Integer(1), SqlValue::Varchar("alice".into())]],
+        "the follower must observe the committed write"
+    );
+
+    cluster.shutdown().await;
+}
+
+/// The leader's own apply-path feed observes the leader's committed writes:
+/// applying an entry on the node that proposed it still emits change events, so
+/// a subscriber connected to the leader sees its own committed writes.
+#[tokio::test]
+async fn leader_apply_feed_observes_own_write() {
+    let cluster = Cluster::boot(3).await;
+
+    let (_, idx) =
+        cluster.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)").await;
+    for id in cluster.ids() {
+        cluster.wait_for_apply(id, idx).await;
+    }
+
+    let leader = cluster.wait_for_leader().await;
+    let mut feed = cluster
+        .node(leader)
+        .subscribe_changes()
+        .expect("apply-path change feed must be available on the leader");
+
+    let (_, write_idx) = cluster.execute("INSERT INTO t VALUES (7, 'seven')").await;
+    cluster.wait_for_apply(leader, write_idx).await;
+
+    wait_for_table_change(&mut feed, "t").await;
+
+    let rows = cluster.node(leader).query("SELECT id, v FROM t").expect("local read");
+    assert_eq!(rows.rows, vec![vec![SqlValue::Integer(7), SqlValue::Varchar("seven".into())]]);
+
+    cluster.shutdown().await;
+}

--- a/crates/vibesql-server/src/http/rest.rs
+++ b/crates/vibesql-server/src/http/rest.rs
@@ -80,14 +80,19 @@ pub struct HttpState {
     /// key from the replicated catalog via
     /// [`ReplicationHandle::primary_key_column`]; #5421 — the GraphQL endpoint,
     /// which introspects the replicated catalog via
-    /// [`ReplicationHandle::schema_snapshot`]) build a **replicated** session
-    /// via [`Self::session`], so writes propose through this handle (leader-only,
+    /// [`ReplicationHandle::schema_snapshot`]; #5422 — SSE subscriptions, which
+    /// are fed from the consensus **apply-path change feed**
+    /// ([`ReplicationHandle::subscribe_changes`]) and re-query the applied state
+    /// via [`ReplicationHandle::with_applied_db`], so a subscriber on any node
+    /// observes committed writes) build a **replicated** session via
+    /// [`Self::session`], so writes propose through this handle (leader-only,
     /// freeze-at-propose) and reads run against the replicated state machine —
-    /// never against the unreplicated local registry database. Surfaces that
-    /// still depend on local-database change-feed/state introspection
-    /// (subscriptions, blob storage) remain gated (see [`Self::replicated_gate`])
-    /// to a clear error rather than silently reading stale data or accepting a
-    /// write that never replicates; those are tracked as follow-ons to #5410.
+    /// never against the unreplicated local registry database. The only HTTP
+    /// surface still gated in replicated mode is the **blob storage** API
+    /// (`/api/storage/*`), whose `BlobStorageService` is a separate byte store
+    /// that does not route through the SQL/consensus write path; it remains
+    /// gated to a clear 503 (deferred to a focused follow-on of #5410) rather
+    /// than accepting a write that never replicates.
     /// `/health` uses the handle to report node role/writability.
     pub replication: Option<StdArc<ReplicationHandle>>,
 }
@@ -147,29 +152,6 @@ impl HttpState {
         }
     }
 
-    /// `Some(error_response)` when this request hits a surface that is not
-    /// yet coherent in replicated mode and must be refused; `None` in
-    /// standalone mode (where every path is sound). Returning a `503` with
-    /// a `Retry-After`-style hint matches how a non-leader PostgreSQL
-    /// session refuses writes — the caller should route to the dedicated
-    /// PostgreSQL wire port, which is fully replicated.
-    pub(crate) fn replicated_gate(
-        &self,
-        feature: &str,
-    ) -> Option<(StatusCode, Json<ErrorResponse>)> {
-        self.replication.as_ref().map(|_| {
-            (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(ErrorResponse::with_code(
-                    format!(
-                        "{feature} is not available over the HTTP API in replicated mode; use the \
-                         PostgreSQL wire protocol port (writes route through consensus there)"
-                    ),
-                    "58000",
-                )),
-            )
-        })
-    }
 }
 
 /// Map an execution error to an HTTP response, translating a structured
@@ -287,9 +269,13 @@ pub fn create_http_router(
         .route("/stats/subscriptions/efficiency", get(get_efficiency_stats))
         .with_state(state);
 
-    // Create storage sub-router with its own state. The blob storage API
-    // also writes to the local registry database, so in replicated mode it
-    // is gated to a uniform 503 rather than nested (#5393).
+    // Create storage sub-router with its own state. The blob storage API is a
+    // separate `BlobStorageService` byte store that does not route through the
+    // SQL/consensus write path, so replicating it is its own design problem
+    // (wrap blob bytes in consensus entries, or a dedicated blob-replication
+    // path). It is therefore deferred to a focused follow-on of #5410/#5422 and
+    // remains gated to a uniform 503 in replicated mode rather than nested
+    // (#5393) — accepting a blob write here would never replicate.
     if is_replicated {
         let gated = Router::new().fallback(|| async {
             (
@@ -947,13 +933,15 @@ async fn subscribe_stream(
 
     debug!("SSE subscription requested for query: {}", params.query);
 
-    // Subscriptions are fed by change events from the local registry
-    // database, which receives no replicated writes — gate them in
-    // replicated mode (feeding subscriptions from applied consensus entries
-    // is follow-on #5410).
-    if let Some((code, body)) = state.replicated_gate("subscriptions") {
-        return (code, body).into_response();
-    }
+    // Subscriptions are coherent in both modes (#5422):
+    //   * Standalone: fed by the local HTTP `Database`'s change stream.
+    //   * Replicated: fed by the consensus **apply-path** change feed — every
+    //     node emits a change event as it applies a committed entry, so a
+    //     subscriber on any node (leader or follower) observes committed writes.
+    // The initial snapshot, PK detection, and initial result below therefore
+    // read from the replicated state machine (not the empty local registry DB)
+    // when in replicated mode, keeping the snapshot consistent with the feed.
+    let replicated = state.is_replicated();
 
     // Get the database name from headers
     let db_name = get_database_name(&headers);
@@ -1001,9 +989,11 @@ async fn subscribe_stream(
         }
     }
 
-    // Execute initial query with the shared database
-    let mut session =
-        crate::session::Session::new(db_name.clone(), "http_user".to_string(), shared_db);
+    // Execute the initial query. In replicated mode `state.session()` returns a
+    // replicated session that reads from the applied state machine; in
+    // standalone mode it is the ordinary local session — so the initial
+    // snapshot always comes from the same source that drives the change feed.
+    let mut session = state.session(&db_name, shared_db.clone());
 
     // Execute the initial query
     let result = if params_vec.is_empty() {
@@ -1012,10 +1002,12 @@ async fn subscribe_stream(
         session.execute_with_params(&params.query, &params_vec).await
     };
 
-    // Validate it's a SELECT statement
-    let columns = match result {
-        Ok(crate::session::ExecutionResult::Select { rows: _, columns }) => {
-            columns.iter().map(|c| c.name.clone()).collect::<Vec<_>>()
+    // Validate it's a SELECT statement. In replicated mode we also keep the
+    // initial rows to prime the subscription's snapshot directly (the change
+    // feed re-queries the same applied state for subsequent updates).
+    let (columns, initial_rows) = match result {
+        Ok(crate::session::ExecutionResult::Select { rows, columns }) => {
+            (columns.iter().map(|c| c.name.clone()).collect::<Vec<_>>(), rows)
         }
         Ok(_) => {
             error!("Subscription query must be a SELECT statement");
@@ -1104,11 +1096,17 @@ async fn subscribe_stream(
     // Detect PK columns for selective column updates
     // Parse the subscription query to detect primary key columns
     if let Ok(stmt) = vibesql_parser::Parser::parse_sql(&params.query) {
-        // Get the database for PK detection
-        let db_for_pk = state.registry.get_or_create(&db_name).await;
-        let db_guard_pk = db_for_pk.read().await;
-        let pk_detection = detect_pk_columns_from_stmt(&stmt, &db_guard_pk);
-        drop(db_guard_pk);
+        // Detect against the applied state machine in replicated mode (where the
+        // schema lives), or the local registry DB in standalone mode.
+        let pk_detection = if let Some(handle) = &state.replication {
+            handle.with_applied_db(|db| detect_pk_columns_from_stmt(&stmt, db))
+        } else {
+            let db_for_pk = state.registry.get_or_create(&db_name).await;
+            let db_guard_pk = db_for_pk.read().await;
+            let detection = detect_pk_columns_from_stmt(&stmt, &db_guard_pk);
+            drop(db_guard_pk);
+            detection
+        };
 
         debug!(
             subscription_id = %subscription_id,
@@ -1132,15 +1130,22 @@ async fn subscribe_stream(
         }
     }
 
-    // Send initial results using the database from the registry
+    // Send initial results. In replicated mode the snapshot is primed directly
+    // from the rows already read off the applied state machine (`initial_rows`),
+    // keeping it consistent with the apply-path change feed. In standalone mode
+    // it re-reads the local registry DB.
     let columns_clone = columns.clone();
-    // Re-get the database from registry and send initial results
-    let db_for_initial = state.registry.get_or_create(&db_name).await;
-    let db_guard = db_for_initial.read().await;
-    if let Err(e) =
-        state.subscription_manager.send_initial_results(subscription_id, &db_guard).await
-    {
+    let initial_result = if replicated {
+        // `ExecutionResult::Select` rows are already `crate::Row`.
+        state.subscription_manager.prime_initial_result(subscription_id, initial_rows).await
+    } else {
+        let db_for_initial = state.registry.get_or_create(&db_name).await;
+        let db_guard = db_for_initial.read().await;
+        let res = state.subscription_manager.send_initial_results(subscription_id, &db_guard).await;
         drop(db_guard);
+        res
+    };
+    if let Err(e) = initial_result {
         error!("Failed to send initial results: {}", e);
         let was_selective_eligible = state.subscription_manager.unsubscribe(subscription_id);
         if let Some(ref metrics) = state.metrics {
@@ -1166,7 +1171,6 @@ async fn subscribe_stream(
 
         return Sse::new(stream).keep_alive(KeepAlive::default()).into_response();
     }
-    drop(db_guard); // Release the read lock before entering the streaming loop
 
     // Create stream that receives updates from subscription and converts to SSE events
     let stream = async_stream::stream! {

--- a/crates/vibesql-server/src/main.rs
+++ b/crates/vibesql-server/src/main.rs
@@ -141,12 +141,50 @@ async fn main() -> Result<()> {
     let subscription_manager = Arc::new(SubscriptionManager::new());
     let subscription_manager_for_handler = Arc::clone(&subscription_manager);
 
-    // Spawn the subscription manager event loop in a background task
+    // Spawn the subscription manager event loop in a background task.
+    //
+    // Standalone mode drives subscriptions from the local HTTP `Database`'s
+    // change stream. Replicated mode (#5422) instead drives them from the
+    // consensus **apply-path** change feed: every node — leader or follower —
+    // emits a change event as it applies a committed entry, and the loop
+    // re-runs affected subscriptions against the applied state machine. This is
+    // what lets a subscriber on any node observe committed writes (the local
+    // HTTP `Database` receives no replicated writes, so its change stream would
+    // never fire). On a snapshot install the feed closes; the loop exits and is
+    // restarted with a fresh receiver.
     let db_for_subscription_task = Arc::clone(&db);
     let subscription_manager_for_loop = Arc::clone(&subscription_manager);
+    let replication_for_subs = replication.clone();
     tokio::spawn(async move {
-        info!("Starting subscription manager event loop");
-        subscription_manager_for_loop.run_event_loop(change_rx, db_for_subscription_task).await;
+        match replication_for_subs {
+            Some(handle) => {
+                info!("Starting replicated (apply-path) subscription event loop");
+                loop {
+                    let Some(change_rx) = handle.subscribe_changes() else {
+                        warn!("Apply-path change feed unavailable; subscriptions disabled");
+                        break;
+                    };
+                    let handle_for_query = Arc::clone(&handle);
+                    let query_fn = move |query: &str| {
+                        handle_for_query.with_applied_db(|db| {
+                            SubscriptionManager::execute_query_against(query, db)
+                        })
+                    };
+                    subscription_manager_for_loop
+                        .run_replicated_event_loop(change_rx, query_fn)
+                        .await;
+                    // The feed closed (snapshot install or shutdown). Re-subscribe
+                    // to pick up the new state machine; if it is gone, stop.
+                    info!("Apply-path change feed closed; re-subscribing");
+                }
+            }
+            None => {
+                info!("Starting subscription manager event loop");
+                subscription_manager_for_loop
+                    .run_event_loop(change_rx, db_for_subscription_task)
+                    .await;
+            }
+        }
         info!("Subscription manager event loop stopped");
     });
 

--- a/crates/vibesql-server/src/replication.rs
+++ b/crates/vibesql-server/src/replication.rs
@@ -290,6 +290,28 @@ impl ReplicationHandle {
         self.node.query(sql).map_err(|e| self.sql_error("the query", e))
     }
 
+    /// Subscribe to the apply-path change feed (#5422): a
+    /// [`ChangeEventReceiver`](vibesql_storage::ChangeEventReceiver) yielding a
+    /// [`ChangeEvent`](vibesql_storage::ChangeEvent) per row the consensus state
+    /// machine applies, in commit order. Available on every node — apply runs
+    /// on all replicas — so a subscriber connected to a follower observes
+    /// committed changes as that follower applies them. This is the replicated
+    /// counterpart of `Database::subscribe_changes` that drives standalone
+    /// subscriptions; the server's replicated subscription loop drains it and
+    /// re-runs each subscription's SELECT against the applied state via
+    /// [`with_applied_db`](Self::with_applied_db).
+    pub fn subscribe_changes(&self) -> Option<vibesql_storage::ChangeEventReceiver> {
+        self.node.subscribe_changes()
+    }
+
+    /// Run a closure against the applied (committed) database under the state
+    /// machine lock (#5422). The replicated subscription loop uses this to
+    /// re-execute a subscription's SELECT against committed state. The closure
+    /// must not block or `.await` — it holds the apply mutex.
+    pub fn with_applied_db<R>(&self, f: impl FnOnce(&vibesql_storage::Database) -> R) -> R {
+        self.node.with_applied_db(f)
+    }
+
     /// Resolve the single-column primary key of `table_name` from the
     /// applied replicated catalog (#5420). The HTTP CRUD by-id endpoints
     /// use this to introspect the PK in replicated mode — where the schema

--- a/crates/vibesql-server/src/subscription/manager/events.rs
+++ b/crates/vibesql-server/src/subscription/manager/events.rs
@@ -85,6 +85,92 @@ impl SubscriptionManager {
         self.execute_with_retry(subscription, db, id).await;
     }
 
+    /// Handle a change event in **replicated mode** (#5422).
+    ///
+    /// Identical fanout to [`handle_change`](Self::handle_change), but each
+    /// affected subscription's SELECT is re-executed against the consensus
+    /// **applied** state machine via `query_fn` (which the server backs with
+    /// `ReplicationHandle::with_applied_db`) instead of a local `Database`. The
+    /// (sync) notification — delta computation, selective-column handling,
+    /// slow-consumer detection — is shared with the standalone path via
+    /// [`notify_with_rows`](Self::notify_with_rows).
+    pub async fn handle_change_replicated<F>(&self, event: vibesql_storage::ChangeEvent, query_fn: &F)
+    where
+        F: Fn(&str) -> Result<Vec<vibesql_storage::Row>, String>,
+    {
+        let table = event.table_name();
+        trace!(table = %table, event = ?event, "Processing replicated apply-path change event");
+
+        let affected_ids = self.find_affected_subscriptions(table);
+        if affected_ids.is_empty() {
+            return;
+        }
+
+        for id in affected_ids {
+            // Clone the query string out before re-querying so the state
+            // machine lock (held inside `query_fn`) never overlaps the DashMap
+            // mutable borrow used for notification.
+            let query = match self.subscriptions.get(&id) {
+                Some(sub) => sub.query.clone(),
+                None => continue,
+            };
+
+            match query_fn(&query) {
+                Ok(rows) => {
+                    if let Some(mut sub_ref) = self.subscriptions.get_mut(&id) {
+                        self.notify_with_rows(sub_ref.value_mut(), id, rows);
+                    }
+                }
+                Err(error_msg) => {
+                    warn!(
+                        subscription_id = %id,
+                        error = %error_msg,
+                        "Replicated subscription query failed; skipping this change"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Run the **replicated** subscription event loop (#5422).
+    ///
+    /// Drains the consensus apply-path change feed (`change_rx`, from
+    /// `ReplicationHandle::subscribe_changes`) and re-checks affected
+    /// subscriptions against the applied state machine using `query_fn`. Runs
+    /// until the feed closes — which happens when the state machine is replaced
+    /// by a snapshot install or the node shuts down.
+    pub async fn run_replicated_event_loop<F>(
+        &self,
+        mut change_rx: vibesql_storage::ChangeEventReceiver,
+        query_fn: F,
+    ) where
+        F: Fn(&str) -> Result<Vec<vibesql_storage::Row>, String>,
+    {
+        loop {
+            match change_rx.try_recv() {
+                Ok(event) => {
+                    self.handle_change_replicated(event, &query_fn).await;
+                }
+                Err(RecvError::Lagged(n)) => {
+                    warn!(
+                        lagged_count = n,
+                        "Replicated SubscriptionManager lagged behind apply-path change events"
+                    );
+                }
+                Err(RecvError::Closed) => {
+                    debug!(
+                        "Apply-path change feed closed (snapshot install or shutdown); stopping \
+                         replicated subscription loop"
+                    );
+                    break;
+                }
+                Err(RecvError::Empty) => {
+                    tokio::task::yield_now().await;
+                }
+            }
+        }
+    }
+
     /// Run the subscription manager event loop
     ///
     /// Listens for change events from the storage layer and processes them.

--- a/crates/vibesql-server/src/subscription/manager/query.rs
+++ b/crates/vibesql-server/src/subscription/manager/query.rs
@@ -25,174 +25,11 @@ impl SubscriptionManager {
 
             match result {
                 Ok(rows) => {
-                    // Successful execution - reset retry count
+                    // Successful execution - reset retry count, then compute the
+                    // delta against the prior result and notify (shared with the
+                    // replicated apply-path loop via `notify_with_rows`).
                     subscription.retry_count = 0;
-
-                    // Convert to Row format
-                    let result_rows: Vec<crate::Row> =
-                        rows.iter().map(|r| crate::Row { values: r.values.to_vec() }).collect();
-
-                    // Hash results for comparison
-                    let new_hash = hash_rows(&result_rows);
-
-                    if new_hash != subscription.last_result_hash {
-                        debug!(
-                            subscription_id = %id,
-                            old_hash = subscription.last_result_hash,
-                            new_hash = new_hash,
-                            row_count = result_rows.len(),
-                            "Results changed, notifying subscriber"
-                        );
-
-                        // Determine whether to send Delta, Partial, or Full update
-                        let update = if let Some(ref old_rows) = subscription.last_result {
-                            // We have previous results - compute delta using PK columns
-                            if let Some(delta) = compute_delta_with_pk(
-                                id,
-                                old_rows,
-                                &result_rows,
-                                &subscription.pk_columns,
-                            ) {
-                                // Check if we can use Partial updates (selective column updates)
-                                // Conditions:
-                                // 1. Subscription is selective_eligible (confident PK detection)
-                                // 2. Delta has only updates (no inserts or deletes)
-                                // 3. Updates exist
-                                if let SubscriptionUpdate::Delta {
-                                    ref inserts,
-                                    ref updates,
-                                    ref deletes,
-                                    ..
-                                } = delta
-                                {
-                                    if subscription.selective_eligible
-                                        && inserts.is_empty()
-                                        && deletes.is_empty()
-                                        && !updates.is_empty()
-                                    {
-                                        // Convert to Partial updates
-                                        let partial_updates: Vec<PartialRowDelta> = updates
-                                            .iter()
-                                            .filter_map(|(old_row, new_row)| {
-                                                PartialRowDelta::from_rows(
-                                                    old_row,
-                                                    new_row,
-                                                    &subscription.pk_columns,
-                                                )
-                                            })
-                                            .collect();
-
-                                        if !partial_updates.is_empty() {
-                                            debug!(
-                                                subscription_id = %id,
-                                                partial_updates = partial_updates.len(),
-                                                "Sending partial update (selective columns)"
-                                            );
-                                            SubscriptionUpdate::Partial {
-                                                subscription_id: id,
-                                                updates: partial_updates,
-                                            }
-                                        } else {
-                                            // Fall back to delta if partial conversion failed
-                                            debug!(
-                                                subscription_id = %id,
-                                                updates = updates.len(),
-                                                "Sending delta update (partial conversion failed)"
-                                            );
-                                            delta
-                                        }
-                                    } else {
-                                        // Log delta statistics and send as-is
-                                        debug!(
-                                            subscription_id = %id,
-                                            inserts = inserts.len(),
-                                            updates = updates.len(),
-                                            deletes = deletes.len(),
-                                            selective_eligible = subscription.selective_eligible,
-                                            "Sending delta update"
-                                        );
-                                        delta
-                                    }
-                                } else {
-                                    delta
-                                }
-                            } else {
-                                // No delta (shouldn't happen if hash changed, but be safe)
-                                SubscriptionUpdate::Full {
-                                    subscription_id: id,
-                                    rows: result_rows.clone(),
-                                }
-                            }
-                        } else {
-                            // No previous results - send full (first update after initial)
-                            debug!(
-                                subscription_id = %id,
-                                "No previous result, sending full update"
-                            );
-                            SubscriptionUpdate::Full {
-                                subscription_id: id,
-                                rows: result_rows.clone(),
-                            }
-                        };
-
-                        // Update stored state
-                        subscription.last_result_hash = new_hash;
-                        subscription.last_result = Some(result_rows);
-
-                        // Check for slow consumer before sending
-                        let capacity = subscription.notify_tx.capacity();
-                        let max_capacity = subscription.notify_tx.max_capacity();
-                        let used = max_capacity.saturating_sub(capacity);
-                        let usage_percent =
-                            if max_capacity > 0 { (used * 100) / max_capacity } else { 0 };
-
-                        if usage_percent >= subscription.slow_consumer_threshold_percent as usize {
-                            warn!(
-                                subscription_id = %id,
-                                used = used,
-                                max_capacity = max_capacity,
-                                usage_percent = usage_percent,
-                                threshold = subscription.slow_consumer_threshold_percent,
-                                "Slow consumer detected: subscription channel is {}% full. \
-                                 Consider increasing channel_buffer_size or client is consuming too slowly.",
-                                usage_percent
-                            );
-                        }
-
-                        // Use try_send for non-blocking send with backpressure detection
-                        match subscription.notify_tx.try_send(update) {
-                            Ok(()) => {
-                                subscription.updates_sent += 1;
-                                trace!(
-                                    subscription_id = %id,
-                                    updates_sent = subscription.updates_sent,
-                                    "Update sent successfully"
-                                );
-                            }
-                            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                                subscription.updates_dropped += 1;
-                                warn!(
-                                    subscription_id = %id,
-                                    updates_dropped = subscription.updates_dropped,
-                                    channel_buffer_size = subscription.channel_buffer_size,
-                                    "Subscription channel full, dropping update. \
-                                     Consider increasing channel_buffer_size in SubscriptionConfig \
-                                     or ensure client is consuming updates faster."
-                                );
-                            }
-                            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                                trace!(
-                                    subscription_id = %id,
-                                    "Notification channel closed, subscription will be cleaned up"
-                                );
-                            }
-                        }
-                    } else {
-                        trace!(
-                            subscription_id = %id,
-                            "Results unchanged, no notification needed"
-                        );
-                    }
+                    self.notify_with_rows(subscription, id, rows);
                     return;
                 }
                 Err(error_msg) => {
@@ -268,6 +105,175 @@ impl SubscriptionManager {
         }
     }
 
+    /// Compute the update (Full / Delta / Partial) from freshly executed
+    /// `rows` against the subscription's prior result and notify the subscriber
+    /// if the result changed.
+    ///
+    /// This is the notification half of [`execute_with_retry`], factored out so
+    /// the **replicated** apply-path subscription loop (#5422) can reuse the
+    /// exact same delta/selective-column/slow-consumer logic. It is synchronous
+    /// (uses `try_send`), so the caller may invoke it after running the query —
+    /// in replicated mode, after re-querying the applied state machine — without
+    /// holding any database lock across an `.await`.
+    pub(crate) fn notify_with_rows(
+        &self,
+        subscription: &mut Subscription,
+        id: SubscriptionId,
+        rows: Vec<vibesql_storage::Row>,
+    ) {
+        // Convert to Row format
+        let result_rows: Vec<crate::Row> =
+            rows.iter().map(|r| crate::Row { values: r.values.to_vec() }).collect();
+
+        // Hash results for comparison
+        let new_hash = hash_rows(&result_rows);
+
+        if new_hash != subscription.last_result_hash {
+            debug!(
+                subscription_id = %id,
+                old_hash = subscription.last_result_hash,
+                new_hash = new_hash,
+                row_count = result_rows.len(),
+                "Results changed, notifying subscriber"
+            );
+
+            // Determine whether to send Delta, Partial, or Full update
+            let update = if let Some(ref old_rows) = subscription.last_result {
+                // We have previous results - compute delta using PK columns
+                if let Some(delta) =
+                    compute_delta_with_pk(id, old_rows, &result_rows, &subscription.pk_columns)
+                {
+                    // Check if we can use Partial updates (selective column updates)
+                    // Conditions:
+                    // 1. Subscription is selective_eligible (confident PK detection)
+                    // 2. Delta has only updates (no inserts or deletes)
+                    // 3. Updates exist
+                    if let SubscriptionUpdate::Delta { ref inserts, ref updates, ref deletes, .. } =
+                        delta
+                    {
+                        if subscription.selective_eligible
+                            && inserts.is_empty()
+                            && deletes.is_empty()
+                            && !updates.is_empty()
+                        {
+                            // Convert to Partial updates
+                            let partial_updates: Vec<PartialRowDelta> = updates
+                                .iter()
+                                .filter_map(|(old_row, new_row)| {
+                                    PartialRowDelta::from_rows(
+                                        old_row,
+                                        new_row,
+                                        &subscription.pk_columns,
+                                    )
+                                })
+                                .collect();
+
+                            if !partial_updates.is_empty() {
+                                debug!(
+                                    subscription_id = %id,
+                                    partial_updates = partial_updates.len(),
+                                    "Sending partial update (selective columns)"
+                                );
+                                SubscriptionUpdate::Partial {
+                                    subscription_id: id,
+                                    updates: partial_updates,
+                                }
+                            } else {
+                                // Fall back to delta if partial conversion failed
+                                debug!(
+                                    subscription_id = %id,
+                                    updates = updates.len(),
+                                    "Sending delta update (partial conversion failed)"
+                                );
+                                delta
+                            }
+                        } else {
+                            // Log delta statistics and send as-is
+                            debug!(
+                                subscription_id = %id,
+                                inserts = inserts.len(),
+                                updates = updates.len(),
+                                deletes = deletes.len(),
+                                selective_eligible = subscription.selective_eligible,
+                                "Sending delta update"
+                            );
+                            delta
+                        }
+                    } else {
+                        delta
+                    }
+                } else {
+                    // No delta (shouldn't happen if hash changed, but be safe)
+                    SubscriptionUpdate::Full { subscription_id: id, rows: result_rows.clone() }
+                }
+            } else {
+                // No previous results - send full (first update after initial)
+                debug!(
+                    subscription_id = %id,
+                    "No previous result, sending full update"
+                );
+                SubscriptionUpdate::Full { subscription_id: id, rows: result_rows.clone() }
+            };
+
+            // Update stored state
+            subscription.last_result_hash = new_hash;
+            subscription.last_result = Some(result_rows);
+
+            // Check for slow consumer before sending
+            let capacity = subscription.notify_tx.capacity();
+            let max_capacity = subscription.notify_tx.max_capacity();
+            let used = max_capacity.saturating_sub(capacity);
+            let usage_percent = if max_capacity > 0 { (used * 100) / max_capacity } else { 0 };
+
+            if usage_percent >= subscription.slow_consumer_threshold_percent as usize {
+                warn!(
+                    subscription_id = %id,
+                    used = used,
+                    max_capacity = max_capacity,
+                    usage_percent = usage_percent,
+                    threshold = subscription.slow_consumer_threshold_percent,
+                    "Slow consumer detected: subscription channel is {}% full. \
+                     Consider increasing channel_buffer_size or client is consuming too slowly.",
+                    usage_percent
+                );
+            }
+
+            // Use try_send for non-blocking send with backpressure detection
+            match subscription.notify_tx.try_send(update) {
+                Ok(()) => {
+                    subscription.updates_sent += 1;
+                    trace!(
+                        subscription_id = %id,
+                        updates_sent = subscription.updates_sent,
+                        "Update sent successfully"
+                    );
+                }
+                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                    subscription.updates_dropped += 1;
+                    warn!(
+                        subscription_id = %id,
+                        updates_dropped = subscription.updates_dropped,
+                        channel_buffer_size = subscription.channel_buffer_size,
+                        "Subscription channel full, dropping update. \
+                         Consider increasing channel_buffer_size in SubscriptionConfig \
+                         or ensure client is consuming updates faster."
+                    );
+                }
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                    trace!(
+                        subscription_id = %id,
+                        "Notification channel closed, subscription will be cleaned up"
+                    );
+                }
+            }
+        } else {
+            trace!(
+                subscription_id = %id,
+                "Results unchanged, no notification needed"
+            );
+        }
+    }
+
     /// Execute the subscription query and return rows or error message
     pub(crate) async fn execute_subscription_query(
         &self,
@@ -291,6 +297,27 @@ impl SubscriptionManager {
                 );
                 Err("Subscription query is not a SELECT".to_string())
             }
+            Err(e) => Err(format!("Failed to parse query: {}", e)),
+        }
+    }
+
+    /// Synchronously execute a subscription's SELECT against an arbitrary
+    /// database, returning its rows (#5422). Unlike
+    /// [`execute_subscription_query`](Self::execute_subscription_query) this is
+    /// `async`-free, so the replicated apply-path loop can call it inside
+    /// [`ReplicationHandle::with_applied_db`] (which holds the state machine
+    /// lock and forbids `.await`). The notification half runs afterwards via
+    /// [`notify_with_rows`](Self::notify_with_rows), outside the lock.
+    pub fn execute_query_against(
+        query: &str,
+        db: &Database,
+    ) -> Result<Vec<vibesql_storage::Row>, String> {
+        let executor = vibesql_executor::SelectExecutor::new(db);
+        match vibesql_parser::Parser::parse_sql(query) {
+            Ok(vibesql_ast::Statement::Select(select)) => {
+                executor.execute(&select).map_err(|e| e.to_string())
+            }
+            Ok(_) => Err("Subscription query is not a SELECT".to_string()),
             Err(e) => Err(format!("Failed to parse query: {}", e)),
         }
     }
@@ -349,6 +376,44 @@ impl SubscriptionManager {
         subscription
             .notify_tx
             .send(SubscriptionUpdate::Full { subscription_id: id, rows: result_rows })
+            .await
+            .map_err(|_| SubscriptionError::ChannelClosed)?;
+
+        Ok(())
+    }
+
+    /// Seed a subscription's initial result from rows the caller already
+    /// executed, and send them as the initial Full update (#5422).
+    ///
+    /// The replicated SSE handler executes a subscription's initial SELECT
+    /// against the **applied** consensus state itself (via the
+    /// `ReplicationHandle` read path), then hands the rows here. This mirrors
+    /// [`send_initial_results`](Self::send_initial_results) but sources the rows
+    /// from the consensus state machine instead of a local `Database`, so the
+    /// initial snapshot is consistent with the apply-path change feed that
+    /// subsequently drives updates.
+    pub async fn prime_initial_result(
+        &self,
+        id: SubscriptionId,
+        rows: Vec<crate::Row>,
+    ) -> Result<(), SubscriptionError> {
+        let mut sub_ref = self.subscriptions.get_mut(&id).ok_or(SubscriptionError::NotFound(id))?;
+        let subscription = sub_ref.value_mut();
+
+        if rows.len() > self.config.max_result_rows {
+            self.result_set_exceeded_count.fetch_add(1, Ordering::Relaxed);
+            return Err(SubscriptionError::ResultSetTooLarge {
+                rows: rows.len(),
+                max: self.config.max_result_rows,
+            });
+        }
+
+        subscription.last_result_hash = hash_rows(&rows);
+        subscription.last_result = Some(rows.clone());
+
+        subscription
+            .notify_tx
+            .send(SubscriptionUpdate::Full { subscription_id: id, rows })
             .await
             .map_err(|_| SubscriptionError::ChannelClosed)?;
 

--- a/crates/vibesql-server/tests/replication_tests.rs
+++ b/crates/vibesql-server/tests/replication_tests.rs
@@ -1870,13 +1870,13 @@ async fn http_write_replicates_to_followers() {
     }
 }
 
-/// In replicated mode the subscription and blob-storage surfaces remain gated
-/// to a clear 503 (they depend on local-database change-feed/state
-/// introspection that is not yet wired through consensus — follow-ons to
-/// #5410). They must never silently execute against the local database. The
-/// CRUD by-id endpoints (#5420) and the GraphQL endpoint (#5421) are no longer
-/// gated — they route through consensus; see `http_crud_by_id_*` and
-/// `http_graphql_*` below.
+/// In replicated mode the **blob-storage** surface remains gated to a clear 503
+/// (the `BlobStorageService` byte store does not route through the
+/// SQL/consensus write path — replicating it is a separate design problem,
+/// deferred to a focused follow-on of #5410/#5422). It must never silently
+/// accept a write that never replicates. The subscription endpoint (#5422), the
+/// CRUD by-id endpoints (#5420), and the GraphQL endpoint (#5421) are no longer
+/// gated — they route through consensus.
 #[tokio::test]
 async fn http_unwired_surfaces_still_gated_in_replicated_mode() {
     let (handles, _dir) = boot_cluster(1).await;
@@ -1884,11 +1884,35 @@ async fn http_unwired_surfaces_still_gated_in_replicated_mode() {
     let (base, _tx) = start_http(Some(Arc::clone(&handles[0]))).await;
     let client = reqwest::Client::new();
 
-    // Subscriptions.
-    let resp = client.get(format!("{base}/api/subscribe?query=SELECT%201")).send().await.unwrap();
-    assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+    // Subscriptions are no longer gated (#5422): the SSE endpoint opens a
+    // text/event-stream (200) fed by the apply-path change feed rather than the
+    // old 503. (A keep-alive stream stays open, so cap the request.)
+    let resp = client
+        .get(format!("{base}/api/subscribe?query=SELECT%201"))
+        .timeout(Duration::from_secs(2))
+        .send()
+        .await;
+    match resp {
+        Ok(resp) => {
+            assert_eq!(
+                resp.status(),
+                reqwest::StatusCode::OK,
+                "the SSE subscription endpoint must be wired (200), not gated"
+            );
+            let ct = resp
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or_default()
+                .to_string();
+            assert!(ct.starts_with("text/event-stream"), "expected an SSE stream, got {ct:?}");
+        }
+        // A read timeout while the keep-alive stream is open also proves the
+        // endpoint is wired (it did not return a 503 body).
+        Err(e) => assert!(e.is_timeout(), "expected an SSE stream or timeout, got {e}"),
+    }
 
-    // Blob storage.
+    // Blob storage stays gated.
     let resp = client.get(format!("{base}/api/storage/anything")).send().await.unwrap();
     assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
 
@@ -2207,4 +2231,117 @@ async fn http_standalone_unaffected() {
     let rows = body["data"]["data"].as_array().expect("data.data array");
     assert_eq!(rows.len(), 1, "standalone GraphQL query must still work: {body}");
     assert_eq!(rows[0]["name"], "Alice", "{body}");
+}
+
+// ---------------------------------------------------------------------------
+// Subscriptions over consensus (#5422)
+// ---------------------------------------------------------------------------
+
+/// Wait (bounded) until every handle has applied dense index `idx`.
+async fn wait_all_applied(handles: &[Arc<ReplicationHandle>], idx: u64) {
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    loop {
+        if handles.iter().all(|h| h.node().last_applied() >= idx) {
+            return;
+        }
+        assert!(tokio::time::Instant::now() < deadline, "timed out waiting for apply of {idx}");
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// A subscriber driven by the **replicated apply-path change feed** observes a
+/// write committed on the leader while subscribed against a **follower** —
+/// end-to-end through the server's `SubscriptionManager` (#5422). This is the
+/// server-side equivalent of the consensus crate's apply-feed test, exercising
+/// `run_replicated_event_loop` + `with_applied_db` + `notify_with_rows`.
+#[tokio::test]
+async fn replicated_subscription_on_follower_sees_leader_write() {
+    use vibesql_server::SubscriptionUpdate;
+
+    let (handles, _dir) = boot_cluster(3).await;
+    let leader_idx = wait_for_leader(&handles).await;
+
+    // Schema + a first row, committed via the leader.
+    let mut leader = replicated_session(&handles[leader_idx]);
+    leader.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)").await.unwrap();
+    let res = leader.execute("INSERT INTO users VALUES (1, 'alice')").await.unwrap();
+    assert!(matches!(res, ExecutionResult::Insert { rows_affected: 1 }));
+
+    let setup_idx = handles[leader_idx].node().last_applied();
+    wait_all_applied(&handles, setup_idx).await;
+
+    // Pick a follower and drive a subscription against ITS applied state.
+    let follower_pos =
+        (0..handles.len()).find(|i| *i != leader_idx).expect("a follower exists");
+    let follower = Arc::clone(&handles[follower_pos]);
+
+    let manager = Arc::new(SubscriptionManager::new());
+    let (tx, mut rx) = tokio::sync::mpsc::channel(32);
+    let query = "SELECT id, name FROM users ORDER BY id".to_string();
+    let sub_id = manager.subscribe(query.clone(), tx).expect("subscribe");
+
+    // Prime the initial snapshot from the follower's applied state, exactly as
+    // the replicated SSE handler does.
+    let initial = follower
+        .with_applied_db(|db| SubscriptionManager::execute_query_against(&query, db))
+        .expect("initial query")
+        .into_iter()
+        .map(|r| vibesql_server::Row { values: r.values.to_vec() })
+        .collect::<Vec<_>>();
+    manager.prime_initial_result(sub_id, initial).await.expect("prime initial");
+
+    // The initial Full update reflects the row already committed.
+    match tokio::time::timeout(WAIT_TIMEOUT, rx.recv()).await.expect("initial event") {
+        Some(SubscriptionUpdate::Full { rows, .. }) => {
+            assert_eq!(rows.len(), 1, "initial snapshot should have one row");
+        }
+        other => panic!("expected initial Full update, got {other:?}"),
+    }
+
+    // Spawn the replicated event loop against the follower's apply-path feed.
+    let change_rx = follower.subscribe_changes().expect("apply-path feed");
+    let manager_for_loop = Arc::clone(&manager);
+    let follower_for_query = Arc::clone(&follower);
+    let loop_task = tokio::spawn(async move {
+        let query_fn = move |q: &str| {
+            follower_for_query.with_applied_db(|db| SubscriptionManager::execute_query_against(q, db))
+        };
+        manager_for_loop.run_replicated_event_loop(change_rx, query_fn).await;
+    });
+
+    // Commit a second row on the leader; the follower applies it, its feed
+    // fires, and the subscriber is notified with the updated result.
+    let res = leader.execute("INSERT INTO users VALUES (2, 'bob')").await.unwrap();
+    assert!(matches!(res, ExecutionResult::Insert { rows_affected: 1 }));
+    let write_idx = handles[leader_idx].node().last_applied();
+    wait_all_applied(&handles, write_idx).await;
+
+    // Drain updates until we observe a result containing both rows. The change
+    // feed may emit a delta or a full update depending on PK detection; either
+    // way the subscriber must end up seeing two rows.
+    let observed_two = tokio::time::timeout(WAIT_TIMEOUT, async {
+        loop {
+            match rx.recv().await {
+                Some(SubscriptionUpdate::Full { rows, .. }) => {
+                    if rows.len() == 2 {
+                        return true;
+                    }
+                }
+                Some(SubscriptionUpdate::Delta { inserts, .. }) => {
+                    if inserts.iter().any(|r| {
+                        r.values.first() == Some(&SqlValue::Integer(2))
+                    }) {
+                        return true;
+                    }
+                }
+                Some(_) => {}
+                None => return false,
+            }
+        }
+    })
+    .await
+    .expect("subscriber should be notified of the leader's committed write");
+    assert!(observed_two, "subscriber must observe the second committed row");
+
+    loop_task.abort();
 }


### PR DESCRIPTION
## Summary

Makes the HTTP **SSE subscription** endpoint (`GET /api/subscribe`) coherent in replicated mode by feeding it from the consensus **apply-path change feed** instead of the local registry database's change stream (which receives no replicated writes). A subscriber connected to **any** node — leader or follower — now observes committed changes in apply (commit) order, with documented consistency.

**Closes #5422.** Part of #5410.

## Scope decision: subscriptions now; blob storage deferred

This PR delivers **subscriptions** (the hard core of #5422). **Blob storage** (`/api/storage/*`) is deferred to a focused follow-on because it is an architecturally separate subsystem: `BlobStorageService` is a raw-byte store with its own `Database` that does **not** route through the SQL executor or the consensus `TxnEntry` write path. Replicating it is its own design problem (wrap blob bytes in consensus entries, or build a dedicated blob-replication path). It stays gated to a clear 503 in replicated mode (accepting a blob write there would never replicate). Because blob storage is still gated, **#5410 (umbrella) stays open** until the blob follow-on lands.

## Apply-path change-feed design (how followers feed subscribers)

- `VibesqlStateMachine` enables change-event broadcasting on its internal `Database` (in `new()` and re-armed in `install_decoded` after a snapshot install). Every row mutated by the `apply` path therefore emits a `ChangeEvent` on the existing storage broadcast channel — automatically, since the storage `table_api` write methods already emit these events. No new emit sites.
- New surface: `VibesqlStateMachine::subscribe_changes()` / `with_applied_db()` → `MvccRaftNode` → `ReplicationHandle::subscribe_changes()` / `with_applied_db()`.
- Apply runs on **all** replicas (the existing `MvccRaftNode::apply` path already drives every follower), so a follower's feed fires as it applies replicated entries — that is what lets a subscriber on a follower see a leader's committed write.
- Server side: a new `SubscriptionManager::run_replicated_event_loop` drains the apply-path feed and, per change, re-runs each affected subscription's SELECT against the applied state (`with_applied_db` + a new sync `execute_query_against`), then notifies via the shared `notify_with_rows` (extracted from `execute_with_retry`, so delta/selective-column/slow-consumer logic is identical to standalone).
- The replicated SSE handler primes its initial snapshot from the applied state machine (replicated session read + `prime_initial_result`) and detects PK columns against the applied catalog, keeping the snapshot consistent with the feed.
- On a snapshot install the feed closes (the SM database is replaced); the loop exits and re-subscribes against the new state machine — the correct response to the applied state jumping forward.

## Split-brain / safety

- No new write path. The replicated additions are read-only: `execute_query_against` rejects non-SELECT; `with_applied_db` only runs SELECTs. The SSE initial query uses the replicated `state.session()` (reads from the state machine), never the local DB.
- The feed reflects **committed/applied** state only — events come from the `apply` path, not speculative/uncommitted writes.
- Standalone is untouched (selected behind `HttpState::replication` / `ReplicationHandle`): standalone subscriptions still drive from the local `Database` change stream via the original `run_event_loop`.

## Test evidence

- **Cross-node (consensus)** — `crates/vibesql-consensus/tests/apply_change_feed.rs`: subscribe on a **follower**, write on the **leader**, assert the follower's apply feed fires for the table and its applied state shows the row; plus a leader-sees-own-write case. (2/2 pass.)
- **Full replicated loop (server)** — `replicated_subscription_on_follower_sees_leader_write` in `replication_tests.rs`: drives `run_replicated_event_loop` + `with_applied_db` through the real `SubscriptionManager`; a write on the leader notifies a subscriber bound to a follower. (pass.)
- **Gating** — `http_unwired_surfaces_still_gated_in_replicated_mode` updated: `/api/subscribe` now returns a `text/event-stream` (200), blob storage still 503, GraphQL still 200.
- **Standalone regression** — `http_sse_subscription_tests` (11), `e2e_subscription_tests` (7), `subscription_metrics_tests` (28), subscription unit tests (184) all pass unchanged.
- Consensus lib + integration suites (172 + 17) pass; clippy clean on touched crates.

## Test plan

- [ ] `cargo test -p vibesql-consensus --test apply_change_feed`
- [ ] `cargo test -p vibesql-server --test replication_tests`
- [ ] `cargo test -p vibesql-server --test http_sse_subscription_tests --test e2e_subscription_tests`
- [ ] `cargo test -p vibesql-consensus --lib`

## Follow-ons

- Route blob storage writes through consensus (or document blobs as out-of-replication) — last child of #5410; **#5410 can close once it lands.**
- Optional: row-level subscription granularity in replicated mode (current path re-queries on table-level change events; correct but coarser than a row-level diff feed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)