### PR TITLE
fix(executor): preserve trailing .0 for whole reals on TEXT affinity

### DIFF
--- a/crates/vibesql-executor/src/insert/validation.rs
+++ b/crates/vibesql-executor/src/insert/validation.rs
@@ -486,17 +486,15 @@ pub fn coerce_value(
                         SqlValue::Smallint(i) => {
                             Ok(SqlValue::Varchar(arcstr::ArcStr::from(i.to_string())))
                         }
-                        SqlValue::Numeric(f) => {
-                            Ok(SqlValue::Varchar(arcstr::ArcStr::from(f.to_string())))
-                        }
-                        SqlValue::Double(f) => {
-                            Ok(SqlValue::Varchar(arcstr::ArcStr::from(f.to_string())))
-                        }
-                        SqlValue::Real(f) => {
-                            Ok(SqlValue::Varchar(arcstr::ArcStr::from(f.to_string())))
-                        }
-                        SqlValue::Float(f) => {
-                            Ok(SqlValue::Varchar(arcstr::ArcStr::from(f.to_string())))
+                        // REAL -> TEXT affinity: use SQLite's %!.15g-style real->text
+                        // formatting (via SqlValue's Display impl), which preserves the
+                        // trailing ".0" for whole reals (e.g. -42.0 -> "-42.0", not "-42").
+                        // f64::to_string() would drop it and break triggerC-4.1.4/4.1.5.
+                        SqlValue::Numeric(_)
+                        | SqlValue::Double(_)
+                        | SqlValue::Real(_)
+                        | SqlValue::Float(_) => {
+                            Ok(SqlValue::Varchar(arcstr::ArcStr::from(value.to_string())))
                         }
                         _ => Ok(value), // Other types pass through
                     }
@@ -625,18 +623,16 @@ pub fn coerce_value(
         (SqlValue::Bigint(i), DataType::Varchar { .. }) => {
             Ok(SqlValue::Varchar(arcstr::ArcStr::from(i.to_string())))
         }
-        (SqlValue::Numeric(f), DataType::Varchar { .. }) => {
-            Ok(SqlValue::Varchar(arcstr::ArcStr::from(f.to_string())))
-        }
-        (SqlValue::Float(f), DataType::Varchar { .. }) => {
-            Ok(SqlValue::Varchar(arcstr::ArcStr::from(f.to_string())))
-        }
-        (SqlValue::Real(f), DataType::Varchar { .. }) => {
-            Ok(SqlValue::Varchar(arcstr::ArcStr::from(f.to_string())))
-        }
-        (SqlValue::Double(f), DataType::Varchar { .. }) => {
-            Ok(SqlValue::Varchar(arcstr::ArcStr::from(f.to_string())))
-        }
+        // REAL -> TEXT affinity: use SQLite's %!.15g-style real->text formatting
+        // (via SqlValue's Display impl) so whole reals keep their trailing ".0"
+        // (e.g. -42.0 -> "-42.0"). f64::to_string() would drop it.
+        (
+            SqlValue::Numeric(_)
+            | SqlValue::Float(_)
+            | SqlValue::Real(_)
+            | SqlValue::Double(_),
+            DataType::Varchar { .. },
+        ) => Ok(SqlValue::Varchar(arcstr::ArcStr::from(value.to_string()))),
         (SqlValue::Boolean(b), DataType::Varchar { .. }) => {
             Ok(SqlValue::Varchar(arcstr::ArcStr::from(if *b { "1" } else { "0" })))
         }
@@ -650,5 +646,59 @@ pub fn coerce_value(
             "Type mismatch: expected {:?}, got {:?}",
             expected_type, value
         ))),
+    }
+}
+
+#[cfg(test)]
+mod text_affinity_tests {
+    use vibesql_types::{DataType, SqlValue};
+
+    use super::coerce_value;
+
+    fn coerce_to_text(value: SqlValue) -> String {
+        let coerced = coerce_value(value, &DataType::Varchar { max_length: None })
+            .expect("coercion to TEXT affinity should succeed");
+        match coerced {
+            SqlValue::Varchar(s) => s.to_string(),
+            other => panic!("expected Varchar, got {:?}", other),
+        }
+    }
+
+    /// REAL -> TEXT affinity must use SQLite's %!.15g-style formatting, which
+    /// PRESERVES the trailing ".0" for whole reals (triggerC-4.1.4/4.1.5).
+    /// A naive f64::to_string() would render -42.0 as "-42" and break those tests.
+    #[test]
+    fn whole_real_keeps_trailing_dot_zero() {
+        assert_eq!(coerce_to_text(SqlValue::Real(-42.0)), "-42.0");
+        assert_eq!(coerce_to_text(SqlValue::Real(8.0)), "8.0");
+        assert_eq!(coerce_to_text(SqlValue::Real(45.0)), "45.0");
+        assert_eq!(coerce_to_text(SqlValue::Real(0.0)), "0.0");
+        assert_eq!(coerce_to_text(SqlValue::Real(-0.0)), "0.0");
+        assert_eq!(coerce_to_text(SqlValue::Real(1000000.0)), "1000000.0");
+    }
+
+    #[test]
+    fn whole_real_keeps_dot_zero_for_all_float_variants() {
+        assert_eq!(coerce_to_text(SqlValue::Numeric(-42.0)), "-42.0");
+        assert_eq!(coerce_to_text(SqlValue::Double(-42.0)), "-42.0");
+        assert_eq!(coerce_to_text(SqlValue::Float(-42.0)), "-42.0");
+    }
+
+    /// Fractional reals must NOT be altered (no naive ".0" stripping).
+    #[test]
+    fn fractional_real_unchanged() {
+        assert_eq!(coerce_to_text(SqlValue::Real(1.5)), "1.5");
+        assert_eq!(coerce_to_text(SqlValue::Real(-42.4)), "-42.4");
+        assert_eq!(coerce_to_text(SqlValue::Real(0.1)), "0.1");
+        assert_eq!(coerce_to_text(SqlValue::Real(-0.5)), "-0.5");
+        assert_eq!(coerce_to_text(SqlValue::Real(2.5)), "2.5");
+    }
+
+    /// Integers keep their plain integer text (no ".0").
+    #[test]
+    fn integers_have_no_dot_zero() {
+        assert_eq!(coerce_to_text(SqlValue::Integer(45)), "45");
+        assert_eq!(coerce_to_text(SqlValue::Bigint(-42)), "-42");
+        assert_eq!(coerce_to_text(SqlValue::Smallint(7)), "7");
     }
 }


### PR DESCRIPTION
Closes #5552

## Verified sqlite3 3.51.0 rule
REAL -> TEXT affinity coercion on INSERT uses SQLite's `%!.15g`-style real->text formatting, the same as `CAST(r AS TEXT)`. Crucially, this **preserves the trailing `.0` for whole-valued reals** so the stored text still reflects that the value was a real:

```
sqlite> CREATE TABLE t(x TEXT); INSERT INTO t VALUES(-42.0); SELECT x, typeof(x) FROM t;
-42.0|text          -- NOT "-42"
```

(The issue title's "without trailing .0" describes VibeSQL's buggy output; sqlite3 keeps the `.0`.)

## Root cause / fix
`coerce_value`'s `Numeric/Double/Real/Float -> Varchar` arms used Rust `f64::to_string()`, which drops the `.0` for whole numbers (`-42.0` -> `"-42"`). VibeSQL's `SqlValue` `Display` impl already implements SQLite's `%!.15g` formatting (keeps `.0` for whole reals, normalizes `-0.0`, uses scientific notation for large/small). The fix routes both TEXT-affinity coercion paths in `crates/vibesql-executor/src/insert/validation.rs` through `value.to_string()` (the Display impl) instead of `f64::to_string()`.

## sqlite3 parity (live SELECT vs sqlite3 3.51.0)
Whole and fractional reals into a TEXT column now match sqlite3 exactly:

| value | sqlite3 3.51.0 | VibeSQL (after fix) |
|-------|----------------|---------------------|
| `-42.0` | `-42.0` | `-42.0` ✅ |
| `8.0` | `8.0` | `8.0` ✅ |
| `45.0` | `45.0` | `45.0` ✅ |
| `0.0` / `-0.0` | `0.0` | `0.0` ✅ |
| `1000000.0` | `1000000.0` | `1000000.0` ✅ |
| `1.5` | `1.5` | `1.5` ✅ |
| `-42.4` | `-42.4` | `-42.4` ✅ |
| `0.1` | `0.1` | `0.1` ✅ |

Scientific cases match on the exponent/value but differ in mantissa-zero rendering (`1.0e+20` vs `1e+20`) — see Follow-ons; this is a pre-existing, separate Display bug not exercised by the triggerC blocker.

## triggerC-4.1.4 / 4.1.5 delta
- **triggerC-4.1.4: now GREEN** (was failing only on the TEXT column rendering `-42` instead of `-42.0`).
- **triggerC-4.1.5: TEXT portion fixed** (`-42.4 text` now correct). The remaining failure is the orthogonal BEFORE-INSERT `NEW.rowid == -1` residual blocker called out in #5552, not the text-affinity bug:
  ```
  Expected: -1 integer -42.4 text ...
  Got:       1 integer -42.4 text ...   (only the rowid value differs; text matches)
  ```

## No regression
- `cargo test -p vibesql-types`: all pass.
- `cargo test -p vibesql-executor`: 2806 passed, 1 failed. The single failure — `update::tests::set_rowid::triggerc_7_5_relocate_in_before_trigger` — is **pre-existing on the base** (introduced by #5556, UPDATE...SET rowid relocation) and verified to fail without this change; it is in the UPDATE path, disjoint from this INSERT-only change.
- Added 4 focused unit tests (`text_affinity_tests`) covering whole/fractional reals across all float variants and integer no-`.0`.
- Existing float-formatting / CAST / display tests in `vibesql-types` unchanged and green.

## Follow-ons
- Scientific-notation mantissa parity: `format_scientific_sqlite` renders `1e+20` where sqlite3 renders `1.0e+20`; the in-code comment already documents the intended `1.0e+15` form. This is a broader `SqlValue` Display bug (affects all scientific reals, with SQLLogicTest blast radius) and is deferred.
- triggerC-4.1.5 / 4.1.8 / 4.1.9 BEFORE-INSERT `NEW.rowid == -1` and `UPDATE SET rowid` residuals (#5517) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)