### PR TITLE
feat(sql): support UPDATE ... [ORDER BY] LIMIT [OFFSET] (#5735)

### DIFF
--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -707,6 +707,11 @@ impl<'a, 'arena> Converter<'a, 'arena> {
                 .as_ref()
                 .map(|froms| froms.iter().map(|f| self.convert_from_clause(f)).collect()),
             where_clause: stmt.where_clause.as_ref().map(|wc| self.convert_where_clause(wc)),
+            // Arena UPDATE does not yet carry ORDER BY / LIMIT / OFFSET; the
+            // standard parser path does.
+            order_by: None,
+            limit: None,
+            offset: None,
             conflict_clause: stmt.conflict_clause.map(ConflictClause::from),
             returning: stmt
                 .returning

--- a/crates/vibesql-ast/src/dml.rs
+++ b/crates/vibesql-ast/src/dml.rs
@@ -191,6 +191,17 @@ pub struct UpdateStmt {
     /// See: <https://www.sqlite.org/lang_update.html#update_from>
     pub from_clause: Option<Vec<FromClause>>,
     pub where_clause: Option<WhereClause>,
+    /// Optional ORDER BY clause (SQLite extension for UPDATE)
+    /// When present with LIMIT, updates rows in the specified order.
+    /// Requires SQLite to be compiled with SQLITE_ENABLE_UPDATE_DELETE_LIMIT;
+    /// VibeSQL supports it unconditionally to match the conformance suite.
+    pub order_by: Option<Vec<OrderByItem>>,
+    /// Optional LIMIT clause (SQLite extension for UPDATE)
+    /// Limits the number of rows updated. May appear with or without ORDER BY.
+    pub limit: Option<Expression>,
+    /// Optional OFFSET clause (SQLite extension for UPDATE)
+    /// When used with LIMIT, skips rows before updating.
+    pub offset: Option<Expression>,
     /// Optional conflict resolution clause (SQLite extension)
     /// Syntax: UPDATE OR REPLACE|IGNORE|ABORT|ROLLBACK|FAIL table SET ...
     pub conflict_clause: Option<ConflictClause>,

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -1452,6 +1452,18 @@ pub fn transform_update<V: ExpressionMutVisitor>(visitor: &mut V, stmt: UpdateSt
             }
             other => other,
         }),
+        order_by: stmt.order_by.map(|items| {
+            items
+                .into_iter()
+                .map(|item| crate::OrderByItem {
+                    expr: transform_expression(visitor, item.expr),
+                    direction: item.direction,
+                    nulls_order: item.nulls_order,
+                })
+                .collect()
+        }),
+        limit: stmt.limit.map(|e| transform_expression(visitor, e)),
+        offset: stmt.offset.map(|e| transform_expression(visitor, e)),
         conflict_clause: stmt.conflict_clause,
         returning: stmt.returning.map(|items| {
             items

--- a/crates/vibesql-ast/tests/statements.rs
+++ b/crates/vibesql-ast/tests/statements.rs
@@ -69,6 +69,9 @@ fn test_create_update_statement() {
         }],
         from_clause: None,
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     });

--- a/crates/vibesql-executor/benches/sysbench_benchmark.rs
+++ b/crates/vibesql-executor/benches/sysbench_benchmark.rs
@@ -204,6 +204,9 @@ fn bind_update(stmt: &UpdateStmt, params: &[SqlValue]) -> UpdateStmt {
             .collect(),
         from_clause: stmt.from_clause.clone(), // UPDATE FROM not used in sysbench
         where_clause: bind_where_clause(&stmt.where_clause, params),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: stmt.conflict_clause.clone(),
         returning: None,
     }

--- a/crates/vibesql-executor/src/tests/triggers/update.rs
+++ b/crates/vibesql-executor/src/tests/triggers/update.rs
@@ -82,6 +82,9 @@ fn test_after_update_trigger_fires() {
                 )),
             },
         )),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -161,6 +164,9 @@ fn test_before_update_trigger_fires() {
                 )),
             },
         )),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -243,6 +249,9 @@ fn test_update_of_fires_only_for_listed_column() {
                     )),
                 },
             )),
+            order_by: None,
+            limit: None,
+            offset: None,
             conflict_clause: None,
             returning: None,
         };

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -146,6 +146,13 @@ pub(super) fn execute_internal(
         && !has_expression_indexes
         // RETURNING needs the two-phase path so NEW rows can be captured
         && stmt.returning.is_none()
+        // ORDER BY / LIMIT / OFFSET (SQLite extension) restrict which rows are
+        // updated; the single-row PK fast path has no row-limiting logic, so
+        // route through the standard scan path (mirrors DELETE skipping its
+        // TRUNCATE fast path when ORDER BY/LIMIT is present).
+        && stmt.order_by.is_none()
+        && stmt.limit.is_none()
+        && stmt.offset.is_none()
         // OR REPLACE / OR IGNORE need the two-phase path to resolve conflicts:
         // REPLACE deletes the conflicting row (firing its DELETE triggers) and
         // IGNORE skips the row. The fast path has no conflict-resolution logic,
@@ -246,8 +253,23 @@ pub(super) fn execute_internal(
     // visibility. Off-state collapses to the pre-MVCC live-row filter.
     let snapshot = crate::mvcc::read_snapshot(database);
     let row_selector = RowSelector::new(schema);
-    let candidate_rows =
+    let mut candidate_rows =
         row_selector.select_rows(table, &stmt.where_clause, &mut evaluator, &snapshot)?;
+
+    // Apply ORDER BY sorting and LIMIT/OFFSET (SQLite extension for UPDATE).
+    // Mirrors the DELETE ... ORDER BY ... LIMIT path: when LIMIT (and optionally
+    // ORDER BY/OFFSET) is present, restrict which of the matched rows are
+    // actually updated. Without ORDER BY, rows are limited in scan order, which
+    // matches SQLite's UPDATE ... LIMIT behavior.
+    if stmt.order_by.is_some() || stmt.limit.is_some() || stmt.offset.is_some() {
+        apply_order_by_and_limit(
+            &mut candidate_rows,
+            stmt.order_by.as_deref(),
+            &stmt.limit,
+            &stmt.offset,
+            &evaluator,
+        )?;
+    }
 
     // Estimate DML cost for query analysis and optimization decisions
     if std::env::var("DML_COST_DEBUG").is_ok() && !candidate_rows.is_empty() {
@@ -2157,4 +2179,121 @@ fn empty_returning(
             )
         })
         .transpose()
+}
+
+/// Sort the candidate rows by the UPDATE `ORDER BY` clause (if any) and then
+/// apply `OFFSET`/`LIMIT` (SQLite extension for UPDATE).
+///
+/// This mirrors the DELETE executor's `apply_order_by_and_limit`. When
+/// `order_by` is `None` the rows are left in their scan order before LIMIT/OFFSET
+/// are applied, matching `UPDATE ... LIMIT n` semantics.
+fn apply_order_by_and_limit(
+    rows_and_indices: &mut Vec<(usize, Row)>,
+    order_by: Option<&[vibesql_ast::OrderByItem]>,
+    limit: &Option<Expression>,
+    offset: &Option<Expression>,
+    evaluator: &ExpressionEvaluator,
+) -> Result<(), ExecutorError> {
+    use vibesql_ast::OrderDirection;
+
+    // Sort rows by ORDER BY columns (if present)
+    if let Some(order_by) = order_by {
+        rows_and_indices.sort_by(|a, b| {
+            for item in order_by {
+                // Evaluate the ORDER BY expression for both rows
+                let val_a = evaluator.eval(&item.expr, &a.1).unwrap_or(SqlValue::Null);
+                let val_b = evaluator.eval(&item.expr, &b.1).unwrap_or(SqlValue::Null);
+
+                // Compare values with proper NULL handling.
+                // NULLS FIRST: nulls come first (default for DESC)
+                // NULLS LAST: nulls come last (default for ASC)
+                let nulls_first = match item.nulls_order {
+                    Some(vibesql_ast::NullsOrder::First) => true,
+                    Some(vibesql_ast::NullsOrder::Last) => false,
+                    None => matches!(item.direction, OrderDirection::Desc),
+                };
+
+                let cmp = match (&val_a, &val_b) {
+                    (SqlValue::Null, SqlValue::Null) => std::cmp::Ordering::Equal,
+                    (SqlValue::Null, _) => {
+                        if nulls_first {
+                            std::cmp::Ordering::Less
+                        } else {
+                            std::cmp::Ordering::Greater
+                        }
+                    }
+                    (_, SqlValue::Null) => {
+                        if nulls_first {
+                            std::cmp::Ordering::Greater
+                        } else {
+                            std::cmp::Ordering::Less
+                        }
+                    }
+                    _ => val_a.partial_cmp(&val_b).unwrap_or(std::cmp::Ordering::Equal),
+                };
+
+                // Apply direction
+                let cmp = match item.direction {
+                    OrderDirection::Desc => cmp.reverse(),
+                    OrderDirection::Asc => cmp,
+                };
+
+                if cmp != std::cmp::Ordering::Equal {
+                    return cmp;
+                }
+            }
+            std::cmp::Ordering::Equal
+        });
+    }
+
+    // Evaluate OFFSET expression if present
+    let offset_val = if let Some(ref offset_expr) = offset {
+        let empty_row = Row::new(vec![]);
+        match evaluator.eval(offset_expr, &empty_row)? {
+            SqlValue::Integer(n) if n >= 0 => n as usize,
+            SqlValue::Bigint(n) if n >= 0 => n as usize,
+            SqlValue::Null => 0, // NULL offset treated as 0
+            _ => {
+                return Err(ExecutorError::TypeError(
+                    "OFFSET value must be a non-negative integer".to_string(),
+                ))
+            }
+        }
+    } else {
+        0
+    };
+
+    // Evaluate LIMIT expression if present
+    let limit_val = if let Some(ref limit_expr) = limit {
+        let empty_row = Row::new(vec![]);
+        match evaluator.eval(limit_expr, &empty_row)? {
+            SqlValue::Integer(n) if n >= 0 => Some(n as usize),
+            SqlValue::Bigint(n) if n >= 0 => Some(n as usize),
+            SqlValue::Integer(-1) | SqlValue::Bigint(-1) => None, // -1 means no limit (SQLite extension)
+            SqlValue::Null => None, // NULL limit treated as no limit
+            _ => {
+                return Err(ExecutorError::TypeError(
+                    "LIMIT value must be a non-negative integer".to_string(),
+                ))
+            }
+        }
+    } else {
+        None
+    };
+
+    // Apply OFFSET: skip first N rows
+    if offset_val > 0 {
+        if offset_val >= rows_and_indices.len() {
+            rows_and_indices.clear();
+        } else {
+            rows_and_indices.drain(..offset_val);
+        }
+    }
+
+    // Apply LIMIT: keep only first N rows
+    if let Some(limit) = limit_val {
+        rows_and_indices.truncate(limit);
+    }
+
+    Ok(())
 }

--- a/crates/vibesql-executor/src/update/mod.rs
+++ b/crates/vibesql-executor/src/update/mod.rs
@@ -131,6 +131,9 @@ impl UpdateExecutor {
     ///     }],
     ///     from_clause: None,
     ///     where_clause: None,
+    ///     order_by: None,
+    ///     limit: None,
+    ///     offset: None,
     ///     conflict_clause: None,
     ///     returning: None,
     /// };

--- a/crates/vibesql-executor/src/update/tests/limit.rs
+++ b/crates/vibesql-executor/src/update/tests/limit.rs
@@ -1,0 +1,157 @@
+//! `UPDATE ... [ORDER BY ...] LIMIT n [OFFSET m]` on base tables (issue #5735).
+//!
+//! SQLite (compiled with SQLITE_ENABLE_UPDATE_DELETE_LIMIT) restricts how many
+//! rows an UPDATE touches via an optional ORDER BY / LIMIT / OFFSET tail, the
+//! same way it does for DELETE. VibeSQL supports it unconditionally to match the
+//! conformance suite (see docs/reference/sqlite/test/wherelimit2.test). These
+//! tests mirror the DELETE...LIMIT executor behavior.
+
+use vibesql_ast::Statement;
+use vibesql_parser::Parser;
+use vibesql_types::SqlValue;
+
+use crate::*;
+
+fn ddl(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse {:?}: {:?}", sql, e));
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT");
+        }
+        other => panic!("unsupported ddl: {:?}", other),
+    }
+}
+
+fn update(db: &mut vibesql_storage::Database, sql: &str) -> usize {
+    match Parser::parse_sql(sql).expect("parse update") {
+        Statement::Update(s) => UpdateExecutor::execute(&s, db).expect("UPDATE"),
+        other => panic!("expected UPDATE, got {:?}", other),
+    }
+}
+
+fn select(db: &mut vibesql_storage::Database, sql: &str) -> Vec<vibesql_storage::Row> {
+    match Parser::parse_sql(sql).expect("parse select") {
+        Statement::Select(s) => SelectExecutor::new(db).execute(&s).expect("SELECT"),
+        other => panic!("expected SELECT, got {:?}", other),
+    }
+}
+
+fn int(v: &SqlValue) -> i64 {
+    match v {
+        SqlValue::Integer(i) => *i,
+        SqlValue::Bigint(i) => *i,
+        other => panic!("expected integer, got {:?}", other),
+    }
+}
+
+/// Count how many rows in `t(a, b)` currently have `b = target`.
+fn count_b(db: &mut vibesql_storage::Database, target: i64) -> usize {
+    select(db, "SELECT a, b FROM t").iter().filter(|r| int(&r.values[1]) == target).count()
+}
+
+fn seed(db: &mut vibesql_storage::Database) {
+    ddl(db, "CREATE TABLE t(a INTEGER PRIMARY KEY, b)");
+    ddl(db, "INSERT INTO t VALUES(1, 10)");
+    ddl(db, "INSERT INTO t VALUES(2, 10)");
+    ddl(db, "INSERT INTO t VALUES(3, 10)");
+    ddl(db, "INSERT INTO t VALUES(4, 10)");
+    ddl(db, "INSERT INTO t VALUES(5, 10)");
+}
+
+/// `UPDATE ... LIMIT n` (no ORDER BY, no WHERE) updates exactly n rows.
+#[test]
+fn update_limit_updates_only_n_rows() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+
+    assert_eq!(update(&mut db, "UPDATE t SET b = 99 LIMIT 2"), 2);
+    assert_eq!(count_b(&mut db, 99), 2);
+    assert_eq!(count_b(&mut db, 10), 3);
+}
+
+/// `UPDATE ... WHERE ... LIMIT n` only updates n of the matching rows.
+#[test]
+fn update_where_limit_caps_matched_rows() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+
+    // All 5 rows match b=10, but LIMIT 1 caps it to a single update.
+    assert_eq!(update(&mut db, "UPDATE t SET b = 99 WHERE b = 10 LIMIT 1"), 1);
+    assert_eq!(count_b(&mut db, 99), 1);
+    assert_eq!(count_b(&mut db, 10), 4);
+}
+
+/// `UPDATE ... ORDER BY ... LIMIT n` updates the first n rows in sort order.
+#[test]
+fn update_order_by_limit_updates_first_rows() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+
+    // ORDER BY a ASC LIMIT 2 -> rows a=1 and a=2 get b=99.
+    assert_eq!(update(&mut db, "UPDATE t SET b = 99 ORDER BY a LIMIT 2"), 2);
+    let rows = select(&mut db, "SELECT a, b FROM t ORDER BY a");
+    let got: Vec<(i64, i64)> =
+        rows.iter().map(|r| (int(&r.values[0]), int(&r.values[1]))).collect();
+    assert_eq!(got, vec![(1, 99), (2, 99), (3, 10), (4, 10), (5, 10)]);
+}
+
+/// `UPDATE ... ORDER BY ... DESC LIMIT n` honors descending order.
+#[test]
+fn update_order_by_desc_limit() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+
+    // ORDER BY a DESC LIMIT 2 -> rows a=5 and a=4.
+    assert_eq!(update(&mut db, "UPDATE t SET b = 99 ORDER BY a DESC LIMIT 2"), 2);
+    let rows = select(&mut db, "SELECT a, b FROM t ORDER BY a");
+    let got: Vec<(i64, i64)> =
+        rows.iter().map(|r| (int(&r.values[0]), int(&r.values[1]))).collect();
+    assert_eq!(got, vec![(1, 10), (2, 10), (3, 10), (4, 99), (5, 99)]);
+}
+
+/// `UPDATE ... ORDER BY ... LIMIT n OFFSET m` skips m rows before updating n.
+#[test]
+fn update_order_by_limit_offset() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+
+    // ORDER BY a LIMIT 2 OFFSET 1 -> rows a=2 and a=3.
+    assert_eq!(update(&mut db, "UPDATE t SET b = 99 ORDER BY a LIMIT 2 OFFSET 1"), 2);
+    let rows = select(&mut db, "SELECT a, b FROM t ORDER BY a");
+    let got: Vec<(i64, i64)> =
+        rows.iter().map(|r| (int(&r.values[0]), int(&r.values[1]))).collect();
+    assert_eq!(got, vec![(1, 10), (2, 99), (3, 99), (4, 10), (5, 10)]);
+}
+
+/// `LIMIT 0` updates no rows.
+#[test]
+fn update_limit_zero_updates_nothing() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+
+    assert_eq!(update(&mut db, "UPDATE t SET b = 99 LIMIT 0"), 0);
+    assert_eq!(count_b(&mut db, 10), 5);
+}
+
+/// `LIMIT -1` means "no limit" (SQLite extension): all matching rows update.
+#[test]
+fn update_limit_negative_one_updates_all() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+
+    assert_eq!(update(&mut db, "UPDATE t SET b = 99 LIMIT -1"), 5);
+    assert_eq!(count_b(&mut db, 99), 5);
+}
+
+/// `UPDATE` without LIMIT still updates every matching row (no regression).
+#[test]
+fn update_without_limit_updates_all() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+
+    assert_eq!(update(&mut db, "UPDATE t SET b = 99 WHERE b = 10"), 5);
+    assert_eq!(count_b(&mut db, 99), 5);
+}

--- a/crates/vibesql-executor/src/update/tests/mod.rs
+++ b/crates/vibesql-executor/src/update/tests/mod.rs
@@ -1,4 +1,5 @@
 //! Tests for UPDATE statement execution.
 
+mod limit;
 mod set_rowid;
 mod trigger_phase_value;

--- a/crates/vibesql-executor/tests/conflict_resolution_tests.rs
+++ b/crates/vibesql-executor/tests/conflict_resolution_tests.rs
@@ -245,6 +245,9 @@ fn test_update_or_ignore_primary_key_conflict() {
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: Some(ConflictClause::Ignore),
         returning: None,
     };
@@ -294,6 +297,9 @@ fn test_update_or_ignore_unique_constraint_conflict() {
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: Some(ConflictClause::Ignore),
         returning: None,
     };
@@ -333,6 +339,9 @@ fn test_update_or_ignore_no_conflict() {
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: Some(ConflictClause::Ignore),
         returning: None,
     };
@@ -380,6 +389,9 @@ fn test_update_or_replace_primary_key_conflict() {
                 "alice@test.com",
             )))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: Some(ConflictClause::Replace),
         returning: None,
     };
@@ -424,6 +436,9 @@ fn test_update_or_replace_unique_constraint_conflict() {
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: Some(ConflictClause::Replace),
         returning: None,
     };
@@ -471,6 +486,9 @@ fn test_update_or_replace_no_conflict() {
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: Some(ConflictClause::Replace),
         returning: None,
     };
@@ -544,6 +562,9 @@ fn test_update_or_ignore_not_null_violation() {
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: Some(ConflictClause::Ignore),
         returning: None,
     };

--- a/crates/vibesql-executor/tests/update_basic_tests.rs
+++ b/crates/vibesql-executor/tests/update_basic_tests.rs
@@ -23,6 +23,9 @@ fn test_update_all_rows() {
             value: Expression::Literal(SqlValue::Integer(50000)),
         }],
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -63,6 +66,9 @@ fn test_update_with_where_clause() {
                 "Engineering",
             )))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -111,6 +117,9 @@ fn test_update_multiple_columns() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -153,6 +162,9 @@ fn test_update_with_expression() {
             },
         }],
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -182,6 +194,9 @@ fn test_update_table_not_found() {
         table_name: "nonexistent".to_string(),
         assignments: vec![],
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -208,6 +223,9 @@ fn test_update_column_not_found() {
             value: Expression::Literal(SqlValue::Integer(123)),
         }],
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -240,6 +258,9 @@ fn test_update_no_matching_rows() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(999))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/update_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/update_columnar_cache_tests.rs
@@ -69,6 +69,9 @@ fn test_update_invalidates_columnar_cache() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -142,6 +145,9 @@ fn test_update_invalidates_prewarmed_cache() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Bob")))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -183,6 +189,9 @@ fn test_update_all_rows_invalidates_cache() {
             value: Expression::Literal(SqlValue::Integer(60000)),
         }],
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -228,6 +237,9 @@ fn test_update_no_match_does_not_invalidate_cache() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(999))), // No such id
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -274,6 +286,9 @@ fn test_multiple_updates_invalidate_cache() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -306,6 +321,9 @@ fn test_multiple_updates_invalidate_cache() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -360,6 +378,9 @@ fn test_update_multiple_columns_invalidates_cache() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/update_constraint_tests/check_constraints.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/check_constraints.rs
@@ -29,6 +29,9 @@ fn test_update_check_constraint_passes() {
             value: Expression::Literal(SqlValue::Integer(100)),
         }],
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -58,6 +61,9 @@ fn test_update_check_constraint_violation() {
             value: Expression::Literal(SqlValue::Integer(-10)),
         }],
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -95,6 +101,9 @@ fn test_update_check_constraint_with_null() {
             value: Expression::Literal(SqlValue::Null),
         }],
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -128,6 +137,9 @@ fn test_update_check_constraint_with_expression() {
             value: Expression::Literal(SqlValue::Integer(15000)),
         }],
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -147,6 +159,9 @@ fn test_update_check_constraint_with_expression() {
             value: Expression::Literal(SqlValue::Integer(60000)),
         }],
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/update_constraint_tests/constraint_test_utils.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/constraint_test_utils.rs
@@ -192,6 +192,9 @@ pub fn create_update_with_id_clause(
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(id))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     }

--- a/crates/vibesql-executor/tests/update_constraint_tests/unique_constraints.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/unique_constraints.rs
@@ -183,6 +183,9 @@ fn test_update_unique_constraint_composite() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/update_default_tests.rs
+++ b/crates/vibesql-executor/tests/update_default_tests.rs
@@ -43,6 +43,9 @@ fn test_update_with_default_value() {
             ))),
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -97,6 +100,9 @@ fn test_update_default_no_default_value_defined() {
             ))),
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/update_onepass_tests.rs
+++ b/crates/vibesql-executor/tests/update_onepass_tests.rs
@@ -128,6 +128,9 @@ fn test_onepass_multiple_literal_assignments() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -172,6 +175,9 @@ fn test_onepass_single_literal_assignment() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(2))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -208,6 +214,9 @@ fn test_onepass_pk_not_found_returns_zero() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(999))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -253,6 +262,9 @@ fn test_onepass_not_null_constraint_enforced() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -300,6 +312,9 @@ fn test_composite_pk_update_both_columns_specified() {
                 right: Box::new(Expression::Literal(SqlValue::Integer(1))),
             }),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -353,6 +368,9 @@ fn test_composite_pk_update_reversed_order() {
                 right: Box::new(Expression::Literal(SqlValue::Integer(1))),
             }),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -391,6 +409,9 @@ fn test_composite_pk_partial_match_uses_scan() {
             op: BinaryOperator::Equal,
             right: Box::new(Expression::Literal(SqlValue::Integer(1))),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -440,6 +461,9 @@ fn test_composite_pk_not_found_returns_zero() {
                 right: Box::new(Expression::Literal(SqlValue::Integer(99))),
             }),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -488,6 +512,9 @@ fn test_composite_pk_multiple_columns_updated() {
                 right: Box::new(Expression::Literal(SqlValue::Integer(1))),
             }),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
@@ -77,6 +77,9 @@ fn test_update_with_subquery_multiple_rows_uses_first() {
             value: Expression::ScalarSubquery(subquery),
         }],
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -175,6 +178,9 @@ fn test_update_with_subquery_multiple_columns_error() {
             value: Expression::ScalarSubquery(subquery),
         }],
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
@@ -137,6 +137,9 @@ fn create_update_stmt(
         assignments: vec![Assignment { column: column.to_string(), value }],
         from_clause: None,
         where_clause,
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     }
@@ -158,6 +161,9 @@ fn create_multi_column_update_stmt(
             .collect(),
         from_clause: None,
         where_clause: None,
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     }

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
@@ -79,6 +79,9 @@ fn test_update_where_scalar_subquery_equal() {
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(Expression::ScalarSubquery(subquery)),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -172,6 +175,9 @@ fn test_update_where_scalar_subquery_less_than() {
             op: vibesql_ast::BinaryOperator::LessThan,
             right: Box::new(Expression::ScalarSubquery(subquery)),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -257,6 +263,9 @@ fn test_update_where_subquery_returns_null() {
             op: vibesql_ast::BinaryOperator::LessThan,
             right: Box::new(Expression::ScalarSubquery(subquery)),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -354,6 +363,9 @@ fn test_update_where_subquery_with_aggregate() {
             op: vibesql_ast::BinaryOperator::Equal,
             right: Box::new(Expression::ScalarSubquery(subquery)),
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -488,6 +500,9 @@ fn test_update_where_and_set_both_use_subqueries() {
             subquery: where_subquery,
             negated: false,
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
@@ -94,6 +94,9 @@ fn test_update_where_in_subquery() {
             subquery,
             negated: false,
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -191,6 +194,9 @@ fn test_update_where_not_in_subquery() {
             subquery,
             negated: true,
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -281,6 +287,9 @@ fn test_update_where_subquery_empty_result() {
             subquery,
             negated: false,
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -388,6 +397,9 @@ fn test_update_where_complex_subquery_condition() {
             subquery,
             negated: false,
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };
@@ -489,6 +501,9 @@ fn test_update_where_multiple_rows_in_subquery() {
             subquery,
             negated: false,
         })),
+        order_by: None,
+        limit: None,
+        offset: None,
         conflict_clause: None,
         returning: None,
     };

--- a/crates/vibesql-parser/src/parser/update.rs
+++ b/crates/vibesql-parser/src/parser/update.rs
@@ -144,6 +144,11 @@ impl Parser {
             None
         };
 
+        // Parse optional ORDER BY / LIMIT / OFFSET (SQLite extension for UPDATE).
+        // Mirrors the DELETE ... ORDER BY ... LIMIT ... OFFSET path so that
+        // UPDATE ... LIMIT n [OFFSET m] restricts how many rows are updated.
+        let (order_by, limit, offset) = self.parse_update_order_limit_offset()?;
+
         // Parse optional RETURNING clause (SQLite 3.35.0+)
         // Syntax: UPDATE ... [WHERE ...] RETURNING expr [, expr ...]
         let returning = if self.peek_keyword(Keyword::Returning) {
@@ -165,9 +170,104 @@ impl Parser {
             assignments,
             from_clause,
             where_clause,
+            order_by,
+            limit,
+            offset,
             conflict_clause,
             returning,
         })
+    }
+
+    /// Parse the optional `ORDER BY ... LIMIT ... OFFSET ...` tail of an UPDATE
+    /// statement (SQLite extension). Returns `(order_by, limit, offset)`.
+    ///
+    /// This mirrors `parse_delete_statement`'s handling so UPDATE and DELETE
+    /// accept the same LIMIT/OFFSET syntax, including the `LIMIT offset,count`
+    /// comma form.
+    #[allow(clippy::type_complexity)]
+    fn parse_update_order_limit_offset(
+        &mut self,
+    ) -> Result<
+        (
+            Option<Vec<vibesql_ast::OrderByItem>>,
+            Option<vibesql_ast::Expression>,
+            Option<vibesql_ast::Expression>,
+        ),
+        ParseError,
+    > {
+        // Parse optional ORDER BY clause
+        let order_by = if self.peek_keyword(Keyword::Order) {
+            self.consume_keyword(Keyword::Order)?;
+            self.expect_keyword(Keyword::By)?;
+
+            let order_items = self.parse_comma_separated_list(|p| {
+                let expr = p.parse_expression()?;
+                let direction = if p.peek_keyword(Keyword::Asc) {
+                    p.consume_keyword(Keyword::Asc)?;
+                    vibesql_ast::OrderDirection::Asc
+                } else if p.peek_keyword(Keyword::Desc) {
+                    p.consume_keyword(Keyword::Desc)?;
+                    vibesql_ast::OrderDirection::Desc
+                } else {
+                    vibesql_ast::OrderDirection::Asc
+                };
+
+                let nulls_order = if p.peek_keyword(Keyword::Nulls) {
+                    p.consume_keyword(Keyword::Nulls)?;
+                    if p.peek_keyword(Keyword::First) {
+                        p.consume_keyword(Keyword::First)?;
+                        Some(vibesql_ast::NullsOrder::First)
+                    } else if p.peek_keyword(Keyword::Last) {
+                        p.consume_keyword(Keyword::Last)?;
+                        Some(vibesql_ast::NullsOrder::Last)
+                    } else {
+                        return Err(ParseError {
+                            message: format!(
+                                "Expected FIRST or LAST after NULLS, found {}",
+                                p.peek().syntax_error()
+                            ),
+                        });
+                    }
+                } else {
+                    None
+                };
+
+                Ok(vibesql_ast::OrderByItem { expr, direction, nulls_order })
+            })?;
+
+            Some(order_items)
+        } else {
+            None
+        };
+
+        // Parse optional LIMIT clause (supports `LIMIT offset,count` comma syntax)
+        let (limit, offset_from_limit) = if self.peek_keyword(Keyword::Limit) {
+            self.consume_keyword(Keyword::Limit)?;
+            let first_expr = self.parse_expression()?;
+
+            if matches!(self.peek(), Token::Comma) {
+                self.advance();
+                let second_expr = self.parse_expression()?;
+                // LIMIT offset,count syntax
+                (Some(second_expr), Some(first_expr))
+            } else {
+                (Some(first_expr), None)
+            }
+        } else {
+            (None, None)
+        };
+
+        // Parse optional OFFSET clause (only if not already set via comma syntax)
+        let offset = if offset_from_limit.is_some() {
+            offset_from_limit
+        } else if self.peek_keyword(Keyword::Offset) {
+            self.consume_keyword(Keyword::Offset)?;
+            Some(self.parse_expression()?)
+        } else {
+            None
+        };
+
+        Ok((order_by, limit, offset))
     }
 
     /// Parse UPDATE statement with a pre-parsed WITH clause (CTEs)
@@ -303,6 +403,9 @@ impl Parser {
             None
         };
 
+        // Parse optional ORDER BY / LIMIT / OFFSET (SQLite extension for UPDATE).
+        let (order_by, limit, offset) = self.parse_update_order_limit_offset()?;
+
         // Parse optional RETURNING clause (SQLite 3.35.0+)
         // Syntax: UPDATE ... [WHERE ...] RETURNING expr [, expr ...]
         let returning = if self.peek_keyword(Keyword::Returning) {
@@ -324,6 +427,9 @@ impl Parser {
             assignments,
             from_clause,
             where_clause,
+            order_by,
+            limit,
+            offset,
             conflict_clause,
             returning,
         })

--- a/crates/vibesql-parser/src/tests/update.rs
+++ b/crates/vibesql-parser/src/tests/update.rs
@@ -314,3 +314,96 @@ fn test_returning_still_usable_as_identifier() {
         _ => panic!("Expected UPDATE statement"),
     }
 }
+
+// ========================================================================
+// UPDATE ... ORDER BY / LIMIT / OFFSET (SQLite extension, issue #5735)
+// ========================================================================
+
+#[test]
+fn test_parse_update_limit() {
+    let result = Parser::parse_sql("UPDATE t SET col = 1 LIMIT 1;");
+    assert!(result.is_ok(), "UPDATE ... LIMIT should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(update) => {
+            assert!(update.limit.is_some());
+            assert!(update.offset.is_none());
+            assert!(update.order_by.is_none());
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
+fn test_parse_update_limit_offset() {
+    let result = Parser::parse_sql("UPDATE t SET col = 1 WHERE x > 0 LIMIT 3 OFFSET 2;");
+    assert!(result.is_ok(), "UPDATE ... LIMIT ... OFFSET should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(update) => {
+            assert!(update.where_clause.is_some());
+            assert!(update.limit.is_some());
+            assert!(update.offset.is_some());
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
+fn test_parse_update_limit_comma_offset() {
+    // SQLite `LIMIT offset,count` form: offset=2, count=3
+    let result = Parser::parse_sql("UPDATE t SET col = 1 LIMIT 2, 3;");
+    assert!(result.is_ok(), "UPDATE ... LIMIT offset,count should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(update) => {
+            assert!(update.limit.is_some());
+            assert!(update.offset.is_some());
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
+fn test_parse_update_order_by_limit_offset() {
+    let result = Parser::parse_sql("UPDATE t SET col = NULL ORDER BY a, b DESC LIMIT 3 OFFSET 1;");
+    assert!(
+        result.is_ok(),
+        "UPDATE ... ORDER BY ... LIMIT ... OFFSET should parse: {:?}",
+        result.err()
+    );
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(update) => {
+            let order_by = update.order_by.expect("order_by should be present");
+            assert_eq!(order_by.len(), 2);
+            assert!(matches!(order_by[1].direction, vibesql_ast::OrderDirection::Desc));
+            assert!(update.limit.is_some());
+            assert!(update.offset.is_some());
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
+fn test_parse_update_with_cte_limit() {
+    // WITH-CTE UPDATE path must also accept LIMIT (wherelimit2 test 7.1).
+    let result = Parser::parse_sql("WITH t1(b) AS (SELECT 2) UPDATE t1 SET a = 3 LIMIT 1;");
+    assert!(result.is_ok(), "WITH ... UPDATE ... LIMIT should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(update) => {
+            assert!(update.with_clause.is_some());
+            assert!(update.limit.is_some());
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}
+
+#[test]
+fn test_parse_update_no_limit_is_none() {
+    let result = Parser::parse_sql("UPDATE t SET col = 1 WHERE x = 2;");
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(update) => {
+            assert!(update.limit.is_none());
+            assert!(update.offset.is_none());
+            assert!(update.order_by.is_none());
+        }
+        _ => panic!("Expected UPDATE statement"),
+    }
+}

--- a/tests/storage/update_pk_performance.rs
+++ b/tests/storage/update_pk_performance.rs
@@ -69,6 +69,9 @@ fn test_update_with_pk_index_performance() {
                 right: Box::new(Expression::Literal(SqlValue::Integer(i))),
             })),
             quoted: false,
+            order_by: None,
+            limit: None,
+            offset: None,
             conflict_clause: None,
             returning: None,
         };


### PR DESCRIPTION
## Summary

Implements the SQLite `UPDATE ... [ORDER BY ...] LIMIT n [OFFSET m]` extension, which previously failed at parse time. `DELETE ... LIMIT` already worked; this mirrors that implementation end-to-end so UPDATE matches.

## Root cause

`UpdateStmt` had no `limit`/`offset` fields (and no `order_by`), so the parser had nowhere to put the clause and rejected `UPDATE t SET col=val LIMIT 1`. `DeleteStmt` already carried these fields.

## Changes (mirroring DELETE)

- **AST** (`crates/vibesql-ast/src/dml.rs`): add `order_by` / `limit` / `offset` to `UpdateStmt`.
- **Parser** (`crates/vibesql-parser/src/parser/update.rs`): parse the `ORDER BY / LIMIT / OFFSET` tail after `WHERE` in both the plain and `WITH`-CTE paths (incl. the `LIMIT offset,count` comma form), factored into `parse_update_order_limit_offset`, modeled exactly on `parse_delete_statement`.
- **Executor** (`crates/vibesql-executor/src/update/executor.rs`): after row selection, sort by `ORDER BY` (when present) and apply `OFFSET`/`LIMIT` to cap which matched rows are updated. `LIMIT` without `ORDER BY` limits in scan order. The single-row PK fast path is skipped when `ORDER BY`/`LIMIT`/`OFFSET` is present (mirrors DELETE skipping its TRUNCATE fast path). Added `apply_order_by_and_limit`, mirroring the DELETE executor helper.
- **Plumbing**: threaded the new fields through `visitor.rs` (`transform_update`); the arena convert path sets them to `None` (like `index_hint`). Updated all `UpdateStmt` literal sites (tests/benches/doctest).

## Verification

- `wherelimit2.test`: **10 passed, 0 failed** (was failing to parse `UPDATE ... LIMIT` before). The harness skips the FTS/window subtests; key passing cases include `7.1` (`WITH ... UPDATE t1 SET a=3 LIMIT 1`).
- `wherelimit.test` is still skipped wholesale by the test shim (per #5721) — unchanged, no scope creep.
- `cargo test -p vibesql-parser -p vibesql-executor`: all pass, including DELETE...LIMIT (no regression).

## Tests added

- Parser (`crates/vibesql-parser/src/tests/update.rs`): `UPDATE ... LIMIT`, `LIMIT ... OFFSET`, `LIMIT offset,count`, `ORDER BY ... LIMIT ... OFFSET`, `WITH ... UPDATE ... LIMIT`, and the no-LIMIT-is-None case.
- Executor (`crates/vibesql-executor/src/update/tests/limit.rs`): LIMIT caps rows, `WHERE ... LIMIT` caps matches, `ORDER BY` ASC/DESC ordering, `LIMIT ... OFFSET`, `LIMIT 0`, `LIMIT -1` (no limit), and a no-LIMIT regression check.

Closes #5735

🤖 Generated with [Claude Code](https://claude.com/claude-code)