### PR TITLE
Lock in transactional CREATE+DROP reload correctness (table-15) (#5624)

### DIFF
--- a/crates/vibesql-executor/src/persistence.rs
+++ b/crates/vibesql-executor/src/persistence.rs
@@ -269,6 +269,157 @@ CREATE INDEX idx_dept ON employees (dept Asc);
         assert!(db.get_index("IDX_DEPT").is_some());
     }
 
+    // Helper used by the issue #5624 regression tests: run one statement through
+    // the appropriate executor so a save_sql_dump round-trip can be exercised.
+    #[cfg(test)]
+    fn exec_one(db: &mut Database, sql: &str) {
+        use crate::{
+            index_ddl::IndexExecutor, BeginTransactionExecutor, CommitExecutor, DropTableExecutor,
+        };
+        let st = vibesql_parser::Parser::parse_sql(sql).unwrap();
+        match st {
+            vibesql_ast::Statement::CreateTable(s) => {
+                CreateTableExecutor::execute(&s, db).unwrap();
+            }
+            vibesql_ast::Statement::CreateIndex(s) => {
+                CreateIndexExecutor::execute(&s, db).unwrap();
+            }
+            vibesql_ast::Statement::DropIndex(s) => {
+                IndexExecutor::execute_drop(&s, db).unwrap();
+            }
+            vibesql_ast::Statement::DropTable(s) => {
+                DropTableExecutor::execute(&s, db).unwrap();
+            }
+            vibesql_ast::Statement::BeginTransaction(s) => {
+                BeginTransactionExecutor::execute(&s, db).unwrap();
+            }
+            vibesql_ast::Statement::Commit(s) => {
+                CommitExecutor::execute(&s, db).unwrap();
+            }
+            other => panic!("unexpected statement in test helper: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_transactional_bulk_create_drop_round_trips_cleanly() {
+        // Regression for issue #5624. table.test table-15.1/15.2 create and then
+        // drop ~2000 tables inside single BEGIN/COMMIT transactions. After such a
+        // transaction commits, the persisted dump must NOT contain any of the
+        // created-then-dropped tables — earlier engine states emitted a stale or
+        // duplicate CREATE for a table that had been dropped within the
+        // transaction, so the next reload aborted with
+        // `there is already a table named <name>` (or similar). The dropped
+        // tables must simply be absent, exactly like sqlite3.
+        let mut db = Database::new();
+
+        // BEGIN; CREATE TABLE tbl0..tblN; COMMIT  (mirrors table-15.1)
+        exec_one(&mut db, "BEGIN");
+        for i in 0..200 {
+            exec_one(&mut db, &format!("CREATE TABLE tbl{} (a, b, c)", i));
+        }
+        exec_one(&mut db, "COMMIT");
+
+        // BEGIN; DROP TABLE tbl0..tblN; COMMIT  (mirrors table-15.2)
+        exec_one(&mut db, "BEGIN");
+        for i in 0..200 {
+            exec_one(&mut db, &format!("DROP TABLE tbl{}", i));
+        }
+        exec_one(&mut db, "COMMIT");
+
+        // After the drop transaction commits, no tbl* tables remain.
+        assert!(db.list_tables().is_empty(), "all tables should be dropped: {:?}", db.list_tables());
+
+        // Save and reload via the engine's own replay path. The dump must reload
+        // cleanly — no duplicate / stale CREATE TABLE for a dropped table.
+        let temp_file = NamedTempFile::new().unwrap();
+        db.save_sql_dump(temp_file.path()).unwrap();
+        let reloaded = load_sql_dump(temp_file.path().to_str().unwrap())
+            .expect("dump of a committed bulk create+drop transaction must reload (issue #5624)");
+        assert!(
+            reloaded.list_tables().is_empty(),
+            "reloaded DB should have no tables, got: {:?}",
+            reloaded.list_tables()
+        );
+    }
+
+    #[test]
+    fn test_transactional_partial_drop_round_trips_cleanly() {
+        // A committed transaction that creates several tables but drops only some
+        // of them must persist exactly the survivors — neither a stale CREATE for
+        // a dropped table nor a missing CREATE for a kept one. Round-trips
+        // through the replay path. (Issue #5624.)
+        let mut db = Database::new();
+
+        exec_one(&mut db, "BEGIN");
+        for i in 0..10 {
+            exec_one(&mut db, &format!("CREATE TABLE t{} (a, b)", i));
+        }
+        // Drop the even-numbered tables within the same transaction.
+        for i in (0..10).step_by(2) {
+            exec_one(&mut db, &format!("DROP TABLE t{}", i));
+        }
+        exec_one(&mut db, "COMMIT");
+
+        let temp_file = NamedTempFile::new().unwrap();
+        db.save_sql_dump(temp_file.path()).unwrap();
+        let reloaded = load_sql_dump(temp_file.path().to_str().unwrap())
+            .expect("partial-drop transaction dump must reload (issue #5624)");
+
+        for i in 0..10 {
+            let exists = reloaded.get_table(&format!("t{}", i)).is_some();
+            if i % 2 == 0 {
+                assert!(!exists, "dropped table t{} must NOT survive reload", i);
+            } else {
+                assert!(exists, "kept table t{} must survive reload", i);
+            }
+        }
+    }
+
+    #[test]
+    fn test_table_replacing_dropped_index_round_trips_cleanly() {
+        // Regression for issue #5624, modeled on table.test lines ~120-142:
+        //   CREATE TABLE test2(one);
+        //   CREATE INDEX test3 ON test2(one);   -- `test3` is an INDEX
+        //   DROP INDEX test3;                    -- `test3` freed
+        //   CREATE TABLE test3(two);             -- `test3` is now a TABLE
+        // After DROP INDEX, the catalog must NOT retain a stale `test3` index.
+        // If it did, the dump would emit BOTH `CREATE TABLE test3` and
+        // `CREATE INDEX test3 ...`, and the reload would abort with
+        // `there is already a table named test3` when the CREATE INDEX replay
+        // hit the namespace-collision guard. Both objects (and only them) must
+        // round-trip.
+        let mut db = Database::new();
+        exec_one(&mut db, "CREATE TABLE test2(one text)");
+        exec_one(&mut db, "CREATE INDEX test3 ON test2(one)");
+        exec_one(&mut db, "DROP INDEX test3");
+        exec_one(&mut db, "CREATE TABLE test3(two text)");
+
+        // No residual `test3` index should remain after DROP INDEX + the
+        // same-named CREATE TABLE.
+        assert!(
+            db.catalog.list_all_indexes().iter().all(|idx| idx.name.to_lowercase() != "test3"),
+            "stale `test3` index must not survive DROP INDEX: {:?}",
+            db.catalog.list_all_indexes().iter().map(|i| i.name.clone()).collect::<Vec<_>>()
+        );
+
+        let temp_file = NamedTempFile::new().unwrap();
+        db.save_sql_dump(temp_file.path()).unwrap();
+        let dump = fs::read_to_string(temp_file.path()).unwrap();
+        // Defense-in-depth: the dump must not emit a CREATE INDEX for the freed
+        // name (which would collide with table test3 on reload).
+        assert!(
+            !dump.to_uppercase().contains("CREATE INDEX TEST3"),
+            "dump must not re-emit the dropped `test3` index:\n{}",
+            dump
+        );
+
+        let reloaded = load_sql_dump(temp_file.path().to_str().unwrap()).expect(
+            "table replacing a dropped same-named index must reload without collision (issue #5624)",
+        );
+        assert!(reloaded.get_table("test2").is_some(), "test2 must survive reload");
+        assert!(reloaded.get_table("test3").is_some(), "test3 (table) must survive reload");
+    }
+
     #[test]
     fn test_table_index_namespace_collision_round_trips_cleanly() {
         // Regression for issue #5613. Before the fix, CREATE TABLE accepted a


### PR DESCRIPTION
Closes #5624

## Summary

Issue #5624 reported that `table.test` table-15.1/15.2 fail on DB reload with
`there is already a table named test3` after creating and dropping ~2000 tables
inside single `BEGIN`/`COMMIT` transactions.

**The bug does not reproduce on the current `main`.** It was filed against an
earlier engine build; the recently-merged verbatim `sql_source` work
(#5619/#5623) and the persistence collision/reserved-name guards
(#5613/#5614/#5617) already fixed the underlying CREATE+DROP serialization.
Verified via native TCL: `table-15.1 ... ok`, `table-15.2 ... ok`, and **no**
`Failed to load database` / `already a table` / `already an index` error anywhere
in the `table.test` run.

Because the failure mode is a real persistence-correctness hazard, this PR adds
**regression tests** (no production code change) so it can never silently regress.

## Root cause (historical)

The TCL shim batches a `BEGIN ... COMMIT` block into one process and persists the
post-commit state as a `.vbsql` SQL dump, reloading it on the next statement via
`load_sql_dump` (the engine's own DDL replay). On an earlier engine, the dump
could emit a stale/duplicate `CREATE TABLE` for a table that was dropped inside
the transaction, or re-emit a `CREATE INDEX` for a name (`test3`) freed by
`DROP INDEX` and then re-used by a same-named `CREATE TABLE`. On replay the
`CREATE INDEX` hit the table/index namespace-collision guard
(`there is already a table named test3`) and aborted the load.

## Tests added (`crates/vibesql-executor/src/persistence.rs`)

- `test_transactional_bulk_create_drop_round_trips_cleanly` — BEGIN; create N
  tables; COMMIT; BEGIN; drop them all; COMMIT; save -> reload yields an empty
  schema (mirrors table-15.1/15.2).
- `test_transactional_partial_drop_round_trips_cleanly` — a committed transaction
  that drops only some created tables persists exactly the survivors.
- `test_table_replacing_dropped_index_round_trips_cleanly` — the exact table.test
  `test3` index/table sequence; asserts no stale `test3` index survives
  `DROP INDEX`, the dump does not re-emit `CREATE INDEX test3`, and the reload
  succeeds with only `test2` and table `test3`.

## Verification

- `table.test` (native TCL): table-15.1/15.2 **pass**; remaining failures
  (42) are pre-existing unrelated conformance gaps (datatype mismatch,
  unsupported DEFAULT functions, ATTACH, etc.) — none are reload duplicate-table
  errors.
- `cargo test -p vibesql-executor` (2903 ok), `-p vibesql-storage`,
  `-p vibesql-catalog` all pass.
- #5613/#5614/#5617 guards intact: their existing round-trip tests
  (`test_table_index_namespace_collision_round_trips_cleanly`,
  `test_dump_with_table_index_collision_is_rejected_on_load`,
  `test_load_dump_with_sqlite_prefixed_table_reloads_cleanly`,
  `test_user_create_sqlite_prefixed_table_still_rejected`) still pass — the
  collision check was **not** weakened.
- No-regression sample (native TCL): select1 188/188, insert 51/51,
  index 69/69, update 126/128 (the 2 update failures are pre-existing,
  not persistence-related).

## Follow-ons

- The other `table.test` conformance gaps (table-8 quoted identifiers,
  table-10 NOT NULL error column attribution, table-13 datatype mismatch,
  table-16 aggregate-in-DEFAULT) are independent and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)