### PR TITLE
feat(executor): reach SQLite's full SQLITE_MAX_TRIGGER_DEPTH (1000) via on-demand stack growth

### DIFF
--- a/crates/vibesql-executor/Cargo.toml
+++ b/crates/vibesql-executor/Cargo.toml
@@ -34,13 +34,6 @@ tokio = { version = "1.0", features = ["sync"] }
 rand = "0.10"
 md-5 = "0.11"
 
-# On-demand stack growth for native trigger recursion (#5534). Lets nested
-# trigger firing reach SQLite's full SQLITE_MAX_TRIGGER_DEPTH (1000) without
-# overflowing a fixed worker-thread stack. stacker has no wasm backend, so it is
-# gated to non-wasm targets; wasm keeps the lower stack-safe native cap.
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-stacker = "0.1.24"
-
 # Arrow dependencies for vectorized execution
 # Using 53.0+ for chrono 0.4.42 compatibility (fixes quarter() method ambiguity)
 arrow = "59.0"
@@ -54,6 +47,16 @@ mysql = { version = "28.0", optional = true }
 # These must be in [dependencies] (not dev-dependencies) to be feature-gated
 tikv-jemallocator = { version = "0.7", optional = true }
 tikv-jemalloc-ctl = { version = "0.7", features = ["stats"], optional = true }
+
+# On-demand stack growth for native trigger recursion (#5534). Lets nested
+# trigger firing reach SQLite's full SQLITE_MAX_TRIGGER_DEPTH (1000) without
+# overflowing a fixed worker-thread stack. stacker has no wasm backend, so it is
+# gated to non-wasm targets; wasm keeps the lower stack-safe native cap.
+# NOTE: this target table must stay at the END of the dependency section — a TOML
+# table header captures every key until the next header, so any plain
+# [dependencies] entry placed below it would be accidentally gated to non-wasm.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+stacker = "0.1.24"
 
 [dev-dependencies]
 vibesql-parser = { version = "0.1.4", path = "../vibesql-parser" }

--- a/crates/vibesql-executor/Cargo.toml
+++ b/crates/vibesql-executor/Cargo.toml
@@ -34,6 +34,13 @@ tokio = { version = "1.0", features = ["sync"] }
 rand = "0.10"
 md-5 = "0.11"
 
+# On-demand stack growth for native trigger recursion (#5534). Lets nested
+# trigger firing reach SQLite's full SQLITE_MAX_TRIGGER_DEPTH (1000) without
+# overflowing a fixed worker-thread stack. stacker has no wasm backend, so it is
+# gated to non-wasm targets; wasm keeps the lower stack-safe native cap.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+stacker = "0.1.24"
+
 # Arrow dependencies for vectorized execution
 # Using 53.0+ for chrono 0.4.42 compatibility (fixes quarter() method ambiguity)
 arrow = "59.0"

--- a/crates/vibesql-executor/src/trigger_execution.rs
+++ b/crates/vibesql-executor/src/trigger_execution.rs
@@ -18,34 +18,74 @@ use crate::errors::ExecutorError;
 /// (e.g. triggerC-2.2/2.3 drive ~500 levels). SQLite's compile-time default is
 /// `SQLITE_MAX_TRIGGER_DEPTH = 1000` (sqlite3 3.51.0). See #5479.
 ///
-/// STACK SAFETY (why 700, not 1000): trigger recursion is implemented as native
-/// Rust call-stack recursion -- each nested DML level adds ~8.7 KiB of stack in
-/// release builds (parse + plan + insert + fire). Empirical boundary on an 8 MiB
-/// thread is a stack overflow at depth ~960. A static cap of 1000 would
-/// therefore CRASH before the cap check ever fired (verified:
-/// `INSERT INTO t2 VALUES(999)` aborts with "stack overflow").
+/// On native targets this now matches SQLite exactly: **1000** (#5534). It used
+/// to be 700, capped for stack safety because trigger recursion is implemented
+/// as native Rust call-stack recursion (~8.7 KiB/level in release) and an 8 MiB
+/// thread overflows at depth ~960 — so a static 1000 would CRASH before the cap
+/// check fired. We removed that stack dependency by growing the native stack
+/// on demand at the trigger-recursion entry point (`stacker::maybe_grow` in
+/// [`grow_stack_for_trigger`]): each nested level ensures a large red-zone of
+/// free stack before re-entering DML, allocating a fresh heap-backed stack
+/// segment when the current thread's stack runs low. Reaching the 1000 cap is
+/// therefore a clean "too many levels of trigger recursion" error, never an
+/// overflow, regardless of the thread's fixed stack size.
 ///
-/// 700 is chosen to: (a) allow the ~500-level recursion SQLite's triggerC-2.x
-/// tests require, while (b) keeping ~24% headroom below the ~960 release-stack
-/// overflow cliff (700 * 8.7 KiB ~= 6.1 MiB of an 8 MiB budget).
+/// WASM has no `stacker` backend, so trigger recursion there stays on the fixed
+/// native stack and must keep the lower stack-safe cap; see
+/// [`MAX_TRIGGER_RECURSION_DEPTH`]'s wasm definition below.
 ///
-/// IMPORTANT — this cap is only stack-safe on a thread with an >= 8 MiB stack.
-/// All execution paths that fire triggers must run on such a thread:
-///   - CLI: a plain `fn main()` on the 8 MiB main thread (and the SQLite TCL
-///     conformance harness runs here), so triggerC-2.x at depth ~500 is safe.
-///   - Server: query execution (including the openraft replicated-apply path)
-///     runs synchronously on tokio worker threads. tokio's default 2 MiB worker
-///     stack overflows at depth ~240 — i.e. a remote client could crash the
-///     server before this cap fires (a DoS). The server therefore builds its
-///     runtime with `thread_stack_size(8 MiB)` so this cap is safe there too;
-///     see `crates/vibesql-server/src/main.rs::SERVER_WORKER_STACK_SIZE` and
-///     the 8 MiB-pinned regression test in `tests/trigger_recursion_stack.rs`.
+/// The runtime `sqlite3_limit(SQLITE_LIMIT_TRIGGER_DEPTH)` clamp
+/// ([`effective_trigger_depth_limit`]) clamps a connection's limit into
+/// `[1, MAX_TRIGGER_RECURSION_DEPTH]`, so raising this cap automatically raises
+/// the runtime ceiling too while preserving the downward-clamp safety (#5536).
+#[cfg(not(target_arch = "wasm32"))]
+const MAX_TRIGGER_RECURSION_DEPTH: usize = 1000;
+
+/// WASM trigger recursion cap.
 ///
-/// Raising this to SQLite's full 1000 requires removing the native-recursion
-/// stack dependency (on-demand stack growth / heap-allocated work stack);
-/// tracked as a follow-on (#5534). See `tests/trigger_recursion_stack.rs` for
-/// the no-overflow guards.
+/// `stacker` has no wasm backend, so on wasm trigger recursion stays on the
+/// fixed native stack and we keep the previously-proven stack-safe value of 700
+/// (the analysis in the native variant above applies: native call-stack
+/// recursion at ~8.7 KiB/level, 700 keeps headroom below an 8 MiB overflow
+/// cliff). Reaching SQLite's full 1000 on wasm would require an explicit
+/// heap-allocated work stack instead of native recursion (Option B in #5534).
+#[cfg(target_arch = "wasm32")]
 const MAX_TRIGGER_RECURSION_DEPTH: usize = 700;
+
+/// Free-stack red zone required before entering one more trigger-recursion
+/// level, and the size of each fresh stack segment `stacker` allocates when the
+/// red zone is not met. A single trigger level (parse + plan + DML + fire) costs
+/// ~8.7 KiB in release and ~50 KiB in debug; 1 MiB of red zone is comfortably
+/// more than one level needs, and a 8 MiB new-segment keeps allocations rare
+/// (one segment covers ~900 release / ~160 debug further levels) so the 1000-cap
+/// recursion grows at most a couple of heap segments. Native targets only.
+#[cfg(not(target_arch = "wasm32"))]
+const TRIGGER_STACK_RED_ZONE: usize = 1024 * 1024;
+#[cfg(not(target_arch = "wasm32"))]
+const TRIGGER_STACK_GROW_SIZE: usize = 8 * 1024 * 1024;
+
+/// Ensure there is enough native stack to descend one more trigger-recursion
+/// level, growing the stack on demand, then run `f`.
+///
+/// This is the load-bearing stack-safety primitive for #5534: it lets nested
+/// trigger firing reach SQLite's full `SQLITE_MAX_TRIGGER_DEPTH = 1000` without
+/// depending on the (fixed) worker-thread stack being large enough for 1000
+/// native frames. `stacker::maybe_grow` is a no-op when ample stack remains, so
+/// the common shallow case has negligible overhead.
+///
+/// On wasm (`stacker` unavailable) this is a transparent pass-through; the lower
+/// wasm cap keeps native recursion within the fixed wasm stack.
+#[cfg(not(target_arch = "wasm32"))]
+#[inline]
+fn grow_stack_for_trigger<R>(f: impl FnOnce() -> R) -> R {
+    stacker::maybe_grow(TRIGGER_STACK_RED_ZONE, TRIGGER_STACK_GROW_SIZE, f)
+}
+
+#[cfg(target_arch = "wasm32")]
+#[inline]
+fn grow_stack_for_trigger<R>(f: impl FnOnce() -> R) -> R {
+    f()
+}
 
 /// Resolve the effective trigger recursion-depth limit for a connection.
 ///
@@ -98,9 +138,10 @@ impl RecursionGuard {
                 // (sqlite3 3.51.0; see triggerC.test 2.x / 6.x and `sqlite3VdbeError`).
                 // Use `Other` so the message surfaces verbatim (no "Unsupported
                 // expression:" wrapper) and the TCL conformance shim passes it
-                // through unchanged. The depth cap itself is raised toward
-                // SQLite's SQLITE_MAX_TRIGGER_DEPTH; see the stack-safety note on
-                // MAX_TRIGGER_RECURSION_DEPTH for why it is 700 rather than 1000.
+                // through unchanged. The depth cap now matches SQLite's full
+                // SQLITE_MAX_TRIGGER_DEPTH (1000) on native targets via on-demand
+                // stack growth; see the stack-safety note on
+                // MAX_TRIGGER_RECURSION_DEPTH.
                 Err(ExecutorError::Other(
                     "too many levels of trigger recursion".to_string(),
                 ))
@@ -406,6 +447,25 @@ impl TriggerFirer {
     /// - For STATEMENT-level triggers, this is called once per statement
     /// - WHEN conditions are evaluated here
     pub fn execute_trigger(
+        db: &mut Database,
+        trigger: &TriggerDefinition,
+        old_row: Option<&Row>,
+        new_row: Option<&Row>,
+    ) -> Result<TriggerOutcome, ExecutorError> {
+        // Grow the native stack on demand before descending one more trigger
+        // level (#5534). Firing a trigger re-enters the full DML path (parse +
+        // plan + execute + fire), which is deep native recursion; without this
+        // the 1000-deep recursion SQLite allows would overflow a fixed
+        // worker-thread stack. `maybe_grow` is ~free when stack is plentiful, so
+        // the non-recursive common case is unaffected. The depth *limit* is
+        // still enforced by `RecursionGuard` in the per-timing entry points; this
+        // only guarantees we have stack to reach that limit cleanly.
+        grow_stack_for_trigger(|| Self::execute_trigger_inner(db, trigger, old_row, new_row))
+    }
+
+    /// Inner body of [`Self::execute_trigger`], run on a guaranteed-sufficient
+    /// native stack (see `grow_stack_for_trigger`).
+    fn execute_trigger_inner(
         db: &mut Database,
         trigger: &TriggerDefinition,
         old_row: Option<&Row>,

--- a/crates/vibesql-executor/tests/trigger_depth_limit_tests.rs
+++ b/crates/vibesql-executor/tests/trigger_depth_limit_tests.rs
@@ -127,7 +127,7 @@ fn runtime_limit_above_cap_does_not_raise_the_stack_safe_cap() {
     // Recursion still aborts at the compile-time cap, not at 100_000 — proven by
     // an unconditional self-insert hitting the canonical error well before the
     // huge requested limit. Run on a generous stack: the native recursion goes
-    // to the cap (~700) before erroring (debug stack frames are large).
+    // to the cap (1000) before erroring (debug stack frames are large).
     std::thread::Builder::new()
         .name("runtime_limit_above_cap".to_string())
         .stack_size(96 * 1024 * 1024)

--- a/crates/vibesql-executor/tests/trigger_recursion_stack.rs
+++ b/crates/vibesql-executor/tests/trigger_recursion_stack.rs
@@ -1,48 +1,65 @@
-//! Depth-cap + stack-safety regression tests for trigger recursion (#5479).
+//! Depth-cap + stack-safety regression tests for trigger recursion
+//! (#5479 / #5533 / #5534).
 //!
-//! VibeSQL caps trigger recursion at `MAX_TRIGGER_RECURSION_DEPTH = 700`. The
-//! previous cap of 16 wrongly rejected legitimate recursive-trigger programs
-//! that SQLite accepts (SQLite's `SQLITE_MAX_TRIGGER_DEPTH` is 1000; its
-//! triggerC-2.x conformance tests drive ~500 levels). The cap is 700 rather
-//! than the full 1000 for stack safety: trigger recursion uses native Rust
-//! call-stack recursion (~8.7 KiB/level in release), and the 8 MiB main thread
-//! used by the CLI/server overflows at depth ~960. 700 keeps headroom below
-//! that cliff while comfortably clearing the ~500 levels SQLite's tests need.
+//! VibeSQL caps trigger recursion at `MAX_TRIGGER_RECURSION_DEPTH`, which on
+//! native targets is now **1000** — matching SQLite's `SQLITE_MAX_TRIGGER_DEPTH`
+//! exactly (verified against sqlite3 3.51.0). The previous cap of 16 wrongly
+//! rejected legitimate recursive-trigger programs that SQLite accepts; #5533
+//! raised it to a stack-safe 700, and #5534 raises it the rest of the way to
+//! 1000 by making the recursion stack-safe instead of relying on the
+//! worker-thread stack being large enough for 1000 native frames.
+//!
+//! Stack safety (#5534): firing a trigger re-enters the full DML path (parse +
+//! plan + execute + fire) as native Rust recursion (~8.7 KiB/level release,
+//! ~50 KiB/level debug). Rather than cap below the overflow cliff, the executor
+//! now grows the native stack on demand at the trigger-recursion entry point
+//! (`stacker::maybe_grow`), so reaching the 1000 cap is a clean
+//! `too many levels of trigger recursion` error on ANY thread size, never an
+//! overflow. The load-bearing test here drives recursion to the cap on a
+//! deliberately SMALL fixed stack (smaller than 1000 native frames would need)
+//! and asserts a clean cap error — i.e. proving on-demand growth works.
 //!
 //! These tests verify that:
 //!   1. recursion well past the old cap of 16 SUCCEEDS,
 //!   2. recursion at ~500 levels (the SQLite triggerC-2.x depth) SUCCEEDS,
-//!   3. recursion that reaches the 700 cap errors with SQLite's exact wording,
-//!      `too many levels of trigger recursion`, instead of overflowing.
-//!
-//! Per-level stack cost is high in DEBUG builds (~50 KiB/level vs ~8.7 KiB in
-//! release), so a default 2 MiB libtest worker thread would overflow well
-//! before depth 700. To exercise the cap deterministically in BOTH debug and
-//! release `cargo test` runs, each deep case runs on a dedicated thread with a
-//! generously sized stack. The point being demonstrated: when the recursion is
-//! given enough stack, depths up to the cap complete cleanly and the over-cap
-//! case errors rather than crashing. The *production* stack-safety guarantee
-//! (cap < release/8 MiB overflow depth) is enforced by the cap value itself,
-//! documented on `MAX_TRIGGER_RECURSION_DEPTH`.
+//!   3. recursion at exactly the 1000 cap SUCCEEDS (triggerC-3.3.x depth),
+//!   4. recursion that exceeds the 1000 cap errors with SQLite's exact wording,
+//!      `too many levels of trigger recursion`, instead of overflowing,
+//!   5. the cap is reached cleanly even on a stack far too small to hold 1000
+//!      native frames, proving the on-demand stack growth (no overflow / DoS).
 
 use vibesql_executor::{InsertExecutor, SelectExecutor, TriggerExecutor};
 use vibesql_parser::Parser;
 use vibesql_storage::Database;
 
-/// A stack large enough to run up to the 700 cap even in debug builds, where a
-/// single trigger level can consume ~50 KiB: 700 * 50 KiB ~= 35 MiB, so 96 MiB
-/// leaves a wide margin.
+/// Native trigger recursion cap (mirrors `MAX_TRIGGER_RECURSION_DEPTH` for
+/// non-wasm targets). Kept in sync with `trigger_execution.rs`.
+const NATIVE_TRIGGER_CAP: usize = 1000;
+
+/// A stack large enough to run up to the cap even in debug builds (~50 KiB per
+/// level): 1000 * 50 KiB ~= 49 MiB, so 96 MiB leaves a wide margin. Used by the
+/// cases that simply exercise the cap *logic*; the on-demand-growth proof below
+/// deliberately uses a SMALL stack instead.
 const DEEP_TEST_STACK: usize = 96 * 1024 * 1024;
 
 /// The actual worker-thread stack the SERVER configures for its tokio runtime
 /// (`crates/vibesql-server/src/main.rs::SERVER_WORKER_STACK_SIZE`). Trigger DML
-/// runs synchronously on these threads, so the production stack-safety of the
-/// 700 cap is exactly the stack-safety of recursion on a thread THIS size — not
-/// the 96 MiB used by `DEEP_TEST_STACK`. The server-path regression test below
-/// pins to this value so it would catch a regression (e.g. dropping the
-/// `thread_stack_size` override back to tokio's 2 MiB default) that the
-/// 96 MiB-pinned tests cannot see.
+/// runs synchronously on these threads. With #5534's on-demand stack growth the
+/// cap no longer depends on this size, but pinning to it documents the real
+/// production config and guards the #5533 DoS fix.
+///
+/// Only referenced by the release-only server-stack regression test; in debug
+/// builds the on-demand-growth proof uses `SMALL_FIXED_STACK` instead.
+#[cfg_attr(debug_assertions, allow(dead_code))]
 const SERVER_WORKER_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+/// A stack deliberately too small to hold 1000 native trigger frames in release
+/// (1000 * ~8.7 KiB ~= 8.5 MiB; 2 MiB overflows at ~240 without growth). The
+/// on-demand-growth test pins to this to prove `stacker` lets recursion reach
+/// the 1000 cap cleanly anyway. (Release-only: debug frames are ~50 KiB and the
+/// stacker red zone/segment sizing differs; the cap *logic* in debug is covered
+/// by the 96 MiB cases.)
+const SMALL_FIXED_STACK: usize = 2 * 1024 * 1024;
 
 /// Parse and dispatch a single SQL statement (CREATE TABLE / CREATE TRIGGER /
 /// INSERT) against `db`.
@@ -108,34 +125,49 @@ fn on_stack<F: FnOnce() + Send + 'static>(name: &str, stack_size: usize, f: F) {
 
 #[test]
 fn recursion_succeeds_past_old_cap_of_16() {
-    // Depth 20 > old cap (16). Must succeed now that the cap is 700. Depth 20 is
+    // Depth 20 > old cap (16). Must succeed under the current cap. Depth 20 is
     // safe even on the default libtest stack, so no big-stack thread needed.
     let (db, res) = run_countdown(20);
-    res.expect("depth-20 recursion should succeed under the 700 cap");
+    res.expect("depth-20 recursion should succeed under the cap");
     assert_eq!(count_rows(&db, "t2"), 21, "rows 20..=0 should all be inserted");
 }
 
 #[test]
 fn recursion_succeeds_at_500_levels() {
     // ~500 levels is the depth SQLite's triggerC-2.2/2.3 require (and is < the
-    // 700 cap). Run on a big stack so the debug per-level frame cost cannot
+    // 1000 cap). Run on a big stack so the debug per-level frame cost cannot
     // overflow a default test thread.
     on_big_stack("trigger-depth-500", || {
         let (db, res) = run_countdown(500);
-        res.expect("depth-500 recursion should succeed under the 700 cap");
+        res.expect("depth-500 recursion should succeed under the cap");
         assert_eq!(count_rows(&db, "t2"), 501);
     });
 }
 
 #[test]
-fn recursion_at_cap_errors_with_sqlite_wording_not_overflow() {
-    // start = 5000 drives recursion to the 700 cap. With enough stack, the cap
-    // check fires and the program errors with SQLite's exact wording rather than
-    // overflowing the stack. This is the core stack-safety assertion: hitting
-    // the cap is a clean error, not a crash.
+fn recursion_succeeds_at_full_1000_cap() {
+    // triggerC-3.3.x require reaching SQLite's full SQLITE_MAX_TRIGGER_DEPTH of
+    // 1000. Driving the chain to exactly the cap must SUCCEED (the error fires
+    // only when the cap is *exceeded*). Run on a big stack: this case checks the
+    // cap *boundary*, not the on-demand growth (covered separately below).
+    on_big_stack("trigger-depth-1000", || {
+        // Each INSERT(new.a) recurses one level per decrement; start = cap - 1
+        // descends exactly to the cap on the final insert and stops at a == 0.
+        let (db, res) = run_countdown((NATIVE_TRIGGER_CAP - 1) as i64);
+        res.expect("recursion to the full 1000 cap should succeed");
+        assert_eq!(count_rows(&db, "t2"), NATIVE_TRIGGER_CAP);
+    });
+}
+
+#[test]
+fn recursion_over_cap_errors_with_sqlite_wording_not_overflow() {
+    // start = 5000 drives recursion past the 1000 cap. With enough stack, the
+    // cap check fires and the program errors with SQLite's exact wording rather
+    // than overflowing the stack. Core stack-safety assertion: exceeding the cap
+    // is a clean error, not a crash.
     on_big_stack("trigger-over-cap", || {
         let (db, res) = run_countdown(5000);
-        let err = res.expect_err("recursion reaching the cap must error");
+        let err = res.expect_err("recursion exceeding the cap must error");
         assert_eq!(
             err.to_string(),
             "too many levels of trigger recursion",
@@ -146,34 +178,70 @@ fn recursion_at_cap_errors_with_sqlite_wording_not_overflow() {
     });
 }
 
-/// Server-DoS regression (#5533): drive recursion to the 700 cap on a thread
-/// sized EXACTLY like the server's tokio worker (`SERVER_WORKER_STACK_SIZE`,
-/// 8 MiB) and assert it errors cleanly with SQLite's wording instead of
-/// overflowing the stack (SIGABRT).
+/// #5534 load-bearing test: prove on-demand stack growth lets recursion reach
+/// the full 1000 cap on a fixed stack FAR too small to hold 1000 native frames.
 ///
-/// This is the test the original PR was missing: the other deep cases pin to a
-/// 96 MiB stack, which proves the *cap logic* is correct but hides the
-/// production failure mode — the server runs trigger DML synchronously on tokio
-/// worker threads, and tokio's default 2 MiB worker stack overflows at depth
-/// ~240, BEFORE the 700 cap fires. A remote client sending a self-recursive
-/// trigger INSERT could thus crash the server. The fix sizes the server's
-/// worker stack at 8 MiB; this test reflects that real config, so if anyone
-/// drops the override (or shrinks the stack below what 700 levels need) it fails
-/// here rather than only crashing in production.
+/// 1000 levels need ~8.5 MiB of native stack in release; this thread is pinned
+/// to 2 MiB, which overflows at depth ~240 WITHOUT growth. With
+/// `stacker::maybe_grow` at the recursion entry point, the executor allocates
+/// fresh heap-backed stack segments on demand, so:
+///   - depth exactly 1000 SUCCEEDS, and
+///   - depth beyond 1000 errors cleanly with SQLite's wording — never a SIGABRT
+///     stack overflow.
+/// If on-demand growth regressed (or were removed), this thread would overflow
+/// and the harness would report the join failure rather than a clean error.
 ///
-/// Release-only: per-level frame cost is ~8.7 KiB in release (700 ~= 6.1 MiB,
-/// fits comfortably in 8 MiB) but ~50 KiB in DEBUG (700 ~= 35 MiB, would
-/// overflow an 8 MiB stack — debug is not the shipping configuration, and the
-/// server is run in release). The 96 MiB-pinned `*_at_cap_*` test above still
-/// exercises the cap logic in debug builds.
+/// Release-only: the 8.7 KiB/level figure (and thus the 2 MiB-is-too-small
+/// premise) is the release frame size; debug frames are ~50 KiB.
+#[cfg(not(debug_assertions))]
+#[test]
+fn ondemand_growth_reaches_1000_cap_on_small_stack_no_overflow() {
+    on_stack("trigger-grow-1000-small-stack", SMALL_FIXED_STACK, || {
+        // Reach exactly the cap on a 2 MiB stack: only possible via on-demand
+        // growth (1000 native frames > 2 MiB).
+        let (db, res) = run_countdown((NATIVE_TRIGGER_CAP - 1) as i64);
+        res.expect("on-demand stack growth should let recursion reach the 1000 cap");
+        assert_eq!(count_rows(&db, "t2"), NATIVE_TRIGGER_CAP);
+    });
+    on_stack("trigger-grow-over-cap-small-stack", SMALL_FIXED_STACK, || {
+        // Exceeding the cap must still be a clean error on the small stack — the
+        // growth makes us reach the cap, the cap (not the stack) stops us.
+        let (db, res) = run_countdown(5000);
+        let err = res.expect_err("over-cap recursion must error cleanly, not overflow");
+        assert_eq!(
+            err.to_string(),
+            "too many levels of trigger recursion",
+            "over-cap recursion on a small stack must error with SQLite's wording",
+        );
+        assert_eq!(count_rows(&db, "t2"), 0);
+    });
+}
+
+/// Server-DoS regression (#5533 / #5534): drive recursion past the 1000 cap on
+/// a thread sized EXACTLY like the server's tokio worker
+/// (`SERVER_WORKER_STACK_SIZE`, 8 MiB) and assert it errors cleanly with
+/// SQLite's wording instead of overflowing the stack (SIGABRT).
+///
+/// The server runs trigger DML synchronously on tokio worker threads. Before
+/// #5534 the cap (700) had to stay below what 8 MiB could hold; with on-demand
+/// stack growth the cap is the full 1000 and the executor grows the stack rather
+/// than relying on the worker stack alone. This test pins to the real server
+/// stack size and asserts a clean cap error, guarding both the #5533 8 MiB
+/// override and the #5534 growth: if the growth regressed AND the stack were
+/// shrunk below what 1000 frames need, this would overflow here rather than only
+/// crashing in production.
+///
+/// Release-only: per-level frame cost is ~8.7 KiB in release vs ~50 KiB in
+/// DEBUG; the over-cap depth is exercised in debug by the 96 MiB-pinned
+/// `*_over_cap_*` case above.
 #[cfg(not(debug_assertions))]
 #[test]
 fn server_runtime_stack_reaches_cap_cleanly_not_overflow() {
-    on_stack("trigger-server-stack-700", SERVER_WORKER_STACK_SIZE, || {
-        // 5000 drives recursion to the 700 cap. On the server's 8 MiB worker
+    on_stack("trigger-server-stack-1000", SERVER_WORKER_STACK_SIZE, || {
+        // 5000 drives recursion past the 1000 cap. On the server's 8 MiB worker
         // stack this must produce a clean cap error, NOT a stack overflow.
         let (db, res) = run_countdown(5000);
-        let err = res.expect_err("recursion reaching the cap must error, not overflow");
+        let err = res.expect_err("recursion exceeding the cap must error, not overflow");
         assert_eq!(
             err.to_string(),
             "too many levels of trigger recursion",
@@ -183,17 +251,18 @@ fn server_runtime_stack_reaches_cap_cleanly_not_overflow() {
     });
 }
 
-/// In DEBUG builds, prove the server's 8 MiB worker stack clears the depth that
-/// overflows tokio's DEFAULT 2 MiB worker (~240 in release; the debug frame is
-/// larger, so we use a conservative 150 that exceeds the ~40-level debug/2 MiB
-/// cliff yet stays well within 8 MiB at ~50 KiB/level). Confirms the
-/// stack-size bump actually buys headroom over the un-fixed default.
+/// In DEBUG builds, prove on-demand stack growth clears the depth that overflows
+/// tokio's DEFAULT 2 MiB worker. The debug per-level frame is ~50 KiB, so 2 MiB
+/// overflows at ~40 levels without growth; here we drive depth 300 on a 2 MiB
+/// stack and require success — only possible because the executor grows the
+/// stack on demand (#5534). Confirms the growth, not merely the 8 MiB bump,
+/// provides headroom.
 #[cfg(debug_assertions)]
 #[test]
-fn server_runtime_stack_clears_default_2mib_cliff() {
-    on_stack("trigger-server-stack-debug", SERVER_WORKER_STACK_SIZE, || {
-        let (db, res) = run_countdown(150);
-        res.expect("depth-150 must succeed on the server's 8 MiB worker stack");
-        assert_eq!(count_rows(&db, "t2"), 151);
+fn ondemand_growth_clears_default_2mib_cliff_debug() {
+    on_stack("trigger-grow-debug", SMALL_FIXED_STACK, || {
+        let (db, res) = run_countdown(300);
+        res.expect("depth-300 must succeed on a 2 MiB stack via on-demand growth");
+        assert_eq!(count_rows(&db, "t2"), 301);
     });
 }


### PR DESCRIPTION
Closes #5534

## Summary
- Raise the native trigger recursion cap from the stack-safe **700** (#5533) to SQLite's full **`SQLITE_MAX_TRIGGER_DEPTH = 1000`** (verified against sqlite3 3.51.0: a ~1000-deep recursive-trigger chain errors with `too many levels of trigger recursion`).
- Make trigger recursion **stack-safe** so 1000 levels cannot overflow a fixed worker-thread stack (the reason 700 was the prior ceiling and the #5533 DoS guard).

## How it's made stack-safe (the load-bearing part)
Firing a trigger re-enters the full DML path (parse + plan + execute + fire) as native Rust recursion (~8.7 KiB/level release, ~50 KiB/level debug). A static 1000 would have **crashed** an 8 MiB thread at depth ~960 before the cap check fired.

This PR wraps the trigger-recursion entry point (`execute_trigger`) in `stacker::maybe_grow` (`grow_stack_for_trigger`): each level guarantees a 1 MiB free red zone before descending, allocating fresh heap-backed 8 MiB stack segments on demand. Reaching the cap is now a clean error on **any** thread size — never an overflow. `maybe_grow` is ~free when stack is plentiful, so the non-recursive common case is unaffected.

`stacker` has no wasm backend, so:
- the dependency is gated to `cfg(not(target_arch = "wasm32"))`,
- wasm keeps the proven stack-safe native cap of **700** (`grow_stack_for_trigger` is a transparent pass-through there).

## #5536 runtime-limit safety preserved
`effective_trigger_depth_limit` still clamps a connection's `sqlite3_limit(SQLITE_LIMIT_TRIGGER_DEPTH)` into `[1, MAX_TRIGGER_RECURSION_DEPTH]`. Raising the cap raises the runtime ceiling while keeping the lowering-only (downward) clamp safety.

## No-DoS-regression evidence
New/updated tests in `tests/trigger_recursion_stack.rs`:
- **`ondemand_growth_reaches_1000_cap_on_small_stack_no_overflow`** (release-only): drives recursion to the full 1000 cap on a deliberately **2 MiB** stack — too small to hold 1000 native frames (~8.5 MiB) — and asserts a clean cap error. This is impossible without on-demand growth, so it proves the DoS is fixed.
- **`ondemand_growth_clears_default_2mib_cliff_debug`** (debug): depth 300 on a 2 MiB stack (overflows at ~40 without growth) succeeds.
- `recursion_succeeds_at_full_1000_cap`: depth-1000 boundary succeeds (triggerC-3.3.x depth).
- `recursion_over_cap_errors_with_sqlite_wording_not_overflow`: over-cap errors with SQLite's exact wording and rolls back.
- `server_runtime_stack_reaches_cap_cleanly_not_overflow`: pinned to the server's real 8 MiB worker stack.

## Test plan
- [x] `cargo build -p vibesql-executor` and `-p vibesql-server`
- [x] `cargo test -p vibesql-executor --lib` → 2855 passed / 0 failed
- [x] `trigger_recursion_stack` 6/6 (release), 5/5 (debug); `trigger_depth_limit_tests` 3/3
- [x] Verified triggerC-3.3.x expectation (depth ~1000) against `/usr/bin/sqlite3` 3.51.0
- [ ] Follow-on: reach 1000 on wasm via an explicit heap work stack (Option B in #5534) if needed

Note: wasm full-build couldn't be exercised locally (pre-existing zstd-sys C-toolchain issue for `wasm32-unknown-unknown`, unrelated to this change); the wasm cfg gating is verified by inspection — the only `stacker::` call site is inside `#[cfg(not(target_arch = "wasm32"))]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)