### PR TITLE
chore(release): make scripts/version.sh implement the v0.10.4 loom contract

### DIFF
--- a/.loom/context/topics/release.md
+++ b/.loom/context/topics/release.md
@@ -113,6 +113,6 @@ Append these VibeSQL-specific follow-ups to the operator hand-off:
 ## Important Notes (VibeSQL-specific)
 
 - **Four version-bearing files, propagation pattern**: only `[workspace.package]` in `Cargo.toml` carries the canonical Rust version; every member crate inherits via `version.workspace = true`. The exception is `crates/vibesql-sqllogictest/Cargo.toml`, which pins to upstream sqllogictest's `0.28.x` — do not touch it.
-- **`Cargo.lock` IS a version-bearing file**: every `vibesql-*` workspace crate has an entry in `Cargo.lock`. `cargo update -w` is required after bumping `Cargo.toml` — it is not a no-op.
+- **`Cargo.lock` IS a version-bearing file, but it is gitignored**: every `vibesql-*` workspace crate has an entry in `Cargo.lock`, so `cargo update -w` is required after bumping `Cargo.toml` — it is not a no-op. However, `Cargo.lock` is gitignored in this repo (regenerated locally), so `commit_and_tag` does NOT stage or commit it; only the four tracked sources (`Cargo.toml`, member `vibesql-*` pins, both pyprojects) are committed atomically.
 - **Web demo and dashboard data are separate**: `make website` + `wrangler deploy` are NOT part of the release tag flow — they run after to refresh the public dashboard.
 - **Do not auto-publish to extra registries.** This skill only triggers what the existing workflows do. If the operator later adds a Homebrew formula, npm package, etc., that's a separate manual step.

--- a/.loom/context/topics/release.md
+++ b/.loom/context/topics/release.md
@@ -6,18 +6,9 @@ Procedural overrides target the named extension points the default skill exposes
 
 ## Advisory reminders (any phase)
 
-### Pre-flight: four version-bearing files must agree
+### Pre-flight: four version-bearing files
 
-VibeSQL has four version-bearing files. The default's Phase 2a tool detection finds `./scripts/version.sh` first; `scripts/version.sh check` verifies the workspace Cargo files but does NOT check the two pyproject files. Run this Phase 1 sanity check in addition to whatever the default does:
-
-```bash
-grep -m1 '^version' Cargo.toml
-grep -m1 '^version' pyproject.toml
-grep -m1 '^version' crates/vibesql-python-bindings/pyproject.toml
-grep -A1 '^name = "vibesql"' Cargo.lock | grep '^version' | sort -u
-```
-
-All four must report the same version. Stop and resolve drift before bumping.
+VibeSQL has four version-bearing file groups: `Cargo.toml` (workspace.package + member-crate internal `vibesql-*` pins), `pyproject.toml` (root), `crates/vibesql-python-bindings/pyproject.toml`, and `Cargo.lock`. `scripts/version.sh check` (invoked automatically by the default Phase 5 verify step) covers all of them. Drift surfaces as a non-zero exit and a `DRIFT: …` line per offending file — stop and resolve before bumping.
 
 ### Pre-flight: CI gating policy
 
@@ -48,21 +39,11 @@ VibeSQL is **pre-1.0**, so MAJOR/MINOR semantics are looser. Treat `0.X.0` as "m
 
 **PATCH bump**: Bug fixes; performance improvements with no semantic change; internal refactors; docs/CLAUDE.md/README updates; dependency bumps; test additions; web demo updates.
 
-### Phase 5: scripts/version.sh interface gap
+### Phase 5: scripts/version.sh implements the v0.10.4 contract
 
-VibeSQL's `scripts/version.sh` exposes `set X.Y.Z [--tag]` and `check`, but **not** the `bump <level>` / `list` subcommands the v0.10.4 default's Phase 5 dispatches to. Workaround until version.sh is extended:
+`scripts/version.sh` exposes `show` / `list` / `check` / `bump <level> [--tag]` / `set <X.Y.Z> [--tag]` per the contract documented in the default skill's "scripts/version.sh interface" section. `bump`/`set` touch all four version-bearing files atomically (workspace.package + member-crate `vibesql-*` pins + both pyprojects + `cargo update -w` to refresh `Cargo.lock`), so Phase 5's auto-dispatch (`./scripts/version.sh bump <level> --tag`) drives the entire bump without operator intervention.
 
-1. Operator manually runs `./scripts/version.sh set <X.Y.Z>` (handles workspace.package version + internal `vibesql-*` dependency pins).
-2. Operator manually bumps the two pyproject files (version.sh doesn't touch them):
-   ```bash
-   sed -i '' 's/^version = ".*"/version = "<X.Y.Z>"/' pyproject.toml
-   sed -i '' 's/^version = ".*"/version = "<X.Y.Z>"/' crates/vibesql-python-bindings/pyproject.toml
-   ```
-3. Refresh Cargo.lock: `cargo update -w`
-4. Verify all four sources agree (see "Pre-flight" above).
-5. Commit + tag (the snippet at the end of the default's Phase 5).
-
-**DO NOT bump** `crates/vibesql-sqllogictest/Cargo.toml` (pinned to upstream sqllogictest's `0.28.x`) or `web-demo/package.json` (independent version line). Confirm explicitly if the operator wants those changed.
+**DO NOT bump** `crates/vibesql-sqllogictest/Cargo.toml` (pinned to upstream sqllogictest's `0.28.x`) or `web-demo/package.json` (independent version line). The bump script intentionally leaves them alone. If the operator wants either changed, that's a separate decision.
 
 ## Procedural overrides at named seams
 

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -19,6 +19,10 @@
 #   4. crates/vibesql-python-bindings/pyproject.toml       (Python bindings manifest)
 #   5. Cargo.lock                                          (refreshed via `cargo update -w`)
 #
+# NOTE: Cargo.lock is gitignored in this repo — it is regenerated locally and is
+# NOT staged or committed by `commit_and_tag`. Files 1-4 are the tracked version
+# sources committed atomically by the `--tag`/commit path.
+#
 # NOTE: pushing a v* tag triggers .github/workflows/release-crates.yml and
 # release-pypi.yml (publishes to crates.io / PyPI). `--tag` only creates the
 # tag locally; push it deliberately with: git push origin vX.Y.Z
@@ -176,8 +180,12 @@ commit_and_tag() {
   local new="$1"
   local want_tag="$2"
   cd "$REPO_ROOT"
+  # Cargo.lock is intentionally omitted: it is gitignored in this repo (regenerated
+  # locally via `cargo update -w`, never committed). Adding it here would make
+  # `git add` exit non-zero on the ignored path and abort the script under
+  # `set -euo pipefail` before the commit/tag runs.
   git add Cargo.toml crates/*/Cargo.toml pyproject.toml \
-    crates/vibesql-python-bindings/pyproject.toml Cargo.lock
+    crates/vibesql-python-bindings/pyproject.toml
   git commit -m "chore(release): prepare v$new release"
   if [[ "$want_tag" == "--tag" ]]; then
     git tag "v$new"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,27 +1,48 @@
 #!/usr/bin/env bash
-# version.sh - Manage version across all VibeSQL workspace manifests
+# version.sh - Manage version across all VibeSQL version-bearing files
+#
+# Implements the contract documented in `.claude/commands/loom/release.md`
+# ("scripts/version.sh interface" section) so /loom:release's Phase 2a detection
+# and Phase 5 dispatch drive the bump fully without operator intervention.
 #
 # Usage:
-#   ./scripts/version.sh                    # Show current version
-#   ./scripts/version.sh check              # Verify all manifests are in sync
-#   ./scripts/version.sh set 0.1.5          # Set explicit version
-#   ./scripts/version.sh set 0.1.5 --tag    # Set version, commit, and tag
+#   ./scripts/version.sh                              # Show current version
+#   ./scripts/version.sh list                         # List version-bearing files (one per line)
+#   ./scripts/version.sh check                        # Verify all version-bearing files agree
+#   ./scripts/version.sh bump <level> [--tag]         # Bump (patch/minor/major), commit, optionally tag
+#   ./scripts/version.sh set <X.Y.Z> [--tag]          # Set explicit version, commit, optionally tag
 #
-# Covers [workspace.package] version in the root Cargo.toml and every
-# internal `vibesql-* = { version = "X.Y.Z", ... }` dependency pin in the
-# root and per-crate manifests (crates.io requires explicit versions on
-# path dependencies at publish time).
+# Version-bearing files (all updated atomically by `set` / `bump`):
+#   1. Cargo.toml                                          ([workspace.package] version)
+#   2. crates/*/Cargo.toml                                 (internal `vibesql-* = { version = ... }` pins)
+#   3. pyproject.toml                                      (root, drives the `vibesql` PyPI wheel)
+#   4. crates/vibesql-python-bindings/pyproject.toml       (Python bindings manifest)
+#   5. Cargo.lock                                          (refreshed via `cargo update -w`)
 #
 # NOTE: pushing a v* tag triggers .github/workflows/release-crates.yml and
 # release-pypi.yml (publishes to crates.io / PyPI). `--tag` only creates the
 # tag locally; push it deliberately with: git push origin vX.Y.Z
+#
+# DO NOT bump:
+#   - crates/vibesql-sqllogictest/Cargo.toml (pinned to upstream sqllogictest 0.28.x)
+#   - web-demo/package.json (tracks its own version independently)
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
-manifest_files() {
+# Cargo workspace + member manifests (where workspace.package version + internal pins live).
+cargo_manifest_files() {
   echo "$REPO_ROOT/Cargo.toml"
   ls "$REPO_ROOT"/crates/*/Cargo.toml
+}
+
+# All version-bearing files, one per line. Consumed by `/loom:release` Phase 5 step 2.
+list_files() {
+  echo "$REPO_ROOT/Cargo.toml"
+  ls "$REPO_ROOT"/crates/*/Cargo.toml
+  echo "$REPO_ROOT/pyproject.toml"
+  echo "$REPO_ROOT/crates/vibesql-python-bindings/pyproject.toml"
+  echo "$REPO_ROOT/Cargo.lock"
 }
 
 get_version() {
@@ -32,10 +53,29 @@ get_version() {
     | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'
 }
 
+# Pull the `version = "X.Y.Z"` line from a pyproject.toml-style file.
+get_pyproject_version() {
+  local file="$1"
+  grep -m1 -E '^version = "[0-9]+\.[0-9]+\.[0-9]+"' "$file" \
+    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'
+}
+
+# Pull the version field for a named package from Cargo.lock.
+get_cargo_lock_version() {
+  local pkg="$1"
+  awk -v pkg="$pkg" '
+    /^\[\[package\]\]/ { in_pkg=0; name=""; next }
+    /^name = / { gsub(/"/, "", $3); name=$3; if (name == pkg) in_pkg=1; next }
+    in_pkg && /^version = / { gsub(/"/, "", $3); print $3; exit }
+  ' "$REPO_ROOT/Cargo.lock"
+}
+
 check_versions() {
   local expected
   expected=$(get_version)
   local all_match=true
+
+  # Cargo manifests: workspace.package version + internal `vibesql-*` dep pins.
   while IFS= read -r file; do
     local rel="${file#"$REPO_ROOT"/}"
     local stray
@@ -51,34 +91,142 @@ check_versions() {
       count=$(grep -cE 'vibesql-[a-z0-9-]+ = \{ version = "' "$file" || true)
       printf "  %-50s %s (%s internal pins)\n" "$rel" "$expected" "$count"
     fi
-  done < <(manifest_files)
+  done < <(cargo_manifest_files)
+
+  # pyproject.toml (root) — drives the `vibesql` PyPI wheel.
+  local py_root
+  py_root=$(get_pyproject_version "$REPO_ROOT/pyproject.toml" || true)
+  if [[ "$py_root" != "$expected" ]]; then
+    printf "  %-50s DRIFT: %s (expected %s)\n" "pyproject.toml" "$py_root" "$expected" >&2
+    all_match=false
+  else
+    printf "  %-50s %s (root pyproject)\n" "pyproject.toml" "$py_root"
+  fi
+
+  # crates/vibesql-python-bindings/pyproject.toml.
+  local py_bind
+  py_bind=$(get_pyproject_version "$REPO_ROOT/crates/vibesql-python-bindings/pyproject.toml" || true)
+  if [[ "$py_bind" != "$expected" ]]; then
+    printf "  %-50s DRIFT: %s (expected %s)\n" \
+      "crates/vibesql-python-bindings/pyproject.toml" "$py_bind" "$expected" >&2
+    all_match=false
+  else
+    printf "  %-50s %s (python bindings)\n" \
+      "crates/vibesql-python-bindings/pyproject.toml" "$py_bind"
+  fi
+
+  # Cargo.lock — every `vibesql-*` workspace crate has an entry. Spot-check the
+  # top-level `vibesql` binary; if any internal crate drifted, `set_version`'s
+  # `cargo update -w` step is the recovery.
+  local lock_v
+  lock_v=$(get_cargo_lock_version "vibesql" || true)
+  if [[ "$lock_v" != "$expected" ]]; then
+    printf "  %-50s DRIFT: %s (expected %s)\n" "Cargo.lock (vibesql)" "$lock_v" "$expected" >&2
+    all_match=false
+  else
+    printf "  %-50s %s (Cargo.lock vibesql package)\n" "Cargo.lock" "$lock_v"
+  fi
+
   if [[ "$all_match" == "true" ]]; then
-    echo "All manifests in sync at $expected"
+    echo "All version-bearing files in sync at $expected"
   else
     echo "Version drift detected" >&2
     exit 1
   fi
 }
 
-set_version() {
+# Update version across all version-bearing files. Internal helper; called by
+# both `set` and `bump`. Does NOT commit or tag — the caller decides.
+write_version() {
   local new="$1"
   if [[ ! "$new" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "error: version must be X.Y.Z, got '$new'" >&2
     exit 2
   fi
-  # Root [workspace.package] version (anchored, see get_version).
+
+  # 1. Workspace.package version (anchored, see get_version).
   sed -i.bak -E 's/^version = "[0-9]+\.[0-9]+\.[0-9]+"$/version = "'"$new"'"/' "$REPO_ROOT/Cargo.toml"
   rm "$REPO_ROOT/Cargo.toml.bak"
-  # Internal dependency pins in every manifest.
+
+  # 2. Internal `vibesql-*` dependency pins in every Cargo manifest.
   while IFS= read -r file; do
     sed -i.bak -E 's/(vibesql-[a-z0-9-]+ = \{ version = ")[0-9]+\.[0-9]+\.[0-9]+(")/\1'"$new"'\2/' "$file"
     rm "$file.bak"
-  done < <(manifest_files)
-  echo "Set version to $new"
+  done < <(cargo_manifest_files)
+
+  # 3. Root pyproject.toml.
+  sed -i.bak -E 's/^version = "[0-9]+\.[0-9]+\.[0-9]+"/version = "'"$new"'"/' "$REPO_ROOT/pyproject.toml"
+  rm "$REPO_ROOT/pyproject.toml.bak"
+
+  # 4. Python-bindings pyproject.toml.
+  sed -i.bak -E 's/^version = "[0-9]+\.[0-9]+\.[0-9]+"/version = "'"$new"'"/' \
+    "$REPO_ROOT/crates/vibesql-python-bindings/pyproject.toml"
+  rm "$REPO_ROOT/crates/vibesql-python-bindings/pyproject.toml.bak"
+
+  # 5. Refresh Cargo.lock so every `vibesql-*` workspace crate picks up the new version.
+  # Run from REPO_ROOT so cargo finds the workspace manifest.
+  (cd "$REPO_ROOT" && cargo update -w >/dev/null 2>&1) \
+    || { echo "error: 'cargo update -w' failed" >&2; exit 3; }
+
+  echo "Set version to $new across $(list_files | wc -l | tr -d ' ') file(s)"
+}
+
+# Commit + (optionally) tag the version bump. Mirrors the prior --tag semantics.
+commit_and_tag() {
+  local new="$1"
+  local want_tag="$2"
+  cd "$REPO_ROOT"
+  git add Cargo.toml crates/*/Cargo.toml pyproject.toml \
+    crates/vibesql-python-bindings/pyproject.toml Cargo.lock
+  git commit -m "chore(release): prepare v$new release"
+  if [[ "$want_tag" == "--tag" ]]; then
+    git tag "v$new"
+    echo "Committed and tagged v$new (local only)"
+    echo "Push deliberately to trigger crates.io/PyPI release workflows:"
+    echo "  git push origin HEAD && git push origin v$new"
+  else
+    echo "Committed v$new (local only, no tag created)"
+  fi
+}
+
+set_version() {
+  local new="$1"
+  local tag_flag="${2:-}"
+  write_version "$new"
+  if [[ -n "$tag_flag" ]]; then
+    commit_and_tag "$new" "$tag_flag"
+  fi
+}
+
+# Compute the next semver from the current version + a bump level.
+next_version() {
+  local current="$1"
+  local level="$2"
+  local major minor patch
+  IFS='.' read -r major minor patch <<< "$current"
+  case "$level" in
+    major) major=$((major+1)); minor=0; patch=0 ;;
+    minor) minor=$((minor+1)); patch=0 ;;
+    patch) patch=$((patch+1)) ;;
+    *) echo "error: bump level must be patch|minor|major, got '$level'" >&2; exit 2 ;;
+  esac
+  echo "$major.$minor.$patch"
+}
+
+bump_version() {
+  local level="$1"
+  local tag_flag="${2:-}"
+  local current new
+  current=$(get_version)
+  new=$(next_version "$current" "$level")
+  echo "Bumping $current -> $new ($level)"
+  write_version "$new"
+  # `bump` always commits; `--tag` decides whether to also tag.
+  commit_and_tag "$new" "$tag_flag"
 }
 
 usage() {
-  sed -n '2,8p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
   exit 0
 }
 
@@ -86,21 +234,19 @@ case "${1:-show}" in
   show|"")
     get_version
     ;;
+  list)
+    list_files
+    ;;
   check)
     check_versions
     ;;
   set)
     new="${2:?usage: set X.Y.Z [--tag]}"
-    set_version "$new"
-    if [[ "${3:-}" == "--tag" ]]; then
-      cd "$REPO_ROOT"
-      git add Cargo.toml crates/*/Cargo.toml
-      git commit -m "chore(release): prepare v$new release"
-      git tag "v$new"
-      echo "Committed and tagged v$new (local only)"
-      echo "Push deliberately to trigger crates.io/PyPI release workflows:"
-      echo "  git push origin HEAD && git push origin v$new"
-    fi
+    set_version "$new" "${3:-}"
+    ;;
+  bump)
+    level="${2:?usage: bump <patch|minor|major> [--tag]}"
+    bump_version "$level" "${3:-}"
     ;;
   -h|--help|help)
     usage


### PR DESCRIPTION
## Summary

The v0.10.4 `/loom:release` default skill (just installed via #5653) detects `./scripts/version.sh` first in its Phase 2a tool probe and then dispatches `list` / `check` / `bump <level> --tag` to whatever script wins detection. VibeSQL's script only had `show`, `check`, and `set X.Y.Z` — and `check` only covered the Cargo manifests. So today's `/loom:release` would error out at Phase 5 (`unknown command: bump`) and miss drift in `pyproject.toml` / `Cargo.lock`.

This PR closes that gap so vibesql's `/loom:release` runs end-to-end without operator-side workarounds, and removes the corresponding "Phase 5 workaround" section from `.loom/context/topics/release.md`.

## What changed

- `scripts/version.sh`
  - `list` — enumerates all 18 version-bearing files (workspace + 14 crate manifests + 2 pyprojects + Cargo.lock), one per line. Consumed by Phase 5 step 2.
  - `check` — extended to verify the two pyproject files and `Cargo.lock`'s `vibesql` package entry. Drift exits non-zero with `DRIFT: …` per file.
  - `bump <level> [--tag]` — new. Computes next semver from current workspace.package version (`patch`/`minor`/`major`), writes across all four sources, commits, optionally tags. Phase 5 auto-dispatch now drives the bump.
  - `set X.Y.Z [--tag]` — extended to also update root `pyproject.toml`, `crates/vibesql-python-bindings/pyproject.toml`, and finalize with `cargo update -w` so `Cargo.lock`'s `vibesql-*` entries pick up the new version.

- `.loom/context/topics/release.md`
  - Deleted the "Phase 5: scripts/version.sh interface gap" section (gap closed).
  - Trimmed the "Pre-flight: four version-bearing files must agree" check from inline grep to a one-liner noting `scripts/version.sh check` covers it.

## Verification

`set 0.2.99` round-trip:

```
$ ./scripts/version.sh set 0.2.99
Set version to 0.2.99 across 18 file(s)

$ ./scripts/version.sh check | tail -4
  pyproject.toml                                     0.2.99 (root pyproject)
  crates/vibesql-python-bindings/pyproject.toml      0.2.99 (python bindings)
  Cargo.lock                                         0.2.99 (Cargo.lock vibesql package)
All version-bearing files in sync at 0.2.99

$ ./scripts/version.sh set 0.2.0
Set version to 0.2.0 across 18 file(s)
# working tree clean afterward
```

`list` returns 18 files. `bump <level>` was code-reviewed but not exercised against a real bump (would commit + dirty the branch).

## Companion to v0.10.4

This is the vibesql-side counterpart to rjwalters/loom#3503 (Option B seam markers, shipped in v0.10.4 as PR rjwalters/loom#3506). With both landed, vibesql is a clean exemplar of loom's universal release system: generic skill prose + a project-side `scripts/version.sh` matching the documented contract + topics-injection for advisory reminders and seam-targeted procedural overrides.

## Test plan

- [ ] CI green
- [ ] (optional) Dry-run `/loom:release` against this branch to confirm Phase 2a detects `version.sh`, Phase 5 calls `bump`, and the topics file's seam overrides compose correctly