### PR TITLE
fix(parser): accept keywords as column refs and table names in expression position

### DIFF
--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -414,6 +414,116 @@ impl Keyword {
             Keyword::Returning
         )
     }
+
+    /// Returns true if this keyword may be used as an unquoted column reference
+    /// in **expression / primary position** (e.g. `SELECT release FROM t`,
+    /// `WHERE asc = 1`).
+    ///
+    /// SQLite reserves only a small set of words and accepts the rest as
+    /// identifiers when they appear where a column reference is expected. This
+    /// predicate models that behavior with a *denylist*: it accepts any keyword
+    /// EXCEPT the ones that must stay reserved as the start of an operand,
+    /// because allowing them there would create grammar ambiguity or mask
+    /// genuine syntax errors.
+    ///
+    /// The denylist intentionally covers three categories of keyword:
+    ///
+    /// 1. **Operators** consumed by the expression precedence cascade in
+    ///    *operator* position (`AND`, `OR`, `NOT`, `IN`, `BETWEEN`, `LIKE`,
+    ///    `GLOB`, `ESCAPE`, `IS`, `ISNULL`, `NOTNULL`, `COLLATE`, `DIV`,
+    ///    `ALL`/`ANY`/`SOME`, `AS`). These must never be reinterpreted as a
+    ///    column when an operand is expected.
+    /// 2. **Statement / clause structure** keywords that terminate or introduce
+    ///    a clause and which the expression caller relies on to STOP parsing
+    ///    (`SELECT`, `FROM`, `WHERE`, `GROUP`, `BY`, `HAVING`, `ORDER`,
+    ///    `LIMIT`, `OFFSET`, `WINDOW`, `UNION`, `INTERSECT`, `EXCEPT`, `INTO`,
+    ///    `VALUES`, `SET`, `ON`, `USING`, `JOIN` and its modifiers, the DML/DDL
+    ///    verbs, etc.).
+    /// 3. **Special primary forms / literals** that have dedicated parsing
+    ///    (`CASE`/`WHEN`/`THEN`/`ELSE`/`END`, `CAST`, `EXISTS`, `NULL`, `TRUE`,
+    ///    `FALSE`, `UNKNOWN`, the `CURRENT_*` constants, `DISTINCT`).
+    ///
+    /// Everything else — including otherwise-reserved column-name words like
+    /// `RELEASE`, `SAVEPOINT`, `KEY`, `ASC`, `DESC`, `BEGIN`, `COMMIT`,
+    /// `ROLLBACK`, `MATCH`, `COLUMN`, `INDEX`, ... — is accepted as a column
+    /// reference, matching SQLite (see table.test table-7.3).
+    pub fn can_be_identifier_in_expression(&self) -> bool {
+        // Words that already round-trip as identifiers in any position are a
+        // superset-safe shortcut.
+        if self.can_be_identifier() {
+            return true;
+        }
+
+        !matches!(
+            self,
+            // --- Category 1: operators (operator-position keywords) ---
+            Keyword::And
+                | Keyword::Or
+                | Keyword::Not
+                | Keyword::In
+                | Keyword::Between
+                | Keyword::Asymmetric
+                | Keyword::Symmetric
+                | Keyword::Like
+                | Keyword::Glob
+                | Keyword::Escape
+                | Keyword::Is
+                | Keyword::Isnull
+                | Keyword::Notnull
+                | Keyword::Collate
+                | Keyword::Div
+                | Keyword::All
+                | Keyword::Any
+                | Keyword::Some
+                | Keyword::As
+                // --- Category 2: statement / clause structure ---
+                | Keyword::Select
+                | Keyword::From
+                | Keyword::Where
+                | Keyword::Group
+                | Keyword::By
+                | Keyword::Having
+                | Keyword::Order
+                | Keyword::Limit
+                | Keyword::Offset
+                | Keyword::Into
+                | Keyword::Values
+                | Keyword::Set
+                | Keyword::On
+                | Keyword::Using
+                | Keyword::Join
+                | Keyword::Union
+                | Keyword::Intersect
+                | Keyword::Except
+                | Keyword::With
+                | Keyword::Recursive
+                | Keyword::Insert
+                | Keyword::Update
+                | Keyword::Delete
+                | Keyword::Create
+                | Keyword::Drop
+                | Keyword::Alter
+                | Keyword::Truncate
+                | Keyword::Replace
+                | Keyword::Pragma
+                // --- Category 3: special primary forms / literals ---
+                | Keyword::Case
+                | Keyword::When
+                | Keyword::Then
+                | Keyword::Else
+                | Keyword::End
+                | Keyword::Cast
+                | Keyword::Exists
+                | Keyword::Null
+                | Keyword::True
+                | Keyword::False
+                | Keyword::Unknown
+                | Keyword::Distinct
+                | Keyword::CurrentDate
+                | Keyword::CurrentTime
+                | Keyword::CurrentTimestamp
+        )
+    }
 }
 
 impl fmt::Display for Keyword {

--- a/crates/vibesql-parser/src/parser/expressions/identifiers.rs
+++ b/crates/vibesql-parser/src/parser/expressions/identifiers.rs
@@ -20,9 +20,20 @@ impl Parser {
                 self.advance();
                 (name, true)
             }
-            Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
-                // Allow certain keywords (MONTH, YEAR, DAY, etc.) to be used as column names
-                // SQL:1999 normalizes unquoted identifiers to lowercase
+            Token::Keyword { keyword: kw, .. } if kw.can_be_identifier_in_expression() => {
+                // SQLite compatibility: in expression / primary position, a keyword that
+                // is not a reserved operator, clause-structure word, or special primary
+                // form is an unquoted column reference. This covers temporal words
+                // (MONTH, YEAR, DAY, ...) as well as otherwise-reserved column names like
+                // RELEASE, SAVEPOINT, ASC, DESC, KEY (see table.test table-7.3).
+                //
+                // Reserved operators (AND, OR, NOT, IN, IS, ...) and clause keywords
+                // (FROM, WHERE, SELECT, ...) are excluded by
+                // `can_be_identifier_in_expression()`, so they still terminate the
+                // expression / are handled in operator position rather than being
+                // swallowed here.
+                //
+                // SQL:1999 normalizes unquoted identifiers to lowercase.
                 let name = format!("{}", kw).to_lowercase();
                 self.advance();
                 (name, false)

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -388,8 +388,14 @@ impl Parser {
                     index_hint,
                 })
             }
-            // Allow unreserved keywords (like NULLS, TIMESTAMP, etc.) as table names
-            Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+            // Allow keywords as table names in FROM position. After FROM a keyword
+            // that is not a clause/operator word is an unquoted table name, mirroring
+            // the column-reference handling in `parse_identifier_expression` and the
+            // CREATE TABLE side (so `FROM savepoint` resolves the table created by
+            // `CREATE TABLE savepoint(...)` — see table.test table-7.3). Clause and
+            // operator keywords (WHERE, JOIN, ON, ...) are excluded by
+            // `can_be_identifier_in_expression()` and continue to terminate the clause.
+            Token::Keyword { keyword: kw, .. } if kw.can_be_identifier_in_expression() => {
                 let table = self.parse_table_ref()?;
 
                 // Check for optional alias

--- a/crates/vibesql-parser/src/tests/select/keyword_as_identifier.rs
+++ b/crates/vibesql-parser/src/tests/select/keyword_as_identifier.rs
@@ -70,3 +70,134 @@ fn test_column_m_in_expression() {
     let result = Parser::parse_sql("SELECT m + 1 FROM t;");
     assert!(result.is_ok(), "Failed to parse m in expression: {:?}", result);
 }
+
+// Issue #5670: otherwise-reserved keywords must be accepted as column references
+// in SELECT-list / expression position and as table names in FROM position, the
+// way SQLite does (table.test table-7.3). The CREATE/INSERT/UPDATE side was fixed
+// in #5674; these tests cover the read/expression side.
+
+#[test]
+fn test_keyword_release_as_column_in_select() {
+    // The exact repro from issue #5670.
+    let result = Parser::parse_sql("SELECT release FROM savepoint;");
+    assert!(result.is_ok(), "Failed to parse SELECT release FROM savepoint: {:?}", result);
+
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            assert_eq!(select.select_list.len(), 1);
+            match &select.select_list[0] {
+                vibesql_ast::SelectItem::Expression { expr, .. } => match expr {
+                    vibesql_ast::Expression::ColumnRef(col_id) => {
+                        assert_eq!(col_id.column_canonical(), "release");
+                    }
+                    _ => panic!("Expected ColumnRef, got {:?}", expr),
+                },
+                _ => panic!("Expected Expression select item"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+#[test]
+fn test_keyword_release_in_where_and_arithmetic() {
+    assert!(Parser::parse_sql("SELECT release + 1 FROM savepoint;").is_ok());
+    assert!(Parser::parse_sql("SELECT release FROM savepoint WHERE release = 10;").is_ok());
+}
+
+#[test]
+fn test_keyword_table_name_in_from() {
+    // `savepoint` is a keyword; it must be usable as a table name in FROM position
+    // (it was already usable in CREATE TABLE via #5674).
+    let result = Parser::parse_sql("SELECT release FROM savepoint;");
+    assert!(result.is_ok(), "keyword table name in FROM failed: {:?}", result);
+
+    let stmt = result.unwrap();
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match select.from {
+            Some(vibesql_ast::FromClause::Table { name, .. }) => {
+                // `parse_table_ref` carries the keyword through via its Display form
+                // (uppercase); table-name resolution is case-insensitive, so the
+                // end-to-end repro resolves regardless. Assert case-insensitively.
+                assert!(
+                    name.eq_ignore_ascii_case("savepoint"),
+                    "expected table name savepoint, got {name:?}"
+                );
+            }
+            other => panic!("Expected FROM table savepoint, got {:?}", other),
+        },
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+#[test]
+fn test_assorted_keyword_column_refs() {
+    // A spread of otherwise-reserved, non-operator/non-clause keywords used as
+    // column references in expression position.
+    for sql in [
+        "SELECT asc FROM t;",
+        "SELECT desc FROM t;",
+        "SELECT key FROM t;",
+        "SELECT begin FROM t;",
+        "SELECT commit FROM t;",
+        "SELECT rollback FROM t;",
+        "SELECT match FROM t;",
+        "SELECT column FROM t;",
+        "SELECT index FROM t;",
+    ] {
+        assert!(Parser::parse_sql(sql).is_ok(), "expected to parse: {sql}");
+    }
+}
+
+#[test]
+fn test_order_by_keyword_column_disambiguates_direction() {
+    // `ORDER BY asc DESC` must parse column `asc` with direction DESC, not as a
+    // bare direction. The expression parser stops before ASC/DESC because they are
+    // not operators, so they bubble up to the ORDER BY direction slot.
+    let stmt = Parser::parse_sql("SELECT asc FROM t ORDER BY asc DESC;")
+        .expect("ORDER BY asc DESC should parse");
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            let order_by = select.order_by.expect("expected ORDER BY");
+            assert_eq!(order_by.len(), 1);
+            assert_eq!(order_by[0].direction, vibesql_ast::OrderDirection::Desc);
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+// --- Ambiguity-safety: reserved operator/clause keywords MUST stay reserved ---
+
+#[test]
+fn test_reserved_operators_not_treated_as_columns() {
+    // These must still parse as their operator/keyword meaning, NOT as column refs.
+    assert!(Parser::parse_sql("SELECT a FROM t WHERE a AND b;").is_ok());
+    assert!(Parser::parse_sql("SELECT a FROM t WHERE NOT a;").is_ok());
+    assert!(Parser::parse_sql("SELECT a FROM t WHERE a IS NULL;").is_ok());
+    assert!(Parser::parse_sql("SELECT a FROM t WHERE a IS NOT NULL;").is_ok());
+    assert!(Parser::parse_sql("SELECT a FROM t WHERE a IN (1, 2, 3);").is_ok());
+    assert!(Parser::parse_sql("SELECT a FROM t WHERE a BETWEEN 1 AND 5;").is_ok());
+    assert!(Parser::parse_sql("SELECT a FROM t WHERE a LIKE '%x%';").is_ok());
+    assert!(Parser::parse_sql("SELECT a FROM t WHERE a = 1 OR b = 2;").is_ok());
+    assert!(Parser::parse_sql("SELECT a FROM t WHERE EXISTS (SELECT 1 FROM t);").is_ok());
+    assert!(Parser::parse_sql("SELECT a FROM t WHERE a IN (SELECT b FROM t);").is_ok());
+}
+
+#[test]
+fn test_reserved_keywords_in_operand_position_still_error() {
+    // A reserved clause/operator keyword where an operand is expected must remain
+    // a syntax error — it must NOT be silently accepted as a column reference.
+    for sql in [
+        "SELECT FROM t;",       // FROM where a select item is expected
+        "SELECT a, FROM t;",    // trailing comma then FROM
+        "SELECT select FROM t;", // SELECT in operand position
+        "SELECT a FROM t WHERE and b;", // AND with no left operand
+        "SELECT a FROM t WHERE a = where;", // WHERE in operand position
+    ] {
+        assert!(
+            Parser::parse_sql(sql).is_err(),
+            "expected a syntax error for: {sql}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Otherwise-reserved keywords used as column names could be **created** (CREATE TABLE / INSERT / UPDATE — fixed in #5674) but not **read**. `SELECT release FROM savepoint` still failed with `near "release": syntax error`, blocking `table.test` table-7.3.

Root cause: the expression/primary parser (`parse_identifier_expression`) and the FROM-clause table-name dispatch only accepted the narrow `Keyword::can_be_identifier()` set, so otherwise-reserved column names like `RELEASE`, `ASC`, `DESC`, `KEY` were rejected in reference position.

## Changes
- `keywords.rs`: add `Keyword::can_be_identifier_in_expression()` — a **denylist** predicate that accepts any keyword as an unquoted identifier in expression/operand position EXCEPT three reserved categories (operators, clause-structure words, special primary forms).
- `expressions/identifiers.rs`: use the new predicate for simple column references.
- `select/from_clause.rs`: use the new predicate for the FROM-clause table-name dispatch, so `FROM savepoint` resolves the table created by `CREATE TABLE savepoint(...)`.
- `tests/select/keyword_as_identifier.rs`: regression tests for keyword column refs / table names, the ORDER BY disambiguation case, and explicit ambiguity-safety tests.

## Ambiguity-safety analysis (the load-bearing part)
Relaxing keywords in expression position is the highest-blast-radius parser change, so the predicate is a **denylist**, not an allowlist. `can_be_identifier_in_expression()` returns `true` for any keyword EXCEPT:

1. **Operators** consumed by the precedence cascade in *operator* position: `AND OR NOT IN BETWEEN LIKE GLOB ESCAPE IS ISNULL NOTNULL COLLATE DIV ALL ANY SOME AS` (+ `ASYMMETRIC/SYMMETRIC`).
2. **Statement/clause structure** keywords that terminate or introduce a clause: `SELECT FROM WHERE GROUP BY HAVING ORDER LIMIT OFFSET INTO VALUES SET ON USING JOIN UNION INTERSECT EXCEPT WITH RECURSIVE` + DML/DDL verbs + `PRAGMA`.
3. **Special primary forms / literals**: `CASE WHEN THEN ELSE END CAST EXISTS NULL TRUE FALSE UNKNOWN DISTINCT CURRENT_DATE/TIME/TIMESTAMP`.

Why this is safe: by the time `parse_identifier_expression` runs we are in **operand** position; the precedence-cascade parsers (`parse_or/and/not/comparison/...`) peek and consume operator keywords *before* descending to primary, and clause keywords terminate the expression one level up. The excluded keywords therefore continue to be handled in their proper position. The newly-accepted keywords (`RELEASE`, `ASC`, `DESC`, `KEY`, `BEGIN`, `COMMIT`, ...) are non-operator, non-clause words that are unambiguous as a column reference exactly where SQLite accepts them.

Verified the safety boundary holds in both directions:
- Operators/clauses still parse correctly: `WHERE a AND b`, `NOT a`, `a IS NULL`, `a IN (...)`, `a IN (SELECT ...)`, `a BETWEEN 1 AND 5`, `EXISTS (...)`, `GROUP BY ... HAVING ...`, `UNION`, `ORDER BY a DESC`, `CASE ... END` — all OK.
- Malformed queries still error: `SELECT FROM t`, `SELECT a, FROM t`, `SELECT select FROM t`, `WHERE and b`, `WHERE a = where` — all still `syntax error`.
- ORDER BY disambiguation: `ORDER BY asc DESC` parses column `asc` with direction `DESC` (confirmed by output ordering), matching SQLite.

## Acceptance Criteria Verification

| Criterion (from #5670) | Status | Verification |
|---|---|---|
| `SELECT release FROM savepoint` resolves | ✅ | End-to-end: `CREATE TABLE savepoint(release); INSERT ...; UPDATE savepoint SET release=5; SELECT release FROM savepoint;` returns `5`. |
| No `make test-tcl` regression | ✅ | Priority-1 TCL: 23394 passed (88.1%), 45 failed — failures are pre-existing, unrelated subsystems (select transforms, joins, where9, insert3). Expression-heavy files clean: select1 100%, where 0 fail, expr 0 fail, orderby1 unchanged (the one failure, 5.1, is identical with/without this change). |

Note: the `table-7.3` *line* in `table.test` also contains an earlier `execsql2 {SELECT * FROM weird}` block that still fails on BOOLEAN affinity (#5671, out of scope) — that masks the suite-level pass for the shared test name, but the savepoint case this issue targets is fully resolved.

## Test Plan
- `cargo test -p vibesql-parser` — 1467 + 8 doctests pass, including new regression tests.
- `cargo clippy -p vibesql-parser` — no new warnings (one pre-existing collapsible-if at from_clause.rs:240, confirmed present on baseline).
- Manual repro + safety/negative cases via the release binary.
- `make test-tcl` — 88.1% pass, no new failures attributable to this change.

Closes #5670