### PR TITLE
perf(storage): add HNSW recall@k benchmark to the suite for regression tracking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # VibeSQL Makefile
 # Convenience targets for common development tasks
 
-.PHONY: all all-bg logs status build build-all build-wasm build-python test test-unit test-workspace test-sqllogictest test-sqllogictest-halting test-tcl test-tcl-all test-tcl-file test-tcl-status test-cluster fuzz fuzz-parser fuzz-expr fuzz-type-convert fuzz-query fuzz-type-coercion fuzz-differential fuzz-list benchmark benchmark-quick benchmark-smoke benchmark-all benchmark-all-bg benchmark-logs benchmark-status benchmark-embedded-all benchmark-server-all benchmark-tpch benchmark-tpch-quick benchmark-tpch-profile benchmark-tpch-server benchmark-tpcc benchmark-tpcc-server benchmark-tpcds benchmark-sysbench benchmark-sysbench-server benchmark-vibesql benchmark-sqlite benchmark-duckdb benchmark-cli benchmark-cli-prep benchmark-cli-quick fmt fmt-check clean help analyze-tests analyze-benchmarks analyze profile-tpch profile-tpcc profile-sysbench profile-select profile-query bench-storage bench-executor bench-types website mysql-start mysql-stop mysql-status strip-quarantine
+.PHONY: all all-bg logs status build build-all build-wasm build-python test test-unit test-workspace test-sqllogictest test-sqllogictest-halting test-tcl test-tcl-all test-tcl-file test-tcl-status test-cluster fuzz fuzz-parser fuzz-expr fuzz-type-convert fuzz-query fuzz-type-coercion fuzz-differential fuzz-list benchmark benchmark-quick benchmark-smoke benchmark-all benchmark-all-bg benchmark-logs benchmark-status benchmark-embedded-all benchmark-server-all benchmark-tpch benchmark-tpch-quick benchmark-tpch-profile benchmark-tpch-server benchmark-tpcc benchmark-tpcc-server benchmark-tpcds benchmark-sysbench benchmark-hnsw benchmark-sysbench-server benchmark-vibesql benchmark-sqlite benchmark-duckdb benchmark-cli benchmark-cli-prep benchmark-cli-quick fmt fmt-check clean help analyze-tests analyze-benchmarks analyze profile-tpch profile-tpcc profile-sysbench profile-select profile-query bench-storage bench-executor bench-types website mysql-start mysql-stop mysql-status strip-quarantine
 
 # Default target: show help
 .DEFAULT_GOAL := help
@@ -138,6 +138,7 @@ help:
 	@echo "  make benchmark-tpcc          - TPC-C OLTP benchmark (embedded engines)"
 	@echo "  make benchmark-tpcds         - TPC-DS decision support (embedded engines)"
 	@echo "  make benchmark-sysbench      - Sysbench OLTP (embedded engines)"
+	@echo "  make benchmark-hnsw          - HNSW recall@k vector-index quality (VibeSQL)"
 	@echo ""
 	@echo "Server benchmarks (VibeSQL-server, MySQL - client-server, requires Docker for MySQL):"
 	@echo "  make benchmark-server-all    - All server benchmarks × all server engines"
@@ -465,6 +466,12 @@ benchmark-tpcds:
 benchmark-sysbench:
 	@echo "Running Sysbench benchmarks (embedded engines)..."
 	@./scripts/bench --test=sysbench --engine=vibesql,sqlite,duckdb
+
+# Run HNSW recall@k quality benchmark (vector index, VibeSQL only)
+# Tracks recall under delete-heavy workloads (fresh / degraded / compacted).
+benchmark-hnsw:
+	@echo "Running HNSW recall@k benchmark (VibeSQL)..."
+	@./scripts/bench --test=hnsw --engine=vibesql
 
 #
 # CLI Benchmarks (apples-to-apples comparison via CLI tools)

--- a/crates/vibesql-storage/Cargo.toml
+++ b/crates/vibesql-storage/Cargo.toml
@@ -111,3 +111,7 @@ harness = false
 [[bench]]
 name = "skip_scan_benchmark"
 harness = false
+
+[[bench]]
+name = "hnsw_recall_benchmark"
+harness = false

--- a/crates/vibesql-storage/benches/hnsw_recall_benchmark.rs
+++ b/crates/vibesql-storage/benches/hnsw_recall_benchmark.rs
@@ -1,0 +1,303 @@
+//! HNSW recall@k quality benchmark
+//!
+//! Promotes the in-test recall measurement from
+//! `test_recall_degrades_without_compaction_then_restored` (#5454 / PR #5461)
+//! into the benchmark suite so HNSW recall under delete-heavy workloads is
+//! tracked over time alongside the TPC / sysbench suites and recall
+//! regressions are caught automatically. See #5466.
+//!
+//! Unlike the latency-oriented benchmarks, this benchmark reports a *quality*
+//! metric: recall@k (the fraction of the true k-nearest neighbours an HNSW
+//! search returns) versus brute-force ground truth. It measures three states
+//! across a sweep of `ef_search` and delete-ratio so degradation and
+//! restoration are both visible:
+//!
+//!   - `fresh`             : index built over only the live vectors (the
+//!                           best-case reference an ANN index can achieve).
+//!   - `degraded`          : index built over the full dataset, then a fraction
+//!                           of vectors lazily deleted *without* compaction —
+//!                           tombstones erode the small-world graph and recall
+//!                           drops.
+//!   - `compacted`         : same deletes, then `compact()` rebuilds the graph
+//!                           from survivors — recall is restored to ~`fresh`.
+//!
+//! The dataset is fully deterministic (seeded xorshift64, no `rand`) so recall
+//! is reproducible run-to-run and the benchmark is not timing-flaky.
+//!
+//! Run directly:
+//!   cargo bench --package vibesql-storage --bench hnsw_recall_benchmark
+//!
+//! Or via the suite:
+//!   make benchmark-hnsw
+//!   ./scripts/bench --test=hnsw
+//!
+//! Output is a plain table parsed by `scripts/process_results.py` (the
+//! `HnswRecallParser`) and stored in the dogfooded results DB
+//! (`hnsw_recall_results`).
+//!
+//! Environment variables:
+//!   HNSW_RECALL_DATASET_SIZE - number of base vectors (default: 3000)
+//!   HNSW_RECALL_DIM          - vector dimensionality (default: 16)
+//!   HNSW_RECALL_K            - recall@k neighbour count (default: 10)
+//!   HNSW_RECALL_QUERIES      - number of probe queries per measurement (default: 100)
+
+use std::collections::HashSet;
+
+use vibesql_ast::VectorDistanceMetric;
+use vibesql_storage::database::indexes::HnswIndex;
+
+// HNSW graph parameters (match the unit test so benchmark and test agree).
+const M: u32 = 16;
+const EF_CONSTRUCTION: u32 = 64;
+
+/// Deterministic pseudo-random generator (xorshift64) so the recall dataset is
+/// reproducible across runs without depending on `rand`. Mirrors `DetRng` in
+/// the hnsw unit tests — the benchmark harness forbids nondeterminism.
+struct DetRng(u64);
+
+impl DetRng {
+    fn new(seed: u64) -> Self {
+        DetRng(seed.max(1))
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+
+    /// Uniform f64 in [0, 1).
+    fn next_f64(&mut self) -> f64 {
+        (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64
+    }
+}
+
+/// Build a deterministic dataset of `n` vectors of `dim` dimensions.
+fn deterministic_dataset(n: usize, dim: usize, seed: u64) -> Vec<(usize, Vec<f64>)> {
+    let mut rng = DetRng::new(seed);
+    (0..n)
+        .map(|i| {
+            let v: Vec<f64> = (0..dim).map(|_| rng.next_f64()).collect();
+            (i, v)
+        })
+        .collect()
+}
+
+/// Brute-force ground-truth: the `k` nearest *live* row ids to `query` (L2),
+/// restricted to `live`.
+fn brute_force_knn(
+    dataset: &[(usize, Vec<f64>)],
+    live: &HashSet<usize>,
+    query: &[f64],
+    k: usize,
+) -> Vec<usize> {
+    let mut scored: Vec<(usize, f64)> = dataset
+        .iter()
+        .filter(|(id, _)| live.contains(id))
+        .map(|(id, v)| {
+            let d: f64 =
+                query.iter().zip(v.iter()).map(|(a, b)| (a - b).powi(2)).sum::<f64>().sqrt();
+            (*id, d)
+        })
+        .collect();
+    scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+    scored.into_iter().take(k).map(|(id, _)| id).collect()
+}
+
+/// Average recall@k of `index` over `num_queries` queries drawn from the live
+/// vectors, against brute-force ground truth.
+fn measure_recall(
+    index: &HnswIndex,
+    dataset: &[(usize, Vec<f64>)],
+    live: &HashSet<usize>,
+    k: usize,
+    num_queries: usize,
+) -> f64 {
+    let live_ids: Vec<usize> =
+        dataset.iter().map(|(id, _)| *id).filter(|id| live.contains(id)).collect();
+    if live_ids.is_empty() {
+        return 1.0;
+    }
+
+    let mut total_hits = 0usize;
+    let mut total_truth = 0usize;
+    for qi in 0..num_queries {
+        // Use an existing live vector as the query (its own neighborhood).
+        let qid = live_ids[qi % live_ids.len()];
+        let query = &dataset[qid].1;
+
+        let truth = brute_force_knn(dataset, live, query, k);
+        let truth_set: HashSet<usize> = truth.iter().copied().collect();
+
+        let approx = index.search(query, k).unwrap();
+        let hits = approx.iter().filter(|(id, _)| truth_set.contains(id)).count();
+
+        total_hits += hits;
+        total_truth += truth.len();
+    }
+
+    if total_truth == 0 {
+        1.0
+    } else {
+        total_hits as f64 / total_truth as f64
+    }
+}
+
+/// One row of recall measurements for a given (ef_search, delete_ratio) point.
+struct RecallPoint {
+    ef_search: usize,
+    delete_ratio: f64,
+    live_count: usize,
+    deleted_count: usize,
+    recall_fresh: f64,
+    recall_degraded: f64,
+    recall_compacted: f64,
+}
+
+/// Run all three states (fresh / degraded / compacted) for a single
+/// (`ef_search`, `delete_ratio`) configuration over `dataset`.
+fn run_point(
+    dataset: &[(usize, Vec<f64>)],
+    dim: usize,
+    k: usize,
+    queries: usize,
+    ef_search: usize,
+    delete_ratio: f64,
+) -> RecallPoint {
+    let n = dataset.len();
+
+    // Deterministically pick a scattered set of survivors so removed nodes
+    // (including graph hubs / entry-point candidates) are interleaved with
+    // survivors, fragmenting the survivor subgraph the way a real delete-heavy
+    // workload does. `keep_every = round(1 / (1 - ratio))`; keep id iff
+    // i % keep_every == 0.
+    let keep_every = ((1.0 / (1.0 - delete_ratio)).round() as usize).max(1);
+    let live: HashSet<usize> = (0..n).filter(|i| i % keep_every == 0).collect();
+    let to_delete: Vec<usize> = (0..n).filter(|i| i % keep_every != 0).collect();
+
+    // --- fresh: built over only the live vectors (reference) ---
+    let mut idx_fresh = HnswIndex::new(dim, M, EF_CONSTRUCTION, VectorDistanceMetric::L2);
+    idx_fresh.set_ef_search(ef_search);
+    let fresh_vectors: Vec<(usize, Vec<f64>)> =
+        dataset.iter().filter(|(id, _)| live.contains(id)).cloned().collect();
+    idx_fresh.build(fresh_vectors).unwrap();
+    let recall_fresh = measure_recall(&idx_fresh, dataset, &live, k, queries);
+
+    // --- degraded: full build, lazy deletes, NO compaction ---
+    let mut idx_degraded = HnswIndex::new(dim, M, EF_CONSTRUCTION, VectorDistanceMetric::L2);
+    idx_degraded.set_ef_search(ef_search);
+    idx_degraded.set_auto_compact(false);
+    idx_degraded.build(dataset.to_vec()).unwrap();
+    for &id in &to_delete {
+        idx_degraded.remove(id);
+    }
+    let recall_degraded = measure_recall(&idx_degraded, dataset, &live, k, queries);
+
+    // --- compacted: same deletes, then explicit compaction ---
+    let mut idx_compacted = HnswIndex::new(dim, M, EF_CONSTRUCTION, VectorDistanceMetric::L2);
+    idx_compacted.set_ef_search(ef_search);
+    idx_compacted.set_auto_compact(false);
+    idx_compacted.build(dataset.to_vec()).unwrap();
+    for &id in &to_delete {
+        idx_compacted.remove(id);
+    }
+    idx_compacted.compact();
+    let recall_compacted = measure_recall(&idx_compacted, dataset, &live, k, queries);
+
+    RecallPoint {
+        ef_search,
+        delete_ratio,
+        live_count: live.len(),
+        deleted_count: to_delete.len(),
+        recall_fresh,
+        recall_degraded,
+        recall_compacted,
+    }
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name).ok().and_then(|s| s.parse().ok()).unwrap_or(default)
+}
+
+fn main() {
+    let n = env_usize("HNSW_RECALL_DATASET_SIZE", 3000);
+    let dim = env_usize("HNSW_RECALL_DIM", 16);
+    let k = env_usize("HNSW_RECALL_K", 10);
+    let queries = env_usize("HNSW_RECALL_QUERIES", 100);
+
+    // A small ef_search makes the graph's navigability (small-world property) —
+    // exactly what lazy unlink erodes — the limiting factor for recall, so
+    // degradation is observable. We also sweep a wider beam to confirm the
+    // tradeoff. delete_ratio sweeps a moderate and a heavy delete fraction.
+    let ef_search_sweep = [12usize, 40];
+    let delete_ratio_sweep = [0.5f64, 0.8];
+
+    let dataset = deterministic_dataset(n, dim, 0xC0FFEE);
+
+    println!("=== HNSW Recall@{k} Benchmark ===");
+    println!(
+        "Dataset: {n} vectors, dim={dim}, queries={queries}, M={M}, ef_construction={EF_CONSTRUCTION}"
+    );
+    println!();
+    println!("--- VibeSQL Recall Results ---");
+    println!(
+        "{:<10} {:>12} {:>8} {:>9} {:>10} {:>10} {:>10}",
+        "EfSearch", "DeleteRatio", "Live", "Deleted", "Fresh", "Degraded", "Compacted"
+    );
+    println!(
+        "{:-<10} {:->12} {:->8} {:->9} {:->10} {:->10} {:->10}",
+        "", "", "", "", "", "", ""
+    );
+
+    let mut points = Vec::new();
+    for &ef_search in &ef_search_sweep {
+        for &delete_ratio in &delete_ratio_sweep {
+            let p = run_point(&dataset, dim, k, queries, ef_search, delete_ratio);
+            println!(
+                "{:<10} {:>12.2} {:>8} {:>9} {:>10.4} {:>10.4} {:>10.4}",
+                p.ef_search,
+                p.delete_ratio,
+                p.live_count,
+                p.deleted_count,
+                p.recall_fresh,
+                p.recall_degraded,
+                p.recall_compacted
+            );
+            points.push(p);
+        }
+    }
+
+    println!();
+
+    // Sanity invariants so a smoke run fails loudly if recall behaviour breaks.
+    // These are deterministic given the seeded dataset, so they are safe to
+    // assert in the benchmark itself (not timing-dependent).
+    for p in &points {
+        assert!(
+            p.recall_fresh > 0.0 && p.recall_fresh <= 1.0,
+            "fresh recall out of range: {:.4}",
+            p.recall_fresh
+        );
+        assert!(
+            p.recall_compacted >= p.recall_degraded - 1e-9,
+            "compaction regressed recall at ef_search={} ratio={:.2}: compacted={:.4} < degraded={:.4}",
+            p.ef_search,
+            p.delete_ratio,
+            p.recall_compacted,
+            p.recall_degraded
+        );
+        assert!(
+            p.recall_compacted >= p.recall_fresh - 0.05,
+            "compaction did not restore recall at ef_search={} ratio={:.2}: compacted={:.4} fresh={:.4}",
+            p.ef_search,
+            p.delete_ratio,
+            p.recall_compacted,
+            p.recall_fresh
+        );
+    }
+
+    println!("HNSW recall benchmark complete ({} configurations).", points.len());
+}

--- a/scripts/bench
+++ b/scripts/bench
@@ -229,7 +229,7 @@ Transaction Filter (--txn):
     # Server tests: tpch-server, tpcc-server, sysbench-server
     parser.add_argument(
         "--test",
-        choices=["tpch", "tpcc", "tpcds", "sysbench", "tpch-server", "tpcc-server", "sysbench-server", "all"],
+        choices=["tpch", "tpcc", "tpcds", "sysbench", "hnsw", "tpch-server", "tpcc-server", "sysbench-server", "all"],
         default="tpch",
         help="Benchmark to run (default: tpch). Server tests use client-server protocol."
     )
@@ -861,6 +861,68 @@ def run_sysbench(config: BenchConfig) -> int:
     return 0
 
 
+def run_hnsw(config: BenchConfig) -> int:
+    """Run the HNSW recall@k quality benchmark (#5466).
+
+    Unlike the latency-oriented suites this measures a *quality* metric: HNSW
+    recall@k vs brute-force ground truth across fresh / degraded (lazy delete) /
+    compacted index states. VibeSQL-only (recall is an engine-internal metric).
+    """
+    print("\n" + "=" * 60)
+    print("HNSW Recall@k Benchmark")
+    print("=" * 60)
+
+    repo_root = Path(__file__).parent.parent
+
+    # Build the benchmark binary (in-memory-indexes keeps benchmark data fast).
+    print("\nBuilding benchmark...")
+    binary = build_bench_and_get_binary(
+        "vibesql-storage", "hnsw_recall_benchmark", features=["in-memory-indexes"]
+    )
+    if not binary:
+        print("❌ Build failed")
+        return 1
+
+    strip_quarantine()
+
+    # Allow quick/smoke runs to shrink the dataset for faster pipeline checks.
+    env = os.environ.copy()
+    if config.test_mode:
+        env.setdefault("HNSW_RECALL_DATASET_SIZE", "800")
+        env.setdefault("HNSW_RECALL_QUERIES", "40")
+    elif config.quick:
+        env.setdefault("HNSW_RECALL_DATASET_SIZE", "1500")
+        env.setdefault("HNSW_RECALL_QUERIES", "60")
+
+    print("\nRunning HNSW recall benchmark...")
+    result = subprocess.run(
+        [binary],
+        cwd=repo_root,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True
+    )
+
+    print(result.stdout)
+
+    with open("/tmp/hnsw_results.txt", "w") as f:
+        f.write(result.stdout)
+
+    if result.returncode != 0:
+        print("❌ HNSW recall benchmark failed (recall invariants not met)")
+        return 1
+
+    # Process results into the dogfooded results DB.
+    print("\nProcessing results into database...")
+    subprocess.run(
+        ["./scripts/process_results.py", "--type=hnsw", "--input", "/tmp/hnsw_results.txt"],
+        cwd=repo_root
+    )
+
+    return 0
+
+
 def run_sysbench_server(config: BenchConfig) -> int:
     """Run Sysbench server benchmark (VibeSQL server vs MySQL)."""
     print("\n" + "=" * 60)
@@ -1284,11 +1346,11 @@ def run_all(config: BenchConfig) -> int:
     # In smoke test mode, include server benchmarks for fair MySQL comparison
     # TPC-DS now supports QUERY_FILTER, so we include it for full pipeline validation
     if config.test_mode:
-        benchmarks = ["tpch", "tpcc", "tpcds", "sysbench", "sysbench-server", "tpch-server", "tpcc-server"]
+        benchmarks = ["tpch", "tpcc", "tpcds", "sysbench", "hnsw", "sysbench-server", "tpch-server", "tpcc-server"]
         print("Note: Skipping footprint in smoke test mode")
     else:
         # Full benchmark suite includes server benchmarks and footprint
-        benchmarks = ["tpch", "tpcc", "tpcds", "sysbench", "sysbench-server", "tpch-server", "tpcc-server", "footprint"]
+        benchmarks = ["tpch", "tpcc", "tpcds", "sysbench", "hnsw", "sysbench-server", "tpch-server", "tpcc-server", "footprint"]
 
     for test in benchmarks:
         config.test = test
@@ -1303,6 +1365,8 @@ def run_all(config: BenchConfig) -> int:
             ret = run_tpcds(config)
         elif test == "sysbench":
             ret = run_sysbench(config)
+        elif test == "hnsw":
+            ret = run_hnsw(config)
         elif test == "sysbench-server":
             ret = run_sysbench_server(config)
         elif test == "tpch-server":
@@ -1465,6 +1529,8 @@ def main():
         return run_tpcds(config)
     elif config.test == "sysbench":
         return run_sysbench(config)
+    elif config.test == "hnsw":
+        return run_hnsw(config)
     elif config.test == "tpch-server":
         return run_tpch_server(config)
     elif config.test == "tpcc-server":

--- a/scripts/benchmark_results_schema_vibesql.sql
+++ b/scripts/benchmark_results_schema_vibesql.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS benchmark_runs (
     run_timestamp TEXT NOT NULL,
     git_commit TEXT,
     git_branch TEXT,
-    benchmark_suite TEXT NOT NULL CHECK (benchmark_suite IN ('tpch', 'tpcc', 'tpcds', 'sysbench', 'sqllogictest_suite', 'custom')),
+    benchmark_suite TEXT NOT NULL CHECK (benchmark_suite IN ('tpch', 'tpcc', 'tpcds', 'sysbench', 'hnsw', 'sqllogictest_suite', 'custom')),
     scale_factor TEXT,
     timeout_secs INTEGER,
     total_queries INTEGER,
@@ -43,6 +43,30 @@ CREATE TABLE IF NOT EXISTS sysbench_results (
     std_dev_ns REAL,
     median_time_ns REAL,
     iterations INTEGER,
+    FOREIGN KEY (run_id) REFERENCES benchmark_runs(run_id)
+);
+
+-- HNSW Recall Results: vector-index quality metrics (recall@k) for
+-- delete-heavy workloads. Unlike the latency-oriented tables above this stores
+-- a *quality* metric: the fraction of true k-nearest neighbours returned by an
+-- approximate HNSW search vs brute-force ground truth, measured across three
+-- index states (fresh build / degraded-by-lazy-deletes / post-compaction) and
+-- a sweep of ef_search + delete ratio. See #5466.
+CREATE TABLE IF NOT EXISTS hnsw_recall_results (
+    result_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL,
+    database_engine TEXT NOT NULL,  -- 'vibesql'
+    k INTEGER NOT NULL,             -- recall@k neighbour count
+    dataset_size INTEGER,           -- number of base vectors
+    dimensions INTEGER,             -- vector dimensionality
+    -- NB: named `ef_search_param` (not `ef_search`) because EF_SEARCH is a
+    -- reserved keyword in VibeSQL's CREATE INDEX ... WITH (...) syntax.
+    ef_search_param INTEGER,        -- query-time search beam width
+    delete_ratio REAL,             -- fraction of vectors lazily deleted
+    live_count INTEGER,            -- surviving vectors
+    deleted_count INTEGER,         -- removed vectors
+    index_state TEXT NOT NULL CHECK (index_state IN ('fresh', 'degraded', 'compacted')),
+    recall REAL NOT NULL,          -- measured recall@k in [0, 1]
     FOREIGN KEY (run_id) REFERENCES benchmark_runs(run_id)
 );
 
@@ -203,6 +227,46 @@ CREATE INDEX IF NOT EXISTS idx_tpcc_results_txn_type ON tpcc_results(transaction
 CREATE INDEX IF NOT EXISTS idx_sysbench_results_run ON sysbench_results(run_id);
 CREATE INDEX IF NOT EXISTS idx_sysbench_results_engine ON sysbench_results(database_engine);
 CREATE INDEX IF NOT EXISTS idx_sysbench_results_test ON sysbench_results(test_name);
+
+-- Indexes for HNSW recall results
+CREATE INDEX IF NOT EXISTS idx_hnsw_recall_results_run ON hnsw_recall_results(run_id);
+CREATE INDEX IF NOT EXISTS idx_hnsw_recall_results_state ON hnsw_recall_results(index_state);
+
+-- View: Latest HNSW recall benchmark summary
+CREATE VIEW IF NOT EXISTS latest_hnsw_recall_summary AS
+SELECT
+    hr.database_engine,
+    hr.k,
+    hr.ef_search_param,
+    hr.delete_ratio,
+    hr.index_state,
+    ROUND(hr.recall, 4) as recall,
+    hr.live_count,
+    hr.deleted_count,
+    brun.timestamp,
+    brun.git_commit
+FROM hnsw_recall_results hr
+JOIN benchmark_runs brun ON hr.run_id = brun.run_id
+WHERE brun.run_id = (SELECT MAX(run_id) FROM benchmark_runs WHERE benchmark_suite = 'hnsw')
+ORDER BY hr.ef_search_param, hr.delete_ratio, hr.index_state;
+
+-- View: HNSW recall trend over time (per ef_search / delete_ratio / state)
+CREATE VIEW IF NOT EXISTS hnsw_recall_trend AS
+SELECT
+    hr.ef_search_param,
+    hr.delete_ratio,
+    hr.index_state,
+    hr.run_id,
+    brun.timestamp,
+    brun.git_commit,
+    hr.recall,
+    LAG(hr.recall) OVER (
+        PARTITION BY hr.ef_search_param, hr.delete_ratio, hr.index_state
+        ORDER BY brun.timestamp
+    ) as prev_recall
+FROM hnsw_recall_results hr
+JOIN benchmark_runs brun ON hr.run_id = brun.run_id
+ORDER BY hr.ef_search_param, hr.delete_ratio, hr.index_state, brun.timestamp;
 
 -- View: Latest TPC-C benchmark summary
 CREATE VIEW IF NOT EXISTS latest_tpcc_summary AS

--- a/scripts/process_results.py
+++ b/scripts/process_results.py
@@ -1309,10 +1309,150 @@ class SysbenchParser(BenchmarkParser):
 
 
 # =============================================================================
+# HNSW Recall Parser
+# =============================================================================
+
+class HnswRecallParser(BenchmarkParser):
+    """Parser for HNSW recall@k quality benchmark results.
+
+    Unlike the latency-oriented parsers this stores a *quality* metric
+    (recall@k) for three index states (fresh / degraded / compacted) across a
+    sweep of ef_search and delete ratio. See #5466.
+
+    Expected output (from crates/vibesql-storage/benches/hnsw_recall_benchmark.rs):
+
+        === HNSW Recall@10 Benchmark ===
+        Dataset: 3000 vectors, dim=16, queries=100, M=16, ef_construction=64
+
+        --- VibeSQL Recall Results ---
+        EfSearch    DeleteRatio     Live   Deleted      Fresh   Degraded  Compacted
+        ---------- ------------ -------- --------- ---------- ---------- ----------
+        12                 0.50     1500      1500     0.9980     0.9850     0.9970
+        ...
+    """
+
+    @property
+    def benchmark_suite(self) -> str:
+        return 'hnsw'
+
+    @classmethod
+    def can_parse(cls, content: str) -> bool:
+        return ('HNSW Recall@' in content or
+                '--- VibeSQL Recall Results ---' in content)
+
+    def parse(self, content: str) -> Tuple[List[Dict], Dict]:
+        results: List[Dict] = []
+
+        # Header: "=== HNSW Recall@10 Benchmark ==="
+        k = 10
+        k_match = re.search(r'HNSW Recall@(\d+)', content)
+        if k_match:
+            k = int(k_match.group(1))
+
+        # Config: "Dataset: 3000 vectors, dim=16, queries=100, ..."
+        dataset_size = None
+        dimensions = None
+        cfg_match = re.search(r'Dataset:\s+(\d+)\s+vectors,\s+dim=(\d+)', content)
+        if cfg_match:
+            dataset_size = int(cfg_match.group(1))
+            dimensions = int(cfg_match.group(2))
+
+        # Data rows:
+        # "12   0.50   1500   1500   0.9980   0.9850   0.9970"
+        # ef_search delete_ratio live deleted fresh degraded compacted
+        row_pattern = re.compile(
+            r'^\s*(\d+)\s+'        # ef_search
+            r'([\d.]+)\s+'        # delete_ratio
+            r'(\d+)\s+'           # live
+            r'(\d+)\s+'           # deleted
+            r'([\d.]+)\s+'        # fresh
+            r'([\d.]+)\s+'        # degraded
+            r'([\d.]+)\s*$',      # compacted
+            re.MULTILINE
+        )
+
+        for m in row_pattern.finditer(content):
+            ef_search = int(m.group(1))
+            delete_ratio = float(m.group(2))
+            live = int(m.group(3))
+            deleted = int(m.group(4))
+            recalls = {
+                'fresh': float(m.group(5)),
+                'degraded': float(m.group(6)),
+                'compacted': float(m.group(7)),
+            }
+            for state, recall in recalls.items():
+                results.append({
+                    'database_engine': 'vibesql',
+                    'k': k,
+                    'dataset_size': dataset_size,
+                    'dimensions': dimensions,
+                    'ef_search': ef_search,
+                    'delete_ratio': delete_ratio,
+                    'live_count': live,
+                    'deleted_count': deleted,
+                    'index_state': state,
+                    'recall': recall,
+                })
+
+        summary = {
+            'k': k,
+            'dataset_size': dataset_size,
+            'dimensions': dimensions,
+            'total_results': len(results),
+            'total_queries': len(results),
+        }
+        return results, summary
+
+    def insert_results(self, db, cursor, results: List[Dict], summary: Dict,
+                       config: Dict) -> int:
+        """Insert HNSW recall results into the database."""
+        git_commit, git_branch = get_git_info()
+        notes = config.get('notes')
+
+        execute_insert(cursor, "benchmark_runs", [
+            "run_timestamp", "git_commit", "git_branch", "benchmark_suite",
+            "scale_factor", "total_queries", "notes"
+        ], [
+            datetime.now().isoformat(),
+            git_commit,
+            git_branch,
+            'hnsw',
+            str(summary.get('dataset_size') or ''),
+            len(results),
+            notes
+        ])
+
+        run_id = get_last_insert_id(cursor, "benchmark_runs", "run_id")
+
+        for result in results:
+            execute_insert(cursor, "hnsw_recall_results", [
+                "run_id", "database_engine", "k", "dataset_size", "dimensions",
+                "ef_search_param", "delete_ratio", "live_count", "deleted_count",
+                "index_state", "recall"
+            ], [
+                run_id,
+                result.get('database_engine', 'vibesql'),
+                result.get('k'),
+                result.get('dataset_size'),
+                result.get('dimensions'),
+                result.get('ef_search'),
+                result.get('delete_ratio'),
+                result.get('live_count'),
+                result.get('deleted_count'),
+                result.get('index_state', 'unknown'),
+                result.get('recall'),
+            ])
+
+        save_connection(db)
+        return run_id
+
+
+# =============================================================================
 # Auto-detection and Parser Registry
 # =============================================================================
 
-PARSERS = [TPCHParser, TPCCParser, TPCDSParser, SysbenchParser]
+PARSERS = [TPCHParser, TPCCParser, TPCDSParser, SysbenchParser, HnswRecallParser]
 
 def detect_benchmark_type(content: str) -> Optional[BenchmarkParser]:
     """Auto-detect benchmark type from content and return appropriate parser."""
@@ -1329,6 +1469,7 @@ def get_parser(benchmark_type: str) -> Optional[BenchmarkParser]:
         'tpcc': TPCCParser,
         'tpcds': TPCDSParser,
         'sysbench': SysbenchParser,
+        'hnsw': HnswRecallParser,
     }
     parser_cls = type_map.get(benchmark_type.lower())
     return parser_cls() if parser_cls else None
@@ -1395,7 +1536,7 @@ Examples:
     # Type specification
     parser.add_argument(
         "--type", "-t",
-        choices=["tpch", "tpcc", "tpcds", "sysbench"],
+        choices=["tpch", "tpcc", "tpcds", "sysbench", "hnsw"],
         help="Benchmark type (auto-detected if not specified)"
     )
 
@@ -1498,6 +1639,7 @@ Examples:
             'tpcc': '/tmp/tpcc_results.txt',
             'tpcds': '/tmp/tpcds_results.txt',
             'sysbench': '/tmp/sysbench_results.txt',
+            'hnsw': '/tmp/hnsw_results.txt',
         }
 
         if args.type and args.type in default_inputs:


### PR DESCRIPTION
Closes #5466

## Summary

Promotes the in-test recall@10 measurement from `test_recall_degrades_without_compaction_then_restored` (#5454 / PR #5461) into the benchmark suite, so HNSW recall under delete-heavy workloads is tracked over time alongside the TPC / sysbench suites and recall regressions are caught automatically rather than only asserted inside one unit test.

This is bench/infra work, not a correctness change.

## Benchmark design

New bench: `crates/vibesql-storage/benches/hnsw_recall_benchmark.rs` (`harness = false`, plain `main()` like the sysbench custom harness).

- **Deterministic dataset**: seeded xorshift64 (`DetRng`, mirrors the #5461 unit test) — no `rand`/`Math.random`, so recall is reproducible run-to-run and the bench is not timing-flaky.
- **Three index states per config** (so a regression in any is visible):
  - `fresh` — index built over only the live vectors (best-case reference).
  - `degraded` — full build, then a scattered fraction of vectors lazily deleted with `set_auto_compact(false)` (tombstones erode the small-world graph → recall drops).
  - `compacted` — same deletes, then `compact()` rebuilds the graph from survivors → recall restored.
- **Sweep**: `ef_search ∈ {12, 40}` × `delete_ratio ∈ {0.5, 0.8}` to surface the navigability/recall tradeoff. A small `ef_search` makes graph navigability (what lazy unlink erodes) the limiting factor, so degradation is observable.
- **Fast**: 3,000 vectors, dim 16, recall@10, 100 probe queries — runs in seconds. Tunable via `HNSW_RECALL_DATASET_SIZE` / `HNSW_RECALL_DIM` / `HNSW_RECALL_K` / `HNSW_RECALL_QUERIES`; `--quick` / `--smoke` shrink the dataset.
- The bench asserts its own recall invariants (compaction never regresses vs degraded; compacted restores to within 0.05 of fresh), so a smoke run fails loudly if recall behaviour breaks.

## Where wired

- `make benchmark-hnsw` → `./scripts/bench --test=hnsw --engine=vibesql`.
- `scripts/bench`: new `run_hnsw()` (builds via `build_bench_and_get_binary`, runs the binary, pipes output to `process_results.py --type=hnsw`); added to `--test` choices and folded into `run_all` (full suite + smoke).
- `Makefile`: `benchmark-hnsw` target, `.PHONY`, and help text.

## How results are recorded (dogfooded .vbsql DB)

Recall is a **quality** metric, so it gets its own table rather than reusing the latency tables:

- `scripts/benchmark_results_schema_vibesql.sql`: new `hnsw_recall_results` table (one row per config × state: `k`, `dataset_size`, `dimensions`, `ef_search_param`, `delete_ratio`, `live_count`, `deleted_count`, `index_state`, `recall`), plus `latest_hnsw_recall_summary` and `hnsw_recall_trend` views and indexes. `'hnsw'` added to the `benchmark_suite` CHECK.
- `scripts/process_results.py`: new `HnswRecallParser` (auto-detect + `--type=hnsw`) parsing the bench table into the new schema.

> Note: the column is `ef_search_param` (not `ef_search`) because `EF_SEARCH` is a reserved keyword in VibeSQL's `CREATE INDEX ... WITH (...)` syntax — `CREATE TABLE ... (ef_search ...)` fails to parse.

## Sample recall numbers (smoke run, 3000 vectors / dim 16 / recall@10)

```
EfSearch    DeleteRatio     Live   Deleted      Fresh   Degraded  Compacted
---------- ------------ -------- --------- ---------- ---------- ----------
12                 0.50     1500      1500     0.9980     0.9850     0.9970
12                 0.80      600      2400     1.0000     0.8120     0.9990
40                 0.50     1500      1500     1.0000     1.0000     1.0000
40                 0.80      600      2400     1.0000     0.9460     1.0000
```

Matches #5461: fresh ~1.0, degraded < 1.0 (drops to 0.812 at the navigability-limited ef_search=12 / 80%-delete point), compaction restores to ~fresh.

## Test plan

- [x] `cargo bench --package vibesql-storage --bench hnsw_recall_benchmark --no-run` (default features + `in-memory-indexes`) — builds clean.
- [x] Smoke run produces sensible recall (table above) and the bench's recall invariants pass.
- [x] `process_results.py --type=hnsw` inserts 12 rows into a fresh results DB with the new schema; suite/type auto-detection still resolves tpch/sysbench/hnsw correctly.
- [x] Schema migration applied to a copy of the real `benchmark_results.vbsql` is idempotent and preserves existing 168 runs.
- [x] `python3 -m py_compile` on `scripts/bench` and `scripts/process_results.py`.

## Follow-ons (not in scope here)

- Surface HNSW recall on the web demo trends (`scripts/export_website_data.py` + web-demo frontend) — the results are now recorded; the demo wiring is a separate change touching `web-demo/`.
- Local neighbor repair on delete (vs full rebuild) and SQL-level compaction-threshold configuration (noted by the #5461 builder; larger design decisions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)