### PR TITLE
fix(catalog): preserve first-occurrence column index on duplicate names

### DIFF
--- a/crates/vibesql-catalog/src/table.rs
+++ b/crates/vibesql-catalog/src/table.rs
@@ -49,13 +49,31 @@ pub struct TableSchema {
 }
 
 impl TableSchema {
+    /// Build the column-name -> index lookup cache, preserving the FIRST
+    /// occurrence of each name on duplicates.
+    ///
+    /// Real tables reject duplicate column names at CREATE TABLE time, but VIEW
+    /// pseudo-schemas built from `SELECT *` over a join can legitimately carry
+    /// duplicate column names (e.g. two columns named `c`). When that happens,
+    /// `get_column_index` must agree with the FIRST-match semantics of
+    /// `columns.iter().position(...)` used by the view UPDATE path. A plain
+    /// `HashMap` collect is last-write-wins, which disagreed with `position()`
+    /// and caused INSTEAD OF UPDATE triggers on such views to read the wrong
+    /// `new.<col>` slot (see issue #5703). Using `entry().or_insert()` keeps the
+    /// first index, matching `position()`.
+    fn build_column_index_cache(columns: &[ColumnSchema]) -> HashMap<String, usize> {
+        columns.iter().enumerate().fold(HashMap::new(), |mut map, (idx, col)| {
+            map.entry(col.name.clone()).or_insert(idx);
+            map
+        })
+    }
+
     pub fn new(name: String, columns: Vec<ColumnSchema>) -> Self {
         // Store columns by exact name for case-sensitive lookups.
         // The parser normalizes unquoted identifiers to uppercase, so case-insensitive
         // matching for regular identifiers works automatically. Delimited identifiers
         // (quoted with "") preserve exact case per SQL:1999 Section 5.2.
-        let column_index_cache: HashMap<String, usize> =
-            columns.iter().enumerate().map(|(idx, col)| (col.name.clone(), idx)).collect();
+        let column_index_cache: HashMap<String, usize> = Self::build_column_index_cache(&columns);
 
         TableSchema {
             name,
@@ -79,8 +97,7 @@ impl TableSchema {
         columns: Vec<ColumnSchema>,
         primary_key: Vec<String>,
     ) -> Self {
-        let column_index_cache: HashMap<String, usize> =
-            columns.iter().enumerate().map(|(idx, col)| (col.name.clone(), idx)).collect();
+        let column_index_cache: HashMap<String, usize> = Self::build_column_index_cache(&columns);
 
         TableSchema {
             name,
@@ -104,8 +121,7 @@ impl TableSchema {
         columns: Vec<ColumnSchema>,
         unique_constraints: Vec<Vec<String>>,
     ) -> Self {
-        let column_index_cache: HashMap<String, usize> =
-            columns.iter().enumerate().map(|(idx, col)| (col.name.clone(), idx)).collect();
+        let column_index_cache: HashMap<String, usize> = Self::build_column_index_cache(&columns);
 
         TableSchema {
             name,
@@ -129,8 +145,7 @@ impl TableSchema {
         columns: Vec<ColumnSchema>,
         foreign_keys: Vec<ForeignKeyConstraint>,
     ) -> Self {
-        let column_index_cache: HashMap<String, usize> =
-            columns.iter().enumerate().map(|(idx, col)| (col.name.clone(), idx)).collect();
+        let column_index_cache: HashMap<String, usize> = Self::build_column_index_cache(&columns);
 
         TableSchema {
             name,
@@ -155,8 +170,7 @@ impl TableSchema {
         primary_key: Option<Vec<String>>,
         unique_constraints: Vec<Vec<String>>,
     ) -> Self {
-        let column_index_cache: HashMap<String, usize> =
-            columns.iter().enumerate().map(|(idx, col)| (col.name.clone(), idx)).collect();
+        let column_index_cache: HashMap<String, usize> = Self::build_column_index_cache(&columns);
 
         TableSchema {
             name,
@@ -183,8 +197,7 @@ impl TableSchema {
         check_constraints: Vec<(String, vibesql_ast::Expression)>,
         foreign_keys: Vec<ForeignKeyConstraint>,
     ) -> Self {
-        let column_index_cache: HashMap<String, usize> =
-            columns.iter().enumerate().map(|(idx, col)| (col.name.clone(), idx)).collect();
+        let column_index_cache: HashMap<String, usize> = Self::build_column_index_cache(&columns);
 
         TableSchema {
             name,
@@ -208,8 +221,7 @@ impl TableSchema {
         columns: Vec<ColumnSchema>,
         storage_format: StorageFormat,
     ) -> Self {
-        let column_index_cache: HashMap<String, usize> =
-            columns.iter().enumerate().map(|(idx, col)| (col.name.clone(), idx)).collect();
+        let column_index_cache: HashMap<String, usize> = Self::build_column_index_cache(&columns);
 
         TableSchema {
             name,

--- a/crates/vibesql-executor/src/tests/triggers/update.rs
+++ b/crates/vibesql-executor/src/tests/triggers/update.rs
@@ -367,6 +367,108 @@ fn test_update_from_on_view_with_instead_of_trigger() {
     assert_eq!(extract_string(&rows[1]), "(4,four)->(fourteen,four)");
 }
 
+/// Regression test for #5703: an INSTEAD OF UPDATE trigger on a view whose
+/// `SELECT *` over a JOIN expands to duplicate column names (two columns named
+/// `c`) must resolve `new.c` to the FIRST `c` (the one targeted by the SET
+/// assignment), not the last.
+///
+/// Root cause: `TableSchema::get_column_index` built its lookup cache via
+/// last-write-wins `HashMap::collect`, while the view UPDATE row-builder uses
+/// first-match `columns.iter().position()`. On a view with duplicate `c`
+/// columns these disagreed, so the trigger body read the unchanged `c` slot and
+/// the UPDATE became a no-op.
+#[test]
+fn test_instead_of_update_of_column_list_on_joined_view() {
+    let mut db = Database::new();
+
+    // t1 and t3 both have a column named `c`. `SELECT *` over the join expands
+    // to columns (a, b, c, d, c, y) — two columns named `c`. v1.c (the first
+    // one) is t1.c. The join on t1.a = t3.k pairs each t1 row with exactly one
+    // t3 row, so each t1 row yields exactly one v1 row (one trigger firing).
+    let setup = [
+        "CREATE TABLE t1(a INT, b INT, c INT, d INT)",
+        "CREATE TABLE t3(k INT, c INT, y INT)",
+        "INSERT INTO t1 VALUES (1, 2, 230, 4)",
+        "INSERT INTO t1 VALUES (5, 6, 236, 8)",
+        "INSERT INTO t3 VALUES (1, 999, 30)",
+        "INSERT INTO t3 VALUES (5, 998, 36)",
+        // The view's SELECT * expands to (a, b, c, d, k, c, y) — two columns
+        // named `c`. v1.c (the first match) is t1.c.
+        "CREATE VIEW v1 AS SELECT * FROM t1 JOIN t3 ON t1.a = t3.k",
+    ];
+
+    for sql in setup {
+        let stmt = Parser::parse_sql(sql).expect("Failed to parse setup SQL");
+        match stmt {
+            Statement::CreateTable(s) => {
+                CreateTableExecutor::execute(&s, &mut db).expect("Failed CREATE TABLE");
+            }
+            Statement::CreateView(s) => {
+                advanced_objects::execute_create_view(&s, &mut db).expect("Failed CREATE VIEW");
+            }
+            Statement::Insert(s) => {
+                InsertExecutor::execute(&mut db, &s).expect("Failed INSERT");
+            }
+            other => panic!("Unexpected setup statement: {:?}", other),
+        }
+    }
+
+    // INSTEAD OF UPDATE OF c trigger: write new.c back into the underlying t1
+    // row identified by old.a. If new.c resolves to the WRONG (last) `c` column,
+    // it carries the unchanged t3.c value and t1.c will not reflect c+1000.
+    let trigger_stmt = CreateTriggerStmt {
+        if_not_exists: false,
+        schema: None,
+        trigger_name: "v1r1".to_string(),
+        name_source: None,
+        timing: TriggerTiming::InsteadOf,
+        event: TriggerEvent::Update(Some(vec!["c".to_string()])),
+        table_name: "V1".to_string(),
+        granularity: TriggerGranularity::Row,
+        when_condition: None,
+        triggered_action: TriggerAction::RawSql(
+            "UPDATE t1 SET c = new.c WHERE a = old.a".to_string(),
+        ),
+    };
+    advanced_objects::execute_create_trigger(&trigger_stmt, &mut db)
+        .expect("Failed to create INSTEAD OF UPDATE OF c trigger");
+
+    // UPDATE v1 SET c = c + 1000 — the SET targets the first `c` (t1.c, values
+    // 230 and 236), so new.c should be 1230 and 1236.
+    let update_sql = "UPDATE v1 SET c = c + 1000";
+    let stmt = Parser::parse_sql(update_sql).expect("Failed to parse UPDATE");
+    let update = match stmt {
+        Statement::Update(s) => s,
+        other => panic!("Expected Update statement, got {:?}", other),
+    };
+    UpdateExecutor::execute(&update, &mut db).expect("UPDATE v1 SET c=c+1000 should succeed");
+
+    // Verify t1.c reflects c+1000 (1230, 1236) — proving new.c resolved to the
+    // first-occurrence column and the trigger UPDATE took effect.
+    let select_sql = "SELECT c FROM t1 ORDER BY a";
+    let stmt = Parser::parse_sql(select_sql).expect("Failed to parse SELECT");
+    let select = match stmt {
+        Statement::Select(s) => s,
+        other => panic!("Expected Select statement, got {:?}", other),
+    };
+    let rows = SelectExecutor::new(&db).execute(&select).expect("SELECT failed");
+
+    let c_values: Vec<i64> = rows
+        .iter()
+        .map(|row| match &row.values[0] {
+            SqlValue::Integer(n) => *n,
+            other => panic!("Expected Integer, got {:?}", other),
+        })
+        .collect();
+
+    assert_eq!(
+        c_values,
+        vec![1230, 1236],
+        "t1.c must reflect c+1000 (new.c resolved to first-occurrence column); \
+         unchanged 230/236 would indicate the split-brain bug (#5703)"
+    );
+}
+
 /// Sanity-check for #5192: UPDATE...FROM on a view where the FROM-side has
 /// zero matching rows should fire zero triggers and not error.
 #[test]

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -2368,7 +2368,6 @@ array set vibesql_skip_tests {
     joinD-1124 "Columnar join ignores non-key conjuncts in compound ON predicate (issue #5702)"
     joinD-1140 "Columnar join ignores non-key conjuncts in compound ON predicate (issue #5702)"
     joinD-1156 "Columnar join ignores non-key conjuncts in compound ON predicate (issue #5702)"
-    joinD-extra-1010 "INSTEAD OF UPDATE trigger on view not applied (issue #5703)"
     where-1.1.8 "EXPLAIN QUERY PLAN output format is SQLite-specific"
     where-1.4.4 "EXPLAIN QUERY PLAN output format is SQLite-specific"
     where-16.4 "Requires temp table from earlier ifcapable tempdb block (cross-test session state)"


### PR DESCRIPTION
## Summary

`joinD-extra-1010` failed because an `UPDATE` against a view with an `INSTEAD OF UPDATE` trigger silently became a no-op. Root cause (per Curator analysis): a column-index split-brain in `TableSchema`.

`TableSchema` built its column-name -> index lookup cache (`column_index_cache`) with a last-write-wins `HashMap::collect`. For a VIEW pseudo-schema whose `SELECT *` over a join expands to duplicate column names (two columns named `c`), `get_column_index("C")` returned the LAST `c`. Meanwhile the view UPDATE row-builder (`collect_view_updates_no_from`) targets the FIRST `c` via `columns.iter().position()`. The trigger body's `new.c` therefore read the wrong, unchanged slot, and `UPDATE v1 SET c=c+1000` had no effect.

## Changes

- `crates/vibesql-catalog/src/table.rs`: added a shared `build_column_index_cache` helper that uses `entry().or_insert()` (first-occurrence wins), and routed all seven `TableSchema` constructors through it. `get_column_index` now agrees with the first-match `position()` used by the view UPDATE path.
- `crates/vibesql-executor/src/tests/triggers/update.rs`: added `test_instead_of_update_of_column_list_on_joined_view`, which builds a view with duplicate `c` columns, fires an `INSTEAD OF UPDATE OF c` trigger, and asserts the underlying `t1.c` becomes `[1230, 1236]`.
- `scripts/tester_vibesql.tcl`: removed the `joinD-extra-1010` skip.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `new.c` resolves to first-occurrence column (c+1000) | ✅ | New unit test asserts `t1.c = [1230, 1236]` |
| Underlying table updated after the trigger fires | ✅ | Same test |
| `joinD-extra-1010` skip removed | ✅ | Removed from `tester_vibesql.tcl` |
| No regressions for views with unique column names | ✅ | Full vibesql-catalog (56) + vibesql-executor (2972 + all integration suites) pass, 0 failures |
| Only view pseudo-schemas affected | ✅ | Real tables reject duplicate names at CREATE TABLE; change is a no-op for unique-name schemas |

## Non-Regression on the cache-semantics change

The switch from last-write-wins to first-occurrence only changes behavior when a `TableSchema` has duplicate column names — impossible for base tables (rejected at CREATE TABLE), so only view pseudo-schemas are affected. Full `cargo test -p vibesql-catalog -p vibesql-executor` passes with zero failures.

## Test Plan

- `cargo test -p vibesql-executor test_instead_of_update_of_column_list_on_joined_view` — passes
- `cargo test -p vibesql-catalog -p vibesql-executor` — all green (catalog 56, executor lib 2972 + all integration suites, 0 failed)
- `cargo clippy -p vibesql-catalog -p vibesql-executor` — clean on changed files
- TCL: `make test-tcl-file FILE=joinD.test` with `joinD-extra-1010` un-skipped (result added in a follow-up comment)

Closes #5703