### PR TITLE
chore(release): resurrect vibesql-cli publishing (closes #5637)

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -61,6 +61,7 @@ jobs:
           cargo publish -p vibesql-bench-common --dry-run --skip-existing
           cargo publish -p vibesql-executor --dry-run --skip-existing
           cargo publish -p vibesql-consensus --dry-run --skip-existing
+          cargo publish -p vibesql-cli --dry-run --skip-existing
           cargo publish -p vibesql --dry-run --skip-existing
 
       - name: Publish vibesql-types
@@ -135,6 +136,14 @@ jobs:
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
         run: sleep 30
 
+      - name: Publish vibesql-cli
+        if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
+        run: cargo publish -p vibesql-cli --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --skip-existing
+
+      - name: Wait for index update
+        if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
+        run: sleep 30
+
       - name: Publish vibesql
         if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
         run: cargo publish -p vibesql --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --skip-existing
@@ -153,4 +162,5 @@ jobs:
           echo "- vibesql-bench-common" >> $GITHUB_STEP_SUMMARY
           echo "- vibesql-executor" >> $GITHUB_STEP_SUMMARY
           echo "- vibesql-consensus" >> $GITHUB_STEP_SUMMARY
+          echo "- vibesql-cli" >> $GITHUB_STEP_SUMMARY
           echo "- vibesql" >> $GITHUB_STEP_SUMMARY

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ serde_yaml = "0.9"
 glob = "0.3"
 md-5 = "0.11"
 rusqlite = { workspace = true }
-vibesql-cli = { path = "crates/vibesql-cli" }
+vibesql-cli = { version = "0.2.0", path = "crates/vibesql-cli" }
 chrono = "0.4"
 
 [workspace]


### PR DESCRIPTION
## Summary

Picks option **(a) Resurrect publishing** for issue #5637. `vibesql-cli` has been absent from `release-crates.yml` for at least two cycles and is stuck at `0.1.3` on crates.io while the workspace ships `0.2.0`, leaving `cargo install vibesql-cli` users on a stale binary.

This PR is the workflow + Cargo.toml prep so the next release publishes `vibesql-cli` automatically. It does **not** cut a new release.

## Changes

1. **`.github/workflows/release-crates.yml`** — add `vibesql-cli` to the publish chain between `vibesql-consensus` and `vibesql` (matches the dependency order: the umbrella `vibesql` carries a dev-dep on `vibesql-cli`, so `vibesql-cli` must be on crates.io first). Includes the standard 30s post-publish sleep and the dry-run list + Summary entry. Uses `--skip-existing` to match the pattern landed by #5640.

2. **`Cargo.toml`** (root) — restore the version pin on the `vibesql-cli` dev-dep:
   ```diff
   - vibesql-cli = { path = "crates/vibesql-cli" }
   + vibesql-cli = { version = "0.2.0", path = "crates/vibesql-cli" }
   ```
   Dropped in 8880ca513 to unblock the v0.2.0 release when `vibesql-cli 0.2.0` didn't exist on crates.io. Now symmetric with every other internal `vibesql-*` dep.

## Follow-up (out of scope)

The actual crates.io refresh requires a subsequent patch release (e.g. **0.2.1**) via `/loom:release`. That is a separate user-driven decision and is intentionally not bundled here.

## Test plan

- [x] `cargo check -p vibesql-cli` — passes
- [ ] CI (workflow YAML lint, full workspace build)
- [ ] Spot-check: the next tagged release pushes `vibesql-cli` to crates.io and `cargo install vibesql-cli` yields the workspace version

Closes #5637