### PR TITLE
fix(executor): raise SQLite-compatible error on nested BEGIN

### DIFF
--- a/crates/vibesql-executor/src/tests/transaction_tests.rs
+++ b/crates/vibesql-executor/src/tests/transaction_tests.rs
@@ -45,7 +45,12 @@ fn test_begin_transaction_already_active() {
         &mut db,
     );
     assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("Transaction already active"));
+    // A nested BEGIN surfaces SQLite's user-facing wording rather than the
+    // internal storage "Transaction already active" message (#5659).
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "cannot start a transaction within a transaction"
+    );
 }
 
 #[test]

--- a/crates/vibesql-executor/src/transaction.rs
+++ b/crates/vibesql-executor/src/transaction.rs
@@ -26,7 +26,24 @@ impl BeginTransactionExecutor {
     pub fn execute(stmt: &BeginStmt, db: &mut Database) -> Result<String, ExecutorError> {
         let durability = convert_durability_hint(&stmt.durability);
         db.begin_transaction_with_durability(durability).map_err(|e| {
-            ExecutorError::StorageError(format!("Failed to begin transaction: {}", e))
+            // A BEGIN issued while a transaction is already open is a
+            // user-level error in SQLite, not an internal storage fault.
+            // SQLite raises SQLITE_ERROR with the message "cannot start a
+            // transaction within a transaction" (see vdbe.c OP_AutoCommit).
+            // Surface that wording verbatim instead of leaking the internal
+            // "Failed to begin transaction: Transaction error: Transaction
+            // already active" storage message (#5659).
+            if matches!(
+                e,
+                vibesql_storage::StorageError::TransactionError(ref m)
+                    if m == "Transaction already active"
+            ) {
+                ExecutorError::SqliteCompatError(
+                    "cannot start a transaction within a transaction".to_string(),
+                )
+            } else {
+                ExecutorError::StorageError(format!("Failed to begin transaction: {}", e))
+            }
         })?;
 
         let msg = match stmt.durability {

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -4207,6 +4207,63 @@ proc uses_sqlite_internals {script} {
 # Test execution commands
 #-----------------------------------------------------------------------------
 
+proc reconcile_skipped_txn_state {script} {
+    # Keep the shim's batched-transaction bookkeeping consistent when a test
+    # that would have closed an open transaction is SKIPPED (#5659).
+    #
+    # Background: because VibeSQL runs each batch as a fresh process, the shim
+    # accumulates everything between BEGIN and COMMIT/ROLLBACK in $::sql_batch
+    # and replays it at the closing statement (see the transaction-batching
+    # block in execsql). where9.test interleaves transaction-mutating blocks
+    # with SELECT-then-ROLLBACK cleanup blocks, e.g.:
+    #
+    #   6.2.6  count_steps -- BEGIN; UPDATE ...      -- opens a txn
+    #   6.2.7  db eval     -- SELECT ...; ROLLBACK   -- closes it
+    #   6.2.8  count_steps -- BEGIN; DELETE ...      -- opens a txn
+    #
+    # 6.2.7 uses `db status sort`, so it is auto-skipped. Skipping it meant its
+    # ROLLBACK never ran, so ::in_transaction stayed 1 with the 6.2.6 BEGIN
+    # still batched. 6.2.8's BEGIN then trial-replayed two nested BEGINs, which
+    # VibeSQL rejected with "Transaction already active" -- cascading the
+    # failure into every subsequent transaction block in the file.
+    #
+    # The fix: if we are inside a batched transaction and the skipped script has
+    # a net transaction-closing effect (more COMMIT/END/ROLLBACK than BEGIN),
+    # apply that close to the shim state so the next BEGIN starts clean. We
+    # discard the pending batch (equivalent to ROLLBACK) rather than flush it:
+    # the skipped cleanup blocks in practice ROLLBACK, and discarding is the
+    # safe choice (a half-built transaction we chose not to run should not be
+    # committed).
+    if {!$::in_transaction} {
+        return
+    }
+
+    # Mask CREATE TRIGGER bodies so trigger BEGIN/END syntax is not miscounted
+    # as transaction control (mirrors the counting in execsql).
+    #
+    # NOTE: unlike execsql's counting (which sees the bare SQL string), the
+    # script here is the raw do_test body and still carries its db-eval /
+    # count_steps wrapper braces. A trailing transaction-control keyword with no
+    # terminating semicolon (the closing ROLLBACK before the wrapper's closing
+    # brace) is therefore NOT at end-of-string, so the trailing condition is
+    # relaxed to match a semicolon, surrounding whitespace, OR end-of-string --
+    # so the closing keyword is still counted. The leading anchor keeps it from
+    # matching substrings inside identifiers or string literals.
+    set count_sql [mask_trigger_bodies $script]
+    set begin_count [regexp -all -nocase \
+        {(?:^|;|\n)\s*BEGIN\s*(?:TRANSACTION|DEFERRED|IMMEDIATE|EXCLUSIVE|;|\s|$)} $count_sql]
+    set end_count [expr {[regexp -all -nocase \
+        {(?:^|;|\n)\s*(?:COMMIT|END)(?:\s+TRANSACTION)?\s*(?:;|\s|$)} $count_sql] + \
+        [regexp -all -nocase {(?:^|;|\n)\s*ROLLBACK\s*(?:;|\s|$)} $count_sql]}]
+
+    if {$end_count > $begin_count} {
+        # Net close: drop the in-flight batch and leave no open transaction.
+        set ::sql_batch {}
+        set ::in_transaction 0
+        set ::txn_had_tolerated_error 0
+    }
+}
+
 proc do_test {name script expected} {
     # Run a test and compare result to expected
 
@@ -4214,6 +4271,7 @@ proc do_test {name script expected} {
     # These are tests that verify SQLite-specific behavior we intentionally don't support
     set skip_check [vibesql_should_skip $name]
     if {[lindex $skip_check 0]} {
+        reconcile_skipped_txn_state $script
         omit_test $name [lindex $skip_check 1]
         return
     }
@@ -4237,6 +4295,7 @@ proc do_test {name script expected} {
             && [string trim $expected] eq ""
         }]
         if {!$is_conflict_setup} {
+            reconcile_skipped_txn_state $script
             omit_test $name $reason
             return
         }


### PR DESCRIPTION
## Summary
A `BEGIN` issued while a transaction is already open surfaced an internal storage error rather than SQLite's user-facing error. This was the clearest real bug in the where9.test Priority-1 set, where many transaction blocks failed with:

```
Got:      1 {Storage error: Failed to begin transaction: Transaction error: Transaction already active}
Expected: 0 {}
```

Investigation showed two layers:

1. **Engine (the issue's explicit ask):** `BeginTransactionExecutor::execute` wrapped any storage error as `Storage error: Failed to begin transaction: ...`. SQLite instead raises `SQLITE_ERROR` with `cannot start a transaction within a transaction` (vdbe.c `OP_AutoCommit`).

2. **Root cause of the where9 cascade (TCL shim):** the shim batches all SQL from `BEGIN` to `COMMIT`/`ROLLBACK` and replays it as one process (VibeSQL has no cross-process transaction state). When a test that *closes* an open transaction is auto-skipped, its `ROLLBACK` never runs, leaving the batched transaction open. The next `BEGIN` block then replays two nested `BEGIN`s and fails. Concretely, `where9-6.2.7` (`SELECT ...; ROLLBACK`) is auto-skipped for using `db status sort`, so the `6.2.6` BEGIN stayed open and `6.2.8`'s BEGIN nested on it.

## Changes
- `crates/vibesql-executor/src/transaction.rs`: detect the storage-layer `Transaction already active` error in `BeginTransactionExecutor::execute` and return `ExecutorError::SqliteCompatError("cannot start a transaction within a transaction")` (verbatim, no internal prefix). Other begin failures keep the existing `Failed to begin transaction: ...` wording.
- `crates/vibesql-executor/src/tests/transaction_tests.rs`: update `test_begin_transaction_already_active` to assert the exact SQLite-compatible message.
- `scripts/tester_vibesql.tcl`: add `reconcile_skipped_txn_state`, invoked before a test is omitted. If the shim is inside a batched transaction and the skipped script has a net transaction-closing effect (more `COMMIT`/`END`/`ROLLBACK` than `BEGIN`), it discards the pending batch and clears `::in_transaction` so the next `BEGIN` starts clean. The trailing-keyword match is relaxed to handle a closing `ROLLBACK` with no terminating semicolon inside a `db eval { ... }` wrapper.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Nested `BEGIN` produces SQLite-compatible behavior/error, not an internal storage error | done | `printf 'BEGIN;\nBEGIN;\n' \| vibesql` now reports `cannot start a transaction within a transaction`; unit test `test_begin_transaction_already_active` asserts the exact message |
| Affected where9 transaction cases pass | done | `6.2.8, 6.3.1, 6.3.3, 6.4.1, 6.4.3, 6.5.1, 6.5.3, 7.0` now pass (where9 went 7 to 16 passing); remaining `6.2.3` is a pre-existing batch-replay result discrepancy and `6.8.1/6.8.4` are `INDEXED BY` parse failures, both unrelated to nested BEGIN |
| No regression in transaction tests (`make test-tcl`) | done | Priority-1 suite: 88.1% (23394 passed, vs ~87.9% baseline); no new failures introduced |

## Test Plan
- `cargo test --release -p vibesql-executor transaction` — 22 passed, 0 failed (includes updated nested-BEGIN test).
- `./scripts/tcltest test where9.test` — transaction-nesting cascade resolved (16 passing, was 7).
- `make test-tcl` — 88.1% pass rate, no new regressions. The `TIMEOUT` and EQP-pattern (#5660) entries are pre-existing.
- Direct repro: nested `BEGIN` in the CLI now returns the SQLite message.

Note: where9 EQP-pattern failures (3.1, 3.2, 5.1, 5.3) are tracked separately in #5660 and are out of scope here.

Closes #5659