### PR TITLE
fix(executor): make mixed-type ORDER BY comparator a genuine total order (#5802)

### DIFF
--- a/crates/vibesql-executor/src/memory/external_sort.rs
+++ b/crates/vibesql-executor/src/memory/external_sort.rs
@@ -167,27 +167,14 @@ impl SortKeyComparator {
 }
 
 /// Compare two SqlValue instances
+///
+/// Delegates to the shared SQLite-style total order (#5802). The previous
+/// hand-rolled version treated every cross-variant pair (even Integer vs
+/// Bigint) as Equal, which is not a total order and could panic inside
+/// `sort_unstable_by` for mixed-type sort keys. NULLs are handled by the
+/// caller ([`SortKeyComparator::compare`]) before this is invoked.
 fn compare_sql_values(a: &SqlValue, b: &SqlValue) -> Ordering {
-    use SqlValue::*;
-    match (a, b) {
-        (Integer(x), Integer(y)) => x.cmp(y),
-        (Smallint(x), Smallint(y)) => x.cmp(y),
-        (Bigint(x), Bigint(y)) => x.cmp(y),
-        (Unsigned(x), Unsigned(y)) => x.cmp(y),
-        (Float(x), Float(y)) => x.partial_cmp(y).unwrap_or(Ordering::Equal),
-        (Real(x), Real(y)) => x.partial_cmp(y).unwrap_or(Ordering::Equal),
-        (Double(x), Double(y)) | (Numeric(x), Numeric(y)) => {
-            x.partial_cmp(y).unwrap_or(Ordering::Equal)
-        }
-        (Character(x), Character(y)) | (Varchar(x), Varchar(y)) => x.cmp(y),
-        (Character(x), Varchar(y)) | (Varchar(x), Character(y)) => x.as_str().cmp(y.as_str()),
-        (Boolean(x), Boolean(y)) => x.cmp(y),
-        (Date(x), Date(y)) => x.cmp(y),
-        (Time(x), Time(y)) => x.cmp(y),
-        (Timestamp(x), Timestamp(y)) => x.cmp(y),
-        (Interval(x), Interval(y)) => x.cmp(y),
-        _ => Ordering::Equal, // Type mismatch - treat as equal
-    }
+    vibesql_types::total_order_cmp(a, b)
 }
 
 impl ExternalSort {

--- a/crates/vibesql-executor/src/select/grouping/aggregates.rs
+++ b/crates/vibesql-executor/src/select/grouping/aggregates.rs
@@ -1075,16 +1075,19 @@ pub fn compare_sql_values_with_collation(
 
 /// Compare two SqlValues for ordering purposes (SQL ORDER BY semantics)
 ///
-/// Implements SQLite type affinity ordering for MIN/MAX aggregates:
-/// - NULL values sort last (NULLS LAST - SQL:1999 default for ASC)
-/// - Numbers (all integer and float types) < text < other types
-/// - Within the same type class, uses natural ordering
+/// Implements SQLite type-class ordering as a genuine total order (#5802):
+/// - NULL values sort last (NULLS LAST - SQL:1999 default for ASC; this is
+///   the contract MIN/MAX aggregates rely on)
+/// - numeric (all integer and float variants, inter-comparable and compared
+///   exactly — never through lossy `as f64` casts) < text < blob < other
+///   types in deterministic slots
+///
+/// See [`vibesql_types::total_order_cmp`] for the full ordering definition
+/// and its totality/transitivity guarantees.
 ///
 /// Note: For ORDER BY with direction-dependent NULL handling (SQLite behavior),
 /// use the NULL ordering logic in apply_order_by() in order.rs instead.
 pub fn compare_sql_values(a: &vibesql_types::SqlValue, b: &vibesql_types::SqlValue) -> Ordering {
-    use vibesql_types::SqlValue;
-
     match (a.is_null(), b.is_null()) {
         // Both NULL - equal
         (true, true) => Ordering::Equal,
@@ -1092,63 +1095,8 @@ pub fn compare_sql_values(a: &vibesql_types::SqlValue, b: &vibesql_types::SqlVal
         (true, false) => Ordering::Greater,
         // Second is NULL - first sorts first (less)
         (false, true) => Ordering::Less,
-        // Neither NULL - compare by type affinity then value
-        (false, false) => {
-            // Helper to determine type class for SQLite affinity ordering
-            // 0 = numeric (integers/reals), 1 = text, 2 = other
-            fn type_class(v: &SqlValue) -> u8 {
-                match v {
-                    SqlValue::Integer(_)
-                    | SqlValue::Bigint(_)
-                    | SqlValue::Smallint(_)
-                    | SqlValue::Unsigned(_)
-                    | SqlValue::Float(_)
-                    | SqlValue::Double(_)
-                    | SqlValue::Numeric(_)
-                    | SqlValue::Real(_) => 0,
-                    SqlValue::Character(_) | SqlValue::Varchar(_) => 1,
-                    _ => 2,
-                }
-            }
-
-            // Helper to convert numeric SqlValue to f64 for cross-type comparison
-            fn to_f64(v: &SqlValue) -> Option<f64> {
-                match v {
-                    SqlValue::Integer(i) => Some(*i as f64),
-                    SqlValue::Bigint(i) => Some(*i as f64),
-                    SqlValue::Smallint(i) => Some(*i as f64),
-                    SqlValue::Unsigned(u) => Some(*u as f64),
-                    SqlValue::Float(f) => Some(*f as f64),
-                    SqlValue::Double(d) => Some(*d),
-                    SqlValue::Numeric(n) => Some(*n),
-                    SqlValue::Real(r) => Some(*r as f64),
-                    _ => None,
-                }
-            }
-
-            let class_a = type_class(a);
-            let class_b = type_class(b);
-
-            if class_a != class_b {
-                // Different type classes - use SQLite affinity ordering
-                class_a.cmp(&class_b)
-            } else if class_a == 0 {
-                // Both numeric - try direct comparison first, then cross-type numeric comparison
-                if let Some(ordering) = PartialOrd::partial_cmp(a, b) {
-                    ordering
-                } else if let (Some(fa), Some(fb)) = (to_f64(a), to_f64(b)) {
-                    // Cross-type numeric comparison (e.g., Integer vs Real)
-                    fa.partial_cmp(&fb).unwrap_or(Ordering::Equal)
-                } else {
-                    Ordering::Equal
-                }
-            } else {
-                // Same type class (non-numeric) - use natural ordering
-                // partial_cmp returns None for incomparable values (NaN)
-                // Default to Equal to maintain sort stability
-                PartialOrd::partial_cmp(a, b).unwrap_or(Ordering::Equal)
-            }
-        }
+        // Neither NULL - delegate to the shared total order
+        (false, false) => vibesql_types::total_order_cmp(a, b),
     }
 }
 
@@ -1592,5 +1540,121 @@ mod tests {
             compare_sql_values(&SqlValue::Integer(2), &SqlValue::Real(2.0)),
             Ordering::Equal
         );
+    }
+
+    /// Regression test for #5802: the mixed-type comparator must be a genuine
+    /// total order. Before the fix, cross-variant numeric pairs (e.g. Integer
+    /// vs Bigint, Bigint vs Double) fell back to lossy `as f64` casts while
+    /// same-variant pairs compared exactly, producing a non-transitive triple:
+    ///
+    ///   a = Bigint(2^53), b = Bigint(2^53 + 1), c = Double(2^53 as f64)
+    ///   a < b (exact i64), but a == c and b == c (2^53 + 1 rounds to 2^53)
+    ///
+    /// which made `sort_by` panic with "user-provided comparison function
+    /// does not correctly implement a total order".
+    #[test]
+    fn test_compare_sql_values_transitive_at_f64_precision_boundary() {
+        use std::cmp::Ordering;
+
+        let a = SqlValue::Bigint(9_007_199_254_740_992); // 2^53
+        let b = SqlValue::Bigint(9_007_199_254_740_993); // 2^53 + 1
+        let c = SqlValue::Double(9_007_199_254_740_992.0); // 2^53 exactly
+
+        assert_eq!(compare_sql_values(&a, &b), Ordering::Less);
+        assert_eq!(compare_sql_values(&a, &c), Ordering::Equal);
+        // Pre-fix this returned Equal (lossy f64 cast), violating transitivity.
+        assert_eq!(compare_sql_values(&b, &c), Ordering::Greater);
+
+        // Integer vs Bigint is cross-variant but both are exact integers; the
+        // comparison must be exact, not routed through f64.
+        assert_eq!(
+            compare_sql_values(
+                &SqlValue::Integer(9_007_199_254_740_992),
+                &SqlValue::Bigint(9_007_199_254_740_993)
+            ),
+            Ordering::Less
+        );
+
+        // NaN must occupy a fixed position in the total order (not collapse to
+        // Equal against every numeric).
+        let nan = SqlValue::Double(f64::NAN);
+        assert_eq!(compare_sql_values(&nan, &nan), Ordering::Equal);
+        let one = SqlValue::Integer(1);
+        let cmp_nan_one = compare_sql_values(&nan, &one);
+        assert_ne!(cmp_nan_one, Ordering::Equal);
+        assert_eq!(compare_sql_values(&one, &nan), cmp_nan_one.reverse());
+    }
+
+    /// Regression test for #5802: sorting >= 100 mixed-type values (integers,
+    /// bigints, doubles at the f64 precision boundary, NaN, text, blobs,
+    /// booleans, NULLs) must not panic and must produce SQLite class ordering
+    /// (numeric < text < blob) with NULLs last (compare_sql_values contract).
+    #[test]
+    fn test_compare_sql_values_total_order_mixed_types_sort() {
+        use std::cmp::Ordering;
+
+        use vibesql_types::StringValue;
+
+        let mut values = Vec::new();
+        for i in 0..8i64 {
+            let base = 9_007_199_254_740_992i64; // 2^53
+            values.push(SqlValue::Bigint(base));
+            values.push(SqlValue::Bigint(base + 1));
+            values.push(SqlValue::Integer(base));
+            values.push(SqlValue::Integer(base + 1));
+            values.push(SqlValue::Double(9_007_199_254_740_992.0));
+            values.push(SqlValue::Double(9.007_199_254_740_993e15));
+            values.push(SqlValue::Double(f64::NAN));
+            values.push(SqlValue::Numeric(1.5));
+            values.push(SqlValue::Real(-2.5));
+            values.push(SqlValue::Integer(i));
+            values.push(SqlValue::Unsigned(u64::MAX));
+            values.push(SqlValue::Varchar(StringValue::from(format!("t{i}"))));
+            values.push(SqlValue::Blob(vec![i as u8, 0x80]));
+            values.push(SqlValue::Boolean(i % 2 == 0));
+            values.push(SqlValue::Null);
+        }
+        assert!(values.len() >= 100, "need >= 100 rows to reproduce the fuzz panic");
+
+        // Pre-fix this panicked: "user-provided comparison function does not
+        // correctly implement a total order" (issue #5802 / fuzz.test).
+        values.sort_by(compare_sql_values);
+
+        // Class ordering: numeric(0) < text(1) < blob/boolean/other(2+) < NULL(last)
+        fn class_of(v: &SqlValue) -> u8 {
+            match v {
+                SqlValue::Integer(_)
+                | SqlValue::Bigint(_)
+                | SqlValue::Smallint(_)
+                | SqlValue::Unsigned(_)
+                | SqlValue::Float(_)
+                | SqlValue::Real(_)
+                | SqlValue::Double(_)
+                | SqlValue::Numeric(_) => 0,
+                SqlValue::Character(_) | SqlValue::Varchar(_) => 1,
+                SqlValue::Blob(_) => 2,
+                SqlValue::Null => 4,
+                _ => 3,
+            }
+        }
+        let classes: Vec<u8> = values.iter().map(class_of).collect();
+        let mut sorted_classes = classes.clone();
+        sorted_classes.sort_unstable();
+        assert_eq!(
+            classes, sorted_classes,
+            "sorted output must group classes as numeric < text < blob < other < NULL"
+        );
+
+        // The sort result must be consistent with the comparator on every
+        // adjacent pair (sanity check that the order is well-formed).
+        for pair in values.windows(2) {
+            assert_ne!(
+                compare_sql_values(&pair[0], &pair[1]),
+                Ordering::Greater,
+                "adjacent pair out of order: {:?} > {:?}",
+                pair[0],
+                pair[1]
+            );
+        }
     }
 }

--- a/crates/vibesql-executor/tests/order_by_mixed_type_total_order_tests.rs
+++ b/crates/vibesql-executor/tests/order_by_mixed_type_total_order_tests.rs
@@ -1,0 +1,144 @@
+//! Regression tests for issue #5802 (found by SQLite's fuzz.test): sorting a
+//! mixed-type column (integers, bigints, doubles, text, blobs, NULLs) with
+//! roughly 65 or more rows panicked with "user-provided comparison function
+//! does not correctly implement a total order".
+//!
+//! Root cause: the ORDER BY comparator compared same-variant numerics exactly
+//! (i64 cmp) but fell back to lossy `as f64` casts for cross-variant numeric
+//! pairs (Integer vs Bigint, Bigint vs Double, ...). At the f64 precision
+//! boundary (|x| >= 2^53) this produced non-transitive triples, e.g.
+//! Bigint(2^53) < Bigint(2^53+1) exactly, while both compared Equal to
+//! Double(2^53 as f64). NaN also collapsed to Equal against every numeric.
+//!
+//! The original fuzz reproduction only fired after WAL crash recovery because
+//! the recovered database faithfully preserves the fuzzer-created mix of
+//! internal SqlValue variants (Integer vs Bigint vs Double), a mix that plain
+//! SQL literals do not recreate (all i64 literals parse to the same variant).
+//! This test injects the variant mix directly through the storage API and then
+//! sorts through the real SELECT ... ORDER BY path.
+
+use vibesql_executor::{CreateTableExecutor, SelectExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::{Database, Row};
+use vibesql_types::{SqlValue, StringValue};
+
+fn setup_db() -> Database {
+    let mut db = Database::new();
+
+    let create = Parser::parse_sql("CREATE TABLE def(c)").unwrap();
+    if let vibesql_ast::Statement::CreateTable(stmt) = create {
+        CreateTableExecutor::execute(&stmt, &mut db).unwrap();
+    }
+
+    // 112 rows (matching the fuzz.test reproduction size) with an adversarial
+    // mix of SqlValue variants around the f64 precision boundary.
+    let base = 9_007_199_254_740_992i64; // 2^53
+    let mut values = Vec::new();
+    for i in 0..8i64 {
+        values.push(SqlValue::Bigint(base));
+        values.push(SqlValue::Bigint(base + 1));
+        values.push(SqlValue::Integer(base));
+        values.push(SqlValue::Integer(base + 1));
+        values.push(SqlValue::Double(9_007_199_254_740_992.0)); // 2^53 exactly
+        values.push(SqlValue::Double(9.007_199_254_740_993e15));
+        values.push(SqlValue::Integer(-2_147_483_648));
+        values.push(SqlValue::Integer(i));
+        values.push(SqlValue::Unsigned(u64::MAX));
+        values.push(SqlValue::Real(0.5 + i as f64));
+        values.push(SqlValue::Varchar(StringValue::from(format!("text-{i}"))));
+        values.push(SqlValue::Blob(vec![i as u8, 0xff, 0x00]));
+        values.push(SqlValue::Blob((-2_147_483_648i64).to_string().into_bytes()));
+        values.push(SqlValue::Null);
+    }
+    assert_eq!(values.len(), 112);
+
+    for v in values {
+        db.insert_row("def", Row::new(vec![v])).unwrap();
+    }
+
+    db
+}
+
+fn execute_query(db: &Database, sql: &str) -> Vec<Row> {
+    let stmt = Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor.execute(&select_stmt).unwrap()
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+/// Type class in SQLite ordering: NULL < numeric < text < blob.
+fn class_of(v: &SqlValue) -> u8 {
+    match v {
+        SqlValue::Null => 0,
+        SqlValue::Integer(_)
+        | SqlValue::Bigint(_)
+        | SqlValue::Smallint(_)
+        | SqlValue::Unsigned(_)
+        | SqlValue::Float(_)
+        | SqlValue::Real(_)
+        | SqlValue::Double(_)
+        | SqlValue::Numeric(_) => 1,
+        SqlValue::Character(_) | SqlValue::Varchar(_) => 2,
+        SqlValue::Blob(_) => 3,
+        other => panic!("unexpected value class in result: {other:?}"),
+    }
+}
+
+#[test]
+fn order_by_mixed_type_column_does_not_panic() {
+    let db = setup_db();
+
+    // Pre-fix: panicked inside sort with "user-provided comparison function
+    // does not correctly implement a total order".
+    let rows = execute_query(&db, "SELECT ALL c FROM def ORDER BY 1 ASC");
+    assert_eq!(rows.len(), 112);
+
+    // ASC default in SQLite: NULLs first, then numeric < text < blob.
+    let classes: Vec<u8> = rows.iter().map(|r| class_of(&r.values[0])).collect();
+    let mut sorted = classes.clone();
+    sorted.sort_unstable();
+    assert_eq!(classes, sorted, "classes must appear as NULL < numeric < text < blob");
+
+    // Exact integer ordering at the f64 precision boundary must be preserved:
+    // every occurrence of 2^53 (Integer/Bigint/Double alike) must come before
+    // every occurrence of 2^53 + 1.
+    let pos_2p53: Vec<usize> = rows
+        .iter()
+        .enumerate()
+        .filter_map(|(i, r)| match &r.values[0] {
+            SqlValue::Integer(n) | SqlValue::Bigint(n) if *n == 9_007_199_254_740_992 => Some(i),
+            SqlValue::Double(d) if *d == 9_007_199_254_740_992.0 => Some(i),
+            _ => None,
+        })
+        .collect();
+    let pos_2p53_plus_1: Vec<usize> = rows
+        .iter()
+        .enumerate()
+        .filter_map(|(i, r)| match &r.values[0] {
+            SqlValue::Integer(n) | SqlValue::Bigint(n) if *n == 9_007_199_254_740_993 => Some(i),
+            _ => None,
+        })
+        .collect();
+    assert!(!pos_2p53.is_empty() && !pos_2p53_plus_1.is_empty());
+    let max_2p53 = pos_2p53.iter().max().unwrap();
+    let min_2p53_plus_1 = pos_2p53_plus_1.iter().min().unwrap();
+    assert!(max_2p53 < min_2p53_plus_1, "2^53 (any variant) must sort strictly before 2^53 + 1");
+}
+
+#[test]
+fn order_by_mixed_type_column_desc_does_not_panic() {
+    let db = setup_db();
+
+    let rows = execute_query(&db, "SELECT ALL c FROM def ORDER BY 1 DESC");
+    assert_eq!(rows.len(), 112);
+
+    // DESC default in SQLite: blob > text > numeric, NULLs last.
+    let classes: Vec<u8> = rows.iter().map(|r| class_of(&r.values[0])).collect();
+    let mut sorted = classes.clone();
+    sorted.sort_unstable();
+    sorted.reverse();
+    assert_eq!(classes, sorted, "DESC classes must appear as blob > text > numeric > NULL");
+}

--- a/crates/vibesql-types/src/lib.rs
+++ b/crates/vibesql-types/src/lib.rs
@@ -17,5 +17,5 @@ pub use sql_mode::{
     types::{TypeBehavior, ValueType},
     ConcatOperator, DivisionBehavior, MySqlModeFlags, OperatorBehavior, SqlMode,
 };
-pub use sql_value::{SqlValue, StringValue};
+pub use sql_value::{total_order_cmp, SqlValue, StringValue};
 pub use temporal::{Date, Interval, IntervalField, Time, Timestamp};

--- a/crates/vibesql-types/src/sql_value/mod.rs
+++ b/crates/vibesql-types/src/sql_value/mod.rs
@@ -3,6 +3,9 @@
 mod comparison;
 mod display;
 mod hash;
+mod total_order;
+
+pub use total_order::total_order_cmp;
 
 use crate::{
     temporal::{Date, Interval, IntervalField, Time, Timestamp},

--- a/crates/vibesql-types/src/sql_value/total_order.rs
+++ b/crates/vibesql-types/src/sql_value/total_order.rs
@@ -1,0 +1,408 @@
+//! A genuine total order over [`SqlValue`] for sorting (issue #5802).
+//!
+//! SQLite's `ORDER BY` (memcompare) semantics define the cross-type ordering
+//!
+//! ```text
+//! NULL < numeric (INTEGER and REAL, inter-comparable, compared exactly) < TEXT < BLOB
+//! ```
+//!
+//! VibeSQL has additional value kinds SQLite does not (BOOLEAN, DATE, TIME,
+//! TIMESTAMP, INTERVAL, VECTOR). To keep the order *total* for arbitrary
+//! mixed-type columns, those are placed in deterministic slots after BLOB,
+//! ordered by a fixed type tag, with exact within-type comparison:
+//!
+//! ```text
+//! NULL < numeric < TEXT < BLOB < BOOLEAN < DATE < TIME < TIMESTAMP < INTERVAL < VECTOR
+//! ```
+//!
+//! Design notes:
+//!
+//! * **Numerics compare exactly, never through lossy `as f64` casts.** All
+//!   integer variants (`Integer`, `Smallint`, `Bigint`, `Unsigned`) are
+//!   widened to `i128` (which holds both `i64::MIN` and `u64::MAX`) and
+//!   compared exactly. Integer-vs-float pairs use the same approach as
+//!   SQLite's `sqlite3IntFloatCompare`: handle NaN/infinities first, then
+//!   compare the integer against the float's exact integer part with a
+//!   fractional tiebreak. This is what makes the order transitive at the f64
+//!   precision boundary (2^53), where `x as f64` rounding previously produced
+//!   non-transitive triples that made `sort_by` panic.
+//! * **NaN has a fixed total position: less than every other numeric, and
+//!   NaN == NaN.** SQLite cannot store NaN (it becomes NULL), but VibeSQL
+//!   values can carry one, and the comparator must remain total. "Less than
+//!   all reals" mirrors NaN being the value closest to NULL.
+//! * `-0.0 == 0.0` (IEEE equality), which is a consistent equivalence class
+//!   and matches SQLite.
+//! * Vectors compare elementwise via `f32::total_cmp`, then by length.
+//!
+//! NULL placement: this function orders NULL *first* (SQLite's native order).
+//! Callers that need NULLS LAST (e.g. MIN/MAX aggregate comparators, ORDER BY
+//! ... DESC defaults) handle NULL themselves before delegating, which all
+//! current executor call sites already do.
+
+use std::cmp::Ordering;
+
+use crate::sql_value::SqlValue;
+
+/// Rank of each type class in the total order. See module docs.
+fn class_rank(v: &SqlValue) -> u8 {
+    match v {
+        SqlValue::Null => 0,
+        SqlValue::Integer(_)
+        | SqlValue::Smallint(_)
+        | SqlValue::Bigint(_)
+        | SqlValue::Unsigned(_)
+        | SqlValue::Float(_)
+        | SqlValue::Real(_)
+        | SqlValue::Double(_)
+        | SqlValue::Numeric(_) => 1,
+        SqlValue::Character(_) | SqlValue::Varchar(_) => 2,
+        SqlValue::Blob(_) => 3,
+        SqlValue::Boolean(_) => 4,
+        SqlValue::Date(_) => 5,
+        SqlValue::Time(_) => 6,
+        SqlValue::Timestamp(_) => 7,
+        SqlValue::Interval(_) => 8,
+        SqlValue::Vector(_) => 9,
+    }
+}
+
+/// Exact numeric representation of a numeric-class `SqlValue`.
+enum Num {
+    Int(i128),
+    Float(f64),
+}
+
+fn numeric_repr(v: &SqlValue) -> Option<Num> {
+    match v {
+        SqlValue::Integer(i) | SqlValue::Bigint(i) => Some(Num::Int(*i as i128)),
+        SqlValue::Smallint(i) => Some(Num::Int(*i as i128)),
+        SqlValue::Unsigned(u) => Some(Num::Int(*u as i128)),
+        SqlValue::Float(f) => Some(Num::Float(*f as f64)),
+        SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f) => Some(Num::Float(*f)),
+        _ => None,
+    }
+}
+
+/// Total comparison of two floats: NaN is less than every other value and
+/// NaN == NaN. (Unlike `f64::total_cmp`, -0.0 == 0.0 here, matching SQL.)
+fn cmp_f64_total(a: f64, b: f64) -> Ordering {
+    match (a.is_nan(), b.is_nan()) {
+        (true, true) => Ordering::Equal,
+        (true, false) => Ordering::Less,
+        (false, true) => Ordering::Greater,
+        (false, false) => a.partial_cmp(&b).expect("non-NaN floats are always comparable"),
+    }
+}
+
+/// Exact comparison of an integer against a float (SQLite
+/// `sqlite3IntFloatCompare` semantics, extended to `i128`).
+///
+/// Returns the ordering of `i` relative to `f`.
+fn cmp_int_f64(i: i128, f: f64) -> Ordering {
+    if f.is_nan() {
+        // NaN is less than every numeric (see module docs), so any integer is greater.
+        return Ordering::Greater;
+    }
+    if f == f64::INFINITY {
+        return Ordering::Less;
+    }
+    if f == f64::NEG_INFINITY {
+        return Ordering::Greater;
+    }
+    // `f` is finite. `i128::MAX as f64` rounds to exactly 2^127; any float at
+    // or above it exceeds every i128 (and a fortiori every SqlValue integer).
+    if f >= i128::MAX as f64 {
+        return Ordering::Less;
+    }
+    // `i128::MIN as f64` is exactly -2^127; any float below it is smaller
+    // than every i128.
+    if f < i128::MIN as f64 {
+        return Ordering::Greater;
+    }
+    // `f.floor()` is an integer-valued finite f64 with |floor| <= 2^127, so
+    // the `as i128` conversion is exact (saturating only at i128::MIN, which
+    // is itself exact).
+    let floor = f.floor();
+    let floor_int = floor as i128;
+    match i.cmp(&floor_int) {
+        Ordering::Equal => {
+            if f > floor {
+                // f has a fractional part: i == floor(f) < f
+                Ordering::Less
+            } else {
+                Ordering::Equal
+            }
+        }
+        ord => ord,
+    }
+}
+
+fn cmp_num(a: Num, b: Num) -> Ordering {
+    match (a, b) {
+        (Num::Int(x), Num::Int(y)) => x.cmp(&y),
+        (Num::Float(x), Num::Float(y)) => cmp_f64_total(x, y),
+        (Num::Int(x), Num::Float(y)) => cmp_int_f64(x, y),
+        (Num::Float(x), Num::Int(y)) => cmp_int_f64(y, x).reverse(),
+    }
+}
+
+/// Compare two [`SqlValue`]s under a genuine total order with SQLite
+/// cross-type ordering semantics (see module docs).
+///
+/// Guarantees (for all values `a`, `b`, `c`):
+/// * totality: always returns an `Ordering` (never panics),
+/// * antisymmetry: `cmp(a, b) == cmp(b, a).reverse()`,
+/// * transitivity: `a <= b && b <= c` implies `a <= c`.
+///
+/// Safe to use with `sort_by`, `sort_unstable_by`, `min_by`, `max_by`, and
+/// `BinaryHeap`-style consumers that require `Ord`-like behavior.
+pub fn total_order_cmp(a: &SqlValue, b: &SqlValue) -> Ordering {
+    use SqlValue::*;
+
+    let (rank_a, rank_b) = (class_rank(a), class_rank(b));
+    if rank_a != rank_b {
+        return rank_a.cmp(&rank_b);
+    }
+
+    match (a, b) {
+        (Null, Null) => Ordering::Equal,
+        (Character(x) | Varchar(x), Character(y) | Varchar(y)) => x.as_str().cmp(y.as_str()),
+        (Blob(x), Blob(y)) => x.cmp(y),
+        (Boolean(x), Boolean(y)) => x.cmp(y),
+        (Date(x), Date(y)) => x.cmp(y),
+        (Time(x), Time(y)) => x.cmp(y),
+        (Timestamp(x), Timestamp(y)) => x.cmp(y),
+        (Interval(x), Interval(y)) => x.cmp(y),
+        (Vector(x), Vector(y)) => {
+            for (xa, ya) in x.iter().zip(y.iter()) {
+                let c = xa.total_cmp(ya);
+                if c != Ordering::Equal {
+                    return c;
+                }
+            }
+            x.len().cmp(&y.len())
+        }
+        _ => {
+            // Same class rank and not matched above: both are numeric.
+            let (na, nb) = (
+                numeric_repr(a).expect("class rank 1 implies numeric"),
+                numeric_repr(b).expect("class rank 1 implies numeric"),
+            );
+            cmp_num(na, nb)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sql_value::StringValue;
+
+    const P53: i64 = 9_007_199_254_740_992; // 2^53
+
+    #[test]
+    fn integer_float_boundary_cases() {
+        use Ordering::*;
+        use SqlValue::*;
+
+        // Exact integer comparison across variants
+        assert_eq!(total_order_cmp(&Bigint(P53), &Bigint(P53 + 1)), Less);
+        assert_eq!(total_order_cmp(&Integer(P53), &Bigint(P53 + 1)), Less);
+        assert_eq!(total_order_cmp(&Unsigned(P53 as u64 + 1), &Integer(P53)), Greater);
+
+        // The non-transitive triple from issue #5802: 2^53 + 1 rounds to 2^53
+        // under `as f64`, but must compare Greater exactly.
+        assert_eq!(total_order_cmp(&Bigint(P53), &Double(P53 as f64)), Equal);
+        assert_eq!(total_order_cmp(&Bigint(P53 + 1), &Double(P53 as f64)), Greater);
+        assert_eq!(total_order_cmp(&Double(P53 as f64), &Bigint(P53 + 1)), Less);
+
+        // i64::MAX vs the float it rounds to (2^63, which is > i64::MAX)
+        let two_p63 = 9.223_372_036_854_776e18;
+        assert_eq!(total_order_cmp(&Integer(i64::MAX), &Double(two_p63)), Less);
+        assert_eq!(total_order_cmp(&Bigint(i64::MAX), &Double(two_p63 - 2048.0)), Greater);
+
+        // i64::MIN is exactly representable as f64
+        assert_eq!(total_order_cmp(&Integer(i64::MIN), &Double(-9.223_372_036_854_776e18)), Equal);
+
+        // u64::MAX vs 2^64 (u64::MAX rounds up to 2^64 under `as f64`)
+        let two_p64 = 1.844_674_407_370_955_2e19;
+        assert_eq!(total_order_cmp(&Unsigned(u64::MAX), &Double(two_p64)), Less);
+
+        // Fractional tiebreak
+        assert_eq!(total_order_cmp(&Integer(3), &Double(3.5)), Less);
+        assert_eq!(total_order_cmp(&Integer(4), &Double(3.5)), Greater);
+        assert_eq!(total_order_cmp(&Integer(-4), &Double(-3.5)), Less);
+        assert_eq!(total_order_cmp(&Integer(-3), &Double(-3.5)), Greater);
+        assert_eq!(total_order_cmp(&Integer(3), &Double(3.0)), Equal);
+
+        // Infinities
+        assert_eq!(total_order_cmp(&Double(f64::INFINITY), &Unsigned(u64::MAX)), Greater);
+        assert_eq!(total_order_cmp(&Double(f64::NEG_INFINITY), &Integer(i64::MIN)), Less);
+        assert_eq!(total_order_cmp(&Double(f64::INFINITY), &Double(f64::INFINITY)), Equal);
+
+        // NaN: fixed slot below every other numeric, NaN == NaN
+        assert_eq!(total_order_cmp(&Double(f64::NAN), &Double(f64::NAN)), Equal);
+        assert_eq!(total_order_cmp(&Double(f64::NAN), &Double(f64::NEG_INFINITY)), Less);
+        assert_eq!(total_order_cmp(&Double(f64::NAN), &Integer(i64::MIN)), Less);
+        assert_eq!(total_order_cmp(&Integer(0), &Double(f64::NAN)), Greater);
+        assert_eq!(total_order_cmp(&Float(f32::NAN), &Double(f64::NAN)), Equal);
+
+        // -0.0 == 0.0 == Integer(0)
+        assert_eq!(total_order_cmp(&Double(-0.0), &Double(0.0)), Equal);
+        assert_eq!(total_order_cmp(&Integer(0), &Double(-0.0)), Equal);
+    }
+
+    #[test]
+    fn class_ordering_null_numeric_text_blob() {
+        use Ordering::*;
+        use SqlValue::*;
+
+        let null = Null;
+        let num = Integer(i64::MAX);
+        let text = Varchar(StringValue::from(""));
+        let blob = Blob(vec![]);
+        let boolean = Boolean(false);
+
+        assert_eq!(total_order_cmp(&null, &num), Less);
+        assert_eq!(total_order_cmp(&num, &text), Less);
+        assert_eq!(total_order_cmp(&text, &blob), Less);
+        assert_eq!(total_order_cmp(&blob, &boolean), Less);
+
+        // Character and Varchar are the same class and inter-comparable
+        assert_eq!(
+            total_order_cmp(
+                &Character(StringValue::from("abc")),
+                &Varchar(StringValue::from("abc"))
+            ),
+            Equal
+        );
+    }
+
+    /// Build a set of adversarial values covering every class and the exact
+    /// pathological numeric boundaries from the fuzz.test panic.
+    fn adversarial_values() -> Vec<SqlValue> {
+        use SqlValue::*;
+
+        let mut vals = vec![Null];
+
+        for i in
+            [0i64, 1, -1, i64::MAX, i64::MIN, P53, P53 + 1, P53 - 1, -P53, -P53 - 1, -2_147_483_648]
+        {
+            vals.push(Integer(i));
+            vals.push(Bigint(i));
+        }
+        for i in [0i16, 1, -1, i16::MAX, i16::MIN] {
+            vals.push(Smallint(i));
+        }
+        for u in [0u64, 1, u64::MAX, 1 << 63, P53 as u64 + 1] {
+            vals.push(Unsigned(u));
+        }
+        for f in [
+            0.0f64,
+            -0.0,
+            1.5,
+            -1.5,
+            0.5,
+            P53 as f64,
+            9_007_199_254_740_994.0, // 2^53 + 2
+            9.223_372_036_854_776e18,
+            -9.223_372_036_854_776e18,
+            1.844_674_407_370_955_2e19,
+            f64::NAN,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            f64::MAX,
+            f64::MIN,
+        ] {
+            vals.push(Double(f));
+            vals.push(Numeric(f));
+            vals.push(Real(f));
+        }
+        for f in [0.0f32, 1.5, -1.5, f32::NAN, f32::INFINITY, 16_777_217.0] {
+            vals.push(Float(f));
+        }
+        for s in ["", "a", "b", "0", "10"] {
+            vals.push(Character(StringValue::from(s)));
+            vals.push(Varchar(StringValue::from(s)));
+        }
+        for b in [vec![], vec![0u8], vec![0xffu8], b"abc".to_vec()] {
+            vals.push(Blob(b));
+        }
+        vals.push(Boolean(false));
+        vals.push(Boolean(true));
+        vals.push(Date("2024-01-15".parse::<crate::temporal::Date>().unwrap()));
+        vals.push(Date("1999-12-31".parse::<crate::temporal::Date>().unwrap()));
+        vals.push(Time("12:34:56".parse::<crate::temporal::Time>().unwrap()));
+        vals.push(Vector(vec![1.0, 2.0]));
+        vals.push(Vector(vec![f32::NAN]));
+        vals.push(Vector(vec![]));
+
+        vals
+    }
+
+    /// Property test: totality, reflexivity, antisymmetry, and full O(n^3)
+    /// transitivity over the adversarial value set (issue #5802 acceptance
+    /// criterion: the comparator is a *genuine* total order).
+    #[test]
+    fn total_order_properties_exhaustive() {
+        let vals = adversarial_values();
+        let n = vals.len();
+        assert!(n >= 60, "want a meaningful adversarial set, got {n}");
+
+        // Reflexivity + antisymmetry over all pairs
+        for a in &vals {
+            assert_eq!(total_order_cmp(a, a), Ordering::Equal, "reflexivity failed for {a:?}");
+        }
+        for a in &vals {
+            for b in &vals {
+                assert_eq!(
+                    total_order_cmp(a, b),
+                    total_order_cmp(b, a).reverse(),
+                    "antisymmetry failed for {a:?} vs {b:?}"
+                );
+            }
+        }
+
+        // Transitivity over all triples: a <= b && b <= c => a <= c,
+        // and strictness: a < b && b <= c => a < c.
+        for a in &vals {
+            for b in &vals {
+                let ab = total_order_cmp(a, b);
+                if ab == Ordering::Greater {
+                    continue;
+                }
+                for c in &vals {
+                    let bc = total_order_cmp(b, c);
+                    if bc == Ordering::Greater {
+                        continue;
+                    }
+                    let ac = total_order_cmp(a, c);
+                    assert_ne!(
+                        ac,
+                        Ordering::Greater,
+                        "transitivity failed: {a:?} <= {b:?} <= {c:?} but {a:?} > {c:?}"
+                    );
+                    if ab == Ordering::Less || bc == Ordering::Less {
+                        assert_eq!(
+                            ac,
+                            Ordering::Less,
+                            "strict transitivity failed: {a:?} < {b:?} <= {c:?} (or <=/<) \
+                             but {a:?} !< {c:?}"
+                        );
+                    }
+                }
+            }
+        }
+
+        // And the std sort must accept it without panicking.
+        let mut sorted = vals.clone();
+        sorted.sort_by(total_order_cmp);
+        // Duplicate the set several times to exceed the small-sort threshold
+        // that triggered the original panic (roughly 65 or more elements).
+        let mut big: Vec<SqlValue> = Vec::new();
+        for _ in 0..3 {
+            big.extend(vals.iter().cloned());
+        }
+        big.sort_unstable_by(total_order_cmp);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the fuzz.test panic `user-provided comparison function does not correctly implement a total order` when sorting a mixed-type column (int/text/real/blob/null) with >= ~65 rows.

Closes #5802
Part of #5779

## Root cause

`compare_sql_values` (crates/vibesql-executor/src/select/grouping/aggregates.rs) compared **same-variant** numerics exactly via `SqlValue`'s `PartialOrd` (which only matches same-variant pairs), but fell back to **lossy `as f64` casts** for cross-variant numeric pairs. The exact non-transitive triple:

- `a = Bigint(9007199254740992)` (2^53)
- `b = Bigint(9007199254740993)` (2^53 + 1)
- `c = Double(9007199254740992.0)` (2^53 exactly)

`a < b` (exact i64 compare, same variant), but `a == c` **and** `b == c` because `9007199254740993 as f64` rounds to 2^53. Additional violations: `Double(NaN)` compared `Equal` to every numeric (while other numerics ordered among themselves), and all non-numeric non-text cross-type pairs (Blob vs Boolean vs Date, ...) collapsed to `Equal`. The second private comparator in `memory/external_sort.rs` was worse still — it treated **every** cross-variant pair (even Integer vs Bigint) as Equal.

## Fix

New shared `vibesql_types::total_order_cmp` (crates/vibesql-types/src/sql_value/total_order.rs) implementing SQLite memcompare semantics as a genuine total order:

```
NULL < numeric < TEXT < BLOB < BOOLEAN < DATE < TIME < TIMESTAMP < INTERVAL < VECTOR
```

- All numeric variants are inter-comparable and compared **exactly**: integer variants widen to `i128` (covers `i64::MIN` through `u64::MAX`); integer-vs-float uses SQLite's `sqlite3IntFloatCompare` approach (NaN/infinities first, i128-range bounds, then exact integer-part comparison with fractional tiebreak) — never lossy `int as f64`.
- NaN has a fixed slot: less than every other numeric, `NaN == NaN` (SQLite can't store NaN, but the order must stay total; documented in module docs).
- VibeSQL-only kinds (BOOLEAN/DATE/.../VECTOR) get deterministic slots after BLOB so the order stays total for exotic mixes (documented choice; SQLite has no such values).
- Both executor comparators (`select/grouping/aggregates.rs` and `memory/external_sort.rs`) now delegate to it. The NULLS-LAST contract of `compare_sql_values` (relied on by MIN/MAX) is preserved — only the non-NULL lattice changed.

## Test evidence (verified fail-before / pass-after)

Before the fix (tests written and run first):
- `test_compare_sql_values_transitive_at_f64_precision_boundary` failed: `compare_sql_values(Bigint(2^53+1), Double(2^53))` returned `Equal` instead of `Greater` — the non-transitive triple confirmed.
- `test_compare_sql_values_total_order_mixed_types_sort` (120 mixed values) failed: sorted output interleaved blob/boolean classes.
- Integration test `order_by_mixed_type_column_does_not_panic` (112 mixed-variant rows through real `SELECT ... ORDER BY 1 ASC`) failed: 2^53+1 sorted before 2^53 occurrences.

After the fix:
- New exhaustive property test in vibesql-types: totality/reflexivity/antisymmetry over all pairs and full O(n^3) transitivity over ~100 adversarial values (2^53 boundary ints, i64::MAX/MIN, u64::MAX, floats equal to those, NaN, +/-inf, -0.0, texts, blobs, booleans, dates, vectors) — passes.
- vibesql-types: 108 lib tests pass (was 105; +3 new).
- vibesql-executor lib: 3049 pass, 0 fail (+2 new comparator tests; `test_deep_case_expressions` stack-overflows pre-existing on this branch's base too — verified via `git stash`, unrelated to this change).
- vibesql-executor all integration test targets: pass (exit 0), including the new `order_by_mixed_type_total_order_tests` (2 tests).
- vibesql-storage WAL tests: 112 pass (no storage changes).
- CLI smoke of the original issue query shape (112 mixed rows, `SELECT ALL c, CAST(-2147483648 AS blob) FROM def ORDER BY 1 ASC`): returns 112 rows, blobs last, no panic.

## TCL conformance smoke (release build in worktree)

| file | total | passed | failed |
|---|---|---|---|
| orderby1.test | 64 | 38 | 0 (26 skipped) |
| cast.test | 126 | 122 | 0 (4 skipped) |
| select1.test | 188 | 188 | 0 |
| types.test | 1 | 0 | 0 (1 skipped) |
| sort.test | 0 extracted | - | - |

No TCL regressions.

## WAL representation investigation (acceptance criterion 3)

Determination: **WAL crash recovery does not change value representation.**
- `write_sql_value`/`read_sql_value` (crates/vibesql-storage/src/persistence/binary/value.rs) are variant-faithful: every `SqlValue` variant has its own type tag and round-trips exactly (Integer stays Integer, Bigint stays Bigint, etc.).
- Both the fresh-insert path and recovery replay normalize through the same `RowNormalizer` (`Table::insert` at crates/vibesql-storage/src/table/mod.rs:275, `Table::update_row` at :853; `RecoveryManager::apply_op` calls these directly), so recovered rows end up with the same variants as originally stored.
- Why the panic only reproduced after recovery: the recovered database **faithfully preserves** the fuzzer-created mix of internal variants (Integer vs Bigint vs Double of the same displayed value). Re-inserting the *displayed* values as SQL literals cannot recreate that mix (all i64 literals parse to one variant), so fresh inserts never assembled the non-transitive triple. WAL was the faithful messenger, not the culprit — no storage fix or follow-up issue needed.
- Minor observation (harmless): `Database::insert_row` logs pre-normalization values to the WAL (crates/vibesql-storage/src/database/table_api.rs:385) while `table.insert` stores post-normalization values; recovery re-normalizes deterministically on replay, so the results are identical.

## Pre-existing failures noted (not addressed here)

- `cargo clippy -p vibesql-executor --tests` fails on `clippy::approx_constant` at crates/vibesql-executor/src/evaluator/expressions/operators.rs:339 (untouched by this PR; evaluator/ is being edited by other agents).
- `evaluator::tests::deep_expression_tests::test_deep_case_expressions` stack-overflows in debug lib tests (reproduced with this PR's changes stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)