### PR TITLE
fix(executor): live columnar values for BEFORE/AFTER UPDATE triggers (#5543)

### DIFF
--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -765,6 +765,24 @@ pub(super) fn execute_internal(
                     .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
             }
 
+            // Invalidate the database-level columnar cache NOW, between the
+            // per-row apply and the AFTER trigger (#5543, the UPDATE analogue
+            // of the #5523/#5542 DELETE fix). `update_row_selective` above only
+            // invalidates the *table-level* columnar cache; the columnar
+            // aggregate path that serves a trigger body's
+            // `SELECT sum(col)/max(col)/col FROM t` reads from the *database*-
+            // level LRU snapshot (`Database::get_columnar`). Left un-invalidated
+            // until the loop end (~the post-loop `invalidate_columnar_cache`
+            // below), an AFTER UPDATE trigger — and the next row's BEFORE
+            // trigger — would observe the *pre-update* column values for this
+            // and prior rows. Dropping the stale snapshot here makes every
+            // mid-statement read see the applied updates, matching sqlite3
+            // 3.51. This is gated on `has_triggers`, so the common no-trigger
+            // bulk UPDATE (the `else` branch below) pays no per-row cost.
+            // Native columnar tables short-circuit this call (they maintain
+            // columnar data incrementally).
+            database.invalidate_columnar_cache(table_name);
+
             // AFTER(R): the row is already updated; drop the must-use outcome
             // since SkipRow cannot un-apply it (#5418).
             let _after_outcome = crate::TriggerFirer::execute_after_triggers(
@@ -1925,6 +1943,16 @@ fn execute_update_from(
                     .update_row_selective(u.row_index, u.new_row.clone(), &u.changed_columns)
                     .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
             }
+
+            // Drop the stale database-level columnar snapshot between apply(R)
+            // and AFTER(R) (#5543) — same rationale as `execute_internal`: a
+            // trigger body's `SELECT sum(col)/max(col)/col FROM t` is served
+            // from `Database::get_columnar`'s LRU, which `update_row_selective`
+            // does not invalidate, so without this an AFTER/next-BEFORE UPDATE
+            // trigger would read pre-update values. Gated on `has_triggers`, so
+            // the no-trigger `else` branch is untouched; native columnar tables
+            // short-circuit the call.
+            database.invalidate_columnar_cache(table_name);
 
             let _after_outcome = crate::TriggerFirer::execute_after_triggers(
                 database,

--- a/crates/vibesql-executor/src/update/mod.rs
+++ b/crates/vibesql-executor/src/update/mod.rs
@@ -30,6 +30,8 @@ mod foreign_keys;
 mod from_clause;
 mod index_sync;
 mod row_selector;
+#[cfg(test)]
+mod tests;
 mod triggers;
 mod value_updater;
 

--- a/crates/vibesql-executor/src/update/tests/mod.rs
+++ b/crates/vibesql-executor/src/update/tests/mod.rs
@@ -1,0 +1,3 @@
+//! Tests for UPDATE statement execution.
+
+mod trigger_phase_value;

--- a/crates/vibesql-executor/src/update/tests/trigger_phase_value.rs
+++ b/crates/vibesql-executor/src/update/tests/trigger_phase_value.rs
@@ -1,0 +1,232 @@
+//! Regression tests for #5543: BEFORE/AFTER UPDATE triggers must observe the
+//! *live* column values / aggregates of the table at each phase of a per-row
+//! UPDATE — the UPDATE analogue of the #5523/#5542 DELETE `count(*)` fix.
+//!
+//! SQLite fires UPDATE row triggers interleaved per row (#5486): for each
+//! affected row R it runs BEFORE(R), applies R's change, then runs AFTER(R)
+//! before moving to R+1. A trigger body that reads the table mid-statement —
+//! `(SELECT sum(col) FROM t)`, `(SELECT max(col) FROM t)`, or a columnar-served
+//! value read — must therefore see exactly the updates applied so far.
+//!
+//! Before this fix `update_row_selective` invalidated only the *table-level*
+//! columnar cache; the *database-level* columnar LRU (`Database::get_columnar`),
+//! which serves the columnar aggregate path for row-oriented tables, was
+//! invalidated only *after* the whole UPDATE loop. The AFTER trigger (and the
+//! next row's BEFORE trigger) then observed pre-update column values. All
+//! expected sequences below were verified live against sqlite3 3.51.0.
+
+use vibesql_ast::Statement;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn exec(db: &mut Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).expect("parse");
+    match stmt {
+        Statement::CreateTable(s) => {
+            crate::CreateTableExecutor::execute(&s, db).unwrap();
+        }
+        Statement::CreateTrigger(s) => {
+            crate::TriggerExecutor::create_trigger(db, &s).unwrap();
+        }
+        Statement::Insert(s) => {
+            crate::InsertExecutor::execute(db, &s).unwrap();
+        }
+        Statement::Update(s) => {
+            crate::UpdateExecutor::execute(&s, db).unwrap();
+        }
+        Statement::Delete(s) => {
+            crate::delete::DeleteExecutor::execute(&s, db).unwrap();
+        }
+        other => panic!("unsupported statement: {other:?}"),
+    }
+}
+
+/// Read the `t` column of the `log` table, in insertion (rowid) order, as a
+/// `Vec<String>`. Uses a LIVE SELECT through the executor so the assertion
+/// exercises the same read path the triggers observe.
+fn log_values(db: &Database) -> Vec<String> {
+    let stmt = vibesql_parser::Parser::parse_sql("SELECT t FROM log").expect("parse select");
+    let select = match stmt {
+        Statement::Select(s) => s,
+        other => panic!("expected SELECT, got {other:?}"),
+    };
+    let result =
+        crate::SelectExecutor::new(db).execute_with_columns(&select).expect("run select");
+    result
+        .rows
+        .iter()
+        .map(|r| match &r.values[0] {
+            SqlValue::Varchar(s) => s.to_string(),
+            other => format!("{other:?}"),
+        })
+        .collect()
+}
+
+/// `t1(a PK, b)` plus a `log` table seeded with three rows.
+fn setup_table(db: &mut Database) {
+    exec(db, "CREATE TABLE t1(a INT PRIMARY KEY, b INT)");
+    exec(db, "CREATE TABLE log(t)");
+    exec(db, "INSERT INTO t1 VALUES(1,10),(2,20),(3,30)");
+}
+
+/// AFTER UPDATE trigger logging the updated column plus running aggregates over
+/// the (now-mutated) table. Single-row UPDATE.
+///
+/// sqlite3 3.51.0: `1:100:sum=150:max=100:cnt=3` — the AFTER trigger sees row 1
+/// already changed (b=100), so sum=100+20+30=150 and max=100.
+#[test]
+fn after_update_trigger_reads_applied_value_single_row() {
+    let mut db = Database::new();
+    setup_table(&mut db);
+    exec(
+        &mut db,
+        "CREATE TRIGGER tr_after AFTER UPDATE ON t1 BEGIN \
+         INSERT INTO log VALUES(old.a || ':' || new.b \
+         || ':sum=' || (SELECT sum(b) FROM t1) \
+         || ':max=' || (SELECT max(b) FROM t1) \
+         || ':cnt=' || (SELECT count(*) FROM t1)); END",
+    );
+
+    exec(&mut db, "UPDATE t1 SET b=100 WHERE a=1");
+
+    assert_eq!(
+        log_values(&db),
+        vec!["1:100:sum=150:max=100:cnt=3".to_string()],
+        "AFTER UPDATE must see row 1's applied value (b=100)"
+    );
+}
+
+/// AFTER UPDATE trigger over a multi-row UPDATE: each AFTER(R) must reflect the
+/// running aggregates as rows are applied one-by-one.
+///
+/// sqlite3 3.51.0 (`UPDATE t1 SET b=b+1`, PK order):
+///   1:11:sum=63:max=31:cnt=3   (after row1: 11+20+30=61? no — see below)
+/// Verified live: rows become b=11,21,31. The aggregates use the *running*
+/// applied state per AFTER(R):
+///   AFTER(1): b=11,20,30 -> sum=61, max=30
+///   AFTER(2): b=11,21,30 -> sum=62, max=30
+///   AFTER(3): b=11,21,31 -> sum=63, max=31
+#[test]
+fn after_update_trigger_reads_applied_value_multi_row() {
+    let mut db = Database::new();
+    setup_table(&mut db);
+    exec(
+        &mut db,
+        "CREATE TRIGGER tr_after AFTER UPDATE ON t1 BEGIN \
+         INSERT INTO log VALUES(old.a || ':' || new.b \
+         || ':sum=' || (SELECT sum(b) FROM t1) \
+         || ':max=' || (SELECT max(b) FROM t1)); END",
+    );
+
+    exec(&mut db, "UPDATE t1 SET b=b+1");
+
+    assert_eq!(
+        log_values(&db),
+        vec![
+            "1:11:sum=61:max=30".to_string(),
+            "2:21:sum=62:max=30".to_string(),
+            "3:31:sum=63:max=31".to_string(),
+        ],
+        "each AFTER(R) must observe the running applied aggregates"
+    );
+}
+
+/// BEFORE UPDATE trigger over a multi-row UPDATE: BEFORE(R) runs before R is
+/// applied but must see rows 1..R-1 already updated.
+///
+/// sqlite3 3.51.0 (`UPDATE t1 SET b=b+100`, PK order):
+///   BEFORE(1): no rows applied -> b=10,20,30 -> sum=60, max=30
+///   BEFORE(2): row1 applied   -> b=110,20,30 -> sum=160, max=110
+///   BEFORE(3): rows1,2 applied -> b=110,120,30 -> sum=260, max=120
+#[test]
+fn before_update_trigger_sees_prior_rows_applied_multi_row() {
+    let mut db = Database::new();
+    setup_table(&mut db);
+    exec(
+        &mut db,
+        "CREATE TRIGGER tr_before BEFORE UPDATE ON t1 BEGIN \
+         INSERT INTO log VALUES('B:' || old.a \
+         || ':sum=' || (SELECT sum(b) FROM t1) \
+         || ':max=' || (SELECT max(b) FROM t1)); END",
+    );
+
+    exec(&mut db, "UPDATE t1 SET b=b+100");
+
+    assert_eq!(
+        log_values(&db),
+        vec![
+            "B:1:sum=60:max=30".to_string(),
+            "B:2:sum=160:max=110".to_string(),
+            "B:3:sum=260:max=120".to_string(),
+        ],
+        "BEFORE(R) must observe rows 1..R-1 already applied"
+    );
+}
+
+/// Combined BEFORE + AFTER UPDATE triggers over a multi-row UPDATE: the
+/// interleaving must be BEFORE(1) AFTER(1) BEFORE(2) AFTER(2) BEFORE(3)
+/// AFTER(3), with each phase seeing the running applied state.
+///
+/// sqlite3 3.51.0 (`UPDATE t1 SET b=b+100`, PK order):
+///   B:1:sum=60   (none applied)
+///   A:1:sum=160  (row1 applied)
+///   B:2:sum=160  (row1 applied)
+///   A:2:sum=260  (rows1,2 applied)
+///   B:3:sum=260  (rows1,2 applied)
+///   A:3:sum=360  (all applied)
+#[test]
+fn combined_before_after_update_trigger_interleaved_sum() {
+    let mut db = Database::new();
+    setup_table(&mut db);
+    exec(
+        &mut db,
+        "CREATE TRIGGER tr_before BEFORE UPDATE ON t1 BEGIN \
+         INSERT INTO log VALUES('B:' || old.a || ':sum=' || (SELECT sum(b) FROM t1)); END",
+    );
+    exec(
+        &mut db,
+        "CREATE TRIGGER tr_after AFTER UPDATE ON t1 BEGIN \
+         INSERT INTO log VALUES('A:' || old.a || ':sum=' || (SELECT sum(b) FROM t1)); END",
+    );
+
+    exec(&mut db, "UPDATE t1 SET b=b+100");
+
+    assert_eq!(
+        log_values(&db),
+        vec![
+            "B:1:sum=60".to_string(),
+            "A:1:sum=160".to_string(),
+            "B:2:sum=160".to_string(),
+            "A:2:sum=260".to_string(),
+            "B:3:sum=260".to_string(),
+            "A:3:sum=360".to_string(),
+        ],
+        "interleaved BEFORE/AFTER must each observe the running applied sum"
+    );
+}
+
+/// No-trigger control: a plain UPDATE (the fast bulk `else` branch that the
+/// per-row columnar invalidation deliberately does NOT touch) must still apply
+/// every row, and a subsequent LIVE aggregate read must reflect all updates.
+/// This guards the perf-sensitive no-trigger path.
+#[test]
+fn no_trigger_update_applies_all_rows() {
+    let mut db = Database::new();
+    setup_table(&mut db);
+
+    exec(&mut db, "UPDATE t1 SET b=b+100");
+
+    let stmt = vibesql_parser::Parser::parse_sql("SELECT sum(b), max(b), count(*) FROM t1")
+        .expect("parse");
+    let select = match stmt {
+        Statement::Select(s) => s,
+        other => panic!("expected SELECT, got {other:?}"),
+    };
+    let result =
+        crate::SelectExecutor::new(&db).execute_with_columns(&select).expect("run select");
+    // sum=110+120+130=360, max=130, count=3
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(result.rows[0].values[0], SqlValue::Integer(360));
+    assert_eq!(result.rows[0].values[1], SqlValue::Integer(130));
+    assert_eq!(result.rows[0].values[2], SqlValue::Integer(3));
+}


### PR DESCRIPTION
## Summary

Closes #5543. The UPDATE analogue of the #5523/#5542 DELETE columnar-cache fix, narrowly scoped to triggers that read updated column *values* (not just `count(*)`).

## Root cause

The per-row interleaved UPDATE path (#5486) fires `BEFORE(R) -> apply(R) -> AFTER(R)`. The apply step (`update_row_selective`) invalidates only the **table-level** columnar cache. But the columnar aggregate path that serves a trigger body's `SELECT sum(col)/max(col)/col FROM t` on a row-oriented table reads from the **database-level** columnar LRU (`Database::get_columnar`), which was invalidated **only after the whole UPDATE loop** (`execute_internal` ~L859, `execute_update_from` ~L2014).

So an AFTER UPDATE trigger — and the next row's BEFORE trigger — observed the **pre-update** column values for this and prior rows mid-statement. `count(*)` is unchanged by UPDATE, so the triggerF-style probes never caught it; it requires a trigger reading an aggregate/value over an *updated column* via the columnar path.

> Note: the issue text described the executor as "batch-phased" (all-BEFORE, all-apply, all-AFTER) using pre-#5486 line numbers. The current code is already per-row interleaved; the fix matches the live structure.

## Invalidation placement

Added `database.invalidate_columnar_cache(table_name)` immediately **after `apply(R)`** and **before `AFTER(R)`** in both trigger loops:
- `execute_internal` (default UPDATE path) — `crates/vibesql-executor/src/update/executor.rs:784`
- `execute_update_from` (`UPDATE ... FROM`) — `crates/vibesql-executor/src/update/executor.rs:1955`

This makes every mid-statement read (AFTER(R) and BEFORE(R+1)) see the running applied state.

## Perf scoping

Both invalidations live **inside the `if has_triggers` branch**. The common no-trigger bulk UPDATE takes the separate `else` branch (and the single-row PK fast path), which are untouched — zero per-row cost when no UPDATE triggers exist. Native columnar tables short-circuit `invalidate_columnar_cache` (they maintain columnar data incrementally).

## sqlite3 3.51.0 parity (verified live)

- **AFTER UPDATE aggregate/column, single row**: `UPDATE t1 SET b=100 WHERE a=1` -> `1:100:sum=150:max=100:cnt=3` (AFTER sees b=100 applied).
- **AFTER UPDATE, multi-row** (`UPDATE t1 SET b=b+1`): `1:11:sum=61:max=30`, `2:21:sum=62:max=30`, `3:31:sum=63:max=31` (running applied aggregates).
- **BEFORE UPDATE mid-multi-row** (`UPDATE t1 SET b=b+100`): `B:1:sum=60:max=30`, `B:2:sum=160:max=110`, `B:3:sum=260:max=120` (BEFORE(R) sees rows 1..R-1 applied).
- **Combined BEFORE+AFTER interleaving**: `B:1:sum=60 A:1:sum=160 B:2:sum=160 A:2:sum=260 B:3:sum=260 A:3:sum=360`.

## Tests

5 new in-source tests in `crates/vibesql-executor/src/update/tests/trigger_phase_value.rs`, all asserting via **LIVE SELECT** against the sqlite3-verified sequences, including a **no-trigger control** guarding the perf path. The 3 multi-row tests **fail without the fix** (observe stale `sum=60` everywhere); pass with it.

## Test / no-regression results

- `cargo test -p vibesql-executor`: green (2788 lib tests + all integration suites, 0 failed).
- triggerF.test: 12/12.
- trigger2.test: 48/51 — the 3 failures (`2.12-before`, `2.12-after`, `2.14-after`) are **pre-existing on main** (verified by rebuilding HEAD without the fix: identical 48/51). They exercise trigger *programs* doing cross-table INSERT...SELECT / mutations, unrelated to columnar-value freshness.

## Follow-ons

- trigger2-2.12 / 2.14 pre-existing failures (trigger-program cross-table semantics) — separate issue, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)