### PR TITLE
fix(cli): track CASE...END inside trigger bodies in statement splitters

### DIFF
--- a/crates/vibesql-cli/src/script.rs
+++ b/crates/vibesql-cli/src/script.rs
@@ -323,6 +323,15 @@ fn parse_statements(script: &str) -> Vec<String> {
     let mut in_string = false;
     let mut in_multiline_comment = false;
     let mut begin_depth = 0; // Track BEGIN...END nesting for trigger bodies
+    // Track CASE...END nesting *within* a trigger body. A `CASE ... END`
+    // expression in a trigger action (e.g. `SELECT CASE WHEN ... THEN
+    // RAISE(IGNORE) END`) introduces an inner `END` that must NOT be counted
+    // as the trigger's terminating `END`. Without this, the splitter closes
+    // the `CREATE TRIGGER` at the CASE's `END`, slicing one statement into
+    // several malformed fragments (issue #5468). We only track CASE depth when
+    // already inside a trigger body (`begin_depth > 0`); top-level CASE
+    // expressions split correctly on their trailing `;` and need no tracking.
+    let mut case_depth = 0;
     let mut chars = script.chars().peekable();
 
     while let Some(ch) = chars.next() {
@@ -399,6 +408,17 @@ fn parse_statements(script: &str) -> Vec<String> {
                     begin_depth += 1;
                 }
                 continue;
+            } else if word == "CASE" && begin_depth > 0 {
+                // A CASE expression inside a trigger body opens a block that is
+                // closed by its own END. Track it so that END does not
+                // prematurely terminate the trigger body (issue #5468).
+                for _ in 0..(rest.len()) {
+                    if let Some(c) = chars.next() {
+                        current_statement.push(c);
+                    }
+                }
+                case_depth += 1;
+                continue;
             } else if word == "END" && begin_depth > 0 {
                 // Consume the rest of the word
                 for _ in 0..(rest.len()) {
@@ -406,7 +426,13 @@ fn parse_statements(script: &str) -> Vec<String> {
                         current_statement.push(c);
                     }
                 }
-                begin_depth -= 1;
+                if case_depth > 0 {
+                    // This END closes an inner CASE expression, not the
+                    // trigger body.
+                    case_depth -= 1;
+                } else {
+                    begin_depth -= 1;
+                }
                 continue;
             }
             // Not BEGIN/END, let normal processing continue
@@ -614,5 +640,74 @@ INSERT INTO logs VALUES (2, 'Success');
         assert_eq!(stmts[0], ".mode json");
         assert_eq!(stmts[1], "SELECT * FROM users;");
         assert_eq!(stmts[2], ".tables");
+    }
+
+    #[test]
+    fn test_parse_trigger_body_simple() {
+        // A trigger body with an inner `;` must stay a single statement.
+        let script = "CREATE TRIGGER t AFTER INSERT ON tbl BEGIN \
+            INSERT INTO log VALUES (1); UPDATE log SET x = 2; END;";
+        let stmts = parse_statements(script);
+        assert_eq!(stmts.len(), 1, "trigger body should be one statement");
+        assert!(stmts[0].starts_with("CREATE TRIGGER t"));
+        assert!(stmts[0].trim_end().ends_with("END;"));
+    }
+
+    #[test]
+    fn test_parse_trigger_body_with_case_end() {
+        // Issue #5468: the END of a CASE...END expression inside a trigger body
+        // must not be treated as the trigger's terminating END.
+        let script = "CREATE TRIGGER before_tbl_insert BEFORE INSERT ON tbl BEGIN \
+            SELECT CASE WHEN (new.a = 4) THEN RAISE(IGNORE) END; END;";
+        let stmts = parse_statements(script);
+        assert_eq!(
+            stmts.len(),
+            1,
+            "CASE...END inside a trigger body must not split the statement, got: {:?}",
+            stmts
+        );
+        assert!(stmts[0].contains("CASE WHEN"));
+        assert!(stmts[0].contains("RAISE(IGNORE)"));
+        // The whole CREATE TRIGGER, including its terminating END, is captured.
+        assert!(stmts[0].trim_end().ends_with("END;"));
+    }
+
+    #[test]
+    fn test_parse_case_trigger_followed_by_statements() {
+        // A CASE-trigger must split cleanly from statements that follow it.
+        let script = "CREATE TABLE tbl(a, b, c); \
+            CREATE TRIGGER before_tbl_insert BEFORE INSERT ON tbl BEGIN \
+            SELECT CASE WHEN (new.a = 4) THEN RAISE(IGNORE) END; END; \
+            INSERT INTO tbl VALUES (1, 2, 3); SELECT * FROM tbl;";
+        let stmts = parse_statements(script);
+        assert_eq!(stmts.len(), 4, "expected 4 statements, got: {:?}", stmts);
+        assert!(stmts[0].starts_with("CREATE TABLE tbl"));
+        assert!(stmts[1].starts_with("CREATE TRIGGER"));
+        assert!(stmts[1].contains("CASE WHEN"));
+        assert!(stmts[1].trim_end().ends_with("END;"));
+        assert!(stmts[2].starts_with("INSERT INTO tbl"));
+        assert!(stmts[3].starts_with("SELECT * FROM tbl"));
+    }
+
+    #[test]
+    fn test_parse_trigger_body_with_nested_case() {
+        // Multiple / nested CASE...END expressions in one trigger body.
+        let script = "CREATE TRIGGER t BEFORE UPDATE ON tbl BEGIN \
+            SELECT CASE WHEN a = 1 THEN CASE WHEN b = 2 THEN RAISE(ABORT, 'x') END END; \
+            SELECT CASE WHEN c = 3 THEN RAISE(IGNORE) END; END;";
+        let stmts = parse_statements(script);
+        assert_eq!(stmts.len(), 1, "nested CASE...END must stay one statement: {:?}", stmts);
+        assert!(stmts[0].trim_end().ends_with("END;"));
+    }
+
+    #[test]
+    fn test_parse_top_level_case_still_splits() {
+        // A CASE...END expression OUTSIDE any trigger body must split normally
+        // on its trailing semicolon (no false CASE tracking).
+        let script = "SELECT CASE WHEN a = 1 THEN 'x' ELSE 'y' END FROM t; SELECT 2;";
+        let stmts = parse_statements(script);
+        assert_eq!(stmts.len(), 2);
+        assert!(stmts[0].contains("CASE WHEN"));
+        assert_eq!(stmts[1], "SELECT 2;");
     }
 }

--- a/crates/vibesql-storage/src/persistence/load.rs
+++ b/crates/vibesql-storage/src/persistence/load.rs
@@ -102,6 +102,15 @@ pub fn parse_sql_statements(content: &str) -> Result<Vec<String>, StorageError> 
     // BEGIN/END nesting depth. While > 0, semicolons inside the trigger body do
     // not terminate the outer statement.
     let mut begin_depth: u32 = 0;
+    // CASE...END nesting depth *within* a trigger body. A `CASE ... END`
+    // expression in a trigger action (e.g.
+    // `SELECT CASE WHEN new.a = 4 THEN RAISE(IGNORE) END`) introduces an inner
+    // `END` that must NOT be counted as the trigger's terminating `END`.
+    // Without this, reloading a dumped `CREATE TRIGGER ... BEGIN ... CASE ...
+    // END ... END;` is split at the CASE's `END`, truncating the trigger body
+    // (issue #5468). Only tracked while inside a trigger body
+    // (`begin_depth > 0`); top-level CASE expressions split on their `;`.
+    let mut case_depth: u32 = 0;
 
     for line in content.lines() {
         let trimmed = line.trim();
@@ -143,8 +152,22 @@ pub fn parse_sql_statements(content: &str) -> Result<Vec<String>, StorageError> 
                         i += consumed;
                         continue;
                     }
+                    // A CASE expression inside a trigger body opens a block that
+                    // its own END closes; track it so END does not prematurely
+                    // close the trigger body (issue #5468).
+                    if begin_depth > 0 {
+                        if let Some(consumed) = match_keyword(&chars, i, "CASE") {
+                            case_depth += 1;
+                            current_statement.push_str("CASE");
+                            i += consumed;
+                            continue;
+                        }
+                    }
                     if let Some(consumed) = match_keyword(&chars, i, "END") {
-                        if begin_depth > 0 {
+                        if case_depth > 0 {
+                            // Closes an inner CASE expression, not the body.
+                            case_depth -= 1;
+                        } else if begin_depth > 0 {
                             begin_depth -= 1;
                         }
                         current_statement.push_str("END");
@@ -353,6 +376,49 @@ SELECT 1;
 "#;
         let statements = parse_sql_statements(content).unwrap();
         assert_eq!(statements.len(), 2);
+        assert!(statements[0].contains("CREATE TRIGGER"));
+        assert!(statements[1].trim().starts_with("SELECT 1"));
+    }
+
+    #[test]
+    fn test_parse_trigger_body_with_case_end() {
+        // Issue #5468: a CASE...END expression inside a trigger body must not
+        // have its END counted as the trigger's terminating END when a dump is
+        // reloaded.
+        let content = r#"
+CREATE TABLE tbl(a, b, c);
+CREATE TRIGGER before_tbl_insert BEFORE INSERT ON tbl BEGIN SELECT CASE WHEN (new.a = 4) THEN RAISE(IGNORE) END; END;
+INSERT INTO tbl VALUES(1, 2, 3);
+"#;
+        let statements = parse_sql_statements(content).unwrap();
+        assert_eq!(statements.len(), 3, "got: {:#?}", statements);
+        assert!(statements[0].contains("CREATE TABLE"));
+        assert!(statements[1].contains("CREATE TRIGGER"));
+        assert!(statements[1].contains("CASE WHEN"));
+        assert!(statements[1].contains("RAISE(IGNORE)"));
+        // The trigger body's terminating END must be captured; without the
+        // CASE-depth fix the statement is truncated at the CASE's END and the
+        // trailing `END;` becomes a separate fragment.
+        assert!(
+            statements[1].contains("RAISE(IGNORE) END; END"),
+            "trigger body truncated at CASE END: {:?}",
+            statements[1]
+        );
+        assert!(statements[2].contains("INSERT INTO tbl VALUES(1, 2, 3)"));
+    }
+
+    #[test]
+    fn test_parse_trigger_body_with_nested_case() {
+        // Multiple / nested CASE...END expressions inside one trigger body.
+        let content = r#"
+CREATE TRIGGER tr BEFORE UPDATE ON t BEGIN
+  SELECT CASE WHEN a = 1 THEN CASE WHEN b = 2 THEN RAISE(ABORT, 'x') END END;
+  SELECT CASE WHEN c = 3 THEN RAISE(IGNORE) END;
+END;
+SELECT 1;
+"#;
+        let statements = parse_sql_statements(content).unwrap();
+        assert_eq!(statements.len(), 2, "got: {:#?}", statements);
         assert!(statements[0].contains("CREATE TRIGGER"));
         assert!(statements[1].trim().starts_with("SELECT 1"));
     }


### PR DESCRIPTION
Closes #5468

## Problem

The VibeSQL statement splitters treated the `END` of a `CASE ... END`
expression *inside a trigger body* as the trigger's terminating `END`,
splitting one `CREATE TRIGGER ... BEGIN ... CASE ... END ... END` into
multiple fragments.

Reproduction (from the issue):
```sql
CREATE TABLE tbl(a,b,c);
CREATE TRIGGER before_tbl_insert BEFORE INSERT ON tbl BEGIN SELECT CASE WHEN (new.a = 4) THEN RAISE(IGNORE) END; END;
```
Previously produced `Storage error: ... No active transaction to commit`
(the orphaned trailing `END;` was read as a transaction `END`/`COMMIT`),
and reloading a persisted such trigger failed with `Unexpected end of input
in trigger action`.

## Where the splitters are / the fix

Two distinct splitters had the same bug (both mirror the parser-side fix in
#5444):

1. **`crates/vibesql-cli/src/script.rs` — `parse_statements`**: splits
   multi-statement `-c` / file / stdin input. Used by `vibesql -c <sql>`,
   which is exactly what the TCL harness invokes (`scripts/tcl_runner.py`:
   `[vibesql, db, "-c", sql, "--format", "raw"]`).
2. **`crates/vibesql-storage/src/persistence/load.rs` — `parse_sql_statements`**:
   splits the persisted `.vbsql` dump on reload. This was the second blocker:
   the trigger created fine, but reloading the dump re-split it at the CASE's
   `END`, truncating the body.

Fix in both: track CASE nesting while inside a trigger body
(`begin_depth > 0`). A `CASE` opens a block that its own `END` closes, so the
trigger body terminates only at the `END` that matches its `BEGIN`. Top-level
CASE expressions are unaffected (no tracking when `begin_depth == 0`) and
still split on their trailing `;`. Nested CASE is handled.

The parser's `split_trigger_body_statements` could not be reused here: it
splits an *already-extracted* body, whereas these splitters must find where
the `CREATE TRIGGER` statement *ends* within a multi-statement stream.

## Verification vs sqlite3 3.51.0

```
$ vibesql db -c "CREATE TABLE tbl(a,b,c); CREATE TRIGGER before_tbl_insert BEFORE INSERT ON tbl BEGIN SELECT CASE WHEN (new.a = 4) THEN RAISE(IGNORE) END; END; INSERT INTO tbl VALUES (1,2,3); INSERT INTO tbl VALUES (4,5,6); SELECT * FROM tbl;" --format raw
123
```
sqlite3 3.51.0 prints `1|2|3` for the same input — RAISE(IGNORE) suppresses
the (4,5,6) insert; the trigger is created and fires correctly. The
create -> persist -> reload -> fire round-trip also works now.

## trigger3.test before / after

| | Total | Passed | Failed | Skipped |
|---|---|---|---|---|
| before | 0 (could not set up fixtures) | 0 | 0 | 0 |
| after | 23 | 14 | 3 | 6 |

The 3 remaining failures are unrelated to splitting (filed as follow-ons):
- `trigger3-1.2`, `trigger3-2.2`: RAISE(ABORT)/RAISE(FAIL) transaction
  rollback semantics ("No active transaction to rollback").
- `trigger3-6`: trigger recursion depth limit (max 16) vs SQLite default.

## Tests / regression

- New unit tests in `script.rs` (CASE-trigger one statement, CASE-trigger
  followed by other statements, nested CASE, top-level CASE still splits) and
  in `load.rs` (CASE-trigger reload, nested CASE).
- `cargo test -p vibesql-cli -p vibesql-storage`: all green.
- TCL regression: `select1.test` 188/188, `trigger1.test` now runs 84 tests
  (was failing the same trigger-body path), no 0-extraction regressions.
- No new clippy warnings in the changed files.

## Follow-ons to file
- RAISE(ABORT)/RAISE(FAIL) txn-rollback semantics in the TCL batch path
  (trigger3-1.2 / 2.2).
- Trigger recursion depth limit vs SQLite (trigger3-6).
- Remaining trigger1.test failures (separate trigger semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)