### PR TITLE
feat(trigger): honor PRAGMA recursive_triggers = off (trigger3-6)

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -1039,6 +1039,20 @@ impl SqlExecutor {
                         message: None,
                     })
                 }
+                "RECURSIVE_TRIGGERS" => {
+                    // SQLite-compatible PRAGMA recursive_triggers (#5535).
+                    // When OFF, a trigger already on the execution stack is not
+                    // re-fired by DML within its own body; when ON (default),
+                    // triggers recurse up to MAX_TRIGGER_RECURSION_DEPTH (#5479).
+                    self.db.set_recursive_triggers(bool_value);
+                    Ok(QueryResult {
+                        rows: Vec::new(),
+                        columns: Vec::new(),
+                        row_count: 0,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
                 "DEFER_FOREIGN_KEYS" => {
                     // SQLite-compatible PRAGMA defer_foreign_keys.
                     // Phase C1 of #5085: store/read the flag and auto-reset
@@ -1133,6 +1147,18 @@ impl SqlExecutor {
                     let value = if self.db.foreign_keys_enabled() { "1" } else { "0" };
                     Ok(QueryResult {
                         columns: vec!["foreign_keys".to_string()],
+                        rows: vec![vec![Some(value.to_string())]],
+                        row_count: 1,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
+                "RECURSIVE_TRIGGERS" => {
+                    // SQLite-compatible PRAGMA recursive_triggers read (#5535).
+                    // Defaults to 1 (ON), matching triggerC-6.1.
+                    let value = if self.db.recursive_triggers() { "1" } else { "0" };
+                    Ok(QueryResult {
+                        columns: vec!["recursive_triggers".to_string()],
                         rows: vec![vec![Some(value.to_string())]],
                         row_count: 1,
                         execution_time_ms: None,

--- a/crates/vibesql-executor/src/tests/trigger_case_body_tests.rs
+++ b/crates/vibesql-executor/src/tests/trigger_case_body_tests.rs
@@ -149,6 +149,14 @@ fn nested_case_end_does_not_truncate_body() {
 #[test]
 fn case_in_where_clause_does_not_truncate_body() {
     let mut db = vibesql_storage::Database::new();
+    // This test's subject is CASE-body parsing, not recursion. The trigger body
+    // performs an `UPDATE t` while firing on `t`, which — now that nested UPDATEs
+    // correctly fire the target's UPDATE triggers (#5535) — would recurse under
+    // the default `recursive_triggers = on` (sqlite3 3.51.0 errors here with
+    // "too many levels of trigger recursion"). Set the pragma OFF to assert the
+    // single-fire shape this test cares about (matching sqlite3's CLI default and
+    // this test's original intent), keeping the recursion suppressed.
+    db.set_recursive_triggers(false);
     exec_ok(&mut db, "CREATE TABLE t (id INTEGER, v INTEGER)");
     exec_ok(&mut db, "CREATE TABLE log (msg VARCHAR(16))");
     exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (1, 0)");
@@ -160,8 +168,8 @@ fn case_in_where_clause_does_not_truncate_body() {
          END",
     );
 
-    // Fire the AFTER UPDATE trigger. Recursion is prevented by SQLite/VibeSQL so
-    // the inner UPDATE does not re-fire infinitely.
+    // Fire the AFTER UPDATE trigger. With recursive_triggers off the inner
+    // UPDATE does not re-fire `tr`, so the body runs exactly once.
     exec_ok(&mut db, "UPDATE t SET v = 1 WHERE id = 1");
 
     assert_eq!(strings(&db, "log", "msg"), vec!["w".to_string()]);

--- a/crates/vibesql-executor/src/trigger_execution.rs
+++ b/crates/vibesql-executor/src/trigger_execution.rs
@@ -1,6 +1,7 @@
 //! Trigger execution logic for firing triggers on DML operations
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
 
 use vibesql_ast::{PseudoTable, TriggerEvent, TriggerGranularity, TriggerTiming};
 use vibesql_catalog::{TableSchema, TriggerDefinition};
@@ -88,6 +89,59 @@ impl Drop for RecursionGuard {
             depth.set(depth.get().saturating_sub(1));
         });
     }
+}
+
+thread_local! {
+    /// Names of triggers currently executing on this thread, keyed by the
+    /// lowercased trigger name with a reference count. Used to honor
+    /// `PRAGMA recursive_triggers = off`: when that pragma is off, a trigger is
+    /// not re-fired by DML performed while the same trigger is already running.
+    ///
+    /// A count (rather than a set) is required because with
+    /// `recursive_triggers = on` the *same* trigger can legitimately appear on
+    /// the stack multiple times (recursive firing), and each level must be
+    /// balanced by its own pop. Trigger names are SQLite-unique per schema, so
+    /// the lowercased name is a stable identity key.
+    static ACTIVE_TRIGGERS: RefCell<HashMap<String, usize>> =
+        RefCell::new(HashMap::new());
+}
+
+/// RAII guard that records a trigger as "currently executing" for the duration
+/// of its action, so the `recursive_triggers = off` suppression check can tell
+/// whether re-entering a trigger would be recursive.
+struct ActiveTriggerGuard {
+    key: String,
+}
+
+impl ActiveTriggerGuard {
+    fn new(trigger_name: &str) -> Self {
+        let key = trigger_name.to_lowercase();
+        ACTIVE_TRIGGERS.with(|active| {
+            *active.borrow_mut().entry(key.clone()).or_insert(0) += 1;
+        });
+        ActiveTriggerGuard { key }
+    }
+}
+
+impl Drop for ActiveTriggerGuard {
+    fn drop(&mut self) {
+        ACTIVE_TRIGGERS.with(|active| {
+            let mut map = active.borrow_mut();
+            if let Some(count) = map.get_mut(&self.key) {
+                *count -= 1;
+                if *count == 0 {
+                    map.remove(&self.key);
+                }
+            }
+        });
+    }
+}
+
+/// Returns true if a trigger with this name is already executing on the current
+/// thread (i.e. firing it now would be a recursive re-entry).
+fn is_trigger_active(trigger_name: &str) -> bool {
+    let key = trigger_name.to_lowercase();
+    ACTIVE_TRIGGERS.with(|active| active.borrow().get(&key).is_some_and(|&c| c > 0))
 }
 
 /// Execution context for triggers with OLD/NEW row access
@@ -324,6 +378,12 @@ impl TriggerFirer {
                 return Ok(TriggerOutcome::Proceed);
             }
         }
+
+        // Mark this trigger as executing for the duration of its action so that
+        // `PRAGMA recursive_triggers = off` can suppress re-entry into the same
+        // trigger from nested DML (#5535). The guard is dropped — and the
+        // trigger un-marked — when the action completes or errors out.
+        let _active = ActiveTriggerGuard::new(&trigger.name);
 
         // 2. Execute trigger action
         Self::execute_trigger_action(db, trigger, old_row, new_row)
@@ -599,6 +659,22 @@ impl TriggerFirer {
         }
     }
 
+    /// Whether firing `trigger` right now must be suppressed because
+    /// `PRAGMA recursive_triggers` is off and the same trigger is already
+    /// executing on this thread.
+    ///
+    /// SQLite's `recursive_triggers = off` does not blanket-disable nested
+    /// trigger firing; it only prevents a trigger from being re-entered while it
+    /// is already running. A *different* trigger reached via nested DML still
+    /// fires, and a trigger fired at the top level (e.g. the DELETE trigger run
+    /// for a REPLACE-induced delete) still fires because it is not yet on the
+    /// stack. This per-trigger rule is what `trigger3-6` and `triggerC-5.3.*`
+    /// depend on (#5535). When `recursive_triggers = on` (the default) this
+    /// always returns false and the depth cap (#5479) governs recursion instead.
+    fn suppressed_by_recursive_triggers_off(db: &Database, trigger: &TriggerDefinition) -> bool {
+        !db.recursive_triggers() && is_trigger_active(&trigger.name)
+    }
+
     /// Execute all BEFORE ROW-level triggers for an operation
     ///
     /// # Arguments
@@ -632,6 +708,11 @@ impl TriggerFirer {
         for trigger in triggers {
             // Only execute ROW-level triggers in this method
             if trigger.granularity == TriggerGranularity::Row {
+                // PRAGMA recursive_triggers = off: don't re-enter a running trigger.
+                if Self::suppressed_by_recursive_triggers_off(db, &trigger) {
+                    continue;
+                }
+
                 // For UPDATE OF triggers, check if monitored columns changed
                 if let (Some(old), Some(new)) = (old_row, new_row) {
                     if !Self::should_fire_update_of(&trigger, old, new, &table_schema) {
@@ -673,6 +754,10 @@ impl TriggerFirer {
         for trigger in triggers {
             // Only execute STATEMENT-level triggers in this method
             if trigger.granularity == TriggerGranularity::Statement {
+                // PRAGMA recursive_triggers = off: don't re-enter a running trigger.
+                if Self::suppressed_by_recursive_triggers_off(db, &trigger) {
+                    continue;
+                }
                 // Statement-level triggers don't have OLD/NEW row access
                 if Self::execute_trigger(db, &trigger, None, None)? == TriggerOutcome::SkipRow {
                     return Ok(TriggerOutcome::SkipRow);
@@ -716,6 +801,11 @@ impl TriggerFirer {
         for trigger in triggers {
             // Only execute ROW-level triggers in this method
             if trigger.granularity == TriggerGranularity::Row {
+                // PRAGMA recursive_triggers = off: don't re-enter a running trigger.
+                if Self::suppressed_by_recursive_triggers_off(db, &trigger) {
+                    continue;
+                }
+
                 // For UPDATE OF triggers, check if monitored columns changed
                 if let (Some(old), Some(new)) = (old_row, new_row) {
                     if !Self::should_fire_update_of(&trigger, old, new, &table_schema) {
@@ -756,6 +846,10 @@ impl TriggerFirer {
         for trigger in triggers {
             // Only execute STATEMENT-level triggers in this method
             if trigger.granularity == TriggerGranularity::Statement {
+                // PRAGMA recursive_triggers = off: don't re-enter a running trigger.
+                if Self::suppressed_by_recursive_triggers_off(db, &trigger) {
+                    continue;
+                }
                 // Statement-level triggers don't have OLD/NEW row access
                 if Self::execute_trigger(db, &trigger, None, None)? == TriggerOutcome::SkipRow {
                     return Ok(TriggerOutcome::SkipRow);

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -92,13 +92,30 @@ pub(super) fn execute_internal(
     // This ensures case-sensitive tables (quoted identifiers) are accessed correctly
     let table_name = &schema_owned.name;
 
-    // Check if table has UPDATE triggers (check once, use multiple times)
-    let has_triggers = trigger_context.is_none()
-        && database
-            .catalog
-            .get_triggers_for_table(table_name, Some(vibesql_ast::TriggerEvent::Update(None)))
-            .next()
-            .is_some();
+    // Check if table has UPDATE triggers (check once, use multiple times).
+    //
+    // ROW-level triggers fire even when this UPDATE runs inside another
+    // trigger's body (i.e. `trigger_context.is_some()`): SQLite fires a nested
+    // UPDATE's row triggers subject only to `recursive_triggers` and the depth
+    // cap, which `TriggerFirer` now enforces directly (#5535). This mirrors the
+    // INSERT path, which already fires nested-INSERT row triggers. Previously
+    // this was gated on `trigger_context.is_none()`, so a nested UPDATE in a
+    // trigger body silently skipped the target table's UPDATE triggers — e.g.
+    // a BEFORE UPDATE `RAISE(IGNORE)` never ran (trigger3-6).
+    //
+    // STATEMENT-level triggers are a VibeSQL extension with no sqlite3 analog
+    // and are NOT fired inside a trigger body; that gating uses
+    // `fire_statement_triggers` below.
+    let has_triggers = database
+        .catalog
+        .get_triggers_for_table(table_name, Some(vibesql_ast::TriggerEvent::Update(None)))
+        .next()
+        .is_some();
+
+    // STATEMENT-level triggers only fire at the top level (not within another
+    // trigger's body), matching the INSERT path's `trigger_context.is_none()`
+    // gate on statement triggers.
+    let fire_statement_triggers = has_triggers && trigger_context.is_none();
 
     // Try fast path for simple single-row PK updates without triggers
     // Conditions: no triggers, no procedural context, simple WHERE pk = value, no assertions
@@ -134,7 +151,7 @@ pub(super) fn execute_internal(
     // statement granularity has no defined "skip the row" semantics. We keep
     // the pre-#5418 behavior (proceed) and explicitly drop the must-use
     // outcome rather than guessing.
-    if has_triggers {
+    if fire_statement_triggers {
         let _stmt_outcome = crate::TriggerFirer::execute_before_statement_triggers(
             database,
             table_name,
@@ -860,7 +877,7 @@ pub(super) fn execute_internal(
     }
 
     // Fire AFTER STATEMENT triggers only if triggers exist
-    if has_triggers {
+    if fire_statement_triggers {
         // Statement-level RAISE(IGNORE) has no sqlite3 analog (see BEFORE
         // STATEMENT note above); drop the must-use outcome (#5418).
         let _stmt_outcome = crate::TriggerFirer::execute_after_statement_triggers(
@@ -1463,6 +1480,11 @@ fn execute_update_from(
     trigger_context: Option<&crate::trigger_execution::TriggerContext<'_>>,
     cte_results: Option<&std::collections::HashMap<String, crate::select::cte::CteResult>>,
 ) -> Result<(usize, Option<crate::select::SelectResult>), ExecutorError> {
+    // STATEMENT-level triggers (a VibeSQL extension) only fire at the top level,
+    // never within another trigger's body — matching `execute_internal`. ROW
+    // triggers (`has_triggers`) still fire when nested (#5535).
+    let fire_statement_triggers = has_triggers && trigger_context.is_none();
+
     // Execute the join and get matched rows with computed SET values
     // Issue #5082: pass trigger_context so the synthetic SELECT can resolve
     // OLD/NEW pseudo-variables when this UPDATE runs inside a trigger body.
@@ -1470,7 +1492,7 @@ fn execute_update_from(
         execute_update_from_join(stmt, from_clauses, database, schema, trigger_context)?;
 
     // Fire BEFORE STATEMENT triggers if needed
-    if has_triggers {
+    if fire_statement_triggers {
         // Statement-level RAISE(IGNORE) has no sqlite3 analog; drop the
         // must-use outcome (#5418).
         let _stmt_outcome = crate::TriggerFirer::execute_before_statement_triggers(
@@ -1493,7 +1515,7 @@ fn execute_update_from(
 
     if updates.is_empty() {
         // Fire AFTER STATEMENT triggers even when no rows matched
-        if has_triggers {
+        if fire_statement_triggers {
             // Statement-level RAISE(IGNORE) has no sqlite3 analog; drop the
             // must-use outcome (#5418).
             let _stmt_outcome = crate::TriggerFirer::execute_after_statement_triggers(
@@ -1840,7 +1862,7 @@ fn execute_update_from(
     // After IGNORE may have filtered to zero rows.
     if updates.is_empty() {
         // Fire AFTER STATEMENT triggers even when all rows skipped.
-        if has_triggers {
+        if fire_statement_triggers {
             // Statement-level RAISE(IGNORE) has no sqlite3 analog; drop the
             // must-use outcome (#5418).
             let _stmt_outcome = crate::TriggerFirer::execute_after_statement_triggers(
@@ -2015,7 +2037,7 @@ fn execute_update_from(
     }
 
     // Fire AFTER STATEMENT triggers
-    if has_triggers {
+    if fire_statement_triggers {
         // Statement-level RAISE(IGNORE) has no sqlite3 analog; drop the
         // must-use outcome (#5418).
         let _stmt_outcome = crate::TriggerFirer::execute_after_statement_triggers(

--- a/crates/vibesql-executor/tests/recursive_triggers_pragma_tests.rs
+++ b/crates/vibesql-executor/tests/recursive_triggers_pragma_tests.rs
@@ -1,0 +1,247 @@
+//! Tests for `PRAGMA recursive_triggers` semantics (#5535).
+//!
+//! With `recursive_triggers = OFF`, a trigger already executing on the stack is
+//! not re-fired by DML performed within its own body — directly- and
+//! mutually-recursive trigger firing is suppressed. A *different* trigger
+//! reached via nested DML still fires, and a trigger fired at the top level
+//! still fires (it is not yet on the stack). With `recursive_triggers = ON`
+//! (VibeSQL's default, matching modern SQLite), triggers recurse up to the depth
+//! cap (#5479).
+//!
+//! Every expectation below was verified against sqlite3 3.51.0. The headline
+//! case (`off_suppresses_self_refiring_trigger3_6_shape`) reproduces the exact
+//! `trigger3-6` scenario from SQLite's `trigger3.test`, which runs the whole
+//! file under `PRAGMA recursive_triggers = off`.
+
+use vibesql_executor::{
+    CreateTableExecutor, InsertExecutor, SelectExecutor, TriggerExecutor, UpdateExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Parse and execute a single SQL statement, dispatching on statement type.
+fn exec(db: &mut Database, sql: &str) {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e:?}"));
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+        }
+        Statement::CreateTrigger(s) => {
+            // Preserve the raw SQL so the trigger body re-parses faithfully.
+            TriggerExecutor::create_trigger_with_sql(db, &s, Some(sql))
+                .expect("CREATE TRIGGER failed");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT failed");
+        }
+        Statement::Update(s) => {
+            UpdateExecutor::execute(&s, db).expect("UPDATE failed");
+        }
+        other => panic!("unsupported statement in test helper: {other:?}"),
+    }
+}
+
+/// Run a SELECT and return its rows as `Vec<Vec<SqlValue>>` (live rows only).
+fn query(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).expect("parse failed");
+    let Statement::Select(select) = stmt else {
+        panic!("expected SELECT");
+    };
+    SelectExecutor::new(db)
+        .execute(&select)
+        .expect("SELECT failed")
+        .into_iter()
+        .map(|row| row.values.to_vec())
+        .collect()
+}
+
+fn i(n: i64) -> SqlValue {
+    SqlValue::Integer(n)
+}
+
+/// `recursive_triggers = off`: the `trigger3-6` self-refiring shape. An AFTER
+/// INSERT trigger on `tbl2` inserts back into `tbl2`; with the pragma off that
+/// nested INSERT must NOT re-fire the trigger, so `tbl2` ends with exactly two
+/// rows (without suppression this recurses to the depth cap and errors). The
+/// body's `UPDATE tbl SET c = 10` runs once.
+///
+/// sqlite3 3.51.0 (recursive_triggers off):
+///   tbl2 -> {1 2 3 , 1 2 3} ; tbl -> {1 2 10}
+#[test]
+fn off_suppresses_self_refiring_trigger3_6_shape() {
+    let mut db = Database::new();
+    db.set_recursive_triggers(false);
+
+    exec(&mut db, "CREATE TABLE tbl(a, b, c)");
+    exec(&mut db, "INSERT INTO tbl VALUES(1, 2, 3)");
+    exec(&mut db, "CREATE TABLE tbl2(a, b, c)");
+    exec(
+        &mut db,
+        "CREATE TRIGGER after_tbl2_insert AFTER INSERT ON tbl2 BEGIN \
+         UPDATE tbl SET c = 10; \
+         INSERT INTO tbl2 VALUES (new.a, new.b, new.c); END",
+    );
+
+    // Without suppression this recurses until the depth cap and errors.
+    exec(&mut db, "INSERT INTO tbl2 VALUES (1, 2, 3)");
+
+    assert_eq!(
+        query(&db, "SELECT * FROM tbl2"),
+        vec![vec![i(1), i(2), i(3)], vec![i(1), i(2), i(3)]],
+        "self-recursive trigger must fire exactly once with recursive_triggers off",
+    );
+    assert_eq!(
+        query(&db, "SELECT * FROM tbl"),
+        vec![vec![i(1), i(2), i(10)]],
+        "the trigger body's UPDATE runs exactly once",
+    );
+}
+
+/// `recursive_triggers = off` is *per trigger*, not a blanket disable: a
+/// DIFFERENT trigger reached via nested DML still fires. Trigger `ta` (on `a`)
+/// inserts into `b`, which fires trigger `tb` (on `b`) once.
+///
+/// sqlite3 3.51.0: log -> {tb , ta}  (tb runs to completion before ta's body
+/// finishes; both fire exactly once).
+#[test]
+fn off_still_fires_distinct_nested_trigger() {
+    let mut db = Database::new();
+    db.set_recursive_triggers(false);
+
+    exec(&mut db, "CREATE TABLE a(x)");
+    exec(&mut db, "CREATE TABLE b(x)");
+    exec(&mut db, "CREATE TABLE log(msg)");
+    exec(
+        &mut db,
+        "CREATE TRIGGER ta AFTER INSERT ON a BEGIN \
+         INSERT INTO b VALUES(new.x); INSERT INTO log VALUES('ta'); END",
+    );
+    exec(
+        &mut db,
+        "CREATE TRIGGER tb AFTER INSERT ON b BEGIN INSERT INTO log VALUES('tb'); END",
+    );
+
+    exec(&mut db, "INSERT INTO a VALUES(1)");
+
+    let txt = |s: &str| SqlValue::Varchar(arcstr::ArcStr::from(s));
+    assert_eq!(
+        query(&db, "SELECT msg FROM log"),
+        vec![vec![txt("tb")], vec![txt("ta")]],
+        "a distinct nested trigger must still fire when recursive_triggers is off",
+    );
+}
+
+/// `recursive_triggers = off` suppresses MUTUAL recursion too: `ta` (on `a`)
+/// inserts into `b`, `tb` (on `b`) inserts back into `a` — but `ta` is already
+/// on the stack, so its re-entry is suppressed. Each fires once.
+///
+/// sqlite3 3.51.0: log -> {ta , tb} (and no infinite loop / cap error).
+#[test]
+fn off_suppresses_mutual_recursion() {
+    let mut db = Database::new();
+    db.set_recursive_triggers(false);
+
+    exec(&mut db, "CREATE TABLE a(x)");
+    exec(&mut db, "CREATE TABLE b(x)");
+    exec(&mut db, "CREATE TABLE log(msg)");
+    exec(
+        &mut db,
+        "CREATE TRIGGER ta AFTER INSERT ON a BEGIN \
+         INSERT INTO log VALUES('ta'); INSERT INTO b VALUES(new.x); END",
+    );
+    exec(
+        &mut db,
+        "CREATE TRIGGER tb AFTER INSERT ON b BEGIN \
+         INSERT INTO log VALUES('tb'); INSERT INTO a VALUES(new.x); END",
+    );
+
+    exec(&mut db, "INSERT INTO a VALUES(1)");
+
+    let txt = |s: &str| SqlValue::Varchar(arcstr::ArcStr::from(s));
+    assert_eq!(
+        query(&db, "SELECT msg FROM log"),
+        vec![vec![txt("ta")], vec![txt("tb")]],
+        "mutual trigger recursion must be suppressed (each fires once) with recursive_triggers off",
+    );
+}
+
+/// `recursive_triggers = on` (the default) keeps recursive firing: a guarded
+/// self-recursive countdown trigger fires once per level.
+///
+/// sqlite3 3.51.0 (recursive_triggers on, the modern default): inserting 5
+/// yields rows 5,4,3,2,1,0 — six rows.
+#[test]
+fn on_recurses_to_completion() {
+    let mut db = Database::new();
+    // Default is ON; assert that and do not change it.
+    assert!(db.recursive_triggers(), "recursive_triggers must default to ON");
+
+    exec(&mut db, "CREATE TABLE t(a INTEGER PRIMARY KEY)");
+    exec(
+        &mut db,
+        "CREATE TRIGGER t_cd AFTER INSERT ON t WHEN (new.a > 0) BEGIN \
+         INSERT INTO t VALUES(new.a - 1); END",
+    );
+
+    exec(&mut db, "INSERT INTO t VALUES(5)");
+
+    assert_eq!(
+        query(&db, "SELECT a FROM t ORDER BY a").len(),
+        6,
+        "recursive_triggers on must recurse: rows 5..=0",
+    );
+}
+
+/// Toggling the pragma mid-session takes effect. Each phase uses a disjoint
+/// value band so the same self-recursive countdown trigger never hits a PRIMARY
+/// KEY collision, isolating the on/off behavior:
+///   - ON: inserting 5 recurses down its band (5,4,3,2,1 — stops at the band
+///     floor) producing 5 rows.
+///   - OFF: inserting 25 fires once (no re-fire), adding 25 and its single
+///     decrement 24 — 2 rows.
+///   - ON: inserting 45 recurses again down its band (45..=41) — 5 rows.
+///
+/// The trigger is guarded `new.a > floor(a)` per band via `new.a % 10 != 1`
+/// so each band yields a fixed, non-overlapping set of rows. Counts verified to
+/// match the equivalent sqlite3 3.51.0 runs (with the pragma set explicitly per
+/// phase, since the sqlite3 CLI defaults the pragma to off).
+#[test]
+fn toggle_mid_session_takes_effect() {
+    let mut db = Database::new();
+
+    exec(&mut db, "CREATE TABLE t(a INTEGER PRIMARY KEY)");
+    // Recurse downward but stop at any value ending in 1, so a start of N0..N9
+    // recurses only within its own ten-band (e.g. 5 -> 4,3,2,1).
+    exec(
+        &mut db,
+        "CREATE TRIGGER t_cd AFTER INSERT ON t WHEN (new.a % 10 > 1) BEGIN \
+         INSERT INTO t VALUES(new.a - 1); END",
+    );
+
+    // ON (default): inserting 5 recurses to 5,4,3,2,1 = 5 rows.
+    assert!(db.recursive_triggers(), "recursive_triggers must default to ON");
+    exec(&mut db, "INSERT INTO t VALUES(5)");
+    assert_eq!(query(&db, "SELECT a FROM t").len(), 5, "ON: 5,4,3,2,1");
+
+    // Switch OFF: inserting 25 fires the trigger once; its body inserts 24 but
+    // that nested INSERT does NOT re-fire the trigger. Adds {25, 24} = 2 rows.
+    db.set_recursive_triggers(false);
+    exec(&mut db, "INSERT INTO t VALUES(25)");
+    assert_eq!(
+        query(&db, "SELECT a FROM t").len(),
+        7,
+        "OFF: only the direct row 25 and its single decrement 24 are added",
+    );
+
+    // Switch back ON: inserting 45 recurses down its band to 45,44,43,42,41.
+    db.set_recursive_triggers(true);
+    exec(&mut db, "INSERT INTO t VALUES(45)");
+    assert_eq!(
+        query(&db, "SELECT a FROM t").len(),
+        12,
+        "ON again: 45,44,43,42,41 added by recursion (5 rows)",
+    );
+}

--- a/crates/vibesql-storage/src/database/session.rs
+++ b/crates/vibesql-storage/src/database/session.rs
@@ -144,6 +144,35 @@ impl Database {
         );
     }
 
+    /// Get the recursive_triggers PRAGMA setting (SQLite compatibility).
+    ///
+    /// When ON (VibeSQL default, matching modern SQLite's documented behavior),
+    /// a trigger's body may fire further triggers — including, indirectly,
+    /// itself — up to `MAX_TRIGGER_RECURSION_DEPTH`. When OFF, a trigger that is
+    /// already executing is not re-fired by DML performed within its own body
+    /// (directly- or mutually-recursive trigger firing is suppressed). This is
+    /// the historical SQLite behavior that pre-recursion tests such as
+    /// `trigger3.test` rely on (see #5535).
+    ///
+    /// Suppression is *per trigger*: a nested DML statement still fires any
+    /// trigger that is not already on the execution stack — only a re-entry into
+    /// a trigger that is currently running is skipped. The depth cap (#5479) is
+    /// orthogonal and still applies when recursion is enabled.
+    pub fn recursive_triggers(&self) -> bool {
+        match self.get_session_variable("RECURSIVE_TRIGGERS") {
+            Some(vibesql_types::SqlValue::Integer(n)) => *n != 0,
+            _ => true, // Default: ON (modern SQLite default; keeps recursive-trigger tests green)
+        }
+    }
+
+    /// Set the recursive_triggers PRAGMA setting (SQLite compatibility).
+    pub fn set_recursive_triggers(&mut self, value: bool) {
+        self.set_session_variable(
+            "RECURSIVE_TRIGGERS",
+            vibesql_types::SqlValue::Integer(if value { 1 } else { 0 }),
+        );
+    }
+
     // ============================================================================
     // Foreign Key Enforcement (SQLite Compatibility)
     // ============================================================================

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -49,6 +49,7 @@ set ::pragma_count_changes 0       ;# Default: OFF (UPDATE/DELETE return nothing
 set ::pragma_reverse_unordered_selects 0  ;# Default: OFF (normal row order)
 set ::pragma_foreign_keys 0              ;# Default: OFF (SQLite default)
 set ::pragma_defer_foreign_keys 0        ;# Default: OFF; auto-resets at COMMIT/ROLLBACK
+set ::pragma_recursive_triggers 1        ;# Default: ON (VibeSQL default; #5535)
 
 # DQS (Double-Quoted Strings) mode tracking
 # When enabled, double-quoted strings are treated as string literals instead of identifiers
@@ -876,6 +877,14 @@ proc build_pragma_prefix {} {
     if {$::pragma_defer_foreign_keys != 0} {
         append prefix "PRAGMA defer_foreign_keys=$::pragma_defer_foreign_keys;\n"
     }
+    # Include recursive_triggers if it's been set to OFF. VibeSQL (like modern
+    # SQLite) defaults this pragma to ON, and the multi-process shim starts each
+    # CLI process at that default, so we only need to re-apply the non-default
+    # OFF state. Tests such as trigger3.test set it off for the whole file
+    # (#5535).
+    if {$::pragma_recursive_triggers != 1} {
+        append prefix "PRAGMA recursive_triggers=$::pragma_recursive_triggers;\n"
+    }
     return $prefix
 }
 
@@ -979,6 +988,20 @@ proc track_pragma_setting {sql} {
     # across the boundary in subsequent CLI process invocations.
     if {[regexp -nocase {(?:^|;)\s*(?:COMMIT|ROLLBACK)\s*(?:;|$)} $sql]} {
         set ::pragma_defer_foreign_keys 0
+    }
+
+    # Look for recursive_triggers settings (find all occurrences, use last one).
+    # Unlike defer_foreign_keys this does NOT reset at COMMIT/ROLLBACK — it is a
+    # connection-level setting that persists for the whole file (#5535).
+    set matches [regexp -all -inline -nocase {PRAGMA\s+(?:database\.)?recursive_triggers\s*[=(]\s*(\w+)\s*[)]?} $sql]
+    foreach {match value} $matches {
+        set upper [string toupper $value]
+        if {$upper eq "ON" || $upper eq "TRUE" || $upper eq "YES" || $value eq "1"} {
+            set ::pragma_recursive_triggers 1
+        } else {
+            set ::pragma_recursive_triggers 0
+        }
+        set found 1
     }
 
     return $found


### PR DESCRIPTION
Closes #5535

## What

VibeSQL ignored `PRAGMA recursive_triggers`: a trigger's nested DML re-fired the same trigger until the depth cap (#5479). `trigger3.test` runs with `PRAGMA recursive_triggers = off` (line 24), so **trigger3-6** failed with `too many levels of trigger recursion`.

## Pragma wiring

- `crates/vibesql-storage/src/database/session.rs`: `recursive_triggers()` / `set_recursive_triggers()` (session variable `RECURSIVE_TRIGGERS`, **default ON** — modern SQLite default; keeps triggerC recursion tests green).
- `crates/vibesql-cli/src/executor/mod.rs`: `PRAGMA recursive_triggers = ON|OFF` (set) and `PRAGMA recursive_triggers` (query, column `recursive_triggers`, default `1`).
- `scripts/tester_vibesql.tcl`: track the pragma and re-apply it across the shim's per-batch CLI processes (the shim spawns a fresh `vibesql` per SQL batch, so session pragmas must be replayed — same mechanism as `foreign_keys` etc.).

## OFF-suppression semantics

`crates/vibesql-executor/src/trigger_execution.rs`: a thread-local active-trigger stack (ref-counted by trigger name). In `execute_trigger` an RAII guard marks the trigger executing for the duration of its body. The four firing loops skip a trigger when `!db.recursive_triggers() && is_trigger_active(name)`.

Suppression is **per-trigger**, matching sqlite3 3.51.0:
- A trigger does not re-enter itself (direct or mutual recursion) while already on the stack.
- A *distinct* nested trigger still fires.
- A trigger fired at the top level (e.g. a REPLACE-induced DELETE trigger) still fires — it's not yet on the stack.

When ON (default), this is a no-op and recursion is governed by the depth cap (#5479).

## Nested-UPDATE trigger firing

`crates/vibesql-executor/src/update/executor.rs`: UPDATEs nested inside a trigger body now fire the target's UPDATE triggers (the `trigger_context.is_none()` gate is dropped for ROW triggers), mirroring the INSERT path. Recursion is now controlled by `recursive_triggers` + the depth cap rather than a blanket no-nested-firing rule. Statement-level triggers (a VibeSQL extension) stay top-level-only via `fire_statement_triggers`. Required for trigger3-6's nested `UPDATE ... RAISE(IGNORE)`.

## sqlite3 3.51.0 parity (verified)

- `recursive_triggers = off`: self-modifying trigger fires once (trigger3-6 shape → tbl2 two rows; nested `UPDATE` honors BEFORE UPDATE `RAISE(IGNORE)`). Distinct nested trigger still fires; mutual recursion suppressed.
- `recursive_triggers = on`: recursion to completion / depth cap (matches sqlite3 ON).
- Toggle mid-session takes effect.

## trigger3 delta

- Before: 14 passed / 3 failed (trigger3-1.2, trigger3-2.2, **trigger3-6**).
- After: 15 passed / 2 failed. **trigger3-6 now passes.** Remaining trigger3-1.2 / trigger3-2.2 are pre-existing, unrelated `No active transaction to rollback` harness failures.

## Default-ON, no regression

- `triggerC.test`: 76→77 passed (triggerC-6.1 pragma probe now returns `1`); no new failures. Recursion-cap tests (#5479) unaffected.
- `trigger2.test`: **2 more pass** (trigger2-2.12-after/-before, nested-UPDATE-trigger cases).
- `trigger1/trigger4/triggerB/triggerD/triggerE`: failure sets **identical** to baseline (diffed against a clean origin/main build) — zero regressions.
- `cargo test -p vibesql-executor`: green (2792 lib tests + integration suites).
- New `crates/vibesql-executor/tests/recursive_triggers_pragma_tests.rs`: 5 LIVE-SELECT tests (off-suppresses-self, distinct-nested-still-fires, mutual-recursion-suppressed, on-recurses, toggle), each matching a verified sqlite3 3.51.0 run.
- One existing lib test (`trigger_case_body_tests::case_in_where_clause_does_not_truncate_body`) updated to set `recursive_triggers = off`: its self-recursive AFTER UPDATE now correctly recurses under default-ON (sqlite3-ON errors here); the pragma-off makes it assert the single-fire shape it actually tests (CASE-body parsing), matching sqlite3's CLI default.

## Follow-ons

- The two pre-existing trigger3-1.2 / trigger3-2.2 `No active transaction to rollback` failures (harness/transaction, unrelated to triggers).
- Raising the recursion cap to SQLite's full 1000 needs heap-allocated trigger recursion (already tracked as #5534).