### PR TITLE
fix(executor): SQLite coercion/truthiness gaps — Boolean leakage, ~/NOT on text/blob, LIKE blob pattern, LIMIT/OFFSET affinity, HAVING (#5803)

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -233,9 +233,7 @@ impl CombinedExpressionEvaluator<'_> {
             vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
-            vibesql_types::SqlValue::Boolean(b) => {
-                arcstr::ArcStr::from(if *b { "1" } else { "0" })
-            }
+            vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for LIKE comparison
             vibesql_types::SqlValue::Blob(b) => {
                 arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned())
@@ -261,8 +259,12 @@ impl CombinedExpressionEvaluator<'_> {
             vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
-            vibesql_types::SqlValue::Boolean(b) => {
-                arcstr::ArcStr::from(if *b { "1" } else { "0" })
+            vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
+            // SQLite treats blob bytes as raw text for the LIKE pattern too:
+            // 'abc' LIKE X'ABCD' → 0 (invalid UTF-8 becomes replacement chars,
+            // which simply never match)
+            vibesql_types::SqlValue::Blob(b) => {
+                arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned())
             }
             _ => {
                 return Err(ExecutorError::TypeMismatch {
@@ -352,9 +354,7 @@ impl CombinedExpressionEvaluator<'_> {
             vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
-            vibesql_types::SqlValue::Boolean(b) => {
-                arcstr::ArcStr::from(if *b { "1" } else { "0" })
-            }
+            vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for GLOB comparison
             vibesql_types::SqlValue::Blob(b) => {
                 arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned())
@@ -380,8 +380,10 @@ impl CombinedExpressionEvaluator<'_> {
             vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
-            vibesql_types::SqlValue::Boolean(b) => {
-                arcstr::ArcStr::from(if *b { "1" } else { "0" })
+            vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
+            // SQLite treats blob bytes as raw text for the GLOB pattern too
+            vibesql_types::SqlValue::Blob(b) => {
+                arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned())
             }
             _ => {
                 return Err(ExecutorError::TypeMismatch {

--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -232,6 +232,10 @@ impl CombinedExpressionEvaluator<'_> {
             vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
+            vibesql_types::SqlValue::Boolean(b) => {
+                arcstr::ArcStr::from(if *b { "1" } else { "0" })
+            }
             // SQLite treats blob bytes as raw text for LIKE comparison
             vibesql_types::SqlValue::Blob(b) => {
                 arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned())
@@ -256,6 +260,10 @@ impl CombinedExpressionEvaluator<'_> {
             vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
+            vibesql_types::SqlValue::Boolean(b) => {
+                arcstr::ArcStr::from(if *b { "1" } else { "0" })
+            }
             _ => {
                 return Err(ExecutorError::TypeMismatch {
                     left: expr_val,
@@ -343,6 +351,10 @@ impl CombinedExpressionEvaluator<'_> {
             vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
+            vibesql_types::SqlValue::Boolean(b) => {
+                arcstr::ArcStr::from(if *b { "1" } else { "0" })
+            }
             // SQLite treats blob bytes as raw text for GLOB comparison
             vibesql_types::SqlValue::Blob(b) => {
                 arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned())
@@ -367,6 +379,10 @@ impl CombinedExpressionEvaluator<'_> {
             vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
+            vibesql_types::SqlValue::Boolean(b) => {
+                arcstr::ArcStr::from(if *b { "1" } else { "0" })
+            }
             _ => {
                 return Err(ExecutorError::TypeMismatch {
                     left: expr_val,

--- a/crates/vibesql-executor/src/evaluator/expressions/operators.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/operators.rs
@@ -6,8 +6,10 @@ use vibesql_types::SqlValue;
 
 use crate::{
     errors::ExecutorError,
-    evaluator::casting::{string_to_number, to_i64},
-    evaluator::operators::is_truthy_string,
+    evaluator::{
+        casting::{string_to_number, to_i64},
+        operators::is_truthy_string,
+    },
 };
 
 /// Evaluate a unary operation
@@ -105,6 +107,12 @@ pub(crate) fn eval_unary_op(
         (Not, SqlValue::Character(s)) | (Not, SqlValue::Varchar(s)) => {
             Ok(SqlValue::Boolean(!is_truthy_string(s)))
         }
+        // BLOB in boolean context - SQLite reads the bytes as text and applies
+        // the same leading-numeric truthiness: NOT zeroblob(10) → 1 (NUL bytes
+        // parse to 0 → falsy), NOT x'31' ("1") → 0
+        (Not, SqlValue::Blob(b)) => {
+            Ok(SqlValue::Boolean(!is_truthy_string(&String::from_utf8_lossy(b))))
+        }
         (Not, SqlValue::Date(_)) => Ok(SqlValue::Boolean(false)), // Date values are truthy
         (Not, SqlValue::Time(_)) => Ok(SqlValue::Boolean(false)), // Time values are truthy
         (Not, SqlValue::Timestamp(_)) => Ok(SqlValue::Boolean(false)), /* Timestamp values are */
@@ -113,6 +121,21 @@ pub(crate) fn eval_unary_op(
 
         // Bitwise NOT (~) - converts to integer and flips all bits
         (BitwiseNot, SqlValue::Null) => Ok(SqlValue::Null),
+        // Text: SQLite coerces via the leading-numeric prefix parse, truncating
+        // any fractional part toward zero, then applies ~ to the integer:
+        //   ~'fault' → ~0 = -1;  ~'12abc' → ~12 = -13;  ~'3.7' → ~3 = -4
+        // (string_to_number's i64 component already truncates toward zero.)
+        (BitwiseNot, SqlValue::Character(s)) | (BitwiseNot, SqlValue::Varchar(s)) => {
+            let (int_val, _, _) = string_to_number(s);
+            Ok(SqlValue::Integer(!int_val))
+        }
+        // BLOB: bytes → text → number, mirroring the unary-minus Blob arm above:
+        //   ~x'313233' ("123") → ~123 = -124
+        (BitwiseNot, SqlValue::Blob(b)) => {
+            let s = String::from_utf8_lossy(b);
+            let (int_val, _, _) = string_to_number(&s);
+            Ok(SqlValue::Integer(!int_val))
+        }
         (BitwiseNot, val) => Ok(SqlValue::Integer(!to_i64(val)?)),
 
         // Type errors
@@ -405,11 +428,7 @@ mod tests {
         let result = eval_unary_op(&UnaryOperator::Minus, &blob).unwrap();
         match result {
             SqlValue::Real(f) => {
-                assert!(
-                    (f + 1e50).abs() / 1e50 < 1e-12,
-                    "Expected ~-1e50, got {}",
-                    f
-                );
+                assert!((f + 1e50).abs() / 1e50 < 1e-12, "Expected ~-1e50, got {}", f);
             }
             other => panic!("Expected Real, got {:?}", other),
         }
@@ -472,5 +491,94 @@ mod tests {
         let blob = SqlValue::Blob(b"-.5".to_vec());
         let result = eval_unary_op(&UnaryOperator::Minus, &blob).unwrap();
         assert_eq!(result, SqlValue::Real(0.5));
+    }
+
+    // Issue #5803: ~ and NOT must coerce text/blob operands like SQLite.
+
+    #[test]
+    fn bitwise_not_on_text() {
+        // ~'fault' → ~0 = -1 (non-numeric text coerces to 0)
+        assert_eq!(
+            eval_unary_op(
+                &UnaryOperator::BitwiseNot,
+                &SqlValue::Varchar(arcstr::ArcStr::from("fault"))
+            )
+            .unwrap(),
+            SqlValue::Integer(-1)
+        );
+        // ~'12abc' → ~12 = -13 (leading-numeric prefix parse)
+        assert_eq!(
+            eval_unary_op(
+                &UnaryOperator::BitwiseNot,
+                &SqlValue::Varchar(arcstr::ArcStr::from("12abc"))
+            )
+            .unwrap(),
+            SqlValue::Integer(-13)
+        );
+        // ~'3.7' → ~3 = -4 (fractional part truncates toward zero)
+        assert_eq!(
+            eval_unary_op(
+                &UnaryOperator::BitwiseNot,
+                &SqlValue::Character(arcstr::ArcStr::from("3.7"))
+            )
+            .unwrap(),
+            SqlValue::Integer(-4)
+        );
+        // ~'-2.5' → ~-2 = 1 (truncation toward zero for negatives too)
+        assert_eq!(
+            eval_unary_op(
+                &UnaryOperator::BitwiseNot,
+                &SqlValue::Varchar(arcstr::ArcStr::from("-2.5"))
+            )
+            .unwrap(),
+            SqlValue::Integer(1)
+        );
+    }
+
+    #[test]
+    fn bitwise_not_on_blob() {
+        // ~x'313233' → bytes "123" → ~123 = -124
+        assert_eq!(
+            eval_unary_op(&UnaryOperator::BitwiseNot, &SqlValue::Blob(b"123".to_vec())).unwrap(),
+            SqlValue::Integer(-124)
+        );
+        // Non-numeric blob → 0 → -1
+        assert_eq!(
+            eval_unary_op(&UnaryOperator::BitwiseNot, &SqlValue::Blob(b"abc".to_vec())).unwrap(),
+            SqlValue::Integer(-1)
+        );
+        // Invalid UTF-8 → replacement char → 0 → -1
+        assert_eq!(
+            eval_unary_op(&UnaryOperator::BitwiseNot, &SqlValue::Blob(vec![0xFFu8])).unwrap(),
+            SqlValue::Integer(-1)
+        );
+    }
+
+    #[test]
+    fn bitwise_not_on_float_still_truncates() {
+        // ~3.7 → ~3 = -4 (pre-existing behavior via to_i64; do not regress)
+        assert_eq!(
+            eval_unary_op(&UnaryOperator::BitwiseNot, &SqlValue::Double(3.7)).unwrap(),
+            SqlValue::Integer(-4)
+        );
+    }
+
+    #[test]
+    fn not_on_blob() {
+        // NOT zeroblob(10): NUL bytes read as text parse to 0 → falsy → 1
+        assert_eq!(
+            eval_unary_op(&UnaryOperator::Not, &SqlValue::Blob(vec![0u8; 10])).unwrap(),
+            SqlValue::Boolean(true)
+        );
+        // NOT x'31' ("1") → truthy → 0
+        assert_eq!(
+            eval_unary_op(&UnaryOperator::Not, &SqlValue::Blob(b"1".to_vec())).unwrap(),
+            SqlValue::Boolean(false)
+        );
+        // Empty blob → falsy → 1
+        assert_eq!(
+            eval_unary_op(&UnaryOperator::Not, &SqlValue::Blob(vec![])).unwrap(),
+            SqlValue::Boolean(true)
+        );
     }
 }

--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -514,6 +514,10 @@ impl ExpressionEvaluator<'_> {
             vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
+            vibesql_types::SqlValue::Boolean(b) => {
+                arcstr::ArcStr::from(if *b { "1" } else { "0" })
+            }
             // SQLite treats blob bytes as raw text for LIKE comparison
             vibesql_types::SqlValue::Blob(b) => {
                 arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned())
@@ -538,6 +542,10 @@ impl ExpressionEvaluator<'_> {
             vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
+            vibesql_types::SqlValue::Boolean(b) => {
+                arcstr::ArcStr::from(if *b { "1" } else { "0" })
+            }
             _ => {
                 return Err(ExecutorError::TypeMismatch {
                     left: expr_val,
@@ -622,6 +630,10 @@ impl ExpressionEvaluator<'_> {
             vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
+            vibesql_types::SqlValue::Boolean(b) => {
+                arcstr::ArcStr::from(if *b { "1" } else { "0" })
+            }
             // SQLite treats blob bytes as raw text for GLOB comparison
             vibesql_types::SqlValue::Blob(b) => {
                 arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned())
@@ -646,6 +658,10 @@ impl ExpressionEvaluator<'_> {
             vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
+            vibesql_types::SqlValue::Boolean(b) => {
+                arcstr::ArcStr::from(if *b { "1" } else { "0" })
+            }
             _ => {
                 return Err(ExecutorError::TypeMismatch {
                     left: expr_val,

--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -515,9 +515,7 @@ impl ExpressionEvaluator<'_> {
             vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
-            vibesql_types::SqlValue::Boolean(b) => {
-                arcstr::ArcStr::from(if *b { "1" } else { "0" })
-            }
+            vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for LIKE comparison
             vibesql_types::SqlValue::Blob(b) => {
                 arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned())
@@ -543,8 +541,12 @@ impl ExpressionEvaluator<'_> {
             vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
-            vibesql_types::SqlValue::Boolean(b) => {
-                arcstr::ArcStr::from(if *b { "1" } else { "0" })
+            vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
+            // SQLite treats blob bytes as raw text for the LIKE pattern too:
+            // 'abc' LIKE X'ABCD' → 0 (invalid UTF-8 becomes replacement chars,
+            // which simply never match)
+            vibesql_types::SqlValue::Blob(b) => {
+                arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned())
             }
             _ => {
                 return Err(ExecutorError::TypeMismatch {
@@ -631,9 +633,7 @@ impl ExpressionEvaluator<'_> {
             vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
-            vibesql_types::SqlValue::Boolean(b) => {
-                arcstr::ArcStr::from(if *b { "1" } else { "0" })
-            }
+            vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for GLOB comparison
             vibesql_types::SqlValue::Blob(b) => {
                 arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned())
@@ -659,8 +659,10 @@ impl ExpressionEvaluator<'_> {
             vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
             vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
-            vibesql_types::SqlValue::Boolean(b) => {
-                arcstr::ArcStr::from(if *b { "1" } else { "0" })
+            vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
+            // SQLite treats blob bytes as raw text for the GLOB pattern too
+            vibesql_types::SqlValue::Blob(b) => {
+                arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned())
             }
             _ => {
                 return Err(ExecutorError::TypeMismatch {
@@ -822,11 +824,9 @@ impl ExpressionEvaluator<'_> {
     /// Evaluate a row-value IN list: `(a, b) IN ((1, 2), (3, 4))` and NOT IN.
     ///
     /// SQLite three-valued semantics (mirroring the scalar IN):
-    /// - TRUE (or FALSE for NOT IN) as soon as one candidate tuple compares
-    ///   fully equal;
-    /// - if no candidate matches but at least one candidate comparison was
-    ///   UNKNOWN (a NULL element with all non-NULL elements equal), the result
-    ///   is NULL;
+    /// - TRUE (or FALSE for NOT IN) as soon as one candidate tuple compares fully equal;
+    /// - if no candidate matches but at least one candidate comparison was UNKNOWN (a NULL element
+    ///   with all non-NULL elements equal), the result is NULL;
     /// - otherwise FALSE (TRUE for NOT IN).
     ///
     /// Each candidate must itself be a row value of the same arity; anything

--- a/crates/vibesql-executor/src/evaluator/operators/comparison/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/comparison/mod.rs
@@ -13,9 +13,7 @@ use vibesql_types::SqlValue;
 
 use crate::{
     errors::ExecutorError,
-    evaluator::casting::{
-        boolean_to_i64, is_approximate_numeric, is_exact_numeric, to_f64, to_i64,
-    },
+    evaluator::casting::{is_approximate_numeric, is_exact_numeric, to_f64, to_i64},
 };
 
 /// Public API for comparison operations
@@ -85,52 +83,24 @@ where
     }
 
     // Boolean coercion for comparisons
-    // If either operand is Boolean and the other is numeric, coerce boolean to i64
+    //
+    // SQLite has no BOOLEAN storage class: EXISTS/IN/comparison results are
+    // the integers 0/1. When a Boolean operand meets a non-Boolean operand
+    // (numeric, text, blob, ...), normalize the Boolean to Integer 0/1 and
+    // re-dispatch so the regular cross-type logic below applies (numeric
+    // coercion, SQLite type ordering: numeric < text < blob).
+    //
+    // Examples (matching SQLite):
+    //   EXISTS(SELECT 1) == 'experiments' → 1 = 'experiments' → 0
+    //   EXISTS(SELECT 1) <  'a'           → 1 < 'a'           → 1
+    //   1 IN (SELECT 1)  == 2             → 1 = 2             → 0
     match (left, right) {
-        // Boolean compared to any numeric type
-        (Boolean(_), right_val)
-            if is_exact_numeric(right_val)
-                || is_approximate_numeric(right_val)
-                || matches!(right_val, Numeric(_)) =>
-        {
-            let left_i64 = boolean_to_i64(left).unwrap(); // Safe: we know left is Boolean
-
-            // For exact numeric, compare as i64
-            if is_exact_numeric(right_val) {
-                let right_i64 = to_i64(right_val)?;
-                return Ok(Boolean(predicate(left_i64.cmp(&right_i64))));
-            }
-
-            // For approximate numeric or Numeric, compare as f64
-            let left_f64 = left_i64 as f64;
-            let right_f64 = to_f64(right_val)?;
-            return Ok(Boolean(predicate(
-                left_f64.partial_cmp(&right_f64).unwrap_or(std::cmp::Ordering::Equal),
-            )));
+        (Boolean(b), other) if !matches!(other, Boolean(_)) => {
+            return compare(&Integer(i64::from(*b)), other, predicate, op_str);
         }
-
-        // Numeric compared to Boolean (symmetric case)
-        (left_val, Boolean(_))
-            if is_exact_numeric(left_val)
-                || is_approximate_numeric(left_val)
-                || matches!(left_val, Numeric(_)) =>
-        {
-            let right_i64 = boolean_to_i64(right).unwrap(); // Safe: we know right is Boolean
-
-            // For exact numeric, compare as i64
-            if is_exact_numeric(left_val) {
-                let left_i64 = to_i64(left_val)?;
-                return Ok(Boolean(predicate(left_i64.cmp(&right_i64))));
-            }
-
-            // For approximate numeric or Numeric, compare as f64
-            let left_f64 = to_f64(left_val)?;
-            let right_f64 = right_i64 as f64;
-            return Ok(Boolean(predicate(
-                left_f64.partial_cmp(&right_f64).unwrap_or(std::cmp::Ordering::Equal),
-            )));
+        (other, Boolean(b)) if !matches!(other, Boolean(_)) => {
+            return compare(other, &Integer(i64::from(*b)), predicate, op_str);
         }
-
         _ => {} // Fall through to existing comparison logic
     }
 
@@ -489,4 +459,109 @@ fn compare_int_float(int_val: i64, float_val: f64) -> std::cmp::Ordering {
 #[inline]
 fn compare_float_int(float_val: f64, int_val: i64) -> std::cmp::Ordering {
     compare_int_float(int_val, float_val).reverse()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(text: &str) -> SqlValue {
+        SqlValue::Varchar(arcstr::ArcStr::from(text))
+    }
+
+    // Issue #5803: Boolean operands normalize to Integer 0/1 before
+    // cross-type dispatch, so Boolean vs text/blob follows SQLite type
+    // ordering (numeric < text < blob) instead of raising a type mismatch.
+
+    #[test]
+    fn boolean_vs_text_all_six_ops() {
+        let t = SqlValue::Boolean(true);
+        // SQLite: SELECT 1 == 'experiments' → 0
+        assert_eq!(ComparisonOps::equal(&t, &s("experiments")).unwrap(), SqlValue::Boolean(false));
+        assert_eq!(
+            ComparisonOps::not_equal(&t, &s("experiments")).unwrap(),
+            SqlValue::Boolean(true)
+        );
+        // SQLite: SELECT 1 < 'a' → 1 (numeric < text)
+        assert_eq!(ComparisonOps::less_than(&t, &s("a")).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(
+            ComparisonOps::less_than_or_equal(&t, &s("a")).unwrap(),
+            SqlValue::Boolean(true)
+        );
+        assert_eq!(ComparisonOps::greater_than(&t, &s("a")).unwrap(), SqlValue::Boolean(false));
+        assert_eq!(
+            ComparisonOps::greater_than_or_equal(&t, &s("a")).unwrap(),
+            SqlValue::Boolean(false)
+        );
+    }
+
+    #[test]
+    fn text_vs_boolean_symmetric_order() {
+        let f = SqlValue::Boolean(false);
+        // text > numeric in SQLite type ordering
+        assert_eq!(ComparisonOps::greater_than(&s("a"), &f).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(ComparisonOps::less_than(&s("a"), &f).unwrap(), SqlValue::Boolean(false));
+        assert_eq!(ComparisonOps::equal(&s("a"), &f).unwrap(), SqlValue::Boolean(false));
+        assert_eq!(ComparisonOps::not_equal(&s("a"), &f).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(
+            ComparisonOps::greater_than_or_equal(&s("a"), &f).unwrap(),
+            SqlValue::Boolean(true)
+        );
+        assert_eq!(
+            ComparisonOps::less_than_or_equal(&s("a"), &f).unwrap(),
+            SqlValue::Boolean(false)
+        );
+    }
+
+    #[test]
+    fn boolean_vs_blob_type_ordering() {
+        let t = SqlValue::Boolean(true);
+        let blob = SqlValue::Blob(vec![0x00]);
+        // numeric < blob
+        assert_eq!(ComparisonOps::less_than(&t, &blob).unwrap(), SqlValue::Boolean(true));
+        assert_eq!(ComparisonOps::equal(&t, &blob).unwrap(), SqlValue::Boolean(false));
+        assert_eq!(ComparisonOps::greater_than(&blob, &t).unwrap(), SqlValue::Boolean(true));
+    }
+
+    #[test]
+    fn boolean_vs_numeric_regression_guard() {
+        // Pre-existing behavior (do not regress): 1 IN (SELECT 1) == 2 → 0
+        let t = SqlValue::Boolean(true);
+        assert_eq!(
+            ComparisonOps::equal(&t, &SqlValue::Integer(2)).unwrap(),
+            SqlValue::Boolean(false)
+        );
+        assert_eq!(
+            ComparisonOps::equal(&t, &SqlValue::Integer(1)).unwrap(),
+            SqlValue::Boolean(true)
+        );
+        assert_eq!(
+            ComparisonOps::less_than(&t, &SqlValue::Double(1.5)).unwrap(),
+            SqlValue::Boolean(true)
+        );
+        assert_eq!(
+            ComparisonOps::equal(&SqlValue::Double(0.0), &SqlValue::Boolean(false)).unwrap(),
+            SqlValue::Boolean(true)
+        );
+    }
+
+    #[test]
+    fn boolean_vs_boolean_unchanged() {
+        assert_eq!(
+            ComparisonOps::equal(&SqlValue::Boolean(true), &SqlValue::Boolean(true)).unwrap(),
+            SqlValue::Boolean(true)
+        );
+        assert_eq!(
+            ComparisonOps::less_than(&SqlValue::Boolean(false), &SqlValue::Boolean(true)).unwrap(),
+            SqlValue::Boolean(true)
+        );
+    }
+
+    #[test]
+    fn boolean_vs_null_returns_null() {
+        assert_eq!(
+            ComparisonOps::equal(&SqlValue::Boolean(true), &SqlValue::Null).unwrap(),
+            SqlValue::Null
+        );
+    }
 }

--- a/crates/vibesql-executor/src/evaluator/operators/logical.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/logical.rs
@@ -59,6 +59,10 @@ pub fn is_truthy(value: &SqlValue) -> bool {
         Numeric(f) => *f != 0.0,
         // String types: SQLite parses leading numeric portion
         Varchar(s) | Character(s) => is_truthy_string(s),
+        // BLOB: SQLite reads the bytes as text and applies the same
+        // leading-numeric coercion: X'31' ("1") is truthy, zeroblob(3)
+        // (NUL bytes) is falsy (#5803)
+        Blob(b) => is_truthy_string(&String::from_utf8_lossy(b)),
         // Other types are not truthy (conservative default)
         _ => false,
     }

--- a/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
@@ -408,9 +408,12 @@ fn value_supported_for_column(col_type: Option<&DataType>, value: &SqlValue) -> 
             SqlValue::Varchar(s) | SqlValue::Character(s) => !string_coerces_to_numeric(s),
             _ => false,
         },
-        // Issue #5340: the expression evaluator raises a type-mismatch error
-        // for Boolean vs string/BLOB/temporal operands, and the columnar
-        // comparator has no error channel, so decline those. Boolean vs
+        // Issues #5340/#5803: the expression evaluator normalizes Boolean to
+        // Integer 0/1 and orders Boolean-vs-string with strict storage-class
+        // ordering (numeric < TEXT, no string parsing). The columnar
+        // numeric-vs-string arm instead coerces parseable strings to numbers,
+        // which would diverge (e.g. `flag = '1'`), so decline string/BLOB/
+        // temporal operands and let the evaluator handle them. Boolean vs
         // Boolean and Boolean vs numeric compare faithfully in both paths
         // (booleans coerce to 0/1).
         Some(DataType::Boolean) => matches!(value, SqlValue::Boolean(_)) || is_numeric_value(value),
@@ -438,9 +441,11 @@ fn value_supported_for_column(col_type: Option<&DataType>, value: &SqlValue) -> 
             // (they raise ColumnarTypeMismatch), so decline and let the
             // evaluator handle it.
             SqlValue::Blob(_) => is_blob_type(other),
-            // Issue #5340: Boolean literal vs string/BLOB column raises a
-            // type-mismatch error in the evaluator; decline (no error
-            // channel in the columnar path).
+            // Issues #5340/#5803: Boolean literal vs string/BLOB column —
+            // the evaluator normalizes Boolean to Integer 0/1 and applies
+            // strict storage-class ordering (no string parsing), while the
+            // columnar numeric-vs-string arm coerces parseable strings to
+            // numbers; decline so the evaluator's semantics win.
             SqlValue::Boolean(_) => !is_string_type(other) && !is_blob_type(other),
             // Everything else (including string/numeric literals against
             // BLOB columns, which compare_values orders via the #5340

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
@@ -284,8 +284,7 @@ impl SelectExecutor<'_> {
                 // `get_expression_collation`. (Column-declared collations on
                 // raw source columns referenced inside the ORDER BY would not
                 // be visible here, but those are unaffected by this fix.)
-                let order_collation =
-                    result_evaluator.get_expression_collation(&order_item.expr);
+                let order_collation = result_evaluator.get_expression_collation(&order_item.expr);
 
                 // Resolve ORDER BY expression to result schema column names
                 // For aggregates, we need ColumnRef expressions to look up computed values
@@ -318,8 +317,9 @@ impl SelectExecutor<'_> {
 
         // Sort using the sort keys with NULLS FIRST/LAST handling
         rows_with_keys.sort_by(|(_, keys_a), (_, keys_b)| {
-            use crate::select::grouping::compare_sql_values_with_collation;
             use vibesql_types::SqlValue;
+
+            use crate::select::grouping::compare_sql_values_with_collation;
 
             for ((val_a, dir, nulls_order, collation), (val_b, _, _, _)) in
                 keys_a.iter().zip(keys_b.iter())
@@ -331,7 +331,8 @@ impl SelectExecutor<'_> {
                     if a_is_null && b_is_null {
                         continue; // Both null, consider equal for this key
                     }
-                    // Determine if nulls should sort first or last based on NULLS order and direction
+                    // Determine if nulls should sort first or last based on NULLS order and
+                    // direction
                     let nulls_first = match nulls_order {
                         Some(vibesql_ast::NullsOrder::First) => true,
                         Some(vibesql_ast::NullsOrder::Last) => false,
@@ -697,30 +698,18 @@ impl SelectExecutor<'_> {
     }
 
     /// Check if a SQL value is truthy (for HAVING clause evaluation)
+    ///
+    /// Delegates to the shared SQLite truthiness helper
+    /// (`crate::evaluator::operators::is_truthy`) so HAVING accepts any
+    /// expression like SQLite does — strings and blobs coerce via the
+    /// leading-numeric parse (`HAVING 'first'` → falsy, `HAVING '1'` →
+    /// truthy, `HAVING X'31'` → truthy, `HAVING zeroblob(3)` → falsy)
+    /// instead of erroring. This also unifies the row-based HAVING path
+    /// with the columnar one (columnar_execution/having.rs). (#5803)
     pub(in crate::select::executor) fn is_truthy(
         &self,
         value: &vibesql_types::SqlValue,
     ) -> Result<bool, ExecutorError> {
-        match value {
-            vibesql_types::SqlValue::Boolean(true) => Ok(true),
-            vibesql_types::SqlValue::Boolean(false) | vibesql_types::SqlValue::Null => Ok(false),
-            // SQLLogicTest compatibility: treat integers as truthy/falsy (C-like behavior)
-            vibesql_types::SqlValue::Integer(0) => Ok(false),
-            vibesql_types::SqlValue::Integer(_) => Ok(true),
-            vibesql_types::SqlValue::Smallint(0) => Ok(false),
-            vibesql_types::SqlValue::Smallint(_) => Ok(true),
-            vibesql_types::SqlValue::Bigint(0) => Ok(false),
-            vibesql_types::SqlValue::Bigint(_) => Ok(true),
-            vibesql_types::SqlValue::Float(0.0) => Ok(false),
-            vibesql_types::SqlValue::Float(_) => Ok(true),
-            vibesql_types::SqlValue::Real(0.0) => Ok(false),
-            vibesql_types::SqlValue::Real(_) => Ok(true),
-            vibesql_types::SqlValue::Double(0.0) => Ok(false),
-            vibesql_types::SqlValue::Double(_) => Ok(true),
-            other => Err(ExecutorError::InvalidWhereClause(format!(
-                "HAVING must evaluate to boolean, got: {:?}",
-                other
-            ))),
-        }
+        Ok(crate::evaluator::operators::is_truthy(value))
     }
 }

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/simple.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/simple.rs
@@ -224,6 +224,10 @@ pub(super) fn evaluate(
                 vibesql_types::SqlValue::Boolean(b) => {
                     arcstr::ArcStr::from(if b { "1" } else { "0" })
                 }
+                // SQLite treats blob bytes as raw text for the LIKE pattern too
+                vibesql_types::SqlValue::Blob(ref b) => {
+                    arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned())
+                }
                 _ => {
                     return Err(ExecutorError::TypeMismatch {
                         left: test_val,

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/simple.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/simple.rs
@@ -182,10 +182,26 @@ pub(super) fn evaluate(
                 executor.evaluate_with_aggregates(pattern, group_rows, group_key, evaluator)?;
 
             // Extract string values
+            // Extract string values, mirroring the coercion rules of the
+            // scalar evaluators (evaluator/expressions/predicates.rs):
+            // numerics render as text, booleans as 0/1, blob bytes as text.
             let text = match test_val {
                 vibesql_types::SqlValue::Varchar(ref s)
                 | vibesql_types::SqlValue::Character(ref s) => s.clone(),
                 vibesql_types::SqlValue::Null => return Ok(vibesql_types::SqlValue::Null),
+                vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
+                vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+                vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
+                vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
+                vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+                // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
+                vibesql_types::SqlValue::Boolean(b) => {
+                    arcstr::ArcStr::from(if b { "1" } else { "0" })
+                }
+                // SQLite treats blob bytes as raw text for LIKE comparison
+                vibesql_types::SqlValue::Blob(ref b) => {
+                    arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned())
+                }
                 _ => {
                     return Err(ExecutorError::TypeMismatch {
                         left: test_val,
@@ -199,6 +215,15 @@ pub(super) fn evaluate(
                 vibesql_types::SqlValue::Varchar(ref s)
                 | vibesql_types::SqlValue::Character(ref s) => s.clone(),
                 vibesql_types::SqlValue::Null => return Ok(vibesql_types::SqlValue::Null),
+                vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
+                vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+                vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
+                vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
+                vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+                // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
+                vibesql_types::SqlValue::Boolean(b) => {
+                    arcstr::ArcStr::from(if b { "1" } else { "0" })
+                }
                 _ => {
                     return Err(ExecutorError::TypeMismatch {
                         left: test_val,

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/having.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/having.rs
@@ -481,12 +481,11 @@ fn expressions_equal(a: &Expression, b: &Expression) -> bool {
 }
 
 /// Check if a SqlValue is truthy (evaluates to true in boolean context)
+///
+/// Delegates to the shared SQLite truthiness helper so the columnar HAVING
+/// path agrees with the row-based one: strings/blobs coerce via the
+/// leading-numeric parse (`'first'` → falsy, `'1'`/`X'31'` → truthy)
+/// rather than "any non-NULL value is truthy". (#5803)
 fn is_truthy(value: &SqlValue) -> Result<bool, ExecutorError> {
-    match value {
-        SqlValue::Boolean(b) => Ok(*b),
-        SqlValue::Integer(i) => Ok(*i != 0),
-        SqlValue::Float(f) => Ok(*f != 0.0),
-        SqlValue::Null => Ok(false),
-        _ => Ok(true), // Non-empty strings, etc. are truthy
-    }
+    Ok(crate::evaluator::operators::is_truthy(value))
 }

--- a/crates/vibesql-executor/src/select/executor/utils.rs
+++ b/crates/vibesql-executor/src/select/executor/utils.rs
@@ -233,6 +233,9 @@ impl SelectExecutor<'_> {
                     Ok(n as usize)
                 }
             }
+            // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
+            // e.g. SELECT 1 LIMIT EXISTS(SELECT 1) returns one row
+            vibesql_types::SqlValue::Boolean(b) => Ok(usize::from(b)),
             vibesql_types::SqlValue::Null => {
                 Err(crate::errors::ExecutorError::InvalidLimitOffset {
                     clause: clause_name.to_string(),

--- a/crates/vibesql-executor/src/select/executor/utils.rs
+++ b/crates/vibesql-executor/src/select/executor/utils.rs
@@ -217,37 +217,22 @@ impl SelectExecutor<'_> {
         // Evaluate the expression
         let value = evaluator.eval(expr, &empty_row)?;
 
-        // Convert to integer
+        // Convert to integer using the shared SQLite LIMIT/OFFSET affinity
+        // rules (integers, booleans as 0/1, integral reals, full-string
+        // numeric text — see select::helpers::coerce_limit_offset_to_i64).
+        let n = crate::select::helpers::coerce_limit_offset_to_i64(value, clause_name)?;
+
         // SQLite compatibility: negative values have special meanings
-        match value {
-            vibesql_types::SqlValue::Integer(n) => {
-                if n < 0 {
-                    if clause_name == "OFFSET" {
-                        // Negative offset is treated as 0
-                        Ok(0)
-                    } else {
-                        // Negative limit means unlimited - return MAX
-                        Ok(usize::MAX)
-                    }
-                } else {
-                    Ok(n as usize)
-                }
+        if n < 0 {
+            if clause_name == "OFFSET" {
+                // Negative offset is treated as 0
+                Ok(0)
+            } else {
+                // Negative limit means unlimited - return MAX
+                Ok(usize::MAX)
             }
-            // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
-            // e.g. SELECT 1 LIMIT EXISTS(SELECT 1) returns one row
-            vibesql_types::SqlValue::Boolean(b) => Ok(usize::from(b)),
-            vibesql_types::SqlValue::Null => {
-                Err(crate::errors::ExecutorError::InvalidLimitOffset {
-                    clause: clause_name.to_string(),
-                    value: "NULL".to_string(),
-                    reason: "must be an integer".to_string(),
-                })
-            }
-            other => Err(crate::errors::ExecutorError::InvalidLimitOffset {
-                clause: clause_name.to_string(),
-                value: format!("{:?}", other),
-                reason: "must be an integer".to_string(),
-            }),
+        } else {
+            Ok(n as usize)
         }
     }
 }

--- a/crates/vibesql-executor/src/select/helpers.rs
+++ b/crates/vibesql-executor/src/select/helpers.rs
@@ -124,22 +124,69 @@ fn evaluate_limit_offset_expr_raw(
     // Evaluate the expression
     let value = evaluator.eval(expr, &empty_row)?;
 
-    // Convert to integer
-    match value {
-        vibesql_types::SqlValue::Integer(n) => Ok(n),
+    // Convert to integer using SQLite's LIMIT/OFFSET affinity rules
+    coerce_limit_offset_to_i64(value, clause_name)
+}
+
+/// Coerce an evaluated LIMIT/OFFSET value to i64 using SQLite semantics.
+///
+/// Shared by both LIMIT/OFFSET evaluation sites (this module and
+/// `select::executor::utils::eval_limit_offset_expr`). SQLite applies
+/// numeric affinity to LIMIT/OFFSET expressions:
+///
+/// - INTEGER values are used as-is
+/// - BOOLEAN → 0/1 (EXISTS/IN results behave as integers; #5803)
+/// - REAL values are accepted iff exactly integral: `LIMIT 2.0` → 2, `LIMIT 56.1` errors
+/// - TEXT is accepted iff the *whole* string (after trimming whitespace) is a numeric literal
+///   representing an integral value: `'2'`, `' 2 '`, `'+2'`, `'2.0'` are accepted; `'The'`,
+///   `'2abc'`, `'2.5'` error. Note this is deliberately NOT the leading-prefix parse used for
+///   truthiness — SQLite raises "datatype mismatch" for partial parses here
+/// - NULL, BLOB and everything else keep erroring (SQLite's "datatype mismatch" wording is tracked
+///   separately in #5804)
+pub(in crate::select) fn coerce_limit_offset_to_i64(
+    value: vibesql_types::SqlValue,
+    clause_name: &str,
+) -> Result<i64, crate::ExecutorError> {
+    use vibesql_types::SqlValue;
+
+    fn integral_f64(f: f64) -> Option<i64> {
+        if f.is_finite() && f.fract() == 0.0 && f >= i64::MIN as f64 && f <= i64::MAX as f64 {
+            Some(f as i64)
+        } else {
+            None
+        }
+    }
+
+    let err = |shown: String| crate::ExecutorError::InvalidLimitOffset {
+        clause: clause_name.to_string(),
+        value: shown,
+        reason: "must be an integer".to_string(),
+    };
+
+    match &value {
+        SqlValue::Integer(n) => Ok(*n),
+        SqlValue::Smallint(n) => Ok(*n as i64),
+        SqlValue::Bigint(n) => Ok(*n),
+        SqlValue::Unsigned(n) => i64::try_from(*n).map_err(|_| err(format!("{:?}", value))),
         // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
         // e.g. SELECT 1 LIMIT EXISTS(SELECT 1) returns one row
-        vibesql_types::SqlValue::Boolean(b) => Ok(i64::from(b)),
-        vibesql_types::SqlValue::Null => Err(crate::ExecutorError::InvalidLimitOffset {
-            clause: clause_name.to_string(),
-            value: "NULL".to_string(),
-            reason: "must be an integer".to_string(),
-        }),
-        other => Err(crate::ExecutorError::InvalidLimitOffset {
-            clause: clause_name.to_string(),
-            value: format!("{:?}", other),
-            reason: "must be an integer".to_string(),
-        }),
+        SqlValue::Boolean(b) => Ok(i64::from(*b)),
+        SqlValue::Float(f) => integral_f64(*f as f64).ok_or_else(|| err(format!("{:?}", value))),
+        SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f) => {
+            integral_f64(*f).ok_or_else(|| err(format!("{:?}", value)))
+        }
+        SqlValue::Varchar(s) | SqlValue::Character(s) => {
+            let trimmed = s.trim();
+            if let Ok(n) = trimmed.parse::<i64>() {
+                Ok(n)
+            } else if let Ok(f) = trimmed.parse::<f64>() {
+                integral_f64(f).ok_or_else(|| err(format!("{:?}", value)))
+            } else {
+                Err(err(format!("{:?}", value)))
+            }
+        }
+        SqlValue::Null => Err(err("NULL".to_string())),
+        _ => Err(err(format!("{:?}", value))),
     }
 }
 
@@ -228,5 +275,70 @@ where
     match limit {
         Some(n) => iter.take(n).collect(),
         None => iter.collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vibesql_types::SqlValue;
+
+    use super::coerce_limit_offset_to_i64;
+
+    fn coerce(value: SqlValue) -> Result<i64, crate::ExecutorError> {
+        coerce_limit_offset_to_i64(value, "LIMIT")
+    }
+
+    fn text(s: &str) -> SqlValue {
+        SqlValue::Varchar(arcstr::ArcStr::from(s))
+    }
+
+    // Issue #5803 item 4: SQLite LIMIT/OFFSET numeric-affinity coercion.
+
+    #[test]
+    fn integers_and_booleans_accepted() {
+        assert_eq!(coerce(SqlValue::Integer(2)).unwrap(), 2);
+        assert_eq!(coerce(SqlValue::Integer(-1)).unwrap(), -1);
+        assert_eq!(coerce(SqlValue::Boolean(true)).unwrap(), 1);
+        assert_eq!(coerce(SqlValue::Boolean(false)).unwrap(), 0);
+        assert_eq!(coerce(SqlValue::Smallint(3)).unwrap(), 3);
+        assert_eq!(coerce(SqlValue::Bigint(4)).unwrap(), 4);
+    }
+
+    #[test]
+    fn integral_reals_accepted_fractional_rejected() {
+        assert_eq!(coerce(SqlValue::Double(2.0)).unwrap(), 2);
+        assert_eq!(coerce(SqlValue::Real(0.0)).unwrap(), 0);
+        assert!(coerce(SqlValue::Double(56.1)).is_err());
+        assert!(coerce(SqlValue::Real(2.5)).is_err());
+        assert!(coerce(SqlValue::Double(f64::NAN)).is_err());
+        assert!(coerce(SqlValue::Double(f64::INFINITY)).is_err());
+    }
+
+    #[test]
+    fn numeric_strings_accepted_full_string_parse() {
+        assert_eq!(coerce(text("2")).unwrap(), 2);
+        assert_eq!(coerce(text("2.0")).unwrap(), 2);
+        assert_eq!(coerce(text(" 2 ")).unwrap(), 2);
+        assert_eq!(coerce(text("+2")).unwrap(), 2);
+        assert_eq!(coerce(text("-3")).unwrap(), -3);
+    }
+
+    #[test]
+    fn non_numeric_and_partial_strings_rejected() {
+        // Full-string affinity parse, NOT the leading-prefix truthiness parse:
+        // SQLite raises "datatype mismatch" for these.
+        assert!(coerce(text("The")).is_err());
+        assert!(coerce(text("2abc")).is_err());
+        assert!(coerce(text("2.5")).is_err());
+        assert!(coerce(text("")).is_err());
+        assert!(coerce(text("inf")).is_err());
+        assert!(coerce(text("nan")).is_err());
+    }
+
+    #[test]
+    fn null_and_blob_rejected() {
+        assert!(coerce(SqlValue::Null).is_err());
+        // LIMIT X'32' keeps erroring (SQLite: datatype mismatch)
+        assert!(coerce(SqlValue::Blob(b"2".to_vec())).is_err());
     }
 }

--- a/crates/vibesql-executor/src/select/helpers.rs
+++ b/crates/vibesql-executor/src/select/helpers.rs
@@ -127,6 +127,9 @@ fn evaluate_limit_offset_expr_raw(
     // Convert to integer
     match value {
         vibesql_types::SqlValue::Integer(n) => Ok(n),
+        // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
+        // e.g. SELECT 1 LIMIT EXISTS(SELECT 1) returns one row
+        vibesql_types::SqlValue::Boolean(b) => Ok(i64::from(b)),
         vibesql_types::SqlValue::Null => Err(crate::ExecutorError::InvalidLimitOffset {
             clause: clause_name.to_string(),
             value: "NULL".to_string(),

--- a/crates/vibesql-executor/tests/columnar_filter_type_pairs_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_filter_type_pairs_tests.rs
@@ -209,8 +209,13 @@ fn null_blobs_excluded_from_all_predicates() {
 }
 
 // ---------------------------------------------------------------------------
-// Issue #5340: Boolean column vs string literal raises the evaluator's
-// type-mismatch error (pushdown declined; no columnar error channel)
+// Boolean column vs string literal: since issue #5803 the evaluator
+// normalizes Boolean to Integer 0/1 and applies SQLite storage-class
+// ordering (numeric < TEXT), so these predicates order instead of raising a
+// type-mismatch error. Pushdown remains declined for the pair (the columnar
+// numeric-vs-string arm coerces parseable strings to numbers, which would
+// diverge from the evaluator's strict type ordering), so the full-scan WHERE
+// path must agree with the evaluator via the projection cross-check.
 // ---------------------------------------------------------------------------
 
 fn boolean_db(rows: usize) -> Database {
@@ -233,20 +238,23 @@ fn boolean_db(rows: usize) -> Database {
 }
 
 #[test]
-fn boolean_column_vs_string_raises_type_mismatch() {
+fn boolean_column_vs_string_orders_by_storage_class() {
     for rows in [2usize, 600] {
         let db = boolean_db(rows);
-        // The expression evaluator raises a type-mismatch error for Boolean
-        // vs string; the full-scan WHERE path must match instead of silently
-        // excluding every row.
-        for pred in ["flag = 'true'", "flag != 'x'", "flag < 'zzz'"] {
-            let result = select_ints(&db, &format!("SELECT id FROM tf WHERE {pred}"));
-            assert!(
-                result.is_err(),
-                "Boolean vs string must raise the evaluator's type-mismatch error \
-                 ({rows} rows) for {pred}, got: {result:?}"
-            );
-        }
+        // Issue #5803: Boolean normalizes to Integer 0/1, then SQLite type
+        // ordering applies (numeric < TEXT). Verified against sqlite3 with a
+        // NUMERIC-affinity column holding 0/1:
+        //   flag = 'true'  -> 0 rows  (integer never equals text)
+        //   flag != 'x'    -> all rows
+        //   flag < 'zzz'   -> all rows (numeric < text)
+        let ids = assert_where_matches_projection(&db, "tf", "flag = 'true'");
+        assert!(ids.is_empty(), "flag = 'true' must match no rows ({rows} rows), got {ids:?}");
+
+        let ids = assert_where_matches_projection(&db, "tf", "flag != 'x'");
+        assert_eq!(ids.len(), rows, "flag != 'x' must match all rows ({rows} rows)");
+
+        let ids = assert_where_matches_projection(&db, "tf", "flag < 'zzz'");
+        assert_eq!(ids.len(), rows, "flag < 'zzz' must match all rows ({rows} rows)");
     }
 }
 
@@ -277,10 +285,7 @@ fn boolean_column_supported_pairs_still_filter() {
 /// `f` = v as a float, so TRUE/FALSE literals partition the rows in half.
 fn numeric_db(rows: usize) -> Database {
     let mut db = Database::new();
-    execute_sql(
-        &mut db,
-        "CREATE TABLE ti (id INTEGER PRIMARY KEY, v INTEGER, f DOUBLE PRECISION)",
-    );
+    execute_sql(&mut db, "CREATE TABLE ti (id INTEGER PRIMARY KEY, v INTEGER, f DOUBLE PRECISION)");
     let mut inserts = String::new();
     for id in 1..=rows {
         let v = id % 2;


### PR DESCRIPTION
Closes #5803

## Summary

Implements all five semantic groups from #5803 plus the PR #5811 scope addition (Boolean IN-subquery leakage), following the curator's consumer-side-coercion root-cause map. Two commits along the curator's recommended seam:

### Commit 1 — Boolean leakage (item 1 + #5811 scope add)

- **`compare()`** (`evaluator/operators/comparison/mod.rs`): normalize a `Boolean` operand to `Integer 0/1` whenever the other side is non-Boolean, then re-dispatch through the existing cross-type logic (numeric coercion, SQLite type ordering numeric < text < blob). Replaces the previous Boolean-vs-numeric-only block; covers all six comparison operators in both operand orders.
- **LIKE/GLOB Boolean operands**: `Boolean` -> `"1"`/`"0"` arms in all three evaluators (`expressions/predicates.rs`, `combined/predicates.rs`, `aggregation/evaluation/simple.rs`).
- **LIMIT/OFFSET**: accept `Boolean` as 0/1 in both evaluation sites.
- **Columnar filter**: Boolean-column-vs-string pushdown stays declined (the columnar numeric-vs-string arm parses strings to numbers, which would diverge from the evaluator's strict storage-class ordering); test updated to assert the new ordering semantics cross-checked against the projection path.

### Commit 2 — coercion/truthiness (items 2–5)

- **Unary `~`/`NOT` on text/blob** (`eval_unary_op`, the single shared fix point): `(BitwiseNot, text|blob)` arms via the existing `string_to_number` leading-prefix parse (fraction truncates toward zero); `(Not, Blob)` via utf8-lossy + `is_truthy_string`. `to_i64` deliberately untouched.
- **LIKE/GLOB blob pattern arm**: pattern side now coerces `Blob` via utf8-lossy in all three evaluators (text side already did).
- **LIMIT/OFFSET numeric affinity**: new shared helper `coerce_limit_offset_to_i64` (`select/helpers.rs`, also used by `select/executor/utils.rs`): integral reals accepted (`2.0` -> 2, `56.1` errors); text accepted iff the whole trimmed string parses to an integral numeric (`'2'`, `'2.0'`, `' 2 '`, `'+2'` OK; `'The'`, `'2abc'`, `'2.5'` error — full-string affinity parse, not the truthiness prefix parse); NULL/Blob keep erroring. Error **wording** (`datatype mismatch`) is #5804's scope.
- **HAVING truthiness**: bespoke restrictive copy in `aggregation/evaluation/mod.rs` (errored on text/blob, missed Unsigned/Numeric) now delegates to the shared `evaluator::operators::is_truthy`; shared helper gains a `Blob` arm (utf8-lossy + leading-numeric parse); columnar HAVING copy (`columnar_execution/having.rs`) delegates too, unifying the row and columnar paths.

## Verification

Every reproducer from the issue + curator verification matrix run via CLI and checked against real `sqlite3` output (33/33 checks after excluding the pre-existing note below):

| Group | Checks |
|---|---|
| Boolean leakage | `EXISTS(SELECT 1) == 'experiments'` -> 0, `EXISTS(SELECT 1) < 'a'` -> 1, `SELECT 1 LIMIT EXISTS(SELECT 1)` -> 1 row, `1 NOT IN (2) LIKE 1` -> 1, `1 IN (1) GLOB '1'` -> 1 |
| Unary | `~'fault'` -> -1, `~'12abc'` -> -13, `~3.7` -> -4, `~X'313233'` -> -124, `NOT zeroblob(10)` -> 1, `NOT 'true'` -> 1, `NOT '1'` -> 0 |
| Blob pattern | `'abc' LIKE X'ABCD'` -> 0, `'abc' GLOB X'ABCD'` -> 0 |
| LIMIT/OFFSET | `'2'`/`2.0`/`'2.0'`/`' 2 '`/`'+2'` accepted; `'The'`/`'2abc'`/`56.1`/`X'32'`/`OFFSET 'The'` still error; `OFFSET '1'` works |
| HAVING | `'first'` -> 0 rows, `'1'` -> rows, `X'31'` -> rows, `zeroblob(3)` -> 0 rows |
| Regression guards | `1 IN (SELECT 1) == 2` -> 0, `1 == 'experiments'` -> 0, `1 LIKE 1` -> 1, WHERE truthiness unchanged vs main |

- `cargo test -p vibesql-executor`: lib suite **3075 passed / 0 failed**; integration suites green (50+ suites completed locally with 0 failures at PR time on a heavily loaded shared machine; the only behavior-affected integration suite, `columnar_filter_type_pairs_tests`, passes with updated expectations). CI runs the full suite.
- TCL regression: `in.test` 114/114, `in4.test` 61/61, `where.test` 168/168, `select1.test` 188/188 — all pass, 0 failures.
- New unit tests: comparison Boolean-vs-text/blob (all six ops, both orders), unary `~`/NOT text/blob, LIMIT/OFFSET coercion helper (accept/reject matrix).

## Pre-existing issues found (not introduced here, out of scope)

1. `evaluator::tests::deep_expression_tests::test_deep_case_expressions` stack-overflows deterministically on unmodified main (91bb7c21a) in local debug runs — verified by checking out main in the same worktree. Full-suite runs here used `--skip` for that single test.
2. `SELECT x FROM t WHERE 'first'` errors ("Filter expression must evaluate to boolean") and `SELECT 1 WHERE 'first'` returns 1 row (SQLite: 0 rows) — identical behavior on the pre-change baseline binary; WHERE-clause string truthiness is a separate gap from #5803's HAVING item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
