### PR TITLE
fix(catalog): permit DROP TABLE of a temp table with dependent temp view/trigger (#5596)

### DIFF
--- a/crates/vibesql-catalog/src/store/tables.rs
+++ b/crates/vibesql-catalog/src/store/tables.rs
@@ -271,12 +271,25 @@ impl super::Catalog {
     ///
     /// Note: Triggers are automatically dropped when the associated table is dropped.
     pub fn drop_table(&mut self, name: &str) -> Result<(), CatalogError> {
-        // Parse qualified name: schema.table or just table
+        // Parse qualified name: schema.table or just table.
+        //
+        // For an *unqualified* name, follow SQLite name-resolution order: the
+        // session's temp schema shadows the current (main) schema. Without this,
+        // `DROP TABLE t` for a temp table `t` would only look in `main` and fail
+        // with "no such table" even though the temp table exists (it is the
+        // schema that `get_table`/`table_exists` resolve to). This also matches
+        // sqlite3 3.51.0, where an unqualified DROP removes the temp table first,
+        // leaving a same-named main table intact. See #5596.
+        let unqualified_schema: Option<String> =
+            if name.contains('.') { None } else { self.resolve_table_schema_name(name) };
         let (schema_name_for_lookup, table_name, original_table_name) =
             if let Some((schema_part, table_part)) = name.split_once('.') {
                 (schema_part, table_part, table_part)
             } else {
-                (self.current_schema.as_str(), name, name)
+                // Use the temp-shadows-main resolved schema when the table exists;
+                // otherwise fall back to the current schema so the lookup below
+                // still produces a "table not found" error against `main`.
+                (unqualified_schema.as_deref().unwrap_or(self.current_schema.as_str()), name, name)
             };
 
         let normalized_table = self.normalize_identifier(table_name);

--- a/crates/vibesql-executor/tests/drop_temp_table_with_dependents_tests.rs
+++ b/crates/vibesql-executor/tests/drop_temp_table_with_dependents_tests.rs
@@ -1,0 +1,193 @@
+//! `DROP TABLE` of a temp table must succeed even while a dependent temp
+//! view/trigger references it, matching sqlite3 3.51.0. The dependent object's
+//! body is left dangling and only errors when next accessed (bare missing-table
+//! name, per #5589's qualifier guards).
+//!
+//! Root cause this exercises (see #5596): the catalog/storage `drop_table` paths
+//! resolved an *unqualified* name only against the current (`main`) schema, so a
+//! bare `DROP TABLE t` for a temp table failed with "no such table" — even with
+//! no dependents at all. The fix follows SQLite name resolution (temp shadows
+//! main) for unqualified DROP, so the temp table is found and removed from its
+//! temp schema, leaving any same-named main table intact.
+//!
+//! Verified against sqlite3 3.51.0:
+//!
+//! ```text
+//! sqlite> create temp table t2(id integer, b);
+//! sqlite> create temp view tv as select id, b from t2;
+//! sqlite> drop table t2;          -- succeeds (dependent view left dangling)
+//! sqlite> select * from tv;
+//! Error: in prepare, no such table: t2
+//!
+//! -- temp shadows main for an unqualified DROP:
+//! sqlite> create table t(id integer); insert into t values(99);
+//! sqlite> create temp table t(id integer); insert into t values(1);
+//! sqlite> drop table t;           -- drops the temp t
+//! sqlite> select * from t;        -- main t survives
+//! 99
+//! ```
+
+use vibesql_executor::{
+    CreateTableExecutor, DropTableExecutor, ExecutorError, InsertExecutor, SelectExecutor,
+    TriggerExecutor, ViewExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+/// Parse and execute a single DDL/DML statement, panicking on failure.
+fn exec_ok(db: &mut Database, sql: &str) {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e:?}"));
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+        }
+        Statement::CreateView(s) => {
+            ViewExecutor::execute_create_view(&s, db).expect("CREATE VIEW failed");
+        }
+        Statement::CreateTrigger(s) => {
+            TriggerExecutor::create_trigger_with_sql(db, &s, Some(sql))
+                .expect("CREATE TRIGGER failed");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT failed");
+        }
+        other => panic!("unsupported statement in exec_ok: {other:?}"),
+    }
+}
+
+fn drop_table(db: &mut Database, sql: &str) -> Result<String, ExecutorError> {
+    let vibesql_ast::Statement::DropTable(s) = Parser::parse_sql(sql).unwrap() else {
+        panic!("expected DROP TABLE")
+    };
+    DropTableExecutor::execute(&s, db)
+}
+
+fn select_err(db: &Database, sql: &str) -> ExecutorError {
+    let vibesql_ast::Statement::Select(s) = Parser::parse_sql(sql).unwrap() else {
+        panic!("expected SELECT")
+    };
+    SelectExecutor::new(db).execute(&s).expect_err("expected SELECT to fail")
+}
+
+fn select_row_count(db: &Database, sql: &str) -> usize {
+    let vibesql_ast::Statement::Select(s) = Parser::parse_sql(sql).unwrap() else {
+        panic!("expected SELECT")
+    };
+    SelectExecutor::new(db).execute(&s).expect("SELECT should succeed").len()
+}
+
+// --- temp table with a dependent temp VIEW ---
+
+#[test]
+fn drop_temp_table_with_dependent_temp_view_succeeds() {
+    let mut db = Database::new();
+    exec_ok(&mut db, "create temp table t2(id integer, b)");
+    exec_ok(&mut db, "create temp view tv as select id, b from t2");
+
+    // sqlite3 permits the drop; the dependent view is left dangling.
+    assert!(
+        drop_table(&mut db, "drop table t2").is_ok(),
+        "DROP of a temp table with a dependent temp view must succeed (sqlite3 parity)"
+    );
+
+    // Catalog and storage are both cleared (no metadata- or data-leak).
+    assert!(!db.catalog.table_exists("t2"), "temp table must be gone from the catalog");
+    assert!(db.get_table("t2").is_none(), "temp table storage entry must be removed");
+
+    // Accessing the now-dangling view errors at use time with the bare name
+    // (#5589's qualifier guards keep temp-view bodies unqualified).
+    assert_eq!(
+        select_err(&db, "select * from tv"),
+        ExecutorError::TableNotFound("t2".to_string()),
+        "dangling temp view must report the missing body table bare on use"
+    );
+}
+
+// --- temp table with a dependent temp TRIGGER (body references the table) ---
+
+#[test]
+fn drop_temp_table_referenced_by_temp_trigger_body_succeeds() {
+    let mut db = Database::new();
+    exec_ok(&mut db, "create table main_t(id integer)");
+    exec_ok(&mut db, "create temp table t3(id integer, b)");
+    // Trigger fires on a *different* table but its body references t3, so the
+    // table is referenced, not the trigger's ON-target. sqlite3 leaves such a
+    // trigger in place and lets the drop proceed.
+    exec_ok(
+        &mut db,
+        "create temp trigger trg after insert on main_t begin insert into t3 values(new.id, 1); end",
+    );
+
+    assert!(
+        drop_table(&mut db, "drop table t3").is_ok(),
+        "DROP of a temp table referenced by a temp trigger body must succeed (sqlite3 parity)"
+    );
+    assert!(!db.catalog.table_exists("t3"));
+    assert!(db.get_table("t3").is_none());
+}
+
+// --- no dependents: the plain temp DROP that was also broken ---
+
+#[test]
+fn drop_temp_table_without_dependents_succeeds() {
+    let mut db = Database::new();
+    exec_ok(&mut db, "create temp table tonly(id integer)");
+
+    assert!(
+        drop_table(&mut db, "drop table tonly").is_ok(),
+        "DROP of a bare temp table name must resolve the temp schema and succeed"
+    );
+    assert!(!db.catalog.table_exists("tonly"));
+    assert!(db.get_table("tonly").is_none());
+}
+
+// --- temp shadows main for an unqualified DROP ---
+
+#[test]
+fn unqualified_drop_removes_temp_then_leaves_main() {
+    let mut db = Database::new();
+    exec_ok(&mut db, "create table t(id integer)");
+    exec_ok(&mut db, "insert into t values(99)");
+    exec_ok(&mut db, "create temp table t(id integer)");
+    exec_ok(&mut db, "insert into t values(1)");
+
+    // First unqualified DROP removes the temp t (temp shadows main).
+    assert!(drop_table(&mut db, "drop table t").is_ok());
+    assert!(
+        db.catalog.table_exists("t"),
+        "the main table t must still exist after dropping temp t"
+    );
+    assert_eq!(
+        select_row_count(&db, "select * from t"),
+        1,
+        "the surviving main t should still hold its single row (99)"
+    );
+
+    // A second unqualified DROP now removes the main t.
+    assert!(drop_table(&mut db, "drop table t").is_ok());
+    assert!(!db.catalog.table_exists("t"), "the main table t must be gone after the second drop");
+}
+
+// --- main-schema behavior must not regress ---
+
+#[test]
+fn drop_main_table_with_dependent_main_view_still_succeeds() {
+    // sqlite3 3.51.0 also permits dropping a main table with a dependent main
+    // view (the view is left dangling); VibeSQL already matched this and must
+    // continue to.
+    let mut db = Database::new();
+    exec_ok(&mut db, "create table m1(id integer, b)");
+    exec_ok(&mut db, "create view mv as select id, b from m1");
+
+    assert!(drop_table(&mut db, "drop table m1").is_ok());
+    assert!(!db.catalog.table_exists("m1"));
+
+    // Dangling main view reports the missing body table with the main qualifier
+    // (#5569 behavior preserved).
+    assert_eq!(
+        select_err(&db, "select * from mv"),
+        ExecutorError::TableNotFound("main.m1".to_string()),
+        "dangling main view must report main.<name> on use (no regression to #5569)"
+    );
+}

--- a/crates/vibesql-executor/tests/temp_view_dml_missing_table_unqualified_tests.rs
+++ b/crates/vibesql-executor/tests/temp_view_dml_missing_table_unqualified_tests.rs
@@ -12,11 +12,12 @@
 //! `select/scan/table.rs` (#5584) for full read/write parity. See #5589.
 //!
 //! Reachability note: the issue's motivating sequence (CREATE temp view over a
-//! temp table, then DROP that temp table) is *not* reachable in VibeSQL today —
-//! `DROP TABLE` is blocked by a dependency check while a dependent temp
-//! view/trigger references the table (a separate divergence from sqlite, tracked
-//! independently). These tests instead use the equally valid and fully reachable
-//! scenario of a view whose body references a *never-existing* table: sqlite (and
+//! temp table, then DROP that temp table) is now reachable in VibeSQL — the
+//! unqualified `DROP TABLE` of a temp table succeeds (the dependent temp
+//! view/trigger is left dangling), matching sqlite3 (fixed in #5596; see
+//! `drop_temp_table_with_dependents_tests.rs`). These tests use the equally
+//! valid and fully reachable scenario of a view whose body references a
+//! *never-existing* table: sqlite (and
 //! VibeSQL) allow `CREATE [TEMP] VIEW` over a missing table with deferred
 //! resolution, and the missing-table error surfaces at DML time through the same
 //! `build_view_schema` qualifier path. Verified against sqlite3 3.51.0:

--- a/crates/vibesql-storage/src/database/operations.rs
+++ b/crates/vibesql-storage/src/database/operations.rs
@@ -203,12 +203,21 @@ impl Operations {
             normalized_name.clone()
         };
 
-        // Get qualified table name for index cleanup
+        // Get qualified table name for index cleanup and storage removal.
+        //
+        // For a bare (unqualified) name, resolve the owning schema with SQLite's
+        // temp-shadows-main order so a temp table is removed from its temp schema
+        // key (`temp_<n>.<table>`) rather than wrongly assuming `main`. Without
+        // this, dropping a temp table would leak its storage entry (and miss its
+        // temp-schema indexes). Resolution must run while the catalog entry still
+        // exists, i.e. before `catalog.drop_table` below. See #5596.
         let qualified_name = if resolved_name.contains('.') {
             resolved_name.clone()
         } else {
-            let current_schema = catalog.get_current_schema();
-            format!("{}.{}", current_schema, resolved_name)
+            let owning_schema = catalog
+                .resolve_table_schema_name(&resolved_name)
+                .unwrap_or_else(|| catalog.get_current_schema().to_string());
+            format!("{}.{}", owning_schema, resolved_name)
         };
 
         // Drop associated indexes BEFORE dropping table (CASCADE behavior)


### PR DESCRIPTION
## Summary

`DROP TABLE <temp_table>` now succeeds even while a dependent temp view/trigger references it, matching sqlite3 3.51.0. The dependent object is left dangling and errors only on next use.

Root cause was narrower than the issue framing implied: an **unqualified** `DROP TABLE t` resolved only against the current (`main`) schema in both the catalog (`store::tables::drop_table`) and storage (`database::operations::drop_table`) paths. So dropping a temp table failed with `Table 't' not found` **even with no dependents at all** — which is exactly why the temp-view/trigger DROP sequence was unreachable. There was no literal "dependency-block" check to relax; the fix is to resolve the temp schema for unqualified DROP.

## Changes

- `crates/vibesql-catalog/src/store/tables.rs` — `drop_table` resolves an unqualified name via `resolve_table_schema_name` (SQLite temp-shadows-main order) instead of assuming `current_schema`.
- `crates/vibesql-storage/src/database/operations.rs` — `drop_table` qualifies the storage key / index-cleanup name the same way, so the temp-schema storage entry (and its indexes) are removed rather than leaked.
- `crates/vibesql-executor/tests/drop_temp_table_with_dependents_tests.rs` — new regression tests.
- `crates/vibesql-executor/tests/temp_view_dml_missing_table_unqualified_tests.rs` — updated the now-stale "not reachable" reachability note.

## sqlite3 3.51.0 parity evidence

```text
create temp table t2(id integer, b);
create temp view tv as select id, b from t2;
drop table t2;            -- succeeds (dependent view dangling)
select * from tv;         -- Error: no such table: t2

create table t(id); insert into t values(99);
create temp table t(id); insert into t values(1);
drop table t;             -- drops the temp t (temp shadows main)
select * from t;          -- 99  (main t survives)

create table m1(id, b);
create view mv as select id, b from m1;
drop table m1;            -- succeeds; select * from mv -> no such table: main.m1
```

VibeSQL now matches all of the above.

## Test plan

- [x] `cargo build` (workspace)
- [x] `cargo test -p vibesql-catalog` (55 pass)
- [x] `cargo test -p vibesql-storage` (no failures)
- [x] `cargo test -p vibesql-executor` (2855 + integration, 0 failures)
- [x] New `drop_temp_table_with_dependents_tests` (5 pass): temp+view, temp+trigger-body, temp no-deps, temp-shadows-main, main+view no-regression
- [x] TCL `view.test` (24/24), `trigger2.test` (70/70), `trigger4.test` (23/23) — 0 failures. `trigger3.test` has 2 pre-existing failures (trigger transaction-rollback, unrelated); `temptable.test` aborts on unsupported `db2` shim command (pre-existing).

Closes #5596

🤖 Generated with [Claude Code](https://claude.com/claude-code)