### PR TITLE
fix(parser): accept keywords as column names and NUMBER(p,s) in CREATE TABLE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ Cargo.lock
 # Claude Code
 .claude/settings.local.json
 
+# Loom worktree-ownership marker
+.loom-managed
+
 # Testing
 *.profdata
 *.profraw

--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,0 @@
-# Loom-managed worktree marker
-# Created by .loom/scripts/worktree.sh
-# Issue: 5661
-# Branch: feature/issue-5661
-# Removing this file makes Loom treat the worktree as user-owned and refuse
-# to clean it up automatically.

--- a/.loom-managed
+++ b/.loom-managed
@@ -1,0 +1,6 @@
+# Loom-managed worktree marker
+# Created by .loom/scripts/worktree.sh
+# Issue: 5661
+# Branch: feature/issue-5661
+# Removing this file makes Loom treat the worktree as user-owned and refuse
+# to clean it up automatically.

--- a/crates/vibesql-parser/src/arena_parser/update.rs
+++ b/crates/vibesql-parser/src/arena_parser/update.rs
@@ -162,13 +162,12 @@ impl<'arena> ArenaParser<'arena> {
                     self.advance();
                     self.intern(&col)
                 }
-                // SQLite allows updating the virtual rowid column
-                Token::Keyword { keyword: Keyword::Rowid, .. } => {
-                    self.advance();
-                    self.intern("rowid")
-                }
-                // Allow unreserved keywords as column names
-                Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                // SQLite compatibility: the left-hand side of a SET assignment is an
+                // unambiguous column-name position (it is followed by `=`), so any
+                // keyword here is an unquoted column name. This covers the virtual ROWID
+                // column and otherwise-reserved words like RELEASE used as column names
+                // (see table.test table-7.3). Normalize to lowercase.
+                Token::Keyword { keyword: kw, .. } => {
                     let col_name = format!("{}", kw).to_lowercase();
                     self.advance();
                     self.intern(&col_name)

--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -419,7 +419,7 @@ impl Parser {
                 }
                 Token::Keyword { keyword: Keyword::References, .. } => {
                     self.advance(); // consume REFERENCES
-                    // Accept both regular and quoted identifiers (e.g., REFERENCES t1, REFERENCES "t1")
+                                    // Accept both regular and quoted identifiers (e.g., REFERENCES t1, REFERENCES "t1")
                     let table = self.parse_identifier().map_err(|_| ParseError {
                         message: "Expected table name after REFERENCES".to_string(),
                     })?;
@@ -427,7 +427,7 @@ impl Parser {
                     // Column specification is optional in SQLite - defaults to PK
                     let column = if self.peek() == &Token::LParen {
                         self.advance(); // consume LParen
-                        // Accept both regular and quoted identifiers for column names
+                                        // Accept both regular and quoted identifiers for column names
                         let col_name = self.parse_identifier().map_err(|_| ParseError {
                             message: "Expected column name in REFERENCES".to_string(),
                         })?;

--- a/crates/vibesql-parser/src/parser/create/table.rs
+++ b/crates/vibesql-parser/src/parser/create/table.rs
@@ -104,9 +104,15 @@ impl Parser {
                     self.advance();
                     c
                 }
-                // Allow unreserved keywords (like TIMESTAMP, DATE, TIME, INTERVAL) as column names
-                // SQL:1999: normalize to lowercase when used as unquoted identifier
-                Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                // SQLite compatibility: at the start of a column definition, a keyword
+                // can only be a column name. Table-level constraint keywords (CONSTRAINT,
+                // PRIMARY, FOREIGN, UNIQUE, CHECK, FULLTEXT) are already consumed above,
+                // so any remaining keyword here is an unquoted column name. SQLite reserves
+                // very few words and accepts the rest as identifiers in this position,
+                // including DESC, ASC, KEY, BEGIN, END (see table.test table-7.x).
+                //
+                // SQL:1999: normalize to lowercase when used as an unquoted identifier.
+                Token::Keyword { keyword: kw, .. } => {
                     let col_name = format!("{}", kw).to_lowercase();
                     self.advance();
                     col_name

--- a/crates/vibesql-parser/src/parser/create/types.rs
+++ b/crates/vibesql-parser/src/parser/create/types.rs
@@ -717,14 +717,17 @@ impl Parser {
                     }
                 }
 
-                // Handle optional length specifier for multi-word types like
-                // NATIVE CHARACTER(70) or VARYING CHARACTER(255)
+                // Handle optional length/precision specifier for multi-word and
+                // unrecognized type names, e.g. NATIVE CHARACTER(70), VARYING
+                // CHARACTER(255), or Oracle/SQLite-style NUMBER(5,10). SQLite accepts
+                // any type name with an optional one- or two-argument size specifier and
+                // stores it by affinity only, so we validate (but discard) the numbers.
                 if matches!(self.peek(), Token::LParen) {
                     self.advance(); // consume (
                     match self.peek() {
                         Token::Number(n) => {
-                            // Validate and consume the length (we don't store it for
-                            // UserDefined types - affinity is what matters in SQLite)
+                            // Validate and consume the precision/length (we don't store it
+                            // for UserDefined types - affinity is what matters in SQLite)
                             let _ = n.parse::<usize>().map_err(|_| ParseError {
                                 message: format!("Invalid {} length", full_type_name),
                             })?;
@@ -734,6 +737,27 @@ impl Parser {
                             return Err(ParseError {
                                 message: format!("Expected number after {}(", full_type_name),
                             })
+                        }
+                    }
+                    // Optional second argument (scale), e.g. NUMBER(5,10) or DECIMAL(10,2)
+                    // spelled with an unrecognized type name.
+                    if matches!(self.peek(), Token::Comma) {
+                        self.advance(); // consume ,
+                        match self.peek() {
+                            Token::Number(n) => {
+                                let _ = n.parse::<usize>().map_err(|_| ParseError {
+                                    message: format!("Invalid {} scale", full_type_name),
+                                })?;
+                                self.advance();
+                            }
+                            _ => {
+                                return Err(ParseError {
+                                    message: format!(
+                                        "Expected scale after {}(precision,",
+                                        full_type_name
+                                    ),
+                                })
+                            }
                         }
                     }
                     self.expect_token(Token::RParen)?;

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -445,9 +445,7 @@ impl Parser {
     /// The error-message is required for ABORT/FAIL/ROLLBACK and forbidden for
     /// IGNORE (matching SQLite, which reports a `near ","`/`near ")"` syntax
     /// error for the mismatched forms).
-    fn parse_raise_expression(
-        &mut self,
-    ) -> Result<vibesql_ast::Expression, ParseError> {
+    fn parse_raise_expression(&mut self) -> Result<vibesql_ast::Expression, ParseError> {
         use vibesql_ast::RaiseAction;
 
         // SQLite only permits RAISE() inside a trigger-program (a

--- a/crates/vibesql-parser/src/parser/expressions/functions/window.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/window.rs
@@ -540,19 +540,21 @@ impl Parser {
                     let mut order_items = Vec::new();
                     loop {
                         let expr = self.parse_expression()?;
-                        let direction =
-                            if matches!(self.peek(), Token::Keyword { keyword: Keyword::Asc, .. }) {
-                                self.advance();
-                                vibesql_ast::OrderDirection::Asc
-                            } else if matches!(
-                                self.peek(),
-                                Token::Keyword { keyword: Keyword::Desc, .. }
-                            ) {
-                                self.advance();
-                                vibesql_ast::OrderDirection::Desc
-                            } else {
-                                vibesql_ast::OrderDirection::Asc
-                            };
+                        let direction = if matches!(
+                            self.peek(),
+                            Token::Keyword { keyword: Keyword::Asc, .. }
+                        ) {
+                            self.advance();
+                            vibesql_ast::OrderDirection::Asc
+                        } else if matches!(
+                            self.peek(),
+                            Token::Keyword { keyword: Keyword::Desc, .. }
+                        ) {
+                            self.advance();
+                            vibesql_ast::OrderDirection::Desc
+                        } else {
+                            vibesql_ast::OrderDirection::Asc
+                        };
 
                         // Window ORDER BY supports NULLS FIRST/LAST (SQL:2003).
                         let nulls_order = if matches!(
@@ -560,10 +562,8 @@ impl Parser {
                             Token::Keyword { keyword: Keyword::Nulls, .. }
                         ) {
                             self.advance(); // consume NULLS
-                            if matches!(
-                                self.peek(),
-                                Token::Keyword { keyword: Keyword::First, .. }
-                            ) {
+                            if matches!(self.peek(), Token::Keyword { keyword: Keyword::First, .. })
+                            {
                                 self.advance();
                                 Some(vibesql_ast::NullsOrder::First)
                             } else if matches!(

--- a/crates/vibesql-parser/src/parser/index.rs
+++ b/crates/vibesql-parser/src/parser/index.rs
@@ -408,9 +408,7 @@ impl Parser {
     /// Emits SQLite's canonical error string `unsupported use of NULLS FIRST`
     /// or `unsupported use of NULLS LAST` so the TCL test suite's
     /// error-message assertions match (nulls1.test 3.1.*).
-    pub(in crate::parser) fn reject_nulls_in_index_position(
-        &mut self,
-    ) -> Result<(), ParseError> {
+    pub(in crate::parser) fn reject_nulls_in_index_position(&mut self) -> Result<(), ParseError> {
         if self.peek_keyword(Keyword::Nulls) {
             self.advance(); // consume NULLS
             let position = if self.peek_keyword(Keyword::First) {
@@ -422,9 +420,7 @@ impl Parser {
                     message: "Expected FIRST or LAST after NULLS".to_string(),
                 });
             };
-            return Err(ParseError {
-                message: format!("unsupported use of NULLS {}", position),
-            });
+            return Err(ParseError { message: format!("unsupported use of NULLS {}", position) });
         }
         Ok(())
     }

--- a/crates/vibesql-parser/src/parser/insert.rs
+++ b/crates/vibesql-parser/src/parser/insert.rs
@@ -52,13 +52,11 @@ impl Parser {
                     p.advance();
                     Ok(name)
                 }
-                // SQLite allows inserting into the virtual rowid column
-                Token::Keyword { keyword: Keyword::Rowid, .. } => {
-                    p.advance();
-                    Ok("rowid".to_string())
-                }
-                // Allow unreserved keywords as column names
-                Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                // SQLite compatibility: inside an INSERT column list `( ... )` any
+                // keyword is an unquoted column name (this includes the virtual ROWID
+                // column and otherwise-reserved words like RELEASE, BEGIN, END used as
+                // column names — see table.test table-7.3). Normalize to lowercase.
+                Token::Keyword { keyword: kw, .. } => {
                     let name = format!("{}", kw).to_lowercase();
                     p.advance();
                     Ok(name)
@@ -194,13 +192,11 @@ impl Parser {
                     p.advance();
                     Ok(name)
                 }
-                // SQLite allows inserting into the virtual rowid column
-                Token::Keyword { keyword: Keyword::Rowid, .. } => {
-                    p.advance();
-                    Ok("rowid".to_string())
-                }
-                // Allow unreserved keywords as column names
-                Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                // SQLite compatibility: inside an INSERT column list `( ... )` any
+                // keyword is an unquoted column name (this includes the virtual ROWID
+                // column and otherwise-reserved words like RELEASE, BEGIN, END used as
+                // column names — see table.test table-7.3). Normalize to lowercase.
+                Token::Keyword { keyword: kw, .. } => {
                     let name = format!("{}", kw).to_lowercase();
                     p.advance();
                     Ok(name)
@@ -303,13 +299,11 @@ impl Parser {
                     p.advance();
                     Ok(name)
                 }
-                // SQLite allows inserting into the virtual rowid column
-                Token::Keyword { keyword: Keyword::Rowid, .. } => {
-                    p.advance();
-                    Ok("rowid".to_string())
-                }
-                // Allow unreserved keywords as column names
-                Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                // SQLite compatibility: inside an INSERT column list `( ... )` any
+                // keyword is an unquoted column name (this includes the virtual ROWID
+                // column and otherwise-reserved words like RELEASE, BEGIN, END used as
+                // column names — see table.test table-7.3). Normalize to lowercase.
+                Token::Keyword { keyword: kw, .. } => {
                     let name = format!("{}", kw).to_lowercase();
                     p.advance();
                     Ok(name)

--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -96,14 +96,7 @@ impl Parser {
     /// with its original quoting), which SQLite preserves in some error
     /// messages.
     pub fn new_with_source(tokens: Vec<Token>, spans: Vec<Span>, source: String) -> Self {
-        Parser {
-            tokens,
-            position: 0,
-            placeholder_count: 0,
-            in_trigger_body: false,
-            source,
-            spans,
-        }
+        Parser { tokens, position: 0, placeholder_count: 0, in_trigger_body: false, source, spans }
     }
 
     /// Current token index (cursor position within the token stream).
@@ -185,9 +178,7 @@ impl Parser {
     /// fire-time re-parse (`TriggerFirer::parse_trigger_sql`) must use this
     /// entry point so a trigger body containing `RAISE()` is admitted on both
     /// paths.
-    pub fn parse_sql_in_trigger_body(
-        input: &str,
-    ) -> Result<vibesql_ast::Statement, ParseError> {
+    pub fn parse_sql_in_trigger_body(input: &str) -> Result<vibesql_ast::Statement, ParseError> {
         let mut lexer = Lexer::new(input);
         let tokens_with_spans = lexer
             .tokenize_with_spans()

--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -214,9 +214,7 @@ impl Parser {
             // create time (triggerE-1.1.1: `WHEN new.a = ?`). NEW/OLD column
             // references are *not* variables and must still be allowed.
             if Self::expression_references_variable(&expr) {
-                return Err(ParseError {
-                    message: TRIGGER_CANNOT_USE_VARIABLES.to_string(),
-                });
+                return Err(ParseError { message: TRIGGER_CANNOT_USE_VARIABLES.to_string() });
             }
             Some(Box::new(expr))
         } else {
@@ -357,9 +355,7 @@ impl Parser {
         // every position is covered uniformly. NEW/OLD references tokenize as
         // ordinary identifiers, never as variable tokens, so they are not caught.
         if Self::trigger_body_text_references_variable(raw_sql) {
-            return Err(ParseError {
-                message: TRIGGER_CANNOT_USE_VARIABLES.to_string(),
-            });
+            return Err(ParseError { message: TRIGGER_CANNOT_USE_VARIABLES.to_string() });
         }
 
         for stmt_sql in crate::split_trigger_body_statements(raw_sql) {

--- a/crates/vibesql-parser/src/parser/update.rs
+++ b/crates/vibesql-parser/src/parser/update.rs
@@ -74,12 +74,12 @@ impl Parser {
                     c
                 }
                 // SQLite allows updating the virtual rowid column
-                Token::Keyword { keyword: Keyword::Rowid, .. } => {
-                    self.advance();
-                    "rowid".to_string()
-                }
-                // Allow unreserved keywords as column names
-                Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                // SQLite compatibility: the left-hand side of a SET assignment is an
+                // unambiguous column-name position (it is followed by `=`), so any
+                // keyword here is an unquoted column name. This covers the virtual ROWID
+                // column and otherwise-reserved words like RELEASE used as column names
+                // (see table.test table-7.3). Normalize to lowercase.
+                Token::Keyword { keyword: kw, .. } => {
                     let col_name = format!("{}", kw).to_lowercase();
                     self.advance();
                     col_name
@@ -232,12 +232,12 @@ impl Parser {
                     self.advance();
                     c
                 }
-                Token::Keyword { keyword: Keyword::Rowid, .. } => {
-                    self.advance();
-                    "rowid".to_string()
-                }
-                // Allow unreserved keywords as column names
-                Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+                // SQLite compatibility: the left-hand side of a SET assignment is an
+                // unambiguous column-name position (it is followed by `=`), so any
+                // keyword here is an unquoted column name. This covers the virtual ROWID
+                // column and otherwise-reserved words like RELEASE used as column names
+                // (see table.test table-7.3). Normalize to lowercase.
+                Token::Keyword { keyword: kw, .. } => {
                     let col_name = format!("{}", kw).to_lowercase();
                     self.advance();
                     col_name

--- a/crates/vibesql-parser/src/tests/create_table/basic.rs
+++ b/crates/vibesql-parser/src/tests/create_table/basic.rs
@@ -288,3 +288,48 @@ fn test_parse_create_table_as_select_captures_name_source() {
         _ => panic!("Expected CREATE TABLE statement"),
     }
 }
+
+/// SQLite accepts otherwise-reserved keywords as unquoted column names in a
+/// CREATE TABLE column list. Table-constraint keywords (PRIMARY, FOREIGN, ...)
+/// are consumed earlier, so any keyword in column-name position is an identifier.
+/// Regression test for issue #5661 (table.test table-7.x: `no such table: weird`).
+#[test]
+fn test_parse_create_table_keyword_column_names() {
+    // desc, asc, key, begin, end are all keywords but valid SQLite column names.
+    let sql = "CREATE TABLE weird(desc text, asc text, key int, begin blob, end clob)";
+    match Parser::parse_sql(sql).expect("keyword column names should parse") {
+        vibesql_ast::Statement::CreateTable(create) => {
+            let names: Vec<&str> = create.columns.iter().map(|c| c.name.as_str()).collect();
+            assert_eq!(names, vec!["desc", "asc", "key", "begin", "end"]);
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+/// SQLite accepts `release` (a keyword) as both a column name and a SET target.
+/// Regression test for issue #5661 (table.test table-7.3: `CREATE TABLE
+/// savepoint(release)` followed by INSERT/UPDATE on `release`).
+#[test]
+fn test_parse_keyword_column_in_insert_and_update() {
+    Parser::parse_sql("CREATE TABLE savepoint(release)")
+        .expect("keyword table and column names should parse");
+    Parser::parse_sql("INSERT INTO savepoint(release) VALUES(10)")
+        .expect("keyword column name in INSERT list should parse");
+    Parser::parse_sql("UPDATE savepoint SET release = 5")
+        .expect("keyword column name in SET clause should parse");
+}
+
+/// SQLite/Oracle-style `NUMBER(precision, scale)` (with an unrecognized type
+/// name carrying a two-argument size specifier) must parse. Regression test for
+/// issue #5661 (table.test table-11.x: `b number(5,10)` blocked `t7` creation).
+#[test]
+fn test_parse_create_table_number_precision_scale() {
+    let sql = "CREATE TABLE t7(a integer primary key, b number(5,10))";
+    match Parser::parse_sql(sql).expect("NUMBER(p,s) should parse") {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns.len(), 2);
+            assert_eq!(create.columns[1].name, "b");
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}

--- a/crates/vibesql-parser/src/tests/create_table/constraints_column.rs
+++ b/crates/vibesql-parser/src/tests/create_table/constraints_column.rs
@@ -578,12 +578,14 @@ fn test_parse_default_interleaved_with_constraints() {
         vibesql_ast::Statement::CreateTable(create) => {
             assert!(create.columns[0].default_value.is_some(), "DEFAULT 0 should be captured");
             // NOT NULL + CHECK should both appear as constraints
-            assert!(create.columns[0].constraints.iter().any(
-                |c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::NotNull)
-            ));
-            assert!(create.columns[0].constraints.iter().any(
-                |c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::Check(_))
-            ));
+            assert!(create.columns[0]
+                .constraints
+                .iter()
+                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::NotNull)));
+            assert!(create.columns[0]
+                .constraints
+                .iter()
+                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::Check(_))));
         }
         _ => panic!("Expected CREATE TABLE statement"),
     }

--- a/crates/vibesql-parser/src/tests/trigger.rs
+++ b/crates/vibesql-parser/src/tests/trigger.rs
@@ -653,8 +653,7 @@ fn test_create_trigger_with_temp_schema_qualifier() {
 #[test]
 fn test_create_temp_trigger_if_not_exists_sets_schema() {
     // TEMP modifier + IF NOT EXISTS: both flags set, schema is temp.
-    let sql =
-        "CREATE TEMP TRIGGER IF NOT EXISTS r1 AFTER INSERT ON t1 BEGIN SELECT 1; END;";
+    let sql = "CREATE TEMP TRIGGER IF NOT EXISTS r1 AFTER INSERT ON t1 BEGIN SELECT 1; END;";
     match Parser::parse_sql(sql).expect("parse") {
         Statement::CreateTrigger(trigger) => {
             assert_eq!(trigger.trigger_name, "r1");
@@ -818,7 +817,11 @@ fn test_create_trigger_body_case_end_not_treated_as_body_terminator() {
             TriggerAction::RawSql(body) => {
                 let up = body.to_uppercase();
                 // Both the CASE expression and the trailing INSERT survive.
-                assert!(up.contains("CASE"), "Body should retain the CASE expression. Got: {}", body);
+                assert!(
+                    up.contains("CASE"),
+                    "Body should retain the CASE expression. Got: {}",
+                    body
+                );
                 assert!(
                     up.contains("INSERT INTO BASE"),
                     "Body should retain the statement after the CASE...END. Got: {}",
@@ -840,11 +843,7 @@ fn test_create_trigger_body_multiple_case_expressions() {
                INSERT INTO log VALUES(CASE WHEN NEW.v > 0 THEN 'a' ELSE 'b' END); \
                END;";
     let result = Parser::parse_sql(sql);
-    assert!(
-        result.is_ok(),
-        "trigger body with multiple CASE...END must parse: {:?}",
-        result.err()
-    );
+    assert!(result.is_ok(), "trigger body with multiple CASE...END must parse: {:?}", result.err());
 }
 
 #[test]
@@ -860,11 +859,7 @@ fn test_create_trigger_body_nested_case_expressions() {
                INSERT INTO log VALUES('done'); \
                END;";
     let result = Parser::parse_sql(sql);
-    assert!(
-        result.is_ok(),
-        "trigger body with nested CASE...END must parse: {:?}",
-        result.err()
-    );
+    assert!(result.is_ok(), "trigger body with nested CASE...END must parse: {:?}", result.err());
 
     match result.unwrap() {
         Statement::CreateTrigger(trigger) => match &trigger.triggered_action {
@@ -889,11 +884,7 @@ fn test_create_trigger_body_case_in_where_clause() {
                INSERT INTO log VALUES('w'); \
                END;";
     let result = Parser::parse_sql(sql);
-    assert!(
-        result.is_ok(),
-        "trigger body with CASE...END in WHERE must parse: {:?}",
-        result.err()
-    );
+    assert!(result.is_ok(), "trigger body with CASE...END in WHERE must parse: {:?}", result.err());
 }
 
 #[test]
@@ -926,11 +917,7 @@ const TRIGGER_VAR_ERR: &str = "trigger cannot use variables";
 fn assert_rejected_as_variable(sql: &str) {
     let result = Parser::parse_sql(sql);
     let err = result.expect_err(&format!("expected rejection for: {sql}"));
-    assert_eq!(
-        err.message, TRIGGER_VAR_ERR,
-        "wrong message for: {sql}\n  got: {}",
-        err.message
-    );
+    assert_eq!(err.message, TRIGGER_VAR_ERR, "wrong message for: {sql}\n  got: {}", err.message);
 }
 
 fn assert_trigger_accepted(sql: &str) {
@@ -949,9 +936,7 @@ fn test_create_trigger_rejects_param_in_when_clause() {
 #[test]
 fn test_create_trigger_rejects_param_in_select_body() {
     // triggerE-1.1.2: SELECT ?
-    assert_rejected_as_variable(
-        "CREATE TRIGGER tr1 BEFORE DELETE ON t1 BEGIN SELECT ?; END;",
-    );
+    assert_rejected_as_variable("CREATE TRIGGER tr1 BEFORE DELETE ON t1 BEGIN SELECT ?; END;");
 }
 
 #[test]
@@ -1006,9 +991,7 @@ fn test_create_trigger_rejects_param_in_update_where() {
 #[test]
 fn test_create_trigger_rejects_param_in_function_arg() {
     // triggerE-1.1.10: function argument
-    assert_rejected_as_variable(
-        "CREATE TRIGGER tr1 AFTER INSERT ON t1 BEGIN SELECT abs(?); END;",
-    );
+    assert_rejected_as_variable("CREATE TRIGGER tr1 AFTER INSERT ON t1 BEGIN SELECT abs(?); END;");
 }
 
 #[test]
@@ -1107,36 +1090,32 @@ fn parse_trigger_name_source(sql: &str) -> (String, Option<String>) {
 
 #[test]
 fn test_name_source_unquoted() {
-    let (name, source) = parse_trigger_name_source(
-        "CREATE TRIGGER tr1 DELETE ON t1 BEGIN SELECT 1; END;",
-    );
+    let (name, source) =
+        parse_trigger_name_source("CREATE TRIGGER tr1 DELETE ON t1 BEGIN SELECT 1; END;");
     assert_eq!(name, "tr1");
     assert_eq!(source.as_deref(), Some("tr1"));
 }
 
 #[test]
 fn test_name_source_double_quoted() {
-    let (name, source) = parse_trigger_name_source(
-        "CREATE TRIGGER \"tr1\" DELETE ON t1 BEGIN SELECT 1; END;",
-    );
+    let (name, source) =
+        parse_trigger_name_source("CREATE TRIGGER \"tr1\" DELETE ON t1 BEGIN SELECT 1; END;");
     assert_eq!(name, "tr1");
     assert_eq!(source.as_deref(), Some("\"tr1\""));
 }
 
 #[test]
 fn test_name_source_bracket_quoted() {
-    let (name, source) = parse_trigger_name_source(
-        "CREATE TRIGGER [tr1] DELETE ON t1 BEGIN SELECT 1; END;",
-    );
+    let (name, source) =
+        parse_trigger_name_source("CREATE TRIGGER [tr1] DELETE ON t1 BEGIN SELECT 1; END;");
     assert_eq!(name, "tr1");
     assert_eq!(source.as_deref(), Some("[tr1]"));
 }
 
 #[test]
 fn test_name_source_backtick_quoted() {
-    let (name, source) = parse_trigger_name_source(
-        "CREATE TRIGGER `tr1` DELETE ON t1 BEGIN SELECT 1; END;",
-    );
+    let (name, source) =
+        parse_trigger_name_source("CREATE TRIGGER `tr1` DELETE ON t1 BEGIN SELECT 1; END;");
     assert_eq!(name, "tr1");
     assert_eq!(source.as_deref(), Some("`tr1`"));
 }


### PR DESCRIPTION
## Summary
`table.test` cases that create tables with keyword/special-character columns failed with `no such table: ...` on a later reference. The root cause was **not** catalog identifier normalization (the original hypothesis) but **CREATE-time parse failures**: the parser rejected otherwise-reserved keywords as column names and could not parse `NUMBER(precision, scale)`. When the `CREATE TABLE` failed, the table was never created, so the next `SELECT`/`INSERT` surfaced as `no such table`.

## Root causes found
1. **Keywords as column names.** CREATE TABLE column lists, INSERT/REPLACE column lists, and UPDATE `SET` targets only accepted keywords gated by `Keyword::can_be_identifier()`. SQLite accepts essentially any keyword as a column name in these unambiguous identifier positions (e.g. `DESC`, `ASC`, `KEY`, `BEGIN`, `END`, `RELEASE`). `CREATE TABLE weird(desc text, ...)` failed to parse → `no such table: weird` (table-7.2/7.3/8.1).
2. **`NUMBER(p,s)` type.** The generic/unrecognized data-type path accepted only a single size argument, so `b number(5,10)` failed and blocked the enclosing `CREATE TABLE t7(...)` (table-11.x/12.1).

## Changes
- `create/table.rs`: accept any keyword as a column name (table-constraint keywords are already consumed before this point).
- `insert.rs`: accept any keyword in INSERT/REPLACE column lists (3 call sites).
- `update.rs` + `arena_parser/update.rs`: accept any keyword as a `SET` target.
- `create/types.rs`: accept an optional second `, scale` argument for unrecognized type names (`NUMBER(precision, scale)`).
- Added parser regression tests for keyword column names (CREATE/INSERT/UPDATE) and `NUMBER(p,s)`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Listed table-7.x/8.x/11.x/12.x cases pass | Partial | table-11.1/11.2/12.1 now pass. table-7.2/8.1/8.5/8.6 are now unblocked at the parse/catalog level (table is created and resolvable) but still fail on **downstream, separate-subsystem** behaviors — see below. |
| Round-trip: create with quoted/special name → query/insert/drop resolve | Yes | `CREATE TABLE savepoint(release); INSERT INTO savepoint(release) VALUES(10); UPDATE savepoint SET release = 5;` all parse and execute. `CREATE TABLE t2 AS SELECT * FROM weird; SELECT * FROM t2;` resolves (no `no such table`). |
| No `make test-tcl` regression | Yes | Aggregate failures dropped **104 → 54** (passed 23335 → 23385) on this branch vs. the prior baseline, recorded in the TCL results DB. No new failures attributable to these parser changes. |

## Scope note (follow-ups filed)
The "no such table" symptom is fully resolved at the parse/catalog layer. A few of the listed cases still fail on independent subsystems that are out of scope for an identifier/parse fix; tracked separately:
- #5670 — keywords not accepted as column references in SELECT/expression position (blocks table-7.3 `SELECT release FROM savepoint`).
- #5671 — BOOLEAN-declared column rejects integer inserts (SQLite affinity), blocks table-7.2/8.1/8.6 via the `weird` table.
- #5672 — `MIN`/`MAX` over a non-column expression unsupported, blocks table-8.3 → cascades to table-8.5.

## Test Plan
- `cargo test -p vibesql-parser` — 1452 + 200 create-table tests pass, including the new regression tests.
- `cargo clippy -p vibesql-parser` — no new warnings (two pre-existing, unrelated).
- `make test-tcl` — 104 → 54 failing tests; `table.test` 46 → 50 passing.
- Manual repro confirmed for `weird`, `savepoint(release)`, and `t7(... number(5,10) ...)`.

Closes #5661