### PR TITLE
feat(storage): schema-aware spatial indexes — same-name cross-schema coexistence (#5558)

### DIFF
--- a/crates/vibesql-executor/src/drop_table.rs
+++ b/crates/vibesql-executor/src/drop_table.rs
@@ -84,8 +84,11 @@ impl DropTableExecutor {
             let qualified = format!("{}.{}", index.schema(), index.name);
             // Try to drop from B-tree storage (ignore errors if not found)
             let _ = database.drop_index(&qualified);
-            // Try to drop from spatial storage (ignore errors if not found)
-            let _ = database.drop_spatial_index(&index.name);
+            // Try to drop from spatial storage (ignore errors if not found).
+            // Spatial indexes are schema-aware (#5558), so use the
+            // schema-qualified name to drop exactly this index and leave a
+            // same-named index in another schema intact.
+            let _ = database.drop_spatial_index(&qualified);
         }
 
         // Drop the table from storage (this also removes from catalog)

--- a/crates/vibesql-executor/src/index_ddl/drop_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/drop_index.rs
@@ -52,10 +52,12 @@ impl DropIndexExecutor {
                 .drop_index(&qualified_table, index_name)
                 .map_err(|e| ExecutorError::Other(format!("Catalog error: {}", e)))?;
 
-            // Check if it's a spatial index in storage (spatial indexes are not
-            // yet schema-aware, so use the bare name)
-            if database.spatial_index_exists(index_name) {
-                database.drop_spatial_index(index_name)?;
+            // Check if it's a spatial index in storage. Spatial indexes are
+            // schema-aware too (#5558), so target the exact index via its
+            // owning schema — a temp index and a same-named main index drop
+            // independently, matching the B-tree path below.
+            if database.spatial_index_exists(&qualified_index) {
+                database.drop_spatial_index(&qualified_index)?;
             }
 
             // Check if it's a B-tree index in storage (schema-qualified)

--- a/crates/vibesql-executor/src/index_ddl/spatial_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/spatial_index.rs
@@ -80,11 +80,16 @@ pub fn create_spatial_index(
     .with_schema(super::schema_of_qualified(qualified_table_name));
     database.catalog.add_index(index_metadata)?;
 
-    // Store in database (use unqualified table name for storage metadata)
+    // Store in database (use unqualified table name for storage metadata).
+    // Tag the owning schema so a temp-table spatial index and a same-named
+    // main-table spatial index coexist as distinct storage entries (#5558),
+    // mirroring the B-tree schema-tagging in #5540. The schema is the same one
+    // the catalog records above.
     let metadata = SpatialIndexMetadata {
         index_name: index_name.clone(),
         table_name: table_name.to_string(),
         column_name: column_name.to_string(),
+        schema: super::schema_of_qualified(qualified_table_name).to_string(),
         created_at: Some(chrono::Utc::now()),
     };
 

--- a/crates/vibesql-executor/src/index_ddl/validation.rs
+++ b/crates/vibesql-executor/src/index_ddl/validation.rs
@@ -236,10 +236,9 @@ fn validate_prefix_lengths(
 
 /// Check if an index with the same name already exists in the target schema.
 ///
-/// Schema-aware (#5540): existence is scoped to `schema_name` (the resolved
-/// owning schema of the target table) so a `temp.i` index can be created while a
-/// `main.i` index already exists, matching SQLite. Spatial indexes remain a
-/// global namespace (they are not yet schema-aware in storage).
+/// Schema-aware (#5540 B-tree, #5558 spatial): existence is scoped to
+/// `schema_name` (the resolved owning schema of the target table) so a `temp.i`
+/// index can be created while a `main.i` index already exists, matching SQLite.
 fn check_index_exists(
     stmt: &CreateIndexStmt,
     database: &Database,
@@ -248,10 +247,11 @@ fn check_index_exists(
     let index_name = &stmt.index_name;
     // Probe the exact schema's index via a schema-qualified lookup. A
     // main-schema index keeps a bare storage key, which the storage resolver
-    // also reaches through the `main.i` qualifier.
+    // also reaches through the `main.i` qualifier. Spatial indexes are
+    // schema-aware too (#5558), so scope their check to the same qualifier.
     let qualified = format!("{}.{}", schema_name, index_name);
     let index_exists =
-        database.get_index(&qualified).is_some() || database.spatial_index_exists(index_name);
+        database.get_index(&qualified).is_some() || database.spatial_index_exists(&qualified);
 
     if index_exists {
         if stmt.if_not_exists {
@@ -300,7 +300,7 @@ pub fn index_already_exists(stmt: &CreateIndexStmt, database: &Database) -> bool
     };
 
     let qualified = format!("{}.{}", schema_name, index_name);
-    database.get_index(&qualified).is_some() || database.spatial_index_exists(index_name)
+    database.get_index(&qualified).is_some() || database.spatial_index_exists(&qualified)
 }
 
 /// Validate that all column references in an expression exist in the table schema.

--- a/crates/vibesql-executor/src/select/executor/index_optimization/spatial.rs
+++ b/crates/vibesql-executor/src/select/executor/index_optimization/spatial.rs
@@ -163,8 +163,14 @@ fn try_detect_spatial_predicate(
     // Compute MBR from query geometry
     let query_mbr = compute_mbr(&query_geometry, &predicate)?;
 
+    // Build a schema-qualified lookup name so the two-phase lookup targets the
+    // exact spatial index that matched here, even when a same-named index
+    // exists in another schema (spatial indexes are schema-aware — #5558).
+    // `get_spatial_index` resolves an explicit `schema.index` form precisely.
+    let index_name = format!("{}.{}", metadata.schema, metadata.index_name);
+
     Ok(Some(SpatialIndexUsage {
-        index_name: metadata.index_name.clone(),
+        index_name,
         column_name: column_name.clone(),
         predicate,
         query_mbr,

--- a/crates/vibesql-executor/tests/spatial_index_tests.rs
+++ b/crates/vibesql-executor/tests/spatial_index_tests.rs
@@ -1,9 +1,12 @@
 //! Integration tests for spatial indexes
 
 use vibesql_ast::{ColumnDef, CreateIndexStmt, CreateTableStmt, IndexColumn, OrderDirection};
-use vibesql_executor::{CreateIndexExecutor, CreateTableExecutor, DropIndexExecutor};
+use vibesql_executor::{
+    CreateIndexExecutor, CreateTableExecutor, DropIndexExecutor, SelectExecutor,
+};
+use vibesql_parser::Parser;
 use vibesql_storage::Database;
-use vibesql_types::DataType;
+use vibesql_types::{DataType, SqlValue};
 
 #[test]
 fn test_create_spatial_index_basic() {
@@ -281,4 +284,117 @@ fn test_spatial_index_if_not_exists() {
 
     let result = CreateIndexExecutor::execute(&create_index_stmt2, &mut db);
     assert!(result.is_ok(), "IF NOT EXISTS should succeed");
+}
+
+// ============================================================================
+// #5558: spatial indexes are schema-aware (same-name cross-schema coexistence)
+// ============================================================================
+
+fn run(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse `{sql}`: {e}"));
+    match stmt {
+        vibesql_ast::Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).unwrap_or_else(|e| panic!("`{sql}`: {e}"));
+        }
+        vibesql_ast::Statement::CreateIndex(s) => {
+            CreateIndexExecutor::execute(&s, db).unwrap_or_else(|e| panic!("`{sql}`: {e}"));
+        }
+        vibesql_ast::Statement::DropIndex(s) => {
+            DropIndexExecutor::execute(&s, db).unwrap_or_else(|e| panic!("`{sql}`: {e}"));
+        }
+        vibesql_ast::Statement::Insert(s) => {
+            vibesql_executor::InsertExecutor::execute(db, &s)
+                .unwrap_or_else(|e| panic!("`{sql}`: {e}"));
+        }
+        other => panic!("unexpected statement for `{sql}`: {other:?}"),
+    }
+}
+
+/// Pull `name` (column 0) strings out of a SELECT result.
+fn index_names(db: &Database, sql: &str) -> Vec<String> {
+    let stmt = Parser::parse_sql(sql).expect("parse SELECT");
+    let vibesql_ast::Statement::Select(s) = stmt else { panic!("expected SELECT") };
+    let r = SelectExecutor::new(db).execute_with_columns(&s).expect("SELECT");
+    r.rows
+        .iter()
+        .map(|row| match &row.values[0] {
+            SqlValue::Varchar(s) | SqlValue::Character(s) => s.to_string(),
+            other => panic!("expected text name, got {other:?}"),
+        })
+        .collect()
+}
+
+/// #5558 (mirrors #5540's `..._coexist` for B-tree): a SPATIAL index named `ix`
+/// in `main` and a SPATIAL index named `ix` in a temp schema must coexist as
+/// distinct storage entries, both usable, with unqualified `DROP INDEX`
+/// resolving temp-shadows-main — matching the schema-aware B-tree behavior.
+#[test]
+fn same_named_spatial_index_across_schemas_coexist() {
+    let mut db = Database::new();
+
+    // Same-named table in main and temp, each with a geometry column.
+    run(&mut db, "CREATE TABLE main_t (id INTEGER, g VARCHAR(200))");
+    run(&mut db, "CREATE TEMP TABLE temp_t (id INTEGER, g VARCHAR(200))");
+
+    // Distinct geometry data so each index is observably populated from its
+    // own table. extract_mbr_from_sql_value accepts raw WKT.
+    run(&mut db, "INSERT INTO main_t VALUES (1, 'POINT(1 1)')");
+    run(&mut db, "INSERT INTO main_t VALUES (2, 'POINT(2 2)')");
+    run(&mut db, "INSERT INTO temp.temp_t VALUES (10, 'POINT(50 50)')");
+
+    // Both CREATE SPATIAL INDEX with the bare name `ix` must succeed: main.ix
+    // and temp.ix are distinct objects (previously the second collided).
+    run(&mut db, "CREATE SPATIAL INDEX ix ON main_t(g)");
+    run(&mut db, "CREATE SPATIAL INDEX ix ON temp_t(g)");
+
+    // Both indexes are registered in their respective schemas' master tables.
+    assert!(
+        index_names(&db, "SELECT name FROM sqlite_master WHERE type='index'")
+            .contains(&"ix".to_string()),
+        "main.ix must be in sqlite_master"
+    );
+    assert!(
+        index_names(&db, "SELECT name FROM sqlite_temp_master WHERE type='index'")
+            .contains(&"ix".to_string()),
+        "temp.ix must be in sqlite_temp_master"
+    );
+
+    // Both spatial indexes coexist in storage and are reachable via their
+    // schema-qualified names with their own contents (no cross-schema leakage).
+    let main_ix = db.get_spatial_index("main.ix").expect("main.ix in storage");
+    assert_eq!(main_ix.len(), 2, "main.ix indexes both main_t rows");
+    // main.ix contains the main_t points, not temp_t's far-away point.
+    assert_eq!(main_ix.locate_at_point(&[1.0, 1.0]).len(), 1, "main.ix has POINT(1 1)");
+    assert!(main_ix.locate_at_point(&[50.0, 50.0]).is_empty(), "main.ix has no temp point");
+
+    // Temp schema name is session-specific; resolve via the catalog.
+    let temp_qualified = format!("{}.ix", db.catalog.temp_schema_name());
+    let temp_ix = db.get_spatial_index(&temp_qualified).expect("temp.ix in storage");
+    assert_eq!(temp_ix.len(), 1, "temp.ix indexes the single temp_t row");
+    assert_eq!(temp_ix.locate_at_point(&[50.0, 50.0]).len(), 1, "temp.ix has POINT(50 50)");
+    assert!(temp_ix.locate_at_point(&[1.0, 1.0]).is_empty(), "temp.ix has no main point");
+
+    // Unqualified DROP INDEX resolves temp-shadows-main: drops temp.ix, leaves
+    // main.ix intact.
+    run(&mut db, "DROP INDEX ix");
+    assert!(
+        !index_names(&db, "SELECT name FROM sqlite_temp_master WHERE type='index'")
+            .contains(&"ix".to_string()),
+        "unqualified DROP INDEX must remove the temp spatial index first"
+    );
+    assert!(
+        index_names(&db, "SELECT name FROM sqlite_master WHERE type='index'")
+            .contains(&"ix".to_string()),
+        "main.ix must survive an unqualified DROP INDEX that resolved to temp.ix"
+    );
+    assert!(db.get_spatial_index("main.ix").is_some(), "main.ix storage entry survives");
+
+    // A second unqualified DROP INDEX now removes main.ix.
+    run(&mut db, "DROP INDEX ix");
+    assert!(
+        !index_names(&db, "SELECT name FROM sqlite_master WHERE type='index'")
+            .contains(&"ix".to_string()),
+        "the second DROP INDEX removes the remaining main spatial index"
+    );
+    assert!(!db.spatial_index_exists("ix"), "no spatial index named ix remains");
 }

--- a/crates/vibesql-storage/src/database/operations.rs
+++ b/crates/vibesql-storage/src/database/operations.rs
@@ -19,7 +19,31 @@ pub struct SpatialIndexMetadata {
     pub index_name: String,
     pub table_name: String,
     pub column_name: String,
+    /// Owning schema of this index (e.g. `main` or a session temp schema like
+    /// `temp_42`). Stored so a temp-table spatial index and a main-table spatial
+    /// index can share a bare name without colliding in the `spatial_indexes`
+    /// map — mirroring the B-tree change in #5540 (storage) / #5513 (catalog).
+    /// See issue #5558.
+    pub schema: String,
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Build the storage key used to key spatial indexes in the `spatial_indexes`
+/// map.
+///
+/// Mirrors the B-tree `make_index_key` introduced in #5540: a `main`-schema
+/// spatial index keeps a *bare* (normalized) key so the common case is
+/// byte-for-byte backward compatible, while a non-`main` (e.g. session temp)
+/// schema gets a `schema.name` prefix. This lets `main.ix` and `temp.ix`
+/// coexist as distinct spatial indexes — matching SQLite and the B-tree
+/// behavior. See issue #5558.
+fn make_spatial_index_key(schema: &str, index_name: &str) -> String {
+    let normalized_name = index_name.to_lowercase();
+    if schema.eq_ignore_ascii_case(vibesql_catalog::DEFAULT_SCHEMA) {
+        normalized_name
+    } else {
+        format!("{}.{}", schema.to_lowercase(), normalized_name)
+    }
 }
 
 /// Manages table and index operations
@@ -28,7 +52,8 @@ pub struct Operations {
     /// User-defined index manager (B-tree indexes)
     index_manager: IndexManager,
     /// Spatial indexes (R-tree) - stored separately from B-tree indexes
-    /// Key: normalized index name (uppercase)
+    /// Key: schema-aware index key (bare normalized name for the `main` schema,
+    ///   `schema.name` for non-`main` schemas — see [`make_spatial_index_key`])
     /// Value: (metadata, spatial index)
     spatial_indexes: HashMap<String, (SpatialIndexMetadata, SpatialIndex)>,
 }
@@ -981,22 +1006,65 @@ impl Operations {
         name.to_lowercase()
     }
 
+    /// Resolve a (possibly bare) spatial-index name to the map key it is stored
+    /// under, following SQLite name resolution.
+    ///
+    /// Mirrors the B-tree `IndexManager::resolve_index_key` from #5540: an
+    /// explicit `schema.index` form targets exactly that schema's index; an
+    /// unqualified lookup prefers a non-`main` (temp) schema index over a
+    /// same-named `main` index (temp shadows main), so `DROP INDEX ix` resolves
+    /// to `temp.ix` when both exist. See issue #5558.
+    fn resolve_spatial_index_key(&self, index_name: &str) -> Option<String> {
+        // Explicit schema-qualified form: target exactly that schema's index.
+        if let Some((schema_part, name_part)) = index_name.split_once('.') {
+            let key = make_spatial_index_key(schema_part, name_part);
+            if self.spatial_indexes.contains_key(&key) {
+                return Some(key);
+            }
+            // Fall through: maybe the caller passed a dotted *index name* (rare)
+            // rather than a schema qualifier; try the whole thing as a bare name.
+        }
+
+        let normalized = Self::normalize_index_name(index_name);
+
+        // Temp schema shadows main: prefer a non-main-schema index with this name.
+        if let Some((key, _)) = self.spatial_indexes.iter().find(|(_, (meta, _))| {
+            !meta.schema.eq_ignore_ascii_case(vibesql_catalog::DEFAULT_SCHEMA)
+                && Self::normalize_index_name(&meta.index_name) == normalized
+        }) {
+            return Some(key.clone());
+        }
+
+        // Otherwise the main-schema (bare) key.
+        if self.spatial_indexes.contains_key(&normalized) {
+            return Some(normalized);
+        }
+
+        None
+    }
+
     /// Create a spatial index
     pub fn create_spatial_index(
         &mut self,
         metadata: SpatialIndexMetadata,
         spatial_index: SpatialIndex,
     ) -> Result<(), StorageError> {
-        let normalized_name = Self::normalize_index_name(&metadata.index_name);
+        // Schema-aware storage key (#5558): bare for `main`, `schema.name`
+        // otherwise — so a temp-table spatial index and a same-named main-table
+        // spatial index coexist as distinct entries.
+        let key = make_spatial_index_key(&metadata.schema, &metadata.index_name);
 
-        if self.index_manager.index_exists(&metadata.index_name) {
+        // Collision check is scoped to the owning schema: an existing B-tree or
+        // spatial index *in the same schema* blocks creation, but a same-named
+        // index in another schema does not.
+        if self.index_manager.index_exists(&key) {
             return Err(StorageError::IndexAlreadyExists(metadata.index_name.clone()));
         }
-        if self.spatial_indexes.contains_key(&normalized_name) {
+        if self.spatial_indexes.contains_key(&key) {
             return Err(StorageError::IndexAlreadyExists(metadata.index_name.clone()));
         }
 
-        self.spatial_indexes.insert(normalized_name, (metadata, spatial_index));
+        self.spatial_indexes.insert(key, (metadata, spatial_index));
         Ok(())
     }
 
@@ -1244,26 +1312,25 @@ impl Operations {
 
     /// Check if a spatial index exists
     pub fn spatial_index_exists(&self, index_name: &str) -> bool {
-        let normalized = Self::normalize_index_name(index_name);
-        self.spatial_indexes.contains_key(&normalized)
+        self.resolve_spatial_index_key(index_name).is_some()
     }
 
     /// Get spatial index metadata
     pub fn get_spatial_index_metadata(&self, index_name: &str) -> Option<&SpatialIndexMetadata> {
-        let normalized = Self::normalize_index_name(index_name);
-        self.spatial_indexes.get(&normalized).map(|(metadata, _)| metadata)
+        let key = self.resolve_spatial_index_key(index_name)?;
+        self.spatial_indexes.get(&key).map(|(metadata, _)| metadata)
     }
 
     /// Get spatial index (immutable)
     pub fn get_spatial_index(&self, index_name: &str) -> Option<&SpatialIndex> {
-        let normalized = Self::normalize_index_name(index_name);
-        self.spatial_indexes.get(&normalized).map(|(_, index)| index)
+        let key = self.resolve_spatial_index_key(index_name)?;
+        self.spatial_indexes.get(&key).map(|(_, index)| index)
     }
 
     /// Get spatial index (mutable)
     pub fn get_spatial_index_mut(&mut self, index_name: &str) -> Option<&mut SpatialIndex> {
-        let normalized = Self::normalize_index_name(index_name);
-        self.spatial_indexes.get_mut(&normalized).map(|(_, index)| index)
+        let key = self.resolve_spatial_index_key(index_name)?;
+        self.spatial_indexes.get_mut(&key).map(|(_, index)| index)
     }
 
     /// Get all spatial indexes for a specific table
@@ -1292,9 +1359,13 @@ impl Operations {
 
     /// Drop a spatial index
     pub fn drop_spatial_index(&mut self, index_name: &str) -> Result<(), StorageError> {
-        let normalized = Self::normalize_index_name(index_name);
+        // Resolve schema-aware (#5558): an unqualified name drops the temp index
+        // first (temp shadows main); an explicit `schema.index` targets exactly.
+        let Some(key) = self.resolve_spatial_index_key(index_name) else {
+            return Err(StorageError::IndexNotFound(index_name.to_string()));
+        };
 
-        if self.spatial_indexes.remove(&normalized).is_none() {
+        if self.spatial_indexes.remove(&key).is_none() {
             return Err(StorageError::IndexNotFound(index_name.to_string()));
         }
 
@@ -1610,5 +1681,85 @@ impl Operations {
 impl Default for Operations {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod spatial_schema_tests {
+    use super::*;
+    use crate::index::SpatialIndex;
+
+    fn meta(index: &str, table: &str, schema: &str) -> SpatialIndexMetadata {
+        SpatialIndexMetadata {
+            index_name: index.to_string(),
+            table_name: table.to_string(),
+            column_name: "g".to_string(),
+            schema: schema.to_string(),
+            created_at: None,
+        }
+    }
+
+    /// #5558: a same-named spatial index in `main` and in a temp schema coexist
+    /// as distinct storage entries, mirroring the B-tree behavior from #5540.
+    #[test]
+    fn same_named_spatial_index_across_schemas_coexist() {
+        let mut ops = Operations::new();
+
+        ops.create_spatial_index(meta("ix", "t", "main"), SpatialIndex::new("g".to_string()))
+            .expect("create main.ix");
+        // Same bare name on a temp-schema table must NOT collide with main.ix.
+        ops.create_spatial_index(
+            meta("ix", "t", "temp_42"),
+            SpatialIndex::new("g".to_string()),
+        )
+        .expect("create temp_42.ix should not collide with main.ix");
+
+        // Both keys are present: bare `ix` (main) and `temp_42.ix` (temp).
+        let keys = ops.list_spatial_indexes();
+        assert!(keys.contains(&"ix".to_string()), "main.ix keyed bare: {keys:?}");
+        assert!(keys.contains(&"temp_42.ix".to_string()), "temp.ix keyed qualified: {keys:?}");
+
+        // Explicit schema-qualified lookups target each one precisely.
+        assert_eq!(ops.get_spatial_index_metadata("main.ix").unwrap().schema, "main");
+        assert_eq!(ops.get_spatial_index_metadata("temp_42.ix").unwrap().schema, "temp_42");
+    }
+
+    /// An unqualified lookup/drop resolves temp-shadows-main (#5558), matching
+    /// the B-tree `resolve_index_key` semantics.
+    #[test]
+    fn unqualified_spatial_lookup_and_drop_resolves_temp_first() {
+        let mut ops = Operations::new();
+        ops.create_spatial_index(meta("ix", "t", "main"), SpatialIndex::new("g".to_string()))
+            .unwrap();
+        ops.create_spatial_index(
+            meta("ix", "t", "temp_42"),
+            SpatialIndex::new("g".to_string()),
+        )
+        .unwrap();
+
+        // Bare name resolves to the temp index (temp shadows main).
+        assert_eq!(ops.get_spatial_index_metadata("ix").unwrap().schema, "temp_42");
+
+        // Unqualified DROP removes the temp index first; main.ix survives.
+        ops.drop_spatial_index("ix").expect("drop resolves temp.ix");
+        assert!(!ops.spatial_index_exists("temp_42.ix"), "temp.ix dropped");
+        assert!(ops.spatial_index_exists("main.ix"), "main.ix survives");
+        assert_eq!(ops.get_spatial_index_metadata("ix").unwrap().schema, "main");
+
+        // A second unqualified DROP now removes main.ix.
+        ops.drop_spatial_index("ix").expect("drop resolves main.ix");
+        assert!(!ops.spatial_index_exists("ix"));
+        assert!(ops.list_spatial_indexes().is_empty());
+    }
+
+    /// Main-schema spatial indexes keep their bare key (backward compatible).
+    #[test]
+    fn main_schema_spatial_index_uses_bare_key() {
+        let mut ops = Operations::new();
+        ops.create_spatial_index(meta("loc", "places", "main"), SpatialIndex::new("g".to_string()))
+            .unwrap();
+        assert_eq!(ops.list_spatial_indexes(), vec!["loc".to_string()]);
+        assert!(ops.spatial_index_exists("loc"));
+        assert!(ops.spatial_index_exists("main.loc"));
     }
 }

--- a/crates/vibesql-storage/src/database/tests/reset_catalog.rs
+++ b/crates/vibesql-storage/src/database/tests/reset_catalog.rs
@@ -150,6 +150,7 @@ fn test_reset_clears_spatial_indexes() {
         index_name: "idx_locations_point".to_string(),
         table_name: "locations".to_string(),
         column_name: "point".to_string(),
+        schema: "main".to_string(),
         created_at: None,
     };
     let spatial_index = SpatialIndex::new("point".to_string());
@@ -186,6 +187,7 @@ fn test_reset_clears_spatial_indexes() {
         index_name: "idx_locations_point".to_string(),
         table_name: "locations".to_string(),
         column_name: "point".to_string(),
+        schema: "main".to_string(),
         created_at: None,
     };
     let spatial_index2 = SpatialIndex::new("point".to_string());


### PR DESCRIPTION
## Summary
Closes #5558

Follow-on from #5540 (PR #5555), which made the **B-tree** storage `IndexManager` schema-aware (keyed `schema.index` for non-`main`, bare for `main`; `make_index_key`/`resolve_index_key` with temp-shadows-main) but explicitly left **spatial** (R-tree) indexes in a single global name namespace. This applies the same schema-tagging to spatial indexes so a spatial index named `ix` can coexist across schemas (main vs temp), matching sqlite3 and the B-tree behavior.

## The spatial schema-tagging change (mirroring #5540)
- `SpatialIndexMetadata` (vibesql-storage `operations.rs`) gains a `schema` field. The `spatial_indexes` map key becomes schema-aware via a new `make_spatial_index_key(schema, name)` — a **bare** normalized key for the `main` schema (byte-for-byte backward compatible) and `schema.name` for non-`main` (session temp) schemas. A temp-table spatial index and a same-named main-table spatial index are therefore distinct entries.
- New `resolve_spatial_index_key` mirrors the B-tree `resolve_index_key`: an explicit `schema.index` form targets exactly that schema's index; an unqualified lookup prefers a non-`main` (temp) index over a same-named `main` index (temp shadows main). `spatial_index_exists`, `get_spatial_index`/`_metadata`/`_mut`, and `drop_spatial_index` all route through it.
- Executor:
  - `create_spatial_index` tags the owning schema via `schema_of_qualified(qualified_table_name)` — the same schema the catalog records (#5513).
  - CREATE INDEX validation (`check_index_exists` / `index_already_exists`) scopes the spatial existence check to the target schema (`schema.index`) so a temp spatial index can be created alongside a same-named main one.
  - `DROP INDEX` and `DROP TABLE`'s index cascade drop the spatial index by its owning schema (schema-qualified), so a temp index and a same-named main index drop independently; an unqualified `DROP INDEX` resolves temp-shadows-main.
  - The spatial query optimizer looks the matched index up by its schema-qualified name, avoiding wrong-schema resolution when same-named indexes coexist.

## Coexistence parity (sqlite3 / #5540 B-tree)
```sql
CREATE TABLE main_t(id, g); CREATE TEMP TABLE temp_t(id, g);
CREATE SPATIAL INDEX ix ON main_t(g);   -- main.ix
CREATE SPATIAL INDEX ix ON temp_t(g);   -- temp.ix  (now succeeds, was rejected)
```
Both spatial indexes coexist (one in `sqlite_master`, one in `sqlite_temp_master`), both are usable with no cross-schema leakage, and an unqualified `DROP INDEX ix` removes the temp index first, leaving `main.ix` intact — matching the schema-aware B-tree behavior from #5540.

## Persistence
No serialized-format change: spatial indexes are recovered by re-executing the `CREATE INDEX` statement on load, which re-derives the owning schema from the catalog-qualified table — so the schema tag is re-established on recovery.

## Tests
- Storage unit tests (`operations.rs::spatial_schema_tests`): same-named coexistence across `main`/`temp`, unqualified lookup/drop resolves temp-first, main-schema keeps a bare key.
- Executor integration test (`spatial_index_tests.rs::same_named_spatial_index_across_schemas_coexist`), mirroring #5540's B-tree `..._coexist`: both registered in their master tables, both spatial indexes populated from their own table (verified via the R-tree), no cross-schema leakage, and correct temp-shadows-main DROP resolution.

## No-regression results
- `cargo test -p vibesql-storage`: 702 lib + integration/doc green (incl. new `spatial_schema_tests`).
- `cargo test -p vibesql-catalog`: 48 green.
- `cargo test -p vibesql-executor --lib`: 2817 passed, 2 ignored.
- Integration: `spatial_index_tests` (5), `spatial_function/operations/measurements/set_operations_tests`, `sqlite_temp_master_tests` (13, incl. #5540 `..._coexist`), `partial_index_tests`, `index_ordering_tests`, `mvcc_index_scan_tests`, `temporal_index_probe_tests` — all green.
- `cargo clippy -p vibesql-storage -p vibesql-executor`: no new warnings on the changed code (pre-existing warnings unchanged).

## Test plan
- [ ] `cargo test -p vibesql-storage -p vibesql-executor`
- [ ] `CREATE SPATIAL INDEX ix ON main_t(g); CREATE SPATIAL INDEX ix ON temp_t(g);` both succeed and `DROP INDEX ix` resolves temp-first

## Follow-ons
- Other non-B-tree index types: IVFFlat/HNSW vector indexes are managed inside the B-tree `IndexManager` (already schema-aware via #5540's keying). No remaining global-namespace index type identified; worth a dedicated follow-on only if a future non-B-tree type is added outside the schema-aware paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)