### PR TITLE
perf(server): names-only replicated Describe to avoid materializing rows

### DIFF
--- a/crates/vibesql-consensus/src/mvcc_raft.rs
+++ b/crates/vibesql-consensus/src/mvcc_raft.rs
@@ -1012,6 +1012,21 @@ impl MvccRaftNode {
         self.sm.machine.query(sql)
     }
 
+    /// Resolve a SELECT's output column names against the locally applied
+    /// state **without executing it** — the names-only counterpart of
+    /// [`query`](Self::query) for the extended-protocol `Describe` (#5484).
+    ///
+    /// Like [`query`](Self::query) this is a local, stale-allowed read with
+    /// no leadership check or network round, available on every node. It
+    /// resolves names via the same [`SelectExecutor::resolve_column_names`]
+    /// the standalone `Describe` uses, so the column labels match the
+    /// standalone path exactly — but, unlike `query`, it materializes no
+    /// rows (a metadata-only catalog read). See
+    /// [`VibesqlStateMachine::resolve_column_names`].
+    pub fn resolve_column_names(&self, sql: &str) -> Result<Vec<String>> {
+        self.sm.machine.resolve_column_names(sql)
+    }
+
     /// Subscribe to this node's apply-path change feed (#5422): a
     /// [`ChangeEventReceiver`](vibesql_storage::ChangeEventReceiver) yielding a
     /// [`ChangeEvent`](vibesql_storage::ChangeEvent) per row mutated by the

--- a/crates/vibesql-consensus/src/state_machine.rs
+++ b/crates/vibesql-consensus/src/state_machine.rs
@@ -643,6 +643,35 @@ impl VibesqlStateMachine {
         Ok(QueryResult::from(result))
     }
 
+    /// Resolve the output column names of a SELECT against the applied
+    /// state **without executing it** — the names-only counterpart of
+    /// [`query`](Self::query) for the extended-protocol `Describe` (#5484).
+    ///
+    /// `Describe` reports the `RowDescription` before any `Execute`, so it
+    /// needs only the resolved column names, never the rows. This resolves
+    /// them via [`SelectExecutor::resolve_column_names`] against the applied
+    /// replicated catalog — the *same* resolver standalone `Describe` uses —
+    /// so the names match the standalone path label-for-label (real names,
+    /// aliases, derived expression names, `SELECT *` / `t.*` / join-wildcard
+    /// expanded against the schema). Unlike [`query`](Self::query) (which
+    /// runs `execute_with_columns` and materializes rows the caller then
+    /// discards), this does no row materialization: it is a pure metadata
+    /// read of the applied catalog. A replica resolves against its own
+    /// applied state, so a `Describe` on a follower sees the right schema.
+    pub fn resolve_column_names(&self, sql: &str) -> Result<Vec<String>> {
+        let inner = self.lock();
+        let statement = vibesql_parser::parse_with_arena_fallback(sql)
+            .map_err(|e| ConsensusError::Backend(format!("parse error: {e}")))?;
+        let Statement::Select(select) = statement else {
+            return Err(ConsensusError::Backend(format!(
+                "resolve_column_names() only accepts SELECT statements, got: {sql}"
+            )));
+        };
+        vibesql_executor::SelectExecutor::new(&inner.db)
+            .resolve_column_names(&select)
+            .map_err(|e| ConsensusError::Backend(format!("column resolution failed: {e}")))
+    }
+
     /// Resolve the (single-column) primary-key column of `table_name`
     /// against the **applied replicated catalog** (#5420). This is the
     /// replicated-mode counterpart of reading the local registry schema:
@@ -1258,6 +1287,59 @@ mod tests {
             .apply(3, &TxnEntry::single("CREATE TABLE composite (a INT, b INT, PRIMARY KEY (a, b))"))
             .unwrap();
         assert_eq!(machine.primary_key_column("composite"), None);
+    }
+
+    #[test]
+    fn resolve_column_names_matches_query_columns_without_executing() {
+        let shapes = [
+            "SELECT id, name FROM users",       // explicit columns
+            "SELECT id AS k, name AS v FROM users", // aliases
+            "SELECT id + 1 FROM users",         // derived expression
+            "SELECT * FROM users",              // wildcard expansion
+            "SELECT users.* FROM users",        // table wildcard
+        ];
+
+        // Names are resolved from the applied catalog, not from data: an
+        // empty table resolves the SAME labels a populated one does, which
+        // is the observable signal that resolution does not read rows
+        // (#5484). We resolve against an empty `users`, then insert rows and
+        // re-resolve — the labels are byte-identical.
+        let machine = VibesqlStateMachine::new();
+        create_users(&machine, 1);
+
+        let mut empty_names = Vec::new();
+        for sql in shapes {
+            // Empty table: `query` returns zero rows but the executed
+            // `.columns` still carries the schema-derived labels (#5428).
+            let executed = machine.query(sql).unwrap();
+            assert!(executed.rows.is_empty(), "{sql}: fixture must start empty");
+            let resolved = machine.resolve_column_names(sql).unwrap();
+            assert_eq!(
+                resolved, executed.columns,
+                "{sql}: names-only must match the executed read path's columns",
+            );
+            assert!(
+                !resolved.iter().any(|n| n.starts_with("col")),
+                "{sql}: must not regress to col0/col1 placeholders, got {resolved:?}",
+            );
+            empty_names.push(resolved);
+        }
+
+        // Now populate and re-resolve: identical labels prove the resolver
+        // is driven by the catalog, never the rows.
+        machine.apply(2, &TxnEntry::single("INSERT INTO users VALUES (1, 'a')")).unwrap();
+        machine.apply(3, &TxnEntry::single("INSERT INTO users VALUES (2, 'b')")).unwrap();
+        for (sql, before) in shapes.iter().zip(empty_names.iter()) {
+            let after = machine.resolve_column_names(sql).unwrap();
+            assert_eq!(
+                &after, before,
+                "{sql}: column labels must not change once rows exist (schema-driven)",
+            );
+        }
+
+        // Non-SELECT is a hard error (the server layer maps SELECT-vs-not
+        // to Some/None before ever calling this).
+        assert!(machine.resolve_column_names("INSERT INTO users VALUES (3, 'c')").is_err());
     }
 
     #[test]

--- a/crates/vibesql-server/src/replication.rs
+++ b/crates/vibesql-server/src/replication.rs
@@ -290,6 +290,17 @@ impl ReplicationHandle {
         self.node.query(sql).map_err(|e| self.sql_error("the query", e))
     }
 
+    /// Resolve a SELECT's output column names against the applied state
+    /// **without executing it** — the names-only path for the
+    /// extended-protocol `Describe` (#5484). Resolves via the same
+    /// `SelectExecutor::resolve_column_names` the standalone `Describe`
+    /// uses (so the labels match label-for-label), but materializes no
+    /// rows, unlike [`query_local`](Self::query_local) which ran a full
+    /// read just to keep its `.columns`.
+    pub fn resolve_column_names(&self, sql: &str) -> Result<Vec<String>, SqlError> {
+        self.node.resolve_column_names(sql).map_err(|e| self.sql_error("the query", e))
+    }
+
     /// Subscribe to the apply-path change feed (#5422): a
     /// [`ChangeEventReceiver`](vibesql_storage::ChangeEventReceiver) yielding a
     /// [`ChangeEvent`](vibesql_storage::ChangeEvent) per row the consensus state

--- a/crates/vibesql-server/src/session.rs
+++ b/crates/vibesql-server/src/session.rs
@@ -428,9 +428,11 @@ impl Session {
     ///   `derive_column_names` used by `execute_with_columns`).
     /// - `Ok(None)` for a non-SELECT (the protocol sends `NoData`).
     ///
-    /// Standalone resolves directly against the local database; replicated
-    /// resolves via a local read through consensus (the state machine already
-    /// resolves names the same way, #5428), so both modes agree.
+    /// Both modes resolve names via the same
+    /// `SelectExecutor::resolve_column_names` without executing the query:
+    /// standalone against the local database, replicated against the applied
+    /// consensus catalog (#5484). Neither materializes rows, and both agree
+    /// label-for-label.
     pub async fn describe_columns(&self, sql: &str) -> Result<Option<Vec<String>>> {
         let prepared = self.stmt_cache.get_or_prepare(sql).map_err(|e| anyhow::anyhow!("{}", e))?;
         let statement = prepared.statement();
@@ -442,10 +444,14 @@ impl Session {
 
         if let Some(state) = self.replication.as_ref() {
             // Replicated: the database lives in the consensus state machine.
-            // A local read resolves the same column names the simple-query
-            // path uses (#5428); we keep only the names, discarding rows.
-            let result = state.handle.query_local(sql)?;
-            return Ok(Some(result.columns));
+            // Resolve names against the applied catalog via the SAME
+            // `SelectExecutor::resolve_column_names` standalone uses (#5484),
+            // so the labels match the standalone path label-for-label — but
+            // WITHOUT executing the query. Previously this ran a full
+            // `query_local` read and kept only `.columns`, materializing rows
+            // a metadata-only Describe immediately discarded.
+            let columns = state.handle.resolve_column_names(sql)?;
+            return Ok(Some(columns));
         }
 
         let db = self.db.read().await;

--- a/crates/vibesql-server/tests/replication_tests.rs
+++ b/crates/vibesql-server/tests/replication_tests.rs
@@ -259,11 +259,13 @@ async fn replicated_select_column_names_match_standalone() {
 /// Extended-protocol `Describe` (#5429) must report the same column names in
 /// replicated mode as it does standalone, with `SELECT *` / `table.*` expanded
 /// against the schema. `Session::describe_columns` resolves names WITHOUT
-/// executing — for a replicated session it routes through a local consensus
-/// read (`query_local`), which resolves names the same way the executed read
-/// path does (#5428). Standalone (the local executor's `resolve_column_names`)
-/// is the oracle: the two must agree label-for-label, and neither may regress
-/// to `col0`/`col1` placeholders.
+/// executing — for a replicated session it routes through a names-only
+/// consensus read (`Replication::resolve_column_names`, #5484), which calls
+/// the SAME `SelectExecutor::resolve_column_names` standalone uses against the
+/// applied catalog and materializes no rows (previously it ran a full
+/// `query_local` read and kept only `.columns`). Standalone (the local
+/// executor's `resolve_column_names`) is the oracle: the two must agree
+/// label-for-label, and neither may regress to `col0`/`col1` placeholders.
 #[tokio::test]
 async fn replicated_describe_columns_match_standalone() {
     let setup = [


### PR DESCRIPTION
Closes #5484

Follow-on from #5429 (PR #5482), flagged by its judge.

## Before / After

**Before** — the replicated extended-protocol `Describe` resolved column
names by running a full read and discarding the rows:

```rust
// Session::describe_columns, replicated branch
let result = state.handle.query_local(sql)?;   // executes the SELECT, materializes rows
return Ok(Some(result.columns));               // ...then keeps only the labels
```

`query_local` → `MvccRaftNode::query` → `VibesqlStateMachine::query` runs
`SelectExecutor::execute_with_columns`, which materializes the full result
set. For a metadata-only `Describe` (which must report `RowDescription`
before any `Execute`) every one of those rows is built and thrown away.

**After** — a names-only path that resolves labels from the applied
catalog without executing the query:

```rust
// Session::describe_columns, replicated branch
let columns = state.handle.resolve_column_names(sql)?;  // schema/catalog only, no rows
return Ok(Some(columns));
```

`Replication::resolve_column_names` → `MvccRaftNode::resolve_column_names`
→ `VibesqlStateMachine::resolve_column_names`, which parses the SELECT and
calls `SelectExecutor::resolve_column_names` — the **same** resolver the
standalone `Describe` already uses — against the applied replicated
database. No rows are materialized.

## Exact-parity argument

The column labels are unchanged, byte-for-byte:

- The standalone `Describe` already calls
  `SelectExecutor::resolve_column_names` (#5429). The new replicated path
  calls the **identical** function, so by construction the two agree
  label-for-label — the same property #5429/#5428 established structurally.
- It runs against the applied replicated catalog (the same `Database` the
  old `query` read used, via the state-machine lock), so a `Describe` on a
  follower resolves against that replica's applied schema. The names that
  `query`'s `execute_with_columns` produced came from the *same*
  `derive_column_names` logic `resolve_column_names` reuses, so the labels
  the old `query_local().columns` path returned and the labels the new
  path returns are identical.
- This is a pure optimization: only the rows-materialized cost changes,
  never the names.

## Non-materialization: test-observable

Yes, observably. The consensus unit test
`resolve_column_names_matches_query_columns_without_executing` proves
resolution is **catalog-driven, not data-driven**: it resolves the
Describe shapes (explicit / alias / derived / `*` / `t.*`) against an
empty `users`, asserts the labels equal the executed read path's
`.columns`, then inserts rows and re-resolves — the labels are
byte-identical with and without rows. (A division-by-zero "would error on
execute" probe was tried first but VibeSQL's SQLite-compat semantics
return NULL rather than erroring, so the empty-vs-populated invariant is
the robust, semantics-independent signal.)

## Test evidence

- `cargo test -p vibesql-consensus` — 178 lib tests pass (incl. the new
  `resolve_column_names_matches_query_columns_without_executing`), all
  integration suites green.
- `cargo test -p vibesql-server` — green, including the existing
  `replicated_describe_columns_match_standalone` (#5429), which still
  asserts the replicated `Describe` matches the standalone oracle
  label-for-label for SELECT * / table.* / explicit / aliased /
  join-wildcard after the change. Its doc comment was updated to describe
  the new names-only routing.
- `cargo clippy -p vibesql-consensus -p vibesql-server` — no new warnings
  in the changed code (pre-existing warnings only).

## Scope notes

Executor changes are limited to **reusing** the existing
`SelectExecutor::resolve_column_names` (read-only); no trigger/insert path
was touched. No overlap with the parallel executor work on #5486 / #5497.