### PR TITLE
fix(tcl): forward --timeout from tcltest and surface timed-out files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,16 +276,18 @@ test-sqllogictest-halting:
 # Run SQLite TCL test suite (Priority 1 - core SQL tests)
 # This is the canonical SQLite conformance test suite
 # Uses errors-only mode by default. Add --verbose for full output.
+# Override the per-file timeout with TCL_TIMEOUT=<seconds> (default: 1200).
+TCL_TIMEOUT ?= 1200
 test-tcl:
 	@echo "Running SQLite TCL test suite (Priority 1 - core SQL)..."
 	@echo "Tests: select, insert, update, delete, where, join, aggregate, func"
-	./scripts/tcltest run --priority 1
+	./scripts/tcltest run --priority 1 --timeout $(TCL_TIMEOUT)
 
 # Run all SQLite TCL tests (all priorities)
 # Uses errors-only mode by default. Add --verbose for full output.
 test-tcl-all:
 	@echo "Running full SQLite TCL test suite (all 1174 files)..."
-	./scripts/tcltest run
+	./scripts/tcltest run --timeout $(TCL_TIMEOUT)
 
 # Run specific TCL test file
 test-tcl-file:
@@ -293,7 +295,7 @@ test-tcl-file:
 		echo "Usage: make test-tcl-file FILE=select1.test"; \
 		exit 1; \
 	fi
-	./scripts/tcltest test $(FILE)
+	./scripts/tcltest test $(FILE) --timeout $(TCL_TIMEOUT)
 
 # Show TCL test status
 test-tcl-status:

--- a/scripts/tcl_runner.py
+++ b/scripts/tcl_runner.py
@@ -822,7 +822,7 @@ def save_to_database(summary: RunSummary, db_path: str, vibesql_path: str):
 TCL_DETAIL_PREFIX = "##TCLTEST## "
 
 
-def run_native_tcl(test_file: str, shim_path: str, verbose: bool = False, timeout: float = 60.0) -> tuple[int, int, int, list[str], list[TestResult]]:
+def run_native_tcl(test_file: str, shim_path: str, verbose: bool = False, timeout: float = 1200.0) -> tuple[int, int, int, list[str], list[TestResult]]:
     """
     Run a TCL test file using the native tclsh interpreter with our VibeSQL shim.
 
@@ -917,8 +917,22 @@ def run_native_tcl(test_file: str, shim_path: str, verbose: bool = False, timeou
         return passed, failed, skipped, failed_tests, per_test_results
 
     except subprocess.TimeoutExpired:
-        print(f"Timeout running {test_file}")
-        return 0, 0, 0, ["TIMEOUT"], []
+        print(f"Timeout running {test_file} (exceeded {timeout:.0f}s)")
+        # Surface the timeout as a visible non-pass result instead of silently
+        # dropping the file from the totals. We emit one synthetic failed detail
+        # row so the file still appears in tcl_test_results and counts toward the
+        # summary's failed total, keeping the summary and detail tables
+        # reconciled (see CLAUDE.md). Without this a timed-out file contributed
+        # zero rows and vanished from the measured suite.
+        timeout_result = TestResult(
+            test_name=f"TIMEOUT (exceeded {timeout:.0f}s)",
+            file_path=test_file,
+            test_type="native-tcl",
+            status="failed",
+            sql="",
+            error_message=f"Test file timed out after {timeout:.0f}s",
+        )
+        return 0, 1, 0, ["TIMEOUT"], [timeout_result]
     except Exception as e:
         print(f"Error running {test_file}: {e}")
         return 0, 0, 0, [str(e)], []
@@ -933,7 +947,7 @@ def main():
     parser.add_argument("--output", "-o", help="Output JSON file")
     parser.add_argument("--parallel", action="store_true", help="Run tests in parallel")
     parser.add_argument("--verbose", "-v", action="store_true")
-    parser.add_argument("--timeout", type=float, default=None, help="Per-test timeout in seconds (default: 5 for static mode, 300 for native TCL)")
+    parser.add_argument("--timeout", type=float, default=None, help="Per-file timeout in seconds (default: 5 for static mode, 1200 for native TCL)")
     parser.add_argument("--native-tcl", action="store_true",
                         help="Run tests using native tclsh instead of parsing (for files with TCL loops)")
     parser.add_argument("--tcl-shim", default=None,
@@ -948,7 +962,11 @@ def main():
     # Set appropriate timeout defaults based on mode
     if args.timeout is None:
         if args.native_tcl:
-            args.timeout = 300.0  # 5 minutes for native TCL (handles heavy INSERT tests)
+            # 20 minutes for native TCL. The per-statement-process shim makes
+            # large auto-generated files (e.g. the Bloom-filter join suite
+            # joinB/C/D/E.test, ~1,974 tests) slow; the prior 300s default timed
+            # them out and silently dropped ~80% of the suite from the totals.
+            args.timeout = 1200.0
         else:
             args.timeout = 5.0   # 5 seconds for static parsing mode
 

--- a/scripts/tcltest
+++ b/scripts/tcltest
@@ -193,9 +193,11 @@ Options for 'run':
   --parallel               Run tests in parallel
   --verbose                Show detailed output
   --no-native-tcl          Use static parsing instead of native tclsh
+  --timeout SECONDS        Per-file timeout (default: 1200 native, 5 static)
 
 Options for 'test':
   --no-native-tcl          Use static parsing instead of native tclsh
+  --timeout SECONDS        Per-file timeout (default: 1200 native, 5 static)
 
 Note: Native tclsh mode is used by default. This correctly handles TCL constructs
 like loops that cannot be statically parsed.
@@ -284,6 +286,7 @@ EOF
 cmd_test() {
     local native_tcl=true  # Default to native TCL mode
     local verbose=false
+    local timeout=""
     local test_file=""
 
     # Parse arguments
@@ -303,11 +306,13 @@ Options:
   --native-tcl       Use native tclsh (default, handles TCL loops)
   --no-native-tcl    Use static parsing instead of native tclsh
   --verbose          Show detailed output including expected vs actual
+  --timeout SECONDS  Per-file timeout (default: 1200 native, 5 static)
 
 Examples:
   ./scripts/tcltest test select1.test
   ./scripts/tcltest test select1.test --verbose
   ./scripts/tcltest test select1.test --no-native-tcl
+  ./scripts/tcltest test joinB.test --timeout 1800
 EOF
                 exit 0
                 ;;
@@ -322,6 +327,10 @@ EOF
             --verbose)
                 verbose=true
                 shift
+                ;;
+            --timeout)
+                timeout="$2"
+                shift 2
                 ;;
             *)
                 if [ -z "$test_file" ]; then
@@ -375,6 +384,10 @@ EOF
         py_args+=("--verbose")
     fi
 
+    if [ -n "$timeout" ]; then
+        py_args+=("--timeout" "$timeout")
+    fi
+
     python3 "${py_args[@]}"
 }
 
@@ -386,6 +399,7 @@ cmd_run() {
     local parallel=false
     local verbose=false
     local native_tcl=true  # Default to native TCL mode
+    local timeout=""
 
     # Parse arguments
     while [[ $# -gt 0 ]]; do
@@ -405,6 +419,7 @@ Options:
   --verbose                Show detailed output
   --native-tcl             Use native tclsh (default, handles TCL loops)
   --no-native-tcl          Use static parsing instead of native tclsh
+  --timeout SECONDS        Per-file timeout (default: 1200 native, 5 static)
 
 Examples:
   # Run Priority 1 tests (core SQL)
@@ -448,6 +463,10 @@ EOF
             --no-native-tcl)
                 native_tcl=false
                 shift
+                ;;
+            --timeout)
+                timeout="$2"
+                shift 2
                 ;;
             *)
                 print_error "Unknown option: $1"
@@ -525,6 +544,10 @@ EOF
 
     if $native_tcl; then
         py_args+=("--native-tcl")
+    fi
+
+    if [ -n "$timeout" ]; then
+        py_args+=("--timeout" "$timeout")
     fi
 
     # Add files


### PR DESCRIPTION
## Summary

`scripts/tcltest`'s `cmd_run()` and `cmd_test()` never passed a `--timeout` to `scripts/tcl_runner.py`, so `make test-tcl` / `test-tcl-all` ran with the native-tcl **300s** default. Slow auto-generated files (the Bloom-filter join suite `joinB/C/D/E.test`, ~1,974 tests) exceeded that limit, timed out, and `run_native_tcl()` returned `0,0,0,["TIMEOUT"],[]` — contributing **zero rows** and silently dropping ~80% of the measured suite (run_id 26: 11,812 tests vs run_id 27 with `--timeout 1200`: 63,416 on the same 158 files).

This PR plumbs `--timeout` through the shell wrapper, raises the native-tcl default, and makes timeouts visible instead of silently dropped.

## Changes

- **`scripts/tcltest`**: add a `--timeout SECONDS` option to `cmd_run()` and `cmd_test()`, forwarding it to `tcl_runner.py --timeout`; document it in the per-command `--help` heredocs and the main help.
- **`scripts/tcl_runner.py`**: raise the native-tcl default timeout from `300.0` to `1200.0` (20 min); update the `--help` text, the inline comment, and the `run_native_tcl` signature default. Static-parsing mode keeps its 5s default.
- **`scripts/tcl_runner.py`**: on `subprocess.TimeoutExpired`, emit one synthetic `status="failed"` `TestResult` (test name `TIMEOUT (exceeded Ns)`) and return `failed=1` so the file appears in `tcl_test_results` and counts toward the summary's failed total — keeping the summary and detail tables reconciled.
- **`Makefile`**: add an overridable `TCL_TIMEOUT ?= 1200` variable forwarded by `test-tcl`, `test-tcl-all`, and `test-tcl-file`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `tcltest run/test --timeout N` forwards to the runner | ✅ | Stubbed `python3`/`vibesql`: `run --timeout 1800` and `test --timeout 900` produce `--timeout` in argv; omitting it produces none |
| Default native-tcl timeout ≥1200s | ✅ | `tcl_runner.py --help` shows "1200 for native TCL"; default set to `1200.0` |
| Timed-out files no longer silently absent | ✅ | Unit-style call of `run_native_tcl` with a sleeping shim returns `failed=1` and a `status=failed` detail row (`TIMEOUT (exceeded 1s)`) |
| Summary/detail tables still reconcile | ✅ | Timeout increments `failed` and emits exactly one matching `failed` detail row |
| `--help` documents `--timeout` for both subcommands | ✅ | `tcltest run --help` and `tcltest test --help` both list `--timeout SECONDS` |

## Test Plan

- `bash -n scripts/tcltest` and `python3 -c "ast.parse(...)"` pass.
- Forwarding verified end-to-end with stub `python3`/`vibesql`: `--timeout` reaches argv only when supplied.
- Timeout path verified by invoking `run_native_tcl()` with a fake shim that sleeps past a 1s timeout: returns `failed=1` plus a visible `status=failed` detail row.
- A full `make test-tcl` (which now defaults to 1200s) was not run here because the release binary is not built in this worktree; the default + forwarding changes are the mechanism that lets the slow join suite be counted (per the run_id 27 evidence in the issue).

Closes #5764