### PR TITLE
fix(storage): quote identifiers in SQL-dump index DDL round-trip

### DIFF
--- a/crates/vibesql-storage/src/persistence/save.rs
+++ b/crates/vibesql-storage/src/persistence/save.rs
@@ -434,8 +434,18 @@ impl Database {
                 write!(writer, " UNIQUE")
                     .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
             }
-            write!(writer, " INDEX {} ON {} (", index_name, metadata.table_name)
-                .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
+            // Identifiers (index name, table name, column names) must be quoted so
+            // that names with embedded special characters (spaces, quotes, parens)
+            // round-trip correctly when the dump is re-lexed on reload. Without
+            // quoting, a table named `t1'x1` produces an unterminated string
+            // literal (`... ON t1'x1 (...`) and the reload aborts.
+            write!(
+                writer,
+                " INDEX {} ON {} (",
+                quote_identifier(&index_name),
+                quote_identifier(&metadata.table_name)
+            )
+            .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
 
             for (i, col) in metadata.columns.iter().enumerate() {
                 if i > 0 {
@@ -446,7 +456,7 @@ impl Database {
                 use vibesql_ast::IndexColumn;
                 match col {
                     IndexColumn::Column { column_name, .. } => {
-                        write!(writer, "{}", column_name).map_err(|e| {
+                        write!(writer, "{}", quote_identifier(column_name)).map_err(|e| {
                             StorageError::NotImplemented(format!("Write error: {}", e))
                         })?;
                     }
@@ -457,8 +467,14 @@ impl Database {
                         })?;
                     }
                 }
-                write!(writer, " {:?}", col.direction())
-                    .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
+                // Emit a valid SQL sort keyword. Only DESC needs to be written;
+                // ASC is the default. The `{:?}` Debug form (`Asc`/`Desc`) is not
+                // valid SQL and would fail to re-lex.
+                use vibesql_ast::OrderDirection;
+                if col.direction() == OrderDirection::Desc {
+                    write!(writer, " DESC")
+                        .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
+                }
             }
 
             write!(writer, ")")

--- a/crates/vibesql-storage/src/persistence/tests/sql_dump.rs
+++ b/crates/vibesql-storage/src/persistence/tests/sql_dump.rs
@@ -292,9 +292,78 @@ fn test_sql_dump_with_indexes() {
         "Should contain CREATE UNIQUE INDEX idx_email_unique"
     );
     assert!(content.contains("ON test_indexes"), "Should reference test_indexes table");
-    assert!(content.contains("Asc"), "Index direction should be included");
+    // ASC is the default sort order and is omitted from the emitted DDL; the
+    // Debug form ("Asc") must never appear because it is not valid SQL.
+    assert!(
+        !content.contains("Asc"),
+        "Debug-formatted sort direction must not leak into the SQL dump"
+    );
 
     // Cleanup
+    std::fs::remove_file(path).ok();
+}
+
+/// Regression test for #5561: indexes whose name, table name, or columns contain
+/// special characters (spaces, single quotes, parens) must be emitted with quoted
+/// identifiers so that the dump re-lexes correctly when the database is reloaded.
+/// Previously the index DDL was emitted with raw identifiers, so a table named
+/// `t1'x1` produced `CREATE INDEX i3 ON t1'x1 (b Asc, c Asc);`, which aborted the
+/// reload with an unterminated-string-literal lexer error.
+#[test]
+fn test_sql_dump_index_quoted_identifiers_roundtrip() {
+    use crate::persistence::load::read_sql_dump;
+
+    let mut db = Database::new();
+    // (parser is used below to prove the emitted DDL re-lexes)
+
+    // Table name with an embedded single quote.
+    let schema = TableSchema::new(
+        "t1'x1".to_string(),
+        vec![
+            ColumnSchema::new("b".to_string(), DataType::Integer, false),
+            ColumnSchema::new("c".to_string(), DataType::Integer, false),
+        ],
+    );
+    db.create_table(schema).unwrap();
+
+    // Index with a DESC column on the oddly-named table.
+    let cols = vec![
+        vibesql_ast::IndexColumn::Column {
+            column_name: "b".to_string(),
+            direction: vibesql_ast::OrderDirection::Desc,
+            prefix_length: None,
+        },
+        vibesql_ast::IndexColumn::Column {
+            column_name: "c".to_string(),
+            direction: vibesql_ast::OrderDirection::Asc,
+            prefix_length: None,
+        },
+    ];
+    db.create_index("i3".to_string(), "t1'x1".to_string(), false, cols).unwrap();
+
+    let path = "/tmp/test_index_quoted_roundtrip.sql";
+    db.save_sql_dump(path).unwrap();
+
+    let content = read_sql_dump(path).unwrap();
+    // Table name must be double-quoted so the single quote does not start a string.
+    assert!(
+        content.contains("ON \"t1'x1\""),
+        "Index DDL must quote the table name. Got:\n{content}"
+    );
+    // The Debug-formatted direction ("Asc") must not appear; DESC is explicit.
+    assert!(!content.contains("Asc"), "Debug sort direction leaked:\n{content}");
+    assert!(content.contains("DESC"), "DESC direction should be emitted:\n{content}");
+
+    // The emitted CREATE INDEX statement must re-lex/parse cleanly. Before the
+    // fix it produced a lexer error on the unquoted `t1'x1` table name.
+    let create_index_stmt = content
+        .lines()
+        .find(|l| l.trim_start().starts_with("CREATE INDEX"))
+        .unwrap_or_else(|| panic!("No CREATE INDEX line in dump:\n{content}"));
+    vibesql_parser::Parser::parse_sql(create_index_stmt).unwrap_or_else(|e| {
+        panic!("Emitted index DDL must re-parse: {e}\nStatement: {create_index_stmt}")
+    });
+
     std::fs::remove_file(path).ok();
 }
 


### PR DESCRIPTION
Closes #5561

## Root cause

The persistence SQL-dump path (`crates/vibesql-storage/src/persistence/save.rs`) emitted `CREATE INDEX` statements with **raw, unquoted identifiers** and the Rust `Debug` form of the sort direction:

```rust
write!(writer, " INDEX {} ON {} (", index_name, metadata.table_name) // raw
write!(writer, "{}", column_name)                                    // raw
write!(writer, " {:?}", col.direction())                             // -> " Asc" / " Desc"
```

For an index on a table whose name contains special characters — e.g. `t1'x1` (created by alter.test at alter-1.1 via `CREATE TABLE [t1'x1](...)`) — this produced:

```
CREATE INDEX i3 ON t1'x1 (b Asc, c Asc);
```

On reload the unquoted `t1'x1` makes `'x1 (b Asc, c Asc);` an unterminated string literal, so the lexer aborts:

```
Parse error: Lexer error: near "'x1 (b Asc, c Asc);": syntax error
```

This aborted `alter.test` in setup at `alter-1.3.0` (`PRAGMA integrity_check`), preventing every later test (alter-2.x .. alter-21.x) from running. (Distinct from #5553 case-folding — this is purely the lex/round-trip of a name with embedded special chars.)

## The fix

In the index export only (the `CREATE TABLE` export already did this correctly):
- Quote `index_name`, `table_name`, and column names with the existing `quote_identifier` helper.
- Emit a valid SQL sort keyword: omit the default `ASC`, emit `DESC` explicitly — instead of the invalid Debug `Asc`/`Desc`.

Now emits: `CREATE INDEX i3 ON "t1'x1" (b, c);` which re-lexes cleanly.

Scope is tight: only the dump emission changed; no lexer/identifier-parsing behavior was touched.

## alter.test progress / delta

- **Before:** file aborts in setup at alter-1.3.0 → no meaningful results.
- **After:** file no longer aborts; all 117 tests execute, reaching alter-21.x. 36 passing (the remaining failures are pre-existing, unrelated feature gaps). alter-1.3 (the RENAME block) now passes; alter-2.x onward are now observable.

## sqlite3 3.51.0 parity

Same `CREATE TABLE [t1'x1] / CREATE INDEX i3 / CREATE INDEX "x1 (b Asc, c Asc)"` + `PRAGMA integrity_check` + `sqlite_master` inspection:
- sqlite3: `integrity_check` -> `ok`; index sql `CREATE INDEX i3 ON "t1'x1"(b,c)` (table name quoted).
- VibeSQL (after fix): `integrity_check` -> `ok`; round-trips through save/reload; matches the quoted-identifier behavior.

## No regression

- `cargo test -p vibesql-parser -p vibesql-executor -p vibesql-storage`: all green (parser 2814 passed; storage suites green).
- Updated `test_sql_dump_with_indexes` (it asserted the now-removed Debug `Asc`) and added `test_sql_dump_index_quoted_identifiers_roundtrip` which proves the emitted DDL re-parses.
- Broad TCL sample unchanged vs baseline: index2 100%, select1 100%, index/where/reindex at their existing pass rates (failures pre-existing, unrelated).

## Follow-ons

- An index created in the **same** `-c`/session as its table is not persisted to the dump (observed during repro: `CREATE TABLE t; CREATE INDEX ... ON t` in one statement batch -> empty `-- Indexes` section). Separate from this lexer bug; will file.
- Index names are lowercased on persistence (case-folding, tracked by #5553) — intentionally out of scope here.