### PR TITLE
fix(server): expand wildcards in extended-protocol Describe RowDescription

### DIFF
--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -416,6 +416,102 @@ impl SelectExecutor<'_> {
         }
     }
 
+    /// Resolve the output column names of a SELECT statement WITHOUT returning rows.
+    ///
+    /// This is the read-only column-name resolver used by the PostgreSQL extended
+    /// query protocol's `Describe` message (#5429), which must report the
+    /// `RowDescription` before any `Execute`. It reuses the exact wildcard
+    /// expansion and expression-naming logic as [`execute_with_columns`]
+    /// (`derive_column_names`), so the names match the simple-query path
+    /// label-for-label, including:
+    /// - explicit columns and aliases (`SELECT a, b AS x` -> `[a, x]`)
+    /// - `SELECT *` / `t.*` expanded against the catalog schema
+    /// - join wildcards (`SELECT t1.*, t2.c` -> t1's columns then `c`)
+    /// - derived names for expression columns
+    ///
+    /// Unlike `execute_with_columns`, this does NOT materialize result rows: it
+    /// builds the FROM-clause schema (the same `FromResult` the executor uses)
+    /// purely to expand wildcards, then derives the names.
+    pub fn resolve_column_names(
+        &self,
+        stmt: &vibesql_ast::SelectStmt,
+    ) -> Result<Vec<String>, ExecutorError> {
+        // Guard exponentially self-referential view nests before touching the
+        // FROM clause (which materializes views), mirroring execute_with_columns
+        // (#5394, view3.test).
+        crate::select::view_reference_guard::check_view_reference_limit(stmt, self.database)?;
+
+        // Resolve SELECT aliases in WHERE clause for schema construction, matching
+        // execute_with_columns so the FROM schema is built identically.
+        let resolved_where = if stmt.where_clause.is_some()
+            && crate::select::order::select_list_has_aliases(&stmt.select_list)
+        {
+            stmt.where_clause.as_ref().map(|where_expr| {
+                if let Some(from_clause) = &stmt.from {
+                    if let Some(early_schema) =
+                        super::aggregation::build_early_schema(from_clause, self.database)
+                    {
+                        return crate::select::order::resolve_where_aliases_with_schema(
+                            where_expr,
+                            &stmt.select_list,
+                            &early_schema,
+                        );
+                    }
+                }
+                crate::select::order::resolve_where_aliases(where_expr, &stmt.select_list)
+            })
+        } else {
+            stmt.where_clause.clone()
+        };
+
+        // Build the FROM result to access the combined schema. This is required
+        // to expand `*` / `table.*` against the real column layout (including
+        // joins and NATURAL/USING deduplication). We do not return the rows.
+        let from_result = if let Some(from_clause) = &stmt.from {
+            let mut cte_results = if let Some(with_clause) = &stmt.with_clause {
+                execute_ctes(with_clause, self.database, |query, cte_ctx| {
+                    self.execute_with_ctes(query, cte_ctx)
+                })?
+            } else {
+                HashMap::new()
+            };
+            if let Some(outer_cte_ctx) = self.cte_context {
+                for (name, result) in outer_cte_ctx {
+                    cte_results.entry(name.clone()).or_insert_with(|| result.clone());
+                }
+            }
+            let limit_val = stmt
+                .limit
+                .as_ref()
+                .map(|expr| self.eval_limit_offset_expr(expr, "LIMIT"))
+                .transpose()?;
+            Some(self.execute_from_with_where(
+                from_clause,
+                &cte_results,
+                resolved_where.as_ref(),
+                stmt.order_by.as_deref(),
+                limit_val,
+                Some(&stmt.select_list),
+            )?)
+        } else {
+            None
+        };
+
+        // Derive column names exactly as execute_with_columns does.
+        let columns = if stmt.select_list.is_empty() {
+            if let Some(values_rows) = &stmt.values {
+                let num_cols = values_rows.first().map(|r| r.len()).unwrap_or(0);
+                (1..=num_cols).map(|i| format!("column{}", i)).collect()
+            } else {
+                Vec::new()
+            }
+        } else {
+            self.derive_column_names(&stmt.select_list, from_result.as_ref())?
+        };
+
+        Ok(columns)
+    }
+
     /// Execute a SELECT statement and return both columns and rows
     pub fn execute_with_columns(
         &self,

--- a/crates/vibesql-server/src/connection/extended.rs
+++ b/crates/vibesql-server/src/connection/extended.rs
@@ -36,6 +36,78 @@ use vibesql_ast::{SelectItem, Statement};
 /// PostgreSQL OID for TEXT type (used as default for unspecified parameter types)
 const TEXT_OID: i32 = 25;
 
+/// Resolve a query's output column names and send the appropriate Describe
+/// reply: `RowDescription` for a SELECT (column names resolved against the
+/// schema, so `SELECT *` / `table.*` report their real columns — #5429), or
+/// `NoData` for a non-SELECT / unresolvable query.
+///
+/// Resolution goes through [`Session::describe_columns`], which uses the same
+/// `derive_column_names` logic as the executed simple-query path
+/// (`execute_with_columns`), so the metadata clients fetch via Describe matches
+/// the rows they later receive. If no session is available, or schema-aware
+/// resolution fails, it falls back to the static-AST extractor
+/// ([`extract_select_columns`]) which handles explicit/aliased columns.
+async fn send_row_description(
+    session: &Option<Session>,
+    query: &str,
+    write_half: &mut OwnedWriteHalf,
+    write_buf: &mut BytesMut,
+) -> anyhow::Result<()> {
+    // Prefer schema-aware resolution (expands `*` / `table.*`).
+    if let Some(s) = session.as_ref() {
+        match s.describe_columns(query).await {
+            Ok(Some(columns)) => {
+                send_fields(write_half, write_buf, columns).await?;
+                return Ok(());
+            }
+            // Not a SELECT (or resolved to no columns) - NoData.
+            Ok(None) => {
+                send_message(write_half, write_buf, &BackendMessage::NoData).await?;
+                return Ok(());
+            }
+            // Schema-aware resolution failed (e.g. table not yet created at
+            // Describe time): fall through to the static-AST extractor, which
+            // still covers explicit/aliased columns. Errors surface at Execute.
+            Err(e) => {
+                debug!("describe_columns failed, falling back to static AST: {}", e);
+            }
+        }
+    }
+
+    // Fallback: static AST extraction (no schema, so `*` yields NoData).
+    match Parser::parse_sql(query) {
+        Ok(parsed) => match extract_select_columns(&parsed) {
+            Some(columns) => send_fields(write_half, write_buf, columns).await?,
+            None => send_message(write_half, write_buf, &BackendMessage::NoData).await?,
+        },
+        // Parse failed - NoData (error will occur at execute time).
+        Err(_) => send_message(write_half, write_buf, &BackendMessage::NoData).await?,
+    }
+
+    Ok(())
+}
+
+/// Send a `RowDescription` for the given resolved column names.
+async fn send_fields(
+    write_half: &mut OwnedWriteHalf,
+    write_buf: &mut BytesMut,
+    columns: Vec<String>,
+) -> anyhow::Result<()> {
+    let fields: Vec<FieldDescription> = columns
+        .into_iter()
+        .map(|name| FieldDescription {
+            name,
+            table_oid: 0,
+            column_attr_number: 0,
+            data_type_oid: TEXT_OID,
+            data_type_size: -1,
+            type_modifier: -1,
+            format_code: 0,
+        })
+        .collect();
+    send_message(write_half, write_buf, &BackendMessage::RowDescription { fields }).await
+}
+
 /// Extract column names from a SELECT statement without executing it
 fn extract_select_columns(stmt: &Statement) -> Option<Vec<String>> {
     match stmt {
@@ -228,6 +300,7 @@ pub async fn handle_bind(
 
 /// Handle Describe message - get information about a statement or portal
 pub async fn handle_describe(
+    session: &Option<Session>,
     extended_state: &ExtendedQueryState,
     write_half: &mut OwnedWriteHalf,
     write_buf: &mut BytesMut,
@@ -263,36 +336,15 @@ pub async fn handle_describe(
             )
             .await?;
 
-            // Try to extract column names from the parsed query AST
-            if let Ok(parsed) = Parser::parse_sql(&stmt.query) {
-                if let Some(columns) = extract_select_columns(&parsed) {
-                    let fields: Vec<FieldDescription> = columns
-                        .into_iter()
-                        .map(|name| FieldDescription {
-                            name,
-                            table_oid: 0,
-                            column_attr_number: 0,
-                            data_type_oid: TEXT_OID,
-                            data_type_size: -1,
-                            type_modifier: -1,
-                            format_code: 0,
-                        })
-                        .collect();
-                    send_message(write_half, write_buf, &BackendMessage::RowDescription { fields })
-                        .await?;
-                } else {
-                    // Query has wildcards or is not a SELECT - send NoData
-                    send_message(write_half, write_buf, &BackendMessage::NoData).await?;
-                }
-            } else {
-                // Parse failed - send NoData (error will occur at execute time)
-                send_message(write_half, write_buf, &BackendMessage::NoData).await?;
-            }
+            // Resolve the SELECT's output column names against the schema so
+            // that `SELECT *` / `table.*` report their real columns in the
+            // RowDescription (#5429), matching the simple-query path.
+            send_row_description(session, &stmt.query, write_half, write_buf).await?;
         }
         b'P' => {
             // Describe portal
             let portal = match extended_state.get_portal(&name) {
-                Some(p) => p,
+                Some(p) => p.clone(),
                 None => {
                     send_error(
                         write_half,
@@ -305,31 +357,9 @@ pub async fn handle_describe(
                 }
             };
 
-            // Try to extract column names from the bound query AST
-            if let Ok(parsed) = Parser::parse_sql(&portal.bound_query) {
-                if let Some(columns) = extract_select_columns(&parsed) {
-                    let fields: Vec<FieldDescription> = columns
-                        .into_iter()
-                        .map(|name| FieldDescription {
-                            name,
-                            table_oid: 0,
-                            column_attr_number: 0,
-                            data_type_oid: TEXT_OID,
-                            data_type_size: -1,
-                            type_modifier: -1,
-                            format_code: 0,
-                        })
-                        .collect();
-                    send_message(write_half, write_buf, &BackendMessage::RowDescription { fields })
-                        .await?;
-                } else {
-                    // Query has wildcards or is not a SELECT - send NoData
-                    send_message(write_half, write_buf, &BackendMessage::NoData).await?;
-                }
-            } else {
-                // Parse failed - send NoData
-                send_message(write_half, write_buf, &BackendMessage::NoData).await?;
-            }
+            // Resolve the bound query's output column names (with `*` expanded
+            // against the schema) for the RowDescription (#5429).
+            send_row_description(session, &portal.bound_query, write_half, write_buf).await?;
         }
         _ => {
             send_error(

--- a/crates/vibesql-server/src/connection/mod.rs
+++ b/crates/vibesql-server/src/connection/mod.rs
@@ -475,6 +475,7 @@ impl ConnectionHandler {
 
             FrontendMessage::Describe { target_type, name } => {
                 handle_describe(
+                    &self.session,
                     &self.extended_state,
                     &mut self.write_half,
                     &mut self.write_buf,

--- a/crates/vibesql-server/src/session.rs
+++ b/crates/vibesql-server/src/session.rs
@@ -416,6 +416,44 @@ impl Session {
         self.execute_prepared(&prepared, params).await
     }
 
+    /// Resolve the output column names of a query for the extended-protocol
+    /// `Describe` message (#5429), WITHOUT executing it.
+    ///
+    /// `Describe` must report the `RowDescription` before any `Execute`, so for
+    /// a SELECT we resolve the result column names (explicit columns, aliases,
+    /// derived expression names, and `SELECT *` / `table.*` expanded against the
+    /// catalog schema). Returns:
+    /// - `Ok(Some(names))` for a SELECT — these match the simple-query path
+    ///   label-for-label (`SelectExecutor::resolve_column_names`, the same
+    ///   `derive_column_names` used by `execute_with_columns`).
+    /// - `Ok(None)` for a non-SELECT (the protocol sends `NoData`).
+    ///
+    /// Standalone resolves directly against the local database; replicated
+    /// resolves via a local read through consensus (the state machine already
+    /// resolves names the same way, #5428), so both modes agree.
+    pub async fn describe_columns(&self, sql: &str) -> Result<Option<Vec<String>>> {
+        let prepared = self.stmt_cache.get_or_prepare(sql).map_err(|e| anyhow::anyhow!("{}", e))?;
+        let statement = prepared.statement();
+
+        let select_stmt = match statement {
+            vibesql_ast::Statement::Select(select_stmt) => select_stmt,
+            _ => return Ok(None),
+        };
+
+        if let Some(state) = self.replication.as_ref() {
+            // Replicated: the database lives in the consensus state machine.
+            // A local read resolves the same column names the simple-query
+            // path uses (#5428); we keep only the names, discarding rows.
+            let result = state.handle.query_local(sql)?;
+            return Ok(Some(result.columns));
+        }
+
+        let db = self.db.read().await;
+        let executor = vibesql_executor::SelectExecutor::new(&db);
+        let columns = executor.resolve_column_names(select_stmt)?;
+        Ok(Some(columns))
+    }
+
     /// Execute one statement of a **replicated** session (#5383): writes
     /// are proposed through consensus (`MvccRaftNode::execute_replicated`,
     /// leader-only, freeze-at-propose), reads run against the replicated

--- a/crates/vibesql-server/tests/extended_protocol_tests.rs
+++ b/crates/vibesql-server/tests/extended_protocol_tests.rs
@@ -176,3 +176,128 @@ async fn test_extended_protocol_error() {
 
     server.shutdown();
 }
+
+/// Connect a tokio-postgres client and spawn its connection task.
+async fn connect_client(server: &common::TestServer) -> tokio_postgres::Client {
+    let (client, connection) = tokio_postgres::connect(
+        &format!("host=127.0.0.1 port={} user=postgres dbname=test", server.addr().port()),
+        NoTls,
+    )
+    .await
+    .expect("Failed to connect");
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("Connection error: {}", e);
+        }
+    });
+    client
+}
+
+/// Extended-protocol Describe must report the result column names in the
+/// `RowDescription` *before* Execute. `tokio_postgres::Client::prepare`
+/// issues Parse + Describe and exposes the RowDescription via
+/// `Statement::columns()`, so this is a true wire-level assertion (#5429).
+///
+/// Before the fix, `SELECT *` / `table.*` resolved to `NoData` (no column
+/// names) because the Describe path used a static AST that could not expand
+/// wildcards. Now Describe expands `*` against the schema, matching what the
+/// executed query returns.
+#[tokio::test]
+async fn test_describe_resolves_wildcard_and_explicit_columns() {
+    let server = start_test_server().await;
+    let client = connect_client(&server).await;
+
+    client
+        .execute("CREATE TABLE t (a INTEGER, b TEXT, c INTEGER)", &[])
+        .await
+        .expect("create table");
+
+    // SELECT * -> Describe must list the table's actual columns in order.
+    let stmt = client.prepare("SELECT * FROM t").await.expect("prepare SELECT *");
+    let names: Vec<&str> = stmt.columns().iter().map(|c| c.name()).collect();
+    assert_eq!(names, vec!["a", "b", "c"], "SELECT * Describe column names");
+
+    // table.* -> same expansion.
+    let stmt = client.prepare("SELECT t.* FROM t").await.expect("prepare SELECT t.*");
+    let names: Vec<&str> = stmt.columns().iter().map(|c| c.name()).collect();
+    assert_eq!(names, vec!["a", "b", "c"], "SELECT t.* Describe column names");
+
+    // Explicit columns and an alias.
+    let stmt =
+        client.prepare("SELECT a, b AS x FROM t").await.expect("prepare explicit+alias");
+    let names: Vec<&str> = stmt.columns().iter().map(|c| c.name()).collect();
+    assert_eq!(names, vec!["a", "x"], "explicit + aliased Describe column names");
+
+    server.shutdown();
+}
+
+/// Describe for a join wildcard must expand each table's columns in order:
+/// `SELECT t1.*, t2.c` -> t1's columns followed by `c` (#5429).
+#[tokio::test]
+async fn test_describe_join_wildcard_columns() {
+    let server = start_test_server().await;
+    let client = connect_client(&server).await;
+
+    client.execute("CREATE TABLE t1 (a INTEGER, b INTEGER)", &[]).await.expect("create t1");
+    client.execute("CREATE TABLE t2 (id INTEGER, c TEXT)", &[]).await.expect("create t2");
+
+    let stmt = client
+        .prepare("SELECT t1.*, t2.c FROM t1 JOIN t2 ON t1.a = t2.id")
+        .await
+        .expect("prepare join wildcard");
+    let names: Vec<&str> = stmt.columns().iter().map(|c| c.name()).collect();
+    assert_eq!(names, vec!["a", "b", "c"], "join wildcard Describe column names");
+
+    server.shutdown();
+}
+
+/// The Describe `RowDescription` must agree with what the executed
+/// (simple-query / `client.query`) path returns for the same SELECT (#5429,
+/// parity with #5428). We compare the prepared statement's column names
+/// against the executed result's column names for each query shape.
+#[tokio::test]
+async fn test_describe_matches_executed_columns() {
+    let server = start_test_server().await;
+    let client = connect_client(&server).await;
+
+    client
+        .execute("CREATE TABLE t (a INTEGER, b TEXT, c INTEGER)", &[])
+        .await
+        .expect("create table");
+    client.execute("INSERT INTO t VALUES (1, 'x', 2)", &[]).await.expect("insert");
+
+    for sql in [
+        "SELECT * FROM t",
+        "SELECT t.* FROM t",
+        "SELECT a, b FROM t",
+        "SELECT a AS x, b AS y FROM t",
+        "SELECT a + c AS sum FROM t",
+    ] {
+        // Describe (Parse + Describe) column names.
+        let stmt = client.prepare(sql).await.unwrap_or_else(|e| panic!("prepare {sql}: {e}"));
+        let described: Vec<String> =
+            stmt.columns().iter().map(|c| c.name().to_string()).collect();
+
+        // Executed result column names.
+        let rows = client.query(sql, &[]).await.unwrap_or_else(|e| panic!("query {sql}: {e}"));
+        let executed: Vec<String> =
+            rows[0].columns().iter().map(|c| c.name().to_string()).collect();
+
+        assert_eq!(
+            described, executed,
+            "Describe vs executed column names disagree for `{sql}`"
+        );
+
+        let is_placeholder = |n: &str| {
+            n.strip_prefix("col").is_some_and(|rest| {
+                !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit())
+            })
+        };
+        assert!(
+            !described.iter().any(|n| is_placeholder(n)),
+            "Describe produced placeholder column names for `{sql}`: {described:?}"
+        );
+    }
+
+    server.shutdown();
+}

--- a/crates/vibesql-server/tests/replication_tests.rs
+++ b/crates/vibesql-server/tests/replication_tests.rs
@@ -256,6 +256,83 @@ async fn replicated_select_column_names_match_standalone() {
     assert_eq!(star, vec!["a".to_string(), "b".to_string()]);
 }
 
+/// Extended-protocol `Describe` (#5429) must report the same column names in
+/// replicated mode as it does standalone, with `SELECT *` / `table.*` expanded
+/// against the schema. `Session::describe_columns` resolves names WITHOUT
+/// executing — for a replicated session it routes through a local consensus
+/// read (`query_local`), which resolves names the same way the executed read
+/// path does (#5428). Standalone (the local executor's `resolve_column_names`)
+/// is the oracle: the two must agree label-for-label, and neither may regress
+/// to `col0`/`col1` placeholders.
+#[tokio::test]
+async fn replicated_describe_columns_match_standalone() {
+    let setup = [
+        "CREATE TABLE t (a INT, b INT)",
+        "CREATE TABLE u (a INT, c VARCHAR(10))",
+        "INSERT INTO t VALUES (1, 10)",
+        "INSERT INTO u VALUES (1, 'one')",
+    ];
+
+    // Describe targets: each query shape that must resolve identically.
+    let selects = [
+        "SELECT a, b FROM t",                          // explicit columns
+        "SELECT a AS x, b AS y FROM t",                // aliases
+        "SELECT a + 1 FROM t",                         // derived expression
+        "SELECT * FROM t",                             // wildcard expansion
+        "SELECT t.* FROM t",                           // table wildcard
+        "SELECT t.*, u.c FROM t JOIN u ON t.a = u.a",  // join wildcard
+    ];
+
+    // Standalone oracle.
+    let mut standalone = Session::new(
+        "testdb".to_string(),
+        "testuser".to_string(),
+        SharedDatabase::new(Database::new()),
+    );
+    for sql in setup {
+        standalone.execute(sql).await.expect("standalone setup");
+    }
+
+    // Replicated leader session.
+    let (handles, _dir) = boot_cluster(1).await;
+    wait_for_leader(&handles).await;
+    let mut replicated = replicated_session(&handles[0]);
+    for sql in setup {
+        replicated.execute(sql).await.expect("replicated setup");
+    }
+
+    for sql in selects {
+        let standalone_cols = standalone
+            .describe_columns(sql)
+            .await
+            .expect("standalone describe")
+            .unwrap_or_else(|| panic!("{sql}: standalone describe returned None for a SELECT"));
+        let replicated_cols = replicated
+            .describe_columns(sql)
+            .await
+            .expect("replicated describe")
+            .unwrap_or_else(|| panic!("{sql}: replicated describe returned None for a SELECT"));
+
+        assert!(
+            !replicated_cols.iter().any(|name| name.starts_with("col")),
+            "{sql}: replicated Describe must not emit col0/col1 placeholders, got {replicated_cols:?}",
+        );
+        assert_eq!(
+            replicated_cols, standalone_cols,
+            "{sql}: replicated Describe column names must match standalone",
+        );
+    }
+
+    // Spot-check the resolved wildcard names so a regression in BOTH paths
+    // cannot pass silently by agreeing on the wrong answer.
+    let star = replicated.describe_columns("SELECT * FROM t").await.unwrap().unwrap();
+    assert_eq!(star, vec!["a".to_string(), "b".to_string()]);
+
+    // A non-SELECT Describe resolves to None (the protocol sends NoData).
+    let non_select = replicated.describe_columns("INSERT INTO t VALUES (2, 20)").await.unwrap();
+    assert!(non_select.is_none(), "non-SELECT Describe must be None, got {non_select:?}");
+}
+
 /// Unsupported features fail with SQLSTATE 0A000 and a follow-on
 /// pointer; invalid SET values fail with 22023.
 #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #5429

The PostgreSQL extended-query-protocol `Describe` message (statement and portal) reported **no column names** for `SELECT *` / `table.*`. `handle_describe` in `crates/vibesql-server/src/connection/extended.rs` resolved column names from a **static AST** (`extract_select_columns`), which cannot expand wildcards without schema — so it emitted `NoData` and PG clients saw empty result metadata before fetching rows.

### Where the empty RowDescription came from
`handle_describe` parsed the query AST and called `extract_select_columns`. For any query containing `*` / `table.*` (or otherwise unresolvable from the AST alone), that returned `None`, and Describe sent `BackendMessage::NoData` instead of a populated `RowDescription`.

### How wildcard expansion was added
- New read-only resolver `SelectExecutor::resolve_column_names` (`crates/vibesql-executor/src/select/executor/execute.rs`): builds the FROM-clause schema (same `FromResult` the executor uses) purely to expand `*` / `table.*` against the real column layout, then derives names via the **exact same** `derive_column_names` used by `execute_with_columns` (#5428). It does **not** materialize rows. It also carries over the view-reference guard and WHERE-alias resolution so the schema is built identically to the executed path.
- `Session::describe_columns` (`crates/vibesql-server/src/session.rs`): drives resolution for both **standalone** (local executor `resolve_column_names`) and **replicated** (local consensus read via `query_local`) sessions; returns `Some(names)` for a SELECT, `None` for non-SELECT (NoData).
- `send_row_description` (`extended.rs`): prefers schema-aware resolution and falls back to the static-AST extractor only if no session is available or resolution fails (e.g. table not yet created — error then surfaces at Execute). Both the statement (`S`) and portal (`P`) Describe branches now route through it.

### Parity with the simple-query path (#5428)
Because Describe reuses `derive_column_names` (the same logic `execute_with_columns` uses), the `RowDescription` matches the executed query's columns label-for-label: explicit columns, aliases, derived expression names, `SELECT *` / `t.*`, and join wildcards. Replicated mode resolves through the same consensus read path the executed query uses, so standalone and replicated agree.

## Test evidence
Wire-level (tokio-postgres `prepare` issues Parse+Describe, exposing `RowDescription` via `Statement::columns()`) in `crates/vibesql-server/tests/extended_protocol_tests.rs`:
- `test_describe_resolves_wildcard_and_explicit_columns` — `SELECT *`, `t.*`, explicit + aliased.
- `test_describe_join_wildcard_columns` — `SELECT t1.*, t2.c` join wildcard ordering.
- `test_describe_matches_executed_columns` — Describe column names == executed (`client.query`) column names for `SELECT *`, `t.*`, explicit, aliased, derived-expression; asserts no `colN` placeholders.

Session-level replicated coverage in `crates/vibesql-server/tests/replication_tests.rs`:
- `replicated_describe_columns_match_standalone` — `Session::describe_columns` in replicated mode matches the standalone oracle for explicit/aliased/derived/`*`/`t.*`/join-wildcard; no placeholders; non-SELECT resolves to `None`.

Results:
- `cargo build -p vibesql-server` — clean (only pre-existing unrelated unused-import warnings).
- `cargo test -p vibesql-server` — **all pass** (436 lib + integration suites, 0 failed), including the 3 new extended-protocol tests and the new replicated test.

## Test plan
- [ ] CI green on `cargo test -p vibesql-server`
- [ ] CI green on `cargo test -p vibesql-executor`
- [ ] Confirm no fmt churn (intentionally no repo-wide `cargo fmt`)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)