### PR TITLE
fix(executor): statement-end orphan FK check after cascade-fired RAISE(IGNORE)

### DIFF
--- a/crates/vibesql-executor/src/delete/integrity.rs
+++ b/crates/vibesql-executor/src/delete/integrity.rs
@@ -192,8 +192,19 @@ pub fn check_no_child_references(
                 }
             }
             ReferentialAction::Cascade => {
-                // Delete child rows that reference the parent
-                cascade_delete(db, &child_table_name, &fk, &parent_key_values)?;
+                // Delete child rows that reference the parent. A child
+                // BEFORE DELETE trigger RAISE(IGNORE) skips that row's
+                // cascade, leaving it as an orphan that must still trip the
+                // statement-end FK check (#5465).
+                cascade_delete(
+                    db,
+                    &child_table_name,
+                    &fk,
+                    fk_idx,
+                    &parent_key_values,
+                    in_txn,
+                    session_defer,
+                )?;
             }
             ReferentialAction::SetNull => {
                 // Set child FK columns to NULL
@@ -271,11 +282,15 @@ fn queue_orphaned_children(
 }
 
 /// Delete child rows that reference a deleted parent row (CASCADE action)
+#[allow(clippy::too_many_arguments)]
 fn cascade_delete(
     db: &mut vibesql_storage::Database,
     child_table_name: &str,
     fk: &vibesql_catalog::ForeignKeyConstraint,
+    fk_idx: usize,
     parent_key_values: &[SqlValue],
+    in_txn: bool,
+    session_defer: bool,
 ) -> Result<(), ExecutorError> {
     // Resolve parent-side collations before borrowing the child table so
     // FK comparisons honor NOCASE/RTRIM (#5147).
@@ -341,10 +356,12 @@ fn cascade_delete(
     // Verified against sqlite3 3.51.0.
     for child_row in &rows_to_delete {
         // BEFORE DELETE row triggers on the child. A RAISE(IGNORE)
-        // (SkipRow) abandons this child row's cascade — it is not deleted
-        // (matching sqlite3, where the surviving orphan then typically
-        // trips an FK check at statement end). A RAISE(ABORT|FAIL|
-        // ROLLBACK) propagates as Err and aborts the whole statement.
+        // (SkipRow) abandons this child row's cascade — it is not deleted.
+        // The surviving child row still references the parent key that is
+        // being deleted, so it becomes an orphan and must trip the
+        // statement-end FK check, exactly as sqlite3 3.51 does (#5465).
+        // A RAISE(ABORT|FAIL|ROLLBACK) propagates as Err and aborts the
+        // whole statement.
         if has_child_delete_triggers {
             let outcome = crate::TriggerFirer::execute_before_triggers(
                 db,
@@ -354,6 +371,27 @@ fn cascade_delete(
                 None,
             )?;
             if outcome == crate::TriggerOutcome::SkipRow {
+                // The skipped child still carries the parent's key, which is
+                // about to disappear (the parent DELETE is applied after this
+                // cascade returns). That is an FK violation. Match sqlite3:
+                //   - immediate FK -> raise now; the statement savepoint
+                //     rolls the whole statement back.
+                //   - deferred FK (INITIALLY DEFERRED or session
+                //     defer_foreign_keys=ON inside a txn) -> queue the
+                //     surviving row for the COMMIT-time re-check.
+                let should_defer = in_txn && (fk.initially_deferred || session_defer);
+                if should_defer {
+                    db.queue_deferred_fk_violation(DeferredFkViolation {
+                        child_table: child_table_name.to_string(),
+                        fk_index: fk_idx,
+                        child_row: child_row.values.to_vec(),
+                        kind: DeferredFkViolationKind::ChildInsertOrUpdate,
+                    });
+                } else {
+                    return Err(ExecutorError::ConstraintViolation(
+                        "FOREIGN KEY constraint failed".to_string(),
+                    ));
+                }
                 continue;
             }
         }

--- a/crates/vibesql-executor/src/tests/fk_cascade_triggers.rs
+++ b/crates/vibesql-executor/src/tests/fk_cascade_triggers.rs
@@ -375,6 +375,168 @@ fn multi_level_cascade_delete_fires_triggers_at_each_level() {
     assert_eq!(query_col(&db, "SELECT id FROM c"), Vec::<SqlValue>::new());
 }
 
+/// #5465: a cascade-fired RAISE(IGNORE) skips the child row's CASCADE delete,
+/// but the surviving child is now an orphan (its parent is being deleted). For
+/// an immediate FK this trips the statement-end FK check, rolling the whole
+/// statement back — exactly as sqlite3 3.51.0:
+///
+/// ```text
+/// DELETE FROM parent WHERE id=1;  -- Error: FOREIGN KEY constraint failed
+/// -- parent 1, child 10 and child 11 all survive (statement rolled back)
+/// ```
+///
+/// Before #5465 VibeSQL honored the skip but never re-ran the orphan check, so
+/// it deleted the parent + child 10 and left child 11 orphaned silently.
+#[test]
+fn cascade_delete_raise_ignore_orphan_trips_statement_end_fk_check() {
+    let mut db = fresh_db();
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE CASCADE)",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_skip BEFORE DELETE ON child WHEN OLD.id = 11 BEGIN SELECT RAISE(IGNORE); END",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO parent VALUES (1)").unwrap();
+    exec(&mut db, "INSERT INTO child VALUES (10, 1), (11, 1)").unwrap();
+
+    // Auto-commit: the implicit statement savepoint rolls the whole statement
+    // back on the FK violation.
+    let err = exec(&mut db, "DELETE FROM parent WHERE id = 1").unwrap_err();
+    assert!(
+        err.contains("FOREIGN KEY constraint failed"),
+        "expected FK violation, got: {err}"
+    );
+    assert!(!db.in_transaction(), "auto-commit must not leak an open transaction");
+
+    // sqlite3 3.51.0: statement rolls back — parent 1 and BOTH children
+    // survive (including child 10, which the cascade had already deleted).
+    assert_eq!(query_col(&db, "SELECT id FROM parent"), vec![SqlValue::Integer(1)]);
+    assert_eq!(
+        query_col(&db, "SELECT id FROM child ORDER BY id"),
+        vec![SqlValue::Integer(10), SqlValue::Integer(11)]
+    );
+}
+
+/// #5465: the same orphan check fires for ON UPDATE CASCADE. A cascade-fired
+/// BEFORE UPDATE RAISE(IGNORE) leaves the child pointing at the OLD parent key,
+/// which the parent UPDATE is about to rewrite — an orphan.
+///
+/// sqlite3 3.51.0: `UPDATE parent SET id=2 WHERE id=1` -> error
+/// `FOREIGN KEY constraint failed`; parent stays 1, both child pids stay 1.
+#[test]
+fn cascade_update_raise_ignore_orphan_trips_statement_end_fk_check() {
+    let mut db = fresh_db();
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON UPDATE CASCADE)",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_skip BEFORE UPDATE ON child WHEN OLD.id = 11 BEGIN SELECT RAISE(IGNORE); END",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO parent VALUES (1)").unwrap();
+    exec(&mut db, "INSERT INTO child VALUES (10, 1), (11, 1)").unwrap();
+
+    let err = exec(&mut db, "UPDATE parent SET id = 2 WHERE id = 1").unwrap_err();
+    assert!(
+        err.contains("FOREIGN KEY constraint failed"),
+        "expected FK violation, got: {err}"
+    );
+    assert!(!db.in_transaction());
+
+    // Statement rolled back: parent key unchanged, both child FKs unchanged.
+    assert_eq!(query_col(&db, "SELECT id FROM parent"), vec![SqlValue::Integer(1)]);
+    assert_eq!(
+        query_col(&db, "SELECT pid FROM child ORDER BY id"),
+        vec![SqlValue::Integer(1), SqlValue::Integer(1)]
+    );
+}
+
+/// #5465 control: RAISE(IGNORE) inside a cascade that leaves a *consistent*
+/// state must NOT raise a false FK violation. Here the trigger's WHEN clause
+/// never matches, so every child cascade-deletes normally and the parent is
+/// removed — no orphan, no error. Locks in that the new orphan check only
+/// fires when a row is actually skipped.
+#[test]
+fn cascade_delete_raise_ignore_not_fired_leaves_consistent_state() {
+    let mut db = fresh_db();
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE CASCADE)",
+    )
+    .unwrap();
+    // WHEN OLD.id = 999 never matches the rows we delete, so RAISE(IGNORE)
+    // never fires and no orphan is created.
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_skip BEFORE DELETE ON child WHEN OLD.id = 999 BEGIN SELECT RAISE(IGNORE); END",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO parent VALUES (1)").unwrap();
+    exec(&mut db, "INSERT INTO child VALUES (10, 1), (11, 1)").unwrap();
+
+    // sqlite3 3.51.0: no error; parent + all children removed.
+    exec(&mut db, "DELETE FROM parent WHERE id = 1").unwrap();
+    assert_eq!(query_col(&db, "SELECT id FROM parent"), Vec::<SqlValue>::new());
+    assert_eq!(query_col(&db, "SELECT id FROM child ORDER BY id"), Vec::<SqlValue>::new());
+}
+
+/// #5465 control: a DEFERRABLE INITIALLY DEFERRED FK does NOT raise the orphan
+/// at statement end — the surviving child is queued and the violation only
+/// surfaces at COMMIT, matching sqlite3 3.51.0:
+///
+/// ```text
+/// BEGIN;
+/// DELETE FROM parent WHERE id=1;  -- no error yet; child 11 orphaned, visible
+/// COMMIT;                         -- Error: FOREIGN KEY constraint failed
+/// ```
+#[test]
+fn cascade_delete_raise_ignore_deferred_fk_defers_orphan_to_commit() {
+    let mut db = fresh_db();
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_skip BEFORE DELETE ON child WHEN OLD.id = 11 BEGIN SELECT RAISE(IGNORE); END",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO parent VALUES (1)").unwrap();
+    exec(&mut db, "INSERT INTO child VALUES (10, 1), (11, 1)").unwrap();
+
+    db.begin_transaction().expect("BEGIN");
+    // Deferred: the DELETE itself succeeds mid-transaction (no immediate error).
+    exec(&mut db, "DELETE FROM parent WHERE id = 1").unwrap();
+    // Mid-txn state: parent + child 10 gone, child 11 survives orphaned.
+    assert_eq!(query_col(&db, "SELECT id FROM parent"), Vec::<SqlValue>::new());
+    assert_eq!(
+        query_col(&db, "SELECT id FROM child ORDER BY id"),
+        vec![SqlValue::Integer(11)]
+    );
+
+    // COMMIT catches the deferred orphan. Use the executor's CommitExecutor
+    // (not the raw storage commit) so the deferred FK re-check runs.
+    let commit = crate::CommitExecutor::execute(&vibesql_ast::CommitStmt, &mut db);
+    assert!(commit.is_err(), "COMMIT must fail on the deferred orphan");
+    let msg = format!("{:?}", commit.unwrap_err());
+    assert!(
+        msg.contains("FOREIGN KEY constraint failed"),
+        "expected FK violation at COMMIT, got: {msg}"
+    );
+}
+
 /// Sanity: cascade delete still works (and deletes the right rows) when the
 /// child table has no triggers — no behavioral regression.
 #[test]

--- a/crates/vibesql-executor/src/update/foreign_keys.rs
+++ b/crates/vibesql-executor/src/update/foreign_keys.rs
@@ -193,9 +193,14 @@ impl ForeignKeyValidator {
         // checker issues). Each entry carries the row index, the OLD child
         // row, and the NEW child row so the cascade can fire the child
         // table's BEFORE/AFTER UPDATE triggers with both pseudo-rows (#5440).
+        // Each entry also carries the FK constraint + its index so that a
+        // cascade-fired BEFORE UPDATE trigger RAISE(IGNORE) (SkipRow) can run
+        // the statement-end orphan FK check on the surviving row (#5465).
         #[allow(clippy::type_complexity)]
         let mut cascade_updates: Vec<(
             String,
+            vibesql_catalog::ForeignKeyConstraint,
+            usize,
             Vec<(usize, vibesql_storage::Row, vibesql_storage::Row)>,
         )> = Vec::new();
 
@@ -316,7 +321,12 @@ impl ForeignKeyValidator {
                                 })
                                 .collect();
 
-                            cascade_updates.push((table_name.clone(), updated_rows));
+                            cascade_updates.push((
+                                table_name.clone(),
+                                fk.clone(),
+                                fk_idx,
+                                updated_rows,
+                            ));
                         }
                         vibesql_catalog::ReferentialAction::SetNull => {
                             // Set child FK columns to NULL
@@ -337,7 +347,12 @@ impl ForeignKeyValidator {
                                 })
                                 .collect();
 
-                            cascade_updates.push((table_name.clone(), updated_rows));
+                            cascade_updates.push((
+                                table_name.clone(),
+                                fk.clone(),
+                                fk_idx,
+                                updated_rows,
+                            ));
                         }
                         vibesql_catalog::ReferentialAction::SetDefault => {
                             // Set child FK columns to their default values by evaluating
@@ -403,7 +418,12 @@ impl ForeignKeyValidator {
                                 })
                                 .collect();
 
-                            cascade_updates.push((table_name.clone(), updated_rows));
+                            cascade_updates.push((
+                                table_name.clone(),
+                                fk.clone(),
+                                fk_idx,
+                                updated_rows,
+                            ));
                         }
                         vibesql_catalog::ReferentialAction::Restrict => {
                             // RESTRICT is immediate by default, but the
@@ -472,7 +492,7 @@ impl ForeignKeyValidator {
         // RAISE(ABORT|FAIL|ROLLBACK) propagates as Err and aborts the
         // whole statement.
         let txn_id = db.transaction_id();
-        for (table_name, mut updates) in cascade_updates {
+        for (table_name, fk, fk_idx, mut updates) in cascade_updates {
             for (_row_idx, _old_row, new_row) in updates.iter_mut() {
                 vibesql_storage::stamp_xmin_for_write(new_row, txn_id);
                 new_row.xmax = None;
@@ -495,6 +515,28 @@ impl ForeignKeyValidator {
                         Some(&new_row),
                     )?;
                     if outcome == crate::TriggerOutcome::SkipRow {
+                        // RAISE(IGNORE) abandons this cascade update: the
+                        // surviving child keeps its OLD FK value, which
+                        // references the parent key that is about to change
+                        // (the parent UPDATE is applied after this cascade
+                        // returns). That is an orphaned FK reference and must
+                        // trip the statement-end FK check, matching sqlite3
+                        // 3.51 (#5465). Immediate FK -> raise now (statement
+                        // savepoint rolls the statement back); deferred FK ->
+                        // queue the surviving OLD row for the COMMIT re-check.
+                        let should_defer = in_txn && (fk.initially_deferred || session_defer);
+                        if should_defer {
+                            db.queue_deferred_fk_violation(DeferredFkViolation {
+                                child_table: table_name.clone(),
+                                fk_index: fk_idx,
+                                child_row: old_row.values.to_vec(),
+                                kind: DeferredFkViolationKind::ChildInsertOrUpdate,
+                            });
+                        } else {
+                            return Err(ExecutorError::ConstraintViolation(
+                                "FOREIGN KEY constraint failed".to_string(),
+                            ));
+                        }
                         continue;
                     }
                 }


### PR DESCRIPTION
Closes #5465

## Root cause (where the statement-end check was skipped)

When an FK `ON DELETE/UPDATE CASCADE` fires a child-table BEFORE trigger that
runs `RAISE(IGNORE)`, the executor honored the per-row skip (from #5440/#5463)
but then never re-ran any FK orphan check on the surviving child row:

- **DELETE**: `crates/vibesql-executor/src/delete/integrity.rs` — in
  `cascade_delete`, the `TriggerOutcome::SkipRow` branch did a bare `continue`,
  leaving the child row in place while the parent DELETE proceeded.
- **UPDATE**: `crates/vibesql-executor/src/update/foreign_keys.rs` — the
  cascade-update apply loop's `SkipRow` branch likewise `continue`d, leaving the
  child pointing at the OLD parent key that the parent UPDATE was about to
  rewrite.

In both cases the surviving child is guaranteed to become an orphan once the
parent operation applies, but VibeSQL left it silently — diverging from sqlite3,
which trips `FOREIGN KEY constraint failed` at statement end and rolls the
statement back.

## Fix

In each `SkipRow` branch, run the statement-end orphan FK check, mirroring the
existing NO ACTION defer/raise logic:

- **Immediate FK**: return `ConstraintViolation("FOREIGN KEY constraint
  failed")`. The statement savepoint (armed by cascade-reachable child triggers,
  #5440/#5464) rolls the whole statement back — including any rows the cascade
  had already deleted/updated.
- **Deferred FK** (`INITIALLY DEFERRED` or session `defer_foreign_keys=ON`
  inside a txn): queue the surviving row as a `DeferredFkViolation` so the
  COMMIT-time re-check (`CommitExecutor`) catches it.

The `fk` constraint + its index are now threaded into `cascade_delete` and into
the `cascade_updates` tuple so the apply loop can build the deferred record /
choose immediate-vs-deferred.

## sqlite3 3.51.0 parity evidence

The exact issue scenario, run against `sqlite3 3.51.0`:

```
PRAGMA foreign_keys=ON;
CREATE TABLE parent (id INTEGER PRIMARY KEY);
CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE CASCADE);
CREATE TRIGGER child_skip BEFORE DELETE ON child WHEN OLD.id=11 BEGIN SELECT RAISE(IGNORE); END;
INSERT INTO parent VALUES (1);
INSERT INTO child VALUES (10,1),(11,1);
DELETE FROM parent WHERE id=1;
-- sqlite3: "FOREIGN KEY constraint failed"; parent 1 + child 10 + child 11 all survive
```

VibeSQL now produces the same error and the same end state (whole statement
rolled back). Also verified:
- `ON UPDATE CASCADE` variant → same `FOREIGN KEY constraint failed`, parent +
  both child FKs unchanged.
- Deferred FK variant: no error mid-txn (parent + child 10 gone, child 11
  orphaned visible), `FOREIGN KEY constraint failed` at COMMIT.
- Control (trigger WHEN never matches): no false violation, parent + all
  children removed cleanly.

## Test results

New tests in `crates/vibesql-executor/src/tests/fk_cascade_triggers.rs`:
- `cascade_delete_raise_ignore_orphan_trips_statement_end_fk_check`
- `cascade_update_raise_ignore_orphan_trips_statement_end_fk_check`
- `cascade_delete_raise_ignore_not_fired_leaves_consistent_state` (control)
- `cascade_delete_raise_ignore_deferred_fk_defers_orphan_to_commit` (deferred)

- `cargo test -p vibesql-executor`: **2723 passed, 0 failed**.
- TCL conformance, base (origin/main `5faca1100`) vs this branch, failing-test
  ID sets byte-for-byte **identical** (no regressions):
  - `fkey1.test`: 0 failures
  - `fkey2.test`: 100 (pre-existing, unchanged)
  - `trigger1.test`: 58 (pre-existing, unchanged)
  - `trigger2.test`: 8 (pre-existing, unchanged)

## Scope / coordination notes

- Changes are confined to the FK integrity-check path
  (`delete/integrity.rs`, `update/foreign_keys.rs`) + the test file. **No changes
  to `trigger_execution.rs` or `raise_scope.rs`**, so there is no overlap with
  the parallel #5486 (BEFORE/AFTER per-row interleaving) trigger-execution seam.

## Follow-ons

- SET NULL / SET DEFAULT cascades on the **DELETE** side
  (`set_null`/`set_default` in `delete/integrity.rs`) currently apply the child
  rewrite via `update_row` **without firing the child's BEFORE UPDATE
  triggers**, so a `RAISE(IGNORE)` cannot intercept them there. sqlite3 fires
  those triggers and the same orphan check would apply — worth a dedicated issue
  to fire SET NULL/SET DEFAULT child triggers and route them through this orphan
  check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)