### PR TITLE
fix(executor): interleave BEFORE/AFTER row triggers per-row in multi-row DML

### DIFF
--- a/crates/vibesql-executor/src/compaction_guard.rs
+++ b/crates/vibesql-executor/src/compaction_guard.rs
@@ -1,0 +1,63 @@
+//! Deferred-compaction coordination for interleaved per-row DML loops.
+//!
+//! Issue #5486: the UPDATE/DELETE executors fire row triggers interleaved per
+//! row (BEFORE -> apply -> AFTER) while iterating over a table's *physical* row
+//! indices. A trigger body may recursively DELETE from that same table (e.g.
+//! fkey2-4.3's recursive AFTER DELETE cascade, or trigger1-1.10). If such a
+//! nested DELETE compacts the table, every physical index shifts and the
+//! ancestor loop's not-yet-processed indices become invalid.
+//!
+//! To prevent that, an interleaved DML loop registers the table it is iterating
+//! over via [`IterationGuard`]. While a table is registered, nested DELETEs on
+//! that table defer compaction ([`is_iterating`] returns `true`); the
+//! outermost loop performs a single compaction once it finishes.
+//!
+//! Deletes on a table that is *not* currently under iteration compact normally
+//! — including a nested DELETE on a different table (e.g. an INSTEAD OF DELETE
+//! trigger on a view whose body deletes from a base table that no ancestor is
+//! iterating).
+
+use std::cell::RefCell;
+
+thread_local! {
+    /// Tables currently being iterated by an interleaved per-row DML loop on
+    /// this thread. A multiset (Vec) so nested loops on the same table register
+    /// independently and each unregisters exactly one entry on drop.
+    static ITERATING_TABLES: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+}
+
+/// RAII guard that registers `table_name` as under interleaved iteration for
+/// its lifetime. Nested DELETEs on the same table will defer compaction while
+/// this guard is alive.
+pub struct IterationGuard {
+    table_name: String,
+}
+
+impl IterationGuard {
+    /// Register `table_name` as under interleaved iteration.
+    pub fn new(table_name: &str) -> Self {
+        ITERATING_TABLES.with(|tables| tables.borrow_mut().push(table_name.to_string()));
+        IterationGuard { table_name: table_name.to_string() }
+    }
+}
+
+impl Drop for IterationGuard {
+    fn drop(&mut self) {
+        ITERATING_TABLES.with(|tables| {
+            let mut tables = tables.borrow_mut();
+            // Remove one matching entry (the most recent), leaving any
+            // outer-loop registration of the same table intact.
+            if let Some(pos) = tables.iter().rposition(|t| t == &self.table_name) {
+                tables.remove(pos);
+            }
+        });
+    }
+}
+
+/// Returns `true` if `table_name` is currently being iterated by an interleaved
+/// per-row DML loop on this thread (case-sensitive match on the canonical
+/// table name the loops register). Callers use this to decide whether to defer
+/// compaction of that table.
+pub fn is_iterating(table_name: &str) -> bool {
+    ITERATING_TABLES.with(|tables| tables.borrow().iter().any(|t| t == table_name))
+}

--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -468,122 +468,112 @@ impl DeleteExecutor {
             )?;
         }
 
-        // Step 3: Fire BEFORE DELETE ROW triggers only if triggers exist.
-        // A RAISE(IGNORE) in a BEFORE DELETE trigger abandons that row: drop it
-        // from the batch so it is neither deleted nor counted (SQLite).
+        // Steps 3-6: Fire BEFORE/AFTER DELETE ROW triggers and physically
+        // delete the rows.
+        //
+        // Issue #5486: SQLite fires row triggers INTERLEAVED per row — for each
+        // affected row R it runs the BEFORE trigger(s) on R, deletes R, then
+        // runs the AFTER trigger(s) on R, *before* moving to R+1. A trigger body
+        // that reads the table mid-statement (e.g. `SELECT sum(a) FROM tbl`)
+        // must therefore see exactly the rows deleted so far. The previous
+        // implementation fired all BEFOREs, then deleted every row, then all
+        // AFTERs, which made such triggers observe the wrong running state.
+        //
+        // When no DELETE triggers exist we keep the batched fast path (no
+        // observable difference, lower overhead). When triggers exist we
+        // interleave per row and defer compaction until the whole loop finishes
+        // (compacting mid-loop would shift the indices of the rows we have not
+        // yet processed).
+        //
+        // Compaction must additionally be deferred whenever an *ancestor*
+        // statement is currently iterating over this same table's physical row
+        // indices via an interleaved per-row DML loop (fkey2-4.3: a recursive
+        // AFTER DELETE trigger cascading through a tree). Compacting here would
+        // shift the ancestor's not-yet-processed indices. The ancestor's loop
+        // (which registered the table via `IterationGuard`) performs the single
+        // compaction once it finishes. A nested DELETE on a *different* table
+        // than any ancestor is iterating compacts normally.
+        let defer_compaction = crate::compaction_guard::is_iterating(table_name);
+        let deleted_count: usize;
         if has_delete_triggers {
-            let mut keep = Vec::with_capacity(rows_and_indices_to_delete.len());
-            for (idx, row) in rows_and_indices_to_delete {
-                let outcome = crate::TriggerFirer::execute_before_triggers(
+            #[cfg(feature = "mvcc_enabled")]
+            let mvcc_delete_txn_id = database.transaction_id();
+
+            // Register this table as under interleaved iteration so nested
+            // DELETEs on it (fired by the row triggers below) defer their
+            // compaction to the `compact_if_needed` call after this loop.
+            let _iter_guard = crate::compaction_guard::IterationGuard::new(table_name);
+
+            let mut deleted = 0usize;
+            let mut applied_rows: Vec<(usize, vibesql_storage::Row)> = Vec::new();
+            let mut compacted = false;
+
+            for (idx, row) in rows_and_indices_to_delete.iter() {
+                // A trigger fired for an earlier row may have already deleted
+                // this row mid-statement (cascade / recursive delete, e.g.
+                // trigger1-1.10's `DELETE FROM t WHERE a = old.a + 2`). SQLite
+                // processes such a row only once, so skip it here — its BEFORE/
+                // AFTER triggers do not fire a second time.
+                if database
+                    .get_table(table_name)
+                    .map(|t| t.is_row_deleted(*idx))
+                    .unwrap_or(true)
+                {
+                    continue;
+                }
+
+                // BEFORE(R): a RAISE(IGNORE) drops this row entirely (skip it,
+                // continue with the remaining rows).
+                let before_outcome = crate::TriggerFirer::execute_before_triggers(
                     database,
                     table_name,
                     vibesql_ast::TriggerEvent::Delete,
-                    Some(&row),
+                    Some(row),
                     None,
                 )?;
-                if outcome != crate::TriggerOutcome::SkipRow {
-                    keep.push((idx, row));
+                if before_outcome == crate::TriggerOutcome::SkipRow {
+                    continue;
                 }
-            }
-            rows_and_indices_to_delete = keep;
-        }
 
-        // Step 4: Handle referential integrity for each row to be deleted
-        // This may CASCADE deletes, SET NULL, or SET DEFAULT in child tables
-        for (_, row) in &rows_and_indices_to_delete {
-            check_no_child_references(database, table_name, row)?;
-        }
+                // Referential integrity for this row (CASCADE / SET NULL /
+                // SET DEFAULT / restrict) — runs as part of processing R, after
+                // its BEFORE trigger and before its physical deletion.
+                check_no_child_references(database, table_name, row)?;
 
-        // Extract indices for deletion
-        let mut deleted_indices: Vec<usize> =
-            rows_and_indices_to_delete.iter().map(|(idx, _)| *idx).collect();
-        deleted_indices.sort_unstable();
+                // WAL + index maintenance for this single row (indices are still
+                // valid: we defer compaction to the end of the loop).
+                database.emit_wal_delete(table_name, *idx as u64, row.values.to_vec());
+                let rows_refs: Vec<(usize, &vibesql_storage::Row)> = vec![(*idx, row)];
+                database.batch_update_indexes_for_delete(table_name, &rows_refs);
+                expression_index_maintenance::maintain_expression_indexes_for_delete(
+                    database, table_name, row, *idx,
+                );
+                partial_index_maintenance::maintain_partial_indexes_for_delete(
+                    database, table_name, row, *idx,
+                );
 
-        // Step 5a: Emit WAL entries and remove entries from user-defined indexes
-        // BEFORE deleting rows (while row indices are still valid and we have old values)
-        // First emit WAL entries for each row (needed for recovery replay)
-        for (idx, row) in &rows_and_indices_to_delete {
-            database.emit_wal_delete(table_name, *idx as u64, row.values.to_vec());
-        }
+                // delete(R): flip the deletion bitmap for just this row so the
+                // AFTER trigger (and the BEFORE trigger of the next row) observes
+                // R as gone. Compaction is deferred (see compact_if_needed below).
+                {
+                    let table_mut = database
+                        .get_table_mut(table_name)
+                        .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
 
-        // Then use batch method for index updates: O(d + m*log n) vs O(d*m*log n)
-        // where d=deletes, m=indexes
-        let rows_refs: Vec<(usize, &vibesql_storage::Row)> =
-            rows_and_indices_to_delete.iter().map(|(idx, row)| (*idx, row)).collect();
-        database.batch_update_indexes_for_delete(table_name, &rows_refs);
+                    #[cfg(feature = "mvcc_enabled")]
+                    if let Some(id) = mvcc_delete_txn_id {
+                        table_mut.stamp_row_xmax_inplace(*idx, id);
+                    }
 
-        // Maintain expression indexes for each deleted row
-        for (row_index, row) in &rows_and_indices_to_delete {
-            expression_index_maintenance::maintain_expression_indexes_for_delete(
-                database, table_name, row, *row_index,
-            );
-            partial_index_maintenance::maintain_partial_indexes_for_delete(
-                database, table_name, row, *row_index,
-            );
-        }
+                    if table_mut.mark_deleted_inplace(*idx) {
+                        deleted += 1;
+                        applied_rows.push((*idx, row.clone()));
+                    }
+                }
 
-        // Phase 1c (Issue #5150 / #5136): stamp xmax on every row about
-        // to be bitmap-deleted with the active txn id when the
-        // `mvcc_enabled` feature is on. Fetched BEFORE the mutable borrow
-        // of `table_mut`. We keep the physical bitmap delete in place;
-        // Phase 1d's visibility filter will eventually treat the xmax
-        // stamp as the canonical deletion record. Off-state: no stamp,
-        // bit-for-bit pre-MVCC behavior.
-        #[cfg(feature = "mvcc_enabled")]
-        let mvcc_delete_txn_id = database.transaction_id();
-
-        // Step 5b: Actually delete the rows using fast path (no table scan needed)
-        let table_mut = database
-            .get_table_mut(table_name)
-            .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
-
-        // Stamp xmax in-place on each row BEFORE bitmap-deleting. The
-        // bitmap delete leaves the row in `self.rows`, so the xmax field
-        // is observable via `Table::scan()` (which returns the raw rows
-        // slice including bitmap-deleted entries).
-        #[cfg(feature = "mvcc_enabled")]
-        if let Some(id) = mvcc_delete_txn_id {
-            for &idx in &deleted_indices {
-                table_mut.stamp_row_xmax_inplace(idx, id);
-            }
-        }
-
-        // Use delete_by_indices_batch for O(d) instead of O(n) where d = deletes
-        // The batch version pre-computes schema lookups for internal hash indexes,
-        // reducing overhead by ~30-40% for multi-row deletes.
-        // User-defined index entries have already been removed by batch_update_indexes_for_delete
-        // above. Note: If >50% of rows are deleted, compaction triggers and row indices
-        // change. When compaction occurs, we must rebuild user-defined indexes.
-        let delete_result = table_mut.delete_by_indices_batch(&deleted_indices);
-
-        // If compaction occurred, rebuild user-defined indexes since all row indices changed
-        if delete_result.compacted {
-            database.rebuild_indexes(table_name);
-            // Expression indexes need special handling (expression evaluation)
-            expression_index_maintenance::rebuild_expression_indexes_after_compaction(
-                database, table_name,
-            );
-            // Partial indexes need WHERE-predicate evaluation per row
-            partial_index_maintenance::rebuild_partial_indexes_after_compaction(
-                database, table_name,
-            );
-        }
-
-        // Invalidate the database-level columnar cache since table data changed.
-        // Note: The table-level cache is already invalidated by delete_by_indices().
-        // Both invalidations are necessary because they manage separate caches:
-        // - Table-level cache: used by Table::scan_columnar() for SIMD filtering
-        // - Database-level cache: used by Database::get_columnar() for cached access
-        if delete_result.deleted_count > 0 {
-            database.invalidate_columnar_cache(table_name);
-        }
-
-        // Step 6: Fire AFTER DELETE ROW triggers only if triggers exist.
-        // AFTER triggers run once the row is already deleted; a RAISE(IGNORE)
-        // here cannot un-delete it (sqlite3 3.51 keeps the row deleted), so
-        // SkipRow is a no-op — drop the must-use outcome (#5418).
-        if has_delete_triggers {
-            for (_, row) in &rows_and_indices_to_delete {
+                // AFTER(R): the row is already deleted; a RAISE(IGNORE) cannot
+                // un-delete it, so SkipRow is a no-op — drop the must-use
+                // outcome (#5418).
                 let _after_outcome = crate::TriggerFirer::execute_after_triggers(
                     database,
                     table_name,
@@ -592,6 +582,123 @@ impl DeleteExecutor {
                     None,
                 )?;
             }
+
+            // Compact once, after all rows are processed (unless deferred to an
+            // ancestor statement). If it compacts, every row index changed and
+            // the user-defined / expression / partial indexes must be rebuilt.
+            if deleted > 0 {
+                if !defer_compaction {
+                    if let Some(table_mut) = database.get_table_mut(table_name) {
+                        compacted = table_mut.compact_if_needed();
+                    }
+                    if compacted {
+                        database.rebuild_indexes(table_name);
+                        expression_index_maintenance::rebuild_expression_indexes_after_compaction(
+                            database, table_name,
+                        );
+                        partial_index_maintenance::rebuild_partial_indexes_after_compaction(
+                            database, table_name,
+                        );
+                    }
+                }
+                database.invalidate_columnar_cache(table_name);
+            }
+
+            // Restrict the row set to those actually deleted so RETURNING and
+            // the deleted-count reflect SQLite semantics (BEFORE-IGNORE'd rows
+            // are excluded).
+            rows_and_indices_to_delete = applied_rows;
+            deleted_count = deleted;
+        } else {
+            // Fast path: no DELETE triggers — batch delete as before.
+
+            // Extract indices for deletion
+            let mut deleted_indices: Vec<usize> =
+                rows_and_indices_to_delete.iter().map(|(idx, _)| *idx).collect();
+            deleted_indices.sort_unstable();
+
+            // Step 4: Handle referential integrity for each row to be deleted
+            // This may CASCADE deletes, SET NULL, or SET DEFAULT in child tables
+            for (_, row) in &rows_and_indices_to_delete {
+                check_no_child_references(database, table_name, row)?;
+            }
+
+            // Step 5a: Emit WAL entries and remove entries from user-defined indexes
+            // BEFORE deleting rows (while row indices are still valid and we have old values)
+            // First emit WAL entries for each row (needed for recovery replay)
+            for (idx, row) in &rows_and_indices_to_delete {
+                database.emit_wal_delete(table_name, *idx as u64, row.values.to_vec());
+            }
+
+            // Then use batch method for index updates: O(d + m*log n) vs O(d*m*log n)
+            // where d=deletes, m=indexes
+            let rows_refs: Vec<(usize, &vibesql_storage::Row)> =
+                rows_and_indices_to_delete.iter().map(|(idx, row)| (*idx, row)).collect();
+            database.batch_update_indexes_for_delete(table_name, &rows_refs);
+
+            // Maintain expression indexes for each deleted row
+            for (row_index, row) in &rows_and_indices_to_delete {
+                expression_index_maintenance::maintain_expression_indexes_for_delete(
+                    database, table_name, row, *row_index,
+                );
+                partial_index_maintenance::maintain_partial_indexes_for_delete(
+                    database, table_name, row, *row_index,
+                );
+            }
+
+            // Phase 1c (Issue #5150 / #5136): stamp xmax on every row about
+            // to be bitmap-deleted with the active txn id when the
+            // `mvcc_enabled` feature is on. Fetched BEFORE the mutable borrow
+            // of `table_mut`.
+            #[cfg(feature = "mvcc_enabled")]
+            let mvcc_delete_txn_id = database.transaction_id();
+
+            // Step 5b: Actually delete the rows using fast path (no table scan needed)
+            let table_mut = database
+                .get_table_mut(table_name)
+                .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
+
+            // Stamp xmax in-place on each row BEFORE bitmap-deleting.
+            #[cfg(feature = "mvcc_enabled")]
+            if let Some(id) = mvcc_delete_txn_id {
+                for &idx in &deleted_indices {
+                    table_mut.stamp_row_xmax_inplace(idx, id);
+                }
+            }
+
+            let delete_result = if defer_compaction {
+                // Nested inside a trigger body: bitmap-delete without compaction
+                // so the ancestor statement's physical row indices stay valid
+                // (the outermost DELETE compacts once at the end).
+                let mut deleted = 0usize;
+                for &idx in &deleted_indices {
+                    if table_mut.mark_deleted_inplace(idx) {
+                        deleted += 1;
+                    }
+                }
+                vibesql_storage::DeleteResult::new(deleted, false)
+            } else {
+                table_mut.delete_by_indices_batch(&deleted_indices)
+            };
+
+            // If compaction occurred, rebuild user-defined indexes since all row indices changed
+            if delete_result.compacted {
+                database.rebuild_indexes(table_name);
+                // Expression indexes need special handling (expression evaluation)
+                expression_index_maintenance::rebuild_expression_indexes_after_compaction(
+                    database, table_name,
+                );
+                // Partial indexes need WHERE-predicate evaluation per row
+                partial_index_maintenance::rebuild_partial_indexes_after_compaction(
+                    database, table_name,
+                );
+            }
+
+            if delete_result.deleted_count > 0 {
+                database.invalidate_columnar_cache(table_name);
+            }
+
+            deleted_count = delete_result.deleted_count;
         }
 
         // Fire AFTER STATEMENT triggers only if triggers exist AND we're not inside a trigger
@@ -629,7 +736,7 @@ impl DeleteExecutor {
             None
         };
 
-        Ok((delete_result.deleted_count, returning))
+        Ok((deleted_count, returning))
     }
 
     /// Extract primary key value from WHERE expression if it's a simple equality

--- a/crates/vibesql-executor/src/lib.rs
+++ b/crates/vibesql-executor/src/lib.rs
@@ -6,6 +6,7 @@ pub mod advanced_objects;
 mod alter;
 pub mod arena;
 pub mod cache;
+mod compaction_guard;
 mod constraint_validator;
 pub mod correlation;
 mod create_table;

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -593,29 +593,6 @@ pub(super) fn execute_internal(
         }
     }
 
-    // Fire BEFORE UPDATE triggers for all rows (before database mutation).
-    // A RAISE(IGNORE) in a BEFORE UPDATE trigger abandons that row: drop it
-    // from the batch so it is neither updated nor counted (SQLite semantics).
-    if has_triggers {
-        let mut keep = Vec::with_capacity(updates.len());
-        for u in updates {
-            let outcome = crate::TriggerFirer::execute_before_triggers(
-                database,
-                table_name,
-                vibesql_ast::TriggerEvent::Update(None),
-                Some(&u.old_row),
-                Some(&u.new_row),
-            )?;
-            if outcome != crate::TriggerOutcome::SkipRow {
-                keep.push(u);
-            }
-        }
-        updates = keep;
-    }
-
-    // Step 8: Apply all updates (after evaluation phase completes)
-    let update_count = updates.len();
-
     // Phase 1c (Issue #5150 / #5136): stamp xmin on every new row with
     // the active txn id when the `mvcc_enabled` feature is on. We must
     // fetch the txn id here, *before* taking the mutable borrow on
@@ -630,41 +607,105 @@ pub(super) fn execute_internal(
         u.new_row.xmax = None;
     }
 
-    // Get mutable table reference
-    let table_mut = database
-        .get_table_mut(table_name)
-        .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
-
-    // Collect the updates first
+    // Step 8: Apply the updates and fire BEFORE/AFTER ROW triggers.
+    //
+    // Issue #5486: SQLite fires row triggers INTERLEAVED per row — for each
+    // affected row R it runs the BEFORE trigger(s) on R, applies R's change,
+    // then runs the AFTER trigger(s) on R, *before* moving to R+1. A trigger
+    // body that reads the table mid-statement (e.g. `SELECT sum(a) FROM tbl`)
+    // must therefore see exactly the rows processed so far. The previous
+    // implementation fired all BEFOREs, then applied all rows, then all
+    // AFTERs, which made such triggers observe the wrong running state.
+    //
+    // A RAISE(IGNORE) in a BEFORE UPDATE trigger abandons that row: it is
+    // neither updated nor counted. AFTER triggers run after the row is already
+    // updated; a RAISE(IGNORE) there cannot revert it (sqlite3 3.51 keeps the
+    // modified row), so SkipRow is a no-op for AFTER.
     let mut index_updates = Vec::new();
-    for u in &updates {
-        table_mut
-            .update_row_selective(u.row_index, u.new_row.clone(), &u.changed_columns)
-            .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
-
-        index_updates.push((
-            u.row_index,
-            u.old_row.clone(),
-            u.new_row.clone(),
-            u.changed_columns.clone(),
-        ));
-    }
-
-    // Fire AFTER UPDATE triggers for all updated rows.
-    // AFTER triggers run once the row is already updated; a RAISE(IGNORE) here
-    // cannot revert it (sqlite3 3.51 keeps the modified row), so SkipRow is a
-    // no-op — explicitly drop the must-use outcome (#5418).
     if has_triggers {
-        for (_index, old_row, new_row, _changed_columns) in &index_updates {
+        // Register this table as under interleaved iteration so a nested DELETE
+        // on it (fired by a row trigger below) defers compaction — compacting
+        // would shift our not-yet-processed physical row indices (#5486).
+        let _iter_guard = crate::compaction_guard::IterationGuard::new(table_name);
+        for u in &updates {
+            // BEFORE(R): a RAISE(IGNORE) drops this row entirely.
+            let before_outcome = crate::TriggerFirer::execute_before_triggers(
+                database,
+                table_name,
+                vibesql_ast::TriggerEvent::Update(None),
+                Some(&u.old_row),
+                Some(&u.new_row),
+            )?;
+            if before_outcome == crate::TriggerOutcome::SkipRow {
+                continue;
+            }
+
+            // A trigger fired for an earlier row (or this row's own BEFORE
+            // trigger) may have deleted this row mid-statement — e.g.
+            // trigger1-1.11, where an AFTER UPDATE trigger runs
+            // `DELETE FROM t WHERE a = old.a + 2`. SQLite does not update a row
+            // that no longer exists, so skip it rather than erroring on the
+            // now-vacant storage slot.
+            if database
+                .get_table(table_name)
+                .map(|t| t.is_row_deleted(u.row_index))
+                .unwrap_or(true)
+            {
+                continue;
+            }
+
+            // apply(R): mutate just this row so the AFTER trigger (and the
+            // BEFORE trigger of the next row) observes R's change.
+            {
+                let table_mut = database
+                    .get_table_mut(table_name)
+                    .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
+                table_mut
+                    .update_row_selective(u.row_index, u.new_row.clone(), &u.changed_columns)
+                    .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+            }
+
+            // AFTER(R): the row is already updated; drop the must-use outcome
+            // since SkipRow cannot un-apply it (#5418).
             let _after_outcome = crate::TriggerFirer::execute_after_triggers(
                 database,
                 table_name,
                 vibesql_ast::TriggerEvent::Update(None),
-                Some(old_row),
-                Some(new_row),
+                Some(&u.old_row),
+                Some(&u.new_row),
             )?;
+
+            index_updates.push((
+                u.row_index,
+                u.old_row.clone(),
+                u.new_row.clone(),
+                u.changed_columns.clone(),
+            ));
+        }
+        // Keep only the rows that actually applied (BEFORE-IGNORE'd rows are
+        // dropped) so RETURNING / change-count reflect SQLite semantics.
+        let applied: HashSet<usize> = index_updates.iter().map(|(idx, ..)| *idx).collect();
+        updates.retain(|u| applied.contains(&u.row_index));
+    } else {
+        // No triggers: apply all updates in one batch borrow.
+        let table_mut = database
+            .get_table_mut(table_name)
+            .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
+        for u in &updates {
+            table_mut
+                .update_row_selective(u.row_index, u.new_row.clone(), &u.changed_columns)
+                .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+
+            index_updates.push((
+                u.row_index,
+                u.old_row.clone(),
+                u.new_row.clone(),
+                u.changed_columns.clone(),
+            ));
         }
     }
+
+    let update_count = index_updates.len();
 
     // Now update user-defined indexes after releasing table borrow
     // Pass changed_columns to skip indexes that don't involve any modified columns
@@ -1625,31 +1666,6 @@ fn execute_update_from(
         }
     }
 
-    // Fire BEFORE UPDATE triggers.
-    // A RAISE(IGNORE) in a BEFORE UPDATE trigger abandons that row (#5418):
-    // drop it from the batch so it is neither updated nor counted, while the
-    // remaining rows proceed — matching the primary UPDATE loop in
-    // `execute_internal` and sqlite3 3.51 semantics.
-    if has_triggers {
-        let mut keep = Vec::with_capacity(updates.len());
-        for u in updates {
-            let outcome = crate::TriggerFirer::execute_before_triggers(
-                database,
-                table_name,
-                vibesql_ast::TriggerEvent::Update(None),
-                Some(&u.old_row),
-                Some(&u.new_row),
-            )?;
-            if outcome != crate::TriggerOutcome::SkipRow {
-                keep.push(u);
-            }
-        }
-        updates = keep;
-    }
-
-    // Apply all updates
-    let update_count = updates.len();
-
     // Phase 1c (Issue #5150 / #5136): stamp xmin on every new row with
     // the active txn id when the `mvcc_enabled` feature is on. Fetch the
     // txn id before taking the mutable borrow on `table_mut`. Off-state
@@ -1660,39 +1676,84 @@ fn execute_update_from(
         u.new_row.xmax = None;
     }
 
-    let table_mut = database
-        .get_table_mut(table_name)
-        .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
-
+    // Apply the updates and fire BEFORE/AFTER ROW triggers interleaved per
+    // row (issue #5486): BEFORE(R) -> apply(R) -> AFTER(R) before moving to
+    // R+1, so a trigger body reading the table mid-statement sees exactly the
+    // rows processed so far. See the matching note in `execute_internal`. A
+    // RAISE(IGNORE) in a BEFORE trigger drops that row; SkipRow in an AFTER
+    // trigger is a no-op (the row is already applied).
     let mut index_updates = Vec::new();
-    for u in &updates {
-        table_mut
-            .update_row_selective(u.row_index, u.new_row.clone(), &u.changed_columns)
-            .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
-
-        index_updates.push((
-            u.row_index,
-            u.old_row.clone(),
-            u.new_row.clone(),
-            u.changed_columns.clone(),
-        ));
-    }
-
-    // Fire AFTER UPDATE triggers.
-    // AFTER triggers run once the row is already updated; a RAISE(IGNORE) here
-    // cannot revert it (sqlite3 3.51 keeps the modified row), so SkipRow is a
-    // no-op — explicitly drop the must-use outcome (#5418).
     if has_triggers {
-        for (_index, old_row, new_row, _changed_columns) in &index_updates {
+        // See the matching note in `execute_internal` — defer nested-DELETE
+        // compaction of this table while we iterate its physical indices.
+        let _iter_guard = crate::compaction_guard::IterationGuard::new(table_name);
+        for u in &updates {
+            let before_outcome = crate::TriggerFirer::execute_before_triggers(
+                database,
+                table_name,
+                vibesql_ast::TriggerEvent::Update(None),
+                Some(&u.old_row),
+                Some(&u.new_row),
+            )?;
+            if before_outcome == crate::TriggerOutcome::SkipRow {
+                continue;
+            }
+
+            // Skip rows an interleaved trigger deleted mid-statement (see the
+            // matching note in `execute_internal`).
+            if database
+                .get_table(table_name)
+                .map(|t| t.is_row_deleted(u.row_index))
+                .unwrap_or(true)
+            {
+                continue;
+            }
+
+            {
+                let table_mut = database
+                    .get_table_mut(table_name)
+                    .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+                table_mut
+                    .update_row_selective(u.row_index, u.new_row.clone(), &u.changed_columns)
+                    .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+            }
+
             let _after_outcome = crate::TriggerFirer::execute_after_triggers(
                 database,
                 table_name,
                 vibesql_ast::TriggerEvent::Update(None),
-                Some(old_row),
-                Some(new_row),
+                Some(&u.old_row),
+                Some(&u.new_row),
             )?;
+
+            index_updates.push((
+                u.row_index,
+                u.old_row.clone(),
+                u.new_row.clone(),
+                u.changed_columns.clone(),
+            ));
+        }
+        let applied: HashSet<usize> = index_updates.iter().map(|(idx, ..)| *idx).collect();
+        updates.retain(|u| applied.contains(&u.row_index));
+    } else {
+        let table_mut = database
+            .get_table_mut(table_name)
+            .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+        for u in &updates {
+            table_mut
+                .update_row_selective(u.row_index, u.new_row.clone(), &u.changed_columns)
+                .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+
+            index_updates.push((
+                u.row_index,
+                u.old_row.clone(),
+                u.new_row.clone(),
+                u.changed_columns.clone(),
+            ));
         }
     }
+
+    let update_count = index_updates.len();
 
     // Update indexes
     for (index, old_row, new_row, changed_columns) in index_updates {

--- a/crates/vibesql-storage/src/table/mod.rs
+++ b/crates/vibesql-storage/src/table/mod.rs
@@ -1051,6 +1051,59 @@ impl Table {
         }
     }
 
+    /// Bitmap-delete a single row by index, updating internal indexes, WITHOUT
+    /// triggering compaction.
+    ///
+    /// This is used by the interleaved per-row DELETE trigger path (#5486),
+    /// where row triggers fire BEFORE -> delete -> AFTER for each row in turn.
+    /// Per-row deletion must not compact mid-loop, because compaction shifts
+    /// every row index and would invalidate the indices of the not-yet-processed
+    /// rows the caller still holds. The caller is responsible for calling
+    /// [`Table::compact_if_needed`] once after the loop completes.
+    ///
+    /// Returns `true` if the row was newly deleted, `false` if the index was
+    /// out of bounds or the row was already deleted.
+    pub fn mark_deleted_inplace(&mut self, idx: usize) -> bool {
+        if idx >= self.rows.len() || self.deleted[idx] {
+            return false;
+        }
+
+        // Update internal hash indexes for this row BEFORE marking deleted,
+        // mirroring `delete_by_indices`.
+        let row = &self.rows[idx];
+        self.indexes.update_for_delete(&self.schema, row);
+
+        self.deleted[idx] = true;
+        self.deleted_count += 1;
+
+        // For native columnar tables, rebuild columnar data so reads (e.g. a
+        // trigger body's SELECT) observe the deletion immediately.
+        if self.native_columnar.is_some() {
+            let _ = self.rebuild_native_columnar();
+        }
+
+        true
+    }
+
+    /// Compact the table if it has crossed the deletion threshold, returning
+    /// whether compaction actually occurred.
+    ///
+    /// Companion to [`Table::mark_deleted_inplace`]: the interleaved per-row
+    /// DELETE path defers compaction until after all rows are processed, then
+    /// calls this once. When it returns `true` the caller must rebuild
+    /// user-defined / expression / partial indexes since all row indices moved.
+    pub fn compact_if_needed(&mut self) -> bool {
+        if self.should_compact() {
+            self.compact();
+            if self.native_columnar.is_some() {
+                let _ = self.rebuild_native_columnar();
+            }
+            true
+        } else {
+            false
+        }
+    }
+
     /// Delete rows matching a predicate
     ///
     /// Uses O(1) bitmap marking for each deleted row instead of O(n) Vec::remove().


### PR DESCRIPTION
## Summary

For a statement affecting multiple rows, SQLite fires `FOR EACH ROW` triggers **interleaved per row**: for each affected row R it runs BEFORE(R) → applies R's change → runs AFTER(R), *before* moving to R+1. VibeSQL's UPDATE and DELETE executors instead ran all BEFOREs, then applied every row, then all AFTERs. A trigger body that reads the table mid-statement (e.g. `SELECT sum(a) FROM tbl`) therefore observed the wrong running state.

Closes #5486

## Firing-order restructure

| Path | Before | After |
|------|--------|-------|
| UPDATE (default `execute_internal`) | all BEFOREs → apply all rows → all AFTERs | per row: `BEFORE(R) → apply(R) → AFTER(R)` |
| UPDATE … FROM (`execute_update_from`) | all BEFOREs → apply all rows → all AFTERs | per row: `BEFORE(R) → apply(R) → AFTER(R)` |
| DELETE | all BEFOREs → delete all rows → all AFTERs | per row: `BEFORE(R) → delete(R) → AFTER(R)` |
| INSERT | already interleaved in the slow (trigger) path | unchanged |

The no-trigger fast paths keep the batched apply/delete (no observable difference, lower overhead).

### Repro from the issue (now matches sqlite3 3.51.0)
`UPDATE tbl SET a=a*10, b=b*10` with BEFORE+AFTER row triggers logging `sum(a)`:
- Before: row idx=2 (AFTER row1) showed `db_sum_a=4` (all-BEFOREs-then-all-AFTERs)
- After: `db_sum_a=13` (row1 applied, row2 not yet) — identical to sqlite3. DELETE and INSERT variants verified the same way.

## Preserved semantics
- Statement-level triggers still fire once (not per row).
- BEFORE `RAISE(IGNORE)` skips just that row; AFTER `SkipRow` is a no-op (row already applied).
- A row deleted by an interleaved trigger mid-statement (cascade/recursion, e.g. `trigger1-1.10/1.11`) is processed only once and skipped if already gone.

## Recursion / compaction safety
A trigger that recursively `DELETE`s from the same table must not compact it while an ancestor loop is iterating its physical row indices (`fkey2-4.3`, recursive AFTER DELETE cascade). Added:
- `Table::mark_deleted_inplace` / `Table::compact_if_needed` — bitmap-delete a single row without compaction; compact once afterward.
- `compaction_guard` thread-local `IterationGuard` — defers compaction of a table while it is under an interleaved per-row DML loop; the outermost loop compacts once at the end. A nested DELETE on a *different* table (e.g. an INSTEAD OF DELETE on a view whose body deletes a base table) compacts normally.

## trigger2.test pass-delta
**4/12 → 12/12** (+8): `trigger2-1.{1,2,3,4}.{1,2}` (the UPDATE/DELETE execution-model sub-tests). The remaining file content aborts mid-file on a pre-existing `CREATE TEMP TABLE` limitation, unrelated to this change.

## No-regression evidence
Per-test PASS/FAIL diff (fix vs clean baseline build) across `trigger`, `trigger1`, `trigger2`, `trigger3`, `trigger5`, `triggerG`, `trigger4`, `trigger6`, `trigger7`, `triggerA`, `triggerB`, `triggerC`, `update`, `delete`, `insert`, `fkey1`, `fkey2`, `fkey3`:
- **Improvements:** +8 trigger2, +1 triggerC-7.3 (also fixes trigger1-1.11 and fkey2-4.3 at the scenario level).
- **Regressions: none.**

`cargo test -p vibesql-executor -p vibesql-storage`: 5014 passed, 0 failed. `cargo clippy` clean on both crates.

## Note for parallel work (#5465)
Coordinated with the FK-cascade work. This PR's DELETE changes are confined to the per-row apply seam in `delete/executor.rs`; `check_no_child_references` (in `delete/integrity.rs`) is called per-row in the interleaved path but **not modified**. No edits to `delete/integrity.rs` or `update/foreign_keys.rs`.

## Test plan
- [x] trigger2.test 4/12 → 12/12
- [x] UPDATE/DELETE/INSERT multi-row BEFORE+AFTER audit-order repros match sqlite3 3.51.0
- [x] mid-statement `sum`/`count` observability matches sqlite3
- [x] recursive trigger cascade (fkey2-4.3) and self-deleting trigger (trigger1-1.11) correct
- [x] `cargo test -p vibesql-executor -p vibesql-storage` green
- [x] no regressions across trigger*/DML/fkey TCL files