### PR TITLE
fix(executor): apply TEXT affinity to numeric literals compared with TEXT columns

### DIFF
--- a/crates/vibesql-executor/src/evaluator/compiled.rs
+++ b/crates/vibesql-executor/src/evaluator/compiled.rs
@@ -14,6 +14,7 @@
 use vibesql_ast::{BinaryOperator, Expression};
 use vibesql_types::SqlValue;
 
+use super::expressions::eval::format_float_for_text_comparison;
 use crate::schema::CombinedSchema;
 
 /// A compiled predicate that can be evaluated efficiently without expression traversal
@@ -204,7 +205,8 @@ impl CompiledPredicate {
             if !Self::literal_supported_for_column(schema, col_idx, value) {
                 return None;
             }
-            return Self::compile_comparison_with_idx(col_idx, op, value.clone(), false);
+            let value = Self::coerce_literal_for_column(schema, col_idx, value.clone());
+            return Self::compile_comparison_with_idx(col_idx, op, value, false);
         }
 
         // Try literal <op> col (reverse the operator)
@@ -214,10 +216,68 @@ impl CompiledPredicate {
             if !Self::literal_supported_for_column(schema, col_idx, value) {
                 return None;
             }
-            return Self::compile_comparison_with_idx(col_idx, op, value.clone(), true);
+            let value = Self::coerce_literal_for_column(schema, col_idx, value.clone());
+            return Self::compile_comparison_with_idx(col_idx, op, value, true);
         }
 
         None
+    }
+
+    /// Issue #5765: apply the column's TEXT affinity to a numeric literal at
+    /// compile time so the compiled fast path matches the interpreted
+    /// evaluator's `apply_affinity_for_comparison` Case 1
+    /// (`evaluator/expressions/eval.rs`).
+    ///
+    /// SQLite rule: comparing a TEXT-affinity column against a numeric literal
+    /// applies TEXT affinity to the literal (renders the number as text) and
+    /// performs a string comparison — so `'2' = 2` is true but `'2.0' = 2` is
+    /// false (`'2.0' != '2'`). Without this, `values_equal` would parse the
+    /// stored text as a number and compare numerically (`2.0 == 2` -> true),
+    /// wrongly matching both rows.
+    ///
+    /// The numeric->text rendering mirrors Case 1 exactly: integers via
+    /// `to_string()`, floating-point via `format_float_for_text_comparison`
+    /// (which preserves the decimal point, so TEXT `'10'` does NOT equal REAL
+    /// `10.0`). Returns the literal unchanged for non-TEXT columns (NUMERIC /
+    /// REAL / INTEGER affinity keep numeric comparison) and for non-numeric
+    /// literals.
+    fn coerce_literal_for_column(
+        schema: &CombinedSchema,
+        col_idx: usize,
+        value: SqlValue,
+    ) -> SqlValue {
+        use vibesql_types::TypeAffinity;
+
+        // Only TEXT-affinity columns coerce the literal. Bare columns (no
+        // declared type) have NONE affinity and use type ordering instead, so
+        // leave them alone — matching the evaluator, which restricts Case 1 to
+        // `TypeAffinity::Text`.
+        match schema.get_column_type_by_index(col_idx) {
+            Some(col_type) if col_type.sqlite_affinity() == TypeAffinity::Text => {}
+            _ => return value,
+        }
+
+        match value {
+            SqlValue::Integer(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+            SqlValue::Smallint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+            SqlValue::Bigint(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+            SqlValue::Unsigned(n) => SqlValue::Varchar(arcstr::ArcStr::from(n.to_string())),
+            SqlValue::Float(n) => SqlValue::Varchar(arcstr::ArcStr::from(
+                format_float_for_text_comparison(f64::from(n)),
+            )),
+            SqlValue::Real(n) => {
+                SqlValue::Varchar(arcstr::ArcStr::from(format_float_for_text_comparison(n)))
+            }
+            SqlValue::Double(n) => {
+                SqlValue::Varchar(arcstr::ArcStr::from(format_float_for_text_comparison(n)))
+            }
+            SqlValue::Numeric(n) => {
+                SqlValue::Varchar(arcstr::ArcStr::from(format_float_for_text_comparison(n)))
+            }
+            // Non-numeric literals (already text, temporal, blob, etc.) are
+            // unaffected by TEXT affinity coercion.
+            other => other,
+        }
     }
 
     /// Issue #5335: decide whether `values_equal` / `compare_range` can
@@ -999,6 +1059,146 @@ mod tests {
             SqlValue::Varchar(arcstr::ArcStr::from("test")),
         ]);
         assert_eq!(compiled.evaluate(&row), Some(false));
+    }
+
+    /// Schema with a single TEXT-affinity column `a` (matches `indexA.test`'s
+    /// `CREATE TABLE x1(a TEXT, ...)`).
+    fn create_text_col_schema() -> CombinedSchema {
+        let columns = vec![ColumnSchema::new(
+            "a".to_string(),
+            DataType::Varchar { max_length: None },
+            true,
+        )];
+        let schema = TableSchema::new("x1".to_string(), columns);
+        CombinedSchema::from_table("x1".to_string(), schema)
+    }
+
+    /// Schema with a single NUMERIC-affinity column `a`
+    /// (matches `indexA.test`'s `CREATE TABLE x2(a NUMERIC, ...)`).
+    fn create_numeric_col_schema() -> CombinedSchema {
+        let columns = vec![ColumnSchema::new(
+            "a".to_string(),
+            DataType::Numeric { precision: 10, scale: 0 },
+            true,
+        )];
+        let schema = TableSchema::new("x2".to_string(), columns);
+        CombinedSchema::from_table("x2".to_string(), schema)
+    }
+
+    fn col_op_lit(op: BinaryOperator, lit: SqlValue) -> Expression {
+        Expression::BinaryOp {
+            left: Box::new(Expression::ColumnRef(
+                vibesql_ast::ColumnIdentifier::simple("a", false),
+            )),
+            op,
+            right: Box::new(Expression::Literal(lit)),
+        }
+    }
+
+    fn lit_op_col(lit: SqlValue, op: BinaryOperator) -> Expression {
+        Expression::BinaryOp {
+            left: Box::new(Expression::Literal(lit)),
+            op,
+            right: Box::new(Expression::ColumnRef(
+                vibesql_ast::ColumnIdentifier::simple("a", false),
+            )),
+        }
+    }
+
+    fn text_row(s: &str) -> Row {
+        Row::from_vec(vec![SqlValue::Varchar(arcstr::ArcStr::from(s))])
+    }
+
+    /// Issue #5765: a TEXT-affinity column compared to a numeric literal must
+    /// apply TEXT affinity to the literal and compare as strings, so the
+    /// compiled fast path matches `apply_affinity_for_comparison` Case 1 and
+    /// the SQLite `indexA.test` expectations (`SELECT ... WHERE a=2` on a TEXT
+    /// column returns only the `'2'` row, not `'2.0'`).
+    #[test]
+    fn test_text_col_vs_numeric_literal_affinity() {
+        let schema = create_text_col_schema();
+
+        // a = 2 (INTEGER literal) -> coerce literal to '2', string compare.
+        let expr = col_op_lit(BinaryOperator::Equal, SqlValue::Integer(2));
+        let compiled = CompiledPredicate::compile(&expr, &schema);
+        assert!(
+            compiled.is_fully_compiled(),
+            "TEXT col = INTEGER must stay on the compiled fast path"
+        );
+        // The literal must have been rendered to text at compile time.
+        if let CompiledPredicate::Equals { value, .. } = &compiled {
+            assert_eq!(*value, SqlValue::Varchar(arcstr::ArcStr::from("2")));
+        } else {
+            panic!("expected Equals predicate");
+        }
+        assert_eq!(compiled.evaluate(&text_row("2")), Some(true), "'2' = 2 -> true");
+        assert_eq!(compiled.evaluate(&text_row("2.0")), Some(false), "'2.0' = 2 -> false");
+
+        // a = 2.0 (REAL literal) -> coerce literal to '2.0', string compare.
+        let expr = col_op_lit(BinaryOperator::Equal, SqlValue::Real(2.0));
+        let compiled = CompiledPredicate::compile(&expr, &schema);
+        if let CompiledPredicate::Equals { value, .. } = &compiled {
+            assert_eq!(*value, SqlValue::Varchar(arcstr::ArcStr::from("2.0")));
+        } else {
+            panic!("expected Equals predicate");
+        }
+        assert_eq!(compiled.evaluate(&text_row("2")), Some(false), "'2' = 2.0 -> false");
+        assert_eq!(compiled.evaluate(&text_row("2.0")), Some(true), "'2.0' = 2.0 -> true");
+    }
+
+    /// Symmetric form: numeric literal on the left (`2 = a`) must coerce the
+    /// same way as `a = 2`.
+    #[test]
+    fn test_text_col_vs_numeric_literal_symmetric() {
+        let schema = create_text_col_schema();
+
+        let expr = lit_op_col(SqlValue::Integer(2), BinaryOperator::Equal);
+        let compiled = CompiledPredicate::compile(&expr, &schema);
+        assert!(compiled.is_fully_compiled());
+        assert_eq!(compiled.evaluate(&text_row("2")), Some(true), "2 = '2' -> true");
+        assert_eq!(compiled.evaluate(&text_row("2.0")), Some(false), "2 = '2.0' -> false");
+    }
+
+    /// NotEqual must be the logical negation of Equal under TEXT affinity.
+    #[test]
+    fn test_text_col_vs_numeric_literal_not_equal() {
+        let schema = create_text_col_schema();
+
+        let expr = col_op_lit(BinaryOperator::NotEqual, SqlValue::Integer(2));
+        let compiled = CompiledPredicate::compile(&expr, &schema);
+        assert!(compiled.is_fully_compiled());
+        assert_eq!(compiled.evaluate(&text_row("2")), Some(false), "'2' <> 2 -> false");
+        assert_eq!(compiled.evaluate(&text_row("2.0")), Some(true), "'2.0' <> 2 -> true");
+    }
+
+    /// Float text representation must be preserved: TEXT '10' does NOT equal
+    /// REAL 10.0 (rendered as '10.0'), but TEXT '10.0' does.
+    #[test]
+    fn test_text_col_vs_real_preserves_decimal_point() {
+        let schema = create_text_col_schema();
+
+        let expr = col_op_lit(BinaryOperator::Equal, SqlValue::Real(10.0));
+        let compiled = CompiledPredicate::compile(&expr, &schema);
+        if let CompiledPredicate::Equals { value, .. } = &compiled {
+            assert_eq!(*value, SqlValue::Varchar(arcstr::ArcStr::from("10.0")));
+        } else {
+            panic!("expected Equals predicate");
+        }
+        assert_eq!(compiled.evaluate(&text_row("10")), Some(false), "'10' = 10.0 -> false");
+        assert_eq!(compiled.evaluate(&text_row("10.0")), Some(true), "'10.0' = 10.0 -> true");
+    }
+
+    /// Regression guard: NUMERIC-affinity columns must NOT have the literal
+    /// coerced to text — they keep numeric comparison semantics (so `'2.0' = 2`
+    /// matches numerically, matching `indexA.test` x2 expectations).
+    #[test]
+    fn test_numeric_col_literal_not_coerced() {
+        let schema = create_numeric_col_schema();
+        let value = CompiledPredicate::coerce_literal_for_column(&schema, 0, SqlValue::Integer(2));
+        assert_eq!(value, SqlValue::Integer(2), "NUMERIC column literal must stay numeric");
+
+        let value = CompiledPredicate::coerce_literal_for_column(&schema, 0, SqlValue::Real(2.0));
+        assert_eq!(value, SqlValue::Real(2.0), "NUMERIC column REAL literal must stay numeric");
     }
 
     #[test]

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -10,7 +10,11 @@ use crate::errors::ExecutorError;
 /// SQLite ensures floats always have a decimal point when converted to text.
 /// For example, 10.0 becomes "10.0", not "10". This is important for type
 /// affinity comparisons where TEXT '10' should not equal REAL 10.0.
-fn format_float_for_text_comparison(n: f64) -> String {
+///
+/// Shared with the compiled fast path (`evaluator::compiled`) so that compiled
+/// and interpreted comparisons render numeric literals identically when applying
+/// TEXT affinity (issue #5765).
+pub(crate) fn format_float_for_text_comparison(n: f64) -> String {
     if n.is_nan() {
         return "NaN".to_string();
     }

--- a/crates/vibesql-executor/src/evaluator/expressions/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/mod.rs
@@ -8,7 +8,7 @@
 //! - `operators` - Operator evaluation (unary +/-)
 //! - `fulltext` - Full-text search evaluation (MATCH...AGAINST)
 
-mod eval;
+pub(crate) mod eval;
 pub(crate) mod fulltext;
 pub(crate) mod operators;
 mod predicates;

--- a/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
@@ -398,6 +398,20 @@ fn value_supported_for_column(col_type: Option<&DataType>, value: &SqlValue) -> 
         // Boolean and Boolean vs numeric compare faithfully in both paths
         // (booleans coerce to 0/1).
         Some(DataType::Boolean) => matches!(value, SqlValue::Boolean(_)) || is_numeric_value(value),
+        // Issue #5765: TEXT-affinity column compared against a numeric literal.
+        // SQLite applies TEXT affinity to the literal (renders the number as
+        // text) and compares as strings, so `'2' = 2` is true but `'2.0' = 2`
+        // is false. The columnar comparators instead coerce the stored text to
+        // a number and compare numerically (`2.0 == 2` -> true), wrongly
+        // matching both rows. There is no faithful columnar arm, so decline
+        // pushdown and let the evaluator's `apply_affinity_for_comparison`
+        // Case 1 handle it. NUMERIC/REAL/INTEGER columns keep numeric
+        // comparison and are unaffected.
+        Some(other)
+            if other.sqlite_affinity() == TypeAffinity::Text && is_numeric_value(value) =>
+        {
+            false
+        }
         Some(other) => match value {
             // Temporal literal against a non-temporal column: only string
             // columns have comparator support (parse-first for Date, TEXT


### PR DESCRIPTION
## Summary

A TEXT-affinity column compared to a numeric literal (e.g. `WHERE a = 2` where `a` is `TEXT`) was evaluated by coercing the stored text to a number and comparing numerically, so `'2.0' = 2` wrongly matched. Per SQLite affinity rules, TEXT affinity is applied to the **literal** and the comparison is performed as strings: `'2' = 2` is true but `'2.0' = 2` is false.

This is a comparison/affinity bug, not a partial-index feature gap (partial indexes already work end-to-end). It surfaces in `indexA.test`, whose `tn=0` cases fail with no index at all.

## Changes

- **`evaluator/compiled.rs`** — compiled predicate fast path: coerce a numeric literal to its TEXT rendering at compile time for TEXT-affinity columns (`coerce_literal_for_column`), mirroring the interpreted evaluator's `apply_affinity_for_comparison` Case 1. Integers via `to_string`, floats via the shared `format_float_for_text_comparison` (preserves the decimal point, so TEXT `'10'` != REAL `10.0`). Adds unit tests.
- **`select/columnar/filter/predicates.rs`** — columnar predicate pushdown (the path table scans actually use for `text_col = <number>`): decline pushdown for a TEXT-affinity column vs a numeric literal so the correct interpreted evaluator runs.
- **`evaluator/expressions/eval.rs` / `expressions/mod.rs`** — promote `format_float_for_text_comparison` to `pub(crate)` and expose `eval` so the compiled path shares the exact numeric->text rendering (keeps the two evaluator paths in sync).

NUMERIC / REAL / INTEGER affinity columns keep numeric comparison (no regression).

## Note on curator analysis

The curator correctly identified the root cause (TEXT-col vs numeric-literal affinity) and pointed at `compiled.rs`. During implementation I found the runtime path for plain table-scan equality is the **columnar predicate pushdown**, not the compiled predicate — so the fix had to be applied there too. Both paths are now fixed and kept consistent with the interpreted evaluator. The curator's "20 failures" baseline was stale; the real baseline at HEAD is 2 affinity failures (see below).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `SELECT *, typeof(a) FROM x1 WHERE a=2` (TEXT) returns only `{2 two ii text}` | ✅ | Verified via CLI repro (1 row) |
| `WHERE a=2.0` returns only `{2.0 twopointoh ii.0 text}` | ✅ | Verified via CLI repro (1 row) |
| indexA affinity failures fixed | ✅ | `indexA.test` 0 failures (was 2 at HEAD) |
| No regression in NUMERIC (x2) / REAL (x3) cases | ✅ | x2/x3 unaffected; `test_numeric_col_literal_not_coerced` |
| Float text representation preserved (TEXT '10' != REAL 10.0) | ✅ | `test_text_col_vs_real_preserves_decimal_point` |
| No Priority-1 TCL regression | ✅ | `select1` 11/11; `where` identical before/after (pre-existing 149 fails) |

## Test Plan

- `cargo test -p vibesql-executor --lib` — 3030 passed, 0 failed (incl. 5 new affinity tests).
- `cargo clippy -p vibesql-executor --lib` — no errors.
- `TCL_TIMEOUT=180 make test-tcl-file FILE=indexA.test`:
  - **Before:** 2 failures (`2.1.0.1`, `2.1.0.2`).
  - **After:** 0 failures (14 passed, 7 skipped).
- Regression spot-check: `select1` 11/11 pass; `where` identical before/after.

## Known pre-existing limitation (out of scope)

indexA still skips 7 tests because the suite aborts at iteration-2 setup with "index i1 already exists": `DROP INDEX IF EXISTS` on a partial index does not persist across process restarts (confirmed reproducible on the unmodified baseline, independent of this fix). This is a separate WAL/DDL-recovery bug that should be tracked in a follow-up issue.

Closes #5765