### PR TITLE
fix(alter): edit verbatim sqlite_master.sql in place for DROP COLUMN / RENAME TO

### DIFF
--- a/crates/vibesql-executor/src/alter/mod.rs
+++ b/crates/vibesql-executor/src/alter/mod.rs
@@ -42,13 +42,13 @@ impl AlterTableExecutor {
     ///
     /// 2. **`sql_source` upkeep.** SQLite edits the verbatim `CREATE TABLE` text
     ///    in `sqlite_master.sql` in place on ALTER rather than reconstructing it.
-    ///    For ADD COLUMN and RENAME COLUMN the stored verbatim text is edited to
-    ///    match SQLite (when `alter_sql` is available / the structure permits);
-    ///    for the remaining variants — including RENAME TO, deferred as a
-    ///    follow-on (see `table_options::execute_rename_table`) — the stale text
-    ///    is invalidated so it is reconstructed from the (now-synced) schema.
-    ///    Either way the stored text remains re-parseable on reload (issue
-    ///    #5619).
+    ///    For ADD COLUMN, RENAME COLUMN, DROP COLUMN, and RENAME TO the stored
+    ///    verbatim text is edited to match SQLite (when `alter_sql` is available
+    ///    / the structure permits; RENAME TO is handled in
+    ///    `table_options::execute_rename_table`). For the remaining variants, and
+    ///    whenever an in-place edit cannot apply cleanly, the stale text is
+    ///    invalidated so it is reconstructed from the (now-synced) schema. Either
+    ///    way the stored text remains re-parseable on reload (issue #5619).
     pub fn execute_with_source(
         stmt: &AlterTableStmt,
         database: &mut Database,
@@ -94,9 +94,10 @@ impl AlterTableExecutor {
                 let old_name = &rename_table.table_name;
                 let new_name = &rename_table.new_table_name;
                 // `execute_rename_table` edits the verbatim CREATE TABLE text in
-                // place (rewriting the table name, quoting it like SQLite) and
-                // keeps the catalog + storage copies in sync via its drop+create,
-                // so no further bookkeeping is needed here.
+                // place (rewriting the table name to the double-quoted new name,
+                // matching sqlite3) and keeps the catalog + storage copies in
+                // sync via its drop+create, so no further bookkeeping is needed
+                // here (issue #5634).
                 let result = table_options::execute_rename_table(rename_table, database);
                 if result.is_ok() {
                     // Invalidate the database-level columnar cache for both table names
@@ -158,12 +159,13 @@ fn sync_catalog_schema_from_storage(database: &mut Database, table_name: &str) {
 /// Edit (or invalidate) the verbatim `CREATE TABLE` text on the storage `Table`
 /// schema for `table_name` after a successful column ALTER.
 ///
-/// For ADD COLUMN and RENAME COLUMN — the cases SQLite edits in place — the
-/// stored text is edited to match SQLite (when the verbatim `alter_sql` is
-/// available / the structure permits). For every other variant, and whenever
-/// the in-place edit cannot be applied cleanly, the stale text is invalidated so
-/// `sqlite_master.sql` falls back to reconstruction from the synced schema. The
-/// result is always re-parseable on reload (issue #5619).
+/// For ADD COLUMN, RENAME COLUMN, and DROP COLUMN — the cases SQLite edits in
+/// place — the stored text is edited to match SQLite (when the verbatim
+/// `alter_sql` is available / the structure permits). (RENAME TO is edited in
+/// place separately, in `table_options::execute_rename_table`.) For every other
+/// variant, and whenever the in-place edit cannot be applied cleanly, the stale
+/// text is invalidated so `sqlite_master.sql` falls back to reconstruction from
+/// the synced schema. The result is always re-parseable on reload (issue #5619).
 fn update_sql_source_after_alter(
     database: &mut Database,
     table_name: &str,
@@ -187,8 +189,11 @@ fn update_sql_source_after_alter(
             &rename.old_column_name,
             &rename.new_column_name,
         ),
-        // DROP COLUMN, ALTER/MODIFY/CHANGE COLUMN, ADD/DROP CONSTRAINT: SQLite's
-        // in-place editing for these is not yet matched; reconstruct instead.
+        AlterTableStmt::DropColumn(drop) => {
+            crate::alter_rewrite::drop_column(&current, &drop.column_name)
+        }
+        // ALTER/MODIFY/CHANGE COLUMN, ADD/DROP CONSTRAINT: SQLite's in-place
+        // editing for these is not yet matched; reconstruct instead.
         _ => None,
     };
 

--- a/crates/vibesql-executor/src/alter/table_options.rs
+++ b/crates/vibesql-executor/src/alter/table_options.rs
@@ -48,18 +48,26 @@ pub(super) fn execute_rename_table(
     new_table.schema_mut().name = stmt.new_table_name.clone();
     // The cloned schema still carries the verbatim CREATE TABLE text captured
     // for the *old* table name (issue #5619). SQLite edits this text in place on
-    // RENAME TO (rewriting the name, quoting it), but matching that here is
-    // deferred (issue #5625, follow-on): the preserved verbatim text for a
-    // renamed table interacts badly with a pre-existing SQL-dump reload gap
-    // (the dump's statement splitter mishandles a `'` inside a `"…"`/`[…]`
-    // quoted identifier, so a renamed table whose original name contained such
-    // characters can corrupt the dump on reload). Reconstructing instead emits
-    // a clean, plainly-quoted name that always reloads. So discard the stale
-    // verbatim text on RENAME TO and fall back to reconstruction — the same
-    // proven-safe behavior as #5623. ADD COLUMN / RENAME COLUMN, which do not
-    // change the table name, *do* get in-place text edits (see
-    // `super::update_sql_source_after_alter`).
-    new_table.schema_mut().invalidate_sql_source();
+    // RENAME TO — rewriting the table name to the double-quoted new name and
+    // preserving all other formatting — rather than reconstructing it
+    // (issue #5634). Apply the same in-place edit here. The dump statement
+    // splitter is now quote-aware (a `'` inside the emitted `"new_name"`
+    // identifier no longer desyncs reload — see
+    // `vibesql_storage::persistence::load::parse_sql_statements`), so the
+    // preserved verbatim text round-trips through both the `.sql` and `.vbsql`
+    // formats. If the in-place edit cannot be applied cleanly, fall back to the
+    // proven-safe invalidate-and-reconstruct path (which emits a clean,
+    // plainly-quoted name) — preserving the re-parseable-on-reload invariant
+    // (issue #5619).
+    let renamed_sql = new_table
+        .schema
+        .sql_source
+        .as_deref()
+        .and_then(|sql| crate::alter_rewrite::rename_table(sql, &stmt.new_table_name));
+    match renamed_sql {
+        Some(text) => new_table.schema_mut().set_sql_source(text),
+        None => new_table.schema_mut().invalidate_sql_source(),
+    }
 
     // Drop old table and create new one with the renamed schema
     // This handles indexes and spatial indexes via CASCADE

--- a/crates/vibesql-executor/src/alter_rewrite.rs
+++ b/crates/vibesql-executor/src/alter_rewrite.rs
@@ -16,12 +16,18 @@
 //!   rewrites the column name in its definition position, preserving everything
 //!   else.
 //!
-//! This module implements those three in-place edits at the token level (using
-//! the parser's lexer for span tracking, the same approach as
-//! `crate::trigger_rename`). DROP COLUMN and the type/constraint-changing ALTER
-//! variants are deliberately out of scope here: they fall back to invalidating
-//! `sql_source` and reconstructing from the (now-synced) catalog schema, which
-//! is correct, just lower fidelity. See issue #5625.
+//! - `ALTER TABLE t DROP COLUMN c`
+//!   removes the column's definition span (the dropped column's name through the
+//!   start of the next column's name, or — for the last column — from the
+//!   preceding comma to the end of the column list), preserving everything else.
+//!
+//! This module implements those in-place edits at the token level (using the
+//! parser's lexer for span tracking, the same approach as
+//! `crate::trigger_rename`). The type/constraint-changing ALTER variants
+//! (ALTER/MODIFY/CHANGE COLUMN, ADD/DROP CONSTRAINT) remain out of scope here:
+//! they fall back to invalidating `sql_source` and reconstructing from the
+//! (now-synced) catalog schema, which is correct, just lower fidelity. See
+//! issues #5625 and #5634.
 //!
 //! Every function returns `Option<String>`: `Some(edited)` only when the edit
 //! is unambiguous and the structure matches expectations; otherwise `None`, so
@@ -108,12 +114,9 @@ fn ident_matches(tok: &Token, name: &str) -> bool {
 /// `CREATE [TEMP|TEMPORARY] TABLE [IF NOT EXISTS]`. Returns `None` if it cannot
 /// be located.
 ///
-/// NOTE: not yet wired into RENAME TO — that variant currently invalidates and
-/// reconstructs (issue #5625 follow-on) because the preserved verbatim text for
-/// a renamed table interacts with a pre-existing SQL-dump reload gap for quoted
-/// identifiers containing `'`. Retained (and unit-tested) so the follow-on can
-/// enable it once the dump/reload path handles such identifiers.
-#[allow(dead_code)]
+/// Wired into RENAME TO via `super::alter::table_options::execute_rename_table`
+/// (issue #5634). The dump statement splitter is quote-aware, so the emitted
+/// `"new_name"` identifier round-trips through `.sql` / `.vbsql` reloads.
 pub fn rename_table(create_sql: &str, new_name: &str) -> Option<String> {
     let tokens = tokenize(create_sql)?;
     let name_idx = table_name_index(&tokens)?;
@@ -155,10 +158,8 @@ fn table_name_index(tokens: &[(Token, Span)]) -> Option<usize> {
     }
     if matches!(tokens.get(i + 1), Some((Token::Symbol('.'), _))) {
         i += 2; // skip `schema .`, the real name follows
-        if !matches!(
-            tokens.get(i),
-            Some((Token::Identifier(_) | Token::DelimitedIdentifier(_), _))
-        ) {
+        if !matches!(tokens.get(i), Some((Token::Identifier(_) | Token::DelimitedIdentifier(_), _)))
+        {
             return None;
         }
     }
@@ -215,12 +216,141 @@ pub fn rename_column(create_sql: &str, old_col: &str, new_col: &str) -> Option<S
 
     let idx = target?;
     let span = tokens[idx].1;
-    let replacement = if is_safe_bare_identifier(new_col) {
-        new_col.to_string()
-    } else {
-        quote_ident(new_col)
-    };
+    let replacement =
+        if is_safe_bare_identifier(new_col) { new_col.to_string() } else { quote_ident(new_col) };
     Some(replace_span(create_sql, span, &replacement))
+}
+
+/// The byte position where a top-level definition begins inside the column
+/// list: the index of the *name token* of a column definition, paired with
+/// whether that definition is a column (vs. a table-level constraint, which we
+/// leave alone).
+struct DefStart {
+    /// Index into the token slice of this definition's first token.
+    tok_idx: usize,
+    /// True when the definition is a column (its first token is an identifier);
+    /// false for a table-level constraint (`PRIMARY KEY`, `UNIQUE`, `CHECK`,
+    /// `FOREIGN KEY`, `CONSTRAINT …`).
+    is_column: bool,
+}
+
+/// Collect the start of every top-level definition in the column list (columns
+/// and table-level constraints), in source order. Depth-1 only; nested parens
+/// (e.g. type sizes, `CHECK(...)`) are skipped.
+fn definition_starts(tokens: &[(Token, Span)], open: usize, close: usize) -> Vec<DefStart> {
+    let mut defs = Vec::new();
+    let mut depth = 0usize;
+    let mut at_def_start = false;
+    for (i, (tok, _)) in tokens.iter().enumerate().take(close).skip(open) {
+        match tok {
+            Token::LParen => {
+                depth += 1;
+                if depth == 1 {
+                    at_def_start = true; // first token inside the column list
+                }
+            }
+            Token::RParen => depth -= 1,
+            Token::Comma if depth == 1 => at_def_start = true,
+            _ if depth == 1 && at_def_start => {
+                at_def_start = false;
+                let is_column = matches!(tok, Token::Identifier(_) | Token::DelimitedIdentifier(_));
+                defs.push(DefStart { tok_idx: i, is_column });
+            }
+            _ => {}
+        }
+    }
+    defs
+}
+
+/// Remove a column definition from the verbatim `CREATE TABLE` text in place,
+/// matching SQLite's `ALTER TABLE ... DROP COLUMN` byte-for-byte (verified
+/// against sqlite3 3.51.0).
+///
+/// SQLite deletes the span from the start of the dropped column's *name* to the
+/// start of the next column's name. For the last column (no following column) it
+/// instead walks backward from the column name to the preceding `,` and deletes
+/// from there to the end of the column list (the closing `)` or the first
+/// table-level constraint). This preserves the user's surrounding whitespace
+/// exactly as SQLite does.
+///
+/// Returns `None` (so the caller falls back to reconstruction) when the column
+/// cannot be located unambiguously, when it is the only/first-of-one column, or
+/// when the structure is otherwise unexpected.
+pub fn drop_column(create_sql: &str, col: &str) -> Option<String> {
+    let tokens = tokenize(create_sql)?;
+    let (open, close) = column_list_parens(&tokens)?;
+    let defs = definition_starts(&tokens, open, close);
+
+    // Index within `defs` of the target column.
+    let mut target: Option<usize> = None;
+    for (di, def) in defs.iter().enumerate() {
+        if def.is_column && ident_matches(&tokens[def.tok_idx].0, col) {
+            if target.is_some() {
+                return None; // ambiguous duplicate column name
+            }
+            target = Some(di);
+        }
+    }
+    let di = target?;
+
+    // Never drop the only remaining column.
+    let column_count = defs.iter().filter(|d| d.is_column).count();
+    if column_count <= 1 {
+        return None;
+    }
+
+    let name_start = tokens[defs[di].tok_idx].1.start;
+
+    // The "next column" is the next *column* definition after this one (a table
+    // constraint does not count — see the table-constraint cases verified
+    // against sqlite3). If there is one, delete `[name_start, next_name_start)`.
+    let next_col = defs[di + 1..].iter().find(|d| d.is_column);
+
+    let bytes = create_sql.as_bytes();
+    let (del_start, del_end) = if let Some(next) = next_col {
+        (name_start, tokens[next.tok_idx].1.start)
+    } else {
+        // Last column (no following *column*; a table-level constraint may
+        // still follow). SQLite deletes from the comma preceding this column up
+        // to its `addColOffset` — the point where ADD COLUMN would insert, which
+        // is the comma preceding the first table-level constraint, or the
+        // closing `)` when there are no constraints. So:
+        //   - end: if a table constraint follows, the comma just before it;
+        //     otherwise the closing `)`.
+        //   - start: walk back to the preceding `,` (matching SQLite's
+        //     `while(*z!=',') z--`).
+        let end = match defs[di + 1..].first() {
+            Some(constraint) => {
+                // Walk back from the constraint token over whitespace to the
+                // separating comma; that comma (and the column text before it)
+                // is what gets removed.
+                let mut e = tokens[constraint.tok_idx].1.start;
+                while e > 0 && bytes[e - 1] != b',' {
+                    e -= 1;
+                }
+                if e == 0 || bytes[e - 1] != b',' {
+                    return None;
+                }
+                e - 1
+            }
+            None => tokens[close].1.start,
+        };
+        let mut start = name_start;
+        while start > 0 && bytes[start - 1] != b',' {
+            start -= 1;
+        }
+        if start == 0 || bytes[start - 1] != b',' {
+            // No preceding comma found (shouldn't happen for a non-first column,
+            // but guards the first-column-with-no-next pathological case).
+            return None;
+        }
+        (start - 1, end)
+    };
+
+    let mut out = String::with_capacity(create_sql.len());
+    out.push_str(&create_sql[..del_start]);
+    out.push_str(&create_sql[del_end..]);
+    Some(out)
 }
 
 /// Extract the verbatim column-definition text from an
@@ -233,14 +363,12 @@ pub fn rename_column(create_sql: &str, old_col: &str, new_col: &str) -> Option<S
 /// located.
 pub fn extract_add_column_text(alter_sql: &str) -> Option<String> {
     let tokens = tokenize(alter_sql)?;
-    let add_pos =
-        tokens.iter().position(|(t, _)| matches!(t, Token::Keyword { keyword: Keyword::Add, .. }))?;
+    let add_pos = tokens
+        .iter()
+        .position(|(t, _)| matches!(t, Token::Keyword { keyword: Keyword::Add, .. }))?;
     let mut start_tok = add_pos + 1;
     // Optional COLUMN keyword.
-    if matches!(
-        tokens.get(start_tok),
-        Some((Token::Keyword { keyword: Keyword::Column, .. }, _))
-    ) {
+    if matches!(tokens.get(start_tok), Some((Token::Keyword { keyword: Keyword::Column, .. }, _))) {
         start_tok += 1;
     }
     let first = tokens.get(start_tok)?;
@@ -359,6 +487,96 @@ mod tests {
         assert!(rename_column(sql, "zzz", "qqq").is_none());
     }
 
+    // DROP COLUMN — byte-for-byte against sqlite3 3.51.0 (verified manually).
+
+    #[test]
+    fn drop_column_last_multiline_matches_sqlite() {
+        // sqlite3: removes `,\n  c   INTEGER\n` (preceding comma to the `)`).
+        let sql = "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  b   TEXT,\n  c   INTEGER\n)";
+        let out = drop_column(sql, "c").unwrap();
+        assert_eq!(out, "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  b   TEXT)");
+    }
+
+    #[test]
+    fn drop_column_first_matches_sqlite() {
+        let sql = "CREATE TABLE t (a INTEGER, b TEXT, c INTEGER)";
+        let out = drop_column(sql, "a").unwrap();
+        assert_eq!(out, "CREATE TABLE t (b TEXT, c INTEGER)");
+    }
+
+    #[test]
+    fn drop_column_middle_matches_sqlite() {
+        let sql = "CREATE TABLE t (a INTEGER, b TEXT, c INTEGER)";
+        let out = drop_column(sql, "b").unwrap();
+        assert_eq!(out, "CREATE TABLE t (a INTEGER, c INTEGER)");
+    }
+
+    #[test]
+    fn drop_column_middle_multiline_matches_sqlite() {
+        let sql = "CREATE TABLE t (\n  a INTEGER,\n  b TEXT,\n  c INTEGER\n)";
+        let out = drop_column(sql, "b").unwrap();
+        assert_eq!(out, "CREATE TABLE t (\n  a INTEGER,\n  c INTEGER\n)");
+    }
+
+    #[test]
+    fn drop_column_first_with_spaces_matches_sqlite() {
+        let sql = "CREATE TABLE t (a INTEGER , b TEXT , c INTEGER)";
+        let out = drop_column(sql, "a").unwrap();
+        assert_eq!(out, "CREATE TABLE t (b TEXT , c INTEGER)");
+    }
+
+    #[test]
+    fn drop_column_last_with_spaces_matches_sqlite() {
+        let sql = "CREATE TABLE t (a INTEGER , b TEXT , c INTEGER)";
+        let out = drop_column(sql, "c").unwrap();
+        assert_eq!(out, "CREATE TABLE t (a INTEGER , b TEXT )");
+    }
+
+    #[test]
+    fn drop_column_before_table_constraint_matches_sqlite() {
+        // sqlite3: the column before a table-level constraint is the "last"
+        // column; its preceding comma through the constraint's start is removed.
+        let sql = "CREATE TABLE t (a INTEGER, b TEXT, c INTEGER, UNIQUE(a))";
+        let out = drop_column(sql, "c").unwrap();
+        assert_eq!(out, "CREATE TABLE t (a INTEGER, b TEXT, UNIQUE(a))");
+    }
+
+    #[test]
+    fn drop_column_middle_with_table_constraint_matches_sqlite() {
+        let sql = "CREATE TABLE t (a INTEGER, b TEXT, c INTEGER, UNIQUE(c))";
+        let out = drop_column(sql, "b").unwrap();
+        assert_eq!(out, "CREATE TABLE t (a INTEGER, c INTEGER, UNIQUE(c))");
+    }
+
+    #[test]
+    fn drop_column_missing_returns_none() {
+        let sql = "CREATE TABLE t (a INTEGER, b TEXT)";
+        assert!(drop_column(sql, "zzz").is_none());
+    }
+
+    #[test]
+    fn drop_column_only_column_returns_none() {
+        let sql = "CREATE TABLE t (a INTEGER)";
+        assert!(drop_column(sql, "a").is_none());
+    }
+
+    #[test]
+    fn drop_column_quoted_name_target() {
+        let sql = "CREATE TABLE t (\"a\" INTEGER, b TEXT)";
+        let out = drop_column(sql, "a").unwrap();
+        assert_eq!(out, "CREATE TABLE t (b TEXT)");
+    }
+
+    #[test]
+    fn rename_table_result_reloads_through_splitter() {
+        // The in-place RENAME TO output is double-quoted; ensure the result is
+        // still a single well-formed CREATE TABLE statement (re-parseable on
+        // reload, issue #5619/#5634).
+        let sql = "CREATE TABLE t (a INTEGER, b TEXT)";
+        let out = rename_table(sql, "t2").unwrap();
+        assert_eq!(out, "CREATE TABLE \"t2\" (a INTEGER, b TEXT)");
+    }
+
     #[test]
     fn extract_add_column_text_with_column_keyword() {
         assert_eq!(
@@ -387,7 +605,8 @@ mod tests {
     fn append_then_extract_matches_sqlite_end_to_end() {
         // ALTER TABLE t ADD COLUMN d TEXT DEFAULT 'x' on the post-ADD-c text.
         let create = "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  b   TEXT\n, c INTEGER)";
-        let coldef = extract_add_column_text("ALTER TABLE t ADD COLUMN d TEXT DEFAULT 'x'").unwrap();
+        let coldef =
+            extract_add_column_text("ALTER TABLE t ADD COLUMN d TEXT DEFAULT 'x'").unwrap();
         let out = append_column(create, &coldef).unwrap();
         assert_eq!(
             out,

--- a/crates/vibesql-executor/tests/alter_inplace_reload_tests.rs
+++ b/crates/vibesql-executor/tests/alter_inplace_reload_tests.rs
@@ -1,0 +1,155 @@
+//! End-to-end regression tests for issue #5634: `ALTER TABLE ... DROP COLUMN`
+//! and `... RENAME TO` edit the verbatim `sqlite_master.sql` text in place
+//! (matching sqlite3 3.51.0 byte-for-byte), and the preserved verbatim text
+//! survives a save/reload round-trip through **both** the `.sql` text dump and
+//! the binary `.vbsql` format.
+//!
+//! RENAME TO is the headline case: sqlite3 emits the new table name
+//! double-quoted (`CREATE TABLE "t2" (...)`), which previously exposed a
+//! pre-existing dump-splitter gap (`parse_sql_statements` treated a `'` inside a
+//! `"…"`/`[…]` quoted identifier as a string delimiter, desyncing statement
+//! splitting and failing reload with `near "CREATE": syntax error`). The
+//! splitter is now quote-aware, so the in-place RENAME TO output reloads
+//! cleanly.
+
+use vibesql_executor::{load_sql_dump, AlterTableExecutor, CreateTableExecutor, SelectExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+/// Create a table preserving the verbatim source text (issue #5619), the way the
+/// CLI/load paths capture it.
+fn create_with_source(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse CREATE");
+    let vibesql_ast::Statement::CreateTable(create) = stmt else {
+        panic!("expected CREATE TABLE");
+    };
+    CreateTableExecutor::execute_with_source(&create, db, Some(sql)).expect("CREATE TABLE");
+}
+
+/// Run an ALTER, passing the verbatim statement text (the path the CLI uses).
+fn alter(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse ALTER");
+    let vibesql_ast::Statement::AlterTable(a) = stmt else {
+        panic!("expected ALTER TABLE");
+    };
+    AlterTableExecutor::execute_with_source(&a, db, Some(sql)).expect("ALTER TABLE");
+}
+
+/// Return the single `sql` text for the named table from `sqlite_master`.
+fn table_sql(db: &Database, table: &str) -> String {
+    // Escape any embedded `'` in the literal so the SELECT we build is valid SQL.
+    let escaped = table.replace('\'', "''");
+    let query = format!("SELECT sql FROM sqlite_master WHERE type='table' AND name='{escaped}'");
+    let stmt = Parser::parse_sql(&query).expect("parse SELECT");
+    let vibesql_ast::Statement::Select(select) = stmt else {
+        panic!("expected SELECT");
+    };
+    let result = SelectExecutor::new(db).execute_with_columns(&select).expect("SELECT");
+    assert_eq!(result.rows.len(), 1, "expected one row for table {table}");
+    match &result.rows[0].values[0] {
+        vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
+            s.to_string()
+        }
+        other => panic!("expected text, got {other:?}"),
+    }
+}
+
+/// Save to a `.sql` dump and reload it through the executor (this exercises the
+/// quote-aware `parse_sql_statements` splitter), returning the reloaded db.
+fn roundtrip_sql_dump(db: &Database, tag: &str) -> Database {
+    let path = std::env::temp_dir().join(format!("vibesql_5634_{tag}.sql"));
+    db.save_sql_dump(&path).expect("save_sql_dump");
+    let reloaded = load_sql_dump(&path).expect("load_sql_dump must not fail (no `near CREATE`)");
+    std::fs::remove_file(&path).ok();
+    reloaded
+}
+
+/// Save to the binary `.vbsql` format and reload it, returning the reloaded db.
+fn roundtrip_binary(db: &Database, tag: &str) -> Database {
+    let path = std::env::temp_dir().join(format!("vibesql_5634_{tag}.vbsql"));
+    db.save_binary(&path).expect("save_binary");
+    let reloaded = Database::load_binary(&path).expect("load_binary");
+    std::fs::remove_file(&path).ok();
+    reloaded
+}
+
+#[test]
+fn rename_to_inplace_survives_sql_dump_reload() {
+    let mut db = Database::new();
+    create_with_source(&mut db, "CREATE TABLE t (\n  a INTEGER PRIMARY KEY,\n  b TEXT\n)");
+    alter(&mut db, "ALTER TABLE t RENAME TO t2");
+
+    let expected = "CREATE TABLE \"t2\" (\n  a INTEGER PRIMARY KEY,\n  b TEXT\n)";
+    assert_eq!(table_sql(&db, "t2"), expected, "RENAME TO in-place must match sqlite3");
+
+    // The double-quoted name must round-trip through the `.sql` dump without the
+    // pre-existing `near "CREATE"` splitter desync (issue #5634).
+    let reloaded = roundtrip_sql_dump(&db, "rename_sql");
+    assert_eq!(
+        table_sql(&reloaded, "t2"),
+        expected,
+        "RENAME TO verbatim text must survive a .sql dump reload"
+    );
+}
+
+#[test]
+fn rename_to_inplace_survives_binary_reload() {
+    let mut db = Database::new();
+    create_with_source(&mut db, "CREATE TABLE t (\n  a INTEGER PRIMARY KEY,\n  b TEXT\n)");
+    alter(&mut db, "ALTER TABLE t RENAME TO t2");
+
+    let expected = "CREATE TABLE \"t2\" (\n  a INTEGER PRIMARY KEY,\n  b TEXT\n)";
+    let reloaded = roundtrip_binary(&db, "rename_bin");
+    assert_eq!(
+        table_sql(&reloaded, "t2"),
+        expected,
+        "RENAME TO verbatim text must survive a .vbsql reload"
+    );
+}
+
+#[test]
+fn drop_column_inplace_survives_both_reloads() {
+    let mut db = Database::new();
+    create_with_source(
+        &mut db,
+        "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  b   TEXT,\n  c   INTEGER\n)",
+    );
+    alter(&mut db, "ALTER TABLE t DROP COLUMN c");
+
+    let expected = "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  b   TEXT)";
+    assert_eq!(table_sql(&db, "t"), expected, "DROP COLUMN in-place must match sqlite3");
+
+    let reloaded_sql = roundtrip_sql_dump(&db, "drop_sql");
+    assert_eq!(
+        table_sql(&reloaded_sql, "t"),
+        expected,
+        "DROP COLUMN verbatim text must survive a .sql dump reload"
+    );
+
+    let reloaded_bin = roundtrip_binary(&db, "drop_bin");
+    assert_eq!(
+        table_sql(&reloaded_bin, "t"),
+        expected,
+        "DROP COLUMN verbatim text must survive a .vbsql reload"
+    );
+}
+
+/// A renamed-to name that itself contains a `'` (legal as a quoted identifier)
+/// is the exact case the old symmetric-quote splitter mangled. The new name is
+/// emitted double-quoted, so a `'` inside it is literal — the dump must reload.
+#[test]
+fn rename_to_name_with_apostrophe_survives_sql_dump_reload() {
+    let mut db = Database::new();
+    create_with_source(&mut db, "CREATE TABLE t (a INTEGER, b TEXT)");
+    alter(&mut db, "ALTER TABLE t RENAME TO \"weird'name\"");
+
+    let expected = "CREATE TABLE \"weird'name\" (a INTEGER, b TEXT)";
+    assert_eq!(table_sql(&db, "weird'name"), expected);
+
+    let reloaded = roundtrip_sql_dump(&db, "rename_apostrophe");
+    assert_eq!(
+        table_sql(&reloaded, "weird'name"),
+        expected,
+        "a renamed name containing `'` must survive the quote-aware splitter (issue #5634)"
+    );
+}

--- a/crates/vibesql-executor/tests/sqlite_schema_tests.rs
+++ b/crates/vibesql-executor/tests/sqlite_schema_tests.rs
@@ -275,14 +275,12 @@ fn test_sqlite_master_sql_strips_trailing_semicolon() {
     assert_eq!(stored, "CREATE TABLE   t  (  a   INT ,  b  TEXT )");
 }
 
-/// Issue #5625: `ALTER TABLE ... RENAME TO` is deferred from in-place verbatim
-/// text editing (the preserved text interacts badly with a pre-existing SQL-dump
-/// reload gap for quoted identifiers containing `'`). It keeps the #5619
-/// behavior: the stale verbatim text is discarded and `sqlite_master.sql` is
-/// reconstructed, so the new name appears and the old one never survives, and
-/// the result stays re-parseable on reload.
+/// Issue #5634: `ALTER TABLE ... RENAME TO` edits the verbatim CREATE TABLE
+/// text in place, rewriting the table name to the double-quoted new name and
+/// preserving all other formatting — byte-for-byte matching sqlite3 3.51.0
+/// (previously deferred to invalidate-and-reconstruct, issue #5625).
 #[test]
-fn test_sqlite_master_sql_rename_table_reconstructs() {
+fn test_sqlite_master_sql_rename_table_edits_text_in_place() {
     let mut db = Database::new();
     let create_sql = "CREATE TABLE oldname (\n      a INTEGER,\n      b TEXT\n    )";
     execute_create_table_with_source(&mut db, create_sql);
@@ -298,17 +296,12 @@ fn test_sqlite_master_sql_rename_table_reconstructs() {
         panic!("expected ALTER TABLE");
     }
 
+    // sqlite3 3.51.0 emits the new name double-quoted, preserving everything
+    // else verbatim: `CREATE TABLE "newname" (\n      a INTEGER,\n      b TEXT\n    )`.
     let after = single_text(&db, "SELECT sql FROM sqlite_master WHERE type='table'");
-    assert_ne!(after, create_sql, "stale verbatim text must not survive a rename");
-    assert!(
-        after.contains("newname"),
-        "reconstructed sql should name the renamed table, got: {}",
-        after
-    );
-    assert!(
-        !after.contains("oldname"),
-        "reconstructed sql must not reference the old table name, got: {}",
-        after
+    assert_eq!(
+        after, "CREATE TABLE \"newname\" (\n      a INTEGER,\n      b TEXT\n    )",
+        "RENAME TO must rewrite the table name in place, double-quoted (issue #5634)"
     );
 }
 
@@ -352,14 +345,15 @@ fn test_sqlite_master_sql_add_column_syncs_catalog_and_edits_text() {
     );
 }
 
-/// Issue #5625 part (1): after `ALTER TABLE ... DROP COLUMN`, the catalog schema
-/// copy must drop the column too. The verbatim text is invalidated for DROP
-/// COLUMN (reconstruction is correct, just lower fidelity — see follow-on), so
-/// the reconstructed sql must reflect the dropped column.
+/// Issue #5634: after `ALTER TABLE ... DROP COLUMN`, the verbatim CREATE TABLE
+/// text is edited in place (the dropped column's definition span removed,
+/// byte-for-byte matching sqlite3 3.51.0), and the catalog schema copy drops the
+/// column too (issue #5625 part 1).
 #[test]
-fn test_drop_column_syncs_catalog_schema() {
+fn test_drop_column_edits_text_and_syncs_catalog() {
     let mut db = Database::new();
-    execute_create_table_with_source(&mut db, "CREATE TABLE t (a INTEGER PRIMARY KEY, b TEXT, c INTEGER)");
+    let create_sql = "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  b   TEXT,\n  c   INTEGER\n)";
+    execute_create_table_with_source(&mut db, create_sql);
 
     let stmt = Parser::parse_sql("ALTER TABLE t DROP COLUMN c").expect("parse");
     if let vibesql_ast::Statement::AlterTable(alter) = stmt {
@@ -368,6 +362,13 @@ fn test_drop_column_syncs_catalog_schema() {
         panic!("expected ALTER TABLE");
     }
 
+    // sqlite3 3.51.0: removes `,\n  c   INTEGER` (preceding comma to the `)`).
+    let sql = single_text(&db, "SELECT sql FROM sqlite_master WHERE type='table'");
+    assert_eq!(
+        sql, "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  b   TEXT)",
+        "DROP COLUMN must remove the column-def span in place (issue #5634)"
+    );
+
     let catalog_schema = db.catalog.get_table("t").expect("catalog has table t");
     let col_names: Vec<&str> = catalog_schema.columns.iter().map(|c| c.name.as_str()).collect();
     assert_eq!(
@@ -375,9 +376,6 @@ fn test_drop_column_syncs_catalog_schema() {
         vec!["a", "b"],
         "catalog schema must drop the column after DROP COLUMN (issue #5625)"
     );
-
-    let sql = single_text(&db, "SELECT sql FROM sqlite_master WHERE type='table'");
-    assert!(!sql.contains(" c "), "reconstructed sql must not mention dropped column c, got: {}", sql);
 }
 
 /// Issue #5625: `ALTER TABLE ... RENAME COLUMN` rewrites the column name in its

--- a/crates/vibesql-storage/src/persistence/load.rs
+++ b/crates/vibesql-storage/src/persistence/load.rs
@@ -79,6 +79,20 @@ pub fn read_sql_dump<P: AsRef<Path>>(path: P) -> Result<String, StorageError> {
     }
 }
 
+/// The quoted context the dump splitter is currently inside. SQLite has three
+/// independent quoting contexts; a delimiter for one is ordinary text inside
+/// another (issue #5634).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Quote {
+    /// `'…'` string literal. Escapes an embedded quote by doubling (`''`); also
+    /// honors the legacy `\'` backslash escape.
+    Single,
+    /// `"…"` quoted identifier. Escapes an embedded quote by doubling (`""`).
+    Double,
+    /// `[…]` quoted identifier. No escape; the first `]` closes it.
+    Bracket,
+}
+
 /// Parse SQL dump content into individual statements
 ///
 /// Handles:
@@ -86,6 +100,8 @@ pub fn read_sql_dump<P: AsRef<Path>>(path: P) -> Result<String, StorageError> {
 /// - Multi-line statements
 /// - Statement termination by semicolon
 /// - String literals (preserves content within quotes)
+/// - Quoted identifiers (`"…"` and `[…]`); a `'` inside one is literal text, not
+///   a string delimiter, and vice versa (tracked via [`Quote`], issue #5634)
 /// - `CREATE TRIGGER ... BEGIN ... END;` blocks where embedded semicolons inside
 ///   the trigger body must NOT terminate the outer statement. We track BEGIN/END
 ///   nesting depth (matched as whole-word identifiers, case-insensitively) and
@@ -96,8 +112,21 @@ pub fn read_sql_dump<P: AsRef<Path>>(path: P) -> Result<String, StorageError> {
 pub fn parse_sql_statements(content: &str) -> Result<Vec<String>, StorageError> {
     let mut statements = Vec::new();
     let mut current_statement = String::new();
-    let mut in_string = false;
-    let mut string_char = ' ';
+    // The kind of quote we are currently inside, if any. SQLite has three
+    // distinct quoting contexts that nest independently — a delimiter for one
+    // context is ordinary text inside another:
+    //   - `Quote::Single` (`'…'`): a string literal. Only `''` escapes; the
+    //     legacy `\'` escape is also honored here (see the `\\` arm below).
+    //   - `Quote::Double` (`"…"`): a quoted identifier. Only `""` escapes.
+    //   - `Quote::Bracket` (`[…]`): a quoted identifier. Has no escape; the
+    //     first `]` closes it.
+    // Tracking these separately is what lets a `'` inside a `"…"`/`[…]`
+    // identifier (e.g. a table renamed by `ALTER TABLE … RENAME TO`, which
+    // sqlite3 emits double-quoted) be treated as literal text rather than as a
+    // string-literal delimiter — without it, such a `'` desyncs statement
+    // splitting and the dump fails to reload with `near "CREATE": syntax error`
+    // (issue #5634).
+    let mut quote: Option<Quote> = None;
     let mut escape_next = false;
     // BEGIN/END nesting depth. While > 0, semicolons inside the trigger body do
     // not terminate the outer statement.
@@ -133,18 +162,18 @@ pub fn parse_sql_statements(content: &str) -> Result<Vec<String>, StorageError> 
                 continue;
             }
 
-            // Check for inline comment (-- outside of string)
-            if !in_string && ch == '-' && i + 1 < chars.len() && chars[i + 1] == '-' {
+            // Check for inline comment (-- outside of any quoted context)
+            if quote.is_none() && ch == '-' && i + 1 < chars.len() && chars[i + 1] == '-' {
                 // Skip rest of line (inline comment)
                 break;
             }
 
             // Detect BEGIN/END as whole-word, case-insensitive identifiers when
-            // not inside a string literal. Track nesting depth so `;` inside a
+            // not inside a quoted context. Track nesting depth so `;` inside a
             // trigger body doesn't prematurely terminate the CREATE TRIGGER.
-            if !in_string && ch.is_ascii_alphabetic() {
-                let prev_is_ident = i > 0
-                    && (chars[i - 1].is_ascii_alphanumeric() || chars[i - 1] == '_');
+            if quote.is_none() && ch.is_ascii_alphabetic() {
+                let prev_is_ident =
+                    i > 0 && (chars[i - 1].is_ascii_alphanumeric() || chars[i - 1] == '_');
                 if !prev_is_ident {
                     if let Some(consumed) = match_keyword(&chars, i, "BEGIN") {
                         begin_depth += 1;
@@ -178,20 +207,55 @@ pub fn parse_sql_statements(content: &str) -> Result<Vec<String>, StorageError> 
             }
 
             match ch {
-                '\\' if in_string && string_char == '\'' => {
+                // Legacy backslash escape inside a `'…'` string literal only.
+                '\\' if quote == Some(Quote::Single) => {
                     current_statement.push(ch);
                     escape_next = true;
                 }
-                '\'' | '"' if !in_string => {
-                    in_string = true;
-                    string_char = ch;
+                // Open a quoted context. Each kind is tracked separately so a
+                // delimiter for one kind is literal text inside another.
+                '\'' if quote.is_none() => {
+                    quote = Some(Quote::Single);
                     current_statement.push(ch);
                 }
-                c if in_string && c == string_char => {
-                    in_string = false;
+                '"' if quote.is_none() => {
+                    quote = Some(Quote::Double);
                     current_statement.push(ch);
                 }
-                ';' if !in_string && begin_depth == 0 => {
+                '[' if quote.is_none() => {
+                    quote = Some(Quote::Bracket);
+                    current_statement.push(ch);
+                }
+                // Close (or escape, via doubling) a `'…'` string literal. SQLite
+                // escapes an embedded quote by doubling it (`''`); a `''` is the
+                // literal quote, not a close. Look ahead one char to disambiguate.
+                '\'' if quote == Some(Quote::Single) => {
+                    if chars.get(i + 1) == Some(&'\'') {
+                        current_statement.push(ch);
+                        current_statement.push('\'');
+                        i += 2;
+                        continue;
+                    }
+                    quote = None;
+                    current_statement.push(ch);
+                }
+                // Close (or escape, via doubling) a `"…"` quoted identifier.
+                '"' if quote == Some(Quote::Double) => {
+                    if chars.get(i + 1) == Some(&'"') {
+                        current_statement.push(ch);
+                        current_statement.push('"');
+                        i += 2;
+                        continue;
+                    }
+                    quote = None;
+                    current_statement.push(ch);
+                }
+                // Close a `[…]` quoted identifier (no escape; first `]` closes).
+                ']' if quote == Some(Quote::Bracket) => {
+                    quote = None;
+                    current_statement.push(ch);
+                }
+                ';' if quote.is_none() && begin_depth == 0 => {
                     current_statement.push(ch);
                     // Statement complete
                     if !current_statement.trim().is_empty() {
@@ -212,9 +276,9 @@ pub fn parse_sql_statements(content: &str) -> Result<Vec<String>, StorageError> 
         // statement string we return here as `sqlite_master.sql`, so flattening
         // newlines to spaces would silently rewrite the user's formatting on a
         // .sql reload. A newline is whitespace to the SQL parser, so statement
-        // splitting and re-parsing are unaffected. The `!in_string` guard
+        // splitting and re-parsing are unaffected. The `quote.is_none()` guard
         // matches the prior behavior (no separator injected mid-literal).
-        if !in_string {
+        if quote.is_none() {
             current_statement.push('\n');
         }
     }
@@ -276,6 +340,71 @@ mod tests {
         let statements = parse_sql_statements(content).unwrap();
         assert_eq!(statements.len(), 1);
         assert!(statements[0].contains("John; Doe"));
+    }
+
+    #[test]
+    fn test_quote_inside_double_quoted_identifier_splits_correctly() {
+        // A `'` inside a `"…"` quoted identifier is literal text, not a string
+        // delimiter. Tracking `'` and `"` as one symmetric context would desync
+        // here, gluing the two statements together (issue #5634).
+        let content = "CREATE TABLE \"weird'name\" (x);\nINSERT INTO \"weird'name\" VALUES (1);";
+        let statements = parse_sql_statements(content).unwrap();
+        assert_eq!(statements.len(), 2, "got: {statements:?}");
+        assert!(statements[0].contains("CREATE TABLE"));
+        assert!(statements[0].contains("weird'name"));
+        assert!(statements[1].contains("INSERT INTO"));
+    }
+
+    #[test]
+    fn test_semicolon_inside_double_quoted_identifier_not_a_terminator() {
+        // A `;` inside a `"…"` identifier must not terminate the statement.
+        let content = "CREATE TABLE \"a;b\" (x);\nCREATE TABLE c (y);";
+        let statements = parse_sql_statements(content).unwrap();
+        assert_eq!(statements.len(), 2, "got: {statements:?}");
+        assert!(statements[0].contains("\"a;b\""));
+        assert!(statements[1].contains("CREATE TABLE c"));
+    }
+
+    #[test]
+    fn test_quote_inside_bracket_identifier_splits_correctly() {
+        // A `'` (and `;`) inside a `[…]` quoted identifier is literal text.
+        let content = "CREATE TABLE [weird';name] (x);\nINSERT INTO [weird';name] VALUES (1);";
+        let statements = parse_sql_statements(content).unwrap();
+        assert_eq!(statements.len(), 2, "got: {statements:?}");
+        assert!(statements[0].contains("[weird';name]"));
+        assert!(statements[1].contains("INSERT INTO"));
+    }
+
+    #[test]
+    fn test_double_quote_inside_string_literal_is_literal() {
+        // A `"` inside a `'…'` string literal is literal text, not an identifier
+        // delimiter; a following `;` still terminates.
+        let content = "INSERT INTO t VALUES ('say \"hi\"');\nINSERT INTO t VALUES (2);";
+        let statements = parse_sql_statements(content).unwrap();
+        assert_eq!(statements.len(), 2, "got: {statements:?}");
+        assert!(statements[0].contains("say \"hi\""));
+        assert!(statements[1].contains("VALUES (2)"));
+    }
+
+    #[test]
+    fn test_doubled_quote_escapes_within_quoted_identifier() {
+        // `""` is an escaped quote inside a `"…"` identifier, not a close. The
+        // `;` that follows the real closing quote terminates the statement.
+        let content = "CREATE TABLE \"a\"\"b\" (x);\nCREATE TABLE c (y);";
+        let statements = parse_sql_statements(content).unwrap();
+        assert_eq!(statements.len(), 2, "got: {statements:?}");
+        assert!(statements[0].contains("\"a\"\"b\""));
+        assert!(statements[1].contains("CREATE TABLE c"));
+    }
+
+    #[test]
+    fn test_doubled_quote_escapes_within_string_literal() {
+        // `''` is an escaped quote inside a `'…'` string literal, not a close.
+        let content = "INSERT INTO t VALUES ('it''s; here');\nINSERT INTO t VALUES (2);";
+        let statements = parse_sql_statements(content).unwrap();
+        assert_eq!(statements.len(), 2, "got: {statements:?}");
+        assert!(statements[0].contains("it''s; here"));
+        assert!(statements[1].contains("VALUES (2)"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Completes the in-place `ALTER TABLE` text editing started in #5633 (issue #5625)
by matching sqlite3 3.51.0 byte-for-byte for the two remaining variants, plus the
blocking dump-splitter fix that RENAME TO required.

- **Dump-splitter fix** (`vibesql-storage` `parse_sql_statements`): now tracks
  single-quote (`'…'`), double-quote (`"…"`), and bracket (`[…]`) contexts
  **separately** (with `''`/`""` escape doubling), matching SQLite's lexing. A
  `'` inside a `"…"`/`[…]` identifier is literal text, not a string delimiter.
  Previously a single symmetric quote state desynced statement splitting and
  failed reload with `near "CREATE": syntax error`.
- **DROP COLUMN** (`alter_rewrite::drop_column`): removes the dropped column's
  definition span (its name through the next column's name, or — for the last
  column — from the preceding comma to the column-list end / first table
  constraint), mirroring sqlite3's `sqlite_drop_column`.
- **RENAME TO** (`alter_rewrite::rename_table`, now wired up): rewrites the table
  name to the double-quoted new name in place, preserving all other formatting.

Both fall back to invalidate-and-reconstruct when an edit can't apply cleanly
(preserving the re-parseable-on-reload invariant, #5619), and keep the #5625
catalog-schema-sync behavior.

## Verification

- Byte-for-byte vs `/usr/bin/sqlite3` 3.51.0 for DROP COLUMN (first/middle/last,
  with/without table constraints, varied whitespace) and RENAME TO (plain,
  quoted original, apostrophe-containing new name).
- End-to-end create -> ALTER -> save -> reload through **both** `.sql` text dump
  and binary `.vbsql` (no `near "CREATE"` error), incl. a renamed name containing
  `'`.
- alter.test 40/117, altertrig.test 36/36, table.test 46/96 — identical before
  and after this change (no regression). Full `cargo test -p vibesql-executor
  -p vibesql-storage -p vibesql-catalog` green.

## Test plan

- [ ] `cargo test -p vibesql-executor -p vibesql-storage -p vibesql-catalog`
- [ ] alter.test / altertrig.test / table.test unchanged
- [ ] sqlite3 3.51.0 byte-match for `SELECT sql FROM sqlite_master` after each ALTER

Closes #5634

🤖 Generated with [Claude Code](https://claude.com/claude-code)