### PR TITLE
fix(sql): resolve comparison collation per SQLite datatype3 §7.1 (in4-4.2, in4-4.4)

### DIFF
--- a/crates/vibesql-executor/src/evaluator/collation.rs
+++ b/crates/vibesql-executor/src/evaluator/collation.rs
@@ -1,0 +1,279 @@
+//! Shared collation-resolution rules for expressions and comparisons.
+//!
+//! Implements SQLite's collating-sequence rules
+//! (https://sqlite.org/datatype3.html#collation, section 7.1):
+//!
+//! For a binary comparison `X <op> Y` the collating sequence is chosen by:
+//! 1. An explicit `COLLATE` operator anywhere inside either operand's
+//!    subtree, with precedence to the left operand.
+//! 2. Otherwise, if either operand *is a column* — optionally wrapped in
+//!    unary `+` and/or `CAST` — that column's collation is used, with
+//!    precedence to the left operand. Note that a column with no declared
+//!    collation still counts: it contributes the default BINARY and blocks
+//!    fallback to the right operand (`a = b` compares BINARY even when `b`
+//!    is NOCASE, per in4-4.1).
+//! 3. Otherwise, BINARY.
+//!
+//! Crucially, a column's *implicit* collation does **not** propagate through
+//! `||` or any other operator or function: `(b || '')` has no collating
+//! sequence even when `b` is declared `COLLATE NOCASE` (issue #5792,
+//! `in4-4.4`). Only an explicit `COLLATE` operator carries through compound
+//! expressions.
+//!
+//! This module is shared by `ExpressionEvaluator` (single-table) and
+//! `CombinedExpressionEvaluator` (multi-table); the two differ only in how a
+//! column reference is resolved to its declared collation, which is supplied
+//! by the `column_collation` callback. The callback returns the column's
+//! *declared* collation, or `None` when the column has none (default
+//! BINARY).
+
+use vibesql_ast::{ColumnIdentifier, Expression, UnaryOperator};
+
+/// Find an *explicit* COLLATE operator anywhere within an expression's
+/// subtree (SQLite's `EP_Collate` propagation).
+///
+/// An explicit `COLLATE` inside any operand of a binary operator beats the
+/// column-derived (implicit) collation of the other operand. We walk through
+/// compound expressions (BinaryOp, UnaryOp, CAST, single-arg
+/// Function/Aggregate) looking specifically for a `Collate` node —
+/// column-level collations are *not* considered explicit and are
+/// deliberately ignored here.
+pub(crate) fn explicit_collation_of(expr: &Expression) -> Option<String> {
+    match expr {
+        Expression::Collate { collation, .. } => Some(collation.clone()),
+        Expression::BinaryOp { left, right, .. } => {
+            explicit_collation_of(left).or_else(|| explicit_collation_of(right))
+        }
+        Expression::UnaryOp { expr, .. } => explicit_collation_of(expr),
+        Expression::Cast { expr, .. } => explicit_collation_of(expr),
+        Expression::AggregateFunction { args, .. } if args.len() == 1 => {
+            explicit_collation_of(&args[0])
+        }
+        Expression::Function { args, .. } if args.len() == 1 => explicit_collation_of(&args[0]),
+        _ => None,
+    }
+}
+
+/// If the expression *is a column operand* in the sense of datatype3 §7.1
+/// rule 2 — a column reference optionally wrapped in unary `+`, `CAST`, or
+/// an explicit `COLLATE` — return `Some(collation)` where the inner value is
+/// the column's declared collation (`None` = default BINARY).
+///
+/// Returns `None` when the expression is not a column operand at all
+/// (literal, `||`, function call, ...), in which case a comparison falls
+/// through to the other operand.
+fn operand_column_collation(
+    expr: &Expression,
+    column_collation: &dyn Fn(&ColumnIdentifier) -> Option<String>,
+) -> Option<Option<String>> {
+    match expr {
+        Expression::ColumnRef(col_id) => Some(column_collation(col_id)),
+        Expression::UnaryOp { op: UnaryOperator::Plus, expr } => {
+            operand_column_collation(expr, column_collation)
+        }
+        Expression::Cast { expr, .. } => operand_column_collation(expr, column_collation),
+        _ => None,
+    }
+}
+
+/// Resolve the effective collating sequence of a single expression.
+///
+/// Mirrors SQLite's `sqlite3ExprCollSeq`:
+/// - An explicit `COLLATE` operator assigns its collation.
+/// - A column reference carries the column's declared (implicit) collation.
+/// - Unary `+` and `CAST` are transparent: a column wrapped in them still
+///   counts as that column.
+/// - Any other operator or function does **not** carry its operands'
+///   implicit collation; only an explicit `COLLATE` somewhere in the subtree
+///   propagates out.
+/// - Everything else has no collating sequence (callers default to BINARY).
+///
+/// `column_collation` resolves a column reference to its declared collation
+/// (schema lookup differs between the single-table and combined evaluators).
+pub(crate) fn resolve_expression_collation(
+    expr: &Expression,
+    column_collation: &dyn Fn(&ColumnIdentifier) -> Option<String>,
+) -> Option<String> {
+    match expr {
+        // Explicit COLLATE has highest priority.
+        Expression::Collate { collation, .. } => Some(collation.clone()),
+        // Column reference - the column's declared collation (implicit).
+        Expression::ColumnRef(col_id) => column_collation(col_id),
+        // Unary `+` and CAST are transparent: `+a` and `CAST(a AS TEXT)`
+        // are still "a column" for collation purposes (datatype3 §7.1 rule 2).
+        Expression::UnaryOp { op: UnaryOperator::Plus, expr } => {
+            resolve_expression_collation(expr, column_collation)
+        }
+        Expression::Cast { expr, .. } => resolve_expression_collation(expr, column_collation),
+        // Any other operator (including `||`), unary op, or function: the
+        // operands' implicit column collation does NOT propagate through.
+        // Only an explicit COLLATE anywhere in the subtree carries out.
+        Expression::BinaryOp { left, right, .. } => {
+            explicit_collation_of(left).or_else(|| explicit_collation_of(right))
+        }
+        Expression::UnaryOp { expr, .. } => explicit_collation_of(expr),
+        Expression::AggregateFunction { args, .. } if args.len() == 1 => {
+            explicit_collation_of(&args[0])
+        }
+        Expression::Function { args, .. } if args.len() == 1 => explicit_collation_of(&args[0]),
+        // Other expressions have no intrinsic collation.
+        _ => None,
+    }
+}
+
+/// Resolve the collating sequence for a binary comparison `left <op> right`
+/// per SQLite datatype3 §7.1:
+///
+/// 1. explicit COLLATE in left subtree, else explicit in right subtree;
+/// 2. else, if the left operand is a column (through unary `+`/CAST), that
+///    column's collation — *including* the default BINARY, which blocks the
+///    right operand's collation;
+/// 3. else the same for the right operand;
+/// 4. else `None` (BINARY).
+pub(crate) fn comparison_collation(
+    left: &Expression,
+    right: &Expression,
+    column_collation: &dyn Fn(&ColumnIdentifier) -> Option<String>,
+) -> Option<String> {
+    if let Some(c) = explicit_collation_of(left).or_else(|| explicit_collation_of(right)) {
+        return Some(c);
+    }
+    if let Some(coll) = operand_column_collation(left, column_collation) {
+        return coll;
+    }
+    if let Some(coll) = operand_column_collation(right, column_collation) {
+        return coll;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use vibesql_ast::{BinaryOperator, ColumnIdentifier, Expression, UnaryOperator};
+    use vibesql_types::SqlValue;
+
+    use super::*;
+
+    fn col(name: &str) -> Expression {
+        Expression::ColumnRef(ColumnIdentifier::unquoted(name))
+    }
+
+    fn lit(s: &str) -> Expression {
+        Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(s)))
+    }
+
+    fn concat(left: Expression, right: Expression) -> Expression {
+        Expression::BinaryOp {
+            op: BinaryOperator::Concat,
+            left: Box::new(left),
+            right: Box::new(right),
+        }
+    }
+
+    /// Lookup where column `b` is declared COLLATE NOCASE and all other
+    /// columns have no declared collation (default BINARY).
+    fn lookup(col_id: &ColumnIdentifier) -> Option<String> {
+        if col_id.column_canonical() == "b" {
+            Some("NOCASE".to_string())
+        } else {
+            None
+        }
+    }
+
+    #[test]
+    fn column_carries_implicit_collation() {
+        assert_eq!(resolve_expression_collation(&col("b"), &lookup), Some("NOCASE".to_string()));
+        assert_eq!(resolve_expression_collation(&col("a"), &lookup), None);
+    }
+
+    #[test]
+    fn implicit_collation_does_not_propagate_through_concat() {
+        // (b || '') has NO collating sequence (issue #5792, in4-4.4)
+        let expr = concat(col("b"), lit(""));
+        assert_eq!(resolve_expression_collation(&expr, &lookup), None);
+    }
+
+    #[test]
+    fn unary_plus_and_cast_are_transparent() {
+        let plus = Expression::UnaryOp { op: UnaryOperator::Plus, expr: Box::new(col("b")) };
+        assert_eq!(resolve_expression_collation(&plus, &lookup), Some("NOCASE".to_string()));
+
+        let cast = Expression::Cast {
+            expr: Box::new(col("b")),
+            data_type: vibesql_types::DataType::Varchar { max_length: None },
+        };
+        assert_eq!(resolve_expression_collation(&cast, &lookup), Some("NOCASE".to_string()));
+
+        // But unary minus is not transparent for implicit collation.
+        let minus = Expression::UnaryOp { op: UnaryOperator::Minus, expr: Box::new(col("b")) };
+        assert_eq!(resolve_expression_collation(&minus, &lookup), None);
+    }
+
+    #[test]
+    fn explicit_collate_propagates_through_concat() {
+        // (a COLLATE RTRIM || '') keeps the explicit collation
+        let collated =
+            Expression::Collate { expr: Box::new(col("a")), collation: "RTRIM".to_string() };
+        let expr = concat(collated, lit(""));
+        assert_eq!(resolve_expression_collation(&expr, &lookup), Some("RTRIM".to_string()));
+    }
+
+    #[test]
+    fn comparison_left_column_binary_blocks_right_nocase() {
+        // a = b -> a is a column with default BINARY collation; left
+        // precedence means BINARY, not b's NOCASE (in4-4.1 expects only
+        // the exact-match row).
+        assert_eq!(comparison_collation(&col("a"), &col("b"), &lookup), None);
+    }
+
+    #[test]
+    fn comparison_left_nocase_wins() {
+        // b = a -> NOCASE (left column's collation wins) (in4-4.2)
+        assert_eq!(comparison_collation(&col("b"), &col("a"), &lookup), Some("NOCASE".to_string()));
+    }
+
+    #[test]
+    fn comparison_concat_wrapped_operands_are_binary() {
+        // (a||'') = (b||'') -> no collation on either side -> BINARY (in4-4.4)
+        let left = concat(col("a"), lit(""));
+        let right = concat(col("b"), lit(""));
+        assert_eq!(comparison_collation(&left, &right, &lookup), None);
+    }
+
+    #[test]
+    fn comparison_concat_left_falls_back_to_right_column() {
+        // (a||'') = b -> LHS is not a column, RHS column's NOCASE applies (in4-4.3)
+        let left = concat(col("a"), lit(""));
+        assert_eq!(comparison_collation(&left, &col("b"), &lookup), Some("NOCASE".to_string()));
+    }
+
+    #[test]
+    fn comparison_literal_vs_nocase_column() {
+        // 'XYZ' = b -> literal has no collation, b's NOCASE applies.
+        assert_eq!(
+            comparison_collation(&lit("XYZ"), &col("b"), &lookup),
+            Some("NOCASE".to_string())
+        );
+        // b = 'XYZ' likewise.
+        assert_eq!(
+            comparison_collation(&col("b"), &lit("XYZ"), &lookup),
+            Some("NOCASE".to_string())
+        );
+    }
+
+    #[test]
+    fn explicit_right_beats_implicit_left() {
+        // b = (a COLLATE RTRIM) -> explicit RTRIM on the right wins over
+        // implicit NOCASE on the left (datatype3 §7.1 rule 1).
+        let collated =
+            Expression::Collate { expr: Box::new(col("a")), collation: "RTRIM".to_string() };
+        assert_eq!(comparison_collation(&col("b"), &collated, &lookup), Some("RTRIM".to_string()));
+    }
+
+    #[test]
+    fn explicit_left_beats_explicit_right() {
+        let l = Expression::Collate { expr: Box::new(col("a")), collation: "RTRIM".to_string() };
+        let r = Expression::Collate { expr: Box::new(col("a")), collation: "NOCASE".to_string() };
+        assert_eq!(comparison_collation(&l, &r, &lookup), Some("RTRIM".to_string()));
+    }
+}

--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -35,32 +35,6 @@ fn format_float_for_text_comparison(n: f64) -> String {
     }
 }
 
-/// Find an *explicit* COLLATE clause anywhere within the expression's
-/// "collation propagation tree".
-///
-/// SQLite's rule (datatype3 §7.1) is that an explicit `COLLATE` clause inside
-/// any operand of a binary operator beats the column-derived (inherited)
-/// collation of the other operand. We walk through compound expressions that
-/// propagate collation (BinaryOp, UnaryOp, single-arg Function/Aggregate)
-/// looking specifically for a `Collate` node — column-level collations are
-/// *not* considered explicit and are deliberately ignored here.
-pub(super) fn explicit_collation_of(expr: &vibesql_ast::Expression) -> Option<String> {
-    match expr {
-        vibesql_ast::Expression::Collate { collation, .. } => Some(collation.clone()),
-        vibesql_ast::Expression::BinaryOp { left, right, .. } => {
-            explicit_collation_of(left).or_else(|| explicit_collation_of(right))
-        }
-        vibesql_ast::Expression::UnaryOp { expr, .. } => explicit_collation_of(expr),
-        vibesql_ast::Expression::AggregateFunction { args, .. } if args.len() == 1 => {
-            explicit_collation_of(&args[0])
-        }
-        vibesql_ast::Expression::Function { args, .. } if args.len() == 1 => {
-            explicit_collation_of(&args[0])
-        }
-        _ => None,
-    }
-}
-
 impl CombinedExpressionEvaluator<'_> {
     /// Get the SQLite type affinity of an expression if it's a column reference.
     ///
@@ -109,75 +83,63 @@ impl CombinedExpressionEvaluator<'_> {
         }
     }
 
+    /// Look up a column's declared collation in the combined schema.
+    ///
+    /// Returns `None` when the column has no declared collation (default
+    /// BINARY) or cannot be resolved.
+    pub(super) fn column_collation_of(
+        &self,
+        col_id: &vibesql_ast::ColumnIdentifier,
+    ) -> Option<String> {
+        let table = col_id.table_canonical();
+        let column = col_id.column_canonical();
+
+        // Look up the column in the combined schema
+        for (_start_idx, table_schema) in self.schema.table_schemas.values() {
+            // If table qualifier is specified, check if this is the right table
+            if let Some(t) = table {
+                let table_name_lower = table_schema.name.to_lowercase();
+                if t.to_lowercase() != table_name_lower {
+                    continue;
+                }
+            }
+
+            // Look up the column in this table
+            if let Some(col_offset) = table_schema.get_column_index(column) {
+                return table_schema.columns[col_offset].collation.clone();
+            }
+        }
+        None
+    }
+
     /// Get the effective collation for an expression.
     ///
-    /// Implements SQLite's collation propagation rules
-    /// (see https://sqlite.org/datatype3.html#collation):
-    /// 1. Explicit COLLATE clause has highest priority and propagates outward
-    ///    through compound expressions.
-    /// 2. Column references inherit the column's declared collation.
-    /// 3. Binary operators (including `||`): if either operand has an *explicit*
-    ///    COLLATE, that wins. Otherwise the left operand's collation is used,
-    ///    falling back to the right operand's.
-    /// 4. Unary operators and single-argument functions / aggregates inherit
-    ///    collation from their operand.
-    /// 5. Otherwise, no collation (use default BINARY).
+    /// Implements SQLite's collation rules (datatype3.html §7.1) via the
+    /// shared resolver in `evaluator::collation`: explicit COLLATE
+    /// propagates out of compound expressions; a column's implicit collation
+    /// is carried only through unary `+` and CAST — it does NOT leak through
+    /// `||` or other operators/functions (issue #5792).
     pub(crate) fn get_expression_collation(
         &self,
         expr: &vibesql_ast::Expression,
     ) -> Option<String> {
-        match expr {
-            // Explicit COLLATE has highest priority
-            vibesql_ast::Expression::Collate { collation, .. } => Some(collation.clone()),
-            // Column reference - look up column's declared collation
-            vibesql_ast::Expression::ColumnRef(col_id) => {
-                let table = col_id.table_canonical();
-                let column = col_id.column_canonical();
+        crate::evaluator::collation::resolve_expression_collation(expr, &|col_id| {
+            self.column_collation_of(col_id)
+        })
+    }
 
-                // Look up the column in the combined schema
-                for (_start_idx, table_schema) in self.schema.table_schemas.values() {
-                    // If table qualifier is specified, check if this is the right table
-                    if let Some(t) = table {
-                        let table_name_lower = table_schema.name.to_lowercase();
-                        if t.to_lowercase() != table_name_lower {
-                            continue;
-                        }
-                    }
-
-                    // Look up the column in this table
-                    if let Some(col_offset) = table_schema.get_column_index(column) {
-                        return table_schema.columns[col_offset].collation.clone();
-                    }
-                }
-                None
-            }
-            // Binary operator: explicit COLLATE on either operand wins, else
-            // inherit from the left operand (SQLite rule).
-            vibesql_ast::Expression::BinaryOp { left, right, .. } => {
-                if let Some(c) = explicit_collation_of(left) {
-                    return Some(c);
-                }
-                if let Some(c) = explicit_collation_of(right) {
-                    return Some(c);
-                }
-                self.get_expression_collation(left)
-                    .or_else(|| self.get_expression_collation(right))
-            }
-            // Unary operator: inherit from operand.
-            vibesql_ast::Expression::UnaryOp { expr, .. } => self.get_expression_collation(expr),
-            // Aggregate function with a single argument: inherit from argument.
-            // (Multi-arg aggregates have no well-defined inherited collation.)
-            vibesql_ast::Expression::AggregateFunction { args, .. } if args.len() == 1 => {
-                self.get_expression_collation(&args[0])
-            }
-            // Scalar function with a single argument: inherit from argument.
-            // (Multi-arg functions have no well-defined inherited collation.)
-            vibesql_ast::Expression::Function { args, .. } if args.len() == 1 => {
-                self.get_expression_collation(&args[0])
-            }
-            // Other expressions don't have intrinsic collation
-            _ => None,
-        }
+    /// Resolve the collating sequence for a binary comparison `left <op>
+    /// right` per SQLite datatype3 §7.1 (explicit COLLATE on either side
+    /// first, then left column's collation — including its default BINARY —
+    /// then right column's). `None` means BINARY.
+    pub(super) fn comparison_collation(
+        &self,
+        left: &vibesql_ast::Expression,
+        right: &vibesql_ast::Expression,
+    ) -> Option<String> {
+        crate::evaluator::collation::comparison_collation(left, right, &|col_id| {
+            self.column_collation_of(col_id)
+        })
     }
 
     /// Check if an expression is a numeric literal (INTEGER or REAL).
@@ -906,7 +868,11 @@ impl CombinedExpressionEvaluator<'_> {
                                     vibesql_ast::Expression::ScalarSubquery(subquery),
                                 ) => {
                                     return self.eval_row_value_subquery_comparison(
-                                        tuple_exprs, op, subquery, true, row,
+                                        tuple_exprs,
+                                        op,
+                                        subquery,
+                                        true,
+                                        row,
                                     );
                                 }
                                 (
@@ -914,7 +880,11 @@ impl CombinedExpressionEvaluator<'_> {
                                     vibesql_ast::Expression::RowValueConstructor(tuple_exprs),
                                 ) => {
                                     return self.eval_row_value_subquery_comparison(
-                                        tuple_exprs, op, subquery, false, row,
+                                        tuple_exprs,
+                                        op,
+                                        subquery,
+                                        false,
+                                        row,
                                     );
                                 }
                                 (
@@ -925,9 +895,9 @@ impl CombinedExpressionEvaluator<'_> {
                                     // values, e.g. (SELECT a,b)==(SELECT x,y). When
                                     // both are single-column this returns None and
                                     // we fall through to scalar comparison.
-                                    if let Some(result) = self
-                                        .eval_two_subquery_row_comparison(left_sub, op, right_sub, row)?
-                                    {
+                                    if let Some(result) = self.eval_two_subquery_row_comparison(
+                                        left_sub, op, right_sub, row,
+                                    )? {
                                         return Ok(result);
                                     }
                                 }
@@ -935,11 +905,12 @@ impl CombinedExpressionEvaluator<'_> {
                             }
                         }
 
-                        // Get effective collation from either side
-                        // Priority: explicit COLLATE > column-level collation
+                        // Get effective collation per SQLite datatype3 §7.1:
+                        // explicit COLLATE (left, then right) > left column's
+                        // collation (its default BINARY blocks the right's) >
+                        // right column's collation > BINARY.
                         let collation = if is_comparison {
-                            self.get_expression_collation(left)
-                                .or_else(|| self.get_expression_collation(right))
+                            self.comparison_collation(left, right)
                         } else {
                             None
                         };
@@ -1133,13 +1104,25 @@ impl CombinedExpressionEvaluator<'_> {
             // Current date/time functions
             vibesql_ast::Expression::CurrentDate => {
                 let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
-                super::super::functions::eval_scalar_function("CURRENT_DATE", &[], &None, &sql_mode, crate::evaluator::SchemaExprContext::None)
+                super::super::functions::eval_scalar_function(
+                    "CURRENT_DATE",
+                    &[],
+                    &None,
+                    &sql_mode,
+                    crate::evaluator::SchemaExprContext::None,
+                )
             }
             vibesql_ast::Expression::CurrentTime { precision: _ } => {
                 // For now, ignore precision and call existing function
                 // Phase 2 will implement precision-aware formatting
                 let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
-                super::super::functions::eval_scalar_function("CURRENT_TIME", &[], &None, &sql_mode, crate::evaluator::SchemaExprContext::None)
+                super::super::functions::eval_scalar_function(
+                    "CURRENT_TIME",
+                    &[],
+                    &None,
+                    &sql_mode,
+                    crate::evaluator::SchemaExprContext::None,
+                )
             }
             vibesql_ast::Expression::CurrentTimestamp { precision: _ } => {
                 // For now, ignore precision and call existing function
@@ -1324,9 +1307,9 @@ impl CombinedExpressionEvaluator<'_> {
             vibesql_ast::RaiseAction::Ignore => Err(ExecutorError::RaiseIgnore),
             _ => {
                 let message = match error_message {
-                    Some(expr) => crate::evaluator::raise::render_raise_message(
-                        self.eval(expr, row)?,
-                    ),
+                    Some(expr) => {
+                        crate::evaluator::raise::render_raise_message(self.eval(expr, row)?)
+                    }
                     None => String::new(),
                 };
                 Err(ExecutorError::Raise { action, message })

--- a/crates/vibesql-executor/src/evaluator/compiled.rs
+++ b/crates/vibesql-executor/src/evaluator/compiled.rs
@@ -202,6 +202,13 @@ impl CompiledPredicate {
         if let (Expression::ColumnRef(col_id), Expression::Literal(value)) = (left, right) {
             let col_idx =
                 schema.get_column_index(col_id.table_canonical(), col_id.column_canonical())?;
+            // Issue #5792: comparisons against a non-BINARY-collated column
+            // (e.g. NOCASE) must apply the collation; the compiled fast path
+            // compares raw values, so decline and fall back to the
+            // collation-aware expression evaluator.
+            if schema.column_has_non_binary_collation(col_idx) {
+                return None;
+            }
             if !Self::literal_supported_for_column(schema, col_idx, value) {
                 return None;
             }
@@ -213,6 +220,10 @@ impl CompiledPredicate {
         if let (Expression::Literal(value), Expression::ColumnRef(col_id)) = (left, right) {
             let col_idx =
                 schema.get_column_index(col_id.table_canonical(), col_id.column_canonical())?;
+            // Issue #5792: see above — collated columns need the full evaluator.
+            if schema.column_has_non_binary_collation(col_idx) {
+                return None;
+            }
             if !Self::literal_supported_for_column(schema, col_idx, value) {
                 return None;
             }
@@ -1033,6 +1044,69 @@ mod tests {
         }
     }
 
+    /// Schema mirroring `in4.test`'s t4a: `a` has default BINARY collation,
+    /// `b` is declared NOCASE (issue #5792).
+    fn create_collated_schema() -> CombinedSchema {
+        let columns = vec![
+            ColumnSchema::new("a".to_string(), DataType::Varchar { max_length: None }, true),
+            ColumnSchema {
+                name: "b".to_string(),
+                data_type: DataType::Varchar { max_length: None },
+                nullable: true,
+                default_value: None,
+                generated_expr: None,
+                is_exact_integer_type: false,
+                collation: Some("NOCASE".to_string()),
+            },
+        ];
+        let schema = TableSchema::new("t4a".to_string(), columns);
+        CombinedSchema::from_table("t4a".to_string(), schema)
+    }
+
+    #[test]
+    fn test_collated_column_comparison_declined() {
+        // Issue #5792: comparisons against a NOCASE column must not compile;
+        // the fast path compares raw values and would miss 'XYZ' = 'xyz'.
+        let schema = create_collated_schema();
+        for (left, right) in [
+            (
+                Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("b", false)),
+                Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("xyz"))),
+            ),
+            (
+                Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("xyz"))),
+                Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("b", false)),
+            ),
+        ] {
+            let expr = Expression::BinaryOp {
+                left: Box::new(left),
+                op: BinaryOperator::Equal,
+                right: Box::new(right),
+            };
+            let compiled = CompiledPredicate::compile(&expr, &schema);
+            assert!(
+                !compiled.is_fully_compiled(),
+                "NOCASE column comparison must fall back to the expression evaluator"
+            );
+        }
+    }
+
+    #[test]
+    fn test_binary_collated_column_still_compiles() {
+        // A column with no declared collation (default BINARY) keeps the
+        // fast path.
+        let schema = create_collated_schema();
+        let expr = Expression::BinaryOp {
+            left: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
+                "a", false,
+            ))),
+            op: BinaryOperator::Equal,
+            right: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("ABC")))),
+        };
+        let compiled = CompiledPredicate::compile(&expr, &schema);
+        assert!(compiled.is_fully_compiled());
+    }
+
     #[test]
     fn test_evaluate_equals() {
         let schema = create_test_schema();
@@ -1064,11 +1138,8 @@ mod tests {
     /// Schema with a single TEXT-affinity column `a` (matches `indexA.test`'s
     /// `CREATE TABLE x1(a TEXT, ...)`).
     fn create_text_col_schema() -> CombinedSchema {
-        let columns = vec![ColumnSchema::new(
-            "a".to_string(),
-            DataType::Varchar { max_length: None },
-            true,
-        )];
+        let columns =
+            vec![ColumnSchema::new("a".to_string(), DataType::Varchar { max_length: None }, true)];
         let schema = TableSchema::new("x1".to_string(), columns);
         CombinedSchema::from_table("x1".to_string(), schema)
     }
@@ -1087,9 +1158,9 @@ mod tests {
 
     fn col_op_lit(op: BinaryOperator, lit: SqlValue) -> Expression {
         Expression::BinaryOp {
-            left: Box::new(Expression::ColumnRef(
-                vibesql_ast::ColumnIdentifier::simple("a", false),
-            )),
+            left: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
+                "a", false,
+            ))),
             op,
             right: Box::new(Expression::Literal(lit)),
         }
@@ -1099,9 +1170,9 @@ mod tests {
         Expression::BinaryOp {
             left: Box::new(Expression::Literal(lit)),
             op,
-            right: Box::new(Expression::ColumnRef(
-                vibesql_ast::ColumnIdentifier::simple("a", false),
-            )),
+            right: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
+                "a", false,
+            ))),
         }
     }
 

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -34,32 +34,6 @@ pub(crate) fn format_float_for_text_comparison(n: f64) -> String {
     }
 }
 
-/// Find an *explicit* COLLATE clause anywhere within the expression's
-/// "collation propagation tree".
-///
-/// SQLite's rule (datatype3 §7.1) is that an explicit `COLLATE` clause inside
-/// any operand of a binary operator beats the column-derived (inherited)
-/// collation of the other operand. We walk through compound expressions that
-/// propagate collation (BinaryOp, UnaryOp, single-arg Function/Aggregate)
-/// looking specifically for a `Collate` node — column-level collations are
-/// *not* considered explicit and are deliberately ignored here.
-fn explicit_collation_of(expr: &vibesql_ast::Expression) -> Option<String> {
-    match expr {
-        vibesql_ast::Expression::Collate { collation, .. } => Some(collation.clone()),
-        vibesql_ast::Expression::BinaryOp { left, right, .. } => {
-            explicit_collation_of(left).or_else(|| explicit_collation_of(right))
-        }
-        vibesql_ast::Expression::UnaryOp { expr, .. } => explicit_collation_of(expr),
-        vibesql_ast::Expression::AggregateFunction { args, .. } if args.len() == 1 => {
-            explicit_collation_of(&args[0])
-        }
-        vibesql_ast::Expression::Function { args, .. } if args.len() == 1 => {
-            explicit_collation_of(&args[0])
-        }
-        _ => None,
-    }
-}
-
 impl ExpressionEvaluator<'_> {
     /// Get the SQLite type affinity of an expression if it's a column reference.
     ///
@@ -93,60 +67,47 @@ impl ExpressionEvaluator<'_> {
         }
     }
 
+    /// Look up a column's declared collation in this evaluator's schema.
+    ///
+    /// Returns `None` when the column has no declared collation (default
+    /// BINARY) or cannot be resolved.
+    pub(super) fn column_collation_of(
+        &self,
+        col_id: &vibesql_ast::ColumnIdentifier,
+    ) -> Option<String> {
+        let column_name = col_id.column_canonical();
+        let col_idx = self.schema.get_column_index(column_name)?;
+        self.schema.columns[col_idx].collation.clone()
+    }
+
     /// Get the effective collation for an expression.
     ///
-    /// Implements SQLite's collation propagation rules
-    /// (see https://sqlite.org/datatype3.html#collation):
-    /// 1. Explicit COLLATE clause has highest priority and propagates outward
-    ///    through compound expressions.
-    /// 2. Column references inherit the column's declared collation.
-    /// 3. Binary operators (including `||`): if either operand has an *explicit*
-    ///    COLLATE, that wins. Otherwise the left operand's collation is used,
-    ///    falling back to the right operand's.
-    /// 4. Unary operators and single-argument functions / aggregates inherit
-    ///    collation from their operand.
-    /// 5. Otherwise, no collation (use default BINARY).
+    /// Implements SQLite's collation rules (datatype3.html §7.1) via the
+    /// shared resolver in `evaluator::collation`: explicit COLLATE
+    /// propagates out of compound expressions; a column's implicit collation
+    /// is carried only through unary `+` and CAST — it does NOT leak through
+    /// `||` or other operators/functions (issue #5792).
     pub(super) fn get_expression_collation(
         &self,
         expr: &vibesql_ast::Expression,
     ) -> Option<String> {
-        match expr {
-            // Explicit COLLATE has highest priority
-            vibesql_ast::Expression::Collate { collation, .. } => Some(collation.clone()),
-            // Column reference - look up column's declared collation
-            vibesql_ast::Expression::ColumnRef(col_id) => {
-                let column_name = col_id.column_canonical();
-                if let Some(col_idx) = self.schema.get_column_index(column_name) {
-                    self.schema.columns[col_idx].collation.clone()
-                } else {
-                    None
-                }
-            }
-            // Binary operator: explicit COLLATE on either operand wins, else
-            // inherit from the left operand (SQLite rule).
-            vibesql_ast::Expression::BinaryOp { left, right, .. } => {
-                if let Some(c) = explicit_collation_of(left) {
-                    return Some(c);
-                }
-                if let Some(c) = explicit_collation_of(right) {
-                    return Some(c);
-                }
-                self.get_expression_collation(left)
-                    .or_else(|| self.get_expression_collation(right))
-            }
-            // Unary operator: inherit from operand.
-            vibesql_ast::Expression::UnaryOp { expr, .. } => self.get_expression_collation(expr),
-            // Aggregate function with a single argument: inherit from argument.
-            vibesql_ast::Expression::AggregateFunction { args, .. } if args.len() == 1 => {
-                self.get_expression_collation(&args[0])
-            }
-            // Scalar function with a single argument: inherit from argument.
-            vibesql_ast::Expression::Function { args, .. } if args.len() == 1 => {
-                self.get_expression_collation(&args[0])
-            }
-            // Other expressions don't have intrinsic collation
-            _ => None,
-        }
+        crate::evaluator::collation::resolve_expression_collation(expr, &|col_id| {
+            self.column_collation_of(col_id)
+        })
+    }
+
+    /// Resolve the collating sequence for a binary comparison `left <op>
+    /// right` per SQLite datatype3 §7.1 (explicit COLLATE on either side
+    /// first, then left column's collation — including its default BINARY —
+    /// then right column's). `None` means BINARY.
+    pub(super) fn comparison_collation(
+        &self,
+        left: &vibesql_ast::Expression,
+        right: &vibesql_ast::Expression,
+    ) -> Option<String> {
+        crate::evaluator::collation::comparison_collation(left, right, &|col_id| {
+            self.column_collation_of(col_id)
+        })
     }
 
     /// Check if an expression is a numeric literal (INTEGER or REAL).
@@ -615,12 +576,12 @@ impl ExpressionEvaluator<'_> {
                             }
                         }
 
-                        // Get effective collation from either side
-                        // Priority: explicit COLLATE > column-level collation
-                        // Check left side first, then right side
+                        // Get effective collation per SQLite datatype3 §7.1:
+                        // explicit COLLATE (left, then right) > left column's
+                        // collation (its default BINARY blocks the right's) >
+                        // right column's collation > BINARY.
                         let collation = if is_comparison {
-                            self.get_expression_collation(left)
-                                .or_else(|| self.get_expression_collation(right))
+                            self.comparison_collation(left, right)
                         } else {
                             None
                         };

--- a/crates/vibesql-executor/src/evaluator/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/mod.rs
@@ -3,6 +3,7 @@ pub mod arena;
 pub(crate) mod caching;
 pub(crate) mod casting;
 pub mod coercion;
+pub(crate) mod collation;
 mod combined;
 mod combined_core;
 pub(crate) mod compiled;

--- a/crates/vibesql-executor/src/schema.rs
+++ b/crates/vibesql-executor/src/schema.rs
@@ -615,6 +615,39 @@ impl CombinedSchema {
         None
     }
 
+    /// Get the declared collation for a column by its combined (absolute)
+    /// index
+    ///
+    /// Returns `None` if the column has no declared collation (default
+    /// BINARY) or the index does not fall inside any table at this schema
+    /// level. Used by the compiled/vectorized/columnar predicate fast paths
+    /// to decline compilation for columns whose comparisons must honor a
+    /// non-BINARY collation (issue #5792) — those fall back to the
+    /// collation-aware expression evaluator.
+    pub fn get_column_collation_by_index(&self, idx: usize) -> Option<&str> {
+        for (table_id, (start_index, schema)) in &self.table_schemas {
+            // Alias tables share start_index 0 with non-contiguous columns;
+            // skip them so we only match real, contiguous column ranges.
+            if self.alias_tables.contains(table_id) {
+                continue;
+            }
+            if idx >= *start_index && idx < start_index + schema.columns.len() {
+                return schema.columns[idx - start_index].collation.as_deref();
+            }
+        }
+        None
+    }
+
+    /// Whether the column at the given combined index has a declared
+    /// non-BINARY collation (e.g. NOCASE, RTRIM). Comparisons on such
+    /// columns cannot be evaluated by the raw-value fast paths.
+    pub fn column_has_non_binary_collation(&self, idx: usize) -> bool {
+        matches!(
+            self.get_column_collation_by_index(idx),
+            Some(c) if !c.eq_ignore_ascii_case("binary")
+        )
+    }
+
     /// Get the type affinity for a column by name
     ///
     /// Returns the SQLite type affinity for the column, which determines how

--- a/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
@@ -291,11 +291,19 @@ fn predicate_supported_by_columnar(predicate: &ColumnPredicate, schema: &Combine
         | ColumnPredicate::LessThanOrEqual { column_idx, value }
         | ColumnPredicate::Equal { column_idx, value }
         | ColumnPredicate::NotEqual { column_idx, value } => {
-            value_supported_for_column(schema.get_column_type_by_index(*column_idx), value)
+            // Issue #5792: comparisons on a non-BINARY-collated column (e.g.
+            // NOCASE) must apply the collation; the columnar comparators
+            // compare raw values, so decline pushdown and fall back to the
+            // collation-aware expression evaluator.
+            !schema.column_has_non_binary_collation(*column_idx)
+                && value_supported_for_column(schema.get_column_type_by_index(*column_idx), value)
         }
         ColumnPredicate::Between { column_idx, low, high } => {
             let col_type = schema.get_column_type_by_index(*column_idx);
-            value_supported_for_column(col_type, low) && value_supported_for_column(col_type, high)
+            // Issue #5792: see above — collated columns need the full evaluator.
+            !schema.column_has_non_binary_collation(*column_idx)
+                && value_supported_for_column(col_type, low)
+                && value_supported_for_column(col_type, high)
         }
         ColumnPredicate::InList { column_idx, values, .. } => {
             let col_type = schema.get_column_type_by_index(*column_idx);
@@ -304,10 +312,13 @@ fn predicate_supported_by_columnar(predicate: &ColumnPredicate, schema: &Combine
         // LIKE patterns are strings; existing comparator behavior applies
         ColumnPredicate::Like { .. } => true,
         ColumnPredicate::ColumnCompare { left_column_idx, right_column_idx, .. } => {
-            column_compare_supported(
-                schema.get_column_type_by_index(*left_column_idx),
-                schema.get_column_type_by_index(*right_column_idx),
-            )
+            // Issue #5792: see above — collated columns need the full evaluator.
+            !schema.column_has_non_binary_collation(*left_column_idx)
+                && !schema.column_has_non_binary_collation(*right_column_idx)
+                && column_compare_supported(
+                    schema.get_column_type_by_index(*left_column_idx),
+                    schema.get_column_type_by_index(*right_column_idx),
+                )
         }
     }
 }
@@ -407,9 +418,7 @@ fn value_supported_for_column(col_type: Option<&DataType>, value: &SqlValue) -> 
         // pushdown and let the evaluator's `apply_affinity_for_comparison`
         // Case 1 handle it. NUMERIC/REAL/INTEGER columns keep numeric
         // comparison and are unaffected.
-        Some(other)
-            if other.sqlite_affinity() == TypeAffinity::Text && is_numeric_value(value) =>
-        {
+        Some(other) if other.sqlite_affinity() == TypeAffinity::Text && is_numeric_value(value) => {
             false
         }
         Some(other) => match value {

--- a/crates/vibesql-executor/src/select/vectorized/compiled_predicate.rs
+++ b/crates/vibesql-executor/src/select/vectorized/compiled_predicate.rs
@@ -446,6 +446,13 @@ impl CompiledWhereClause {
             return false;
         }
 
+        // Issue #5792: BETWEEN on a non-BINARY-collated column (e.g. NOCASE)
+        // must apply the collation; fall back to the collation-aware
+        // expression evaluator.
+        if schema.column_has_non_binary_collation(column_idx) {
+            return false;
+        }
+
         predicates.push(CompiledPredicate::Between { column_idx, low, high, negated, symmetric });
 
         true
@@ -513,6 +520,15 @@ impl CompiledWhereClause {
         if let (Some(left_idx), Some(right_idx)) =
             (Self::try_extract_column(left, schema), Self::try_extract_column(right, schema))
         {
+            // Issue #5792: comparisons involving a non-BINARY-collated column
+            // (e.g. NOCASE) must apply the collation; this fast path compares
+            // raw values, so decline and fall back to the collation-aware
+            // expression evaluator.
+            if schema.column_has_non_binary_collation(left_idx)
+                || schema.column_has_non_binary_collation(right_idx)
+            {
+                return false;
+            }
             predicates.push(CompiledPredicate::ColumnColumn { left_idx, right_idx, op: comp_op });
             return true;
         }
@@ -521,6 +537,10 @@ impl CompiledWhereClause {
         if let (Some(column_idx), Some(literal)) =
             (Self::try_extract_column(left, schema), Self::try_extract_literal(right))
         {
+            // Issue #5792: see above — collated columns need the full evaluator.
+            if schema.column_has_non_binary_collation(column_idx) {
+                return false;
+            }
             predicates.push(CompiledPredicate::ColumnLiteral { column_idx, op: comp_op, literal });
             return true;
         }
@@ -529,6 +549,10 @@ impl CompiledWhereClause {
         if let (Some(literal), Some(column_idx)) =
             (Self::try_extract_literal(left), Self::try_extract_column(right, schema))
         {
+            // Issue #5792: see above — collated columns need the full evaluator.
+            if schema.column_has_non_binary_collation(column_idx) {
+                return false;
+            }
             let flipped_op = Self::flip_operator(comp_op);
             predicates.push(CompiledPredicate::ColumnLiteral {
                 column_idx,
@@ -1284,6 +1308,115 @@ mod tests {
             compiled.is_some(),
             "Column-to-column inequality should compile into a ColumnColumn predicate"
         );
+        assert_eq!(compiled.unwrap().predicates.len(), 1);
+    }
+
+    /// Schema mirroring `in4.test`'s t4a: `a` has default BINARY collation,
+    /// `b` is declared NOCASE (issue #5792).
+    fn make_collated_schema() -> CombinedSchema {
+        let schema = TableSchema::new(
+            "t4a".to_string(),
+            vec![
+                ColumnSchema {
+                    name: "a".to_string(),
+                    data_type: DataType::Varchar { max_length: None },
+                    nullable: true,
+                    default_value: None,
+                    generated_expr: None,
+                    is_exact_integer_type: false,
+                    collation: None,
+                },
+                ColumnSchema {
+                    name: "b".to_string(),
+                    data_type: DataType::Varchar { max_length: None },
+                    nullable: true,
+                    default_value: None,
+                    generated_expr: None,
+                    is_exact_integer_type: false,
+                    collation: Some("NOCASE".to_string()),
+                },
+            ],
+        );
+        CombinedSchema::from_table("t4a".to_string(), schema)
+    }
+
+    fn col_ref(name: &str) -> Expression {
+        Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(name, false))
+    }
+
+    fn text_lit(s: &str) -> Expression {
+        Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(s)))
+    }
+
+    #[test]
+    fn test_collated_column_literal_comparison_declined() {
+        // Issue #5792: b = 'xyz' on a NOCASE column must not compile — the
+        // fast path compares raw values and would miss 'XYZ'.
+        let schema = make_collated_schema();
+        let expr = Expression::BinaryOp {
+            left: Box::new(col_ref("b")),
+            op: BinaryOperator::Equal,
+            right: Box::new(text_lit("xyz")),
+        };
+        assert!(
+            CompiledWhereClause::try_compile(&expr, &schema).is_none(),
+            "comparison on a NOCASE column must fall back to the expression evaluator"
+        );
+
+        // Literal-on-left likewise.
+        let expr = Expression::BinaryOp {
+            left: Box::new(text_lit("xyz")),
+            op: BinaryOperator::Equal,
+            right: Box::new(col_ref("b")),
+        };
+        assert!(CompiledWhereClause::try_compile(&expr, &schema).is_none());
+    }
+
+    #[test]
+    fn test_collated_column_column_comparison_declined() {
+        // Issue #5792: b = a (either side NOCASE) must not compile.
+        let schema = make_collated_schema();
+        for (l, r) in [("b", "a"), ("a", "b")] {
+            let expr = Expression::BinaryOp {
+                left: Box::new(col_ref(l)),
+                op: BinaryOperator::Equal,
+                right: Box::new(col_ref(r)),
+            };
+            assert!(
+                CompiledWhereClause::try_compile(&expr, &schema).is_none(),
+                "{}={} involves a NOCASE column and must fall back",
+                l,
+                r
+            );
+        }
+    }
+
+    #[test]
+    fn test_collated_column_between_declined() {
+        // Issue #5792: BETWEEN on a NOCASE column must not compile.
+        let schema = make_collated_schema();
+        let expr = Expression::Between {
+            expr: Box::new(col_ref("b")),
+            low: Box::new(text_lit("XYZ")),
+            high: Box::new(text_lit("XYZ")),
+            negated: false,
+            symmetric: false,
+        };
+        assert!(CompiledWhereClause::try_compile(&expr, &schema).is_none());
+    }
+
+    #[test]
+    fn test_binary_collated_column_still_compiles() {
+        // A column with no declared collation (default BINARY) keeps the
+        // fast path.
+        let schema = make_collated_schema();
+        let expr = Expression::BinaryOp {
+            left: Box::new(col_ref("a")),
+            op: BinaryOperator::Equal,
+            right: Box::new(text_lit("ABC")),
+        };
+        let compiled = CompiledWhereClause::try_compile(&expr, &schema);
+        assert!(compiled.is_some(), "BINARY-collated column should still compile");
         assert_eq!(compiled.unwrap().predicates.len(), 1);
     }
 }

--- a/crates/vibesql-executor/tests/comparison_collation_tests.rs
+++ b/crates/vibesql-executor/tests/comparison_collation_tests.rs
@@ -1,0 +1,195 @@
+//! Regression tests for issue #5792: comparison collation resolution
+//! (SQLite datatype3.html section 7.1) — `in4.test` subtests `in4-4.*`.
+//!
+//! Two defects are covered:
+//!
+//! - Defect A (slow path): implicit column collation must NOT propagate
+//!   through `||` (or other operators/functions) — `(b||'')` has no
+//!   collating sequence even when `b` is declared `COLLATE NOCASE`, so
+//!   `(a||'')=(b||'')` compares BINARY.
+//! - Defect B (fast paths): compiled/vectorized/columnar predicates compare
+//!   raw values, so compilation must be declined for columns with a
+//!   non-BINARY collation and fall back to the collation-aware evaluator
+//!   (`b=a` must apply NOCASE; `b='XYZ'` must match 'xyz').
+//!
+//! Expected values verified against sqlite3 (and `in4.test` lines 255-292).
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            vibesql_executor::InsertExecutor::execute(db, &insert).unwrap();
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+/// Run a single-column SELECT and collect the integer results.
+fn query_ints(db: &vibesql_storage::Database, sql: &str) -> Vec<i64> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        let rows = executor
+            .execute(&select_stmt)
+            .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e));
+        rows.iter()
+            .map(|row| {
+                assert_eq!(row.values.len(), 1, "Expected one column for: {}", sql);
+                match &row.values[0] {
+                    SqlValue::Integer(i) => *i,
+                    SqlValue::Bigint(i) => *i,
+                    SqlValue::Smallint(i) => i64::from(*i),
+                    other => panic!("Expected integer result for {}: {:?}", sql, other),
+                }
+            })
+            .collect()
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+fn assert_rows(db: &vibesql_storage::Database, sql: &str, expected: &[i64]) {
+    let actual = query_ints(db, sql);
+    assert_eq!(actual, expected, "Query: {} -- expected {:?}, got {:?}", sql, expected, actual);
+}
+
+/// The `t4a` fixture from `in4.test`: `a` has default BINARY collation,
+/// `b` is declared NOCASE.
+fn db_with_t4a() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t4a(a TEXT, b TEXT COLLATE nocase, c)");
+    run_stmt(&mut db, "INSERT INTO t4a VALUES('ABC','abc',1)");
+    run_stmt(&mut db, "INSERT INTO t4a VALUES('def','xyz',2)");
+    run_stmt(&mut db, "INSERT INTO t4a VALUES('ghi','ghi',3)");
+    db
+}
+
+// ---------------------------------------------------------------------------
+// The in4-4.* block (column vs column, concat-wrapped operands)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn in4_4_1_left_binary_column_blocks_right_nocase() {
+    // a = b: `a` IS a column, so its default BINARY collation applies with
+    // left precedence — b's NOCASE must not be used.
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE a=b ORDER BY c", &[3]);
+}
+
+#[test]
+fn in4_4_2_left_nocase_column_wins() {
+    // b = a: left column's NOCASE collation applies ('ABC' matches 'abc').
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE b=a ORDER BY c", &[1, 3]);
+}
+
+#[test]
+fn in4_4_3_concat_left_falls_through_to_right_column() {
+    // (a||'') = b: the left operand is not a column (no collation), so the
+    // right column's NOCASE applies.
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE (a||'')=b ORDER BY c", &[1, 3]);
+}
+
+#[test]
+fn in4_4_4_nocase_does_not_leak_through_concat() {
+    // (a||'') = (b||''): neither operand has a collating sequence — b's
+    // NOCASE must NOT propagate through `||` — so the comparison is BINARY.
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE (a||'')=(b||'') ORDER BY c", &[3]);
+}
+
+#[test]
+fn in4_4_5_in_single_element_uses_lhs_collation() {
+    // a IN (b): IN uses the LHS collation (BINARY for column a).
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE a IN (b) ORDER BY c", &[3]);
+}
+
+#[test]
+fn in4_4_6_concat_lhs_in_is_binary() {
+    // (a||'') IN (b): LHS has no collation -> BINARY.
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE (a||'') IN (b) ORDER BY c", &[3]);
+}
+
+// ---------------------------------------------------------------------------
+// Column vs literal (fast-path decline coverage)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nocase_column_vs_literal_matches_case_insensitively() {
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE b='XYZ' ORDER BY c", &[2]);
+    // Reversed operand order behaves the same.
+    assert_rows(&db, "SELECT c FROM t4a WHERE 'XYZ'=b ORDER BY c", &[2]);
+}
+
+#[test]
+fn binary_column_vs_literal_stays_case_sensitive() {
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE a='abc' ORDER BY c", &[]);
+    assert_rows(&db, "SELECT c FROM t4a WHERE a='ABC' ORDER BY c", &[1]);
+}
+
+#[test]
+fn nocase_column_inequality_uses_collation() {
+    // b <> 'XYZ' must exclude the nocase-equal row 2.
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE b<>'XYZ' ORDER BY c", &[1, 3]);
+}
+
+// ---------------------------------------------------------------------------
+// Explicit COLLATE and rule-2 wrappers (unary +, CAST)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn explicit_collate_on_right_beats_implicit_left() {
+    // a = (b COLLATE nocase): explicit COLLATE (rule 1) wins over the left
+    // column's implicit BINARY.
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE a=(b COLLATE nocase) ORDER BY c", &[1, 3]);
+}
+
+#[test]
+fn explicit_collate_propagates_through_concat() {
+    // (a COLLATE nocase)||'' keeps the explicit collation, so the comparison
+    // is NOCASE even though both operands are concat expressions.
+    let db = db_with_t4a();
+    assert_rows(
+        &db,
+        "SELECT c FROM t4a WHERE ((a COLLATE nocase)||'')=(b||'') ORDER BY c",
+        &[1, 3],
+    );
+}
+
+#[test]
+fn unary_plus_preserves_column_collation() {
+    // +b is still "column b" for collation purposes (datatype3 §7.1 rule 2).
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE +b=a ORDER BY c", &[1, 3]);
+}
+
+#[test]
+fn cast_preserves_column_collation() {
+    // CAST(b AS TEXT) is still "column b" for collation purposes.
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE CAST(b AS TEXT)=a ORDER BY c", &[1, 3]);
+}
+
+// ---------------------------------------------------------------------------
+// BETWEEN on a collated column (vectorized fast path must decline)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn between_on_nocase_column_applies_collation() {
+    // b BETWEEN 'XYZ' AND 'XYZ' is equivalent to b='XYZ' -> row 2 (nocase).
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE b BETWEEN 'XYZ' AND 'XYZ' ORDER BY c", &[2]);
+}


### PR DESCRIPTION
Closes #5792
Part of epic #5779

## Root cause (confirmed)

`in4-4.4` (`(a||'')=(b||'')` returning `1 3` instead of `3`) is a comparison **collation-resolution** bug with two verified defects, exactly as curated:

- **Defect A (slow path):** `get_expression_collation` recursed into *any* `BinaryOp`'s operands, so `(b||'')` inherited `b`'s NOCASE. Per SQLite (datatype3.html §7.1 / `sqlite3ExprCollSeq`), implicit column collation is carried only through unary `+` and `CAST`; only an *explicit* `COLLATE` operator propagates out of other operators/functions.
- **Defect B (fast paths):** the compiled (`evaluator/compiled.rs`), vectorized (`select/vectorized/compiled_predicate.rs`), and columnar (`select/columnar/filter/predicates.rs`) predicate paths compared raw values with no collation awareness — `b=a` returned `3` instead of `1 3`, and `b='XYZ'` returned nothing instead of `2`.

One subtlety worth noting: rule 2 has **left precedence including the default BINARY** — in `a=b`, `a` *is a column*, so its default BINARY applies and blocks `b`'s NOCASE (that is why `in4-4.1` expects `3` while `in4-4.2` expects `1 3`). The resolver models this explicitly.

## Fix

- **New shared module `crates/vibesql-executor/src/evaluator/collation.rs`** implementing the §7.1 rules: `explicit_collation_of` (explicit COLLATE anywhere in the subtree, SQLite's `EP_Collate` propagation), `resolve_expression_collation` (single-expression collation; column collation transparent only through unary `+`/`CAST`), and `comparison_collation` (explicit-left > explicit-right > left-column incl. default BINARY > right-column > BINARY). Both `ExpressionEvaluator` and `CombinedExpressionEvaluator` now delegate to it via a column-lookup callback, removing the previously duplicated logic.
- **Comparison sites** in both evaluators use the full precedence chain (an explicit `COLLATE` on the right operand now correctly beats an implicit column collation on the left, per rule 1).
- **Fast paths decline compilation for non-BINARY-collated columns** (the #5335 `literal_supported_for_column` precedent), falling back to the collation-aware evaluator: new `CombinedSchema::get_column_collation_by_index` / `column_has_non_binary_collation`, gates in `evaluator/compiled.rs` (`try_compile_comparison`), `select/vectorized/compiled_predicate.rs` (column-literal, column-column, BETWEEN), and `select/columnar/filter/predicates.rs` (comparisons, BETWEEN, ColumnCompare). Columns with no declared collation keep the fast paths — benchmark workloads are unaffected.

## Acceptance criteria (all verified against sqlite3)

| Query | Expected | Before | After |
|---|---|---|---|
| `a=b` (in4-4.1) | 3 | 3 | 3 |
| `b=a` (in4-4.2) | 1 3 | **3** | 1 3 |
| `(a\|\|'')=b` (in4-4.3) | 1 3 | 1 3 | 1 3 |
| `(a\|\|'')=(b\|\|'')` (in4-4.4) | 3 | **1 3** | 3 |
| `a IN (b)` (in4-4.5) | 3 | 3 | 3 |
| `(a\|\|'') IN (b)` (in4-4.6) | 3 | 3 | 3 |
| `b='XYZ'` | 2 | **(none)** | 2 |
| `a=(b COLLATE nocase)` | 1 3 | 1 3 | 1 3 |

## Test deltas (TCL, before -> after; run via `make test-tcl-file`)

| File | Before | After | Delta |
|---|---|---|---|
| in4.test | 60/61 passed, 1 failed (`in4-4.4`) | **61/61 passed, 0 failed** | +1 fixed |
| in.test | 114/114, 0 failed | 114/114, 0 failed | none |
| in2.test | 1999/1999, 0 failed | 1999/1999, 0 failed | none |
| in3.test | 12/18, 6 failed | 12/18, 6 failed | none (pre-existing, unrelated: in3-3.2/3.3/3.4/3.6/4.1/4.2 — index/EQP plan-shape tests) |
| in5.test | 29/29, 0 failed | 29/29, 0 failed | none |
| collate1–5, 7–9.test | all skipped (0 run) | all skipped | none |
| collate6.test | 12/15, 3 failed | 12/15, 3 failed | none (pre-existing: collate6-1.3/1.7/2.2) |

## Cargo tests

- `cargo test -p vibesql-executor --release`: **all pass** (exit 0) with the functional changes.
- New tests (all pass):
  - `evaluator/collation.rs` unit tests: resolver rules (no propagation through `||`, unary `+`/CAST transparency, left-BINARY blocking right-NOCASE, explicit-COLLATE precedence).
  - `evaluator/compiled.rs` + `select/vectorized/compiled_predicate.rs`: NOCASE columns decline compilation; BINARY-default columns still compile.
  - `tests/comparison_collation_tests.rs`: full t4a scenario end-to-end (14 tests), expectations verified against sqlite3.
- `cargo clippy -p vibesql-executor --all-targets`: no warnings in touched files (163 pre-existing crate warnings unchanged).
- `cargo fmt` applied to touched files.

## Scope notes / deferred

- **IN-list collation** (`b IN ('xyz')` should use LHS NOCASE): the slow-path `eval_in_list` is not collation-aware today, and the fast path matches it, so gating the IN-list fast paths would change nothing. Deferred with this note per the issue's scope ("scalar comparison collation only"); `in4-4.5`/`in4-4.6` pass because their LHS collations are BINARY either way.
- `in3.test` / `collate6.test` failures are pre-existing and untouched (plan-text/index-shape and custom-collation gaps); `collate1-5,7-9` are skipped entirely by the harness (require TCL custom collation registration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)