### PR TITLE
fix(executor,parser): evaluate volatile ORDER-BY/GROUP-BY exprs once + JSON5 + non-aggregate ORDER BY error

### DIFF
--- a/crates/vibesql-executor/Cargo.toml
+++ b/crates/vibesql-executor/Cargo.toml
@@ -30,6 +30,7 @@ bumpalo = { version = "3.16", features = ["collections"] }
 ahash = "0.8"
 arcstr = "1.2"
 serde_json = "1.0"
+json5 = "0.4"
 tokio = { version = "1.0", features = ["sync"] }
 rand = "0.10"
 md-5 = "0.11"

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/json_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/json_funcs.rs
@@ -27,11 +27,16 @@ pub(crate) fn json(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     match &args[0] {
         SqlValue::Null => Ok(SqlValue::Null),
         SqlValue::Varchar(s) | SqlValue::Character(s) => {
-            // Parse the JSON to validate it
-            let parsed: Result<serde_json::Value, _> = serde_json::from_str(s.as_str());
+            // Parse the JSON to validate it. SQLite's json() accepts a relaxed
+            // JSON5-like superset (unquoted object keys, single-quoted strings,
+            // trailing commas, comments, etc.). Try strict serde_json first for
+            // speed and exact behavior on canonical JSON, then fall back to a
+            // JSON5 parser so inputs like `{a:3}` are accepted, matching SQLite.
+            let parsed: Result<serde_json::Value, _> = serde_json::from_str(s.as_str())
+                .or_else(|_| json5::from_str::<serde_json::Value>(s.as_str()));
             match parsed {
                 Ok(value) => {
-                    // Re-serialize to minified JSON (compact format)
+                    // Re-serialize to minified, strict JSON (compact format)
                     let minified = serde_json::to_string(&value).map_err(|e| {
                         ExecutorError::SqliteCompatError(format!("malformed JSON: {}", e))
                     })?;
@@ -129,6 +134,40 @@ mod tests {
     #[test]
     fn test_json_non_string_input() {
         let result = json(&[SqlValue::Integer(42)]);
+        assert!(result.is_err());
+    }
+
+    // SQLite's json() accepts a relaxed JSON5-like syntax. These regression
+    // tests cover the aggorderby-9.x cases (unquoted keys) plus the broader
+    // JSON5 features, verifying we canonicalize back to strict minified JSON.
+    #[test]
+    fn test_json_json5_unquoted_key() {
+        let result = json(&[SqlValue::Varchar("{a:3}".into())]).unwrap();
+        assert_eq!(result, SqlValue::Varchar(r#"{"a":3}"#.into()));
+    }
+
+    #[test]
+    fn test_json_json5_multiple_unquoted_keys() {
+        let result = json(&[SqlValue::Varchar("{x:2, y:5}".into())]).unwrap();
+        assert_eq!(result, SqlValue::Varchar(r#"{"x":2,"y":5}"#.into()));
+    }
+
+    #[test]
+    fn test_json_json5_single_quoted_string() {
+        let result = json(&[SqlValue::Varchar("{'k':'v'}".into())]).unwrap();
+        assert_eq!(result, SqlValue::Varchar(r#"{"k":"v"}"#.into()));
+    }
+
+    #[test]
+    fn test_json_json5_trailing_comma() {
+        let result = json(&[SqlValue::Varchar("[1,2,3,]".into())]).unwrap();
+        assert_eq!(result, SqlValue::Varchar("[1,2,3]".into()));
+    }
+
+    #[test]
+    fn test_json_strict_json_still_rejects_garbage() {
+        // Genuinely malformed input must still error even with JSON5 fallback.
+        let result = json(&[SqlValue::Varchar("{not valid at all".into())]);
         assert!(result.is_err());
     }
 }

--- a/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
@@ -488,13 +488,33 @@ impl SelectExecutor<'_> {
                     for item in &expanded_select_list {
                         match item {
                             vibesql_ast::SelectItem::Expression { expr, .. } => {
-                                let value = self.evaluate_with_aggregates_and_grouping(
-                                    expr,
-                                    &group_rows,
-                                    &group_key,
-                                    &evaluator,
-                                    &grouping_context,
-                                )?;
+                                // Issue #5712 (distinct2-5030): when a SELECT expression
+                                // is non-deterministic (e.g. `abs(random())%5`) and is also
+                                // a GROUP BY key, it must be evaluated exactly once — at
+                                // grouping time. Re-evaluating it here would call the
+                                // volatile function again and produce an output value that
+                                // disagrees with the group key (and with ORDER BY, which
+                                // references the same key). Reuse the already-computed
+                                // group_key value for such columns.
+                                let reused = if !crate::evaluator::expression_hash::ExpressionHasher::is_deterministic(expr) {
+                                    resolved_set
+                                        .group_by_exprs
+                                        .iter()
+                                        .position(|gb| gb == expr)
+                                        .and_then(|idx| group_key.get(idx).cloned())
+                                } else {
+                                    None
+                                };
+                                let value = match reused {
+                                    Some(v) => v,
+                                    None => self.evaluate_with_aggregates_and_grouping(
+                                        expr,
+                                        &group_rows,
+                                        &group_key,
+                                        &evaluator,
+                                        &grouping_context,
+                                    )?,
+                                };
                                 aggregate_results.push(value);
                             }
                             vibesql_ast::SelectItem::Wildcard { .. }

--- a/crates/vibesql-executor/src/select/executor/nonagg/materialized.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/materialized.rs
@@ -189,6 +189,37 @@ impl SelectExecutor<'_> {
             }
         }
 
+        // Issue #5712 (distinct2-5020): when every ORDER BY term references a
+        // SELECT output column whose projected expression is non-deterministic
+        // (e.g. `abs(random())%5 AS r ... ORDER BY r`), the expression must be
+        // evaluated exactly once — at projection time — and the sort must read
+        // the already-projected output value. The normal flow sorts *before*
+        // projecting, which re-evaluates the volatile expression and yields a
+        // sort key that doesn't match the row's output value.
+        //
+        // In that case we flip the order: project (and DISTINCT-dedup) first,
+        // then sort the projected rows positionally by output column index.
+        if let Some(term_output_indices) = self.volatile_order_by_output_indices(stmt, &sorted_by) {
+            // Convert to RowWithSortKeys without sorting; project eagerly.
+            let result_rows: Vec<RowWithSortKeys> =
+                filtered_rows.into_iter().map(|row| (row, None)).collect();
+            let projected = self.apply_eager_projection(
+                stmt,
+                result_rows,
+                &schema,
+                &evaluator,
+                &window_mapping,
+            )?;
+
+            let order_by = stmt.order_by.as_ref().expect("volatile path requires ORDER BY");
+            let sorted = crate::select::order::apply_order_by_on_projected_output(
+                projected,
+                order_by,
+                &term_output_indices,
+            );
+            return Ok(sorted);
+        }
+
         // Convert to RowWithSortKeys format
         let mut result_rows: Vec<RowWithSortKeys> =
             filtered_rows.into_iter().map(|row| (row, None)).collect();
@@ -402,6 +433,57 @@ impl SelectExecutor<'_> {
             }
         }
         false
+    }
+
+    /// Detect the issue #5712 volatile-ORDER-BY case.
+    ///
+    /// Returns `Some(indices)` — one output column index per ORDER BY term — when
+    /// the query must be evaluated by projecting first and then sorting on the
+    /// projected output (so a non-deterministic projected expression is computed
+    /// exactly once). Returns `None` to use the normal sort-then-project flow.
+    ///
+    /// Conditions (all must hold):
+    /// - there is an explicit ORDER BY,
+    /// - the rows are not already pre-sorted by an index scan,
+    /// - there is no LIMIT/OFFSET (the project-first path would otherwise clip rows before
+    ///   sorting),
+    /// - there are no window functions or set operations,
+    /// - every ORDER BY term references an output column whose projected expression is
+    ///   non-deterministic.
+    fn volatile_order_by_output_indices(
+        &self,
+        stmt: &vibesql_ast::SelectStmt,
+        sorted_by: &Option<Vec<(String, vibesql_ast::OrderDirection)>>,
+    ) -> Option<Vec<usize>> {
+        let order_by = stmt.order_by.as_ref()?;
+
+        if stmt.set_operation.is_some()
+            || stmt.limit.is_some()
+            || stmt.offset.is_some()
+            || has_window_functions(&stmt.select_list)
+        {
+            return None;
+        }
+
+        // If an index scan already produced the requested order, the normal path
+        // (which skips re-sorting) is correct and cheaper.
+        if self.check_if_already_sorted(sorted_by, order_by) {
+            return None;
+        }
+
+        let mut indices = Vec::with_capacity(order_by.len());
+        for item in order_by {
+            // Only the volatile-output case is special-cased; if any term is not
+            // a non-deterministic output-column reference, fall back to the
+            // normal flow (which is correct for deterministic expressions).
+            let idx = crate::select::order::order_by_volatile_output_index(
+                &item.expr,
+                &stmt.select_list,
+            )?;
+            indices.push(idx);
+        }
+
+        Some(indices)
     }
 
     /// Apply projection strategy (eager or lazy based on DISTINCT/SET operations)

--- a/crates/vibesql-executor/src/select/order/mod.rs
+++ b/crates/vibesql-executor/src/select/order/mod.rs
@@ -19,9 +19,9 @@ use crate::{errors::ExecutorError, evaluator::CombinedExpressionEvaluator};
 
 // Re-export public API
 pub(crate) use resolution::{
-    extract_order_by_aggregates, extract_window_aggregates, resolve_order_by_alias,
-    resolve_order_by_for_aggregates, resolve_where_aliases, resolve_where_aliases_with_schema,
-    select_list_has_aliases,
+    extract_order_by_aggregates, extract_window_aggregates, order_by_volatile_output_index,
+    resolve_order_by_alias, resolve_order_by_for_aggregates, resolve_where_aliases,
+    resolve_where_aliases_with_schema, select_list_has_aliases,
 };
 
 /// Sort key for ORDER BY: (value, direction, nulls_order, collation)
@@ -80,6 +80,47 @@ pub(super) fn apply_order_by(
     parallel::sort_rows(&mut rows);
 
     Ok(rows)
+}
+
+/// Sort already-projected output rows by ORDER BY terms that reference output
+/// columns positionally.
+///
+/// This is used when at least one ORDER BY term references a SELECT output
+/// column whose projected expression is non-deterministic (e.g.
+/// `abs(random())%5`). In that situation the expression must be evaluated
+/// exactly once — at projection time — and the sort must read the projected
+/// output value rather than re-evaluating the expression (which would call the
+/// volatile function again and produce a sort key inconsistent with the row's
+/// output). See issue #5712 (distinct2-5020).
+///
+/// `term_output_indices[i]` gives the 0-based output column index that ORDER BY
+/// term `i` sorts on. All terms must map to an output column for this path.
+pub(crate) fn apply_order_by_on_projected_output(
+    rows: Vec<vibesql_storage::Row>,
+    order_by: &[vibesql_ast::OrderByItem],
+    term_output_indices: &[usize],
+) -> Vec<vibesql_storage::Row> {
+    debug_assert_eq!(order_by.len(), term_output_indices.len());
+
+    let mut rows_with_keys: Vec<RowWithSortKeys> = rows
+        .into_iter()
+        .map(|row| {
+            let keys: Vec<SortKey> = order_by
+                .iter()
+                .zip(term_output_indices.iter())
+                .map(|(order_item, &out_idx)| {
+                    let value =
+                        row.values.get(out_idx).cloned().unwrap_or(vibesql_types::SqlValue::Null);
+                    (value, order_item.direction.clone(), order_item.nulls_order, None)
+                })
+                .collect();
+            (row, Some(keys))
+        })
+        .collect();
+
+    parallel::sort_rows(&mut rows_with_keys);
+
+    rows_with_keys.into_iter().map(|(row, _)| row).collect()
 }
 
 #[cfg(test)]

--- a/crates/vibesql-executor/src/select/order/resolution.rs
+++ b/crates/vibesql-executor/src/select/order/resolution.rs
@@ -304,6 +304,83 @@ fn expressions_equal(a: &vibesql_ast::Expression, b: &vibesql_ast::Expression) -
     }
 }
 
+/// For a single ORDER BY term, determine whether it references a SELECT output
+/// column whose projected expression is **non-deterministic** (e.g.
+/// `abs(random())%5`). When it does, the term must be sorted on the already
+/// projected output value (by column position) rather than by re-evaluating the
+/// expression — otherwise a volatile function like `random()` is called a second
+/// time during sort-key evaluation and the sort key no longer matches the row's
+/// output value (issue #5712, distinct2-5020).
+///
+/// Returns `Some(output_column_index)` when the term maps to a non-deterministic
+/// projected column and the mapping is unambiguous; otherwise `None` (the caller
+/// falls back to normal expression-based resolution).
+///
+/// Only the wildcard-free case is handled: when the SELECT list contains a
+/// wildcard the 1:1 mapping from select-item index to output-column index no
+/// longer holds, so we conservatively return `None`.
+pub(crate) fn order_by_volatile_output_index(
+    order_expr: &vibesql_ast::Expression,
+    select_list: &[vibesql_ast::SelectItem],
+) -> Option<usize> {
+    use crate::evaluator::expression_hash::ExpressionHasher;
+
+    // Wildcards break the simple item-index == output-index mapping.
+    let has_wildcard = select_list.iter().any(|item| {
+        matches!(
+            item,
+            vibesql_ast::SelectItem::Wildcard { .. }
+                | vibesql_ast::SelectItem::QualifiedWildcard { .. }
+        )
+    });
+    if has_wildcard {
+        return None;
+    }
+
+    // Helper: a projected select item is "volatile" if it is an expression that
+    // is not deterministic (RANDOM(), CURRENT_TIMESTAMP, etc.).
+    let item_is_volatile = |item: &vibesql_ast::SelectItem| -> bool {
+        matches!(
+            item,
+            vibesql_ast::SelectItem::Expression { expr, .. }
+            if !ExpressionHasher::is_deterministic(expr)
+        )
+    };
+
+    // Case 1: ORDER BY N (positional reference into the SELECT list).
+    if let ColumnPositionResult::Position(pos) = extract_column_position(order_expr) {
+        if pos >= 1 && (pos as usize) <= select_list.len() {
+            let idx = (pos as usize) - 1;
+            if item_is_volatile(&select_list[idx]) {
+                return Some(idx);
+            }
+        }
+        return None;
+    }
+
+    // Case 2: ORDER BY <alias>, where <alias> is a bare (unqualified) name that
+    // matches a SELECT-list alias whose expression is non-deterministic.
+    if let vibesql_ast::Expression::ColumnRef(col_id) = order_expr {
+        if col_id.schema_canonical().is_none() && col_id.table_canonical().is_none() {
+            let column = col_id.column_canonical();
+            for (idx, item) in select_list.iter().enumerate() {
+                if let vibesql_ast::SelectItem::Expression {
+                    expr, alias: Some(alias_name), ..
+                } = item
+                {
+                    if alias_name.eq_ignore_ascii_case(column)
+                        && !ExpressionHasher::is_deterministic(expr)
+                    {
+                        return Some(idx);
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
 // =============================================================================
 // ORDER BY Alias Resolution for Regular Queries
 // =============================================================================

--- a/crates/vibesql-executor/tests/order_by_volatile_alias_tests.rs
+++ b/crates/vibesql-executor/tests/order_by_volatile_alias_tests.rs
@@ -1,0 +1,89 @@
+//! Regression tests for issue #5712 (distinct2-5020): a volatile (non-deterministic)
+//! projected expression referenced by ORDER BY must be evaluated exactly once.
+//!
+//! `SELECT DISTINCT abs(random())%5 AS r FROM cnt ORDER BY r` must produce a
+//! result where the ORDER BY sorts on the *projected* value of `r`, not on a
+//! freshly re-evaluated `abs(random())%5`. If the expression were re-evaluated
+//! during sort-key computation, `random()` would be called a second time and the
+//! sort key would no longer match the output value — yielding unsorted output
+//! and/or values outside the projected DISTINCT set.
+
+use vibesql_executor::{CreateTableExecutor, InsertExecutor, SelectExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn setup_db() -> Database {
+    let mut db = Database::new();
+
+    let create = Parser::parse_sql("CREATE TABLE cnt(a)").unwrap();
+    if let vibesql_ast::Statement::CreateTable(stmt) = create {
+        CreateTableExecutor::execute(&stmt, &mut db).unwrap();
+    }
+
+    // 50 rows, mirroring the distinct2-5020 fixture (WITH RECURSIVE 1..50).
+    for i in 1..=50 {
+        let sql = format!("INSERT INTO cnt VALUES ({i})");
+        let stmt = Parser::parse_sql(&sql).unwrap();
+        if let vibesql_ast::Statement::Insert(insert_stmt) = stmt {
+            InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
+        }
+    }
+
+    db
+}
+
+fn execute_query(db: &Database, sql: &str) -> Vec<vibesql_storage::Row> {
+    let stmt = Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor.execute(&select_stmt).unwrap()
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+fn int_values(rows: &[vibesql_storage::Row]) -> Vec<i64> {
+    rows.iter()
+        .map(|r| match &r.values[0] {
+            SqlValue::Integer(i) => *i,
+            other => panic!("expected integer, got {other:?}"),
+        })
+        .collect()
+}
+
+#[test]
+fn distinct_volatile_alias_order_by_is_evaluated_once() {
+    let db = setup_db();
+
+    // Run several times — random() makes this probabilistic, and a regression
+    // (re-evaluation) would almost certainly surface across repeated runs.
+    for _ in 0..20 {
+        let rows = execute_query(&db, "SELECT DISTINCT abs(random())%5 AS r FROM cnt ORDER BY r");
+        let vals = int_values(&rows);
+
+        // With 50 rows and 5 buckets, all of 0..=4 are present with overwhelming
+        // probability; assert the exact SQLite expectation.
+        assert_eq!(vals, vec![0, 1, 2, 3, 4], "DISTINCT volatile ORDER BY mismatch");
+
+        // Output must be sorted (the sort key must equal the projected value).
+        let mut sorted = vals.clone();
+        sorted.sort();
+        assert_eq!(vals, sorted, "result not sorted by projected output value");
+    }
+}
+
+#[test]
+fn volatile_alias_order_by_positional_is_evaluated_once() {
+    let db = setup_db();
+
+    for _ in 0..20 {
+        let rows = execute_query(&db, "SELECT DISTINCT abs(random())%5 AS r FROM cnt ORDER BY 1");
+        let vals = int_values(&rows);
+        let mut sorted = vals.clone();
+        sorted.sort();
+        assert_eq!(vals, sorted, "ORDER BY 1 on volatile alias must sort projected output");
+        // Every value must be a valid bucket (no leaked re-evaluated key).
+        assert!(vals.iter().all(|v| (0..=4).contains(v)));
+    }
+}

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -260,12 +260,16 @@ impl Parser {
                 }
             }
 
-            // Parse optional ORDER BY clause for aggregate functions
+            // Parse optional ORDER BY clause inside a function call.
             // SQL:2003 syntax: aggregate(expr ORDER BY order_list)
             // Example: GROUP_CONCAT(name ORDER BY name ASC)
-            if might_be_aggregate
-                && matches!(self.peek(), Token::Keyword { keyword: Keyword::Order, .. })
-            {
+            //
+            // We parse ORDER BY unconditionally (not gated on `might_be_aggregate`)
+            // so that the keyword is always consumed. Whether ORDER BY is *allowed*
+            // is validated post-parse via the `is_aggregate` check below, which emits
+            // the SQLite-compatible "ORDER BY may not be used with non-aggregate F()"
+            // error instead of a generic `near "ORDER"` syntax error.
+            if matches!(self.peek(), Token::Keyword { keyword: Keyword::Order, .. }) {
                 self.advance(); // consume ORDER
                 self.expect_keyword(Keyword::By)?;
 
@@ -412,21 +416,17 @@ impl Parser {
                 filter,
             }))
         } else {
-            // ORDER BY and FILTER are only allowed in aggregate functions
+            // ORDER BY and FILTER are only allowed in aggregate functions.
+            // SQLite reports the function name using its original (as-written)
+            // case, e.g. `... non-aggregate abs()` for `abs(a ORDER BY ...)`.
             if order_by.is_some() {
                 return Err(ParseError {
-                    message: format!(
-                        "ORDER BY may not be used with non-aggregate {}()",
-                        first.to_uppercase()
-                    ),
+                    message: format!("ORDER BY may not be used with non-aggregate {}()", first),
                 });
             }
             if filter.is_some() {
                 return Err(ParseError {
-                    message: format!(
-                        "FILTER may not be used with non-aggregate {}()",
-                        first.to_uppercase()
-                    ),
+                    message: format!("FILTER may not be used with non-aggregate {}()", first),
                 });
             }
             Ok(Some(vibesql_ast::Expression::Function { name: func_id, args, character_unit }))

--- a/crates/vibesql-parser/src/tests/aggregates.rs
+++ b/crates/vibesql-parser/src/tests/aggregates.rs
@@ -333,3 +333,20 @@ fn test_filter_not_allowed_on_non_aggregate() {
     let result = Parser::parse_sql("SELECT UPPER(name) FILTER (WHERE active = 1) FROM users;");
     assert!(result.is_err(), "Expected parse error for FILTER on non-aggregate");
 }
+
+#[test]
+fn test_order_by_not_allowed_on_non_aggregate() {
+    // Issue #5712 (aggorderby-1.3): ORDER BY inside a non-aggregate function
+    // must produce the SQLite-compatible message
+    // "ORDER BY may not be used with non-aggregate <F>()" rather than a generic
+    // `near "ORDER": syntax error`. The ORDER BY keyword must be parsed
+    // unconditionally so the post-parse aggregate check can emit the error.
+    let result = Parser::parse_sql("SELECT abs(a ORDER BY max(d)) FROM t1;");
+    assert!(result.is_err(), "Expected parse error for ORDER BY on non-aggregate");
+    let msg = result.unwrap_err().to_string();
+    // SQLite reports the function name in its original case: `abs()`.
+    assert!(
+        msg.contains("ORDER BY may not be used with non-aggregate abs()"),
+        "Unexpected error message: {msg}"
+    );
+}

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -384,6 +384,19 @@ proc translate_error_to_sqlite {vibesql_error} {
         return "misuse of aggregate function"
     }
 
+    # ORDER BY / FILTER used with a non-aggregate function (aggorderby-1.3,
+    # filter1-*) — SQLite returns the message verbatim, not wrapped. This must be
+    # checked BEFORE the generic "ORDER BY ... aggregate" fallback below, which
+    # would otherwise mis-translate it to "misuse of aggregate".
+    #
+    # The `Parse error:` prefix is optional: catchsql translates the message a
+    # second time (execsql already translated it once when raising), so on the
+    # second pass the prefix has already been stripped. Match both forms and pass
+    # the message through verbatim (idempotent).
+    if {[regexp -nocase {^(?:Parse error: )?((?:ORDER BY|FILTER) may not be used with non-aggregate .+\(\))$} $error_msg -> parse_msg]} {
+        return $parse_msg
+    }
+
     # Legacy: Aggregate in ORDER BY context (for old error messages)
     if {[regexp -nocase {aggregate.*ORDER BY|ORDER BY.*aggregate} $error_msg]} {
         if {[regexp -nocase {(min|max|sum|avg|count)} $error_msg -> func_name]} {
@@ -2769,6 +2782,13 @@ array set vibesql_skip_tests {
     expr-7.7 "Uses db status stmt_status - SQLite API"
     expr-7.8 "Uses db status stmt_status - SQLite API"
 
+    aggerror-1.1 "Uses x_count, a custom C aggregate registered via sqlite3_create_aggregate (C embedding API; not reachable from the SQL CLI - issue #5712)"
+    aggerror-1.2 "Uses x_count, a custom C aggregate registered via sqlite3_create_aggregate (C embedding API; not reachable from the SQL CLI - issue #5712)"
+    aggerror-1.3 "Uses x_count, a custom C aggregate registered via sqlite3_create_aggregate (C embedding API; not reachable from the SQL CLI - issue #5712)"
+    aggerror-1.4 "Uses x_count, a custom C aggregate registered via sqlite3_create_aggregate (C embedding API; not reachable from the SQL CLI - issue #5712)"
+    aggerror-1.5 "Uses x_count, a custom C aggregate registered via sqlite3_create_aggregate (C embedding API; not reachable from the SQL CLI - issue #5712)"
+    aggerror-1.6 "Uses x_count, a custom C aggregate registered via sqlite3_create_aggregate (C embedding API; not reachable from the SQL CLI - issue #5712)"
+
     distinct-1.1.1 "Uses sqlite_sort_count"
     distinct-1.2.1 "Uses sqlite_sort_count"
     distinct-1.8.1 "Uses sqlite_sort_count"
@@ -2814,6 +2834,8 @@ array set vibesql_skip_tests {
     distinct-6.3.2 "Uses sqlite_sort_count"
     distinct-6.4.1 "Uses sqlite_sort_count"
     distinct-6.4.2 "Uses sqlite_sort_count"
+
+    distinct2-120 "Forward alias reference in JOIN ON clause (ON references t2.i0 before t2 is introduced); SQLite defers ON evaluation until all FROM aliases are collected. Fuzz-derived edge case - SQLite permissive forward-alias join scoping not implemented (issue #5712)"
 
     view-1.1 "View query result ordering differs"
     view-1.1.100 "Uses db config command"


### PR DESCRIPTION
## Summary
Fixes the aggregate/DISTINCT TCL failures clustered in `aggerror`, `aggorderby`, and `distinct2` (issue #5712). Three real code fixes plus targeted, annotated skips for two harness/edge-case limitations.

## Changes
- **Parser** (`functions/mod.rs`): parse `ORDER BY` inside *any* function call unconditionally (removed the `might_be_aggregate` gate) so the existing post-parse `is_aggregate` check emits `ORDER BY may not be used with non-aggregate <f>()` (original case) instead of a generic `near "ORDER": syntax error` (aggorderby-1.3). The function name is now reported in its as-written case to match SQLite.
- **`json()`** (`json_funcs.rs` + `Cargo.toml`): added a `json5` fallback after strict `serde_json`, so SQLite's relaxed JSON5 input (unquoted keys, single quotes, trailing commas) is accepted and re-serialized to strict minified JSON (aggorderby-9.0–9.3).
- **Non-agg materialized path** (`materialized.rs` + `order/mod.rs` + `order/resolution.rs`): when every ORDER BY term references a non-deterministic projected output column (e.g. `abs(random())%5 AS r ... ORDER BY r`), project (and DISTINCT-dedup) first, then sort positionally on the projected output — so volatile expressions are evaluated exactly once (distinct2-5020).
- **GROUP BY path** (`aggregation/mod.rs`): reuse the group-key value for a non-deterministic SELECT expression that is also a GROUP BY key, instead of re-evaluating it independently (distinct2-5030).
- **TCL shim** (`tester_vibesql.tcl`): skip the 6 `aggerror` `x_count` tests (custom C aggregate via `sqlite3_create_aggregate` — not reachable from the SQL CLI) and `distinct2-120` (forward-alias JOIN-ON scoping, fuzz-derived edge case), each with a clear annotation referencing #5712; pass the non-aggregate ORDER BY/FILTER error message through verbatim.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| aggerror passes or justified-skip | ✅ | 6 skipped (C-API custom aggregate), 0 failed |
| aggorderby passes | ✅ | 29 passed, 0 failed (1.3 + 9.0–9.3 fixed) |
| distinct2 passes or justified-skip | ✅ | 43 passed, 0 failed, 1 skipped (distinct2-120) |
| No regression to func.test (14547/0) | ✅ | 14547 passed, 0 failed after JSON5 change |
| No parser/executor regressions | ✅ | parser 1476/0; executor lib 2984/0 + all integration binaries 0 failed |

## Test Plan
- `python3 scripts/tcl_runner.py --vibesql ./target/release/vibesql --native-tcl --timeout 300 --files docs/reference/sqlite/test/<F>.test` for aggerror/aggorderby/distinct2/func — all green as above.
- Added Rust regression tests:
  - `crates/vibesql-parser/src/tests/aggregates.rs::test_order_by_not_allowed_on_non_aggregate` (parser error message).
  - `crates/vibesql-executor/src/evaluator/.../json_funcs.rs` JSON5 cases.
  - `crates/vibesql-executor/tests/order_by_volatile_alias_tests.rs` (volatile-expr-once for DISTINCT alias + positional ORDER BY).
- `cargo test -p vibesql-parser` and `cargo test -p vibesql-executor` pass with no regressions.

Closes #5712