### PR TITLE
feat(trigger): parse CREATE TEMP/TEMPORARY TRIGGER + schema-qualified names

### DIFF
--- a/crates/vibesql-ast/src/ddl/schema.rs
+++ b/crates/vibesql-ast/src/ddl/schema.rs
@@ -130,6 +130,14 @@ pub struct CreateTriggerStmt {
     /// name already exists is a no-op success rather than a "trigger already
     /// exists" error (SQLite semantics).
     pub if_not_exists: bool,
+    /// Optional schema qualifier for the trigger, taken from either the
+    /// `TEMP`/`TEMPORARY` modifier (`CREATE TEMP TRIGGER ...` → `Some("temp")`)
+    /// or an explicit schema prefix on the name (`CREATE TRIGGER main.r1 ...`
+    /// → `Some("main")`). `None` means the trigger lives in the default
+    /// (main) schema. SQLite places a trigger in the same schema as its target
+    /// table and uses this to disambiguate when a temp table shadows a main
+    /// table of the same name (triggerD-3.1/3.2).
+    pub schema: Option<String>,
     pub trigger_name: String,
     pub timing: TriggerTiming,
     pub event: TriggerEvent,

--- a/crates/vibesql-catalog/src/store/tables.rs
+++ b/crates/vibesql-catalog/src/store/tables.rs
@@ -490,6 +490,7 @@ mod tests {
         // Create trigger with UPPERCASE table reference
         let trigger = TriggerDefinition {
             name: "Tr1".to_string(),
+            schema: None,
             timing: TriggerTiming::After,
             event: TriggerEvent::Update(None), // None = no column list
             table_name: "T1".to_string(),      // Different case than table creation
@@ -564,6 +565,7 @@ mod tests {
         // Create trigger with exact case match
         let trigger = TriggerDefinition {
             name: "Tr1".to_string(),
+            schema: None,
             timing: TriggerTiming::After,
             event: TriggerEvent::Update(None),
             table_name: "t1".to_string(), // Exact match required in case-sensitive mode
@@ -597,6 +599,7 @@ mod tests {
         for i in 1..=3 {
             let trigger = TriggerDefinition {
                 name: format!("tr{}", i),
+                schema: None,
                 timing: TriggerTiming::After,
                 event: TriggerEvent::Update(None),
                 table_name: "t1".to_string(),
@@ -639,6 +642,7 @@ mod tests {
         // Create triggers on both tables
         let trigger1 = TriggerDefinition {
             name: "tr1".to_string(),
+            schema: None,
             timing: TriggerTiming::After,
             event: TriggerEvent::Update(None),
             table_name: "t1".to_string(),
@@ -650,6 +654,7 @@ mod tests {
         };
         let trigger2 = TriggerDefinition {
             name: "tr2".to_string(),
+            schema: None,
             timing: TriggerTiming::After,
             event: TriggerEvent::Update(None),
             table_name: "t2".to_string(),

--- a/crates/vibesql-catalog/src/trigger.rs
+++ b/crates/vibesql-catalog/src/trigger.rs
@@ -7,6 +7,12 @@ use vibesql_ast::{TriggerAction, TriggerEvent, TriggerGranularity, TriggerTiming
 pub struct TriggerDefinition {
     /// Name of the trigger
     pub name: String,
+    /// Schema the trigger belongs to. `None` means the default (main) schema.
+    /// SQLite places a trigger in the same schema as its target table; a
+    /// `temp` schema is used for `CREATE TEMP TRIGGER` / `CREATE TRIGGER temp.x`
+    /// so it binds to the temp-table namesake rather than the main table when
+    /// both exist (triggerD-3.1/3.2).
+    pub schema: Option<String>,
     /// Trigger timing (BEFORE, AFTER, INSTEAD OF)
     pub timing: TriggerTiming,
     /// Trigger event (INSERT, UPDATE, DELETE)
@@ -41,6 +47,7 @@ impl TriggerDefinition {
     ) -> Self {
         TriggerDefinition {
             name,
+            schema: None,
             timing,
             event,
             table_name,
@@ -69,6 +76,7 @@ impl TriggerDefinition {
     ) -> Self {
         TriggerDefinition {
             name,
+            schema: None,
             timing,
             event,
             table_name,
@@ -78,6 +86,24 @@ impl TriggerDefinition {
             enabled: true,
             sql_definition: Some(sql_definition),
         }
+    }
+
+    /// Set the schema this trigger belongs to (builder-style).
+    ///
+    /// `None` keeps the trigger in the default (main) schema. A `Some("temp")`
+    /// value places it in the session temp schema so it binds to a temp-table
+    /// namesake. The schema name is stored verbatim; lookups compare it
+    /// case-insensitively.
+    pub fn with_schema(mut self, schema: Option<String>) -> Self {
+        self.schema = schema;
+        self
+    }
+
+    /// Returns true if this trigger lives in the temp schema.
+    pub fn is_temp(&self) -> bool {
+        self.schema
+            .as_deref()
+            .is_some_and(|s| s.eq_ignore_ascii_case("temp"))
     }
 
     /// Check if the trigger is enabled

--- a/crates/vibesql-executor/src/sqlite_schema.rs
+++ b/crates/vibesql-executor/src/sqlite_schema.rs
@@ -571,6 +571,7 @@ mod tests {
 
         let trigger = TriggerDefinition {
             name: "audit_insert".to_string(),
+            schema: None,
             table_name: "users".to_string(),
             timing: TriggerTiming::After,
             event: TriggerEvent::Insert,
@@ -597,6 +598,7 @@ mod tests {
 
         let trigger = TriggerDefinition {
             name: "track_status_change".to_string(),
+            schema: None,
             table_name: "orders".to_string(),
             timing: TriggerTiming::Before,
             event: TriggerEvent::Update(Some(vec!["status".to_string(), "updated_at".to_string()])),
@@ -619,6 +621,7 @@ mod tests {
 
         let trigger = TriggerDefinition {
             name: "instead_delete".to_string(),
+            schema: None,
             table_name: "my_view".to_string(),
             timing: TriggerTiming::InsteadOf,
             event: TriggerEvent::Delete,

--- a/crates/vibesql-executor/src/tests/triggers/conditions.rs
+++ b/crates/vibesql-executor/src/tests/triggers/conditions.rs
@@ -52,6 +52,7 @@ fn test_when_clause_filters_firing() {
     // Create trigger with WHEN (amount > 100) condition
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "log_high_amount".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,

--- a/crates/vibesql-executor/src/tests/triggers/coordination.rs
+++ b/crates/vibesql-executor/src/tests/triggers/coordination.rs
@@ -17,6 +17,7 @@ fn test_multiple_triggers_fire_in_order() {
     // Create first AFTER INSERT trigger
     let trigger1 = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "log_insert_1".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -33,6 +34,7 @@ fn test_multiple_triggers_fire_in_order() {
     // Create second AFTER INSERT trigger
     let trigger2 = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "log_insert_2".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -80,6 +82,7 @@ fn test_trigger_with_multiple_statements() {
     // Create trigger with multiple statements (separated by semicolons)
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "log_multiple".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -168,6 +171,7 @@ fn test_before_trigger_executes_first() {
     // Create BEFORE INSERT trigger that increments counter
     let before_trigger = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "before_trigger".to_string(),
         timing: TriggerTiming::Before,
         event: TriggerEvent::Insert,

--- a/crates/vibesql-executor/src/tests/triggers/ddl.rs
+++ b/crates/vibesql-executor/src/tests/triggers/ddl.rs
@@ -25,6 +25,7 @@ fn test_create_trigger() {
     // Create a trigger
     let stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "my_trigger".to_string(),
         timing: TriggerTiming::Before,
         event: TriggerEvent::Insert,
@@ -63,6 +64,7 @@ fn test_create_trigger_duplicate_error() {
     // Create a trigger
     let stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "my_trigger".to_string(),
         timing: TriggerTiming::Before,
         event: TriggerEvent::Insert,
@@ -97,6 +99,7 @@ fn test_create_trigger_if_not_exists_is_noop_when_present() {
 
     let stmt = CreateTriggerStmt {
         if_not_exists: true,
+        schema: None,
         trigger_name: "my_trigger".to_string(),
         timing: TriggerTiming::Before,
         event: TriggerEvent::Insert,
@@ -138,6 +141,7 @@ fn test_create_trigger_on_system_table_wording() {
 
     let stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "tr1".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Update(None),
@@ -160,6 +164,7 @@ fn test_create_instead_of_trigger_on_table_wording() {
 
     let stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "t1t".to_string(),
         timing: TriggerTiming::InsteadOf,
         event: TriggerEvent::Update(None),
@@ -191,6 +196,7 @@ fn test_create_before_after_trigger_on_view_wording() {
     for (timing, label) in [(TriggerTiming::Before, "BEFORE"), (TriggerTiming::After, "AFTER")] {
         let stmt = CreateTriggerStmt {
             if_not_exists: false,
+            schema: None,
             trigger_name: "v1t".to_string(),
             timing,
             event: TriggerEvent::Update(None),
@@ -223,6 +229,7 @@ fn test_drop_trigger() {
     // Create a trigger
     let stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "my_trigger".to_string(),
         timing: TriggerTiming::Before,
         event: TriggerEvent::Insert,
@@ -312,6 +319,7 @@ fn test_create_trigger_all_variations() {
     for (timing, suffix, target) in timings {
         let stmt = CreateTriggerStmt {
             if_not_exists: false,
+            schema: None,
             trigger_name: format!("trigger_{}", suffix),
             timing: timing.clone(),
             event: TriggerEvent::Insert,
@@ -353,6 +361,7 @@ fn make_test_table(db: &mut Database) {
 fn create_trigger_stmt(name: &str) -> CreateTriggerStmt {
     CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: name.to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -520,5 +529,59 @@ fn test_rename_table_rewrites_trigger_body_and_fires() {
         rows[0].values[0],
         vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("fired-2")),
         "trigger did not fire correctly against the renamed table"
+    );
+}
+
+/// `CREATE TEMP TRIGGER` parses, registers with the temp schema recorded on the
+/// catalog definition, and fires on its target table. Regression coverage for
+/// issue #5521 (triggerD TEMP/TEMPORARY support).
+#[test]
+fn test_create_temp_trigger_parses_records_schema_and_fires() {
+    use crate::{InsertExecutor, SelectExecutor};
+
+    let mut db = Database::new();
+
+    for sql in ["CREATE TABLE t1 (x INTEGER);", "CREATE TABLE log (y INTEGER);"] {
+        match vibesql_parser::Parser::parse_sql(sql).unwrap() {
+            vibesql_ast::Statement::CreateTable(stmt) => {
+                CreateTableExecutor::execute(&stmt, &mut db).unwrap();
+            }
+            other => panic!("Expected CreateTable, got {:?}", other),
+        }
+    }
+
+    // CREATE TEMP TRIGGER must parse and create successfully.
+    let trigger_sql =
+        "CREATE TEMP TRIGGER tr1 AFTER INSERT ON t1 BEGIN INSERT INTO log VALUES(new.x + 100); END";
+    match vibesql_parser::Parser::parse_sql(trigger_sql).unwrap() {
+        vibesql_ast::Statement::CreateTrigger(stmt) => {
+            assert_eq!(stmt.schema.as_deref(), Some("temp"), "TEMP modifier sets schema");
+            crate::TriggerExecutor::create_trigger(&mut db, &stmt).unwrap();
+        }
+        other => panic!("Expected CreateTrigger, got {:?}", other),
+    }
+
+    // The temp schema is recorded on the stored catalog definition.
+    let def = db.catalog.get_trigger("tr1").expect("temp trigger registered");
+    assert!(def.is_temp(), "stored trigger must record the temp schema");
+
+    // The temp trigger fires on its target table.
+    match vibesql_parser::Parser::parse_sql("INSERT INTO t1 VALUES (5);").unwrap() {
+        vibesql_ast::Statement::Insert(stmt) => {
+            InsertExecutor::execute(&mut db, &stmt).unwrap();
+        }
+        other => panic!("Expected Insert, got {:?}", other),
+    }
+
+    let select = match vibesql_parser::Parser::parse_sql("SELECT y FROM log;").unwrap() {
+        vibesql_ast::Statement::Select(stmt) => stmt,
+        other => panic!("Expected Select, got {:?}", other),
+    };
+    let rows = SelectExecutor::new(&db).execute(&select).expect("select from log");
+    assert_eq!(rows.len(), 1, "temp trigger should have fired once");
+    assert_eq!(
+        rows[0].values[0],
+        vibesql_types::SqlValue::Integer(105),
+        "temp trigger body did not fire with the inserted NEW row"
     );
 }

--- a/crates/vibesql-executor/src/tests/triggers/delete.rs
+++ b/crates/vibesql-executor/src/tests/triggers/delete.rs
@@ -38,6 +38,7 @@ fn test_after_delete_trigger_fires() {
     // Create AFTER DELETE trigger
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "log_delete".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Delete,
@@ -109,6 +110,7 @@ fn test_before_delete_trigger_fires() {
     // Create BEFORE DELETE trigger
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "log_before_delete".to_string(),
         timing: TriggerTiming::Before,
         event: TriggerEvent::Delete,

--- a/crates/vibesql-executor/src/tests/triggers/error_handling.rs
+++ b/crates/vibesql-executor/src/tests/triggers/error_handling.rs
@@ -16,6 +16,7 @@ fn test_trigger_failure_causes_rollback() {
     // Create trigger that always fails (inserts into non-existent table)
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "failing_trigger".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -92,6 +93,7 @@ fn test_recursion_prevention() {
     // Create trigger that inserts into the same table (infinite loop)
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "recursive_trigger".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,

--- a/crates/vibesql-executor/src/tests/triggers/insert.rs
+++ b/crates/vibesql-executor/src/tests/triggers/insert.rs
@@ -17,6 +17,7 @@ fn test_after_insert_trigger_fires() {
     // Create AFTER INSERT trigger
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "log_insert".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -64,6 +65,7 @@ fn test_after_insert_trigger_fires_for_each_row() {
     // Create AFTER INSERT trigger
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "log_insert".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -125,6 +127,7 @@ fn test_before_insert_trigger_fires() {
     // Create BEFORE INSERT trigger
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "log_before_insert".to_string(),
         timing: TriggerTiming::Before,
         event: TriggerEvent::Insert,
@@ -198,6 +201,7 @@ fn test_insert_trigger_body_semicolon_inside_string_literal_is_not_split() {
 
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "log_semicolon".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -248,6 +252,7 @@ fn test_insert_trigger_body_escaped_quote_with_semicolon_is_intact() {
 
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "log_escaped".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -296,6 +301,7 @@ fn test_insert_trigger_multi_statement_body_with_semicolon_string() {
 
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "log_multi".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,

--- a/crates/vibesql-executor/src/tests/triggers/pseudo_vars.rs
+++ b/crates/vibesql-executor/src/tests/triggers/pseudo_vars.rs
@@ -35,6 +35,7 @@ fn test_new_in_insert_trigger() {
     // Create trigger that uses NEW to log inserted employee
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "log_new_employee".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Insert,
@@ -112,6 +113,7 @@ fn test_old_and_new_in_update_trigger() {
     // Create trigger that uses both OLD and NEW
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "log_salary_change".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Update(None), // No specific column list
@@ -189,6 +191,7 @@ fn test_old_in_delete_trigger() {
     // Create trigger that uses OLD
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "log_deletion".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Delete,

--- a/crates/vibesql-executor/src/tests/triggers/update.rs
+++ b/crates/vibesql-executor/src/tests/triggers/update.rs
@@ -42,6 +42,7 @@ fn test_after_update_trigger_fires() {
     // Create AFTER UPDATE trigger
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "log_update".to_string(),
         timing: TriggerTiming::After,
         event: TriggerEvent::Update(None),
@@ -118,6 +119,7 @@ fn test_before_update_trigger_fires() {
     // Create BEFORE UPDATE trigger
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "log_before_update".to_string(),
         timing: TriggerTiming::Before,
         event: TriggerEvent::Update(None),
@@ -220,6 +222,7 @@ fn test_update_from_on_view_with_instead_of_trigger() {
     // trigger-body SQL execution path.
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "tr1".to_string(),
         timing: TriggerTiming::InsteadOf,
         event: TriggerEvent::Update(None),
@@ -308,6 +311,7 @@ fn test_update_from_on_view_zero_matches() {
 
     let trigger_stmt = CreateTriggerStmt {
         if_not_exists: false,
+        schema: None,
         trigger_name: "tr1".to_string(),
         timing: TriggerTiming::InsteadOf,
         event: TriggerEvent::Update(None),

--- a/crates/vibesql-executor/src/trigger_ddl.rs
+++ b/crates/vibesql-executor/src/trigger_ddl.rs
@@ -94,7 +94,10 @@ impl TriggerExecutor {
             }
         }
 
-        // Create trigger definition from statement, preserving original SQL when available
+        // Create trigger definition from statement, preserving original SQL when available.
+        // The trigger's schema (from `CREATE TEMP TRIGGER` or an explicit
+        // `schema.` prefix) is threaded through so it binds to the correct
+        // table when a temp table shadows a main table of the same name.
         let trigger = match original_sql {
             Some(sql) => TriggerDefinition::new_with_sql(
                 stmt.trigger_name.clone(),
@@ -115,7 +118,8 @@ impl TriggerExecutor {
                 stmt.when_condition.clone(),
                 stmt.triggered_action.clone(),
             ),
-        };
+        }
+        .with_schema(stmt.schema.clone());
 
         // Store in catalog
         db.catalog.create_trigger(trigger)?;

--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -27,11 +27,11 @@ impl Parser {
         // Expect CREATE keyword
         self.expect_keyword(Keyword::Create)?;
 
-        // Optional TEMP/TEMPORARY modifier, accepted for SQLite compatibility and
-        // ignored: SQLite places TEMP triggers in a session-scoped `temp` schema,
-        // but VibeSQL has no multi-session or ATTACH support, so the trigger is
-        // created as a regular trigger.
-        let _ =
+        // Optional TEMP/TEMPORARY modifier (SQLite places such a trigger in the
+        // session `temp` schema). We record that as `schema = Some("temp")` so
+        // the trigger is registered against the temp schema, mirroring how a
+        // temp table/index shadows its main-schema namesake (triggerD-3.x).
+        let is_temp =
             self.try_consume_keyword(Keyword::Temp) || self.try_consume_keyword(Keyword::Temporary);
 
         // Expect TRIGGER keyword
@@ -48,8 +48,31 @@ impl Parser {
             false
         };
 
-        // Parse trigger name
-        let trigger_name = self.parse_identifier()?;
+        // Parse trigger name, allowing an optional schema qualifier
+        // (`CREATE TRIGGER main.r1 ...` / `CREATE TRIGGER temp.r1 ...`). The
+        // table-ref helper also accepts a keyword schema (`temp`, `main`).
+        let name_ref = self.parse_table_ref()?;
+        let trigger_name = name_ref.name;
+
+        // Resolve the trigger's schema. An explicit `schema.` prefix wins; if
+        // absent, the `TEMP`/`TEMPORARY` modifier implies the `temp` schema.
+        // SQLite forbids combining `CREATE TEMP TRIGGER` with an explicit
+        // non-temp schema (e.g. `CREATE TEMP TRIGGER main.r1`); reject that.
+        let schema = match (is_temp, name_ref.schema_name) {
+            (_, Some(schema_name)) => {
+                if is_temp && !schema_name.eq_ignore_ascii_case("temp") {
+                    return Err(ParseError {
+                        message: format!(
+                            "temporary trigger may not have qualified name: \"{}.{}\"",
+                            schema_name, trigger_name
+                        ),
+                    });
+                }
+                Some(schema_name)
+            }
+            (true, None) => Some("temp".to_string()),
+            (false, None) => None,
+        };
 
         // Parse timing: BEFORE | AFTER | INSTEAD OF (optional, defaults to BEFORE per SQLite)
         let timing = if self.try_consume_keyword(Keyword::Before) {
@@ -181,6 +204,7 @@ impl Parser {
 
         Ok(vibesql_ast::CreateTriggerStmt {
             if_not_exists,
+            schema,
             trigger_name,
             timing,
             event,

--- a/crates/vibesql-parser/src/tests/trigger.rs
+++ b/crates/vibesql-parser/src/tests/trigger.rs
@@ -467,6 +467,8 @@ fn test_create_temp_trigger_after_insert() {
             assert_eq!(trigger.timing, TriggerTiming::After);
             assert_eq!(trigger.event, TriggerEvent::Insert);
             assert_eq!(trigger.table_name, "t1");
+            // The TEMP modifier places the trigger in the temp schema.
+            assert_eq!(trigger.schema.as_deref(), Some("temp"));
         }
         _ => panic!("Expected CreateTrigger statement"),
     }
@@ -485,6 +487,8 @@ fn test_create_temporary_trigger_after_insert() {
             assert_eq!(trigger.timing, TriggerTiming::After);
             assert_eq!(trigger.event, TriggerEvent::Insert);
             assert_eq!(trigger.table_name, "t1");
+            // TEMPORARY behaves identically to TEMP.
+            assert_eq!(trigger.schema.as_deref(), Some("temp"));
         }
         _ => panic!("Expected CreateTrigger statement"),
     }
@@ -506,6 +510,76 @@ fn test_create_temp_trigger_omitted_timing_defaults_to_before() {
         }
         _ => panic!("Expected CreateTrigger statement"),
     }
+}
+
+#[test]
+fn test_create_trigger_schema_defaults_to_none() {
+    // A plain CREATE TRIGGER (no TEMP, no schema prefix) has no schema.
+    let sql = "CREATE TRIGGER tr1 AFTER INSERT ON t1 BEGIN SELECT 1; END;";
+    match Parser::parse_sql(sql).expect("parse") {
+        Statement::CreateTrigger(trigger) => {
+            assert_eq!(trigger.trigger_name, "tr1");
+            assert_eq!(trigger.schema, None);
+        }
+        other => panic!("Expected CreateTrigger, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_trigger_with_main_schema_qualifier() {
+    // `CREATE TRIGGER main.r1 ...` (triggerD-3.1) parses with schema "main".
+    let sql = "CREATE TRIGGER main.r1 AFTER INSERT ON t1 BEGIN SELECT 1; END;";
+    match Parser::parse_sql(sql).expect("parse") {
+        Statement::CreateTrigger(trigger) => {
+            assert_eq!(trigger.trigger_name, "r1");
+            assert_eq!(trigger.schema.as_deref(), Some("main"));
+        }
+        other => panic!("Expected CreateTrigger, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_trigger_with_temp_schema_qualifier() {
+    // `CREATE TRIGGER temp.r1 ...` (triggerD-3.2) parses with the temp schema.
+    // Note `temp` is a keyword, so this also exercises keyword-as-schema.
+    let sql = "CREATE TRIGGER temp.r1 AFTER INSERT ON t1 BEGIN SELECT 1; END;";
+    match Parser::parse_sql(sql).expect("parse") {
+        Statement::CreateTrigger(trigger) => {
+            assert_eq!(trigger.trigger_name, "r1");
+            assert!(
+                trigger.schema.as_deref().is_some_and(|s| s.eq_ignore_ascii_case("temp")),
+                "expected temp schema, got {:?}",
+                trigger.schema
+            );
+        }
+        other => panic!("Expected CreateTrigger, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_temp_trigger_if_not_exists_sets_schema() {
+    // TEMP modifier + IF NOT EXISTS: both flags set, schema is temp.
+    let sql =
+        "CREATE TEMP TRIGGER IF NOT EXISTS r1 AFTER INSERT ON t1 BEGIN SELECT 1; END;";
+    match Parser::parse_sql(sql).expect("parse") {
+        Statement::CreateTrigger(trigger) => {
+            assert_eq!(trigger.trigger_name, "r1");
+            assert!(trigger.if_not_exists);
+            assert_eq!(trigger.schema.as_deref(), Some("temp"));
+        }
+        other => panic!("Expected CreateTrigger, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_temp_trigger_with_non_temp_schema_rejected() {
+    // SQLite rejects combining `CREATE TEMP TRIGGER` with an explicit
+    // non-temp schema, e.g. `CREATE TEMP TRIGGER main.r1`.
+    let sql = "CREATE TEMP TRIGGER main.r1 AFTER INSERT ON t1 BEGIN SELECT 1; END;";
+    assert!(
+        Parser::parse_sql(sql).is_err(),
+        "CREATE TEMP TRIGGER with explicit main schema must be rejected"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #5521

## TEMP/TEMPORARY parse approach
`CREATE TRIGGER` now accepts the optional `TEMP`/`TEMPORARY` modifier and an optional schema qualifier on the trigger name, in SQLite's keyword order:

```
CREATE [TEMP|TEMPORARY] TRIGGER [IF NOT EXISTS] [schema.]name ...
```

- The trigger name is parsed via the existing `parse_table_ref()` helper (which already handles dotted `schema.name` and keyword schemas like `temp`/`main`), replacing the single-identifier parse that choked on `main.r1` / `temp.r1`.
- Schema resolution: an explicit `schema.` prefix wins; otherwise `TEMP`/`TEMPORARY` implies the `temp` schema; otherwise `None` (main). Combining `CREATE TEMP TRIGGER` with a non-temp explicit schema (e.g. `CREATE TEMP TRIGGER main.r1`) is rejected, matching SQLite.
- Ordering composes correctly with `IF NOT EXISTS` (#5488) and the existing bound-param rejection (#5487).

## AST / catalog / executor threading
- `CreateTriggerStmt` gains `schema: Option<String>` (vibesql-ast).
- `TriggerDefinition` gains `schema: Option<String>` plus `with_schema(..)` / `is_temp()` (vibesql-catalog); `new`/`new_with_sql` default it to `None` to avoid churn at non-parser construction sites.
- `TriggerExecutor::create_trigger_with_sql` threads `stmt.schema` onto the stored definition.

## triggerD delta
Baseline (origin/main): 6 passed. With this PR: still 6 passed, but the failure mode for 3.1/3.2 changes:
- Before: hard syntax errors (`Expected BEFORE, AFTER...` for `main.r300`; `found reserved keyword 'TEMP'` for `temp.r301`).
- After: both **parse and create successfully**. 3.1 now executes (got `10003 10004` vs expected `10003`); 3.2 surfaces a shim-level `no such table: temp.t300` (the CLI reproduction works).

Going green requires **schema-aware trigger firing** (a `main` trigger must fire only on the main table, a `temp` trigger only on the temp table). That is a cross-cutting change across the DML firing call sites and is intentionally out of this PR's scope (parser + AST + minimal executor threading; avoid the trigger-execution recursion zone of #5479). Filed as follow-on **#5531**.

## sqlite3 3.51.0 parity
`CREATE TEMP TRIGGER`, `CREATE TEMPORARY TRIGGER`, `CREATE TEMP TRIGGER IF NOT EXISTS`, and `CREATE TRIGGER main.x` / `temp.x` all parse and create; the trigger fires on its table (verified via CLI and an executor test asserting a live SELECT). `CREATE TEMP TRIGGER main.x` is rejected as SQLite does for a qualified temp object.

## Tests
- Parser unit tests: schema defaults to `None`; `main.`/`temp.` qualifiers; `TEMP`/`TEMPORARY` set `temp` schema; `TEMP` + `IF NOT EXISTS`; `TEMP` + non-temp schema rejected. Existing TEMP-trigger tests extended to assert the schema field.
- Executor test: `CREATE TEMP TRIGGER` registers with `is_temp()` true and fires on its target table (asserted via SELECT).
- `cargo test -p vibesql-parser -p vibesql-executor -p vibesql-catalog -p vibesql-ast` green.
- `cargo build --workspace` green (AST/catalog field additions threaded through all construction sites).
- No regression: trigger1 (25), triggerE (22), triggerF (11) pass counts unchanged.

## Follow-ons
- #5531 — schema-aware trigger firing to complete triggerD-3.1/3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)