### PR TITLE
fix(storage): scope spilled-index undo to statement savepoint (RAISE(ABORT))

### DIFF
--- a/crates/vibesql-storage/src/btree/node/btree_index/mod.rs
+++ b/crates/vibesql-storage/src/btree/node/btree_index/mod.rs
@@ -167,6 +167,59 @@ impl BTreeIndex {
             None => return Ok(()),
         };
 
+        self.replay_inverses(log)
+    }
+
+    /// Current length of the active undo-log, or `None` when logging is not
+    /// armed. Used as a *nested savepoint marker* (issue #5434): a statement
+    /// savepoint records this length when it is armed, and
+    /// [`Self::rollback_undo_log_to`] later reverses only the entries appended
+    /// after that point — restoring the tree to its pre-statement state while
+    /// leaving the enclosing transaction's undo-log (and its recording) intact.
+    pub fn undo_log_marker(&self) -> Option<usize> {
+        self.undo_log.as_ref().map(|log| log.len())
+    }
+
+    /// Reverse only the undo-log entries recorded *after* `marker`, restoring
+    /// the tree to the state it had when the marker was taken, while keeping
+    /// undo-logging armed for the enclosing transaction (issue #5434 —
+    /// statement-savepoint rollback).
+    ///
+    /// The retained prefix (entries `0..marker`) stays in the log so a later
+    /// full-transaction ROLLBACK still reverses the mutations made *before* the
+    /// statement savepoint was armed. The replay of the reversed suffix runs
+    /// with logging detached so it does not record new entries; the prefix is
+    /// re-attached afterwards.
+    ///
+    /// No-op when logging is not armed. A `marker` past the current log length
+    /// (e.g. the log was already shortened) reverses nothing.
+    pub fn rollback_undo_log_to(&mut self, marker: usize) -> Result<(), StorageError> {
+        let suffix = match self.undo_log.as_mut() {
+            Some(log) if log.len() > marker => log.split_off(marker),
+            // Logging not armed, or nothing recorded since the marker.
+            _ => return Ok(()),
+        };
+
+        // Detach the retained prefix so the inverse operations below run on the
+        // non-logging fast path (they must not append to the prefix), then
+        // re-attach it so the enclosing transaction keeps recording.
+        let prefix = self.undo_log.take();
+        let result = self.replay_inverses(suffix);
+        self.undo_log = prefix.or(Some(Vec::new()));
+        result
+    }
+
+    /// Apply the logical inverses in `log` in reverse order (LIFO) so
+    /// overlapping mutations on the same key unwind correctly. Logging must be
+    /// detached on `self` so the inverse operations run on the non-logging fast
+    /// path and do not record new entries. Shared by [`Self::rollback_undo_log`]
+    /// (full reverse) and [`Self::rollback_undo_log_to`] (suffix reverse).
+    fn replay_inverses(&mut self, log: Vec<DiskUndoOp>) -> Result<(), StorageError> {
+        debug_assert!(
+            self.undo_log.is_none(),
+            "replay_inverses must run with the undo-log detached so inverses are \
+             not re-recorded",
+        );
         for op in log.into_iter().rev() {
             match op {
                 DiskUndoOp::DeleteSpecific { key, row_id } => {
@@ -179,7 +232,6 @@ impl BTreeIndex {
                 }
             }
         }
-
         Ok(())
     }
 

--- a/crates/vibesql-storage/src/btree/node/tests.rs
+++ b/crates/vibesql-storage/src/btree/node/tests.rs
@@ -1557,3 +1557,88 @@ fn no_undo_logging_has_no_overhead_and_no_reversal() {
     index.rollback_undo_log().unwrap(); // no log => no-op
     assert_eq!(index.lookup(&vec![SqlValue::Integer(20)]).unwrap(), vec![2]);
 }
+
+// ----------------------------------------------------------------------------
+// Statement-scoped nested undo markers (issue #5434)
+// ----------------------------------------------------------------------------
+
+#[test]
+fn undo_log_marker_reverses_only_suffix() {
+    // A statement savepoint marks the log mid-transaction; rollback_to reverses
+    // only entries recorded after the mark, leaving earlier mutations in place
+    // and undo-logging still armed.
+    let (mut index, _dir) = undo_test_index(&[(10, 1)]);
+
+    index.begin_undo_logging();
+    assert_eq!(index.undo_log_marker(), Some(0));
+
+    // Pre-savepoint mutation.
+    index.insert(vec![SqlValue::Integer(20)], 2).unwrap();
+
+    // Statement savepoint marker.
+    let marker = index.undo_log_marker().unwrap();
+    assert_eq!(marker, 1, "one entry recorded before the marker");
+
+    // Post-savepoint (statement) mutations.
+    index.insert(vec![SqlValue::Integer(30)], 3).unwrap();
+    index.delete(&vec![SqlValue::Integer(10)]).unwrap();
+    assert_eq!(index.lookup(&vec![SqlValue::Integer(30)]).unwrap(), vec![3]);
+    assert!(index.lookup(&vec![SqlValue::Integer(10)]).unwrap().is_empty());
+
+    // Roll back only the statement.
+    index.rollback_undo_log_to(marker).unwrap();
+
+    assert!(
+        index.lookup(&vec![SqlValue::Integer(30)]).unwrap().is_empty(),
+        "statement insert reversed"
+    );
+    assert_eq!(
+        index.lookup(&vec![SqlValue::Integer(10)]).unwrap(),
+        vec![1],
+        "statement delete restored"
+    );
+    assert_eq!(
+        index.lookup(&vec![SqlValue::Integer(20)]).unwrap(),
+        vec![2],
+        "pre-savepoint mutation preserved"
+    );
+
+    // Logging is still armed and the retained prefix is intact.
+    assert!(index.is_undo_logging(), "logging stays armed after a partial rollback");
+    assert_eq!(index.undo_log_marker(), Some(marker), "prefix retained");
+
+    // A subsequent full rollback reverses the surviving prefix too.
+    index.rollback_undo_log().unwrap();
+    assert!(
+        index.lookup(&vec![SqlValue::Integer(20)]).unwrap().is_empty(),
+        "full ROLLBACK reverses the retained prefix"
+    );
+    assert_eq!(index.lookup(&vec![SqlValue::Integer(10)]).unwrap(), vec![1]);
+}
+
+#[test]
+fn undo_log_marker_at_end_reverses_nothing() {
+    // Marking at the current tail then rolling back to it is a no-op for the
+    // tree, and keeps logging armed.
+    let (mut index, _dir) = undo_test_index(&[(10, 1)]);
+
+    index.begin_undo_logging();
+    index.insert(vec![SqlValue::Integer(20)], 2).unwrap();
+
+    let marker = index.undo_log_marker().unwrap();
+    index.rollback_undo_log_to(marker).unwrap();
+
+    assert_eq!(index.lookup(&vec![SqlValue::Integer(20)]).unwrap(), vec![2]);
+    assert!(index.is_undo_logging());
+    assert_eq!(index.undo_log_marker(), Some(marker));
+}
+
+#[test]
+fn undo_log_marker_without_logging_is_noop() {
+    // No log armed: marker is None and rollback_to does nothing.
+    let (mut index, _dir) = undo_test_index(&[(10, 1)]);
+    assert_eq!(index.undo_log_marker(), None);
+    index.insert(vec![SqlValue::Integer(20)], 2).unwrap();
+    index.rollback_undo_log_to(0).unwrap(); // no log => no-op
+    assert_eq!(index.lookup(&vec![SqlValue::Integer(20)]).unwrap(), vec![2]);
+}

--- a/crates/vibesql-storage/src/database/indexes/index_manager.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_manager.rs
@@ -196,6 +196,69 @@ impl IndexManager {
         }
     }
 
+    // ------------------------------------------------------------------------
+    // Statement-scoped nested undo markers (issue #5434)
+    //
+    // A statement-level savepoint (`RAISE(ABORT)` scope, #5431) snapshots the
+    // in-memory `Operations` wholesale, but a disk-backed tree clones as a
+    // shallow `Arc<Mutex<BTreeIndex>>` bump — the snapshot shares the *same*
+    // live spilled tree, so restoring the clone does not undo the statement's
+    // spilled-index mutations (the same class of bug #5425/#5433 fixed at
+    // transaction scope). To scope the disk undo-log to a single statement we
+    // record a *marker* (per-tree undo-log length) when the savepoint is armed
+    // and reverse only the entries appended since that marker on rollback. The
+    // retained prefix stays in the enclosing transaction's undo-log so a later
+    // full ROLLBACK still reverses pre-statement mutations.
+    // ------------------------------------------------------------------------
+
+    /// Capture a per-tree undo-log marker for every disk-backed B+ tree that is
+    /// currently undo-logging, keyed by normalized index name. Returned to the
+    /// statement savepoint, which passes it back to
+    /// [`Self::rollback_disk_undo_logs_to`] on `RAISE(ABORT)` (issue #5434).
+    ///
+    /// Trees that are not undo-logging (no enclosing transaction armed the log)
+    /// contribute no marker — there is nothing disk-backed to reverse for them.
+    pub fn mark_disk_undo_logs(&self) -> HashMap<String, usize> {
+        let mut markers = HashMap::new();
+        for (name, index_data) in &self.index_data {
+            if let IndexData::DiskBacked { btree, .. } = index_data {
+                if let Ok(guard) = acquire_btree_lock(btree) {
+                    if let Some(marker) = guard.undo_log_marker() {
+                        markers.insert(name.clone(), marker);
+                    }
+                }
+            }
+        }
+        markers
+    }
+
+    /// Reverse the undo-log suffix recorded since the markers captured by
+    /// [`Self::mark_disk_undo_logs`], restoring every spilled index to its
+    /// pre-statement state while leaving undo-logging armed for the enclosing
+    /// transaction (issue #5434 — statement-savepoint rollback).
+    ///
+    /// A tree present at mark time but missing here is reversed in full back to
+    /// its empty marker only if it has a marker entry; trees without a marker
+    /// entry (they were not disk-backed / not logging when armed) are left
+    /// untouched. A tree that began spilling *after* the marker was taken has
+    /// no entry and is handled by the wholesale in-memory snapshot restore.
+    pub fn rollback_disk_undo_logs_to(&mut self, markers: &HashMap<String, usize>) {
+        for (name, index_data) in self.index_data.iter_mut() {
+            if let IndexData::DiskBacked { btree, .. } = index_data {
+                if let Some(&marker) = markers.get(name) {
+                    if let Ok(mut guard) = acquire_btree_lock(btree) {
+                        if let Err(e) = guard.rollback_undo_log_to(marker) {
+                            log::warn!(
+                                "Failed to roll back disk-backed index undo-log to \
+                                 statement marker for '{name}': {e:?}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     /// Check if an index exists
     pub fn index_exists(&self, index_name: &str) -> bool {
         let normalized = normalize_index_name(index_name);
@@ -1048,6 +1111,175 @@ mod tests {
         assert_eq!(disk_lookup(&manager, "idx_t_id", 40), vec![1]);
         assert!(disk_lookup(&manager, "idx_t_id", 20).is_empty());
         assert!(disk_lookup(&manager, "idx_t_id", 30).is_empty());
+    }
+
+    // ========================================================================
+    // Statement-scoped disk undo markers (issue #5434 — RAISE(ABORT) scope)
+    // ========================================================================
+
+    /// #5434 core: a `RAISE(ABORT)` statement on a *spilled* (disk-backed) index
+    /// table must reverse ONLY the current statement's index-key mutations.
+    /// Mutations made by earlier statements in the same transaction (before the
+    /// statement savepoint was armed) must survive, exactly as #5431 specifies
+    /// for in-memory state.
+    #[test]
+    fn statement_marker_reverses_only_current_statement() {
+        let (mut manager, schema, _dir) = spilled_index_manager("idx_t_id", &[(10, 0)]);
+
+        // BEGIN: arm the transaction-level undo-log on disk-backed indexes.
+        manager.begin_disk_undo_logging();
+
+        // --- Statement 1 (before the statement savepoint): insert key 20. ---
+        manager.add_to_indexes_for_insert("t", &schema, &row(20), 1);
+        assert_eq!(disk_lookup(&manager, "idx_t_id", 20), vec![1]);
+
+        // --- Arm the statement savepoint (mark the disk undo-log position). ---
+        let markers = manager.mark_disk_undo_logs();
+
+        // --- Statement 2 (the aborting statement): insert 30, delete 10. ---
+        manager.add_to_indexes_for_insert("t", &schema, &row(30), 2);
+        manager.update_indexes_for_delete_with_values("t", &schema, &[SqlValue::Integer(10)], 0);
+        assert_eq!(disk_lookup(&manager, "idx_t_id", 30), vec![2]);
+        assert!(disk_lookup(&manager, "idx_t_id", 10).is_empty());
+
+        // --- RAISE(ABORT): roll back only statement 2's disk mutations. ---
+        manager.rollback_disk_undo_logs_to(&markers);
+
+        // Statement 2's mutations are reversed:
+        assert!(
+            disk_lookup(&manager, "idx_t_id", 30).is_empty(),
+            "current statement's inserted key must be reversed"
+        );
+        assert_eq!(
+            disk_lookup(&manager, "idx_t_id", 10),
+            vec![0],
+            "current statement's deleted key must be restored"
+        );
+        // Statement 1's mutation survives (it predates the savepoint):
+        assert_eq!(
+            disk_lookup(&manager, "idx_t_id", 20),
+            vec![1],
+            "prior statement's index key must NOT be reversed by RAISE(ABORT)"
+        );
+
+        // The enclosing transaction's undo-log is still armed (so an outer
+        // ROLLBACK would still reverse statement 1).
+        match manager.index_data.get("idx_t_id").unwrap() {
+            IndexData::DiskBacked { btree, .. } => {
+                assert!(
+                    acquire_btree_lock(btree).unwrap().is_undo_logging(),
+                    "undo-logging stays armed after a statement-savepoint rollback"
+                );
+            }
+            other => panic!("expected DiskBacked, got {:?}", other),
+        }
+    }
+
+    /// #5434: after a statement-savepoint rollback, a subsequent full-
+    /// transaction ROLLBACK still reverses the surviving prior-statement
+    /// mutations (the retained undo-log prefix).
+    #[test]
+    fn statement_marker_rollback_then_txn_rollback() {
+        let (mut manager, schema, _dir) = spilled_index_manager("idx_t_id", &[(10, 0)]);
+
+        manager.begin_disk_undo_logging();
+
+        // Statement 1: insert key 20 (survives the statement abort).
+        manager.add_to_indexes_for_insert("t", &schema, &row(20), 1);
+
+        // Statement savepoint + statement 2 that aborts.
+        let markers = manager.mark_disk_undo_logs();
+        manager.add_to_indexes_for_insert("t", &schema, &row(30), 2);
+        manager.rollback_disk_undo_logs_to(&markers);
+        assert_eq!(disk_lookup(&manager, "idx_t_id", 20), vec![1]);
+        assert!(disk_lookup(&manager, "idx_t_id", 30).is_empty());
+
+        // Now ROLLBACK the whole transaction: even statement 1's surviving
+        // insert must be reversed back to the pre-transaction state.
+        manager.rollback_disk_undo_logs();
+        assert!(
+            disk_lookup(&manager, "idx_t_id", 20).is_empty(),
+            "outer ROLLBACK reverses the surviving prior-statement key"
+        );
+        assert_eq!(disk_lookup(&manager, "idx_t_id", 10), vec![0]);
+    }
+
+    /// #5434: after a statement-savepoint rollback, COMMIT persists the
+    /// surviving prior-statement mutations (the retained prefix is discarded,
+    /// not reversed).
+    #[test]
+    fn statement_marker_rollback_then_txn_commit() {
+        let (mut manager, schema, _dir) = spilled_index_manager("idx_t_id", &[(10, 0)]);
+
+        manager.begin_disk_undo_logging();
+
+        manager.add_to_indexes_for_insert("t", &schema, &row(20), 1);
+
+        let markers = manager.mark_disk_undo_logs();
+        manager.add_to_indexes_for_insert("t", &schema, &row(30), 2);
+        manager.rollback_disk_undo_logs_to(&markers);
+
+        // COMMIT.
+        manager.clear_disk_undo_logs();
+
+        assert_eq!(
+            disk_lookup(&manager, "idx_t_id", 20),
+            vec![1],
+            "prior-statement insert persists on COMMIT after a statement abort"
+        );
+        assert!(
+            disk_lookup(&manager, "idx_t_id", 30).is_empty(),
+            "aborted statement's insert never persists"
+        );
+        assert_eq!(disk_lookup(&manager, "idx_t_id", 10), vec![0]);
+    }
+
+    /// #5434: a key inserted EARLIER in the same transaction (before the
+    /// statement savepoint) and re-touched by the aborting statement must keep
+    /// its pre-statement value. Here statement 1 inserts row 1 under key 50, the
+    /// aborting statement adds a duplicate row 2 under the same key; RAISE(ABORT)
+    /// must leave exactly the pre-statement row set {1}.
+    #[test]
+    fn statement_marker_preserves_prior_value_on_shared_key() {
+        let (mut manager, schema, _dir) = spilled_index_manager("idx_t_id", &[]);
+
+        manager.begin_disk_undo_logging();
+
+        // Statement 1: insert key 50 -> row 1.
+        manager.add_to_indexes_for_insert("t", &schema, &row(50), 1);
+
+        // Statement savepoint, then the aborting statement adds a duplicate.
+        let markers = manager.mark_disk_undo_logs();
+        manager.add_to_indexes_for_insert("t", &schema, &row(50), 2);
+        assert_eq!(disk_lookup(&manager, "idx_t_id", 50), vec![1, 2]);
+
+        manager.rollback_disk_undo_logs_to(&markers);
+        assert_eq!(
+            disk_lookup(&manager, "idx_t_id", 50),
+            vec![1],
+            "only the aborting statement's duplicate is removed; prior row kept"
+        );
+    }
+
+    /// #5434: `rollback_disk_undo_logs_to` with empty markers (no disk-backed
+    /// index was undo-logging at arm time) is a no-op and does not disturb the
+    /// undo-log — the wholesale in-memory snapshot handles those cases.
+    #[test]
+    fn statement_marker_empty_is_noop() {
+        let (mut manager, schema, _dir) = spilled_index_manager("idx_t_id", &[(10, 0)]);
+
+        manager.begin_disk_undo_logging();
+        manager.add_to_indexes_for_insert("t", &schema, &row(20), 1);
+
+        let empty: HashMap<String, usize> = HashMap::new();
+        manager.rollback_disk_undo_logs_to(&empty);
+
+        // Nothing reversed; the transaction undo-log is intact and a full
+        // ROLLBACK still works.
+        assert_eq!(disk_lookup(&manager, "idx_t_id", 20), vec![1]);
+        manager.rollback_disk_undo_logs();
+        assert!(disk_lookup(&manager, "idx_t_id", 20).is_empty());
+        assert_eq!(disk_lookup(&manager, "idx_t_id", 10), vec![0]);
     }
 
     // ========================================================================

--- a/crates/vibesql-storage/src/database/operations.rs
+++ b/crates/vibesql-storage/src/database/operations.rs
@@ -1540,6 +1540,20 @@ impl Operations {
         self.index_manager.clear_disk_undo_logs();
     }
 
+    /// Capture per-tree disk undo-log markers for a statement-level savepoint
+    /// (issue #5434). See [`super::indexes::IndexManager::mark_disk_undo_logs`].
+    pub fn mark_disk_undo_logs(&self) -> HashMap<String, usize> {
+        self.index_manager.mark_disk_undo_logs()
+    }
+
+    /// Reverse the disk-backed index undo-log suffix recorded since the given
+    /// statement-savepoint markers (issue #5434 — `RAISE(ABORT)` scope),
+    /// leaving the enclosing transaction's undo-log intact. See
+    /// [`super::indexes::IndexManager::rollback_disk_undo_logs_to`].
+    pub fn rollback_disk_undo_logs_to(&mut self, markers: &HashMap<String, usize>) {
+        self.index_manager.rollback_disk_undo_logs_to(markers);
+    }
+
     /// Reset the operations manager to empty state (clears all indexes).
     ///
     /// Clears all index data but preserves configuration (database path, storage backend, config).

--- a/crates/vibesql-storage/src/database/transactions.rs
+++ b/crates/vibesql-storage/src/database/transactions.rs
@@ -93,6 +93,18 @@ pub struct StatementSavepoint {
     /// Length of the deferred-FK queue at statement start, so violations
     /// queued by the aborted statement are discarded on rollback.
     deferred_fk_len: usize,
+    /// Per-tree disk undo-log markers captured at statement start (issue
+    /// #5434), keyed by normalized index name.
+    ///
+    /// The wholesale `operations` clone above shares the same live
+    /// `Arc<Mutex<BTreeIndex>>` as the spilled (disk-backed) indexes, so
+    /// restoring it is a no-op for their key mutations (the same shallow-clone
+    /// gap #5425/#5433 fixed at transaction scope). Instead, on
+    /// `RAISE(ABORT)` we reverse just the disk undo-log entries appended since
+    /// these markers — undoing the statement's spilled-index mutations while
+    /// leaving the enclosing transaction's undo-log (pre-statement mutations)
+    /// intact. Empty when no disk-backed index was undo-logging at arm time.
+    disk_undo_markers: HashMap<String, usize>,
 }
 
 /// Transaction state
@@ -760,6 +772,10 @@ impl TransactionManager {
                     operations: operations.clone(),
                     changes_len: changes.len(),
                     deferred_fk_len: deferred_fk_violations.len(),
+                    // #5434: snapshot per-tree disk undo-log positions so a
+                    // RAISE(ABORT) reverses only this statement's spilled-index
+                    // mutations, not earlier ones in the same transaction.
+                    disk_undo_markers: operations.mark_disk_undo_logs(),
                 }));
                 true
             }
@@ -784,6 +800,18 @@ impl TransactionManager {
                 statement_savepoint, changes, deferred_fk_violations, ..
             } => match statement_savepoint.take() {
                 Some(sp) => {
+                    // #5434: reverse this statement's disk-backed (spilled)
+                    // index mutations *before* swapping in the wholesale
+                    // snapshot — mirroring `rollback_transaction`'s ordering.
+                    // The snapshot's `operations` clone shares the same live
+                    // `Arc<Mutex<BTreeIndex>>` as the spilled indexes, so the
+                    // clone restore is a no-op for them; reversing the undo-log
+                    // suffix on the live `operations` reverts the shared B+ tree
+                    // back to its pre-statement state, and the prefix (earlier
+                    // statements' mutations) stays in the enclosing txn's
+                    // undo-log for a potential outer ROLLBACK. No-op when no
+                    // disk-backed index was undo-logging at arm time.
+                    operations.rollback_disk_undo_logs_to(&sp.disk_undo_markers);
                     *catalog = sp.catalog;
                     *tables = sp.tables;
                     *operations = sp.operations;


### PR DESCRIPTION
## Summary

Closes #5434.

#5431 added a statement-level savepoint (the `RAISE(ABORT)` scope) that snapshots `Operations` **wholesale** (`*operations = sp.operations` clone). But `IndexData::DiskBacked` clones as a **shallow `Arc<Mutex<BTreeIndex>>` bump** — the snapshot shares the *same live spilled B+ tree* as the statement, so restoring the clone is a **no-op for spilled (disk-backed) indexes**. A `RAISE(ABORT)` on a table whose index has spilled to disk therefore did **not** undo that statement's spilled-index key mutations (index/row divergence). This is exactly the shallow-clone gap #5425/#5433 fixed at *transaction* scope, here at *statement* scope.

## Design: statement-scoped disk-undo marker (the #5433 follow-on gap)

The txn-level disk undo-log (`begin/rollback/clear_disk_undo_logs`) is armed at the COW chokepoint on the live shared trees and reversed at txn ROLLBACK. For statement savepoints we add a **nested undo marker** into that same per-tree log:

- **arm**: `arm_statement_savepoint` records each disk-backed tree's current undo-log length (`mark_disk_undo_logs` → `HashMap<index_name, usize>`), stored on `StatementSavepoint.disk_undo_markers`.
- **rollback** (`RAISE(ABORT)`): `rollback_statement_savepoint` calls `rollback_disk_undo_logs_to(&markers)` **before** swapping in the wholesale in-memory snapshot — mirroring the ordering `rollback_transaction` already uses (reverse disk undo-log, then restore snapshot). It reverses only the undo-log **suffix** recorded since the marker (LIFO), restoring the spilled tree to its pre-statement state, while **keeping logging armed** and **retaining the prefix** (pre-statement mutations) in the enclosing txn's undo-log.
- **release**: keeps the entries — they remain owned by the enclosing txn's undo-log for COMMIT (discard) or an outer ROLLBACK (full reverse).

Because the snapshot's `operations` clone re-points at the *same* (now-reverted) `Arc<Mutex<BTreeIndex>>`, the wholesale restore then handles the in-memory indexes while the live disk trees are already correct.

### Layers

| Layer | Added |
|---|---|
| `BTreeIndex` | `undo_log_marker()`, `rollback_undo_log_to(marker)` (suffix reverse via shared `replay_inverses` helper; `rollback_undo_log` now delegates to it) |
| `IndexManager` | `mark_disk_undo_logs()`, `rollback_disk_undo_logs_to(&markers)` |
| `Operations` | thin wrappers |
| `StatementSavepoint` | `disk_undo_markers` field; capture at arm; reverse-suffix-then-snapshot on rollback |

No executor changes: the existing `arm/rollback_statement_savepoint` API signatures are unchanged — the marker is captured/used internally from the `operations` argument already threaded by #5431's `raise_scope.rs`. Storage-only.

## Verification — only the current statement is reversed

`statement_marker_reverses_only_current_statement` (index-manager, real maintenance entry points + `spill_index_to_disk`):
- Statement 1 inserts key 20; **arm** marker; statement 2 inserts 30, deletes 10; `rollback_disk_undo_logs_to(markers)`.
- 30 reversed, 10 restored (current statement undone) — **20 survives** (prior statement NOT reversed), and undo-logging stays armed.

`statement_marker_preserves_prior_value_on_shared_key`: a key inserted *before* the savepoint and re-touched (duplicate row) by the aborting statement keeps exactly its pre-statement row set.

Then:
- `statement_marker_rollback_then_txn_commit`: COMMIT after a statement abort persists the surviving prior-statement key.
- `statement_marker_rollback_then_txn_rollback`: an outer ROLLBACK still reverses the surviving prefix.
- `statement_marker_empty_is_noop`: empty markers (no disk-backed index logging at arm) are a no-op; full ROLLBACK still works.

BTree-level: `undo_log_marker_reverses_only_suffix`, `undo_log_marker_at_end_reverses_nothing`, `undo_log_marker_without_logging_is_noop`.

## Test plan / results

- [x] new btree marker tests (3) green
- [x] new statement-scope index-manager tests (5) green
- [x] `cargo test -p vibesql-storage` — 692 lib tests pass (default features)
- [x] `cargo test -p vibesql-storage --features mvcc_enabled` — 701 lib tests pass
- [x] `cargo test -p vibesql-executor` — all pass (RAISE(ABORT) #5431 unaffected)
- [x] regression: #5425/#5433 txn-level disk undo tests + #5431 in-memory statement-savepoint tests still pass
- [x] clippy clean on new code

## Follow-ons

- None blocking. The marker map is keyed by index name; if a future change renames indexes mid-transaction the marker key would need rekeying — not currently possible inside a txn. Could add an end-to-end SQL-level integration test (trigger firing `RAISE(ABORT)` on a forced-spilled table) once a convenient harness exists; the unit tests already exercise the spilled path via `spill_index_to_disk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)