### PR TITLE
fix(parser): accept subquery in trigger WHEN clause (trigger2-3.2)

### DIFF
--- a/crates/vibesql-executor/tests/trigger_when_subquery_tests.rs
+++ b/crates/vibesql-executor/tests/trigger_when_subquery_tests.rs
@@ -1,0 +1,92 @@
+//! Subquery-in-WHEN trigger firing tests (#5581).
+//!
+//! SQLite allows a trigger's WHEN clause to contain a subquery, e.g.
+//! `WHEN (SELECT count(*) FROM tbl) = 0`. The trigger fires only when the
+//! subquery condition holds, evaluated against the table state as-of trigger
+//! firing. This reproduces SQLite's `trigger2-3.2` scenario.
+//!
+//! Expectations verified against sqlite3 3.51.0:
+//! ```text
+//! CREATE TABLE tbl (a, b, c, d);
+//! CREATE TABLE log (a);
+//! INSERT INTO log VALUES (0);
+//! CREATE TRIGGER t1 BEFORE INSERT ON tbl WHEN new.a > 20 ...;
+//! CREATE TRIGGER t2 BEFORE INSERT ON tbl WHEN (SELECT count(*) FROM tbl) = 0 ...;
+//! -- inserting (0,..) into an empty tbl  -> log = 1  (t2 fires)
+//! -- inserting (0,..) into a non-empty tbl -> log = 0 (neither fires)
+//! -- inserting (200,..)                   -> log = 1  (t1 fires)
+//! ```
+
+use vibesql_executor::{
+    CreateTableExecutor, InsertExecutor, SelectExecutor, TriggerExecutor, UpdateExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn exec(db: &mut Database, sql: &str) {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e:?}"));
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+        }
+        Statement::CreateTrigger(s) => {
+            TriggerExecutor::create_trigger_with_sql(db, &s, Some(sql))
+                .expect("CREATE TRIGGER failed");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT failed");
+        }
+        Statement::Update(s) => {
+            UpdateExecutor::execute(&s, db).expect("UPDATE failed");
+        }
+        other => panic!("unsupported statement in test helper: {other:?}"),
+    }
+}
+
+fn query_scalar_i64(db: &Database, sql: &str) -> i64 {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).expect("parse failed");
+    let Statement::Select(select) = stmt else { panic!("expected SELECT") };
+    let rows = SelectExecutor::new(db).execute(&select).expect("SELECT failed");
+    match &rows[0].values[0] {
+        SqlValue::Integer(n) => *n,
+        other => panic!("expected integer, got {other:?}"),
+    }
+}
+
+/// trigger2-3.2: a WHEN subquery (`(SELECT count(*) FROM tbl) = 0`) is parsed,
+/// evaluated at fire time against current table state, and the trigger fires
+/// exactly when the subquery condition holds. Matches sqlite3 3.51.0 `{1 0 1}`.
+#[test]
+fn when_subquery_fires_per_subquery_result_trigger2_3_2() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE tbl (a, b, c, d);");
+    exec(&mut db, "CREATE TABLE log (a);");
+    exec(&mut db, "INSERT INTO log VALUES (0);");
+    exec(
+        &mut db,
+        "CREATE TRIGGER t1 BEFORE INSERT ON tbl WHEN new.a > 20 \
+         BEGIN UPDATE log SET a = a + 1; END;",
+    );
+    exec(
+        &mut db,
+        "CREATE TRIGGER t2 BEFORE INSERT ON tbl WHEN (SELECT count(*) FROM tbl) = 0 \
+         BEGIN UPDATE log SET a = a + 1; END;",
+    );
+
+    // tbl is empty -> the subquery WHEN of t2 is true -> log becomes 1.
+    exec(&mut db, "INSERT INTO tbl VALUES(0, 0, 0, 0);");
+    assert_eq!(query_scalar_i64(&db, "SELECT a FROM log;"), 1, "empty-table insert: t2 should fire");
+    exec(&mut db, "UPDATE log SET a = 0;");
+
+    // tbl now has a row -> subquery WHEN of t2 is false, a=0 so t1 false -> log stays 0.
+    exec(&mut db, "INSERT INTO tbl VALUES(0, 0, 0, 0);");
+    assert_eq!(query_scalar_i64(&db, "SELECT a FROM log;"), 0, "non-empty insert: neither fires");
+    exec(&mut db, "UPDATE log SET a = 0;");
+
+    // a=200 -> t1 (new.a > 20) fires; t2's subquery WHEN is false -> log becomes 1.
+    exec(&mut db, "INSERT INTO tbl VALUES(200, 0, 0, 0);");
+    assert_eq!(query_scalar_i64(&db, "SELECT a FROM log;"), 1, "a>20 insert: t1 should fire");
+}

--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -190,14 +190,17 @@ impl Parser {
         // Parse optional WHEN condition
         // SQLite syntax: WHEN expression (no parens required)
         // PostgreSQL syntax: WHEN (expression) (parens required)
-        // We support both for compatibility
+        //
+        // We delegate to the full expression parser, which natively handles
+        // both forms: a bare condition (`WHEN new.a > 20`), a parenthesized
+        // condition (`WHEN (new.a > 20)`), AND a leading subquery
+        // (`WHEN (SELECT count(*) FROM tbl) = 0`, trigger2-3.2). Consuming the
+        // opening paren ourselves as an optional PostgreSQL-style wrapper would
+        // mis-handle the subquery case — the `(` belongs to the subquery, so
+        // stripping it leaves `SELECT ... ) = 0`, which the expression parser
+        // (rightly) rejects. Letting `parse_expression` see the `(` lets its
+        // scalar-subquery / parenthesized-expression handling do the right thing.
         let when_condition = if self.try_consume_keyword(Keyword::When) {
-            let has_paren = if self.peek() == &Token::LParen {
-                self.advance(); // consume optional (
-                true
-            } else {
-                false
-            };
             // The WHEN condition is part of the trigger-program, so SQLite
             // permits RAISE() there too. Mark the parser as inside a trigger
             // body for the duration of the WHEN expression so RAISE() is
@@ -207,9 +210,6 @@ impl Parser {
             let expr_result = self.parse_expression();
             self.in_trigger_body = prev_in_trigger_body;
             let expr = expr_result?;
-            if has_paren {
-                self.expect_token(Token::RParen)?;
-            }
             // SQLite rejects a bound parameter / variable in the WHEN clause at
             // create time (triggerE-1.1.1: `WHEN new.a = ?`). NEW/OLD column
             // references are *not* variables and must still be allowed.

--- a/crates/vibesql-parser/src/tests/trigger.rs
+++ b/crates/vibesql-parser/src/tests/trigger.rs
@@ -1,6 +1,6 @@
 //! Tests for CREATE TRIGGER and DROP TRIGGER parsing
 
-use vibesql_ast::{Statement, TriggerEvent, TriggerGranularity, TriggerTiming};
+use vibesql_ast::{Expression, Statement, TriggerEvent, TriggerGranularity, TriggerTiming};
 
 use crate::Parser;
 
@@ -161,6 +161,39 @@ fn test_create_trigger_with_when_condition() {
         Statement::CreateTrigger(trigger) => {
             assert_eq!(trigger.trigger_name, "my_trigger");
             assert!(trigger.when_condition.is_some(), "Expected WHEN condition");
+        }
+        _ => panic!("Expected CreateTrigger statement"),
+    }
+}
+
+#[test]
+fn test_create_trigger_when_subquery() {
+    // trigger2-3.2: SQLite accepts a subquery in the WHEN clause. The leading
+    // `(` belongs to the scalar subquery, not a PostgreSQL-style wrapper, so the
+    // full expression parser must see it (regression guard for the previous
+    // optional-paren handling that mis-parsed `(SELECT ...) = 0`).
+    let sql = "CREATE TRIGGER t2 BEFORE INSERT ON tbl \
+               WHEN (SELECT count(*) FROM tbl) = 0 \
+               BEGIN UPDATE log SET a = a + 1; END;";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse WHEN subquery: {:?}", result.err());
+
+    let stmt = result.unwrap();
+    match stmt {
+        Statement::CreateTrigger(trigger) => {
+            assert_eq!(trigger.trigger_name, "t2");
+            let when = trigger.when_condition.expect("Expected WHEN condition");
+            // The condition is `<scalar subquery> = 0`.
+            match when.as_ref() {
+                Expression::BinaryOp { left, .. } => {
+                    assert!(
+                        matches!(left.as_ref(), Expression::ScalarSubquery(_)),
+                        "Expected LHS of WHEN to be a scalar subquery, got {:?}",
+                        left
+                    );
+                }
+                other => panic!("Expected BinaryOp in WHEN, got {:?}", other),
+            }
         }
         _ => panic!("Expected CreateTrigger statement"),
     }


### PR DESCRIPTION
Closes #5581

## Parse-vs-execution diagnosis

This is a **pure parse rejection**; the executor was already capable.

The WHEN parser (`crates/vibesql-parser/src/parser/trigger.rs`) greedily
consumed a leading `(` as an optional PostgreSQL-style wrapper before calling
`parse_expression()`. That works for `WHEN (1 = 1)` but breaks
`WHEN (SELECT count(*) FROM tbl) = 0`: the `(` actually belongs to the scalar
subquery, so stripping it left the parser looking at `SELECT ... ) = 0`, which
the expression parser (rightly) rejects — aborting trigger creation at
trigger2-3.2.

The executor side already evaluates a scalar subquery in the WHEN condition:
`evaluate_when_condition` builds an `ExpressionEvaluator::with_trigger_context`
that carries the DB reference, and `Expression::ScalarSubquery` is handled by
`eval_scalar_subquery` (which uses that DB reference). No executor change was
needed for the non-correlated case.

## The fix

Remove the manual optional-paren consumption in the WHEN parser and delegate the
entire condition to `parse_expression()`. The full expression parser's
`parse_parenthesized` natively handles all three forms:

- bare condition: `WHEN new.a > 20`
- parenthesized condition: `WHEN (new.a > 20)`
- leading scalar subquery: `WHEN (SELECT count(*) FROM tbl) = 0`

The existing create-time rejection of bound parameters in WHEN
(`WHEN new.a = ?`, triggerE-1.1.1) is preserved.

## sqlite3 3.51.0 parity

trigger2-3.2 scenario, both engines:

```
INSERT INTO tbl VALUES(0,0,0,0);   -- empty tbl -> t2 WHEN subquery true  -> log=1
INSERT INTO tbl VALUES(0,0,0,0);   -- non-empty -> neither fires          -> log=0
INSERT INTO tbl VALUES(200,0,0,0); -- new.a>20  -> t1 fires               -> log=1
```

sqlite3 3.51.0: `1 0 1`. VibeSQL after fix: `1 0 1`. Matches `$t232 = {1 0 1}`.

## trigger2 section-3 delta

- Before: `trigger2.test` aborted in section 3.2 (CREATE TRIGGER with WHEN
  subquery rejected at parse time).
- After: `make test-tcl-file FILE=trigger2.test` -> **70/70 pass** (section 3.2
  and the rest of the file complete).

## No regression

- `cargo test -p vibesql-parser`: green (1450 + 8 doc-tests; added
  `test_create_trigger_when_subquery`).
- `cargo test -p vibesql-executor`: green (added
  `trigger_when_subquery_tests::when_subquery_fires_per_subquery_result_trigger2_3_2`).
- Other `trigger*.test` files: unchanged pass counts (the change strictly widens
  what the WHEN parser accepts; previously-valid forms still parse — verified
  `WHEN (expr)`, `WHEN expr`, `WHEN (a AND b)`, and `?`-rejection).

## Deferred / follow-on

A WHEN subquery whose inner SELECT references the firing row's `NEW`/`OLD`
(correlated, e.g. `WHEN (SELECT count(*) FROM seen WHERE a = NEW.a) = 0`) still
fails at fire time — the subquery's `SelectExecutor` does not carry the trigger
context. This is **not** needed by trigger2-3.2 (its subquery is
non-correlated). Filed as #5585 (`Part of #5581`).