### PR TITLE
fix(parser): BETWEEN/LIKE/GLOB operands parse at the shift tier (tier asymmetry vs negated forms)

### DIFF
--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -587,9 +587,12 @@ impl Parser {
                 };
 
                 // Parse low AND high
-                let low = self.parse_additive_expression()?;
+                // Bounds parse at the shift tier (same as NOT BETWEEN): everything
+                // tighter than the comparison tier is allowed; only the boolean AND
+                // separating low/high must not be consumed.
+                let low = self.parse_shift_expression()?;
                 self.consume_keyword(Keyword::And)?;
-                let high = self.parse_additive_expression()?;
+                let high = self.parse_shift_expression()?;
 
                 left = vibesql_ast::Expression::Between {
                     expr: Box::new(left),
@@ -603,13 +606,13 @@ impl Parser {
                 // It's LIKE (not negated)
                 self.consume_keyword(Keyword::Like)?;
 
-                // Parse pattern expression
-                let pattern = self.parse_additive_expression()?;
+                // Parse pattern expression at the shift tier (same as NOT LIKE)
+                let pattern = self.parse_shift_expression()?;
 
                 // Check for optional ESCAPE clause
                 let escape = if self.peek_keyword(Keyword::Escape) {
                     self.consume_keyword(Keyword::Escape)?;
-                    Some(Box::new(self.parse_additive_expression()?))
+                    Some(Box::new(self.parse_shift_expression()?))
                 } else {
                     None
                 };
@@ -625,13 +628,13 @@ impl Parser {
                 // It's GLOB (SQLite) (not negated)
                 self.consume_keyword(Keyword::Glob)?;
 
-                // Parse pattern expression
-                let pattern = self.parse_additive_expression()?;
+                // Parse pattern expression at the shift tier (same as NOT GLOB)
+                let pattern = self.parse_shift_expression()?;
 
                 // Check for optional ESCAPE clause
                 let escape = if self.peek_keyword(Keyword::Escape) {
                     self.consume_keyword(Keyword::Escape)?;
-                    Some(Box::new(self.parse_additive_expression()?))
+                    Some(Box::new(self.parse_shift_expression()?))
                 } else {
                     None
                 };

--- a/crates/vibesql-parser/src/tests/arena_parser.rs
+++ b/crates/vibesql-parser/src/tests/arena_parser.rs
@@ -532,3 +532,89 @@ fn test_arena_not_in_chained_not_in() {
         ));
     });
 }
+
+// ============================================================================
+// BETWEEN/LIKE bounds with shift operators (issue #5813)
+//
+// The arena parser has no shift tier, so expressions with << / >> in BETWEEN
+// bounds or LIKE patterns must FAIL arena parsing (never silently truncate),
+// and parse_with_arena_fallback must route them to the standard parser,
+// which (post-#5813) accepts shift-tier operands in both the negated and
+// non-negated forms.
+// ============================================================================
+
+#[test]
+fn test_arena_between_shift_bound_fails_no_silent_truncation() {
+    // Must be a hard arena-parse error, NOT a successful parse of the
+    // truncated prefix "SELECT 1 BETWEEN 0 AND 1".
+    let arena = Bump::new();
+    let result = ArenaParser::parse_select_with_interner("SELECT 1 BETWEEN 0 AND 1<<2", &arena);
+    assert!(
+        result.is_err(),
+        "arena parser has no shift tier; BETWEEN with << bound must fail arena parse, got: {:?}",
+        result.map(|(stmt, _)| format!("{:?}", stmt.select_list[0]))
+    );
+}
+
+#[test]
+fn test_arena_like_shift_pattern_fails_no_silent_truncation() {
+    let arena = Bump::new();
+    let result = ArenaParser::parse_select_with_interner("SELECT 2 LIKE 1<<1", &arena);
+    assert!(
+        result.is_err(),
+        "arena parser has no shift tier; LIKE with << pattern must fail arena parse, got: {:?}",
+        result.map(|(stmt, _)| format!("{:?}", stmt.select_list[0]))
+    );
+}
+
+#[test]
+fn test_arena_fallback_between_shift_bound() {
+    // sqlite3: SELECT 1 BETWEEN 0 AND 1<<2; -- 1
+    // End-to-end through the arena-with-fallback entry point: arena parse
+    // fails, standard parser (fixed by #5813) produces the Between node.
+    let stmt = crate::parse_with_arena_fallback("SELECT 1 BETWEEN 0 AND 1<<2;")
+        .expect("fallback path should parse BETWEEN with shift bound");
+    let vibesql_ast::Statement::Select(select) = stmt else {
+        panic!("expected SELECT statement");
+    };
+    let vibesql_ast::SelectItem::Expression { expr, .. } = &select.select_list[0] else {
+        panic!("expected expression select item");
+    };
+    let vibesql_ast::Expression::Between { high, negated, .. } = expr else {
+        panic!("expected Between expression, got {:?}", expr);
+    };
+    assert!(!negated);
+    assert!(
+        matches!(
+            **high,
+            vibesql_ast::Expression::BinaryOp { op: vibesql_ast::BinaryOperator::LeftShift, .. }
+        ),
+        "high bound should be 1<<2, got {:?}",
+        high
+    );
+}
+
+#[test]
+fn test_arena_fallback_like_shift_pattern() {
+    // sqlite3: SELECT 2 LIKE 1<<1; -- 1
+    let stmt = crate::parse_with_arena_fallback("SELECT 2 LIKE 1<<1;")
+        .expect("fallback path should parse LIKE with shift pattern");
+    let vibesql_ast::Statement::Select(select) = stmt else {
+        panic!("expected SELECT statement");
+    };
+    let vibesql_ast::SelectItem::Expression { expr, .. } = &select.select_list[0] else {
+        panic!("expected expression select item");
+    };
+    let vibesql_ast::Expression::Like { pattern, negated, .. } = expr else {
+        panic!("expected Like expression, got {:?}", expr);
+    };
+    assert!(!negated);
+    assert!(
+        matches!(
+            **pattern,
+            vibesql_ast::Expression::BinaryOp { op: vibesql_ast::BinaryOperator::LeftShift, .. }
+        ),
+        "pattern should be 1<<1, got {:?}",
+        pattern
+    );
+}

--- a/crates/vibesql-parser/src/tests/predicates.rs
+++ b/crates/vibesql-parser/src/tests/predicates.rs
@@ -326,3 +326,255 @@ fn test_not_between_asymmetric() {
         panic!("Expected SELECT statement");
     }
 }
+
+// ============================================================================
+// BETWEEN/LIKE/GLOB operands parse at the shift tier (issue #5813)
+//
+// Per SQLite, everything tighter than the comparison tier is allowed in
+// BETWEEN bounds and LIKE/GLOB patterns; only the boolean AND separating
+// BETWEEN's low/high must not be consumed. The negated forms (NOT BETWEEN,
+// NOT LIKE, NOT GLOB) already parsed at the shift tier, so the non-negated
+// forms must match. All expected results below were verified against sqlite3.
+// ============================================================================
+
+/// Parse a `SELECT <expr>;` statement and return the first select-list expression.
+fn parse_select_expr(sql: &str) -> vibesql_ast::Expression {
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("should parse: {}: {:?}", sql, e));
+    if let vibesql_ast::Statement::Select(select) = stmt {
+        if let vibesql_ast::SelectItem::Expression { expr, .. } = &select.select_list[0] {
+            return expr.clone();
+        }
+    }
+    panic!("expected SELECT with expression select list: {}", sql);
+}
+
+fn assert_left_shift(expr: &vibesql_ast::Expression, context: &str) {
+    assert!(
+        matches!(
+            expr,
+            vibesql_ast::Expression::BinaryOp { op: vibesql_ast::BinaryOperator::LeftShift, .. }
+        ),
+        "{} should be a << BinaryOp, got {:?}",
+        context,
+        expr
+    );
+}
+
+#[test]
+fn test_between_shift_in_high_bound() {
+    // sqlite3: SELECT 1 BETWEEN 0 AND 1<<2; -- 1  (high bound is 1<<2 = 4)
+    let expr = parse_select_expr("SELECT 1 BETWEEN 0 AND 1<<2;");
+    match expr {
+        vibesql_ast::Expression::Between { low, high, negated, .. } => {
+            assert!(!negated);
+            assert!(matches!(
+                *low,
+                vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(0))
+            ));
+            assert_left_shift(&high, "BETWEEN high bound");
+        }
+        other => panic!("expected Between expression, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_between_shift_in_low_bound() {
+    // sqlite3: SELECT 8 BETWEEN 1<<1 AND 10; -- 1  (low bound is 1<<1 = 2)
+    let expr = parse_select_expr("SELECT 8 BETWEEN 1<<1 AND 10;");
+    match expr {
+        vibesql_ast::Expression::Between { low, high, negated, .. } => {
+            assert!(!negated);
+            assert_left_shift(&low, "BETWEEN low bound");
+            assert!(matches!(
+                *high,
+                vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(10))
+            ));
+        }
+        other => panic!("expected Between expression, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_between_right_shift_in_low_bound() {
+    // sqlite3: SELECT 5 BETWEEN 16>>2 AND 6; -- 1  (low bound is 16>>2 = 4)
+    let expr = parse_select_expr("SELECT 5 BETWEEN 16>>2 AND 6;");
+    match expr {
+        vibesql_ast::Expression::Between { low, negated, .. } => {
+            assert!(!negated);
+            assert!(
+                matches!(
+                    *low,
+                    vibesql_ast::Expression::BinaryOp {
+                        op: vibesql_ast::BinaryOperator::RightShift,
+                        ..
+                    }
+                ),
+                "BETWEEN low bound should be a >> BinaryOp, got {:?}",
+                low
+            );
+        }
+        other => panic!("expected Between expression, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_like_shift_pattern() {
+    // sqlite3: SELECT 2 LIKE 1<<1; -- 1  (pattern is 1<<1 = 2)
+    let expr = parse_select_expr("SELECT 2 LIKE 1<<1;");
+    match expr {
+        vibesql_ast::Expression::Like { pattern, negated, escape, .. } => {
+            assert!(!negated);
+            assert!(escape.is_none());
+            assert_left_shift(&pattern, "LIKE pattern");
+        }
+        other => panic!("expected Like expression, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_like_escape_shift_parses() {
+    // Parse-level only: sqlite3 accepts this syntactically (it fails later at
+    // runtime with "ESCAPE expression must be a single character").
+    let expr = parse_select_expr("SELECT 'a' LIKE 'b' ESCAPE 1<<1;");
+    match expr {
+        vibesql_ast::Expression::Like { escape, negated, .. } => {
+            assert!(!negated);
+            let escape = escape.expect("ESCAPE clause should be present");
+            assert_left_shift(&escape, "LIKE ESCAPE expression");
+        }
+        other => panic!("expected Like expression, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_glob_shift_pattern() {
+    // sqlite3: SELECT 2 GLOB 1<<1; -- 1  (pattern is 1<<1 = 2)
+    let expr = parse_select_expr("SELECT 2 GLOB 1<<1;");
+    match expr {
+        vibesql_ast::Expression::Glob { pattern, negated, escape, .. } => {
+            assert!(!negated);
+            assert!(escape.is_none());
+            assert_left_shift(&pattern, "GLOB pattern");
+        }
+        other => panic!("expected Glob expression, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_glob_escape_shift_parses() {
+    // Parse-level only, mirroring the LIKE ESCAPE case.
+    let expr = parse_select_expr("SELECT 'a' GLOB 'b' ESCAPE 1<<1;");
+    match expr {
+        vibesql_ast::Expression::Glob { escape, negated, .. } => {
+            assert!(!negated);
+            let escape = escape.expect("ESCAPE clause should be present");
+            assert_left_shift(&escape, "GLOB ESCAPE expression");
+        }
+        other => panic!("expected Glob expression, got {:?}", other),
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Symmetry: the negated and non-negated forms must produce identically shaped
+// ASTs, differing only in the `negated` flag.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn test_between_negated_symmetry_with_shift_bounds() {
+    // sqlite3: SELECT 1 BETWEEN 0 AND 1<<2;     -- 1
+    // sqlite3: SELECT 1 NOT BETWEEN 0 AND 1<<2; -- 0
+    let plain = parse_select_expr("SELECT 1 BETWEEN 0 AND 1<<2;");
+    let negated = parse_select_expr("SELECT 1 NOT BETWEEN 0 AND 1<<2;");
+    match (plain, negated) {
+        (
+            vibesql_ast::Expression::Between {
+                expr: e1,
+                low: l1,
+                high: h1,
+                negated: n1,
+                symmetric: s1,
+            },
+            vibesql_ast::Expression::Between {
+                expr: e2,
+                low: l2,
+                high: h2,
+                negated: n2,
+                symmetric: s2,
+            },
+        ) => {
+            assert!(!n1);
+            assert!(n2);
+            assert_eq!(e1, e2, "BETWEEN subject must parse identically in both forms");
+            assert_eq!(l1, l2, "BETWEEN low bound must parse identically in both forms");
+            assert_eq!(h1, h2, "BETWEEN high bound must parse identically in both forms");
+            assert_eq!(s1, s2);
+        }
+        other => panic!("expected two Between expressions, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_like_negated_symmetry_with_shift_pattern() {
+    // sqlite3: SELECT 2 LIKE 1<<1;     -- 1
+    // sqlite3: SELECT 2 NOT LIKE 1<<1; -- 0
+    let plain = parse_select_expr("SELECT 2 LIKE 1<<1;");
+    let negated = parse_select_expr("SELECT 2 NOT LIKE 1<<1;");
+    match (plain, negated) {
+        (
+            vibesql_ast::Expression::Like { expr: e1, pattern: p1, negated: n1, escape: esc1 },
+            vibesql_ast::Expression::Like { expr: e2, pattern: p2, negated: n2, escape: esc2 },
+        ) => {
+            assert!(!n1);
+            assert!(n2);
+            assert_eq!(e1, e2, "LIKE subject must parse identically in both forms");
+            assert_eq!(p1, p2, "LIKE pattern must parse identically in both forms");
+            assert_eq!(esc1, esc2);
+        }
+        other => panic!("expected two Like expressions, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_glob_negated_symmetry_with_shift_pattern() {
+    // sqlite3: SELECT 2 GLOB 1<<1;     -- 1
+    // sqlite3: SELECT 2 NOT GLOB 1<<1; -- 0
+    let plain = parse_select_expr("SELECT 2 GLOB 1<<1;");
+    let negated = parse_select_expr("SELECT 2 NOT GLOB 1<<1;");
+    match (plain, negated) {
+        (
+            vibesql_ast::Expression::Glob { expr: e1, pattern: p1, negated: n1, escape: esc1 },
+            vibesql_ast::Expression::Glob { expr: e2, pattern: p2, negated: n2, escape: esc2 },
+        ) => {
+            assert!(!n1);
+            assert!(n2);
+            assert_eq!(e1, e2, "GLOB subject must parse identically in both forms");
+            assert_eq!(p1, p2, "GLOB pattern must parse identically in both forms");
+            assert_eq!(esc1, esc2);
+        }
+        other => panic!("expected two Glob expressions, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_between_shift_bound_does_not_consume_boolean_and() {
+    // The AND separating low/high must still terminate the low bound, and a
+    // following boolean AND must still terminate the whole BETWEEN.
+    // sqlite3: SELECT 1 BETWEEN 0 AND 1<<2 AND 2 BETWEEN 1<<0 AND 3; -- 1
+    let expr = parse_select_expr("SELECT 1 BETWEEN 0 AND 1<<2 AND 2 BETWEEN 1<<0 AND 3;");
+    match expr {
+        vibesql_ast::Expression::BinaryOp { op, left, right } => {
+            assert_eq!(op, vibesql_ast::BinaryOperator::And);
+            assert!(
+                matches!(*left, vibesql_ast::Expression::Between { negated: false, .. }),
+                "left of AND should be a Between, got {:?}",
+                left
+            );
+            assert!(
+                matches!(*right, vibesql_ast::Expression::Between { negated: false, .. }),
+                "right of AND should be a Between, got {:?}",
+                right
+            );
+        }
+        other => panic!("expected boolean AND of two Between expressions, got {:?}", other),
+    }
+}


### PR DESCRIPTION
Closes #5813

## Problem

The standard parser's comparison tier parsed non-negated BETWEEN/LIKE/GLOB operands with `parse_additive_expression` (shift operators rejected) while the negated forms used `parse_shift_expression`:

```sql
SELECT 1 BETWEEN 0 AND 1<<2;      -- before: Parse error: Unexpected operator: <<
SELECT 1 NOT BETWEEN 5 AND 1<<3;  -- parsed fine
```

sqlite3 returns `1` for the first query (`<<` binds tighter than BETWEEN, so the high bound is 4).

## Fix

Minimal, per the curator's analysis on #5812: bump the six call sites in the non-negated BETWEEN/LIKE/GLOB branches of `crates/vibesql-parser/src/parser/expressions/operators.rs` (BETWEEN low/high, LIKE pattern + ESCAPE, GLOB pattern + ESCAPE) from `parse_additive_expression` to `parse_shift_expression`, matching the negated forms and SQLite. No tier restructuring — that is #5812's separately sequenced refactor.

**Arena parser: no change needed.** It has no shift tier, so shift-bearing input fails arena parse and `parse_with_arena_fallback` routes to the fixed standard parser. New tests verify this claim directly (hard arena-parse failure, never silent truncation of `1 BETWEEN 0 AND 1<<2` into `1 BETWEEN 0 AND 1`, plus the successful fallback path).

## Tests

New in `tests/predicates.rs` (all expected values verified against sqlite3):
- Shift operands in BETWEEN low/high bounds (`<<` and `>>`), LIKE/GLOB patterns, LIKE/GLOB ESCAPE expressions
- Symmetry tests asserting negated and non-negated BETWEEN/LIKE/GLOB parse identically shaped ASTs (equal subject/bounds/pattern/escape, differing only in `negated`)
- `SELECT 1 BETWEEN 0 AND 1<<2 AND 2 BETWEEN 1<<0 AND 3` — the separating AND and the boolean AND still terminate correctly

New in `tests/arena_parser.rs`:
- Arena parse of BETWEEN/LIKE with shift operands fails hard (no silent truncation)
- `parse_with_arena_fallback` end-to-end produces the correct Between/Like nodes

## Evidence

- `cargo test -p vibesql-parser`: 1528 passed, 0 failed (+ 8 doc-tests)
- `cargo clippy -p vibesql-parser`: no new warnings (1 pre-existing in `from_clause.rs`, untouched)
- Release-binary spot checks all match sqlite3:
  - `SELECT 1 BETWEEN 0 AND 1<<2;` → 1 (was parse error)
  - `SELECT 8 BETWEEN 1<<1 AND 10;` → 1, `SELECT 5 BETWEEN 16>>2 AND 6;` → 1
  - `SELECT 2 LIKE 1<<1;` → 1, `SELECT 2 GLOB 1<<1;` → 1
  - Negated forms unchanged: `NOT BETWEEN`/`NOT LIKE`/`NOT GLOB` variants → 0/0/0 as in sqlite3
- TCL regressions: `expr.test` 638 passed / 0 failed, `between.test` 12/0, `in4.test` 61/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)