### PR TITLE
fix(executor): bulk INSERT...SELECT skips deleted source rows (trigger2-2.14)

### DIFF
--- a/crates/vibesql-executor/src/insert/bulk_transfer.rs
+++ b/crates/vibesql-executor/src/insert/bulk_transfer.rs
@@ -177,8 +177,13 @@ fn execute_bulk_transfer(
             .get_table(source_table)
             .ok_or_else(|| ExecutorError::TableNotFound(source_table.to_string()))?;
 
-        // Collect all rows (need to clone to avoid borrow issues)
-        src_table.scan().iter().map(|row| row.values.clone()).collect::<Vec<_>>()
+        // Use scan_live() to skip rows that have been deleted but not yet
+        // compacted. `scan()` returns raw storage including deleted rows; an
+        // AFTER DELETE trigger body running `INSERT INTO log SELECT * FROM tbl`
+        // must not observe the row that was just deleted mid-statement
+        // (trigger2-2.14-after). The non-bulk SELECT path already filters
+        // deleted rows, so this keeps the fast path consistent.
+        src_table.scan_live().map(|(_, row)| row.values.clone()).collect::<Vec<_>>()
     };
 
     let mut pk_values_seen = Vec::new();


### PR DESCRIPTION
Closes #5547

## Root cause

`trigger2.test` section 2 cross-checks each trigger *program* run inline vs. fired by an event. The remaining failure on `main` was **trigger2-2.14-after** (program #5 = `INSERT INTO log SELECT * FROM tbl`, fired by an `AFTER DELETE`).

The DELETE executor already marks the row deleted (`mark_deleted_inplace`) and invalidates the columnar cache *before* firing the `AFTER DELETE` trigger, so an AFTER trigger should not observe the deleted row. But the trigger body `INSERT INTO log SELECT * FROM tbl` (no column list, no CTE/RETURNING) took the **bulk-transfer fast path**, and that path read its source rows via `Table::scan()` — which returns *raw* storage **including rows marked deleted but not yet compacted**. The just-deleted row was therefore copied into `log`, producing a phantom 3rd row.

```
expected (sqlite3 3.51.0): log = {1 2 3, 10 20 30}
vibesql (before fix):      log = {1 2 3, 10 20 30, 1 2 3}   <- phantom deleted row
```

## The fix

`crates/vibesql-executor/src/insert/bulk_transfer.rs`: switch the source scan from `scan()` to `scan_live()`, which filters deleted-but-not-yet-compacted rows. This matches the non-bulk `SELECT` path (which already filters deleted rows) and sqlite3.

One-line semantic change; no behavior change for INSERT...SELECT outside an interleaved delete (deleted rows were never meant to be visible).

## sqlite3 3.51.0 parity (2.12 / 2.14)

- **2.14-after**: now `log = {1 2 3, 10 20 30}`, matching sqlite3 exactly (verified by reproducing the exact SQL against sqlite3 3.51.0).
- **2.12** (program #4, self INSERT+UPDATE+DELETE): already passing on current `main` (fixed by intervening PRs incl. #5565); confirmed still green.
- General check: `DELETE FROM a WHERE x=3; INSERT INTO b SELECT * FROM a;` now matches sqlite3 (deleted row excluded).

## trigger2 delta

`make test-tcl-file FILE=trigger2.test`: **50/51 -> 51/51** (100%).

## No regression

- `cargo test -p vibesql-executor`: all suites green (0 failed).
- TCL, baseline (origin/main) vs. with-fix, identical failure sets (no regressions, no accidental fixes):
  - trigger1 / trigger3 / triggerC: unchanged
  - fkey2.test: 123 sub-failures unchanged (cascade-delete heavy path)
  - insert.test, insert2.test, fkey1.test: 0 failures
  - trigger4 / trigger5: 100%
- Builds on #5493 (from-less SELECT in trigger body), #5486 (per-row interleave), #5550 (recursive_triggers); does not touch their logic.

Note: `trigger2.test` still aborts at section 3 (`do_test trigger2-3.1`) with a pre-existing `UPDATE OF c, d` parser "near c: syntax error" — unrelated to this fix (present identically on baseline), out of scope here.