### PR TITLE
fix(executor): keep temp-view INSTEAD OF DML missing-body-table unqualified (#5589)

### DIFF
--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -1250,13 +1250,19 @@ fn build_view_schema(
     view_def: &vibesql_catalog::ViewDefinition,
 ) -> Result<vibesql_catalog::TableSchema, ExecutorError> {
     // Execute the view's SELECT query to get column names. A table referenced by
-    // the view body that has since been dropped surfaces here; sqlite3 reports it
-    // schema-qualified (`no such table: main.test2`) because the view body
-    // resolves against the database schema, so qualify the bare name.
+    // the view body that has since been dropped surfaces here; for a main-schema
+    // view sqlite3 reports it schema-qualified (`no such table: main.test2`)
+    // because the view body resolves against the database schema, so qualify the
+    // bare name. A temp view's body resolves against the temp schema, which
+    // sqlite3 reports unqualified, so skip the qualifier there. This mirrors the
+    // read-path guard in select/scan/table.rs (#5584) for read/write parity.
     let select_executor = crate::SelectExecutor::new(database);
-    let result = select_executor
-        .execute_with_columns(&view_def.query)
-        .map_err(ExecutorError::with_main_schema_qualifier)?;
+    let select_result = select_executor.execute_with_columns(&view_def.query);
+    let result = if view_def.is_temp() {
+        select_result?
+    } else {
+        select_result.map_err(ExecutorError::with_main_schema_qualifier)?
+    };
 
     // Use explicit column names if provided, otherwise derive from SELECT
     let column_names: Vec<String> =

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -1689,13 +1689,20 @@ fn build_view_schema(
     view_def: &vibesql_catalog::ViewDefinition,
 ) -> Result<vibesql_catalog::TableSchema, ExecutorError> {
     // Execute the view's SELECT query to get column names. A table referenced by
-    // the view body that has since been dropped surfaces here; sqlite3 reports it
-    // schema-qualified (`no such table: main.test2`, trigger4-3.1/3.2) because the
-    // view body resolves against the database schema, so qualify the bare name.
+    // the view body that has since been dropped surfaces here; for a main-schema
+    // view sqlite3 reports it schema-qualified (`no such table: main.test2`,
+    // trigger4-3.1/3.2) because the view body resolves against the database
+    // schema, so qualify the bare name. A temp view's body resolves against the
+    // temp schema, which sqlite3 reports unqualified, so skip the qualifier
+    // there. This mirrors the read-path guard in select/scan/table.rs (#5584)
+    // for read/write parity.
     let select_executor = crate::SelectExecutor::new(db);
-    let result = select_executor
-        .execute_with_columns(&view_def.query)
-        .map_err(ExecutorError::with_main_schema_qualifier)?;
+    let select_result = select_executor.execute_with_columns(&view_def.query);
+    let result = if view_def.is_temp() {
+        select_result?
+    } else {
+        select_result.map_err(ExecutorError::with_main_schema_qualifier)?
+    };
 
     // Use explicit column names if provided, otherwise derive from SELECT
     let column_names: Vec<String> =

--- a/crates/vibesql-executor/src/update/triggers.rs
+++ b/crates/vibesql-executor/src/update/triggers.rs
@@ -424,13 +424,20 @@ pub(super) fn build_view_schema(
     view_def: &ViewDefinition,
 ) -> Result<TableSchema, ExecutorError> {
     // Execute the view's SELECT query to get column names. A table referenced by
-    // the view body that has since been dropped surfaces here; sqlite3 reports it
-    // schema-qualified (`no such table: main.test2`, trigger4-3.3) because the
-    // view body resolves against the database schema, so qualify the bare name.
+    // the view body that has since been dropped surfaces here; for a main-schema
+    // view sqlite3 reports it schema-qualified (`no such table: main.test2`,
+    // trigger4-3.3) because the view body resolves against the database schema,
+    // so qualify the bare name. A temp view's body resolves against the temp
+    // schema, which sqlite3 reports unqualified, so skip the qualifier there.
+    // This mirrors the read-path guard in select/scan/table.rs (#5584) for
+    // read/write parity.
     let select_executor = crate::SelectExecutor::new(database);
-    let result = select_executor
-        .execute_with_columns(&view_def.query)
-        .map_err(ExecutorError::with_main_schema_qualifier)?;
+    let select_result = select_executor.execute_with_columns(&view_def.query);
+    let result = if view_def.is_temp() {
+        select_result?
+    } else {
+        select_result.map_err(ExecutorError::with_main_schema_qualifier)?
+    };
 
     // Use explicit column names if provided, otherwise derive from SELECT
     let column_names: Vec<String> =

--- a/crates/vibesql-executor/tests/temp_view_dml_missing_table_unqualified_tests.rs
+++ b/crates/vibesql-executor/tests/temp_view_dml_missing_table_unqualified_tests.rs
@@ -1,0 +1,172 @@
+//! INSERT/UPDATE/DELETE on a view whose body references a missing table must
+//! report that table schema-qualified (`main.<name>`) for a **main** view but
+//! *unqualified* (bare `<name>`) for a **temp** view, matching sqlite3 3.51.0.
+//!
+//! A view body resolves its tables against its own schema: a main-schema view
+//! body resolves against the database schema, so sqlite3 names a missing table
+//! with the implicit `main.` prefix; a temp view body resolves against the temp
+//! schema, which sqlite3 reports *without* a prefix. The three INSTEAD OF
+//! view-DML paths (`delete/executor.rs`, `insert/execution.rs`,
+//! `update/triggers.rs`) build a view pseudo-schema and now guard the `main.`
+//! qualifier behind `ViewDefinition::is_temp()`, mirroring the read-path guard in
+//! `select/scan/table.rs` (#5584) for full read/write parity. See #5589.
+//!
+//! Reachability note: the issue's motivating sequence (CREATE temp view over a
+//! temp table, then DROP that temp table) is *not* reachable in VibeSQL today —
+//! `DROP TABLE` is blocked by a dependency check while a dependent temp
+//! view/trigger references the table (a separate divergence from sqlite, tracked
+//! independently). These tests instead use the equally valid and fully reachable
+//! scenario of a view whose body references a *never-existing* table: sqlite (and
+//! VibeSQL) allow `CREATE [TEMP] VIEW` over a missing table with deferred
+//! resolution, and the missing-table error surfaces at DML time through the same
+//! `build_view_schema` qualifier path. Verified against sqlite3 3.51.0:
+//!
+//! ```text
+//! sqlite> create temp view tv as select id, b from nonexistent;
+//! sqlite> create temp trigger tv_ins instead of insert on tv begin select 1; end;
+//! sqlite> insert into tv values(1,2);
+//! Error: in prepare, no such table: nonexistent          -- temp: bare
+//!
+//! sqlite> create view mv as select id, b from nonexistent;
+//! sqlite> create trigger mv_ins instead of insert on mv begin select 1; end;
+//! sqlite> insert into mv values(1,2);
+//! Error: in prepare, no such table: main.nonexistent     -- main: qualified
+//! ```
+
+use vibesql_executor::{
+    DeleteExecutor, ExecutorError, InsertExecutor, TriggerExecutor, UpdateExecutor, ViewExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+/// Parse and execute a single DDL statement (CREATE VIEW / CREATE TRIGGER),
+/// panicking on failure.
+fn exec_ok(db: &mut Database, sql: &str) {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e:?}"));
+    match stmt {
+        Statement::CreateView(s) => {
+            ViewExecutor::execute_create_view(&s, db).expect("CREATE VIEW failed");
+        }
+        Statement::CreateTrigger(s) => {
+            TriggerExecutor::create_trigger_with_sql(db, &s, Some(sql))
+                .expect("CREATE TRIGGER failed");
+        }
+        other => panic!("unsupported statement in exec_ok: {other:?}"),
+    }
+}
+
+/// Build a temp view over a never-existing table plus temp INSTEAD OF triggers.
+fn setup_temp_view(db: &mut Database) {
+    exec_ok(db, "create temp view tv as select id, b from nonexistent");
+    exec_ok(db, "create temp trigger tv_ins instead of insert on tv begin select 1; end");
+    exec_ok(db, "create temp trigger tv_upd instead of update on tv begin select 1; end");
+    exec_ok(db, "create temp trigger tv_del instead of delete on tv begin select 1; end");
+    assert!(
+        db.catalog.get_view("tv").expect("temp view tv should exist").is_temp(),
+        "tv must be a temp view for this test to exercise the temp (bare) branch"
+    );
+}
+
+/// Build a main-schema view over a never-existing table plus INSTEAD OF triggers.
+fn setup_main_view(db: &mut Database) {
+    exec_ok(db, "create view mv as select id, b from nonexistent");
+    exec_ok(db, "create trigger mv_ins instead of insert on mv begin select 1; end");
+    exec_ok(db, "create trigger mv_upd instead of update on mv begin select 1; end");
+    exec_ok(db, "create trigger mv_del instead of delete on mv begin select 1; end");
+    assert!(
+        !db.catalog.get_view("mv").expect("main view mv should exist").is_temp(),
+        "mv must be a main-schema view for this test to exercise the qualified branch"
+    );
+}
+
+fn insert_err(db: &mut Database, sql: &str) -> ExecutorError {
+    let vibesql_ast::Statement::Insert(s) = Parser::parse_sql(sql).unwrap() else {
+        panic!("expected INSERT")
+    };
+    InsertExecutor::execute(db, &s).expect_err("expected INSERT to fail")
+}
+
+fn update_err(db: &mut Database, sql: &str) -> ExecutorError {
+    let vibesql_ast::Statement::Update(s) = Parser::parse_sql(sql).unwrap() else {
+        panic!("expected UPDATE")
+    };
+    UpdateExecutor::execute(&s, db).expect_err("expected UPDATE to fail")
+}
+
+fn delete_err(db: &mut Database, sql: &str) -> ExecutorError {
+    let vibesql_ast::Statement::Delete(s) = Parser::parse_sql(sql).unwrap() else {
+        panic!("expected DELETE")
+    };
+    DeleteExecutor::execute(&s, db).expect_err("expected DELETE to fail")
+}
+
+// --- temp view: missing body table stays bare (the #5589 fix) ---
+
+#[test]
+fn insert_on_temp_view_with_missing_body_table_stays_unqualified() {
+    let mut db = Database::new();
+    setup_temp_view(&mut db);
+    assert_eq!(
+        insert_err(&mut db, "insert into tv values(1,2)"),
+        ExecutorError::TableNotFound("nonexistent".to_string()),
+        "temp-view INSERT must report the missing body table bare (sqlite3 parity)"
+    );
+}
+
+#[test]
+fn update_on_temp_view_with_missing_body_table_stays_unqualified() {
+    let mut db = Database::new();
+    setup_temp_view(&mut db);
+    assert_eq!(
+        update_err(&mut db, "update tv set b=4 where id=1"),
+        ExecutorError::TableNotFound("nonexistent".to_string()),
+        "temp-view UPDATE must report the missing body table bare (sqlite3 parity)"
+    );
+}
+
+#[test]
+fn delete_on_temp_view_with_missing_body_table_stays_unqualified() {
+    let mut db = Database::new();
+    setup_temp_view(&mut db);
+    assert_eq!(
+        delete_err(&mut db, "delete from tv where id=1"),
+        ExecutorError::TableNotFound("nonexistent".to_string()),
+        "temp-view DELETE must report the missing body table bare (sqlite3 parity)"
+    );
+}
+
+// --- main view: missing body table stays qualified (#5569 must not regress) ---
+
+#[test]
+fn insert_on_main_view_with_missing_body_table_stays_qualified() {
+    let mut db = Database::new();
+    setup_main_view(&mut db);
+    assert_eq!(
+        insert_err(&mut db, "insert into mv values(1,2)"),
+        ExecutorError::TableNotFound("main.nonexistent".to_string()),
+        "main-view INSERT must still report main.<name> (no regression to #5569)"
+    );
+}
+
+#[test]
+fn update_on_main_view_with_missing_body_table_stays_qualified() {
+    let mut db = Database::new();
+    setup_main_view(&mut db);
+    assert_eq!(
+        update_err(&mut db, "update mv set b=4 where id=1"),
+        ExecutorError::TableNotFound("main.nonexistent".to_string()),
+        "main-view UPDATE must still report main.<name> (no regression to #5569)"
+    );
+}
+
+#[test]
+fn delete_on_main_view_with_missing_body_table_stays_qualified() {
+    let mut db = Database::new();
+    setup_main_view(&mut db);
+    assert_eq!(
+        delete_err(&mut db, "delete from mv where id=1"),
+        ExecutorError::TableNotFound("main.nonexistent".to_string()),
+        "main-view DELETE must still report main.<name> (no regression to #5569)"
+    );
+}


### PR DESCRIPTION
Closes #5589

## Summary

Follow-on from #5569 / #5584. The three INSTEAD OF view-DML `build_view_schema` sites introduced in #5569 qualified a missing view-body table as `main.<name>` **unconditionally** (no temp check). A temp view's body resolves against the temp schema, which sqlite3 3.51.0 reports *unqualified*, so a temp-view INSERT/UPDATE/DELETE over a missing body table should report the bare name.

This applies the same `if view_def.is_temp() { ... } else { ....map_err(with_main_schema_qualifier) }` guard that #5584 added to the read path (`select/scan/table.rs`) to the three DML sites, for full read/write parity.

## The 3 DML sites guarded (mirroring #5584)

- `crates/vibesql-executor/src/delete/executor.rs` (`build_view_schema`)
- `crates/vibesql-executor/src/insert/execution.rs` (`build_view_schema`)
- `crates/vibesql-executor/src/update/triggers.rs` (`build_view_schema`)

Each now runs `execute_with_columns(&view_def.query)` and only applies `ExecutorError::with_main_schema_qualifier` when the view is **not** temp.

## sqlite3 3.51.0 parity (verified)

- **temp** view INSTEAD OF INSERT/UPDATE/DELETE, missing body table → bare `nonexistent`
- **main** view INSTEAD OF INSERT/UPDATE/DELETE, missing body table → `main.nonexistent`

```text
sqlite> create temp view tv as select id, b from nonexistent;
sqlite> create temp trigger tv_ins instead of insert on tv begin select 1; end;
sqlite> insert into tv values(1,2);
Error: in prepare, no such table: nonexistent          -- temp: bare

sqlite> create view mv as select id, b from nonexistent;
sqlite> create trigger mv_ins instead of insert on mv begin select 1; end;
sqlite> insert into mv values(1,2);
Error: in prepare, no such table: main.nonexistent     -- main: qualified
```

## Reachability note

The issue's motivating sequence (CREATE temp view over a temp table, then DROP that temp table) is **not reachable in VibeSQL today**: `DROP TABLE` is blocked by a dependency check while a dependent temp view/trigger references the table (a separate sqlite divergence, worth tracking independently — see follow-on below). I confirmed this directly: `DROP TABLE t2` under a dependent temp view returns `Catalog error: Table 't2' not found`, while the same DROP for a main table succeeds and leaves the body dangling.

The tests therefore use the **equally valid and fully reachable** scenario of a view whose body references a *never-existing* table. sqlite (and VibeSQL) allow `CREATE [TEMP] VIEW` over a missing table with deferred resolution, and the missing-table error surfaces at DML time through the same `build_view_schema` qualifier path — exercising the exact code under test.

## Tests

New `crates/vibesql-executor/tests/temp_view_dml_missing_table_unqualified_tests.rs` (6 tests):
- temp-view INSERT/UPDATE/DELETE → bare `nonexistent` (the #5589 fix)
- main-view INSERT/UPDATE/DELETE → `main.nonexistent` (regression guard for #5569)

## No regression

- #5569 main-view DML tests: 3/3 pass
- #5584 read-path tests: 2/2 pass
- `cargo test -p vibesql-executor`: all 31 test binaries pass, 0 failures

## Follow-on

The DROP-dependency divergence (VibeSQL refusing to drop a temp table referenced by a dependent temp view/trigger, which sqlite permits) is separate and will be filed as a follow-on issue; aligning it would make the issue's original DROP-based sequence reachable, at which point these guards already produce the correct bare name.