### PR TITLE
feat(web): surface HNSW recall@k on the trends dashboard

### DIFF
--- a/scripts/export_website_data.py
+++ b/scripts/export_website_data.py
@@ -132,6 +132,20 @@ class BenchmarkData:
             return None
         return max(suite_runs, key=lambda x: x[0])  # Max by RUN_ID
 
+    def table_exists(self, table: str) -> bool:
+        """Check whether a table exists in the database.
+
+        Some result DBs (e.g. environments where a particular benchmark has
+        never run) may not have every table. Callers should use this before
+        querying optional tables so a missing table degrades gracefully rather
+        than raising.
+        """
+        self.cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (table,),
+        )
+        return self.cursor.fetchone() is not None
+
     def get_table_results(self, table: str) -> List[tuple]:
         """Get all results from a table (cached)."""
         if table not in self._results_cache:
@@ -263,6 +277,61 @@ def export_sysbench_benchmarks(data: BenchmarkData) -> Optional[Dict]:
     return {
         "benchmarks": benchmarks,
         "metadata": {"suite": "sysbench", "timestamp": latest_timestamp, "git_commit": latest_commit, "table_size": latest_scale}
+    }
+
+
+def export_hnsw_recall_benchmarks(data: BenchmarkData) -> Optional[Dict]:
+    """Export HNSW recall@k results to JSON format.
+
+    Surfaces the latest HNSW recall benchmark run: recall@k measured across
+    index states (fresh / degraded-by-lazy-deletes / compacted) over a sweep of
+    ef_search and delete ratio. This is a *quality* metric (fraction of true
+    k-nearest neighbours returned vs brute-force ground truth), distinct from
+    the latency-oriented suites. See #5466 / #5480.
+
+    Returns a valid (possibly empty) payload so the web demo can render
+    gracefully even when no recall data has been collected. Returns None only
+    when the optional results table does not exist at all.
+    """
+    if not data.table_exists('hnsw_recall_results'):
+        return None
+
+    columns = data.get_table_columns('hnsw_recall_results')
+    col = {name: idx for idx, name in enumerate(columns)}
+
+    run = data.get_latest_run('hnsw')
+    if not run:
+        # Table exists but no run recorded yet — emit a valid empty payload.
+        return {
+            "measurements": [],
+            "metadata": {"suite": "hnsw_recall", "timestamp": None, "git_commit": None},
+        }
+
+    run_id, timestamp, commit = run[0], run[1], run[2]
+    results = data.get_results_for_run('hnsw_recall_results', run_id)
+
+    measurements = []
+    for row in results:
+        def field(name: str) -> Any:
+            idx = col.get(name)
+            return row[idx] if idx is not None and idx < len(row) else None
+
+        recall = field('recall')
+        measurements.append({
+            "k": field('k'),
+            "dataset_size": field('dataset_size'),
+            "dimensions": field('dimensions'),
+            "ef_search": field('ef_search_param'),
+            "delete_ratio": field('delete_ratio'),
+            "live_count": field('live_count'),
+            "deleted_count": field('deleted_count'),
+            "index_state": field('index_state'),
+            "recall": round(recall, 4) if recall is not None else None,
+        })
+
+    return {
+        "measurements": measurements,
+        "metadata": {"suite": "hnsw_recall", "timestamp": timestamp, "git_commit": commit},
     }
 
 
@@ -535,6 +604,55 @@ def export_trends(data: BenchmarkData) -> Dict:
             trends["sysbench"] = {
                 "suite": "sysbench", "display_name": "Sysbench",
                 "description": "OLTP micro-benchmarks", "data": sysbench_data
+            }
+
+    # HNSW recall@k trends (vector index quality under delete-heavy workloads)
+    # Stored in the optional hnsw_recall_results table (see #5466 / #5480).
+    # Each run records recall@k across index states (fresh / degraded /
+    # compacted) over a sweep of ef_search and delete ratio. We surface, per
+    # run, the mean recall for each index state so the headline regression
+    # — recall collapse under lazy deletes ("degraded") and its recovery via
+    # compaction — is visible over time next to the TPC / sysbench suites.
+    if data.table_exists('hnsw_recall_results'):
+        hnsw_runs = data.get_runs_by_suite('hnsw')
+        hnsw_columns = data.get_table_columns('hnsw_recall_results')
+        state_idx = hnsw_columns.index('index_state')
+        recall_idx = hnsw_columns.index('recall')
+
+        hnsw_data = []
+        for run in hnsw_runs:
+            run_id, timestamp, commit = run[0], run[1], run[2]
+            results = data.get_results_for_run('hnsw_recall_results', run_id)
+
+            # Bucket recall measurements by index state for this run.
+            state_recalls: Dict[str, List[float]] = {}
+            for row in results:
+                state = row[state_idx]
+                recall = row[recall_idx]
+                if state is None or recall is None:
+                    continue
+                state_recalls.setdefault(state, []).append(recall)
+
+            if not state_recalls:
+                continue
+
+            point: Dict[str, Any] = {
+                "date": timestamp[:10] if timestamp else "",
+                "timestamp": timestamp or "",
+                "commit": commit or "",
+            }
+            for state in ('fresh', 'degraded', 'compacted'):
+                vals = state_recalls.get(state)
+                if vals:
+                    point[f"recall_{state}"] = round(sum(vals) / len(vals), 4)
+            hnsw_data.append(point)
+
+        if hnsw_data:
+            trends["hnsw_recall"] = {
+                "suite": "hnsw_recall", "display_name": "HNSW Recall@k",
+                "description": "Vector index recall under delete-heavy workloads",
+                "metric": "recall", "metric_label": "Recall@k",
+                "data": hnsw_data
             }
 
     commit, _ = get_git_info()
@@ -1007,6 +1125,14 @@ def main():
             sqlite_count = tpcds['metadata']['sqlite_queries']
             duckdb_count = tpcds['metadata']['duckdb_queries']
             print(f"  TPC-DS: {len(tpcds['benchmarks'])} benchmarks (V:{vibesql_count} S:{sqlite_count} D:{duckdb_count}) -> {path.name}")
+            exported.append(path)
+
+        hnsw_recall = export_hnsw_recall_benchmarks(data)
+        if hnsw_recall is not None:
+            path = benchmarks_dir / "hnsw_recall_results.json"
+            with open(path, 'w') as f:
+                json.dump(hnsw_recall, f, indent=2)
+            print(f"  HNSW Recall: {len(hnsw_recall['measurements'])} measurements -> {path.name}")
             exported.append(path)
 
         tpch = export_tpch_benchmarks(data)

--- a/web-demo/src/trends.ts
+++ b/web-demo/src/trends.ts
@@ -2,7 +2,8 @@
  * Performance Trends page
  *
  * Loads and displays historical benchmark performance data for VibeSQL Embedded.
- * Shows trends over time for TPC-H, TPC-DS, TPC-C, and Sysbench benchmarks.
+ * Shows trends over time for TPC-H, TPC-DS, TPC-C, Sysbench, and HNSW recall@k
+ * benchmarks.
  */
 
 import './styles/main.css'
@@ -48,6 +49,9 @@ interface TrendDataPoint {
   tps?: number
   latency_us?: number
   workloads?: Record<string, number>
+  recall_fresh?: number
+  recall_degraded?: number
+  recall_compacted?: number
 }
 
 interface BenchmarkTrend {
@@ -68,6 +72,7 @@ interface TrendData {
     tpcds?: BenchmarkTrend
     tpcc?: BenchmarkTrend
     sysbench?: BenchmarkTrend
+    hnsw_recall?: BenchmarkTrend
   }
 }
 
@@ -92,6 +97,18 @@ const COLORS = {
     bg: 'rgba(34, 197, 94, 0.2)', // Green
     border: 'rgba(34, 197, 94, 1)',
   },
+  recallFresh: {
+    bg: 'rgba(59, 130, 246, 0.2)', // Blue
+    border: 'rgba(59, 130, 246, 1)',
+  },
+  recallDegraded: {
+    bg: 'rgba(239, 68, 68, 0.2)', // Red (recall collapse)
+    border: 'rgba(239, 68, 68, 1)',
+  },
+  recallCompacted: {
+    bg: 'rgba(34, 197, 94, 0.2)', // Green (recovery)
+    border: 'rgba(34, 197, 94, 1)',
+  },
 }
 
 // ============================================================================
@@ -111,6 +128,9 @@ function createTimeSeriesChart(
       color: { bg: string; border: string }
     }[]
     higherIsBetter?: boolean
+    // 'time' (ms), 'tps', or 'recall' (fraction in [0, 1]). Controls tooltip
+    // formatting and y-axis bounds. Defaults to 'time'.
+    valueMode?: 'time' | 'tps' | 'recall'
   }
 ): void {
   const canvas = document.getElementById(canvasId) as HTMLCanvasElement
@@ -197,7 +217,8 @@ function createTimeSeriesChart(
           },
         },
         y: {
-          beginAtZero: !config.higherIsBetter,
+          beginAtZero: config.valueMode === 'recall' ? true : !config.higherIsBetter,
+          max: config.valueMode === 'recall' ? 1 : undefined,
           title: {
             display: true,
             text: config.yAxisLabel,
@@ -238,7 +259,10 @@ function createTimeSeriesChart(
             label: (context: ChartTooltipItem) => {
               const value = context.parsed.y
               if (value === null) return `${context.dataset.label}: N/A`
-              if (config.higherIsBetter) {
+              if (config.valueMode === 'recall') {
+                return `${context.dataset.label}: ${value.toFixed(4)}`
+              }
+              if (config.valueMode === 'tps' || config.higherIsBetter) {
                 return `${context.dataset.label}: ${value.toFixed(2)} TPS`
               }
               return `${context.dataset.label}: ${value.toFixed(2)} ms`
@@ -279,6 +303,28 @@ function renderTPCCChart(trend: BenchmarkTrend): void {
     yAxisLabel: 'Transactions per Second (TPS)',
     datasets: [{ key: 'tps', label: 'TPS', color: COLORS.tps }],
     higherIsBetter: true,
+    valueMode: 'tps',
+  })
+}
+
+function renderHnswRecallChart(trend: BenchmarkTrend): void {
+  createTimeSeriesChart('hnsw-recall-chart', trend.data, {
+    yAxisLabel: 'Recall@k (higher is better)',
+    datasets: [
+      { key: 'recall_fresh', label: 'Fresh build', color: COLORS.recallFresh },
+      {
+        key: 'recall_degraded',
+        label: 'Degraded (lazy deletes)',
+        color: COLORS.recallDegraded,
+      },
+      {
+        key: 'recall_compacted',
+        label: 'Compacted',
+        color: COLORS.recallCompacted,
+      },
+    ],
+    higherIsBetter: true,
+    valueMode: 'recall',
   })
 }
 
@@ -440,6 +486,12 @@ async function init(): Promise<void> {
     showNoDataMessage('sysbench-chart', 'No Sysbench trend data available.')
   }
 
+  if (data.benchmarks.hnsw_recall && data.benchmarks.hnsw_recall.data.length > 0) {
+    renderHnswRecallChart(data.benchmarks.hnsw_recall)
+  } else {
+    showNoDataMessage('hnsw-recall-chart', 'No HNSW recall trend data available.')
+  }
+
   // Re-render charts on theme change (watch for dark class toggle)
   const observer = new MutationObserver(mutations => {
     for (const mutation of mutations) {
@@ -456,6 +508,9 @@ async function init(): Promise<void> {
         }
         if (data.benchmarks.sysbench && data.benchmarks.sysbench.data.length > 0) {
           renderSysbenchChart(data.benchmarks.sysbench)
+        }
+        if (data.benchmarks.hnsw_recall && data.benchmarks.hnsw_recall.data.length > 0) {
+          renderHnswRecallChart(data.benchmarks.hnsw_recall)
         }
         break
       }

--- a/web-demo/trends.html
+++ b/web-demo/trends.html
@@ -117,6 +117,20 @@
         </div>
       </div>
 
+      <!-- HNSW Recall Trend Chart -->
+      <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 border border-gray-300 dark:border-gray-600">
+        <h2 class="text-2xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
+          HNSW Recall@k Trend
+        </h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+          Vector index search quality under delete-heavy workloads - showing recall@k for fresh,
+          degraded (lazy deletes), and compacted index states (higher is better)
+        </p>
+        <div class="relative" style="height: 350px;">
+          <canvas id="hnsw-recall-chart"></canvas>
+        </div>
+      </div>
+
       <!-- Methodology Note -->
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 border border-gray-300 dark:border-gray-600">
         <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
@@ -131,6 +145,7 @@
             <li><strong>TPC-H & TPC-DS:</strong> Decision support benchmarks measuring query execution time (lower is better)</li>
             <li><strong>TPC-C:</strong> OLTP benchmark measuring transactions per second (higher is better)</li>
             <li><strong>Sysbench:</strong> Micro-benchmarks measuring individual operation latency (lower is better)</li>
+            <li><strong>HNSW Recall@k:</strong> Approximate vector search quality (fraction of true k-nearest neighbours returned vs brute-force ground truth) under delete-heavy workloads; recall collapses under lazy deletes ("degraded") and recovers after compaction (higher is better)</li>
           </ul>
           <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">
             Charts show the min (best), avg, and max (worst) performance for each run.


### PR DESCRIPTION
## Summary

Closes #5480. Follow-on from #5466 / PR #5476 (merged), which added the `hnsw_recall_results` table to the dogfooded `benchmark_results.vbsql`. The web demo didn't display it yet — this PR is pure presentation/export work (no Rust, no benchmark changes; the data capture already exists).

## What was exported

`scripts/export_website_data.py`:
- `BenchmarkData.table_exists(table)` — new helper so optional result tables degrade gracefully instead of raising when absent.
- `export_hnsw_recall_benchmarks(data)` — writes `web-demo/public/benchmarks/hnsw_recall_results.json` with the latest HNSW run's per-config measurements (`k`, `dataset_size`, `dimensions`, `ef_search` [from `ef_search_param`], `delete_ratio`, `live_count`, `deleted_count`, `index_state`, `recall`). Wired into `main()`.
- `export_trends(data)` — new `hnsw_recall` section: per-run mean recall@k for `fresh` / `degraded` / `compacted` index states, added to `trends_results.json`.

## Web-demo view added

`web-demo/src/trends.ts` + `web-demo/trends.html`: a new **HNSW Recall@k Trend** chart sitting alongside the existing TPC-H/TPC-DS/TPC-C/Sysbench charts. It reuses the existing `createTimeSeriesChart` helper and `trends_results.json` loading pattern. Three series (fresh / degraded-by-lazy-deletes / compacted) make the headline story visible: recall collapses under delete-heavy workloads and recovers after compaction. A new `valueMode: 'recall'` formats the tooltip as a fraction and bounds the y-axis to [0, 1].

## Empty-data handling

- If `hnsw_recall_results` does not exist (as in this environment — the bench has not been run locally), the exporter skips it cleanly; `export_website_data.py` runs to completion (verified — 7 files exported, no crash).
- If the table exists but has no rows, the exporter emits a valid empty payload (`{"measurements": [], ...}`).
- The web-demo view calls `showNoDataMessage('hnsw-recall-chart', ...)` when the `hnsw_recall` trend is missing/empty, so the page renders gracefully.
- No synthetic/seeded recall numbers are committed. The regenerated `benchmark_results.json` / `trends_results.json` / `dashboard.json` (which `export_website_data.py` rewrites with *local* machine data) were reverted — those are updated by dedicated `chore(web): update benchmark data` commits, matching the existing convention. The new recall JSON will appear on the next real benchmark export.

## Verification

- `python3 ./scripts/export_website_data.py` — completes, no crash with the table absent.
- Exporter JSON shape validated with a synthetic in-memory cursor (not committed): both `hnsw_recall_results.json` and the trends `hnsw_recall` section produce correct output; latest-run selection works.
- `pnpm install` + `pnpm lint` — clean (0 errors; only pre-existing `no-console` warnings in unrelated files). `trends.ts` passes eslint and prettier.
- `pnpm build` / `tsc --noEmit` — the only error is `Cannot find module '../../public/pkg/vibesql_wasm.js'`, a pre-existing environment limitation (the WASM artifact is generated by `make build-wasm` from Rust and is untracked/absent here). It is unrelated to this change; my TS compiles cleanly.
- Browser dev-server render not exercised because the WASM artifact required to boot the demo locally is not built in this environment. The new chart follows the exact pattern of the existing trend charts and uses the same no-data fallback they do.

## Follow-ons

- Once the HNSW bench has run and recorded rows, regenerate website data (`make website`) and commit `hnsw_recall_results.json` + updated `trends_results.json` via the usual `chore(web)` data-update commit.
- Optional future enhancement: a recall-vs-`ef_search` chart (the per-config data is already exported in `hnsw_recall_results.json`); this PR surfaces the over-time trend, which is the headline metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)