### PR TITLE
fix(tcl-harness): cap O(n^2) in-transaction trial-check to unblock table.test

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -40,6 +40,20 @@ set ::total_changes 0
 set ::sql_batch {}
 set ::in_transaction 0
 
+# Maximum batch size for which we perform the per-statement in-transaction
+# "trial check" (see trial_check_in_transaction). The trial re-executes the
+# ENTIRE accumulated batch + the new statement + ROLLBACK on every statement
+# submitted inside a transaction, which is O(n^2) over the transaction length.
+# That is fine for the small transactions that actually need precise error
+# attribution (e.g. fkey6's BEGIN; UPDATE; ... COMMIT, 1-2 statements), but it
+# makes large stress transactions (e.g. table.test table-15: 2000 CREATE/DROP
+# statements inside one BEGIN/COMMIT) take O(n^2) time and blow past the
+# harness timeout. Once the batch exceeds this threshold we stop trial-checking
+# and simply accumulate; any error then surfaces at the eventual COMMIT/flush
+# (the pre-#5210 behavior), which is correct for these stress cases since they
+# do not assert per-statement error boundaries.
+set ::trial_check_max_batch 50
+
 # When an aborting RAISE (RAISE(ABORT) / RAISE(FAIL)) or an ordinary constraint
 # violation fires *inside* an open transaction, SQLite rolls back only the
 # offending statement and leaves the enclosing transaction OPEN (#5478). The
@@ -1181,6 +1195,18 @@ proc trial_check_in_transaction {new_sql} {
     #
     # Returns: a TCL error (via `error ...`) if the trial reports an error,
     # otherwise returns silently.
+    #
+    # PERFORMANCE GUARD: re-executing the whole accumulated batch on every
+    # statement is O(n^2) over the transaction length. For large transactions
+    # (well beyond anything that asserts per-statement error attribution) this
+    # dominates runtime and can exceed the harness timeout (table.test
+    # table-15: 2000 statements in one BEGIN/COMMIT). Once the batch is large,
+    # skip the trial and just accumulate; errors then surface at the eventual
+    # COMMIT/flush, which is the correct/expected behavior for such stress
+    # transactions. See $::trial_check_max_batch for the rationale.
+    if {[llength $::sql_batch] >= $::trial_check_max_batch} {
+        return
+    }
     set trial_stmts {}
     foreach stmt $::sql_batch {
         set s [string trimright $stmt]


### PR DESCRIPTION
## Summary
Closes #5620.

`table.test` timed out (>300s) in native-TCL mode on its large-schema stress sections. The root cause is the shim's `trial_check_in_transaction`, which re-executes the **entire accumulated SQL batch + the new statement + ROLLBACK on every statement** submitted inside a transaction (added in #5210 to attribute deferred FK errors to the right test boundary). That is O(n^2) over the transaction length, and `table-15` creates and then drops **2000 tables inside single `BEGIN`/`COMMIT` blocks** — roughly 2M re-executed statements across ever-growing CLI processes.

## Fix
Add a batch-size guard (`$::trial_check_max_batch = 50`). Once a transaction's accumulated batch exceeds the threshold, skip the trial and just accumulate; any error then surfaces at the eventual `COMMIT`/flush (the pre-#5210 behavior), which is correct for stress transactions that assert no per-statement error boundary. The threshold is far above the small transactions (1-2 statements) that actually need precise attribution.

Net change: +26 lines in `scripts/tester_vibesql.tcl` (one early-return guard + rationale comments). No engine changes.

## Measured impact
- `table.test`: **>300s timeout → ~52s**. Now reports a real count: 96 tests, 29 pass, 57 fail, 10 skip. `table-15.1`/`table-15.2` (the 2000-statement transactions, the actual bottleneck) now **pass**, and the file runs to completion through table-19.
- Micro-benchmark of 400 CREATEs inside one transaction: **12.3s → 0.75s**.

## No-regression evidence
Apples-to-apples base-vs-change via `tclsh <shim> <file>` (same binary). Identical pass/fail/skip on every file:

| file | base (P/F/S) | change (P/F/S) |
|------|------|------|
| select1 | 188/0/0 | 188/0/0 |
| where | 148/20/139 | 148/20/139 |
| view | 24/0/93 | 24/0/93 |
| trigger1 | 32/38/14 | 32/38/14 |
| trigger2 | 70/0/0 | 70/0/0 |
| index | 68/1/32 | 68/1/32 |
| alter | 36/64/17 | 36/64/17 |
| insert | 51/0/19 | 51/0/19 |
| update | 126/2/10 | 126/2/10 |
| fkey1 | 20/0/6 | 20/0/6 |
| fkey2 | 806/103/0 | 806/103/0 |
| **fkey6** (trial-check's origin) | 33/0/5 | 33/0/5 |

## Notes / scope
- `table-4.x` and other `table-N` correctness failures are pre-existing engine/CREATE-TABLE conformance gaps, out of scope here — this PR addresses only the harness timeout so the section produces a real pass/fail signal (the issue's acceptance criterion).

## Test plan
- [x] `make test-tcl-file FILE=table.test` completes within timeout
- [x] `table-15.1`/`table-15.2` pass
- [x] Broad no-regression sample (12 files) identical base vs change
- [x] fkey6 (the case the trial-check was added for) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)