### PR TITLE
fix(executor): respect where_filtered in iterator path so UNION ALL branch WHERE keeps affinity

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/filter/comparison.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/comparison.rs
@@ -174,6 +174,30 @@ pub(super) fn compare_values(a: &SqlValue, b: &SqlValue) -> CompareResult {
 
         // Mixed numeric types: coerce to f64 with epsilon comparison for floats
         _ => {
+            // Issue #5749: an exact integer compared against an approximate
+            // float must NOT round the integer through `as f64` first — for
+            // magnitudes above 2^53 that loses precision, so e.g.
+            // `Integer(i64::MAX) >= 9223372036854775808.0` (the f64 value that
+            // `i64::MAX + 1` overflows to) wrongly compared Equal and admitted
+            // the row. The expression evaluator handles this with a precise
+            // integer/float comparator; mirror it here so the columnar filter
+            // agrees, keeping `where_filtered` trustworthy across all execution
+            // paths (fast_path, materialized, and the iterator path). Only the
+            // exact-integer storage classes qualify (Numeric is decimal and
+            // handled by the f64 path below).
+            if let Some(int_val) = exact_integer(a) {
+                if let Some(float_val) = approximate_float(b) {
+                    return CompareResult::Ordering(compare_int_float(int_val, float_val));
+                }
+            }
+            if let Some(float_val) = approximate_float(a) {
+                if let Some(int_val) = exact_integer(b) {
+                    return CompareResult::Ordering(
+                        compare_int_float(int_val, float_val).reverse(),
+                    );
+                }
+            }
+
             // First try direct numeric comparison
             if let (Some(a_f64), Some(b_f64)) = (to_f64(a), to_f64(b)) {
                 // Use epsilon comparison for floating point values to handle precision issues
@@ -247,6 +271,95 @@ pub(super) fn compare_values(a: &SqlValue, b: &SqlValue) -> CompareResult {
             return CompareResult::Incomparable;
         }
     })
+}
+
+/// Extract an exact-integer storage-class value as `i64`.
+///
+/// Issue #5749: only the storage classes that hold an exact integer qualify for
+/// the precise integer/float comparator. `Numeric` is a decimal type and
+/// `Boolean` is handled by the generic numeric path, so they are intentionally
+/// excluded here.
+#[inline]
+fn exact_integer(v: &SqlValue) -> Option<i64> {
+    match v {
+        SqlValue::Integer(n) | SqlValue::Bigint(n) => Some(*n),
+        SqlValue::Smallint(n) => Some(*n as i64),
+        SqlValue::Unsigned(n) => i64::try_from(*n).ok(),
+        _ => None,
+    }
+}
+
+/// Extract an approximate (binary floating point) storage-class value as `f64`.
+#[inline]
+fn approximate_float(v: &SqlValue) -> Option<f64> {
+    match v {
+        SqlValue::Float(n) => Some(*n as f64),
+        SqlValue::Real(n) | SqlValue::Double(n) => Some(*n),
+        _ => None,
+    }
+}
+
+/// Compare an exact integer with a float precisely, handling the magnitude range
+/// above 2^53 where `i64 as f64` loses precision.
+///
+/// Issue #5749: this mirrors the expression evaluator's `compare_int_float`
+/// (`evaluator/operators/comparison/mod.rs`) so the columnar filter and the
+/// evaluator agree on results such as `i64::MAX` vs `9223372036854775808.0`
+/// (the f64 that `i64::MAX + 1` overflows to). Keeping them in agreement is what
+/// makes the `where_filtered` fast-path guard safe.
+#[inline]
+fn compare_int_float(int_val: i64, float_val: f64) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+
+    // NaN: treat as Equal so every predicate fails (matches evaluator).
+    if float_val.is_nan() {
+        return Ordering::Equal;
+    }
+
+    // Infinity.
+    if float_val.is_infinite() {
+        return if float_val.is_sign_positive() { Ordering::Less } else { Ordering::Greater };
+    }
+
+    // Within the exact-representation range (|x| <= 2^53) with no fractional
+    // part, compare as integers.
+    const EXACT_INT_MAX: f64 = 9007199254740992.0; // 2^53
+    const EXACT_INT_MIN: f64 = -9007199254740992.0;
+    if float_val >= EXACT_INT_MIN && float_val <= EXACT_INT_MAX && float_val.fract() == 0.0 {
+        return int_val.cmp(&(float_val as i64));
+    }
+
+    // Fractional floats: compare via float (int rounding is irrelevant to the
+    // strict inequality result here).
+    if float_val.fract() != 0.0 {
+        let int_as_float = int_val as f64;
+        return int_as_float.partial_cmp(&float_val).unwrap_or(Ordering::Equal);
+    }
+
+    // Imprecise integral floats (2^53 < |value|). float(i64::MAX) rounds UP to
+    // 2^63, so any i64 is strictly less than it.
+    const I64_MAX_PLUS_ONE_AS_F64: f64 = 9223372036854775808.0_f64; // 2^63
+    if float_val >= I64_MAX_PLUS_ONE_AS_F64 {
+        return Ordering::Less;
+    }
+    const I64_MIN_AS_F64: f64 = -9223372036854775808.0_f64; // -2^63
+    if float_val < I64_MIN_AS_F64 {
+        return Ordering::Greater;
+    }
+    if float_val == I64_MIN_AS_F64 {
+        return int_val.cmp(&i64::MIN);
+    }
+
+    // Imprecise zone (2^53 < |value| < 2^63): account for rounding of the int.
+    let int_as_float = int_val as f64;
+    if int_as_float == float_val {
+        let round_trip = int_as_float as i64;
+        if round_trip == int_val {
+            return Ordering::Equal;
+        }
+        return if round_trip > int_val { Ordering::Less } else { Ordering::Greater };
+    }
+    int_as_float.partial_cmp(&float_val).unwrap_or(Ordering::Equal)
 }
 
 /// Parse a date string in YYYY-MM-DD format
@@ -327,6 +440,60 @@ mod tests {
             result,
             CompareResult::Ordering(std::cmp::Ordering::Less),
             "Float(50.0) should be < Integer(85)"
+        );
+    }
+
+    /// Issue #5749: precise integer-vs-float comparison near i64::MAX.
+    ///
+    /// `i64::MAX + 1` overflows arithmetic to the f64 `9223372036854775808.0`
+    /// (= 2^63). A naive `i64::MAX as f64` also rounds UP to 2^63, so the lossy
+    /// path reported Equal and `a >= 2^63` wrongly matched. The precise
+    /// comparator must report `i64::MAX < 2^63`. This mirrors the expression
+    /// evaluator so the columnar `where_filtered` flag stays trustworthy.
+    #[test]
+    fn test_issue_5749_integer_max_vs_overflow_float() {
+        use std::cmp::Ordering;
+
+        let int_max = SqlValue::Integer(i64::MAX);
+        let overflow_float = SqlValue::Double(9223372036854775808.0); // 2^63
+
+        // i64::MAX must compare strictly LESS than 2^63, so `>=` is false.
+        assert_eq!(
+            compare_values(&int_max, &overflow_float),
+            CompareResult::Ordering(Ordering::Less),
+            "i64::MAX must be < 2^63 (not Equal via lossy f64 rounding)"
+        );
+        // And the reversed orientation must be Greater.
+        assert_eq!(
+            compare_values(&overflow_float, &int_max),
+            CompareResult::Ordering(Ordering::Greater),
+            "2^63 must be > i64::MAX"
+        );
+    }
+
+    /// Issue #5749: ordinary small-magnitude integer/float pairs must still
+    /// compare correctly through the precise path (no behavior change below
+    /// 2^53).
+    #[test]
+    fn test_issue_5749_small_integer_vs_float_unchanged() {
+        use std::cmp::Ordering;
+
+        assert_eq!(
+            compare_values(&SqlValue::Integer(85), &SqlValue::Double(85.0)),
+            CompareResult::Ordering(Ordering::Equal),
+        );
+        assert_eq!(
+            compare_values(&SqlValue::Integer(85), &SqlValue::Double(85.5)),
+            CompareResult::Ordering(Ordering::Less),
+        );
+        assert_eq!(
+            compare_values(&SqlValue::Integer(86), &SqlValue::Float(85.5)),
+            CompareResult::Ordering(Ordering::Greater),
+        );
+        // Exact integral float within 2^53 compares as integers.
+        assert_eq!(
+            compare_values(&SqlValue::Bigint(1_000_000), &SqlValue::Double(1_000_000.0)),
+            CompareResult::Ordering(Ordering::Equal),
         );
     }
 
@@ -547,8 +714,7 @@ mod tests {
     /// Test evaluate_predicate with text vs integer
     #[test]
     fn test_evaluate_predicate_text_vs_integer() {
-        use super::super::evaluation::evaluate_predicate;
-        use super::super::predicates::ColumnPredicate;
+        use super::super::{evaluation::evaluate_predicate, predicates::ColumnPredicate};
 
         // GreaterThan predicate: column > 123
         let predicate =

--- a/crates/vibesql-executor/src/select/executor/nonagg/iterator.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/iterator.rs
@@ -68,6 +68,17 @@ impl SelectExecutor<'_> {
     ) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
         let schema = from_result.schema.clone();
         let _sorted_by = from_result.sorted_by.clone();
+        // Issue #5749: Capture whether the scan already fully applied the WHERE
+        // clause BEFORE consuming `from_result`. When the columnar/table scan
+        // fully consumed the predicate (only set on full coverage — see
+        // `extract_full_coverage_predicates` + the `!has_complex_predicates`
+        // gate in scan/table.rs), the Stage-2 FilterIterator below must NOT
+        // re-evaluate WHERE. Re-evaluation uses the expression evaluator's
+        // affinity rules, which can disagree with the columnar filter for a
+        // NONE-affinity column (e.g. `a = '14'` on a typeless column), wrongly
+        // dropping rows that the scan correctly matched. This mirrors the guards
+        // already present in fast_path/mod.rs and nonagg/materialized.rs.
+        let where_filtered = from_result.where_filtered;
         let rows = from_result.into_rows();
 
         // Create evaluator using consolidated ExecutionContext
@@ -123,39 +134,48 @@ impl SelectExecutor<'_> {
         let mut iterator: Box<dyn RowIterator> =
             Box::new(TableScanIterator::new(schema.clone(), rows));
 
-        // Stage 2: WHERE filter (if present)
-        if let Some(ref where_expr) = resolved_where {
-            // Optimize WHERE clause
-            let where_optimization = optimize_where_clause(Some(where_expr), &evaluator)?;
+        // Stage 2: WHERE filter (if present AND not already consumed by the scan)
+        //
+        // Issue #5749: skip re-evaluation when the scan already fully applied the
+        // WHERE clause (`where_filtered == true`). Re-applying here would run the
+        // predicate through the expression evaluator's affinity rules, which can
+        // contradict the columnar filter for NONE-affinity columns and wrongly
+        // drop matching rows (e.g. `SELECT a FROM t1 WHERE a='14' UNION ALL ...`).
+        // Mirrors the guards in fast_path/mod.rs and nonagg/materialized.rs.
+        if !where_filtered {
+            if let Some(ref where_expr) = resolved_where {
+                // Optimize WHERE clause
+                let where_optimization = optimize_where_clause(Some(where_expr), &evaluator)?;
 
-            match where_optimization {
-                crate::optimizer::WhereOptimization::AlwaysFalse => {
-                    // WHERE FALSE - return empty result immediately
-                    return Ok(Vec::new());
-                }
-                crate::optimizer::WhereOptimization::AlwaysTrue => {
-                    // WHERE TRUE - no filtering needed, keep current iterator
-                }
-                crate::optimizer::WhereOptimization::Optimized(expr) => {
-                    // Apply optimized WHERE clause - use the evaluator that has outer context if
-                    // present
-                    iterator = Box::new(FilterIterator::new(
-                        iterator,
-                        expr,
-                        evaluator.clone_for_new_expression(),
-                    ));
-                }
-                crate::optimizer::WhereOptimization::Unchanged(Some(expr)) => {
-                    // Apply original WHERE clause - use the evaluator that has outer context if
-                    // present
-                    iterator = Box::new(FilterIterator::new(
-                        iterator,
-                        expr.clone(),
-                        evaluator.clone_for_new_expression(),
-                    ));
-                }
-                crate::optimizer::WhereOptimization::Unchanged(None) => {
-                    // No WHERE clause - keep current iterator
+                match where_optimization {
+                    crate::optimizer::WhereOptimization::AlwaysFalse => {
+                        // WHERE FALSE - return empty result immediately
+                        return Ok(Vec::new());
+                    }
+                    crate::optimizer::WhereOptimization::AlwaysTrue => {
+                        // WHERE TRUE - no filtering needed, keep current iterator
+                    }
+                    crate::optimizer::WhereOptimization::Optimized(expr) => {
+                        // Apply optimized WHERE clause - use the evaluator that has outer context
+                        // if present
+                        iterator = Box::new(FilterIterator::new(
+                            iterator,
+                            expr,
+                            evaluator.clone_for_new_expression(),
+                        ));
+                    }
+                    crate::optimizer::WhereOptimization::Unchanged(Some(expr)) => {
+                        // Apply original WHERE clause - use the evaluator that has outer context if
+                        // present
+                        iterator = Box::new(FilterIterator::new(
+                            iterator,
+                            expr.clone(),
+                            evaluator.clone_for_new_expression(),
+                        ));
+                    }
+                    crate::optimizer::WhereOptimization::Unchanged(None) => {
+                        // No WHERE clause - keep current iterator
+                    }
                 }
             }
         }
@@ -203,7 +223,8 @@ impl SelectExecutor<'_> {
 
         // SQLite compatibility: Do NOT apply implicit value-based sorting (issue #4537)
         // SQLite returns rows in storage order (insertion order / rowid order) when no ORDER BY
-        // is specified. Implicit sorting by value breaks this behavior and causes TCL test failures.
+        // is specified. Implicit sorting by value breaks this behavior and causes TCL test
+        // failures.
         //
         // Previously we sorted for "deterministic results", but SQLite's deterministic behavior
         // is based on physical storage order, not value-based sorting.

--- a/crates/vibesql-executor/tests/union_branch_where_affinity_tests.rs
+++ b/crates/vibesql-executor/tests/union_branch_where_affinity_tests.rs
@@ -1,0 +1,219 @@
+//! Regression tests for issue #5749:
+//! "[executor] WHERE on a UNION ALL branch loses column type affinity".
+//!
+//! Root cause: `execute_with_iterators`
+//! (`select/executor/nonagg/iterator.rs`) ignored `from_result.where_filtered`
+//! and UNCONDITIONALLY re-applied the WHERE clause via a `FilterIterator`. The
+//! columnar table scan had already applied the predicate WITH numeric coercion
+//! (setting `where_filtered = true`), but the second evaluation runs through the
+//! expression evaluator's `apply_affinity_for_comparison`, which does NOT coerce
+//! `'14'` -> 14 for a NONE-affinity (typeless) column. So `a = '14'` matched in
+//! the scan but the re-evaluation dropped the row, yielding an empty branch.
+//!
+//! The fast path (`fast_path/mod.rs`) and the materialized path
+//! (`nonagg/materialized.rs`) already guarded their WHERE re-application behind
+//! `where_filtered`, which is why standalone `SELECT a FROM t1 WHERE a='14'`
+//! (a simple point query routed through the fast path) returned the row
+//! correctly. Only compound (UNION ALL / set-operation / compound-derived-table)
+//! queries went through `execute_with_iterators` and lost the row.
+//!
+//! The fix mirrors those two guards: skip the Stage-2 FilterIterator when
+//! `where_filtered == true`. `where_filtered` is only set when the scan FULLY
+//! applied the predicate (gated on `extract_full_coverage_predicates` succeeding
+//! for all conjuncts and on the absence of complex predicates such as scalar
+//! subqueries — see `select/scan/table.rs`), so skipping re-application is safe
+//! and never wrongly admits rows. The partial-coverage / complex-predicate tests
+//! below confirm re-application still happens when `where_filtered == false`.
+
+use vibesql_executor::{CreateTableExecutor, InsertExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Execute one or more non-SELECT SQL statements separated by ';'.
+fn execute_sql(db: &mut Database, sql: &str) {
+    for sql_stmt in sql.split(';') {
+        let trimmed = sql_stmt.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
+        match stmt {
+            vibesql_ast::Statement::CreateTable(s) => {
+                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+            }
+            vibesql_ast::Statement::Insert(s) => {
+                InsertExecutor::execute(db, &s).expect("INSERT failed");
+            }
+            other => panic!("Unsupported statement type: {:?}", other),
+        }
+    }
+}
+
+/// Execute a SELECT and return the first column of each row, preserving order.
+fn select_first_col(db: &Database, sql: &str) -> Vec<SqlValue> {
+    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
+    let select_stmt = match stmt {
+        vibesql_ast::Statement::Select(s) => s,
+        other => panic!("Expected SELECT statement, got {:?}", other),
+    };
+    let executor = vibesql_executor::SelectExecutor::new(db);
+    executor
+        .execute(&select_stmt)
+        .expect("SELECT execution failed")
+        .iter()
+        .map(|row| row.values[0].clone())
+        .collect()
+}
+
+/// `CREATE TABLE t1(a, b, c)` — every column is typeless (NONE affinity).
+/// `t2(d)` is also typeless and kept empty for the derived-table case.
+fn setup_db() -> Database {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        "CREATE TABLE t1(a, b, c); INSERT INTO t1 VALUES(14, 16, 18); CREATE TABLE t2(d)",
+    );
+    db
+}
+
+fn i(n: i64) -> SqlValue {
+    SqlValue::Integer(n)
+}
+
+/// Repro 1 (left branch). Before the fix this returned `{999}` only.
+#[test]
+fn test_union_all_left_branch_where_affinity() {
+    let db = setup_db();
+    let rows = select_first_col(&db, "SELECT a FROM t1 WHERE a = '14' UNION ALL SELECT 999");
+    assert_eq!(
+        rows,
+        vec![i(14), i(999)],
+        "left branch `a = '14'` on a typeless column must match the stored integer 14"
+    );
+}
+
+/// Repro 2 (right branch). The right branch of a set operation executes through
+/// the same `execute_with_iterators` path via `execute_set_operations`.
+#[test]
+fn test_union_all_right_branch_where_affinity() {
+    let db = setup_db();
+    let rows = select_first_col(&db, "SELECT 999 UNION ALL SELECT a FROM t1 WHERE a = '14'");
+    assert_eq!(
+        rows,
+        vec![i(999), i(14)],
+        "right branch `a = '14'` on a typeless column must match the stored integer 14"
+    );
+}
+
+/// Repro 3 (compound derived table). `t2` is empty, so only the 14 row should
+/// surface. Before the fix this returned `{}`.
+#[test]
+fn test_union_all_compound_derived_table_where_affinity() {
+    let db = setup_db();
+    let rows = select_first_col(
+        &db,
+        "SELECT * FROM (SELECT a FROM t1 WHERE a = '14' UNION ALL SELECT d FROM t2) AS v",
+    );
+    assert_eq!(rows, vec![i(14)], "compound-derived-table branch must keep the matching 14 row");
+}
+
+/// Standalone (fast-path) case must continue to return the row — guards against
+/// a regression to the path that already worked.
+#[test]
+fn test_standalone_where_affinity_unchanged() {
+    let db = setup_db();
+    let rows = select_first_col(&db, "SELECT a FROM t1 WHERE a = '14'");
+    assert_eq!(rows, vec![i(14)], "standalone `a = '14'` must still return 14");
+}
+
+/// Integer-literal form must keep working in compound queries.
+#[test]
+fn test_union_all_integer_literal_unchanged() {
+    let db = setup_db();
+    let rows = select_first_col(&db, "SELECT a FROM t1 WHERE a = 14 UNION ALL SELECT 999");
+    assert_eq!(rows, vec![i(14), i(999)]);
+}
+
+/// Partial / range predicates: the scan only fully consumes table-local
+/// columnar predicates. A `>` predicate over a compound query must still filter
+/// correctly (re-application path, where_filtered == true here because `a > 15`
+/// is a full-coverage columnar predicate). This asserts no rows are wrongly
+/// admitted or dropped.
+#[test]
+fn test_union_all_range_predicate() {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        "CREATE TABLE t3(a, b, c); \
+         INSERT INTO t3 VALUES(14, 16, 18); \
+         INSERT INTO t3 VALUES(20, 21, 22); \
+         INSERT INTO t3 VALUES(30, 31, 32)",
+    );
+    let rows = select_first_col(&db, "SELECT a FROM t3 WHERE a > 15 UNION ALL SELECT 999");
+    assert_eq!(rows, vec![i(20), i(30), i(999)]);
+}
+
+/// Complex predicate (scalar subquery) in a compound branch. This is the
+/// INVERSE risk of the fix: such a predicate is routed to `complex_predicates`,
+/// so the scan does NOT mark `where_filtered = true`, and the WHERE MUST be
+/// re-applied by the iterator. If the guard wrongly trusted a stale flag here,
+/// the subquery conjunct would be dropped and extra rows admitted.
+#[test]
+fn test_union_all_scalar_subquery_predicate_not_dropped() {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        "CREATE TABLE t4(a, b, c); \
+         INSERT INTO t4 VALUES(14, 16, 18); \
+         INSERT INTO t4 VALUES(20, 21, 22); \
+         INSERT INTO t4 VALUES(30, 31, 32)",
+    );
+    let rows = select_first_col(
+        &db,
+        "SELECT a FROM t4 WHERE a = (SELECT MAX(a) FROM t4) UNION ALL SELECT 999",
+    );
+    assert_eq!(
+        rows,
+        vec![i(30), i(999)],
+        "scalar-subquery conjunct must be re-applied (where_filtered stays false)"
+    );
+}
+
+/// Issue #5749 (regression guard for the columnar precision fix that the
+/// `where_filtered` guard exposed): once the iterator path trusts
+/// `where_filtered`, the columnar filter must agree with the expression
+/// evaluator on `i64::MAX >= (i64::MAX + 1)`. The overflow promotes to the f64
+/// 2^63; a lossy `i64::MAX as f64` also rounds to 2^63 and would wrongly match.
+/// SQLite returns an empty set here (TCL where-27.1).
+#[test]
+fn test_integer_max_overflow_comparison_not_matched() {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        "CREATE TABLE big(a INTEGER PRIMARY KEY); INSERT INTO big(a) VALUES(9223372036854775807)",
+    );
+    let rows = select_first_col(&db, "SELECT 1 FROM big WHERE a >= (9223372036854775807 + 1)");
+    assert!(
+        rows.is_empty(),
+        "i64::MAX must NOT satisfy `a >= i64::MAX + 1` (overflow promotes to 2^63 float); got {:?}",
+        rows
+    );
+}
+
+/// OR predicate across a compound query — exercises a non-trivial columnar
+/// predicate shape; results must match exactly.
+#[test]
+fn test_union_all_or_predicate() {
+    let mut db = Database::new();
+    execute_sql(
+        &mut db,
+        "CREATE TABLE t5(a, b, c); \
+         INSERT INTO t5 VALUES(14, 16, 18); \
+         INSERT INTO t5 VALUES(20, 21, 22); \
+         INSERT INTO t5 VALUES(30, 31, 32)",
+    );
+    let rows =
+        select_first_col(&db, "SELECT a FROM t5 WHERE a = 14 OR a = 30 UNION ALL SELECT 999");
+    assert_eq!(rows, vec![i(14), i(30), i(999)]);
+}


### PR DESCRIPTION
Closes #5749
Unblocks #5723

## Problem

A `WHERE` clause on a `UNION ALL` branch lost the column's numeric type affinity, so `a = '14'` on a typeless (NONE-affinity) column silently returned zero rows. The identical predicate as a standalone query returned the correct row.

## Root cause

`execute_with_iterators` (`select/executor/nonagg/iterator.rs`) discarded `from_result.where_filtered` and UNCONDITIONALLY re-applied the WHERE via a `FilterIterator`. The columnar table scan had already applied the predicate WITH numeric coercion (setting `where_filtered = true`), but the re-evaluation runs through the expression evaluator's `apply_affinity_for_comparison`, which does NOT coerce `'14'` -> 14 for a NONE-affinity column — so the matched row was dropped.

The fast path (`fast_path/mod.rs:203`) and the materialized path (`nonagg/materialized.rs:155`) already guard their WHERE re-application behind `where_filtered`; only the iterator path (used by compound UNION ALL / set-operation / compound-derived-table queries) didn't.

## Fix

1. **Primary** — gate the Stage-2 `FilterIterator` behind `if !where_filtered`, mirroring the two existing guards. `where_filtered` is only set on full coverage (`extract_full_coverage_predicates` + the `!has_complex_predicates` gate in `scan/table.rs`), so the guard never wrongly admits rows; complex predicates (e.g. scalar subqueries) keep `where_filtered = false` and are re-applied.

2. **Complementary** — trusting `where_filtered` exposed a latent columnar-vs-evaluator divergence (TCL `where-27.1`): `i64::MAX >= (i64::MAX + 1)` overflows to the f64 `2^63`, and a lossy `i64::MAX as f64` also rounds to `2^63`, so the columnar `compare_values` reported Equal and wrongly matched. The columnar comparator now uses a precise integer/float comparison for exact-integer-vs-approximate-float pairs (mirrors the evaluator's `compare_int_float`; no behavior change for magnitudes below 2^53), keeping `where_filtered` trustworthy across all paths.

## Verification

Repros (all correct after fix):
- `SELECT a FROM t1 WHERE a='14' UNION ALL SELECT 999` → `{14, 999}` (was `{999}`)
- `SELECT 999 UNION ALL SELECT a FROM t1 WHERE a='14'` → `{999, 14}` (was `{999}`)
- `SELECT * FROM (SELECT a FROM t1 WHERE a='14' UNION ALL SELECT d FROM t2) AS v` → `{14}` (was `{}`)
- Standalone `SELECT a FROM t1 WHERE a='14'` → `{14}` (still correct)

Tests added:
- 9 executor integration tests (`tests/union_branch_where_affinity_tests.rs`): 3 repros + right-branch + derived-table + standalone + integer-literal + range + scalar-subquery partial-coverage + i64::MAX overflow.
- 2 columnar comparator unit tests in `comparison.rs` (overflow precision + small-magnitude unchanged).

Regression status:
- `cargo test -p vibesql-executor`: 129 test binaries, 0 failures.
- TCL: `where` (168/0), `where9` (19/0), `whereB` (63/0), `unionall`/`unionall2` (4/0 each), `selectA` (227/0), `selectB` (162/0), `selectC` (24/0), `where2/3/7`, `in`, `intpkey`, `cast` all pass. `affinity2` (3 fail) and `affinity3` (5 fail) failures are PRE-EXISTING on main (verified by stash + rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)