### PR TITLE
fix(wal): resume LSN across CLI restarts so committed DML survives reopen

### DIFF
--- a/crates/vibesql-cli/src/executor/wal.rs
+++ b/crates/vibesql-cli/src/executor/wal.rs
@@ -87,12 +87,26 @@ impl WalState {
         let paths = WalPaths::derive(db_path);
 
         // Step 1: recover from the last checkpoint + replay post-checkpoint WAL.
-        // (Phase 1: DDL is replayed; DML replay is a Phase 2 stub — see module docs.)
         let manager = RecoveryManager::new(&paths.checkpoint_dir).with_wal(&paths.wal_path);
-        let (mut db, _stats) = manager.recover()?;
+        let (mut db, stats) = manager.recover()?;
 
         // Step 2: attach the live persistence engine so new ops hit the WAL.
-        let engine = PersistenceEngine::new(&paths.wal_path, PersistenceConfig::default())?;
+        //
+        // Crucially, resume LSN numbering *past* everything recovery saw
+        // (`last_lsn` covers the loaded checkpoint and every WAL entry). Each new
+        // checkpoint is stamped from `persistence_next_lsn`, and recovery selects
+        // the checkpoint with the highest LSN. If we restarted LSNs at 1 on every
+        // open (the pre-#5766 behavior), a later process's checkpoint could carry
+        // a *lower* LSN than an earlier one and recovery would resurrect stale,
+        // pre-mutation state — silently losing committed DELETE/UPDATE/INSERT data
+        // across CLI restarts. Resuming at `last_lsn + 1` keeps checkpoint LSNs
+        // monotonic so the newest committed state always wins.
+        let resume_lsn = stats.last_lsn.saturating_add(1);
+        let engine = PersistenceEngine::open_with_start_lsn(
+            &paths.wal_path,
+            PersistenceConfig::default(),
+            resume_lsn,
+        )?;
         db.enable_persistence(engine);
 
         let checkpoint_writer = CheckpointWriter::new(&paths.checkpoint_dir)?;

--- a/crates/vibesql-cli/tests/wal_recovery_test.rs
+++ b/crates/vibesql-cli/tests/wal_recovery_test.rs
@@ -363,3 +363,95 @@ fn test_subprocess_committed_rows_survive_sigkill() {
         );
     }
 }
+
+/// Run a one-shot `vibesql <db> < script` invocation to completion (clean exit).
+#[cfg(unix)]
+fn run_script(binary: &str, db: &Path, home: &Path, script: &str) -> String {
+    use std::io::Write;
+
+    let mut child = Command::new(binary)
+        .arg(db)
+        .env("HOME", home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn vibesql");
+    {
+        let mut stdin = child.stdin.take().expect("child stdin");
+        stdin.write_all(script.as_bytes()).unwrap();
+        stdin.flush().unwrap();
+        // Drop stdin (EOF) → script mode runs to completion and exits cleanly,
+        // writing a checkpoint + truncating the WAL on the way out.
+    }
+    let out = child.wait_with_output().expect("vibesql did not exit");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+/// End-to-end regression for #5766: committed DML written by one CLI *process*
+/// must survive when a *subsequent* process re-opens the same file-backed DB
+/// under the default (WAL-on) config.
+///
+/// This is the exact shape of the bug: separate `vibesql <db> < stmt`
+/// invocations (which is how the TCL shim drives `execsql`). Before the fix the
+/// LSN counter reset to 1 each open, so the post-DELETE checkpoint carried a
+/// lower LSN than the pre-DELETE one and recovery resurrected the pre-delete
+/// state — the final `SELECT count(*)` returned 3 instead of 2.
+#[cfg(unix)]
+#[test]
+fn test_committed_delete_survives_separate_process_reopen() {
+    let home = tempfile::tempdir().unwrap();
+    // Default config (WAL on). No ~/.vibesqlrc needed.
+    let db_path = home.path().join("crossproc.vbsql");
+    let bin = vibesql_binary();
+
+    // Process 1: create + insert 3 rows inside an explicit transaction.
+    run_script(
+        bin,
+        &db_path,
+        home.path(),
+        "CREATE TABLE t(x);\nBEGIN;\nINSERT INTO t VALUES(1);\n\
+         INSERT INTO t VALUES(2);\nINSERT INTO t VALUES(3);\nCOMMIT;\n",
+    );
+
+    // Process 2: delete one committed row.
+    run_script(bin, &db_path, home.path(), "DELETE FROM t WHERE x=1;\n");
+
+    // Process 3: the deletion must be visible — count is 2, not 3.
+    let out = run_script(bin, &db_path, home.path(), "SELECT count(*) AS n FROM t;\n");
+    assert!(
+        out.contains('2') && !out.contains('3'),
+        "committed DELETE must persist across separate process re-opens with WAL on \
+         by default (expected count 2); got output:\n{out}"
+    );
+}
+
+/// Companion to the DELETE case: two bare auto-commit INSERTs issued by two
+/// separate processes must *accumulate* (final count 2), and a third process's
+/// UPDATE must also persist. Exercises the auto-commit path and UPDATE/INSERT
+/// (not just DELETE) across re-opens.
+#[cfg(unix)]
+#[test]
+fn test_autocommit_writes_accumulate_across_separate_processes() {
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("accumulate.vbsql");
+    let bin = vibesql_binary();
+
+    run_script(bin, &db_path, home.path(), "CREATE TABLE t(x, y);\n");
+    run_script(bin, &db_path, home.path(), "INSERT INTO t VALUES(1, 10);\n");
+    run_script(bin, &db_path, home.path(), "INSERT INTO t VALUES(2, 20);\n");
+
+    let count = run_script(bin, &db_path, home.path(), "SELECT count(*) AS n FROM t;\n");
+    assert!(
+        count.contains('2'),
+        "auto-commit INSERTs from separate processes must accumulate (expected 2); got:\n{count}"
+    );
+
+    // An UPDATE from yet another process must persist too.
+    run_script(bin, &db_path, home.path(), "UPDATE t SET y=99 WHERE x=1;\n");
+    let updated = run_script(bin, &db_path, home.path(), "SELECT y FROM t WHERE x=1;\n");
+    assert!(
+        updated.contains("99"),
+        "committed UPDATE must persist across a process re-open; got:\n{updated}"
+    );
+}

--- a/crates/vibesql-storage/src/wal/checkpoint.rs
+++ b/crates/vibesql-storage/src/wal/checkpoint.rs
@@ -136,6 +136,13 @@ impl CheckpointHeader {
 pub struct CheckpointInfo {
     /// Path to the checkpoint file
     pub path: PathBuf,
+    /// Monotonic checkpoint id parsed from the `checkpoint_<id>.vchk` filename.
+    ///
+    /// Ids strictly increase in creation order, so they break ties when two
+    /// checkpoints share an LSN — recovery can then deterministically pick the
+    /// most recently written one instead of relying on directory iteration
+    /// order (issue #5766).
+    pub id: u64,
     /// LSN at which the checkpoint was taken
     pub lsn: Lsn,
     /// Timestamp when the checkpoint was created
@@ -176,15 +183,8 @@ impl CheckpointWriter {
 
         if let Ok(entries) = fs::read_dir(dir) {
             for entry in entries.flatten() {
-                let path = entry.path();
-                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                    if let Some(id_str) =
-                        name.strip_prefix("checkpoint_").and_then(|s| s.strip_suffix(".vchk"))
-                    {
-                        if let Ok(id) = id_str.parse::<u64>() {
-                            max_id = max_id.max(id);
-                        }
-                    }
+                if let Some(id) = checkpoint_id_from_path(&entry.path()) {
+                    max_id = max_id.max(id);
                 }
             }
         }
@@ -250,7 +250,14 @@ impl CheckpointWriter {
             file_size
         );
 
-        Ok(CheckpointInfo { path: final_path, lsn, timestamp_ms, num_tables, file_size })
+        Ok(CheckpointInfo {
+            path: final_path,
+            id: checkpoint_id,
+            lsn,
+            timestamp_ms,
+            num_tables,
+            file_size,
+        })
     }
 
     /// Get the path to the checkpoint directory
@@ -273,8 +280,13 @@ impl CheckpointWriter {
             }
         }
 
-        // Sort by LSN
-        checkpoints.sort_by_key(|c| c.lsn);
+        // Sort by LSN, then by checkpoint id as a deterministic tie-break so that
+        // when two checkpoints share an LSN the most recently written one (higher
+        // id) sorts last and "wins" newest-first selection during recovery
+        // (issue #5766). Without the id tie-break, equal-LSN checkpoints were
+        // ordered by directory-iteration order and recovery could load stale
+        // state.
+        checkpoints.sort_by(|a, b| a.lsn.cmp(&b.lsn).then(a.id.cmp(&b.id)));
         Ok(checkpoints)
     }
 
@@ -290,8 +302,11 @@ impl CheckpointWriter {
             .map_err(|e| StorageError::IoError(format!("Failed to get checkpoint size: {}", e)))?
             .len();
 
+        let id = checkpoint_id_from_path(path).unwrap_or(0);
+
         Ok(CheckpointInfo {
             path: path.to_path_buf(),
+            id,
             lsn: header.lsn,
             timestamp_ms: header.timestamp_ms,
             num_tables: header.num_tables,
@@ -322,6 +337,14 @@ impl CheckpointWriter {
 
         Ok(removed)
     }
+}
+
+/// Parse the monotonic checkpoint id from a `checkpoint_<id>.vchk` path.
+///
+/// Returns `None` for paths that don't match the naming scheme.
+fn checkpoint_id_from_path(path: &Path) -> Option<u64> {
+    let name = path.file_name().and_then(|n| n.to_str())?;
+    name.strip_prefix("checkpoint_").and_then(|s| s.strip_suffix(".vchk"))?.parse::<u64>().ok()
 }
 
 /// Read checkpoint data (excluding header) from a checkpoint file
@@ -496,6 +519,49 @@ mod tests {
         let remaining = writer.list_checkpoints().unwrap();
         assert_eq!(remaining[0].lsn, 40);
         assert_eq!(remaining[1].lsn, 50);
+    }
+
+    #[test]
+    fn test_equal_lsn_checkpoints_tiebreak_by_id() {
+        // Regression for #5766: when two checkpoints share an LSN, recovery must
+        // deterministically prefer the most recently written one. `list_checkpoints`
+        // sorts by (lsn, id) and `latest_checkpoint` returns the last, so the
+        // higher-id checkpoint at the same LSN must win — regardless of the order
+        // the filesystem happens to enumerate the directory.
+        let temp_dir = TempDir::new().unwrap();
+        let mut writer = CheckpointWriter::new(temp_dir.path()).unwrap();
+
+        // Three checkpoints, all stamped at the SAME LSN (the pre-fix failure
+        // mode where the LSN counter reset each restart). The last one written
+        // (highest id) carries the newest state.
+        let _c1 = writer.create_checkpoint(5, b"oldest", 1).unwrap();
+        let _c2 = writer.create_checkpoint(5, b"middle", 1).unwrap();
+        let c3 = writer.create_checkpoint(5, b"newest-state", 1).unwrap();
+
+        let checkpoints = writer.list_checkpoints().unwrap();
+        assert_eq!(checkpoints.len(), 3);
+        // Sorted ascending by id when LSNs tie.
+        assert!(checkpoints[0].id < checkpoints[1].id);
+        assert!(checkpoints[1].id < checkpoints[2].id);
+
+        let latest = writer.latest_checkpoint().unwrap().unwrap();
+        assert_eq!(latest.id, c3.id, "highest-id checkpoint must win an LSN tie");
+
+        let (_, data) = read_checkpoint_data(&latest.path).unwrap();
+        assert_eq!(data, b"newest-state", "recovery must load the newest equal-LSN checkpoint");
+    }
+
+    #[test]
+    fn test_checkpoint_info_carries_id() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut writer = CheckpointWriter::new(temp_dir.path()).unwrap();
+
+        let info = writer.create_checkpoint(10, b"data", 1).unwrap();
+        assert_eq!(info.id, 1);
+
+        // The id round-trips through a fresh read of the directory.
+        let listed = writer.list_checkpoints().unwrap();
+        assert_eq!(listed[0].id, 1);
     }
 
     #[test]

--- a/crates/vibesql-storage/src/wal/engine.rs
+++ b/crates/vibesql-storage/src/wal/engine.rs
@@ -158,7 +158,7 @@ pub enum WalMessage {
 #[cfg(not(target_arch = "wasm32"))]
 mod native {
     use std::{
-        fs::OpenOptions,
+        fs::{self, OpenOptions},
         io::{BufWriter, Seek, Write},
         path::Path,
         sync::{
@@ -170,6 +170,8 @@ mod native {
     };
 
     use parking_lot::Mutex;
+
+    use crate::wal::format::WAL_HEADER_SIZE;
 
     use super::*;
 
@@ -308,37 +310,97 @@ mod native {
     }
 
     impl PersistenceEngine {
-        /// Create a new persistence engine writing to a file
+        /// Create a new persistence engine writing to a file.
+        ///
+        /// LSN numbering starts at 1. For an existing WAL that is being reopened
+        /// after recovery, use [`PersistenceEngine::open_with_start_lsn`] so that
+        /// LSNs (and the checkpoints stamped from them) continue to advance
+        /// monotonically across process restarts.
         pub fn new<P: AsRef<Path>>(
             path: P,
             config: PersistenceConfig,
         ) -> Result<Self, StorageError> {
+            Self::open_with_start_lsn(path, config, 1)
+        }
+
+        /// Open (or create) a file-backed persistence engine, resuming LSN
+        /// numbering at `start_lsn`.
+        ///
+        /// This is the constructor the CLI uses after recovery: it passes
+        /// `recovered_lsn + 1` so that the first WAL entry — and therefore the
+        /// next checkpoint stamped from `next_lsn` — has a strictly higher LSN
+        /// than anything already persisted. Without this, every process restart
+        /// reset the LSN to 1, successive checkpoints collided on (or regressed
+        /// below) earlier LSNs, and recovery's "highest LSN wins" selection
+        /// resurrected stale pre-mutation state (issue #5766).
+        ///
+        /// If the WAL file already contains a header, this appends to it rather
+        /// than writing a second header (which would corrupt the log and break
+        /// post-restart WAL replay).
+        pub fn open_with_start_lsn<P: AsRef<Path>>(
+            path: P,
+            config: PersistenceConfig,
+            start_lsn: Lsn,
+        ) -> Result<Self, StorageError> {
+            // Does a valid (header-bearing) WAL already exist? If so we must NOT
+            // write a fresh header on top of it.
+            let has_header = fs::metadata(path.as_ref())
+                .map(|m| m.len() >= WAL_HEADER_SIZE as u64)
+                .unwrap_or(false);
+
             let file = OpenOptions::new()
                 .create(true)
+                .read(true)
                 .append(true)
                 .open(path.as_ref())
                 .map_err(|e| StorageError::IoError(e.to_string()))?;
 
             let writer = BufWriter::new(file);
-            Self::with_writer(writer, config)
+            Self::with_writer_opts(writer, config, start_lsn, !has_header)
         }
 
-        /// Create a new persistence engine with a custom writer
+        /// Create a new persistence engine with a custom writer.
+        ///
+        /// Writes a fresh WAL header and starts LSN numbering at 1.
         pub fn with_writer<W: Write + Seek + Send + 'static>(
             writer: W,
             config: PersistenceConfig,
         ) -> Result<Self, StorageError> {
+            Self::with_writer_opts(writer, config, 1, true)
+        }
+
+        /// Create a persistence engine over a custom writer with explicit
+        /// starting LSN and header-writing behavior.
+        ///
+        /// * `start_lsn` — the first LSN this engine will assign.
+        /// * `write_header` — when `true`, write a fresh WAL header (new file);
+        ///   when `false`, append to an existing header-bearing WAL.
+        fn with_writer_opts<W: Write + Seek + Send + 'static>(
+            writer: W,
+            config: PersistenceConfig,
+            start_lsn: Lsn,
+            write_header: bool,
+        ) -> Result<Self, StorageError> {
             let (sender, receiver) = mpsc::sync_channel(config.channel_capacity);
             let stats = Arc::new(Mutex::new(PersistenceStats::default()));
-            let next_lsn = Arc::new(Mutex::new(1u64));
+            let next_lsn = Arc::new(Mutex::new(start_lsn.max(1)));
             let shutdown = Arc::new(Mutex::new(false));
 
             let stats_clone = stats.clone();
             let flush_interval = Duration::from_millis(config.flush_interval_ms);
             let flush_count = config.flush_count;
+            let resume_lsn = start_lsn.max(1);
 
             let handle = thread::spawn(move || {
-                Self::writer_loop(writer, receiver, stats_clone, flush_interval, flush_count);
+                Self::writer_loop(
+                    writer,
+                    receiver,
+                    stats_clone,
+                    flush_interval,
+                    flush_count,
+                    write_header,
+                    resume_lsn,
+                );
             });
 
             Ok(Self { sender, handle: Some(handle), stats, next_lsn, shutdown, config })
@@ -351,8 +413,17 @@ mod native {
             stats: Arc<Mutex<PersistenceStats>>,
             flush_interval: Duration,
             flush_count: usize,
+            write_header: bool,
+            resume_lsn: Lsn,
         ) {
-            let mut wal_writer = match WalWriter::create(writer) {
+            // For a brand-new WAL we write a header (`create`); for an existing
+            // header-bearing WAL we append without a second header (`open`).
+            let wal_writer_result = if write_header {
+                WalWriter::create(writer)
+            } else {
+                WalWriter::open(writer, resume_lsn)
+            };
+            let mut wal_writer = match wal_writer_result {
                 Ok(w) => w,
                 Err(e) => {
                     log::error!("Failed to create WAL writer: {}", e);

--- a/crates/vibesql-storage/src/wal/recovery.rs
+++ b/crates/vibesql-storage/src/wal/recovery.rs
@@ -76,6 +76,13 @@ impl Default for RecoveryConfig {
 pub struct RecoveryStats {
     /// Checkpoint LSN that was loaded (0 if no checkpoint)
     pub checkpoint_lsn: Lsn,
+    /// Highest LSN observed anywhere during recovery — the loaded checkpoint LSN
+    /// or any WAL entry read (including entries at/below the checkpoint LSN).
+    ///
+    /// Callers resume the live WAL's LSN counter at `last_lsn + 1` so that new
+    /// entries — and the checkpoints stamped from them — keep advancing
+    /// monotonically across process restarts (issue #5766).
+    pub last_lsn: Lsn,
     /// Number of WAL entries replayed
     pub entries_replayed: u64,
     /// Number of entries skipped (before checkpoint LSN)
@@ -216,6 +223,7 @@ impl RecoveryManager {
         // Step 1: Find and load the latest valid checkpoint
         let (mut db, checkpoint_lsn) = self.load_latest_checkpoint(&mut stats)?;
         stats.checkpoint_lsn = checkpoint_lsn;
+        stats.last_lsn = stats.last_lsn.max(checkpoint_lsn);
 
         // Step 2: Replay WAL entries after the checkpoint LSN
         if let Some(ref wal_path) = self.wal_path {
@@ -320,6 +328,10 @@ impl RecoveryManager {
         loop {
             match wal_reader.read_entry()? {
                 ReadResult::Entry(entry) => {
+                    // Track the highest LSN seen so callers can resume the live
+                    // WAL counter past it (even for entries we skip below).
+                    stats.last_lsn = stats.last_lsn.max(entry.lsn);
+
                     // Skip entries at or before checkpoint LSN
                     if entry.lsn <= start_lsn {
                         stats.entries_skipped += 1;
@@ -1260,6 +1272,98 @@ mod tests {
         assert!(table.is_row_deleted(1));
         // Row 2 untouched.
         assert_eq!(table.get_row(2).unwrap().values[0], SqlValue::Integer(3));
+    }
+
+    #[test]
+    fn test_committed_dml_survives_cross_restart_via_resumed_lsn() {
+        // Regression for #5766. This mirrors what the CLI's `WalState` does across
+        // *separate process invocations* against a file-backed DB: each "process"
+        // recovers, resumes the live WAL LSN counter past everything recovery saw
+        // (`last_lsn + 1`), applies a committed mutation, writes a checkpoint at
+        // `next_lsn - 1`, and exits.
+        //
+        // Before the fix the LSN counter reset to 1 every open, so a later
+        // process's checkpoint could carry a *lower* LSN than an earlier one.
+        // Recovery selects the highest-LSN checkpoint, so it resurrected the stale
+        // pre-mutation state and silently dropped the newest committed write.
+        // Resuming the LSN keeps checkpoint LSNs monotonic so the newest state wins.
+        let temp_dir = TempDir::new().unwrap();
+        let checkpoint_dir = temp_dir.path().join("checkpoints");
+        let wal_path = temp_dir.path().join("test.wal");
+
+        // Mirror of `WalState::checkpoint`: stamp a checkpoint at next_lsn - 1.
+        fn write_checkpoint(db: &Database, dir: &Path) {
+            db.sync_persistence().unwrap();
+            let lsn = db.persistence_next_lsn().unwrap_or(1).saturating_sub(1);
+            let data = db.to_uncompressed_bytes().unwrap();
+            let mut writer = CheckpointWriter::new(dir).unwrap();
+            writer.create_checkpoint(lsn, &data, db.list_tables().len() as u32).unwrap();
+        }
+
+        // Mirror of `WalState::open`: recover, then resume the LSN at last_lsn + 1.
+        fn open(dir: &Path, wal: &Path) -> Database {
+            let manager = RecoveryManager::new(dir).with_wal(wal);
+            let (mut db, stats) = manager.recover().unwrap();
+            let resume = stats.last_lsn.saturating_add(1);
+            let engine =
+                PersistenceEngine::open_with_start_lsn(wal, PersistenceConfig::default(), resume)
+                    .unwrap();
+            db.enable_persistence(engine);
+            db
+        }
+
+        let row = |id: i64, name: &str| {
+            crate::row::Row::new(vec![
+                SqlValue::Integer(id),
+                SqlValue::Varchar(arcstr::ArcStr::from(name)),
+            ])
+        };
+
+        // --- Cycle 1: create table + insert 3 committed rows, checkpoint, exit.
+        {
+            let mut db = open(&checkpoint_dir, &wal_path);
+            db.create_table(simple_schema("t")).unwrap();
+            db.insert_row("main.t", row(1, "a")).unwrap();
+            db.insert_row("main.t", row(2, "b")).unwrap();
+            db.insert_row("main.t", row(3, "c")).unwrap();
+            write_checkpoint(&db, &checkpoint_dir);
+        }
+
+        // --- Cycle 2: reopen, delete row 0 (a committed mutation that *advances*
+        // the LSN), checkpoint, exit. This is the post-delete state that must win.
+        {
+            let mut db = open(&checkpoint_dir, &wal_path);
+            assert_eq!(live_row_count(&db, "main.t"), 3, "cycle 2 must see all 3 rows");
+            // Emit a WAL delete (advances the engine LSN, exactly like the DELETE
+            // executor) and mark the row deleted so the checkpoint captures it.
+            db.emit_wal_delete("main.t", 0, vec![SqlValue::Integer(1)]);
+            db.get_table_mut("main.t").unwrap().mark_deleted_inplace(0);
+            write_checkpoint(&db, &checkpoint_dir);
+        }
+
+        // --- Cycle 3: reopen and assert the delete persisted (2 live rows), i.e.
+        // recovery picked the post-delete checkpoint, not the stale 3-row one.
+        {
+            let db = open(&checkpoint_dir, &wal_path);
+            assert_eq!(
+                live_row_count(&db, "main.t"),
+                2,
+                "committed DELETE must survive the restart; recovery must not resurrect \
+                 the pre-delete checkpoint (#5766)"
+            );
+        }
+
+        // The checkpoint LSNs must be strictly monotonic across the two cycles so
+        // that highest-LSN selection lands on the newest state.
+        let writer = CheckpointWriter::new(&checkpoint_dir).unwrap();
+        let checkpoints = writer.list_checkpoints().unwrap();
+        assert_eq!(checkpoints.len(), 2, "one checkpoint per write cycle");
+        assert!(
+            checkpoints[1].lsn > checkpoints[0].lsn,
+            "later checkpoint must carry a higher LSN (got {} then {})",
+            checkpoints[0].lsn,
+            checkpoints[1].lsn
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Committed `INSERT`/`UPDATE`/`DELETE` written by one `vibesql` CLI process was **silently lost** when a subsequent process re-opened the same file-backed database under the default (WAL-on) config — a data-durability regression introduced by WAL-on-by-default (`608aa85aa`, Phase 2 of #5698).

Root cause (verified): the persistence engine reset its LSN counter to `1` on every open. Each CLI process checkpoints on clean exit, stamping the checkpoint at `persistence_next_lsn - 1`. Because LSNs restarted at 1, a **later** process's checkpoint could carry a **lower** LSN than an earlier one. Recovery selects the highest-LSN checkpoint, so it resurrected the stale pre-mutation checkpoint and discarded the newest committed state.

Reproduced at HEAD (checkpoint LSNs went `1, 6, 1` — recovery picked LSN 6, the pre-delete state). After the fix the LSNs are monotonic (`1, 6, 7`) and recovery picks the newest.

This is **not** the DML LIMIT/OFFSET bug the issue was originally filed against (already fixed in `14e717fc3`/#5754) — confirmed via the curator's reframe.

## Changes

- **Resume LSN across restarts.** `RecoveryStats` now records `last_lsn` (the loaded checkpoint LSN and the max WAL entry LSN seen). `WalState::open` starts the live engine at `last_lsn + 1` via the new `PersistenceEngine::open_with_start_lsn`, keeping checkpoint LSNs monotonic so the newest committed state always wins.
- **Stop corrupting the WAL on reopen.** Opening a header-bearing WAL now appends without writing a second header. The old `create(true).append(true)` + unconditional `WalWriter::create` path wrote a duplicate header into an existing WAL, which broke post-restart WAL replay.
- **Deterministic checkpoint tie-break.** `CheckpointInfo` now carries the monotonic checkpoint id parsed from the `checkpoint_<id>.vchk` filename, and `list_checkpoints` sorts by `(lsn, id)` so equal-LSN checkpoints deterministically prefer the most recently written one (defensive hardening that lands regardless).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Committed DML (autocommit + BEGIN/COMMIT) survives a CLI restart with WAL on | ✅ | Minimal repro now prints `count 2` (was `3`); autocommit accumulate + UPDATE repros pass |
| Successive checkpoints at distinct states are distinguishable by recovery | ✅ | Checkpoint LSNs now monotonic (`1,6,7`); `+ (lsn, id)` tie-break unit test |
| `TCL_TIMEOUT=180 make test-tcl-file FILE=wherelimit.test` passes (near-0) | ✅ | **41 failing → 2** (58/60, 96.7%) |
| No regression with `wal = false` (snapshot path) | ✅ | `wal=false` repro still correct (`count 2`), no `.wal`/`-checkpoints` created |
| Rust regression test for checkpoint+WAL recovery across simulated restart | ✅ | Added storage + CLI subprocess tests (below) |
| No regressions in affected crates | ✅ | `cargo test -p vibesql-storage -p vibesql-cli` green |

## Test Plan

- **Storage unit tests** (`crates/vibesql-storage/src/wal/`): equal-LSN checkpoints tie-break by id; `CheckpointInfo` carries id; cross-restart cycle with resumed LSN preserves a committed DELETE and keeps checkpoint LSNs monotonic.
- **CLI integration tests** (`crates/vibesql-cli/tests/wal_recovery_test.rs`): separate-process reopen preserves a committed DELETE (count 2, not 3); auto-commit INSERTs from separate processes accumulate and a later UPDATE persists. Existing SIGKILL crash-recovery tests still pass.
- Full `cargo test -p vibesql-storage -p vibesql-cli`: all green.

## Remaining wherelimit failures (out of scope)

`wherelimit-4.2`/`4.3` still fail with `no such table: tv`. This is a **separate** gap: the binary checkpoint format serializes tables and triggers but **not views**. The snapshot/`wal=false` path keeps views because it uses a SQL dump (regenerated `CREATE VIEW` text). Fixing this requires a binary catalog format version bump and is filed as a follow-up rather than expanded into this durability fix. (The curator-noted #5752 alias cases `wherelimit-0.4`/`0.5.2` now **pass**.)

Closes #5766