### PR TITLE
fix(test-harness): mark every non-completed TCL file with an explicit status row; report run universe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,10 @@ Results are stored in two tables in `~/.vibesql/test_results/tcl_test_results.vb
 
 Both native-TCL mode (the default) and static-parsing mode now write per-test detail rows, so the summary and detail tables reconcile exactly.
 
+**Marker statuses**: a file that does not run to completion never silently vanishes from the universe. The runner writes a synthetic marker row per compromised file — `status='timeout'` (per-file timeout expired; any tests that completed before the kill are salvaged as normal rows), `status='incomplete'` (tclsh worker killed by a signal or the shim crashed before its summary trailer; partial rows are kept), or `status='error'` (runner-level failure). Marker rows count as failures in pass-rate math so a compromised run reads *worse*, never silently smaller. `make test-tcl-status` reports files-attempted vs files-with-results plus marker counts, and warns when the file universe shrinks vs the previous run.
+
+> **Quiet-machine guidance:** full canonical runs must be done on a quiet machine (no concurrent builds/benchmarks). A loaded machine produces timeout/incomplete markers, and a run containing any markers is not comparable to a clean-run baseline — rerun the affected files (or the whole suite) on a quiet machine.
+
 **Canonical "current pass rate" query** (run against `tcl_test_results`; its numbers match `make test-tcl-status` to within ±1 rounding):
 
 ```sql
@@ -66,9 +70,10 @@ SELECT
   SUM(CASE WHEN status='passed'  THEN 1 ELSE 0 END) AS passed,
   SUM(CASE WHEN status='failed'  THEN 1 ELSE 0 END) AS failed,
   SUM(CASE WHEN status='skipped' THEN 1 ELSE 0 END) AS skipped,
+  SUM(CASE WHEN status IN ('timeout','incomplete','error') THEN 1 ELSE 0 END) AS not_run_markers,
   ROUND(
     100.0 * SUM(CASE WHEN status='passed' THEN 1 ELSE 0 END)
-      / NULLIF(SUM(CASE WHEN status IN ('passed','failed') THEN 1 ELSE 0 END), 0),
+      / NULLIF(SUM(CASE WHEN status IN ('passed','failed','timeout','incomplete','error') THEN 1 ELSE 0 END), 0),
     1
   ) AS pass_rate
 FROM tcl_test_results
@@ -82,11 +87,11 @@ Run it with:
 ./target/release/vibesql ~/.vibesql/test_results/tcl_test_results.vbsql -c "<query above>"
 ```
 
-**Per-file failure breakdown** (these per-file failure counts sum to the total-failed reported by `make test-tcl-status`):
+**Per-file failure breakdown** (these per-file failure counts sum to the total-failed reported by `make test-tcl-status`; timeout/incomplete/error marker rows are included because the summary table counts them as failures):
 
 ```sql
 SELECT file_path,
-  SUM(CASE WHEN status='failed' THEN 1 ELSE 0 END) AS failed
+  SUM(CASE WHEN status IN ('failed','timeout','incomplete','error') THEN 1 ELSE 0 END) AS failed
 FROM tcl_test_results
 WHERE run_id = (SELECT MAX(run_id) FROM tcl_test_results)
 GROUP BY file_path

--- a/scripts/tcl_runner.py
+++ b/scripts/tcl_runner.py
@@ -1261,10 +1261,12 @@ def main():
             json.dump(summary.to_dict(), f, indent=2)
         print(f"JSON output: {args.output}")
 
-    # Exit with error if there were failures
+    # Exit with error if there were failures. status='error' rows (parse
+    # errors and runner-error marker rows) also fail the run so a compromised
+    # static run exits non-zero, matching native mode (#5822 review note).
     if _SAVE_HAD_FATAL_INSERT_FAILURES:
         sys.exit(2)
-    if summary.failed > 0:
+    if summary.failed > 0 or summary.parse_errors > 0:
         sys.exit(1)
 
 

--- a/scripts/tcl_runner.py
+++ b/scripts/tcl_runner.py
@@ -642,6 +642,21 @@ class TclTestRunner:
                 elif result.status == "error":
                     summary.parse_errors += 1
 
+        def runner_error_marker(file_path: str, e: Exception) -> TestResult:
+            """Synthetic detail row for a file the runner failed to process.
+
+            Without this the file contributed zero detail rows and silently
+            vanished from the run universe (issue #5821).
+            """
+            return TestResult(
+                test_name="RUNNER ERROR",
+                file_path=file_path,
+                test_type="runner",
+                status="error",
+                sql="",
+                error_message=str(e)[:500],
+            )
+
         if parallel:
             # Parallel execution
             with ThreadPoolExecutor(max_workers=os.cpu_count()) as executor:
@@ -652,8 +667,8 @@ class TclTestRunner:
                         results, file_setup_failed = future.result()
                         process_file_results(results, file_setup_failed)
                     except Exception as e:
-                        summary.parse_errors += 1
                         print(f"Error processing {file_path}: {e}")
+                        process_file_results([runner_error_marker(file_path, e)], False)
         else:
             # Sequential execution
             for i, file_path in enumerate(file_paths):
@@ -664,8 +679,8 @@ class TclTestRunner:
                     results, file_setup_failed = self.run_file(file_path)
                     process_file_results(results, file_setup_failed)
                 except Exception as e:
-                    summary.parse_errors += 1
                     print(f"Error processing {file_path}: {e}")
+                    process_file_results([runner_error_marker(file_path, e)], False)
 
         summary.completed_at = datetime.now().isoformat()
         return summary
@@ -821,6 +836,98 @@ def save_to_database(summary: RunSummary, db_path: str, vibesql_path: str):
 # Format emitted by tester_vibesql.tcl: "##TCLTEST## <status>\t<name>"
 TCL_DETAIL_PREFIX = "##TCLTEST## "
 
+# Detail-row statuses used for synthetic "the file did not run to completion"
+# marker rows. These keep compromised files visible in the run universe so
+# per-run pass rates remain comparable (see issue #5821 / CLAUDE.md):
+#   timeout    - the per-file wall-clock timeout expired (subprocess killed)
+#   incomplete - the tclsh worker died early (killed by a signal, or the shim
+#                crashed before printing its "Tests run:" summary trailer)
+#   error      - the runner itself failed to launch/process the file
+MARKER_STATUSES = ("timeout", "incomplete", "error")
+
+
+def _parse_shim_output(output: str, test_file: str) -> tuple[int, int, int, list[str], list["TestResult"], str, bool]:
+    """
+    Parse tclsh shim output (possibly partial) into per-test results.
+
+    Returns:
+        (passed, failed, skipped, failed_test_names, per_test_results,
+         human_output, saw_summary)
+
+    `saw_summary` is True when the shim's "Tests run:" trailer is present,
+    i.e. the file ran to completion (finish_test was reached). Partial output
+    from a killed/crashed worker lacks the trailer.
+    """
+    passed = 0
+    failed = 0
+    skipped = 0
+    failed_tests: list[str] = []
+    per_test_results: list[TestResult] = []
+    human_lines: list[str] = []
+    saw_summary = False
+
+    for line in output.split('\n'):
+        # Machine-readable per-test detail line
+        if line.startswith(TCL_DETAIL_PREFIX):
+            payload = line[len(TCL_DETAIL_PREFIX):]
+            if '\t' in payload:
+                status, test_name = payload.split('\t', 1)
+            else:
+                status, test_name = payload, ""
+            status = status.strip()
+            test_name = test_name.strip()
+            per_test_results.append(TestResult(
+                test_name=test_name,
+                file_path=test_file,
+                test_type="native-tcl",
+                status=status,
+                sql="",
+            ))
+            continue
+
+        # Non-detail line: keep for human output and summary parsing
+        human_lines.append(line)
+
+        if 'Tests run:' in line:
+            saw_summary = True
+        elif 'Tests passed:' in line:
+            match = re.search(r'Tests passed:\s*(\d+)', line)
+            if match:
+                passed = int(match.group(1))
+        elif 'Tests failed:' in line:
+            match = re.search(r'Tests failed:\s*(\d+)', line)
+            if match:
+                failed = int(match.group(1))
+        elif 'Tests skipped:' in line:
+            match = re.search(r'Tests skipped:\s*(\d+)', line)
+            if match:
+                skipped = int(match.group(1))
+
+    # Extract failed test names if present
+    human_output = '\n'.join(human_lines)
+    if 'Failed tests:' in human_output:
+        in_failed_section = False
+        for line in human_lines:
+            if 'Failed tests:' in line:
+                in_failed_section = True
+                continue
+            if in_failed_section and line.strip().startswith('-'):
+                failed_tests.append(line.strip().lstrip('- '))
+
+    return passed, failed, skipped, failed_tests, per_test_results, human_output, saw_summary
+
+
+def _counts_from_details(per_test_results: list["TestResult"]) -> tuple[int, int, int]:
+    """Derive (passed, failed, skipped) counts from per-test detail rows.
+
+    Used when the shim's summary trailer is absent (worker killed/crashed),
+    so the trailer counts are missing or untrustworthy.
+    """
+    passed = sum(1 for r in per_test_results if r.status == "passed")
+    failed = sum(1 for r in per_test_results if r.status == "failed")
+    skipped = sum(1 for r in per_test_results if r.status == "skipped")
+    return passed, failed, skipped
+
 
 def run_native_tcl(test_file: str, shim_path: str, verbose: bool = False, timeout: float = 1200.0) -> tuple[int, int, int, list[str], list[TestResult]]:
     """
@@ -833,6 +940,17 @@ def run_native_tcl(test_file: str, shim_path: str, verbose: bool = False, timeou
     "##TCLTEST## <status>\t<name>" line per test. We parse those into per-test
     TestResult rows so native-TCL runs populate the tcl_test_results detail
     table (not just the tcl_test_runs summary).
+
+    A file that does not run to completion never silently vanishes from the
+    universe (issue #5821). Three escape paths are covered:
+      1. Wall-clock timeout: partial output from e.stdout/e.stderr is salvaged
+         and a synthetic `timeout` marker row is appended.
+      2. Worker killed by a signal or shim crash (subprocess.run returns, but
+         returncode < 0 or the "Tests run:" trailer is missing): the partial
+         results are kept and an `incomplete` marker row is appended.
+      3. Runner-level exception: an `error` marker row is emitted.
+    Marker rows count toward the failed total so compromised runs exit
+    non-zero and their totals are visibly worse, never silently smaller.
 
     Returns: (passed, failed, skipped, failed_test_names, per_test_results)
     """
@@ -849,93 +967,102 @@ def run_native_tcl(test_file: str, shim_path: str, verbose: bool = False, timeou
         )
         output = result.stdout + result.stderr
 
-        # Parse the summary from output
-        # Expected format:
-        # Tests run:    N
-        # Tests passed: N
-        # Tests failed: N
-        # Tests skipped: N
-
-        passed = 0
-        failed = 0
-        skipped = 0
-        failed_tests = []
-        per_test_results: list[TestResult] = []
-        human_lines: list[str] = []
-
-        for line in output.split('\n'):
-            # Machine-readable per-test detail line
-            if line.startswith(TCL_DETAIL_PREFIX):
-                payload = line[len(TCL_DETAIL_PREFIX):]
-                if '\t' in payload:
-                    status, test_name = payload.split('\t', 1)
-                else:
-                    status, test_name = payload, ""
-                status = status.strip()
-                test_name = test_name.strip()
-                per_test_results.append(TestResult(
-                    test_name=test_name,
-                    file_path=test_file,
-                    test_type="native-tcl",
-                    status=status,
-                    sql="",
-                ))
-                continue
-
-            # Non-detail line: keep for human output and summary parsing
-            human_lines.append(line)
-
-            if 'Tests passed:' in line:
-                match = re.search(r'Tests passed:\s*(\d+)', line)
-                if match:
-                    passed = int(match.group(1))
-            elif 'Tests failed:' in line:
-                match = re.search(r'Tests failed:\s*(\d+)', line)
-                if match:
-                    failed = int(match.group(1))
-            elif 'Tests skipped:' in line:
-                match = re.search(r'Tests skipped:\s*(\d+)', line)
-                if match:
-                    skipped = int(match.group(1))
-
-        # Extract failed test names if present
-        human_output = '\n'.join(human_lines)
-        if 'Failed tests:' in human_output:
-            in_failed_section = False
-            for line in human_lines:
-                if 'Failed tests:' in line:
-                    in_failed_section = True
-                    continue
-                if in_failed_section and line.strip().startswith('-'):
-                    failed_tests.append(line.strip().lstrip('- '))
+        passed, failed, skipped, failed_tests, per_test_results, human_output, saw_summary = \
+            _parse_shim_output(output, test_file)
 
         # Print human-readable output only (detail markers are stripped so they
         # don't clutter the console).
         if human_output.strip():
             print(human_output)
 
+        # Detect an incomplete run: the worker was killed by a signal
+        # (returncode < 0, e.g. OOM-kill / SIGKILL under load) or the shim
+        # crashed before printing its summary trailer. Either way the partial
+        # ##TCLTEST## rows must NOT be treated as the file's complete result
+        # set: keep them, derive counts from them (the trailer is missing),
+        # and append an explicit `incomplete` marker row.
+        incomplete = (result.returncode is not None and result.returncode < 0) or not saw_summary
+        if incomplete:
+            if result.returncode is not None and result.returncode < 0:
+                reason = f"worker killed by signal {-result.returncode}"
+            else:
+                reason = f"worker exited (code {result.returncode}) without summary trailer"
+            passed, failed, skipped = _counts_from_details(per_test_results)
+            print(
+                f"WARNING: incomplete run for {test_file}: {reason}; "
+                f"kept {len(per_test_results)} partial result(s), writing 'incomplete' marker row"
+            )
+            per_test_results.append(TestResult(
+                test_name=f"INCOMPLETE ({reason})",
+                file_path=test_file,
+                test_type="native-tcl",
+                status="incomplete",
+                sql="",
+                error_message=f"File did not run to completion: {reason}. "
+                              f"{len(per_test_results)} partial result(s) salvaged.",
+            ))
+            failed_tests.append(f"INCOMPLETE: {reason}")
+            return passed, failed + 1, skipped, failed_tests, per_test_results
+
         return passed, failed, skipped, failed_tests, per_test_results
 
-    except subprocess.TimeoutExpired:
-        print(f"Timeout running {test_file} (exceeded {timeout:.0f}s)")
+    except subprocess.TimeoutExpired as e:
+        # Salvage whatever completed before the kill: subprocess.run captures
+        # the partial stdout/stderr on TimeoutExpired. Note: TimeoutExpired
+        # carries raw bytes even when text=True. The trailer is never present
+        # here, so derive counts from the salvaged detail rows.
+        def _to_text(data) -> str:
+            if data is None:
+                return ""
+            if isinstance(data, bytes):
+                return data.decode("utf-8", errors="replace")
+            return data
+
+        partial_output = _to_text(e.stdout) + _to_text(e.stderr)
+        _, _, _, failed_tests, per_test_results, human_output, _ = \
+            _parse_shim_output(partial_output, test_file)
+        passed, failed, skipped = _counts_from_details(per_test_results)
+
+        if human_output.strip():
+            print(human_output)
+        print(
+            f"Timeout running {test_file} (exceeded {timeout:.0f}s); "
+            f"salvaged {len(per_test_results)} partial result(s), writing 'timeout' marker row"
+        )
+
         # Surface the timeout as a visible non-pass result instead of silently
-        # dropping the file from the totals. We emit one synthetic failed detail
-        # row so the file still appears in tcl_test_results and counts toward the
-        # summary's failed total, keeping the summary and detail tables
-        # reconciled (see CLAUDE.md). Without this a timed-out file contributed
-        # zero rows and vanished from the measured suite.
-        timeout_result = TestResult(
+        # dropping the file from the totals. The synthetic `timeout` detail row
+        # keeps the file in tcl_test_results and counts toward the summary's
+        # failed total, keeping the summary and detail tables reconciled (see
+        # CLAUDE.md). Without this a timed-out file contributed zero rows and
+        # vanished from the measured suite.
+        per_test_results.append(TestResult(
             test_name=f"TIMEOUT (exceeded {timeout:.0f}s)",
             file_path=test_file,
             test_type="native-tcl",
-            status="failed",
+            status="timeout",
             sql="",
-            error_message=f"Test file timed out after {timeout:.0f}s",
-        )
-        return 0, 1, 0, ["TIMEOUT"], [timeout_result]
+            error_message=f"Test file timed out after {timeout:.0f}s. "
+                          f"{len(per_test_results)} partial result(s) salvaged.",
+        ))
+        failed_tests.append("TIMEOUT")
+        return passed, failed + 1, skipped, failed_tests, per_test_results
+
     except Exception as e:
+        # Runner-level failure (tclsh missing, OS error, ...). Emit an explicit
+        # `error` marker row so the file stays in the universe instead of
+        # contributing zero rows, and count it as a failure so the run exits
+        # non-zero.
         print(f"Error running {test_file}: {e}")
-        return 0, 0, 0, [str(e)], []
+        error_result = TestResult(
+            test_name="RUNNER ERROR",
+            file_path=test_file,
+            test_type="native-tcl",
+            status="error",
+            sql="",
+            error_message=str(e)[:500],
+        )
+        return 0, 1, 0, [f"RUNNER ERROR: {e}"], [error_result]
 
 
 def main():
@@ -994,6 +1121,13 @@ def main():
         total_skipped = 0
         all_failed_tests = []
         all_results: list[TestResult] = []
+        # Run-universe accounting (issue #5821): every attempted file must be
+        # visible in the summary, either via real results or a marker row.
+        files_attempted = len(file_paths)
+        files_with_results = 0
+        files_timeout = 0
+        files_incomplete = 0
+        files_error = 0
 
         for file_path in file_paths:
             if args.verbose:
@@ -1008,15 +1142,44 @@ def main():
             all_failed_tests.extend(failed_tests)
             all_results.extend(results)
 
+            statuses = {r.status for r in results}
+            if results:
+                files_with_results += 1
+            if "timeout" in statuses:
+                files_timeout += 1
+            if "incomplete" in statuses:
+                files_incomplete += 1
+            if "error" in statuses:
+                files_error += 1
+
         # Print summary
         total_tests = total_passed + total_failed + total_skipped
+        files_compromised = files_timeout + files_incomplete + files_error
         print()
         print("=" * 50)
         print(f"Total tests: {total_tests}")
         print(f"Passed:      {total_passed} ({total_passed/total_tests*100:.1f}%)" if total_tests > 0 else "Passed: 0")
         print(f"Failed:      {total_failed}")
         print(f"Skipped:     {total_skipped}")
+        print("-" * 50)
+        print(f"Files attempted:    {files_attempted}")
+        print(f"Files with results: {files_with_results}")
+        if files_timeout > 0:
+            print(f"Files timed out:    {files_timeout} (marked status='timeout')")
+        if files_incomplete > 0:
+            print(f"Files incomplete:   {files_incomplete} (worker died; marked status='incomplete')")
+        if files_error > 0:
+            print(f"Files runner-error: {files_error} (marked status='error')")
         print("=" * 50)
+
+        if files_compromised > 0 or files_with_results < files_attempted:
+            print(
+                f"\nWARNING: {files_compromised} of {files_attempted} attempted file(s) "
+                f"did not run to completion (timeout/kill/error markers written). "
+                f"Totals from this run are NOT comparable to a clean-run baseline. "
+                f"Re-run the affected files on a quiet machine.",
+                file=sys.stderr,
+            )
 
         if all_failed_tests:
             print("\nFailed tests:")
@@ -1074,7 +1237,18 @@ def main():
     print(f"Errors:      {summary.parse_errors}")
     if summary.setup_failures > 0:
         print(f"Setup failures: {summary.setup_failures} files")
+    print("-" * 50)
+    files_with_results = len({r.file_path for r in summary.results})
+    print(f"Files attempted:    {summary.total_files}")
+    print(f"Files with results: {files_with_results}")
     print("=" * 50)
+    if files_with_results < summary.total_files:
+        print(
+            f"\nWARNING: {summary.total_files - files_with_results} of "
+            f"{summary.total_files} attempted file(s) produced no detail rows. "
+            f"Totals from this run are NOT comparable to a clean-run baseline.",
+            file=sys.stderr,
+        )
 
     # Save to database if specified
     if args.results_db:

--- a/scripts/tcltest
+++ b/scripts/tcltest
@@ -591,6 +591,62 @@ cmd_status() {
         )
         LIMIT 1
     " 2>/dev/null || print_warning "No test runs yet. Run: ./scripts/tcltest run"
+
+    # Run-universe reconciliation (issue #5821): report files-attempted vs
+    # files-with-results plus timeout/incomplete/error marker counts, and warn
+    # loudly when the file universe shrank vs the previous run — a shrunken
+    # universe means the pass rate is NOT comparable across runs.
+    local run_id
+    run_id="$("$VIBESQL_BIN" "$RESULTS_DB" --format raw -c "
+        SELECT COALESCE((SELECT MAX(run_id) FROM tcl_test_results), 0)
+    " 2>/dev/null | tr -cd '0-9')" || run_id=""
+
+    if [ -n "$run_id" ] && [ "$run_id" != "0" ]; then
+        echo ""
+        echo "=== Run universe (run_id $run_id) ==="
+        "$VIBESQL_BIN" "$RESULTS_DB" -c "
+            SELECT
+                (SELECT total_files FROM tcl_test_runs WHERE run_id = $run_id) as files_attempted,
+                COUNT(DISTINCT file_path) as files_with_results,
+                SUM(CASE WHEN status = 'timeout' THEN 1 ELSE 0 END) as timeout_markers,
+                SUM(CASE WHEN status = 'incomplete' THEN 1 ELSE 0 END) as incomplete_markers,
+                SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as error_markers
+            FROM tcl_test_results
+            WHERE run_id = $run_id
+        " 2>/dev/null || true
+
+        local attempted with_results markers prev_run prev_files
+        attempted="$("$VIBESQL_BIN" "$RESULTS_DB" --format raw -c "
+            SELECT COALESCE(total_files, 0) FROM tcl_test_runs WHERE run_id = $run_id
+        " 2>/dev/null | tr -cd '0-9')" || attempted=""
+        with_results="$("$VIBESQL_BIN" "$RESULTS_DB" --format raw -c "
+            SELECT COUNT(DISTINCT file_path) FROM tcl_test_results WHERE run_id = $run_id
+        " 2>/dev/null | tr -cd '0-9')" || with_results=""
+        markers="$("$VIBESQL_BIN" "$RESULTS_DB" --format raw -c "
+            SELECT COUNT(*) FROM tcl_test_results
+            WHERE run_id = $run_id AND status IN ('timeout', 'incomplete', 'error')
+        " 2>/dev/null | tr -cd '0-9')" || markers=""
+
+        if [ -n "$markers" ] && [ "$markers" -gt 0 ] 2>/dev/null; then
+            print_warning "$markers file(s) in run $run_id did not run to completion (timeout/incomplete/error markers). Pass rate is NOT comparable to a clean-run baseline. Re-run on a quiet machine."
+        fi
+        if [ -n "$attempted" ] && [ -n "$with_results" ] && [ "$with_results" -lt "$attempted" ] 2>/dev/null; then
+            print_warning "Run $run_id attempted $attempted file(s) but only $with_results produced detail rows — $((attempted - with_results)) file(s) are missing from the universe entirely."
+        fi
+
+        # Compare against the previous run's file universe
+        prev_run="$("$VIBESQL_BIN" "$RESULTS_DB" --format raw -c "
+            SELECT COALESCE(MAX(run_id), 0) FROM tcl_test_results WHERE run_id < $run_id
+        " 2>/dev/null | tr -cd '0-9')" || prev_run=""
+        if [ -n "$prev_run" ] && [ "$prev_run" != "0" ]; then
+            prev_files="$("$VIBESQL_BIN" "$RESULTS_DB" --format raw -c "
+                SELECT COUNT(DISTINCT file_path) FROM tcl_test_results WHERE run_id = $prev_run
+            " 2>/dev/null | tr -cd '0-9')" || prev_files=""
+            if [ -n "$prev_files" ] && [ -n "$with_results" ] && [ "$with_results" -lt "$prev_files" ] 2>/dev/null; then
+                print_warning "File universe SHRANK: run $run_id covers $with_results file(s) vs $prev_files in previous run $prev_run. Cross-run pass-rate comparison is invalid (different universes)."
+            fi
+        fi
+    fi
 }
 
 # Analyze command: failure pattern analysis

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -6013,10 +6013,15 @@ proc run_test_file {filename} {
         puts "Skipping entire file: $filename"
         puts "  Reason: $reason"
         puts ""
-        # Count as skipped but don't run any tests
+        # Count as skipped but don't run any tests. Call finish_test (rather
+        # than a bare return) so the "Tests run:" summary trailer is printed:
+        # the runner treats a missing trailer as an incomplete/killed worker
+        # and would otherwise write a false 'incomplete' marker row for every
+        # legitimately skipped file (#5822 review). Invariant: trailer <=>
+        # shim completed, including the skip-entire-file path.
         incr ::nSkip
         emit_test_detail skipped "$basename (entire file)"
-        return
+        finish_test
     }
 
     # Reset cascade tracking for new test file


### PR DESCRIPTION
Closes #5821

## Problem

When a TCL test file did not run to completion, the harness could leave **zero or partial detail rows with no marker**, so the file silently vanished from the run universe and cross-run pass rates became incomparable (run_id 3 evidence: 554/729 files, 175 files with zero rows, others truncated mid-file).

PR #5768 already marked the `subprocess.TimeoutExpired` path, but three escape paths remained unmarked (root-caused in the curator comment):

1. **Worker killed by signal / shim crash**: `subprocess.run` returns normally but `returncode` was never checked and partial `##TCLTEST##` output was parsed as if complete.
2. **Generic `except Exception`** paths returned zero rows with no marker (both native mode and the static-mode `run_files` loop).
3. **`TimeoutExpired` discarded salvageable partial output** in `e.stdout`/`e.stderr`.

## Changes

### `scripts/tcl_runner.py` (native mode)
- Extracted shim-output parsing into `_parse_shim_output()`, which also detects the shim's `Tests run:` summary trailer (only printed when `finish_test` is reached).
- **Incomplete detection**: `returncode < 0` (killed by signal) or missing trailer -> keep the partial rows, derive counts from them (the trailer counts are absent), and append a synthetic `status='incomplete'` marker row.
- **Timeout salvage**: on `TimeoutExpired`, parse the partial output carried by the exception (note: it is `bytes` even with `text=True`) so tests that completed before the kill are kept, then append a `status='timeout'` marker row (previously a bare `status='failed'` row with zero salvage).
- **Runner exceptions** emit a `status='error'` marker row and count as a failure (previously zero rows and a clean exit).
- Marker rows count toward the failed total, so a compromised run reads *worse* and exits non-zero — never silently smaller.
- Summary prints `Files attempted` vs `Files with results` plus per-category marker counts, with a loud not-baseline-comparable warning.

### `scripts/tcl_runner.py` (static mode)
- `run_files` exception paths (sequential and parallel) route a `status='error'` marker row through `process_file_results` instead of dropping the file.
- Summary prints files-attempted vs files-with-results.

### `scripts/tcltest` (`status` / `make test-tcl-status`)
- New **Run universe** section: `files_attempted`, `files_with_results`, and timeout/incomplete/error marker counts for the latest run with detail rows.
- Loud warnings when: markers exist; attempted > with-results; or the file universe **shrank vs the previous run** (cross-run comparison invalid).
- Numeric extraction uses `tr -cd '0-9'` because `--format raw` emits a trailing `0x1E` record separator that `tr -d '[:space:]'` does not strip.

### `CLAUDE.md`
- Marker statuses documented; canonical pass-rate query counts `timeout`/`incomplete`/`error` in the denominator (markers read as failures) and adds a `not_run_markers` column; per-file breakdown updated to match the summary-table failed total.
- Quiet-machine guidance for canonical runs documented (acceptance criterion).

Status choice: distinct `status='timeout'` (and `incomplete`/`error`) per the issue's acceptance criteria, rather than #5768's `status='failed'` — but all markers still count as failures in pass-rate math. The `status` column has no CHECK constraint, so no schema migration is needed. `--retry-timeouts` (a "consider" item) is deferred; the universe warnings make compromised runs impossible to miss.

## Test evidence

All harness paths exercised against the release binary (Python harness code; no Rust changes):

- **Normal flow (regression)**: `./scripts/tcltest test select1.test` (the `make test-tcl-file` path) -> 188/188 passed, `Files attempted: 1 / Files with results: 1`, no marker rows, exit 0.
- **Timeout + salvage**: `func.test` with `--timeout 15` -> 59 partial results salvaged + 1 `timeout` marker row; 60/60 detail rows inserted; DB shows `passed=59, timeout=1` with marker `error_message='Test file timed out after 15s. 59 partial result(s) salvaged.'`.
- **Kill path**: fake shim emitting 3 detail lines then `kill -9 [pid]` -> `WARNING: ... worker killed by signal 9; kept 3 partial result(s)`, `incomplete` marker written, exit 1.
- **Crash path**: fake shim exiting 1 without the trailer -> `worker exited (code 1) without summary trailer`, partial rows kept, `incomplete` marker, exit 1.
- **Runner error**: `tclsh` removed from PATH -> `error` marker row, counted as failure, exit non-zero.
- **`tcltest status`**: synthetic 2-run DB (run 1: 3 files clean; run 2: 3 attempted, 1 with results incl. a timeout marker) -> universe table correct and all three warnings fire (markers present / attempted>with-results / universe shrank 3->1). Clean-run DB shows the universe table with no warnings; empty DB skips the section cleanly.
- **Canonical query**: updated CLAUDE.md query runs against the marker DB and reconciles with the summary-table headline (66.7% both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)