### PR TITLE
fix(sql): apply LHS collation to scalar IN-list comparisons (NOCASE/RTRIM)

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -672,6 +672,13 @@ impl CombinedExpressionEvaluator<'_> {
             return Ok(vibesql_types::SqlValue::Null);
         }
 
+        // Issue #5806: per SQLite (datatype3.html §7.2), `x IN (y, z, ...)`
+        // uses the collating sequence of the LHS `x` (explicit COLLATE, or
+        // the column's declared collation); list-element collations are
+        // irrelevant. The NOCASE/RTRIM transform is applied to both sides
+        // AFTER affinity coercion so coerced strings are normalized too.
+        let collation = self.get_expression_collation(expr);
+
         // For small lists (≤3 items), use linear search to avoid HashSet overhead
         // For larger lists, use HashSet for O(1) lookup performance
         if values.len() <= 3 {
@@ -696,6 +703,14 @@ impl CombinedExpressionEvaluator<'_> {
                     value_expr,
                     value,
                 );
+
+                // Apply the LHS collation to both sides (issue #5806)
+                let (expr_coerced, value_coerced) =
+                    crate::evaluator::row_value::apply_collation_to_pair(
+                        expr_coerced,
+                        value_coerced,
+                        collation.as_deref(),
+                    );
 
                 // Compare using equality
                 let eq_result = ExpressionEvaluator::eval_binary_op_static(
@@ -722,7 +737,8 @@ impl CombinedExpressionEvaluator<'_> {
         } else {
             // HashSet optimization for larger lists
             // Evaluate each IN list value once (instead of per row) and collect into HashSet
-            // Apply affinity coercion before adding to the HashSet
+            // Apply affinity coercion (then the LHS collation transform, #5806)
+            // before adding to the HashSet
             let mut value_set = std::collections::HashSet::new();
             let mut found_null = false;
 
@@ -740,9 +756,18 @@ impl CombinedExpressionEvaluator<'_> {
                         value_expr,
                         value,
                     );
-                    value_set.insert(value_coerced);
+                    value_set.insert(crate::evaluator::row_value::apply_collation_to_value(
+                        value_coerced,
+                        collation.as_deref(),
+                    ));
                 }
             }
+
+            // Apply the LHS collation to the probe value as well (issue #5806)
+            let expr_val = crate::evaluator::row_value::apply_collation_to_value(
+                expr_val,
+                collation.as_deref(),
+            );
 
             // O(n) lookup with SQL type coercion (where n = unique values in list)
             // This preserves correctness while still benefiting from single evaluation of IN list

--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -694,6 +694,13 @@ impl ExpressionEvaluator<'_> {
             return Ok(vibesql_types::SqlValue::Null);
         }
 
+        // Issue #5806: per SQLite (datatype3.html §7.2), `x IN (y, z, ...)`
+        // uses the collating sequence of the LHS `x` (explicit COLLATE, or
+        // the column's declared collation); list-element collations are
+        // irrelevant. The NOCASE/RTRIM transform is applied to both sides
+        // AFTER affinity coercion so coerced strings are normalized too.
+        let collation = self.get_expression_collation(expr);
+
         // For small lists (≤3 items), use linear search to avoid HashSet overhead
         // For larger lists, use HashSet for O(1) lookup performance
         if values.len() <= 3 {
@@ -717,6 +724,14 @@ impl ExpressionEvaluator<'_> {
                     value,
                 );
 
+                // Apply the LHS collation to both sides (issue #5806)
+                let (expr_coerced, value_coerced) =
+                    crate::evaluator::row_value::apply_collation_to_pair(
+                        expr_coerced,
+                        value_coerced,
+                        collation.as_deref(),
+                    );
+
                 let eq_result = self.eval_binary_op(
                     &expr_coerced,
                     &vibesql_ast::BinaryOperator::Equal,
@@ -736,7 +751,8 @@ impl ExpressionEvaluator<'_> {
         } else {
             // HashSet optimization for larger lists
             // Evaluate each IN list value once (instead of per row) and collect into HashSet
-            // Apply affinity coercion before adding to the HashSet
+            // Apply affinity coercion (then the LHS collation transform, #5806)
+            // before adding to the HashSet
             let mut value_set = std::collections::HashSet::new();
             let mut found_null = false;
 
@@ -754,9 +770,18 @@ impl ExpressionEvaluator<'_> {
                         value_expr,
                         value,
                     );
-                    value_set.insert(value_coerced);
+                    value_set.insert(crate::evaluator::row_value::apply_collation_to_value(
+                        value_coerced,
+                        collation.as_deref(),
+                    ));
                 }
             }
+
+            // Apply the LHS collation to the probe value as well (issue #5806)
+            let expr_val = crate::evaluator::row_value::apply_collation_to_value(
+                expr_val,
+                collation.as_deref(),
+            );
 
             // O(n) lookup with SQL type coercion (where n = unique values in list)
             // This preserves correctness while still benefiting from single evaluation of IN list

--- a/crates/vibesql-executor/src/evaluator/row_value.rs
+++ b/crates/vibesql-executor/src/evaluator/row_value.rs
@@ -27,6 +27,31 @@ use vibesql_types::SqlValue;
 
 use crate::errors::ExecutorError;
 
+/// Apply a collation transformation to a single already-evaluated value,
+/// mirroring the scalar comparison path: NOCASE uppercases string values,
+/// RTRIM trims trailing whitespace, any other collation (BINARY, ...) or
+/// `None` leaves the value unchanged.
+pub(crate) fn apply_collation_to_value(val: SqlValue, collation: Option<&str>) -> SqlValue {
+    let Some(collation_name) = collation else {
+        return val;
+    };
+    if collation_name.eq_ignore_ascii_case("nocase") {
+        match val {
+            SqlValue::Varchar(s) => SqlValue::Varchar(arcstr::ArcStr::from(s.to_uppercase())),
+            SqlValue::Character(s) => SqlValue::Character(arcstr::ArcStr::from(s.to_uppercase())),
+            other => other,
+        }
+    } else if collation_name.eq_ignore_ascii_case("rtrim") {
+        match val {
+            SqlValue::Varchar(s) => SqlValue::Varchar(arcstr::ArcStr::from(s.trim_end())),
+            SqlValue::Character(s) => SqlValue::Character(arcstr::ArcStr::from(s.trim_end())),
+            other => other,
+        }
+    } else {
+        val
+    }
+}
+
 /// Apply a collation transformation to both sides of a single element
 /// comparison inside a row-value, mirroring the scalar comparison path:
 /// NOCASE uppercases string values, RTRIM trims trailing whitespace, any other
@@ -36,31 +61,7 @@ pub(crate) fn apply_collation_to_pair(
     right: SqlValue,
     collation: Option<&str>,
 ) -> (SqlValue, SqlValue) {
-    let Some(collation_name) = collation else {
-        return (left, right);
-    };
-
-    fn transform(val: SqlValue, collation_name: &str) -> SqlValue {
-        if collation_name.eq_ignore_ascii_case("nocase") {
-            match val {
-                SqlValue::Varchar(s) => SqlValue::Varchar(arcstr::ArcStr::from(s.to_uppercase())),
-                SqlValue::Character(s) => {
-                    SqlValue::Character(arcstr::ArcStr::from(s.to_uppercase()))
-                }
-                other => other,
-            }
-        } else if collation_name.eq_ignore_ascii_case("rtrim") {
-            match val {
-                SqlValue::Varchar(s) => SqlValue::Varchar(arcstr::ArcStr::from(s.trim_end())),
-                SqlValue::Character(s) => SqlValue::Character(arcstr::ArcStr::from(s.trim_end())),
-                other => other,
-            }
-        } else {
-            val
-        }
-    }
-
-    (transform(left, collation_name), transform(right, collation_name))
+    (apply_collation_to_value(left, collation), apply_collation_to_value(right, collation))
 }
 
 /// Compare two already-evaluated row values with a comparison operator.

--- a/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
@@ -307,7 +307,12 @@ fn predicate_supported_by_columnar(predicate: &ColumnPredicate, schema: &Combine
         }
         ColumnPredicate::InList { column_idx, values, .. } => {
             let col_type = schema.get_column_type_by_index(*column_idx);
-            values.iter().all(|v| value_supported_for_column(col_type, v))
+            // Issue #5806: IN on a non-BINARY-collated column (e.g. NOCASE)
+            // must apply the LHS collation; the columnar comparators compare
+            // raw values, so decline pushdown and fall back to the
+            // collation-aware expression evaluator.
+            !schema.column_has_non_binary_collation(*column_idx)
+                && values.iter().all(|v| value_supported_for_column(col_type, v))
         }
         // LIKE patterns are strings; existing comparator behavior applies
         ColumnPredicate::Like { .. } => true,

--- a/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
@@ -146,6 +146,28 @@ pub(crate) fn execute_index_scan(
         })
     };
 
+    // Issue #5806: an IN-list probe looks up the raw literal values in the
+    // index, but the index stores raw (BINARY-ordered) keys while IN on a
+    // non-BINARY-collated column (e.g. NOCASE) must match per the LHS
+    // collation ('XYZ' must find stored 'xyz'). Such a probe silently loses
+    // rows, and the WHERE post-filter can only remove rows, never restore
+    // missed ones. Decline the probe so we fall back to the
+    // full-index-scan + collation-aware WHERE-filter path below (correct,
+    // just slower). BINARY/undeclared collations keep the fast probe.
+    let index_predicate = if matches!(index_predicate, Some(IndexPredicate::In(_)))
+        && first_indexed_column
+            .and_then(|idx_col| idx_col.column_name())
+            .and_then(|col_name| {
+                table.schema.columns.iter().find(|c| c.name.eq_ignore_ascii_case(col_name))
+            })
+            .and_then(|c| c.collation.as_deref())
+            .is_some_and(|coll| !coll.eq_ignore_ascii_case("binary"))
+    {
+        None
+    } else {
+        index_predicate
+    };
+
     // Issue #5333: when the index stores temporal keys (e.g. an expression
     // index on date()/datetime(), or a plain TIMESTAMP column index) but the
     // WHERE clause supplies string bounds, coerce the bounds to the stored

--- a/crates/vibesql-executor/src/select/vectorized/compiled_predicate.rs
+++ b/crates/vibesql-executor/src/select/vectorized/compiled_predicate.rs
@@ -401,6 +401,13 @@ impl CompiledWhereClause {
             return false;
         }
 
+        // Issue #5806: IN on a non-BINARY-collated column (e.g. NOCASE) must
+        // apply the LHS collation; fall back to the collation-aware
+        // expression evaluator (same gate as BETWEEN below, #5792).
+        if schema.column_has_non_binary_collation(column_idx) {
+            return false;
+        }
+
         predicates.push(CompiledPredicate::InList { column_idx, values: literal_values, negated });
 
         true

--- a/crates/vibesql-executor/tests/in_list_collation_tests.rs
+++ b/crates/vibesql-executor/tests/in_list_collation_tests.rs
@@ -1,0 +1,257 @@
+//! Regression tests for issue #5806: scalar IN-list comparisons must use the
+//! collating sequence of the LHS (SQLite datatype3.html section 7.2).
+//!
+//! `x IN (y, z, ...)` uses only the collation of `x` — an explicit COLLATE
+//! operator, or the column's declared collation. List-element collations are
+//! irrelevant. Four code paths are covered:
+//!
+//! - the slow-path `eval_in_list` (both the <=3-element linear scan and the
+//!   >3-element HashSet lookup), in both evaluators;
+//! - the columnar `ColumnPredicate::InList` pushdown (declined for
+//!   non-BINARY-collated columns);
+//! - the vectorized `try_compile_in_list` (same decline);
+//! - the index-probe path (`IndexPredicate::In` is declined for a
+//!   non-BINARY-collated indexed column, falling back to the
+//!   collation-aware WHERE filter).
+//!
+//! Expected values verified against sqlite3 3.x with the same fixture.
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::CreateIndex(create_index) => {
+            vibesql_executor::CreateIndexExecutor::execute(&create_index, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            vibesql_executor::InsertExecutor::execute(db, &insert).unwrap();
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+/// Run a single-column SELECT and collect the integer results.
+fn query_ints(db: &vibesql_storage::Database, sql: &str) -> Vec<i64> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        let rows = executor
+            .execute(&select_stmt)
+            .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e));
+        rows.iter()
+            .map(|row| {
+                assert_eq!(row.values.len(), 1, "Expected one column for: {}", sql);
+                match &row.values[0] {
+                    SqlValue::Integer(i) => *i,
+                    SqlValue::Bigint(i) => *i,
+                    SqlValue::Smallint(i) => i64::from(*i),
+                    other => panic!("Expected integer result for {}: {:?}", sql, other),
+                }
+            })
+            .collect()
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+fn assert_rows(db: &vibesql_storage::Database, sql: &str, expected: &[i64]) {
+    let actual = query_ints(db, sql);
+    assert_eq!(actual, expected, "Query: {} -- expected {:?}, got {:?}", sql, expected, actual);
+}
+
+/// The `t4a` fixture from `in4.test`: `a` has default BINARY collation,
+/// `b` is declared NOCASE.
+fn db_with_t4a() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t4a(a TEXT, b TEXT COLLATE nocase, c)");
+    run_stmt(&mut db, "INSERT INTO t4a VALUES('ABC','abc',1)");
+    run_stmt(&mut db, "INSERT INTO t4a VALUES('def','xyz',2)");
+    run_stmt(&mut db, "INSERT INTO t4a VALUES('ghi','ghi',3)");
+    db
+}
+
+/// Same fixture with an index on the NOCASE column (index-probe path).
+fn db_with_t4a_indexed() -> vibesql_storage::Database {
+    let mut db = db_with_t4a();
+    run_stmt(&mut db, "CREATE INDEX i4ab ON t4a(b)");
+    db
+}
+
+// ---------------------------------------------------------------------------
+// The five verified reproducers from issue #5806 (no index)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nocase_column_in_single_literal() {
+    // sqlite3: b IN ('XYZ') matches 'xyz' (NOCASE), returns 2.
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE b IN ('XYZ')", &[2]);
+}
+
+#[test]
+fn nocase_column_in_two_literals_linear_path() {
+    // <=3 elements exercises the linear-scan path.
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE b IN ('ABC','GHI') ORDER BY c", &[1, 3]);
+}
+
+#[test]
+fn explicit_collate_nocase_on_lhs() {
+    // a COLLATE nocase IN ('abc'): explicit COLLATE on the LHS applies even
+    // though column a's declared collation is BINARY. (Slow path only —
+    // fast paths require a bare column LHS.)
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE a COLLATE nocase IN ('abc')", &[1]);
+}
+
+#[test]
+fn nocase_column_in_four_literals_hashset_path() {
+    // >3 elements exercises the HashSet path (values transformed before
+    // insertion, probe value transformed before lookup).
+    let db = db_with_t4a();
+    assert_rows(
+        &db,
+        "SELECT c FROM t4a WHERE b IN ('ABC','GHI','QRS','XYZ') ORDER BY c",
+        &[1, 2, 3],
+    );
+}
+
+#[test]
+fn nocase_column_not_in_hashset_path() {
+    // NOT IN must be the exact complement: every row matches some element
+    // under NOCASE, so the result is empty.
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE b NOT IN ('ABC','GHI','QRS','XYZ') ORDER BY c", &[]);
+}
+
+// ---------------------------------------------------------------------------
+// Index-probe path (IN on an indexed NOCASE column)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn indexed_nocase_column_in_single_literal() {
+    let db = db_with_t4a_indexed();
+    assert_rows(&db, "SELECT c FROM t4a WHERE b IN ('XYZ')", &[2]);
+}
+
+#[test]
+fn indexed_nocase_column_in_four_literals() {
+    let db = db_with_t4a_indexed();
+    assert_rows(
+        &db,
+        "SELECT c FROM t4a WHERE b IN ('ABC','GHI','QRS','XYZ') ORDER BY c",
+        &[1, 2, 3],
+    );
+}
+
+#[test]
+fn indexed_nocase_column_not_in() {
+    let db = db_with_t4a_indexed();
+    assert_rows(&db, "SELECT c FROM t4a WHERE b NOT IN ('ABC','GHI','QRS','XYZ') ORDER BY c", &[]);
+}
+
+#[test]
+fn indexed_binary_column_in_keeps_exact_matching() {
+    // BINARY column with an index: IN stays case-sensitive and the index
+    // probe stays usable.
+    let mut db = db_with_t4a_indexed();
+    run_stmt(&mut db, "CREATE INDEX i4aa ON t4a(a)");
+    assert_rows(&db, "SELECT c FROM t4a WHERE a IN ('abc','ghi') ORDER BY c", &[3]);
+    assert_rows(&db, "SELECT c FROM t4a WHERE a IN ('ABC','ghi') ORDER BY c", &[1, 3]);
+}
+
+// ---------------------------------------------------------------------------
+// BINARY / uncollated LHS keeps existing behavior
+// ---------------------------------------------------------------------------
+
+#[test]
+fn binary_column_in_stays_case_sensitive() {
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE a IN ('abc')", &[]);
+    assert_rows(&db, "SELECT c FROM t4a WHERE a IN ('ABC')", &[1]);
+    // HashSet path (>3 elements): only the exact-case 'ghi' matches.
+    assert_rows(&db, "SELECT c FROM t4a WHERE a IN ('abc','ghi','qrs','xyz') ORDER BY c", &[3]);
+}
+
+#[test]
+fn concat_wrapped_nocase_lhs_is_binary() {
+    // (b||'') has no collating sequence (implicit collation does not leak
+    // through ||), so the IN comparison is BINARY.
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE (b||'') IN ('XYZ')", &[]);
+    assert_rows(&db, "SELECT c FROM t4a WHERE (b||'') IN ('xyz')", &[2]);
+}
+
+// ---------------------------------------------------------------------------
+// NULL three-valued logic is preserved after the collation transform
+// ---------------------------------------------------------------------------
+
+#[test]
+fn null_in_list_still_yields_unknown() {
+    // b IN ('QRS', NULL): no match + NULL in list -> UNKNOWN -> row filtered.
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE b IN ('QRS', NULL) ORDER BY c", &[]);
+    // A NOCASE match still wins over the NULL.
+    assert_rows(&db, "SELECT c FROM t4a WHERE b IN ('XYZ', NULL) ORDER BY c", &[2]);
+    // NOT IN with a NULL in the list can never be TRUE.
+    assert_rows(&db, "SELECT c FROM t4a WHERE b NOT IN ('QRS', NULL) ORDER BY c", &[]);
+    // HashSet path (>3 elements) with NULL behaves identically.
+    assert_rows(&db, "SELECT c FROM t4a WHERE b IN ('QRS','TUV','WXY',NULL) ORDER BY c", &[]);
+    assert_rows(&db, "SELECT c FROM t4a WHERE b IN ('XYZ','TUV','WXY',NULL) ORDER BY c", &[2]);
+}
+
+#[test]
+fn empty_in_list_unaffected() {
+    // Empty IN list: FALSE for IN, TRUE for NOT IN (SQLite extension),
+    // regardless of collation.
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE b IN () ORDER BY c", &[]);
+    assert_rows(&db, "SELECT c FROM t4a WHERE b NOT IN () ORDER BY c", &[1, 2, 3]);
+}
+
+// ---------------------------------------------------------------------------
+// RTRIM collation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rtrim_column_in_ignores_trailing_whitespace() {
+    // sqlite3: CREATE TABLE t5(x TEXT COLLATE rtrim, y);
+    // 'xyz' IN ('xyz   ') matches under RTRIM (both sides right-trimmed).
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t5(x TEXT COLLATE rtrim, y)");
+    run_stmt(&mut db, "INSERT INTO t5 VALUES('xyz',1)");
+    run_stmt(&mut db, "INSERT INTO t5 VALUES('abc   ',2)");
+    run_stmt(&mut db, "INSERT INTO t5 VALUES('def',3)");
+
+    assert_rows(&db, "SELECT y FROM t5 WHERE x IN ('xyz   ')", &[1]);
+    assert_rows(&db, "SELECT y FROM t5 WHERE x IN ('abc')", &[2]);
+    // Case still matters under RTRIM.
+    assert_rows(&db, "SELECT y FROM t5 WHERE x IN ('XYZ   ')", &[]);
+    // HashSet path.
+    assert_rows(&db, "SELECT y FROM t5 WHERE x IN ('abc','qrs','tuv','wxy') ORDER BY y", &[2]);
+    // NOT IN complement.
+    assert_rows(&db, "SELECT y FROM t5 WHERE x NOT IN ('xyz   ','abc','q','r') ORDER BY y", &[3]);
+}
+
+// ---------------------------------------------------------------------------
+// Composition with affinity coercion (transform applies AFTER affinity)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nocase_text_column_with_numeric_list_elements() {
+    // TEXT affinity coerces numeric list elements to strings before the
+    // collation transform; numbers have no case so matching is unaffected,
+    // but the path must not panic or mis-match.
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t6(x TEXT COLLATE nocase, y)");
+    run_stmt(&mut db, "INSERT INTO t6 VALUES('12',1)");
+    run_stmt(&mut db, "INSERT INTO t6 VALUES('AbC',2)");
+
+    assert_rows(&db, "SELECT y FROM t6 WHERE x IN (12)", &[1]);
+    assert_rows(&db, "SELECT y FROM t6 WHERE x IN (12, 'aBc') ORDER BY y", &[1, 2]);
+}


### PR DESCRIPTION
## Summary

Per SQLite datatype3.html §7.2, `x IN (y, z, ...)` uses the collating sequence of the LHS `x` only. All four IN-list evaluation paths compared raw values, so `b IN ('XYZ')` on a `TEXT COLLATE nocase` column missed the `'xyz'` row, explicit `a COLLATE nocase IN (...)` was ignored, and `NOT IN` inverted the wrong result. This applies the #5805/#5810 collation infrastructure to the IN-list paths and gates the raw-value fast paths, mirroring the #5792 pattern.

## Changes

- **Slow path (both evaluators)**: `eval_in_list` resolves the LHS collation once via `get_expression_collation` and applies the shared NOCASE/RTRIM transform to both sides **after** affinity coercion (`apply_affinity_for_in_comparison`), in both the ≤3-element linear scan and the >3-element HashSet path (list values transformed before insertion, probe value before lookup). Covers explicit `COLLATE` on the LHS for free.
- **Shared helper**: extracted `apply_collation_to_value` in `evaluator/row_value.rs`; `apply_collation_to_pair` (#5810) is now implemented in terms of it (no behavior change).
- **Columnar**: `predicate_supported_by_columnar` declines the `ColumnPredicate::InList` pushdown for non-BINARY-collated columns (same gate style as the #5792 Equal/Between/ColumnCompare arms directly above it).
- **Vectorized**: `try_compile_in_list` gains the same `column_has_non_binary_collation` gate `try_compile_between` already has.
- **Index probe**: `execute_index_scan` declines `IndexPredicate::In` when the probed column has a declared non-BINARY collation. The index stores raw BINARY-ordered keys, so the probe silently loses rows that the WHERE post-filter can never restore; declining falls back to the full-index-scan + collation-aware WHERE-filter path (correct, just slower). This single gate also covers the multi-index-OR branches, which route through `execute_index_scan`.
- **Tests**: new `crates/vibesql-executor/tests/in_list_collation_tests.rs` (14 tests) following the #5805 `comparison_collation_tests.rs` precedent — the five issue reproducers, indexed variants, BINARY-column fast-path preservation, concat-wrapped LHS (no collation leak), NULL three-valued logic, empty list, RTRIM, and affinity composition. All expected values verified against sqlite3 side by side.

**Out of scope, filed as follow-up**: the sibling pre-existing bug where *equality/range/composite/prefix* index probes also ignore collation (`b = 'XYZ'` **with** an index on NOCASE `b` returns 0 rows on main, independent of this PR) — #5823.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| All five reproducer queries match sqlite3 (with and without index on `b`) | ✅ | Manual run of the issue's reproducer against the release build diffs clean vs sqlite3 (q1=2, q2=1,3, q3=1, q4=1,2,3, q5=empty; indexed IN variants identical); each is also a unit test |
| `x COLLATE nocase IN (...)` honors the explicit collation | ✅ | `explicit_collate_nocase_on_lhs` test; `get_expression_collation` resolves explicit COLLATE ahead of column collation |
| BINARY/uncollated LHS keeps columnar, vectorized, and index fast paths | ✅ | Gates only trigger on `column_has_non_binary_collation` / declared non-BINARY collation; `binary_column_in_stays_case_sensitive` + `indexed_binary_column_in_keeps_exact_matching` tests |
| `in4.test` stays 61/61 | ✅ | `make test-tcl-file FILE=in4.test`: 61 passed, 0 failed (run against the fixed release binary) |

## Test Plan

- `cargo test -p vibesql-executor --lib`: 3061 passed, 0 failed (`test_deep_case_expressions` stack overflow is environmental/pre-existing — aborts identically on a clean baseline build, passes with `RUST_MIN_STACK=32M`)
- `cargo test -p vibesql-executor --test in_list_collation_tests --test comparison_collation_tests --test columnar_filter_type_pairs_tests --test columnar_compound_on_predicate_tests --test mvcc_index_scan_tests --test foreign_key_collation_action_tests --test columnar_storage_tests`: all pass (71 tests)
- TCL: `in4.test` 61/61, `in.test` 114/0, `in2.test` 1999/0, `in5.test` 29/0, `where.test` 168/0, `collate1/2/3.test` unchanged (all-skipped). `in3.test` (12/6) and `index.test` (54/15) failures are pre-existing: identical counts and identical failing-test sets on a baseline (stashed) build; the failures are IN-subquery EQP and numeric-affinity conformance gaps unrelated to collation.
- Manual reproducer diffed against sqlite3 (documented in the issue), including `CREATE INDEX i4ab ON t4a(b)` variants.

Closes #5806