### PR TITLE
fix(storage): preserve original index-name case in SQL dump (#5579)

### DIFF
--- a/crates/vibesql-executor/src/sqlite_schema.rs
+++ b/crates/vibesql-executor/src/sqlite_schema.rs
@@ -804,6 +804,50 @@ mod tests {
         assert_eq!(sql, "CREATE UNIQUE INDEX idx_email ON users(email(50))");
     }
 
+    /// Regression test for #5579: `sqlite_master` must report the index name and
+    /// SQL with their original case (the case the user typed in `CREATE INDEX`),
+    /// matching sqlite3 3.51.0. The catalog stores the original-case name, so
+    /// both the `name` column and the generated `sql` column preserve it.
+    #[test]
+    fn test_sqlite_schema_index_preserves_name_case() {
+        let mut catalog = Catalog::new();
+        catalog.set_case_sensitive_identifiers(false);
+
+        let columns = vec![ColumnSchema::new("a".to_string(), DataType::Integer, false)];
+        let table = TableSchema::new("t".to_string(), columns);
+        catalog.create_table(table).unwrap();
+
+        let index = IndexMetadata::new(
+            "MyIdx".to_string(),
+            "t".to_string(),
+            IndexType::BTree,
+            vec![IndexedColumn::new_column("a".to_string(), SortOrder::Ascending)],
+            false,
+        );
+        catalog.add_index(index).unwrap();
+
+        let result = execute_sqlite_schema_query(&catalog).unwrap();
+        let index_row = result
+            .rows
+            .iter()
+            .find(|r| matches!(&r.values[0], SqlValue::Varchar(s) if s.as_str() == "index"))
+            .expect("Should have an index row");
+
+        // `name` column preserves original case (not "myidx").
+        assert_eq!(index_row.values[1], SqlValue::Varchar(arcstr::ArcStr::from("MyIdx")));
+
+        // `sql` column preserves original case.
+        if let SqlValue::Varchar(sql) = &index_row.values[4] {
+            assert!(
+                sql.contains("CREATE INDEX MyIdx ON t"),
+                "sqlite_master.sql must preserve original index-name case, got: {sql}"
+            );
+            assert!(!sql.contains("myidx"), "index name must not be lowercased, got: {sql}");
+        } else {
+            panic!("Expected VARCHAR for sql column");
+        }
+    }
+
     #[test]
     fn test_generate_create_trigger_sql_basic() {
         use vibesql_ast::{TriggerAction, TriggerEvent, TriggerGranularity, TriggerTiming};

--- a/crates/vibesql-storage/src/persistence/save.rs
+++ b/crates/vibesql-storage/src/persistence/save.rs
@@ -434,6 +434,14 @@ impl Database {
                 write!(writer, " UNIQUE")
                     .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
             }
+            // Emit the index name with its original case (#5579). `index_name`
+            // here is the IndexManager's *storage key*, which is normalized to
+            // lowercase for case-insensitive lookup (see `make_index_key`).
+            // `metadata.index_name` preserves the name exactly as the user wrote
+            // it in `CREATE INDEX`, matching sqlite3 — whose `.dump` and
+            // `sqlite_master.name`/`.sql` retain the original spelling while
+            // still resolving names case-insensitively.
+            //
             // Identifiers (index name, table name, column names) must be quoted so
             // that names with embedded special characters (spaces, quotes, parens)
             // round-trip correctly when the dump is re-lexed on reload. Without
@@ -442,7 +450,7 @@ impl Database {
             write!(
                 writer,
                 " INDEX {} ON {} (",
-                quote_identifier(&index_name),
+                quote_identifier(&metadata.index_name),
                 quote_identifier(&metadata.table_name)
             )
             .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;

--- a/crates/vibesql-storage/src/persistence/tests/sql_dump.rs
+++ b/crates/vibesql-storage/src/persistence/tests/sql_dump.rs
@@ -367,6 +367,93 @@ fn test_sql_dump_index_quoted_identifiers_roundtrip() {
     std::fs::remove_file(path).ok();
 }
 
+/// Regression test for #5579: the SQL dump must preserve the *original case* of
+/// an index name, matching sqlite3 3.51.0 (whose `.dump` and `sqlite_master`
+/// retain the spelling the user typed). The IndexManager keys indexes by a
+/// lowercased storage key for case-insensitive lookup, but `metadata.index_name`
+/// retains the original case, which is what the dump must emit. A mixed-case
+/// name with embedded special characters also exercises the quoting path.
+#[test]
+fn test_sql_dump_preserves_index_name_case() {
+    use crate::persistence::load::read_sql_dump;
+
+    let mut db = Database::new();
+
+    let schema = TableSchema::new(
+        "t".to_string(),
+        vec![
+            ColumnSchema::new("b".to_string(), DataType::Integer, false),
+            ColumnSchema::new("c".to_string(), DataType::Integer, false),
+        ],
+    );
+    db.create_table(schema).unwrap();
+
+    // Simple mixed-case name (no special chars): emitted unquoted, original case.
+    let cols1 = vec![vibesql_ast::IndexColumn::Column {
+        column_name: "b".to_string(),
+        direction: vibesql_ast::OrderDirection::Asc,
+        prefix_length: None,
+    }];
+    db.create_index("MyIdx".to_string(), "t".to_string(), false, cols1).unwrap();
+
+    // Mixed-case name with spaces/parens: emitted quoted, original case preserved
+    // (mirrors the repro in #5579: "x1 (b Asc, c Asc)").
+    let cols2 = vec![
+        vibesql_ast::IndexColumn::Column {
+            column_name: "b".to_string(),
+            direction: vibesql_ast::OrderDirection::Desc,
+            prefix_length: None,
+        },
+        vibesql_ast::IndexColumn::Column {
+            column_name: "c".to_string(),
+            direction: vibesql_ast::OrderDirection::Asc,
+            prefix_length: None,
+        },
+    ];
+    db.create_index("x1 (b Asc, c Asc)".to_string(), "t".to_string(), false, cols2).unwrap();
+
+    let path = "/tmp/test_index_name_case.sql";
+    db.save_sql_dump(path).unwrap();
+
+    let content = read_sql_dump(path).unwrap();
+
+    // Original case retained, not lowercased.
+    assert!(
+        content.contains("CREATE INDEX MyIdx ON"),
+        "Index name case must be preserved (expected `MyIdx`). Got:\n{content}"
+    );
+    assert!(
+        !content.contains("myidx"),
+        "Index name must not be lowercased. Got:\n{content}"
+    );
+    assert!(
+        content.contains("\"x1 (b Asc, c Asc)\""),
+        "Quoted index name must preserve original case. Got:\n{content}"
+    );
+    assert!(
+        !content.contains("x1 (b asc, c asc)"),
+        "Quoted index name must not be lowercased. Got:\n{content}"
+    );
+
+    // Case-insensitive lookup is unaffected: a lowercased probe still finds the
+    // index that was created with mixed case.
+    assert!(db.index_exists("myidx"), "case-insensitive lookup must still work");
+
+    // Both emitted CREATE INDEX statements must re-lex/parse cleanly (the dump
+    // is text-only at this layer; a full execute round-trip lives in the
+    // executor crate, which has the parser+executor wired together).
+    for line in content.lines().filter(|l| l.trim_start().starts_with("CREATE INDEX")) {
+        vibesql_parser::Parser::parse_sql(line)
+            .unwrap_or_else(|e| panic!("Emitted index DDL must re-parse: {e}\nStatement: {line}"));
+    }
+
+    // Case-insensitive DROP removes the mixed-case index.
+    db.drop_index("MYIDX").expect("case-insensitive DROP must drop the mixed-case index");
+    assert!(!db.index_exists("MyIdx"), "index should be gone after case-insensitive drop");
+
+    std::fs::remove_file(path).ok();
+}
+
 #[test]
 fn test_sql_dump_all_data_types() {
     let mut db = Database::new();


### PR DESCRIPTION
Closes #5579

## Problem
VibeSQL's SQL dump (`Database::save_sql_dump`) emitted index names **lowercased**, whereas sqlite3 3.51.0 preserves the original spelling the user typed in `CREATE INDEX` (in both `.dump` and `sqlite_master`).

Repro from the issue:
```
CREATE INDEX "x1 (b Asc, c Asc)" ON t(b DESC, c);
# VibeSQL dump (before): CREATE INDEX "x1 (b asc, c asc)" ON t (b DESC, c);   ← lowercased
# sqlite3 .dump:         CREATE INDEX "x1 (b Asc, c Asc)" ON t(b DESC, c);    ← original case
```

## Root cause
The dump loop iterated `list_indexes()`, which returns the IndexManager's **storage keys**. Those keys are normalized to lowercase by `make_index_key` (#5540 schema-aware keying) for case-insensitive lookup. The DDL was then emitted from that normalized key. The original-case name was available all along on `metadata.index_name` (the executor passes `stmt.index_name` through verbatim).

## Fix
Emit `quote_identifier(&metadata.index_name)` (original case) instead of the normalized key. The **lookup key stays normalized** — only the displayed/dumped name changes — so case-insensitive resolution, DROP, and #5540 temp/main coexistence are unaffected.

`sqlite_master` already preserved case (it reads `catalog` `IndexMetadata.name`, also original-case); a regression test now locks that in.

## How original case is preserved (mirroring tables/triggers)
Like tables/triggers, the original-case name is stored on the metadata struct and emitted directly; only the map key is lowercased for lookup. No new field was needed — `IndexMetadata.index_name` already carried the original case; the dump was simply reading the wrong source.

## sqlite3 3.51.0 parity (verified end-to-end via built CLI)
- Quoted, special-char name: dump + `sqlite_master.name`/`.sql` → `"x1 (b Asc, c Asc)"` (was `x1 (b asc, c asc)`).
- Unquoted mixed-case name: `MyIdx2` preserved (was `myidx2`).
- Case-insensitive lookup intact: `DROP INDEX myidx` drops `MyIdx`; index disappears from `sqlite_master`.

## Round-trip
Emitted DDL re-lexes/parses cleanly (asserted in the storage test); the `.vbsql` dump reloads on each CLI open with the index preserved and usable.

## No regression
`cargo test -p vibesql-storage -p vibesql-catalog -p vibesql-executor` all green (storage 703+; catalog 48; executor 2835+). #5540/#5555 schema-keying, #5561/#5567 quoting, and partial-index dump tests unaffected.

## Tests added
- `vibesql-storage … sql_dump::test_sql_dump_preserves_index_name_case` — quoted + unquoted mixed-case names preserved in dump; case-insensitive `index_exists`/`DROP`; emitted DDL re-parses.
- `vibesql-executor … sqlite_schema::test_sqlite_schema_index_preserves_name_case` — `sqlite_master.name` and `.sql` preserve original case.

## Follow-ons
- Quote-**style** parity: sqlite3 preserves the exact token, so a name typed `"MyIdx"` (quoted) reloads quoted; VibeSQL stores only the name string and re-derives quoting from content, so a simple quoted name emits unquoted. Cosmetic only (reloads fine); out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)