### PR TITLE
fix(tcl): un-skip table.test (blanket table- skip removed; surfaces real CREATE TABLE gaps)

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3709,7 +3709,6 @@ variable vibesql_skip_patterns {
     {utf16align- "UTF16 alignment test - encoding differs"}
     {subquery- "Subquery handling differs"}
     {resolver01- "Name resolution handling differs"}
-    {table- "Table creation error messages differ"}
     {tableopts- "Table options differ"}
     {temptable- "Temp table tests require cross-test session state"}
     {temptable2- "Temp table tests require cross-test session state"}


### PR DESCRIPTION
## Summary

`table.test` reported **0 run / 96 skipped** under the native-TCL harness, giving zero conformance signal (#5612). Root cause was **not** an unsupported top-level TCL construct (as the issue hypothesized) but a single overly-broad entry in `vibesql_skip_patterns` in `scripts/tester_vibesql.tcl`:

```
{table- "Table creation error messages differ"}
```

`vibesql_should_skip` does `string match "table-*"` against every test name, so this blanket-skipped all 96 `table-N.M` tests. Removing the one line lets the file run.

**Result:** table.test goes from `0 run / 0 pass / 0 fail / 96 skip` to `87 run / 11 pass / 76 fail / 9 skip`.

## Why this is safe (shared-harness regression risk)

`scripts/tester_vibesql.tcl` is shared across all 1,174 conformance files, so I validated scope carefully:

- **Only table.test uses `table-` test names.** Verified with grep across all test files. `tableopts-`/`temptable-` do **not** match `table-*` (next char is `o`/... not `-`) and have their own separate skip entries, which are untouched.
- **16-file before/after sample, byte-identical except table.test:** select1, where, view, trigger1, trigger2, index, alter, tableopts, temptable, subquery, resolver01, collate1, rowid, types, unique2 — all unchanged. Plus an 11-file confirmatory sample (insert/update/delete/orderby1/minmax/index2/index3/fkey1/view/aggnested/conflict) ran normally.

## The 76 failures are genuine engine gaps, not harness artifacts

Filed as follow-ons (left visible per conformance-suite convention, not masked):
- **#5613** — `CREATE TABLE` allows a name already used by an INDEX, and the resulting schema becomes **unloadable** (`Failed to load database: ... there is already a table named test3`). This single bug cascades into ~74 of the 76 failures.
- **#5614** — reserved-name `sqlite_master` not rejected, duplicate column names accepted, quoted-identifier / duplicate-table error original-case echo (relates to #5553), `sql`-column whitespace echo.

The 11 passing tests (and the now-visible failures) restore the DDL / identifier-resolution coverage signal the issue asked for.

## Test plan
- [x] `tclsh scripts/tester_vibesql.tcl docs/reference/sqlite/test/table.test` → 87 run / 11 pass (was 0/0)
- [x] 16-file before/after regression sample: only table.test changed
- [x] No Rust changed (harness is TCL); no cargo build needed

Closes #5612

🤖 Generated with [Claude Code](https://claude.com/claude-code)