### PR TITLE
fix(executor): IPK-as-rowid intermediate-collision parity with sqlite3 (#5575)

### DIFF
--- a/crates/vibesql-executor/src/update/index_sync.rs
+++ b/crates/vibesql-executor/src/update/index_sync.rs
@@ -680,49 +680,81 @@ pub(super) fn validate_post_statement_uniqueness(
     Ok(())
 }
 
-/// Validate `UPDATE ... SET rowid = <expr>` relocations on a rowid table that
-/// has no INTEGER PRIMARY KEY (i.e. the rowid is virtual, stored in
-/// `Row::row_id` rather than aliased to a real column).
+/// Validate `UPDATE ... SET rowid = <expr>` relocations on a rowid table.
 ///
-/// SQLite lets `SET rowid=` / `SET _rowid_=` move a row to a new rowid, but the
-/// target rowid must be unique: relocating onto a rowid that another live row
-/// already occupies raises `UNIQUE constraint failed: <table>.rowid`. INTEGER
-/// PRIMARY KEY tables don't reach here — there the assignment writes the IPK
-/// column and the standard PK uniqueness check (`validate_post_statement_uniqueness`)
-/// catches the collision against `<table>.<ipk>`.
+/// SQLite lets `SET rowid=` / `SET _rowid_=` (and, on an INTEGER PRIMARY KEY
+/// table, `SET <ipk>=`) move a row to a new rowid, but the target rowid must be
+/// unique. sqlite3 3.51.0 does NOT defer this check: it processes the UPDATE one
+/// row at a time in ascending (old) rowid order and, as each row is relocated,
+/// requires the target rowid to be free *at that moment* — so a single-statement
+/// swap / N-cycle / ascending `+1` cascade is rejected even though the final
+/// state would be consistent. This is distinct from the deferred (final-state)
+/// PK/UNIQUE checking that sqlite3 applies elsewhere and that VibeSQL implements
+/// in [`validate_post_statement_uniqueness`].
 ///
-/// The effective rowid of a live row at physical index `i` is
-/// `row.row_id.unwrap_or(i + 1)`, matching the read path. Rows that are
-/// themselves part of this UPDATE are excluded from the "existing" set: only
-/// their post-statement (new) rowid participates, so swaps and self-moves are
-/// not spurious conflicts. This mirrors the deferred two-phase semantics of the
-/// PK/UNIQUE checks above.
+/// Two storage models reach here, both validated row-by-row with the same
+/// immediate semantics:
+///
+/// * **Virtual rowid** (no INTEGER PRIMARY KEY): the rowid lives in
+///   `Row::row_id`; `SET rowid=` writes it. The effective rowid of a live row at
+///   physical index `i` is `row.row_id.unwrap_or(i + 1)`, matching the read
+///   path. A collision reports against `<table>.rowid` (issue #5559).
+///
+/// * **INTEGER PRIMARY KEY** (`schema.rowid_alias_column` is set): the rowid IS
+///   the IPK column, so `SET rowid=` / `SET <ipk>=` writes that column. The
+///   effective rowid is the IPK column value. A collision reports against
+///   `<table>.<ipk>` (issue #5575). The deferred PK check in
+///   `validate_post_statement_uniqueness` runs first and (correctly) allows the
+///   swap on final-state grounds; this immediate check then rejects it on the
+///   intermediate collision, leaving regular-column deferred PK/UNIQUE behavior
+///   untouched.
+///
+/// In both models, rows that are themselves part of this UPDATE vacate their old
+/// rowid before their new rowid is written, so swaps and self-moves are not
+/// spurious conflicts where the target was already freed.
 pub(super) fn validate_rowid_relocation(
     updates: &[PendingUpdate],
     schema: &TableSchema,
     table: &Table,
 ) -> Result<(), ExecutorError> {
-    // Only relevant for virtual-rowid tables. INTEGER PRIMARY KEY tables store
-    // the rowid in a real column and are validated by the PK path.
-    if schema.rowid_alias_column.is_some() {
-        return Ok(());
-    }
+    // Resolve a row's effective rowid under whichever storage model applies:
+    //   - INTEGER PRIMARY KEY: the IPK column value (the rowid alias).
+    //   - virtual rowid:       Row::row_id, falling back to physical index + 1.
+    // Returns None when the IPK value is non-integer/NULL (no integer rowid to
+    // relocate) — such rows simply don't participate in the rowid relocation
+    // check (PK NULL/typing is handled by the standard constraint paths).
+    let ipk_col = schema.rowid_alias_column;
+    let effective_rowid = |row: &Row, physical_index: usize| -> Option<u64> {
+        match ipk_col {
+            Some(idx) => match &row.values[idx] {
+                SqlValue::Integer(i) => Some(*i as u64),
+                SqlValue::Bigint(i) => Some(*i as u64),
+                _ => None,
+            },
+            None => Some(row.row_id.unwrap_or((physical_index + 1) as u64)),
+        }
+    };
 
-    // Identify the updates that actually move the rowid. value_updater sets
-    // `new_row.row_id` for a `SET rowid=` assignment but leaves changed_columns
-    // empty, so we detect relocations by comparing the new rowid against the
-    // row's original effective rowid (old_row.row_id, falling back to physical
-    // index + 1).
+    // Identify the updates that actually move the rowid.
+    //
+    // For a virtual rowid, value_updater sets `new_row.row_id` for a `SET rowid=`
+    // assignment but leaves changed_columns empty, so we detect relocations by
+    // comparing the new effective rowid against the old one. For an IPK table the
+    // assignment writes the IPK column, so the same old-vs-new comparison covers
+    // both `SET rowid=` and `SET <ipk>=`.
     //
     // Each relocation is (old_rowid, new_rowid); old_rowid drives the processing
     // order (see below).
     let mut relocations: Vec<(u64, u64)> = Vec::new(); // (old_rowid, new_rowid)
     for u in updates {
-        let new_rowid = match u.new_row.row_id {
+        let new_rowid = match effective_rowid(&u.new_row, u.row_index) {
             Some(id) => id,
             None => continue,
         };
-        let old_rowid = u.old_row.row_id.unwrap_or((u.row_index + 1) as u64);
+        let old_rowid = match effective_rowid(&u.old_row, u.row_index) {
+            Some(id) => id,
+            None => continue,
+        };
         if new_rowid != old_rowid {
             relocations.push((old_rowid, new_rowid));
         }
@@ -733,15 +765,15 @@ pub(super) fn validate_rowid_relocation(
 
     // Row-by-row intermediate-collision check, matching sqlite3 3.51.0.
     //
-    // sqlite3 does NOT defer rowid uniqueness to the final state: it processes
-    // the UPDATE one row at a time in ascending (old) rowid order and, as each
-    // row is relocated, requires the target rowid to be free *at that moment*.
-    // The live set at that moment includes:
+    // sqlite3 processes the UPDATE one row at a time in ascending (old) rowid
+    // order and, as each row is relocated, requires the target rowid to be free
+    // *at that moment*. The live set at that moment includes:
     //   - rows not yet processed (un-updated rows, and updated rows whose old
     //     rowid sorts later), and
     //   - rows already relocated earlier in this statement.
     // A row that previously occupied the target but has already been relocated
-    // away does NOT collide. Verified against sqlite3 3.51.0:
+    // away does NOT collide. Verified against sqlite3 3.51.0 (both virtual-rowid
+    // and INTEGER PRIMARY KEY tables behave identically):
     //   * swap (1<->2) / N-cycle           -> UNIQUE constraint failed
     //   * `SET rowid=rowid+1` (ascending)  -> error (1 collides with live 2)
     //   * `SET rowid=rowid-1` (ascending)  -> ok (each old slot vacated first)
@@ -749,20 +781,28 @@ pub(super) fn validate_rowid_relocation(
     //   * `SET rowid=rowid` (self no-op)   -> ok
     //
     // This is intentionally narrower than the deferred PK/UNIQUE model used for
-    // regular columns: it is rowid-specific to mirror sqlite3's immediate
-    // (non-deferred) rowid handling without changing constraint checking
-    // elsewhere.
+    // regular columns: it is rowid-specific (including the IPK-as-rowid alias) to
+    // mirror sqlite3's immediate (non-deferred) rowid handling without changing
+    // constraint checking elsewhere.
     //
-    // `occupied` starts as every live row's effective rowid (a row at physical
-    // index `i` has effective rowid `row.row_id.unwrap_or(i + 1)`, matching the
-    // read path). Updated rows that do NOT move keep their slot here untouched.
-    let mut occupied: HashSet<u64> =
-        table.scan_live().map(|(i, row)| row.row_id.unwrap_or((i + 1) as u64)).collect();
+    // `occupied` starts as every live row's effective rowid. Updated rows that do
+    // NOT move keep their slot here untouched.
+    let mut occupied: HashSet<u64> = table
+        .scan_live()
+        .filter_map(|(i, row)| effective_rowid(row, i))
+        .collect();
 
     // Process relocations in ascending OLD-rowid order — sqlite3 visits rows in
     // rowid order, so this reproduces its intermediate states (and the
     // asymmetry between an ascending `+1` shift and a descending `-1` shift).
     relocations.sort_unstable_by_key(|&(old_rowid, _)| old_rowid);
+
+    // Collision is reported against the rowid alias column for an IPK table,
+    // else against the special `rowid` pseudo-column.
+    let conflict_column = match ipk_col {
+        Some(idx) => format!("{}.{}", schema.name, schema.columns[idx].name),
+        None => format!("{}.rowid", schema.name),
+    };
 
     for (old_rowid, new_rowid) in relocations {
         // The row vacates its old slot before its new rowid is written.
@@ -770,8 +810,8 @@ pub(super) fn validate_rowid_relocation(
         if !occupied.insert(new_rowid) {
             // Target rowid is still occupied at this point in the statement.
             return Err(ExecutorError::ConstraintViolation(format!(
-                "UNIQUE constraint failed: {}.rowid",
-                schema.name
+                "UNIQUE constraint failed: {}",
+                conflict_column
             )));
         }
     }

--- a/crates/vibesql-executor/src/update/tests/set_rowid.rs
+++ b/crates/vibesql-executor/src/update/tests/set_rowid.rs
@@ -278,6 +278,218 @@ fn set_rowid_ipk_conflict_errors() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Issue #5575: single-statement IPK (rowid-alias) relocation is checked
+// IMMEDIATELY row-by-row, exactly like the virtual-rowid path above. On an
+// INTEGER PRIMARY KEY table the IPK column IS the rowid, so a `SET <ipk>=` /
+// `SET rowid=` swap / N-cycle / ascending `+1` cascade must error on the
+// intermediate collision (NOT be deferred to the final state), reported against
+// `<table>.<ipk>`. The `-1` descending cascade, move-to-gap, and self no-op
+// still succeed. All verified against sqlite3 3.51.0.
+//
+// This is the IPK counterpart of the virtual-rowid tests above. It must NOT
+// change deferred PK/UNIQUE checking for regular columns — see
+// `regular_unique_column_swap_still_allowed_deferred` below.
+// ---------------------------------------------------------------------------
+
+/// IPK swap via the IPK column: `UPDATE t SET k=CASE...` errors on the
+/// intermediate collision (sqlite3 3.51.0: `UNIQUE constraint failed: t.k`).
+#[test]
+fn set_ipk_swap_errors_intermediate_collision() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE t(k INTEGER PRIMARY KEY, v)");
+    ddl(&mut db, "INSERT INTO t VALUES(1, 'a')");
+    ddl(&mut db, "INSERT INTO t VALUES(2, 'b')");
+
+    let err = update(&mut db, "UPDATE t SET k = CASE k WHEN 1 THEN 2 WHEN 2 THEN 1 END")
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: t.k"),
+        "expected IPK UNIQUE error for swap, got: {}",
+        err
+    );
+
+    // Table unchanged after the aborted UPDATE.
+    let rows = select(&mut db, "SELECT k, v FROM t ORDER BY k");
+    let got: Vec<(i64, String)> =
+        rows.iter().map(|r| (int(&r.values[0]), text(&r.values[1]))).collect();
+    assert_eq!(got, vec![(1, "a".to_string()), (2, "b".to_string())]);
+}
+
+/// IPK swap via the `rowid` alias on an IPK table — same immediate check, still
+/// reported against the IPK column name (sqlite3 3.51.0).
+#[test]
+fn set_rowid_alias_ipk_swap_errors() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE t(k INTEGER PRIMARY KEY, v)");
+    ddl(&mut db, "INSERT INTO t VALUES(1, 'a')");
+    ddl(&mut db, "INSERT INTO t VALUES(2, 'b')");
+
+    let err = update(
+        &mut db,
+        "UPDATE t SET rowid = CASE rowid WHEN 1 THEN 2 WHEN 2 THEN 1 END",
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: t.k"),
+        "expected IPK UNIQUE error for rowid-alias swap, got: {}",
+        err
+    );
+}
+
+/// IPK 3-cycle (1->2, 2->3, 3->1) errors: ascending processing, 1->2 collides
+/// with the still-live IPK 2. Matches sqlite3 3.51.0.
+#[test]
+fn set_ipk_three_cycle_errors() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE t(k INTEGER PRIMARY KEY, v)");
+    ddl(&mut db, "INSERT INTO t VALUES(1, 'a')");
+    ddl(&mut db, "INSERT INTO t VALUES(2, 'b')");
+    ddl(&mut db, "INSERT INTO t VALUES(3, 'c')");
+
+    let err = update(
+        &mut db,
+        "UPDATE t SET k = CASE k WHEN 1 THEN 2 WHEN 2 THEN 3 WHEN 3 THEN 1 END",
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: t.k"),
+        "expected IPK UNIQUE error for 3-cycle, got: {}",
+        err
+    );
+}
+
+/// `UPDATE t SET k = k + 1` over ascending IPK rows cascade-collides: 1 -> 2
+/// collides with the still-live IPK 2. sqlite3 3.51.0 errors (the IPK is the
+/// rowid; checked immediately, not deferred).
+#[test]
+fn set_ipk_plus_one_cascade_errors() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE t(k INTEGER PRIMARY KEY, v)");
+    ddl(&mut db, "INSERT INTO t VALUES(1, 'a')");
+    ddl(&mut db, "INSERT INTO t VALUES(2, 'b')");
+    ddl(&mut db, "INSERT INTO t VALUES(3, 'c')");
+
+    let err = update(&mut db, "UPDATE t SET k = k + 1").unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: t.k"),
+        "expected IPK UNIQUE error for +1 cascade, got: {}",
+        err
+    );
+}
+
+/// `UPDATE t SET k = k - 1` over ascending IPK rows succeeds: processed
+/// ascending, each old IPK slot is vacated before the next row needs it. sqlite3
+/// 3.51.0 accepts this — the asymmetry with `+1` confirms the immediate
+/// row-by-row ascending order (same as virtual rowid).
+#[test]
+fn set_ipk_minus_one_cascade_ok() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE t(k INTEGER PRIMARY KEY, v)");
+    ddl(&mut db, "INSERT INTO t VALUES(2, 'a')");
+    ddl(&mut db, "INSERT INTO t VALUES(3, 'b')");
+    ddl(&mut db, "INSERT INTO t VALUES(4, 'c')");
+
+    assert_eq!(update(&mut db, "UPDATE t SET k = k - 1").unwrap(), 3);
+
+    let rows = select(&mut db, "SELECT k, v FROM t ORDER BY k");
+    let got: Vec<(i64, String)> =
+        rows.iter().map(|r| (int(&r.values[0]), text(&r.values[1]))).collect();
+    assert_eq!(
+        got,
+        vec![(1, "a".to_string()), (2, "b".to_string()), (3, "c".to_string())]
+    );
+}
+
+/// Relocating an IPK row into a free gap (no collision at any step) succeeds.
+/// Matches sqlite3 3.51.0.
+#[test]
+fn set_ipk_move_to_gap_ok() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE t(k INTEGER PRIMARY KEY, v)");
+    ddl(&mut db, "INSERT INTO t VALUES(1, 'a')");
+    ddl(&mut db, "INSERT INTO t VALUES(2, 'b')");
+
+    assert_eq!(update(&mut db, "UPDATE t SET k = k + 100 WHERE k = 1").unwrap(), 1);
+
+    let rows = select(&mut db, "SELECT k, v FROM t ORDER BY k");
+    let got: Vec<(i64, String)> =
+        rows.iter().map(|r| (int(&r.values[0]), text(&r.values[1]))).collect();
+    assert_eq!(got, vec![(2, "b".to_string()), (101, "a".to_string())]);
+}
+
+/// `UPDATE t SET k = k` is a no-op for every IPK row and must not error. Matches
+/// sqlite3 3.51.0.
+#[test]
+fn set_ipk_self_noop_ok() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE t(k INTEGER PRIMARY KEY, v)");
+    ddl(&mut db, "INSERT INTO t VALUES(1, 'a')");
+    ddl(&mut db, "INSERT INTO t VALUES(2, 'b')");
+    ddl(&mut db, "INSERT INTO t VALUES(3, 'c')");
+
+    assert_eq!(update(&mut db, "UPDATE t SET k = k").unwrap(), 3);
+
+    let rows = select(&mut db, "SELECT k, v FROM t ORDER BY k");
+    let got: Vec<(i64, String)> =
+        rows.iter().map(|r| (int(&r.values[0]), text(&r.values[1]))).collect();
+    assert_eq!(
+        got,
+        vec![(1, "a".to_string()), (2, "b".to_string()), (3, "c".to_string())]
+    );
+}
+
+/// REGRESSION GUARD (#5575 caution): the immediate IPK-as-rowid check must NOT
+/// leak into regular (non-rowid) UNIQUE columns. VibeSQL defers UNIQUE checks
+/// for regular columns to the final state (issue #5137), which lets a swap on a
+/// non-IPK UNIQUE column be accepted here. `k` below is a plain UNIQUE column
+/// (the rowid is the separate `id` IPK), so the immediate rowid relocation check
+/// must not fire — this swap must STILL be allowed exactly as before this fix.
+///
+/// (sqlite3 3.51.0 actually rejects this regular-column swap too — VibeSQL's
+/// deferred acceptance is a separate, pre-existing parity gap that is explicitly
+/// OUT OF SCOPE for #5575; #5575 must not regress it in either direction.)
+#[test]
+fn regular_unique_column_swap_still_allowed_deferred() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE u(id INTEGER PRIMARY KEY, k INT UNIQUE)");
+    ddl(&mut db, "INSERT INTO u VALUES(1, 10)");
+    ddl(&mut db, "INSERT INTO u VALUES(2, 20)");
+
+    // Swap the regular UNIQUE column `k` (NOT the IPK). Deferred final-state check
+    // sees no duplicate, so VibeSQL accepts it — the immediate IPK relocation
+    // check (which only inspects the rowid-alias column) must stay clear of it.
+    assert_eq!(
+        update(&mut db, "UPDATE u SET k = CASE k WHEN 10 THEN 20 WHEN 20 THEN 10 END").unwrap(),
+        2
+    );
+
+    let rows = select(&mut db, "SELECT id, k FROM u ORDER BY id");
+    let got: Vec<(i64, i64)> =
+        rows.iter().map(|r| (int(&r.values[0]), int(&r.values[1]))).collect();
+    assert_eq!(got, vec![(1, 20), (2, 10)]);
+}
+
+/// REGRESSION GUARD: a regular UNIQUE-column *shift* (`k = k - 10`) on a table
+/// whose IPK (`id`) is unchanged must still succeed via the deferred path
+/// (issue #5137). The IPK column is untouched, so the immediate rowid check finds
+/// no relocations and does not interfere.
+#[test]
+fn regular_unique_column_shift_still_allowed_deferred() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE u(id INTEGER PRIMARY KEY, k INT UNIQUE)");
+    ddl(&mut db, "INSERT INTO u VALUES(1, 10)");
+    ddl(&mut db, "INSERT INTO u VALUES(2, 20)");
+    ddl(&mut db, "INSERT INTO u VALUES(3, 30)");
+
+    assert_eq!(update(&mut db, "UPDATE u SET k = k - 10").unwrap(), 3);
+
+    let rows = select(&mut db, "SELECT id, k FROM u ORDER BY id");
+    let got: Vec<(i64, i64)> =
+        rows.iter().map(|r| (int(&r.values[0]), int(&r.values[1]))).collect();
+    assert_eq!(got, vec![(1, 0), (2, 10), (3, 20)]);
+}
+
 /// An index on another column still finds the row after a rowid relocation.
 #[test]
 fn index_consistent_after_relocate() {

--- a/crates/vibesql-executor/tests/update_deferred_uniqueness_tests.rs
+++ b/crates/vibesql-executor/tests/update_deferred_uniqueness_tests.rs
@@ -104,9 +104,22 @@ fn pk_shift_decrement_succeeds() {
 }
 
 #[test]
-fn pk_shift_increment_succeeds() {
-    // Mirror of the decrement case — `UPDATE p SET a = a + 1` shifts upward, transiently
-    // collides between rows, must still succeed.
+fn ipk_shift_increment_errors_intermediate_collision() {
+    // `UPDATE p SET a = a + 1` on an INTEGER PRIMARY KEY table is NOT deferred in
+    // sqlite3 3.51.0: the IPK IS the rowid, which sqlite3 checks IMMEDIATELY
+    // row-by-row in ascending rowid order, not at statement end. Processing rowid
+    // 1 -> 2 collides with the still-live rowid 2, so sqlite3 errors:
+    //   Error: UNIQUE constraint failed: p.a
+    // (verified against sqlite3 3.51.0; issue #5575). This is the ASCENDING-cascade
+    // half of the same +1/-1 asymmetry exercised by the rowid relocation tests in
+    // src/update/tests/set_rowid.rs — the `-1` descending counterpart
+    // (`pk_shift_decrement_succeeds` above) still succeeds because each old slot
+    // is vacated before the next row needs it.
+    //
+    // NOTE: this previously asserted SUCCESS (final state 2,3,4 has no duplicate),
+    // modeling the IPK like a deferred regular UNIQUE column. That diverged from
+    // sqlite3, which #5575 corrects. Regular (non-rowid) UNIQUE columns remain
+    // deferred — see `composite_pk_shift_succeeds` / `unique_index_shift_succeeds`.
     let mut db = Database::new();
     run_sql(
         &mut db,
@@ -116,18 +129,25 @@ fn pk_shift_increment_succeeds() {
          INSERT INTO p VALUES (3, 'three');",
     );
 
-    let count = run_update(&mut db, "UPDATE p SET a = a + 1").expect("PK increment should succeed");
-    assert_eq!(count, 3);
+    let result = run_update(&mut db, "UPDATE p SET a = a + 1");
+    let err = result.expect_err(
+        "IPK ascending +1 cascade must error on intermediate collision (sqlite3 3.51.0)",
+    );
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: p.a"),
+        "expected `UNIQUE constraint failed: p.a`, got: {}",
+        err
+    );
 
-    let rows = get_rows(&db, "p");
-    let pks: Vec<i64> = rows
+    // Table unchanged after the aborted UPDATE.
+    let pks: Vec<i64> = get_rows(&db, "p")
         .iter()
         .map(|r| match r[0] {
             SqlValue::Integer(n) => n,
             _ => panic!("expected integer pk"),
         })
         .collect();
-    assert_eq!(pks, vec![2, 3, 4]);
+    assert_eq!(pks, vec![1, 2, 3]);
 }
 
 #[test]


### PR DESCRIPTION
Closes #5575

Follow-on from #5559 (PR #5574), which fixed the **virtual-rowid** intermediate-collision case. This applies the same immediate row-by-row check to the **INTEGER PRIMARY KEY (rowid-alias)** path.

## Verified sqlite3 3.51.0 distinction: IPK is immediate, regular UNIQUE is deferred

On an INTEGER PRIMARY KEY table the IPK column **is** the rowid, and sqlite3 checks the rowid **IMMEDIATELY** row-by-row in ascending rowid order — *not* deferred to the final statement state. Captured against sqlite3 3.51.0:

| Statement (IPK column `id`/`k`) | sqlite3 3.51.0 | rule |
|---|---|---|
| `UPDATE t SET id = CASE id WHEN 1 THEN 2 WHEN 2 THEN 1 END` (swap) | `Error: UNIQUE constraint failed: t.id` | immediate |
| 3-cycle `1->2,2->3,3->1` | `UNIQUE constraint failed: t.id` | immediate |
| `UPDATE t SET id = id+1` (ascending cascade) | `UNIQUE constraint failed: t.id` | immediate |
| `UPDATE t SET id = id-1` (descending) | ok | each old slot vacated first |
| move-to-gap (`id+10` on one row) | ok | no collision |
| `UPDATE t SET id = id` (self no-op) | ok | no relocation |
| `SET rowid=` swap on IPK table | `UNIQUE constraint failed: t.id` | alias writes IPK |

Contrast — **regular (non-rowid) UNIQUE/PK columns are deferred** to the final state (this is the behavior #5575 explicitly warns must be PRESERVED). e.g. `UPDATE u SET k = k - 10` on a `k INT UNIQUE` column succeeds because the final state is duplicate-free (VibeSQL issue #5137). VibeSQL keeps allowing those.

> Note: sqlite3 3.51.0 *also* rejects a regular UNIQUE-column **swap** (`k=CASE...`); VibeSQL's deferred path currently accepts it. That is a separate, pre-existing parity gap (UNIQUE-column immediate checking), explicitly **out of scope** for #5575 — filed as a follow-on below. #5575 does not regress it in either direction.

## The fix

`crates/vibesql-executor/src/update/index_sync.rs` — `validate_rowid_relocation` previously early-returned for IPK tables (`schema.rowid_alias_column.is_some()`), leaving them to the deferred PK check. It now covers **both** rowid storage models:

- **virtual rowid**: effective rowid = `Row::row_id` (fallback `physical_index + 1`) — unchanged (#5559).
- **INTEGER PRIMARY KEY**: effective rowid = the IPK column value; `SET rowid=` and `SET <ipk>=` both write that column, so the same old-vs-new comparison detects relocations. A collision reports against `<table>.<ipk>`.

The same ascending-old-rowid, vacate-then-occupy intermediate-collision algorithm is reused. **`validate_post_statement_uniqueness` is unchanged** — regular-column deferred PK/UNIQUE checking is untouched. The deferred PK check still runs first (and allows the IPK swap on final-state grounds); the immediate rowid check then rejects it on the intermediate collision.

## Parity tests (live SELECT + error assertions, matching sqlite3)

`crates/vibesql-executor/src/update/tests/set_rowid.rs` (+8 IPK + 2 regression-guard):
- `set_ipk_swap_errors_intermediate_collision`, `set_rowid_alias_ipk_swap_errors`, `set_ipk_three_cycle_errors`, `set_ipk_plus_one_cascade_errors` -> `UNIQUE constraint failed: t.k`
- `set_ipk_minus_one_cascade_ok`, `set_ipk_move_to_gap_ok`, `set_ipk_self_noop_ok` -> succeed with verified final state
- `regular_unique_column_swap_still_allowed_deferred`, `regular_unique_column_shift_still_allowed_deferred` -> regular UNIQUE column updates **still allowed** (deferred path not touched)

`crates/vibesql-executor/tests/update_deferred_uniqueness_tests.rs`: corrected `pk_shift_increment_succeeds` (asserted the IPK `+1` cascade *succeeded* — diverged from sqlite3 3.51.0, which errors) -> renamed `ipk_shift_increment_errors_intermediate_collision`, now asserts the error. The `-1` decrement / negation / composite-PK / user-UNIQUE-index deferred tests are unchanged and still pass.

## No regression

`cargo test -p vibesql-executor` green — all 112 test result lines, 0 failures. Includes #5559/#5517 rowid tests and the #5137 deferred PK/UNIQUE suite. `cargo clippy -p vibesql-executor` clean for the touched files.

## Follow-ons (filed separately)
- Regular (non-rowid) UNIQUE-column single-statement **swap** should error per sqlite3 (immediate UNIQUE checking) — VibeSQL currently defers it. Separate constraint-checking model; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)