### PR TITLE
fix(executor): live count(*) for combined BEFORE+AFTER DELETE triggers (triggerF 1.4.2)

### DIFF
--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -599,6 +599,19 @@ impl DeleteExecutor {
                     }
                 }
 
+                // Invalidate the database-level columnar cache NOW, between the
+                // bitmap delete and the AFTER trigger (#5523). For row-oriented
+                // tables the columnar aggregate path serves a trigger body's
+                // `SELECT count(*) FROM t` from this LRU-cached snapshot; left
+                // un-invalidated until the loop end, a combined BEFORE+AFTER
+                // DELETE trigger pair would make the AFTER trigger observe the
+                // *pre-delete* count (and the next row's BEFORE trigger a
+                // running count that never decreased). The bitmap/native-columnar
+                // state is already updated by `mark_deleted_inplace`; this drops
+                // the stale row-oriented snapshot so each phase sees the live
+                // count. (Native columnar tables short-circuit this call.)
+                database.invalidate_columnar_cache(table_name);
+
                 // AFTER(R): the row is already deleted; a RAISE(IGNORE) cannot
                 // un-delete it, so SkipRow is a no-op — drop the must-use
                 // outcome (#5418).

--- a/crates/vibesql-executor/src/delete/tests/mod.rs
+++ b/crates/vibesql-executor/src/delete/tests/mod.rs
@@ -4,4 +4,5 @@ mod basic;
 mod common;
 mod edge_cases;
 mod subqueries;
+mod trigger_phase_count;
 mod truncate_optimization;

--- a/crates/vibesql-executor/src/delete/tests/trigger_phase_count.rs
+++ b/crates/vibesql-executor/src/delete/tests/trigger_phase_count.rs
@@ -1,0 +1,137 @@
+//! Regression tests for #5523: a combined BEFORE+AFTER DELETE trigger pair must
+//! observe the *live* `count(*)` of the table at each phase of a per-row DELETE.
+//!
+//! SQLite fires DELETE row triggers interleaved per row (#5486): for each
+//! affected row R it runs BEFORE(R) (R still present -> count includes it),
+//! removes R, then runs AFTER(R) (R gone -> count excludes it). A trigger body
+//! that reads `(SELECT count(*) FROM t)` must therefore see the running count.
+//!
+//! Before this fix the database-level columnar cache (which serves the columnar
+//! aggregate path that computes `count(*)` for row-oriented tables) was only
+//! invalidated *after* the whole DELETE loop. The AFTER trigger then observed
+//! the pre-delete count. All expected sequences below were verified live against
+//! sqlite3 3.51.0.
+
+use vibesql_ast::Statement;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn exec(db: &mut Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).expect("parse");
+    match stmt {
+        Statement::CreateTable(s) => {
+            crate::CreateTableExecutor::execute(&s, db).unwrap();
+        }
+        Statement::CreateTrigger(s) => {
+            crate::TriggerExecutor::create_trigger(db, &s).unwrap();
+        }
+        Statement::Insert(s) => {
+            crate::InsertExecutor::execute(db, &s).unwrap();
+        }
+        Statement::Delete(s) => {
+            crate::delete::DeleteExecutor::execute(&s, db).unwrap();
+        }
+        other => panic!("unsupported statement: {other:?}"),
+    }
+}
+
+/// Read the `t` column of the `log` table, in insertion (rowid) order, as a
+/// `Vec<String>`. Uses a LIVE SELECT through the executor so the assertion
+/// exercises the same read path triggers observe.
+fn log_values(db: &Database) -> Vec<String> {
+    let stmt = vibesql_parser::Parser::parse_sql("SELECT t FROM log").expect("parse select");
+    let select = match stmt {
+        Statement::Select(s) => s,
+        other => panic!("expected SELECT, got {other:?}"),
+    };
+    let result =
+        crate::SelectExecutor::new(db).execute_with_columns(&select).expect("run select");
+    result
+        .rows
+        .iter()
+        .map(|r| match &r.values[0] {
+            SqlValue::Varchar(s) => s.to_string(),
+            other => format!("{other:?}"),
+        })
+        .collect()
+}
+
+/// Create `t1` plus a `log` table and the combined BEFORE+AFTER DELETE triggers
+/// that each log `old.a || old.b || (SELECT count(*) FROM t1)`.
+fn setup(db: &mut Database) {
+    exec(db, "CREATE TABLE t1(a INT PRIMARY KEY, b)");
+    exec(db, "CREATE TABLE log(t)");
+    exec(
+        db,
+        "CREATE TRIGGER tr1 AFTER DELETE ON t1 BEGIN \
+         INSERT INTO log VALUES(old.a || old.b || (SELECT count(*) FROM t1)); END",
+    );
+    exec(
+        db,
+        "CREATE TRIGGER tr2 BEFORE DELETE ON t1 BEGIN \
+         INSERT INTO log VALUES(old.a || old.b || (SELECT count(*) FROM t1)); END",
+    );
+    exec(db, "INSERT INTO t1 VALUES(1,'one'),(2,'two'),(3,'three')");
+}
+
+/// Single-row DELETE: BEFORE sees the pre-delete count (3), AFTER sees the
+/// post-delete count (2). Matches sqlite3 3.51.0 `1one3 1one2`.
+#[test]
+fn before_after_delete_trigger_phase_count_single_row() {
+    let mut db = Database::new();
+    setup(&mut db);
+
+    exec(&mut db, "DELETE FROM t1 WHERE a=1");
+
+    assert_eq!(
+        log_values(&db),
+        vec!["1one3".to_string(), "1one2".to_string()],
+        "BEFORE must see count=3 (row present), AFTER count=2 (row gone)"
+    );
+}
+
+/// Multi-row DELETE: the running count must decrement per row across the
+/// interleaved loop. Matches sqlite3 3.51.0 `2two2 2two1 3three1 3three0`
+/// after row a=1 is removed first.
+#[test]
+fn before_after_delete_trigger_phase_count_multi_row() {
+    let mut db = Database::new();
+    setup(&mut db);
+
+    // Remove a=1 so the remaining rows are a=2, a=3 (two live rows).
+    exec(&mut db, "DELETE FROM t1 WHERE a=1");
+    exec(&mut db, "DELETE FROM log");
+
+    // DELETE all remaining rows: row a=2 then a=3 (PK order).
+    exec(&mut db, "DELETE FROM t1");
+
+    assert_eq!(
+        log_values(&db),
+        vec![
+            "2two2".to_string(),
+            "2two1".to_string(),
+            "3three1".to_string(),
+            "3three0".to_string(),
+        ],
+        "each phase must observe the live running count"
+    );
+}
+
+/// With ONLY an AFTER DELETE trigger the count was already correct; lock it in
+/// so the per-row invalidation does not regress the single-trigger case.
+#[test]
+fn after_only_delete_trigger_phase_count() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INT PRIMARY KEY, b)");
+    exec(&mut db, "CREATE TABLE log(t)");
+    exec(
+        &mut db,
+        "CREATE TRIGGER tr1 AFTER DELETE ON t1 BEGIN \
+         INSERT INTO log VALUES(old.a || old.b || (SELECT count(*) FROM t1)); END",
+    );
+    exec(&mut db, "INSERT INTO t1 VALUES(1,'one'),(2,'two'),(3,'three')");
+
+    exec(&mut db, "DELETE FROM t1 WHERE a=1");
+
+    assert_eq!(log_values(&db), vec!["1one2".to_string()], "AFTER sees count=2");
+}


### PR DESCRIPTION
## Summary

Fixes the lone remaining `triggerF.test` failure (1.4.2): a plain `DELETE`
on a table with BOTH a `BEFORE DELETE` and an `AFTER DELETE` trigger made the
AFTER trigger observe a **stale** `(SELECT count(*) FROM t)` — it saw the
pre-delete count instead of the post-delete count.

## Root cause

The per-row interleaved DELETE path (#5486) already fires the row triggers in
SQLite order — `BEFORE(R)` -> `mark_deleted_inplace(R)` -> `AFTER(R)` — and the
deletion bitmap (and native-columnar data) update immediately for row R.

But for **row-oriented** tables the columnar aggregate path that computes
`count(*)` reads from the **database-level columnar LRU cache**
(`Database::get_columnar`). That cache was only invalidated **after** the whole
DELETE loop finished (`invalidate_columnar_cache` at the end of the trigger
branch). During the loop, the AFTER trigger (and the next row's BEFORE trigger)
served `count(*)` from the pre-delete cached snapshot, so the running count
never decreased.

With only an AFTER trigger present the count happened to be correct; the bug
surfaced only with a combined BEFORE+AFTER pair (the interleaved path is the one
that holds the stale snapshot across the AFTER fire).

## The fix

Invalidate the columnar cache **immediately after the per-row bitmap delete and
before `AFTER(R)` fires**, in `crates/vibesql-executor/src/delete/executor.rs`.
Each trigger phase now reads the live running count. Native columnar tables
short-circuit the call (they maintain columnar data incrementally), so the only
behavioral change is dropping the stale row-oriented snapshot mid-loop.

```
mark_deleted_inplace(R)            // bitmap + native-columnar updated
database.invalidate_columnar_cache(table_name)   // NEW: drop stale row-oriented snapshot
AFTER(R) fires                     // now reads count() excluding R
```

## sqlite3 3.51.0 parity

Verified live against `sqlite3 3.51.0`:

- Single-row `DELETE FROM t1 WHERE a=1` -> log `1one3 1one2` (BEFORE sees 3, AFTER sees 2)
- Multi-row `DELETE FROM t1` (rows a=2,a=3) -> `2two2 2two1 3three1 3three0`

Both now match VibeSQL exactly. New regression tests in
`crates/vibesql-executor/src/delete/tests/trigger_phase_count.rs` assert these
sequences via a LIVE `SELECT` through the executor (single-row, multi-row, and
an AFTER-only control case).

## Conformance / no regression

- `triggerF.test`: **11/12 -> 12/12**
- `trigger2.test`: 48/51 (unchanged, pre-existing failures)
- `trigger1.test`: 29/84 (unchanged, pre-existing failures)
- `delete2.test`: 6/9 (unchanged)
- `cargo test -p vibesql-executor` (lib + integration): green (2780 lib tests pass)

## Follow-ons

- The UPDATE per-row interleaved path (`update/executor.rs`) has the same
  late-invalidation structure. UPDATE does not change `count(*)`, so triggerF is
  unaffected, but a trigger body reading a just-updated **column value** of
  another row via the columnar path could observe a stale value mid-statement.
  Worth a dedicated issue to confirm/lock down UPDATE-phase column visibility.

Closes #5523

🤖 Generated with [Claude Code](https://claude.com/claude-code)