### PR TITLE
feat(executor): cascade-drop INSTEAD OF triggers when their view is dropped

### DIFF
--- a/crates/vibesql-catalog/src/store/advanced/triggers.rs
+++ b/crates/vibesql-catalog/src/store/advanced/triggers.rs
@@ -214,6 +214,64 @@ impl super::super::Catalog {
             .collect()
     }
 
+    /// Drop all INSTEAD OF triggers defined *on* a view (called when dropping the
+    /// view).
+    ///
+    /// SQLite drops every trigger whose `ON <view>` target is the dropped view —
+    /// an INSTEAD OF trigger cannot outlive the view it is attached to (verified
+    /// against sqlite3 3.51.0):
+    ///
+    /// ```sql
+    /// CREATE VIEW v AS SELECT a FROM base;
+    /// CREATE TRIGGER v_ins INSTEAD OF INSERT ON v BEGIN INSERT INTO base VALUES(NEW.a); END;
+    /// DROP VIEW v;   -- v_ins is gone; recreating v + v_ins succeeds
+    /// ```
+    ///
+    /// This is the view analogue of [`Catalog::drop_table_triggers`] (#5597). It
+    /// is kept separate because views live in a single flat map (not the
+    /// per-schema table maps), so the table-based [`trigger_bound_schema`]
+    /// resolution does not apply to a view target. Instead, schema-awareness is
+    /// derived directly from the `temp`/`main` tag both the view and the trigger
+    /// carry: a temp trigger on a temp view, and a main trigger on a main view.
+    /// This keeps a `main` INSTEAD OF trigger on a `main` view from being dropped
+    /// when a same-named `temp` view is dropped, and vice versa (temp shadows
+    /// main).
+    ///
+    /// Must be called *before* the view is removed from the catalog. `view_name`
+    /// is the bare (unqualified) view name; `view_is_temp` indicates whether the
+    /// dropped view lives in the temp schema (`ViewDefinition::is_temp`).
+    ///
+    /// Returns the names of the dropped triggers.
+    pub fn drop_view_triggers(&mut self, view_name: &str, view_is_temp: bool) -> Vec<String> {
+        // A bare/qualified view name: only the last component is the view name
+        // (qualified DROP VIEW resolves to the supplied schema, but the catalog
+        // stores views by bare name).
+        let bare_view_name = view_name.rsplit_once('.').map_or(view_name, |(_, n)| n);
+
+        let triggers_to_remove: Vec<String> = self
+            .triggers
+            .values()
+            .filter(|trigger| {
+                // Only INSTEAD OF triggers defined ON the dropped view
+                // (case-insensitive, SQLite-compatible). INSTEAD OF is the only
+                // timing valid on a view, but checking it keeps this strictly
+                // view-scoped and never disturbs table triggers.
+                trigger.timing == vibesql_ast::TriggerTiming::InsteadOf
+                    && trigger.table_name.eq_ignore_ascii_case(bare_view_name)
+                    // Temp-shadows-main: drop only triggers whose schema matches
+                    // the dropped view's schema (temp trigger <-> temp view,
+                    // main trigger <-> main view).
+                    && trigger.is_temp() == view_is_temp
+            })
+            .map(|trigger| trigger.name.clone())
+            .collect();
+
+        triggers_to_remove
+            .into_iter()
+            .filter_map(|name| self.triggers.remove(&name).map(|_| name))
+            .collect()
+    }
+
     /// List all trigger names
     pub fn list_triggers(&self) -> Vec<String> {
         self.triggers.keys().cloned().collect()
@@ -259,6 +317,19 @@ mod tests {
             TriggerTiming::Before,
             TriggerEvent::Insert,
             table.to_string(),
+            TriggerGranularity::Row,
+            None,
+            TriggerAction::RawSql("SELECT 1".to_string()),
+        )
+    }
+
+    /// An INSTEAD OF INSERT trigger on `view` (the only timing valid on a view).
+    fn instead_of_trigger(name: &str, view: &str) -> TriggerDefinition {
+        TriggerDefinition::new(
+            name.to_string(),
+            TriggerTiming::InsteadOf,
+            TriggerEvent::Insert,
+            view.to_string(),
             TriggerGranularity::Row,
             None,
             TriggerAction::RawSql("SELECT 1".to_string()),
@@ -392,6 +463,68 @@ mod tests {
         let dropped_main = catalog.drop_table_triggers("main.t");
         assert_eq!(dropped_main, vec!["rmain".to_string()]);
         assert!(catalog.get_trigger("rmain").is_none());
+    }
+
+    /// `drop_view_triggers` removes the INSTEAD OF triggers defined ON the
+    /// dropped view and leaves triggers on a *different* view untouched —
+    /// matching sqlite3 3.51.0 (DROP VIEW cascade-drops its INSTEAD OF triggers).
+    #[test]
+    fn drop_view_triggers_removes_only_triggers_on_the_view() {
+        let mut catalog = Catalog::new();
+        catalog.set_case_sensitive_identifiers(false);
+
+        // v_ins is ON v (should be dropped); v2_ins is ON v2 (should survive).
+        catalog.create_trigger(instead_of_trigger("v_ins", "v")).unwrap();
+        catalog.create_trigger(instead_of_trigger("v2_ins", "v2")).unwrap();
+
+        let dropped = catalog.drop_view_triggers("v", false);
+        assert_eq!(dropped, vec!["v_ins".to_string()]);
+        assert!(catalog.get_trigger("v_ins").is_none());
+        assert!(catalog.get_trigger("v2_ins").is_some());
+    }
+
+    /// A table trigger (non-INSTEAD OF) sharing a view's name is never disturbed
+    /// by `drop_view_triggers` — only INSTEAD OF triggers ON the view are dropped.
+    #[test]
+    fn drop_view_triggers_ignores_table_triggers() {
+        let mut catalog = Catalog::new();
+        catalog.set_case_sensitive_identifiers(false);
+
+        // A BEFORE INSERT (table) trigger that happens to share the dropped view's
+        // name must be left alone; only INSTEAD OF triggers belong to views.
+        catalog.create_trigger(sample_trigger("tbl_tr", "v")).unwrap();
+        catalog.create_trigger(instead_of_trigger("v_ins", "v")).unwrap();
+
+        let dropped = catalog.drop_view_triggers("v", false);
+        assert_eq!(dropped, vec!["v_ins".to_string()]);
+        assert!(catalog.get_trigger("v_ins").is_none());
+        assert!(catalog.get_trigger("tbl_tr").is_some());
+    }
+
+    /// Dropping a `temp` view removes its temp INSTEAD OF trigger but leaves a
+    /// same-named `main` view's trigger intact (temp shadows main), and vice
+    /// versa — mirroring the table-trigger schema isolation.
+    #[test]
+    fn drop_view_triggers_is_schema_aware() {
+        let mut catalog = Catalog::new();
+        catalog.set_case_sensitive_identifiers(false);
+
+        // main trigger on main view v; temp trigger on temp view v.
+        catalog.create_trigger(instead_of_trigger("vmain", "v")).unwrap();
+        catalog
+            .create_trigger(instead_of_trigger("vtemp", "v").with_schema(Some("temp".to_string())))
+            .unwrap();
+
+        // Dropping the temp view removes only the temp-bound trigger.
+        let dropped = catalog.drop_view_triggers("v", true);
+        assert_eq!(dropped, vec!["vtemp".to_string()]);
+        assert!(catalog.get_trigger("vtemp").is_none());
+        assert!(catalog.get_trigger("vmain").is_some());
+
+        // Dropping the main view now removes the main-bound trigger.
+        let dropped_main = catalog.drop_view_triggers("v", false);
+        assert_eq!(dropped_main, vec!["vmain".to_string()]);
+        assert!(catalog.get_trigger("vmain").is_none());
     }
 
     /// A temp trigger on a table that exists only in main binds to (and fires

--- a/crates/vibesql-executor/src/advanced_objects/views.rs
+++ b/crates/vibesql-executor/src/advanced_objects/views.rs
@@ -135,6 +135,17 @@ pub fn execute_drop_view(stmt: &DropViewStmt, db: &mut Database) -> Result<(), E
         ViewDropBehavior::Silent // SQLite-compatible: allow dropping even with dependents
     };
 
+    // Resolve the view's temp/main schema tag *before* the catalog removes it so
+    // the INSTEAD OF trigger cascade can apply the temp-shadows-main filter.
+    let view_is_temp = db.catalog.get_view(&stmt.view_name).is_some_and(|v| v.is_temp());
+
     db.catalog.drop_view_with_behavior(&stmt.view_name, drop_behavior)?;
+
+    // Cascade-drop the INSTEAD OF triggers defined ON this view, matching sqlite3
+    // 3.51.0: an INSTEAD OF trigger cannot outlive the view it is attached to, so
+    // `DROP VIEW v` removes every trigger whose `ON v` target is the dropped view
+    // (leaving triggers on a *different* view alone). See
+    // `Catalog::drop_view_triggers` (view analogue of the table path in #5597).
+    db.catalog.drop_view_triggers(&stmt.view_name, view_is_temp);
     Ok(())
 }

--- a/crates/vibesql-executor/src/view_ddl.rs
+++ b/crates/vibesql-executor/src/view_ddl.rs
@@ -84,11 +84,35 @@ impl ViewExecutor {
             ViewDropBehavior::Silent // SQLite-compatible: allow dropping even with dependents
         };
 
+        // Cascade-drop the INSTEAD OF triggers defined ON this view, matching
+        // sqlite3 3.51.0: an INSTEAD OF trigger cannot outlive the view it is
+        // attached to, so `DROP VIEW v` removes every trigger whose `ON v`
+        // target is the dropped view. Resolve the view's temp/main schema tag
+        // *before* the catalog removes it so the temp-shadows-main filter can be
+        // applied (a main trigger on a main view must not be dropped when a
+        // same-named temp view is dropped, and vice versa). A trigger on a
+        // *different* view is left alone. See `Catalog::drop_view_triggers`
+        // (view analogue of the table path in #5597).
+        let view_is_temp =
+            database.catalog.get_view(&stmt.view_name).is_some_and(|v| v.is_temp());
+
         // Drop the view
         let result = database.catalog.drop_view_with_behavior(&stmt.view_name, drop_behavior);
 
         match result {
-            Ok(()) => Ok(format!("View '{}' dropped", stmt.view_name)),
+            Ok(()) => {
+                let dropped_triggers =
+                    database.catalog.drop_view_triggers(&stmt.view_name, view_is_temp);
+                if dropped_triggers.is_empty() {
+                    Ok(format!("View '{}' dropped", stmt.view_name))
+                } else {
+                    Ok(format!(
+                        "View '{}' and {} associated trigger(s) dropped",
+                        stmt.view_name,
+                        dropped_triggers.len()
+                    ))
+                }
+            }
             Err(e) => {
                 // If IF EXISTS and view doesn't exist, that's OK
                 if stmt.if_exists

--- a/crates/vibesql-executor/tests/drop_view_cascade_triggers_tests.rs
+++ b/crates/vibesql-executor/tests/drop_view_cascade_triggers_tests.rs
@@ -1,0 +1,176 @@
+//! Integration tests for `DROP VIEW` cascade-dropping INSTEAD OF triggers.
+//!
+//! Issue #5598: An INSTEAD OF trigger defined ON a view cannot outlive that view.
+//! `DROP VIEW v` must remove every INSTEAD OF trigger whose `ON v` target is the
+//! dropped view, leaving triggers on a *different* view alone. This matches
+//! sqlite3 3.51.0:
+//!
+//! ```sql
+//! CREATE VIEW v AS SELECT a FROM base;
+//! CREATE TRIGGER v_ins INSTEAD OF INSERT ON v BEGIN INSERT INTO base VALUES(NEW.a); END;
+//! DROP VIEW v;   -- v_ins is gone; recreating v + v_ins succeeds
+//! ```
+//!
+//! This is the view analogue of the table-trigger cascade fixed in #5597.
+
+use vibesql_executor::{CreateTableExecutor, TriggerExecutor, ViewExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+fn exec_create_table(db: &mut Database, sql: &str) {
+    match Parser::parse_sql(sql).expect("parse CREATE TABLE") {
+        vibesql_ast::Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE")
+        }
+        other => panic!("expected CREATE TABLE, got {other:?}"),
+    };
+}
+
+fn exec_create_view(db: &mut Database, sql: &str) {
+    match Parser::parse_sql(sql).expect("parse CREATE VIEW") {
+        vibesql_ast::Statement::CreateView(s) => {
+            ViewExecutor::execute_create_view(&s, db).expect("CREATE VIEW");
+        }
+        other => panic!("expected CREATE VIEW, got {other:?}"),
+    };
+}
+
+fn exec_create_trigger(db: &mut Database, sql: &str) {
+    match Parser::parse_sql(sql).expect("parse CREATE TRIGGER") {
+        vibesql_ast::Statement::CreateTrigger(s) => {
+            TriggerExecutor::create_trigger(db, &s).expect("CREATE TRIGGER");
+        }
+        other => panic!("expected CREATE TRIGGER, got {other:?}"),
+    };
+}
+
+fn exec_drop_view(db: &mut Database, sql: &str) -> String {
+    match Parser::parse_sql(sql).expect("parse DROP VIEW") {
+        vibesql_ast::Statement::DropView(s) => {
+            ViewExecutor::execute_drop_view(&s, db).expect("DROP VIEW")
+        }
+        other => panic!("expected DROP VIEW, got {other:?}"),
+    }
+}
+
+/// DROP VIEW via the live CLI dispatch path
+/// (`advanced_objects::execute_drop_view`).
+fn exec_drop_view_advanced(db: &mut Database, sql: &str) {
+    match Parser::parse_sql(sql).expect("parse DROP VIEW") {
+        vibesql_ast::Statement::DropView(s) => {
+            vibesql_executor::advanced_objects::execute_drop_view(&s, db).expect("DROP VIEW")
+        }
+        other => panic!("expected DROP VIEW, got {other:?}"),
+    }
+}
+
+/// sqlite3 parity: `DROP VIEW v` drops the INSTEAD OF trigger ON v, leaves the
+/// INSTEAD OF trigger on a different view, and re-creating v + its trigger
+/// succeeds (no orphaned stale trigger).
+#[test]
+fn drop_view_cascade_drops_instead_of_trigger() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TABLE base (a, b)");
+    exec_create_view(&mut db, "CREATE VIEW v AS SELECT a, b FROM base");
+    exec_create_view(&mut db, "CREATE VIEW v2 AS SELECT a FROM base");
+    exec_create_trigger(
+        &mut db,
+        "CREATE TRIGGER v_ins INSTEAD OF INSERT ON v \
+         BEGIN INSERT INTO base VALUES (NEW.a, NEW.b); END",
+    );
+    exec_create_trigger(
+        &mut db,
+        "CREATE TRIGGER v2_ins INSTEAD OF INSERT ON v2 \
+         BEGIN INSERT INTO base (a) VALUES (NEW.a); END",
+    );
+
+    assert!(db.catalog.get_trigger("v_ins").is_some());
+    assert!(db.catalog.get_trigger("v2_ins").is_some());
+
+    let msg = exec_drop_view(&mut db, "DROP VIEW v");
+    assert!(msg.contains("trigger"), "drop message should report the cascade: {msg}");
+
+    // The trigger ON v is gone; the trigger ON v2 survives.
+    assert!(db.catalog.get_trigger("v_ins").is_none(), "v_ins should be cascade-dropped");
+    assert!(db.catalog.get_trigger("v2_ins").is_some(), "v2_ins must survive");
+
+    // No orphan: re-creating the view and its trigger succeeds (would error with
+    // TriggerAlreadyExists if the old one were still in the catalog).
+    exec_create_view(&mut db, "CREATE VIEW v AS SELECT a, b FROM base");
+    exec_create_trigger(
+        &mut db,
+        "CREATE TRIGGER v_ins INSTEAD OF INSERT ON v \
+         BEGIN INSERT INTO base VALUES (NEW.a, NEW.b); END",
+    );
+    assert!(db.catalog.get_trigger("v_ins").is_some());
+}
+
+/// Dropping a view with no triggers reports the plain message (no cascade).
+#[test]
+fn drop_view_without_triggers_reports_plain_message() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TABLE base (a)");
+    exec_create_view(&mut db, "CREATE VIEW v AS SELECT a FROM base");
+
+    let msg = exec_drop_view(&mut db, "DROP VIEW v");
+    assert!(!msg.contains("trigger"), "no-trigger drop should not mention triggers: {msg}");
+}
+
+/// Dropping a `temp` view cascade-drops its temp INSTEAD OF trigger.
+///
+/// Note: the catalog stores views in a single flat (non-per-schema) map, so a
+/// `temp` view and a same-named `main` view cannot coexist (the second CREATE
+/// VIEW errors with ViewAlreadyExists — a pre-existing limitation, see #5598).
+/// The temp-vs-main schema *isolation* of the cascade is therefore covered at
+/// the catalog unit level (`drop_view_triggers_is_schema_aware`); here we verify
+/// the executor path wires the temp view's schema tag through to the cascade.
+#[test]
+fn drop_temp_view_cascade_drops_its_temp_trigger() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TABLE base (a)");
+    exec_create_view(&mut db, "CREATE TEMP VIEW tv AS SELECT a FROM base");
+    exec_create_trigger(
+        &mut db,
+        "CREATE TEMP TRIGGER tv_ins INSTEAD OF INSERT ON tv \
+         BEGIN INSERT INTO base VALUES (NEW.a); END",
+    );
+
+    assert!(db.catalog.get_trigger("tv_ins").is_some());
+    let msg = exec_drop_view(&mut db, "DROP VIEW tv");
+    assert!(msg.contains("trigger"), "temp view drop should report the cascade: {msg}");
+    assert!(db.catalog.get_trigger("tv_ins").is_none(), "temp trigger dropped with temp view");
+}
+
+/// The live CLI dispatch path (`advanced_objects::execute_drop_view`, used by the
+/// shell/script runner) cascade-drops the INSTEAD OF trigger ON the view and
+/// leaves the trigger on a different view alone — no orphan left behind.
+#[test]
+fn drop_view_advanced_path_cascade_drops_instead_of_trigger() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TABLE base (a, b)");
+    exec_create_view(&mut db, "CREATE VIEW v AS SELECT a, b FROM base");
+    exec_create_view(&mut db, "CREATE VIEW v2 AS SELECT a FROM base");
+    exec_create_trigger(
+        &mut db,
+        "CREATE TRIGGER v_ins INSTEAD OF INSERT ON v \
+         BEGIN INSERT INTO base VALUES (NEW.a, NEW.b); END",
+    );
+    exec_create_trigger(
+        &mut db,
+        "CREATE TRIGGER v2_ins INSTEAD OF INSERT ON v2 \
+         BEGIN INSERT INTO base (a) VALUES (NEW.a); END",
+    );
+
+    exec_drop_view_advanced(&mut db, "DROP VIEW v");
+    assert!(db.catalog.get_trigger("v_ins").is_none(), "v_ins should be cascade-dropped");
+    assert!(db.catalog.get_trigger("v2_ins").is_some(), "v2_ins must survive");
+
+    // No orphan: re-creating the view + trigger succeeds.
+    exec_create_view(&mut db, "CREATE VIEW v AS SELECT a, b FROM base");
+    exec_create_trigger(
+        &mut db,
+        "CREATE TRIGGER v_ins INSTEAD OF INSERT ON v \
+         BEGIN INSERT INTO base VALUES (NEW.a, NEW.b); END",
+    );
+    assert!(db.catalog.get_trigger("v_ins").is_some());
+}


### PR DESCRIPTION
## Summary

`DROP VIEW v` now cascade-drops every INSTEAD OF trigger defined ON the dropped view, matching sqlite3 3.51.0 — a trigger cannot outlive the view it is attached to. Previously such triggers were orphaned in the catalog, which blocked re-creating the view + trigger (`Trigger 'x' already exists`) and left a stale `sqlite_master` entry. This is the view analogue of the table-trigger cascade in #5597 (closes #5583).

## Changes

- **`Catalog::drop_view_triggers(view_name, view_is_temp)`** (new, `crates/vibesql-catalog/src/store/advanced/triggers.rs`): removes only INSTEAD OF triggers whose `ON <view>` target is the dropped view. Schema-aware: because views live in a single flat map (not the per-schema table maps used by `drop_table_triggers`), the temp-shadows-main filter is derived from the temp/main tag both the view and the trigger carry — a temp view's trigger is dropped with the temp view while a same-named main view's trigger is left intact, and vice versa.
- **Wired into both DROP VIEW surfaces**: the live CLI dispatch path (`advanced_objects::execute_drop_view`) and `ViewExecutor::execute_drop_view`. The view's temp/main tag is resolved *before* catalog removal so the cascade can filter by schema.
- Table triggers and triggers on a *different* view are never touched.

## Verified against sqlite3 3.51.0

`DROP VIEW v` drops `v_ins` (INSTEAD OF on v), keeps `v2_ins` (on v2), and re-creating `v` + `v_ins` succeeds. VibeSQL release binary now produces identical behavior (was leaving `v_ins` orphaned + failing recreate before this change).

## Tests

- 3 new catalog unit tests: removes only triggers on the view; ignores table triggers sharing the view's name; temp-vs-main schema isolation.
- 4 new executor integration tests (`drop_view_cascade_triggers_tests.rs`): cascade via `ViewExecutor` and via the live `advanced_objects` path; no-trigger plain message; temp-view cascade.

## Test plan

- [x] `cargo build` (catalog + executor + release bin)
- [x] `cargo test -p vibesql-catalog` — 55 passed, 0 failed (incl. 3 new)
- [x] `cargo test -p vibesql-executor --lib` — 2838 passed, 0 failed
- [x] `cargo test -p vibesql-executor --test drop_view_cascade_triggers_tests` — 4 passed
- [x] TCL: `view.test` 24/0, `trigger2.test` 70/0 (no regressions). `trigger1.test` (38 fail) and `trigger3.test` (2 fail) failures are pre-existing and unrelated (sqlite_master ordering, syntax, datatype, transaction-rollback — none touch DROP VIEW cascade).

Closes #5598

🤖 Generated with [Claude Code](https://claude.com/claude-code)