### PR TITLE
docs(release): document PyPI v0.1.4 incident + add skip-existing to publish step (closes #5638)

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -147,4 +147,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+          skip-existing: true
           # No password needed - uses trusted publishing via OIDC
+          # skip-existing makes partial re-runs idempotent: if some
+          # distributions already uploaded in a prior attempt, the
+          # action skips them instead of failing the whole job. See
+          # docs/PUBLISHING_CHECKLIST.md "PyPI v0.1.4 Incident".

--- a/docs/PUBLISHING_CHECKLIST.md
+++ b/docs/PUBLISHING_CHECKLIST.md
@@ -276,6 +276,103 @@ twine delete vibesql 0.1.2
 - **docs.rs** automatically builds documentation for crates.io releases
 - **Test before publishing** - dry-run everything first
 
+## PyPI v0.1.4 Incident (2026-01-19)
+
+PyPI's release history for `vibesql` skips from `0.1.3` to `0.2.0` — no `0.1.4`
+distribution will ever be published. This is intentional and permanent; this
+section documents what is known about why.
+
+### What happened
+
+- The `release-pypi.yml` workflow ran for tag `v0.1.4` as
+  [run `21127010213`](https://github.com/rjwalters/vibesql/actions/runs/21127010213).
+- All five `Build wheels` jobs (Linux x86_64/aarch64, macOS x86_64/arm64,
+  Windows x64) and the `Build source distribution` job reported success and
+  uploaded their artifacts.
+- The final `Publish to PyPI` job reported `failure`. PyPI never received
+  the v0.1.4 sdist or any of the v0.1.4 wheels.
+- The subsequent v0.2.0 run
+  ([`27573307431`](https://github.com/rjwalters/vibesql/actions/runs/27573307431))
+  used the same workflow file with no relevant configuration changes between
+  the two releases, and it succeeded on the first try. `vibesql 0.2.0` is now
+  live on PyPI with the sdist plus all five wheels (Linux x86_64/aarch64,
+  macOS x86_64/arm64, Windows x64).
+
+### What is not knowable now
+
+GitHub Actions log retention is 90 days; the v0.1.4 run logs return HTTP 410
+and the specific error from `pypa/gh-action-pypi-publish` is no longer
+recoverable. The exact failure mode cannot be confirmed in retrospect.
+
+### Most likely cause (inference, not confirmation)
+
+Because the v0.2.0 publish succeeded on the same workflow with no operator
+intervention on the PyPI side, the v0.1.4 failure is most consistent with a
+**transient upload-side fault** in one of:
+
+1. A 5xx response from PyPI's upload endpoint (PyPI does occasionally serve
+   transient 502/503s, especially during deploys).
+2. An OIDC token-exchange edge case — the GitHub-issued OIDC token must
+   match PyPI's trusted-publisher record exactly on owner, repository,
+   workflow filename, and environment; a timing or claim-mismatch glitch
+   would surface as a 4xx without leaving residue.
+3. A partial upload where some artifacts succeeded and a retry then hit
+   `400 File already exists` for the already-uploaded files, failing the
+   whole step.
+
+We do **not** have evidence to single out any one of these, and we should
+not claim a root cause we cannot verify.
+
+### Recovery
+
+No recovery was attempted: `v0.1.4` was abandoned on PyPI and the next
+release (`v0.2.0`) shipped through the same pipeline without changes. The
+gap on PyPI's history is permanent — only `0.1.2`, `0.1.3`, and `0.2.0`
+will ever appear.
+
+### Mitigation shipped alongside this note
+
+`release-pypi.yml` now passes `skip-existing: true` to
+`pypa/gh-action-pypi-publish`. This makes partial re-runs idempotent: if a
+future publish uploads some distributions and fails on others, retrying the
+job will skip the already-uploaded files instead of 4xx-ing the whole step.
+This is the PyPI analogue of the `cargo publish --skip-existing` pattern
+used for crates.io publishing.
+
+`skip-existing: true` does **not** silently overwrite published files —
+PyPI forbids that. It only suppresses the "file already exists" error for
+distributions that are byte-identical to what is already on PyPI.
+
+### Operator follow-up (not enforced)
+
+Periodically re-verify the trusted-publisher record at
+<https://pypi.org/manage/project/vibesql/settings/publishing/>. It should
+match exactly:
+
+- Owner: `rjwalters`
+- Repository: `vibesql`
+- Workflow filename: `release-pypi.yml`
+- Environment: `pypi`
+
+A drift in any of these (for example, a repo rename) would surface as an
+OIDC publish failure on the very next release.
+
+### Future observability
+
+If a future publish failure is suspected to be on the PyPI side, options
+to consider before logs expire:
+
+- Add `verbose: true` to the publish action (gives more detail on which
+  file failed and why).
+- Pipe the `pypa/gh-action-pypi-publish` output to `$GITHUB_STEP_SUMMARY`
+  so the failure mode is preserved in the workflow run summary, which has
+  a longer effective retention than raw step logs.
+- Snapshot `dist/` contents to a workflow artifact before the publish step
+  so the exact files attempted can be re-inspected later.
+
+These are not implemented here — they are listed so the next operator
+hitting a similar failure does not have to re-derive the option set.
+
 ## Quick Reference
 
 ```bash


### PR DESCRIPTION
## Summary

- Documents the `vibesql 0.1.4` PyPI publish failure (run [`21127010213`](https://github.com/rjwalters/vibesql/actions/runs/21127010213)) as a forensic entry in `docs/PUBLISHING_CHECKLIST.md`. The 90-day GHA log retention has expired, so the exact failure mode cannot be confirmed; the note explains what is known, what is inferred (most likely a transient PyPI 5xx, an OIDC token-exchange edge case, or a partial-upload retry hitting "file already exists"), and what is not knowable now.
- Records that the gap on PyPI (`0.1.2`, `0.1.3`, `0.2.0` — no `0.1.4`) is permanent and intentional, and that `v0.2.0` shipped through the same unmodified workflow on first try.
- Adds `skip-existing: true` to the `pypa/gh-action-pypi-publish` step in `.github/workflows/release-pypi.yml` so partial re-runs are idempotent (the PyPI analogue of the `cargo publish --skip-existing` pattern landed in #5640 / #5636). Does not change OIDC trusted-publishing behavior.
- Lists an operator-side follow-up to periodically re-verify the trusted-publisher record at https://pypi.org/manage/project/vibesql/settings/publishing/ (owner `rjwalters`, repository `vibesql`, workflow `release-pypi.yml`, environment `pypi`). Not enforced in this PR.

## Out of scope (intentional)

- No attempt to "restore" `vibesql 0.1.4` to PyPI — that version is permanently gone.
- No action-version bumps or other unrelated workflow edits.
- No new observability code yet; future options (`verbose: true`, piping output to `$GITHUB_STEP_SUMMARY`, snapshotting `dist/`) are listed in the doc for the next operator to consider.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-pypi.yml'))"` — YAML still parses.
- [ ] Next tagged release exercises `skip-existing: true` end-to-end (cannot be tested without cutting a release).

Closes #5638