### PR TITLE
fix(types): keep mantissa .0 in scientific REAL display (sqlite3 parity)

### DIFF
--- a/crates/vibesql-types/src/sql_value/display.rs
+++ b/crates/vibesql-types/src/sql_value/display.rs
@@ -71,8 +71,11 @@ fn format_with_significant_digits(n: f64, sig_digits: usize) -> String {
 /// Format scientific notation like SQLite: 1.0e+15, 1.0e-05
 /// - Lowercase 'e'
 /// - Explicit + or - sign for exponent
-/// - Two-digit exponent (padded with leading zero if needed)
-/// - Strip trailing zeros from mantissa (but keep at least one decimal place)
+/// - Minimum two-digit exponent (padded with leading zero if needed; wider for
+///   large magnitudes, e.g. e+100, e+308)
+/// - Strip trailing zeros from the mantissa but ALWAYS keep at least one
+///   fractional digit, so a whole mantissa renders "1.0e+20" (not "1e+20"),
+///   matching sqlite3's %!.15g output.
 fn format_scientific_sqlite(s: &str) -> String {
     // Input format from Rust: "1.50000000000000e10" or "1.5e-5"
     // Output format for SQLite: "1.5e+10" or "1.5e-05"
@@ -80,8 +83,21 @@ fn format_scientific_sqlite(s: &str) -> String {
         let (mantissa, exp_part) = s.split_at(e_pos);
         let exp_str = &exp_part[1..]; // Skip the 'e'
 
-        // Strip trailing zeros from mantissa and trailing decimal point
-        let mantissa = mantissa.trim_end_matches('0').trim_end_matches('.');
+        // Strip trailing zeros from the mantissa, but keep at least one
+        // fractional digit so a whole mantissa renders as "1.0", matching
+        // sqlite3's %!.15g (e.g. "1.0e+20", not "1e+20"). Fractional mantissas
+        // are preserved as-is ("1.5e+20", "9.99e+30").
+        let mantissa: std::borrow::Cow<'_, str> = if mantissa.contains('.') {
+            let trimmed = mantissa.trim_end_matches('0');
+            if trimmed.ends_with('.') {
+                std::borrow::Cow::Owned(format!("{}0", trimmed))
+            } else {
+                std::borrow::Cow::Borrowed(trimmed)
+            }
+        } else {
+            // No decimal point at all (e.g. "1e10"): add ".0".
+            std::borrow::Cow::Owned(format!("{}.0", mantissa))
+        };
 
         let (sign, exp_digits) = if let Some(stripped) = exp_str.strip_prefix('-') {
             ("-", stripped)
@@ -217,22 +233,53 @@ mod tests {
 
     #[test]
     fn test_format_f64_scientific() {
-        // Very large numbers use scientific notation (SQLite format: e+XX or e-XX)
-        assert_eq!(format_f64(1e15), "1e+15");
-        assert_eq!(format_f64(1e16), "1e+16");
+        // Whole mantissas keep ".0" to match sqlite3 3.51.0 (%!.15g):
+        //   SELECT 1e15  -> 1.0e+15
+        //   SELECT 1e16  -> 1.0e+16
+        //   SELECT 1e-5  -> 1.0e-05
+        //   SELECT 1e-10 -> 1.0e-10
+        assert_eq!(format_f64(1e15), "1.0e+15");
+        assert_eq!(format_f64(1e16), "1.0e+16");
         // Very small numbers use scientific notation
-        assert_eq!(format_f64(0.00001), "1e-05");
-        assert_eq!(format_f64(1e-10), "1e-10");
+        assert_eq!(format_f64(0.00001), "1.0e-05");
+        assert_eq!(format_f64(1e-10), "1.0e-10");
+
+        // Verified directly against sqlite3 3.51.0 (one query per value):
+        assert_eq!(format_f64(1e20), "1.0e+20"); // whole mantissa, +exp
+        assert_eq!(format_f64(1e-20), "1.0e-20"); // whole mantissa, -exp
+        assert_eq!(format_f64(1.5e20), "1.5e+20"); // fractional mantissa preserved
+        assert_eq!(format_f64(9.99e30), "9.99e+30"); // multi-digit fractional mantissa
+        assert_eq!(format_f64(1e100), "1.0e+100"); // 3-digit exponent
+        assert_eq!(format_f64(1e308), "1.0e+308"); // largest 3-digit exponent
+        assert_eq!(format_f64(-1e20), "-1.0e+20"); // negative
+        assert_eq!(format_f64(1.23456789012346e15), "1.23456789012346e+15"); // 15 sig figs
+    }
+
+    #[test]
+    fn test_format_f64_scientific_boundary() {
+        // Fixed vs scientific threshold matches sqlite3 3.51.0:
+        // scientific when |x| >= 1e15 or (0 < |x| < 1e-4).
+        assert_eq!(format_f64(1e14), "100000000000000.0"); // fixed
+        assert_eq!(format_f64(1e15), "1.0e+15"); // scientific
+        assert_eq!(format_f64(0.0001), "0.0001"); // fixed
+        assert_eq!(format_f64(0.00001), "1.0e-05"); // scientific
+        // Zero is never scientific.
+        assert_eq!(format_f64(0.0), "0.0");
     }
 
     #[test]
     fn test_format_scientific_sqlite() {
-        // Test the SQLite-compatible scientific notation formatter
-        assert_eq!(format_scientific_sqlite("1e15"), "1e+15");
-        assert_eq!(format_scientific_sqlite("1e5"), "1e+05");
+        // Whole mantissas keep ".0" (matches sqlite3 %!.15g)
+        assert_eq!(format_scientific_sqlite("1e15"), "1.0e+15");
+        assert_eq!(format_scientific_sqlite("1e5"), "1.0e+05");
+        assert_eq!(format_scientific_sqlite("1.00000000000000e20"), "1.0e+20");
+        // Fractional mantissas are preserved (and not given a spurious ".0")
         assert_eq!(format_scientific_sqlite("1.5e-5"), "1.5e-05");
         assert_eq!(format_scientific_sqlite("1.5e-15"), "1.5e-15");
+        assert_eq!(format_scientific_sqlite("9.99000000000000e30"), "9.99e+30");
         assert_eq!(format_scientific_sqlite("9.22337203685478e18"), "9.22337203685478e+18");
+        // Exponent widening beyond two digits is preserved.
+        assert_eq!(format_scientific_sqlite("1.00000000000000e100"), "1.0e+100");
     }
 
     #[test]


### PR DESCRIPTION
Closes #5563

## Problem
When VibeSQL rendered a REAL in scientific notation, `format_scientific_sqlite` (`crates/vibesql-types/src/sql_value/display.rs`) stripped a whole mantissa to a bare integer — `1e20` displayed as `1e+20`. sqlite3 3.51.0 (`%!.15g`) renders `1.0e+20`, always keeping at least one fractional digit. Spun out of #5552 / PR #5562, where scientific parity was explicitly deferred.

## Verified sqlite3 3.51.0 scientific-notation rule
Captured directly from `sqlite3 :memory:` (one query per value):
- **Threshold (fixed vs scientific):** scientific iff `|x| >= 1e15` OR `0 < |x| < 1e-4`. Verified at the boundary: `1e14 -> 100000000000000.0` (fixed) vs `1e15 -> 1.0e+15` (scientific); `0.0001 -> 0.0001` (fixed) vs `0.00001 -> 1.0e-05` (scientific). Zero is never scientific (`0.0`). This threshold was already correct in VibeSQL and is unchanged.
- **Mantissa:** up to 15 significant digits, trailing zeros stripped, but **always at least one fractional digit** — a whole mantissa keeps `.0` (`1.0e+20`), fractional mantissas are preserved verbatim (`1.5e+20`, `9.99e+30`, `1.23456789012346e+15`).
- **Exponent:** lowercase `e`, sign **always present** (`+`/`-`), **minimum 2 digits** (`e+15`, not `e+015`), widened when needed (`e+100`, `e+308`).
- **Negatives:** sign on the mantissa (`-1.0e+20`).

Rust's `{:.14e}` produces the same 15-sig-fig mantissa with identical rounding (e.g. `1.7976931348623157e308 -> 1.79769313486232e+308`, `5e-324 -> 4.94065645841247e-324`), so only the `.0` retention needed fixing.

## Fix
In `format_scientific_sqlite`, replaced the unconditional `.trim_end_matches('0').trim_end_matches('.')` (which deleted the decimal point) with: strip trailing mantissa zeros but keep a `.0` when the mantissa is whole; if no decimal point is present at all, append `.0`. Fractional mantissas pass through unchanged. The exponent sign/min-2-digit/widening logic is untouched. Doc comment and unit tests updated to assert the sqlite-matching form.

## Parity table (VibeSQL vs sqlite3 3.51.0, live `SELECT`)
| query | sqlite3 3.51.0 | VibeSQL (after fix) | |
|-------|----------------|---------------------|---|
| `SELECT 1e20` | `1.0e+20` | `1.0e+20` | whole mantissa |
| `SELECT 1.5e20` | `1.5e+20` | `1.5e+20` | fractional |
| `SELECT 9.99e30` | `9.99e+30` | `9.99e+30` | multi-digit fractional |
| `SELECT 1e308` | `1.0e+308` | `1.0e+308` | large +exp (3-digit) |
| `SELECT 1e-20` | `1.0e-20` | `1.0e-20` | small -exp |
| `SELECT 0.00001` | `1.0e-05` | `1.0e-05` | small (-exp, 2-digit pad) |
| `SELECT -1e20` | `-1.0e+20` | `-1.0e+20` | negative |
| `SELECT 0.0` | `0.0` | `0.0` | zero (not scientific) |
| `SELECT 1e14` | `100000000000000.0` | `100000000000000.0` | boundary: fixed |
| `SELECT 1e15` | `1.0e+15` | `1.0e+15` | boundary: scientific |
| `SELECT 0.0001` | `0.0001` | `0.0001` | boundary: fixed |
| `SELECT 1.23456789012346e15` | `1.23456789012346e+15` | `1.23456789012346e+15` | 15 sig figs |
| `SELECT 5e-324` | `4.94065645841247e-324` | `4.94065645841247e-324` | denormal min |
| `SELECT 1.7976931348623157e308` | `1.79769313486232e+308` | `1.79769313486232e+308` | f64 max |

All 23 cases tested match exactly. Fixed-notation reals (#5552) are unchanged (`1.5`, `100.0`, `0.001`, `123456789012345.0` verified identical).

## No-regression (blast radius)
This Display path feeds SELECT output, CAST AS TEXT, and SQLLogicTest comparisons, so I ran:
- `cargo test -p vibesql-types` — green (19 display unit tests, updated assertions now match sqlite3).
- `cargo test -p vibesql-executor` — **4406 passed, 0 failed**.
- Grep confirmed no other Rust test asserts a scientific-notation Display string.
- Full SQLLogicTest suite (`./scripts/sqllogictest run`): **6,069,160 records, 6,068,981 passed — 100.0% in both MySQL and SQLite dialect modes**. 179 file-level failures are pre-existing `index/` (BETWEEN/commute) and `select/` feature gaps; **zero involve scientific notation** (verified by scanning `detailed_failures`). No movement away from parity; this moves scientific-notation reals toward parity.

## Follow-ons
- None required for this issue. `format_f32` shares the same scientific path so f32 REALs benefit automatically; no separate f32 scientific gap observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)