### PR TITLE
Raft: route HTTP blob storage writes through consensus (last child of #5410)

### DIFF
--- a/crates/vibesql-server/src/http/rest.rs
+++ b/crates/vibesql-server/src/http/rest.rs
@@ -87,12 +87,13 @@ pub struct HttpState {
     /// observes committed writes) build a **replicated** session via
     /// [`Self::session`], so writes propose through this handle (leader-only,
     /// freeze-at-propose) and reads run against the replicated state machine —
-    /// never against the unreplicated local registry database. The only HTTP
-    /// surface still gated in replicated mode is the **blob storage** API
-    /// (`/api/storage/*`), whose `BlobStorageService` is a separate byte store
-    /// that does not route through the SQL/consensus write path; it remains
-    /// gated to a clear 503 (deferred to a focused follow-on of #5410) rather
-    /// than accepting a write that never replicates.
+    /// never against the unreplicated local registry database. #5455 wired the
+    /// last gated surface — the **blob storage** API (`/api/storage/*`): in
+    /// replicated mode blobs are stored as rows in the replicated
+    /// `__vibesql_blobs` table, so an upload/delete proposes through this handle
+    /// (leader-only; a follower write is refused with 421, never stored locally)
+    /// and a download reads the replicated state machine. No HTTP surface
+    /// remains gated to 503 in replicated mode.
     /// `/health` uses the handle to report node role/writability.
     pub replication: Option<StdArc<ReplicationHandle>>,
 }
@@ -249,6 +250,10 @@ pub fn create_http_router(
     };
     let is_replicated = state.replication.is_some();
 
+    // Clone the state for the replicated storage sub-router before the main
+    // router consumes `state` via `.with_state` (#5455).
+    let storage_state = state.clone();
+
     // Create main router with state
     let main_router = Router::new()
         .route("/health", get(health_check))
@@ -269,25 +274,19 @@ pub fn create_http_router(
         .route("/stats/subscriptions/efficiency", get(get_efficiency_stats))
         .with_state(state);
 
-    // Create storage sub-router with its own state. The blob storage API is a
-    // separate `BlobStorageService` byte store that does not route through the
-    // SQL/consensus write path, so replicating it is its own design problem
-    // (wrap blob bytes in consensus entries, or a dedicated blob-replication
-    // path). It is therefore deferred to a focused follow-on of #5410/#5422 and
-    // remains gated to a uniform 503 in replicated mode rather than nested
-    // (#5393) — accepting a blob write here would never replicate.
+    // Create the storage sub-router. The blob storage API is backed by a
+    // separate `BlobStorageService` byte store in standalone mode, which would
+    // never replicate on its own. In replicated mode (#5455) blob writes are
+    // therefore routed through the **same consensus SQL write path** as every
+    // other replicated HTTP surface: each blob is a row in the replicated
+    // `__vibesql_blobs` table, so an upload/delete proposes through consensus
+    // (leader-only; a follower write surfaces as 421, never stored locally —
+    // the split-brain invariant) and a download reads the replicated state
+    // machine. This is the last #5410 child: with blob storage wired, no HTTP
+    // surface remains gated to 503 in replicated mode.
     if is_replicated {
-        let gated = Router::new().fallback(|| async {
-            (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(ErrorResponse::with_code(
-                    "the blob storage API is not available over HTTP in replicated mode; use the \
-                     PostgreSQL wire protocol port",
-                    "58000",
-                )),
-            )
-        });
-        main_router.nest("/api/storage", gated)
+        let storage_router = super::storage::create_replicated_storage_router(storage_state);
+        main_router.nest("/api/storage", storage_router)
     } else {
         let storage_router = super::storage::create_storage_router(db, registry);
         main_router.nest("/api/storage", storage_router)

--- a/crates/vibesql-server/src/http/storage.rs
+++ b/crates/vibesql-server/src/http/storage.rs
@@ -2,6 +2,32 @@
 //!
 //! This module provides REST endpoints for uploading, downloading,
 //! and managing blobs via HTTP.
+//!
+//! # Replicated vs. standalone storage (#5455)
+//!
+//! The blob storage API has two backends selected by the server mode:
+//!
+//! * **Standalone**: blobs are written to a separate [`BlobStorageService`]
+//!   byte store (OpenDAL — filesystem, S3, GCS, Azure, in-memory). This path is
+//!   unchanged: the bytes live outside the SQL database and never touch
+//!   consensus.
+//!
+//! * **Replicated**: a separate node-local byte store would never replicate, so
+//!   blob writes are instead routed through the **same consensus SQL write
+//!   path** every other replicated HTTP surface uses. Each blob is a row in the
+//!   replicated `__vibesql_blobs` system table `(id, content_type, size,
+//!   created_at, data BLOB)`. An upload proposes an `INSERT` through consensus
+//!   via the [`HttpState::session`](crate::http::rest::HttpState) choke point
+//!   (leader-only, freeze-at-propose); a delete proposes a `DELETE`; a download
+//!   / metadata read runs the `SELECT` against the replicated state machine. So
+//!   a blob written on the leader replicates to every follower and is readable
+//!   on any node, an upload/delete on a follower surfaces the `NOT_LEADER`
+//!   refusal as `421` (never written locally — the split-brain invariant), and
+//!   there is no local-only blob write. The blob bytes ride the Raft log as a
+//!   SQL `BLOB` literal; this is sound for modest blobs but large blobs would
+//!   bloat the log/snapshots, so replicated uploads are capped at
+//!   [`MAX_REPLICATED_BLOB_BYTES`] (streaming large blobs out-of-band is a
+//!   documented follow-on).
 
 use std::sync::Arc;
 
@@ -17,10 +43,23 @@ use tokio::sync::RwLock;
 use tracing::{debug, error};
 use vibesql_storage::{BlobId, BlobStorageConfig, BlobStorageService, Database};
 
+use super::rest::{execution_error_response, get_database_name, HttpState};
 use super::types::*;
 use crate::registry::DatabaseRegistry;
 
-/// State for storage endpoints
+/// Replicated system table that holds blobs as rows so blob writes ride the
+/// consensus SQL write path (#5455).
+const BLOB_TABLE: &str = "__vibesql_blobs";
+
+/// Upper bound on a blob uploaded in replicated mode. Replicated blobs flow
+/// through the Raft log (and into snapshots) as a SQL `BLOB` literal, so a very
+/// large blob would bloat the log; cap at a conservative size and reject larger
+/// uploads with a clear error. Streaming large blobs out-of-band (e.g. an
+/// external object store referenced by a replicated row) is a documented
+/// follow-on.
+pub const MAX_REPLICATED_BLOB_BYTES: usize = 8 * 1024 * 1024;
+
+/// State for the standalone storage endpoints (separate byte store).
 #[derive(Clone)]
 pub struct StorageState {
     /// Database registry for shared database access
@@ -58,7 +97,7 @@ impl StorageState {
     }
 }
 
-/// Create the storage API router
+/// Create the storage API router for **standalone** mode (separate byte store).
 pub fn create_storage_router(db: Arc<Database>, registry: DatabaseRegistry) -> Router {
     let state = StorageState::new(db, registry);
 
@@ -67,6 +106,21 @@ pub fn create_storage_router(db: Arc<Database>, registry: DatabaseRegistry) -> R
         .route("/{blob_id}", get(download_blob))
         .route("/{blob_id}", delete(delete_blob))
         .route("/{blob_id}/metadata", get(get_blob_metadata))
+        .with_state(state)
+}
+
+/// Create the storage API router for **replicated** mode (#5455).
+///
+/// Blob writes route through consensus (the `__vibesql_blobs` table) via the
+/// shared [`HttpState::session`] choke point, exactly like the other replicated
+/// HTTP surfaces, so they replicate to every node, are readable on any node, and
+/// a write on a follower is refused with `421` rather than written locally.
+pub fn create_replicated_storage_router(state: HttpState) -> Router {
+    Router::new()
+        .route("/upload", post(replicated_upload_blob))
+        .route("/{blob_id}", get(replicated_download_blob))
+        .route("/{blob_id}", delete(replicated_delete_blob))
+        .route("/{blob_id}/metadata", get(replicated_get_blob_metadata))
         .with_state(state)
 }
 
@@ -248,6 +302,297 @@ async fn delete_blob(
     }
 }
 
+// ===========================================================================
+// Replicated blob handlers (#5455) — blobs as rows in the consensus state
+// machine, routed through the shared `HttpState::session` choke point.
+// ===========================================================================
+
+/// Render bytes as a SQL `BLOB` literal (`X'..'`). Hex digits cannot break out
+/// of the literal, so this is injection-safe for arbitrary blob bytes.
+fn blob_literal(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2 + 3);
+    s.push_str("X'");
+    for b in bytes {
+        s.push_str(&format!("{:02X}", b));
+    }
+    s.push('\'');
+    s
+}
+
+/// Escape a value for a single-quoted SQL string literal (double any quote).
+fn sql_string_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+/// Ensure the replicated `__vibesql_blobs` table exists, creating it through
+/// consensus on first use. `CREATE TABLE IF NOT EXISTS` is idempotent and
+/// deterministic, so it is safe to propose on every upload.
+async fn ensure_blob_table(state: &HttpState, db_name: &str) -> Result<(), anyhow::Error> {
+    let shared_db = state.registry.get_or_create(db_name).await;
+    let mut session = state.session(db_name, shared_db);
+    let ddl = format!(
+        "CREATE TABLE IF NOT EXISTS {BLOB_TABLE} (\
+            id VARCHAR(64) PRIMARY KEY, \
+            content_type VARCHAR(255), \
+            size BIGINT, \
+            created_at VARCHAR(64), \
+            data BLOB)"
+    );
+    session.execute(&ddl).await?;
+    Ok(())
+}
+
+/// Upload a blob in replicated mode: propose an INSERT through consensus.
+async fn replicated_upload_blob(
+    State(state): State<HttpState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> axum::response::Response {
+    let content_type = headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream")
+        .to_string();
+
+    let size = body.len() as i64;
+
+    if body.len() > MAX_REPLICATED_BLOB_BYTES {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(ErrorResponse::new(format!(
+                "blob is {} bytes; replicated blob uploads are capped at {} bytes (large blobs \
+                 would bloat the Raft log/snapshots)",
+                body.len(),
+                MAX_REPLICATED_BLOB_BYTES
+            ))),
+        )
+            .into_response();
+    }
+
+    let db_name = get_database_name(&headers);
+
+    // Create the blob table through consensus if needed.
+    if let Err(e) = ensure_blob_table(&state, &db_name).await {
+        return execution_error_response(&e);
+    }
+
+    let id = BlobId::new();
+    let created_at = chrono::Utc::now().to_rfc3339();
+
+    debug!("Uploading replicated blob {}: {} bytes, content-type: {}", id, size, content_type);
+
+    let sql = format!(
+        "INSERT INTO {BLOB_TABLE} (id, content_type, size, created_at, data) VALUES ({}, {}, {}, {}, {})",
+        sql_string_literal(&id.to_string()),
+        sql_string_literal(&content_type),
+        size,
+        sql_string_literal(&created_at),
+        blob_literal(&body),
+    );
+
+    let shared_db = state.registry.get_or_create(&db_name).await;
+    let mut session = state.session(&db_name, shared_db);
+    match session.execute(&sql).await {
+        Ok(_) => {
+            let url = format!("/api/storage/{}", id);
+            let response = BlobUploadResponse { id: id.to_string(), size, content_type, url };
+            (StatusCode::CREATED, Json(response)).into_response()
+        }
+        Err(e) => {
+            error!("Failed to upload replicated blob {}: {}", id, e);
+            // NOT_LEADER → 421 (+ leader hint), staleness/FATAL → 503, a
+            // deterministic SQL error → 400 — the same mapping the SQL/CRUD
+            // surfaces use, so a follower upload is refused, never stored locally.
+            execution_error_response(&e)
+        }
+    }
+}
+
+/// Read a single blob row's columns from the replicated state machine.
+///
+/// Returns `Ok(Some(..))` when the blob exists, `Ok(None)` when it does not (or
+/// the table has not been created yet), and `Err` only on a consensus refusal.
+async fn fetch_replicated_blob(
+    state: &HttpState,
+    db_name: &str,
+    id: &BlobId,
+) -> Result<Option<(String, i64, String, Vec<u8>)>, anyhow::Error> {
+    let sql = format!(
+        "SELECT content_type, size, created_at, data FROM {BLOB_TABLE} WHERE id = {}",
+        sql_string_literal(&id.to_string()),
+    );
+    let shared_db = state.registry.get_or_create(db_name).await;
+    let mut session = state.session(db_name, shared_db);
+    let result = match session.execute(&sql).await {
+        Ok(r) => r,
+        Err(e) => {
+            // A missing table reads as "no such blob", not a server error — the
+            // table is created lazily on first upload. Any other error (e.g. a
+            // consensus refusal) propagates.
+            let msg = e.to_string().to_lowercase();
+            if msg.contains("no such table")
+                || msg.contains("does not exist")
+                || msg.contains("not found")
+                || msg.contains("unknown table")
+            {
+                return Ok(None);
+            }
+            return Err(e);
+        }
+    };
+
+    let crate::session::ExecutionResult::Select { rows, .. } = result else {
+        return Ok(None);
+    };
+    let Some(row) = rows.into_iter().next() else {
+        return Ok(None);
+    };
+
+    use vibesql_types::SqlValue;
+    let content_type = match row.values.first() {
+        Some(SqlValue::Character(s)) | Some(SqlValue::Varchar(s)) => s.to_string(),
+        _ => "application/octet-stream".to_string(),
+    };
+    let size = match row.values.get(1) {
+        Some(SqlValue::Bigint(n)) => *n,
+        Some(SqlValue::Integer(n)) => *n,
+        _ => 0,
+    };
+    let created_at = match row.values.get(2) {
+        Some(SqlValue::Character(s)) | Some(SqlValue::Varchar(s)) => s.to_string(),
+        _ => String::new(),
+    };
+    let data = match row.values.get(3) {
+        Some(SqlValue::Blob(b)) => b.clone(),
+        _ => Vec::new(),
+    };
+
+    Ok(Some((content_type, size, created_at, data)))
+}
+
+/// Download a blob in replicated mode: read from the replicated state machine.
+async fn replicated_download_blob(
+    State(state): State<HttpState>,
+    headers: HeaderMap,
+    Path(blob_id): Path<String>,
+) -> axum::response::Response {
+    let id = match BlobId::parse(&blob_id) {
+        Some(id) => id,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse::new(format!("Invalid blob ID: {}", blob_id))),
+            )
+                .into_response();
+        }
+    };
+
+    let db_name = get_database_name(&headers);
+    debug!("Downloading replicated blob: {}", id);
+
+    match fetch_replicated_blob(&state, &db_name, &id).await {
+        Ok(Some((content_type, _size, _created_at, data))) => {
+            let mut out_headers = HeaderMap::new();
+            out_headers.insert(
+                header::CONTENT_TYPE,
+                content_type
+                    .parse()
+                    .unwrap_or(header::HeaderValue::from_static("application/octet-stream")),
+            );
+            out_headers.insert(header::CONTENT_LENGTH, data.len().to_string().parse().unwrap());
+            (StatusCode::OK, out_headers, data).into_response()
+        }
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new(format!("Blob not found: {}", blob_id))),
+        )
+            .into_response(),
+        Err(e) => execution_error_response(&e),
+    }
+}
+
+/// Get blob metadata in replicated mode: read from the replicated state machine.
+async fn replicated_get_blob_metadata(
+    State(state): State<HttpState>,
+    headers: HeaderMap,
+    Path(blob_id): Path<String>,
+) -> axum::response::Response {
+    let id = match BlobId::parse(&blob_id) {
+        Some(id) => id,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse::new(format!("Invalid blob ID: {}", blob_id))),
+            )
+                .into_response();
+        }
+    };
+
+    let db_name = get_database_name(&headers);
+    debug!("Getting metadata for replicated blob: {}", id);
+
+    match fetch_replicated_blob(&state, &db_name, &id).await {
+        Ok(Some((content_type, size, created_at, _data))) => {
+            let response = BlobMetadataResponse {
+                id: id.to_string(),
+                size,
+                content_type,
+                created_at,
+            };
+            (StatusCode::OK, Json(response)).into_response()
+        }
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new(format!("Blob not found: {}", blob_id))),
+        )
+            .into_response(),
+        Err(e) => execution_error_response(&e),
+    }
+}
+
+/// Delete a blob in replicated mode: propose a DELETE through consensus.
+async fn replicated_delete_blob(
+    State(state): State<HttpState>,
+    headers: HeaderMap,
+    Path(blob_id): Path<String>,
+) -> axum::response::Response {
+    let id = match BlobId::parse(&blob_id) {
+        Some(id) => id,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse::new(format!("Invalid blob ID: {}", blob_id))),
+            )
+                .into_response();
+        }
+    };
+
+    let db_name = get_database_name(&headers);
+    debug!("Deleting replicated blob: {}", id);
+
+    // Create the table if it does not exist so a delete-before-any-upload is
+    // idempotent (204), matching the standalone delete semantics.
+    if let Err(e) = ensure_blob_table(&state, &db_name).await {
+        return execution_error_response(&e);
+    }
+
+    let sql = format!(
+        "DELETE FROM {BLOB_TABLE} WHERE id = {}",
+        sql_string_literal(&id.to_string()),
+    );
+
+    let shared_db = state.registry.get_or_create(&db_name).await;
+    let mut session = state.session(&db_name, shared_db);
+    match session.execute(&sql).await {
+        // Delete is idempotent — deleting a non-existent blob still succeeds.
+        Ok(_) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => {
+            error!("Failed to delete replicated blob {}: {}", id, e);
+            execution_error_response(&e)
+        }
+    }
+}
+
 /// Tests for blob storage HTTP handlers.
 /// These tests require the memory storage backend to be enabled.
 #[cfg(all(test, feature = "opendal", feature = "storage-memory"))]
@@ -342,5 +687,18 @@ mod tests {
         let response = router.oneshot(request).await.unwrap();
         // Delete is idempotent - deleting non-existent blob returns 204
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[test]
+    fn test_blob_literal_roundtrip_safe() {
+        // Quotes/backslashes cannot break out of an X'' hex literal.
+        assert_eq!(blob_literal(&[0x00, 0xFF, 0x41]), "X'00FF41'");
+        assert_eq!(blob_literal(&[]), "X''");
+    }
+
+    #[test]
+    fn test_sql_string_literal_escapes_quotes() {
+        assert_eq!(sql_string_literal("a'b"), "'a''b'");
+        assert_eq!(sql_string_literal("plain"), "'plain'");
     }
 }

--- a/crates/vibesql-server/tests/replication_tests.rs
+++ b/crates/vibesql-server/tests/replication_tests.rs
@@ -1870,13 +1870,12 @@ async fn http_write_replicates_to_followers() {
     }
 }
 
-/// In replicated mode the **blob-storage** surface remains gated to a clear 503
-/// (the `BlobStorageService` byte store does not route through the
-/// SQL/consensus write path — replicating it is a separate design problem,
-/// deferred to a focused follow-on of #5410/#5422). It must never silently
-/// accept a write that never replicates. The subscription endpoint (#5422), the
-/// CRUD by-id endpoints (#5420), and the GraphQL endpoint (#5421) are no longer
-/// gated — they route through consensus.
+/// In replicated mode every HTTP surface now routes through consensus — none
+/// stays gated to 503 (#5455). The subscription endpoint (#5422), the CRUD
+/// by-id endpoints (#5420), the GraphQL endpoint (#5421), and the **blob
+/// storage** API (#5455 — blobs as rows in the replicated `__vibesql_blobs`
+/// table) all route through the consensus path. This test name is retained for
+/// history; it now asserts the surfaces are wired, not gated.
 #[tokio::test]
 async fn http_unwired_surfaces_still_gated_in_replicated_mode() {
     let (handles, _dir) = boot_cluster(1).await;
@@ -1912,9 +1911,19 @@ async fn http_unwired_surfaces_still_gated_in_replicated_mode() {
         Err(e) => assert!(e.is_timeout(), "expected an SSE stream or timeout, got {e}"),
     }
 
-    // Blob storage stays gated.
-    let resp = client.get(format!("{base}/api/storage/anything")).send().await.unwrap();
-    assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+    // Blob storage is no longer gated (#5455): GET of a well-formed but unknown
+    // blob id reads the replicated state machine and returns 404 (not the old
+    // 503). A malformed id returns 400. Either way it is wired, not gated.
+    let resp = client
+        .get(format!("{base}/api/storage/550e8400-e29b-41d4-a716-446655440000"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "the blob storage API must be wired (404 for an unknown blob), not gated (503)"
+    );
 
     // GraphQL is no longer gated — an introspection query succeeds (200)
     // against the replicated catalog rather than returning the old 503.
@@ -1926,6 +1935,213 @@ async fn http_unwired_surfaces_still_gated_in_replicated_mode() {
         .await
         .unwrap();
     assert_eq!(resp.status(), reqwest::StatusCode::OK);
+}
+
+/// A blob uploaded on the leader's HTTP port replicates through consensus and
+/// is readable on a **follower's** HTTP port (#5455): the blob is a row in the
+/// replicated `__vibesql_blobs` table, so it rides the same consensus write
+/// path as every other replicated HTTP write. A `GET` on node B returns the
+/// exact bytes and content-type, and a `DELETE` on the leader replicates so the
+/// follower's `GET` then 404s.
+#[tokio::test]
+async fn http_blob_put_replicates_and_reads_on_follower() {
+    let (handles, _dir) = boot_cluster(3).await;
+    wait_for_leader(&handles).await;
+    let client = reqwest::Client::new();
+
+    let blob_bytes = b"hello replicated blob \x00\x01\x02\xff".to_vec();
+
+    // Upload through whichever node currently leads, retrying across leadership
+    // changes (a 421 means the chosen node stopped leading): the write must land
+    // on the leader and replicate.
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    let (blob_id, _leader_tx, leader_base) = loop {
+        let leader = wait_for_leader(&handles).await;
+        let (leader_base, leader_tx) = start_http(Some(Arc::clone(&handles[leader]))).await;
+        let resp = client
+            .post(format!("{leader_base}/api/storage/upload"))
+            .header("content-type", "application/octet-stream")
+            .body(blob_bytes.clone())
+            .send()
+            .await
+            .unwrap();
+        if resp.status() == reqwest::StatusCode::CREATED {
+            let upload: serde_json::Value =
+                serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+            assert_eq!(upload["size"].as_i64(), Some(blob_bytes.len() as i64));
+            let blob_id = upload["id"].as_str().expect("blob id").to_string();
+            break (blob_id, leader_tx, leader_base);
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "leader upload never succeeded (last status {})",
+            resp.status()
+        );
+        drop(leader_tx);
+        tokio::time::sleep(POLL_INTERVAL).await;
+    };
+
+    // Pick a follower and serve its HTTP port.
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    let follower = loop {
+        if let Some(i) = handles.iter().position(|h| h.role() == Role::Follower) {
+            break i;
+        }
+        assert!(tokio::time::Instant::now() < deadline, "timed out waiting for a follower");
+        tokio::time::sleep(POLL_INTERVAL).await;
+    };
+    let (follower_base, _txf) = start_http(Some(Arc::clone(&handles[follower]))).await;
+
+    // The follower converges: a GET returns the exact bytes once it has applied
+    // the upload entry.
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    loop {
+        let resp = client
+            .get(format!("{follower_base}/api/storage/{blob_id}"))
+            .send()
+            .await
+            .unwrap();
+        if resp.status() == reqwest::StatusCode::OK {
+            let ct = resp
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or_default()
+                .to_string();
+            assert!(ct.starts_with("application/octet-stream"), "content-type {ct:?}");
+            let got = resp.bytes().await.unwrap().to_vec();
+            assert_eq!(got, blob_bytes, "follower GET must return the exact replicated bytes");
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "follower did not converge to the replicated blob (status {})",
+            resp.status()
+        );
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+
+    // DELETE on the leader replicates; the follower's GET then 404s. Retry
+    // across leadership changes (a 421 means the bound node stopped leading).
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    let mut delete_base = leader_base;
+    let mut _delete_txs = Vec::new();
+    loop {
+        let resp = client
+            .delete(format!("{delete_base}/api/storage/{blob_id}"))
+            .send()
+            .await
+            .unwrap();
+        if resp.status() == reqwest::StatusCode::NO_CONTENT {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "leader delete never succeeded (last status {})",
+            resp.status()
+        );
+        let leader = wait_for_leader(&handles).await;
+        let (base, tx) = start_http(Some(Arc::clone(&handles[leader]))).await;
+        delete_base = base;
+        _delete_txs.push(tx);
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    loop {
+        let resp = client
+            .get(format!("{follower_base}/api/storage/{blob_id}"))
+            .send()
+            .await
+            .unwrap();
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "follower did not converge to the replicated delete (status {})",
+            resp.status()
+        );
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// A blob upload on a **follower** is refused with a 421 + leader hint and is
+/// never stored locally (#5455 — the split-brain invariant): the blob write
+/// proposes through consensus, which a follower cannot accept, so it surfaces
+/// the NOT_LEADER refusal exactly like every other replicated HTTP write.
+#[tokio::test]
+async fn http_blob_upload_on_follower_redirects_with_leader_hint() {
+    let (handles, _dir) = boot_cluster(3).await;
+    wait_for_leader(&handles).await;
+    let client = reqwest::Client::new();
+
+    // Upload on whichever node is *currently* a follower (re-resolved each
+    // attempt so leadership flux does not race us): the write must be refused
+    // with 421 + a leader hint and must never be stored locally. Retry while a
+    // request lands on a node that has just become leader.
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    loop {
+        // A follower that knows who leads (so the hint is populated).
+        let follower = match handles
+            .iter()
+            .position(|h| h.role() == Role::Follower && h.node().current_leader().is_some())
+        {
+            Some(i) => i,
+            None => {
+                assert!(
+                    tokio::time::Instant::now() < deadline,
+                    "timed out waiting for a follower"
+                );
+                tokio::time::sleep(POLL_INTERVAL).await;
+                continue;
+            }
+        };
+        let leader_id = handles[follower].node().current_leader().unwrap();
+
+        let (base, _tx) = start_http(Some(Arc::clone(&handles[follower]))).await;
+        let resp = client
+            .post(format!("{base}/api/storage/upload"))
+            .header("content-type", "text/plain")
+            .body("follower blob")
+            .send()
+            .await
+            .unwrap();
+
+        if resp.status() != reqwest::StatusCode::MISDIRECTED_REQUEST {
+            // The chosen node became leader between selection and the request;
+            // retry with a freshly resolved follower.
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "a follower upload was not refused with 421 (status {})",
+                resp.status()
+            );
+            tokio::time::sleep(POLL_INTERVAL).await;
+            continue;
+        }
+
+        let leader_hint = resp
+            .headers()
+            .get("X-VibeSQL-Leader")
+            .expect("leader-hint header")
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(leader_hint.contains(&format!("node {leader_id}")), "{leader_hint}");
+
+        // The follower's local state machine never stored a blob: the blob table
+        // is either absent or empty — no local-only blob write (split-brain).
+        let count = handles[follower]
+            .node()
+            .query("SELECT COUNT(*) FROM __vibesql_blobs")
+            .ok()
+            .and_then(|r| r.first().and_then(|row| row.first()).map(ToString::to_string));
+        assert!(
+            count.is_none() || count.as_deref() == Some("0"),
+            "a blob upload on a follower must not store anything locally (saw {count:?})"
+        );
+        break;
+    }
 }
 
 /// In replicated mode a GraphQL **mutation** routes through consensus and a


### PR DESCRIPTION
## Summary

Wires the **last gated HTTP surface** — blob storage (`/api/storage/*`) — through consensus in replicated mode. With this, no HTTP surface remains gated to 503 in replicated mode.

**Closes #5455.** This is the last child of #5410 — **the #5410 umbrella can now be closed.**

### Blob architecture finding
Blobs are a **separate byte store**, not a DB table: `BlobStorageService` (crates/vibesql-storage/src/blob/service.rs) writes blob bytes to OpenDAL backends (filesystem / S3 / GCS / Azure / in-memory) keyed by path. It does **not** route through the SQL executor or the consensus `TxnEntry` write path; its `db` field is unused and metadata persistence was an unimplemented TODO stub. In replicated mode it was gated to a clear 503 (a write there would never replicate).

### Chosen consensus-routing approach
Route blob writes through the **existing consensus SQL write path** — the same `HttpState::session` choke point + error mapping (#5410/#5423/#5441) every other replicated HTTP surface uses — by storing each blob as a row in a replicated `__vibesql_blobs` system table `(id, content_type, size, created_at, data BLOB)`:

- **Upload / Delete** → propose `INSERT` / `DELETE` through consensus (leader-only, freeze-at-propose). A follower write surfaces the NOT_LEADER refusal as **421 + leader hint** and is **never stored locally** (split-brain invariant).
- **Download / Metadata** → read the blob row from the replicated state machine (default `ReadConsistency::Local`), so a blob is readable on any node once applied.
- Blob bytes ride the Raft log as a SQL `BLOB` literal (`X'..'`, injection-safe). No new consensus entry kind and **no consensus-crate changes** were needed.

This was chosen over (a) a new blob-op `TxnEntry` kind (large change to the consensus crate + state machine, holding a blob store on every replica) — unnecessary since blobs can ride the existing SQL path, and (b) a dedicated blob-replication channel (reinvents Raft).

### Size tradeoff + scope decision
Replicated blob bytes flow through the Raft log and snapshots. This is sound for modest blobs but large blobs would bloat the log, so replicated uploads are **capped at `MAX_REPLICATED_BLOB_BYTES` (8 MiB)** and over-cap uploads return **413**. Streaming large blobs out-of-band (an external object store referenced by a replicated row) is a documented **follow-on**, not needed to close #5455. Standalone mode is fully delivered and unchanged.

### Split-brain confirmation
A blob upload on a follower is refused with 421 + leader hint and stores nothing locally (`http_blob_upload_on_follower_redirects_with_leader_hint` asserts the follower's `__vibesql_blobs` is absent/empty). No blob write executes locally on a replicated node outside consensus.

### Standalone regression
Standalone storage is behind the replication handle: `create_storage_router` (the `BlobStorageService` path) is unchanged and selected when not replicated. All 7 standalone storage unit tests pass.

## Test plan

- [x] `http_blob_put_replicates_and_reads_on_follower` — leader PUT replicates; GET on node B returns exact bytes + content-type; DELETE on leader replicates (follower GET then 404s). Multi-node (3), retries across leadership flux.
- [x] `http_blob_upload_on_follower_redirects_with_leader_hint` — follower PUT → 421 + leader hint, nothing stored locally.
- [x] `http_unwired_surfaces_still_gated_in_replicated_mode` — updated: blob storage no longer 503 (404 for unknown blob = wired).
- [x] Standalone storage unit tests (7) unchanged + 2 new (`blob_literal`, `sql_string_literal` injection-safety).
- [x] Full `http_` replication suite (17 tests) green across 3 consecutive runs.
- [x] `cargo build -p vibesql-server` and `cargo clippy -p vibesql-server` clean (0 errors/warnings in touched files).

### Follow-ons
- Streaming/large replicated blobs out-of-band (external object store referenced by a replicated row) beyond the 8 MiB cap.
- Optional: per-database blob table naming / GC of orphaned rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)