### PR TITLE
fix(alter): sync catalog schema on ALTER + edit verbatim sql in place

### DIFF
--- a/crates/vibesql-catalog/src/store/tables.rs
+++ b/crates/vibesql-catalog/src/store/tables.rs
@@ -301,6 +301,52 @@ impl super::Catalog {
         }
     }
 
+    /// Overwrite the catalog copy of `name`'s schema with `new_schema`.
+    ///
+    /// VibeSQL stores a table's schema twice — once in the storage `Table`
+    /// (mutated directly by ALTER TABLE column operations) and once here in the
+    /// catalog (the copy read by `sqlite_master`, `PRAGMA table_info`, and
+    /// column resolution for DML). The two copies start out identical at CREATE
+    /// time, but ALTER ADD/DROP/RENAME/MODIFY COLUMN only edited the storage
+    /// copy, leaving the catalog stale. This pushes the freshly mutated storage
+    /// schema back into the catalog so both copies stay consistent (issue #5625).
+    ///
+    /// No-op when the table is not found. Mirrors `invalidate_table_sql_source`'s
+    /// name-resolution order (qualified schema, then temp schema, then current
+    /// schema). The lookup key (canonical, possibly case-folded name) is left
+    /// unchanged; only the stored `TableSchema` value is replaced.
+    pub fn replace_table_schema(&mut self, name: &str, new_schema: TableSchema) {
+        let case_sensitive = self.case_sensitive_identifiers;
+
+        if let Some((schema_name, table_name)) = name.split_once('.') {
+            let normalized_table = self.normalize_identifier(table_name);
+            if let Some(schema) = self.get_schema_case_insensitive_mut(schema_name) {
+                if let Some(table) = schema.get_table_mut(&normalized_table, case_sensitive) {
+                    *table = new_schema;
+                }
+            }
+            return;
+        }
+
+        let normalized_table = self.normalize_identifier(name);
+
+        // Temp schema shadows the current schema (SQLite semantics).
+        let temp_schema_name = self.temp_schema_name.clone();
+        if let Some(temp_schema) = self.schemas.get_mut(&temp_schema_name) {
+            if let Some(table) = temp_schema.get_table_mut(&normalized_table, case_sensitive) {
+                *table = new_schema;
+                return;
+            }
+        }
+
+        let current_schema = self.current_schema.clone();
+        if let Some(schema) = self.schemas.get_mut(&current_schema) {
+            if let Some(table) = schema.get_table_mut(&normalized_table, case_sensitive) {
+                *table = new_schema;
+            }
+        }
+    }
+
     /// Drop a table schema (supports qualified names like "schema.table").
     /// Respects the `case_sensitive_identifiers` setting.
     ///

--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -517,7 +517,14 @@ impl SqlExecutor {
                 }
             }
             vibesql_ast::Statement::AlterTable(alter_stmt) => {
-                match vibesql_executor::AlterTableExecutor::execute(&alter_stmt, &mut self.db) {
+                // Pass the verbatim original statement text so ADD COLUMN /
+                // RENAME edits the stored CREATE TABLE text in place (matching
+                // SQLite) instead of reconstructing it (issue #5625).
+                match vibesql_executor::AlterTableExecutor::execute_with_source(
+                    &alter_stmt,
+                    &mut self.db,
+                    Some(sql),
+                ) {
                     Ok(msg) => {
                         result.message = Some(msg);
                         result.row_count = 0; // DDL doesn't return rows

--- a/crates/vibesql-executor/src/alter/mod.rs
+++ b/crates/vibesql-executor/src/alter/mod.rs
@@ -14,10 +14,45 @@ use crate::{errors::ExecutorError, privilege_checker::PrivilegeChecker};
 pub struct AlterTableExecutor;
 
 impl AlterTableExecutor {
-    /// Execute an ALTER TABLE statement
+    /// Execute an ALTER TABLE statement.
+    ///
+    /// Convenience wrapper over [`execute_with_source`](Self::execute_with_source)
+    /// for callers that do not have the original statement text (e.g. an AST
+    /// built programmatically). Without the source text, ADD COLUMN falls back
+    /// to reconstructing `sqlite_master.sql` from the schema rather than editing
+    /// the verbatim text in place. See issue #5625.
     pub fn execute(
         stmt: &AlterTableStmt,
         database: &mut Database,
+    ) -> Result<String, ExecutorError> {
+        Self::execute_with_source(stmt, database, None)
+    }
+
+    /// Execute an ALTER TABLE statement, optionally given the verbatim original
+    /// statement text (`alter_sql`).
+    ///
+    /// After a successful structural ALTER, two pieces of bookkeeping run
+    /// (issue #5625):
+    ///
+    /// 1. **Catalog schema sync.** Column operations (ADD/DROP/RENAME/MODIFY)
+    ///    only mutate the *storage* `Table` copy of the schema. The *catalog*
+    ///    copy — read by `sqlite_master`, `PRAGMA table_info`, and DML column
+    ///    resolution — is then re-synced from the storage copy so both stay
+    ///    consistent. (RENAME TABLE syncs via drop+create and is exempt.)
+    ///
+    /// 2. **`sql_source` upkeep.** SQLite edits the verbatim `CREATE TABLE` text
+    ///    in `sqlite_master.sql` in place on ALTER rather than reconstructing it.
+    ///    For ADD COLUMN and RENAME COLUMN the stored verbatim text is edited to
+    ///    match SQLite (when `alter_sql` is available / the structure permits);
+    ///    for the remaining variants — including RENAME TO, deferred as a
+    ///    follow-on (see `table_options::execute_rename_table`) — the stale text
+    ///    is invalidated so it is reconstructed from the (now-synced) schema.
+    ///    Either way the stored text remains re-parseable on reload (issue
+    ///    #5619).
+    pub fn execute_with_source(
+        stmt: &AlterTableStmt,
+        database: &mut Database,
+        alter_sql: Option<&str>,
     ) -> Result<String, ExecutorError> {
         // Get table name from the statement and check ALTER privilege
         let table_name = match stmt {
@@ -58,17 +93,16 @@ impl AlterTableExecutor {
                 // For RENAME TABLE, invalidate both old and new table names
                 let old_name = &rename_table.table_name;
                 let new_name = &rename_table.new_table_name;
+                // `execute_rename_table` edits the verbatim CREATE TABLE text in
+                // place (rewriting the table name, quoting it like SQLite) and
+                // keeps the catalog + storage copies in sync via its drop+create,
+                // so no further bookkeeping is needed here.
                 let result = table_options::execute_rename_table(rename_table, database);
                 if result.is_ok() {
                     // Invalidate the database-level columnar cache for both table names
                     // since the cache key is based on table name
                     database.invalidate_columnar_cache(old_name);
                     database.invalidate_columnar_cache(new_name);
-                    // Discard the verbatim CREATE TABLE text carried over from the
-                    // pre-rename schema: it still names the old table, so emitting
-                    // it in sqlite_master.sql / the SQL dump would be wrong and
-                    // could break reload (issue #5619).
-                    invalidate_sql_source(database, new_name);
                 }
                 return result;
             }
@@ -88,27 +122,78 @@ impl AlterTableExecutor {
         // fresh data with the updated schema rather than stale cached data.
         if result.is_ok() {
             database.invalidate_columnar_cache(table_name);
-            // Any structural ALTER (add/drop/rename column, change type, add/drop
-            // constraint, ...) makes the captured verbatim CREATE TABLE text
-            // stale. Discard it so sqlite_master.sql and the SQL dump fall back
-            // to a reconstruction that matches the live schema (issue #5619).
-            invalidate_sql_source(database, table_name);
+
+            // Update the stored verbatim CREATE TABLE text: edit it in place for
+            // the variants SQLite edits in place (ADD COLUMN / RENAME COLUMN),
+            // otherwise invalidate so it is reconstructed (issue #5625).
+            update_sql_source_after_alter(database, table_name, stmt, alter_sql);
+
+            // Re-sync the catalog schema copy from the (mutated) storage copy.
+            // Column ALTERs only touched the storage `Table`; the catalog copy —
+            // read by sqlite_master / PRAGMA table_info / DML resolution — would
+            // otherwise stay stale (issue #5625).
+            sync_catalog_schema_from_storage(database, table_name);
         }
 
         result
     }
 }
 
-/// Discard any preserved verbatim CREATE TABLE source text for `table_name`
-/// after a successful ALTER, so that sqlite_master.sql and SQL-dump persistence
-/// reflect the mutated schema instead of the original text. See issue #5619.
+/// Copy the (just-mutated) storage `Table` schema for `table_name` into the
+/// catalog so both copies of the schema stay consistent after a column ALTER.
 ///
-/// The schema is stored twice — once in the storage `Table` (read by the
-/// SQL-dump path) and once in the catalog (read by sqlite_master) — so both
-/// copies must be cleared.
-fn invalidate_sql_source(database: &mut Database, table_name: &str) {
-    if let Some(table) = database.get_table_mut(table_name) {
-        table.schema_mut().invalidate_sql_source();
+/// VibeSQL keeps a table's schema in two places: the storage `Table` (mutated
+/// by the ALTER column executors) and the catalog `TableSchema` (read by
+/// `sqlite_master`, `PRAGMA table_info`, and column resolution for DML). They
+/// start identical at CREATE time; this restores that invariant after an ALTER.
+/// No-op if the storage table is missing. See issue #5625.
+fn sync_catalog_schema_from_storage(database: &mut Database, table_name: &str) {
+    let schema = match database.get_table(table_name) {
+        Some(table) => table.schema.clone(),
+        None => return,
+    };
+    database.catalog.replace_table_schema(table_name, schema);
+}
+
+/// Edit (or invalidate) the verbatim `CREATE TABLE` text on the storage `Table`
+/// schema for `table_name` after a successful column ALTER.
+///
+/// For ADD COLUMN and RENAME COLUMN — the cases SQLite edits in place — the
+/// stored text is edited to match SQLite (when the verbatim `alter_sql` is
+/// available / the structure permits). For every other variant, and whenever
+/// the in-place edit cannot be applied cleanly, the stale text is invalidated so
+/// `sqlite_master.sql` falls back to reconstruction from the synced schema. The
+/// result is always re-parseable on reload (issue #5619).
+fn update_sql_source_after_alter(
+    database: &mut Database,
+    table_name: &str,
+    stmt: &AlterTableStmt,
+    alter_sql: Option<&str>,
+) {
+    let Some(table) = database.get_table_mut(table_name) else {
+        return;
+    };
+    let Some(current) = table.schema.sql_source.clone() else {
+        // No verbatim text to edit; nothing to do (reconstruction is used).
+        return;
+    };
+
+    let edited: Option<String> = match stmt {
+        AlterTableStmt::AddColumn(_) => alter_sql
+            .and_then(crate::alter_rewrite::extract_add_column_text)
+            .and_then(|coldef| crate::alter_rewrite::append_column(&current, &coldef)),
+        AlterTableStmt::RenameColumn(rename) => crate::alter_rewrite::rename_column(
+            &current,
+            &rename.old_column_name,
+            &rename.new_column_name,
+        ),
+        // DROP COLUMN, ALTER/MODIFY/CHANGE COLUMN, ADD/DROP CONSTRAINT: SQLite's
+        // in-place editing for these is not yet matched; reconstruct instead.
+        _ => None,
+    };
+
+    match edited {
+        Some(text) => table.schema_mut().set_sql_source(text),
+        None => table.schema_mut().invalidate_sql_source(),
     }
-    database.catalog.invalidate_table_sql_source(table_name);
 }

--- a/crates/vibesql-executor/src/alter/table_options.rs
+++ b/crates/vibesql-executor/src/alter/table_options.rs
@@ -47,10 +47,18 @@ pub(super) fn execute_rename_table(
     let mut new_table = old_table.clone();
     new_table.schema_mut().name = stmt.new_table_name.clone();
     // The cloned schema still carries the verbatim CREATE TABLE text captured
-    // for the *old* table name (issue #5619). Discard it here, before the schema
-    // is cloned into both the catalog and storage copies, so sqlite_master.sql
-    // and the SQL dump fall back to a reconstruction that names the renamed
-    // table instead of re-emitting stale text (which could break reload).
+    // for the *old* table name (issue #5619). SQLite edits this text in place on
+    // RENAME TO (rewriting the name, quoting it), but matching that here is
+    // deferred (issue #5625, follow-on): the preserved verbatim text for a
+    // renamed table interacts badly with a pre-existing SQL-dump reload gap
+    // (the dump's statement splitter mishandles a `'` inside a `"…"`/`[…]`
+    // quoted identifier, so a renamed table whose original name contained such
+    // characters can corrupt the dump on reload). Reconstructing instead emits
+    // a clean, plainly-quoted name that always reloads. So discard the stale
+    // verbatim text on RENAME TO and fall back to reconstruction — the same
+    // proven-safe behavior as #5623. ADD COLUMN / RENAME COLUMN, which do not
+    // change the table name, *do* get in-place text edits (see
+    // `super::update_sql_source_after_alter`).
     new_table.schema_mut().invalidate_sql_source();
 
     // Drop old table and create new one with the renamed schema

--- a/crates/vibesql-executor/src/alter_rewrite.rs
+++ b/crates/vibesql-executor/src/alter_rewrite.rs
@@ -1,0 +1,397 @@
+//! In-place edits to the verbatim `CREATE TABLE` text stored in
+//! `TableSchema::sql_source`, applied on `ALTER TABLE`.
+//!
+//! SQLite does not reconstruct `sqlite_master.sql` from the parsed schema after
+//! an ALTER — it edits the *original* `CREATE TABLE` statement text in place,
+//! preserving the user's whitespace and formatting everywhere except the parts
+//! the ALTER touches (verified against sqlite3 3.51.0):
+//!
+//! - `ALTER TABLE t ADD COLUMN c INTEGER`
+//!   appends `, c INTEGER` immediately before the closing `)` of the column
+//!   list, leaving the rest of the text byte-for-byte unchanged.
+//! - `ALTER TABLE t RENAME TO t2`
+//!   rewrites the table name to the double-quoted new name (`"t2"`), preserving
+//!   everything else.
+//! - `ALTER TABLE t RENAME COLUMN b TO bb`
+//!   rewrites the column name in its definition position, preserving everything
+//!   else.
+//!
+//! This module implements those three in-place edits at the token level (using
+//! the parser's lexer for span tracking, the same approach as
+//! `crate::trigger_rename`). DROP COLUMN and the type/constraint-changing ALTER
+//! variants are deliberately out of scope here: they fall back to invalidating
+//! `sql_source` and reconstructing from the (now-synced) catalog schema, which
+//! is correct, just lower fidelity. See issue #5625.
+//!
+//! Every function returns `Option<String>`: `Some(edited)` only when the edit
+//! is unambiguous and the structure matches expectations; otherwise `None`, so
+//! the caller falls back to invalidate-and-reconstruct. The returned text is
+//! always still a valid `CREATE TABLE` statement (the edits only insert a
+//! comma-separated column def or swap one identifier), so it remains
+//! re-parseable on reload — the staleness-safety invariant from issue #5619.
+
+use vibesql_parser::{Keyword, Lexer, Span, Token};
+
+/// Tokenize `sql`, dropping the trailing `Eof`. Returns `None` if the text
+/// cannot be tokenized (it always should, since it round-tripped the parser).
+fn tokenize(sql: &str) -> Option<Vec<(Token, Span)>> {
+    let mut tokens = Lexer::new(sql).tokenize_with_spans().ok()?;
+    if matches!(tokens.last(), Some((Token::Eof, _))) {
+        tokens.pop();
+    }
+    Some(tokens)
+}
+
+/// Index of the `(` token that opens the column-definition list of a
+/// `CREATE TABLE` statement, and the matching closing `)`.
+///
+/// The opening paren is the first top-level `(` after the table name. Returns
+/// `None` if no balanced top-level paren pair is found (e.g. `CREATE TABLE t AS
+/// SELECT ...`, which has no column list to edit).
+fn column_list_parens(tokens: &[(Token, Span)]) -> Option<(usize, usize)> {
+    let open = tokens.iter().position(|(t, _)| matches!(t, Token::LParen))?;
+    let mut depth = 0usize;
+    for (i, (tok, _)) in tokens.iter().enumerate().skip(open) {
+        match tok {
+            Token::LParen => depth += 1,
+            Token::RParen => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some((open, i));
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Append a column definition to the verbatim `CREATE TABLE` text, matching
+/// SQLite's `ALTER TABLE ... ADD COLUMN`: insert `, <coldef>` immediately
+/// before the closing `)` of the column list, preserving all other formatting.
+///
+/// `coldef` is the verbatim column-definition text from the ALTER statement
+/// (e.g. `c INTEGER`, `d TEXT DEFAULT 'x'`). Returns `None` when the text has no
+/// editable column list (the caller then reconstructs instead).
+pub fn append_column(create_sql: &str, coldef: &str) -> Option<String> {
+    let coldef = coldef.trim();
+    if coldef.is_empty() {
+        return None;
+    }
+    let tokens = tokenize(create_sql)?;
+    let (_open, close) = column_list_parens(&tokens)?;
+    let insert_at = tokens[close].1.start;
+
+    let mut out = String::with_capacity(create_sql.len() + coldef.len() + 2);
+    out.push_str(&create_sql[..insert_at]);
+    out.push_str(", ");
+    out.push_str(coldef);
+    out.push_str(&create_sql[insert_at..]);
+    Some(out)
+}
+
+/// Whether `tok` is an identifier-like token whose text matches `name`
+/// (case-insensitively for bare identifiers; delimited identifiers are also
+/// matched case-insensitively, since SQLite folds the ALTER target name).
+fn ident_matches(tok: &Token, name: &str) -> bool {
+    match tok {
+        Token::Identifier(s) | Token::DelimitedIdentifier(s) => s.eq_ignore_ascii_case(name),
+        _ => false,
+    }
+}
+
+/// Rewrite the table name in the verbatim `CREATE TABLE` text to the
+/// double-quoted `new_name`, matching SQLite's `ALTER TABLE ... RENAME TO`
+/// (which quotes the new name and preserves all other formatting).
+///
+/// The table name is the first identifier token after
+/// `CREATE [TEMP|TEMPORARY] TABLE [IF NOT EXISTS]`. Returns `None` if it cannot
+/// be located.
+///
+/// NOTE: not yet wired into RENAME TO — that variant currently invalidates and
+/// reconstructs (issue #5625 follow-on) because the preserved verbatim text for
+/// a renamed table interacts with a pre-existing SQL-dump reload gap for quoted
+/// identifiers containing `'`. Retained (and unit-tested) so the follow-on can
+/// enable it once the dump/reload path handles such identifiers.
+#[allow(dead_code)]
+pub fn rename_table(create_sql: &str, new_name: &str) -> Option<String> {
+    let tokens = tokenize(create_sql)?;
+    let name_idx = table_name_index(&tokens)?;
+    let span = tokens[name_idx].1;
+    Some(replace_span(create_sql, span, &quote_ident(new_name)))
+}
+
+/// Index of the table-name identifier token in a `CREATE TABLE` statement.
+fn table_name_index(tokens: &[(Token, Span)]) -> Option<usize> {
+    let mut i = 0;
+    // CREATE
+    if !matches!(tokens.get(i), Some((Token::Keyword { keyword: Keyword::Create, .. }, _))) {
+        return None;
+    }
+    i += 1;
+    // optional TEMP / TEMPORARY
+    if matches!(
+        tokens.get(i),
+        Some((Token::Keyword { keyword: Keyword::Temp | Keyword::Temporary, .. }, _))
+    ) {
+        i += 1;
+    }
+    // TABLE
+    if !matches!(tokens.get(i), Some((Token::Keyword { keyword: Keyword::Table, .. }, _))) {
+        return None;
+    }
+    i += 1;
+    // optional IF NOT EXISTS
+    if matches!(tokens.get(i), Some((Token::Keyword { keyword: Keyword::If, .. }, _)))
+        && matches!(tokens.get(i + 1), Some((Token::Keyword { keyword: Keyword::Not, .. }, _)))
+        && matches!(tokens.get(i + 2), Some((Token::Keyword { keyword: Keyword::Exists, .. }, _)))
+    {
+        i += 3;
+    }
+    // table name (may be schema-qualified: skip `schema .`)
+    match tokens.get(i) {
+        Some((Token::Identifier(_) | Token::DelimitedIdentifier(_), _)) => {}
+        _ => return None,
+    }
+    if matches!(tokens.get(i + 1), Some((Token::Symbol('.'), _))) {
+        i += 2; // skip `schema .`, the real name follows
+        if !matches!(
+            tokens.get(i),
+            Some((Token::Identifier(_) | Token::DelimitedIdentifier(_), _))
+        ) {
+            return None;
+        }
+    }
+    Some(i)
+}
+
+/// Rewrite a column name in its *definition position* within the verbatim
+/// `CREATE TABLE` text, matching SQLite's `ALTER TABLE ... RENAME COLUMN`.
+///
+/// Only the identifier that names the column at the start of a column definition
+/// (the first token of the column list, or the first token after a top-level
+/// comma inside the column list) is rewritten — references elsewhere (e.g. in a
+/// table-level constraint) are conservatively left untouched. Returns `None`
+/// when the definition cannot be located unambiguously, so the caller falls back
+/// to reconstruction. `new_name` is emitted bare when it is a safe identifier,
+/// otherwise double-quoted.
+pub fn rename_column(create_sql: &str, old_col: &str, new_col: &str) -> Option<String> {
+    let tokens = tokenize(create_sql)?;
+    let (open, close) = column_list_parens(&tokens)?;
+
+    // Walk the column list at paren depth 1, tracking the start of each
+    // definition (top-level comma boundaries).
+    let mut depth = 0usize;
+    let mut at_def_start = false;
+    let mut target: Option<usize> = None;
+    for (i, (tok, _)) in tokens.iter().enumerate().take(close).skip(open) {
+        match tok {
+            Token::LParen => {
+                if depth == 1 {
+                    at_def_start = false;
+                }
+                depth += 1;
+                if depth == 1 {
+                    at_def_start = true; // first token inside the column list
+                }
+            }
+            Token::RParen => depth -= 1,
+            Token::Comma if depth == 1 => at_def_start = true,
+            _ if depth == 1 => {
+                if at_def_start {
+                    at_def_start = false;
+                    if ident_matches(tok, old_col) {
+                        if target.is_some() {
+                            // Two definitions match: ambiguous; bail.
+                            return None;
+                        }
+                        target = Some(i);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let idx = target?;
+    let span = tokens[idx].1;
+    let replacement = if is_safe_bare_identifier(new_col) {
+        new_col.to_string()
+    } else {
+        quote_ident(new_col)
+    };
+    Some(replace_span(create_sql, span, &replacement))
+}
+
+/// Extract the verbatim column-definition text from an
+/// `ALTER TABLE ... ADD [COLUMN] <coldef>` statement, so it can be appended to
+/// the stored `CREATE TABLE` text exactly as the user typed it (matching
+/// SQLite, which appends the original ALTER column text byte-for-byte).
+///
+/// Returns the substring from the first token after `ADD [COLUMN]` through the
+/// last non-`;` token, trimmed. Returns `None` if the `ADD` clause cannot be
+/// located.
+pub fn extract_add_column_text(alter_sql: &str) -> Option<String> {
+    let tokens = tokenize(alter_sql)?;
+    let add_pos =
+        tokens.iter().position(|(t, _)| matches!(t, Token::Keyword { keyword: Keyword::Add, .. }))?;
+    let mut start_tok = add_pos + 1;
+    // Optional COLUMN keyword.
+    if matches!(
+        tokens.get(start_tok),
+        Some((Token::Keyword { keyword: Keyword::Column, .. }, _))
+    ) {
+        start_tok += 1;
+    }
+    let first = tokens.get(start_tok)?;
+    let start = first.1.start;
+    // Find the end: last token that is not a trailing semicolon.
+    let mut end = first.1.end;
+    for (tok, span) in tokens.iter().skip(start_tok) {
+        if matches!(tok, Token::Semicolon) {
+            break;
+        }
+        end = span.end;
+    }
+    let text = alter_sql.get(start..end)?.trim();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text.to_string())
+    }
+}
+
+/// Replace the byte range `span` in `sql` with `replacement`.
+fn replace_span(sql: &str, span: Span, replacement: &str) -> String {
+    let mut out = String::with_capacity(sql.len() + replacement.len());
+    out.push_str(&sql[..span.start]);
+    out.push_str(replacement);
+    out.push_str(&sql[span.end..]);
+    out
+}
+
+/// Double-quote an identifier (SQLite escapes embedded `"` by doubling).
+fn quote_ident(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+/// Whether `name` can be emitted as a bare (unquoted) identifier: ASCII
+/// alphanumeric/underscore, not starting with a digit, and non-empty. Used so a
+/// plain column rename produces `bb` rather than `"bb"`.
+fn is_safe_bare_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c == '_' || c.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn append_column_matches_sqlite() {
+        let sql = "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  b   TEXT\n)";
+        let out = append_column(sql, "c INTEGER").unwrap();
+        assert_eq!(out, "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  b   TEXT\n, c INTEGER)");
+    }
+
+    #[test]
+    fn append_column_preserves_default_text() {
+        let sql = "CREATE TABLE t (a INTEGER)";
+        let out = append_column(sql, "d TEXT DEFAULT 'x'").unwrap();
+        assert_eq!(out, "CREATE TABLE t (a INTEGER, d TEXT DEFAULT 'x')");
+    }
+
+    #[test]
+    fn append_column_no_column_list_returns_none() {
+        // CREATE TABLE ... AS SELECT has no editable column list.
+        assert!(append_column("CREATE TABLE t AS SELECT 1", "c INTEGER").is_none());
+    }
+
+    #[test]
+    fn rename_table_quotes_new_name() {
+        let sql = "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  b   TEXT\n)";
+        let out = rename_table(sql, "t2").unwrap();
+        assert_eq!(out, "CREATE TABLE \"t2\" (\n  a   INTEGER PRIMARY KEY,\n  b   TEXT\n)");
+    }
+
+    #[test]
+    fn rename_table_handles_quoted_original() {
+        let sql = "CREATE TABLE \"My Table\" (x int)";
+        let out = rename_table(sql, "t3").unwrap();
+        assert_eq!(out, "CREATE TABLE \"t3\" (x int)");
+    }
+
+    #[test]
+    fn rename_table_if_not_exists() {
+        let sql = "CREATE TABLE IF NOT EXISTS t (x int)";
+        let out = rename_table(sql, "t2").unwrap();
+        assert_eq!(out, "CREATE TABLE IF NOT EXISTS \"t2\" (x int)");
+    }
+
+    #[test]
+    fn rename_column_in_definition_position() {
+        let sql = "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  b   TEXT\n)";
+        let out = rename_column(sql, "b", "bb").unwrap();
+        assert_eq!(out, "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  bb   TEXT\n)");
+    }
+
+    #[test]
+    fn rename_column_first_column() {
+        let sql = "CREATE TABLE t (a INTEGER, b TEXT)";
+        let out = rename_column(sql, "a", "aa").unwrap();
+        assert_eq!(out, "CREATE TABLE t (aa INTEGER, b TEXT)");
+    }
+
+    #[test]
+    fn rename_column_quotes_unsafe_name() {
+        let sql = "CREATE TABLE t (a INTEGER, b TEXT)";
+        let out = rename_column(sql, "b", "new col").unwrap();
+        assert_eq!(out, "CREATE TABLE t (a INTEGER, \"new col\" TEXT)");
+    }
+
+    #[test]
+    fn rename_column_missing_returns_none() {
+        let sql = "CREATE TABLE t (a INTEGER, b TEXT)";
+        assert!(rename_column(sql, "zzz", "qqq").is_none());
+    }
+
+    #[test]
+    fn extract_add_column_text_with_column_keyword() {
+        assert_eq!(
+            extract_add_column_text("ALTER TABLE t ADD COLUMN c INTEGER").as_deref(),
+            Some("c INTEGER")
+        );
+    }
+
+    #[test]
+    fn extract_add_column_text_without_column_keyword() {
+        assert_eq!(
+            extract_add_column_text("ALTER TABLE t ADD c INTEGER").as_deref(),
+            Some("c INTEGER")
+        );
+    }
+
+    #[test]
+    fn extract_add_column_text_preserves_default_and_strips_semicolon() {
+        assert_eq!(
+            extract_add_column_text("ALTER TABLE t ADD COLUMN d TEXT DEFAULT 'x';").as_deref(),
+            Some("d TEXT DEFAULT 'x'")
+        );
+    }
+
+    #[test]
+    fn append_then_extract_matches_sqlite_end_to_end() {
+        // ALTER TABLE t ADD COLUMN d TEXT DEFAULT 'x' on the post-ADD-c text.
+        let create = "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  b   TEXT\n, c INTEGER)";
+        let coldef = extract_add_column_text("ALTER TABLE t ADD COLUMN d TEXT DEFAULT 'x'").unwrap();
+        let out = append_column(create, &coldef).unwrap();
+        assert_eq!(
+            out,
+            "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  b   TEXT\n, c INTEGER, d TEXT DEFAULT 'x')"
+        );
+    }
+}

--- a/crates/vibesql-executor/src/lib.rs
+++ b/crates/vibesql-executor/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod advanced_objects;
 mod alter;
+mod alter_rewrite;
 pub mod arena;
 pub mod cache;
 mod compaction_guard;

--- a/crates/vibesql-executor/tests/sqlite_schema_tests.rs
+++ b/crates/vibesql-executor/tests/sqlite_schema_tests.rs
@@ -275,13 +275,14 @@ fn test_sqlite_master_sql_strips_trailing_semicolon() {
     assert_eq!(stored, "CREATE TABLE   t  (  a   INT ,  b  TEXT )");
 }
 
-/// Issue #5619 (correctness guard): after ALTER TABLE mutates the schema, the
-/// previously-captured verbatim CREATE text is stale (it still names the old
-/// table / lacks the new column). It must be discarded so sqlite_master.sql
-/// reflects the live schema instead of the original source text — which would
-/// otherwise be wrong and could break SQL-dump reload.
+/// Issue #5625: `ALTER TABLE ... RENAME TO` is deferred from in-place verbatim
+/// text editing (the preserved text interacts badly with a pre-existing SQL-dump
+/// reload gap for quoted identifiers containing `'`). It keeps the #5619
+/// behavior: the stale verbatim text is discarded and `sqlite_master.sql` is
+/// reconstructed, so the new name appears and the old one never survives, and
+/// the result stays re-parseable on reload.
 #[test]
-fn test_sqlite_master_sql_invalidated_after_alter_rename() {
+fn test_sqlite_master_sql_rename_table_reconstructs() {
     let mut db = Database::new();
     let create_sql = "CREATE TABLE oldname (\n      a INTEGER,\n      b TEXT\n    )";
     execute_create_table_with_source(&mut db, create_sql);
@@ -290,7 +291,6 @@ fn test_sqlite_master_sql_invalidated_after_alter_rename() {
     let before = single_text(&db, "SELECT sql FROM sqlite_master WHERE type='table'");
     assert_eq!(before, create_sql);
 
-    // Rename the table; this invalidates the stale verbatim source.
     let stmt = Parser::parse_sql("ALTER TABLE oldname RENAME TO newname").expect("parse");
     if let vibesql_ast::Statement::AlterTable(alter) = stmt {
         AlterTableExecutor::execute(&alter, &mut db).expect("rename");
@@ -310,6 +310,101 @@ fn test_sqlite_master_sql_invalidated_after_alter_rename() {
         "reconstructed sql must not reference the old table name, got: {}",
         after
     );
+}
+
+/// Issue #5625 part (1): after `ALTER TABLE ... ADD COLUMN`, the catalog schema
+/// copy — read by sqlite_master, PRAGMA table_info, and DML column resolution —
+/// must reflect the added column (previously only the storage copy was updated,
+/// leaving the catalog stale). And part (2): the verbatim CREATE TABLE text is
+/// edited in place (`, c INTEGER` appended) to match sqlite3 3.51.0.
+#[test]
+fn test_sqlite_master_sql_add_column_syncs_catalog_and_edits_text() {
+    let mut db = Database::new();
+    let create_sql = "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  b   TEXT\n)";
+    execute_create_table_with_source(&mut db, create_sql);
+
+    let stmt = Parser::parse_sql("ALTER TABLE t ADD COLUMN c INTEGER").expect("parse");
+    if let vibesql_ast::Statement::AlterTable(alter) = stmt {
+        AlterTableExecutor::execute_with_source(
+            &alter,
+            &mut db,
+            Some("ALTER TABLE t ADD COLUMN c INTEGER"),
+        )
+        .expect("add column");
+    } else {
+        panic!("expected ALTER TABLE");
+    }
+
+    // Part (2): verbatim text edited in place, exactly like sqlite3.
+    let sql = single_text(&db, "SELECT sql FROM sqlite_master WHERE type='table'");
+    assert_eq!(
+        sql, "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  b   TEXT\n, c INTEGER)",
+        "ADD COLUMN must append the verbatim column def before the closing paren (issue #5625)"
+    );
+
+    // Part (1): the catalog copy now lists the added column.
+    let catalog_schema = db.catalog.get_table("t").expect("catalog has table t");
+    let col_names: Vec<&str> = catalog_schema.columns.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(
+        col_names,
+        vec!["a", "b", "c"],
+        "catalog schema must include the added column after ADD COLUMN (issue #5625)"
+    );
+}
+
+/// Issue #5625 part (1): after `ALTER TABLE ... DROP COLUMN`, the catalog schema
+/// copy must drop the column too. The verbatim text is invalidated for DROP
+/// COLUMN (reconstruction is correct, just lower fidelity — see follow-on), so
+/// the reconstructed sql must reflect the dropped column.
+#[test]
+fn test_drop_column_syncs_catalog_schema() {
+    let mut db = Database::new();
+    execute_create_table_with_source(&mut db, "CREATE TABLE t (a INTEGER PRIMARY KEY, b TEXT, c INTEGER)");
+
+    let stmt = Parser::parse_sql("ALTER TABLE t DROP COLUMN c").expect("parse");
+    if let vibesql_ast::Statement::AlterTable(alter) = stmt {
+        AlterTableExecutor::execute(&alter, &mut db).expect("drop column");
+    } else {
+        panic!("expected ALTER TABLE");
+    }
+
+    let catalog_schema = db.catalog.get_table("t").expect("catalog has table t");
+    let col_names: Vec<&str> = catalog_schema.columns.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(
+        col_names,
+        vec!["a", "b"],
+        "catalog schema must drop the column after DROP COLUMN (issue #5625)"
+    );
+
+    let sql = single_text(&db, "SELECT sql FROM sqlite_master WHERE type='table'");
+    assert!(!sql.contains(" c "), "reconstructed sql must not mention dropped column c, got: {}", sql);
+}
+
+/// Issue #5625: `ALTER TABLE ... RENAME COLUMN` rewrites the column name in its
+/// definition position in the verbatim text (matching sqlite3) AND syncs the
+/// catalog so the renamed column resolves.
+#[test]
+fn test_rename_column_edits_text_and_syncs_catalog() {
+    let mut db = Database::new();
+    let create_sql = "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  b   TEXT\n)";
+    execute_create_table_with_source(&mut db, create_sql);
+
+    let stmt = Parser::parse_sql("ALTER TABLE t RENAME COLUMN b TO bb").expect("parse");
+    if let vibesql_ast::Statement::AlterTable(alter) = stmt {
+        AlterTableExecutor::execute(&alter, &mut db).expect("rename column");
+    } else {
+        panic!("expected ALTER TABLE");
+    }
+
+    let sql = single_text(&db, "SELECT sql FROM sqlite_master WHERE type='table'");
+    assert_eq!(
+        sql, "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  bb   TEXT\n)",
+        "RENAME COLUMN must rewrite the column name in place (issue #5625)"
+    );
+
+    let catalog_schema = db.catalog.get_table("t").expect("catalog has table t");
+    let col_names: Vec<&str> = catalog_schema.columns.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(col_names, vec!["a", "bb"], "catalog schema must reflect the renamed column");
 }
 
 /// Without captured source text (e.g. AST built programmatically), the engine


### PR DESCRIPTION
Closes #5625

## Summary

Two related fixes for `sqlite_master.sql` / schema state after `ALTER TABLE`:

- **Part (1) — catalog schema sync (correctness).** ALTER ADD/DROP/RENAME/MODIFY COLUMN only mutated the **storage** `Table` copy of the schema, leaving the **catalog** `TableSchema` copy stale. The catalog copy is what `sqlite_master`, `PRAGMA table_info`, and DML column resolution read, so an added column didn't appear there in-session (and `INSERT`/`SELECT` against it failed with "no such column") until a cross-process reload re-derived the schema from storage. Now the catalog is re-synced from the mutated storage copy after every successful column ALTER, via a new `Catalog::replace_table_schema`.

- **Part (2) — in-place verbatim text editing (fidelity).** SQLite edits the verbatim `CREATE TABLE` text in `sqlite_master.sql` in place on ALTER rather than reconstructing it. New `alter_rewrite` module does token-level edits (lexer span tracking, same approach as `trigger_rename`) so the echoed `sql` matches sqlite3 3.51.0 byte-for-byte for the common cases:
  - **ADD COLUMN** appends `, <verbatim coldef>` before the closing paren (`, c INTEGER`, `, d TEXT DEFAULT 'x'`).
  - **RENAME COLUMN** rewrites the column name in its definition position.
  - Falls back to invalidate-and-reconstruct whenever an edit can't be applied cleanly, so the stored text always stays re-parseable on reload (the #5619 staleness-safety invariant).

### Per-variant sqlite3 3.51.0 behavior (verified)
| Variant | sqlite_master.sql | table_info | This PR |
|---|---|---|---|
| ADD COLUMN | appends `, <coldef>` before `)` | shows new col | matched in place + catalog synced |
| RENAME COLUMN | rewrites name in def position | shows new name | matched in place + catalog synced |
| DROP COLUMN | removes the col def text | drops col | catalog synced; text **reconstructed** (follow-on) |
| RENAME TO | rewrites name (quoted) in place | unchanged cols | catalog synced (via drop+create); text **reconstructed** (follow-on) |

### Deferred (follow-on)
- **DROP COLUMN** and **RENAME TO** keep the #5623 invalidate-and-reconstruct behavior (still correct, just lower fidelity than sqlite3's in-place edit). RENAME TO is held back specifically because the preserved verbatim text for a renamed table exposes a pre-existing SQL-dump reload gap (the dump statement splitter mishandles a `'` inside a quoted identifier); reconstruction sidesteps it by emitting a plainly-quoted name. The `alter_rewrite::rename_table` helper is implemented + unit-tested and ready to wire up once that dump/reload gap is fixed.

## No-regression evidence
| Test | main (#5623) | this PR |
|---|---|---|
| alter.test | 37/100 | **40/100** (+3 = the catalog-sync fixes) |
| altertrig.test | 26/36 | 26/36 (trigger-body rewrite #5509/#5602 intact) |
| table.test | 44/86 | 44/86 (table-1.1 verbatim still passes) |

`cargo test -p vibesql-executor -p vibesql-catalog -p vibesql-storage` all green; new regression tests cover catalog sync + in-place editing for ADD COLUMN, DROP COLUMN, RENAME COLUMN, RENAME TO, plus `alter_rewrite` unit tests.

## Test plan
- [ ] CI: workspace build + `cargo test`
- [ ] `make test-tcl-file FILE=alter.test` / `altertrig.test` / `table.test`
- [ ] Manual: `ADD COLUMN` then `SELECT sql FROM sqlite_master` + `PRAGMA table_info` + `INSERT` using the new column, survives reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)