### PR TITLE
feat(storage): persist generated-column expressions in binary catalog (format v11)

### DIFF
--- a/crates/vibesql-storage/src/persistence/binary/catalog.rs
+++ b/crates/vibesql-storage/src/persistence/binary/catalog.rs
@@ -84,6 +84,15 @@ pub fn write_catalog<W: Write>(writer: &mut W, db: &Database) -> Result<(), Stor
                 if let Some(coll) = &col.collation {
                     write_string(writer, coll)?;
                 }
+                // Write generated-column expression (v11+, issue #5794).
+                // Mirrors the default_value encoding: present-flag bool +
+                // expression. Without this, a reloaded schema forgets the
+                // `c AS (a+b)` expression and post-reload INSERTs store NULL
+                // for the generated column.
+                write_bool(writer, col.generated_expr.is_some())?;
+                if let Some(gen_expr) = &col.generated_expr {
+                    super::expression::write_expression(writer, gen_expr)?;
+                }
             }
 
             // Write primary key columns (v3+)
@@ -442,12 +451,26 @@ pub fn read_catalog_v<R: Read>(reader: &mut R, version: u8) -> Result<Database, 
                 None
             };
 
+            // Read generated-column expression (v11+, issue #5794).
+            // v10-and-earlier files do not include this field; absence means
+            // "not a generated column" (None), which matches prior behavior.
+            let generated_expr = if version >= 11 {
+                let has_generated = read_bool(reader)?;
+                if has_generated {
+                    Some(super::expression::read_expression(reader)?)
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
             columns.push(vibesql_catalog::ColumnSchema {
                 name: col_name,
                 data_type,
                 nullable,
                 default_value,
-                generated_expr: None,
+                generated_expr,
                 collation,
                 // Default to false for backward compatibility with existing databases
                 // New tables will have this set correctly at creation time
@@ -1237,5 +1260,130 @@ mod tests {
         let reloaded_v10 = read_catalog_v(&mut &buf[..], VERSION).unwrap();
         assert!(reloaded_v10.catalog.list_views().is_empty());
         assert!(reloaded_v10.get_table("t1").is_some());
+    }
+
+    /// Issue #5794: a generated-column expression (`c AS (a+b)`) must survive
+    /// a binary catalog round-trip.
+    ///
+    /// Generated values are materialized at INSERT time, so rows written
+    /// before a save always reload correctly — the failure mode is that a
+    /// reloaded schema without `generated_expr` computes NULL for every
+    /// *subsequent* INSERT. This is the cross-process reload guarantee the
+    /// TCL shim relies on (each `do_execsql_test` batch runs in a fresh CLI
+    /// process against a shared `.vbsql` file), and why `alterdropcol.test`
+    /// section 4 failed before v11.
+    #[test]
+    fn test_binary_catalog_round_trips_generated_column_expr() {
+        let gen_expr = vibesql_parser::arena_parser::parse_expression_to_owned("a + b").unwrap();
+
+        let mut db = Database::new();
+        let schema = vibesql_catalog::TableSchema::new(
+            "mt".to_string(),
+            vec![
+                vibesql_catalog::ColumnSchema {
+                    name: "a".to_string(),
+                    data_type: vibesql_types::DataType::Integer,
+                    nullable: true,
+                    default_value: None,
+                    generated_expr: None,
+                    collation: None,
+                    is_exact_integer_type: true,
+                },
+                vibesql_catalog::ColumnSchema {
+                    name: "b".to_string(),
+                    data_type: vibesql_types::DataType::Integer,
+                    nullable: true,
+                    default_value: None,
+                    generated_expr: None,
+                    collation: None,
+                    is_exact_integer_type: true,
+                },
+                vibesql_catalog::ColumnSchema {
+                    name: "c".to_string(),
+                    data_type: vibesql_types::DataType::Integer,
+                    nullable: true,
+                    default_value: None,
+                    generated_expr: Some(gen_expr.clone()),
+                    collation: None,
+                    is_exact_integer_type: true,
+                },
+                vibesql_catalog::ColumnSchema {
+                    name: "d".to_string(),
+                    data_type: vibesql_types::DataType::Varchar { max_length: None },
+                    nullable: true,
+                    default_value: None,
+                    generated_expr: None,
+                    collation: None,
+                    is_exact_integer_type: false,
+                },
+            ],
+        );
+        db.create_table_with_identifier(schema, vibesql_catalog::TableIdentifier::new("mt", false))
+            .unwrap();
+
+        let mut buf = Vec::new();
+        write_catalog(&mut buf, &db).unwrap();
+        let reloaded = read_catalog_v(&mut &buf[..], VERSION).unwrap();
+
+        let table = reloaded.get_table("mt").expect("mt must survive the round-trip");
+        assert_eq!(
+            table.schema.columns[2].generated_expr,
+            Some(gen_expr),
+            "generated-column expression must survive binary persistence (issue #5794)"
+        );
+        // Non-generated columns must stay non-generated.
+        assert_eq!(table.schema.columns[0].generated_expr, None);
+        assert_eq!(table.schema.columns[1].generated_expr, None);
+        assert_eq!(table.schema.columns[3].generated_expr, None);
+    }
+
+    /// Issue #5794 backward compat: a v10 (pre-generated-expr) file must load
+    /// cleanly under the v11 reader, yielding `generated_expr: None` rather
+    /// than an error.
+    ///
+    /// Unlike the v9→v10 views case (where the new section trails the old
+    /// layout), the generated-expr field sits *inside* each per-column record,
+    /// so a v11-written buffer is NOT byte-compatible with a v10 read. This
+    /// test therefore hand-encodes a genuine v10 catalog byte stream — column
+    /// records ending at the collation flag — and reads it with
+    /// `version = 10`, exercising exactly the path a real v10 file takes
+    /// through the v11 binary: the `version >= 11` gate is skipped, no
+    /// generated-expr bytes are consumed, and every column loads with
+    /// `generated_expr: None`.
+    #[test]
+    fn test_v10_file_loads_generated_expr_as_none() {
+        use super::super::io::{write_bool, write_string, write_u32};
+
+        // Hand-encode a v10 catalog: one table `t1` with one column `a`.
+        let mut buf: Vec<u8> = Vec::new();
+        write_u32(&mut buf, 0).unwrap(); // schemas: none
+        write_u32(&mut buf, 0).unwrap(); // roles: none
+        write_u32(&mut buf, 0).unwrap(); // sequences: none (v2+)
+        write_u32(&mut buf, 1).unwrap(); // tables: one
+        write_string(&mut buf, "t1").unwrap();
+        write_u32(&mut buf, 1).unwrap(); // columns: one
+        write_string(&mut buf, "a").unwrap(); // column name
+        write_string(&mut buf, "INTEGER").unwrap(); // data type
+        write_bool(&mut buf, true).unwrap(); // nullable
+        write_bool(&mut buf, false).unwrap(); // no default_value (v2+)
+        write_bool(&mut buf, false).unwrap(); // no collation (v5+)
+                                              // (v10 column records END here: no generated-expr field)
+        write_bool(&mut buf, false).unwrap(); // no primary key (v3+)
+        write_bool(&mut buf, false).unwrap(); // unquoted identifier (v4+)
+        write_bool(&mut buf, false).unwrap(); // no sql_source (v9+)
+        write_u32(&mut buf, 0).unwrap(); // indexes: none
+        write_u32(&mut buf, 0).unwrap(); // views: none (v10+)
+        write_u32(&mut buf, 0).unwrap(); // triggers: none
+
+        let reloaded = read_catalog_v(&mut &buf[..], 10).unwrap();
+        let table =
+            reloaded.get_table("t1").expect("a v10 table must still load under the v11 binary");
+        assert_eq!(table.schema.columns.len(), 1);
+        assert_eq!(
+            table.schema.columns[0].generated_expr, None,
+            "a v10 file has no generated-expr field; the v11 reader must default it to None"
+        );
+        assert_eq!(table.schema.columns[0].collation, None);
+        assert!(table.schema.columns[0].nullable);
     }
 }

--- a/crates/vibesql-storage/src/persistence/binary/format.rs
+++ b/crates/vibesql-storage/src/persistence/binary/format.rs
@@ -40,7 +40,17 @@ pub const MAGIC: &[u8; 5] = b"VBSQL";
 ///        read path is gated on `version >= 10` and treats absence as "zero
 ///        views." A v10 file opened by a v9 binary is rejected cleanly by
 ///        `read_header` (version > VERSION). Issue #5771.
-pub const VERSION: u8 = 10;
+/// - v11: Added generated-column expression persistence per column
+///        (`ColumnSchema::generated_expr`, the `c AS (a+b)` in `CREATE TABLE`).
+///        Generated values are materialized at INSERT time, so rows written
+///        before a save always reload correctly — but without the expression
+///        the reloaded schema is amnesiac and post-reload INSERTs store NULL
+///        for the generated column. Encoded like `default_value`:
+///        present-flag bool + expression, after the collation field. v10 and
+///        earlier files remain readable: the read path is gated on
+///        `version >= 11` and treats absence as `generated_expr = None`
+///        (prior behavior). Issue #5794.
+pub const VERSION: u8 = 11;
 
 /// Type tags for binary serialization
 #[repr(u8)]

--- a/crates/vibesql-storage/src/wal/recovery.rs
+++ b/crates/vibesql-storage/src/wal/recovery.rs
@@ -1366,6 +1366,67 @@ mod tests {
         );
     }
 
+    /// Issue #5794: a generated-column expression must survive WAL checkpoint
+    /// recovery. `RecoveryManager::load_checkpoint` parses the checkpoint body
+    /// with `read_catalog_v`, so the binary-format v11 field is the same fix —
+    /// this test pins the recovery path specifically: checkpoint a schema with
+    /// `c AS (a+b)`, recover from it, and assert the expression is intact so a
+    /// post-recovery INSERT can compute the generated value instead of NULL.
+    #[test]
+    fn test_checkpoint_recovery_preserves_generated_column_expr() {
+        let temp_dir = TempDir::new().unwrap();
+        let checkpoint_dir = temp_dir.path().join("checkpoints");
+
+        let gen_expr = vibesql_parser::arena_parser::parse_expression_to_owned("a + b").unwrap();
+
+        // Build a DB whose table has a generated column, plus one materialized
+        // row (as INSERT-time evaluation would have stored it).
+        let db_bytes = {
+            let mut db = Database::new();
+            let mut col_c = ColumnSchema::new("c".to_string(), DataType::Integer, true);
+            col_c.generated_expr = Some(gen_expr.clone());
+            db.create_table(TableSchema::new(
+                "mt".to_string(),
+                vec![
+                    ColumnSchema::new("a".to_string(), DataType::Integer, true),
+                    ColumnSchema::new("b".to_string(), DataType::Integer, true),
+                    col_c,
+                ],
+            ))
+            .unwrap();
+            db.insert_row(
+                "main.mt",
+                crate::row::Row::new(vec![
+                    SqlValue::Integer(1),
+                    SqlValue::Integer(2),
+                    SqlValue::Integer(3),
+                ]),
+            )
+            .unwrap();
+            db.to_uncompressed_bytes().unwrap()
+        };
+
+        // Write the checkpoint (what the CLI's `\save` / clean exit does),
+        // then recover from it (what a fresh process does on open).
+        let mut writer = CheckpointWriter::new(&checkpoint_dir).unwrap();
+        writer.create_checkpoint(1, &db_bytes, 1).unwrap();
+
+        let manager = RecoveryManager::new(&checkpoint_dir);
+        let (recovered, stats) = manager.recover().unwrap();
+        assert_eq!(stats.checkpoint_lsn, 1, "recovery must load the checkpoint");
+
+        let table = recovered.get_table("main.mt").expect("mt must survive recovery");
+        assert_eq!(
+            table.schema.columns[2].generated_expr,
+            Some(gen_expr),
+            "generated-column expression must survive checkpoint recovery (issue #5794)"
+        );
+        // The materialized row data must survive too.
+        let rows: Vec<_> = table.scan_live().map(|(_, r)| r.clone()).collect();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].values[2], SqlValue::Integer(3));
+    }
+
     #[test]
     fn test_recovery_discards_uncommitted_transaction() {
         let temp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Generated columns (`c AS (a+b)`) are materialized at INSERT time, so rows written before a save always reload correctly — but the binary catalog never persisted `ColumnSchema::generated_expr`, and `read_catalog_v` hardcoded it to `None`. After a reload the schema was amnesiac and every subsequent INSERT stored NULL for the generated column. This is exactly why `alterdropcol.test` section 4 failed: the TCL shim runs each `do_execsql_test` batch in a separate CLI process against the shared `.vbsql` file.

This PR bumps the binary format to v11 and persists `Option<generated_expr>` per column, following the established version-gate pattern (v2–v10). WAL checkpoint recovery shares `read_catalog_v`, so crash recovery is covered by the same change.

Per the curator's scope correction: no VIRTUAL/STORED kind byte is added (`ColumnSchema` has no kind field; both kinds are materialized identically today), and `persistence/json.rs` is untouched (broadly lossy for expressions; separate concern).

## Changes

- `crates/vibesql-storage/src/persistence/binary/format.rs` — `VERSION` 10 → 11 with version-history doc comment
- `crates/vibesql-storage/src/persistence/binary/catalog.rs`
  - `write_catalog`: emit present-flag + expression per column after the collation field, mirroring the `default_value` encoding (reuses the existing expression serializer)
  - `read_catalog_v`: version-gated read (`version >= 11`); v10-and-earlier files load with `generated_expr: None` (prior behavior, no regression)
  - New tests: round-trip at `VERSION`, and a backward-compat test that hand-encodes a genuine v10 byte stream (the new field is mid-record, so the v9→v10 trailing-section test trick does not apply)
- `crates/vibesql-storage/src/wal/recovery.rs` — new test pinning the checkpoint-recovery path: a schema with `c AS (a+b)` recovers with the expression and materialized row data intact

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `VERSION` is 11; v10 files still load | ✅ | `test_v10_file_loads_generated_expr_as_none` reads a hand-encoded v10 stream under the v11 reader |
| Generated-column expressions survive save/reload; post-reload INSERTs compute correct values | ✅ | `test_binary_catalog_round_trips_generated_column_expr` + two-process CLI probe below |
| `alterdropcol.test` section 4: all `4.$tn.1/5/7/9` pass for all 5 iterations | ✅ | 62 → 84 passed; all twenty section-4 tests now pass (see below) |
| No change to `sqlite_master.sql` output | ✅ | `sql_source` (v9) path untouched; existing `test_binary_catalog_preserves_verbatim_sql_source` still passes |
| WAL checkpoint recovery covered | ✅ | `test_checkpoint_recovery_preserves_generated_column_expr` (recovery shares `read_catalog_v`) |
| No regressions | ✅ | `cargo test -p vibesql-storage`: 776 tests, 0 failures |

## Test Plan

**Unit tests** — `cargo test -p vibesql-storage`: 732 + 16 + 13 + 15 = 776 passed, 0 failed (includes the 3 new tests).

**Two-process CLI probe** (release binary):

```
# Process 1: CREATE TABLE mt(a, b PRIMARY KEY, c AS (a+b), d); INSERT (1,2,'hello')
# Process 2 (fresh reload): INSERT (10,20,'world'); SELECT * FROM mt;
#   before: 10 | 20 | NULL | world
#   after:  10 | 20 | 30   | world   ✅
```

**TCL conformance** — `make test-tcl-file FILE=alterdropcol.test`:

| | Passed | Failed | Skipped |
|---|---|---|---|
| Before (main @ 841f5fc03) | 62 | 35 | 3 |
| After | 84 | 13 | 3 |

All twenty `4.$tn.{1,5,7,9}` tests (tn = 1..5, incl. WITHOUT ROWID / VIRTUAL / STORED iterations) plus `9.1.1`/`9.1.2` now pass. The remaining 13 failures (3.1, 5.2.x–5.5.x, 7.0–7.3, 8.1–8.2) are pre-existing and identical to the baseline failure set.

Closes #5794