### PR TITLE
fix(tcl): make trial-check and backup copies WAL-inclusive

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -1235,6 +1235,59 @@ proc track_pragma_setting {sql} {
     return $found
 }
 
+# -- WAL-inclusive database copy helpers (#5782) -----------------------------
+#
+# WAL is on by default (#5760). For a database file `<root>.vbsql`, committed
+# state lives in sibling paths derived by `crates/vibesql-cli/src/executor/wal.rs`:
+#
+#   <root>.wal            — active write-ahead log   (path.with_extension("wal"))
+#   <root>-checkpoints/   — checkpoint archive dir   (<stem>-checkpoints/)
+#
+# A piped CLI invocation may write committed rows ONLY to these siblings and
+# not to the `.vbsql` snapshot at all (the snapshot is written on checkpoint /
+# clean exit). Any construct that copies the database with a bare
+# `file copy -force <root>.vbsql <dst>` therefore loses the committed state and
+# produces an empty destination. `copy_db_with_wal` copies the snapshot plus
+# both siblings so the destination sees the full committed database.
+
+proc wal_sibling_paths {db_path} {
+    # Mirror WalPaths::derive: <root>.wal and <root>-checkpoints/.
+    # `file rootname` strips the final extension, matching Rust's
+    # `with_extension("wal")` / `file_stem` + "-checkpoints".
+    set root [file rootname $db_path]
+    return [list "${root}.wal" "${root}-checkpoints"]
+}
+
+proc copy_db_with_wal {from to} {
+    # Copy a VibeSQL database file together with its WAL siblings so the
+    # destination reflects committed state that may live outside the .vbsql
+    # snapshot. Safe when the snapshot or siblings are absent.
+    lassign [wal_sibling_paths $from] from_wal from_ckpt
+    lassign [wal_sibling_paths $to]   to_wal   to_ckpt
+
+    # Clear any stale destination siblings so we never mix old WAL state in.
+    catch {file delete -force $to_wal}
+    catch {file delete -force $to_ckpt}
+
+    if {[file exists $from]} {
+        catch {file copy -force $from $to}
+    }
+    if {[file exists $from_wal]} {
+        catch {file copy -force $from_wal $to_wal}
+    }
+    if {[file exists $from_ckpt]} {
+        catch {file copy -force $from_ckpt $to_ckpt}
+    }
+}
+
+proc delete_db_with_wal {db_path} {
+    # Delete a database file and its WAL siblings (trial-db teardown).
+    lassign [wal_sibling_paths $db_path] wal ckpt
+    catch {file delete -force $db_path}
+    catch {file delete -force $wal}
+    catch {file delete -force $ckpt}
+}
+
 proc trial_check_in_transaction {new_sql} {
     # Trial-execute the cumulative transaction batch (existing $::sql_batch
     # plus $new_sql) with an appended ROLLBACK, so that errors from $new_sql
@@ -1304,11 +1357,15 @@ proc trial_check_in_transaction {new_sql} {
         catch {exec $::vibesql_path < $tmpfile 2>@1} result
     } else {
         set trial_db "/tmp/vibesql_trialdb_[pid]_[clock microseconds].vbsql"
-        if {[file exists $::db_file]} {
-            file copy -force $::db_file $trial_db
-        }
+        # Copy the FULL database — snapshot plus WAL siblings — so the trial
+        # sees committed state. With WAL on by default (#5760) the committed
+        # rows can live only in <root>.wal / <root>-checkpoints/ (the .vbsql
+        # snapshot may not exist yet), so a snapshot-only copy would yield an
+        # empty trial db and spuriously fail every in-transaction statement,
+        # rolling back the real inserts (#5782).
+        copy_db_with_wal $::db_file $trial_db
         catch {exec $::vibesql_path $trial_db < $tmpfile 2>@1} result
-        file delete -force $trial_db
+        delete_db_with_wal $trial_db
     }
     file delete -force $tmpfile
 
@@ -5521,14 +5578,19 @@ proc copy_file {from to} {
     # file open, so a plain filesystem copy is the right behavior. Defined
     # here (#5460) so triggerA.test's malloc-test snapshot step doesn't abort
     # the whole file with "invalid command name".
-    catch {file copy -force $from $to}
+    #
+    # WAL-inclusive (#5782): with WAL on by default committed state may live in
+    # the <root>.wal / <root>-checkpoints/ siblings rather than the snapshot,
+    # so a bare snapshot copy would restore an empty database.
+    copy_db_with_wal $from $to
 }
 
 proc forcecopy {from to} {
     # Force-copy variant (deletes destination first). Same rationale as
-    # copy_file above (#5460).
+    # copy_file above (#5460); WAL-inclusive per #5782 (copy_db_with_wal
+    # already clears stale destination siblings before copying).
     catch {file delete -force $to}
-    catch {file copy -force $from $to}
+    copy_db_with_wal $from $to
 }
 
 proc sqlite3_extended_result_codes {db onoff} {


### PR DESCRIPTION
## Summary

The ~1,998 `in2.test` "IN failures" were **not** an IN-operator engine bug — they were a test-harness artifact introduced when WAL became default-on (#5760).

`in2.test` inserts its 4,001 rows inside a `db transaction { ... }`. The shim's `trial_check_in_transaction` validates each in-transaction statement by `file copy`-ing the database to an isolated trial db — but it copied **only the bare `<root>.vbsql` snapshot**. With WAL on by default, committed state lives in the sibling `<root>.wal` and `<root>-checkpoints/` files, and the `.vbsql` snapshot may not exist yet. The snapshot-only copy therefore produced an **empty** trial db, every statement failed the trial with "no such table", the `db transaction` rolled back, and the real inserts were never flushed — so every one of the ~1,998 loop tests (all expecting `1`) returned the wrong result.

This is the same class of WAL-default/harness interaction as #5766. The fix is harness-only; no engine change.

## Changes

- Add `wal_sibling_paths` / `copy_db_with_wal` / `delete_db_with_wal` helpers to `scripts/tester_vibesql.tcl`. They copy (and tear down) the `.vbsql` snapshot **plus** its `<root>.wal` and `<root>-checkpoints/` siblings. Sibling naming mirrors `WalPaths::derive` in `crates/vibesql-cli/src/executor/wal.rs` exactly (`file rootname` = `with_extension("wal")` / `<stem>-checkpoints`).
- Route `trial_check_in_transaction`'s trial-db copy through `copy_db_with_wal` (and teardown through `delete_db_with_wal`). Guards the case where the snapshot is absent but the WAL siblings exist.
- Make `copy_file` / `forcecopy` (used by malloc/backup/snapshot tests) WAL-inclusive via the same helper, closing the same latent bug for db-backup constructs.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `in2.test` goes from ~1,998 failures to ~0 | ✅ | `TCL_TIMEOUT=300 make test-tcl-file FILE=in2.test`: **1999/1999 pass** (was 1/1999) |
| Fix helps any `db transaction`-using file | ✅ | `rowhash.test` 1→10 passing; `tkt3093.test` 2→3 passing (before/after, same binary) |
| No regression | ✅ | `select1.test` 185/188 identical pre- and post-fix (3 failures pre-existing, unrelated) |
| Reduced repro persists transaction rows | ✅ | Mini test (`CREATE TABLE` + plain insert + `db transaction { inserts }` + `SELECT count(*)`): 2/4 pre-fix → 4/4 post-fix |
| WAL sibling naming matches CLI | ✅ | `file rootname $p` + `.wal` / `-checkpoints` mirrors `WalPaths::derive` (`path.with_extension("wal")`, `<stem>-checkpoints/`) |

## Test Plan

Verified with the freshly-built shared `target/release/vibesql` (today's main; no Rust change required):

- `in2.test`: 1 → 1999 passing.
- Broader `db transaction` recovery: `rowhash.test` 1→10, `tkt3093.test` 2→3.
- Regression: `select1.test` unchanged at 185/188 (pre-existing failures).
- Reduced repro confirms the root cause: without the fix, the `db transaction` insert is lost with "no such table"; with the fix, rows persist.

## Follow-up

Filed #5792 for the one small **real** IN engine gap the curator flagged (`in4-4.4`: duplicate rows from IN over an index, `Got: 1 3` vs `Expected: 3`). It is unrelated to this harness fix and out of scope here.

Closes #5782