### PR TITLE
fix(wal): flush buffered header on empty sync so checkpoint truncate never short-reads

### DIFF
--- a/crates/vibesql-cli/src/executor/wal.rs
+++ b/crates/vibesql-cli/src/executor/wal.rs
@@ -171,4 +171,32 @@ mod tests {
         assert_eq!(p.wal_path, PathBuf::from("/tmp/mydata.wal"));
         assert_eq!(p.checkpoint_dir, PathBuf::from("/tmp/mydata-checkpoints"));
     }
+
+    /// Regression for #5785: the very first checkpoint on a freshly-opened
+    /// WAL-backed database must succeed even when no WAL entries have been
+    /// written yet (e.g. the opening statement is a no-op `DROP TABLE IF EXISTS`
+    /// that produces zero WAL ops). Before the fix, the WAL header was buffered
+    /// but never flushed, so the on-disk WAL was 0 bytes and `truncate_wal`
+    /// failed its header read with "failed to fill whole buffer", surfacing as a
+    /// leaked auto-save warning.
+    #[test]
+    fn test_checkpoint_on_fresh_wal_with_no_entries_succeeds() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("fresh.vbsql");
+        let db_path_str = db_path.to_string_lossy().to_string();
+
+        let (db, mut wal_state) = WalState::open(&db_path_str).unwrap();
+
+        // No writes performed — this mirrors an opening no-op DDL. The checkpoint
+        // must not error.
+        wal_state.checkpoint(&db).expect("checkpoint on empty fresh WAL must succeed");
+
+        // A second checkpoint (already-checkpointed / still empty) must also be a
+        // clean no-op.
+        wal_state.checkpoint(&db).expect("repeat checkpoint must succeed");
+
+        // The WAL on disk must now be a valid header-bearing (or empty) file that
+        // recovery can reopen without error.
+        let (_db2, _stats) = WalState::open(&db_path_str).expect("reopen after checkpoint");
+    }
 }

--- a/crates/vibesql-storage/src/wal/engine.rs
+++ b/crates/vibesql-storage/src/wal/engine.rs
@@ -550,6 +550,20 @@ mod native {
                 // notifying waiters so the happens-before edge into the caller
                 // includes the counter update.
                 if is_explicit_flush {
+                    // Flush the underlying writer even though no entries are
+                    // pending. For a brand-new WAL the 32-byte header written by
+                    // `WalWriter::create` is still sitting in the BufWriter and
+                    // has not reached the OS file. Skipping the flush here left
+                    // the on-disk WAL at 0 bytes, so the very next checkpoint's
+                    // `truncate_wal` opened a header-less file and failed the
+                    // header `read_exact` with a confusing short read
+                    // ("failed to fill whole buffer"). An explicit sync promises
+                    // durability, so it must push buffered bytes (including the
+                    // header) to disk regardless of whether new entries were
+                    // batched. See issue #5785.
+                    if let Err(e) = writer.flush() {
+                        log::error!("Failed to flush WAL on empty explicit sync: {}", e);
+                    }
                     stats.lock().explicit_flushes += 1;
                 }
                 // Still notify waiters even if batch is empty

--- a/crates/vibesql-storage/src/wal/reader.rs
+++ b/crates/vibesql-storage/src/wal/reader.rs
@@ -8,7 +8,7 @@ use std::io::{Read, Seek, SeekFrom};
 
 use super::{
     entry::{Lsn, WalEntry},
-    format::{WalHeader, WAL_HEADER_SIZE},
+    format::{WalHeader, WAL_HEADER_SIZE, WAL_VERSION},
     writer::verify_checksum,
 };
 use crate::{persistence::binary::io::read_u32, StorageError};
@@ -41,6 +41,29 @@ pub struct WalReader<R: Read + Seek> {
 impl<R: Read + Seek> WalReader<R> {
     /// Open a WAL file for reading
     pub fn open(mut reader: R) -> Result<Self, StorageError> {
+        // A completely empty (0-byte) WAL has no header yet — for example a file
+        // that was just created but whose buffered header has not been flushed,
+        // or a crash between file creation and the first header write. Treat it
+        // as a valid but empty WAL that yields immediate EOF, rather than failing
+        // the header `read_exact` with a confusing short read
+        // ("failed to fill whole buffer"). This keeps `truncate_wal` and
+        // recovery's `replay_wal` robust to a header-less WAL. See issue #5785.
+        let end =
+            reader.seek(SeekFrom::End(0)).map_err(|e| StorageError::IoError(e.to_string()))?;
+        reader.seek(SeekFrom::Start(0)).map_err(|e| StorageError::IoError(e.to_string()))?;
+        if end == 0 {
+            return Ok(Self {
+                reader,
+                // Synthetic header for an empty log; no entries will be read so
+                // the version only matters for deserialization that never runs.
+                header: WalHeader { version: WAL_VERSION, created_ms: 0 },
+                // No header on disk, so entry reads start at offset 0 and hit EOF.
+                position: 0,
+                entries_read: 0,
+                last_lsn: None,
+            });
+        }
+
         // Read and validate header
         let header = WalHeader::read(&mut reader)?;
 
@@ -348,6 +371,36 @@ mod tests {
 
         // Should detect corruption and report recovery point
         assert!(info.entry_count < 5);
+    }
+
+    #[test]
+    fn test_open_empty_wal_yields_no_entries() {
+        // Regression for #5785: a 0-byte WAL (header buffered but not yet
+        // flushed, or a crash before the first header write) must be treated as
+        // an empty log, not fail the header read with "failed to fill whole
+        // buffer".
+        let cursor = Cursor::new(Vec::new());
+        let mut reader = WalReader::open(cursor).expect("empty WAL must open cleanly");
+
+        let entries = reader.read_all().unwrap();
+        assert!(entries.is_empty(), "empty WAL must yield zero entries");
+
+        // A second read still reports clean EOF.
+        match reader.read_entry().unwrap() {
+            ReadResult::Eof => {}
+            other => panic!("expected Eof on empty WAL, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_find_recovery_point_empty_wal() {
+        // Recovery over a 0-byte WAL must succeed with no entries rather than
+        // erroring on the header short read (#5785).
+        let cursor = Cursor::new(Vec::new());
+        let info = find_recovery_point(cursor).unwrap();
+
+        assert_eq!(info.entry_count, 0);
+        assert_eq!(info.last_lsn, None);
     }
 
     #[test]

--- a/crates/vibesql-storage/src/wal/truncate.rs
+++ b/crates/vibesql-storage/src/wal/truncate.rs
@@ -291,6 +291,25 @@ mod tests {
     }
 
     #[test]
+    fn test_truncate_empty_wal_is_noop() {
+        // Regression for #5785: checkpoint auto-save calls `truncate_wal` on the
+        // active WAL. When the WAL was just created and its header is still
+        // buffered (0 bytes on disk), truncation must succeed as a no-op instead
+        // of failing the header read with "failed to fill whole buffer".
+        let temp_dir = TempDir::new().unwrap();
+        let wal_path = temp_dir.path().join("empty.wal");
+        File::create(&wal_path).unwrap(); // 0-byte file
+
+        assert_eq!(fs::metadata(&wal_path).unwrap().len(), 0);
+
+        let result = truncate_wal(&wal_path, 5, Some(0)).unwrap();
+        assert_eq!(result.entries_removed, 0);
+        assert_eq!(result.entries_kept, 0);
+        assert_eq!(result.oldest_lsn, None);
+        assert_eq!(result.newest_lsn, None);
+    }
+
+    #[test]
     fn test_truncate_wal_no_removal() {
         let temp_dir = TempDir::new().unwrap();
         let wal_path = create_test_wal(temp_dir.path(), 100);


### PR DESCRIPTION
## Summary

Fixes a real WAL robustness bug: a freshly-opened WAL-backed database whose first statement produces **no** WAL entries (e.g. a no-op `DROP TABLE IF EXISTS t1`) leaked this warning during script-mode auto-save:

```
Warning: Failed to auto-save database: Failed to checkpoint WAL database: I/O error: failed to fill whole buffer
```

The TCL harness merges stderr into stdout, so this text landed on expected-empty DDL/DML test blocks and manifested as ~8 spurious **window-family** failures (window1 §18/§29, plus window2/3/4/7/8). This is the residual defect the curator identified — the window-function **engine has no gaps**; this was a WAL auto-save artifact.

## Root cause (fixed at source, not worked around)

`WalWriter::create` writes the 32-byte WAL header into the background writer's `BufWriter`, but `flush_batch` early-returned on an **empty batch without flushing**. So an explicit `sync_persistence()` on an entry-less WAL never pushed the buffered header to disk, leaving the on-disk WAL at **0 bytes**. The checkpoint's `truncate_wal` then opened a header-less file and failed `WalHeader::read`'s `read_exact` with `ErrorKind::UnexpectedEof`, whose message is literally `"failed to fill whole buffer"`.

Reproduced deterministically before the fix:
```
$ printf 'DROP TABLE IF EXISTS t1;\n' | vibesql /tmp/a.vbsql
0 rows
Warning: Failed to auto-save database: Failed to checkpoint WAL database: I/O error: failed to fill whole buffer
```
Gone after the fix (`NO WARNING LEAK`).

## Changes

- **`wal/engine.rs`**: an explicit flush now flushes the underlying writer even when the batch is empty, so a sync durably persists the buffered header. This is the true durability root cause — a sync that reports success must actually reach disk.
- **`wal/reader.rs`**: `WalReader::open` treats a 0-byte WAL as a valid empty log yielding immediate EOF instead of erroring on the header short read. This also hardens recovery's `replay_wal` (same latent short-read) against a header-less WAL.
- Tests: empty-WAL open + recovery-point (`reader.rs`), empty-WAL truncate no-op (`truncate.rs`), and a CLI `WalState` checkpoint-on-fresh-WAL end-to-end regression (`executor/wal.rs`).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| WAL checkpoint auto-save error no longer occurs for normal DDL/DML scripts | ✅ | Reproduced original error on `main` binary; rebuilt binary shows `NO WARNING LEAK` for no-op DDL, DDL+DML batch, and DML batch |
| Root-cause fix (not symptom hiding) | ✅ | Fixed the buffered-header-never-flushed durability bug in `flush_batch`; reader hardening covers recovery too |
| window1.test → ~0 failures | ✅ | 2 → **0** failures (`TCL_TIMEOUT=300 ./scripts/tcltest test window1.test`) |
| Window family improves | ✅ | window2 1→0, window3 1→0, window4 1→0, window7 1→0, window8 1→0; window9 3→2 (residual VIEW bug, out of scope) |
| Rust test for empty/truncated/already-checkpointed WAL checkpoint | ✅ | `test_open_empty_wal_yields_no_entries`, `test_find_recovery_point_empty_wal`, `test_truncate_empty_wal_is_noop`, `test_checkpoint_on_fresh_wal_with_no_entries_succeeds` |
| `cargo test -p vibesql-storage -p vibesql-cli` green, no regressions | ✅ | storage 729 + cli 134/16/13/15 + integration all pass, 0 failures |
| window9 VIEW bug filed separately | ✅ | #5798 |

## Test Plan

- `cargo test -p vibesql-storage -p vibesql-cli` — all green.
- Recovery verified intact: DDL+DML written, process exits, reopened DB still returns the committed row.
- `TCL_TIMEOUT=300` window family sweep (window1–window9) with the freshly-built shared `target/release/vibesql`.

## Follow-up (out of scope)

- #5798 — window9 §8 VIEW visibility bug (`no such table: v1`); the only residual window-family failures after this PR.

Closes #5785