### PR TITLE
spike(consensus): openraft 0.10 upgrade is a wholesale rewrite (blocks #5389)

### DIFF
--- a/crates/vibesql-consensus/Cargo.toml
+++ b/crates/vibesql-consensus/Cargo.toml
@@ -38,6 +38,12 @@ vibesql-types = { version = "0.2.0", path = "../vibesql-types" }
 # `storage-v2` unseals the RaftLogStorage/RaftStateMachine traits (the v2
 # storage API) so this crate can implement them; `serde` because our log
 # entry payloads and vote state will be serialized for durability in PR 2.
+#
+# NOTE (#5389): the upgrade target is openraft 0.10's `ReadPolicy::LeaseRead`
+# fast path. A spike against 0.10.0-alpha.21 confirms 0.10 is a wholesale
+# rewrite of the storage and network traits (361 build errors, the full
+# migration inventory is in #5389's draft PR body). Pinned to 0.9.24 here
+# until the v2 storage migration is sequenced as its own PR.
 openraft = { version = "0.9.24", features = ["serde", "storage-v2"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Status: BLOCKED — escape-hatch invoked

Refs #5389. This PR is the blocker write-up the builder's escape hatch calls for when an issue's premise turns out to be a wholesale rewrite that doesn't fit a single PR. The intended landing — `ReadPolicy::LeaseRead` opt-in fast path on top of an openraft 0.10 upgrade — cannot be delivered behind a single PR because the 0.10 upgrade itself is a >2,000-LOC trait-impl rewrite of consensus-critical code, not the in-place version bump the issue's enrichment anticipated.

## What the spike did

Bumped `crates/vibesql-consensus/Cargo.toml` to `openraft = \"=0.10.0-alpha.21\"` (no source changes), ran `cargo build -p vibesql-consensus`.

Result: **361 compile errors**, 32 warnings, no successful link. The pre-existing `storage-v2` feature is also gone (\"DEPRECATED: removed since 0.10.0\" per upstream `Cargo.toml`), so even the feature flag list needs reworking.

Error tally (by code, top of the list):

```
 128  E0277: u64: RaftTypeConfig not satisfied
  50  E0277: BasicNode: StdError not satisfied
  26  E0277: u64: RaftLeaderId not satisfied
  18  E0308: mismatched types
  16  E0223: ambiguous associated type
  16  E0107: struct takes 3 generic args but 2 supplied
  14  E0277: u64: RaftTypeConfig in StorageError<u64>
  14  E0107: struct takes 4 generic args but 1 supplied
  10  E0107: enum takes at most 2 generic args but 3 supplied
   8  E0277: BasicNode: NodeId not satisfied
   ...
   2  E0407: method `truncate` is not a member of trait `RaftLogStorage`
   2  E0407: method `read_vote` is not a member of trait `RaftLogStorage`
   2  E0046: not all trait items implemented, missing: `truncate_after`
   2  E0046: not all trait items implemented, missing: `read_vote`
```

## Inventory of the breaking surface (verified against `databendlabs/openraft@main`)

### RaftTypeConfig grew nine associated types

0.9: `D, R, NodeId, Node, AsyncRuntime, Responder, Entry, SnapshotData`.
0.10: adds `Term, LeaderId, Vote, ErrorSource, Batch<T>`; removes implicit `u64` everywhere. Every site that mentioned `u64` (NodeId), `BasicNode`, `Vote<u64>`, `LogId<u64>`, `StorageError<u64>` has to switch to the type-alias form: `TermOf<C>`, `LeaderIdOf<C>`, `VoteOf<C>`, `LogIdOf<C>`, `NodeIdOf<C>`, `SnapshotMetaOf<C>`, etc. This is the source of all 128 `u64: RaftTypeConfig` errors and most of the 14/16/10 generic-arg-count errors.

The `declare_raft_types!` macro form for 0.9:

```rust
openraft::declare_raft_types!(
    pub(crate) TypeConfig:
        D = Vec<u8>,
        R = AppResponse,
);
```

…has to be extended to specify Vote, LeaderId, Entry, SnapshotData, AsyncRuntime, Responder explicitly, otherwise the `Copy + Default + Ord` bounds on RaftTypeConfig itself break (the new trait bound list is `Sized + Send + Sync + Debug + Clone + Copy + Default + Eq + Ord + 'static`).

### RaftLogStorage migration

| 0.9 | 0.10 |
|-----|------|
| `get_log_state() -> Result<LogState, StorageError<u64>>` | `Result<LogState<C>, io::Error>` |
| `save_vote(&Vote<u64>) -> Result<(), StorageError<u64>>` | `save_vote(&VoteOf<C>) -> Result<(), io::Error>` |
| `read_vote() -> Result<Option<Vote<u64>>, ...>` | **removed**; lives on a separate API now |
| `append<I>(I, callback: LogFlushed<TypeConfig>)` | `append<I>(I, callback: IOFlushed<C>)` (with `OptionalSend` bounds, not `Send`) |
| `truncate(LogId<u64>)` | `truncate_after(Option<LogIdOf<C>>)` |
| `purge(LogId<u64>) -> Result<(), StorageError<u64>>` | `purge(LogIdOf<C>) -> Result<(), io::Error>` |
| `save_committed(Option<LogId<u64>>)` | `save_committed(Option<LogIdOf<C>>)` |

Hit sites: `InMemoryLogStore` (`openraft_backend.rs`) AND `DurableLogStore` (`durable.rs`, 1,361 LOC; this is the real production log store and the bulk of the rewrite work).

### RaftStateMachine migration — the apply protocol changed

| 0.9 | 0.10 |
|-----|------|
| `apply<I: IntoIterator<Item=Entry<TC>>>(entries) -> Result<Vec<R>, StorageError<u64>>` | `apply<S: Stream<Item=Result<EntryResponder<C>, io::Error>> + Unpin>(stream) -> Result<(), io::Error>`. **Responses no longer come back by value — they are pushed onto each entry's `EntryResponder` mid-apply.** |
| `applied_state() -> Result<(Option<LogId<u64>>, StoredMembership<u64, BasicNode>), StorageError<u64>>` | `Result<(Option<LogIdOf<C>>, StoredMembershipOf<C>), io::Error>` |
| `begin_receiving_snapshot() -> Result<Box<Cursor<Vec<u8>>>, ...>` | `Result<C::SnapshotData, io::Error>` (no `Box`) |
| `install_snapshot(&SnapshotMeta<u64, BasicNode>, Box<Cursor<Vec<u8>>>)` | `install_snapshot(&SnapshotMetaOf<C>, C::SnapshotData)` |
| `get_snapshot_builder()` | now deprecated; new code uses `try_create_snapshot_builder(force: bool) -> Option<Self::SnapshotBuilder>` |

The stream-based apply is the biggest semantic shift: VibeSQL's `MvccStateMachine` (`state_machine.rs`, 2,300 LOC) currently builds its `AppResponse::Mvcc { index, outcome }` from inside the loop and returns the vector. Under 0.10 it has to forward each response through the per-entry `EntryResponder<C>::send(Result<ROf<C>, io::Error>)`, which is structurally different — and threads the apply-side fatal-halt semantics (the `ConsensusError::FatalApply` path documented in `mvcc_raft.rs:28-44`) through a different error channel than today's `StorageError` return.

### RaftNetwork → RaftNetworkV2

| 0.9 | 0.10 |
|-----|------|
| `RaftNetwork::append_entries / install_snapshot / vote` | trait `RaftNetwork` is now empty/legacy. Real network is `RaftNetworkV2` |
| Three RPCs | Five: `append_entries`, `stream_append`, `vote`, **`pre_vote`** (new), `full_snapshot`, plus `transfer_leader` and `backoff` hooks |
| `install_snapshot` per-chunk RPC | `full_snapshot(vote, snapshot, cancel)` — whole-snapshot semantic, transport handles chunking. Legacy chunked `install_snapshot` is **gone from the trait** (`E0407: install_snapshot not a member of RaftNetwork`) |

Hit sites: `tcp.rs` (489 LOC, defines `TcpNetwork` and the chunked-install transfer design that was specifically called out in the existing module docs), `network.rs` (219 LOC, channel transport for tests). Both need to switch to V2 and re-implement chunking semantics around `full_snapshot`'s `cancel: Future<Output=ReplicationClosed>` cooperative-cancel contract.

### Error types collapsed onto `io::Error`

`StorageError<u64>` is gone from storage traits; everything returns `io::Error` (or a typed `StreamingError<C>` for the network's snapshot path). The existing crate threads `StorageError<u64>` through `openraft_backend.rs`, `durable.rs`, the recovery paths, and the tests' `manufacture_installed_snapshot` helper. All of them migrate.

### RPCError shape changed

`RPCError<u64, BasicNode, E>` → `RPCError<C: RaftTypeConfig, E: StdError = Infallible>`. The bound `E: StdError` is new — the source of all 50 `BasicNode: StdError` errors comes from places that built `RPCError::Unreachable(Unreachable::new(&io_error_with_no_E))`.

## Why this can't ride in one PR

- **Consensus-critical breadth.** The rewrite touches 4 crate files at ~6,800 combined LOC (`openraft_backend.rs` 2,085, `mvcc_raft.rs` 2,393, `durable.rs` 1,361, `state_machine.rs` 2,300, plus `tcp.rs` 489 and `network.rs` 219 for transport). Half a dozen of those 2,300 lines in the state machine alone get rearchitected — the apply protocol shifts from value-returning to responder-driven.
- **Stream-based apply** is not a mechanical rename. It changes how `MvccStateMachine` propagates per-entry outcomes (today: return value; 0.10: per-entry `EntryResponder<C>::send`). The fatal-halt machinery the module docs justify (`mvcc_raft.rs:28-44`) — \"a fatal apply must HALT the node, never advance `last_applied`\" — has to be re-proved against the new protocol. That requires careful redesign and its own correctness review, not a casual translation.
- **No reference implementation.** openraft 0.10's own changelog has no `v0.10.0` section yet (the curator flagged this in the issue enrichment); the only authoritative spec for the migration is the upstream source. An in-tree implementation derived only from source-reading is the highest-risk possible change to make to consensus code — exactly what the issue acknowledged when it noted \"storage/network trait churn expected\".
- **Pre-release dependency, scope-extended.** The original justification for accepting the alpha pin was \"in-place upgrade for one specific feature (LeaseRead)\". The reality is more like a complete v2 storage migration. That changes the risk/reward enough to warrant explicit scoping: the upgrade should land as its own PR(s), with its own correctness gates, and the LeaseRead opt-in sits on top of that.

## Recommended decomposition

This PR's contribution to the next round is the verified inventory above. Suggested follow-on sequencing (for the curator/judge to break out as separate issues):

1. **openraft 0.10 storage migration (this issue's blocker).** Just the v2-storage trait migration: `RaftLogStorage`, `RaftStateMachine`, `RaftTypeConfig`, error-type collapse to `io::Error`. New `Term`/`LeaderId`/`Vote`/`Batch`/`ErrorSource` associated types. **Default behavior unchanged** at the public API boundary; verified by `cargo test -p vibesql-consensus` keeping all existing tests green (including `tests/leader_reads.rs::partitioned_stale_leader_is_fenced_from_linearizable_reads` under the existing ReadIndex semantics).
2. **openraft 0.10 network migration.** `RaftNetwork`→`RaftNetworkV2`. Rework `tcp.rs` and `network.rs` for the new whole-snapshot `full_snapshot` semantic and the cooperative cancel contract; add `pre_vote` and `transfer_leader` stubs. `make test-cluster` is the gate.
3. **`ReadPolicy::LeaseRead` opt-in (this issue's actual deliverable).** Sits on top of (1) + (2). The `query_linearizable(read_policy: ReadPolicy)` signature change, the `RaftTuning::lease_reads` config flag, the lease-aware fencing test sweep, and the latency benchmark.

The third one is where the curator's acceptance criteria — LeaseRead off by default, fencing test passes under both modes, latency comparison documented — actually get exercised. Splitting it this way also bounds the blast radius of any 0.10-alpha churn: if the alpha pin breaks under us, only the bottom-most PR is destabilized, not the LeaseRead landing.

## What this PR changes

Only `crates/vibesql-consensus/Cargo.toml`: a comment that records the blocker rationale next to the openraft pin. The pin itself stays at `0.9.24` so main continues to build. No source changes, no test changes.

```diff
 # `storage-v2` unseals the RaftLogStorage/RaftStateMachine traits (the v2
 # storage API) so this crate can implement them; `serde` because our log
 # entry payloads and vote state will be serialized for durability in PR 2.
+#
+# NOTE (#5389): the upgrade target is openraft 0.10's `ReadPolicy::LeaseRead`
+# fast path. A spike against 0.10.0-alpha.21 confirms 0.10 is a wholesale
+# rewrite of the storage and network traits (361 build errors, the full
+# migration inventory is in #5389's draft PR body). Pinned to 0.9.24 here
+# until the v2 storage migration is sequenced as its own PR.
 openraft = { version = "0.9.24", features = ["serde", "storage-v2"] }
```

## Not addressed here (deliberately)

- The benchmark (LeaseRead vs ReadIndex). Cannot be measured until LeaseRead exists.
- The fencing test under LeaseRead. Same reason.
- The module-doc update at `mvcc_raft.rs:155-169`. The current text correctly documents the lease fast path as deliberately deferred; updating it before the actual landing would mislead readers.

Refs #5389. Not `Closes #5389` — the issue remains the canonical anchor for the eventual three-PR sequence above, which collectively delivers what the issue body asks for.

Builder escape hatch invoked per `.loom/roles/builder.md`: scope outgrew a single PR, consensus-critical, draft + FAILURE returned for judge/curator triage.