### PR TITLE
feat(sql): re-validate views/triggers/CHECKs on DROP COLUMN; lax CREATE VIEW (Phase 3 of #5784)

### DIFF
--- a/crates/vibesql-executor/src/advanced_objects/views.rs
+++ b/crates/vibesql-executor/src/advanced_objects/views.rs
@@ -67,13 +67,24 @@ pub fn execute_create_view(stmt: &CreateViewStmt, db: &mut Database) -> Result<(
             // bare, matching SQLite's query-time messages.
             use crate::select::SelectExecutor;
             let executor = SelectExecutor::new(db);
-            let result = executor.execute_with_simple_columns(&stmt.query).map_err(|e| match e {
-                e @ ExecutorError::OrderByTermNotInResultSet { .. } => ExecutorError::SqliteCompatError(
-                    format!("error in view {}: {}", stmt.view_name, e),
-                ),
-                other => other,
-            })?;
-            Some(result.columns)
+            match executor.execute_with_simple_columns(&stmt.query) {
+                Ok(result) => Some(result.columns),
+                Err(e @ ExecutorError::OrderByTermNotInResultSet { .. }) => {
+                    return Err(ExecutorError::SqliteCompatError(format!(
+                        "error in view {}: {}",
+                        stmt.view_name, e
+                    )));
+                }
+                // Lax view creation (SQLite semantics, issue #5795 /
+                // alterdropcol.test 5.2.1): a view whose SELECT names a column
+                // that does not (yet) resolve is still created — SQLite defers
+                // column resolution to query time. The view is stored with no
+                // derived column list; querying it re-runs the SELECT and
+                // surfaces the resolution error then, and ALTER-time schema
+                // re-parses report it as `error in view <name>: ...`.
+                Err(ExecutorError::ColumnNotFound { .. }) => None,
+                Err(other) => return Err(other),
+            }
         }
     };
 

--- a/crates/vibesql-executor/src/alter/columns.rs
+++ b/crates/vibesql-executor/src/alter/columns.rs
@@ -136,6 +136,12 @@ pub(super) fn execute_drop_column(
         )));
     }
 
+    // Pre-drop schema re-parse: a view or trigger that is *already* broken —
+    // even one unrelated to this table — aborts the ALTER before anything is
+    // touched, matching SQLite's first schema re-parse (no "after drop column"
+    // suffix; the object was broken before the drop). See issue #5795.
+    super::drop_column_checks::precheck_schema_objects(database)?;
+
     // Dependent-object validation: dropping the column must not leave an
     // explicit index (plain or expression/partial) dangling. SQLite re-parses
     // the schema after the drop and rolls back with this message when an index
@@ -149,6 +155,13 @@ pub(super) fn execute_drop_column(
             )));
         }
     }
+
+    // Post-drop schema re-parse: a table-level CHECK, dependent view, or
+    // trigger that would reference the gone column aborts the ALTER, matching
+    // SQLite's second schema re-parse (`error in <type> <name> after drop
+    // column: ...`). Validation runs against a simulated post-drop schema, so
+    // nothing has been mutated yet and no rollback is needed. See issue #5795.
+    super::drop_column_checks::postcheck_schema_objects(database, table_name, col)?;
 
     let table = database
         .get_table_mut(table_name)

--- a/crates/vibesql-executor/src/alter/drop_column_checks.rs
+++ b/crates/vibesql-executor/src/alter/drop_column_checks.rs
@@ -1,0 +1,576 @@
+//! Whole-schema re-validation for `ALTER TABLE ... DROP COLUMN`.
+//!
+//! SQLite re-parses the entire schema twice when a column is dropped
+//! (`alter.c`, `renameTestSchema`):
+//!
+//! 1. **Pre-check** (`zWhen = ""`): any view or trigger that is *already*
+//!    broken — independent of the drop — aborts the ALTER with
+//!    `error in <type> <name>: <inner error>`.
+//! 2. **Post-check** (`zWhen = "after drop column"`): the schema as it would
+//!    look *after* the drop is re-resolved; a view/trigger/table-level CHECK
+//!    left dangling by the drop aborts with
+//!    `error in <type> <name> after drop column: <inner error>`.
+//!
+//! Both checks run before any mutation, so a failed DROP COLUMN leaves the
+//! schema and rows untouched (atomicity for free). See issue #5795 /
+//! `alterdropcol.test` sections 3 and 5.
+//!
+//! The static resolvers here are deliberately **conservative**: they only
+//! report a missing column when the query scope is fully understood (plain
+//! tables/views in FROM, no CTEs / set operations / derived tables). Anything
+//! more complex is skipped rather than risk a false positive that would block
+//! a DROP COLUMN SQLite allows. Constructs we do not descend into are treated
+//! as valid (false negatives only).
+
+use vibesql_ast::{
+    visitor::{walk_expression, walk_statement, ExpressionVisitor, StatementVisitor, VisitResult},
+    ColumnConstraintKind, ColumnIdentifier, Expression, FromClause, PseudoTable, SelectItem,
+    Statement, TableConstraintKind, TriggerAction,
+};
+use vibesql_catalog::{TableSchema, TriggerDefinition, ViewDefinition};
+use vibesql_storage::Database;
+
+use crate::errors::ExecutorError;
+
+/// Pre-drop check: abort if any existing view or trigger is already broken
+/// (references a column that does not resolve against the *current* schema).
+///
+/// Matches SQLite's first schema re-parse: the inner error carries no
+/// "after drop column" suffix because the object was broken before the drop.
+pub(super) fn precheck_schema_objects(database: &Database) -> Result<(), ExecutorError> {
+    check_schema_objects(database, None)
+}
+
+/// Post-drop check: abort if dropping `column` from `table_name` would leave a
+/// dependent table-level CHECK, view, or trigger referencing a gone column.
+///
+/// Resolution runs against a *simulated* post-drop schema (the altered table's
+/// column set minus `column`), so nothing needs to be rolled back on failure.
+pub(super) fn postcheck_schema_objects(
+    database: &Database,
+    table_name: &str,
+    column: &str,
+) -> Result<(), ExecutorError> {
+    // Table-level CHECK constraints (and column-level CHECKs owned by *other*
+    // columns) on the altered table must still resolve after the drop. The
+    // in-memory `check_constraints` list has no column/table origin, so the
+    // origin is recovered from the verbatim CREATE TABLE text (`sql_source`),
+    // exactly the text SQLite itself re-parses. A CHECK attached to the
+    // dropped column is removed together with the column and is exempt.
+    if let Some(table) = database.get_table(table_name) {
+        if let Some(missing) = check_constraint_missing_column(&table.schema, column) {
+            return Err(ExecutorError::Other(format!(
+                "error in table {} after drop column: no such column: {}",
+                table_name, missing
+            )));
+        }
+    }
+
+    check_schema_objects(database, Some((table_name, column)))
+}
+
+/// Shared pre-/post-check walk over every view and trigger in the schema.
+///
+/// `dropped` is `None` for the pre-check (validate against the current
+/// schema) and `Some((table, column))` for the post-check (validate against
+/// the schema as it would look after dropping `column` from `table`).
+fn check_schema_objects(
+    database: &Database,
+    dropped: Option<(&str, &str)>,
+) -> Result<(), ExecutorError> {
+    let suffix = if dropped.is_some() { " after drop column" } else { "" };
+
+    // Resolve the altered table to its canonical catalog name once so FROM
+    // references in any spelling ("T1", "main.t1", ...) simulate the drop.
+    let sim = DropSimulation::new(database, dropped);
+
+    for name in database.catalog.list_views() {
+        if let Some(view) = database.catalog.get_view(&name) {
+            if let Some(missing) = find_missing_column_in_view(view, &sim) {
+                return Err(ExecutorError::Other(format!(
+                    "error in view {}{}: no such column: {}",
+                    view.name, suffix, missing
+                )));
+            }
+        }
+    }
+
+    for name in database.catalog.list_triggers() {
+        if let Some(trigger) = database.catalog.get_trigger(&name) {
+            if let Some(missing) = find_missing_pseudo_in_trigger(trigger, &sim) {
+                return Err(ExecutorError::Other(format!(
+                    "error in trigger {}{}: no such column: {}",
+                    trigger.name, suffix, missing
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ============================================================================
+// Simulated post-drop schema resolution
+// ============================================================================
+
+/// Column resolution against the schema, optionally simulating the drop of
+/// one column from one table (the post-check view of the world).
+struct DropSimulation<'a> {
+    db: &'a Database,
+    /// `(canonical altered-table name, dropped column)`; `None` = pre-check.
+    dropped: Option<(String, &'a str)>,
+}
+
+impl<'a> DropSimulation<'a> {
+    fn new(db: &'a Database, dropped: Option<(&str, &'a str)>) -> Self {
+        let dropped = dropped.map(|(table, column)| {
+            let canonical = db
+                .catalog
+                .get_table(table)
+                .map(|s| s.name.clone())
+                .unwrap_or_else(|| table.to_string());
+            (canonical, column)
+        });
+        DropSimulation { db, dropped }
+    }
+
+    /// The (possibly simulated) column names of a FROM-clause relation, or
+    /// `None` when they cannot be determined statically (unknown relation, or
+    /// a view without a resolved column list) — the caller then skips
+    /// validation of the referencing object.
+    fn columns_of_relation(&self, name: &str) -> Option<Vec<String>> {
+        if let Some(schema) = self.db.catalog.get_table(name) {
+            let mut cols: Vec<String> = schema.columns.iter().map(|c| c.name.clone()).collect();
+            if let Some((altered, dropped_col)) = &self.dropped {
+                if schema.name.eq_ignore_ascii_case(altered) {
+                    cols.retain(|c| !c.eq_ignore_ascii_case(dropped_col));
+                }
+            }
+            return Some(cols);
+        }
+        if let Some(view) = self.db.catalog.get_view(name) {
+            // A lax-created (unresolved) view has no column list; validating
+            // objects built on top of it is skipped — the broken view itself
+            // is reported directly when its own turn comes.
+            return view.columns.clone();
+        }
+        None
+    }
+}
+
+// ============================================================================
+// View validation
+// ============================================================================
+
+/// One resolvable relation in a view's FROM clause.
+struct FromSource {
+    /// Lookup key: the alias if given, else the (unqualified) table name.
+    /// Stored lowercase for comparison against `ColumnIdentifier` canonicals.
+    key: String,
+    columns: Vec<String>,
+}
+
+/// First column reference in `view`'s defining query that does not resolve
+/// against the (possibly simulated) schema, in SQL text order — or `None`
+/// when the view is valid or too complex to validate statically.
+fn find_missing_column_in_view(view: &ViewDefinition, sim: &DropSimulation) -> Option<String> {
+    let query = &view.query;
+
+    // Constructs that introduce additional name scopes are skipped wholesale:
+    // resolving them faithfully would duplicate the planner, and a false
+    // positive here would block a DROP COLUMN that SQLite allows.
+    if query.with_clause.is_some() || query.values.is_some() || query.set_operation.is_some() {
+        return None;
+    }
+    let from = query.from.as_ref()?;
+
+    let mut sources = Vec::new();
+    if !collect_from_sources(from, sim, &mut sources) {
+        return None;
+    }
+
+    // Select-list aliases are legal targets for references in WHERE / GROUP
+    // BY / HAVING / ORDER BY (SQLite is lenient here); accepting them
+    // everywhere can only under-report, never false-positive.
+    let aliases: Vec<String> = query
+        .select_list
+        .iter()
+        .filter_map(|item| match item {
+            SelectItem::Expression { alias: Some(a), .. } => Some(a.clone()),
+            _ => None,
+        })
+        .collect();
+
+    let scope = ViewScope { sources: &sources, aliases: &aliases };
+
+    // Walk in SQL text order so the *first* dangling reference is reported,
+    // matching SQLite's message (e.g. `d` for `SELECT d, e FROM p1`).
+    for item in &query.select_list {
+        if let SelectItem::Expression { expr, .. } = item {
+            if let Some(missing) = first_missing_in_expr(expr, &scope) {
+                return Some(missing);
+            }
+        }
+    }
+    if let Some(missing) = first_missing_in_join_conditions(from, &scope) {
+        return Some(missing);
+    }
+    if let Some(where_clause) = &query.where_clause {
+        if let Some(missing) = first_missing_in_expr(where_clause, &scope) {
+            return Some(missing);
+        }
+    }
+    if let Some(group_by) = &query.group_by {
+        for expr in group_by.all_expressions() {
+            if let Some(missing) = first_missing_in_expr(expr, &scope) {
+                return Some(missing);
+            }
+        }
+    }
+    if let Some(having) = &query.having {
+        if let Some(missing) = first_missing_in_expr(having, &scope) {
+            return Some(missing);
+        }
+    }
+    if let Some(order_by) = &query.order_by {
+        for item in order_by {
+            if let Some(missing) = first_missing_in_expr(&item.expr, &scope) {
+                return Some(missing);
+            }
+        }
+    }
+
+    None
+}
+
+/// Flatten a FROM tree into per-relation column sets. Returns `false` (skip
+/// the whole view) on derived tables, VALUES sources, or relations whose
+/// columns cannot be determined.
+fn collect_from_sources(
+    from: &FromClause,
+    sim: &DropSimulation,
+    out: &mut Vec<FromSource>,
+) -> bool {
+    match from {
+        FromClause::Table { name, alias, column_aliases, .. } => {
+            let Some(mut cols) = sim.columns_of_relation(name) else {
+                return false;
+            };
+            if let Some(aliases) = column_aliases {
+                cols = aliases.clone();
+            }
+            let key = alias
+                .clone()
+                .unwrap_or_else(|| name.rsplit('.').next().unwrap_or(name).to_string());
+            out.push(FromSource { key: key.to_ascii_lowercase(), columns: cols });
+            true
+        }
+        FromClause::Join { left, right, .. } => {
+            collect_from_sources(left, sim, out) && collect_from_sources(right, sim, out)
+        }
+        FromClause::Subquery { .. } | FromClause::Values { .. } => false,
+    }
+}
+
+/// First dangling reference in any JOIN `ON` condition of the FROM tree.
+fn first_missing_in_join_conditions(from: &FromClause, scope: &ViewScope) -> Option<String> {
+    match from {
+        FromClause::Join { left, right, condition, .. } => {
+            if let Some(missing) = first_missing_in_join_conditions(left, scope) {
+                return Some(missing);
+            }
+            if let Some(missing) = first_missing_in_join_conditions(right, scope) {
+                return Some(missing);
+            }
+            condition.as_ref().and_then(|cond| first_missing_in_expr(cond, scope))
+        }
+        _ => None,
+    }
+}
+
+struct ViewScope<'a> {
+    sources: &'a [FromSource],
+    aliases: &'a [String],
+}
+
+/// SQLite's implicit rowid pseudo-columns, always accepted.
+fn is_rowid_pseudo(name: &str) -> bool {
+    matches!(name, "rowid" | "oid" | "_rowid_")
+}
+
+/// First unresolvable `ColumnRef` in `expr` (pre-order), or `None`.
+///
+/// Only expression shapes enumerated here are descended into; anything else
+/// (subqueries, window functions, ...) is treated as valid — conservative in
+/// the direction that never blocks a legal DROP COLUMN.
+fn first_missing_in_expr(expr: &Expression, scope: &ViewScope) -> Option<String> {
+    match expr {
+        Expression::ColumnRef(col) => check_column_ref(col, scope),
+        Expression::BinaryOp { left, right, .. } => {
+            first_missing_in_expr(left, scope).or_else(|| first_missing_in_expr(right, scope))
+        }
+        Expression::IsDistinctFrom { left, right, .. } => {
+            first_missing_in_expr(left, scope).or_else(|| first_missing_in_expr(right, scope))
+        }
+        Expression::Conjunction(children) | Expression::Disjunction(children) => {
+            children.iter().find_map(|c| first_missing_in_expr(c, scope))
+        }
+        Expression::UnaryOp { expr, .. }
+        | Expression::IsNull { expr, .. }
+        | Expression::IsTruthValue { expr, .. }
+        | Expression::Collate { expr, .. }
+        | Expression::Cast { expr, .. } => first_missing_in_expr(expr, scope),
+        Expression::Function { args, .. } => {
+            args.iter().find_map(|a| first_missing_in_expr(a, scope))
+        }
+        Expression::AggregateFunction { args, filter, .. } => args
+            .iter()
+            .find_map(|a| first_missing_in_expr(a, scope))
+            .or_else(|| filter.as_ref().and_then(|f| first_missing_in_expr(f, scope))),
+        Expression::Case { operand, when_clauses, else_result } => operand
+            .as_ref()
+            .and_then(|o| first_missing_in_expr(o, scope))
+            .or_else(|| {
+                when_clauses.iter().find_map(|w| {
+                    w.conditions
+                        .iter()
+                        .find_map(|c| first_missing_in_expr(c, scope))
+                        .or_else(|| first_missing_in_expr(&w.result, scope))
+                })
+            })
+            .or_else(|| else_result.as_ref().and_then(|e| first_missing_in_expr(e, scope))),
+        Expression::InList { expr, values, .. } => first_missing_in_expr(expr, scope)
+            .or_else(|| values.iter().find_map(|e| first_missing_in_expr(e, scope))),
+        Expression::Between { expr, low, high, .. } => first_missing_in_expr(expr, scope)
+            .or_else(|| first_missing_in_expr(low, scope))
+            .or_else(|| first_missing_in_expr(high, scope)),
+        Expression::Like { expr, pattern, .. } => {
+            first_missing_in_expr(expr, scope).or_else(|| first_missing_in_expr(pattern, scope))
+        }
+        Expression::Glob { expr, pattern, .. } => {
+            first_missing_in_expr(expr, scope).or_else(|| first_missing_in_expr(pattern, scope))
+        }
+        Expression::RowValueConstructor(values) => {
+            values.iter().find_map(|v| first_missing_in_expr(v, scope))
+        }
+        // Subqueries, window functions, and anything not enumerated above:
+        // do not descend (assume valid).
+        _ => None,
+    }
+}
+
+/// Resolve one column reference against the view scope. Returns the display
+/// name of the column when it is definitely unresolvable, `None` otherwise
+/// (resolved, or too ambiguous to judge).
+fn check_column_ref(col: &ColumnIdentifier, scope: &ViewScope) -> Option<String> {
+    // Schema-qualified references are rare in view bodies; skip rather than
+    // model schema resolution here.
+    if col.schema_canonical().is_some() {
+        return None;
+    }
+    let name = col.column_canonical();
+    if is_rowid_pseudo(name) {
+        return None;
+    }
+
+    if let Some(table) = col.table_canonical() {
+        match scope.sources.iter().find(|s| s.key == table) {
+            // Unknown qualifier: conservatively assume something we did not
+            // model (rather than report the column as missing).
+            None => None,
+            Some(source) => {
+                if source.columns.iter().any(|c| c.eq_ignore_ascii_case(name)) {
+                    None
+                } else {
+                    Some(col.column_display().to_string())
+                }
+            }
+        }
+    } else if scope.sources.iter().any(|s| s.columns.iter().any(|c| c.eq_ignore_ascii_case(name)))
+        || scope.aliases.iter().any(|a| a.eq_ignore_ascii_case(name))
+    {
+        None
+    } else {
+        Some(col.column_display().to_string())
+    }
+}
+
+// ============================================================================
+// Trigger validation
+// ============================================================================
+
+/// First `NEW.<col>` / `OLD.<col>` reference in `trigger` (WHEN condition
+/// first, then the body statements in order) that does not name a column of
+/// the trigger's target table — formatted as `new.<col>` / `old.<col>` for the
+/// error message. `None` when the trigger is valid or cannot be judged.
+fn find_missing_pseudo_in_trigger(
+    trigger: &TriggerDefinition,
+    sim: &DropSimulation,
+) -> Option<String> {
+    // NEW/OLD resolve against the trigger's target table (or view for
+    // INSTEAD OF triggers). If the target's columns cannot be determined,
+    // skip the trigger.
+    let columns = sim.columns_of_relation(&trigger.table_name)?;
+
+    let mut refs: Vec<(PseudoTable, String)> = Vec::new();
+    if let Some(when) = &trigger.when_condition {
+        collect_pseudo_refs_in_expr(when, &mut refs);
+    }
+    let TriggerAction::RawSql(sql) = &trigger.triggered_action;
+    match crate::trigger_execution::TriggerFirer::parse_trigger_sql(sql) {
+        Ok(statements) => {
+            for stmt in &statements {
+                collect_pseudo_refs_in_statement(stmt, &mut refs);
+            }
+        }
+        // Unparseable body: cannot judge, skip.
+        Err(_) => return None,
+    }
+
+    for (pseudo, column) in refs {
+        if is_rowid_pseudo(&column.to_ascii_lowercase()) {
+            continue;
+        }
+        if !columns.iter().any(|c| c.eq_ignore_ascii_case(&column)) {
+            let prefix = match pseudo {
+                PseudoTable::New => "new",
+                PseudoTable::Old => "old",
+            };
+            return Some(format!("{}.{}", prefix, column));
+        }
+    }
+    None
+}
+
+/// Visitor collecting every `NEW.x` / `OLD.x` reference in encounter order.
+struct PseudoRefCollector<'a> {
+    refs: &'a mut Vec<(PseudoTable, String)>,
+}
+
+impl ExpressionVisitor for PseudoRefCollector<'_> {
+    fn visit_pseudo_variable(&mut self, pseudo_table: &PseudoTable, column: &str) -> VisitResult {
+        self.refs.push((*pseudo_table, column.to_string()));
+        VisitResult::Continue
+    }
+}
+
+impl StatementVisitor for PseudoRefCollector<'_> {}
+
+fn collect_pseudo_refs_in_expr(expr: &Expression, refs: &mut Vec<(PseudoTable, String)>) {
+    let mut collector = PseudoRefCollector { refs };
+    walk_expression(&mut collector, expr);
+}
+
+fn collect_pseudo_refs_in_statement(stmt: &Statement, refs: &mut Vec<(PseudoTable, String)>) {
+    let mut collector = PseudoRefCollector { refs };
+    walk_statement(&mut collector, stmt);
+}
+
+// ============================================================================
+// Table-level CHECK validation (origin recovered from the CREATE TABLE text)
+// ============================================================================
+
+/// Display name of the first reference to `dropped` inside a CHECK constraint
+/// that would *survive* the drop: a table-level CHECK, or a column-level CHECK
+/// attached to a column other than the dropped one. A CHECK attached to the
+/// dropped column itself is removed with the column (SQLite semantics,
+/// alterdropcol.test 3.2) and never reported.
+///
+/// Column-vs-table origin is not tracked in `TableSchema::check_constraints`,
+/// so it is recovered by re-parsing the verbatim `CREATE TABLE` text — the
+/// same text SQLite's own re-parse reads. Without `sql_source` (schema built
+/// programmatically) the origin is unknown and the legacy behavior (silently
+/// dropping CHECKs that reference the column) is kept.
+fn check_constraint_missing_column(schema: &TableSchema, dropped: &str) -> Option<String> {
+    let source = schema.sql_source.as_deref()?;
+    let stmt = vibesql_parser::Parser::parse_sql(source).ok()?;
+    let Statement::CreateTable(create) = stmt else {
+        return None;
+    };
+
+    // Table-level CHECK constraints always survive the drop.
+    for constraint in &create.table_constraints {
+        if let TableConstraintKind::Check { expr } = &constraint.kind {
+            if let Some(display) = find_column_ref_display(expr, dropped) {
+                return Some(display);
+            }
+        }
+    }
+
+    // Column-level CHECKs on *other* columns also survive; only the dropped
+    // column's own CHECKs vanish with it.
+    for column in &create.columns {
+        if column.name.eq_ignore_ascii_case(dropped) {
+            continue;
+        }
+        for constraint in &column.constraints {
+            if let ColumnConstraintKind::Check(expr) = &constraint.kind {
+                if let Some(display) = find_column_ref_display(expr, dropped) {
+                    return Some(display);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Display name of the first `ColumnRef` in `expr` naming `target`
+/// (case-insensitive), or `None`. Mirrors
+/// `super::validation::expression_references_column` but reports the name as
+/// written so the error text matches SQLite byte-for-byte.
+fn find_column_ref_display(expr: &Expression, target: &str) -> Option<String> {
+    match expr {
+        Expression::ColumnRef(col) => {
+            if col.column_canonical().eq_ignore_ascii_case(target) {
+                Some(col.column_display().to_string())
+            } else {
+                None
+            }
+        }
+        Expression::BinaryOp { left, right, .. }
+        | Expression::IsDistinctFrom { left, right, .. } => {
+            find_column_ref_display(left, target).or_else(|| find_column_ref_display(right, target))
+        }
+        Expression::Conjunction(children) | Expression::Disjunction(children) => {
+            children.iter().find_map(|c| find_column_ref_display(c, target))
+        }
+        Expression::UnaryOp { expr, .. }
+        | Expression::IsNull { expr, .. }
+        | Expression::IsTruthValue { expr, .. }
+        | Expression::Collate { expr, .. }
+        | Expression::Cast { expr, .. } => find_column_ref_display(expr, target),
+        Expression::Function { args, .. } => {
+            args.iter().find_map(|a| find_column_ref_display(a, target))
+        }
+        Expression::AggregateFunction { args, filter, .. } => args
+            .iter()
+            .find_map(|a| find_column_ref_display(a, target))
+            .or_else(|| filter.as_ref().and_then(|f| find_column_ref_display(f, target))),
+        Expression::Case { operand, when_clauses, else_result } => operand
+            .as_ref()
+            .and_then(|o| find_column_ref_display(o, target))
+            .or_else(|| {
+                when_clauses.iter().find_map(|w| {
+                    w.conditions
+                        .iter()
+                        .find_map(|c| find_column_ref_display(c, target))
+                        .or_else(|| find_column_ref_display(&w.result, target))
+                })
+            })
+            .or_else(|| else_result.as_ref().and_then(|e| find_column_ref_display(e, target))),
+        Expression::InList { expr, values, .. } => find_column_ref_display(expr, target)
+            .or_else(|| values.iter().find_map(|e| find_column_ref_display(e, target))),
+        Expression::Between { expr, low, high, .. } => find_column_ref_display(expr, target)
+            .or_else(|| find_column_ref_display(low, target))
+            .or_else(|| find_column_ref_display(high, target)),
+        Expression::Like { expr, pattern, .. } => find_column_ref_display(expr, target)
+            .or_else(|| find_column_ref_display(pattern, target)),
+        Expression::Glob { expr, pattern, .. } => find_column_ref_display(expr, target)
+            .or_else(|| find_column_ref_display(pattern, target)),
+        Expression::RowValueConstructor(values) => {
+            values.iter().find_map(|v| find_column_ref_display(v, target))
+        }
+        _ => None,
+    }
+}

--- a/crates/vibesql-executor/src/alter/mod.rs
+++ b/crates/vibesql-executor/src/alter/mod.rs
@@ -2,6 +2,7 @@
 
 mod columns;
 mod constraints;
+mod drop_column_checks;
 mod table_options;
 mod validation;
 

--- a/crates/vibesql-executor/tests/alter_drop_column_validation_tests.rs
+++ b/crates/vibesql-executor/tests/alter_drop_column_validation_tests.rs
@@ -16,7 +16,8 @@
 //! rewrites the verbatim `sqlite_master.sql` text in place.
 
 use vibesql_executor::{
-    AlterTableExecutor, CreateIndexExecutor, CreateTableExecutor, SelectExecutor, ViewExecutor,
+    AlterTableExecutor, CreateIndexExecutor, CreateTableExecutor, InsertExecutor, SelectExecutor,
+    TriggerExecutor, ViewExecutor,
 };
 use vibesql_parser::Parser;
 use vibesql_storage::Database;
@@ -162,4 +163,210 @@ fn drop_unconstrained_column_succeeds_and_rewrites_schema_text() {
     // CREATE TABLE text in place, matching sqlite3 (whitespace preserved).
     try_alter(&mut db, "ALTER TABLE t1 DROP COLUMN b").expect("DROP COLUMN b");
     assert_eq!(table_sql(&db, "t1"), "CREATE TABLE t1(a, c)");
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3 (issue #5795): lax view creation + pre-/post-drop schema re-parse
+// (alterdropcol.test sections 3 and 5, sqlite3 3.51.0 verbatim messages).
+// ---------------------------------------------------------------------------
+
+fn create_trigger(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse CREATE TRIGGER");
+    let vibesql_ast::Statement::CreateTrigger(trigger) = stmt else {
+        panic!("expected CREATE TRIGGER");
+    };
+    TriggerExecutor::create_trigger(db, &trigger).expect("CREATE TRIGGER");
+}
+
+fn insert(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse INSERT");
+    let vibesql_ast::Statement::Insert(ins) = stmt else {
+        panic!("expected INSERT");
+    };
+    InsertExecutor::execute(db, &ins).expect("INSERT");
+}
+
+/// alterdropcol.test 5.2.1: SQLite defers view column resolution, so a view
+/// whose SELECT names a not-yet-resolvable column is still created.
+#[test]
+fn create_view_with_unresolvable_column_is_lax() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE p1(a PRIMARY KEY, b UNIQUE)");
+    create_view(&mut db, "CREATE VIEW v1 AS SELECT d, e FROM p1");
+    assert!(db.catalog.get_view("v1").is_some(), "lax view v1 should exist");
+}
+
+/// alterdropcol.test 5.2.2: the pre-drop schema re-parse covers the *whole*
+/// schema — here the broken view selects from p1, unrelated to the altered
+/// table c1. No "after drop column" suffix (broken before the drop), and the
+/// inner column name is unquoted.
+#[test]
+fn precheck_rejects_drop_when_unrelated_view_is_broken() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE p1(a PRIMARY KEY, b UNIQUE)");
+    create_table(&mut db, "CREATE TABLE c1(x, y)");
+    create_view(&mut db, "CREATE VIEW v1 AS SELECT d, e FROM p1");
+    assert_eq!(
+        drop_column_err(&mut db, "ALTER TABLE c1 DROP COLUMN x"),
+        "error in view v1: no such column: d"
+    );
+    // The failed ALTER must leave c1 untouched.
+    assert!(db.get_table("c1").unwrap().schema.has_column("x"));
+}
+
+/// alterdropcol.test 5.3.2: a view broken *by* the drop fails the post-check
+/// with the "after drop column" suffix, and the drop is not applied.
+#[test]
+fn postcheck_rejects_drop_that_breaks_dependent_view() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE c1(x, y)");
+    create_view(&mut db, "CREATE VIEW v1 AS SELECT x, y FROM c1");
+    assert_eq!(
+        drop_column_err(&mut db, "ALTER TABLE c1 DROP COLUMN x"),
+        "error in view v1 after drop column: no such column: x"
+    );
+    assert!(db.get_table("c1").unwrap().schema.has_column("x"));
+}
+
+/// alterdropcol.test 5.4.2: a trigger referencing a nonexistent `new.<col>`
+/// was broken before the drop, so the pre-check reports it without the
+/// "after drop column" suffix — and with the `new.` qualifier in the message.
+#[test]
+fn precheck_rejects_drop_when_trigger_references_missing_new_column() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE p1(a PRIMARY KEY, b UNIQUE)");
+    create_table(&mut db, "CREATE TABLE c1(x, y)");
+    create_trigger(
+        &mut db,
+        "CREATE TRIGGER tr AFTER INSERT ON c1 BEGIN \
+           INSERT INTO p1 VALUES(new.y, new.xyz); \
+         END",
+    );
+    assert_eq!(
+        drop_column_err(&mut db, "ALTER TABLE c1 DROP COLUMN y"),
+        "error in trigger tr: no such column: new.xyz"
+    );
+    assert!(db.get_table("c1").unwrap().schema.has_column("y"));
+}
+
+/// When both a pre-broken trigger and a would-break view exist, the pre-check
+/// wins (5.4.2 pattern: v1 references c1.y, which is being dropped, but the
+/// already-broken trigger is reported instead).
+#[test]
+fn precheck_wins_over_postcheck() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE p1(a PRIMARY KEY, b UNIQUE)");
+    create_table(&mut db, "CREATE TABLE c1(x, y)");
+    create_view(&mut db, "CREATE VIEW v1 AS SELECT x, y FROM c1");
+    create_trigger(
+        &mut db,
+        "CREATE TRIGGER tr AFTER INSERT ON c1 BEGIN \
+           INSERT INTO p1 VALUES(new.y, new.xyz); \
+         END",
+    );
+    assert_eq!(
+        drop_column_err(&mut db, "ALTER TABLE c1 DROP COLUMN y"),
+        "error in trigger tr: no such column: new.xyz"
+    );
+}
+
+/// alterdropcol.test 3.1: a *table-level* CHECK referencing the dropped
+/// column survives the drop, so the post-check errors instead of silently
+/// stripping the constraint.
+#[test]
+fn postcheck_rejects_drop_that_breaks_table_level_check() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t12(a, b, c, CHECK(c>10))");
+    assert_eq!(
+        drop_column_err(&mut db, "ALTER TABLE t12 DROP COLUMN c"),
+        "error in table t12 after drop column: no such column: c"
+    );
+    assert!(db.get_table("t12").unwrap().schema.has_column("c"));
+    // The CHECK constraint must also survive the failed ALTER.
+    assert_eq!(db.get_table("t12").unwrap().schema.check_constraints.len(), 1);
+}
+
+/// alterdropcol.test 3.2 (positive control): a *column-level* CHECK attached
+/// to the dropped column is removed together with the column.
+#[test]
+fn drop_column_with_own_column_level_check_succeeds() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t13(a, b, c CHECK(c>10))");
+    try_alter(&mut db, "ALTER TABLE t13 DROP COLUMN c").expect("DROP COLUMN c");
+    let schema = &db.get_table("t13").unwrap().schema;
+    assert!(!schema.has_column("c"));
+    assert!(schema.check_constraints.is_empty(), "own CHECK dropped with the column");
+}
+
+/// A column-level CHECK on a *different* column referencing the dropped one
+/// survives the drop and must fail the post-check (SQLite re-parse
+/// semantics).
+#[test]
+fn postcheck_rejects_drop_referenced_by_other_columns_check() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t14(a, b CHECK(c>10), c)");
+    assert_eq!(
+        drop_column_err(&mut db, "ALTER TABLE t14 DROP COLUMN c"),
+        "error in table t14 after drop column: no such column: c"
+    );
+}
+
+/// Atomicity control: a failed post-check leaves schema text and row data
+/// untouched.
+#[test]
+fn failed_drop_leaves_schema_and_rows_untouched() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE c1(x, y)");
+    insert(&mut db, "INSERT INTO c1 VALUES(1, 2)");
+    insert(&mut db, "INSERT INTO c1 VALUES(3, 4)");
+    create_view(&mut db, "CREATE VIEW v1 AS SELECT x, y FROM c1");
+
+    drop_column_err(&mut db, "ALTER TABLE c1 DROP COLUMN x");
+
+    assert_eq!(table_sql(&db, "c1"), "CREATE TABLE c1(x, y)");
+    let table = db.get_table("c1").unwrap();
+    assert_eq!(table.row_count(), 2);
+    assert_eq!(table.schema.columns.len(), 2);
+}
+
+/// `DROP COLUMN IF EXISTS` on a missing column is a no-op that skips the
+/// schema re-parse entirely (even with a broken view present).
+#[test]
+fn if_exists_noop_skips_schema_recheck() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE p1(a PRIMARY KEY, b UNIQUE)");
+    create_table(&mut db, "CREATE TABLE c1(x, y)");
+    create_view(&mut db, "CREATE VIEW v1 AS SELECT d, e FROM p1");
+    try_alter(&mut db, "ALTER TABLE c1 DROP COLUMN IF EXISTS nosuch")
+        .expect("IF EXISTS no-op should succeed despite broken view");
+}
+
+/// A view over `SELECT *` adapts to the drop and must not block it
+/// (alterdropcol.test 1.6.1 pattern).
+#[test]
+fn star_view_does_not_block_drop() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t1(a, b, c)");
+    create_view(&mut db, "CREATE VIEW v1 AS SELECT * FROM t1");
+    try_alter(&mut db, "ALTER TABLE t1 DROP COLUMN b").expect("DROP COLUMN b");
+    assert_eq!(table_sql(&db, "t1"), "CREATE TABLE t1(a, c)");
+}
+
+/// A trigger on the altered table whose `new.<col>` reference names the
+/// dropped column fails the post-check with the "after drop column" suffix.
+#[test]
+fn postcheck_rejects_drop_that_breaks_trigger_on_altered_table() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE p1(a PRIMARY KEY, b UNIQUE)");
+    create_table(&mut db, "CREATE TABLE c1(x, y)");
+    create_trigger(
+        &mut db,
+        "CREATE TRIGGER tr AFTER INSERT ON c1 BEGIN \
+           INSERT INTO p1 VALUES(new.x, new.y); \
+         END",
+    );
+    assert_eq!(
+        drop_column_err(&mut db, "ALTER TABLE c1 DROP COLUMN y"),
+        "error in trigger tr after drop column: no such column: new.y"
+    );
 }


### PR DESCRIPTION
Closes #5795

Phase 3 of #5784: match SQLite's dry-run whole-schema re-parse for `ALTER TABLE ... DROP COLUMN` (`alter.c` renameTestSchema semantics), plus lax `CREATE VIEW`.

## What this does

- **Pre-check** (new `crates/vibesql-executor/src/alter/drop_column_checks.rs`): before anything is touched, every view and trigger in the schema is statically re-resolved. An *already-broken* object — even one unrelated to the altered table — aborts the ALTER with `error in <type> <name>: no such column: <col>` (no "after drop column" suffix; `new.`/`old.` qualifier preserved for triggers; inner names unquoted).
- **Post-check**: dependent views, triggers, and surviving CHECK constraints are re-resolved against a *simulated* post-drop schema. Failure aborts with `error in <type> <name> after drop column: no such column: <col>`. Because validation runs before any mutation, failed drops are atomic with no rollback machinery.
- **CHECK origin (3.1 vs 3.2)**: table-level vs column-level origin is recovered by re-parsing the verbatim `CREATE TABLE` text (`sql_source`) — the same text SQLite re-parses — so a column's own CHECK still vanishes with it (3.2 stays green) while a table-level CHECK (or a CHECK on a *different* column) referencing the dropped column errors (3.1). No storage-format change, no catalog shape change.
- **Lax CREATE VIEW** (5.2.1): `execute_create_view` no longer fails when the view body names an unresolvable column — SQLite defers resolution to query time. The view is stored without a derived column list; the existing eager-validation paths (set-operation arity, ORDER BY resolution allow-list, #5394 view-reference guard) are untouched.

The static resolvers are deliberately conservative: only fully-understood scopes (plain tables/views in FROM; no CTEs, set operations, or derived tables) can report a missing column; anything else is skipped, so a DROP COLUMN SQLite allows is never blocked (false negatives only).

## Results

`make test-tcl-file FILE=alterdropcol.test`: **83 passed / 14 failed → 90 passed / 7 failed**

Fixed: 3.1, 5.2.1, 5.2.2, 5.3.1, 5.3.2, 5.4.2, 5.5.2 (all 8 in-scope tests incl. 3.2 kept green).
Remaining 7 are out of scope: 5.1 → #5826 (sqlite_schema creation-order enumeration, split per curator note), 7.0–7.3 / 8.1 / 8.2 → #5796.

## Regression sweep (worktree run vs main baseline)

| File | Baseline | This branch |
|------|----------|-------------|
| altertab.test | 27 passed / 0 failed | 27 / 0 |
| view.test | 24 / 0 | 24 / 0 |
| window1.test (incl. 32.10) | 271 / 0 | 271 / 0 |
| select7.test (incl. 8.2) | 24 / 0 | 24 / 0 |
| altercol.test | 71 / 15 | 71 / 15 (pre-existing) |
| alter.test | 40 / 61 | 40 / 61 (pre-existing) |
| trigger1.test | 35 / 35 | 35 / 35 (pre-existing) |
| triggerA.test | 15 / 2 | 15 / 2 (pre-existing) |

`cargo test -p vibesql-executor -p vibesql-catalog`: all green (includes 12 new integration tests in `alter_drop_column_validation_tests.rs`: lax view creation, pre-check on an unrelated broken view, post-check view/trigger/table-CHECK errors, column-CHECK positive control, pre-check-wins ordering, atomicity control, IF EXISTS no-op skip, `SELECT *` view non-blocking). `cargo fmt --check` clean; no clippy warnings in changed files.

Note: one TCL run flaked 9.2.2 (50k-row WITHOUT ROWID drop) under machine load; it reproduces cleanly by hand and passed on both reruns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
