### PR TITLE
fix(executor): error on rowid reference against a view (no such column: rowid)

### DIFF
--- a/crates/vibesql-catalog/src/table.rs
+++ b/crates/vibesql-catalog/src/table.rs
@@ -32,6 +32,12 @@ pub struct TableSchema {
     pub rowid_alias_column: Option<usize>,
     /// If true, table was created with WITHOUT ROWID clause (SQLite compatibility).
     pub without_rowid: bool,
+    /// If true, this schema is a pseudo-schema standing in for a VIEW rather than
+    /// a base table. Views have no implicit rowid, so references to the
+    /// `rowid`/`oid`/`_rowid_` pseudo-columns against a view must error with
+    /// `no such column: rowid` (SQLite semantics; `allow_rowid_in_view` is off by
+    /// default). See issue #5492.
+    pub is_view: bool,
 }
 
 impl TableSchema {
@@ -54,6 +60,7 @@ impl TableSchema {
             storage_format: StorageFormat::default(),
             rowid_alias_column: None,
             without_rowid: false,
+            is_view: false,
         }
     }
 
@@ -77,6 +84,7 @@ impl TableSchema {
             storage_format: StorageFormat::default(),
             rowid_alias_column: None,
             without_rowid: false,
+            is_view: false,
         }
     }
 
@@ -100,6 +108,7 @@ impl TableSchema {
             storage_format: StorageFormat::default(),
             rowid_alias_column: None,
             without_rowid: false,
+            is_view: false,
         }
     }
 
@@ -123,6 +132,7 @@ impl TableSchema {
             storage_format: StorageFormat::default(),
             rowid_alias_column: None,
             without_rowid: false,
+            is_view: false,
         }
     }
 
@@ -147,6 +157,7 @@ impl TableSchema {
             storage_format: StorageFormat::default(),
             rowid_alias_column: None,
             without_rowid: false,
+            is_view: false,
         }
     }
 
@@ -173,6 +184,7 @@ impl TableSchema {
             storage_format: StorageFormat::default(),
             rowid_alias_column: None,
             without_rowid: false,
+            is_view: false,
         }
     }
 
@@ -196,6 +208,7 @@ impl TableSchema {
             storage_format,
             rowid_alias_column: None,
             without_rowid: false,
+            is_view: false,
         }
     }
 
@@ -208,6 +221,11 @@ impl TableSchema {
     /// This column's value IS the rowid in SQLite compatibility mode
     pub fn set_rowid_alias_column(&mut self, column_index: Option<usize>) {
         self.rowid_alias_column = column_index;
+    }
+
+    /// Mark this schema as a VIEW pseudo-schema (no implicit rowid). See #5492.
+    pub fn set_is_view(&mut self, is_view: bool) {
+        self.is_view = is_view;
     }
 
     /// Check if this table uses columnar storage

--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -1244,7 +1244,12 @@ fn build_view_schema(
         .map(|name| vibesql_catalog::ColumnSchema::new(name, vibesql_types::DataType::Null, true))
         .collect();
 
-    Ok(vibesql_catalog::TableSchema::new(view_def.name.clone(), columns))
+    // Mark this as a VIEW pseudo-schema: views have no implicit rowid, so
+    // `rowid`/`oid`/`_rowid_` references against the view must error rather than
+    // silently resolve (#5492).
+    let mut schema = vibesql_catalog::TableSchema::new(view_def.name.clone(), columns);
+    schema.set_is_view(true);
+    Ok(schema)
 }
 
 /// Check if a SqlValue is truthy using SQLite truthiness rules.

--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -604,7 +604,9 @@ impl CombinedExpressionEvaluator<'_> {
                         if let Some(ref table_id) = table_id {
                             if let Some((_, table_schema)) = self.schema.table_schemas.get(table_id)
                             {
-                                if table_schema.without_rowid {
+                                // WITHOUT ROWID tables (#4953) and VIEWs (#5492)
+                                // both lack the rowid pseudo-column.
+                                if table_schema.without_rowid || table_schema.is_view {
                                     return Err(ExecutorError::ColumnNotFound {
                                         column_name: column.to_string(),
                                         table_name: table_id.display().to_string(),
@@ -618,9 +620,10 @@ impl CombinedExpressionEvaluator<'_> {
                                 }
                             }
                         } else {
-                            // Unqualified rowid - check if any table in scope is WITHOUT ROWID
+                            // Unqualified rowid - check if any table in scope is
+                            // WITHOUT ROWID or a VIEW (neither has a rowid).
                             for (tid, (_, table_schema)) in &self.schema.table_schemas {
-                                if table_schema.without_rowid {
+                                if table_schema.without_rowid || table_schema.is_view {
                                     return Err(ExecutorError::ColumnNotFound {
                                         column_name: column.to_string(),
                                         table_name: tid.display().to_string(),

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -1069,6 +1069,25 @@ impl ExpressionEvaluator<'_> {
         if column_lower == "rowid" || column_lower == "_rowid_" || column_lower == "oid" {
             // First check if schema has a real column with this name
             if self.schema.get_column_index(column).is_none() {
+                // VIEWs have no implicit rowid. Unless a real column named
+                // rowid/oid/_rowid_ is exposed by the view (handled above by the
+                // get_column_index check), referencing the pseudo-column against
+                // a view must error with `no such column: rowid` — matching
+                // sqlite3 with the default `allow_rowid_in_view` off (#5492).
+                if self.schema.is_view {
+                    return Err(ExecutorError::ColumnNotFound {
+                        column_name: column.to_string(),
+                        table_name: self.schema.name.clone(),
+                        searched_tables: vec![self.schema.name.clone()],
+                        available_columns: self
+                            .schema
+                            .columns
+                            .iter()
+                            .map(|c| c.name.clone())
+                            .collect(),
+                    });
+                }
+
                 // WITHOUT ROWID tables do not have the rowid pseudo-column
                 if self.schema.without_rowid {
                     return Err(ExecutorError::ColumnNotFound {

--- a/crates/vibesql-executor/src/schema.rs
+++ b/crates/vibesql-executor/src/schema.rs
@@ -225,7 +225,12 @@ impl CombinedSchema {
             })
             .collect();
 
-        let schema = vibesql_catalog::TableSchema::new(alias.clone(), columns);
+        // A derived table (FROM subquery) has no implicit rowid, just like a
+        // view: `SELECT rowid FROM (SELECT ...)` must error with
+        // `no such column: rowid` (sqlite3 parity, #5492). Mark the synthetic
+        // schema as a view so the rowid pseudo-column is not exposed.
+        let mut schema = vibesql_catalog::TableSchema::new(alias.clone(), columns);
+        schema.set_is_view(true);
         let mut table_schemas = HashMap::new();
         let table_id = TableIdentifier::unquoted(&alias);
         table_schemas.insert(table_id, (0, schema));

--- a/crates/vibesql-executor/src/select/executor/validation/column_refs.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/column_refs.rs
@@ -218,10 +218,13 @@ pub fn validate_column_ref(
         if let Some(ref qualifier) = col_ref.table {
             let qualifier_lower = qualifier.to_lowercase();
 
-            // Check if the qualified table is a WITHOUT ROWID table
+            // Check if the qualified table is a WITHOUT ROWID table or a VIEW.
+            // Neither exposes the rowid pseudo-column: WITHOUT ROWID tables have
+            // no rowid (#4953), and views have no implicit rowid at all (#5492).
             for (table_id, (_, table_schema)) in &schema.table_schemas {
-                if table_id.canonical() == qualifier_lower && table_schema.without_rowid {
-                    // WITHOUT ROWID tables do not have rowid pseudo-column
+                if table_id.canonical() == qualifier_lower
+                    && (table_schema.without_rowid || table_schema.is_view)
+                {
                     return Err(ExecutorError::ColumnNotFound {
                         column_name: col_ref.column.clone(),
                         table_name: qualifier.clone(),
@@ -245,15 +248,18 @@ pub fn validate_column_ref(
             }
         } else {
             // Unqualified ROWID is valid if there's at least one table in scope
-            // AND none of the tables are WITHOUT ROWID
+            // AND none of the tables are WITHOUT ROWID or a VIEW (neither
+            // exposes a rowid pseudo-column — #4953 / #5492).
             if !schema.table_schemas.is_empty() {
-                // Check if any table in scope is WITHOUT ROWID
+                // Check if any table in scope is WITHOUT ROWID or a VIEW.
                 let has_without_rowid_table =
-                    schema.table_schemas.values().any(|(_, ts)| ts.without_rowid);
+                    schema.table_schemas.values().any(|(_, ts)| ts.without_rowid || ts.is_view);
                 if has_without_rowid_table {
-                    // Get the first WITHOUT ROWID table for error message
-                    if let Some((table_id, (_, table_schema))) =
-                        schema.table_schemas.iter().find(|(_, (_, ts))| ts.without_rowid)
+                    // Get the first WITHOUT ROWID table or VIEW for error message
+                    if let Some((table_id, (_, table_schema))) = schema
+                        .table_schemas
+                        .iter()
+                        .find(|(_, (_, ts))| ts.without_rowid || ts.is_view)
                     {
                         return Err(ExecutorError::ColumnNotFound {
                             column_name: col_ref.column.clone(),
@@ -327,8 +333,8 @@ mod tests {
 
     use super::*;
 
-    fn make_test_schema() -> CombinedSchema {
-        let columns = vec![
+    fn make_columns() -> Vec<ColumnSchema> {
+        vec![
             ColumnSchema {
                 name: "ID".to_string(),
                 data_type: DataType::Integer,
@@ -347,9 +353,75 @@ mod tests {
                 is_exact_integer_type: false,
                 collation: None,
             },
-        ];
-        let table_schema = TableSchema::new("PRODUCTS".to_string(), columns);
+        ]
+    }
+
+    fn make_test_schema() -> CombinedSchema {
+        let table_schema = TableSchema::new("PRODUCTS".to_string(), make_columns());
         CombinedSchema::from_table("PRODUCTS".to_string(), table_schema)
+    }
+
+    fn make_view_schema() -> CombinedSchema {
+        let mut view_schema = TableSchema::new("V1".to_string(), make_columns());
+        view_schema.set_is_view(true);
+        CombinedSchema::from_table("V1".to_string(), view_schema)
+    }
+
+    #[test]
+    fn test_rowid_resolves_on_table() {
+        // Base tables expose the rowid pseudo-column (and its aliases).
+        let schema = make_test_schema();
+        for name in ["rowid", "oid", "_rowid_", "ROWID"] {
+            let col_ref = ColumnReference { table: None, column: name.to_string() };
+            assert!(
+                validate_column_ref(&col_ref, &schema, None).is_ok(),
+                "expected `{name}` to resolve on a base table"
+            );
+            let qualified =
+                ColumnReference { table: Some("PRODUCTS".to_string()), column: name.to_string() };
+            assert!(
+                validate_column_ref(&qualified, &schema, None).is_ok(),
+                "expected `PRODUCTS.{name}` to resolve on a base table"
+            );
+        }
+    }
+
+    #[test]
+    fn test_rowid_errors_on_view() {
+        // Views have no implicit rowid: rowid/oid/_rowid_ must error (#5492).
+        let schema = make_view_schema();
+        for name in ["rowid", "oid", "_rowid_", "ROWID"] {
+            let col_ref = ColumnReference { table: None, column: name.to_string() };
+            assert!(
+                matches!(
+                    validate_column_ref(&col_ref, &schema, None),
+                    Err(ExecutorError::ColumnNotFound { .. })
+                ),
+                "expected unqualified `{name}` to error on a view"
+            );
+            let qualified =
+                ColumnReference { table: Some("V1".to_string()), column: name.to_string() };
+            assert!(
+                matches!(
+                    validate_column_ref(&qualified, &schema, None),
+                    Err(ExecutorError::ColumnNotFound { .. })
+                ),
+                "expected qualified `V1.{name}` to error on a view"
+            );
+        }
+    }
+
+    #[test]
+    fn test_view_column_named_rowid_resolves() {
+        // A view that explicitly exposes a real column named "rowid" resolves to
+        // that column rather than erroring (matches sqlite3 3.51.0).
+        let mut cols = make_columns();
+        cols[0].name = "ROWID".to_string();
+        let mut view_schema = TableSchema::new("V2".to_string(), cols);
+        view_schema.set_is_view(true);
+        let schema = CombinedSchema::from_table("V2".to_string(), view_schema);
+        let col_ref = ColumnReference { table: None, column: "rowid".to_string() };
+        assert!(validate_column_ref(&col_ref, &schema, None).is_ok());
     }
 
     #[test]

--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -355,7 +355,11 @@ pub(crate) fn execute_table_scan(
                 .collect()
         };
 
-        let view_schema = vibesql_catalog::TableSchema::new(table_name.to_string(), columns);
+        let mut view_schema = vibesql_catalog::TableSchema::new(table_name.to_string(), columns);
+        // Views have no implicit rowid: a `rowid`/`oid`/`_rowid_` reference
+        // against a view in a SELECT must error (`no such column: rowid`),
+        // matching sqlite3 with the default `allow_rowid_in_view` off (#5492).
+        view_schema.set_is_view(true);
         let effective_name = alias.cloned().unwrap_or_else(|| table_name.to_string());
         // SQL:1999 E051-09: Apply column aliases if provided
         let view_schema = apply_column_aliases(view_schema, column_aliases)?;

--- a/crates/vibesql-executor/src/update/triggers.rs
+++ b/crates/vibesql-executor/src/update/triggers.rs
@@ -443,5 +443,10 @@ pub(super) fn build_view_schema(
         .map(|name| ColumnSchema::new(name, DataType::Null, true))
         .collect();
 
-    Ok(TableSchema::new(view_def.name.clone(), columns))
+    // Mark this as a VIEW pseudo-schema: views have no implicit rowid, so
+    // `rowid`/`oid`/`_rowid_` references against the view must error rather than
+    // silently resolve (#5492).
+    let mut schema = TableSchema::new(view_def.name.clone(), columns);
+    schema.set_is_view(true);
+    Ok(schema)
 }

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -4267,7 +4267,13 @@ proc check_single_capability {cap} {
     # every trigger*.test file to `finish_test; return` at its capability
     # guard, extracting 0 tests. Removing it lets SQLite's canonical trigger
     # conformance actually execute against VibeSQL.
-    set unsupported_caps {wal vacuum_incr autovacuum stat4 stat3 tclvar vtab rtree fts3 fts4 fts5 conflict hiddencolumns progress}
+    # `allow_rowid_in_view` is the SQLITE_ALLOW_ROWID_IN_VIEW compile-time
+    # option, which is OFF by default in SQLite. VibeSQL matches the default:
+    # a view has no implicit rowid, so `rowid`/`oid`/`_rowid_` against a view
+    # errors with `no such column: rowid` (#5492). Marking it unsupported makes
+    # `ifcapable !allow_rowid_in_view` blocks (e.g. trigger9-4.2/4.3) take their
+    # error-expecting branch, matching real sqlite3 with the option off.
+    set unsupported_caps {wal vacuum_incr autovacuum stat4 stat3 tclvar vtab rtree fts3 fts4 fts5 conflict hiddencolumns progress allow_rowid_in_view}
 
     # Handle negated capability (e.g., !autovacuum)
     set negate 0


### PR DESCRIPTION
## Summary

Closes #5492

A `rowid`/`oid`/`_rowid_` reference against a **VIEW** (or a FROM subquery /
derived table) must error with `no such column: rowid` — matching sqlite3
3.51.0 with the default `allow_rowid_in_view` compile option **off**. Views
have no implicit rowid.

### Where rowid-on-view was wrongly permitted

VibeSQL exposed the rowid pseudo-column on view pseudo-schemas and on the
view-scan/derived-table schemas, so:
- `UPDATE v1 SET a=b WHERE rowid=2` and `DELETE FROM v1 WHERE rowid=1`
  *executed* (firing INSTEAD OF triggers) instead of erroring — the per-row
  evaluators (`evaluator/expressions/eval.rs`, `evaluator/combined/eval.rs`)
  only short-circuited rowid for `WITHOUT ROWID` tables, never for views.
- `SELECT rowid FROM v1` returned rows — the view scan in
  `select/scan/table.rs` built a plain `TableSchema` (rowid-capable), and the
  SELECT name-resolution validator (`select/executor/validation/column_refs.rs`)
  only rejected rowid for `WITHOUT ROWID` tables.
- `SELECT rowid FROM (SELECT ...)` returned rows — derived tables
  (`schema.rs::from_derived_table`) had no rowid guard either.

### The fix

- Add an `is_view: bool` marker to `TableSchema` (catalog), defaulting to
  `false`, with a `set_is_view` setter.
- Set `is_view = true` on every VIEW/derived-table pseudo-schema:
  `update/triggers.rs::build_view_schema`,
  `delete/executor.rs::build_view_schema`, the SELECT view scan in
  `select/scan/table.rs`, and `schema.rs::from_derived_table`.
- Teach the three rowid-resolution paths to treat `is_view` like
  `without_rowid` (no rowid pseudo-column → `no such column: rowid`):
  the single-table evaluator, the combined (join) evaluator, and the SELECT
  name-resolution validator.
- TCL shim: mark `allow_rowid_in_view` as unsupported so
  `ifcapable !allow_rowid_in_view` blocks (trigger9-4.2/4.3) take their
  error-expecting branch, matching real sqlite3 with the option off.

### sqlite3 3.51.0 parity (verified)

| Statement | sqlite3 3.51.0 | VibeSQL (after) |
|---|---|---|
| `SELECT rowid FROM v1` | `no such column: rowid` | error |
| `SELECT oid FROM v1` | `no such column: oid` | error |
| `SELECT _rowid_ FROM v1` | `no such column: _rowid_` | error |
| `UPDATE v1 SET a=b WHERE rowid=2` | `no such column: rowid` | error |
| `DELETE FROM v1 WHERE rowid=1` | `no such column: rowid` | error |
| `SELECT rowid FROM (SELECT a,b FROM t1)` | `no such column: rowid` | error |
| `SELECT rowid FROM v2` where `v2 AS SELECT a AS rowid, b ...` | `10` | `10` |
| `SELECT rowid FROM t1` (base table) | `1` | `1` |
| `SELECT oid FROM t1`, `SELECT t1.rowid FROM t1` | resolve | resolve |

The error preserves the referenced column name (`oid`/`_rowid_`), matching
sqlite3; the TCL shim normalizes `Column 'X' not found ...` → `no such column: x`.
A view column genuinely named `rowid` (real column) still resolves — the
`get_column_index` precedence check is unchanged.

### Conformance delta

- **trigger9.test**: 14 pass / 2 fail → **16 pass / 0 fail** (4.2, 4.3 now pass).
- **triggerC.test**: 61 pass / 56 fail (unchanged). The 7.x failures are
  pre-existing and unrelated (`UPDATE t7 SET rowid=8` mutation + BEFORE/AFTER
  trigger interaction on *base tables*, not views).
- **view.test**: 24 pass / 0 fail (unchanged — no regression).
- **trigger1.test**: 20 pass / 50 fail (unchanged — pre-existing failures).

### Test plan

- [x] `cargo test -p vibesql-executor --lib` — 2743 passed, 0 failed
      (incl. 3 new `column_refs` tests: table resolves, view errors,
      view-column-named-rowid resolves)
- [x] `cargo test -p vibesql-catalog` — 45 passed, 0 failed
- [x] `cargo clippy -p vibesql-executor -p vibesql-catalog` — 0 errors
- [x] trigger9.test: +2 tests now pass; triggerC/view/trigger1: no regression
      (baseline-compared with code changes stashed)
- [x] sqlite3 3.51.0 parity manually verified for all cases above

🤖 Generated with [Claude Code](https://claude.com/claude-code)