### PR TITLE
fix(executor): qualify dropped view-body table as main.<name> (trigger4-3.x)

### DIFF
--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -1249,9 +1249,14 @@ fn build_view_schema(
     database: &Database,
     view_def: &vibesql_catalog::ViewDefinition,
 ) -> Result<vibesql_catalog::TableSchema, ExecutorError> {
-    // Execute the view's SELECT query to get column names
+    // Execute the view's SELECT query to get column names. A table referenced by
+    // the view body that has since been dropped surfaces here; sqlite3 reports it
+    // schema-qualified (`no such table: main.test2`) because the view body
+    // resolves against the database schema, so qualify the bare name.
     let select_executor = crate::SelectExecutor::new(database);
-    let result = select_executor.execute_with_columns(&view_def.query)?;
+    let result = select_executor
+        .execute_with_columns(&view_def.query)
+        .map_err(ExecutorError::with_main_schema_qualifier)?;
 
     // Use explicit column names if provided, otherwise derive from SELECT
     let column_names: Vec<String> =

--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -1354,6 +1354,24 @@ impl ExecutorError {
             ExecutorError::SqliteCompatError(msg) if msg.starts_with("non-deterministic use of ")
         )
     }
+
+    /// Qualify a `TableNotFound` for an unqualified table name with the implicit
+    /// `main.` schema prefix, matching sqlite3's reporting when a table is
+    /// resolved against the database schema (e.g. a table referenced in a view
+    /// definition body that has since been dropped: `no such table: main.test2`,
+    /// trigger4-3.1/3.2/3.3).
+    ///
+    /// Only bare names are rewritten — names that already carry a schema
+    /// qualifier (contain a `.`) and every other error variant are returned
+    /// unchanged.
+    pub fn with_main_schema_qualifier(self) -> ExecutorError {
+        match self {
+            ExecutorError::TableNotFound(name) if !name.contains('.') => {
+                ExecutorError::TableNotFound(format!("main.{}", name))
+            }
+            other => other,
+        }
+    }
 }
 
 impl std::error::Error for ExecutorError {}
@@ -1594,5 +1612,39 @@ impl From<vibesql_catalog::CatalogError> for ExecutorError {
                 ))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ExecutorError;
+
+    #[test]
+    fn with_main_schema_qualifier_prefixes_bare_table_name() {
+        let err = ExecutorError::TableNotFound("test2".to_string());
+        assert_eq!(
+            err.with_main_schema_qualifier(),
+            ExecutorError::TableNotFound("main.test2".to_string())
+        );
+    }
+
+    #[test]
+    fn with_main_schema_qualifier_leaves_already_qualified_name() {
+        let err = ExecutorError::TableNotFound("other.test2".to_string());
+        assert_eq!(
+            err.with_main_schema_qualifier(),
+            ExecutorError::TableNotFound("other.test2".to_string())
+        );
+    }
+
+    #[test]
+    fn with_main_schema_qualifier_ignores_other_variants() {
+        let err = ExecutorError::ColumnNotFound {
+            column_name: "x".to_string(),
+            table_name: "t".to_string(),
+            searched_tables: vec!["t".to_string()],
+            available_columns: vec![],
+        };
+        assert_eq!(err.clone().with_main_schema_qualifier(), err);
     }
 }

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -1672,9 +1672,14 @@ fn build_view_schema(
     db: &vibesql_storage::Database,
     view_def: &vibesql_catalog::ViewDefinition,
 ) -> Result<vibesql_catalog::TableSchema, ExecutorError> {
-    // Execute the view's SELECT query to get column names
+    // Execute the view's SELECT query to get column names. A table referenced by
+    // the view body that has since been dropped surfaces here; sqlite3 reports it
+    // schema-qualified (`no such table: main.test2`, trigger4-3.1/3.2) because the
+    // view body resolves against the database schema, so qualify the bare name.
     let select_executor = crate::SelectExecutor::new(db);
-    let result = select_executor.execute_with_columns(&view_def.query)?;
+    let result = select_executor
+        .execute_with_columns(&view_def.query)
+        .map_err(ExecutorError::with_main_schema_qualifier)?;
 
     // Use explicit column names if provided, otherwise derive from SELECT
     let column_names: Vec<String> =

--- a/crates/vibesql-executor/src/update/triggers.rs
+++ b/crates/vibesql-executor/src/update/triggers.rs
@@ -423,9 +423,14 @@ pub(super) fn build_view_schema(
     database: &Database,
     view_def: &ViewDefinition,
 ) -> Result<TableSchema, ExecutorError> {
-    // Execute the view's SELECT query to get column names
+    // Execute the view's SELECT query to get column names. A table referenced by
+    // the view body that has since been dropped surfaces here; sqlite3 reports it
+    // schema-qualified (`no such table: main.test2`, trigger4-3.3) because the
+    // view body resolves against the database schema, so qualify the bare name.
     let select_executor = crate::SelectExecutor::new(database);
-    let result = select_executor.execute_with_columns(&view_def.query)?;
+    let result = select_executor
+        .execute_with_columns(&view_def.query)
+        .map_err(ExecutorError::with_main_schema_qualifier)?;
 
     // Use explicit column names if provided, otherwise derive from SELECT
     let column_names: Vec<String> =

--- a/crates/vibesql-executor/tests/view_dml_missing_table_main_qualifier_tests.rs
+++ b/crates/vibesql-executor/tests/view_dml_missing_table_main_qualifier_tests.rs
@@ -1,0 +1,122 @@
+//! INSERT/UPDATE/DELETE on a view whose body references a since-dropped table
+//! must report the missing table schema-qualified (`main.<name>`), matching
+//! sqlite3 3.51.0 (trigger4-3.1/3.2/3.3).
+//!
+//! A view body resolves its tables against the database schema, so when one of
+//! those tables is missing sqlite3 names it with the implicit `main.` prefix.
+//! VibeSQL surfaces that during the INSTEAD OF view-DML path while building the
+//! view pseudo-schema. Verified against sqlite3 3.51.0:
+//!
+//! ```text
+//! sqlite> insert into test values(7,8,9);
+//! Parse error: no such table: main.test2
+//! ```
+
+use vibesql_executor::{
+    CreateTableExecutor, DeleteExecutor, InsertExecutor, TriggerExecutor, UpdateExecutor,
+    ViewExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+/// Parse and execute a single DDL/DML statement, panicking on failure.
+fn exec_ok(db: &mut Database, sql: &str) {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e:?}"));
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+        }
+        Statement::CreateView(s) => {
+            ViewExecutor::execute_create_view(&s, db).expect("CREATE VIEW failed");
+        }
+        Statement::CreateTrigger(s) => {
+            TriggerExecutor::create_trigger_with_sql(db, &s, Some(sql))
+                .expect("CREATE TRIGGER failed");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT failed");
+        }
+        Statement::DropTable(s) => {
+            vibesql_executor::DropTableExecutor::execute(&s, db).expect("DROP TABLE failed");
+        }
+        other => panic!("unsupported statement in exec_ok: {other:?}"),
+    }
+}
+
+/// Build the trigger4 fixture and drop `test2` so the view body is now dangling.
+fn setup_dangling_view(db: &mut Database) {
+    exec_ok(db, "create table test1(id integer primary key, a)");
+    exec_ok(db, "create table test2(id integer, b)");
+    exec_ok(
+        db,
+        "create view test as select test1.id as id, a as a, b as b \
+         from test1 join test2 on test2.id = test1.id",
+    );
+    exec_ok(
+        db,
+        "create trigger I_test instead of insert on test begin \
+           insert into test1 (id,a) values (NEW.id,NEW.a); \
+           insert into test2 (id,b) values (NEW.id,NEW.b); \
+         end",
+    );
+    exec_ok(
+        db,
+        "create trigger U_test instead of update on test begin \
+           update test1 set a=NEW.a where id=NEW.id; \
+           update test2 set b=NEW.b where id=NEW.id; \
+         end",
+    );
+    exec_ok(
+        db,
+        "create trigger D_test instead of delete on test begin \
+           delete from test1 where id=OLD.id; \
+           delete from test2 where id=OLD.id; \
+         end",
+    );
+    exec_ok(db, "drop table test2");
+}
+
+/// The error string the shim translates to `no such table: main.test2`.
+fn assert_main_test2(err: vibesql_executor::ExecutorError) {
+    assert_eq!(
+        err,
+        vibesql_executor::ExecutorError::TableNotFound("main.test2".to_string()),
+        "expected the missing view-body table to be reported as main.test2"
+    );
+}
+
+#[test]
+fn insert_on_view_with_dropped_body_table_qualifies_main() {
+    // trigger4-3.1 / 3.2
+    let mut db = Database::new();
+    setup_dangling_view(&mut db);
+
+    let stmt = Parser::parse_sql("insert into test values(7,8,9)").unwrap();
+    let vibesql_ast::Statement::Insert(insert) = stmt else { panic!("expected INSERT") };
+    let err = InsertExecutor::execute(&mut db, &insert).unwrap_err();
+    assert_main_test2(err);
+}
+
+#[test]
+fn update_on_view_with_dropped_body_table_qualifies_main() {
+    // trigger4-3.3
+    let mut db = Database::new();
+    setup_dangling_view(&mut db);
+
+    let stmt = Parser::parse_sql("update test set a=222 where id=1").unwrap();
+    let vibesql_ast::Statement::Update(update) = stmt else { panic!("expected UPDATE") };
+    let err = UpdateExecutor::execute(&update, &mut db).unwrap_err();
+    assert_main_test2(err);
+}
+
+#[test]
+fn delete_on_view_with_dropped_body_table_qualifies_main() {
+    let mut db = Database::new();
+    setup_dangling_view(&mut db);
+
+    let stmt = Parser::parse_sql("delete from test where id=1").unwrap();
+    let vibesql_ast::Statement::Delete(delete) = stmt else { panic!("expected DELETE") };
+    let err = DeleteExecutor::execute(&delete, &mut db).unwrap_err();
+    assert_main_test2(err);
+}


### PR DESCRIPTION
Closes #5528

## Exact sqlite3 3.51.0 behavior
When a view's body SELECT references a table that has since been dropped, sqlite3 reports the missing table **schema-qualified** with the implicit `main.` prefix, because a view body resolves its tables against the database schema. Reproduced on sqlite3 3.51.0:

```
sqlite> create table test1(id integer primary key,a);
sqlite> create table test2(id integer,b);
sqlite> create view test as select test1.id as id,a as a,b as b
   ...> from test1 join test2 on test2.id = test1.id;
sqlite> create trigger I_test instead of insert on test begin ... end;
sqlite> drop table test2;
sqlite> insert into test values(7,8,9);
Parse error: no such table: main.test2          -- (trigger4-3.1/3.2)
sqlite> update test set a=222 where id=1;
Parse error: no such table: main.test2          -- (trigger4-3.3)
```

VibeSQL previously emitted the bare `no such table: test2`.

## The fix
The error surfaces while the three INSTEAD OF view-DML paths build the view pseudo-schema by executing the view's SELECT query (`build_view_schema` in `insert/execution.rs`, `update/triggers.rs`, `delete/executor.rs`). Added `ExecutorError::with_main_schema_qualifier()` (in `errors.rs`), which prefixes a `TableNotFound` for a bare (unqualified, no `.`) table name with `main.`, and applied it via `.map_err(...)` on the view-query execution in those three paths. Already-qualified names and every other error variant are left untouched.

The TCL shim already translates `Table 'main.test2' not found` -> `no such table: main.test2` (lowercasing the captured name), so emitting the qualified name in the executor is sufficient.

## trigger4.test delta
- Before: 20/23 passing (failing: trigger4-3.1, 3.2, 3.3)
- After: **23/23 passing** (+3)

## sqlite3 parity
Verified against sqlite3 3.51.0 for INSERT, UPDATE, and DELETE on the view with a dropped body table — all now emit `no such table: main.test2`, matching exactly.

## Tests
- New `tests/view_dml_missing_table_main_qualifier_tests.rs`: INSERT/UPDATE/DELETE on a view with a dropped body table each assert `TableNotFound("main.test2")`.
- Unit tests for `with_main_schema_qualifier` (bare -> qualified, already-qualified untouched, non-`TableNotFound` untouched).
- `cargo test -p vibesql-executor`: green (2817 lib + all integration suites, 0 failed).
- No regression: `view.test`/`view2.test`/`view3.test` 0 failures; trigger suite unchanged (pre-existing failures unrelated).

## Scope / follow-ons
Scoped to what trigger4-3.x needs (view-DML schema building). The broader `main.`-qualification rule is intentionally **not** addressed here and remains divergent:
- Plain `SELECT * FROM <view>` over a dropped body table still emits the bare name (sqlite3: `main.test2`). Suggested follow-on: `Part of #5528` — qualify missing view-body tables in the read path.
- `CREATE TRIGGER ... ON <missing-table>` and other direct table-not-found contexts (trigger1-1.2/1.6 `main.<t>`) also expect `main.` and remain unqualified. Suggested follow-on: `Part of #5528` — general schema-qualified table-not-found resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)