### PR TITLE
fix(executor): OLD/NEW in INSERT...SELECT trigger bodies + trigger*.test triage

### DIFF
--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -239,10 +239,21 @@ fn execute_insert_internal(
             }
 
             // Fall back to normal path: execute SELECT and convert to expressions
-            // If we have a with_clause (CTEs), reuse the results materialized above
+            // If we have a with_clause (CTEs), reuse the results materialized above.
+            //
+            // When this INSERT runs inside a trigger body and the source is a
+            // from-less SELECT that references OLD/NEW (e.g.
+            // `INSERT INTO log SELECT OLD.a || ',' || OLD.b;`, trigger5-1.1),
+            // the SELECT needs the firing row's pseudo-variable context — the
+            // same context the WHEN clause and body DML statements already get.
+            // Without it the evaluator rejects the OLD/NEW column references
+            // with "Column reference requires FROM clause" (#5470).
             let select_result = if let Some(ref ctes) = cte_results {
                 // Create executor with CTE results
                 let select_executor = crate::SelectExecutor::new_with_cte(db, ctes);
+                select_executor.execute_with_columns(select_stmt)?
+            } else if let Some(ctx) = trigger_context {
+                let select_executor = crate::SelectExecutor::new_with_trigger_context(db, ctx);
                 select_executor.execute_with_columns(select_stmt)?
             } else {
                 let select_executor = crate::SelectExecutor::new(db);

--- a/crates/vibesql-executor/src/tests/trigger_case_body_tests.rs
+++ b/crates/vibesql-executor/src/tests/trigger_case_body_tests.rs
@@ -290,6 +290,61 @@ fn from_less_select_expression_over_new_and_old() {
 }
 
 #[test]
+fn insert_select_from_less_resolves_old_in_trigger_body() {
+    // #5470 (trigger5.test 1.1): a trigger body of the form
+    //   `INSERT INTO log SELECT <expr referencing OLD>;`
+    // (an INSERT whose source is a *from-less* SELECT) must resolve the firing
+    // row's OLD context. Before the fix the INSERT...SELECT source executor was
+    // built with `SelectExecutor::new` (no trigger context), so the OLD column
+    // references failed at fire time with "Column reference requires FROM
+    // clause" and the AFTER DELETE trigger never logged anything.
+    //
+    // sqlite3 3.51.0: deleting the single row logs the rendered string built
+    // from OLD.a / OLD.b / OLD.c.
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE item (a INTEGER, b INTEGER, c INTEGER)");
+    exec_ok(&mut db, "CREATE TABLE undo (msg VARCHAR(64))");
+    exec_ok(&mut db, "INSERT INTO item (a, b, c) VALUES (1, 2, 3)");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER tr AFTER DELETE ON item FOR EACH ROW BEGIN \
+         INSERT INTO undo SELECT 'a=' || OLD.a || ',b=' || OLD.b || ',c=' || OLD.c; \
+         END",
+    );
+
+    exec_ok(&mut db, "DELETE FROM item WHERE a = 1");
+
+    assert_eq!(strings(&db, "undo", "msg"), vec!["a=1,b=2,c=3".to_string()]);
+    assert!(column_values(&db, "item", "a").is_empty(), "row should be deleted");
+}
+
+#[test]
+fn insert_select_from_less_resolves_new_in_trigger_body() {
+    // #5470 (triggerG.test 100 class): an AFTER INSERT trigger whose body uses
+    //   `INSERT INTO log SELECT <expr referencing NEW>;`
+    // (from-less SELECT) must resolve the firing row's NEW context in the
+    // INSERT...SELECT source. Same root cause as the OLD case above.
+    //
+    // sqlite3 3.51.0: inserting c = 2 then c = 7 logs NEW.c * 100 = 200, 700.
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE t (c INTEGER)");
+    exec_ok(&mut db, "CREATE TABLE log (val INTEGER)");
+    exec_ok(
+        &mut db,
+        "CREATE TRIGGER tr AFTER INSERT ON t FOR EACH ROW BEGIN \
+         INSERT INTO log SELECT NEW.c * 100; \
+         END",
+    );
+
+    exec_ok(&mut db, "INSERT INTO t (c) VALUES (2)");
+    exec_ok(&mut db, "INSERT INTO t (c) VALUES (7)");
+
+    let mut logged = ints(&db, "log", "val");
+    logged.sort_unstable();
+    assert_eq!(logged, vec![200, 700]);
+}
+
+#[test]
 fn instead_of_insert_case_then_base_write_fires_both() {
     // End-to-end INSTEAD OF variant that avoids the from-less `NEW` resolution
     // limitation: the CASE...END lives in the INSERT's VALUES (which carries the

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -1864,6 +1864,7 @@ array set vibesql_skip_files {
     where8 "Tests OR optimization via execsql_status2 internal statistics - query results correct"
     update2 "Uses repeat() function which is a SQLite test extension"
     func5 "Uses counter1/counter2 custom TCL functions - SQLite test extension"
+    trigger6 "Entire file is built around a custom counter() TCL function (db function counter ...) used to verify INSERT/UPDATE expressions are evaluated exactly once; the tables and triggers are created in 6-1.1 alongside the function registration, so once 6-1.1 is auto-skipped (custom function) every later test cascade-fails with 'no such table: log/t1' (#5470)"
     delete_db "Uses sqlite3_delete_database - SQLite internal function"
     incrblobfault "Uses incrblob - SQLite incremental blob I/O API"
     incrblob "Uses incrblob - SQLite incremental blob I/O API"
@@ -3337,6 +3338,18 @@ array set vibesql_skip_tests {
     fkey8-5.2 "UPDATE/DELETE PK affinity is fixed (#5145), but schema-reload drops DEFERRABLE INITIALLY DEFERRED so the deferred-INSERT on child fires immediately across CLI invocations — tracked separately in #5172"
 
     triggerupfrom-2.3 "Cascades from auto-skipped test 2.2. CREATE TEMP TRIGGER now parses (#5218), but 2.2 references aux.t3 and is auto-skipped by the ATTACH/aux regex (VibeSQL has no ATTACH/multi-database support), so the rows 2.2 inserts (10 y {}, 20 y {}) never exist and 2.3's expected output cannot match. The UPDATE…FROM trigger logic in 2.3 itself works correctly when run in isolation (verified during #5192 builder pass)."
+
+    trigger9-1.2.1 "Cascades from auto-skipped trigger9-1.1, which uses the SQLite test function randstr(10000,10000) to populate t1; without it t1 is never created and every 1.x test fails with 'no such table: t1' (#5470)."
+    trigger9-1.3.1 "Cascades from auto-skipped trigger9-1.1 (randstr() builds t1); 'no such table: t1' (#5470)."
+    trigger9-1.4.1 "Cascades from auto-skipped trigger9-1.1 (randstr() builds t1); 'no such table: t1' (#5470)."
+    trigger9-1.5.1 "Cascades from auto-skipped trigger9-1.1 (randstr() builds t1); 'no such table: t1' (#5470)."
+    trigger9-1.6.1 "Cascades from auto-skipped trigger9-1.1 (randstr() builds t1); 'no such table: t1' (#5470)."
+    trigger9-1.7.1 "Cascades from auto-skipped trigger9-1.1 (randstr() builds t1); 'no such table: t1' (#5470)."
+    trigger9-3.2 "Cascades from auto-skipped trigger9-1.1, which creates t2 alongside the randstr()-populated t1; without t2 these INSTEAD OF view tests fail with 'no such table: t2' (#5470)."
+    trigger9-3.3 "Cascades from auto-skipped trigger9-1.1 (creates t2); 'no such table: t2' (#5470)."
+    trigger9-3.4 "Cascades from auto-skipped trigger9-1.1 (creates t2); 'no such table: t2' (#5470)."
+    trigger9-3.5 "Cascades from auto-skipped trigger9-1.1 (creates t2); 'no such table: t2' (#5470)."
+    trigger9-3.6 "Cascades from auto-skipped trigger9-1.1 (creates t2); 'no such table: t2' (#5470)."
 
     date-2.40 "needs the sqlite_current_time fake-clock hook the harness cannot honor ('now' uses real clock; zero-argument datetime() itself is supported as of #5317)"
     date-4.1 "sqlite_current_time fake-clock hook not honored by VibeSQL binary ('now' uses real clock; harness limitation)"


### PR DESCRIPTION
## Summary
Triage of the remaining `trigger*.test` conformance failures (#5470), plus the cheap, clearly-correct executor fixes found during triage. Code changes are confined to executor trigger paths and the TCL test harness; no consensus / server changes.

### Bucket-(b) fixes made in this PR
1. **INSERT...SELECT trigger-context resolution** (`crates/vibesql-executor/src/insert/execution.rs`). When an `INSERT ... SELECT` runs inside a trigger body and its source is a from-less SELECT referencing OLD/NEW, the SELECT now executes with the firing row's trigger context instead of `SelectExecutor::new`. Previously it failed with `Column reference requires FROM clause`.
   - trigger5-1.1: 0 -> 1 passing.
   - triggerG (100/110/200): 3 -> 6 passing.
   - New executor unit tests added (`trigger_case_body_tests.rs`), asserted against sqlite3 3.51.0.
2. **trigger6 skip-file** — the whole file is built on a custom `counter()` TCL function; once `6-1.1` auto-skips, every later test cascade-fails on `no such table`. Now skipped cleanly (5 failed -> 0). Matches the existing custom-function skip-file pattern (func5/update2/where8).
3. **trigger9 cascade skips documented** — `9-1.x` / `9-3.x` depend on `9-1.1`, which uses the SQLite test function `randstr()`; documented per-test skips referencing #5470 (mirrors the `triggerupfrom-2.3` precedent). trigger9: 12 failed -> 1 (only the rowid-in-view case, tracked by #5492).

`cargo test -p vibesql-executor --lib`: 2719 passed, 0 failed.

## Triage table
| File / tests | Root-cause category | Bucket | Tracking |
|---|---|---|---|
| trigger5-1.1; triggerG 100/200 | from-less SELECT OLD/NEW in INSERT...SELECT | (b) FIXED | this PR |
| trigger6 (all) | depends on custom counter() TCL fn (cascade) | (b) FIXED (skip-file) | this PR |
| trigger9 1.2.1-1.7.1, 3.2-3.6 | depends on randstr() in 9-1.1 (cascade) | (b) FIXED (doc skip) | this PR |
| triggerC 3.1.2, 4.1.x, 7.2/7.5/7.6/7.8/7.9; triggerD 2.2 | NEW/OLD.rowid unresolved in trigger bodies | (c) | #5485 |
| triggerD 1.3, 1.4 | real column named `rowid` shadowed by pseudo-rowid | (c) | #5485 (precedence note) |
| trigger2 1.1.x-1.4.x | BEFORE/AFTER row triggers not interleaved per-row | (c) | #5486 |
| triggerE (all 1.1.x/1.2.x) | CREATE TRIGGER with bound param must be rejected | (c) | #5487 |
| trigger1 IF NOT EXISTS / parse / wording | CREATE TRIGGER parser+validation gaps | (c)/(a) | #5488, #5469 |
| altertrig (all) | ALTER RENAME not rewritten into trigger body sql | (c) | #5489 |
| triggerC 5.x; triggerF 1.x.2 | OR REPLACE delete triggers (WITHOUT ROWID / unique idx) | (c) | #5490 |
| trigger9 4.3b; triggerC 7.x rowid-in-view | rowid reference on a view must error | (c) | #5492 |
| trigger3 1.2/2.2; trigger1-1.3 | RAISE(ABORT/FAIL) txn rollback in TCL batch path | (a) | #5478 |
| trigger3-6; triggerC 2.x/3.x recursion | recursion depth limit (16) + wording | (a) | #5479, #5469 |
| triggerC 2.x/3.x/13.2; trigger4-3.x; triggerB 2.x; trigger1 wording | error message wording divergence | (a) | #5469 |
| triggerC 10.x/15.x/16.x; triggerG 300/310 | parser gaps (RAISE top-level, hex literal, syntax) | (c) | #5488 (parser surface) |

(a) = already covered by an open issue; (b) = fixed here; (c) = new follow-on filed.

## Issues filed during triage
#5485, #5486, #5487, #5488, #5489, #5490, #5492.

## Test plan
- [x] `cargo test -p vibesql-executor --lib` (2719 passed)
- [x] `make test-tcl-file FILE=trigger5.test` (1/0), `triggerG` (6 passing), `trigger6` (skipped), `trigger9` (17/1)
- [x] No regressions across all `trigger*.test` files
- [x] New OLD/NEW INSERT...SELECT behavior verified against sqlite3 3.51.0

Closes #5470

🤖 Generated with [Claude Code](https://claude.com/claude-code)