### PR TITLE
fix(executor): stop dropping scalar-subquery predicate AND'd with same-table predicate

### DIFF
--- a/crates/vibesql-executor/src/pipeline/columnar.rs
+++ b/crates/vibesql-executor/src/pipeline/columnar.rs
@@ -10,7 +10,7 @@ use super::{ExecutionContext, ExecutionPipeline, PipelineInput, PipelineOutput};
 use crate::{
     errors::ExecutorError,
     select::columnar::{
-        extract_aggregates, extract_column_predicates, simd_filter_batch, AggregateSource,
+        extract_aggregates, extract_full_coverage_predicates, simd_filter_batch, AggregateSource,
         ColumnarBatch,
     },
 };
@@ -106,11 +106,21 @@ impl ExecutionPipeline for ColumnarPipeline {
 
             let predicate = predicate.unwrap();
 
-            // Try to extract simple predicates for SIMD filtering
-            let predicates = match extract_column_predicates(predicate, ctx.schema, ctx.database.case_sensitive_like()) {
+            // Try to extract simple predicates for SIMD filtering.
+            //
+            // Issue #5719: use the strict, full-coverage extractor. It returns
+            // `Some` only when *every* conjunct can be evaluated columnarly, so
+            // a WHERE that mixes a foldable predicate with a scalar subquery (or
+            // any other non-foldable conjunct) falls back to the full-expression
+            // evaluator instead of silently dropping the non-foldable predicate.
+            let predicates = match extract_full_coverage_predicates(
+                predicate,
+                ctx.schema,
+                ctx.database.case_sensitive_like(),
+            ) {
                 Some(preds) => preds,
                 None => {
-                    // Complex predicate - fall back to row-oriented filtering
+                    // Predicate not fully columnar - fall back to row-oriented filtering
                     let rows = batch.to_rows()?;
                     return self.fallback_filter(rows, Some(predicate), ctx);
                 }
@@ -142,11 +152,17 @@ impl ExecutionPipeline for ColumnarPipeline {
 
         let predicate = predicate.unwrap();
 
-        // Try to extract simple predicates for SIMD filtering
-        let predicates = match extract_column_predicates(predicate, ctx.schema, ctx.database.case_sensitive_like()) {
+        // Try to extract simple predicates for SIMD filtering.
+        //
+        // Issue #5719: strict full-coverage extraction (see batch path above).
+        let predicates = match extract_full_coverage_predicates(
+            predicate,
+            ctx.schema,
+            ctx.database.case_sensitive_like(),
+        ) {
             Some(preds) => preds,
             None => {
-                // Complex predicate - fall back to row-oriented filtering
+                // Predicate not fully columnar - fall back to row-oriented filtering
                 return self.fallback_filter(rows, Some(predicate), ctx);
             }
         };

--- a/crates/vibesql-executor/src/pipeline/native_columnar.rs
+++ b/crates/vibesql-executor/src/pipeline/native_columnar.rs
@@ -11,7 +11,7 @@ use super::{ExecutionContext, ExecutionPipeline, PipelineInput, PipelineOutput};
 use crate::{
     errors::ExecutorError,
     select::columnar::{
-        extract_aggregates, extract_column_predicates, simd_filter_batch, AggregateOp,
+        extract_aggregates, extract_full_coverage_predicates, simd_filter_batch, AggregateOp,
         AggregateSource, AggregateSpec, ColumnarBatch,
     },
 };
@@ -122,11 +122,20 @@ impl ExecutionPipeline for NativeColumnarPipeline {
 
             let predicate = predicate.unwrap();
 
-            // Extract simple predicates for SIMD filtering
-            let predicates = match extract_column_predicates(predicate, ctx.schema, ctx.database.case_sensitive_like()) {
+            // Extract simple predicates for SIMD filtering.
+            //
+            // Issue #5719: strict full-coverage extraction. Returns `Some` only
+            // when every conjunct is columnar; otherwise fall back to the full
+            // expression evaluator so non-foldable conjuncts (e.g. scalar
+            // subqueries) are not silently dropped.
+            let predicates = match extract_full_coverage_predicates(
+                predicate,
+                ctx.schema,
+                ctx.database.case_sensitive_like(),
+            ) {
                 Some(preds) => preds,
                 None => {
-                    // Complex predicate - fall back to row filtering
+                    // Predicate not fully columnar - fall back to row filtering
                     let rows = batch.to_rows()?;
                     return self.fallback_filter(rows, Some(predicate), ctx);
                 }
@@ -150,8 +159,14 @@ impl ExecutionPipeline for NativeColumnarPipeline {
 
         let predicate = predicate.unwrap();
 
-        // Try to extract simple predicates
-        let predicates = match extract_column_predicates(predicate, ctx.schema, ctx.database.case_sensitive_like()) {
+        // Try to extract simple predicates.
+        //
+        // Issue #5719: strict full-coverage extraction (see batch path above).
+        let predicates = match extract_full_coverage_predicates(
+            predicate,
+            ctx.schema,
+            ctx.database.case_sensitive_like(),
+        ) {
             Some(preds) => preds,
             None => {
                 return self.fallback_filter(rows, Some(predicate), ctx);

--- a/crates/vibesql-executor/src/select/columnar/filter/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/mod.rs
@@ -13,8 +13,8 @@ mod predicates;
 pub(super) use comparison::parse_date_string;
 pub use evaluation::{evaluate_column_compare, evaluate_predicate, evaluate_predicate_tree};
 pub use predicates::{
-    collect_referenced_columns, extract_column_predicates, extract_predicate_tree,
-    remap_predicates, ColumnPredicate, CompareOp, PredicateTree,
+    collect_referenced_columns, extract_column_predicates, extract_full_coverage_predicates,
+    extract_predicate_tree, remap_predicates, ColumnPredicate, CompareOp, PredicateTree,
 };
 
 use crate::{

--- a/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
@@ -498,6 +498,65 @@ pub fn extract_column_predicates(
     Some(predicates)
 }
 
+/// Extract a flat list of AND-ed column predicates that *fully* cover the WHERE
+/// clause, or `None` if any conjunct cannot be represented columnarly.
+///
+/// Issue #5719: `extract_column_predicates` is deliberately lenient — its AND
+/// branch silently skips conjuncts it cannot fold (so cross-table push-down
+/// callers can still extract the columns they own). That leniency is *wrong*
+/// for the columnar pipeline `apply_filter` step, which marks the WHERE clause
+/// as fully consumed after SIMD filtering. When a WHERE mixes a foldable
+/// predicate (`status = 'failed'`) with a non-foldable one
+/// (`run_id = (SELECT MAX(run_id) FROM t)`), the lenient extractor returns a
+/// partial set, the SIMD path applies only the partial predicate, and the
+/// scalar-subquery predicate is dropped → over-counted results.
+///
+/// This function is strict and all-or-nothing: it builds the `PredicateTree`
+/// (whose AND branch uses `?`, so it fails when *any* conjunct is
+/// non-extractable) and flattens it to a flat AND-of-leaves list suitable for
+/// `simd_filter_batch`. It returns `None` when:
+/// - any conjunct cannot be extracted (→ caller must fall back to the full expression evaluator,
+///   which handles scalar subqueries, functions, etc.);
+/// - the tree contains an OR node (the flat SIMD filter list cannot represent disjunctions; such
+///   queries already fall back today).
+///
+/// When it returns `Some`, the returned predicates fully cover the WHERE
+/// clause, so the fast SIMD path stays correct *and* there is no perf
+/// regression for analytical queries whose WHERE is fully columnar.
+pub fn extract_full_coverage_predicates(
+    expr: &Expression,
+    schema: &CombinedSchema,
+    case_sensitive_like: bool,
+) -> Option<Vec<ColumnPredicate>> {
+    let tree = extract_predicate_tree(expr, schema, case_sensitive_like)?;
+    let mut predicates = Vec::new();
+    flatten_and_tree(&tree, &mut predicates)?;
+    if predicates.is_empty() {
+        return None;
+    }
+    Some(predicates)
+}
+
+/// Flatten a strictly-AND predicate tree into a flat list of leaf predicates.
+///
+/// Returns `None` if the tree contains an OR node, since a flat AND-only
+/// predicate list cannot represent disjunctions.
+fn flatten_and_tree(tree: &PredicateTree, out: &mut Vec<ColumnPredicate>) -> Option<()> {
+    match tree {
+        PredicateTree::Leaf(predicate) => {
+            out.push(predicate.clone());
+            Some(())
+        }
+        PredicateTree::And(children) => {
+            for child in children {
+                flatten_and_tree(child, out)?;
+            }
+            Some(())
+        }
+        PredicateTree::Or(_) => None,
+    }
+}
+
 /// Try to fold a constant expression to a literal value
 ///
 /// Handles simple arithmetic expressions like `1+2`, `10-5`, `2*3`, etc.

--- a/crates/vibesql-executor/src/select/columnar/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/mod.rs
@@ -57,7 +57,7 @@ pub use executor::execute_columnar_batch;
 pub use filter::{
     apply_columnar_filter, apply_columnar_filter_simd_streaming, create_filter_bitmap,
     create_filter_bitmap_tree, evaluate_predicate_tree, extract_column_predicates,
-    extract_predicate_tree, ColumnPredicate, PredicateTree,
+    extract_full_coverage_predicates, extract_predicate_tree, ColumnPredicate, PredicateTree,
 };
 use log;
 pub use scan::ColumnarScan;
@@ -475,9 +475,17 @@ pub fn execute_columnar(
 ) -> Option<Result<Vec<Row>, ExecutorError>> {
     log::debug!("  Executing columnar query with {} rows", rows.len());
 
-    // Extract column predicates from filter expression
+    // Extract column predicates from filter expression.
+    //
+    // Issue #5719: this columnar aggregate path applies the WHERE itself and
+    // returns the aggregate as the final result, so the extracted predicates
+    // must FULLY cover the WHERE clause. Use the strict full-coverage extractor
+    // — it returns `None` when any conjunct (e.g. a scalar subquery) cannot be
+    // folded columnarly, so the caller falls back to row-based execution that
+    // evaluates the complete WHERE. The lenient `extract_column_predicates`
+    // would silently drop the non-foldable conjunct and over-count.
     let predicates = if let Some(filter_expr) = filter {
-        match extract_column_predicates(filter_expr, schema, case_sensitive_like) {
+        match extract_full_coverage_predicates(filter_expr, schema, case_sensitive_like) {
             Some(preds) => {
                 log::debug!("    ✓ Extracted {} column predicates for SIMD filtering", preds.len());
                 preds

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/mod.rs
@@ -473,9 +473,15 @@ impl SelectExecutor<'_> {
         // IMPORTANT: If we have a WHERE clause but can't extract predicates (e.g., IS NULL,
         // IS NOT NULL, or other unsupported expressions), we MUST fall back to row-based
         // execution. Using an empty predicate list would incorrectly skip filtering! (#4XXX)
+        // Issue #5719: this native columnar path applies the WHERE itself and
+        // returns the aggregate result, so the extracted predicates must FULLY
+        // cover the WHERE. Use the strict full-coverage extractor — it returns
+        // `None` when any conjunct (e.g. a scalar subquery) is non-columnar, so
+        // we fall back to row-based execution rather than silently dropping the
+        // conjunct and over-counting.
         let predicates = match stmt.where_clause.as_ref() {
             Some(where_expr) => {
-                match columnar::extract_column_predicates(
+                match columnar::extract_full_coverage_predicates(
                     where_expr,
                     &schema,
                     self.database.case_sensitive_like(),

--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -12,6 +12,8 @@
 
 use std::collections::HashMap;
 
+use vibesql_catalog::TableIdentifier;
+
 use super::predicates::{apply_table_local_predicates, filter_and_clone_rows};
 #[cfg(feature = "parallel")]
 use crate::select::parallel::parallel_scan_materialize;
@@ -36,7 +38,6 @@ use crate::{
         execute_sqlite_stat1_query, get_sqlite_stat1_table_schema, is_sqlite_stat_table,
     },
 };
-use vibesql_catalog::TableIdentifier;
 
 /// Minimum row count to benefit from SIMD columnar filtering
 /// Below this threshold, row-by-row filtering is faster due to conversion overhead
@@ -595,10 +596,23 @@ pub(crate) fn execute_table_scan(
         // - IN predicates from OR expressions use the alias (e.g., "n1" from "nation n1")
         // - Regular predicates may use the actual table name
         let effective_name_lower = effective_name.to_lowercase();
-        let has_filters = predicate_plan.has_table_filters(&effective_name)
+        let has_table_local = predicate_plan.has_table_filters(&effective_name)
             || predicate_plan.has_table_filters(&effective_name_lower)
             || predicate_plan.has_table_filters(table_name)
             || predicate_plan.has_table_filters(&table_name.to_lowercase());
+
+        // Issue #5719: the optimized `has_filters` block below applies only the
+        // table-local predicates and then marks the WHERE as fully consumed
+        // (`from_rows_where_filtered(.., None)`). When the WHERE also carries a
+        // "complex" predicate — e.g. a scalar-subquery equality
+        // `run_id = (SELECT MAX(run_id) FROM t)`, which `decompose_where_clause`
+        // routes to `complex_predicates` rather than `table_local_predicates` —
+        // consuming the WHERE here would silently DROP that conjunct and
+        // over-return rows. In that case fall through to the unfiltered path,
+        // which preserves the WHERE (`where_filtered = false`) so the executor
+        // re-evaluates the FULL WHERE clause (including the scalar subquery).
+        let has_complex_predicates = !predicate_plan.get_complex_predicates().is_empty();
+        let has_filters = has_table_local && !has_complex_predicates;
 
         if crate::profiling::is_scan_debug_enabled() {
             eprintln!("[SCAN_PATH] {} (alias={}) table: has_filters={} (effective_name={}, table_name={})",
@@ -610,11 +624,24 @@ pub(crate) fn execute_table_scan(
         if has_filters {
             // Try columnar filter optimization for simple predicates
             // Extract predicates once and choose the best execution path (#2972)
-            if let Some(column_predicates) = crate::select::columnar::extract_column_predicates(
-                where_expr,
-                &schema,
-                database.case_sensitive_like(),
-            ) {
+            //
+            // Issue #5719: this single-table scan path consumes the ENTIRE WHERE
+            // clause — on success it returns `from_rows_where_filtered(.., None)`,
+            // marking the WHERE as fully applied. The lenient
+            // `extract_column_predicates` silently skips conjuncts it cannot fold
+            // (e.g. a scalar subquery `run_id = (SELECT MAX(run_id) FROM t)`),
+            // which would then be dropped entirely, over-returning rows. Use the
+            // strict full-coverage extractor: it returns `Some` only when every
+            // conjunct is columnar, otherwise we fall through to the generic
+            // predicate path below, which evaluates the full WHERE (including
+            // scalar subqueries) correctly.
+            if let Some(column_predicates) =
+                crate::select::columnar::extract_full_coverage_predicates(
+                    where_expr,
+                    &schema,
+                    database.case_sensitive_like(),
+                )
+            {
                 // OPTIMIZATION: Avoid double-cloning rows
                 // Before: scan_live_vec() clones ALL rows, then filter clones passing rows again
                 // After: scan() returns &[Row] references, filter returns indices,

--- a/crates/vibesql-executor/tests/scalar_subquery_and_predicate_tests.rs
+++ b/crates/vibesql-executor/tests/scalar_subquery_and_predicate_tests.rs
@@ -1,0 +1,201 @@
+//! Regression tests for issue #5719
+//!
+//! A scalar-subquery equality predicate was silently dropped when AND'd with
+//! another same-table predicate on the columnar analytical fast path.
+//!
+//! Root cause: `ColumnarPipeline::apply_filter` /
+//! `NativeColumnarPipeline::apply_filter` called the lenient
+//! `extract_column_predicates`, whose AND branch silently skips conjuncts it
+//! cannot fold columnarly. For a WHERE like
+//! `status = 'failed' AND run_id = (SELECT MAX(run_id) FROM t)` it returned only
+//! `[status = 'failed']` (NOT `None`), so the SIMD path applied just that
+//! predicate and the scalar-subquery conjunct was dropped → over-counted rows.
+//!
+//! The fix routes both pipelines through the strict
+//! `extract_full_coverage_predicates`, which returns `Some` only when every
+//! conjunct is columnar; otherwise the pipeline falls back to the full
+//! expression evaluator (which handles scalar subqueries correctly).
+//!
+//! The analytical pattern (aggregate + selective projection / arithmetic /
+//! GROUP BY) is what selects the StandardColumnar strategy, so the tests use
+//! aggregate queries. A control case with `SELECT *` (RowOriented path) and a
+//! lone scalar-subquery WHERE (no AND) guard against regressions.
+
+use vibesql_catalog::{ColumnSchema, TableSchema};
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::{Database, Row};
+use vibesql_types::{DataType, SqlValue};
+
+fn parse_select(sql: &str) -> vibesql_ast::SelectStmt {
+    match Parser::parse_sql(sql) {
+        Ok(vibesql_ast::Statement::Select(select_stmt)) => *select_stmt,
+        _ => panic!("Failed to parse SELECT statement: {}", sql),
+    }
+}
+
+fn run(db: &Database, sql: &str) -> Vec<Row> {
+    let select = parse_select(sql);
+    SelectExecutor::new(db).execute(&select).unwrap()
+}
+
+/// Build the reproduction table.
+///
+/// ```sql
+/// CREATE TABLE t (run_id INTEGER, status TEXT, amount INTEGER);
+/// ```
+///
+/// The max run_id is 3. Among rows with `run_id = 3` exactly two have
+/// `status = 'failed'` (amounts 100 and 40). Many extra rows with smaller
+/// run_ids and `status = 'failed'` exist so that dropping the
+/// `run_id = (SELECT MAX(run_id) FROM t)` conjunct visibly over-counts.
+fn setup_db() -> Database {
+    let mut db = Database::new();
+
+    let schema = TableSchema::new(
+        "T".to_string(),
+        vec![
+            ColumnSchema::new("run_id".to_string(), DataType::Integer, true),
+            ColumnSchema::new("status".to_string(), DataType::Varchar { max_length: None }, true),
+            ColumnSchema::new("amount".to_string(), DataType::Integer, true),
+        ],
+    );
+    db.create_table(schema).unwrap();
+
+    let mut insert = |run_id: i64, status: &str, amount: i64| {
+        db.insert_row(
+            "T",
+            Row::new(vec![
+                SqlValue::Integer(run_id),
+                SqlValue::Varchar(status.into()),
+                SqlValue::Integer(amount),
+            ]),
+        )
+        .unwrap();
+    };
+
+    // run_id = 1: 5 failed rows (these must NOT be counted)
+    for amount in [1, 2, 3, 4, 5] {
+        insert(1, "failed", amount);
+    }
+    insert(1, "passed", 6);
+
+    // run_id = 2: 3 failed rows (these must NOT be counted)
+    for amount in [10, 11, 12] {
+        insert(2, "failed", amount);
+    }
+    insert(2, "passed", 13);
+
+    // run_id = 3 (the MAX): exactly 2 failed rows (amounts 100, 40), 1 passed.
+    insert(3, "failed", 100);
+    insert(3, "passed", 99);
+    insert(3, "failed", 40);
+
+    db
+}
+
+/// The exact headline repro: COUNT(*) over a same-table column predicate AND a
+/// scalar-subquery equality predicate. Before the fix this returned 10 (every
+/// `status = 'failed'` row) instead of 2 (only `run_id = MAX`).
+#[test]
+fn test_count_col_and_scalar_subquery_not_overcounted() {
+    let db = setup_db();
+
+    let sql = "SELECT COUNT(*) FROM t \
+               WHERE status = 'failed' AND run_id = (SELECT MAX(run_id) FROM t)";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(
+        result[0].values[0],
+        SqlValue::Integer(2),
+        "COUNT(*) must be 2 (failed rows at run_id=MAX), not over-counted"
+    );
+}
+
+/// The scalar-subquery conjunct on the *left* of the AND must be honored too —
+/// guards against an order-dependent partial extraction.
+#[test]
+fn test_count_scalar_subquery_and_col_left_order() {
+    let db = setup_db();
+
+    let sql = "SELECT COUNT(*) FROM t \
+               WHERE run_id = (SELECT MAX(run_id) FROM t) AND status = 'failed'";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].values[0], SqlValue::Integer(2));
+}
+
+/// SUM variant: only the two run_id=MAX failed rows (100 + 40) contribute.
+#[test]
+fn test_sum_col_and_scalar_subquery() {
+    let db = setup_db();
+
+    let sql = "SELECT SUM(amount) FROM t \
+               WHERE status = 'failed' AND run_id = (SELECT MAX(run_id) FROM t)";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].values[0], SqlValue::Integer(140), "SUM(amount) must be 100 + 40 = 140");
+}
+
+/// MAX variant: max amount among run_id=MAX failed rows is 100.
+#[test]
+fn test_max_col_and_scalar_subquery() {
+    let db = setup_db();
+
+    let sql = "SELECT MAX(amount) FROM t \
+               WHERE status = 'failed' AND run_id = (SELECT MAX(run_id) FROM t)";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].values[0], SqlValue::Integer(100));
+}
+
+/// Control: lone scalar-subquery predicate (no AND). Must work and count all
+/// three run_id=MAX rows (2 failed + 1 passed).
+#[test]
+fn test_count_scalar_subquery_alone() {
+    let db = setup_db();
+
+    let sql = "SELECT COUNT(*) FROM t WHERE run_id = (SELECT MAX(run_id) FROM t)";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].values[0], SqlValue::Integer(3));
+}
+
+/// Control: `SELECT *` takes the RowOriented path (no analytical pattern) and
+/// must already be correct. This asserts the same predicate set returns exactly
+/// the 2 matching rows.
+#[test]
+fn test_select_star_col_and_scalar_subquery() {
+    let db = setup_db();
+
+    let sql = "SELECT run_id, status, amount FROM t \
+               WHERE status = 'failed' AND run_id = (SELECT MAX(run_id) FROM t) \
+               ORDER BY amount";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 2, "exactly 2 rows: run_id=3 failed");
+    assert_eq!(result[0].values[0], SqlValue::Integer(3));
+    assert_eq!(result[0].values[2], SqlValue::Integer(40));
+    assert_eq!(result[1].values[0], SqlValue::Integer(3));
+    assert_eq!(result[1].values[2], SqlValue::Integer(100));
+}
+
+/// Fully-columnar WHERE (two simple column predicates, no subquery) must still
+/// take the fast SIMD path and return the correct count — guards against the
+/// fix accidentally forcing fallback for fully-covered WHEREs.
+#[test]
+fn test_count_two_column_predicates_full_coverage() {
+    let db = setup_db();
+
+    // run_id = 1 AND status = 'failed' → the 5 seeded failed rows at run_id=1.
+    let sql = "SELECT COUNT(*) FROM t WHERE status = 'failed' AND run_id = 1";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].values[0], SqlValue::Integer(5));
+}


### PR DESCRIPTION
Closes #5719

## Problem

A WHERE clause that AND's a foldable column predicate with a scalar-subquery
equality predicate — e.g.

```sql
SELECT COUNT(*) FROM t WHERE status='failed' AND run_id=(SELECT MAX(run_id) FROM t);
```

silently **dropped** the scalar-subquery conjunct on the columnar / analytical
fast paths, over-returning rows (`3` instead of `1` in the issue repro). This
is the confirmed major contributor to `select9.test` failures (#5720).

## Root cause

`extract_column_predicates` is intentionally lenient: its AND branch skips
conjuncts it cannot fold columnarly (so cross-table push-down callers can still
extract the columns they own). Several call sites treat the extracted set as the
**complete** WHERE filter — they apply only the foldable predicate and then mark
the WHERE as fully consumed. The non-foldable scalar-subquery conjunct was
dropped forever.

Two independent mechanisms were involved:
1. The columnar pipeline / aggregate paths (`apply_filter`, `execute_columnar`,
   native columnar aggregate) trusted the partial predicate list.
2. The single-table table scan classified the scalar subquery into
   `complex_predicates` (not table-local), applied only the table-local
   predicates, and still marked the WHERE consumed via
   `from_rows_where_filtered(.., None)`.

## Fix

- New strict extractor `extract_full_coverage_predicates`: builds the
  `PredicateTree` (AND branch uses `?`, so it fails if **any** conjunct is
  non-extractable), flattens to a flat AND-of-leaves list, and returns `None`
  when coverage is incomplete or the tree contains OR. Callers then fall back to
  the full row-based expression evaluator (which handles scalar subqueries).
  Fully-columnar WHEREs still take the fast SIMD path — no perf regression.
- Routed the WHERE-consuming call sites through it: `ColumnarPipeline` /
  `NativeColumnarPipeline::apply_filter`, `execute_columnar`, the native
  columnar aggregate path, and the single-table table scan.
- Gated the optimized single-table scan block on `complex_predicates` being
  empty; otherwise fall through to the unfiltered path so the executor
  re-evaluates the FULL WHERE (`where_filtered = false`).

## Verification

Exact issue repro now returns `1` (was `3`). `SELECT *`, GROUP BY, and a
fully-columnar control all correct.

New regression tests (`scalar_subquery_and_predicate_tests.rs`): COUNT/SUM/MAX
with column + scalar-subquery AND (both operand orders), lone scalar subquery,
`SELECT *` row path, and a fully-columnar two-column WHERE (fast-path guard) —
all 7 pass.

`cargo test -p vibesql-executor`: full suite green, 0 failures.
`where.test` TCL: 168 passed, 0 failed (no regression).
fmt/clippy: changed files clean; remaining drift is pre-existing in untouched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)