### PR TITLE
fix(loom): make worktree submodule init selective with free-space guard

### DIFF
--- a/.loom/scripts/worktree.sh
+++ b/.loom/scripts/worktree.sh
@@ -385,6 +385,7 @@ Usage:
   pnpm worktree <issue-number> <branch>                 Create worktree with custom branch
   pnpm worktree <issue-number> --sparse <paths...>      Cone-mode sparse checkout
   pnpm worktree <issue-number> --full                   Convert sparse worktree to full
+  pnpm worktree <issue-number> --all-submodules         Init ALL submodules (incl. heavy ones)
   pnpm worktree --check                                 Check if in a worktree
   pnpm worktree --json <issue-number>                   Machine-readable JSON output
   pnpm worktree --return-to <dir> <issue-number>        Store return directory
@@ -407,6 +408,11 @@ Examples:
   pnpm worktree 42 --full
     Converts an existing sparse worktree back to a full checkout
     (no-op on an already-full worktree).
+
+  pnpm worktree 42 --all-submodules
+    Initializes every submodule, including heavy ones that are skipped by
+    default (e.g. third_party/sqllogictest, ~1.1G). Same as
+    LOOM_WORKTREE_SUBMODULES=all.
 
   pnpm worktree --check
     Shows current worktree status
@@ -439,10 +445,21 @@ Safety Features:
   ✓ Repo-global lock serializes concurrent invocations (issue #3380)
   ✓ Recovers from stale .git/worktrees/issue-N/index.lock files
   ✓ Recovers from half-created .loom/worktrees/issue-N/ dirs
+  ✓ Skips heavy submodules by default (e.g. third_party/sqllogictest, ~1.1G)
+  ✓ Free-space guard skips submodule clones when the disk is low
 
 Environment Variables:
   LOOM_WORKTREE_ALWAYS_INCLUDE      Extra sparse-mode safety paths (space-sep)
   LOOM_SUBMODULE_TIMEOUT            Per-submodule init timeout (default 300s)
+  LOOM_WORKTREE_SUBMODULE_SKIP      Space-separated submodule paths to skip on
+                                    init (default "third_party/sqllogictest").
+                                    Set to "" to init everything by default.
+  LOOM_WORKTREE_SUBMODULES          Set to "all" to force initializing every
+                                    submodule (same as --all-submodules).
+  LOOM_WORKTREE_MIN_FREE_MB         Skip a submodule clone when free space on the
+                                    worktree volume is below this many MB
+                                    (default 2048). Prevents disk-exhaustion
+                                    deadlocks during large clones.
   LOOM_WORKTREE_LOCK_TIMEOUT        Lock acquisition timeout in seconds
                                     (default 600 — sized to cover worst-case
                                     cold-clone submodule init)
@@ -533,6 +550,7 @@ fi
 #   --full
 SPARSE_MODE=false
 FULL_MODE=false
+ALL_SUBMODULES=false
 SPARSE_PATHS=()
 CUSTOM_BRANCH=""
 
@@ -549,6 +567,12 @@ while [[ $# -gt 0 ]]; do
             ;;
         --full)
             FULL_MODE=true
+            shift
+            ;;
+        --all-submodules)
+            # Opt in to initializing every submodule, overriding the default
+            # skip-list (which excludes heavy submodules like sqllogictest).
+            ALL_SUBMODULES=true
             shift
             ;;
         --*)
@@ -1051,6 +1075,23 @@ EOF
     UNINIT_SUBMODULES=$(cd "$ABS_WORKTREE_PATH" && git submodule status 2>/dev/null | grep '^-' | wc -l | tr -d ' ')
     SUBMODULE_TIMEOUT="${LOOM_SUBMODULE_TIMEOUT:-300}"
 
+    # Selective submodule init (issue #5773):
+    #   By default we skip heavy submodules (e.g. the 1.1G third_party/sqllogictest)
+    #   that most tasks never need, to avoid wasting time and — on a near-full
+    #   disk — exhausting the volume mid-clone. The consuming scripts already
+    #   degrade gracefully and print on-demand init guidance when a skipped
+    #   submodule is actually needed (scripts/sqllogictest, scripts/tcltest).
+    #   Override the skip-list with LOOM_WORKTREE_SUBMODULE_SKIP, or force a full
+    #   init with --all-submodules / LOOM_WORKTREE_SUBMODULES=all.
+    SUBMODULE_SKIP_LIST="${LOOM_WORKTREE_SUBMODULE_SKIP-third_party/sqllogictest}"
+    if [[ "$ALL_SUBMODULES" == "true" || "$LOOM_WORKTREE_SUBMODULES" == "all" ]]; then
+        SUBMODULE_SKIP_LIST=""
+    fi
+    # Pre-flight free-space guard: never start a clone that could drive the
+    # worktree volume to 0 bytes. Below this threshold (MB) clones are skipped
+    # with a warning rather than attempted. Override via LOOM_WORKTREE_MIN_FREE_MB.
+    SUBMODULE_MIN_FREE_MB="${LOOM_WORKTREE_MIN_FREE_MB:-2048}"
+
     if [[ "$UNINIT_SUBMODULES" -gt 0 ]]; then
         if [[ "$JSON_OUTPUT" != "true" ]]; then
             print_info "Initializing $UNINIT_SUBMODULES submodule(s) with shared objects..."
@@ -1060,6 +1101,35 @@ EOF
 
         # Process each uninitialized submodule
         git submodule status | grep '^-' | awk '{print $2}' | while read -r submod_path; do
+            # Skip-list: don't clone submodules the default task doesn't need.
+            skip_this_submod=false
+            for skip_path in $SUBMODULE_SKIP_LIST; do
+                if [[ "$submod_path" == "$skip_path" ]]; then
+                    skip_this_submod=true
+                    break
+                fi
+            done
+            if [[ "$skip_this_submod" == "true" ]]; then
+                if [[ "$JSON_OUTPUT" != "true" ]]; then
+                    print_info "Skipping submodule $submod_path (opt in with --all-submodules or LOOM_WORKTREE_SUBMODULES=all)"
+                fi
+                continue
+            fi
+
+            # Free-space guard: skip (don't attempt) the clone when the volume
+            # is already low, rather than risk filling it mid-download.
+            avail_kb=$(df -Pk "$ABS_WORKTREE_PATH" 2>/dev/null | awk 'NR==2{print $4}')
+            if [[ -n "$avail_kb" ]]; then
+                avail_mb=$(( avail_kb / 1024 ))
+                if [[ "$avail_mb" -lt "$SUBMODULE_MIN_FREE_MB" ]]; then
+                    if [[ "$JSON_OUTPUT" != "true" ]]; then
+                        print_warning "Low disk space (${avail_mb}MB < ${SUBMODULE_MIN_FREE_MB}MB): skipping clone of $submod_path"
+                        print_info "Free space and re-run, or lower LOOM_WORKTREE_MIN_FREE_MB, then: git submodule update --init --recursive -- $submod_path"
+                    fi
+                    continue
+                fi
+            fi
+
             ref_path="$MAIN_GIT_DIR/modules/$submod_path"
 
             if [[ -d "$ref_path" ]]; then


### PR DESCRIPTION
## Summary

`./.loom/scripts/worktree.sh <N>` initialized **all** git submodules unconditionally, including the 1.1G `third_party/sqllogictest`. During the #5765 sweep this clone ran the APFS volume to 0 bytes free mid-download, producing an unrecoverable deadlock (with the disk full, the Bash harness could not even create a command's output file, so no `rm` could reclaim space). This makes submodule init selective and adds a pre-flight free-space guard.

## Changes

- **Default skip-list** (`LOOM_WORKTREE_SUBMODULE_SKIP`, default `third_party/sqllogictest`): the L1062 loop now `continue`s past skipped submodules with an informational message. The common TCL case (`docs/reference/sqlite`, `third_party/sqltest`) still initializes automatically.
- **`--all-submodules` flag** (or `LOOM_WORKTREE_SUBMODULES=all`): opt-in escape hatch that clears the skip-list and restores full init including the heavy submodule.
- **Pre-flight free-space guard** (`LOOM_WORKTREE_MIN_FREE_MB`, default 2048): reads available space via `df -Pk` before each clone; if below the threshold the clone is skipped with a loud warning instead of attempted. The worktree is still created successfully (exit 0). This is the actual deadlock fix.
- **Docs**: updated `--help` usage line, examples, Safety Features, and Environment Variables blocks. Existing `--reference` sharing and `LOOM_SUBMODULE_TIMEOUT` behavior unchanged.
- `.gitmodules` is **not** modified.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Default does not clone `third_party/sqllogictest`; `docs/reference/sqlite` still inits | ✅ | Decision-logic smoke test: default branch clones sqlite + sqltest, skips sqllogictest |
| `--all-submodules` / `LOOM_WORKTREE_SUBMODULES=all` restores full init | ✅ | Smoke test: both clear the skip-list and clone all 3 submodules |
| `LOOM_WORKTREE_SUBMODULE_SKIP` overrides the default skip-list | ✅ | Smoke test with `"docs/reference/sqlite third_party/sqllogictest"` skips both, clones sqltest; `${VAR-default}` semantics let `""` disable skipping |
| Free-space guard skips clones below threshold with a warning; worktree still created | ✅ | Smoke test with availMB=100 < 2048 warns and skips all clones; guard uses `continue`, not exit |
| `--help` documents the new flag and env vars | ✅ | `worktree.sh --help` renders all three env vars + flag |
| No CI workflow / release script modified | ✅ | Only `.loom/scripts/worktree.sh` changed (`git diff --stat`); CI uses `actions/checkout` with `submodules: recursive`, never `worktree.sh` |
| Skipped submodule degrades gracefully | ✅ | `scripts/sqllogictest` (L51-59) already prints on-demand init guidance when missing — unchanged |

## Test Plan

- `bash -n .loom/scripts/worktree.sh` passes (syntax OK).
- `df -Pk` free-space read verified on the macOS/APFS volume (returns KB; converted to MB).
- Decision-logic smoke test covering all five branches: default skip, `--all-submodules`, `LOOM_WORKTREE_SUBMODULES=all`, custom `LOOM_WORKTREE_SUBMODULE_SKIP`, and low-disk guard — all produce the expected clone/skip set.
- This worktree was created manually (not via the pre-fix `worktree.sh`) to avoid re-triggering the disk-exhaustion deadlock; disk stayed at ~19GB free throughout.

Closes #5773