### PR TITLE
feat(executor): honor sqlite3_limit(SQLITE_LIMIT_TRIGGER_DEPTH) at runtime (triggerC-3.5/3.6)

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -1053,6 +1053,28 @@ impl SqlExecutor {
                         message: None,
                     })
                 }
+                "TRIGGER_DEPTH_LIMIT" => {
+                    // Per-connection trigger recursion-depth limit (#5536).
+                    //
+                    // SQLite has no SQL PRAGMA for this — it is a C-API knob
+                    // (`sqlite3_limit(db, SQLITE_LIMIT_TRIGGER_DEPTH, N)`). The
+                    // TCL conformance shim runs each SQL batch in a fresh CLI
+                    // process, so it carries the runtime limit forward by
+                    // re-emitting this internal PRAGMA in its per-batch prefix
+                    // (see scripts/tester_vibesql.tcl `sqlite3_limit`). The
+                    // executor clamps N into its stack-safe range when firing
+                    // triggers; we just store the raw value here.
+                    if let Some(n) = pragma_value_to_i64(value) {
+                        self.db.set_trigger_depth_limit(n);
+                    }
+                    Ok(QueryResult {
+                        rows: Vec::new(),
+                        columns: Vec::new(),
+                        row_count: 0,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
                 "DEFER_FOREIGN_KEYS" => {
                     // SQLite-compatible PRAGMA defer_foreign_keys.
                     // Phase C1 of #5085: store/read the flag and auto-reset
@@ -1634,6 +1656,21 @@ fn pragma_value_to_bool(value: &vibesql_ast::PragmaValue) -> bool {
             let upper = s.to_uppercase();
             matches!(upper.as_str(), "ON" | "TRUE" | "YES" | "1")
         }
+    }
+}
+
+/// Parse a numeric PRAGMA value into an `i64`, if it is integral.
+///
+/// Used by integer-valued internal PRAGMAs such as `trigger_depth_limit`
+/// (#5536). Returns `None` for non-numeric or non-integral values so the caller
+/// can leave the existing setting unchanged.
+fn pragma_value_to_i64(value: &vibesql_ast::PragmaValue) -> Option<i64> {
+    match value {
+        vibesql_ast::PragmaValue::Number(num) | vibesql_ast::PragmaValue::SignedNumber(num) => {
+            num.trim().parse::<i64>().ok()
+        }
+        vibesql_ast::PragmaValue::String(s) => s.trim().parse::<i64>().ok(),
+        vibesql_ast::PragmaValue::Identifier(_) => None,
     }
 }
 

--- a/crates/vibesql-executor/src/trigger_execution.rs
+++ b/crates/vibesql-executor/src/trigger_execution.rs
@@ -47,6 +47,29 @@ use crate::errors::ExecutorError;
 /// the no-overflow guards.
 const MAX_TRIGGER_RECURSION_DEPTH: usize = 700;
 
+/// Resolve the effective trigger recursion-depth limit for a connection.
+///
+/// SQLite lets a connection lower its trigger-recursion limit at runtime via
+/// `sqlite3_limit(db, SQLITE_LIMIT_TRIGGER_DEPTH, N)` (exercised by
+/// triggerC-3.5.x / 3.6.x). VibeSQL honors that here (#5536):
+///   - no per-connection limit set: the compile-time stack-safe cap
+///     `MAX_TRIGGER_RECURSION_DEPTH`,
+///   - a per-connection limit `N`: `N` clamped into the stack-safe range
+///     `[1, MAX_TRIGGER_RECURSION_DEPTH]`.
+///
+/// Clamping matches SQLite, which never lets a runtime limit exceed the
+/// compile-time `SQLITE_MAX_TRIGGER_DEPTH`, and never lets it drop below 1
+/// (a value <= 0 is treated as "query only" by `sqlite3_limit` and leaves the
+/// existing limit unchanged; here a non-positive stored value falls back to the
+/// cap). Lowering the limit can only make recursion abort *sooner*, so it is
+/// always stack-safe.
+fn effective_trigger_depth_limit(db: &Database) -> usize {
+    match db.trigger_depth_limit() {
+        Some(n) if n >= 1 => (n as usize).min(MAX_TRIGGER_RECURSION_DEPTH),
+        _ => MAX_TRIGGER_RECURSION_DEPTH,
+    }
+}
+
 thread_local! {
     /// Current trigger recursion depth for this thread
     static TRIGGER_RECURSION_DEPTH: Cell<usize> = const { Cell::new(0) };
@@ -59,12 +82,18 @@ struct RecursionGuard;
 impl RecursionGuard {
     /// Create a new recursion guard, incrementing the depth
     ///
+    /// The effective limit is the connection's runtime
+    /// `SQLITE_LIMIT_TRIGGER_DEPTH` (when lowered via `sqlite3_limit`), clamped
+    /// to the stack-safe compile-time cap. See [`effective_trigger_depth_limit`]
+    /// and #5536.
+    ///
     /// # Returns
     /// Ok(RecursionGuard) if depth is within limits, Err if limit exceeded
-    fn new() -> Result<Self, ExecutorError> {
+    fn new(db: &Database) -> Result<Self, ExecutorError> {
+        let limit = effective_trigger_depth_limit(db);
         TRIGGER_RECURSION_DEPTH.with(|depth| {
             let current = depth.get();
-            if current >= MAX_TRIGGER_RECURSION_DEPTH {
+            if current >= limit {
                 // SQLite emits exactly "too many levels of trigger recursion"
                 // (sqlite3 3.51.0; see triggerC.test 2.x / 6.x and `sqlite3VdbeError`).
                 // Use `Other` so the message surfaces verbatim (no "Unsupported
@@ -729,7 +758,7 @@ impl TriggerFirer {
         dml_schema: Option<&str>,
     ) -> Result<TriggerOutcome, ExecutorError> {
         // Check recursion depth before executing any triggers
-        let _guard = RecursionGuard::new()?;
+        let _guard = RecursionGuard::new(db)?;
 
         let triggers =
             Self::find_triggers_in_schema(db, table_name, TriggerTiming::Before, event, dml_schema);
@@ -793,7 +822,7 @@ impl TriggerFirer {
         dml_schema: Option<&str>,
     ) -> Result<TriggerOutcome, ExecutorError> {
         // Check recursion depth before executing any triggers
-        let _guard = RecursionGuard::new()?;
+        let _guard = RecursionGuard::new(db)?;
 
         let triggers =
             Self::find_triggers_in_schema(db, table_name, TriggerTiming::Before, event, dml_schema);
@@ -846,7 +875,7 @@ impl TriggerFirer {
         dml_schema: Option<&str>,
     ) -> Result<TriggerOutcome, ExecutorError> {
         // Check recursion depth before executing any triggers
-        let _guard = RecursionGuard::new()?;
+        let _guard = RecursionGuard::new(db)?;
 
         let triggers =
             Self::find_triggers_in_schema(db, table_name, TriggerTiming::After, event, dml_schema);
@@ -909,7 +938,7 @@ impl TriggerFirer {
         dml_schema: Option<&str>,
     ) -> Result<TriggerOutcome, ExecutorError> {
         // Check recursion depth before executing any triggers
-        let _guard = RecursionGuard::new()?;
+        let _guard = RecursionGuard::new(db)?;
 
         let triggers =
             Self::find_triggers_in_schema(db, table_name, TriggerTiming::After, event, dml_schema);

--- a/crates/vibesql-executor/tests/trigger_depth_limit_tests.rs
+++ b/crates/vibesql-executor/tests/trigger_depth_limit_tests.rs
@@ -1,0 +1,147 @@
+//! Tests for the per-connection runtime trigger-depth limit (#5536).
+//!
+//! SQLite lets a connection lower its trigger-recursion limit at runtime via
+//! `sqlite3_limit(db, SQLITE_LIMIT_TRIGGER_DEPTH, N)` (exercised by SQLite's
+//! triggerC-3.5.x / 3.6.x). VibeSQL stores that value on the `Database`
+//! (`set_trigger_depth_limit`, surfaced to the CLI/TCL shim via the internal
+//! `PRAGMA trigger_depth_limit`) and honors it in `RecursionGuard`, clamped to
+//! the stack-safe compile-time cap.
+//!
+//! Every expectation below mirrors SQLite's triggerC-3.6.x against
+//! sqlite3 3.51.0, where `SQLITE_LIMIT_TRIGGER_DEPTH` is set to 1.
+
+use vibesql_executor::{
+    CreateTableExecutor, DeleteExecutor, InsertExecutor, SelectExecutor, TriggerExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Parse and execute a single non-SELECT statement, returning the executor
+/// result so callers can assert on success *or* failure.
+fn try_exec(db: &mut Database, sql: &str) -> Result<(), String> {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).map_err(|e| format!("parse failed for `{sql}`: {e:?}"))?;
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).map_err(|e| e.to_string())?;
+        }
+        Statement::CreateTrigger(s) => {
+            TriggerExecutor::create_trigger_with_sql(db, &s, Some(sql))
+                .map_err(|e| e.to_string())?;
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).map_err(|e| e.to_string())?;
+        }
+        Statement::Delete(s) => {
+            DeleteExecutor::execute(&s, db).map_err(|e| e.to_string())?;
+        }
+        other => panic!("unsupported statement in test helper: {other:?}"),
+    }
+    Ok(())
+}
+
+/// Execute a statement that must succeed.
+fn exec(db: &mut Database, sql: &str) {
+    try_exec(db, sql).unwrap_or_else(|e| panic!("`{sql}` failed: {e}"));
+}
+
+/// Run a single-value SELECT count(*) and return it.
+fn count(db: &Database, sql: &str) -> i64 {
+    use vibesql_ast::Statement;
+    let Statement::Select(select) = Parser::parse_sql(sql).expect("parse failed") else {
+        panic!("expected SELECT");
+    };
+    let rows = SelectExecutor::new(db).execute(&select).expect("SELECT failed");
+    match rows[0].values[0] {
+        SqlValue::Integer(n) => n,
+        ref other => panic!("expected integer count, got {other:?}"),
+    }
+}
+
+/// triggerC-3.6.x shape: a WHEN-guarded self-insert with the runtime trigger
+/// limit lowered to 1.
+///
+/// - Inserting 2000 fires zero nested triggers (`WHEN new.x<2000` is false), so it succeeds even
+///   with a limit of 1 (triggerC-3.6.1/3.6.2).
+/// - Inserting 1999 fires one nested trigger (1999 -> 2000), which trips the limit of 1, so the
+///   statement aborts with SQLite's exact wording and rolls back (triggerC-3.6.3/3.6.4).
+#[test]
+fn runtime_limit_of_one_aborts_at_one_level() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t3b(x)");
+    exec(
+        &mut db,
+        "CREATE TRIGGER t3bi AFTER INSERT ON t3b WHEN new.x<2000 \
+         BEGIN INSERT INTO t3b VALUES(new.x+1); END",
+    );
+
+    // sqlite3_limit(db, SQLITE_LIMIT_TRIGGER_DEPTH, 1)
+    db.set_trigger_depth_limit(1);
+    assert_eq!(db.trigger_depth_limit(), Some(1));
+
+    // Non-recursing insert succeeds under the limit (3.6.1/3.6.2).
+    exec(&mut db, "INSERT INTO t3b VALUES(2000)");
+    assert_eq!(count(&db, "SELECT count(*) FROM t3b"), 1);
+
+    exec(&mut db, "DELETE FROM t3b");
+
+    // One-level recursion trips the limit of 1 and aborts (3.6.3).
+    let err = try_exec(&mut db, "INSERT INTO t3b VALUES(1999)")
+        .expect_err("recursion must abort at the runtime limit");
+    assert_eq!(err, "too many levels of trigger recursion");
+
+    // The aborted statement rolled back: table empty (3.6.4).
+    assert_eq!(count(&db, "SELECT count(*) FROM t3b"), 0);
+}
+
+/// Without a per-connection limit, the same one-level recursion succeeds: the
+/// default cap is far above 1. This pins the regression — the limit must only
+/// take effect when explicitly lowered.
+#[test]
+fn default_limit_allows_recursion_blocked_by_a_low_runtime_limit() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t3b(x)");
+    exec(
+        &mut db,
+        "CREATE TRIGGER t3bi AFTER INSERT ON t3b WHEN new.x<2000 \
+         BEGIN INSERT INTO t3b VALUES(new.x+1); END",
+    );
+
+    assert_eq!(db.trigger_depth_limit(), None, "no runtime limit by default");
+
+    // 1999 -> 2000 is one level of recursion; with the default cap it succeeds.
+    exec(&mut db, "INSERT INTO t3b VALUES(1999)");
+    assert_eq!(count(&db, "SELECT count(*) FROM t3b"), 2);
+}
+
+/// A runtime limit at or above the compile-time cap is treated as "no override":
+/// it must not raise the stack-safe cap (clamping is one-directional, downward).
+/// triggerC resets the limit to `SQLITE_MAX_TRIGGER_DEPTH` (1000) at the end of
+/// the 3.x block to restore the default — this guards that path.
+#[test]
+fn runtime_limit_above_cap_does_not_raise_the_stack_safe_cap() {
+    let mut db = Database::new();
+    db.set_trigger_depth_limit(100_000);
+
+    // Recursion still aborts at the compile-time cap, not at 100_000 — proven by
+    // an unconditional self-insert hitting the canonical error well before the
+    // huge requested limit. Run on a generous stack: the native recursion goes
+    // to the cap (~700) before erroring (debug stack frames are large).
+    std::thread::Builder::new()
+        .name("runtime_limit_above_cap".to_string())
+        .stack_size(96 * 1024 * 1024)
+        .spawn(move || {
+            exec(&mut db, "CREATE TABLE t(x)");
+            exec(
+                &mut db,
+                "CREATE TRIGGER ti AFTER INSERT ON t BEGIN INSERT INTO t VALUES(new.x+1); END",
+            );
+            let err = try_exec(&mut db, "INSERT INTO t VALUES(1)")
+                .expect_err("unbounded recursion must hit the compile-time cap");
+            assert_eq!(err, "too many levels of trigger recursion");
+        })
+        .expect("spawn thread")
+        .join()
+        .expect("cap must error, not overflow the stack");
+}

--- a/crates/vibesql-storage/src/database/session.rs
+++ b/crates/vibesql-storage/src/database/session.rs
@@ -173,6 +173,38 @@ impl Database {
         );
     }
 
+    /// Get the per-connection trigger recursion-depth limit, if one has been set
+    /// via `sqlite3_limit(db, SQLITE_LIMIT_TRIGGER_DEPTH, N)` (#5536).
+    ///
+    /// Returns `None` when the connection has not lowered the limit, in which
+    /// case the executor falls back to its compile-time
+    /// `MAX_TRIGGER_RECURSION_DEPTH` cap. A returned `Some(n)` is the raw value
+    /// requested by the caller; the executor clamps it into the stack-safe range
+    /// `[1, MAX_TRIGGER_RECURSION_DEPTH]` (the cap that keeps native recursion
+    /// from overflowing the stack lives in `vibesql-executor`, so the clamp is
+    /// applied there to avoid a storage -> executor dependency).
+    ///
+    /// This mirrors SQLite's `db->aLimit[SQLITE_LIMIT_TRIGGER_DEPTH]`, a
+    /// per-connection runtime value layered on top of the compile-time
+    /// `SQLITE_MAX_TRIGGER_DEPTH`.
+    pub fn trigger_depth_limit(&self) -> Option<i64> {
+        match self.get_session_variable("TRIGGER_DEPTH_LIMIT") {
+            Some(vibesql_types::SqlValue::Integer(n)) => Some(*n),
+            _ => None,
+        }
+    }
+
+    /// Set the per-connection trigger recursion-depth limit (#5536).
+    ///
+    /// Stores the raw requested value; clamping into the stack-safe range is the
+    /// executor's responsibility (see [`Self::trigger_depth_limit`]).
+    pub fn set_trigger_depth_limit(&mut self, value: i64) {
+        self.set_session_variable(
+            "TRIGGER_DEPTH_LIMIT",
+            vibesql_types::SqlValue::Integer(value),
+        );
+    }
+
     // ============================================================================
     // Foreign Key Enforcement (SQLite Compatibility)
     // ============================================================================

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -50,6 +50,7 @@ set ::pragma_reverse_unordered_selects 0  ;# Default: OFF (normal row order)
 set ::pragma_foreign_keys 0              ;# Default: OFF (SQLite default)
 set ::pragma_defer_foreign_keys 0        ;# Default: OFF; auto-resets at COMMIT/ROLLBACK
 set ::pragma_recursive_triggers 1        ;# Default: ON (VibeSQL default; #5535)
+set ::pragma_trigger_depth_limit 0       ;# 0 = default cap; >0 = per-connection SQLITE_LIMIT_TRIGGER_DEPTH (#5536)
 
 # DQS (Double-Quoted Strings) mode tracking
 # When enabled, double-quoted strings are treated as string literals instead of identifiers
@@ -1005,6 +1006,14 @@ proc build_pragma_prefix {} {
     # (#5535).
     if {$::pragma_recursive_triggers != 1} {
         append prefix "PRAGMA recursive_triggers=$::pragma_recursive_triggers;\n"
+    }
+    # Carry the per-connection trigger-depth limit forward (#5536). SQLite sets
+    # this via the C API `sqlite3_limit(db, SQLITE_LIMIT_TRIGGER_DEPTH, N)`, which
+    # has no SQL PRAGMA; VibeSQL exposes an internal `PRAGMA trigger_depth_limit`
+    # so the shim's per-batch CLI processes inherit the value the test set. 0
+    # means "unset" (use VibeSQL's default cap), so only re-apply a positive N.
+    if {$::pragma_trigger_depth_limit > 0} {
+        append prefix "PRAGMA trigger_depth_limit=$::pragma_trigger_depth_limit;\n"
     }
     # Replay real TEMP tables (#5591) so connection-scoped temp objects exist in
     # this fresh CLI process. Skip names whose CREATE TEMP TABLE is already in the
@@ -5184,10 +5193,34 @@ proc sqlite3_exec {db sql} {
 }
 
 proc sqlite3_limit {db limit_name args} {
-    # SQLite limit configuration
-    # Returns the current limit value; if args provided, sets new limit
-    # We return sensible defaults based on the limit type
+    # SQLite limit configuration. Mirrors the C API `sqlite3_limit`: returns the
+    # PRIOR limit value and, when a (non-negative) new value is supplied, lowers
+    # the limit. Most categories are stubbed with sensible SQLite defaults; only
+    # SQLITE_LIMIT_TRIGGER_DEPTH is actually honored end-to-end (#5536).
     switch -glob $limit_name {
+        SQLITE_LIMIT_TRIGGER_DEPTH {
+            # Prior value: the connection limit if one is set, else the
+            # compile-time default ($::SQLITE_MAX_TRIGGER_DEPTH).
+            if {$::pragma_trigger_depth_limit > 0} {
+                set prev $::pragma_trigger_depth_limit
+            } else {
+                set prev $::SQLITE_MAX_TRIGGER_DEPTH
+            }
+            if {[llength $args] > 0} {
+                set newval [lindex $args 0]
+                # sqlite3_limit ignores negative values (query-only); a value at
+                # or above the compile-time max means "use the default cap", so
+                # store 0 (unset) to drop any prior per-connection limit.
+                if {$newval >= 0} {
+                    if {$newval >= $::SQLITE_MAX_TRIGGER_DEPTH} {
+                        set ::pragma_trigger_depth_limit 0
+                    } else {
+                        set ::pragma_trigger_depth_limit $newval
+                    }
+                }
+            }
+            return $prev
+        }
         SQLITE_LIMIT_FUNCTION_ARG { return 127 }
         SQLITE_LIMIT_LENGTH { return 1000000000 }
         SQLITE_LIMIT_COLUMN { return 2000 }
@@ -5198,7 +5231,6 @@ proc sqlite3_limit {db limit_name args} {
         SQLITE_LIMIT_ATTACHED { return 10 }
         SQLITE_LIMIT_LIKE_PATTERN_LENGTH { return 50000 }
         SQLITE_LIMIT_VARIABLE_NUMBER { return 999 }
-        SQLITE_LIMIT_TRIGGER_DEPTH { return 1000 }
         default { return 1000000 }
     }
 }


### PR DESCRIPTION
## Summary
- Honor the per-connection runtime trigger-recursion limit set via `sqlite3_limit(db, SQLITE_LIMIT_TRIGGER_DEPTH, N)`. Previously VibeSQL only had a fixed compile-time cap (700) and ignored any runtime limit, so triggerC-3.5.x/3.6.x could not pass.
- Store the limit on the session (`Database::set_trigger_depth_limit` / `trigger_depth_limit`), and surface it to the multi-process TCL shim through an internal `PRAGMA trigger_depth_limit`. `RecursionGuard` now reads the connection's effective limit (runtime value clamped to `[1, MAX_TRIGGER_RECURSION_DEPTH]`, defaulting to the compile-time cap when unset).
- Wire the shim's `sqlite3_limit` stub to actually track `SQLITE_LIMIT_TRIGGER_DEPTH` and re-emit it in the per-batch PRAGMA prefix so each fresh CLI process inherits it (mirrors how `recursive_triggers` is carried forward).

## Mechanism
- The shim runs each SQL batch in a **fresh CLI process**, so a "per-connection" runtime limit must be replayed every batch. The established pattern (used by `recursive_triggers`) is a tracked-PRAGMA prefix; this PR reuses it. SQLite has no SQL PRAGMA for the trigger depth, so VibeSQL adds an internal `PRAGMA trigger_depth_limit` consumed only by the shim.
- Clamping is one-directional (downward only): a requested value `>= SQLITE_MAX_TRIGGER_DEPTH` is treated as "use the default cap" (the shim stores 0/unset; the executor falls back to `MAX_TRIGGER_RECURSION_DEPTH`). Lowering the limit can only abort recursion sooner, so it remains stack-safe. Error wording is unchanged: `too many levels of trigger recursion` (matches sqlite3 3.51.0).

## triggerC.test before/after
- Before: 79 passed / 38 failed.
- After: 84 passed / 33 failed.
- Newly passing: triggerC-3.5.3, 3.5.4, 3.6.2, 3.6.3, 3.6.4.
- Still failing (out of scope): triggerC-3.3.1/3.3.2 require recursing to depth 1000, above VibeSQL's stack-safe static cap of 700 — tracked by #5534 (raise the static cap via stack-safe recursion). All other remaining failures (4.x/5.x/6.x/7.x/10.x/11.x/12.x/15.x/16.x) are pre-existing and unrelated.

## No-regression evidence
- `cargo test -p vibesql-executor`: all pass (2838 lib + all integration/doctests, including the new `trigger_depth_limit_tests.rs`).
- `cargo test -p vibesql-cli -p vibesql-storage`: all pass.
- TCL: trigger1 (32/38), trigger2 (70/0), trigger3 (15/2) — identical to baseline (none of these use `sqlite3_limit`; the change is a strict no-op when no limit is set).
- New Rust regression test (`crates/vibesql-executor/tests/trigger_depth_limit_tests.rs`) covers: limit=1 aborts at one level and rolls back; non-recursing insert succeeds under a limit of 1; default (no limit) still recurses; a limit above the cap does not raise the stack-safe cap.

## Follow-ons
- #5534: raise the static `MAX_TRIGGER_RECURSION_DEPTH` to the full `SQLITE_MAX_TRIGGER_DEPTH` (1000) via stack-safe recursion — required for triggerC-3.3.x.

Closes #5536

🤖 Generated with [Claude Code](https://claude.com/claude-code)