### PR TITLE
fix(tcl-harness): frame raw rows with ASCII 30 so embedded newlines survive (#5630)

### DIFF
--- a/crates/vibesql-cli/src/formatter.rs
+++ b/crates/vibesql-cli/src/formatter.rs
@@ -196,14 +196,33 @@ impl ResultFormatter {
     }
 
     /// Print results in raw format for SQLite TCL test compatibility.
-    /// - ASCII 31 (Unit Separator) between values within each row
-    /// - One row per line
+    /// - ASCII 31 (Unit Separator, `\x1f`) between values within each row
+    /// - ASCII 30 (Record Separator, `\x1e`) terminating each row
     /// - NULL values output as empty strings
     /// - No headers, no borders, no row count
     ///
-    /// We use ASCII 31 instead of pipe because pipe can appear in SQL string values.
-    /// The TCL shim (scripts/tester_vibesql.tcl) expects this delimiter.
+    /// We use ASCII 31 between values (instead of pipe) because pipe can appear
+    /// in SQL string values. We terminate rows with ASCII 30 (instead of a plain
+    /// newline) because a single column VALUE may itself contain an embedded
+    /// newline (e.g. the verbatim multi-line `CREATE TABLE` text stored in
+    /// `sqlite_master.sql`). Using `\n` as the row terminator made such values
+    /// ambiguous with the row boundary, mis-splitting one row into several.
+    /// ASCII 30/31 are the canonical control characters for record/field
+    /// framing and cannot occur in ordinary SQL values, so embedded newlines are
+    /// preserved verbatim. The TCL shim (scripts/tester_vibesql.tcl,
+    /// `parse_raw_result`) splits on these same separators.
     fn print_raw(&self, result: &QueryResult) {
+        // Single write; no trailing newline. The harness frames rows on \x1e.
+        print!("{}", Self::format_raw(result));
+    }
+
+    /// Build the raw-format payload for `result` (see `print_raw`).
+    ///
+    /// Columns are joined with ASCII 31 (`\x1f`) and each row is terminated with
+    /// ASCII 30 (`\x1e`). Zero rows yields an empty string. Extracted as a pure
+    /// function so the exact framing can be unit-tested.
+    fn format_raw(result: &QueryResult) -> String {
+        let mut out = String::new();
         for row in &result.rows {
             let values: Vec<&str> = row
                 .iter()
@@ -213,8 +232,10 @@ impl ResultFormatter {
                     val.as_ref().map(|s| s.as_str()).unwrap_or("")
                 })
                 .collect();
-            println!("{}", values.join("\x1f"));
+            out.push_str(&values.join("\x1f"));
+            out.push('\x1e');
         }
+        out
     }
 }
 
@@ -343,5 +364,56 @@ mod tests {
 
         // Should handle empty results gracefully
         formatter.print_raw(&result);
+    }
+
+    #[test]
+    fn test_format_raw_framing() {
+        // Rows are terminated with \x1e (Record Separator) and columns are
+        // joined with \x1f (Unit Separator). Zero rows yields empty output.
+        let result = create_test_result();
+        assert_eq!(
+            ResultFormatter::format_raw(&result),
+            "1\x1fAlice\x1e2\x1fBob\x1e"
+        );
+
+        // NULL (None) renders as an empty string; a real "NULL" string stays.
+        let nulls = QueryResult {
+            columns: vec!["a".to_string(), "b".to_string()],
+            rows: vec![vec![None, Some("NULL".to_string())]],
+            row_count: 1,
+            execution_time_ms: None,
+            message: None,
+        };
+        assert_eq!(ResultFormatter::format_raw(&nulls), "\x1fNULL\x1e");
+
+        // Zero rows => empty string.
+        let empty = QueryResult {
+            columns: vec![],
+            rows: vec![],
+            row_count: 0,
+            execution_time_ms: None,
+            message: None,
+        };
+        assert_eq!(ResultFormatter::format_raw(&empty), "");
+    }
+
+    #[test]
+    fn test_format_raw_preserves_embedded_newline() {
+        // A single column value containing an embedded newline (e.g. the
+        // verbatim multi-line CREATE TABLE text from sqlite_master.sql) must be
+        // emitted verbatim, framed by a single trailing \x1e — NOT split into
+        // multiple rows. This is the bug fixed by issue #5630.
+        let multiline = "CREATE TABLE t(\n  a INT\n)";
+        let result = QueryResult {
+            columns: vec!["sql".to_string()],
+            rows: vec![vec![Some(multiline.to_string())]],
+            row_count: 1,
+            execution_time_ms: None,
+            message: None,
+        };
+        let out = ResultFormatter::format_raw(&result);
+        assert_eq!(out, format!("{}\x1e", multiline));
+        // Exactly one row terminator: the embedded \n did not create a boundary.
+        assert_eq!(out.matches('\x1e').count(), 1);
     }
 }

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -1778,59 +1778,70 @@ proc execsql {sql {db ""}} {
 }
 
 proc parse_raw_result {output} {
-    # Parse VibeSQL raw format output into TCL list
-    # Raw format uses ASCII 31 (Unit Separator) between values, one row per line
-    # We use ASCII 31 instead of pipe because pipe can appear in SQL values
-    # NULL values are already empty strings, string 'NULL' stays as "NULL"
-    # This matches SQLite TCL interface behavior for NULL representation
+    # Parse VibeSQL raw format output into TCL list.
+    #
+    # Raw format framing (see crates/vibesql-cli/src/formatter.rs print_raw):
+    #   - ASCII 31 (Unit Separator, \x1f) between values within a row
+    #   - ASCII 30 (Record Separator, \x1e) terminating each row
+    #
+    # We deliberately split ROWS on \x1e rather than on a plain newline: a
+    # single column VALUE may itself contain embedded newlines (e.g. the
+    # verbatim multi-line CREATE TABLE text returned by
+    # `SELECT sql FROM sqlite_master` after issue #5619/#5623). Splitting rows
+    # on \n mis-split such a value into several rows (issue #5630). ASCII 30/31
+    # are control characters that cannot appear in ordinary SQL values, so an
+    # embedded newline is preserved verbatim inside its column.
+    #
+    # NULL values are emitted as empty strings; the literal string 'NULL' stays
+    # as "NULL". This matches SQLite's TCL interface NULL representation.
     set data {}
 
-    # Special case: completely empty output means zero rows
-    # This must be checked BEFORE stripping the trailing newline
+    # Special case: completely empty output means zero rows.
+    # Check this BEFORE stripping the trailing record separator.
     if {$output eq ""} {
         return {}
     }
 
-    # Special case: single newline means one row with NULL value
-    # This is how VibeSQL outputs a single-column NULL result
-    # Check this BEFORE stripping the trailing newline
-    if {$output eq "\n"} {
+    # Special case: a single record separator means one row whose single column
+    # is NULL (VibeSQL emits an empty value followed by \x1e). Check this BEFORE
+    # stripping the trailing separator.
+    if {$output eq "\x1e"} {
         # Return null_string if set, otherwise empty string
         set null_rep [expr {[info exists ::null_string] && $::null_string ne "" ? $::null_string : ""}]
         return [list $null_rep]
     }
 
-    # Strip exactly one trailing newline if present.
-    # VibeSQL outputs each row followed by a newline, including the last row.
+    # Strip exactly one trailing record separator if present.
+    # VibeSQL terminates every row with \x1e, including the last row.
     # Without this, split would create an extra empty element at the end.
-    # Example: "abc\n" (one row) → split gives {"abc" ""} but we want {"abc"}
-    if {[string index $output end] eq "\n"} {
+    # Example: "abc\x1e" (one row) -> split gives {"abc" ""} but we want {"abc"}
+    if {[string index $output end] eq "\x1e"} {
         set output [string range $output 0 end-1]
     }
 
-    set lines [split $output "\n"]
+    set rows [split $output "\x1e"]
 
-    foreach line $lines {
-        # Skip error lines
-        if {[regexp {^Error} $line]} {
-            error [translate_error_to_sqlite $line]
+    foreach row $rows {
+        # Skip error lines. Errors are reported as plain text (not raw-framed),
+        # so they may still arrive newline-terminated; match the leading token.
+        if {[regexp {^Error} $row]} {
+            error [translate_error_to_sqlite $row]
         }
 
-        # Handle empty lines (represent rows where all values are NULL)
-        # For a single-column query with NULL, the line will be empty
-        if {$line eq ""} {
-            # Empty line = row with single NULL value
+        # Handle empty rows (represent a row whose single column is NULL).
+        # For a single-column query returning NULL, the row will be empty.
+        if {$row eq ""} {
+            # Empty row = row with single NULL value
             # Use null_string if set, otherwise empty string
             set null_rep [expr {[info exists ::null_string] && $::null_string ne "" ? $::null_string : ""}]
             lappend data $null_rep
             continue
         }
 
-        # Split by Unit Separator (ASCII 31) and add each value to the result
-        # VibeSQL uses ASCII 31 as delimiter because pipe can appear in SQL values
-        # Empty values represent NULL - use null_string if set
+        # Split by Unit Separator (ASCII 31) and add each value to the result.
+        # Empty values represent NULL - use null_string if set.
         set null_rep [expr {[info exists ::null_string] && $::null_string ne "" ? $::null_string : ""}]
-        foreach val [split $line "\x1f"] {
+        foreach val [split $row "\x1f"] {
             if {$val eq ""} {
                 lappend data $null_rep
             } else {


### PR DESCRIPTION
## Summary

The native-TCL conformance harness consumed the CLI's raw output format by joining columns on ASCII 31 (Unit Separator, `\x1f`) but splitting **rows** on a plain newline (`\n`). A single column VALUE that itself contains an embedded newline -- e.g. the verbatim multi-line `CREATE TABLE` text now returned by `SELECT sql FROM sqlite_master` after #5619 / #5623 -- was therefore mis-split into multiple rows. `table-1.1` (and any test asserting a multi-line single-column value) failed *through the harness* even though the engine output was byte-for-byte correct (proven independently in #5623).

This is a cross-cutting harness/CLI **contract** change, so both sides were updated consistently:

- **Emit side** -- `crates/vibesql-cli/src/formatter.rs` `print_raw`: each raw row is now terminated with ASCII 30 (Record Separator, `\x1e`) instead of a newline; columns remain joined with `\x1f`. The raw payload is extracted into a pure `format_raw()` helper so the framing is unit-testable.
- **Parse side** -- `scripts/tester_vibesql.tcl` `parse_raw_result`: rows are split on `\x1e` (with the trailing-separator and single-NULL-row special cases ported over verbatim). Columns are still split on `\x1f`.

ASCII 30/31 are the canonical record/field control characters and cannot occur in ordinary SQL values, so embedded newlines are now preserved verbatim inside their column.

`od -c` of the new raw output for a multi-line `CREATE TABLE` plus scalar rows:
```
C R E A T E   T A B L E   t 1 ( \n     a   i n t , \n     b   t e x t \n ) 036 1 036 2 036 3 036
```
(`036` = octal for `\x1e`; the embedded `\n`s no longer create row boundaries.)

## table-1.1 before / after (harness)

- Before (base = #5623): `table-1.1` red. `table.test` = 96 total, **44 passed**, 42 failed, 10 skipped.
- After: `table-1.1... ok`. `table.test` = 96 total, **46 passed**, 40 failed, 10 skipped.

Same total (96) and same skip count (10); +2 passes / -2 failures (`table-1.1` and one sibling multi-line assertion).

## Broad no-regression evidence (base vs change)

Because the raw protocol is shared by all 1,174 conformance files, a base-vs-change sample was run with identical test files; only the binary + shim differ. Counts are P / F / S.

| file | base | change |
|---|---|---|
| table | 44/42/10 | **46/40/10** |
| select1 | 188/0/0 | 188/0/0 |
| where | 148/20/139 | 148/20/139 |
| view | 24/0/93 | 24/0/93 |
| trigger1 | 32/38/14 | 32/38/14 |
| trigger2 | 70/0/0 | 70/0/0 |
| index | 69/0/32 | 69/0/32 |
| alter | 37/63/17 | 37/63/17 |
| insert | 51/0/19 | 51/0/19 |
| update | 126/2/10 | 126/2/10 |
| join | 174/3/1 | 174/3/1 |
| aggnested | 0/0/5 | 0/0/5 |
| minmax | 95/5/9 | 95/5/9 |

All files identical except the intended `table.test` improvement.

## Test plan
- [x] `cargo build --release -p vibesql-cli`
- [x] `cargo test -p vibesql-cli` (all pass, incl. new `test_format_raw_framing` and `test_format_raw_preserves_embedded_newline`)
- [x] `table.test` through the harness: `table-1.1... ok`
- [x] Base-vs-change regression sample (13 files): identical P/F/S except intended `table.test` gain

Closes #5630

🤖 Generated with [Claude Code](https://claude.com/claude-code)