### PR TITLE
fix(executor): qualify dropped view-body table as main.<name> on SELECT (read path)

### DIFF
--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -322,8 +322,24 @@ pub(crate) fn execute_table_scan(
         use crate::select::SelectExecutor;
         let executor = SelectExecutor::new(database);
 
-        // Get both rows and column metadata
-        let select_result = executor.execute_with_columns(&view.query)?;
+        // Get both rows and column metadata.
+        //
+        // A main-schema view body resolves its tables against the database
+        // schema, so when one of those tables has since been dropped sqlite3
+        // names it with the implicit `main.` prefix (`no such table:
+        // main.test2`). Qualify the missing-table error here so the read path
+        // matches sqlite3 3.51.0 and the INSTEAD OF view-DML paths fixed in
+        // #5569. Two cases stay unqualified, also matching sqlite3: a bare
+        // `SELECT * FROM missing_table` (not via a view) never reaches this
+        // view-body resolution, and a temp view's body resolves against the
+        // temp schema, which sqlite3 reports without a schema prefix. See #5570.
+        let select_result = if view.is_temp() {
+            executor.execute_with_columns(&view.query)?
+        } else {
+            executor
+                .execute_with_columns(&view.query)
+                .map_err(ExecutorError::with_main_schema_qualifier)?
+        };
 
         // Build a schema from the column names
         // Apply view's explicit column aliases if provided

--- a/crates/vibesql-executor/tests/view_read_missing_table_main_qualifier_tests.rs
+++ b/crates/vibesql-executor/tests/view_read_missing_table_main_qualifier_tests.rs
@@ -1,0 +1,96 @@
+//! A plain `SELECT * FROM <view>` over a view whose body references a
+//! since-dropped table must report the missing table schema-qualified
+//! (`main.<name>`), matching sqlite3 3.51.0. This is the read-path companion to
+//! the INSTEAD OF view-DML fix in #5569 (#5528 / trigger4-3.x). See #5570.
+//!
+//! A main-schema view body resolves its tables against the database schema, so
+//! when one of those tables is missing sqlite3 names it with the implicit
+//! `main.` prefix. Verified against sqlite3 3.51.0:
+//!
+//! ```text
+//! sqlite> create table test1(id integer primary key,a);
+//! sqlite> create table test2(id integer,b);
+//! sqlite> create view test as select test1.id as id,a as a,b as b
+//!    ...>   from test1 join test2 on test2.id = test1.id;
+//! sqlite> drop table test2;
+//! sqlite> select * from test;
+//! Error: in prepare, no such table: main.test2
+//! ```
+//!
+//! Two cases stay unqualified, also matching sqlite3 3.51.0:
+//!
+//! ```text
+//! sqlite> select * from missing_table;            -- direct, not via a view
+//! Error: in prepare, no such table: missing_table
+//! ```
+
+use vibesql_executor::{CreateTableExecutor, SelectExecutor, ViewExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+/// Parse and execute a single DDL statement, panicking on failure.
+fn exec_ok(db: &mut Database, sql: &str) {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e:?}"));
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+        }
+        Statement::CreateView(s) => {
+            ViewExecutor::execute_create_view(&s, db).expect("CREATE VIEW failed");
+        }
+        Statement::DropTable(s) => {
+            vibesql_executor::DropTableExecutor::execute(&s, db).expect("DROP TABLE failed");
+        }
+        other => panic!("unsupported statement in exec_ok: {other:?}"),
+    }
+}
+
+/// Run a SELECT and return its execution error (panics if it unexpectedly
+/// succeeds or fails to parse as a SELECT).
+fn select_err(db: &Database, sql: &str) -> vibesql_executor::ExecutorError {
+    let stmt = Parser::parse_sql(sql).expect("parse failed");
+    let vibesql_ast::Statement::Select(select) = stmt else { panic!("expected SELECT") };
+    let executor = SelectExecutor::new(db);
+    executor.execute(&select).expect_err("expected SELECT to fail")
+}
+
+/// Build the trigger4 fixture and drop `test2` so the view body is dangling.
+fn setup_dangling_view(db: &mut Database) {
+    exec_ok(db, "create table test1(id integer primary key, a)");
+    exec_ok(db, "create table test2(id integer, b)");
+    exec_ok(
+        db,
+        "create view test as select test1.id as id, a as a, b as b \
+         from test1 join test2 on test2.id = test1.id",
+    );
+    exec_ok(db, "drop table test2");
+}
+
+#[test]
+fn select_on_view_with_dropped_body_table_qualifies_main() {
+    let mut db = Database::new();
+    setup_dangling_view(&mut db);
+
+    let err = select_err(&db, "select * from test");
+    assert_eq!(
+        err,
+        vibesql_executor::ExecutorError::TableNotFound("main.test2".to_string()),
+        "SELECT over a view with a dropped body table must report main.test2 (sqlite3 parity)"
+    );
+}
+
+#[test]
+fn direct_select_on_missing_table_stays_unqualified() {
+    // A direct `SELECT * FROM missing_table` (not via a view) never reaches the
+    // view-body resolution and so stays bare, matching sqlite3 3.51.0 and the
+    // scope boundary with #5571.
+    let db = Database::new();
+
+    let err = select_err(&db, "select * from missing_table");
+    assert_eq!(
+        err,
+        vibesql_executor::ExecutorError::TableNotFound("missing_table".to_string()),
+        "direct SELECT on a missing table must stay unqualified"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #5570 (follow-on from #5528 / PR #5569).

A plain `SELECT * FROM <view>` over a view whose body references a since-dropped table now reports the missing table schema-qualified (`no such table: main.test2`), matching sqlite3 3.51.0. PR #5569 fixed the INSTEAD OF view-DML paths (INSERT/UPDATE/DELETE); this is the read-path companion.

## Read-path qualification site

`crates/vibesql-executor/src/select/scan/table.rs` — the single view-body execution in `execute_table_scan` (the `if let Some(view) = database.catalog.get_view(...)` branch). The `executor.execute_with_columns(&view.query)?` call now applies `.map_err(ExecutorError::with_main_schema_qualifier)` for main-schema views.

## Reuse, not duplication

Reuses `ExecutorError::with_main_schema_qualifier` introduced in #5569 (`errors.rs`); no new helper. It only rewrites a bare `TableNotFound` to `main.<name>` and leaves already-qualified names and all other variants untouched.

## sqlite3 3.51.0 parity (verified)

| Case | sqlite3 3.51.0 | VibeSQL (after fix) |
|------|----------------|---------------------|
| `SELECT * FROM <view>` with dropped body table | `no such table: main.test2` | `main.test2` (qualified) |
| `SELECT * FROM missing_table` (direct, not via view) | `no such table: missing_table` | `missing_table` (bare) |
| Temp view whose body table was dropped | `no such table: t2` (unqualified) | bare (guarded by `ViewDefinition::is_temp()`) |

Direct missing-table SELECT is deliberately left bare (that is #5571's scope). Temp views skip qualification via `is_temp()` so they stay unqualified, matching sqlite (temp schema is not prefixed `main.`).

## No regression

- `cargo test -p vibesql-executor` green (all suites, 0 failures).
- #5569 DML view tests (`view_dml_missing_table_main_qualifier_tests`) still pass (3/3).
- `view.test` 24/24, `trigger4.test` 23/23 (#5569's target) — unchanged.
- New test file `view_read_missing_table_main_qualifier_tests.rs`: SELECT-on-view qualifies `main.test2`; direct missing-table SELECT stays bare.

## Test plan

- [x] `cargo test -p vibesql-executor`
- [x] `make test-tcl-file FILE=view.test`
- [x] `make test-tcl-file FILE=trigger4.test`
- [x] End-to-end CLI repro (view qualified, direct bare)

🤖 Generated with [Claude Code](https://claude.com/claude-code)