### PR TITLE
fix(executor): UPDATE SET rowid intermediate-collision parity with sqlite3 (#5559)

### DIFF
--- a/crates/vibesql-executor/src/update/index_sync.rs
+++ b/crates/vibesql-executor/src/update/index_sync.rs
@@ -713,7 +713,10 @@ pub(super) fn validate_rowid_relocation(
     // empty, so we detect relocations by comparing the new rowid against the
     // row's original effective rowid (old_row.row_id, falling back to physical
     // index + 1).
-    let mut relocations: Vec<(usize, u64)> = Vec::new(); // (row_index, new_rowid)
+    //
+    // Each relocation is (old_rowid, new_rowid); old_rowid drives the processing
+    // order (see below).
+    let mut relocations: Vec<(u64, u64)> = Vec::new(); // (old_rowid, new_rowid)
     for u in updates {
         let new_rowid = match u.new_row.row_id {
             Some(id) => id,
@@ -721,45 +724,55 @@ pub(super) fn validate_rowid_relocation(
         };
         let old_rowid = u.old_row.row_id.unwrap_or((u.row_index + 1) as u64);
         if new_rowid != old_rowid {
-            relocations.push((u.row_index, new_rowid));
+            relocations.push((old_rowid, new_rowid));
         }
     }
     if relocations.is_empty() {
         return Ok(());
     }
 
-    // Set of rows participating in this UPDATE (their original slots are vacated
-    // — only their new rowid matters).
-    let updated_indices: HashSet<usize> = updates.iter().map(|u| u.row_index).collect();
+    // Row-by-row intermediate-collision check, matching sqlite3 3.51.0.
+    //
+    // sqlite3 does NOT defer rowid uniqueness to the final state: it processes
+    // the UPDATE one row at a time in ascending (old) rowid order and, as each
+    // row is relocated, requires the target rowid to be free *at that moment*.
+    // The live set at that moment includes:
+    //   - rows not yet processed (un-updated rows, and updated rows whose old
+    //     rowid sorts later), and
+    //   - rows already relocated earlier in this statement.
+    // A row that previously occupied the target but has already been relocated
+    // away does NOT collide. Verified against sqlite3 3.51.0:
+    //   * swap (1<->2) / N-cycle           -> UNIQUE constraint failed
+    //   * `SET rowid=rowid+1` (ascending)  -> error (1 collides with live 2)
+    //   * `SET rowid=rowid-1` (ascending)  -> ok (each old slot vacated first)
+    //   * relocate into a free gap         -> ok
+    //   * `SET rowid=rowid` (self no-op)   -> ok
+    //
+    // This is intentionally narrower than the deferred PK/UNIQUE model used for
+    // regular columns: it is rowid-specific to mirror sqlite3's immediate
+    // (non-deferred) rowid handling without changing constraint checking
+    // elsewhere.
+    //
+    // `occupied` starts as every live row's effective rowid (a row at physical
+    // index `i` has effective rowid `row.row_id.unwrap_or(i + 1)`, matching the
+    // read path). Updated rows that do NOT move keep their slot here untouched.
+    let mut occupied: HashSet<u64> =
+        table.scan_live().map(|(i, row)| row.row_id.unwrap_or((i + 1) as u64)).collect();
 
-    for &(row_index, new_rowid) in &relocations {
-        // Collision with an existing live row that is NOT part of this UPDATE.
-        for (idx, row) in table.scan_live() {
-            if updated_indices.contains(&idx) {
-                continue;
-            }
-            let existing_rowid = row.row_id.unwrap_or((idx + 1) as u64);
-            if existing_rowid == new_rowid {
-                return Err(ExecutorError::ConstraintViolation(format!(
-                    "UNIQUE constraint failed: {}.rowid",
-                    schema.name
-                )));
-            }
-        }
+    // Process relocations in ascending OLD-rowid order — sqlite3 visits rows in
+    // rowid order, so this reproduces its intermediate states (and the
+    // asymmetry between an ascending `+1` shift and a descending `-1` shift).
+    relocations.sort_unstable_by_key(|&(old_rowid, _)| old_rowid);
 
-        // Collision with another row's post-statement rowid (cross-update),
-        // e.g. two rows both relocated onto the same target.
-        for u in updates {
-            if u.row_index == row_index {
-                continue;
-            }
-            let other_new = u.new_row.row_id.unwrap_or((u.row_index + 1) as u64);
-            if other_new == new_rowid {
-                return Err(ExecutorError::ConstraintViolation(format!(
-                    "UNIQUE constraint failed: {}.rowid",
-                    schema.name
-                )));
-            }
+    for (old_rowid, new_rowid) in relocations {
+        // The row vacates its old slot before its new rowid is written.
+        occupied.remove(&old_rowid);
+        if !occupied.insert(new_rowid) {
+            // Target rowid is still occupied at this point in the statement.
+            return Err(ExecutorError::ConstraintViolation(format!(
+                "UNIQUE constraint failed: {}.rowid",
+                schema.name
+            )));
         }
     }
 

--- a/crates/vibesql-executor/src/update/tests/set_rowid.rs
+++ b/crates/vibesql-executor/src/update/tests/set_rowid.rs
@@ -121,6 +121,132 @@ fn set_rowid_conflict_errors() {
     assert_eq!(got, vec![(1, 1), (2, 2), (3, 3)]);
 }
 
+/// Single-statement rowid SWAP must error with `UNIQUE constraint failed:
+/// t.rowid` (issue #5559). sqlite3 3.51.0 processes the UPDATE row-by-row in
+/// ascending rowid order: relocating rowid 1 -> 2 collides with rowid 2, which
+/// is still live at that moment. The final state would be consistent, but
+/// sqlite3 checks the intermediate state, so this must be rejected.
+#[test]
+fn set_rowid_swap_errors_intermediate_collision() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE t(a)");
+    ddl(&mut db, "INSERT INTO t VALUES(10)"); // rowid 1
+    ddl(&mut db, "INSERT INTO t VALUES(20)"); // rowid 2
+
+    let err = update(
+        &mut db,
+        "UPDATE t SET rowid = CASE rowid WHEN 1 THEN 2 WHEN 2 THEN 1 END",
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: t.rowid"),
+        "expected rowid UNIQUE error for swap, got: {}",
+        err
+    );
+
+    // Table unchanged after the aborted UPDATE.
+    let rows = select(&mut db, "SELECT rowid, a FROM t ORDER BY rowid");
+    let got: Vec<(i64, i64)> =
+        rows.iter().map(|r| (int(&r.values[0]), int(&r.values[1]))).collect();
+    assert_eq!(got, vec![(1, 10), (2, 20)]);
+}
+
+/// A 3-cycle rotation (1->2, 2->3, 3->1) also errors: processed ascending,
+/// 1->2 collides with the still-live rowid 2. Matches sqlite3 3.51.0.
+#[test]
+fn set_rowid_three_cycle_errors() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE t(a)");
+    ddl(&mut db, "INSERT INTO t VALUES(10)");
+    ddl(&mut db, "INSERT INTO t VALUES(20)");
+    ddl(&mut db, "INSERT INTO t VALUES(30)");
+
+    let err = update(
+        &mut db,
+        "UPDATE t SET rowid = CASE rowid WHEN 1 THEN 2 WHEN 2 THEN 3 WHEN 3 THEN 1 END",
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: t.rowid"),
+        "expected rowid UNIQUE error for 3-cycle, got: {}",
+        err
+    );
+}
+
+/// `SET rowid = rowid + 1` over ascending rows cascade-collides: processed
+/// ascending, rowid 1 -> 2 collides with the still-live rowid 2. sqlite3 3.51.0
+/// errors (processing order matters; see the `-1` counterpart below).
+#[test]
+fn set_rowid_plus_one_cascade_errors() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE t(a)");
+    ddl(&mut db, "INSERT INTO t VALUES(10)");
+    ddl(&mut db, "INSERT INTO t VALUES(20)");
+    ddl(&mut db, "INSERT INTO t VALUES(30)");
+
+    let err = update(&mut db, "UPDATE t SET rowid = rowid + 1").unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: t.rowid"),
+        "expected rowid UNIQUE error for +1 cascade, got: {}",
+        err
+    );
+}
+
+/// `SET rowid = rowid - 1` over ascending rows succeeds: processed ascending,
+/// each row's old slot is vacated before the next row needs it (1->0, then
+/// 2->1 onto the now-free slot 1, ...). sqlite3 3.51.0 accepts this — the
+/// asymmetry with `+1` confirms the row-by-row ascending processing order.
+#[test]
+fn set_rowid_minus_one_cascade_ok() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE t(a)");
+    ddl(&mut db, "INSERT INTO t VALUES(10)");
+    ddl(&mut db, "INSERT INTO t VALUES(20)");
+    ddl(&mut db, "INSERT INTO t VALUES(30)");
+
+    assert_eq!(update(&mut db, "UPDATE t SET rowid = rowid - 1").unwrap(), 3);
+
+    let rows = select(&mut db, "SELECT rowid, a FROM t ORDER BY rowid");
+    let got: Vec<(i64, i64)> =
+        rows.iter().map(|r| (int(&r.values[0]), int(&r.values[1]))).collect();
+    assert_eq!(got, vec![(0, 10), (1, 20), (2, 30)]);
+}
+
+/// Relocating into a free gap (no collision at any intermediate step) succeeds.
+/// Matches sqlite3 3.51.0.
+#[test]
+fn set_rowid_move_to_gap_ok() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE t(a)");
+    ddl(&mut db, "INSERT INTO t VALUES(10)");
+    ddl(&mut db, "INSERT INTO t VALUES(20)");
+
+    assert_eq!(update(&mut db, "UPDATE t SET rowid = rowid + 100 WHERE rowid = 1").unwrap(), 1);
+
+    let rows = select(&mut db, "SELECT rowid, a FROM t ORDER BY rowid");
+    let got: Vec<(i64, i64)> =
+        rows.iter().map(|r| (int(&r.values[0]), int(&r.values[1]))).collect();
+    assert_eq!(got, vec![(2, 20), (101, 10)]);
+}
+
+/// `SET rowid = rowid` is a no-op for every row and must not error. Matches
+/// sqlite3 3.51.0.
+#[test]
+fn set_rowid_self_noop_ok() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE t(a)");
+    ddl(&mut db, "INSERT INTO t VALUES(10)");
+    ddl(&mut db, "INSERT INTO t VALUES(20)");
+    ddl(&mut db, "INSERT INTO t VALUES(30)");
+
+    assert_eq!(update(&mut db, "UPDATE t SET rowid = rowid").unwrap(), 3);
+
+    let rows = select(&mut db, "SELECT rowid, a FROM t ORDER BY rowid");
+    let got: Vec<(i64, i64)> =
+        rows.iter().map(|r| (int(&r.values[0]), int(&r.values[1]))).collect();
+    assert_eq!(got, vec![(1, 10), (2, 20), (3, 30)]);
+}
+
 /// On an INTEGER PRIMARY KEY table, `SET rowid=` writes the IPK column.
 #[test]
 fn set_rowid_aliases_ipk() {


### PR DESCRIPTION
Closes #5559

Follow-on from #5517 / #5556 (found by that PR's judge).

## Problem
A single-statement rowid SWAP — e.g. `UPDATE t SET rowid = CASE rowid WHEN 1 THEN 2 WHEN 2 THEN 1 END` — was ACCEPTED by VibeSQL (final state consistent, returns Ok) but sqlite3 3.51.0 REJECTS it with `UNIQUE constraint failed: t.rowid`. The deferred two-phase check from #5556 (`validate_rowid_relocation`) only inspected FINAL-state collision, so it missed the row-by-row INTERMEDIATE collision sqlite3 detects.

## Verified sqlite3 3.51.0 intermediate-collision rule
sqlite3 does **not** defer rowid uniqueness. It processes the UPDATE one row at a time **in ascending (old) rowid order**, and as each row relocates `old -> new` it requires `new` to be free **at that moment**. The live set at that moment includes rows not yet processed (un-updated rows + updated rows whose old rowid sorts later) AND rows already relocated earlier in the statement; a row that previously held `new` but has already moved away does not collide.

Modeled exactly as: `occupied = {all live rowids}`; for each relocation in ascending old-rowid order: `occupied.remove(old)`, then error if `new` already in `occupied`, else `occupied.insert(new)`.

Confirmed against `sqlite3 :memory:` (3.51.0):
| case | sqlite3 | reason |
|------|---------|--------|
| swap 1<->2 | error | 1->2 hits still-live 2 |
| 3-cycle 1->2->3->1 | error | 1->2 hits still-live 2 |
| `SET rowid=rowid+1` (asc rows) | error | 1->2 hits still-live 2 |
| `SET rowid=rowid-1` (asc rows) | ok | each old slot vacated before reuse |
| `SET rowid=rowid+2` over 1,2,3 | error | 1->3 hits still-live 3 |
| `SET rowid=N` two rows -> same N | error | second hits first's relocated slot |
| move row into free gap | ok | target never occupied |
| `SET rowid=rowid` (self no-op) | ok | no relocation |

The asymmetry between `+1` (error) and `-1` (ok) is the load-bearing proof that processing order is ascending rowid and the check is immediate, not deferred.

## Fix
`crates/vibesql-executor/src/update/index_sync.rs::validate_rowid_relocation`: replaced the final-state collision scan with the row-by-row occupied-set simulation above (sorted ascending by old rowid). Intentionally narrow — rowid-specific. Deferred PK/UNIQUE checking for regular columns (`validate_post_statement_uniqueness`) is untouched; INTEGER PRIMARY KEY tables still early-return to the PK path.

## Parity (new tests, `crates/vibesql-executor/src/update/tests/set_rowid.rs`)
- `set_rowid_swap_errors_intermediate_collision` — swap -> UNIQUE error, table unchanged
- `set_rowid_three_cycle_errors` — 3-cycle -> UNIQUE error
- `set_rowid_plus_one_cascade_errors` — `+1` cascade -> UNIQUE error
- `set_rowid_minus_one_cascade_ok` — `-1` cascade -> ok, asserts (0,1,2)
- `set_rowid_move_to_gap_ok` — relocate into gap -> ok
- `set_rowid_self_noop_ok` — `SET rowid=rowid` -> ok

## No regression
- All #5517 tests green: `set_rowid_relocates_row`, `set_underscore_rowid_alias`, `set_rowid_conflict_errors`, `set_rowid_aliases_ipk`, `set_rowid_ipk_conflict_errors`, `index_consistent_after_relocate`, `triggers_see_old_and_new_rowid`, `triggerc_7_5_relocate_in_before_trigger`.
- `cargo test -p vibesql-executor` green: lib 2823 passed / 0 failed (+6 new); integration suites all pass.
- `cargo clippy -p vibesql-executor` clean for changed files.

## Follow-ons
- IPK-alias swap (`UPDATE t SET id = CASE id WHEN 1 THEN 2 WHEN 2 THEN 1 END` on `INTEGER PRIMARY KEY`) has the same intermediate-vs-deferred class gap: sqlite3 errors `UNIQUE constraint failed: t.id` row-by-row, while VibeSQL's `validate_post_statement_uniqueness` is final-state deferred. Out of scope here (this PR is rowid-specific per the issue); worth a separate issue to align IPK/PK rowid-alias relocation with sqlite3's immediate semantics.

Do not merge yourself.