### PR TITLE
feat(wal): replay committed DML on crash recovery; WAL on by default (Phase 2 of #5698)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,22 @@ cargo build --release --features mvcc_enabled
 
 The replicated state machine applies committed transactions from the Raft log. HTTP REST, GraphQL, and CRUD writes route through consensus when the server runs in replicated mode.
 
+## CLI Durability (Write-Ahead Log)
+
+The `vibesql` CLI keeps a Write-Ahead Log for file-backed databases so committed changes survive an unclean shutdown (crash, SIGKILL, power loss). WAL is **on by default**; set `[database] wal = false` in `~/.vibesqlrc` to opt out and use the snapshot-only path.
+
+For a database file `mydata.vbsql`, WAL-active mode maintains two sibling files next to it:
+
+```text
+mydata.vbsql            — binary snapshot (last checkpoint, loaded on open)
+mydata.wal              — active write-ahead log
+mydata-checkpoints/     — checkpoint archive directory (checkpoint_*.vchk)
+```
+
+On open, the CLI recovers from the latest checkpoint and replays WAL entries written after it; on `\save` / clean exit it writes a fresh checkpoint and truncates the WAL. Recovery restores both table schemas (DDL) and committed row data (DML inserts, updates, deletes); uncommitted transactions at crash time are discarded, and a truncated WAL tail recovers up to the last complete, checksum-valid entry.
+
+The engine lives in `crates/vibesql-storage/src/wal/` (writer, reader, checkpoint, truncate, recovery). DML WAL ops carry an inline `table_name` (WAL format version 2) so `RecoveryManager::apply_op` can route each row mutation back to its table during replay. Server-mode durability is separate (the replicated server routes writes through the Raft log + MVCC state machine).
+
 ## Release Flow
 
 Run `/loom:release` from this repo to drive a v0.X.Y cut interactively:

--- a/crates/vibesql-cli/src/config.rs
+++ b/crates/vibesql-cli/src/config.rs
@@ -41,21 +41,21 @@ pub struct DatabaseConfig {
     #[serde(default = "default_sql_mode")]
     pub sql_mode: String,
 
-    /// Opt-in Write-Ahead Log (WAL) durability for file-backed databases.
+    /// Write-Ahead Log (WAL) durability for file-backed databases.
     ///
-    /// Defaults to `false`, so the shipping default behavior (in-memory +
-    /// snapshot-on-exit) is unchanged. When set to `true` AND a database file
-    /// path is given, the CLI initializes the WAL persistence engine on open
-    /// (replaying the last checkpoint + WAL via `RecoveryManager::recover`) and
-    /// replaces snapshot-on-save with a checkpoint + WAL truncate.
+    /// Defaults to `true`. When a database file path is given, the CLI
+    /// initializes the WAL persistence engine on open (replaying the last
+    /// checkpoint + WAL via `RecoveryManager::recover`) and replaces
+    /// snapshot-on-save with a checkpoint + WAL truncate.
     ///
-    /// Phase 1 (current): DDL (table schemas) is durable across an unclean
-    /// shutdown; committed row data is durable as of the last checkpoint
-    /// (every `\save` / clean exit). DML replay of WAL entries written *after*
-    /// the last checkpoint is still a stub (see `RecoveryManager::apply_op`),
-    /// so a crash between writes and the next checkpoint may lose those rows.
-    /// Full DML crash-recovery and flipping this default to `true` is Phase 2.
-    #[serde(default)]
+    /// Both DDL (table schemas) and committed DML (row data) survive an unclean
+    /// shutdown: `RecoveryManager::apply_op` replays Insert/Update/Delete from
+    /// the WAL, routed by the inline `table_name` carried in WAL format v2 ops.
+    /// Uncommitted transactions at crash time are discarded.
+    ///
+    /// Opt out with `[database] wal = false` to fall back to the snapshot-only
+    /// path (in-memory + SQL-dump snapshot on save/exit, no WAL sibling files).
+    #[serde(default = "default_true")]
     pub wal: bool,
 }
 
@@ -114,7 +114,7 @@ impl Default for DatabaseConfig {
             default_path: None,
             auto_save: default_true(),
             sql_mode: default_sql_mode(),
-            wal: false,
+            wal: default_true(),
         }
     }
 }
@@ -186,29 +186,30 @@ mod tests {
         assert_eq!(config.database.sql_mode, "mysql");
         assert_eq!(config.history.max_entries, 10000);
         assert_eq!(config.query.timeout_seconds, 0);
-        // WAL is opt-in: default must be OFF so existing behavior is unchanged.
-        assert!(!config.database.wal);
+        // WAL is on by default (Phase 2, #5698): committed rows survive crashes.
+        assert!(config.database.wal);
     }
 
     #[test]
-    fn test_wal_defaults_off_when_unspecified() {
-        // A config that omits `wal` must parse with wal = false.
+    fn test_wal_defaults_on_when_unspecified() {
+        // A config that omits `wal` must parse with wal = true (the new default).
         let toml_str = r#"
 [database]
 auto_save = true
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
-        assert!(!config.database.wal);
+        assert!(config.database.wal);
     }
 
     #[test]
-    fn test_wal_opt_in_parses() {
+    fn test_wal_opt_out_parses() {
+        // Users can still disable WAL explicitly to get the snapshot-only path.
         let toml_str = r#"
 [database]
-wal = true
+wal = false
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
-        assert!(config.database.wal);
+        assert!(!config.database.wal);
     }
 
     #[test]

--- a/crates/vibesql-cli/src/executor/wal.rs
+++ b/crates/vibesql-cli/src/executor/wal.rs
@@ -1,10 +1,11 @@
 // ============================================================================
-// CLI WAL (Write-Ahead Log) Persistence Wiring — Phase 1
+// CLI WAL (Write-Ahead Log) Persistence Wiring
 // ============================================================================
 //
-// This module wires VibeSQL's existing WAL + crash-recovery engine
-// (`crates/vibesql-storage/src/wal/`) into the CLI behind the opt-in
-// `[database] wal = true` config flag.
+// This module wires VibeSQL's WAL + crash-recovery engine
+// (`crates/vibesql-storage/src/wal/`) into the CLI. WAL is on by default
+// (`[database] wal = true`) for file-backed databases; set `wal = false` to opt
+// out and use the snapshot-only path.
 //
 // ## File layout
 //
@@ -17,27 +18,19 @@
 // mydata-checkpoints/   — checkpoint archive directory (checkpoint_*.vchk)
 // ```
 //
-// ## Durability model (Phase 1)
+// ## Durability model
 //
 // On open (when WAL is active), `RecoveryManager::recover()` loads the latest
 // checkpoint and replays WAL entries written after it. On `\save` / clean exit,
 // the CLI writes a fresh checkpoint at the engine's current LSN and truncates
 // the WAL up to that LSN.
 //
-// IMPORTANT — KNOWN GAP (Phase 2): `RecoveryManager::apply_op` currently only
-// replays DDL (CreateTable) from the WAL; Insert/Update/Delete replay is a stub
-// (it counts ops but does not re-apply them, because the WAL stores a hashed
-// `table_id` with no `table_id -> table_name` resolution). The practical
-// consequence:
-//
-//   * Table *schemas* (DDL) survive an unclean shutdown (SIGKILL) via WAL replay.
-//   * Committed *row data* (DML) is durable only as of the last checkpoint
-//     (every `\save` / clean exit). Rows written to the WAL *after* the last
-//     checkpoint are NOT yet replayed on recovery and may be lost on a crash.
-//
-// Fixing DML replay and flipping the `wal` default to `true` is tracked as
-// Phase 2 of issue #5698. Do not advertise this as full row-level durability
-// until Phase 2 lands.
+// Both DDL and committed DML survive an unclean shutdown (SIGKILL, power loss):
+// `RecoveryManager::apply_op` replays CreateTable/DropTable *and*
+// Insert/Update/Delete, routing each row mutation by the inline `table_name`
+// carried in WAL format v2 DML ops. Uncommitted transactions at crash time are
+// discarded (their ops are buffered but never applied). A truncated WAL tail
+// (partial final write) recovers up to the last complete, checksum-valid entry.
 
 use std::path::{Path, PathBuf};
 

--- a/crates/vibesql-cli/src/main.rs
+++ b/crates/vibesql-cli/src/main.rs
@@ -50,7 +50,7 @@ CONFIGURATION:
     [database]
     default_path = \"~/data.db\"    # Default database file
     auto_save = true               # Auto-save on exit
-    wal = false                    # Opt-in Write-Ahead Log durability (default off)
+    wal = true                     # Write-Ahead Log durability (default on; set false to opt out)
 
     [history]
     file = \"~/.vibesql_history\"   # Command history file
@@ -59,20 +59,20 @@ CONFIGURATION:
     [query]
     timeout_seconds = 0            # Query timeout (0 = no limit)
 
-WRITE-AHEAD LOG (WAL) DURABILITY (opt-in):
-  Set [database] wal = true to enable WAL persistence for a file-backed
-  database. When active for 'mydata.vbsql', the CLI maintains two sibling
-  files next to the database:
+WRITE-AHEAD LOG (WAL) DURABILITY (on by default):
+  For a file-backed database the CLI keeps a Write-Ahead Log so committed
+  changes survive an unclean shutdown (crash, SIGKILL, power loss). When
+  active for 'mydata.vbsql', it maintains two sibling files next to the
+  database:
     mydata.wal              # active write-ahead log
     mydata-checkpoints/     # checkpoint archive (checkpoint_*.vchk)
   On open the CLI recovers from the latest checkpoint and replays the WAL;
   on \\save / clean exit it writes a checkpoint and truncates the WAL.
 
-  Phase 1 status: table schemas (DDL) survive an unclean shutdown, and
-  committed row data is durable as of the last checkpoint. Replay of row
-  changes (DML) written after the last checkpoint is not yet implemented,
-  so a crash between writes and the next checkpoint may lose those rows.
-  Default is wal = false, which preserves the snapshot-on-exit behavior.
+  Both table schemas (DDL) and committed row data (DML inserts, updates,
+  and deletes) are restored on recovery; uncommitted transactions at crash
+  time are discarded. Set [database] wal = false to opt out and use the
+  snapshot-only path instead (no WAL sibling files).
 
 EXAMPLES:
   # Start interactive REPL with in-memory database
@@ -248,8 +248,9 @@ fn main() -> anyhow::Result<()> {
     // Use command-line database if provided, otherwise use config default
     let database = database_arg.or(config.database.default_path.clone());
 
-    // Opt-in WAL durability ([database] wal = true). Default false leaves the
-    // existing snapshot-on-exit behavior untouched.
+    // WAL durability ([database] wal = true, the default). Committed DDL + DML
+    // survive an unclean shutdown for file-backed databases. Set wal = false to
+    // opt out and fall back to the snapshot-only path.
     let wal = config.database.wal;
 
     if let Some(cmd) = args.command {

--- a/crates/vibesql-cli/tests/persistence_test.rs
+++ b/crates/vibesql-cli/tests/persistence_test.rs
@@ -1,6 +1,16 @@
-// Integration tests for database file persistence
+// Integration tests for database file persistence (snapshot / SQL-dump path).
+//
+// These tests assert the snapshot-on-save behavior: the single `.db` file is a
+// SQL text dump whose contents can be inspected directly. WAL is on by default
+// (issue #5698), which would instead write a binary checkpoint plus `.wal` /
+// `-checkpoints/` sibling files. To keep exercising the snapshot path
+// deterministically, every subprocess here runs with a temp `$HOME/.vibesqlrc`
+// that sets `wal = false`. The WAL crash-recovery path has its own coverage in
+// `wal_recovery_test.rs`.
 
-use std::{fs, process::Command};
+use std::{fs, path::Path, process::Command};
+
+use tempfile::TempDir;
 
 /// Get the path to the vibesql binary.
 /// Uses CARGO_BIN_EXE_vibesql which is set by cargo during test compilation,
@@ -9,27 +19,50 @@ fn vibesql_binary() -> &'static str {
     env!("CARGO_BIN_EXE_vibesql")
 }
 
+/// Create a temp `$HOME` containing a `.vibesqlrc` that disables WAL, so these
+/// snapshot-path tests are unaffected by the WAL-on-by-default global default
+/// and by any sibling files left in `/tmp` from prior runs.
+fn snapshot_home() -> TempDir {
+    let home = tempfile::tempdir().expect("create temp home");
+    fs::write(home.path().join(".vibesqlrc"), "[database]\nwal = false\n")
+        .expect("write .vibesqlrc");
+    home
+}
+
+/// Run `vibesql -c <sql>` against `db` in snapshot (wal = false) mode.
+fn run_snapshot(home: &TempDir, db: &str, sql: &str) -> std::process::Output {
+    Command::new(vibesql_binary())
+        .args(["--database", db, "-c", sql])
+        .env("HOME", home.path())
+        .output()
+        .expect("Failed to execute command")
+}
+
+/// Remove a database file and any WAL sibling files that a prior (WAL-enabled)
+/// run may have left behind, so the snapshot path starts from a clean slate.
+fn clean_db(db: &str) {
+    let _ = fs::remove_file(db);
+    let p = Path::new(db);
+    let _ = fs::remove_file(p.with_extension("wal"));
+    if let (Some(parent), Some(stem)) = (p.parent(), p.file_stem()) {
+        let _ = fs::remove_dir_all(parent.join(format!("{}-checkpoints", stem.to_string_lossy())));
+    }
+}
+
 #[test]
 fn test_command_mode_persistence() {
+    let home = snapshot_home();
     let test_db = "/tmp/test_vibesql_cmd_mode.db";
 
-    // Clean up any existing test file
-    let _ = fs::remove_file(test_db);
+    // Clean up any existing test file (and WAL siblings from earlier runs)
+    clean_db(test_db);
 
     // Create a table
-    let output = Command::new(vibesql_binary())
-        .args(["--database", test_db, "-c", "CREATE TABLE test_users (id INTEGER, name TEXT)"])
-        .output()
-        .expect("Failed to execute command");
-
+    let output = run_snapshot(&home, test_db, "CREATE TABLE test_users (id INTEGER, name TEXT)");
     assert!(output.status.success(), "CREATE TABLE should succeed");
 
     // Insert data
-    let output = Command::new(vibesql_binary())
-        .args(["--database", test_db, "-c", "INSERT INTO test_users VALUES (1, 'Alice')"])
-        .output()
-        .expect("Failed to execute command");
-
+    let output = run_snapshot(&home, test_db, "INSERT INTO test_users VALUES (1, 'Alice')");
     assert!(output.status.success(), "INSERT should succeed");
 
     // Verify the file was created
@@ -44,84 +77,60 @@ fn test_command_mode_persistence() {
     assert!(content.contains("Alice"), "Database should contain inserted data");
 
     // Query the data in a new session
-    let output = Command::new(vibesql_binary())
-        .args(["--database", test_db, "-c", "SELECT * FROM test_users"])
-        .output()
-        .expect("Failed to execute command");
-
+    let output = run_snapshot(&home, test_db, "SELECT * FROM test_users");
     assert!(output.status.success(), "SELECT should succeed");
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Alice"), "Query should return inserted data");
 
     // Clean up
-    let _ = fs::remove_file(test_db);
+    clean_db(test_db);
 }
 
 #[test]
 fn test_multiple_sessions_persistence() {
+    let home = snapshot_home();
     let test_db = "/tmp/test_vibesql_multi_session.db";
 
-    // Clean up any existing test file
-    let _ = fs::remove_file(test_db);
+    // Clean up any existing test file (and WAL siblings from earlier runs)
+    clean_db(test_db);
 
     // Session 1: Create table
-    let output = Command::new(vibesql_binary())
-        .args([
-            "--database",
-            test_db,
-            "-c",
-            "CREATE TABLE products (id INTEGER, name TEXT, price REAL)",
-        ])
-        .output()
-        .expect("Failed to execute command");
-
+    let output =
+        run_snapshot(&home, test_db, "CREATE TABLE products (id INTEGER, name TEXT, price REAL)");
     assert!(output.status.success());
 
     // Session 2: Insert first row
-    let output = Command::new(vibesql_binary())
-        .args(["--database", test_db, "-c", "INSERT INTO products VALUES (1, 'Widget', 9.99)"])
-        .output()
-        .expect("Failed to execute command");
-
+    let output = run_snapshot(&home, test_db, "INSERT INTO products VALUES (1, 'Widget', 9.99)");
     assert!(output.status.success());
 
     // Session 3: Insert second row
-    let output = Command::new(vibesql_binary())
-        .args(["--database", test_db, "-c", "INSERT INTO products VALUES (2, 'Gadget', 19.99)"])
-        .output()
-        .expect("Failed to execute command");
-
+    let output = run_snapshot(&home, test_db, "INSERT INTO products VALUES (2, 'Gadget', 19.99)");
     assert!(output.status.success());
 
     // Session 4: Query all data
-    let output = Command::new(vibesql_binary())
-        .args(["--database", test_db, "-c", "SELECT * FROM products"])
-        .output()
-        .expect("Failed to execute command");
-
+    let output = run_snapshot(&home, test_db, "SELECT * FROM products");
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Widget"), "Should contain first row");
     assert!(stdout.contains("Gadget"), "Should contain second row");
 
     // Clean up
-    let _ = fs::remove_file(test_db);
+    clean_db(test_db);
 }
 
 #[test]
 fn test_binary_file_error_message() {
     // Create a fake binary database file (simulating SQLite with non-UTF8 bytes)
+    let home = snapshot_home();
     let test_db = "/tmp/test_vibesql_binary.db";
+    clean_db(test_db);
     let mut binary_data = b"SQLite format 3\0".to_vec();
     // Add some non-UTF8 bytes
     binary_data.extend_from_slice(&[0xFF, 0xFE, 0xFD, 0xFC, 0x00, 0x01, 0x02]);
     fs::write(test_db, binary_data).expect("Failed to create test file");
 
     // Try to open it with vibesql
-    let output = Command::new(vibesql_binary())
-        .args(["--database", test_db, "-c", "SELECT 1"])
-        .output()
-        .expect("Failed to execute command");
+    let output = run_snapshot(&home, test_db, "SELECT 1");
 
     assert!(!output.status.success(), "Should fail for binary file");
 
@@ -133,22 +142,19 @@ fn test_binary_file_error_message() {
     );
 
     // Clean up
-    let _ = fs::remove_file(test_db);
+    clean_db(test_db);
 }
 
 #[test]
 fn test_new_database_file_creation() {
+    let home = snapshot_home();
     let test_db = "/tmp/test_vibesql_new_file.db";
 
-    // Clean up any existing test file
-    let _ = fs::remove_file(test_db);
+    // Clean up any existing test file (and WAL siblings from earlier runs)
+    clean_db(test_db);
 
     // Create database with a non-existent file path
-    let output = Command::new(vibesql_binary())
-        .args(["--database", test_db, "-c", "CREATE TABLE new_table (id INTEGER)"])
-        .output()
-        .expect("Failed to execute command");
-
+    let output = run_snapshot(&home, test_db, "CREATE TABLE new_table (id INTEGER)");
     assert!(output.status.success(), "Should succeed creating new database file");
 
     // Verify the file was created
@@ -162,7 +168,7 @@ fn test_new_database_file_creation() {
     );
 
     // Clean up
-    let _ = fs::remove_file(test_db);
+    clean_db(test_db);
 }
 
 #[test]
@@ -170,23 +176,18 @@ fn test_untyped_column_persistence() {
     // Regression test for issue #4324: Untyped columns persist as BLOB, breaking reloads
     // When a table with untyped columns is persisted and reloaded, it should still
     // accept any value type (SQLite type affinity behavior).
+    let home = snapshot_home();
     let test_db = "/tmp/test_vibesql_untyped_column.db";
 
-    // Clean up any existing test file
-    let _ = fs::remove_file(test_db);
+    // Clean up any existing test file (and WAL siblings from earlier runs)
+    clean_db(test_db);
 
     // Session 1: Create table with untyped column
-    let output = Command::new(vibesql_binary())
-        .args(["--database", test_db, "-c", "CREATE TABLE t(a)"])
-        .output()
-        .expect("Failed to execute command");
+    let output = run_snapshot(&home, test_db, "CREATE TABLE t(a)");
     assert!(output.status.success(), "CREATE TABLE should succeed");
 
     // Session 2: Insert integer value (this was failing before the fix)
-    let output = Command::new(vibesql_binary())
-        .args(["--database", test_db, "-c", "INSERT INTO t VALUES(1)"])
-        .output()
-        .expect("Failed to execute command");
+    let output = run_snapshot(&home, test_db, "INSERT INTO t VALUES(1)");
     assert!(
         output.status.success(),
         "INSERT integer should succeed after reload. stderr: {}",
@@ -194,24 +195,15 @@ fn test_untyped_column_persistence() {
     );
 
     // Session 3: Insert string value
-    let output = Command::new(vibesql_binary())
-        .args(["--database", test_db, "-c", "INSERT INTO t VALUES('hello')"])
-        .output()
-        .expect("Failed to execute command");
+    let output = run_snapshot(&home, test_db, "INSERT INTO t VALUES('hello')");
     assert!(output.status.success(), "INSERT string should succeed after reload");
 
     // Session 4: Insert float value
-    let output = Command::new(vibesql_binary())
-        .args(["--database", test_db, "-c", "INSERT INTO t VALUES(3.14)"])
-        .output()
-        .expect("Failed to execute command");
+    let output = run_snapshot(&home, test_db, "INSERT INTO t VALUES(3.14)");
     assert!(output.status.success(), "INSERT float should succeed after reload");
 
     // Session 5: Query all data to verify persistence
-    let output = Command::new(vibesql_binary())
-        .args(["--database", test_db, "-c", "SELECT * FROM t"])
-        .output()
-        .expect("Failed to execute command");
+    let output = run_snapshot(&home, test_db, "SELECT * FROM t");
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("1"), "Should contain integer value");
@@ -219,5 +211,5 @@ fn test_untyped_column_persistence() {
     assert!(stdout.contains("3.14"), "Should contain float value");
 
     // Clean up
-    let _ = fs::remove_file(test_db);
+    clean_db(test_db);
 }

--- a/crates/vibesql-cli/tests/wal_recovery_test.rs
+++ b/crates/vibesql-cli/tests/wal_recovery_test.rs
@@ -1,20 +1,21 @@
 // ============================================================================
-// WAL Recovery Integration Tests — Phase 1 of issue #5698
+// WAL Recovery Integration Tests — issue #5698
 // ============================================================================
 //
-// Phase 1 wires VibeSQL's WAL + crash-recovery engine into the CLI behind the
-// opt-in `[database] wal = true` config flag. These tests assert what Phase 1
-// actually delivers:
+// Phase 1 wired VibeSQL's WAL + crash-recovery engine into the CLI behind the
+// `[database] wal = true` config flag. Phase 2 (this file's current state) makes
+// committed *row data* (DML) durable across an unclean shutdown by replaying
+// Insert/Update/Delete from the WAL, and flips `wal` on by default.
 //
-//   * DDL (table schemas) survives an unclean shutdown and is recovered by
-//     replaying the WAL (no checkpoint required).
-//   * DML (row data) replay from the WAL is a KNOWN GAP (Phase 2): rows written
-//     to the WAL after the last checkpoint are NOT yet replayed on recovery.
-//     `test_dml_replay_is_a_known_gap_phase2` documents this explicitly so a
-//     future Phase 2 change will flip it (and can be promoted to the full
-//     crash-recovery assertion).
-//   * End-to-end: a real `vibesql` subprocess with `wal = true` survives a
-//     SIGKILL with its table schema intact on reopen.
+// These tests assert:
+//
+//   * DDL (table schemas) survives an unclean shutdown via WAL replay.
+//   * DML (row data) survives an unclean shutdown via WAL replay — both inserts
+//     and the post-recovery state of updates/deletes.
+//   * Uncommitted rows (BEGIN ... INSERT, no COMMIT before the crash) are NOT
+//     replayed.
+//   * End-to-end: a real `vibesql` subprocess survives a SIGKILL with both its
+//     table schema and its committed rows intact on reopen.
 
 use std::{
     fs,
@@ -98,53 +99,98 @@ fn test_ddl_survives_crash_via_wal_replay() {
     assert!(stats.tables_created >= 1, "recovery stats should record the replayed CreateTable");
 }
 
-/// DML replay from the WAL is a KNOWN GAP in Phase 1.
+/// DML (row data) survives a crash via WAL replay (Phase 2, #5698).
 ///
-/// `RecoveryManager::apply_op` currently only replays DDL; Insert/Update/Delete
-/// are stubbed (counted but not applied), because the WAL stores a hashed
-/// `table_id` with no `table_id -> table_name` resolution. This test pins that
-/// behavior: after a crash, the table schema is recovered but the inserted row
-/// is NOT. Phase 2 (#5698) will make DML durable and should flip this test into
-/// the full crash-recovery assertion.
+/// `RecoveryManager::apply_op` now applies Insert/Update/Delete during replay,
+/// routed by the inline `table_name` carried in WAL format v2 DML ops. We emit a
+/// CreateTable + a couple of Inserts to the WAL, flush, then "crash" with no
+/// checkpoint. Recovery must restore both the schema AND the rows.
 #[test]
-fn test_dml_replay_is_a_known_gap_phase2() {
+fn test_dml_survives_crash_via_wal_replay() {
     let dir = tempfile::tempdir().unwrap();
-    let db_path = dir.path().join("dml_gap.vbsql");
+    let db_path = dir.path().join("dml_replay.vbsql");
     let (wal_path, checkpoint_dir) = wal_paths(&db_path);
 
-    // --- Session 1: create a table and insert a row, flush, then "crash".
+    // --- Session 1: create a table and insert rows, flush, then "crash".
     {
         let mut db = Database::new();
         let engine = PersistenceEngine::new(&wal_path, PersistenceConfig::default()).unwrap();
         db.enable_persistence(engine);
 
-        db.create_table(simple_schema("gappy")).unwrap();
-        db.insert_row("gappy", Row::from_vec(vec![SqlValue::Integer(1)])).unwrap();
+        db.create_table(simple_schema("rows_survive")).unwrap();
+        db.insert_row("rows_survive", Row::from_vec(vec![SqlValue::Integer(1)])).unwrap();
+        db.insert_row("rows_survive", Row::from_vec(vec![SqlValue::Integer(2)])).unwrap();
 
         db.sync_persistence().unwrap();
     }
 
+    // No checkpoint was written: recovery relies on WAL replay alone.
+    assert!(
+        !checkpoint_dir.exists() || fs::read_dir(&checkpoint_dir).unwrap().next().is_none(),
+        "no checkpoint should exist; DML must be recovered from the WAL"
+    );
+
     // --- Session 2: recover from the WAL.
     let manager = RecoveryManager::new(&checkpoint_dir).with_wal(&wal_path);
-    let (recovered, _stats) = manager.recover().unwrap();
+    let (recovered, stats) = manager.recover().unwrap();
 
-    // DDL recovered:
     let table_name = recovered
         .list_tables()
         .into_iter()
-        .find(|t| t.to_lowercase().contains("gappy"))
+        .find(|t| t.to_lowercase().contains("rows_survive"))
         .expect("table schema should be recovered via WAL replay");
 
-    // DML NOT recovered (Phase 1 stub). If this assertion ever fails, Phase 2
-    // landed: promote this test to assert the row IS present and remove the
-    // "known gap" framing.
-    let row_count = recovered.get_table(&table_name).map(|t| t.row_count()).unwrap_or(0);
-    assert_eq!(
-        row_count, 0,
-        "PHASE 1 KNOWN GAP: WAL DML replay is stubbed, so the inserted row must \
-         NOT be recovered yet. If this fails, Phase 2 (#5698) is done — update \
-         this test to assert the row survives."
-    );
+    assert_eq!(stats.inserts_applied, 2, "both inserts should be replayed");
+
+    let table = recovered.get_table(&table_name).expect("table exists after recovery");
+    let rows: Vec<_> = table.scan_live().map(|(_, r)| r.clone()).collect();
+    assert_eq!(rows.len(), 2, "both committed rows must survive a crash via WAL replay");
+    assert_eq!(rows[0].values[0], SqlValue::Integer(1));
+    assert_eq!(rows[1].values[0], SqlValue::Integer(2));
+}
+
+/// Uncommitted rows (an open transaction at crash time) are NOT replayed.
+///
+/// A `TxnBegin` followed by an insert, with no `TxnCommit` before the crash,
+/// leaves the insert buffered in the recovery `TransactionTracker` and it must
+/// be discarded.
+#[test]
+fn test_uncommitted_dml_not_replayed() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("uncommitted.vbsql");
+    let (wal_path, checkpoint_dir) = wal_paths(&db_path);
+
+    // --- Session 1: one committed (auto-commit) insert, then an OPEN
+    // transaction with an insert that never commits before the "crash".
+    {
+        let mut db = Database::new();
+        let engine = PersistenceEngine::new(&wal_path, PersistenceConfig::default()).unwrap();
+        db.enable_persistence(engine);
+
+        db.create_table(simple_schema("txn")).unwrap();
+        db.insert_row("txn", Row::from_vec(vec![SqlValue::Integer(1)])).unwrap();
+
+        db.begin_transaction().unwrap();
+        db.insert_row("txn", Row::from_vec(vec![SqlValue::Integer(2)])).unwrap();
+        // No commit_transaction(): simulate a crash mid-transaction.
+
+        db.sync_persistence().unwrap();
+    }
+
+    // --- Session 2: recover and assert only the committed row is present.
+    let manager = RecoveryManager::new(&checkpoint_dir).with_wal(&wal_path);
+    let (recovered, _stats) = manager.recover().unwrap();
+
+    let table_name = recovered
+        .list_tables()
+        .into_iter()
+        .find(|t| t.to_lowercase().contains("txn"))
+        .expect("table schema should be recovered");
+
+    let table = recovered.get_table(&table_name).unwrap();
+    let rows: Vec<_> = table.scan_live().map(|(_, r)| r.clone()).collect();
+    assert_eq!(rows.len(), 1, "only the committed row may survive; uncommitted row discarded");
+    assert_eq!(rows[0].values[0], SqlValue::Integer(1));
 }
 
 // ----------------------------------------------------------------------------
@@ -192,17 +238,30 @@ fn test_subprocess_ddl_survives_sigkill_with_wal() {
         stdin.flush().unwrap();
     }
 
-    // Wait until the WAL-active save path has written the checkpoint + WAL
-    // sibling files to disk, then hard-kill the process. Polling (rather than a
-    // fixed sleep) makes the test robust to scheduling jitter under a loaded
-    // test runner.
+    // Wait until the WAL-active save path has actually checkpointed the DDL,
+    // then hard-kill the process. We poll for a checkpoint *file* (not just the
+    // checkpoint directory, which `WalState::open` creates eagerly before any
+    // statement runs) and add a short settle so the write is fully flushed
+    // before SIGKILL. Polling (rather than a fixed sleep) makes the test robust
+    // to scheduling jitter under a loaded, parallel test runner.
     let (wal_path, checkpoint_dir) = wal_paths(&db_path);
+    let has_checkpoint_file = |dir: &Path| {
+        fs::read_dir(dir)
+            .map(|rd| {
+                rd.filter_map(Result::ok).any(|e| e.path().extension().is_some_and(|x| x == "vchk"))
+            })
+            .unwrap_or(false)
+    };
     let mut waited = Duration::ZERO;
     let step = Duration::from_millis(50);
-    while !(wal_path.exists() || checkpoint_dir.exists()) && waited < Duration::from_secs(10) {
+    while !(checkpoint_dir.exists() && has_checkpoint_file(&checkpoint_dir))
+        && waited < Duration::from_secs(10)
+    {
         thread::sleep(step);
         waited += step;
     }
+    // Settle: ensure the checkpoint write + WAL truncate finished on disk.
+    thread::sleep(Duration::from_millis(200));
 
     // Hard kill — SIGKILL, no graceful shutdown / exit-time save.
     let _ = child.kill();
@@ -231,4 +290,76 @@ fn test_subprocess_ddl_survives_sigkill_with_wal() {
         combined.to_uppercase().contains("KILL_SURVIVOR"),
         "table schema must survive SIGKILL with wal = true; got output:\n{combined}"
     );
+}
+
+/// End-to-end Phase 2 crash recovery: a real `vibesql` subprocess writes
+/// committed rows, gets SIGKILLed, and on reopen the rows are still present.
+///
+/// This is the primary Phase 2 acceptance gate: committed *row data* — not just
+/// schema — survives an unclean shutdown. WAL is on by default now, so we do not
+/// even need a `~/.vibesqlrc`; we just point at a `.vbsql` file.
+#[cfg(unix)]
+#[test]
+fn test_subprocess_committed_rows_survive_sigkill() {
+    use std::{io::Write, thread, time::Duration};
+
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("rows_crash.vbsql");
+    let db_str = db_path.to_string_lossy().to_string();
+    let (wal_path, checkpoint_dir) = wal_paths(&db_path);
+
+    // --- Session 1: create a table and insert rows over stdin (each auto-commit
+    // modification statement drives the WAL-active save path), then SIGKILL.
+    let mut child: Child = Command::new(vibesql_binary())
+        .arg("--database")
+        .arg(&db_str)
+        .env("HOME", home.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn vibesql");
+
+    {
+        let mut stdin = child.stdin.take().expect("child stdin");
+        writeln!(stdin, "CREATE TABLE survivors (id INTEGER, label VARCHAR(50));").unwrap();
+        writeln!(stdin, "INSERT INTO survivors VALUES (1, 'alpha');").unwrap();
+        writeln!(stdin, "INSERT INTO survivors VALUES (2, 'beta');").unwrap();
+        writeln!(stdin, "INSERT INTO survivors VALUES (3, 'gamma');").unwrap();
+        stdin.flush().unwrap();
+        // Drop stdin (EOF) so script mode processes the statements and runs the
+        // per-statement WAL-active save for each.
+    }
+
+    // Wait until the WAL-active save path has produced sibling files on disk.
+    let mut waited = Duration::ZERO;
+    let step = Duration::from_millis(50);
+    while !(wal_path.exists() || checkpoint_dir.exists()) && waited < Duration::from_secs(10) {
+        thread::sleep(step);
+        waited += step;
+    }
+    // Give the script a moment to finish applying all three inserts.
+    thread::sleep(Duration::from_millis(300));
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    // --- Session 2: reopen and confirm all three committed rows are present.
+    let output = Command::new(vibesql_binary())
+        .arg("--database")
+        .arg(&db_str)
+        .arg("-c")
+        .arg("SELECT id, label FROM survivors ORDER BY id")
+        .env("HOME", home.path())
+        .output()
+        .expect("failed to reopen vibesql");
+
+    let combined = String::from_utf8_lossy(&output.stdout).to_string();
+    for label in ["alpha", "beta", "gamma"] {
+        assert!(
+            combined.contains(label),
+            "committed row '{label}' must survive SIGKILL with wal on by default; \
+             got output:\n{combined}"
+        );
+    }
 }

--- a/crates/vibesql-storage/src/database/persistence_api.rs
+++ b/crates/vibesql-storage/src/database/persistence_api.rs
@@ -106,6 +106,7 @@ impl Database {
     ) {
         self.emit_wal_op(WalOp::Delete {
             table_id: self.table_name_to_id(table_name),
+            table_name: table_name.to_string(),
             row_id,
             old_values,
         });

--- a/crates/vibesql-storage/src/database/table_api.rs
+++ b/crates/vibesql-storage/src/database/table_api.rs
@@ -384,6 +384,7 @@ impl Database {
         if !self.is_temp_table(table_name) {
             self.emit_wal_op(WalOp::Insert {
                 table_id: self.table_name_to_id(table_name),
+                table_name: table_name.to_string(),
                 row_id: row_index as u64,
                 values: row.values.to_vec(),
             });
@@ -488,6 +489,7 @@ impl Database {
             if !is_temp {
                 self.emit_wal_op(WalOp::Insert {
                     table_id,
+                    table_name: table_name.to_string(),
                     row_id: row_index as u64,
                     values: row.values.to_vec(),
                 });
@@ -686,6 +688,7 @@ impl Database {
         if !self.is_temp_table(&resolved_name) {
             self.emit_wal_op(WalOp::Update {
                 table_id: self.table_name_to_id(&resolved_name),
+                table_name: resolved_name.clone(),
                 row_id: row_index as u64,
                 old_values: old_row.values.to_vec(),
                 new_values: new_row.values.to_vec(),

--- a/crates/vibesql-storage/src/wal/engine.rs
+++ b/crates/vibesql-storage/src/wal/engine.rs
@@ -945,7 +945,12 @@ mod tests {
         let engine = PersistenceEngine::with_writer(cursor, PersistenceConfig::default()).unwrap();
 
         let lsn = engine
-            .send(WalOp::Insert { table_id: 1, row_id: 100, values: vec![SqlValue::Integer(42)] })
+            .send(WalOp::Insert {
+                table_id: 1,
+                table_name: "main.t".to_string(),
+                row_id: 100,
+                values: vec![SqlValue::Integer(42)],
+            })
             .unwrap();
 
         assert_eq!(lsn, 1);
@@ -966,6 +971,7 @@ mod tests {
             let lsn = engine
                 .send(WalOp::Insert {
                     table_id: 1,
+                    table_name: "main.t".to_string(),
                     row_id: i as u64,
                     values: vec![SqlValue::Integer(i)],
                 })
@@ -990,6 +996,7 @@ mod tests {
             engine
                 .send(WalOp::Insert {
                     table_id: 1,
+                    table_name: "main.t".to_string(),
                     row_id: i as u64,
                     values: vec![SqlValue::Integer(i)],
                 })
@@ -1019,6 +1026,7 @@ mod tests {
             engine
                 .send(WalOp::Insert {
                     table_id: 1,
+                    table_name: "main.t".to_string(),
                     row_id: i as u64,
                     values: vec![SqlValue::Integer(i)],
                 })
@@ -1047,7 +1055,12 @@ mod tests {
         let engine = PersistenceEngine::with_writer(cursor, PersistenceConfig::default()).unwrap();
 
         engine
-            .send(WalOp::Insert { table_id: 1, row_id: 1, values: vec![SqlValue::Integer(1)] })
+            .send(WalOp::Insert {
+                table_id: 1,
+                table_name: "main.t".to_string(),
+                row_id: 1,
+                values: vec![SqlValue::Integer(1)],
+            })
             .unwrap();
 
         // Flush should return immediately
@@ -1064,7 +1077,12 @@ mod tests {
             PersistenceEngine::with_writer(cursor, PersistenceConfig::default()).unwrap();
 
         engine
-            .send(WalOp::Insert { table_id: 1, row_id: 1, values: vec![SqlValue::Integer(1)] })
+            .send(WalOp::Insert {
+                table_id: 1,
+                table_name: "main.t".to_string(),
+                row_id: 1,
+                values: vec![SqlValue::Integer(1)],
+            })
             .unwrap();
 
         // Should complete within timeout
@@ -1089,6 +1107,7 @@ mod tests {
             engine
                 .send(WalOp::Insert {
                     table_id: 1,
+                    table_name: "main.t".to_string(),
                     row_id: i as u64,
                     values: vec![SqlValue::Integer(i)],
                 })
@@ -1118,6 +1137,7 @@ mod tests {
             engine
                 .send(WalOp::Insert {
                     table_id: 1,
+                    table_name: "main.t".to_string(),
                     row_id: i as u64,
                     values: vec![SqlValue::Integer(i)],
                 })
@@ -1160,6 +1180,7 @@ mod tests {
             engine
                 .send(WalOp::Insert {
                     table_id: 1,
+                    table_name: "main.t".to_string(),
                     row_id: i as u64,
                     values: vec![SqlValue::Integer(i)],
                 })
@@ -1204,6 +1225,7 @@ mod tests {
             let lsn = engine
                 .send(WalOp::Insert {
                     table_id: 1,
+                    table_name: "main.t".to_string(),
                     row_id: i as u64,
                     values: vec![SqlValue::Integer(i)],
                 })
@@ -1238,6 +1260,7 @@ mod tests {
             engine
                 .send(WalOp::Insert {
                     table_id: 1,
+                    table_name: "main.t".to_string(),
                     row_id: i as u64,
                     values: vec![SqlValue::Integer(i)],
                 })

--- a/crates/vibesql-storage/src/wal/entry.rs
+++ b/crates/vibesql-storage/src/wal/entry.rs
@@ -35,12 +35,25 @@ pub struct WalEntry {
 #[derive(Debug, Clone, PartialEq)]
 pub enum WalOp {
     // DML Operations
+    //
+    // As of WAL format version 2, DML ops carry the fully-qualified
+    // `table_name` so recovery can route the mutation back to the correct
+    // table during replay. The numeric `table_id` is a hash of the name and is
+    // retained for diagnostics/compat, but it is NOT sufficient to resolve a
+    // table during recovery: it lives in a different id space than the
+    // monotonic `table_id` stored in `CreateTable`.
     /// Insert a row into a table
-    Insert { table_id: u32, row_id: u64, values: Vec<SqlValue> },
+    Insert { table_id: u32, table_name: String, row_id: u64, values: Vec<SqlValue> },
     /// Update a row in a table
-    Update { table_id: u32, row_id: u64, old_values: Vec<SqlValue>, new_values: Vec<SqlValue> },
+    Update {
+        table_id: u32,
+        table_name: String,
+        row_id: u64,
+        old_values: Vec<SqlValue>,
+        new_values: Vec<SqlValue>,
+    },
     /// Delete a row from a table
-    Delete { table_id: u32, row_id: u64, old_values: Vec<SqlValue> },
+    Delete { table_id: u32, table_name: String, row_id: u64, old_values: Vec<SqlValue> },
 
     // DDL Operations
     /// Create a new table
@@ -130,11 +143,23 @@ impl WalEntry {
         Ok(())
     }
 
-    /// Deserialize an entry from bytes
+    /// Deserialize an entry from bytes (current WAL format version).
     pub fn deserialize<R: Read>(reader: &mut R) -> Result<Self, StorageError> {
+        Self::deserialize_versioned(reader, crate::wal::format::WAL_VERSION)
+    }
+
+    /// Deserialize an entry from bytes for a specific WAL format `version`.
+    ///
+    /// DML ops gained an inline `table_name` in version 2; pass the version
+    /// read from the WAL header so older logs (version 1) are parsed with the
+    /// legacy layout.
+    pub fn deserialize_versioned<R: Read>(
+        reader: &mut R,
+        version: u32,
+    ) -> Result<Self, StorageError> {
         let lsn = read_u64(reader)?;
         let timestamp_ms = read_u64(reader)?;
-        let op = WalOp::deserialize(reader)?;
+        let op = WalOp::deserialize_versioned(reader, version)?;
         Ok(Self { lsn, timestamp_ms, op })
     }
 }
@@ -143,28 +168,31 @@ impl WalOp {
     /// Serialize the operation to bytes
     pub fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), StorageError> {
         match self {
-            WalOp::Insert { table_id, row_id, values } => {
+            WalOp::Insert { table_id, table_name, row_id, values } => {
                 writer
                     .write_all(&[WalOpTag::Insert as u8])
                     .map_err(|e| StorageError::IoError(e.to_string()))?;
                 write_u32(writer, *table_id)?;
+                write_string(writer, table_name)?;
                 write_u64(writer, *row_id)?;
                 write_sql_values(writer, values)?;
             }
-            WalOp::Update { table_id, row_id, old_values, new_values } => {
+            WalOp::Update { table_id, table_name, row_id, old_values, new_values } => {
                 writer
                     .write_all(&[WalOpTag::Update as u8])
                     .map_err(|e| StorageError::IoError(e.to_string()))?;
                 write_u32(writer, *table_id)?;
+                write_string(writer, table_name)?;
                 write_u64(writer, *row_id)?;
                 write_sql_values(writer, old_values)?;
                 write_sql_values(writer, new_values)?;
             }
-            WalOp::Delete { table_id, row_id, old_values } => {
+            WalOp::Delete { table_id, table_name, row_id, old_values } => {
                 writer
                     .write_all(&[WalOpTag::Delete as u8])
                     .map_err(|e| StorageError::IoError(e.to_string()))?;
                 write_u32(writer, *table_id)?;
+                write_string(writer, table_name)?;
                 write_u64(writer, *row_id)?;
                 write_sql_values(writer, old_values)?;
             }
@@ -238,31 +266,53 @@ impl WalOp {
         Ok(())
     }
 
-    /// Deserialize an operation from bytes
+    /// Deserialize an operation from bytes (current WAL format version).
     pub fn deserialize<R: Read>(reader: &mut R) -> Result<Self, StorageError> {
+        Self::deserialize_versioned(reader, crate::wal::format::WAL_VERSION)
+    }
+
+    /// Deserialize an operation from bytes for a specific WAL format `version`.
+    ///
+    /// Version 2 added an inline `table_name` to the Insert/Update/Delete DML
+    /// ops. For version 1 logs the field is absent on disk, so we synthesize an
+    /// empty name (recovery treats an empty DML table name as unroutable and
+    /// skips it — version-1 DML replay was never functional anyway).
+    pub fn deserialize_versioned<R: Read>(
+        reader: &mut R,
+        version: u32,
+    ) -> Result<Self, StorageError> {
         let mut tag_buf = [0u8; 1];
         reader.read_exact(&mut tag_buf).map_err(|e| StorageError::IoError(e.to_string()))?;
         let tag = WalOpTag::from_u8(tag_buf[0])?;
 
+        // DML ops carry an inline table_name starting at WAL format version 2.
+        let dml_has_table_name = version >= 2;
+
         match tag {
             WalOpTag::Insert => {
                 let table_id = read_u32(reader)?;
+                let table_name =
+                    if dml_has_table_name { read_string(reader)? } else { String::new() };
                 let row_id = read_u64(reader)?;
                 let values = read_sql_values(reader)?;
-                Ok(WalOp::Insert { table_id, row_id, values })
+                Ok(WalOp::Insert { table_id, table_name, row_id, values })
             }
             WalOpTag::Update => {
                 let table_id = read_u32(reader)?;
+                let table_name =
+                    if dml_has_table_name { read_string(reader)? } else { String::new() };
                 let row_id = read_u64(reader)?;
                 let old_values = read_sql_values(reader)?;
                 let new_values = read_sql_values(reader)?;
-                Ok(WalOp::Update { table_id, row_id, old_values, new_values })
+                Ok(WalOp::Update { table_id, table_name, row_id, old_values, new_values })
             }
             WalOpTag::Delete => {
                 let table_id = read_u32(reader)?;
+                let table_name =
+                    if dml_has_table_name { read_string(reader)? } else { String::new() };
                 let row_id = read_u64(reader)?;
                 let old_values = read_sql_values(reader)?;
-                Ok(WalOp::Delete { table_id, row_id, old_values })
+                Ok(WalOp::Delete { table_id, table_name, row_id, old_values })
             }
             WalOpTag::CreateTable => {
                 let table_id = read_u32(reader)?;
@@ -372,6 +422,7 @@ mod tests {
             1234567890,
             WalOp::Insert {
                 table_id: 42,
+                table_name: "main.users".to_string(),
                 row_id: 100,
                 values: vec![
                     SqlValue::Integer(1),
@@ -397,6 +448,7 @@ mod tests {
             1234567891,
             WalOp::Update {
                 table_id: 42,
+                table_name: "main.users".to_string(),
                 row_id: 100,
                 old_values: vec![
                     SqlValue::Integer(1),
@@ -425,6 +477,7 @@ mod tests {
             1234567892,
             WalOp::Delete {
                 table_id: 42,
+                table_name: "main.users".to_string(),
                 row_id: 100,
                 old_values: vec![SqlValue::Integer(1), SqlValue::Null],
             },

--- a/crates/vibesql-storage/src/wal/format.rs
+++ b/crates/vibesql-storage/src/wal/format.rs
@@ -29,8 +29,15 @@ use crate::{
 /// Magic number for WAL files: "VWAL"
 pub const WAL_MAGIC: &[u8; 4] = b"VWAL";
 
-/// Current WAL format version
-pub const WAL_VERSION: u32 = 1;
+/// Current WAL format version.
+///
+/// - v1: original format; DML ops (`Insert`/`Update`/`Delete`) carried only a
+///   numeric `table_id`, so row data could not be routed to a table during
+///   crash recovery (DML replay was a no-op).
+/// - v2: DML ops carry an inline `table_name`, enabling correct DML replay.
+///   Older v1 logs are still readable (the table name is parsed as absent and
+///   such DML entries are skipped during replay).
+pub const WAL_VERSION: u32 = 2;
 
 /// Size of the WAL header in bytes
 pub const WAL_HEADER_SIZE: usize = 32;

--- a/crates/vibesql-storage/src/wal/reader.rs
+++ b/crates/vibesql-storage/src/wal/reader.rs
@@ -85,9 +85,10 @@ impl<R: Read + Seek> WalReader<R> {
             return Ok(ReadResult::Corruption { position: self.position });
         }
 
-        // Deserialize entry
+        // Deserialize entry using the WAL file's format version (DML ops gained
+        // an inline table_name in version 2; older logs lack it on disk).
         let mut data_reader = &data[..];
-        let entry = WalEntry::deserialize(&mut data_reader)?;
+        let entry = WalEntry::deserialize_versioned(&mut data_reader, self.header.version)?;
 
         // Update state
         self.position += 4 + 4 + len as u64; // len + crc + data
@@ -234,7 +235,12 @@ mod tests {
             let entry = WalEntry::new(
                 i,
                 1234567890 + i,
-                WalOp::Insert { table_id: 1, row_id: i, values: vec![SqlValue::Integer(i as i64)] },
+                WalOp::Insert {
+                    table_id: 1,
+                    table_name: "main.t".to_string(),
+                    row_id: i,
+                    values: vec![SqlValue::Integer(i as i64)],
+                },
             );
             writer.append(&entry).unwrap();
         }

--- a/crates/vibesql-storage/src/wal/recovery.rs
+++ b/crates/vibesql-storage/src/wal/recovery.rs
@@ -433,29 +433,92 @@ impl RecoveryManager {
         stats: &mut RecoveryStats,
     ) -> Result<(), StorageError> {
         match op {
-            WalOp::Insert { table_id: _, row_id: _, values } => {
-                // For recovery, we need to determine the table name from the table_id
-                // This is a simplified approach - in practice we'd maintain a table_id -> name
-                // mapping For now, we'll use a different approach: replay through
-                // the existing database APIs Since the table should already exist
-                // (created during checkpoint or earlier WAL replay)
-
-                // Note: This is a simplified implementation. A full implementation would:
-                // 1. Maintain a table_id -> table_name mapping during recovery
-                // 2. Or store table_name in the WAL entry itself
-
-                // For the demo, we'll skip the actual insert since we don't have the table name
-                // A real implementation would need to resolve table_id to table_name
-                stats.inserts_applied += 1;
-                log::trace!("Applied insert: {:?}", values);
+            WalOp::Insert { table_id: _, table_name, row_id, values } => {
+                // WAL format v2+ carries the fully-qualified table_name so the
+                // mutation can be routed to the correct table during replay.
+                // (v1 logs serialize an empty name; such DML is unroutable and
+                // is skipped — v1 DML replay was never functional.)
+                if table_name.is_empty() {
+                    log::warn!(
+                        "Skipping Insert during recovery: WAL entry has no table_name \
+                         (legacy v1 format, row_id={})",
+                        row_id
+                    );
+                    return Ok(());
+                }
+                match db.get_table_mut(&table_name) {
+                    Some(table) => {
+                        let row = crate::row::Row::new(values);
+                        match table.insert(row) {
+                            Ok(()) => stats.inserts_applied += 1,
+                            Err(e) => log::warn!(
+                                "Failed to apply Insert to {} during recovery: {}",
+                                table_name,
+                                e
+                            ),
+                        }
+                    }
+                    None => log::warn!(
+                        "Skipping Insert during recovery: table {} not found",
+                        table_name
+                    ),
+                }
             }
-            WalOp::Update { table_id: _, row_id: _, old_values: _, new_values } => {
-                stats.updates_applied += 1;
-                log::trace!("Applied update: {:?}", new_values);
+            WalOp::Update { table_id: _, table_name, row_id, old_values: _, new_values } => {
+                if table_name.is_empty() {
+                    log::warn!(
+                        "Skipping Update during recovery: WAL entry has no table_name \
+                         (legacy v1 format, row_id={})",
+                        row_id
+                    );
+                    return Ok(());
+                }
+                match db.get_table_mut(&table_name) {
+                    Some(table) => {
+                        let row = crate::row::Row::new(new_values);
+                        match table.update_row(row_id as usize, row) {
+                            Ok(()) => stats.updates_applied += 1,
+                            Err(e) => log::warn!(
+                                "Failed to apply Update to {} (row {}) during recovery: {}",
+                                table_name,
+                                row_id,
+                                e
+                            ),
+                        }
+                    }
+                    None => log::warn!(
+                        "Skipping Update during recovery: table {} not found",
+                        table_name
+                    ),
+                }
             }
-            WalOp::Delete { table_id: _, row_id: _, old_values: _ } => {
-                stats.deletes_applied += 1;
-                log::trace!("Applied delete");
+            WalOp::Delete { table_id: _, table_name, row_id, old_values: _ } => {
+                if table_name.is_empty() {
+                    log::warn!(
+                        "Skipping Delete during recovery: WAL entry has no table_name \
+                         (legacy v1 format, row_id={})",
+                        row_id
+                    );
+                    return Ok(());
+                }
+                match db.get_table_mut(&table_name) {
+                    Some(table) => {
+                        if table.mark_deleted_inplace(row_id as usize) {
+                            stats.deletes_applied += 1;
+                        } else {
+                            log::warn!(
+                                "Delete during recovery did not mark a row in {} (row {} \
+                                 missing or already deleted)",
+                                table_name,
+                                row_id
+                            );
+                        }
+                    }
+                    None => log::warn!(
+                        "Skipping Delete during recovery: table {} not found",
+                        table_name
+                    ),
+                }
             }
             WalOp::CreateTable { table_id: _, table_name, schema_data } => {
                 // Deserialize schema and create table
@@ -853,7 +916,12 @@ mod tests {
         tracker.buffer_op(
             1,
             10,
-            WalOp::Insert { table_id: 1, row_id: 0, values: vec![SqlValue::Integer(42)] },
+            WalOp::Insert {
+                table_id: 1,
+                table_name: "main.t".to_string(),
+                row_id: 0,
+                values: vec![SqlValue::Integer(42)],
+            },
         );
 
         // Commit
@@ -870,7 +938,12 @@ mod tests {
         tracker.buffer_op(
             1,
             10,
-            WalOp::Insert { table_id: 1, row_id: 0, values: vec![SqlValue::Integer(42)] },
+            WalOp::Insert {
+                table_id: 1,
+                table_name: "main.t".to_string(),
+                row_id: 0,
+                values: vec![SqlValue::Integer(42)],
+            },
         );
 
         // Rollback discards operations
@@ -982,5 +1055,364 @@ mod tests {
         assert_eq!(stats.transactions_committed, 0);
         assert_eq!(stats.transactions_rolled_back, 0);
         assert!(!stats.corruption_detected);
+    }
+
+    // ------------------------------------------------------------------
+    // Phase 2 (#5698): DML replay during recovery
+    // ------------------------------------------------------------------
+    //
+    // These tests drive a real `Database` with the persistence engine
+    // enabled so the WAL is populated with genuine ops (carrying the
+    // qualified `table_name` introduced in WAL format v2), then recover
+    // from the on-disk WAL and assert that row *data* — not just schema —
+    // is restored.
+
+    use crate::wal::{PersistenceConfig, PersistenceEngine};
+    use crate::Database;
+
+    /// Build a simple `id INTEGER, name VARCHAR` schema.
+    fn simple_schema(name: &str) -> TableSchema {
+        TableSchema::new(
+            name.to_string(),
+            vec![
+                ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                ColumnSchema::new(
+                    "name".to_string(),
+                    DataType::Varchar { max_length: Some(50) },
+                    true,
+                ),
+            ],
+        )
+    }
+
+    /// Count live rows in a recovered table by qualified name.
+    fn live_row_count(db: &Database, qualified: &str) -> usize {
+        db.get_table(qualified).map(|t| t.scan_live().count()).unwrap_or(0)
+    }
+
+    /// Serialize a schema into the WAL `CreateTable.schema_data` layout that
+    /// `deserialize_table_schema` (in this module) expects. Mirrors the
+    /// production `serialize_table_schema` helper, kept local to avoid reaching
+    /// into the private `database::table_api` module from a test.
+    fn serialize_schema_for_test(schema: &TableSchema) -> Vec<u8> {
+        let mut data = Vec::new();
+        data.extend_from_slice(schema.name.as_bytes());
+        data.push(0);
+        data.extend_from_slice(&(schema.columns.len() as u32).to_le_bytes());
+        for col in &schema.columns {
+            data.extend_from_slice(col.name.as_bytes());
+            data.push(0);
+            let type_str = format!("{:?}", col.data_type);
+            data.extend_from_slice(type_str.as_bytes());
+            data.push(0);
+            data.push(if col.nullable { 1 } else { 0 });
+        }
+        data
+    }
+
+    #[test]
+    fn test_recovery_replays_dml_inserts() {
+        let temp_dir = TempDir::new().unwrap();
+        let checkpoint_dir = temp_dir.path().join("checkpoints");
+        let wal_path = temp_dir.path().join("test.wal");
+
+        // 1. Write a table + rows through a persistence-enabled Database so the
+        //    WAL captures real CreateTable + Insert ops.
+        {
+            let mut db = Database::new();
+            let engine = PersistenceEngine::new(&wal_path, PersistenceConfig::default()).unwrap();
+            db.enable_persistence(engine);
+
+            db.create_table(simple_schema("people")).unwrap();
+            db.insert_row(
+                "main.people",
+                crate::row::Row::new(vec![
+                    SqlValue::Integer(1),
+                    SqlValue::Varchar(arcstr::ArcStr::from("alice")),
+                ]),
+            )
+            .unwrap();
+            db.insert_row(
+                "main.people",
+                crate::row::Row::new(vec![
+                    SqlValue::Integer(2),
+                    SqlValue::Varchar(arcstr::ArcStr::from("bob")),
+                ]),
+            )
+            .unwrap();
+
+            // Flush everything to the WAL, then simulate a crash by dropping the
+            // Database WITHOUT writing a checkpoint.
+            db.sync_persistence().unwrap();
+        }
+
+        // 2. Recover from the WAL alone (no checkpoint).
+        let manager = RecoveryManager::new(&checkpoint_dir).with_wal(&wal_path);
+        let (db, stats) = manager.recover().unwrap();
+
+        assert_eq!(stats.tables_created, 1, "table schema should be replayed");
+        assert_eq!(stats.inserts_applied, 2, "both inserts should be applied");
+        assert_eq!(live_row_count(&db, "main.people"), 2, "both rows must survive recovery");
+
+        let table = db.get_table("main.people").expect("table exists after recovery");
+        let rows: Vec<_> = table.scan_live().map(|(_, r)| r.clone()).collect();
+        assert_eq!(rows[0].values[0], SqlValue::Integer(1));
+        assert_eq!(rows[1].values[0], SqlValue::Integer(2));
+    }
+
+    #[test]
+    fn test_recovery_replays_update_and_delete() {
+        use crate::wal::entry::WalEntry;
+        use crate::wal::writer::WalWriter;
+
+        let temp_dir = TempDir::new().unwrap();
+        let checkpoint_dir = temp_dir.path().join("checkpoints");
+        let wal_path = temp_dir.path().join("test.wal");
+
+        // Build the schema-serialized bytes for a CreateTable op using the same
+        // null-terminated layout `serialize_table_schema` / `deserialize_table_schema`
+        // agree on, so recovery can rebuild the table.
+        let schema = simple_schema("t");
+        let schema_data = serialize_schema_for_test(&schema);
+
+        // Hand-author a WAL: CreateTable, three Inserts, one Update (row 0), one
+        // Delete (row 1) — all as standalone (auto-commit) ops carrying the
+        // qualified table_name. This directly exercises apply_op's DML arms.
+        {
+            let file = std::fs::File::create(&wal_path).unwrap();
+            let mut writer = WalWriter::create(file).unwrap();
+            let mut lsn = 1u64;
+            let mut append = |writer: &mut WalWriter<std::fs::File>, op: WalOp, lsn: &mut u64| {
+                writer.append(&WalEntry::new(*lsn, 0, op)).unwrap();
+                *lsn += 1;
+            };
+
+            append(
+                &mut writer,
+                WalOp::CreateTable { table_id: 0, table_name: "main.t".into(), schema_data },
+                &mut lsn,
+            );
+            for i in 1..=3i64 {
+                append(
+                    &mut writer,
+                    WalOp::Insert {
+                        table_id: 0,
+                        table_name: "main.t".into(),
+                        row_id: (i - 1) as u64,
+                        values: vec![
+                            SqlValue::Integer(i),
+                            SqlValue::Varchar(arcstr::ArcStr::from(format!("v{i}"))),
+                        ],
+                    },
+                    &mut lsn,
+                );
+            }
+            append(
+                &mut writer,
+                WalOp::Update {
+                    table_id: 0,
+                    table_name: "main.t".into(),
+                    row_id: 0,
+                    old_values: vec![
+                        SqlValue::Integer(1),
+                        SqlValue::Varchar(arcstr::ArcStr::from("v1")),
+                    ],
+                    new_values: vec![
+                        SqlValue::Integer(1),
+                        SqlValue::Varchar(arcstr::ArcStr::from("updated")),
+                    ],
+                },
+                &mut lsn,
+            );
+            append(
+                &mut writer,
+                WalOp::Delete {
+                    table_id: 0,
+                    table_name: "main.t".into(),
+                    row_id: 1,
+                    old_values: vec![
+                        SqlValue::Integer(2),
+                        SqlValue::Varchar(arcstr::ArcStr::from("v2")),
+                    ],
+                },
+                &mut lsn,
+            );
+            writer.flush().unwrap();
+        }
+
+        let manager = RecoveryManager::new(&checkpoint_dir).with_wal(&wal_path);
+        let (db, stats) = manager.recover().unwrap();
+
+        assert_eq!(stats.inserts_applied, 3);
+        assert_eq!(stats.updates_applied, 1);
+        assert_eq!(stats.deletes_applied, 1);
+
+        // 3 inserted, 1 deleted => 2 live rows.
+        assert_eq!(live_row_count(&db, "main.t"), 2);
+
+        let table = db.get_table("main.t").unwrap();
+        // Row 0 was updated.
+        assert_eq!(
+            table.get_row(0).unwrap().values[1],
+            SqlValue::Varchar(arcstr::ArcStr::from("updated"))
+        );
+        // Row 1 was deleted.
+        assert!(table.is_row_deleted(1));
+        // Row 2 untouched.
+        assert_eq!(table.get_row(2).unwrap().values[0], SqlValue::Integer(3));
+    }
+
+    #[test]
+    fn test_recovery_discards_uncommitted_transaction() {
+        let temp_dir = TempDir::new().unwrap();
+        let checkpoint_dir = temp_dir.path().join("checkpoints");
+        let wal_path = temp_dir.path().join("test.wal");
+
+        {
+            let mut db = Database::new();
+            let engine = PersistenceEngine::new(&wal_path, PersistenceConfig::default()).unwrap();
+            db.enable_persistence(engine);
+
+            db.create_table(simple_schema("t")).unwrap();
+            // One committed (auto-commit) insert.
+            db.insert_row(
+                "main.t",
+                crate::row::Row::new(vec![
+                    SqlValue::Integer(1),
+                    SqlValue::Varchar(arcstr::ArcStr::from("committed")),
+                ]),
+            )
+            .unwrap();
+
+            // Begin an explicit transaction, insert, then crash WITHOUT
+            // committing. The TxnBegin op is emitted to the WAL; the buffered
+            // insert must NOT be applied on recovery.
+            db.begin_transaction().unwrap();
+            db.insert_row(
+                "main.t",
+                crate::row::Row::new(vec![
+                    SqlValue::Integer(2),
+                    SqlValue::Varchar(arcstr::ArcStr::from("uncommitted")),
+                ]),
+            )
+            .unwrap();
+
+            db.sync_persistence().unwrap();
+            // Drop without commit_transaction() => simulated crash mid-txn.
+        }
+
+        let manager = RecoveryManager::new(&checkpoint_dir).with_wal(&wal_path);
+        let (db, _stats) = manager.recover().unwrap();
+
+        // Only the committed row should survive.
+        assert_eq!(live_row_count(&db, "main.t"), 1, "uncommitted row must be discarded");
+        let table = db.get_table("main.t").unwrap();
+        let rows: Vec<_> = table.scan_live().map(|(_, r)| r.clone()).collect();
+        assert_eq!(rows[0].values[0], SqlValue::Integer(1));
+    }
+
+    #[test]
+    fn test_recovery_tolerates_truncated_wal_tail() {
+        // A WAL whose final entry was only partially written (e.g. the process
+        // died mid-flush) must recover every complete entry before the
+        // truncation point and stop cleanly at the corruption — without losing
+        // the earlier committed rows.
+        let temp_dir = TempDir::new().unwrap();
+        let checkpoint_dir = temp_dir.path().join("checkpoints");
+        let wal_path = temp_dir.path().join("test.wal");
+
+        // 1. Write a valid WAL: CreateTable + two Inserts.
+        {
+            let mut db = Database::new();
+            let engine = PersistenceEngine::new(&wal_path, PersistenceConfig::default()).unwrap();
+            db.enable_persistence(engine);
+
+            db.create_table(simple_schema("t")).unwrap();
+            db.insert_row(
+                "main.t",
+                crate::row::Row::new(vec![
+                    SqlValue::Integer(1),
+                    SqlValue::Varchar(arcstr::ArcStr::from("one")),
+                ]),
+            )
+            .unwrap();
+            db.insert_row(
+                "main.t",
+                crate::row::Row::new(vec![
+                    SqlValue::Integer(2),
+                    SqlValue::Varchar(arcstr::ArcStr::from("two")),
+                ]),
+            )
+            .unwrap();
+            db.sync_persistence().unwrap();
+        }
+
+        // 2. Simulate a torn final write by chopping the last byte off the WAL.
+        let original_len = std::fs::metadata(&wal_path).unwrap().len();
+        assert!(original_len > 1);
+        let file = std::fs::OpenOptions::new().write(true).open(&wal_path).unwrap();
+        file.set_len(original_len - 1).unwrap();
+        drop(file);
+
+        // 3. Recovery must tolerate the truncated tail: it detects corruption,
+        //    stops, and keeps the rows from the complete entries. The last
+        //    (now-torn) Insert is dropped, leaving exactly one row.
+        let manager = RecoveryManager::new(&checkpoint_dir).with_wal(&wal_path);
+        let (db, stats) = manager.recover().unwrap();
+
+        assert!(stats.corruption_detected, "truncated tail should be flagged as corruption");
+        assert_eq!(
+            live_row_count(&db, "main.t"),
+            1,
+            "rows before the torn tail must survive; the torn entry is dropped"
+        );
+        let table = db.get_table("main.t").unwrap();
+        let rows: Vec<_> = table.scan_live().map(|(_, r)| r.clone()).collect();
+        assert_eq!(rows[0].values[0], SqlValue::Integer(1));
+    }
+
+    #[test]
+    fn test_recovery_v1_dml_skipped_gracefully() {
+        // A WAL Insert serialized under format v1 (no inline table_name) must be
+        // parsed without error and skipped during replay rather than corrupting
+        // recovery. We hand-build a v1 op and deserialize it with version 1.
+        use crate::wal::entry::WalEntry;
+
+        // Serialize a current (v2) Insert, then re-read it as v1: the v1 reader
+        // stops before the table_name field, so we instead construct the raw v1
+        // byte layout directly: tag + table_id + row_id + values.
+        let mut buf = Vec::new();
+        // tag = Insert (0x01)
+        buf.push(0x01);
+        // table_id: u32 = 7
+        buf.extend_from_slice(&7u32.to_le_bytes());
+        // row_id: u64 = 0
+        buf.extend_from_slice(&0u64.to_le_bytes());
+        // values: len=1, then one Integer
+        buf.extend_from_slice(&1u32.to_le_bytes());
+        // Encode SqlValue::Integer(99) via the same value writer path.
+        let mut value_buf = Vec::new();
+        crate::persistence::binary::value::write_sql_value(&mut value_buf, &SqlValue::Integer(99))
+            .unwrap();
+        buf.extend_from_slice(&value_buf);
+
+        // Prepend lsn + timestamp for a full WalEntry (v1 entry layout is
+        // identical except the op body).
+        let mut entry_buf = Vec::new();
+        entry_buf.extend_from_slice(&1u64.to_le_bytes()); // lsn
+        entry_buf.extend_from_slice(&0u64.to_le_bytes()); // timestamp_ms
+        entry_buf.extend_from_slice(&buf);
+
+        let mut reader = &entry_buf[..];
+        let entry = WalEntry::deserialize_versioned(&mut reader, 1).unwrap();
+        match entry.op {
+            WalOp::Insert { table_id, table_name, row_id, values } => {
+                assert_eq!(table_id, 7);
+                assert!(table_name.is_empty(), "v1 op has no inline table_name");
+                assert_eq!(row_id, 0);
+                assert_eq!(values, vec![SqlValue::Integer(99)]);
+            }
+            other => panic!("expected Insert, got {:?}", other),
+        }
     }
 }

--- a/crates/vibesql-storage/src/wal/truncate.rs
+++ b/crates/vibesql-storage/src/wal/truncate.rs
@@ -254,7 +254,12 @@ mod tests {
             let entry = WalEntry::new(
                 i,
                 1234567890 + i,
-                WalOp::Insert { table_id: 1, row_id: i, values: vec![SqlValue::Integer(i as i64)] },
+                WalOp::Insert {
+                    table_id: 1,
+                    table_name: "main.t".to_string(),
+                    row_id: i,
+                    values: vec![SqlValue::Integer(i as i64)],
+                },
             );
             wal_writer.append(&entry).unwrap();
         }

--- a/crates/vibesql-storage/src/wal/writer.rs
+++ b/crates/vibesql-storage/src/wal/writer.rs
@@ -196,7 +196,12 @@ mod tests {
         let entry = WalEntry::new(
             1,
             1234567890,
-            WalOp::Insert { table_id: 1, row_id: 100, values: vec![SqlValue::Integer(42)] },
+            WalOp::Insert {
+                table_id: 1,
+                table_name: "main.t".to_string(),
+                row_id: 100,
+                values: vec![SqlValue::Integer(42)],
+            },
         );
 
         let lsn = writer.append(&entry).unwrap();
@@ -216,7 +221,12 @@ mod tests {
             let entry = WalEntry::new(
                 i,
                 1234567890 + i,
-                WalOp::Insert { table_id: 1, row_id: i, values: vec![SqlValue::Integer(i as i64)] },
+                WalOp::Insert {
+                    table_id: 1,
+                    table_name: "main.t".to_string(),
+                    row_id: i,
+                    values: vec![SqlValue::Integer(i as i64)],
+                },
             );
             let lsn = writer.append(&entry).unwrap();
             assert_eq!(lsn, i);
@@ -236,6 +246,7 @@ mod tests {
         let lsn = writer
             .append_op(WalOp::Insert {
                 table_id: 1,
+                table_name: "main.t".to_string(),
                 row_id: 100,
                 values: vec![SqlValue::Varchar(arcstr::ArcStr::from("test"))],
             })


### PR DESCRIPTION
## Summary

Phase 2 of #5698. Phase 1 (PR #5706) wired the WAL engine into the CLI, but `RecoveryManager::apply_op` only replayed DDL — committed `Insert`/`Update`/`Delete` written after the last checkpoint were lost on an unclean shutdown. This PR makes committed DML durable across a crash and flips `[database] wal` on by default.

Closes #5698

## Approach: (B) embed `table_name` in DML WAL ops (WAL format v2)

Approach (A) — a `table_id -> table_name` map built from `CreateTable` ops during replay — is **structurally impossible** here: `CreateTable.table_id` comes from the monotonic `next_table_id()`, while DML ops' `table_id` is `hash(qualified_name) as u32` (`table_name_to_id`). They live in disjoint id spaces, so a map keyed by `CreateTable.table_id` can never resolve a DML `table_id`. Approach (B) is the only correct option, and it's also self-describing and robust for multi-session use.

- `WalOp::Insert/Update/Delete` now carry an inline `table_name`; `WAL_VERSION` bumped `1 -> 2`.
- Backward compat: deserialization is version-aware (`deserialize_versioned`, threaded from the WAL header). v1 logs (no inline name) still parse cleanly and their DML is **skipped** during replay with a warning — v1 DML replay never worked anyway, and WAL files are transient (truncated on every checkpoint/clean exit).
- `RecoveryManager::apply_op` routes DML to the table by name (`Table::insert` / `update_row` / `mark_deleted_inplace`). Replay is in LSN order, so physical row indices stay aligned for subsequent Update/Delete by `row_id`.
- Uncommitted transactions at crash time remain buffered-and-discarded (existing `TransactionTracker`).

## Default flip

`[database] wal` now defaults to `true` (file-backed DBs); `wal = false` opts out to the snapshot-only path. Done **only after** the crash-recovery tests pass.

## Tests

Storage (`wal::recovery`):
- `test_recovery_replays_dml_inserts` — committed inserts survive WAL-only recovery.
- `test_recovery_replays_update_and_delete` — update + delete replay correctly.
- `test_recovery_discards_uncommitted_transaction` — open-txn insert is discarded.
- `test_recovery_tolerates_truncated_wal_tail` — torn final write recovers up to the last valid entry.
- `test_recovery_v1_dml_skipped_gracefully` — v1 (no table_name) parses and is skipped.

CLI (`wal_recovery_test.rs`):
- Phase 1's "DML known gap" test flipped to **`test_dml_survives_crash_via_wal_replay`** (positive assertion).
- `test_uncommitted_dml_not_replayed`.
- **`test_subprocess_committed_rows_survive_sigkill`** — real `vibesql` subprocess: insert rows → SIGKILL → reopen → all committed rows present (primary acceptance gate).
- Hardened the Phase 1 DDL SIGKILL test against a checkpoint-write race.

`persistence_test.rs` (snapshot-path tests) now run explicitly with `wal = false` and clean WAL siblings, since they assert on the single SQL-dump file.

All of: `vibesql-storage` (719 lib + integration), `vibesql-cli` (config, wal_recovery, persistence) pass. `cargo check --workspace` and `cargo check -p vibesql-storage --features mvcc_enabled` clean.

## Docs

`--help`, `executor/wal.rs` module docs, and a new `CLAUDE.md` "CLI Durability" section document WAL-on-by-default, the `.wal` + `-checkpoints/` sibling layout, and full DDL+DML crash durability; the Phase 2 DML-loss caveat is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)