### PR TITLE
fix(executor): name CTAS expression columns after the expression text

### DIFF
--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -879,12 +879,15 @@ impl CreateTableExecutor {
                         return Err(ExecutorError::TableNotFound(qualifier.clone()));
                     }
                 }
-                vibesql_ast::SelectItem::Expression { expr, alias, .. } => {
+                vibesql_ast::SelectItem::Expression { expr, alias, source_text } => {
                     let name = if let Some(alias) = alias {
                         alias.clone()
                     } else {
-                        // Try to derive from expression
-                        Self::derive_column_name_from_expr(expr, &mut counter)
+                        // Derive a name from the expression, preferring the
+                        // original SQL source text so expression columns are
+                        // named after the expression the way SQLite does
+                        // (e.g. `max(b+c)`, `b+c`) rather than `column1`.
+                        Self::derive_column_name_from_expr(expr, source_text, &mut counter)
                     };
                     names.push(name);
                 }
@@ -935,14 +938,35 @@ impl CreateTableExecutor {
         Ok(names)
     }
 
-    /// Derive a column name from an expression
-    fn derive_column_name_from_expr(expr: &vibesql_ast::Expression, counter: &mut usize) -> String {
+    /// Derive a column name from a CTAS select-list expression.
+    ///
+    /// SQLite names a result column after the original text of the
+    /// expression when there is no explicit alias (e.g. `SELECT max(b+c)`
+    /// yields a column named `max(b+c)`, `SELECT b+c` yields `b+c`). For a
+    /// bare column reference the name is just the column name. Only when no
+    /// source text is available (e.g. a programmatically-built AST) do we
+    /// fall back to the synthetic `columnN` placeholder.
+    fn derive_column_name_from_expr(
+        expr: &vibesql_ast::Expression,
+        source_text: &Option<String>,
+        counter: &mut usize,
+    ) -> String {
+        // A bare column reference is always named after the column itself,
+        // matching the regular SELECT result-column naming (short mode).
+        if let vibesql_ast::Expression::ColumnRef(col_id) = expr {
+            return col_id.column_canonical().to_string();
+        }
+
+        // For every other expression (functions, aggregates, arithmetic,
+        // literals, ...) SQLite uses the original SQL text of the
+        // select-list item as the column name.
+        if let Some(src) = source_text {
+            return src.clone();
+        }
+
+        // No source text available (programmatically-built AST): fall back to
+        // the previous best-effort naming.
         match expr {
-            vibesql_ast::Expression::ColumnRef(col_id) => col_id.column_canonical().to_string(),
-            vibesql_ast::Expression::Literal(_) => {
-                *counter += 1;
-                format!("column{}", counter)
-            }
             vibesql_ast::Expression::Function { name, .. } => {
                 // Use the function name as the column name
                 name.to_string().to_lowercase()


### PR DESCRIPTION
## Summary
`CREATE TABLE AS SELECT` (CTAS) named any non-trivial expression column `column1`, `column2`, ... instead of deriving the name from the expression text the way SQLite does. SQLite names a result column after the original SQL text of the select-list item when there is no explicit alias, so `SELECT max(b+c)` yields a column named `max(b+c)` and `SELECT b+c` yields `b+c`.

This was the remaining reason `table.test` table-8.3 and table-8.5 did not fully PASS: after #5681 they returned the correct **value** (`5`) but the column was still named `column1`.

## Changes
- `crates/vibesql-executor/src/create_table.rs`: `derive_column_name_from_expr` now prefers the `source_text` already captured on `SelectItem::Expression` (the same field the regular SELECT result-column naming path uses) for every expression except a bare column reference, which keeps its short column name. The synthetic `columnN` placeholder is only used when no source text is available (e.g. a programmatically-built AST). The CTAS Expression arm now threads `source_text` into that helper.

This reuses the existing `source_text` mechanism rather than duplicating the SELECT naming logic.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| CTAS derives expression column names from the expression text (e.g. `max(b+c)`, `b+c`) | ✅ | `CREATE TABLE tt AS SELECT count(*) AS cnt, max(b+c) FROM t3` now produces a `max(b+c)` column; `SELECT b+c` -> `b+c`; `SELECT sum(b+c)` -> `sum(b+c)` |
| `table.test` table-8.3 passes | ✅ | Failed at baseline, passes after fix |
| `table.test` table-8.5 passes | ✅ | Failed at baseline, passes after fix |
| No regression in `make test-tcl` | ✅ | Latest run: 39 failed (down from baseline 45); 23398 passed. No table/CTAS tests in the remaining failures |

### Note on table-8.3.1
table-8.3.1 (and table-8.1.1) assert the exact `sqlite_master.sql` schema **text** (`CREATE TABLE "t4""abc"(cnt,"max(b+c)")` with no column types and SQLite's quoting/whitespace). The column name is now correct there too, but those tests additionally require omitting column types for expression columns and matching SQLite's identifier quoting/whitespace in the reconstructed schema text — a separate schema-serialization concern outside this issue's scope. They fail at baseline and still fail (not regressed); fixing them is follow-up work.

## Test Plan
- Reproduced the bug, then confirmed `max(b+c)`, `b+c`, `sum(b+c)` column names via `SELECT sql FROM sqlite_master`.
- `cargo test -p vibesql-executor --lib`: 2948 passed, 0 failed.
- `./scripts/tcltest test table.test`: 62 -> 64 passing; table-8.3 and table-8.5 moved from fail to pass, no other test changed status.
- `make test-tcl`: 39 failures (baseline 45); no CTAS/table regressions.

Closes #5680