### PR TITLE
bench: fail loud on partial-success when engines skipped (closes #5644)

### DIFF
--- a/scripts/bench
+++ b/scripts/bench
@@ -108,6 +108,32 @@ def get_git_info() -> Dict[str, str]:
         return {"commit": "unknown", "branch": "unknown"}
 
 
+def record_skipped_engine(test_name: str, engine: str, reason: str) -> None:
+    """Record an engine skip so the orchestrator (bench-all) can surface it.
+
+    Some phases of `make benchmark-all` (notably MySQL) can silently drop out
+    mid-run if Docker dies after the pre-flight check. Without a record, the
+    orchestrator reports "All phases completed successfully!" and the web
+    dashboard ships stale data from the previous cycle (see #5644).
+
+    We append a TSV line `<test>\\t<engine>\\t<reason>` to the marker file
+    pointed at by the `VIBESQL_BENCH_SKIP_MARKER` env var. If unset, this is
+    a no-op — single-shot `./scripts/bench` invocations stay quiet, only
+    `./scripts/bench-all` opts in.
+    """
+    marker = os.environ.get("VIBESQL_BENCH_SKIP_MARKER")
+    if not marker:
+        return
+    try:
+        with open(marker, "a") as f:
+            # Sanitize: the orchestrator parses lines by tab; replace tabs/newlines.
+            safe_reason = reason.replace("\t", " ").replace("\n", " ")
+            f.write(f"{test_name}\t{engine}\t{safe_reason}\n")
+    except OSError:
+        # Don't let bookkeeping errors blow up the benchmark itself.
+        pass
+
+
 def clean_benchmark_crates():
     """Clean benchmark crates to ensure fresh builds.
 
@@ -515,6 +541,7 @@ def run_tpch_comparison(config: BenchConfig) -> int:
                 print(f"✓ MySQL ready: {mysql_url}")
         else:
             print("⚠ MySQL unavailable (Docker not available)")
+            record_skipped_engine("tpch", "mysql", "Docker not available")
             if len(config.engines) == 1:
                 return 1
             # Continue without MySQL
@@ -659,11 +686,12 @@ def run_tpcc(config: BenchConfig) -> int:
             print(f"✓ MySQL ready: {env['MYSQL_URL']}")
         else:
             print("⚠ MySQL unavailable (Docker not available)")
+            record_skipped_engine("tpcc", "mysql", "Docker not available")
             if "mysql" in config.engines and len(config.engines) == 1:
                 return 1
             # Remove MySQL from engines if it's the only one failing
             config.engines = [e for e in config.engines if e != "mysql"]
-    
+
     # Run benchmark
     print(f"\nRunning TPC-C (duration={duration}s)...")
 
@@ -744,6 +772,7 @@ def run_tpcds(config: BenchConfig) -> int:
             print(f"✓ MySQL ready: {mysql_url}")
     else:
         print("⚠ MySQL unavailable (Docker not available, skipping MySQL comparison)")
+        record_skipped_engine("tpcds", "mysql", "Docker not available")
 
     # Use isolated runner to avoid memory pressure
     print("Running TPC-DS (isolated mode - each engine in separate process)...")
@@ -788,6 +817,7 @@ def run_sysbench(config: BenchConfig) -> int:
             print(f"✓ MySQL ready: {env['MYSQL_URL']}")
         else:
             print("⚠ MySQL unavailable (Docker not available)")
+            record_skipped_engine("sysbench", "mysql", "Docker not available")
             # Remove MySQL from engines if Docker not available
             config.engines = [e for e in config.engines if e != "mysql"]
 
@@ -980,6 +1010,7 @@ def run_sysbench_server(config: BenchConfig) -> int:
             print(f"✓ MySQL ready: {env['MYSQL_URL']}")
         else:
             print("⚠ MySQL unavailable (Docker not available)")
+            record_skipped_engine("sysbench-server", "mysql", "Docker not available")
 
     print(f"\nRunning Sysbench server (duration={duration}s)...")
     with open("/tmp/sysbench_server_results.txt", "w") as f:
@@ -1063,6 +1094,7 @@ def run_tpch_server(config: BenchConfig) -> int:
             print(f"✓ MySQL ready: {env['MYSQL_URL']}")
         else:
             print("⚠ MySQL unavailable (Docker not available)")
+            record_skipped_engine("tpch-server", "mysql", "Docker not available")
 
     print(f"\nRunning TPC-H server (SF={scale_factor})...")
     result = subprocess.run(
@@ -1171,6 +1203,7 @@ def run_tpcc_server(config: BenchConfig) -> int:
             print(f"✓ MySQL ready: {env['MYSQL_URL']}")
         else:
             print("⚠ MySQL unavailable (Docker not available)")
+            record_skipped_engine("tpcc-server", "mysql", "Docker not available")
 
     # Build command with transaction filter if specified
     cmd = [bench_bin]

--- a/scripts/bench-all
+++ b/scripts/bench-all
@@ -43,6 +43,14 @@ PHASE2_STATUS=""
 PHASE3_STATUS=""
 TOTAL_START=$(date +%s)
 
+# Marker file used by `scripts/bench` to record engines that were silently
+# skipped mid-run (typically MySQL when Docker dies after the pre-flight
+# check). See #5644. We export the env var so child invocations of
+# `./scripts/bench` participate, and reset the file at startup so stale
+# entries from prior runs don't carry over.
+export VIBESQL_BENCH_SKIP_MARKER="${VIBESQL_BENCH_SKIP_MARKER:-/tmp/vibesql-benchmark-skipped-engines}"
+: > "$VIBESQL_BENCH_SKIP_MARKER" || true
+
 # Ensure Docker is running for MySQL benchmarks
 ensure_docker() {
     echo -e "${BOLD}Pre-flight check: Docker${NC}"
@@ -271,6 +279,35 @@ main() {
     if [ $failed -ne 0 ]; then
         echo -e "${RED}Some phases failed. Check output above for details.${NC}"
         exit 1
+    fi
+
+    # Check for engines that were silently skipped mid-run (e.g. Docker died,
+    # so MySQL phases were dropped). Without this surfacing, the orchestrator
+    # would claim success while the web dashboard ships stale data from the
+    # previous cycle. See #5644.
+    if [ -s "$VIBESQL_BENCH_SKIP_MARKER" ]; then
+        local skipped_count
+        skipped_count=$(wc -l < "$VIBESQL_BENCH_SKIP_MARKER" | tr -d ' ')
+        local skipped_engines
+        skipped_engines=$(awk -F'\t' '{print $2}' "$VIBESQL_BENCH_SKIP_MARKER" | sort -u | paste -sd, -)
+
+        echo ""
+        echo -e "${YELLOW}══════════════════════════════════════════════════════════════════${NC}"
+        echo -e "${YELLOW}${BOLD}                    PARTIAL SUCCESS                                ${NC}"
+        echo -e "${YELLOW}══════════════════════════════════════════════════════════════════${NC}"
+        echo -e "${YELLOW}Completed with ${skipped_count} skipped engine phase(s): ${skipped_engines}${NC}"
+        echo ""
+        echo "Skipped phase(s):"
+        # Format: <test>\t<engine>\t<reason>
+        awk -F'\t' '{printf "  - %-20s engine=%-10s reason=%s\n", $1, $2, $3}' "$VIBESQL_BENCH_SKIP_MARKER"
+        echo ""
+        echo "Web dashboard will ship stale data for these engines unless they"
+        echo "are re-run. To recover MySQL phases:"
+        echo "  - Ensure Docker Desktop is running"
+        echo "  - Run: make benchmark-server-all   # re-runs all MySQL phases"
+        echo -e "${YELLOW}══════════════════════════════════════════════════════════════════${NC}"
+        # Exit 2 to distinguish partial-success from full failure (exit 1).
+        exit 2
     fi
 
     echo -e "${GREEN}All phases completed successfully!${NC}"


### PR DESCRIPTION
## Summary

- `make benchmark-all` was silently dropping MySQL phases when Docker died mid-run, but still printed "All phases completed successfully!" — letting https://vibesql.org/ ship stale v0.1.4 MySQL numbers next to fresh v0.2.0 numbers from other engines, invisible to viewers (#5644).
- Wires a small marker-file protocol between `scripts/bench` and `scripts/bench-all`: every "MySQL unavailable" code path now records `<test>\t<engine>\t<reason>` to a marker file when `VIBESQL_BENCH_SKIP_MARKER` is set.
- After all phases, `bench-all` checks the marker; if non-empty it prints a yellow `PARTIAL SUCCESS` block listing each skipped phase and exits 2 (distinct from exit 1 = full failure).

## Design choices

- **Why a marker file, not a return code?** `bench-all` invokes `make benchmark-server-all` which fires three separate `./scripts/bench` calls. Threading a skip-set back through `make` would require parsing stdout or env-var smuggling; a marker file is the smallest invariant that survives `subprocess` boundaries.
- **Why exit 2?** Keeps existing exit semantics intact (0 = clean, 1 = full failure) and lets CI / wrappers distinguish "phases skipped, dashboard may be stale" from "benchmarks crashed."
- **Why opt-in via env var?** Single-shot `./scripts/bench --test=tpch --engine=mysql` calls (developer workflow) shouldn't grow a side-effect file. `bench-all` is the only caller that opts in.
- All 7 "MySQL unavailable" sites in `scripts/bench` now record a skip: tpch, tpcc, tpcds, sysbench, tpch-server, tpcc-server, sysbench-server.

## Test plan

- [x] `bash -n scripts/bench-all` — syntax OK
- [x] `python3 -c "import ast; ast.parse(open('scripts/bench').read())"` — syntax OK
- [x] Functional test of `record_skipped_engine`: writes TSV correctly, sanitizes embedded tabs/newlines, no-ops when env var unset.
- [x] Validated `awk`/`wc`/`paste` snippets in `bench-all` against a sample marker file — count, unique-engines, and per-line summary all format correctly.
- [ ] End-to-end repro (manual): kill Docker mid-run during `make benchmark-all`, observe yellow PARTIAL SUCCESS block + exit code 2.

Closes #5644