### PR TITLE
test(tcl): classify where9 EQP failures as real optimizer gaps and skip with follow-up

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -2495,6 +2495,10 @@ array set vibesql_skip_tests {
     where9-9.1 "Uses INDEXED BY hint - SQLite-specific"
     where9-10.1 "Uses INDEXED BY hint - SQLite-specific"
     where9-10.2 "Uses INDEXED BY hint - SQLite-specific"
+    where9-3.1 "Requires MULTI-INDEX OR optimization - real index-selection gap, tracked in #5668"
+    where9-3.2 "Requires MULTI-INDEX OR optimization - real index-selection gap, tracked in #5668"
+    where9-5.1 "Requires MULTI-INDEX OR optimization - real index-selection gap, tracked in #5668"
+    where9-5.3 "OR-aware index selection differs (t1c full scan vs SQLite t1b range) - real optimizer gap, tracked in #5668"
 
     func-10.1 "Uses testfunc - SQLite test extension"
     func-10.2 "Uses testfunc - SQLite test extension"


### PR DESCRIPTION
## Summary

Triage and resolve the `where9.test` EXPLAIN QUERY PLAN conformance failures (#5660). Per the issue's mandate, each EQP failure was **classified cosmetic-vs-real with live evidence before any change**. All four turned out to be **real index-selection gaps**, so the conformance noise is resolved via documented harness skips and the underlying optimizer work is split into follow-up #5668 — rather than forcing a risky optimizer change or chasing EQP text equality.

## Cosmetic vs Real classification (with evidence)

Live comparison: sqlite3 3.51.0 vs VibeSQL release, where9 schema. **Every VibeSQL query returns correct rows** — only the access path / plan differs.

| Test | SQLite plan | VibeSQL plan | Verdict |
|------|-------------|--------------|---------|
| where9-5.1 | `MULTI-INDEX OR` (union of `t1c (c=?)` + `t1d (d=?)`) | `SCAN t1 USING INDEX t1c` (single index, full scan) | **REAL** — no multi-index OR |
| where9-5.3 | `SEARCH t1 USING INDEX t1b (b>?)` (AND-clause range) | `SCAN t1 USING INDEX t1c` | **REAL** — OR-aware index-selection differs |
| where9-3.1 | `SEARCH t1 PK` + `MULTI-INDEX OR` on `t2` (`t2d`+`t2f`) | `SCAN t1` / `SCAN t2` (no index for OR join) | **REAL** — no multi-index OR |
| where9-3.2 | same as 3.1 with `LEFT-JOIN` | `SCAN t1` / `SCAN t2` | **REAL** — no multi-index OR |

**No cosmetic cases were found.** Each mismatch is a genuinely different chosen plan (different/no index, full scan vs range search vs index-union). EQP text normalization cannot make these match without first implementing the optimizer feature — which is exactly the "invent optimizer work" trap the issue warns against. where9-5.2 already passes (`SEARCH t1 USING INDEX t1b (b=?)`), confirming VibeSQL's EQP formatter itself is correct; the gap is purely plan quality.

## Changes

- `scripts/tester_vibesql.tcl`: add documented `vibesql_should_skip` entries for where9-3.1, 3.2, 5.1, 5.3, each explaining the real optimizer gap and pointing at follow-up #5668. This matches the existing pattern for engine-specific EQP differences in the same file. **No engine/optimizer code changed** — zero regression risk to query results.
- Filed **#5668** ("optimizer: MULTI-INDEX OR optimization and OR-aware index selection") capturing the real work: OR-by-union index evaluation, OR-aware cost model, and `MULTI-INDEX OR` EQP rendering, with the live evidence above.

## What was fixed vs deferred

- **Fixed (this PR):** conformance noise from the 4 EQP mismatches, via documented skips. where9 no longer reports EQP failures.
- **Deferred (#5668):** the actual MULTI-INDEX OR optimizer feature — substantial and risky, split out per the builder escape-hatch guidance.
- **Out of scope:** the remaining where9 failures (`Transaction already active`, cascading `no such table: t1`) are nested-BEGIN transaction issues owned by #5659 — not touched.

## Acceptance Criteria Verification

| Criterion (from #5660) | Status | Verification |
|------------------------|--------|--------------|
| Each EQP failure classified cosmetic-vs-real with evidence | ✅ | Table above; live sqlite3 vs VibeSQL EQP captured for all 4 |
| Cosmetic ones resolved via EQP normalization | ✅ (vacuously) | None were cosmetic; documented in PR |
| Real index-selection gaps fixed or split into follow-up | ✅ | Split into #5668 (risky optimizer work, not forced) |
| Do not blindly chase EQP text equality | ✅ | No engine change; no text-equality hack |

## Test Plan

- `./scripts/tcltest test where9.test`: the 4 EQP tests are now omitted (skipped 65→69); no EQP failures remain. Remaining 12 failures are all #5659's transaction/cascade cases.
- `./scripts/tcltest test where7.test`: 2007/2026 pass, 0 fail — confirms the skip-dict edit didn't break harness parsing.
- No Rust crates touched, so `cargo test` is N/A for this change; `cargo build --release` succeeds (used to capture EQP evidence).

Closes #5660