### PR TITLE
feat(executor): execute MULTI-INDEX OR via rowid-deduped per-branch index union

### DIFF
--- a/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
@@ -695,6 +695,128 @@ pub(crate) fn execute_index_scan(
     }
 }
 
+/// Execute a MULTI-INDEX OR scan (epic #5668, PR 2).
+///
+/// Executes the union of per-branch index lookups for a top-level OR whose every
+/// branch is independently indexable, then applies the residual non-OR
+/// AND-conjuncts as a post-filter.
+///
+/// # Correctness (the dominant risk — see #5668 §2b/§3)
+///
+/// - **Exactly-once semantics.** A row satisfying multiple branches (e.g.
+///   `c = 31031 OR d IS NULL` where both hold) must appear **exactly once**.
+///   SQLite deduplicates by **rowid**: it unions the rowid sets from each
+///   per-branch lookup, deduplicating, then fetches each surviving row once.
+///   This function accumulates rows into an **insertion-ordered** dedup set
+///   keyed by rowid (first-encounter order: branch 1's matches, then branch 2's
+///   not-already-seen, ...), matching SQLite's union emission order. Any explicit
+///   `ORDER BY` sorts downstream as today.
+/// - **`IS NULL` vs `=`.** Each branch is executed by running its original
+///   branch predicate through [`execute_index_scan`]. An `IS NULL` branch is
+///   therefore evaluated as `col IS NULL` (a NULL-key match), distinct from the
+///   `=` equality seek a `col = ?` branch performs — never conflated.
+/// - **Residual.** The non-OR AND-conjuncts (e.g. `b > 1000`) are applied as a
+///   filter **around** the deduped union, so they constrain rows regardless of
+///   which branch matched them.
+///
+/// # Rowid source
+///
+/// [`execute_index_scan`] sets each cloned row's `row_id` (1-based; an explicitly
+/// relocated rowid wins over physical-index+1). MULTI-INDEX OR is only selected
+/// for tables that have a rowid (WITHOUT ROWID tables fall back to single-scan +
+/// residual at selection time), so every branch row carries a stable rowid.
+#[allow(private_interfaces)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn execute_multi_index_or(
+    table_name: &str,
+    alias: Option<&String>,
+    branches: &[super::selection::OrBranch],
+    residual: Option<&Expression>,
+    database: &Database,
+    cte_results: &HashMap<String, CteResult>,
+) -> Result<super::super::FromResult, ExecutorError> {
+    use std::collections::HashSet;
+
+    // Build the result schema once (independent of the per-branch scans, which
+    // each build their own equivalent schema internally).
+    let table = database
+        .get_table(table_name)
+        .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+    let effective_name = alias.cloned().unwrap_or_else(|| table_name.to_string());
+    let schema = CombinedSchema::from_table(effective_name, table.schema.clone());
+
+    // Insertion-ordered rowid dedup: `seen` rejects duplicates, `deduped` holds
+    // the surviving rows in first-encounter order.
+    let mut seen: HashSet<u64> = HashSet::new();
+    let mut deduped: Vec<Row> = Vec::new();
+
+    for branch in branches {
+        // Execute this branch's index lookup with the branch predicate as the
+        // WHERE clause. We pass no ORDER BY / LIMIT: the union's ordering is the
+        // first-encounter order, and any LIMIT must apply to the whole union
+        // downstream (never per-branch). `execute_index_scan` re-applies the
+        // branch predicate as a filter on the fetched rows, so both `=` and
+        // `IS NULL` branches return exactly their matching rows.
+        let branch_result = execute_index_scan(
+            table_name,
+            &branch.index_name,
+            alias,
+            Some(&branch.branch_predicate),
+            None, // sorted_columns: union order, not index order
+            None, // limit: applied downstream over the whole union
+            database,
+            cte_results,
+        )?;
+
+        for row in branch_result.into_rows() {
+            // Every branch row carries a rowid (see #4954 / #5517 handling in
+            // execute_index_scan). If one is somehow absent, fall back to a
+            // synthetic key that still dedups identical rows within this union.
+            let key = match row.row_id {
+                Some(id) => id,
+                None => {
+                    // Defensive: should not happen for rowid tables (selection
+                    // guards out WITHOUT ROWID). Skip the row rather than risk a
+                    // mis-dedup; the debug_assert flags it in test builds.
+                    debug_assert!(
+                        false,
+                        "MULTI-INDEX OR branch row missing row_id on a rowid table"
+                    );
+                    continue;
+                }
+            };
+
+            if seen.insert(key) {
+                deduped.push(row);
+            }
+        }
+    }
+
+    // Apply the residual non-OR AND-conjuncts (e.g. `b > 1000`) around the union.
+    let rows = if let Some(residual_expr) = residual {
+        let predicate_plan = PredicatePlan::from_where_clause(Some(residual_expr), &schema)
+            .map_err(ExecutorError::InvalidWhereClause)?;
+        let row_refs: Vec<&Row> = deduped.iter().collect();
+        let filtered = apply_where_filter_zerocopy(
+            row_refs,
+            &schema,
+            &predicate_plan,
+            table_name,
+            database,
+            cte_results,
+        )?;
+        filtered.into_iter().cloned().collect()
+    } else {
+        deduped
+    };
+
+    // The union has no inherent sort order (first-encounter), so report it as a
+    // plain WHERE-filtered result: the original WHERE clause is fully satisfied
+    // by the branch predicates + residual, so downstream WHERE re-filtering is
+    // unnecessary.
+    Ok(super::super::FromResult::from_rows_where_filtered(schema, rows, None))
+}
+
 /// Apply WHERE filter using zero-copy row references
 ///
 /// This function filters rows by reference, avoiding clones for rows that don't pass the filter.

--- a/crates/vibesql-executor/src/select/scan/index_scan/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/mod.rs
@@ -27,6 +27,8 @@ pub(crate) mod selection;
 
 // Re-export public APIs
 pub(crate) use execution::execute_index_scan;
+// MULTI-INDEX OR execution (epic #5668, PR 2).
+pub(crate) use execution::execute_multi_index_or;
 pub(super) use execution::execute_skip_scan;
 pub(crate) use selection::{
     cost_based_index_selection, eqp_ordering_index, needs_temp_btree_for_order_by_eqp,

--- a/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
@@ -1762,6 +1762,27 @@ pub(crate) fn select_index_scan_method(
     order_by: Option<&[vibesql_ast::OrderByItem]>,
     database: &Database,
 ) -> Option<IndexScanChoice> {
+    // CONSERVATIVE TRIGGER (epic #5668, PR 2). Try MULTI-INDEX OR FIRST, but only
+    // for a genuine multi-index union (see `try_multi_index_or`). This must be
+    // checked before regular single-index selection because the rule/cost-based
+    // selectors return *some* single index for almost any OR that mentions an
+    // indexed column (then apply the whole OR as a residual filter) — which would
+    // shadow the union path entirely. The trigger is narrow (≥2 distinct indexes,
+    // flag on, rowid table) and produces an identical row set, so no query's
+    // results change; only the access path differs for true multi-index ORs.
+    if let Some(choice) = try_multi_index_or(table_name, where_clause, order_by, database) {
+        if crate::profiling::is_scan_debug_enabled() {
+            if let IndexScanChoice::MultiIndexOr { ref branches, .. } = choice {
+                eprintln!(
+                    "[SCAN_PATH] Selected MULTI-INDEX OR for table={}, branches={}",
+                    table_name,
+                    branches.len()
+                );
+            }
+        }
+        return Some(choice);
+    }
+
     // First, try regular cost-based index selection
     if let Some((index_name, sorted_columns)) =
         cost_based_index_selection(table_name, where_clause, order_by, database)
@@ -1796,6 +1817,111 @@ pub(crate) fn select_index_scan_method(
 
     // No index or skip-scan option found
     None
+}
+
+/// Whether the MULTI-INDEX OR optimization (epic #5668) is enabled.
+///
+/// The feature is **ON by default** and disabled only when the
+/// `MULTI_INDEX_OR_DISABLED` environment variable is set, mirroring the
+/// `JOIN_REORDER_DISABLED` opt-out (see `reorder::utils::should_apply_join_reordering`).
+/// When disabled, [`select_index_scan_method`] never produces an
+/// [`IndexScanChoice::MultiIndexOr`], so behavior is byte-identical to before
+/// the feature landed.
+pub(crate) fn multi_index_or_enabled() -> bool {
+    std::env::var("MULTI_INDEX_OR_DISABLED").is_err()
+}
+
+/// Database-backed [`BranchIndexResolver`](super::or_analysis::BranchIndexResolver).
+///
+/// Resolves a single OR-branch predicate to the index VibeSQL would actually use
+/// for it, by running the branch predicate through [`cost_based_index_selection`]
+/// (the same selection used for the whole WHERE clause). A branch is considered
+/// independently indexable iff that selection yields a `Regular` index. This
+/// reuses the existing, well-tested selection logic so a resolved branch is
+/// guaranteed executable via [`execute_index_scan`](super::execution).
+struct DatabaseBranchResolver<'a> {
+    table_name: &'a str,
+    database: &'a Database,
+}
+
+impl super::or_analysis::BranchIndexResolver for DatabaseBranchResolver<'_> {
+    fn resolve(&self, branch: &Expression) -> Option<String> {
+        // No ORDER BY here: a branch is indexable purely as a WHERE lookup.
+        cost_based_index_selection(self.table_name, Some(branch), None, self.database)
+            .map(|(index_name, _sorted_columns)| index_name)
+    }
+}
+
+/// Attempt to build a MULTI-INDEX OR plan for `where_clause` against `table_name`.
+///
+/// Returns `Some(IndexScanChoice::MultiIndexOr { .. })` only for a **genuine
+/// multi-index union**: every top-level OR branch independently resolves to an
+/// index AND the branches reference **at least two distinct indexes**. Returns
+/// `None` (leaving the caller's existing single-scan / full-scan path unchanged)
+/// when the feature is disabled, the table is WITHOUT ROWID, the analyzer rejects
+/// the WHERE clause, or all branches resolve to the **same** index (the existing
+/// single-index scan already handles that case identically and more cheaply).
+///
+/// ## Conservative trigger (epic #5668, PR 2)
+///
+/// This is the entry condition for the new execution path. It is intentionally
+/// the *narrowest* trigger that still exercises MULTI-INDEX OR execution:
+/// - It fires only for ORs whose branches genuinely span multiple distinct
+///   indexes — exactly the case a single-index scan cannot model without falling
+///   back to a full residual filter.
+/// - The result row set is **identical** to the prior single-index-scan +
+///   full-OR-residual path (an OR over indexed branches), so there is **no result
+///   change** for any query — only the access path differs. The oracle/property
+///   test asserts this set-equality against the full-scan baseline.
+/// - The honest cost-model decision (weighing MULTI-INDEX OR against a single
+///   index or full scan by estimated cost) is deferred to PR 3; here selection is
+///   a structural trigger, not a cost decision.
+///
+/// ## WITHOUT ROWID guard
+///
+/// MULTI-INDEX OR deduplicates by rowid, which WITHOUT ROWID tables do not have.
+/// Such tables fall back to the single-scan + residual path (out of scope for
+/// this PR, per #5668 §2b).
+fn try_multi_index_or(
+    table_name: &str,
+    where_clause: Option<&Expression>,
+    order_by: Option<&[vibesql_ast::OrderByItem]>,
+    database: &Database,
+) -> Option<IndexScanChoice> {
+    if !multi_index_or_enabled() {
+        return None;
+    }
+
+    // ORDER BY out of scope for the conservative trigger: a single index may
+    // satisfy the ordering, and the union has no inherent sort order. Defer any
+    // ORDER BY query to the existing single-index / full-scan path so we never
+    // perturb ORDER BY plan optimizations. (PR 3+ can revisit under the cost
+    // model.)
+    if order_by.is_some() {
+        return None;
+    }
+
+    let where_expr = where_clause?;
+
+    // WITHOUT ROWID tables have no rowid to dedup on — fall back.
+    let table = database.get_table(table_name)?;
+    if table.schema.without_rowid {
+        return None;
+    }
+
+    let resolver = DatabaseBranchResolver { table_name, database };
+    let plan = super::or_analysis::analyze_multi_index_or(where_expr, &resolver)?;
+
+    // Genuine multi-index union only: require at least two DISTINCT indexes.
+    // If every branch resolves to the same index, the existing single-index
+    // scan + residual already covers it identically and more cheaply.
+    let distinct_indexes: std::collections::HashSet<&str> =
+        plan.branches.iter().map(|b| b.index_name.as_str()).collect();
+    if distinct_indexes.len() < 2 {
+        return None;
+    }
+
+    Some(IndexScanChoice::MultiIndexOr { branches: plan.branches, residual: plan.residual })
 }
 
 #[cfg(test)]

--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -492,14 +492,31 @@ pub(crate) fn execute_table_scan(
                     );
                 }
             }
-            super::index_scan::IndexScanChoice::MultiIndexOr { .. } => {
-                // MULTI-INDEX OR (epic #5668). PR 1 only adds the plan
-                // representation + analyzer; selection never produces this
-                // variant yet, so this arm is unreachable. Execution lands in
-                // PR 2. The `unreachable!` documents the invariant without
-                // changing any existing behavior.
-                unreachable!(
-                    "MultiIndexOr is plan representation only in PR 1 and is never selected"
+            super::index_scan::IndexScanChoice::MultiIndexOr { branches, residual } => {
+                // MULTI-INDEX OR (epic #5668, PR 2). Execute the union of
+                // per-branch index lookups, deduplicating by rowid
+                // (insertion-ordered), then apply the residual non-OR
+                // AND-conjuncts as a post-filter.
+                //
+                // Selection only produces this variant for a genuine multi-index
+                // union (>= 2 distinct indexes, no ORDER BY, rowid table) with
+                // the feature flag on — see `try_multi_index_or`. The resulting
+                // row set is identical to the prior single-index-scan + full-OR
+                // residual path; only the access path differs.
+                if crate::profiling::is_scan_debug_enabled() {
+                    eprintln!(
+                        "[SCAN_PATH] Using MULTI-INDEX OR: table={}, branches={}",
+                        table_name,
+                        branches.len()
+                    );
+                }
+                return super::index_scan::execute_multi_index_or(
+                    table_name,
+                    alias,
+                    &branches,
+                    residual.as_ref(),
+                    database,
+                    cte_results,
                 );
             }
         }

--- a/crates/vibesql-executor/tests/multi_index_or_tests.rs
+++ b/crates/vibesql-executor/tests/multi_index_or_tests.rs
@@ -1,0 +1,368 @@
+//! Correctness tests for MULTI-INDEX OR single-table execution (epic #5668, PR 2).
+//!
+//! These tests exercise the flag-gated MULTI-INDEX OR execution path wired into
+//! the single-table scan dispatch. The dominant risk for this PR is **rowid
+//! deduplication correctness**: a row satisfying multiple OR branches must appear
+//! exactly once. See #5668 §2b/§3.
+//!
+//! Trigger reminder: MULTI-INDEX OR is selected only when (a) the
+//! `MULTI_INDEX_OR_DISABLED` flag is unset (default ON), (b) no single index
+//! (regular or skip-scan) applies to the WHERE clause, and (c) every top-level OR
+//! branch is independently indexable. These tests build schemas where each OR
+//! branch column has its own single-column index so the analyzer resolves every
+//! branch while no single index covers the whole OR.
+
+use std::sync::Mutex;
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+// `std::env::set_var` is process-global; serialize the flag-toggling test so it
+// cannot race with the default-ON tests.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse {sql}: {e:?}"));
+    match stmt {
+        vibesql_ast::Statement::CreateTable(c) => {
+            vibesql_executor::CreateTableExecutor::execute(&c, db).unwrap();
+        }
+        vibesql_ast::Statement::CreateIndex(c) => {
+            vibesql_executor::CreateIndexExecutor::execute(&c, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(i) => {
+            vibesql_executor::InsertExecutor::execute(db, &i).unwrap();
+        }
+        other => panic!("Unsupported statement in setup: {other:?}"),
+    }
+}
+
+/// Run a SELECT returning a single integer column as a Vec<i64>, in the order
+/// the executor emits rows (no sorting applied here).
+fn query_ints_raw(db: &vibesql_storage::Database, sql: &str) -> Vec<i64> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    let vibesql_ast::Statement::Select(select) = stmt else { panic!("not a SELECT: {sql}") };
+    SelectExecutor::new(db)
+        .execute(&select)
+        .unwrap_or_else(|e| panic!("query failed {sql}: {e:?}"))
+        .into_iter()
+        .map(|row| match &row.values[0] {
+            SqlValue::Integer(n) => *n,
+            SqlValue::Bigint(n) => *n,
+            other => panic!("expected integer, got {other:?}"),
+        })
+        .collect()
+}
+
+/// Run a SELECT and return the single-int column **sorted ascending**.
+///
+/// NOTE: a SQL `ORDER BY` would bypass the MULTI-INDEX OR conservative trigger
+/// (ORDER BY is deferred to the single-index path), so these tests must NOT use
+/// `ORDER BY` in SQL — they sort in-test for deterministic set comparison.
+fn query_ints_sorted(db: &vibesql_storage::Database, sql: &str) -> Vec<i64> {
+    let mut v = query_ints_raw(db, sql);
+    v.sort_unstable();
+    v
+}
+
+/// A table `t(a INTEGER PRIMARY KEY, b INT, c INT, d INT)` with single-column
+/// indexes on `c` and `d`. No composite/index covers an OR over `c` and `d`, so
+/// `WHERE c=? OR d=?` routes through MULTI-INDEX OR.
+fn setup_cd_table(db: &mut vibesql_storage::Database) {
+    run_stmt(db, "CREATE TABLE t(a INTEGER PRIMARY KEY, b INTEGER, c INTEGER, d INTEGER)");
+    run_stmt(db, "CREATE INDEX t_c ON t(c)");
+    run_stmt(db, "CREATE INDEX t_d ON t(d)");
+}
+
+#[test]
+fn rows_matching_both_branches_appear_exactly_once() {
+    let _g = ENV_LOCK.lock().unwrap();
+    let mut db = vibesql_storage::Database::new();
+    setup_cd_table(&mut db);
+    // Row a=1 satisfies BOTH branches (c=10 AND d=10). It must appear once.
+    run_stmt(&mut db, "INSERT INTO t VALUES (1, 0, 10, 10)");
+    run_stmt(&mut db, "INSERT INTO t VALUES (2, 0, 10, 99)"); // c only
+    run_stmt(&mut db, "INSERT INTO t VALUES (3, 0, 99, 10)"); // d only
+    run_stmt(&mut db, "INSERT INTO t VALUES (4, 0, 99, 99)"); // neither
+
+    let rows = query_ints_sorted(&db, "SELECT a FROM t WHERE c = 10 OR d = 10");
+    assert_eq!(rows, vec![1, 2, 3], "row 1 (both branches) must appear exactly once");
+}
+
+#[test]
+fn is_null_branch_returns_correct_rows_distinct_from_equality() {
+    let _g = ENV_LOCK.lock().unwrap();
+    let mut db = vibesql_storage::Database::new();
+    setup_cd_table(&mut db);
+    run_stmt(&mut db, "INSERT INTO t VALUES (1, 0, 10, NULL)"); // c matches, d NULL
+    run_stmt(&mut db, "INSERT INTO t VALUES (2, 0, 99, NULL)"); // d IS NULL only
+    run_stmt(&mut db, "INSERT INTO t VALUES (3, 0, 99, 5)"); // neither
+    run_stmt(&mut db, "INSERT INTO t VALUES (4, 0, 10, 5)"); // c matches only
+
+    // `d IS NULL` is a NULL-key match, NOT `d = NULL` (which matches nothing).
+    let rows = query_ints_sorted(&db, "SELECT a FROM t WHERE c = 10 OR d IS NULL");
+    assert_eq!(rows, vec![1, 2, 4]);
+
+    // Sanity: `d = NULL` (equality with NULL) matches nothing — the IS NULL
+    // branch is genuinely distinct from an equality seek.
+    let none = query_ints_sorted(&db, "SELECT a FROM t WHERE d = NULL");
+    assert!(none.is_empty(), "d = NULL must match no rows");
+}
+
+#[test]
+fn empty_branch_results_are_handled() {
+    let _g = ENV_LOCK.lock().unwrap();
+    let mut db = vibesql_storage::Database::new();
+    setup_cd_table(&mut db);
+    run_stmt(&mut db, "INSERT INTO t VALUES (1, 0, 10, 1)");
+    run_stmt(&mut db, "INSERT INTO t VALUES (2, 0, 20, 2)");
+
+    // One branch matches nothing (c = 777), the other matches one row.
+    let rows = query_ints_sorted(&db, "SELECT a FROM t WHERE c = 777 OR d = 2");
+    assert_eq!(rows, vec![2]);
+
+    // Both branches empty.
+    let none = query_ints_sorted(&db, "SELECT a FROM t WHERE c = 777 OR d = 888");
+    assert!(none.is_empty());
+}
+
+#[test]
+fn null_keys_do_not_spuriously_match_equality_branches() {
+    let _g = ENV_LOCK.lock().unwrap();
+    let mut db = vibesql_storage::Database::new();
+    setup_cd_table(&mut db);
+    // Rows with NULL in the indexed columns must not match `c = ?` / `d = ?`.
+    run_stmt(&mut db, "INSERT INTO t VALUES (1, 0, NULL, NULL)");
+    run_stmt(&mut db, "INSERT INTO t VALUES (2, 0, 10, NULL)");
+    run_stmt(&mut db, "INSERT INTO t VALUES (3, 0, NULL, 20)");
+
+    let rows = query_ints_sorted(&db, "SELECT a FROM t WHERE c = 10 OR d = 20");
+    assert_eq!(rows, vec![2, 3], "NULL-key row 1 must not match either equality branch");
+}
+
+#[test]
+fn residual_filter_applied_around_union() {
+    let _g = ENV_LOCK.lock().unwrap();
+    let mut db = vibesql_storage::Database::new();
+    setup_cd_table(&mut db);
+    // (c = 10 OR d = 20) AND b > 1000
+    run_stmt(&mut db, "INSERT INTO t VALUES (1, 5000, 10, 0)"); // c match, b>1000  -> in
+    run_stmt(&mut db, "INSERT INTO t VALUES (2, 5, 10, 0)"); // c match, b<=1000 -> out
+    run_stmt(&mut db, "INSERT INTO t VALUES (3, 9000, 0, 20)"); // d match, b>1000  -> in
+    run_stmt(&mut db, "INSERT INTO t VALUES (4, 9000, 0, 0)"); // neither branch -> out
+
+    let rows = query_ints_sorted(&db, "SELECT a FROM t WHERE (c = 10 OR d = 20) AND b > 1000");
+    assert_eq!(rows, vec![1, 3]);
+}
+
+#[test]
+fn three_way_or_dedups_across_all_branches() {
+    let _g = ENV_LOCK.lock().unwrap();
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(a INTEGER PRIMARY KEY, c INT, d INT, e INT)");
+    run_stmt(&mut db, "CREATE INDEX t_c ON t(c)");
+    run_stmt(&mut db, "CREATE INDEX t_d ON t(d)");
+    run_stmt(&mut db, "CREATE INDEX t_e ON t(e)");
+    // Row 1 matches all three branches; must appear once.
+    run_stmt(&mut db, "INSERT INTO t VALUES (1, 1, 1, 1)");
+    run_stmt(&mut db, "INSERT INTO t VALUES (2, 1, 9, 9)");
+    run_stmt(&mut db, "INSERT INTO t VALUES (3, 9, 1, 9)");
+    run_stmt(&mut db, "INSERT INTO t VALUES (4, 9, 9, 1)");
+    run_stmt(&mut db, "INSERT INTO t VALUES (5, 9, 9, 9)");
+
+    let rows = query_ints_sorted(&db, "SELECT a FROM t WHERE c = 1 OR d = 1 OR e = 1");
+    assert_eq!(rows, vec![1, 2, 3, 4]);
+}
+
+#[test]
+fn disabled_flag_reverts_to_prior_behavior() {
+    let _g = ENV_LOCK.lock().unwrap();
+    // With the flag set, the MULTI-INDEX OR path must not be taken; the query
+    // still returns correct results via the existing full-scan + residual path.
+    // SAFETY: serialized by ENV_LOCK; restored before unlock.
+    unsafe {
+        std::env::set_var("MULTI_INDEX_OR_DISABLED", "1");
+    }
+
+    let result = std::panic::catch_unwind(|| {
+        let mut db = vibesql_storage::Database::new();
+        setup_cd_table(&mut db);
+        run_stmt(&mut db, "INSERT INTO t VALUES (1, 0, 10, 10)");
+        run_stmt(&mut db, "INSERT INTO t VALUES (2, 0, 10, 99)");
+        run_stmt(&mut db, "INSERT INTO t VALUES (3, 0, 99, 10)");
+        run_stmt(&mut db, "INSERT INTO t VALUES (4, 0, 99, 99)");
+        query_ints_sorted(&db, "SELECT a FROM t WHERE c = 10 OR d = 10")
+    });
+
+    unsafe {
+        std::env::remove_var("MULTI_INDEX_OR_DISABLED");
+    }
+
+    let rows = result.expect("query panicked");
+    // Same correct result as the enabled path — the flag only affects the
+    // access path, never the row set.
+    assert_eq!(rows, vec![1, 2, 3]);
+}
+
+#[test]
+fn same_index_or_does_not_use_multi_index_path() {
+    let _g = ENV_LOCK.lock().unwrap();
+    // `c = 1 OR c = 2` resolves both branches to the SAME index (t_c). The
+    // conservative trigger requires >= 2 distinct indexes, so this stays on the
+    // existing single-index path — and must still be correct.
+    let mut db = vibesql_storage::Database::new();
+    setup_cd_table(&mut db);
+    run_stmt(&mut db, "INSERT INTO t VALUES (1, 0, 1, 0)");
+    run_stmt(&mut db, "INSERT INTO t VALUES (2, 0, 2, 0)");
+    run_stmt(&mut db, "INSERT INTO t VALUES (3, 0, 3, 0)");
+
+    let rows = query_ints_sorted(&db, "SELECT a FROM t WHERE c = 1 OR c = 2");
+    assert_eq!(rows, vec![1, 2]);
+}
+
+// ---- Oracle / property test ------------------------------------------------
+//
+// For randomized data + randomized indexable-OR predicates, the MULTI-INDEX OR
+// result set must be identical to a reference computed directly from the raw
+// data in Rust (the authoritative "full-scan residual" baseline). This is the
+// single strongest guard against a wrong rowid dedup (#5668 §3): the reference
+// is computed independently of any executor scan path.
+
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+/// One generated row: (rowid a, b, c, d) where c/d may be NULL.
+#[derive(Clone, Copy)]
+struct OracleRow {
+    a: i64,
+    b: i64,
+    c: Option<i64>,
+    d: Option<i64>,
+}
+
+/// A generated indexable-OR predicate over (c, d) with an optional residual on b.
+struct OraclePredicate {
+    /// Branches: each is a column ('c' or 'd') and an equality value, or an
+    /// IS NULL test (`None` value).
+    branches: Vec<(char, Option<i64>)>,
+    /// Optional residual `b > threshold`.
+    residual_b_gt: Option<i64>,
+}
+
+impl OraclePredicate {
+    fn to_sql(&self) -> String {
+        let or_part = self
+            .branches
+            .iter()
+            .map(|(col, val)| match val {
+                Some(v) => format!("{col} = {v}"),
+                None => format!("{col} IS NULL"),
+            })
+            .collect::<Vec<_>>()
+            .join(" OR ");
+        match self.residual_b_gt {
+            Some(t) => format!("SELECT a FROM t WHERE ({or_part}) AND b > {t}"),
+            None => format!("SELECT a FROM t WHERE {or_part}"),
+        }
+    }
+
+    /// Reference evaluation directly over the raw rows (the oracle baseline).
+    fn eval_reference(&self, rows: &[OracleRow]) -> Vec<i64> {
+        let mut out: Vec<i64> = rows
+            .iter()
+            .filter(|r| {
+                let or_ok = self.branches.iter().any(|(col, val)| {
+                    let cell = if *col == 'c' { r.c } else { r.d };
+                    match val {
+                        // Equality: NULL never matches (SQL semantics).
+                        Some(v) => cell == Some(*v),
+                        // IS NULL.
+                        None => cell.is_none(),
+                    }
+                });
+                let residual_ok = match self.residual_b_gt {
+                    Some(t) => r.b > t,
+                    None => true,
+                };
+                or_ok && residual_ok
+            })
+            .map(|r| r.a)
+            .collect();
+        out.sort_unstable();
+        out
+    }
+}
+
+#[test]
+fn oracle_property_test_multi_index_or_matches_reference() {
+    let _g = ENV_LOCK.lock().unwrap();
+    let mut rng = ChaCha8Rng::seed_from_u64(0x5668_0002_DEAD_BEEF);
+
+    // Run many independent trials with fresh randomized data + predicates.
+    for trial in 0..200u32 {
+        let mut db = vibesql_storage::Database::new();
+        setup_cd_table(&mut db);
+
+        // Generate 10..40 rows. Small value domains => frequent multi-branch
+        // overlaps (the dedup stress case) and frequent NULLs.
+        let n = rng.random_range(10..40);
+        let mut rows = Vec::with_capacity(n);
+        for i in 0..n {
+            let a = (i + 1) as i64;
+            let b = rng.random_range(0..2000);
+            let c = if rng.random_range(0..4) == 0 { None } else { Some(rng.random_range(0..6)) };
+            let d = if rng.random_range(0..4) == 0 { None } else { Some(rng.random_range(0..6)) };
+            rows.push(OracleRow { a, b, c, d });
+            let c_sql = c.map(|v| v.to_string()).unwrap_or_else(|| "NULL".into());
+            let d_sql = d.map(|v| v.to_string()).unwrap_or_else(|| "NULL".into());
+            run_stmt(&mut db, &format!("INSERT INTO t VALUES ({a}, {b}, {c_sql}, {d_sql})"));
+        }
+
+        // Build a randomized indexable-OR predicate with 2..4 branches spanning
+        // both columns (so >= 2 distinct indexes => the MULTI-INDEX OR trigger
+        // fires) plus an optional residual.
+        let branch_count = rng.random_range(2..5);
+        let mut branches = Vec::with_capacity(branch_count);
+        for _ in 0..branch_count {
+            let col = if rng.random_bool(0.5) { 'c' } else { 'd' };
+            // 1-in-4 IS NULL, else equality on a small value.
+            let val = if rng.random_range(0..4) == 0 {
+                None
+            } else {
+                Some(rng.random_range(0..6))
+            };
+            branches.push((col, val));
+        }
+        // Force both columns to appear at least once so >=2 distinct indexes
+        // resolve (otherwise the trial would silently fall to the single-index
+        // path and not exercise MULTI-INDEX OR).
+        if branches.iter().all(|(col, _)| *col == 'c') {
+            branches[0].0 = 'd';
+        } else if branches.iter().all(|(col, _)| *col == 'd') {
+            branches[0].0 = 'c';
+        }
+
+        let residual_b_gt = if rng.random_bool(0.5) { Some(rng.random_range(0..2000)) } else { None };
+        let pred = OraclePredicate { branches, residual_b_gt };
+
+        let sql = pred.to_sql();
+        let actual = query_ints_sorted(&db, &sql);
+        let expected = pred.eval_reference(&rows);
+
+        assert_eq!(
+            actual, expected,
+            "trial {trial}: MULTI-INDEX OR result diverged from reference\n  SQL: {sql}",
+        );
+
+        // Also assert NO duplicate rowids slipped through (exactly-once).
+        let raw = query_ints_raw(&db, &sql);
+        let mut sorted_raw = raw.clone();
+        sorted_raw.sort_unstable();
+        sorted_raw.dedup();
+        assert_eq!(
+            raw.len(),
+            sorted_raw.len(),
+            "trial {trial}: duplicate rowid in MULTI-INDEX OR output\n  SQL: {sql}\n  raw: {raw:?}",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

PR 2/5 of the MULTI-INDEX OR epic (#5668). Makes the `IndexScanChoice::MultiIndexOr` variant (added in PR 1, #5688) **executable** for single-table scans. This is the correctness-critical PR: a wrong rowid dedup silently returns wrong query results. The whole feature is flag-gated and behind a conservative selection trigger; results are identical to before for every query — only the access path changes for genuine multi-index ORs.

## Changes

- **Execution** (`crates/vibesql-executor/src/select/scan/index_scan/execution.rs::execute_multi_index_or`): for each indexable OR branch, run the branch predicate through the existing `execute_index_scan` (so `=` uses an equality seek and `IS NULL` routes through the IS-NULL-aware filter on the indexed column — never conflated); accumulate matching rows into an **insertion-ordered dedup set keyed by rowid** (`HashSet<u64>` + `Vec<Row>`, first-encounter order) so a row satisfying multiple branches is fetched **exactly once**; apply the residual non-OR AND-conjuncts (e.g. `b > 1000`) as a post-filter around the union.
- **Database-backed `BranchIndexResolver`** (`selection.rs::DatabaseBranchResolver`): the resolver PR 1 deferred. Resolves each branch to the index VibeSQL would actually use by running the branch predicate through `cost_based_index_selection`.
- **Conservative trigger** (`selection.rs::try_multi_index_or`, wired into `select_index_scan_method`): fires **only** for a genuine multi-index union — every top-level OR branch independently indexable AND the branches span **≥ 2 distinct indexes** — with **no ORDER BY** and on a **rowid table**. Same-index ORs (`c=1 OR c=2`) and ORDER BY queries stay on the existing path. The honest cost-model decision is deferred to PR 3.
- **WITHOUT ROWID guard**: such tables have no rowid to dedup on, so they fall back to single-scan + residual (out of scope per #5668 §2b).
- **Flag gate** `MULTI_INDEX_OR_DISABLED` (default ON), mirroring `JOIN_REORDER_DISABLED`. When set, the variant is never produced and behavior is byte-identical to before.
- **`table.rs`** dispatch arm now executes the union instead of `unreachable!`.

### What triggers the new path (precisely)
`select_index_scan_method` calls `try_multi_index_or` FIRST. It returns the `MultiIndexOr` choice iff: the flag is unset; there is no `ORDER BY`; the table has a rowid; the top-level WHERE is an OR (optionally AND'd with residual conjuncts) whose every branch independently resolves to an index; and those branches reference **≥ 2 distinct indexes**. Otherwise selection falls through unchanged to regular / skip-scan / full-scan. This is the narrowest trigger that still exercises execution: it never alters the row set of any query (oracle-verified), only the access path of true multi-index ORs.

### Dedup approach
Per branch, `execute_index_scan` yields rows with `row_id` set (1-based; relocated rowid honored). Rows are pushed into a `Vec<Row>` only on first encounter of their rowid (tracked by a `HashSet<u64>`), giving SQLite-faithful first-encounter union order with exactly-once semantics. The residual is then applied around the deduped union.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Rows matching BOTH branches appear exactly once | ✅ | `rows_matching_both_branches_appear_exactly_once`, `three_way_or_dedups_across_all_branches` |
| `IS NULL` branch correct, distinct from `=` | ✅ | `is_null_branch_returns_correct_rows_distinct_from_equality` (and `d = NULL` matches nothing) |
| Empty-branch results | ✅ | `empty_branch_results_are_handled` |
| NULL keys don't spuriously match equality | ✅ | `null_keys_do_not_spuriously_match_equality_branches` |
| Residual filter (`b>1000`) applied around union | ✅ | `residual_filter_applied_around_union` |
| Oracle/property test vs full-scan-residual baseline | ✅ | `oracle_property_test_multi_index_or_matches_reference` — 200 trials of randomized data + randomized indexable-OR predicates, diffed against an independent in-Rust reference (set-equal + no duplicate rowids). `SCAN_PATH_VERBOSE` confirms 196 of the trial queries genuinely took the MULTI-INDEX OR path. |
| `MULTI_INDEX_OR_DISABLED=1` reverts behavior | ✅ | `disabled_flag_reverts_to_prior_behavior` |
| WITHOUT ROWID guarded out | ✅ | `try_multi_index_or` checks `schema.without_rowid` |
| No result regression | ✅ | Per-file `make test-tcl` (static) **enabled vs disabled** identical for where/where2/where9/index/in/select9; full executor lib (2961) + integration suites pass; `select9` native slowness is pre-existing (times out identically with the flag disabled). |

## Test Plan

- `cargo test -p vibesql-executor --test multi_index_or_tests` — 9 passed (incl. 200-trial oracle).
- `cargo test -p vibesql-executor --lib` — 2961 passed.
- Index/explain/join integration suites — pass.
- TCL: per-file enabled-vs-disabled equality confirms no result change introduced by the feature.

Notes: PR 2/5 of #5668. Does NOT implement the cost-model auto-selection (PR 3), EQP rendering (PR 4), or join/correlated handling (PR 5).

Closes #5684