### PR TITLE
feat(executor): cascade-drop triggers ON a dropped table (temp lifecycle)

### DIFF
--- a/crates/vibesql-catalog/src/store/advanced/triggers.rs
+++ b/crates/vibesql-catalog/src/store/advanced/triggers.rs
@@ -143,6 +143,77 @@ impl super::super::Catalog {
         }
     }
 
+    /// Drop all triggers defined *on* a table (called when dropping the table).
+    ///
+    /// SQLite drops every trigger whose `ON <table>` target is the dropped table
+    /// (verified against sqlite3 3.51.0):
+    ///
+    /// ```sql
+    /// CREATE TEMP TABLE t(a);
+    /// CREATE TEMP TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1; END;
+    /// DROP TABLE t;   -- tr is gone
+    /// ```
+    ///
+    /// A trigger merely *referencing* the table from its body (but defined ON a
+    /// different table) is NOT dropped, and a view referencing the table is NOT
+    /// dropped either — those are out of scope here and handled by their own
+    /// lifecycle rules.
+    ///
+    /// Schema-aware (mirrors [`Catalog::drop_table_indexes`], #5513): the dropped
+    /// table's owning schema is resolved with the same temp-shadows-main order as
+    /// table lookup, and a trigger is removed only when it is *bound* to that same
+    /// schema. This keeps a `main` trigger on `main.t` from being dropped when a
+    /// same-named `temp.t` is dropped, and vice versa (triggerD-3.1/3.2 binding).
+    ///
+    /// Must be called *before* the table is removed from the catalog so trigger
+    /// binding can still resolve the target table's schema. `table_name` may be
+    /// schema-qualified (e.g. `temp.t`) to target a specific schema.
+    ///
+    /// Returns the names of the dropped triggers.
+    pub fn drop_table_triggers(&mut self, table_name: &str) -> Vec<String> {
+        // Resolve which schema the table being dropped lives in, mirroring
+        // `drop_table_indexes`. If the table is already gone, fall back to a
+        // name-only match across schemas.
+        let resolved_schema = self.resolve_table_schema_name(table_name);
+
+        let (bare_table_name, schema_filter) =
+            if let Some((schema_part, table_part)) = table_name.split_once('.') {
+                (table_part.to_string(), Some(self.resolve_schema_name(schema_part).to_string()))
+            } else {
+                (table_name.to_string(), resolved_schema)
+            };
+
+        let triggers_to_remove: Vec<String> = self
+            .triggers
+            .values()
+            .filter(|trigger| {
+                // Only triggers defined ON the dropped table (case-insensitive,
+                // SQLite-compatible).
+                if !trigger.table_name.eq_ignore_ascii_case(&bare_table_name) {
+                    return false;
+                }
+                match &schema_filter {
+                    // Drop only triggers bound to the same internal schema as the
+                    // dropped table. When the trigger's binding cannot be resolved
+                    // (e.g. its target was already gone), drop it — its only
+                    // anchor was the table now being removed.
+                    Some(schema) => self
+                        .trigger_bound_schema(trigger)
+                        .is_none_or(|bound| bound.eq_ignore_ascii_case(schema)),
+                    // No resolvable owning schema for the dropped table: match by
+                    // table name only (mirrors the index-drop fallback).
+                    None => true,
+                }
+            })
+            .map(|trigger| trigger.name.clone())
+            .collect();
+
+        triggers_to_remove
+            .into_iter()
+            .filter_map(|name| self.triggers.remove(&name).map(|_| name))
+            .collect()
+    }
+
     /// List all trigger names
     pub fn list_triggers(&self) -> Vec<String> {
         self.triggers.keys().cloned().collect()
@@ -262,6 +333,65 @@ mod tests {
         let mut both = names_in_schema(&catalog, "t300", None);
         both.sort();
         assert_eq!(both, vec!["r300".to_string(), "r301".to_string()]);
+    }
+
+    /// `drop_table_triggers` removes triggers defined ON the dropped table and
+    /// leaves triggers that are on a different table (even if they reference the
+    /// dropped one in their body) untouched — matching sqlite3 3.51.0.
+    #[test]
+    fn drop_table_triggers_removes_only_triggers_on_the_table() {
+        let mut catalog = Catalog::new();
+        catalog.set_case_sensitive_identifiers(false);
+
+        let col = || ColumnSchema::new("x".to_string(), DataType::Integer, true);
+        catalog.create_table(TableSchema::new("t".to_string(), vec![col()])).unwrap();
+        catalog.create_table(TableSchema::new("other".to_string(), vec![col()])).unwrap();
+
+        // tr is ON t (should be dropped); tr2 is ON other (should survive even
+        // though sqlite3 would also let it reference t in its body).
+        catalog.create_trigger(sample_trigger("tr", "t")).unwrap();
+        catalog.create_trigger(sample_trigger("tr2", "other")).unwrap();
+
+        let dropped = catalog.drop_table_triggers("t");
+        assert_eq!(dropped, vec!["tr".to_string()]);
+        assert!(catalog.get_trigger("tr").is_none());
+        assert!(catalog.get_trigger("tr2").is_some());
+    }
+
+    /// Dropping a `temp` table removes its temp trigger but leaves a same-named
+    /// `main` table's trigger intact (schema-aware binding, mirrors the
+    /// index-drop schema isolation).
+    #[test]
+    fn drop_table_triggers_is_schema_aware() {
+        let mut catalog = Catalog::new();
+        catalog.set_case_sensitive_identifiers(false);
+
+        let col = || ColumnSchema::new("x".to_string(), DataType::Integer, true);
+        // t exists in BOTH main and temp.
+        catalog.create_table(TableSchema::new("t".to_string(), vec![col()])).unwrap();
+        let temp_schema = catalog.temp_schema_name().to_string();
+        catalog
+            .create_table_in_schema(&temp_schema, TableSchema::new("t".to_string(), vec![col()]))
+            .unwrap();
+
+        // main trigger bound to main.t; temp trigger bound to temp.t.
+        catalog
+            .create_trigger(sample_trigger("rmain", "t").with_schema(Some("main".to_string())))
+            .unwrap();
+        catalog
+            .create_trigger(sample_trigger("rtemp", "t").with_schema(Some("temp".to_string())))
+            .unwrap();
+
+        // Dropping the temp table removes only the temp-bound trigger.
+        let dropped = catalog.drop_table_triggers("temp.t");
+        assert_eq!(dropped, vec!["rtemp".to_string()]);
+        assert!(catalog.get_trigger("rtemp").is_none());
+        assert!(catalog.get_trigger("rmain").is_some());
+
+        // Dropping the main table now removes the main-bound trigger.
+        let dropped_main = catalog.drop_table_triggers("main.t");
+        assert_eq!(dropped_main, vec!["rmain".to_string()]);
+        assert!(catalog.get_trigger("rmain").is_none());
     }
 
     /// A temp trigger on a table that exists only in main binds to (and fires

--- a/crates/vibesql-executor/src/drop_table.rs
+++ b/crates/vibesql-executor/src/drop_table.rs
@@ -91,19 +91,36 @@ impl DropTableExecutor {
             let _ = database.drop_spatial_index(&qualified);
         }
 
+        // Cascade-drop triggers defined ON this table, matching sqlite3 3.51.0:
+        // `DROP TABLE t` removes every trigger whose `ON t` target is the dropped
+        // table (temp or main). Must run while the table still exists in the
+        // catalog so the trigger's schema binding can resolve. A trigger that only
+        // *references* the table from its body, and a view referencing the table,
+        // are intentionally left alone (sqlite3 leaves those — the view errors on
+        // use). See `Catalog::drop_table_triggers`.
+        let dropped_triggers = database.catalog.drop_table_triggers(&stmt.table_name);
+        let trigger_count = dropped_triggers.len();
+
         // Drop the table from storage (this also removes from catalog)
         database
             .drop_table(&stmt.table_name)
             .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
 
         // Return success message
-        if index_count > 0 {
-            Ok(format!(
+        match (index_count, trigger_count) {
+            (0, 0) => Ok(format!("Table '{}' dropped successfully", stmt.table_name)),
+            (i, 0) => Ok(format!(
                 "Table '{}' and {} associated index(es) dropped successfully",
-                stmt.table_name, index_count
-            ))
-        } else {
-            Ok(format!("Table '{}' dropped successfully", stmt.table_name))
+                stmt.table_name, i
+            )),
+            (0, t) => Ok(format!(
+                "Table '{}' and {} associated trigger(s) dropped successfully",
+                stmt.table_name, t
+            )),
+            (i, t) => Ok(format!(
+                "Table '{}', {} associated index(es), and {} associated trigger(s) dropped successfully",
+                stmt.table_name, i, t
+            )),
         }
     }
 }

--- a/crates/vibesql-executor/tests/sqlite_temp_master_tests.rs
+++ b/crates/vibesql-executor/tests/sqlite_temp_master_tests.rs
@@ -14,6 +14,7 @@
 
 use vibesql_executor::{
     CreateIndexExecutor, CreateTableExecutor, DropIndexExecutor, DropTableExecutor, SelectExecutor,
+    TriggerExecutor, ViewExecutor,
 };
 use vibesql_parser::Parser;
 use vibesql_storage::{Database, Row};
@@ -68,6 +69,41 @@ fn exec_drop_table(db: &mut Database, sql: &str) {
         }
         other => panic!("expected DROP TABLE, got {other:?}"),
     };
+}
+
+fn exec_create_trigger(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse CREATE TRIGGER");
+    match stmt {
+        vibesql_ast::Statement::CreateTrigger(s) => {
+            TriggerExecutor::create_trigger(db, &s).expect("CREATE TRIGGER");
+        }
+        other => panic!("expected CREATE TRIGGER, got {other:?}"),
+    };
+}
+
+fn exec_create_view(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse CREATE VIEW");
+    match stmt {
+        vibesql_ast::Statement::CreateView(s) => {
+            ViewExecutor::execute_create_view(&s, db).expect("CREATE VIEW");
+        }
+        other => panic!("expected CREATE VIEW, got {other:?}"),
+    };
+}
+
+/// Run a SELECT and return whether it errored (used to assert "view errors on
+/// use" parity after its underlying table is dropped).
+fn select_is_err(db: &Database, sql: &str) -> bool {
+    let stmt = match Parser::parse_sql(sql) {
+        Ok(s) => s,
+        Err(_) => return true,
+    };
+    match stmt {
+        vibesql_ast::Statement::Select(s) => {
+            SelectExecutor::new(db).execute_with_columns(&s).is_err()
+        }
+        other => panic!("expected SELECT, got {other:?}"),
+    }
 }
 
 fn select(db: &Database, sql: &str) -> (Vec<String>, Vec<Row>) {
@@ -247,4 +283,129 @@ fn temp_index_dropped_with_temp_table() {
         names(&after_main).contains(&"mi".to_string()),
         "main index must survive dropping the temp table"
     );
+}
+
+/// Issue #5583 — temp lifecycle: a temp trigger defined ON a temp table is
+/// dropped together with that table, while a temp VIEW referencing the table is
+/// NOT auto-dropped (it remains in sqlite_temp_master and errors on use).
+///
+/// Verified against sqlite3 3.51.0:
+///
+/// ```text
+/// CREATE TEMP TABLE t(a);
+/// CREATE TEMP TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1; END;
+/// CREATE TEMP VIEW v AS SELECT * FROM t;
+/// DROP TABLE t;                  -- tr gone, v remains
+/// SELECT type,name FROM sqlite_temp_master;  -- only: view v
+/// SELECT * FROM v;               -- Error: no such table: t
+/// ```
+#[test]
+fn temp_trigger_dropped_with_temp_table_view_remains() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TEMP TABLE t (a)");
+    exec_create_trigger(&mut db, "CREATE TEMP TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1; END");
+    exec_create_view(&mut db, "CREATE TEMP VIEW v AS SELECT * FROM t");
+
+    // Before the drop: both the trigger and the view are surfaced by temp_master.
+    let (_, before) = select(&db, "SELECT name FROM sqlite_temp_master WHERE type='trigger'");
+    assert!(names(&before).contains(&"tr".to_string()), "temp trigger should be listed before drop");
+    let (_, before_v) = select(&db, "SELECT name FROM sqlite_temp_master WHERE type='view'");
+    assert!(names(&before_v).contains(&"v".to_string()), "temp view should be listed before drop");
+
+    // Drop the temp table (schema-qualified: unqualified DROP TABLE not resolving
+    // into temp is a separate pre-existing limitation, same as the index test).
+    exec_drop_table(&mut db, "DROP TABLE temp.t");
+
+    // The temp trigger ON the table is gone (matches sqlite3).
+    let (_, after_tr) = select(&db, "SELECT name FROM sqlite_temp_master WHERE type='trigger'");
+    assert!(
+        !names(&after_tr).contains(&"tr".to_string()),
+        "temp trigger ON the dropped table must be cascade-dropped"
+    );
+
+    // The view referencing the table is NOT auto-dropped (matches sqlite3).
+    let (_, after_v) = select(&db, "SELECT name FROM sqlite_temp_master WHERE type='view'");
+    assert!(
+        names(&after_v).contains(&"v".to_string()),
+        "a view merely referencing the dropped table must NOT be auto-dropped"
+    );
+
+    // ...but the surviving view errors on use, since its base table is gone.
+    assert!(
+        select_is_err(&db, "SELECT * FROM v"),
+        "the surviving view must error on use after its base table is dropped"
+    );
+}
+
+/// Issue #5583 — main-schema parity: `DROP TABLE` drops a trigger defined ON the
+/// table, but NOT a trigger defined ON a *different* table even if it references
+/// the dropped one in its body.
+///
+/// Verified against sqlite3 3.51.0:
+///
+/// ```text
+/// CREATE TABLE t(a);  CREATE TABLE other(b);
+/// CREATE TRIGGER tr  AFTER INSERT ON t     BEGIN SELECT 1; END;
+/// CREATE TRIGGER tr2 AFTER INSERT ON other BEGIN INSERT INTO t VALUES(1); END;
+/// DROP TABLE t;       -- tr gone, tr2 remains (it is ON other)
+/// ```
+#[test]
+fn main_drop_table_drops_only_triggers_on_that_table() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TABLE t (a)");
+    exec_create_table(&mut db, "CREATE TABLE other (b)");
+    exec_create_trigger(&mut db, "CREATE TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1; END");
+    exec_create_trigger(
+        &mut db,
+        "CREATE TRIGGER tr2 AFTER INSERT ON other BEGIN INSERT INTO t VALUES (1); END",
+    );
+
+    exec_drop_table(&mut db, "DROP TABLE t");
+
+    let (_, after) = select(&db, "SELECT name FROM sqlite_master WHERE type='trigger'");
+    let listed = names(&after);
+    assert!(
+        !listed.contains(&"tr".to_string()),
+        "trigger ON the dropped table must be removed: {listed:?}"
+    );
+    assert!(
+        listed.contains(&"tr2".to_string()),
+        "trigger ON a different table (even if it references the dropped one) must survive: {listed:?}"
+    );
+}
+
+/// Issue #5583 — connection-close / schema isolation: each connection owns its
+/// own `Catalog` (per `Catalog::new()` session), so temp triggers and views are
+/// connection-local by construction and a fresh connection sees none of the
+/// previous connection's temp objects. (Connection close is structural: the
+/// `Catalog` — including the flat view/trigger maps and the session temp schema —
+/// is dropped wholesale.)
+#[test]
+fn temp_trigger_and_view_are_connection_local() {
+    // Connection A creates temp objects.
+    let mut db_a = Database::new();
+    exec_create_table(&mut db_a, "CREATE TEMP TABLE t (a)");
+    exec_create_trigger(&mut db_a, "CREATE TEMP TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1; END");
+    exec_create_view(&mut db_a, "CREATE TEMP VIEW v AS SELECT * FROM t");
+
+    let (_, a_objs) = select(&db_a, "SELECT name FROM sqlite_temp_master");
+    let a_listed = names(&a_objs);
+    assert!(a_listed.contains(&"tr".to_string()));
+    assert!(a_listed.contains(&"v".to_string()));
+
+    // A separate connection B sees none of A's temp objects.
+    let db_b = Database::new();
+    let (_, b_objs) = select(&db_b, "SELECT name FROM sqlite_temp_master");
+    let b_listed = names(&b_objs);
+    assert!(
+        !b_listed.contains(&"tr".to_string()),
+        "connection B must not see connection A's temp trigger: {b_listed:?}"
+    );
+    assert!(
+        !b_listed.contains(&"v".to_string()),
+        "connection B must not see connection A's temp view: {b_listed:?}"
+    );
+
+    // Closing connection A (drop) releases its temp objects with the Catalog.
+    drop(db_a);
 }


### PR DESCRIPTION
## Summary

Implements the temp views/triggers **lifecycle** half of #5541 (the introspection half landed in #5582). The concrete remaining gap was: a trigger defined *ON* a table should be dropped when that table is dropped. This adds that cascade (temp and main), matching sqlite3 3.51.0, and documents that connection-close is already correct by construction.

Closes #5583

## Verified sqlite3 3.51.0 lifecycle semantics

Confirmed directly against `sqlite3 3.51.0`:

- **Trigger ON the dropped table → dropped.**
  ```sql
  CREATE TEMP TABLE t(a);
  CREATE TEMP TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1; END;
  DROP TABLE t;   -- tr is gone from sqlite_temp_master
  ```
- **View referencing the dropped table → NOT auto-dropped** (it stays in the schema and errors on use):
  ```sql
  CREATE TEMP VIEW v AS SELECT * FROM t;
  DROP TABLE t;   -- v remains; SELECT * FROM v -> "no such table: t"
  ```
- **Trigger ON a *different* table that references the dropped one → NOT dropped:**
  ```sql
  CREATE TABLE t(a); CREATE TABLE other(b);
  CREATE TRIGGER tr  AFTER INSERT ON t     BEGIN SELECT 1; END;
  CREATE TRIGGER tr2 AFTER INSERT ON other BEGIN INSERT INTO t VALUES(1); END;
  DROP TABLE t;   -- tr gone, tr2 survives (it is ON other)
  ```
- **Connection close** drops all temp objects (table + view + trigger) together.

## The fix + scope decision

**1. DROP-with-table (the real gap):**
- New `Catalog::drop_table_triggers(table_name)` in `crates/vibesql-catalog/src/store/advanced/triggers.rs`, mirroring the existing `drop_table_indexes`: it resolves the dropped table's internal schema (temp-shadows-main) and removes only triggers whose `ON <table>` target matches **and** whose binding (`trigger_bound_schema`, from #5532/triggerD-3.1/3.2) resolves to that same schema. So dropping `temp.t` removes only temp-bound triggers; dropping `main.t` removes only main-bound ones.
- `DropTableExecutor::execute` now calls it **before** the table is removed from the catalog (so trigger binding can still resolve), alongside the existing index cascade. The success message is extended to report dropped trigger counts.
- **No view change** — sqlite3 does NOT auto-drop a view referencing a dropped table; we match that exactly (verified by a test asserting the view survives and errors on use). Avoided over-dropping: a trigger is removed *only* if it is defined ON the dropped table, never merely for referencing it.

**2. Connection-close (investigated → already correct, no code needed):** Each connection owns its `Catalog` by value (`Database.catalog`, created per `Catalog::new()` with a unique session id). The flat `views`/`triggers` maps and the session temp schema all live inside that `Catalog`, so closing a connection drops every temp object wholesale. There is no shared/persistent catalog to leak into. A cross-connection test asserts a fresh connection sees none of another connection's temp trigger/view.

## sqlite3 parity / tests

- `crates/vibesql-catalog/src/store/advanced/triggers.rs`: unit tests `drop_table_triggers_removes_only_triggers_on_the_table` (ON-table vs references-table) and `drop_table_triggers_is_schema_aware` (temp vs main isolation).
- `crates/vibesql-executor/tests/sqlite_temp_master_tests.rs`: integration tests via live `sqlite_temp_master`/`sqlite_master` + `SELECT`:
  - `temp_trigger_dropped_with_temp_table_view_remains` — temp trigger gone, view remains and errors on use.
  - `main_drop_table_drops_only_triggers_on_that_table` — main parity (tr dropped, tr2 survives).
  - `temp_trigger_and_view_are_connection_local` — connection-close / per-Catalog isolation.

## No regression

`cargo test -p vibesql-executor -p vibesql-catalog` fully green (catalog 52, executor lib 2835 + all integration suites, doc-tests 31; 0 failures). New `drop_table_triggers` is additive; the qualified-`DROP TABLE temp.t` form is used in the temp tests because unqualified DROP TABLE not resolving into the temp schema is a pre-existing, separate limitation (same caveat as the #5513 index test).

## Coordination / follow-ons

- Touches `drop_table.rs` + catalog triggers only; does not collide with #5589 (executor view-DML qualifier, reads `ViewDefinition.is_temp()`) or #5591 (tcl shim).
- Possible follow-ons (out of scope here, matching sqlite3): unqualified `DROP TABLE` resolving temp-shadows-main; `DROP VIEW` cascading `INSTEAD OF` triggers defined on the view (sqlite3 does this — verified — but it is a separate DROP VIEW concern).