### PR TITLE
fix(test): unbreak main — triggerc_7_5 stale assertion after #5550×#5556 interaction

### DIFF
--- a/crates/vibesql-executor/src/update/tests/set_rowid.rs
+++ b/crates/vibesql-executor/src/update/tests/set_rowid.rs
@@ -207,19 +207,19 @@ fn triggers_see_old_and_new_rowid() {
 ///   T7 = (2,3,4) (3,5,7) (8,1,2)
 ///   T8 = "after fired 1->8", "after fired 3->3"
 ///
-/// This issue's SET-rowid relocation makes the *table* state (T7) match sqlite3
+/// The SET-rowid relocation (#5517) makes the *table* state (T7) match sqlite3
 /// exactly: the nested `UPDATE t7 SET rowid=8` fired inside the BEFORE trigger
 /// relocates rowid 1 -> 8.
 ///
-/// The T8 AFTER-trigger log is only PARTIALLY correct: the outer UPDATE's AFTER
-/// trigger fires ("after fired 3->3"), but the nested UPDATE (run inside the
-/// BEFORE trigger, i.e. with a trigger context) does NOT fire its own AFTER
-/// trigger, so "after fired 1->8" is missing. That gap is in the trigger
-/// execution path — `execute_internal` forces `has_triggers=false` whenever a
-/// `trigger_context` is present, suppressing all nested-DML triggers — which is
-/// separate from rowid relocation and tracked as a follow-on (see PR body,
-/// "Part of #5517"). This test pins the relocation behavior we DO fix and
-/// documents the residual triggerC-7.5/7.6 delta.
+/// The T8 AFTER-trigger log now ALSO matches sqlite3 exactly. The nested
+/// `UPDATE t7 SET rowid=8` fired inside the BEFORE trigger body fires its own
+/// AFTER trigger ("after fired 1->8") and logs FIRST (it completes before the
+/// outer UPDATE's AFTER trigger runs), then the outer UPDATE's AFTER trigger
+/// logs "after fired 3->3". This is the post-#5550 behavior: #5550 made nested
+/// DML fired from a trigger body fire its own row triggers, which fully resolved
+/// the gap previously tracked by #5557 for this scenario. (PR #5556 was written
+/// against a base predating #5550 and pinned the THEN-missing "after fired 1->8"
+/// as a documented follow-on; that delta no longer exists.)
 #[test]
 fn triggerc_7_5_relocate_in_before_trigger() {
     let mut db = vibesql_storage::Database::new();
@@ -249,9 +249,16 @@ fn triggerc_7_5_relocate_in_before_trigger() {
         .collect();
     assert_eq!(got, vec![(2, 3, 4), (3, 5, 7), (8, 1, 2)]);
 
-    // Outer UPDATE's AFTER trigger fires; the nested UPDATE's AFTER trigger does
-    // not (documented follow-on). sqlite3 also logs "after fired 1->8" first.
+    // Both AFTER triggers fire, in sqlite3 3.51.0 order: the nested UPDATE's
+    // AFTER trigger logs "after fired 1->8" first (it completes inside the BEFORE
+    // trigger body), then the outer UPDATE's AFTER trigger logs "after fired 3->3".
     let t8 = select(&mut db, "SELECT x FROM t8 ORDER BY rowid");
     let log: Vec<String> = t8.iter().map(|r| text(&r.values[0])).collect();
-    assert_eq!(log, vec!["after fired 3->3".to_string()]);
+    assert_eq!(
+        log,
+        vec![
+            "after fired 1->8".to_string(),
+            "after fired 3->3".to_string()
+        ]
+    );
 }


### PR DESCRIPTION
Closes #5564

## Root cause (main CI red)

The test `update::tests::set_rowid::triggerc_7_5_relocate_in_before_trigger`
(`crates/vibesql-executor/src/update/tests/set_rowid.rs`, added by merged
PR #5556 for issue #5517) FAILS on current `origin/main`.

PR #5556's CI ran on a base predating PR #5550 (issue #5535, recursive_triggers).
#5550 made nested DML fired from inside a trigger body fire its own ROW triggers
(verified sqlite-correct). So the nested `UPDATE t7 SET rowid=8` in this test's
BEFORE trigger now ALSO fires its AFTER trigger, producing an extra
`after fired 1->8` log line. The stale assertion — written to document the
THEN-missing behavior (the #5557 gap) — only expected `["after fired 3->3"]`.

Both PRs are individually fine; their interaction left a stale test on main.

## sqlite3 3.51.0-verified corrected expectation

Reproduced the test's exact scenario against `/usr/bin/sqlite3` 3.51.0:

```
== T7 ==
2|3|4
3|5|7
8|1|2
== T8 (log, rowid order) ==
after fired 1->8
after fired 3->3
```

Corrected expectation: `T8 == ["after fired 1->8", "after fired 3->3"]`.
The nested UPDATE's AFTER trigger fires and logs FIRST (it completes inside the
BEFORE trigger body, before the outer UPDATE's AFTER trigger runs).

VibeSQL's current (post-#5550) output now matches sqlite3 exactly. This is not a
tautology — the assertion checks the live audit log (`t8`) and table state (`t7`)
against the sqlite3-confirmed ordering.

## Is #5557 resolved?

Yes — for this scenario. #5557 ("Nested DML fired from a trigger body does not
fire its own row triggers, triggerC-7.5/7.6 AFTER log") tracked the missing
`after fired 1->8`. #5550 fully fixed that: nested-DML row triggers now fire,
and the log matches sqlite3 3.51.0. Recommend closing #5557 as resolved by #5550.

## Verification

- `cargo test -p vibesql-executor --lib triggerc_7_5_relocate_in_before_trigger` → ok
- `cargo test -p vibesql-executor --lib` → 2803 passed; 0 failed
- `cargo test -p vibesql-executor` → green (lib + doctests, exit 0)
- Spot-ran `--lib trigger` (162 ok) and `--lib update::` (17 ok) — nothing else stale.