### PR TITLE
chore(release): use cargo publish --skip-existing in release-crates.yml

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -52,20 +52,20 @@ jobs:
         if: github.event.inputs.dry_run == 'true'
         run: |
           echo "Dry run mode - will verify packages but not publish"
-          cargo publish -p vibesql-types --dry-run
-          cargo publish -p vibesql-l10n --dry-run
-          cargo publish -p vibesql-ast --dry-run
-          cargo publish -p vibesql-parser --dry-run
-          cargo publish -p vibesql-catalog --dry-run
-          cargo publish -p vibesql-storage --dry-run
-          cargo publish -p vibesql-bench-common --dry-run
-          cargo publish -p vibesql-executor --dry-run
-          cargo publish -p vibesql-consensus --dry-run
-          cargo publish -p vibesql --dry-run
+          cargo publish -p vibesql-types --dry-run --skip-existing
+          cargo publish -p vibesql-l10n --dry-run --skip-existing
+          cargo publish -p vibesql-ast --dry-run --skip-existing
+          cargo publish -p vibesql-parser --dry-run --skip-existing
+          cargo publish -p vibesql-catalog --dry-run --skip-existing
+          cargo publish -p vibesql-storage --dry-run --skip-existing
+          cargo publish -p vibesql-bench-common --dry-run --skip-existing
+          cargo publish -p vibesql-executor --dry-run --skip-existing
+          cargo publish -p vibesql-consensus --dry-run --skip-existing
+          cargo publish -p vibesql --dry-run --skip-existing
 
       - name: Publish vibesql-types
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
-        run: cargo publish -p vibesql-types --token ${{ secrets.CARGO_REGISTRY_TOKEN }} || echo "Already published or failed"
+        run: cargo publish -p vibesql-types --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --skip-existing
 
       - name: Wait for index update
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
@@ -73,7 +73,7 @@ jobs:
 
       - name: Publish vibesql-l10n
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
-        run: cargo publish -p vibesql-l10n --token ${{ secrets.CARGO_REGISTRY_TOKEN }} || echo "Already published or failed"
+        run: cargo publish -p vibesql-l10n --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --skip-existing
 
       - name: Wait for index update
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
@@ -81,7 +81,7 @@ jobs:
 
       - name: Publish vibesql-ast
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
-        run: cargo publish -p vibesql-ast --token ${{ secrets.CARGO_REGISTRY_TOKEN }} || echo "Already published or failed"
+        run: cargo publish -p vibesql-ast --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --skip-existing
 
       - name: Wait for index update
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
@@ -89,7 +89,7 @@ jobs:
 
       - name: Publish vibesql-parser
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
-        run: cargo publish -p vibesql-parser --token ${{ secrets.CARGO_REGISTRY_TOKEN }} || echo "Already published or failed"
+        run: cargo publish -p vibesql-parser --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --skip-existing
 
       - name: Wait for index update
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
@@ -97,7 +97,7 @@ jobs:
 
       - name: Publish vibesql-catalog
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
-        run: cargo publish -p vibesql-catalog --token ${{ secrets.CARGO_REGISTRY_TOKEN }} || echo "Already published or failed"
+        run: cargo publish -p vibesql-catalog --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --skip-existing
 
       - name: Wait for index update
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
@@ -105,7 +105,7 @@ jobs:
 
       - name: Publish vibesql-storage
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
-        run: cargo publish -p vibesql-storage --token ${{ secrets.CARGO_REGISTRY_TOKEN }} || echo "Already published or failed"
+        run: cargo publish -p vibesql-storage --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --skip-existing
 
       - name: Wait for index update
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
@@ -113,7 +113,7 @@ jobs:
 
       - name: Publish vibesql-bench-common
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
-        run: cargo publish -p vibesql-bench-common --token ${{ secrets.CARGO_REGISTRY_TOKEN }} || echo "Already published or failed"
+        run: cargo publish -p vibesql-bench-common --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --skip-existing
 
       - name: Wait for index update
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
@@ -121,7 +121,7 @@ jobs:
 
       - name: Publish vibesql-executor
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
-        run: cargo publish -p vibesql-executor --token ${{ secrets.CARGO_REGISTRY_TOKEN }} || echo "Already published or failed"
+        run: cargo publish -p vibesql-executor --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --skip-existing
 
       - name: Wait for index update
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
@@ -129,7 +129,7 @@ jobs:
 
       - name: Publish vibesql-consensus
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
-        run: cargo publish -p vibesql-consensus --token ${{ secrets.CARGO_REGISTRY_TOKEN }} || echo "Already published or failed"
+        run: cargo publish -p vibesql-consensus --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --skip-existing
 
       - name: Wait for index update
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
@@ -137,7 +137,7 @@ jobs:
 
       - name: Publish vibesql
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
-        run: cargo publish -p vibesql --token ${{ secrets.CARGO_REGISTRY_TOKEN }} || echo "Already published or failed"
+        run: cargo publish -p vibesql --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --skip-existing
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary

Every publish step in `.github/workflows/release-crates.yml` ended with `|| echo "Already published or failed"`, which swallowed real `cargo publish` failures and reported the workflow step as success. This caused two observed silent failures of the umbrella `vibesql` crate (v0.1.4 was stuck on crates.io for ~5 months; v0.2.0 had the same problem in commit 1c4d56bd7 and was only caught manually).

Replace every `cargo publish ... || echo "Already published or failed"` with `cargo publish ... --skip-existing` (supported by Rust 1.74+).

With `--skip-existing`:
- Already-published versions exit 0 cleanly (silent success — the legitimate "already on the index" case we want to tolerate).
- Real errors (resolver failures, network errors, validation, missing deps, etc.) propagate non-zero and fail the workflow step loudly.

Also added `--skip-existing` to the dry-run block for uniformity (no-op there, but keeps the invocations consistent across both paths).

## Changes

- `.github/workflows/release-crates.yml`: 9 publish steps and 10 dry-run lines updated. No other files touched.

## Test plan

- [ ] Workflow YAML parses (validated locally with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Trigger a workflow_dispatch dry-run on this branch: `gh workflow run release-crates.yml --ref feature/issue-5636 -f dry_run=true` and confirm it still passes cleanly
- [ ] On the next real tag push, confirm a publish failure (if one occurs) now surfaces as a red step instead of green

Closes #5636

🤖 Generated with [Claude Code](https://claude.com/claude-code)