### PR TITLE
feat(executor): median/percentile/percentile_cont/percentile_disc aggregates (percentile.c)

### DIFF
--- a/crates/vibesql-executor/src/evaluator/operators/arithmetic/multiplication.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/arithmetic/multiplication.rs
@@ -34,9 +34,13 @@ impl Multiplication {
                 .checked_mul(b)
                 .map(Integer)
                 .unwrap_or_else(|| super::nan_to_null(Double(a as f64 * b as f64)))),
-            super::CoercedValues::ApproximateNumeric(a, b) => {
-                Ok(super::nan_to_null(Float((a * b) as f32)))
-            }
+            // ApproximateNumeric multiplication returns Real (f64) for SQLite
+            // compatibility. SQLite's REAL type is 8-byte IEEE floating point
+            // (f64), not 4-byte (f32) - squeezing the product through f32 loses
+            // precision that SQLite retains (e.g. 15*0.01 must be the f64
+            // product 0.15000000000000002, not f32's 0.15000000596). Mirrors
+            // the same fix in division.rs. (#5818)
+            super::CoercedValues::ApproximateNumeric(a, b) => Ok(super::nan_to_null(Real(a * b))),
             super::CoercedValues::Numeric(a, b) => Ok(super::nan_to_null(Numeric(a * b))),
         }
     }

--- a/crates/vibesql-executor/src/evaluator/window/aggregates.rs
+++ b/crates/vibesql-executor/src/evaluator/window/aggregates.rs
@@ -502,6 +502,61 @@ where
     max_val.unwrap_or(SqlValue::Null)
 }
 
+/// Evaluate a PERCENTILE-family aggregate window function over a frame.
+///
+/// Handles median(Y), percentile(Y,P), percentile_cont(Y,F) and
+/// percentile_disc(Y,F) by recomputing the ordered aggregate over each frame
+/// (collect + sort + interpolate). SQLite's percentile.c keeps a sorted array
+/// and uses an inverse function; per-frame recomputation produces identical
+/// observable results and is acceptable for conformance.
+///
+/// `fraction_expr` is the second argument (None for median). `func_name` must
+/// be the canonical lowercase name for SQLite-exact error messages.
+/// Errors (invalid/inconsistent fraction, non-numeric or Inf input) surface
+/// as `ExecutorError::SqliteCompatError` with percentile.c's exact wording.
+#[allow(clippy::too_many_arguments)]
+pub fn evaluate_percentile_window<F, I>(
+    partition: &Partition,
+    frame_indices: I,
+    arg_expr: &Expression,
+    fraction_expr: Option<&Expression>,
+    func_name: &str,
+    filter: Option<&Expression>,
+    eval_fn: F,
+) -> Result<SqlValue, crate::errors::ExecutorError>
+where
+    F: Fn(&Expression, &Row) -> Result<SqlValue, String>,
+    I: IntoIterator<Item = usize>,
+{
+    // Reuse the grouped-aggregate accumulator so the step/finalize semantics
+    // (validation, deferred errors, interpolation) live in exactly one place.
+    let mut acc = crate::select::grouping::AggregateAccumulator::new(func_name, false)?;
+
+    for idx in frame_indices {
+        if idx >= partition.len() {
+            continue;
+        }
+
+        let row = &partition.rows[idx];
+
+        // Check FILTER condition first
+        if !passes_filter(filter, row, &eval_fn) {
+            continue;
+        }
+
+        let fraction_value = match fraction_expr {
+            // An evaluation failure yields NULL, which the accumulator
+            // reports as an out-of-range fraction (matching SQLite).
+            Some(expr) => Some(eval_fn(expr, row).unwrap_or(SqlValue::Null)),
+            None => None,
+        };
+        let value = eval_fn(arg_expr, row).unwrap_or(SqlValue::Null);
+        acc.accumulate_percentile(&value, fraction_value.as_ref());
+    }
+
+    acc.finalize()
+}
+
 /// Evaluate GROUP_CONCAT aggregate window function over a frame
 ///
 /// Concatenates string values in the frame using the specified separator.

--- a/crates/vibesql-executor/src/evaluator/window/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/window/mod.rs
@@ -29,7 +29,7 @@ mod value;
 pub use aggregates::{
     evaluate_avg_window, evaluate_count_window, evaluate_group_concat_window,
     evaluate_group_concat_window_with_expr, evaluate_max_window, evaluate_min_window,
-    evaluate_sum_window, evaluate_total_window,
+    evaluate_percentile_window, evaluate_sum_window, evaluate_total_window,
 };
 pub use frames::{calculate_frame, calculate_frame_with_exclusion, validate_frame, validate_range_order_by, FrameResult};
 pub use partitioning::{partition_rows, partition_rows_with_collations, Partition};

--- a/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
@@ -421,7 +421,18 @@ fn expression_in_scope_chain_has_outer_correlated_aggregate(
         Expression::Function { name, args, .. }
             if matches!(
                 name.to_uppercase().as_str(),
-                "COUNT" | "SUM" | "AVG" | "TOTAL" | "MIN" | "MAX" | "GROUP_CONCAT" | "STRING_AGG"
+                "COUNT"
+                    | "SUM"
+                    | "AVG"
+                    | "TOTAL"
+                    | "MIN"
+                    | "MAX"
+                    | "GROUP_CONCAT"
+                    | "STRING_AGG"
+                    | "MEDIAN"
+                    | "PERCENTILE"
+                    | "PERCENTILE_CONT"
+                    | "PERCENTILE_DISC"
             ) =>
         {
             let upper = name.to_uppercase();
@@ -747,7 +758,18 @@ fn expr_has_column_referencing_aggregate(expr: &vibesql_ast::Expression) -> bool
         Expression::Function { name, args, .. }
             if matches!(
                 name.to_uppercase().as_str(),
-                "COUNT" | "SUM" | "AVG" | "TOTAL" | "MIN" | "MAX" | "GROUP_CONCAT" | "STRING_AGG"
+                "COUNT"
+                    | "SUM"
+                    | "AVG"
+                    | "TOTAL"
+                    | "MIN"
+                    | "MAX"
+                    | "GROUP_CONCAT"
+                    | "STRING_AGG"
+                    | "MEDIAN"
+                    | "PERCENTILE"
+                    | "PERCENTILE_CONT"
+                    | "PERCENTILE_DISC"
             ) =>
         {
             // Old Function variant aggregate. min/max with >1 args are scalar.
@@ -907,7 +929,8 @@ impl SelectExecutor<'_> {
                 // Check if this is an aggregate function name
                 let is_aggregate = match name_upper.as_str() {
                     "COUNT" | "SUM" | "AVG" | "TOTAL" | "GROUP_CONCAT" | "STRING_AGG"
-                    | "JSON_GROUP_ARRAY" | "MD5SUM" => true,
+                    | "JSON_GROUP_ARRAY" | "MD5SUM" | "MEDIAN" | "PERCENTILE"
+                    | "PERCENTILE_CONT" | "PERCENTILE_DISC" => true,
                     "MIN" | "MAX" => args.len() <= 1, // multi-arg min/max are scalar functions
                     _ => false,
                 };

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/aggregate_function.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/aggregate_function.rs
@@ -292,6 +292,24 @@ fn validate_aggregate_args(
             }
             Ok(())
         }
+        "MEDIAN" => {
+            // median(Y) requires exactly 1 argument (percentile.c)
+            if has_wildcard || arg_count != 1 {
+                return Err(ExecutorError::WrongNumberOfArguments {
+                    function_name: name.display().to_string(),
+                });
+            }
+            Ok(())
+        }
+        "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC" => {
+            // percentile(Y,P) family requires exactly 2 arguments (percentile.c)
+            if has_wildcard || arg_count != 2 {
+                return Err(ExecutorError::WrongNumberOfArguments {
+                    function_name: name.display().to_string(),
+                });
+            }
+            Ok(())
+        }
         _ => {
             // Unknown aggregate functions require at least 1 argument
             if arg_count == 0 {
@@ -424,6 +442,36 @@ pub(super) fn evaluate(
     // GROUP_CONCAT(expr ORDER BY ...) - sorted concatenation
     // STRING_AGG is an alias for GROUP_CONCAT (SQLite 3.44+)
     let name_upper = name.to_uppercase();
+
+    // Handle the PERCENTILE family (median/percentile/percentile_cont/
+    // percentile_disc). The second argument (the fraction P/F) is evaluated
+    // per row and validated inside the accumulator, mirroring SQLite's
+    // percentile.c step function (same per-row threading as GROUP_CONCAT's
+    // separator argument).
+    if matches!(
+        name_upper.as_str(),
+        "MEDIAN" | "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC"
+    ) {
+        let fraction_expr = args.get(1);
+        for row in group_rows {
+            evaluator.clear_cse_cache();
+            // Skip rows that don't pass the FILTER condition
+            if !passes_filter(row, evaluator)? {
+                continue;
+            }
+            let fraction_value = match fraction_expr {
+                Some(expr) => Some(evaluator.eval(expr, row)?),
+                None => None,
+            };
+            let value = evaluator.eval(&args[0], row)?;
+            acc.accumulate_percentile(&value, fraction_value.as_ref());
+        }
+
+        let result = acc.finalize()?;
+        executor.get_aggregate_cache().borrow_mut().insert(cache_key, result.clone());
+        return Ok(result);
+    }
+
     if name_upper == "GROUP_CONCAT" || name_upper == "STRING_AGG" {
         let separator = if args.len() == 2 {
             // Evaluate separator (second argument)

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/function.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/function.rs
@@ -27,7 +27,7 @@ pub(super) fn evaluate(
     let name_upper = name.to_uppercase();
     let is_aggregate = match name_upper.as_str() {
         "COUNT" | "SUM" | "AVG" | "TOTAL" | "GROUP_CONCAT" | "STRING_AGG" | "JSON_GROUP_ARRAY"
-        | "MD5SUM" => true,
+        | "MD5SUM" | "MEDIAN" | "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC" => true,
         "MIN" | "MAX" => args.len() <= 1, // multi-arg min/max are scalar functions
         _ => false,
     };

--- a/crates/vibesql-executor/src/select/executor/aggregation/window.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/window.rs
@@ -22,9 +22,9 @@ use crate::{
             calculate_frame_with_exclusion, evaluate_avg_window, evaluate_count_window,
             evaluate_cume_dist, evaluate_dense_rank, evaluate_group_concat_window_with_expr,
             evaluate_lag, evaluate_lead, evaluate_max_window, evaluate_min_window, evaluate_ntile,
-            evaluate_percent_rank, evaluate_rank, evaluate_row_number, evaluate_sum_window,
-            evaluate_total_window, partition_rows, sort_partition, validate_frame,
-            validate_range_order_by,
+            evaluate_percent_rank, evaluate_percentile_window, evaluate_rank, evaluate_row_number,
+            evaluate_sum_window, evaluate_total_window, partition_rows, sort_partition,
+            validate_frame, validate_range_order_by,
         },
         CombinedExpressionEvaluator,
     },
@@ -776,6 +776,27 @@ pub(super) fn apply_window_functions_to_aggregates(
                                     None,
                                     inner_eval_fn,
                                 )
+                            }
+                            "MEDIAN" | "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC" => {
+                                let fname = win_func.func_name.to_lowercase();
+                                let expected_args = if fname == "median" { 1 } else { 2 };
+                                if win_func.args.len() != expected_args {
+                                    return Err(ExecutorError::WrongNumberOfArguments {
+                                        function_name: fname,
+                                    });
+                                }
+                                // Fraction expression (second arg) is evaluated
+                                // per row via the mapped result column
+                                let fraction_expr = mapped_args.get(1);
+                                evaluate_percentile_window(
+                                    partition,
+                                    frame_indices,
+                                    &arg_expr,
+                                    fraction_expr,
+                                    &fname,
+                                    None,
+                                    inner_eval_fn,
+                                )?
                             }
                             other => {
                                 return Err(ExecutorError::UnsupportedExpression(format!(

--- a/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
@@ -14,7 +14,20 @@ use crate::{errors::ExecutorError, schema::CombinedSchema};
 /// Check if a function name is an aggregate function
 pub fn is_aggregate_function(name: &str) -> bool {
     let upper = name.to_uppercase();
-    matches!(upper.as_str(), "COUNT" | "SUM" | "AVG" | "MIN" | "MAX" | "TOTAL" | "GROUP_CONCAT")
+    matches!(
+        upper.as_str(),
+        "COUNT"
+            | "SUM"
+            | "AVG"
+            | "MIN"
+            | "MAX"
+            | "TOTAL"
+            | "GROUP_CONCAT"
+            | "MEDIAN"
+            | "PERCENTILE"
+            | "PERCENTILE_CONT"
+            | "PERCENTILE_DISC"
+    )
 }
 
 /// Action taken at each node during a generic expression walk.
@@ -211,6 +224,22 @@ pub fn check_aggregate_arg_count(expr: &Expression) -> Option<String> {
                         None
                     }
                 }
+                "MEDIAN" => {
+                    // median(Y) takes exactly 1 argument (percentile.c)
+                    if has_wildcard || arg_count != 1 {
+                        Some(name.display().to_string())
+                    } else {
+                        None
+                    }
+                }
+                "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC" => {
+                    // percentile family takes exactly 2 arguments (percentile.c)
+                    if has_wildcard || arg_count != 2 {
+                        Some(name.display().to_string())
+                    } else {
+                        None
+                    }
+                }
                 _ => None,
             }
         }
@@ -256,6 +285,20 @@ pub fn check_aggregate_arg_count(expr: &Expression) -> Option<String> {
                     }
                     "GROUP_CONCAT" => {
                         if arg_count == 0 || arg_count > 2 {
+                            Some(name.display().to_string())
+                        } else {
+                            None
+                        }
+                    }
+                    "MEDIAN" => {
+                        if has_wildcard || arg_count != 1 {
+                            Some(name.display().to_string())
+                        } else {
+                            None
+                        }
+                    }
+                    "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC" => {
+                        if has_wildcard || arg_count != 2 {
                             Some(name.display().to_string())
                         } else {
                             None

--- a/crates/vibesql-executor/src/select/grouping/aggregates.rs
+++ b/crates/vibesql-executor/src/select/grouping/aggregates.rs
@@ -68,6 +68,28 @@ pub enum AggregateAccumulator {
     },
     /// MD5SUM - Compute MD5 hash of concatenated values (SQLite TCL test compatible)
     Md5sum { values: Vec<String>, distinct: bool, seen: Option<HashSet<String>> },
+    /// PERCENTILE family - median(Y), percentile(Y,P), percentile_cont(Y,F),
+    /// percentile_disc(Y,F). Semantics match SQLite's percentile.c extension:
+    /// collect all non-NULL Y values, sort, then interpolate at
+    /// `fraction * (N-1)`. Errors (invalid/inconsistent fraction, non-numeric
+    /// or infinite Y) are deferred and raised at finalize time.
+    Percentile {
+        /// Collected Y values (non-NULL, finite)
+        values: Vec<f64>,
+        /// Normalized fraction (0.0..=1.0) captured from the first input row
+        fraction: Option<f64>,
+        /// Maximum raw fraction: 100.0 for percentile(), 1.0 for the others
+        mx_frac: f64,
+        /// True for percentile_disc() (no interpolation; picks a[floor(ix)])
+        discrete: bool,
+        /// True for median() (fixed fraction 0.5, no second argument)
+        is_median: bool,
+        /// Lowercase function name for SQLite-exact error messages
+        name: String,
+        /// First deferred error message (SQLite-exact), raised at finalize
+        error: Option<String>,
+        distinct: bool,
+    },
 }
 
 impl AggregateAccumulator {
@@ -120,6 +142,25 @@ impl AggregateAccumulator {
                 distinct,
                 seen: if distinct { Some(HashSet::new()) } else { None },
             }),
+            "MEDIAN" | "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC" => {
+                let upper = function_name.to_uppercase();
+                let (mx_frac, discrete, is_median, name) = match upper.as_str() {
+                    "PERCENTILE" => (100.0, false, false, "percentile"),
+                    "PERCENTILE_CONT" => (1.0, false, false, "percentile_cont"),
+                    "PERCENTILE_DISC" => (1.0, true, false, "percentile_disc"),
+                    _ => (1.0, false, true, "median"),
+                };
+                Ok(AggregateAccumulator::Percentile {
+                    values: Vec::new(),
+                    fraction: None,
+                    mx_frac,
+                    discrete,
+                    is_median,
+                    name: name.to_string(),
+                    error: None,
+                    distinct,
+                })
+            }
             _ => Err(crate::errors::ExecutorError::UnsupportedExpression(format!(
                 "Unknown aggregate function: {}",
                 function_name
@@ -350,6 +391,12 @@ impl AggregateAccumulator {
                 }
             }
 
+            // PERCENTILE family - single-argument form (median). Two-argument
+            // forms thread the per-row fraction through accumulate_percentile.
+            AggregateAccumulator::Percentile { .. } => {
+                self.accumulate_percentile(value, None);
+            }
+
             // MD5SUM - collects string values for MD5 hashing (like GROUP_CONCAT)
             AggregateAccumulator::Md5sum { ref mut values, distinct, seen } => {
                 // Skip NULL values like GROUP_CONCAT
@@ -414,6 +461,103 @@ impl AggregateAccumulator {
         }
     }
 
+    /// Accumulate one row for the PERCENTILE family of aggregates.
+    ///
+    /// `fraction_arg` is the per-row second argument (P/F) for
+    /// percentile()/percentile_cont()/percentile_disc(); it is `None` for
+    /// median(), which uses a fixed fraction of 0.5.
+    ///
+    /// Mirrors percentStep() in SQLite's ext/misc/percentile.c:
+    /// 1. The fraction is validated per row (numeric, in `0..=mx_frac`).
+    /// 2. The normalized fraction may differ from the first row's by at most
+    ///    0.001, else "not the same for all input rows".
+    /// 3. NULL Y values are skipped (NaN is treated as NULL, matching SQLite
+    ///    which stores NaN as NULL).
+    /// 4. Non-NULL non-numeric Y is an error (by type - no text coercion).
+    /// 5. +/-Inf Y is an error.
+    ///
+    /// Errors are deferred (recorded in `error`) and raised at finalize.
+    pub fn accumulate_percentile(
+        &mut self,
+        value: &vibesql_types::SqlValue,
+        fraction_arg: Option<&vibesql_types::SqlValue>,
+    ) {
+        let AggregateAccumulator::Percentile {
+            ref mut values,
+            ref mut fraction,
+            mx_frac,
+            is_median,
+            name,
+            ref mut error,
+            ..
+        } = self
+        else {
+            return;
+        };
+
+        if error.is_some() {
+            return;
+        }
+
+        // Requirement 3: fraction must be numeric and within range (per row).
+        let rpct = if *is_median && fraction_arg.is_none() {
+            0.5
+        } else {
+            let coerced = fraction_arg.and_then(percentile_fraction_as_number);
+            match coerced {
+                Some(p) if (0.0..=*mx_frac).contains(&p) => p / *mx_frac,
+                _ => {
+                    *error = Some(format!(
+                        "the fraction argument to {}() is not between 0.0 and {:.1}",
+                        name, mx_frac
+                    ));
+                    return;
+                }
+            }
+        };
+
+        // Requirement 2: the normalized fraction must match the first row's
+        // stored value to within 0.001 (percentSameValue in percentile.c).
+        match fraction {
+            None => *fraction = Some(rpct),
+            Some(first) => {
+                let diff = *first - rpct;
+                if !(-0.001..=0.001).contains(&diff) {
+                    *error = Some(format!(
+                        "the fraction argument to {}() is not the same for all input rows",
+                        name
+                    ));
+                    return;
+                }
+            }
+        }
+
+        // Requirement: NULL Y values are ignored.
+        if value.is_null() {
+            return;
+        }
+
+        // Requirement 4: non-NULL Y must be numeric BY TYPE (no coercion -
+        // TEXT '50' and blobs are errors, unlike most SQLite functions).
+        let Some(y) = percentile_numeric_y(value) else {
+            *error = Some(format!("input to {}() is not numeric", name));
+            return;
+        };
+
+        // SQLite interprets NaN as NULL, so a NaN Y is skipped, not an error.
+        if y.is_nan() {
+            return;
+        }
+
+        // Requirement 5: infinity is an error.
+        if y.is_infinite() {
+            *error = Some(format!("Inf input to {}()", name));
+            return;
+        }
+
+        values.push(y);
+    }
+
     pub fn finalize(&self) -> Result<vibesql_types::SqlValue, crate::errors::ExecutorError> {
         match self {
             AggregateAccumulator::Count { count, .. } => {
@@ -474,6 +618,39 @@ impl AggregateAccumulator {
                 // Convert values to JSON array string
                 let json_array = sql_values_to_json_array(values);
                 Ok(vibesql_types::SqlValue::Varchar(json_array.into()))
+            }
+            AggregateAccumulator::Percentile { values, fraction, discrete, error, distinct, .. } => {
+                // Deferred step errors surface at finalize time with the
+                // SQLite-exact message (SqliteCompatError displays as-is).
+                if let Some(msg) = error {
+                    return Err(crate::errors::ExecutorError::SqliteCompatError(msg.clone()));
+                }
+                if values.is_empty() {
+                    return Ok(vibesql_types::SqlValue::Null);
+                }
+                let mut sorted = values.clone();
+                // No NaN can be present (skipped during accumulation), so
+                // total_cmp == partial order here.
+                sorted.sort_by(f64::total_cmp);
+                if *distinct {
+                    sorted.dedup();
+                }
+                // percentCompute() in percentile.c: ix = fraction * (N-1);
+                // disc -> a[floor(ix)]; cont -> linear interpolation between
+                // the two neighbors. Result is always REAL.
+                let frac = fraction.unwrap_or(0.5);
+                let n = sorted.len();
+                let ix = frac * (n - 1) as f64;
+                let i1 = ix as usize;
+                let vx = if *discrete {
+                    sorted[i1]
+                } else {
+                    let i2 = if ix == i1 as f64 || i1 == n - 1 { i1 } else { i1 + 1 };
+                    let v1 = sorted[i1];
+                    let v2 = sorted[i2];
+                    v1 + (v2 - v1) * (ix - i1 as f64)
+                };
+                Ok(vibesql_types::SqlValue::Double(vx))
             }
             AggregateAccumulator::Md5sum { values, .. } => {
                 use md5::{Digest, Md5};
@@ -754,6 +931,46 @@ impl AggregateAccumulator {
                 }
             }
 
+            // PERCENTILE family: merge value lists, propagate deferred errors,
+            // and enforce fraction consistency across the two halves.
+            (
+                AggregateAccumulator::Percentile {
+                    values: v1,
+                    fraction: f1,
+                    error: e1,
+                    name,
+                    ..
+                },
+                AggregateAccumulator::Percentile {
+                    values: v2, fraction: f2, error: e2, ..
+                },
+            ) => {
+                if e1.is_none() {
+                    if let Some(msg) = e2 {
+                        *e1 = Some(msg);
+                    }
+                }
+                if e1.is_some() {
+                    return Ok(());
+                }
+                if let Some(b) = f2 {
+                    match *f1 {
+                        None => *f1 = Some(b),
+                        Some(a) => {
+                            let diff = a - b;
+                            if !(-0.001..=0.001).contains(&diff) {
+                                *e1 = Some(format!(
+                                    "the fraction argument to {}() is not the same for all input rows",
+                                    name
+                                ));
+                                return Ok(());
+                            }
+                        }
+                    }
+                }
+                v1.extend(v2);
+            }
+
             // MD5SUM: Merge value lists
             (
                 AggregateAccumulator::Md5sum { values: v1, distinct: d1, seen: seen1 },
@@ -831,6 +1048,46 @@ fn sql_value_to_f64(value: &vibesql_types::SqlValue) -> Option<f64> {
         vibesql_types::SqlValue::Float(x) => Some(*x as f64),
         vibesql_types::SqlValue::Real(x) => Some(*x as f64),
         vibesql_types::SqlValue::Double(x) => Some(*x),
+        _ => None,
+    }
+}
+
+/// Coerce the percentile fraction argument (P/F) to a number, mirroring
+/// sqlite3_value_numeric_type(): INTEGER/FLOAT pass through, TEXT converts
+/// only when it is a complete well-formed numeral, everything else (NULL,
+/// blob, non-numeric text) is invalid.
+fn percentile_fraction_as_number(value: &vibesql_types::SqlValue) -> Option<f64> {
+    use vibesql_types::SqlValue;
+    match value {
+        SqlValue::Integer(v) => Some(*v as f64),
+        SqlValue::Smallint(v) => Some(*v as f64),
+        SqlValue::Bigint(v) => Some(*v as f64),
+        SqlValue::Unsigned(v) => Some(*v as f64),
+        SqlValue::Float(v) => Some(*v as f64),
+        SqlValue::Real(v) => Some(*v as f64),
+        SqlValue::Double(v) => Some(*v),
+        SqlValue::Numeric(v) => Some(*v),
+        SqlValue::Boolean(b) => Some(if *b { 1.0 } else { 0.0 }),
+        SqlValue::Varchar(s) | SqlValue::Character(s) => s.trim().parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+/// Extract the percentile Y value as f64 when the value's TYPE is numeric.
+/// Unlike most SQLite aggregates, percentile does NOT coerce text/blob to a
+/// number - a non-NULL non-numeric Y is an error (percentile.c requirement 4).
+fn percentile_numeric_y(value: &vibesql_types::SqlValue) -> Option<f64> {
+    use vibesql_types::SqlValue;
+    match value {
+        SqlValue::Integer(v) => Some(*v as f64),
+        SqlValue::Smallint(v) => Some(*v as f64),
+        SqlValue::Bigint(v) => Some(*v as f64),
+        SqlValue::Unsigned(v) => Some(*v as f64),
+        SqlValue::Float(v) => Some(*v as f64),
+        SqlValue::Real(v) => Some(*v as f64),
+        SqlValue::Double(v) => Some(*v),
+        SqlValue::Numeric(v) => Some(*v),
+        SqlValue::Boolean(b) => Some(if *b { 1.0 } else { 0.0 }),
         _ => None,
     }
 }

--- a/crates/vibesql-executor/src/select/window/evaluation.rs
+++ b/crates/vibesql-executor/src/select/window/evaluation.rs
@@ -17,8 +17,9 @@ use crate::{
         window::{
             calculate_frame_with_exclusion, evaluate_avg_window, evaluate_count_window,
             evaluate_group_concat_window_with_expr, evaluate_max_window, evaluate_min_window,
-            evaluate_sum_window, evaluate_total_window, partition_rows_with_collations,
-            sort_partition_with_collations, validate_frame, validate_range_order_by, Partition,
+            evaluate_percentile_window, evaluate_sum_window, evaluate_total_window,
+            partition_rows_with_collations, sort_partition_with_collations, validate_frame,
+            validate_range_order_by, Partition,
         },
         CombinedExpressionEvaluator,
     },
@@ -760,6 +761,25 @@ fn evaluate_window_function_for_partition(
                             filter,
                             agg_eval_fn,
                         )
+                    }
+                    "MEDIAN" | "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC" => {
+                        let fname = func_name.to_lowercase();
+                        let expected_args = if fname == "median" { 1 } else { 2 };
+                        if args.len() != expected_args {
+                            return Err(ExecutorError::WrongNumberOfArguments {
+                                function_name: fname,
+                            });
+                        }
+                        let fraction_expr = args.get(1);
+                        evaluate_percentile_window(
+                            partition,
+                            frame_indices,
+                            &args[0],
+                            fraction_expr,
+                            &fname,
+                            filter,
+                            agg_eval_fn,
+                        )?
                     }
                     "JSON_GROUP_ARRAY" => {
                         if args.is_empty() {

--- a/crates/vibesql-executor/src/tests/aggregate_percentile_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_percentile_tests.rs
@@ -1,0 +1,391 @@
+//! PERCENTILE family aggregate tests: median(Y), percentile(Y,P),
+//! percentile_cont(Y,F), percentile_disc(Y,F)
+//!
+//! Semantics follow SQLite's ext/misc/percentile.c extension (built into
+//! modern SQLite by default). Expected values below were verified against
+//! sqlite3 3.51.0 (see issue #5818).
+
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+use super::super::*;
+use crate::select::grouping::AggregateAccumulator;
+
+/// Execute a SQL statement; errors are mapped through Display so that
+/// SQLite-exact messages (SqliteCompatError et al) can be asserted verbatim.
+fn execute_sql(db: &mut Database, sql: &str) -> Result<Vec<vibesql_storage::Row>, String> {
+    let stmt = Parser::parse_sql(sql).map_err(|e| e.message)?;
+
+    match stmt {
+        vibesql_ast::Statement::Select(select_stmt) => {
+            let executor = SelectExecutor::new(db);
+            executor.execute(&select_stmt).map_err(|e| e.to_string())
+        }
+        vibesql_ast::Statement::CreateTable(create_stmt) => {
+            CreateTableExecutor::execute(&create_stmt, db).map_err(|e| e.to_string())?;
+            Ok(vec![])
+        }
+        vibesql_ast::Statement::Insert(insert_stmt) => {
+            InsertExecutor::execute(db, &insert_stmt).map_err(|e| e.to_string())?;
+            Ok(vec![])
+        }
+        _ => Err("Unsupported statement type".to_string()),
+    }
+}
+
+/// Build the canonical percentile.test table:
+/// t1(x) = 1,4,6,7,8,9,11,11,11
+fn setup_t1(db: &mut Database) {
+    execute_sql(db, "CREATE TABLE t1(x REAL)").unwrap();
+    execute_sql(db, "INSERT INTO t1 VALUES(1),(4),(6),(7),(8),(9),(11),(11),(11)").unwrap();
+}
+
+/// Run a single-value aggregate query and return the Display form of the
+/// result (SQLite REAL formatting, e.g. "8.0").
+fn query_display(db: &mut Database, sql: &str) -> String {
+    let rows = execute_sql(db, sql).unwrap();
+    assert_eq!(rows.len(), 1, "expected a single row from {sql}");
+    rows[0].values[0].to_string()
+}
+
+#[test]
+fn test_percentile_basic_values() {
+    // sqlite3-verified: percentile(x,0) -> 1.0, percentile(x,15) -> 4.4,
+    // percentile(x,20) -> 5.2, percentile(x,50) -> 8.0, percentile(x,100) -> 11.0
+    let mut db = Database::new();
+    setup_t1(&mut db);
+
+    assert_eq!(query_display(&mut db, "SELECT percentile(x,0) FROM t1"), "1.0");
+    assert_eq!(query_display(&mut db, "SELECT percentile(x,15) FROM t1"), "4.4");
+    assert_eq!(query_display(&mut db, "SELECT percentile(x,20) FROM t1"), "5.2");
+    assert_eq!(query_display(&mut db, "SELECT percentile(x,50) FROM t1"), "8.0");
+    assert_eq!(query_display(&mut db, "SELECT percentile(x,100) FROM t1"), "11.0");
+    // The 11,11,11 tail: percentile(x,80) -> 11.0
+    assert_eq!(query_display(&mut db, "SELECT percentile(x,80) FROM t1"), "11.0");
+    assert_eq!(query_display(&mut db, "SELECT percentile(x,12.5) FROM t1"), "4.0");
+}
+
+#[test]
+fn test_percentile_cont_disc_median() {
+    let mut db = Database::new();
+    setup_t1(&mut db);
+
+    assert_eq!(query_display(&mut db, "SELECT percentile_cont(x,0.15) FROM t1"), "4.4");
+    assert_eq!(query_display(&mut db, "SELECT percentile_disc(x,0.15) FROM t1"), "4.0");
+    assert_eq!(query_display(&mut db, "SELECT percentile_disc(x,0.5) FROM t1"), "8.0");
+    // sqlite3-verified: median(x) -> 8.0
+    assert_eq!(query_display(&mut db, "SELECT median(x) FROM t1"), "8.0");
+}
+
+#[test]
+fn test_percentile_nulls_ignored() {
+    // sqlite3-verified after adding two NULLs: percentile(x,50) -> 8.0,
+    // percentile_cont(x,0.125) -> 4.0, percentile_disc(x,0.89) -> 11.0
+    let mut db = Database::new();
+    setup_t1(&mut db);
+    execute_sql(&mut db, "INSERT INTO t1 VALUES(NULL),(NULL)").unwrap();
+
+    assert_eq!(query_display(&mut db, "SELECT percentile(x,50) FROM t1"), "8.0");
+    assert_eq!(query_display(&mut db, "SELECT percentile_cont(x,0.125) FROM t1"), "4.0");
+    assert_eq!(query_display(&mut db, "SELECT percentile_disc(x,0.89) FROM t1"), "11.0");
+    assert_eq!(query_display(&mut db, "SELECT median(x) FROM t1"), "8.0");
+}
+
+#[test]
+fn test_percentile_empty_and_all_null_returns_null() {
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(x REAL)").unwrap();
+
+    // Empty table -> NULL (requirement 8)
+    let rows = execute_sql(&mut db, "SELECT percentile(x,50) FROM t1").unwrap();
+    assert_eq!(rows[0].values[0], SqlValue::Null);
+
+    // All-NULL input -> NULL
+    execute_sql(&mut db, "INSERT INTO t1 VALUES(NULL),(NULL)").unwrap();
+    let rows = execute_sql(&mut db, "SELECT median(x) FROM t1").unwrap();
+    assert_eq!(rows[0].values[0], SqlValue::Null);
+}
+
+#[test]
+fn test_percentile_single_value_always_real() {
+    // Requirement 9 + 11: one non-NULL value returns that value, always REAL
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(x)").unwrap();
+    execute_sql(&mut db, "INSERT INTO t1 VALUES(NULL),(12345),(NULL)").unwrap();
+
+    assert_eq!(query_display(&mut db, "SELECT percentile(x,0) FROM t1"), "12345.0");
+    assert_eq!(query_display(&mut db, "SELECT percentile(x,50) FROM t1"), "12345.0");
+    assert_eq!(query_display(&mut db, "SELECT percentile(x,100) FROM t1"), "12345.0");
+}
+
+#[test]
+fn test_percentile_integer_fraction_argument() {
+    // Fraction supplied as INTEGER must work (percentile(x,50), cont(x,1))
+    let mut db = Database::new();
+    setup_t1(&mut db);
+
+    assert_eq!(query_display(&mut db, "SELECT percentile_cont(x,1) FROM t1"), "11.0");
+    assert_eq!(query_display(&mut db, "SELECT percentile_cont(x,0) FROM t1"), "1.0");
+    assert_eq!(query_display(&mut db, "SELECT percentile_disc(x,1) FROM t1"), "11.0");
+}
+
+#[test]
+fn test_percentile_fraction_out_of_range_errors() {
+    // sqlite3-verified error strings (tests percentile-1.10 through 1.14.3)
+    let mut db = Database::new();
+    setup_t1(&mut db);
+
+    for sql in [
+        "SELECT percentile(x,null) FROM t1",
+        "SELECT percentile(x,'fifty') FROM t1",
+        "SELECT percentile(x,-0.0000001) FROM t1",
+        "SELECT percentile(x,100.0000001) FROM t1",
+    ] {
+        let err = execute_sql(&mut db, sql).unwrap_err();
+        assert_eq!(
+            err, "the fraction argument to percentile() is not between 0.0 and 100.0",
+            "wrong error for {sql}"
+        );
+    }
+
+    let err = execute_sql(&mut db, "SELECT percentile_cont(x,1.0000001) FROM t1").unwrap_err();
+    assert_eq!(err, "the fraction argument to percentile_cont() is not between 0.0 and 1.0");
+    let err = execute_sql(&mut db, "SELECT percentile_disc(x,1.0000001) FROM t1").unwrap_err();
+    assert_eq!(err, "the fraction argument to percentile_disc() is not between 0.0 and 1.0");
+}
+
+#[test]
+fn test_percentile_fraction_consistency() {
+    // percentile-1.4/1.5: P may vary by at most 0.001 (normalized) vs the
+    // FIRST row. 15+0.000001*rowid passes; 15+0.1*rowid errors.
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(id INTEGER, x REAL)").unwrap();
+    execute_sql(
+        &mut db,
+        "INSERT INTO t1 VALUES(1,1),(2,4),(3,6),(4,7),(5,8),(6,9),(7,11),(8,11),(9,11)",
+    )
+    .unwrap();
+
+    let rows =
+        execute_sql(&mut db, "SELECT round(percentile(x, 15+0.000001*id),1) FROM t1").unwrap();
+    assert_eq!(rows[0].values[0].to_string(), "4.4");
+
+    let err = execute_sql(&mut db, "SELECT percentile(x, 15+0.1*id) FROM t1").unwrap_err();
+    assert_eq!(err, "the fraction argument to percentile() is not the same for all input rows");
+    let err = execute_sql(&mut db, "SELECT percentile_cont(x, (15+0.1*id)*0.01) FROM t1")
+        .unwrap_err();
+    assert_eq!(
+        err,
+        "the fraction argument to percentile_cont() is not the same for all input rows"
+    );
+}
+
+#[test]
+fn test_percentile_tolerance_boundary_direct() {
+    // percentSameValue: |diff| <= 0.001 (on the NORMALIZED fraction P/100)
+    // is "same". All boundary expectations below are sqlite3 3.51.0-verified
+    // with the identical double arithmetic:
+    //   15.0 vs 15.0999 -> diff  -0.000999.. -> accepted
+    //   15.0 vs 15.1    -> diff  -0.0010000000000000009 (float rounding
+    //                      lands just OUTSIDE 0.001)   -> error
+    use vibesql_types::SqlValue as V;
+
+    // Just inside the tolerance: OK
+    let mut acc = AggregateAccumulator::new("PERCENTILE", false).unwrap();
+    acc.accumulate_percentile(&V::Double(1.0), Some(&V::Double(15.0)));
+    acc.accumulate_percentile(&V::Double(2.0), Some(&V::Double(15.0999)));
+    assert!(acc.finalize().is_ok(), "normalized diff just below 0.001 must be accepted");
+
+    // 15.0 vs 15.1: sqlite3-verified error (float diff exceeds 0.001)
+    let mut acc = AggregateAccumulator::new("PERCENTILE", false).unwrap();
+    acc.accumulate_percentile(&V::Double(1.0), Some(&V::Double(15.0)));
+    acc.accumulate_percentile(&V::Double(2.0), Some(&V::Double(15.1)));
+    let err = acc.finalize().unwrap_err().to_string();
+    assert_eq!(err, "the fraction argument to percentile() is not the same for all input rows");
+
+    // Clearly outside: error
+    let mut acc = AggregateAccumulator::new("PERCENTILE", false).unwrap();
+    acc.accumulate_percentile(&V::Double(1.0), Some(&V::Double(15.0)));
+    acc.accumulate_percentile(&V::Double(2.0), Some(&V::Double(15.2)));
+    assert!(acc.finalize().is_err());
+
+    // Comparison is anchored to the FIRST row's fraction, not the previous
+    // row's: 15.0, 15.0999, 15.1998 errors on the third row even though each
+    // adjacent step is within tolerance.
+    let mut acc = AggregateAccumulator::new("PERCENTILE", false).unwrap();
+    acc.accumulate_percentile(&V::Double(1.0), Some(&V::Double(15.0)));
+    acc.accumulate_percentile(&V::Double(2.0), Some(&V::Double(15.0999)));
+    acc.accumulate_percentile(&V::Double(3.0), Some(&V::Double(15.1998)));
+    assert!(acc.finalize().is_err(), "tolerance must be anchored to the first row");
+}
+
+#[test]
+fn test_percentile_non_numeric_input_errors() {
+    // Requirement 4: non-NULL non-numeric Y errors by TYPE - no coercion.
+    // TEXT '50' is an error even though it looks numeric (percentile-1.15).
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE t2(x)").unwrap();
+    execute_sql(&mut db, "INSERT INTO t2 VALUES('50'),(1)").unwrap();
+
+    let err = execute_sql(&mut db, "SELECT median(x) FROM t2").unwrap_err();
+    assert_eq!(err, "input to median() is not numeric");
+    let err = execute_sql(&mut db, "SELECT percentile(x, 50) FROM t2").unwrap_err();
+    assert_eq!(err, "input to percentile() is not numeric");
+    let err = execute_sql(&mut db, "SELECT percentile_cont(x, 0.5) FROM t2").unwrap_err();
+    assert_eq!(err, "input to percentile_cont() is not numeric");
+    let err = execute_sql(&mut db, "SELECT percentile_disc(x, 0.5) FROM t2").unwrap_err();
+    assert_eq!(err, "input to percentile_disc() is not numeric");
+}
+
+#[test]
+fn test_percentile_infinity_errors() {
+    // Requirement 5: +/-Inf input errors (percentile-1.20/1.21)
+    let mut db = Database::new();
+    setup_t1(&mut db);
+    execute_sql(&mut db, "INSERT INTO t1 VALUES(1.0e300*1.0e300)").unwrap();
+
+    let err = execute_sql(&mut db, "SELECT percentile(x,50) FROM t1").unwrap_err();
+    assert_eq!(err, "Inf input to percentile()");
+    let err = execute_sql(&mut db, "SELECT median(x) FROM t1").unwrap_err();
+    assert_eq!(err, "Inf input to median()");
+
+    let mut db = Database::new();
+    setup_t1(&mut db);
+    execute_sql(&mut db, "INSERT INTO t1 VALUES(-1.0e300*1.0e300)").unwrap();
+    let err = execute_sql(&mut db, "SELECT percentile(x,50) FROM t1").unwrap_err();
+    assert_eq!(err, "Inf input to percentile()");
+}
+
+#[test]
+fn test_percentile_wrong_number_of_arguments() {
+    // percentile-1.8/1.9: SQLite-exact arg-count errors
+    let mut db = Database::new();
+    setup_t1(&mut db);
+
+    for (sql, func) in [
+        ("SELECT percentile(x,0,1) FROM t1", "percentile"),
+        ("SELECT percentile_cont(x,0,1) FROM t1", "percentile_cont"),
+        ("SELECT percentile_disc(x,0,1) FROM t1", "percentile_disc"),
+        ("SELECT median(x,0) FROM t1", "median"),
+        ("SELECT percentile(x) FROM t1", "percentile"),
+        ("SELECT percentile_cont(x) FROM t1", "percentile_cont"),
+        ("SELECT percentile_disc(x) FROM t1", "percentile_disc"),
+        ("SELECT median() FROM t1", "median"),
+    ] {
+        let err = execute_sql(&mut db, sql).unwrap_err();
+        assert_eq!(
+            err,
+            format!("wrong number of arguments to function {func}()"),
+            "wrong error for {sql}"
+        );
+    }
+}
+
+#[test]
+fn test_percentile_random_input_order() {
+    // percentile-1.6/1.7: input order must not matter
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE t2(x REAL)").unwrap();
+    execute_sql(&mut db, "INSERT INTO t2 VALUES(11),(8),(1),(11),(9),(4),(11),(7),(6)").unwrap();
+
+    assert_eq!(query_display(&mut db, "SELECT percentile(x,50) FROM t2"), "8.0");
+    assert_eq!(query_display(&mut db, "SELECT percentile(x,15) FROM t2"), "4.4");
+    assert_eq!(query_display(&mut db, "SELECT percentile_disc(x,0.2) FROM t2"), "4.0");
+}
+
+#[test]
+fn test_median_group_by() {
+    // percentile-4.2: median with GROUP BY
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE products(vendorId INT, price REAL)").unwrap();
+    execute_sql(
+        &mut db,
+        "INSERT INTO products VALUES (1001,25.99),(1001,25.99),(1001,14.75),(1001,11.99),\
+         (1002,33.49),(1003,245.00),(1003,55.99),(1003,11.01),(1004,12.45),(1004,9.99)",
+    )
+    .unwrap();
+
+    let rows = execute_sql(
+        &mut db,
+        "SELECT vendorId, median(price) FROM products GROUP BY 1 ORDER BY 1",
+    )
+    .unwrap();
+    assert_eq!(rows.len(), 4);
+    let got: Vec<(String, String)> = rows
+        .iter()
+        .map(|r| (r.values[0].to_string(), r.values[1].to_string()))
+        .collect();
+    assert_eq!(
+        got,
+        vec![
+            ("1001".to_string(), "20.37".to_string()),
+            ("1002".to_string(), "33.49".to_string()),
+            ("1003".to_string(), "55.99".to_string()),
+            ("1004".to_string(), "11.22".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn test_median_window_function() {
+    // percentile-4.1 (abridged): median() as a window function with
+    // PARTITION BY
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE products(vendorId INT, price REAL)").unwrap();
+    execute_sql(
+        &mut db,
+        "INSERT INTO products VALUES (1001,25.99),(1001,25.99),(1001,14.75),(1001,11.99),\
+         (1002,33.49)",
+    )
+    .unwrap();
+
+    let rows = execute_sql(
+        &mut db,
+        "SELECT vendorId, median(price) OVER (PARTITION BY vendorId) FROM products \
+         ORDER BY vendorId",
+    )
+    .unwrap();
+    assert_eq!(rows.len(), 5);
+    for row in &rows[0..4] {
+        assert_eq!(row.values[1].to_string(), "20.37");
+    }
+    assert_eq!(rows[4].values[1].to_string(), "33.49");
+}
+
+#[test]
+fn test_percentile_window_function_with_fraction() {
+    // percentile-5.1 (abridged): percentile(cost, P) OVER (PARTITION BY class)
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE user(name TEXT, class TEXT, cost REAL)").unwrap();
+    execute_sql(
+        &mut db,
+        "INSERT INTO user VALUES ('Hank','W',24.99),('Irma','W',24.99),('Mia','W',59.53),\
+         ('Nate','W',23.50)",
+    )
+    .unwrap();
+
+    let rows = execute_sql(
+        &mut db,
+        "SELECT name, percentile(cost, 25) OVER (PARTITION BY class) FROM user ORDER BY name",
+    )
+    .unwrap();
+    assert_eq!(rows.len(), 4);
+    // sqlite3-verified: P25 of {23.5, 24.99, 24.99, 59.53} is 24.6175
+    for row in &rows {
+        assert_eq!(row.values[1].to_string(), "24.6175");
+    }
+}
+
+#[test]
+fn test_median_fuzzer_regression() {
+    // percentile-6.0 fuzzer find, sqlite3-verified -> 0.55
+    let mut db = Database::new();
+    let rows = execute_sql(
+        &mut db,
+        "WITH RECURSIVE c(n) AS (VALUES(1) UNION ALL SELECT n+1 FROM c WHERE n<12) \
+         SELECT median(iif(n%2,0.1,1.0)) FROM c",
+    )
+    .unwrap();
+    assert_eq!(rows[0].values[0].to_string(), "0.55");
+}

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -62,6 +62,7 @@ mod aggregate_edge_case_tests;
 mod aggregate_group_by_tests;
 mod aggregate_having_tests;
 mod aggregate_min_max_tests;
+mod aggregate_percentile_tests;
 mod aggregate_random_patterns;
 mod aggregate_without_from;
 mod alter_rename_collision;

--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -1164,7 +1164,18 @@ impl<'arena> ArenaParser<'arena> {
         // while MIN/MAX with a single argument are aggregate functions
         let might_be_aggregate = matches!(
             name_upper.as_str(),
-            "COUNT" | "SUM" | "AVG" | "MIN" | "MAX" | "GROUP_CONCAT" | "STRING_AGG" | "TOTAL"
+            "COUNT"
+                | "SUM"
+                | "AVG"
+                | "MIN"
+                | "MAX"
+                | "GROUP_CONCAT"
+                | "STRING_AGG"
+                | "TOTAL"
+                | "MEDIAN"
+                | "PERCENTILE"
+                | "PERCENTILE_CONT"
+                | "PERCENTILE_DISC"
         );
 
         if might_be_aggregate {
@@ -1192,6 +1203,8 @@ impl<'arena> ArenaParser<'arena> {
             let is_aggregate = match name_upper.as_str() {
                 "COUNT" | "SUM" | "AVG" | "TOTAL" => true,
                 "GROUP_CONCAT" | "STRING_AGG" => args.len() <= 2, // 1 or 2 args
+                // percentile.c family - arg counts validated by the executor
+                "MEDIAN" | "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC" => true,
                 "MIN" | "MAX" => args.len() <= 1 && !distinct,
                 _ => false,
             };

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -148,6 +148,10 @@ impl Parser {
                 | "STRING_AGG"
                 | "TOTAL"
                 | "JSON_GROUP_ARRAY"
+                | "MEDIAN"
+                | "PERCENTILE"
+                | "PERCENTILE_CONT"
+                | "PERCENTILE_DISC"
         );
 
         // Parse optional DISTINCT or ALL for potential aggregate functions
@@ -393,6 +397,9 @@ impl Parser {
             "COUNT" | "SUM" | "AVG" | "TOTAL" => true,
             "GROUP_CONCAT" | "STRING_AGG" => args.len() <= 2, // 1 or 2 args
             "JSON_GROUP_ARRAY" => true,                       // JSON aggregate function
+            // percentile.c family - arg counts validated by the executor so
+            // it can emit SQLite-exact "wrong number of arguments" errors
+            "MEDIAN" | "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC" => true,
             "MIN" | "MAX" => args.len() <= 1 && !distinct, // multi-arg or DISTINCT with >1 arg = scalar
             _ => false,
         };

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -5072,7 +5072,15 @@ proc check_single_capability {cap} {
     # errors with `no such column: rowid` (#5492). Marking it unsupported makes
     # `ifcapable !allow_rowid_in_view` blocks (e.g. trigger9-4.2/4.3) take their
     # error-expecting branch, matching real sqlite3 with the option off.
-    set unsupported_caps {wal vacuum_incr autovacuum stat4 stat3 tclvar vtab rtree fts3 fts4 fts5 conflict hiddencolumns progress allow_rowid_in_view}
+    # `ordered_set_aggregates` is the SQLITE_ENABLE_ORDERED_SET_AGGREGATES
+    # compile-time option (percentile_cont(F) WITHIN GROUP (ORDER BY x)),
+    # which is OFF by default in SQLite. VibeSQL matches the default: the
+    # WITHIN GROUP syntax errors with `near "(": syntax error`, exactly like
+    # a stock sqlite3 build. Marking it unsupported makes percentile.test's
+    # `ifcapable ordered_set_aggregates` blocks (~89 tests) skip and its
+    # else-branch (expecting the syntax error) run (#5818, 2026-07-03).
+    # WITHIN GROUP parser support is tracked as a follow-up to #5818.
+    set unsupported_caps {wal vacuum_incr autovacuum stat4 stat3 tclvar vtab rtree fts3 fts4 fts5 conflict hiddencolumns progress allow_rowid_in_view ordered_set_aggregates}
 
     # Handle negated capability (e.g., !autovacuum)
     set negate 0
@@ -5131,10 +5139,19 @@ proc ifcapable {args} {
         return
     }
 
+    # Propagate exceptional return codes (break/continue/return) from the
+    # evaluated script to the caller's frame, exactly like SQLite's real
+    # tester.tcl. Without `return -code`, a body like
+    #   ifcapable !ordered_set_aggregates break
+    # inside a foreach loop (percentile.test line 449) raises
+    # `invoked "break" outside of a loop` inside this proc and aborts the
+    # whole file evaluation mid-run (#5818).
     if {$result} {
-        uplevel 1 $script
+        set rc [catch {uplevel 1 $script} msg]
+        return -code $rc $msg
     } elseif {$else_script ne ""} {
-        uplevel 1 $else_script
+        set rc [catch {uplevel 1 $else_script} msg]
+        return -code $rc $msg
     }
 }
 


### PR DESCRIPTION
Closes #5818

## Summary

Implements SQLite's percentile.c extension family as native VibeSQL aggregates — `median(Y)`, `percentile(Y,P)`, `percentile_cont(Y,F)`, `percentile_disc(Y,F)` — in plain, GROUP BY, and window-function (OVER) forms.

**percentile.test: 5/209 passing before → 106/121 attempted-and-passing after** (0 failures attributable to the executor; details below).

## Implementation

- **Single accumulator** (`AggregateAccumulator::Percentile` in `crates/vibesql-executor/src/select/grouping/aggregates.rs`) implements percentile.c's percentStep/percentCompute: collect non-NULL numeric Y, sort, interpolate at `fraction*(N-1)` (`percentile_disc` picks `a[floor(ix)]`); result is always REAL. Both window paths (`evaluator/window/aggregates.rs::evaluate_percentile_window` and the two dispatchers) reuse it, so step/finalize semantics live in exactly one place.
- **SQLite-exact deferred errors**, raised at finalize with percentile.c's verbatim wording:
  - `the fraction argument to X() is not between 0.0 and 100.0` (or `1.0`)
  - `the fraction argument to X() is not the same for all input rows` (0.001 tolerance on the normalized fraction, anchored to the FIRST row)
  - `input to X() is not numeric` — by TYPE, no text coercion (TEXT `'50'` errors)
  - `Inf input to X()`; NaN Y is treated as NULL and skipped
  - `wrong number of arguments to function X()` (median: 1 arg; others: exactly 2)
- **Per-row fraction threading** in grouped and window evaluation (same pattern as GROUP_CONCAT's separator argument); accumulator `merge` supports parallel aggregation with cross-half fraction-consistency checks.
- **Detection/validation lists** extended in both parsers (recursive + arena) and the executor so the family participates in aggregation-context detection, correlated-subquery analysis, and arg-count validation.

## Supporting fixes

- **`multiplication.rs`**: approximate-numeric products now return `Real` (f64) instead of squeezing through f32, mirroring the existing division.rs fix. Load-bearing here: percentile.test computes fractions as `$in*0.01`, and the f32 product (0.15000000596...) skews interpolated results away from SQLite's exact values. `expr.test` (660 tests, arithmetic-heavy): 0 failures.
- **TCL shim**: `ordered_set_aggregates` marked unsupported — `WITHIN GROUP` requires SQLite's non-default `SQLITE_ENABLE_ORDERED_SET_AGGREGATES` compile option; stock sqlite3 errors with the same `near "(": syntax error` VibeSQL produces, and percentile.test's `ifcapable` else-branches expect exactly that. Parser support tracked in follow-up #5852.
- **TCL shim**: `ifcapable` now propagates break/continue/return via `return -code` (like SQLite's real tester.tcl). Previously `ifcapable !ordered_set_aggregates break` inside a foreach raised `invoked "break" outside of a loop` and aborted the whole file evaluation mid-run.

## Verification

- 17 new unit tests (`crates/vibesql-executor/src/tests/aggregate_percentile_tests.rs`) with expected values and error strings verified against sqlite3 3.51.0, including the fraction-tolerance boundary (15.0 vs 15.0999 accepted, 15.0 vs 15.1 rejected, anchoring to first row) and empty/all-NULL/single-value/Inf/NaN edges.
- Full `cargo test -p vibesql-executor`: pass (exit 0).
- `make test-tcl-file FILE=percentile.test`: 106 passed / 5 failed / 10 skipped (baseline on main: 5 passed / 185 failed).
- Regression files: `distinctagg.test` 0 failed, `expr.test` 0 failed. (`types3.test` fails 2/2 identically on main — pre-existing missing `tcl_variable_type` shim command, unrelated.)

## Remaining 5 failures are shim artifacts, not executor bugs

percentile-1.15.2–1.15.4, 1.16, 1.17 fail due to two pre-existing `tester_vibesql.tcl` transaction-machinery limitations (trial-check error misattribution across batched statements; multi-statement `ROLLBACK; BEGIN; ...` bodies flushed as one batch). The identical statement sequence produces the correct per-statement errors and results when run against the CLI directly. Full diagnosis and fix sketch filed as #5853.

## Follow-ups

- #5852 — `WITHIN GROUP (ORDER BY ...)` ordered-set aggregate syntax (~88 gated tests)
- #5853 — shim trial-check attribution + ROLLBACK;BEGIN batching (the remaining 5 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)