### PR TITLE
test(consensus): boot TCP test clusters on pre-bound ephemeral listeners (#5507)

### DIFF
--- a/crates/vibesql-consensus/src/mvcc_raft.rs
+++ b/crates/vibesql-consensus/src/mvcc_raft.rs
@@ -806,13 +806,62 @@ impl MvccRaftNode {
                 "failed to bind consensus listener on {listen_addr}: {e}"
             ))
         })?;
+        Self::join_tcp_on_listener(node_id, config, listener, log_store, sm, bootstrap, tuning).await
+    }
 
+    /// The shared tail of every TCP join, given an **already-bound**
+    /// listener.
+    async fn join_tcp_on_listener<LS>(
+        node_id: u64,
+        config: &ClusterConfig,
+        listener: tokio::net::TcpListener,
+        log_store: LS,
+        sm: MvccStateMachine,
+        bootstrap: Bootstrap,
+        tuning: RaftTuning,
+    ) -> Result<Self>
+    where
+        LS: RaftLogStorage<TypeConfig>,
+    {
         let network = crate::tcp::TcpNetworkFactory::new(config);
         let mut node = Self::boot(node_id, network, log_store, sm, tuning).await?;
         node.listener_task = Some(crate::tcp::spawn_listener(node.raft.clone(), listener));
 
         initialize_membership(&node.raft, config.membership(), bootstrap).await?;
         Ok(node)
+    }
+
+    /// Boot a TCP MVCC cluster voter on a **caller-supplied, already-bound**
+    /// listener instead of binding `config.addr(node_id)` here.
+    ///
+    /// The no-gap path for ephemeral-port test clusters — see
+    /// [`OpenraftBackend::join_tcp_cluster_with_listener`] for the rationale:
+    /// the harness binds every node's `127.0.0.1:0` listener up front, reads
+    /// back the OS-assigned ports, wires peers to them, and hands the same
+    /// sockets back here, so no freed port is ever rebound (no
+    /// "Address already in use" race under parallel CI).
+    ///
+    /// Intended for tests/harnesses; `#[doc(hidden)]`.
+    #[doc(hidden)]
+    pub async fn join_tcp_cluster_with_listener(
+        node_id: u64,
+        config: &ClusterConfig,
+        listener: std::net::TcpListener,
+        tuning: RaftTuning,
+    ) -> Result<Self> {
+        let listener = crate::tcp::adopt_listener(listener).map_err(|e| {
+            ConsensusError::Backend(format!("failed to adopt consensus listener: {e}"))
+        })?;
+        Self::join_tcp_on_listener(
+            node_id,
+            config,
+            listener,
+            InMemoryLogStore::default(),
+            MvccStateMachine::volatile(),
+            Bootstrap::Initialize,
+            tuning,
+        )
+        .await
     }
 
     /// Spawn the Raft core over `sm`: storage + state machine + network,

--- a/crates/vibesql-consensus/src/openraft_backend.rs
+++ b/crates/vibesql-consensus/src/openraft_backend.rs
@@ -1247,13 +1247,111 @@ impl<E> OpenraftBackend<E> {
                 "failed to bind consensus listener on {listen_addr}: {e}"
             ))
         })?;
+        Self::join_tcp_on_listener(
+            node_id,
+            config,
+            listener,
+            log_store,
+            state_machine,
+            bootstrap,
+            tuning,
+        )
+        .await
+    }
 
+    /// The shared tail of every TCP join, given an **already-bound**
+    /// listener: build the network factory from `config`, boot the core,
+    /// spawn the accept loop on `listener`, then establish membership.
+    async fn join_tcp_on_listener<LS>(
+        node_id: u64,
+        config: &ClusterConfig,
+        listener: tokio::net::TcpListener,
+        log_store: LS,
+        state_machine: InMemoryStateMachine,
+        bootstrap: Bootstrap,
+        tuning: RaftTuning,
+    ) -> Result<Self>
+    where
+        LS: RaftLogStorage<TypeConfig>,
+    {
         let network = crate::tcp::TcpNetworkFactory::new(config);
         let mut backend = Self::boot(node_id, network, log_store, state_machine, tuning).await?;
         backend.listener_task = Some(crate::tcp::spawn_listener(backend.raft.clone(), listener));
 
         backend.establish_membership(config.membership(), bootstrap).await?;
         Ok(backend)
+    }
+
+    /// Boot a TCP cluster voter on a **caller-supplied, already-bound**
+    /// listener instead of binding `config.addr(node_id)` here.
+    ///
+    /// This is the no-gap path for ephemeral-port test clusters: the harness
+    /// binds every node's listener at `127.0.0.1:0` up front, reads back the
+    /// OS-assigned ports, wires each node's `config` to those real ports, and
+    /// hands the very same sockets back here — so no port is ever released
+    /// and rebound, closing the reserve-then-rebind window that races
+    /// parallel CI for "Address already in use".
+    ///
+    /// `listener` must already be bound to the address `config` advertises
+    /// for `node_id`; nothing here validates that, since the local config's
+    /// own-address entry is exactly the bound address by construction.
+    ///
+    /// Intended for tests/harnesses; `#[doc(hidden)]` to keep it off the
+    /// public surface.
+    #[doc(hidden)]
+    pub async fn join_tcp_cluster_with_listener(
+        node_id: u64,
+        config: &ClusterConfig,
+        listener: std::net::TcpListener,
+        tuning: RaftTuning,
+    ) -> Result<Self> {
+        let listener = crate::tcp::adopt_listener(listener).map_err(|e| {
+            ConsensusError::Backend(format!("failed to adopt consensus listener: {e}"))
+        })?;
+        Self::join_tcp_on_listener(
+            node_id,
+            config,
+            listener,
+            InMemoryLogStore::default(),
+            InMemoryStateMachine::volatile(),
+            Bootstrap::Initialize,
+            tuning,
+        )
+        .await
+    }
+
+    /// Like [`join_tcp_cluster_with_listener`](Self::join_tcp_cluster_with_listener),
+    /// but the node's Raft log and vote are durable under `dir` (so the
+    /// restart/snapshot scenarios that need a persistent log can still boot
+    /// on a pre-bound ephemeral-port listener).
+    #[doc(hidden)]
+    pub async fn join_tcp_cluster_with_listener_and_data_dir(
+        node_id: u64,
+        config: &ClusterConfig,
+        listener: std::net::TcpListener,
+        dir: impl AsRef<Path>,
+        tuning: RaftTuning,
+    ) -> Result<Self> {
+        let listener = crate::tcp::adopt_listener(listener).map_err(|e| {
+            ConsensusError::Backend(format!("failed to adopt consensus listener: {e}"))
+        })?;
+        let dir = dir.as_ref();
+        let storage = DurableStorage::open(dir)?;
+        let bootstrap = if storage.log_has_state {
+            Bootstrap::Recover { last_log_index: None }
+        } else {
+            Bootstrap::Initialize
+        };
+        Self::join_tcp_on_listener(
+            node_id,
+            config,
+            listener,
+            storage.log_store,
+            storage.state_machine,
+            bootstrap,
+            tuning,
+        )
+        .await
     }
 
     async fn start<LS>(

--- a/crates/vibesql-consensus/src/tcp.rs
+++ b/crates/vibesql-consensus/src/tcp.rs
@@ -206,6 +206,21 @@ pub(crate) async fn bind_listener(addr: &str) -> io::Result<TcpListener> {
     socket.listen(1024)
 }
 
+/// Adopt an already-bound [`std::net::TcpListener`] as the consensus
+/// listener, switching it to non-blocking for the tokio reactor.
+///
+/// This is the no-gap counterpart to [`bind_listener`]: a caller can bind a
+/// port (e.g. `127.0.0.1:0` to let the OS pick), read back the real bound
+/// address, wire peers to it, and only *then* hand the very same socket here
+/// — so nothing ever rebinds a freed port. Tests use it (via the
+/// `join_tcp_cluster_with_listener` constructors) to spin up clusters on
+/// ephemeral ports without the reserve-then-rebind window that otherwise
+/// races parallel runs for "Address already in use".
+pub(crate) fn adopt_listener(listener: std::net::TcpListener) -> io::Result<TcpListener> {
+    listener.set_nonblocking(true)?;
+    TcpListener::from_std(listener)
+}
+
 /// Spawn the accept loop feeding inbound RPCs into the local `Raft`.
 ///
 /// Aborting the returned handle ends the loop **and** every accepted

--- a/crates/vibesql-consensus/tests/apply_change_feed.rs
+++ b/crates/vibesql-consensus/tests/apply_change_feed.rs
@@ -22,15 +22,13 @@ use vibesql_types::SqlValue;
 const WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 const POLL_INTERVAL: Duration = Duration::from_millis(20);
 
-fn free_localhost_addrs(n: u64) -> BTreeMap<u64, String> {
-    let listeners: Vec<(u64, StdTcpListener)> = (1..=n)
-        .map(|id| (id, StdTcpListener::bind("127.0.0.1:0").expect("reserve ephemeral port")))
-        .collect();
-    listeners
-        .iter()
-        .map(|(id, listener)| {
-            (*id, listener.local_addr().expect("reserved port address").to_string())
-        })
+/// Bind `n` distinct localhost listeners on OS-assigned ephemeral ports,
+/// returned **still bound** so each node boots directly onto its own socket
+/// — no port is freed and rebound (no "Address already in use" race under
+/// parallel CI, #5507).
+fn bound_localhost_listeners(n: u64) -> BTreeMap<u64, StdTcpListener> {
+    (1..=n)
+        .map(|id| (id, StdTcpListener::bind("127.0.0.1:0").expect("bind ephemeral port")))
         .collect()
 }
 
@@ -41,14 +39,24 @@ struct Cluster {
 
 impl Cluster {
     async fn boot(n: u64) -> Self {
-        let addrs = free_localhost_addrs(n);
+        let mut listeners = bound_localhost_listeners(n);
+        let addrs: BTreeMap<u64, String> = listeners
+            .iter()
+            .map(|(id, l)| (*id, l.local_addr().expect("bound port address").to_string()))
+            .collect();
         let mut nodes = BTreeMap::new();
         for id in 1..=n {
             let view = (1..=n).map(|peer| (peer, addrs[&peer].clone()));
             let config = ClusterConfig::new(view).expect("valid cluster config");
-            let node = MvccRaftNode::join_tcp_cluster_tuned(id, &config, RaftTuning::default())
-                .await
-                .expect("boot mvcc tcp node");
+            let listener = listeners.remove(&id).expect("a bound listener per node");
+            let node = MvccRaftNode::join_tcp_cluster_with_listener(
+                id,
+                &config,
+                listener,
+                RaftTuning::default(),
+            )
+            .await
+            .expect("boot mvcc tcp node");
             nodes.insert(id, node);
         }
         Self { nodes }

--- a/crates/vibesql-consensus/tests/follower_reads.rs
+++ b/crates/vibesql-consensus/tests/follower_reads.rs
@@ -46,17 +46,15 @@ const WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 /// Poll interval inside bounded waits.
 const POLL_INTERVAL: Duration = Duration::from_millis(20);
 
-/// Reserve `n` distinct localhost addresses with OS-assigned ephemeral
-/// ports, keyed by node id `1..=n` (same strategy as tcp_cluster.rs).
-fn free_localhost_addrs(n: u64) -> BTreeMap<u64, String> {
-    let listeners: Vec<(u64, StdTcpListener)> = (1..=n)
-        .map(|id| (id, StdTcpListener::bind("127.0.0.1:0").expect("reserve ephemeral port")))
-        .collect();
-    listeners
-        .iter()
-        .map(|(id, listener)| {
-            (*id, listener.local_addr().expect("reserved port address").to_string())
-        })
+/// Bind `n` distinct localhost listeners on OS-assigned ephemeral ports,
+/// keyed by node id `1..=n`. The listeners are returned **still bound** so
+/// the cluster boots each node directly onto its own socket
+/// ([`MvccRaftNode::join_tcp_cluster_with_listener`]) — no port is ever
+/// released and rebound, closing the reserve-then-rebind window that races
+/// parallel CI for "Address already in use" (#5507).
+fn bound_localhost_listeners(n: u64) -> BTreeMap<u64, StdTcpListener> {
+    (1..=n)
+        .map(|id| (id, StdTcpListener::bind("127.0.0.1:0").expect("bind ephemeral port")))
         .collect()
 }
 
@@ -162,7 +160,14 @@ impl MvccTcpCluster {
     }
 
     async fn build(n: u64, with_proxies: bool, tuning: RaftTuning) -> Self {
-        let addrs = free_localhost_addrs(n);
+        // Bind every node's listener up front and keep the sockets; each
+        // node boots directly onto its own bound listener, so no port is
+        // freed and rebound (no port-collision race under parallel CI).
+        let mut listeners = bound_localhost_listeners(n);
+        let addrs: BTreeMap<u64, String> = listeners
+            .iter()
+            .map(|(id, l)| (*id, l.local_addr().expect("bound port address").to_string()))
+            .collect();
 
         let mut proxies = BTreeMap::new();
         if with_proxies {
@@ -177,8 +182,8 @@ impl MvccTcpCluster {
 
         let mut nodes = BTreeMap::new();
         for id in 1..=n {
-            // Node `id`'s view: its own real address (it binds it), every
-            // peer behind this node's outgoing proxy when partitionable.
+            // Node `id`'s view: its own real bound address, every peer
+            // behind this node's outgoing proxy when partitionable.
             let view = (1..=n).map(|peer| {
                 let addr = if peer == id || !with_proxies {
                     addrs[&peer].clone()
@@ -188,7 +193,8 @@ impl MvccTcpCluster {
                 (peer, addr)
             });
             let config = ClusterConfig::new(view).expect("valid cluster config");
-            let node = MvccRaftNode::join_tcp_cluster_tuned(id, &config, tuning)
+            let listener = listeners.remove(&id).expect("a bound listener per node");
+            let node = MvccRaftNode::join_tcp_cluster_with_listener(id, &config, listener, tuning)
                 .await
                 .expect("boot mvcc tcp node");
             nodes.insert(id, node);

--- a/crates/vibesql-consensus/tests/leader_reads.rs
+++ b/crates/vibesql-consensus/tests/leader_reads.rs
@@ -34,7 +34,8 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::task::JoinHandle;
 
 use vibesql_consensus::{
-    ApplyOutcome, ClusterConfig, ConsensusError, LogIndex, MvccRaftNode, QueryResult, Role,
+    ApplyOutcome, ClusterConfig, ConsensusError, LogIndex, MvccRaftNode, QueryResult, RaftTuning,
+    Role,
 };
 use vibesql_types::SqlValue;
 
@@ -45,18 +46,15 @@ const WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 /// Poll interval inside bounded waits.
 const POLL_INTERVAL: Duration = Duration::from_millis(20);
 
-/// Reserve `n` distinct localhost addresses with OS-assigned ephemeral
-/// ports, keyed by node id `1..=n` (same strategy as tcp_cluster.rs: all
-/// reservations held at once, released just before the nodes bind them).
-fn free_localhost_addrs(n: u64) -> BTreeMap<u64, String> {
-    let listeners: Vec<(u64, StdTcpListener)> = (1..=n)
-        .map(|id| (id, StdTcpListener::bind("127.0.0.1:0").expect("reserve ephemeral port")))
-        .collect();
-    listeners
-        .iter()
-        .map(|(id, listener)| {
-            (*id, listener.local_addr().expect("reserved port address").to_string())
-        })
+/// Bind `n` distinct localhost listeners on OS-assigned ephemeral ports,
+/// keyed by node id `1..=n`. The listeners are returned **still bound** so
+/// the cluster boots each node directly onto its own socket
+/// ([`MvccRaftNode::join_tcp_cluster_with_listener`]) — no port is ever
+/// released and rebound, closing the reserve-then-rebind window that races
+/// parallel CI for "Address already in use" (#5507).
+fn bound_localhost_listeners(n: u64) -> BTreeMap<u64, StdTcpListener> {
+    (1..=n)
+        .map(|id| (id, StdTcpListener::bind("127.0.0.1:0").expect("bind ephemeral port")))
         .collect()
 }
 
@@ -164,7 +162,14 @@ impl MvccTcpCluster {
     }
 
     async fn build(n: u64, with_proxies: bool) -> Self {
-        let addrs = free_localhost_addrs(n);
+        // Bind every node's listener up front and keep the sockets; each
+        // node boots directly onto its own bound listener, so no port is
+        // freed and rebound (no port-collision race under parallel CI).
+        let mut listeners = bound_localhost_listeners(n);
+        let addrs: BTreeMap<u64, String> = listeners
+            .iter()
+            .map(|(id, l)| (*id, l.local_addr().expect("bound port address").to_string()))
+            .collect();
 
         let mut proxies = BTreeMap::new();
         if with_proxies {
@@ -179,8 +184,8 @@ impl MvccTcpCluster {
 
         let mut nodes = BTreeMap::new();
         for id in 1..=n {
-            // Node `id`'s view: its own real address (it binds it), every
-            // peer behind this node's outgoing proxy when partitionable.
+            // Node `id`'s view: its own real bound address, every peer
+            // behind this node's outgoing proxy when partitionable.
             let view = (1..=n).map(|peer| {
                 let addr = if peer == id || !with_proxies {
                     addrs[&peer].clone()
@@ -190,8 +195,15 @@ impl MvccTcpCluster {
                 (peer, addr)
             });
             let config = ClusterConfig::new(view).expect("valid cluster config");
-            let node =
-                MvccRaftNode::join_tcp_cluster(id, &config).await.expect("boot mvcc tcp node");
+            let listener = listeners.remove(&id).expect("a bound listener per node");
+            let node = MvccRaftNode::join_tcp_cluster_with_listener(
+                id,
+                &config,
+                listener,
+                RaftTuning::default(),
+            )
+            .await
+            .expect("boot mvcc tcp node");
             nodes.insert(id, node);
         }
 

--- a/crates/vibesql-consensus/tests/tcp_cluster.rs
+++ b/crates/vibesql-consensus/tests/tcp_cluster.rs
@@ -13,12 +13,15 @@
 //! ## Port strategy
 //!
 //! Nothing here hardcodes the 5433 port convention: every cluster binds OS-
-//! assigned ephemeral ports (`127.0.0.1:0`, all reservations held
-//! simultaneously, then released just before the nodes rebind them), so
-//! parallel tests and busy CI runners cannot collide. Ephemeral allocation
-//! is cyclic, so a just-released port is not handed out again within a test
-//! run, and the consensus listener binds with `SO_REUSEADDR`, so a
-//! restarted node can rebind its own port immediately.
+//! assigned ephemeral ports (`127.0.0.1:0`) and boots each node **directly
+//! onto its own pre-bound listener**
+//! ([`OpenraftBackend::join_tcp_cluster_with_listener_and_data_dir`]) — the
+//! listeners are held bound from allocation through boot, so no port is ever
+//! released and rebound. That closes the reserve-then-rebind window that
+//! previously let a parallel test or busy CI runner grab a just-freed port
+//! and fail an unrelated PR with "Address already in use" (#5507). The
+//! consensus listener binds with `SO_REUSEADDR`, so a restarted node
+//! (`restore`) can rebind its own fixed port immediately after `kill`.
 //!
 //! ## Partitions
 //!
@@ -61,19 +64,20 @@ const WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 /// Poll interval inside bounded waits.
 const POLL_INTERVAL: Duration = Duration::from_millis(20);
 
-/// Reserve `n` distinct localhost addresses with OS-assigned ephemeral
-/// ports, keyed by node id `1..=n`. All reservations are held at once (so
-/// they are guaranteed distinct) and released on return, just before the
-/// cluster's nodes bind them for real.
-fn free_localhost_addrs(n: u64) -> BTreeMap<u64, String> {
-    let listeners: Vec<(u64, StdTcpListener)> = (1..=n)
-        .map(|id| (id, StdTcpListener::bind("127.0.0.1:0").expect("reserve ephemeral port")))
-        .collect();
-    listeners
-        .iter()
-        .map(|(id, listener)| {
-            (*id, listener.local_addr().expect("reserved port address").to_string())
-        })
+/// Bind `n` distinct localhost listeners on OS-assigned ephemeral ports,
+/// keyed by node id `1..=n`. The listeners are returned **still bound** so
+/// the cluster boots each node directly onto its own socket
+/// ([`OpenraftBackend::join_tcp_cluster_with_listener_and_data_dir`]) — no
+/// port is freed and rebound, closing the reserve-then-rebind window that
+/// races parallel CI for "Address already in use" (#5507).
+///
+/// Restart (`restore`) still rebinds a node's fixed address by name via the
+/// transport's `SO_REUSEADDR` path: by then the original port is the node's
+/// own (it just released it on `kill`), so the bounded retry loop in
+/// `restore` reclaims it without contending with unrelated tests.
+fn bound_localhost_listeners(n: u64) -> BTreeMap<u64, StdTcpListener> {
+    (1..=n)
+        .map(|id| (id, StdTcpListener::bind("127.0.0.1:0").expect("bind ephemeral port")))
         .collect()
 }
 
@@ -203,7 +207,14 @@ impl TcpTestCluster {
     }
 
     async fn build(n: u64, with_proxies: bool, tuning: RaftTuning) -> Self {
-        let addrs = free_localhost_addrs(n);
+        // Bind every node's listener up front and keep the sockets; each
+        // node boots directly onto its own bound listener, so no port is
+        // freed and rebound (no port-collision race under parallel CI).
+        let mut listeners = bound_localhost_listeners(n);
+        let addrs: BTreeMap<u64, String> = listeners
+            .iter()
+            .map(|(id, l)| (*id, l.local_addr().expect("bound port address").to_string()))
+            .collect();
 
         let mut proxies = BTreeMap::new();
         if with_proxies {
@@ -218,8 +229,8 @@ impl TcpTestCluster {
 
         let mut nodes = BTreeMap::new();
         for id in 1..=n {
-            // Node `id`'s view: its own real address (it binds it), every
-            // peer behind this node's outgoing proxy when partitionable.
+            // Node `id`'s view: its own real bound address, every peer
+            // behind this node's outgoing proxy when partitionable.
             let view = (1..=n).map(|peer| {
                 let addr = if peer == id || !with_proxies {
                     addrs[&peer].clone()
@@ -230,9 +241,11 @@ impl TcpTestCluster {
             });
             let config = ClusterConfig::new(view).expect("valid cluster config");
             let dir = TempDir::new().expect("create node data directory");
-            let backend = OpenraftBackend::join_tcp_cluster_with_data_dir_tuned(
+            let listener = listeners.remove(&id).expect("a bound listener per node");
+            let backend = OpenraftBackend::join_tcp_cluster_with_listener_and_data_dir(
                 id,
                 &config,
+                listener,
                 dir.path(),
                 tuning,
             )
@@ -867,14 +880,21 @@ async fn execute_on_mvcc_leader(
 /// mount end-to-end over real sockets.)
 #[tokio::test]
 async fn mvcc_three_node_cluster_replicates_over_tcp() {
-    let addrs = free_localhost_addrs(3);
+    let mut listeners = bound_localhost_listeners(3);
+    let addrs: BTreeMap<u64, String> = listeners
+        .iter()
+        .map(|(id, l)| (*id, l.local_addr().expect("bound port address").to_string()))
+        .collect();
     let config = ClusterConfig::new(addrs).expect("valid cluster config");
 
     let mut nodes: BTreeMap<u64, MvccRaftNode> = BTreeMap::new();
     for id in 1..=3 {
+        let listener = listeners.remove(&id).expect("a bound listener per node");
         nodes.insert(
             id,
-            MvccRaftNode::join_tcp_cluster(id, &config).await.expect("boot mvcc tcp node"),
+            MvccRaftNode::join_tcp_cluster_with_listener(id, &config, listener, RaftTuning::default())
+                .await
+                .expect("boot mvcc tcp node"),
         );
     }
 

--- a/crates/vibesql-server/src/replication.rs
+++ b/crates/vibesql-server/src/replication.rs
@@ -185,6 +185,22 @@ impl ReplicationHandle {
         Ok(Arc::new(Self { node, cluster, node_id }))
     }
 
+    /// Wrap an already-booted consensus node as a [`ReplicationHandle`],
+    /// bypassing the `cluster.toml` load + address-bind that
+    /// [`start`](Self::start) performs.
+    ///
+    /// This exists for test harnesses that boot consensus voters on
+    /// **pre-bound ephemeral listeners**
+    /// ([`MvccRaftNode::join_tcp_cluster_with_listener`]) to avoid the
+    /// reserve-then-rebind port-collision race under parallel CI (#5507).
+    /// Production servers always go through [`start`](Self::start).
+    ///
+    /// `#[doc(hidden)]` to keep it off the public surface.
+    #[doc(hidden)]
+    pub fn from_node(node: MvccRaftNode, cluster: ClusterConfig, node_id: u64) -> Arc<Self> {
+        Arc::new(Self { node, cluster, node_id })
+    }
+
     /// The underlying consensus node.
     pub fn node(&self) -> &MvccRaftNode {
         &self.node

--- a/crates/vibesql-server/tests/replication_tests.rs
+++ b/crates/vibesql-server/tests/replication_tests.rs
@@ -20,9 +20,9 @@ use tokio::{
     sync::{broadcast, oneshot},
 };
 use tokio_postgres::{error::SqlState, NoTls};
-use vibesql_consensus::Role;
+use vibesql_consensus::{ClusterConfig, MvccRaftNode, RaftTuning, Role};
 use vibesql_server::{
-    config::{Config, ReplicationConfig},
+    config::Config,
     connection::{ConnectionHandler, TableMutationNotification},
     observability::ObservabilityProvider,
     registry::DatabaseRegistry,
@@ -42,50 +42,41 @@ const POLL_INTERVAL: Duration = Duration::from_millis(20);
 // Cluster helpers
 // ---------------------------------------------------------------------------
 
-/// Reserve `n` distinct localhost addresses with OS-assigned ephemeral
-/// ports (same strategy as the consensus crate's TCP tests: all
-/// reservations held at once, released just before the nodes bind them).
-fn free_localhost_addrs(n: u64) -> Vec<(u64, String)> {
-    let listeners: Vec<(u64, StdTcpListener)> = (1..=n)
-        .map(|id| (id, StdTcpListener::bind("127.0.0.1:0").expect("reserve ephemeral port")))
-        .collect();
-    listeners
-        .iter()
-        .map(|(id, listener)| {
-            (*id, listener.local_addr().expect("reserved port address").to_string())
-        })
+/// Bind `n` distinct localhost listeners on OS-assigned ephemeral ports,
+/// keyed by node id `1..=n`. Returned **still bound** so each node boots
+/// directly onto its own socket — no port is freed and rebound, closing the
+/// reserve-then-rebind window that races parallel CI for "Address already
+/// in use" (#5507).
+fn bound_localhost_listeners(n: u64) -> Vec<(u64, StdTcpListener)> {
+    (1..=n)
+        .map(|id| (id, StdTcpListener::bind("127.0.0.1:0").expect("bind ephemeral port")))
         .collect()
 }
 
-/// Write a `cluster.toml` for the given members and return its path
-/// (inside `dir`).
-fn write_cluster_toml(dir: &std::path::Path, members: &[(u64, String)]) -> std::path::PathBuf {
-    let mut toml = String::new();
-    for (id, addr) in members {
-        toml.push_str(&format!("[[node]]\nid = {id}\naddr = \"{addr}\"\n\n"));
-    }
-    let path = dir.join("cluster.toml");
-    std::fs::write(&path, toml).expect("write cluster.toml");
-    path
-}
-
-/// Boot an `n`-node replicated cluster on ephemeral ports, returning the
-/// handles (keyed 1..=n in order) and the tempdir holding the config.
+/// Boot an `n`-node replicated cluster on pre-bound ephemeral ports,
+/// returning the handles (keyed 1..=n in order) and a tempdir kept alive
+/// for the caller's lifetime (no longer holds a `cluster.toml` — the no-gap
+/// boot path wires peers straight from the bound listeners — but the return
+/// shape is preserved so call sites are unchanged).
 async fn boot_cluster(n: u64) -> (Vec<Arc<ReplicationHandle>>, tempfile::TempDir) {
     let dir = tempfile::tempdir().expect("tempdir");
-    let members = free_localhost_addrs(n);
-    let path = write_cluster_toml(dir.path(), &members);
+
+    // Bind every node's consensus listener up front and keep the sockets;
+    // each node boots directly onto its own bound listener.
+    let listeners = bound_localhost_listeners(n);
+    let members: Vec<(u64, String)> = listeners
+        .iter()
+        .map(|(id, l)| (*id, l.local_addr().expect("bound port address").to_string()))
+        .collect();
+    let cluster = ClusterConfig::new(members.iter().cloned()).expect("valid cluster config");
+    let tuning = RaftTuning { staleness_beacon_ms: 0, ..RaftTuning::default() };
 
     let mut handles = Vec::new();
-    for (id, _) in &members {
-        let config = ReplicationConfig {
-            enabled: true,
-            cluster_config: Some(path.clone()),
-            node_id: Some(*id),
-            data_dir: None,
-            staleness_beacon_ms: 0,
-        };
-        handles.push(ReplicationHandle::start(&config).await.expect("boot consensus node"));
+    for (id, listener) in listeners {
+        let node = MvccRaftNode::join_tcp_cluster_with_listener(id, &cluster, listener, tuning)
+            .await
+            .expect("boot consensus node");
+        handles.push(ReplicationHandle::from_node(node, cluster.clone(), id));
     }
     (handles, dir)
 }


### PR DESCRIPTION
Closes #5507

## Problem

The consensus/replication TCP test harnesses bound `127.0.0.1:0`, read back the OS-assigned port, then **released** the listener (`StdTcpListener` dropped) before each node later *rebound* it. Under parallel CI, another test (or another reservation in the same harness) could grab a just-freed port in that reserve-then-rebind gap, intermittently failing **unrelated** PRs with:

```
failed to bind consensus listener on 127.0.0.1:<port>: Address already in use (os error 98)
```

`SO_REUSEADDR` does not help here: it covers TIME_WAIT, not a port another process is actively listening on. So even with ephemeral ports, the TOCTOU window was real (the flaky `read_your_writes_token_serves_on_any_node` is the symptom called out in the issue).

## Fixed-port / reserve-release sites found

All used the same `free_localhost_addrs` reserve-then-release pattern (no literal hardcoded ports remained in `main`, but the gap was the actual race):

- `crates/vibesql-consensus/tests/follower_reads.rs`
- `crates/vibesql-consensus/tests/leader_reads.rs`
- `crates/vibesql-consensus/tests/tcp_cluster.rs` (incl. `mvcc_three_node_cluster_replicates_over_tcp`)
- `crates/vibesql-consensus/tests/apply_change_feed.rs`
- `crates/vibesql-server/tests/replication_tests.rs` (wrote a `cluster.toml` from reserved-then-released ports)

## Approach — ephemeral `:0`, held bound (no gap)

Bind every node's listener at `127.0.0.1:0` up front, read back the real OS-assigned address, and boot each node **directly onto that same socket** — the listener is never released and rebound, so the collision window is gone.

Minimal transport additions (runtime behavior unchanged; production still binds by address):

- `tcp::adopt_listener(std::net::TcpListener) -> tokio::net::TcpListener` (sets non-blocking).
- `#[doc(hidden)]` `MvccRaftNode::join_tcp_cluster_with_listener` and `OpenraftBackend::join_tcp_cluster_with_listener[_and_data_dir]` — accept a pre-bound listener instead of binding `config.addr(node_id)`. Implemented by extracting the existing post-bind tail (`join_tcp_on_listener`).
- `#[doc(hidden)]` `ReplicationHandle::from_node(node, cluster, node_id)` so the server test harness can wrap a node booted on a pre-bound listener (no `cluster.toml` round-trip).

## Peer wiring — how ports are discovered before peers connect

The chicken-and-egg (peers must know each other's ports before dialing) is resolved by ordering:

1. Bind all `n` listeners at `:0` simultaneously and hold them (guaranteed distinct).
2. Read `local_addr()` from each to get the real ports.
3. Build each node's `ClusterConfig` peer map from those real addresses (proxies still interpose per-edge for partition tests).
4. Hand each node its own held listener via `*_with_listener*`.

Restart (`tcp_cluster.rs::restore`) still rebinds a node's fixed address by name via the `SO_REUSEADDR` path — by then the port is the node's own (just released on `kill`), reclaimed by the existing bounded retry loop.

Tests still exercise real TCP multi-node consensus end-to-end (leader/follower reads, RYW tokens, linearizable fencing, minority partition, chunked snapshot install). Only port assignment changed.

## Evidence — repeated / parallel runs

- `cargo test -p vibesql-consensus` green, run back-to-back twice (178 + 2 + 4 + 2 + 9 tests, all pass).
- 24 concurrent test-binary instances (6x each of follower_reads/leader_reads/tcp_cluster/apply_change_feed, `--test-threads=4`): **all passed, zero "Address already in use"**.
- `read_your_writes_token_serves_on_any_node` run 16x in parallel: **16/16 pass**.
- `cargo test -p vibesql-server --test replication_tests`: 52 pass; stable back-to-back.
- `cargo build --workspace` and `cargo clippy -p vibesql-consensus --tests` / `-p vibesql-server --tests` clean for touched files.

## Follow-ons

- Running ~8 entire copies of the **server** `replication_tests` binary simultaneously surfaced election-timeout flakes (`not the cluster leader`) under CPU saturation — **not** port collisions (zero "Address already in use"); this is the separate "busy CI runner election" class already noted in `tcp_cluster.rs`. Out of scope here; worth a dedicated issue if it recurs in real CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)