### PR TITLE
fix(storage): never silently present an empty database on unreadable checkpoint/snapshot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,9 @@ mydata.wal              — active write-ahead log
 mydata-checkpoints/     — checkpoint archive directory (checkpoint_*.vchk)
 ```
 
-On open, the CLI recovers from the latest checkpoint and replays WAL entries written after it; on `\save` / clean exit it writes a fresh checkpoint and truncates the WAL. Recovery restores both table schemas (DDL) and committed row data (DML inserts, updates, deletes); uncommitted transactions at crash time are discarded, and a truncated WAL tail recovers up to the last complete, checksum-valid entry.
+On open, the CLI recovers from the latest checkpoint and replays WAL entries written after it; on `\save` / clean exit it writes a fresh checkpoint and truncates the WAL. Recovery restores both table schemas (DDL) and committed row data (DML inserts, updates, deletes); uncommitted transactions at crash time are discarded, and a truncated WAL tail recovers up to the last complete, checksum-valid entry. A legacy snapshot-only `.vbsql` (no checkpoint archive yet) is loaded as the recovery base on first WAL open.
+
+**Recovery failure policy (never silently empty):** a database written by a newer VibeSQL binary (forward format version) is a hard open error — "database written by a newer version of VibeSQL" — never an empty or stale database, and never masked by the SQL-dump fallback. An unreadable/corrupt newest checkpoint is also a hard error by default; pass `--recover-fallback` to explicitly opt into recovering from the newest readable older checkpoint (every skipped checkpoint file is reported on stderr). If a `.vbsql` mysteriously opens empty under an old binary, suspect format-version skew before assuming data loss — the checkpoint files are intact on disk.
 
 The engine lives in `crates/vibesql-storage/src/wal/` (writer, reader, checkpoint, truncate, recovery). DML WAL ops carry an inline `table_name` (WAL format version 2) so `RecoveryManager::apply_op` can route each row mutation back to its table during replay. Server-mode durability is separate (the replicated server routes writes through the Raft log + MVCC state machine).
 

--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -124,44 +124,134 @@ fn format_sql_value(v: &SqlValue) -> String {
     }
 }
 
+/// Load an existing database file, auto-detecting its format.
+///
+/// Tries the native binary/compressed/JSON loader first, auto-imports SQLite
+/// files, and falls back to SQL-dump parsing for text files.
+///
+/// A `StorageError::UnsupportedFormatVersion` (file written by a newer VibeSQL
+/// binary) is a hard error and is deliberately NOT masked by the SQL-dump
+/// fallback: before issue #5807 the version mismatch fell through to a
+/// confusing dump-parse error (or, on the WAL path, a silently empty
+/// database).
+fn load_database_file(db_path: &str) -> anyhow::Result<Database> {
+    match Database::load(db_path) {
+        Ok(db) => Ok(db),
+        Err(e @ vibesql_storage::StorageError::UnsupportedFormatVersion { .. }) => {
+            Err(anyhow::anyhow!("Failed to open database at {}: {}", db_path, e))
+        }
+        Err(ref e) if e.to_string().contains("SQLite database detected") => {
+            // Auto-import SQLite database
+            let result = crate::sqlite_io::import_sqlite(db_path).map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to read binary SQLite database at {}: {}. \
+                     If this file is a VibeSQL SQL dump, rename it with a .sql extension \
+                     to load it in SQL dump format.",
+                    db_path,
+                    e
+                )
+            })?;
+            for warning in &result.warnings {
+                eprintln!("{}", warning);
+            }
+            eprintln!(
+                "Imported SQLite database: {} tables, {} rows",
+                result.tables_imported, result.rows_imported
+            );
+            Ok(result.database)
+        }
+        Err(_) => {
+            // Fall back to SQL dump loading (requires executor for parsing)
+            vibesql_executor::load_sql_dump(db_path)
+                .map_err(|e| anyhow::anyhow!("Failed to load database: {}", e))
+        }
+    }
+}
+
+/// Options controlling how the executor opens a database file.
+///
+/// Bundled into a struct so the `--recover-fallback` opt-in (issue #5807)
+/// threads through `Repl`/`ScriptExecutor` without growing a trail of bools.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DbOpenOptions {
+    /// Activate the WAL persistence path for file-backed databases
+    /// (`[database] wal`, on by default).
+    pub wal: bool,
+    /// Explicit opt-in (`--recover-fallback`): when the newest checkpoint is
+    /// unreadable, recover from the newest readable older checkpoint instead
+    /// of refusing to open. Skipped checkpoints are reported on stderr.
+    pub recover_fallback: bool,
+}
+
 impl SqlExecutor {
     /// Create an executor with WAL disabled (default snapshot persistence).
     ///
     /// Equivalent to `new_with_wal(database, false)`. Retained for callers and
     /// tests that do not opt into the WAL path. (The binary itself always goes
-    /// through `new_with_wal`; this wrapper is used by the in-crate tests.)
+    /// through `new_with_options`; this wrapper is used by the in-crate tests.)
     #[allow(dead_code)]
     pub fn new(database: Option<String>) -> anyhow::Result<Self> {
         Self::new_with_wal(database, false)
     }
 
+    /// Create an executor with the given WAL setting and default recovery
+    /// strictness (no checkpoint fallback).
+    pub fn new_with_wal(database: Option<String>, wal: bool) -> anyhow::Result<Self> {
+        Self::new_with_options(database, DbOpenOptions { wal, recover_fallback: false })
+    }
+
     /// Create an executor, optionally activating the opt-in WAL persistence path.
     ///
-    /// When `wal` is `true` AND `database` resolves to a real file path (not
-    /// `:memory:` and not `None`), the executor:
+    /// When `options.wal` is `true` AND `database` resolves to a real file path
+    /// (not `:memory:` and not `None`), the executor:
     ///   * recovers the database from `<stem>-checkpoints/` + `<stem>.wal` via
     ///     `RecoveryManager::recover()`,
     ///   * attaches a live `PersistenceEngine` so subsequent writes are logged,
     ///   * and routes `save_database` to checkpoint + WAL truncate.
     ///
-    /// When `wal` is `false` (the default), or for in-memory databases, behavior
-    /// is unchanged: snapshot load on open, full snapshot save on `\save`/exit.
+    /// When `options.wal` is `false`, or for in-memory databases, behavior is
+    /// unchanged: snapshot load on open, full snapshot save on `\save`/exit.
     ///
-    /// Phase 1 durability note: DDL survives an unclean shutdown via WAL replay;
-    /// committed row data is durable as of the last checkpoint. Post-checkpoint
-    /// DML replay is a Phase 2 stub (see `executor::wal` module docs and #5698).
-    pub fn new_with_wal(database: Option<String>, wal: bool) -> anyhow::Result<Self> {
+    /// Failure policy (issue #5807): a database file written by a newer VibeSQL
+    /// binary, or whose newest checkpoint is unreadable, is a hard open error —
+    /// the CLI must never silently present an empty (or stale) database.
+    /// `options.recover_fallback` opts into older-checkpoint recovery, loudly.
+    pub fn new_with_options(
+        database: Option<String>,
+        options: DbOpenOptions,
+    ) -> anyhow::Result<Self> {
         // Treat :memory: as an in-memory database (no file path)
         let database = database.filter(|p| !is_memory_database(p));
 
         // WAL-active path: only when explicitly opted in AND a file path exists.
         // For in-memory databases the WAL is silently disabled (no file to
         // attach to) — consistent with the issue's documented edge case.
-        if wal {
+        if options.wal {
             if let Some(ref db_path) = database {
-                let (mut db, wal_state) = wal::WalState::open(db_path).map_err(|e| {
-                    anyhow::anyhow!("Failed to open WAL-backed database at {}: {}", db_path, e)
-                })?;
+                // Legacy snapshot-only support (#5807): a `.vbsql` written
+                // before WAL mode has no checkpoint archive. Load the snapshot
+                // as the recovery base so its data is preserved (and captured
+                // by the first checkpoint) instead of being silently ignored.
+                // When any checkpoint exists, checkpoints are the newer truth
+                // and the base is skipped entirely.
+                let paths = wal::WalPaths::derive(db_path);
+                let base = if !paths.has_checkpoint_files()
+                    && std::fs::metadata(db_path).map(|m| m.len() > 0).unwrap_or(false)
+                {
+                    Some(load_database_file(db_path)?)
+                } else {
+                    None
+                };
+
+                let (mut db, wal_state) =
+                    wal::WalState::open_with_base(db_path, base, options.recover_fallback)
+                        .map_err(|e| {
+                            anyhow::anyhow!(
+                                "Failed to open WAL-backed database at {}: {}",
+                                db_path,
+                                e
+                            )
+                        })?;
                 // Rebuild expression-index bodies that the snapshot loader left
                 // empty (it cannot evaluate index expressions). Without this an
                 // expression index would silently return zero rows after reopen.
@@ -186,36 +276,7 @@ impl SqlExecutor {
         let mut db = if let Some(db_path) = database {
             // Check if file exists
             if std::path::Path::new(&db_path).exists() {
-                // Try auto-detecting format first (handles binary, compressed, JSON)
-                // Fall back to SQL dump if that fails
-                match Database::load(&db_path) {
-                    Ok(db) => db,
-                    Err(ref e) if e.to_string().contains("SQLite database detected") => {
-                        // Auto-import SQLite database
-                        let result = crate::sqlite_io::import_sqlite(&db_path).map_err(|e| {
-                            anyhow::anyhow!(
-                                "Failed to read binary SQLite database at {}: {}. \
-                                 If this file is a VibeSQL SQL dump, rename it with a .sql extension \
-                                 to load it in SQL dump format.",
-                                db_path,
-                                e
-                            )
-                        })?;
-                        for warning in &result.warnings {
-                            eprintln!("{}", warning);
-                        }
-                        eprintln!(
-                            "Imported SQLite database: {} tables, {} rows",
-                            result.tables_imported, result.rows_imported
-                        );
-                        result.database
-                    }
-                    Err(_) => {
-                        // Fall back to SQL dump loading (requires executor for parsing)
-                        vibesql_executor::load_sql_dump(&db_path)
-                            .map_err(|e| anyhow::anyhow!("Failed to load database: {}", e))?
-                    }
-                }
+                load_database_file(&db_path)?
             } else {
                 // File doesn't exist, create new database
                 // (Will be saved when user uses \save or when modifications occur)

--- a/crates/vibesql-cli/src/executor/wal.rs
+++ b/crates/vibesql-cli/src/executor/wal.rs
@@ -13,7 +13,8 @@
 // paths from the file stem:
 //
 // ```text
-// mydata.vbsql          — binary snapshot (loaded on open if it exists)
+// mydata.vbsql          — binary snapshot (legacy; loaded as the recovery base
+//                         when no checkpoint archive exists yet — see #5807)
 // mydata.wal            — active write-ahead log
 // mydata-checkpoints/   — checkpoint archive directory (checkpoint_*.vchk)
 // ```
@@ -35,7 +36,10 @@
 use std::path::{Path, PathBuf};
 
 use vibesql_storage::{
-    wal::{truncate_wal, CheckpointWriter, PersistenceConfig, PersistenceEngine, RecoveryManager},
+    wal::{
+        truncate_wal, CheckpointWriter, PersistenceConfig, PersistenceEngine, RecoveryConfig,
+        RecoveryManager,
+    },
     Database, StorageError,
 };
 
@@ -65,6 +69,21 @@ impl WalPaths {
 
         WalPaths { wal_path, checkpoint_dir }
     }
+
+    /// True when the checkpoint archive directory contains at least one
+    /// `.vchk` file.
+    ///
+    /// Used to detect a legacy snapshot-only database (issue #5807): a
+    /// `.vbsql` file written before WAL mode has no checkpoint archive, and
+    /// its snapshot must be loaded as the recovery base instead of being
+    /// silently ignored.
+    pub fn has_checkpoint_files(&self) -> bool {
+        std::fs::read_dir(&self.checkpoint_dir)
+            .map(|entries| {
+                entries.flatten().any(|e| e.path().extension().is_some_and(|ext| ext == "vchk"))
+            })
+            .unwrap_or(false)
+    }
 }
 
 /// Active WAL state held by `SqlExecutor` when `[database] wal = true`.
@@ -83,12 +102,60 @@ impl WalState {
     ///
     /// Returns the recovered (and persistence-enabled) `Database` together with
     /// the `WalState` the executor must keep for checkpoint-on-save.
+    ///
+    /// (The binary itself goes through [`WalState::open_with_base`]; this
+    /// wrapper is used by the in-crate tests.)
+    #[allow(dead_code)]
     pub fn open(db_path: &str) -> Result<(Database, WalState), StorageError> {
+        Self::open_with_base(db_path, None, false)
+    }
+
+    /// Like [`WalState::open`], with two additions for issue #5807:
+    ///
+    /// * `base` — pre-loaded snapshot used **only when no checkpoint files exist** (legacy
+    ///   snapshot-only `.vbsql` databases), so their data is never silently ignored under
+    ///   WAL-default.
+    /// * `recover_fallback` — explicit opt-in (`--recover-fallback`) to recover from an older
+    ///   checkpoint when the newest is unreadable. Off (the default), an unreadable checkpoint is a
+    ///   hard open error. Every checkpoint skipped under the opt-in is reported loudly on stderr —
+    ///   the CLI installs no `log` backend, so `log::warn!` from the recovery engine would be
+    ///   silently discarded.
+    pub fn open_with_base(
+        db_path: &str,
+        base: Option<Database>,
+        recover_fallback: bool,
+    ) -> Result<(Database, WalState), StorageError> {
         let paths = WalPaths::derive(db_path);
 
         // Step 1: recover from the last checkpoint + replay post-checkpoint WAL.
-        let manager = RecoveryManager::new(&paths.checkpoint_dir).with_wal(&paths.wal_path);
-        let (mut db, stats) = manager.recover()?;
+        let config = RecoveryConfig {
+            allow_checkpoint_fallback: recover_fallback,
+            ..RecoveryConfig::default()
+        };
+        let manager =
+            RecoveryManager::with_config(&paths.checkpoint_dir, config).with_wal(&paths.wal_path);
+        let (mut db, stats) = manager.recover_with_base(base)?;
+
+        // Surface skipped checkpoints prominently (issue #5807). This can only
+        // be non-empty under the explicit --recover-fallback opt-in, but the
+        // consequence (opening state older than the newest checkpoint) must
+        // still be impossible to miss.
+        if !stats.skipped_checkpoints.is_empty() {
+            eprintln!(
+                "WARNING: recovery skipped {} unreadable checkpoint file(s) in {}:",
+                stats.skipped_checkpoints.len(),
+                paths.checkpoint_dir.display()
+            );
+            for skipped in &stats.skipped_checkpoints {
+                eprintln!("  {}: {}", skipped.path.display(), skipped.error);
+            }
+            eprintln!(
+                "WARNING: the database was opened from an OLDER checkpoint (LSN {}); \
+                 changes committed after it may be missing. The skipped files were \
+                 left on disk untouched.",
+                stats.checkpoint_lsn
+            );
+        }
 
         // Step 2: attach the live persistence engine so new ops hit the WAL.
         //

--- a/crates/vibesql-cli/src/main.rs
+++ b/crates/vibesql-cli/src/main.rs
@@ -134,6 +134,14 @@ struct Args {
     #[arg(long, value_name = "LOCALE", global = true)]
     lang: Option<String>,
 
+    /// If the newest checkpoint is unreadable, recover from the newest
+    /// readable older checkpoint instead of refusing to open. Skipped
+    /// checkpoints are reported on stderr; changes committed after the loaded
+    /// checkpoint may be missing. (Never applies to version mismatches: a
+    /// database written by a newer VibeSQL always requires a newer binary.)
+    #[arg(long)]
+    recover_fallback: bool,
+
     #[command(subcommand)]
     subcommand: Option<Commands>,
 }
@@ -250,21 +258,26 @@ fn main() -> anyhow::Result<()> {
 
     // WAL durability ([database] wal = true, the default). Committed DDL + DML
     // survive an unclean shutdown for file-backed databases. Set wal = false to
-    // opt out and fall back to the snapshot-only path.
-    let wal = config.database.wal;
+    // opt out and fall back to the snapshot-only path. --recover-fallback opts
+    // into older-checkpoint recovery when the newest checkpoint is unreadable
+    // (issue #5807: never a silent fallback).
+    let open_options = executor::DbOpenOptions {
+        wal: config.database.wal,
+        recover_fallback: args.recover_fallback,
+    };
 
     if let Some(cmd) = args.command {
         // Execute command mode
-        execute_command(&cmd, database, format, wal)?;
+        execute_command(&cmd, database, format, open_options)?;
     } else if let Some(file_path) = args.file {
         // Execute file mode
-        execute_file(&file_path, database, args.verbose, format, wal)?;
+        execute_file(&file_path, database, args.verbose, format, open_options)?;
     } else if args.stdin || is_stdin_piped() {
         // Execute from stdin
-        execute_stdin(database, args.verbose, format, wal)?;
+        execute_stdin(database, args.verbose, format, open_options)?;
     } else {
         // Interactive REPL mode
-        let mut repl = Repl::new(database, format, wal)?;
+        let mut repl = Repl::new(database, format, open_options)?;
         repl.run()?;
     }
 
@@ -305,11 +318,17 @@ fn run_import(input: &str, output: Option<&str>) -> anyhow::Result<()> {
 }
 
 fn run_export(input: &str, output: &str) -> anyhow::Result<()> {
-    // Load the VibeSQL database
-    let db = vibesql_storage::Database::load(input).or_else(|_| {
-        vibesql_executor::load_sql_dump(input)
-            .map_err(|e| anyhow::anyhow!("Failed to load database: {}", e))
-    })?;
+    // Load the VibeSQL database. A forward-version error (file written by a
+    // newer VibeSQL binary) is fatal and must not be masked by the SQL-dump
+    // fallback (issue #5807).
+    let db = match vibesql_storage::Database::load(input) {
+        Ok(db) => db,
+        Err(e @ vibesql_storage::StorageError::UnsupportedFormatVersion { .. }) => {
+            return Err(anyhow::anyhow!("Failed to open database at {}: {}", input, e));
+        }
+        Err(_) => vibesql_executor::load_sql_dump(input)
+            .map_err(|e| anyhow::anyhow!("Failed to load database: {}", e))?,
+    };
 
     let result = sqlite_io::export_sqlite(&db, output)?;
 
@@ -395,9 +414,9 @@ fn execute_command(
     cmd: &str,
     database: Option<String>,
     format: Option<OutputFormat>,
-    wal: bool,
+    options: executor::DbOpenOptions,
 ) -> anyhow::Result<()> {
-    let mut executor = ScriptExecutor::new(database, false, format, wal)?;
+    let mut executor = ScriptExecutor::new(database, false, format, options)?;
     executor.execute_script(cmd)?;
     Ok(())
 }
@@ -407,9 +426,9 @@ fn execute_file(
     database: Option<String>,
     verbose: bool,
     format: Option<OutputFormat>,
-    wal: bool,
+    options: executor::DbOpenOptions,
 ) -> anyhow::Result<()> {
-    let mut executor = ScriptExecutor::new(database, verbose, format, wal)?;
+    let mut executor = ScriptExecutor::new(database, verbose, format, options)?;
     executor.execute_file(path)?;
     Ok(())
 }
@@ -418,9 +437,9 @@ fn execute_stdin(
     database: Option<String>,
     verbose: bool,
     format: Option<OutputFormat>,
-    wal: bool,
+    options: executor::DbOpenOptions,
 ) -> anyhow::Result<()> {
-    let mut executor = ScriptExecutor::new(database, verbose, format, wal)?;
+    let mut executor = ScriptExecutor::new(database, verbose, format, options)?;
     executor.execute_stdin()?;
     Ok(())
 }

--- a/crates/vibesql-cli/src/repl.rs
+++ b/crates/vibesql-cli/src/repl.rs
@@ -5,7 +5,7 @@ use vibesql_l10n::vibe_msg;
 
 use crate::{
     commands::MetaCommand,
-    executor::SqlExecutor,
+    executor::{DbOpenOptions, SqlExecutor},
     formatter::{OutputFormat, ResultFormatter},
     util::is_memory_database,
 };
@@ -28,17 +28,18 @@ pub struct Repl {
 impl Repl {
     /// Construct a REPL.
     ///
-    /// `wal` activates the opt-in WAL persistence path for file-backed
-    /// databases (see `SqlExecutor::new_with_wal`); `false` preserves the
-    /// default snapshot-on-exit behavior.
+    /// `options.wal` activates the WAL persistence path for file-backed
+    /// databases (see `SqlExecutor::new_with_options`); `false` preserves the
+    /// snapshot-on-exit behavior. `options.recover_fallback` opts into
+    /// older-checkpoint recovery when the newest checkpoint is unreadable.
     pub fn new(
         database: Option<String>,
         format: Option<OutputFormat>,
-        wal: bool,
+        options: DbOpenOptions,
     ) -> anyhow::Result<Self> {
         // Treat :memory: as an in-memory database (no file path for saving)
         let database_path = database.as_ref().filter(|p| !is_memory_database(p)).cloned();
-        let executor = SqlExecutor::new_with_wal(database, wal)?;
+        let executor = SqlExecutor::new_with_options(database, options)?;
         let editor = DefaultEditor::new()?;
         let mut formatter = ResultFormatter::new();
 

--- a/crates/vibesql-cli/src/script.rs
+++ b/crates/vibesql-cli/src/script.rs
@@ -7,7 +7,7 @@ use vibesql_l10n::vibe_msg;
 
 use crate::{
     commands::MetaCommand,
-    executor::SqlExecutor,
+    executor::{DbOpenOptions, SqlExecutor},
     formatter::{OutputFormat, ResultFormatter},
     util::is_memory_database,
 };
@@ -23,18 +23,19 @@ pub struct ScriptExecutor {
 impl ScriptExecutor {
     /// Construct a script executor.
     ///
-    /// `wal` activates the opt-in WAL persistence path for file-backed
-    /// databases (see `SqlExecutor::new_with_wal`); `false` preserves the
-    /// default snapshot-on-exit behavior.
+    /// `options.wal` activates the WAL persistence path for file-backed
+    /// databases (see `SqlExecutor::new_with_options`); `false` preserves the
+    /// snapshot-on-exit behavior. `options.recover_fallback` opts into
+    /// older-checkpoint recovery when the newest checkpoint is unreadable.
     pub fn new(
         database: Option<String>,
         verbose: bool,
         format: Option<OutputFormat>,
-        wal: bool,
+        options: DbOpenOptions,
     ) -> anyhow::Result<Self> {
         // Treat :memory: as an in-memory database (no file path for saving)
         let database_path = database.as_ref().filter(|p| !is_memory_database(p)).cloned();
-        let executor = SqlExecutor::new_with_wal(database, wal)?;
+        let executor = SqlExecutor::new_with_options(database, options)?;
         let mut formatter = ResultFormatter::new();
 
         if let Some(fmt) = format {

--- a/crates/vibesql-cli/tests/recovery_failure_test.rs
+++ b/crates/vibesql-cli/tests/recovery_failure_test.rs
@@ -1,0 +1,265 @@
+// ============================================================================
+// Recovery failure-surfacing tests — issue #5807
+// ============================================================================
+//
+// The CLI must NEVER silently present an empty (or stale) database when the
+// on-disk state cannot be read. These subprocess tests pin the user-visible
+// contract (exit codes + stderr), which is the level at which the original
+// incident manifested: a forward-format-version checkpoint opened as
+// `SELECT name FROM sqlite_master` → 0 rows, exit 0, empty stderr.
+//
+//   * Checkpoint written by a newer binary (embedded format vN+1, valid CRC) → hard error naming
+//     the version mismatch; no fallback to an older checkpoint (stale-state resurrection is also
+//     data loss); no new checkpoint written (the emptiness must never be checkpointed as "real"
+//     state).
+//   * Corrupt newest checkpoint with a valid older one → hard error by default;
+//     `--recover-fallback` opts into older-checkpoint recovery with a loud stderr report of what
+//     was skipped.
+//   * Legacy snapshot-only `.vbsql` (no checkpoint archive, no WAL) → opens WITH its data under the
+//     WAL default instead of being silently ignored.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+use vibesql_catalog::{ColumnSchema, TableSchema};
+use vibesql_storage::{wal::CheckpointWriter, Database, Row};
+use vibesql_types::{DataType, SqlValue};
+
+fn vibesql_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_vibesql")
+}
+
+/// Run `vibesql <db> [extra args] -c <sql>` with an isolated `$HOME` (no
+/// user `~/.vibesqlrc`; WAL stays at its on-by-default setting).
+fn run_cli(home: &Path, db: &Path, extra_args: &[&str], sql: &str) -> Output {
+    Command::new(vibesql_binary())
+        .arg(db.to_string_lossy().to_string())
+        .args(extra_args)
+        .arg("-c")
+        .arg(sql)
+        .env("HOME", home)
+        .output()
+        .expect("failed to run vibesql")
+}
+
+fn simple_schema(name: &str) -> TableSchema {
+    TableSchema::new(
+        name.to_string(),
+        vec![ColumnSchema::new("id".to_string(), DataType::Integer, true)],
+    )
+}
+
+/// Write a real checkpoint containing a single one-row table `table_name`
+/// into `<db stem>-checkpoints/`, at the given LSN. Returns the file path.
+fn write_checkpoint(db_path: &Path, lsn: u64, table_name: &str) -> PathBuf {
+    let stem = db_path.file_stem().unwrap().to_string_lossy().to_string();
+    let dir = db_path.parent().unwrap().join(format!("{stem}-checkpoints"));
+
+    let mut db = Database::new();
+    db.create_table(simple_schema(table_name)).unwrap();
+    db.insert_row(table_name, Row::from_vec(vec![SqlValue::Integer(1)])).unwrap();
+
+    let data = db.to_uncompressed_bytes().unwrap();
+    let mut writer = CheckpointWriter::new(&dir).unwrap();
+    writer.create_checkpoint(lsn, &data, 1).unwrap().path
+}
+
+/// CRC-32 (IEEE, same polynomial as the checkpoint writer) — reimplemented
+/// here because the storage-internal helper is `pub(crate)`.
+fn crc32(data: &[u8]) -> u32 {
+    let mut crc = 0xFFFF_FFFFu32;
+    for &byte in data {
+        crc ^= byte as u32;
+        for _ in 0..8 {
+            if crc & 1 != 0 {
+                crc = (crc >> 1) ^ 0xEDB8_8320;
+            } else {
+                crc >>= 1;
+            }
+        }
+    }
+    crc ^ 0xFFFF_FFFF
+}
+
+/// Patch a checkpoint's *embedded* VBSQL snapshot version byte (file offset
+/// 37, after the 32-byte envelope header + 5-byte "VBSQL" magic) to 255 and
+/// re-stamp the envelope CRC (bytes 28..32, over the payload) so the envelope
+/// is fully valid — exactly what a checkpoint written by a newer VibeSQL
+/// binary looks like to this one.
+fn bump_embedded_format_version(path: &Path) {
+    let mut bytes = fs::read(path).unwrap();
+    assert_eq!(&bytes[..4], b"VCHK", "not a checkpoint envelope");
+    assert_eq!(&bytes[32..37], b"VBSQL", "payload is not a binary snapshot");
+    bytes[37] = 255;
+    let crc = crc32(&bytes[32..]);
+    bytes[28..32].copy_from_slice(&crc.to_le_bytes());
+    fs::write(path, bytes).unwrap();
+}
+
+/// Corrupt a checkpoint's payload without fixing the envelope CRC.
+fn corrupt_payload(path: &Path) {
+    let mut bytes = fs::read(path).unwrap();
+    assert!(bytes.len() > 40);
+    bytes[40] ^= 0xFF;
+    fs::write(path, bytes).unwrap();
+}
+
+fn count_checkpoint_files(db_path: &Path) -> usize {
+    let stem = db_path.file_stem().unwrap().to_string_lossy().to_string();
+    let dir = db_path.parent().unwrap().join(format!("{stem}-checkpoints"));
+    match fs::read_dir(dir) {
+        Ok(entries) => entries
+            .flatten()
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "vchk"))
+            .count(),
+        Err(_) => 0,
+    }
+}
+
+/// The original incident: every checkpoint claims a newer format version.
+/// Open must fail hard with a clear message — never `sqlite_master` → 0 rows,
+/// exit 0 — and must not checkpoint the emptiness as new "real" state.
+#[test]
+fn test_forward_version_checkpoint_is_hard_open_error() {
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("future.vbsql");
+
+    let checkpoint = write_checkpoint(&db_path, 1, "precious_data");
+    bump_embedded_format_version(&checkpoint);
+
+    let out = run_cli(home.path(), &db_path, &[], "SELECT name FROM sqlite_master");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        !out.status.success(),
+        "open must fail; stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    assert!(
+        stderr.contains("newer version of VibeSQL"),
+        "stderr must explain the version mismatch; was: {stderr}"
+    );
+    assert_eq!(
+        count_checkpoint_files(&db_path),
+        1,
+        "no new checkpoint may be written after a failed open"
+    );
+}
+
+/// Newest checkpoint forward-version with an older *valid* checkpoint
+/// present: still a hard error — silently resurrecting the older (stale)
+/// state is also data loss. `--recover-fallback` must NOT override this.
+#[test]
+fn test_forward_version_newest_never_falls_back_to_older() {
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("mixed.vbsql");
+
+    write_checkpoint(&db_path, 1, "older_state");
+    let newest = write_checkpoint(&db_path, 2, "newest_state");
+    bump_embedded_format_version(&newest);
+
+    for extra in [&[][..], &["--recover-fallback"][..]] {
+        let out = run_cli(home.path(), &db_path, extra, "SELECT name FROM sqlite_master");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            !out.status.success(),
+            "must not fall back past a forward-version checkpoint (args: {extra:?}); \
+             stdout: {}",
+            String::from_utf8_lossy(&out.stdout)
+        );
+        assert!(
+            stderr.contains("newer version of VibeSQL"),
+            "stderr must explain the version mismatch (args: {extra:?}); was: {stderr}"
+        );
+    }
+}
+
+/// Corrupt newest checkpoint, valid older one: refuse to open by default
+/// (naming the file and the opt-in); with `--recover-fallback`, open the
+/// older state and report the skipped checkpoint loudly on stderr.
+#[test]
+fn test_corrupt_newest_checkpoint_default_error_fallback_optin_loud() {
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("corrupt.vbsql");
+
+    write_checkpoint(&db_path, 1, "older_state");
+    let newest = write_checkpoint(&db_path, 2, "newest_state");
+    corrupt_payload(&newest);
+
+    // Default: hard error naming the unreadable checkpoint and the opt-in.
+    let out = run_cli(home.path(), &db_path, &[], "SELECT name FROM sqlite_master");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!out.status.success(), "corrupt newest checkpoint must refuse to open by default");
+    assert!(
+        stderr.contains(&newest.display().to_string()),
+        "stderr must name the unreadable checkpoint; was: {stderr}"
+    );
+    assert!(
+        stderr.contains("recover-fallback"),
+        "stderr must mention the --recover-fallback opt-in; was: {stderr}"
+    );
+
+    // Opt-in: opens the older state, loudly.
+    let out =
+        run_cli(home.path(), &db_path, &["--recover-fallback"], "SELECT name FROM sqlite_master");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "opt-in fallback must open; stderr: {stderr}");
+    assert!(stdout.contains("older_state"), "older state must be visible; stdout: {stdout}");
+    assert!(!stdout.contains("newest_state"));
+    assert!(
+        stderr.contains("WARNING") && stderr.contains(&newest.display().to_string()),
+        "fallback must be loud and name the skipped checkpoint; was: {stderr}"
+    );
+}
+
+/// Legacy snapshot-only `.vbsql` (written before WAL mode: no checkpoint
+/// archive, no `.wal` sibling) must open WITH its data under the WAL default —
+/// and the data must survive the session's checkpoint so subsequent opens
+/// (which then recover from the checkpoint archive) still see it.
+#[test]
+fn test_legacy_snapshot_only_file_opens_with_data() {
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("legacy.vbsql");
+
+    let mut db = Database::new();
+    db.create_table(simple_schema("legacy_table")).unwrap();
+    db.insert_row("legacy_table", Row::from_vec(vec![SqlValue::Integer(42)])).unwrap();
+    db.save(&db_path).unwrap();
+    assert_eq!(count_checkpoint_files(&db_path), 0, "precondition: snapshot-only");
+
+    let out = run_cli(home.path(), &db_path, &[], "SELECT id FROM legacy_table");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "legacy snapshot must open; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(stdout.contains("42"), "legacy snapshot data must be visible; stdout: {stdout}");
+
+    // Reopen: whatever the first session checkpointed must still contain the
+    // legacy data (the first WAL session must not bury it under an empty
+    // checkpoint).
+    let out = run_cli(home.path(), &db_path, &[], "SELECT id FROM legacy_table");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(out.status.success());
+    assert!(stdout.contains("42"), "legacy data must survive reopen; stdout: {stdout}");
+}
+
+/// A fresh, nonexistent database file still opens as an empty database — the
+/// hard-error paths must not break the legitimate empty-start case.
+#[test]
+fn test_fresh_database_still_opens_empty() {
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("brand_new.vbsql");
+
+    let out = run_cli(home.path(), &db_path, &[], "CREATE TABLE t(id INTEGER); SELECT 1;");
+    assert!(
+        out.status.success(),
+        "fresh database must open; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -1445,6 +1445,11 @@ impl From<vibesql_storage::StorageError> for ExecutorError {
             vibesql_storage::StorageError::NotImplemented(msg) => {
                 ExecutorError::StorageError(format!("Not implemented: {}", msg))
             }
+            err @ vibesql_storage::StorageError::UnsupportedFormatVersion { .. } => {
+                // Forward-incompatible file format (#5807): preserve the full
+                // "written by a newer version of VibeSQL" message.
+                ExecutorError::StorageError(err.to_string())
+            }
             vibesql_storage::StorageError::IoError(msg) => {
                 ExecutorError::StorageError(format!("I/O error: {}", msg))
             }

--- a/crates/vibesql-storage/src/error.rs
+++ b/crates/vibesql-storage/src/error.rs
@@ -36,6 +36,15 @@ pub enum StorageError {
     UniqueConstraintViolation(String),
     InvalidIndexColumn(String),
     NotImplemented(String),
+    /// The file was written by a newer VibeSQL binary (forward-incompatible
+    /// binary format version). Typed so open/recovery paths can hard-error
+    /// instead of silently falling back to older or empty state (issue #5807).
+    UnsupportedFormatVersion {
+        /// Version byte found in the file header.
+        found: u8,
+        /// Highest version this binary supports (`persistence::binary::VERSION`).
+        supported: u8,
+    },
     IoError(String),
     InvalidPageSize {
         expected: usize,
@@ -131,6 +140,14 @@ impl std::fmt::Display for StorageError {
             }
             StorageError::NotImplemented(msg) => {
                 write!(f, "{}", vibe_msg!("storage-not-implemented", message = msg.as_str()))
+            }
+            StorageError::UnsupportedFormatVersion { found, supported } => {
+                write!(
+                    f,
+                    "database written by a newer version of VibeSQL (format v{}; this binary \
+                     supports up to v{}) — upgrade the vibesql binary; the data file is intact",
+                    found, supported
+                )
             }
             StorageError::IoError(msg) => {
                 write!(f, "{}", vibe_msg!("storage-io-error", message = msg.as_str()))

--- a/crates/vibesql-storage/src/persistence/binary/format.rs
+++ b/crates/vibesql-storage/src/persistence/binary/format.rs
@@ -158,10 +158,14 @@ pub fn read_header<R: Read>(reader: &mut R) -> Result<u8, StorageError> {
         .map_err(|e| StorageError::NotImplemented(format!("Failed to read version: {}", e)))?;
 
     if version[0] > VERSION {
-        return Err(StorageError::NotImplemented(format!(
-            "Unsupported format version: {} (current version: {})",
-            version[0], VERSION
-        )));
+        // Typed forward-version error (issue #5807): callers (checkpoint
+        // recovery, CLI open) must treat this as fatal — never fall back to an
+        // older checkpoint or an empty database, and never mask it behind a
+        // SQL-dump reparse attempt.
+        return Err(StorageError::UnsupportedFormatVersion {
+            found: version[0],
+            supported: VERSION,
+        });
     }
 
     // Read flags (reserved for future use)
@@ -195,5 +199,24 @@ mod tests {
         let mut reader = &buf[..];
         let version = read_header(&mut reader).unwrap();
         assert_eq!(version, VERSION);
+    }
+
+    /// Issue #5807: a header claiming a format version newer than this binary
+    /// must surface as the typed `UnsupportedFormatVersion` error so open
+    /// paths can hard-error instead of silently falling back.
+    #[test]
+    fn test_read_header_forward_version_is_typed_error() {
+        let mut buf = Vec::new();
+        write_header(&mut buf).unwrap();
+        buf[5] = VERSION + 1;
+
+        let mut reader = &buf[..];
+        let err = read_header(&mut reader).unwrap_err();
+        assert_eq!(
+            err,
+            StorageError::UnsupportedFormatVersion { found: VERSION + 1, supported: VERSION }
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("newer version of VibeSQL"), "message was: {msg}");
     }
 }

--- a/crates/vibesql-storage/src/wal/checkpoint.rs
+++ b/crates/vibesql-storage/src/wal/checkpoint.rs
@@ -373,7 +373,10 @@ pub fn read_checkpoint_data(path: &Path) -> Result<(CheckpointHeader, Vec<u8>), 
 }
 
 /// CRC-32 implementation (same as in writer.rs for consistency)
-fn crc32(data: &[u8]) -> u32 {
+///
+/// `pub(crate)` so recovery tests can re-stamp a checkpoint envelope checksum
+/// after deliberately patching the payload (issue #5807 forward-version tests).
+pub(crate) fn crc32(data: &[u8]) -> u32 {
     const CRC32_TABLE: [u32; 256] = {
         let mut table = [0u32; 256];
         let mut i = 0;

--- a/crates/vibesql-storage/src/wal/mod.rs
+++ b/crates/vibesql-storage/src/wal/mod.rs
@@ -91,7 +91,9 @@ pub use engine::{
 pub use entry::{Lsn, WalEntry, WalOp, WalOpTag};
 pub use format::{WalHeader, WAL_HEADER_SIZE, WAL_MAGIC, WAL_VERSION};
 pub use reader::{find_recovery_point, ReadResult, RecoveryInfo, WalIterator, WalReader};
-pub use recovery::{needs_recovery, recover, RecoveryConfig, RecoveryManager, RecoveryStats};
+pub use recovery::{
+    needs_recovery, recover, RecoveryConfig, RecoveryManager, RecoveryStats, SkippedCheckpoint,
+};
 pub use scheduler::{
     CheckpointConfig, CheckpointScheduler, CheckpointStats, CheckpointTrigger,
     CheckpointTriggerState, DEFAULT_CHECKPOINT_INTERVAL_SECS, DEFAULT_KEEP_CHECKPOINTS,

--- a/crates/vibesql-storage/src/wal/recovery.rs
+++ b/crates/vibesql-storage/src/wal/recovery.rs
@@ -55,9 +55,24 @@ pub struct RecoveryConfig {
     /// Whether to stop on first WAL corruption or continue with partial recovery
     pub stop_on_corruption: bool,
     /// Maximum number of checkpoints to try if the latest is corrupted
+    /// (only relevant when `allow_checkpoint_fallback` is enabled)
     pub max_checkpoint_retries: usize,
     /// Progress callback interval (number of entries between callbacks)
     pub progress_interval: usize,
+    /// Whether recovery may fall back to an *older* checkpoint when the newest
+    /// one is unreadable (corrupt envelope, bad checksum, parse failure).
+    ///
+    /// Default is `false` (issue #5807): an unreadable newest checkpoint is a
+    /// hard error, because silently opening older state — or an empty database
+    /// — presents as data loss, and any subsequent save checkpoints that stale
+    /// state as the newest. The CLI exposes this as the explicit
+    /// `--recover-fallback` opt-in; every skipped checkpoint is then recorded
+    /// in [`RecoveryStats::skipped_checkpoints`] so callers can surface it.
+    ///
+    /// A checkpoint with a *newer format version* than this binary is always a
+    /// hard error, regardless of this flag: falling back past it would
+    /// resurrect stale state, which is also data loss.
+    pub allow_checkpoint_fallback: bool,
 }
 
 impl Default for RecoveryConfig {
@@ -67,8 +82,23 @@ impl Default for RecoveryConfig {
             stop_on_corruption: true,
             max_checkpoint_retries: 3,
             progress_interval: 10000,
+            allow_checkpoint_fallback: false,
         }
     }
+}
+
+/// A checkpoint file that recovery skipped because it could not be loaded.
+///
+/// Only produced when [`RecoveryConfig::allow_checkpoint_fallback`] is enabled;
+/// callers MUST surface these to the user (the CLI prints them to stderr —
+/// `log::warn!` is unconditionally discarded there because no log backend is
+/// installed).
+#[derive(Debug, Clone)]
+pub struct SkippedCheckpoint {
+    /// Path of the checkpoint file that failed to load.
+    pub path: PathBuf,
+    /// Human-readable description of the failure.
+    pub error: String,
 }
 
 /// Statistics about a recovery operation
@@ -105,6 +135,13 @@ pub struct RecoveryStats {
     pub corruption_detected: bool,
     /// Position where corruption was detected (if any)
     pub corruption_position: Option<u64>,
+    /// Checkpoint files that could not be loaded and were skipped in favor of
+    /// an older checkpoint (only non-empty when
+    /// [`RecoveryConfig::allow_checkpoint_fallback`] is enabled). Callers must
+    /// surface these prominently — the recovered state predates the skipped
+    /// checkpoints, so changes committed after the loaded checkpoint may be
+    /// missing.
+    pub skipped_checkpoints: Vec<SkippedCheckpoint>,
 }
 
 /// Transaction state during recovery
@@ -218,10 +255,26 @@ impl RecoveryManager {
 
     /// Perform full recovery and return the recovered database
     pub fn recover(&self) -> Result<(Database, RecoveryStats), StorageError> {
+        self.recover_with_base(None)
+    }
+
+    /// Perform full recovery, optionally seeding from a caller-provided base
+    /// database.
+    ///
+    /// `base` is used **only when no checkpoint files exist at all**: it lets
+    /// the CLI open a legacy snapshot-only `.vbsql` file (written before WAL
+    /// mode, so it has no `<stem>-checkpoints/` archive) with its data instead
+    /// of silently presenting an empty database (issue #5807). When any
+    /// checkpoint file exists — readable or not — checkpoints win and `base`
+    /// is ignored.
+    pub fn recover_with_base(
+        &self,
+        base: Option<Database>,
+    ) -> Result<(Database, RecoveryStats), StorageError> {
         let mut stats = RecoveryStats::default();
 
         // Step 1: Find and load the latest valid checkpoint
-        let (mut db, checkpoint_lsn) = self.load_latest_checkpoint(&mut stats)?;
+        let (mut db, checkpoint_lsn) = self.load_latest_checkpoint(&mut stats, base)?;
         stats.checkpoint_lsn = checkpoint_lsn;
         stats.last_lsn = stats.last_lsn.max(checkpoint_lsn);
 
@@ -235,29 +288,76 @@ impl RecoveryManager {
         Ok((db, stats))
     }
 
-    /// Find and load the latest valid checkpoint
+    /// Find and load the latest valid checkpoint.
+    ///
+    /// Failure policy (issue #5807 — opening must NEVER silently present an
+    /// empty or stale database):
+    /// * No checkpoint files at all → `base` (if provided) or a fresh empty database. This is the
+    ///   only legitimate empty-DB start.
+    /// * Newest checkpoint written by a newer binary (`UnsupportedFormatVersion`) → hard error,
+    ///   always. Falling back to an older checkpoint would silently resurrect stale state.
+    /// * Newest checkpoint unreadable for any other reason → hard error unless
+    ///   `allow_checkpoint_fallback` is set, in which case older checkpoints are tried and every
+    ///   skipped file is recorded in `stats.skipped_checkpoints` for the caller to surface.
+    /// * All checkpoints unreadable → hard error listing what failed.
     fn load_latest_checkpoint(
         &self,
         stats: &mut RecoveryStats,
+        base: Option<Database>,
     ) -> Result<(Database, Lsn), StorageError> {
-        // List all checkpoints
-        let checkpoints = self.list_checkpoints()?;
+        // Enumerate every `.vchk` file ourselves: `CheckpointWriter::list_checkpoints`
+        // silently drops files whose header cannot be read, which would let a
+        // header-corrupt newest checkpoint vanish from consideration entirely.
+        let (checkpoints, unreadable) = self.enumerate_checkpoints()?;
 
-        if checkpoints.is_empty() {
-            // No checkpoints found - start with empty database
+        if checkpoints.is_empty() && unreadable.is_empty() {
+            // No checkpoint files at all — a legitimately fresh (or legacy
+            // snapshot-only) database.
+            if let Some(base_db) = base {
+                log::info!("No checkpoints found, starting from provided base snapshot");
+                return Ok((base_db, 0));
+            }
             log::info!("No checkpoints found, starting with empty database");
             return Ok((Database::new(), 0));
         }
 
+        let fallback = self.config.allow_checkpoint_fallback;
+
+        // Checkpoint files whose envelope header cannot even be read: we cannot
+        // order them by LSN, so one of them may well be the newest state.
+        if !unreadable.is_empty() && !fallback {
+            let detail = unreadable
+                .iter()
+                .map(|s| format!("{}: {}", s.path.display(), s.error))
+                .collect::<Vec<_>>()
+                .join("; ");
+            return Err(StorageError::IoError(format!(
+                "refusing to open: {} checkpoint file(s) in {} are unreadable ({}). \
+                 The database was NOT modified. Re-run with --recover-fallback to skip \
+                 unreadable checkpoints and recover from the newest readable one \
+                 (changes committed after that checkpoint may be missing).",
+                unreadable.len(),
+                self.checkpoint_dir.display(),
+                detail
+            )));
+        }
+        if !unreadable.is_empty() {
+            stats.corruption_detected = true;
+            stats.skipped_checkpoints.extend(unreadable);
+        }
+
         // Try checkpoints from newest to oldest
         let mut retries = 0;
+        let mut failures: Vec<String> = Vec::new();
         for checkpoint in checkpoints.into_iter().rev() {
             if retries >= self.config.max_checkpoint_retries {
-                log::warn!(
-                    "Exceeded max checkpoint retries ({}), starting with empty database",
-                    self.config.max_checkpoint_retries
-                );
-                return Ok((Database::new(), 0));
+                return Err(StorageError::IoError(format!(
+                    "recovery gave up after {} unreadable checkpoint(s) in {} ({}); \
+                     refusing to open as an empty database",
+                    retries,
+                    self.checkpoint_dir.display(),
+                    failures.join("; ")
+                )));
             }
 
             match self.load_checkpoint(&checkpoint.path) {
@@ -265,27 +365,92 @@ impl RecoveryManager {
                     log::info!("Loaded checkpoint at LSN {} from {:?}", lsn, checkpoint.path);
                     return Ok((db, lsn));
                 }
+                Err(e @ StorageError::UnsupportedFormatVersion { .. }) => {
+                    // Forward-version is ALWAYS fatal — even with fallback
+                    // enabled. An older checkpoint would silently resurrect
+                    // stale state, and a subsequent save would checkpoint that
+                    // stale state as the newest (issue #5807).
+                    return Err(e);
+                }
                 Err(e) => {
+                    if !fallback {
+                        return Err(StorageError::IoError(format!(
+                            "refusing to open: newest checkpoint {} is unreadable ({}). \
+                             The database was NOT modified; older checkpoints were not tried. \
+                             Re-run with --recover-fallback to recover from an older checkpoint \
+                             (changes committed after it may be missing).",
+                            checkpoint.path.display(),
+                            e
+                        )));
+                    }
                     log::warn!("Failed to load checkpoint {:?}: {}", checkpoint.path, e);
                     retries += 1;
+                    failures.push(format!("{}: {}", checkpoint.path.display(), e));
                     stats.corruption_detected = true;
+                    stats.skipped_checkpoints.push(SkippedCheckpoint {
+                        path: checkpoint.path.clone(),
+                        error: e.to_string(),
+                    });
                 }
             }
         }
 
-        // All checkpoints failed - start with empty database
-        log::warn!("All checkpoints failed to load, starting with empty database");
-        Ok((Database::new(), 0))
+        // Checkpoint files exist but none could be loaded — never open empty.
+        Err(StorageError::IoError(format!(
+            "all checkpoint(s) in {} failed to load ({}); refusing to open as an \
+             empty database — the checkpoint files are intact on disk",
+            self.checkpoint_dir.display(),
+            if failures.is_empty() {
+                stats
+                    .skipped_checkpoints
+                    .iter()
+                    .map(|s| format!("{}: {}", s.path.display(), s.error))
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            } else {
+                failures.join("; ")
+            }
+        )))
     }
 
-    /// List all checkpoint files sorted by LSN
-    fn list_checkpoints(&self) -> Result<Vec<CheckpointInfo>, StorageError> {
+    /// Enumerate all `.vchk` files in the checkpoint directory.
+    ///
+    /// Returns the readable checkpoints sorted by (LSN, id) ascending, plus the
+    /// files whose envelope header could not be read (and therefore cannot be
+    /// ordered).
+    fn enumerate_checkpoints(
+        &self,
+    ) -> Result<(Vec<CheckpointInfo>, Vec<SkippedCheckpoint>), StorageError> {
+        let mut checkpoints = Vec::new();
+        let mut unreadable = Vec::new();
+
         if !self.checkpoint_dir.exists() {
-            return Ok(Vec::new());
+            return Ok((checkpoints, unreadable));
         }
 
-        let checkpoint_writer = CheckpointWriter::new(&self.checkpoint_dir)?;
-        checkpoint_writer.list_checkpoints()
+        let entries = fs::read_dir(&self.checkpoint_dir).map_err(|e| {
+            StorageError::IoError(format!(
+                "Failed to read checkpoint dir {}: {}",
+                self.checkpoint_dir.display(),
+                e
+            ))
+        })?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().is_some_and(|ext| ext == "vchk") {
+                match CheckpointWriter::read_checkpoint_info(&path) {
+                    Ok(info) => checkpoints.push(info),
+                    Err(e) => {
+                        unreadable.push(SkippedCheckpoint { path, error: e.to_string() });
+                    }
+                }
+            }
+        }
+
+        // Same ordering contract as `CheckpointWriter::list_checkpoints`:
+        // (LSN, id) ascending so the newest state sorts last (issue #5766).
+        checkpoints.sort_by(|a, b| a.lsn.cmp(&b.lsn).then(a.id.cmp(&b.id)));
+        Ok((checkpoints, unreadable))
     }
 
     /// Load a specific checkpoint file and return the database and LSN
@@ -914,6 +1079,8 @@ mod tests {
         assert!(config.stop_on_corruption);
         assert_eq!(config.max_checkpoint_retries, 3);
         assert_eq!(config.progress_interval, 10000);
+        // #5807: silent fallback to an older checkpoint is opt-in only.
+        assert!(!config.allow_checkpoint_fallback);
     }
 
     #[test]
@@ -1579,5 +1746,203 @@ mod tests {
             }
             other => panic!("expected Insert, got {:?}", other),
         }
+    }
+
+    // ------------------------------------------------------------------
+    // Issue #5807: recovery must never silently present an empty or stale
+    // database. Forward-version checkpoints are always fatal; corrupt
+    // checkpoints are fatal unless fallback is explicitly opted into, and
+    // then every skipped file is recorded in `RecoveryStats`.
+    // ------------------------------------------------------------------
+
+    use crate::wal::checkpoint::crc32;
+
+    /// Write a real checkpoint for `db` at `lsn` and return its path.
+    fn write_db_checkpoint(dir: &Path, lsn: Lsn, db: &Database) -> PathBuf {
+        let mut writer = CheckpointWriter::new(dir).unwrap();
+        let data = db.to_uncompressed_bytes().unwrap();
+        let info = writer.create_checkpoint(lsn, &data, db.list_tables().len() as u32).unwrap();
+        info.path
+    }
+
+    /// Build a database containing a single table named `table_name`.
+    fn db_with_table(table_name: &str) -> Database {
+        let mut db = Database::new();
+        db.create_table(simple_schema(table_name)).unwrap();
+        db
+    }
+
+    /// Patch a checkpoint's *embedded* VBSQL snapshot version byte to
+    /// `VERSION + 1` and re-stamp the envelope CRC so the envelope remains
+    /// fully valid — exactly what a checkpoint written by a newer binary looks
+    /// like to this reader (mirrors the issue's reproduction).
+    ///
+    /// Checkpoint file layout: 32-byte envelope header (magic "VCHK" ...,
+    /// payload CRC32 at bytes 28..32), then the binary snapshot payload
+    /// (magic "VBSQL" at 32..37, format version byte at 37).
+    fn bump_embedded_format_version(path: &Path) {
+        let mut bytes = fs::read(path).unwrap();
+        assert_eq!(&bytes[..4], b"VCHK", "not a checkpoint envelope");
+        assert_eq!(&bytes[32..37], b"VBSQL", "payload is not a binary snapshot");
+        bytes[37] = crate::persistence::binary::format::VERSION + 1;
+        let crc = crc32(&bytes[32..]);
+        bytes[28..32].copy_from_slice(&crc.to_le_bytes());
+        fs::write(path, bytes).unwrap();
+    }
+
+    /// Corrupt a checkpoint's payload *without* fixing the envelope CRC, so
+    /// `read_checkpoint_data` fails its checksum verification.
+    fn corrupt_payload(path: &Path) {
+        let mut bytes = fs::read(path).unwrap();
+        assert!(bytes.len() > 40);
+        bytes[40] ^= 0xFF;
+        fs::write(path, bytes).unwrap();
+    }
+
+    fn fallback_config() -> RecoveryConfig {
+        RecoveryConfig { allow_checkpoint_fallback: true, ..Default::default() }
+    }
+
+    /// Newest checkpoint written by a newer binary → hard error, never a
+    /// fallback to the older checkpoint — with or without fallback enabled.
+    #[test]
+    fn test_forward_version_newest_checkpoint_is_hard_error() {
+        let temp_dir = TempDir::new().unwrap();
+        let dir = temp_dir.path().join("checkpoints");
+
+        write_db_checkpoint(&dir, 1, &db_with_table("older_state"));
+        let newest = write_db_checkpoint(&dir, 2, &db_with_table("newest_state"));
+        bump_embedded_format_version(&newest);
+
+        // Default config: hard error.
+        let err = RecoveryManager::new(&dir).recover().unwrap_err();
+        assert!(
+            matches!(err, StorageError::UnsupportedFormatVersion { .. }),
+            "expected UnsupportedFormatVersion, got: {err:?}"
+        );
+        assert!(err.to_string().contains("newer version of VibeSQL"), "message was: {err}");
+
+        // Even with fallback explicitly enabled: falling back past a
+        // forward-version checkpoint silently resurrects stale state.
+        let err = RecoveryManager::with_config(&dir, fallback_config()).recover().unwrap_err();
+        assert!(
+            matches!(err, StorageError::UnsupportedFormatVersion { .. }),
+            "fallback must not skip a forward-version checkpoint, got: {err:?}"
+        );
+    }
+
+    /// All checkpoints forward-version → hard error, never an empty database.
+    #[test]
+    fn test_all_forward_version_checkpoints_hard_error() {
+        let temp_dir = TempDir::new().unwrap();
+        let dir = temp_dir.path().join("checkpoints");
+
+        let only = write_db_checkpoint(&dir, 1, &db_with_table("future_state"));
+        bump_embedded_format_version(&only);
+
+        let err = RecoveryManager::new(&dir).recover().unwrap_err();
+        assert!(matches!(err, StorageError::UnsupportedFormatVersion { .. }), "got: {err:?}");
+    }
+
+    /// Corrupt newest checkpoint with a valid older one: default is a hard
+    /// error naming the file; opting into fallback loads the older checkpoint
+    /// and records the skip in `RecoveryStats`.
+    #[test]
+    fn test_corrupt_newest_checkpoint_default_error_fallback_optin() {
+        let temp_dir = TempDir::new().unwrap();
+        let dir = temp_dir.path().join("checkpoints");
+
+        write_db_checkpoint(&dir, 1, &db_with_table("older_state"));
+        let newest = write_db_checkpoint(&dir, 2, &db_with_table("newest_state"));
+        corrupt_payload(&newest);
+
+        // Default: refuse to open, naming the unreadable newest checkpoint.
+        let err = RecoveryManager::new(&dir).recover().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&newest.display().to_string()),
+            "error must name the unreadable checkpoint; was: {msg}"
+        );
+        assert!(msg.contains("recover-fallback"), "error must mention the opt-in; was: {msg}");
+
+        // Opt-in fallback: loads the older checkpoint and records the skip.
+        let (db, stats) = RecoveryManager::with_config(&dir, fallback_config()).recover().unwrap();
+        assert!(db.get_table("main.older_state").is_some(), "older state must be loaded");
+        assert!(db.get_table("main.newest_state").is_none());
+        assert!(stats.corruption_detected);
+        assert_eq!(stats.skipped_checkpoints.len(), 1);
+        assert_eq!(stats.skipped_checkpoints[0].path, newest);
+    }
+
+    /// Every checkpoint unreadable → hard error even with fallback enabled;
+    /// never an empty database when checkpoint files exist.
+    #[test]
+    fn test_all_checkpoints_corrupt_hard_error_even_with_fallback() {
+        let temp_dir = TempDir::new().unwrap();
+        let dir = temp_dir.path().join("checkpoints");
+
+        let a = write_db_checkpoint(&dir, 1, &db_with_table("state_a"));
+        let b = write_db_checkpoint(&dir, 2, &db_with_table("state_b"));
+        corrupt_payload(&a);
+        corrupt_payload(&b);
+
+        let err = RecoveryManager::new(&dir).recover().unwrap_err();
+        assert!(err.to_string().contains(&b.display().to_string()), "was: {err}");
+
+        let err = RecoveryManager::with_config(&dir, fallback_config()).recover().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("refusing to open") || msg.contains("failed to load"),
+            "all-corrupt must never yield Ok(empty); was: {msg}"
+        );
+    }
+
+    /// A checkpoint file whose envelope header itself is unreadable (bad
+    /// magic) cannot be LSN-ordered — it may be the newest state. Default:
+    /// hard error. Fallback: proceed from readable checkpoints, recording it.
+    #[test]
+    fn test_header_unreadable_checkpoint_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let dir = temp_dir.path().join("checkpoints");
+
+        write_db_checkpoint(&dir, 1, &db_with_table("good_state"));
+        let garbage = dir.join("checkpoint_9.vchk");
+        fs::write(&garbage, b"not a checkpoint at all").unwrap();
+
+        let err = RecoveryManager::new(&dir).recover().unwrap_err();
+        assert!(
+            err.to_string().contains(&garbage.display().to_string()),
+            "error must name the unreadable file; was: {err}"
+        );
+
+        let (db, stats) = RecoveryManager::with_config(&dir, fallback_config()).recover().unwrap();
+        assert!(db.get_table("main.good_state").is_some());
+        assert!(stats.corruption_detected);
+        assert_eq!(stats.skipped_checkpoints.len(), 1);
+        assert_eq!(stats.skipped_checkpoints[0].path, garbage);
+    }
+
+    /// `recover_with_base` seeds from the provided base only when no
+    /// checkpoint files exist (legacy snapshot-only `.vbsql`); any existing
+    /// checkpoint takes precedence.
+    #[test]
+    fn test_recover_with_base_seeds_only_without_checkpoints() {
+        let temp_dir = TempDir::new().unwrap();
+        let dir = temp_dir.path().join("checkpoints");
+
+        // No checkpoints: base wins.
+        let (db, stats) = RecoveryManager::new(&dir)
+            .recover_with_base(Some(db_with_table("legacy_snapshot")))
+            .unwrap();
+        assert!(db.get_table("main.legacy_snapshot").is_some());
+        assert_eq!(stats.checkpoint_lsn, 0);
+
+        // With a checkpoint present: checkpoint wins, base is ignored.
+        write_db_checkpoint(&dir, 1, &db_with_table("checkpointed"));
+        let (db, _stats) = RecoveryManager::new(&dir)
+            .recover_with_base(Some(db_with_table("legacy_snapshot")))
+            .unwrap();
+        assert!(db.get_table("main.checkpointed").is_some());
+        assert!(db.get_table("main.legacy_snapshot").is_none());
     }
 }


### PR DESCRIPTION
Closes #5807

## Problem

`RecoveryManager` downgraded every checkpoint failure to `log::warn` (unconditionally discarded — the CLI installs no log backend) and fell back to an older checkpoint or a brand-new empty database. A forward format version (file written by a newer binary) presented as total data loss: `sqlite_master` → 0 rows, exit 0, empty stderr — and any subsequent save checkpointed the emptiness as the newest state. Separately, `WalState::open` never read a legacy snapshot-only `.vbsql`, so those also opened silently empty under the WAL default.

## Failure policy now

1. **Forward format version is a typed hard error, always.** New `StorageError::UnsupportedFormatVersion { found, supported }`; `read_header` returns it, recovery propagates it (never falls back past it — older-checkpoint resurrection is also data loss), and every CLI open path surfaces "database written by a newer version of VibeSQL (format vN; this binary supports up to vM) — upgrade the vibesql binary; the data file is intact":
   - WAL path (`WalState::open_with_base`)
   - non-WAL `Database::load` path — the SQL-dump fallback at `executor/mod.rs` no longer masks it (extracted into `load_database_file`)
   - `vibesql export` (`run_export`)
2. **Unreadable/corrupt newest checkpoint is a hard error by default**, naming the file, the error, and the `--recover-fallback` opt-in. With `--recover-fallback` (`RecoveryConfig::allow_checkpoint_fallback`), recovery proceeds from the newest readable older checkpoint; every skipped file is recorded in `RecoveryStats::skipped_checkpoints` and printed prominently on **stderr** (`eprintln!`, not the discarded `log` facade), including the LSN actually loaded.
3. **All checkpoint files unreadable → hard error** listing what failed. Empty-DB start is legitimate only when no `.vchk` files exist. Checkpoint enumeration no longer silently drops header-unreadable `.vchk` files (they cannot be LSN-ordered, so one of them may be the newest state).
4. **Legacy snapshot-only `.vbsql`** (no checkpoint archive) is loaded as the recovery base on first WAL open (`RecoveryManager::recover_with_base`) instead of being silently ignored — the first session's checkpoint then preserves it.

Forward-version + valid newer-LSN WAL entries still hard-errors: checkpoint loading fails before WAL replay begins.

## Verification

- `cargo test -p vibesql-storage -p vibesql-cli` — all green (exit 0).
- New storage unit tests (`wal/recovery.rs`): forward-version newest / all checkpoints (hard error even with fallback enabled), corrupt newest (default error naming file + opt-in fallback with skip recording), header-unreadable garbage file, `recover_with_base` seeding semantics; plus `format.rs` typed-error test.
- New CLI subprocess integration tests (`crates/vibesql-cli/tests/recovery_failure_test.rs`, 5 tests): pin exit codes + stderr for the incident reproductions, "no new checkpoint written after a failed open", legacy snapshot data surviving the first WAL session, and fresh-DB still opens empty.
- Manual reproductions (debug binary, isolated `$HOME`, WAL default on):
  - **v12-bumped checkpoint** (embedded version byte + restamped CRC, per the curator's repro snippet): exit 1, stderr `database written by a newer version of VibeSQL (format v12; this binary supports up to v11)`; checkpoint file count unchanged after the failed open.
  - **Corrupt newest checkpoint, valid older present**: default open exits 1 naming `checkpoint_4.vchk` and the checksum mismatch, older checkpoints untried; `--recover-fallback` opens the older state with a two-part stderr WARNING (skipped file + "opened from an OLDER checkpoint (LSN 3)").
  - **Snapshot-only `.vbsql`** (written with `wal = false`, no checkpoints dir): opens under WAL default with its data (`SELECT id` → 42), survives reopen.
  - **Copy of the dogfooded results DB** (`~/.vibesql/test_results/tcl_test_results` checkpoints + WAL, copied to scratch): opens fine, `SELECT COUNT(*) FROM tcl_test_runs` → 3.
- `cargo fmt --check` clean; `cargo clippy -p vibesql-cli -p vibesql-storage --all-targets` exit 0 (remaining warnings are pre-existing in other crates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
