### PR TITLE
test(tcl): isolate transaction trial-check to stop pre-BEGIN DDL leak (select3)

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -1227,10 +1227,26 @@ proc trial_check_in_transaction {new_sql} {
     puts $f $combined
     close $f
 
+    # Run the trial against an isolated COPY of the shared database, never the
+    # real $::db_file. The trial appends a ROLLBACK so that statements *inside*
+    # the transaction leave nothing behind — but any statement that runs BEFORE
+    # the transaction's BEGIN (e.g. select3-1.0's `CREATE TABLE t1(...); BEGIN;`)
+    # auto-commits and is NOT undone by that ROLLBACK. Running the trial directly
+    # against $::db_file therefore leaks such pre-BEGIN DDL/DML into the shared
+    # file; the real batch (replayed at COMMIT) then re-issues the same
+    # `CREATE TABLE t1` and aborts with "table t1 already exists", cascading into
+    # empty results for every later test in the file (#5656). Operating on a
+    # throwaway copy gives identical error-detection behavior with zero
+    # persistent effect on the shared database.
     if {$::db_file eq ""} {
         catch {exec $::vibesql_path < $tmpfile 2>@1} result
     } else {
-        catch {exec $::vibesql_path $::db_file < $tmpfile 2>@1} result
+        set trial_db "/tmp/vibesql_trialdb_[pid]_[clock microseconds].vbsql"
+        if {[file exists $::db_file]} {
+            file copy -force $::db_file $trial_db
+        }
+        catch {exec $::vibesql_path $trial_db < $tmpfile 2>@1} result
+        file delete -force $trial_db
     }
     file delete -force $tmpfile
 


### PR DESCRIPTION
## Summary
`select3.test` reported 49 failing cases (30 under the current native-TCL run), all GROUP BY / aggregate queries returning empty or wrong results. The root cause was **not** in the executor or optimizer — the aggregate code paths produce SQLite-identical results when run directly. It was a setup cascade in the TCL test shim, matching hypothesis #3 in the issue (the `table t1 already exists` line).

`select3-1.0` does `CREATE TABLE t1(...); BEGIN;` and then accumulates `INSERT`s before `COMMIT`. The shim's `trial_check_in_transaction` re-executes the accumulated batch with an appended `ROLLBACK` to attribute per-statement errors to the right test — but it ran that trial **directly against the shared `$::db_file`**. The trailing `ROLLBACK` only undoes work done *inside* the transaction; the `CREATE TABLE t1` runs *before* `BEGIN`, so it auto-commits and survives the rollback. That leaked `t1` into the shared database. When the real batch replayed at `COMMIT`, its `CREATE TABLE t1` hit `table t1 already exists`, aborting the whole batch and leaving `t1` empty — cascading into empty/`{}` results for every later assertion in the file.

Fix: run the trial against a **throwaway copy** of the database. Error detection is identical (same starting state) but the trial now has zero persistent effect, so pre-BEGIN auto-committed statements no longer leak.

## Changes
- `scripts/tester_vibesql.tcl` — in `trial_check_in_transaction`, copy `$::db_file` to a unique trial db, run the trial there, and delete it (instead of mutating the shared db file directly).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `select3.test` failure count materially reduced (target <5) | ✅ | 30 failures → **0** (`63/63` pass, 27 skipped) |
| Each remaining failure fixed or classified | ✅ | No remaining `select3` failures |
| No regression in `make test-tcl` (baseline 87.7%, 134 fails) | ✅ | Improved to **87.9% / 104 fails** (−30, no regressions) |
| `table t1 already exists` confirmed not the table.test reload class | ✅ | It is the trial-check pre-BEGIN DDL leak, a distinct shim issue from #5624/#5632 |

## Test Plan
- `./scripts/tcltest test select3.test` → 63 passed, 0 failed (was 30 failed).
- `./scripts/tcltest run --priority 1` → 23335/26560 passed (87.9%), 104 failed, down from the 134-fail baseline. No file regressed.
- Verified directly that the GROUP BY/aggregate queries already returned SQLite-correct values on a fresh DB — confirming the executor was never at fault.
- Confirmed the lone `TIMEOUT` (`select9.test`) is pre-existing: it times out identically (300s) on the baseline shim with my change stashed, and `select9` contains only 3 transaction statements so the per-trial copy is not implicated.

Closes #5656