### PR TITLE
fix(persistence): preserve original-case identifier echo across dump/reload (#5618)

### DIFF
--- a/crates/vibesql-executor/src/persistence.rs
+++ b/crates/vibesql-executor/src/persistence.rs
@@ -335,4 +335,48 @@ CREATE TABLE data (id INTEGER);
         // Verify table exists (note: identifiers are uppercased)
         assert!(db.get_table("DATA").is_some());
     }
+
+    // Issue #5618: a dump → reload round-trip must preserve the *original*
+    // declared spelling that `sqlite_master.name` / `PRAGMA table_info` echo,
+    // even though lookups remain case-insensitive (#5553). Before the fix, the
+    // dump emitted the lowercase canonical catalog key, and a keyword name like
+    // `"create"` was written unquoted and re-lexed back to the keyword `CREATE`.
+    #[test]
+    fn test_dump_reload_preserves_original_case_and_quoted_keywords() {
+        let mut db = Database::new();
+        for sql in [
+            "CREATE TABLE \"create\" (f1 INT)",
+            "CREATE TABLE big (a, b)",
+            "CREATE TABLE \"MixedCase\" (\"ColA\" INT, \"B\" INT)",
+        ] {
+            let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+            if let vibesql_ast::Statement::CreateTable(s) = stmt {
+                CreateTableExecutor::execute(&s, &mut db).unwrap();
+            } else {
+                panic!("expected CreateTable for: {sql}");
+            }
+        }
+
+        let temp_file = NamedTempFile::new().unwrap();
+        db.save_sql_dump(temp_file.path()).unwrap();
+        let reloaded = load_sql_dump(temp_file.path().to_str().unwrap()).unwrap();
+
+        // Table name echo preserves the original spelling. Lookup is
+        // case-insensitive, so resolve via the canonical key, then assert the
+        // stored display name.
+        let create_tbl = reloaded.get_table("create").expect("quoted-keyword table must survive");
+        assert_eq!(
+            create_tbl.schema.name, "create",
+            "quoted keyword table name must round-trip verbatim (not folded to CREATE)"
+        );
+
+        let mixed = reloaded.get_table("mixedcase").expect("mixed-case table must survive");
+        assert_eq!(mixed.schema.name, "MixedCase", "mixed-case table name must be preserved");
+        // Column-name echo preserves original case too.
+        assert_eq!(mixed.schema.columns[0].name, "ColA");
+        assert_eq!(mixed.schema.columns[1].name, "B");
+
+        let big = reloaded.get_table("big").expect("table must survive");
+        assert_eq!(big.schema.name, "big");
+    }
 }

--- a/crates/vibesql-parser/src/lib.rs
+++ b/crates/vibesql-parser/src/lib.rs
@@ -39,6 +39,28 @@ pub use token::Token;
 pub use trigger_body::split_trigger_body_statements;
 use vibesql_ast::Statement;
 
+/// Returns `true` if `name` is a SQL keyword (case-insensitive).
+///
+/// Used by callers that emit SQL text (e.g. the persistence dump) to decide
+/// whether a bare identifier must be double-quoted to survive a round-trip. A
+/// keyword-named identifier such as `create` must be written as `"create"`;
+/// otherwise the reload re-lexes it as the keyword token and loses the original
+/// spelling/case (issue #5618).
+pub fn is_keyword(name: &str) -> bool {
+    // Re-lex the bare name: if it tokenizes to a single keyword token, the
+    // word is reserved/keyword and must be quoted to round-trip as an
+    // identifier. (A genuine identifier lexes to `Token::Identifier`.)
+    let mut lexer = Lexer::new(name);
+    match lexer.tokenize() {
+        Ok(tokens) => {
+            // tokenize() appends a trailing Eof token.
+            matches!(tokens.first(), Some(Token::Keyword { .. }))
+                && matches!(tokens.get(1), Some(Token::Eof) | None)
+        }
+        Err(_) => false,
+    }
+}
+
 /// Parse SQL using arena allocation where supported, falling back to standard parsing.
 ///
 /// This function provides optimized parsing by:
@@ -199,5 +221,28 @@ mod arena_fallback_tests {
         let sql = "SELECT row_number() OVER win2 FROM t1 WINDOW win AS (PARTITION BY z), win2 AS (win ORDER BY x)";
         let result = Parser::parse_sql(sql);
         assert!(result.is_ok(), "Window inheritance failed: {:?}", result.err());
+    }
+
+    #[test]
+    fn test_is_keyword() {
+        // Reserved/keyword words (case-insensitive) — these must be quoted to be
+        // used as identifiers, and a SQL emitter must quote them (issue #5618).
+        assert!(is_keyword("create"));
+        assert!(is_keyword("CREATE"));
+        assert!(is_keyword("Select"));
+        assert!(is_keyword("from"));
+        assert!(is_keyword("table"));
+
+        // Ordinary identifiers are not keywords.
+        assert!(!is_keyword("mixedcase"));
+        assert!(!is_keyword("MixedCase"));
+        assert!(!is_keyword("f1"));
+        assert!(!is_keyword("users"));
+        assert!(!is_keyword("col_a"));
+
+        // A multi-token / punctuated string is not a single keyword.
+        assert!(!is_keyword("create table"));
+        assert!(!is_keyword("a.b"));
+        assert!(!is_keyword(""));
     }
 }

--- a/crates/vibesql-storage/src/persistence/save.rs
+++ b/crates/vibesql-storage/src/persistence/save.rs
@@ -153,11 +153,19 @@ impl Database {
                     continue;
                 };
 
+                // Echo the table's *original* declared spelling, not the
+                // lowercase canonical catalog key. SQLite preserves the original
+                // case (including quoted reserved words like `"create"`) in
+                // sqlite_master, and the dump must round-trip that spelling so a
+                // reload reproduces the same `sqlite_master.name` (issue #5618).
+                // `table.schema.name` retains the verbatim name; `table_name`
+                // (from `schema.list_tables()`) is the case-folded key.
+                let original_name = &table.schema.name;
                 // For default schema, use unqualified name in output for cleaner SQL
                 let output_name = if schema_name == vibesql_catalog::DEFAULT_SCHEMA {
-                    table_name.clone()
+                    original_name.clone()
                 } else {
-                    qualified_name.clone()
+                    format!("{}.{}", schema_name, original_name)
                 };
                 // CREATE TABLE statement
                 let schema = &table.schema;
@@ -385,10 +393,12 @@ impl Database {
                     };
 
                     for (_idx, row) in table.scan_live() {
-                        write!(writer, "INSERT INTO {}{} VALUES (", &quoted_output_name, column_list)
-                            .map_err(|e| {
-                                StorageError::NotImplemented(format!("Write error: {}", e))
-                            })?;
+                        write!(
+                            writer,
+                            "INSERT INTO {}{} VALUES (",
+                            &quoted_output_name, column_list
+                        )
+                        .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
 
                         // Only include values for non-generated columns
                         let mut first = true;
@@ -495,9 +505,8 @@ impl Database {
             if let Some(catalog_meta) = self.catalog.find_index_by_name(&index_name) {
                 if let Some(where_expr) = catalog_meta.where_clause.as_deref() {
                     use vibesql_ast::pretty_print::ToSql;
-                    write!(writer, " WHERE {}", where_expr.to_sql()).map_err(|e| {
-                        StorageError::NotImplemented(format!("Write error: {}", e))
-                    })?;
+                    write!(writer, " WHERE {}", where_expr.to_sql())
+                        .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
                 }
             }
 
@@ -555,9 +564,7 @@ impl Database {
                             "-- Skipped trigger '{}' (no preserved SQL text)",
                             trigger_def.name
                         )
-                        .map_err(|e| {
-                            StorageError::NotImplemented(format!("Write error: {}", e))
-                        })?;
+                        .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
                     }
                 }
             }
@@ -594,7 +601,11 @@ fn quote_identifier(name: &str) -> String {
     // - is empty
     let needs_quoting = name.is_empty()
         || name.starts_with(|c: char| c.is_ascii_digit())
-        || !name.chars().all(|c| c.is_alphanumeric() || c == '_');
+        || !name.chars().all(|c| c.is_alphanumeric() || c == '_')
+        // A keyword-named identifier (e.g. `create`, `select`) must be quoted so
+        // a reload re-lexes it as an identifier rather than the keyword token,
+        // preserving the original spelling/case in sqlite_master (issue #5618).
+        || vibesql_parser::is_keyword(name);
 
     if needs_quoting {
         // Escape any embedded double-quotes by doubling them

--- a/crates/vibesql-storage/src/persistence/tests/sql_dump.rs
+++ b/crates/vibesql-storage/src/persistence/tests/sql_dump.rs
@@ -422,10 +422,7 @@ fn test_sql_dump_preserves_index_name_case() {
         content.contains("CREATE INDEX MyIdx ON"),
         "Index name case must be preserved (expected `MyIdx`). Got:\n{content}"
     );
-    assert!(
-        !content.contains("myidx"),
-        "Index name must not be lowercased. Got:\n{content}"
-    );
+    assert!(!content.contains("myidx"), "Index name must not be lowercased. Got:\n{content}");
     assert!(
         content.contains("\"x1 (b Asc, c Asc)\""),
         "Quoted index name must preserve original case. Got:\n{content}"
@@ -662,4 +659,71 @@ fn test_read_sql_dump_file_not_found() {
     let result = read_sql_dump("/tmp/nonexistent_file_xyz123.sql");
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("does not exist"));
+}
+
+// Issue #5618: the SQL dump must echo a table's *original* declared spelling
+// (not the lowercase canonical catalog key) so a reload reproduces the same
+// `sqlite_master.name`. A keyword-named identifier (e.g. `"create"`) must also
+// be double-quoted so the reload re-lexes it as an identifier rather than the
+// keyword token (which would otherwise come back uppercased as `CREATE`).
+#[test]
+fn test_sql_dump_preserves_quoted_keyword_table_name() {
+    use vibesql_ast::TableIdentifier;
+
+    let mut db = Database::new();
+    let schema = TableSchema::new(
+        "create".to_string(),
+        vec![ColumnSchema::new("f1".to_string(), DataType::Integer, true)],
+    );
+    // Quoted reserved word as a table name (CREATE TABLE "create" (f1 int)).
+    db.create_table_with_identifier(schema, TableIdentifier::new("create", true)).unwrap();
+
+    let path = "/tmp/test_dump_quoted_keyword.sql";
+    db.save_sql_dump(path).unwrap();
+    let content = std::fs::read_to_string(path).unwrap();
+    std::fs::remove_file(path).ok();
+
+    // The keyword name must be quoted with its original (lowercase) spelling.
+    assert!(
+        content.contains("CREATE TABLE \"create\" ("),
+        "dump should quote the keyword table name verbatim; got:\n{content}"
+    );
+    // It must NOT emit a bare `CREATE TABLE create (` which would re-lex as the
+    // CREATE keyword and round-trip to the wrong case.
+    assert!(
+        !content.contains("CREATE TABLE create ("),
+        "dump must not emit an unquoted keyword table name; got:\n{content}"
+    );
+}
+
+#[test]
+fn test_sql_dump_preserves_mixed_case_table_and_column_names() {
+    use vibesql_ast::TableIdentifier;
+
+    let mut db = Database::new();
+    let schema = TableSchema::new(
+        "MixedCase".to_string(),
+        vec![
+            ColumnSchema::new("ColA".to_string(), DataType::Integer, true),
+            ColumnSchema::new("B".to_string(), DataType::Integer, true),
+        ],
+    );
+    db.create_table_with_identifier(schema, TableIdentifier::new("MixedCase", true)).unwrap();
+
+    let path = "/tmp/test_dump_mixed_case.sql";
+    db.save_sql_dump(path).unwrap();
+    let content = std::fs::read_to_string(path).unwrap();
+    std::fs::remove_file(path).ok();
+
+    // Original case must be preserved for both table and column names.
+    assert!(
+        content.contains("CREATE TABLE MixedCase ("),
+        "dump should echo the original table case; got:\n{content}"
+    );
+    assert!(content.contains("ColA"), "dump should echo the original column case; got:\n{content}");
+    // It must NOT have been folded to the lowercase canonical key.
+    assert!(
+        !content.contains("CREATE TABLE mixedcase ("),
+        "dump must not fold the table name to lowercase; got:\n{content}"
+    );
 }


### PR DESCRIPTION
## Summary
- Fixes the quoted-identifier / mixed-case **original-case echo** gap from #5618. SQLite echoes a table's verbatim declared spelling in `sqlite_master.name` / `PRAGMA table_info` (e.g. `"create"` -> `create`, `"MixedCase"` -> `MixedCase`) while resolving case-insensitively (#5553). VibeSQL did this correctly **in memory**, but lost it on the SQL-dump round-trip (close + reopen).
- Root cause was entirely in the **SQL-dump persistence path**, not the lexer/in-memory path:
  1. The dump emitted the lowercase **canonical catalog key** instead of the table's original name -> `MixedCase` round-tripped as `mixedcase`.
  2. A keyword-named identifier was written **unquoted** (`CREATE TABLE create (...)`), so the reload re-lexed it as the `CREATE` keyword and echoed it back as `CREATE`.
- Fix: emit `table.schema.name` (the original spelling) and double-quote keyword identifiers via a new `vibesql_parser::is_keyword` helper, so a reload reproduces the same `sqlite_master.name`. Column-name echo was already correct (verified).

## sqlite3 3.51.0 reference behavior
```
sqlite> CREATE TABLE "create"(x);
sqlite> CREATE TABLE "MixedCase"("ColA" int, "B" int);
sqlite> SELECT name FROM sqlite_master;   -- create, MixedCase  (NOT CREATE / mixedcase)
sqlite> PRAGMA table_info("MixedCase");   -- ColA, B  (original column case)
```

## Changes
- `crates/vibesql-parser/src/lib.rs` — new public `is_keyword(name)` (re-lexes the bare name; true iff it tokenizes to a single keyword token).
- `crates/vibesql-storage/src/persistence/save.rs` — dump uses the original table name; `quote_identifier` now also quotes keyword names.
- Tests: parser (`is_keyword`), storage (`sql_dump`: quoted-keyword + mixed-case/column echo), executor (`persistence`: full dump -> reload round-trip).

## table.test before/after
The five target cases now pass: **table-1.10, table-3.2, table-3.3, table-3.4, table-3.5** (verified end-to-end through the conformance shim).

Note: the full `table.test` file still **times out** in the native-TCL harness on `table-4.x` (creates 100 tables with up to 100 columns each) — a pre-existing performance limitation on `main`, unrelated to this change. The remaining failures before `table-4.x` (table-1.1, 3.1, 2.1b/c, etc.) are pre-existing and about verbatim `sql`-column text / reserved sqlite_master name, also out of scope here.

## No-regression sample (identical before/after)
| file | passed | failed |
|------|--------|--------|
| select1 | 188 | 0 |
| where | 148 | 20 |
| view | 24 | 0 |
| trigger1 | 32 | 38 |
| trigger2 | 70 | 0 |
| index | 68 | 1 |
| alter | 36 | 64 |

Baseline (pre-change binary) produced the exact same numbers — no regressions.

## Test plan
- [x] `cargo test -p vibesql-parser -p vibesql-storage -p vibesql-executor` all pass
- [x] New regression tests at parser / storage / executor layers
- [x] table-1.10 / 3.2-3.5 pass via the TCL shim
- [x] No-regression sample matches baseline

## Follow-ons
- table-1.1 / 3.1: store and echo the **verbatim `sql` column** (SQLite keeps the exact original CREATE text; VibeSQL regenerates it with uppercased types). Separate from the `name` echo fixed here.
- `table.test` harness timeout on the bulk `table-4.x` table-creation section (CREATE TABLE throughput).

Closes #5618