### PR TITLE
fix(executor): share volatile ORDER BY value and refine DISTINCT/compound EQP

### DIFF
--- a/crates/vibesql-executor/src/explain.rs
+++ b/crates/vibesql-executor/src/explain.rs
@@ -24,8 +24,9 @@ use crate::{
     errors::ExecutorError,
     optimizer::index_planner::IndexPlanner,
     select::scan::index_scan::{
-        cost_based_index_selection, eqp_ordering_index, needs_temp_btree_for_order_by_eqp,
-        select_index_scan_method, IndexScanChoice,
+        collect_equality_pinned_columns_with_collation, cost_based_index_selection,
+        eqp_ordering_index, needs_temp_btree_for_order_by_eqp, select_index_scan_method,
+        EqualityPinnedColumn, IndexScanChoice,
     },
 };
 
@@ -957,17 +958,53 @@ impl ExplainExecutor {
         let distinct_index_order: Option<Vec<vibesql_ast::OrderByItem>> =
             if stmt.distinct && stmt.group_by.is_none() {
                 distinct_key.as_ref().and_then(|key| {
-                    let items = Self::exprs_as_asc_order_items(key);
-                    if Self::needs_temp_btree_for_order_by(
-                        stmt.from.as_ref(),
-                        stmt.where_clause.as_ref(),
-                        &items,
-                        database,
-                    ) {
-                        None
-                    } else {
-                        Some(items)
+                    // Columns the WHERE clause constrains to a single value are
+                    // constant within the scan output, so SQLite drops them from
+                    // the distinctness key before deciding whether an index can
+                    // deliver it (orderby5 1.1–1.6). The collation of the WHERE
+                    // comparison must match the collation the DISTINCT applies to
+                    // the column, or the pin does not make it constant for
+                    // distinctness (orderby5 1.2.2 / 1.2.3).
+                    let pinned =
+                        collect_equality_pinned_columns_with_collation(stmt.where_clause.as_ref());
+                    let mut removed: Vec<&Expression> = Vec::new();
+                    let mut unpinned_key: Vec<&Expression> = Vec::new();
+                    for e in key.iter().copied() {
+                        if Self::distinct_expr_is_where_pinned(e, &pinned) {
+                            removed.push(e);
+                        } else {
+                            unpinned_key.push(e);
+                        }
                     }
+                    if unpinned_key.is_empty() {
+                        // Every DISTINCT column is constant — the result has at
+                        // most one distinct row, so no temp B-tree is needed.
+                        return Some(Vec::new());
+                    }
+                    // The equality predicate that pinned a removed column is
+                    // "consumed" by the distinctness reduction. Drop it from the
+                    // WHERE before the index-delivery check so a column pinned to
+                    // a constant (and NOT itself indexed, e.g. `a=0` over
+                    // `t1bc(b,c)`) does not look like a competing access path that
+                    // would otherwise block riding the ordering index.
+                    let removed_columns: Vec<String> = removed
+                        .iter()
+                        .filter_map(|e| Self::distinct_key_column_name(e))
+                        .collect();
+                    let reduced_where = Self::where_without_pinned_columns(
+                        stmt.where_clause.as_ref(),
+                        &removed_columns,
+                    );
+                    // DISTINCT is order-insensitive, so the index may deliver any
+                    // permutation of the reduced key (orderby5 1.2.1 / 1.5 / 1.6:
+                    // `DISTINCT a, c, b WHERE a=0` reduces to `(c, b)` which index
+                    // t1bc(b, c) covers after reordering to `(b, c)`).
+                    Self::key_index_order(
+                        stmt.from.as_ref(),
+                        reduced_where.as_ref(),
+                        &unpinned_key,
+                        database,
+                    )
                 })
             } else {
                 None
@@ -1261,9 +1298,53 @@ impl ExplainExecutor {
         // merge pre-sorted branches, so rendering MERGE would fabricate a
         // plan shape that never executes (per the #5355/#5360/#5366
         // truthfulness precedent).
-        root.needs_temp_btree_for_order_by = stmt.order_by.is_some();
+        //
+        // Narrow carve-out: when EVERY branch is a constant-row query (no FROM,
+        // SELECT list of literals only — e.g. `SELECT 5 UNION ALL SELECT 3`),
+        // there is no table to sort and SQLite emits no temp B-tree for the
+        // ORDER BY (orderby1 5.1). The runtime likewise sorts a tiny constant
+        // result without a table-backed temp structure, so suppressing the line
+        // is truthful for this shape.
+        root.needs_temp_btree_for_order_by =
+            stmt.order_by.is_some() && !Self::all_compound_branches_are_constant(stmt);
 
         Ok(root)
+    }
+
+    /// True when every branch of a compound (set-operation) query is a
+    /// constant-row query: no FROM clause and a SELECT list consisting solely of
+    /// literal expressions (or a VALUES body of literals). SQLite computes the
+    /// ORDER BY of such an all-constant compound without a temp B-tree
+    /// (orderby1 5.1).
+    fn all_compound_branches_are_constant(stmt: &SelectStmt) -> bool {
+        fn expr_is_literal(expr: &Expression) -> bool {
+            matches!(expr, Expression::Literal(_))
+        }
+        fn branch_is_constant(stmt: &SelectStmt) -> bool {
+            if stmt.from.is_some() {
+                return false;
+            }
+            if let Some(rows) = &stmt.values {
+                return rows.iter().all(|row| row.iter().all(expr_is_literal));
+            }
+            !stmt.select_list.is_empty()
+                && stmt.select_list.iter().all(|item| match item {
+                    SelectItem::Expression { expr, .. } => expr_is_literal(expr),
+                    SelectItem::Wildcard { .. } | SelectItem::QualifiedWildcard { .. } => false,
+                })
+        }
+
+        if !branch_is_constant(stmt) {
+            return false;
+        }
+        let mut current = stmt.set_operation.as_ref();
+        while let Some(set_op) = current {
+            if !branch_is_constant(&set_op.right) {
+                return false;
+            }
+            current = set_op.right.set_operation.as_ref();
+        }
+        true
     }
 
     /// Count the distinct window-function sorting passes required by the
@@ -1517,6 +1598,114 @@ impl ExplainExecutor {
             .collect()
     }
 
+    /// True when a DISTINCT-key expression is a (possibly `COLLATE`-wrapped)
+    /// reference to a column the WHERE clause constrains to a single value under
+    /// the *same* collation. Such a column is constant across the scan output and
+    /// contributes nothing to distinctness, so SQLite removes it from the
+    /// distinctness key (orderby5 1.1–1.6).
+    ///
+    /// The collation must match: `SELECT DISTINCT a ... WHERE a='x' COLLATE
+    /// nocase` does not make BINARY-collated `a` constant (orderby5 1.2.2), and
+    /// `SELECT DISTINCT a COLLATE nocase ... WHERE a='x'` is not made constant by
+    /// a BINARY pin (orderby5 1.2.3). A bare column with no explicit COLLATE on
+    /// either the key or the pin matches (both default to BINARY).
+    fn distinct_expr_is_where_pinned(expr: &Expression, pinned: &[EqualityPinnedColumn]) -> bool {
+        let (column, key_collation) = match expr {
+            Expression::ColumnRef(col_id) => (col_id.column_canonical().to_uppercase(), None),
+            Expression::Collate { expr: inner, collation } => {
+                if let Expression::ColumnRef(col_id) = &**inner {
+                    (col_id.column_canonical().to_uppercase(), Some(collation.to_lowercase()))
+                } else {
+                    return false;
+                }
+            }
+            _ => return false,
+        };
+        pinned
+            .iter()
+            .any(|p| p.column.eq_ignore_ascii_case(&column) && p.collation == key_collation)
+    }
+
+    /// The uppercased column name of a DISTINCT-key expression that is a bare
+    /// column or a single `COLLATE`-wrapped column; `None` otherwise.
+    fn distinct_key_column_name(expr: &Expression) -> Option<String> {
+        match expr {
+            Expression::ColumnRef(col_id) => Some(col_id.column_canonical().to_uppercase()),
+            Expression::Collate { expr: inner, .. } => {
+                if let Expression::ColumnRef(col_id) = &**inner {
+                    Some(col_id.column_canonical().to_uppercase())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    /// Rebuild a WHERE clause with the top-level `col = literal` equality
+    /// conjuncts on any of `removed_columns` dropped (the distinctness reduction
+    /// already accounted for them as constants). Returns `None` when nothing
+    /// remains. Only AND/Conjunction nesting is descended into; any other shape
+    /// is preserved verbatim.
+    fn where_without_pinned_columns(
+        where_clause: Option<&Expression>,
+        removed_columns: &[String],
+    ) -> Option<Expression> {
+        fn is_removed_equality(expr: &Expression, removed: &[String]) -> bool {
+            let col = match expr {
+                Expression::BinaryOp { left, op: vibesql_ast::BinaryOperator::Equal, right } => {
+                    let from_side = |side: &Expression| -> Option<String> {
+                        match side {
+                            Expression::ColumnRef(c) => Some(c.column_canonical().to_uppercase()),
+                            Expression::Collate { expr: inner, .. } => {
+                                if let Expression::ColumnRef(c) = &**inner {
+                                    Some(c.column_canonical().to_uppercase())
+                                } else {
+                                    None
+                                }
+                            }
+                            _ => None,
+                        }
+                    };
+                    from_side(left).or_else(|| from_side(right))
+                }
+                _ => None,
+            };
+            col.is_some_and(|c| removed.iter().any(|r| r.eq_ignore_ascii_case(&c)))
+        }
+
+        fn reduce(expr: &Expression, removed: &[String]) -> Option<Expression> {
+            match expr {
+                Expression::BinaryOp { left, op: vibesql_ast::BinaryOperator::And, right } => {
+                    let l = reduce(left, removed);
+                    let r = reduce(right, removed);
+                    match (l, r) {
+                        (Some(l), Some(r)) => Some(Expression::BinaryOp {
+                            left: Box::new(l),
+                            op: vibesql_ast::BinaryOperator::And,
+                            right: Box::new(r),
+                        }),
+                        (Some(e), None) | (None, Some(e)) => Some(e),
+                        (None, None) => None,
+                    }
+                }
+                Expression::Conjunction(exprs) => {
+                    let kept: Vec<Expression> =
+                        exprs.iter().filter_map(|e| reduce(e, removed)).collect();
+                    match kept.len() {
+                        0 => None,
+                        1 => kept.into_iter().next(),
+                        _ => Some(Expression::Conjunction(kept)),
+                    }
+                }
+                _ if is_removed_equality(expr, removed) => None,
+                other => Some(other.clone()),
+            }
+        }
+
+        where_clause.and_then(|w| reduce(w, removed_columns))
+    }
+
     /// Wrap key expressions as ASC ORDER BY items for the index-delivery
     /// checks (grouping and dedup keys have no inherent direction).
     fn exprs_as_asc_order_items(exprs: &[&Expression]) -> Vec<vibesql_ast::OrderByItem> {
@@ -1568,7 +1757,22 @@ impl ExplainExecutor {
         group_key: &[&Expression],
         database: &Database,
     ) -> Option<Vec<vibesql_ast::OrderByItem>> {
-        let items = Self::exprs_as_asc_order_items(group_key);
+        Self::key_index_order(from, where_clause, group_key, database)
+    }
+
+    /// The ASC ORDER BY items under which an index delivers `key` order, trying
+    /// the key as written first and then each candidate index's column-order
+    /// permutation (grouping and DISTINCT are both order-insensitive, so SQLite
+    /// reorders the key terms to match a covering index — `GROUP BY b, a` /
+    /// `SELECT DISTINCT b, a` with index `(a, b)` both suppress, verified live).
+    /// Returns `None` when no index delivers any permutation.
+    fn key_index_order(
+        from: Option<&vibesql_ast::FromClause>,
+        where_clause: Option<&vibesql_ast::Expression>,
+        key: &[&Expression],
+        database: &Database,
+    ) -> Option<Vec<vibesql_ast::OrderByItem>> {
+        let items = Self::exprs_as_asc_order_items(key);
         if !Self::needs_temp_btree_for_order_by(from, where_clause, &items, database) {
             return Some(items);
         }
@@ -1578,7 +1782,7 @@ impl ExplainExecutor {
         let Some(vibesql_ast::FromClause::Table { name, .. }) = from else {
             return None;
         };
-        let col_names: Option<Vec<&str>> = group_key
+        let col_names: Option<Vec<&str>> = key
             .iter()
             .map(|e| match e {
                 Expression::ColumnRef(col_id) => Some(col_id.column_canonical()),
@@ -1589,7 +1793,7 @@ impl ExplainExecutor {
 
         for index_name in database.list_indexes_for_table(name) {
             let Some(index) = database.get_index(&index_name) else { continue };
-            // Permute the group terms into this index's column order; every
+            // Permute the key terms into this index's column order; every
             // term must appear as an index column for the realignment to be
             // meaningful.
             let positions: Option<Vec<usize>> = col_names
@@ -1602,15 +1806,14 @@ impl ExplainExecutor {
                 .collect();
             let Some(positions) = positions else { continue };
 
-            let mut order: Vec<usize> = (0..group_key.len()).collect();
+            let mut order: Vec<usize> = (0..key.len()).collect();
             order.sort_by_key(|&i| positions[i]);
-            if order.iter().zip(0..group_key.len()).all(|(&a, b)| a == b) {
+            if order.iter().zip(0..key.len()).all(|(&a, b)| a == b) {
                 continue; // Same as the as-written key already checked.
             }
-            let permuted: Vec<&Expression> = order.iter().map(|&i| group_key[i]).collect();
+            let permuted: Vec<&Expression> = order.iter().map(|&i| key[i]).collect();
             let permuted_items = Self::exprs_as_asc_order_items(&permuted);
-            if !Self::needs_temp_btree_for_order_by(from, where_clause, &permuted_items, database)
-            {
+            if !Self::needs_temp_btree_for_order_by(from, where_clause, &permuted_items, database) {
                 return Some(permuted_items);
             }
         }

--- a/crates/vibesql-executor/src/select/order/resolution.rs
+++ b/crates/vibesql-executor/src/select/order/resolution.rs
@@ -378,6 +378,25 @@ pub(crate) fn order_by_volatile_output_index(
         }
     }
 
+    // Case 3: ORDER BY <expr> where <expr> is structurally identical to a
+    // non-deterministic SELECT-list expression (e.g.
+    // `SELECT random() AS y FROM t1 ORDER BY random()`). The ORDER BY term is
+    // neither a positional reference nor a bare alias, so Cases 1 and 2 miss it,
+    // yet SQLite evaluates the volatile expression once per row and reuses that
+    // value for both the projected output and the sort key. Re-evaluating
+    // `random()` independently during sorting would produce a sort key that no
+    // longer matches the projected value, leaving the output unsorted
+    // (orderby9-1.1).
+    for (idx, item) in select_list.iter().enumerate() {
+        if let vibesql_ast::SelectItem::Expression { expr: select_expr, .. } = item {
+            if !ExpressionHasher::is_deterministic(select_expr)
+                && expressions_equal(order_expr, select_expr)
+            {
+                return Some(idx);
+            }
+        }
+    }
+
     None
 }
 

--- a/crates/vibesql-executor/src/select/scan/index_scan/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/mod.rs
@@ -31,7 +31,8 @@ pub(crate) use execution::execute_index_scan;
 pub(crate) use execution::execute_multi_index_or;
 pub(super) use execution::execute_skip_scan;
 pub(crate) use selection::{
-    cost_based_index_selection, eqp_ordering_index, multi_index_or_enabled,
-    needs_temp_btree_for_order_by_eqp, select_index_scan_method, IndexScanChoice,
+    collect_equality_pinned_columns_with_collation, cost_based_index_selection, eqp_ordering_index,
+    multi_index_or_enabled, needs_temp_btree_for_order_by_eqp, select_index_scan_method,
+    EqualityPinnedColumn, IndexScanChoice,
 };
 // predicate types are accessed directly via predicate::* for better type clarity

--- a/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/selection.rs
@@ -1255,6 +1255,107 @@ pub(crate) fn count_single_value_pinned_index_columns(
     count
 }
 
+/// A column constrained to a single value by a WHERE equality, together with the
+/// collation that governed the comparison. Used by the DISTINCT EQP suppression
+/// (orderby5): a `SELECT DISTINCT` key column may be dropped from the distinctness
+/// key when WHERE constrains it to one value — but only when the collation of the
+/// WHERE comparison matches the collation under which the DISTINCT considers it,
+/// since `a = 'xyz' COLLATE nocase` does not make BINARY-collated `a` constant
+/// (orderby5 1.2.2 / 1.2.3).
+///
+/// `collation` is the lowercased collation name, or `None` for the default
+/// (BINARY) collation when no explicit `COLLATE` appears on the predicate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EqualityPinnedColumn {
+    /// Uppercased column name.
+    pub column: String,
+    /// Lowercased explicit collation, or `None` for default (BINARY).
+    pub collation: Option<String>,
+}
+
+/// Collect the columns constrained to a single value by top-level `col = literal`
+/// equalities in the WHERE clause, recording the collation that governed each
+/// comparison.
+///
+/// Only bare `col = literal` / `literal = col` (and the AND/Conjunction nesting of
+/// such) are recognized. A `COLLATE` wrapper on the column side is captured as the
+/// pin's collation; a `COLLATE` on the literal side is recorded as the comparison
+/// collation as well (SQLite applies the explicit collation of either operand to
+/// the comparison). Anything else — IN-lists, `+a=0`, function calls — does not
+/// produce a single-value, collation-known pin and is skipped, which keeps the
+/// `+a=0` (orderby5 1.7) and IN cases conservative.
+pub(crate) fn collect_equality_pinned_columns_with_collation(
+    where_clause: Option<&Expression>,
+) -> Vec<EqualityPinnedColumn> {
+    let mut out = Vec::new();
+    if let Some(expr) = where_clause {
+        collect_equality_pinned_with_collation_inner(expr, &mut out);
+    }
+    out
+}
+
+/// If `expr` is a bare column reference, optionally wrapped in a single `COLLATE`,
+/// return `(uppercased column, explicit collation lowercased or None)`.
+fn column_with_collation(expr: &Expression) -> Option<(String, Option<String>)> {
+    match expr {
+        Expression::ColumnRef(col_id) => Some((col_id.column_canonical().to_uppercase(), None)),
+        Expression::Collate { expr: inner, collation } => {
+            if let Expression::ColumnRef(col_id) = &**inner {
+                Some((col_id.column_canonical().to_uppercase(), Some(collation.to_lowercase())))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// If `expr` is a literal, optionally wrapped in a single `COLLATE`, return the
+/// explicit collation (lowercased) the comparison would carry from that operand,
+/// or `Some(None)` when it is a bare literal. Returns `None` when `expr` is not a
+/// (possibly collated) literal.
+fn literal_collation(expr: &Expression) -> Option<Option<String>> {
+    match expr {
+        _ if is_literal(expr) => Some(None),
+        Expression::Collate { expr: inner, collation } if is_literal(inner) => {
+            Some(Some(collation.to_lowercase()))
+        }
+        _ => None,
+    }
+}
+
+fn collect_equality_pinned_with_collation_inner(
+    expr: &Expression,
+    out: &mut Vec<EqualityPinnedColumn>,
+) {
+    match expr {
+        Expression::BinaryOp { left, op: vibesql_ast::BinaryOperator::Equal, right } => {
+            // Determine the (column, column-side collation) and the literal-side
+            // collation, in whichever order the operands appear.
+            let pair = column_with_collation(left)
+                .zip(literal_collation(right))
+                .or_else(|| column_with_collation(right).zip(literal_collation(left)));
+            if let Some(((column, col_coll), lit_coll)) = pair {
+                // SQLite resolves the comparison collation from an explicit
+                // COLLATE on either operand (column side takes precedence). The
+                // pin only makes the column constant under that collation.
+                let collation = col_coll.or(lit_coll);
+                out.push(EqualityPinnedColumn { column, collation });
+            }
+        }
+        Expression::BinaryOp { left, op: vibesql_ast::BinaryOperator::And, right } => {
+            collect_equality_pinned_with_collation_inner(left, out);
+            collect_equality_pinned_with_collation_inner(right, out);
+        }
+        Expression::Conjunction(exprs) => {
+            for e in exprs {
+                collect_equality_pinned_with_collation_inner(e, out);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Collect all column names that have equality predicates (col = literal or col IS literal)
 ///
 /// Also recognizes positive IN-list (`col IN (literal-list)`) and IN-subquery

--- a/crates/vibesql-executor/tests/explain_temp_btree_annotation_tests.rs
+++ b/crates/vibesql-executor/tests/explain_temp_btree_annotation_tests.rs
@@ -1390,3 +1390,163 @@ fn test_compound_order_by_inside_coroutine() {
          `--SCAN q\n"
     );
 }
+
+// ---------------------------------------------------------------------------
+// DISTINCT with WHERE-equality-pinned columns (orderby5, issue #5713)
+// ---------------------------------------------------------------------------
+//
+// A column constrained to one value by a WHERE equality is constant across the
+// scan output and contributes nothing to distinctness, so SQLite drops it from
+// the DISTINCT key before deciding whether an index delivers the remaining key.
+// `SELECT DISTINCT a, b, c FROM t1 WHERE a=0` reduces its key to (b, c) which
+// the index t1bc(b, c) covers, so no `USE TEMP B-TREE FOR DISTINCT` line.
+// Every shape below was verified live against sqlite3 3.51.0.
+
+/// t1(a, b, c) with a composite index on (b, c) — the orderby5 fixture.
+fn setup_orderby5_db() -> Database {
+    let mut db = Database::new();
+    run_ddl(&mut db, "CREATE TABLE t1(a, b, c)");
+    run_ddl(&mut db, "CREATE INDEX t1bc ON t1(b, c)");
+    db
+}
+
+// orderby5 1.1: WHERE pins `a`; reduced key (b, c) is delivered by t1bc.
+#[test]
+fn test_distinct_where_pinned_leading_column_suppressed() {
+    let db = setup_orderby5_db();
+    let output = eqp(&db, "SELECT DISTINCT a, b, c FROM t1 WHERE a=0");
+
+    assert!(
+        !output.contains("USE TEMP B-TREE FOR DISTINCT"),
+        "WHERE-pinned `a` reduces DISTINCT key to (b, c), covered by t1bc:\n{}",
+        output
+    );
+}
+
+// orderby5 1.2.1 / 1.5 / 1.6: DISTINCT is order-insensitive, so the reduced
+// key (c, b) is reordered to (b, c) to match t1bc.
+#[test]
+fn test_distinct_where_pinned_permuted_key_suppressed() {
+    let db = setup_orderby5_db();
+
+    for sql in [
+        "SELECT DISTINCT a, c, b FROM t1 WHERE a=0",
+        "SELECT DISTINCT c, a, b FROM t1 WHERE a=0",
+        "SELECT DISTINCT c, b, a FROM t1 WHERE a=0",
+        "SELECT DISTINCT b, a, c FROM t1 WHERE a=0",
+        "SELECT DISTINCT b, c, a FROM t1 WHERE a=0",
+    ] {
+        let output = eqp(&db, sql);
+        assert!(
+            !output.contains("USE TEMP B-TREE FOR DISTINCT"),
+            "reduced/permuted key must be delivered by t1bc for `{}`:\n{}",
+            sql,
+            output
+        );
+    }
+}
+
+// All DISTINCT columns pinned → at most one distinct row, no temp structure.
+#[test]
+fn test_distinct_all_columns_pinned_suppressed() {
+    let db = setup_orderby5_db();
+    let output = eqp(&db, "SELECT DISTINCT a FROM t1 WHERE a=0");
+
+    assert!(
+        !output.contains("USE TEMP B-TREE FOR DISTINCT"),
+        "fully-pinned DISTINCT key needs no temp structure:\n{}",
+        output
+    );
+}
+
+// orderby5 1.2.2: WHERE pins `a` under nocase, but the DISTINCT key uses
+// BINARY-collated `a` — the pin does NOT make BINARY `a` constant, so the
+// DISTINCT line MUST stay (collation guard).
+#[test]
+fn test_distinct_where_pin_collation_mismatch_keeps_line() {
+    let db = setup_orderby5_db();
+    let output = eqp(&db, "SELECT DISTINCT a, c, b FROM t1 WHERE a='xyz' COLLATE nocase");
+
+    assert!(
+        output.contains("USE TEMP B-TREE FOR DISTINCT"),
+        "nocase WHERE pin must not suppress a BINARY DISTINCT key:\n{}",
+        output
+    );
+}
+
+// orderby5 1.2.3: the DISTINCT key uses `a COLLATE nocase` but WHERE pins
+// BINARY `a` — also a mismatch; the line MUST stay.
+#[test]
+fn test_distinct_key_collation_mismatch_keeps_line() {
+    let db = setup_orderby5_db();
+    let output = eqp(&db, "SELECT DISTINCT a COLLATE nocase, c, b FROM t1 WHERE a='xyz'");
+
+    assert!(
+        output.contains("USE TEMP B-TREE FOR DISTINCT"),
+        "BINARY WHERE pin must not suppress a nocase DISTINCT key:\n{}",
+        output
+    );
+}
+
+// orderby5 1.2.4: both the WHERE pin and the DISTINCT key use nocase — the
+// collations match, `a COLLATE nocase` is constant, reduced key (c, b) is
+// delivered by t1bc, and the line is suppressed.
+#[test]
+fn test_distinct_key_collation_match_suppressed() {
+    let db = setup_orderby5_db();
+    let output =
+        eqp(&db, "SELECT DISTINCT a COLLATE nocase, c, b FROM t1 WHERE a='xyz' COLLATE nocase");
+
+    assert!(
+        !output.contains("USE TEMP B-TREE FOR DISTINCT"),
+        "matching nocase pin/key must suppress the DISTINCT line:\n{}",
+        output
+    );
+}
+
+// orderby5 1.7: `+a=0` is not a bare equality (the unary `+` blocks the pin),
+// so `a` stays in the key; (c, b, a) is not deliverable by t1bc → line stays.
+#[test]
+fn test_distinct_non_equality_predicate_keeps_line() {
+    let db = setup_orderby5_db();
+    let output = eqp(&db, "SELECT DISTINCT c, b, a FROM t1 WHERE +a=0");
+
+    assert!(
+        output.contains("USE TEMP B-TREE FOR DISTINCT"),
+        "`+a=0` does not pin `a`, so the key is not deliverable:\n{}",
+        output
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Constant-only compound + ORDER BY (orderby1 5.1, issue #5713)
+// ---------------------------------------------------------------------------
+
+// orderby1 5.1: every branch is a constant-row query, so SQLite sorts the tiny
+// result with no temp B-tree. `SELECT 5 UNION ALL SELECT 3 ORDER BY 1` shows no
+// trailing `USE TEMP B-TREE FOR ORDER BY` line.
+#[test]
+fn test_constant_compound_order_by_no_temp_btree() {
+    let db = setup_compound_db();
+    let output = eqp(&db, "SELECT 5 UNION ALL SELECT 3 ORDER BY 1");
+
+    assert!(
+        !output.contains("USE TEMP B-TREE FOR ORDER BY"),
+        "all-constant compound ORDER BY needs no temp B-tree:\n{}",
+        output
+    );
+}
+
+// A compound with at least one table-backed branch still emits the trailing
+// sort line (the carve-out is narrow — only all-constant compounds qualify).
+#[test]
+fn test_table_backed_compound_order_by_keeps_temp_btree() {
+    let db = setup_compound_db();
+    let output = eqp(&db, "SELECT a FROM u1 UNION ALL SELECT 3 ORDER BY 1");
+
+    assert!(
+        output.contains("USE TEMP B-TREE FOR ORDER BY"),
+        "a table-backed branch must keep the trailing sort line:\n{}",
+        output
+    );
+}

--- a/crates/vibesql-executor/tests/order_by_volatile_alias_tests.rs
+++ b/crates/vibesql-executor/tests/order_by_volatile_alias_tests.rs
@@ -87,3 +87,45 @@ fn volatile_alias_order_by_positional_is_evaluated_once() {
         assert!(vals.iter().all(|v| (0..=4).contains(v)));
     }
 }
+
+/// Issue #5713 / orderby9-1.1: `SELECT random() AS y FROM t ORDER BY random()`.
+/// The ORDER BY term is neither a positional reference nor a bare alias — it is a
+/// structurally-identical function call to the SELECT-list expression. SQLite
+/// evaluates `random()` once per row and reuses that value for both the projected
+/// output and the sort key, so the output must be sorted by the projected `y`.
+/// Re-evaluating `random()` independently during the sort would leave the output
+/// unsorted (the failure this test guards against).
+#[test]
+fn volatile_order_by_structural_match_is_evaluated_once() {
+    let db = setup_db();
+
+    // random() returns a 64-bit value; run many times since a regression
+    // (independent re-evaluation) would almost surely surface as unsorted output.
+    for _ in 0..50 {
+        let rows = execute_query(&db, "SELECT random() AS y FROM cnt ORDER BY random()");
+        let vals = int_values(&rows);
+        assert_eq!(vals.len(), 50, "one projected value per row");
+
+        let mut sorted = vals.clone();
+        sorted.sort();
+        assert_eq!(
+            vals, sorted,
+            "ORDER BY random() must sort on the projected random() output, not a re-evaluated key"
+        );
+    }
+}
+
+/// The structural-match path must also work without an alias on the SELECT-list
+/// expression (`SELECT random() FROM t ORDER BY random()`).
+#[test]
+fn volatile_order_by_structural_match_no_alias() {
+    let db = setup_db();
+
+    for _ in 0..50 {
+        let rows = execute_query(&db, "SELECT random() FROM cnt ORDER BY random()");
+        let vals = int_values(&rows);
+        let mut sorted = vals.clone();
+        sorted.sort();
+        assert_eq!(vals, sorted, "unaliased ORDER BY random() must sort projected output");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes three ORDER BY failures surfaced by the SQLite TCL suite (orderby5, orderby9, orderby1). One is a real wrong-results bug (volatile-function double evaluation); the other two are EQP-text parity issues where only the rendered annotation changes, not the executed plan.

## Changes

### Cluster B — orderby9-1.1 (wrong results, highest priority)
`SELECT random() AS y FROM t1 ORDER BY random()` re-evaluated `random()` during sorting, so the sort key never matched the projected value and the output came out unsorted. Added Case 3 to `order_by_volatile_output_index` (`select/order/resolution.rs`): when an ORDER BY term is structurally identical to a non-deterministic SELECT-list expression (gated on `!is_deterministic`, matched via the existing `expressions_equal`), it now sorts on the projected output column. Cases 1/2 (positional, alias) were already handled; the dispatch in `nonagg/materialized.rs` already routes correctly.

### Cluster A — orderby5 (7 EQP failures)
`SELECT DISTINCT a, b, c FROM t1 WHERE a=0` with index `t1bc(b,c)` asserted `~/B-TREE/` but emitted `USE TEMP B-TREE FOR DISTINCT`. A WHERE-equality-pinned column is constant across the scan, so it now drops from the DISTINCT key before the index-delivery check (reduced key `(b,c)` is covered by `t1bc`). Implemented in `explain.rs`:
- New `collect_equality_pinned_columns_with_collation` helper in `index_scan/selection.rs` records each pin's collation.
- `distinct_expr_is_where_pinned` requires the pin collation to **match** the DISTINCT-key collation, so `WHERE a='xyz' COLLATE nocase` does not suppress a BINARY key and vice-versa (collation guard, orderby5 1.2.2/1.2.3).
- The consumed equality predicate is stripped from the WHERE before the delivery check so a constant, non-indexed column does not look like a competing access path.
- Extracted `key_index_order` from `group_key_index_order` so the reduced DISTINCT key is matched against index permutations (DISTINCT is order-insensitive: `a, c, b` reduces to `(c, b)` → reordered to `(b, c)`).

### Cluster C — orderby1-5.1 (1 EQP failure)
`SELECT 5 UNION ALL SELECT 3 ORDER BY 1` emitted `USE TEMP B-TREE FOR ORDER BY` unconditionally. Added a narrow `all_compound_branches_are_constant` carve-out in `explain.rs`: when every compound branch is a constant-row query (no FROM, literal SELECT list / VALUES), the line is suppressed. Table-backed compounds keep it.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| orderby9-1.1 wrong results fixed | ✅ | `ORDER BY random()` output sorted across 50+ runs (CLI + Rust test) |
| orderby5 7 fails pass | ✅ | TCL orderby5: 15 passed / 0 failed (1.2.2/1.2.3 previously skipped now pass) |
| Collation guard not over-suppressed | ✅ | 1.2.2/1.2.3 keep B-TREE; 1.2.4 (matching nocase) suppresses; Rust tests |
| orderby1-5.1 passes | ✅ | TCL orderby1: 38 passed / 0 failed |
| No EQP regressions | ✅ | `cargo test -p vibesql-executor` all green; where9 3 fails are pre-existing (same on main, unrelated transaction-state tests) |
| Only EQP annotation changes, not plans | ✅ | `eqp_ordering_index` returns None for empty key; reduced-WHERE check rides only non-competing ordering indexes |

## Test Plan

- `cargo test -p vibesql-executor` — full suite green (incl. explain/temp-btree, multi-index-OR, skip-scan, index-ordering, where9 binary).
- New Rust tests: `volatile_order_by_structural_match_is_evaluated_once` / `_no_alias` (repeated `ORDER BY random()` sortedness); DISTINCT pin + collation-guard + permutation + all-pinned tests; constant-compound carve-out tests.
- TCL: orderby5 15/0, orderby9 3/0, orderby1 38/0.
- `cargo clippy -p vibesql-executor` — no warnings on changed code.

Closes #5713