### PR TITLE
fix(executor): apply rowid INTEGER affinity coercion on INSERT

### DIFF
--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -71,6 +71,72 @@ pub fn execute_insert_with_trigger_context(
         .map(|outcome| outcome.affected_rows)
 }
 
+/// Result of applying SQLite rowid (INTEGER) affinity to a value supplied for
+/// the rowid / INTEGER PRIMARY KEY position on INSERT.
+enum RowidAffinity {
+    /// The value coerced to a concrete integer rowid.
+    Value(i64),
+    /// The value was NULL (or DEFAULT) — auto-assign the next rowid.
+    Auto,
+}
+
+/// Apply SQLite's rowid (INTEGER) affinity to an already-evaluated value.
+///
+/// SQLite coerces the value supplied for a rowid / INTEGER PRIMARY KEY into an
+/// integer before storing it (and before triggers observe `NEW.rowid`):
+/// - integers pass through;
+/// - a TEXT value that is losslessly an integer (e.g. `'45'`) is coerced;
+/// - a REAL value that is losslessly an integer (e.g. `45.0`, `-42.0`) is
+///   coerced; a value with a fractional part (e.g. `42.4`) cannot be a rowid
+///   and raises `datatype mismatch`;
+/// - NULL means auto-assign;
+/// - anything else (non-numeric TEXT, BLOB, fractional REAL) raises
+///   `datatype mismatch`, matching sqlite3 3.51.
+///
+/// sqlite3 3.51.0 accepts any integer rowid, including zero and negatives
+/// (`INSERT INTO t(rowid) VALUES(-42.0)` stores rowid -42; triggerC-4.1.4), so
+/// no positivity restriction is applied — only the affinity coercion and the
+/// lossless-integer check.
+fn coerce_rowid_affinity(
+    value: &vibesql_types::SqlValue,
+) -> Result<RowidAffinity, ExecutorError> {
+    use vibesql_types::SqlValue;
+
+    let datatype_mismatch =
+        || ExecutorError::UnsupportedExpression("datatype mismatch".to_string());
+
+    // Coerce a lossless-integer f64 to i64, else datatype mismatch.
+    let from_float = |f: f64| -> Result<i64, ExecutorError> {
+        if f.fract() == 0.0 && f >= i64::MIN as f64 && f <= i64::MAX as f64 {
+            Ok(f as i64)
+        } else {
+            Err(datatype_mismatch())
+        }
+    };
+
+    let i = match value {
+        SqlValue::Null => return Ok(RowidAffinity::Auto),
+        SqlValue::Integer(i) => *i,
+        SqlValue::Bigint(i) => *i,
+        SqlValue::Smallint(i) => *i as i64,
+        SqlValue::Varchar(s) | SqlValue::Character(s) => {
+            let trimmed = s.trim();
+            if let Ok(i) = trimmed.parse::<i64>() {
+                i
+            } else if let Ok(f) = trimmed.parse::<f64>() {
+                from_float(f)?
+            } else {
+                return Err(datatype_mismatch());
+            }
+        }
+        SqlValue::Float(f) => from_float(*f as f64)?,
+        SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f) => from_float(*f)?,
+        _ => return Err(datatype_mismatch()),
+    };
+
+    Ok(RowidAffinity::Value(i))
+}
+
 /// Internal implementation of INSERT execution
 fn execute_insert_internal(
     db: &mut vibesql_storage::Database,
@@ -407,153 +473,63 @@ fn execute_insert_internal(
             // Get the rowid expression
             let rowid_expr = &value_exprs[rowid_pos];
 
-            // Extract literal value from expression
-            // For INTEGER PRIMARY KEY columns (rowid_is_pseudo_column=false), allow any integer
-            // For pseudo-columns (rowid, _rowid_, oid), only allow positive integers
-            match rowid_expr {
-                vibesql_ast::Expression::Literal(val) => {
-                    match val {
-                        vibesql_types::SqlValue::Integer(i) => {
-                            // For pseudo-columns, require positive; for IPK columns, allow any value
-                            if resolved_columns.rowid_is_pseudo_column && *i <= 0 {
-                                return Err(ExecutorError::UnsupportedExpression(
-                                    "datatype mismatch".to_string(),
-                                ));
-                            }
-                            let rowid = *i as u64;
-                            // Update batch_max_rowid for subsequent NULL auto-assignments
-                            if *i > 0 {
-                                batch_max_rowid = batch_max_rowid.max(rowid);
-                            }
-                            Some(rowid)
+            // Apply a coerced rowid affinity result, updating batch_max_rowid
+            // for subsequent NULL/DEFAULT auto-assignments. SQLite's INTEGER
+            // affinity is applied to the rowid value before storage (and before
+            // triggers observe NEW.rowid): a TEXT/REAL value that is losslessly
+            // an integer is coerced (e.g. '45' -> 45, -42.0 -> -42), a value
+            // with a fractional part (e.g. 42.4) or a non-numeric TEXT/BLOB
+            // raises "datatype mismatch" (triggerC-4.1.x).
+            let mut apply_affinity = |affinity: RowidAffinity| -> u64 {
+                match affinity {
+                    RowidAffinity::Value(i) => {
+                        let rowid = i as u64;
+                        if i > 0 {
+                            batch_max_rowid = batch_max_rowid.max(rowid);
                         }
-                        vibesql_types::SqlValue::Bigint(i) => {
-                            if resolved_columns.rowid_is_pseudo_column && *i <= 0 {
-                                return Err(ExecutorError::UnsupportedExpression(
-                                    "datatype mismatch".to_string(),
-                                ));
-                            }
-                            let rowid = *i as u64;
-                            if *i > 0 {
-                                batch_max_rowid = batch_max_rowid.max(rowid);
-                            }
-                            Some(rowid)
-                        }
-                        vibesql_types::SqlValue::Null => {
-                            // NULL rowid means auto-assign: max_seen + 1
-                            batch_max_rowid += 1;
-                            Some(batch_max_rowid)
-                        }
-                        // SQLite type affinity: try to convert numeric strings to integers
-                        vibesql_types::SqlValue::Varchar(s)
-                        | vibesql_types::SqlValue::Character(s) => {
-                            let trimmed = s.trim();
-                            if let Ok(i) = trimmed.parse::<i64>() {
-                                if resolved_columns.rowid_is_pseudo_column && i <= 0 {
-                                    return Err(ExecutorError::UnsupportedExpression(
-                                        "datatype mismatch".to_string(),
-                                    ));
-                                }
-                                let rowid = i as u64;
-                                if i > 0 {
-                                    batch_max_rowid = batch_max_rowid.max(rowid);
-                                }
-                                Some(rowid)
-                            } else {
-                                // Non-numeric string cannot be used as rowid
-                                return Err(ExecutorError::UnsupportedExpression(
-                                    "datatype mismatch".to_string(),
-                                ));
-                            }
-                        }
-                        // SQLite type affinity: convert float literals to integers if whole numbers
-                        vibesql_types::SqlValue::Float(f) => {
-                            let f64_val = *f as f64;
-                            if f64_val.fract() == 0.0
-                                && f64_val >= i64::MIN as f64
-                                && f64_val <= i64::MAX as f64
-                            {
-                                let i = f64_val as i64;
-                                if resolved_columns.rowid_is_pseudo_column && i <= 0 {
-                                    return Err(ExecutorError::UnsupportedExpression(
-                                        "datatype mismatch".to_string(),
-                                    ));
-                                }
-                                let rowid = i as u64;
-                                if i > 0 {
-                                    batch_max_rowid = batch_max_rowid.max(rowid);
-                                }
-                                Some(rowid)
-                            } else {
-                                return Err(ExecutorError::UnsupportedExpression(
-                                    "datatype mismatch".to_string(),
-                                ));
-                            }
-                        }
-                        vibesql_types::SqlValue::Real(f)
-                        | vibesql_types::SqlValue::Double(f)
-                        | vibesql_types::SqlValue::Numeric(f) => {
-                            if f.fract() == 0.0 && *f >= i64::MIN as f64 && *f <= i64::MAX as f64 {
-                                let i = *f as i64;
-                                if resolved_columns.rowid_is_pseudo_column && i <= 0 {
-                                    return Err(ExecutorError::UnsupportedExpression(
-                                        "datatype mismatch".to_string(),
-                                    ));
-                                }
-                                let rowid = i as u64;
-                                if i > 0 {
-                                    batch_max_rowid = batch_max_rowid.max(rowid);
-                                }
-                                Some(rowid)
-                            } else {
-                                return Err(ExecutorError::UnsupportedExpression(
-                                    "datatype mismatch".to_string(),
-                                ));
-                            }
-                        }
-                        _ => {
-                            return Err(ExecutorError::UnsupportedExpression(
-                                "datatype mismatch".to_string(),
-                            ));
-                        }
+                        rowid
+                    }
+                    RowidAffinity::Auto => {
+                        batch_max_rowid += 1;
+                        batch_max_rowid
                     }
                 }
-                vibesql_ast::Expression::Default => {
-                    // DEFAULT means auto-assign, like NULL
-                    batch_max_rowid += 1;
-                    Some(batch_max_rowid)
+            };
+
+            match rowid_expr {
+                // Literal value: apply rowid (INTEGER) affinity directly.
+                vibesql_ast::Expression::Literal(val) => {
+                    Some(apply_affinity(coerce_rowid_affinity(val)?))
                 }
+                // DEFAULT means auto-assign, like NULL.
+                vibesql_ast::Expression::Default => Some(apply_affinity(RowidAffinity::Auto)),
+                // Negative numeric literal (parsed as unary minus over a literal):
+                // negate, then apply rowid affinity. This handles -42 (integer)
+                // AND -42.0 (real) uniformly (triggerC-4.1.4).
                 vibesql_ast::Expression::UnaryOp {
                     op: vibesql_ast::UnaryOperator::Minus,
                     expr,
-                } => {
-                    // Handle negative integers (parsed as unary minus)
-                    match expr.as_ref() {
-                        vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(i)) => {
-                            let neg_val = -(*i);
-                            if resolved_columns.rowid_is_pseudo_column && neg_val <= 0 {
-                                return Err(ExecutorError::UnsupportedExpression(
-                                    "datatype mismatch".to_string(),
-                                ));
-                            }
-                            // Note: negative rowid as u64 wraps, but SQLite allows this for IPK
-                            Some(neg_val as u64)
+                } if matches!(expr.as_ref(), vibesql_ast::Expression::Literal(_)) => {
+                    let vibesql_ast::Expression::Literal(inner) = expr.as_ref() else {
+                        unreachable!("guarded by matches! above")
+                    };
+                    let negated = match inner {
+                        vibesql_types::SqlValue::Integer(i) => vibesql_types::SqlValue::Integer(-*i),
+                        vibesql_types::SqlValue::Bigint(i) => vibesql_types::SqlValue::Bigint(-*i),
+                        vibesql_types::SqlValue::Smallint(i) => {
+                            vibesql_types::SqlValue::Smallint(-*i)
                         }
-                        vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Bigint(i)) => {
-                            let neg_val = -(*i);
-                            if resolved_columns.rowid_is_pseudo_column && neg_val <= 0 {
-                                return Err(ExecutorError::UnsupportedExpression(
-                                    "datatype mismatch".to_string(),
-                                ));
-                            }
-                            Some(neg_val as u64)
-                        }
+                        vibesql_types::SqlValue::Float(f) => vibesql_types::SqlValue::Float(-*f),
+                        vibesql_types::SqlValue::Real(f) => vibesql_types::SqlValue::Real(-*f),
+                        vibesql_types::SqlValue::Double(f) => vibesql_types::SqlValue::Double(-*f),
+                        vibesql_types::SqlValue::Numeric(f) => vibesql_types::SqlValue::Numeric(-*f),
                         _ => {
                             return Err(ExecutorError::UnsupportedExpression(
                                 "datatype mismatch".to_string(),
                             ));
                         }
-                    }
+                    };
+                    Some(apply_affinity(coerce_rowid_affinity(&negated)?))
                 }
                 _ => {
                     // For complex expressions (CASE, functions, subqueries, trigger
@@ -591,42 +567,9 @@ fn execute_insert_internal(
                     }
                     let val = evaluator.eval(rowid_expr, &dummy_row)?;
 
-                    match val {
-                        vibesql_types::SqlValue::Integer(i) => {
-                            if resolved_columns.rowid_is_pseudo_column && i <= 0 {
-                                return Err(ExecutorError::UnsupportedExpression(
-                                    "datatype mismatch".to_string(),
-                                ));
-                            }
-                            let rowid = i as u64;
-                            if i > 0 {
-                                batch_max_rowid = batch_max_rowid.max(rowid);
-                            }
-                            Some(rowid)
-                        }
-                        vibesql_types::SqlValue::Bigint(i) => {
-                            if resolved_columns.rowid_is_pseudo_column && i <= 0 {
-                                return Err(ExecutorError::UnsupportedExpression(
-                                    "datatype mismatch".to_string(),
-                                ));
-                            }
-                            let rowid = i as u64;
-                            if i > 0 {
-                                batch_max_rowid = batch_max_rowid.max(rowid);
-                            }
-                            Some(rowid)
-                        }
-                        vibesql_types::SqlValue::Null => {
-                            // NULL rowid means auto-assign: max_seen + 1
-                            batch_max_rowid += 1;
-                            Some(batch_max_rowid)
-                        }
-                        _ => {
-                            return Err(ExecutorError::UnsupportedExpression(
-                                "datatype mismatch".to_string(),
-                            ));
-                        }
-                    }
+                    // Apply rowid (INTEGER) affinity to the evaluated value,
+                    // matching the literal path (triggerC-4.1.x).
+                    Some(apply_affinity(coerce_rowid_affinity(&val)?))
                 }
             }
         } else {

--- a/crates/vibesql-executor/tests/insert_rowid_affinity_tests.rs
+++ b/crates/vibesql-executor/tests/insert_rowid_affinity_tests.rs
@@ -1,0 +1,178 @@
+//! Regression tests for issue #5520: rowid (INTEGER) affinity coercion on INSERT.
+//!
+//! SQLite applies INTEGER affinity to the value supplied for a rowid /
+//! INTEGER PRIMARY KEY position before storing it (and before triggers observe
+//! `NEW.rowid`):
+//!   - a TEXT value that is losslessly an integer (e.g. `'45'`) is coerced,
+//!   - a REAL value that is losslessly an integer (e.g. `45.0`, `-42.0`) is
+//!     coerced to the integer rowid,
+//!   - a value with a fractional part (e.g. `42.4`) or a non-numeric TEXT/BLOB
+//!     raises `datatype mismatch`.
+//!
+//! Before #5520, VibeSQL handled positive REAL/TEXT rowid *literals*, but the
+//! unary-minus path (e.g. `-42.0`) only handled integers, so the residual
+//! triggerC-4.1.4 case
+//! (`INSERT INTO t4(rowid,a,b,c) VALUES(-42.0, -42.0, -42.0, -42.0)`) failed
+//! with `datatype mismatch`. This file pins the affinity behavior to match
+//! sqlite3 3.51.0.
+
+use vibesql_executor::{InsertExecutor, SelectExecutor, TriggerExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn exec(db: &mut Database, sql: &str) -> Result<(), vibesql_executor::ExecutorError> {
+    match Parser::parse_sql(sql).expect("test SQL should parse") {
+        vibesql_ast::Statement::CreateTable(s) => {
+            vibesql_executor::CreateTableExecutor::execute(&s, db)?;
+        }
+        vibesql_ast::Statement::CreateTrigger(s) => {
+            TriggerExecutor::create_trigger_with_sql(db, &s, Some(sql))?;
+        }
+        vibesql_ast::Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s)?;
+        }
+        other => panic!("unexpected statement in test: {other:?}"),
+    }
+    Ok(())
+}
+
+/// Run a SELECT, returning rows as Vec<Vec<SqlValue>>.
+fn query(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    match Parser::parse_sql(sql).expect("select should parse") {
+        vibesql_ast::Statement::Select(s) => SelectExecutor::new(db)
+            .execute(&s)
+            .expect("select should succeed")
+            .into_iter()
+            .map(|r| r.values.to_vec())
+            .collect(),
+        _ => panic!("expected SELECT"),
+    }
+}
+
+/// Fetch the rowid (as i64) + typeof(rowid) for the single row of `t`, via a
+/// LIVE SELECT. The rowid is stored as a u64 and surfaced by VibeSQL as
+/// `Bigint`; reinterpret it as i64 so negative rowids round-trip (matching how
+/// `NEW.rowid` is resolved and how sqlite3 reports them).
+fn rowid_and_type(db: &Database, table: &str) -> (i64, SqlValue) {
+    let rows = query(db, &format!("SELECT rowid, typeof(rowid) FROM {table}"));
+    assert_eq!(rows.len(), 1, "expected exactly one row in {table}");
+    let rowid = match &rows[0][0] {
+        SqlValue::Integer(i) => *i,
+        SqlValue::Bigint(i) => *i,
+        other => panic!("rowid not an integer type: {other:?}"),
+    };
+    (rowid, rows[0][1].clone())
+}
+
+/// `INSERT INTO t(rowid, ...) VALUES('45', ...)` — a TEXT-integer rowid is
+/// coerced to an INTEGER rowid (matches sqlite3 3.51.0).
+#[test]
+fn text_integer_rowid_coerced_to_integer() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(a TEXT)").unwrap();
+    exec(&mut db, "INSERT INTO t(rowid, a) VALUES('45', 'x')").unwrap();
+
+    let (rowid, ty) = rowid_and_type(&db, "t");
+    assert_eq!(rowid, 45);
+    assert_eq!(ty, SqlValue::Varchar("integer".into()));
+}
+
+/// `INSERT INTO t(rowid, ...) VALUES(45.0, ...)` — a positive REAL-integer
+/// rowid is coerced to an INTEGER rowid.
+#[test]
+fn positive_real_integer_rowid_coerced_to_integer() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(a TEXT)").unwrap();
+    exec(&mut db, "INSERT INTO t(rowid, a) VALUES(45.0, 'x')").unwrap();
+
+    let (rowid, ty) = rowid_and_type(&db, "t");
+    assert_eq!(rowid, 45);
+    assert_eq!(ty, SqlValue::Varchar("integer".into()));
+}
+
+/// `INSERT INTO t(rowid, ...) VALUES(-42.0, ...)` — the triggerC-4.1.4 case: a
+/// NEGATIVE REAL-integer rowid (parsed as unary minus over a real literal) is
+/// coerced to an INTEGER rowid. Before #5520 this raised `datatype mismatch`.
+#[test]
+fn negative_real_integer_rowid_coerced_to_integer() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(a TEXT)").unwrap();
+    exec(&mut db, "INSERT INTO t(rowid, a) VALUES(-42.0, 'x')").unwrap();
+
+    let (rowid, ty) = rowid_and_type(&db, "t");
+    assert_eq!(rowid, -42);
+    assert_eq!(ty, SqlValue::Varchar("integer".into()));
+}
+
+/// A NEGATIVE INTEGER rowid is still accepted for an explicit rowid INSERT.
+#[test]
+fn negative_integer_rowid_accepted() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(a TEXT)").unwrap();
+    exec(&mut db, "INSERT INTO t(rowid, a) VALUES(-7, 'x')").unwrap();
+
+    let (rowid, ty) = rowid_and_type(&db, "t");
+    assert_eq!(rowid, -7);
+    assert_eq!(ty, SqlValue::Varchar("integer".into()));
+}
+
+/// A REAL rowid with a fractional part cannot be a rowid: `datatype mismatch`
+/// (matches sqlite3 3.51.0), for both positive and negative.
+#[test]
+fn fractional_real_rowid_raises_datatype_mismatch() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(a TEXT)").unwrap();
+
+    let pos = exec(&mut db, "INSERT INTO t(rowid, a) VALUES(42.4, 'x')");
+    assert!(pos.is_err(), "fractional rowid should be rejected");
+    assert!(format!("{:?}", pos.unwrap_err()).contains("datatype mismatch"));
+
+    let neg = exec(&mut db, "INSERT INTO t(rowid, a) VALUES(-42.4, 'x')");
+    assert!(neg.is_err(), "fractional negative rowid should be rejected");
+    assert!(format!("{:?}", neg.unwrap_err()).contains("datatype mismatch"));
+}
+
+/// A non-numeric TEXT rowid raises `datatype mismatch`.
+#[test]
+fn non_numeric_text_rowid_raises_datatype_mismatch() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(a TEXT)").unwrap();
+
+    let res = exec(&mut db, "INSERT INTO t(rowid, a) VALUES('abc', 'x')");
+    assert!(res.is_err(), "non-numeric text rowid should be rejected");
+    assert!(format!("{:?}", res.unwrap_err()).contains("datatype mismatch"));
+}
+
+/// triggerC-4.1.4 (rowid slice): an AFTER INSERT trigger reading `new.rowid`
+/// (and `typeof(new.rowid)`) observes the coerced INTEGER rowid, and an INTEGER
+/// column reading `new.b` observes the coerced integer — for the exact
+/// triggerC-4.1.4 statement
+/// `INSERT INTO t4(rowid,a,b,c) VALUES(-42.0, -42.0, -42.0, -42.0)`.
+///
+/// Note: the TEXT column `a` and REAL column `c` (real → text formatting,
+/// e.g. `-42.0` vs `-42`) are a separate number-to-text affinity gap tracked
+/// outside #5520; this test pins only the rowid/INTEGER coercion that #5520
+/// closes.
+#[test]
+fn trigger_observes_coerced_rowid_for_negative_real() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE log(t TEXT)").unwrap();
+    exec(&mut db, "CREATE TABLE t4(a TEXT, b INTEGER, c REAL)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER t4ai AFTER INSERT ON t4 BEGIN \
+         INSERT INTO log VALUES(new.rowid || ' ' || typeof(new.rowid) || ' ' || \
+                                new.b     || ' ' || typeof(new.b)); \
+         END",
+    )
+    .unwrap();
+
+    // triggerC-4.1.4: VALUES(-42.0, -42.0, -42.0, -42.0)
+    exec(&mut db, "INSERT INTO t4(rowid,a,b,c) VALUES(-42.0, -42.0, -42.0, -42.0)").unwrap();
+
+    let rows = query(&db, "SELECT t FROM log");
+    assert_eq!(rows.len(), 1);
+    // sqlite3 3.51.0: new.rowid = -42 (integer), new.b = -42 (integer).
+    assert_eq!(rows[0][0], SqlValue::Varchar("-42 integer -42 integer".into()));
+}


### PR DESCRIPTION
Closes #5520

## Affinity-coercion gap
On `INSERT INTO t(rowid,...) VALUES(<value>,...)`, the rowid value extraction in `crates/vibesql-executor/src/insert/execution.rs` only fully applied INTEGER (rowid) affinity to a subset of expression shapes:

- A **negative numeric literal** (`-42.0`, parsed as `UnaryOp{Minus, Literal(Numeric(42.0))}`) hit a branch that only handled `Integer`/`Bigint` inner literals, so `-42.0` fell through to `datatype mismatch` — the residual **triggerC-4.1.4** failure flagged by the #5519 judge.
- The complex-expression (evaluator) path only accepted `Integer`/`Bigint`/`Null`, rejecting an evaluated `Numeric`/`Real`/`Varchar` rowid that sqlite3 coerces.
- Pseudo-column rowids carried a `rowid <= 0` rejection, but sqlite3 3.51.0 accepts zero and negative explicit rowids (verified directly).

## The fix
Introduced a single `coerce_rowid_affinity(value)` helper that applies SQLite's rowid INTEGER affinity to an already-evaluated `SqlValue` and routed **all** rowid expression shapes (literal, `DEFAULT`, unary-minus literal, and the evaluator path) through it:

- integers (and `Smallint`) pass through;
- a lossless-integer TEXT value is coerced (`'45'` -> `45`);
- a lossless-integer REAL value is coerced (`45.0` -> `45`, `-42.0` -> `-42`);
- a fractional REAL (`42.4`) or non-numeric TEXT/BLOB raises `datatype mismatch`;
- `NULL`/`DEFAULT` auto-assign the next rowid.

This also collapses ~170 lines of duplicated per-variant matching into the shared helper (net **+113 / -170**).

## sqlite3 3.51.0 parity (verified against `/usr/bin/sqlite3` 3.51.0)
| Input (explicit `rowid`) | sqlite3 | VibeSQL (after) |
|---|---|---|
| `'45'` (text) | `45` integer | `45` integer |
| `45.0` (real) | `45` integer | `45` integer |
| `-42.0` (real) | `-42` integer | `-42` integer |
| `-7` (int) | `-7` integer | `-7` integer |
| `42.4` / `-42.4` | datatype mismatch | datatype mismatch |
| `'abc'` | datatype mismatch | datatype mismatch |

A trigger reading `NEW.rowid` observes the coerced integer (verified via LIVE SELECT in the new tests).

## triggerC-4.1.x delta
- **Before #5520** (per issue): `triggerC-4.1.4` errored with `datatype mismatch` (the whole INSERT failed; `-42.0` rowid rejected).
- **After**: the INSERT succeeds; `NEW.rowid = -42 integer` and the INTEGER column `NEW.b = -42 integer` are coerced correctly. `triggerC` overall: **66 -> 76 passing** (+10).
- `triggerC-4.1.4` is now blocked only by an **orthogonal** number->text formatting gap: TEXT-affinity column `a` shows `-42` where sqlite3 shows `-42.0` (Rust `f64::to_string()` drops the `.0`). `4.1.8/4.1.9` are blocked by `UPDATE SET rowid` (#5517). These are out of scope for the rowid-affinity gap this issue tracks (see follow-on).

## No regression
- `cargo test -p vibesql-executor`: **4379 passed, 0 failed** (108 test binaries).
- New `crates/vibesql-executor/tests/insert_rowid_affinity_tests.rs`: 7 tests, all green (text/positive-real/negative-real/negative-int coercion; fractional + non-numeric -> datatype mismatch; trigger `NEW.rowid` observation).

## Follow-ons
- Number->text affinity formatting: a whole REAL stored in a TEXT-affinity column should render `-42.0`, not `-42` (fully unblocks triggerC-4.1.4/4.1.5).
- `UPDATE SET rowid` (triggerC-4.1.8/4.1.9) — coordinated with #5517.
- BEFORE-INSERT `NEW.rowid == -1` before auto-assignment (triggerC-4.1.5).

## Test plan
- [x] `cargo test -p vibesql-executor` green (no regressions)
- [x] New rowid-affinity regression tests green
- [x] sqlite3 3.51.0 parity verified for text/real -> int coercion + datatype-mismatch cases
- [x] triggerC delta measured (66 -> 76)

🤖 Generated with [Claude Code](https://claude.com/claude-code)