### PR TITLE
fix(executor): resolve NEW/OLD in trigger WHEN-clause subqueries (#5585)

### DIFF
--- a/crates/vibesql-executor/src/evaluator/expressions/subqueries.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/subqueries.rs
@@ -26,6 +26,15 @@ impl ExpressionEvaluator<'_> {
             "IN with subquery requires database reference".to_string(),
         ))?;
 
+        // Trigger context (#5585): substitute NEW/OLD pseudo-variables with their
+        // literal values so a correlated IN subquery in a trigger WHEN clause
+        // resolves against the firing row. See `substitute_trigger_pseudo_vars`.
+        let substituted_subquery = match self.trigger_context {
+            Some(trigger_ctx) => Some(substitute_trigger_pseudo_vars(subquery, trigger_ctx)?),
+            None => None,
+        };
+        let subquery = substituted_subquery.as_ref().unwrap_or(subquery);
+
         // Handle row value IN subquery: (a, b) IN (SELECT x, y FROM t)
         if let vibesql_ast::Expression::RowValueConstructor(expr_elements) = expr {
             return self.eval_row_value_in_subquery(
@@ -213,51 +222,77 @@ impl ExpressionEvaluator<'_> {
         let outer_combined =
             crate::schema::CombinedSchema::from_table(table_name_for_outer, self.schema.clone());
 
-        // Check if this is a non-correlated subquery that can be cached
-        let is_correlated = crate::correlation::is_correlated(subquery, &outer_combined);
+        // Trigger context: when this scalar subquery is evaluated from within a
+        // trigger's WHEN clause (or body), its inner SELECT may reference the
+        // firing row's NEW/OLD pseudo-columns, e.g.
+        // `WHEN (SELECT count(*) FROM seen WHERE a = NEW.a) = 0` (#5585).
+        //
+        // We resolve NEW/OLD against the trigger context and substitute the
+        // resulting literal values into a cloned subquery AST *before*
+        // execution. This makes the subquery fully self-contained (no
+        // pseudo-variables, not correlated to NEW/OLD), so every downstream
+        // path — table scan with predicate pushdown, the iterator/materialized
+        // WHERE filter, aggregation, nested subqueries — works unchanged
+        // without threading the trigger context through the whole scan
+        // machinery. The substituted result is row-specific, so it is executed
+        // fresh (not cached). Non-trigger callers (trigger_context == None) fall
+        // through to the unchanged cached/correlated paths below.
+        if let Some(trigger_ctx) = self.trigger_context {
+            let substituted = substitute_trigger_pseudo_vars(subquery, trigger_ctx)?;
+            let select_executor = crate::select::SelectExecutor::new_with_depth(database, self.depth);
+            let rows = select_executor.execute(&substituted)?;
+            return super::super::subqueries_shared::eval_scalar_subquery_core(&rows);
+        }
 
-        // Execute or retrieve from cache
-        let rows = if !is_correlated {
-            // Non-correlated subquery - try cache first
-            let cache_key = compute_subquery_hash(subquery);
+        let rows = {
+            // Check if this is a non-correlated subquery that can be cached
+            let is_correlated = crate::correlation::is_correlated(subquery, &outer_combined);
 
-            // Check cache (use peek() for readonly access)
-            let cached_result = self.subquery_cache.borrow().peek(&cache_key).cloned();
+            // Execute or retrieve from cache
+            if !is_correlated {
+                // Non-correlated subquery - try cache first
+                let cache_key = compute_subquery_hash(subquery);
 
-            if let Some(cached_rows) = cached_result {
-                // Cache hit - use cached result
-                cached_rows
+                // Check cache (use peek() for readonly access)
+                let cached_result = self.subquery_cache.borrow().peek(&cache_key).cloned();
+
+                if let Some(cached_rows) = cached_result {
+                    // Cache hit - use cached result
+                    cached_rows
+                } else {
+                    // Cache miss - execute and cache
+                    // Use CTE context if available for WITH clause support in UPDATE/DELETE
+                    let select_executor = if let Some(cte_ctx) = self.cte_context {
+                        crate::select::SelectExecutor::new_with_cte_and_depth(
+                            database, cte_ctx, self.depth,
+                        )
+                    } else {
+                        crate::select::SelectExecutor::new_with_depth(database, self.depth)
+                    };
+                    let executed_rows = select_executor.execute(subquery)?;
+
+                    // Cache the result
+                    self.subquery_cache.borrow_mut().put(cache_key, executed_rows.clone());
+                    executed_rows
+                }
             } else {
-                // Cache miss - execute and cache
-                // Use CTE context if available for WITH clause support in UPDATE/DELETE
-                let select_executor = if let Some(cte_ctx) = self.cte_context {
+                // Correlated subquery - execute with outer context (can't cache)
+                let select_executor = if !outer_combined.table_schemas.is_empty() {
+                    crate::select::SelectExecutor::new_with_outer_context_and_depth(
+                        database,
+                        row,
+                        &outer_combined,
+                        self.depth,
+                    )
+                } else if let Some(cte_ctx) = self.cte_context {
                     crate::select::SelectExecutor::new_with_cte_and_depth(
                         database, cte_ctx, self.depth,
                     )
                 } else {
-                    crate::select::SelectExecutor::new_with_depth(database, self.depth)
+                    crate::select::SelectExecutor::new(database)
                 };
-                let executed_rows = select_executor.execute(subquery)?;
-
-                // Cache the result
-                self.subquery_cache.borrow_mut().put(cache_key, executed_rows.clone());
-                executed_rows
+                select_executor.execute(subquery)?
             }
-        } else {
-            // Correlated subquery - execute with outer context (can't cache)
-            let select_executor = if !outer_combined.table_schemas.is_empty() {
-                crate::select::SelectExecutor::new_with_outer_context_and_depth(
-                    database,
-                    row,
-                    &outer_combined,
-                    self.depth,
-                )
-            } else if let Some(cte_ctx) = self.cte_context {
-                crate::select::SelectExecutor::new_with_cte_and_depth(database, cte_ctx, self.depth)
-            } else {
-                crate::select::SelectExecutor::new(database)
-            };
-            select_executor.execute(subquery)?
         };
 
         // Delegate to shared logic
@@ -284,6 +319,16 @@ impl ExpressionEvaluator<'_> {
         let database = self.database.ok_or(ExecutorError::UnsupportedFeature(
             "EXISTS requires database reference".to_string(),
         ))?;
+
+        // Trigger context (#5585): substitute NEW/OLD pseudo-variables with their
+        // literal values so a correlated EXISTS subquery in a trigger WHEN clause
+        // (e.g. `WHEN EXISTS (SELECT 1 FROM other WHERE other.id = NEW.id)`)
+        // resolves against the firing row. See `substitute_trigger_pseudo_vars`.
+        let substituted_subquery = match self.trigger_context {
+            Some(trigger_ctx) => Some(substitute_trigger_pseudo_vars(subquery, trigger_ctx)?),
+            None => None,
+        };
+        let subquery = substituted_subquery.as_ref().unwrap_or(subquery);
 
         // Convert TableSchema to CombinedSchema for outer context
         // Use table_alias if set (for UPDATE t1 AS xyz), otherwise use schema name
@@ -365,6 +410,16 @@ impl ExpressionEvaluator<'_> {
         let database = self.database.ok_or(ExecutorError::UnsupportedFeature(
             "Quantified comparison requires database reference".to_string(),
         ))?;
+
+        // Trigger context (#5585): substitute NEW/OLD pseudo-variables with their
+        // literal values so a correlated ALL/ANY/SOME subquery in a trigger WHEN
+        // clause resolves against the firing row. See
+        // `substitute_trigger_pseudo_vars`.
+        let substituted_subquery = match self.trigger_context {
+            Some(trigger_ctx) => Some(substitute_trigger_pseudo_vars(subquery, trigger_ctx)?),
+            None => None,
+        };
+        let subquery = substituted_subquery.as_ref().unwrap_or(subquery);
 
         // Evaluate the left-hand expression
         let left_val = self.eval(expr, row)?;
@@ -597,6 +652,58 @@ impl ExpressionEvaluator<'_> {
             Ok(SqlValue::Boolean(negated))
         }
     }
+}
+
+/// Substitute trigger NEW/OLD pseudo-variables in a subquery with their literal
+/// values resolved from the trigger context (#5585).
+///
+/// A trigger's WHEN clause (or body) may contain a subquery whose inner SELECT
+/// references the firing row, e.g. `(SELECT count(*) FROM seen WHERE a = NEW.a)`.
+/// The subquery is executed by a fresh `SelectExecutor` that does not carry the
+/// trigger context, so a `NEW.a` reference inside it would otherwise fail with
+/// "Pseudo-variable NEW.a is only valid within trigger bodies". By replacing each
+/// `OLD.col` / `NEW.col` with the concrete value from the firing row, the
+/// returned subquery is self-contained and resolves through all the normal
+/// execution paths (scan pushdown, WHERE filter, aggregation, nesting).
+///
+/// Resolution errors (e.g. `NEW` not available for a DELETE trigger, or an
+/// unknown column) are propagated.
+fn substitute_trigger_pseudo_vars(
+    subquery: &vibesql_ast::SelectStmt,
+    trigger_ctx: &crate::trigger_execution::TriggerContext<'_>,
+) -> Result<vibesql_ast::SelectStmt, ExecutorError> {
+    struct PseudoVarSubstitutor<'a, 'b> {
+        trigger_ctx: &'a crate::trigger_execution::TriggerContext<'b>,
+        error: Option<ExecutorError>,
+    }
+
+    impl vibesql_ast::visitor::ExpressionMutVisitor for PseudoVarSubstitutor<'_, '_> {
+        fn post_visit_expression(
+            &mut self,
+            expr: vibesql_ast::Expression,
+        ) -> vibesql_ast::Expression {
+            if self.error.is_some() {
+                return expr;
+            }
+            if let vibesql_ast::Expression::PseudoVariable { pseudo_table, column } = &expr {
+                match self.trigger_ctx.resolve_pseudo_var(*pseudo_table, column) {
+                    Ok(value) => return vibesql_ast::Expression::Literal(value),
+                    Err(e) => {
+                        self.error = Some(e);
+                        return expr;
+                    }
+                }
+            }
+            expr
+        }
+    }
+
+    let mut substitutor = PseudoVarSubstitutor { trigger_ctx, error: None };
+    let rewritten = vibesql_ast::visitor::transform_select(&mut substitutor, subquery.clone());
+    if let Some(e) = substitutor.error {
+        return Err(e);
+    }
+    Ok(rewritten)
 }
 
 /// Apply SQLite affinity coercion rules for IN subquery comparisons

--- a/crates/vibesql-executor/tests/trigger_when_subquery_tests.rs
+++ b/crates/vibesql-executor/tests/trigger_when_subquery_tests.rs
@@ -90,3 +90,158 @@ fn when_subquery_fires_per_subquery_result_trigger2_3_2() {
     exec(&mut db, "INSERT INTO tbl VALUES(200, 0, 0, 0);");
     assert_eq!(query_scalar_i64(&db, "SELECT a FROM log;"), 1, "a>20 insert: t1 should fire");
 }
+
+/// #5585: a *correlated* WHEN subquery — one whose inner SELECT references the
+/// firing row's NEW pseudo-column — evaluates against current DB state and the
+/// trigger fires per the subquery result. Before the fix, the inner subquery's
+/// SelectExecutor carried no trigger context, so `NEW.a` failed at fire time
+/// with "Pseudo-variable NEW.a is only valid within trigger bodies".
+///
+/// Verified against sqlite3 3.51.0:
+/// ```text
+/// CREATE TABLE t(a);
+/// CREATE TABLE seen(a);
+/// CREATE TABLE log(n); INSERT INTO log VALUES(0);
+/// CREATE TRIGGER tr AFTER INSERT ON t
+///   WHEN (SELECT count(*) FROM seen WHERE a = NEW.a) = 0
+///   BEGIN UPDATE log SET n = n + 1; INSERT INTO seen VALUES(NEW.a); END;
+/// INSERT INTO t VALUES(5);  -- fires: seen has no a=5 -> log=1, seen={5}
+/// INSERT INTO t VALUES(5);  -- does not fire: seen already has a=5
+/// INSERT INTO t VALUES(7);  -- fires: log=2, seen={5,7}
+/// -- final: log.n = 2, seen = 5,7
+/// ```
+#[test]
+fn when_correlated_subquery_referencing_new_fires_per_condition_5585() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t (a);");
+    exec(&mut db, "CREATE TABLE seen (a);");
+    exec(&mut db, "CREATE TABLE log (n);");
+    exec(&mut db, "INSERT INTO log VALUES (0);");
+    exec(
+        &mut db,
+        "CREATE TRIGGER tr AFTER INSERT ON t \
+         WHEN (SELECT count(*) FROM seen WHERE a = NEW.a) = 0 \
+         BEGIN UPDATE log SET n = n + 1; INSERT INTO seen VALUES(NEW.a); END;",
+    );
+
+    // First insert of 5: seen has no a=5 -> WHEN is true -> fires.
+    exec(&mut db, "INSERT INTO t VALUES(5);");
+    assert_eq!(query_scalar_i64(&db, "SELECT n FROM log;"), 1, "first 5: trigger should fire");
+
+    // Second insert of 5: seen already has a=5 -> WHEN is false -> does not fire.
+    exec(&mut db, "INSERT INTO t VALUES(5);");
+    assert_eq!(query_scalar_i64(&db, "SELECT n FROM log;"), 1, "second 5: trigger should not fire");
+
+    // Insert of 7: seen has no a=7 -> WHEN is true -> fires.
+    exec(&mut db, "INSERT INTO t VALUES(7);");
+    assert_eq!(query_scalar_i64(&db, "SELECT n FROM log;"), 2, "7: trigger should fire");
+
+    // seen = {5, 7} (matches sqlite3 3.51.0).
+    assert_eq!(query_scalar_i64(&db, "SELECT count(*) FROM seen;"), 2, "seen should hold {{5,7}}");
+    assert_eq!(
+        query_scalar_i64(&db, "SELECT count(*) FROM seen WHERE a = 5;"),
+        1,
+        "seen should contain exactly one a=5"
+    );
+    assert_eq!(
+        query_scalar_i64(&db, "SELECT count(*) FROM seen WHERE a = 7;"),
+        1,
+        "seen should contain exactly one a=7"
+    );
+}
+
+/// #5585: a correlated WHEN subquery returning a scalar value (not just a
+/// count) referencing NEW. Mirrors the issue's `(SELECT val FROM other WHERE
+/// other.id = NEW.id) > 0` shape. Verified against sqlite3 3.51.0: with
+/// other = {(1,10),(2,0),(3,5)}, inserting ids 1,2,3 fires only for ids whose
+/// matching `val > 0`, i.e. hit = {1,3}.
+#[test]
+fn when_correlated_scalar_subquery_referencing_new_5585() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t (id, x);");
+    exec(&mut db, "CREATE TABLE other (id, val);");
+    exec(&mut db, "CREATE TABLE hit (id);");
+    exec(&mut db, "INSERT INTO other VALUES(1, 10);");
+    exec(&mut db, "INSERT INTO other VALUES(2, 0);");
+    exec(&mut db, "INSERT INTO other VALUES(3, 5);");
+    exec(
+        &mut db,
+        "CREATE TRIGGER tr AFTER INSERT ON t \
+         WHEN (SELECT val FROM other WHERE other.id = NEW.id) > 0 \
+         BEGIN INSERT INTO hit VALUES(NEW.id); END;",
+    );
+
+    exec(&mut db, "INSERT INTO t VALUES(1, 'a');");
+    exec(&mut db, "INSERT INTO t VALUES(2, 'b');");
+    exec(&mut db, "INSERT INTO t VALUES(3, 'c');");
+
+    assert_eq!(query_scalar_i64(&db, "SELECT count(*) FROM hit;"), 2, "hit should be {{1,3}}");
+    assert_eq!(
+        query_scalar_i64(&db, "SELECT count(*) FROM hit WHERE id = 1;"),
+        1,
+        "id 1 (val 10 > 0) should fire"
+    );
+    assert_eq!(
+        query_scalar_i64(&db, "SELECT count(*) FROM hit WHERE id = 2;"),
+        0,
+        "id 2 (val 0, not > 0) should not fire"
+    );
+    assert_eq!(
+        query_scalar_i64(&db, "SELECT count(*) FROM hit WHERE id = 3;"),
+        1,
+        "id 3 (val 5 > 0) should fire"
+    );
+}
+
+/// #5585: a correlated EXISTS subquery in a trigger WHEN clause referencing NEW.
+/// Verified against sqlite3 3.51.0: with other = {2,4}, inserting ids 1,2,4
+/// fires only when NEW.id EXISTS in other, i.e. hit = {2,4}.
+#[test]
+fn when_correlated_exists_subquery_referencing_new_5585() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t (id);");
+    exec(&mut db, "CREATE TABLE other (id);");
+    exec(&mut db, "CREATE TABLE hit (id);");
+    exec(&mut db, "INSERT INTO other VALUES(2);");
+    exec(&mut db, "INSERT INTO other VALUES(4);");
+    exec(
+        &mut db,
+        "CREATE TRIGGER tr AFTER INSERT ON t \
+         WHEN EXISTS (SELECT 1 FROM other WHERE other.id = NEW.id) \
+         BEGIN INSERT INTO hit VALUES(NEW.id); END;",
+    );
+
+    exec(&mut db, "INSERT INTO t VALUES(1);");
+    exec(&mut db, "INSERT INTO t VALUES(2);");
+    exec(&mut db, "INSERT INTO t VALUES(4);");
+
+    assert_eq!(query_scalar_i64(&db, "SELECT count(*) FROM hit;"), 2, "hit should be {{2,4}}");
+    assert_eq!(query_scalar_i64(&db, "SELECT count(*) FROM hit WHERE id = 1;"), 0, "id 1 not in other");
+    assert_eq!(query_scalar_i64(&db, "SELECT count(*) FROM hit WHERE id = 2;"), 1, "id 2 in other");
+    assert_eq!(query_scalar_i64(&db, "SELECT count(*) FROM hit WHERE id = 4;"), 1, "id 4 in other");
+}
+
+/// #5585 regression guard: a *non-trigger* correlated scalar subquery (ordinary
+/// query, no trigger context) is unaffected by the pseudo-variable substitution
+/// path. The subquery here correlates to the outer table's column, not NEW/OLD.
+#[test]
+fn non_trigger_correlated_scalar_subquery_unaffected_5585() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE outer_t (id, label);");
+    exec(&mut db, "CREATE TABLE inner_t (id, val);");
+    exec(&mut db, "INSERT INTO outer_t VALUES(1, 'a');");
+    exec(&mut db, "INSERT INTO outer_t VALUES(2, 'b');");
+    exec(&mut db, "INSERT INTO inner_t VALUES(1, 100);");
+    exec(&mut db, "INSERT INTO inner_t VALUES(2, 200);");
+
+    // Correlated scalar subquery against the outer row's column; no trigger.
+    assert_eq!(
+        query_scalar_i64(
+            &db,
+            "SELECT (SELECT val FROM inner_t WHERE inner_t.id = outer_t.id) \
+             FROM outer_t WHERE id = 2;",
+        ),
+        200,
+        "ordinary correlated scalar subquery must resolve to inner_t.val for id=2",
+    );
+}


### PR DESCRIPTION
Closes #5585

## Summary

A trigger's `WHEN` clause may contain a subquery whose inner `SELECT`
references the firing row's `NEW`/`OLD` pseudo-columns, e.g.

```sql
CREATE TRIGGER tr AFTER INSERT ON t
  WHEN (SELECT count(*) FROM seen WHERE a = NEW.a) = 0
  BEGIN UPDATE log SET n = n + 1; INSERT INTO seen VALUES(NEW.a); END;
```

Before this change the inner subquery executed in a fresh `SelectExecutor`
that carried no trigger context, so `NEW.a` failed at fire time with
`Pseudo-variable NEW.a is only valid within trigger bodies`. Follow-on from
#5581/#5586, which handled *non-correlated* WHEN subqueries.

## Fix: trigger-context threading into scalar-subquery eval

In the scalar / `EXISTS` / `IN` / quantified subquery evaluation paths
(`crates/vibesql-executor/src/evaluator/expressions/subqueries.rs`), when a
trigger context is present, each `NEW`/`OLD` pseudo-variable in a cloned
subquery AST is substituted with its concrete value resolved from the firing
row (`TriggerContext::resolve_pseudo_var`) *before* execution, via the AST
`transform_select` visitor. The rewritten subquery is then self-contained —
no pseudo-variables, not correlated to NEW/OLD — so it resolves through every
normal execution path (table scan with predicate pushdown, the
iterator/materialized WHERE filter, aggregation, nested subqueries) without
threading the trigger context through the whole scan machinery. The
substituted result is row-specific, so it executes fresh (not cached).

## sqlite3 3.51.0 parity

Reproduced and matched against sqlite3 3.51.0:

- Correlated `count` WHEN subquery: `WHEN (SELECT count(*) FROM seen WHERE a = NEW.a) = 0` → fires per de-dup condition; final `log.n=2`, `seen={5,7}`.
- Correlated scalar WHEN subquery: `WHEN (SELECT val FROM other WHERE other.id = NEW.id) > 0` → fires only for matching `val > 0` (hit = {1,3}).
- Correlated `EXISTS` WHEN subquery: `WHEN EXISTS (SELECT 1 FROM other WHERE other.id = NEW.id)` → fires only when NEW.id exists (hit = {2,4}).

## No regression (non-trigger subqueries unaffected)

The substitution only runs when `trigger_context` is `Some`; otherwise the
existing cached/correlated subquery paths run unchanged. A regression-guard
test asserts an ordinary correlated scalar subquery (no trigger) still
resolves correctly.

- `cargo test -p vibesql-executor`: 4441 passed, 0 failed.
- `cargo test -p vibesql-ast`: 152 passed, 0 failed.
- New tests in `trigger_when_subquery_tests.rs`: correlated count/scalar/EXISTS WHEN subqueries + non-trigger regression guard (5 passing).
- #5586's non-correlated `trigger2-3.2` test still passes.

## Trigger TCL delta

`trigger2.test` (which contains the `trigger2-3.2` WHEN-subquery scenario)
remains 100% pass (70/70). Other trigger files (trigger1/trigger3/triggerC)
have only their pre-existing, unrelated feature-gap failures — none touched
by this subquery-context change.

## Scope / coordination

Scoped to WHEN-clause correlated subqueries (what #5585 names). The same
substitution naturally covers trigger-body subqueries that flow through these
evaluator paths. Touches only the scalar-subquery evaluator + a small AST
substitution helper. Note: parallel builder #5531 touches trigger *firing
dispatch* (`trigger_execution.rs`); this PR does not modify trigger firing —
only the subquery evaluator — so overlap is minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)