### PR TITLE
bench: wire HNSW recall@k as its own phase in make benchmark-all

### DIFF
--- a/scripts/bench
+++ b/scripts/bench
@@ -909,18 +909,31 @@ def run_hnsw(config: BenchConfig) -> int:
     with open("/tmp/hnsw_results.txt", "w") as f:
         f.write(result.stdout)
 
-    if result.returncode != 0:
-        print("❌ HNSW recall benchmark failed (recall invariants not met)")
+    # Process results into the dogfooded results DB even if the benchmark
+    # binary exited non-zero (an assert! firing means a recall *regression*
+    # — we still want the measurements in the DB so the trends dashboard
+    # surfaces the drop instead of silently emitting `0 measurements`. See #5645.
+    bench_failed = result.returncode != 0
+    if bench_failed:
+        print("⚠ HNSW recall benchmark exited non-zero (recall invariants not met) — capturing measurements anyway")
+
+    # Only attempt to process if we actually got the expected output table.
+    # Avoid feeding empty / build-failure stdout to the parser.
+    has_results_block = "--- VibeSQL Recall Results ---" in result.stdout
+    if has_results_block:
+        print("\nProcessing results into database...")
+        proc = subprocess.run(
+            ["./scripts/process_results.py", "--type=hnsw", "--input", "/tmp/hnsw_results.txt"],
+            cwd=repo_root
+        )
+        if proc.returncode != 0:
+            print("⚠ HNSW result processing failed")
+            return proc.returncode
+    else:
+        print("❌ HNSW benchmark produced no parseable results table")
         return 1
 
-    # Process results into the dogfooded results DB.
-    print("\nProcessing results into database...")
-    subprocess.run(
-        ["./scripts/process_results.py", "--type=hnsw", "--input", "/tmp/hnsw_results.txt"],
-        cwd=repo_root
-    )
-
-    return 0
+    return 1 if bench_failed else 0
 
 
 def run_sysbench_server(config: BenchConfig) -> int:
@@ -1345,12 +1358,17 @@ def run_all(config: BenchConfig) -> int:
     # Define benchmark list based on mode
     # In smoke test mode, include server benchmarks for fair MySQL comparison
     # TPC-DS now supports QUERY_FILTER, so we include it for full pipeline validation
+    # Note: `hnsw` is intentionally NOT in this list. It is run as its own phase
+    # in `scripts/bench-all` (via `make benchmark-hnsw`) so a failure or skip in
+    # the latency suites does not silently drop the recall@k measurements from
+    # the trends dashboard. See #5645. Direct callers of `./scripts/bench
+    # --test=all` who want HNSW should additionally invoke `--test=hnsw`.
     if config.test_mode:
-        benchmarks = ["tpch", "tpcc", "tpcds", "sysbench", "hnsw", "sysbench-server", "tpch-server", "tpcc-server"]
+        benchmarks = ["tpch", "tpcc", "tpcds", "sysbench", "sysbench-server", "tpch-server", "tpcc-server"]
         print("Note: Skipping footprint in smoke test mode")
     else:
         # Full benchmark suite includes server benchmarks and footprint
-        benchmarks = ["tpch", "tpcc", "tpcds", "sysbench", "hnsw", "sysbench-server", "tpch-server", "tpcc-server", "footprint"]
+        benchmarks = ["tpch", "tpcc", "tpcds", "sysbench", "sysbench-server", "tpch-server", "tpcc-server", "footprint"]
 
     for test in benchmarks:
         config.test = test

--- a/scripts/bench-all
+++ b/scripts/bench-all
@@ -5,6 +5,12 @@
 # Runs the full benchmark matrix with timing breakdown:
 # 1. Embedded benchmarks (TPC-H, TPC-C, TPC-DS, Sysbench)
 # 2. Server benchmarks (TPC-H, TPC-C, Sysbench over PostgreSQL wire protocol)
+# 3. HNSW recall@k vector-index quality benchmark (VibeSQL)
+#
+# Phase 3 is run independently of phases 1 and 2 because recall@k is an
+# in-process quality metric that does not depend on Docker / MySQL / server
+# transports — a failure in the latency suites must not silently drop the
+# HNSW measurements from the trends dashboard. See #5645.
 #
 # Note: Tests (unit tests, SQLLogicTest) are NOT included.
 # Run 'make test' separately if you need test validation.
@@ -31,8 +37,10 @@ NC='\033[0m'
 # Timing data (bash 3 compatible - use separate variables)
 PHASE1_TIME=0
 PHASE2_TIME=0
+PHASE3_TIME=0
 PHASE1_STATUS=""
 PHASE2_STATUS=""
+PHASE3_STATUS=""
 TOTAL_START=$(date +%s)
 
 # Ensure Docker is running for MySQL benchmarks
@@ -139,6 +147,13 @@ print_summary() {
         bench_time=$((bench_time + PHASE2_TIME))
     fi
 
+    if [ -n "$PHASE3_STATUS" ]; then
+        local icon="✓"
+        [ "$PHASE3_STATUS" != "success" ] && icon="✗"
+        printf "%-25s %10s %10s\n" "HNSW Recall@k" "$(format_duration $PHASE3_TIME)" "$icon"
+        bench_time=$((bench_time + PHASE3_TIME))
+    fi
+
     echo "═════════════════════════════════════════════════════"
     printf "${BOLD}%-25s %10s${NC}\n" "TOTAL:" "$(format_duration $total_duration)"
     echo ""
@@ -184,6 +199,7 @@ main() {
     echo "Running full benchmark matrix:"
     echo "  1. Embedded benchmarks (TPC-H, TPC-C, TPC-DS, Sysbench)"
     echo "  2. Server benchmarks (PostgreSQL wire protocol)"
+    echo "  3. HNSW recall@k vector-index quality (VibeSQL)"
     echo ""
     echo "Note: Tests not included. Run 'make test' separately."
     echo ""
@@ -227,6 +243,27 @@ main() {
         fi
         PHASE2_TIME=$(($(date +%s) - phase_start))
     fi
+
+    # Phase 3: HNSW recall@k (vector index quality, VibeSQL only).
+    # Intentionally NOT gated on earlier phases — recall@k is an in-process
+    # quality metric independent of Docker / MySQL / server transports, and a
+    # failure in the latency suites previously caused the trends dashboard to
+    # silently render `HNSW Recall: 0 measurements`. See #5645.
+    echo ""
+    echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${BOLD}[HNSW Recall@k]${NC} Starting..."
+    echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    phase_start=$(date +%s)
+
+    if make benchmark-hnsw; then
+        PHASE3_STATUS="success"
+        echo -e "${GREEN}✓ [HNSW Recall@k] completed in $(format_duration $(($(date +%s) - phase_start)))${NC}"
+    else
+        PHASE3_STATUS="failed"
+        failed=1
+        echo -e "${RED}✗ [HNSW Recall@k] failed after $(format_duration $(($(date +%s) - phase_start)))${NC}"
+    fi
+    PHASE3_TIME=$(($(date +%s) - phase_start))
 
     # Print summary
     print_summary


### PR DESCRIPTION
## Summary

Closes #5645

The 2026-06-15 `make benchmark-all` run produced `HNSW Recall: 0 measurements -> hnsw_recall_results.json`, leaving the trends dashboard tile empty. This PR ensures the recall@k measurements reliably land in the dogfooded results DB on every `make benchmark-all` invocation.

## Root cause

HNSW recall was being run from inside `./scripts/bench --test=all`'s benchmark loop, where two failure modes silently dropped measurements:

- `run_hnsw` only called `process_results.py` when the benchmark binary exited zero. A recall regression (one of the `assert!`s in `hnsw_recall_benchmark.rs`) caused otherwise-valid measurements to be discarded instead of stored — the trends tile could not surface the drop.
- Burying HNSW behind the latency suites coupled its measurements to unrelated infrastructure (Docker, MySQL, server transports). Any failure or skip upstream silently meant no recall data.

## Changes

- **`scripts/bench-all`**: HNSW is now its own Phase 3, gated only on the benchmark binary itself (not on phases 1/2). The phase shows up in the summary table alongside Embedded and Server benchmarks.
- **`scripts/bench` (`run_all`)**: removes `hnsw` from the benchmark loop so it is not run twice when invoked via `make benchmark-all`. Direct callers of `./scripts/bench --test=hnsw` are unchanged.
- **`scripts/bench` (`run_hnsw`)**: writes measurements to the dogfooded results DB even when the benchmark binary exits non-zero, as long as the parseable results table was emitted. A recall regression is now visible in the trends dashboard instead of being silently dropped. Adds a clearer error path when the binary truly produced no output.

## Test plan

- [x] `cargo check -p vibesql-storage`
- [x] `cargo bench --package vibesql-storage --bench hnsw_recall_benchmark --no-run --features in-memory-indexes`
- [x] `HNSW_RECALL_DATASET_SIZE=600 HNSW_RECALL_QUERIES=30 ./scripts/bench --test=hnsw --engine=vibesql` — produces 4 configurations, processed into DB (12 measurements)
- [x] `python3 scripts/export_website_data.py` now reports `HNSW Recall: 12 measurements -> hnsw_recall_results.json` (was `0 measurements` on `main`)
- [x] `bash -n scripts/bench-all` (syntax)
- [x] `python3 -c "import py_compile; py_compile.compile('scripts/bench', doraise=True)"` (syntax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)