### PR TITLE
feat(sql): row-value IN-list, COLLATE in tuples, misuse errors, CASE/BETWEEN row values

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -160,8 +160,7 @@ impl CombinedExpressionEvaluator<'_> {
                 if let Some(c) = explicit_collation_of(right) {
                     return Some(c);
                 }
-                self.get_expression_collation(left)
-                    .or_else(|| self.get_expression_collation(right))
+                self.get_expression_collation(left).or_else(|| self.get_expression_collation(right))
             }
             // Unary operator: inherit from operand.
             vibesql_ast::Expression::UnaryOp { expr, .. } => self.get_expression_collation(expr),
@@ -906,7 +905,11 @@ impl CombinedExpressionEvaluator<'_> {
                                     vibesql_ast::Expression::ScalarSubquery(subquery),
                                 ) => {
                                     return self.eval_row_value_subquery_comparison(
-                                        tuple_exprs, op, subquery, true, row,
+                                        tuple_exprs,
+                                        op,
+                                        subquery,
+                                        true,
+                                        row,
                                     );
                                 }
                                 (
@@ -914,7 +917,11 @@ impl CombinedExpressionEvaluator<'_> {
                                     vibesql_ast::Expression::RowValueConstructor(tuple_exprs),
                                 ) => {
                                     return self.eval_row_value_subquery_comparison(
-                                        tuple_exprs, op, subquery, false, row,
+                                        tuple_exprs,
+                                        op,
+                                        subquery,
+                                        false,
+                                        row,
                                     );
                                 }
                                 (
@@ -925,11 +932,20 @@ impl CombinedExpressionEvaluator<'_> {
                                     // values, e.g. (SELECT a,b)==(SELECT x,y). When
                                     // both are single-column this returns None and
                                     // we fall through to scalar comparison.
-                                    if let Some(result) = self
-                                        .eval_two_subquery_row_comparison(left_sub, op, right_sub, row)?
-                                    {
+                                    if let Some(result) = self.eval_two_subquery_row_comparison(
+                                        left_sub, op, right_sub, row,
+                                    )? {
                                         return Ok(result);
                                     }
+                                }
+                                // A row value compared against anything that is
+                                // not a row value or a scalar subquery (e.g.
+                                // `(a, b) = 1`) is a misuse per SQLite.
+                                (vibesql_ast::Expression::RowValueConstructor(elems), _)
+                                | (_, vibesql_ast::Expression::RowValueConstructor(elems))
+                                    if elems.len() > 1 =>
+                                {
+                                    return Err(ExecutorError::RowValueMisused);
                                 }
                                 _ => {}
                             }
@@ -1133,13 +1149,25 @@ impl CombinedExpressionEvaluator<'_> {
             // Current date/time functions
             vibesql_ast::Expression::CurrentDate => {
                 let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
-                super::super::functions::eval_scalar_function("CURRENT_DATE", &[], &None, &sql_mode, crate::evaluator::SchemaExprContext::None)
+                super::super::functions::eval_scalar_function(
+                    "CURRENT_DATE",
+                    &[],
+                    &None,
+                    &sql_mode,
+                    crate::evaluator::SchemaExprContext::None,
+                )
             }
             vibesql_ast::Expression::CurrentTime { precision: _ } => {
                 // For now, ignore precision and call existing function
                 // Phase 2 will implement precision-aware formatting
                 let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
-                super::super::functions::eval_scalar_function("CURRENT_TIME", &[], &None, &sql_mode, crate::evaluator::SchemaExprContext::None)
+                super::super::functions::eval_scalar_function(
+                    "CURRENT_TIME",
+                    &[],
+                    &None,
+                    &sql_mode,
+                    crate::evaluator::SchemaExprContext::None,
+                )
             }
             vibesql_ast::Expression::CurrentTimestamp { precision: _ } => {
                 // For now, ignore precision and call existing function
@@ -1303,6 +1331,10 @@ impl CombinedExpressionEvaluator<'_> {
                 self.eval_raise(*action, error_message.as_deref(), row)
             }
 
+            // Row value constructor in a scalar context (bare in a SELECT list,
+            // function argument, arithmetic operand, ...) — "row value misused".
+            vibesql_ast::Expression::RowValueConstructor(_) => Err(ExecutorError::RowValueMisused),
+
             // Unsupported expressions
             _ => Err(ExecutorError::UnsupportedExpression(format!("{:?}", expr))),
         }
@@ -1324,9 +1356,9 @@ impl CombinedExpressionEvaluator<'_> {
             vibesql_ast::RaiseAction::Ignore => Err(ExecutorError::RaiseIgnore),
             _ => {
                 let message = match error_message {
-                    Some(expr) => crate::evaluator::raise::render_raise_message(
-                        self.eval(expr, row)?,
-                    ),
+                    Some(expr) => {
+                        crate::evaluator::raise::render_raise_message(self.eval(expr, row)?)
+                    }
                     None => String::new(),
                 };
                 Err(ExecutorError::Raise { action, message })
@@ -1401,20 +1433,17 @@ impl CombinedExpressionEvaluator<'_> {
     /// - (a, b) < (c, d) is true if a < c OR (a = c AND b < d)
     /// - (a, b) = (c, d) is true if a = c AND b = d
     /// - (a, b) <> (c, d) is true if a <> c OR b <> d
-    fn eval_row_value_comparison(
+    pub(in crate::evaluator) fn eval_row_value_comparison(
         &self,
         left_exprs: &[vibesql_ast::Expression],
         op: &vibesql_ast::BinaryOperator,
         right_exprs: &[vibesql_ast::Expression],
         row: &vibesql_storage::Row,
     ) -> Result<SqlValue, ExecutorError> {
-        // Row values must have the same number of elements
+        // Row values must have the same number of elements (SQLite reports a
+        // mismatched-arity comparison as "row value misused").
         if left_exprs.len() != right_exprs.len() {
-            return Err(ExecutorError::UnsupportedExpression(format!(
-                "Row value constructor size mismatch: left has {} elements, right has {}",
-                left_exprs.len(),
-                right_exprs.len()
-            )));
+            return Err(ExecutorError::RowValueMisused);
         }
 
         // Empty row values are not allowed
@@ -1424,15 +1453,24 @@ impl CombinedExpressionEvaluator<'_> {
             ));
         }
 
-        // Evaluate each element pair and apply per-column SQLite type affinity,
-        // mirroring the scalar comparison path so that mixed TEXT/NUMERIC tuples
-        // compare per SQLite rules instead of by raw storage class.
+        // Evaluate each element pair and apply per-element collation and
+        // per-column SQLite type affinity, mirroring the scalar comparison path
+        // so that mixed TEXT/NUMERIC tuples compare per SQLite rules instead of
+        // by raw storage class.
         let mut left_values = Vec::with_capacity(left_exprs.len());
         let mut right_values = Vec::with_capacity(right_exprs.len());
 
         for (left_expr, right_expr) in left_exprs.iter().zip(right_exprs.iter()) {
             let left_val = self.eval(left_expr, row)?;
             let right_val = self.eval(right_expr, row)?;
+            let collation = self
+                .get_expression_collation(left_expr)
+                .or_else(|| self.get_expression_collation(right_expr));
+            let (left_val, right_val) = crate::evaluator::row_value::apply_collation_to_pair(
+                left_val,
+                right_val,
+                collation.as_deref(),
+            );
             let (left_val, right_val) =
                 self.apply_affinity_for_comparison(left_expr, left_val, right_expr, right_val);
             left_values.push(left_val);
@@ -1531,6 +1569,14 @@ impl CombinedExpressionEvaluator<'_> {
         let mut other_values = Vec::with_capacity(arity);
         for (tuple_expr, sub_val) in tuple_exprs.iter().zip(subquery_values) {
             let tuple_val = self.eval(tuple_expr, row)?;
+            // Per-element collation from the tuple side (explicit COLLATE or
+            // column-declared collation), e.g. `(a COLLATE nocase, b) = (SELECT ...)`.
+            let collation = self.get_expression_collation(tuple_expr);
+            let (tuple_val, sub_val) = crate::evaluator::row_value::apply_collation_to_pair(
+                tuple_val,
+                sub_val,
+                collation.as_deref(),
+            );
             let synthetic = vibesql_ast::Expression::Literal(sub_val.clone());
             let (tuple_val, sub_val) =
                 self.apply_affinity_for_comparison(tuple_expr, tuple_val, &synthetic, sub_val);
@@ -1603,11 +1649,7 @@ impl CombinedExpressionEvaluator<'_> {
         row: &vibesql_storage::Row,
     ) -> Result<SqlValue, ExecutorError> {
         if left_exprs.len() != right_exprs.len() {
-            return Err(ExecutorError::UnsupportedExpression(format!(
-                "Row value constructor size mismatch: left has {} elements, right has {}",
-                left_exprs.len(),
-                right_exprs.len()
-            )));
+            return Err(ExecutorError::RowValueMisused);
         }
         if left_exprs.is_empty() {
             return Err(ExecutorError::UnsupportedExpression(
@@ -1615,21 +1657,64 @@ impl CombinedExpressionEvaluator<'_> {
             ));
         }
 
-        let mut left_values = Vec::with_capacity(left_exprs.len());
-        let mut right_values = Vec::with_capacity(right_exprs.len());
+        // Element-wise NULL-safe distinctness. Elements may themselves be row
+        // values (e.g. `(2,(2,0)) IS (2,(2,0))`), which recurse structurally.
+        let mut any_distinct = false;
         for (left_expr, right_expr) in left_exprs.iter().zip(right_exprs.iter()) {
-            let left_val = self.eval(left_expr, row)?;
-            let right_val = self.eval(right_expr, row)?;
-            let (left_val, right_val) =
-                self.apply_affinity_for_comparison(left_expr, left_val, right_expr, right_val);
-            left_values.push(left_val);
-            right_values.push(right_val);
+            if self.row_value_element_is_distinct(left_expr, right_expr, row)? {
+                any_distinct = true;
+                break;
+            }
         }
 
-        Ok(crate::evaluator::row_value::row_values_is_distinct(
-            &left_values,
-            &right_values,
-            negated,
-        ))
+        // negated == true corresponds to IS (NULL-safe equality).
+        Ok(SqlValue::Boolean(if negated { !any_distinct } else { any_distinct }))
+    }
+
+    /// NULL-safe distinctness of a single row-value element pair.
+    ///
+    /// Nested row values on both sides recurse structurally; a row value paired
+    /// with a scalar (or mismatched nested arity) is a misuse per SQLite.
+    fn row_value_element_is_distinct(
+        &self,
+        left_expr: &vibesql_ast::Expression,
+        right_expr: &vibesql_ast::Expression,
+        row: &vibesql_storage::Row,
+    ) -> Result<bool, ExecutorError> {
+        match (left_expr, right_expr) {
+            (
+                vibesql_ast::Expression::RowValueConstructor(left_elems),
+                vibesql_ast::Expression::RowValueConstructor(right_elems),
+            ) => {
+                if left_elems.len() != right_elems.len() {
+                    return Err(ExecutorError::RowValueMisused);
+                }
+                for (l, r) in left_elems.iter().zip(right_elems.iter()) {
+                    if self.row_value_element_is_distinct(l, r, row)? {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            }
+            (vibesql_ast::Expression::RowValueConstructor(_), _)
+            | (_, vibesql_ast::Expression::RowValueConstructor(_)) => {
+                Err(ExecutorError::RowValueMisused)
+            }
+            _ => {
+                let left_val = self.eval(left_expr, row)?;
+                let right_val = self.eval(right_expr, row)?;
+                let collation = self
+                    .get_expression_collation(left_expr)
+                    .or_else(|| self.get_expression_collation(right_expr));
+                let (left_val, right_val) = crate::evaluator::row_value::apply_collation_to_pair(
+                    left_val,
+                    right_val,
+                    collation.as_deref(),
+                );
+                let (left_val, right_val) =
+                    self.apply_affinity_for_comparison(left_expr, left_val, right_expr, right_val);
+                Ok(super::super::core::values_are_distinct(&left_val, &right_val))
+            }
+        }
     }
 }

--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -32,6 +32,46 @@ impl CombinedExpressionEvaluator<'_> {
     ) -> Result<vibesql_types::SqlValue, ExecutorError> {
         use vibesql_types::SqlValue;
 
+        // Handle row value constructor BETWEEN
+        // (a, b) BETWEEN (low_a, low_b) AND (high_a, high_b)
+        // is equivalent to: (a, b) >= (low_a, low_b) AND (a, b) <= (high_a, high_b)
+        if let (
+            vibesql_ast::Expression::RowValueConstructor(expr_exprs),
+            vibesql_ast::Expression::RowValueConstructor(low_exprs),
+            vibesql_ast::Expression::RowValueConstructor(high_exprs),
+        ) = (expr, low, high)
+        {
+            return self.eval_row_value_between(
+                expr_exprs, low_exprs, high_exprs, negated, symmetric, row,
+            );
+        }
+
+        // Scalar-subquery operand with row-value bounds:
+        // `(SELECT 2,2) BETWEEN (1,1) AND (3,3)` — evaluate the subquery to a
+        // row of the bounds' arity and reuse the row-value BETWEEN logic.
+        if let (
+            vibesql_ast::Expression::ScalarSubquery(subquery),
+            vibesql_ast::Expression::RowValueConstructor(low_exprs),
+            vibesql_ast::Expression::RowValueConstructor(high_exprs),
+        ) = (expr, low, high)
+        {
+            if low_exprs.len() > 1 && low_exprs.len() == high_exprs.len() {
+                let sub_values =
+                    self.eval_scalar_subquery_as_row(subquery, row, low_exprs.len())?;
+                let sub_exprs: Vec<vibesql_ast::Expression> =
+                    sub_values.into_iter().map(vibesql_ast::Expression::Literal).collect();
+                return self.eval_row_value_between(
+                    &sub_exprs, low_exprs, high_exprs, negated, symmetric, row,
+                );
+            }
+        }
+
+        // A row value mixed with scalar operands in BETWEEN is a misuse.
+        let is_multi_row_value = |e: &vibesql_ast::Expression| matches!(e, vibesql_ast::Expression::RowValueConstructor(elems) if elems.len() > 1);
+        if is_multi_row_value(expr) || is_multi_row_value(low) || is_multi_row_value(high) {
+            return Err(ExecutorError::RowValueMisused);
+        }
+
         let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
 
         // Get effective collation: explicit COLLATE or column-level collation
@@ -433,6 +473,164 @@ impl CombinedExpressionEvaluator<'_> {
         Ok(vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(result)))
     }
 
+    /// Evaluate row value BETWEEN predicate
+    ///
+    /// `(a, b) BETWEEN (low_a, low_b) AND (high_a, high_b)`
+    /// is equivalent to: `(a, b) >= (low_a, low_b) AND (a, b) <= (high_a, high_b)`
+    ///
+    /// NULL handling follows the standard row value comparison semantics.
+    fn eval_row_value_between(
+        &self,
+        expr_exprs: &[vibesql_ast::Expression],
+        low_exprs: &[vibesql_ast::Expression],
+        high_exprs: &[vibesql_ast::Expression],
+        negated: bool,
+        symmetric: bool,
+        row: &vibesql_storage::Row,
+    ) -> Result<vibesql_types::SqlValue, ExecutorError> {
+        use vibesql_types::SqlValue;
+
+        // Row values must have the same number of elements (SQLite reports a
+        // mismatched-arity BETWEEN as "row value misused").
+        if expr_exprs.len() != low_exprs.len() || expr_exprs.len() != high_exprs.len() {
+            return Err(ExecutorError::RowValueMisused);
+        }
+
+        if expr_exprs.is_empty() {
+            return Err(ExecutorError::UnsupportedExpression(
+                "Empty row value constructors are not allowed".to_string(),
+            ));
+        }
+
+        // Determine effective bounds (swap if symmetric and low > high)
+        let (effective_low, effective_high) = if symmetric {
+            let gt_op = vibesql_ast::BinaryOperator::GreaterThan;
+            let low_gt_high = self.eval_row_value_comparison(low_exprs, &gt_op, high_exprs, row)?;
+
+            if matches!(low_gt_high, SqlValue::Boolean(true)) {
+                (high_exprs, low_exprs) // Swap
+            } else {
+                (low_exprs, high_exprs)
+            }
+        } else {
+            (low_exprs, high_exprs)
+        };
+
+        if negated {
+            // NOT BETWEEN: expr < low OR expr > high
+            let lt_op = vibesql_ast::BinaryOperator::LessThan;
+            let gt_op = vibesql_ast::BinaryOperator::GreaterThan;
+
+            let lt_low = self.eval_row_value_comparison(expr_exprs, &lt_op, effective_low, row)?;
+            let gt_high =
+                self.eval_row_value_comparison(expr_exprs, &gt_op, effective_high, row)?;
+
+            // OR logic with three-valued semantics
+            match (&lt_low, &gt_high) {
+                (SqlValue::Boolean(true), _) | (_, SqlValue::Boolean(true)) => {
+                    Ok(SqlValue::Boolean(true))
+                }
+                (SqlValue::Boolean(false), SqlValue::Boolean(false)) => {
+                    Ok(SqlValue::Boolean(false))
+                }
+                _ => Ok(SqlValue::Null),
+            }
+        } else {
+            // BETWEEN: expr >= low AND expr <= high
+            let ge_op = vibesql_ast::BinaryOperator::GreaterThanOrEqual;
+            let le_op = vibesql_ast::BinaryOperator::LessThanOrEqual;
+
+            let ge_low = self.eval_row_value_comparison(expr_exprs, &ge_op, effective_low, row)?;
+            let le_high =
+                self.eval_row_value_comparison(expr_exprs, &le_op, effective_high, row)?;
+
+            // AND logic with three-valued semantics
+            match (&ge_low, &le_high) {
+                (SqlValue::Boolean(true), SqlValue::Boolean(true)) => Ok(SqlValue::Boolean(true)),
+                (SqlValue::Boolean(false), _) | (_, SqlValue::Boolean(false)) => {
+                    Ok(SqlValue::Boolean(false))
+                }
+                _ => Ok(SqlValue::Null),
+            }
+        }
+    }
+
+    /// Evaluate a row-value IN list: `(a, b) IN ((1, 2), (3, 4))` and NOT IN.
+    ///
+    /// See the single-table `ExpressionEvaluator::eval_row_value_in_list` for the
+    /// three-valued semantics; this is the multi-table mirror.
+    fn eval_row_value_in_list(
+        &self,
+        elem_exprs: &[vibesql_ast::Expression],
+        values: &[vibesql_ast::Expression],
+        negated: bool,
+        row: &vibesql_storage::Row,
+    ) -> Result<vibesql_types::SqlValue, ExecutorError> {
+        use vibesql_types::SqlValue;
+
+        if values.is_empty() {
+            return Ok(SqlValue::Boolean(negated));
+        }
+
+        let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
+        let arity = elem_exprs.len();
+
+        // Evaluate the left-hand tuple once.
+        let mut left_vals = Vec::with_capacity(arity);
+        for elem in elem_exprs {
+            left_vals.push(self.eval(elem, row)?);
+        }
+
+        let mut found_unknown = false;
+        for candidate in values {
+            let cand_exprs = match candidate {
+                vibesql_ast::Expression::RowValueConstructor(cand) => cand,
+                _ => return Err(ExecutorError::RowValueMisused),
+            };
+            if cand_exprs.len() != arity {
+                return Err(ExecutorError::RowValueMisused);
+            }
+
+            // Per-element collation and affinity, mirroring row-value `=`.
+            let mut l_vals = Vec::with_capacity(arity);
+            let mut r_vals = Vec::with_capacity(arity);
+            for ((l_expr, l_val), r_expr) in
+                elem_exprs.iter().zip(left_vals.iter()).zip(cand_exprs.iter())
+            {
+                let r_val = self.eval(r_expr, row)?;
+                let collation = self
+                    .get_expression_collation(l_expr)
+                    .or_else(|| self.get_expression_collation(r_expr));
+                let (l_val, r_val) = crate::evaluator::row_value::apply_collation_to_pair(
+                    l_val.clone(),
+                    r_val,
+                    collation.as_deref(),
+                );
+                let (l_val, r_val) =
+                    self.apply_affinity_for_comparison(l_expr, l_val, r_expr, r_val);
+                l_vals.push(l_val);
+                r_vals.push(r_val);
+            }
+
+            match crate::evaluator::row_value::compare_row_values(
+                &l_vals,
+                &vibesql_ast::BinaryOperator::Equal,
+                &r_vals,
+                |l, o, r| ExpressionEvaluator::eval_binary_op_static(l, o, r, sql_mode.clone()),
+            )? {
+                SqlValue::Boolean(true) => return Ok(SqlValue::Boolean(!negated)),
+                SqlValue::Null => found_unknown = true,
+                _ => {}
+            }
+        }
+
+        if found_unknown {
+            Ok(SqlValue::Null)
+        } else {
+            Ok(SqlValue::Boolean(negated))
+        }
+    }
+
     /// Evaluate IN operator with value list: expr IN (val1, val2, ...)
     /// SQL:1999 Section 8.4: IN predicate
     /// Returns TRUE if expr equals any value in the list
@@ -450,6 +648,13 @@ impl CombinedExpressionEvaluator<'_> {
         negated: bool,
         row: &vibesql_storage::Row,
     ) -> Result<vibesql_types::SqlValue, ExecutorError> {
+        // Row-value IN list: `(a, b) IN ((1, 2), (3, 4))`
+        if let vibesql_ast::Expression::RowValueConstructor(elem_exprs) = expr {
+            if elem_exprs.len() > 1 {
+                return self.eval_row_value_in_list(elem_exprs, values, negated, row);
+            }
+        }
+
         // Empty set optimization (SQLite behavior):
         // If the list is empty, return FALSE for IN, TRUE for NOT IN
         // This is true regardless of whether the left expression is NULL
@@ -611,6 +816,14 @@ impl CombinedExpressionEvaluator<'_> {
                     negated,
                     row,
                 );
+            }
+            // Row value IS'd against something that is neither a row value nor
+            // a scalar subquery (e.g. `(a, a) IS 1`) is a misuse per SQLite.
+            (vibesql_ast::Expression::RowValueConstructor(elems), _)
+            | (_, vibesql_ast::Expression::RowValueConstructor(elems))
+                if elems.len() > 1 =>
+            {
+                return Err(ExecutorError::RowValueMisused);
             }
             _ => {}
         }

--- a/crates/vibesql-executor/src/evaluator/combined/special.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/special.rs
@@ -19,6 +19,43 @@ impl CombinedExpressionEvaluator<'_> {
         match operand {
             // Simple CASE: CASE operand WHEN value THEN result ...
             Some(operand_expr) => {
+                // Row-value operand or WHEN values (e.g.
+                // `CASE (2,2) WHEN (1,1) THEN ... END`): compare with row-value
+                // equality by delegating to the binary `=` dispatch, which
+                // handles tuple-vs-tuple and tuple-vs-subquery forms.
+                let row_value_case = matches!(
+                    operand_expr.as_ref(),
+                    vibesql_ast::Expression::RowValueConstructor(elems) if elems.len() > 1
+                ) || when_clauses.iter().any(|wc| {
+                    wc.conditions.iter().any(|c| {
+                        matches!(
+                            c,
+                            vibesql_ast::Expression::RowValueConstructor(elems) if elems.len() > 1
+                        )
+                    })
+                });
+                if row_value_case {
+                    for when_clause in when_clauses {
+                        for condition_expr in &when_clause.conditions {
+                            let eq_expr = vibesql_ast::Expression::BinaryOp {
+                                left: operand_expr.clone(),
+                                op: vibesql_ast::BinaryOperator::Equal,
+                                right: Box::new(condition_expr.clone()),
+                            };
+                            if matches!(
+                                self.eval(&eq_expr, row)?,
+                                vibesql_types::SqlValue::Boolean(true)
+                            ) {
+                                return self.eval(&when_clause.result, row);
+                            }
+                        }
+                    }
+                    return match else_result {
+                        Some(else_expr) => self.eval(else_expr, row),
+                        None => Ok(vibesql_types::SqlValue::Null),
+                    };
+                }
+
                 let operand_value = self.eval(operand_expr, row)?;
 
                 // Iterate through WHEN clauses

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/in_subquery.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/in_subquery.rs
@@ -126,6 +126,31 @@ impl CombinedExpressionEvaluator<'_> {
             );
         }
 
+        // Multi-column scalar subquery on the LHS of IN:
+        // `(SELECT a, b) IN (SELECT x, y FROM t)` — evaluate the LHS subquery
+        // to a row and reuse the row-value IN path.
+        if let vibesql_ast::Expression::ScalarSubquery(left_sub) = expr {
+            if !crate::evaluator::row_value::subquery_is_obviously_single_column(left_sub) {
+                let arity = super::schema_utils::compute_select_list_column_count(
+                    left_sub,
+                    database,
+                    self.cte_context,
+                )?;
+                if arity > 1 {
+                    let left_values = self.eval_scalar_subquery_as_row(left_sub, row, arity)?;
+                    let elem_exprs: Vec<vibesql_ast::Expression> =
+                        left_values.into_iter().map(vibesql_ast::Expression::Literal).collect();
+                    return self.eval_row_value_in_subquery(
+                        &elem_exprs,
+                        subquery,
+                        negated,
+                        row,
+                        database,
+                    );
+                }
+            }
+        }
+
         // Evaluate the left-hand expression
         let expr_val = self.eval(expr, row)?;
 

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs
@@ -118,6 +118,14 @@ pub fn compute_select_list_column_count(
     database: &vibesql_storage::Database,
     cte_results: Option<&HashMap<String, CteResult>>,
 ) -> Result<usize, ExecutorError> {
+    // VALUES statements (e.g. `IN (VALUES(1, 2))`) carry no select list; the
+    // column count is the arity of the value rows.
+    if let Some(values) = &stmt.values {
+        if stmt.select_list.is_empty() {
+            return Ok(values.first().map_or(0, |row| row.len()));
+        }
+    }
+
     let left_count =
         compute_single_select_column_count(&stmt.select_list, &stmt.from, database, cte_results)?;
 

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -131,8 +131,7 @@ impl ExpressionEvaluator<'_> {
                 if let Some(c) = explicit_collation_of(right) {
                     return Some(c);
                 }
-                self.get_expression_collation(left)
-                    .or_else(|| self.get_expression_collation(right))
+                self.get_expression_collation(left).or_else(|| self.get_expression_collation(right))
             }
             // Unary operator: inherit from operand.
             vibesql_ast::Expression::UnaryOp { expr, .. } => self.get_expression_collation(expr),
@@ -611,6 +610,16 @@ impl ExpressionEvaluator<'_> {
                                         return Ok(result);
                                     }
                                 }
+                                // A row value compared against anything that is
+                                // not a row value or a scalar subquery (e.g.
+                                // `(a, b) = 1` or `(a, b) = (SELECT ...) COLLATE x`)
+                                // is a misuse per SQLite.
+                                (vibesql_ast::Expression::RowValueConstructor(elems), _)
+                                | (_, vibesql_ast::Expression::RowValueConstructor(elems))
+                                    if elems.len() > 1 =>
+                                {
+                                    return Err(ExecutorError::RowValueMisused);
+                                }
                                 _ => {}
                             }
                         }
@@ -824,6 +833,15 @@ impl ExpressionEvaluator<'_> {
                             tuple_exprs, subquery, *negated, row,
                         );
                     }
+                    // Row value IS'd against something that is neither a row
+                    // value nor a scalar subquery (e.g. `(a, a) IS 1`) is a
+                    // misuse per SQLite.
+                    (vibesql_ast::Expression::RowValueConstructor(elems), _)
+                    | (_, vibesql_ast::Expression::RowValueConstructor(elems))
+                        if elems.len() > 1 =>
+                    {
+                        return Err(ExecutorError::RowValueMisused);
+                    }
                     _ => {}
                 }
 
@@ -1036,12 +1054,12 @@ impl ExpressionEvaluator<'_> {
                 Ok(result)
             }
 
-            // Row value constructor - evaluate to a vector of values
-            // This is only reached when a row value appears outside a comparison context
-            // (e.g., in SELECT list which is not supported)
-            vibesql_ast::Expression::RowValueConstructor(_) => Err(ExecutorError::UnsupportedExpression(
-                "Row value constructors are only supported in comparison expressions".to_string(),
-            )),
+            // Row value constructor - only reached when a row value appears in a
+            // scalar context (e.g. bare in a SELECT list, function argument,
+            // arithmetic operand). SQLite reports this as "row value misused".
+            vibesql_ast::Expression::RowValueConstructor(_) => {
+                Err(ExecutorError::RowValueMisused)
+            }
 
             // COLLATE expression - evaluate inner expression (collation affects string comparison)
             // TODO: Full collation support - for now just evaluate the inner expression
@@ -1391,13 +1409,10 @@ impl ExpressionEvaluator<'_> {
         right_exprs: &[vibesql_ast::Expression],
         row: &vibesql_storage::Row,
     ) -> Result<SqlValue, ExecutorError> {
-        // Row values must have the same number of elements
+        // Row values must have the same number of elements (SQLite reports a
+        // mismatched-arity comparison as "row value misused").
         if left_exprs.len() != right_exprs.len() {
-            return Err(ExecutorError::UnsupportedExpression(format!(
-                "Row value constructor size mismatch: left has {} elements, right has {}",
-                left_exprs.len(),
-                right_exprs.len()
-            )));
+            return Err(ExecutorError::RowValueMisused);
         }
 
         // Empty row values are not allowed
@@ -1417,6 +1432,17 @@ impl ExpressionEvaluator<'_> {
         for (left_expr, right_expr) in left_exprs.iter().zip(right_exprs.iter()) {
             let left_val = self.eval(left_expr, row)?;
             let right_val = self.eval(right_expr, row)?;
+            // Per-element collation, mirroring the scalar comparison path:
+            // explicit COLLATE or column-declared collation on either element
+            // (left side takes priority) applies to that element pair only.
+            let collation = self
+                .get_expression_collation(left_expr)
+                .or_else(|| self.get_expression_collation(right_expr));
+            let (left_val, right_val) = crate::evaluator::row_value::apply_collation_to_pair(
+                left_val,
+                right_val,
+                collation.as_deref(),
+            );
             let (left_val, right_val) =
                 self.apply_affinity_for_comparison(left_expr, left_val, right_expr, right_val);
             left_values.push(left_val);
@@ -1513,6 +1539,14 @@ impl ExpressionEvaluator<'_> {
         let mut other_values = Vec::with_capacity(arity);
         for (tuple_expr, sub_val) in tuple_exprs.iter().zip(subquery_values) {
             let tuple_val = self.eval(tuple_expr, row)?;
+            // Per-element collation from the tuple side (explicit COLLATE or
+            // column-declared collation), e.g. `(a COLLATE nocase, b) = (SELECT ...)`.
+            let collation = self.get_expression_collation(tuple_expr);
+            let (tuple_val, sub_val) = crate::evaluator::row_value::apply_collation_to_pair(
+                tuple_val,
+                sub_val,
+                collation.as_deref(),
+            );
             // Treat the subquery result column as a non-column value so the same
             // affinity rules used for `tuple_col <op> <computed value>` apply.
             let synthetic = vibesql_ast::Expression::Literal(sub_val.clone());
@@ -1596,13 +1630,10 @@ impl ExpressionEvaluator<'_> {
         negated: bool,
         row: &vibesql_storage::Row,
     ) -> Result<SqlValue, ExecutorError> {
-        // Row values must have the same number of elements
+        // Row values must have the same number of elements (SQLite reports a
+        // mismatched-arity comparison as "row value misused").
         if left_exprs.len() != right_exprs.len() {
-            return Err(ExecutorError::UnsupportedExpression(format!(
-                "Row value constructor size mismatch: left has {} elements, right has {}",
-                left_exprs.len(),
-                right_exprs.len()
-            )));
+            return Err(ExecutorError::RowValueMisused);
         }
 
         // Empty row values are not allowed
@@ -1612,22 +1643,64 @@ impl ExpressionEvaluator<'_> {
             ));
         }
 
-        // Evaluate all elements with per-column affinity, then compare NULL-safely.
-        let mut left_values = Vec::with_capacity(left_exprs.len());
-        let mut right_values = Vec::with_capacity(right_exprs.len());
+        // Element-wise NULL-safe distinctness. Elements may themselves be row
+        // values (e.g. `(2,(2,0)) IS (2,(2,0))`), which recurse structurally.
+        let mut any_distinct = false;
         for (left_expr, right_expr) in left_exprs.iter().zip(right_exprs.iter()) {
-            let left_val = self.eval(left_expr, row)?;
-            let right_val = self.eval(right_expr, row)?;
-            let (left_val, right_val) =
-                self.apply_affinity_for_comparison(left_expr, left_val, right_expr, right_val);
-            left_values.push(left_val);
-            right_values.push(right_val);
+            if self.row_value_element_is_distinct(left_expr, right_expr, row)? {
+                any_distinct = true;
+                break;
+            }
         }
 
-        Ok(crate::evaluator::row_value::row_values_is_distinct(
-            &left_values,
-            &right_values,
-            negated,
-        ))
+        // negated == true corresponds to IS (NULL-safe equality).
+        Ok(SqlValue::Boolean(if negated { !any_distinct } else { any_distinct }))
+    }
+
+    /// NULL-safe distinctness of a single row-value element pair.
+    ///
+    /// Nested row values on both sides recurse structurally; a row value paired
+    /// with a scalar (or mismatched nested arity) is a misuse per SQLite.
+    fn row_value_element_is_distinct(
+        &self,
+        left_expr: &vibesql_ast::Expression,
+        right_expr: &vibesql_ast::Expression,
+        row: &vibesql_storage::Row,
+    ) -> Result<bool, ExecutorError> {
+        match (left_expr, right_expr) {
+            (
+                vibesql_ast::Expression::RowValueConstructor(left_elems),
+                vibesql_ast::Expression::RowValueConstructor(right_elems),
+            ) => {
+                if left_elems.len() != right_elems.len() {
+                    return Err(ExecutorError::RowValueMisused);
+                }
+                for (l, r) in left_elems.iter().zip(right_elems.iter()) {
+                    if self.row_value_element_is_distinct(l, r, row)? {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            }
+            (vibesql_ast::Expression::RowValueConstructor(_), _)
+            | (_, vibesql_ast::Expression::RowValueConstructor(_)) => {
+                Err(ExecutorError::RowValueMisused)
+            }
+            _ => {
+                let left_val = self.eval(left_expr, row)?;
+                let right_val = self.eval(right_expr, row)?;
+                let collation = self
+                    .get_expression_collation(left_expr)
+                    .or_else(|| self.get_expression_collation(right_expr));
+                let (left_val, right_val) = crate::evaluator::row_value::apply_collation_to_pair(
+                    left_val,
+                    right_val,
+                    collation.as_deref(),
+                );
+                let (left_val, right_val) =
+                    self.apply_affinity_for_comparison(left_expr, left_val, right_expr, right_val);
+                Ok(super::super::core::values_are_distinct(&left_val, &right_val))
+            }
+        }
     }
 }

--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -48,6 +48,33 @@ impl ExpressionEvaluator<'_> {
             );
         }
 
+        // Scalar-subquery operand with row-value bounds:
+        // `(SELECT 2,2) BETWEEN (1,1) AND (3,3)` — evaluate the subquery to a
+        // row of the bounds' arity and reuse the row-value BETWEEN logic.
+        if let (
+            vibesql_ast::Expression::ScalarSubquery(subquery),
+            vibesql_ast::Expression::RowValueConstructor(low_exprs),
+            vibesql_ast::Expression::RowValueConstructor(high_exprs),
+        ) = (expr, low, high)
+        {
+            if low_exprs.len() > 1 && low_exprs.len() == high_exprs.len() {
+                let sub_values =
+                    self.eval_scalar_subquery_as_row(subquery, row, low_exprs.len())?;
+                let sub_exprs: Vec<vibesql_ast::Expression> =
+                    sub_values.into_iter().map(vibesql_ast::Expression::Literal).collect();
+                return self.eval_row_value_between(
+                    &sub_exprs, low_exprs, high_exprs, negated, symmetric, row,
+                );
+            }
+        }
+
+        // A row value mixed with scalar operands in BETWEEN (e.g.
+        // `(1,2) BETWEEN 1 AND 2` or `1 BETWEEN (1,2) AND 2`) is a misuse.
+        let is_multi_row_value = |e: &vibesql_ast::Expression| matches!(e, vibesql_ast::Expression::RowValueConstructor(elems) if elems.len() > 1);
+        if is_multi_row_value(expr) || is_multi_row_value(low) || is_multi_row_value(high) {
+            return Err(ExecutorError::RowValueMisused);
+        }
+
         let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
 
         // Get effective collation: explicit COLLATE or column-level collation
@@ -644,6 +671,13 @@ impl ExpressionEvaluator<'_> {
         negated: bool,
         row: &vibesql_storage::Row,
     ) -> Result<vibesql_types::SqlValue, ExecutorError> {
+        // Row-value IN list: `(a, b) IN ((1, 2), (3, 4))`
+        if let vibesql_ast::Expression::RowValueConstructor(elem_exprs) = expr {
+            if elem_exprs.len() > 1 {
+                return self.eval_row_value_in_list(elem_exprs, values, negated, row);
+            }
+        }
+
         // Handle empty IN list: returns false for IN, true for NOT IN
         // This is per SQLite behavior (SQL:1999 extension, not standard SQL)
         if values.is_empty() {
@@ -744,6 +778,89 @@ impl ExpressionEvaluator<'_> {
         }
     }
 
+    /// Evaluate a row-value IN list: `(a, b) IN ((1, 2), (3, 4))` and NOT IN.
+    ///
+    /// SQLite three-valued semantics (mirroring the scalar IN):
+    /// - TRUE (or FALSE for NOT IN) as soon as one candidate tuple compares
+    ///   fully equal;
+    /// - if no candidate matches but at least one candidate comparison was
+    ///   UNKNOWN (a NULL element with all non-NULL elements equal), the result
+    ///   is NULL;
+    /// - otherwise FALSE (TRUE for NOT IN).
+    ///
+    /// Each candidate must itself be a row value of the same arity; anything
+    /// else is a misuse per SQLite ("row value misused").
+    fn eval_row_value_in_list(
+        &self,
+        elem_exprs: &[vibesql_ast::Expression],
+        values: &[vibesql_ast::Expression],
+        negated: bool,
+        row: &vibesql_storage::Row,
+    ) -> Result<vibesql_types::SqlValue, ExecutorError> {
+        use vibesql_types::SqlValue;
+
+        if values.is_empty() {
+            return Ok(SqlValue::Boolean(negated));
+        }
+
+        let arity = elem_exprs.len();
+
+        // Evaluate the left-hand tuple once.
+        let mut left_vals = Vec::with_capacity(arity);
+        for elem in elem_exprs {
+            left_vals.push(self.eval(elem, row)?);
+        }
+
+        let mut found_unknown = false;
+        for candidate in values {
+            let cand_exprs = match candidate {
+                vibesql_ast::Expression::RowValueConstructor(cand) => cand,
+                _ => return Err(ExecutorError::RowValueMisused),
+            };
+            if cand_exprs.len() != arity {
+                return Err(ExecutorError::RowValueMisused);
+            }
+
+            // Per-element collation and affinity, mirroring row-value `=`.
+            let mut l_vals = Vec::with_capacity(arity);
+            let mut r_vals = Vec::with_capacity(arity);
+            for ((l_expr, l_val), r_expr) in
+                elem_exprs.iter().zip(left_vals.iter()).zip(cand_exprs.iter())
+            {
+                let r_val = self.eval(r_expr, row)?;
+                let collation = self
+                    .get_expression_collation(l_expr)
+                    .or_else(|| self.get_expression_collation(r_expr));
+                let (l_val, r_val) = crate::evaluator::row_value::apply_collation_to_pair(
+                    l_val.clone(),
+                    r_val,
+                    collation.as_deref(),
+                );
+                let (l_val, r_val) =
+                    self.apply_affinity_for_comparison(l_expr, l_val, r_expr, r_val);
+                l_vals.push(l_val);
+                r_vals.push(r_val);
+            }
+
+            match crate::evaluator::row_value::compare_row_values(
+                &l_vals,
+                &vibesql_ast::BinaryOperator::Equal,
+                &r_vals,
+                |l, o, r| self.eval_binary_op(l, o, r),
+            )? {
+                SqlValue::Boolean(true) => return Ok(SqlValue::Boolean(!negated)),
+                SqlValue::Null => found_unknown = true,
+                _ => {}
+            }
+        }
+
+        if found_unknown {
+            Ok(SqlValue::Null)
+        } else {
+            Ok(SqlValue::Boolean(negated))
+        }
+    }
+
     /// Evaluate row value BETWEEN predicate
     ///
     /// `(a, b) BETWEEN (low_a, low_b) AND (high_a, high_b)`
@@ -761,14 +878,10 @@ impl ExpressionEvaluator<'_> {
     ) -> Result<vibesql_types::SqlValue, ExecutorError> {
         use vibesql_types::SqlValue;
 
-        // Row values must have the same number of elements
+        // Row values must have the same number of elements (SQLite reports a
+        // mismatched-arity BETWEEN as "row value misused").
         if expr_exprs.len() != low_exprs.len() || expr_exprs.len() != high_exprs.len() {
-            return Err(ExecutorError::UnsupportedExpression(format!(
-                "Row value constructor size mismatch in BETWEEN: expr has {} elements, low has {}, high has {}",
-                expr_exprs.len(),
-                low_exprs.len(),
-                high_exprs.len()
-            )));
+            return Err(ExecutorError::RowValueMisused);
         }
 
         if expr_exprs.is_empty() {

--- a/crates/vibesql-executor/src/evaluator/expressions/special.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/special.rs
@@ -15,6 +15,43 @@ impl ExpressionEvaluator<'_> {
         match operand {
             // Simple CASE: CASE operand WHEN value THEN result ...
             Some(operand_expr) => {
+                // Row-value operand or WHEN values (e.g.
+                // `CASE (2,2) WHEN (1,1) THEN ... END`): compare with row-value
+                // equality by delegating to the binary `=` dispatch, which
+                // handles tuple-vs-tuple and tuple-vs-subquery forms.
+                let row_value_case = matches!(
+                    operand_expr.as_ref(),
+                    vibesql_ast::Expression::RowValueConstructor(elems) if elems.len() > 1
+                ) || when_clauses.iter().any(|wc| {
+                    wc.conditions.iter().any(|c| {
+                        matches!(
+                            c,
+                            vibesql_ast::Expression::RowValueConstructor(elems) if elems.len() > 1
+                        )
+                    })
+                });
+                if row_value_case {
+                    for when_clause in when_clauses {
+                        for condition_expr in &when_clause.conditions {
+                            let eq_expr = vibesql_ast::Expression::BinaryOp {
+                                left: operand_expr.clone(),
+                                op: vibesql_ast::BinaryOperator::Equal,
+                                right: Box::new(condition_expr.clone()),
+                            };
+                            if matches!(
+                                self.eval(&eq_expr, row)?,
+                                vibesql_types::SqlValue::Boolean(true)
+                            ) {
+                                return self.eval(&when_clause.result, row);
+                            }
+                        }
+                    }
+                    return match else_result {
+                        Some(else_expr) => self.eval(else_expr, row),
+                        None => Ok(vibesql_types::SqlValue::Null),
+                    };
+                }
+
                 let operand_value = self.eval(operand_expr, row)?;
 
                 for when_clause in when_clauses {

--- a/crates/vibesql-executor/src/evaluator/expressions/subqueries.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/subqueries.rs
@@ -46,6 +46,31 @@ impl ExpressionEvaluator<'_> {
             );
         }
 
+        // Multi-column scalar subquery on the LHS of IN:
+        // `(SELECT a, b) IN (SELECT x, y FROM t)` — evaluate the LHS subquery
+        // to a row and reuse the row-value IN path.
+        if let vibesql_ast::Expression::ScalarSubquery(left_sub) = expr {
+            if !crate::evaluator::row_value::subquery_is_obviously_single_column(left_sub) {
+                let arity = crate::evaluator::combined::subqueries::schema_utils::compute_select_list_column_count(
+                    left_sub,
+                    database,
+                    self.cte_context,
+                )?;
+                if arity > 1 {
+                    let left_values = self.eval_scalar_subquery_as_row(left_sub, row, arity)?;
+                    let elem_exprs: Vec<vibesql_ast::Expression> =
+                        left_values.into_iter().map(vibesql_ast::Expression::Literal).collect();
+                    return self.eval_row_value_in_subquery(
+                        &elem_exprs,
+                        subquery,
+                        negated,
+                        row,
+                        database,
+                    );
+                }
+            }
+        }
+
         let expr_val = self.eval(expr, row)?;
 
         // Convert TableSchema to CombinedSchema for outer context
@@ -297,7 +322,8 @@ impl ExpressionEvaluator<'_> {
         // through to the unchanged cached/correlated paths below.
         if let Some(trigger_ctx) = self.trigger_context {
             let substituted = substitute_trigger_pseudo_vars(subquery, trigger_ctx)?;
-            let select_executor = crate::select::SelectExecutor::new_with_depth(database, self.depth);
+            let select_executor =
+                crate::select::SelectExecutor::new_with_depth(database, self.depth);
             let rows = select_executor.execute(&substituted)?;
             return Ok(rows);
         }

--- a/crates/vibesql-executor/src/evaluator/row_value.rs
+++ b/crates/vibesql-executor/src/evaluator/row_value.rs
@@ -27,6 +27,42 @@ use vibesql_types::SqlValue;
 
 use crate::errors::ExecutorError;
 
+/// Apply a collation transformation to both sides of a single element
+/// comparison inside a row-value, mirroring the scalar comparison path:
+/// NOCASE uppercases string values, RTRIM trims trailing whitespace, any other
+/// collation (BINARY, ...) leaves values unchanged.
+pub(crate) fn apply_collation_to_pair(
+    left: SqlValue,
+    right: SqlValue,
+    collation: Option<&str>,
+) -> (SqlValue, SqlValue) {
+    let Some(collation_name) = collation else {
+        return (left, right);
+    };
+
+    fn transform(val: SqlValue, collation_name: &str) -> SqlValue {
+        if collation_name.eq_ignore_ascii_case("nocase") {
+            match val {
+                SqlValue::Varchar(s) => SqlValue::Varchar(arcstr::ArcStr::from(s.to_uppercase())),
+                SqlValue::Character(s) => {
+                    SqlValue::Character(arcstr::ArcStr::from(s.to_uppercase()))
+                }
+                other => other,
+            }
+        } else if collation_name.eq_ignore_ascii_case("rtrim") {
+            match val {
+                SqlValue::Varchar(s) => SqlValue::Varchar(arcstr::ArcStr::from(s.trim_end())),
+                SqlValue::Character(s) => SqlValue::Character(arcstr::ArcStr::from(s.trim_end())),
+                other => other,
+            }
+        } else {
+            val
+        }
+    }
+
+    (transform(left, collation_name), transform(right, collation_name))
+}
+
 /// Compare two already-evaluated row values with a comparison operator.
 ///
 /// `eval_op` performs the scalar comparison for a single element pair and must

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
@@ -12,8 +12,9 @@ use super::join_helpers::{
     build_combined_schema, expression_has_is_null, extract_equijoin_conditions,
     extract_join_conditions, extract_non_join_predicates, flatten_join_tree_simple,
     flatten_join_tree_with_types, has_cross_join_with_on_condition, has_outer_join,
-    is_columnar_supported_join, is_column_in_table, is_column_in_tables,
-    join_tree_has_residual_on_conjuncts, resolve_join_column_indices, EquiJoinCondition,
+    is_column_in_table, is_column_in_tables, is_columnar_supported_join,
+    join_tree_has_residual_on_conjuncts, resolve_join_column_indices, where_clause_fully_covered,
+    EquiJoinCondition,
 };
 use crate::{
     errors::ExecutorError,
@@ -21,7 +22,10 @@ use crate::{
     optimizer::optimize_expression,
     schema::CombinedSchema,
     select::{
-        columnar, cte::CteResult, executor::builder::SelectExecutor, helpers::apply_distinct,
+        columnar,
+        cte::CteResult,
+        executor::builder::SelectExecutor,
+        helpers::apply_distinct,
         join::hash_join::columnar as columnar_join,
         order::{apply_order_by, RowWithSortKeys},
         projection::project_row_combined,
@@ -297,18 +301,22 @@ impl SelectExecutor<'_> {
         let combined_schema = build_combined_schema(&batches);
 
         // Execute joins in sequence, building up the result batch
-        let joined_batch =
-            match self.execute_columnar_join_chain(&batches, &join_conditions, &combined_schema, &join_types) {
-                Ok(Some(batch)) => batch,
-                Ok(None) => {
-                    log::debug!("Columnar join: join chain execution returned None");
-                    return Ok(None);
-                }
-                Err(e) => {
-                    log::debug!("Columnar join: join chain execution failed: {:?}", e);
-                    return Ok(None);
-                }
-            };
+        let joined_batch = match self.execute_columnar_join_chain(
+            &batches,
+            &join_conditions,
+            &combined_schema,
+            &join_types,
+        ) {
+            Ok(Some(batch)) => batch,
+            Ok(None) => {
+                log::debug!("Columnar join: join chain execution returned None");
+                return Ok(None);
+            }
+            Err(e) => {
+                log::debug!("Columnar join: join chain execution failed: {:?}", e);
+                return Ok(None);
+            }
+        };
 
         // Apply remaining WHERE predicates (non-join conditions) using SIMD filtering
         // First, constant-fold the WHERE clause to handle expressions like `BETWEEN 1 AND 1+2`
@@ -337,11 +345,33 @@ impl SelectExecutor<'_> {
                 );
                 return Ok(None);
             }
+
+            // Verify every WHERE conjunct is fully consumed by the columnar
+            // pipeline (as a hash-join key or an extractable column predicate).
+            // Otherwise the unhandled conjunct would be silently dropped —
+            // e.g. `(x == a) AND (+zY == iB)` used to lose the unary-plus
+            // comparison entirely. Fall back to row-oriented execution.
+            if !where_clause_fully_covered(
+                where_expr,
+                &combined_schema,
+                self.database.case_sensitive_like(),
+            ) {
+                log::debug!(
+                    "Columnar join: WHERE clause has conjuncts the columnar path cannot consume, falling back"
+                );
+                return Ok(None);
+            }
         }
 
         let predicates = folded_where
             .as_ref()
-            .and_then(|where_expr| extract_non_join_predicates(where_expr, &combined_schema, self.database.case_sensitive_like()))
+            .and_then(|where_expr| {
+                extract_non_join_predicates(
+                    where_expr,
+                    &combined_schema,
+                    self.database.case_sensitive_like(),
+                )
+            })
             .unwrap_or_default();
 
         let filtered_batch = if predicates.is_empty() {
@@ -358,12 +388,18 @@ impl SelectExecutor<'_> {
 
         if has_group_by {
             // Execute GROUP BY aggregation
-            let result = self.execute_columnar_join_group_by(stmt, &filtered_batch, &combined_schema);
+            let result =
+                self.execute_columnar_join_group_by(stmt, &filtered_batch, &combined_schema);
 
             // Apply ORDER BY to GROUP BY results if needed (#5033)
             if let Ok(Some(rows)) = result {
                 if let Some(order_by) = &stmt.order_by {
-                    let sorted = self.apply_columnar_join_order_by(rows, order_by, &stmt.select_list, &combined_schema)?;
+                    let sorted = self.apply_columnar_join_order_by(
+                        rows,
+                        order_by,
+                        &stmt.select_list,
+                        &combined_schema,
+                    )?;
                     Ok(Some(sorted))
                 } else {
                     Ok(Some(rows))
@@ -405,7 +441,12 @@ impl SelectExecutor<'_> {
 
                 // Apply ORDER BY if present (#5033)
                 let final_rows = if let Some(order_by) = &stmt.order_by {
-                    self.apply_columnar_join_order_by(rows, order_by, &stmt.select_list, &combined_schema)?
+                    self.apply_columnar_join_order_by(
+                        rows,
+                        order_by,
+                        &stmt.select_list,
+                        &combined_schema,
+                    )?
                 } else {
                     rows
                 };
@@ -448,7 +489,12 @@ impl SelectExecutor<'_> {
                 // bounds" errors when ORDER BY referenced columns dropped by the
                 // projection.
                 let sorted_rows = if let Some(order_by) = &stmt.order_by {
-                    self.apply_columnar_join_order_by(rows, order_by, &stmt.select_list, &combined_schema)?
+                    self.apply_columnar_join_order_by(
+                        rows,
+                        order_by,
+                        &stmt.select_list,
+                        &combined_schema,
+                    )?
                 } else {
                     rows
                 };
@@ -511,10 +557,7 @@ impl SelectExecutor<'_> {
             let table_ref = alias.as_deref().unwrap_or(table_name.as_str());
 
             // Get the join type for this table (default to Inner for backward compatibility)
-            let jt = join_types
-                .get(i)
-                .and_then(|jt| jt.clone())
-                .unwrap_or(JoinType::Inner);
+            let jt = join_types.get(i).and_then(|jt| jt.clone()).unwrap_or(JoinType::Inner);
 
             // Find a join condition that connects this table to already-joined tables
             let join_cond = join_conditions.iter().find(|cond| {
@@ -589,30 +632,24 @@ impl SelectExecutor<'_> {
 
             // Execute the hash join based on join type
             current_batch = match jt {
-                JoinType::Inner | JoinType::Cross => {
-                    columnar_join::columnar_hash_join_inner(
-                        &current_batch,
-                        batch,
-                        left_col_idx,
-                        right_col_idx,
-                    )?
-                }
-                JoinType::LeftOuter => {
-                    columnar_join::columnar_hash_join_left_outer(
-                        &current_batch,
-                        batch,
-                        left_col_idx,
-                        right_col_idx,
-                    )?
-                }
-                JoinType::RightOuter => {
-                    columnar_join::columnar_hash_join_right_outer(
-                        &current_batch,
-                        batch,
-                        left_col_idx,
-                        right_col_idx,
-                    )?
-                }
+                JoinType::Inner | JoinType::Cross => columnar_join::columnar_hash_join_inner(
+                    &current_batch,
+                    batch,
+                    left_col_idx,
+                    right_col_idx,
+                )?,
+                JoinType::LeftOuter => columnar_join::columnar_hash_join_left_outer(
+                    &current_batch,
+                    batch,
+                    left_col_idx,
+                    right_col_idx,
+                )?,
+                JoinType::RightOuter => columnar_join::columnar_hash_join_right_outer(
+                    &current_batch,
+                    batch,
+                    left_col_idx,
+                    right_col_idx,
+                )?,
                 _ => {
                     // FullOuter, Semi, Anti - not supported, fall back
                     log::debug!(
@@ -646,21 +683,15 @@ impl SelectExecutor<'_> {
             return Ok(rows);
         }
 
-        log::debug!(
-            "Columnar join: applying ORDER BY to {} rows",
-            rows.len()
-        );
+        log::debug!("Columnar join: applying ORDER BY to {} rows", rows.len());
 
         // Wrap rows as RowWithSortKeys (with None sort keys - apply_order_by will compute them)
-        let rows_with_keys: Vec<RowWithSortKeys> =
-            rows.into_iter().map(|r| (r, None)).collect();
+        let rows_with_keys: Vec<RowWithSortKeys> = rows.into_iter().map(|r| (r, None)).collect();
 
         // Create evaluator for ORDER BY expression evaluation
         // SAFETY: combined_schema lives for the duration of this function call
-        let schema_ref: &'static CombinedSchema =
-            unsafe { std::mem::transmute(combined_schema) };
-        let evaluator =
-            CombinedExpressionEvaluator::with_database(schema_ref, self.database);
+        let schema_ref: &'static CombinedSchema = unsafe { std::mem::transmute(combined_schema) };
+        let evaluator = CombinedExpressionEvaluator::with_database(schema_ref, self.database);
 
         // Apply ORDER BY sorting
         let sorted = apply_order_by(rows_with_keys, order_by, &evaluator, select_list)?;
@@ -847,8 +878,8 @@ fn check_expr_for_unsupported_agg(expr: &vibesql_ast::Expression) -> bool {
             }
             if args.len() == 1 {
                 match &args[0] {
-                    vibesql_ast::Expression::Wildcard => false,        // COUNT(*)
-                    vibesql_ast::Expression::ColumnRef(_) => false,    // SUM(col)
+                    vibesql_ast::Expression::Wildcard => false, // COUNT(*)
+                    vibesql_ast::Expression::ColumnRef(_) => false, // SUM(col)
                     // Everything else (BinaryOp, CASE, Function, etc.) will be
                     // rejected by the join GROUP BY path, either as an
                     // unsupported arg type or as AggregateSource::Expression.
@@ -865,11 +896,7 @@ fn check_expr_for_unsupported_agg(expr: &vibesql_ast::Expression) -> bool {
         }
         vibesql_ast::Expression::UnaryOp { expr, .. } => check_expr_for_unsupported_agg(expr),
         vibesql_ast::Expression::Cast { expr, .. } => check_expr_for_unsupported_agg(expr),
-        vibesql_ast::Expression::Case {
-            operand,
-            when_clauses,
-            else_result,
-        } => {
+        vibesql_ast::Expression::Case { operand, when_clauses, else_result } => {
             if operand.as_ref().is_some_and(|e| check_expr_for_unsupported_agg(e)) {
                 return true;
             }

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
@@ -40,10 +40,8 @@ pub(super) fn has_outer_join(from: &FromClause) -> bool {
     match from {
         FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => false,
         FromClause::Join { left, right, join_type, .. } => {
-            matches!(
-                join_type,
-                JoinType::LeftOuter | JoinType::RightOuter | JoinType::FullOuter
-            ) || has_outer_join(left)
+            matches!(join_type, JoinType::LeftOuter | JoinType::RightOuter | JoinType::FullOuter)
+                || has_outer_join(left)
                 || has_outer_join(right)
         }
     }
@@ -301,6 +299,50 @@ pub(super) fn extract_equijoin_conditions(
     }
 }
 
+/// Check that every top-level AND conjunct of the WHERE clause is fully
+/// consumed by the columnar join pipeline: either a pure equi-join condition
+/// (`col = col`, which becomes a hash-join key) or a conjunct that
+/// `extract_column_predicates` can represent columnarly.
+///
+/// Any other conjunct (e.g. a comparison wrapped in a unary operator like
+/// `+zY == iB`, an OR, a row-value comparison, ...) would be *silently
+/// dropped* by the extraction in `extract_non_join_predicates`, producing
+/// over-returned rows. When this returns `false` the caller must fall back to
+/// row-oriented execution, which evaluates the full WHERE expression per row.
+pub(super) fn where_clause_fully_covered(
+    expr: &Expression,
+    schema: &CombinedSchema,
+    case_sensitive_like: bool,
+) -> bool {
+    match expr {
+        Expression::BinaryOp { left, op: BinaryOperator::And, right } => {
+            where_clause_fully_covered(left, schema, case_sensitive_like)
+                && where_clause_fully_covered(right, schema, case_sensitive_like)
+        }
+        Expression::Conjunction(children) => children
+            .iter()
+            .all(|child| where_clause_fully_covered(child, schema, case_sensitive_like)),
+        // Pure equi-join conjunct: consumed as a hash-join key (mirrors the
+        // extraction rule in extract_equijoin_conditions, including the
+        // unqualified-schema requirement — a schema-qualified col = col is
+        // neither extracted as a join key nor kept as a filter, so it must
+        // trigger the fallback).
+        Expression::BinaryOp { left, op: BinaryOperator::Equal, right } => {
+            if let (Expression::ColumnRef(left_col_id), Expression::ColumnRef(right_col_id)) =
+                (left.as_ref(), right.as_ref())
+            {
+                left_col_id.schema_canonical().is_none()
+                    && right_col_id.schema_canonical().is_none()
+            } else {
+                columnar::extract_column_predicates(expr, schema, case_sensitive_like).is_some()
+            }
+        }
+        // A constant-folded always-true WHERE needs no filtering.
+        Expression::Literal(vibesql_types::SqlValue::Boolean(true)) => true,
+        _ => columnar::extract_column_predicates(expr, schema, case_sensitive_like).is_some(),
+    }
+}
+
 /// Extract non-join predicates (conditions that aren't col1 = col2)
 pub(super) fn extract_non_join_predicates(
     expr: &Expression,
@@ -335,13 +377,17 @@ fn extract_non_join_predicates_recursive(
                 return;
             }
             // Try to extract as column predicate
-            if let Some(pred) = columnar::extract_column_predicates(expr, schema, case_sensitive_like) {
+            if let Some(pred) =
+                columnar::extract_column_predicates(expr, schema, case_sensitive_like)
+            {
                 predicates.extend(pred);
             }
         }
         _ => {
             // Try to extract other predicates
-            if let Some(pred) = columnar::extract_column_predicates(expr, schema, case_sensitive_like) {
+            if let Some(pred) =
+                columnar::extract_column_predicates(expr, schema, case_sensitive_like)
+            {
                 predicates.extend(pred);
             }
         }
@@ -527,8 +573,7 @@ mod residual_on_conjunct_tests {
     /// A multi-table chain of pure equi-joins stays columnar.
     #[test]
     fn nested_pure_equijoins_have_no_residual() {
-        let from =
-            from_clause_of("SELECT * FROM t1 JOIN t2 ON t1.b = t2.x JOIN t3 ON t2.y = t3.z");
+        let from = from_clause_of("SELECT * FROM t1 JOIN t2 ON t1.b = t2.x JOIN t3 ON t2.y = t3.z");
         assert!(!join_tree_has_residual_on_conjuncts(&from));
     }
 }

--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -113,6 +113,35 @@ impl SelectExecutor<'_> {
             }
         }
 
+        // Row-value misuse validation (SQLite: "row value misused" at prepare
+        // time, even for empty tables). A row value is only legal in the
+        // comparison / IS / BETWEEN / IN / simple-CASE positions; anywhere else
+        // (bare in a SELECT list, compared against a scalar, ORDER BY /
+        // GROUP BY expression) is an error.
+        for item in &stmt.select_list {
+            if let vibesql_ast::SelectItem::Expression { expr, .. } = item {
+                super::validation::validate_row_value_usage(expr)?;
+            }
+        }
+        if let Some(where_expr) = &stmt.where_clause {
+            super::validation::validate_row_value_usage(where_expr)?;
+        }
+        if let Some(having_expr) = &stmt.having {
+            super::validation::validate_row_value_usage(having_expr)?;
+        }
+        if let Some(order_by) = stmt.order_by.as_deref() {
+            for item in order_by {
+                super::validation::validate_row_value_usage(&item.expr)?;
+            }
+        }
+        if let Some(group_by) = &stmt.group_by {
+            if let Some(exprs) = group_by.as_simple() {
+                for expr in exprs {
+                    super::validation::validate_row_value_usage(expr)?;
+                }
+            }
+        }
+
         // Validate GROUP BY clauses across this statement and all nested
         // subqueries for window-function misuse, including positional
         // (`GROUP BY 1`) and alias references that resolve to a window

--- a/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
@@ -39,6 +39,15 @@ pub(super) fn validate_where_clause_subqueries(
             // Issue #3562: Pass CTE context so CTEs can be resolved
             let expected = match lhs.as_ref() {
                 Expression::RowValueConstructor(elements) => elements.len(),
+                // Multi-column scalar-subquery LHS (`(SELECT a, b) IN (...)`)
+                // expects its own column count.
+                Expression::ScalarSubquery(left_sub) => {
+                    match compute_select_list_column_count(left_sub, database, cte_results) {
+                        Ok(n) => n,
+                        // Cannot be determined statically — defer to runtime.
+                        Err(_) => return Ok(()),
+                    }
+                }
                 _ => 1,
             };
             let column_count = compute_select_list_column_count(subquery, database, cte_results)?;
@@ -113,6 +122,14 @@ pub(crate) fn compute_select_list_column_count(
     database: &vibesql_storage::Database,
     cte_results: Option<&HashMap<String, CteResult>>,
 ) -> Result<usize, ExecutorError> {
+    // VALUES statements (e.g. `IN (VALUES(1, 2))`) carry no select list; the
+    // column count is the arity of the value rows.
+    if let Some(values) = &stmt.values {
+        if stmt.select_list.is_empty() {
+            return Ok(values.first().map_or(0, |row| row.len()));
+        }
+    }
+
     let left_count = compute_single_select_column_count(stmt, database, cte_results)?;
 
     // Issue #4881: Validate set operation column counts

--- a/crates/vibesql-executor/src/select/executor/validation/in_subquery_columns.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/in_subquery_columns.rs
@@ -65,10 +65,21 @@ fn validate_expr(
 ) -> Result<(), ExecutorError> {
     match expr {
         Expression::In { expr: lhs, subquery, .. } => {
-            // Row-value LHS expects one subquery column per LHS element;
-            // any other LHS is scalar and expects exactly one column.
+            // Row-value LHS expects one subquery column per LHS element; a
+            // multi-column scalar-subquery LHS (`(SELECT a, b) IN (...)`)
+            // expects its own column count; any other LHS is scalar and
+            // expects exactly one column.
             let expected = match lhs.as_ref() {
                 Expression::RowValueConstructor(items) => items.len(),
+                Expression::ScalarSubquery(left_sub) => {
+                    match crate::evaluator::compute_select_list_column_count(
+                        left_sub, database, None,
+                    ) {
+                        Ok(n) => n,
+                        // Cannot be determined statically — defer to runtime.
+                        Err(_) => return validate_expr(lhs, database),
+                    }
+                }
                 _ => 1,
             };
 

--- a/crates/vibesql-executor/src/select/executor/validation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/mod.rs
@@ -17,6 +17,7 @@ mod column_refs;
 mod in_subquery_columns;
 mod index_hints;
 mod join_limits;
+mod row_values;
 mod schema;
 
 use std::collections::HashSet;
@@ -33,6 +34,7 @@ pub use column_refs::{extract_column_refs, validate_column_ref};
 pub use in_subquery_columns::validate_in_subquery_column_counts;
 pub use index_hints::validate_index_hints;
 pub use join_limits::validate_join_table_limit;
+pub use row_values::validate_row_value_usage;
 pub use schema::validate_aggregate_subquery_outer_refs;
 use vibesql_ast::{Expression, SelectItem};
 

--- a/crates/vibesql-executor/src/select/executor/validation/row_values.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/row_values.rs
@@ -1,0 +1,413 @@
+//! Static validation of row-value (tuple) usage.
+//!
+//! SQLite rejects a row value used in a scalar context at prepare time with
+//! "row value misused" — even when the table is empty and no row would ever be
+//! evaluated (e.g. `SELECT * FROM empty WHERE (a,a) <= 1`). This walker mirrors
+//! that behavior: it flags row values that appear anywhere other than the
+//! positions where SQLite accepts them:
+//!
+//! - both sides of a comparison / `IS` (`(a,b) = (c,d)`, arity must match;
+//!   nested row values pair up recursively);
+//! - one side of a comparison / `IS` when the other side is a scalar subquery
+//!   (`(a,b) = (SELECT x,y)`);
+//! - all three operands of BETWEEN (row values or scalar subqueries);
+//! - the left-hand side of `IN (SELECT ...)` and `IN (list)` (where every list
+//!   element must be a row value of the same arity);
+//! - the operand / WHEN values of a simple CASE.
+//!
+//! Runtime checks in the evaluators cover the same shapes for non-SELECT
+//! statements; this static pass exists so empty-table queries still error.
+
+use vibesql_ast::{BinaryOperator, Expression};
+
+use crate::errors::ExecutorError;
+
+/// True for a row value constructor with more than one element (a
+/// single-element parenthesized expression is just a scalar).
+fn is_multi_row_value(expr: &Expression) -> bool {
+    matches!(expr, Expression::RowValueConstructor(elems) if elems.len() > 1)
+}
+
+/// Acceptable opposite operand for a row value in a comparison context.
+fn is_row_value_or_subquery(expr: &Expression) -> bool {
+    is_multi_row_value(expr) || matches!(expr, Expression::ScalarSubquery(_))
+}
+
+fn is_comparison_op(op: &BinaryOperator) -> bool {
+    matches!(
+        op,
+        BinaryOperator::Equal
+            | BinaryOperator::NotEqual
+            | BinaryOperator::LessThan
+            | BinaryOperator::LessThanOrEqual
+            | BinaryOperator::GreaterThan
+            | BinaryOperator::GreaterThanOrEqual
+    )
+}
+
+/// Validate row-value usage in an expression appearing in a scalar-producing
+/// context (SELECT list item, WHERE clause, ORDER BY / GROUP BY / HAVING
+/// expression).
+pub fn validate_row_value_usage(expr: &Expression) -> Result<(), ExecutorError> {
+    walk(expr)
+}
+
+/// Validate a row-value vs row-value comparison pair: arities must match and
+/// nested row values must pair up structurally.
+fn validate_pair(left: &[Expression], right: &[Expression]) -> Result<(), ExecutorError> {
+    if left.len() != right.len() {
+        return Err(ExecutorError::RowValueMisused);
+    }
+    for (l, r) in left.iter().zip(right.iter()) {
+        match (l, r) {
+            (Expression::RowValueConstructor(le), Expression::RowValueConstructor(re)) => {
+                validate_pair(le, re)?;
+            }
+            (Expression::RowValueConstructor(_), _) | (_, Expression::RowValueConstructor(_)) => {
+                return Err(ExecutorError::RowValueMisused);
+            }
+            _ => {
+                walk(l)?;
+                walk(r)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate the elements of a row value whose opposite operand is a scalar
+/// subquery (each element must itself be scalar).
+fn validate_elements_scalar(elems: &[Expression]) -> Result<(), ExecutorError> {
+    for e in elems {
+        walk(e)?;
+    }
+    Ok(())
+}
+
+fn walk(expr: &Expression) -> Result<(), ExecutorError> {
+    match expr {
+        // A row value reached outside one of the accepted positions below is a
+        // misuse (bare in a SELECT list, function argument, arithmetic
+        // operand, ORDER BY / GROUP BY expression, ...).
+        Expression::RowValueConstructor(elems) => {
+            if elems.len() > 1 {
+                return Err(ExecutorError::RowValueMisused);
+            }
+            validate_elements_scalar(elems)
+        }
+
+        Expression::BinaryOp { left, op, right } if is_comparison_op(op) => {
+            match (left.as_ref(), right.as_ref()) {
+                (Expression::RowValueConstructor(le), Expression::RowValueConstructor(re))
+                    if le.len() > 1 || re.len() > 1 =>
+                {
+                    validate_pair(le, re)
+                }
+                (Expression::RowValueConstructor(le), other) if le.len() > 1 => {
+                    if matches!(other, Expression::ScalarSubquery(_)) {
+                        validate_elements_scalar(le)
+                    } else {
+                        Err(ExecutorError::RowValueMisused)
+                    }
+                }
+                (other, Expression::RowValueConstructor(re)) if re.len() > 1 => {
+                    if matches!(other, Expression::ScalarSubquery(_)) {
+                        validate_elements_scalar(re)
+                    } else {
+                        Err(ExecutorError::RowValueMisused)
+                    }
+                }
+                _ => {
+                    walk(left)?;
+                    walk(right)
+                }
+            }
+        }
+
+        Expression::BinaryOp { left, right, .. } => {
+            walk(left)?;
+            walk(right)
+        }
+
+        Expression::IsDistinctFrom { left, right, .. } => match (left.as_ref(), right.as_ref()) {
+            (Expression::RowValueConstructor(le), Expression::RowValueConstructor(re))
+                if le.len() > 1 || re.len() > 1 =>
+            {
+                validate_pair(le, re)
+            }
+            (Expression::RowValueConstructor(le), other) if le.len() > 1 => {
+                if matches!(other, Expression::ScalarSubquery(_)) {
+                    validate_elements_scalar(le)
+                } else {
+                    Err(ExecutorError::RowValueMisused)
+                }
+            }
+            (other, Expression::RowValueConstructor(re)) if re.len() > 1 => {
+                if matches!(other, Expression::ScalarSubquery(_)) {
+                    validate_elements_scalar(re)
+                } else {
+                    Err(ExecutorError::RowValueMisused)
+                }
+            }
+            _ => {
+                walk(left)?;
+                walk(right)
+            }
+        },
+
+        Expression::Between { expr, low, high, .. } => {
+            let operands = [expr.as_ref(), low.as_ref(), high.as_ref()];
+            if operands.iter().any(|e| is_multi_row_value(e)) {
+                // All three operands must be row values or scalar subqueries,
+                // and the row-value operands must agree on arity.
+                if !operands.iter().all(|e| is_row_value_or_subquery(e)) {
+                    return Err(ExecutorError::RowValueMisused);
+                }
+                let mut arity: Option<usize> = None;
+                for operand in operands {
+                    if let Expression::RowValueConstructor(elems) = operand {
+                        if let Some(a) = arity {
+                            if a != elems.len() {
+                                return Err(ExecutorError::RowValueMisused);
+                            }
+                        } else {
+                            arity = Some(elems.len());
+                        }
+                        validate_elements_scalar(elems)?;
+                    }
+                }
+                Ok(())
+            } else {
+                walk(expr)?;
+                walk(low)?;
+                walk(high)
+            }
+        }
+
+        Expression::InList { expr, values, .. } => {
+            if let Expression::RowValueConstructor(elems) = expr.as_ref() {
+                if elems.len() > 1 {
+                    validate_elements_scalar(elems)?;
+                    for value in values {
+                        match value {
+                            Expression::RowValueConstructor(cand) if cand.len() == elems.len() => {
+                                validate_elements_scalar(cand)?;
+                            }
+                            _ => return Err(ExecutorError::RowValueMisused),
+                        }
+                    }
+                    return Ok(());
+                }
+            }
+            walk(expr)?;
+            for value in values {
+                walk(value)?;
+            }
+            Ok(())
+        }
+
+        // Row value on the left of `IN (SELECT ...)` is legal; arity is
+        // validated at execution time against the subquery's column count.
+        Expression::In { expr, .. } => {
+            if let Expression::RowValueConstructor(elems) = expr.as_ref() {
+                validate_elements_scalar(elems)
+            } else {
+                walk(expr)
+            }
+        }
+
+        // Simple CASE with a row-value operand or row-value WHEN values is
+        // legal (compared with row-value equality). Only the results and ELSE
+        // are scalar contexts.
+        Expression::Case { operand, when_clauses, else_result } => {
+            let row_value_case = operand.as_deref().is_some_and(is_row_value_or_subquery)
+                || when_clauses.iter().any(|wc| wc.conditions.iter().any(is_multi_row_value));
+            if !row_value_case {
+                if let Some(op_expr) = operand {
+                    walk(op_expr)?;
+                }
+                for wc in when_clauses {
+                    for cond in &wc.conditions {
+                        walk(cond)?;
+                    }
+                }
+            }
+            for wc in when_clauses {
+                walk(&wc.result)?;
+            }
+            if let Some(else_expr) = else_result {
+                walk(else_expr)?;
+            }
+            Ok(())
+        }
+
+        // Subqueries are validated independently when they execute.
+        Expression::ScalarSubquery(_) | Expression::Exists { .. } => Ok(()),
+
+        Expression::QuantifiedComparison { expr, .. } => walk(expr),
+
+        Expression::UnaryOp { expr, .. } => walk(expr),
+        Expression::Collate { expr, .. } => walk(expr),
+        Expression::Cast { expr, .. } => walk(expr),
+        Expression::IsNull { expr, .. } => walk(expr),
+        Expression::IsTruthValue { expr, .. } => walk(expr),
+        Expression::Like { expr, pattern, escape, .. } => {
+            walk(expr)?;
+            walk(pattern)?;
+            if let Some(esc) = escape {
+                walk(esc)?;
+            }
+            Ok(())
+        }
+        Expression::Glob { expr, pattern, .. } => {
+            walk(expr)?;
+            walk(pattern)
+        }
+        Expression::Function { args, .. } => {
+            for arg in args {
+                walk(arg)?;
+            }
+            Ok(())
+        }
+        Expression::AggregateFunction { args, .. } => {
+            for arg in args {
+                walk(arg)?;
+            }
+            Ok(())
+        }
+        Expression::Conjunction(children) | Expression::Disjunction(children) => {
+            for child in children {
+                walk(child)?;
+            }
+            Ok(())
+        }
+        Expression::Trim { removal_char, string, .. } => {
+            if let Some(rc) = removal_char {
+                walk(rc)?;
+            }
+            walk(string)
+        }
+        Expression::Position { substring, string, .. } => {
+            walk(substring)?;
+            walk(string)
+        }
+        Expression::Extract { expr, .. } => walk(expr),
+
+        // Everything else (literals, column refs, placeholders, ...) contains
+        // no nested expressions we need to inspect.
+        _ => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vibesql_parser::Parser;
+
+    use super::*;
+
+    fn where_expr_of(sql: &str) -> Expression {
+        match Parser::parse_sql(sql) {
+            Ok(vibesql_ast::Statement::Select(select)) => {
+                select.where_clause.expect("query must have a WHERE clause")
+            }
+            other => panic!("expected SELECT, got {:?}", other),
+        }
+    }
+
+    fn select_item_of(sql: &str) -> Expression {
+        match Parser::parse_sql(sql) {
+            Ok(vibesql_ast::Statement::Select(select)) => match &select.select_list[0] {
+                vibesql_ast::SelectItem::Expression { expr, .. } => expr.clone(),
+                other => panic!("expected expression item, got {:?}", other),
+            },
+            other => panic!("expected SELECT, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn row_value_vs_scalar_comparison_is_misused() {
+        for op in ["=", "==", "!=", "<>", "<", "<=", ">", ">="] {
+            let expr = where_expr_of(&format!("SELECT * FROM t WHERE (a,a) {} 1", op));
+            assert!(
+                matches!(validate_row_value_usage(&expr), Err(ExecutorError::RowValueMisused)),
+                "expected misuse for operator {}",
+                op
+            );
+        }
+    }
+
+    #[test]
+    fn row_value_is_scalar_is_misused() {
+        let expr = where_expr_of("SELECT * FROM t WHERE (a,a) IS 1");
+        assert!(matches!(validate_row_value_usage(&expr), Err(ExecutorError::RowValueMisused)));
+        let expr = where_expr_of("SELECT * FROM t WHERE (a,a) IS NOT 1");
+        assert!(matches!(validate_row_value_usage(&expr), Err(ExecutorError::RowValueMisused)));
+    }
+
+    #[test]
+    fn row_value_vs_row_value_is_legal() {
+        let expr = where_expr_of("SELECT * FROM t WHERE (a,b) = (1,2)");
+        assert!(validate_row_value_usage(&expr).is_ok());
+        let expr = where_expr_of("SELECT * FROM t WHERE (a,b) < (c,d)");
+        assert!(validate_row_value_usage(&expr).is_ok());
+    }
+
+    #[test]
+    fn row_value_vs_subquery_is_legal() {
+        let expr = where_expr_of("SELECT * FROM t WHERE (a,b) = (SELECT x, y FROM u)");
+        assert!(validate_row_value_usage(&expr).is_ok());
+    }
+
+    #[test]
+    fn row_value_arity_mismatch_is_misused() {
+        let expr = where_expr_of("SELECT * FROM t WHERE (a,b) = (1,2,3)");
+        assert!(matches!(validate_row_value_usage(&expr), Err(ExecutorError::RowValueMisused)));
+    }
+
+    #[test]
+    fn nested_row_values_pair_up() {
+        let expr = select_item_of("SELECT (2,(2,0)) IS (2,(2,0))");
+        assert!(validate_row_value_usage(&expr).is_ok());
+        let expr = select_item_of("SELECT (2,(2,0)) IS (2,(2,0,1))");
+        assert!(matches!(validate_row_value_usage(&expr), Err(ExecutorError::RowValueMisused)));
+    }
+
+    #[test]
+    fn bare_row_value_in_select_list_is_misused() {
+        let expr = select_item_of("SELECT (1,2)");
+        assert!(matches!(validate_row_value_usage(&expr), Err(ExecutorError::RowValueMisused)));
+    }
+
+    #[test]
+    fn between_mixed_scalar_is_misused() {
+        let expr = select_item_of("SELECT (1,2) BETWEEN 1 AND 2");
+        assert!(matches!(validate_row_value_usage(&expr), Err(ExecutorError::RowValueMisused)));
+        let expr = select_item_of("SELECT 1 BETWEEN (1,2) AND 2");
+        assert!(matches!(validate_row_value_usage(&expr), Err(ExecutorError::RowValueMisused)));
+        let expr = select_item_of("SELECT 2 BETWEEN 1 AND (1,2)");
+        assert!(matches!(validate_row_value_usage(&expr), Err(ExecutorError::RowValueMisused)));
+    }
+
+    #[test]
+    fn between_all_row_values_is_legal() {
+        let expr = select_item_of("SELECT (2,2) BETWEEN (1,1) AND (3,3)");
+        assert!(validate_row_value_usage(&expr).is_ok());
+        let expr = where_expr_of("SELECT 1 WHERE (SELECT 2,2) BETWEEN (1,1) AND (3,3)");
+        assert!(validate_row_value_usage(&expr).is_ok());
+    }
+
+    #[test]
+    fn row_value_in_list_shapes() {
+        let expr = where_expr_of("SELECT * FROM t WHERE (a,b) IN ((1,2),(3,4))");
+        assert!(validate_row_value_usage(&expr).is_ok());
+        // Mismatched candidate arity
+        let expr = where_expr_of("SELECT * FROM t WHERE (a,b) IN ((1,2,3))");
+        assert!(matches!(validate_row_value_usage(&expr), Err(ExecutorError::RowValueMisused)));
+    }
+
+    #[test]
+    fn case_with_row_values_is_legal() {
+        let expr = select_item_of("SELECT CASE (2,2) WHEN (1,1) THEN 2 ELSE 1 END");
+        assert!(validate_row_value_usage(&expr).is_ok());
+    }
+}

--- a/crates/vibesql-executor/tests/row_value_features_tests.rs
+++ b/crates/vibesql-executor/tests/row_value_features_tests.rs
@@ -1,0 +1,352 @@
+//! Tests for the remaining row-value features from issue #5790:
+//!
+//! - Row-value `IN (list)` / `NOT IN (list)` with SQLite three-valued NULL
+//!   semantics and per-column affinity.
+//! - "row value misused" errors for row values in scalar contexts (compared
+//!   against scalars, bare in a SELECT list, in ORDER BY / GROUP BY, mixed
+//!   into BETWEEN), raised at prepare time even for empty tables.
+//! - COLLATE (explicit and column-declared) honored inside row-value
+//!   comparison, including the tuple-vs-subquery form.
+//! - Row-value simple CASE (`CASE (2,2) WHEN (1,1) THEN ... END`).
+//! - Row-value BETWEEN with a scalar-subquery operand and in multi-table
+//!   (combined evaluator) contexts.
+//! - Multi-column scalar subquery on the LHS of IN.
+//! - `IN (VALUES(...))` table value constructors.
+//! - Nested row values inside IS.
+//! - Join WHERE-clause conjunct coverage: predicates the columnar join path
+//!   cannot consume (e.g. `+col == other`) must not be silently dropped.
+//!
+//! Expected values verified against SQLite (rowvalue.test / rowvalue2.test).
+
+use vibesql_executor::{ExecutorError, SelectExecutor};
+use vibesql_types::SqlValue;
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            vibesql_executor::InsertExecutor::execute(db, &insert).unwrap();
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+/// Run a SELECT that yields a single scalar value; normalize Boolean to 0/1
+/// Integer (SQLite has no boolean storage class).
+fn query_scalar(db: &vibesql_storage::Database, sql: &str) -> SqlValue {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        let rows = executor
+            .execute(&select_stmt)
+            .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e));
+        assert_eq!(rows.len(), 1, "Expected exactly one row for: {}", sql);
+        assert_eq!(rows[0].values.len(), 1, "Expected exactly one column for: {}", sql);
+        match &rows[0].values[0] {
+            SqlValue::Boolean(b) => SqlValue::Integer(*b as i64),
+            other => other.clone(),
+        }
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+fn assert_scalar(db: &vibesql_storage::Database, sql: &str, expected: SqlValue) {
+    let actual = query_scalar(db, sql);
+    assert_eq!(actual, expected, "Query: {} -- expected {:?}, got {:?}", sql, expected, actual);
+}
+
+/// Run a SELECT and return the first column of every row.
+fn query_column(db: &vibesql_storage::Database, sql: &str) -> Vec<SqlValue> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        let rows = executor
+            .execute(&select_stmt)
+            .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e));
+        rows.iter().map(|r| r.values[0].clone()).collect()
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+/// Run a SELECT expecting an error; return it.
+fn query_err(db: &vibesql_storage::Database, sql: &str) -> ExecutorError {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        match executor.execute(&select_stmt) {
+            Ok(_) => panic!("Expected error for: {}", sql),
+            Err(e) => e,
+        }
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+fn assert_misused(db: &vibesql_storage::Database, sql: &str) {
+    let err = query_err(db, sql);
+    assert!(
+        matches!(err, ExecutorError::RowValueMisused),
+        "Query: {} -- expected RowValueMisused, got {:?}",
+        sql,
+        err
+    );
+}
+
+const I: fn(i64) -> SqlValue = SqlValue::Integer;
+
+// ─── Row-value IN (list) ────────────────────────────────────────────────────
+
+#[test]
+fn tuple_in_list_matches() {
+    let db = vibesql_storage::Database::new();
+    assert_scalar(&db, "SELECT (1,2) IN ((1,2),(3,4))", I(1));
+    assert_scalar(&db, "SELECT (3,4) IN ((1,2),(3,4))", I(1));
+    assert_scalar(&db, "SELECT (1,3) IN ((1,2),(3,4))", I(0));
+    assert_scalar(&db, "SELECT (1,2) NOT IN ((1,2),(3,4))", I(0));
+    assert_scalar(&db, "SELECT (5,6) NOT IN ((1,2),(3,4))", I(1));
+}
+
+#[test]
+fn tuple_in_list_null_semantics() {
+    let db = vibesql_storage::Database::new();
+    // Partial match with NULL in the undecided position → UNKNOWN.
+    assert_scalar(&db, "SELECT (1, NULL) IN ((1, 2))", SqlValue::Null);
+    // A definitively unequal element makes the row FALSE, not UNKNOWN.
+    assert_scalar(&db, "SELECT (1, NULL) IN ((2, 2))", I(0));
+    // NULL on the candidate side behaves the same way.
+    assert_scalar(&db, "SELECT (1, 2) IN ((1, NULL))", SqlValue::Null);
+    assert_scalar(&db, "SELECT (1, 2) IN ((2, NULL))", I(0));
+    // A definite match wins even when other candidates have NULLs.
+    assert_scalar(&db, "SELECT (1, 2) IN ((1, NULL), (1, 2))", I(1));
+    // NOT IN flips definite results; UNKNOWN stays NULL.
+    assert_scalar(&db, "SELECT (1, NULL) NOT IN ((1, 2))", SqlValue::Null);
+    assert_scalar(&db, "SELECT (1, NULL) NOT IN ((2, 2))", I(1));
+}
+
+#[test]
+fn tuple_in_list_column_affinity() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(a TEXT, b INTEGER)");
+    run_stmt(&mut db, "INSERT INTO t VALUES('12', 3)");
+    // TEXT-affinity column vs integer literal in the tuple: the literal is
+    // coerced to text (mirrors scalar `a = 12`).
+    assert_scalar(&db, "SELECT (a, b) IN ((12, 3)) FROM t", I(1));
+    assert_scalar(&db, "SELECT (a, b) IN (('12', 3)) FROM t", I(1));
+    assert_scalar(&db, "SELECT (a, b) IN (('12', '3')) FROM t", I(1));
+}
+
+#[test]
+fn tuple_in_list_arity_mismatch_is_misused() {
+    let db = vibesql_storage::Database::new();
+    assert_misused(&db, "SELECT (1,2) IN ((1,2,3))");
+    assert_misused(&db, "SELECT (1,2) IN ((1,2), 3)");
+}
+
+#[test]
+fn tuple_in_empty_list() {
+    let db = vibesql_storage::Database::new();
+    assert_scalar(&db, "SELECT (1,2) IN ()", I(0));
+    assert_scalar(&db, "SELECT (1,2) NOT IN ()", I(1));
+}
+
+// ─── "row value misused" errors ─────────────────────────────────────────────
+
+#[test]
+fn row_value_vs_scalar_comparison_errors_even_on_empty_table() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t11(a)");
+    // No rows: the error must still surface (SQLite raises at prepare time).
+    for op in ["<=", "<", ">=", ">", "==", "<>"] {
+        assert_misused(&db, &format!("SELECT * FROM t11 WHERE (a,a) {} 1", op));
+    }
+    assert_misused(&db, "SELECT * FROM t11 WHERE (a,a) IS 1");
+    assert_misused(&db, "SELECT * FROM t11 WHERE (a,a) IS NOT 1");
+}
+
+#[test]
+fn bare_row_value_contexts_are_misused() {
+    let db = vibesql_storage::Database::new();
+    assert_misused(&db, "SELECT (1,2) AS x WHERE x=3");
+    assert_misused(&db, "SELECT (1,2) BETWEEN 1 AND 2");
+    assert_misused(&db, "SELECT 1 BETWEEN (1,2) AND 2");
+    assert_misused(&db, "SELECT 2 BETWEEN 1 AND (1,2)");
+    assert_misused(&db, "SELECT (1,2) FROM (SELECT 1) ORDER BY 1");
+    assert_misused(&db, "SELECT (1,2) FROM (SELECT 1) GROUP BY 1");
+}
+
+#[test]
+fn row_value_compared_to_collated_subquery_is_misused() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE hh(a, b, c)");
+    run_stmt(&mut db, "INSERT INTO hh VALUES('abc', 1, 'i')");
+    // COLLATE applied to the subquery makes the RHS a scalar context.
+    assert_misused(&db, "SELECT c FROM hh WHERE (a, b) = (SELECT 'abc', 1) COLLATE nocase");
+    assert_misused(&db, "SELECT c FROM hh WHERE (a, b) = 1");
+}
+
+// ─── COLLATE inside row-value comparison ────────────────────────────────────
+
+#[test]
+fn explicit_collate_in_row_value_comparison() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t0(c0)");
+    run_stmt(&mut db, "INSERT INTO t0(c0) VALUES('a')");
+    // rowvalue.test 25.10–25.40: NOCASE from either element side.
+    assert_scalar(&db, "SELECT (t0.c0, 0) < ('B' COLLATE NOCASE, 0) FROM t0", I(1));
+    assert_scalar(&db, "SELECT ('B' COLLATE NOCASE, 0) > (t0.c0, 0) FROM t0", I(1));
+    assert_scalar(&db, "SELECT ('B', 0) > (t0.c0 COLLATE nocase, 0) FROM t0", I(1));
+    assert_scalar(&db, "SELECT (t0.c0 COLLATE nocase, 0) < ('B', 0) FROM t0", I(1));
+    // Without the collation, binary comparison flips the result ('a' > 'B').
+    assert_scalar(&db, "SELECT (t0.c0, 0) < ('B', 0) FROM t0", I(0));
+}
+
+#[test]
+fn collate_in_row_value_vs_subquery() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE hh(a, b, c)");
+    for row in [
+        "('abc', 1, 'i')",
+        "('ABC', 1, 'ii')",
+        "('def', 2, 'iii')",
+        "('DEF', 2, 'iv')",
+        "('GHI', 3, 'v')",
+        "('ghi', 3, 'vi')",
+    ] {
+        run_stmt(&mut db, &format!("INSERT INTO hh VALUES{}", row));
+    }
+    // rowvalue.test 6.8 / 6.9.
+    let rows =
+        query_column(&db, "SELECT c FROM hh WHERE (a COLLATE nocase, b) = (SELECT 'def', 2)");
+    assert_eq!(
+        rows,
+        vec![SqlValue::Varchar("iii".into()), SqlValue::Varchar("iv".into())],
+        "6.8: NOCASE must apply to the first tuple element"
+    );
+    let rows =
+        query_column(&db, "SELECT c FROM hh WHERE (a COLLATE nocase, b) IS NOT (SELECT 'def', 2)");
+    assert_eq!(
+        rows,
+        vec![
+            SqlValue::Varchar("i".into()),
+            SqlValue::Varchar("ii".into()),
+            SqlValue::Varchar("v".into()),
+            SqlValue::Varchar("vi".into())
+        ],
+        "6.9: NOCASE must apply to IS NOT against a subquery"
+    );
+}
+
+// ─── Row-value CASE / BETWEEN ───────────────────────────────────────────────
+
+#[test]
+fn row_value_simple_case() {
+    let db = vibesql_storage::Database::new();
+    assert_scalar(&db, "SELECT CASE (2,2) WHEN (1,1) THEN 2 ELSE 1 END", I(1));
+    assert_scalar(&db, "SELECT CASE (2,2) WHEN (2,2) THEN 2 ELSE 1 END", I(2));
+    // Subquery operand (rowvalue.test 14.3).
+    assert_scalar(&db, "SELECT CASE (SELECT 2,2) WHEN (1,1) THEN 2 ELSE 1 END", I(1));
+    assert_scalar(&db, "SELECT CASE (SELECT 2,2) WHEN (2,2) THEN 2 ELSE 1 END", I(2));
+}
+
+#[test]
+fn row_value_between_with_subquery_operand() {
+    let db = vibesql_storage::Database::new();
+    // rowvalue.test 14.4.
+    assert_scalar(&db, "SELECT (SELECT 2,2) BETWEEN (1,1) AND (3,3)", I(1));
+    assert_scalar(&db, "SELECT (SELECT 4,2) BETWEEN (1,1) AND (3,3)", I(0));
+}
+
+#[test]
+fn row_value_between_in_where_clause() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t12(x)");
+    run_stmt(&mut db, "INSERT INTO t12 VALUES(2)");
+    run_stmt(&mut db, "INSERT INTO t12 VALUES(4)");
+    // rowvalue.test 14.5 / 14.6: the predicate must not be dropped by the
+    // columnar filter path.
+    let rows = query_column(&db, "SELECT 1 FROM t12 WHERE (x,1) BETWEEN (1,1) AND (3,3)");
+    assert_eq!(rows, vec![I(1)], "14.5: only x=2 satisfies the row-value BETWEEN");
+    let rows = query_column(&db, "SELECT 1 FROM t12 WHERE (1,x) BETWEEN (1,1) AND (3,3)");
+    assert_eq!(rows, vec![I(1), I(1)], "14.6: both rows satisfy the row-value BETWEEN");
+}
+
+// ─── Multi-column subquery LHS of IN / IN (VALUES ...) ─────────────────────
+
+#[test]
+fn multi_column_subquery_lhs_of_in() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE b3(a, b)");
+    run_stmt(&mut db, "CREATE TABLE b5(a, b)");
+    run_stmt(&mut db, "INSERT INTO b3 VALUES(1, 1)");
+    run_stmt(&mut db, "INSERT INTO b3 VALUES(1, 2)");
+    run_stmt(&mut db, "INSERT INTO b5 VALUES(1, 1)");
+    run_stmt(&mut db, "INSERT INTO b5 VALUES(1, 2)");
+    // rowvalue.test 18.1.
+    let rows =
+        query_column(&db, "SELECT a FROM b3 WHERE (SELECT b3.a, b3.b) IN (SELECT a, b FROM b5)");
+    assert_eq!(rows, vec![I(1), I(1)]);
+    // rowvalue.test 22.100: compound subquery LHS takes its first row.
+    assert_scalar(&db, "SELECT (SELECT 3,4 UNION SELECT 5,6 ORDER BY 1) IN (SELECT 3,4)", I(1));
+    assert_scalar(&db, "SELECT (SELECT 3,4 UNION SELECT 5,6 ORDER BY 1) IN (SELECT 5,6)", I(0));
+    assert_scalar(
+        &db,
+        "SELECT (SELECT 3,4 UNION SELECT 5,6 ORDER BY 1 DESC) IN (SELECT 5,6)",
+        I(1),
+    );
+}
+
+#[test]
+fn in_values_table_constructor() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t1(a, b)");
+    run_stmt(&mut db, "INSERT INTO t1 VALUES(1, 2)");
+    run_stmt(&mut db, "INSERT INTO t1 VALUES(3, 4)");
+    // rowvalue.test 21.0-style.
+    let rows = query_column(&db, "SELECT a FROM t1 WHERE (a,b) IN (VALUES(1,2))");
+    assert_eq!(rows, vec![I(1)]);
+    // Scalar LHS with VALUES.
+    assert_scalar(&db, "SELECT 1 IN (VALUES(1))", I(1));
+    assert_scalar(&db, "SELECT 2 IN (VALUES(1))", I(0));
+}
+
+// ─── Nested row values inside IS ────────────────────────────────────────────
+
+#[test]
+fn nested_row_value_is() {
+    let db = vibesql_storage::Database::new();
+    // rowvalue.test 20.1.
+    assert_scalar(&db, "SELECT (2,(2,0)) IS (2,(2,0))", I(1));
+    assert_scalar(&db, "SELECT (2,(2,0)) IS (2,(2,1))", I(0));
+    assert_scalar(&db, "SELECT (2,(2,NULL)) IS (2,(2,NULL))", I(1));
+}
+
+// ─── Join WHERE conjunct coverage (unary-plus predicate must not drop) ─────
+
+#[test]
+fn join_where_conjunct_with_unary_plus_not_dropped() {
+    let mut db = vibesql_storage::Database::new();
+    // rowvalue2.test section 5 fixture.
+    run_stmt(&mut db, "CREATE TABLE r1(a TEXT, iB TEXT)");
+    run_stmt(&mut db, "CREATE TABLE r2(x TEXT, zY INTEGER)");
+    run_stmt(&mut db, "INSERT INTO r1 VALUES(35, 35)");
+    run_stmt(&mut db, "INSERT INTO r2 VALUES(35, 36)");
+    run_stmt(&mut db, "INSERT INTO r2 VALUES(35, 4)");
+    run_stmt(&mut db, "INSERT INTO r2 VALUES(35, 35)");
+
+    // The scalar-expanded form: `+zY` strips affinity, so the INTEGER value is
+    // converted to TEXT for comparison with the TEXT column iB — only the
+    // zY=35 row matches. Before the coverage check, the columnar join dropped
+    // the second conjunct and returned all three rows.
+    let rows =
+        query_column(&db, "SELECT zY FROM r1, r2 WHERE (x == a) AND (+zY == iB) ORDER BY zY");
+    assert_eq!(rows, vec![I(35)]);
+
+    // The row-value form must agree with the scalar-expanded form.
+    let rows = query_column(&db, "SELECT zY FROM r1, r2 WHERE (x, +zY) == (a, iB) ORDER BY zY");
+    assert_eq!(rows, vec![I(35)]);
+}

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -290,7 +290,13 @@ impl Parser {
                             self.expect_token(Token::LParen)?;
                         }
 
-                        let subquery = self.parse_select_statement()?;
+                        // NOT IN (VALUES(...), ...) — a table value constructor
+                        // subquery (rowvalue.test 17.1 / 21.0).
+                        let subquery = if self.peek_keyword(Keyword::Values) {
+                            self.parse_embedded_select_statement()?
+                        } else {
+                            self.parse_select_statement()?
+                        };
 
                         // Consume matching closing parentheses
                         for _ in 0..extra_paren_depth {
@@ -508,7 +514,13 @@ impl Parser {
                         self.expect_token(Token::LParen)?;
                     }
 
-                    let subquery = self.parse_select_statement()?;
+                    // IN (VALUES(...), ...) — a table value constructor
+                    // subquery (rowvalue.test 17.1 / 21.0).
+                    let subquery = if self.peek_keyword(Keyword::Values) {
+                        self.parse_embedded_select_statement()?
+                    } else {
+                        self.parse_select_statement()?
+                    };
 
                     // Consume matching closing parentheses
                     for _ in 0..extra_paren_depth {


### PR DESCRIPTION
## Summary

Implements the bulk of the remaining row-value gaps from #5790 (follow-up to #5791), in both the single-table and combined expression evaluators.

**Implemented:**

1. **Row-value `IN (list)`** — `(a,b) IN ((1,2),(3,4))` and `NOT IN` with SQLite three-valued NULL semantics (a definitively unequal element makes a candidate FALSE, an undecided NULL makes the result UNKNOWN) plus per-element collation and type affinity. Non-tuple or wrong-arity candidates raise `row value misused`.
2. **COLLATE inside row-value comparison** — explicit `COLLATE` and column-declared collation apply per element pair in tuple comparisons, `IS`/`IS NOT`, and the tuple-vs-subquery forms (rowvalue.test sections 6 and 25).
3. **`row value misused` errors** — raised at runtime *and* at prepare time via a new static validation walker (`validation/row_values.rs`), so empty-table queries error like SQLite: row-value vs scalar comparisons/`IS`, bare row values in SELECT list / ORDER BY / GROUP BY, BETWEEN mixing row values with scalars, arity mismatches including nested tuples (sections 11, 13, 6.6/6.7, 29.1). Note: `ORDER BY (a,b)` is *rejected* per SQLite semantics (rowvalue.test 13.4/13.5), not sorted lexicographically as the issue text speculated.
4. **Row-value simple CASE** — `CASE (2,2) WHEN (1,1) THEN ... END`, including subquery operands (14.2/14.3).
5. **Row-value BETWEEN** — added to the combined evaluator (previously errored or was silently dropped in WHERE contexts) and scalar-subquery operand support (14.4–14.6, 33.x).
6. **Nested row values inside IS** — `(2,(2,0)) IS (2,(2,0))` compares structurally (20.1).
7. **Multi-column scalar subquery LHS of IN** — `(SELECT a,b) IN (SELECT x,y)`, including compound UNION subqueries (18.1/18.4, 22.100).
8. **`IN (VALUES(...))`** — parser routes VALUES inside `IN (...)` to the table-value-constructor subquery parser; column-count computation handles VALUES statements (17.1, 21.0).
9. **Columnar join WHERE coverage check** — every WHERE conjunct must be consumed as a hash-join key or an extractable columnar predicate, else the join falls back to row-oriented execution. Conjuncts like `+zY == iB` were previously *silently dropped*, over-returning rows (root cause of rowvalue2.test 5.1/5.3 — a general join-correctness bug, not just a row-value issue).

## TCL results

| File | Before | After |
|---|---|---|
| rowvalue.test | 63 failed / 298 (78.5%) | 18 failed / 298 (93.6%) |
| rowvalue2.test | 2 failed / 3834 (99.9%) | 0 failed (100.0%) |

No regressions: select1.test (188/188), in.test (114 pass / 0 fail), where.test, whereB.test (63/63), between.test, collate1.test all at their prior pass rates.

## Tests added

- `crates/vibesql-executor/tests/row_value_features_tests.rs` — 17 integration tests: tuple IN-list (match/NULL/affinity/arity/empty), misuse errors incl. empty-table prepare-time errors, COLLATE in tuple comparison and tuple-vs-subquery, row-value CASE and BETWEEN (incl. WHERE-clause predicate-drop regression), subquery-LHS IN, `IN (VALUES)`, nested IS, and the join unary-plus predicate-drop fix.
- `validation/row_values.rs` — 11 unit tests for the static misuse walker.

## Deferred (documented on #5790)

- 15.2–15.5 (vector-size mismatch errors concealed by UPDATE/DELETE/INSERT/DETACH contexts)
- 16.1–16.5, 30.1–30.3 (`UPDATE ... SET (a,b,c) = (SELECT ...)` tuple assignment, incl. triggers/window functions)
- 18.2/18.5 (`(VALUES(x,y))` as a correlated expression — needs correlated VALUES row resolution)
- 23.100/23.110 (column collation priority: a column's implicit BINARY collation must win over the right operand's declared collation)
- 24.100 (constant folding of `CAST(literal AS type)` discards the CAST's affinity; fixing requires changing the optimizer's fold strategy)
- 28.10 (sub-select column-count error surfaced from trigger bodies)
- 34.5 (EXPLAIN QUERY PLAN output shape)

## Caveats

- `cargo clippy --all-targets` has pre-existing failures in untouched bench/test files (`random_range` rand API mismatch from #5689) and pre-existing warnings; no new warnings introduced in touched files.
- `cargo fmt` is not clean workspace-wide at baseline; all files touched by this PR are fmt-clean.

Part of #5790

🤖 Generated with [Claude Code](https://claude.com/claude-code)