### PR TITLE
refactor(consensus): simplify cast_operand_could_be_time_inner to &TableSchema (post-#5483)

### DIFF
--- a/crates/vibesql-consensus/src/freeze.rs
+++ b/crates/vibesql-consensus/src/freeze.rs
@@ -1494,14 +1494,15 @@ impl ExpressionVisitor for TimeCastDetector<'_> {
                 // reach here: they freeze at propose and arrive
                 // substituted to a TIMESTAMP literal.
                 if cast_operand_could_be_time(operand, self.schema) {
-                    self.error = Some(format!(
+                    self.error = Some(
                         "CAST(<expression> AS TIMESTAMP) where the operand may be a TIME value \
                          stamps the apply-time current date per row (SQL:1999) and cannot be \
                          replicated deterministically; freeze the value at propose (use a TIME \
                          literal) or combine it with an explicit date instead. The replicated \
                          path conservatively rejects any TIME→TIMESTAMP cast whose operand is \
                          not provably non-TIME (#5398)"
-                    ));
+                            .to_string(),
+                    );
                     return VisitResult::Stop;
                 }
                 VisitResult::Continue
@@ -1540,7 +1541,7 @@ fn cast_operand_could_be_time(
     operand: &Expression,
     schema: &vibesql_catalog::TableSchema,
 ) -> bool {
-    cast_operand_could_be_time_inner(operand, Some(schema))
+    cast_operand_could_be_time_inner(operand, schema)
 }
 
 /// Is this operand **provably TIME without any schema** — i.e. known to
@@ -1579,7 +1580,7 @@ fn cast_operand_is_provably_time(operand: &Expression) -> bool {
 
 fn cast_operand_could_be_time_inner(
     operand: &Expression,
-    schema: Option<&vibesql_catalog::TableSchema>,
+    schema: &vibesql_catalog::TableSchema,
 ) -> bool {
     match operand {
         // Literals: only a TIME literal is TIME, and those are frozen at
@@ -1590,15 +1591,11 @@ fn cast_operand_could_be_time_inner(
         // The apply-time clock reads that *produce* TIME.
         Expression::CurrentTime { .. } => true,
 
-        // A column reference: provably non-TIME only when a schema is in
-        // scope, it binds to the target table, and that column's type is
-        // known and not TIME. Other-table / unqualified-but-absent
-        // columns (and *all* columns when no schema is available) are
-        // unresolvable → conservatively possibly-TIME.
+        // A column reference: provably non-TIME only when it binds to the
+        // target table and that column's type is known and not TIME.
+        // Other-table / unqualified-but-absent columns are unresolvable →
+        // conservatively possibly-TIME.
         Expression::ColumnRef(col) => {
-            let Some(schema) = schema else {
-                return true;
-            };
             let binds_to_target = col.table_canonical().is_none_or(|t| {
                 t.eq_ignore_ascii_case(&schema.name) || t.eq_ignore_ascii_case("excluded")
             });


### PR DESCRIPTION
## Summary
Trivial post-#5483 cleanup in `crates/vibesql-consensus/src/freeze.rs`.

- `cast_operand_could_be_time_inner` took `schema: Option<&TableSchema>`, but after #5483 removed the schema-free query-body caller, every call site now passes `Some(schema)`: the public wrapper `cast_operand_could_be_time` and the function's own `CASE` recursion (which threads the same value). The `None` arm in the `ColumnRef` branch was dead.
- Simplified the signature to `&TableSchema`, dropped the dead `let Some(schema) = schema else { return true }` early-return, and updated the wrapper call site to pass `schema` directly.
- Also fixed the in-function pre-existing `clippy::useless_format` (an arg-less `format!`, noted out-of-scope by the #5483 judge, from #5382) since it lives in code touched here.

## Verification
- Confirmed via grep that all 3 references to `cast_operand_could_be_time_inner` pass `Some(..)`/thread the param — no caller legitimately passes `None`.
- Pure refactor — no behavior change. The #5483 determinism contract is preserved.

## Test plan
- [x] `cargo build -p vibesql-consensus` — green
- [x] `cargo test -p vibesql-consensus` — 177 lib + all integration tests pass (full freeze suite + two-machine `replicated::tests` convergence tests unchanged and green)
- [x] `cargo clippy -p vibesql-consensus --all-targets` — no new warnings; the `useless_format` warning is now gone (vibesql-consensus lib clean)

Closes #5491

🤖 Generated with [Claude Code](https://claude.com/claude-code)