### PR TITLE
fix(executor): resolve trigger WHEN columns at prepare time + allow outer-correlated aggregate in HAVING subquery

### DIFF
--- a/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
@@ -154,12 +154,21 @@ impl SelectExecutor<'_> {
                 });
             }
 
-            // Check for aggregates/windows inside bare scalar subqueries
-            // in HAVING (e.g. `HAVING (SELECT (a, b))` triggers row-value-misused;
-            // `HAVING (SELECT sum(x))` triggers misuse of aggregate). #5069
+            // Check for aggregates/windows inside bare scalar subqueries in
+            // HAVING (e.g. `HAVING (SELECT (a, b))` triggers row-value-misused). #5069
+            //
+            // HAVING only exists on an aggregating outer query, so a bare scalar
+            // subquery whose aggregate references an outer column is NOT a misuse
+            // here — it borrows the established outer aggregation context and
+            // collapses over the current group, exactly like the SELECT-list case
+            // (#5104). SQLite accepts e.g.
+            //   ... GROUP BY a0.a HAVING (SELECT sum((a1.a==a0.a) IN (SELECT b FROM t4)))
+            // (in-23.0). We therefore pass `SubqueryContext::SelectList` so the
+            // outer-correlated-aggregate rejection is skipped while row-value
+            // misuse (an error in any context) is still caught.
             crate::select::executor::validation::validate_subquery_context_misuse(
                 having_expr,
-                crate::select::executor::validation::SubqueryContext::WhereOrEqual,
+                crate::select::executor::validation::SubqueryContext::SelectList,
             )?;
         }
 

--- a/crates/vibesql-executor/src/trigger_execution.rs
+++ b/crates/vibesql-executor/src/trigger_execution.rs
@@ -394,6 +394,76 @@ impl TriggerFirer {
             .collect()
     }
 
+    /// Validate that every applicable trigger's WHEN clause resolves its column
+    /// references against the target table.
+    ///
+    /// SQLite resolves a trigger's WHEN clause at statement-prepare time, so an
+    /// UPDATE/INSERT/DELETE whose trigger carries `WHEN nosuchcol` errors with
+    /// `no such column: nosuchcol` *even when zero rows match* (update-14.2/14.4).
+    /// The per-row firing path (`evaluate_when_condition`) already propagates
+    /// such errors, but it never runs when the statement touches no rows — so the
+    /// error would otherwise be silently swallowed and the UPDATE would report
+    /// `0 {}`. This method closes that gap by probing the WHEN clause once per
+    /// statement, independent of the matched-row count.
+    ///
+    /// We probe by evaluating each WHEN condition against a synthetic all-NULL
+    /// row of the table schema, reusing the exact resolution semantics of the
+    /// per-row path (OLD/NEW pseudo-variables, rowid aliases, etc.). Only column
+    /// and table resolution failures are propagated; any other evaluation outcome
+    /// (a boolean verdict, a NULL, or a runtime error that depends on actual row
+    /// data) is ignored here and handled by the normal per-row path when rows are
+    /// present.
+    ///
+    /// Called at the top level of a DML statement (not inside a trigger body),
+    /// matching SQLite's prepare-time resolution of the outermost statement.
+    pub fn validate_when_clauses_for_event(
+        db: &Database,
+        table_name: &str,
+        event: TriggerEvent,
+        dml_schema: Option<&str>,
+    ) -> Result<(), ExecutorError> {
+        let triggers = db
+            .catalog
+            .get_triggers_for_table_in_schema(table_name, Some(event), dml_schema)
+            .filter(|trigger| trigger.enabled && trigger.when_condition.is_some())
+            .cloned()
+            .collect::<Vec<_>>();
+
+        if triggers.is_empty() {
+            return Ok(());
+        }
+
+        let schema = Self::resolve_trigger_schema(db, table_name)?;
+        let null_row = Row::new(vec![SqlValue::Null; schema.columns.len()]);
+
+        for trigger in &triggers {
+            let when_expr = match trigger.when_condition.as_deref() {
+                Some(expr) => expr,
+                None => continue,
+            };
+
+            // Provide the synthetic NULL row as both OLD and NEW so OLD/NEW
+            // qualified references resolve regardless of the event kind. We
+            // only care about column/table resolution here, not the verdict.
+            match Self::evaluate_when_condition(
+                db,
+                &trigger.table_name,
+                when_expr,
+                Some(&null_row),
+                Some(&null_row),
+            ) {
+                // Resolution errors must surface even with zero matched rows.
+                Err(e @ ExecutorError::ColumnNotFound { .. })
+                | Err(e @ ExecutorError::TableNotFound(_)) => return Err(e),
+                // Any other outcome (verdict, NULL, or a data-dependent runtime
+                // error) is handled by the per-row path when rows are present.
+                _ => {}
+            }
+        }
+
+        Ok(())
+    }
+
     /// Check if an UPDATE OF trigger should fire based on which columns changed
     ///
     /// # Arguments

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -118,6 +118,21 @@ pub(super) fn execute_internal(
     // gate on statement triggers.
     let fire_statement_triggers = has_triggers && trigger_context.is_none();
 
+    // Resolve trigger WHEN clauses at statement-prepare time (SQLite semantics).
+    // A trigger `WHEN nosuchcol` must error `no such column: nosuchcol` even when
+    // the UPDATE matches zero rows (update-14.2/14.4); the per-row firing path
+    // never runs in that case, so validate the WHEN clauses up front. Only at the
+    // top level (not inside another trigger body), matching SQLite's prepare-time
+    // resolution of the outermost statement.
+    if has_triggers && trigger_context.is_none() {
+        crate::TriggerFirer::validate_when_clauses_for_event(
+            database,
+            table_name,
+            vibesql_ast::TriggerEvent::Update(None),
+            None,
+        )?;
+    }
+
     // Try fast path for simple single-row PK updates without triggers
     // Conditions: no triggers, no procedural context, simple WHERE pk = value, no assertions
     // Skip fast path if assertions exist because we need rollback capability on violation

--- a/crates/vibesql-executor/tests/having_subquery_aggregate_in_subquery_tests.rs
+++ b/crates/vibesql-executor/tests/having_subquery_aggregate_in_subquery_tests.rs
@@ -1,0 +1,103 @@
+//! Regression tests for outer-correlated aggregates inside a bare scalar
+//! subquery in a HAVING clause (in-23.0, sqlite3 forum/forumpost/dc16ec63d3).
+//!
+//! A HAVING clause only exists on an aggregating outer query, so a bare
+//! (FROM-less) scalar subquery whose aggregate references an outer column is NOT
+//! a "misuse of aggregate": it borrows the outer aggregation context and
+//! collapses over the current group, exactly like the SELECT-list case (#5104).
+//! Previously VibeSQL validated HAVING with `SubqueryContext::WhereOrEqual` and
+//! wrongly rejected:
+//!
+//! ```sql
+//! SELECT a0.a, group_concat(a1.a) AS b
+//!   FROM t4 AS a0 JOIN t4 AS a1
+//!  GROUP BY a0.a
+//! HAVING (SELECT sum( (a1.a == +a0.a COLLATE NOCASE) IN (SELECT b FROM t4)));
+//! ```
+//!
+//! with `misuse of aggregate: sum()`. Expected output verified against
+//! sqlite3 3.51.0.
+
+use vibesql_ast::Statement;
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+fn run(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse {sql}: {e:?}"));
+    match stmt {
+        Statement::CreateTable(s) => {
+            vibesql_executor::CreateTableExecutor::execute(&s, db).unwrap();
+        }
+        Statement::CreateIndex(s) => {
+            vibesql_executor::CreateIndexExecutor::execute(&s, db).unwrap();
+        }
+        Statement::Insert(i) => {
+            vibesql_executor::InsertExecutor::execute(db, &i).unwrap();
+        }
+        other => panic!("unsupported setup statement: {other:?}"),
+    }
+}
+
+fn rows_as_strings(db: &Database, sql: &str) -> Vec<Vec<String>> {
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse {sql}: {e:?}"));
+    let Statement::Select(select) = stmt else { panic!("expected SELECT, got {stmt:?}") };
+    let rows = SelectExecutor::new(db).execute(&select).expect("SELECT failed");
+    rows.iter().map(|r| r.values.iter().map(|v| v.to_string()).collect()).collect()
+}
+
+fn setup(db: &mut Database) {
+    run(db, "CREATE TABLE t4(a TEXT, b INT);");
+    run(db, "INSERT INTO t4(a,b) VALUES('abc',0),('ABC',1),('def',2);");
+    run(db, "CREATE INDEX t4x ON t4(a, +a COLLATE NOCASE);");
+}
+
+/// in-23.0: `sum( <outer-correlated bool> IN (SELECT b FROM t4) )` inside a bare
+/// scalar subquery in HAVING must be accepted, not rejected as misuse.
+#[test]
+fn having_bare_subquery_aggregate_in_subquery_is_not_misuse() {
+    let mut db = Database::new();
+    setup(&mut db);
+
+    let rows = rows_as_strings(
+        &db,
+        "SELECT a0.a, group_concat(a1.a) AS b \
+           FROM t4 AS a0 JOIN t4 AS a1 \
+          GROUP BY a0.a \
+         HAVING (SELECT sum( (a1.a == +a0.a COLLATE NOCASE) IN (SELECT b FROM t4)));",
+    );
+
+    // sqlite3 3.51.0: every group survives the HAVING (the sum is non-zero/true).
+    assert_eq!(
+        rows,
+        vec![
+            vec!["ABC".to_string(), "abc,ABC,def".to_string()],
+            vec!["abc".to_string(), "abc,ABC,def".to_string()],
+            vec!["def".to_string(), "abc,ABC,def".to_string()],
+        ],
+    );
+}
+
+/// in-23.0-b: same shape with GLOB instead of `==` — also accepted.
+#[test]
+fn having_bare_subquery_aggregate_in_subquery_glob_is_not_misuse() {
+    let mut db = Database::new();
+    setup(&mut db);
+
+    let rows = rows_as_strings(
+        &db,
+        "SELECT a0.a, group_concat(a1.a) AS b \
+           FROM t4 AS a0 JOIN t4 AS a1 \
+          GROUP BY a0.a \
+         HAVING (SELECT sum( (a1.a GLOB +a0.a COLLATE NOCASE) IN (SELECT b FROM t4)));",
+    );
+
+    assert_eq!(
+        rows,
+        vec![
+            vec!["ABC".to_string(), "abc,ABC,def".to_string()],
+            vec!["abc".to_string(), "abc,ABC,def".to_string()],
+            vec!["def".to_string(), "abc,ABC,def".to_string()],
+        ],
+    );
+}

--- a/crates/vibesql-executor/tests/trigger_when_subquery_tests.rs
+++ b/crates/vibesql-executor/tests/trigger_when_subquery_tests.rs
@@ -221,6 +221,71 @@ fn when_correlated_exists_subquery_referencing_new_5585() {
     assert_eq!(query_scalar_i64(&db, "SELECT count(*) FROM hit WHERE id = 4;"), 1, "id 4 in other");
 }
 
+/// Helper: parse + execute an UPDATE, returning its Result so the caller can
+/// assert success or a specific error. Unlike `exec`, this does not panic on a
+/// DML error.
+fn try_update(db: &mut Database, sql: &str) -> Result<usize, vibesql_executor::ExecutorError> {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e:?}"));
+    let Statement::Update(s) = stmt else { panic!("expected UPDATE, got {stmt:?}") };
+    UpdateExecutor::execute(&s, db)
+}
+
+/// update-14.2/14.4 regression: a trigger WHEN clause that references a
+/// nonexistent column must surface `no such column` even when the UPDATE matches
+/// zero rows. SQLite resolves the WHEN clause at statement-prepare time, so an
+/// `UPDATE t SET ...` on an *empty* table whose BEFORE/AFTER UPDATE trigger
+/// carries `WHEN nosuchcol` errors rather than silently reporting 0 rows.
+#[test]
+fn trigger_when_unresolvable_column_errors_on_empty_table() {
+    for timing in ["BEFORE", "AFTER"] {
+        let mut db = Database::new();
+        exec(&mut db, "CREATE TABLE t (a, b, c);");
+        exec(
+            &mut db,
+            &format!(
+                "CREATE TRIGGER tr {timing} UPDATE ON t WHEN nosuchcol \
+                 BEGIN SELECT 1; END;",
+            ),
+        );
+
+        // Table is empty: the UPDATE matches zero rows. The WHEN clause's
+        // unresolvable column must still produce a column-not-found error.
+        let err = try_update(&mut db, "UPDATE t SET a = 1;").expect_err(&format!(
+            "{timing} UPDATE trigger with `WHEN nosuchcol` must error on an empty table",
+        ));
+        match err {
+            vibesql_executor::ExecutorError::ColumnNotFound { column_name, .. } => {
+                assert_eq!(
+                    column_name.to_lowercase(),
+                    "nosuchcol",
+                    "error should name the unresolvable WHEN column",
+                );
+            }
+            other => panic!("expected ColumnNotFound for {timing} trigger, got {other:?}"),
+        }
+    }
+}
+
+/// Guard against false positives: a *valid* WHEN clause (including OLD/NEW
+/// pseudo-variable references) on an empty table must NOT error from the
+/// statement-prepare-time WHEN validation — the UPDATE simply matches no rows.
+#[test]
+fn trigger_when_valid_columns_no_error_on_empty_table() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t (a, b);");
+    exec(&mut db, "CREATE TRIGGER tr1 BEFORE UPDATE ON t WHEN a > 0 BEGIN SELECT 1; END;");
+    exec(
+        &mut db,
+        "CREATE TRIGGER tr2 AFTER UPDATE ON t WHEN OLD.a <> NEW.a BEGIN SELECT 1; END;",
+    );
+
+    // Empty table: zero rows matched, valid WHEN clauses, must succeed with 0.
+    let updated = try_update(&mut db, "UPDATE t SET a = 1;")
+        .expect("valid WHEN clauses must not error on an empty-table UPDATE");
+    assert_eq!(updated, 0, "no rows should be updated on an empty table");
+}
+
 /// #5585 regression guard: a *non-trigger* correlated scalar subquery (ordinary
 /// query, no trigger context) is unaffected by the pseudo-variable substitution
 /// path. The subquery here correlates to the outer table's column, not NEW/OLD.


### PR DESCRIPTION
## Summary

Two independent SQLite error-semantics fixes split from #5715, one per failing TCL test file. Both are small and self-contained.

- **Fix A — update.test (trigger WHEN swallows column-not-found):** `UPDATE t SET ...` whose BEFORE/AFTER trigger has `WHEN nosuchcol` returned `0 {}` instead of `1 {no such column: nosuchcol}` when the table is empty. SQLite resolves the WHEN clause at statement-prepare time, so the error must surface even with zero matched rows. The per-row firing path already propagated the error but never ran on an empty table.

- **Fix B — in.test (aggregate ref inside subquery wrongly flagged):** `HAVING (SELECT sum((a1.a == +a0.a COLLATE NOCASE) IN (SELECT b FROM t4)))` errored `misuse of aggregate: sum()`. A HAVING clause only exists on an aggregating outer query, so a bare scalar subquery whose aggregate references an outer column legitimately borrows the outer aggregation context (the same implicit-collapse case as the SELECT list, #5104).

## Changes

- `crates/vibesql-executor/src/trigger_execution.rs`: add `TriggerFirer::validate_when_clauses_for_event`, which probes each applicable trigger's WHEN clause against a synthetic NULL row and propagates only `ColumnNotFound`/`TableNotFound`, reusing the per-row resolution semantics (OLD/NEW pseudo-vars, rowid aliases) so valid WHEN clauses on empty tables do not false-positive.
- `crates/vibesql-executor/src/update/executor.rs`: invoke the validator once per top-level UPDATE that has triggers (skipped inside trigger bodies, matching SQLite's prepare-time resolution of the outermost statement).
- `crates/vibesql-executor/src/select/executor/aggregation/mod.rs`: validate HAVING bare scalar subqueries with `SubqueryContext::SelectList` instead of `WhereOrEqual`, so outer-correlated aggregates are not rejected as misuse while row-value misuse is still caught.
- Regression tests:
  - `crates/vibesql-executor/tests/trigger_when_subquery_tests.rs`: trigger WHEN with a nonexistent column errors on an empty-table UPDATE (BEFORE + AFTER); valid WHEN clauses (incl. OLD/NEW) on an empty table do **not** error.
  - `crates/vibesql-executor/tests/having_subquery_aggregate_in_subquery_tests.rs` (new): in-23.0 / in-23.0-b accepted with the expected rows.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| update.test failing tests pass | ✅ | update-14.2 + 14.4 now pass; file 126→128 passing, 0 failed |
| in.test failing test passes | ✅ | in-23.0 now passes; file 113→114 passing, 0 failed |
| Regression tests for both fixes | ✅ | 2 new trigger-WHEN tests + 2 new HAVING-subquery tests (all pass) |
| No regression to trigger/aggregate/subquery suites | ✅ | executor lib 2988 pass; trigger/having/subquery integration suites all pass; aggnested/select1/select5/select6/count/window1/where/where9 TCL show no new failures |
| Fix B does not break correlated-subquery aggregate validation | ✅ | Row-value misuse still caught in HAVING; SELECT-list collapse path (#5104) unchanged; valid-WHEN guard test prevents false positives |

## Test Plan

- `cargo test -p vibesql-executor --lib` → 2988 passed, 0 failed
- New + related integration suites (trigger_when_subquery, having_subquery, scalar_subquery, update_subquery, cte/tpch/correlated subquery, recursive/temp/depth triggers): all pass
- `python3 scripts/tcl_runner.py --native-tcl --files update.test` → 0 failed; same for in.test → 0 failed
- Pre-existing trigger1.test (38) and where9.test (2) failures are unrelated (syntax/datatype/EQP) and contain no column-not-found regressions

Closes #5737

🤖 Generated with [Claude Code](https://claude.com/claude-code)