### PR TITLE
feat(sql): row-value comparison against subqueries, affinity, and NULL-ordering fix

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -884,19 +884,54 @@ impl CombinedExpressionEvaluator<'_> {
 
                         // Handle row value constructor comparisons
                         // SQL:1999 Section 7.1: Row value constructor comparison
-                        // (a, b) op (c, d) uses lexicographic ordering
+                        // (a, b) op (c, d) uses lexicographic ordering. The
+                        // right-hand side may also be a scalar subquery that
+                        // returns a row of the same arity, e.g.
+                        // (a, b, c) > (SELECT a, b, c FROM t WHERE ...).
                         if is_comparison {
-                            if let (
-                                vibesql_ast::Expression::RowValueConstructor(left_values),
-                                vibesql_ast::Expression::RowValueConstructor(right_values),
-                            ) = (left.as_ref(), right.as_ref())
-                            {
-                                return self.eval_row_value_comparison(
-                                    left_values,
-                                    op,
-                                    right_values,
-                                    row,
-                                );
+                            match (left.as_ref(), right.as_ref()) {
+                                (
+                                    vibesql_ast::Expression::RowValueConstructor(left_values),
+                                    vibesql_ast::Expression::RowValueConstructor(right_values),
+                                ) => {
+                                    return self.eval_row_value_comparison(
+                                        left_values,
+                                        op,
+                                        right_values,
+                                        row,
+                                    );
+                                }
+                                (
+                                    vibesql_ast::Expression::RowValueConstructor(tuple_exprs),
+                                    vibesql_ast::Expression::ScalarSubquery(subquery),
+                                ) => {
+                                    return self.eval_row_value_subquery_comparison(
+                                        tuple_exprs, op, subquery, true, row,
+                                    );
+                                }
+                                (
+                                    vibesql_ast::Expression::ScalarSubquery(subquery),
+                                    vibesql_ast::Expression::RowValueConstructor(tuple_exprs),
+                                ) => {
+                                    return self.eval_row_value_subquery_comparison(
+                                        tuple_exprs, op, subquery, false, row,
+                                    );
+                                }
+                                (
+                                    vibesql_ast::Expression::ScalarSubquery(left_sub),
+                                    vibesql_ast::Expression::ScalarSubquery(right_sub),
+                                ) => {
+                                    // Two multi-column subqueries compared as row
+                                    // values, e.g. (SELECT a,b)==(SELECT x,y). When
+                                    // both are single-column this returns None and
+                                    // we fall through to scalar comparison.
+                                    if let Some(result) = self
+                                        .eval_two_subquery_row_comparison(left_sub, op, right_sub, row)?
+                                    {
+                                        return Ok(result);
+                                    }
+                                }
+                                _ => {}
                             }
                         }
 
@@ -1389,165 +1424,212 @@ impl CombinedExpressionEvaluator<'_> {
             ));
         }
 
-        // Evaluate all elements
+        // Evaluate each element pair and apply per-column SQLite type affinity,
+        // mirroring the scalar comparison path so that mixed TEXT/NUMERIC tuples
+        // compare per SQLite rules instead of by raw storage class.
         let mut left_values = Vec::with_capacity(left_exprs.len());
         let mut right_values = Vec::with_capacity(right_exprs.len());
 
         for (left_expr, right_expr) in left_exprs.iter().zip(right_exprs.iter()) {
-            left_values.push(self.eval(left_expr, row)?);
-            right_values.push(self.eval(right_expr, row)?);
+            let left_val = self.eval(left_expr, row)?;
+            let right_val = self.eval(right_expr, row)?;
+            let (left_val, right_val) =
+                self.apply_affinity_for_comparison(left_expr, left_val, right_expr, right_val);
+            left_values.push(left_val);
+            right_values.push(right_val);
         }
 
         let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
 
-        // Perform comparison based on operator
-        match op {
-            vibesql_ast::BinaryOperator::Equal => {
-                // (a, b) = (c, d) → a = c AND b = d
-                let mut has_null = false;
-                for (left_val, right_val) in left_values.iter().zip(right_values.iter()) {
-                    let cmp_result = ExpressionEvaluator::eval_binary_op_static(
-                        left_val,
-                        op,
-                        right_val,
-                        sql_mode.clone(),
-                    )?;
-                    match cmp_result {
-                        SqlValue::Boolean(false) => return Ok(SqlValue::Boolean(false)),
-                        SqlValue::Null => has_null = true,
-                        SqlValue::Boolean(true) => {}
-                        _ => {
-                            return Err(ExecutorError::TypeError(format!(
-                                "Comparison returned non-boolean: {:?}",
-                                cmp_result
-                            )))
-                        }
-                    }
-                }
-                if has_null {
-                    Ok(SqlValue::Null)
-                } else {
-                    Ok(SqlValue::Boolean(true))
-                }
-            }
-
-            vibesql_ast::BinaryOperator::NotEqual => {
-                // (a, b) <> (c, d) → a <> c OR b <> d
-                let mut has_null = false;
-                for (left_val, right_val) in left_values.iter().zip(right_values.iter()) {
-                    let eq_result = ExpressionEvaluator::eval_binary_op_static(
-                        left_val,
-                        &vibesql_ast::BinaryOperator::Equal,
-                        right_val,
-                        sql_mode.clone(),
-                    )?;
-                    match eq_result {
-                        SqlValue::Boolean(false) => return Ok(SqlValue::Boolean(true)),
-                        SqlValue::Null => has_null = true,
-                        SqlValue::Boolean(true) => {}
-                        _ => {
-                            return Err(ExecutorError::TypeError(format!(
-                                "Comparison returned non-boolean: {:?}",
-                                eq_result
-                            )))
-                        }
-                    }
-                }
-                if has_null {
-                    Ok(SqlValue::Null)
-                } else {
-                    Ok(SqlValue::Boolean(false))
-                }
-            }
-
-            vibesql_ast::BinaryOperator::LessThan
-            | vibesql_ast::BinaryOperator::LessThanOrEqual
-            | vibesql_ast::BinaryOperator::GreaterThan
-            | vibesql_ast::BinaryOperator::GreaterThanOrEqual => {
-                self.eval_row_value_ordering(&left_values, op, &right_values, sql_mode)
-            }
-
-            _ => Err(ExecutorError::UnsupportedExpression(format!(
-                "Unsupported operator for row value comparison: {:?}",
-                op
-            ))),
-        }
+        crate::evaluator::row_value::compare_row_values(
+            &left_values,
+            op,
+            &right_values,
+            |l, o, r| ExpressionEvaluator::eval_binary_op_static(l, o, r, sql_mode.clone()),
+        )
     }
 
-    /// Helper for lexicographic ordering comparison of row values
-    fn eval_row_value_ordering(
+    /// Compare a row-value tuple against a scalar subquery that yields a single
+    /// row of the same arity, e.g. `(a, b, c) > (SELECT a, b, c FROM t WHERE ...)`.
+    ///
+    /// `tuple_on_left` is true when the tuple is the left-hand operand; when the
+    /// subquery is on the left the operator is flipped so the lexicographic
+    /// comparison is always evaluated tuple-on-left.
+    pub(in crate::evaluator) fn eval_row_value_subquery_comparison(
         &self,
-        left_values: &[SqlValue],
+        tuple_exprs: &[vibesql_ast::Expression],
         op: &vibesql_ast::BinaryOperator,
-        right_values: &[SqlValue],
-        sql_mode: vibesql_types::SqlMode,
+        subquery: &vibesql_ast::SelectStmt,
+        tuple_on_left: bool,
+        row: &vibesql_storage::Row,
     ) -> Result<SqlValue, ExecutorError> {
-        let is_less = matches!(
-            op,
-            vibesql_ast::BinaryOperator::LessThan | vibesql_ast::BinaryOperator::LessThanOrEqual
-        );
-        let is_or_equal = matches!(
-            op,
-            vibesql_ast::BinaryOperator::LessThanOrEqual
-                | vibesql_ast::BinaryOperator::GreaterThanOrEqual
-        );
+        if tuple_exprs.is_empty() {
+            return Err(ExecutorError::UnsupportedExpression(
+                "Empty row value constructors are not allowed".to_string(),
+            ));
+        }
 
-        let strict_op = if is_less {
-            vibesql_ast::BinaryOperator::LessThan
+        let (tuple_values, subquery_values) =
+            self.eval_row_value_tuple_and_subquery(tuple_exprs, subquery, row)?;
+
+        // Always evaluate with the tuple on the left. `subquery OP tuple` is
+        // equivalent to `tuple flip(OP) subquery`, so only the operator flips.
+        let effective_op = if tuple_on_left {
+            *op
         } else {
-            vibesql_ast::BinaryOperator::GreaterThan
+            crate::evaluator::row_value::flip_comparison_operator(op)
         };
 
-        let eq_op = vibesql_ast::BinaryOperator::Equal;
-        let mut has_null = false;
+        let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
 
-        for i in 0..left_values.len() {
-            let left_val = &left_values[i];
-            let right_val = &right_values[i];
+        crate::evaluator::row_value::compare_row_values(
+            &tuple_values,
+            &effective_op,
+            &subquery_values,
+            |l, o, r| ExpressionEvaluator::eval_binary_op_static(l, o, r, sql_mode.clone()),
+        )
+    }
 
-            let strict_result = ExpressionEvaluator::eval_binary_op_static(
-                left_val,
-                &strict_op,
-                right_val,
-                sql_mode.clone(),
-            )?;
-            match strict_result {
-                SqlValue::Boolean(true) => return Ok(SqlValue::Boolean(true)),
-                SqlValue::Null => has_null = true,
-                SqlValue::Boolean(false) => {
-                    let eq_result = ExpressionEvaluator::eval_binary_op_static(
-                        left_val,
-                        &eq_op,
-                        right_val,
-                        sql_mode.clone(),
-                    )?;
-                    match eq_result {
-                        SqlValue::Boolean(true) => {}
-                        SqlValue::Boolean(false) => return Ok(SqlValue::Boolean(false)),
-                        SqlValue::Null => has_null = true,
-                        _ => {
-                            return Err(ExecutorError::TypeError(format!(
-                                "Comparison returned non-boolean: {:?}",
-                                eq_result
-                            )))
-                        }
-                    }
-                }
-                _ => {
-                    return Err(ExecutorError::TypeError(format!(
-                        "Comparison returned non-boolean: {:?}",
-                        strict_result
-                    )))
-                }
-            }
+    /// `(a, b) IS [NOT] (SELECT ...)` — NULL-safe row-value comparison against a
+    /// scalar subquery that yields a single row of the same arity.
+    pub(in crate::evaluator) fn eval_row_value_is_distinct_subquery(
+        &self,
+        tuple_exprs: &[vibesql_ast::Expression],
+        subquery: &vibesql_ast::SelectStmt,
+        negated: bool,
+        row: &vibesql_storage::Row,
+    ) -> Result<SqlValue, ExecutorError> {
+        if tuple_exprs.is_empty() {
+            return Err(ExecutorError::UnsupportedExpression(
+                "Empty row value constructors are not allowed".to_string(),
+            ));
         }
 
-        if has_null {
-            Ok(SqlValue::Null)
-        } else if is_or_equal {
-            Ok(SqlValue::Boolean(true))
-        } else {
-            Ok(SqlValue::Boolean(false))
+        let (tuple_values, subquery_values) =
+            self.eval_row_value_tuple_and_subquery(tuple_exprs, subquery, row)?;
+
+        Ok(crate::evaluator::row_value::row_values_is_distinct(
+            &tuple_values,
+            &subquery_values,
+            negated,
+        ))
+    }
+
+    /// Shared helper for row-value-vs-subquery operators: evaluates the tuple
+    /// elements and the subquery row, applying per-element affinity (treating the
+    /// subquery columns as non-column values, like literals).
+    fn eval_row_value_tuple_and_subquery(
+        &self,
+        tuple_exprs: &[vibesql_ast::Expression],
+        subquery: &vibesql_ast::SelectStmt,
+        row: &vibesql_storage::Row,
+    ) -> Result<(Vec<SqlValue>, Vec<SqlValue>), ExecutorError> {
+        let arity = tuple_exprs.len();
+        let subquery_values = self.eval_scalar_subquery_as_row(subquery, row, arity)?;
+
+        let mut tuple_values = Vec::with_capacity(arity);
+        let mut other_values = Vec::with_capacity(arity);
+        for (tuple_expr, sub_val) in tuple_exprs.iter().zip(subquery_values) {
+            let tuple_val = self.eval(tuple_expr, row)?;
+            let synthetic = vibesql_ast::Expression::Literal(sub_val.clone());
+            let (tuple_val, sub_val) =
+                self.apply_affinity_for_comparison(tuple_expr, tuple_val, &synthetic, sub_val);
+            tuple_values.push(tuple_val);
+            other_values.push(sub_val);
         }
+        Ok((tuple_values, other_values))
+    }
+
+    /// Compare two scalar subqueries as row values, e.g.
+    /// `(SELECT a, b) == (SELECT x, y)`. Returns `Ok(None)` when both are
+    /// single-column (caller falls back to scalar comparison); `Ok(Some(result))`
+    /// for the multi-column row-value comparison. Mismatched arities error.
+    pub(in crate::evaluator) fn eval_two_subquery_row_comparison(
+        &self,
+        left_sub: &vibesql_ast::SelectStmt,
+        op: &vibesql_ast::BinaryOperator,
+        right_sub: &vibesql_ast::SelectStmt,
+        row: &vibesql_storage::Row,
+    ) -> Result<Option<SqlValue>, ExecutorError> {
+        if crate::evaluator::row_value::subquery_is_obviously_single_column(left_sub)
+            && crate::evaluator::row_value::subquery_is_obviously_single_column(right_sub)
+        {
+            return Ok(None);
+        }
+
+        let database = self.database.ok_or(ExecutorError::UnsupportedFeature(
+            "Subquery execution requires database reference".to_string(),
+        ))?;
+        let left_arity = super::subqueries::schema_utils::compute_select_list_column_count(
+            left_sub,
+            database,
+            self.cte_context,
+        )?;
+        let right_arity = super::subqueries::schema_utils::compute_select_list_column_count(
+            right_sub,
+            database,
+            self.cte_context,
+        )?;
+
+        if left_arity == 1 && right_arity == 1 {
+            return Ok(None);
+        }
+        if left_arity != right_arity {
+            return Err(ExecutorError::SubqueryColumnCountMismatch {
+                expected: left_arity,
+                actual: right_arity,
+            });
+        }
+
+        let left_values = self.eval_scalar_subquery_as_row(left_sub, row, left_arity)?;
+        let right_values = self.eval_scalar_subquery_as_row(right_sub, row, right_arity)?;
+
+        let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
+        Ok(Some(crate::evaluator::row_value::compare_row_values(
+            &left_values,
+            op,
+            &right_values,
+            |l, o, r| ExpressionEvaluator::eval_binary_op_static(l, o, r, sql_mode.clone()),
+        )?))
+    }
+
+    /// `(a, b) IS [NOT] (c, d)` — NULL-safe element-wise row-value comparison.
+    /// SQLite applies the same per-column affinity to IS / IS NOT as to = / <>.
+    pub(in crate::evaluator) fn eval_row_value_is_distinct(
+        &self,
+        left_exprs: &[vibesql_ast::Expression],
+        right_exprs: &[vibesql_ast::Expression],
+        negated: bool,
+        row: &vibesql_storage::Row,
+    ) -> Result<SqlValue, ExecutorError> {
+        if left_exprs.len() != right_exprs.len() {
+            return Err(ExecutorError::UnsupportedExpression(format!(
+                "Row value constructor size mismatch: left has {} elements, right has {}",
+                left_exprs.len(),
+                right_exprs.len()
+            )));
+        }
+        if left_exprs.is_empty() {
+            return Err(ExecutorError::UnsupportedExpression(
+                "Empty row value constructors are not allowed".to_string(),
+            ));
+        }
+
+        let mut left_values = Vec::with_capacity(left_exprs.len());
+        let mut right_values = Vec::with_capacity(right_exprs.len());
+        for (left_expr, right_expr) in left_exprs.iter().zip(right_exprs.iter()) {
+            let left_val = self.eval(left_expr, row)?;
+            let right_val = self.eval(right_expr, row)?;
+            let (left_val, right_val) =
+                self.apply_affinity_for_comparison(left_expr, left_val, right_expr, right_val);
+            left_values.push(left_val);
+            right_values.push(right_val);
+        }
+
+        Ok(crate::evaluator::row_value::row_values_is_distinct(
+            &left_values,
+            &right_values,
+            negated,
+        ))
     }
 }

--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -588,6 +588,33 @@ impl CombinedExpressionEvaluator<'_> {
         negated: bool,
         row: &vibesql_storage::Row,
     ) -> Result<vibesql_types::SqlValue, ExecutorError> {
+        // Row-value IS / IS NOT: `(a, b) IS (c, d)` and the subquery form
+        // `(a, b, c) IS (SELECT a, b, c FROM ...)`. NULL-safe, element-wise.
+        match (left, right) {
+            (
+                vibesql_ast::Expression::RowValueConstructor(left_exprs),
+                vibesql_ast::Expression::RowValueConstructor(right_exprs),
+            ) => {
+                return self.eval_row_value_is_distinct(left_exprs, right_exprs, negated, row);
+            }
+            (
+                vibesql_ast::Expression::RowValueConstructor(tuple_exprs),
+                vibesql_ast::Expression::ScalarSubquery(subquery),
+            )
+            | (
+                vibesql_ast::Expression::ScalarSubquery(subquery),
+                vibesql_ast::Expression::RowValueConstructor(tuple_exprs),
+            ) => {
+                return self.eval_row_value_is_distinct_subquery(
+                    tuple_exprs,
+                    subquery,
+                    negated,
+                    row,
+                );
+            }
+            _ => {}
+        }
+
         let left_val = self.eval(left, row)?;
         let right_val = self.eval(right, row)?;
 

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/scalar.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/scalar.rs
@@ -59,6 +59,59 @@ impl CombinedExpressionEvaluator<'_> {
         subquery: &vibesql_ast::SelectStmt,
         row: &vibesql_storage::Row,
     ) -> Result<vibesql_types::SqlValue, ExecutorError> {
+        let rows = self.execute_scalar_subquery_rows(subquery, row)?;
+        crate::evaluator::subqueries_shared::eval_scalar_subquery_core(&rows)
+    }
+
+    /// Evaluate a scalar subquery as a row value of `expected` columns, for use
+    /// in row-value comparisons like `(a, b, c) > (SELECT a, b, c FROM ...)`.
+    ///
+    /// Returns the first result row's values (SQLite uses the first row when a
+    /// scalar subquery yields several). A subquery returning no rows behaves as a
+    /// row of NULLs. The column count is validated against `expected`.
+    pub(in crate::evaluator) fn eval_scalar_subquery_as_row(
+        &self,
+        subquery: &vibesql_ast::SelectStmt,
+        row: &vibesql_storage::Row,
+        expected: usize,
+    ) -> Result<Vec<vibesql_types::SqlValue>, ExecutorError> {
+        let rows = self.execute_scalar_subquery_rows(subquery, row)?;
+        if rows.is_empty() {
+            let database = self.database.ok_or(ExecutorError::UnsupportedFeature(
+                "Subquery execution requires database reference".to_string(),
+            ))?;
+            let column_count = super::schema_utils::compute_select_list_column_count(
+                subquery,
+                database,
+                self.cte_context,
+            )?;
+            if column_count != expected {
+                return Err(ExecutorError::SubqueryColumnCountMismatch {
+                    expected,
+                    actual: column_count,
+                });
+            }
+            return Ok(vec![vibesql_types::SqlValue::Null; expected]);
+        }
+
+        let first = &rows[0];
+        if first.values.len() != expected {
+            return Err(ExecutorError::SubqueryColumnCountMismatch {
+                expected,
+                actual: first.values.len(),
+            });
+        }
+        Ok(first.values.to_vec())
+    }
+
+    /// Execute a scalar subquery and return its result rows (without the
+    /// single-row / single-column reduction). Shared by `eval_scalar_subquery`
+    /// and `eval_scalar_subquery_as_row`.
+    pub(in crate::evaluator::combined) fn execute_scalar_subquery_rows(
+        &self,
+        subquery: &vibesql_ast::SelectStmt,
+        row: &vibesql_storage::Row,
+    ) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
         // Check depth limit to prevent stack overflow
         if self.depth >= crate::limits::MAX_EXPRESSION_DEPTH {
             return Err(ExecutorError::ExpressionDepthExceeded {
@@ -137,7 +190,7 @@ impl CombinedExpressionEvaluator<'_> {
                     )
                 };
                 let rows = select_executor.execute(subquery)?;
-                return crate::evaluator::subqueries_shared::eval_scalar_subquery_core(&rows);
+                return Ok(rows);
             }
         } else {
             // Has outer_schema but not in schema.table_schemas - still pass outer context!
@@ -183,7 +236,7 @@ impl CombinedExpressionEvaluator<'_> {
                 )
             };
             let rows = select_executor.execute(subquery)?;
-            return crate::evaluator::subqueries_shared::eval_scalar_subquery_core(&rows);
+            return Ok(rows);
         };
 
         // Try cache lookup
@@ -252,7 +305,6 @@ impl CombinedExpressionEvaluator<'_> {
             executed_rows
         };
 
-        // Delegate to shared logic
-        crate::evaluator::subqueries_shared::eval_scalar_subquery_core(&rows)
+        Ok(rows)
     }
 }

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -569,14 +569,49 @@ impl ExpressionEvaluator<'_> {
 
                         // Handle row value constructor comparisons
                         // SQL:1999 Section 7.1: Row value constructor comparison
-                        // (a, b) op (c, d) uses lexicographic ordering
+                        // (a, b) op (c, d) uses lexicographic ordering. The
+                        // right-hand side may also be a scalar subquery that
+                        // returns a row of the same arity, e.g.
+                        // (a, b, c) > (SELECT a, b, c FROM t WHERE ...).
                         if is_comparison {
-                            if let (
-                                vibesql_ast::Expression::RowValueConstructor(left_values),
-                                vibesql_ast::Expression::RowValueConstructor(right_values),
-                            ) = (left.as_ref(), right.as_ref())
-                            {
-                                return self.eval_row_value_comparison(left_values, op, right_values, row);
+                            match (left.as_ref(), right.as_ref()) {
+                                (
+                                    vibesql_ast::Expression::RowValueConstructor(left_values),
+                                    vibesql_ast::Expression::RowValueConstructor(right_values),
+                                ) => {
+                                    return self.eval_row_value_comparison(left_values, op, right_values, row);
+                                }
+                                (
+                                    vibesql_ast::Expression::RowValueConstructor(tuple_exprs),
+                                    vibesql_ast::Expression::ScalarSubquery(subquery),
+                                ) => {
+                                    return self.eval_row_value_subquery_comparison(
+                                        tuple_exprs, op, subquery, true, row,
+                                    );
+                                }
+                                (
+                                    vibesql_ast::Expression::ScalarSubquery(subquery),
+                                    vibesql_ast::Expression::RowValueConstructor(tuple_exprs),
+                                ) => {
+                                    return self.eval_row_value_subquery_comparison(
+                                        tuple_exprs, op, subquery, false, row,
+                                    );
+                                }
+                                (
+                                    vibesql_ast::Expression::ScalarSubquery(left_sub),
+                                    vibesql_ast::Expression::ScalarSubquery(right_sub),
+                                ) => {
+                                    // Two multi-column subqueries compared as row
+                                    // values, e.g. (SELECT a,b)==(SELECT x,y). When
+                                    // both are single-column this returns None and
+                                    // we fall through to scalar comparison.
+                                    if let Some(result) = self
+                                        .eval_two_subquery_row_comparison(left_sub, op, right_sub, row)?
+                                    {
+                                        return Ok(result);
+                                    }
+                                }
+                                _ => {}
                             }
                         }
 
@@ -770,12 +805,26 @@ impl ExpressionEvaluator<'_> {
                 // Handle row value constructor IS [NOT] DISTINCT FROM
                 // (a, b) IS (c, d) is equivalent to (a, b) IS NOT DISTINCT FROM (c, d)
                 // SQLite: a IS b returns TRUE if both are NULL or both are equal (not NULL-propagating)
-                if let (
-                    vibesql_ast::Expression::RowValueConstructor(left_exprs),
-                    vibesql_ast::Expression::RowValueConstructor(right_exprs),
-                ) = (left.as_ref(), right.as_ref())
-                {
-                    return self.eval_row_value_is_distinct(left_exprs, right_exprs, *negated, row);
+                match (left.as_ref(), right.as_ref()) {
+                    (
+                        vibesql_ast::Expression::RowValueConstructor(left_exprs),
+                        vibesql_ast::Expression::RowValueConstructor(right_exprs),
+                    ) => {
+                        return self.eval_row_value_is_distinct(left_exprs, right_exprs, *negated, row);
+                    }
+                    (
+                        vibesql_ast::Expression::RowValueConstructor(tuple_exprs),
+                        vibesql_ast::Expression::ScalarSubquery(subquery),
+                    )
+                    | (
+                        vibesql_ast::Expression::ScalarSubquery(subquery),
+                        vibesql_ast::Expression::RowValueConstructor(tuple_exprs),
+                    ) => {
+                        return self.eval_row_value_is_distinct_subquery(
+                            tuple_exprs, subquery, *negated, row,
+                        );
+                    }
+                    _ => {}
                 }
 
                 let left_val = self.eval(left, row)?;
@@ -1358,182 +1407,177 @@ impl ExpressionEvaluator<'_> {
             ));
         }
 
-        // Evaluate all elements
+        // Evaluate each element pair and apply per-column SQLite type affinity,
+        // mirroring the scalar comparison path so that mixed TEXT/NUMERIC tuples
+        // (e.g. (textcol, intcol) == (intcol, textcol)) compare per SQLite rules
+        // instead of by raw storage class.
         let mut left_values = Vec::with_capacity(left_exprs.len());
         let mut right_values = Vec::with_capacity(right_exprs.len());
 
         for (left_expr, right_expr) in left_exprs.iter().zip(right_exprs.iter()) {
-            left_values.push(self.eval(left_expr, row)?);
-            right_values.push(self.eval(right_expr, row)?);
+            let left_val = self.eval(left_expr, row)?;
+            let right_val = self.eval(right_expr, row)?;
+            let (left_val, right_val) =
+                self.apply_affinity_for_comparison(left_expr, left_val, right_expr, right_val);
+            left_values.push(left_val);
+            right_values.push(right_val);
         }
 
-        // Perform comparison based on operator
-        match op {
-            vibesql_ast::BinaryOperator::Equal => {
-                // (a, b) = (c, d) → a = c AND b = d
-                // If any comparison is NULL, result is NULL (unless a definite FALSE)
-                let mut has_null = false;
-                for (left_val, right_val) in left_values.iter().zip(right_values.iter()) {
-                    let cmp_result = self.eval_binary_op(left_val, op, right_val)?;
-                    match cmp_result {
-                        SqlValue::Boolean(false) => return Ok(SqlValue::Boolean(false)),
-                        SqlValue::Null => has_null = true,
-                        SqlValue::Boolean(true) => {}
-                        _ => {
-                            return Err(ExecutorError::TypeError(format!(
-                                "Comparison returned non-boolean: {:?}",
-                                cmp_result
-                            )))
-                        }
-                    }
-                }
-                if has_null {
-                    Ok(SqlValue::Null)
-                } else {
-                    Ok(SqlValue::Boolean(true))
-                }
-            }
-
-            vibesql_ast::BinaryOperator::NotEqual => {
-                // (a, b) <> (c, d) → a <> c OR b <> d
-                // If any comparison is TRUE, result is TRUE
-                // If any comparison is NULL and no TRUE found, result is NULL
-                let mut has_null = false;
-                for (left_val, right_val) in left_values.iter().zip(right_values.iter()) {
-                    let eq_result = self.eval_binary_op(
-                        left_val,
-                        &vibesql_ast::BinaryOperator::Equal,
-                        right_val,
-                    )?;
-                    match eq_result {
-                        SqlValue::Boolean(false) => return Ok(SqlValue::Boolean(true)), // Not equal found
-                        SqlValue::Null => has_null = true,
-                        SqlValue::Boolean(true) => {} // Equal, continue checking
-                        _ => {
-                            return Err(ExecutorError::TypeError(format!(
-                                "Comparison returned non-boolean: {:?}",
-                                eq_result
-                            )))
-                        }
-                    }
-                }
-                if has_null {
-                    Ok(SqlValue::Null)
-                } else {
-                    Ok(SqlValue::Boolean(false)) // All elements were equal
-                }
-            }
-
-            vibesql_ast::BinaryOperator::LessThan
-            | vibesql_ast::BinaryOperator::LessThanOrEqual
-            | vibesql_ast::BinaryOperator::GreaterThan
-            | vibesql_ast::BinaryOperator::GreaterThanOrEqual => {
-                // Lexicographic ordering: compare element by element
-                // (a, b) < (c, d) → a < c OR (a = c AND b < d)
-                self.eval_row_value_ordering(&left_values, op, &right_values)
-            }
-
-            _ => Err(ExecutorError::UnsupportedExpression(format!(
-                "Unsupported operator for row value comparison: {:?}",
-                op
-            ))),
-        }
+        crate::evaluator::row_value::compare_row_values(
+            &left_values,
+            op,
+            &right_values,
+            |l, o, r| self.eval_binary_op(l, o, r),
+        )
     }
 
-    /// Helper for lexicographic ordering comparison of row values
+    /// Compare a row-value tuple against a scalar subquery that yields a single
+    /// row of the same arity, e.g. `(a, b, c) > (SELECT a, b, c FROM t WHERE ...)`.
     ///
-    /// For < and <=:
-    /// (a, b) < (c, d) → a < c OR (a = c AND b < d)
-    ///
-    /// For > and >=:
-    /// (a, b) > (c, d) → a > c OR (a = c AND b > d)
-    fn eval_row_value_ordering(
+    /// `tuple_on_left` is true when the tuple is the left-hand operand; when the
+    /// subquery is on the left the operator is flipped so the lexicographic
+    /// comparison is always evaluated tuple-on-left.
+    pub(super) fn eval_row_value_subquery_comparison(
         &self,
-        left_values: &[SqlValue],
+        tuple_exprs: &[vibesql_ast::Expression],
         op: &vibesql_ast::BinaryOperator,
-        right_values: &[SqlValue],
+        subquery: &vibesql_ast::SelectStmt,
+        tuple_on_left: bool,
+        row: &vibesql_storage::Row,
     ) -> Result<SqlValue, ExecutorError> {
-        let is_less = matches!(
-            op,
-            vibesql_ast::BinaryOperator::LessThan | vibesql_ast::BinaryOperator::LessThanOrEqual
-        );
-        let is_or_equal = matches!(
-            op,
-            vibesql_ast::BinaryOperator::LessThanOrEqual
-                | vibesql_ast::BinaryOperator::GreaterThanOrEqual
-        );
+        if tuple_exprs.is_empty() {
+            return Err(ExecutorError::UnsupportedExpression(
+                "Empty row value constructors are not allowed".to_string(),
+            ));
+        }
 
-        // The strict comparison operator (without the equality part)
-        let strict_op = if is_less {
-            vibesql_ast::BinaryOperator::LessThan
+        let (tuple_values, subquery_values) =
+            self.eval_row_value_tuple_and_subquery(tuple_exprs, subquery, row)?;
+
+        // Always evaluate with the tuple on the left. When the subquery was the
+        // original left-hand operand (`subquery OP tuple`), that is equivalent to
+        // `tuple flip(OP) subquery`, so only the operator is flipped.
+        let effective_op = if tuple_on_left {
+            *op
         } else {
-            vibesql_ast::BinaryOperator::GreaterThan
+            crate::evaluator::row_value::flip_comparison_operator(op)
         };
 
-        let eq_op = vibesql_ast::BinaryOperator::Equal;
+        crate::evaluator::row_value::compare_row_values(
+            &tuple_values,
+            &effective_op,
+            &subquery_values,
+            |l, o, r| self.eval_binary_op(l, o, r),
+        )
+    }
 
-        // Track if we've seen NULL in any comparison
-        let mut has_null = false;
-
-        // Compare element by element
-        for i in 0..left_values.len() {
-            let left_val = &left_values[i];
-            let right_val = &right_values[i];
-
-            // First check if this element satisfies the strict inequality
-            let strict_result = self.eval_binary_op(left_val, &strict_op, right_val)?;
-            match strict_result {
-                SqlValue::Boolean(true) => {
-                    // Strict inequality satisfied at this position → result is TRUE
-                    return Ok(SqlValue::Boolean(true));
-                }
-                SqlValue::Null => {
-                    // NULL comparison - we can't determine result yet
-                    has_null = true;
-                }
-                SqlValue::Boolean(false) => {
-                    // Not strictly less/greater - check if equal
-                    let eq_result = self.eval_binary_op(left_val, &eq_op, right_val)?;
-                    match eq_result {
-                        SqlValue::Boolean(true) => {
-                            // Equal at this position - continue to next element
-                        }
-                        SqlValue::Boolean(false) => {
-                            // Not equal and not strictly less/greater means strictly greater/less
-                            // So the comparison fails
-                            return Ok(SqlValue::Boolean(false));
-                        }
-                        SqlValue::Null => {
-                            has_null = true;
-                        }
-                        _ => {
-                            return Err(ExecutorError::TypeError(format!(
-                                "Comparison returned non-boolean: {:?}",
-                                eq_result
-                            )))
-                        }
-                    }
-                }
-                _ => {
-                    return Err(ExecutorError::TypeError(format!(
-                        "Comparison returned non-boolean: {:?}",
-                        strict_result
-                    )))
-                }
-            }
+    /// `(a, b) IS [NOT] (SELECT ...)` — NULL-safe row-value comparison against a
+    /// scalar subquery that yields a single row of the same arity.
+    pub(super) fn eval_row_value_is_distinct_subquery(
+        &self,
+        tuple_exprs: &[vibesql_ast::Expression],
+        subquery: &vibesql_ast::SelectStmt,
+        negated: bool,
+        row: &vibesql_storage::Row,
+    ) -> Result<SqlValue, ExecutorError> {
+        if tuple_exprs.is_empty() {
+            return Err(ExecutorError::UnsupportedExpression(
+                "Empty row value constructors are not allowed".to_string(),
+            ));
         }
 
-        // We've compared all elements and they were all equal (no strict inequality found)
-        if has_null {
-            // NULL was encountered somewhere
-            Ok(SqlValue::Null)
-        } else if is_or_equal {
-            // For <= or >=, all equal means TRUE
-            Ok(SqlValue::Boolean(true))
-        } else {
-            // For < or >, all equal means FALSE
-            Ok(SqlValue::Boolean(false))
+        let (tuple_values, subquery_values) =
+            self.eval_row_value_tuple_and_subquery(tuple_exprs, subquery, row)?;
+
+        Ok(crate::evaluator::row_value::row_values_is_distinct(
+            &tuple_values,
+            &subquery_values,
+            negated,
+        ))
+    }
+
+    /// Shared helper for row-value-vs-subquery operators: evaluates the tuple
+    /// elements and the subquery row, applying per-element affinity (treating the
+    /// subquery columns as non-column values, like literals) so the returned
+    /// value pairs are ready for comparison.
+    fn eval_row_value_tuple_and_subquery(
+        &self,
+        tuple_exprs: &[vibesql_ast::Expression],
+        subquery: &vibesql_ast::SelectStmt,
+        row: &vibesql_storage::Row,
+    ) -> Result<(Vec<SqlValue>, Vec<SqlValue>), ExecutorError> {
+        let arity = tuple_exprs.len();
+        let subquery_values = self.eval_scalar_subquery_as_row(subquery, row, arity)?;
+
+        let mut tuple_values = Vec::with_capacity(arity);
+        let mut other_values = Vec::with_capacity(arity);
+        for (tuple_expr, sub_val) in tuple_exprs.iter().zip(subquery_values) {
+            let tuple_val = self.eval(tuple_expr, row)?;
+            // Treat the subquery result column as a non-column value so the same
+            // affinity rules used for `tuple_col <op> <computed value>` apply.
+            let synthetic = vibesql_ast::Expression::Literal(sub_val.clone());
+            let (tuple_val, sub_val) =
+                self.apply_affinity_for_comparison(tuple_expr, tuple_val, &synthetic, sub_val);
+            tuple_values.push(tuple_val);
+            other_values.push(sub_val);
         }
+        Ok((tuple_values, other_values))
+    }
+
+    /// Compare two scalar subqueries as row values, e.g.
+    /// `(SELECT a, b) == (SELECT x, y)`. Returns `Ok(None)` when both subqueries
+    /// are single-column (the caller then performs an ordinary scalar
+    /// comparison); returns `Ok(Some(result))` for the multi-column row-value
+    /// comparison. Mismatched arities raise a SQLite-compatible column-count error.
+    pub(super) fn eval_two_subquery_row_comparison(
+        &self,
+        left_sub: &vibesql_ast::SelectStmt,
+        op: &vibesql_ast::BinaryOperator,
+        right_sub: &vibesql_ast::SelectStmt,
+        row: &vibesql_storage::Row,
+    ) -> Result<Option<SqlValue>, ExecutorError> {
+        // Fast path: two obviously single-column subqueries are a scalar compare.
+        if crate::evaluator::row_value::subquery_is_obviously_single_column(left_sub)
+            && crate::evaluator::row_value::subquery_is_obviously_single_column(right_sub)
+        {
+            return Ok(None);
+        }
+
+        let database = self.database.ok_or(ExecutorError::UnsupportedFeature(
+            "Subquery execution requires database reference".to_string(),
+        ))?;
+        let left_arity =
+            crate::evaluator::combined::subqueries::schema_utils::compute_select_list_column_count(
+                left_sub,
+                database,
+                self.cte_context,
+            )?;
+        let right_arity =
+            crate::evaluator::combined::subqueries::schema_utils::compute_select_list_column_count(
+                right_sub,
+                database,
+                self.cte_context,
+            )?;
+
+        if left_arity == 1 && right_arity == 1 {
+            return Ok(None);
+        }
+        if left_arity != right_arity {
+            return Err(ExecutorError::SubqueryColumnCountMismatch {
+                expected: left_arity,
+                actual: right_arity,
+            });
+        }
+
+        let left_values = self.eval_scalar_subquery_as_row(left_sub, row, left_arity)?;
+        let right_values = self.eval_scalar_subquery_as_row(right_sub, row, right_arity)?;
+
+        Ok(Some(crate::evaluator::row_value::compare_row_values(
+            &left_values,
+            op,
+            &right_values,
+            |l, o, r| self.eval_binary_op(l, o, r),
+        )?))
     }
 
     /// Evaluate row value IS [NOT] DISTINCT FROM comparison
@@ -1544,7 +1588,7 @@ impl ExpressionEvaluator<'_> {
     /// - `(a, b) IS NOT (c, d)` means `(a, b) IS DISTINCT FROM (c, d)`
     ///   Returns TRUE if any element is distinct (NULL IS NOT NULL = TRUE)
     ///
-    /// Note: This differs from `=` comparison where NULL = NULL returns NULL
+    /// SQLite applies the same per-column affinity to IS / IS NOT as to = / <>.
     fn eval_row_value_is_distinct(
         &self,
         left_exprs: &[vibesql_ast::Expression],
@@ -1568,34 +1612,22 @@ impl ExpressionEvaluator<'_> {
             ));
         }
 
-        // Evaluate all elements and check distinctness
-        // IS NOT DISTINCT FROM (negated=true in SQLite's IS syntax):
-        //   All elements must be "not distinct" (NULL-safe equal)
-        // IS DISTINCT FROM (negated=false in SQLite's IS NOT syntax):
-        //   At least one element must be "distinct"
+        // Evaluate all elements with per-column affinity, then compare NULL-safely.
+        let mut left_values = Vec::with_capacity(left_exprs.len());
+        let mut right_values = Vec::with_capacity(right_exprs.len());
         for (left_expr, right_expr) in left_exprs.iter().zip(right_exprs.iter()) {
             let left_val = self.eval(left_expr, row)?;
             let right_val = self.eval(right_expr, row)?;
-
-            let is_distinct = super::super::core::values_are_distinct(&left_val, &right_val);
-
-            if negated {
-                // IS NOT DISTINCT FROM: all must be not distinct
-                // If any is distinct, return FALSE
-                if is_distinct {
-                    return Ok(SqlValue::Boolean(false));
-                }
-            } else {
-                // IS DISTINCT FROM: if any is distinct, return TRUE
-                if is_distinct {
-                    return Ok(SqlValue::Boolean(true));
-                }
-            }
+            let (left_val, right_val) =
+                self.apply_affinity_for_comparison(left_expr, left_val, right_expr, right_val);
+            left_values.push(left_val);
+            right_values.push(right_val);
         }
 
-        // If we get here:
-        // - For IS NOT DISTINCT FROM (negated=true): all were not distinct → TRUE
-        // - For IS DISTINCT FROM (negated=false): none were distinct → FALSE
-        Ok(SqlValue::Boolean(negated))
+        Ok(crate::evaluator::row_value::row_values_is_distinct(
+            &left_values,
+            &right_values,
+            negated,
+        ))
     }
 }

--- a/crates/vibesql-executor/src/evaluator/expressions/subqueries.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/subqueries.rs
@@ -203,6 +203,64 @@ impl ExpressionEvaluator<'_> {
         subquery: &vibesql_ast::SelectStmt,
         row: &vibesql_storage::Row,
     ) -> Result<vibesql_types::SqlValue, ExecutorError> {
+        let rows = self.execute_scalar_subquery_rows(subquery, row)?;
+        super::super::subqueries_shared::eval_scalar_subquery_core(&rows)
+    }
+
+    /// Evaluate a scalar subquery as a row value of `expected` columns, for use
+    /// in row-value comparisons like `(a, b, c) > (SELECT a, b, c FROM ...)`.
+    ///
+    /// Returns the first result row's values (SQLite uses the first row when a
+    /// scalar subquery yields several). A subquery returning no rows behaves as a
+    /// row of NULLs. The column count is validated against `expected`, producing
+    /// a SQLite-compatible "sub-select returns N values" arity error on mismatch.
+    pub(super) fn eval_scalar_subquery_as_row(
+        &self,
+        subquery: &vibesql_ast::SelectStmt,
+        row: &vibesql_storage::Row,
+        expected: usize,
+    ) -> Result<Vec<vibesql_types::SqlValue>, ExecutorError> {
+        let rows = self.execute_scalar_subquery_rows(subquery, row)?;
+        if rows.is_empty() {
+            // No rows: behaves as a row of NULLs, but still validate arity so a
+            // width mismatch reports the same error SQLite raises at prepare time.
+            let database = self.database.ok_or(ExecutorError::UnsupportedFeature(
+                "Subquery execution requires database reference".to_string(),
+            ))?;
+            let column_count =
+                crate::evaluator::combined::subqueries::schema_utils::compute_select_list_column_count(
+                    subquery,
+                    database,
+                    self.cte_context,
+                )?;
+            if column_count != expected {
+                return Err(ExecutorError::SubqueryColumnCountMismatch {
+                    expected,
+                    actual: column_count,
+                });
+            }
+            return Ok(vec![vibesql_types::SqlValue::Null; expected]);
+        }
+
+        let first = &rows[0];
+        if first.values.len() != expected {
+            return Err(ExecutorError::SubqueryColumnCountMismatch {
+                expected,
+                actual: first.values.len(),
+            });
+        }
+        Ok(first.values.to_vec())
+    }
+
+    /// Execute a scalar subquery and return its result rows (without the
+    /// single-row / single-column reduction). Shared by `eval_scalar_subquery`
+    /// (which reduces to one value) and `eval_scalar_subquery_as_row` (which
+    /// keeps the full row for row-value comparisons).
+    pub(super) fn execute_scalar_subquery_rows(
+        &self,
+        subquery: &vibesql_ast::SelectStmt,
+        row: &vibesql_storage::Row,
+    ) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
         // Check depth limit to prevent stack overflow
         if self.depth >= crate::limits::MAX_EXPRESSION_DEPTH {
             return Err(ExecutorError::ExpressionDepthExceeded {
@@ -241,7 +299,7 @@ impl ExpressionEvaluator<'_> {
             let substituted = substitute_trigger_pseudo_vars(subquery, trigger_ctx)?;
             let select_executor = crate::select::SelectExecutor::new_with_depth(database, self.depth);
             let rows = select_executor.execute(&substituted)?;
-            return super::super::subqueries_shared::eval_scalar_subquery_core(&rows);
+            return Ok(rows);
         }
 
         let rows = {
@@ -295,8 +353,7 @@ impl ExpressionEvaluator<'_> {
             }
         };
 
-        // Delegate to shared logic
-        super::super::subqueries_shared::eval_scalar_subquery_core(&rows)
+        Ok(rows)
     }
 
     /// Evaluate EXISTS predicate

--- a/crates/vibesql-executor/src/evaluator/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod parallel;
 mod parallel;
 pub(crate) mod pattern;
 pub(crate) mod raise;
+pub(crate) mod row_value;
 mod schema_context;
 mod single;
 mod subqueries_shared;

--- a/crates/vibesql-executor/src/evaluator/row_value.rs
+++ b/crates/vibesql-executor/src/evaluator/row_value.rs
@@ -1,0 +1,205 @@
+//! Shared row-value (tuple) comparison logic
+//!
+//! Row values are tuples used in comparisons and IN, e.g. `(a, b) = (1, 2)`,
+//! `(a, b) < (c, d)`, `(a, b, c) > (SELECT a, b, c FROM t WHERE ...)`.
+//!
+//! The functions here operate on already-evaluated value slices so they can be
+//! shared by both the single-table `ExpressionEvaluator` and the multi-table
+//! `CombinedExpressionEvaluator`, and reused whether the right-hand side is a
+//! literal tuple or a row produced by a scalar subquery. Each evaluator supplies
+//! its own scalar comparison via the `eval_op` closure (one uses an instance
+//! method, the other a static method that also threads `SqlMode`).
+//!
+//! ## SQL semantics (SQL:1999 §7.1, matching SQLite)
+//!
+//! Comparison is lexicographic with three-valued NULL logic:
+//! - `=`  : TRUE iff every element compares equal; FALSE as soon as one element
+//!   is definitively unequal; otherwise (some element comparison UNKNOWN and no
+//!   definitive inequality) UNKNOWN (NULL).
+//! - `<>` : the negation of `=` (TRUE as soon as one element is definitively
+//!   unequal; FALSE if all equal; otherwise UNKNOWN).
+//! - `<`, `<=`, `>`, `>=` : compare element by element; a NULL at the first
+//!   differing position makes the ordering UNKNOWN (NULL) immediately, while a
+//!   definite strict inequality settles the result even if later elements are
+//!   NULL.
+
+use vibesql_types::SqlValue;
+
+use crate::errors::ExecutorError;
+
+/// Compare two already-evaluated row values with a comparison operator.
+///
+/// `eval_op` performs the scalar comparison for a single element pair and must
+/// return `Boolean(_)` or `Null`. The operator must be one of the six SQL
+/// comparison operators; anything else yields an `UnsupportedExpression` error.
+pub(crate) fn compare_row_values<F>(
+    left_values: &[SqlValue],
+    op: &vibesql_ast::BinaryOperator,
+    right_values: &[SqlValue],
+    eval_op: F,
+) -> Result<SqlValue, ExecutorError>
+where
+    F: Fn(&SqlValue, &vibesql_ast::BinaryOperator, &SqlValue) -> Result<SqlValue, ExecutorError>,
+{
+    use vibesql_ast::BinaryOperator;
+
+    match op {
+        BinaryOperator::Equal => {
+            // (a, b) = (c, d) → a = c AND b = d
+            let mut has_null = false;
+            for (left_val, right_val) in left_values.iter().zip(right_values.iter()) {
+                match eval_op(left_val, op, right_val)? {
+                    SqlValue::Boolean(false) => return Ok(SqlValue::Boolean(false)),
+                    SqlValue::Null => has_null = true,
+                    SqlValue::Boolean(true) => {}
+                    other => {
+                        return Err(ExecutorError::TypeError(format!(
+                            "Comparison returned non-boolean: {:?}",
+                            other
+                        )))
+                    }
+                }
+            }
+            Ok(if has_null { SqlValue::Null } else { SqlValue::Boolean(true) })
+        }
+
+        BinaryOperator::NotEqual => {
+            // (a, b) <> (c, d) → a <> c OR b <> d
+            let mut has_null = false;
+            for (left_val, right_val) in left_values.iter().zip(right_values.iter()) {
+                match eval_op(left_val, &BinaryOperator::Equal, right_val)? {
+                    SqlValue::Boolean(false) => return Ok(SqlValue::Boolean(true)),
+                    SqlValue::Null => has_null = true,
+                    SqlValue::Boolean(true) => {}
+                    other => {
+                        return Err(ExecutorError::TypeError(format!(
+                            "Comparison returned non-boolean: {:?}",
+                            other
+                        )))
+                    }
+                }
+            }
+            Ok(if has_null { SqlValue::Null } else { SqlValue::Boolean(false) })
+        }
+
+        BinaryOperator::LessThan
+        | BinaryOperator::LessThanOrEqual
+        | BinaryOperator::GreaterThan
+        | BinaryOperator::GreaterThanOrEqual => {
+            compare_row_values_ordering(left_values, op, right_values, eval_op)
+        }
+
+        _ => Err(ExecutorError::UnsupportedExpression(format!(
+            "Unsupported operator for row value comparison: {:?}",
+            op
+        ))),
+    }
+}
+
+/// Lexicographic ordering comparison (`<`, `<=`, `>`, `>=`) on evaluated values.
+fn compare_row_values_ordering<F>(
+    left_values: &[SqlValue],
+    op: &vibesql_ast::BinaryOperator,
+    right_values: &[SqlValue],
+    eval_op: F,
+) -> Result<SqlValue, ExecutorError>
+where
+    F: Fn(&SqlValue, &vibesql_ast::BinaryOperator, &SqlValue) -> Result<SqlValue, ExecutorError>,
+{
+    use vibesql_ast::BinaryOperator;
+
+    let is_less = matches!(op, BinaryOperator::LessThan | BinaryOperator::LessThanOrEqual);
+    let is_or_equal =
+        matches!(op, BinaryOperator::LessThanOrEqual | BinaryOperator::GreaterThanOrEqual);
+
+    // The strict comparison operator (without the equality part).
+    let strict_op = if is_less { BinaryOperator::LessThan } else { BinaryOperator::GreaterThan };
+    let eq_op = BinaryOperator::Equal;
+
+    for (left_val, right_val) in left_values.iter().zip(right_values.iter()) {
+        // We only reach this position because every prior element compared
+        // definitively equal, so this element decides the lexicographic order:
+        //  - a definite strict inequality settles the result (TRUE),
+        //  - a definite equality moves on to the next element,
+        //  - a definite non-equality (with strict FALSE) settles it (FALSE),
+        //  - a NULL on either side makes this first differing position
+        //    undetermined, so the whole comparison is UNKNOWN. It must return
+        //    NULL *immediately* — a later element must not be allowed to force a
+        //    definite result once the ordering is already undetermined here.
+        match eval_op(left_val, &strict_op, right_val)? {
+            SqlValue::Boolean(true) => return Ok(SqlValue::Boolean(true)),
+            SqlValue::Null => return Ok(SqlValue::Null),
+            SqlValue::Boolean(false) => {
+                // Not strictly less/greater — only continue if elements are equal.
+                match eval_op(left_val, &eq_op, right_val)? {
+                    SqlValue::Boolean(true) => {} // equal here, look at next element
+                    SqlValue::Boolean(false) => return Ok(SqlValue::Boolean(false)),
+                    SqlValue::Null => return Ok(SqlValue::Null),
+                    other => {
+                        return Err(ExecutorError::TypeError(format!(
+                            "Comparison returned non-boolean: {:?}",
+                            other
+                        )))
+                    }
+                }
+            }
+            other => {
+                return Err(ExecutorError::TypeError(format!(
+                    "Comparison returned non-boolean: {:?}",
+                    other
+                )))
+            }
+        }
+    }
+
+    // All elements compared definitively equal: <= / >= are TRUE, < / > FALSE.
+    Ok(SqlValue::Boolean(is_or_equal))
+}
+
+/// Cheap static check: is a subquery *obviously* single-column (so a comparison
+/// with it is an ordinary scalar comparison, not a row-value comparison)? Returns
+/// true only for a single non-wildcard projected expression with no set
+/// operation; anything with a wildcard or set operation needs a schema-aware
+/// column-count computation to decide.
+pub(crate) fn subquery_is_obviously_single_column(sub: &vibesql_ast::SelectStmt) -> bool {
+    sub.set_operation.is_none()
+        && sub.select_list.len() == 1
+        && matches!(sub.select_list[0], vibesql_ast::SelectItem::Expression { .. })
+}
+
+/// Flip a comparison operator so the operands can be swapped while preserving
+/// the comparison's meaning (`a < b` ⇔ `b > a`). Equality operators are
+/// symmetric and returned unchanged.
+pub(crate) fn flip_comparison_operator(
+    op: &vibesql_ast::BinaryOperator,
+) -> vibesql_ast::BinaryOperator {
+    use vibesql_ast::BinaryOperator;
+    match op {
+        BinaryOperator::LessThan => BinaryOperator::GreaterThan,
+        BinaryOperator::LessThanOrEqual => BinaryOperator::GreaterThanOrEqual,
+        BinaryOperator::GreaterThan => BinaryOperator::LessThan,
+        BinaryOperator::GreaterThanOrEqual => BinaryOperator::LessThanOrEqual,
+        other => *other,
+    }
+}
+
+/// Row-value `IS [NOT] DISTINCT FROM` on already-evaluated values.
+///
+/// `negated == true` corresponds to `IS` / `IS NOT DISTINCT FROM` (NULL-safe
+/// equality: NULL IS NULL is TRUE), `negated == false` to `IS NOT` /
+/// `IS DISTINCT FROM`. The result is never NULL.
+pub(crate) fn row_values_is_distinct(
+    left_values: &[SqlValue],
+    right_values: &[SqlValue],
+    negated: bool,
+) -> SqlValue {
+    for (left_val, right_val) in left_values.iter().zip(right_values.iter()) {
+        if crate::evaluator::core::values_are_distinct(left_val, right_val) {
+            // For IS NOT DISTINCT FROM (negated): a distinct element → FALSE.
+            // For IS DISTINCT FROM: a distinct element → TRUE.
+            return SqlValue::Boolean(!negated);
+        }
+    }
+    // No element was distinct.
+    SqlValue::Boolean(negated)
+}

--- a/crates/vibesql-executor/tests/row_value_subquery_comparison_tests.rs
+++ b/crates/vibesql-executor/tests/row_value_subquery_comparison_tests.rs
@@ -1,0 +1,261 @@
+//! Tests for row-value (tuple) comparisons against scalar subqueries and for
+//! row-value comparison affinity — issue #5781.
+//!
+//! Covers:
+//! - `(a, b, c) <op> (SELECT a, b, c ...)` for every comparison operator, including the
+//!   subquery-on-left form and `IS` / `IS NOT`.
+//! - `(SELECT a, b) <op> (SELECT x, y)` (both sides multi-column subqueries).
+//! - Per-column type affinity inside row-value comparison (mixed TEXT/INTEGER).
+//! - Three-valued NULL semantics for row-value comparison.
+//!
+//! Expected values were verified against SQLite semantics (SQL:1999 §7.1).
+//! Both a table-backed path (combined evaluator) and, where meaningful, the
+//! FROM-less path (simple evaluator) are exercised.
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            vibesql_executor::InsertExecutor::execute(db, &insert).unwrap();
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+/// Run a SELECT that yields a single scalar value; normalize Boolean to 0/1
+/// Integer (SQLite has no boolean storage class).
+fn query_scalar(db: &vibesql_storage::Database, sql: &str) -> SqlValue {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        let rows = executor
+            .execute(&select_stmt)
+            .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e));
+        assert_eq!(rows.len(), 1, "Expected exactly one row for: {}", sql);
+        assert_eq!(rows[0].values.len(), 1, "Expected exactly one column for: {}", sql);
+        match &rows[0].values[0] {
+            SqlValue::Boolean(b) => SqlValue::Integer(*b as i64),
+            other => other.clone(),
+        }
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+fn assert_scalar(db: &vibesql_storage::Database, sql: &str, expected: SqlValue) {
+    let actual = query_scalar(db, sql);
+    assert_eq!(actual, expected, "Query: {} -- expected {:?}, got {:?}", sql, expected, actual);
+}
+
+/// Run a SELECT and return the first column of every row as a Vec<SqlValue>.
+fn query_column(db: &vibesql_storage::Database, sql: &str) -> Vec<SqlValue> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        let rows = executor
+            .execute(&select_stmt)
+            .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e));
+        rows.iter().map(|r| r.values[0].clone()).collect()
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+/// t3 mirrors the SQLite rowvalue2.test section-3 fixture shape: typeless
+/// columns holding string slices, plus a whole-word column `w`.
+fn db_with_t3() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t3(a, b, c, w)");
+    run_stmt(&mut db, "INSERT INTO t3 VALUES('air', 'far', 'e', 'airfare')");
+    run_stmt(&mut db, "INSERT INTO t3 VALUES('air', 'fie', 'ld', 'airfield')");
+    run_stmt(&mut db, "INSERT INTO t3 VALUES('air', 'fie', 'lds', 'airfields')");
+    db
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1: (a, b, c) <op> (SELECT a, b, c ...)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tuple_gt_subquery_matches_lexicographically_greater_rows() {
+    let db = db_with_t3();
+    // airfare is the smallest word; airfield and airfields are strictly greater.
+    let sql = "SELECT w FROM t3 \
+        WHERE (a, b, c) > (SELECT a, b, c FROM t3 WHERE w = 'airfare') \
+        ORDER BY w";
+    assert_eq!(
+        query_column(&db, sql),
+        vec![SqlValue::Varchar("airfield".into()), SqlValue::Varchar("airfields".into()),]
+    );
+}
+
+#[test]
+fn tuple_ge_subquery_includes_equal_row() {
+    let db = db_with_t3();
+    let sql = "SELECT w FROM t3 \
+        WHERE (a, b, c) >= (SELECT a, b, c FROM t3 WHERE w = 'airfare') \
+        ORDER BY w";
+    assert_eq!(
+        query_column(&db, sql),
+        vec![
+            SqlValue::Varchar("airfare".into()),
+            SqlValue::Varchar("airfield".into()),
+            SqlValue::Varchar("airfields".into()),
+        ]
+    );
+}
+
+#[test]
+fn tuple_eq_and_is_subquery_match_single_row() {
+    let db = db_with_t3();
+    for op in ["==", "IS"] {
+        let sql = format!(
+            "SELECT w FROM t3 \
+             WHERE (a, b, c) {op} (SELECT a, b, c FROM t3 WHERE w = 'airfield')"
+        );
+        assert_eq!(
+            query_column(&db, &sql),
+            vec![SqlValue::Varchar("airfield".into())],
+            "operator {op}"
+        );
+    }
+}
+
+#[test]
+fn tuple_lt_subquery_matches_smaller_rows() {
+    let db = db_with_t3();
+    let sql = "SELECT w FROM t3 \
+        WHERE (a, b, c) < (SELECT a, b, c FROM t3 WHERE w = 'airfield') \
+        ORDER BY w";
+    assert_eq!(query_column(&db, sql), vec![SqlValue::Varchar("airfare".into())]);
+}
+
+#[test]
+fn subquery_on_left_flips_operator_correctly() {
+    let db = db_with_t3();
+    // (SELECT airfare) < (a, b, c)  ==  (a, b, c) > (SELECT airfare)
+    let left = "SELECT w FROM t3 \
+        WHERE (SELECT a, b, c FROM t3 WHERE w = 'airfare') < (a, b, c) ORDER BY w";
+    let right = "SELECT w FROM t3 \
+        WHERE (a, b, c) > (SELECT a, b, c FROM t3 WHERE w = 'airfare') ORDER BY w";
+    assert_eq!(query_column(&db, left), query_column(&db, right));
+    assert_eq!(query_column(&db, left).len(), 2);
+}
+
+#[test]
+fn tuple_is_not_subquery() {
+    let db = db_with_t3();
+    // Every row IS NOT DISTINCT-negated from a different row except itself.
+    let sql = "SELECT w FROM t3 \
+        WHERE (a, b, c) IS NOT (SELECT a, b, c FROM t3 WHERE w = 'airfare') \
+        ORDER BY w";
+    assert_eq!(
+        query_column(&db, sql),
+        vec![SqlValue::Varchar("airfield".into()), SqlValue::Varchar("airfields".into()),]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 extension: (SELECT a, b) <op> (SELECT x, y)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn two_multicolumn_subqueries_equal() {
+    let db = vibesql_storage::Database::new();
+    assert_scalar(&db, "SELECT (SELECT 1, 2, 3) == (SELECT 1, 2, 3)", SqlValue::Integer(1));
+    assert_scalar(&db, "SELECT (SELECT 1, 0, 3) == (SELECT 1, 2, 3)", SqlValue::Integer(0));
+    assert_scalar(&db, "SELECT (SELECT 1, 2, 3) != (SELECT 1, 2, 3)", SqlValue::Integer(0));
+    assert_scalar(&db, "SELECT (SELECT 1, 0, 3) != (SELECT 1, 2, 3)", SqlValue::Integer(1));
+}
+
+#[test]
+fn two_multicolumn_subqueries_ordering() {
+    let db = vibesql_storage::Database::new();
+    assert_scalar(&db, "SELECT (SELECT 1, 1, 3) < (SELECT 1, 2, 3)", SqlValue::Integer(1));
+    assert_scalar(&db, "SELECT (SELECT 1, 3, 3) < (SELECT 1, 2, 3)", SqlValue::Integer(0));
+    assert_scalar(&db, "SELECT (SELECT 1, 2, 3) <= (SELECT 1, 2, 3)", SqlValue::Integer(1));
+    assert_scalar(&db, "SELECT (SELECT 1, 3, 3) >= (SELECT 1, 2, 3)", SqlValue::Integer(1));
+}
+
+#[test]
+fn single_column_subquery_comparison_still_scalar() {
+    // Regression: two single-column subqueries must remain a scalar comparison.
+    let db = vibesql_storage::Database::new();
+    assert_scalar(&db, "SELECT (SELECT 5) > (SELECT 3)", SqlValue::Integer(1));
+    assert_scalar(&db, "SELECT (SELECT 3) > (SELECT 5)", SqlValue::Integer(0));
+    assert_scalar(&db, "SELECT (SELECT 5) == (SELECT 5)", SqlValue::Integer(1));
+}
+
+// ---------------------------------------------------------------------------
+// Three-valued NULL semantics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn null_tuple_comparison_is_unknown() {
+    let db = vibesql_storage::Database::new();
+    // (1, NULL) = (1, 2): first pair equal, second is UNKNOWN → UNKNOWN (NULL).
+    assert_scalar(&db, "SELECT (SELECT 1, NULL) == (SELECT 1, 2)", SqlValue::Null);
+    // (2, NULL) = (1, 2): first pair definitively unequal → FALSE.
+    assert_scalar(&db, "SELECT (SELECT 2, NULL) == (SELECT 1, 2)", SqlValue::Integer(0));
+    // Ordering: (1, NULL) < (2, NULL): first pair 1<2 is a definite result → TRUE.
+    assert_scalar(&db, "SELECT (SELECT 1, NULL) < (SELECT 2, NULL)", SqlValue::Integer(1));
+    // (1, NULL) < (1, 2): first equal, second NULL before a difference → UNKNOWN.
+    assert_scalar(&db, "SELECT (SELECT 1, NULL) < (SELECT 1, 2)", SqlValue::Null);
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: type affinity inside row-value comparison
+// ---------------------------------------------------------------------------
+
+/// r1/r2 mirror rowvalue2.test section 5: mixed TEXT and INTEGER columns whose
+/// row-value comparison must apply the same affinity as the scalar form.
+fn db_with_affinity_tables() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE r1(a TEXT, iB TEXT)");
+    run_stmt(&mut db, "CREATE TABLE r2(x TEXT, zY INTEGER)");
+    run_stmt(&mut db, "INSERT INTO r1 VALUES(35, 35)");
+    run_stmt(&mut db, "INSERT INTO r2 VALUES(35, 36)");
+    run_stmt(&mut db, "INSERT INTO r2 VALUES(35, 4)");
+    run_stmt(&mut db, "INSERT INTO r2 VALUES(35, 35)");
+    db
+}
+
+#[test]
+fn row_value_comparison_applies_affinity() {
+    let db = db_with_affinity_tables();
+    // The row-value form must agree with the scalar-expanded form. zY has
+    // INTEGER affinity, iB has TEXT affinity: (x, zY) == (a, iB) matches the
+    // r2 row where zY == 35 after affinity coercion, exactly like
+    // (x == a) AND (zY == iB).
+    let row_value = "SELECT zY FROM r1, r2 WHERE (x, zY) == (a, iB) ORDER BY zY";
+    let scalar = "SELECT zY FROM r1, r2 WHERE (x == a) AND (zY == iB) ORDER BY zY";
+    let rv = query_column(&db, row_value);
+    assert_eq!(rv, query_column(&db, scalar));
+    assert_eq!(rv, vec![SqlValue::Integer(35)]);
+}
+
+// ---------------------------------------------------------------------------
+// Arity mismatch errors (SQLite-compatible)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn arity_mismatch_between_tuple_and_subquery_errors() {
+    let db = db_with_t3();
+    let stmt = vibesql_parser::Parser::parse_sql(
+        "SELECT w FROM t3 WHERE (a, b) > (SELECT a, b, c FROM t3 WHERE w = 'airfare')",
+    )
+    .unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(&db);
+        let result = executor.execute(&select_stmt);
+        assert!(result.is_err(), "expected arity-mismatch error, got {:?}", result);
+    } else {
+        panic!("expected SELECT");
+    }
+}


### PR DESCRIPTION
## Summary

Extends VibeSQL's half-built row-value (tuple) support to the executor contexts that SQLite's `rowvalue*.test` suites exercise heavily. The dominant driver — a row value compared against a subquery — was parsing fine but falling through to the unsupported-expression catch-all. This PR routes all row-value comparisons through a single shared, value-based core and adds the missing contexts.

Empirically: **`rowvalue2.test` 2100 → 2 failures (99.9%)**, **`rowvalue.test` 114 → 70 failures**. No regressions.

## Changes

- **Row-value vs scalar subquery** (Phase 1, the big win): `(a,b,c) <op> (SELECT a,b,c FROM ...)`, the subquery-on-left form (operator flipped, tuple kept on the left), and `(a,b,c) IS [NOT] (SELECT ...)`. The subquery is evaluated to a row of the tuple's arity (all-NULLs if it returns no rows; arity validated with a SQLite-compatible column-count error).
- **Direct row-value `IS` / `IS NOT` in the combined evaluator** (WHERE clauses): previously hit the `Unsupported expression: RowValueConstructor` catch-all. Now NULL-safe and element-wise.
- **Subquery-vs-subquery row comparison**: `(SELECT a,b) <op> (SELECT x,y)`. A cheap static single-column guard leaves ordinary scalar-subquery comparisons untouched.
- **Per-column type affinity** (Phase 3) inside row-value comparison and `IS`, mirroring the scalar path so mixed TEXT/INTEGER tuples compare per SQLite rules instead of by raw storage class.
- **NULL three-valued ordering fix**: a NULL at the first differing position now yields UNKNOWN immediately instead of allowing a later element to force a definite result. This corrected the shared lexicographic-ordering logic used by the pre-existing direct tuple-vs-tuple path as well (it cleared all of `rowvalue2.test` section 4).
- New shared module `evaluator/row_value.rs` holds the value-based comparison / IS / operator-flip primitives, eliminating the duplicated ordering logic that existed in both evaluators. Scalar-subquery evaluation is refactored to expose executed rows so the single-value and full-row paths share one implementation.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `(a,b) op (SELECT ...)` works with correct NULL semantics (Phase 1) | ✅ | `rowvalue2.test` section 3 subselect family now passes; unit tests for every operator + subquery-on-left |
| Type affinity applied inside row-value comparison (Phase 3) | ✅ | `rowvalue2.test` section 5 (r1/r2 mixed TEXT/INTEGER) passes except the 2 unary-plus `==` edge cases; unit test `row_value_comparison_applies_affinity` |
| Rust unit tests for the new row-value paths | ✅ | New `row_value_subquery_comparison_tests.rs` (12 tests): subquery comparison, subquery-vs-subquery, affinity, NULL 3-valued, arity-mismatch error |
| `rowvalue2.test` / `rowvalue.test` before/after recorded | ✅ | rowvalue2 2100→2 (99.9%); rowvalue 114→70 |
| No regressions | ✅ | `cargo test -p vibesql-executor --tests` (129 binaries) all pass; `select1.test` 185/188 (3 pre-existing, non-row-value) |

## Test Plan

- `cargo test -p vibesql-executor --tests` → 129 test binaries, 0 failures (run with a larger stack to avoid an unrelated pre-existing debug-mode deep-recursion CASE overflow in the lib unit tests).
- `TCL_TIMEOUT=1200 make test-tcl-file FILE=rowvalue2.test` → 3832/3834 (99.9%). Now slower than the 300s default because the ~2,100 previously-erroring subselect subtests actually execute.
- `TCL_TIMEOUT=300 make test-tcl-file FILE=rowvalue.test` → 227/298 (76.2%).
- `clippy` clean on all touched files.

## Scope / deferred

This lands Phase 1 (subquery comparison) + Phase 3 (affinity) + the NULL-ordering and direct-`IS` fixes. **Phase 2 (row-value `IN (list)`) and Phase 4 (row-value in ORDER BY / projection)**, plus the 2 unary-plus-affinity `==` cases, COLLATE-in-row-value, and the advanced index/LEFT-JOIN row-value cases in `rowvalue.test`, are deferred to **#5790**.

### Notes on NULL semantics (reviewer attention welcome)
Row-value equality (`=`/`<>`) accumulates NULL across all elements (any NULL without a definitive inequality → UNKNOWN), whereas ordering (`<`,`<=`,`>`,`>=`) short-circuits: a definite strict inequality settles the result even with later NULLs, but a NULL at the first *undecided* position is UNKNOWN immediately. Verified against the scalar-expansion oracle in `rowvalue2.test` sections 2 and 4.

Part of #5781