### PR TITLE
fix(executor): INSTEAD OF trigger WHEN clauses on views (#5438)

### DIFF
--- a/crates/vibesql-executor/src/tests/raise_trigger_tests.rs
+++ b/crates/vibesql-executor/src/tests/raise_trigger_tests.rs
@@ -592,14 +592,14 @@ fn instead_of_insert_without_ignore_writes_base() {
     assert_eq!(ints(&db, "base", "v"), vec![10]);
 }
 
-// NOTE: the INSTEAD OF UPDATE/DELETE tests below use a single, *unconditional*
-// trigger (no trigger-level WHEN clause). VibeSQL has a pre-existing limitation
-// where an INSTEAD OF trigger's WHEN condition cannot be evaluated on a view —
-// `evaluate_when_condition` resolves the schema via `catalog.get_table`, which
-// returns None for a view, yielding `TableNotFound`. That gap is independent of
-// #5418 (SkipRow plumbing) and is tracked as a separate follow-on. The
-// unconditional form still exercises the INSTEAD OF SkipRow path: a
-// `SELECT raise(IGNORE)` placed before the base write abandons the operation.
+// NOTE: the INSTEAD OF UPDATE/DELETE tests immediately below use a single,
+// *unconditional* trigger (no trigger-level WHEN clause). They exercise the
+// INSTEAD OF SkipRow path: a `SELECT raise(IGNORE)` placed before the base
+// write abandons the operation. INSTEAD OF triggers that *do* carry a WHEN
+// clause are covered separately in the "INSTEAD OF + WHEN clause (#5438)"
+// section further down — previously such triggers failed with TableNotFound
+// because `evaluate_when_condition` resolved the schema via `catalog.get_table`
+// (None for a view); they now fall back to the view pseudo-schema.
 
 /// INSTEAD OF UPDATE: RAISE(IGNORE) before the base UPDATE abandons the view
 /// update, so the base table is not written.
@@ -695,6 +695,126 @@ fn instead_of_delete_without_ignore_deletes_base() {
     exec_dml(&mut db, "DELETE FROM vw").expect("INSTEAD OF DELETE must succeed");
 
     assert!(db.get_table("base").unwrap().scan().is_empty());
+}
+
+// ===========================================================================
+// INSTEAD OF + WHEN clause (#5438)
+//
+// An INSTEAD OF trigger (on a VIEW) that carries a `WHEN` condition previously
+// failed with `TableNotFound`: `evaluate_when_condition` resolved the OLD/NEW
+// schema via `catalog.get_table`, which returns None for a view. The fix
+// mirrors the trigger-body path — when the target is a view, the schema is
+// built from the view definition (`resolve_trigger_schema`). The WHEN clause
+// is evaluated against the NEW/OLD pseudo-rows, and the trigger fires only when
+// the condition is true (skipped otherwise), matching sqlite3 3.51.x.
+//
+// sqlite3 3.51.0, INSTEAD OF UPDATE ON vw WHEN OLD.id = 1 over rows (1,10),(2,20)
+// after `UPDATE vw SET v = 999`: row id=1 -> v=999, row id=2 -> v=20 (skipped).
+// ===========================================================================
+
+/// INSTEAD OF UPDATE with `WHEN OLD.id = 1`: the trigger body fires only for the
+/// row whose OLD.id is 1; the other row is left untouched (WHEN false skips it).
+#[test]
+fn instead_of_update_when_old_fires_selectively() {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE base (id INTEGER, v INTEGER)");
+    exec_ok(&mut db, "INSERT INTO base (id, v) VALUES (1, 10)");
+    exec_ok(&mut db, "INSERT INTO base (id, v) VALUES (2, 20)");
+    exec_ok(&mut db, "CREATE VIEW vw AS SELECT id, v FROM base");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg INSTEAD OF UPDATE ON vw WHEN OLD.id = 1 \
+         BEGIN \
+           UPDATE base SET v = NEW.v WHERE id = OLD.id; \
+         END",
+    );
+
+    // Reproduces the original bug report: this used to error with
+    // TableNotFound("vw").
+    exec_dml(&mut db, "UPDATE vw SET v = 999")
+        .expect("INSTEAD OF UPDATE with WHEN must not error on a view");
+
+    // Only the WHEN-true row (id=1) had its body fire; id=2 is unchanged.
+    assert_eq!(ints(&db, "base", "id"), vec![1, 2]);
+    assert_eq!(ints(&db, "base", "v"), vec![999, 20]);
+}
+
+/// INSTEAD OF INSERT with `WHEN NEW.v > 0`: the body fires for the positive row
+/// and is skipped for the non-positive row (matching sqlite3 — a WHEN-false
+/// INSTEAD OF INSERT performs no base write either).
+#[test]
+fn instead_of_insert_when_new_fires_selectively() {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE base (id INTEGER, v INTEGER)");
+    exec_ok(&mut db, "CREATE VIEW vw AS SELECT id, v FROM base");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg INSTEAD OF INSERT ON vw WHEN NEW.v > 0 \
+         BEGIN \
+           INSERT INTO base (id, v) VALUES (NEW.id, NEW.v); \
+         END",
+    );
+
+    exec_dml(&mut db, "INSERT INTO vw (id, v) VALUES (1, 10)")
+        .expect("INSTEAD OF INSERT with WHEN must not error on a view");
+    exec_dml(&mut db, "INSERT INTO vw (id, v) VALUES (2, -5)")
+        .expect("WHEN-false INSTEAD OF INSERT must not error");
+
+    // Only the WHEN-true insert (v=10) reached the base table.
+    assert_eq!(ints(&db, "base", "id"), vec![1]);
+    assert_eq!(ints(&db, "base", "v"), vec![10]);
+}
+
+/// INSTEAD OF DELETE with `WHEN OLD.v > 15`: only the row whose OLD.v exceeds 15
+/// is deleted from the base table; the other view row is skipped.
+#[test]
+fn instead_of_delete_when_old_fires_selectively() {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE base (id INTEGER, v INTEGER)");
+    exec_ok(&mut db, "INSERT INTO base (id, v) VALUES (1, 10)");
+    exec_ok(&mut db, "INSERT INTO base (id, v) VALUES (2, 20)");
+    exec_ok(&mut db, "CREATE VIEW vw AS SELECT id, v FROM base");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg INSTEAD OF DELETE ON vw WHEN OLD.v > 15 \
+         BEGIN \
+           DELETE FROM base WHERE id = OLD.id; \
+         END",
+    );
+
+    exec_dml(&mut db, "DELETE FROM vw")
+        .expect("INSTEAD OF DELETE with WHEN must not error on a view");
+
+    // Only id=2 (v=20 > 15) was deleted; id=1 (v=10) survives. Asserted through
+    // the live SELECT path — `Table::scan()` still surfaces tombstoned rows, so
+    // a deletion check must read via SELECT (matches sqlite3 3.51.0: `1|10`).
+    assert_eq!(
+        select_rows(&db, "SELECT id, v FROM base ORDER BY id"),
+        vec![vec![SqlValue::Integer(1), SqlValue::Integer(10)]],
+    );
+}
+
+/// Regression guard for the get_table path: a WHEN clause on a *base-table*
+/// trigger must still work (the view fallback must not disturb real tables).
+#[test]
+fn base_table_trigger_when_clause_still_works() {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE t (id INTEGER, v INTEGER)");
+    exec_ok(&mut db, "CREATE TABLE log (id INTEGER, v INTEGER)");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER trg AFTER INSERT ON t WHEN NEW.v > 0 \
+         BEGIN \
+           INSERT INTO log (id, v) VALUES (NEW.id, NEW.v); \
+         END",
+    );
+
+    exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (1, 10)").expect("base insert ok");
+    exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (2, -5)").expect("base insert ok");
+
+    // log only captured the WHEN-true insert.
+    assert_eq!(ints(&db, "log", "id"), vec![1]);
+    assert_eq!(ints(&db, "log", "v"), vec![10]);
 }
 
 // ===========================================================================

--- a/crates/vibesql-executor/src/trigger_execution.rs
+++ b/crates/vibesql-executor/src/trigger_execution.rs
@@ -263,11 +263,13 @@ impl TriggerFirer {
         old_row: Option<&Row>,
         new_row: Option<&Row>,
     ) -> Result<bool, ExecutorError> {
-        // Get table schema
-        let schema = db
-            .catalog
-            .get_table(table_name)
-            .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+        // Resolve the schema for OLD/NEW column resolution. For a normal table
+        // trigger this is the base table's schema. For an INSTEAD OF trigger the
+        // target is a VIEW (views are not tables, so `get_table` returns None),
+        // in which case we build a pseudo-schema from the view definition —
+        // mirroring `execute_trigger_action`. Without this fallback, an INSTEAD
+        // OF trigger carrying a WHEN clause always failed with TableNotFound.
+        let schema = Self::resolve_trigger_schema(db, table_name)?;
 
         // Use NEW row as the base row for evaluation (prefer NEW over OLD)
         // The trigger context will handle OLD/NEW pseudo-variable references
@@ -278,11 +280,11 @@ impl TriggerFirer {
         })?;
 
         // Create trigger context for OLD/NEW pseudo-variable resolution
-        let trigger_context = TriggerContext { old_row, new_row, table_schema: schema };
+        let trigger_context = TriggerContext { old_row, new_row, table_schema: &schema };
 
         // Create evaluator with trigger context
         let evaluator =
-            crate::ExpressionEvaluator::with_trigger_context(schema, db, &trigger_context);
+            crate::ExpressionEvaluator::with_trigger_context(&schema, db, &trigger_context);
         let result = evaluator.eval(when_expr, row)?;
 
         // Convert to boolean
@@ -319,16 +321,9 @@ impl TriggerFirer {
         // Parse the trigger action SQL
         let statements = Self::parse_trigger_sql(&sql)?;
 
-        // Get table schema for trigger context (clone to avoid borrow checker issues)
-        // For INSTEAD OF triggers on views, build schema from the view definition
-        let schema = if let Some(table_schema) = db.catalog.get_table(&trigger.table_name) {
-            table_schema.clone()
-        } else if let Some(view_def) = db.catalog.get_view(&trigger.table_name) {
-            // Build a pseudo-schema from the view for OLD/NEW column resolution
-            Self::build_view_schema(db, view_def)?
-        } else {
-            return Err(ExecutorError::TableNotFound(trigger.table_name.clone()));
-        };
+        // Get table schema for trigger context.
+        // For INSTEAD OF triggers on views, build schema from the view definition.
+        let schema = Self::resolve_trigger_schema(db, &trigger.table_name)?;
 
         // Create trigger context for OLD/NEW pseudo-variable resolution
         let trigger_context = TriggerContext { old_row, new_row, table_schema: &schema };
@@ -346,6 +341,27 @@ impl TriggerFirer {
         }
 
         Ok(TriggerOutcome::Proceed)
+    }
+
+    /// Resolve the schema used for OLD/NEW column resolution when a trigger fires.
+    ///
+    /// For a regular table trigger this is the base table's schema. For an
+    /// INSTEAD OF trigger the target is a VIEW — views are not tables, so
+    /// `catalog.get_table` returns None and we fall back to a pseudo-schema
+    /// built from the view definition. The schema is returned by value (owned)
+    /// because the view path constructs it on the fly; the base-table path
+    /// clones the catalog entry.
+    fn resolve_trigger_schema(
+        db: &Database,
+        table_name: &str,
+    ) -> Result<TableSchema, ExecutorError> {
+        if let Some(table_schema) = db.catalog.get_table(table_name) {
+            Ok(table_schema.clone())
+        } else if let Some(view_def) = db.catalog.get_view(table_name) {
+            Self::build_view_schema(db, view_def)
+        } else {
+            Err(ExecutorError::TableNotFound(table_name.to_string()))
+        }
     }
 
     /// Build a pseudo TableSchema from a view definition for trigger OLD/NEW column resolution


### PR DESCRIPTION
Closes #5438

## Root cause
`TriggerFirer::evaluate_when_condition` resolved the OLD/NEW schema via
`db.catalog.get_table(table_name)`, which returns `None` for a view name.
Because INSTEAD OF triggers exist only for views, any INSTEAD OF trigger with a
`WHEN` clause always failed with `ExecutorError::TableNotFound(view_name)`.

The trigger-*body* path (`execute_trigger_action`) already handled this via
`build_view_schema` (added in #5436), but the WHEN-condition path did not — so
PR #5436's INSTEAD OF tests deliberately used unconditional triggers to dodge
this gap.

## Fix
Extracted the schema resolution into `resolve_trigger_schema`:
`get_table` -> `get_view` -> `build_view_schema`. Both the WHEN-condition path
and the trigger-body path now share it. The WHEN expression evaluates against
the NEW/OLD pseudo-rows using the view's column schema. The base-table
`get_table` path is unchanged (a real table still resolves to its own schema).

Diff is scoped to the WHEN-condition view-resolution path plus a refactor that
de-duplicates the already-present body path.

## sqlite3 3.51.0 verification
```
-- INSTEAD OF UPDATE ON vw WHEN OLD.id = 1, base rows (1,10),(2,20)
UPDATE vw SET v = 999;        -- => 1|999, 2|20  (id=2 skipped: WHEN false)

-- INSTEAD OF INSERT ON vw WHEN NEW.v > 0
INSERT INTO vw VALUES(1,10);  -- inserted
INSERT INTO vw VALUES(2,-5);  -- skipped, no base write (matches sqlite3)

-- INSTEAD OF DELETE ON vw WHEN OLD.v > 15, base rows (1,10),(2,20)
DELETE FROM vw;               -- => 1|10  (only v=20>15 deleted)
```
VibeSQL now matches all three.

## Tests
New tests in `crates/vibesql-executor/src/tests/raise_trigger_tests.rs`:
- `instead_of_update_when_old_fires_selectively` (reproduces the original bug report)
- `instead_of_insert_when_new_fires_selectively`
- `instead_of_delete_when_old_fires_selectively` (reads via live `SELECT`, since `Table::scan()` surfaces tombstoned rows)
- `base_table_trigger_when_clause_still_works` (regression guard for the `get_table` path)

Regression of #5436's INSTEAD-OF SkipRow tests still green.

## Test plan
- [x] `cargo test -p vibesql-executor` — 2701 passed, 0 failed
- [x] All 19 `instead_of` tests pass, incl. the 4 new ones
- [x] `view.test` TCL: 24/24 passed, 0 failed (no regression)
- [x] sqlite3 3.51.0 parity confirmed for INSERT/UPDATE/DELETE WHEN cases

## Follow-ons
- The trigger TCL files (`trigger1..9.test`) extract 0 tests under the static-parse harness here (pre-existing harness limitation, unrelated to this change). Worth a separate issue to enable native-TCL execution for trigger conformance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)