### PR TITLE
CREATE TRIGGER: parse IF NOT EXISTS, reject FOR EACH STATEMENT, surface body syntax errors

### DIFF
--- a/crates/vibesql-ast/src/ddl/schema.rs
+++ b/crates/vibesql-ast/src/ddl/schema.rs
@@ -126,6 +126,10 @@ pub struct DropViewStmt {
 /// CREATE TRIGGER statement
 #[derive(Debug, Clone, PartialEq)]
 pub struct CreateTriggerStmt {
+    /// `CREATE TRIGGER IF NOT EXISTS ...`: when true, creating a trigger whose
+    /// name already exists is a no-op success rather than a "trigger already
+    /// exists" error (SQLite semantics).
+    pub if_not_exists: bool,
     pub trigger_name: String,
     pub timing: TriggerTiming,
     pub event: TriggerEvent,

--- a/crates/vibesql-executor/src/advanced_objects/triggers.rs
+++ b/crates/vibesql-executor/src/advanced_objects/triggers.rs
@@ -12,6 +12,14 @@ pub fn execute_create_trigger(
 ) -> Result<(), ExecutorError> {
     use vibesql_catalog::TriggerDefinition;
 
+    // `CREATE TRIGGER IF NOT EXISTS <name>` is a no-op success when a trigger
+    // with that name already exists (SQLite semantics, trigger1-1.2.0). Mirrors
+    // the guard in `TriggerExecutor::create_trigger_with_sql` so every CREATE
+    // TRIGGER path honors the clause.
+    if stmt.if_not_exists && db.catalog.get_trigger(&stmt.trigger_name).is_some() {
+        return Ok(());
+    }
+
     let trigger = TriggerDefinition::new(
         stmt.trigger_name.clone(),
         stmt.timing.clone(),

--- a/crates/vibesql-executor/src/tests/triggers/conditions.rs
+++ b/crates/vibesql-executor/src/tests/triggers/conditions.rs
@@ -51,6 +51,7 @@ fn test_when_clause_filters_firing() {
 
     // Create trigger with WHEN (amount > 100) condition
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "log_high_amount".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,

--- a/crates/vibesql-executor/src/tests/triggers/coordination.rs
+++ b/crates/vibesql-executor/src/tests/triggers/coordination.rs
@@ -16,6 +16,7 @@ fn test_multiple_triggers_fire_in_order() {
 
     // Create first AFTER INSERT trigger
     let trigger1 = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "log_insert_1".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -31,6 +32,7 @@ fn test_multiple_triggers_fire_in_order() {
 
     // Create second AFTER INSERT trigger
     let trigger2 = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "log_insert_2".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -77,6 +79,7 @@ fn test_trigger_with_multiple_statements() {
 
     // Create trigger with multiple statements (separated by semicolons)
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "log_multiple".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -164,6 +167,7 @@ fn test_before_trigger_executes_first() {
 
     // Create BEFORE INSERT trigger that increments counter
     let before_trigger = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "before_trigger".to_string(),
         timing: TriggerTiming::Before,
         event: TriggerEvent::Insert,

--- a/crates/vibesql-executor/src/tests/triggers/ddl.rs
+++ b/crates/vibesql-executor/src/tests/triggers/ddl.rs
@@ -24,6 +24,7 @@ fn test_create_trigger() {
 
     // Create a trigger
     let stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "my_trigger".to_string(),
         timing: TriggerTiming::Before,
         event: TriggerEvent::Insert,
@@ -61,6 +62,7 @@ fn test_create_trigger_duplicate_error() {
 
     // Create a trigger
     let stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "my_trigger".to_string(),
         timing: TriggerTiming::Before,
         event: TriggerEvent::Insert,
@@ -79,6 +81,46 @@ fn test_create_trigger_duplicate_error() {
 }
 
 #[test]
+fn test_create_trigger_if_not_exists_is_noop_when_present() {
+    // `CREATE TRIGGER IF NOT EXISTS` for an already-existing trigger is a
+    // no-op success (SQLite trigger1-1.2.0), not a "trigger already exists"
+    // error.
+    let mut db = Database::new();
+
+    let create_table_sql = "CREATE TABLE test_table (id INT, name VARCHAR(255));";
+    match vibesql_parser::Parser::parse_sql(create_table_sql).unwrap() {
+        vibesql_ast::Statement::CreateTable(stmt) => {
+            CreateTableExecutor::execute(&stmt, &mut db).unwrap();
+        }
+        _ => panic!("Expected CreateTable"),
+    }
+
+    let stmt = CreateTriggerStmt {
+        if_not_exists: true,
+        trigger_name: "my_trigger".to_string(),
+        timing: TriggerTiming::Before,
+        event: TriggerEvent::Insert,
+        table_name: "test_table".to_string(),
+        granularity: TriggerGranularity::Row,
+        when_condition: None,
+        triggered_action: TriggerAction::RawSql("BEGIN SELECT 1; END".to_string()),
+    };
+
+    // First create succeeds.
+    crate::advanced_objects::execute_create_trigger(&stmt, &mut db)
+        .expect("first create should succeed");
+
+    // Second create with IF NOT EXISTS is a no-op success, not an error.
+    let result = crate::advanced_objects::execute_create_trigger(&stmt, &mut db);
+    assert!(result.is_ok(), "IF NOT EXISTS create should be a no-op: {:?}", result.err());
+
+    // Without IF NOT EXISTS, the same duplicate still errors.
+    let strict = CreateTriggerStmt { if_not_exists: false, ..stmt.clone() };
+    let result = crate::advanced_objects::execute_create_trigger(&strict, &mut db);
+    assert!(result.is_err(), "duplicate without IF NOT EXISTS should error");
+}
+
+#[test]
 fn test_drop_trigger() {
     let mut db = Database::new();
 
@@ -94,6 +136,7 @@ fn test_drop_trigger() {
 
     // Create a trigger
     let stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "my_trigger".to_string(),
         timing: TriggerTiming::Before,
         event: TriggerEvent::Insert,
@@ -152,6 +195,7 @@ fn test_create_trigger_all_variations() {
 
     for (timing, suffix) in timings {
         let stmt = CreateTriggerStmt {
+            if_not_exists: false,
             trigger_name: format!("trigger_{}", suffix),
             timing: timing.clone(),
             event: TriggerEvent::Insert,

--- a/crates/vibesql-executor/src/tests/triggers/delete.rs
+++ b/crates/vibesql-executor/src/tests/triggers/delete.rs
@@ -37,6 +37,7 @@ fn test_after_delete_trigger_fires() {
 
     // Create AFTER DELETE trigger
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "log_delete".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Delete,
@@ -107,6 +108,7 @@ fn test_before_delete_trigger_fires() {
 
     // Create BEFORE DELETE trigger
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "log_before_delete".to_string(),
         timing: TriggerTiming::Before,
         event: TriggerEvent::Delete,

--- a/crates/vibesql-executor/src/tests/triggers/error_handling.rs
+++ b/crates/vibesql-executor/src/tests/triggers/error_handling.rs
@@ -15,6 +15,7 @@ fn test_trigger_failure_causes_rollback() {
 
     // Create trigger that always fails (inserts into non-existent table)
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "failing_trigger".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -90,6 +91,7 @@ fn test_recursion_prevention() {
 
     // Create trigger that inserts into the same table (infinite loop)
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "recursive_trigger".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,

--- a/crates/vibesql-executor/src/tests/triggers/insert.rs
+++ b/crates/vibesql-executor/src/tests/triggers/insert.rs
@@ -16,6 +16,7 @@ fn test_after_insert_trigger_fires() {
 
     // Create AFTER INSERT trigger
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "log_insert".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -62,6 +63,7 @@ fn test_after_insert_trigger_fires_for_each_row() {
 
     // Create AFTER INSERT trigger
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "log_insert".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -122,6 +124,7 @@ fn test_before_insert_trigger_fires() {
 
     // Create BEFORE INSERT trigger
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "log_before_insert".to_string(),
         timing: TriggerTiming::Before,
         event: TriggerEvent::Insert,
@@ -194,6 +197,7 @@ fn test_insert_trigger_body_semicolon_inside_string_literal_is_not_split() {
     create_audit_table(&mut db);
 
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "log_semicolon".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -243,6 +247,7 @@ fn test_insert_trigger_body_escaped_quote_with_semicolon_is_intact() {
     create_audit_table(&mut db);
 
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "log_escaped".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -290,6 +295,7 @@ fn test_insert_trigger_multi_statement_body_with_semicolon_string() {
     create_audit_table(&mut db);
 
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "log_multi".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,

--- a/crates/vibesql-executor/src/tests/triggers/pseudo_vars.rs
+++ b/crates/vibesql-executor/src/tests/triggers/pseudo_vars.rs
@@ -34,6 +34,7 @@ fn test_new_in_insert_trigger() {
 
     // Create trigger that uses NEW to log inserted employee
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "log_new_employee".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -110,6 +111,7 @@ fn test_old_and_new_in_update_trigger() {
 
     // Create trigger that uses both OLD and NEW
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "log_salary_change".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Update(None), // No specific column list
@@ -186,6 +188,7 @@ fn test_old_in_delete_trigger() {
 
     // Create trigger that uses OLD
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "log_deletion".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Delete,

--- a/crates/vibesql-executor/src/tests/triggers/update.rs
+++ b/crates/vibesql-executor/src/tests/triggers/update.rs
@@ -41,6 +41,7 @@ fn test_after_update_trigger_fires() {
 
     // Create AFTER UPDATE trigger
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "log_update".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Update(None),
@@ -116,6 +117,7 @@ fn test_before_update_trigger_fires() {
 
     // Create BEFORE UPDATE trigger
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "log_before_update".to_string(),
         timing: TriggerTiming::Before,
         event: TriggerEvent::Update(None),
@@ -217,6 +219,7 @@ fn test_update_from_on_view_with_instead_of_trigger() {
     // SQL with old/new references so it must run through the normal
     // trigger-body SQL execution path.
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "tr1".to_string(),
         timing: TriggerTiming::InsteadOf,
         event: TriggerEvent::Update(None),
@@ -304,6 +307,7 @@ fn test_update_from_on_view_zero_matches() {
     }
 
     let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
         trigger_name: "tr1".to_string(),
         timing: TriggerTiming::InsteadOf,
         event: TriggerEvent::Update(None),

--- a/crates/vibesql-executor/src/trigger_ddl.rs
+++ b/crates/vibesql-executor/src/trigger_ddl.rs
@@ -38,6 +38,14 @@ impl TriggerExecutor {
         stmt: &CreateTriggerStmt,
         original_sql: Option<&str>,
     ) -> Result<String, ExecutorError> {
+        // `CREATE TRIGGER IF NOT EXISTS <name>` is a no-op success when a
+        // trigger with that name already exists (SQLite semantics, trigger1-1.2.0).
+        // SQLite resolves the existing-trigger check before validating the target
+        // object, so an already-present trigger short-circuits here.
+        if stmt.if_not_exists && db.catalog.get_trigger(&stmt.trigger_name).is_some() {
+            return Ok(format!("Trigger '{}' already exists", stmt.trigger_name));
+        }
+
         // INSTEAD OF triggers can only be created on views
         // BEFORE and AFTER triggers can only be created on tables
         if stmt.timing == TriggerTiming::InsteadOf {

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -428,9 +428,12 @@ impl Parser {
                     index_hint,
                 })
             }
-            _ => Err(ParseError {
-                message: "Expected table name or subquery in FROM clause".to_string(),
-            }),
+            // No table name / subquery where one was required (e.g. `SELECT * FROM;`).
+            // SQLite reports this as a token-level syntax error — `near ";": syntax
+            // error` — rather than a descriptive message, so mirror that. This also
+            // lets CREATE TRIGGER bodies surface the same syntax error at create time
+            // (trigger1-2.1 / 2.2).
+            _ => Err(ParseError { message: self.peek().syntax_error() }),
         }
     }
 

--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -31,6 +31,17 @@ impl Parser {
         // Expect TRIGGER keyword
         self.expect_keyword(Keyword::Trigger)?;
 
+        // Optional IF NOT EXISTS: when present, creating a trigger whose name
+        // already exists is a no-op success instead of an error (SQLite).
+        let if_not_exists = if self.peek_keyword(Keyword::If) {
+            self.advance(); // consume IF
+            self.expect_keyword(Keyword::Not)?;
+            self.expect_keyword(Keyword::Exists)?;
+            true
+        } else {
+            false
+        };
+
         // Parse trigger name
         let trigger_name = self.parse_identifier()?;
 
@@ -95,21 +106,24 @@ impl Parser {
         // Parse table name
         let table_name = self.parse_identifier()?;
 
-        // Parse optional FOR EACH ROW/STATEMENT
+        // Parse optional FOR EACH ROW.
+        //
+        // SQLite's grammar only accepts `FOR EACH ROW`; there are no
+        // statement-level triggers. Anything else after `FOR EACH` (most
+        // notably `STATEMENT`) is a syntax error in SQLite — e.g.
+        // `near "STATEMENT": syntax error` (trigger1-1.1.3). We surface the
+        // same `near "<tok>": syntax error` so the rejection matches SQLite
+        // rather than silently accepting an unsupported granularity.
         let granularity = if self.try_consume_keyword(Keyword::For) {
             self.expect_keyword(Keyword::Each)?;
             if self.try_consume_keyword(Keyword::Row) {
                 vibesql_ast::TriggerGranularity::Row
-            } else if self.try_consume_keyword(Keyword::Statement) {
-                vibesql_ast::TriggerGranularity::Statement
             } else {
-                return Err(ParseError {
-                    message: "Expected ROW or STATEMENT after FOR EACH".to_string(),
-                });
+                return Err(ParseError { message: self.peek().syntax_error() });
             }
         } else {
-            // Default to ROW for SQLite compatibility
-            // SQLite doesn't support STATEMENT-level triggers - all triggers are FOR EACH ROW
+            // Default to ROW for SQLite compatibility (all SQLite triggers are
+            // FOR EACH ROW, whether or not the clause is written).
             vibesql_ast::TriggerGranularity::Row
         };
 
@@ -152,6 +166,7 @@ impl Parser {
         }
 
         Ok(vibesql_ast::CreateTriggerStmt {
+            if_not_exists,
             trigger_name,
             timing,
             event,
@@ -261,11 +276,21 @@ impl Parser {
     /// (but SQLite accepts at create time) are preserved as before.
     fn validate_trigger_body(raw_sql: &str) -> Result<(), ParseError> {
         for stmt_sql in crate::split_trigger_body_statements(raw_sql) {
+            // Re-append the statement terminator the splitter stripped. SQLite
+            // parses the whole body in one pass, so a statement that ends
+            // prematurely (e.g. `SELECT * FROM`) reports the *following* `;` as
+            // the offending token (`near ";": syntax error`, trigger1-2.1 /
+            // 2.2). Parsing the split statement alone would instead hit EOF and
+            // report `incomplete input`; restoring the `;` makes the offending
+            // token — and thus the message — match SQLite. A `;` after a valid
+            // statement is harmless (parsing stops at the statement boundary).
+            let stmt_with_terminator = format!("{stmt_sql};");
+
             // Parse each body statement as a trigger-program statement so
             // `RAISE()` is admitted (SQLite only permits RAISE() within a
             // trigger-program; `parse_sql` rejects it at parse time, but a
             // trigger body legitimately contains it).
-            if let Err(e) = Self::parse_sql_in_trigger_body(&stmt_sql) {
+            if let Err(e) = Self::parse_sql_in_trigger_body(&stmt_with_terminator) {
                 if Self::is_create_time_rejection(&e) {
                     // Propagate verbatim so the message (e.g.
                     // `unsupported use of NULLS FIRST`) matches the
@@ -284,12 +309,25 @@ impl Parser {
     /// Is this body-statement parse error one that SQLite also rejects at
     /// `CREATE TRIGGER` time (rather than a VibeSQL parser gap)?
     ///
-    /// Scoped to the `NULLS FIRST/LAST`-in-index-position error class
-    /// (nulls1.test 3.1.12), whose message is emitted verbatim by
-    /// `reject_nulls_in_index_position`. Additional create-time rejection
-    /// classes can be added here as they are identified.
+    /// Two classes are propagated:
+    ///
+    /// 1. The `NULLS FIRST/LAST`-in-index-position error class (nulls1.test
+    ///    3.1.12), whose message is emitted verbatim by
+    ///    `reject_nulls_in_index_position`.
+    /// 2. Token-level syntax errors (`near "X": syntax error`). A genuine
+    ///    syntax error in a body statement — e.g. `SELECT * FROM;`
+    ///    (trigger1-2.1 / 2.2) — is rejected by SQLite at create time, so we
+    ///    surface it too. This is deliberately distinguished from VibeSQL
+    ///    *parser gaps*, which produce descriptive messages (e.g. "Expected
+    ///    ...") rather than the `near "X": syntax error` form; those are still
+    ///    tolerated so we don't reject bodies SQLite accepts but VibeSQL
+    ///    cannot yet parse.
+    ///
+    /// Additional create-time rejection classes can be added here as they are
+    /// identified.
     fn is_create_time_rejection(error: &ParseError) -> bool {
         error.message.starts_with("unsupported use of NULLS ")
+            || (error.message.starts_with("near \"") && error.message.ends_with("\": syntax error"))
     }
 
     /// Parse ALTER TRIGGER statement

--- a/crates/vibesql-parser/src/tests/trigger.rs
+++ b/crates/vibesql-parser/src/tests/trigger.rs
@@ -76,19 +76,78 @@ fn test_create_trigger_for_each_row() {
 }
 
 #[test]
-fn test_create_trigger_for_each_statement() {
+fn test_create_trigger_for_each_statement_rejected() {
+    // SQLite only supports `FOR EACH ROW`; `FOR EACH STATEMENT` is a syntax
+    // error (`near "STATEMENT": syntax error`, trigger1-1.1.3). Verify we
+    // reject it rather than silently accepting an unsupported granularity.
     let sql = "CREATE TRIGGER my_trigger BEFORE INSERT ON my_table FOR EACH STATEMENT BEGIN END;";
+    let result = Parser::parse_sql(sql);
+    let err = result.expect_err("FOR EACH STATEMENT should be rejected");
+    assert_eq!(err.message, "near \"STATEMENT\": syntax error");
+}
+
+#[test]
+fn test_create_trigger_if_not_exists_parsed() {
+    // `CREATE TRIGGER IF NOT EXISTS ...` must parse and set the flag
+    // (trigger1-1.2.0). Previously the `IF` keyword caused
+    // `Expected identifier, found reserved keyword 'IF'`.
+    let sql =
+        "CREATE TRIGGER IF NOT EXISTS my_trigger AFTER INSERT ON my_table BEGIN SELECT 1; END;";
     let result = Parser::parse_sql(sql);
     assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
 
-    let stmt = result.unwrap();
-    match stmt {
+    match result.unwrap() {
         Statement::CreateTrigger(trigger) => {
+            assert!(trigger.if_not_exists, "if_not_exists should be true");
             assert_eq!(trigger.trigger_name, "my_trigger");
-            assert_eq!(trigger.granularity, TriggerGranularity::Statement);
         }
         _ => panic!("Expected CreateTrigger statement"),
     }
+}
+
+#[test]
+fn test_create_trigger_without_if_not_exists_flag_absent() {
+    // Without the clause, if_not_exists must be false.
+    let sql = "CREATE TRIGGER my_trigger AFTER INSERT ON my_table BEGIN SELECT 1; END;";
+    match Parser::parse_sql(sql).expect("should parse") {
+        Statement::CreateTrigger(trigger) => {
+            assert!(!trigger.if_not_exists, "if_not_exists should be false");
+        }
+        _ => panic!("Expected CreateTrigger statement"),
+    }
+}
+
+#[test]
+fn test_create_trigger_if_not_exists_works_with_temp() {
+    // The IF NOT EXISTS clause follows the optional TEMP modifier.
+    let sql = "CREATE TEMP TRIGGER IF NOT EXISTS my_trigger AFTER INSERT ON my_table BEGIN SELECT 1; END;";
+    match Parser::parse_sql(sql).expect("should parse") {
+        Statement::CreateTrigger(trigger) => {
+            assert!(trigger.if_not_exists);
+            assert_eq!(trigger.trigger_name, "my_trigger");
+        }
+        _ => panic!("Expected CreateTrigger statement"),
+    }
+}
+
+#[test]
+fn test_create_trigger_body_syntax_error_rejected_at_create_time() {
+    // A genuine syntax error in a body statement (`SELECT * FROM;`) is
+    // rejected by SQLite at CREATE TRIGGER time with `near ";": syntax error`
+    // (trigger1-2.1). Verify we surface the same token-level syntax error
+    // rather than silently accepting the body.
+    let sql = "CREATE TRIGGER r1 AFTER INSERT ON t1 BEGIN SELECT * FROM; END;";
+    let err = Parser::parse_sql(sql).expect_err("body syntax error should be rejected");
+    assert_eq!(err.message, "near \";\": syntax error");
+}
+
+#[test]
+fn test_create_trigger_body_syntax_error_after_valid_statement() {
+    // trigger1-2.2: first body statement is valid, second has the syntax
+    // error; the error must still be raised at create time.
+    let sql = "CREATE TRIGGER r1 AFTER INSERT ON t1 BEGIN SELECT * FROM t1; SELECT * FROM; END;";
+    let err = Parser::parse_sql(sql).expect_err("body syntax error should be rejected");
+    assert_eq!(err.message, "near \";\": syntax error");
 }
 
 #[test]


### PR DESCRIPTION
Closes #5488

## Summary
Closes the parser/validation-side `CREATE TRIGGER` gaps surfaced by `trigger1.test`. Stays within `vibesql-parser` plus the minimal CREATE-statement semantic plumbing for `IF NOT EXISTS`. Does **not** touch executor trigger *firing*, the statement splitters, or error *wording* (the wording subset stays with #5469).

## Changes
- **`CREATE TRIGGER IF NOT EXISTS`** — now parsed (added `if_not_exists` to `CreateTriggerStmt`). Creating an already-existing trigger with the clause is a no-op success; without it, the existing "already exists" error path is unchanged. The no-op guard is mirrored in both CREATE TRIGGER executor entry points (`TriggerExecutor::create_trigger_with_sql`, used by CLI/server/consensus, and `advanced_objects::execute_create_trigger`, used by WASM). Wording of the *without*-clause error is left to #5469.
- **`FOR EACH STATEMENT`** — now rejected with `near "STATEMENT": syntax error` (SQLite only supports `FOR EACH ROW`); previously silently accepted.
- **Body syntax errors at create time** — a genuine token-level syntax error in a trigger body (e.g. `SELECT * FROM;`) is now surfaced at `CREATE TRIGGER` time as `near ";": syntax error`. The empty-FROM-target error message was changed from a descriptive string to SQLite's token-level form (`near "<tok>": syntax error`); body validation propagates token-level syntax errors while still tolerating VibeSQL parser gaps (descriptive messages), so bodies SQLite accepts but VibeSQL can't yet parse are preserved as before.

## trigger1.test pass-delta: 12 -> 17 (+5)
Now passing (were failing on main): **1.1.3** (FOR EACH STATEMENT rejected), **1.2.0** (IF NOT EXISTS no-op), **2.1** and **2.2** (body `SELECT * FROM;` syntax error at create time), **3.1** (downstream of 1.2.0).

## Verified against sqlite3 3.51.0
- `CREATE TRIGGER IF NOT EXISTS <existing>` -> no-op success
- `FOR EACH STATEMENT` -> `near "STATEMENT": syntax error`
- `SELECT * FROM;` in body -> `near ";": syntax error`

## Deferred (out of scope, not regressions)
The remaining `trigger1.test` failures are not parser-validation of the CREATE statement:
- **Error wording (#5469):** `Trigger 'tr1' already exists` vs `trigger tr1 already exists`; missing `main.` schema qualifier (`no such table: main.t2`); system-table / INSTEAD-OF-on-table / BEFORE-AFTER-on-view messages (1.2.1/2/3, 1.9, 1.12, 1.13, 1.14, 1.1.1, 3.2/3.4/3.5).
- **Transaction rollback** of trigger DDL (1.3, 1.4, 1.6.1): `No active transaction to rollback` — executor/transaction behavior, not parsing.

These are tracked by #5469 (wording) or are transaction-engine concerns; no new follow-on filed since they map to existing scope.

## Tests
- `cargo test -p vibesql-parser` — green (1416 unit + 8 doc). New parser tests: IF NOT EXISTS present/absent/with-TEMP, FOR EACH STATEMENT rejection, body syntax-error rejection (single + after-valid-statement).
- `cargo test -p vibesql-executor` — green. New test: IF NOT EXISTS is a no-op when present, still errors without the clause.
- `make test-tcl-file FILE=trigger1.test` — 17/84 (was 12/84).
- Regression spot-checks: `select1.test` 100%, `join.test` 97.8% (failures are pre-existing result-ordering / EQP, unrelated to this change).

## Test plan
- [ ] `cargo test -p vibesql-parser`
- [ ] `cargo test -p vibesql-executor`
- [ ] `make test-tcl-file FILE=trigger1.test` shows 17 passing