### PR TITLE
fix(tcl-harness): demote CREATE TEMP TABLE so temp tables survive batch reloads

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -55,11 +55,16 @@ set ::pragma_defer_foreign_keys 0        ;# Default: OFF; auto-resets at COMMIT/
 # This emulates SQLite's deprecated DQS_DML mode (SQLITE_DBCONFIG_DQS_DML)
 set ::dqs_dml_mode 0  ;# Default: OFF (double quotes are identifiers)
 
-# TEMP TABLE emulation
-# Since VibeSQL stores temp tables in the main schema, we rename them to avoid conflicts.
-# Maps: original_name -> unique_name (e.g., "t1" -> "_temp_t1_12345")
-set ::temp_table_map [dict create]
-set ::temp_table_session_id [pid]  ;# Use PID for uniqueness
+# TEMP TABLE emulation — see strip_temp_table_keyword (below) for the rationale.
+# SQLite keeps a single connection open for the whole test file, so a TEMP table
+# created in one statement is visible to every later statement. This shim, by
+# contrast, spawns a fresh VibeSQL CLI process per SQL batch against a shared
+# file-backed database. VibeSQL (correctly) treats TEMP tables as connection-
+# scoped and drops them on process exit (#5505/#5511), so a real CREATE TEMP
+# TABLE would vanish before the next batch — and any index DDL created on it
+# would leak into the persistent schema and fail to reload ("Table 'main.<t>'
+# not found", #5512). To match SQLite's whole-test temp-visibility under this
+# multi-process model we demote TEMP tables to ordinary (persistent) tables.
 
 # SQLite configuration variables (used by tests)
 set ::AUTOVACUUM 0       ;# Auto-vacuum not supported
@@ -462,88 +467,76 @@ proc translate_error_to_sqlite {vibesql_error} {
 #-----------------------------------------------------------------------------
 # TEMP TABLE Emulation
 #-----------------------------------------------------------------------------
-# VibeSQL stores temp tables in the main schema, but SQLite uses a separate
-# temp schema. Tests may create temp tables with the same names as regular
-# tables, or reuse temp table names across test cases expecting isolation.
+# Demote `CREATE TEMP[ORARY] TABLE` to `CREATE TABLE`, keeping the original
+# name unchanged.
 #
-# Solution: Rename temp tables to unique names (_temp_<name>_<session>_<counter>)
-# and rewrite all SQL to use the unique names.
+# Why: SQLite's TCL interface holds one connection open for the entire test
+# file, so a TEMP table is visible to every subsequent statement in that file.
+# This shim instead runs each SQL batch in its own short-lived VibeSQL CLI
+# process against a shared file-backed database. VibeSQL correctly scopes TEMP
+# tables to the connection and drops them when the process exits (#5505/#5511),
+# so a genuine TEMP table created in one batch is gone by the next — and worse,
+# `CREATE INDEX` on it leaks into the persistent schema and then fails to reload
+# the next time the file is opened, surfacing as the spurious harness log line
+# `Table 'main.<t>' not found` (#5512).
+#
+# The earlier emulation also renamed temp tables to unique `_temp_<n>_<pid>_<c>`
+# identifiers and rewrote every reference via a `::temp_table_map` dict. That was
+# fragile (the word-boundary rewrite mangled column names, so it was disabled at
+# the call site) AND the in-memory map did not survive the between-batch process
+# reload — the root cause of #5512. Demotion needs no rename and no persistent
+# state: the table keeps its real name, lives in the main schema, persists across
+# batches like an ordinary table, and references resolve naturally. The map is
+# eliminated entirely.
+#
+# Shadowing: in SQLite a TEMP table shadows a same-named main table for the rest
+# of the connection. Some tests rely on this — e.g. where-15.1 does
+# `CREATE TEMP TABLE t1 (...)` while a main `t1` from the file's setup is still
+# live. A bare demotion would then hit `table "t1" already exists`. To emulate
+# the shadow we inject `DROP TABLE IF EXISTS <name>;` ahead of each demoted
+# `CREATE TEMP TABLE` (unless it carries IF NOT EXISTS, which has its own
+# create-if-absent semantics). This is lossy for the rare test that later
+# re-reads the shadowed main table after dropping the temp, but it matches the
+# observable result for the common create-then-use pattern and is strictly
+# better than the previous abort.
+#
+# Scope: only `CREATE TEMP TABLE` is demoted. TEMP VIEW/TRIGGER are left alone —
+# some tests deliberately exercise their session-isolation semantics (see the
+# skip list), and they are not implicated in #5512.
 
-proc get_temp_table_name {original_name} {
-    # Get or create a unique name for a temp table
-    global temp_table_map temp_table_session_id
-    variable temp_counter
-    if {![info exists temp_counter]} {
-        set temp_counter 0
-    }
-
-    set key [string tolower $original_name]
-    if {[dict exists $::temp_table_map $key]} {
-        return [dict get $::temp_table_map $key]
-    }
-
-    incr temp_counter
-    set unique_name "_temp_${original_name}_${::temp_table_session_id}_${temp_counter}"
-    dict set ::temp_table_map $key $unique_name
-    return $unique_name
-}
-
-proc clear_temp_table {original_name} {
-    # Remove a temp table mapping (called on DROP)
-    set key [string tolower $original_name]
-    if {[dict exists $::temp_table_map $key]} {
-        dict unset ::temp_table_map $key
-    }
-}
-
-proc reset_temp_tables {} {
-    # Reset all temp table mappings (called at test cleanup)
-    set ::temp_table_map [dict create]
-}
-
-proc rewrite_temp_table_sql {sql} {
-    # Rewrite SQL to handle temp table creation and references
-    # Returns modified SQL with temp tables renamed
-
-    set result $sql
-
-    # Handle CREATE TEMP TABLE / CREATE TEMPORARY TABLE
-    # Pattern: CREATE TEMP[ORARY] TABLE [IF NOT EXISTS] name
-    if {[regexp -nocase {CREATE\s+TEMP(?:ORARY)?\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\[?[a-zA-Z_][a-zA-Z0-9_]*\]?)} $sql match table_name]} {
-        # Strip brackets if present
-        set clean_name [string trim $table_name {[]}]
-        set unique_name [get_temp_table_name $clean_name]
-
-        # Replace CREATE TEMP TABLE with CREATE TABLE using unique name
-        # Remove TEMP/TEMPORARY keyword and replace table name
-        set result [regsub -nocase {CREATE\s+TEMP(?:ORARY)?\s+TABLE\s+(IF\s+NOT\s+EXISTS\s+)?(\[?[a-zA-Z_][a-zA-Z0-9_]*\]?)} $result "CREATE TABLE \\1$unique_name"]
-    }
-
-    # Handle DROP TABLE for temp tables
-    # Check if this is dropping a known temp table
-    if {[regexp -nocase {DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?(\[?[a-zA-Z_][a-zA-Z0-9_]*\]?)} $sql match table_name]} {
-        set clean_name [string trim $table_name {[]}]
-        set key [string tolower $clean_name]
-        if {[dict exists $::temp_table_map $key]} {
-            set unique_name [dict get $::temp_table_map $key]
-            set result [regsub -nocase "DROP\\s+TABLE\\s+(IF\\s+EXISTS\\s+)?\\[?${clean_name}\\]?" $result "DROP TABLE \\1$unique_name"]
-            clear_temp_table $clean_name
+proc strip_temp_table_keyword {sql} {
+    # Demote every `CREATE TEMP[ORARY] TABLE <name>` to a plain `CREATE TABLE`,
+    # keeping <name> unchanged, and prepend `DROP TABLE IF EXISTS <name>;` to
+    # emulate the temp-over-main shadow (skipped when IF NOT EXISTS is present).
+    #
+    # Implemented as a manual left-to-right scan (regsub -command needs Tcl 8.7;
+    # the runner is on 8.5). \y word boundaries keep the keyword match out of
+    # identifiers/string literals; the captured name handles optional []/""/``
+    # quoting. Submatches: c1 = optional "IF NOT EXISTS ", c2 = the table name.
+    set pat {\yCREATE\s+TEMP(?:ORARY)?\s+TABLE\s+(IF\s+NOT\s+EXISTS\s+)?(\[[^\]]+\]|"[^"]+"|`[^`]+`|[A-Za-z_][A-Za-z0-9_]*)}
+    set out ""
+    set pos 0
+    while {1} {
+        set rest [string range $sql $pos end]
+        if {![regexp -indices -nocase $pat $rest m c1 c2]} {
+            append out $rest
+            break
         }
+        lassign $m ms me
+        # Copy the text before the match unchanged.
+        append out [string range $rest 0 [expr {$ms - 1}]]
+        set name [string range $rest [lindex $c2 0] [lindex $c2 1]]
+        if {[lindex $c1 0] >= 0} {
+            # IF NOT EXISTS present: preserve it, do not pre-drop (create-if-absent).
+            append out "CREATE TABLE IF NOT EXISTS ${name}"
+        } else {
+            # Pre-drop to emulate the temp-over-main shadow.
+            append out "DROP TABLE IF EXISTS ${name}; CREATE TABLE ${name}"
+        }
+        set pos [expr {$pos + $me + 1}]
+        if {$pos > [string length $sql]} break
     }
-
-    # Replace references to known temp tables in the SQL
-    # This handles SELECT, INSERT, UPDATE, DELETE, etc.
-    dict for {original_key unique_name} $::temp_table_map {
-        # Simple word-boundary replacement using \y (TCL word boundary)
-        # This is safer than complex nested loops with regex metacharacters
-
-        # Replace table name with word boundaries
-        # Pattern: word boundary + table name + word boundary (case insensitive)
-        set pattern "(?i)\\y${original_key}\\y"
-        set result [regsub -all $pattern $result $unique_name]
-    }
-
-    return $result
+    return $out
 }
 
 #-----------------------------------------------------------------------------
@@ -1261,11 +1254,9 @@ proc execsql {sql {db ""}} {
         set sql [convert_dqs_to_single_quotes $sql]
     }
 
-    # TEMP TABLE emulation is disabled - simple word-boundary replacement
-    # breaks column names and other identifiers. Proper solution requires
-    # either SQL parsing or actual TEMP TABLE support in VibeSQL.
-    # TODO: Implement proper TEMP TABLE support in VibeSQL core
-    # set sql [rewrite_temp_table_sql $sql]
+    # Demote CREATE TEMP TABLE -> CREATE TABLE so temp tables persist across the
+    # shim's per-batch process model (see strip_temp_table_keyword, #5512).
+    set sql [strip_temp_table_keyword $sql]
 
     # Always track PRAGMA settings in any SQL (handles multi-statement blocks)
     track_pragma_setting $sql
@@ -1763,6 +1754,9 @@ proc execsql_with_headers {sql {db ""}} {
         set sql [convert_dqs_to_single_quotes $sql]
     }
 
+    # Demote CREATE TEMP TABLE -> CREATE TABLE (see strip_temp_table_keyword, #5512).
+    set sql [strip_temp_table_keyword $sql]
+
     # Always track PRAGMA settings in any SQL (handles multi-statement blocks)
     track_pragma_setting $sql
 
@@ -1802,6 +1796,9 @@ proc execsql2 {sql {db ""}} {
     if {$::dqs_dml_mode} {
         set sql [convert_dqs_to_single_quotes $sql]
     }
+
+    # Demote CREATE TEMP TABLE -> CREATE TABLE (see strip_temp_table_keyword, #5512).
+    set sql [strip_temp_table_keyword $sql]
 
     # Always track PRAGMA settings in any SQL (handles multi-statement blocks)
     track_pragma_setting $sql
@@ -5301,10 +5298,6 @@ proc run_test_file {filename} {
     # Clear the opened_dbs tracking so all databases are treated as "first time" opens
     # This ensures sqlite3 proc will delete stale database files from previous test runs
     set ::opened_dbs {}
-
-    # Reset temp table mappings for fresh session
-    # This ensures temp table names don't conflict across test files
-    reset_temp_tables
 
     puts "Running: $filename"
     puts ""


### PR DESCRIPTION
Closes #5512

## Root cause
The TCL conformance shim (`scripts/tester_vibesql.tcl`) runs **each SQL batch in its own short-lived VibeSQL CLI process** against a shared file-backed database, while SQLite keeps **one connection open for the whole test file**. Since #5505/#5511 the engine correctly scopes `TEMP` tables to the connection and drops them when the process exits. So a genuine `CREATE TEMP TABLE` created in one `execsql` batch is gone by the next batch — and a `CREATE INDEX` on it leaks into the persistent schema and then fails to reload the next time the file is opened, surfacing as the spurious harness log line:

```
Table 'main.<t>' not found
```

(Verified directly: `CREATE TEMP TABLE tbl(a,b); CREATE INDEX tbl_idx ON tbl(b);` in process 1, then a fresh process loads the DB and replays the stored `CREATE INDEX tbl_idx ON tbl (b Asc)`, which now resolves `tbl` to `main.tbl` → not found.)

The pre-existing emulation renamed temp tables to unique `_temp_<n>_<pid>_<c>` identifiers and rewrote references via an in-memory `::temp_table_map` dict. That was fragile (the word-boundary rewrite mangled column names, so it was already disabled at the call site) **and** the map did not survive the between-batch process reload — the literal root cause described in the issue.

## Approach chosen: demote (not pass-through, not persist-map)
I evaluated all three:
- **Pass-through** (let the engine handle real TEMP tables): rejected. Confirmed empirically that a real TEMP table from batch N is dropped before batch N+1 in this per-batch-process model, so `trigger2.test`'s create-temp-then-use-in-next-batch pattern fails with `tbl not found`. The engine's temp lifecycle is correct (matches SQLite's drop-on-close); it's the harness's multi-process model that diverges from SQLite's single-connection model.
- **Persist/rebuild the map**: would re-introduce the fragile rename + reference-rewrite machinery that already broke column names.
- **Demote** (chosen): strip the `TEMP`/`TEMPORARY` keyword so the table is created in the main schema under its **real name**. It persists across batches like any ordinary table, references resolve naturally with **no rename and no map**, and both the table and any index on it reload cleanly. The `::temp_table_map` and its helpers are deleted entirely.

To emulate SQLite's temp-over-main shadow (e.g. `where-15.1` creates `CREATE TEMP TABLE t1` while a main `t1` from setup is still live), each demoted `CREATE` is prefixed with `DROP TABLE IF EXISTS <name>;` (skipped when `IF NOT EXISTS` is present). Scope is limited to `CREATE TEMP TABLE`; `TEMP VIEW`/`TEMP TRIGGER` are untouched (some tests rely on their session-isolation semantics).

The new `strip_temp_table_keyword` proc uses a manual `regexp -indices` scan (the runner is on Tcl 8.5, which lacks `regsub -command`) and was unit-tested for: basic/TEMPORARY, multi-statement batches, `IF NOT EXISTS`, bracket/double-quote/backtick-quoted names, leading/newline whitespace, case-insensitivity, and non-matches (`tempfoo`, `temp_col`, plain `CREATE TABLE`).

## TCL files improved (before → after, same engine binary)
| File | Before | After |
|------|--------|-------|
| `trigger2.test` | 12 pass / 0 fail (aborted mid-file on `main.tbl not found`) | **48 pass** / 3 fail |
| `trigger1.test` | 20 pass / 50 fail | **24 pass** / 46 fail |

The remaining `trigger2` failures (`2.12`/`2.14`) are unrelated ("Trigger recursion depth limit exceeded"); the `main.tbl not found` artifact is fully eliminated.

## No-regression evidence
Ran an identical 29-file set (all Priority-1 core categories + temp-heavy files) against the **old** shim vs the **new** shim with the same release binary:

- **Old shim:** 966 pass / 95 fail
- **New shim:** 1006 pass / 94 fail
- **Net: +40 pass, -1 fail (i.e. one fewer failure overall), zero `main.<t> not found` artifacts**

Per-file: `select1` (188/0), `where` (148/20), `join` (174/3), `insert` (51/0), `update` (126/2), `index` (68/1), `orderby1` (37/1), `view` (24/0), etc. are **identical** before/after. `where-15.1` (temp shadow) confirmed still passing after adding the `DROP TABLE IF EXISTS` shadow emulation.

Harness-only change — no engine code touched, so `cargo` tests are unaffected.

## Follow-ons
- #5513 (make temp indexes fully schema-aware in the engine): the `main.<t> not found` reload artifact also stems from `CREATE INDEX` on a TEMP table leaking into the persistent schema. This PR sidesteps it at the harness level; #5513 remains the engine-side fix.

## Coordination note
Per-issue parallel work: #5469 may also edit `scripts/tester_vibesql.tcl`, but in the error allow-list (a different function). This PR touches only the temp-table-rewrite area (`strip_temp_table_keyword`, the three `execsql*` call sites, and the removed `::temp_table_map` helpers) — disjoint hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)