### PR TITLE
feat(catalog): schema-aware indexes + sqlite_temp_master (#5513)

### DIFF
--- a/crates/vibesql-catalog/src/index.rs
+++ b/crates/vibesql-catalog/src/index.rs
@@ -8,6 +8,16 @@
 pub struct IndexMetadata {
     /// Name of the index
     pub name: String,
+    /// Name of the schema that owns this index (e.g. `main` or a session temp
+    /// schema like `temp_123`).
+    ///
+    /// SQLite-compatibility: an index lives in the same schema as the table it
+    /// indexes. A temp-table index belongs to the session temp schema, where it
+    /// is listed in `sqlite_temp_master` (not `sqlite_master`) and is dropped
+    /// when the temp table is dropped or the connection closes. Tagging the
+    /// owning schema lets a temp index and a main index share a name without
+    /// colliding. See issue #5513.
+    pub schema: String,
     /// Name of the table this index belongs to
     pub table_name: String,
     /// Type of index
@@ -158,7 +168,12 @@ pub enum SortOrder {
 }
 
 impl IndexMetadata {
-    /// Create a new index metadata entry
+    /// Create a new index metadata entry.
+    ///
+    /// The owning schema defaults to [`crate::DEFAULT_SCHEMA`] (`main`). Use
+    /// [`IndexMetadata::with_schema`] to tag a temp-schema index. Defaulting to
+    /// `main` keeps the dozens of existing call sites (and persisted/recovered
+    /// indexes, which all live in `main`) behaving exactly as before.
     pub fn new(
         name: String,
         table_name: String,
@@ -166,7 +181,29 @@ impl IndexMetadata {
         columns: Vec<IndexedColumn>,
         is_unique: bool,
     ) -> Self {
-        Self { name, table_name, index_type, columns, is_unique, where_clause: None }
+        Self {
+            name,
+            schema: crate::DEFAULT_SCHEMA.to_string(),
+            table_name,
+            index_type,
+            columns,
+            is_unique,
+            where_clause: None,
+        }
+    }
+
+    /// Set the owning schema for this index (builder-style chaining).
+    ///
+    /// Used by CREATE INDEX once the target table's schema has been resolved
+    /// (temp shadows main per SQLite name resolution). See issue #5513.
+    pub fn with_schema(mut self, schema: impl Into<String>) -> Self {
+        self.schema = schema.into();
+        self
+    }
+
+    /// Returns the owning schema name (e.g. `main` or `temp_123`).
+    pub fn schema(&self) -> &str {
+        &self.schema
     }
 
     /// Attach a partial-index predicate (CREATE INDEX ... WHERE expr).
@@ -183,8 +220,20 @@ impl IndexMetadata {
         self.where_clause.is_some()
     }
 
-    /// Get the fully qualified index name (table.index)
+    /// Get the catalog key for this index: `schema.table.index`.
+    ///
+    /// Including the schema lets a temp-table index and a main-table index
+    /// share a name (and even a table name, when a temp table shadows a main
+    /// table) without colliding in the catalog's index registry. See #5513.
     pub fn qualified_name(&self) -> String {
+        format!("{}.{}.{}", self.schema, self.table_name, self.name)
+    }
+
+    /// Get the schema-less `table.index` form (no owning schema prefix).
+    ///
+    /// Useful for display / SHOW output that should not surface the internal
+    /// session temp-schema name.
+    pub fn table_qualified_name(&self) -> String {
         format!("{}.{}", self.table_name, self.name)
     }
 
@@ -239,7 +288,23 @@ mod tests {
             false,
         );
 
-        assert_eq!(index.qualified_name(), "users.idx_name");
+        // Defaults to the `main` schema; key is schema.table.index.
+        assert_eq!(index.qualified_name(), "main.users.idx_name");
+        assert_eq!(index.table_qualified_name(), "users.idx_name");
+        assert_eq!(index.schema(), "main");
+
+        // A temp-schema index keys under its temp schema, so it never collides
+        // with a same-named main index on a same-named table.
+        let temp_index = IndexMetadata::new(
+            "idx_name".to_string(),
+            "users".to_string(),
+            IndexType::BTree,
+            vec![IndexedColumn::new_column("name".to_string(), SortOrder::Ascending)],
+            false,
+        )
+        .with_schema("temp_7");
+        assert_eq!(temp_index.qualified_name(), "temp_7.users.idx_name");
+        assert_ne!(temp_index.qualified_name(), index.qualified_name());
     }
 
     #[test]

--- a/crates/vibesql-catalog/src/store/indexes.rs
+++ b/crates/vibesql-catalog/src/store/indexes.rs
@@ -55,29 +55,94 @@ impl Catalog {
         Ok(())
     }
 
-    /// Remove an index from the catalog
+    /// Remove an index from the catalog.
+    ///
+    /// `table_name` may carry a schema (`schema.table`) — used by DROP INDEX so
+    /// a temp index and a same-named main index on a same-named table can be
+    /// dropped independently. When unqualified, the index is matched across all
+    /// schemas (index names are unique within a database in practice).
     pub fn drop_index(
         &mut self,
         table_name: &str,
         index_name: &str,
     ) -> Result<IndexMetadata, CatalogError> {
-        let qualified_name = format!("{}.{}", table_name, index_name);
+        let key = self.resolve_index_key(table_name, index_name).ok_or_else(|| {
+            CatalogError::IndexNotFound {
+                index_name: index_name.to_string(),
+                table_name: table_name.to_string(),
+            }
+        })?;
 
-        self.indexes.shift_remove(&qualified_name).ok_or_else(|| CatalogError::IndexNotFound {
+        self.indexes.shift_remove(&key).ok_or_else(|| CatalogError::IndexNotFound {
             index_name: index_name.to_string(),
             table_name: table_name.to_string(),
         })
     }
 
-    /// Get an index by table and index name
+    /// Get an index by table and index name.
+    ///
+    /// `table_name` may be schema-qualified (`schema.table`) to disambiguate a
+    /// temp index from a same-named main index; otherwise the first match
+    /// across schemas is returned.
     pub fn get_index(&self, table_name: &str, index_name: &str) -> Option<&IndexMetadata> {
-        let qualified_name = format!("{}.{}", table_name, index_name);
-        self.indexes.get(&qualified_name)
+        let key = self.resolve_index_key(table_name, index_name)?;
+        self.indexes.get(&key)
     }
 
-    /// Get all indexes for a specific table
+    /// Resolve the catalog key (`schema.table.index`) for the given table/index
+    /// pair. Accepts a schema-qualified `table_name` for exact targeting, or an
+    /// unqualified one, in which case the first matching index (by table + name,
+    /// case-insensitively) is used.
+    fn resolve_index_key(&self, table_name: &str, index_name: &str) -> Option<String> {
+        if let Some((schema_part, table_part)) = table_name.split_once('.') {
+            let resolved_schema = self.resolve_schema_name(schema_part);
+            // Try the exact key first.
+            let exact = format!("{}.{}.{}", resolved_schema, table_part, index_name);
+            if self.indexes.contains_key(&exact) {
+                return Some(exact);
+            }
+            // Fall back to a case-insensitive search constrained to that schema.
+            let resolved_schema_lc = resolved_schema.to_lowercase();
+            let table_lc = table_part.to_lowercase();
+            let index_lc = index_name.to_lowercase();
+            return self
+                .indexes
+                .iter()
+                .find(|(_, idx)| {
+                    idx.schema.to_lowercase() == resolved_schema_lc
+                        && idx.table_name.to_lowercase() == table_lc
+                        && idx.name.to_lowercase() == index_lc
+                })
+                .map(|(k, _)| k.clone());
+        }
+
+        // Unqualified: match by table + index name across all schemas.
+        let table_lc = table_name.to_lowercase();
+        let index_lc = index_name.to_lowercase();
+        self.indexes
+            .iter()
+            .find(|(_, idx)| {
+                idx.table_name.to_lowercase() == table_lc
+                    && idx.name.to_lowercase() == index_lc
+            })
+            .map(|(k, _)| k.clone())
+    }
+
+    /// Get all indexes for a specific table.
+    ///
+    /// Matches by bare table name across all schemas. For schema-scoped views,
+    /// prefer [`Catalog::get_schema_indexes`].
     pub fn get_table_indexes(&self, table_name: &str) -> Vec<&IndexMetadata> {
         self.indexes.values().filter(|index| index.table_name == table_name).collect()
+    }
+
+    /// Get all indexes owned by a specific schema (e.g. `main` or `temp_123`).
+    ///
+    /// Drives the per-schema split between `sqlite_master` (main objects) and
+    /// `sqlite_temp_master` (temp objects). See issue #5513.
+    pub fn get_schema_indexes(&self, schema_name: &str) -> Vec<&IndexMetadata> {
+        let resolved = self.resolve_schema_name(schema_name);
+        self.indexes.values().filter(|index| index.schema == resolved).collect()
     }
 
     /// Look up an index by its name alone (across all tables in this catalog).
@@ -120,12 +185,42 @@ impl Catalog {
         self.indexes.values().collect()
     }
 
-    /// Drop all indexes associated with a table (called when dropping table)
+    /// Drop all indexes associated with a table (called when dropping a table).
+    ///
+    /// Schema-aware (#5513): the dropped table's owning schema is resolved using
+    /// the same temp-shadows-main order as table lookup, so dropping a TEMP
+    /// table removes only that temp table's indexes and leaves a same-named main
+    /// table's indexes intact (and vice versa). `table_name` may be
+    /// schema-qualified to target a specific schema.
     pub fn drop_table_indexes(&mut self, table_name: &str) -> Vec<IndexMetadata> {
+        // Resolve which schema the table being dropped lives in. If the table is
+        // already gone from the catalog (callers sometimes drop indexes after
+        // the table), fall back to matching by bare table name across schemas.
+        let resolved_schema = self.resolve_table_schema_name(table_name);
+
+        let (bare_table_name, schema_filter) =
+            if let Some((schema_part, table_part)) = table_name.split_once('.') {
+                (table_part.to_string(), Some(self.resolve_schema_name(schema_part).to_string()))
+            } else {
+                (table_name.to_string(), resolved_schema)
+            };
+
+        let bare_table_lc = bare_table_name.to_lowercase();
+
         let indexes_to_remove: Vec<String> = self
             .indexes
             .iter()
-            .filter(|(_, index)| index.table_name == table_name)
+            .filter(|(_, index)| {
+                if index.table_name.to_lowercase() != bare_table_lc {
+                    return false;
+                }
+                match &schema_filter {
+                    Some(schema) => index.schema.eq_ignore_ascii_case(schema),
+                    // No resolvable owning schema: match by table name only
+                    // (preserves the pre-#5513 fallback behaviour).
+                    None => true,
+                }
+            })
             .map(|(qualified_name, _)| qualified_name.clone())
             .collect();
 
@@ -334,6 +429,109 @@ mod tests {
         // Expression index should be added successfully
         assert!(catalog.add_index(index).is_ok());
         assert!(catalog.get_index("users", "idx_expr").is_some());
+    }
+
+    #[test]
+    fn test_temp_and_main_index_coexist() {
+        // #5513: a temp-schema index and a main-schema index can share a name,
+        // even on a same-named table, without colliding in the catalog.
+        let mut catalog = create_test_catalog();
+
+        // Create a shadowing temp.users table so both schemas hold `users`.
+        let temp_schema = catalog.temp_schema_name().to_string();
+        let temp_table = TableSchema::new(
+            "users".to_string(),
+            vec![ColumnSchema::new(
+                "name".to_string(),
+                vibesql_types::DataType::Varchar { max_length: Some(50) },
+                true,
+            )],
+        );
+        catalog.create_table_in_schema(&temp_schema, temp_table).unwrap();
+
+        let main_idx = IndexMetadata::new(
+            "idx_name".to_string(),
+            "users".to_string(),
+            IndexType::BTree,
+            vec![IndexedColumn::new_column("name".to_string(), SortOrder::Ascending)],
+            false,
+        ); // defaults to schema "main"
+        let temp_idx = IndexMetadata::new(
+            "idx_name".to_string(),
+            "users".to_string(),
+            IndexType::BTree,
+            vec![IndexedColumn::new_column("name".to_string(), SortOrder::Ascending)],
+            false,
+        )
+        .with_schema(temp_schema.clone());
+
+        catalog.add_index(main_idx).unwrap();
+        // Same name, same table name, different schema -> must NOT collide.
+        catalog.add_index(temp_idx).expect("temp index should coexist with main index");
+
+        // Both registered, keyed independently by schema.
+        let main_only = catalog.get_schema_indexes("main");
+        let temp_only = catalog.get_schema_indexes(&temp_schema);
+        assert_eq!(main_only.len(), 1);
+        assert_eq!(temp_only.len(), 1);
+        assert_eq!(main_only[0].schema(), "main");
+        assert_eq!(temp_only[0].schema(), temp_schema);
+
+        // get_index can disambiguate via a schema-qualified table name.
+        assert_eq!(catalog.get_index("main.users", "idx_name").unwrap().schema(), "main");
+        assert_eq!(
+            catalog.get_index(&format!("{}.users", temp_schema), "idx_name").unwrap().schema(),
+            temp_schema
+        );
+    }
+
+    #[test]
+    fn test_drop_table_indexes_is_schema_scoped() {
+        // #5513: dropping a temp table removes only the temp-schema index,
+        // leaving the same-named main-schema index intact.
+        let mut catalog = create_test_catalog();
+        let temp_schema = catalog.temp_schema_name().to_string();
+        let temp_table = TableSchema::new(
+            "users".to_string(),
+            vec![ColumnSchema::new(
+                "name".to_string(),
+                vibesql_types::DataType::Varchar { max_length: Some(50) },
+                true,
+            )],
+        );
+        catalog.create_table_in_schema(&temp_schema, temp_table).unwrap();
+
+        catalog
+            .add_index(IndexMetadata::new(
+                "idx_name".to_string(),
+                "users".to_string(),
+                IndexType::BTree,
+                vec![IndexedColumn::new_column("name".to_string(), SortOrder::Ascending)],
+                false,
+            ))
+            .unwrap();
+        catalog
+            .add_index(
+                IndexMetadata::new(
+                    "idx_name".to_string(),
+                    "users".to_string(),
+                    IndexType::BTree,
+                    vec![IndexedColumn::new_column("name".to_string(), SortOrder::Ascending)],
+                    false,
+                )
+                .with_schema(temp_schema.clone()),
+            )
+            .unwrap();
+
+        // Drop the temp `users` table's indexes (temp shadows main for the bare
+        // name) -> only the temp index goes.
+        let dropped = catalog.drop_table_indexes("users");
+        assert_eq!(dropped.len(), 1);
+        assert_eq!(dropped[0].schema(), temp_schema);
+
+        // Main index survives.
+        assert_eq!(catalog.get_schema_indexes("main").len(), 1);
+        assert!(catalog.get_schema_indexes(&temp_schema).is_empty());
     }
 
     #[test]

--- a/crates/vibesql-catalog/src/store/tables.rs
+++ b/crates/vibesql-catalog/src/store/tables.rs
@@ -347,6 +347,16 @@ impl super::Catalog {
             .unwrap_or_default()
     }
 
+    /// List all table names in a specific schema.
+    ///
+    /// The `temp` alias is resolved to this session's temp schema, so
+    /// `list_tables_in_schema("temp")` returns the session's temp tables. Used
+    /// by `sqlite_temp_master` introspection. See issue #5513.
+    pub fn list_tables_in_schema(&self, schema_name: &str) -> Vec<String> {
+        let resolved = self.resolve_schema_name(schema_name);
+        self.schemas.get(resolved).map(|schema| schema.list_tables()).unwrap_or_default()
+    }
+
     /// List all table names with qualified names (schema.table).
     pub fn list_all_tables(&self) -> Vec<String> {
         let mut result = Vec::new();

--- a/crates/vibesql-executor/src/index_ddl/btree_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/btree_index.rs
@@ -64,6 +64,9 @@ pub fn create_btree_index(
         catalog_columns,
         unique,
     )
+    // Tag the owning schema (e.g. `main` or a session temp schema) so a
+    // temp-table index is separable from a main-table index. See issue #5513.
+    .with_schema(super::schema_of_qualified(qualified_table_name))
     .with_where_clause(stmt.where_clause.as_ref().map(|expr| (**expr).clone()));
     database.catalog.add_index(index_metadata)?;
 
@@ -82,7 +85,10 @@ pub fn create_btree_index(
         has_expression,
     );
     if let Err(e) = build_result {
-        let _ = database.catalog.drop_index(table_name, index_name);
+        // Roll back the catalog entry using the schema-qualified table name so
+        // we drop exactly the index just added (not a same-named main index when
+        // the target was a temp table). See issue #5513.
+        let _ = database.catalog.drop_index(qualified_table_name, index_name);
         return Err(e);
     }
 

--- a/crates/vibesql-executor/src/index_ddl/mod.rs
+++ b/crates/vibesql-executor/src/index_ddl/mod.rs
@@ -36,6 +36,20 @@ use vibesql_storage::Database;
 
 use crate::errors::ExecutorError;
 
+/// Extract the schema part of a `schema.table` qualified name.
+///
+/// CREATE INDEX builds `qualified_table_name` as `schema.table` after resolving
+/// the target table's owning schema (temp shadows main per SQLite name
+/// resolution). The schema part is what an index must be tagged with so a
+/// temp-table index lands in the temp schema. Falls back to `main` for a bare
+/// (unqualified) name. See issue #5513.
+pub(crate) fn schema_of_qualified(qualified_table_name: &str) -> &str {
+    qualified_table_name
+        .split_once('.')
+        .map(|(schema, _)| schema)
+        .unwrap_or(vibesql_catalog::DEFAULT_SCHEMA)
+}
+
 /// Unified executor for index operations (CREATE, DROP, and REINDEX INDEX)
 ///
 /// This struct provides backward compatibility with the original API,

--- a/crates/vibesql-executor/src/index_ddl/spatial_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/spatial_index.rs
@@ -75,7 +75,9 @@ pub fn create_spatial_index(
             vibesql_catalog::SortOrder::Ascending,
         )],
         false,
-    );
+    )
+    // Tag the owning schema so a temp-table index is separable (#5513).
+    .with_schema(super::schema_of_qualified(qualified_table_name));
     database.catalog.add_index(index_metadata)?;
 
     // Store in database (use unqualified table name for storage metadata)

--- a/crates/vibesql-executor/src/index_ddl/vector_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/vector_index.rs
@@ -71,7 +71,9 @@ pub fn create_ivfflat_index(
             vibesql_catalog::SortOrder::Ascending, // Not meaningful for vector indexes
         )],
         false, // IVFFlat indexes are never unique
-    );
+    )
+    // Tag the owning schema so a temp-table index is separable (#5513).
+    .with_schema(super::schema_of_qualified(qualified_table_name));
     database.catalog.add_index(index_metadata)?;
 
     // Create the IVFFlat index in storage
@@ -160,7 +162,9 @@ pub fn create_hnsw_index(
             vibesql_catalog::SortOrder::Ascending, // Not meaningful for vector indexes
         )],
         false, // HNSW indexes are never unique
-    );
+    )
+    // Tag the owning schema so a temp-table index is separable (#5513).
+    .with_schema(super::schema_of_qualified(qualified_table_name));
     database.catalog.add_index(index_metadata)?;
 
     // Create the HNSW index in storage

--- a/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
@@ -15,7 +15,9 @@ use crate::{
     errors::ExecutorError,
     schema::CombinedSchema,
     select::cte::CteResult,
-    sqlite_schema::{get_sqlite_schema_table_schema, is_sqlite_schema_table},
+    sqlite_schema::{
+        get_sqlite_schema_table_schema, is_sqlite_schema_table, is_sqlite_temp_schema_table,
+    },
 };
 
 /// Validate IN subqueries in WHERE clause before row iteration
@@ -205,8 +207,9 @@ fn compute_single_select_column_count(
                         continue;
                     }
                 }
-                // Issue #4577: Check for sqlite_schema/sqlite_master virtual tables
-                if is_sqlite_schema_table(qualifier) {
+                // Issue #4577: Check for sqlite_schema/sqlite_master virtual tables.
+                // #5513: sqlite_temp_master shares the same column shape.
+                if is_sqlite_schema_table(qualifier) || is_sqlite_temp_schema_table(qualifier) {
                     count += get_sqlite_schema_table_schema().columns.len();
                     continue;
                 }
@@ -248,8 +251,9 @@ fn count_columns_in_from_clause(
                     return Ok(schema.columns.len());
                 }
             }
-            // Issue #4577: Check for sqlite_schema/sqlite_master virtual tables
-            if is_sqlite_schema_table(name) {
+            // Issue #4577: Check for sqlite_schema/sqlite_master virtual tables.
+            // #5513: sqlite_temp_master shares the same column shape.
+            if is_sqlite_schema_table(name) || is_sqlite_temp_schema_table(name) {
                 return Ok(get_sqlite_schema_table_schema().columns.len());
             }
             // Check for views before regular tables

--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -29,7 +29,8 @@ use crate::{
         cte::CteResult,
     },
     sqlite_schema::{
-        execute_sqlite_schema_query, get_sqlite_schema_table_schema, is_sqlite_schema_table,
+        execute_sqlite_schema_query, execute_sqlite_temp_schema_query,
+        get_sqlite_schema_table_schema, is_sqlite_schema_table, is_sqlite_temp_schema_table,
     },
     sqlite_stat::{
         execute_sqlite_stat1_query, get_sqlite_stat1_table_schema, is_sqlite_stat_table,
@@ -255,6 +256,21 @@ pub(crate) fn execute_table_scan(
         // SQL:1999 E051-09: Apply column aliases if provided
         let table_schema = apply_column_aliases(table_schema, column_aliases)?;
         // Note: Keep schema name as original table name for column name generation
+        let schema = CombinedSchema::from_table(effective_name, table_schema);
+
+        return Ok(super::FromResult::from_rows(schema, result.rows));
+    }
+
+    // Check if it's sqlite_temp_master or sqlite_temp_schema (temp-schema
+    // introspection — temp tables and indexes on temp tables). See #5513.
+    if is_sqlite_temp_schema_table(table_name) {
+        let result = execute_sqlite_temp_schema_query(&database.catalog)?;
+
+        // sqlite_temp_master shares sqlite_master's column shape.
+        let table_schema = get_sqlite_schema_table_schema();
+
+        let effective_name = alias.cloned().unwrap_or_else(|| table_name.to_string());
+        let table_schema = apply_column_aliases(table_schema, column_aliases)?;
         let schema = CombinedSchema::from_table(effective_name, table_schema);
 
         return Ok(super::FromResult::from_rows(schema, result.rows));

--- a/crates/vibesql-executor/src/sqlite_schema.rs
+++ b/crates/vibesql-executor/src/sqlite_schema.rs
@@ -29,6 +29,16 @@ pub fn is_sqlite_schema_table(table_name: &str) -> bool {
     matches!(normalized.as_str(), "sqlite_master" | "sqlite_schema")
 }
 
+/// Check if a table reference is sqlite_temp_master or sqlite_temp_schema.
+///
+/// These are the temp-schema introspection views: they list objects that live
+/// in the session temp schema (temp tables, and indexes on temp tables), and
+/// are the temp-schema counterpart to `sqlite_master`. See issue #5513.
+pub fn is_sqlite_temp_schema_table(table_name: &str) -> bool {
+    let normalized = table_name.to_lowercase();
+    matches!(normalized.as_str(), "sqlite_temp_master" | "sqlite_temp_schema")
+}
+
 /// Get the schema for sqlite_master/sqlite_schema
 pub fn get_sqlite_schema_table_schema() -> TableSchema {
     TableSchema::new(
@@ -47,7 +57,23 @@ pub fn get_sqlite_schema_table_schema() -> TableSchema {
     )
 }
 
-/// Execute a sqlite_master/sqlite_schema query
+/// Build a single sqlite_master-format row.
+fn schema_row(obj_type: &str, name: &str, tbl_name: &str, sql: String) -> Row {
+    Row::new(vec![
+        SqlValue::Varchar(arcstr::ArcStr::from(obj_type)),
+        SqlValue::Varchar(arcstr::ArcStr::from(name)),
+        SqlValue::Varchar(arcstr::ArcStr::from(tbl_name)),
+        SqlValue::Integer(0), // rootpage - always 0 for VibeSQL
+        SqlValue::Varchar(arcstr::ArcStr::from(sql)),
+    ])
+}
+
+/// Execute a `sqlite_master` / `sqlite_schema` query.
+///
+/// Lists **main-schema** objects only. Temp-schema objects (temp tables and
+/// indexes on temp tables) are reported by `sqlite_temp_master`, matching
+/// SQLite 3.51.0 where a temp-table index appears in `sqlite_temp_master` and
+/// never in `sqlite_master`. See issue #5513.
 pub fn execute_sqlite_schema_query(
     catalog: &vibesql_catalog::Catalog,
 ) -> Result<SelectResult, ExecutorError> {
@@ -55,43 +81,28 @@ pub fn execute_sqlite_schema_query(
     let column_names: Vec<String> = schema.columns.iter().map(|c| c.name.clone()).collect();
     let mut rows = Vec::new();
 
-    // Add tables
+    // Add tables. `list_tables()` returns the current (main) schema only, so
+    // temp tables are already excluded here.
     for table_name in catalog.list_tables() {
         if let Some(table) = catalog.get_table(&table_name) {
             let sql = generate_create_table_sql(table);
-            rows.push(Row::new(vec![
-                SqlValue::Varchar(arcstr::ArcStr::from("table")),
-                SqlValue::Varchar(arcstr::ArcStr::from(table_name.clone())),
-                SqlValue::Varchar(arcstr::ArcStr::from(table_name)),
-                SqlValue::Integer(0), // rootpage - always 0 for VibeSQL
-                SqlValue::Varchar(arcstr::ArcStr::from(sql)),
-            ]));
+            rows.push(schema_row("table", &table_name, &table_name, sql));
         }
     }
 
-    // Add indexes
-    for index in catalog.list_all_indexes() {
+    // Add indexes owned by the main schema. Temp-table indexes are tagged with
+    // their temp schema (#5513) and surface only via sqlite_temp_master.
+    for index in catalog.get_schema_indexes(vibesql_catalog::DEFAULT_SCHEMA) {
         let sql = generate_create_index_sql(index);
-        rows.push(Row::new(vec![
-            SqlValue::Varchar(arcstr::ArcStr::from("index")),
-            SqlValue::Varchar(arcstr::ArcStr::from(index.name.clone())),
-            SqlValue::Varchar(arcstr::ArcStr::from(index.table_name.clone())),
-            SqlValue::Integer(0), // rootpage - always 0 for VibeSQL
-            SqlValue::Varchar(arcstr::ArcStr::from(sql)),
-        ]));
+        rows.push(schema_row("index", &index.name, &index.table_name, sql));
     }
 
     // Add views
     for view_name in catalog.list_views() {
         if let Some(view) = catalog.get_view(&view_name) {
             let sql = generate_create_view_sql(view);
-            rows.push(Row::new(vec![
-                SqlValue::Varchar(arcstr::ArcStr::from("view")),
-                SqlValue::Varchar(arcstr::ArcStr::from(view.name.clone())),
-                SqlValue::Varchar(arcstr::ArcStr::from(view.name.clone())), // tbl_name is same as name for views
-                SqlValue::Integer(0), // rootpage - always 0 for VibeSQL
-                SqlValue::Varchar(arcstr::ArcStr::from(sql)),
-            ]));
+            // tbl_name is same as name for views
+            rows.push(schema_row("view", &view.name, &view.name, sql));
         }
     }
 
@@ -99,14 +110,49 @@ pub fn execute_sqlite_schema_query(
     for trigger_name in catalog.list_triggers() {
         if let Some(trigger) = catalog.get_trigger(&trigger_name) {
             let sql = generate_create_trigger_sql(trigger);
-            rows.push(Row::new(vec![
-                SqlValue::Varchar(arcstr::ArcStr::from("trigger")),
-                SqlValue::Varchar(arcstr::ArcStr::from(trigger.name.clone())),
-                SqlValue::Varchar(arcstr::ArcStr::from(trigger.table_name.clone())),
-                SqlValue::Integer(0), // rootpage - always 0 for VibeSQL
-                SqlValue::Varchar(arcstr::ArcStr::from(sql)),
-            ]));
+            rows.push(schema_row("trigger", &trigger.name, &trigger.table_name, sql));
         }
+    }
+
+    Ok(SelectResult { columns: column_names, rows })
+}
+
+/// Execute a `sqlite_temp_master` / `sqlite_temp_schema` query.
+///
+/// Lists the session's **temp-schema** objects: temp tables and indexes on temp
+/// tables. Mirrors SQLite 3.51.0, where:
+///   CREATE TEMP TABLE t(a); CREATE INDEX i ON t(a);
+///   SELECT name,type FROM sqlite_temp_master;  -- lists t and i
+/// while `sqlite_master` lists neither. See issue #5513.
+///
+/// Scope note: VibeSQL does not yet schema-tag temp **views** or temp
+/// **triggers** (tracked separately — see follow-ons), so this view currently
+/// surfaces temp tables and temp-table indexes. That is sufficient for the
+/// index introspection parity this issue targets.
+pub fn execute_sqlite_temp_schema_query(
+    catalog: &vibesql_catalog::Catalog,
+) -> Result<SelectResult, ExecutorError> {
+    let schema = get_sqlite_schema_table_schema();
+    let column_names: Vec<String> = schema.columns.iter().map(|c| c.name.clone()).collect();
+    let mut rows = Vec::new();
+
+    let temp_schema = catalog.temp_schema_name();
+
+    // Add temp tables (objects living in the session temp schema).
+    for table_name in catalog.list_tables_in_schema(temp_schema) {
+        // Look up via the temp-qualified name so we read the temp copy even when
+        // a same-named main table shadows it for unqualified lookups.
+        let qualified = format!("{}.{}", temp_schema, table_name);
+        if let Some(table) = catalog.get_table(&qualified) {
+            let sql = generate_create_table_sql(table);
+            rows.push(schema_row("table", &table_name, &table_name, sql));
+        }
+    }
+
+    // Add indexes owned by the temp schema.
+    for index in catalog.get_schema_indexes(temp_schema) {
+        let sql = generate_create_index_sql(index);
+        rows.push(schema_row("index", &index.name, &index.table_name, sql));
     }
 
     Ok(SelectResult { columns: column_names, rows })
@@ -386,6 +432,86 @@ mod tests {
         assert!(!is_sqlite_schema_table("users"));
         assert!(!is_sqlite_schema_table("sqlite_stat1"));
         assert!(!is_sqlite_schema_table("information_schema.tables"));
+        // sqlite_temp_master is a distinct view, not sqlite_master.
+        assert!(!is_sqlite_schema_table("sqlite_temp_master"));
+    }
+
+    #[test]
+    fn test_is_sqlite_temp_schema_table() {
+        assert!(is_sqlite_temp_schema_table("sqlite_temp_master"));
+        assert!(is_sqlite_temp_schema_table("sqlite_temp_schema"));
+        assert!(is_sqlite_temp_schema_table("SQLITE_TEMP_MASTER"));
+        assert!(is_sqlite_temp_schema_table("Sqlite_Temp_Schema"));
+        assert!(!is_sqlite_temp_schema_table("sqlite_master"));
+        assert!(!is_sqlite_temp_schema_table("users"));
+    }
+
+    #[test]
+    fn test_temp_index_separated_from_main_in_schema_views() {
+        // #5513: a temp-schema index appears in sqlite_temp_master and is
+        // excluded from sqlite_master; a main index is the reverse.
+        let mut catalog = Catalog::new();
+
+        // main.t with a main index.
+        let main_table = TableSchema::new(
+            "t".to_string(),
+            vec![ColumnSchema::new("a".to_string(), DataType::Integer, true)],
+        );
+        catalog.create_table(main_table).unwrap();
+        catalog
+            .add_index(IndexMetadata::new(
+                "main_i".to_string(),
+                "t".to_string(),
+                IndexType::BTree,
+                vec![IndexedColumn::new_column("a".to_string(), SortOrder::Ascending)],
+                false,
+            ))
+            .unwrap();
+
+        // temp.tt with a temp index.
+        let temp_schema = catalog.temp_schema_name().to_string();
+        let temp_table = TableSchema::new(
+            "tt".to_string(),
+            vec![ColumnSchema::new("a".to_string(), DataType::Integer, true)],
+        );
+        catalog.create_table_in_schema(&temp_schema, temp_table).unwrap();
+        catalog
+            .add_index(
+                IndexMetadata::new(
+                    "temp_i".to_string(),
+                    "tt".to_string(),
+                    IndexType::BTree,
+                    vec![IndexedColumn::new_column("a".to_string(), SortOrder::Ascending)],
+                    false,
+                )
+                .with_schema(temp_schema.clone()),
+            )
+            .unwrap();
+
+        let master = execute_sqlite_schema_query(&catalog).unwrap();
+        let master_names: Vec<String> = master
+            .rows
+            .iter()
+            .map(|r| match &r.values[1] {
+                SqlValue::Varchar(s) => s.to_string(),
+                _ => String::new(),
+            })
+            .collect();
+        assert!(master_names.contains(&"main_i".to_string()), "master should list main index");
+        assert!(!master_names.contains(&"temp_i".to_string()), "master must exclude temp index");
+
+        let temp_master = execute_sqlite_temp_schema_query(&catalog).unwrap();
+        let temp_names: Vec<String> = temp_master
+            .rows
+            .iter()
+            .map(|r| match &r.values[1] {
+                SqlValue::Varchar(s) => s.to_string(),
+                _ => String::new(),
+            })
+            .collect();
+        assert!(temp_names.contains(&"temp_i".to_string()), "temp_master should list temp index");
+        assert!(temp_names.contains(&"tt".to_string()), "temp_master should list temp table");
+        assert!(!temp_names.contains(&"main_i".to_string()), "temp_master must exclude main index");
     }
 
     #[test]

--- a/crates/vibesql-executor/tests/sqlite_temp_master_tests.rs
+++ b/crates/vibesql-executor/tests/sqlite_temp_master_tests.rs
@@ -1,0 +1,175 @@
+//! Integration tests for schema-aware catalog indexes and `sqlite_temp_master`.
+//!
+//! Issue #5513: A temp-table index lives in the session temp schema. It must be
+//! listed in `sqlite_temp_master` (not `sqlite_master`), dropped with its temp
+//! table, and able to coexist with a same-named main-schema index. This matches
+//! SQLite 3.51.0:
+//!
+//! ```sql
+//! CREATE TEMP TABLE t(a);
+//! CREATE INDEX i ON t(a);
+//! SELECT name,type FROM sqlite_temp_master;  -- lists t and i
+//! SELECT name FROM sqlite_master;            -- lists neither
+//! ```
+
+use vibesql_executor::{
+    CreateIndexExecutor, CreateTableExecutor, DropTableExecutor, SelectExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::{Database, Row};
+use vibesql_types::SqlValue;
+
+fn exec_create_table(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse CREATE TABLE");
+    match stmt {
+        vibesql_ast::Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE")
+        }
+        other => panic!("expected CREATE TABLE, got {other:?}"),
+    };
+}
+
+fn exec_create_index(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse CREATE INDEX");
+    match stmt {
+        vibesql_ast::Statement::CreateIndex(s) => {
+            CreateIndexExecutor::execute(&s, db).expect("CREATE INDEX")
+        }
+        other => panic!("expected CREATE INDEX, got {other:?}"),
+    };
+}
+
+fn exec_drop_table(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse DROP TABLE");
+    match stmt {
+        vibesql_ast::Statement::DropTable(s) => {
+            DropTableExecutor::execute(&s, db).expect("DROP TABLE")
+        }
+        other => panic!("expected DROP TABLE, got {other:?}"),
+    };
+}
+
+fn select(db: &Database, sql: &str) -> (Vec<String>, Vec<Row>) {
+    let stmt = Parser::parse_sql(sql).expect("parse SELECT");
+    match stmt {
+        vibesql_ast::Statement::Select(s) => {
+            let executor = SelectExecutor::new(db);
+            let r = executor.execute_with_columns(&s).expect("SELECT");
+            (r.columns, r.rows)
+        }
+        other => panic!("expected SELECT, got {other:?}"),
+    }
+}
+
+/// Pull the `name` (column 0) string values out of a result set.
+fn names(rows: &[Row]) -> Vec<String> {
+    rows.iter()
+        .map(|r| match &r.values[0] {
+            SqlValue::Varchar(s) => s.to_string(),
+            other => panic!("expected text name, got {other:?}"),
+        })
+        .collect()
+}
+
+/// sqlite3 parity: a temp table and its index appear in `sqlite_temp_master`.
+#[test]
+fn temp_table_and_index_listed_in_temp_master() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TEMP TABLE t (a)");
+    exec_create_index(&mut db, "CREATE INDEX i ON t(a)");
+
+    let (_, rows) = select(&db, "SELECT name FROM sqlite_temp_master ORDER BY name");
+    let listed = names(&rows);
+    assert!(listed.contains(&"t".to_string()), "temp table t should be in sqlite_temp_master: {listed:?}");
+    assert!(listed.contains(&"i".to_string()), "temp index i should be in sqlite_temp_master: {listed:?}");
+}
+
+/// sqlite3 parity: temp objects are absent from `sqlite_master`.
+#[test]
+fn temp_index_absent_from_sqlite_master() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TEMP TABLE t (a)");
+    exec_create_index(&mut db, "CREATE INDEX i ON t(a)");
+
+    let (_, rows) = select(&db, "SELECT name FROM sqlite_master");
+    let listed = names(&rows);
+    assert!(!listed.contains(&"t".to_string()), "temp table must NOT be in sqlite_master: {listed:?}");
+    assert!(!listed.contains(&"i".to_string()), "temp index must NOT be in sqlite_master: {listed:?}");
+}
+
+/// A main-table index stays in `sqlite_master` and is absent from temp_master.
+#[test]
+fn main_index_in_master_not_temp_master() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TABLE base (a)");
+    exec_create_index(&mut db, "CREATE INDEX mi ON base(a)");
+
+    let (_, master) = select(&db, "SELECT name FROM sqlite_master");
+    assert!(names(&master).contains(&"mi".to_string()), "main index should be in sqlite_master");
+
+    let (_, temp) = select(&db, "SELECT name FROM sqlite_temp_master");
+    assert!(!names(&temp).contains(&"mi".to_string()), "main index must NOT be in sqlite_temp_master");
+}
+
+/// Catalog-level `main.i` / `temp.i` coexistence (same name, even same table)
+/// is proven in `vibesql-catalog`'s `test_temp_and_main_index_coexist`.
+///
+/// At the SQL layer it is not yet reachable because the **storage** index
+/// manager keys indexes by bare name (a global namespace), so a second
+/// `CREATE INDEX i ...` is rejected before the catalog is consulted. Tracked as
+/// a follow-on (storage index-manager schema-tagging). This test documents the
+/// current SQL-level behaviour so the follow-on has a clear before/after.
+#[test]
+fn sql_level_same_name_index_across_schemas_currently_rejected() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TABLE base (a)");
+    exec_create_table(&mut db, "CREATE TEMP TABLE t (a)");
+
+    exec_create_index(&mut db, "CREATE INDEX i ON base(a)"); // main.i on base
+
+    // Second index of the same name (on the temp table) is rejected today by
+    // the storage-layer name namespace.
+    let stmt = Parser::parse_sql("CREATE INDEX i ON t(a)").unwrap();
+    let result = match stmt {
+        vibesql_ast::Statement::CreateIndex(s) => CreateIndexExecutor::execute(&s, &mut db),
+        other => panic!("expected CREATE INDEX, got {other:?}"),
+    };
+    assert!(
+        result.is_err(),
+        "documents current SQL-level limitation; see storage schema-tagging follow-on"
+    );
+}
+
+/// A temp index is dropped together with its temp table, and dropping the temp
+/// table does not disturb a main index on another table.
+#[test]
+fn temp_index_dropped_with_temp_table() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TABLE base (a)");
+    exec_create_table(&mut db, "CREATE TEMP TABLE t (a)");
+    exec_create_index(&mut db, "CREATE INDEX mi ON base(a)"); // main index
+    exec_create_index(&mut db, "CREATE INDEX ti ON t(a)"); // temp index
+
+    // Before: temp_master lists the temp index; master lists the main index.
+    let (_, before) = select(&db, "SELECT name FROM sqlite_temp_master WHERE type='index'");
+    assert!(names(&before).contains(&"ti".to_string()));
+
+    // Drop the temp table. Use the schema-qualified name because an unqualified
+    // DROP TABLE does not yet resolve into the temp schema (separate pre-existing
+    // limitation, unrelated to #5513's index work).
+    exec_drop_table(&mut db, "DROP TABLE temp.t");
+
+    // After: temp index gone from temp_master.
+    let (_, after_temp) = select(&db, "SELECT name FROM sqlite_temp_master WHERE type='index'");
+    assert!(
+        !names(&after_temp).contains(&"ti".to_string()),
+        "temp index should be dropped with the temp table"
+    );
+
+    // Main index on the other table survives.
+    let (_, after_main) = select(&db, "SELECT name FROM sqlite_master WHERE type='index'");
+    assert!(
+        names(&after_main).contains(&"mi".to_string()),
+        "main index must survive dropping the temp table"
+    );
+}


### PR DESCRIPTION
## Summary

Part of #5513. Makes catalog indexes schema-aware and implements
`sqlite_temp_master`, completing the engine-side follow-on to #5505's
CREATE INDEX temp-shadow *resolution*.

### Schema-tagging approach
- `IndexMetadata` gains a `schema` field (defaults to `main`, so the dozens
  of existing call sites and all persisted/recovered indexes behave exactly
  as before). New `with_schema()` / `schema()` helpers.
- The catalog index registry is now keyed by **`schema.table.index`**
  (`IndexMetadata::qualified_name()`), so a temp-table index and a main-table
  index never collide — even on a same-named (shadowing) table.
- CREATE INDEX (`btree`/`spatial`/`vector`) tags the index with the schema of
  the resolved target table via a new `schema_of_qualified()` helper. Temp
  shadows main per #5505, so `CREATE INDEX i ON t` where `t` is a TEMP table
  lands the index in the temp schema.
- `Catalog::get_index` / `drop_index` accept an optional `schema.table`
  qualifier and otherwise resolve by table+name; `drop_table_indexes` is now
  schema-scoped (resolves the dropped table's owning schema with the same
  temp-shadows-main order), so dropping a TEMP table removes only its temp
  indexes and leaves a same-named main table's indexes intact. New
  `get_schema_indexes()` drives the per-schema split.

### sqlite_temp_master implementation
- New `execute_sqlite_temp_schema_query` + `is_sqlite_temp_schema_table`,
  mirroring `sqlite_master`'s row builder and column shape. Lists the session
  temp schema's **temp tables and temp-table indexes**.
- `execute_sqlite_schema_query` (sqlite_master) now lists **main-schema
  indexes only** (`get_schema_indexes("main")`); temp indexes are excluded.
- Routed in `select/scan/table.rs` and recognised by the select column-count
  validation (`sqlite_temp_master` / `sqlite_temp_schema`, case-insensitive).

### sqlite3 3.51.0 parity (verified by tests)
For `CREATE TEMP TABLE t(a); CREATE INDEX i ON t(a);`
- `sqlite_temp_master` lists `t` and `i` ✓
- `sqlite_master` lists neither ✓
- a main index stays in `sqlite_master`, absent from temp_master ✓
- temp index is dropped with the temp table; a main index on another table
  survives ✓
- `main.i` / `temp.i` coexistence proven at the catalog layer ✓

### Test evidence
- `cargo test -p vibesql-catalog` green (incl. new
  `test_temp_and_main_index_coexist`, `test_drop_table_indexes_is_schema_scoped`).
- `cargo test -p vibesql-executor --lib` green (2777 passed), incl. new
  `sqlite_schema::tests::test_temp_index_separated_from_main_in_schema_views`.
- New integration suite `tests/sqlite_temp_master_tests.rs` (5 tests) green.
- `cargo test -p vibesql-storage` green; index/schema/drop/partial/spatial/
  temporal-probe integration suites green.
- TCL `index.test`: 68 passed, 1 failed (`index-18.4`) — a pre-existing
  trigger reserved-name validation gap, unrelated to this change.
  `temptable.test`: 0 failures (50 skipped — multi-connection harness gaps).

## Deferred (follow-ons to file)
1. **Storage-layer index-manager schema-tagging** — the storage index manager
   still keys indexes by bare name (a global namespace), so a second
   `CREATE INDEX i ...` is rejected before the catalog is consulted. SQL-level
   same-name coexistence across schemas is documented + tested as the current
   limitation (`sql_level_same_name_index_across_schemas_currently_rejected`).
2. **Temp views / temp triggers in sqlite_temp_master** — these objects are
   not yet schema-tagged (triggers tracked under #5531). `sqlite_temp_master`
   currently surfaces temp tables and temp-table indexes, sufficient for the
   index-introspection parity this issue targets.
3. **Unqualified DROP TABLE on a temp table** — pre-existing: an unqualified
   `DROP TABLE t` does not resolve into the temp schema (the test drops via
   `DROP TABLE temp.t`). Independent of the index work here.

## Coordination
Confined to `vibesql-catalog` index schema-tagging + the `sqlite_temp_master`
synthesis in `vibesql-executor`. Does not touch the trigger-firing path
(#5531) or the parallel trigger PRs (#5523, #5527). `sqlite_temp_master` adds
a sibling synthesis function next to `sqlite_master`; if #5531 later routes
temp triggers through a shared catalog-view path, `execute_sqlite_temp_schema_query`
is the place to extend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)