### PR TITLE
fix(tcl-shim): stub load_static_extension and make 14 setup-aborting test files visible

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -2266,17 +2266,20 @@ proc catchsql {sql {db ""}} {
 # Format: file_basename (without .test) -> reason
 variable vibesql_skip_files
 array set vibesql_skip_files {
-    insert4 "Tests SQLite's internal INSERT transfer optimization (sqlite3_xferopt_count)"
-    insert5 "Tests SQLite's internal INSERT from SELECT optimization with xfer count"
+    insert4 "Tests SQLite's internal INSERT transfer optimization (sqlite3_xferopt_count) — verifies internal VDBE opcode counters, not SQL correctness"
+    insert5 "Tests SQLite's internal INSERT from SELECT optimization with xfer count — inspects EXPLAIN for OpenEphemeral opcode, SQLite-internal"
     intreal "Tests custom intreal() function registered via sqlite3_create_function"
     intarray "Tests sqlite3_intarray_create extension API - SQLite-specific"
-    indexedby "Uses INDEXED BY hint syntax which is SQLite-specific"
-    wherelimit "Tests UPDATE/DELETE ... LIMIT syntax which is SQLite-specific"
-    where8 "Tests OR optimization via execsql_status2 internal statistics - query results correct"
+    index6 "Requires wholenumber vtab extension (load_static_extension db wholenumber) for test-data population; ifcapable !vtab exits before any test runs. vtab is unsupported in VibeSQL."
+    index7 "Requires wholenumber vtab extension (load_static_extension db wholenumber) for test-data population in WITHOUT ROWID partial-index tests; ifcapable !vtab exits before any test runs. vtab is unsupported in VibeSQL."
+    orderby7 "Tests ORDER BY on FTS3 virtual-table joins; ifcapable !fts3 exits before any test runs. fts3 is unsupported in VibeSQL."
+    whereJ "Tests query-plan choices that depend on STAT4 histogram statistics; ifcapable !stat4 exits before any test runs. VibeSQL uses a different cost model."
+    where8 "Tests OR optimization via execsql_status2 internal statistics (sqlite_search_count index-step counts) - query results correct, step counts not meaningful for VibeSQL"
     update2 "Uses repeat() function which is a SQLite test extension"
+    func4 "Entire file tests tointeger()/toreal() provided only by the static `totype` test extension (load_static_extension db totype). VibeSQL implements neither function, so 120+ of the 200 tests fail purely because the functions are missing. The load_static_extension shim stub now prevents the crash-abort (the file previously aborted at file scope), but a documented file skip is clearer than 120 visible function-missing failures. Tracked: tointeger()/toreal() are out-of-scope SQLite test extensions."
     func5 "Uses counter1/counter2 custom TCL functions - SQLite test extension"
     trigger6 "Entire file is built around a custom counter() TCL function (db function counter ...) used to verify INSERT/UPDATE expressions are evaluated exactly once; the tables and triggers are created in 6-1.1 alongside the function registration, so once 6-1.1 is auto-skipped (custom function) every later test cascade-fails with 'no such table: log/t1' (#5470)"
-    delete_db "Uses sqlite3_delete_database - SQLite internal function"
+    delete_db "Tests the sqlite3_delete_database() C-API (cleans up WAL/journal files) - not a SQL feature"
     incrblobfault "Uses incrblob - SQLite incremental blob I/O API"
     incrblob "Uses incrblob - SQLite incremental blob I/O API"
     incrblob2 "Uses incrblob - SQLite incremental blob I/O API"
@@ -2389,6 +2392,7 @@ array set vibesql_skip_tests {
     update-21.3 "min/max UPDATE optimization - requires multi-pass mode for subqueries"
     update-21.4 "min/max UPDATE optimization - requires multi-pass mode for subqueries"
     update-21.12 "EXPLAIN QUERY PLAN output format is SQLite-specific"
+    indexedby-2.6 "Error-message-format difference: 'SELECT ... INDEXED BY WHERE ...' (no index name) is correctly rejected by VibeSQL, but with 'Parse error: Expected index name after INDEXED BY' rather than SQLite's 'near \"WHERE\": syntax error'. INDEXED BY functionality itself works; only the parser error text differs."
     func-29.1 "Uses sqlite3_db_status internal SQLite API"
     func-29.2 "Uses sqlite3_db_status internal SQLite API"
     func-29.3 "Uses sqlite3_db_status internal SQLite API"
@@ -4967,6 +4971,23 @@ proc verify_ex_errcode {name expected {db db}} {
 proc sqlite3_connection_pointer {db} {
     # Stub for SQLite internal API - return dummy pointer
     return "0x12345678"
+}
+
+proc load_static_extension {db args} {
+    # SQLite's test harness statically links a handful of test extensions
+    # (totype, wholenumber, etc.) and loads them into a connection via
+    # `load_static_extension db <name> ...`. VibeSQL does not load C
+    # extensions, so this command would otherwise abort the entire test
+    # file with "invalid command name load_static_extension" before any
+    # test runs (e.g. func4.test, which loads the `totype` extension at
+    # file scope to register tointeger()/toreal()). Provide a no-op stub so
+    # the rest of the file is still extracted and executed; individual tests
+    # that genuinely depend on an extension-provided function will fail (or
+    # be skipped) on their own, visibly, rather than masking the whole file
+    # as a silent 0/0/0 crash. Files whose *test data* depends on an
+    # extension vtable (index6/index7's `wholenumber`) are handled by
+    # explicit vibesql_skip_files entries instead.
+    return ""
 }
 
 proc sqlite3_create_function {args} {


### PR DESCRIPTION
## Summary

Issue #5721 reported 14 core TCL test files aborting at setup and reporting as silent 0/0/0, masking their true status. This contained change to `scripts/tester_vibesql.tcl` ensures every one of those files **visibly runs** or **visibly skips with a documented reason** — no file is silently empty.

## Changes (`scripts/tester_vibesql.tcl` only)

**Add `load_static_extension` stub**
- New no-op `load_static_extension` proc. `func4.test` previously crash-aborted the entire file with `invalid command name "load_static_extension"` before any test ran. The stub lets the file be extracted/executed instead of aborting.

**Remove stale skips (now-resolved features) so they RUN**
- Removed `indexedby` and `wherelimit` from `vibesql_skip_files`.
- `indexedby`: now runs 19 tests, 18 pass, 1 documented per-test skip (`indexedby-2.6` — error-message-format diff only; INDEXED BY itself works).
- `wherelimit`: now runs 60 tests, 31 pass, 29 real DELETE/UPDATE...LIMIT conformance failures now **visible** (tracked in #5747). `DELETE/UPDATE ... ORDER BY ... LIMIT` already works (#5742); the gaps are LIMIT-without-ORDER-BY, negative LIMIT/OFFSET, comma syntax, RETURNING+ORDER BY, and a few error-format diffs.

**Add documented skips (genuinely unsupported, were silent 0/0/0)**
- `index6`, `index7` — wholenumber vtab via `ifcapable !vtab`.
- `orderby7` — fts3 virtual table.
- `whereJ` — STAT4 histogram statistics.
- These exited via `ifcapable` guards before the skip logic fired; now they print `Skipping entire file` with a clear reason.

**Add documented `func4` file skip**
- After the stub un-masks func4, 122/200 tests fail purely because `tointeger()`/`toreal()` (totype extension) are unimplemented. A documented file skip is clearer than 120 function-missing failures. The stub still benefits any other file that loads a non-essential extension.

**Clarify annotations** for `delete_db`, `insert4`, `insert5`, `where8` (left skipped; reasons sharpened).

## Per-file disposition

| File | Before | After |
|------|--------|-------|
| indexedby | file-skip (stale) | RUNS 19: 18 pass, 1 per-test skip (err-format) |
| wherelimit | file-skip (stale) | RUNS 60: 31 pass, 29 real fails (#5747) |
| func4 | crash-abort (0/0/0) | documented file-skip (totype ext) |
| index6 | silent 0/0/0 | documented file-skip (vtab) |
| index7 | silent 0/0/0 | documented file-skip (vtab) |
| orderby7 | silent 0/0/0 | documented file-skip (fts3) |
| whereJ | silent 0/0/0 | documented file-skip (stat4) |
| delete_db / insert4 / insert5 / where8 | file-skip | file-skip, clearer annotations |

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| No file silently 0/0/0 | ✅ | All 14 either run with real pass/fail or print "Skipping entire file" + reason |
| Remove stale indexedby/wherelimit skips; verify they run | ✅ | indexedby 19 run, wherelimit 60 run (real pass/fail, no abort) |
| Add documented skips for index6/index7/orderby7/whereJ | ✅ | Explicit `vibesql_skip_files` entries with reasons |
| Add load_static_extension stub; run func4, report real result | ✅ | func4 un-crashed → 78 pass/122 fail; "many fail" → documented file skip per directive |
| File 3 focused follow-ups | ✅ | func5 #5744, update2 #5745, where4 #5746 (+ wherelimit gaps #5747) |
| Single-file diff, no fmt churn | ✅ | `git diff --stat`: only `scripts/tester_vibesql.tcl` (+27/-6) |

## Test Plan (wide before/after — no regression)

Ran each file with the original shim (before) and the modified shim (after). The wide regression sample is **byte-identical**:

| File | Before | After |
|------|--------|-------|
| select1 | 188/188/0 | 188/188/0 |
| where | 168/168/0 (skip 139) | 168/168/0 (skip 139) |
| func | 14547/14547/0 (skip 202) | 14547/14547/0 (skip 202) |
| delete | 49/49/0 | 49/49/0 |
| update | 128/128/0 | 128/128/0 |
| index | 69/69/0 | 69/69/0 |
| where9 | 19/19/0 | 19/19/0 |

Targeted files before→after: indexedby (skipfile → 19 run/18 pass/1 skip), wherelimit (skipfile → 60 run/31 pass/29 fail), func4 (crash → documented file-skip), index6 (silent 0/0/0 → documented file-skip).

## Follow-ups filed (label `tcl-tests`)

- #5744 — func5: narrow file skip (func5-1.* instr() tests can run)
- #5745 — update2: audit native repeat() support
- #5746 — where4: !tclvar||!bloblit guard exits whole file
- #5747 — wherelimit: DELETE/UPDATE...LIMIT conformance gaps (29 surfaced failures)

Closes #5721