### PR TITLE
feat(storage): schema-aware index manager — same-named indexes coexist across schemas (#5540)

### DIFF
--- a/crates/vibesql-executor/src/drop_table.rs
+++ b/crates/vibesql-executor/src/drop_table.rs
@@ -74,10 +74,15 @@ impl DropTableExecutor {
         let dropped_indexes = database.catalog.drop_table_indexes(&stmt.table_name);
         let index_count = dropped_indexes.len();
 
-        // Drop physical indexes from storage
+        // Drop physical indexes from storage. Use the schema-qualified name so a
+        // temp-table index and a same-named main-table index are dropped
+        // independently — the storage index manager is schema-aware (#5540), and
+        // a bare name would resolve temp-shadows-main and could drop the wrong
+        // one.
         for index in &dropped_indexes {
+            let qualified = format!("{}.{}", index.schema(), index.name);
             // Try to drop from B-tree storage (ignore errors if not found)
-            let _ = database.drop_index(&index.name);
+            let _ = database.drop_index(&qualified);
             // Try to drop from spatial storage (ignore errors if not found)
             let _ = database.drop_spatial_index(&index.name);
         }

--- a/crates/vibesql-executor/src/index_ddl/drop_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/drop_index.rs
@@ -22,30 +22,45 @@ impl DropIndexExecutor {
     pub fn execute(stmt: &DropIndexStmt, database: &mut Database) -> Result<String, ExecutorError> {
         let index_name = &stmt.index_name;
 
-        // First check catalog metadata to find which table this index belongs to
+        // Find which table/schema this index belongs to. With schema-aware
+        // indexes (#5540 storage / #5513 catalog) a temp index and a main index
+        // can share a name; an unqualified `DROP INDEX` resolves temp-shadows-
+        // main, so prefer a temp-schema index over a same-named main index —
+        // matching sqlite3.
         let all_indexes = database.catalog.list_all_indexes();
-        let index_metadata = all_indexes.iter().find(|idx| idx.name == *index_name);
+        let index_metadata = all_indexes
+            .iter()
+            .find(|idx| {
+                idx.name == *index_name
+                    && vibesql_catalog::Catalog::is_temp_schema(idx.schema())
+            })
+            .or_else(|| all_indexes.iter().find(|idx| idx.name == *index_name));
 
         if let Some(metadata) = index_metadata {
-            let table_name = metadata.table_name.clone();
+            // Target the resolved index exactly via its owning schema so a temp
+            // index and a same-named main index are dropped independently.
+            let schema = metadata.schema().to_string();
+            let qualified_table = format!("{}.{}", schema, metadata.table_name);
+            let qualified_index = format!("{}.{}", schema, index_name);
 
             // Emit WAL entry for persistence BEFORE dropping
             database.emit_wal_drop_index(index_name_to_id(index_name), index_name);
 
-            // Drop from catalog
+            // Drop from catalog (schema-qualified table so the exact index goes)
             database
                 .catalog
-                .drop_index(&table_name, index_name)
+                .drop_index(&qualified_table, index_name)
                 .map_err(|e| ExecutorError::Other(format!("Catalog error: {}", e)))?;
 
-            // Check if it's a spatial index in storage
+            // Check if it's a spatial index in storage (spatial indexes are not
+            // yet schema-aware, so use the bare name)
             if database.spatial_index_exists(index_name) {
                 database.drop_spatial_index(index_name)?;
             }
 
-            // Check if it's a B-tree index in storage
-            if database.index_exists(index_name) {
-                database.drop_index(index_name)?;
+            // Check if it's a B-tree index in storage (schema-qualified)
+            if database.index_exists(&qualified_index) {
+                database.drop_index(&qualified_index)?;
             }
 
             return Ok(format!("Index '{}' dropped successfully", index_name));

--- a/crates/vibesql-executor/src/index_ddl/validation.rs
+++ b/crates/vibesql-executor/src/index_ddl/validation.rs
@@ -98,8 +98,9 @@ pub fn validate_create_index(
     // Validate prefix length specifications
     validate_prefix_lengths(&stmt.columns, &table_schema)?;
 
-    // Check if index already exists
-    check_index_exists(stmt, database)?;
+    // Check if index already exists (scoped to the target schema — #5540: a
+    // temp index and a main index can share a name, so existence is per-schema).
+    check_index_exists(stmt, database, &schema_name)?;
 
     // Check SQLite namespace (tables and indexes share namespace)
     check_namespace_collision(&stmt.index_name, database)?;
@@ -233,11 +234,24 @@ fn validate_prefix_lengths(
     Ok(())
 }
 
-/// Check if an index with the same name already exists.
-fn check_index_exists(stmt: &CreateIndexStmt, database: &Database) -> Result<(), ExecutorError> {
+/// Check if an index with the same name already exists in the target schema.
+///
+/// Schema-aware (#5540): existence is scoped to `schema_name` (the resolved
+/// owning schema of the target table) so a `temp.i` index can be created while a
+/// `main.i` index already exists, matching SQLite. Spatial indexes remain a
+/// global namespace (they are not yet schema-aware in storage).
+fn check_index_exists(
+    stmt: &CreateIndexStmt,
+    database: &Database,
+    schema_name: &str,
+) -> Result<(), ExecutorError> {
     let index_name = &stmt.index_name;
+    // Probe the exact schema's index via a schema-qualified lookup. A
+    // main-schema index keeps a bare storage key, which the storage resolver
+    // also reaches through the `main.i` qualifier.
+    let qualified = format!("{}.{}", schema_name, index_name);
     let index_exists =
-        database.index_exists(index_name) || database.spatial_index_exists(index_name);
+        database.get_index(&qualified).is_some() || database.spatial_index_exists(index_name);
 
     if index_exists {
         if stmt.if_not_exists {
@@ -268,9 +282,25 @@ fn check_namespace_collision(index_name: &str, database: &Database) -> Result<()
 }
 
 /// Check if an index already exists (for IF NOT EXISTS handling).
+///
+/// Schema-aware (#5540): scoped to the target table's owning schema so a temp
+/// index does not short-circuit on a same-named main index (and vice versa).
 pub fn index_already_exists(stmt: &CreateIndexStmt, database: &Database) -> bool {
     let index_name = &stmt.index_name;
-    database.index_exists(index_name) || database.spatial_index_exists(index_name)
+
+    // Resolve the target table's owning schema (temp shadows main for an
+    // unqualified name; an explicit `schema.table` is honored).
+    let schema_name = if let Some((schema_part, _)) = stmt.table_name.split_once('.') {
+        schema_part.to_string()
+    } else {
+        database
+            .catalog
+            .resolve_table_schema_name(&stmt.table_name)
+            .unwrap_or_else(|| database.catalog.get_current_schema().to_string())
+    };
+
+    let qualified = format!("{}.{}", schema_name, index_name);
+    database.get_index(&qualified).is_some() || database.spatial_index_exists(index_name)
 }
 
 /// Validate that all column references in an expression exist in the table schema.

--- a/crates/vibesql-executor/tests/sqlite_temp_master_tests.rs
+++ b/crates/vibesql-executor/tests/sqlite_temp_master_tests.rs
@@ -13,7 +13,7 @@
 //! ```
 
 use vibesql_executor::{
-    CreateIndexExecutor, CreateTableExecutor, DropTableExecutor, SelectExecutor,
+    CreateIndexExecutor, CreateTableExecutor, DropIndexExecutor, DropTableExecutor, SelectExecutor,
 };
 use vibesql_parser::Parser;
 use vibesql_storage::{Database, Row};
@@ -37,6 +37,27 @@ fn exec_create_index(db: &mut Database, sql: &str) {
         }
         other => panic!("expected CREATE INDEX, got {other:?}"),
     };
+}
+
+fn exec_drop_index(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse DROP INDEX");
+    match stmt {
+        vibesql_ast::Statement::DropIndex(s) => {
+            DropIndexExecutor::execute(&s, db).expect("DROP INDEX")
+        }
+        other => panic!("expected DROP INDEX, got {other:?}"),
+    };
+}
+
+/// Execute an INSERT statement.
+fn exec_insert(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse INSERT");
+    match stmt {
+        vibesql_ast::Statement::Insert(s) => {
+            vibesql_executor::InsertExecutor::execute(db, &s).expect("INSERT");
+        }
+        other => panic!("expected INSERT, got {other:?}"),
+    }
 }
 
 fn exec_drop_table(db: &mut Database, sql: &str) {
@@ -111,32 +132,86 @@ fn main_index_in_master_not_temp_master() {
     assert!(!names(&temp).contains(&"mi".to_string()), "main index must NOT be in sqlite_temp_master");
 }
 
-/// Catalog-level `main.i` / `temp.i` coexistence (same name, even same table)
-/// is proven in `vibesql-catalog`'s `test_temp_and_main_index_coexist`.
+/// Count the rows of a single-column COUNT(*) result.
+fn scalar_i64(db: &Database, sql: &str) -> i64 {
+    let (_, rows) = select(db, sql);
+    assert_eq!(rows.len(), 1, "expected one result row for {sql}");
+    match &rows[0].values[0] {
+        SqlValue::Integer(n) => *n,
+        SqlValue::Bigint(n) => *n,
+        other => panic!("expected integer scalar, got {other:?}"),
+    }
+}
+
+/// #5540 (was #5513's documented SQL-level limitation): a temp-schema index and
+/// a main-schema index can share a bare name at the SQL level, because the
+/// storage index manager is now schema-aware. Both must coexist, both must be
+/// usable, and an unqualified DROP INDEX must resolve temp-shadows-main —
+/// matching sqlite3 3.51.0:
 ///
-/// At the SQL layer it is not yet reachable because the **storage** index
-/// manager keys indexes by bare name (a global namespace), so a second
-/// `CREATE INDEX i ...` is rejected before the catalog is consulted. Tracked as
-/// a follow-on (storage index-manager schema-tagging). This test documents the
-/// current SQL-level behaviour so the follow-on has a clear before/after.
+/// ```sql
+/// CREATE TABLE main_t(a); CREATE TEMP TABLE temp_t(a);
+/// CREATE INDEX ix ON main_t(a);  -- main.ix
+/// CREATE INDEX ix ON temp_t(a);  -- temp.ix  (succeeds in sqlite3)
+/// ```
 #[test]
-fn sql_level_same_name_index_across_schemas_currently_rejected() {
+fn sql_level_same_name_index_across_schemas_coexist() {
     let mut db = Database::new();
-    exec_create_table(&mut db, "CREATE TABLE base (a)");
-    exec_create_table(&mut db, "CREATE TEMP TABLE t (a)");
+    exec_create_table(&mut db, "CREATE TABLE main_t (a)");
+    exec_create_table(&mut db, "CREATE TEMP TABLE temp_t (a)");
 
-    exec_create_index(&mut db, "CREATE INDEX i ON base(a)"); // main.i on base
+    // Distinct data so a live SELECT through each index is observable.
+    exec_insert(&mut db, "INSERT INTO main_t VALUES (1)");
+    exec_insert(&mut db, "INSERT INTO main_t VALUES (2)");
+    exec_insert(&mut db, "INSERT INTO temp.temp_t VALUES (10)");
 
-    // Second index of the same name (on the temp table) is rejected today by
-    // the storage-layer name namespace.
-    let stmt = Parser::parse_sql("CREATE INDEX i ON t(a)").unwrap();
-    let result = match stmt {
-        vibesql_ast::Statement::CreateIndex(s) => CreateIndexExecutor::execute(&s, &mut db),
-        other => panic!("expected CREATE INDEX, got {other:?}"),
-    };
+    // main.ix and temp.ix share the bare name `ix` — both CREATE INDEX succeed.
+    exec_create_index(&mut db, "CREATE INDEX ix ON main_t(a)");
+    exec_create_index(&mut db, "CREATE INDEX ix ON temp_t(a)");
+
+    // Both indexes are registered in their respective schemas' master tables.
+    let (_, master) = select(&db, "SELECT name FROM sqlite_master WHERE type='index'");
+    assert!(names(&master).contains(&"ix".to_string()), "main.ix must be in sqlite_master");
+    let (_, temp_master) =
+        select(&db, "SELECT name FROM sqlite_temp_master WHERE type='index'");
     assert!(
-        result.is_err(),
-        "documents current SQL-level limitation; see storage schema-tagging follow-on"
+        names(&temp_master).contains(&"ix".to_string()),
+        "temp.ix must be in sqlite_temp_master"
+    );
+
+    // Both indexes are usable: a live SELECT through each returns the right rows.
+    assert_eq!(scalar_i64(&db, "SELECT count(*) FROM main_t WHERE a = 1"), 1);
+    assert_eq!(scalar_i64(&db, "SELECT count(*) FROM main_t WHERE a = 2"), 1);
+    assert_eq!(scalar_i64(&db, "SELECT count(*) FROM temp.temp_t WHERE a = 10"), 1);
+    // The temp index does not leak the main table's values, and vice versa.
+    assert_eq!(scalar_i64(&db, "SELECT count(*) FROM temp.temp_t WHERE a = 1"), 0);
+    assert_eq!(scalar_i64(&db, "SELECT count(*) FROM main_t WHERE a = 10"), 0);
+
+    // Unqualified DROP INDEX resolves temp-shadows-main: it drops temp.ix and
+    // leaves main.ix intact (matching sqlite3's name resolution).
+    exec_drop_index(&mut db, "DROP INDEX ix");
+
+    let (_, temp_after) =
+        select(&db, "SELECT name FROM sqlite_temp_master WHERE type='index'");
+    assert!(
+        !names(&temp_after).contains(&"ix".to_string()),
+        "unqualified DROP INDEX must remove the temp index first"
+    );
+    let (_, master_after) = select(&db, "SELECT name FROM sqlite_master WHERE type='index'");
+    assert!(
+        names(&master_after).contains(&"ix".to_string()),
+        "main.ix must survive an unqualified DROP INDEX that resolved to temp.ix"
+    );
+
+    // The surviving main index still works.
+    assert_eq!(scalar_i64(&db, "SELECT count(*) FROM main_t WHERE a = 2"), 1);
+
+    // A second unqualified DROP INDEX now removes main.ix.
+    exec_drop_index(&mut db, "DROP INDEX ix");
+    let (_, master_final) = select(&db, "SELECT name FROM sqlite_master WHERE type='index'");
+    assert!(
+        !names(&master_final).contains(&"ix".to_string()),
+        "the second DROP INDEX removes the remaining main index"
     );
 }
 

--- a/crates/vibesql-storage/src/database/indexes/index_maintenance/create.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance/create.rs
@@ -12,7 +12,10 @@ use crate::{
     database::indexes::{
         hnsw::HnswIndex,
         index_manager::IndexManager,
-        index_metadata::{normalize_index_name, IndexData, IndexMetadata, DISK_BACKED_THRESHOLD},
+        index_metadata::{
+            make_index_key, normalize_index_name, IndexData, IndexMetadata, DEFAULT_INDEX_SCHEMA,
+            DISK_BACKED_THRESHOLD,
+        },
         ivfflat::IVFFlatIndex,
     },
     page::PageManager,
@@ -34,6 +37,7 @@ impl IndexManager {
         &mut self,
         index_name: String,
         table_name: String,
+        schema: &str,
         table_schema: &vibesql_catalog::TableSchema,
         table_rows: &[Row],
         unique: bool,
@@ -41,10 +45,12 @@ impl IndexManager {
         where_clause: Option<Box<vibesql_ast::Expression>>,
         included_row_indices: Option<&std::collections::HashSet<usize>>,
     ) -> Result<(), StorageError> {
-        // Normalize index name for case-insensitive comparison
-        let normalized_name = normalize_index_name(&index_name);
+        // Schema-qualified storage key (#5540): a temp index and a main index can
+        // share a bare name; only the owning schema disambiguates them. A
+        // main-schema index keeps a bare key for backward compatibility.
+        let normalized_name = make_index_key(schema, &index_name);
 
-        // Check if index already exists
+        // Check if index already exists (per-schema namespace)
         if self.indexes.contains_key(&normalized_name) {
             return Err(StorageError::IndexAlreadyExists(index_name));
         }
@@ -61,10 +67,11 @@ impl IndexManager {
             column_indices.push(column_idx);
         }
 
-        // Store index metadata (use normalized name as key)
+        // Store index metadata (keyed by the schema-qualified storage key)
         let metadata = IndexMetadata {
             index_name: index_name.clone(),
             table_name: table_name.clone(),
+            schema: schema.to_string(),
             unique,
             columns: columns.clone(),
             where_clause,
@@ -245,6 +252,7 @@ impl IndexManager {
         &mut self,
         index_name: String,
         table_name: String,
+        schema: &str,
         _table_schema: &vibesql_catalog::TableSchema,
         unique: bool,
         columns: Vec<vibesql_ast::IndexColumn>,
@@ -252,15 +260,15 @@ impl IndexManager {
     ) -> Result<(), StorageError> {
         use std::collections::BTreeMap;
 
-        // Normalize index name for case-insensitive comparison
-        let normalized_name = normalize_index_name(&index_name);
+        // Schema-qualified storage key (#5540).
+        let normalized_name = make_index_key(schema, &index_name);
 
-        // Check if index already exists
+        // Check if index already exists (per-schema namespace)
         if self.indexes.contains_key(&normalized_name) {
             return Err(StorageError::IndexAlreadyExists(index_name));
         }
 
-        // Store index metadata (use normalized name as key)
+        // Store index metadata (keyed by the schema-qualified storage key)
         // Expression indexes do not currently use partial-index semantics; the
         // caller is responsible for filtering rows via `create_index_with_keys`'s
         // `keys` parameter (so passing only matching rows is the equivalent of
@@ -268,6 +276,7 @@ impl IndexManager {
         let metadata = IndexMetadata {
             index_name: index_name.clone(),
             table_name: table_name.clone(),
+            schema: schema.to_string(),
             unique,
             columns: columns.clone(),
             where_clause: None,
@@ -383,6 +392,7 @@ impl IndexManager {
         let metadata = IndexMetadata {
             index_name: index_name.clone(),
             table_name: table_name.clone(),
+            schema: DEFAULT_INDEX_SCHEMA.to_string(),
             unique: false, // IVFFlat indexes are never unique
             columns: vec![vibesql_ast::IndexColumn::Column {
                 column_name,
@@ -454,6 +464,7 @@ impl IndexManager {
         let metadata = IndexMetadata {
             index_name: index_name.clone(),
             table_name: table_name.clone(),
+            schema: DEFAULT_INDEX_SCHEMA.to_string(),
             unique: false, // IVFFlat indexes are never unique
             columns: vec![vibesql_ast::IndexColumn::Column {
                 column_name,
@@ -653,6 +664,7 @@ impl IndexManager {
         let metadata = IndexMetadata {
             index_name: index_name.clone(),
             table_name: table_name.clone(),
+            schema: DEFAULT_INDEX_SCHEMA.to_string(),
             unique: false, // HNSW indexes are never unique
             columns: vec![vibesql_ast::IndexColumn::Column {
                 column_name,
@@ -773,10 +785,15 @@ impl IndexManager {
     // Drop Index Operations
     // ============================================================================
 
-    /// Drop an index
+    /// Drop an index.
+    ///
+    /// `index_name` may be a bare name (resolved temp-shadows-main, #5540) or an
+    /// explicit `schema.index` qualifier for exact targeting.
     pub fn drop_index(&mut self, index_name: &str) -> Result<(), StorageError> {
-        // Normalize index name for case-insensitive comparison
-        let normalized = normalize_index_name(index_name);
+        // Resolve the schema-qualified storage key (temp shadows main).
+        let normalized = self
+            .resolve_index_key(index_name)
+            .ok_or_else(|| StorageError::IndexNotFound(index_name.to_string()))?;
 
         if self.indexes.remove(&normalized).is_none() {
             return Err(StorageError::IndexNotFound(index_name.to_string()));

--- a/crates/vibesql-storage/src/database/indexes/index_manager.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_manager.rs
@@ -6,7 +6,9 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use vibesql_types::{DataType, SqlValue};
 
-use super::index_metadata::{acquire_btree_lock, normalize_index_name, IndexData, IndexMetadata};
+use super::index_metadata::{
+    acquire_btree_lock, normalize_index_name, IndexData, IndexMetadata, DEFAULT_INDEX_SCHEMA,
+};
 #[cfg(target_arch = "wasm32")]
 use crate::backend::MemoryStorage;
 #[cfg(not(target_arch = "wasm32"))]
@@ -259,10 +261,50 @@ impl IndexManager {
         }
     }
 
+    /// Resolve a (possibly bare) index name to the actual map key it is stored
+    /// under, following SQLite name resolution.
+    ///
+    /// Schema-awareness (#5540): a `main`-schema index is keyed by its bare
+    /// normalized name; a temp-schema index is keyed `temp_<id>.<name>`. For an
+    /// unqualified lookup the session temp schema shadows `main`, so we prefer a
+    /// matching temp-schema index over a same-named main index — matching
+    /// `DROP INDEX i` resolving to `temp.i` when both exist.
+    ///
+    /// Accepts an explicit `schema.index` form too (used by DROP TABLE / DROP
+    /// INDEX paths that already know the owning schema) for exact targeting.
+    /// Returns the storage key if a matching index exists.
+    pub(super) fn resolve_index_key(&self, index_name: &str) -> Option<String> {
+        // Explicit schema-qualified form: target exactly that schema's index.
+        if let Some((schema_part, name_part)) = index_name.split_once('.') {
+            let key = super::index_metadata::make_index_key(schema_part, name_part);
+            if self.indexes.contains_key(&key) {
+                return Some(key);
+            }
+            // Fall through: maybe the caller passed a dotted *index name* (rare)
+            // rather than a schema qualifier; try the whole thing as a bare name.
+        }
+
+        let normalized = normalize_index_name(index_name);
+
+        // Temp schema shadows main: prefer a non-main-schema index with this name.
+        if let Some((key, _)) = self.indexes.iter().find(|(_, meta)| {
+            !meta.schema.eq_ignore_ascii_case(DEFAULT_INDEX_SCHEMA)
+                && normalize_index_name(&meta.index_name) == normalized
+        }) {
+            return Some(key.clone());
+        }
+
+        // Otherwise the main-schema (bare) key.
+        if self.indexes.contains_key(&normalized) {
+            return Some(normalized);
+        }
+
+        None
+    }
+
     /// Check if an index exists
     pub fn index_exists(&self, index_name: &str) -> bool {
-        let normalized = normalize_index_name(index_name);
-        self.indexes.contains_key(&normalized)
+        self.resolve_index_key(index_name).is_some()
     }
 
     /// Check if any indexes exist for a specific table
@@ -283,18 +325,18 @@ impl IndexManager {
 
     /// Get index metadata
     pub fn get_index(&self, index_name: &str) -> Option<&IndexMetadata> {
-        let normalized = normalize_index_name(index_name);
-        self.indexes.get(&normalized)
+        let key = self.resolve_index_key(index_name)?;
+        self.indexes.get(&key)
     }
 
     /// Get index data
     pub fn get_index_data(&self, index_name: &str) -> Option<&IndexData> {
-        let normalized = normalize_index_name(index_name);
+        let key = self.resolve_index_key(index_name)?;
 
         // Record access for LRU tracking (uses interior mutability)
-        self.resource_tracker.record_access(&normalized);
+        self.resource_tracker.record_access(&key);
 
-        self.index_data.get(&normalized)
+        self.index_data.get(&key)
     }
 
     /// Check unique constraints for user-defined indexes before insert
@@ -413,8 +455,10 @@ impl IndexManager {
         index_name: &str,
         where_clause: Option<Box<vibesql_ast::Expression>>,
     ) -> bool {
-        let normalized = super::index_metadata::normalize_index_name(index_name);
-        if let Some(meta) = self.indexes.get_mut(&normalized) {
+        let Some(key) = self.resolve_index_key(index_name) else {
+            return false;
+        };
+        if let Some(meta) = self.indexes.get_mut(&key) {
             meta.where_clause = where_clause;
             true
         } else {
@@ -673,6 +717,7 @@ mod tests {
             IndexMetadata {
                 index_name: index_name.to_string(),
                 table_name: "events".to_string(),
+                schema: "main".to_string(),
                 unique: false,
                 columns: vec![vibesql_ast::IndexColumn::new_column(
                     "created_at".to_string(),
@@ -733,6 +778,7 @@ mod tests {
                 IndexMetadata {
                     index_name: index_name.to_string(),
                     table_name: "events".to_string(),
+                    schema: "main".to_string(),
                     unique: false,
                     columns: vec![vibesql_ast::IndexColumn::new_column(
                         "c".to_string(),
@@ -806,6 +852,7 @@ mod tests {
             IndexMetadata {
                 index_name: index_name.to_string(),
                 table_name: "t".to_string(),
+                schema: "main".to_string(),
                 unique: false,
                 columns: vec![vibesql_ast::IndexColumn::new_column(
                     "id".to_string(),
@@ -934,6 +981,7 @@ mod tests {
         let mk_meta = |name: &str| IndexMetadata {
             index_name: name.to_string(),
             table_name: "t".to_string(),
+            schema: "main".to_string(),
             unique: false,
             columns: vec![vibesql_ast::IndexColumn::new_column(
                 "id".to_string(),

--- a/crates/vibesql-storage/src/database/indexes/index_metadata.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_metadata.rs
@@ -20,6 +20,38 @@ pub(super) fn normalize_index_name(name: &str) -> String {
     name.to_lowercase()
 }
 
+/// Default owning schema for a storage-side index.
+///
+/// Mirrors `vibesql_catalog::DEFAULT_SCHEMA`. Indexes created through paths
+/// that don't (yet) thread a schema fall back to this so behaviour is unchanged
+/// for the common main-schema case.
+pub(super) const DEFAULT_INDEX_SCHEMA: &str = "main";
+
+/// Build the storage key used to key indexes in the [`IndexManager`]'s maps.
+///
+/// Making the key schema-aware (#5540) lets a temp-schema index and a
+/// main-schema index share the same bare name without colliding — matching
+/// SQLite, where `main.i` and `temp.i` are distinct objects. The catalog made
+/// the same change in #5513 (`schema.table.index`); storage keys on
+/// `schema.index` because storage never needs to disambiguate by table.
+///
+/// To keep the overwhelmingly common main-schema path byte-for-byte
+/// backward-compatible (the index file names, the resource-tracker keys, and
+/// the ~50 bare-name read-path callers all key on the index name today), a
+/// `main`-schema index keeps a *bare* key (just the normalized name). Only
+/// non-`main` schemas (session temp schemas like `temp_42`) get a
+/// `schema.index` prefix. A bare name therefore resolves to a main index by
+/// default, and a temp index is reached through the temp-prefixed key — the
+/// resolver in [`super::index_manager`] handles temp-shadows-main lookups.
+pub(super) fn make_index_key(schema: &str, index_name: &str) -> String {
+    let normalized_name = normalize_index_name(index_name);
+    if schema.eq_ignore_ascii_case(DEFAULT_INDEX_SCHEMA) {
+        normalized_name
+    } else {
+        format!("{}.{}", schema.to_lowercase(), normalized_name)
+    }
+}
+
 /// Threshold for choosing disk-backed indexes (number of table rows)
 /// Tables with more rows than this will use disk-backed B+ tree indexes
 /// Set to very high value (100K) to keep Phase 2 conservative - disk-backed
@@ -71,6 +103,11 @@ pub(super) fn acquire_btree_lock(
 pub struct IndexMetadata {
     pub index_name: String,
     pub table_name: String,
+    /// Owning schema of this index (e.g. `main` or a session temp schema like
+    /// `temp_42`). Stored so a temp-table index and a main-table index can
+    /// share a bare name without colliding in the [`IndexManager`] maps. See
+    /// issue #5540 (storage) / #5513 (catalog).
+    pub schema: String,
     pub unique: bool,
     pub columns: Vec<IndexColumn>,
     /// Optional WHERE predicate for partial indexes (CREATE INDEX ... WHERE expr).

--- a/crates/vibesql-storage/src/database/operations.rs
+++ b/crates/vibesql-storage/src/database/operations.rs
@@ -500,11 +500,21 @@ impl Operations {
         // Validate prefix lengths against column types and widths
         Self::validate_prefix_lengths(table_schema, &columns)?;
 
+        // Resolve the owning schema for the storage-side index key (#5540).
+        // `resolve_table_schema_name` follows SQLite name resolution (temp shadows
+        // main for unqualified names; explicit `schema.table` honored), matching
+        // the schema the catalog tags the index with in #5513. Falls back to the
+        // default (main) schema when the table can't be resolved.
+        let index_schema = catalog
+            .resolve_table_schema_name(&table_name)
+            .unwrap_or_else(|| vibesql_catalog::DEFAULT_SCHEMA.to_string());
+
         // Pass table rows directly by reference - avoid cloning all rows
         // This is critical for performance at scale (O(n) clone was causing major slowdown)
         self.index_manager.create_index(
             index_name,
             table_name,
+            &index_schema,
             table_schema,
             table.scan(),
             unique,
@@ -533,9 +543,15 @@ impl Operations {
             .get_table(&table_name)
             .ok_or_else(|| StorageError::TableNotFound(table_name.clone()))?;
 
+        // Resolve the owning schema for the storage-side index key (#5540).
+        let index_schema = catalog
+            .resolve_table_schema_name(&table_name)
+            .unwrap_or_else(|| vibesql_catalog::DEFAULT_SCHEMA.to_string());
+
         self.index_manager.create_index_with_keys(
             index_name,
             table_name,
+            &index_schema,
             table_schema,
             unique,
             columns,

--- a/crates/vibesql-storage/src/database/tests/indexes.rs
+++ b/crates/vibesql-storage/src/database/tests/indexes.rs
@@ -149,6 +149,7 @@ fn test_disk_backed_index_creation_with_bulk_load() {
     let result = index_manager.create_index(
         "idx_id".to_string(),
         "test_table".to_string(),
+        "main",
         &table_schema,
         &table_rows,
         false, // non-unique
@@ -192,6 +193,7 @@ fn test_in_memory_index_for_small_tables() {
     let result = index_manager.create_index(
         "idx_value".to_string(),
         "small_table".to_string(),
+        "main",
         &table_schema,
         &table_rows,
         false,
@@ -262,6 +264,7 @@ fn test_budget_enforcement_with_spill_policy() {
     let result1 = index_manager.create_index(
         "idx_1".to_string(),
         "test_table".to_string(),
+        "main",
         &table_schema,
         &table_rows,
         false,
@@ -279,6 +282,7 @@ fn test_budget_enforcement_with_spill_policy() {
     let result2 = index_manager.create_index(
         "idx_2".to_string(),
         "test_table".to_string(),
+        "main",
         &table_schema,
         &table_rows,
         false,
@@ -336,6 +340,7 @@ fn test_lru_eviction_order() {
         .create_index(
             "idx_1".to_string(),
             "test_table".to_string(),
+            "main",
             &table_schema,
             &table_rows,
             false,
@@ -356,6 +361,7 @@ fn test_lru_eviction_order() {
         .create_index(
             "idx_2".to_string(),
             "test_table".to_string(),
+            "main",
             &table_schema,
             &table_rows,
             false,
@@ -381,6 +387,7 @@ fn test_lru_eviction_order() {
         .create_index(
             "idx_3".to_string(),
             "test_table".to_string(),
+            "main",
             &table_schema,
             &table_rows,
             false,
@@ -430,6 +437,7 @@ fn test_access_tracking() {
         .create_index(
             "idx_test".to_string(),
             "test_table".to_string(),
+            "main",
             &table_schema,
             &table_rows,
             false,
@@ -488,6 +496,7 @@ fn test_resource_cleanup_on_drop() {
         .create_index(
             "idx_test".to_string(),
             "test_table".to_string(),
+            "main",
             &table_schema,
             &table_rows,
             false,


### PR DESCRIPTION
## Summary
Closes #5540

Follow-on from #5513/#5539, which made the **catalog** index registry schema-aware (keyed by `schema.table.index`) but left the **storage** index manager keying indexes by bare name in a single global namespace. As a result, `CREATE INDEX i ON main_t(...)` followed by `CREATE INDEX i ON temp_t(...)` was rejected at the SQL level even though sqlite3 allows it (main and temp are separate schemas). #5539 locked this as a known limitation (`sql_level_same_name_index_across_schemas_currently_rejected`).

## The storage-key schema-awareness change
- `vibesql-storage` `IndexMetadata` gains a `schema` field. The `IndexManager` map key becomes `schema.index` for non-`main` schemas, while a `main`-schema index keeps a **bare** key — byte-for-byte backward compatible with index file names, resource-tracker keys, and the ~50 bare-name read-path callers.
- New `IndexManager::resolve_index_key` resolves a bare-name lookup **temp-shadows-main**, so `get_index` / `get_index_data` / `index_exists` / `drop_index` / `set_index_where_clause` reach the right entry without changing every caller. It also accepts an explicit `schema.index` form for exact targeting.
- `create_index` / `create_index_with_keys` now take the owning schema, which `operations` derives via `catalog.resolve_table_schema_name` — the same schema the catalog assigns in #5513.
- CREATE INDEX validation (`check_index_exists` / `index_already_exists`) is scoped to the target schema. `DROP INDEX` (executor) and `DROP TABLE`'s index cascade target indexes by their owning schema so a temp index and a same-named main index drop independently; an unqualified `DROP INDEX` resolves temp-shadows-main.

## sqlite3 3.51.0 parity (coexistence + drop resolution)
```sql
CREATE TABLE main_t(a); CREATE TEMP TABLE temp_t(a);
CREATE INDEX ix ON main_t(a);   -- main.ix
CREATE INDEX ix ON temp_t(a);   -- temp.ix  (now succeeds, was rejected)
```
Both indexes coexist (one in `sqlite_master`, one in `sqlite_temp_master`), both are usable, and an unqualified `DROP INDEX ix` removes the temp index first, leaving `main.ix` intact — matching sqlite3.

## Updated #5539 limitation test
`crates/vibesql-executor/tests/sqlite_temp_master_tests.rs`: the documenting test `sql_level_same_name_index_across_schemas_currently_rejected` is replaced by `sql_level_same_name_index_across_schemas_coexist`, which asserts the NEW behaviour — coexistence in both master tables, both indexes usable via live `SELECT`s, no cross-schema value leakage, and correct temp-shadows-main DROP resolution (drops temp.ix, then main.ix).

## No-regression results
- `cargo test -p vibesql-storage`: 698 lib + integration/doc tests pass.
- `cargo test -p vibesql-catalog`: 48 pass (incl. #5513 `test_temp_and_main_index_coexist`, `test_drop_table_indexes_is_schema_scoped`).
- `cargo test -p vibesql-executor --lib`: 2792 pass; `index_ddl` suite (42) green incl. `test_create_index_temp_shadows_main` and the schema-qualified-table tests.
- `sqlite_temp_master_tests`: 5/5 pass.
- TCL deltas (`index*.test`, `tempdb.test`, `temptable.test`): no new failures vs. base. The only failures (`index-18.4` = reserved `sqlite_` trigger name; `tempdb-1.2/2.2/2.3` = temp-db attach semantics) are pre-existing and unrelated to index schema-awareness.
- One full-suite stack overflow in `evaluator::tests::deep_expression_tests::test_reasonable_depth_expressions` is a pre-existing thread-stack flake (passes in isolation; unrelated to this change).

## Test plan
- [ ] `cargo test -p vibesql-storage -p vibesql-catalog -p vibesql-executor`
- [ ] Verify `CREATE INDEX ix ON main_t(a); CREATE INDEX ix ON temp_t(a);` both succeed and `DROP INDEX ix` resolves temp-first

## Follow-ons
- Spatial indexes remain a global namespace in storage (not yet schema-aware); same-named spatial indexes across schemas are still a single namespace. Out of scope here (B-tree indexes only), worth a dedicated follow-on if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)