### PR TITLE
feat(executor): list temp views + temp triggers in sqlite_temp_master

### DIFF
--- a/crates/vibesql-catalog/src/view.rs
+++ b/crates/vibesql-catalog/src/view.rs
@@ -7,6 +7,12 @@ use vibesql_ast::SelectStmt;
 pub struct ViewDefinition {
     /// Name of the view
     pub name: String,
+    /// Schema the view belongs to. `None` means the default (main) schema.
+    /// A `Some("temp")` value is used for `CREATE TEMP VIEW` / `CREATE
+    /// TEMPORARY VIEW`, mirroring the `schema` tag on triggers (#5532) and
+    /// indexes (#5513). Temp views are surfaced by `sqlite_temp_master` and
+    /// excluded from `sqlite_master` (#5541).
+    pub schema: Option<String>,
     /// Optional column names for the view
     pub columns: Option<Vec<String>>,
     /// The SELECT query that defines the view
@@ -26,7 +32,14 @@ impl ViewDefinition {
         query: SelectStmt,
         with_check_option: bool,
     ) -> Self {
-        ViewDefinition { name, columns, query, with_check_option, sql_definition: None }
+        ViewDefinition {
+            name,
+            schema: None,
+            columns,
+            query,
+            with_check_option,
+            sql_definition: None,
+        }
     }
 
     /// Create a new view definition with SQL definition string
@@ -39,10 +52,29 @@ impl ViewDefinition {
     ) -> Self {
         ViewDefinition {
             name,
+            schema: None,
             columns,
             query,
             with_check_option,
             sql_definition: Some(sql_definition),
         }
+    }
+
+    /// Set the schema this view belongs to (builder-style).
+    ///
+    /// `None` keeps the view in the default (main) schema. A `Some("temp")`
+    /// value places it in the session temp schema so it is surfaced via
+    /// `sqlite_temp_master` rather than `sqlite_master`. The schema name is
+    /// stored verbatim; the temp check compares it case-insensitively.
+    pub fn with_schema(mut self, schema: Option<String>) -> Self {
+        self.schema = schema;
+        self
+    }
+
+    /// Returns true if this view lives in the temp schema.
+    pub fn is_temp(&self) -> bool {
+        self.schema
+            .as_deref()
+            .is_some_and(|s| s.eq_ignore_ascii_case("temp"))
     }
 }

--- a/crates/vibesql-executor/src/advanced_objects/views.rs
+++ b/crates/vibesql-executor/src/advanced_objects/views.rs
@@ -77,6 +77,11 @@ pub fn execute_create_view(stmt: &CreateViewStmt, db: &mut Database) -> Result<(
         }
     };
 
+    // Tag temp views with the `temp` schema so they surface via
+    // sqlite_temp_master and are excluded from sqlite_master (#5541), mirroring
+    // the temp-trigger schema tag (#5532) and temp-index tag (#5513).
+    let schema = if stmt.temporary { Some("temp".to_string()) } else { None };
+
     let view = if let Some(ref sql) = stmt.sql_definition {
         ViewDefinition::new_with_sql(
             stmt.view_name.clone(),
@@ -92,7 +97,8 @@ pub fn execute_create_view(stmt: &CreateViewStmt, db: &mut Database) -> Result<(
             (*stmt.query).clone(),
             stmt.with_check_option,
         )
-    };
+    }
+    .with_schema(schema);
 
     if stmt.or_replace || (stmt.if_not_exists && !view_exists) {
         // For OR REPLACE, drop the view if it exists, then CREATE

--- a/crates/vibesql-executor/src/sqlite_schema.rs
+++ b/crates/vibesql-executor/src/sqlite_schema.rs
@@ -97,18 +97,26 @@ pub fn execute_sqlite_schema_query(
         rows.push(schema_row("index", &index.name, &index.table_name, sql));
     }
 
-    // Add views
+    // Add views. Temp views are tagged with the `temp` schema (#5541) and
+    // surface only via sqlite_temp_master, so skip them here.
     for view_name in catalog.list_views() {
         if let Some(view) = catalog.get_view(&view_name) {
+            if view.is_temp() {
+                continue;
+            }
             let sql = generate_create_view_sql(view);
             // tbl_name is same as name for views
             rows.push(schema_row("view", &view.name, &view.name, sql));
         }
     }
 
-    // Add triggers
+    // Add triggers. Temp triggers are tagged with the `temp` schema (#5532)
+    // and surface only via sqlite_temp_master, so skip them here.
     for trigger_name in catalog.list_triggers() {
         if let Some(trigger) = catalog.get_trigger(&trigger_name) {
+            if trigger.is_temp() {
+                continue;
+            }
             let sql = generate_create_trigger_sql(trigger);
             rows.push(schema_row("trigger", &trigger.name, &trigger.table_name, sql));
         }
@@ -119,16 +127,13 @@ pub fn execute_sqlite_schema_query(
 
 /// Execute a `sqlite_temp_master` / `sqlite_temp_schema` query.
 ///
-/// Lists the session's **temp-schema** objects: temp tables and indexes on temp
-/// tables. Mirrors SQLite 3.51.0, where:
+/// Lists the session's **temp-schema** objects: temp tables, indexes on temp
+/// tables, temp views, and temp triggers. Mirrors SQLite 3.51.0, where:
 ///   CREATE TEMP TABLE t(a); CREATE INDEX i ON t(a);
-///   SELECT name,type FROM sqlite_temp_master;  -- lists t and i
-/// while `sqlite_master` lists neither. See issue #5513.
-///
-/// Scope note: VibeSQL does not yet schema-tag temp **views** or temp
-/// **triggers** (tracked separately — see follow-ons), so this view currently
-/// surfaces temp tables and temp-table indexes. That is sufficient for the
-/// index introspection parity this issue targets.
+///   CREATE TEMP VIEW v AS SELECT 1; CREATE TEMP TRIGGER tr AFTER INSERT ON t ...;
+///   SELECT name,type FROM sqlite_temp_master;  -- lists t, i, v and tr
+/// while `sqlite_master` lists none of them. Temp tables/indexes were added in
+/// #5513 (PR #5539); temp views/triggers in #5541.
 pub fn execute_sqlite_temp_schema_query(
     catalog: &vibesql_catalog::Catalog,
 ) -> Result<SelectResult, ExecutorError> {
@@ -153,6 +158,31 @@ pub fn execute_sqlite_temp_schema_query(
     for index in catalog.get_schema_indexes(temp_schema) {
         let sql = generate_create_index_sql(index);
         rows.push(schema_row("index", &index.name, &index.table_name, sql));
+    }
+
+    // Add temp views. Views are stored flat in the catalog (not partitioned by
+    // schema), so filter on the per-view `temp` tag set at CREATE TEMP VIEW
+    // time (#5541).
+    for view_name in catalog.list_views() {
+        if let Some(view) = catalog.get_view(&view_name) {
+            if !view.is_temp() {
+                continue;
+            }
+            let sql = generate_create_view_sql(view);
+            rows.push(schema_row("view", &view.name, &view.name, sql));
+        }
+    }
+
+    // Add temp triggers. Triggers are also stored flat; filter on the `temp`
+    // schema tag from CREATE TEMP TRIGGER (#5532).
+    for trigger_name in catalog.list_triggers() {
+        if let Some(trigger) = catalog.get_trigger(&trigger_name) {
+            if !trigger.is_temp() {
+                continue;
+            }
+            let sql = generate_create_trigger_sql(trigger);
+            rows.push(schema_row("trigger", &trigger.name, &trigger.table_name, sql));
+        }
     }
 
     Ok(SelectResult { columns: column_names, rows })
@@ -512,6 +542,90 @@ mod tests {
         assert!(temp_names.contains(&"temp_i".to_string()), "temp_master should list temp index");
         assert!(temp_names.contains(&"tt".to_string()), "temp_master should list temp table");
         assert!(!temp_names.contains(&"main_i".to_string()), "temp_master must exclude main index");
+    }
+
+    #[test]
+    fn test_temp_view_and_trigger_separated_from_main_in_schema_views() {
+        // #5541: temp views/triggers appear in sqlite_temp_master and are
+        // excluded from sqlite_master; main views/triggers are the reverse.
+        use vibesql_ast::{TriggerAction, TriggerEvent, TriggerGranularity, TriggerTiming};
+        use vibesql_catalog::{TriggerDefinition, ViewDefinition};
+
+        let mut catalog = Catalog::new();
+
+        // A base table for the triggers to target.
+        let base = TableSchema::new(
+            "t".to_string(),
+            vec![ColumnSchema::new("a".to_string(), DataType::Integer, true)],
+        );
+        catalog.create_table(base).unwrap();
+
+        // main view + temp view.
+        catalog
+            .create_view(ViewDefinition::new(
+                "main_v".to_string(),
+                None,
+                create_minimal_select_stmt(),
+                false,
+            ))
+            .unwrap();
+        catalog
+            .create_view(
+                ViewDefinition::new("temp_v".to_string(), None, create_minimal_select_stmt(), false)
+                    .with_schema(Some("temp".to_string())),
+            )
+            .unwrap();
+
+        // main trigger + temp trigger.
+        let mk_trigger = |name: &str| {
+            TriggerDefinition::new(
+                name.to_string(),
+                TriggerTiming::After,
+                TriggerEvent::Insert,
+                "t".to_string(),
+                TriggerGranularity::Row,
+                None,
+                TriggerAction::RawSql("SELECT 1".to_string()),
+            )
+        };
+        catalog.create_trigger(mk_trigger("main_tr")).unwrap();
+        catalog
+            .create_trigger(mk_trigger("temp_tr").with_schema(Some("temp".to_string())))
+            .unwrap();
+
+        let names = |result: &SelectResult| -> Vec<String> {
+            result
+                .rows
+                .iter()
+                .map(|r| match &r.values[1] {
+                    SqlValue::Varchar(s) => s.to_string(),
+                    _ => String::new(),
+                })
+                .collect()
+        };
+
+        let master = execute_sqlite_schema_query(&catalog).unwrap();
+        let master_names = names(&master);
+        assert!(master_names.contains(&"main_v".to_string()), "master should list main view");
+        assert!(master_names.contains(&"main_tr".to_string()), "master should list main trigger");
+        assert!(!master_names.contains(&"temp_v".to_string()), "master must exclude temp view");
+        assert!(
+            !master_names.contains(&"temp_tr".to_string()),
+            "master must exclude temp trigger"
+        );
+
+        let temp_master = execute_sqlite_temp_schema_query(&catalog).unwrap();
+        let temp_names = names(&temp_master);
+        assert!(temp_names.contains(&"temp_v".to_string()), "temp_master should list temp view");
+        assert!(
+            temp_names.contains(&"temp_tr".to_string()),
+            "temp_master should list temp trigger"
+        );
+        assert!(!temp_names.contains(&"main_v".to_string()), "temp_master must exclude main view");
+        assert!(
+            !temp_names.contains(&"main_tr".to_string()),
+            "temp_master must exclude main trigger"
+        );
     }
 
     #[test]

--- a/crates/vibesql-executor/src/view_ddl.rs
+++ b/crates/vibesql-executor/src/view_ddl.rs
@@ -30,6 +30,11 @@ impl ViewExecutor {
             })?;
         }
 
+        // Tag temp views with the `temp` schema so they surface via
+        // sqlite_temp_master and are excluded from sqlite_master (#5541),
+        // mirroring the temp-trigger (#5532) and temp-index (#5513) tags.
+        let schema = if stmt.temporary { Some("temp".to_string()) } else { None };
+
         // Create the view definition
         let view_def = if let Some(ref sql) = stmt.sql_definition {
             ViewDefinition::new_with_sql(
@@ -46,7 +51,8 @@ impl ViewExecutor {
                 *stmt.query.clone(),
                 stmt.with_check_option,
             )
-        };
+        }
+        .with_schema(schema);
 
         // Add to catalog
         database

--- a/crates/vibesql-executor/tests/case_sensitivity_tests.rs
+++ b/crates/vibesql-executor/tests/case_sensitivity_tests.rs
@@ -280,6 +280,7 @@ fn test_view_lookup_case_insensitive_when_enabled() {
 
     let view = ViewDefinition {
         name: "active_users".to_string(),
+        schema: None,
         query: select_stmt,
         columns: None,
         with_check_option: false,
@@ -344,6 +345,7 @@ fn test_drop_view_case_insensitive_when_enabled() {
 
     let view = ViewDefinition {
         name: "product_view".to_string(),
+        schema: None,
         query: select_stmt,
         columns: None,
         with_check_option: false,
@@ -410,6 +412,7 @@ fn test_view_case_sensitive_mode() {
 
     let view = ViewDefinition {
         name: "user_view".to_string(),
+        schema: None,
         query: select_stmt,
         columns: None,
         with_check_option: false,


### PR DESCRIPTION
## Summary

Extends `sqlite_temp_master` / `sqlite_temp_schema` (added for temp tables + temp-table indexes in #5513 / PR #5539) to also list temp **views** and temp **triggers**, and excludes those temp objects from `sqlite_master` — matching sqlite3 3.51.0.

## Changes

- **Schema-tag temp views**: added `schema: Option<String>` (+ `with_schema()` / `is_temp()`) to `ViewDefinition`, mirroring the trigger `schema` tag from #5532 and the index `schema` tag from #5513. Set to `Some("temp")` on `CREATE TEMP VIEW` / `CREATE TEMPORARY VIEW` in both view-create paths (`advanced_objects/views.rs` — the live CLI path — and `view_ddl.rs`).
- **Temp triggers**: already schema-tagged by #5532 (`stmt.schema = Some("temp")` threaded into `TriggerDefinition.schema`); no parsing changes needed.
- **`execute_sqlite_schema_query` (sqlite_master)**: skips views/triggers where `is_temp()`.
- **`execute_sqlite_temp_schema_query` (sqlite_temp_master)**: now also emits temp views and temp triggers (filtered by the per-object `temp` tag, since views/triggers are stored flat in the catalog, not schema-partitioned).

## sqlite3 3.51.0 parity (verified via live CLI)

Setup: `CREATE TABLE t; CREATE VIEW mv; CREATE TRIGGER mtr ON t; CREATE TEMP TABLE tt; CREATE INDEX ti ON tt; CREATE TEMP VIEW tv; CREATE TEMP TRIGGER ttr ON tt;`

| view | VibeSQL | sqlite3 3.51.0 |
|------|---------|----------------|
| `sqlite_master` | `table t`, `trigger mtr`, `view mv` | identical |
| `sqlite_temp_master` | `index ti`, `table tt`, `trigger ttr`, `view tv` | identical |

Temp view/trigger appear **only** in `sqlite_temp_master`; main view/trigger appear **only** in `sqlite_master`.

## Scope decision

Both temp views **and** temp triggers are now listed, so this fully closes the issue. CREATE TEMP VIEW was already parsed (`CreateViewStmt.temporary`) and CREATE TEMP TRIGGER was already schema-tagged (#5532), so no parser prerequisites were needed.

Out of scope (not part of this issue's introspection goal, can be follow-ons): dropping temp views/triggers on connection close / with their temp table (the issue's "Suggested work" third bullet) — VibeSQL's session-temp lifecycle handling is separate from catalog introspection.

## Tests

- New unit test `test_temp_view_and_trigger_separated_from_main_in_schema_views` in `sqlite_schema.rs`: temp view/trigger listed in temp_master + absent from master; main view/trigger the reverse.
- #5539 regression test `test_temp_index_separated_from_main_in_schema_views` still green.
- `cargo test -p vibesql-catalog -p vibesql-executor` green; `cargo test -p vibesql-parser` green (1455 tests).
- TCL `view.test` 24/24 passed, 0 failed. `trigger1.test` failures are pre-existing (none reference sqlite_master/temp_master).
- Live CLI parity check against sqlite3 3.51.0 (table above).

## Coordination

Parallel builders: #5577 (trigger **parsing** UPDATE OF) and #5568 (storage dump) — this PR touches trigger/view **schema-tagging + listing** only (`sqlite_schema.rs`, catalog `view.rs`), no overlap with trigger parsing or the dump path.

Closes #5541