### PR TITLE
fix(executor): fire child row triggers on FK ON DELETE/UPDATE CASCADE

### DIFF
--- a/crates/vibesql-executor/src/delete/integrity.rs
+++ b/crates/vibesql-executor/src/delete/integrity.rs
@@ -312,11 +312,17 @@ fn cascade_delete(
         }
     }
 
-    // Recursively check integrity for each child row before deleting
-    // This handles multi-level CASCADE (grandchildren, etc.)
-    for child_row in &rows_to_delete {
-        check_no_child_references(db, child_table_name, child_row)?;
-    }
+    // FK cascade fires the child table's row triggers, matching sqlite3
+    // 3.51 (#5440). sqlite3 fires child BEFORE/AFTER DELETE triggers for
+    // every cascaded row regardless of the `recursive_triggers` pragma —
+    // that pragma gates a trigger re-firing itself, not FK-cascade-fired
+    // triggers. The depth-16 RecursionGuard inside the firing helpers
+    // bounds multi-level FK chains.
+    let has_child_delete_triggers = db
+        .catalog
+        .get_triggers_for_table(child_table_name, Some(vibesql_ast::TriggerEvent::Delete))
+        .next()
+        .is_some();
 
     // Phase 1c (Issue #5150 / #5136) note: FK cascade DELETE uses the
     // content-matching `delete_where` predicate (not index-based), so we
@@ -328,11 +334,50 @@ fn cascade_delete(
     // This is a known minor gap; cascade DELETE in a transaction with
     // mvcc_enabled is uncommon and the off-state behavior is unchanged.
 
-    // Now delete the child rows
-    let child_table_mut = db.get_table_mut(child_table_name).unwrap();
-    for row_to_delete in &rows_to_delete {
-        // Ignore delete_result since we unconditionally rebuild indexes after the loop
-        let _ = child_table_mut.delete_where(|row| row == row_to_delete);
+    // Process each cascaded child row in collection order so that trigger
+    // firing interleaves with multi-level cascade exactly as sqlite3 does
+    // (#5440): for a given child row the order is
+    //   BEFORE child trigger -> grandchild cascade -> delete -> AFTER child trigger.
+    // Verified against sqlite3 3.51.0.
+    for child_row in &rows_to_delete {
+        // BEFORE DELETE row triggers on the child. A RAISE(IGNORE)
+        // (SkipRow) abandons this child row's cascade — it is not deleted
+        // (matching sqlite3, where the surviving orphan then typically
+        // trips an FK check at statement end). A RAISE(ABORT|FAIL|
+        // ROLLBACK) propagates as Err and aborts the whole statement.
+        if has_child_delete_triggers {
+            let outcome = crate::TriggerFirer::execute_before_triggers(
+                db,
+                child_table_name,
+                vibesql_ast::TriggerEvent::Delete,
+                Some(child_row),
+                None,
+            )?;
+            if outcome == crate::TriggerOutcome::SkipRow {
+                continue;
+            }
+        }
+
+        // Recursively check integrity for this child row before deleting.
+        // This handles multi-level CASCADE (grandchildren, etc.) and runs
+        // after the child's BEFORE trigger, matching sqlite3 ordering.
+        check_no_child_references(db, child_table_name, child_row)?;
+
+        // Delete this child row.
+        let child_table_mut = db.get_table_mut(child_table_name).unwrap();
+        // Ignore delete_result since we unconditionally rebuild indexes after the loop.
+        let _ = child_table_mut.delete_where(|row| row == child_row);
+
+        // AFTER DELETE row triggers fire once this child row is gone.
+        if has_child_delete_triggers {
+            let _after = crate::TriggerFirer::execute_after_triggers(
+                db,
+                child_table_name,
+                vibesql_ast::TriggerEvent::Delete,
+                Some(child_row),
+                None,
+            )?;
+        }
     }
 
     // Rebuild indexes after deletion (handles both compaction and non-compaction cases)

--- a/crates/vibesql-executor/src/raise_scope.rs
+++ b/crates/vibesql-executor/src/raise_scope.rs
@@ -43,8 +43,34 @@ use crate::errors::ExecutorError;
 /// A `RAISE()` can only originate from a trigger body, so a table with no
 /// triggers can never need a statement savepoint. This lets the common
 /// (trigger-free) DML path skip the snapshot entirely.
+///
+/// FK cascade caveat (#5440): a DELETE/UPDATE on `table` can cascade into
+/// child tables and fire *their* row triggers, which may `RAISE(ABORT)`. So
+/// when foreign keys are enabled and any table in the database carries a
+/// trigger, this statement could still fire a `RAISE()` even if `table`
+/// itself has none. We arm the savepoint conservatively in that case so a
+/// cascade-fired `RAISE(ABORT)` rolls back the whole statement (matching
+/// sqlite3 3.51). The check is cheap: it only walks the catalog, and only
+/// when FKs are on.
 pub(crate) fn table_may_fire_trigger(db: &Database, table: &str) -> bool {
-    db.catalog.get_triggers_for_table(table, None).next().is_some()
+    if db.catalog.get_triggers_for_table(table, None).next().is_some() {
+        return true;
+    }
+
+    // Cascade can reach another table's trigger only when FK enforcement is
+    // active. Bail out cheaply otherwise.
+    if !db.foreign_keys_enabled() {
+        return false;
+    }
+
+    // Conservative: any trigger anywhere in the DB could be reached by a
+    // cascade chain rooted at `table`. We don't trace the full FK graph here
+    // — arming an unused savepoint is harmless (it is released on success),
+    // whereas missing one would silently skip statement rollback.
+    db.catalog
+        .list_tables()
+        .iter()
+        .any(|t| db.catalog.get_triggers_for_table(t, None).next().is_some())
 }
 
 /// Apply the transaction-scope rollback for a `RAISE(action, msg)` that

--- a/crates/vibesql-executor/src/tests/fk_cascade_triggers.rs
+++ b/crates/vibesql-executor/src/tests/fk_cascade_triggers.rs
@@ -1,0 +1,319 @@
+//! Tests for FK ON DELETE/UPDATE CASCADE firing child-table row triggers (#5440).
+//!
+//! sqlite3 3.51 fires the child table's BEFORE/AFTER DELETE/UPDATE row
+//! triggers for every row removed/updated via a parent cascade. These tests
+//! lock in the matching behavior: per-row trigger firing, RAISE(ABORT)
+//! aborting the whole statement, RAISE(IGNORE) skipping a child row's cascade,
+//! and multi-level cascade ordering. All expectations were verified live
+//! against sqlite3 3.51.0.
+
+use vibesql_ast::Statement;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Parse and execute a single DDL/DML statement.
+fn exec(db: &mut Database, sql: &str) -> Result<String, String> {
+    let stmt =
+        vibesql_parser::Parser::parse_sql(sql).map_err(|e| format!("Parse error: {:?}", e))?;
+    match stmt {
+        Statement::CreateTable(s) => {
+            crate::CreateTableExecutor::execute(&s, db).map_err(|e| e.to_string())
+        }
+        Statement::CreateTrigger(s) => {
+            crate::TriggerExecutor::create_trigger(db, &s).map_err(|e| e.to_string())
+        }
+        Statement::Insert(s) => crate::InsertExecutor::execute(db, &s)
+            .map(|count| format!("{} row(s) inserted", count))
+            .map_err(|e| e.to_string()),
+        Statement::Delete(s) => crate::delete::DeleteExecutor::execute(&s, db)
+            .map(|count| format!("{} row(s) deleted", count))
+            .map_err(|e| e.to_string()),
+        Statement::Update(s) => crate::update::UpdateExecutor::execute(&s, db)
+            .map(|count| format!("{} row(s) updated", count))
+            .map_err(|e| e.to_string()),
+        other => Err(format!("Unsupported statement type: {:?}", other)),
+    }
+}
+
+/// Run a SELECT and return the first column of every row as a `Vec<SqlValue>`.
+fn query_col(db: &Database, sql: &str) -> Vec<SqlValue> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).expect("parse select");
+    let select = match stmt {
+        Statement::Select(s) => s,
+        other => panic!("expected SELECT, got {:?}", other),
+    };
+    let result = crate::SelectExecutor::new(db).execute_with_columns(&select).expect("run select");
+    result.rows.iter().map(|r| r.values[0].clone()).collect()
+}
+
+/// Collect the `msg` audit column as a Vec<String> in insertion order.
+fn audit_msgs(db: &Database) -> Vec<String> {
+    query_col(db, "SELECT msg FROM audit ORDER BY seq")
+        .into_iter()
+        .map(|v| match v {
+            SqlValue::Varchar(s) => s.to_string(),
+            other => format!("{:?}", other),
+        })
+        .collect()
+}
+
+fn fresh_db() -> Database {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    db
+}
+
+fn create_audit(db: &mut Database) {
+    exec(db, "CREATE TABLE audit (seq INTEGER PRIMARY KEY AUTOINCREMENT, msg TEXT)").unwrap();
+}
+
+/// Parent DELETE with ON DELETE CASCADE fires the child's AFTER DELETE
+/// trigger once per cascaded row.
+#[test]
+fn cascade_delete_fires_child_after_delete_trigger() {
+    let mut db = fresh_db();
+    create_audit(&mut db);
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE CASCADE)",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_ad AFTER DELETE ON child BEGIN INSERT INTO audit(msg) VALUES('deleted ' || OLD.id); END",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO parent VALUES (1), (2)").unwrap();
+    exec(&mut db, "INSERT INTO child VALUES (10, 1), (11, 1), (20, 2)").unwrap();
+
+    exec(&mut db, "DELETE FROM parent WHERE id = 1").unwrap();
+
+    // sqlite3 3.51: AFTER DELETE fires for each cascaded child row.
+    assert_eq!(audit_msgs(&db), vec!["deleted 10", "deleted 11"]);
+    // Child rows referencing parent 1 are gone; row 20 (parent 2) remains.
+    assert_eq!(query_col(&db, "SELECT id FROM child ORDER BY id"), vec![SqlValue::Integer(20)]);
+}
+
+/// Both BEFORE and AFTER DELETE child triggers fire, in sqlite3 order
+/// (BEFORE before the cascaded delete, AFTER after).
+#[test]
+fn cascade_delete_fires_before_and_after_child_triggers_in_order() {
+    let mut db = fresh_db();
+    create_audit(&mut db);
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE CASCADE)",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_bd BEFORE DELETE ON child BEGIN INSERT INTO audit(msg) VALUES('before ' || OLD.id); END",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_ad AFTER DELETE ON child BEGIN INSERT INTO audit(msg) VALUES('after ' || OLD.id); END",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO parent VALUES (1)").unwrap();
+    exec(&mut db, "INSERT INTO child VALUES (10, 1), (11, 1)").unwrap();
+
+    exec(&mut db, "DELETE FROM parent WHERE id = 1").unwrap();
+
+    // Verified against sqlite3 3.51.0.
+    assert_eq!(
+        audit_msgs(&db),
+        vec!["before 10", "after 10", "before 11", "after 11"]
+    );
+}
+
+/// A child BEFORE DELETE trigger RAISE(ABORT) on a cascaded row aborts the
+/// whole statement: the cascade's already-applied partial deletes are rolled
+/// back. Observable statement-level rollback for RAISE(ABORT) is implemented
+/// via the statement savepoint, which is only armed inside an explicit
+/// transaction (matching how the direct-DML RAISE(ABORT) atomicity is tested,
+/// see raise_trigger_tests.rs). #5440 broadens the savepoint-arming gate so a
+/// cascade-reachable child trigger arms it even when the parent table has no
+/// triggers of its own.
+#[test]
+fn cascade_delete_child_before_raise_abort_rolls_back_statement() {
+    let mut db = fresh_db();
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE CASCADE)",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_guard BEFORE DELETE ON child WHEN OLD.id = 11 BEGIN SELECT RAISE(ABORT, 'no delete 11'); END",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO parent VALUES (1)").unwrap();
+    exec(&mut db, "INSERT INTO child VALUES (10, 1), (11, 1)").unwrap();
+
+    db.begin_transaction().expect("BEGIN");
+    let err = exec(&mut db, "DELETE FROM parent WHERE id = 1").unwrap_err();
+    assert!(err.contains("no delete 11"), "unexpected error: {err}");
+    // ABORT keeps the transaction open (only the statement is rolled back).
+    assert!(db.in_transaction(), "ABORT must keep the transaction open");
+    db.commit_transaction().expect("COMMIT");
+
+    // sqlite3 aborts the whole statement: parent and both child rows survive,
+    // including the child[10] that the cascade had already deleted.
+    assert_eq!(query_col(&db, "SELECT id FROM parent"), vec![SqlValue::Integer(1)]);
+    assert_eq!(
+        query_col(&db, "SELECT id FROM child ORDER BY id"),
+        vec![SqlValue::Integer(10), SqlValue::Integer(11)]
+    );
+}
+
+/// Parent PK UPDATE with ON UPDATE CASCADE fires the child's BEFORE/AFTER
+/// UPDATE triggers for each cascaded row, with OLD/NEW reflecting the FK
+/// rewrite.
+#[test]
+fn cascade_update_fires_child_update_triggers() {
+    let mut db = fresh_db();
+    create_audit(&mut db);
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON UPDATE CASCADE)",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_bu BEFORE UPDATE ON child BEGIN INSERT INTO audit(msg) VALUES('before ' || OLD.id); END",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_au AFTER UPDATE ON child BEGIN INSERT INTO audit(msg) VALUES('after ' || OLD.pid || '->' || NEW.pid || ' id=' || NEW.id); END",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO parent VALUES (1)").unwrap();
+    exec(&mut db, "INSERT INTO child VALUES (10, 1), (11, 1)").unwrap();
+
+    exec(&mut db, "UPDATE parent SET id = 99 WHERE id = 1").unwrap();
+
+    // Verified against sqlite3 3.51.0.
+    assert_eq!(
+        audit_msgs(&db),
+        vec!["before 10", "after 1->99 id=10", "before 11", "after 1->99 id=11"]
+    );
+    // Child FK columns were rewritten to the new parent key.
+    assert_eq!(
+        query_col(&db, "SELECT pid FROM child ORDER BY id"),
+        vec![SqlValue::Integer(99), SqlValue::Integer(99)]
+    );
+}
+
+/// A child BEFORE UPDATE RAISE(ABORT) on a cascaded row rolls back the whole
+/// statement (including the cascade's already-applied partial updates). As
+/// with the DELETE case, observable statement rollback is exercised inside an
+/// explicit transaction.
+#[test]
+fn cascade_update_child_before_raise_abort_rolls_back_statement() {
+    let mut db = fresh_db();
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON UPDATE CASCADE)",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_guard BEFORE UPDATE ON child WHEN OLD.id = 11 BEGIN SELECT RAISE(ABORT, 'no update 11'); END",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO parent VALUES (1)").unwrap();
+    exec(&mut db, "INSERT INTO child VALUES (10, 1), (11, 1)").unwrap();
+
+    db.begin_transaction().expect("BEGIN");
+    let err = exec(&mut db, "UPDATE parent SET id = 99 WHERE id = 1").unwrap_err();
+    assert!(err.contains("no update 11"), "unexpected error: {err}");
+    assert!(db.in_transaction(), "ABORT must keep the transaction open");
+    db.commit_transaction().expect("COMMIT");
+
+    // Statement aborted: parent key unchanged, child FKs unchanged (including
+    // child[10] whose cascade update had already been applied).
+    assert_eq!(query_col(&db, "SELECT id FROM parent"), vec![SqlValue::Integer(1)]);
+    assert_eq!(
+        query_col(&db, "SELECT pid FROM child ORDER BY id"),
+        vec![SqlValue::Integer(1), SqlValue::Integer(1)]
+    );
+}
+
+/// Multi-level cascade fires triggers at every level, interleaved per row in
+/// sqlite3 order: child BEFORE -> grandchild cascade -> child AFTER.
+#[test]
+fn multi_level_cascade_delete_fires_triggers_at_each_level() {
+    let mut db = fresh_db();
+    create_audit(&mut db);
+    exec(&mut db, "CREATE TABLE a (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE b (id INTEGER PRIMARY KEY, aid INTEGER REFERENCES a(id) ON DELETE CASCADE)",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE c (id INTEGER PRIMARY KEY, bid INTEGER REFERENCES b(id) ON DELETE CASCADE)",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER b_bd BEFORE DELETE ON b BEGIN INSERT INTO audit(msg) VALUES('b before ' || OLD.id); END",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER b_ad AFTER DELETE ON b BEGIN INSERT INTO audit(msg) VALUES('b after ' || OLD.id); END",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER c_bd BEFORE DELETE ON c BEGIN INSERT INTO audit(msg) VALUES('c before ' || OLD.id); END",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER c_ad AFTER DELETE ON c BEGIN INSERT INTO audit(msg) VALUES('c after ' || OLD.id); END",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO a VALUES (1)").unwrap();
+    exec(&mut db, "INSERT INTO b VALUES (100, 1)").unwrap();
+    exec(&mut db, "INSERT INTO c VALUES (1000, 100)").unwrap();
+
+    exec(&mut db, "DELETE FROM a WHERE id = 1").unwrap();
+
+    // Verified against sqlite3 3.51.0: the grandchild (c) triggers fire
+    // between b's BEFORE and AFTER triggers.
+    assert_eq!(
+        audit_msgs(&db),
+        vec!["b before 100", "c before 1000", "c after 1000", "b after 100"]
+    );
+    assert_eq!(query_col(&db, "SELECT id FROM b"), Vec::<SqlValue>::new());
+    assert_eq!(query_col(&db, "SELECT id FROM c"), Vec::<SqlValue>::new());
+}
+
+/// Sanity: cascade delete still works (and deletes the right rows) when the
+/// child table has no triggers — no behavioral regression.
+#[test]
+fn cascade_delete_without_child_triggers_unaffected() {
+    let mut db = fresh_db();
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE CASCADE)",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO parent VALUES (1), (2)").unwrap();
+    exec(&mut db, "INSERT INTO child VALUES (10, 1), (11, 1), (20, 2)").unwrap();
+
+    exec(&mut db, "DELETE FROM parent WHERE id = 1").unwrap();
+
+    assert_eq!(query_col(&db, "SELECT id FROM child ORDER BY id"), vec![SqlValue::Integer(20)]);
+}

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -80,6 +80,7 @@ mod error_display;
 mod expression_eval;
 mod expression_index_dml_tests;
 mod expression_index_tests;
+mod fk_cascade_triggers;
 mod foreign_key_mismatch;
 mod fulltext_search;
 mod function_tests;

--- a/crates/vibesql-executor/src/update/foreign_keys.rs
+++ b/crates/vibesql-executor/src/update/foreign_keys.rs
@@ -189,8 +189,15 @@ impl ForeignKeyValidator {
         let session_defer = db.defer_foreign_keys();
         let in_txn = db.in_transaction();
 
-        // Collect cascade updates to apply after scanning (to avoid borrow checker issues)
-        let mut cascade_updates: Vec<(String, Vec<(usize, vibesql_storage::Row)>)> = Vec::new();
+        // Collect cascade updates to apply after scanning (to avoid borrow
+        // checker issues). Each entry carries the row index, the OLD child
+        // row, and the NEW child row so the cascade can fire the child
+        // table's BEFORE/AFTER UPDATE triggers with both pseudo-rows (#5440).
+        #[allow(clippy::type_complexity)]
+        let mut cascade_updates: Vec<(
+            String,
+            Vec<(usize, vibesql_storage::Row, vibesql_storage::Row)>,
+        )> = Vec::new();
 
         // Phase C2: collected NO ACTION orphans to queue after scanning
         // (queueing requires &mut Database, which conflicts with the
@@ -289,17 +296,23 @@ impl ForeignKeyValidator {
                     // Check the referential action
                     match fk.on_update {
                         vibesql_catalog::ReferentialAction::Cascade => {
-                            // Prepare cascade updates for this table
-                            let updated_rows: Vec<(usize, vibesql_storage::Row)> = matching_rows
+                            // Prepare cascade updates for this table, keeping
+                            // the OLD row so child UPDATE triggers see it.
+                            let updated_rows: Vec<(
+                                usize,
+                                vibesql_storage::Row,
+                                vibesql_storage::Row,
+                            )> = matching_rows
                                 .into_iter()
-                                .map(|(row_idx, mut child_row)| {
+                                .map(|(row_idx, old_child_row)| {
+                                    let mut child_row = old_child_row.clone();
                                     // Update the FK columns to match the new parent key
                                     for (fk_col_idx, new_parent_val) in
                                         fk.column_indices.iter().zip(&new_parent_key_values)
                                     {
                                         child_row.values[*fk_col_idx] = new_parent_val.clone();
                                     }
-                                    (row_idx, child_row)
+                                    (row_idx, old_child_row, child_row)
                                 })
                                 .collect();
 
@@ -307,15 +320,20 @@ impl ForeignKeyValidator {
                         }
                         vibesql_catalog::ReferentialAction::SetNull => {
                             // Set child FK columns to NULL
-                            let updated_rows: Vec<(usize, vibesql_storage::Row)> = matching_rows
+                            let updated_rows: Vec<(
+                                usize,
+                                vibesql_storage::Row,
+                                vibesql_storage::Row,
+                            )> = matching_rows
                                 .into_iter()
-                                .map(|(row_idx, mut child_row)| {
+                                .map(|(row_idx, old_child_row)| {
+                                    let mut child_row = old_child_row.clone();
                                     // Set FK columns to NULL
                                     for &fk_col_idx in &fk.column_indices {
                                         child_row.values[fk_col_idx] =
                                             vibesql_types::SqlValue::Null;
                                     }
-                                    (row_idx, child_row)
+                                    (row_idx, old_child_row, child_row)
                                 })
                                 .collect();
 
@@ -369,14 +387,19 @@ impl ForeignKeyValidator {
                             }
 
                             // Apply default values to matching rows
-                            let updated_rows: Vec<(usize, vibesql_storage::Row)> = matching_rows
+                            let updated_rows: Vec<(
+                                usize,
+                                vibesql_storage::Row,
+                                vibesql_storage::Row,
+                            )> = matching_rows
                                 .into_iter()
-                                .map(|(row_idx, mut child_row)| {
+                                .map(|(row_idx, old_child_row)| {
+                                    let mut child_row = old_child_row.clone();
                                     // Set FK columns to their default values
                                     for (i, &fk_col_idx) in fk.column_indices.iter().enumerate() {
                                         child_row.values[fk_col_idx] = default_values[i].clone();
                                     }
-                                    (row_idx, child_row)
+                                    (row_idx, old_child_row, child_row)
                                 })
                                 .collect();
 
@@ -437,17 +460,60 @@ impl ForeignKeyValidator {
         // xmin on every cascade-update new row version. Off-state is a
         // no-op. We capture the txn id once outside the per-table loop
         // since the txn doesn't change within an UPDATE.
+        //
+        // FK cascade fires the child table's BEFORE/AFTER UPDATE row
+        // triggers for every cascaded row, matching sqlite3 3.51 (#5440).
+        // sqlite3 fires these regardless of the `recursive_triggers`
+        // pragma; the depth-16 RecursionGuard inside the firing helpers
+        // bounds multi-level FK chains. Per row the order is
+        //   BEFORE child trigger -> update -> AFTER child trigger
+        // (verified against sqlite3 3.51.0). A RAISE(IGNORE) (SkipRow) in a
+        // BEFORE trigger abandons that child row's cascade update; a
+        // RAISE(ABORT|FAIL|ROLLBACK) propagates as Err and aborts the
+        // whole statement.
         let txn_id = db.transaction_id();
         for (table_name, mut updates) in cascade_updates {
-            for (_row_idx, new_row) in updates.iter_mut() {
+            for (_row_idx, _old_row, new_row) in updates.iter_mut() {
                 vibesql_storage::stamp_xmin_for_write(new_row, txn_id);
                 new_row.xmax = None;
             }
-            let child_table = db.get_table_mut(&table_name).unwrap();
-            for (row_idx, new_row) in updates {
+
+            let has_child_update_triggers = db
+                .catalog
+                .get_triggers_for_table(&table_name, Some(vibesql_ast::TriggerEvent::Update(None)))
+                .next()
+                .is_some();
+
+            for (row_idx, old_row, new_row) in updates {
+                // BEFORE UPDATE row triggers on the child.
+                if has_child_update_triggers {
+                    let outcome = crate::TriggerFirer::execute_before_triggers(
+                        db,
+                        &table_name,
+                        vibesql_ast::TriggerEvent::Update(None),
+                        Some(&old_row),
+                        Some(&new_row),
+                    )?;
+                    if outcome == crate::TriggerOutcome::SkipRow {
+                        continue;
+                    }
+                }
+
+                let child_table = db.get_table_mut(&table_name).unwrap();
                 child_table
-                    .update_row(row_idx, new_row)
+                    .update_row(row_idx, new_row.clone())
                     .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+
+                // AFTER UPDATE row triggers fire once the row is updated.
+                if has_child_update_triggers {
+                    let _after = crate::TriggerFirer::execute_after_triggers(
+                        db,
+                        &table_name,
+                        vibesql_ast::TriggerEvent::Update(None),
+                        Some(&old_row),
+                        Some(&new_row),
+                    )?;
+                }
             }
             // Rebuild indexes after updates (following the same pattern as DELETE operations)
             db.rebuild_indexes(&table_name);


### PR DESCRIPTION
## Summary

FK `ON DELETE CASCADE` / `ON UPDATE CASCADE` removed/updated child rows **without** firing those child tables' BEFORE/AFTER row triggers, silently bypassing audit logs, validation, and RAISE guards on cascaded rows — a SQLite-compatibility correctness gap (#5440, found during PR #5436 judge cross-check). sqlite3 3.51 fires child triggers for every cascaded row.

This routes cascaded child operations through the **existing** trigger-firing machinery (`TriggerFirer::execute_before_triggers` / `execute_after_triggers`) rather than the raw delete/update, matching sqlite3.

## How cascaded ops now route through trigger firing

- **`cascade_delete`** (`delete/integrity.rs`): processes each cascaded child row in collection order, firing `BEFORE child trigger -> grandchild cascade -> delete -> AFTER child trigger`. This interleaving matches sqlite3 exactly for multi-level chains.
- **UPDATE cascade path** (`update/foreign_keys.rs`): `cascade_updates` now carries `(row_idx, OLD row, NEW row)` so the child's BEFORE/AFTER UPDATE triggers fire per cascaded row with both pseudo-rows; order is `BEFORE -> update -> AFTER`.
- A child BEFORE-trigger `RAISE(IGNORE)` (`SkipRow`) abandons that row's cascade (the row is not deleted/updated); `RAISE(ABORT|FAIL|ROLLBACK)` propagates as `Err` and aborts the statement.

## Recursion / `recursive_triggers`

- Multi-level cascade recursion is bounded by the existing depth-16 `RecursionGuard` inside the firing helpers.
- The `recursive_triggers` pragma is **not implemented** in VibeSQL. It does **not** gate FK-cascade-fired triggers in sqlite3 anyway (verified: child triggers fire on cascade with the pragma both ON and OFF — it only governs a trigger re-firing itself). So `recursive_triggers` is out of scope here.

## Statement rollback for cascade-fired RAISE(ABORT)

`raise_scope::table_may_fire_trigger` previously checked only the parent table, so a cascade-reachable child `RAISE(ABORT)` would not arm the statement savepoint when the parent had no triggers. It now arms the savepoint conservatively when FKs are on and any table carries a trigger, so a cascade-fired `RAISE(ABORT)` rolls back the whole statement (observable inside an explicit transaction, consistent with the existing direct-DML RAISE atomicity model).

## sqlite3 3.51.0-verified cases (all reproduced live)

- Parent DELETE + child `AFTER DELETE` trigger → fires per cascaded row.
- Child `BEFORE` + `AFTER DELETE` ordering on cascade.
- Child `BEFORE DELETE RAISE(ABORT)` → whole statement rolled back (parent + all child rows survive, including ones the cascade already deleted).
- `ON UPDATE CASCADE` + child `BEFORE`/`AFTER UPDATE` triggers (OLD/NEW reflect FK rewrite).
- Child `BEFORE UPDATE RAISE(ABORT)` → statement rolled back.
- Multi-level (a→b→c) cascade: grandchild triggers fire interleaved between the child's BEFORE and AFTER (`b before -> c before -> c after -> b after`).
- No-trigger cascade unchanged.

## Scope decision

Single-level **and** multi-level cascade trigger firing are both implemented and verified — the existing depth guard made multi-level a natural fit, so no split was needed.

## Follow-ons

- **Auto-commit statement atomicity for cascade RAISE(ABORT)** is a pre-existing, broader limitation: outside an explicit transaction the statement savepoint is never armed, so a multi-row cascade's partial changes are not rolled back on `RAISE(ABORT)` (this equally affects direct multi-row DML today). The abort tests here use an explicit transaction, matching the existing RAISE-atomicity test idiom. Worth a dedicated follow-on if auto-commit statement-level atomicity is desired.
- **Cascade-fired `RAISE(IGNORE)` orphan handling**: in sqlite3 a skipped child row then trips an FK check at statement end. We honor the skip (row survives) but do not re-run a per-statement FK orphan check on the surviving row.

## Test plan

- [x] `cargo test -p vibesql-executor --lib` (2708 passed, incl. new `fk_cascade_triggers` suite)
- [x] `cargo test -p vibesql-executor` integration tests green
- [x] `cargo clippy -p vibesql-executor` clean on changed files
- [x] TCL: `fkey1.test` 19/19, `fkey5.test` 53/53, no regressions (trigger1-3/fkey2-4 extract 0 testable assertions — pre-existing harness behavior)

Closes #5440

🤖 Generated with [Claude Code](https://claude.com/claude-code)