### PR TITLE
fix(executor): echo source quoting in table "already exists" error

### DIFF
--- a/crates/vibesql-ast/src/ddl/table.rs
+++ b/crates/vibesql-ast/src/ddl/table.rs
@@ -161,6 +161,14 @@ pub struct CreateTableStmt {
     pub table_options: Vec<TableOption>,
     /// Whether the table name was quoted (delimited) in the original SQL.
     pub quoted: bool,
+    /// The table name exactly as it appeared in the source, including any
+    /// quoting delimiters (`"tbl1"`, `[tbl1]`, `` `tbl1` ``) and original
+    /// casing. `table_name` holds the normalized identifier used for catalog
+    /// lookups, but SQLite echoes the *original* spelling in the "table ...
+    /// already exists" error. `None` when the source spelling is not available
+    /// (e.g. AST built programmatically), in which case callers fall back to
+    /// `table_name`.
+    pub name_source: Option<String>,
     /// Optional AS SELECT query for CREATE TABLE ... AS SELECT syntax
     /// When present, columns are derived from the query result
     pub as_query: Option<Box<crate::SelectStmt>>,

--- a/crates/vibesql-ast/tests/ddl.rs
+++ b/crates/vibesql-ast/tests/ddl.rs
@@ -35,6 +35,7 @@ fn test_create_table_statement() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     });

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -60,6 +60,7 @@ impl CreateTableExecutor {
     ///     table_constraints: vec![],
     ///     table_options: vec![],
     ///     quoted: false,
+    ///     name_source: None,
     ///     as_query: None, without_rowid: false,
     /// };
     ///
@@ -102,6 +103,7 @@ impl CreateTableExecutor {
                 &schema_name,
                 identifier,
                 stmt.if_not_exists,
+                stmt.name_source.as_deref(),
                 query,
             );
         }
@@ -120,11 +122,19 @@ impl CreateTableExecutor {
                     table_name, schema_name
                 ));
             }
-            return Err(ExecutorError::TableAlreadyExists(format!(
-                "{}.{}",
-                schema_name,
-                identifier.display()
-            )));
+            // A bare `CREATE TABLE` over an existing name is an error. SQLite
+            // echoes the table name *exactly as written in the source*,
+            // preserving its quoting form and casing — `table "tbl1" already
+            // exists` / `table [tbl1] already exists` (sqlite3 3.51.0). The
+            // parser captures that verbatim spelling in `name_source`; fall back
+            // to the schema-qualified normalized name when it is unavailable
+            // (e.g. programmatically-built AST). Mirrors the CREATE TRIGGER
+            // mechanism from #5538.
+            let echoed = stmt
+                .name_source
+                .clone()
+                .unwrap_or_else(|| format!("{}.{}", schema_name, identifier.display()));
+            return Err(ExecutorError::TableAlreadyExists(echoed));
         }
 
         // Check for AUTO_INCREMENT constraints
@@ -604,6 +614,7 @@ impl CreateTableExecutor {
         schema_name: &str,
         identifier: TableIdentifier,
         if_not_exists: bool,
+        name_source: Option<&str>,
         query: &vibesql_ast::SelectStmt,
     ) -> Result<String, ExecutorError> {
         // Check if table already exists
@@ -614,11 +625,13 @@ impl CreateTableExecutor {
                     table_name, schema_name
                 ));
             }
-            return Err(ExecutorError::TableAlreadyExists(format!(
-                "{}.{}",
-                schema_name,
-                identifier.display()
-            )));
+            // Echo the source quoting form when available (see the bare CREATE
+            // TABLE path above for rationale); fall back to the schema-qualified
+            // normalized name for programmatically-built ASTs.
+            let echoed = name_source
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("{}.{}", schema_name, identifier.display()));
+            return Err(ExecutorError::TableAlreadyExists(echoed));
         }
 
         // Execute the SELECT query to get results

--- a/crates/vibesql-executor/src/drop_table.rs
+++ b/crates/vibesql-executor/src/drop_table.rs
@@ -44,6 +44,7 @@ impl DropTableExecutor {
     ///     table_constraints: vec![],
     ///     table_options: vec![],
     ///     quoted: false,
+    ///     name_source: None,
     ///     as_query: None, without_rowid: false,
     /// };
     /// CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
@@ -129,6 +130,7 @@ mod tests {
             table_constraints: vec![],
             table_options: vec![],
             quoted: false,
+            name_source: None,
             as_query: None,
             without_rowid: false,
         };
@@ -197,6 +199,7 @@ mod tests {
             table_constraints: vec![],
             table_options: vec![],
             quoted: false,
+            name_source: None,
             as_query: None,
             without_rowid: false,
         };
@@ -248,6 +251,7 @@ mod tests {
             table_constraints: vec![],
             table_options: vec![],
             quoted: false,
+            name_source: None,
             as_query: None,
             without_rowid: false,
         };
@@ -297,6 +301,7 @@ mod tests {
             table_constraints: vec![],
             table_options: vec![],
             quoted: false,
+            name_source: None,
             as_query: None,
             without_rowid: false,
         };
@@ -336,6 +341,7 @@ mod tests {
                 table_constraints: vec![],
                 table_options: vec![],
                 quoted: false,
+                name_source: None,
                 as_query: None,
                 without_rowid: false,
             };
@@ -377,6 +383,7 @@ mod tests {
             table_constraints: vec![],
             table_options: vec![],
             quoted: false,
+            name_source: None,
             as_query: None,
             without_rowid: false,
         };
@@ -427,6 +434,7 @@ mod tests {
             table_constraints: vec![],
             table_options: vec![],
             quoted: false,
+            name_source: None,
             as_query: None,
             without_rowid: false,
         };
@@ -517,6 +525,7 @@ mod tests {
             table_constraints: vec![],
             table_options: vec![],
             quoted: false,
+            name_source: None,
             as_query: None,
             without_rowid: false,
         };
@@ -580,6 +589,7 @@ mod tests {
             table_constraints: vec![],
             table_options: vec![],
             quoted: false,
+            name_source: None,
             as_query: None,
             without_rowid: false,
         };

--- a/crates/vibesql-executor/src/index_ddl/analyze.rs
+++ b/crates/vibesql-executor/src/index_ddl/analyze.rs
@@ -162,6 +162,7 @@ mod tests {
             table_constraints: vec![],
             table_options: vec![],
             quoted: false,
+            name_source: None,
             as_query: None,
             without_rowid: false,
         };

--- a/crates/vibesql-executor/src/index_ddl/create_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/create_index.rs
@@ -181,6 +181,7 @@ mod tests {
             table_constraints: vec![],
             table_options: vec![],
             quoted: false,
+            name_source: None,
             as_query: None,
             without_rowid: false,
         };
@@ -469,6 +470,7 @@ mod tests {
             table_constraints: vec![],
             table_options: vec![],
             quoted: false,
+            name_source: None,
             as_query: None,
             without_rowid: false,
         }
@@ -616,6 +618,7 @@ mod tests {
             table_constraints: vec![],
             table_options: vec![],
             quoted: false,
+            name_source: None,
             as_query: None,
             without_rowid: false,
         };
@@ -1040,6 +1043,7 @@ mod tests {
             table_constraints: vec![],
             table_options: vec![],
             quoted: false,
+            name_source: None,
             as_query: None,
             without_rowid: false,
         };

--- a/crates/vibesql-executor/src/index_ddl/drop_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/drop_index.rs
@@ -134,6 +134,7 @@ mod tests {
             table_constraints: vec![],
             table_options: vec![],
             quoted: false,
+            name_source: None,
             as_query: None,
             without_rowid: false,
         };

--- a/crates/vibesql-executor/src/index_ddl/reindex.rs
+++ b/crates/vibesql-executor/src/index_ddl/reindex.rs
@@ -113,6 +113,7 @@ mod tests {
             table_constraints: vec![],
             table_options: vec![],
             quoted: false,
+            name_source: None,
             as_query: None,
             without_rowid: false,
         };

--- a/crates/vibesql-executor/src/select_into.rs
+++ b/crates/vibesql-executor/src/select_into.rs
@@ -58,6 +58,7 @@ impl SelectIntoExecutor {
             table_constraints: vec![],
             table_options: vec![],
             quoted: false, // Synthesized from SELECT INTO, treat as unquoted
+            name_source: None,
             as_query: None,
             without_rowid: false,
         };

--- a/crates/vibesql-executor/src/tests/auto_increment_tests.rs
+++ b/crates/vibesql-executor/src/tests/auto_increment_tests.rs
@@ -48,6 +48,7 @@ fn test_auto_increment_basic_inserts() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -144,6 +145,7 @@ fn test_multiple_auto_increment_error() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -194,6 +196,7 @@ fn test_last_insert_rowid_basic() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -289,6 +292,7 @@ fn test_last_insert_rowid_multi_row_insert() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -372,6 +376,7 @@ fn test_last_insert_rowid_no_auto_increment() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -447,6 +452,7 @@ fn test_last_insert_rowid_via_select() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };

--- a/crates/vibesql-executor/src/tests/create_table_constraints.rs
+++ b/crates/vibesql-executor/src/tests/create_table_constraints.rs
@@ -42,6 +42,7 @@ fn test_create_table_with_column_primary_key() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -103,6 +104,7 @@ fn test_create_table_with_table_primary_key() {
         }],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -149,6 +151,7 @@ fn test_create_table_with_multiple_primary_keys_fails() {
         }],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -192,6 +195,7 @@ fn test_create_table_with_column_unique_constraint() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -253,6 +257,7 @@ fn test_create_table_with_table_unique_constraint() {
         }],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -299,6 +304,7 @@ fn test_create_table_with_check_constraint() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -341,6 +347,7 @@ fn test_auto_index_for_single_column_primary_key() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -389,6 +396,7 @@ fn test_integer_primary_key_no_autoindex() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -457,6 +465,7 @@ fn test_auto_index_for_composite_primary_key() {
         }],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -512,6 +521,7 @@ fn test_auto_index_for_single_unique_constraint() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -581,6 +591,7 @@ fn test_auto_index_for_multiple_unique_constraints() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -648,6 +659,7 @@ fn test_auto_index_for_composite_unique_constraint() {
         }],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -708,6 +720,7 @@ fn test_auto_index_for_primary_key_plus_unique() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -767,6 +780,7 @@ fn test_auto_index_visible_in_catalog() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };

--- a/crates/vibesql-executor/src/tests/create_table_tests.rs
+++ b/crates/vibesql-executor/src/tests/create_table_tests.rs
@@ -50,6 +50,7 @@ fn test_create_simple_table() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -135,6 +136,7 @@ fn test_create_table_with_multiple_types() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -172,6 +174,7 @@ fn test_create_table_already_exists() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -184,6 +187,93 @@ fn test_create_table_already_exists() {
     let result = CreateTableExecutor::execute(&stmt, &mut db);
     assert!(result.is_err());
     assert!(matches!(result, Err(crate::errors::ExecutorError::TableAlreadyExists(_))));
+}
+
+/// Helper: parse a CREATE TABLE statement string and return the typed AST.
+fn parse_create_table(sql: &str) -> CreateTableStmt {
+    match vibesql_parser::Parser::parse_sql(sql).expect("parse failed") {
+        vibesql_ast::Statement::CreateTable(stmt) => stmt,
+        other => panic!("Expected CreateTable, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_duplicate_table_already_exists_echoes_source_quoting() {
+    // SQLite (3.51.0) echoes the table name *exactly as written* in the
+    // "already exists" error, preserving its quoting form and casing:
+    //   CREATE TABLE  tbl1  -> table tbl1 already exists
+    //   CREATE TABLE "tbl1" -> table "tbl1" already exists
+    //   CREATE TABLE [tbl1] -> table [tbl1] already exists
+    //   CREATE TABLE `tbl1` -> table `tbl1` already exists
+    //   CREATE TABLE "TBL1" -> table "TBL1" already exists
+    //
+    // VibeSQL surfaces this via `Table '<echoed>' already exists`; the TCL
+    // conformance shim rewrites it to SQLite's lowercase-wrapper form while
+    // preserving `<echoed>`. We assert the raw VibeSQL message here. The error
+    // echoes the *failing* (second) statement's source spelling, regardless of
+    // how the first (existing) table was spelled.
+    // (first_sql, dup_sql, expected_message). The dup statement collides with
+    // the first under VibeSQL's identifier-equality rules, and the error echoes
+    // the *dup* statement's verbatim spelling.
+    let cases = [
+        ("CREATE TABLE tbl1 (a)", "CREATE TABLE tbl1 (a)", "Table 'tbl1' already exists"),
+        ("CREATE TABLE tbl1 (a)", "CREATE TABLE \"tbl1\" (a)", "Table '\"tbl1\"' already exists"),
+        ("CREATE TABLE tbl1 (a)", "CREATE TABLE [tbl1] (a)", "Table '[tbl1]' already exists"),
+        ("CREATE TABLE tbl1 (a)", "CREATE TABLE `tbl1` (a)", "Table '`tbl1`' already exists"),
+        // Casing is preserved verbatim in the echoed name.
+        (
+            "CREATE TABLE \"TBL1\" (a)",
+            "CREATE TABLE \"TBL1\" (a)",
+            "Table '\"TBL1\"' already exists",
+        ),
+    ];
+
+    for (first_sql, dup_sql, expected) in cases {
+        let mut db = Database::new();
+
+        // First create succeeds and registers the table.
+        let first = parse_create_table(first_sql);
+        CreateTableExecutor::execute(&first, &mut db).expect("first create should succeed");
+
+        // Re-creating with the (possibly quoted) duplicate name errors, echoing
+        // the source quoting form of the failing statement.
+        let dup = parse_create_table(dup_sql);
+        let err = CreateTableExecutor::execute(&dup, &mut db)
+            .expect_err("duplicate table must be rejected");
+        assert_eq!(err.to_string(), expected, "for SQL: {dup_sql}");
+    }
+}
+
+#[test]
+fn test_duplicate_table_as_select_echoes_source_quoting() {
+    // CREATE TABLE ... AS SELECT over an existing name also preserves the
+    // source quoting form (sqlite3 3.51.0).
+    let mut db = Database::new();
+    let first = parse_create_table("CREATE TABLE tbl1 (a)");
+    CreateTableExecutor::execute(&first, &mut db).expect("first create should succeed");
+
+    let dup = parse_create_table("CREATE TABLE \"tbl1\" AS SELECT 1");
+    let err =
+        CreateTableExecutor::execute(&dup, &mut db).expect_err("duplicate CTAS must be rejected");
+    assert_eq!(err.to_string(), "Table '\"tbl1\"' already exists");
+}
+
+#[test]
+fn test_duplicate_table_programmatic_ast_falls_back_to_normalized_name() {
+    // An AST built without source spelling (name_source == None) falls back to
+    // the schema-qualified normalized name in the error, preserving the legacy
+    // behavior the TCL shim's schema-prefix-strip handles.
+    let mut db = Database::new();
+    let mut stmt = parse_create_table("CREATE TABLE tbl1 (a)");
+    stmt.name_source = None;
+    CreateTableExecutor::execute(&stmt, &mut db).expect("first create should succeed");
+
+    let err =
+        CreateTableExecutor::execute(&stmt, &mut db).expect_err("duplicate must be rejected");
+    // schema-qualified fallback (e.g. "public.tbl1" / "main.tbl1").
+    let msg = err.to_string();
+    assert!(msg.ends_with("tbl1' already exists"), "unexpected fallback message: {msg}");
+    assert!(msg.contains('.'), "expected schema-qualified fallback: {msg}");
 }
 
 #[test]
@@ -229,6 +319,7 @@ fn test_create_table_with_nullable_columns() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -255,6 +346,7 @@ fn test_create_table_empty_columns_list() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -289,6 +381,7 @@ fn test_create_multiple_tables() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -312,6 +405,7 @@ fn test_create_multiple_tables() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -345,6 +439,7 @@ fn test_create_table_with_special_characters_in_name() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -375,6 +470,7 @@ fn test_create_table_case_sensitivity() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -398,6 +494,7 @@ fn test_create_table_case_sensitivity() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -463,6 +560,7 @@ fn test_create_table_with_spatial_types() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -516,6 +614,7 @@ fn test_create_table_multipolygon_sqllogictest() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };

--- a/crates/vibesql-executor/src/tests/select_into_tests.rs
+++ b/crates/vibesql-executor/src/tests/select_into_tests.rs
@@ -36,6 +36,7 @@ fn test_select_into_single_row() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -150,6 +151,7 @@ fn test_select_into_no_rows_error() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -220,6 +222,7 @@ fn test_select_into_multiple_rows_error() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -300,6 +303,7 @@ fn test_select_into_with_expressions() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };

--- a/crates/vibesql-executor/src/tests/triggers/conditions.rs
+++ b/crates/vibesql-executor/src/tests/triggers/conditions.rs
@@ -42,6 +42,7 @@ fn test_when_clause_filters_firing() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };

--- a/crates/vibesql-executor/src/tests/triggers/coordination.rs
+++ b/crates/vibesql-executor/src/tests/triggers/coordination.rs
@@ -148,6 +148,7 @@ fn test_before_trigger_executes_first() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };

--- a/crates/vibesql-executor/src/tests/triggers/mod.rs
+++ b/crates/vibesql-executor/src/tests/triggers/mod.rs
@@ -45,6 +45,7 @@ pub(super) fn create_audit_table(db: &mut Database) {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -82,6 +83,7 @@ pub(super) fn create_users_table(db: &mut Database) {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };

--- a/crates/vibesql-executor/src/tests/truncate_cascade_tests.rs
+++ b/crates/vibesql-executor/src/tests/truncate_cascade_tests.rs
@@ -47,6 +47,7 @@ fn create_table_with_pk(db: &mut Database, table_name: &str, pk_column: &str) {
         }],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -117,6 +118,7 @@ fn create_table_with_fk(
         ],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };

--- a/crates/vibesql-executor/src/tests/truncate_table_tests.rs
+++ b/crates/vibesql-executor/src/tests/truncate_table_tests.rs
@@ -40,6 +40,7 @@ fn test_truncate_single_table() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -98,6 +99,7 @@ fn test_truncate_multiple_tables() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -121,6 +123,7 @@ fn test_truncate_multiple_tables() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -144,6 +147,7 @@ fn test_truncate_multiple_tables() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -233,6 +237,7 @@ fn test_truncate_multiple_tables_if_exists_mixed() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -280,6 +285,7 @@ fn test_truncate_multiple_tables_all_or_nothing_validation() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -325,6 +331,7 @@ fn test_truncate_empty_table() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -392,6 +399,7 @@ fn test_truncate_resets_auto_increment() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -506,6 +514,7 @@ fn test_truncate_resets_auto_increment_multiple_inserts() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -604,6 +613,7 @@ fn test_truncate_without_auto_increment() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };

--- a/crates/vibesql-executor/src/truncate/mod.rs
+++ b/crates/vibesql-executor/src/truncate/mod.rs
@@ -65,6 +65,7 @@ impl TruncateTableExecutor {
     ///     table_constraints: vec![],
     ///     table_options: vec![],
     ///     quoted: false,
+    ///     name_source: None,
     ///     as_query: None, without_rowid: false,
     /// };
     /// CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();

--- a/crates/vibesql-executor/tests/index_ordering_tests.rs
+++ b/crates/vibesql-executor/tests/index_ordering_tests.rs
@@ -37,6 +37,7 @@ fn test_index_ordering() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };

--- a/crates/vibesql-executor/tests/spatial_index_tests.rs
+++ b/crates/vibesql-executor/tests/spatial_index_tests.rs
@@ -39,6 +39,7 @@ fn test_create_spatial_index_basic() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -108,6 +109,7 @@ fn test_spatial_index_multiple_columns_error() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -173,6 +175,7 @@ fn test_drop_spatial_index() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -239,6 +242,7 @@ fn test_spatial_index_if_not_exists() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };

--- a/crates/vibesql-executor/tests/truncate_tests.rs
+++ b/crates/vibesql-executor/tests/truncate_tests.rs
@@ -50,6 +50,7 @@ fn create_test_table(db: &mut Database, table_name: &str) {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };
@@ -540,6 +541,7 @@ fn test_truncate_preserves_table_structure() {
         table_constraints: vec![],
         table_options: vec![],
         quoted: false,
+        name_source: None,
         as_query: None,
         without_rowid: false,
     };

--- a/crates/vibesql-parser/src/parser/create/table.rs
+++ b/crates/vibesql-parser/src/parser/create/table.rs
@@ -34,8 +34,20 @@ impl Parser {
             false
         };
 
-        // Parse table name with quoted flag (supports schema.table)
+        // Parse table name with quoted flag (supports schema.table).
+        // Capture the verbatim source spelling of the table-name token before
+        // `parse_table_ref` normalizes (de-quotes) it. SQLite echoes the table
+        // name exactly as written — including its quoting form and casing — in
+        // the "table ... already exists" error, whereas `table_name` below holds
+        // the normalized identifier used for catalog lookups. For a
+        // `schema.name` qualified reference the table-name token is the one
+        // following the `.` separator, so we record the cursor position of the
+        // *final* identifier token consumed by the table ref. (Mirrors the
+        // CREATE TRIGGER mechanism from #5538.)
+        let name_start_pos = self.current_position();
         let table = self.parse_table_ref()?;
+        let name_token_pos = self.current_position().saturating_sub(1).max(name_start_pos);
+        let name_source = self.token_source_at(name_token_pos).map(str::to_string);
 
         // Check for CREATE TABLE ... AS SELECT syntax
         if self.peek_keyword(Keyword::As) {
@@ -56,6 +68,7 @@ impl Parser {
                 table_constraints: Vec::new(),
                 table_options: Vec::new(),
                 quoted: table.is_any_quoted(),
+                name_source,
                 as_query: Some(Box::new(select_stmt)),
                 without_rowid: false, // CREATE TABLE AS SELECT cannot be WITHOUT ROWID
             });
@@ -256,6 +269,7 @@ impl Parser {
             table_constraints,
             table_options,
             quoted: table.is_any_quoted(),
+            name_source,
             as_query: None,
             without_rowid,
         })

--- a/crates/vibesql-parser/src/tests/create_table/basic.rs
+++ b/crates/vibesql-parser/src/tests/create_table/basic.rs
@@ -244,3 +244,47 @@ fn test_parse_generated_column_short_form() {
         _ => panic!("Expected CREATE TABLE statement"),
     }
 }
+
+/// The parser captures the *verbatim* source spelling of the table-name token
+/// (including quotes/brackets/backticks and casing) in `name_source`, so the
+/// executor can echo it in the "table ... already exists" error to match
+/// sqlite3 3.51.0. Mirrors the CREATE TRIGGER mechanism from #5538 (issue #5544).
+#[test]
+fn test_parse_create_table_captures_name_source() {
+    let cases = [
+        ("CREATE TABLE tbl1 (a)", "tbl1", "tbl1"),
+        ("CREATE TABLE \"tbl1\" (a)", "tbl1", "\"tbl1\""),
+        ("CREATE TABLE [tbl1] (a)", "tbl1", "[tbl1]"),
+        ("CREATE TABLE `tbl1` (a)", "tbl1", "`tbl1`"),
+        ("CREATE TABLE \"TBL1\" (a)", "TBL1", "\"TBL1\""),
+        // schema-qualified: name_source is the table-name token (no schema prefix).
+        ("CREATE TABLE main.\"tbl1\" (a)", "main.tbl1", "\"tbl1\""),
+    ];
+
+    for (sql, expected_name, expected_source) in cases {
+        match Parser::parse_sql(sql).expect("parse failed") {
+            vibesql_ast::Statement::CreateTable(create) => {
+                assert_eq!(create.table_name, expected_name, "table_name for: {sql}");
+                assert_eq!(
+                    create.name_source.as_deref(),
+                    Some(expected_source),
+                    "name_source for: {sql}"
+                );
+            }
+            _ => panic!("Expected CREATE TABLE statement for: {sql}"),
+        }
+    }
+}
+
+/// CREATE TABLE ... AS SELECT also captures the table-name source spelling.
+#[test]
+fn test_parse_create_table_as_select_captures_name_source() {
+    match Parser::parse_sql("CREATE TABLE \"tbl1\" AS SELECT 1").expect("parse failed") {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_name, "tbl1");
+            assert_eq!(create.name_source.as_deref(), Some("\"tbl1\""));
+            assert!(create.as_query.is_some());
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -331,12 +331,21 @@ proc translate_error_to_sqlite {vibesql_error} {
         return "misuse of window function [string tolower $func_name]()"
     }
 
-    # Table already exists: "Table 'public.X' already exists" -> {table "x" already exists}
-    # Strip schema prefix (e.g., "public.t1" -> "t1")
+    # Table already exists: "Table 'X' already exists" -> "table X already exists"
+    # SQLite (sqlite3 3.51.0) echoes the duplicate table name *exactly as written
+    # in the source*, preserving its quoting form and casing — `table "tbl1"
+    # already exists`, `table [tbl1] already exists`, `table tbl1 already exists`.
+    # VibeSQL's parser now captures that verbatim source spelling
+    # (CreateTableStmt::name_source) and embeds it in the error, so `X` already
+    # carries the original delimiters/casing — we emit the lowercase `table`
+    # wrapper and pass the name through unchanged (issue #5544, mirroring #5527
+    # for triggers). Programmatically-built ASTs (no source) fall back to a
+    # `schema.name` form; strip the schema prefix in that case so legacy callers
+    # stay correct. (Note: `name_source` is a single bare token and never
+    # contains a `.`, so the split only ever strips a fallback schema prefix.)
     if {[regexp -nocase {^Table '([^']+)' already exists} $error_msg -> full_name]} {
-        # Remove schema prefix if present
         set table_name [lindex [split $full_name "."] end]
-        return "table \"[string tolower $table_name]\" already exists"
+        return "table $table_name already exists"
     }
 
     # Index already exists: "Index 'X' already exists" -> "index X already exists"


### PR DESCRIPTION
## Summary

Follow-on from #5527 (PR #5538, MERGED), which made the duplicate **CREATE TRIGGER** "already exists" error echo the trigger name's verbatim source quoting. The judge verified TABLES had the same gap. This applies the identical `name_source` / byte-span source-preservation mechanism to **CreateTableStmt** so a duplicate `CREATE TABLE` echoes the table name exactly as written, matching sqlite3 3.51.0.

## Mirrored mechanism (from #5538)

- The CREATE TABLE parser (`crates/vibesql-parser/src/parser/create/table.rs`) captures the verbatim source spelling of the table-name token via the existing `Parser::token_source_at` helper (byte spans wired by `Parser::new_with_source`). It records the *final* identifier token of the table ref, so `schema.name` yields just the `name` token.
- New `CreateTableStmt::name_source: Option<String>` (`crates/vibesql-ast/src/ddl/table.rs`) carries that verbatim spelling alongside the normalized `table_name` used for catalog lookups. `None` for programmatically-built ASTs.
- Both the bare CREATE TABLE and CREATE TABLE ... AS SELECT "already exists" error sites (`crates/vibesql-executor/src/create_table.rs`) echo `name_source`, falling back to the schema-qualified normalized name (`schema.identifier`) when it is unavailable.
- The TCL shim's table-already-exists branch (`scripts/tester_vibesql.tcl`) now passes the embedded name through unchanged (no `string tolower` / double-quote re-wrap), so it carries the original delimiters and casing.

## Scope guard

- **INDEXES** are intentionally left on the existing lowercase path: sqlite3 does **not** preserve quoting in `index ix1 already exists`, so the shim's index branch is already correct and untouched.
- **Trigger** quoting (#5538) is unaffected (verified: `Trigger '"tr1"' already exists` still echoed; trigger1-1.2.1/1.2.2/1.2.3 still pass).

## sqlite3 3.51.0 parity per quoting form

Verified via the release binary (`Table 'X' already exists` -> shim -> `table X already exists`):

| source form | error (after shim) | sqlite3 3.51.0 |
|---|---|---|
| `tbl1`   | `table tbl1 already exists`   | match |
| `"tbl1"` | `table "tbl1" already exists` | match |
| `[tbl1]` | `table [tbl1] already exists` | match |
| `` `tbl1` `` | `` table `tbl1` already exists `` | match |
| `"TBL1"` | `table "TBL1" already exists` | match |

The echoed name is the *failing* (second) statement's spelling, matching sqlite3.

## TCL delta

`table.test` (table-2.1.1 / table-3.2..3.5) and `e_createtable.test` (assert these forms) are currently **fully skipped** by the VibeSQL native-TCL harness (they rely on file-backed reopen / ATTACH patterns the shim doesn't run), so the **measurable conformance delta is 0**. This change removes a latent shim bug (the old `string tolower` + `"X"` re-wrap was wrong for brackets/backticks/casing and would fail those assertions once the files are enabled). Correctness is covered by parser/executor unit tests and direct-binary verification. `trigger1.test` 1.2.x still pass — no regression.

## Tests

- Parser (`create_table/basic.rs`): `test_parse_create_table_captures_name_source` (all forms + schema-qualified), `test_parse_create_table_as_select_captures_name_source`.
- Executor (`create_table_tests.rs`): `test_duplicate_table_already_exists_echoes_source_quoting`, `test_duplicate_table_as_select_echoes_source_quoting`, `test_duplicate_table_programmatic_ast_falls_back_to_normalized_name`.
- `cargo test -p vibesql-parser -p vibesql-executor` green (incl. doctests).
- `cargo build --workspace` clean (the `name_source` field was threaded through all CreateTableStmt construction sites; default `None`).

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test -p vibesql-parser -p vibesql-executor` green
- [x] sqlite3 3.51.0 parity verified per quoting form via release binary
- [x] index already-exists unchanged (lowercase); trigger quoting (#5538) not regressed

Closes #5544

🤖 Generated with [Claude Code](https://claude.com/claude-code)