### PR TITLE
fix(trigger): transactional DDL rollback + DROP TRIGGER IF EXISTS (trigger1 1.3/1.4/1.6.1)

### DIFF
--- a/crates/vibesql-ast/src/ddl/schema.rs
+++ b/crates/vibesql-ast/src/ddl/schema.rs
@@ -176,6 +176,9 @@ pub enum TriggerAction {
 pub struct DropTriggerStmt {
     pub trigger_name: String,
     pub cascade: bool,
+    /// `DROP TRIGGER IF EXISTS` — when true, dropping a non-existent trigger
+    /// is a no-op instead of an error (SQLite / SQL:2008 semantics).
+    pub if_exists: bool,
 }
 
 /// ALTER TRIGGER statement

--- a/crates/vibesql-executor/src/advanced_objects/triggers.rs
+++ b/crates/vibesql-executor/src/advanced_objects/triggers.rs
@@ -68,6 +68,11 @@ pub fn execute_drop_trigger(
     stmt: &DropTriggerStmt,
     db: &mut Database,
 ) -> Result<(), ExecutorError> {
+    // `DROP TRIGGER IF EXISTS` on a missing trigger is a no-op (SQLite /
+    // SQL:2008); a bare DROP TRIGGER errors with TriggerNotFound.
+    if stmt.if_exists && db.catalog.get_trigger(&stmt.trigger_name).is_none() {
+        return Ok(());
+    }
     db.catalog.drop_trigger(&stmt.trigger_name)?;
     Ok(())
 }

--- a/crates/vibesql-executor/src/tests/triggers/ddl.rs
+++ b/crates/vibesql-executor/src/tests/triggers/ddl.rs
@@ -152,7 +152,8 @@ fn test_drop_trigger() {
     assert!(db.catalog.get_trigger("my_trigger").is_some());
 
     // Drop the trigger
-    let drop_stmt = DropTriggerStmt { trigger_name: "my_trigger".to_string(), cascade: false };
+    let drop_stmt =
+        DropTriggerStmt { trigger_name: "my_trigger".to_string(), cascade: false, if_exists: false };
 
     let result = crate::advanced_objects::execute_drop_trigger(&drop_stmt, &mut db);
     assert!(result.is_ok(), "Failed to drop trigger: {:?}", result.err());
@@ -165,11 +166,28 @@ fn test_drop_trigger() {
 fn test_drop_trigger_not_found() {
     let mut db = Database::new();
 
-    let drop_stmt =
-        DropTriggerStmt { trigger_name: "nonexistent_trigger".to_string(), cascade: false };
+    let drop_stmt = DropTriggerStmt {
+        trigger_name: "nonexistent_trigger".to_string(),
+        cascade: false,
+        if_exists: false,
+    };
 
     let result = crate::advanced_objects::execute_drop_trigger(&drop_stmt, &mut db);
     assert!(result.is_err(), "Should fail when dropping non-existent trigger");
+}
+
+#[test]
+fn test_drop_trigger_if_exists_missing_is_noop() {
+    let mut db = Database::new();
+
+    let drop_stmt = DropTriggerStmt {
+        trigger_name: "nonexistent_trigger".to_string(),
+        cascade: false,
+        if_exists: true,
+    };
+
+    let result = crate::advanced_objects::execute_drop_trigger(&drop_stmt, &mut db);
+    assert!(result.is_ok(), "DROP TRIGGER IF EXISTS on missing trigger should be a no-op");
 }
 
 #[test]
@@ -211,4 +229,104 @@ fn test_create_trigger_all_variations() {
         let trigger = db.catalog.get_trigger(&format!("trigger_{}", suffix)).unwrap();
         assert_eq!(trigger.timing, timing);
     }
+}
+
+// ---------------------------------------------------------------------------
+// Transactional DDL: CREATE TRIGGER participates in the surrounding
+// transaction (#5497 / trigger1-1.3).
+//
+// SQLite (3.51.0) treats trigger DDL as transactional: a `BEGIN; CREATE
+// TRIGGER ...; ROLLBACK;` leaves no trigger behind and raises no error,
+// while a matching COMMIT keeps it. These tests assert that via live
+// catalog introspection through the same `TriggerExecutor` /
+// `Database` transaction path the CLI uses.
+// ---------------------------------------------------------------------------
+
+fn make_test_table(db: &mut Database) {
+    let sql = "CREATE TABLE t1 (a INT, b INT, c INT);";
+    match vibesql_parser::Parser::parse_sql(sql).unwrap() {
+        vibesql_ast::Statement::CreateTable(stmt) => {
+            CreateTableExecutor::execute(&stmt, db).unwrap();
+        }
+        _ => panic!("Expected CreateTable"),
+    }
+}
+
+fn create_trigger_stmt(name: &str) -> CreateTriggerStmt {
+    CreateTriggerStmt {
+        if_not_exists: false,
+        trigger_name: name.to_string(),
+        timing: TriggerTiming::After,
+        event: TriggerEvent::Insert,
+        table_name: "t1".to_string(),
+        granularity: TriggerGranularity::Row,
+        when_condition: None,
+        triggered_action: TriggerAction::RawSql("SELECT 1;".to_string()),
+    }
+}
+
+#[test]
+fn test_create_trigger_rolled_back_with_transaction() {
+    // BEGIN; CREATE TRIGGER tr2 ...; ROLLBACK; => no error, no trigger left.
+    let mut db = Database::new();
+    make_test_table(&mut db);
+
+    db.begin_transaction().expect("BEGIN");
+    crate::TriggerExecutor::create_trigger(&mut db, &create_trigger_stmt("tr2"))
+        .expect("CREATE TRIGGER inside txn");
+    // Visible to its own transaction before rollback.
+    assert!(db.catalog.get_trigger("tr2").is_some(), "trigger visible inside txn");
+
+    // ROLLBACK must succeed (no "No active transaction to rollback") and undo
+    // the catalog mutation.
+    db.rollback_transaction().expect("ROLLBACK after CREATE TRIGGER");
+    assert!(
+        db.catalog.get_trigger("tr2").is_none(),
+        "trigger must be gone after ROLLBACK (transactional DDL, #5497)"
+    );
+
+    // And re-creating it now succeeds (mirrors trigger1-1.3's second CREATE).
+    crate::TriggerExecutor::create_trigger(&mut db, &create_trigger_stmt("tr2"))
+        .expect("re-CREATE TRIGGER after rollback");
+    assert!(db.catalog.get_trigger("tr2").is_some());
+}
+
+#[test]
+fn test_create_trigger_kept_after_commit() {
+    // BEGIN; CREATE TRIGGER tr2 ...; COMMIT; => trigger persists.
+    let mut db = Database::new();
+    make_test_table(&mut db);
+
+    db.begin_transaction().expect("BEGIN");
+    crate::TriggerExecutor::create_trigger(&mut db, &create_trigger_stmt("tr2"))
+        .expect("CREATE TRIGGER inside txn");
+    db.commit_transaction().expect("COMMIT after CREATE TRIGGER");
+
+    assert!(
+        db.catalog.get_trigger("tr2").is_some(),
+        "trigger must survive COMMIT (transactional DDL, #5497)"
+    );
+}
+
+#[test]
+fn test_drop_trigger_rolled_back_with_transaction() {
+    // Committed trigger, then BEGIN; DROP TRIGGER; ROLLBACK; => trigger restored.
+    let mut db = Database::new();
+    make_test_table(&mut db);
+    crate::TriggerExecutor::create_trigger(&mut db, &create_trigger_stmt("tr2"))
+        .expect("CREATE TRIGGER");
+
+    db.begin_transaction().expect("BEGIN");
+    crate::TriggerExecutor::drop_trigger(
+        &mut db,
+        &DropTriggerStmt { trigger_name: "tr2".to_string(), cascade: false, if_exists: false },
+    )
+    .expect("DROP TRIGGER inside txn");
+    assert!(db.catalog.get_trigger("tr2").is_none(), "trigger dropped inside txn");
+
+    db.rollback_transaction().expect("ROLLBACK after DROP TRIGGER");
+    assert!(
+        db.catalog.get_trigger("tr2").is_some(),
+        "dropped trigger must be restored after ROLLBACK (#5497)"
+    );
 }

--- a/crates/vibesql-executor/src/trigger_ddl.rs
+++ b/crates/vibesql-executor/src/trigger_ddl.rs
@@ -126,6 +126,14 @@ impl TriggerExecutor {
     ) -> Result<String, ExecutorError> {
         // Check if trigger exists
         if db.catalog.get_trigger(&stmt.trigger_name).is_none() {
+            // `DROP TRIGGER IF EXISTS` on a missing trigger is a no-op
+            // (SQLite / SQL:2008 semantics); a bare DROP TRIGGER still errors.
+            if stmt.if_exists {
+                return Ok(format!(
+                    "Trigger '{}' does not exist, skipping",
+                    stmt.trigger_name
+                ));
+            }
             return Err(ExecutorError::TriggerNotFound(stmt.trigger_name.clone()));
         }
 

--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -445,7 +445,7 @@ impl Parser {
     /// Parse DROP TRIGGER statement
     ///
     /// Syntax:
-    ///   DROP TRIGGER trigger_name [CASCADE | RESTRICT]
+    ///   DROP TRIGGER [IF EXISTS] trigger_name [CASCADE | RESTRICT]
     pub(super) fn parse_drop_trigger_statement(
         &mut self,
     ) -> Result<vibesql_ast::DropTriggerStmt, ParseError> {
@@ -454,6 +454,16 @@ impl Parser {
 
         // Expect TRIGGER keyword
         self.expect_keyword(Keyword::Trigger)?;
+
+        // Optional IF EXISTS (SQLite / SQL:2008): dropping a missing trigger
+        // becomes a no-op instead of an error.
+        let if_exists = if self.peek_keyword(Keyword::If) {
+            self.advance(); // consume IF
+            self.expect_keyword(Keyword::Exists)?;
+            true
+        } else {
+            false
+        };
 
         // Parse trigger name
         let trigger_name = self.parse_identifier()?;
@@ -473,7 +483,7 @@ impl Parser {
             self.advance();
         }
 
-        Ok(vibesql_ast::DropTriggerStmt { trigger_name, cascade })
+        Ok(vibesql_ast::DropTriggerStmt { trigger_name, cascade, if_exists })
     }
 }
 

--- a/crates/vibesql-parser/src/tests/trigger.rs
+++ b/crates/vibesql-parser/src/tests/trigger.rs
@@ -206,6 +206,34 @@ fn test_drop_trigger_basic() {
 }
 
 #[test]
+fn test_drop_trigger_if_exists() {
+    // `DROP TRIGGER IF EXISTS name` must parse (trigger1-1.4 / 1.6.1, #5497).
+    let sql = "DROP TRIGGER IF EXISTS my_trigger;";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        Statement::DropTrigger(drop_trigger) => {
+            assert_eq!(drop_trigger.trigger_name, "my_trigger");
+            assert!(drop_trigger.if_exists, "IF EXISTS flag should be set");
+            assert!(!drop_trigger.cascade);
+        }
+        _ => panic!("Expected DropTrigger statement"),
+    }
+}
+
+#[test]
+fn test_drop_trigger_basic_no_if_exists() {
+    // Bare DROP TRIGGER leaves if_exists false.
+    match Parser::parse_sql("DROP TRIGGER my_trigger;").unwrap() {
+        Statement::DropTrigger(drop_trigger) => {
+            assert!(!drop_trigger.if_exists);
+        }
+        _ => panic!("Expected DropTrigger statement"),
+    }
+}
+
+#[test]
 fn test_drop_trigger_cascade() {
     let sql = "DROP TRIGGER my_trigger CASCADE;";
     let result = Parser::parse_sql(sql);

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -1179,15 +1179,35 @@ proc mask_trigger_bodies {sql} {
     set out $sql
     set search_from 0
     while {1} {
-        # Locate the BEGIN that opens a CREATE TRIGGER body, at/after search_from.
+        # Locate the `CREATE [TEMP] TRIGGER` keyword, at/after search_from.
+        #
+        # Do NOT try to match through to the opening BEGIN with `.*?BEGIN` in a
+        # single regex: TCL's ARE prefers the longest overall match, so the
+        # non-greedy `.*?` is overridden and the match runs to the *last* BEGIN
+        # in the string. When two CREATE TRIGGER statements share one batch
+        # (e.g. `BEGIN; CREATE TRIGGER ...; ROLLBACK; CREATE TRIGGER ...;`)
+        # that over-match swallows the intervening ROLLBACK, mis-routing the
+        # batch into the transaction-trial path and producing a spurious
+        # "No active transaction to rollback" (#5497). Instead, anchor on the
+        # CREATE TRIGGER keyword and find the *first* BEGIN word token after it.
         set rest [string range $out $search_from end]
         if {![regexp -indices -nocase \
-                {CREATE\s+(?:TEMP\s+|TEMPORARY\s+)?TRIGGER\y.*?\yBEGIN\y} \
+                {CREATE\s+(?:TEMP\s+|TEMPORARY\s+)?TRIGGER\y} \
                 $rest m]} {
             break
         }
         set abs_create_start [expr {$search_from + [lindex $m 0]}]
-        set abs_begin_end [expr {$search_from + [lindex $m 1]}]
+        set hdr_end [expr {$search_from + [lindex $m 1]}]
+
+        # Find the first BEGIN word token after the TRIGGER keyword — this is
+        # the trigger body's opening BEGIN. (The trigger header between the
+        # keyword and BEGIN cannot contain a BEGIN/CASE/END word.)
+        set hdr_tail [string range $out [expr {$hdr_end + 1}] end]
+        if {![regexp -indices -nocase {\mBEGIN\M} $hdr_tail bm]} {
+            # No body BEGIN found — not a maskable trigger body; stop scanning.
+            break
+        }
+        set abs_begin_end [expr {$hdr_end + 1 + [lindex $bm 1]}]
         set body_start [expr {$abs_begin_end + 1}]
 
         # Walk word tokens after the trigger's BEGIN, tracking nesting depth.


### PR DESCRIPTION
Closes #5497

## Root cause (why ROLLBACK saw no active transaction)

The issue assumed an engine transactional-DDL gap. Triage proved the **storage
engine already handles trigger DDL transactionally**: against the release CLI,
`BEGIN; CREATE TRIGGER t ...; ROLLBACK;` leaves no trigger behind and raises no
error, and `... COMMIT;` keeps it. (`rollback_transaction` in
`crates/vibesql-storage/src/database/transactions.rs` restores the catalog
snapshot, which removes the trigger.)

The real cause of `No active transaction to rollback` was a **TCL test-shim
bug** in `scripts/tester_vibesql.tcl::mask_trigger_bodies`. It located a trigger
body's opening BEGIN with `CREATE...TRIGGER\y.*?\yBEGIN\y`. TCL's ARE prefers the
longest overall match, so the non-greedy `.*?` was overridden and the match ran
to the **last** BEGIN in the string. For the trigger1-1.3 batch
(`BEGIN; CREATE TRIGGER ...; ROLLBACK; CREATE TRIGGER ...;`) the over-match
swallowed the intervening `ROLLBACK`, so BEGIN/END counting saw `net_begin = 1`
and mis-routed the batch into the transaction-trial path, which appends a
trailing `ROLLBACK`. By that point the inner ROLLBACK had already closed the
transaction, so the appended one correctly hit no active transaction.

## Fix

- **Shim** (`mask_trigger_bodies`): anchor on the `CREATE [TEMP] TRIGGER`
  keyword, then find the **first** `BEGIN` word token after it as the body
  start. Single-trigger masking is unchanged; the depth-walk (BEGIN/CASE/END
  nesting) is preserved. Multi-trigger batches now mask each body separately and
  preserve text between them.
- **`DROP TRIGGER IF EXISTS`** (trigger1-1.4 / 1.6.1): the parser rejected
  `IF EXISTS`. Added `if_exists` to `DropTriggerStmt` and the DROP TRIGGER
  grammar; both drop paths (`TriggerExecutor::drop_trigger`,
  `advanced_objects::execute_drop_trigger`) now no-op on a missing trigger when
  `IF EXISTS` is given. Bare `DROP TRIGGER <missing>` still errors.

### Does it generalize to other DDL?
The engine's transactional-DDL was never broken, so no engine generalization is
needed. The shim mask fix applies to any batch with multiple CREATE TRIGGER
statements (independent of CREATE/DROP TABLE/INDEX/VIEW).

## sqlite3 3.51.0 parity
- `BEGIN; CREATE TRIGGER ...; ROLLBACK;` -> trigger gone, no error (both).
- `BEGIN; CREATE TRIGGER ...; COMMIT;` -> trigger present (both).
- `DROP TRIGGER IF EXISTS <missing>` -> no-op (both); bare `DROP TRIGGER
  <missing>` -> error (both).

## trigger1.test delta
17 -> **20** passing. `trigger1-1.3`, `trigger1-1.4`, `trigger1-1.6.1` now pass
(verified via `--verbose`).

## Tests
- Parser: `test_drop_trigger_if_exists`, `test_drop_trigger_basic_no_if_exists`.
- Executor (live catalog introspection):
  `test_create_trigger_rolled_back_with_transaction`,
  `test_create_trigger_kept_after_commit`,
  `test_drop_trigger_rolled_back_with_transaction`,
  `test_drop_trigger_if_exists_missing_is_noop`.

## No-regression evidence
- `cargo test -p vibesql-storage -p vibesql-executor -p vibesql-parser
  -p vibesql-ast`: all green (0 failures).
- `cargo build --workspace`: clean.
- TCL spot-check: fkey1 (0 failed), fkey2 (806/909), trigger2/3/4/5 unchanged
  from baseline. Shim change only affects multi-CREATE-TRIGGER batches; bodies
  with single triggers and CASE...END nesting verified identical.

## Follow-ons
- `trigger3-1.2 / 2.2` fail with the same `No active transaction to rollback`
  but a **different** mechanism: `RAISE(ABORT)`/`RAISE(FAIL)` inside a DML
  trigger should abort only the statement while leaving the explicit
  transaction open, but the shim's separate-process batching closes it before
  the follow-up `ROLLBACK`. Not a CREATE/DROP TRIGGER DDL issue; worth a
  separate issue (RAISE-abort transaction continuity across the shim boundary).

## Notes on parallel work
Did not touch executor trigger firing (`trigger_execution.rs`, #5486) or
server/consensus Describe (#5484). DROP TRIGGER DDL changes are confined to
`trigger_ddl.rs` / `advanced_objects/triggers.rs` (catalog drop, not the
firing loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)