### PR TITLE
fix(create-table,default): accept quoted/multi-arg type specs and scalar DEFAULT functions

### DIFF
--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -391,6 +391,16 @@ pub enum ExecutorError {
     NoSuchFunction {
         function_name: String,
     },
+    /// Unknown function used where it is not valid (SQLite-compatible error).
+    /// Format: "unknown function: X()"
+    ///
+    /// SQLite reports this when a function that is not a valid scalar function
+    /// (e.g. an aggregate such as `avg`/`count`, or a genuinely unknown name)
+    /// is referenced while materializing a DEFAULT value at INSERT time
+    /// (table-16.2 .. table-16.7).
+    UnknownFunction {
+        function_name: String,
+    },
     /// No such index (SQLite-compatible error, e.g. INDEXED BY with an
     /// unknown index or an index on a different table)
     /// Format: "no such index: X"
@@ -1327,6 +1337,10 @@ impl std::fmt::Display for ExecutorError {
                     "{}",
                     vibe_msg!("executor-no-such-function", function_name = function_name.as_str())
                 )
+            }
+            ExecutorError::UnknownFunction { function_name } => {
+                // SQLite-compatible: "unknown function: name()"
+                write!(f, "unknown function: {}()", function_name)
             }
             ExecutorError::NoSuchIndex { index_name } => {
                 // SQLite-compatible error message format

--- a/crates/vibesql-executor/src/evaluator/functions/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/mod.rs
@@ -313,6 +313,31 @@ pub(super) fn eval_scalar_function(
     }
 }
 
+/// Evaluate a scalar function for a DEFAULT expression at INSERT time.
+///
+/// DEFAULT expressions are materialized without a row/schema/database context,
+/// so only deterministic scalar functions whose arguments reduce to constants
+/// (e.g. `abs(1)`) are supported. Aggregate functions never reach this path:
+/// they parse as `Expression::AggregateFunction` and are rejected by the
+/// DEFAULT evaluator with an `unknown function` error (table-16.2 ..
+/// table-16.7), matching SQLite.
+///
+/// `schema_context` is `None` here because DEFAULT materialization is not a
+/// schema-attached context (CHECK/generated/index); the non-deterministic
+/// date/time guards do not apply.
+pub(crate) fn eval_scalar_function_for_default(
+    name: &str,
+    args: &[vibesql_types::SqlValue],
+) -> Result<vibesql_types::SqlValue, ExecutorError> {
+    eval_scalar_function(
+        name,
+        args,
+        &None,
+        &vibesql_types::SqlMode::default(),
+        super::SchemaExprContext::None,
+    )
+}
+
 /// Pins `eval_scalar_function`'s dispatch table against the central
 /// volatility classification in [`vibesql_ast::volatility`].
 ///

--- a/crates/vibesql-executor/src/insert/defaults.rs
+++ b/crates/vibesql-executor/src/insert/defaults.rs
@@ -172,7 +172,7 @@ pub fn evaluate_default_expression(
             let col_name = col_id.column_canonical();
             Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(col_name)))
         }
-        vibesql_ast::Expression::Function { name, .. } => {
+        vibesql_ast::Expression::Function { name, args, .. } => {
             // Evaluate special SQL functions that can be used in DEFAULT
             match name.to_uppercase().as_str() {
                 "CURRENT_DATE" => {
@@ -236,11 +236,40 @@ pub fn evaluate_default_expression(
                     // Return current role (placeholder - would come from session context)
                     Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("public")))
                 }
-                _ => Err(ExecutorError::UnsupportedExpression(format!(
-                    "Function '{}' not supported in DEFAULT expressions",
-                    name
-                ))),
+                _ => {
+                    // SQLite allows deterministic scalar functions in DEFAULT
+                    // clauses (e.g. `DEFAULT(abs(1))`, table-16.3). The value is
+                    // materialized at INSERT time, so the arguments must reduce
+                    // to constants. Evaluate each argument as a DEFAULT
+                    // sub-expression, then dispatch to the scalar function table.
+                    let mut arg_values = Vec::with_capacity(args.len());
+                    for arg in args {
+                        arg_values.push(evaluate_default_expression(arg)?);
+                    }
+                    crate::evaluator::functions::eval_scalar_function_for_default(
+                        name.display(),
+                        &arg_values,
+                    )
+                    .map_err(|err| match err {
+                        // A scalar function that does not exist surfaces as
+                        // SQLite's "unknown function: name()" in this
+                        // context rather than the generic "no such function".
+                        ExecutorError::NoSuchFunction { function_name } => {
+                            ExecutorError::UnknownFunction {
+                                function_name: function_name.to_lowercase(),
+                            }
+                        }
+                        other => other,
+                    })
+                }
             }
+        }
+        // Aggregate functions (COUNT, AVG, MIN, MAX, STRING_AGG, ...) are not
+        // valid in DEFAULT expressions. SQLite reports these as unknown
+        // functions when the default is materialized at INSERT time
+        // (table-16.2 max, 16.4 avg, 16.5 count, 16.6/16.7 string_agg).
+        vibesql_ast::Expression::AggregateFunction { name, .. } => {
+            Err(ExecutorError::UnknownFunction { function_name: name.canonical().to_string() })
         }
         // The parser represents bare `DEFAULT CURRENT_DATE` /
         // `CURRENT_TIME` / `CURRENT_TIMESTAMP` as dedicated AST variants
@@ -437,6 +466,57 @@ fn compute_next_integer_pk_value(
 
     // Return max + 1 (or 1 if table was empty, since max_val starts at 0)
     Ok(max_val + 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vibesql_ast::{Expression, FunctionIdentifier};
+    use vibesql_types::SqlValue;
+
+    fn int_lit(v: i64) -> Expression {
+        Expression::Literal(SqlValue::Integer(v))
+    }
+
+    #[test]
+    fn deterministic_scalar_function_evaluates_in_default() {
+        // table-16.3: DEFAULT(abs(1)) -> 1
+        let expr = Expression::Function {
+            name: FunctionIdentifier::new("abs"),
+            args: vec![int_lit(-1)],
+            character_unit: None,
+        };
+        let result = evaluate_default_expression(&expr).expect("abs(-1) should evaluate");
+        assert_eq!(result, SqlValue::Integer(1));
+    }
+
+    #[test]
+    fn aggregate_function_rejected_as_unknown_in_default() {
+        // table-16.4 / 16.5 / 16.6: aggregates surface as "unknown function: name()".
+        for name in ["avg", "count", "max", "string_agg"] {
+            let expr = Expression::AggregateFunction {
+                name: FunctionIdentifier::new(name),
+                distinct: false,
+                args: vec![int_lit(1)],
+                order_by: None,
+                filter: None,
+            };
+            let err =
+                evaluate_default_expression(&expr).expect_err("aggregate in DEFAULT should error");
+            assert_eq!(err.to_string(), format!("unknown function: {}()", name));
+        }
+    }
+
+    #[test]
+    fn unknown_scalar_function_reports_unknown_function() {
+        let expr = Expression::Function {
+            name: FunctionIdentifier::new("definitely_not_a_function"),
+            args: vec![],
+            character_unit: None,
+        };
+        let err = evaluate_default_expression(&expr).expect_err("unknown function should error");
+        assert_eq!(err.to_string(), "unknown function: definitely_not_a_function()");
+    }
 }
 
 /// Apply generated/computed column values

--- a/crates/vibesql-parser/src/parser/create/types.rs
+++ b/crates/vibesql-parser/src/parser/create/types.rs
@@ -19,6 +19,19 @@ impl Parser {
     pub(in crate::parser) fn parse_data_type_with_integer_flag(
         &mut self,
     ) -> Result<(vibesql_types::DataType, bool), ParseError> {
+        // A delimited (quoted/bracketed) type name is taken verbatim and treated
+        // as an opaque SQLite-style type whose storage is governed by affinity
+        // only. This covers `"col.1" [char.3]` and `f "VARCHAR (+1,-10, 5)"`
+        // (table-8.9, table-8.10), where the quoted text is the full type name.
+        if let Token::DelimitedIdentifier(name) = self.peek() {
+            let type_name = name.clone();
+            self.advance();
+            // A delimited identifier may still be followed by a size specifier,
+            // e.g. `"DECIMAL"(10,2)`. Consume and discard it (affinity only).
+            self.consume_optional_type_arg_list()?;
+            return Ok((vibesql_types::DataType::UserDefined { type_name }, false));
+        }
+
         // Get the type name from the token. Note that identifiers are already
         // normalized to lowercase by the lexer, so we use uppercase for matching
         // but store the lowercase form.
@@ -221,34 +234,16 @@ impl Parser {
             }
             "VARCHAR" => {
                 // Parse VARCHAR or VARCHAR(n) or VARCHAR(n CHARACTERS) or VARCHAR(n OCTETS)
-                // Length is optional - if not specified, defaults to None (unlimited)
+                // Length is optional - if not specified, defaults to None (unlimited).
+                //
+                // SQLite accepts arbitrary, possibly-signed, multi-argument size
+                // specifiers on any type name (e.g. VARCHAR(1,10), VARCHAR(+1,-10);
+                // table-8.10). The arguments are ignored for affinity, so we keep
+                // the first non-negative argument as the length (when present) and
+                // tolerantly skip the rest.
                 let max_length = if matches!(self.peek(), Token::LParen) {
-                    self.advance(); // consume LParen
-                    let len = match self.peek() {
-                        Token::Number(n) => {
-                            let len = n.parse::<usize>().map_err(|_| ParseError {
-                                message: "Invalid VARCHAR length".to_string(),
-                            })?;
-                            self.advance();
-                            len
-                        }
-                        _ => {
-                            return Err(ParseError {
-                                message: "Expected number after VARCHAR(".to_string(),
-                            })
-                        }
-                    };
-
-                    // Check for CHARACTERS or OCTETS modifier
-                    // For MVP, we accept both but treat them the same (as character count)
-                    if self.try_consume_keyword(Keyword::Characters)
-                        || self.try_consume_keyword(Keyword::Octets)
-                    {
-                        // Modifier consumed, continue
-                    }
-
-                    self.expect_token(Token::RParen)?;
-                    Some(len)
+                    let first = self.consume_optional_type_arg_list()?;
+                    first.and_then(|n| usize::try_from(n).ok())
                 } else {
                     None // No length specified, use default
                 };
@@ -720,52 +715,88 @@ impl Parser {
                 // Handle optional length/precision specifier for multi-word and
                 // unrecognized type names, e.g. NATIVE CHARACTER(70), VARYING
                 // CHARACTER(255), or Oracle/SQLite-style NUMBER(5,10). SQLite accepts
-                // any type name with an optional one- or two-argument size specifier and
-                // stores it by affinity only, so we validate (but discard) the numbers.
-                if matches!(self.peek(), Token::LParen) {
-                    self.advance(); // consume (
-                    match self.peek() {
-                        Token::Number(n) => {
-                            // Validate and consume the precision/length (we don't store it
-                            // for UserDefined types - affinity is what matters in SQLite)
-                            let _ = n.parse::<usize>().map_err(|_| ParseError {
-                                message: format!("Invalid {} length", full_type_name),
-                            })?;
-                            self.advance();
-                        }
-                        _ => {
-                            return Err(ParseError {
-                                message: format!("Expected number after {}(", full_type_name),
-                            })
-                        }
-                    }
-                    // Optional second argument (scale), e.g. NUMBER(5,10) or DECIMAL(10,2)
-                    // spelled with an unrecognized type name.
-                    if matches!(self.peek(), Token::Comma) {
-                        self.advance(); // consume ,
-                        match self.peek() {
-                            Token::Number(n) => {
-                                let _ = n.parse::<usize>().map_err(|_| ParseError {
-                                    message: format!("Invalid {} scale", full_type_name),
-                                })?;
-                                self.advance();
-                            }
-                            _ => {
-                                return Err(ParseError {
-                                    message: format!(
-                                        "Expected scale after {}(precision,",
-                                        full_type_name
-                                    ),
-                                })
-                            }
-                        }
-                    }
-                    self.expect_token(Token::RParen)?;
-                }
+                // any type name with an optional, possibly-signed, multi-argument size
+                // specifier and stores it by affinity only, so we discard the numbers.
+                self.consume_optional_type_arg_list()?;
 
                 Ok((vibesql_types::DataType::UserDefined { type_name: full_type_name }, false))
             }
         }
+    }
+
+    /// Consume an optional SQLite-style type size specifier and return the
+    /// first numeric argument (signed), if any.
+    ///
+    /// SQLite permits any type name to carry a parenthesized list of one or
+    /// more optionally-signed numeric arguments, e.g. `VARCHAR(1,10)`,
+    /// `VARCHAR(+1,-10)`, `NUMBER(5,10)` (table-8.10). The arguments do not
+    /// affect storage (affinity is derived from the type *name*), so callers
+    /// generally discard the result; `Varchar` keeps the first argument as a
+    /// best-effort declared length when it is non-negative.
+    ///
+    /// CHARACTERS / OCTETS unit modifiers (after a single argument) are also
+    /// accepted and discarded. If the next token is not `(`, this is a no-op
+    /// and returns `None`.
+    pub(in crate::parser) fn consume_optional_type_arg_list(
+        &mut self,
+    ) -> Result<Option<i64>, ParseError> {
+        if !matches!(self.peek(), Token::LParen) {
+            return Ok(None);
+        }
+        self.advance(); // consume (
+
+        let mut first: Option<i64> = None;
+
+        loop {
+            // Optional leading sign on the numeric argument.
+            let mut negate = false;
+            loop {
+                match self.peek() {
+                    Token::Symbol('+') => {
+                        self.advance();
+                    }
+                    Token::Symbol('-') => {
+                        negate = !negate;
+                        self.advance();
+                    }
+                    _ => break,
+                }
+            }
+
+            match self.peek() {
+                Token::Number(n) => {
+                    let value = n.parse::<i64>().map_err(|_| ParseError {
+                        message: format!("Invalid numeric type argument: {}", n),
+                    })?;
+                    let value = if negate { -value } else { value };
+                    if first.is_none() {
+                        first = Some(value);
+                    }
+                    self.advance();
+                }
+                _ => {
+                    return Err(ParseError {
+                        message: "Expected numeric type argument".to_string(),
+                    })
+                }
+            }
+
+            // CHARACTERS / OCTETS unit modifier (single-argument character types).
+            if self.try_consume_keyword(Keyword::Characters)
+                || self.try_consume_keyword(Keyword::Octets)
+            {
+                // Modifier consumed, continue.
+            }
+
+            if matches!(self.peek(), Token::Comma) {
+                self.advance(); // consume , and parse the next argument
+                continue;
+            }
+            break;
+        }
+
+        self.expect_token(Token::RParen)?;
+        Ok(first)
     }
 
     /// Parse interval field (YEAR, MONTH, DAY, HOUR, MINUTE, SECOND)

--- a/crates/vibesql-parser/src/tests/create_table/sqlite_type_aliases.rs
+++ b/crates/vibesql-parser/src/tests/create_table/sqlite_type_aliases.rs
@@ -215,3 +215,89 @@ fn test_multiple_columns_with_sqlite_types() {
         _ => panic!("Expected CREATE TABLE statement"),
     }
 }
+
+// ========================================================================
+// Multi-argument / signed type size specifiers (table-8.10)
+// ========================================================================
+// SQLite accepts arbitrary, possibly-signed, multi-argument size specifiers
+// on any type name. The arguments do not affect affinity; the type *name*
+// alone determines storage. See table.test table-8.10.
+
+#[test]
+fn test_parse_varchar_two_size_args() {
+    let result = Parser::parse_sql("CREATE TABLE t(c VARCHAR(1,10));");
+    assert!(result.is_ok(), "Should parse VARCHAR(1,10): {:?}", result.err());
+}
+
+#[test]
+fn test_parse_varchar_signed_size_args() {
+    let result = Parser::parse_sql("CREATE TABLE t(d VARCHAR(+1,-10), e VARCHAR (+1,-10));");
+    assert!(result.is_ok(), "Should parse signed VARCHAR size args: {:?}", result.err());
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns.len(), 2);
+            // Both remain TEXT-affinity VARCHAR regardless of the (ignored) args.
+            for col in &create.columns {
+                assert_eq!(col.data_type.sqlite_affinity(), vibesql_types::TypeAffinity::Text);
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_unknown_type_signed_size_args() {
+    // NUMBER(5,10)-style two-argument specifier on an unrecognized type name.
+    let result = Parser::parse_sql("CREATE TABLE t(a NUMBER(+5,-10));");
+    assert!(result.is_ok(), "Should parse NUMBER(+5,-10): {:?}", result.err());
+}
+
+// ========================================================================
+// Delimited (quoted / bracketed) type names (table-8.9, table-8.10)
+// ========================================================================
+// A quoted or bracketed type name is taken verbatim as an opaque SQLite-style
+// type whose storage is governed by affinity only.
+
+#[test]
+fn test_parse_bracket_quoted_type_name() {
+    // table-8.9: CREATE TABLE t10("col.1" [char.3])
+    let result = Parser::parse_sql(r#"CREATE TABLE t10("col.1" [char.3]);"#);
+    assert!(result.is_ok(), "Should parse bracketed type name: {:?}", result.err());
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.columns.len(), 1);
+            match &create.columns[0].data_type {
+                vibesql_types::DataType::UserDefined { type_name } => {
+                    assert_eq!(type_name, "char.3");
+                    // Contains "char" → TEXT affinity.
+                    assert_eq!(
+                        create.columns[0].data_type.sqlite_affinity(),
+                        vibesql_types::TypeAffinity::Text
+                    );
+                }
+                other => panic!("Expected UserDefined, got {:?}", other),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_double_quoted_type_name_with_args_in_text() {
+    // table-8.10: f "VARCHAR (+1,-10, 5)" — the entire parenthesized spec is
+    // inside the quotes, so it is a single verbatim type name.
+    let result = Parser::parse_sql(r#"CREATE TABLE t(f "VARCHAR (+1,-10, 5)");"#);
+    assert!(result.is_ok(), "Should parse quoted type name verbatim: {:?}", result.err());
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => match &create.columns[0].data_type {
+            vibesql_types::DataType::UserDefined { type_name } => {
+                assert_eq!(type_name, "VARCHAR (+1,-10, 5)");
+            }
+            other => panic!("Expected UserDefined, got {:?}", other),
+        },
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}


### PR DESCRIPTION
## Summary
Fixes three `table.test` conformance gaps in CREATE TABLE parsing and DEFAULT-expression evaluation (issue #5662), after re-baselining against `main` (PR #5674 already fixed table-11.1 / keywords-as-column / NUMBER(p,s)).

## Changes
**Parser — type specifiers (`crates/vibesql-parser/src/parser/create/types.rs`)**
- Accept delimited (bracket/double-quoted) type names verbatim as opaque SQLite-style types whose storage is affinity-only, e.g. `"col.1" [char.3]` and `f "VARCHAR (+1,-10, 5)"` (table-8.9, table-8.10).
- Accept arbitrary, possibly-signed, multi-argument type size specifiers on any type via a new `consume_optional_type_arg_list` helper, e.g. `VARCHAR(1,10)`, `VARCHAR(+1,-10)`, `VARCHAR (+1,-10)`, `NUMBER(+5,-10)` (table-8.10). This replaces the strict single-number VARCHAR parser and the two-number generic fall-through.

**DEFAULT expressions (`crates/vibesql-executor/src/insert/defaults.rs`, `evaluator/functions/mod.rs`, `errors.rs`)**
- Evaluate deterministic scalar functions in DEFAULT clauses (e.g. `DEFAULT(abs(1))`) by reducing constant arguments and dispatching to the scalar-function table (table-16.3).
- Reject aggregate functions (`COUNT`/`AVG`/`MIN`/`MAX`/`STRING_AGG`/…) and genuinely unknown functions with SQLite's `unknown function: name()` message, via a new `ExecutorError::UnknownFunction` variant (table-16.2, 16.4–16.7). Aggregates are distinguished structurally: the parser already lowers them to `Expression::AggregateFunction`, so `DEFAULT(max(1))` is rejected while `DEFAULT(abs(1))` evaluates.

Deliberately-rejected functions in DEFAULT: any function lowered to an aggregate (`count`, `sum`, `avg`, `total`, `min`/`max` with ≤1 arg, `group_concat`, `string_agg`, `json_group_array`), and any unknown scalar name — all surface as `unknown function: <name>()`, matching SQLite.

## Acceptance Criteria Verification
| Criterion | Status | Verification |
|-----------|--------|--------------|
| CREATE parser `near` syntax errors for table-8.9 / 8.10 eliminated | ✅ | Both now parse (no `Expected data type` / `near ","`); new parser unit tests in `sqlite_type_aliases.rs` |
| DEFAULT accepts deterministic scalar functions (≥ `abs`) | ✅ | table-16.3 passes; unit test `deterministic_scalar_function_evaluates_in_default` |
| Aggregates/unknown rejected with SQLite message | ✅ | table-16.2,16.4–16.7 pass; unit test `aggregate_function_rejected_as_unknown_in_default` |
| No `make test-tcl` regression | ✅ | Priority-1 suite 88.1% / 45 failures (down from ~54 baseline) |

## Test Plan
- `./scripts/tcltest test table.test`: 50 → 56 passing (the table-16.x DEFAULT family now passes; 8.9/8.10 parse cleanly).
- `cargo test -p vibesql-parser --lib` (1460 pass) and `-p vibesql-executor --lib` (2940 pass), including new targeted tests.
- Full Priority-1 `make test-tcl`: 88.1% pass, 45 failures (no regression).

## Coordination / out of scope
- **table-8.3** (`MIN/MAX not supported for expression aggregates` in CREATE TABLE AS SELECT) is left to **#5672**, which owns MIN/MAX over non-column expressions — a separate columnar-executor change. Not duplicated here.
- **table-7.3** (`CREATE TABLE savepoint(release)` → `near "release"`) is keyword-as-column in SELECT/expression position, owned by **#5670**. The CREATE half parses; the remaining error is in statement/expression position.
- table-8.9/8.10 now **parse** but do not yet fully pass because their assertions check CREATE-TABLE-AS-SELECT schema-text reconstruction (quoting + affinity-derived type names + exact formatting), a broader serialization feature shared with the already-failing table-8.1.1 / 8.3.1 / 12.2 family — out of scope for this issue's parser/DEFAULT gaps.

Closes #5662