### PR TITLE
fix(catalog): resolve CREATE INDEX target via temp-shadow search order (#5505)

### DIFF
--- a/crates/vibesql-catalog/src/store/indexes.rs
+++ b/crates/vibesql-catalog/src/store/indexes.rs
@@ -18,25 +18,20 @@ impl Catalog {
             });
         }
 
-        // Verify table exists
-        let case_sensitive = self.case_sensitive_identifiers;
-        let table_exists = self
-            .schemas
-            .get(&self.current_schema)
-            .and_then(|schema| schema.get_table(&index.table_name, case_sensitive))
-            .is_some();
-
-        if !table_exists {
-            return Err(CatalogError::TableNotFound { table_name: index.table_name.clone() });
-        }
+        // Verify table exists. Use the temp-shadow-aware resolver so an index
+        // on an unqualified TEMP table (which lives in the session temp schema,
+        // not `main`) is accepted. Previously this only checked the current
+        // (main) schema, causing CREATE INDEX on a temp table to fail with
+        // `TableNotFound`. See issue #5505.
+        let table = match self.get_table(&index.table_name) {
+            Some(table) => table,
+            None => {
+                return Err(CatalogError::TableNotFound { table_name: index.table_name.clone() });
+            }
+        };
 
         // Verify all column-based index columns exist in the table
         // Expression indexes skip this validation (they reference expressions, not specific columns)
-        let table = self
-            .schemas
-            .get(&self.current_schema)
-            .and_then(|schema| schema.get_table(&index.table_name, case_sensitive))
-            .unwrap(); // Safe because we checked above
 
         for col in &index.columns {
             // Only validate column existence for non-expression index columns

--- a/crates/vibesql-catalog/src/store/tables.rs
+++ b/crates/vibesql-catalog/src/store/tables.rs
@@ -363,6 +363,52 @@ impl super::Catalog {
         self.get_table(name).is_some()
     }
 
+    /// Resolve the internal schema name that an unqualified table resolves to.
+    ///
+    /// Follows SQLite name-resolution order for unqualified identifiers: the
+    /// session's temp schema shadows the current (main) schema. If a qualified
+    /// `schema.table` name is supplied, the supplied schema is resolved
+    /// (mapping the literal `temp` alias to the session temp schema) without
+    /// shadowing.
+    ///
+    /// Returns the internal schema name (e.g. `main` or `temp_123`) where the
+    /// table actually lives, or `None` if no such table exists.
+    ///
+    /// This is the canonical way for DDL that must pre-qualify an unqualified
+    /// table name (e.g. CREATE INDEX) to discover the correct schema instead
+    /// of assuming `main`. See issue #5505.
+    pub fn resolve_table_schema_name(&self, name: &str) -> Option<String> {
+        if let Some((schema_part, table_part)) = name.split_once('.') {
+            // Qualified: resolve the supplied schema (temp alias -> session temp),
+            // and confirm the table exists there.
+            let resolved_schema = self.resolve_schema_name(schema_part);
+            let normalized_table = self.normalize_identifier(table_part);
+            return self.get_schema_case_insensitive(resolved_schema).and_then(|schema| {
+                schema
+                    .get_table(&normalized_table, self.case_sensitive_identifiers)
+                    .map(|_| resolved_schema.to_string())
+            });
+        }
+
+        let normalized_table = self.normalize_identifier(name);
+
+        // Temp schema shadows main for unqualified names (SQLite semantics).
+        if let Some(temp_schema) = self.schemas.get(&self.temp_schema_name) {
+            if temp_schema
+                .get_table(&normalized_table, self.case_sensitive_identifiers)
+                .is_some()
+            {
+                return Some(self.temp_schema_name.clone());
+            }
+        }
+
+        self.schemas.get(&self.current_schema).and_then(|schema| {
+            schema
+                .get_table(&normalized_table, self.case_sensitive_identifiers)
+                .map(|_| self.current_schema.clone())
+        })
+    }
+
     /// Check if table exists using SQL:1999 identifier semantics.
     ///
     /// Uses the `quoted` flag in the identifier to determine case-sensitivity:
@@ -467,6 +513,39 @@ mod tests {
             "Trigger should be automatically deleted when table is dropped, \
                  regardless of case used in CREATE TRIGGER vs DROP TABLE"
         );
+    }
+
+    #[test]
+    fn test_resolve_table_schema_name_temp_shadows_main() {
+        // #5505: an unqualified name resolves to the temp schema when a temp
+        // table of that name exists, even if a main table also exists.
+        let mut catalog = crate::Catalog::new();
+        catalog.set_case_sensitive_identifiers(false);
+
+        let col = ColumnSchema::new("a".to_string(), DataType::Integer, true);
+
+        // Only main.t exists -> resolves to main.
+        catalog.create_table(TableSchema::new("t".to_string(), vec![col.clone()])).unwrap();
+        assert_eq!(
+            catalog.resolve_table_schema_name("t").as_deref(),
+            Some(catalog.current_schema.as_str())
+        );
+
+        // Add a shadowing temp.t -> unqualified now resolves to the temp schema.
+        let temp_schema = catalog.temp_schema_name().to_string();
+        catalog
+            .create_table_in_schema(&temp_schema, TableSchema::new("t".to_string(), vec![col]))
+            .unwrap();
+        assert_eq!(catalog.resolve_table_schema_name("t").as_deref(), Some(temp_schema.as_str()));
+
+        // A qualified `main.t` still resolves to main (no shadowing for qualified).
+        assert_eq!(
+            catalog.resolve_table_schema_name(&format!("{}.t", catalog.current_schema)).as_deref(),
+            Some(catalog.current_schema.as_str())
+        );
+
+        // An unknown table resolves to None.
+        assert_eq!(catalog.resolve_table_schema_name("missing"), None);
     }
 
     #[test]

--- a/crates/vibesql-executor/src/index_ddl/create_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/create_index.rs
@@ -437,6 +437,115 @@ mod tests {
         assert!(db.index_exists("idx_users_email_qualified"));
     }
 
+    /// Build a `CreateTableStmt` with two unconstrained columns (a, b).
+    /// `temporary` selects between a main table and a TEMP table.
+    fn simple_ab_table(name: &str, temporary: bool) -> CreateTableStmt {
+        CreateTableStmt {
+            temporary,
+            if_not_exists: false,
+            table_name: name.to_string(),
+            columns: vec![
+                ColumnDef {
+                    name: "a".to_string(),
+                    data_type: DataType::Integer,
+                    nullable: true,
+                    constraints: vec![],
+                    default_value: None,
+                    comment: None,
+                    generated_expr: None,
+                    is_exact_integer_type: false,
+                },
+                ColumnDef {
+                    name: "b".to_string(),
+                    data_type: DataType::Integer,
+                    nullable: true,
+                    constraints: vec![],
+                    default_value: None,
+                    comment: None,
+                    generated_expr: None,
+                    is_exact_integer_type: false,
+                },
+            ],
+            table_constraints: vec![],
+            table_options: vec![],
+            quoted: false,
+            as_query: None,
+            without_rowid: false,
+        }
+    }
+
+    fn index_on_b(index_name: &str, table_name: &str) -> CreateIndexStmt {
+        CreateIndexStmt {
+            index_name: index_name.to_string(),
+            if_not_exists: false,
+            table_name: table_name.to_string(),
+            index_type: vibesql_ast::IndexType::BTree { unique: false },
+            columns: vec![IndexColumn::Column {
+                column_name: "b".to_string(),
+                direction: OrderDirection::Asc,
+                prefix_length: None,
+            }],
+            where_clause: None,
+        }
+    }
+
+    /// Regression test for #5505: `CREATE INDEX` on an unqualified TEMP table
+    /// must resolve the table in the session temp schema, not assume `main`.
+    #[test]
+    fn test_create_index_on_temp_table_resolves_temp_schema() {
+        let mut db = Database::new();
+
+        // CREATE TEMP TABLE tbl(a, b)
+        CreateTableExecutor::execute(&simple_ab_table("tbl", true), &mut db).unwrap();
+
+        // CREATE INDEX tbl_idx ON tbl(b) -- unqualified, must find the temp table
+        let result = CreateIndexExecutor::execute(&index_on_b("tbl_idx", "tbl"), &mut db);
+        assert!(
+            result.is_ok(),
+            "CREATE INDEX on a temp table should succeed (got {:?})",
+            result.err()
+        );
+
+        // The index must be reported against the temp schema, matching sqlite3
+        // which records the index in sqlite_temp_master.
+        let msg = result.unwrap();
+        assert!(
+            msg.contains(&format!("{}.tbl", db.catalog.temp_schema_name())),
+            "index should be created in the temp schema, got: {msg}"
+        );
+
+        // Index exists and is honored against live temp-table data.
+        assert!(db.index_exists("tbl_idx"));
+
+        db.insert_row("tbl", Row::new(vec![SqlValue::Integer(1), SqlValue::Integer(2)])).unwrap();
+        db.insert_row("tbl", Row::new(vec![SqlValue::Integer(3), SqlValue::Integer(4)])).unwrap();
+
+        let rows: Vec<_> = db.get_table("tbl").unwrap().scan_live().collect();
+        assert_eq!(rows.len(), 2, "temp table should hold the inserted rows");
+    }
+
+    /// Regression test for #5505: when a table of the same name exists in both
+    /// `main` and the temp schema, an unqualified `CREATE INDEX` resolves to the
+    /// TEMP table (temp shadows main), matching sqlite3 3.51.0.
+    #[test]
+    fn test_create_index_temp_shadows_main() {
+        let mut db = Database::new();
+
+        // main.t and a shadowing temp.t
+        CreateTableExecutor::execute(&simple_ab_table("t", false), &mut db).unwrap();
+        CreateTableExecutor::execute(&simple_ab_table("t", true), &mut db).unwrap();
+
+        let result = CreateIndexExecutor::execute(&index_on_b("ix", "t"), &mut db);
+        assert!(result.is_ok(), "CREATE INDEX should resolve to temp.t (got {:?})", result.err());
+
+        let msg = result.unwrap();
+        assert!(
+            msg.contains(&format!("{}.t", db.catalog.temp_schema_name())),
+            "unqualified index target must shadow to the temp table, got: {msg}"
+        );
+        assert!(db.index_exists("ix"));
+    }
+
     #[test]
     fn test_create_index_on_nonexistent_schema_qualified_table() {
         let mut db = Database::new();

--- a/crates/vibesql-executor/src/index_ddl/validation.rs
+++ b/crates/vibesql-executor/src/index_ddl/validation.rs
@@ -41,12 +41,22 @@ pub fn validate_create_index(
     stmt: &CreateIndexStmt,
     database: &Database,
 ) -> Result<ValidationResult, ExecutorError> {
-    // Parse qualified table name (schema.table or just table)
+    // Parse qualified table name (schema.table or just table).
+    //
+    // For an UNqualified name we must follow SQLite name resolution: the
+    // session temp schema shadows `main`, so an unqualified table that names a
+    // TEMP table resolves to the temp schema. Previously this hard-coded the
+    // current (main) schema, so `CREATE INDEX ix ON t` where `t` is a TEMP
+    // table failed with `Table 'main.t' not found`. See issue #5505.
     let (schema_name, table_name) =
         if let Some((schema_part, table_part)) = stmt.table_name.split_once('.') {
             (schema_part.to_string(), table_part.to_string())
         } else {
-            (database.catalog.get_current_schema().to_string(), stmt.table_name.clone())
+            let resolved_schema = database
+                .catalog
+                .resolve_table_schema_name(&stmt.table_name)
+                .unwrap_or_else(|| database.catalog.get_current_schema().to_string());
+            (resolved_schema, stmt.table_name.clone())
         };
 
     // Check if target is sqlite_master/sqlite_schema (read-only system table)

--- a/crates/vibesql-storage/src/database/operations.rs
+++ b/crates/vibesql-storage/src/database/operations.rs
@@ -467,16 +467,28 @@ impl Operations {
             table_name.to_lowercase()
         };
 
-        // Try to find the table with normalized name or qualified name
+        // Try to find the table with normalized name or qualified name.
+        //
+        // For an unqualified name, follow SQLite name resolution: the session
+        // temp schema shadows `main`. A TEMP table is stored under the
+        // `temp_<id>.<table>` physical key, so an unqualified index target that
+        // names a temp table must be looked up there before falling back to the
+        // current (main) schema. Previously only the current schema was tried,
+        // so CREATE INDEX on a temp table failed with `TableNotFound`. See #5505.
         let table = if let Some(tbl) = tables.get(&normalized_name) {
             tbl
         } else if !table_name.contains('.') {
-            // Try with schema prefix
-            let current_schema = catalog.get_current_schema();
-            let qualified_name = format!("{}.{}", current_schema, normalized_name);
-            tables
-                .get(&qualified_name)
-                .ok_or_else(|| StorageError::TableNotFound(table_name.clone()))?
+            // Temp schema first (temp tables shadow main).
+            let temp_qualified = format!("{}.{}", catalog.temp_schema_name(), normalized_name);
+            if let Some(tbl) = tables.get(&temp_qualified) {
+                tbl
+            } else {
+                let current_schema = catalog.get_current_schema();
+                let qualified_name = format!("{}.{}", current_schema, normalized_name);
+                tables
+                    .get(&qualified_name)
+                    .ok_or_else(|| StorageError::TableNotFound(table_name.clone()))?
+            }
         } else {
             return Err(StorageError::TableNotFound(table_name.clone()));
         };
@@ -1008,16 +1020,28 @@ impl Operations {
             table_name.to_lowercase()
         };
 
-        // Try to find the table with normalized name or qualified name
+        // Try to find the table with normalized name or qualified name.
+        //
+        // For an unqualified name, follow SQLite name resolution: the session
+        // temp schema shadows `main`. A TEMP table is stored under the
+        // `temp_<id>.<table>` physical key, so an unqualified index target that
+        // names a temp table must be looked up there before falling back to the
+        // current (main) schema. Previously only the current schema was tried,
+        // so CREATE INDEX on a temp table failed with `TableNotFound`. See #5505.
         let table = if let Some(tbl) = tables.get(&normalized_name) {
             tbl
         } else if !table_name.contains('.') {
-            // Try with schema prefix
-            let current_schema = catalog.get_current_schema();
-            let qualified_name = format!("{}.{}", current_schema, normalized_name);
-            tables
-                .get(&qualified_name)
-                .ok_or_else(|| StorageError::TableNotFound(table_name.clone()))?
+            // Temp schema first (temp tables shadow main).
+            let temp_qualified = format!("{}.{}", catalog.temp_schema_name(), normalized_name);
+            if let Some(tbl) = tables.get(&temp_qualified) {
+                tbl
+            } else {
+                let current_schema = catalog.get_current_schema();
+                let qualified_name = format!("{}.{}", current_schema, normalized_name);
+                tables
+                    .get(&qualified_name)
+                    .ok_or_else(|| StorageError::TableNotFound(table_name.clone()))?
+            }
         } else {
             return Err(StorageError::TableNotFound(table_name.clone()));
         };
@@ -1120,16 +1144,28 @@ impl Operations {
             table_name.to_lowercase()
         };
 
-        // Try to find the table with normalized name or qualified name
+        // Try to find the table with normalized name or qualified name.
+        //
+        // For an unqualified name, follow SQLite name resolution: the session
+        // temp schema shadows `main`. A TEMP table is stored under the
+        // `temp_<id>.<table>` physical key, so an unqualified index target that
+        // names a temp table must be looked up there before falling back to the
+        // current (main) schema. Previously only the current schema was tried,
+        // so CREATE INDEX on a temp table failed with `TableNotFound`. See #5505.
         let table = if let Some(tbl) = tables.get(&normalized_name) {
             tbl
         } else if !table_name.contains('.') {
-            // Try with schema prefix
-            let current_schema = catalog.get_current_schema();
-            let qualified_name = format!("{}.{}", current_schema, normalized_name);
-            tables
-                .get(&qualified_name)
-                .ok_or_else(|| StorageError::TableNotFound(table_name.clone()))?
+            // Temp schema first (temp tables shadow main).
+            let temp_qualified = format!("{}.{}", catalog.temp_schema_name(), normalized_name);
+            if let Some(tbl) = tables.get(&temp_qualified) {
+                tbl
+            } else {
+                let current_schema = catalog.get_current_schema();
+                let qualified_name = format!("{}.{}", current_schema, normalized_name);
+                tables
+                    .get(&qualified_name)
+                    .ok_or_else(|| StorageError::TableNotFound(table_name.clone()))?
+            }
         } else {
             return Err(StorageError::TableNotFound(table_name.clone()));
         };


### PR DESCRIPTION
Closes #5505

## Root cause
`CREATE TEMP TABLE t(...); CREATE INDEX ix ON t(...)` failed with
`Table 'main.t' not found`. An unqualified index target was pre-qualified
to the current (`main`) schema **before** the catalog lookup ran, so the
TEMP table — which lives in the session temp schema, not `main` — was
never found. This aborted `trigger2.test` mid-file at the
`CREATE TEMP TABLE tbl (a, b); CREATE INDEX tbl_idx ON tbl(b);`
iteration (filed during #5486 / #5504 triage).

Three independent places assumed `main` for an unqualified index target:

1. **executor CREATE INDEX validation** (`index_ddl/validation.rs`) —
   built `qualified_table_name` from `get_current_schema()` (= `main`)
   for unqualified names, bypassing the catalog's temp-shadow logic.
2. **`Catalog::add_index`** (`catalog/store/indexes.rs`) — only checked
   `current_schema` for the target table, so it returned `TableNotFound`
   for a temp table even once validation was fixed.
3. **storage index-creation table lookup** (`storage/database/operations.rs`,
   3 index-build paths: btree, IVFFlat, HNSW/expression) — only tried the
   unqualified key and the `current_schema`-qualified key.

## The fix: temp-shadows-main search order
SQLite resolves an unqualified name to the TEMP table first, then `main`
(temp shadows main). All three paths now follow that order:

- Added `Catalog::resolve_table_schema_name(name)` — the canonical
  resolver that returns the internal schema (`main` or `temp_<id>`) an
  unqualified name resolves to, temp first.
- Validation routes unqualified names through it before qualifying.
- `Catalog::add_index` uses the temp-shadow-aware `get_table()`.
- Storage index lookups try the session temp-schema key before the
  current-schema key.

An index on a TEMP table now lands against the temp table (success
message reports `temp_<id>.tbl`), matching SQLite recording it in
`sqlite_temp_master`.

## sqlite3 3.51.0 parity (verified)
- `CREATE TEMP TABLE tbl(a,b); CREATE INDEX tbl_idx ON tbl(b); INSERT...;
  SELECT...` succeeds; `WHERE b=?` is served by the index.
- When `t` exists in both temp and main, unqualified `CREATE INDEX ON t`
  and `SELECT FROM t` resolve to the TEMP table (temp shadows main).

## trigger2.test progress
Previously aborted mid-file at the TEMP-table iteration. Now runs to
completion: **12/12 passing**. (A residual `main.tbl not found` line in
the harness log is a pre-existing TCL-harness artifact: the shim rewrites
`CREATE TEMP TABLE` into a uniquely-named *main* table and that rename map
does not survive the harness's between-batch file reload — unrelated to
this DB-level fix. Filed as a follow-on.)

## Tests
- New: `test_create_index_on_temp_table_resolves_temp_schema`,
  `test_create_index_temp_shadows_main` (executor);
  `test_resolve_table_schema_name_temp_shadows_main` (catalog).
- `cargo test -p vibesql-catalog`: 45 passed.
- `cargo test -p vibesql-storage --lib`: 699 passed.
- `cargo test -p vibesql-executor`: green (no regressions to
  index/alter/temp tests).

## Test plan
- [x] sqlite3 3.51.0 parity (temp index success + temp shadows main)
- [x] trigger2.test 12/12
- [x] catalog + storage unit tests green
- [x] executor unit tests green