### PR TITLE
feat(parser): accept INDEXED BY / NOT INDEXED hint on DELETE and UPDATE

### DIFF
--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -699,6 +699,8 @@ impl<'a, 'arena> Converter<'a, 'arena> {
             table_name: self.resolve(stmt.table_name),
             quoted: stmt.quoted,
             alias: stmt.alias.map(|a| self.resolve(a)),
+            // Arena UPDATE does not yet carry an index hint; the standard parser path does.
+            index_hint: None,
             assignments: stmt.assignments.iter().map(|a| self.convert_assignment(a)).collect(),
             from_clause: stmt
                 .from_clause
@@ -734,6 +736,8 @@ impl<'a, 'arena> Converter<'a, 'arena> {
             only: stmt.only,
             table_name: self.resolve(stmt.table_name),
             quoted: stmt.quoted,
+            // Arena DELETE does not yet carry an index hint; the standard parser path does.
+            index_hint: None,
             where_clause: stmt.where_clause.as_ref().map(|wc| self.convert_where_clause(wc)),
             order_by: stmt
                 .order_by

--- a/crates/vibesql-ast/src/dml.rs
+++ b/crates/vibesql-ast/src/dml.rs
@@ -181,6 +181,10 @@ pub struct UpdateStmt {
     pub quoted: bool,
     /// Optional table alias (SQLite extension: UPDATE t1 AS xyz SET ...)
     pub alias: Option<String>,
+    /// Optional index hint (SQLite extension: UPDATE t1 INDEXED BY idx ... / NOT INDEXED).
+    /// Advisory only; VibeSQL's planner chooses indexes independently, so the hint is
+    /// parsed for SQLite compatibility but has no effect on plan selection.
+    pub index_hint: Option<crate::IndexHint>,
     pub assignments: Vec<Assignment>,
     /// Optional FROM clause for multi-table UPDATE (SQLite 3.33.0+ / SQL:1999)
     /// Syntax: UPDATE t1 SET col = t2.val FROM t2 WHERE t1.id = t2.id
@@ -219,6 +223,10 @@ pub struct DeleteStmt {
     /// Whether the table name was quoted (delimited) in the original SQL.
     /// Per SQL:1999, quoted identifiers are case-sensitive.
     pub quoted: bool,
+    /// Optional index hint (SQLite extension: DELETE FROM t1 INDEXED BY idx ... / NOT INDEXED).
+    /// Advisory only; VibeSQL's planner chooses indexes independently, so the hint is
+    /// parsed for SQLite compatibility but has no effect on plan selection.
+    pub index_hint: Option<crate::IndexHint>,
     pub where_clause: Option<WhereClause>,
     /// Optional ORDER BY clause (SQLite extension for DELETE)
     /// When present with LIMIT, deletes rows in the specified order

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -1437,6 +1437,7 @@ pub fn transform_update<V: ExpressionMutVisitor>(visitor: &mut V, stmt: UpdateSt
         table_name: stmt.table_name,
         quoted: stmt.quoted,
         alias: stmt.alias,
+        index_hint: stmt.index_hint,
         assignments: stmt
             .assignments
             .into_iter()
@@ -1485,6 +1486,7 @@ pub fn transform_delete<V: ExpressionMutVisitor>(visitor: &mut V, stmt: DeleteSt
         only: stmt.only,
         table_name: stmt.table_name,
         quoted: stmt.quoted,
+        index_hint: stmt.index_hint,
         where_clause: stmt.where_clause.map(|w| match w {
             WhereClause::Condition(expr) => {
                 WhereClause::Condition(transform_expression(visitor, expr))

--- a/crates/vibesql-ast/tests/statements.rs
+++ b/crates/vibesql-ast/tests/statements.rs
@@ -58,6 +58,7 @@ fn test_create_insert_statement() {
 #[test]
 fn test_create_update_statement() {
     let stmt = Statement::Update(UpdateStmt {
+        index_hint: None,
         with_clause: None,
         table_name: "users".to_string(),
         quoted: false,
@@ -81,6 +82,7 @@ fn test_create_update_statement() {
 #[test]
 fn test_create_delete_statement() {
     let stmt = Statement::Delete(DeleteStmt {
+        index_hint: None,
         with_clause: None,
         only: false,
         table_name: "users".to_string(),

--- a/crates/vibesql-executor/benches/sysbench_benchmark.rs
+++ b/crates/vibesql-executor/benches/sysbench_benchmark.rs
@@ -177,6 +177,7 @@ fn bind_delete(stmt: &DeleteStmt, params: &[SqlValue]) -> DeleteStmt {
         quoted: false,
         only: stmt.only,
         table_name: stmt.table_name.clone(),
+        index_hint: stmt.index_hint.clone(),
         where_clause: bind_where_clause(&stmt.where_clause, params),
         order_by: None,
         limit: None,
@@ -192,6 +193,7 @@ fn bind_update(stmt: &UpdateStmt, params: &[SqlValue]) -> UpdateStmt {
         table_name: stmt.table_name.clone(),
         quoted: false,
         alias: stmt.alias.clone(),
+        index_hint: stmt.index_hint.clone(),
         assignments: stmt
             .assignments
             .iter()

--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -80,6 +80,7 @@ impl DeleteExecutor {
     ///     only: false,
     ///     table_name: "users".to_string(),
     ///     quoted: false,
+    ///     index_hint: None,
     ///     where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
     ///         left: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("id", false))),
     ///         op: BinaryOperator::Equal,

--- a/crates/vibesql-executor/src/delete/tests/basic.rs
+++ b/crates/vibesql-executor/src/delete/tests/basic.rs
@@ -14,6 +14,7 @@ fn test_delete_all_rows() {
 
     // DELETE FROM users;
     let stmt = DeleteStmt {
+        index_hint: None,
         with_clause: None,
         only: false,
         table_name: "users".to_string(),
@@ -39,6 +40,7 @@ fn test_delete_with_simple_where() {
 
     // DELETE FROM users WHERE id = 2;
     let stmt = DeleteStmt {
+        index_hint: None,
         with_clause: None,
         quoted: false,
         only: false,
@@ -81,6 +83,7 @@ fn test_delete_with_boolean_where() {
 
     // DELETE FROM users WHERE active = TRUE;
     let stmt = DeleteStmt {
+        index_hint: None,
         with_clause: None,
         quoted: false,
         only: false,
@@ -121,6 +124,7 @@ fn test_delete_multiple_rows() {
 
     // DELETE FROM users WHERE id > 1;
     let stmt = DeleteStmt {
+        index_hint: None,
         with_clause: None,
         quoted: false,
         only: false,

--- a/crates/vibesql-executor/src/delete/tests/edge_cases.rs
+++ b/crates/vibesql-executor/src/delete/tests/edge_cases.rs
@@ -13,6 +13,7 @@ fn test_delete_table_not_found() {
     let mut db = Database::new();
 
     let stmt = DeleteStmt {
+        index_hint: None,
         with_clause: None,
         only: false,
         table_name: "nonexistent".to_string(),
@@ -36,6 +37,7 @@ fn test_delete_no_matching_rows() {
 
     // DELETE FROM users WHERE id = 999;
     let stmt = DeleteStmt {
+        index_hint: None,
         with_clause: None,
         quoted: false,
         only: false,
@@ -74,6 +76,7 @@ fn test_delete_from_empty_table() {
 
     // DELETE FROM empty_users;
     let stmt = DeleteStmt {
+        index_hint: None,
         with_clause: None,
         only: false,
         table_name: "empty_users".to_string(),
@@ -96,6 +99,7 @@ fn test_delete_column_not_found() {
 
     // DELETE FROM users WHERE nonexistent_column = 1;
     let stmt = DeleteStmt {
+        index_hint: None,
         with_clause: None,
         quoted: false,
         only: false,

--- a/crates/vibesql-executor/src/delete/tests/subqueries.rs
+++ b/crates/vibesql-executor/src/delete/tests/subqueries.rs
@@ -216,6 +216,7 @@ mod in_subquery {
 
         // DELETE FROM employees WHERE dept_id IN (SELECT dept_id FROM inactive_depts)
         let stmt = DeleteStmt {
+            index_hint: None,
             with_clause: None,
             quoted: false,
             only: false,
@@ -288,6 +289,7 @@ mod in_subquery {
 
         // DELETE FROM employees WHERE dept_id NOT IN (SELECT dept_id FROM active_depts)
         let stmt = DeleteStmt {
+            index_hint: None,
             with_clause: None,
             quoted: false,
             only: false,
@@ -371,6 +373,7 @@ mod scalar_subquery {
 
         // DELETE FROM employees WHERE salary < (SELECT AVG(salary) FROM employees)
         let stmt = DeleteStmt {
+            index_hint: None,
             with_clause: None,
             quoted: false,
             only: false,
@@ -456,6 +459,7 @@ mod scalar_subquery {
 
         // DELETE FROM items WHERE price = (SELECT MAX(price) FROM items)
         let stmt = DeleteStmt {
+            index_hint: None,
             with_clause: None,
             quoted: false,
             only: false,
@@ -532,6 +536,7 @@ mod scalar_subquery {
 
         // DELETE FROM employees WHERE salary > (SELECT threshold FROM config)
         let stmt = DeleteStmt {
+            index_hint: None,
             with_clause: None,
             quoted: false,
             only: false,
@@ -607,6 +612,7 @@ mod empty_subquery {
 
         // DELETE FROM employees WHERE dept_id IN (SELECT dept_id FROM old_depts)
         let stmt = DeleteStmt {
+            index_hint: None,
             with_clause: None,
             quoted: false,
             only: false,
@@ -698,6 +704,7 @@ mod complex_subquery {
         // DELETE FROM orders WHERE customer_id IN (SELECT customer_id FROM inactive_customers WHERE
         // status = 'inactive')
         let stmt = DeleteStmt {
+            index_hint: None,
             with_clause: None,
             quoted: false,
             only: false,

--- a/crates/vibesql-executor/src/delete/tests/truncate_optimization.rs
+++ b/crates/vibesql-executor/src/delete/tests/truncate_optimization.rs
@@ -43,6 +43,7 @@ fn test_truncate_optimization_basic() {
 
     // DELETE FROM large_table (no WHERE) - should use TRUNCATE fast path
     let stmt = DeleteStmt {
+        index_hint: None,
         with_clause: None,
         only: false,
         table_name: "large_table".to_string(),
@@ -123,6 +124,7 @@ fn test_truncate_blocked_by_fk_reference() {
     // Should NOT use TRUNCATE because child references exist
     // Should fail with FK constraint violation
     let stmt = DeleteStmt {
+        index_hint: None,
         with_clause: None,
         only: false,
         table_name: "parent".to_string(),
@@ -199,6 +201,7 @@ fn test_truncate_allowed_when_no_fk_references() {
     // Cannot use TRUNCATE because FK constraint exists (even though no child rows reference it)
     // This is conservative but correct - we don't scan child table to check
     let stmt = DeleteStmt {
+        index_hint: None,
         with_clause: None,
         only: false,
         table_name: "parent".to_string(),
@@ -264,6 +267,7 @@ fn test_truncate_blocked_by_delete_trigger() {
     // Should use row-by-row deletion (which currently doesn't execute triggers, but that's
     // separate)
     let stmt = DeleteStmt {
+        index_hint: None,
         with_clause: None,
         only: false,
         table_name: "test_table".to_string(),
@@ -327,6 +331,7 @@ fn test_truncate_allowed_with_insert_trigger() {
     // DELETE FROM test_table (no WHERE)
     // Should use TRUNCATE because only INSERT trigger exists (not DELETE)
     let stmt = DeleteStmt {
+        index_hint: None,
         with_clause: None,
         only: false,
         table_name: "test_table".to_string(),
@@ -376,6 +381,7 @@ fn test_truncate_performance() {
     }
 
     let stmt = DeleteStmt {
+        index_hint: None,
         with_clause: None,
         only: false,
         table_name: "large_table".to_string(),

--- a/crates/vibesql-executor/src/tests/not_operator_tests.rs
+++ b/crates/vibesql-executor/src/tests/not_operator_tests.rs
@@ -240,6 +240,7 @@ fn test_not_in_delete_where() {
 
     // DELETE FROM tab0 WHERE NOT (col0 < 542)
     let stmt = vibesql_ast::DeleteStmt {
+        index_hint: None,
         with_clause: None,
         quoted: false,
         only: false,

--- a/crates/vibesql-executor/src/tests/triggers/delete.rs
+++ b/crates/vibesql-executor/src/tests/triggers/delete.rs
@@ -55,6 +55,7 @@ fn test_after_delete_trigger_fires() {
 
     // Delete the user - should fire trigger
     let delete = vibesql_ast::DeleteStmt {
+        index_hint: None,
         with_clause: None,
         quoted: false,
         only: false,
@@ -128,6 +129,7 @@ fn test_before_delete_trigger_fires() {
 
     // Delete the user - should fire trigger
     let delete = vibesql_ast::DeleteStmt {
+        index_hint: None,
         with_clause: None,
         quoted: false,
         only: false,

--- a/crates/vibesql-executor/src/tests/triggers/update.rs
+++ b/crates/vibesql-executor/src/tests/triggers/update.rs
@@ -59,6 +59,7 @@ fn test_after_update_trigger_fires() {
 
     // Update the user - should fire trigger
     let update = vibesql_ast::UpdateStmt {
+        index_hint: None,
         with_clause: None,
         quoted: false,
         alias: None,
@@ -137,6 +138,7 @@ fn test_before_update_trigger_fires() {
 
     // Update the user - should fire trigger
     let update = vibesql_ast::UpdateStmt {
+        index_hint: None,
         with_clause: None,
         quoted: false,
         alias: None,
@@ -220,6 +222,7 @@ fn test_update_of_fires_only_for_listed_column() {
     // Helper: UPDATE one column of user id=1 to `value`.
     let update_col = |db: &mut Database, column: &str, value: vibesql_types::SqlValue| {
         let update = vibesql_ast::UpdateStmt {
+            index_hint: None,
             with_clause: None,
             quoted: false,
             alias: None,

--- a/crates/vibesql-executor/src/update/mod.rs
+++ b/crates/vibesql-executor/src/update/mod.rs
@@ -124,6 +124,7 @@ impl UpdateExecutor {
     ///     table_name: "employees".to_string(),
     ///     quoted: false,
     ///     alias: None,
+    ///     index_hint: None,
     ///     assignments: vec![Assignment {
     ///         column: "salary".to_string(),
     ///         value: Expression::Literal(SqlValue::Integer(60000)),

--- a/crates/vibesql-executor/tests/conflict_resolution_tests.rs
+++ b/crates/vibesql-executor/tests/conflict_resolution_tests.rs
@@ -228,6 +228,7 @@ fn test_update_or_ignore_primary_key_conflict() {
 
     // Try UPDATE OR IGNORE to change Alice's id to 2 (conflicts with Bob)
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         table_name: "users".to_string(),
@@ -276,6 +277,7 @@ fn test_update_or_ignore_unique_constraint_conflict() {
 
     // Try UPDATE OR IGNORE to change Alice's email to Bob's (conflicts with UNIQUE)
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         table_name: "users".to_string(),
@@ -314,6 +316,7 @@ fn test_update_or_ignore_no_conflict() {
 
     // UPDATE OR IGNORE with no conflicts should work normally
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         table_name: "users".to_string(),
@@ -358,6 +361,7 @@ fn test_update_or_replace_primary_key_conflict() {
 
     // UPDATE OR REPLACE to change Alice's id to 2 (should delete Bob first)
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         table_name: "users".to_string(),
@@ -403,6 +407,7 @@ fn test_update_or_replace_unique_constraint_conflict() {
 
     // UPDATE OR REPLACE to change Alice's email to Bob's (should delete Bob first)
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         table_name: "users".to_string(),
@@ -449,6 +454,7 @@ fn test_update_or_replace_no_conflict() {
 
     // UPDATE OR REPLACE with no conflicts should work normally without deleting anyone
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         table_name: "users".to_string(),
@@ -521,6 +527,7 @@ fn test_update_or_ignore_not_null_violation() {
 
     // Try UPDATE OR IGNORE to set email to NULL (NOT NULL violation)
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         table_name: "users".to_string(),

--- a/crates/vibesql-executor/tests/update_basic_tests.rs
+++ b/crates/vibesql-executor/tests/update_basic_tests.rs
@@ -12,6 +12,7 @@ fn test_update_all_rows() {
     setup_test_table(&mut db);
 
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -42,6 +43,7 @@ fn test_update_with_where_clause() {
     setup_test_table(&mut db);
 
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -86,6 +88,7 @@ fn test_update_multiple_columns() {
     setup_test_table(&mut db);
 
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -129,6 +132,7 @@ fn test_update_with_expression() {
 
     // Give everyone a 10% raise: salary = salary * 110 DIV 100
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -170,6 +174,7 @@ fn test_update_table_not_found() {
     let mut db = Database::new();
 
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -192,6 +197,7 @@ fn test_update_column_not_found() {
     setup_test_table(&mut db);
 
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -217,6 +223,7 @@ fn test_update_no_matching_rows() {
     setup_test_table(&mut db);
 
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,

--- a/crates/vibesql-executor/tests/update_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/update_columnar_cache_tests.rs
@@ -52,6 +52,7 @@ fn test_update_invalidates_columnar_cache() {
 
     // Execute UPDATE - give Alice a raise
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -124,6 +125,7 @@ fn test_update_invalidates_prewarmed_cache() {
 
     // UPDATE to change Bob's salary
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -170,6 +172,7 @@ fn test_update_all_rows_invalidates_cache() {
 
     // UPDATE all rows - give everyone the same salary
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -208,6 +211,7 @@ fn test_update_no_match_does_not_invalidate_cache() {
 
     // UPDATE with WHERE clause that matches no rows
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -253,6 +257,7 @@ fn test_multiple_updates_invalidate_cache() {
 
     // First UPDATE
     let stmt1 = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -284,6 +289,7 @@ fn test_multiple_updates_invalidate_cache() {
 
     // Second UPDATE
     let stmt2 = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -331,6 +337,7 @@ fn test_update_multiple_columns_invalidates_cache() {
 
     // UPDATE multiple columns at once
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,

--- a/crates/vibesql-executor/tests/update_constraint_tests/check_constraints.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/check_constraints.rs
@@ -18,6 +18,7 @@ fn test_update_check_constraint_passes() {
 
     // Update to valid price (should succeed)
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -46,6 +47,7 @@ fn test_update_check_constraint_violation() {
 
     // Try to update to negative price (should fail)
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -82,6 +84,7 @@ fn test_update_check_constraint_with_null() {
 
     // Update to NULL (should succeed - NULL is treated as UNKNOWN which passes CHECK)
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -114,6 +117,7 @@ fn test_update_check_constraint_with_expression() {
 
     // Update bonus to still be less than salary (should succeed)
     let stmt1 = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -132,6 +136,7 @@ fn test_update_check_constraint_with_expression() {
 
     // Try to update bonus to be >= salary (should fail)
     let stmt2 = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,

--- a/crates/vibesql-executor/tests/update_constraint_tests/constraint_test_utils.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/constraint_test_utils.rs
@@ -175,6 +175,7 @@ pub fn create_update_with_id_clause(
     id: i64,
 ) -> vibesql_ast::UpdateStmt {
     vibesql_ast::UpdateStmt {
+        index_hint: None,
         with_clause: None,
         quoted: false,
         alias: None,

--- a/crates/vibesql-executor/tests/update_constraint_tests/unique_constraints.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/unique_constraints.rs
@@ -160,6 +160,7 @@ fn test_update_unique_constraint_composite() {
 
     // Try to update Bob to have the same first_name and last_name as Alice (should fail)
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,

--- a/crates/vibesql-executor/tests/update_default_tests.rs
+++ b/crates/vibesql-executor/tests/update_default_tests.rs
@@ -29,6 +29,7 @@ fn test_update_with_default_value() {
 
     // UPDATE users SET name = DEFAULT WHERE id = 1
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -82,6 +83,7 @@ fn test_update_default_no_default_value_defined() {
 
     // UPDATE users SET name = DEFAULT WHERE id = 1
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,

--- a/crates/vibesql-executor/tests/update_onepass_tests.rs
+++ b/crates/vibesql-executor/tests/update_onepass_tests.rs
@@ -101,6 +101,7 @@ fn test_onepass_multiple_literal_assignments() {
 
     // UPDATE items SET name = 'Updated', price = 999, quantity = 50 WHERE id = 1
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -154,6 +155,7 @@ fn test_onepass_single_literal_assignment() {
 
     // UPDATE items SET price = 777 WHERE id = 2
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -189,6 +191,7 @@ fn test_onepass_pk_not_found_returns_zero() {
 
     // UPDATE items SET price = 999 WHERE id = 999 (non-existent)
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -233,6 +236,7 @@ fn test_onepass_not_null_constraint_enforced() {
 
     // Try to set NOT NULL column to NULL
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -269,6 +273,7 @@ fn test_composite_pk_update_both_columns_specified() {
 
     // UPDATE order_items SET quantity = 99 WHERE order_id = 1 AND item_id = 1
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -321,6 +326,7 @@ fn test_composite_pk_update_reversed_order() {
     // UPDATE order_items SET price = 500 WHERE item_id = 2 AND order_id = 1
     // (columns in reverse order from PK definition)
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -368,6 +374,7 @@ fn test_composite_pk_partial_match_uses_scan() {
     // UPDATE order_items SET quantity = 1 WHERE order_id = 1
     // Only one PK column specified - should update multiple rows
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -406,6 +413,7 @@ fn test_composite_pk_not_found_returns_zero() {
 
     // UPDATE order_items SET quantity = 999 WHERE order_id = 99 AND item_id = 99
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -447,6 +455,7 @@ fn test_composite_pk_multiple_columns_updated() {
 
     // UPDATE order_items SET quantity = 100, price = 1000 WHERE order_id = 2 AND item_id = 1
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,

--- a/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
@@ -66,6 +66,7 @@ fn test_update_with_subquery_multiple_rows_uses_first() {
     });
 
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -163,6 +164,7 @@ fn test_update_with_subquery_multiple_columns_error() {
     });
 
     let stmt = UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,

--- a/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
@@ -129,6 +129,7 @@ fn create_update_stmt(
     where_clause: Option<vibesql_ast::WhereClause>,
 ) -> UpdateStmt {
     UpdateStmt {
+        index_hint: None,
         with_clause: None,
         quoted: false,
         alias: None,
@@ -146,6 +147,7 @@ fn create_multi_column_update_stmt(
     assignments: Vec<(&str, Expression)>,
 ) -> UpdateStmt {
     UpdateStmt {
+        index_hint: None,
         with_clause: None,
         quoted: false,
         alias: None,

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
@@ -62,6 +62,7 @@ fn test_update_where_scalar_subquery_equal() {
 
     // UPDATE employees SET salary = 55000 WHERE salary = (SELECT min_salary FROM config)
     let stmt = vibesql_ast::UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -154,6 +155,7 @@ fn test_update_where_scalar_subquery_less_than() {
 
     // UPDATE employees SET bonus = 5000 WHERE salary < (SELECT AVG(salary) FROM employees)
     let stmt = vibesql_ast::UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -238,6 +240,7 @@ fn test_update_where_subquery_returns_null() {
 
     // UPDATE employees SET salary = 60000 WHERE salary < (SELECT max_salary FROM config)
     let stmt = vibesql_ast::UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         table_name: "employees".to_string(),
@@ -334,6 +337,7 @@ fn test_update_where_subquery_with_aggregate() {
 
     // UPDATE items SET discounted = TRUE WHERE price = (SELECT MAX(price) FROM items)
     let stmt = vibesql_ast::UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -467,6 +471,7 @@ fn test_update_where_and_set_both_use_subqueries() {
     // UPDATE employees SET salary = (SELECT target FROM salary_targets) WHERE dept_id IN (SELECT
     // dept_id FROM active_depts)
     let stmt = vibesql_ast::UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
@@ -77,6 +77,7 @@ fn test_update_where_in_subquery() {
 
     // UPDATE employees SET salary = 80000 WHERE dept_id IN (SELECT dept_id FROM active_depts)
     let stmt = vibesql_ast::UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -173,6 +174,7 @@ fn test_update_where_not_in_subquery() {
 
     // UPDATE employees SET active = FALSE WHERE dept_id NOT IN (SELECT dept_id FROM active_depts)
     let stmt = vibesql_ast::UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -262,6 +264,7 @@ fn test_update_where_subquery_empty_result() {
 
     // UPDATE employees SET active = FALSE WHERE dept_id IN (SELECT dept_id FROM inactive_depts)
     let stmt = vibesql_ast::UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -368,6 +371,7 @@ fn test_update_where_complex_subquery_condition() {
     // UPDATE employees SET salary = 70000 WHERE dept_id IN (SELECT dept_id FROM departments WHERE
     // budget > 80000)
     let stmt = vibesql_ast::UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,
@@ -468,6 +472,7 @@ fn test_update_where_multiple_rows_in_subquery() {
 
     // UPDATE employees SET active = FALSE WHERE dept_id IN (SELECT dept_id FROM active_depts)
     let stmt = vibesql_ast::UpdateStmt {
+        index_hint: None,
         with_clause: None,
         from_clause: None,
         quoted: false,

--- a/crates/vibesql-parser/src/parser/delete.rs
+++ b/crates/vibesql-parser/src/parser/delete.rs
@@ -30,6 +30,11 @@ impl Parser {
             self.advance(); // consume ')'
         }
 
+        // Parse optional INDEXED BY / NOT INDEXED hint (SQLite extension).
+        // Syntax: DELETE FROM t1 INDEXED BY idx WHERE ...
+        // Advisory only: VibeSQL's planner chooses indexes independently.
+        let index_hint = self.parse_index_hint()?;
+
         // Parse optional WHERE clause
         let where_clause = if self.peek_keyword(Keyword::Where) {
             self.consume_keyword(Keyword::Where)?;
@@ -134,6 +139,7 @@ impl Parser {
             only,
             table_name,
             quoted,
+            index_hint,
             where_clause,
             order_by,
             limit,
@@ -171,6 +177,10 @@ impl Parser {
             }
             self.advance();
         }
+
+        // Parse optional INDEXED BY / NOT INDEXED hint (SQLite extension).
+        // Advisory only: VibeSQL's planner chooses indexes independently.
+        let index_hint = self.parse_index_hint()?;
 
         // Parse optional WHERE clause
         let where_clause = if self.peek_keyword(Keyword::Where) {
@@ -275,6 +285,7 @@ impl Parser {
             only,
             table_name,
             quoted,
+            index_hint,
             where_clause,
             order_by,
             limit,

--- a/crates/vibesql-parser/src/parser/update.rs
+++ b/crates/vibesql-parser/src/parser/update.rs
@@ -45,9 +45,9 @@ impl Parser {
         let alias = if self.try_consume_keyword(Keyword::As) {
             // AS keyword present, alias required
             Some(self.parse_identifier()?)
-        } else if !self.peek_keyword(Keyword::Set) {
-            // No AS keyword, but might have alias before SET
-            // Check if current token is an identifier (not SET keyword)
+        } else if !self.peek_keyword(Keyword::Set) && !self.peek_index_hint() {
+            // No AS keyword, but might have alias before SET / index hint.
+            // INDEXED / NOT are keywords, so they are not consumed as an alias here.
             match self.peek() {
                 Token::Identifier(name) | Token::DelimitedIdentifier(name) => {
                     let alias_name = name.clone();
@@ -59,6 +59,11 @@ impl Parser {
         } else {
             None
         };
+
+        // Parse optional INDEXED BY / NOT INDEXED hint (SQLite extension).
+        // Syntax: UPDATE t1 INDEXED BY idx SET ...
+        // Advisory only: VibeSQL's planner chooses indexes independently.
+        let index_hint = self.parse_index_hint()?;
 
         // Parse SET keyword
         self.expect_keyword(Keyword::Set)?;
@@ -156,6 +161,7 @@ impl Parser {
             table_name,
             quoted,
             alias,
+            index_hint,
             assignments,
             from_clause,
             where_clause,
@@ -207,7 +213,7 @@ impl Parser {
         // Parse optional alias: UPDATE t1 AS alias SET ... or UPDATE t1 alias SET ...
         let alias = if self.try_consume_keyword(Keyword::As) {
             Some(self.parse_identifier()?)
-        } else if !self.peek_keyword(Keyword::Set) {
+        } else if !self.peek_keyword(Keyword::Set) && !self.peek_index_hint() {
             match self.peek() {
                 Token::Identifier(name) | Token::DelimitedIdentifier(name) => {
                     let alias_name = name.clone();
@@ -219,6 +225,10 @@ impl Parser {
         } else {
             None
         };
+
+        // Parse optional INDEXED BY / NOT INDEXED hint (SQLite extension).
+        // Advisory only: VibeSQL's planner chooses indexes independently.
+        let index_hint = self.parse_index_hint()?;
 
         // Parse SET keyword
         self.expect_keyword(Keyword::Set)?;
@@ -310,6 +320,7 @@ impl Parser {
             table_name,
             quoted,
             alias,
+            index_hint,
             assignments,
             from_clause,
             where_clause,

--- a/crates/vibesql-parser/src/tests/delete.rs
+++ b/crates/vibesql-parser/src/tests/delete.rs
@@ -20,6 +20,39 @@ fn test_parse_delete_basic() {
 }
 
 #[test]
+fn test_parse_delete_indexed_by() {
+    // SQLite INDEXED BY hint on DELETE (issue #5734, where9-6.8.x).
+    let result = Parser::parse_sql("DELETE FROM t1 INDEXED BY t1b WHERE a = 1;");
+    assert!(result.is_ok(), "DELETE ... INDEXED BY should parse: {result:?}");
+
+    match result.unwrap() {
+        vibesql_ast::Statement::Delete(delete) => {
+            assert_eq!(delete.table_name, "t1");
+            assert_eq!(
+                delete.index_hint,
+                Some(vibesql_ast::IndexHint::IndexedBy("t1b".to_string()))
+            );
+            assert!(delete.where_clause.is_some());
+        }
+        _ => panic!("Expected DELETE statement"),
+    }
+}
+
+#[test]
+fn test_parse_delete_not_indexed() {
+    // SQLite NOT INDEXED hint on DELETE (issue #5734).
+    let result = Parser::parse_sql("DELETE FROM t1 NOT INDEXED WHERE a = 1;");
+    assert!(result.is_ok(), "DELETE ... NOT INDEXED should parse: {result:?}");
+
+    match result.unwrap() {
+        vibesql_ast::Statement::Delete(delete) => {
+            assert_eq!(delete.index_hint, Some(vibesql_ast::IndexHint::NotIndexed));
+        }
+        _ => panic!("Expected DELETE statement"),
+    }
+}
+
+#[test]
 fn test_parse_delete_no_where() {
     let result = Parser::parse_sql("DELETE FROM users;");
     assert!(result.is_ok());

--- a/crates/vibesql-parser/src/tests/update.rs
+++ b/crates/vibesql-parser/src/tests/update.rs
@@ -22,6 +22,56 @@ fn test_parse_update_basic() {
 }
 
 #[test]
+fn test_parse_update_indexed_by() {
+    // SQLite INDEXED BY hint on UPDATE (issue #5734, where9-6.8.x).
+    let result = Parser::parse_sql("UPDATE t1 INDEXED BY t1b SET a = a + 100 WHERE a = 1;");
+    assert!(result.is_ok(), "UPDATE ... INDEXED BY should parse: {result:?}");
+
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(update) => {
+            assert_eq!(update.table_name, "t1");
+            assert_eq!(update.alias, None);
+            assert_eq!(
+                update.index_hint,
+                Some(vibesql_ast::IndexHint::IndexedBy("t1b".to_string()))
+            );
+            assert_eq!(update.assignments.len(), 1);
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
+fn test_parse_update_not_indexed() {
+    // SQLite NOT INDEXED hint on UPDATE (issue #5734).
+    let result = Parser::parse_sql("UPDATE t1 NOT INDEXED SET a = 1;");
+    assert!(result.is_ok(), "UPDATE ... NOT INDEXED should parse: {result:?}");
+
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(update) => {
+            assert_eq!(update.index_hint, Some(vibesql_ast::IndexHint::NotIndexed));
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
+fn test_parse_update_alias_still_parses_with_hint_path() {
+    // Ensure adding the index-hint hook did not break plain alias parsing.
+    let result = Parser::parse_sql("UPDATE t1 x SET a = 1;");
+    assert!(result.is_ok(), "UPDATE with alias should still parse: {result:?}");
+
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(update) => {
+            assert_eq!(update.table_name, "t1");
+            assert_eq!(update.alias, Some("x".to_string()));
+            assert_eq!(update.index_hint, None);
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
 fn test_parse_update_multiple_columns() {
     let result = Parser::parse_sql("UPDATE users SET name = 'Bob', age = 30;");
     assert!(result.is_ok());

--- a/tests/storage/update_pk_performance.rs
+++ b/tests/storage/update_pk_performance.rs
@@ -50,6 +50,7 @@ fn test_update_with_pk_index_performance() {
 
     for i in 0..1000 {
         let stmt = UpdateStmt {
+            index_hint: None,
             with_clause: None,
             table_name: "test_table".to_string(),
             alias: None,


### PR DESCRIPTION
## Summary

SQLite allows an `INDEXED BY <name>` / `NOT INDEXED` hint on the target table of DELETE and UPDATE statements (e.g. `DELETE FROM t1 INDEXED BY t1b WHERE ...`). The FROM-clause parser already had `parse_index_hint()`, but `parse_delete_statement()` and `parse_update_statement()` never called it, so these statements failed with `near "INDEXED": syntax error`.

This fixes the TCL conformance failures **where9-6.8.1** and **where9-6.8.4**.

## Changes

- Add `index_hint: Option<IndexHint>` to `DeleteStmt` and `UpdateStmt` (`crates/vibesql-ast/src/dml.rs`).
- Parse the hint after the table name (and after the optional alias, for UPDATE) in both the plain and WITH-CTE parser paths (`crates/vibesql-parser/src/parser/{delete,update}.rs`).
- For UPDATE, guard the bare-alias detection with `!peek_index_hint()` so the `INDEXED`/`NOT` keywords are not mistaken for a table alias.
- Wire the new field through `visitor.rs`, `arena/convert.rs` (arena variants don't carry the hint -> `None`), the sysbench bench, and update existing constructors.

## Hint semantics: parsed but advisory (ignored for planning)

The hint is **advisory only**. VibeSQL's planner chooses indexes independently, so the hint is parsed and carried on the AST but does not affect plan selection. This matches SQLite's behavior for *result correctness*: the where9-6.8.x tests use `catchsql { ... }` and assert only `{0 {}}` (the statement succeeds with no error and no output), which they now do. The referenced index (`t1b`) exists in the test fixture, so even a validating implementation would pass; ignoring the hint produces the same observable result.

## Verification

- `where9.test`: **Passed: 19, Failed: 0** (was failing 6.8.1 / 6.8.4 on main).
- `cargo test -p vibesql-parser`: 1474 lib tests pass, incl. new regression tests.
- `cargo test -p vibesql-executor -p vibesql-ast`: all green (incl. doctests with the updated DELETE/UPDATE examples).
- New parser regression tests: `test_parse_delete_indexed_by`, `test_parse_delete_not_indexed`, `test_parse_update_indexed_by`, `test_parse_update_not_indexed`, `test_parse_update_alias_still_parses_with_hint_path`.

Closes #5734

🤖 Generated with [Claude Code](https://claude.com/claude-code)