### PR TITLE
fix(executor): immediate intermediate-collision check for regular UNIQUE/PK on UPDATE (#5588)

### DIFF
--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -26,6 +26,7 @@ use super::{
         detect_surviving_replace_conflict, find_conflicting_rows_for_update,
         resolve_cross_update_conflicts_for_replace, validate_cross_update_uniqueness,
         validate_post_statement_uniqueness, validate_rowid_relocation,
+        validate_unique_relocation,
     },
     row_selector::RowSelector,
     triggers,
@@ -489,6 +490,20 @@ pub(super) fn execute_internal(
         // sqlite3 (triggerC-7.x). IPK tables write the real PK column and are
         // covered by the PK check above.
         validate_rowid_relocation(&updates, schema, table_for_check)?;
+
+        // Regular (non-rowid) UNIQUE / PRIMARY KEY columns also get sqlite3's
+        // IMMEDIATE row-by-row intermediate-collision check (issue #5588): a
+        // single-statement swap / ascending-shift on a UNIQUE column errors even
+        // though its FINAL state is duplicate-free. The deferred validator above
+        // still permits #5137 descending-shift / negation cases that sqlite3
+        // accepts; this additive check only rejects what sqlite3 rejects.
+        validate_unique_relocation(
+            &updates,
+            schema,
+            table_for_check,
+            database,
+            table_name,
+        )?;
     }
 
     // For REPLACE: handle cross-update conflicts by keeping only the last update
@@ -1920,6 +1935,16 @@ fn execute_update_from(
 
         // Virtual-rowid relocation collision check (see default-path call).
         validate_rowid_relocation(&updates, schema, table_for_check)?;
+
+        // Regular (non-rowid) UNIQUE / PRIMARY KEY immediate intermediate-collision
+        // check (issue #5588) — see default-path call for rationale.
+        validate_unique_relocation(
+            &updates,
+            schema,
+            table_for_check,
+            database,
+            table_name,
+        )?;
     }
 
     // Handle CASCADE updates for primary key changes

--- a/crates/vibesql-executor/src/update/index_sync.rs
+++ b/crates/vibesql-executor/src/update/index_sync.rs
@@ -818,3 +818,207 @@ pub(super) fn validate_rowid_relocation(
 
     Ok(())
 }
+
+/// Validate relocations on **regular (non-rowid) UNIQUE / PRIMARY KEY** keys with
+/// sqlite3's IMMEDIATE row-by-row semantics (issue #5588).
+///
+/// [`validate_rowid_relocation`] applies the immediate intermediate-collision
+/// check to the rowid / INTEGER-PRIMARY-KEY column. This function does the same
+/// for the other unique key spaces — composite/regular PRIMARY KEYs (on
+/// virtual-rowid tables), table-level `UNIQUE(...)` constraints, and
+/// `CREATE UNIQUE INDEX` indexes — because sqlite3 3.51.0 checks those keys
+/// IMMEDIATELY too, not deferred to the final statement state.
+///
+/// ## sqlite3 3.51.0 behavior (verified against `/usr/bin/sqlite3` 3.51.0)
+///
+/// sqlite3 processes an UPDATE one row at a time in ascending rowid order. As it
+/// rewrites each row it removes the row's OLD index entry and then inserts its
+/// NEW entry, requiring the new key to be free *at that moment*. The live set at
+/// that moment is the union of (a) rows not yet processed and (b) rows already
+/// relocated earlier in this statement. A key that was vacated earlier in the
+/// statement is reusable; a key still held by an un-processed row is a conflict.
+///
+/// On a `id INTEGER PRIMARY KEY, k INT UNIQUE` table (so `k`'s rowids are
+/// `id` 1,2,3 in ascending order):
+///
+/// | statement                                   | sqlite3 3.51.0                       |
+/// |---------------------------------------------|--------------------------------------|
+/// | `SET k = CASE k WHEN 10 THEN 20 ...` (swap) | `UNIQUE constraint failed: u.k`      |
+/// | `SET k = k + 10` (ascending cascade)        | `UNIQUE constraint failed: u.k`      |
+/// | `SET k = k - 10` (descending cascade)       | ok — each old slot vacated first     |
+/// | 3-cycle 10->20->30->10                       | `UNIQUE constraint failed: u.k`      |
+/// | shift one row onto an existing value         | `UNIQUE constraint failed: u.k`      |
+/// | move one row to a free value                 | ok                                   |
+/// | `SET k = -k` (negation, no key reuse)        | ok                                   |
+/// | reuse-before-free (rowid order decides)      | `UNIQUE constraint failed: u.k`      |
+/// | free-before-reuse (rowid order decides)      | ok                                   |
+/// | composite `UNIQUE(a,b)` swap                  | `UNIQUE constraint failed: u.a, u.b` |
+/// | `SET k = NULL` (NULLs are distinct)          | ok                                   |
+///
+/// The `+1`/`-1` asymmetry and the rowid-order dependence are identical to the
+/// rowid path — they fall out of processing in ascending rowid order with
+/// vacate-before-occupy.
+///
+/// ## Relationship to the deferred check ([`validate_post_statement_uniqueness`])
+///
+/// This is an ADDITIVE immediate check that runs alongside the deferred
+/// final-state validator, mirroring how the rowid path was added in #5575/#5587.
+/// The deferred validator still runs (and still permits transient-duplicate
+/// shifts whose FINAL state is unique — issue #5137); this function then rejects
+/// the cases sqlite3 rejects on an intermediate collision. Because the algorithm
+/// is vacate-before-occupy in ascending rowid order, every #5137 descending-shift
+/// / negation / composite-shift case that sqlite3 accepts is also accepted here,
+/// so the deferred behavior those tests lock in is preserved unchanged.
+///
+/// The IPK column is intentionally skipped here (it is the rowid alias, already
+/// covered by [`validate_rowid_relocation`]); a composite PRIMARY KEY containing
+/// the IPK is still a multi-column key and is checked as a whole.
+pub(super) fn validate_unique_relocation(
+    updates: &[PendingUpdate],
+    schema: &TableSchema,
+    table: &Table,
+    database: &Database,
+    table_name: &str,
+) -> Result<(), ExecutorError> {
+    if updates.is_empty() {
+        return Ok(());
+    }
+
+    // A row's effective rowid drives the processing order so we reproduce
+    // sqlite3's ascending-rowid intermediate states. Matches the read path /
+    // `validate_rowid_relocation` (Row::row_id, fallback physical index + 1).
+    let order_rowid = |row: &Row, physical_index: usize| -> u64 {
+        row.row_id.unwrap_or((physical_index + 1) as u64)
+    };
+
+    // Run the shared immediate intermediate-collision algorithm for one key
+    // space (a set of column indices forming a UNIQUE/PK key). `conflict_label`
+    // is the already-qualified `table.col[, table.col...]` string sqlite3 emits.
+    let check_key_space =
+        |col_idxs: &[usize], conflict_label: &str| -> Result<(), ExecutorError> {
+            if col_idxs.is_empty() {
+                return Ok(());
+            }
+
+            let key_of = |row: &Row| -> Vec<SqlValue> {
+                col_idxs.iter().map(|&i| row.values[i].clone()).collect()
+            };
+
+            // Relocations that actually change this key, ordered by old rowid.
+            // (order_rowid, old_key, new_key). NULL handling is applied during
+            // the scan below, not here, so a move to/from NULL still vacates.
+            let mut relocations: Vec<(u64, Vec<SqlValue>, Vec<SqlValue>)> = Vec::new();
+            for u in updates {
+                let old_key = key_of(&u.old_row);
+                let new_key = key_of(&u.new_row);
+                if old_key == new_key {
+                    continue; // no-op for this key space
+                }
+                relocations.push((order_rowid(&u.old_row, u.row_index), old_key, new_key));
+            }
+            if relocations.is_empty() {
+                return Ok(());
+            }
+
+            // `occupied` is every live row's current (non-NULL) key. A key that
+            // contains NULL is never inserted because NULL != NULL in SQL — such
+            // rows neither occupy nor conflict.
+            let mut occupied: HashSet<Vec<SqlValue>> = table
+                .scan_live()
+                .map(|(_, row)| key_of(row))
+                .filter(|k| !k.contains(&SqlValue::Null))
+                .collect();
+
+            // Ascending old-rowid order reproduces sqlite3's intermediate states
+            // and the +1/-1 (and rowid-order) asymmetry.
+            relocations.sort_by_key(|&(order, _, _)| order);
+
+            for (_order, old_key, new_key) in relocations {
+                // Vacate the old key first (no-op if it held a NULL and so was
+                // never in `occupied`).
+                if !old_key.contains(&SqlValue::Null) {
+                    occupied.remove(&old_key);
+                }
+                // Occupying a NULL-containing key never conflicts.
+                if new_key.contains(&SqlValue::Null) {
+                    continue;
+                }
+                if !occupied.insert(new_key) {
+                    return Err(ExecutorError::ConstraintViolation(format!(
+                        "UNIQUE constraint failed: {}",
+                        conflict_label
+                    )));
+                }
+            }
+
+            Ok(())
+        };
+
+    // 1. PRIMARY KEY — but skip the rowid-alias (IPK) column, which
+    //    `validate_rowid_relocation` already handles immediately. A composite PK
+    //    that merely *contains* the IPK is still a multi-column key checked here.
+    if schema.rowid_alias_column.is_none() {
+        if let (Some(pk_indices), Some(pk_cols)) =
+            (schema.get_primary_key_indices(), schema.primary_key.as_ref())
+        {
+            let label = pk_cols
+                .iter()
+                .map(|c| format!("{}.{}", schema.name, c))
+                .collect::<Vec<_>>()
+                .join(", ");
+            check_key_space(&pk_indices, &label)?;
+        }
+    }
+
+    // 2. Table-level UNIQUE(...) constraints.
+    let unique_constraint_indices = schema.get_unique_constraint_indices();
+    for (constraint_idx, unique_indices) in unique_constraint_indices.iter().enumerate() {
+        let label = schema.unique_constraints[constraint_idx]
+            .iter()
+            .map(|c| format!("{}.{}", schema.name, c))
+            .collect::<Vec<_>>()
+            .join(", ");
+        check_key_space(unique_indices, &label)?;
+    }
+
+    // 3. User-defined UNIQUE indexes (CREATE UNIQUE INDEX). Expression indexes
+    //    are skipped (handled elsewhere), matching the deferred validator.
+    for index_name in database.list_indexes_for_table(table_name) {
+        let index_metadata = match database.get_index(&index_name) {
+            Some(m) => m,
+            None => continue,
+        };
+        if !index_metadata.unique {
+            continue;
+        }
+
+        let mut col_idxs: Vec<usize> = Vec::with_capacity(index_metadata.columns.len());
+        let mut is_expression_index = false;
+        for ic in &index_metadata.columns {
+            if ic.get_expression().is_some() {
+                is_expression_index = true;
+                break;
+            }
+            match ic.column_name().and_then(|cn| schema.get_column_index(cn)) {
+                Some(ci) => col_idxs.push(ci),
+                None => {
+                    is_expression_index = true;
+                    break;
+                }
+            }
+        }
+        if is_expression_index {
+            continue;
+        }
+
+        let label = index_metadata
+            .columns
+            .iter()
+            .map(|col| format!("{}.{}", table_name, col.column_name().unwrap_or("?")))
+            .collect::<Vec<_>>()
+            .join(", ");
+        check_key_space(&col_idxs, &label)?;
+    }
+
+    Ok(())
+}

--- a/crates/vibesql-executor/src/update/tests/set_rowid.rs
+++ b/crates/vibesql-executor/src/update/tests/set_rowid.rs
@@ -297,9 +297,11 @@ fn set_rowid_ipk_conflict_errors() {
 // `<table>.<ipk>`. The `-1` descending cascade, move-to-gap, and self no-op
 // still succeed. All verified against sqlite3 3.51.0.
 //
-// This is the IPK counterpart of the virtual-rowid tests above. It must NOT
-// change deferred PK/UNIQUE checking for regular columns — see
-// `regular_unique_column_swap_still_allowed_deferred` below.
+// This is the IPK counterpart of the virtual-rowid tests above. The deferred
+// final-state PK/UNIQUE check for regular columns is unchanged; the additive
+// immediate check for those columns is covered by the #5588 tests near the end
+// of this file, and the legitimate deferred *shift* cases (#5137) still pass —
+// see `regular_unique_column_shift_still_allowed_deferred` below.
 // ---------------------------------------------------------------------------
 
 /// IPK swap via the IPK column: `UPDATE t SET k=CASE...` errors on the
@@ -449,35 +451,38 @@ fn set_ipk_self_noop_ok() {
     );
 }
 
-/// REGRESSION GUARD (#5575 caution): the immediate IPK-as-rowid check must NOT
-/// leak into regular (non-rowid) UNIQUE columns. VibeSQL defers UNIQUE checks
-/// for regular columns to the final state (issue #5137), which lets a swap on a
-/// non-IPK UNIQUE column be accepted here. `k` below is a plain UNIQUE column
-/// (the rowid is the separate `id` IPK), so the immediate rowid relocation check
-/// must not fire — this swap must STILL be allowed exactly as before this fix.
+/// Issue #5588: a single-statement swap on a regular (non-rowid) UNIQUE column
+/// errors IMMEDIATELY in sqlite3 3.51.0, exactly like the IPK swap above. `k`
+/// here is a plain UNIQUE column (the rowid is the separate `id` IPK). Processing
+/// in ascending rowid order, `id=1`'s `k` 10 -> 20 collides with `id=2`'s
+/// still-live `k=20`, so sqlite3 reports `UNIQUE constraint failed: u.k`.
 ///
-/// (sqlite3 3.51.0 actually rejects this regular-column swap too — VibeSQL's
-/// deferred acceptance is a separate, pre-existing parity gap that is explicitly
-/// OUT OF SCOPE for #5575; #5575 must not regress it in either direction.)
+/// NOTE: this test previously asserted that the swap was ACCEPTED (VibeSQL's old
+/// deferred-only behavior). #5588 closes that parity gap by adding an immediate
+/// intermediate-collision check (`validate_unique_relocation`) for regular UNIQUE
+/// columns, mirroring the rowid/IPK path. The deferred final-state validator is
+/// unchanged; the legitimate deferred *shift* cases (#5137) still pass — see
+/// `regular_unique_column_shift_still_allowed_deferred` below.
 #[test]
-fn regular_unique_column_swap_still_allowed_deferred() {
+fn regular_unique_column_swap_errors_intermediate_collision() {
     let mut db = vibesql_storage::Database::new();
     ddl(&mut db, "CREATE TABLE u(id INTEGER PRIMARY KEY, k INT UNIQUE)");
     ddl(&mut db, "INSERT INTO u VALUES(1, 10)");
     ddl(&mut db, "INSERT INTO u VALUES(2, 20)");
 
-    // Swap the regular UNIQUE column `k` (NOT the IPK). Deferred final-state check
-    // sees no duplicate, so VibeSQL accepts it — the immediate IPK relocation
-    // check (which only inspects the rowid-alias column) must stay clear of it.
-    assert_eq!(
-        update(&mut db, "UPDATE u SET k = CASE k WHEN 10 THEN 20 WHEN 20 THEN 10 END").unwrap(),
-        2
+    let err = update(&mut db, "UPDATE u SET k = CASE k WHEN 10 THEN 20 WHEN 20 THEN 10 END")
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: u.k"),
+        "expected regular-UNIQUE swap to error immediately, got: {}",
+        err
     );
 
+    // Table unchanged after the aborted UPDATE.
     let rows = select(&mut db, "SELECT id, k FROM u ORDER BY id");
     let got: Vec<(i64, i64)> =
         rows.iter().map(|r| (int(&r.values[0]), int(&r.values[1]))).collect();
-    assert_eq!(got, vec![(1, 20), (2, 10)]);
+    assert_eq!(got, vec![(1, 10), (2, 20)]);
 }
 
 /// REGRESSION GUARD: a regular UNIQUE-column *shift* (`k = k - 10`) on a table
@@ -690,4 +695,304 @@ fn shadow_column_named_rowid_reflected_in_triggers() {
     assert_eq!(int(&after_delete[0].values[2]), 200);
     assert_eq!(int(&after_delete[0].values[3]), 300);
     assert_eq!(int(&after_delete[0].values[4]), 400);
+}
+
+// ===========================================================================
+// Issue #5588: regular (non-rowid) UNIQUE / PRIMARY KEY columns also get the
+// IMMEDIATE row-by-row intermediate-collision check, mirroring the rowid/IPK
+// path (#5559/#5575). sqlite3 3.51.0 processes the UPDATE in ascending rowid
+// order with vacate-before-occupy. Every case below was verified against
+// /usr/bin/sqlite3 3.51.0. The genuine deferred-shift cases that sqlite3 still
+// accepts (issue #5137) are covered both here (the `*_ok` cases) and in
+// tests/update_deferred_uniqueness_tests.rs — those must keep passing.
+// ===========================================================================
+
+/// `UPDATE u SET k = k + 10` (ascending shift) on a regular UNIQUE column errors:
+/// processing `id=1` first, `k` 10 -> 20 collides with `id=2`'s still-live 20.
+/// sqlite3 3.51.0: `UNIQUE constraint failed: u.k`.
+#[test]
+fn regular_unique_plus_ten_cascade_errors() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE u(id INTEGER PRIMARY KEY, k INT UNIQUE)");
+    ddl(&mut db, "INSERT INTO u VALUES(1, 10)");
+    ddl(&mut db, "INSERT INTO u VALUES(2, 20)");
+    ddl(&mut db, "INSERT INTO u VALUES(3, 30)");
+
+    let err = update(&mut db, "UPDATE u SET k = k + 10").unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: u.k"),
+        "expected ascending-shift UNIQUE error, got: {}",
+        err
+    );
+
+    let rows = select(&mut db, "SELECT id, k FROM u ORDER BY id");
+    let got: Vec<(i64, i64)> =
+        rows.iter().map(|r| (int(&r.values[0]), int(&r.values[1]))).collect();
+    assert_eq!(got, vec![(1, 10), (2, 20), (3, 30)]);
+}
+
+/// `UPDATE u SET k = k - 10` (descending shift) on a regular UNIQUE column
+/// SUCCEEDS — each old slot is vacated before the next row reuses it (issue
+/// #5137). sqlite3 3.51.0 accepts this; the immediate check must not regress it.
+#[test]
+fn regular_unique_minus_ten_cascade_ok() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE u(id INTEGER PRIMARY KEY, k INT UNIQUE)");
+    ddl(&mut db, "INSERT INTO u VALUES(1, 10)");
+    ddl(&mut db, "INSERT INTO u VALUES(2, 20)");
+    ddl(&mut db, "INSERT INTO u VALUES(3, 30)");
+
+    assert_eq!(update(&mut db, "UPDATE u SET k = k - 10").unwrap(), 3);
+
+    let rows = select(&mut db, "SELECT id, k FROM u ORDER BY id");
+    let got: Vec<(i64, i64)> =
+        rows.iter().map(|r| (int(&r.values[0]), int(&r.values[1]))).collect();
+    assert_eq!(got, vec![(1, 0), (2, 10), (3, 20)]);
+}
+
+/// Regular UNIQUE 3-cycle (10->20->30->10) errors on the first intermediate
+/// collision. sqlite3 3.51.0: `UNIQUE constraint failed: u.k`.
+#[test]
+fn regular_unique_three_cycle_errors() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE u(id INTEGER PRIMARY KEY, k INT UNIQUE)");
+    ddl(&mut db, "INSERT INTO u VALUES(1, 10)");
+    ddl(&mut db, "INSERT INTO u VALUES(2, 20)");
+    ddl(&mut db, "INSERT INTO u VALUES(3, 30)");
+
+    let err = update(
+        &mut db,
+        "UPDATE u SET k = CASE k WHEN 10 THEN 20 WHEN 20 THEN 30 WHEN 30 THEN 10 END",
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: u.k"),
+        "expected 3-cycle UNIQUE error, got: {}",
+        err
+    );
+}
+
+/// Shifting one regular-UNIQUE row onto an existing live value errors. sqlite3
+/// 3.51.0: `UNIQUE constraint failed: u.k`.
+#[test]
+fn regular_unique_shift_into_occupied_errors() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE u(id INTEGER PRIMARY KEY, k INT UNIQUE)");
+    ddl(&mut db, "INSERT INTO u VALUES(1, 10)");
+    ddl(&mut db, "INSERT INTO u VALUES(2, 20)");
+
+    let err = update(&mut db, "UPDATE u SET k = 20 WHERE k = 10").unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: u.k"),
+        "expected shift-into-occupied UNIQUE error, got: {}",
+        err
+    );
+}
+
+/// Moving one regular-UNIQUE row to a free value SUCCEEDS (no collision).
+#[test]
+fn regular_unique_move_to_gap_ok() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE u(id INTEGER PRIMARY KEY, k INT UNIQUE)");
+    ddl(&mut db, "INSERT INTO u VALUES(1, 10)");
+    ddl(&mut db, "INSERT INTO u VALUES(2, 20)");
+
+    assert_eq!(update(&mut db, "UPDATE u SET k = 99 WHERE k = 10").unwrap(), 1);
+
+    let rows = select(&mut db, "SELECT id, k FROM u ORDER BY id");
+    let got: Vec<(i64, i64)> =
+        rows.iter().map(|r| (int(&r.values[0]), int(&r.values[1]))).collect();
+    assert_eq!(got, vec![(1, 99), (2, 20)]);
+}
+
+/// `UPDATE u SET k = -k` (negation, no key reuse) SUCCEEDS. New values (-10,-20)
+/// collide with no live key. sqlite3 3.51.0 accepts.
+#[test]
+fn regular_unique_negation_ok() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE u(id INTEGER PRIMARY KEY, k INT UNIQUE)");
+    ddl(&mut db, "INSERT INTO u VALUES(1, 10)");
+    ddl(&mut db, "INSERT INTO u VALUES(2, 20)");
+
+    assert_eq!(update(&mut db, "UPDATE u SET k = -k").unwrap(), 2);
+
+    let rows = select(&mut db, "SELECT id, k FROM u ORDER BY id");
+    let got: Vec<(i64, i64)> =
+        rows.iter().map(|r| (int(&r.values[0]), int(&r.values[1]))).collect();
+    assert_eq!(got, vec![(1, -10), (2, -20)]);
+}
+
+/// free-before-reuse SUCCEEDS: `id=1` (k=10) vacates 10 to a gap (99), then
+/// `id=2` (k=20) takes the freed 10. Processed ascending, the slot is free in
+/// time. sqlite3 3.51.0 accepts.
+#[test]
+fn regular_unique_free_before_reuse_ok() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE u(id INTEGER PRIMARY KEY, k INT UNIQUE)");
+    ddl(&mut db, "INSERT INTO u VALUES(1, 10)");
+    ddl(&mut db, "INSERT INTO u VALUES(2, 20)");
+
+    assert_eq!(
+        update(&mut db, "UPDATE u SET k = CASE k WHEN 10 THEN 99 WHEN 20 THEN 10 END").unwrap(),
+        2
+    );
+
+    let rows = select(&mut db, "SELECT id, k FROM u ORDER BY id");
+    let got: Vec<(i64, i64)> =
+        rows.iter().map(|r| (int(&r.values[0]), int(&r.values[1]))).collect();
+    assert_eq!(got, vec![(1, 99), (2, 10)]);
+}
+
+/// reuse-before-free ERRORS: rowid order is decisive. `id=1` holds k=20 and wants
+/// k=10, but `id=2` still holds k=10 when `id=1` is processed first. sqlite3
+/// 3.51.0: `UNIQUE constraint failed: u.k` (contrast with free-before-reuse).
+#[test]
+fn regular_unique_reuse_before_free_errors() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE u(id INTEGER PRIMARY KEY, k INT UNIQUE)");
+    ddl(&mut db, "INSERT INTO u VALUES(1, 20)");
+    ddl(&mut db, "INSERT INTO u VALUES(2, 10)");
+
+    let err = update(&mut db, "UPDATE u SET k = CASE k WHEN 20 THEN 10 WHEN 10 THEN 99 END")
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: u.k"),
+        "expected reuse-before-free UNIQUE error, got: {}",
+        err
+    );
+}
+
+/// Swapping a regular UNIQUE column to NULL for all rows SUCCEEDS — multiple
+/// NULLs are allowed in a UNIQUE column. sqlite3 3.51.0 accepts.
+#[test]
+fn regular_unique_to_null_ok() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE u(id INTEGER PRIMARY KEY, k INT UNIQUE)");
+    ddl(&mut db, "INSERT INTO u VALUES(1, 10)");
+    ddl(&mut db, "INSERT INTO u VALUES(2, 20)");
+
+    assert_eq!(update(&mut db, "UPDATE u SET k = NULL").unwrap(), 2);
+
+    let rows = select(&mut db, "SELECT id, k FROM u ORDER BY id");
+    assert_eq!(rows.len(), 2);
+    assert!(matches!(rows[0].values[1], SqlValue::Null));
+    assert!(matches!(rows[1].values[1], SqlValue::Null));
+}
+
+/// Composite table-level `UNIQUE(a,b)` swap errors immediately, reported against
+/// both columns. sqlite3 3.51.0: `UNIQUE constraint failed: c.a, c.b`.
+#[test]
+fn regular_composite_unique_swap_errors() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE c(id INTEGER PRIMARY KEY, a INT, b INT, UNIQUE(a, b))");
+    ddl(&mut db, "INSERT INTO c VALUES(1, 1, 1)");
+    ddl(&mut db, "INSERT INTO c VALUES(2, 2, 2)");
+
+    let err = update(
+        &mut db,
+        "UPDATE c SET a = CASE a WHEN 1 THEN 2 WHEN 2 THEN 1 END, \
+         b = CASE b WHEN 1 THEN 2 WHEN 2 THEN 1 END",
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: c.a, c.b"),
+        "expected composite-UNIQUE swap error, got: {}",
+        err
+    );
+}
+
+/// Composite PRIMARY KEY swap on a virtual-rowid table errors immediately,
+/// reported against the PK columns. sqlite3 3.51.0: `UNIQUE constraint failed: c.a, c.b`.
+#[test]
+fn composite_pk_swap_errors() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE c(a INT, b INT, v TEXT, PRIMARY KEY(a, b))");
+    ddl(&mut db, "INSERT INTO c VALUES(1, 1, 'r1')");
+    ddl(&mut db, "INSERT INTO c VALUES(2, 2, 'r2')");
+
+    let err = update(
+        &mut db,
+        "UPDATE c SET a = CASE a WHEN 1 THEN 2 WHEN 2 THEN 1 END, \
+         b = CASE b WHEN 1 THEN 2 WHEN 2 THEN 1 END",
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: c.a, c.b"),
+        "expected composite-PK swap error, got: {}",
+        err
+    );
+}
+
+/// Composite PRIMARY KEY descending shift (`b = b - 1`) SUCCEEDS — the #5137
+/// deferred case. Must keep passing alongside the swap-errors case above.
+#[test]
+fn composite_pk_descending_shift_ok() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE c(a INT, b INT, v TEXT, PRIMARY KEY(a, b))");
+    ddl(&mut db, "INSERT INTO c VALUES(1, 0, 'r1')");
+    ddl(&mut db, "INSERT INTO c VALUES(1, 1, 'r2')");
+    ddl(&mut db, "INSERT INTO c VALUES(1, 2, 'r3')");
+
+    assert_eq!(update(&mut db, "UPDATE c SET b = b - 1").unwrap(), 3);
+
+    let rows = select(&mut db, "SELECT a, b FROM c ORDER BY b");
+    let got: Vec<(i64, i64)> =
+        rows.iter().map(|r| (int(&r.values[0]), int(&r.values[1]))).collect();
+    assert_eq!(got, vec![(1, -1), (1, 0), (1, 1)]);
+}
+
+/// User-defined `CREATE UNIQUE INDEX` swap errors immediately, reported against
+/// the indexed column. sqlite3 3.51.0: `UNIQUE constraint failed: u.k`.
+#[test]
+fn user_unique_index_swap_errors() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE u(id INTEGER PRIMARY KEY, k INT)");
+    ddl(&mut db, "CREATE UNIQUE INDEX u_k ON u(k)");
+    ddl(&mut db, "INSERT INTO u VALUES(1, 10)");
+    ddl(&mut db, "INSERT INTO u VALUES(2, 20)");
+
+    let err = update(&mut db, "UPDATE u SET k = CASE k WHEN 10 THEN 20 WHEN 20 THEN 10 END")
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: u.k"),
+        "expected user-UNIQUE-index swap error, got: {}",
+        err
+    );
+}
+
+/// User-defined UNIQUE index descending shift (`k = k - 10`) SUCCEEDS — the
+/// #5137 deferred case via the user-index path. Must keep passing.
+#[test]
+fn user_unique_index_descending_shift_ok() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE u(id INTEGER PRIMARY KEY, k INT)");
+    ddl(&mut db, "CREATE UNIQUE INDEX u_k ON u(k)");
+    ddl(&mut db, "INSERT INTO u VALUES(1, 10)");
+    ddl(&mut db, "INSERT INTO u VALUES(2, 20)");
+    ddl(&mut db, "INSERT INTO u VALUES(3, 30)");
+
+    assert_eq!(update(&mut db, "UPDATE u SET k = k - 10").unwrap(), 3);
+
+    let rows = select(&mut db, "SELECT id, k FROM u ORDER BY id");
+    let got: Vec<(i64, i64)> =
+        rows.iter().map(|r| (int(&r.values[0]), int(&r.values[1]))).collect();
+    assert_eq!(got, vec![(1, 0), (2, 10), (3, 20)]);
+}
+
+/// Regular UNIQUE column on a VIRTUAL-rowid table (no IPK): swap still errors via
+/// the storage rowid order. sqlite3 3.51.0: `UNIQUE constraint failed: u.k`.
+#[test]
+fn regular_unique_swap_errors_virtual_rowid_table() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE u(x TEXT, k INT UNIQUE)");
+    ddl(&mut db, "INSERT INTO u VALUES('a', 10)");
+    ddl(&mut db, "INSERT INTO u VALUES('b', 20)");
+
+    let err = update(&mut db, "UPDATE u SET k = CASE k WHEN 10 THEN 20 WHEN 20 THEN 10 END")
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: u.k"),
+        "expected virtual-rowid table UNIQUE swap error, got: {}",
+        err
+    );
 }


### PR DESCRIPTION
Closes #5588

Follow-on from #5575 (PR #5587), which made the **rowid / INTEGER PRIMARY KEY** path do sqlite3's IMMEDIATE row-by-row intermediate-collision check. #5587 explicitly left **regular (non-rowid) UNIQUE/PK columns** on the deferred path and filed this gap. This PR closes it.

## sqlite3 3.51.0 behavior (verified against `/usr/bin/sqlite3` 3.51.0)

sqlite3 processes an UPDATE one row at a time in **ascending rowid order**, removing each row's OLD index entry then inserting its NEW one, requiring the new key to be free *at that moment*. The same rule governs regular UNIQUE columns, composite/regular PRIMARY KEYs, and `CREATE UNIQUE INDEX` — identical to the rowid/IPK rule, just on a different key space.

Table built on `CREATE TABLE u(id INTEGER PRIMARY KEY, k INT UNIQUE)` (rowids = id 1,2,3):

| statement | sqlite3 3.51.0 | rule |
|---|---|---|
| `SET k = CASE k WHEN 10 THEN 20 WHEN 20 THEN 10 END` (swap) | `UNIQUE constraint failed: u.k` | immediate |
| `SET k = k + 10` (ascending cascade) | `UNIQUE constraint failed: u.k` | immediate |
| `SET k = k - 10` (descending cascade) | **ok** | each old slot vacated first (#5137) |
| 3-cycle `10->20->30->10` | `UNIQUE constraint failed: u.k` | immediate |
| shift one row onto an existing value (`SET k=20 WHERE k=10`) | `UNIQUE constraint failed: u.k` | immediate |
| move one row to a free value (`SET k=99 WHERE k=10`) | **ok** | no collision |
| `SET k = -k` (negation, no key reuse) | **ok** | no live collision |
| reuse-before-free (rowid order: id1 k20->10, id2 k10->99) | `UNIQUE constraint failed: u.k` | rowid order decides |
| free-before-reuse (id1 k10->99, id2 k20->10) | **ok** | rowid order decides |
| `SET k = NULL` (all rows) | **ok** | multiple NULLs allowed |
| composite `UNIQUE(a,b)` swap | `UNIQUE constraint failed: u.a, u.b` | immediate |
| composite `PRIMARY KEY(a,b)` swap | `UNIQUE constraint failed: c.a, c.b` | immediate |
| `WITHOUT ROWID` PK swap | `UNIQUE constraint failed: w.k` | immediate |

The `+1`/`-1` and rowid-order asymmetries fall out of ascending-rowid processing with vacate-before-occupy — exactly the rowid path's algorithm.

## The fix

New `validate_unique_relocation` in `crates/vibesql-executor/src/update/index_sync.rs`, modeled byte-for-algorithm on the existing `validate_rowid_relocation` (#5587). For each key space it:

1. seeds an `occupied` set with every live row's current (non-NULL) key,
2. collects relocations (rows whose key changed) ordered by **old rowid** (`row_id.unwrap_or(physical_index+1)`),
3. for each in ascending order: removes the old key, then inserts the new key — error if already occupied.

Key spaces checked: regular/composite **PRIMARY KEY** (skipping the rowid-alias IPK column, already covered by `validate_rowid_relocation`), table-level **UNIQUE(...)** constraints, and user-defined **UNIQUE indexes** (expression indexes skipped). NULL-containing keys never occupy/conflict (NULL != NULL).

Wired in additively at **both** UPDATE call sites in `executor.rs`, immediately after `validate_rowid_relocation`, for the non-IGNORE/non-REPLACE default and FROM paths.

## How I verified #5137 does NOT regress

The guardrail concern is that naive immediate checking breaks legitimate transient-duplicate shifts that sqlite3 accepts. Three layers of evidence:

1. **`validate_post_statement_uniqueness` is byte-for-byte unchanged** — `git diff` touches only `executor.rs` (2 call-site additions + 1 import) and adds one new function to `index_sync.rs`. The deferred validator preserved under #5137 is untouched. The new check is purely additive.

2. **The algorithm cannot reject a #5137 case.** sqlite3 accepts exactly the cases this vacate-before-occupy/ascending-rowid algorithm accepts (descending shift, negation, composite-PK shift, user-index shift, move-to-gap, no-op). This is the same algorithm #5587 proved correct for the rowid path; it is just applied to other key spaces.

3. **Tests prove it.** `cargo test -p vibesql-executor --test update_deferred_uniqueness_tests` — all **23** #5137/#5140 deferred tests pass **unchanged** (including `pk_shift_decrement_succeeds`, `pk_negation_succeeds`, `composite_pk_shift_succeeds`, `unique_index_shift_succeeds` and their UPDATE-FROM variants). New `*_ok` tests in `set_rowid.rs` additionally lock in the descending-shift / negation / move-to-gap / free-before-reuse / NULL cases as still-accepted.

## Tests

`crates/vibesql-executor/src/update/tests/set_rowid.rs`:
- Updated the former `regular_unique_column_swap_still_allowed_deferred` (which asserted the swap was accepted — that was the #5588 gap) to `regular_unique_column_swap_errors_intermediate_collision`, now asserting the sqlite3 error.
- Added 14 #5588 parity tests (live SELECT + error assertions) covering every row of the table above: ascending/descending cascade, 3-cycle, shift-into-occupied, move-to-gap, negation, free-before-reuse vs reuse-before-free, swap-to-NULL, composite UNIQUE swap, composite PK swap + descending shift, user UNIQUE index swap + descending shift, and a virtual-rowid-table regular UNIQUE swap.

## Test results

- `cargo build` (full workspace) — clean.
- `cargo test -p vibesql-executor` — all suites pass, **0 failures** (set_rowid: 39 pass incl. all new; deferred-uniqueness: 23 pass).
- `cargo clippy -p vibesql-executor` — clean for the touched files.
- TCL: `update.test` 126 pass / 2 fail, `index.test` 68 pass / 1 fail — the 3 failures (`update-14.2`, `update-14.4`, `index-18.4`) are **pre-existing and unrelated** (trigger WHEN-clause `no such column` resolution and `sqlite_`-reserved trigger names; none touch UNIQUE constraint checking, and they run against 0-row tables where the new check early-returns).

## Follow-ons
- The 3 unrelated TCL failures above (trigger WHEN-clause column resolution; reserved `sqlite_` object names) are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)