### PR TITLE
fix(executor): sort INTERSECT/EXCEPT DISTINCT output to match SQLite B-tree order

### DIFF
--- a/crates/vibesql-executor/src/select/set_operations.rs
+++ b/crates/vibesql-executor/src/select/set_operations.rs
@@ -1,6 +1,9 @@
 //! Set operations (UNION, INTERSECT, EXCEPT) for SELECT queries
 
-use std::{cmp::Ordering, collections::{HashMap, HashSet}};
+use std::{
+    cmp::Ordering,
+    collections::{HashMap, HashSet},
+};
 
 use crate::errors::ExecutorError;
 
@@ -15,9 +18,9 @@ use crate::errors::ExecutorError;
 ///
 /// Canonicalization rules:
 /// - All exact integer types collapse to `Bigint`.
-/// - All inexact numeric types (`Real`, `Float`, `Double`, `Numeric`) collapse
-///   to `Numeric(f64)`. If the value is a finite whole number, it further
-///   collapses to `Bigint` so e.g. `Real(30.0)` matches `Integer(30)`.
+/// - All inexact numeric types (`Real`, `Float`, `Double`, `Numeric`) collapse to `Numeric(f64)`.
+///   If the value is a finite whole number, it further collapses to `Bigint` so e.g. `Real(30.0)`
+///   matches `Integer(30)`.
 /// - All other values are returned unchanged.
 fn canonicalize_numeric(val: &vibesql_types::SqlValue) -> vibesql_types::SqlValue {
     use vibesql_types::SqlValue;
@@ -164,8 +167,7 @@ pub(super) fn apply_set_operation(
                 let mut combined = left;
                 combined.extend(right);
 
-                let mut index_by_key: HashMap<Vec<vibesql_types::SqlValue>, usize> =
-                    HashMap::new();
+                let mut index_by_key: HashMap<Vec<vibesql_types::SqlValue>, usize> = HashMap::new();
                 let mut result: Vec<vibesql_storage::Row> = Vec::with_capacity(combined.len());
                 for row in combined {
                     let key = normalize_row_for_comparison(&row.values, collations);
@@ -223,6 +225,16 @@ pub(super) fn apply_set_operation(
                         result.push(row);
                     }
                 }
+
+                // Sort the deduplicated result. SQLite's INTERSECT uses an
+                // ephemeral B-tree for deduplication, which naturally yields
+                // sorted output; mirror that here (same sort as UNION DISTINCT)
+                // so we don't leak left-branch scan order.
+                result.sort_by(|a, b| {
+                    let ka = normalize_row_for_comparison(&a.values, collations);
+                    let kb = normalize_row_for_comparison(&b.values, collations);
+                    compare_normalized_rows(&ka, &kb)
+                });
                 Ok(result)
             }
         }
@@ -273,8 +285,140 @@ pub(super) fn apply_set_operation(
                         result.push(row);
                     }
                 }
+
+                // Sort the deduplicated result. SQLite's EXCEPT uses an
+                // ephemeral B-tree for deduplication, which naturally yields
+                // sorted output; mirror that here (same sort as UNION DISTINCT)
+                // so we don't leak left-branch scan order.
+                result.sort_by(|a, b| {
+                    let ka = normalize_row_for_comparison(&a.values, collations);
+                    let kb = normalize_row_for_comparison(&b.values, collations);
+                    compare_normalized_rows(&ka, &kb)
+                });
                 Ok(result)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vibesql_ast::{SelectStmt, SetOperation, SetOperator};
+    use vibesql_storage::Row;
+    use vibesql_types::SqlValue;
+
+    use super::apply_set_operation;
+
+    /// Minimal placeholder SELECT for the `right` field of `SetOperation`.
+    /// `apply_set_operation` only inspects `set_op.op` and `set_op.all`; the
+    /// `right` statement is never read (rows are pre-evaluated), so an empty
+    /// statement is sufficient.
+    fn empty_select() -> SelectStmt {
+        SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list: Vec::new(),
+            into_table: None,
+            into_variables: None,
+            from: None,
+            where_clause: None,
+            group_by: None,
+            having: None,
+            window_definitions: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            set_operation: None,
+            values: None,
+        }
+    }
+
+    fn set_op(op: SetOperator, all: bool) -> SetOperation {
+        SetOperation { op, all, right: Box::new(empty_select()) }
+    }
+
+    fn int_row(n: i64) -> Row {
+        Row::new(vec![SqlValue::Integer(n)])
+    }
+
+    fn first_cols(rows: &[Row]) -> Vec<i64> {
+        rows.iter()
+            .map(|r| match &r.values[0] {
+                SqlValue::Integer(n) => *n,
+                SqlValue::Bigint(n) => *n,
+                other => panic!("unexpected value: {other:?}"),
+            })
+            .collect()
+    }
+
+    /// INTERSECT DISTINCT must return rows in SQL-canonical sorted order,
+    /// not left-branch scan order. Regression for issue #5720 (Bug 1).
+    #[test]
+    fn intersect_distinct_returns_sorted_rows() {
+        // Left scan order is 3, 9, 6 — deliberately unsorted.
+        let left = vec![int_row(3), int_row(9), int_row(6)];
+        let right = vec![int_row(6), int_row(9), int_row(3)];
+        let collations = vec![None];
+
+        let result =
+            apply_set_operation(left, right, &set_op(SetOperator::Intersect, false), &collations)
+                .expect("intersect distinct");
+
+        assert_eq!(first_cols(&result), vec![3, 6, 9]);
+    }
+
+    /// EXCEPT DISTINCT must return rows in SQL-canonical sorted order,
+    /// not left-branch scan order. Regression for issue #5720 (Bug 1).
+    #[test]
+    fn except_distinct_returns_sorted_rows() {
+        // Left scan order 1, 5, 7, 2, 4, 8, 10 with 3,6,9 removed by right.
+        let left = vec![
+            int_row(1),
+            int_row(5),
+            int_row(7),
+            int_row(2),
+            int_row(4),
+            int_row(8),
+            int_row(10),
+            int_row(3),
+            int_row(6),
+            int_row(9),
+        ];
+        let right = vec![int_row(3), int_row(6), int_row(9)];
+        let collations = vec![None];
+
+        let result =
+            apply_set_operation(left, right, &set_op(SetOperator::Except, false), &collations)
+                .expect("except distinct");
+
+        assert_eq!(first_cols(&result), vec![1, 2, 4, 5, 7, 8, 10]);
+    }
+
+    /// EXCEPT DISTINCT where nothing is removed still sorts the left side.
+    #[test]
+    fn except_distinct_no_matches_still_sorted() {
+        let left = vec![int_row(5), int_row(1), int_row(3)];
+        let right = vec![int_row(99)];
+        let collations = vec![None];
+
+        let result =
+            apply_set_operation(left, right, &set_op(SetOperator::Except, false), &collations)
+                .expect("except distinct");
+
+        assert_eq!(first_cols(&result), vec![1, 3, 5]);
+    }
+
+    /// INTERSECT DISTINCT with an empty left branch yields no rows.
+    #[test]
+    fn intersect_distinct_empty_left() {
+        let left: Vec<Row> = Vec::new();
+        let right = vec![int_row(1), int_row(2)];
+        let collations = vec![None];
+
+        let result =
+            apply_set_operation(left, right, &set_op(SetOperator::Intersect, false), &collations)
+                .expect("intersect distinct");
+
+        assert!(result.is_empty());
     }
 }

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -2264,6 +2264,10 @@ array set vibesql_skip_tests {
     select7-6.2 "VibeSQL does not enforce SQLite's 500-term compound SELECT limit"
     select7-6.6 "Tests SQLite-specific error message format for empty identifiers"
     select6-1.9 "Expression-based column names (min(x)+y) not supported as column references"
+    select9-3.X "Test-infra cascade (issue #5720): cleanup DROP INDEX i1 fails with 'no such index: i1' because select9-3.2 (which CREATE INDEX i1) is auto-skipped — it uses the cksort sort-tracking helper (depends on the sqlite_sort_count TCL var, unavailable to the VibeSQL CLI). Not a SQL engine defect."
+    select9-4.X "Test-infra cascade (issue #5720): cleanup DROP INDEX i1 fails with 'no such index: i1' because select9-4.2 (which CREATE INDEX i1) is auto-skipped — it uses the cksort sort-tracking helper (depends on the sqlite_sort_count TCL var, unavailable to the VibeSQL CLI). Not a SQL engine defect."
+    select9-5.1 "Optimizer enhancement tracked in issue #5723: outer WHERE predicate is not pushed into UNION ALL compound-view branches, so EXPLAIN QUERY PLAN of 'SELECT * FROM v5 WHERE x=... ORDER BY y' contains SCAN instead of index SEARCH (asserts ~/SCAN/). Not a set-operation correctness bug."
+    select9-5.2 "Optimizer enhancement tracked in issue #5723: outer WHERE predicate is not pushed into UNION ALL compound-view branches (asserts ~/SCAN/ for 'SELECT x, y FROM v5 WHERE x=... ORDER BY y'). Not a set-operation correctness bug."
     selectB-3.8 "Tests internal VDBE transform optimization"
     selectB-4.8 "Tests internal VDBE transform optimization"
     selectB-5.8 "Tests internal VDBE transform optimization"
@@ -3869,6 +3873,8 @@ array set vibesql_skip_tests {
 
 # Pattern-based skip list for tests with many numbered variants
 variable vibesql_skip_patterns {
+    {select9-2.*.3 "user-defined COLLATE (C-API) not reachable from SQL CLI - harness limitation (issue #5720). These compound-SELECT ORDER BY ... COLLATE reverse cases depend on the 'reverse' collation registered via 'db collate reverse reverse', which the TCL shim cannot bridge to the VibeSQL CLI subprocess (same class as the sqlite3_create_aggregate stub in #5712). Covers select9-2.x.3 and its .flipped and limit/offset variants for all index loops."}
+    {select9-2.*.6 "user-defined COLLATE (C-API) not reachable from SQL CLI - harness limitation (issue #5720). UNION ALL ... ORDER BY ... COLLATE reverse cases depending on the 'reverse' collation registered via 'db collate reverse reverse'. Covers select9-2.x.6 and its .flipped and limit/offset variants for all index loops."}
     {orderby8-1. "ORDER BY with many columns - stress test"}
     {indexexpr3- "EXPLAIN output format differs (tests check COVERING INDEX output)"}
     {orderbyA- "ORDER BY optimization differs"}


### PR DESCRIPTION
## Summary

`select9.test` reported **2,149 failures** (the largest single TCL failure source in the core suite). The curator root-caused all of them to 4 distinct signatures. This PR drives select9.test to **0 failures** by fixing the one real engine bug and applying attributed targeted skips / a follow-up issue for the harness-limitation and optimizer-enhancement cases.

## Changes

**Bug 1 — INTERSECT/EXCEPT DISTINCT missing post-dedup sort (265 failures, real correctness bug)**
- `crates/vibesql-executor/src/select/set_operations.rs`: INTERSECT DISTINCT and EXCEPT DISTINCT returned rows in left-branch scan order. SQLite dedups via an ephemeral B-tree (sorted output); the UNION DISTINCT branch already mirrors this with a post-dedup `sort_by`. Added the identical `sort_by(compare_normalized_rows(normalize_row_for_comparison(...)))` to both branches.
- Added 4 unit tests (`intersect_distinct_returns_sorted_rows`, `except_distinct_returns_sorted_rows`, `except_distinct_no_matches_still_sorted`, `intersect_distinct_empty_left`).

**Bug 2 — user-defined `COLLATE reverse` (1,880 failures, harness limitation)**
- `scripts/tester_vibesql.tcl`: targeted skip patterns `select9-2.*.3` and `select9-2.*.6` (covers `.flipped` + limit/offset variants across all 5 index loops). These depend on the `reverse` collation registered via the C-API `db collate`, which the SQL-CLI shim cannot bridge (same class as the `sqlite3_create_aggregate` stub handled in #5712). No blanket file skip.

**Bug 4 — DROP INDEX cascade (2 failures, test-infra)**
- `scripts/tester_vibesql.tcl`: targeted skip `select9-3.X` / `select9-4.X`. Their cleanup `DROP INDEX i1` fails because the index-creating tests (`3.2`/`4.2`) use the `cksort` sort-tracking helper and are auto-skipped. Pure test-infra cascade.

**Bug 3 — WHERE pushdown into UNION ALL compound view (2 failures, optimizer enhancement)**
- Split to follow-up issue #5723. `scripts/tester_vibesql.tcl`: targeted skip `select9-5.1` / `select9-5.2` pointing at #5723.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| INTERSECT DISTINCT returns sorted order | ✅ | `SELECT a,b FROM t1 INTERSECT SELECT d,e FROM t2` -> 3,6,9 sorted (binary + unit test) |
| EXCEPT DISTINCT returns sorted order | ✅ | `SELECT a,b FROM t1 EXCEPT SELECT d,e FROM t2` -> 1,2,4,5,7,8,10 sorted (binary + unit test) |
| select9-1.x.11/13/16 pass (265 tests) | ✅ | select9.test failures 2,149 -> 0 |
| select9-2.x COLLATE: targeted attributed skips, no blanket skip | ✅ | patterns `select9-2.*.3`/`*.6` with "user-defined COLLATE (C-API)" attribution |
| select9-5.1/5.2 split to new issue | ✅ | #5723 created; skips reference it |
| select9-3.X/4.X documented as test-infra cascade | ✅ | annotated skips citing cksort auto-skip |
| No regression to select*/subquery*/where* | ✅ | where.test 0 fail; select1/5 0 fail; select4-11.16 pre-existing (INSERT+UNION error-message, unrelated; skipped in baseline run) |
| `cargo test` passes in vibesql-executor | ✅ | 0 failed across all executor test binaries |

## Test Plan

- `cargo test -p vibesql-executor` — 0 failures.
- `python3 scripts/tcl_runner.py --vibesql ./target/release/vibesql --native-tcl --timeout 900 --files docs/reference/sqlite/test/select9.test` — **passed 34262 / failed 0 / skipped 2454** (was passed 34557 / failed 2,149 before; the gap is now attributed skips, not failures).
- Regression: where.test 0 fail, select1/select5 0 fail.
- Manual binary verification of both INTERSECT/EXCEPT repros (sorted output).

Closes #5720