### PR TITLE
test(tcl): narrow func5 skip, fix update2 annotation, run where4 non-tclvar tests

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -2275,9 +2275,8 @@ array set vibesql_skip_files {
     orderby7 "Tests ORDER BY on FTS3 virtual-table joins; ifcapable !fts3 exits before any test runs. fts3 is unsupported in VibeSQL."
     whereJ "Tests query-plan choices that depend on STAT4 histogram statistics; ifcapable !stat4 exits before any test runs. VibeSQL uses a different cost model."
     where8 "Tests OR optimization via execsql_status2 internal statistics (sqlite_search_count index-step counts) - query results correct, step counts not meaningful for VibeSQL"
-    update2 "Uses repeat() function which is a SQLite test extension"
+    update2 "Audited #5745: the file injects repeat() via `db func repeat [list string repeat]` and every test calls repeat(str,n) to build large UPDATE payloads. VibeSQL does NOT implement a repeat() scalar function, and REPEAT is a reserved keyword (stored-procedure REPEAT/UNTIL loops), so `SELECT repeat('ab',3)` is a parse error — the test extension cannot be substituted by a native function. All tests depend on repeat(), so the file is skipped. (The original 'SQLite test extension' note was misleading: repeat() is a standard string function elsewhere, just unimplemented + keyword-shadowed here.)"
     func4 "Entire file tests tointeger()/toreal() provided only by the static `totype` test extension (load_static_extension db totype). VibeSQL implements neither function, so 120+ of the 200 tests fail purely because the functions are missing. The load_static_extension shim stub now prevents the crash-abort (the file previously aborted at file scope), but a documented file skip is clearer than 120 visible function-missing failures. Tracked: tointeger()/toreal() are out-of-scope SQLite test extensions."
-    func5 "Uses counter1/counter2 custom TCL functions - SQLite test extension"
     trigger6 "Entire file is built around a custom counter() TCL function (db function counter ...) used to verify INSERT/UPDATE expressions are evaluated exactly once; the tables and triggers are created in 6-1.1 alongside the function registration, so once 6-1.1 is auto-skipped (custom function) every later test cascade-fails with 'no such table: log/t1' (#5470)"
     delete_db "Tests the sqlite3_delete_database() C-API (cleans up WAL/journal files) - not a SQL feature"
     incrblobfault "Uses incrblob - SQLite incremental blob I/O API"
@@ -3734,7 +3733,8 @@ array set vibesql_skip_tests {
 
     update2-1.1.1 "Uses REPEAT TCL command - SQLite test extension"
 
-    func5-2.2 "Uses counter1 - custom TCL function not available"
+    func5-2.2 "Uses counter1 - custom TCL function registered via sqlite3_create_function (C-API, unreachable from SQL CLI). func5-1.* (instr/encoding) run; only func5-2.* need the counter1/counter2 deterministic-vs-nondeterministic factoring test (#5744)."
+    func5-2.3 "Uses counter2 - custom TCL function registered via sqlite3_create_function (C-API, unreachable from SQL CLI) (#5744)"
 
     in6-1.1 "Uses sqlite_stat1 internal statistics table"
     in6-1.5 "Cascades from in6-1.1 sqlite_stat1 failure"
@@ -4891,6 +4891,24 @@ proc ifcapable {args} {
 
     # Evaluate capability expression (may be compound with || or &&)
     set result [eval_capability_expr $capability]
+
+    # where4.test special case (#5746): the file opens with
+    #   ifcapable !tclvar||!bloblit { finish_test; return }
+    # `tclvar` is unsupported in VibeSQL, so `!tclvar` is true and the `||`
+    # guard exits the entire file before any setup runs (silent 0/0/0).
+    # But `bloblit` (hex blob literals like X'78') IS supported, and the
+    # IS-NULL-index-optimization / blob-literal tests (where4-1.0, 1.11,
+    # 2.*, 4.*, 7.*) are valid VibeSQL SQL. Suppress this one file-scope exit
+    # guard so the setup and those tests run. The genuinely tclvar-dependent
+    # test (where4-1.1b, `w IS $null`) and the sqlite_search_count tests stay
+    # per-test skipped in vibesql_skip_tests.
+    if {$result && [info exists ::current_test_file_basename] \
+            && $::current_test_file_basename eq "where4" \
+            && [string match "*tclvar*" $capability] \
+            && [string match "*bloblit*" $capability] \
+            && [string match "*finish_test*" $script]} {
+        return
+    }
 
     if {$result} {
         uplevel 1 $script


### PR DESCRIPTION
Three TCL-shim follow-ups from #5721 curator triage, bundled into one PR because all touch the skip config in `scripts/tester_vibesql.tcl` (separate PRs would conflict). Diff is scoped to that single file.

## #5744 — func5: narrow the file skip
- Removed the file-level `func5` skip.
- `func5-1.1`, `func5-1.2` (`instr()` + `PRAGMA encoding=UTF16le`) and `func5-2.1` (plain CREATE/SELECT) now run and **pass**.
- `func5-2.2`/`func5-2.3` need `counter1`/`counter2` registered via `sqlite3_create_function` (C-API, unreachable from the SQL CLI) — kept per-test skipped with documented reasons.
- The top-level `set cvalue [db one {SELECT counter2(...)}]` between 2.2 and 2.3 aborts file evaluation mid-file with `no such function: counter2`; this is **surfaced as a visible "Setup error"**, not masked.
- **Result:** func5 = 3 passed / 0 failed / 1 skipped (was file-skipped, 0 run).

## #5745 — update2: audited `repeat()`
- `SELECT repeat('ab', 3)` is a **parse error** in VibeSQL: there is no `repeat()` scalar function, and `REPEAT` is a reserved keyword (stored-procedure `REPEAT/UNTIL` loops). The test's `db func repeat` injection cannot be substituted by a native function, and every update2 test depends on it.
- Skip **retained**; the inaccurate "SQLite test extension" annotation **corrected** to document the real reason.

## #5746 — where4: `ifcapable !tclvar||!bloblit` guard
- The file opened with `ifcapable !tclvar||!bloblit { finish_test; return }`. `tclvar` is unsupported, so `!tclvar` fired the OR and the whole file exited before setup (silent 0/0/0).
- `bloblit` (hex blob literals like `X'78'`) **is** supported (`hex(x'1234')` → `1234`, blob comparison works).
- Added a **tightly-gated special case** in `ifcapable` that suppresses only this `where4` file-scope exit guard (keyed on basename `where4` + the exact tclvar/bloblit/finish_test guard shape), letting the IS-NULL index-opt / blob-literal tests run. tclvar (`where4-1.1b`) and `sqlite_search_count` tests stay per-test skipped.
- **Result:** where4 = 16 passed / 0 failed / 24 skipped (was silent 0/0/0).

## Validation — wide before/after (no regressions)
| file | before | after |
|------|--------|-------|
| select1 | 188 pass / 0 fail | 188 pass / 0 fail |
| where | 168 pass / 0 fail / 139 skip | 168 pass / 0 fail / 139 skip |
| delete | 49 pass / 0 fail / 12 skip | 49 pass / 0 fail / 12 skip |
| update | 128 pass / 0 fail / 10 skip | 128 pass / 0 fail / 10 skip |
| index | 69 pass / 0 fail / 32 skip | 69 pass / 0 fail / 32 skip |
| func | identical (intermittent 0/0/0 under back-to-back spawn; unaffected by this change) | identical |
| func5 | file-skip (0 run) | **3 pass / 0 fail / 1 skip** |
| update2 | file-skip (annotation wrong) | file-skip (annotation corrected) |
| where4 | silent 0/0/0 | **16 pass / 0 fail / 24 skip** |

The `where4` special case is gated strictly on `::current_test_file_basename eq "where4"`, so it cannot affect any other file. No new engine failures exposed (0 failures across the entire sample).

Closes #5744
Closes #5745
Closes #5746

🤖 Generated with [Claude Code](https://claude.com/claude-code)