### PR TITLE
fix(executor): fire child UPDATE triggers on ON DELETE SET NULL/SET DEFAULT cascades

### DIFF
--- a/crates/vibesql-executor/src/delete/integrity.rs
+++ b/crates/vibesql-executor/src/delete/integrity.rs
@@ -207,12 +207,33 @@ pub fn check_no_child_references(
                 )?;
             }
             ReferentialAction::SetNull => {
-                // Set child FK columns to NULL
-                set_null(db, &child_table_name, &fk, &parent_key_values)?;
+                // Set child FK columns to NULL. Fires the child's
+                // BEFORE/AFTER UPDATE row triggers; a BEFORE UPDATE
+                // RAISE(IGNORE) skips that child's rewrite, leaving an
+                // orphan that the statement-end FK check must trip (#5465).
+                set_null(
+                    db,
+                    &child_table_name,
+                    &fk,
+                    fk_idx,
+                    &parent_key_values,
+                    in_txn,
+                    session_defer,
+                )?;
             }
             ReferentialAction::SetDefault => {
-                // Set child FK columns to their default values
-                set_default(db, &child_table_name, &fk, &parent_key_values)?;
+                // Set child FK columns to their default values. Fires the
+                // child's BEFORE/AFTER UPDATE row triggers; same
+                // RAISE(IGNORE) -> orphan-check semantics as SET NULL.
+                set_default(
+                    db,
+                    &child_table_name,
+                    &fk,
+                    fk_idx,
+                    &parent_key_values,
+                    in_txn,
+                    session_defer,
+                )?;
             }
         }
     }
@@ -425,11 +446,15 @@ fn cascade_delete(
 }
 
 /// Set child FK columns to NULL (SET NULL action)
+#[allow(clippy::too_many_arguments)]
 fn set_null(
     db: &mut vibesql_storage::Database,
     child_table_name: &str,
     fk: &vibesql_catalog::ForeignKeyConstraint,
+    fk_idx: usize,
     parent_key_values: &[SqlValue],
+    in_txn: bool,
+    session_defer: bool,
 ) -> Result<(), ExecutorError> {
     // Resolve parent-side collations before borrowing the child table so
     // FK comparisons honor NOCASE/RTRIM (#5147).
@@ -439,9 +464,13 @@ fn set_null(
     // SET NULL targets. Off-state collapses to scan_live.
     let snapshot = crate::mvcc::read_snapshot(db);
 
-    // Collect indices of rows to update.
+    // Collect (row index, OLD row, NEW row) triples to rewrite. The OLD
+    // row is the current child row; the NEW row carries the FK columns set
+    // to NULL. We keep OLD so the child's UPDATE triggers see the correct
+    // OLD.* values, matching sqlite3 3.51 (the SET NULL action is an UPDATE
+    // on the child).
     let child_table = db.get_table(child_table_name).unwrap();
-    let mut rows_to_update: Vec<(usize, vibesql_storage::Row)> = Vec::new();
+    let mut rows_to_update: Vec<(usize, vibesql_storage::Row, vibesql_storage::Row)> = Vec::new();
 
     for (idx, child_row) in child_table.scan_visible(&snapshot) {
         let child_fk_values: Vec<SqlValue> =
@@ -462,43 +491,37 @@ fn set_null(
             },
         );
         if matches {
+            let old_row = child_row.clone();
             // Create updated row with FK columns set to NULL
-            let mut updated_row = child_row.clone();
+            let mut updated_row = old_row.clone();
             for &fk_col_idx in &fk.column_indices {
                 updated_row.values[fk_col_idx] = SqlValue::Null;
             }
-            rows_to_update.push((idx, updated_row));
+            rows_to_update.push((idx, old_row, updated_row));
         }
     }
 
-    // Phase 1c (Issue #5150 / #5136): stamp xmin on every FK-cascaded
-    // SET NULL new row version. Off-state is a no-op.
-    let txn_id = db.transaction_id();
-    for (_, updated_row) in rows_to_update.iter_mut() {
-        vibesql_storage::stamp_xmin_for_write(updated_row, txn_id);
-        updated_row.xmax = None;
-    }
-
-    // Now update the rows
-    let child_table_mut = db.get_table_mut(child_table_name).unwrap();
-    for (idx, updated_row) in rows_to_update {
-        child_table_mut
-            .update_row(idx, updated_row)
-            .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
-    }
-
-    // Rebuild indexes after update
-    db.rebuild_indexes(child_table_name);
-
-    Ok(())
+    apply_cascade_child_updates(
+        db,
+        child_table_name,
+        fk,
+        fk_idx,
+        rows_to_update,
+        in_txn,
+        session_defer,
+    )
 }
 
 /// Set child FK columns to their default values (SET DEFAULT action)
+#[allow(clippy::too_many_arguments)]
 fn set_default(
     db: &mut vibesql_storage::Database,
     child_table_name: &str,
     fk: &vibesql_catalog::ForeignKeyConstraint,
+    fk_idx: usize,
     parent_key_values: &[SqlValue],
+    in_txn: bool,
+    session_defer: bool,
 ) -> Result<(), ExecutorError> {
     // Get child schema to access column defaults
     let child_schema = db.catalog.get_table(child_table_name).unwrap().clone();
@@ -537,9 +560,13 @@ fn set_default(
     // SET DEFAULT targets. Off-state collapses to scan_live.
     let snapshot = crate::mvcc::read_snapshot(db);
 
-    // Collect indices of rows to update.
+    // Collect (row index, OLD row, NEW row) triples to rewrite. The OLD
+    // row is the current child row; the NEW row carries the FK columns set
+    // to their defaults. We keep OLD so the child's UPDATE triggers see the
+    // correct OLD.* values, matching sqlite3 3.51 (the SET DEFAULT action
+    // is an UPDATE on the child).
     let child_table = db.get_table(child_table_name).unwrap();
-    let mut rows_to_update: Vec<(usize, vibesql_storage::Row)> = Vec::new();
+    let mut rows_to_update: Vec<(usize, vibesql_storage::Row, vibesql_storage::Row)> = Vec::new();
 
     for (idx, child_row) in child_table.scan_visible(&snapshot) {
         let child_fk_values: Vec<SqlValue> =
@@ -560,32 +587,124 @@ fn set_default(
             },
         );
         if matches {
+            let old_row = child_row.clone();
             // Create updated row with FK columns set to default values
-            let mut updated_row = child_row.clone();
+            let mut updated_row = old_row.clone();
             for (i, &fk_col_idx) in fk.column_indices.iter().enumerate() {
                 updated_row.values[fk_col_idx] = default_values[i].clone();
             }
-            rows_to_update.push((idx, updated_row));
+            rows_to_update.push((idx, old_row, updated_row));
         }
     }
 
-    // Phase 1c (Issue #5150 / #5136): stamp xmin on every FK-cascaded
-    // SET DEFAULT new row version. Off-state is a no-op.
+    apply_cascade_child_updates(
+        db,
+        child_table_name,
+        fk,
+        fk_idx,
+        rows_to_update,
+        in_txn,
+        session_defer,
+    )
+}
+
+/// Apply a set of cascade-driven child-row rewrites (SET NULL / SET
+/// DEFAULT), firing the child table's BEFORE/AFTER UPDATE row triggers per
+/// row exactly as sqlite3 3.51 does. This mirrors the UPDATE-side cascade
+/// apply loop in `update/foreign_keys.rs` (#5440 / #5498) so the DELETE-side
+/// SET NULL / SET DEFAULT actions get identical trigger semantics.
+///
+/// For each affected child row:
+///   1. Fire BEFORE UPDATE triggers (OLD = current row, NEW = rewritten row).
+///   2. On `RAISE(IGNORE)` (SkipRow) the child's rewrite is abandoned: the
+///      surviving child keeps its OLD FK value, which references the parent
+///      key that is about to disappear (the parent DELETE is applied after
+///      this cascade returns). That is an orphaned FK reference and must
+///      trip the statement-end FK check (#5465) — immediate FK raises now;
+///      deferred FK queues the surviving OLD row for the COMMIT re-check.
+///   3. Otherwise apply the rewrite via `update_row`, then fire AFTER UPDATE
+///      triggers.
+///
+/// `RAISE(ABORT|FAIL|ROLLBACK)` propagates as `Err` and aborts the statement.
+#[allow(clippy::too_many_arguments)]
+fn apply_cascade_child_updates(
+    db: &mut vibesql_storage::Database,
+    child_table_name: &str,
+    fk: &vibesql_catalog::ForeignKeyConstraint,
+    fk_idx: usize,
+    mut rows_to_update: Vec<(usize, vibesql_storage::Row, vibesql_storage::Row)>,
+    in_txn: bool,
+    session_defer: bool,
+) -> Result<(), ExecutorError> {
+    // Phase 1c (Issue #5150 / #5136): stamp xmin on every FK-cascaded new
+    // row version. Off-state is a no-op.
     let txn_id = db.transaction_id();
-    for (_, updated_row) in rows_to_update.iter_mut() {
-        vibesql_storage::stamp_xmin_for_write(updated_row, txn_id);
-        updated_row.xmax = None;
+    for (_, _old_row, new_row) in rows_to_update.iter_mut() {
+        vibesql_storage::stamp_xmin_for_write(new_row, txn_id);
+        new_row.xmax = None;
     }
 
-    // Now update the rows
-    let child_table_mut = db.get_table_mut(child_table_name).unwrap();
-    for (idx, updated_row) in rows_to_update {
+    // FK cascade fires the child table's BEFORE/AFTER UPDATE row triggers
+    // for every cascaded row, matching sqlite3 3.51 (#5440). sqlite3 fires
+    // these regardless of the `recursive_triggers` pragma; the depth-16
+    // RecursionGuard inside the firing helpers bounds multi-level FK chains.
+    let has_child_update_triggers = db
+        .catalog
+        .get_triggers_for_table(child_table_name, Some(vibesql_ast::TriggerEvent::Update(None)))
+        .next()
+        .is_some();
+
+    for (idx, old_row, new_row) in rows_to_update {
+        // BEFORE UPDATE row triggers on the child (OLD = current row, NEW =
+        // rewritten row).
+        if has_child_update_triggers {
+            let outcome = crate::TriggerFirer::execute_before_triggers(
+                db,
+                child_table_name,
+                vibesql_ast::TriggerEvent::Update(None),
+                Some(&old_row),
+                Some(&new_row),
+            )?;
+            if outcome == crate::TriggerOutcome::SkipRow {
+                // RAISE(IGNORE) abandons this cascade rewrite; the surviving
+                // child still references the parent key being deleted, so it
+                // becomes an orphan that must trip the statement-end FK
+                // check, exactly as sqlite3 3.51 does (#5465).
+                let should_defer = in_txn && (fk.initially_deferred || session_defer);
+                if should_defer {
+                    db.queue_deferred_fk_violation(DeferredFkViolation {
+                        child_table: child_table_name.to_string(),
+                        fk_index: fk_idx,
+                        child_row: old_row.values.to_vec(),
+                        kind: DeferredFkViolationKind::ChildInsertOrUpdate,
+                    });
+                } else {
+                    return Err(ExecutorError::ConstraintViolation(
+                        "FOREIGN KEY constraint failed".to_string(),
+                    ));
+                }
+                continue;
+            }
+        }
+
+        let child_table_mut = db.get_table_mut(child_table_name).unwrap();
         child_table_mut
-            .update_row(idx, updated_row)
+            .update_row(idx, new_row.clone())
             .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+
+        // AFTER UPDATE row triggers fire once this child row is rewritten.
+        if has_child_update_triggers {
+            let _after = crate::TriggerFirer::execute_after_triggers(
+                db,
+                child_table_name,
+                vibesql_ast::TriggerEvent::Update(None),
+                Some(&old_row),
+                Some(&new_row),
+            )?;
+        }
     }
 
-    // Rebuild indexes after update
+    // Rebuild indexes after updates.
     db.rebuild_indexes(child_table_name);
 
     Ok(())

--- a/crates/vibesql-executor/src/tests/fk_cascade_triggers.rs
+++ b/crates/vibesql-executor/src/tests/fk_cascade_triggers.rs
@@ -555,3 +555,230 @@ fn cascade_delete_without_child_triggers_unaffected() {
 
     assert_eq!(query_col(&db, "SELECT id FROM child ORDER BY id"), vec![SqlValue::Integer(20)]);
 }
+
+// ---------------------------------------------------------------------------
+// #5501: ON DELETE SET NULL / SET DEFAULT must fire the child's BEFORE/AFTER
+// UPDATE row triggers (the action is an UPDATE on the child), and a child
+// BEFORE UPDATE RAISE(IGNORE) must skip that child's rewrite — re-using the
+// statement-end orphan FK check from #5465. All expectations verified live
+// against sqlite3 3.51.0.
+// ---------------------------------------------------------------------------
+
+/// Parent DELETE with ON DELETE SET NULL fires the child's BEFORE and AFTER
+/// UPDATE triggers once per rewritten row, with OLD/NEW reflecting the FK
+/// being nulled.
+///
+/// sqlite3 3.51.0 audit for two children referencing parent 1:
+/// ```text
+/// before update 10 old.pid=1 new.pid=NULL
+/// after update 10
+/// before update 11 old.pid=1 new.pid=NULL
+/// after update 11
+/// ```
+#[test]
+fn set_null_fires_child_before_and_after_update_triggers() {
+    let mut db = fresh_db();
+    create_audit(&mut db);
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE SET NULL)",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_bu BEFORE UPDATE ON child BEGIN INSERT INTO audit(msg) VALUES('before update ' || OLD.id || ' old.pid=' || IFNULL(OLD.pid,'NULL') || ' new.pid=' || IFNULL(NEW.pid,'NULL')); END",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_au AFTER UPDATE ON child BEGIN INSERT INTO audit(msg) VALUES('after update ' || OLD.id); END",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO parent VALUES (1)").unwrap();
+    exec(&mut db, "INSERT INTO child VALUES (10, 1), (11, 1)").unwrap();
+
+    exec(&mut db, "DELETE FROM parent WHERE id = 1").unwrap();
+
+    // Verified against sqlite3 3.51.0.
+    assert_eq!(
+        audit_msgs(&db),
+        vec![
+            "before update 10 old.pid=1 new.pid=NULL",
+            "after update 10",
+            "before update 11 old.pid=1 new.pid=NULL",
+            "after update 11",
+        ]
+    );
+    // Both child FK columns nulled out.
+    assert_eq!(
+        query_col(&db, "SELECT IFNULL(pid, -1) FROM child ORDER BY id"),
+        vec![SqlValue::Integer(-1), SqlValue::Integer(-1)]
+    );
+}
+
+/// Parent DELETE with ON DELETE SET DEFAULT fires the child's BEFORE/AFTER
+/// UPDATE triggers with NEW reflecting the column default.
+///
+/// sqlite3 3.51.0: child pid default 99; audit shows `bu 10 new.pid=99` /
+/// `au 10`; final child pid = 99.
+#[test]
+fn set_default_fires_child_before_and_after_update_triggers() {
+    let mut db = fresh_db();
+    create_audit(&mut db);
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER DEFAULT 99 REFERENCES parent(id) ON DELETE SET DEFAULT)",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_bu BEFORE UPDATE ON child BEGIN INSERT INTO audit(msg) VALUES('bu ' || OLD.id || ' new.pid=' || IFNULL(NEW.pid,'NULL')); END",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_au AFTER UPDATE ON child BEGIN INSERT INTO audit(msg) VALUES('au ' || OLD.id); END",
+    )
+    .unwrap();
+    // Parent 99 must exist so the SET DEFAULT rewrite (pid -> 99) is a valid FK.
+    exec(&mut db, "INSERT INTO parent VALUES (1), (99)").unwrap();
+    exec(&mut db, "INSERT INTO child VALUES (10, 1)").unwrap();
+
+    exec(&mut db, "DELETE FROM parent WHERE id = 1").unwrap();
+
+    // Verified against sqlite3 3.51.0.
+    assert_eq!(audit_msgs(&db), vec!["bu 10 new.pid=99", "au 10"]);
+    assert_eq!(query_col(&db, "SELECT pid FROM child"), vec![SqlValue::Integer(99)]);
+}
+
+/// #5501 + #5465: a SET NULL child BEFORE UPDATE RAISE(IGNORE) skips that
+/// child's rewrite, leaving it still pointing at the parent being deleted —
+/// an orphan that trips the immediate statement-end FK check and rolls the
+/// whole statement back.
+///
+/// sqlite3 3.51.0 (auto-commit): `DELETE FROM parent WHERE id=1` -> error
+/// `FOREIGN KEY constraint failed`; parent 1 stays, child 10 keeps pid=1.
+#[test]
+fn set_null_raise_ignore_orphan_trips_statement_end_fk_check() {
+    let mut db = fresh_db();
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE SET NULL)",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_skip BEFORE UPDATE ON child WHEN OLD.id = 10 BEGIN SELECT RAISE(IGNORE); END",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO parent VALUES (1)").unwrap();
+    exec(&mut db, "INSERT INTO child VALUES (10, 1)").unwrap();
+
+    let err = exec(&mut db, "DELETE FROM parent WHERE id = 1").unwrap_err();
+    assert!(
+        err.contains("FOREIGN KEY constraint failed"),
+        "expected FK violation, got: {err}"
+    );
+    assert!(!db.in_transaction(), "auto-commit must not leak an open transaction");
+
+    // sqlite3 3.51.0: statement rolled back — parent and child both intact,
+    // child still references the parent (pid unchanged).
+    assert_eq!(query_col(&db, "SELECT id FROM parent"), vec![SqlValue::Integer(1)]);
+    assert_eq!(query_col(&db, "SELECT pid FROM child"), vec![SqlValue::Integer(1)]);
+}
+
+/// #5501 + #5465: the same RAISE(IGNORE) skip on a SET DEFAULT child trips
+/// the orphan check (the skipped child keeps its OLD FK to the deleted parent).
+#[test]
+fn set_default_raise_ignore_orphan_trips_statement_end_fk_check() {
+    let mut db = fresh_db();
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER DEFAULT 99 REFERENCES parent(id) ON DELETE SET DEFAULT)",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_skip BEFORE UPDATE ON child WHEN OLD.id = 10 BEGIN SELECT RAISE(IGNORE); END",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO parent VALUES (1), (99)").unwrap();
+    exec(&mut db, "INSERT INTO child VALUES (10, 1)").unwrap();
+
+    let err = exec(&mut db, "DELETE FROM parent WHERE id = 1").unwrap_err();
+    assert!(
+        err.contains("FOREIGN KEY constraint failed"),
+        "expected FK violation, got: {err}"
+    );
+    assert!(!db.in_transaction());
+
+    // Statement rolled back: parent 1 and child 10 (pid=1) both intact.
+    assert_eq!(
+        query_col(&db, "SELECT id FROM parent ORDER BY id"),
+        vec![SqlValue::Integer(1), SqlValue::Integer(99)]
+    );
+    assert_eq!(query_col(&db, "SELECT pid FROM child"), vec![SqlValue::Integer(1)]);
+}
+
+/// #5501 + #5465 control: a SET NULL RAISE(IGNORE) under a DEFERRABLE
+/// INITIALLY DEFERRED FK does NOT raise at statement end. The skipped child is
+/// queued and the violation surfaces only at COMMIT, matching sqlite3 3.51.0.
+#[test]
+fn set_null_raise_ignore_deferred_fk_defers_orphan_to_commit() {
+    let mut db = fresh_db();
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED)",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_skip BEFORE UPDATE ON child WHEN OLD.id = 10 BEGIN SELECT RAISE(IGNORE); END",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO parent VALUES (1)").unwrap();
+    exec(&mut db, "INSERT INTO child VALUES (10, 1)").unwrap();
+
+    db.begin_transaction().expect("BEGIN");
+    // Deferred: the DELETE itself succeeds mid-transaction (no immediate error).
+    exec(&mut db, "DELETE FROM parent WHERE id = 1").unwrap();
+    // Mid-txn: parent gone, child 10 survives orphaned with its OLD pid=1.
+    assert_eq!(query_col(&db, "SELECT id FROM parent"), Vec::<SqlValue>::new());
+    assert_eq!(query_col(&db, "SELECT pid FROM child"), vec![SqlValue::Integer(1)]);
+
+    let commit = crate::CommitExecutor::execute(&vibesql_ast::CommitStmt, &mut db);
+    assert!(commit.is_err(), "COMMIT must fail on the deferred orphan");
+    let msg = format!("{:?}", commit.unwrap_err());
+    assert!(
+        msg.contains("FOREIGN KEY constraint failed"),
+        "expected FK violation at COMMIT, got: {msg}"
+    );
+}
+
+/// #5501 sanity: SET NULL with no child triggers still rewrites the FK to
+/// NULL — no behavioral regression on the no-trigger path.
+#[test]
+fn set_null_without_child_triggers_unaffected() {
+    let mut db = fresh_db();
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE SET NULL)",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO parent VALUES (1), (2)").unwrap();
+    exec(&mut db, "INSERT INTO child VALUES (10, 1), (11, 1), (20, 2)").unwrap();
+
+    exec(&mut db, "DELETE FROM parent WHERE id = 1").unwrap();
+
+    // Children of parent 1 nulled; child of parent 2 unchanged.
+    assert_eq!(
+        query_col(&db, "SELECT IFNULL(pid, -1) FROM child ORDER BY id"),
+        vec![SqlValue::Integer(-1), SqlValue::Integer(-1), SqlValue::Integer(2)]
+    );
+}


### PR DESCRIPTION
Closes #5501

## Where SET NULL / SET DEFAULT skipped child trigger firing

In `crates/vibesql-executor/src/delete/integrity.rs`, the DELETE-side FK
cascade handlers `set_null` and `set_default` rewrote each matching child row
directly via `child_table_mut.update_row(idx, updated_row)` **without firing
the child table's BEFORE/AFTER UPDATE row triggers**. Consequences:

- A child `BEFORE UPDATE` trigger never fired, so it could not observe the
  SET NULL / SET DEFAULT rewrite (no audit row in sqlite3-style logging).
- A child `RAISE(IGNORE)` could not intercept the rewrite.
- The statement-end orphan FK check from #5465 / #5498 never applied on this
  path, so a would-be-skipped rewrite could not trip an FK violation.

(The UPDATE-side SET NULL / SET DEFAULT path in `update/foreign_keys.rs`
already routes through a trigger-firing apply loop — this gap was specific to
the DELETE side.)

## The fix

Both `set_null` and `set_default` now collect `(row_idx, OLD row, NEW row)`
triples and funnel them through a new shared helper
`apply_cascade_child_updates`, which mirrors the UPDATE-side cascade apply
loop (`update/foreign_keys.rs`, from #5440 / #5498):

1. Fire `BEFORE UPDATE` triggers (`OLD` = current row, `NEW` = FK set to
   NULL / default).
2. On `RAISE(IGNORE)` (`TriggerOutcome::SkipRow`) the child's rewrite is
   abandoned; the surviving child still references the parent key being
   deleted — an orphan. This **reuses** #5465's machinery: immediate FK
   raises `FOREIGN KEY constraint failed` (statement savepoint rolls the
   statement back); a `DEFERRABLE INITIALLY DEFERRED` / session-deferred FK
   queues the surviving OLD row via `queue_deferred_fk_violation` for the
   COMMIT re-check.
3. Otherwise apply the rewrite via `update_row`, then fire `AFTER UPDATE`
   triggers.

`RAISE(ABORT|FAIL|ROLLBACK)` propagates as `Err` and aborts the statement,
per the merged RAISE per-variant scope. xmin/xmax stamping is preserved
(off-state is a no-op). Changes are confined to `delete/integrity.rs` plus
tests; no fork of the #5465 / #5498 deferred-queue machinery.

## sqlite3 3.51.0 parity (verified live)

- **SET NULL**: `DELETE FROM parent` fires child `BEFORE UPDATE` +
  `AFTER UPDATE` for each rewritten child; audit matches
  (`before update 10 old.pid=1 new.pid=NULL` / `after update 10` ...); child
  FK columns become NULL.
- **SET DEFAULT**: same firing; `NEW.pid` reflects the column default (99);
  child FK becomes the default.
- **RAISE(IGNORE)** on the child BEFORE UPDATE: the child's rewrite is
  skipped; the surviving orphan trips `FOREIGN KEY constraint failed`
  (immediate) and the whole DELETE rolls back (parent + child unchanged).
  Deferred FK: DELETE succeeds mid-txn, COMMIT fails with the same error.

## Tests

Added to `crates/vibesql-executor/src/tests/fk_cascade_triggers.rs`
(asserting via live SELECT of the audit table + final child rows):

- `set_null_fires_child_before_and_after_update_triggers`
- `set_default_fires_child_before_and_after_update_triggers`
- `set_null_raise_ignore_orphan_trips_statement_end_fk_check`
- `set_default_raise_ignore_orphan_trips_statement_end_fk_check`
- `set_null_raise_ignore_deferred_fk_defers_orphan_to_commit`
- `set_null_without_child_triggers_unaffected` (no-trigger regression guard)

## Test evidence / no regression

- `cargo test -p vibesql-executor`: **2757 passed, 0 failed** (lib) plus all
  integration suites green (fkey/trigger/deferred FK suites included).
- TCL pass-delta (branch vs base, identical binaries compared): **0** —
  `fkey1` 19, `fkey2` 806, `fkey3` 26, `fkey5` 53, `fkey6` 33, `trigger1` 20
  on both. No regression; the SET NULL/DEFAULT-fires-child-trigger scenario
  isn't represented in the existing TCL fkey/trigger files, so no pass count
  moves — the new behavior is covered by the Rust tests above.
- No regression to `fkey*.test` / `trigger*.test` / #5465 / #5498 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)