### PR TITLE
fix(ast): render compound-query ORDER BY/LIMIT/OFFSET after the set operation in ToSql

### DIFF
--- a/crates/vibesql-ast/src/pretty_print.rs
+++ b/crates/vibesql-ast/src/pretty_print.rs
@@ -5,8 +5,7 @@
 //! # Example
 //!
 //! ```
-//! use vibesql_ast::pretty_print::ToSql;
-//! use vibesql_ast::{BinaryOperator, Expression};
+//! use vibesql_ast::{pretty_print::ToSql, BinaryOperator, Expression};
 //! use vibesql_types::SqlValue;
 //!
 //! // Convert operators to SQL
@@ -927,6 +926,17 @@ impl ToSql for SelectStmt {
             }
         }
 
+        // Set operation (UNION, INTERSECT, EXCEPT) must be rendered BEFORE
+        // ORDER BY / LIMIT / OFFSET: the parser attaches those clauses to the
+        // outermost (leftmost) SelectStmt of a compound query, where they apply
+        // to the entire set-operation result. Emitting them before the set
+        // operation would produce invalid SQL like
+        // `SELECT 0 ORDER BY 1 UNION SELECT 1`, which fails to re-parse when a
+        // persisted view definition is reloaded (issue #5798).
+        if let Some(set_op) = &self.set_operation {
+            result.push_str(&format!(" {}", set_op.to_sql()));
+        }
+
         // ORDER BY (applies to both SELECT and VALUES)
         if let Some(order_by) = &self.order_by {
             let items: Vec<String> = order_by.iter().map(|o| o.to_sql()).collect();
@@ -941,11 +951,6 @@ impl ToSql for SelectStmt {
         // OFFSET
         if let Some(offset) = &self.offset {
             result.push_str(&format!(" OFFSET {}", offset.to_sql()));
-        }
-
-        // Set operation
-        if let Some(set_op) = &self.set_operation {
-            result.push_str(&format!(" {}", set_op.to_sql()));
         }
 
         result
@@ -1372,6 +1377,66 @@ mod tests {
             values: None,
         };
         assert_eq!(stmt.to_sql(), "SELECT DISTINCT name FROM users ORDER BY name ASC LIMIT 10");
+    }
+
+    /// Issue #5798: in a compound query the parser attaches ORDER BY / LIMIT /
+    /// OFFSET to the outermost SelectStmt where they apply to the entire set
+    /// operation, so ToSql must render them AFTER the set operation. Rendering
+    /// them before produced invalid SQL (`SELECT 0 ORDER BY 1 UNION SELECT 1`)
+    /// that failed to re-parse when persisted view definitions were reloaded.
+    #[test]
+    fn test_union_with_order_by_renders_order_by_after_set_operation() {
+        let right = SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list: vec![SelectItem::Expression {
+                expr: Expression::Literal(SqlValue::Integer(1)),
+                alias: None,
+                source_text: None,
+            }],
+            into_table: None,
+            into_variables: None,
+            from: None,
+            where_clause: None,
+            group_by: None,
+            having: None,
+            window_definitions: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            set_operation: None,
+            values: None,
+        };
+        let stmt = SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list: vec![SelectItem::Expression {
+                expr: Expression::Literal(SqlValue::Integer(0)),
+                alias: Some("x".to_string()),
+                source_text: None,
+            }],
+            into_table: None,
+            into_variables: None,
+            from: None,
+            where_clause: None,
+            group_by: None,
+            having: None,
+            window_definitions: None,
+            order_by: Some(vec![OrderByItem {
+                expr: Expression::Literal(SqlValue::Integer(1)),
+                direction: OrderDirection::Asc,
+                nulls_order: None,
+            }]),
+            limit: Some(Expression::Literal(SqlValue::Integer(10))),
+            offset: None,
+            set_operation: Some(SetOperation {
+                op: SetOperator::Union,
+                all: false,
+                right: Box::new(right),
+            }),
+            values: None,
+        };
+        assert_eq!(stmt.to_sql(), "SELECT 0 AS x UNION SELECT 1 ORDER BY 1 ASC LIMIT 10");
     }
 
     #[test]

--- a/crates/vibesql-storage/src/persistence/binary/catalog.rs
+++ b/crates/vibesql-storage/src/persistence/binary/catalog.rs
@@ -343,8 +343,9 @@ pub fn read_catalog_v<R: Read>(reader: &mut R, version: u8) -> Result<Database, 
     let schema_count = read_u32(reader)?;
     for _ in 0..schema_count {
         let schema_name = read_string(reader)?;
-        // Skip built-in schemas (main and all temp schemas) - they are already created by Database::new()
-        // This handles backward compatibility with databases saved before the write-side fix
+        // Skip built-in schemas (main and all temp schemas) - they are already created by
+        // Database::new() This handles backward compatibility with databases saved before
+        // the write-side fix
         if schema_name == vibesql_catalog::DEFAULT_SCHEMA
             || vibesql_catalog::Catalog::is_temp_schema(&schema_name)
         {
@@ -950,8 +951,7 @@ pub(super) fn parse_data_type(type_str: &str) -> Result<vibesql_types::DataType,
 
 #[cfg(test)]
 mod tests {
-    use super::super::format::VERSION;
-    use super::{read_catalog_v, write_catalog};
+    use super::{super::format::VERSION, read_catalog_v, write_catalog};
     use crate::Database;
 
     /// Issue #5619: the verbatim original `CREATE TABLE` source text
@@ -1109,6 +1109,18 @@ mod tests {
         .with_schema(Some("temp".to_string()));
         db.catalog.create_view(temp).unwrap();
 
+        // 5. Compound view: UNION with a trailing ORDER BY (issue #5798, window9.test §8). The
+        //    ORDER BY applies to the whole compound, so ToSql must render it AFTER the set
+        //    operation — otherwise the persisted SELECT text is invalid SQL and the view is dropped
+        //    on reload (checkpoint recovery falls back to an older/empty state).
+        let compound = vibesql_catalog::ViewDefinition::new(
+            "v_compound".to_string(),
+            None,
+            parse("SELECT 0 AS x UNION SELECT count() OVER() FROM (SELECT 0) ORDER BY 1"),
+            false,
+        );
+        db.catalog.create_view(compound).unwrap();
+
         // Round-trip the catalog at the current version.
         let mut buf = Vec::new();
         write_catalog(&mut buf, &db).unwrap();
@@ -1137,6 +1149,42 @@ mod tests {
         let v = reloaded.catalog.get_view("v_temp").expect("v_temp must survive");
         assert_eq!(v.schema.as_deref(), Some("temp"));
         assert!(v.is_temp());
+
+        // Compound view (UNION + ORDER BY, issue #5798): must survive the
+        // round-trip with the ORDER BY still applying to the whole compound.
+        // The parser assigns synthetic subquery aliases from a global counter
+        // (`(subquery-N)`), so normalize those before comparing.
+        let normalize = |sql: &str| -> String {
+            let mut out = String::with_capacity(sql.len());
+            let mut rest = sql;
+            while let Some(start) = rest.find("(subquery-") {
+                let after = &rest[start + "(subquery-".len()..];
+                let end = after.find(')').map(|i| start + "(subquery-".len() + i + 1);
+                match end {
+                    Some(end) => {
+                        out.push_str(&rest[..start]);
+                        out.push_str("(subquery-N)");
+                        rest = &rest[end..];
+                    }
+                    None => break,
+                }
+            }
+            out.push_str(rest);
+            out
+        };
+        let v = reloaded.catalog.get_view("v_compound").expect("v_compound must survive");
+        assert_eq!(
+            normalize(&v.query.to_sql()),
+            normalize(
+                &parse("SELECT 0 AS x UNION SELECT count() OVER() FROM (SELECT 0) ORDER BY 1")
+                    .to_sql()
+            )
+        );
+        assert!(
+            v.query.to_sql().find("UNION").unwrap() < v.query.to_sql().find("ORDER BY").unwrap(),
+            "ORDER BY must render after the set operation, got: {}",
+            v.query.to_sql()
+        );
     }
 
     /// Issue #5771 backward compat: a v9 (pre-views) file must load cleanly


### PR DESCRIPTION
## Root cause

`SelectStmt::to_sql()` (crates/vibesql-ast/src/pretty_print.rs) emitted ORDER BY / LIMIT / OFFSET **before** the set operation. The parser attaches those clauses to the outermost SelectStmt of a compound query, where they apply to the entire UNION/INTERSECT/EXCEPT result (and it rejects them appearing before a set operation, so that invariant always holds).

window9.test §8.2 creates:

```sql
CREATE VIEW v1 AS SELECT 0 AS x UNION SELECT count() OVER() FROM (SELECT 0) ORDER BY 1;
```

The binary catalog persists each view's defining SELECT via `to_sql()` (crates/vibesql-storage/src/persistence/binary/catalog.rs), which produced the invalid text `SELECT 0 AS x ORDER BY 1 ASC UNION SELECT count() OVER () FROM (SELECT 0)`. On the next batched-CLI session the checkpoint failed to re-parse, recovery fell back to an older/empty checkpoint (with only a `log::warn!`), and the view silently vanished — hence `no such table: v1` in tests 8.3/8.4. The window engine itself was never at fault.

## Fix

Render the set operation before ORDER BY / LIMIT / OFFSET in `SelectStmt::to_sql()`. One-hunk reordering plus explanatory comment.

## Tests

- New `vibesql-ast` unit test: compound SELECT with ORDER BY + LIMIT renders `... UNION SELECT 1 ORDER BY 1 ASC LIMIT 10`.
- Extended `test_binary_catalog_round_trips_views` (vibesql-storage) with a compound (UNION + ORDER BY + window function) view; asserts it survives the round-trip and that ORDER BY renders after UNION.

## Test evidence

| Suite | Before | After |
|---|---|---|
| window9.test | 8.3, 8.4 failed (`no such table: v1`) | 38/38 passed, 0 failed, 4 skipped |
| window1–window8, windowA–windowE, windowerr, windowfault, windowpushd | 0 failures | 0 failures (all files re-run) |
| `cargo test -p vibesql-ast` | — | pass (incl. new test) |
| `cargo test -p vibesql-storage --lib catalog` | — | 9 passed |
| `cargo test -p vibesql-storage --lib wal` | — | 112 passed |
| `cargo test -p vibesql-storage --lib persistence` | — | 94 passed |

CLI repro (fails before, passes after): create the view above in one `vibesql file.vbsql -c ...` invocation, reopen, `SELECT x FROM v1`.

`cargo clippy --release -p vibesql-ast -p vibesql-storage`: no findings in changed files. Formatted with nightly rustfmt (repo config uses nightly-only options).

Closes #5798

🤖 Generated with [Claude Code](https://claude.com/claude-code)