### PR TITLE
fix(executor): match sqlite3 wording for ALTER TABLE RENAME TO collision

### DIFF
--- a/crates/vibesql-executor/src/alter/table_options.rs
+++ b/crates/vibesql-executor/src/alter/table_options.rs
@@ -10,9 +10,14 @@ pub(super) fn execute_rename_table(
     stmt: &RenameTableStmt,
     database: &mut Database,
 ) -> Result<String, ExecutorError> {
-    // Check if new table name already exists
-    if database.get_table(&stmt.new_table_name).is_some() {
-        return Err(ExecutorError::TableAlreadyExists(stmt.new_table_name.clone()));
+    // Check if the new name already names a table or an index. SQLite shares a
+    // single object namespace for tables and indexes, so a RENAME TO collision
+    // against either reports the same SQLite-compatible message
+    // (`there is already another table or index with this name: <name>`).
+    if database.get_table(&stmt.new_table_name).is_some()
+        || database.index_exists(&stmt.new_table_name)
+    {
+        return Err(ExecutorError::RenameTargetExists(stmt.new_table_name.clone()));
     }
 
     // Get the old table to ensure it exists

--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -2,6 +2,10 @@
 pub enum ExecutorError {
     TableNotFound(String),
     TableAlreadyExists(String),
+    /// ALTER TABLE ... RENAME TO target collides with an existing table or
+    /// index name. SQLite reports this with a distinct message that spans both
+    /// the table and index namespaces.
+    RenameTargetExists(String),
     /// SQLite system table may not be modified (sqlite_master, sqlite_schema)
     SqliteSystemTableReadOnly {
         table_name: String,
@@ -471,6 +475,12 @@ impl std::fmt::Display for ExecutorError {
             }
             ExecutorError::TableAlreadyExists(name) => {
                 write!(f, "{}", vibe_msg!("executor-table-already-exists", name = name.as_str()))
+            }
+            ExecutorError::RenameTargetExists(name) => {
+                // SQLite-compatible error message format. SQLite 3.51.0 emits
+                // this exact string for `ALTER TABLE ... RENAME TO <name>` when
+                // <name> already names a table or an index.
+                write!(f, "there is already another table or index with this name: {}", name)
             }
             ExecutorError::SqliteSystemTableReadOnly { table_name, operation } => {
                 // SQLite-compatible error message format

--- a/crates/vibesql-executor/src/tests/alter_rename_collision.rs
+++ b/crates/vibesql-executor/src/tests/alter_rename_collision.rs
@@ -1,0 +1,79 @@
+//! Tests for `ALTER TABLE ... RENAME TO <existing>` error parity with
+//! sqlite3 3.51.0 (#5554).
+//!
+//! sqlite3 3.51.0 reports a single message spanning both the table and index
+//! namespaces when the rename target already exists:
+//!
+//! ```text
+//! sqlite> CREATE TABLE a(x); CREATE TABLE b(y);
+//! sqlite> ALTER TABLE a RENAME TO b;
+//! Error: there is already another table or index with this name: b
+//! ```
+//!
+//! Renaming onto an existing INDEX name yields the same message:
+//!
+//! ```text
+//! sqlite> CREATE TABLE a(x); CREATE INDEX idx ON a(x);
+//! sqlite> ALTER TABLE a RENAME TO idx;
+//! Error: there is already another table or index with this name: idx
+//! ```
+
+use vibesql_ast::Statement;
+use vibesql_storage::Database;
+
+use crate::errors::ExecutorError;
+
+/// Parse and execute a statement, returning the typed executor error so tests
+/// can assert both the variant and the rendered (SQLite-compatible) message.
+fn exec(db: &mut Database, sql: &str) -> Result<String, ExecutorError> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).expect("parse");
+    match stmt {
+        Statement::CreateTable(s) => crate::CreateTableExecutor::execute(&s, db),
+        Statement::CreateIndex(s) => crate::CreateIndexExecutor::execute(&s, db),
+        Statement::AlterTable(s) => crate::alter::AlterTableExecutor::execute(&s, db),
+        other => panic!("unexpected statement: {:?}", other),
+    }
+}
+
+#[test]
+fn rename_onto_existing_table_matches_sqlite_message() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE a(x)").unwrap();
+    exec(&mut db, "CREATE TABLE b(y)").unwrap();
+
+    let err = exec(&mut db, "ALTER TABLE a RENAME TO b").unwrap_err();
+    assert_eq!(err, ExecutorError::RenameTargetExists("b".to_string()));
+    assert_eq!(
+        err.to_string(),
+        "there is already another table or index with this name: b"
+    );
+
+    // The failed rename must leave the original table intact.
+    assert!(db.get_table("a").is_some(), "source table should survive a failed rename");
+}
+
+#[test]
+fn rename_onto_existing_index_matches_sqlite_message() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE a(x)").unwrap();
+    exec(&mut db, "CREATE INDEX idx ON a(x)").unwrap();
+
+    let err = exec(&mut db, "ALTER TABLE a RENAME TO idx").unwrap_err();
+    assert_eq!(err, ExecutorError::RenameTargetExists("idx".to_string()));
+    assert_eq!(
+        err.to_string(),
+        "there is already another table or index with this name: idx"
+    );
+
+    assert!(db.get_table("a").is_some(), "source table should survive a failed rename");
+}
+
+#[test]
+fn valid_rename_still_succeeds() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE a(x)").unwrap();
+
+    exec(&mut db, "ALTER TABLE a RENAME TO c").unwrap();
+    assert!(db.get_table("c").is_some(), "renamed table should exist under the new name");
+    assert!(db.get_table("a").is_none(), "old table name should no longer exist");
+}

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -64,6 +64,7 @@ mod aggregate_having_tests;
 mod aggregate_min_max_tests;
 mod aggregate_random_patterns;
 mod aggregate_without_from;
+mod alter_rename_collision;
 mod alter_table_constraints;
 mod auto_increment_tests;
 mod between_predicates;


### PR DESCRIPTION
Closes #5554

## Problem

`ALTER TABLE x RENAME TO y` where `y` already exists emitted VibeSQL's generic `Table 'y' already exists` instead of sqlite3's distinct message.

## Verified sqlite3 3.51.0 wording

```
$ sqlite3 :memory: "CREATE TABLE a(x); CREATE TABLE b(x); ALTER TABLE a RENAME TO b;"
Error: in prepare, there is already another table or index with this name: b

$ sqlite3 :memory: "CREATE TABLE a(x); CREATE INDEX idx ON a(x); ALTER TABLE a RENAME TO idx;"
Error: in prepare, there is already another table or index with this name: idx
```

sqlite3 shares a single object namespace for tables and indexes, so a rename collision against **either** reports the same message.

## Fix

- New `ExecutorError::RenameTargetExists(String)` variant rendering the exact sqlite3 string `there is already another table or index with this name: <name>` (hardcoded SQLite-compatible message, mirroring `SqliteSystemTableReadOnly`). The shared `executor-table-already-exists` l10n key — used by CREATE TABLE — is intentionally left untouched.
- `execute_rename_table` (`crates/vibesql-executor/src/alter/table_options.rs`) now checks **both namespaces**: `database.get_table(new) || database.index_exists(new)`, returning the new variant.

## Parity (verified end-to-end via release CLI)

| Case | sqlite3 3.51.0 | VibeSQL (after fix) |
|------|----------------|---------------------|
| RENAME onto existing **table** | `there is already another table or index with this name: b` | match |
| RENAME onto existing **index** | `there is already another table or index with this name: idx` | match |
| valid RENAME | succeeds | succeeds |

(The harness prefix differs — sqlite3 `Error: in prepare,` vs VibeSQL CLI `Error executing statement N:` — but the core message is identical.)

## TCL shim

No shim change needed. The new message already equals sqlite3's wording, doesn't match any existing `^Table '...' already exists` transform, and falls through the shim's verbatim default (`scripts/tester_vibesql.tcl:486`) unchanged after the CLI-prefix strip — a direct match to `alter.test` alter-2.2 / alter-2.3 (`{there is already another table or index with this name: t3}` / `i3}`).

## TCL delta

`alter.test` currently aborts in setup at alter-1.3.0 (`PRAGMA integrity_check`) due to a pre-existing parser/persistence lexer error on a quoted index name (`'x1 (b Asc, c Asc)`), which is unrelated to this fix and occurs before alter-2.2/2.3 are reached. The new message was therefore verified directly via the release CLI rather than through a full-file TCL run. Filed as a follow-on (see below).

## Tests

New `crates/vibesql-executor/src/tests/alter_rename_collision.rs`:
- RENAME onto existing table -> asserts variant + exact message; source table survives
- RENAME onto existing index -> asserts variant + exact message; source table survives
- valid RENAME -> succeeds

## No regression

`cargo test -p vibesql-executor --lib` — all alter/rename/error_display/trigger-DDL tests pass (40 in the filtered set; 3 new tests green).

One **pre-existing, unrelated** failure: `update::tests::set_rowid::triggerc_7_5_relocate_in_before_trigger` (introduced in #5556, the base commit; UPDATE+AFTER-trigger firing order, no DDL/rename involved). Reproduces in isolation on the untouched base. Overlaps parallel builder #5500's area. Not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)