### PR TITLE
fix(parser): parse IN/NOT IN as a composable left-associative binary operator

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -92,19 +92,126 @@ impl<'arena> ArenaParser<'arena> {
     }
 
     /// Parse comparison expression.
+    ///
+    /// Per SQLite, all operators in this tier (=, <, >, IS, IN, BETWEEN, LIKE,
+    /// ISNULL, NOTNULL, ...) are left-associative and composable, so they chain:
+    /// `1 IN (1) NOT IN (SELECT 2)` parses as `(1 IN (1)) NOT IN (SELECT 2)`.
+    /// Additionally, IN's right operand is syntactically closed (a parenthesized
+    /// list/subquery), so a tighter-binding operator that follows an IN node takes
+    /// the whole IN expression as its left operand:
+    /// `1 IN (SELECT 1) + 1` parses as `(1 IN (SELECT 1)) + 1`.
     fn parse_comparison_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
         let mut left = self.parse_additive_expression()?;
 
-        // Check for IN, BETWEEN, LIKE operators
-        if self.peek_keyword(Keyword::Not) {
-            let saved_pos = self.position;
-            self.advance();
+        loop {
+            // Check for IN, BETWEEN, LIKE operators
+            if self.peek_keyword(Keyword::Not) {
+                let saved_pos = self.position;
+                self.advance();
 
-            if self.peek_keyword(Keyword::In) {
+                if self.peek_keyword(Keyword::In) {
+                    self.consume_keyword(Keyword::In)?;
+                    self.expect_token(Token::LParen)?;
+
+                    // Check for parenthesized subqueries like NOT IN ((SELECT ...))
+                    let (is_subquery_through_parens, extra_paren_depth) =
+                        self.peek_select_through_parens();
+
+                    if self.peek_keyword(Keyword::Select)
+                        || self.peek_keyword(Keyword::Values)
+                        || is_subquery_through_parens
+                    {
+                        // Consume any extra opening parentheses
+                        for _ in 0..extra_paren_depth {
+                            self.expect_token(Token::LParen)?;
+                        }
+
+                        let subquery = self.parse_select_statement()?;
+
+                        // Consume matching closing parentheses
+                        for _ in 0..extra_paren_depth {
+                            self.expect_token(Token::RParen)?;
+                        }
+                        self.expect_token(Token::RParen)?;
+                        let left_ref = self.arena.alloc(left);
+                        left = Expression::Extended(self.arena.alloc(ExtendedExpr::In {
+                            expr: left_ref,
+                            subquery,
+                            negated: true,
+                        }));
+                    } else {
+                        let values = self.parse_expression_list()?;
+                        self.expect_token(Token::RParen)?;
+                        let left_ref = self.arena.alloc(left);
+                        left = Expression::Extended(self.arena.alloc(ExtendedExpr::InList {
+                            expr: left_ref,
+                            values,
+                            negated: true,
+                        }));
+                    }
+
+                    // IN's right operand is syntactically closed, so tighter-binding
+                    // operators that follow take the whole IN node as their left
+                    // operand (SQLite: `1 NOT IN (SELECT 1) + 1`).
+                    left = self.continue_higher_precedence_ops(left)?;
+                    continue;
+                } else if self.peek_keyword(Keyword::Between) {
+                    self.consume_keyword(Keyword::Between)?;
+                    let symmetric = self.try_consume_keyword(Keyword::Symmetric);
+                    if !symmetric {
+                        self.try_consume_keyword(Keyword::Asymmetric);
+                    }
+
+                    let low = self.parse_additive_expression()?;
+                    self.consume_keyword(Keyword::And)?;
+                    let high = self.parse_additive_expression()?;
+
+                    let left_ref = self.arena.alloc(left);
+                    let low_ref = self.arena.alloc(low);
+                    let high_ref = self.arena.alloc(high);
+
+                    left = Expression::Extended(self.arena.alloc(ExtendedExpr::Between {
+                        expr: left_ref,
+                        low: low_ref,
+                        high: high_ref,
+                        negated: true,
+                        symmetric,
+                    }));
+                    continue;
+                } else if self.peek_keyword(Keyword::Like) {
+                    self.consume_keyword(Keyword::Like)?;
+                    let pattern = self.parse_additive_expression()?;
+                    let escape: Option<&Expression<'arena>> = if self.peek_keyword(Keyword::Escape)
+                    {
+                        self.consume_keyword(Keyword::Escape)?;
+                        Some(self.arena.alloc(self.parse_additive_expression()?))
+                    } else {
+                        None
+                    };
+                    let left_ref = self.arena.alloc(left);
+                    let pattern_ref = self.arena.alloc(pattern);
+                    left = Expression::Extended(self.arena.alloc(ExtendedExpr::Like {
+                        expr: left_ref,
+                        pattern: pattern_ref,
+                        negated: true,
+                        escape,
+                    }));
+                    continue;
+                } else if self.peek_keyword(Keyword::Null) {
+                    // SQLite compatibility: "expr NOT NULL" (without IS) is equivalent to "expr IS NOT NULL"
+                    self.consume_keyword(Keyword::Null)?;
+                    let left_ref = self.arena.alloc(left);
+                    left = Expression::IsNull { expr: left_ref, negated: true };
+                    continue;
+                } else {
+                    self.position = saved_pos;
+                    break;
+                }
+            } else if self.peek_keyword(Keyword::In) {
                 self.consume_keyword(Keyword::In)?;
                 self.expect_token(Token::LParen)?;
 
-                // Check for parenthesized subqueries like NOT IN ((SELECT ...))
+                // Check for parenthesized subqueries like IN ((SELECT ...))
                 let (is_subquery_through_parens, extra_paren_depth) =
                     self.peek_select_through_parens();
 
@@ -125,21 +232,27 @@ impl<'arena> ArenaParser<'arena> {
                     }
                     self.expect_token(Token::RParen)?;
                     let left_ref = self.arena.alloc(left);
-                    return Ok(Expression::Extended(self.arena.alloc(ExtendedExpr::In {
+                    left = Expression::Extended(self.arena.alloc(ExtendedExpr::In {
                         expr: left_ref,
                         subquery,
-                        negated: true,
-                    })));
+                        negated: false,
+                    }));
                 } else {
                     let values = self.parse_expression_list()?;
                     self.expect_token(Token::RParen)?;
                     let left_ref = self.arena.alloc(left);
-                    return Ok(Expression::Extended(self.arena.alloc(ExtendedExpr::InList {
+                    left = Expression::Extended(self.arena.alloc(ExtendedExpr::InList {
                         expr: left_ref,
                         values,
-                        negated: true,
-                    })));
+                        negated: false,
+                    }));
                 }
+
+                // IN's right operand is syntactically closed, so tighter-binding
+                // operators that follow take the whole IN node as their left
+                // operand (SQLite: `1 IN (SELECT 1) + 1` = `(1 IN (SELECT 1)) + 1`).
+                left = self.continue_higher_precedence_ops(left)?;
+                continue;
             } else if self.peek_keyword(Keyword::Between) {
                 self.consume_keyword(Keyword::Between)?;
                 let symmetric = self.try_consume_keyword(Keyword::Symmetric);
@@ -155,13 +268,14 @@ impl<'arena> ArenaParser<'arena> {
                 let low_ref = self.arena.alloc(low);
                 let high_ref = self.arena.alloc(high);
 
-                return Ok(Expression::Extended(self.arena.alloc(ExtendedExpr::Between {
+                left = Expression::Extended(self.arena.alloc(ExtendedExpr::Between {
                     expr: left_ref,
                     low: low_ref,
                     high: high_ref,
-                    negated: true,
+                    negated: false,
                     symmetric,
-                })));
+                }));
+                continue;
             } else if self.peek_keyword(Keyword::Like) {
                 self.consume_keyword(Keyword::Like)?;
                 let pattern = self.parse_additive_expression()?;
@@ -173,249 +287,237 @@ impl<'arena> ArenaParser<'arena> {
                 };
                 let left_ref = self.arena.alloc(left);
                 let pattern_ref = self.arena.alloc(pattern);
-                return Ok(Expression::Extended(self.arena.alloc(ExtendedExpr::Like {
+                left = Expression::Extended(self.arena.alloc(ExtendedExpr::Like {
                     expr: left_ref,
                     pattern: pattern_ref,
-                    negated: true,
+                    negated: false,
                     escape,
-                })));
-            } else if self.peek_keyword(Keyword::Null) {
-                // SQLite compatibility: "expr NOT NULL" (without IS) is equivalent to "expr IS NOT NULL"
-                self.consume_keyword(Keyword::Null)?;
-                let left_ref = self.arena.alloc(left);
-                return Ok(Expression::IsNull { expr: left_ref, negated: true });
-            } else {
-                self.position = saved_pos;
+                }));
+                continue;
             }
-        } else if self.peek_keyword(Keyword::In) {
-            self.consume_keyword(Keyword::In)?;
-            self.expect_token(Token::LParen)?;
 
-            // Check for parenthesized subqueries like IN ((SELECT ...))
-            let (is_subquery_through_parens, extra_paren_depth) = self.peek_select_through_parens();
+            // Check for comparison operators
+            let is_comparison = match self.peek() {
+                Token::Symbol('=') | Token::Symbol('<') | Token::Symbol('>') => true,
+                Token::Operator(s) => matches!(
+                    s,
+                    MultiCharOperator::LessEqual
+                        | MultiCharOperator::GreaterEqual
+                        | MultiCharOperator::NotEqual
+                        | MultiCharOperator::NotEqualAlt
+                        | MultiCharOperator::DoubleEqual
+                        | MultiCharOperator::CosineDistance
+                        | MultiCharOperator::NegativeInnerProduct
+                        | MultiCharOperator::L2Distance
+                ),
+                _ => false,
+            };
 
-            if self.peek_keyword(Keyword::Select)
-                || self.peek_keyword(Keyword::Values)
-                || is_subquery_through_parens
-            {
-                // Consume any extra opening parentheses
-                for _ in 0..extra_paren_depth {
+            if is_comparison {
+                let op = match self.peek() {
+                    Token::Symbol('=') => BinaryOperator::Equal,
+                    Token::Symbol('<') => BinaryOperator::LessThan,
+                    Token::Symbol('>') => BinaryOperator::GreaterThan,
+                    Token::Operator(s) => match s {
+                        MultiCharOperator::LessEqual => BinaryOperator::LessThanOrEqual,
+                        MultiCharOperator::GreaterEqual => BinaryOperator::GreaterThanOrEqual,
+                        MultiCharOperator::NotEqual | MultiCharOperator::NotEqualAlt => {
+                            BinaryOperator::NotEqual
+                        }
+                        // SQLite compatibility: == is a synonym for =
+                        MultiCharOperator::DoubleEqual => BinaryOperator::Equal,
+                        // Vector distance operators (pgvector compatible)
+                        MultiCharOperator::CosineDistance => BinaryOperator::CosineDistance,
+                        MultiCharOperator::NegativeInnerProduct => {
+                            BinaryOperator::NegativeInnerProduct
+                        }
+                        MultiCharOperator::L2Distance => BinaryOperator::L2Distance,
+                        _ => {
+                            return Err(ParseError {
+                                message: "Unexpected || operator in comparison".to_string(),
+                            })
+                        }
+                    },
+                    _ => unreachable!(),
+                };
+                self.advance();
+
+                // Check for quantified comparison (ALL, ANY, SOME)
+                if self.peek_keyword(Keyword::All)
+                    || self.peek_keyword(Keyword::Any)
+                    || self.peek_keyword(Keyword::Some)
+                {
+                    let quantifier = if self.try_consume_keyword(Keyword::All) {
+                        Quantifier::All
+                    } else if self.try_consume_keyword(Keyword::Any) {
+                        Quantifier::Any
+                    } else {
+                        self.consume_keyword(Keyword::Some)?;
+                        Quantifier::Some
+                    };
+
                     self.expect_token(Token::LParen)?;
-                }
-
-                let subquery = self.parse_select_statement()?;
-
-                // Consume matching closing parentheses
-                for _ in 0..extra_paren_depth {
+                    let subquery = self.parse_select_statement()?;
                     self.expect_token(Token::RParen)?;
+
+                    let left_ref = self.arena.alloc(left);
+                    left = Expression::Extended(self.arena.alloc(
+                        ExtendedExpr::QuantifiedComparison {
+                            expr: left_ref,
+                            op,
+                            quantifier,
+                            subquery,
+                        },
+                    ));
+                    continue;
                 }
-                self.expect_token(Token::RParen)?;
+
+                let right = self.parse_additive_expression()?;
                 let left_ref = self.arena.alloc(left);
-                return Ok(Expression::Extended(self.arena.alloc(ExtendedExpr::In {
-                    expr: left_ref,
-                    subquery,
-                    negated: false,
-                })));
-            } else {
-                let values = self.parse_expression_list()?;
-                self.expect_token(Token::RParen)?;
-                let left_ref = self.arena.alloc(left);
-                return Ok(Expression::Extended(self.arena.alloc(ExtendedExpr::InList {
-                    expr: left_ref,
-                    values,
-                    negated: false,
-                })));
-            }
-        } else if self.peek_keyword(Keyword::Between) {
-            self.consume_keyword(Keyword::Between)?;
-            let symmetric = self.try_consume_keyword(Keyword::Symmetric);
-            if !symmetric {
-                self.try_consume_keyword(Keyword::Asymmetric);
+                let right_ref = self.arena.alloc(right);
+                left = Expression::BinaryOp { op, left: left_ref, right: right_ref };
+                continue;
             }
 
-            let low = self.parse_additive_expression()?;
-            self.consume_keyword(Keyword::And)?;
-            let high = self.parse_additive_expression()?;
+            // Check for IS NULL / IS NOT NULL / IS [NOT] DISTINCT FROM / IS [NOT] TRUE/FALSE/UNKNOWN
+            if self.peek_keyword(Keyword::Is) {
+                self.consume_keyword(Keyword::Is)?;
+                let negated = self.try_consume_keyword(Keyword::Not);
 
-            let left_ref = self.arena.alloc(left);
-            let low_ref = self.arena.alloc(low);
-            let high_ref = self.arena.alloc(high);
-
-            return Ok(Expression::Extended(self.arena.alloc(ExtendedExpr::Between {
-                expr: left_ref,
-                low: low_ref,
-                high: high_ref,
-                negated: false,
-                symmetric,
-            })));
-        } else if self.peek_keyword(Keyword::Like) {
-            self.consume_keyword(Keyword::Like)?;
-            let pattern = self.parse_additive_expression()?;
-            let escape: Option<&Expression<'arena>> = if self.peek_keyword(Keyword::Escape) {
-                self.consume_keyword(Keyword::Escape)?;
-                Some(self.arena.alloc(self.parse_additive_expression()?))
-            } else {
-                None
-            };
-            let left_ref = self.arena.alloc(left);
-            let pattern_ref = self.arena.alloc(pattern);
-            return Ok(Expression::Extended(self.arena.alloc(ExtendedExpr::Like {
-                expr: left_ref,
-                pattern: pattern_ref,
-                negated: false,
-                escape,
-            })));
-        }
-
-        // Check for comparison operators
-        let is_comparison = match self.peek() {
-            Token::Symbol('=') | Token::Symbol('<') | Token::Symbol('>') => true,
-            Token::Operator(s) => matches!(
-                s,
-                MultiCharOperator::LessEqual
-                    | MultiCharOperator::GreaterEqual
-                    | MultiCharOperator::NotEqual
-                    | MultiCharOperator::NotEqualAlt
-                    | MultiCharOperator::DoubleEqual
-                    | MultiCharOperator::CosineDistance
-                    | MultiCharOperator::NegativeInnerProduct
-                    | MultiCharOperator::L2Distance
-            ),
-            _ => false,
-        };
-
-        if is_comparison {
-            let op = match self.peek() {
-                Token::Symbol('=') => BinaryOperator::Equal,
-                Token::Symbol('<') => BinaryOperator::LessThan,
-                Token::Symbol('>') => BinaryOperator::GreaterThan,
-                Token::Operator(s) => match s {
-                    MultiCharOperator::LessEqual => BinaryOperator::LessThanOrEqual,
-                    MultiCharOperator::GreaterEqual => BinaryOperator::GreaterThanOrEqual,
-                    MultiCharOperator::NotEqual | MultiCharOperator::NotEqualAlt => {
-                        BinaryOperator::NotEqual
-                    }
-                    // SQLite compatibility: == is a synonym for =
-                    MultiCharOperator::DoubleEqual => BinaryOperator::Equal,
-                    // Vector distance operators (pgvector compatible)
-                    MultiCharOperator::CosineDistance => BinaryOperator::CosineDistance,
-                    MultiCharOperator::NegativeInnerProduct => BinaryOperator::NegativeInnerProduct,
-                    MultiCharOperator::L2Distance => BinaryOperator::L2Distance,
-                    _ => {
-                        return Err(ParseError {
-                            message: "Unexpected || operator in comparison".to_string(),
-                        })
-                    }
-                },
-                _ => unreachable!(),
-            };
-            self.advance();
-
-            // Check for quantified comparison (ALL, ANY, SOME)
-            if self.peek_keyword(Keyword::All)
-                || self.peek_keyword(Keyword::Any)
-                || self.peek_keyword(Keyword::Some)
-            {
-                let quantifier = if self.try_consume_keyword(Keyword::All) {
-                    Quantifier::All
-                } else if self.try_consume_keyword(Keyword::Any) {
-                    Quantifier::Any
+                // Check for DISTINCT FROM (SQL:1999), NULL, TRUE, FALSE, or UNKNOWN
+                if self.peek_keyword(Keyword::Distinct) {
+                    self.consume_keyword(Keyword::Distinct)?;
+                    self.expect_keyword(Keyword::From)?;
+                    let right = self.parse_additive_expression()?;
+                    let left_ref = self.arena.alloc(left);
+                    let right_ref = self.arena.alloc(right);
+                    left = Expression::IsDistinctFrom { left: left_ref, right: right_ref, negated };
+                } else if self.peek_keyword(Keyword::True) {
+                    self.consume_keyword(Keyword::True)?;
+                    let left_ref = self.arena.alloc(left);
+                    left = Expression::IsTruthValue {
+                        expr: left_ref,
+                        truth_value: TruthValue::True,
+                        negated,
+                    };
+                } else if self.peek_keyword(Keyword::False) {
+                    self.consume_keyword(Keyword::False)?;
+                    let left_ref = self.arena.alloc(left);
+                    left = Expression::IsTruthValue {
+                        expr: left_ref,
+                        truth_value: TruthValue::False,
+                        negated,
+                    };
+                } else if self.peek_keyword(Keyword::Unknown) {
+                    self.consume_keyword(Keyword::Unknown)?;
+                    let left_ref = self.arena.alloc(left);
+                    left = Expression::IsTruthValue {
+                        expr: left_ref,
+                        truth_value: TruthValue::Unknown,
+                        negated,
+                    };
+                } else if self.peek_keyword(Keyword::Null) {
+                    // IS NULL / IS NOT NULL
+                    self.consume_keyword(Keyword::Null)?;
+                    let left_ref = self.arena.alloc(left);
+                    left = Expression::IsNull { expr: left_ref, negated };
                 } else {
-                    self.consume_keyword(Keyword::Some)?;
-                    Quantifier::Some
-                };
-
-                self.expect_token(Token::LParen)?;
-                let subquery = self.parse_select_statement()?;
-                self.expect_token(Token::RParen)?;
-
-                let left_ref = self.arena.alloc(left);
-                return Ok(Expression::Extended(self.arena.alloc(
-                    ExtendedExpr::QuantifiedComparison { expr: left_ref, op, quantifier, subquery },
-                )));
+                    // SQLite compatibility: IS <expr> - compare using IS semantics (NULL-safe equals)
+                    // This handles cases like `expr IS 0` or `expr IS 1`
+                    let right = self.parse_additive_expression()?;
+                    let left_ref = self.arena.alloc(left);
+                    let right_ref = self.arena.alloc(right);
+                    // IS is equivalent to IS NOT DISTINCT FROM (NULL-safe equals)
+                    // IS NOT is equivalent to IS DISTINCT FROM (NULL-safe not equals)
+                    left = Expression::IsDistinctFrom {
+                        left: left_ref,
+                        right: right_ref,
+                        negated: !negated,
+                    };
+                }
+                continue;
             }
 
-            let right = self.parse_additive_expression()?;
-            let left_ref = self.arena.alloc(left);
-            let right_ref = self.arena.alloc(right);
-            left = Expression::BinaryOp { op, left: left_ref, right: right_ref };
-        }
-
-        // Check for IS NULL / IS NOT NULL / IS [NOT] DISTINCT FROM / IS [NOT] TRUE/FALSE/UNKNOWN
-        if self.peek_keyword(Keyword::Is) {
-            self.consume_keyword(Keyword::Is)?;
-            let negated = self.try_consume_keyword(Keyword::Not);
-
-            // Check for DISTINCT FROM (SQL:1999), NULL, TRUE, FALSE, or UNKNOWN
-            if self.peek_keyword(Keyword::Distinct) {
-                self.consume_keyword(Keyword::Distinct)?;
-                self.expect_keyword(Keyword::From)?;
-                let right = self.parse_additive_expression()?;
-                let left_ref = self.arena.alloc(left);
-                let right_ref = self.arena.alloc(right);
-                left = Expression::IsDistinctFrom { left: left_ref, right: right_ref, negated };
-            } else if self.peek_keyword(Keyword::True) {
-                self.consume_keyword(Keyword::True)?;
-                let left_ref = self.arena.alloc(left);
-                left = Expression::IsTruthValue {
-                    expr: left_ref,
-                    truth_value: TruthValue::True,
-                    negated,
-                };
-            } else if self.peek_keyword(Keyword::False) {
-                self.consume_keyword(Keyword::False)?;
-                let left_ref = self.arena.alloc(left);
-                left = Expression::IsTruthValue {
-                    expr: left_ref,
-                    truth_value: TruthValue::False,
-                    negated,
-                };
-            } else if self.peek_keyword(Keyword::Unknown) {
-                self.consume_keyword(Keyword::Unknown)?;
-                let left_ref = self.arena.alloc(left);
-                left = Expression::IsTruthValue {
-                    expr: left_ref,
-                    truth_value: TruthValue::Unknown,
-                    negated,
-                };
-            } else if self.peek_keyword(Keyword::Null) {
-                // IS NULL / IS NOT NULL
-                self.consume_keyword(Keyword::Null)?;
-                let left_ref = self.arena.alloc(left);
-                left = Expression::IsNull { expr: left_ref, negated };
-            } else {
-                // SQLite compatibility: IS <expr> - compare using IS semantics (NULL-safe equals)
-                // This handles cases like `expr IS 0` or `expr IS 1`
-                let right = self.parse_additive_expression()?;
-                let left_ref = self.arena.alloc(left);
-                let right_ref = self.arena.alloc(right);
-                // IS is equivalent to IS NOT DISTINCT FROM (NULL-safe equals)
-                // IS NOT is equivalent to IS DISTINCT FROM (NULL-safe not equals)
-                left = Expression::IsDistinctFrom {
-                    left: left_ref,
-                    right: right_ref,
-                    negated: !negated,
-                };
-            }
-        }
-
-        // SQLite compatibility: ISNULL and NOTNULL as postfix operators
-        // These are equivalent to IS NULL and IS NOT NULL respectively
-        // Loop to support chaining: `x NOTNULL NOTNULL` → `(x IS NOT NULL) IS NOT NULL`
-        loop {
+            // SQLite compatibility: ISNULL and NOTNULL as postfix operators
+            // These are equivalent to IS NULL and IS NOT NULL respectively
+            // The enclosing loop supports chaining: `x NOTNULL NOTNULL`
             if self.peek_keyword(Keyword::Isnull) {
                 self.consume_keyword(Keyword::Isnull)?;
                 let left_ref = self.arena.alloc(left);
                 left = Expression::IsNull { expr: left_ref, negated: false };
-            } else if self.peek_keyword(Keyword::Notnull) {
+                continue;
+            }
+            if self.peek_keyword(Keyword::Notnull) {
                 self.consume_keyword(Keyword::Notnull)?;
                 let left_ref = self.arena.alloc(left);
                 left = Expression::IsNull { expr: left_ref, negated: true };
-            } else {
-                break;
+                continue;
             }
+
+            // No more operators at this precedence tier
+            break;
         }
 
+        Ok(left)
+    }
+
+    /// Continue parsing tighter-binding binary operators (multiplicative, concat,
+    /// additive) with an already-parsed left operand.
+    ///
+    /// Used after an IN/NOT IN node: its right operand is syntactically closed
+    /// (a parenthesized list/subquery), so per SQLite a tighter-binding operator
+    /// that follows takes the entire IN expression as its left operand:
+    /// `1 IN (SELECT 1) + 1` parses as `(1 IN (SELECT 1)) + 1`.
+    ///
+    /// Each operator's right operand is parsed at the next-tighter tier, so
+    /// relative precedence among these operators is preserved
+    /// (e.g. `x IN (1) + 2 * 3` parses as `(x IN (1)) + (2 * 3)`).
+    ///
+    /// Note: the arena parser has no shift/bitwise tiers; expressions using
+    /// those operators fail here and fall back to the standard parser.
+    fn continue_higher_precedence_ops(
+        &mut self,
+        mut left: Expression<'arena>,
+    ) -> Result<Expression<'arena>, ParseError> {
+        loop {
+            let (op, right) = match self.peek() {
+                // Multiplicative tier: right operand at unary tier
+                Token::Symbol('*') => {
+                    self.advance();
+                    (BinaryOperator::Multiply, self.parse_unary_expression()?)
+                }
+                Token::Symbol('/') => {
+                    self.advance();
+                    (BinaryOperator::Divide, self.parse_unary_expression()?)
+                }
+                Token::Symbol('%') => {
+                    self.advance();
+                    (BinaryOperator::Modulo, self.parse_unary_expression()?)
+                }
+                Token::Keyword { keyword: Keyword::Div, .. } => {
+                    self.advance();
+                    (BinaryOperator::IntegerDivide, self.parse_unary_expression()?)
+                }
+                // Concat tier: right operand at multiplicative tier
+                Token::Operator(MultiCharOperator::Concat) => {
+                    self.advance();
+                    (BinaryOperator::Concat, self.parse_multiplicative_expression()?)
+                }
+                // Additive tier: right operand at concat tier
+                Token::Symbol('+') => {
+                    self.advance();
+                    (BinaryOperator::Plus, self.parse_concat_expression()?)
+                }
+                Token::Symbol('-') => {
+                    self.advance();
+                    (BinaryOperator::Minus, self.parse_concat_expression()?)
+                }
+                _ => break,
+            };
+            let left_ref = self.arena.alloc(left);
+            let right_ref = self.arena.alloc(right);
+            left = Expression::BinaryOp { op, left: left_ref, right: right_ref };
+        }
         Ok(left)
     }
 

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -216,26 +216,260 @@ impl Parser {
 
     /// Parse comparison expression (handles =, <, >, <=, >=, !=, <>, IN, BETWEEN, LIKE, IS NULL)
     /// These operators have lower precedence than arithmetic operators
+    ///
+    /// Per SQLite, all operators in this tier (=, <, >, IS, IN, BETWEEN, LIKE, GLOB,
+    /// ISNULL, NOTNULL, ...) are left-associative and composable, so they chain:
+    /// `1 IN (1) NOT IN (SELECT 2)` parses as `(1 IN (1)) NOT IN (SELECT 2)`.
+    /// Additionally, IN's right operand is syntactically closed (a parenthesized
+    /// list/subquery or a table name), so a tighter-binding operator that follows an
+    /// IN node takes the whole IN expression as its left operand:
+    /// `1 IN (SELECT 1) + 1` parses as `(1 IN (SELECT 1)) + 1`.
     pub(super) fn parse_comparison_expression(
         &mut self,
     ) -> Result<vibesql_ast::Expression, ParseError> {
         let mut left = self.parse_shift_expression()?;
 
-        // Check for IN operator (including NOT IN) and BETWEEN (including NOT BETWEEN)
-        if self.peek_keyword(Keyword::Not) {
-            // Peek ahead to see if it's "NOT IN" or "NOT BETWEEN"
-            let saved_pos = self.position;
-            self.advance(); // consume NOT
+        loop {
+            // Check for IN operator (including NOT IN) and BETWEEN (including NOT BETWEEN)
+            if self.peek_keyword(Keyword::Not) {
+                // Peek ahead to see if it's "NOT IN" or "NOT BETWEEN"
+                let saved_pos = self.position;
+                self.advance(); // consume NOT
 
-            if self.peek_keyword(Keyword::In) {
-                // It's NOT IN
+                if self.peek_keyword(Keyword::In) {
+                    // It's NOT IN
+                    self.consume_keyword(Keyword::In)?;
+
+                    // Check if it's NOT IN table_name (SQLite syntax) or NOT IN (...)
+                    if self.peek() != &Token::LParen {
+                        // SQLite compatibility: NOT IN table_name is equivalent to NOT IN (SELECT *
+                        // FROM table_name) Parse the table name and expand to a
+                        // subquery
+                        let table_ref = self.parse_table_ref()?;
+                        let table_name = table_ref.full_name();
+                        let quoted = table_ref.is_any_quoted();
+
+                        // Create a SELECT * FROM table_name subquery
+                        let subquery = vibesql_ast::SelectStmt {
+                            with_clause: None,
+                            distinct: false,
+                            select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
+                            into_table: None,
+                            into_variables: None,
+                            from: Some(vibesql_ast::FromClause::Table {
+                                index_hint: None,
+                                name: table_name,
+                                alias: None,
+                                column_aliases: None,
+                                quoted,
+                            }),
+                            where_clause: None,
+                            group_by: None,
+                            having: None,
+                            window_definitions: None,
+                            order_by: None,
+                            limit: None,
+                            offset: None,
+                            set_operation: None,
+                            values: None,
+                        };
+
+                        left = vibesql_ast::Expression::In {
+                            expr: Box::new(left),
+                            subquery: Box::new(subquery),
+                            negated: true,
+                        };
+                    } else {
+                        // Standard syntax: NOT IN (...)
+                        self.expect_token(Token::LParen)?;
+
+                        // Check if it's a subquery (SELECT ...) or a value list
+                        // Also check for parenthesized subqueries like NOT IN ((SELECT ...))
+                        let (is_subquery_through_parens, extra_paren_depth) =
+                            self.peek_select_through_parens();
+
+                        if self.peek_keyword(Keyword::Select)
+                            || self.peek_keyword(Keyword::Values)
+                            || self.peek_keyword(Keyword::With)
+                            || is_subquery_through_parens
+                        {
+                            // It's a subquery: NOT IN (SELECT ...) or NOT IN ((SELECT ...))
+                            // Consume any extra opening parentheses
+                            for _ in 0..extra_paren_depth {
+                                self.expect_token(Token::LParen)?;
+                            }
+
+                            let subquery = self.parse_select_statement()?;
+
+                            // Consume matching closing parentheses
+                            for _ in 0..extra_paren_depth {
+                                self.expect_token(Token::RParen)?;
+                            }
+                            self.expect_token(Token::RParen)?;
+
+                            // Don't return - assign to left and continue to check for IS NULL
+                            left = vibesql_ast::Expression::In {
+                                expr: Box::new(left),
+                                subquery: Box::new(subquery),
+                                negated: true,
+                            };
+                        } else {
+                            // It's a value list: NOT IN (val1, val2, ...)
+                            let values = self.parse_expression_list()?;
+                            self.expect_token(Token::RParen)?;
+
+                            // Empty IN lists are allowed per SQL:1999 (evaluates to TRUE for NOT IN)
+                            // Don't return - assign to left and continue to check for IS NULL
+                            left = vibesql_ast::Expression::InList {
+                                expr: Box::new(left),
+                                values,
+                                negated: true,
+                            };
+                        }
+                    }
+
+                    // IN's right operand is syntactically closed, so tighter-binding
+                    // operators that follow take the whole IN node as their left
+                    // operand (SQLite: `1 NOT IN (SELECT 1) << 2`).
+                    left = self.continue_higher_precedence_ops(left)?;
+                    continue;
+                } else if self.peek_keyword(Keyword::Between) {
+                    // It's NOT BETWEEN
+                    self.consume_keyword(Keyword::Between)?;
+
+                    // Check for optional ASYMMETRIC or SYMMETRIC
+                    let symmetric = if self.peek_keyword(Keyword::Symmetric) {
+                        self.consume_keyword(Keyword::Symmetric)?;
+                        true
+                    } else {
+                        // ASYMMETRIC is default, but can be explicitly specified
+                        if self.peek_keyword(Keyword::Asymmetric) {
+                            self.consume_keyword(Keyword::Asymmetric)?;
+                        }
+                        false
+                    };
+
+                    // Parse low AND high
+                    let low = self.parse_shift_expression()?;
+                    self.consume_keyword(Keyword::And)?;
+                    let high = self.parse_shift_expression()?;
+
+                    left = vibesql_ast::Expression::Between {
+                        expr: Box::new(left),
+                        low: Box::new(low),
+                        high: Box::new(high),
+                        negated: true,
+                        symmetric,
+                    };
+                    continue;
+                } else if self.peek_keyword(Keyword::Like) {
+                    // It's NOT LIKE
+                    self.consume_keyword(Keyword::Like)?;
+
+                    // Parse pattern expression
+                    let pattern = self.parse_shift_expression()?;
+
+                    // Check for optional ESCAPE clause
+                    let escape = if self.peek_keyword(Keyword::Escape) {
+                        self.consume_keyword(Keyword::Escape)?;
+                        Some(Box::new(self.parse_shift_expression()?))
+                    } else {
+                        None
+                    };
+
+                    left = vibesql_ast::Expression::Like {
+                        expr: Box::new(left),
+                        pattern: Box::new(pattern),
+                        negated: true,
+                        escape,
+                    };
+                    continue;
+                } else if self.peek_keyword(Keyword::Glob) {
+                    // It's NOT GLOB (SQLite)
+                    self.consume_keyword(Keyword::Glob)?;
+
+                    // Parse pattern expression
+                    let pattern = self.parse_shift_expression()?;
+
+                    // Check for optional ESCAPE clause
+                    let escape = if self.peek_keyword(Keyword::Escape) {
+                        self.consume_keyword(Keyword::Escape)?;
+                        Some(Box::new(self.parse_shift_expression()?))
+                    } else {
+                        None
+                    };
+
+                    left = vibesql_ast::Expression::Glob {
+                        expr: Box::new(left),
+                        pattern: Box::new(pattern),
+                        negated: true,
+                        escape,
+                    };
+                    continue;
+                } else if self.peek_keyword(Keyword::Null) {
+                    // SQLite compatibility: "expr NOT NULL" (without IS) is equivalent to "expr IS NOT
+                    // NULL" BUT: In column definition context, "DEFAULT expr NOT NULL"
+                    // should parse NOT NULL as a column constraint, not as part of the
+                    // expression.
+                    //
+                    // Heuristic: If the left expression is a simple literal and what follows NULL
+                    // could be a column constraint context (`,` `)` or constraint keyword), then
+                    // treat NOT NULL as a column constraint, not an operator.
+                    // This handles: DEFAULT 'table' NOT NULL
+                    // But allows: WHERE col NOT NULL (col is not a literal)
+                    self.consume_keyword(Keyword::Null)?;
+
+                    // Check if left is a literal (in which case NOT NULL as an operator is semantically
+                    // odd)
+                    let left_is_literal = matches!(&left, vibesql_ast::Expression::Literal(_));
+
+                    // Check what comes after NULL
+                    let next_could_be_column_constraint = match self.peek() {
+                        Token::Comma | Token::RParen => true,
+                        Token::Keyword { keyword: kw, .. } => matches!(
+                            kw,
+                            // Column constraint keywords that can follow NOT NULL
+                            Keyword::Check
+                                | Keyword::Unique
+                                | Keyword::Primary
+                                | Keyword::References
+                                | Keyword::Collate
+                                | Keyword::Default
+                                | Keyword::On
+                                | Keyword::Generated
+                                | Keyword::AutoIncrement
+                                | Keyword::Constraint
+                        ),
+                        Token::Semicolon | Token::Eof => false, // At end of query, treat as operator
+                        _ => false,
+                    };
+
+                    if left_is_literal && next_could_be_column_constraint {
+                        // Likely in column definition: DEFAULT 'value' NOT NULL
+                        // Restore position - NOT NULL should be parsed as column constraint
+                        self.position = saved_pos;
+                        break;
+                    } else {
+                        // General case: expr NOT NULL is an operator
+                        left =
+                            vibesql_ast::Expression::IsNull { expr: Box::new(left), negated: true };
+                        continue;
+                    }
+                } else {
+                    // Not "NOT IN", "NOT BETWEEN", "NOT LIKE", "NOT GLOB", or "NOT NULL", restore
+                    // position and stop scanning this tier. Note: NOT EXISTS is handled in
+                    // parse_primary_expression()
+                    self.position = saved_pos;
+                    break;
+                }
+            } else if self.peek_keyword(Keyword::In) {
+                // It's IN (not negated)
                 self.consume_keyword(Keyword::In)?;
 
-                // Check if it's NOT IN table_name (SQLite syntax) or NOT IN (...)
+                // Check if it's IN table_name (SQLite syntax) or IN (...)
                 if self.peek() != &Token::LParen {
-                    // SQLite compatibility: NOT IN table_name is equivalent to NOT IN (SELECT *
-                    // FROM table_name) Parse the table name and expand to a
-                    // subquery
+                    // SQLite compatibility: IN table_name is equivalent to IN (SELECT * FROM
+                    // table_name) Parse the table name and expand to a subquery
                     let table_ref = self.parse_table_ref()?;
                     let table_name = table_ref.full_name();
                     let quoted = table_ref.is_any_quoted();
@@ -268,14 +502,14 @@ impl Parser {
                     left = vibesql_ast::Expression::In {
                         expr: Box::new(left),
                         subquery: Box::new(subquery),
-                        negated: true,
+                        negated: false,
                     };
                 } else {
-                    // Standard syntax: NOT IN (...)
+                    // Standard syntax: IN (...)
                     self.expect_token(Token::LParen)?;
 
                     // Check if it's a subquery (SELECT ...) or a value list
-                    // Also check for parenthesized subqueries like NOT IN ((SELECT ...))
+                    // Also check for parenthesized subqueries like IN ((SELECT ...))
                     let (is_subquery_through_parens, extra_paren_depth) =
                         self.peek_select_through_parens();
 
@@ -284,7 +518,7 @@ impl Parser {
                         || self.peek_keyword(Keyword::With)
                         || is_subquery_through_parens
                     {
-                        // It's a subquery: NOT IN (SELECT ...) or NOT IN ((SELECT ...))
+                        // It's a subquery: IN (SELECT ...) or IN ((SELECT ...))
                         // Consume any extra opening parentheses
                         for _ in 0..extra_paren_depth {
                             self.expect_token(Token::LParen)?;
@@ -302,24 +536,30 @@ impl Parser {
                         left = vibesql_ast::Expression::In {
                             expr: Box::new(left),
                             subquery: Box::new(subquery),
-                            negated: true,
+                            negated: false,
                         };
                     } else {
-                        // It's a value list: NOT IN (val1, val2, ...)
+                        // It's a value list: IN (val1, val2, ...)
                         let values = self.parse_expression_list()?;
                         self.expect_token(Token::RParen)?;
 
-                        // Empty IN lists are allowed per SQL:1999 (evaluates to TRUE for NOT IN)
+                        // Empty IN lists are allowed per SQL:1999 (evaluates to FALSE)
                         // Don't return - assign to left and continue to check for IS NULL
                         left = vibesql_ast::Expression::InList {
                             expr: Box::new(left),
                             values,
-                            negated: true,
+                            negated: false,
                         };
                     }
                 }
+
+                // IN's right operand is syntactically closed, so tighter-binding
+                // operators that follow take the whole IN node as their left
+                // operand (SQLite: `1 IN (SELECT 1) + 1` = `(1 IN (SELECT 1)) + 1`).
+                left = self.continue_higher_precedence_ops(left)?;
+                continue;
             } else if self.peek_keyword(Keyword::Between) {
-                // It's NOT BETWEEN
+                // It's BETWEEN (not negated)
                 self.consume_keyword(Keyword::Between)?;
 
                 // Check for optional ASYMMETRIC or SYMMETRIC
@@ -335,449 +575,309 @@ impl Parser {
                 };
 
                 // Parse low AND high
-                let low = self.parse_shift_expression()?;
+                let low = self.parse_additive_expression()?;
                 self.consume_keyword(Keyword::And)?;
-                let high = self.parse_shift_expression()?;
+                let high = self.parse_additive_expression()?;
 
-                // Don't return - assign to left and continue to check for IS NULL
                 left = vibesql_ast::Expression::Between {
                     expr: Box::new(left),
                     low: Box::new(low),
                     high: Box::new(high),
-                    negated: true,
+                    negated: false,
                     symmetric,
                 };
+                continue;
             } else if self.peek_keyword(Keyword::Like) {
-                // It's NOT LIKE
+                // It's LIKE (not negated)
                 self.consume_keyword(Keyword::Like)?;
 
                 // Parse pattern expression
-                let pattern = self.parse_shift_expression()?;
+                let pattern = self.parse_additive_expression()?;
 
                 // Check for optional ESCAPE clause
                 let escape = if self.peek_keyword(Keyword::Escape) {
                     self.consume_keyword(Keyword::Escape)?;
-                    Some(Box::new(self.parse_shift_expression()?))
+                    Some(Box::new(self.parse_additive_expression()?))
                 } else {
                     None
                 };
 
-                // Don't return - assign to left and continue to check for IS NULL
                 left = vibesql_ast::Expression::Like {
                     expr: Box::new(left),
                     pattern: Box::new(pattern),
-                    negated: true,
+                    negated: false,
                     escape,
                 };
+                continue;
             } else if self.peek_keyword(Keyword::Glob) {
-                // It's NOT GLOB (SQLite)
+                // It's GLOB (SQLite) (not negated)
                 self.consume_keyword(Keyword::Glob)?;
 
                 // Parse pattern expression
-                let pattern = self.parse_shift_expression()?;
+                let pattern = self.parse_additive_expression()?;
 
                 // Check for optional ESCAPE clause
                 let escape = if self.peek_keyword(Keyword::Escape) {
                     self.consume_keyword(Keyword::Escape)?;
-                    Some(Box::new(self.parse_shift_expression()?))
+                    Some(Box::new(self.parse_additive_expression()?))
                 } else {
                     None
                 };
 
-                // Don't return - assign to left and continue to check for IS NULL
                 left = vibesql_ast::Expression::Glob {
                     expr: Box::new(left),
                     pattern: Box::new(pattern),
-                    negated: true,
+                    negated: false,
                     escape,
                 };
-            } else if self.peek_keyword(Keyword::Null) {
-                // SQLite compatibility: "expr NOT NULL" (without IS) is equivalent to "expr IS NOT
-                // NULL" BUT: In column definition context, "DEFAULT expr NOT NULL"
-                // should parse NOT NULL as a column constraint, not as part of the
-                // expression.
-                //
-                // Heuristic: If the left expression is a simple literal and what follows NULL
-                // could be a column constraint context (`,` `)` or constraint keyword), then
-                // treat NOT NULL as a column constraint, not an operator.
-                // This handles: DEFAULT 'table' NOT NULL
-                // But allows: WHERE col NOT NULL (col is not a literal)
-                self.consume_keyword(Keyword::Null)?;
-
-                // Check if left is a literal (in which case NOT NULL as an operator is semantically
-                // odd)
-                let left_is_literal = matches!(&left, vibesql_ast::Expression::Literal(_));
-
-                // Check what comes after NULL
-                let next_could_be_column_constraint = match self.peek() {
-                    Token::Comma | Token::RParen => true,
-                    Token::Keyword { keyword: kw, .. } => matches!(
-                        kw,
-                        // Column constraint keywords that can follow NOT NULL
-                        Keyword::Check
-                            | Keyword::Unique
-                            | Keyword::Primary
-                            | Keyword::References
-                            | Keyword::Collate
-                            | Keyword::Default
-                            | Keyword::On
-                            | Keyword::Generated
-                            | Keyword::AutoIncrement
-                            | Keyword::Constraint
-                    ),
-                    Token::Semicolon | Token::Eof => false, // At end of query, treat as operator
-                    _ => false,
-                };
-
-                if left_is_literal && next_could_be_column_constraint {
-                    // Likely in column definition: DEFAULT 'value' NOT NULL
-                    // Restore position - NOT NULL should be parsed as column constraint
-                    self.position = saved_pos;
-                } else {
-                    // General case: expr NOT NULL is an operator
-                    return Ok(vibesql_ast::Expression::IsNull {
-                        expr: Box::new(left),
-                        negated: true,
-                    });
-                }
-            } else {
-                // Not "NOT IN", "NOT BETWEEN", "NOT LIKE", "NOT GLOB", or "NOT NULL", restore
-                // position and continue Note: NOT EXISTS is handled in
-                // parse_primary_expression()
-                self.position = saved_pos;
+                continue;
             }
-        } else if self.peek_keyword(Keyword::In) {
-            // It's IN (not negated)
-            self.consume_keyword(Keyword::In)?;
 
-            // Check if it's IN table_name (SQLite syntax) or IN (...)
-            if self.peek() != &Token::LParen {
-                // SQLite compatibility: IN table_name is equivalent to IN (SELECT * FROM
-                // table_name) Parse the table name and expand to a subquery
-                let table_ref = self.parse_table_ref()?;
-                let table_name = table_ref.full_name();
-                let quoted = table_ref.is_any_quoted();
+            // Check for comparison operators (both single-char and multi-char)
+            // Note: Exclude || (concat) operator which should be handled in additive expression
+            let is_comparison = match self.peek() {
+                Token::Symbol('=') | Token::Symbol('<') | Token::Symbol('>') => true,
+                Token::Operator(op) => !matches!(op, crate::token::MultiCharOperator::Concat),
+                _ => false,
+            };
 
-                // Create a SELECT * FROM table_name subquery
-                let subquery = vibesql_ast::SelectStmt {
-                    with_clause: None,
-                    distinct: false,
-                    select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
-                    into_table: None,
-                    into_variables: None,
-                    from: Some(vibesql_ast::FromClause::Table {
-                        index_hint: None,
-                        name: table_name,
-                        alias: None,
-                        column_aliases: None,
-                        quoted,
-                    }),
-                    where_clause: None,
-                    group_by: None,
-                    having: None,
-                    window_definitions: None,
-                    order_by: None,
-                    limit: None,
-                    offset: None,
-                    set_operation: None,
-                    values: None,
-                };
-
-                left = vibesql_ast::Expression::In {
-                    expr: Box::new(left),
-                    subquery: Box::new(subquery),
-                    negated: false,
-                };
-            } else {
-                // Standard syntax: IN (...)
-                self.expect_token(Token::LParen)?;
-
-                // Check if it's a subquery (SELECT ...) or a value list
-                // Also check for parenthesized subqueries like IN ((SELECT ...))
-                let (is_subquery_through_parens, extra_paren_depth) =
-                    self.peek_select_through_parens();
-
-                if self.peek_keyword(Keyword::Select)
-                    || self.peek_keyword(Keyword::Values)
-                    || self.peek_keyword(Keyword::With)
-                    || is_subquery_through_parens
-                {
-                    // It's a subquery: IN (SELECT ...) or IN ((SELECT ...))
-                    // Consume any extra opening parentheses
-                    for _ in 0..extra_paren_depth {
-                        self.expect_token(Token::LParen)?;
+            if is_comparison {
+                let op = match self.peek() {
+                    Token::Symbol('=') => vibesql_ast::BinaryOperator::Equal,
+                    Token::Symbol('<') => vibesql_ast::BinaryOperator::LessThan,
+                    Token::Symbol('>') => vibesql_ast::BinaryOperator::GreaterThan,
+                    Token::Operator(op) => {
+                        use crate::token::MultiCharOperator;
+                        match op {
+                            MultiCharOperator::LessEqual => {
+                                vibesql_ast::BinaryOperator::LessThanOrEqual
+                            }
+                            MultiCharOperator::GreaterEqual => {
+                                vibesql_ast::BinaryOperator::GreaterThanOrEqual
+                            }
+                            MultiCharOperator::NotEqual | MultiCharOperator::NotEqualAlt => {
+                                vibesql_ast::BinaryOperator::NotEqual
+                            }
+                            // SQLite compatibility: == is a synonym for =
+                            MultiCharOperator::DoubleEqual => vibesql_ast::BinaryOperator::Equal,
+                            // Vector distance operators (pgvector compatible)
+                            MultiCharOperator::CosineDistance => {
+                                vibesql_ast::BinaryOperator::CosineDistance
+                            }
+                            MultiCharOperator::NegativeInnerProduct => {
+                                vibesql_ast::BinaryOperator::NegativeInnerProduct
+                            }
+                            MultiCharOperator::L2Distance => {
+                                vibesql_ast::BinaryOperator::L2Distance
+                            }
+                            MultiCharOperator::Concat
+                            | MultiCharOperator::LeftShift
+                            | MultiCharOperator::RightShift
+                            | MultiCharOperator::JsonExtract
+                            | MultiCharOperator::JsonExtractText => {
+                                return Err(ParseError {
+                                    message: format!("Unexpected operator: {}", op),
+                                })
+                            }
+                        }
                     }
+                    _ => unreachable!(),
+                };
+                self.advance();
 
+                // Check for quantified comparison (ALL, ANY, SOME)
+                if self.peek_keyword(Keyword::All)
+                    || self.peek_keyword(Keyword::Any)
+                    || self.peek_keyword(Keyword::Some)
+                {
+                    let quantifier = if self.peek_keyword(Keyword::All) {
+                        self.consume_keyword(Keyword::All)?;
+                        vibesql_ast::Quantifier::All
+                    } else if self.peek_keyword(Keyword::Any) {
+                        self.consume_keyword(Keyword::Any)?;
+                        vibesql_ast::Quantifier::Any
+                    } else {
+                        self.consume_keyword(Keyword::Some)?;
+                        vibesql_ast::Quantifier::Some
+                    };
+
+                    // Expect opening paren
+                    self.expect_token(Token::LParen)?;
+
+                    // Parse subquery
                     let subquery = self.parse_select_statement()?;
 
-                    // Consume matching closing parentheses
-                    for _ in 0..extra_paren_depth {
-                        self.expect_token(Token::RParen)?;
-                    }
+                    // Expect closing paren
                     self.expect_token(Token::RParen)?;
 
-                    // Don't return - assign to left and continue to check for IS NULL
-                    left = vibesql_ast::Expression::In {
+                    left = vibesql_ast::Expression::QuantifiedComparison {
                         expr: Box::new(left),
+                        op,
+                        quantifier,
                         subquery: Box::new(subquery),
-                        negated: false,
                     };
-                } else {
-                    // It's a value list: IN (val1, val2, ...)
-                    let values = self.parse_expression_list()?;
-                    self.expect_token(Token::RParen)?;
-
-                    // Empty IN lists are allowed per SQL:1999 (evaluates to FALSE)
-                    // Don't return - assign to left and continue to check for IS NULL
-                    left = vibesql_ast::Expression::InList {
-                        expr: Box::new(left),
-                        values,
-                        negated: false,
-                    };
+                    continue;
                 }
+
+                let right = self.parse_shift_expression()?;
+                left = vibesql_ast::Expression::BinaryOp {
+                    op,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                };
+                continue;
             }
-        } else if self.peek_keyword(Keyword::Between) {
-            // It's BETWEEN (not negated)
-            self.consume_keyword(Keyword::Between)?;
 
-            // Check for optional ASYMMETRIC or SYMMETRIC
-            let symmetric = if self.peek_keyword(Keyword::Symmetric) {
-                self.consume_keyword(Keyword::Symmetric)?;
-                true
-            } else {
-                // ASYMMETRIC is default, but can be explicitly specified
-                if self.peek_keyword(Keyword::Asymmetric) {
-                    self.consume_keyword(Keyword::Asymmetric)?;
-                }
-                false
-            };
+            // Check for IS NULL / IS NOT NULL / IS [NOT] DISTINCT FROM / IS [NOT] TRUE/FALSE/UNKNOWN
+            if self.peek_keyword(Keyword::Is) {
+                self.consume_keyword(Keyword::Is)?;
 
-            // Parse low AND high
-            let low = self.parse_additive_expression()?;
-            self.consume_keyword(Keyword::And)?;
-            let high = self.parse_additive_expression()?;
-
-            // Don't return - assign to left and continue to check for IS NULL
-            left = vibesql_ast::Expression::Between {
-                expr: Box::new(left),
-                low: Box::new(low),
-                high: Box::new(high),
-                negated: false,
-                symmetric,
-            };
-        } else if self.peek_keyword(Keyword::Like) {
-            // It's LIKE (not negated)
-            self.consume_keyword(Keyword::Like)?;
-
-            // Parse pattern expression
-            let pattern = self.parse_additive_expression()?;
-
-            // Check for optional ESCAPE clause
-            let escape = if self.peek_keyword(Keyword::Escape) {
-                self.consume_keyword(Keyword::Escape)?;
-                Some(Box::new(self.parse_additive_expression()?))
-            } else {
-                None
-            };
-
-            // Don't return - assign to left and continue to check for IS NULL
-            left = vibesql_ast::Expression::Like {
-                expr: Box::new(left),
-                pattern: Box::new(pattern),
-                negated: false,
-                escape,
-            };
-        } else if self.peek_keyword(Keyword::Glob) {
-            // It's GLOB (SQLite) (not negated)
-            self.consume_keyword(Keyword::Glob)?;
-
-            // Parse pattern expression
-            let pattern = self.parse_additive_expression()?;
-
-            // Check for optional ESCAPE clause
-            let escape = if self.peek_keyword(Keyword::Escape) {
-                self.consume_keyword(Keyword::Escape)?;
-                Some(Box::new(self.parse_additive_expression()?))
-            } else {
-                None
-            };
-
-            // Don't return - assign to left and continue to check for IS NULL
-            left = vibesql_ast::Expression::Glob {
-                expr: Box::new(left),
-                pattern: Box::new(pattern),
-                negated: false,
-                escape,
-            };
-        }
-
-        // Check for comparison operators (both single-char and multi-char)
-        // Note: Exclude || (concat) operator which should be handled in additive expression
-        let is_comparison = match self.peek() {
-            Token::Symbol('=') | Token::Symbol('<') | Token::Symbol('>') => true,
-            Token::Operator(op) => !matches!(op, crate::token::MultiCharOperator::Concat),
-            _ => false,
-        };
-
-        if is_comparison {
-            let op = match self.peek() {
-                Token::Symbol('=') => vibesql_ast::BinaryOperator::Equal,
-                Token::Symbol('<') => vibesql_ast::BinaryOperator::LessThan,
-                Token::Symbol('>') => vibesql_ast::BinaryOperator::GreaterThan,
-                Token::Operator(op) => {
-                    use crate::token::MultiCharOperator;
-                    match op {
-                        MultiCharOperator::LessEqual => {
-                            vibesql_ast::BinaryOperator::LessThanOrEqual
-                        }
-                        MultiCharOperator::GreaterEqual => {
-                            vibesql_ast::BinaryOperator::GreaterThanOrEqual
-                        }
-                        MultiCharOperator::NotEqual | MultiCharOperator::NotEqualAlt => {
-                            vibesql_ast::BinaryOperator::NotEqual
-                        }
-                        // SQLite compatibility: == is a synonym for =
-                        MultiCharOperator::DoubleEqual => vibesql_ast::BinaryOperator::Equal,
-                        // Vector distance operators (pgvector compatible)
-                        MultiCharOperator::CosineDistance => {
-                            vibesql_ast::BinaryOperator::CosineDistance
-                        }
-                        MultiCharOperator::NegativeInnerProduct => {
-                            vibesql_ast::BinaryOperator::NegativeInnerProduct
-                        }
-                        MultiCharOperator::L2Distance => vibesql_ast::BinaryOperator::L2Distance,
-                        MultiCharOperator::Concat
-                        | MultiCharOperator::LeftShift
-                        | MultiCharOperator::RightShift
-                        | MultiCharOperator::JsonExtract
-                        | MultiCharOperator::JsonExtractText => {
-                            return Err(ParseError {
-                                message: format!("Unexpected operator: {}", op),
-                            })
-                        }
-                    }
-                }
-                _ => unreachable!(),
-            };
-            self.advance();
-
-            // Check for quantified comparison (ALL, ANY, SOME)
-            if self.peek_keyword(Keyword::All)
-                || self.peek_keyword(Keyword::Any)
-                || self.peek_keyword(Keyword::Some)
-            {
-                let quantifier = if self.peek_keyword(Keyword::All) {
-                    self.consume_keyword(Keyword::All)?;
-                    vibesql_ast::Quantifier::All
-                } else if self.peek_keyword(Keyword::Any) {
-                    self.consume_keyword(Keyword::Any)?;
-                    vibesql_ast::Quantifier::Any
+                // Check for NOT
+                let negated = if self.peek_keyword(Keyword::Not) {
+                    self.consume_keyword(Keyword::Not)?;
+                    true
                 } else {
-                    self.consume_keyword(Keyword::Some)?;
-                    vibesql_ast::Quantifier::Some
+                    false
                 };
 
-                // Expect opening paren
-                self.expect_token(Token::LParen)?;
-
-                // Parse subquery
-                let subquery = self.parse_select_statement()?;
-
-                // Expect closing paren
-                self.expect_token(Token::RParen)?;
-
-                return Ok(vibesql_ast::Expression::QuantifiedComparison {
-                    expr: Box::new(left),
-                    op,
-                    quantifier,
-                    subquery: Box::new(subquery),
-                });
+                // Check for DISTINCT FROM (SQL:1999), NULL, TRUE, FALSE, or UNKNOWN
+                if self.peek_keyword(Keyword::Distinct) {
+                    self.consume_keyword(Keyword::Distinct)?;
+                    self.expect_keyword(Keyword::From)?;
+                    let right = self.parse_shift_expression()?;
+                    left = vibesql_ast::Expression::IsDistinctFrom {
+                        left: Box::new(left),
+                        right: Box::new(right),
+                        negated,
+                    };
+                } else if self.peek_keyword(Keyword::True) {
+                    self.consume_keyword(Keyword::True)?;
+                    left = vibesql_ast::Expression::IsTruthValue {
+                        expr: Box::new(left),
+                        truth_value: vibesql_ast::TruthValue::True,
+                        negated,
+                    };
+                } else if self.peek_keyword(Keyword::False) {
+                    self.consume_keyword(Keyword::False)?;
+                    left = vibesql_ast::Expression::IsTruthValue {
+                        expr: Box::new(left),
+                        truth_value: vibesql_ast::TruthValue::False,
+                        negated,
+                    };
+                } else if self.peek_keyword(Keyword::Unknown) {
+                    self.consume_keyword(Keyword::Unknown)?;
+                    left = vibesql_ast::Expression::IsTruthValue {
+                        expr: Box::new(left),
+                        truth_value: vibesql_ast::TruthValue::Unknown,
+                        negated,
+                    };
+                } else if self.peek_keyword(Keyword::Null) {
+                    // IS NULL / IS NOT NULL
+                    self.consume_keyword(Keyword::Null)?;
+                    left = vibesql_ast::Expression::IsNull { expr: Box::new(left), negated };
+                } else {
+                    // SQLite compatibility: IS <expr> - compare using IS semantics (NULL-safe equals)
+                    // This handles cases like `expr IS 0` or `expr IS 1`
+                    let right = self.parse_shift_expression()?;
+                    left = vibesql_ast::Expression::IsDistinctFrom {
+                        left: Box::new(left),
+                        right: Box::new(right),
+                        // IS is equivalent to IS NOT DISTINCT FROM (NULL-safe equals)
+                        // IS NOT is equivalent to IS DISTINCT FROM (NULL-safe not equals)
+                        negated: !negated,
+                    };
+                }
+                continue;
             }
 
-            let right = self.parse_shift_expression()?;
+            // SQLite compatibility: ISNULL and NOTNULL as postfix operators
+            // These are equivalent to IS NULL and IS NOT NULL respectively
+            // The enclosing loop supports chaining: `x NOTNULL NOTNULL`
+            if self.peek_keyword(Keyword::Isnull) {
+                self.consume_keyword(Keyword::Isnull)?;
+                left = vibesql_ast::Expression::IsNull { expr: Box::new(left), negated: false };
+                continue;
+            }
+            if self.peek_keyword(Keyword::Notnull) {
+                self.consume_keyword(Keyword::Notnull)?;
+                left = vibesql_ast::Expression::IsNull { expr: Box::new(left), negated: true };
+                continue;
+            }
+
+            // No more operators at this precedence tier
+            break;
+        }
+
+        Ok(left)
+    }
+
+    /// Continue parsing tighter-binding binary operators (multiplicative, concat,
+    /// additive, shift) with an already-parsed left operand.
+    ///
+    /// Used after an IN/NOT IN node: its right operand is syntactically closed
+    /// (a parenthesized list/subquery or a table name), so per SQLite a
+    /// tighter-binding operator that follows takes the entire IN expression as
+    /// its left operand: `1 IN (SELECT 1) + 1` parses as `(1 IN (SELECT 1)) + 1`
+    /// and `1 NOT IN (SELECT 1) << 2` as `(1 NOT IN (SELECT 1)) << 2`.
+    ///
+    /// Each operator's right operand is parsed at the next-tighter tier, so
+    /// relative precedence among these operators is preserved
+    /// (e.g. `x IN (1) + 2 * 3` parses as `(x IN (1)) + (2 * 3)`).
+    fn continue_higher_precedence_ops(
+        &mut self,
+        mut left: vibesql_ast::Expression,
+    ) -> Result<vibesql_ast::Expression, ParseError> {
+        use crate::token::MultiCharOperator;
+        loop {
+            let (op, right) = match self.peek() {
+                // Multiplicative tier: right operand at unary tier
+                Token::Symbol('*') => {
+                    self.advance();
+                    (vibesql_ast::BinaryOperator::Multiply, self.parse_unary_expression()?)
+                }
+                Token::Symbol('/') => {
+                    self.advance();
+                    (vibesql_ast::BinaryOperator::Divide, self.parse_unary_expression()?)
+                }
+                Token::Symbol('%') => {
+                    self.advance();
+                    (vibesql_ast::BinaryOperator::Modulo, self.parse_unary_expression()?)
+                }
+                Token::Keyword { keyword: Keyword::Div, .. } => {
+                    self.advance();
+                    (vibesql_ast::BinaryOperator::IntegerDivide, self.parse_unary_expression()?)
+                }
+                // Concat tier: right operand at multiplicative tier
+                Token::Operator(MultiCharOperator::Concat) => {
+                    self.advance();
+                    (vibesql_ast::BinaryOperator::Concat, self.parse_multiplicative_expression()?)
+                }
+                // Additive tier: right operand at concat tier
+                Token::Symbol('+') => {
+                    self.advance();
+                    (vibesql_ast::BinaryOperator::Plus, self.parse_concat_expression()?)
+                }
+                Token::Symbol('-') => {
+                    self.advance();
+                    (vibesql_ast::BinaryOperator::Minus, self.parse_concat_expression()?)
+                }
+                // Shift tier: right operand at additive tier
+                Token::Operator(MultiCharOperator::LeftShift) => {
+                    self.advance();
+                    (vibesql_ast::BinaryOperator::LeftShift, self.parse_additive_expression()?)
+                }
+                Token::Operator(MultiCharOperator::RightShift) => {
+                    self.advance();
+                    (vibesql_ast::BinaryOperator::RightShift, self.parse_additive_expression()?)
+                }
+                _ => break,
+            };
             left = vibesql_ast::Expression::BinaryOp {
                 op,
                 left: Box::new(left),
                 right: Box::new(right),
             };
         }
-
-        // Check for IS NULL / IS NOT NULL / IS [NOT] DISTINCT FROM / IS [NOT] TRUE/FALSE/UNKNOWN
-        if self.peek_keyword(Keyword::Is) {
-            self.consume_keyword(Keyword::Is)?;
-
-            // Check for NOT
-            let negated = if self.peek_keyword(Keyword::Not) {
-                self.consume_keyword(Keyword::Not)?;
-                true
-            } else {
-                false
-            };
-
-            // Check for DISTINCT FROM (SQL:1999), NULL, TRUE, FALSE, or UNKNOWN
-            if self.peek_keyword(Keyword::Distinct) {
-                self.consume_keyword(Keyword::Distinct)?;
-                self.expect_keyword(Keyword::From)?;
-                let right = self.parse_shift_expression()?;
-                left = vibesql_ast::Expression::IsDistinctFrom {
-                    left: Box::new(left),
-                    right: Box::new(right),
-                    negated,
-                };
-            } else if self.peek_keyword(Keyword::True) {
-                self.consume_keyword(Keyword::True)?;
-                left = vibesql_ast::Expression::IsTruthValue {
-                    expr: Box::new(left),
-                    truth_value: vibesql_ast::TruthValue::True,
-                    negated,
-                };
-            } else if self.peek_keyword(Keyword::False) {
-                self.consume_keyword(Keyword::False)?;
-                left = vibesql_ast::Expression::IsTruthValue {
-                    expr: Box::new(left),
-                    truth_value: vibesql_ast::TruthValue::False,
-                    negated,
-                };
-            } else if self.peek_keyword(Keyword::Unknown) {
-                self.consume_keyword(Keyword::Unknown)?;
-                left = vibesql_ast::Expression::IsTruthValue {
-                    expr: Box::new(left),
-                    truth_value: vibesql_ast::TruthValue::Unknown,
-                    negated,
-                };
-            } else if self.peek_keyword(Keyword::Null) {
-                // IS NULL / IS NOT NULL
-                self.consume_keyword(Keyword::Null)?;
-                left = vibesql_ast::Expression::IsNull { expr: Box::new(left), negated };
-            } else {
-                // SQLite compatibility: IS <expr> - compare using IS semantics (NULL-safe equals)
-                // This handles cases like `expr IS 0` or `expr IS 1`
-                let right = self.parse_shift_expression()?;
-                left = vibesql_ast::Expression::IsDistinctFrom {
-                    left: Box::new(left),
-                    right: Box::new(right),
-                    // IS is equivalent to IS NOT DISTINCT FROM (NULL-safe equals)
-                    // IS NOT is equivalent to IS DISTINCT FROM (NULL-safe not equals)
-                    negated: !negated,
-                };
-            }
-        }
-
-        // SQLite compatibility: ISNULL and NOTNULL as postfix operators
-        // These are equivalent to IS NULL and IS NOT NULL respectively
-        // Loop to support chaining: `x NOTNULL NOTNULL` → `(x IS NOT NULL) IS NOT NULL`
-        loop {
-            if self.peek_keyword(Keyword::Isnull) {
-                self.consume_keyword(Keyword::Isnull)?;
-                left = vibesql_ast::Expression::IsNull { expr: Box::new(left), negated: false };
-            } else if self.peek_keyword(Keyword::Notnull) {
-                self.consume_keyword(Keyword::Notnull)?;
-                left = vibesql_ast::Expression::IsNull { expr: Box::new(left), negated: true };
-            } else {
-                break;
-            }
-        }
-
         Ok(left)
     }
 

--- a/crates/vibesql-parser/src/tests/arena_parser.rs
+++ b/crates/vibesql-parser/src/tests/arena_parser.rs
@@ -351,3 +351,184 @@ fn test_arena_parser_source_text_in_select_item() {
         panic!("Expected Expression select item");
     }
 }
+
+// ============================================================================
+// IN / NOT IN Composability Tests (issue #5801)
+//
+// Mirror of the standard-parser tests in tests/in_list.rs: the arena parser
+// must agree with the standard parser so the arena fast path never diverges
+// (parse_with_arena_fallback would otherwise silently fall back). Per SQLite,
+// IN is a left-associative comparison-tier operator with a syntactically
+// closed right operand, so both another comparison-tier operator and a
+// tighter-binding operator (+, *, ...) may follow an IN node.
+// ============================================================================
+
+/// Parse `SELECT <expr> ...` with the arena parser and pass the first
+/// select-list expression to the given assertion callback.
+fn with_arena_select_expr(sql: &str, check: impl FnOnce(&vibesql_ast::arena::Expression<'_>)) {
+    let arena = Bump::new();
+    let result = ArenaParser::parse_select_with_interner(sql, &arena);
+    assert!(result.is_ok(), "arena parser should parse {:?}: {:?}", sql, result.err());
+    let (stmt, _interner) = result.unwrap();
+    if let vibesql_ast::arena::SelectItem::Expression { expr, .. } = &stmt.select_list[0] {
+        check(expr);
+    } else {
+        panic!("expected Expression select item for {:?}", sql);
+    }
+}
+
+#[test]
+fn test_arena_in_subquery_chained_not_in_subquery() {
+    // sqlite3: SELECT 1 IN (SELECT 1) NOT IN (SELECT 2); -- 1
+    with_arena_select_expr("SELECT 1 IN (SELECT 1) NOT IN (SELECT 2)", |expr| {
+        let vibesql_ast::arena::Expression::Extended(ext) = expr else {
+            panic!("expected Extended expression, got {:?}", expr);
+        };
+        let vibesql_ast::arena::ExtendedExpr::In { expr: inner, negated, .. } = ext else {
+            panic!("expected outer In, got {:?}", ext);
+        };
+        assert!(*negated, "outer NOT IN should be negated");
+        assert!(
+            matches!(
+                inner,
+                vibesql_ast::arena::Expression::Extended(vibesql_ast::arena::ExtendedExpr::In {
+                    negated: false,
+                    ..
+                })
+            ),
+            "left operand should be the inner IN node: {:?}",
+            inner
+        );
+    });
+}
+
+#[test]
+fn test_arena_in_subquery_followed_by_plus() {
+    // sqlite3: SELECT 1 IN (SELECT 1) + 1; -- 2
+    with_arena_select_expr("SELECT 1 IN (SELECT 1) + 1", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, left, .. } = expr else {
+            panic!("expected BinaryOp Plus at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Plus);
+        assert!(
+            matches!(
+                left,
+                vibesql_ast::arena::Expression::Extended(
+                    vibesql_ast::arena::ExtendedExpr::In { .. }
+                )
+            ),
+            "left operand of + should be the IN node: {:?}",
+            left
+        );
+    });
+}
+
+#[test]
+fn test_arena_in_list_chained_not_in_subquery() {
+    // sqlite3: SELECT 1 IN (1,2) NOT IN (SELECT 2); -- 1
+    with_arena_select_expr("SELECT 1 IN (1,2) NOT IN (SELECT 2)", |expr| {
+        let vibesql_ast::arena::Expression::Extended(ext) = expr else {
+            panic!("expected Extended expression, got {:?}", expr);
+        };
+        let vibesql_ast::arena::ExtendedExpr::In { expr: inner, negated, .. } = ext else {
+            panic!("expected outer In, got {:?}", ext);
+        };
+        assert!(*negated);
+        assert!(
+            matches!(
+                inner,
+                vibesql_ast::arena::Expression::Extended(
+                    vibesql_ast::arena::ExtendedExpr::InList { negated: false, .. }
+                )
+            ),
+            "left operand should be the inner IN list node: {:?}",
+            inner
+        );
+    });
+}
+
+#[test]
+fn test_arena_in_lhs_precedence_preserved() {
+    // sqlite3: SELECT 1 + 2 IN (3); -- 1, i.e. (1 + 2) IN (3)
+    with_arena_select_expr("SELECT 1 + 2 IN (3)", |expr| {
+        let vibesql_ast::arena::Expression::Extended(ext) = expr else {
+            panic!("expected Extended expression, got {:?}", expr);
+        };
+        let vibesql_ast::arena::ExtendedExpr::InList { expr: inner, negated, .. } = ext else {
+            panic!("expected InList at top level, got {:?}", ext);
+        };
+        assert!(!negated);
+        assert!(
+            matches!(
+                inner,
+                vibesql_ast::arena::Expression::BinaryOp {
+                    op: vibesql_ast::BinaryOperator::Plus,
+                    ..
+                }
+            ),
+            "left operand of IN should be (1 + 2): {:?}",
+            inner
+        );
+    });
+}
+
+#[test]
+fn test_arena_chained_in_lists() {
+    // sqlite3: SELECT 1 IN (2) IN (0); -- 1, i.e. ((1 IN (2)) IN (0))
+    with_arena_select_expr("SELECT 1 IN (2) IN (0)", |expr| {
+        let vibesql_ast::arena::Expression::Extended(ext) = expr else {
+            panic!("expected Extended expression, got {:?}", expr);
+        };
+        let vibesql_ast::arena::ExtendedExpr::InList { expr: inner, .. } = ext else {
+            panic!("expected outer InList, got {:?}", ext);
+        };
+        assert!(
+            matches!(
+                inner,
+                vibesql_ast::arena::Expression::Extended(
+                    vibesql_ast::arena::ExtendedExpr::InList { .. }
+                )
+            ),
+            "IN chains must be left-associative: {:?}",
+            inner
+        );
+    });
+}
+
+#[test]
+fn test_arena_in_followed_by_comparison() {
+    // sqlite3: SELECT 1 IN (1) = 1; -- 1
+    with_arena_select_expr("SELECT 1 IN (1) = 1", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, left, .. } = expr else {
+            panic!("expected BinaryOp Equal at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Equal);
+        assert!(matches!(
+            left,
+            vibesql_ast::arena::Expression::Extended(
+                vibesql_ast::arena::ExtendedExpr::InList { .. }
+            )
+        ));
+    });
+}
+
+#[test]
+fn test_arena_not_in_chained_not_in() {
+    // sqlite3: SELECT 1 NOT IN (SELECT 1) NOT IN (SELECT 0); -- 0
+    with_arena_select_expr("SELECT 1 NOT IN (SELECT 1) NOT IN (SELECT 0)", |expr| {
+        let vibesql_ast::arena::Expression::Extended(ext) = expr else {
+            panic!("expected Extended expression, got {:?}", expr);
+        };
+        let vibesql_ast::arena::ExtendedExpr::In { expr: inner, negated, .. } = ext else {
+            panic!("expected outer In, got {:?}", ext);
+        };
+        assert!(*negated);
+        assert!(matches!(
+            inner,
+            vibesql_ast::arena::Expression::Extended(vibesql_ast::arena::ExtendedExpr::In {
+                negated: true,
+                ..
+            })
+        ));
+    });
+}

--- a/crates/vibesql-parser/src/tests/in_list.rs
+++ b/crates/vibesql-parser/src/tests/in_list.rs
@@ -314,3 +314,219 @@ fn test_parse_not_in_parenthesized_subquery() {
         }
     }
 }
+
+// ========================================================================
+// IN / NOT IN Composability Tests (issue #5801)
+//
+// Per SQLite, IN is an ordinary left-associative binary operator in the
+// comparison tier, and its right operand is syntactically closed (a
+// parenthesized list/subquery or a table name). So another comparison-tier
+// operator OR a tighter-binding operator (+, <<, *, ...) may follow an IN
+// node, taking the whole IN expression as its left operand.
+// All expected shapes below were verified against sqlite3.
+// ========================================================================
+
+/// Parse a `SELECT <expr>;` statement and return the first select-list expression.
+fn parse_select_expr(sql: &str) -> vibesql_ast::Expression {
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("should parse: {}: {:?}", sql, e));
+    if let vibesql_ast::Statement::Select(select) = stmt {
+        if let vibesql_ast::SelectItem::Expression { expr, .. } = &select.select_list[0] {
+            return expr.clone();
+        }
+    }
+    panic!("expected SELECT with expression select list: {}", sql);
+}
+
+#[test]
+fn test_in_subquery_chained_not_in_subquery() {
+    // sqlite3: SELECT 1 IN (SELECT 1) NOT IN (SELECT 2); -- 1
+    let expr = parse_select_expr("SELECT 1 IN (SELECT 1) NOT IN (SELECT 2);");
+    if let vibesql_ast::Expression::In { expr: inner, negated, .. } = expr {
+        assert!(negated, "outer NOT IN should be negated");
+        assert!(
+            matches!(*inner, vibesql_ast::Expression::In { negated: false, .. }),
+            "left operand should be the inner (non-negated) IN node: {:?}",
+            inner
+        );
+    } else {
+        panic!("expected outer In expression");
+    }
+}
+
+#[test]
+fn test_in_subquery_followed_by_plus() {
+    // sqlite3: SELECT 1 IN (SELECT 1) + 1; -- 2
+    // + binds tighter than IN, but IN's right operand is closed, so the whole
+    // IN node becomes the left operand of +.
+    let expr = parse_select_expr("SELECT 1 IN (SELECT 1) + 1;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Plus);
+        assert!(
+            matches!(*left, vibesql_ast::Expression::In { .. }),
+            "left operand of + should be the IN node: {:?}",
+            left
+        );
+    } else {
+        panic!("expected BinaryOp Plus at top level");
+    }
+}
+
+#[test]
+fn test_in_list_chained_not_in_subquery() {
+    // sqlite3: SELECT 1 IN (1,2) NOT IN (SELECT 2); -- 1
+    let expr = parse_select_expr("SELECT 1 IN (1,2) NOT IN (SELECT 2);");
+    if let vibesql_ast::Expression::In { expr: inner, negated, .. } = expr {
+        assert!(negated);
+        assert!(
+            matches!(*inner, vibesql_ast::Expression::InList { negated: false, .. }),
+            "left operand should be the inner IN list node: {:?}",
+            inner
+        );
+    } else {
+        panic!("expected outer In expression");
+    }
+}
+
+#[test]
+fn test_not_in_subquery_followed_by_shift() {
+    // sqlite3: SELECT 1 NOT IN (SELECT 1) << 2; -- 0
+    let expr = parse_select_expr("SELECT 1 NOT IN (SELECT 1) << 2;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::LeftShift);
+        assert!(
+            matches!(*left, vibesql_ast::Expression::In { negated: true, .. }),
+            "left operand of << should be the NOT IN node: {:?}",
+            left
+        );
+    } else {
+        panic!("expected BinaryOp LeftShift at top level");
+    }
+}
+
+#[test]
+fn test_not_in_shift_inside_function_call() {
+    // sqlite3: SELECT lower(1 NOT IN (SELECT 1) << 2); -- '0'
+    let result = Parser::parse_sql("SELECT lower(1 NOT IN (SELECT 1) << 2);");
+    assert!(
+        result.is_ok(),
+        "NOT IN followed by << inside function args should parse: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_parenthesized_in_chained_not_in_still_works() {
+    // sqlite3: SELECT (1 IN (SELECT 1)) NOT IN (SELECT 2); -- 1 (worked before the fix)
+    let expr = parse_select_expr("SELECT (1 IN (SELECT 1)) NOT IN (SELECT 2);");
+    if let vibesql_ast::Expression::In { expr: inner, negated, .. } = expr {
+        assert!(negated);
+        assert!(matches!(*inner, vibesql_ast::Expression::In { negated: false, .. }));
+    } else {
+        panic!("expected outer In expression");
+    }
+}
+
+#[test]
+fn test_in_lhs_precedence_preserved() {
+    // sqlite3: SELECT 1 + 2 IN (3); -- 1
+    // + binds tighter than IN on the LEFT side too: (1 + 2) IN (3).
+    let expr = parse_select_expr("SELECT 1 + 2 IN (3);");
+    if let vibesql_ast::Expression::InList { expr: inner, negated, .. } = expr {
+        assert!(!negated);
+        assert!(
+            matches!(
+                *inner,
+                vibesql_ast::Expression::BinaryOp { op: vibesql_ast::BinaryOperator::Plus, .. }
+            ),
+            "left operand of IN should be (1 + 2): {:?}",
+            inner
+        );
+    } else {
+        panic!("expected InList at top level");
+    }
+}
+
+#[test]
+fn test_chained_in_lists() {
+    // sqlite3: SELECT 1 IN (2) IN (0); -- 1, i.e. ((1 IN (2)) IN (0))
+    let expr = parse_select_expr("SELECT 1 IN (2) IN (0);");
+    if let vibesql_ast::Expression::InList { expr: inner, .. } = expr {
+        assert!(
+            matches!(*inner, vibesql_ast::Expression::InList { .. }),
+            "IN chains must be left-associative: {:?}",
+            inner
+        );
+    } else {
+        panic!("expected outer InList");
+    }
+}
+
+#[test]
+fn test_not_in_chained_not_in() {
+    // sqlite3: SELECT 1 NOT IN (SELECT 1) NOT IN (SELECT 0); -- 0
+    let expr = parse_select_expr("SELECT 1 NOT IN (SELECT 1) NOT IN (SELECT 0);");
+    if let vibesql_ast::Expression::In { expr: inner, negated, .. } = expr {
+        assert!(negated);
+        assert!(matches!(*inner, vibesql_ast::Expression::In { negated: true, .. }));
+    } else {
+        panic!("expected outer In expression");
+    }
+}
+
+#[test]
+fn test_in_followed_by_comparison() {
+    // sqlite3: SELECT 1 IN (1) = 1; -- 1, i.e. ((1 IN (1)) = 1)
+    let expr = parse_select_expr("SELECT 1 IN (1) = 1;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Equal);
+        assert!(matches!(*left, vibesql_ast::Expression::InList { .. }));
+    } else {
+        panic!("expected BinaryOp Equal at top level");
+    }
+}
+
+#[test]
+fn test_in_followed_by_multiply() {
+    // sqlite3: SELECT 1 IN (1) * 3; -- 3
+    let expr = parse_select_expr("SELECT 1 IN (1) * 3;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Multiply);
+        assert!(matches!(*left, vibesql_ast::Expression::InList { .. }));
+    } else {
+        panic!("expected BinaryOp Multiply at top level");
+    }
+}
+
+#[test]
+fn test_like_chained_with_in() {
+    // sqlite3: SELECT 'a' LIKE 'a' IN (1); -- 1, i.e. (('a' LIKE 'a') IN (1))
+    let expr = parse_select_expr("SELECT 'a' LIKE 'a' IN (1);");
+    if let vibesql_ast::Expression::InList { expr: inner, .. } = expr {
+        assert!(matches!(*inner, vibesql_ast::Expression::Like { .. }));
+    } else {
+        panic!("expected InList at top level");
+    }
+}
+
+#[test]
+fn test_between_chained_with_in() {
+    // sqlite3: SELECT 1 BETWEEN 0 AND 2 IN (1); -- 1, i.e. ((1 BETWEEN 0 AND 2) IN (1))
+    let expr = parse_select_expr("SELECT 1 BETWEEN 0 AND 2 IN (1);");
+    if let vibesql_ast::Expression::InList { expr: inner, .. } = expr {
+        assert!(matches!(*inner, vibesql_ast::Expression::Between { .. }));
+    } else {
+        panic!("expected InList at top level");
+    }
+}
+
+#[test]
+fn test_in_followed_by_isnull() {
+    // sqlite3: SELECT 1 IN (1) ISNULL; -- 0
+    let expr = parse_select_expr("SELECT 1 IN (1) ISNULL;");
+    if let vibesql_ast::Expression::IsNull { expr: inner, negated } = expr {
+        assert!(!negated);
+        assert!(matches!(*inner, vibesql_ast::Expression::InList { .. }));
+    } else {
+        panic!("expected IsNull at top level");
+    }
+}


### PR DESCRIPTION
## Problem

IN / NOT IN was parsed as a one-shot, terminal production in both parsers, so nothing could follow an IN node:

```sql
SELECT 1 IN (SELECT 1) NOT IN (SELECT 2);  -- near "NOT": syntax error
SELECT 1 IN (SELECT 1) + 1;                -- near "+": syntax error
SELECT lower(1 NOT IN (SELECT 1) << 2);    -- Unexpected operator: <<
```

Per SQLite, IN is an ordinary left-associative binary operator in the comparison tier, and because its right operand is syntactically closed (parenthesized list/subquery or table name), even tighter-binding operators (`+`, `<<`, `*`, ...) that follow take the whole IN node as their left operand. This accounted for the bulk of the ~14,853 fuzz.test failures (epic #5779).

## Fix (both parsers)

**`crates/vibesql-parser/src/parser/expressions/operators.rs`** (standard parser) and **`crates/vibesql-parser/src/arena_parser/expression.rs`** (arena parser, so the fast path never diverges from the fallback):

1. `parse_comparison_expression` is now a chaining loop: every comparison-tier operator (IN, BETWEEN, LIKE, GLOB, `=`/`<`/`>`/..., IS, ISNULL, NOTNULL, `expr NOT NULL`, quantified comparisons) assigns to `left` and continues, giving SQLite's left-associative chaining (`1 IN (1) NOT IN (SELECT 2)` = `(1 IN (1)) NOT IN (SELECT 2)`; also fixes `1 = 2 = 3`).
2. After an IN/InList node, a new `continue_higher_precedence_ops` helper consumes tighter-binding operators (`*`, `/`, `%`, DIV, `||`, `+`, `-`, and `<<`/`>>` in the standard parser) with the IN node as LHS. Each operator's RHS is parsed at its next-tighter tier, so relative precedence among them is preserved.
3. Careful cases preserved: the `DEFAULT <literal> NOT NULL` column-constraint heuristic and the bare-`NOT` restore path break out of the loop; BETWEEN's internal `AND` parsing is untouched; left-side precedence is unchanged (`1 + 2 IN (3)` still parses as `(1 + 2) IN (3)`).

## Reproducers, CLI-verified (release build, `:memory:`)

| Query | sqlite3 | VibeSQL (this PR) |
|---|---|---|
| `SELECT 1 IN (SELECT 1) NOT IN (SELECT 2);` | 1 | 1 |
| `SELECT 1 IN (SELECT 1) + 1;` | 2 | 2 |
| `SELECT 1 IN (1,2) NOT IN (SELECT 2);` | 1 | 1 |
| `SELECT lower(1 NOT IN (SELECT 1) << 2);` | 0 | 0 |
| `SELECT (1 IN (SELECT 1)) NOT IN (SELECT 2);` | 1 | 1 (unchanged) |
| `SELECT 1 + 2 IN (3);` | 1 | 1 |
| `SELECT 1 IN (2) IN (0);` | 1 | 1 |
| `SELECT 1 IN (1) = 1;` / `* 3` / `ISNULL` | 1 / 3 / 0 | 1 / 3 / 0 |
| `SELECT 'a' LIKE 'a' IN (1);` | 1 | 1 |
| `SELECT 1 BETWEEN 0 AND 2 IN (1);` | 1 | 1 |
| `SELECT 2 NOT NULL = 1;` | 1 | 1 |
| `SELECT 1 = 2 = 3;` | 0 | 0 |

**Note on the issue's expected values:** the issue lists `SELECT 1 IN (1,2) NOT IN (SELECT 2);` as expecting 0, but actual sqlite3 returns **1** (`(1 IN (1,2))` = 1, then `1 NOT IN (2)` = 1). Tests use sqlite3's actual value.

**Pre-existing, out-of-scope evaluation bug found while verifying:** `SELECT 1 NOT IN (SELECT 1) NOT IN (SELECT 0);` returns 1, sqlite3 says 0. This is NOT a parse issue: the already-working parenthesized form `SELECT (1 NOT IN (SELECT 1)) NOT IN (SELECT 0);` returns the same wrong 1 on current main. Root cause is executor-side Boolean-vs-Integer comparison in IN-subquery evaluation (`SELECT (1=2) NOT IN (SELECT 0);` → 1, but `... NOT IN (0)` list form → 0). The parser now produces the identical AST for both forms; the structural parse test for this chain passes.

## Tests

- 13 new standard-parser tests in `crates/vibesql-parser/src/tests/in_list.rs` and 7 mirrored arena-parser tests in `crates/vibesql-parser/src/tests/arena_parser.rs` (all AST-shape assertions verified against sqlite3 behavior).
- `cargo test -p vibesql-parser`: **1513 passed, 0 failed** (+ 8 doc-tests).
- `cargo test -p vibesql-executor --release`: **all suites green** (3031 + integration suites, 0 failed).
- `cargo check --workspace`: clean (pre-existing warnings only, none in touched files).
- `cargo clippy -p vibesql-parser`: only pre-existing warnings in untouched files.

## TCL regression (this branch vs. main-checkout binary on identical test files)

| File | main: passed/failed | this PR: passed/failed |
|---|---|---|
| in.test | 114 / 0 | 114 / 0 |
| in2.test | 1999 / 0 | 1999 / 0 |
| in3.test | 12 / 6 | 12 / 6 (pre-existing, unrelated) |
| in4.test | 60 / 1 | 60 / 1 (pre-existing) |
| in5.test | 29 / 0 | 29 / 0 |
| rowvalue.test | 234 / 63 | 234 / 63 (pre-existing) |
| expr.test | 638 / 0 | 638 / 0 |

## fuzz.test (full run, native TCL mode)

```
Total tests: 35031
Passed:      34306 (97.9%)
Failed:      725
Skipped:     0
```

Failures drop from **~14,853 → 725**, meeting the issue's ~700 acceptance target. Remaining failures are unrelated classes (datatype mismatch, ORDER BY term range errors, etc.).

Part of epic #5779.

Fixes #5801
