### PR TITLE
docs(perf): record TPC-C measurement under contention; v0.2.0 dashboard caveat (closes #5643)

### DIFF
--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -84,3 +84,9 @@ A timeline of major milestones in the development of VibeSQL.
 - **SQLite compatibility push** — full SQLITE_MAX_TRIGGER_DEPTH (1000) trigger semantics, ALTER TABLE RENAME COLUMN with trigger-body rewrite, schema-aware index manager, FK deferral, window-function correctness
 - **EXPLAIN QUERY PLAN** moved close to sqlite3 parity (view/subquery expansion, window-sort annotations, ordering-index scan lines)
 - Released as **v0.2.0** on 2026-06-15 (369 commits since v0.1.4)
+
+### June 15, 2026: TPC-C Dashboard Contention Caveat
+
+- v0.2.0 release-window TPC-C dashboard captured all three engines (VibeSQL, SQLite, DuckDB) at ~1/3 of their v0.1.4 throughput, the signature of host-level contention rather than a code regression (see [docs/performance/tpcc_regression.md](performance/tpcc_regression.md))
+- Same-host re-measurement on `feature/issue-5643` (head `9e1ac205`, descended from the v0.2.0 release commit `ec54522d1`) recovered VibeSQL TPC-C to **9,276 TPS** (vs the 5,307 TPS dashboard number, vs the 10,758 TPS v0.1.4 README baseline); SQLite recovered to 2,813 TPS and DuckDB to 450 TPS
+- Re-measurement was itself taken under sweep-concurrency contention; a truly idle re-run is still warranted before refreshing the website dashboard or filing a bisect

--- a/docs/performance/tpcc_regression.md
+++ b/docs/performance/tpcc_regression.md
@@ -1,0 +1,88 @@
+# TPC-C Throughput: v0.1.4 vs v0.2.0 Investigation
+
+## Summary
+
+The v0.2.0 release dashboard (2026-06-15) shipped a TPC-C mixed-workload number of
+**5,307 TPS** for VibeSQL, down sharply from the v0.1.4 README claim of **10,758 TPS**.
+A follow-up re-measurement on the same host (see Issue #5643) shows the v0.2.0 release
+dashboard number was **depressed by host contention**, not a code regression. The actual
+v0.2.0-codebase throughput on the same hardware is closer to **9,276 TPS** — still ~14%
+below the v0.1.4 baseline, but well within the same order of magnitude.
+
+## Context
+
+The v0.2.0 benchmark snapshot (`web-demo/public/benchmarks/tpcc_results.json`, captured
+at the v0.2.0 release commit `ec54522d1` / dashboard timestamp `2026-06-15T13:56:44`)
+recorded:
+
+| Engine  | v0.2.0 dashboard TPS | v0.1.4 README TPS |
+| ------- | -------------------: | ----------------: |
+| VibeSQL |              5,306.65 |          10,758   |
+| SQLite  |                794.62 |           1,969   |
+| DuckDB  |                 94.89 |             323   |
+
+All three engines lost ~60-70% of throughput simultaneously, which is the
+characteristic signature of host-level contention rather than a per-engine regression.
+
+## Re-measurement (2026-06-15, Issue #5643)
+
+Re-ran `make benchmark-tpcc` (60 s mixed-workload, embedded engines) on the same
+host on `feature/issue-5643` (head `9e1ac205`, descended from `ec54522d1`):
+
+| Engine  | Re-measured TPS | vs v0.2.0 dashboard | vs v0.1.4 baseline |
+| ------- | --------------: | ------------------: | -----------------: |
+| VibeSQL |        9,276.23 |             +74.8%  |             -13.8% |
+| SQLite  |        2,812.80 |            +254.0%  |             +42.9% |
+| DuckDB  |          449.60 |            +373.7%  |             +39.2% |
+
+Persisted in the benchmark history database as Run ID 176
+(`/Users/rwalters/.vibesql/test_results/benchmark_results.vbsql`).
+
+### Important caveat — measurement was *also* under contention
+
+This re-measurement was taken while a parallel Loom builder (Issue #5644) and the
+TPC-C build itself were running on the same host. **The host was not idle.** The
+true v0.2.0 number is almost certainly higher than 9,276 TPS — a truly idle re-run
+is still warranted before any conclusion about a real (vs. ambient) regression.
+
+The fact that all three engines roughly **tripled** between the v0.2.0 dashboard
+snapshot and this re-measurement strongly suggests the dashboard window saw a
+much heavier contention spike than the re-measurement window.
+
+## Decision
+
+- The **v0.2.0 release dashboard TPC-C numbers were depressed by sweep-concurrency
+  contention** during the release-window benchmark. They should not be interpreted
+  as a code regression vs. v0.1.4.
+- The website's `tpcc_results.json` still carries the contention-depressed
+  dashboard number. Refreshing it via `make website` + `wrangler deploy` is a
+  follow-up task — out of scope for this docs-only entry, and ideally done after
+  one more truly-idle re-run for confidence.
+- The remaining ~14% gap between the contention-affected re-measurement (9,276 TPS)
+  and the v0.1.4 baseline (10,758 TPS) may itself be either residual contention
+  or a small real regression. A clean-machine TPC-C bisect against `ec54522d1`
+  (v0.2.0) and prior tagged commits would settle it, but is not currently a
+  release blocker.
+
+## Follow-up
+
+If a clean-machine re-run shows VibeSQL TPC-C TPS materially below the v0.1.4
+baseline (e.g., < 9,000 TPS sustained across two idle runs), file a bisect issue
+that:
+
+1. Identifies the v0.1.4 commit boundary (last release commit before the v0.2.0
+   work landed).
+2. Bisects across the Raft replication and MVCC merges (the two largest v0.2.0
+   workstreams most likely to have added per-transaction overhead even in
+   single-node embedded mode).
+3. Checks whether `mvcc_enabled` is unintentionally compiled into the default
+   embedded benchmark target — if so, that alone could explain a single-digit
+   percentage-point regression.
+
+## References
+
+- Issue: rjwalters/vibesql#5643
+- v0.2.0 release commit: `ec54522d1`
+- v0.2.0 release dashboard JSON: `web-demo/public/benchmarks/tpcc_results.json`
+- Benchmark history DB: `~/.vibesql/test_results/benchmark_results.vbsql`
+  (Run ID 176)


### PR DESCRIPTION
## Summary

- Investigation of the apparent TPC-C TPS halving between v0.1.4 (10,758 TPS) and the v0.2.0 release-dashboard number (5,307 TPS).
- Re-ran `make benchmark-tpcc` on the **same host** as the v0.2.0 release dashboard, descended from the v0.2.0 release commit `ec54522d1` (current head `9e1ac205`).
- All three embedded engines recovered roughly 3x: VibeSQL **9,276 TPS**, SQLite **2,813 TPS**, DuckDB **450 TPS** (vs the dashboard's 5,307 / 795 / 95). That uniform recovery is the signature of host-level contention, not a per-engine regression.
- **Caveat — measurement contention.** Per the dispatching instructions, this builder ran in parallel with another `/sweep` builder (issue #5644) and TPC-C had to rebuild cargo first. The host was NOT idle. The true v0.2.0 figure is almost certainly higher than 9,276 TPS; a truly idle re-run is still warranted before refreshing the website dashboard.
- VibeSQL re-measurement (9,276 TPS) is well above the issue's 8,000 TPS "contention noise confirmed" threshold, so this PR follows the documentation-only branch of the decision tree.

## What this PR changes

- New `docs/performance/tpcc_regression.md` — full write-up of the v0.2.0 dashboard number, the re-measurement, the contention caveat, and the recommended follow-up.
- `docs/HISTORY.md` — short timeline entry under v0.2.0 pointing at the perf doc.

## What this PR explicitly does NOT change

- No edits to benchmark code, `README.md` perf tables, or `web-demo/public/benchmarks/tpcc_results.json`. Refreshing the live dashboard would require a fresh `make website` plus `wrangler deploy`, which is gated on a truly-idle re-run and is left to the reviewer.

## Measurement details

Run via `make benchmark-tpcc` (60 s mixed workload, embedded engines, scale factor 1.0), persisted as Run ID 176 in `~/.vibesql/test_results/benchmark_results.vbsql`.

| Engine  | v0.2.0 dashboard | This re-measurement | v0.1.4 README |
| ------- | ---------------: | ------------------: | ------------: |
| VibeSQL |        5,306.65  |           9,276.23  |       10,758  |
| SQLite  |          794.62  |           2,812.80  |        1,969  |
| DuckDB  |           94.89  |             449.60  |          323  |

## Suggested follow-up (for the reviewer, not done here)

1. Re-run `make benchmark-tpcc` on a truly idle host (no concurrent Loom builders, no other cargo).
2. If the idle VibeSQL number is materially below the v0.1.4 baseline (e.g. < 9,000 TPS across two idle runs), file a clean-machine TPC-C bisect issue across the Raft + MVCC merges between `v0.1.4` and `ec54522d1`. Also verify that `mvcc_enabled` is not unintentionally compiled into the default embedded benchmark target.
3. If the idle number is in the 9.5–11k TPS range, refresh `web-demo/public/benchmarks/tpcc_results.json` via `make website` and `wrangler deploy`.

Closes #5643