### PR TITLE
fix(parser): accept unparenthesized UPDATE OF column list (trigger2-3.1)

### DIFF
--- a/crates/vibesql-catalog/src/store/advanced/triggers.rs
+++ b/crates/vibesql-catalog/src/store/advanced/triggers.rs
@@ -56,7 +56,14 @@ impl super::super::Catalog {
         self.triggers.values().filter(move |trigger| {
             // Case-insensitive table name matching (SQLite-compatible)
             trigger.table_name.eq_ignore_ascii_case(table_name)
-                && event.as_ref().is_none_or(|e| trigger.event == *e)
+                // Match by event *kind* (INSERT / UPDATE / DELETE), not by exact
+                // value. An `UPDATE OF c, d` trigger has event
+                // `Update(Some([c, d]))`, but the executor dispatches the generic
+                // `Update(None)` event for every UPDATE; comparing for equality
+                // would never match column-list triggers, so they would never
+                // fire (issue #5577). The column-list firing restriction is
+                // applied later by `should_fire_update_of`.
+                && event.as_ref().is_none_or(|e| event_kind_matches(&trigger.event, e))
         })
     }
 
@@ -73,6 +80,21 @@ impl super::super::Catalog {
     pub fn has_any_triggers(&self) -> bool {
         !self.triggers.is_empty()
     }
+}
+
+/// Compare two trigger events by *kind* (INSERT / UPDATE / DELETE), ignoring an
+/// UPDATE's optional `OF <columns>` list.
+///
+/// The executor dispatches the generic `Update(None)` event for every UPDATE,
+/// while a column-list trigger is stored as `Update(Some([...]))`. Matching by
+/// kind lets such triggers be discovered; the per-row column-list restriction is
+/// enforced separately by the executor's `should_fire_update_of`.
+fn event_kind_matches(a: &vibesql_ast::TriggerEvent, b: &vibesql_ast::TriggerEvent) -> bool {
+    use vibesql_ast::TriggerEvent::*;
+    matches!(
+        (a, b),
+        (Insert, Insert) | (Update(_), Update(_)) | (Delete, Delete)
+    )
 }
 
 #[cfg(test)]

--- a/crates/vibesql-executor/src/tests/triggers/update.rs
+++ b/crates/vibesql-executor/src/tests/triggers/update.rs
@@ -168,6 +168,93 @@ fn test_before_update_trigger_fires() {
     assert_eq!(count_audit_rows(&db), 1);
 }
 
+/// Issue #5577: `UPDATE OF <col>` firing-restriction semantics.
+///
+/// An `AFTER UPDATE OF username` trigger must fire only when the listed column
+/// actually changes value. Updating an unlisted column (`id`) — or writing the
+/// same value back to `username` — must NOT fire it. This exercises the parse
+/// fix (unparenthesized column list) end-to-end together with the executor's
+/// `should_fire_update_of` restriction.
+#[test]
+fn test_update_of_fires_only_for_listed_column() {
+    let mut db = Database::new();
+    create_users_table(&mut db);
+    create_audit_table(&mut db);
+
+    // Seed one user.
+    let insert = vibesql_ast::InsertStmt {
+        with_clause: None,
+        schema_name: None,
+        schema_quoted: false,
+        table_quoted: false,
+        table_name: "USERS".to_string(),
+        columns: vec!["id".to_string(), "username".to_string()],
+        source: vibesql_ast::InsertSource::Values(vec![vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("alice"),
+            )),
+        ]]),
+        conflict_clause: None,
+        on_conflict: None,
+        on_duplicate_key_update: None,
+        returning: None,
+    };
+    InsertExecutor::execute(&mut db, &insert).expect("Failed to insert");
+
+    // Parse the trigger with the standard unparenthesized column list to make
+    // sure the parse fix and executor agree on the column.
+    let trigger_stmt = match Parser::parse_sql(
+        "CREATE TRIGGER log_username AFTER UPDATE OF username ON USERS \
+         BEGIN INSERT INTO audit_log (event) VALUES ('username changed'); END;",
+    )
+    .expect("Failed to parse UPDATE OF trigger")
+    {
+        Statement::CreateTrigger(t) => t,
+        other => panic!("Expected CreateTrigger, got {other:?}"),
+    };
+    assert_eq!(trigger_stmt.event, TriggerEvent::Update(Some(vec!["username".to_string()])));
+    crate::advanced_objects::execute_create_trigger(&trigger_stmt, &mut db)
+        .expect("Failed to create trigger");
+
+    // Helper: UPDATE one column of user id=1 to `value`.
+    let update_col = |db: &mut Database, column: &str, value: vibesql_types::SqlValue| {
+        let update = vibesql_ast::UpdateStmt {
+            with_clause: None,
+            quoted: false,
+            alias: None,
+            table_name: "USERS".to_string(),
+            assignments: vec![vibesql_ast::Assignment {
+                column: column.to_string(),
+                value: vibesql_ast::Expression::Literal(value),
+            }],
+            from_clause: None,
+            where_clause: Some(vibesql_ast::WhereClause::Condition(
+                vibesql_ast::Expression::BinaryOp {
+                    op: vibesql_ast::BinaryOperator::Equal,
+                    left: Box::new(vibesql_ast::Expression::ColumnRef(
+                        vibesql_ast::ColumnIdentifier::simple("id", false),
+                    )),
+                    right: Box::new(vibesql_ast::Expression::Literal(
+                        vibesql_types::SqlValue::Integer(1),
+                    )),
+                },
+            )),
+            conflict_clause: None,
+            returning: None,
+        };
+        UpdateExecutor::execute(&update, db).expect("Failed to update");
+    };
+
+    // Updating an unlisted column (id) must NOT fire the trigger.
+    update_col(&mut db, "id", SqlValue::Integer(1));
+    assert_eq!(count_audit_rows(&db), 0, "UPDATE OF must not fire for unlisted column");
+
+    // Updating the listed column to a new value MUST fire the trigger.
+    update_col(&mut db, "username", SqlValue::Varchar(arcstr::ArcStr::from("bob")));
+    assert_eq!(count_audit_rows(&db), 1, "UPDATE OF must fire when listed column changes");
+}
+
 /// Issue #5192 (triggerupfrom-4.3 regression):
 ///
 /// UPDATE...FROM that targets a VIEW with an INSTEAD OF UPDATE trigger must

--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -115,9 +115,23 @@ impl Parser {
             vibesql_ast::TriggerEvent::Insert
         } else if self.try_consume_keyword(Keyword::Update) {
             // Check for optional OF column_list
+            //
+            // Standard SQLite (3.51.0) uses an UNPARENTHESIZED comma-separated
+            // column list terminated by ON:
+            //   CREATE TRIGGER tr AFTER UPDATE OF c, d ON tbl ...
+            // SQLite itself rejects the parenthesized form `UPDATE OF (c, d)`.
+            // VibeSQL accepts BOTH: the standard unparenthesized form for
+            // conformance (trigger2-3.x), and the parenthesized form as a
+            // lenient extension (it was previously the only accepted form).
             let columns = if self.try_consume_keyword(Keyword::Of) {
                 let mut cols = Vec::new();
-                self.expect_token(Token::LParen)?;
+                // Optional opening paren (lenient extension; not valid SQLite).
+                let has_paren = if matches!(self.peek(), Token::LParen) {
+                    self.advance();
+                    true
+                } else {
+                    false
+                };
                 loop {
                     let col = self.parse_identifier()?;
                     cols.push(col);
@@ -128,7 +142,11 @@ impl Parser {
                         break;
                     }
                 }
-                self.expect_token(Token::RParen)?;
+                if has_paren {
+                    self.expect_token(Token::RParen)?;
+                }
+                // For the unparenthesized form the column list runs until ON,
+                // which is consumed by `expect_keyword(On)` further below.
                 Some(cols)
             } else {
                 None

--- a/crates/vibesql-parser/src/tests/trigger.rs
+++ b/crates/vibesql-parser/src/tests/trigger.rs
@@ -168,7 +168,9 @@ fn test_create_trigger_with_when_condition() {
 
 #[test]
 fn test_create_trigger_update_of_columns() {
-    let sql = "CREATE TRIGGER my_trigger BEFORE UPDATE OF (col1, col2) ON my_table BEGIN END;";
+    // Standard SQLite (3.51.0): UNPARENTHESIZED comma-separated column list,
+    // terminated by ON (trigger2-3.1). This is the canonical form.
+    let sql = "CREATE TRIGGER my_trigger BEFORE UPDATE OF col1, col2 ON my_table BEGIN END;";
     let result = Parser::parse_sql(sql);
     assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
 
@@ -185,6 +187,65 @@ fn test_create_trigger_update_of_columns() {
                 _ => panic!("Expected UPDATE OF with columns"),
             }
         }
+        _ => panic!("Expected CreateTrigger statement"),
+    }
+}
+
+#[test]
+fn test_create_trigger_update_of_single_column() {
+    // Single unparenthesized column (sqlite3 accepts `UPDATE OF c`).
+    let sql = "CREATE TRIGGER tr AFTER UPDATE OF c ON tbl BEGIN END;";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        Statement::CreateTrigger(trigger) => match &trigger.event {
+            TriggerEvent::Update(Some(cols)) => {
+                assert_eq!(cols, &vec!["c".to_string()]);
+            }
+            other => panic!("Expected UPDATE OF with single column, got {other:?}"),
+        },
+        _ => panic!("Expected CreateTrigger statement"),
+    }
+}
+
+#[test]
+fn test_create_trigger_update_of_multi_after() {
+    // Mirrors trigger2-3.1: AFTER UPDATE OF c, d ON tbl.
+    let sql = "CREATE TRIGGER tbl_after_update_cd AFTER UPDATE OF c, d ON tbl BEGIN END;";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        Statement::CreateTrigger(trigger) => {
+            assert_eq!(trigger.timing, TriggerTiming::After);
+            assert_eq!(trigger.table_name, "tbl");
+            match &trigger.event {
+                TriggerEvent::Update(Some(cols)) => {
+                    assert_eq!(cols, &vec!["c".to_string(), "d".to_string()]);
+                }
+                other => panic!("Expected UPDATE OF c, d, got {other:?}"),
+            }
+        }
+        _ => panic!("Expected CreateTrigger statement"),
+    }
+}
+
+#[test]
+fn test_create_trigger_update_of_parenthesized_lenient() {
+    // Lenient extension: VibeSQL still accepts the parenthesized form even
+    // though sqlite3 3.51.0 rejects it. Retained for backwards compatibility.
+    let sql = "CREATE TRIGGER my_trigger BEFORE UPDATE OF (col1, col2) ON my_table BEGIN END;";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        Statement::CreateTrigger(trigger) => match &trigger.event {
+            TriggerEvent::Update(Some(cols)) => {
+                assert_eq!(cols, &vec!["col1".to_string(), "col2".to_string()]);
+            }
+            other => panic!("Expected UPDATE OF with columns, got {other:?}"),
+        },
         _ => panic!("Expected CreateTrigger statement"),
     }
 }


### PR DESCRIPTION
## Summary

Closes #5577

VibeSQL's trigger parser rejected the standard SQLite (3.51.0) syntax
`CREATE TRIGGER ... { BEFORE | AFTER } UPDATE OF c, d ON t`, emitting
`near "<col>": syntax error`, because it required parentheses around the
column list (`UPDATE OF (c, d)`). This blocked **trigger2.test section 3**
(the `trigger2-3.1` setup failed to parse, aborting the rest of the file).

### Parse fix
`crates/vibesql-parser/src/parser/trigger.rs`: after `OF`, parse a
comma-separated identifier list that runs until `ON` (consumed by the
existing `expect_keyword(On)`). Single (`UPDATE OF c`) and multi
(`UPDATE OF c, d`) forms both parse.

### Parenthesized-form decision
sqlite3 3.51.0 **rejects** `UPDATE OF (c, d)` (`near "(": syntax error`).
To match parity while not breaking VibeSQL's existing tests/round-trips,
the PR **accepts both**: the standard unparenthesized form (canonical) and
the parenthesized form as a documented **lenient extension**. The existing
unit test was migrated to the standard unparenthesized form; a dedicated
test retains coverage of the lenient parenthesized form.

### Firing-semantics fix (discovered while testing)
The catalog (`vibesql-catalog/.../triggers.rs`) filtered triggers by exact
event **equality**, so an `Update(Some([c,d]))` trigger never matched the
generic `Update(None)` the executor dispatches for every UPDATE. Result:
`UPDATE OF` triggers **never fired at all**. Matching is now by event
**kind** (INSERT/UPDATE/DELETE); the per-column firing restriction is still
enforced downstream by the executor's `should_fire_update_of`. With this,
the `trigger2-3.1` scenario yields the expected `log` count of **3**
(verified against sqlite3 3.51.0).

## sqlite3 3.51.0 parity
- `UPDATE OF c, d ON tbl` parses (multi) ✓
- `UPDATE OF c ON tbl` parses (single) ✓
- `UPDATE OF (c, d)` rejected by sqlite3; accepted by VibeSQL as lenient ext (documented) ✓
- Firing restriction: trigger fires only when a listed column actually changes — `trigger2-3.1` produces `3`, matching sqlite3 ✓

## Test delta
- **trigger2.test**: 51 → **52** passing; section 3.1 (`UPDATE OF`) now
  executes and passes. Execution now progresses into 3.2, where it hits an
  **unrelated** abort: subquery in a trigger `WHEN` clause
  (`WHEN (SELECT count(*) FROM tbl) = 0`) — see follow-on.
- **trigger1.test**: 31/39/14 (passed/failed/skipped) unchanged — no regression
  (none of its failures involve `UPDATE OF`).
- New parser tests: multi, single, and (lenient) parenthesized forms.
- New executor test: `test_update_of_fires_only_for_listed_column` — fires on
  the listed column, not on an unlisted column.
- `cargo test -p vibesql-parser -p vibesql-executor -p vibesql-catalog` green.

## Follow-on
- Subquery in trigger `WHEN` clause (`WHEN (SELECT ...)`) — blocks
  `trigger2-3.2`; separate parser/executor gap (will file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)