### PR TITLE
fix(alter): abort RENAME COLUMN on ambiguous trigger-body column ref

### DIFF
--- a/crates/vibesql-executor/src/alter/columns.rs
+++ b/crates/vibesql-executor/src/alter/columns.rs
@@ -260,13 +260,27 @@ pub(super) fn execute_rename_column(
     // Invalidate the database-level columnar cache since the schema changed.
     database.invalidate_columnar_cache(&stmt.table_name);
 
-    // Propagate the rename into trigger bodies that reference this column.
-    super::table_options::rewrite_triggers_for_column_rename(
+    // Propagate the rename into trigger bodies that reference this column. If an
+    // unqualified reference to the renamed column is ambiguous in a trigger
+    // body, SQLite (legacy_alter_table=OFF) aborts the whole ALTER and leaves
+    // the schema unchanged. Roll back the schema rename on that error so the
+    // ALTER is atomic, matching SQLite.
+    if let Err(err) = super::table_options::rewrite_triggers_for_column_rename(
         database,
         &stmt.table_name,
         &stmt.old_column_name,
         &stmt.new_column_name,
-    );
+    ) {
+        if let Some(table) = database.get_table_mut(&stmt.table_name) {
+            if let Some(idx) = table.schema.get_column_index(&stmt.new_column_name) {
+                // Best-effort rollback; the column was just renamed so this
+                // restores the original name.
+                let _ = table.schema_mut().rename_column(idx, &stmt.old_column_name);
+            }
+        }
+        database.invalidate_columnar_cache(&stmt.table_name);
+        return Err(err);
+    }
 
     Ok(format!(
         "Column '{}' renamed to '{}' in table '{}'",

--- a/crates/vibesql-executor/src/alter/table_options.rs
+++ b/crates/vibesql-executor/src/alter/table_options.rs
@@ -124,12 +124,19 @@ fn rewrite_triggers_for_rename(database: &mut Database, old_name: &str, new_name
 /// bodies that resolve to the renamed column are rewritten (unquoted), while the
 /// rest of the `CREATE TRIGGER` text is preserved verbatim. The renamed table's
 /// own `ON`-target name does not change. See `crate::trigger_rename`.
+///
+/// If an unqualified reference to the renamed column is *ambiguous* in a trigger
+/// body (the renamed table and another in-scope table both own a column of that
+/// name), SQLite aborts the whole ALTER and leaves the schema unchanged. This
+/// returns `Err(ExecutorError::AmbiguousColumnName { .. })` (wrapped to mirror
+/// SQLite's `error in trigger <name>: ambiguous column name: <col>` message) so
+/// the caller can abort before committing the rename.
 pub(super) fn rewrite_triggers_for_column_rename(
     database: &mut Database,
     table: &str,
     old_column: &str,
     new_column: &str,
-) {
+) -> Result<(), ExecutorError> {
     // Snapshot table -> column-name set so the rewrite resolver can attribute
     // unqualified columns to their owning table without borrowing the database
     // while we mutate the catalog. The snapshot reflects the *post-rename* schema
@@ -160,7 +167,12 @@ pub(super) fn rewrite_triggers_for_column_rename(
         schema.get(&t_lc).is_some_and(|cols| cols.iter().any(|col| col.eq_ignore_ascii_case(c)))
     };
 
+    // Two-phase: compute every trigger update first so that an ambiguity error
+    // in any trigger aborts the whole ALTER *before* any catalog mutation. This
+    // mirrors SQLite, which leaves the schema entirely unchanged on a genuine
+    // ambiguity rather than partially rewriting earlier triggers.
     let trigger_names = database.catalog.list_triggers();
+    let mut pending_updates = Vec::new();
     for name in trigger_names {
         let Some(existing) = database.catalog.get_trigger(&name) else {
             continue;
@@ -169,22 +181,38 @@ pub(super) fn rewrite_triggers_for_column_rename(
         let body_text = match &existing.triggered_action {
             TriggerAction::RawSql(sql) => sql.clone(),
         };
+        // An ambiguous unqualified reference to the renamed column aborts the
+        // ALTER (SQLite: "error in trigger <name>: ambiguous column name: <col>").
+        // Map the resolver error to that message, using `Other` so the verbatim
+        // SQLite wording is preserved.
+        let ambiguity_error = |col: String| {
+            ExecutorError::Other(format!(
+                "error in trigger {}: ambiguous column name: {}",
+                name, col
+            ))
+        };
         let new_body = rewrite_column_refs_in_trigger_sql(
             &body_text,
             table,
             old_column,
             new_column,
             &table_has_column,
-        );
-        let new_sql_definition = existing.sql_definition.as_ref().map(|sql| {
-            rewrite_column_refs_in_trigger_sql(
-                sql,
-                table,
-                old_column,
-                new_column,
-                &table_has_column,
-            )
-        });
+        )
+        .map_err(ambiguity_error)?;
+        let new_sql_definition = existing
+            .sql_definition
+            .as_ref()
+            .map(|sql| {
+                rewrite_column_refs_in_trigger_sql(
+                    sql,
+                    table,
+                    old_column,
+                    new_column,
+                    &table_has_column,
+                )
+            })
+            .transpose()
+            .map_err(ambiguity_error)?;
 
         let body_changed = new_body != body_text;
         let sql_def_changed = new_sql_definition.as_deref() != existing.sql_definition.as_deref();
@@ -200,7 +228,11 @@ pub(super) fn rewrite_triggers_for_column_rename(
         if sql_def_changed {
             updated.sql_definition = new_sql_definition;
         }
+        pending_updates.push(updated);
+    }
 
+    for updated in pending_updates {
         let _ = database.catalog.update_trigger(updated);
     }
+    Ok(())
 }

--- a/crates/vibesql-executor/src/tests/alter_rename_column_triggers.rs
+++ b/crates/vibesql-executor/src/tests/alter_rename_column_triggers.rs
@@ -167,3 +167,60 @@ fn rename_column_onto_existing_errors() {
     let err = exec(&mut db, "ALTER TABLE t2 RENAME c TO d").unwrap_err();
     assert!(matches!(err, ExecutorError::ColumnAlreadyExists(_)), "got: {err:?}");
 }
+
+#[test]
+fn rename_column_ambiguous_in_trigger_aborts_and_leaves_schema_unchanged() {
+    // sqlite3 3.51.0 (legacy_alter_table=OFF): an unqualified reference to the
+    // renamed column that is ambiguous across multiple in-scope tables aborts
+    // the entire ALTER ("SQL logic error" at the shell; "error in trigger r1:
+    // ambiguous column name: e" via the C API) and leaves the schema unchanged.
+    let mut db = Database::new();
+    setup(&mut db);
+    // Both t3 and t4 own column `e`; the trigger's WHERE `e` is ambiguous.
+    exec(
+        &mut db,
+        "CREATE TRIGGER r1 INSERT ON t3 BEGIN \
+         UPDATE t3 SET e=1 FROM t4 WHERE e=2; END",
+    )
+    .unwrap();
+
+    let body_before = trigger_body(&db, "r1");
+    let sql_before = trigger_sql(&db, "r1");
+
+    let err = exec(&mut db, "ALTER TABLE t3 RENAME e TO abc").unwrap_err();
+    match &err {
+        ExecutorError::Other(msg) => {
+            assert_eq!(msg, "error in trigger r1: ambiguous column name: e", "got: {msg}");
+        }
+        other => panic!("expected ambiguity Other error, got: {other:?}"),
+    }
+
+    // Schema unchanged: t3.e still exists, t3.abc does not.
+    let t3 = db.get_table("t3").expect("t3 exists");
+    assert!(t3.schema.has_column("e"), "t3.e should be unchanged after aborted ALTER");
+    assert!(!t3.schema.has_column("abc"), "t3.abc must not exist after aborted ALTER");
+
+    // Trigger untouched.
+    assert_eq!(trigger_body(&db, "r1"), body_before, "trigger body must be unchanged");
+    assert_eq!(trigger_sql(&db, "r1"), sql_before, "trigger sql must be unchanged");
+}
+
+#[test]
+fn rename_column_unambiguous_still_succeeds_with_other_table_sharing_name() {
+    // Guard against over-eager aborting: a qualified `t3.e` is unambiguous even
+    // though t4 also owns `e`, so the ALTER must still succeed.
+    let mut db = Database::new();
+    setup(&mut db);
+    exec(
+        &mut db,
+        "CREATE TRIGGER r1 INSERT ON t3 BEGIN \
+         UPDATE t3 SET a=1 FROM t4 WHERE t3.e=2; END",
+    )
+    .unwrap();
+
+    exec(&mut db, "ALTER TABLE t3 RENAME e TO abc").unwrap();
+
+    let t3 = db.get_table("t3").expect("t3 exists");
+    assert!(t3.schema.has_column("abc"));
+    assert!(trigger_sql(&db, "r1").contains("t3.abc=2"), "{}", trigger_sql(&db, "r1"));
+}

--- a/crates/vibesql-executor/src/trigger_rename.rs
+++ b/crates/vibesql-executor/src/trigger_rename.rs
@@ -206,18 +206,25 @@ fn is_table_position(
 ///
 /// This is a *targeted* resolver covering the cases exercised by
 /// `altertrig.test` (qualified `table.col` / `alias.col` references and
-/// unqualified columns whose only in-scope owner is the renamed table). It does
-/// not reproduce SQLite's full ambiguity diagnostics.
+/// unqualified columns whose only in-scope owner is the renamed table).
+///
+/// When an unqualified reference to the renamed column would be genuinely
+/// *ambiguous* (the renamed table and another in-scope table both own a column
+/// of that name), this returns `Err(column_name)`. SQLite
+/// (`legacy_alter_table=OFF`) aborts the entire `ALTER TABLE ... RENAME COLUMN`
+/// in that case with `error in trigger <name>: ambiguous column name: <col>`
+/// and leaves the schema unchanged; the caller is responsible for surfacing
+/// that error and not committing the rename.
 pub fn rewrite_column_refs_in_trigger_sql(
     sql: &str,
     renamed_table: &str,
     old_column: &str,
     new_column: &str,
     table_has_column: &dyn Fn(&str, &str) -> bool,
-) -> String {
+) -> Result<String, String> {
     let tokens = match Lexer::new(sql).tokenize_with_spans() {
         Ok(t) => t,
-        Err(_) => return sql.to_string(),
+        Err(_) => return Ok(sql.to_string()),
     };
 
     let significant: Vec<usize> =
@@ -266,22 +273,38 @@ pub fn rewrite_column_refs_in_trigger_sql(
         // owner of this column.
         if name.eq_ignore_ascii_case(old_column) && is_column_position(&tokens, &significant, pos) {
             let scope_key = paren_scope_at(&tokens, &significant, pos);
-            if unqualified_resolves_to_renamed_table(
+            match resolve_unqualified_column(
                 renamed_table,
                 old_column,
                 scope_key,
                 &scopes,
                 table_has_column,
             ) {
-                edits.push(tokens[idx].1);
+                Resolution::Rewrite => edits.push(tokens[idx].1),
+                Resolution::Ambiguous => return Err(name.clone()),
+                Resolution::Skip => {}
             }
         }
     }
 
     if edits.is_empty() {
-        return sql.to_string();
+        return Ok(sql.to_string());
     }
-    apply_column_edits(sql, &edits, new_column)
+    Ok(apply_column_edits(sql, &edits, new_column))
+}
+
+/// Outcome of resolving an unqualified column reference against the renamed
+/// table within a trigger body scope.
+enum Resolution {
+    /// The reference resolves unambiguously to the renamed table's renamed
+    /// column; rewrite it.
+    Rewrite,
+    /// The reference does not resolve to the renamed table (the renamed table is
+    /// not in scope, or does not own the column); leave it untouched.
+    Skip,
+    /// The reference is ambiguous: the renamed table and another in-scope table
+    /// both own a column of this name. SQLite aborts the ALTER here.
+    Ambiguous,
 }
 
 /// A table reference appearing in a FROM/UPDATE/INTO clause: its real table name
@@ -448,20 +471,22 @@ fn qualifier_is_renamed_table(
     false
 }
 
-/// For an unqualified column, decide whether it resolves to the renamed table:
-/// the renamed table must be in scope, the renamed table must own the old
-/// column, and no *other* in-scope table must also own a column of that name
-/// (which would make the reference ambiguous — SQLite errors there, so we
-/// conservatively decline to rewrite).
-fn unqualified_resolves_to_renamed_table(
+/// For an unqualified column, decide how it resolves against the renamed table:
+/// - `Rewrite` when the renamed table is in scope, owns the old column, and no *other* in-scope
+///   table also owns a column of that name;
+/// - `Ambiguous` when the renamed table is in scope and owns the column but at least one other
+///   in-scope table also owns a column of that name (SQLite aborts the ALTER here);
+/// - `Skip` otherwise (the renamed table is not in scope or does not own the column, so the
+///   reference is unrelated to the rename).
+fn resolve_unqualified_column(
     renamed_table: &str,
     old_column: &str,
     scope_key: Option<usize>,
     scopes: &std::collections::HashMap<Option<usize>, Vec<TableRef>>,
     table_has_column: &dyn Fn(&str, &str) -> bool,
-) -> bool {
+) -> Resolution {
     if !table_has_column(renamed_table, old_column) {
-        return false;
+        return Resolution::Skip;
     }
 
     let mut renamed_in_scope = false;
@@ -483,7 +508,11 @@ fn unqualified_resolves_to_renamed_table(
         }
     }
 
-    renamed_in_scope && !other_owner
+    match (renamed_in_scope, other_owner) {
+        (true, false) => Resolution::Rewrite,
+        (true, true) => Resolution::Ambiguous,
+        (false, _) => Resolution::Skip,
+    }
 }
 
 /// Decide whether the identifier at `significant[pos]` is in a position where it
@@ -530,6 +559,11 @@ mod tests {
     }
 
     fn rewrite_col(sql: &str, table: &str, old: &str, new: &str) -> String {
+        rewrite_column_refs_in_trigger_sql(sql, table, old, new, &altertrig_schema)
+            .expect("rewrite should not be ambiguous in this fixture")
+    }
+
+    fn rewrite_col_result(sql: &str, table: &str, old: &str, new: &str) -> Result<String, String> {
         rewrite_column_refs_in_trigger_sql(sql, table, old, new, &altertrig_schema)
     }
 
@@ -613,6 +647,41 @@ mod tests {
     fn col_unqualified_other_table_not_in_scope_unchanged() {
         let sql = "CREATE TRIGGER r1 INSERT ON t1 BEGIN UPDATE t1 SET a=1 FROM t3 WHERE e=1; END";
         assert_eq!(rewrite_col(sql, "t2", "c", "abc"), sql);
+    }
+
+    #[test]
+    fn col_ambiguous_unqualified_errors() {
+        // Both t3 and t4 own column `e`, both in scope (UPDATE t3 ... FROM t4),
+        // and the unqualified `e` in WHERE is ambiguous. sqlite3 3.51.0
+        // (legacy_alter_table=OFF) aborts the ALTER with "ambiguous column
+        // name: e", so the rewriter must surface an error rather than silently
+        // skip. Renaming either table's `e` is ambiguous.
+        let sql = "CREATE TRIGGER r1 INSERT ON t3 BEGIN UPDATE t3 SET e=1 FROM t4 WHERE e=2; END";
+        let err = rewrite_col_result(sql, "t3", "e", "abc").expect_err("should be ambiguous");
+        assert_eq!(err, "e");
+        // Symmetric: renaming t4.e is ambiguous in the same trigger body.
+        let err = rewrite_col_result(sql, "t4", "e", "abc").expect_err("should be ambiguous");
+        assert_eq!(err, "e");
+    }
+
+    #[test]
+    fn col_ambiguity_only_when_renamed_table_in_scope() {
+        // The renamed table (t2) is not in scope, so the unqualified `e` is not
+        // ambiguous with respect to this rename: skip (no error, no change).
+        let sql = "CREATE TRIGGER r1 INSERT ON t1 BEGIN UPDATE t3 SET e=1 FROM t4 WHERE e=2; END";
+        assert_eq!(rewrite_col_result(sql, "t2", "c", "abc").unwrap(), sql);
+    }
+
+    #[test]
+    fn col_qualified_ref_not_ambiguous() {
+        // A qualified `t3.e` is unambiguous even though t4 also owns `e`; it
+        // must rewrite (not error).
+        let sql =
+            "CREATE TRIGGER r1 INSERT ON t3 BEGIN UPDATE t3 SET a=1 FROM t4 WHERE t3.e=2; END";
+        assert_eq!(
+            rewrite_col_result(sql, "t3", "e", "abc").unwrap(),
+            "CREATE TRIGGER r1 INSERT ON t3 BEGIN UPDATE t3 SET a=1 FROM t4 WHERE t3.abc=2; END"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Follow-on from #5602. Makes `ALTER TABLE ... RENAME COLUMN` abort with a SQLite-matching error when the rename would make an unqualified column reference inside a trigger body genuinely ambiguous, instead of silently letting the ALTER succeed while leaving the trigger body untouched.

- `rewrite_column_refs_in_trigger_sql` now returns `Result<String, String>`; its resolver distinguishes Rewrite / Skip / **Ambiguous**, returning `Err(col)` on genuine ambiguity (renamed table + another in-scope table both own that column).
- `rewrite_triggers_for_column_rename` maps that error to `error in trigger <name>: ambiguous column name: <col>` and computes all trigger updates **before** any catalog mutation (two-phase) so nothing is partially rewritten.
- `execute_rename_column` rolls back the schema rename if the trigger rewrite errors, making the ALTER atomic (schema unchanged), matching SQLite.

### sqlite3 3.51.0 (legacy_alter_table=OFF) behavior confirmed
```sql
CREATE TABLE t3(e,f); CREATE TABLE t4(e,f);
CREATE TRIGGER r1 INSERT ON t3 BEGIN UPDATE t3 SET e=1 FROM t4 WHERE e=2; END;
ALTER TABLE t3 RENAME e TO abc;   -- aborts; schema + trigger unchanged
```
- Shell surfaces `Runtime error ... SQL logic error` (generic SQLITE_ERROR); the C-API / TCL message is `error in trigger r1: ambiguous column name: e` (cf. `altercol.test` `error in trigger tr1: $error` pattern).
- Abort condition: the renamed table is in scope AND another in-scope table also owns a column of that name AND the reference is unqualified. Qualified refs (`t3.e`) and renames where the renamed table is not in scope still succeed.

## Test plan
- [x] New Rust unit tests in `trigger_rename.rs`: ambiguous-abort (both rename directions), ambiguity-only-when-renamed-table-in-scope, qualified-not-ambiguous.
- [x] New integration tests in `tests/alter_rename_column_triggers.rs`: end-to-end ambiguous abort leaves schema + trigger unchanged with the exact SQLite message; unambiguous qualified rename still succeeds with another table sharing the name.
- [x] `cargo build -p vibesql-executor` clean (pre-existing warnings only).
- [x] `cargo test -p vibesql-executor` all green.
- [x] `make test-tcl-file FILE=altertrig.test` still **36/36**.

## Follow-ons
- The two-phase rewrite avoids partial catalog mutation; the schema rollback in `execute_rename_column` is best-effort (relies on the rename being reversible). A future general transactional rollback for ALTER would subsume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #5603