### PR TITLE
fix(executor): main.-qualify CREATE TRIGGER missing-table errors (trigger1-1.1.1)

### DIFF
--- a/crates/vibesql-executor/src/tests/triggers/ddl.rs
+++ b/crates/vibesql-executor/src/tests/triggers/ddl.rs
@@ -232,6 +232,52 @@ fn test_create_instead_of_trigger_on_table_wording() {
 }
 
 #[test]
+fn test_create_trigger_missing_table_is_main_qualified() {
+    // sqlite3 (3.51.0, trigger1-1.1.1) reports a CREATE TRIGGER target table
+    // that does not exist in the implicit `main` schema with the `main.`
+    // qualifier:
+    //   CREATE TRIGGER trig UPDATE ON no_such_table ...
+    //   -> "no such table: main.no_such_table"
+    // This holds for BEFORE/AFTER (table-target) and INSTEAD OF (view-target)
+    // triggers, and regardless of `IF NOT EXISTS`.
+    //
+    // VibeSQL surfaces TableNotFound via the localized `Table '<name>' not found`
+    // wording; the TCL conformance shim rewrites it to SQLite's
+    // `no such table: <name>` form. The load-bearing part is the `main.`-qualified
+    // name carried in the error, so we assert the raw VibeSQL message here.
+    let cases = [
+        "CREATE TRIGGER trig UPDATE ON no_such_table BEGIN SELECT 1; END;",
+        "CREATE TRIGGER IF NOT EXISTS trig UPDATE ON no_such_table BEGIN SELECT 1; END;",
+        "CREATE TRIGGER trig INSTEAD OF UPDATE ON no_such_table BEGIN SELECT 1; END;",
+    ];
+
+    for sql in cases {
+        let mut db = Database::new();
+        let stmt = parse_create_trigger(sql);
+        let err = crate::advanced_objects::execute_create_trigger(&stmt, &mut db)
+            .expect_err("CREATE TRIGGER on a missing table must be rejected");
+        assert_eq!(err.to_string(), "Table 'main.no_such_table' not found", "for SQL: {sql}");
+    }
+}
+
+#[test]
+fn test_create_temp_trigger_missing_table_is_not_qualified() {
+    // sqlite3 (3.51.0, trigger1-1.1.2) leaves a TEMP trigger's missing target
+    // table BARE (not `main.`-qualified): the target is resolved against the
+    // temp schema, not main.
+    //   CREATE TEMP TRIGGER trig UPDATE ON no_such_table ...
+    //   -> "no such table: no_such_table"
+    // Asserted against VibeSQL's raw `Table '<name>' not found` wording (see the
+    // sibling test above for why).
+    let mut db = Database::new();
+    let stmt =
+        parse_create_trigger("CREATE TEMP TRIGGER trig UPDATE ON no_such_table BEGIN SELECT 1; END;");
+    let err = crate::advanced_objects::execute_create_trigger(&stmt, &mut db)
+        .expect_err("CREATE TEMP TRIGGER on a missing table must be rejected");
+    assert_eq!(err.to_string(), "Table 'no_such_table' not found");
+}
+
+#[test]
 fn test_create_before_after_trigger_on_view_wording() {
     // SQLite (3.51.0, trigger1-1.13/1.14):
     //   "cannot create BEFORE trigger on view: v1"

--- a/crates/vibesql-executor/src/trigger_ddl.rs
+++ b/crates/vibesql-executor/src/trigger_ddl.rs
@@ -67,6 +67,25 @@ impl TriggerExecutor {
             ));
         }
 
+        // sqlite3 reports a missing CREATE TRIGGER target table in the implicit
+        // `main` schema with the `main.` qualifier
+        // (`no such table: main.no_such_table`, trigger1-1.1.1), but leaves a
+        // TEMP trigger's missing target bare (`no such table: no_such_table`,
+        // trigger1-1.1.2). The trigger's schema is `Some("temp")` for
+        // `CREATE TEMP TRIGGER`; in every other case the target resolves against
+        // the main schema and is qualified.
+        let target_is_temp_schema = stmt
+            .schema
+            .as_deref()
+            .is_some_and(|s| s.eq_ignore_ascii_case("temp"));
+        let qualify_missing_table = |err: ExecutorError| -> ExecutorError {
+            if target_is_temp_schema {
+                err
+            } else {
+                err.with_main_schema_qualifier()
+            }
+        };
+
         // INSTEAD OF triggers can only be created on views;
         // BEFORE and AFTER triggers can only be created on (non-view) tables.
         let target_is_view = db.catalog.get_view(&stmt.table_name).is_some();
@@ -81,7 +100,9 @@ impl TriggerExecutor {
                     )));
                 }
                 // Neither a view nor a table: report the missing target.
-                return Err(ExecutorError::TableNotFound(stmt.table_name.clone()));
+                return Err(qualify_missing_table(ExecutorError::TableNotFound(
+                    stmt.table_name.clone(),
+                )));
             }
         } else {
             // BEFORE / AFTER on a view is rejected with SQLite's exact wording
@@ -100,7 +121,9 @@ impl TriggerExecutor {
             }
             // Verify the target table exists.
             if !db.catalog.table_exists(&stmt.table_name) {
-                return Err(ExecutorError::TableNotFound(stmt.table_name.clone()));
+                return Err(qualify_missing_table(ExecutorError::TableNotFound(
+                    stmt.table_name.clone(),
+                )));
             }
         }
 


### PR DESCRIPTION
## Summary
- sqlite3 3.51.0 reports a `CREATE TRIGGER` target table that does not exist in the implicit `main` schema with the `main.` qualifier (`no such table: main.no_such_table`, trigger1-1.1.1), while leaving a TEMP trigger's missing target **bare** (`no such table: no_such_table`, trigger1-1.1.2). VibeSQL previously reported both unqualified.
- Reuses the existing `ExecutorError::with_main_schema_qualifier` helper at the two `CREATE TRIGGER` target-table `TableNotFound` sites in `crates/vibesql-executor/src/trigger_ddl.rs`, gated on the trigger **not** being TEMP so the intentionally-unqualified temp-schema case is preserved.

## Characterization (sqlite3 3.51.0)
`main.`-qualified:
- `CREATE TRIGGER ... ON no_such_table` (incl. `IF NOT EXISTS`, INSTEAD OF) -> `main.no_such_table`
- trigger-**body** DML on a missing table (already handled by #5584/#5595)

Bare (NOT qualified) — left unchanged:
- `CREATE TEMP TRIGGER ... ON no_such_table` -> bare
- direct top-level `SELECT/INSERT/UPDATE/DELETE FROM no_such_table` -> bare
- `DROP TABLE no_such_table` -> bare
- `DROP TRIGGER biggles` -> `no such trigger: biggles` (not a table error)

This is deliberately **not** a blanket qualification, per the issue's warning.

## trigger1.test before/after
- trigger1-1.1.1 (`CREATE TRIGGER ... ON no_such_table`): now **ok** (was producing bare `no_such_table`).
- trigger1-1.1.2 (`CREATE TEMP TRIGGER ...`): still **ok** (bare, preserved).
- trigger1-1.2.x, 1.6.x (trigger-already-exists / no-such-trigger): still **ok**.
- Remaining 38 trigger1 failures (1.8, 3.x, 4.x, 6.x, 8.x) are pre-existing and unrelated to table-not-found qualification (TEMP-table sqlite_master visibility, other trigger features).

## No-regression evidence (broad suite, this branch)
- select1.test: 188/188 passed, 0 failed
- trigger2.test: 70/70 passed, 0 failed
- view.test: 0 failed
- where.test: 20 failures (pre-existing; no CREATE-TRIGGER-on-missing-table cases involved)
- `cargo test -p vibesql-executor`: 0 failures across all test binaries

## Test plan
- [x] `cargo build` (release) succeeds
- [x] `cargo test -p vibesql-executor` passes (new regression tests `test_create_trigger_missing_table_is_main_qualified` + `test_create_temp_trigger_missing_table_is_not_qualified`)
- [x] `make test-tcl-file FILE=trigger1.test` improves 1.1.1 with no regressions to 1.1.2 / 1.2.x / 1.6.x
- [x] broad-suite sample (select1/where/view/trigger2) shows no new failures

Closes #5571

🤖 Generated with [Claude Code](https://claude.com/claude-code)