### PR TITLE
fix(storage): index-ordered scans wrong after mid-statement tombstone delete (#5524)

### DIFF
--- a/crates/vibesql-executor/src/insert/replace.rs
+++ b/crates/vibesql-executor/src/insert/replace.rs
@@ -264,8 +264,11 @@ pub fn handle_replace_conflicts(
         // never did so; that is a separate pre-existing gap tracked outside
         // this PR.
     } else {
-        // No compaction - just adjust remaining user-defined index entries
-        // (entries pointing to indices > deleted need to be decremented)
+        // No compaction: the deleted keys' index entries were already removed
+        // by `batch_update_indexes_for_delete`, and the bitmap-delete model
+        // keeps every surviving row's physical position stable, so no row-id
+        // renumbering is needed. `adjust_indexes_after_delete` is a no-op that
+        // documents this maintenance contract (issue #5524).
         db.adjust_indexes_after_delete(table_name, &deleted_indices);
     }
 

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -96,6 +96,7 @@ mod natural_join;
 mod non_unique_disk_index_tests;
 mod not_operator_tests;
 mod operator_edge_cases;
+mod order_by_compaction_tests;
 mod order_by_index_optimization_tests;
 mod phase3_join_optimization;
 mod predicate_pushdown;

--- a/crates/vibesql-executor/src/tests/order_by_compaction_tests.rs
+++ b/crates/vibesql-executor/src/tests/order_by_compaction_tests.rs
@@ -1,0 +1,211 @@
+//! Regression tests for issue #5524.
+//!
+//! An in-memory `ORDER BY <pk>` index-ordered scan returned the wrong rows
+//! after a DML statement compacted (or tombstoned) rows mid-statement, because
+//! the user-defined B-tree index's lazy `pending_deletions` adjustment got out
+//! of sync with the table's physical row positions. The unordered scan and
+//! `count(*)` returned correct results, but the index-ordered `ORDER BY` scan
+//! consulted stale physical positions and produced empty / wrong output.
+//!
+//! These tests drive pure in-memory `Database` usage (no persistence reload,
+//! which would otherwise mask the bug by rebuilding indices) and assert that
+//! the index-ordered scan matches the unordered scan exactly.
+
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+use crate::select::SelectExecutor;
+use crate::{
+    CreateTableExecutor, DeleteExecutor, InsertExecutor, UpdateExecutor,
+};
+
+fn create_test_db() -> Database {
+    let mut db = Database::new();
+    db.catalog.set_case_sensitive_identifiers(false);
+    db
+}
+
+/// Execute a non-SELECT statement.
+fn exec(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse {sql:?}: {e:?}"));
+    match stmt {
+        vibesql_ast::Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).unwrap();
+        }
+        vibesql_ast::Statement::Update(s) => {
+            UpdateExecutor::execute(&s, db).unwrap();
+        }
+        vibesql_ast::Statement::Delete(s) => {
+            DeleteExecutor::execute(&s, db).unwrap();
+        }
+        other => panic!("unexpected statement type for exec(): {other:?}"),
+    }
+}
+
+/// Execute a SELECT and return the rows as Vec<Vec<SqlValue>>.
+fn query(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse {sql:?}: {e:?}"));
+    let vibesql_ast::Statement::Select(select_stmt) = stmt else {
+        panic!("expected SELECT statement: {sql:?}");
+    };
+    let executor = SelectExecutor::new(db);
+    executor
+        .execute(&select_stmt)
+        .unwrap_or_else(|e| panic!("execute {sql:?}: {e:?}"))
+        .into_iter()
+        .map(|r| r.values.to_vec())
+        .collect()
+}
+
+/// Same query but sorted in Rust so it can be compared against the
+/// index-ordered scan regardless of natural scan order.
+fn query_sorted(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let mut rows = query(db, sql);
+    rows.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
+    rows
+}
+
+/// The exact repro from issue #5524: an `UPDATE OR REPLACE` that deletes a
+/// conflicting row mid-statement, after a prior tombstone exists, leaving one
+/// live row. The index-ordered `ORDER BY a` scan must return that one row.
+#[test]
+fn test_order_by_pk_after_mid_statement_compaction_5524() {
+    let mut db = create_test_db();
+
+    exec(&mut db, "CREATE TABLE t1(a INT PRIMARY KEY, b) WITHOUT ROWID");
+    exec(&mut db, "INSERT INTO t1 VALUES (1, 'one'), (2, 'two'), (3, 'three')");
+    // Tombstone at idx0.
+    exec(&mut db, "DELETE FROM t1 WHERE a = 1");
+    exec(&mut db, "INSERT OR REPLACE INTO t1 VALUES (2, 'three')");
+    // Deletes the conflicting (3,three); should compact/tombstone mid-statement.
+    exec(&mut db, "UPDATE OR REPLACE t1 SET a = 3 WHERE a = 2");
+
+    let unordered = query_sorted(&db, "SELECT a, b FROM t1");
+    let count: i64 = match query(&db, "SELECT count(*) FROM t1")[0][0] {
+        SqlValue::Integer(n) => n,
+        ref v => panic!("count not integer: {v:?}"),
+    };
+    let ordered_asc = query(&db, "SELECT a, b FROM t1 ORDER BY a");
+    let ordered_desc = query(&db, "SELECT a, b FROM t1 ORDER BY a DESC");
+
+    assert_eq!(
+        count as usize,
+        unordered.len(),
+        "count(*) must match unordered row count"
+    );
+
+    // The core assertion: the index-ordered scan must return the same live
+    // rows as the unordered scan.
+    assert_eq!(
+        ordered_asc, unordered,
+        "ORDER BY a (ASC) must return the same live rows as the unordered scan"
+    );
+
+    let mut desc_resorted = ordered_desc.clone();
+    desc_resorted.sort_by(|x, y| format!("{x:?}").cmp(&format!("{y:?}")));
+    assert_eq!(
+        desc_resorted, unordered,
+        "ORDER BY a DESC must return the same live rows as the unordered scan"
+    );
+
+    // Matches sqlite3 3.51.0: final live state is exactly (3, 'three').
+    assert_eq!(
+        ordered_asc,
+        vec![vec![SqlValue::Integer(3), SqlValue::Varchar(arcstr::ArcStr::from("three"))]],
+        "final state should be the single row (3, 'three')"
+    );
+}
+
+/// Plain DELETE that crosses the compaction threshold mid-statement, leaving a
+/// gap. Index-ordered scan must still match the unordered scan.
+#[test]
+fn test_order_by_pk_after_delete_compaction_with_gaps_5524() {
+    let mut db = create_test_db();
+
+    exec(&mut db, "CREATE TABLE t2(a INT PRIMARY KEY, b)");
+    exec(
+        &mut db,
+        "INSERT INTO t2 VALUES (10,'a'),(20,'b'),(30,'c'),(40,'d'),(50,'e')",
+    );
+    // Delete a majority to force compaction (> 50% deleted).
+    exec(&mut db, "DELETE FROM t2 WHERE a IN (10, 30, 50)");
+
+    let unordered = query_sorted(&db, "SELECT a, b FROM t2");
+    let ordered = query(&db, "SELECT a, b FROM t2 ORDER BY a");
+
+    assert_eq!(ordered, unordered, "ORDER BY a must match unordered scan after compaction");
+    assert_eq!(
+        ordered,
+        vec![
+            vec![SqlValue::Integer(20), SqlValue::Varchar(arcstr::ArcStr::from("b"))],
+            vec![SqlValue::Integer(40), SqlValue::Varchar(arcstr::ArcStr::from("d"))],
+        ]
+    );
+}
+
+/// Multiple indexes: a secondary index ORDER BY must also remain correct after
+/// a compacting delete.
+#[test]
+fn test_order_by_secondary_index_after_compaction_5524() {
+    let mut db = create_test_db();
+
+    exec(&mut db, "CREATE TABLE t3(a INT PRIMARY KEY, b INT, c)");
+    db.create_index(
+        "idx_t3_b".to_string(),
+        "t3".to_string(),
+        false,
+        vec![vibesql_ast::IndexColumn::Column {
+            column_name: "b".to_string(),
+            prefix_length: None,
+            direction: vibesql_ast::OrderDirection::Asc,
+        }],
+    )
+    .unwrap();
+
+    exec(
+        &mut db,
+        "INSERT INTO t3 VALUES (1,50,'x'),(2,40,'y'),(3,30,'z'),(4,20,'w'),(5,10,'v')",
+    );
+    // Delete majority -> compaction, then both PK and secondary index must be
+    // rebuilt to the post-compaction positions.
+    exec(&mut db, "DELETE FROM t3 WHERE a IN (1, 2, 3)");
+
+    let unordered = query_sorted(&db, "SELECT a, b FROM t3");
+
+    let by_pk = query(&db, "SELECT a, b FROM t3 ORDER BY a");
+    assert_eq!(by_pk, unordered, "ORDER BY pk must match unordered scan");
+
+    let by_b = query(&db, "SELECT a, b FROM t3 ORDER BY b");
+    assert_eq!(
+        by_b,
+        vec![
+            vec![SqlValue::Integer(5), SqlValue::Integer(10)],
+            vec![SqlValue::Integer(4), SqlValue::Integer(20)],
+        ],
+        "ORDER BY secondary index column must match post-compaction order"
+    );
+}
+
+/// Tombstone-only path (no compaction): deleting a minority via the in-place
+/// mark path still keeps the index-ordered scan correct.
+#[test]
+fn test_order_by_pk_after_partial_delete_no_compaction_5524() {
+    let mut db = create_test_db();
+
+    exec(&mut db, "CREATE TABLE t4(a INT PRIMARY KEY, b)");
+    exec(
+        &mut db,
+        "INSERT INTO t4 VALUES (1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e')",
+    );
+    // Delete a single row (minority -> no compaction, just a tombstone).
+    exec(&mut db, "DELETE FROM t4 WHERE a = 3");
+
+    let unordered = query_sorted(&db, "SELECT a, b FROM t4");
+    let ordered = query(&db, "SELECT a, b FROM t4 ORDER BY a");
+    assert_eq!(ordered, unordered, "ORDER BY a must match unordered scan with a tombstone");
+    assert_eq!(ordered.len(), 4);
+}

--- a/crates/vibesql-storage/src/database/indexes/index_maintenance/delete.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance/delete.rs
@@ -339,112 +339,51 @@ impl IndexManager {
         }
     }
 
-    /// Adjust row indices after row deletions for user-defined indexes
+    /// Hook called after rows are tombstone-deleted (without compaction) so
+    /// user-defined indexes can stay in sync with the table's physical row
+    /// positions.
     ///
-    /// For in-memory indexes, this uses lazy adjustment: instead of immediately adjusting
-    /// all row indices (O(n) for table size), we store the deleted indices in a pending
-    /// list and apply the adjustment lazily during lookups. This makes single-row deletes
-    /// O(1) instead of O(n).
+    /// # No-op by design (issue #5524)
     ///
-    /// For disk-backed indexes, we still use the immediate adjustment approach since
-    /// the B+tree has its own row ID adjustment mechanism.
+    /// VibeSQL tables use an **append-only + deletion-bitmap** storage model:
+    /// rows are appended to the end of the row vector and never moved, deletes
+    /// flip a tombstone bit, and physical row positions only ever change during
+    /// an explicit [`Table::compact`] — which always triggers a full
+    /// [`Database::rebuild_indexes`] in every caller. Surviving rows therefore
+    /// keep their physical positions across a non-compacting delete.
     ///
-    /// # Arguments
-    /// * `table_name` - The table whose indexes need adjustment
-    /// * `deleted_indices` - Sorted list of deleted row indices (ascending order)
-    pub fn adjust_indexes_after_delete(&mut self, table_name: &str, deleted_indices: &[usize]) {
-        if deleted_indices.is_empty() {
-            return;
-        }
-
-        // Find all indexes for this table
-        let index_names: Vec<String> = self
-            .indexes
-            .iter()
-            .filter(|(_, metadata)| metadata.table_name.eq_ignore_ascii_case(table_name))
-            .map(|(name, _)| name.clone())
-            .collect();
-
-        for index_name in index_names {
-            if let Some(index_data) = self.index_data.get_mut(&index_name) {
-                match index_data {
-                    IndexData::InMemory { pending_deletions, .. } => {
-                        // Lazy adjustment: merge deleted_indices into pending_deletions
-                        // This is O(d) where d = number of deletes, instead of O(n) for table size
-                        //
-                        // Note: deleted_indices are raw indices that haven't been adjusted yet.
-                        // We need to adjust them based on existing pending_deletions before
-                        // merging.
-                        let adjusted_deletions: Vec<usize> = deleted_indices
-                            .iter()
-                            .map(|&idx| {
-                                // The deleted index needs to be adjusted for previously pending
-                                // deletions that are less than it,
-                                // since those deletions affect the raw row indices
-                                let adjustment = pending_deletions.partition_point(|&d| d < idx);
-                                idx - adjustment
-                            })
-                            .collect();
-
-                        // Merge adjusted deletions into pending_deletions (maintaining sorted
-                        // order)
-                        if pending_deletions.is_empty() {
-                            *pending_deletions = adjusted_deletions;
-                        } else {
-                            // Merge two sorted lists
-                            let mut merged = Vec::with_capacity(
-                                pending_deletions.len() + adjusted_deletions.len(),
-                            );
-                            let mut i = 0;
-                            let mut j = 0;
-                            while i < pending_deletions.len() && j < adjusted_deletions.len() {
-                                if pending_deletions[i] <= adjusted_deletions[j] {
-                                    merged.push(pending_deletions[i]);
-                                    i += 1;
-                                } else {
-                                    merged.push(adjusted_deletions[j]);
-                                    j += 1;
-                                }
-                            }
-                            merged.extend_from_slice(&pending_deletions[i..]);
-                            merged.extend_from_slice(&adjusted_deletions[j..]);
-                            *pending_deletions = merged;
-                        }
-
-                        // Compact if needed (apply pending deletions when list gets too large)
-                        if index_data.needs_compaction() {
-                            index_data.compact_pending_deletions();
-                        }
-                    }
-                    IndexData::DiskBacked { btree, .. } => {
-                        // For disk-backed indexes, we still use immediate adjustment
-                        // since the B+tree has its own efficient row ID adjustment
-                        match acquire_btree_lock(btree) {
-                            Ok(mut guard) => {
-                                guard.adjust_row_ids_after_delete(deleted_indices);
-                            }
-                            Err(e) => {
-                                log::warn!(
-                                    "BTreeIndex lock acquisition failed in adjust_indexes_after_delete: {}",
-                                    e
-                                );
-                            }
-                        }
-                    }
-                    IndexData::IVFFlat { .. } | IndexData::Hnsw { .. } => {
-                        // No row-id adjustment is needed for vector indexes here.
-                        //
-                        // Deletes tombstone rows via the table's deletion bitmap
-                        // and do NOT renumber surviving row positions, so the
-                        // absolute row_ids stored in the vector index remain
-                        // valid. The deleted row's vector was already removed in
-                        // `update_indexes_for_delete_with_values`. Row positions
-                        // only change on compaction, which renumbers rows and
-                        // triggers a full vector-index rebuild (#5446) via
-                        // `rebuild_indexes`.
-                    }
-                }
-            }
-        }
+    /// The deleted row's index entry has already been removed by
+    /// [`IndexManager::batch_update_indexes_for_delete`] before this is called.
+    /// That entry removal is the *only* maintenance a tombstone delete needs;
+    /// the remaining entries still point at valid physical positions.
+    ///
+    /// Previously this method "renumbered" the surviving entries by recording
+    /// the deleted positions in a lazy `pending_deletions` list (in-memory) or
+    /// decrementing stored row-ids (disk-backed), on the assumption that a
+    /// delete compacts the table the way `Vec::remove` would. That assumption is
+    /// false for the bitmap model, so the renumbered index positions drifted
+    /// below the true physical positions. An index-ordered scan
+    /// (`SELECT ... ORDER BY <indexed-col>`) then resolved those stale positions
+    /// through [`Table::get_row`], landing on a tombstoned slot (or a different
+    /// live row) and returning wrong / empty results — while the unordered
+    /// sequential scan, which ignores the index, stayed correct. This silently
+    /// surfaced in pure in-memory usage; the CLI/persistence reload masked it by
+    /// rebuilding indexes on load.
+    ///
+    /// The DELETE fast path already relied on entry-removal alone (it never
+    /// called this hook on the non-compacting branch), confirming that no
+    /// renumbering is required. We keep the method (and its callers) so the
+    /// maintenance contract stays explicit, but it intentionally does nothing.
+    ///
+    /// [`Table::compact`]: crate::table::Table
+    /// [`Database::rebuild_indexes`]: crate::Database
+    /// [`Table::get_row`]: crate::table::Table::get_row
+    /// [`IndexManager::batch_update_indexes_for_delete`]: Self::batch_update_indexes_for_delete
+    pub fn adjust_indexes_after_delete(&mut self, _table_name: &str, _deleted_indices: &[usize]) {
+        // Intentionally a no-op — see the doc comment above (issue #5524).
+        //
+        // Physical row positions are stable across a non-compacting delete, so
+        // the index entries (minus the already-removed deleted keys) remain
+        // correct. Any renumbering here would corrupt index-ordered scans.
     }
 }


### PR DESCRIPTION
## Summary

Fixes a silent read-path correctness bug: after a DML statement tombstone-deletes rows in-memory (e.g. an `UPDATE OR REPLACE` / `INSERT OR REPLACE` that deletes a conflicting row), a subsequent `SELECT ... ORDER BY <indexed-col>` that uses an index-ordered scan returned the wrong rows (often empty), while the unordered `SELECT` and `count(*)` stayed correct.

Closes #5524

## Root cause — where index positions went stale

`IndexManager::adjust_indexes_after_delete` renumbered surviving user-index row positions after a non-compacting delete:
- in-memory indexes: merged the deleted physical positions into the lazy `pending_deletions` list, so every scan path (`point_lookup`, `range_scan`, `reverse_scan`, `prefix_match`, `covering`, `streaming`) subtracted them via `adjust_row_index`;
- disk-backed indexes: decremented stored row-ids via `BTreeIndex::adjust_row_ids_after_delete`.

That renumbering assumes a delete *compacts* the table the way `Vec::remove` does. But VibeSQL tables are **append-only with a deletion bitmap**: rows are only ever pushed to the end, deletes flip a tombstone bit, and physical positions change **only** during an explicit `Table::compact()` — which every caller already follows with a full `Database::rebuild_indexes`. So across a non-compacting delete the surviving rows keep their physical positions, but the index renumbered them downward.

The index-ordered scan (`index_scan/execution.rs`) feeds the index-returned (adjusted) positions straight into `Table::get_row(idx)` / `Table::is_row_visible(idx)`, which treat `idx` as a **physical** position and skip tombstones. With the index drifted below the true positions, the scan landed on a tombstoned slot → `get_row` returns `None` → empty/wrong result. The unordered sequential scan ignores the index, so it stayed correct. CLI/persistence reload masked the bug by rebuilding indexes on load.

Repro state from the issue: live row at physical idx1, `pending_deletions=[0]` ⇒ `adjust_row_index(1) = 1 - 1 = 0`, and physical row 0 is the tombstone ⇒ `get_row(0) = None`.

## The fix

Make `adjust_indexes_after_delete` a **no-op**. The deleted keys' entries are already removed by `batch_update_indexes_for_delete`, which is the *only* maintenance a tombstone delete needs — exactly what the DELETE fast path already relied on (it never called this hook on its non-compacting branch). The method and its callers are kept so the maintenance contract stays explicit and documented.

Compaction sites covered (all already full-rebuild indexes, so unaffected and verified):
- `delete_by_indices` / `delete_by_indices_batch` (`compacted` ⇒ `rebuild_indexes`)
- `compact_if_needed` after the per-row `mark_deleted_inplace` trigger loop (#5486)
- `gc_old_versions` via `vacuum_mvcc` (rebuilds whenever rows reclaimed)

Non-compacting delete sites that called the (now no-op) hook:
- `UPDATE OR REPLACE` conflict delete (FROM and non-FROM paths)
- `INSERT OR REPLACE` conflict delete

## sqlite3 3.51.0 parity

The exact issue repro now yields the single live row `(3, 'three')` for `SELECT a,b FROM t1 ORDER BY a`, matching sqlite3 3.51.0 and the unordered scan / `count(*)`.

## Reproduction + tests

New `crates/vibesql-executor/src/tests/order_by_compaction_tests.rs` (pure in-memory `Database`, no reload):
- `test_order_by_pk_after_mid_statement_compaction_5524` — exact issue repro (was `[]`, now `[(3,three)]`); also checks DESC
- `test_order_by_pk_after_delete_compaction_with_gaps_5524` — compacting DELETE leaving gaps
- `test_order_by_secondary_index_after_compaction_5524` — PK + secondary index after compaction
- `test_order_by_pk_after_partial_delete_no_compaction_5524` — tombstone-only, no compaction

Each asserts the index-ordered scan returns exactly the same live rows as the unordered scan.

## No-regression results

- `cargo test -p vibesql-storage --lib`: 699 passed, 0 failed (708 with `mvcc_enabled`)
- `cargo test -p vibesql-executor`: 4347 passed, 0 failed (lib + integration); executor lib `mvcc_enabled`: 2776 passed, 0 failed
- repro tests pass under both default and `mvcc_enabled` (MVCC visibility preserved)
- index / compact / vacuum / order-by-index-optimization / persistence-integration suites all green
- whole workspace builds

## Follow-ons

- The `pending_deletions` lazy-adjustment machinery (and `BTreeIndex::adjust_row_ids_after_delete`) is now never fed non-empty input through the maintenance path; it remains as defensive (effectively dead-in-practice) scan-path code. A future cleanup could remove `pending_deletions`/`adjust_row_index*` entirely and drop the now-vestigial `adjust_indexes_after_delete` callers.

## Test plan

- [x] `cargo test -p vibesql-storage -p vibesql-executor` green
- [x] new in-memory ORDER BY compaction regression tests pass (default + `mvcc_enabled`)
- [x] no regression in index/scan/compaction/persistence suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)