### PR TITLE
fix(trigger): align CREATE TRIGGER / recursion error wording with sqlite3 3.51.0

### DIFF
--- a/crates/vibesql-executor/src/advanced_objects/triggers.rs
+++ b/crates/vibesql-executor/src/advanced_objects/triggers.rs
@@ -5,33 +5,18 @@ use vibesql_storage::Database;
 
 use crate::errors::ExecutorError;
 
-/// Execute CREATE TRIGGER statement
+/// Execute CREATE TRIGGER statement.
+///
+/// Delegates to [`crate::TriggerExecutor::create_trigger`] so that every
+/// CREATE TRIGGER entry point (CLI, consensus, WASM) shares one validation path
+/// — IF NOT EXISTS handling, system-table rejection, and the
+/// view/table/INSTEAD-OF target checks (with SQLite-exact error wording). The
+/// success message is discarded here since this entry point returns `()`.
 pub fn execute_create_trigger(
     stmt: &CreateTriggerStmt,
     db: &mut Database,
 ) -> Result<(), ExecutorError> {
-    use vibesql_catalog::TriggerDefinition;
-
-    // `CREATE TRIGGER IF NOT EXISTS <name>` is a no-op success when a trigger
-    // with that name already exists (SQLite semantics, trigger1-1.2.0). Mirrors
-    // the guard in `TriggerExecutor::create_trigger_with_sql` so every CREATE
-    // TRIGGER path honors the clause.
-    if stmt.if_not_exists && db.catalog.get_trigger(&stmt.trigger_name).is_some() {
-        return Ok(());
-    }
-
-    let trigger = TriggerDefinition::new(
-        stmt.trigger_name.clone(),
-        stmt.timing.clone(),
-        stmt.event.clone(),
-        stmt.table_name.clone(),
-        stmt.granularity.clone(),
-        stmt.when_condition.clone(),
-        stmt.triggered_action.clone(),
-    );
-
-    db.catalog.create_trigger(trigger)?;
-    Ok(())
+    crate::TriggerExecutor::create_trigger(db, stmt).map(|_| ())
 }
 
 /// Execute ALTER TRIGGER statement

--- a/crates/vibesql-executor/src/tests/triggers/ddl.rs
+++ b/crates/vibesql-executor/src/tests/triggers/ddl.rs
@@ -120,6 +120,92 @@ fn test_create_trigger_if_not_exists_is_noop_when_present() {
     assert!(result.is_err(), "duplicate without IF NOT EXISTS should error");
 }
 
+/// Helper: create an empty test table named `t1` for the wording tests below.
+fn create_t1(db: &mut Database) {
+    match vibesql_parser::Parser::parse_sql("CREATE TABLE t1 (a INT, b INT);").unwrap() {
+        vibesql_ast::Statement::CreateTable(stmt) => {
+            CreateTableExecutor::execute(&stmt, db).unwrap();
+        }
+        other => panic!("Expected CreateTable, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_trigger_on_system_table_wording() {
+    // SQLite (3.51.0, trigger1-1.9) rejects CREATE TRIGGER on a system table with
+    // exactly "cannot create trigger on system table".
+    let mut db = Database::new();
+
+    let stmt = CreateTriggerStmt {
+        if_not_exists: false,
+        trigger_name: "tr1".to_string(),
+        timing: TriggerTiming::After,
+        event: TriggerEvent::Update(None),
+        table_name: "sqlite_master".to_string(),
+        granularity: TriggerGranularity::Row,
+        when_condition: None,
+        triggered_action: TriggerAction::RawSql("SELECT 1;".to_string()),
+    };
+
+    let err = crate::advanced_objects::execute_create_trigger(&stmt, &mut db)
+        .expect_err("trigger on system table must be rejected");
+    assert_eq!(err.to_string(), "cannot create trigger on system table");
+}
+
+#[test]
+fn test_create_instead_of_trigger_on_table_wording() {
+    // SQLite (3.51.0, trigger1-1.12): "cannot create INSTEAD OF trigger on table: t1".
+    let mut db = Database::new();
+    create_t1(&mut db);
+
+    let stmt = CreateTriggerStmt {
+        if_not_exists: false,
+        trigger_name: "t1t".to_string(),
+        timing: TriggerTiming::InsteadOf,
+        event: TriggerEvent::Update(None),
+        table_name: "t1".to_string(),
+        granularity: TriggerGranularity::Row,
+        when_condition: None,
+        triggered_action: TriggerAction::RawSql("SELECT 1;".to_string()),
+    };
+
+    let err = crate::advanced_objects::execute_create_trigger(&stmt, &mut db)
+        .expect_err("INSTEAD OF trigger on a table must be rejected");
+    assert_eq!(err.to_string(), "cannot create INSTEAD OF trigger on table: t1");
+}
+
+#[test]
+fn test_create_before_after_trigger_on_view_wording() {
+    // SQLite (3.51.0, trigger1-1.13/1.14):
+    //   "cannot create BEFORE trigger on view: v1"
+    //   "cannot create AFTER trigger on view: v1"
+    let mut db = Database::new();
+    create_t1(&mut db);
+    match vibesql_parser::Parser::parse_sql("CREATE VIEW v1 AS SELECT * FROM t1;").unwrap() {
+        vibesql_ast::Statement::CreateView(stmt) => {
+            crate::advanced_objects::execute_create_view(&stmt, &mut db).unwrap();
+        }
+        other => panic!("Expected CreateView, got {:?}", other),
+    }
+
+    for (timing, label) in [(TriggerTiming::Before, "BEFORE"), (TriggerTiming::After, "AFTER")] {
+        let stmt = CreateTriggerStmt {
+            if_not_exists: false,
+            trigger_name: "v1t".to_string(),
+            timing,
+            event: TriggerEvent::Update(None),
+            table_name: "v1".to_string(),
+            granularity: TriggerGranularity::Row,
+            when_condition: None,
+            triggered_action: TriggerAction::RawSql("SELECT 1;".to_string()),
+        };
+
+        let err = crate::advanced_objects::execute_create_trigger(&stmt, &mut db)
+            .expect_err("BEFORE/AFTER trigger on a view must be rejected");
+        assert_eq!(err.to_string(), format!("cannot create {} trigger on view: v1", label));
+    }
+}
+
 #[test]
 fn test_drop_trigger() {
     let mut db = Database::new();
@@ -204,20 +290,32 @@ fn test_create_trigger_all_variations() {
         _ => panic!("Expected CreateTable"),
     }
 
-    // Test different timing values
+    // A view is required for the INSTEAD OF variation: SQLite (and now VibeSQL)
+    // rejects INSTEAD OF on a table and BEFORE/AFTER on a view, so each timing
+    // must target a compatible object.
+    match vibesql_parser::Parser::parse_sql("CREATE VIEW test_view AS SELECT * FROM test_table;")
+        .unwrap()
+    {
+        vibesql_ast::Statement::CreateView(stmt) => {
+            crate::advanced_objects::execute_create_view(&stmt, &mut db).unwrap();
+        }
+        other => panic!("Expected CreateView, got {:?}", other),
+    }
+
+    // Test different timing values, each on a valid target object.
     let timings = vec![
-        (TriggerTiming::Before, "before"),
-        (TriggerTiming::After, "after"),
-        (TriggerTiming::InsteadOf, "insteadof"),
+        (TriggerTiming::Before, "before", "test_table"),
+        (TriggerTiming::After, "after", "test_table"),
+        (TriggerTiming::InsteadOf, "insteadof", "test_view"),
     ];
 
-    for (timing, suffix) in timings {
+    for (timing, suffix, target) in timings {
         let stmt = CreateTriggerStmt {
             if_not_exists: false,
             trigger_name: format!("trigger_{}", suffix),
             timing: timing.clone(),
             event: TriggerEvent::Insert,
-            table_name: "test_table".to_string(),
+            table_name: target.to_string(),
             granularity: TriggerGranularity::Row,
             when_condition: None,
             triggered_action: TriggerAction::RawSql("SELECT 1;".to_string()),

--- a/crates/vibesql-executor/src/tests/triggers/error_handling.rs
+++ b/crates/vibesql-executor/src/tests/triggers/error_handling.rs
@@ -126,13 +126,9 @@ fn test_recursion_prevention() {
     };
     let result = InsertExecutor::execute(&mut db, &insert);
 
-    // Verify insert failed with recursion error
+    // Verify insert failed with recursion error using SQLite's exact wording
+    // (sqlite3 3.51.0, triggerC.test): "too many levels of trigger recursion".
     assert!(result.is_err(), "Insert should have failed due to recursion limit");
     let err = result.unwrap_err();
-    let err_msg = format!("{:?}", err);
-    assert!(
-        err_msg.contains("recursion") || err_msg.contains("depth"),
-        "Error should mention recursion or depth: {}",
-        err_msg
-    );
+    assert_eq!(err.to_string(), "too many levels of trigger recursion");
 }

--- a/crates/vibesql-executor/src/trigger_ddl.rs
+++ b/crates/vibesql-executor/src/trigger_ddl.rs
@@ -46,18 +46,49 @@ impl TriggerExecutor {
             return Ok(format!("Trigger '{}' already exists", stmt.trigger_name));
         }
 
-        // INSTEAD OF triggers can only be created on views
-        // BEFORE and AFTER triggers can only be created on tables
+        // Reject triggers on SQLite system tables (any "sqlite_" prefixed name,
+        // e.g. sqlite_master / sqlite_schema / sqlite_stat1). SQLite emits exactly
+        // "cannot create trigger on system table" (sqlite3 3.51.0, trigger1-1.9).
+        // These messages are produced verbatim via `Other` so the TCL conformance
+        // shim passes them through unchanged.
+        if is_system_table_name(&stmt.table_name) {
+            return Err(ExecutorError::Other(
+                "cannot create trigger on system table".to_string(),
+            ));
+        }
+
+        // INSTEAD OF triggers can only be created on views;
+        // BEFORE and AFTER triggers can only be created on (non-view) tables.
+        let target_is_view = db.catalog.get_view(&stmt.table_name).is_some();
         if stmt.timing == TriggerTiming::InsteadOf {
-            // Verify the target view exists
-            if db.catalog.get_view(&stmt.table_name).is_none() {
-                return Err(ExecutorError::Other(format!(
-                    "INSTEAD OF trigger requires a view, but '{}' is not a view",
-                    stmt.table_name
-                )));
+            // INSTEAD OF on a real table is rejected with SQLite's exact wording
+            // "cannot create INSTEAD OF trigger on table: <name>" (trigger1-1.12).
+            if !target_is_view {
+                if db.catalog.table_exists(&stmt.table_name) {
+                    return Err(ExecutorError::Other(format!(
+                        "cannot create INSTEAD OF trigger on table: {}",
+                        stmt.table_name
+                    )));
+                }
+                // Neither a view nor a table: report the missing target.
+                return Err(ExecutorError::TableNotFound(stmt.table_name.clone()));
             }
         } else {
-            // Verify the target table exists
+            // BEFORE / AFTER on a view is rejected with SQLite's exact wording
+            // "cannot create BEFORE|AFTER trigger on view: <name>" (trigger1-1.13/1.14).
+            if target_is_view {
+                let timing_label = match stmt.timing {
+                    TriggerTiming::Before => "BEFORE",
+                    TriggerTiming::After => "AFTER",
+                    // InsteadOf handled in the branch above.
+                    TriggerTiming::InsteadOf => unreachable!(),
+                };
+                return Err(ExecutorError::Other(format!(
+                    "cannot create {} trigger on view: {}",
+                    timing_label, stmt.table_name
+                )));
+            }
+            // Verify the target table exists.
             if !db.catalog.table_exists(&stmt.table_name) {
                 return Err(ExecutorError::TableNotFound(stmt.table_name.clone()));
             }
@@ -146,4 +177,13 @@ impl TriggerExecutor {
 
         Ok(format!("Trigger '{}' dropped successfully", stmt.trigger_name))
     }
+}
+
+/// Returns true if `name` refers to a SQLite system table. SQLite reserves any
+/// object whose name begins with the case-insensitive prefix `sqlite_` for
+/// internal use (sqlite_master / sqlite_schema / sqlite_stat* / sqlite_sequence,
+/// etc.), and rejects `CREATE TRIGGER` on such tables.
+fn is_system_table_name(name: &str) -> bool {
+    let bytes = name.as_bytes();
+    bytes.len() >= 7 && bytes[..7].eq_ignore_ascii_case(b"sqlite_")
 }

--- a/crates/vibesql-executor/src/trigger_execution.rs
+++ b/crates/vibesql-executor/src/trigger_execution.rs
@@ -30,10 +30,16 @@ impl RecursionGuard {
         TRIGGER_RECURSION_DEPTH.with(|depth| {
             let current = depth.get();
             if current >= MAX_TRIGGER_RECURSION_DEPTH {
-                Err(ExecutorError::UnsupportedExpression(format!(
-                    "Trigger recursion depth limit exceeded (max: {}). Possible infinite trigger loop.",
-                    MAX_TRIGGER_RECURSION_DEPTH
-                )))
+                // SQLite emits exactly "too many levels of trigger recursion"
+                // (sqlite3 3.51.0; see triggerC.test 2.x / 6.x and `sqlite3VdbeError`).
+                // Use `Other` so the message surfaces verbatim (no "Unsupported
+                // expression:" wrapper) and the TCL conformance shim passes it
+                // through unchanged. NOTE: the depth *value* (16 vs SQLite's
+                // SQLITE_MAX_TRIGGER_DEPTH = 1000) is tracked separately in #5479;
+                // this change only aligns the message text.
+                Err(ExecutorError::Other(
+                    "too many levels of trigger recursion".to_string(),
+                ))
             } else {
                 depth.set(current + 1);
                 Ok(RecursionGuard)

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -344,6 +344,16 @@ proc translate_error_to_sqlite {vibesql_error} {
         return "duplicate column name: [string tolower $col_name]"
     }
 
+    # Trigger already exists: "Trigger 'X' already exists" -> "trigger X already exists"
+    # SQLite reports `trigger <name> already exists` (lowercase, unquoted) for a
+    # duplicate CREATE TRIGGER without IF NOT EXISTS (sqlite3 3.51.0, trigger1-1.2.1).
+    # SQLite echoes the name's original quoting in trigger1-1.2.2/1.2.3
+    # (e.g. {"tr1"} / {[tr1]}); VibeSQL's parser does not preserve the source
+    # token, so those two sub-cases remain a known gap (see issue follow-on).
+    if {[regexp -nocase {^Trigger '([^']+)' already exists} $error_msg -> trig_name]} {
+        return "trigger $trig_name already exists"
+    }
+
     # No tables specified: "no tables specified"
     if {[regexp -nocase {no tables? specified|FROM clause.*required|SELECT \* requires FROM clause} $error_msg]} {
         return "no tables specified"


### PR DESCRIPTION
Closes #5469

## Summary
VibeSQL's trigger DDL/runtime error messages diverged from SQLite's canonical wording, so many `trigger*.test` conformance assertions failed purely on text (behavior was already correct). This PR aligns the trigger-related error messages with **sqlite3 3.51.0**, plus one additive TCL-shim normalization entry. Code changes are confined to trigger error-production sites.

Scope is **wording / message-routing only**. The recursion *depth value* (16 vs SQLite's `SQLITE_MAX_TRIGGER_DEPTH` = 1000) is intentionally left to #5479 (see overlap note below).

## Messages corrected (before -> after, with sqlite3 3.51.0 citation)

1. **Trigger recursion limit** (`crates/vibesql-executor/src/trigger_execution.rs`)
   - before: `Unsupported expression: Trigger recursion depth limit exceeded (max: 16). Possible infinite trigger loop.`
   - after: `too many levels of trigger recursion`
   - sqlite3: `triggerC.test` 1.12 / 2.x / 3.x / 6.x expect `{too many levels of trigger recursion}`; verified `sqlite3 :memory:` infinite-recursion trigger -> `too many levels of trigger recursion`.

2. **trigger already exists** (TCL shim `scripts/tester_vibesql.tcl`, additive entry)
   - VibeSQL emits the friendly `Trigger 'tr1' already exists`; the shim now normalizes it to `trigger tr1 already exists` (mirrors the existing table/index/column already-exists rules).
   - sqlite3: `trigger1-1.2.1` expects `{trigger tr1 already exists}`; verified `sqlite3 :memory:` duplicate `CREATE TRIGGER` -> `trigger tr1 already exists`.

3. **CREATE TRIGGER on a system table** (`trigger_ddl.rs`)
   - before: `no such table: sqlite_master`
   - after: `cannot create trigger on system table`
   - sqlite3: `trigger1-1.9` expects `{cannot create trigger on system table}`; verified `sqlite3 :memory:` -> `cannot create trigger on system table`.

4. **INSTEAD OF trigger on a table** (`trigger_ddl.rs`)
   - before: `INSTEAD OF trigger requires a view, but 't1' is not a view`
   - after: `cannot create INSTEAD OF trigger on table: t1`
   - sqlite3: `trigger1-1.12` expects `{cannot create INSTEAD OF trigger on table: t1}`; verified `sqlite3 :memory:` -> identical.

5. **BEFORE/AFTER trigger on a view** (`trigger_ddl.rs`)
   - before: `no such table: v1`
   - after: `cannot create BEFORE trigger on view: v1` / `cannot create AFTER trigger on view: v1`
   - sqlite3: `trigger1-1.13` / `1.14` expect `{cannot create BEFORE|AFTER trigger on view: v1}`; verified `sqlite3 :memory:` -> identical.

These exact SQLite strings are produced verbatim via `ExecutorError::Other`, so the TCL shim's fallback passes them through unchanged. The two CREATE TRIGGER entry points were unified: `advanced_objects::execute_create_trigger` (used by the WASM bindings) now delegates to `TriggerExecutor::create_trigger`, so every path shares one validation site.

## TCL conformance deltas (sqlite3 3.51.0 suite, measured before/after on this branch)
| file | before | after | delta |
|------|--------|-------|-------|
| trigger1.test | 20 | 25 | **+5** (1.2.1, 1.9, 1.12, 1.13, 1.14) |
| triggerC.test | 66 | 72 | **+6** (recursion-message cases) |
| trigger4.test | 20 | 20 | 0 (unaffected) |
| triggerB.test | 197 | 197 | 0 (unaffected) |

## Overlap with #5479 (recursion DEPTH/limit)
This PR owns the recursion **message text**. The remaining `triggerC` recursion failures (e.g. 2.2, 2.3, 3.3.1, 3.6.3) are **depth-value** failures: legitimate recursion that needs depth > 16, where VibeSQL now emits the correct message but SQLite (cap 1000) succeeds. Bumping `MAX_TRIGGER_RECURSION_DEPTH` to 1000 is #5479's job; with this PR's message fix already in place, that change should flip those tests directly.

## Tests
- New Rust assertions in `tests/triggers/ddl.rs`: system-table, INSTEAD-OF-on-table, BEFORE/AFTER-on-view wording.
- `tests/triggers/error_handling.rs::test_recursion_prevention` tightened to assert the exact `too many levels of trigger recursion` string.
- `cargo test -p vibesql-executor -p vibesql-parser` green (the `deep_expression_tests` stack-overflow seen once under 4-way concurrent builders is pre-existing flakiness, unrelated to triggers; passes in isolation and on a clean run).

## Follow-ons (to file)
- Quoted-name echo in "already exists": `trigger1-1.2.2`/`1.2.3` expect `trigger "tr1" already exists` / `trigger [tr1] already exists`. VibeSQL's parser strips the source quoting, so the name token is not preserved — needs parser token preservation. Out of scope here.
- NEW/OLD pseudo-variable context errors (`trigger4.test`) and `main.` table-name qualification (`trigger4-3.x`: `no such table: main.test2`) — separate clusters noted in #5469.

## Test plan
- [ ] CI green
- [ ] `make test-tcl-file FILE=trigger1.test` shows 25 passing
- [ ] `make test-tcl-file FILE=triggerC.test` shows 72 passing

Generated with [Claude Code](https://claude.com/claude-code)