### PR TITLE
fix(storage): serialize concurrent CLI sessions with an exclusive lock on <stem>.lock

### DIFF
--- a/crates/vibesql-cli/src/config.rs
+++ b/crates/vibesql-cli/src/config.rs
@@ -57,6 +57,14 @@ pub struct DatabaseConfig {
     /// path (in-memory + SQL-dump snapshot on save/exit, no WAL sibling files).
     #[serde(default = "default_true")]
     pub wal: bool,
+
+    /// Busy timeout (milliseconds) for the exclusive inter-process database
+    /// lock (issue #5808). While another CLI session holds the same
+    /// file-backed database open, a new session retries acquiring the
+    /// `<stem>.lock` sibling for up to this long before failing with the
+    /// SQLite-compatible error `database is locked`. `0` = fail immediately.
+    #[serde(default = "default_lock_timeout_ms")]
+    pub lock_timeout_ms: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -102,6 +110,10 @@ fn default_sql_mode() -> String {
     "mysql".to_string()
 }
 
+fn default_lock_timeout_ms() -> u64 {
+    5000
+}
+
 impl Default for DisplayConfig {
     fn default() -> Self {
         DisplayConfig { format: default_format() }
@@ -115,6 +127,7 @@ impl Default for DatabaseConfig {
             auto_save: default_true(),
             sql_mode: default_sql_mode(),
             wal: default_true(),
+            lock_timeout_ms: default_lock_timeout_ms(),
         }
     }
 }
@@ -199,6 +212,29 @@ auto_save = true
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         assert!(config.database.wal);
+    }
+
+    #[test]
+    fn test_lock_timeout_defaults_when_unspecified() {
+        // A config that omits `lock_timeout_ms` must parse with the 5000 ms
+        // default (issue #5808).
+        let toml_str = r#"
+[database]
+wal = true
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.database.lock_timeout_ms, 5000);
+        assert_eq!(Config::default().database.lock_timeout_ms, 5000);
+    }
+
+    #[test]
+    fn test_lock_timeout_override_parses() {
+        let toml_str = r#"
+[database]
+lock_timeout_ms = 250
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.database.lock_timeout_ms, 250);
     }
 
     #[test]

--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -25,6 +25,12 @@ pub struct SqlExecutor {
     /// When `Some`, `save_database` checkpoints + truncates the WAL instead of
     /// writing a full snapshot. `None` preserves the default snapshot behavior.
     wal_state: Option<wal::WalState>,
+    /// Exclusive inter-process lock on the database (`<stem>.lock` sibling),
+    /// held for every file-backed session — WAL-active AND snapshot-only —
+    /// for the whole session (issue #5808). `None` for `:memory:` / no-path
+    /// sessions. Declared last so it drops AFTER `db` (and `wal_state`),
+    /// keeping the lock held through the exit-time checkpoint/save.
+    _db_lock: Option<vibesql_storage::DatabaseLock>,
 }
 
 #[derive(Debug, Clone)]
@@ -172,7 +178,7 @@ fn load_database_file(db_path: &str) -> anyhow::Result<Database> {
 ///
 /// Bundled into a struct so the `--recover-fallback` opt-in (issue #5807)
 /// threads through `Repl`/`ScriptExecutor` without growing a trail of bools.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy)]
 pub struct DbOpenOptions {
     /// Activate the WAL persistence path for file-backed databases
     /// (`[database] wal`, on by default).
@@ -181,6 +187,18 @@ pub struct DbOpenOptions {
     /// unreadable, recover from the newest readable older checkpoint instead
     /// of refusing to open. Skipped checkpoints are reported on stderr.
     pub recover_fallback: bool,
+    /// Busy timeout (milliseconds) for the exclusive inter-process database
+    /// lock (`[database] lock_timeout_ms`, default 5000). While another
+    /// session holds the same file-backed database, the open retries for up
+    /// to this long before failing with `database is locked`. `0` = fail
+    /// immediately.
+    pub lock_timeout_ms: u64,
+}
+
+impl Default for DbOpenOptions {
+    fn default() -> Self {
+        DbOpenOptions { wal: false, recover_fallback: false, lock_timeout_ms: 5000 }
+    }
 }
 
 impl SqlExecutor {
@@ -197,7 +215,7 @@ impl SqlExecutor {
     /// Create an executor with the given WAL setting and default recovery
     /// strictness (no checkpoint fallback).
     pub fn new_with_wal(database: Option<String>, wal: bool) -> anyhow::Result<Self> {
-        Self::new_with_options(database, DbOpenOptions { wal, recover_fallback: false })
+        Self::new_with_options(database, DbOpenOptions { wal, ..DbOpenOptions::default() })
     }
 
     /// Create an executor, optionally activating the opt-in WAL persistence path.
@@ -222,6 +240,41 @@ impl SqlExecutor {
     ) -> anyhow::Result<Self> {
         // Treat :memory: as an in-memory database (no file path)
         let database = database.filter(|p| !is_memory_database(p));
+
+        // Exclusive inter-process lock for EVERY file-backed session — WAL
+        // and snapshot-only alike (issue #5808). VibeSQL holds the whole
+        // database in memory and checkpoints/saves its own image, so two
+        // concurrent writers cannot be merged: the last save wins and
+        // clobbers the other session's committed writes. Acquired BEFORE any
+        // recovery/load so no other process can be mid-checkpoint while we
+        // read, and held (via `_db_lock`) until the executor drops — i.e.
+        // after the exit-time checkpoint/save.
+        //
+        // `:memory:` / no-path sessions take no lock and create no `.lock`
+        // file (`database` is already `None` for them here).
+        let db_lock = match database {
+            Some(ref db_path) => {
+                let lock = vibesql_storage::acquire_exclusive(
+                    std::path::Path::new(db_path),
+                    std::time::Duration::from_millis(options.lock_timeout_ms),
+                )
+                .map_err(|e| match e {
+                    // Exact SQLite CLI wording: `Error: database is locked`.
+                    vibesql_storage::StorageError::DatabaseLocked => anyhow::anyhow!("{}", e),
+                    other => anyhow::anyhow!("Failed to lock database at {}: {}", db_path, other),
+                })?;
+
+                // Safe only under the exclusive lock: remove stale temp stubs
+                // left by interrupted checkpoint/truncate writers
+                // (`checkpoint_*.tmp`, `<stem>.wal.tmp`). Completed `.vchk`
+                // files are never touched.
+                let paths = wal::WalPaths::derive(db_path);
+                vibesql_storage::cleanup_stale_temp_files(&paths.wal_path, &paths.checkpoint_dir);
+
+                Some(lock)
+            }
+            None => None,
+        };
 
         // WAL-active path: only when explicitly opted in AND a file path exists.
         // For in-memory databases the WAL is silently disabled (no file to
@@ -268,6 +321,7 @@ impl SqlExecutor {
                     timing_enabled: false,
                     count_changes: false,
                     wal_state: Some(wal_state),
+                    _db_lock: db_lock,
                 });
             }
         }
@@ -292,7 +346,13 @@ impl SqlExecutor {
         vibesql_executor::rebuild_pending_expression_indexes(&mut db)
             .map_err(|e| anyhow::anyhow!("Failed to rebuild expression indexes: {}", e))?;
 
-        Ok(SqlExecutor { db, timing_enabled: false, count_changes: false, wal_state: None })
+        Ok(SqlExecutor {
+            db,
+            timing_enabled: false,
+            count_changes: false,
+            wal_state: None,
+            _db_lock: db_lock,
+        })
     }
 
     /// Returns true if the WAL persistence path is active for this session.

--- a/crates/vibesql-cli/src/main.rs
+++ b/crates/vibesql-cli/src/main.rs
@@ -264,6 +264,10 @@ fn main() -> anyhow::Result<()> {
     let open_options = executor::DbOpenOptions {
         wal: config.database.wal,
         recover_fallback: args.recover_fallback,
+        // Inter-process lock busy timeout (issue #5808): a second session on
+        // the same file-backed database waits up to this long, then fails
+        // with the SQLite-compatible `database is locked`.
+        lock_timeout_ms: config.database.lock_timeout_ms,
     };
 
     if let Some(cmd) = args.command {

--- a/crates/vibesql-cli/tests/locking_test.rs
+++ b/crates/vibesql-cli/tests/locking_test.rs
@@ -1,0 +1,456 @@
+// ============================================================================
+// Inter-Process Locking Integration Tests — issue #5808
+// ============================================================================
+//
+// VibeSQL holds the whole database in memory and checkpoints its own image,
+// so concurrent CLI writer sessions cannot be merged: they race on WAL
+// appends, checkpoint IDs, and WAL truncation (last writer clobbers). The
+// fix is a whole-session EXCLUSIVE advisory lock (`std::fs::File::try_lock`,
+// flock on Unix) on a dedicated `<stem>.lock` sibling, taken by every
+// file-backed open — WAL-active and snapshot-only alike.
+//
+// These tests spawn real `vibesql` subprocesses (CARGO_BIN_EXE_vibesql) and
+// use MARKER-BASED synchronization, never fixed sleeps for correctness:
+//
+//   * WAL sibling files (`<stem>.wal` / `<stem>-checkpoints/`) are created strictly AFTER lock
+//     acquisition during open, so their appearance proves the holder owns the lock.
+//   * For the snapshot-only (`wal = false`) path — which creates no sibling files — a zero-timeout
+//     probe subprocess is retried until it observes `database is locked`, which is itself the proof
+//     the holder owns the lock.
+//
+// All poll loops use generous (60 s) deadlines so a loaded parallel test
+// runner cannot produce false failures.
+
+#![cfg(unix)]
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+fn vibesql_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_vibesql")
+}
+
+/// Generous deadline for all poll loops (loaded machines, parallel tests).
+const POLL_DEADLINE: Duration = Duration::from_secs(60);
+const POLL_STEP: Duration = Duration::from_millis(25);
+
+/// Write a `~/.vibesqlrc` into `home` with the given `[database]` body.
+fn write_config(home: &Path, database_section: &str) {
+    fs::write(home.join(".vibesqlrc"), format!("[database]\n{database_section}\n")).unwrap();
+}
+
+/// Derive the WAL sibling paths the CLI uses (mirrors `WalPaths::derive`).
+fn wal_siblings(db_path: &Path) -> (PathBuf, PathBuf) {
+    let wal = db_path.with_extension("wal");
+    let stem = db_path.file_stem().unwrap().to_string_lossy().to_string();
+    let dir = db_path.parent().unwrap().join(format!("{stem}-checkpoints"));
+    (wal, dir)
+}
+
+/// Spawn a `vibesql` session that OPENS the database and then HOLDS it open,
+/// blocked reading stdin (script mode reads stdin to EOF; the executor — and
+/// with it the exclusive lock — is created before any stdin is read).
+///
+/// Returns the child; drop/close its stdin to let it run to a clean exit.
+fn spawn_holder(db_path: &Path, home: &Path) -> Child {
+    Command::new(vibesql_binary())
+        .arg("--database")
+        .arg(db_path.as_os_str())
+        .env("HOME", home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn holder vibesql")
+}
+
+/// Marker-based wait: block until the holder has acquired the lock, proven by
+/// the WAL sibling files, which the CLI creates strictly AFTER acquisition.
+fn wait_until_holder_owns_lock_wal(db_path: &Path) {
+    let (wal_path, ckpt_dir) = wal_siblings(db_path);
+    let deadline = Instant::now() + POLL_DEADLINE;
+    while !(wal_path.exists() || ckpt_dir.exists()) {
+        assert!(
+            Instant::now() < deadline,
+            "holder never created WAL siblings (never finished opening?)"
+        );
+        thread::sleep(POLL_STEP);
+    }
+}
+
+/// Run a short-lived `vibesql <db> -c <sql>` session and return
+/// `(success, stdout, stderr)`.
+fn run_command_session(db_path: &Path, home: &Path, sql: &str) -> (bool, String, String) {
+    let output = Command::new(vibesql_binary())
+        .arg("--database")
+        .arg(db_path.as_os_str())
+        .arg("-c")
+        .arg(sql)
+        .env("HOME", home)
+        .output()
+        .expect("failed to run vibesql -c session");
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+/// Marker-based wait for the snapshot-only path (no WAL sibling files):
+/// retry a ZERO-timeout probe session until it reports `database is locked` —
+/// the observation itself proves the holder owns the lock.
+fn wait_until_holder_owns_lock_probe(db_path: &Path, probe_home: &Path) {
+    let deadline = Instant::now() + POLL_DEADLINE;
+    loop {
+        let (ok, _out, err) = run_command_session(db_path, probe_home, "SELECT 1;");
+        if !ok && err.contains("database is locked") {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "probe never observed the lock held (holder never acquired?); last: ok={ok} err={err}"
+        );
+        thread::sleep(POLL_STEP);
+    }
+}
+
+// ----------------------------------------------------------------------------
+// (a) Second writer blocked, then times out with `database is locked`
+// ----------------------------------------------------------------------------
+
+/// While one session holds a file-backed database open, a second
+/// `vibesql <db> -c "INSERT ..."` must exit non-zero after its busy timeout
+/// with stderr containing the exact SQLite wording `database is locked`.
+/// After the holder exits cleanly, the same command must succeed.
+#[test]
+fn test_second_writer_times_out_with_database_is_locked() {
+    let home_a = tempfile::tempdir().unwrap();
+    let home_b = tempfile::tempdir().unwrap();
+    // Short busy timeout for B so the negative case is fast.
+    write_config(home_b.path(), "lock_timeout_ms = 300");
+
+    let db_path = home_a.path().join("contended.vbsql");
+
+    let mut holder = spawn_holder(&db_path, home_a.path());
+    wait_until_holder_owns_lock_wal(&db_path);
+
+    // Second writer: must wait out its 300 ms busy timeout, then fail loudly.
+    let started = Instant::now();
+    let (ok, _out, err) = run_command_session(
+        &db_path,
+        home_b.path(),
+        "CREATE TABLE intruder (id INTEGER); INSERT INTO intruder VALUES (1);",
+    );
+    assert!(!ok, "second writer must exit non-zero while the database is held");
+    assert!(
+        err.contains("database is locked"),
+        "stderr must contain the exact SQLite wording `database is locked`; got:\n{err}"
+    );
+    assert!(
+        started.elapsed() >= Duration::from_millis(300),
+        "second writer must wait out the busy timeout before failing"
+    );
+
+    // Release: close the holder's stdin; it runs its (empty) script and exits
+    // cleanly, dropping the lock.
+    drop(holder.stdin.take());
+    let status = holder.wait().expect("holder wait");
+    assert!(status.success(), "holder must exit cleanly");
+
+    // The lock is released on clean exit: the same command now succeeds.
+    let (ok, _out, err) = run_command_session(
+        &db_path,
+        home_b.path(),
+        "CREATE TABLE intruder (id INTEGER); INSERT INTO intruder VALUES (1);",
+    );
+    assert!(ok, "writer must succeed after the holder released the lock; stderr:\n{err}");
+}
+
+// ----------------------------------------------------------------------------
+// (a2) Brief overlap shorter than the busy timeout succeeds (waits, acquires)
+// ----------------------------------------------------------------------------
+
+/// A second session started during an overlap shorter than its busy timeout
+/// must NOT fail: it waits in the retry loop and acquires once the holder
+/// releases.
+#[test]
+fn test_waiter_within_busy_timeout_succeeds_after_release() {
+    let home_a = tempfile::tempdir().unwrap();
+    let home_b = tempfile::tempdir().unwrap();
+    // Generous busy timeout: B must outlast the overlap comfortably.
+    write_config(home_b.path(), "lock_timeout_ms = 60000");
+
+    let db_path = home_a.path().join("overlap.vbsql");
+
+    let mut holder = spawn_holder(&db_path, home_a.path());
+    wait_until_holder_owns_lock_wal(&db_path);
+
+    // Spawn B while A verifiably holds the lock. B enters the retry loop.
+    let mut waiter = Command::new(vibesql_binary())
+        .arg("--database")
+        .arg(db_path.as_os_str())
+        .arg("-c")
+        .arg("CREATE TABLE waited (id INTEGER); INSERT INTO waited VALUES (42);")
+        .env("HOME", home_b.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn waiter");
+
+    // B must still be alive while A holds the lock (it is waiting, not dead).
+    // Bounded observation window — this can only under-observe on a slow
+    // machine, never produce a false failure.
+    let observe_until = Instant::now() + Duration::from_millis(500);
+    while Instant::now() < observe_until {
+        assert!(
+            waiter.try_wait().expect("try_wait").is_none(),
+            "waiter must block while the holder owns the lock, not exit"
+        );
+        thread::sleep(POLL_STEP);
+    }
+
+    // Release the holder; the waiter must then acquire and succeed.
+    drop(holder.stdin.take());
+    assert!(holder.wait().expect("holder wait").success());
+
+    let out = waiter.wait_with_output().expect("waiter wait");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "waiter within its busy timeout must succeed after release; stderr:\n{err}"
+    );
+
+    // And its write is durably visible to a fresh session.
+    let (ok, stdout, _err) = run_command_session(&db_path, home_b.path(), "SELECT id FROM waited;");
+    assert!(ok);
+    assert!(stdout.contains("42"), "waiter's committed row must be visible; got:\n{stdout}");
+}
+
+// ----------------------------------------------------------------------------
+// (b) SIGKILL of the holder: kernel releases the lock, next open is immediate
+// ----------------------------------------------------------------------------
+
+/// After SIGKILL of the lock holder, a subsequent open must succeed
+/// IMMEDIATELY (zero busy timeout) — kernel advisory locks die with the
+/// process; there is no stale-lock recovery step.
+#[test]
+fn test_sigkill_holder_releases_lock_immediately() {
+    let home_a = tempfile::tempdir().unwrap();
+    let home_b = tempfile::tempdir().unwrap();
+    // Zero timeout: the reopen below must succeed on the FIRST attempt.
+    write_config(home_b.path(), "lock_timeout_ms = 0");
+
+    let db_path = home_a.path().join("killed.vbsql");
+
+    let mut holder = spawn_holder(&db_path, home_a.path());
+    wait_until_holder_owns_lock_wal(&db_path);
+
+    // Hard kill — no graceful shutdown, no drop handlers, no unlock call.
+    holder.kill().expect("kill holder");
+    holder.wait().expect("reap holder");
+
+    // The very next open (zero busy timeout!) must acquire without retrying.
+    let (ok, _out, err) = run_command_session(
+        &db_path,
+        home_b.path(),
+        "CREATE TABLE after_kill (id INTEGER); INSERT INTO after_kill VALUES (7);",
+    );
+    assert!(ok, "open after SIGKILL of the holder must succeed immediately; stderr:\n{err}");
+}
+
+// ----------------------------------------------------------------------------
+// (c) Stale checkpoint_*.tmp stubs and <stem>.wal.tmp cleaned on next open
+// ----------------------------------------------------------------------------
+
+/// Pre-seed the 32-byte `checkpoint_*.tmp` stubs (exactly what interrupted
+/// checkpoint writers leave — one bare `CheckpointHeader`, zero data) plus a
+/// `<stem>.wal.tmp` truncate scratch file, then open the database: both must
+/// be removed, completed `.vchk` checkpoints must be untouched, and the data
+/// must still be there.
+#[test]
+fn test_stale_tmp_stubs_cleaned_on_next_open() {
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("stubs.vbsql");
+    let (wal_path, ckpt_dir) = wal_siblings(&db_path);
+
+    // Session 1: create real durable state (checkpoint archive + WAL).
+    let (ok, _out, err) = run_command_session(
+        &db_path,
+        home.path(),
+        "CREATE TABLE keep (id INTEGER); INSERT INTO keep VALUES (1);",
+    );
+    assert!(ok, "seed session failed: {err}");
+    assert!(ckpt_dir.exists(), "seed session must create the checkpoint archive");
+
+    // Record the completed checkpoints that must survive cleanup untouched.
+    let vchk_before: Vec<PathBuf> = fs::read_dir(&ckpt_dir)
+        .unwrap()
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|x| x == "vchk"))
+        .collect();
+    assert!(!vchk_before.is_empty(), "seed session must have written a .vchk checkpoint");
+
+    // Pre-seed the stale temp files an interrupted writer would leave behind.
+    let stub_a = ckpt_dir.join("checkpoint_9998.tmp");
+    let stub_b = ckpt_dir.join("checkpoint_9999.tmp");
+    let wal_tmp = wal_path.with_extension("wal.tmp");
+    fs::write(&stub_a, [0u8; 32]).unwrap();
+    fs::write(&stub_b, [0u8; 32]).unwrap();
+    fs::write(&wal_tmp, b"orphaned truncate scratch").unwrap();
+
+    // Session 2: opening the database must clean the stubs (under the
+    // exclusive lock, before recovery) and still see the committed data.
+    let (ok, stdout, err) = run_command_session(&db_path, home.path(), "SELECT id FROM keep;");
+    assert!(ok, "reopen over stale stubs failed: {err}");
+    assert!(stdout.contains("1"), "committed row must survive; got:\n{stdout}");
+
+    assert!(!stub_a.exists(), "stale checkpoint_*.tmp stub must be removed on open");
+    assert!(!stub_b.exists(), "stale checkpoint_*.tmp stub must be removed on open");
+    assert!(!wal_tmp.exists(), "stale <stem>.wal.tmp must be removed on open");
+    for vchk in &vchk_before {
+        assert!(vchk.exists(), "completed checkpoint {} must be untouched", vchk.display());
+    }
+
+    // The lock sibling exists and is left in place (never renamed/deleted).
+    assert!(db_path.with_extension("lock").exists(), ".lock sibling must be left in place");
+}
+
+// ----------------------------------------------------------------------------
+// Snapshot-only mode (wal = false) takes the same lock
+// ----------------------------------------------------------------------------
+
+/// The snapshot-only path has the same last-writer-wins clobber, so it must
+/// be protected by the same whole-session exclusive lock.
+#[test]
+fn test_snapshot_only_mode_is_locked_too() {
+    let home_a = tempfile::tempdir().unwrap();
+    let home_b = tempfile::tempdir().unwrap();
+    write_config(home_a.path(), "wal = false");
+    write_config(home_b.path(), "wal = false\nlock_timeout_ms = 0");
+
+    let db_path = home_a.path().join("snapshot.vbsql");
+
+    let mut holder = spawn_holder(&db_path, home_a.path());
+    // No WAL siblings in snapshot-only mode: the zero-timeout probe observing
+    // `database is locked` IS the marker that the holder owns the lock.
+    wait_until_holder_owns_lock_probe(&db_path, home_b.path());
+
+    // Clean release: a subsequent session succeeds.
+    drop(holder.stdin.take());
+    assert!(holder.wait().expect("holder wait").success());
+
+    let (ok, _out, err) = run_command_session(&db_path, home_b.path(), "SELECT 1;");
+    assert!(ok, "snapshot-only session must succeed after release; stderr:\n{err}");
+}
+
+// ----------------------------------------------------------------------------
+// :memory: and no-database sessions take no lock and create no .lock file
+// ----------------------------------------------------------------------------
+
+#[test]
+fn test_memory_and_no_database_sessions_create_no_lock_file() {
+    let home = tempfile::tempdir().unwrap();
+    let workdir = tempfile::tempdir().unwrap();
+
+    let no_lock_files = |dir: &Path| {
+        fs::read_dir(dir)
+            .unwrap()
+            .flatten()
+            .all(|e| e.path().extension().is_none_or(|x| x != "lock"))
+    };
+
+    // :memory: session.
+    let status = Command::new(vibesql_binary())
+        .arg("--database")
+        .arg(":memory:")
+        .arg("-c")
+        .arg("SELECT 1;")
+        .env("HOME", home.path())
+        .current_dir(workdir.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("run :memory: session");
+    assert!(status.success());
+
+    // No-database session.
+    let status = Command::new(vibesql_binary())
+        .arg("-c")
+        .arg("SELECT 1;")
+        .env("HOME", home.path())
+        .current_dir(workdir.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("run no-database session");
+    assert!(status.success());
+
+    assert!(no_lock_files(workdir.path()), "no .lock file may be created in the working dir");
+    assert!(no_lock_files(home.path()), "no .lock file may be created in $HOME");
+}
+
+// ----------------------------------------------------------------------------
+// (d) TCL-shim flow: serial short-lived -c subprocesses keep working
+// ----------------------------------------------------------------------------
+
+/// The TCL runner touches its shared results database only through SERIAL,
+/// short-lived `vibesql <db> -c "..."` subprocesses. Each acquires and
+/// releases the exclusive lock in turn; none may ever see `database is
+/// locked`. (Uses the default 5000 ms busy timeout, like the real shim.)
+#[test]
+fn test_serial_short_lived_sessions_never_contend() {
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("results.vbsql");
+
+    let (ok, _out, err) = run_command_session(
+        &db_path,
+        home.path(),
+        "CREATE TABLE log (id INTEGER PRIMARY KEY, note VARCHAR(20));",
+    );
+    assert!(ok, "create failed: {err}");
+
+    for i in 1..=5 {
+        let (ok, _out, err) = run_command_session(
+            &db_path,
+            home.path(),
+            &format!("INSERT INTO log VALUES ({i}, 'run {i}');"),
+        );
+        assert!(ok, "serial session {i} failed: {err}");
+        assert!(
+            !err.contains("database is locked"),
+            "serial sessions must never contend; session {i} stderr:\n{err}"
+        );
+    }
+
+    let (ok, stdout, err) = run_command_session(&db_path, home.path(), "SELECT COUNT(*) FROM log;");
+    assert!(ok, "count failed: {err}");
+    assert!(stdout.contains("5"), "all 5 serial writes must be durable; got:\n{stdout}");
+}
+
+// ----------------------------------------------------------------------------
+// The lock file itself is never locked-out by leftovers: repeated sessions
+// reuse the same `<stem>.lock` (left in place on exit by design).
+// ----------------------------------------------------------------------------
+
+#[test]
+fn test_lock_file_left_in_place_and_reused() {
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("reuse.vbsql");
+    let lock_path = db_path.with_extension("lock");
+
+    let (ok, _out, _err) =
+        run_command_session(&db_path, home.path(), "CREATE TABLE r (id INTEGER);");
+    assert!(ok);
+    assert!(lock_path.exists(), ".lock must exist after a file-backed session");
+
+    // Second session with the leftover .lock present: must open fine.
+    let (ok, _out, err) = run_command_session(&db_path, home.path(), "SELECT 1;");
+    assert!(ok, "leftover .lock must not block a fresh session: {err}");
+    assert!(lock_path.exists(), ".lock is left in place (never renamed or deleted)");
+}

--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -1453,6 +1453,11 @@ impl From<vibesql_storage::StorageError> for ExecutorError {
             vibesql_storage::StorageError::IoError(msg) => {
                 ExecutorError::StorageError(format!("I/O error: {}", msg))
             }
+            err @ vibesql_storage::StorageError::DatabaseLocked => {
+                // Exact SQLite wording ("database is locked") -- preserved
+                // verbatim so scripts can match on it (issue #5808).
+                ExecutorError::StorageError(err.to_string())
+            }
             vibesql_storage::StorageError::InvalidPageSize { expected, actual } => {
                 ExecutorError::StorageError(format!(
                     "Invalid page size: expected {}, got {}",

--- a/crates/vibesql-storage/src/error.rs
+++ b/crates/vibesql-storage/src/error.rs
@@ -46,6 +46,10 @@ pub enum StorageError {
         supported: u8,
     },
     IoError(String),
+    /// Another process holds the exclusive inter-process database lock
+    /// (issue #5808). Displays the exact SQLite-compatible wording
+    /// `database is locked` — contractual, do not change.
+    DatabaseLocked,
     InvalidPageSize {
         expected: usize,
         actual: usize,
@@ -151,6 +155,11 @@ impl std::fmt::Display for StorageError {
             }
             StorageError::IoError(msg) => {
                 write!(f, "{}", vibe_msg!("storage-io-error", message = msg.as_str()))
+            }
+            StorageError::DatabaseLocked => {
+                // Exact SQLite wording — deliberately not localized so scripts
+                // and the TCL shim can match on it (issue #5808).
+                write!(f, "database is locked")
             }
             StorageError::InvalidPageSize { expected, actual } => {
                 write!(

--- a/crates/vibesql-storage/src/lib.rs
+++ b/crates/vibesql-storage/src/lib.rs
@@ -15,6 +15,10 @@ pub mod columnar_cache;
 pub mod database;
 pub mod error;
 pub mod index;
+// Inter-process advisory locking (flock/LockFileEx via std file locks) is
+// unavailable on wasm32 — cfg-gated so the WASM build keeps compiling.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod lock;
 pub mod mvcc;
 pub mod page;
 pub mod persistence;
@@ -47,6 +51,8 @@ pub use database::{
 };
 pub use error::{StorageError, StorageResult};
 pub use index::{extract_mbr_from_sql_value, SpatialIndex, SpatialIndexEntry};
+#[cfg(not(target_arch = "wasm32"))]
+pub use lock::{acquire_exclusive, cleanup_stale_temp_files, DatabaseLock};
 pub use mvcc::{mvcc_enabled, stamp_xmax_for_write, stamp_xmin_for_write, TxnSnapshot};
 pub use persistence::load::{parse_sql_statements, read_sql_dump};
 pub use query_buffer_pool::{

--- a/crates/vibesql-storage/src/lock.rs
+++ b/crates/vibesql-storage/src/lock.rs
@@ -1,0 +1,298 @@
+// ============================================================================
+// Inter-Process Database Locking (issue #5808)
+// ============================================================================
+//
+// VibeSQL loads the entire database into memory at open and checkpoints its
+// own image at save time (`db.to_uncompressed_bytes()`). Two concurrent
+// writer sessions therefore cannot be merged — the last checkpoint wins and
+// clobbers the other session's committed writes wholesale, and concurrent WAL
+// appends interleave entries from divergent in-memory states. Whole-database,
+// whole-session EXCLUSIVE locking is the semantically correct scope, not
+// merely the simplest.
+//
+// ## Mechanism
+//
+// A kernel advisory lock (`flock` on Unix, `LockFileEx` on Windows) via
+// `std::fs::File::try_lock` (stable since Rust 1.89 — no new dependency).
+// The kernel releases the lock automatically when the holding process dies,
+// including SIGKILL, so no stale-lock recovery scheme is needed.
+//
+// ## Lock target
+//
+// A dedicated sibling `<stem>.lock` file that is never renamed or deleted.
+// We deliberately do NOT lock the `.vbsql` or `.wal` files directly: both are
+// replaced via temp-file + rename (snapshot save; `truncate_wal`), which would
+// orphan the lock on the old inode and let a second process acquire a "fresh"
+// lock on the new one. The `.lock` file is created with `create(true)` (so a
+// brand-new database path locks fine) and is left in place on exit.
+//
+// ## Caveat
+//
+// Advisory locks are unreliable on NFS filesystems — the same caveat SQLite
+// carries. Server/Raft mode is out of scope: replicated writes already
+// serialize through the consensus log.
+
+use std::{
+    fs::{File, OpenOptions, TryLockError},
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
+
+use crate::error::StorageError;
+
+/// Interval between lock acquisition retries while waiting out the busy
+/// timeout.
+const RETRY_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Derive the lock file path for a database file path.
+///
+/// `mydata.vbsql` -> `mydata.lock` (sibling, shares the stem).
+pub fn lock_path_for(db_path: &Path) -> PathBuf {
+    db_path.with_extension("lock")
+}
+
+/// RAII guard for the exclusive inter-process database lock.
+///
+/// The lock is released when the guard is dropped (the kernel also releases
+/// it automatically if the process dies first, including SIGKILL).
+#[derive(Debug)]
+pub struct DatabaseLock {
+    /// Held open for the lifetime of the guard; closing the file releases the
+    /// advisory lock.
+    file: File,
+    /// Path of the `.lock` file (kept for diagnostics).
+    path: PathBuf,
+}
+
+impl DatabaseLock {
+    /// Path of the underlying `.lock` file.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for DatabaseLock {
+    fn drop(&mut self) {
+        // Explicit unlock before close for clarity; closing the file would
+        // release the flock anyway. Errors are ignored — there is no useful
+        // recovery at drop time and the kernel cleans up on process exit.
+        let _ = self.file.unlock();
+    }
+}
+
+/// Acquire the exclusive inter-process lock for the database at `db_path`.
+///
+/// Retries every [`RETRY_INTERVAL`] until `timeout` elapses (a `timeout` of
+/// zero means a single attempt: fail immediately when contended), then fails
+/// with [`StorageError::DatabaseLocked`], whose display is the exact
+/// SQLite-compatible wording `database is locked`.
+///
+/// The lock is scoped to the whole session: hold the returned guard until the
+/// final checkpoint/save has completed (i.e. drop it last).
+pub fn acquire_exclusive(db_path: &Path, timeout: Duration) -> Result<DatabaseLock, StorageError> {
+    let lock_path = lock_path_for(db_path);
+
+    // `truncate(false)`: the lock file's contents are irrelevant (it is a pure
+    // flock target), but truncating another process's open lock file would be
+    // needless churn.
+    let file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|e| {
+            StorageError::IoError(format!(
+                "Failed to open lock file {}: {}",
+                lock_path.display(),
+                e
+            ))
+        })?;
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        match file.try_lock() {
+            Ok(()) => return Ok(DatabaseLock { file, path: lock_path }),
+            Err(TryLockError::WouldBlock) => {
+                if Instant::now() >= deadline {
+                    return Err(StorageError::DatabaseLocked);
+                }
+                std::thread::sleep(
+                    RETRY_INTERVAL.min(deadline.saturating_duration_since(Instant::now())),
+                );
+            }
+            Err(TryLockError::Error(e)) => {
+                return Err(StorageError::IoError(format!(
+                    "Failed to lock {}: {}",
+                    lock_path.display(),
+                    e
+                )));
+            }
+        }
+    }
+}
+
+/// Remove stale temp files left behind by interrupted checkpoint/truncate
+/// writers: `checkpoint_*.tmp` stubs in the checkpoint archive directory and
+/// the `<stem>.wal.tmp` truncate scratch file.
+///
+/// This is safe ONLY while holding the exclusive [`DatabaseLock`] — no other
+/// process can be mid-checkpoint. Completed `.vchk` checkpoint files are
+/// never touched. Best-effort: individual removal failures are skipped (the
+/// stubs are inert; they will be retried on the next open).
+///
+/// Returns the number of files removed.
+pub fn cleanup_stale_temp_files(wal_path: &Path, checkpoint_dir: &Path) -> usize {
+    let mut removed = 0usize;
+
+    // `<stem>.wal` -> `<stem>.wal.tmp` (mirrors `truncate_wal`'s temp path).
+    let wal_tmp = wal_path.with_extension("wal.tmp");
+    if wal_tmp.exists() && std::fs::remove_file(&wal_tmp).is_ok() {
+        removed += 1;
+    }
+
+    if let Ok(entries) = std::fs::read_dir(checkpoint_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let is_checkpoint_stub = path.extension().is_some_and(|ext| ext == "tmp")
+                && path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with("checkpoint_"));
+            if is_checkpoint_stub && std::fs::remove_file(&path).is_ok() {
+                removed += 1;
+            }
+        }
+    }
+
+    removed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lock_path_derivation() {
+        assert_eq!(
+            lock_path_for(Path::new("/tmp/mydata.vbsql")),
+            PathBuf::from("/tmp/mydata.lock")
+        );
+        assert_eq!(lock_path_for(Path::new("mydata")), PathBuf::from("mydata.lock"));
+    }
+
+    #[test]
+    fn test_acquire_creates_lock_file_and_release_allows_reacquire() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("db.vbsql");
+
+        let guard = acquire_exclusive(&db_path, Duration::ZERO).expect("first acquire");
+        assert!(guard.path().exists(), ".lock sibling must be created");
+        assert_eq!(guard.path(), dir.path().join("db.lock"));
+        drop(guard);
+
+        // Released on drop: a fresh handle can lock again immediately.
+        let guard2 = acquire_exclusive(&db_path, Duration::ZERO).expect("reacquire after drop");
+        drop(guard2);
+    }
+
+    /// A brand-new database path (no `.vbsql` on disk yet) must lock fine.
+    #[test]
+    fn test_acquire_on_nonexistent_database_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("does_not_exist_yet.vbsql");
+        assert!(!db_path.exists());
+        let _guard = acquire_exclusive(&db_path, Duration::ZERO).expect("acquire on new path");
+    }
+
+    /// On Unix, `flock` locks are per open-file-description, so a second
+    /// handle in the SAME process conflicts too — enough for a fast unit test
+    /// of the timeout path. (Cross-process behavior is covered by the
+    /// two-process integration tests in `crates/vibesql-cli/tests/`.)
+    #[cfg(unix)]
+    #[test]
+    fn test_contended_acquire_times_out_with_database_is_locked() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("db.vbsql");
+
+        let _holder = acquire_exclusive(&db_path, Duration::ZERO).expect("holder acquires");
+
+        let start = Instant::now();
+        let err = acquire_exclusive(&db_path, Duration::from_millis(100))
+            .expect_err("second acquire must fail while held");
+        assert!(matches!(err, StorageError::DatabaseLocked));
+        // Exact SQLite-compatible wording — contractual (issue #5808).
+        assert_eq!(err.to_string(), "database is locked");
+        assert!(
+            start.elapsed() >= Duration::from_millis(100),
+            "must wait out the busy timeout before failing"
+        );
+    }
+
+    /// Zero timeout = single attempt, immediate failure when contended.
+    #[cfg(unix)]
+    #[test]
+    fn test_zero_timeout_fails_immediately() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("db.vbsql");
+
+        let _holder = acquire_exclusive(&db_path, Duration::ZERO).expect("holder acquires");
+        let err = acquire_exclusive(&db_path, Duration::ZERO).expect_err("must fail");
+        assert!(matches!(err, StorageError::DatabaseLocked));
+    }
+
+    /// Waiting within the busy timeout succeeds once the holder releases.
+    #[cfg(unix)]
+    #[test]
+    fn test_waiter_acquires_after_holder_releases() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("db.vbsql");
+
+        let holder = acquire_exclusive(&db_path, Duration::ZERO).expect("holder acquires");
+        let db_path_clone = db_path.clone();
+        let waiter =
+            std::thread::spawn(move || acquire_exclusive(&db_path_clone, Duration::from_secs(30)));
+        // Brief hold, then release — the waiter must then acquire well within
+        // its generous timeout.
+        std::thread::sleep(Duration::from_millis(50));
+        drop(holder);
+        let acquired = waiter.join().unwrap();
+        assert!(acquired.is_ok(), "waiter must acquire after release: {:?}", acquired.err());
+    }
+
+    #[test]
+    fn test_cleanup_removes_tmp_stubs_and_preserves_vchk() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("db.wal");
+        let ckpt_dir = dir.path().join("db-checkpoints");
+        std::fs::create_dir_all(&ckpt_dir).unwrap();
+
+        // 32-byte stubs — exactly what interrupted checkpoint writers leave.
+        std::fs::write(ckpt_dir.join("checkpoint_99.tmp"), [0u8; 32]).unwrap();
+        std::fs::write(ckpt_dir.join("checkpoint_100.tmp"), [0u8; 32]).unwrap();
+        std::fs::write(ckpt_dir.join("checkpoint_98.vchk"), b"complete checkpoint").unwrap();
+        // Truncate scratch file next to the WAL.
+        std::fs::write(dir.path().join("db.wal.tmp"), b"partial rewrite").unwrap();
+        // Unrelated .tmp (no checkpoint_ prefix) must be left alone.
+        std::fs::write(ckpt_dir.join("other.tmp"), b"not ours").unwrap();
+
+        let removed = cleanup_stale_temp_files(&wal_path, &ckpt_dir);
+        assert_eq!(removed, 3);
+
+        assert!(!ckpt_dir.join("checkpoint_99.tmp").exists());
+        assert!(!ckpt_dir.join("checkpoint_100.tmp").exists());
+        assert!(!dir.path().join("db.wal.tmp").exists());
+        assert!(ckpt_dir.join("checkpoint_98.vchk").exists(), ".vchk must be untouched");
+        assert!(ckpt_dir.join("other.tmp").exists(), "unrelated .tmp must be untouched");
+    }
+
+    /// Cleanup on a database with no WAL siblings at all is a quiet no-op.
+    #[test]
+    fn test_cleanup_noop_when_nothing_to_clean() {
+        let dir = tempfile::tempdir().unwrap();
+        let removed = cleanup_stale_temp_files(
+            &dir.path().join("db.wal"),
+            &dir.path().join("db-checkpoints"),
+        );
+        assert_eq!(removed, 0);
+    }
+}


### PR DESCRIPTION
## Summary

Concurrent CLI sessions on the same file-backed database had no inter-process coordination and raced on WAL appends (interleaved LSN streams from divergent in-memory states), checkpoint IDs (`File::create` truncating the other writer's in-progress temp file — the observed 32-byte `checkpoint_*.tmp` stubs), and WAL truncation (temp+rename orphaning the other session's appends). Because VibeSQL holds the whole database in memory and checkpoints its own image, concurrent writer sessions can never be merged — the last save clobbers the other's committed writes — so every file-backed open now takes a whole-database, whole-session EXCLUSIVE advisory lock, exactly as the curator's design resolved.

## Changes

- **New `crates/vibesql-storage/src/lock.rs`** (cfg-gated off for `wasm32`): `DatabaseLock` RAII guard + `acquire_exclusive()` built on `std::fs::File::try_lock` (stable since Rust 1.89 — no new dependency; flock on Unix / LockFileEx on Windows, so the kernel releases the lock automatically when the holder dies, including SIGKILL). Lock target is a dedicated, never-renamed/never-deleted `<stem>.lock` sibling — locking `.vbsql`/`.wal` directly would orphan the lock across their temp+rename replacement. Includes `cleanup_stale_temp_files()` for `checkpoint_*.tmp` stubs and `<stem>.wal.tmp` (safe only under the exclusive lock; `.vchk` files never touched).
- **`StorageError::DatabaseLocked`** displaying the exact SQLite wording `database is locked` (deliberately not localized; preserved verbatim through the executor error mapping).
- **CLI open path** (`SqlExecutor::new_with_options`): acquires the lock for EVERY file-backed session — WAL-active AND snapshot-only (`wal = false`) — BEFORE any recovery/load, then cleans stale temp stubs. Guard is held on the executor, declared after `db`, so it drops only after the exit-time checkpoint/save. `:memory:` / no-path sessions take no lock and create no `.lock` file.
- **Busy timeout**: `[database] lock_timeout_ms` in `~/.vibesqlrc` (default 5000 ms, `0` = fail immediately), plumbed through `DbOpenOptions`; 10 ms retry loop, then the open fails with `database is locked` (non-zero exit).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Second `vibesql <db> -c "INSERT ..."` fails non-zero with stderr containing exactly `database is locked` after the busy timeout | Pass | `test_second_writer_times_out_with_database_is_locked` (asserts non-zero exit, exact wording, and that the 300 ms busy timeout elapsed); manual demo prints `Error: database is locked`, exit code 1 |
| Brief overlap shorter than the busy timeout succeeds (waits, then acquires) | Pass | `test_waiter_within_busy_timeout_succeeds_after_release` — waiter verifiably blocks while the holder owns the lock, then acquires and its committed row is durable |
| Lock released on clean exit AND after SIGKILL — subsequent open succeeds immediately, no stale-lock recovery | Pass | Clean-exit rerun in test (a); `test_sigkill_holder_releases_lock_immediately` reopens with `lock_timeout_ms = 0` (single attempt) after `kill -9` |
| Stale `checkpoint_*.tmp` stubs and `<stem>.wal.tmp` removed on next open; `.vchk` untouched | Pass | Unit test `test_cleanup_removes_tmp_stubs_and_preserves_vchk` (32-byte stubs, unrelated `.tmp` preserved) + e2e `test_stale_tmp_stubs_cleaned_on_next_open` (pre-existing `.vchk` names asserted intact, data survives) |
| `:memory:` and no-database sessions acquire no lock, create no `.lock` file | Pass | `test_memory_and_no_database_sessions_create_no_lock_file` |
| Snapshot-only mode (`wal = false`) protected by the same lock | Pass | `test_snapshot_only_mode_is_locked_too` (zero-timeout probe observes `database is locked` while held; succeeds after release) |
| TCL shim flow unaffected (serial short-lived `-c` subprocesses) | Pass | `test_serial_short_lived_sessions_never_contend` + real shim run: `./scripts/tcltest test select1.test` → 188/188 passed with the locked binary |
| WASM build of `vibesql-storage` still compiles (lock module cfg-gated) | Pass | `cargo check -p vibesql-wasm-bindings --lib --target wasm32-unknown-unknown` (CI-mirror command) finishes clean |
| Brand-new DB path (no `.vbsql` yet) locks and opens | Pass | Unit test `test_acquire_on_nonexistent_database_path`; `.lock` created via `create(true)` |

## Test Plan

- `cargo test -p vibesql-storage --lib` — 747 passed (includes 8 new `lock::` unit tests: acquire/release/reacquire, contended timeout with exact `database is locked` wording, zero-timeout immediate failure, waiter-acquires-after-release, stub cleanup preserving `.vchk`, no-op cleanup, lock-path derivation, new-DB path)
- `cargo test -p vibesql-cli` — all targets green, including the new two-process contention suite `tests/locking_test.rs` (8 tests) spawning real `vibesql` subprocesses via `CARGO_BIN_EXE_vibesql` with **marker-based synchronization** (WAL sibling files are created strictly after lock acquisition; the snapshot-only path uses a zero-timeout probe whose `database is locked` observation is itself the marker) and generous 60 s poll deadlines — no fixed sleeps for correctness
- `cargo test -p vibesql-executor` targets compile; `DatabaseLocked` mapped in the exhaustive `StorageError` match
- `cargo check -p vibesql-wasm-bindings --lib --target wasm32-unknown-unknown` — clean (mirrors the `wasm-check` CI job)
- `cargo clippy -p vibesql-storage -p vibesql-cli` — no warnings in changed files (pre-existing warnings elsewhere untouched)
- Manual: holder session open + second `-c INSERT` → `Error: database is locked`, exit 1; `<stem>.lock` left in place and reused across sessions

## Notes for review

- The lock is acquired before recovery/load so stale-stub cleanup can never race a live checkpoint writer; it is released only after the exit-time checkpoint (guard field declared after `db` — drop order is load-bearing and documented on the field).
- Follow-ups deliberately out of scope (per curator): `--read-only` shared-lock open mode; server/Raft-mode file locking (writes already serialize through consensus). Advisory locks carry the usual NFS caveat (same as SQLite), documented in the module header.

Closes #5808