### PR TITLE
fix(server): gate GraphQL legacy raw-WHERE escape hatch behind opt-in flag

### DIFF
--- a/crates/vibesql-server/benches/sysbench_server.rs
+++ b/crates/vibesql-server/benches/sysbench_server.rs
@@ -100,6 +100,7 @@ async fn start_vibesql_server(
             ssl_enabled: false,
             ssl_cert: None,
             ssl_key: None,
+            graphql_allow_raw_where: false,
         },
         auth: AuthConfig { method: "trust".to_string(), password_file: None },
         logging: LoggingConfig { level: "error".to_string(), file: None },

--- a/crates/vibesql-server/benches/tpcc_server.rs
+++ b/crates/vibesql-server/benches/tpcc_server.rs
@@ -164,6 +164,7 @@ async fn start_vibesql_server_with_db(
             ssl_enabled: false,
             ssl_cert: None,
             ssl_key: None,
+            graphql_allow_raw_where: false,
         },
         auth: AuthConfig { method: "trust".to_string(), password_file: None },
         logging: LoggingConfig { level: "error".to_string(), file: None },

--- a/crates/vibesql-server/benches/tpch_server.rs
+++ b/crates/vibesql-server/benches/tpch_server.rs
@@ -154,6 +154,7 @@ async fn start_vibesql_server_with_db(
             ssl_enabled: false,
             ssl_cert: None,
             ssl_key: None,
+            graphql_allow_raw_where: false,
         },
         auth: AuthConfig { method: "trust".to_string(), password_file: None },
         logging: LoggingConfig { level: "error".to_string(), file: None },

--- a/crates/vibesql-server/src/config.rs
+++ b/crates/vibesql-server/src/config.rs
@@ -67,6 +67,28 @@ pub struct ServerConfig {
     pub ssl_cert: Option<PathBuf>,
     /// SSL key file path
     pub ssl_key: Option<PathBuf>,
+    /// Allow the legacy GraphQL `where: "<raw sql>"` escape hatch
+    /// (default: false).
+    ///
+    /// # Security
+    ///
+    /// The GraphQL surface accepts two WHERE forms. The structured form —
+    /// `where: { ... }` — parameterizes every value and escapes every
+    /// identifier, so it is injection-safe. The legacy raw form —
+    /// `where: "<raw sql>"` — interpolates the client-supplied string
+    /// **verbatim** into the generated SQL with no parameterization or
+    /// escaping. That is a SQL-injection surface: any client that can reach
+    /// the GraphQL endpoint can splice arbitrary SQL into the WHERE clause.
+    ///
+    /// This flag is therefore **off by default**. When disabled, a query
+    /// that supplies a raw-string WHERE is rejected with a clear error and
+    /// **no SQL is executed**; clients should migrate to the structured
+    /// form, which covers the common comparison, string, list, null, and
+    /// AND/OR/NOT cases. When explicitly enabled, the raw form works as
+    /// before — an operator turning this on is consciously accepting the
+    /// trusted-input-only risk for that endpoint.
+    #[serde(default)]
+    pub graphql_allow_raw_where: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -197,6 +219,7 @@ impl Default for Config {
                 ssl_enabled: false,
                 ssl_cert: None,
                 ssl_key: None,
+                graphql_allow_raw_where: false,
             },
             auth: AuthConfig { method: "trust".to_string(), password_file: None },
             logging: LoggingConfig { level: "info".to_string(), file: None },
@@ -260,6 +283,7 @@ impl Config {
     /// | `VIBESQL_SERVER_SSL_ENABLED` | `server.ssl_enabled` |
     /// | `VIBESQL_SERVER_SSL_CERT` | `server.ssl_cert` |
     /// | `VIBESQL_SERVER_SSL_KEY` | `server.ssl_key` |
+    /// | `VIBESQL_SERVER_GRAPHQL_ALLOW_RAW_WHERE` | `server.graphql_allow_raw_where` |
     /// | `VIBESQL_AUTH_METHOD` | `auth.method` |
     /// | `VIBESQL_AUTH_PASSWORD_FILE` | `auth.password_file` |
     /// | `VIBESQL_LOG_LEVEL` | `logging.level` |
@@ -302,6 +326,9 @@ impl Config {
         }
         if let Ok(val) = env::var("VIBESQL_SERVER_SSL_KEY") {
             self.server.ssl_key = Some(PathBuf::from(val));
+        }
+        if let Ok(val) = env::var("VIBESQL_SERVER_GRAPHQL_ALLOW_RAW_WHERE") {
+            self.server.graphql_allow_raw_where = parse_bool(&val);
         }
 
         // Auth configuration
@@ -422,6 +449,65 @@ mod tests {
         assert_eq!(config.server.max_connections, 100);
         assert!(!config.server.ssl_enabled);
         assert_eq!(config.auth.method, "trust");
+    }
+
+    #[test]
+    fn test_graphql_allow_raw_where_defaults_off() {
+        // The legacy raw-WHERE escape hatch must be opt-in (#5448).
+        let config = Config::default();
+        assert!(!config.server.graphql_allow_raw_where);
+    }
+
+    #[test]
+    fn test_graphql_allow_raw_where_from_toml() {
+        let toml_str = r#"
+[server]
+host = "0.0.0.0"
+port = 5432
+max_connections = 100
+ssl_enabled = false
+graphql_allow_raw_where = true
+
+[auth]
+method = "trust"
+
+[logging]
+level = "info"
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert!(config.server.graphql_allow_raw_where);
+    }
+
+    #[test]
+    fn test_graphql_allow_raw_where_toml_default_when_absent() {
+        // Omitting the field must fall back to the safe default (off).
+        let toml_str = r#"
+[server]
+host = "0.0.0.0"
+port = 5432
+max_connections = 100
+ssl_enabled = false
+
+[auth]
+method = "trust"
+
+[logging]
+level = "info"
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert!(!config.server.graphql_allow_raw_where);
+    }
+
+    #[test]
+    fn test_env_override_graphql_allow_raw_where() {
+        let _lock = ENV_TEST_MUTEX.lock().unwrap();
+        let mut config = Config::default();
+        assert!(!config.server.graphql_allow_raw_where);
+
+        env::set_var("VIBESQL_SERVER_GRAPHQL_ALLOW_RAW_WHERE", "true");
+        config.apply_env_overrides();
+        assert!(config.server.graphql_allow_raw_where);
+        env::remove_var("VIBESQL_SERVER_GRAPHQL_ALLOW_RAW_WHERE");
     }
 
     #[test]

--- a/crates/vibesql-server/src/http/graphql/parser.rs
+++ b/crates/vibesql-server/src/http/graphql/parser.rs
@@ -459,9 +459,40 @@ fn extract_where_clauses(query: &str) -> Result<(Option<WhereClause>, Option<Str
     }
 }
 
-/// Convert GraphQL query info to SQL (simple version without relationships)
+/// Error returned when a query uses the legacy raw-string WHERE clause while
+/// the raw-WHERE escape hatch is disabled (the default). Surfaced to the
+/// client verbatim; no SQL is generated or executed.
+pub const RAW_WHERE_DISABLED_ERROR: &str =
+    "raw where clause is disabled; enable server.graphql_allow_raw_where \
+     (env VIBESQL_SERVER_GRAPHQL_ALLOW_RAW_WHERE) or use the structured \
+     where: { ... } form";
+
+/// Render the SQL fragment for a legacy raw-string WHERE clause, or reject it
+/// when the raw-WHERE escape hatch is disabled.
+///
+/// The raw string is interpolated **verbatim** — it is an explicit,
+/// trusted-input-only SQL-injection surface (see
+/// [`crate::config::ServerConfig::graphql_allow_raw_where`]). When
+/// `allow_raw_where` is false (the default) this returns
+/// [`RAW_WHERE_DISABLED_ERROR`] and the caller emits no SQL.
+fn render_raw_where(raw_where: &str, allow_raw_where: bool) -> Result<String, String> {
+    if allow_raw_where {
+        Ok(format!(" WHERE {}", raw_where))
+    } else {
+        Err(RAW_WHERE_DISABLED_ERROR.to_string())
+    }
+}
+
+/// Convert GraphQL query info to SQL (simple version without relationships).
+///
+/// `allow_raw_where` gates the legacy `where: "<raw sql>"` escape hatch. When
+/// false (the default), any query that supplies a raw-string WHERE is rejected
+/// with [`RAW_WHERE_DISABLED_ERROR`] and **no SQL is produced** — see
+/// [`crate::config::ServerConfig::graphql_allow_raw_where`]. The structured
+/// `where: { ... }` form is unaffected by this flag.
 pub fn graphql_to_sql(
     query_info: &GraphQLQueryInfo,
+    allow_raw_where: bool,
 ) -> Result<(String, Vec<vibesql_types::SqlValue>), String> {
     match query_info {
         GraphQLQueryInfo::Query {
@@ -488,8 +519,8 @@ pub fn graphql_to_sql(
                 let where_sql = where_clause_to_sql(clause, &mut params)?;
                 sql.push_str(&format!(" WHERE {}", where_sql));
             } else if let Some(raw_where) = where_clause_raw {
-                // Fall back to raw WHERE clause (legacy)
-                sql.push_str(&format!(" WHERE {}", raw_where));
+                // Fall back to raw WHERE clause (legacy, gated escape hatch).
+                sql.push_str(&render_raw_where(raw_where, allow_raw_where)?);
             }
 
             if let Some(limit) = limit {
@@ -569,8 +600,8 @@ pub fn graphql_to_sql(
                             let where_sql = where_clause_to_sql(clause, &mut params)?;
                             sql.push_str(&format!(" WHERE {}", where_sql));
                         } else if let Some(raw_where) = where_clause_raw {
-                            // Fall back to raw WHERE clause (legacy)
-                            sql.push_str(&format!(" WHERE {}", raw_where));
+                            // Fall back to raw WHERE clause (legacy, gated).
+                            sql.push_str(&render_raw_where(raw_where, allow_raw_where)?);
                         }
 
                         Ok((sql, params))
@@ -587,8 +618,8 @@ pub fn graphql_to_sql(
                         let where_sql = where_clause_to_sql(clause, &mut params)?;
                         sql.push_str(&format!(" WHERE {}", where_sql));
                     } else if let Some(raw_where) = where_clause_raw {
-                        // Fall back to raw WHERE clause (legacy)
-                        sql.push_str(&format!(" WHERE {}", raw_where));
+                        // Fall back to raw WHERE clause (legacy, gated).
+                        sql.push_str(&render_raw_where(raw_where, allow_raw_where)?);
                     } else {
                         return Err("DELETE requires WHERE clause".to_string());
                     }
@@ -600,12 +631,18 @@ pub fn graphql_to_sql(
     }
 }
 
-/// Generate SQL for the main query (without JOINs - we'll use separate queries for nested data)
+/// Generate SQL for the main query (without JOINs - we'll use separate queries
+/// for nested data).
+///
+/// `allow_raw_where` is forwarded to [`graphql_to_sql`]; see that function and
+/// [`crate::config::ServerConfig::graphql_allow_raw_where`] for the legacy
+/// raw-WHERE gating semantics.
 pub fn generate_main_query_sql(
     query_info: &GraphQLQueryInfo,
+    allow_raw_where: bool,
 ) -> Result<(String, Vec<vibesql_types::SqlValue>), String> {
     // Just delegate to the simple version for the main query
-    graphql_to_sql(query_info)
+    graphql_to_sql(query_info, allow_raw_where)
 }
 
 /// Check if a query has nested fields that need relationship resolution
@@ -694,7 +731,8 @@ mod tests {
     fn test_graphql_to_sql_with_structured_where() {
         let query = r#"{ users(where: {"age": {"gte": 18}, "status": "active"}) { id, name } }"#;
         let result = parse_graphql_query(query).unwrap();
-        let (sql, params) = graphql_to_sql(&result).unwrap();
+        // Structured WHERE works regardless of the raw-WHERE flag (here: off).
+        let (sql, params) = graphql_to_sql(&result, false).unwrap();
         // Check key parts are present (order may vary due to HashMap)
         assert!(sql.starts_with("SELECT"), "SQL should start with SELECT");
         assert!(sql.contains("FROM users"), "SQL should contain 'FROM users'");
@@ -708,7 +746,7 @@ mod tests {
     fn test_graphql_to_sql_with_or() {
         let query = r#"{ users(where: {"OR": [{"name": {"contains": "john"}}, {"email": {"endsWith": "@test.com"}}]}) { id, name } }"#;
         let result = parse_graphql_query(query).unwrap();
-        let (sql, _) = graphql_to_sql(&result).unwrap();
+        let (sql, _) = graphql_to_sql(&result, false).unwrap();
         assert!(sql.contains("OR"));
     }
 
@@ -716,9 +754,80 @@ mod tests {
     fn test_graphql_with_limit_offset() {
         let query = r#"{ users(limit: 10, offset: 20) { id, name } }"#;
         let result = parse_graphql_query(query).unwrap();
-        let (sql, _) = graphql_to_sql(&result).unwrap();
+        let (sql, _) = graphql_to_sql(&result, false).unwrap();
         assert!(sql.contains("LIMIT 10"));
         assert!(sql.contains("OFFSET 20"));
+    }
+
+    // --- Raw-WHERE escape-hatch gating (#5448) ---------------------------
+
+    /// With the flag OFF (the default), a SELECT using the legacy raw-string
+    /// WHERE is rejected and produces no SQL.
+    #[test]
+    fn test_raw_where_select_rejected_when_disabled() {
+        let query = r#"{ users(where: "id = 1 OR 1=1") { id, name } }"#;
+        let result = parse_graphql_query(query).unwrap();
+        let err = graphql_to_sql(&result, false).unwrap_err();
+        assert_eq!(err, RAW_WHERE_DISABLED_ERROR);
+    }
+
+    /// With the flag ON, the raw-string WHERE is applied verbatim (legacy
+    /// behavior; the operator has accepted the trusted-input risk).
+    #[test]
+    fn test_raw_where_select_applied_when_enabled() {
+        let query = r#"{ users(where: "id = 1") { id, name } }"#;
+        let result = parse_graphql_query(query).unwrap();
+        let (sql, params) = graphql_to_sql(&result, true).unwrap();
+        assert!(sql.contains("WHERE id = 1"), "raw WHERE should be applied: {sql}");
+        assert!(params.is_empty(), "raw WHERE produces no bound params");
+    }
+
+    /// The injection payload reaches the generated SQL verbatim only when the
+    /// flag is ON — demonstrating both why it is dangerous and that the
+    /// default-off gate closes the surface.
+    #[test]
+    fn test_raw_where_injection_surface_gated() {
+        let query = r#"{ users(where: "1=1; DROP TABLE users") { id } }"#;
+        let result = parse_graphql_query(query).unwrap();
+        // OFF: rejected, no SQL.
+        assert_eq!(graphql_to_sql(&result, false).unwrap_err(), RAW_WHERE_DISABLED_ERROR);
+        // ON: interpolated verbatim (the documented trusted-input risk).
+        let (sql, _) = graphql_to_sql(&result, true).unwrap();
+        assert!(sql.contains("DROP TABLE users"));
+    }
+
+    /// A DELETE using raw WHERE is rejected when disabled (no SQL), applied
+    /// when enabled.
+    #[test]
+    fn test_raw_where_delete_gating() {
+        let query = r#"mutation { delete(table: "users", where: "id = 5") { id } }"#;
+        let result = parse_graphql_query(query).unwrap();
+        assert_eq!(graphql_to_sql(&result, false).unwrap_err(), RAW_WHERE_DISABLED_ERROR);
+        let (sql, _) = graphql_to_sql(&result, true).unwrap();
+        assert!(sql.starts_with("DELETE FROM users"), "got: {sql}");
+        assert!(sql.contains("WHERE id = 5"), "got: {sql}");
+    }
+
+    /// Structured WHERE is unaffected by the flag: it works with the gate both
+    /// off and on, never depending on the escape hatch.
+    #[test]
+    fn test_structured_where_unaffected_by_flag() {
+        let query = r#"{ users(where: {"id": {"eq": 1}}) { id, name } }"#;
+        let result = parse_graphql_query(query).unwrap();
+        for allow_raw in [false, true] {
+            let (sql, params) = graphql_to_sql(&result, allow_raw).unwrap();
+            assert!(sql.contains("WHERE id = $1"), "structured WHERE should parameterize: {sql}");
+            assert_eq!(params.len(), 1);
+        }
+    }
+
+    /// A query with no WHERE at all is unaffected by the flag.
+    #[test]
+    fn test_no_where_unaffected_by_flag() {
+        let query = r#"{ users { id, name } }"#;
+        let result = parse_graphql_query(query).unwrap();
+        let (sql, _) = graphql_to_sql(&result, false).unwrap();
+        assert!(!sql.contains("WHERE"));
     }
 
     #[test]

--- a/crates/vibesql-server/src/http/rest.rs
+++ b/crates/vibesql-server/src/http/rest.rs
@@ -96,6 +96,16 @@ pub struct HttpState {
     /// remains gated to 503 in replicated mode.
     /// `/health` uses the handle to report node role/writability.
     pub replication: Option<StdArc<ReplicationHandle>>,
+    /// Whether the legacy GraphQL `where: "<raw sql>"` escape hatch is enabled
+    /// (default: false). Mirrors
+    /// [`crate::config::ServerConfig::graphql_allow_raw_where`].
+    ///
+    /// When false, a GraphQL query that supplies a raw-string WHERE is rejected
+    /// before any SQL executes (the raw string is otherwise interpolated
+    /// verbatim — a SQL-injection surface). The flag is honored identically in
+    /// standalone and replicated mode, since it gates GraphQL→SQL lowering,
+    /// which is shared by both paths.
+    pub graphql_allow_raw_where: bool,
 }
 
 impl HttpState {
@@ -234,12 +244,16 @@ fn sql_error_message(e: &SqlError) -> String {
 /// * `registry` - Database registry for shared database access
 /// * `subscription_manager` - Subscription manager for real-time updates
 /// * `metrics` - Optional server metrics for observability
+/// * `graphql_allow_raw_where` - Enable the legacy GraphQL `where: "<raw sql>"`
+///   escape hatch (default off; see
+///   [`crate::config::ServerConfig::graphql_allow_raw_where`])
 pub fn create_http_router(
     db: Arc<Database>,
     registry: DatabaseRegistry,
     subscription_manager: Arc<SubscriptionManager>,
     metrics: Option<ServerMetrics>,
     replication: Option<StdArc<ReplicationHandle>>,
+    graphql_allow_raw_where: bool,
 ) -> Router {
     let state = HttpState {
         registry: registry.clone(),
@@ -247,6 +261,7 @@ pub fn create_http_router(
         subscription_manager: subscription_manager.clone(),
         metrics,
         replication,
+        graphql_allow_raw_where,
     };
     let is_replicated = state.replication.is_some();
 
@@ -368,8 +383,10 @@ async fn graphql_handler(
     // Check if we have nested fields that need relationship resolution
     let has_nested = graphql::has_nested_fields(&query_info);
 
-    // Convert to SQL
-    let (sql, params) = match graphql::graphql_to_sql(&query_info) {
+    // Convert to SQL. The legacy raw-string WHERE escape hatch is gated by
+    // `graphql_allow_raw_where` (default off): when disabled, a raw-WHERE query
+    // is rejected here with a clear error and no SQL executes.
+    let (sql, params) = match graphql::graphql_to_sql(&query_info, state.graphql_allow_raw_where) {
         Ok((sql, params)) => (sql, params),
         Err(e) => {
             error!("Failed to convert GraphQL to SQL: {}", e);

--- a/crates/vibesql-server/src/main.rs
+++ b/crates/vibesql-server/src/main.rs
@@ -200,6 +200,7 @@ async fn main() -> Result<()> {
 
         let metrics_for_http = observability.metrics().cloned();
         let replication_for_http = replication.clone();
+        let graphql_allow_raw_where = config.server.graphql_allow_raw_where;
         tokio::spawn(async move {
             let app = create_http_router(
                 db_for_http,
@@ -207,6 +208,7 @@ async fn main() -> Result<()> {
                 subscription_manager_for_http,
                 metrics_for_http,
                 replication_for_http,
+                graphql_allow_raw_where,
             );
             let listener = tokio::net::TcpListener::bind(&http_addr)
                 .await

--- a/crates/vibesql-server/tests/common/mod.rs
+++ b/crates/vibesql-server/tests/common/mod.rs
@@ -143,6 +143,7 @@ pub async fn start_test_server_with_config(mut config: Config) -> TestServer {
                 subscription_manager_for_http,
                 metrics_for_http,
                 None,
+                false,
             );
             axum::serve(http_listener, app).await.expect("HTTP server error");
         });
@@ -205,6 +206,7 @@ pub fn test_config() -> Config {
             ssl_enabled: false,
             ssl_cert: None,
             ssl_key: None,
+            graphql_allow_raw_where: false,
         },
         auth: AuthConfig { method: "trust".to_string(), password_file: None },
         logging: LoggingConfig {
@@ -346,6 +348,7 @@ pub async fn start_test_server_with_metrics(mut config: Config) -> TestServerWit
                 subscription_manager_for_http,
                 metrics_for_http,
                 None,
+                false,
             );
             axum::serve(http_listener, app).await.expect("HTTP server error");
         });

--- a/crates/vibesql-server/tests/replication_tests.rs
+++ b/crates/vibesql-server/tests/replication_tests.rs
@@ -1358,6 +1358,14 @@ async fn wire_protocol_extended_write_on_follower_redirects() {
 /// Bind the HTTP router (in replicated mode against `handle`) to an
 /// ephemeral port and return its base URL plus a shutdown sender.
 async fn start_http(handle: Option<Arc<ReplicationHandle>>) -> (String, oneshot::Sender<()>) {
+    // Default: the legacy raw-WHERE escape hatch is off (#5448).
+    start_http_with_raw_where(handle, false).await
+}
+
+async fn start_http_with_raw_where(
+    handle: Option<Arc<ReplicationHandle>>,
+    graphql_allow_raw_where: bool,
+) -> (String, oneshot::Sender<()>) {
     use vibesql_server::{http::create_http_router, registry::DatabaseRegistry};
     use vibesql_storage::Database;
 
@@ -1368,7 +1376,7 @@ async fn start_http(handle: Option<Arc<ReplicationHandle>>) -> (String, oneshot:
     let db = Arc::new(Database::new());
     let registry = DatabaseRegistry::new();
     let subs = Arc::new(SubscriptionManager::new());
-    let app = create_http_router(db, registry, subs, None, handle);
+    let app = create_http_router(db, registry, subs, None, handle, graphql_allow_raw_where);
 
     tokio::spawn(async move {
         axum::serve(listener, app)
@@ -2386,6 +2394,102 @@ async fn http_graphql_string_arg_is_injection_safe() {
         handles[0].node().query("SELECT COUNT(*) FROM gql_inj").unwrap()[0][0].to_string(),
         "1"
     );
+}
+
+/// With the legacy raw-WHERE escape hatch disabled (the default), a GraphQL
+/// query using `where: "<raw sql>"` is rejected with a clear error and no SQL
+/// executes — the unescaped injection surface is closed by default (#5448).
+/// Verified in replicated mode (gating is honored on the consensus path too).
+#[tokio::test]
+async fn http_graphql_raw_where_rejected_when_disabled() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let (base, _tx) = start_http(Some(Arc::clone(&handles[0]))).await; // raw-WHERE off
+    let client = reqwest::Client::new();
+
+    for sql in [
+        "CREATE TABLE gql_raw_off (id INT, name VARCHAR(100))",
+        "INSERT INTO gql_raw_off VALUES (1, 'Alice')",
+    ] {
+        let resp = client
+            .post(format!("{base}/api/query"))
+            .header("content-type", "application/json")
+            .body(serde_json::json!({ "sql": sql }).to_string())
+            .send()
+            .await
+            .unwrap();
+        assert!(resp.status().is_success(), "{sql}: {}", resp.status());
+    }
+
+    // Raw-string WHERE: must be refused before any SQL runs.
+    let query = serde_json::json!({
+        "query": r#"{ gql_raw_off(where: "1=1") { id name } }"#
+    })
+    .to_string();
+    let resp = client
+        .post(format!("{base}/api/graphql"))
+        .header("content-type", "application/json")
+        .body(query)
+        .send()
+        .await
+        .unwrap();
+    // The handler returns a GraphQL error payload (HTTP 400) with no data.
+    assert_eq!(resp.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+    assert!(body["data"].is_null(), "no data should be returned, got {body}");
+    let errors = body["errors"].as_array().expect("errors array");
+    assert!(
+        errors.iter().any(|e| e["message"]
+            .as_str()
+            .map(|m| m.contains("raw where clause is disabled"))
+            .unwrap_or(false)),
+        "expected a clear raw-WHERE-disabled error, got {body}"
+    );
+}
+
+/// With the flag explicitly enabled, the legacy `where: "<raw sql>"` form is
+/// applied verbatim — the opt-in operator accepts the trusted-input risk
+/// (#5448). Honored on the replicated consensus path.
+#[tokio::test]
+async fn http_graphql_raw_where_applied_when_enabled() {
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    // raw-WHERE explicitly enabled.
+    let (base, _tx) = start_http_with_raw_where(Some(Arc::clone(&handles[0])), true).await;
+    let client = reqwest::Client::new();
+
+    for sql in [
+        "CREATE TABLE gql_raw_on (id INT, name VARCHAR(100))",
+        "INSERT INTO gql_raw_on VALUES (1, 'Alice')",
+        "INSERT INTO gql_raw_on VALUES (2, 'Bob')",
+    ] {
+        let resp = client
+            .post(format!("{base}/api/query"))
+            .header("content-type", "application/json")
+            .body(serde_json::json!({ "sql": sql }).to_string())
+            .send()
+            .await
+            .unwrap();
+        assert!(resp.status().is_success(), "{sql}: {}", resp.status());
+    }
+
+    // Raw-string WHERE is applied: selects only id = 1.
+    let query = serde_json::json!({
+        "query": r#"{ gql_raw_on(where: "id = 1") { id name } }"#
+    })
+    .to_string();
+    let resp = client
+        .post(format!("{base}/api/graphql"))
+        .header("content-type", "application/json")
+        .body(query)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+    let rows = body["data"]["data"].as_array().expect("data.data array");
+    assert_eq!(rows.len(), 1, "raw WHERE should filter to one row, got {body}");
+    assert_eq!(rows[0]["id"].as_i64(), Some(1));
 }
 
 /// Standalone HTTP is unaffected: `/health` is 200 with no `replication`


### PR DESCRIPTION
## Summary

Hardens the GraphQL legacy `where: "<raw sql>"` escape hatch against SQL injection (filed by the #5447 judge).

The structured `where: { ... }` path parameterizes values and escapes identifiers (injection-safe, verified by the #5447 test). But the legacy raw-string form (`where_clause_raw`, `parser.rs`) interpolated the client-supplied string **verbatim** into the generated SQL with no parameterization or escaping — a real injection surface, now also reachable on the replicated consensus path.

**Chosen approach: (a)** — gate the raw-string form behind a new server config flag, **default OFF**, rather than removing it (breaking opt-in users) or trying to re-render it through the safe builder (would defeat the escape-hatch purpose).

- New flag `server.graphql_allow_raw_where` (env `VIBESQL_SERVER_GRAPHQL_ALLOW_RAW_WHERE`), default `false`, with a doc-comment documenting the trusted-input-only injection risk.
- When **OFF** (default): a GraphQL query/mutation using `where: "..."` is rejected with a clear error (`raw where clause is disabled; enable server.graphql_allow_raw_where ... or use the structured where: { ... } form`) and **no SQL executes**.
- When **ON**: the raw form works exactly as before — the operator consciously accepts the risk.
- Structured `where: { ... }` is **unaffected** by the flag.
- The flag is honored identically in **standalone and replicated** mode (it gates the shared GraphQL->SQL lowering in `graphql_to_sql`).

### Structured WHERE coverage (why default-off is safe)
The structured builder (`where_clause.rs`) covers the common cases without the escape hatch: comparison (`eq/ne/gt/gte/lt/lte`), string (`like/ilike/contains/startsWith/endsWith`), list (`in/notIn`), null (`isNull`), and `AND`/`OR`/`NOT` combinators — all parameterized. So default-off does not cripple normal usage.

## Changes
- `config.rs`: add `ServerConfig::graphql_allow_raw_where` (serde default false), env override, default-impl, docs.
- `http/graphql/parser.rs`: thread `allow_raw_where` into `graphql_to_sql` / `generate_main_query_sql`; reject raw WHERE via `render_raw_where` + `RAW_WHERE_DISABLED_ERROR` when disabled (covers SELECT/UPDATE/DELETE).
- `http/rest.rs`: carry the flag on `HttpState`, pass it from `graphql_handler`; new `create_http_router` param.
- `main.rs`: wire `config.server.graphql_allow_raw_where` into the router.
- Callers updated (test helpers, benches).

## Test plan
- [x] `cargo build -p vibesql-server` — clean (pre-existing unrelated warnings only)
- [x] `cargo test -p vibesql-server --lib` — 431 passed
- [x] Parser unit tests: raw-WHERE rejected when disabled / applied when enabled (SELECT + DELETE), injection payload gated, structured + no-WHERE unaffected by flag
- [x] Config tests: default off, TOML on/absent, env override
- [x] Integration (replicated, `replication_tests.rs`): `http_graphql_raw_where_rejected_when_disabled` (400 + clear error, table untouched), `http_graphql_raw_where_applied_when_enabled` (raw WHERE filters), and the existing `http_graphql_string_arg_is_injection_safe` still passes
- [x] `cargo clippy -p vibesql-server` — no new errors; `cargo check --benches` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)