### PR TITLE
fix(join): expand qualified wildcards correctly when SELECT order differs from FROM order

### DIFF
--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
@@ -359,10 +359,21 @@ impl SelectExecutor<'_> {
         } else {
             // No GROUP BY - convert to rows and apply projection
 
-            // Check if we need projection (i.e., not just SELECT *)
-            let is_select_star = stmt.select_list.iter().all(|item| {
-                matches!(item, SelectItem::Wildcard { .. } | SelectItem::QualifiedWildcard { .. })
-            });
+            // Check if we need projection.
+            //
+            // Only a plain unqualified `*` (one or more) may bypass projection
+            // and return the physical batch rows directly, because the physical
+            // row layout already matches `SELECT *` column order.
+            //
+            // A qualified wildcard (`t1.*`) must NOT bypass projection: it
+            // selects a subset of columns, and when the SELECT-list table order
+            // differs from the FROM/physical order, returning the raw physical
+            // row emits the wrong columns under the derived headers (#5665).
+            // Route any select list containing a qualified wildcard through
+            // `project_row_combined`, which resolves each table's columns by its
+            // actual start index in the combined schema.
+            let is_select_star =
+                stmt.select_list.iter().all(|item| matches!(item, SelectItem::Wildcard { .. }));
 
             if is_select_star {
                 // SELECT * - apply columnar deduplication if DISTINCT, then convert to rows


### PR DESCRIPTION
## Summary

`SELECT t1.*, t2.*` over a join projected the **wrong physical columns** under the right headers when the SELECT-list table order differed from the FROM-clause order, and a single `SELECT t1.*` emitted the full joined row instead of just that table's columns.

Root cause: the columnar join no-GROUP-BY path (`columnar_execution/join.rs`) computed `is_select_star` as "every select item is a wildcard **or qualified wildcard**" and, when true, returned the physical batch rows directly without projection. That bypass is only valid for an unqualified `*`, whose column order already matches the physical row layout. A qualified wildcard selects a subset of columns by table, so returning the raw physical row emits the wrong columns when SELECT order != FROM/physical order.

Example (FROM order `t2, t1`; SELECT order `t1, t2`):
```sql
SELECT t1.*, t2.* FROM t2 JOIN t1 ON b=c;
```
Before: header `a b c d`, values `(t2.c, t2.d, t1.a, t1.b)`. After: values correctly `(t1.a, t1.b, t2.c, t2.d)`, matching explicit `SELECT a,b,c,d`.

## Changes

- Restrict the columnar-join projection bypass to **unqualified `*` only**. Any select list containing a qualified wildcard now routes through `project_row_combined`, which resolves each table's columns by its actual start index in the combined schema — independent of SELECT-vs-FROM order. (`project_row_combined`'s qualified-wildcard arm was already correct; it just was not being reached.)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `SELECT t1.*, t2.*` projects correct columns regardless of SELECT-vs-FROM order (inner + outer) | ✅ | Manual repro on `JOIN` and `LEFT JOIN` with `FROM t2 .. t1`; values now match explicit `a,b,c,d`. 3-table out-of-order (`t3.*, t1.*, t2.*`) also verified. |
| `SELECT t1.*` projects only that table's columns | ✅ | Now returns 2 columns `a b` (was full 4-column row). |
| `join7-*.50` failures resolved | ✅ | `join7.test`: 300/300 passing (was failing the 6 `*.50` cases). |
| No regression in the join family / overall test-tcl | ✅ | Executor unit tests 2940/0. Remaining `join.test`/`join5.test` failures are pre-existing implementation-defined LEFT JOIN row ordering and EQP plan-string mismatches — explicitly out-of-scope per the issue. `SELECT *` still bypasses projection unchanged. |

## Test Plan

- `cargo build --release` + manual repro from the issue (inner join, left join, single `t1.*`, 3-table out-of-order).
- `./scripts/tcltest test join7.test` → 300/300.
- `cargo test --release -p vibesql-executor --lib` → 2940 passed, 0 failed.
- Spot-checked `select1-4` / `where` TCL families: no new failures.

Closes #5665