### PR TITLE
fix(insert): apply SQLite NUMERIC/TEXT affinity for BOOLEAN and CLOB columns

### DIFF
--- a/crates/vibesql-executor/src/insert/validation.rs
+++ b/crates/vibesql-executor/src/insert/validation.rs
@@ -195,6 +195,56 @@ pub fn coerce_value(
         (SqlValue::Varchar(_), DataType::Varchar { .. }) => Ok(value),
         (SqlValue::Character(_), DataType::Character { .. }) => Ok(value),
         (SqlValue::Boolean(_), DataType::Boolean) => Ok(value),
+
+        // BOOLEAN-declared columns follow SQLite NUMERIC affinity. SQLite has no
+        // native boolean storage class — a `BOOLEAN` column gets NUMERIC affinity
+        // and stores 0/1 as integers (e.g. `[14_vac] boolean` accepting the
+        // integer 0 in table-7.2). Mirror the NUMERIC-affinity arms below so a
+        // BOOLEAN column accepts the same inputs a NUMERIC column would, without
+        // forcing values into VibeSQL's strict Boolean storage class.
+        // Numeric inputs are stored as-is; whole-valued reals collapse to integers.
+        (SqlValue::Integer(_) | SqlValue::Bigint(_) | SqlValue::Smallint(_), DataType::Boolean) => {
+            Ok(value)
+        }
+        (SqlValue::Numeric(f) | SqlValue::Double(f), DataType::Boolean) => {
+            if f.fract() == 0.0 && *f >= i64::MIN as f64 && *f <= i64::MAX as f64 {
+                Ok(SqlValue::Integer(*f as i64))
+            } else {
+                Ok(value)
+            }
+        }
+        (SqlValue::Real(f), DataType::Boolean) => {
+            if f.fract() == 0.0 && *f >= i64::MIN as f64 && *f <= i64::MAX as f64 {
+                Ok(SqlValue::Integer(*f as i64))
+            } else {
+                Ok(value)
+            }
+        }
+        (SqlValue::Float(f), DataType::Boolean) => {
+            let f64_val = *f as f64;
+            if f64_val.fract() == 0.0 && f64_val >= i64::MIN as f64 && f64_val <= i64::MAX as f64 {
+                Ok(SqlValue::Integer(f64_val as i64))
+            } else {
+                Ok(SqlValue::Double(f64_val))
+            }
+        }
+        // Text into a BOOLEAN column: NUMERIC affinity tries integer, then real,
+        // otherwise the text is kept verbatim (SQLite behavior).
+        (SqlValue::Varchar(s) | SqlValue::Character(s), DataType::Boolean) => {
+            let trimmed = s.trim();
+            if let Ok(i) = trimmed.parse::<i64>() {
+                Ok(SqlValue::Integer(i))
+            } else if let Ok(f) = trimmed.parse::<f64>() {
+                if f.fract() == 0.0 && f >= i64::MIN as f64 && f <= i64::MAX as f64 {
+                    Ok(SqlValue::Integer(f as i64))
+                } else {
+                    Ok(SqlValue::Double(f))
+                }
+            } else {
+                Ok(value)
+            }
+        }
+
         (SqlValue::Float(_), DataType::Float { .. }) => Ok(value),
         (SqlValue::Real(_), DataType::Real) => Ok(value),
         (SqlValue::Double(_), DataType::DoublePrecision) => Ok(value),
@@ -437,6 +487,22 @@ pub fn coerce_value(
         // (which default to BLOB affinity) can store values of any type.
         // The value is stored as-is without conversion.
         (_, DataType::BinaryLargeObject) => Ok(value),
+
+        // CharacterLargeObject (CLOB) has TEXT affinity in SQLite (the type name
+        // contains "CLOB"). A CLOB column must accept any value by rendering its
+        // text form rather than rejecting it as a datatype mismatch — this
+        // unblocks the `end clob` column in table-7.2/8.1/8.6, which stores the
+        // string `y'all`. Text passes through; numbers and booleans stringify;
+        // blobs are stored as-is (SQLite keeps blobs in any column).
+        (_, DataType::CharacterLargeObject) => match &value {
+            SqlValue::Varchar(_) | SqlValue::Character(_) | SqlValue::Blob(_) => Ok(value),
+            SqlValue::Boolean(b) => {
+                Ok(SqlValue::Varchar(arcstr::ArcStr::from(if *b { "1" } else { "0" })))
+            }
+            // REAL -> TEXT keeps SQLite's %!.15g formatting (whole reals retain ".0")
+            // via SqlValue's Display impl; integers/temporals stringify canonically.
+            _ => Ok(SqlValue::Varchar(arcstr::ArcStr::from(value.to_string()))),
+        },
 
         // UserDefined types: Apply SQLite's type affinity rules based on the type name
         // See https://www.sqlite.org/datatype3.html#determination_of_column_affinity
@@ -716,5 +782,69 @@ mod text_affinity_tests {
         assert_eq!(coerce_to_text(SqlValue::Integer(45)), "45");
         assert_eq!(coerce_to_text(SqlValue::Bigint(-42)), "-42");
         assert_eq!(coerce_to_text(SqlValue::Smallint(7)), "7");
+    }
+}
+
+#[cfg(test)]
+mod boolean_affinity_tests {
+    use vibesql_types::{DataType, SqlValue};
+
+    use super::coerce_value;
+
+    fn coerce_to_bool_col(value: SqlValue) -> SqlValue {
+        coerce_value(value, &DataType::Boolean)
+            .expect("coercion into a BOOLEAN-affinity column should succeed")
+    }
+
+    /// SQLite has NUMERIC affinity for BOOLEAN-declared columns and stores
+    /// integer 0/1 as integers. The integer must round-trip unchanged
+    /// (table-7.2: `INSERT INTO weird(... [14_vac] boolean ...) VALUES(...,0,...)`).
+    #[test]
+    fn integer_inserts_round_trip() {
+        assert_eq!(coerce_to_bool_col(SqlValue::Integer(0)), SqlValue::Integer(0));
+        assert_eq!(coerce_to_bool_col(SqlValue::Integer(1)), SqlValue::Integer(1));
+        assert_eq!(coerce_to_bool_col(SqlValue::Integer(42)), SqlValue::Integer(42));
+        assert_eq!(coerce_to_bool_col(SqlValue::Bigint(7)), SqlValue::Bigint(7));
+        assert_eq!(coerce_to_bool_col(SqlValue::Smallint(-3)), SqlValue::Smallint(-3));
+    }
+
+    /// Genuine boolean values are preserved (TRUE/FALSE literals, predicate results).
+    #[test]
+    fn boolean_values_preserved() {
+        assert_eq!(coerce_to_bool_col(SqlValue::Boolean(true)), SqlValue::Boolean(true));
+        assert_eq!(coerce_to_bool_col(SqlValue::Boolean(false)), SqlValue::Boolean(false));
+    }
+
+    /// NULL is accepted for any type (NOT NULL is enforced separately).
+    #[test]
+    fn null_passes_through() {
+        assert_eq!(coerce_to_bool_col(SqlValue::Null), SqlValue::Null);
+    }
+
+    /// NUMERIC affinity collapses whole-valued reals to integers and keeps
+    /// fractional reals as floating point.
+    #[test]
+    fn real_inputs_follow_numeric_affinity() {
+        assert_eq!(coerce_to_bool_col(SqlValue::Real(1.0)), SqlValue::Integer(1));
+        assert_eq!(coerce_to_bool_col(SqlValue::Double(0.0)), SqlValue::Integer(0));
+        assert_eq!(coerce_to_bool_col(SqlValue::Numeric(2.0)), SqlValue::Integer(2));
+        assert_eq!(coerce_to_bool_col(SqlValue::Real(1.5)), SqlValue::Real(1.5));
+    }
+
+    /// Text into a BOOLEAN column converts to a number when possible, else stays text.
+    #[test]
+    fn text_inputs_follow_numeric_affinity() {
+        assert_eq!(
+            coerce_to_bool_col(SqlValue::Varchar(arcstr::ArcStr::from("1"))),
+            SqlValue::Integer(1)
+        );
+        assert_eq!(
+            coerce_to_bool_col(SqlValue::Varchar(arcstr::ArcStr::from("0"))),
+            SqlValue::Integer(0)
+        );
+        assert_eq!(
+            coerce_to_bool_col(SqlValue::Varchar(arcstr::ArcStr::from("abc"))),
+            SqlValue::Varchar(arcstr::ArcStr::from("abc"))
+        );
     }
 }


### PR DESCRIPTION
## Summary
A column declared `BOOLEAN` was mapped to VibeSQL's strict `DataType::Boolean`, whose INSERT coercion accepted only `SqlValue::Boolean` and rejected integers with `Type mismatch: expected Boolean, got Integer(0)`. SQLite has no native boolean storage class — a `BOOLEAN`-declared column carries **NUMERIC affinity** and stores `0`/`1` as integers. This PR aligns INSERT coercion with SQLite's affinity rules.

The same `table.test` cases that motivated this issue (7.2/8.1/8.6) also exercise a `CLOB` column, which had no coercion arm and fell through to the same type-mismatch error. CLOB has **TEXT affinity** in SQLite, so that arm is added too — both are required to actually unblock the named tests.

## Changes
- `crates/vibesql-executor/src/insert/validation.rs` — `coerce_value`:
  - **BOOLEAN → NUMERIC affinity**: integers pass through unchanged; whole-valued reals collapse to integers; fractional reals stay floating point; text converts to a number when possible (else kept verbatim). `SqlValue::Boolean` (TRUE/FALSE literals, predicate results) and `NULL` still pass through unchanged, so boolean predicate semantics are untouched.
  - **CLOB → TEXT affinity**: a `CharacterLargeObject` column accepts any value by rendering its canonical text form (blobs stored as-is), mirroring the existing TEXT-affinity arm.
- Added `boolean_affinity_tests` unit module covering integer round-trip, boolean preservation, NULL pass-through, and NUMERIC affinity for real/text inputs.

The storage normalization layer already accepted any value for `DataType::Boolean`/`CharacterLargeObject` (SQLite affinity), so the strict rejection lived solely in the executor's `coerce_value`.

## Relationship to #5676
#5676 (merged) added temporal→TEXT coercion for `Varchar`-affinity columns. This PR adds the distinct NUMERIC-affinity (BOOLEAN) and CLOB TEXT-affinity cases; there is no overlap, and the temporal→TEXT arms are preserved.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Integer `0`/`1` insert into a BOOLEAN column succeeds and round-trips | ✅ | `CREATE TABLE weird(b boolean); INSERT INTO weird VALUES(0),(1); SELECT * FROM weird` → `0`, `1`; unit test `integer_inserts_round_trip` |
| No regression in boolean predicate evaluation | ✅ | `SqlValue::Boolean(true/false)` and `NULL` pass through unchanged (`boolean_values_preserved`, `null_passes_through`); `INSERT ... VALUES(TRUE)` still stores `1` |
| No `make test-tcl` regression | ✅ | Priority-1 suite: 45 file-level failures (incl. 1 environmental TIMEOUT) — matches the #5676 baseline exactly |
| table-7.2 / 8.1 / 8.6 improve | ✅ | `table.test`: **57→61 passed, 25→21 failed**; table-7.2, 8.1, 8.6 now pass |

## Test Plan
- `cargo test -p vibesql-executor`: **2945 lib + all integration suites pass** (incl. 5 new `boolean_affinity_tests`).
- `./scripts/tcltest test table.test`: **57→61 passed, 25→21 failed**. table-7.2/8.1/8.6 moved from failed to passed.
- `make test-tcl`: 45 file-level failures (1 environmental TIMEOUT), at the #5676 baseline — no regression.
- CLI repro before/after: `INSERT INTO weird(... [14_vac] boolean, ... end clob) VALUES('a','b',9,0,'xyz','hi','y''all')` now succeeds and round-trips all columns.

### Out of scope
`table-8.1.1` still fails: it asserts the exact `CREATE TABLE t2(...)` DDL text rendered by `CREATE TABLE AS SELECT` (a schema-reconstruction concern), not INSERT affinity. Left for a separate follow-up.

Closes #5671