### PR TITLE
fix(trigger): resolve NEW.rowid / OLD.rowid (oid/_rowid_) in trigger bodies

### DIFF
--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -537,13 +537,26 @@ impl DeleteExecutor {
                     continue;
                 }
 
+                // Stamp the OLD row with its rowid so `OLD.rowid` (and the
+                // `oid` / `_rowid_` aliases) resolve in the trigger body (#5485).
+                // `scan()` returns the raw stored rows, which may not carry
+                // `row_id`; the physical index is the source of truth (rowid =
+                // idx + 1), and an explicit stored row_id is preserved.
+                let old_row_for_triggers = {
+                    let mut r = row.clone();
+                    if r.row_id.is_none() {
+                        r.row_id = Some((*idx + 1) as u64);
+                    }
+                    r
+                };
+
                 // BEFORE(R): a RAISE(IGNORE) drops this row entirely (skip it,
                 // continue with the remaining rows).
                 let before_outcome = crate::TriggerFirer::execute_before_triggers(
                     database,
                     table_name,
                     vibesql_ast::TriggerEvent::Delete,
-                    Some(row),
+                    Some(&old_row_for_triggers),
                     None,
                 )?;
                 if before_outcome == crate::TriggerOutcome::SkipRow {
@@ -593,7 +606,7 @@ impl DeleteExecutor {
                     database,
                     table_name,
                     vibesql_ast::TriggerEvent::Delete,
-                    Some(row),
+                    Some(&old_row_for_triggers),
                     None,
                 )?;
             }

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -1267,6 +1267,19 @@ fn execute_insert_internal(
             // (it hid a row SQLite keeps — visible only as a bitmap tombstone in
             // raw `Table::scan()`, missing from any live SELECT). See #5474.
             if has_insert_triggers {
+                // Stamp the NEW row with its allocated rowid so `NEW.rowid` (and
+                // the `oid` / `_rowid_` aliases) resolve in the AFTER INSERT
+                // trigger body (#5485). For an explicit `INSERT INTO t(rowid,...)`
+                // the row already carries `row_id`; for an auto-allocated rowid
+                // the row was created with `row_id == None`, and the actual rowid
+                // is `rowid_to_use` (physical_row_count_before + 1).
+                let after_row = {
+                    let mut r = row.clone();
+                    if r.row_id.is_none() {
+                        r.row_id = Some(rowid_to_use);
+                    }
+                    r
+                };
                 // A `TriggerOutcome::SkipRow` (RAISE(IGNORE) in an AFTER trigger)
                 // has no SQLite-observable effect here: the row is already
                 // inserted and RAISE(IGNORE) only abandons the rest of the
@@ -1277,7 +1290,7 @@ fn execute_insert_internal(
                     table_name,
                     vibesql_ast::TriggerEvent::Insert,
                     None,
-                    Some(&row),
+                    Some(&after_row),
                 )?;
             }
 

--- a/crates/vibesql-executor/src/tests/triggers/pseudo_vars.rs
+++ b/crates/vibesql-executor/src/tests/triggers/pseudo_vars.rs
@@ -342,3 +342,204 @@ fn test_old_and_new_into_ipk_column_in_update_trigger() {
     // NEW.v (200) becomes the audit IPK/rowid; OLD.v (100) is the value column.
     assert_eq!(audit_rows(&db), vec![(200, 100, 200)]);
 }
+
+// ============================================================================
+// #5485: NEW.rowid / OLD.rowid (and the oid / _rowid_ aliases) in trigger bodies
+//
+// All expected values verified against sqlite3 3.51.0. These triggers log the
+// firing row's rowid into a text `log` table and assert via a LIVE SELECT.
+// ============================================================================
+
+/// Read `SELECT t FROM log ORDER BY rowid` as a Vec<String>.
+fn log_text(db: &Database) -> Vec<String> {
+    let stmt =
+        vibesql_parser::Parser::parse_sql("SELECT t FROM log ORDER BY rowid;").unwrap();
+    let result = match stmt {
+        vibesql_ast::Statement::Select(s) => {
+            SelectExecutor::new(db).execute_with_columns(&s).unwrap()
+        }
+        _ => panic!("Expected Select"),
+    };
+    result
+        .rows
+        .iter()
+        .map(|r| match &r.values[0] {
+            vibesql_types::SqlValue::Varchar(s) => s.to_string(),
+            other => panic!("expected text, got {:?}", other),
+        })
+        .collect()
+}
+
+/// AFTER INSERT NEW.rowid yields the allocated rowid (sqlite3: `1 integer`).
+/// This is the exact repro from issue #5485.
+#[test]
+fn test_new_rowid_in_after_insert_trigger() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE log (t TEXT);");
+    exec(&mut db, "CREATE TABLE t4 (a TEXT, b INTEGER, c REAL);");
+    exec(
+        &mut db,
+        "CREATE TRIGGER t4ai AFTER INSERT ON t4 \
+         BEGIN INSERT INTO log VALUES (new.rowid || ' ' || typeof(new.rowid)); END;",
+    );
+    exec(&mut db, "INSERT INTO t4 VALUES (8, 8, 8);");
+    assert_eq!(log_text(&db), vec!["1 integer".to_string()]);
+}
+
+/// BEFORE INSERT with an auto-allocated rowid reports new.rowid as -1, then
+/// AFTER INSERT reports the real rowid (sqlite3: `B:-1`, `A:1`). Matches
+/// triggerC-4.1.2 case 2.
+#[test]
+fn test_new_rowid_before_vs_after_insert_auto() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE log (t TEXT);");
+    exec(&mut db, "CREATE TABLE t4 (a TEXT, b INTEGER, c REAL);");
+    exec(
+        &mut db,
+        "CREATE TRIGGER t4bi BEFORE INSERT ON t4 \
+         BEGIN INSERT INTO log VALUES ('B:' || new.rowid); END;",
+    );
+    exec(
+        &mut db,
+        "CREATE TRIGGER t4ai AFTER INSERT ON t4 \
+         BEGIN INSERT INTO log VALUES ('A:' || new.rowid); END;",
+    );
+    exec(&mut db, "INSERT INTO t4 VALUES ('1', '1', '1');");
+    assert_eq!(log_text(&db), vec!["B:-1".to_string(), "A:1".to_string()]);
+}
+
+/// An explicit `INSERT INTO t4(rowid, ...)` makes new.rowid the explicit value
+/// in BOTH the BEFORE and AFTER INSERT triggers (sqlite3: `B:45`, `A:45`).
+#[test]
+fn test_new_rowid_explicit_before_and_after_insert() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE log (t TEXT);");
+    exec(&mut db, "CREATE TABLE t4 (a TEXT, b INTEGER, c REAL);");
+    exec(
+        &mut db,
+        "CREATE TRIGGER t4bi BEFORE INSERT ON t4 \
+         BEGIN INSERT INTO log VALUES ('B:' || new.rowid); END;",
+    );
+    exec(
+        &mut db,
+        "CREATE TRIGGER t4ai AFTER INSERT ON t4 \
+         BEGIN INSERT INTO log VALUES ('A:' || new.rowid); END;",
+    );
+    exec(&mut db, "INSERT INTO t4(rowid, a, b, c) VALUES (45, 45, 45, 45);");
+    assert_eq!(log_text(&db), vec!["B:45".to_string(), "A:45".to_string()]);
+}
+
+/// OLD.rowid resolves in BEFORE and AFTER DELETE triggers (sqlite3: `B:1`, `A:1`).
+#[test]
+fn test_old_rowid_in_delete_triggers() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE log (t TEXT);");
+    exec(&mut db, "CREATE TABLE t4 (a TEXT, b INTEGER, c REAL);");
+    exec(&mut db, "INSERT INTO t4 VALUES ('a', 'b', 'c');");
+    exec(
+        &mut db,
+        "CREATE TRIGGER t4bd BEFORE DELETE ON t4 \
+         BEGIN INSERT INTO log VALUES ('B:' || old.rowid); END;",
+    );
+    exec(
+        &mut db,
+        "CREATE TRIGGER t4ad AFTER DELETE ON t4 \
+         BEGIN INSERT INTO log VALUES ('A:' || old.rowid); END;",
+    );
+    exec(&mut db, "DELETE FROM t4;");
+    assert_eq!(log_text(&db), vec!["B:1".to_string(), "A:1".to_string()]);
+}
+
+/// OLD.rowid and NEW.rowid resolve in BEFORE and AFTER UPDATE triggers; with no
+/// rowid change both equal the row's rowid (sqlite3: `B:1/1`, `A:1/1`).
+#[test]
+fn test_old_and_new_rowid_in_update_triggers() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE log (t TEXT);");
+    exec(&mut db, "CREATE TABLE t4 (a TEXT, b INTEGER, c REAL);");
+    exec(&mut db, "INSERT INTO t4 VALUES ('a', 1, 1.0);");
+    exec(
+        &mut db,
+        "CREATE TRIGGER t4bu BEFORE UPDATE ON t4 \
+         BEGIN INSERT INTO log VALUES ('B:' || old.rowid || '/' || new.rowid); END;",
+    );
+    exec(
+        &mut db,
+        "CREATE TRIGGER t4au AFTER UPDATE ON t4 \
+         BEGIN INSERT INTO log VALUES ('A:' || old.rowid || '/' || new.rowid); END;",
+    );
+    exec(&mut db, "UPDATE t4 SET a = 'z';");
+    assert_eq!(log_text(&db), vec!["B:1/1".to_string(), "A:1/1".to_string()]);
+}
+
+/// The `oid` and `_rowid_` aliases behave like `rowid` (sqlite3: `1|1`).
+#[test]
+fn test_rowid_aliases_oid_and_underscore_rowid() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE log (t TEXT);");
+    exec(&mut db, "CREATE TABLE t4 (a TEXT, b INTEGER, c REAL);");
+    exec(
+        &mut db,
+        "CREATE TRIGGER t4ai AFTER INSERT ON t4 \
+         BEGIN INSERT INTO log VALUES (new.oid || '|' || new._rowid_); END;",
+    );
+    exec(&mut db, "INSERT INTO t4 VALUES ('a', 'b', 'c');");
+    assert_eq!(log_text(&db), vec!["1|1".to_string()]);
+}
+
+/// A *real* column literally named `rowid` shadows the pseudo-column: NEW.rowid
+/// resolves to that column's stored value, not the row's rowid (sqlite3: `hello`).
+/// Mirrors triggerD-1.x.
+#[test]
+fn test_real_rowid_column_shadows_pseudo_column() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE log (t TEXT);");
+    exec(&mut db, "CREATE TABLE t (rowid TEXT, b TEXT);");
+    exec(
+        &mut db,
+        "CREATE TRIGGER tai AFTER INSERT ON t \
+         BEGIN INSERT INTO log VALUES (new.rowid); END;",
+    );
+    exec(&mut db, "INSERT INTO t VALUES ('hello', 'y');");
+    assert_eq!(log_text(&db), vec!["hello".to_string()]);
+}
+
+/// NEW.rowid on a WITHOUT ROWID table must error — WITHOUT ROWID tables have no
+/// rowid pseudo-column (sqlite3: `no such column: new.rowid`).
+#[test]
+fn test_new_rowid_on_without_rowid_table_errors() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE log (t TEXT);");
+    exec(&mut db, "CREATE TABLE w (a TEXT PRIMARY KEY, b TEXT) WITHOUT ROWID;");
+    exec(
+        &mut db,
+        "CREATE TRIGGER wai AFTER INSERT ON w \
+         BEGIN INSERT INTO log VALUES (new.rowid); END;",
+    );
+    let stmt = vibesql_parser::Parser::parse_sql("INSERT INTO w VALUES ('x', 'y');").unwrap();
+    let err = match stmt {
+        vibesql_ast::Statement::Insert(s) => InsertExecutor::execute(&mut db, &s),
+        _ => panic!("Expected Insert"),
+    };
+    assert!(
+        err.is_err(),
+        "NEW.rowid on a WITHOUT ROWID table should error, got {:?}",
+        err
+    );
+}
+
+/// On a table with an INTEGER PRIMARY KEY (rowid alias), NEW.rowid returns the
+/// IPK column value (sqlite3: NEW.rowid == NEW.id).
+#[test]
+fn test_new_rowid_uses_integer_primary_key_alias() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE log (t TEXT);");
+    exec(&mut db, "CREATE TABLE t (id INTEGER PRIMARY KEY, b TEXT);");
+    exec(
+        &mut db,
+        "CREATE TRIGGER tai AFTER INSERT ON t \
+         BEGIN INSERT INTO log VALUES (new.rowid || '/' || new.id); END;",
+    );
+    exec(&mut db, "INSERT INTO t VALUES (42, 'x');");
+    assert_eq!(log_text(&db), vec!["42/42".to_string()]);
+}

--- a/crates/vibesql-executor/src/trigger_execution.rs
+++ b/crates/vibesql-executor/src/trigger_execution.rs
@@ -59,6 +59,12 @@ pub struct TriggerContext<'a> {
     pub new_row: Option<&'a Row>,
     /// Table schema for column lookups
     pub table_schema: &'a TableSchema,
+    /// True when the trigger target is a VIEW (INSTEAD OF trigger). Views have
+    /// no rowid, so `NEW.rowid` / `OLD.rowid` must error there — matching both
+    /// sqlite3 and the view-rowid rejection from #5492. The pseudo-schema built
+    /// from a view definition does not carry `without_rowid`, so we track the
+    /// view-ness explicitly rather than inferring it from the schema.
+    pub is_view: bool,
 }
 
 impl<'a> TriggerContext<'a> {
@@ -93,24 +99,62 @@ impl<'a> TriggerContext<'a> {
             })?,
         };
 
-        // Find column index in schema
-        let col_idx =
-            self.table_schema.columns.iter().position(|c| c.name == column).ok_or_else(|| {
-                ExecutorError::ColumnNotFound {
-                    column_name: column.to_string(),
-                    table_name: self.table_schema.name.clone(),
-                    searched_tables: vec![self.table_schema.name.clone()],
-                    available_columns: self
-                        .table_schema
-                        .columns
-                        .iter()
-                        .map(|c| c.name.clone())
-                        .collect(),
-                }
-            })?;
+        // Find column index in schema. A *real* column always wins over the
+        // rowid pseudo-column — including a real column literally named
+        // `rowid` / `oid` / `_rowid_` (triggerD-1.x). Only when no real column
+        // matches do we fall back to the rowid pseudo-column below.
+        // `get_column_index` matches the case-insensitive resolution the column
+        // evaluator uses (the parser uppercases unquoted identifiers).
+        if let Some(col_idx) = self.table_schema.get_column_index(column) {
+            return Ok(row.values[col_idx].clone());
+        }
 
-        // Return the value
-        Ok(row.values[col_idx].clone())
+        // SQLite compatibility: resolve the ROWID pseudo-column on the firing
+        // OLD/NEW row. `rowid`, `_rowid_`, and `oid` are aliases that yield the
+        // row's unique identifier (#5485). This mirrors the rowid resolution in
+        // the column evaluator (`evaluator/expressions/eval.rs`): real columns
+        // already took precedence above.
+        let column_lower = column.to_lowercase();
+        if column_lower == "rowid" || column_lower == "_rowid_" || column_lower == "oid" {
+            // A VIEW has no rowid. An INSTEAD OF trigger fires on a view, so
+            // `NEW.rowid` / `OLD.rowid` there must error — consistent with the
+            // view-rowid rejection in #5492 (no such column: rowid).
+            //
+            // WITHOUT ROWID tables likewise do not expose the rowid
+            // pseudo-column (Issue #4953): error to match sqlite3.
+            if !self.is_view && !self.table_schema.without_rowid {
+                // INTEGER PRIMARY KEY acts as a rowid alias: its column value IS
+                // the rowid, so return that column's value (#4536).
+                if let Some(ipk_col_idx) = self.table_schema.rowid_alias_column {
+                    return row
+                        .values
+                        .get(ipk_col_idx)
+                        .cloned()
+                        .ok_or(ExecutorError::ColumnIndexOutOfBounds { index: ipk_col_idx });
+                }
+
+                // Otherwise return the firing row's rowid. For a row that already
+                // has a rowid (AFTER INSERT, BEFORE/AFTER UPDATE/DELETE, or an
+                // explicit `INSERT INTO t(rowid,...)`), that's `row.row_id`. For a
+                // BEFORE INSERT on an auto-allocated rowid the row is not yet
+                // written and SQLite reports `new.rowid` as -1 (triggerC-4.1.2):
+                // mirror that sentinel here.
+                return Ok(SqlValue::Bigint(row.row_id.map(|id| id as i64).unwrap_or(-1)));
+            }
+        }
+
+        // Not a real column and not a resolvable rowid pseudo-column.
+        Err(ExecutorError::ColumnNotFound {
+            column_name: column.to_string(),
+            table_name: self.table_schema.name.clone(),
+            searched_tables: vec![self.table_schema.name.clone()],
+            available_columns: self
+                .table_schema
+                .columns
+                .iter()
+                .map(|c| c.name.clone())
+                .collect(),
+        })
     }
 }
 
@@ -270,6 +314,9 @@ impl TriggerFirer {
         // mirroring `execute_trigger_action`. Without this fallback, an INSTEAD
         // OF trigger carrying a WHEN clause always failed with TableNotFound.
         let schema = Self::resolve_trigger_schema(db, table_name)?;
+        // INSTEAD OF triggers fire on a view (not a table); the rowid
+        // pseudo-column is unavailable there (#5485 / #5492).
+        let is_view = db.catalog.get_table(table_name).is_none();
 
         // Use NEW row as the base row for evaluation (prefer NEW over OLD)
         // The trigger context will handle OLD/NEW pseudo-variable references
@@ -280,7 +327,7 @@ impl TriggerFirer {
         })?;
 
         // Create trigger context for OLD/NEW pseudo-variable resolution
-        let trigger_context = TriggerContext { old_row, new_row, table_schema: &schema };
+        let trigger_context = TriggerContext { old_row, new_row, table_schema: &schema, is_view };
 
         // Create evaluator with trigger context
         let evaluator =
@@ -324,9 +371,12 @@ impl TriggerFirer {
         // Get table schema for trigger context.
         // For INSTEAD OF triggers on views, build schema from the view definition.
         let schema = Self::resolve_trigger_schema(db, &trigger.table_name)?;
+        // INSTEAD OF triggers fire on a view (not a table); the rowid
+        // pseudo-column is unavailable there (#5485 / #5492).
+        let is_view = db.catalog.get_table(&trigger.table_name).is_none();
 
         // Create trigger context for OLD/NEW pseudo-variable resolution
-        let trigger_context = TriggerContext { old_row, new_row, table_schema: &schema };
+        let trigger_context = TriggerContext { old_row, new_row, table_schema: &schema, is_view };
 
         // Execute each statement in the trigger body with trigger context.
         // A RAISE(IGNORE) inside any statement abandons the rest of this


### PR DESCRIPTION
Closes #5485

## Where NEW/OLD.rowid was unresolvable
Inside a trigger body, `NEW.rowid` / `OLD.rowid` (and the `oid` / `_rowid_`
aliases) failed with `no such column: rowid`. Two gaps:

1. `TriggerContext::resolve_pseudo_var` (`crates/vibesql-executor/src/trigger_execution.rs`)
   only looked at `table_schema.columns` — no rowid fallback to the firing row.
2. The OLD/NEW rows handed to the firing sites did not reliably carry `row_id`:
   - the DELETE scan path (`delete/executor.rs`) cloned the scanned row from
     `Table::scan()` (raw rows, no `row_id`);
   - the AFTER INSERT path (`insert/execution.rs`) fired with the `make_row`
     value whose `row_id` was `None` for an auto-allocated rowid.

## The fix
- `resolve_pseudo_var` now mirrors the column evaluator's rowid resolution:
  - a **real column** (incl. one literally named `rowid` / `oid` / `_rowid_`)
    shadows the pseudo-column (case-insensitive via `get_column_index`);
  - a **VIEW** (INSTEAD OF trigger) errors — there is no rowid. `TriggerContext`
    carries a new `is_view` flag (a view's pseudo-schema can't be told apart by
    `without_rowid`), set from `catalog.get_table(...).is_none()`. This keeps the
    #5492 view-rowid rejection intact;
  - a **WITHOUT ROWID** table errors (`without_rowid`);
  - an **INTEGER PRIMARY KEY** returns its column value (rowid alias);
  - otherwise return `row.row_id`; a BEFORE INSERT on an auto-allocated rowid
    has no row yet, so it reports `-1` (the sqlite3 sentinel).
- DELETE stamps `OLD.row_id` (`idx + 1`, preserving an explicit stored row_id)
  before firing BEFORE/AFTER DELETE triggers.
- AFTER INSERT stamps `NEW.row_id` with the allocated rowid (`rowid_to_use`).

Changes are confined to the trigger-context evaluator + the DELETE/INSERT
trigger-firing sites; the upsert (#5490) and FK-cascade (#5501) paths are
untouched.

## sqlite3 3.51.0 parity (verified)
| case | sqlite3 | vibesql |
|------|---------|---------|
| AFTER INSERT `new.rowid` | `1` | `1` |
| BEFORE INSERT auto / AFTER | `-1` / `1` | `-1` / `1` |
| explicit `INSERT(rowid,...)` BEFORE/AFTER | `45` / `45` | `45` / `45` |
| DELETE `old.rowid` BEFORE/AFTER | `1` / `1` | `1` / `1` |
| UPDATE `old.rowid`/`new.rowid` | `1`/`1` | `1`/`1` |
| `oid` / `_rowid_` aliases | `1` | `1` |
| real column named `rowid` | column value | column value |
| WITHOUT ROWID `new.rowid` | error | error |
| INSTEAD OF view `new.rowid` | error | error |
| INTEGER PRIMARY KEY `new.rowid` | IPK value | IPK value |

## triggerC / triggerD delta
- triggerC: **61 -> 66** passed (4.1.2, 4.1.3, 4.1.6, 4.1.7, 7.2 now pass).
- triggerD: **3 -> 6** passed (2.2, 2.3, 2.4 now pass — the rowid pseudo-column tests).

Residual triggerC/D failures are orthogonal: recursion-error message text
(3.1.2), rowid affinity coercion / datatype mismatch (4.1.4), `UPDATE ... SET
rowid` cascade (#5517: triggerC-4.1.5/4.1.8/4.1.9, triggerD-1.3/1.4), and
`CREATE TEMP TRIGGER` parsing (triggerD-3.1/3.2).

## No #5492 regression
INSTEAD OF view trigger `NEW.rowid` still errors (`Column 'rowid' not found`),
verified manually against the release binary and via `view.test` (24/0,
unchanged).

## Tests
- `crates/vibesql-executor/src/tests/triggers/pseudo_vars.rs`: 8 new tests
  (AFTER INSERT rowid; BEFORE/AFTER auto -1/1; explicit rowid; DELETE old.rowid;
  UPDATE old/new.rowid; oid/_rowid_ aliases; real-column shadow; WITHOUT ROWID
  error; IPK alias) — all assert via live SELECT against an audit/log table.
- `cargo test -p vibesql-executor`: green (4312 passed, 0 failed).
- No regression: trigger1 (20/50), trigger2 (12/0), trigger3 (14/3),
  triggerA (17/0), triggerB (197/5), view (24/0) — identical before/after.

## Follow-ons
- `UPDATE ... SET rowid` on base tables + trigger interaction (#5517).
- rowid affinity coercion on INSERT (triggerC-4.1.4 datatype mismatch).
- recursion-limit error message text alignment (triggerC-3.1.2).
- `CREATE TEMP TRIGGER` parser support (triggerD-3.1/3.2).