### PR TITLE
Preserve verbatim CREATE TABLE text in sqlite_master.sql (table-1.1)

### DIFF
--- a/crates/vibesql-catalog/src/schema.rs
+++ b/crates/vibesql-catalog/src/schema.rs
@@ -76,6 +76,12 @@ impl Schema {
         self.tables.get(identifier.canonical())
     }
 
+    /// Mutable lookup of a table in this schema by name.
+    pub fn get_table_mut(&mut self, name: &str, case_sensitive: bool) -> Option<&mut TableSchema> {
+        let identifier = TableIdentifier::new(name, case_sensitive);
+        self.tables.get_mut(identifier.canonical())
+    }
+
     /// Drop a table from this schema using TableIdentifier for proper case handling.
     pub fn drop_table_by_identifier(
         &mut self,

--- a/crates/vibesql-catalog/src/store/mod.rs
+++ b/crates/vibesql-catalog/src/store/mod.rs
@@ -225,6 +225,28 @@ impl Catalog {
                 .map(|(_, schema)| schema)
         }
     }
+
+    /// Mutable counterpart to `get_schema_case_insensitive`.
+    pub(crate) fn get_schema_case_insensitive_mut(
+        &mut self,
+        schema_name: &str,
+    ) -> Option<&mut crate::Schema> {
+        let effective_schema_name = if schema_name.eq_ignore_ascii_case(crate::TEMP_SCHEMA) {
+            self.temp_schema_name.clone()
+        } else {
+            schema_name.to_string()
+        };
+
+        if self.case_sensitive_identifiers {
+            self.schemas.get_mut(&effective_schema_name)
+        } else {
+            let normalized_name = effective_schema_name.to_uppercase();
+            self.schemas
+                .iter_mut()
+                .find(|(key, _)| key.to_uppercase() == normalized_name)
+                .map(|(_, schema)| schema)
+        }
+    }
 }
 
 impl Default for Catalog {

--- a/crates/vibesql-catalog/src/store/tables.rs
+++ b/crates/vibesql-catalog/src/store/tables.rs
@@ -263,6 +263,44 @@ impl super::Catalog {
         }
     }
 
+    /// Discard the verbatim `CREATE TABLE` source text (`TableSchema::sql_source`)
+    /// stored on the catalog copy of `name`'s schema. Used after ALTER TABLE so
+    /// that `sqlite_master.sql` reflects the mutated schema via reconstruction
+    /// instead of stale original text. No-op when the table is not found. Mirrors
+    /// `get_table`'s name-resolution order (temp schema, then current schema).
+    /// See issue #5619.
+    pub fn invalidate_table_sql_source(&mut self, name: &str) {
+        let case_sensitive = self.case_sensitive_identifiers;
+
+        if let Some((schema_name, table_name)) = name.split_once('.') {
+            let normalized_table = self.normalize_identifier(table_name);
+            if let Some(schema) = self.get_schema_case_insensitive_mut(schema_name) {
+                if let Some(table) = schema.get_table_mut(&normalized_table, case_sensitive) {
+                    table.invalidate_sql_source();
+                }
+            }
+            return;
+        }
+
+        let normalized_table = self.normalize_identifier(name);
+
+        // Temp schema shadows the current schema (SQLite semantics).
+        let temp_schema_name = self.temp_schema_name.clone();
+        if let Some(temp_schema) = self.schemas.get_mut(&temp_schema_name) {
+            if let Some(table) = temp_schema.get_table_mut(&normalized_table, case_sensitive) {
+                table.invalidate_sql_source();
+                return;
+            }
+        }
+
+        let current_schema = self.current_schema.clone();
+        if let Some(schema) = self.schemas.get_mut(&current_schema) {
+            if let Some(table) = schema.get_table_mut(&normalized_table, case_sensitive) {
+                table.invalidate_sql_source();
+            }
+        }
+    }
+
     /// Drop a table schema (supports qualified names like "schema.table").
     /// Respects the `case_sensitive_identifiers` setting.
     ///

--- a/crates/vibesql-catalog/src/table.rs
+++ b/crates/vibesql-catalog/src/table.rs
@@ -38,6 +38,14 @@ pub struct TableSchema {
     /// `no such column: rowid` (SQLite semantics; `allow_rowid_in_view` is off by
     /// default). See issue #5492.
     pub is_view: bool,
+    /// Verbatim original `CREATE TABLE` source text, exactly as the user typed
+    /// it (whitespace and formatting preserved), with any trailing semicolon
+    /// stripped. SQLite stores the byte-for-byte original statement in
+    /// `sqlite_master.sql`; when this is `Some`, `sqlite_master` returns it
+    /// verbatim instead of a reconstruction from the parsed schema. `None` when
+    /// the source text is unavailable (e.g. schema built programmatically), in
+    /// which case callers fall back to reconstructing the SQL. See issue #5619.
+    pub sql_source: Option<String>,
 }
 
 impl TableSchema {
@@ -61,6 +69,7 @@ impl TableSchema {
             rowid_alias_column: None,
             without_rowid: false,
             is_view: false,
+            sql_source: None,
         }
     }
 
@@ -85,6 +94,7 @@ impl TableSchema {
             rowid_alias_column: None,
             without_rowid: false,
             is_view: false,
+            sql_source: None,
         }
     }
 
@@ -109,6 +119,7 @@ impl TableSchema {
             rowid_alias_column: None,
             without_rowid: false,
             is_view: false,
+            sql_source: None,
         }
     }
 
@@ -133,6 +144,7 @@ impl TableSchema {
             rowid_alias_column: None,
             without_rowid: false,
             is_view: false,
+            sql_source: None,
         }
     }
 
@@ -158,6 +170,7 @@ impl TableSchema {
             rowid_alias_column: None,
             without_rowid: false,
             is_view: false,
+            sql_source: None,
         }
     }
 
@@ -185,6 +198,7 @@ impl TableSchema {
             rowid_alias_column: None,
             without_rowid: false,
             is_view: false,
+            sql_source: None,
         }
     }
 
@@ -209,12 +223,35 @@ impl TableSchema {
             rowid_alias_column: None,
             without_rowid: false,
             is_view: false,
+            sql_source: None,
         }
     }
 
     /// Set the storage format for this table
     pub fn set_storage_format(&mut self, storage_format: StorageFormat) {
         self.storage_format = storage_format;
+    }
+
+    /// Set the verbatim original `CREATE TABLE` source text (see `sql_source`).
+    /// Any trailing semicolon and surrounding whitespace are stripped so the
+    /// stored text matches SQLite's `sqlite_master.sql` (which excludes the
+    /// terminating `;`). See issue #5619.
+    pub fn set_sql_source(&mut self, sql_source: impl Into<String>) {
+        let s = sql_source.into();
+        let trimmed = s.trim();
+        let trimmed = trimmed.strip_suffix(';').unwrap_or(trimmed).trim_end();
+        self.sql_source = Some(trimmed.to_string());
+    }
+
+    /// Discard any captured verbatim `CREATE TABLE` source text (see
+    /// `sql_source`). Must be called whenever the schema is structurally mutated
+    /// (e.g. by ALTER TABLE) so the stale original text is not re-emitted in
+    /// `sqlite_master.sql` or the SQL-dump persistence path — which would no
+    /// longer match the live schema and could even fail to reload (a renamed
+    /// table whose verbatim text still names the old table). After invalidation,
+    /// callers fall back to reconstructing the SQL. See issue #5619.
+    pub fn invalidate_sql_source(&mut self) {
+        self.sql_source = None;
     }
 
     /// Set the rowid alias column (for INTEGER PRIMARY KEY columns)

--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -214,7 +214,13 @@ impl SqlExecutor {
                 }
             }
             vibesql_ast::Statement::CreateTable(create_stmt) => {
-                match vibesql_executor::CreateTableExecutor::execute(&create_stmt, &mut self.db) {
+                // Pass the verbatim original statement text so sqlite_master.sql
+                // preserves the user's exact CREATE TABLE formatting (issue #5619).
+                match vibesql_executor::CreateTableExecutor::execute_with_source(
+                    &create_stmt,
+                    &mut self.db,
+                    Some(sql),
+                ) {
                     Ok(_) => {
                         result.row_count = 0; // DDL doesn't return rows
                     }

--- a/crates/vibesql-executor/src/alter/mod.rs
+++ b/crates/vibesql-executor/src/alter/mod.rs
@@ -64,6 +64,11 @@ impl AlterTableExecutor {
                     // since the cache key is based on table name
                     database.invalidate_columnar_cache(old_name);
                     database.invalidate_columnar_cache(new_name);
+                    // Discard the verbatim CREATE TABLE text carried over from the
+                    // pre-rename schema: it still names the old table, so emitting
+                    // it in sqlite_master.sql / the SQL dump would be wrong and
+                    // could break reload (issue #5619).
+                    invalidate_sql_source(database, new_name);
                 }
                 return result;
             }
@@ -83,8 +88,27 @@ impl AlterTableExecutor {
         // fresh data with the updated schema rather than stale cached data.
         if result.is_ok() {
             database.invalidate_columnar_cache(table_name);
+            // Any structural ALTER (add/drop/rename column, change type, add/drop
+            // constraint, ...) makes the captured verbatim CREATE TABLE text
+            // stale. Discard it so sqlite_master.sql and the SQL dump fall back
+            // to a reconstruction that matches the live schema (issue #5619).
+            invalidate_sql_source(database, table_name);
         }
 
         result
     }
+}
+
+/// Discard any preserved verbatim CREATE TABLE source text for `table_name`
+/// after a successful ALTER, so that sqlite_master.sql and SQL-dump persistence
+/// reflect the mutated schema instead of the original text. See issue #5619.
+///
+/// The schema is stored twice — once in the storage `Table` (read by the
+/// SQL-dump path) and once in the catalog (read by sqlite_master) — so both
+/// copies must be cleared.
+fn invalidate_sql_source(database: &mut Database, table_name: &str) {
+    if let Some(table) = database.get_table_mut(table_name) {
+        table.schema_mut().invalidate_sql_source();
+    }
+    database.catalog.invalidate_table_sql_source(table_name);
 }

--- a/crates/vibesql-executor/src/alter/table_options.rs
+++ b/crates/vibesql-executor/src/alter/table_options.rs
@@ -46,6 +46,12 @@ pub(super) fn execute_rename_table(
     // Clone the table and update its schema name
     let mut new_table = old_table.clone();
     new_table.schema_mut().name = stmt.new_table_name.clone();
+    // The cloned schema still carries the verbatim CREATE TABLE text captured
+    // for the *old* table name (issue #5619). Discard it here, before the schema
+    // is cloned into both the catalog and storage copies, so sqlite_master.sql
+    // and the SQL dump fall back to a reconstruction that names the renamed
+    // table instead of re-emitting stale text (which could break reload).
+    new_table.schema_mut().invalidate_sql_source();
 
     // Drop old table and create new one with the renamed schema
     // This handles indexes and spatial indexes via CASCADE

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -71,7 +71,30 @@ impl CreateTableExecutor {
         stmt: &CreateTableStmt,
         database: &mut Database,
     ) -> Result<String, ExecutorError> {
-        Self::execute_impl(stmt, database, false)
+        Self::execute_impl(stmt, database, false, None)
+    }
+
+    /// Execute a `CREATE TABLE` statement (user-facing path), recording the
+    /// verbatim original source text.
+    ///
+    /// SQLite stores the byte-for-byte original `CREATE TABLE` statement in
+    /// `sqlite_master.sql` (whitespace and formatting preserved). When
+    /// `sql_source` is `Some`, it is stamped onto the catalog `TableSchema` so
+    /// that `sqlite_master`/`sqlite_schema` returns it verbatim instead of a
+    /// reconstruction. The trailing semicolon (if any) is stripped by
+    /// `TableSchema::set_sql_source` to match SQLite. Pass `None` when the source
+    /// text is unavailable (e.g. AST built programmatically); callers then fall
+    /// back to reconstructing the SQL. See issue #5619.
+    ///
+    /// This is the UNTRUSTED path — it keeps the #5614 reserved-name and #5553
+    /// duplicate-column guards. For replaying a persisted dump use
+    /// [`execute_for_load_with_source`].
+    pub fn execute_with_source(
+        stmt: &CreateTableStmt,
+        database: &mut Database,
+        sql_source: Option<&str>,
+    ) -> Result<String, ExecutorError> {
+        Self::execute_impl(stmt, database, false, sql_source)
     }
 
     /// Execute a CREATE TABLE statement on a TRUSTED (engine-internal) path.
@@ -96,13 +119,30 @@ impl CreateTableExecutor {
         stmt: &CreateTableStmt,
         database: &mut Database,
     ) -> Result<String, ExecutorError> {
-        Self::execute_impl(stmt, database, true)
+        Self::execute_impl(stmt, database, true, None)
+    }
+
+    /// Trusted load path (see [`execute_for_load`]) that ALSO records the
+    /// verbatim original `CREATE TABLE` source text for `sqlite_master.sql`.
+    ///
+    /// This is the entry point used when reloading a persisted `.sql` dump: it
+    /// must bypass the user-facing guards (#5614/#5553) so a previously
+    /// persisted schema always round-trips, while still preserving the byte-for-
+    /// byte original source so `sqlite_master.sql` keeps the user's formatting
+    /// across a save/reload cycle (issue #5619).
+    pub fn execute_for_load_with_source(
+        stmt: &CreateTableStmt,
+        database: &mut Database,
+        sql_source: Option<&str>,
+    ) -> Result<String, ExecutorError> {
+        Self::execute_impl(stmt, database, true, sql_source)
     }
 
     fn execute_impl(
         stmt: &CreateTableStmt,
         database: &mut Database,
         trusted: bool,
+        sql_source: Option<&str>,
     ) -> Result<String, ExecutorError> {
         // Parse qualified table name (schema.table or just table)
         // For TEMP tables, use the session-specific temp schema (SQLite compatibility)
@@ -302,6 +342,13 @@ impl CreateTableExecutor {
 
         // Create TableSchema with unqualified name
         let mut table_schema = TableSchema::new(table_name.clone(), columns);
+
+        // Preserve the verbatim original CREATE TABLE text for sqlite_master.sql
+        // (SQLite stores it byte-for-byte; see issue #5619). The trailing
+        // semicolon is stripped by set_sql_source to match SQLite.
+        if let Some(src) = sql_source {
+            table_schema.set_sql_source(src);
+        }
 
         // Apply WITHOUT ROWID flag from AST (SQLite compatibility)
         table_schema.without_rowid = stmt.without_rowid;

--- a/crates/vibesql-executor/src/persistence.rs
+++ b/crates/vibesql-executor/src/persistence.rs
@@ -111,7 +111,17 @@ fn execute_statement_for_load(
             // ALTER TABLE RENAME gap) must still reload rather than brick the
             // database. User-issued CREATE TABLE still goes through
             // `CreateTableExecutor::execute`, which keeps the guards (issue #5614).
-            CreateTableExecutor::execute_for_load(&create_stmt, db)?;
+            //
+            // We use the trusted+verbatim variant so the reload ALSO preserves
+            // the byte-for-byte original CREATE TABLE text for sqlite_master.sql
+            // (issue #5619). The bypassed guards (#5614/#5553) and the verbatim
+            // source capture are complementary: a persisted dump must reload AND
+            // keep the user's original formatting after a save/reload cycle.
+            CreateTableExecutor::execute_for_load_with_source(
+                &create_stmt,
+                db,
+                Some(original_sql),
+            )?;
         }
         vibesql_ast::Statement::CreateIndex(index_stmt) => {
             CreateIndexExecutor::execute(&index_stmt, db)?;

--- a/crates/vibesql-executor/src/sqlite_schema.rs
+++ b/crates/vibesql-executor/src/sqlite_schema.rs
@@ -217,6 +217,16 @@ pub fn execute_sqlite_temp_schema_query(
 
 /// Generate CREATE TABLE SQL statement for a table
 fn generate_create_table_sql(table: &TableSchema) -> String {
+    // SQLite stores the original CREATE TABLE statement byte-verbatim in
+    // sqlite_master.sql (whitespace and formatting preserved). When we captured
+    // the original source text at CREATE time (issue #5619), return it as-is
+    // rather than reconstructing a normalized form from the parsed schema. We
+    // only reconstruct when the verbatim text is unavailable (e.g. schemas built
+    // programmatically, or after ALTER TABLE invalidated the stale source).
+    if let Some(ref src) = table.sql_source {
+        return src.clone();
+    }
+
     let mut sql = format!("CREATE TABLE {} (\n", table.name);
     let mut definitions: Vec<String> = Vec::new();
 

--- a/crates/vibesql-executor/tests/sqlite_schema_tests.rs
+++ b/crates/vibesql-executor/tests/sqlite_schema_tests.rs
@@ -9,7 +9,9 @@
 //! SELECT name FROM sqlite_master WHERE type = 'table';
 //! ```
 
-use vibesql_executor::{CreateIndexExecutor, CreateTableExecutor, SelectExecutor, ViewExecutor};
+use vibesql_executor::{
+    AlterTableExecutor, CreateIndexExecutor, CreateTableExecutor, SelectExecutor, ViewExecutor,
+};
 use vibesql_parser::Parser;
 use vibesql_storage::Database;
 
@@ -20,6 +22,31 @@ fn execute_create_table(db: &mut Database, sql: &str) {
         CreateTableExecutor::execute(&create_stmt, db).expect("Failed to execute CREATE TABLE");
     } else {
         panic!("Expected CREATE TABLE statement");
+    }
+}
+
+/// Helper to execute a CREATE TABLE statement while preserving the verbatim
+/// original source text (issue #5619), mirroring how the CLI/load paths call
+/// `execute_with_source`.
+fn execute_create_table_with_source(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("Failed to parse SQL");
+    if let vibesql_ast::Statement::CreateTable(create_stmt) = stmt {
+        CreateTableExecutor::execute_with_source(&create_stmt, db, Some(sql))
+            .expect("Failed to execute CREATE TABLE");
+    } else {
+        panic!("Expected CREATE TABLE statement");
+    }
+}
+
+/// Extract the single text value from a one-row, one-column query result.
+fn single_text(db: &Database, query: &str) -> String {
+    let (_columns, rows) = execute_select(db, query);
+    assert_eq!(rows.len(), 1, "expected exactly one row for query: {}", query);
+    match &rows[0].values[0] {
+        vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
+            s.to_string()
+        }
+        other => panic!("expected text sql value, got {:?}", other),
     }
 }
 
@@ -216,4 +243,88 @@ fn test_sqlite_schema_in_subquery() {
 
     assert_eq!(columns.len(), 1);
     assert!(!rows.is_empty());
+}
+
+/// Issue #5619 / table-1.1: SQLite stores the original CREATE TABLE statement
+/// byte-verbatim in sqlite_master.sql, preserving the user's exact whitespace
+/// and formatting. When the source text is captured at CREATE time, the engine
+/// must return it as-is rather than a normalized reconstruction.
+#[test]
+fn test_sqlite_master_sql_preserves_verbatim_whitespace() {
+    let mut db = Database::new();
+    // This is the exact statement from SQLite's table.test table-1.1, including
+    // the multi-line layout and leading indentation on the column definitions.
+    let create_sql = "CREATE TABLE test1 (\n      one varchar(10),\n      two text\n    )";
+    execute_create_table_with_source(&mut db, create_sql);
+
+    let stored = single_text(&db, "SELECT sql FROM sqlite_master WHERE type='table'");
+    assert_eq!(
+        stored, create_sql,
+        "sqlite_master.sql must preserve the verbatim CREATE TABLE text (issue #5619)"
+    );
+}
+
+/// A trailing semicolon on the original statement must not be stored: SQLite's
+/// sqlite_master.sql excludes the terminating `;`.
+#[test]
+fn test_sqlite_master_sql_strips_trailing_semicolon() {
+    let mut db = Database::new();
+    execute_create_table_with_source(&mut db, "CREATE TABLE   t  (  a   INT ,  b  TEXT ) ;");
+
+    let stored = single_text(&db, "SELECT sql FROM sqlite_master WHERE type='table'");
+    assert_eq!(stored, "CREATE TABLE   t  (  a   INT ,  b  TEXT )");
+}
+
+/// Issue #5619 (correctness guard): after ALTER TABLE mutates the schema, the
+/// previously-captured verbatim CREATE text is stale (it still names the old
+/// table / lacks the new column). It must be discarded so sqlite_master.sql
+/// reflects the live schema instead of the original source text — which would
+/// otherwise be wrong and could break SQL-dump reload.
+#[test]
+fn test_sqlite_master_sql_invalidated_after_alter_rename() {
+    let mut db = Database::new();
+    let create_sql = "CREATE TABLE oldname (\n      a INTEGER,\n      b TEXT\n    )";
+    execute_create_table_with_source(&mut db, create_sql);
+
+    // Sanity: verbatim text is returned before any ALTER.
+    let before = single_text(&db, "SELECT sql FROM sqlite_master WHERE type='table'");
+    assert_eq!(before, create_sql);
+
+    // Rename the table; this invalidates the stale verbatim source.
+    let stmt = Parser::parse_sql("ALTER TABLE oldname RENAME TO newname").expect("parse");
+    if let vibesql_ast::Statement::AlterTable(alter) = stmt {
+        AlterTableExecutor::execute(&alter, &mut db).expect("rename");
+    } else {
+        panic!("expected ALTER TABLE");
+    }
+
+    let after = single_text(&db, "SELECT sql FROM sqlite_master WHERE type='table'");
+    assert_ne!(after, create_sql, "stale verbatim text must not survive a rename");
+    assert!(
+        after.contains("newname"),
+        "reconstructed sql should name the renamed table, got: {}",
+        after
+    );
+    assert!(
+        !after.contains("oldname"),
+        "reconstructed sql must not reference the old table name, got: {}",
+        after
+    );
+}
+
+/// Without captured source text (e.g. AST built programmatically), the engine
+/// falls back to reconstructing a valid CREATE TABLE statement.
+#[test]
+fn test_sqlite_master_sql_reconstructs_without_source() {
+    let mut db = Database::new();
+    // execute_create_table uses the plain `execute` path (no source text).
+    execute_create_table(&mut db, "CREATE TABLE noverb (a INTEGER, b TEXT)");
+
+    let stored = single_text(&db, "SELECT sql FROM sqlite_master WHERE type='table'");
+    assert!(
+        stored.to_uppercase().starts_with("CREATE TABLE"),
+        "fallback reconstruction should still produce CREATE TABLE, got: {}",
+        stored
+    );
+    assert!(stored.contains("noverb"), "reconstruction should name the table, got: {}", stored);
 }

--- a/crates/vibesql-storage/src/persistence/binary/catalog.rs
+++ b/crates/vibesql-storage/src/persistence/binary/catalog.rs
@@ -103,6 +103,23 @@ pub fn write_catalog<W: Write>(writer: &mut W, db: &Database) -> Result<(), Stor
                 .map(|id| id.is_quoted())
                 .unwrap_or(false);
             write_bool(writer, quoted)?;
+
+            // Write the verbatim original CREATE TABLE text (v9+, issue #5619).
+            // SQLite stores the byte-for-byte source in sqlite_master.sql; the
+            // binary catalog must persist it so a cross-process reload (e.g. the
+            // TCL shim's per-batch CLI processes against a shared .vbsql file)
+            // returns the user's exact formatting rather than a reconstruction.
+            // Written last in the per-table record so v8-and-earlier readers,
+            // which stop after `quoted`, are unaffected.
+            match &table.schema.sql_source {
+                Some(src) => {
+                    write_bool(writer, true)?;
+                    write_string(writer, src)?;
+                }
+                None => {
+                    write_bool(writer, false)?;
+                }
+            }
         }
     }
 
@@ -395,16 +412,38 @@ pub fn read_catalog_v<R: Read>(reader: &mut R, version: u8) -> Result<Database, 
         // For older versions, default to unquoted (case-insensitive)
         let quoted = if version >= 4 { read_bool(reader)? } else { false };
 
-        table_schemas.push((table_name, columns, primary_key, quoted));
+        // Read the verbatim original CREATE TABLE text (v9+, issue #5619).
+        // v8-and-earlier files do not include this field, so absence means
+        // "no captured source" (None) and the schema falls back to a
+        // reconstructed CREATE TABLE for sqlite_master.sql.
+        let sql_source = if version >= 9 {
+            let has_source = read_bool(reader)?;
+            if has_source {
+                Some(read_string(reader)?)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        table_schemas.push((table_name, columns, primary_key, quoted, sql_source));
     }
 
     // Create tables
-    for (table_name, columns, primary_key, quoted) in table_schemas {
-        let schema = if let Some(pk_cols) = primary_key {
+    for (table_name, columns, primary_key, quoted, sql_source) in table_schemas {
+        let mut schema = if let Some(pk_cols) = primary_key {
             vibesql_catalog::TableSchema::with_primary_key(table_name.clone(), columns, pk_cols)
         } else {
             vibesql_catalog::TableSchema::new(table_name.clone(), columns)
         };
+
+        // Restore the verbatim CREATE TABLE source dropped by the TableSchema
+        // constructors above (issue #5619). set_sql_source strips the trailing
+        // semicolon to match SQLite.
+        if let Some(src) = sql_source {
+            schema.set_sql_source(src);
+        }
 
         // Use TableIdentifier to preserve case-sensitivity semantics
         let identifier = vibesql_catalog::TableIdentifier::from_canonical(table_name, quoted);
@@ -776,5 +815,97 @@ pub(super) fn parse_data_type(type_str: &str) -> Result<vibesql_types::DataType,
         // Null type
         "NULL" => Ok(DataType::Null),
         _ => Err(StorageError::NotImplemented(format!("Unsupported data type: {}", type_str))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::format::VERSION;
+    use super::{read_catalog_v, write_catalog};
+    use crate::Database;
+
+    /// Issue #5619: the verbatim original `CREATE TABLE` source text
+    /// (`TableSchema::sql_source`) must survive a binary catalog round-trip.
+    ///
+    /// This is the cross-process reload guarantee: the TCL shim spawns a fresh
+    /// CLI process per batch against a shared `.vbsql` file, so a CREATE in one
+    /// process is read back via `SELECT sql FROM sqlite_master` in another only
+    /// if the binary format persists `sql_source`. Before v9 the catalog
+    /// reconstructed each table via `TableSchema::new`, silently dropping the
+    /// field.
+    #[test]
+    fn test_binary_catalog_preserves_verbatim_sql_source() {
+        let mut db = Database::new();
+
+        // A deliberately multi-line, original-formatting CREATE TABLE.
+        let original_sql = "CREATE TABLE t1(\n  a INTEGER,\n  b TEXT\n)";
+
+        let mut schema = vibesql_catalog::TableSchema::new(
+            "t1".to_string(),
+            vec![
+                vibesql_catalog::ColumnSchema {
+                    name: "a".to_string(),
+                    data_type: vibesql_types::DataType::Integer,
+                    nullable: true,
+                    default_value: None,
+                    generated_expr: None,
+                    collation: None,
+                    is_exact_integer_type: true,
+                },
+                vibesql_catalog::ColumnSchema {
+                    name: "b".to_string(),
+                    data_type: vibesql_types::DataType::Varchar { max_length: None },
+                    nullable: true,
+                    default_value: None,
+                    generated_expr: None,
+                    collation: None,
+                    is_exact_integer_type: false,
+                },
+            ],
+        );
+        schema.set_sql_source(original_sql);
+        let identifier = vibesql_catalog::TableIdentifier::new("t1", false);
+        db.create_table_with_identifier(schema, identifier).unwrap();
+
+        // Round-trip the catalog through the binary encoder/decoder at the
+        // current version.
+        let mut buf = Vec::new();
+        write_catalog(&mut buf, &db).unwrap();
+        let reloaded = read_catalog_v(&mut &buf[..], VERSION).unwrap();
+
+        let table = reloaded.get_table("t1").expect("t1 must survive the round-trip");
+        assert_eq!(
+            table.schema.sql_source.as_deref(),
+            Some(original_sql),
+            "verbatim multi-line CREATE TABLE source must survive binary persistence (issue #5619)"
+        );
+    }
+
+    /// A table with no captured source must round-trip as `None` (the
+    /// reconstructed-SQL fallback path), not as an empty string or an error.
+    #[test]
+    fn test_binary_catalog_no_sql_source_round_trips_as_none() {
+        let mut db = Database::new();
+        let schema = vibesql_catalog::TableSchema::new(
+            "t2".to_string(),
+            vec![vibesql_catalog::ColumnSchema {
+                name: "x".to_string(),
+                data_type: vibesql_types::DataType::Integer,
+                nullable: true,
+                default_value: None,
+                generated_expr: None,
+                collation: None,
+                is_exact_integer_type: true,
+            }],
+        );
+        let identifier = vibesql_catalog::TableIdentifier::new("t2", false);
+        db.create_table_with_identifier(schema, identifier).unwrap();
+
+        let mut buf = Vec::new();
+        write_catalog(&mut buf, &db).unwrap();
+        let reloaded = read_catalog_v(&mut &buf[..], VERSION).unwrap();
+
+        let table = reloaded.get_table("t2").expect("t2 must survive the round-trip");
+        assert_eq!(table.schema.sql_source, None);
     }
 }

--- a/crates/vibesql-storage/src/persistence/binary/format.rs
+++ b/crates/vibesql-storage/src/persistence/binary/format.rs
@@ -27,7 +27,12 @@ pub const MAGIC: &[u8; 5] = b"VBSQL";
 /// - v8: Added partial-index WHERE clause persistence per index. v7 files
 ///       remain readable: the read path treats absent partial-index data as
 ///       "no WHERE clause" (full index). Issue #5181.
-pub const VERSION: u8 = 8;
+/// - v9: Added verbatim `TableSchema::sql_source` persistence per table (the
+///       byte-for-byte original `CREATE TABLE` text shown in
+///       `sqlite_master.sql`). v8 and earlier files remain readable: the read
+///       path treats the absent field as `sql_source = None`, falling back to
+///       the reconstructed CREATE TABLE text. Issue #5619.
+pub const VERSION: u8 = 9;
 
 /// Type tags for binary serialization
 #[repr(u8)]

--- a/crates/vibesql-storage/src/persistence/load.rs
+++ b/crates/vibesql-storage/src/persistence/load.rs
@@ -206,9 +206,16 @@ pub fn parse_sql_statements(content: &str) -> Result<Vec<String>, StorageError> 
             i += 1;
         }
 
-        // Add space between lines (preserves SQL readability)
+        // Re-insert the line break that `content.lines()` stripped, rather than
+        // collapsing it to a single space. The on-disk dump stores the verbatim
+        // multi-line `CREATE TABLE` text (issue #5619); the executor captures the
+        // statement string we return here as `sqlite_master.sql`, so flattening
+        // newlines to spaces would silently rewrite the user's formatting on a
+        // .sql reload. A newline is whitespace to the SQL parser, so statement
+        // splitting and re-parsing are unaffected. The `!in_string` guard
+        // matches the prior behavior (no separator injected mid-literal).
         if !in_string {
-            current_statement.push(' ');
+            current_statement.push('\n');
         }
     }
 

--- a/crates/vibesql-storage/src/persistence/save.rs
+++ b/crates/vibesql-storage/src/persistence/save.rs
@@ -170,6 +170,27 @@ impl Database {
                 // CREATE TABLE statement
                 let schema = &table.schema;
                 let quoted_output_name = quote_identifier(&output_name);
+
+                // Emit the verbatim original CREATE TABLE text when we captured
+                // it (issue #5619), so sqlite_master.sql keeps the user's exact
+                // formatting across a .vbsql save/reload round-trip. The verbatim
+                // text uses the unqualified, originally-spelled table name, so it
+                // is only valid for the default schema; tables in other schemas
+                // fall through to the qualified reconstruction below. The reload
+                // path re-stamps sql_source from this emitted text.
+                if schema_name == vibesql_catalog::DEFAULT_SCHEMA {
+                    if let Some(src) = schema.sql_source.as_deref() {
+                        writeln!(writer, "{};", src.trim_end_matches(';').trim_end()).map_err(
+                            |e| StorageError::NotImplemented(format!("Write error: {}", e)),
+                        )?;
+                        write_table_data(&mut writer, table, schema, &quoted_output_name)?;
+                        writeln!(writer).map_err(|e| {
+                            StorageError::NotImplemented(format!("Write error: {}", e))
+                        })?;
+                        continue;
+                    }
+                }
+
                 write!(writer, "CREATE TABLE {} (", &quoted_output_name)
                     .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
 
@@ -364,61 +385,11 @@ impl Database {
                 writeln!(writer, ";")
                     .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
 
-                // INSERT statements for data (only live/non-deleted rows)
-                // Using scan_live() to skip rows marked as deleted in the deletion bitmap.
-                // Note: We must skip generated columns - they cannot be inserted directly.
-                if table.row_count() > 0 {
-                    writeln!(writer)
-                        .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
-
-                    // Find indices of non-generated columns
-                    let non_generated_indices: Vec<usize> = schema
-                        .columns
-                        .iter()
-                        .enumerate()
-                        .filter(|(_, col)| col.generated_expr.is_none())
-                        .map(|(i, _)| i)
-                        .collect();
-
-                    // Build column list for INSERT if we have generated columns
-                    let has_generated_columns = non_generated_indices.len() < schema.columns.len();
-                    let column_list: String = if has_generated_columns {
-                        let col_names: Vec<&str> = non_generated_indices
-                            .iter()
-                            .map(|&i| schema.columns[i].name.as_str())
-                            .collect();
-                        format!(" ({})", col_names.join(", "))
-                    } else {
-                        String::new()
-                    };
-
-                    for (_idx, row) in table.scan_live() {
-                        write!(
-                            writer,
-                            "INSERT INTO {}{} VALUES (",
-                            &quoted_output_name, column_list
-                        )
-                        .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
-
-                        // Only include values for non-generated columns
-                        let mut first = true;
-                        for &col_idx in &non_generated_indices {
-                            if !first {
-                                write!(writer, ", ").map_err(|e| {
-                                    StorageError::NotImplemented(format!("Write error: {}", e))
-                                })?;
-                            }
-                            first = false;
-                            write!(writer, "{}", sql_value_to_literal(&row.values[col_idx]))
-                                .map_err(|e| {
-                                    StorageError::NotImplemented(format!("Write error: {}", e))
-                                })?;
-                        }
-                        writeln!(writer, ");").map_err(|e| {
-                            StorageError::NotImplemented(format!("Write error: {}", e))
-                        })?;
-                    }
-                }
+                // INSERT statements for data (only live/non-deleted rows).
+                // Shared with the verbatim-source path via write_table_data so
+                // both emit identical data (scan_live skips deleted rows and
+                // generated columns are excluded).
+                write_table_data(&mut writer, table, schema, &quoted_output_name)?;
 
                 writeln!(writer)
                     .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
@@ -590,6 +561,64 @@ impl Database {
 
         Ok(())
     }
+}
+
+/// Emit `INSERT INTO ...` statements for a table's live (non-deleted) rows.
+///
+/// Shared by the verbatim and reconstructed CREATE TABLE paths so that a table
+/// whose original source text is preserved (issue #5619) still dumps its data
+/// identically. Generated columns are skipped — they cannot be inserted
+/// directly — and only live rows (via `scan_live`) are written.
+fn write_table_data<W: Write>(
+    writer: &mut W,
+    table: &crate::Table,
+    schema: &vibesql_catalog::TableSchema,
+    quoted_output_name: &str,
+) -> Result<(), StorageError> {
+    if table.row_count() == 0 {
+        return Ok(());
+    }
+
+    writeln!(writer).map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
+
+    // Find indices of non-generated columns.
+    let non_generated_indices: Vec<usize> = schema
+        .columns
+        .iter()
+        .enumerate()
+        .filter(|(_, col)| col.generated_expr.is_none())
+        .map(|(i, _)| i)
+        .collect();
+
+    // Build column list for INSERT only when generated columns are present.
+    let has_generated_columns = non_generated_indices.len() < schema.columns.len();
+    let column_list: String = if has_generated_columns {
+        let col_names: Vec<&str> =
+            non_generated_indices.iter().map(|&i| schema.columns[i].name.as_str()).collect();
+        format!(" ({})", col_names.join(", "))
+    } else {
+        String::new()
+    };
+
+    for (_idx, row) in table.scan_live() {
+        write!(writer, "INSERT INTO {}{} VALUES (", quoted_output_name, column_list)
+            .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
+
+        let mut first = true;
+        for &col_idx in &non_generated_indices {
+            if !first {
+                write!(writer, ", ")
+                    .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
+            }
+            first = false;
+            write!(writer, "{}", sql_value_to_literal(&row.values[col_idx]))
+                .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
+        }
+        writeln!(writer, ");")
+            .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
+    }
+
+    Ok(())
 }
 
 /// Quote an identifier if it contains special characters or starts with a digit.

--- a/crates/vibesql-storage/src/persistence/tests/binary_persistence.rs
+++ b/crates/vibesql-storage/src/persistence/tests/binary_persistence.rs
@@ -48,6 +48,47 @@ fn test_quoted_table_identifier_roundtrip() {
     std::fs::remove_file(path).ok();
 }
 
+/// Issue #5619: the verbatim original `CREATE TABLE` source text must survive a
+/// full file-level `save_binary` → `load_binary` round-trip (header + catalog +
+/// data sections), not just the in-memory catalog encoder. This is the actual
+/// cross-process path: one process writes the `.vbsql` file, another opens it
+/// and answers `SELECT sql FROM sqlite_master`.
+#[test]
+fn test_binary_file_roundtrip_preserves_verbatim_sql_source() {
+    let mut db = Database::new();
+
+    let original_sql = "CREATE TABLE t1(\n  a INTEGER,\n  b TEXT\n)";
+    let mut schema = TableSchema::new(
+        "t1".to_string(),
+        vec![
+            ColumnSchema::new("a".to_string(), DataType::Integer, true),
+            ColumnSchema::new("b".to_string(), DataType::Varchar { max_length: None }, true),
+        ],
+    );
+    schema.set_sql_source(original_sql);
+    db.create_table_with_identifier(schema, TableIdentifier::new("t1", false)).unwrap();
+
+    // Insert a row so the data section is exercised alongside the catalog.
+    db.get_table_mut("t1")
+        .unwrap()
+        .insert(crate::Row::new(vec![SqlValue::Integer(1), SqlValue::Varchar("x".into())]))
+        .unwrap();
+
+    let path = "/tmp/test_sql_source_binary_roundtrip.vbsql";
+    db.save_binary(path).unwrap();
+
+    let loaded_db = Database::load_binary(path).unwrap();
+    let table = loaded_db.get_table("t1").expect("t1 must survive the binary file round-trip");
+    assert_eq!(
+        table.schema.sql_source.as_deref(),
+        Some(original_sql),
+        "verbatim multi-line CREATE TABLE source must survive a save_binary/load_binary cycle"
+    );
+    assert_eq!(table.row_count(), 1);
+
+    std::fs::remove_file(path).ok();
+}
+
 /// Test that unquoted tables remain unquoted through roundtrip
 #[test]
 fn test_unquoted_table_identifier_roundtrip() {
@@ -322,8 +363,6 @@ fn test_default_rows_carry_pre_mvcc_sentinel() {
 /// as a real v6 file would.
 #[test]
 fn test_v6_to_v7_read_compatibility_via_synthesized_v6_file() {
-    use std::io::Write;
-
     use crate::row::PRE_MVCC_TXN_ID;
 
     // 1) Build a v7 database with default-sentinel rows. We pick rows whose
@@ -369,7 +408,14 @@ fn test_v6_to_v7_read_compatibility_via_synthesized_v6_file() {
         // Patch version byte from 7 back to 6 to claim v6 format.
         v6_bytes[5] = 6;
 
-        // Catalog (unchanged between v6 and v7).
+        // Catalog: emitted by the current writer (latest catalog format). This
+        // test only synthesizes the v6 *data* layout (the per-row MVCC prefix is
+        // what differs at the v6/v7 boundary); the catalog section is read back
+        // at the current version below so that catalog fields added in later
+        // versions (e.g. v9 verbatim sql_source, #5619) stay byte-aligned. The
+        // header still claims v6 to document the synthetic data layout, but the
+        // sections are decoded with explicit per-section versions rather than a
+        // single header-derived version.
         crate::persistence::binary::catalog::write_catalog(&mut v6_bytes, &db).unwrap();
 
         // Data section, v6 layout: per-table {name, row_count, then for each
@@ -394,15 +440,22 @@ fn test_v6_to_v7_read_compatibility_via_synthesized_v6_file() {
         let _ = v7_bytes; // silence unused warning if logic above changes
     }
 
-    // 4) Write the synthetic v6 bytes to disk and load via the public API.
-    let v6_path = "/tmp/test_v6_compat_synthetic.vbsql";
-    {
-        let mut f = std::fs::File::create(v6_path).unwrap();
-        f.write_all(&v6_bytes).unwrap();
-        f.flush().unwrap();
-    }
+    // 4) Decode the synthetic file directly, reading the catalog at the current
+    //    version (it was written by the latest writer) and the data section at
+    //    v6 (the layout we synthesized: no per-row MVCC prefix). This mirrors
+    //    what `Database::load_binary` does, except it lets us mix the catalog
+    //    and data versions — necessary because the single header version byte
+    //    cannot express "latest catalog + v6 data".
+    let mut reader = &v6_bytes[..];
+    let header_version = crate::persistence::binary::read_header(&mut reader).unwrap();
+    assert_eq!(header_version, 6, "synthetic file claims v6 in its header");
+    let mut loaded_db = crate::persistence::binary::read_catalog_v(
+        &mut reader,
+        crate::persistence::binary::format::VERSION,
+    )
+    .unwrap();
+    crate::persistence::binary::read_data(&mut reader, &mut loaded_db, 6).unwrap();
 
-    let loaded_db = Database::load_binary(v6_path).unwrap();
     let loaded_table = loaded_db.get_table("v6compat").unwrap();
     assert_eq!(loaded_table.row_count(), 2);
 
@@ -424,8 +477,6 @@ fn test_v6_to_v7_read_compatibility_via_synthesized_v6_file() {
     }
     assert!(found.contains(&11));
     assert!(found.contains(&22));
-
-    std::fs::remove_file(v6_path).ok();
 }
 
 /// Sanity: confirm the public format constant has actually been bumped to v7.

--- a/crates/vibesql-storage/src/persistence/tests/sql_dump.rs
+++ b/crates/vibesql-storage/src/persistence/tests/sql_dump.rs
@@ -56,6 +56,38 @@ fn test_save_sql_dump() {
     std::fs::remove_file(path).ok();
 }
 
+/// Issue #5619: a TableSchema carrying verbatim CREATE TABLE source text must
+/// emit that text byte-for-byte in the SQL dump (instead of a normalized
+/// reconstruction), so the original whitespace survives a save/reload round-trip
+/// and sqlite_master.sql stays SQLite-compatible.
+#[test]
+fn test_sql_dump_emits_verbatim_create_source() {
+    let mut db = Database::new();
+
+    let mut schema = TableSchema::new(
+        "test1".to_string(),
+        vec![
+            ColumnSchema::new("one".to_string(), DataType::Varchar { max_length: Some(10) }, true),
+            ColumnSchema::new("two".to_string(), DataType::Varchar { max_length: None }, true),
+        ],
+    );
+    let verbatim = "CREATE TABLE test1 (\n      one varchar(10),\n      two text\n    )";
+    schema.set_sql_source(verbatim);
+    db.create_table(schema).unwrap();
+
+    let path = "/tmp/test_db_verbatim_5619.sql";
+    db.save_sql_dump(path).unwrap();
+
+    let content = std::fs::read_to_string(path).unwrap();
+    assert!(
+        content.contains(verbatim),
+        "dump should contain the verbatim CREATE TABLE text, got:\n{}",
+        content
+    );
+
+    std::fs::remove_file(path).ok();
+}
+
 #[test]
 fn test_sql_value_to_literal() {
     use crate::persistence::save::sql_value_to_literal;


### PR DESCRIPTION
Closes #5619

## Summary
Engine fix (confirmed engine-side, not a harness artifact). SQLite stores the original `CREATE TABLE` statement byte-verbatim in `sqlite_master.sql` (preserving the user's exact whitespace/formatting). VibeSQL re-serialized from the parsed AST via `generate_create_table_sql`, normalizing the text, so table-1.1 — which compares `SELECT sql FROM sqlite_master` against the original multi-line statement — failed.

Ground truth confirmed with `/usr/bin/sqlite3` 3.51.0: it stores the verbatim text (newlines and leading indentation intact), with the trailing `;` excluded.

## Approach
- New `TableSchema::sql_source: Option<String>` holds the verbatim original text (mirrors the existing CREATE VIEW/TRIGGER `sql_definition` pattern).
- `CreateTableExecutor::execute_with_source` captures the original statement text; wired into the CLI dispatch (interactive) and the SQL-dump load path. `execute` stays a thin wrapper passing `None`.
- `sqlite_master`/`sqlite_schema` returns `sql_source` verbatim when present, else reconstructs.
- The SQL-dump persistence path emits the verbatim text (default schema) and re-stamps it on reload, so the formatting survives a `.vbsql` save/reload round-trip. This is required because the TCL shim runs each SQL batch in a fresh process: the table is created in one process and read back in another after reloading from disk.

## Correctness guard (ALTER)
A naive verbatim cache is stale after `ALTER TABLE` (e.g. a renamed table whose verbatim text still names the old table would emit wrong `sqlite_master.sql` **and break SQL-dump reload**). The verbatim source is invalidated on any successful ALTER, on **both** schema copies (storage `Table` read by the dump, and the catalog read by `sqlite_master`), falling back to reconstruction. Without this guard the engine would have regressed (mid-file reload crash on `alter.test`); with it, `alter.test` actually runs further than `main` (which aborts mid-file for an unrelated reason).

## Results
- `table.test` table-1.x: **9 passed / 0 failed** (incl. table-1.1) via the real TCL shim. (The full `table.test` file times out under the runner's harness on both this branch and `main` — infrastructure, not correctness.)
- No regressions in a broad sample: `select1.test` 188/0, `insert.test` 51/0, `update.test` 126/2 (the 2 are pre-existing `no such column` error-message gaps, unchanged by this PR), `where.test` 148/20 (identical to `main`).
- `cargo test` green for vibesql-catalog, vibesql-storage, vibesql-executor (2884 lib + integration), vibesql-cli.

## Tests added
- `sqlite_schema_tests.rs`: verbatim whitespace preservation (table-1.1), trailing-semicolon stripping, ALTER-rename invalidation, no-source reconstruction fallback.
- `sql_dump.rs`: dump emits verbatim CREATE text.

## Notes / follow-ons
- `ALTER TABLE ADD/DROP COLUMN` does not sync the catalog schema copy (pre-existing on `main`: `sqlite_master.sql` already omitted added columns). This PR matches that existing behavior and does not address it.
- This branch's worktree forked from a pre-#5614 main snapshot, so `index-18.4` (reserved-name `sqlite_tr1`) shows as failing locally; that fix is already on current `main` and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)