### PR TITLE
fix(executor): roll back statement savepoint on constraint violation in explicit txn (#5502)

### DIFF
--- a/crates/vibesql-executor/src/raise_scope.rs
+++ b/crates/vibesql-executor/src/raise_scope.rs
@@ -215,11 +215,23 @@ where
             Err(apply_raise_scope(db, action, message))
         }
         Err(other) => {
-            // Non-RAISE errors keep their pre-existing behavior. The DML
-            // executors already perform their own targeted rollback for these
-            // (e.g. constraint failures), so we just drop the snapshot.
+            // Non-RAISE errors (constraint violations — FK/UNIQUE/CHECK/NOT
+            // NULL, including the cascade-orphan immediate-FK check from #5465)
+            // get SQLite's statement-atomicity scope: roll the statement
+            // savepoint *back*, undoing every partial change this statement
+            // applied (e.g. an already-cascaded child DELETE), while leaving
+            // the enclosing transaction open for the application to COMMIT or
+            // ROLLBACK. This mirrors the auto-commit path (`run_auto_commit`),
+            // which rolls back its whole implicit transaction on any `Err`, and
+            // `RAISE(ABORT)`, which also rolls the statement back.
+            //
+            // Releasing instead of rolling back (the pre-#5502 behavior) relied
+            // on the DML executors performing their own targeted rollback, but
+            // for cascade/multi-row paths there is no such rollback — leaving
+            // inconsistent partial state (#5502). RAISE-variant scopes are
+            // unaffected: they are handled in the arm above.
             if armed {
-                db.release_statement_savepoint();
+                db.rollback_statement_savepoint();
             }
             Err(other)
         }

--- a/crates/vibesql-executor/src/tests/fk_cascade_triggers.rs
+++ b/crates/vibesql-executor/src/tests/fk_cascade_triggers.rs
@@ -782,3 +782,128 @@ fn set_null_without_child_triggers_unaffected() {
         vec![SqlValue::Integer(-1), SqlValue::Integer(-1), SqlValue::Integer(2)]
     );
 }
+
+// ---------------------------------------------------------------------------
+// #5502: immediate-FK ConstraintViolation inside an EXPLICIT transaction must
+// roll the offending STATEMENT back (undoing every partial change it applied,
+// including an already-cascaded child DELETE) while leaving the enclosing
+// transaction OPEN. Before #5502 the non-RAISE `Err` arm of
+// `run_inside_transaction` *released* the statement savepoint instead of
+// rolling it back, leaving inconsistent partial state (#5498 found
+// `parent={1}, child={11}` — the parent DELETE reverted but child[10]'s
+// already-cascaded delete persisted).
+//
+// Scope note vs sqlite3 3.51.0: in an explicit txn sqlite3 leaves the partial
+// state `parent={}, child={11}` for *this* cascade-orphan case (it does not
+// undo the already-cascaded child[10] delete). VibeSQL's statement-savepoint
+// rolls the whole statement back atomically — `parent={1}, child={10,11}` —
+// which the savepoint mechanism cannot make selective. This is the resolution
+// the issue explicitly accepts: "internally consistent and recoverable
+// without manual ROLLBACK", matching the same statement-rollback scope as
+// RAISE(ABORT) and the auto-commit path. For *plain* constraint violations
+// (UNIQUE/CHECK/NOT NULL/plain FK) this is exact sqlite3 parity — see
+// raise_trigger_tests.rs.
+// ---------------------------------------------------------------------------
+
+/// #5502: cascade RAISE(IGNORE) orphan immediate-FK error inside an explicit
+/// transaction rolls the whole DELETE statement back (statement savepoint),
+/// leaving the transaction OPEN so the application can COMMIT or ROLLBACK.
+#[test]
+fn cascade_delete_raise_ignore_orphan_in_explicit_txn_rolls_back_statement_keeps_txn_open() {
+    let mut db = fresh_db();
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE CASCADE)",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_skip BEFORE DELETE ON child WHEN OLD.id = 11 BEGIN SELECT RAISE(IGNORE); END",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO parent VALUES (1)").unwrap();
+    exec(&mut db, "INSERT INTO child VALUES (10, 1), (11, 1)").unwrap();
+
+    db.begin_transaction().expect("BEGIN");
+
+    // The cascade fires, child 11's BEFORE DELETE RAISE(IGNORE) leaves it as an
+    // orphan, the immediate FK check raises. The statement savepoint must roll
+    // the WHOLE statement back (including child 10's already-cascaded delete).
+    let err = exec(&mut db, "DELETE FROM parent WHERE id = 1").unwrap_err();
+    assert!(
+        err.contains("FOREIGN KEY constraint failed"),
+        "expected FK violation, got: {err}"
+    );
+
+    // The transaction stays OPEN (a constraint violation is statement-scoped,
+    // not transaction-scoped — SQLite's default).
+    assert!(db.in_transaction(), "constraint violation must keep the transaction open");
+
+    // Statement fully rolled back: parent 1 and BOTH children survive, with NO
+    // inconsistent partial state (the #5502 bug left parent gone OR child 10
+    // lost). Verified via a LIVE SELECT against the in-transaction state.
+    assert_eq!(query_col(&db, "SELECT id FROM parent"), vec![SqlValue::Integer(1)]);
+    assert_eq!(
+        query_col(&db, "SELECT id FROM child ORDER BY id"),
+        vec![SqlValue::Integer(10), SqlValue::Integer(11)]
+    );
+
+    // The transaction is recoverable: a clean COMMIT now succeeds because the
+    // state is consistent (no orphan was left behind).
+    crate::CommitExecutor::execute(&vibesql_ast::CommitStmt, &mut db)
+        .expect("COMMIT should succeed — no orphan persisted after statement rollback");
+    assert!(!db.in_transaction());
+    assert_eq!(query_col(&db, "SELECT id FROM parent"), vec![SqlValue::Integer(1)]);
+    assert_eq!(
+        query_col(&db, "SELECT id FROM child ORDER BY id"),
+        vec![SqlValue::Integer(10), SqlValue::Integer(11)]
+    );
+}
+
+/// #5502: an EARLIER statement in the same explicit transaction must survive
+/// when a later statement trips the cascade-orphan immediate FK. Only the
+/// offending statement is rolled back; the transaction stays open.
+#[test]
+fn cascade_orphan_in_explicit_txn_preserves_earlier_statements() {
+    let mut db = fresh_db();
+    exec(&mut db, "CREATE TABLE parent (id INTEGER PRIMARY KEY)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON DELETE CASCADE)",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE log (id INTEGER PRIMARY KEY)",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER child_skip BEFORE DELETE ON child WHEN OLD.id = 11 BEGIN SELECT RAISE(IGNORE); END",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO parent VALUES (1)").unwrap();
+    exec(&mut db, "INSERT INTO child VALUES (10, 1), (11, 1)").unwrap();
+
+    db.begin_transaction().expect("BEGIN");
+
+    // Earlier statement: a plain insert into an unrelated table.
+    exec(&mut db, "INSERT INTO log VALUES (100)").unwrap();
+
+    // Offending statement: cascade orphan immediate FK.
+    let err = exec(&mut db, "DELETE FROM parent WHERE id = 1").unwrap_err();
+    assert!(err.contains("FOREIGN KEY constraint failed"), "got: {err}");
+    assert!(db.in_transaction(), "txn must stay open");
+
+    // Earlier statement survives; offending statement fully undone.
+    assert_eq!(query_col(&db, "SELECT id FROM log"), vec![SqlValue::Integer(100)]);
+    assert_eq!(query_col(&db, "SELECT id FROM parent"), vec![SqlValue::Integer(1)]);
+    assert_eq!(
+        query_col(&db, "SELECT id FROM child ORDER BY id"),
+        vec![SqlValue::Integer(10), SqlValue::Integer(11)]
+    );
+
+    crate::CommitExecutor::execute(&vibesql_ast::CommitStmt, &mut db).expect("COMMIT ok");
+    assert_eq!(query_col(&db, "SELECT id FROM log"), vec![SqlValue::Integer(100)]);
+}

--- a/crates/vibesql-executor/src/tests/raise_trigger_tests.rs
+++ b/crates/vibesql-executor/src/tests/raise_trigger_tests.rs
@@ -1686,3 +1686,81 @@ fn procedural_delete_raise_rollback_aborts_whole_txn() {
         ],
     );
 }
+
+// ===========================================================================
+// #5502: plain constraint violations (UNIQUE / CHECK) inside an explicit
+// transaction roll the offending STATEMENT back and keep the transaction open
+// — SQLite's default conflict resolution (ABORT scope). This is the same
+// `run_inside_transaction` `Err(other)` path the cascade-orphan immediate FK
+// flows through; before #5502 it *released* the statement savepoint (leaving
+// partial multi-row changes) instead of rolling it back.
+//
+// These exercise the *trigger-armed* statement-savepoint path: a trigger on
+// the table makes `table_may_fire_trigger` true so the statement is wrapped in
+// a savepoint. (A constraint violation on a trigger-free table never arms a
+// savepoint — it takes the fast pass-through — so it is out of scope here.)
+//
+// End state verified live against sqlite3 3.51.0: the earlier statement's row
+// survives, the violating multi-row statement is fully undone, the txn stays
+// open, and a subsequent COMMIT succeeds. This is EXACT sqlite3 parity for the
+// plain-constraint case (unlike the cascade-orphan case, where the savepoint's
+// whole-statement rollback is a coarser-but-consistent superset of sqlite3's
+// partial state).
+// ===========================================================================
+
+/// #5502: a multi-row INSERT whose later row violates UNIQUE, on a table that
+/// carries a trigger (so the statement savepoint is armed), inside an explicit
+/// transaction rolls the whole statement back and keeps the txn open.
+#[test]
+fn unique_violation_in_explicit_txn_rolls_back_statement_keeps_txn_open() {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER UNIQUE)");
+    // A trigger anywhere on the table arms the statement savepoint for its DML.
+    exec_ok(&mut db, "CREATE TRIGGER trg AFTER INSERT ON t BEGIN SELECT 1; END");
+
+    db.begin_transaction().expect("BEGIN");
+
+    // Earlier statement: survives the later violation.
+    exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (1, 100)").expect("stmt 1 ok");
+
+    // Offending statement: row (3,100) duplicates v=100 -> UNIQUE violation.
+    let err = exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (2, 200), (3, 100)")
+        .expect_err("expected UNIQUE violation");
+    assert!(err.to_string().contains("UNIQUE"), "expected UNIQUE error, got: {err}");
+
+    // Constraint violation is statement-scoped: txn stays open.
+    assert!(db.in_transaction(), "UNIQUE violation must keep the transaction open");
+
+    // Whole offending statement undone (row 2 NOT left behind); earlier row 1
+    // survives. Matches sqlite3 3.51.0.
+    assert_eq!(select_rows(&db, "SELECT id FROM t ORDER BY id"), vec![vec![ipk(1)]]);
+
+    // Recoverable: COMMIT succeeds and persists exactly the earlier statement.
+    crate::CommitExecutor::execute(&vibesql_ast::CommitStmt, &mut db).expect("COMMIT ok");
+    assert!(!db.in_transaction());
+    assert_eq!(select_rows(&db, "SELECT id FROM t ORDER BY id"), vec![vec![ipk(1)]]);
+}
+
+/// #5502: same statement-rollback scope for a CHECK constraint violation on a
+/// later row of a multi-row INSERT inside an explicit transaction.
+#[test]
+fn check_violation_in_explicit_txn_rolls_back_statement_keeps_txn_open() {
+    let mut db = vibesql_storage::Database::new();
+    exec_ok(&mut db, "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER CHECK (v < 50))");
+    exec_ok(&mut db, "CREATE TRIGGER trg AFTER INSERT ON t BEGIN SELECT 1; END");
+
+    db.begin_transaction().expect("BEGIN");
+    exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (1, 10)").expect("stmt 1 ok");
+
+    // Row (3,99) violates CHECK (v < 50).
+    let err = exec_dml(&mut db, "INSERT INTO t (id, v) VALUES (2, 20), (3, 99)")
+        .expect_err("expected CHECK violation");
+    assert!(err.to_string().contains("CHECK"), "expected CHECK error, got: {err}");
+
+    assert!(db.in_transaction(), "CHECK violation must keep the transaction open");
+    // Whole statement undone (row 2 NOT kept); earlier row 1 survives.
+    assert_eq!(select_rows(&db, "SELECT id FROM t ORDER BY id"), vec![vec![ipk(1)]]);
+
+    crate::CommitExecutor::execute(&vibesql_ast::CommitStmt, &mut db).expect("COMMIT ok");
+    assert_eq!(select_rows(&db, "SELECT id FROM t ORDER BY id"), vec![vec![ipk(1)]]);
+}


### PR DESCRIPTION
Closes #5502

## Root cause

In `crates/vibesql-executor/src/raise_scope.rs`, `run_inside_transaction` (the explicit-transaction statement-savepoint path) handled non-RAISE errors in its `Err(other)` arm by calling `db.release_statement_savepoint()` — **disarm, no rollback** — on the assumption that "the DML executors already perform their own targeted rollback for these (e.g. constraint failures)."

For the cascade-orphan immediate-FK check from #5465 (and other multi-row / cascade paths) there is **no** such targeted rollback of the partial work. So when a `BEGIN; DELETE parent;` fired a cascade where a child `RAISE(IGNORE)` left an orphan and the immediate FK raised `ConstraintViolation`, the savepoint was released and the already-cascaded child delete persisted — leaving inconsistent partial state. #5498 observed `parent={1}, child={11}` (parent delete reverted by the `Err` short-circuit, but child[10]'s cascade delete lost).

The auto-commit path was already correct (it rolls back its whole implicit transaction on any `Err`), and `RAISE(ABORT)` was correct (it flows through `rollback_statement_savepoint()`). Only the explicit-txn non-RAISE path was wrong.

## The fix (release -> rollback)

The `Err(other)` arm now calls `db.rollback_statement_savepoint()` instead of `db.release_statement_savepoint()` when a savepoint was armed. A plain constraint violation (FK/UNIQUE/CHECK/NOT NULL) is statement-scoped in SQLite: the offending **statement** is rolled back (undoing every partial change it applied), and the enclosing transaction stays **open** for the application to COMMIT/ROLLBACK. This matches the savepoint's documented contract ("a `RAISE(ABORT)` or ordinary constraint failure can undo just that statement's partial changes while keeping the enclosing transaction open").

RAISE-variant scopes are untouched — they are handled in the arm above (`apply_raise_scope`): `RAISE(ROLLBACK)` rolls back the whole txn, `RAISE(ABORT)` rolls back the statement, `RAISE(FAIL)` keeps partial changes. No change to #5417 behavior.

## sqlite3 3.51.0 parity (statement rollback, txn open)

Verified against sqlite3 3.51.0 in an explicit `BEGIN`:

- **Plain UNIQUE / CHECK / NOT NULL / plain FK** (multi-row stmt, later row violates): the offending statement is fully rolled back, the earlier statement's rows survive, the txn stays open, a subsequent COMMIT succeeds. **Exact parity.** This is the broader "same property affects other immediate-FK paths" the #5498 judge noted.
- **Cascade RAISE(IGNORE) orphan immediate FK** (the #5502 repro): sqlite3 leaves the partial state `parent={}, child={11}` (it does not undo the already-cascaded child[10] delete). VibeSQL's statement savepoint rolls the whole statement back atomically -> `parent={1}, child={10,11}`, which the savepoint mechanism cannot make selective. This is the resolution #5502 explicitly accepts: "internally consistent and recoverable without manual ROLLBACK", and is the same statement-rollback scope as `RAISE(ABORT)` and the auto-commit path. It replaces the broken `parent={1}, child={11}` with a clean, consistent, recoverable state.

## No RAISE-variant regression

`RAISE(ABORT)` (statement rollback), `RAISE(FAIL)` (keep partial), `RAISE(ROLLBACK)` (whole-txn rollback) and `RAISE(IGNORE)` are all handled in the separate `Err(Raise { .. })` arm and were not modified. The full `raise_trigger_tests` (#5417) and `fk_cascade_triggers` (#5440/#5465/#5498/#5501) suites pass unchanged.

## Tests

New tests (all assert via LIVE SELECT the post-error state + txn-still-open + recoverable COMMIT):
- `fk_cascade_triggers::cascade_delete_raise_ignore_orphan_in_explicit_txn_rolls_back_statement_keeps_txn_open` — the #5502 repro: statement rolled back, txn open, clean COMMIT.
- `fk_cascade_triggers::cascade_orphan_in_explicit_txn_preserves_earlier_statements` — only the offending statement is undone; an earlier statement survives.
- `raise_trigger_tests::unique_violation_in_explicit_txn_rolls_back_statement_keeps_txn_open` — plain UNIQUE on a trigger-armed table, exact sqlite3 parity.
- `raise_trigger_tests::check_violation_in_explicit_txn_rolls_back_statement_keeps_txn_open` — plain CHECK, same.

Results:
- `cargo test -p vibesql-executor --lib`: **2787 passed, 0 failed** (with `RUST_MIN_STACK` to avoid a pre-existing, unrelated deep-recursion stack-overflow flake in `evaluator::tests::deep_expression_tests`/`cse_tests`).
- FK/transaction integration tests (`foreign_key_tests`, `foreign_key_deferred_tests`, `foreign_key_deferred_phase_c3_tests`, `transaction_tests`, `conflict_resolution_tests`): all pass.

## Scope

Changes limited to `raise_scope.rs` (the statement-savepoint rollback path) plus the two test files. No changes to `update/executor.rs` loop bodies or storage (avoiding overlap with parallel builders #5543 / #5537).