### PR TITLE
fix(test-infra): stop parse_result dropping every 3rd row of boxed multi-row results

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -1932,24 +1932,29 @@ proc parse_result {output {tolerate_attributed_error 0}} {
     #   +----+
     #   1 rows
     #
-    # When a batch contains multiple result-producing statements (common when
-    # transactions are batched through `flush_batch` and PRAGMA reads are
-    # interleaved), the output contains multiple such tables back-to-back.
-    # We reset the per-table separator counter on the "N rows" trailer (or on
-    # the next leading separator after a 3rd separator) so the header of each
-    # subsequent table is correctly skipped instead of being captured as data.
-    # Without this, fkey6-1.10.1 saw the literal column name `defer_foreign_keys`
-    # appended between each pragma read in the result list.
+    # IMPORTANT: VibeSQL boxes EACH data row in its own `+---+` frame, so a
+    # single N-row result emits a repeating `+---+ | val | +---+ ...` pattern,
+    # NOT one header block followed by a fixed three separators. A separator
+    # *counter* therefore cannot distinguish "row separator" from "new-table
+    # start": a `>= 3` reset misfires every third row within one result and
+    # silently drops it (e.g. where9-6.2.3 lost output rows 86/89/95).
+    #
+    # The only reliable table boundary is the trailing `N rows` line emitted
+    # after every boxed result (including each interleaved PRAGMA read). So we
+    # track header-skip state per table with a boolean: the FIRST pipe row of
+    # each table is its column header (skipped); every later pipe row until the
+    # next `N rows` trailer is data. This both keeps fkey6-1.10.1 correct (each
+    # PRAGMA read's header is still skipped) and stops dropping data rows.
     set data {}
     set lines [split $output "\n"]
-    set separator_count 0
+    set header_seen 0
 
     foreach line $lines {
         # Skip empty lines
         if {[string trim $line] eq ""} continue
-        # `N rows` marks the end of a table — reset for the next one
+        # `N rows` marks the end of a table — the next pipe row is a new header
         if {[regexp {^\d+ rows?$} $line]} {
-            set separator_count 0
+            set header_seen 0
             continue
         }
         if {[regexp {^=+$} $line]} continue
@@ -1968,23 +1973,14 @@ proc parse_result {output {tolerate_attributed_error 0}} {
             error [translate_error_to_sqlite $line]
         }
 
-        # Count separators - header is between 1st and 2nd separator
-        if {[regexp {^\+[-+]+\+$} $line]} {
-            # If we already saw the closing separator of the previous table
-            # (count==3) and no `N rows` trailer arrived (e.g. trimmed), the
-            # next `+---+` is the top of a new table.
-            if {$separator_count >= 3} {
-                set separator_count 1
-            } else {
-                incr separator_count
-            }
-            continue
-        }
+        # Separator frames carry no data — VibeSQL emits one around every row.
+        if {[regexp {^\+[-+]+\+$} $line]} continue
 
         # Extract data from pipe-delimited lines
         if {[regexp {^\|(.+)\|$} $line -> content]} {
-            # Skip header row (first row, before 2nd separator)
-            if {$separator_count < 2} {
+            # The first pipe row of each table is its column header — skip it.
+            if {!$header_seen} {
+                set header_seen 1
                 continue
             }
             set vals [split $content "|"]


### PR DESCRIPTION
## Summary
`parse_result` in `scripts/tester_vibesql.tcl` (used by the transactional `execsql`/`flush_batch` path) silently dropped every third data row of any multi-row result, producing spurious test failures. VibeSQL boxes **each data row** in its own `+---+` frame, so an N-row result emits a repeating `+---+ | val | +---+ ...` pattern — not one header block bounded by three fixed separators. The old separator-*counter* reset (`if {$separator_count >= 3} { set separator_count 1 }`), added in #5180 to detect a new table when the trailing `N rows` line was trimmed, misfired every third row inside a single result and discarded it as a "header".

For `where9-6.2.3` this dropped output rows 86/89/95: `Got: 93 85 87 88 93 94 98` vs `Expected: 93 85 86 87 88 89 93 94 95 98`. The DELETE/query itself is correct (confirmed via CLI by the #5715 curator); only the shim parse was wrong.

## Changes
- Replace the separator counter in `parse_result` with a per-table `header_seen` boolean, reset only on the reliable `N rows` trailer (emitted after every boxed result, including each interleaved PRAGMA read).
- The first pipe row of each table is its column header (skipped); every later pipe row until the next `N rows` trailer is captured as data.
- Separator frames now carry no state — they are simply skipped, since VibeSQL emits one around every row.

This is the curator's Option B (fix the state machine directly). Option A (`.mode raw` + `parse_raw_result` for the batched path) was evaluated and rejected: in batched/error scenarios `.mode raw` still emits plain-text `Error executing statement N:` lines plus a `=== Script Execution Summary ===` block, which would require teaching the proven raw path the `tolerate_attributed_error` (#5478) and summary-trailer handling — a larger blast radius than this contained fix.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `where9-6.2.3` passes | ✅ | `where9-6.2.3... ok` (was FAILED with rows 86/89/95 dropped) |
| 10+ row batched result returns all rows | ✅ | where9-6.2.3's 10-row result now returns all 10 values |
| No regression to smaller batched/transactional results | ✅ | fkey6-1.10.1 (the case the `>=3` reset targeted) still `ok`; fkey6 33/0 |
| Shim-only, no executor changes | ✅ | Diff touches only `scripts/tester_vibesql.tcl` |

## Test Plan: wide before/after sample
`python3 scripts/tcl_runner.py --vibesql ./target/release/vibesql --native-tcl --timeout 900 --files docs/reference/sqlite/test/<f>.test`

| File | Before P/F | After P/F |
|------|-----------|-----------|
| select1 | 188 / 0 | 188 / 0 |
| select4 | 123 / 0 | 123 / 0 |
| select9 | 34262 / 0 | 34262 / 0 |
| where | 168 / 0 | 168 / 0 |
| update | 126 / 2 | 126 / 2 |
| insert | 51 / 0 | 51 / 0 |
| in | 113 / 1 | 113 / 1 |
| delete | 48 / 1 | 48 / 1 |
| func | 14547 / 0 | 14547 / 0 |
| aggorderby | 29 / 0 | 29 / 0 |
| distinct2 | 43 / 0 | 43 / 0 |
| orderby5 | 15 / 0 | 15 / 0 |
| cast | 122 / 0 | 122 / 0 |
| index | 69 / 0 | 69 / 0 |
| where9 | 16 / 3 | **17 / 2** |

No file's pass count dropped; no file's fail count increased. Total sample failures: 7 → 6 (where9-6.2.3 now clears). Net improvement, zero regression.

Closes #5732