### PR TITLE
fix(executor): keep AFTER-trigger RAISE(FAIL) offending row on live read

### DIFF
--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -1236,43 +1236,38 @@ fn execute_insert_internal(
                 row_count_before,
             );
 
-            // Fire AFTER INSERT triggers only if triggers exist
-            // If AFTER triggers fail, we need to rollback the insert
+            // Fire AFTER INSERT triggers only if triggers exist.
+            //
+            // On a trigger error we simply propagate it: the statement-scope
+            // machinery in `raise_scope::run_top_level_dml` (which wraps every
+            // top-level INSERT) handles undoing the right amount of work, exactly
+            // matching sqlite3 3.51 (#5464, #5474):
+            //   - RAISE(ABORT)/RAISE(ROLLBACK)/any non-RAISE trigger error → the
+            //     statement savepoint (in an explicit txn) or implicit
+            //     transaction (auto-commit) rolls back the *whole* statement,
+            //     removing this offending row AND every earlier row.
+            //   - RAISE(FAIL) → the partial changes the statement already applied
+            //     are KEPT, including this offending row (which was inserted
+            //     before its AFTER trigger fired). SQLite keeps it; so do we.
+            //
+            // Previously this site unconditionally tombstoned the just-inserted
+            // offending row on any trigger error. That was redundant for
+            // ABORT/non-RAISE (rollback already removes it) and *wrong* for FAIL
+            // (it hid a row SQLite keeps — visible only as a bitmap tombstone in
+            // raw `Table::scan()`, missing from any live SELECT). See #5474.
             if has_insert_triggers {
-                let trigger_result = crate::TriggerFirer::execute_after_triggers(
+                // A `TriggerOutcome::SkipRow` (RAISE(IGNORE) in an AFTER trigger)
+                // has no SQLite-observable effect here: the row is already
+                // inserted and RAISE(IGNORE) only abandons the rest of the
+                // trigger program, leaving the row in place. So we only act on
+                // the error (RAISE / non-RAISE) path; drop the Ok outcome.
+                let _after_outcome = crate::TriggerFirer::execute_after_triggers(
                     db,
                     table_name,
                     vibesql_ast::TriggerEvent::Insert,
                     None,
                     Some(&row),
-                );
-
-                if let Err(trigger_error) = trigger_result {
-                    // Rollback: Delete the row we just inserted
-                    // Note: This is a simple rollback mechanism for Phase 3
-                    // Full transaction support will come in a later phase
-                    let table = db
-                        .get_table_mut(&storage_table_name)
-                        .ok_or_else(|| ExecutorError::TableNotFound(full_table_name.clone()))?;
-
-                    // Delete the last row (the one we just inserted)
-                    // Row was inserted at index row_count_before
-                    use std::cell::Cell;
-                    let current_index = Cell::new(0);
-                    let target_index = row_count_before;
-                    // Ignore delete_result since we unconditionally rebuild indexes below
-                    let _ = table.delete_where(|_row| {
-                        let index = current_index.get();
-                        current_index.set(index + 1);
-                        index == target_index
-                    });
-
-                    // Rebuild indexes since we modified the table (handles compaction)
-                    db.rebuild_indexes(&storage_table_name);
-
-                    // Re-throw the trigger error
-                    return Err(trigger_error);
-                }
+                )?;
             }
 
             rows_inserted += 1;

--- a/crates/vibesql-executor/src/tests/raise_trigger_tests.rs
+++ b/crates/vibesql-executor/src/tests/raise_trigger_tests.rs
@@ -397,11 +397,17 @@ fn raise_fail_keeps_partial_statement_changes_with_after_trigger() {
 
     // FAIL keeps the rows applied before the trigger fired: row 1 (earlier
     // statement), row 2 ('okA'), and row 3 ('BAD' — inserted before its AFTER
-    // trigger raised). Row 4 ('okB') was never reached.
-    assert_eq!(ints(&db, "t", "id"), vec![1, 2, 3]);
+    // trigger raised). Row 4 ('okB') was never reached. Asserted through the
+    // live SELECT path (not raw `Table::scan()`): the offending 'BAD' row must
+    // be genuinely live, not a bitmap tombstone (#5474). sqlite3 3.51.0:
+    // `1|before, 2|okA, 3|BAD`.
     assert_eq!(
-        texts(&db, "t", "v"),
-        vec!["before".to_string(), "okA".to_string(), "BAD".to_string()]
+        select_rows(&db, "SELECT id, v FROM t ORDER BY id"),
+        vec![
+            vec![ipk(1), SqlValue::Varchar("before".into())],
+            vec![ipk(2), SqlValue::Varchar("okA".into())],
+            vec![ipk(3), SqlValue::Varchar("BAD".into())],
+        ],
     );
 }
 
@@ -464,23 +470,22 @@ fn autocommit_after_insert_abort_rolls_back_whole_statement() {
 /// RAISE(FAIL) keeps the rows the statement applied before the abort, even in
 /// auto-commit — the implicit transaction commits (rather than rolls back) for
 /// FAIL. This is the FAIL-vs-ABORT distinction made observable in auto-commit by
-/// #5464.
+/// #5464, with the offending-row visibility corrected in #5474.
 ///
 /// sqlite3 3.51.0 (live read):
 ///   INSERT INTO t VALUES (2,'okA'),(3,'BAD'),(4,'okB');  -- Error: boom
 ///   SELECT id FROM t;  -- 2, 3  (okA + the BAD row inserted before its AFTER
 ///                                trigger raised; okB never reached)
 ///
-/// VibeSQL keeps the pre-offending row (okA) — the #5464 deliverable: FAIL does
-/// NOT roll back the whole statement (contrast ABORT, which does). The offending
-/// row (BAD) itself is *not* surfaced through the live SELECT path: VibeSQL's
-/// per-row AFTER-trigger handler unconditionally tombstones the offending row
-/// when its trigger errors (a pre-existing executor quirk independent of #5464 —
-/// see the FAIL section of raise_scope.rs / follow-on issue). What #5464 fixes is
-/// that okA survives at all (previously the distinction was unobservable in
-/// auto-commit, where FAIL behaved like ABORT only by accident of read path).
+/// Both rows must be present through the live SELECT path: okA (the row applied
+/// before the offending one) AND BAD (the offending row itself — an AFTER INSERT
+/// trigger fires *after* the row is inserted, so SQLite keeps it under FAIL).
+/// Before #5474 the per-row AFTER-trigger handler unconditionally tombstoned the
+/// offending row on any trigger error, so a live SELECT saw only okA; #5474
+/// removes that ad-hoc tombstone and lets `run_top_level_dml` keep the FAIL
+/// changes intact.
 #[test]
-fn autocommit_after_insert_fail_keeps_pre_offending_rows() {
+fn autocommit_after_insert_fail_keeps_pre_offending_and_offending_rows() {
     let mut db = db_with_trigger("AFTER INSERT", "FAIL");
 
     match exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (2, 'okA'), (3, 'BAD'), (4, 'okB')") {
@@ -491,13 +496,17 @@ fn autocommit_after_insert_fail_keeps_pre_offending_rows() {
     }
 
     assert!(!db.in_transaction(), "auto-commit must not leak an open transaction");
-    // FAIL keeps the row applied before the offending row (okA); okB was never
+    // FAIL keeps the row applied before the offending row (okA) AND the offending
+    // row itself (BAD — inserted before its AFTER trigger fired); okB was never
     // reached. Crucially this is NOT empty — FAIL did not roll back the whole
     // statement the way ABORT does (see
     // `autocommit_after_insert_abort_rolls_back_whole_statement`).
     assert_eq!(
         select_rows(&db, "SELECT id, v FROM t ORDER BY id"),
-        vec![vec![ipk(2), SqlValue::Varchar("okA".into())]],
+        vec![
+            vec![ipk(2), SqlValue::Varchar("okA".into())],
+            vec![ipk(3), SqlValue::Varchar("BAD".into())],
+        ],
     );
 }
 
@@ -523,6 +532,36 @@ fn autocommit_before_insert_abort_rolls_back_whole_statement() {
         select_rows(&db, "SELECT id FROM t ORDER BY id"),
         Vec::<Vec<SqlValue>>::new(),
         "ABORT undoes okA (applied before the BAD row's BEFORE trigger raised)"
+    );
+}
+
+/// BEFORE INSERT trigger that RAISE(FAIL)s on a later row of a multi-row INSERT,
+/// in auto-commit: rows applied before the offending row are KEPT, but the
+/// offending row itself is NOT — a BEFORE trigger fires *before* the row is
+/// inserted, so the FAILing row never lands. This is the BEFORE/AFTER contrast
+/// of #5474: under FAIL an AFTER trigger keeps the offending row, a BEFORE
+/// trigger does not.
+///
+/// sqlite3 3.51.0 (live read):
+///   INSERT INTO t VALUES (2,'okA'),(3,'BAD'),(4,'okB');  -- Error: boom
+///   SELECT id,v FROM t;  -- 2|okA  (okB never reached; BAD never inserted)
+#[test]
+fn autocommit_before_insert_fail_keeps_pre_offending_rows_only() {
+    let mut db = db_with_trigger("BEFORE INSERT", "FAIL");
+
+    match exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (2, 'okA'), (3, 'BAD'), (4, 'okB')") {
+        Err(ExecutorError::Raise { action, .. }) => {
+            assert_eq!(action, vibesql_ast::RaiseAction::Fail);
+        }
+        other => panic!("expected RAISE(FAIL), got {:?}", other),
+    }
+
+    assert!(!db.in_transaction());
+    // Only okA survives: the BEFORE trigger raised before the BAD row was
+    // inserted, so unlike the AFTER case the offending row is absent.
+    assert_eq!(
+        select_rows(&db, "SELECT id, v FROM t ORDER BY id"),
+        vec![vec![ipk(2), SqlValue::Varchar("okA".into())]],
     );
 }
 


### PR DESCRIPTION
Closes #5474

## Root cause

The per-row AFTER INSERT trigger handler in `crates/vibesql-executor/src/insert/execution.rs` (~line 1241, "simple rollback mechanism for Phase 3") **unconditionally tombstoned the just-inserted offending row** whenever its AFTER trigger errored — regardless of the RAISE variant.

This was:
- **Redundant** for `RAISE(ABORT)` / `RAISE(ROLLBACK)` / any non-RAISE trigger error: `raise_scope::run_top_level_dml` (which wraps every top-level INSERT, #5464) already rolls back the *whole* statement — the statement savepoint inside an explicit transaction, or an implicit transaction in auto-commit — so the offending row (and every earlier row) is removed.
- **Wrong** for `RAISE(FAIL)`: SQLite 3.51 *keeps* the offending row under FAIL (an AFTER INSERT trigger fires *after* the row is inserted), and #5464 makes the FAIL path commit the partial changes. The ad-hoc tombstone fought that — the row was left as a bitmap tombstone, present in raw `Table::scan()` but missing from any live `SELECT` / `scan_live()`. This was masked because the explicit-txn FAIL test read raw `scan()`.

## The fix

**Removed** the ad-hoc tombstone. The AFTER-trigger error now propagates directly and `run_top_level_dml` owns the undo scope (ABORT/ROLLBACK/non-RAISE roll back the whole statement; FAIL commits the partial changes including the offending row). The analogous UPDATE/DELETE AFTER-trigger sites already propagate the error without a tombstone, so no change was needed there.

## BEFORE/AFTER x FAIL/ABORT vs sqlite3 3.51.0 (auto-commit, live read)

`INSERT INTO t VALUES (2,'okA'),(3,'BAD'),(4,'okB')` with a trigger that `RAISE(<action>)` when `NEW.v='BAD'`:

| Timing | Action | sqlite3 3.51.0 | VibeSQL (after fix) |
|--------|--------|----------------|---------------------|
| AFTER  | FAIL   | `2\|okA, 3\|BAD` (offending row kept) | `2\|okA, 3\|BAD` ✅ |
| AFTER  | ABORT  | _(none — whole statement rolled back)_ | _(none)_ ✅ |
| BEFORE | FAIL   | `2\|okA` (offending row never inserted) | `2\|okA` ✅ |
| BEFORE | ABORT  | _(none)_ | _(none)_ ✅ |

(Before the fix the AFTER/FAIL live read showed only `2\|okA` — the `3\|BAD` row was a hidden tombstone.)

## Tests

All assertions go through the live `SELECT` path (the #5437/#5442 lesson — not `Table::scan`).

- Corrected `raise_fail_keeps_partial_statement_changes_with_after_trigger` (explicit txn): was asserting via `ints()` = raw `scan()` (which surfaced the tombstone and passed for the wrong reason); now asserts via `select_rows` and requires the offending row to be genuinely live.
- Tightened `autocommit_after_insert_fail_keeps_pre_offending_rows` -> `..._and_offending_rows`: previously documented the quirk and asserted only `2\|okA`; now requires `2\|okA, 3\|BAD`.
- Added `autocommit_before_insert_fail_keeps_pre_offending_rows_only`: asserts the BEFORE/AFTER contrast under FAIL (`2\|okA` only).
- Existing ABORT cases (`autocommit_after_insert_abort_...`, `autocommit_before_insert_abort_...`) already used live SELECT and still pass.

`cargo test -p vibesql-executor`: all green (49 raise-related tests pass; full crate suite passes). No new compiler warnings.

## Test plan

- [x] `cargo test -p vibesql-executor`
- [x] 4-way matrix verified against sqlite3 3.51.0