### PR TITLE
fix(executor): ordinary column named rowid wins in UPDATE NEW/OLD (triggerD-1.3/1.4)

### DIFF
--- a/crates/vibesql-executor/src/update/tests/set_rowid.rs
+++ b/crates/vibesql-executor/src/update/tests/set_rowid.rs
@@ -43,6 +43,16 @@ fn update(db: &mut vibesql_storage::Database, sql: &str) -> Result<usize, crate:
     }
 }
 
+/// Run a DELETE (fires DELETE triggers).
+fn delete(db: &mut vibesql_storage::Database, sql: &str) {
+    match Parser::parse_sql(sql).expect("parse delete") {
+        Statement::Delete(s) => {
+            DeleteExecutor::execute(&s, db).expect("DELETE");
+        }
+        other => panic!("expected DELETE, got {:?}", other),
+    }
+}
+
 /// Run a SELECT and return rows (each row carries its resolved row_id).
 fn select(db: &mut vibesql_storage::Database, sql: &str) -> Vec<vibesql_storage::Row> {
     match Parser::parse_sql(sql).expect("parse select") {
@@ -599,4 +609,85 @@ fn triggerc_7_5_relocate_in_before_trigger() {
             "after fired 3->3".to_string()
         ]
     );
+}
+
+/// triggerD-1.3/1.4 (issue #5599): an *ordinary* user column literally named
+/// `rowid` (or `oid` / `_rowid_`) shadows the system rowid alias. `UPDATE t1 SET
+/// rowid=rowid+1` must write that ordinary column, and the table's BEFORE/AFTER
+/// UPDATE triggers (and a later DELETE trigger) must see the *updated* ordinary
+/// value via `new.rowid` — not the row's internal system rowid.
+///
+/// Distinct from #5517 (which relocates the *system* rowid on a table that has
+/// no such ordinary column); the `set_rowid_relocates_row` test above covers
+/// that path and must keep passing alongside this one. Verified against
+/// sqlite3 3.51.0.
+#[test]
+fn shadow_column_named_rowid_reflected_in_triggers() {
+    let mut db = vibesql_storage::Database::new();
+    // t1 has ordinary columns named rowid/oid/_rowid_ that shadow the aliases.
+    ddl(&mut db, "CREATE TABLE t1(rowid, oid, _rowid_, x)");
+    ddl(&mut db, "CREATE TABLE log(a, b, c, d, e)");
+    ddl(
+        &mut db,
+        "CREATE TRIGGER r3 BEFORE UPDATE ON t1 BEGIN \
+         INSERT INTO log VALUES('r3.old', old.rowid, old.oid, old._rowid_, old.x); \
+         INSERT INTO log VALUES('r3.new', new.rowid, new.oid, new._rowid_, new.x); END",
+    );
+    ddl(
+        &mut db,
+        "CREATE TRIGGER r4 AFTER UPDATE ON t1 BEGIN \
+         INSERT INTO log VALUES('r4.old', old.rowid, old.oid, old._rowid_, old.x); \
+         INSERT INTO log VALUES('r4.new', new.rowid, new.oid, new._rowid_, new.x); END",
+    );
+    ddl(
+        &mut db,
+        "CREATE TRIGGER r6 AFTER DELETE ON t1 BEGIN \
+         INSERT INTO log VALUES('r6', old.rowid, old.oid, old._rowid_, old.x); END",
+    );
+    ddl(&mut db, "INSERT INTO t1 VALUES(100, 200, 300, 400)");
+
+    // SET rowid=rowid+1 updates the ORDINARY column rowid: 100 -> 101.
+    assert_eq!(update(&mut db, "UPDATE t1 SET rowid=rowid+1").unwrap(), 1);
+
+    // The stored ordinary column reflects the update.
+    let t1 = select(&mut db, "SELECT rowid, oid, _rowid_, x FROM t1");
+    assert_eq!(int(&t1[0].values[0]), 101);
+    assert_eq!(int(&t1[0].values[1]), 200);
+    assert_eq!(int(&t1[0].values[2]), 300);
+    assert_eq!(int(&t1[0].values[3]), 400);
+
+    // BEFORE sees old=100/new=101; AFTER sees old=100/new=101 (sqlite3 3.51.0).
+    let rows = select(&mut db, "SELECT a, b, c, d, e FROM log ORDER BY _rowid_");
+    let log: Vec<(String, i64, i64, i64, i64)> = rows
+        .iter()
+        .map(|r| {
+            (
+                text(&r.values[0]),
+                int(&r.values[1]),
+                int(&r.values[2]),
+                int(&r.values[3]),
+                int(&r.values[4]),
+            )
+        })
+        .collect();
+    assert_eq!(
+        log,
+        vec![
+            ("r3.old".to_string(), 100, 200, 300, 400),
+            ("r3.new".to_string(), 101, 200, 300, 400),
+            ("r4.old".to_string(), 100, 200, 300, 400),
+            ("r4.new".to_string(), 101, 200, 300, 400),
+        ]
+    );
+
+    // A later DELETE trigger sees the updated ordinary value (triggerD-1.4).
+    delete(&mut db, "DELETE FROM log");
+    delete(&mut db, "DELETE FROM t1");
+    let after_delete = select(&mut db, "SELECT a, b, c, d, e FROM log");
+    assert_eq!(after_delete.len(), 1);
+    assert_eq!(text(&after_delete[0].values[0]), "r6");
+    assert_eq!(int(&after_delete[0].values[1]), 101);
+    assert_eq!(int(&after_delete[0].values[2]), 200);
+    assert_eq!(int(&after_delete[0].values[3]), 300);
+    assert_eq!(int(&after_delete[0].values[4]), 400);
 }

--- a/crates/vibesql-executor/src/update/value_updater.rs
+++ b/crates/vibesql-executor/src/update/value_updater.rs
@@ -43,7 +43,19 @@ impl<'a> ValueUpdater<'a> {
             let is_rowid =
                 col_name_lower == "rowid" || col_name_lower == "_rowid_" || col_name_lower == "oid";
 
-            if is_rowid {
+            // A *real* column literally named `rowid`/`oid`/`_rowid_` shadows the
+            // system rowid alias (triggerD-1.3/1.4, ticket
+            // [34d2ae1c6d08b5271ba5e5592936d4a1d913ffe3]). `UPDATE t SET rowid=..`
+            // on `t(rowid, ...)` must write that ordinary column, not relocate the
+            // row's internal rowid. Only treat the assignment as a system-rowid
+            // update when no ordinary column shadows the name — this preserves the
+            // virtual-rowid relocation behavior (#5517) for tables that have *no*
+            // such column. The INTEGER PRIMARY KEY alias is itself a real column
+            // (`rowid_alias_column`), so it also flows through the normal
+            // column-update path below and writes the PK column as before.
+            let shadowing_column = self.schema.get_column_index(&assignment.column);
+
+            if is_rowid && shadowing_column.is_none() {
                 // Handle rowid update
                 // If the table has an INTEGER PRIMARY KEY (rowid alias), update that column
                 // Otherwise, update the row's internal row_id field


### PR DESCRIPTION
## Summary

Fixes #5599. A table with an **ordinary user column literally named** `rowid` / `oid` / `_rowid_` shadows the system rowid alias. `UPDATE t1 SET rowid=rowid+1` on `t1(rowid, oid, _rowid_, x)` must write that ordinary column so trigger bodies observe the updated value via `new.rowid` (e.g. `101`), not the stale system rowid (`100`).

## Root cause

The UPDATE **write path** (`ValueUpdater::apply_assignments`) checked whether the assigned column name was `rowid`/`oid`/`_rowid_` and, if so, treated the assignment as a *system-rowid relocation* — **before** checking for a shadowing ordinary column. So `SET rowid=rowid+1` mutated the row's internal `row_id` instead of the column at index 0; the SET-modified value never reached the column, and the BEFORE/AFTER UPDATE triggers (plus a later DELETE trigger) all saw the stale value.

The NEW/OLD **read/resolution** path (`TriggerContext::resolve_pseudo_var`) was already correct — a real column wins over the rowid pseudo-column — so this was purely a write-path gap.

## Fix

The system-rowid relocation branch now only fires when **no ordinary column shadows the name** (`schema.get_column_index(col).is_none()`). Otherwise the assignment flows through the normal column-update path. The INTEGER PRIMARY KEY alias is itself a real column, so it continues to write the PK column as before.

This is **distinct from #5517** (relocating the *system* rowid on a table with no such column), whose behavior is fully preserved.

## Tests

- `triggerD.test`: **8/2 → 10/0** (triggerD-1.3 and 1.4 now GREEN; matches sqlite3 3.51.0).
- New Rust regression test `shadow_column_named_rowid_reflected_in_triggers` mirroring triggerD-1.3/1.4.
- All 24 `update::tests::set_rowid` tests (the #5517 system-rowid behavior) keep passing.
- Full `cargo test -p vibesql-executor` suite passes.

## Test plan

- [x] `cargo build -p vibesql-executor`
- [x] `cargo test -p vibesql-executor` (no failures)
- [x] `make test-tcl-file FILE=triggerD.test` → 10/0
- [x] Reproduced expected outputs against `/usr/bin/sqlite3` 3.51.0

Remaining `update.test` (14.2/14.4) and `delete.test` (7.6) failures are pre-existing and unrelated (malformed-WHEN-clause error reporting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)