### PR TITLE
docs(roadmap): mark WAL-on-by-default shipped; correct SQLite TCL frontier framing

### DIFF
--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -90,3 +90,11 @@ A timeline of major milestones in the development of VibeSQL.
 - v0.2.0 release-window TPC-C dashboard captured all three engines (VibeSQL, SQLite, DuckDB) at ~1/3 of their v0.1.4 throughput, the signature of host-level contention rather than a code regression (see [docs/performance/tpcc_regression.md](performance/tpcc_regression.md))
 - Same-host re-measurement on `feature/issue-5643` (head `9e1ac205`, descended from the v0.2.0 release commit `ec54522d1`) recovered VibeSQL TPC-C to **9,276 TPS** (vs the 5,307 TPS dashboard number, vs the 10,758 TPS v0.1.4 README baseline); SQLite recovered to 2,813 TPS and DuckDB to 450 TPS
 - Re-measurement was itself taken under sweep-concurrency contention; a truly idle re-run is still warranted before refreshing the website dashboard or filing a bisect
+
+### June 2026: WAL-default durability + SQLite TCL frontier correction
+
+- **WAL became the default CLI durability path** — file-backed databases now recover automatically from an unclean shutdown via checkpoint + WAL replay (DDL and committed DML), opt out with `[database] wal = false`. Shipped across #5698 Phases 1-2 (#5706, #5760), with LSN resume across CLI restarts so committed DML survives reopen (#5770)
+- **The SQLite TCL Priority-1 frontier collapsed** after analysis confirmed the join suite (joinB/C/D/E) passes 100% (1,974 tests, 0 failures), retiring the earlier "join/index/where optimizer-plan parity" framing
+  - `indexA.test` was a TEXT-affinity comparison bug (numeric literals vs TEXT columns), not a missing partial-index feature — fixed in #5769
+  - `wherelimit.test` was a WAL durability regression (committed DML lost on reopen), not a DML LIMIT/OFFSET gap — fixed in #5770; the last 2 failures trace to views not yet serialized in the checkpoint format (#5771, open)
+- **`tcltest` now forwards `--timeout`** (native per-file default raised to 1200s) so slow files are no longer silently dropped, making conformance numbers trustworthy (#5768)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,10 +12,14 @@ VibeSQL has achieved **100% SQL:1999 compliance** and **100% SQLLogicTest confor
 | TPC-H | 22/22 queries (100%) |
 | TPC-C | All transactions |
 | TPC-DS | 102/102 queries (100%) |
-| SQLite TCL suite (canonical) | Core SQL passing; remaining gaps are optimizer-plan parity — run `make test-tcl-status` for the live number |
+| SQLite TCL suite (canonical) | Core SQL passing; join suite (joinB/C/D/E) at 100%; the two largest Priority-1 clusters (indexA, wherelimit) now resolved, tail is small — run `make test-tcl-status` for the live number |
 
 The curated suites above are at 100%. The canonical SQLite TCL suite (1,174 files) is the
 ongoing conformance frontier — see [Current Focus](#current-focus) and [Known Gaps](#known-gaps).
+Trustworthy TCL numbers require forwarding a generous per-file timeout (e.g.
+`./scripts/tcltest run --priority 1 --timeout 1200`; the native default is 1200s after #5768),
+otherwise slow files time out and are silently dropped. Read the canonical pass-rate / per-file
+queries against the `tcl_test_results` table (see `CLAUDE.md`) or run `make test-tcl-status`.
 
 See [HISTORY.md](HISTORY.md) for development timeline.
 
@@ -34,7 +38,7 @@ See [HISTORY.md](HISTORY.md) for development timeline.
 ### Storage & Persistence (v0.2.0)
 - Versioned `VBSQL` binary snapshot format (currently format v9, evolved across MVCC and other additions) with optional zstd compression
 - CLI loads a database on open and auto-saves on exit (`auto_save = true`); JSON and SQL-dump load/save also supported
-- Write-ahead log engine — writer/reader/checkpoint/scheduler/truncate plus crash recovery (checkpoint + WAL replay with corruption tolerance), exposed via `enable_persistence()` / `sync_persistence()` / `emit_wal_*`. Currently opt-in, not the default durability path.
+- Write-ahead log engine — writer/reader/checkpoint/scheduler/truncate plus crash recovery (checkpoint + WAL replay with corruption tolerance), exposed via `enable_persistence()` / `sync_persistence()` / `emit_wal_*`. **WAL is on by default** for file-backed CLI databases — an unclean shutdown recovers automatically via checkpoint + WAL replay (DDL and committed DML); opt out with `[database] wal = false`. Shipped across #5698 Phases 1-2 (#5706, #5760), with LSN resume across CLI restarts in #5770.
 - OPFS backend for browser/WASM (Origin Private File System)
 - Server-mode durability runs through the Raft log + MVCC state machine (see Replication & Consensus)
 
@@ -71,7 +75,7 @@ See [HISTORY.md](HISTORY.md) for development timeline.
 
 ## Current Focus
 
-1. **SQLite TCL conformance** - Closing the canonical-suite tail, concentrated in join/index/where optimizer-plan parity (e.g. MULTI-INDEX OR planning, EXPLAIN QUERY PLAN shape, type affinity, parser edge cases). This is where the bulk of recent commits land.
+1. **SQLite TCL conformance** - Closing the canonical-suite tail. The join suite (joinB/C/D/E) passes 100%, and the two clusters that were previously the bulk of Priority-1 failures are now fixed: `indexA.test` (a TEXT-affinity comparison bug — `CREATE INDEX ... WHERE` partial indexes already worked, #5769) and `wherelimit.test` (a WAL durability regression where committed DML was lost on reopen, not a DML LIMIT/OFFSET gap, #5770). The remaining Priority-1 frontier is therefore small — e.g. view serialization in binary checkpoints (#5771). Trustworthy measurement requires forwarding a generous `--timeout` (native default 1200s after #5768) and reading the `tcl_test_results` detail table; run `make test-tcl-status` for the live number.
 2. **Performance optimization** - TPC-C OLTP throughput improvements
 3. **Bug fixes** - Address issues as discovered
 4. **Documentation** - Keep guides current, improve API docs
@@ -85,10 +89,6 @@ These are potential enhancements, not committed work. They would only be pursued
 
 Compile SQL to native code for hot queries using LLVM or Cranelift. Could provide 5-10x speedup but requires significant architectural changes.
 
-### Default-On WAL Durability
-
-The WAL + crash-recovery engine already exists (see [Storage & Persistence](#storage--persistence-v020)) but is opt-in; the shipping default is in-memory with snapshot-on-exit. Wiring the WAL as the default durability path in the CLI and server — so an unclean shutdown recovers automatically — is the natural next step.
-
 ### Range-Sharded Replication
 
 Multi-Raft-group replication where each key range owns its own consensus group (CockroachDB/TiKV model). VibeSQL v0.2.0 ships single-group whole-database replication (rqlite/dqlite model) via the `vibesql-consensus` crate; range sharding and distributed multi-shard transactions are deferred until single-group scale shows specific bottlenecks. See [ADR-0004](decisions/0004-consensus-library.md) for the topology decision.
@@ -101,8 +101,8 @@ Pre-computed aggregations with incremental refresh. Useful for repeated complex 
 
 The curated suites (SQLLogicTest, SQL:1999, TPC-H/DS/C) are at 100%. Open areas:
 
-- **SQLite TCL conformance** - canonical suite not yet fully green; remaining failures cluster in join/index/where optimizer-plan parity (run `make test-tcl-status` for current numbers)
-- **Default-on durability** - WAL/crash-recovery engine is built but opt-in; default mode is snapshot-on-exit, so an unclean shutdown loses changes since the last save
+- **SQLite TCL conformance** - canonical suite not yet fully green, but the frontier is now small: the join suite (joinB/C/D/E) passes 100% and the previously dominant indexA / wherelimit clusters are resolved (#5769, #5770). Run `make test-tcl-status` for the live number (forward a generous `--timeout`; native default is 1200s after #5768 so slow files are no longer silently dropped)
+- **View serialization in checkpoints (#5771)** - views are not serialized in the binary checkpoint/`.vbsql` format, so they are lost across a WAL restart; this is the residual cause of the last 2 `wherelimit.test` failures
 - TPC-C OLTP throughput optimization
 - Query performance for complex analytical queries
 - Memory efficiency for large-scale workloads


### PR DESCRIPTION
## Summary

`docs/ROADMAP.md` and `docs/HISTORY.md` were stale after this sweep's merges to `origin/main`. WAL was still listed as a future idea / known gap even though it ships on by default (#5760), and the SQLite TCL section claimed the frontier was "join/index/where optimizer-plan parity" with joinD as the frontier — which is wrong (joinB/C/D/E pass 100%). This PR corrects both, documentation-only.

## Changes

- **ROADMAP status table**: TCL cell now states the join suite is at 100% and the indexA/wherelimit clusters are resolved, with the `--timeout` measurement caveat (native default 1200s after #5768).
- **ROADMAP Recently Completed → Storage & Persistence**: WAL bullet now says WAL is on by default (crash recovery via checkpoint + WAL replay; opt out with `[database] wal = false`), citing #5698 Phases 1-2 (#5706, #5760) and the LSN-resume fix #5770.
- **ROADMAP Current Focus item 1**: removed the "join/index/where optimizer-plan parity / joinD frontier" framing; now states the join suite passes 100%, indexA (TEXT-affinity, #5769) and wherelimit (WAL durability regression, #5770) are fixed, and the remaining tail is small (e.g. #5771).
- **ROADMAP Future Ideas**: deleted the "Default-On WAL Durability" section (shipped).
- **ROADMAP Known Gaps**: rewrote the TCL bullet, deleted the "Default-on durability" bullet, added a #5771 (view serialization) bullet.
- **HISTORY.md**: added a June 2026 milestone covering WAL-default (#5760/#5770), the indexA fix (#5769), and the tcltest `--timeout` fix (#5768).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| No "Default-On WAL Durability" Future Idea nor "Default-on durability" Known Gap | ✅ | Section + bullet deleted; `grep "default-on"` clean |
| WAL bullet under Recently Completed says on by default | ✅ | Edited line 37 |
| No text claims join suite / joinD is the TCL frontier | ✅ | `grep "joinD\|optimizer-plan parity"` only matches the HISTORY note about the *retired* framing |
| ROADMAP names resolved clusters (indexA, wherelimit) + #5771 + `--timeout` caveat | ✅ | Status table, Current Focus, Known Gaps |
| HISTORY June 2026 entry covers #5760/#5770, #5769, #5768 | ✅ | New milestone added |
| All cited issue/PR numbers resolve | ✅ | Verified #5698/#5706/#5760/#5768/#5769/#5770/#5771 via `gh` |
| No broken Markdown anchors after deleting the section | ✅ | `grep "#default-on-wal-durability"` returns no references |

## Test Plan

Documentation-only change; no build required. Verified edits against the actual `docs/ROADMAP.md` in a worktree branched from current `origin/main` (HEAD `fd49d1210`, includes #5768/#5769/#5770), and confirmed every cited issue/PR number resolves with `gh`.

Closes #5767