### PR TITLE
fix(executor): variable refs in fired triggers evaluate to NULL (part of #5500)

### DIFF
--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -905,25 +905,48 @@ impl ExpressionEvaluator<'_> {
                 }
             }
 
-            // Placeholder (?) - must be bound before evaluation
+            // Placeholder (?) - must be bound before evaluation, EXCEPT inside a
+            // firing trigger program. A trigger whose definition was loaded from
+            // the schema (e.g. via writable_schema) may legally contain a bound
+            // parameter: a trigger program is compiled once with no bind context,
+            // so SQLite evaluates such a reference to NULL rather than raising
+            // (triggerE.test section 2). The create-time path still rejects
+            // variables in `CREATE TRIGGER` (handled in the parser); this only
+            // affects bodies that reach the firing path with a variable token.
             vibesql_ast::Expression::Placeholder(idx) => {
-                Err(ExecutorError::UnsupportedExpression(
-                    format!("Unbound placeholder ?{} - placeholders must be bound to values before execution", idx)
-                ))
+                if self.trigger_context.is_some() {
+                    Ok(SqlValue::Null)
+                } else {
+                    Err(ExecutorError::UnsupportedExpression(
+                        format!("Unbound placeholder ?{} - placeholders must be bound to values before execution", idx)
+                    ))
+                }
             }
 
-            // Numbered placeholder ($1, $2, etc.) - must be bound before evaluation
+            // Numbered placeholder ($1, $2, etc.) - must be bound before
+            // evaluation, except inside a firing trigger program where an
+            // unbound variable evaluates to NULL (see Placeholder above).
             vibesql_ast::Expression::NumberedPlaceholder(idx) => {
-                Err(ExecutorError::UnsupportedExpression(
-                    format!("Unbound numbered placeholder ${} - placeholders must be bound to values before execution", idx)
-                ))
+                if self.trigger_context.is_some() {
+                    Ok(SqlValue::Null)
+                } else {
+                    Err(ExecutorError::UnsupportedExpression(
+                        format!("Unbound numbered placeholder ${} - placeholders must be bound to values before execution", idx)
+                    ))
+                }
             }
 
-            // Named placeholder (:name) - must be bound before evaluation
+            // Named placeholder (:name) - must be bound before evaluation,
+            // except inside a firing trigger program where an unbound variable
+            // evaluates to NULL (see Placeholder above).
             vibesql_ast::Expression::NamedPlaceholder(name) => {
-                Err(ExecutorError::UnsupportedExpression(
-                    format!("Unbound named placeholder :{} - placeholders must be bound to values before execution", name)
-                ))
+                if self.trigger_context.is_some() {
+                    Ok(SqlValue::Null)
+                } else {
+                    Err(ExecutorError::UnsupportedExpression(
+                        format!("Unbound named placeholder :{} - placeholders must be bound to values before execution", name)
+                    ))
+                }
             }
 
             // Conjunction (AND) - evaluate all children with short-circuit

--- a/crates/vibesql-executor/src/tests/triggers/mod.rs
+++ b/crates/vibesql-executor/src/tests/triggers/mod.rs
@@ -20,6 +20,7 @@ mod delete;
 mod error_handling;
 mod insert;
 mod pseudo_vars;
+mod schema_loaded_variables;
 mod update;
 
 // ============================================================================

--- a/crates/vibesql-executor/src/tests/triggers/schema_loaded_variables.rs
+++ b/crates/vibesql-executor/src/tests/triggers/schema_loaded_variables.rs
@@ -1,0 +1,203 @@
+//! Tests for variable references in triggers that reach the firing path
+//! (triggerE.test section 2).
+//!
+//! SQLite rejects a bound parameter / variable in a `CREATE TRIGGER` body at
+//! create time (`trigger cannot use variables`) — VibeSQL enforces this in the
+//! parser (#5487 / triggerE.test section 1). However, a trigger whose definition
+//! is loaded from the schema *without* going through that parser check (in
+//! SQLite: `PRAGMA writable_schema = 1; INSERT INTO sqlite_master VALUES('trigger', ...)`)
+//! can carry a variable reference. When such a trigger fires, the variable —
+//! which has no bind context, since a trigger program is compiled once — must
+//! evaluate to **NULL** rather than raising "unbound placeholder" (triggerE.test
+//! 2.2.x / 2.3).
+//!
+//! VibeSQL does not yet support `writable_schema` / direct `INSERT INTO
+//! sqlite_master` (it is rejected as a read-only system table), so the full
+//! triggerE section 2 cannot run end-to-end through SQL. These tests instead
+//! register a `CreateTriggerStmt` AST with a variable body directly via
+//! `execute_create_trigger` — exactly the catalog state a schema-loaded trigger
+//! would produce — and verify the fire-time variable→NULL semantics that
+//! section 2 depends on. See issue #5500.
+
+use vibesql_ast::{
+    CreateTriggerStmt, TriggerAction, TriggerEvent, TriggerGranularity, TriggerTiming,
+};
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+use crate::{CreateTableExecutor, InsertExecutor, SelectExecutor};
+
+fn exec_sql(db: &mut Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).unwrap();
+        }
+        other => panic!("unexpected statement: {:?}", other),
+    }
+}
+
+fn select_rows(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::Select(s) => {
+            let executor = SelectExecutor::new(db);
+            let result = executor.execute_with_columns(&s).unwrap();
+            result.rows.into_iter().map(|r| r.values.to_vec()).collect()
+        }
+        _ => panic!("expected SELECT"),
+    }
+}
+
+/// triggerE.test 2.2.x: a schema-loaded trigger whose body INSERTs bound
+/// parameters (`?1`, `?2`) must, when fired, insert NULL for each parameter
+/// rather than raising "unbound placeholder".
+#[test]
+fn numbered_placeholder_in_trigger_body_fires_as_null() {
+    let mut db = Database::new();
+    exec_sql(&mut db, "CREATE TABLE t1 (a INT, b INT);");
+    exec_sql(&mut db, "CREATE TABLE t2 (c INT, d INT);");
+
+    // Mirrors the trigger 2.1 stuffs into sqlite_master:
+    //   CREATE TRIGGER tr1 AFTER INSERT ON t1 BEGIN
+    //     INSERT INTO t2 VALUES(?1, ?2);
+    //   END
+    // We build the AST directly (bypassing the parser's create-time rejection),
+    // exactly as a writable_schema load would.
+    let trigger = CreateTriggerStmt {
+        if_not_exists: false,
+        schema: None,
+        trigger_name: "tr1".to_string(),
+        name_source: None,
+        timing: TriggerTiming::After,
+        event: TriggerEvent::Insert,
+        table_name: "t1".to_string(),
+        granularity: TriggerGranularity::Row,
+        when_condition: None,
+        triggered_action: TriggerAction::RawSql("INSERT INTO t2 VALUES(?1, ?2);".to_string()),
+    };
+    crate::advanced_objects::execute_create_trigger(&trigger, &mut db).unwrap();
+
+    // Firing the trigger must not error; ?1/?2 become NULL.
+    exec_sql(&mut db, "INSERT INTO t1 VALUES (1, 2);");
+
+    let rows = select_rows(&db, "SELECT c, d FROM t2;");
+    assert_eq!(rows, vec![vec![SqlValue::Null, SqlValue::Null]]);
+}
+
+/// `?` (anonymous placeholder) in a trigger body also fires as NULL.
+#[test]
+fn anonymous_placeholder_in_trigger_body_fires_as_null() {
+    let mut db = Database::new();
+    exec_sql(&mut db, "CREATE TABLE t1 (a INT);");
+    exec_sql(&mut db, "CREATE TABLE t2 (c INT);");
+
+    let trigger = CreateTriggerStmt {
+        if_not_exists: false,
+        schema: None,
+        trigger_name: "tr_anon".to_string(),
+        name_source: None,
+        timing: TriggerTiming::After,
+        event: TriggerEvent::Insert,
+        table_name: "t1".to_string(),
+        granularity: TriggerGranularity::Row,
+        when_condition: None,
+        triggered_action: TriggerAction::RawSql("INSERT INTO t2 VALUES(?);".to_string()),
+    };
+    crate::advanced_objects::execute_create_trigger(&trigger, &mut db).unwrap();
+
+    exec_sql(&mut db, "INSERT INTO t1 VALUES (1);");
+
+    let rows = select_rows(&db, "SELECT c FROM t2;");
+    assert_eq!(rows, vec![vec![SqlValue::Null]]);
+}
+
+/// `:name` (named placeholder) in a trigger body also fires as NULL.
+#[test]
+fn named_placeholder_in_trigger_body_fires_as_null() {
+    let mut db = Database::new();
+    exec_sql(&mut db, "CREATE TABLE t1 (a INT);");
+    exec_sql(&mut db, "CREATE TABLE t2 (c INT);");
+
+    let trigger = CreateTriggerStmt {
+        if_not_exists: false,
+        schema: None,
+        trigger_name: "tr_named".to_string(),
+        name_source: None,
+        timing: TriggerTiming::After,
+        event: TriggerEvent::Insert,
+        table_name: "t1".to_string(),
+        granularity: TriggerGranularity::Row,
+        when_condition: None,
+        triggered_action: TriggerAction::RawSql("INSERT INTO t2 VALUES(:p);".to_string()),
+    };
+    crate::advanced_objects::execute_create_trigger(&trigger, &mut db).unwrap();
+
+    exec_sql(&mut db, "INSERT INTO t1 VALUES (1);");
+
+    let rows = select_rows(&db, "SELECT c FROM t2;");
+    assert_eq!(rows, vec![vec![SqlValue::Null]]);
+}
+
+/// triggerE.test 2.3: a variable reference in a schema-loaded trigger's WHEN
+/// clause evaluates to NULL. `WHEN ?1 IS NULL` therefore reduces to
+/// `NULL IS NULL` (true), and `WHERE c IS ?2` matches rows whose `c IS NULL`.
+#[test]
+fn variable_in_when_clause_and_body_where_fires_as_null() {
+    let mut db = Database::new();
+    exec_sql(&mut db, "CREATE TABLE t2 (c, d);");
+    exec_sql(&mut db, "CREATE TABLE t3 (e, f);");
+
+    // CREATE TRIGGER tr2 AFTER INSERT ON t3 WHEN ?1 IS NULL BEGIN
+    //   UPDATE t2 SET c=d WHERE c IS ?2;
+    // END
+    // The WHEN parses to `?1 IS NULL`; build the AST directly to bypass the
+    // create-time variable rejection (which would reject `?1` in WHEN).
+    let when = vibesql_ast::Expression::IsNull {
+        expr: Box::new(vibesql_ast::Expression::NumberedPlaceholder(1)),
+        negated: false,
+    };
+    let trigger = CreateTriggerStmt {
+        if_not_exists: false,
+        schema: None,
+        trigger_name: "tr2".to_string(),
+        name_source: None,
+        timing: TriggerTiming::After,
+        event: TriggerEvent::Insert,
+        table_name: "t3".to_string(),
+        granularity: TriggerGranularity::Row,
+        when_condition: Some(Box::new(when)),
+        triggered_action: TriggerAction::RawSql("UPDATE t2 SET c = d WHERE c IS ?2;".to_string()),
+    };
+    crate::advanced_objects::execute_create_trigger(&trigger, &mut db).unwrap();
+
+    // Seed t2 with one non-NULL-c row and one NULL-c row.
+    exec_sql(&mut db, "INSERT INTO t2 VALUES('x', 'y');");
+    exec_sql(&mut db, "INSERT INTO t2 VALUES(NULL, 'z');");
+
+    // Fire: WHEN ?1 IS NULL -> NULL IS NULL -> true, so the trigger runs.
+    // Body: UPDATE t2 SET c=d WHERE c IS ?2 -> WHERE c IS NULL -> only the
+    // (NULL,'z') row updates, becoming ('z','z'). Matches sqlite3 3.51.0.
+    exec_sql(&mut db, "INSERT INTO t3 VALUES(1, 2);");
+
+    let t3 = select_rows(&db, "SELECT e, f FROM t3;");
+    assert_eq!(t3, vec![vec![SqlValue::Integer(1), SqlValue::Integer(2)]]);
+
+    let t2 = select_rows(&db, "SELECT c, d FROM t2;");
+    assert_eq!(
+        t2,
+        vec![
+            vec![
+                SqlValue::Varchar(arcstr::ArcStr::from("x")),
+                SqlValue::Varchar(arcstr::ArcStr::from("y")),
+            ],
+            vec![
+                SqlValue::Varchar(arcstr::ArcStr::from("z")),
+                SqlValue::Varchar(arcstr::ArcStr::from("z")),
+            ],
+        ]
+    );
+}


### PR DESCRIPTION
## Summary

`Part of #5500` (triggerE.test section 2).

Implements the **executor-side** fire-time semantics that triggerE.test section 2 relies on: a variable / bound-parameter reference reached while a trigger program is firing now evaluates to **NULL** instead of raising "unbound placeholder". The full section-2 TCL tests remain gated on `writable_schema` support (see scope below).

## Scope decision: writable_schema dependency

triggerE.test section 2 loads a variable-bearing trigger into the catalog with:

```sql
PRAGMA writable_schema = 1;
INSERT INTO sqlite_master VALUES('trigger','tr1','t1',0,'CREATE TRIGGER ... ?1 ...');
```

VibeSQL does **not** support `writable_schema` / `PRAGMA writable_schema` / `DEFENSIVE`, and `INSERT INTO sqlite_master` is explicitly rejected as a read-only system table (`insert/execution.rs`). The catalog only ever receives triggers via `CREATE TRIGGER`, whose parser rejects variables at create time (#5487). So:

- **2.1** stays SKIPPED (writable_schema unsupported).
- **2.2.2 / 2.2.3 / 2.3** stay FAILED in TCL — they all cascade from 2.1 never registering the trigger.

Building writable_schema (the PRAGMA, defensive-mode config, direct schema-table mutation, and schema reload from the table) is a large feature, out of scope here. **Full section-2 TCL passage is gated on writable_schema support** — filed as a follow-on.

## variable→NULL implementation

`crates/vibesql-executor/src/evaluator/expressions/eval.rs` — the three placeholder arms (`Placeholder` `?`, `NumberedPlaceholder` `?N`/`$N`, `NamedPlaceholder` `:name`) now return `Ok(SqlValue::Null)` when `self.trigger_context.is_some()`, instead of erroring. This is the single evaluator used for both the trigger WHEN clause (`evaluate_when_condition`) and body statements (INSERT VALUES / UPDATE SET+WHERE / SELECT via `*_with_trigger_context`). Outside trigger context the unbound-placeholder error is preserved unchanged. The parser's create-time `trigger cannot use variables` rejection (#5487) is untouched.

## sqlite3 3.51.0 parity (reachable cases)

Verified the target behavior directly against `sqlite3` 3.51.0:
- `INSERT INTO t2 VALUES(?1, ?2)` body fired → `(NULL, NULL)`.
- `WHEN ?1 IS NULL` → `NULL IS NULL` → true; body `UPDATE t2 SET c=d WHERE c IS ?2` → `WHERE c IS NULL`; t3=`(1,2)`, t2=`[('x','y'),('z','z')]`.

Because writable_schema is unsupported, the LIVE path used to reach the firing code is `execute_create_trigger` with a directly-constructed `CreateTriggerStmt` AST carrying a variable body — exactly the catalog state a schema load would produce. 4 new tests in `tests/triggers/schema_loaded_variables.rs` cover `?1/?2`, `?`, `:name`, and the WHEN+WHERE case, all asserting the sqlite3-matched values.

## triggerE delta

Unchanged: **22/26 passed, 1 skipped (2.1), 3 failed (2.2.2/2.2.3/2.3)** — the failures are entirely cascaded from 2.1 (writable_schema), not from variable evaluation. The variable→NULL behavior itself is fully implemented and tested; it will light up section 2 the moment writable_schema lands.

## Tests

- `cargo test -p vibesql-executor`: 2806 passed, **1 pre-existing failure** (`update::tests::set_rowid::triggerc_7_5_relocate_in_before_trigger` — confirmed failing identically on the merge base 2de7fe8e, introduced by #5556; unrelated to this change), 2 ignored.
- `cargo test -p vibesql-parser trigger`: 87 passed (the #5487 create-time rejection preserved).
- New `triggers::schema_loaded_variables` suite: 4 passed.

## Follow-ons

- **writable_schema support** (`PRAGMA writable_schema`, `sqlite3_db_config DEFENSIVE`, direct `INSERT INTO sqlite_master`, and schema reload) — the remaining gate for triggerE.test section 2 end-to-end. Required to close #5500.
- Pre-existing failure `triggerc_7_5_relocate_in_before_trigger` (BEFORE-trigger rowid relocation ordering) — separate from this work.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>