### PR TITLE
fix(executor): rewrite trigger table refs + verbatim sql on ALTER TABLE RENAME

### DIFF
--- a/crates/vibesql-executor/src/alter/table_options.rs
+++ b/crates/vibesql-executor/src/alter/table_options.rs
@@ -1,9 +1,9 @@
 //! Table-level operation executors for ALTER TABLE
 
-use vibesql_ast::RenameTableStmt;
+use vibesql_ast::{RenameTableStmt, TriggerAction};
 use vibesql_storage::Database;
 
-use crate::errors::ExecutorError;
+use crate::{errors::ExecutorError, trigger_rename::rewrite_table_refs_in_trigger_sql};
 
 /// Execute RENAME TABLE
 pub(super) fn execute_rename_table(
@@ -45,6 +45,12 @@ pub(super) fn execute_rename_table(
             .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
     }
 
+    // Propagate the rename into any trigger definitions that reference the old
+    // table name. SQLite (legacy_alter_table=OFF) rewrites table references
+    // inside trigger bodies and the trigger's ON-target, and keeps the stored
+    // `sqlite_master.sql` text consistent. See `crate::trigger_rename`.
+    rewrite_triggers_for_rename(database, &stmt.table_name, &stmt.new_table_name);
+
     // Invalidate the database-level columnar cache for both old and new table names.
     // The old table name's cache is invalidated since the table no longer exists,
     // and the new table name's cache is invalidated to ensure fresh columnar data.
@@ -52,4 +58,53 @@ pub(super) fn execute_rename_table(
     database.invalidate_columnar_cache(&stmt.new_table_name);
 
     Ok(format!("Table '{}' renamed to '{}'", stmt.table_name, stmt.new_table_name))
+}
+
+/// Rewrite all trigger definitions in the catalog that reference `old_name`,
+/// replacing table references with `new_name`.
+///
+/// This keeps three pieces of trigger state consistent with SQLite's
+/// `legacy_alter_table=OFF` behavior:
+/// - `table_name`: the trigger's ON-target, if it was the renamed table;
+/// - `triggered_action` (the raw body SQL used when the trigger fires);
+/// - `sql_definition` (the verbatim `CREATE TRIGGER` text shown in
+///   `sqlite_master`/`sqlite_schema`).
+fn rewrite_triggers_for_rename(database: &mut Database, old_name: &str, new_name: &str) {
+    let trigger_names = database.catalog.list_triggers();
+    for name in trigger_names {
+        let Some(existing) = database.catalog.get_trigger(&name) else {
+            continue;
+        };
+
+        // Does this trigger reference the renamed table anywhere?
+        let on_target_match = existing.table_name.eq_ignore_ascii_case(old_name);
+        let body_text = match &existing.triggered_action {
+            TriggerAction::RawSql(sql) => sql.clone(),
+        };
+        let new_body = rewrite_table_refs_in_trigger_sql(&body_text, old_name, new_name);
+        let new_sql_definition = existing
+            .sql_definition
+            .as_ref()
+            .map(|sql| rewrite_table_refs_in_trigger_sql(sql, old_name, new_name));
+
+        let body_changed = new_body != body_text;
+        let sql_def_changed = new_sql_definition.as_deref() != existing.sql_definition.as_deref();
+
+        if !on_target_match && !body_changed && !sql_def_changed {
+            continue;
+        }
+
+        let mut updated = existing.clone();
+        if on_target_match {
+            updated.table_name = new_name.to_string();
+        }
+        if body_changed {
+            updated.triggered_action = TriggerAction::RawSql(new_body);
+        }
+        updated.sql_definition = new_sql_definition;
+
+        // The trigger is known to exist (we just read it), so update_trigger
+        // cannot fail; ignore the result defensively.
+        let _ = database.catalog.update_trigger(updated);
+    }
 }

--- a/crates/vibesql-executor/src/lib.rs
+++ b/crates/vibesql-executor/src/lib.rs
@@ -51,6 +51,7 @@ pub mod timeout;
 mod transaction;
 mod trigger_ddl;
 mod trigger_execution;
+mod trigger_rename;
 pub mod truncate;
 mod truncate_table;
 mod truncate_validation;

--- a/crates/vibesql-executor/src/sqlite_schema.rs
+++ b/crates/vibesql-executor/src/sqlite_schema.rs
@@ -246,6 +246,18 @@ fn generate_create_view_sql(view: &vibesql_catalog::ViewDefinition) -> String {
 fn generate_create_trigger_sql(trigger: &vibesql_catalog::TriggerDefinition) -> String {
     use vibesql_ast::{TriggerAction, TriggerEvent, TriggerGranularity, TriggerTiming};
 
+    // Prefer the original SQL text when available so `sqlite_master.sql` matches
+    // SQLite's verbatim form (no injected BEFORE/FOR EACH ROW, original spacing
+    // and quoting preserved). This mirrors `generate_create_view_sql` and is the
+    // form kept consistent by `crate::trigger_rename` across ALTER TABLE RENAME.
+    // SQLite stores the statement text without the trailing `;`, so strip one if
+    // present.
+    if let Some(ref sql) = trigger.sql_definition {
+        let trimmed = sql.trim_end();
+        let trimmed = trimmed.strip_suffix(';').unwrap_or(trimmed);
+        return trimmed.trim_end().to_string();
+    }
+
     let timing = match trigger.timing {
         TriggerTiming::Before => "BEFORE",
         TriggerTiming::After => "AFTER",

--- a/crates/vibesql-executor/src/tests/triggers/ddl.rs
+++ b/crates/vibesql-executor/src/tests/triggers/ddl.rs
@@ -330,3 +330,97 @@ fn test_drop_trigger_rolled_back_with_transaction() {
         "dropped trigger must be restored after ROLLBACK (#5497)"
     );
 }
+
+/// ALTER TABLE RENAME must rewrite references to the renamed table inside an
+/// existing trigger body, keep `sqlite_master.sql` consistent (verbatim, with
+/// only the renamed identifier double-quoted), and the trigger must still fire
+/// correctly against the new table name. Mirrors SQLite (legacy_alter_table=OFF)
+/// behavior exercised by `altertrig.test`. Regression coverage for issue #5489.
+#[test]
+fn test_rename_table_rewrites_trigger_body_and_fires() {
+    use crate::{AlterTableExecutor, InsertExecutor, SelectExecutor};
+
+    let mut db = Database::new();
+
+    // Set up: t1 fires a trigger that reads from t3; log captures the count.
+    for sql in [
+        "CREATE TABLE t1 (x INTEGER, d VARCHAR(50));",
+        "CREATE TABLE t2 (y INTEGER);",
+        "CREATE TABLE t3 (z INTEGER);",
+        "CREATE TABLE log (msg VARCHAR(50));",
+    ] {
+        match vibesql_parser::Parser::parse_sql(sql).unwrap() {
+            vibesql_ast::Statement::CreateTable(stmt) => {
+                CreateTableExecutor::execute(&stmt, &mut db).unwrap();
+            }
+            other => panic!("Expected CreateTable, got {:?}", other),
+        }
+    }
+
+    // Create the trigger preserving the original SQL text (the path the CLI /
+    // bindings use) so `sqlite_master.sql` round-trips verbatim.
+    let trigger_sql = "CREATE TRIGGER r1 AFTER INSERT ON t1 BEGIN\n  \
+        INSERT INTO log VALUES('fired-' || (SELECT count(*) FROM t3));\nEND";
+    match vibesql_parser::Parser::parse_sql(trigger_sql).unwrap() {
+        vibesql_ast::Statement::CreateTrigger(stmt) => {
+            crate::TriggerExecutor::create_trigger_with_sql(&mut db, &stmt, Some(trigger_sql))
+                .unwrap();
+        }
+        other => panic!("Expected CreateTrigger, got {:?}", other),
+    }
+
+    // Seed t3 so the trigger has something to count.
+    for sql in ["INSERT INTO t3 VALUES (1);", "INSERT INTO t3 VALUES (2);"] {
+        match vibesql_parser::Parser::parse_sql(sql).unwrap() {
+            vibesql_ast::Statement::Insert(stmt) => {
+                InsertExecutor::execute(&mut db, &stmt).unwrap();
+            }
+            other => panic!("Expected Insert, got {:?}", other),
+        }
+    }
+
+    // Rename t3 -> t5.
+    match vibesql_parser::Parser::parse_sql("ALTER TABLE t3 RENAME TO t5;").unwrap() {
+        vibesql_ast::Statement::AlterTable(stmt) => {
+            AlterTableExecutor::execute(&stmt, &mut db).unwrap();
+        }
+        other => panic!("Expected AlterTable, got {:?}", other),
+    }
+
+    // sqlite_master.sql must show the rewritten reference, double-quoted, with
+    // the rest preserved verbatim (no injected BEFORE / FOR EACH ROW).
+    let schema = crate::sqlite_schema::execute_sqlite_schema_query(&db.catalog).unwrap();
+    let trigger_row = schema
+        .rows
+        .iter()
+        .find(|r| matches!(&r.values[0], vibesql_types::SqlValue::Varchar(s) if s.as_str() == "trigger"))
+        .expect("trigger row in sqlite_master");
+    let sql_text = match &trigger_row.values[4] {
+        vibesql_types::SqlValue::Varchar(s) => s.to_string(),
+        other => panic!("expected sql text, got {:?}", other),
+    };
+    let expected = "CREATE TRIGGER r1 AFTER INSERT ON t1 BEGIN\n  \
+        INSERT INTO log VALUES('fired-' || (SELECT count(*) FROM \"t5\"));\nEND";
+    assert_eq!(sql_text, expected, "sqlite_master.sql not rewritten to match SQLite");
+
+    // The trigger must still fire against the renamed table. Inserting into t1
+    // counts rows in t5 (the former t3), so the logged message is "fired-2".
+    match vibesql_parser::Parser::parse_sql("INSERT INTO t1 VALUES (10, 'a');").unwrap() {
+        vibesql_ast::Statement::Insert(stmt) => {
+            InsertExecutor::execute(&mut db, &stmt).unwrap();
+        }
+        other => panic!("Expected Insert, got {:?}", other),
+    }
+
+    let select = match vibesql_parser::Parser::parse_sql("SELECT msg FROM log;").unwrap() {
+        vibesql_ast::Statement::Select(stmt) => stmt,
+        other => panic!("Expected Select, got {:?}", other),
+    };
+    let rows = SelectExecutor::new(&db).execute(&select).expect("select from log");
+    assert_eq!(rows.len(), 1, "trigger should have inserted exactly one log row");
+    assert_eq!(
+        rows[0].values[0],
+        vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("fired-2")),
+        "trigger did not fire correctly against the renamed table"
+    );
+}

--- a/crates/vibesql-executor/src/trigger_rename.rs
+++ b/crates/vibesql-executor/src/trigger_rename.rs
@@ -1,0 +1,274 @@
+//! Rewrite table references inside trigger definitions when a table is renamed
+//! via `ALTER TABLE ... RENAME TO ...`.
+//!
+//! SQLite (with `legacy_alter_table=OFF`, the default) rewrites references to a
+//! renamed table inside existing trigger bodies and updates the `sql` text stored
+//! in `sqlite_master`/`sqlite_schema` accordingly, while otherwise preserving the
+//! original `CREATE TRIGGER` text verbatim (only the renamed identifiers change,
+//! and they are emitted double-quoted). See `altertrig.test`.
+//!
+//! This module implements a *targeted, token-level* rewrite that handles the
+//! table-name-in-body cases covered by `altertrig.test`. It deliberately does
+//! **not** attempt the full SQLite name-resolver: column renames inside trigger
+//! bodies (which require schema-aware resolution of unqualified columns) are out
+//! of scope here and tracked as a follow-on.
+//!
+//! Rewrite scope (what counts as a reference to the renamed *table*):
+//! - an identifier in a FROM/JOIN/INTO/UPDATE table position,
+//! - an identifier that immediately follows a comma inside a FROM list,
+//! - an identifier used as a qualifier (e.g. `t4.col` -> `"abc".col`),
+//! - the trigger's own `ON <table>` target (the header table).
+//!
+//! Matched identifiers are replaced in place with the double-quoted new name,
+//! preserving all surrounding whitespace and punctuation verbatim.
+
+use vibesql_parser::{Keyword, Lexer, Span, Token};
+
+/// Rewrite occurrences of `old_table` (case-insensitively) that are *table
+/// references* inside the given `CREATE TRIGGER` SQL text, replacing them with
+/// the double-quoted `new_table`.
+///
+/// Returns the rewritten SQL. If the text cannot be tokenized (it should always
+/// be tokenizable since it round-tripped through the parser already) the input
+/// is returned unchanged.
+pub fn rewrite_table_refs_in_trigger_sql(sql: &str, old_table: &str, new_table: &str) -> String {
+    let tokens = match Lexer::new(sql).tokenize_with_spans() {
+        Ok(t) => t,
+        Err(_) => return sql.to_string(),
+    };
+
+    // Collect the spans of identifier tokens that should be rewritten.
+    let edits = collect_table_ref_spans(&tokens, old_table);
+    if edits.is_empty() {
+        return sql.to_string();
+    }
+
+    apply_edits(sql, &edits, new_table)
+}
+
+/// Apply replacement edits (sorted, non-overlapping spans) to `sql`, replacing
+/// each span's text with the double-quoted `new_table`.
+fn apply_edits(sql: &str, edits: &[Span], new_table: &str) -> String {
+    let replacement = format!("\"{}\"", new_table);
+    let mut out = String::with_capacity(sql.len() + edits.len() * (replacement.len() + 2));
+    let mut cursor = 0usize;
+    for span in edits {
+        if span.start < cursor {
+            // Overlapping/out-of-order span; skip defensively.
+            continue;
+        }
+        out.push_str(&sql[cursor..span.start]);
+        out.push_str(&replacement);
+        cursor = span.end;
+    }
+    out.push_str(&sql[cursor..]);
+    out
+}
+
+/// Walk the token stream and return the spans of identifier tokens that are
+/// references to `old_table` and should be rewritten.
+fn collect_table_ref_spans(tokens: &[(Token, Span)], old_table: &str) -> Vec<Span> {
+    let mut spans = Vec::new();
+
+    // Per-paren-depth flag: are we currently inside a FROM list (so a comma
+    // separates table references)? Index 0 is the top level.
+    let mut from_list_stack: Vec<bool> = vec![false];
+
+    // Track whether we have already consumed the trigger header's `ON <table>`
+    // target. The header `ON` introduces the trigger's table; any later `ON`
+    // belongs to a JOIN condition (where the following identifier is a column,
+    // handled instead by qualifier detection).
+    let mut seen_header_on = false;
+    let mut expect_header_table = false;
+
+    let significant: Vec<usize> =
+        (0..tokens.len()).filter(|&i| !matches!(tokens[i].0, Token::Eof)).collect();
+
+    for (pos, &idx) in significant.iter().enumerate() {
+        let (tok, span) = &tokens[idx];
+
+        match tok {
+            Token::LParen => {
+                // A new scope: subqueries reset FROM-list tracking. Inherit
+                // `false` so commas inside e.g. function args are not treated
+                // as table separators until a FROM keyword appears.
+                from_list_stack.push(false);
+            }
+            Token::RParen => {
+                if from_list_stack.len() > 1 {
+                    from_list_stack.pop();
+                }
+            }
+            Token::Keyword { keyword, .. } => {
+                update_from_list_for_keyword(*keyword, &mut from_list_stack);
+                if *keyword == Keyword::On && !seen_header_on {
+                    seen_header_on = true;
+                    expect_header_table = true;
+                    continue;
+                }
+            }
+            Token::Identifier(name) => {
+                let is_match = name.eq_ignore_ascii_case(old_table);
+
+                // Header `ON <table>` target.
+                if expect_header_table {
+                    expect_header_table = false;
+                    if is_match {
+                        spans.push(*span);
+                    }
+                    continue;
+                }
+
+                if is_match && is_table_position(tokens, &significant, pos, &from_list_stack) {
+                    spans.push(*span);
+                }
+            }
+            _ => {
+                // Any non-identifier token following the header `ON` means the
+                // target was already a (quoted) identifier or something else.
+                expect_header_table = false;
+            }
+        }
+    }
+
+    spans
+}
+
+/// Update the FROM-list flag for the current paren scope based on a keyword.
+fn update_from_list_for_keyword(keyword: Keyword, from_list_stack: &mut [bool]) {
+    let top = from_list_stack.last_mut().expect("stack always has top level");
+    match keyword {
+        // Keywords that (re)open a table list at the current scope.
+        Keyword::From | Keyword::Join | Keyword::Into | Keyword::Update => {
+            *top = true;
+        }
+        // Keywords that end the FROM/table list.
+        Keyword::Set
+        | Keyword::Where
+        | Keyword::Select
+        | Keyword::Group
+        | Keyword::Order
+        | Keyword::Having
+        | Keyword::On
+        | Keyword::Using
+        | Keyword::Values
+        | Keyword::Limit => {
+            *top = false;
+        }
+        _ => {}
+    }
+}
+
+/// Decide whether the identifier at `significant[pos]` occupies a table-name
+/// position (and therefore, when it matches the renamed table, is a reference
+/// that should be rewritten).
+fn is_table_position(
+    tokens: &[(Token, Span)],
+    significant: &[usize],
+    pos: usize,
+    from_list_stack: &[bool],
+) -> bool {
+    // Qualifier position: `<ident>.` — the identifier names a table/alias.
+    if let Some(&next_idx) = significant.get(pos + 1) {
+        if matches!(tokens[next_idx].0, Token::Symbol('.')) {
+            return true;
+        }
+    }
+
+    // Position based on the preceding significant token.
+    if pos == 0 {
+        return false;
+    }
+    let prev_idx = significant[pos - 1];
+    match &tokens[prev_idx].0 {
+        Token::Keyword { keyword, .. } => matches!(
+            keyword,
+            Keyword::From | Keyword::Join | Keyword::Into | Keyword::Update | Keyword::Table
+        ),
+        // A comma inside a FROM list separates table references.
+        Token::Comma => *from_list_stack.last().unwrap_or(&false),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rewrite(sql: &str, old: &str, new: &str) -> String {
+        rewrite_table_refs_in_trigger_sql(sql, old, new)
+    }
+
+    #[test]
+    fn rewrites_table_after_comma_in_from_list() {
+        // altertrig.test 1.1
+        let sql = "CREATE TRIGGER r1 INSERT ON t1 BEGIN \n  UPDATE t1 SET d='xyz' FROM t2, t3; \nEND";
+        let got = rewrite(sql, "t3", "t5");
+        assert_eq!(
+            got,
+            "CREATE TRIGGER r1 INSERT ON t1 BEGIN \n  UPDATE t1 SET d='xyz' FROM t2, \"t5\"; \nEND"
+        );
+    }
+
+    #[test]
+    fn rewrites_table_in_subquery_from() {
+        // altertrig.test 1.3
+        let sql = "CREATE TRIGGER r1 INSERT ON t1 BEGIN \n  UPDATE t1 SET d='xyz' FROM t2, (SELECT * FROM t5); \nEND";
+        let got = rewrite(sql, "t5", "t3");
+        assert_eq!(
+            got,
+            "CREATE TRIGGER r1 INSERT ON t1 BEGIN \n  UPDATE t1 SET d='xyz' FROM t2, (SELECT * FROM \"t3\"); \nEND"
+        );
+    }
+
+    #[test]
+    fn rewrites_multiple_table_refs_nested() {
+        // altertrig.test 2.2: both t3 refs rewritten, column `e` untouched.
+        let sql = "CREATE TRIGGER r1 INSERT ON t1 BEGIN \n  UPDATE t1 SET a='xyz' FROM t3, (SELECT * FROM (SELECT e FROM t3)); \nEND";
+        let got = rewrite(sql, "t3", "t10");
+        assert_eq!(
+            got,
+            "CREATE TRIGGER r1 INSERT ON t1 BEGIN \n  UPDATE t1 SET a='xyz' FROM \"t10\", (SELECT * FROM (SELECT e FROM \"t10\")); \nEND"
+        );
+    }
+
+    #[test]
+    fn rewrites_qualifier_and_join_target() {
+        // altertrig.test 2.8: t4 after NATURAL JOIN and as qualifier t4.e.
+        let sql = "CREATE TRIGGER r1 INSERT ON t1 BEGIN \n  UPDATE t1 SET a=1 FROM t3 NATURAL JOIN t4 WHERE t4.e=a; \nEND";
+        let got = rewrite(sql, "t4", "abc");
+        assert_eq!(
+            got,
+            "CREATE TRIGGER r1 INSERT ON t1 BEGIN \n  UPDATE t1 SET a=1 FROM t3 NATURAL JOIN \"abc\" WHERE \"abc\".e=a; \nEND"
+        );
+    }
+
+    #[test]
+    fn does_not_rewrite_unrelated_column_of_same_name() {
+        // A bare column reference named like the renamed table must not change.
+        let sql = "CREATE TRIGGER r1 INSERT ON t1 BEGIN \n  UPDATE t1 SET a=1 WHERE z=1; \nEND";
+        let got = rewrite(sql, "z", "zz");
+        assert_eq!(got, sql);
+    }
+
+    #[test]
+    fn rewrites_header_on_table() {
+        // If the trigger's own ON-table is renamed, the header is rewritten.
+        let sql = "CREATE TRIGGER r1 INSERT ON t3 BEGIN \n  UPDATE t1 SET a=1; \nEND";
+        let got = rewrite(sql, "t3", "t5");
+        assert_eq!(got, "CREATE TRIGGER r1 INSERT ON \"t5\" BEGIN \n  UPDATE t1 SET a=1; \nEND");
+    }
+
+    #[test]
+    fn no_match_returns_input_unchanged() {
+        let sql = "CREATE TRIGGER r1 INSERT ON t1 BEGIN UPDATE t1 SET a=1; END";
+        assert_eq!(rewrite(sql, "nosuch", "x"), sql);
+    }
+
+    #[test]
+    fn case_insensitive_match() {
+        let sql = "CREATE TRIGGER r1 INSERT ON t1 BEGIN UPDATE t1 SET a=1 FROM T3; END";
+        let got = rewrite(sql, "t3", "t5");
+        assert_eq!(got, "CREATE TRIGGER r1 INSERT ON t1 BEGIN UPDATE t1 SET a=1 FROM \"t5\"; END");
+    }
+}


### PR DESCRIPTION
## Summary
`ALTER TABLE x RENAME TO y` now propagates the rename into existing trigger
definitions and keeps `sqlite_master.sql` consistent with SQLite
(`legacy_alter_table=OFF`), matching sqlite3 3.51.0 / `altertrig.test`.

Two distinct bugs from the issue are fixed:

1. **Verbatim sqlite_master text.** Triggers' `sql` in `sqlite_master`/
   `sqlite_schema` is now rendered from the preserved original SQL text (like
   views via `generate_create_view_sql`) instead of re-serializing from the AST.
   The old path injected `BEFORE`/`FOR EACH ROW`, dropped the space before
   `BEGIN`, and normalized spacing/quoting (`d = 'xyz'` vs `d='xyz'`).
2. **Rename propagated into trigger bodies.** New `trigger_rename` module does a
   targeted, token-level rewrite of *table* references and applies it to both
   the verbatim `sql_definition` (for `sqlite_master`) and the raw body used at
   fire time (so the trigger keeps firing against the new name).

## Rewrite approach / scope covered
Token-level rewrite over the trigger SQL (using the lexer's span-aware
`tokenize_with_spans`), substituting matched identifiers in place with the
double-quoted new name and preserving all surrounding whitespace/punctuation.
An identifier counts as a reference to the renamed *table* when it is:
- in a `FROM`/`JOIN`/`INTO`/`UPDATE`/`TABLE` table position,
- the first identifier after a comma inside a FROM list (paren-depth tracked),
- a qualifier (`t4.col` -> `"abc".col`), or
- the trigger's own header `ON <table>` target.

Matching is case-insensitive; bare columns that merely share the renamed table's
name are left untouched (positional rules + qualifier detection).

## Deferred
Column-rename propagation (`ALTER TABLE ... RENAME COLUMN`) inside trigger bodies
is **not** in this PR — it needs both the `RENAME COLUMN` parser form (not yet
supported) and a schema-aware name resolver. Tracked in #5509.

## altertrig.test delta
21 -> **26** passing (`make test-tcl-file FILE=altertrig.test`). Newly passing:
1.1, 1.3, 2.1.4, 2.2.4, 2.8.4. The remaining 10 failures are all the
column-rename cases (2.3-2.7), deferred to #5509.

## sqlite3 3.51.0 sqlite_master parity evidence
Create table + trigger referencing it, `ALTER TABLE t3 RENAME TO t5`:

VibeSQL and sqlite3 (`legacy_alter_table=OFF`) both produce, byte-for-byte:
```
CREATE TRIGGER r1 AFTER INSERT ON t1 BEGIN
  INSERT INTO log VALUES('fired-' || (SELECT count(*) FROM "t5"));
END
```
The trigger also fires correctly post-rename (both engines log `fired-2`,
counting rows in the former t3 / new t5).

## Tests
- New `trigger_rename` unit tests (8) covering FROM-list comma, subquery FROM,
  nested refs, qualifier + JOIN target, header `ON`, same-named-column safety,
  case-insensitive match, no-op.
- New executor integration test
  `test_rename_table_rewrites_trigger_body_and_fires` asserting both
  `sqlite_master.sql` parity and live trigger firing against the renamed table.

## No regression
- `cargo test -p vibesql-executor --lib`: 2733 passed, 0 failed.
- `cargo test -p vibesql-catalog --lib`: 45 passed, 0 failed.
- TCL: `altertab.test` 26/0, `triggerupfrom.test` 8/0. `trigger1.test` (17/53),
  `trigger2.test` (4/8), `altercol.test` (51/35) are **identical** to baseline
  (verified by stash + rebuild) — pre-existing, unrelated failures.

Closes #5489

🤖 Generated with [Claude Code](https://claude.com/claude-code)