### PR TITLE
perf(tpcc): add write-faithful TPC-C transactions behind TPCC_WRITE_FAITHFUL

### DIFF
--- a/crates/vibesql-executor/benches/tpcc/transactions.rs
+++ b/crates/vibesql-executor/benches/tpcc/transactions.rs
@@ -26,8 +26,15 @@
 
 use std::{sync::Arc, time::Instant};
 
-use vibesql_executor::{PreparedStatementCache, SelectExecutor};
+use vibesql_executor::{
+    DeleteExecutor, InsertExecutor, PreparedStatementCache, SelectExecutor, UpdateExecutor,
+};
 use vibesql_types::SqlValue;
+
+/// Fixed timestamp used for write-faithful row payloads (reproducible, matches loader).
+const WRITE_FAITHFUL_TS: &str = "2024-01-01 00:00:00";
+/// Fixed 24-char district-info string used for synthesized order_line rows.
+const WRITE_FAITHFUL_DIST_INFO: &str = "ABCDEFGHIJKLMNOPQRSTUVWX";
 
 // Import transaction types from shared crate
 pub use vibesql_bench_common::tpcc::{
@@ -149,6 +156,55 @@ fn execute_query_for_int(
         }
     }
     Err("No result returned".to_string())
+}
+
+/// Helper function to execute a templated DML statement (INSERT/UPDATE/DELETE).
+///
+/// This is the write-path sibling of [`execute_query`]. It binds the same stable
+/// `?`-placeholder template through the prepared-statement cache, but instead of routing the
+/// bound AST to `SelectExecutor` it dispatches on the DML variant to the real
+/// `InsertExecutor` / `UpdateExecutor` / `DeleteExecutor`. Because it goes through those
+/// executors against a `&mut Database`, it exercises the genuine write path: index
+/// maintenance, delete compaction (`should_compact()`), and WAL flush.
+///
+/// `execute_query`'s `match` only accepts `Statement::Select` (silently dropping DML), so the
+/// write-faithful variant must use this helper rather than reusing `execute_query`.
+///
+/// Returns the number of rows affected.
+fn execute_dml(
+    cache: &PreparedStatementCache,
+    db: &mut vibesql_storage::Database,
+    template: &str,
+    params: &[SqlValue],
+) -> Result<usize, String> {
+    let parse_start = Instant::now();
+
+    let prepared = cache.get_or_prepare(template).map_err(|e| format!("Prepare error: {}", e))?;
+    let stmt = prepared.bind(params).map_err(|e| format!("Bind error: {}", e))?;
+
+    let parse_time = parse_start.elapsed().as_micros() as u64;
+    PARSE_TIME_US.with(|t| t.set(t.get() + parse_time));
+
+    let execute_start = Instant::now();
+
+    let result = match stmt {
+        vibesql_ast::Statement::Insert(insert) => {
+            InsertExecutor::execute(db, &insert).map_err(|e| format!("Insert error: {}", e))
+        }
+        vibesql_ast::Statement::Update(update) => {
+            UpdateExecutor::execute(&update, db).map_err(|e| format!("Update error: {}", e))
+        }
+        vibesql_ast::Statement::Delete(delete) => {
+            DeleteExecutor::execute(&delete, db).map_err(|e| format!("Delete error: {}", e))
+        }
+        _ => Err("execute_dml expected INSERT/UPDATE/DELETE statement".to_string()),
+    };
+
+    let execute_time = execute_start.elapsed().as_micros() as u64;
+    EXECUTE_TIME_US.with(|t| t.set(t.get() + execute_time));
+    QUERY_COUNT.with(|c| c.set(c.get() + 1));
+
+    result
 }
 
 /// Print profiling summary (call at end of benchmark)
@@ -554,6 +610,442 @@ impl<'a> TPCCExecutor for VibesqlTransactionExecutor<'a> {
     }
 }
 
+// ============================================================================
+// Write-faithful TPC-C transactions (TPCC_WRITE_FAITHFUL=1)
+// ============================================================================
+//
+// The read-only executors above model the five transactions as SELECTs only, so write-path
+// costs (delete compaction, index maintenance, WAL flush) never surface. The write-faithful
+// path issues the real INSERT/UPDATE/DELETE statements for New-Order, Payment, and Delivery
+// (Order-Status and Stock-Level are read-only in real TPC-C and stay read-only here).
+//
+// CONCURRENCY RESOLUTION (serial-only, v1): the VibeSQL DML executors require
+// `db: &mut Database`, but the read-only `VibesqlTransactionExecutor` holds a shared
+// `&Database` and is `Sync` across parallel clients — a shared `&Database` cannot drive
+// `&mut`-requiring DML. Rather than introduce per-client owned databases (more code) or
+// unsafe aliasing, the write-faithful path runs SERIAL-ONLY: the bench forces
+// `num_clients = 1` and the executor owns a `&mut Database`. Comparative per-transaction
+// latency does not require parallelism. See `TPCCWriteExecutor` + `run_write_benchmark` in
+// `tpcc_benchmark.rs`.
+
+/// Trait for write-faithful TPC-C transaction executors.
+///
+/// Unlike [`TPCCExecutor`] (which takes `&self` and is shared across parallel clients), this
+/// trait takes `&mut self` so the VibeSQL implementation can drive `&mut Database` DML. It is
+/// driven by the serial `run_write_benchmark` runner.
+pub trait TPCCWriteExecutor {
+    fn new_order(&mut self, input: &NewOrderInput) -> TransactionResult;
+    fn payment(&mut self, input: &PaymentInput) -> TransactionResult;
+    fn order_status(&mut self, input: &OrderStatusInput) -> TransactionResult;
+    fn delivery(&mut self, input: &DeliveryInput) -> TransactionResult;
+    fn stock_level(&mut self, input: &StockLevelInput) -> TransactionResult;
+}
+
+/// Write-faithful TPC-C transaction executor for VibeSQL.
+///
+/// Owns a mutable borrow of the database so it can run real DML through
+/// `InsertExecutor`/`UpdateExecutor`/`DeleteExecutor` via [`execute_dml`]. Read-side lookups
+/// reuse [`execute_query`]/[`execute_query_for_int`] through a shared reborrow of the same
+/// database. Cache is a plain (non-`Arc`) instance since this path is single-threaded.
+pub struct VibesqlWriteExecutor<'a> {
+    pub db: &'a mut vibesql_storage::Database,
+    cache: PreparedStatementCache,
+}
+
+impl<'a> VibesqlWriteExecutor<'a> {
+    pub fn new(db: &'a mut vibesql_storage::Database) -> Self {
+        Self { db, cache: PreparedStatementCache::new(64) }
+    }
+
+    /// Write-faithful New-Order: reads warehouse/district/customer/item/stock, then writes
+    /// the order header, the new_order marker row, and one order_line per item, updating
+    /// stock and advancing the district's next-order-id (which also keeps the orders /
+    /// order_line / new_order primary keys unique across repeated transactions).
+    fn new_order_impl(&mut self, input: &NewOrderInput) -> Result<(), String> {
+        // Read warehouse tax (read-only lookup).
+        execute_query(
+            &self.cache,
+            &*self.db,
+            "SELECT w_tax FROM warehouse WHERE w_id = ?",
+            &[SqlValue::Integer(input.w_id as i64)],
+        )?;
+
+        // Read the district's next order id; this becomes the new order's o_id.
+        let o_id = execute_query_for_int(
+            &self.cache,
+            &*self.db,
+            "SELECT d_next_o_id FROM district WHERE d_w_id = ? AND d_id = ?",
+            &[SqlValue::Integer(input.w_id as i64), SqlValue::Integer(input.d_id as i64)],
+        )?;
+
+        // Read customer info (read-only lookup).
+        execute_query(
+            &self.cache,
+            &*self.db,
+            "SELECT c_discount, c_last, c_credit FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?",
+            &[
+                SqlValue::Integer(input.w_id as i64),
+                SqlValue::Integer(input.d_id as i64),
+                SqlValue::Integer(input.c_id as i64),
+            ],
+        )?;
+
+        // Advance the district's next order id (write).
+        execute_dml(
+            &self.cache,
+            self.db,
+            "UPDATE district SET d_next_o_id = d_next_o_id + 1 WHERE d_w_id = ? AND d_id = ?",
+            &[SqlValue::Integer(input.w_id as i64), SqlValue::Integer(input.d_id as i64)],
+        )?;
+
+        // Insert the order header (o_carrier_id is NULL until delivered).
+        execute_dml(
+            &self.cache,
+            self.db,
+            "INSERT INTO orders VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            &[
+                SqlValue::Integer(o_id),
+                SqlValue::Integer(input.d_id as i64),
+                SqlValue::Integer(input.w_id as i64),
+                SqlValue::Integer(input.c_id as i64),
+                SqlValue::Varchar(arcstr::ArcStr::from(WRITE_FAITHFUL_TS)),
+                SqlValue::Null,
+                SqlValue::Integer(input.ol_cnt as i64),
+                SqlValue::Integer(1),
+            ],
+        )?;
+
+        // Insert the new_order marker row.
+        execute_dml(
+            &self.cache,
+            self.db,
+            "INSERT INTO new_order VALUES (?, ?, ?)",
+            &[
+                SqlValue::Integer(o_id),
+                SqlValue::Integer(input.d_id as i64),
+                SqlValue::Integer(input.w_id as i64),
+            ],
+        )?;
+
+        // Per item: read item + stock, update stock, insert the order_line row.
+        for (idx, item) in input.items.iter().enumerate() {
+            execute_query(
+                &self.cache,
+                &*self.db,
+                "SELECT i_price, i_name, i_data FROM item WHERE i_id = ?",
+                &[SqlValue::Integer(item.ol_i_id as i64)],
+            )?;
+
+            execute_query(
+                &self.cache,
+                &*self.db,
+                "SELECT s_quantity, s_ytd, s_order_cnt FROM stock WHERE s_i_id = ? AND s_w_id = ?",
+                &[
+                    SqlValue::Integer(item.ol_i_id as i64),
+                    SqlValue::Integer(item.ol_supply_w_id as i64),
+                ],
+            )?;
+
+            execute_dml(
+                &self.cache,
+                self.db,
+                "UPDATE stock SET s_ytd = s_ytd + ?, s_order_cnt = s_order_cnt + 1, \
+                 s_quantity = s_quantity - ? WHERE s_i_id = ? AND s_w_id = ?",
+                &[
+                    SqlValue::Integer(item.ol_quantity as i64),
+                    SqlValue::Integer(item.ol_quantity as i64),
+                    SqlValue::Integer(item.ol_i_id as i64),
+                    SqlValue::Integer(item.ol_supply_w_id as i64),
+                ],
+            )?;
+
+            execute_dml(
+                &self.cache,
+                self.db,
+                "INSERT INTO order_line VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                &[
+                    SqlValue::Integer(o_id),
+                    SqlValue::Integer(input.d_id as i64),
+                    SqlValue::Integer(input.w_id as i64),
+                    SqlValue::Integer((idx + 1) as i64),
+                    SqlValue::Integer(item.ol_i_id as i64),
+                    SqlValue::Integer(item.ol_supply_w_id as i64),
+                    SqlValue::Null,
+                    SqlValue::Integer(item.ol_quantity as i64),
+                    SqlValue::Numeric(item.ol_quantity as f64 * 10.0),
+                    SqlValue::Varchar(arcstr::ArcStr::from(WRITE_FAITHFUL_DIST_INFO)),
+                ],
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// Write-faithful Payment: updates warehouse / district / customer balances and inserts a
+    /// history row.
+    fn payment_impl(&mut self, input: &PaymentInput) -> Result<(), String> {
+        // Update warehouse YTD.
+        execute_dml(
+            &self.cache,
+            self.db,
+            "UPDATE warehouse SET w_ytd = w_ytd + ? WHERE w_id = ?",
+            &[SqlValue::Numeric(input.h_amount), SqlValue::Integer(input.w_id as i64)],
+        )?;
+
+        // Update district YTD.
+        execute_dml(
+            &self.cache,
+            self.db,
+            "UPDATE district SET d_ytd = d_ytd + ? WHERE d_w_id = ? AND d_id = ?",
+            &[
+                SqlValue::Numeric(input.h_amount),
+                SqlValue::Integer(input.w_id as i64),
+                SqlValue::Integer(input.d_id as i64),
+            ],
+        )?;
+
+        // Resolve the customer id (by id, or by last name lookup).
+        let c_id = if let Some(c_id) = input.c_id {
+            c_id as i64
+        } else {
+            execute_query_for_int(
+                &self.cache,
+                &*self.db,
+                "SELECT c_id FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_last = ? ORDER BY c_first LIMIT 1",
+                &[
+                    SqlValue::Integer(input.c_w_id as i64),
+                    SqlValue::Integer(input.c_d_id as i64),
+                    SqlValue::Varchar(arcstr::ArcStr::from(input.c_last.as_ref().unwrap().as_str())),
+                ],
+            )?
+        };
+
+        // Update customer balance / ytd payment / payment count.
+        execute_dml(
+            &self.cache,
+            self.db,
+            "UPDATE customer SET c_balance = c_balance - ?, c_ytd_payment = c_ytd_payment + ?, \
+             c_payment_cnt = c_payment_cnt + 1 WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?",
+            &[
+                SqlValue::Numeric(input.h_amount),
+                SqlValue::Numeric(input.h_amount),
+                SqlValue::Integer(input.c_w_id as i64),
+                SqlValue::Integer(input.c_d_id as i64),
+                SqlValue::Integer(c_id),
+            ],
+        )?;
+
+        // Insert the history row.
+        execute_dml(
+            &self.cache,
+            self.db,
+            "INSERT INTO history VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            &[
+                SqlValue::Integer(c_id),
+                SqlValue::Integer(input.c_d_id as i64),
+                SqlValue::Integer(input.c_w_id as i64),
+                SqlValue::Integer(input.d_id as i64),
+                SqlValue::Integer(input.w_id as i64),
+                SqlValue::Varchar(arcstr::ArcStr::from(WRITE_FAITHFUL_TS)),
+                SqlValue::Numeric(input.h_amount),
+                SqlValue::Varchar(arcstr::ArcStr::from(WRITE_FAITHFUL_DIST_INFO)),
+            ],
+        )?;
+
+        Ok(())
+    }
+
+    /// Write-faithful Delivery: for each district, find the oldest undelivered order, delete
+    /// its new_order row, and stamp the carrier id / delivery date on orders and order_line.
+    /// The `DELETE FROM new_order` is what exercises delete compaction and delete-time index
+    /// maintenance. Districts with no pending new_order are skipped (no panic).
+    fn delivery_impl(&mut self, input: &DeliveryInput) -> Result<(), String> {
+        for d_id in 1..=10 {
+            // Find the oldest new_order for this district (read).
+            let o_id = match execute_query_for_int(
+                &self.cache,
+                &*self.db,
+                "SELECT no_o_id FROM new_order WHERE no_w_id = ? AND no_d_id = ? ORDER BY no_o_id LIMIT 1",
+                &[SqlValue::Integer(input.w_id as i64), SqlValue::Integer(d_id as i64)],
+            ) {
+                Ok(id) => id,
+                // No pending new order for this district — skip it (spec-faithful, no panic).
+                Err(_) => continue,
+            };
+
+            // Delete the new_order marker row (exercises compaction + index maintenance).
+            execute_dml(
+                &self.cache,
+                self.db,
+                "DELETE FROM new_order WHERE no_w_id = ? AND no_d_id = ? AND no_o_id = ?",
+                &[
+                    SqlValue::Integer(input.w_id as i64),
+                    SqlValue::Integer(d_id as i64),
+                    SqlValue::Integer(o_id),
+                ],
+            )?;
+
+            // Stamp the carrier id on the order header.
+            execute_dml(
+                &self.cache,
+                self.db,
+                "UPDATE orders SET o_carrier_id = ? WHERE o_w_id = ? AND o_d_id = ? AND o_id = ?",
+                &[
+                    SqlValue::Integer(input.o_carrier_id as i64),
+                    SqlValue::Integer(input.w_id as i64),
+                    SqlValue::Integer(d_id as i64),
+                    SqlValue::Integer(o_id),
+                ],
+            )?;
+
+            // Stamp the delivery date on the order's lines.
+            execute_dml(
+                &self.cache,
+                self.db,
+                "UPDATE order_line SET ol_delivery_d = ? WHERE ol_w_id = ? AND ol_d_id = ? AND ol_o_id = ?",
+                &[
+                    SqlValue::Varchar(arcstr::ArcStr::from(WRITE_FAITHFUL_TS)),
+                    SqlValue::Integer(input.w_id as i64),
+                    SqlValue::Integer(d_id as i64),
+                    SqlValue::Integer(o_id),
+                ],
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// Read-only Order-Status (unchanged from the read-only executor — Order-Status is a read
+    /// in real TPC-C).
+    fn order_status_impl(&self, input: &OrderStatusInput) -> Result<(), String> {
+        let c_id = if let Some(c_id) = input.c_id {
+            execute_query(
+                &self.cache,
+                &*self.db,
+                "SELECT c_id, c_first, c_middle, c_last, c_balance FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?",
+                &[
+                    SqlValue::Integer(input.w_id as i64),
+                    SqlValue::Integer(input.d_id as i64),
+                    SqlValue::Integer(c_id as i64),
+                ],
+            )?;
+            c_id as i64
+        } else {
+            execute_query(
+                &self.cache,
+                &*self.db,
+                "SELECT c_id, c_first, c_middle, c_last, c_balance FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_last = ? ORDER BY c_first",
+                &[
+                    SqlValue::Integer(input.w_id as i64),
+                    SqlValue::Integer(input.d_id as i64),
+                    SqlValue::Varchar(arcstr::ArcStr::from(input.c_last.as_ref().unwrap().as_str())),
+                ],
+            )?;
+            1
+        };
+
+        execute_query(
+            &self.cache,
+            &*self.db,
+            "SELECT o_id, o_entry_d, o_carrier_id FROM orders WHERE o_w_id = ? AND o_d_id = ? AND o_c_id = ? ORDER BY o_id DESC LIMIT 1",
+            &[
+                SqlValue::Integer(input.w_id as i64),
+                SqlValue::Integer(input.d_id as i64),
+                SqlValue::Integer(c_id),
+            ],
+        )?;
+
+        Ok(())
+    }
+
+    /// Read-only Stock-Level (unchanged — Stock-Level is a read in real TPC-C).
+    fn stock_level_impl(&self, input: &StockLevelInput) -> Result<(), String> {
+        let d_next_o_id = execute_query_for_int(
+            &self.cache,
+            &*self.db,
+            "SELECT d_next_o_id FROM district WHERE d_w_id = ? AND d_id = ?",
+            &[SqlValue::Integer(input.w_id as i64), SqlValue::Integer(input.d_id as i64)],
+        )?;
+
+        let ol_o_id_min = d_next_o_id - 20;
+        execute_query(
+            &self.cache,
+            &*self.db,
+            "SELECT COUNT(DISTINCT ol_i_id) FROM order_line \
+             WHERE ol_w_id = ? AND ol_d_id = ? \
+             AND ol_o_id >= ? AND ol_o_id < ? \
+             AND ol_i_id IN (SELECT s_i_id FROM stock WHERE s_w_id = ? AND s_quantity < ?)",
+            &[
+                SqlValue::Integer(input.w_id as i64),
+                SqlValue::Integer(input.d_id as i64),
+                SqlValue::Integer(ol_o_id_min),
+                SqlValue::Integer(d_next_o_id),
+                SqlValue::Integer(input.w_id as i64),
+                SqlValue::Integer(input.threshold as i64),
+            ],
+        )?;
+
+        Ok(())
+    }
+
+    /// Expose cache statistics for benchmark reporting.
+    pub fn cache_stats(&self) -> vibesql_executor::PreparedStatementCacheStats {
+        self.cache.stats()
+    }
+}
+
+impl<'a> TPCCWriteExecutor for VibesqlWriteExecutor<'a> {
+    fn new_order(&mut self, input: &NewOrderInput) -> TransactionResult {
+        let start = Instant::now();
+        let result = self.new_order_impl(input);
+        TransactionResult {
+            success: result.is_ok(),
+            duration_us: start.elapsed().as_micros() as u64,
+            error: result.err(),
+        }
+    }
+
+    fn payment(&mut self, input: &PaymentInput) -> TransactionResult {
+        let start = Instant::now();
+        let result = self.payment_impl(input);
+        TransactionResult {
+            success: result.is_ok(),
+            duration_us: start.elapsed().as_micros() as u64,
+            error: result.err(),
+        }
+    }
+
+    fn order_status(&mut self, input: &OrderStatusInput) -> TransactionResult {
+        let start = Instant::now();
+        let result = self.order_status_impl(input);
+        TransactionResult {
+            success: result.is_ok(),
+            duration_us: start.elapsed().as_micros() as u64,
+            error: result.err(),
+        }
+    }
+
+    fn delivery(&mut self, input: &DeliveryInput) -> TransactionResult {
+        let start = Instant::now();
+        let result = self.delivery_impl(input);
+        TransactionResult {
+            success: result.is_ok(),
+            duration_us: start.elapsed().as_micros() as u64,
+            error: result.err(),
+        }
+    }
+
+    fn stock_level(&mut self, input: &StockLevelInput) -> TransactionResult {
+        let start = Instant::now();
+        let result = self.stock_level_impl(input);
+        TransactionResult {
+            success: result.is_ok(),
+            duration_us: start.elapsed().as_micros() as u64,
+            error: result.err(),
+        }
+    }
+}
+
 /// TPC-C transaction executor for SQLite
 #[cfg(feature = "sqlite")]
 pub struct SqliteTransactionExecutor<'a> {
@@ -783,6 +1275,311 @@ impl<'a> TPCCExecutor for SqliteTransactionExecutor<'a> {
 
     fn stock_level(&self, input: &StockLevelInput) -> TransactionResult {
         self.stock_level(input)
+    }
+}
+
+/// Write-faithful TPC-C transaction executor for SQLite.
+///
+/// Issues the SAME logical INSERT/UPDATE/DELETE write set as [`VibesqlWriteExecutor`] so the
+/// per-transaction VibeSQL/SQLite ratio reflects engine cost, not differing work
+/// (apples-to-apples). SQLite's `Connection` methods take `&self`, but this implements the
+/// `&mut self` [`TPCCWriteExecutor`] trait so both engines share the serial
+/// `run_write_benchmark` runner.
+#[cfg(feature = "sqlite")]
+pub struct SqliteWriteExecutor<'a> {
+    pub conn: &'a rusqlite::Connection,
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> SqliteWriteExecutor<'a> {
+    pub fn new(conn: &'a rusqlite::Connection) -> Self {
+        Self { conn }
+    }
+
+    fn new_order_impl(&self, input: &NewOrderInput) -> Result<(), String> {
+        let map = |e: rusqlite::Error| e.to_string();
+
+        // Read warehouse tax (read-only lookup).
+        let _: f64 = self
+            .conn
+            .query_row(
+                "SELECT w_tax FROM warehouse WHERE w_id = ?",
+                rusqlite::params![input.w_id],
+                |r| r.get(0),
+            )
+            .map_err(map)?;
+
+        // Read the district's next order id; this becomes the new order's o_id.
+        let o_id: i64 = self
+            .conn
+            .query_row(
+                "SELECT d_next_o_id FROM district WHERE d_w_id = ? AND d_id = ?",
+                rusqlite::params![input.w_id, input.d_id],
+                |r| r.get(0),
+            )
+            .map_err(map)?;
+
+        // Read customer info (read-only lookup).
+        let _: f64 = self
+            .conn
+            .query_row(
+                "SELECT c_discount FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?",
+                rusqlite::params![input.w_id, input.d_id, input.c_id],
+                |r| r.get(0),
+            )
+            .map_err(map)?;
+
+        // Advance the district's next order id (write).
+        self.conn
+            .execute(
+                "UPDATE district SET d_next_o_id = d_next_o_id + 1 WHERE d_w_id = ? AND d_id = ?",
+                rusqlite::params![input.w_id, input.d_id],
+            )
+            .map_err(map)?;
+
+        // Insert order header (o_carrier_id NULL until delivered).
+        self.conn
+            .execute(
+                "INSERT INTO orders VALUES (?, ?, ?, ?, ?, NULL, ?, 1)",
+                rusqlite::params![
+                    o_id,
+                    input.d_id,
+                    input.w_id,
+                    input.c_id,
+                    WRITE_FAITHFUL_TS,
+                    input.ol_cnt
+                ],
+            )
+            .map_err(map)?;
+
+        // Insert new_order marker row.
+        self.conn
+            .execute(
+                "INSERT INTO new_order VALUES (?, ?, ?)",
+                rusqlite::params![o_id, input.d_id, input.w_id],
+            )
+            .map_err(map)?;
+
+        for (idx, item) in input.items.iter().enumerate() {
+            // Read item + stock (read-only lookups).
+            let _: f64 = self
+                .conn
+                .query_row(
+                    "SELECT i_price FROM item WHERE i_id = ?",
+                    rusqlite::params![item.ol_i_id],
+                    |r| r.get(0),
+                )
+                .map_err(map)?;
+            let _: i64 = self
+                .conn
+                .query_row(
+                    "SELECT s_quantity FROM stock WHERE s_i_id = ? AND s_w_id = ?",
+                    rusqlite::params![item.ol_i_id, item.ol_supply_w_id],
+                    |r| r.get(0),
+                )
+                .map_err(map)?;
+
+            self.conn
+                .execute(
+                    "UPDATE stock SET s_ytd = s_ytd + ?, s_order_cnt = s_order_cnt + 1, \
+                     s_quantity = s_quantity - ? WHERE s_i_id = ? AND s_w_id = ?",
+                    rusqlite::params![
+                        item.ol_quantity,
+                        item.ol_quantity,
+                        item.ol_i_id,
+                        item.ol_supply_w_id
+                    ],
+                )
+                .map_err(map)?;
+
+            self.conn
+                .execute(
+                    "INSERT INTO order_line VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)",
+                    rusqlite::params![
+                        o_id,
+                        input.d_id,
+                        input.w_id,
+                        (idx + 1) as i64,
+                        item.ol_i_id,
+                        item.ol_supply_w_id,
+                        item.ol_quantity,
+                        item.ol_quantity as f64 * 10.0,
+                        WRITE_FAITHFUL_DIST_INFO
+                    ],
+                )
+                .map_err(map)?;
+        }
+
+        Ok(())
+    }
+
+    fn payment_impl(&self, input: &PaymentInput) -> Result<(), String> {
+        let map = |e: rusqlite::Error| e.to_string();
+
+        self.conn
+            .execute(
+                "UPDATE warehouse SET w_ytd = w_ytd + ? WHERE w_id = ?",
+                rusqlite::params![input.h_amount, input.w_id],
+            )
+            .map_err(map)?;
+
+        self.conn
+            .execute(
+                "UPDATE district SET d_ytd = d_ytd + ? WHERE d_w_id = ? AND d_id = ?",
+                rusqlite::params![input.h_amount, input.w_id, input.d_id],
+            )
+            .map_err(map)?;
+
+        let c_id: i64 = if let Some(c_id) = input.c_id {
+            c_id as i64
+        } else {
+            self.conn
+                .query_row(
+                    "SELECT c_id FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_last = ? ORDER BY c_first LIMIT 1",
+                    rusqlite::params![input.c_w_id, input.c_d_id, input.c_last.as_ref().unwrap()],
+                    |r| r.get(0),
+                )
+                .map_err(map)?
+        };
+
+        self.conn
+            .execute(
+                "UPDATE customer SET c_balance = c_balance - ?, c_ytd_payment = c_ytd_payment + ?, \
+                 c_payment_cnt = c_payment_cnt + 1 WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?",
+                rusqlite::params![input.h_amount, input.h_amount, input.c_w_id, input.c_d_id, c_id],
+            )
+            .map_err(map)?;
+
+        self.conn
+            .execute(
+                "INSERT INTO history VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                rusqlite::params![
+                    c_id,
+                    input.c_d_id,
+                    input.c_w_id,
+                    input.d_id,
+                    input.w_id,
+                    WRITE_FAITHFUL_TS,
+                    input.h_amount,
+                    WRITE_FAITHFUL_DIST_INFO
+                ],
+            )
+            .map_err(map)?;
+
+        Ok(())
+    }
+
+    fn delivery_impl(&self, input: &DeliveryInput) -> Result<(), String> {
+        let map = |e: rusqlite::Error| e.to_string();
+
+        for d_id in 1..=10 {
+            let o_id: i64 = match self.conn.query_row(
+                "SELECT no_o_id FROM new_order WHERE no_w_id = ? AND no_d_id = ? ORDER BY no_o_id LIMIT 1",
+                rusqlite::params![input.w_id, d_id],
+                |r| r.get(0),
+            ) {
+                Ok(id) => id,
+                Err(rusqlite::Error::QueryReturnedNoRows) => continue,
+                Err(e) => return Err(map(e)),
+            };
+
+            self.conn
+                .execute(
+                    "DELETE FROM new_order WHERE no_w_id = ? AND no_d_id = ? AND no_o_id = ?",
+                    rusqlite::params![input.w_id, d_id, o_id],
+                )
+                .map_err(map)?;
+
+            self.conn
+                .execute(
+                    "UPDATE orders SET o_carrier_id = ? WHERE o_w_id = ? AND o_d_id = ? AND o_id = ?",
+                    rusqlite::params![input.o_carrier_id, input.w_id, d_id, o_id],
+                )
+                .map_err(map)?;
+
+            self.conn
+                .execute(
+                    "UPDATE order_line SET ol_delivery_d = ? WHERE ol_w_id = ? AND ol_d_id = ? AND ol_o_id = ?",
+                    rusqlite::params![WRITE_FAITHFUL_TS, input.w_id, d_id, o_id],
+                )
+                .map_err(map)?;
+        }
+
+        Ok(())
+    }
+
+    fn order_status_impl(&self, input: &OrderStatusInput) -> Result<(), String> {
+        // Read-only — reuse the read-only SQLite executor's behavior.
+        let exec = SqliteTransactionExecutor::new(self.conn);
+        let r = exec.order_status(input);
+        if r.success {
+            Ok(())
+        } else {
+            Err(r.error.unwrap_or_default())
+        }
+    }
+
+    fn stock_level_impl(&self, input: &StockLevelInput) -> Result<(), String> {
+        let exec = SqliteTransactionExecutor::new(self.conn);
+        let r = exec.stock_level(input);
+        if r.success {
+            Ok(())
+        } else {
+            Err(r.error.unwrap_or_default())
+        }
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> TPCCWriteExecutor for SqliteWriteExecutor<'a> {
+    fn new_order(&mut self, input: &NewOrderInput) -> TransactionResult {
+        let start = Instant::now();
+        let result = self.new_order_impl(input);
+        TransactionResult {
+            success: result.is_ok(),
+            duration_us: start.elapsed().as_micros() as u64,
+            error: result.err(),
+        }
+    }
+
+    fn payment(&mut self, input: &PaymentInput) -> TransactionResult {
+        let start = Instant::now();
+        let result = self.payment_impl(input);
+        TransactionResult {
+            success: result.is_ok(),
+            duration_us: start.elapsed().as_micros() as u64,
+            error: result.err(),
+        }
+    }
+
+    fn order_status(&mut self, input: &OrderStatusInput) -> TransactionResult {
+        let start = Instant::now();
+        let result = self.order_status_impl(input);
+        TransactionResult {
+            success: result.is_ok(),
+            duration_us: start.elapsed().as_micros() as u64,
+            error: result.err(),
+        }
+    }
+
+    fn delivery(&mut self, input: &DeliveryInput) -> TransactionResult {
+        let start = Instant::now();
+        let result = self.delivery_impl(input);
+        TransactionResult {
+            success: result.is_ok(),
+            duration_us: start.elapsed().as_micros() as u64,
+            error: result.err(),
+        }
+    }
+
+    fn stock_level(&mut self, input: &StockLevelInput) -> TransactionResult {
+        let start = Instant::now();
+        let result = self.stock_level_impl(input);
+        TransactionResult {
+            success: result.is_ok(),
+            duration_us: start.elapsed().as_micros() as u64,
+            error: result.err(),
+        }
     }
 }
 

--- a/crates/vibesql-executor/benches/tpcc_benchmark.rs
+++ b/crates/vibesql-executor/benches/tpcc_benchmark.rs
@@ -10,6 +10,13 @@
 //!   TPCC_WARMUP_SECS   - Warmup duration in seconds (default: 10)
 //!   TPCC_CLIENTS       - Number of parallel clients (default: 1)
 //!                        Set to 0 or "auto" for memory-aware auto-scaling
+//!   TPCC_WRITE_FAITHFUL - When 1/true, New-Order/Payment/Delivery issue real
+//!                        INSERT/UPDATE/DELETE so write-path costs (delete compaction, index
+//!                        maintenance, WAL flush) become measurable (default: off). This path
+//!                        is serial-only (forces TPCC_CLIENTS=1) because the VibeSQL DML
+//!                        executors require `&mut Database`. Order-Status/Stock-Level remain
+//!                        read-only. Run with ENGINE_FILTER=vibesql,sqlite for same-run
+//!                        per-transaction VibeSQL/SQLite ratios.
 //!   ENGINE_FILTER      - Comma-separated list of engines to run (default: vibesql,sqlite,duckdb)
 //!                        Note: MySQL excluded by default (use server benchmarks for MySQL)
 //!
@@ -300,6 +307,153 @@ fn aggregate_results(client_results: &[TPCCBenchmarkResults]) -> TPCCBenchmarkRe
 /// that contained nearly identical code.
 fn run_benchmark<E: TPCCExecutor>(
     executor: &E,
+    transaction_type: TransactionType,
+    num_warehouses: i32,
+    duration: Duration,
+    warmup: Duration,
+    print_phases: bool,
+) -> TPCCBenchmarkResults {
+    let mut workload = TPCCWorkload::new(42, num_warehouses);
+
+    let mut results = TPCCBenchmarkResults::new();
+    let mut new_order_times: Vec<u64> = Vec::new();
+    let mut payment_times: Vec<u64> = Vec::new();
+    let mut order_status_times: Vec<u64> = Vec::new();
+    let mut delivery_times: Vec<u64> = Vec::new();
+    let mut stock_level_times: Vec<u64> = Vec::new();
+
+    // Warmup phase
+    if print_phases {
+        eprintln!("Warmup phase ({:?})...", warmup);
+    }
+    let warmup_start = Instant::now();
+    while warmup_start.elapsed() < warmup {
+        let txn_type = match transaction_type {
+            TransactionType::Mixed => workload.next_transaction_type(),
+            TransactionType::NewOrder => 0,
+            TransactionType::Payment => 1,
+            TransactionType::OrderStatus => 2,
+            TransactionType::Delivery => 3,
+            TransactionType::StockLevel => 4,
+        };
+
+        match txn_type {
+            0 => {
+                let _ = executor.new_order(&workload.generate_new_order());
+            }
+            1 => {
+                let _ = executor.payment(&workload.generate_payment());
+            }
+            2 => {
+                let _ = executor.order_status(&workload.generate_order_status());
+            }
+            3 => {
+                let _ = executor.delivery(&workload.generate_delivery());
+            }
+            4 => {
+                let _ = executor.stock_level(&workload.generate_stock_level());
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    // Measurement phase
+    if print_phases {
+        eprintln!("Measurement phase ({:?})...", duration);
+    }
+    let benchmark_start = Instant::now();
+    while benchmark_start.elapsed() < duration {
+        let txn_type = match transaction_type {
+            TransactionType::Mixed => workload.next_transaction_type(),
+            TransactionType::NewOrder => 0,
+            TransactionType::Payment => 1,
+            TransactionType::OrderStatus => 2,
+            TransactionType::Delivery => 3,
+            TransactionType::StockLevel => 4,
+        };
+
+        let result = match txn_type {
+            0 => {
+                let r = executor.new_order(&workload.generate_new_order());
+                new_order_times.push(r.duration_us);
+                r
+            }
+            1 => {
+                let r = executor.payment(&workload.generate_payment());
+                payment_times.push(r.duration_us);
+                r
+            }
+            2 => {
+                let r = executor.order_status(&workload.generate_order_status());
+                order_status_times.push(r.duration_us);
+                r
+            }
+            3 => {
+                let r = executor.delivery(&workload.generate_delivery());
+                delivery_times.push(r.duration_us);
+                r
+            }
+            4 => {
+                let r = executor.stock_level(&workload.generate_stock_level());
+                stock_level_times.push(r.duration_us);
+                r
+            }
+            _ => unreachable!(),
+        };
+
+        results.total_transactions += 1;
+        if result.success {
+            results.successful_transactions += 1;
+        } else {
+            results.failed_transactions += 1;
+        }
+    }
+
+    results.total_duration_ms = benchmark_start.elapsed().as_millis() as u64;
+    if results.total_duration_ms > 0 {
+        results.transactions_per_second =
+            results.total_transactions as f64 / (results.total_duration_ms as f64 / 1000.0);
+    }
+
+    // Calculate averages
+    if !new_order_times.is_empty() {
+        results.new_order_count = new_order_times.len() as u64;
+        results.new_order_avg_us =
+            new_order_times.iter().sum::<u64>() as f64 / new_order_times.len() as f64;
+    }
+    if !payment_times.is_empty() {
+        results.payment_count = payment_times.len() as u64;
+        results.payment_avg_us =
+            payment_times.iter().sum::<u64>() as f64 / payment_times.len() as f64;
+    }
+    if !order_status_times.is_empty() {
+        results.order_status_count = order_status_times.len() as u64;
+        results.order_status_avg_us =
+            order_status_times.iter().sum::<u64>() as f64 / order_status_times.len() as f64;
+    }
+    if !delivery_times.is_empty() {
+        results.delivery_count = delivery_times.len() as u64;
+        results.delivery_avg_us =
+            delivery_times.iter().sum::<u64>() as f64 / delivery_times.len() as f64;
+    }
+    if !stock_level_times.is_empty() {
+        results.stock_level_count = stock_level_times.len() as u64;
+        results.stock_level_avg_us =
+            stock_level_times.iter().sum::<u64>() as f64 / stock_level_times.len() as f64;
+    }
+
+    results
+}
+
+/// Run a write-faithful TPC-C benchmark (serial, single client).
+///
+/// This is the serial counterpart of [`run_benchmark`] for the `TPCC_WRITE_FAITHFUL=1` path.
+/// It takes a `&mut E: TPCCWriteExecutor` so the VibeSQL implementation can drive `&mut
+/// Database` DML (INSERT/UPDATE/DELETE). The write-faithful path is serial-only by design
+/// (see the concurrency-resolution note in `tpcc/transactions.rs`): parallel write clients
+/// would require per-client owned databases, which is deferred.
+fn run_write_benchmark<E: TPCCWriteExecutor>(
+    executor: &mut E,
     transaction_type: TransactionType,
     num_warehouses: i32,
     duration: Duration,
@@ -1322,6 +1476,14 @@ fn main() {
     let duration = Duration::from_secs(duration_secs);
     let warmup = Duration::from_secs(warmup_secs);
 
+    // Write-faithful mode: when set, New-Order / Payment / Delivery issue real
+    // INSERT/UPDATE/DELETE so write-path costs (delete compaction, index maintenance, WAL
+    // flush) become measurable. Default off, so existing read-only runs are unchanged.
+    // This path is serial-only (see below): the VibeSQL DML executors require `&mut Database`.
+    let write_faithful = std::env::var("TPCC_WRITE_FAITHFUL")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
     // Parse number of clients (0 or "auto" means auto-scale)
     let num_clients_env = env::var("TPCC_CLIENTS").ok();
     let num_clients_raw: Option<usize> = num_clients_env.as_ref().and_then(|s| {
@@ -1354,11 +1516,23 @@ fn main() {
     let is_micro_mode = scale_factor < 1.0;
 
     // Determine number of clients (after we know num_warehouses for auto-scaling)
-    let num_clients = match num_clients_raw {
+    let mut num_clients = match num_clients_raw {
         Some(0) => compute_parallelism(num_warehouses), // Auto-scale
         Some(n) => n.max(1),                            // User-specified
         None => 1,                                      // Default: single client
     };
+
+    // Write-faithful mode is serial-only: the VibeSQL DML executors need `&mut Database`,
+    // which a shared (`Sync`) executor cannot provide across parallel clients. Force a single
+    // client so both engines run the identical serial write workload from an identical fresh
+    // DB (per-engine reload happens below), keeping the per-type ratio reproducible.
+    if write_faithful && num_clients > 1 {
+        eprintln!(
+            "Note: TPCC_WRITE_FAITHFUL=1 forces serial execution (num_clients=1); requested {} ignored.",
+            num_clients
+        );
+        num_clients = 1;
+    }
 
     // Parse engine filter (defaults to embedded databases only - no MySQL)
     let engine_filter = EngineFilter::from_env_embedded();
@@ -1372,6 +1546,9 @@ fn main() {
     eprintln!("  Duration: {} seconds", duration_secs);
     eprintln!("  Warmup: {} seconds", warmup_secs);
     eprintln!("  Transaction type: {}", transaction_type.name());
+    if write_faithful {
+        eprintln!("  Write-faithful: ON (real INSERT/UPDATE/DELETE; serial-only)");
+    }
     eprintln!("  Engines: {}", engine_filter.enabled_list());
     if num_clients > 1 {
         eprintln!("  Clients: {} (parallel mode)", num_clients);
@@ -1386,31 +1563,16 @@ fn main() {
     if engine_filter.vibesql {
         eprintln!("\nLoading VibeSQL TPC-C database (SF {})...", scale_factor);
         let load_start = Instant::now();
-        let vibesql_db = load_vibesql(scale_factor);
+        let mut vibesql_db = load_vibesql(scale_factor);
         eprintln!("VibeSQL loaded in {:?}", load_start.elapsed());
 
-        // Run VibeSQL benchmark using SQL execution (fair comparison with other databases)
-        eprintln!("\n--- VibeSQL Benchmark ---");
-        tpcc::transactions::reset_profile_counters();
-        let vibesql_executor = VibesqlTransactionExecutor::new(&vibesql_db);
-
-        vibesql_results = Some(if num_clients > 1 {
-            // Parallel multi-client execution
-            let (client_results, aggregate) = run_parallel_benchmark(
-                &vibesql_executor,
-                transaction_type,
-                num_warehouses,
-                num_clients,
-                duration,
-                warmup,
-                true,
-            );
-            print_parallel_results(&client_results, &aggregate, transaction_type);
-            aggregate
-        } else {
-            // Single-client execution (original behavior)
-            let results = run_benchmark(
-                &vibesql_executor,
+        if write_faithful {
+            // Write-faithful, serial path: owns `&mut Database` to drive real DML.
+            eprintln!("\n--- VibeSQL Benchmark (write-faithful) ---");
+            tpcc::transactions::reset_profile_counters();
+            let mut vibesql_executor = VibesqlWriteExecutor::new(&mut vibesql_db);
+            let results = run_write_benchmark(
+                &mut vibesql_executor,
                 transaction_type,
                 num_warehouses,
                 duration,
@@ -1418,24 +1580,69 @@ fn main() {
                 true,
             );
             print_results(&results, transaction_type);
-            results
-        });
+            tpcc::transactions::print_profile_summary();
 
-        tpcc::transactions::print_profile_summary();
+            let cache_stats = vibesql_executor.cache_stats();
+            eprintln!("\n--- Prepared Statement Cache ---");
+            eprintln!(
+                "Hits: {}  Misses: {}  Evictions: {}  Size: {}  Hit rate: {:.4}",
+                cache_stats.hits,
+                cache_stats.misses,
+                cache_stats.evictions,
+                cache_stats.size,
+                cache_stats.hit_rate
+            );
+            vibesql_results = Some(results);
+        } else {
+            // Run VibeSQL benchmark using SQL execution (fair comparison with other databases)
+            eprintln!("\n--- VibeSQL Benchmark ---");
+            tpcc::transactions::reset_profile_counters();
+            let vibesql_executor = VibesqlTransactionExecutor::new(&vibesql_db);
 
-        // Report prepared-statement cache effectiveness. With `?`-placeholder templates the
-        // cache key is the template, so misses are bounded by the number of distinct templates
-        // (a handful) and the hit rate approaches 1.0 — confirming the reparse was eliminated.
-        let cache_stats = vibesql_executor.cache_stats();
-        eprintln!("\n--- Prepared Statement Cache ---");
-        eprintln!(
-            "Hits: {}  Misses: {}  Evictions: {}  Size: {}  Hit rate: {:.4}",
-            cache_stats.hits,
-            cache_stats.misses,
-            cache_stats.evictions,
-            cache_stats.size,
-            cache_stats.hit_rate
-        );
+            vibesql_results = Some(if num_clients > 1 {
+                // Parallel multi-client execution
+                let (client_results, aggregate) = run_parallel_benchmark(
+                    &vibesql_executor,
+                    transaction_type,
+                    num_warehouses,
+                    num_clients,
+                    duration,
+                    warmup,
+                    true,
+                );
+                print_parallel_results(&client_results, &aggregate, transaction_type);
+                aggregate
+            } else {
+                // Single-client execution (original behavior)
+                let results = run_benchmark(
+                    &vibesql_executor,
+                    transaction_type,
+                    num_warehouses,
+                    duration,
+                    warmup,
+                    true,
+                );
+                print_results(&results, transaction_type);
+                results
+            });
+
+            tpcc::transactions::print_profile_summary();
+
+            // Report prepared-statement cache effectiveness. With `?`-placeholder templates
+            // the cache key is the template, so misses are bounded by the number of distinct
+            // templates (a handful) and the hit rate approaches 1.0 — confirming the reparse
+            // was eliminated.
+            let cache_stats = vibesql_executor.cache_stats();
+            eprintln!("\n--- Prepared Statement Cache ---");
+            eprintln!(
+                "Hits: {}  Misses: {}  Evictions: {}  Size: {}  Hit rate: {:.4}",
+                cache_stats.hits,
+                cache_stats.misses,
+                cache_stats.evictions,
+                cache_stats.size,
+                cache_stats.hit_rate
+            );
+        }
     } else {
         eprintln!("\nSkipping VibeSQL (filtered out by ENGINE_FILTER)");
     }
@@ -1447,7 +1654,26 @@ fn main() {
 
         // SQLite benchmark
         eprintln!("\n\n--- SQLite Benchmark ---");
-        Some(if num_clients > 1 {
+        Some(if write_faithful {
+            // Write-faithful, serial path: issues the same logical write set as VibeSQL
+            // against a fresh DB so the per-transaction ratio is apples-to-apples.
+            eprintln!("Loading SQLite database (write-faithful)...");
+            let sqlite_load_start = Instant::now();
+            let sqlite_conn = load_sqlite(scale_factor);
+            eprintln!("SQLite loaded in {:?}", sqlite_load_start.elapsed());
+
+            let mut sqlite_executor = SqliteWriteExecutor::new(&sqlite_conn);
+            let results = run_write_benchmark(
+                &mut sqlite_executor,
+                transaction_type,
+                num_warehouses,
+                duration,
+                warmup,
+                true,
+            );
+            print_results(&results, transaction_type);
+            results
+        } else if num_clients > 1 {
             // Parallel multi-client execution (each client gets its own DB)
             let (client_results, aggregate) = run_sqlite_parallel_benchmark(
                 scale_factor,
@@ -1656,6 +1882,67 @@ fn main() {
                 mysql_res.transactions_per_second,
                 compute_avg(mysql_res),
                 num_clients
+            );
+        }
+
+        // Per-transaction-type VibeSQL/SQLite ratio (same-run comparison). This is the
+        // headline comparative metric — absolute localhost TPS is NOT a success goal. A ratio
+        // > 1.0 means VibeSQL is slower than SQLite for that transaction type. Reads
+        // (Order-Status / Stock-Level) stay read-only in both engines; under
+        // TPCC_WRITE_FAITHFUL=1 the write txns (New-Order / Payment / Delivery) exercise the
+        // real write path, so comparing their ratio against the read ratio shows whether the
+        // write path opens a new relative gap.
+        if let (Some(ref v), Some(ref s)) = (&vibesql_results, &sqlite_results) {
+            let label = if write_faithful { "write-faithful" } else { "read-only" };
+            eprintln!("\n--- VibeSQL / SQLite avg-latency ratio per transaction type ({label}) ---");
+            eprintln!(
+                "(ratio > 1.0 => VibeSQL slower; same process, identical fresh DB per engine)"
+            );
+            eprintln!("{:<14} {:>14} {:>14} {:>10}", "Transaction", "VibeSQL (us)", "SQLite (us)", "Ratio");
+            eprintln!("{:-<14} {:->14} {:->14} {:->10}", "", "", "", "");
+
+            let print_ratio = |name: &str, v_avg: f64, v_cnt: u64, s_avg: f64, s_cnt: u64| {
+                if v_cnt == 0 || s_cnt == 0 {
+                    return;
+                }
+                let ratio = if s_avg > 0.0 { v_avg / s_avg } else { 0.0 };
+                eprintln!("{:<14} {:>14.2} {:>14.2} {:>10.2}", name, v_avg, s_avg, ratio);
+            };
+
+            print_ratio(
+                "New-Order",
+                v.new_order_avg_us,
+                v.new_order_count,
+                s.new_order_avg_us,
+                s.new_order_count,
+            );
+            print_ratio(
+                "Payment",
+                v.payment_avg_us,
+                v.payment_count,
+                s.payment_avg_us,
+                s.payment_count,
+            );
+            print_ratio(
+                "Order-Status",
+                v.order_status_avg_us,
+                v.order_status_count,
+                s.order_status_avg_us,
+                s.order_status_count,
+            );
+            print_ratio(
+                "Delivery",
+                v.delivery_avg_us,
+                v.delivery_count,
+                s.delivery_avg_us,
+                s.delivery_count,
+            );
+            print_ratio(
+                "Stock-Level",
+                v.stock_level_avg_us,
+                v.stock_level_count,
+                s.stock_level_avg_us,
+                s.stock_level_count,
             );
         }
     }


### PR DESCRIPTION
## Summary

The TPC-C harness (`crates/vibesql-executor/benches/tpcc/transactions.rs`) modeled all five transactions as SELECTs only, so write-path costs — delete compaction (`should_compact()`), delete-time index maintenance (`update_for_delete`/`batch_update_for_delete`), and WAL flush — were invisible. The read-only TPS was therefore an upper bound on true mixed OLTP throughput.

This adds a write-faithful variant of New-Order, Payment, and Delivery that issues **real INSERT/UPDATE/DELETE**, gated by a new `TPCC_WRITE_FAITHFUL` env flag (default off). Order-Status and Stock-Level stay read-only (they are reads in real TPC-C). The harness emits per-transaction-type VibeSQL/SQLite latency ratios from a single same-run invocation.

## Changes

- **`execute_dml()` helper** (`tpcc/transactions.rs`): binds the same `?`-placeholder templates through the prepared-statement cache, then dispatches on the `Insert`/`Update`/`Delete` AST variant to `InsertExecutor`/`UpdateExecutor`/`DeleteExecutor`. `execute_query` `match`es only `Statement::Select` and silently drops DML, so it cannot be reused for writes (the #5761 templating pattern itself carries over cleanly).
- **`TPCCWriteExecutor` trait** (`&mut self`) plus `VibesqlWriteExecutor` and `SqliteWriteExecutor` issuing the **identical logical write set** so the ratio reflects engine cost, not differing work.
- **Serial-only concurrency resolution**: the VibeSQL DML executors require `db: &mut Database`, but the shared `&Database` read-only executor is `Sync` across parallel clients and cannot drive `&mut` DML. Write-faithful forces `num_clients=1` with an owned `&mut Database`, running through a dedicated serial `run_write_benchmark`. No per-client owned DBs, no unsafe aliasing, no interior-mutability hacks. Documented in the bench header.
- **Per-type VibeSQL/SQLite ratio reporting** added to the comparison summary, labeled `write-faithful` / `read-only`.
- New-Order advances `district.d_next_o_id` and uses it as the new `o_id`, keeping orders/order_line/new_order primary keys unique across repeated transactions; Delivery skips districts with no pending `new_order` (no panic).

## Concurrency choice (per issue requirement)

**Serial-only (option 1)** was chosen. Rationale: comparative per-transaction latency does not require parallelism; this keeps the diff small and stays within the scope guard (no engine changes). Per-client owned DBs (option 2) are deferred until parallel write numbers are explicitly wanted.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `TPCC_WRITE_FAITHFUL` gates write-faithful New-Order/Payment/Delivery (real DML); Order-Status/Stock-Level read-only | ✅ | Flag in `main()`; write txns route through `execute_dml`; reads unchanged |
| Writes execute through real DML executors, not `SelectExecutor`; no SQL-bypassing fast path | ✅ | `execute_dml` dispatches to `InsertExecutor`/`UpdateExecutor`/`DeleteExecutor` against `&mut Database` |
| `&mut Database` parallelism constraint resolved per a documented option | ✅ | Serial-only (option 1); forces `num_clients=1`; noted in bench header |
| Per-type latency reported as VibeSQL/SQLite ratio from one `ENGINE_FILTER=vibesql,sqlite` process; absolute TPS not the metric | ✅ | Ratio table emitted; see run below |
| SQLite runs the same logical write set (apples-to-apples) | ✅ | `SqliteWriteExecutor` mirrors the VibeSQL write set |
| Read-only behavior unchanged when flag unset | ✅ | Verified: flag-off run shows no write-faithful path, original read-only table preserved |
| No changes under `crates/vibesql-storage/` or executor engine | ✅ | `git diff --name-only` = only the two bench files |
| `cargo check`/bench compiles; short run 100% txn success | ✅ | `cargo check`/`clippy` clean on `tpcc_benchmark`; run below = 100% success both engines |

## Test Plan / Same-run results

`TPCC_WRITE_FAITHFUL=1 ENGINE_FILTER=vibesql,sqlite TPCC_DURATION_SECS=8 TPCC_SCALE_FACTOR=1` (single process, fresh DB per engine), 100% txn success on both engines:

```
--- VibeSQL / SQLite avg-latency ratio per transaction type (write-faithful) ---
Transaction      VibeSQL (us)    SQLite (us)      Ratio
New-Order              452.68         138.00       3.28
Payment                 46.65          16.86       2.77
Order-Status            52.44          17.65       2.97
Delivery           1480312.17         392.34    3773.04
Stock-Level            472.23        6836.61       0.07
```

**Interpretation (comparative, not absolute):** New-Order and Payment writes track the read-only ratio (~2.8–3.3x, comparable to Order-Status's 2.97x read ratio) — the write path does **not** open a new large relative gap for INSERT/UPDATE. **Delivery is the exception**: its `DELETE FROM new_order` runs ~1.48 s/txn (3773x SQLite), so only 6 deliveries completed in 8 s. This is the catastrophic write-path cost the issue set out to make measurable — the harness is doing its job.

Flag **unset** (regression check): VibeSQL read-only path runs as before (faster than SQLite on pure reads), no write-faithful output, original summary table intact.

## Write-path observation worth a follow-up

VibeSQL's `DELETE FROM new_order` in Delivery is pathologically slow (~148 ms per single-row delete at SF=1, where `new_order` holds ~9k rows). This points squarely at the delete-time path the issue anchored — `Table::should_compact()` (`crates/vibesql-storage/src/table/mod.rs`) and `update_for_delete`/`batch_update_for_delete` (`indexes.rs`). Per the scope guard this PR does **not** touch storage; recommend a follow-up issue to profile and fix single-row delete compaction / index maintenance on large tables.

## Notes

- A near-duplicate harness at `crates/vibesql-server/benches/tpcc/transactions.rs` is intentionally out of scope (separate follow-up).
- Pre-existing, unrelated: the `tpcds_benchmark` bench in this crate fails to compile on `origin/main` (`random_range` / `rand` API). Not touched here; `tpcc_benchmark` builds clean.

Closes #5757