### PR TITLE
fix(executor): UPDATE OR REPLACE/IGNORE conflict resolution + DELETE triggers on WITHOUT ROWID (triggerF)

### DIFF
--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -112,6 +112,11 @@ pub(super) fn execute_internal(
         && !has_expression_indexes
         // RETURNING needs the two-phase path so NEW rows can be captured
         && stmt.returning.is_none()
+        // OR REPLACE / OR IGNORE need the two-phase path to resolve conflicts:
+        // REPLACE deletes the conflicting row (firing its DELETE triggers) and
+        // IGNORE skips the row. The fast path has no conflict-resolution logic,
+        // so it would wrongly raise a PK/UNIQUE violation (issue #5490).
+        && stmt.conflict_clause.is_none()
     {
         if let Some(result) = fast_path::try_fast_path_update(stmt, database, schema)? {
             // Invalidate columnar cache after fast path update
@@ -481,10 +486,53 @@ pub(super) fn execute_internal(
 
         if !rows_to_delete_for_replace.is_empty() {
             // Get rows for index cleanup
-            let rows_for_index: Vec<(usize, Row)> = rows_to_delete_for_replace
+            let mut rows_for_index: Vec<(usize, Row)> = rows_to_delete_for_replace
                 .iter()
                 .filter_map(|&idx| table.scan().get(idx).map(|r| (idx, r.clone())))
                 .collect();
+
+            // Issue #5490: UPDATE OR REPLACE removes the conflicting row(s), and
+            // SQLite fires that row's DELETE triggers (BEFORE before removal,
+            // AFTER once it is gone) — matching the INSERT OR REPLACE path
+            // (`insert/replace.rs`). Without this, a WITHOUT ROWID `UPDATE OR
+            // REPLACE` that resolves a PRIMARY KEY conflict silently dropped the
+            // replaced row's DELETE trigger (triggerF.test 1.2/1.3/1.4).
+            let has_delete_triggers = database
+                .catalog
+                .get_triggers_for_table(table_name, Some(vibesql_ast::TriggerEvent::Delete))
+                .next()
+                .is_some();
+
+            // Fire BEFORE DELETE triggers for each conflicting row before it is
+            // removed. A RAISE(IGNORE) in a BEFORE DELETE trigger abandons that
+            // row's deletion (#5418 parity): drop it from the to-delete set so
+            // the conflicting row survives. The subsequent UPDATE then applies
+            // against the still-conflicting state; if a real conflict remains,
+            // `update_row_selective` surfaces a PK/UNIQUE error, matching
+            // sqlite3 3.51 with recursive_triggers=ON.
+            if has_delete_triggers {
+                let mut kept = Vec::with_capacity(rows_for_index.len());
+                for (idx, row) in rows_for_index {
+                    let outcome = crate::TriggerFirer::execute_before_triggers(
+                        database,
+                        table_name,
+                        vibesql_ast::TriggerEvent::Delete,
+                        Some(&row),
+                        None,
+                    )?;
+                    if outcome != crate::TriggerOutcome::SkipRow {
+                        kept.push((idx, row));
+                    }
+                }
+                rows_for_index = kept;
+
+                // Keep `rows_to_delete_for_replace` in sync with the rows that
+                // survived BEFORE-trigger RAISE(IGNORE) so the deletion below
+                // only tombstones the rows we actually removed.
+                let surviving: HashSet<usize> =
+                    rows_for_index.iter().map(|(idx, _)| *idx).collect();
+                rows_to_delete_for_replace.retain(|idx| surviving.contains(idx));
+            }
 
             // Update indexes before deletion
             let rows_refs: Vec<(usize, &Row)> =
@@ -544,10 +592,48 @@ pub(super) fn execute_internal(
                 database.adjust_indexes_after_delete(table_name, &rows_to_delete_for_replace);
             }
 
+            // Invalidate the database-level columnar cache since rows were
+            // removed (the table-level cache is handled by delete_by_indices).
+            if delete_result.deleted_count > 0 {
+                database.invalidate_columnar_cache(table_name);
+            }
+
+            // Fire AFTER DELETE triggers for each removed conflicting row, now
+            // that it is gone (issue #5490). The trigger body observes the
+            // post-delete table state — e.g. triggerF.test's
+            // `(SELECT count(*) FROM t1)` — matching sqlite3. A RAISE(IGNORE)
+            // here cannot un-delete the row (sqlite3 3.51 keeps it deleted), so
+            // the outcome is a no-op.
+            if has_delete_triggers {
+                for (_, row) in &rows_for_index {
+                    let _after_outcome = crate::TriggerFirer::execute_after_triggers(
+                        database,
+                        table_name,
+                        vibesql_ast::TriggerEvent::Delete,
+                        Some(row),
+                        None,
+                    )?;
+                }
+            }
+
             // Re-fetch table for the remaining operations
             let _table = database
                 .get_table(table_name)
                 .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
+
+            // Issue #5490: deleting the conflicting row(s) above may have
+            // COMPACTED the table (the storage layer compacts once the
+            // tombstone ratio crosses its threshold — and a prior tombstone
+            // from an earlier statement makes that easy to reach even when this
+            // statement only removes one row). Compaction shifts every live
+            // row's physical index, leaving the `PendingUpdate::row_index`
+            // values captured before the delete stale — the apply phase would
+            // then write to the wrong slot or a freed slot ("Column index out
+            // of bounds"). Re-resolve each update's physical index from the
+            // current table state by matching its OLD row (unique by PK).
+            // Previously this drift was masked only by the CLI/persistence
+            // reload between statements; pure in-memory sessions hit it.
+            remap_update_indices_after_compaction(database, table_name, &mut updates)?;
         }
     }
 
@@ -787,6 +873,46 @@ pub(super) fn execute_internal(
     };
 
     Ok((update_count, returning))
+}
+
+/// Re-resolve each pending update's physical `row_index` against the current
+/// table state after a REPLACE-conflict delete (issue #5490).
+///
+/// Deleting the conflicting row(s) can compact the table, which shifts every
+/// live row's physical index and invalidates the `row_index` captured when the
+/// updates were collected. We locate each update's row by its OLD row value
+/// (unique by primary key for the REPLACE path) among the live rows. Updates
+/// whose old row can no longer be found — e.g. it was itself the conflicting
+/// row removed by a sibling update — are dropped.
+fn remap_update_indices_after_compaction(
+    database: &Database,
+    table_name: &str,
+    updates: &mut Vec<PendingUpdate>,
+) -> Result<(), ExecutorError> {
+    let table = database
+        .get_table(table_name)
+        .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+
+    // Build a value -> physical index map over the live rows. Keyed on the full
+    // row values so it works for both WITHOUT ROWID (PK-keyed) and ROWID tables.
+    let mut live_index: std::collections::HashMap<&[SqlValue], usize> =
+        std::collections::HashMap::new();
+    for (idx, row) in table.scan_live() {
+        live_index.entry(row.values.as_ref()).or_insert(idx);
+    }
+
+    updates.retain_mut(|u| {
+        if let Some(&idx) = live_index.get(u.old_row.values.as_ref()) {
+            u.row_index = idx;
+            true
+        } else {
+            // The old row is gone (already removed as a conflicting row). Drop
+            // this update; there is nothing left to modify.
+            false
+        }
+    });
+
+    Ok(())
 }
 
 /// Validate only NOT NULL and CHECK constraints (for REPLACE conflict resolution)
@@ -1514,7 +1640,7 @@ fn execute_update_from(
 
             if !rows_to_delete_for_replace.is_empty() {
                 // Get rows for index cleanup (immutable borrow scope).
-                let rows_for_index: Vec<(usize, Row)> = {
+                let mut rows_for_index: Vec<(usize, Row)> = {
                     let table = database
                         .get_table(table_name)
                         .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
@@ -1523,6 +1649,36 @@ fn execute_update_from(
                         .filter_map(|&idx| table.scan().get(idx).map(|r| (idx, r.clone())))
                         .collect()
                 };
+
+                // Issue #5490: UPDATE OR REPLACE ... FROM removes the conflicting
+                // row(s) too, so fire the replaced row's DELETE triggers (BEFORE
+                // before removal, AFTER once gone) — matching the non-FROM path
+                // above and INSERT OR REPLACE.
+                let has_delete_triggers = database
+                    .catalog
+                    .get_triggers_for_table(table_name, Some(vibesql_ast::TriggerEvent::Delete))
+                    .next()
+                    .is_some();
+
+                if has_delete_triggers {
+                    let mut kept = Vec::with_capacity(rows_for_index.len());
+                    for (idx, row) in rows_for_index {
+                        let outcome = crate::TriggerFirer::execute_before_triggers(
+                            database,
+                            table_name,
+                            vibesql_ast::TriggerEvent::Delete,
+                            Some(&row),
+                            None,
+                        )?;
+                        if outcome != crate::TriggerOutcome::SkipRow {
+                            kept.push((idx, row));
+                        }
+                    }
+                    rows_for_index = kept;
+                    let surviving: HashSet<usize> =
+                        rows_for_index.iter().map(|(idx, _)| *idx).collect();
+                    rows_to_delete_for_replace.retain(|idx| surviving.contains(idx));
+                }
 
                 // Update indexes before deletion
                 let rows_refs: Vec<(usize, &Row)> =
@@ -1577,6 +1733,28 @@ fn execute_update_from(
                 } else {
                     database.adjust_indexes_after_delete(table_name, &rows_to_delete_for_replace);
                 }
+
+                if delete_result.deleted_count > 0 {
+                    database.invalidate_columnar_cache(table_name);
+                }
+
+                // Fire AFTER DELETE triggers now that the conflicting rows are
+                // gone (issue #5490).
+                if has_delete_triggers {
+                    for (_, row) in &rows_for_index {
+                        let _after_outcome = crate::TriggerFirer::execute_after_triggers(
+                            database,
+                            table_name,
+                            vibesql_ast::TriggerEvent::Delete,
+                            Some(row),
+                            None,
+                        )?;
+                    }
+                }
+
+                // Re-resolve stale update indices after a possibly-compacting
+                // REPLACE-conflict delete (issue #5490 — see the non-FROM path).
+                remap_update_indices_after_compaction(database, table_name, &mut updates)?;
             }
         }
     } else {

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -23,8 +23,9 @@ use super::{
     foreign_keys::ForeignKeyValidator,
     from_clause::{apply_update_from_matches, execute_update_from_join},
     index_sync::{
-        find_conflicting_rows_for_update, resolve_cross_update_conflicts_for_replace,
-        validate_cross_update_uniqueness, validate_post_statement_uniqueness,
+        detect_surviving_replace_conflict, find_conflicting_rows_for_update,
+        resolve_cross_update_conflicts_for_replace, validate_cross_update_uniqueness,
+        validate_post_statement_uniqueness,
     },
     row_selector::RowSelector,
     triggers,
@@ -506,12 +507,13 @@ pub(super) fn execute_internal(
             // Fire BEFORE DELETE triggers for each conflicting row before it is
             // removed. A RAISE(IGNORE) in a BEFORE DELETE trigger abandons that
             // row's deletion (#5418 parity): drop it from the to-delete set so
-            // the conflicting row survives. The subsequent UPDATE then applies
-            // against the still-conflicting state; if a real conflict remains,
-            // `update_row_selective` surfaces a PK/UNIQUE error, matching
-            // sqlite3 3.51 with recursive_triggers=ON.
+            // the conflicting row survives.
             if has_delete_triggers {
                 let mut kept = Vec::with_capacity(rows_for_index.len());
+                // Rows whose deletion was abandoned by a BEFORE DELETE
+                // RAISE(IGNORE) — they stay live and may still collide with the
+                // pending UPDATE's NEW row.
+                let mut abandoned: Vec<(usize, Row)> = Vec::new();
                 for (idx, row) in rows_for_index {
                     let outcome = crate::TriggerFirer::execute_before_triggers(
                         database,
@@ -522,6 +524,8 @@ pub(super) fn execute_internal(
                     )?;
                     if outcome != crate::TriggerOutcome::SkipRow {
                         kept.push((idx, row));
+                    } else {
+                        abandoned.push((idx, row));
                     }
                 }
                 rows_for_index = kept;
@@ -532,6 +536,22 @@ pub(super) fn execute_internal(
                 let surviving: HashSet<usize> =
                     rows_for_index.iter().map(|(idx, _)| *idx).collect();
                 rows_to_delete_for_replace.retain(|idx| surviving.contains(idx));
+
+                // Issue #5490 (doctor): a BEFORE DELETE RAISE(IGNORE) that
+                // abandoned a conflict-row deletion leaves the conflicting row
+                // live. If a pending update's NEW row would land on the same
+                // PK/UNIQUE key, applying it would create a duplicate key
+                // (silent corruption). sqlite3 3.51 (recursive_triggers=ON)
+                // raises `UNIQUE constraint failed: <table>.<col>` and leaves
+                // the table unchanged — so detect the collision here, BEFORE any
+                // storage mutation, and abort.
+                detect_surviving_replace_conflict(
+                    &updates,
+                    schema,
+                    &abandoned,
+                    database,
+                    table_name,
+                )?;
             }
 
             // Update indexes before deletion
@@ -579,15 +599,9 @@ pub(super) fn execute_internal(
                 partial_index_maintenance::rebuild_partial_indexes_after_compaction(
                     database, table_name,
                 );
-                // KNOWN LIMITATION: After compaction, row indices in the `updates` vector
-                // may be stale since compaction can shift row positions. This is safe in
-                // practice because:
-                // 1. Compaction only occurs when deletion count exceeds a high threshold
-                //    (typically when > 50% of rows are deleted)
-                // 2. UPDATE OR REPLACE typically deletes a small number of conflicting rows
-                // 3. The likelihood of triggering compaction during UPDATE OR REPLACE is low
-                // For correctness in edge cases, a future improvement could re-scan the
-                // table to recalculate update indices based on row content matching.
+                // Stale `updates` row indices after compaction are repaired by
+                // `remap_update_indices_after_compaction` below (re-resolves each
+                // pending update's physical slot by matching its OLD row).
             } else {
                 database.adjust_indexes_after_delete(table_name, &rows_to_delete_for_replace);
             }
@@ -1662,6 +1676,9 @@ fn execute_update_from(
 
                 if has_delete_triggers {
                     let mut kept = Vec::with_capacity(rows_for_index.len());
+                    // Conflict rows whose deletion was abandoned by a BEFORE
+                    // DELETE RAISE(IGNORE) — they stay live.
+                    let mut abandoned: Vec<(usize, Row)> = Vec::new();
                     for (idx, row) in rows_for_index {
                         let outcome = crate::TriggerFirer::execute_before_triggers(
                             database,
@@ -1672,12 +1689,28 @@ fn execute_update_from(
                         )?;
                         if outcome != crate::TriggerOutcome::SkipRow {
                             kept.push((idx, row));
+                        } else {
+                            abandoned.push((idx, row));
                         }
                     }
                     rows_for_index = kept;
                     let surviving: HashSet<usize> =
                         rows_for_index.iter().map(|(idx, _)| *idx).collect();
                     rows_to_delete_for_replace.retain(|idx| surviving.contains(idx));
+
+                    // Issue #5490 (doctor): same duplicate-PK guard as the
+                    // non-FROM path. A BEFORE DELETE RAISE(IGNORE) that left a
+                    // conflict row live makes the pending update's NEW row a
+                    // duplicate-key violation; match sqlite3 3.51's
+                    // `UNIQUE constraint failed` + table-unchanged behavior by
+                    // aborting before any storage mutation.
+                    detect_surviving_replace_conflict(
+                        &updates,
+                        schema,
+                        &abandoned,
+                        database,
+                        table_name,
+                    )?;
                 }
 
                 // Update indexes before deletion
@@ -1725,11 +1758,8 @@ fn execute_update_from(
                     partial_index_maintenance::rebuild_partial_indexes_after_compaction(
                         database, table_name,
                     );
-                    // KNOWN LIMITATION: same caveat as the default path — after
-                    // compaction, row indices in `updates` may be stale. This is
-                    // safe in practice because UPDATE OR REPLACE typically deletes
-                    // a small number of conflicting rows (well below the
-                    // compaction threshold).
+                    // Stale `updates` row indices after compaction are repaired
+                    // by `remap_update_indices_after_compaction` below.
                 } else {
                     database.adjust_indexes_after_delete(table_name, &rows_to_delete_for_replace);
                 }

--- a/crates/vibesql-executor/src/update/index_sync.rs
+++ b/crates/vibesql-executor/src/update/index_sync.rs
@@ -117,6 +117,168 @@ pub(super) fn find_conflicting_rows_for_update(
     conflicting_indices
 }
 
+/// Issue #5490 (doctor follow-up): detect a REPLACE conflict that survived a
+/// BEFORE DELETE `RAISE(IGNORE)`.
+///
+/// During UPDATE OR REPLACE the conflicting row(s) are normally deleted to make
+/// room for the updated row. When the table has a BEFORE DELETE trigger that
+/// runs `RAISE(IGNORE)`, that conflict-row deletion is abandoned and the
+/// conflicting row stays live. If a pending update's NEW row would land on the
+/// same PRIMARY KEY / UNIQUE value as one of those *surviving* conflict rows,
+/// applying the update would create a duplicate key (silent corruption).
+///
+/// sqlite3 3.51.0 (with `recursive_triggers=ON`, which is how VibeSQL fires the
+/// BEFORE DELETE trigger here) instead raises `UNIQUE constraint failed: <table>.<col>`
+/// and leaves the table unchanged. This helper reproduces that: it returns the
+/// matching error when any update collides with a surviving conflict row, so the
+/// caller can abort *before* mutating storage.
+///
+/// `surviving_conflict_rows` are the rows that were marked for REPLACE deletion
+/// but kept alive by a BEFORE DELETE `RAISE(IGNORE)` (their pre-trigger values).
+pub(super) fn detect_surviving_replace_conflict(
+    updates: &[PendingUpdate],
+    schema: &TableSchema,
+    surviving_conflict_rows: &[(usize, Row)],
+    database: &Database,
+    table_name: &str,
+) -> Result<(), ExecutorError> {
+    if surviving_conflict_rows.is_empty() || updates.is_empty() {
+        return Ok(());
+    }
+
+    let surviving_indices: HashSet<usize> =
+        surviving_conflict_rows.iter().map(|(idx, _)| *idx).collect();
+
+    // PRIMARY KEY collisions.
+    if let Some(pk_indices) = schema.get_primary_key_indices() {
+        let mut surviving_pks: HashSet<Vec<SqlValue>> = HashSet::new();
+        for (_, row) in surviving_conflict_rows {
+            let pk: Vec<SqlValue> =
+                pk_indices.iter().map(|&i| row.values[i].clone()).collect();
+            if !pk.contains(&SqlValue::Null) {
+                surviving_pks.insert(pk);
+            }
+        }
+        for u in updates {
+            // A surviving conflict row is, by definition, not the row being
+            // updated (own rows are excluded from the delete set), so any match
+            // is a genuine duplicate-key collision.
+            if surviving_indices.contains(&u.row_index) {
+                continue;
+            }
+            let new_pk: Vec<SqlValue> =
+                pk_indices.iter().map(|&i| u.new_row.values[i].clone()).collect();
+            if new_pk.contains(&SqlValue::Null) {
+                continue;
+            }
+            if surviving_pks.contains(&new_pk) {
+                let pk_col_names = schema.primary_key.as_ref().unwrap();
+                let qualified: Vec<String> =
+                    pk_col_names.iter().map(|c| format!("{}.{}", schema.name, c)).collect();
+                return Err(ExecutorError::ConstraintViolation(format!(
+                    "UNIQUE constraint failed: {}",
+                    qualified.join(", ")
+                )));
+            }
+        }
+    }
+
+    // Table-level UNIQUE constraint collisions.
+    let unique_constraint_indices = schema.get_unique_constraint_indices();
+    for (constraint_idx, unique_indices) in unique_constraint_indices.iter().enumerate() {
+        let mut surviving_keys: HashSet<Vec<SqlValue>> = HashSet::new();
+        for (_, row) in surviving_conflict_rows {
+            let key: Vec<SqlValue> =
+                unique_indices.iter().map(|&i| row.values[i].clone()).collect();
+            if !key.contains(&SqlValue::Null) {
+                surviving_keys.insert(key);
+            }
+        }
+        for u in updates {
+            if surviving_indices.contains(&u.row_index) {
+                continue;
+            }
+            let new_key: Vec<SqlValue> =
+                unique_indices.iter().map(|&i| u.new_row.values[i].clone()).collect();
+            if new_key.contains(&SqlValue::Null) {
+                continue;
+            }
+            if surviving_keys.contains(&new_key) {
+                let unique_col_names = &schema.unique_constraints[constraint_idx];
+                let qualified: Vec<String> =
+                    unique_col_names.iter().map(|c| format!("{}.{}", schema.name, c)).collect();
+                return Err(ExecutorError::ConstraintViolation(format!(
+                    "UNIQUE constraint failed: {}",
+                    qualified.join(", ")
+                )));
+            }
+        }
+    }
+
+    // User-defined UNIQUE indexes (CREATE UNIQUE INDEX).
+    for index_name in database.list_indexes_for_table(table_name) {
+        let index_metadata = match database.get_index(&index_name) {
+            Some(m) => m,
+            None => continue,
+        };
+        if !index_metadata.unique {
+            continue;
+        }
+
+        // Resolve plain (non-expression) column indices for this index.
+        let mut col_idxs: Vec<usize> = Vec::with_capacity(index_metadata.columns.len());
+        let mut is_expression_index = false;
+        for ic in &index_metadata.columns {
+            if ic.get_expression().is_some() {
+                is_expression_index = true;
+                break;
+            }
+            match ic.column_name().and_then(|cn| schema.get_column_index(cn)) {
+                Some(ci) => col_idxs.push(ci),
+                None => {
+                    is_expression_index = true;
+                    break;
+                }
+            }
+        }
+        if is_expression_index {
+            continue;
+        }
+
+        let mut surviving_keys: HashSet<Vec<SqlValue>> = HashSet::new();
+        for (_, row) in surviving_conflict_rows {
+            let key: Vec<SqlValue> = col_idxs.iter().map(|&i| row.values[i].clone()).collect();
+            if !key.contains(&SqlValue::Null) {
+                surviving_keys.insert(key);
+            }
+        }
+        for u in updates {
+            if surviving_indices.contains(&u.row_index) {
+                continue;
+            }
+            let new_key: Vec<SqlValue> =
+                col_idxs.iter().map(|&i| u.new_row.values[i].clone()).collect();
+            if new_key.contains(&SqlValue::Null) {
+                continue;
+            }
+            if surviving_keys.contains(&new_key) {
+                let columns_str = index_metadata
+                    .columns
+                    .iter()
+                    .map(|col| format!("{}.{}", table_name, col.column_name().unwrap_or("?")))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return Err(ExecutorError::ConstraintViolation(format!(
+                    "UNIQUE constraint failed: {}",
+                    columns_str
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Validate that multiple updates in the same batch don't produce conflicting
 /// PK or UNIQUE constraint values. This ensures SQL's deferred constraint semantics
 /// where all rows must satisfy constraints after the entire UPDATE completes.

--- a/crates/vibesql-executor/tests/update_or_replace_without_rowid_delete_trigger_tests.rs
+++ b/crates/vibesql-executor/tests/update_or_replace_without_rowid_delete_trigger_tests.rs
@@ -1,0 +1,278 @@
+//! Regression tests for issue #5490:
+//! `UPDATE OR REPLACE` (and the REPLACE side of `INSERT OR REPLACE`) on a
+//! WITHOUT ROWID table must
+//!   (a) RESOLVE a PRIMARY KEY / UNIQUE conflict by deleting the conflicting
+//!       existing row(s), and
+//!   (b) FIRE the DELETE trigger(s) for those removed rows.
+//!
+//! Before the fix, a WITHOUT ROWID `UPDATE OR REPLACE` that hit a PRIMARY KEY
+//! conflict took the single-row fast path, which has no conflict-resolution
+//! logic, and raised `PRIMARY KEY constraint violation`. Even via the slow
+//! path the conflicting row was tombstoned without firing its DELETE trigger.
+//!
+//! Behavior is verified against sqlite3 3.51.0 (recursive_triggers ON), which
+//! is the semantics VibeSQL matches for REPLACE-conflict DELETE triggers (the
+//! INSERT OR REPLACE path already did so — see `insert/replace.rs`).
+
+use vibesql_executor::{
+    CreateTableExecutor, DeleteExecutor, InsertExecutor, SelectExecutor, TriggerExecutor,
+    UpdateExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Parse and execute a single SQL statement, dispatching on statement type.
+fn exec(db: &mut Database, sql: &str) {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e:?}"));
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+        }
+        Statement::CreateTrigger(s) => {
+            TriggerExecutor::create_trigger(db, &s).expect("CREATE TRIGGER failed");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT failed");
+        }
+        Statement::Update(s) => {
+            UpdateExecutor::execute(&s, db).expect("UPDATE failed");
+        }
+        Statement::Delete(s) => {
+            DeleteExecutor::execute(&s, db).expect("DELETE failed");
+        }
+        other => panic!("unsupported statement in test helper: {other:?}"),
+    }
+}
+
+/// Like [`exec`] but returns the Result of an UPDATE so a test can assert it
+/// did NOT error (the pre-fix bug raised a PK violation here).
+fn try_update(db: &mut Database, sql: &str) -> Result<usize, vibesql_executor::ExecutorError> {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).expect("parse failed");
+    match stmt {
+        Statement::Update(s) => UpdateExecutor::execute(&s, db),
+        other => panic!("expected UPDATE, got {other:?}"),
+    }
+}
+
+/// Run a SELECT and return its rows as `Vec<Vec<SqlValue>>` (live rows only).
+fn query(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).expect("parse failed");
+    let Statement::Select(select) = stmt else {
+        panic!("expected SELECT");
+    };
+    let executor = SelectExecutor::new(db);
+    executor
+        .execute(&select)
+        .expect("SELECT failed")
+        .into_iter()
+        .map(|row| row.values.to_vec())
+        .collect()
+}
+
+/// Run an unordered SELECT and sort the resulting rows in Rust by their first
+/// column. Used instead of SQL `ORDER BY` because an index-ordered scan over a
+/// freshly-compacted in-memory table currently returns the wrong rows (a
+/// separate read-path bug filed as a follow-on; the persisting CLI path is
+/// unaffected). Sorting in Rust keeps these tests focused on #5490's conflict
+/// resolution + DELETE-trigger behavior.
+fn sorted_rows(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let mut rows = query(db, sql);
+    rows.sort_by(|a, b| format!("{:?}", a[0]).cmp(&format!("{:?}", b[0])));
+    rows
+}
+
+/// Collect a single TEXT column from a SELECT as a `Vec<String>`.
+fn text_column(db: &Database, sql: &str) -> Vec<String> {
+    query(db, sql)
+        .into_iter()
+        .map(|row| match &row[0] {
+            SqlValue::Varchar(s) => s.to_string(),
+            other => panic!("expected text value, got {other:?}"),
+        })
+        .collect()
+}
+
+/// triggerF.test case 1.2: AFTER DELETE trigger on a WITHOUT ROWID table.
+/// The DELETE trigger must fire once for the plain DELETE and once each for
+/// the INSERT OR REPLACE and UPDATE OR REPLACE conflict resolutions, with the
+/// trigger body observing the post-delete `count(*)`.
+#[test]
+fn after_delete_trigger_fires_for_or_replace_conflicts_without_rowid() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INT PRIMARY KEY, b) WITHOUT ROWID");
+    exec(&mut db, "CREATE TABLE log(t)");
+    exec(
+        &mut db,
+        "CREATE TRIGGER trd AFTER DELETE ON t1 BEGIN \
+         INSERT INTO log VALUES(old.a || old.b || (SELECT count(*) FROM t1)); END",
+    );
+
+    exec(&mut db, "INSERT INTO t1 VALUES(1, 'one')");
+    exec(&mut db, "INSERT INTO t1 VALUES(2, 'two')");
+    exec(&mut db, "INSERT INTO t1 VALUES(3, 'three')");
+
+    exec(&mut db, "DELETE FROM t1 WHERE a=1");
+    exec(&mut db, "INSERT OR REPLACE INTO t1 VALUES(2, 'three')");
+    // The pre-fix bug raised a PK violation on this statement.
+    try_update(&mut db, "UPDATE OR REPLACE t1 SET a=3 WHERE a=2")
+        .expect("UPDATE OR REPLACE must resolve the PK conflict, not raise");
+
+    // DELETE trigger log matches sqlite3 3.51.0 exactly.
+    assert_eq!(
+        text_column(&db, "SELECT t FROM log"),
+        vec!["1one2".to_string(), "2two1".to_string(), "3three1".to_string()],
+    );
+
+    // Conflict resolved: old row gone, replacement present.
+    let rows = sorted_rows(&db, "SELECT a, b FROM t1");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], SqlValue::Integer(3));
+}
+
+/// triggerF.test case 1.3: BEFORE DELETE trigger on a WITHOUT ROWID table.
+#[test]
+fn before_delete_trigger_fires_for_or_replace_conflicts_without_rowid() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INT PRIMARY KEY, b) WITHOUT ROWID");
+    exec(&mut db, "CREATE TABLE log(t)");
+    exec(
+        &mut db,
+        "CREATE TRIGGER trd BEFORE DELETE ON t1 BEGIN \
+         INSERT INTO log VALUES(old.a || old.b || (SELECT count(*) FROM t1)); END",
+    );
+
+    exec(&mut db, "INSERT INTO t1 VALUES(1, 'one')");
+    exec(&mut db, "INSERT INTO t1 VALUES(2, 'two')");
+    exec(&mut db, "INSERT INTO t1 VALUES(3, 'three')");
+
+    exec(&mut db, "DELETE FROM t1 WHERE a=1");
+    exec(&mut db, "INSERT OR REPLACE INTO t1 VALUES(2, 'three')");
+    try_update(&mut db, "UPDATE OR REPLACE t1 SET a=3 WHERE a=2")
+        .expect("UPDATE OR REPLACE must resolve the PK conflict, not raise");
+
+    // BEFORE DELETE observes the pre-delete count, matching sqlite3 3.51.0.
+    assert_eq!(
+        text_column(&db, "SELECT t FROM log"),
+        vec!["1one3".to_string(), "2two2".to_string(), "3three2".to_string()],
+    );
+}
+
+/// A WITHOUT ROWID row that conflicts on multiple UNIQUE constraints at once:
+/// UPDATE OR REPLACE must delete every conflicting row and fire the DELETE
+/// trigger for each, leaving exactly the updated row.
+#[test]
+fn update_or_replace_multi_unique_conflict_without_rowid() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(a INT PRIMARY KEY, b UNIQUE, c UNIQUE) WITHOUT ROWID");
+    exec(&mut db, "CREATE TABLE log(t)");
+    exec(
+        &mut db,
+        "CREATE TRIGGER trd AFTER DELETE ON t BEGIN INSERT INTO log VALUES('del' || old.a); END",
+    );
+    exec(&mut db, "INSERT INTO t VALUES(1, 10, 100)");
+    exec(&mut db, "INSERT INTO t VALUES(2, 20, 200)");
+    exec(&mut db, "INSERT INTO t VALUES(3, 30, 300)");
+
+    // Row a=1 -> b=20 (conflicts with a=2) and c=300 (conflicts with a=3).
+    try_update(&mut db, "UPDATE OR REPLACE t SET b=20, c=300 WHERE a=1")
+        .expect("multi-conflict UPDATE OR REPLACE must resolve, not raise");
+
+    // Only the updated row remains.
+    let rows = sorted_rows(&db, "SELECT a, b, c FROM t");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0],
+        vec![SqlValue::Integer(1), SqlValue::Integer(20), SqlValue::Integer(300)]
+    );
+
+    // Both conflicting rows' DELETE triggers fired (order-independent check).
+    let mut log = text_column(&db, "SELECT t FROM log");
+    log.sort();
+    assert_eq!(log, vec!["del2".to_string(), "del3".to_string()]);
+}
+
+/// Regression guard for ROWID tables: UPDATE OR REPLACE must still resolve the
+/// conflict AND fire the replaced row's DELETE trigger (no regression from the
+/// fast-path change that now routes conflict clauses through the slow path).
+#[test]
+fn update_or_replace_rowid_table_still_resolves_and_fires_delete_trigger() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(a INTEGER PRIMARY KEY, b)");
+    exec(&mut db, "CREATE TABLE log(t)");
+    exec(
+        &mut db,
+        "CREATE TRIGGER trd AFTER DELETE ON t BEGIN \
+         INSERT INTO log VALUES('del' || old.a || old.b); END",
+    );
+    exec(&mut db, "INSERT INTO t VALUES(1, 'one')");
+    exec(&mut db, "INSERT INTO t VALUES(2, 'two')");
+    exec(&mut db, "INSERT INTO t VALUES(3, 'three')");
+
+    try_update(&mut db, "UPDATE OR REPLACE t SET a=3 WHERE a=2")
+        .expect("ROWID UPDATE OR REPLACE must resolve the PK conflict");
+
+    let rows = sorted_rows(&db, "SELECT a, b FROM t");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0], vec![SqlValue::Integer(1), text("one")]);
+    assert_eq!(rows[1], vec![SqlValue::Integer(3), text("two")]);
+
+    // The conflicting (3,'three') row was deleted and its trigger fired.
+    assert_eq!(text_column(&db, "SELECT t FROM log"), vec!["del3three".to_string()]);
+}
+
+fn text(s: &str) -> SqlValue {
+    SqlValue::Varchar(arcstr::ArcStr::from(s))
+}
+
+/// In-memory regression for the compaction-induced index drift exposed by the
+/// fast-path bypass (#5490): a prior tombstone (`DELETE FROM t1 WHERE a=1`)
+/// plus the REPLACE-conflict delete can compact the table mid-statement,
+/// shifting the update target's physical index. Before the fix this raised
+/// `StorageError("Column index ... out of bounds")` or silently dropped the
+/// row. The CLI masked it because each statement reloads from disk.
+#[test]
+fn update_or_replace_after_tombstone_without_rowid_inmemory() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INT PRIMARY KEY, b) WITHOUT ROWID");
+    exec(&mut db, "INSERT INTO t1 VALUES(1, 'one')");
+    exec(&mut db, "INSERT INTO t1 VALUES(2, 'two')");
+    exec(&mut db, "INSERT INTO t1 VALUES(3, 'three')");
+    exec(&mut db, "DELETE FROM t1 WHERE a=1");
+
+    // a=2 -> a=3 conflicts with the existing (3,'three'); REPLACE deletes it.
+    try_update(&mut db, "UPDATE OR REPLACE t1 SET a=3 WHERE a=2")
+        .expect("UPDATE OR REPLACE must not error on a compacted table");
+
+    let rows = sorted_rows(&db, "SELECT a, b FROM t1");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0], vec![SqlValue::Integer(3), text("two")]);
+}
+
+/// Same drift case but with an intervening INSERT OR REPLACE (the exact
+/// triggerF.test 1.x.1 statement sequence) and no triggers.
+#[test]
+fn insert_then_update_or_replace_without_rowid_inmemory() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INT PRIMARY KEY, b) WITHOUT ROWID");
+    exec(&mut db, "INSERT INTO t1 VALUES(1, 'one')");
+    exec(&mut db, "INSERT INTO t1 VALUES(2, 'two')");
+    exec(&mut db, "INSERT INTO t1 VALUES(3, 'three')");
+    exec(&mut db, "DELETE FROM t1 WHERE a=1");
+    exec(&mut db, "INSERT OR REPLACE INTO t1 VALUES(2, 'three')");
+
+    try_update(&mut db, "UPDATE OR REPLACE t1 SET a=3 WHERE a=2")
+        .expect("UPDATE OR REPLACE must not error");
+
+    // NOTE: read with an unordered SELECT and sort in Rust. An `ORDER BY a`
+    // index-ordered scan over this specific in-memory tombstone layout returns
+    // the wrong rows — a SEPARATE pre-existing read-path bug (filed as a
+    // follow-on), unrelated to #5490's conflict resolution. The persisting CLI
+    // path is unaffected, which is why triggerF.test passes.
+    let rows = sorted_rows(&db, "SELECT a, b FROM t1");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0], vec![SqlValue::Integer(3), text("three")]);
+}

--- a/crates/vibesql-executor/tests/update_or_replace_without_rowid_delete_trigger_tests.rs
+++ b/crates/vibesql-executor/tests/update_or_replace_without_rowid_delete_trigger_tests.rs
@@ -228,6 +228,71 @@ fn text(s: &str) -> SqlValue {
     SqlValue::Varchar(arcstr::ArcStr::from(s))
 }
 
+/// Issue #5490 (doctor blocker): a `BEFORE DELETE` trigger that runs
+/// `RAISE(IGNORE)` abandons the REPLACE-conflict row's deletion, so the
+/// conflicting row stays live. `UPDATE OR REPLACE` would then drive the updated
+/// row onto a PK that another (surviving) row still holds — a duplicate PRIMARY
+/// KEY. sqlite3 3.51.0 (recursive_triggers=ON) instead raises
+/// `UNIQUE constraint failed: t1.a` and leaves the table unchanged. Before this
+/// fix VibeSQL returned Ok and left two rows sharing PK a=3 (silent corruption).
+#[test]
+fn update_or_replace_before_delete_ignore_raises_unique_and_leaves_table_unchanged() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INT PRIMARY KEY, b) WITHOUT ROWID");
+    // RAISE(IGNORE) only for the conflicting row (a=3), so the deletion that
+    // UPDATE OR REPLACE wants to perform is abandoned.
+    exec(
+        &mut db,
+        "CREATE TRIGGER trd BEFORE DELETE ON t1 WHEN old.a=3 BEGIN SELECT RAISE(IGNORE); END",
+    );
+    exec(&mut db, "INSERT INTO t1 VALUES(2, 'two')");
+    exec(&mut db, "INSERT INTO t1 VALUES(3, 'three')");
+
+    let err = try_update(&mut db, "UPDATE OR REPLACE t1 SET a=3 WHERE a=2")
+        .expect_err("surviving conflict row must raise a UNIQUE error, not silently dup the PK");
+    // Display localizes a "Constraint violation: " prefix; assert the SQLite
+    // sub-message + the qualified PK column, matching sqlite3 3.51.0's
+    // `UNIQUE constraint failed: t1.a`.
+    let msg = err.to_string();
+    assert!(msg.contains("UNIQUE constraint failed: t1.a"), "got error: {msg}");
+
+    // Table unchanged — verified via a live SELECT (no duplicate PK).
+    let rows = sorted_rows(&db, "SELECT a, b FROM t1");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0], vec![SqlValue::Integer(2), text("two")]);
+    assert_eq!(rows[1], vec![SqlValue::Integer(3), text("three")]);
+}
+
+/// Same blocker via the `UPDATE ... FROM` path: the surviving BEFORE DELETE
+/// RAISE(IGNORE) conflict must raise `UNIQUE constraint failed: t1.a` and leave
+/// the table unchanged, matching sqlite3 3.51.0.
+#[test]
+fn update_or_replace_from_before_delete_ignore_raises_unique_and_leaves_table_unchanged() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INT PRIMARY KEY, b) WITHOUT ROWID");
+    exec(
+        &mut db,
+        "CREATE TRIGGER trd BEFORE DELETE ON t1 WHEN old.a=3 BEGIN SELECT RAISE(IGNORE); END",
+    );
+    exec(&mut db, "INSERT INTO t1 VALUES(2, 'two')");
+    exec(&mut db, "INSERT INTO t1 VALUES(3, 'three')");
+    exec(&mut db, "CREATE TABLE src(x, y)");
+    exec(&mut db, "INSERT INTO src VALUES(2, 3)");
+
+    let err = try_update(&mut db, "UPDATE OR REPLACE t1 SET a=src.y FROM src WHERE t1.a=src.x")
+        .expect_err("surviving conflict row must raise a UNIQUE error in the FROM path too");
+    // Display localizes a "Constraint violation: " prefix; assert the SQLite
+    // sub-message + the qualified PK column, matching sqlite3 3.51.0's
+    // `UNIQUE constraint failed: t1.a`.
+    let msg = err.to_string();
+    assert!(msg.contains("UNIQUE constraint failed: t1.a"), "got error: {msg}");
+
+    let rows = sorted_rows(&db, "SELECT a, b FROM t1");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0], vec![SqlValue::Integer(2), text("two")]);
+    assert_eq!(rows[1], vec![SqlValue::Integer(3), text("three")]);
+}
+
 /// In-memory regression for the compaction-induced index drift exposed by the
 /// fast-path bypass (#5490): a prior tombstone (`DELETE FROM t1 WHERE a=1`)
 /// plus the REPLACE-conflict delete can compact the table mid-statement,

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3909,8 +3909,24 @@ proc do_test {name script expected} {
     # Do this BEFORE incrementing test count or printing test name
     set internal_check [uses_sqlite_internals $script]
     if {[lindex $internal_check 0]} {
-        omit_test $name [lindex $internal_check 1]
-        return
+        # Setup-only blocks (no expected result to assert) that merely use an
+        # OR REPLACE / OR IGNORE conflict clause must still RUN: VibeSQL now
+        # resolves those conflicts (including on WITHOUT ROWID tables, firing
+        # the replaced row's DELETE triggers — issue #5490). Skipping such a
+        # setup block leaves dependent assertions reading an empty/unmodified
+        # table and cascades into spurious failures (e.g. triggerF 1.x.1 sets
+        # up state with INSERT/UPDATE OR REPLACE that triggerF 1.x.2 asserts).
+        # Genuine conflict-resolution ASSERTIONS (non-empty expected) stay
+        # skipped exactly as before, and OR ABORT/ROLLBACK/FAIL are unaffected.
+        set reason [lindex $internal_check 1]
+        set is_conflict_setup [expr {
+            [string match "*conflict resolution clause*" $reason]
+            && [string trim $expected] eq ""
+        }]
+        if {!$is_conflict_setup} {
+            omit_test $name $reason
+            return
+        }
     }
 
     incr ::nTest


### PR DESCRIPTION
## Summary

Closes #5490

On a WITHOUT ROWID table, `UPDATE OR REPLACE` raised `PRIMARY KEY constraint violation` instead of resolving the conflict, and never fired the replaced row's DELETE trigger (triggerF.test 1.2/1.3/1.4). This fixes the conflict resolution and the DELETE-trigger firing to match sqlite3 3.51.0, and also fixes the parallel `UPDATE OR IGNORE` PK-conflict case.

## Root cause

Three distinct defects in the UPDATE path, all on the conflict-resolution side:

1. **Fast path ignored conflict clauses.** The single-row UPDATE fast path (`update/fast_path.rs`) has no conflict-resolution logic, yet ran for any UPDATE without *UPDATE* triggers (DELETE triggers don't gate it). So `UPDATE OR REPLACE`/`OR IGNORE` on a PK-only conflict took the fast path and unconditionally raised a PK violation — this is what the issue reproduced.
   - Fix: skip the fast path whenever `stmt.conflict_clause` is set, routing OR REPLACE/OR IGNORE through the two-phase path.

2. **Two-phase OR REPLACE deleted conflicting rows silently.** The slow path tombstoned the conflicting row(s) but never fired their DELETE triggers (unlike the INSERT OR REPLACE path in `insert/replace.rs`).
   - Fix: fire BEFORE DELETE (before removal) and AFTER DELETE (after removal) for each conflict-removed row, with BEFORE-trigger `RAISE(IGNORE)` abandoning that row's deletion (parity with `insert/replace.rs` / #5418). Applied to both the plain UPDATE and the `UPDATE ... FROM` paths. VibeSQL fires these REPLACE-conflict DELETE triggers unconditionally — matching sqlite3 with `recursive_triggers=ON` and the existing INSERT OR REPLACE behavior (VibeSQL does not model the `recursive_triggers` pragma).

3. **Compaction-induced stale row indices.** Deleting the conflicting row can compact the table mid-statement (a prior tombstone from an earlier statement makes the threshold easy to reach), shifting every live row's physical index and invalidating the captured `PendingUpdate::row_index`. The apply phase then wrote to a freed slot (`StorageError("Column index out of bounds")`) or dropped the row. This was a documented "known limitation" previously masked only by CLI/persistence reloads between statements.
   - Fix: after the conflict delete, re-resolve each update's physical index from the current live rows by matching its OLD row (`remap_update_indices_after_compaction`).

## sqlite3 3.51.0 parity

Verified the issue repro on all four triggerF trigger configurations against sqlite3 3.51.0 (recursive_triggers ON) — logs match exactly: `1one2 2two1 3three1`, `1one3 2two2 3three2`, etc. ROWID `UPDATE OR REPLACE` and `UPDATE OR IGNORE` (ROWID and WITHOUT ROWID) also match sqlite3.

## triggerF.test delta

- Before: 5/12 passing (1.2.2, 1.3.2, 1.4.2 failed; conflict-clause setup blocks were skipped, leaving the log empty).
- After: **11/12 passing** (0 skipped).
- Remaining failure **1.4.2** is a pre-existing, unrelated plain-`DELETE` bug: with *both* a BEFORE and an AFTER DELETE trigger that read `(SELECT count(*) FROM t1)`, the AFTER trigger observes a stale count (`1one3 1one3` instead of `1one3 1one2`). The REPLACE-conflict trigger entries my fix adds are all correct. Filed as a follow-on.

## No ROWID regression

ROWID-table `UPDATE OR REPLACE` still resolves the conflict and now also fires the replaced row's DELETE trigger (matching sqlite3). Confirmed by toggling the fix off/on against the trigger TCL suite:
- `triggerC`: 61 -> **64** passing (+3, no new failures).
- `trigger1` (20/50/14), `trigger2` (12/0/0), `trigger3` (14/3/6), `triggerA` (17/0/1), `update` (126/2/10), `insert` (51/0/19), `insert2` (16/0/11), `upsert1` (32/0/3): **unchanged** vs baseline.

## Harness note

The TCL shim (`scripts/tester_vibesql.tcl`) previously skipped any test whose top-level SQL used an OR REPLACE/IGNORE conflict clause ("not fully supported"). That omitted triggerF's setup blocks (`do_execsql_test 1.x.1`), leaving the dependent assertions reading an empty table. Setup-only blocks (no expected result) that merely use OR REPLACE/IGNORE now run; genuine conflict-resolution assertions (non-empty expected) and OR ABORT/ROLLBACK/FAIL stay skipped exactly as before. Verified this change does not alter any other trigger/insert/update test file's counts.

## Tests

- New `crates/vibesql-executor/tests/update_or_replace_without_rowid_delete_trigger_tests.rs`:
  - AFTER / BEFORE DELETE trigger fires for OR REPLACE conflicts on WITHOUT ROWID (triggerF 1.2/1.3 via live SELECT + audit log, asserted against sqlite3 values).
  - Multi-UNIQUE conflict (one row conflicting on two UNIQUE indexes) — both conflicting rows deleted, both DELETE triggers fired.
  - ROWID OR REPLACE regression guard.
  - Two in-memory compaction-drift cases (with/without an intervening INSERT OR REPLACE).
- `cargo test -p vibesql-executor`: green (all 45 test binaries pass).

## Follow-ons

- Plain `DELETE` with combined BEFORE+AFTER DELETE triggers: AFTER trigger sees a stale `count(*)` (triggerF 1.4.2).
- In-memory `ORDER BY <pk>` index-ordered scan over a freshly-compacted WITHOUT ROWID table returns the wrong rows (read-path bug; CLI/persistence path unaffected). The new tests sort in Rust to avoid this.
- Multi-conflict DELETE-trigger firing order differs from sqlite3 (row-scan order vs index order); cosmetic, not covered by triggerF.

## Scope

Changes confined to the OR REPLACE/IGNORE / upsert conflict path in `update/executor.rs` plus the test-harness skip narrowing. Did not touch the trigger NEW/OLD.rowid evaluator (#5485) or FK-cascade integrity paths (#5501).

🤖 Generated with [Claude Code](https://claude.com/claude-code)