### PR TITLE
feat(parser): accept SQLite fallback keywords as identifiers (keyword1.test 116/116)

### DIFF
--- a/crates/vibesql-cli/src/script.rs
+++ b/crates/vibesql-cli/src/script.rs
@@ -389,6 +389,22 @@ fn parse_statements(script: &str) -> Vec<String> {
             let rest: String = chars.clone().take_while(|c| c.is_ascii_alphabetic()).collect();
             let word = format!("{}{}", ch, rest).to_uppercase();
             if word == "BEGIN" {
+                // A BEGIN can only open a multi-statement body inside a
+                // CREATE TRIGGER / PROCEDURE / FUNCTION statement. Anywhere
+                // else the word is a transaction BEGIN or a plain identifier —
+                // BEGIN is a SQLite *fallback* keyword, so `CREATE TABLE
+                // begin(begin begin)` and `INSERT INTO begin VALUES(99)` are
+                // legal (keyword1.test) — and must not suppress statement
+                // splitting. Without this gate, an identifier `begin` set
+                // begin_depth > 0 and glued every following statement into one.
+                let prefix_upper = current_statement[..current_statement.len() - 1].to_uppercase();
+                let in_body_context = prefix_upper
+                    .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+                    .any(|w| matches!(w, "TRIGGER" | "PROCEDURE" | "FUNCTION"));
+                if !in_body_context {
+                    // Treat as a normal word (transaction BEGIN or identifier).
+                    continue;
+                }
                 // Consume the rest of the word
                 for _ in 0..(rest.len()) {
                     if let Some(c) = chars.next() {
@@ -647,6 +663,40 @@ INSERT INTO logs VALUES (2, 'Success');
         assert_eq!(stmts[0], ".mode json");
         assert_eq!(stmts[1], "SELECT * FROM users;");
         assert_eq!(stmts[2], ".tables");
+    }
+
+    #[test]
+    fn test_parse_begin_as_identifier_does_not_glue_statements() {
+        // Issue #5816 (keyword1.test): BEGIN is a SQLite fallback keyword, so
+        // `begin` is a legal table/column name. An identifier `begin` must not
+        // be mistaken for a trigger-body opener — that suppressed semicolon
+        // splitting and glued every following statement into one.
+        let script = "CREATE TABLE begin(begin begin);             INSERT INTO begin VALUES(99);             INSERT INTO begin SELECT a FROM t1;             SELECT * FROM begin ORDER BY begin ASC;";
+        let stmts = parse_statements(script);
+        assert_eq!(
+            stmts.len(),
+            4,
+            "identifier `begin` must not suppress statement splitting, got: {:?}",
+            stmts
+        );
+        assert_eq!(stmts[0], "CREATE TABLE begin(begin begin);");
+        assert_eq!(stmts[1], "INSERT INTO begin VALUES(99);");
+    }
+
+    #[test]
+    fn test_parse_transaction_begin_still_splits() {
+        // A transaction BEGIN (statement-position, not inside CREATE
+        // TRIGGER/PROCEDURE/FUNCTION) must not open a block either.
+        let script = "BEGIN; INSERT INTO t VALUES(1); COMMIT;";
+        let stmts = parse_statements(script);
+        assert_eq!(stmts.len(), 3, "transaction BEGIN must split normally, got: {:?}", stmts);
+
+        // Bare BEGIN followed by a statement keyword (no semicolon glue).
+        let script = "BEGIN
+TRANSACTION;
+INSERT INTO t VALUES(1);";
+        let stmts = parse_statements(script);
+        assert_eq!(stmts.len(), 2, "BEGIN TRANSACTION must split normally, got: {:?}", stmts);
     }
 
     #[test]

--- a/crates/vibesql-parser/src/arena_parser/ddl.rs
+++ b/crates/vibesql-parser/src/arena_parser/ddl.rs
@@ -154,7 +154,17 @@ impl<'arena> ArenaParser<'arena> {
             false
         };
 
-        let index_name = self.parse_arena_identifier()?;
+        // SQLite fallback keywords are legal index names (keyword1.test:
+        // `CREATE INDEX abort ON t1(a)`). Lowercased like any unquoted
+        // identifier.
+        let index_name = match self.peek() {
+            Token::Keyword { keyword: kw, .. } if kw.is_sqlite_fallback_keyword() => {
+                let name = kw.to_string().to_lowercase();
+                self.advance();
+                self.intern(&name)
+            }
+            _ => self.parse_arena_identifier()?,
+        };
 
         self.consume_keyword(Keyword::On)?;
         let table_name = self.parse_arena_identifier()?;

--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -755,8 +755,14 @@ impl<'arena> ArenaParser<'arena> {
                 self.advance();
                 Ok(Some(vibesql_ast::arena::IndexHint::IndexedBy(self.intern(&name))))
             }
-            Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
-                let name = kw.to_string();
+            // SQLite fallback keywords are legal index names here too
+            // (keyword1.test: `SELECT b FROM t1 INDEXED BY abort WHERE a=2`).
+            // Lowercased like any unquoted identifier so catalog lookup matches
+            // the name stored by `CREATE INDEX abort ...`.
+            Token::Keyword { keyword: kw, .. }
+                if kw.can_be_identifier() || kw.is_sqlite_fallback_keyword() =>
+            {
+                let name = kw.to_string().to_lowercase();
                 self.advance();
                 Ok(Some(vibesql_ast::arena::IndexHint::IndexedBy(self.intern(&name))))
             }

--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -429,19 +429,31 @@ impl Keyword {
     /// The denylist intentionally covers three categories of keyword:
     ///
     /// 1. **Operators** consumed by the expression precedence cascade in
-    ///    *operator* position (`AND`, `OR`, `NOT`, `IN`, `BETWEEN`, `LIKE`,
-    ///    `GLOB`, `ESCAPE`, `IS`, `ISNULL`, `NOTNULL`, `COLLATE`, `DIV`,
+    ///    *operator* position (`AND`, `OR`, `NOT`, `IN`, `BETWEEN`,
+    ///    `ESCAPE`, `IS`, `ISNULL`, `NOTNULL`, `COLLATE`, `DIV`,
     ///    `ALL`/`ANY`/`SOME`, `AS`). These must never be reinterpreted as a
-    ///    column when an operand is expected.
+    ///    column when an operand is expected. Note that `LIKE`/`GLOB` are
+    ///    *not* denied: at operand start they can only be a column reference
+    ///    (or a `like(...)`/`glob(...)` function call, which the function-call
+    ///    parser claims first); their operator role only arises in operator
+    ///    position, which this predicate never governs (keyword1.test).
     /// 2. **Statement / clause structure** keywords that terminate or introduce
     ///    a clause and which the expression caller relies on to STOP parsing
-    ///    (`SELECT`, `FROM`, `WHERE`, `GROUP`, `BY`, `HAVING`, `ORDER`,
-    ///    `LIMIT`, `OFFSET`, `WINDOW`, `UNION`, `INTERSECT`, `EXCEPT`, `INTO`,
+    ///    (`SELECT`, `FROM`, `WHERE`, `GROUP`, `HAVING`, `ORDER`,
+    ///    `LIMIT`, `WINDOW`, `UNION`, `INTERSECT`, `EXCEPT`, `INTO`,
     ///    `VALUES`, `SET`, `ON`, `USING`, `JOIN` and its modifiers, the DML/DDL
-    ///    verbs, etc.).
+    ///    verbs, etc.). Words that only structure a clause *after* another
+    ///    keyword has been consumed (`BY`, `OFFSET`, `WITH`, `RECURSIVE`,
+    ///    `REPLACE`, `PRAGMA`) are NOT denied: at operand start they are
+    ///    unambiguous column references, matching SQLite's fallback rules
+    ///    (`SELECT by FROM t ORDER BY by`, keyword1.test).
     /// 3. **Special primary forms / literals** that have dedicated parsing
-    ///    (`CASE`/`WHEN`/`THEN`/`ELSE`/`END`, `CAST`, `EXISTS`, `NULL`, `TRUE`,
-    ///    `FALSE`, `UNKNOWN`, the `CURRENT_*` constants, `DISTINCT`).
+    ///    (`CASE`/`WHEN`/`THEN`/`ELSE`, `CAST`, `EXISTS`, `NULL`, `TRUE`,
+    ///    `FALSE`, `UNKNOWN`, the `CURRENT_*` constants, `DISTINCT`). `END` is
+    ///    NOT denied: it is only meaningful *after* a complete CASE body, where
+    ///    the CASE parser consumes it at clause level before expression
+    ///    parsing resumes; at operand start SQLite treats it as a column
+    ///    (`ORDER BY end`, keyword1.test).
     ///
     /// Everything else — including otherwise-reserved column-name words like
     /// `RELEASE`, `SAVEPOINT`, `KEY`, `ASC`, `DESC`, `BEGIN`, `COMMIT`,
@@ -464,8 +476,6 @@ impl Keyword {
                 | Keyword::Between
                 | Keyword::Asymmetric
                 | Keyword::Symmetric
-                | Keyword::Like
-                | Keyword::Glob
                 | Keyword::Escape
                 | Keyword::Is
                 | Keyword::Isnull
@@ -481,11 +491,9 @@ impl Keyword {
                 | Keyword::From
                 | Keyword::Where
                 | Keyword::Group
-                | Keyword::By
                 | Keyword::Having
                 | Keyword::Order
                 | Keyword::Limit
-                | Keyword::Offset
                 | Keyword::Into
                 | Keyword::Values
                 | Keyword::Set
@@ -495,8 +503,6 @@ impl Keyword {
                 | Keyword::Union
                 | Keyword::Intersect
                 | Keyword::Except
-                | Keyword::With
-                | Keyword::Recursive
                 | Keyword::Insert
                 | Keyword::Update
                 | Keyword::Delete
@@ -504,14 +510,11 @@ impl Keyword {
                 | Keyword::Drop
                 | Keyword::Alter
                 | Keyword::Truncate
-                | Keyword::Replace
-                | Keyword::Pragma
                 // --- Category 3: special primary forms / literals ---
                 | Keyword::Case
                 | Keyword::When
                 | Keyword::Then
                 | Keyword::Else
-                | Keyword::End
                 | Keyword::Cast
                 | Keyword::Exists
                 | Keyword::Null
@@ -522,6 +525,121 @@ impl Keyword {
                 | Keyword::CurrentDate
                 | Keyword::CurrentTime
                 | Keyword::CurrentTimestamp
+        )
+    }
+
+    /// Returns true if this keyword may be used as an unquoted *table name*
+    /// (e.g. after `FROM`, in `INSERT INTO`, `DROP TABLE`).
+    ///
+    /// This is the expression-position set plus the special primary forms
+    /// `CAST` and `CURRENT_DATE`/`CURRENT_TIME`/`CURRENT_TIMESTAMP`: in
+    /// expression position those words must keep their dedicated parsing
+    /// (`CAST(x AS t)`, the datetime literals), but in table-name position no
+    /// such form can occur, so SQLite's fallback rules accept them as plain
+    /// names (`SELECT * FROM cast`, keyword1.test).
+    pub fn can_be_identifier_in_table_position(&self) -> bool {
+        self.can_be_identifier_in_expression()
+            || matches!(
+                self,
+                Keyword::Cast
+                    | Keyword::CurrentDate
+                    | Keyword::CurrentTime
+                    | Keyword::CurrentTimestamp
+            )
+    }
+
+    /// Returns true if this keyword is in SQLite's `%fallback ID` set — the
+    /// keywords that SQLite's parser demotes to plain identifiers whenever the
+    /// keyword reading does not fit the grammar (see `parse.y` in the SQLite
+    /// sources, and keyword1.test which exercises them as table, column, type,
+    /// and index names).
+    ///
+    /// VibeSQL uses this predicate for positions where SQLite accepts any
+    /// fallback keyword as a name but truly-reserved words (`PRIMARY`, `NOT`,
+    /// `CROSS`, `SELECT`, ...) must stay rejected:
+    ///
+    /// - column *type* names (`CREATE TABLE abort(abort abort)` is legal;
+    ///   `CREATE TABLE t(x primary)` is not)
+    /// - index names in `CREATE INDEX` / `DROP INDEX`
+    /// - index names after `INDEXED BY`
+    ///
+    /// Two members of SQLite's fallback set are deliberately omitted:
+    /// `GENERATED` and `ALWAYS`. VibeSQL parses `ADD COLUMN x GENERATED ALWAYS
+    /// AS (...)` by consuming `GENERATED` before the type, so demoting it here
+    /// would swallow generated-column syntax in ALTER TABLE.
+    pub fn is_sqlite_fallback_keyword(&self) -> bool {
+        matches!(
+            self,
+            Keyword::Abort
+                | Keyword::Action
+                | Keyword::After
+                | Keyword::Analyze
+                | Keyword::Asc
+                | Keyword::Before
+                | Keyword::Begin
+                | Keyword::By
+                | Keyword::Cascade
+                | Keyword::Cast
+                | Keyword::Column
+                | Keyword::Conflict
+                | Keyword::Current
+                | Keyword::CurrentDate
+                | Keyword::CurrentTime
+                | Keyword::CurrentTimestamp
+                | Keyword::Deferred
+                | Keyword::Desc
+                | Keyword::Do
+                | Keyword::Each
+                | Keyword::End
+                | Keyword::Exclude
+                | Keyword::Explain
+                | Keyword::Fail
+                | Keyword::First
+                | Keyword::Following
+                | Keyword::For
+                | Keyword::Glob
+                | Keyword::Groups
+                | Keyword::If
+                | Keyword::Ignore
+                | Keyword::Immediate
+                | Keyword::Initially
+                | Keyword::Instead
+                | Keyword::Key
+                | Keyword::Last
+                | Keyword::Like
+                | Keyword::Match
+                | Keyword::Materialized
+                | Keyword::No
+                | Keyword::Nulls
+                | Keyword::Of
+                | Keyword::Offset
+                | Keyword::Others
+                | Keyword::Partition
+                | Keyword::Plan
+                | Keyword::Pragma
+                | Keyword::Preceding
+                | Keyword::Query
+                | Keyword::Range
+                | Keyword::Recursive
+                | Keyword::Reindex
+                | Keyword::Release
+                | Keyword::Rename
+                | Keyword::Replace
+                | Keyword::Restrict
+                | Keyword::Rollback
+                | Keyword::Row
+                | Keyword::Rows
+                | Keyword::Savepoint
+                | Keyword::Temp
+                | Keyword::Temporary
+                | Keyword::Ties
+                | Keyword::Trigger
+                | Keyword::Unbounded
+                | Keyword::Vacuum
+                | Keyword::View
+                | Keyword::Virtual
+                | Keyword::With
+                | Keyword::Without
         )
     }
 }

--- a/crates/vibesql-parser/src/parser/create/types.rs
+++ b/crates/vibesql-parser/src/parser/create/types.rs
@@ -51,6 +51,15 @@ impl Parser {
             Token::Keyword { keyword: Keyword::Varying, .. } => "varying".to_string(),
             // SQLite ANY type - represents any type, stored with no affinity
             Token::Keyword { keyword: Keyword::Any, .. } => "any".to_string(),
+            // SQLite fallback keywords are legal type names (keyword1.test:
+            // `CREATE TABLE abort(abort abort)`). Truly-reserved words
+            // (PRIMARY, NOT, CROSS, ...) are not in the fallback set and still
+            // fail with "Expected data type", matching SQLite. The name is
+            // lowercased like any unquoted identifier and resolves through the
+            // affinity-based UserDefined catch-all below.
+            Token::Keyword { keyword, .. } if keyword.is_sqlite_fallback_keyword() => {
+                keyword.to_string().to_lowercase()
+            }
             _ => return Err(ParseError { message: "Expected data type".to_string() }),
         };
         self.advance();

--- a/crates/vibesql-parser/src/parser/helpers.rs
+++ b/crates/vibesql-parser/src/parser/helpers.rs
@@ -156,6 +156,24 @@ impl Parser {
         }
     }
 
+    /// Parse an identifier, delimited identifier, or SQLite *fallback* keyword
+    /// as a name. Used for positions where SQLite demotes fallback keywords to
+    /// identifiers but keeps truly-reserved words rejected — e.g. index names
+    /// in `CREATE INDEX abort ON t1(a)` / `DROP INDEX abort` (keyword1.test).
+    ///
+    /// Keyword-derived names are lowercased, consistent with the lexer's
+    /// normalization of unquoted identifiers.
+    pub(super) fn parse_identifier_or_fallback_keyword(&mut self) -> Result<String, ParseError> {
+        match self.peek() {
+            Token::Keyword { keyword: kw, .. } if kw.is_sqlite_fallback_keyword() => {
+                let name = kw.to_string().to_lowercase();
+                self.advance();
+                Ok(name)
+            }
+            _ => self.parse_identifier(),
+        }
+    }
+
     /// Parse an identifier or keyword as an alias name.
     /// In SQL, keywords can be used as aliases after AS (e.g., `d_year AS year`).
     /// This is standard SQL behavior supported by most databases.

--- a/crates/vibesql-parser/src/parser/index.rs
+++ b/crates/vibesql-parser/src/parser/index.rs
@@ -73,8 +73,11 @@ impl Parser {
             false
         };
 
-        // Parse index name
-        let index_name = self.parse_identifier()?;
+        // Parse index name. SQLite fallback keywords are legal index names
+        // (keyword1.test: `CREATE INDEX abort ON t1(a)`). Bare `IF` is still
+        // consumed by the IF NOT EXISTS check above and errors, matching
+        // SQLite (the test quotes `"if"` here).
+        let index_name = self.parse_identifier_or_fallback_keyword()?;
 
         // Expect ON keyword
         self.expect_keyword(Keyword::On)?;
@@ -678,8 +681,8 @@ impl Parser {
             false
         };
 
-        // Parse index name
-        let index_name = self.parse_identifier()?;
+        // Parse index name (SQLite fallback keywords allowed, keyword1.test)
+        let index_name = self.parse_identifier_or_fallback_keyword()?;
 
         // Expect ON keyword
         self.expect_keyword(Keyword::On)?;
@@ -735,8 +738,8 @@ impl Parser {
             false
         };
 
-        // Parse index name
-        let index_name = self.parse_identifier()?;
+        // Parse index name (SQLite fallback keywords allowed, keyword1.test)
+        let index_name = self.parse_identifier_or_fallback_keyword()?;
 
         Ok(vibesql_ast::DropIndexStmt { if_exists, index_name })
     }

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -394,8 +394,11 @@ impl Parser {
             // CREATE TABLE side (so `FROM savepoint` resolves the table created by
             // `CREATE TABLE savepoint(...)` — see table.test table-7.3). Clause and
             // operator keywords (WHERE, JOIN, ON, ...) are excluded by
-            // `can_be_identifier_in_expression()` and continue to terminate the clause.
-            Token::Keyword { keyword: kw, .. } if kw.can_be_identifier_in_expression() => {
+            // `can_be_identifier_in_table_position()` and continue to terminate the
+            // clause; unlike expression position, CAST and the CURRENT_* words are
+            // accepted here because no special primary form can start after FROM
+            // (keyword1.test: `SELECT * FROM cast`).
+            Token::Keyword { keyword: kw, .. } if kw.can_be_identifier_in_table_position() => {
                 let table = self.parse_table_ref()?;
 
                 // Check for optional alias
@@ -485,8 +488,14 @@ impl Parser {
                 self.advance();
                 Ok(Some(vibesql_ast::IndexHint::IndexedBy(name)))
             }
-            Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
-                let name = kw.to_string();
+            // SQLite fallback keywords are legal index names here too
+            // (keyword1.test: `SELECT b FROM t1 INDEXED BY abort WHERE a=2`).
+            // Lowercased like any unquoted identifier so catalog lookup matches
+            // the name stored by `CREATE INDEX abort ...`.
+            Token::Keyword { keyword: kw, .. }
+                if kw.can_be_identifier() || kw.is_sqlite_fallback_keyword() =>
+            {
+                let name = kw.to_string().to_lowercase();
                 self.advance();
                 Ok(Some(vibesql_ast::IndexHint::IndexedBy(name)))
             }

--- a/crates/vibesql-parser/src/tests/create_table/keyword_type_names.rs
+++ b/crates/vibesql-parser/src/tests/create_table/keyword_type_names.rs
@@ -1,0 +1,204 @@
+use super::super::*;
+
+// ========================================================================
+// SQLite fallback keywords as identifiers (keyword1.test, issue #5816)
+// ========================================================================
+// SQLite's parser demotes "fallback" keywords to plain identifiers whenever
+// the keyword reading does not fit the grammar (%fallback ID in parse.y).
+// keyword1.test exercises 58 such words as table, column, *type*, and index
+// names. Truly-reserved words (PRIMARY, NOT, CROSS, SELECT, ...) must stay
+// rejected in type-name position — verified against the sqlite3 oracle.
+
+/// The full kwlist from keyword1.test. Every word must be accepted in
+/// `CREATE TABLE <kw>(<kw> <kw>)` (with `if` quoted in table position, as in
+/// the test itself, since bare `CREATE TABLE if` collides with IF NOT EXISTS
+/// in SQLite too).
+const KEYWORD1_KWLIST: &[&str] = &[
+    "abort",
+    "after",
+    "analyze",
+    "asc",
+    "attach",
+    "before",
+    "begin",
+    "by",
+    "cascade",
+    "cast",
+    "column",
+    "conflict",
+    "current_date",
+    "current_time",
+    "current_timestamp",
+    "database",
+    "deferred",
+    "desc",
+    "detach",
+    "end",
+    "each",
+    "exclusive",
+    "explain",
+    "fail",
+    "for",
+    "glob",
+    "if",
+    "ignore",
+    "immediate",
+    "initially",
+    "instead",
+    "key",
+    "like",
+    "match",
+    "of",
+    "offset",
+    "plan",
+    "pragma",
+    "query",
+    "raise",
+    "recursive",
+    "regexp",
+    "reindex",
+    "release",
+    "rename",
+    "replace",
+    "restrict",
+    "rollback",
+    "row",
+    "savepoint",
+    "temp",
+    "temporary",
+    "trigger",
+    "vacuum",
+    "view",
+    "virtual",
+    "with",
+    "without",
+];
+
+#[test]
+fn test_all_keyword1_words_accepted_as_table_column_and_type_names() {
+    for kw in KEYWORD1_KWLIST {
+        let table = if *kw == "if" { format!("\"{}\"", kw) } else { (*kw).to_string() };
+        let sql = format!("CREATE TABLE {}({} {});", table, kw, kw);
+        let result = Parser::parse_sql(&sql);
+        assert!(
+            result.is_ok(),
+            "keyword1.test word {:?} must parse as table/column/type name: {:?}",
+            kw,
+            result.err()
+        );
+    }
+}
+
+#[test]
+fn test_fallback_keyword_type_name_becomes_user_defined() {
+    // Spot-check that a fallback keyword in type position maps to
+    // DataType::UserDefined with the lowercased name (affinity-only storage,
+    // like any unrecognized SQLite type name).
+    for kw in ["abort", "end", "with", "current_date", "cast"] {
+        let sql = format!("CREATE TABLE t1(x {});", kw);
+        let stmt = Parser::parse_sql(&sql)
+            .unwrap_or_else(|e| panic!("type name {:?} must parse: {:?}", kw, e));
+        match stmt {
+            vibesql_ast::Statement::CreateTable(create) => match &create.columns[0].data_type {
+                vibesql_types::DataType::UserDefined { type_name } => {
+                    assert_eq!(type_name, kw, "keyword type name must be stored lowercased");
+                }
+                other => panic!("Expected UserDefined for {:?}, got {:?}", kw, other),
+            },
+            _ => panic!("Expected CREATE TABLE statement"),
+        }
+    }
+}
+
+#[test]
+fn test_reserved_words_still_rejected_as_type_names() {
+    // sqlite3 oracle: these are NOT fallback keywords and are rejected in
+    // type-name position (`CREATE TABLE t(x primary)` is a syntax error).
+    // NULL / UNIQUE are deliberately absent here: SQLite (and VibeSQL) parse
+    // `CREATE TABLE t(x null)` / `(x unique)` as a typeless column with a
+    // constraint, so they are accepted — via a different production.
+    for kw in
+        ["primary", "not", "cross", "select", "from", "where", "table", "references", "default"]
+    {
+        let sql = format!("CREATE TABLE t1(x {});", kw);
+        let result = Parser::parse_sql(&sql);
+        assert!(
+            result.is_err(),
+            "reserved word {:?} must NOT be accepted as a type name (SQLite parity)",
+            kw
+        );
+    }
+}
+
+#[test]
+fn test_column_constraints_still_parse_after_keyword_relaxation() {
+    // Regression guards from issue #5816 acceptance criteria.
+    for sql in [
+        "CREATE TABLE t1(a PRIMARY KEY);",
+        "CREATE TABLE t1(a NOT NULL);",
+        "CREATE TABLE t1(a INTEGER PRIMARY KEY);",
+        "CREATE TABLE t1(a VARYING CHARACTER(255));",
+        "CREATE TABLE t1(a, b);",
+        "CREATE INDEX IF NOT EXISTS i1 ON t1(a);",
+    ] {
+        let result = Parser::parse_sql(sql);
+        assert!(result.is_ok(), "{:?} must still parse: {:?}", sql, result.err());
+    }
+}
+
+#[test]
+fn test_fallback_keywords_in_expression_and_from_position() {
+    // keyword1.test .1 shape: bare keyword as table name (FROM) and as a
+    // column reference in ORDER BY. These words were previously denylisted in
+    // expression position.
+    for kw in ["by", "end", "like", "glob", "offset", "pragma", "recursive", "replace", "with"] {
+        let sql = format!("SELECT * FROM {} ORDER BY {} ASC;", kw, kw);
+        let result = Parser::parse_sql(&sql);
+        assert!(
+            result.is_ok(),
+            "bare {:?} must parse in FROM and ORDER BY position: {:?}",
+            kw,
+            result.err()
+        );
+    }
+
+    // CAST / CURRENT_* keep their special expression parsing (SQLite rejects
+    // bare `ORDER BY cast` too — keyword1.test quotes them there) but are
+    // legal table names after FROM.
+    for kw in ["cast", "current_date", "current_time", "current_timestamp"] {
+        let sql = format!("SELECT * FROM {};", kw);
+        let result = Parser::parse_sql(&sql);
+        assert!(result.is_ok(), "{:?} must parse as FROM table name: {:?}", kw, result.err());
+
+        let sql = format!("SELECT x FROM t ORDER BY {} ASC;", kw);
+        // CURRENT_* parse as datetime literals in ORDER BY (valid); bare CAST
+        // must remain a syntax error, matching SQLite.
+        if kw == "cast" {
+            assert!(
+                Parser::parse_sql(&sql).is_err(),
+                "bare ORDER BY cast must stay a syntax error (SQLite parity)"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_operator_and_special_form_usage_still_parses() {
+    // Relaxing LIKE/GLOB/END/etc. in *operand* position must not disturb
+    // their operator / special-form roles.
+    for sql in [
+        "SELECT a FROM t WHERE a LIKE 'x%';",
+        "SELECT a FROM t WHERE a NOT LIKE 'x%';",
+        "SELECT a FROM t WHERE a GLOB 'x*';",
+        "SELECT CASE WHEN a > 1 THEN 2 ELSE 3 END FROM t;",
+        "SELECT replace('abc', 'b', 'x');",
+        "SELECT like('a%', 'abc');",
+        "SELECT * FROM t LIMIT 10 OFFSET 5;",
+        "WITH q AS (SELECT 1 AS x) SELECT x FROM q;",
+        "SELECT (WITH q AS (SELECT 1 AS x) SELECT x FROM q);",
+        "SELECT CAST(a AS INTEGER) FROM t;",
+    ] {
+        let result = Parser::parse_sql(sql);
+        assert!(result.is_ok(), "{:?} must still parse: {:?}", sql, result.err());
+    }
+}

--- a/crates/vibesql-parser/src/tests/create_table/mod.rs
+++ b/crates/vibesql-parser/src/tests/create_table/mod.rs
@@ -3,6 +3,7 @@ mod basic;
 mod bit_type;
 mod constraints_column;
 mod constraints_table;
+mod keyword_type_names;
 mod mysql_table_options;
 mod northwind;
 mod numeric_types;

--- a/crates/vibesql-parser/src/tests/index.rs
+++ b/crates/vibesql-parser/src/tests/index.rs
@@ -625,3 +625,84 @@ fn test_create_index_with_window_function_in_where_rejected_at_validation() {
         other => panic!("Expected CreateIndex, got: {:?}", other),
     }
 }
+
+// ========================================================================
+// SQLite fallback keywords as index names (keyword1.test, issue #5816)
+// ========================================================================
+
+#[test]
+fn test_create_index_with_fallback_keyword_name() {
+    // keyword1.test .2 shape: `CREATE INDEX abort ON t1(a)`. SQLite accepts
+    // any fallback keyword as an index name; the parsed name is lowercased
+    // like any unquoted identifier.
+    for kw in ["abort", "end", "view", "with", "temp", "cast", "current_date"] {
+        let sql = format!("CREATE INDEX {} ON t1(a)", kw);
+        let result = Parser::parse_sql(&sql);
+        assert!(result.is_ok(), "CREATE INDEX {:?} must parse: {:?}", kw, result.err());
+        match result.unwrap() {
+            Statement::CreateIndex(stmt) => {
+                assert_eq!(stmt.index_name, *kw);
+                assert_eq!(stmt.table_name, "t1");
+            }
+            other => panic!("Expected CreateIndex, got: {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn test_create_index_reserved_word_name_rejected() {
+    // Truly-reserved words are not fallback keywords and stay rejected,
+    // matching SQLite. Bare `if` is also rejected (consumed by the
+    // IF NOT EXISTS check) — keyword1.test quotes it as `"if"`.
+    for kw in ["primary", "select", "not", "if"] {
+        let sql = format!("CREATE INDEX {} ON t1(a)", kw);
+        assert!(
+            Parser::parse_sql(&sql).is_err(),
+            "CREATE INDEX {:?} must stay a parse error (SQLite parity)",
+            kw
+        );
+    }
+    // The quoted form works.
+    let result = Parser::parse_sql("CREATE INDEX \"if\" ON t1(a)");
+    assert!(result.is_ok(), "CREATE INDEX \"if\" must parse: {:?}", result.err());
+}
+
+#[test]
+fn test_drop_index_with_fallback_keyword_name() {
+    for kw in ["abort", "end", "view"] {
+        let sql = format!("DROP INDEX {}", kw);
+        let result = Parser::parse_sql(&sql);
+        assert!(result.is_ok(), "DROP INDEX {:?} must parse: {:?}", kw, result.err());
+        match result.unwrap() {
+            Statement::DropIndex(stmt) => assert_eq!(stmt.index_name, *kw),
+            other => panic!("Expected DropIndex, got: {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn test_indexed_by_with_fallback_keyword_name() {
+    // keyword1.test .2 shape: `SELECT b FROM t1 INDEXED BY abort WHERE a=2`,
+    // including bare `if` (which the test does NOT quote in this position).
+    for kw in ["abort", "if", "end", "with", "cast"] {
+        let sql = format!("SELECT b FROM t1 INDEXED BY {} WHERE a = 2", kw);
+        let result = Parser::parse_sql(&sql);
+        assert!(result.is_ok(), "INDEXED BY {:?} must parse: {:?}", kw, result.err());
+        match result.unwrap() {
+            Statement::Select(stmt) => {
+                let from = stmt.from.expect("FROM clause expected");
+                match from {
+                    vibesql_ast::FromClause::Table { index_hint, .. } => {
+                        assert_eq!(
+                            index_hint,
+                            Some(vibesql_ast::IndexHint::IndexedBy(kw.to_string())),
+                            "hint name must be lowercased for catalog lookup"
+                        );
+                    }
+                    other => panic!("Expected Table from-clause, got: {:?}", other),
+                }
+            }
+            other => panic!("Expected Select, got: {:?}", other),
+        }
+    }
+}

--- a/crates/vibesql-storage/src/persistence/binary/catalog.rs
+++ b/crates/vibesql-storage/src/persistence/binary/catalog.rs
@@ -968,7 +968,15 @@ pub(super) fn parse_data_type(type_str: &str) -> Result<vibesql_types::DataType,
         }
         // Null type
         "NULL" => Ok(DataType::Null),
-        _ => Err(StorageError::NotImplemented(format!("Unsupported data type: {}", type_str))),
+        // Any other name is a SQLite-style user-defined type. The save side
+        // (`data_type_to_sql`) writes `UserDefined` type names verbatim, so an
+        // unknown name here is the round-trip of a type like
+        // `CREATE TABLE t(x banana)` or a fallback keyword used as a type name
+        // (`CREATE TABLE attach(attach attach)`, keyword1.test). Storage is
+        // governed by affinity only, exactly as at first parse. Erroring here
+        // used to make such tables silently vanish on reopen (issue #5816;
+        // the error-swallow itself is tracked in #5855).
+        _ => Ok(DataType::UserDefined { type_name: type_str.to_string() }),
     }
 }
 
@@ -1031,6 +1039,63 @@ mod tests {
             table.schema.sql_source.as_deref(),
             Some(original_sql),
             "verbatim multi-line CREATE TABLE source must survive binary persistence (issue #5619)"
+        );
+    }
+
+    /// Issue #5816: `UserDefined` column types (any SQLite-style type name,
+    /// including fallback keywords like `attach` used as a type) must survive
+    /// a binary catalog round-trip. The save side writes the type name
+    /// verbatim; before this fix the read side had no `UserDefined` fallback,
+    /// so `CREATE TABLE t(x banana)` reloaded as "Unsupported data type" and
+    /// the table silently vanished on reopen (swallow tracked in #5855).
+    #[test]
+    fn test_binary_catalog_round_trips_user_defined_type() {
+        let mut db = Database::new();
+
+        let schema = vibesql_catalog::TableSchema::new(
+            "t3".to_string(),
+            vec![
+                vibesql_catalog::ColumnSchema {
+                    name: "x".to_string(),
+                    data_type: vibesql_types::DataType::UserDefined {
+                        type_name: "banana".to_string(),
+                    },
+                    nullable: true,
+                    default_value: None,
+                    generated_expr: None,
+                    collation: None,
+                    is_exact_integer_type: false,
+                },
+                vibesql_catalog::ColumnSchema {
+                    name: "attach".to_string(),
+                    data_type: vibesql_types::DataType::UserDefined {
+                        type_name: "attach".to_string(),
+                    },
+                    nullable: true,
+                    default_value: None,
+                    generated_expr: None,
+                    collation: None,
+                    is_exact_integer_type: false,
+                },
+            ],
+        );
+        let identifier = vibesql_catalog::TableIdentifier::new("t3", false);
+        db.create_table_with_identifier(schema, identifier).unwrap();
+
+        let mut buf = Vec::new();
+        write_catalog(&mut buf, &db).unwrap();
+        let reloaded = read_catalog_v(&mut &buf[..], VERSION).unwrap();
+
+        let table = reloaded.get_table("t3").expect("t3 must survive the round-trip");
+        assert_eq!(
+            table.schema.columns[0].data_type,
+            vibesql_types::DataType::UserDefined { type_name: "banana".to_string() },
+            "UserDefined type name must survive binary persistence (issue #5816)"
+        );
+        assert_eq!(
+            table.schema.columns[1].data_type,
+            vibesql_types::DataType::UserDefined { type_name: "attach".to_string() },
+            "fallback-keyword type name must survive binary persistence (issue #5816)"
         );
     }
 


### PR DESCRIPTION
## Summary

SQLite demotes its `%fallback` keyword set to plain identifiers wherever the keyword reading does not fit the grammar. keyword1.test exercises 58 such words as table, column, **type**, and index names — all 116 tests failed. This PR implements the curator's three diagnosed bugs plus two additional root causes uncovered during implementation, taking keyword1.test from **0/116 to 116/116**.

## Changes

**Bug 1 — keywords as column type names** (`parser/create/types.rs`, `keywords.rs`)
- New `Keyword::is_sqlite_fallback_keyword()` mirrors `parse.y`'s `%fallback ID` list (intersected with VibeSQL's keyword enum, minus `GENERATED`/`ALWAYS` which `ALTER TABLE ADD COLUMN` must consume before the type).
- Type-name position accepts fallback keywords as `DataType::UserDefined` (lowercased). Truly-reserved words (`PRIMARY`, `NOT`, `CROSS`, `SELECT`, ...) stay rejected — **verified against the sqlite3 oracle for all 58 kwlist words and 11 reserved words** (`NULL`/`UNIQUE` are accepted by both engines via the column-constraint production, not as types).

**Bug 2 — UserDefined types silently lost on reopen** (`storage/persistence/binary/catalog.rs`)
- `parse_data_type` now falls back to `DataType::UserDefined` for unknown type names instead of `Err(NotImplemented)`. The save side writes UserDefined names verbatim, so `CREATE TABLE t(x banana)` previously made the table vanish silently in the next process. Scope note: this fixes the round-trip only; the silent error-swallow on open remains tracked as P0 #5855 (this change removes the trigger for the keyword1 case but does not build fail-closed machinery).

**Bug 3 — keywords as index names** (`parser/index.rs`, `arena_parser/ddl.rs`, `parser/select/from_clause.rs`, `arena_parser/select.rs`, `parser/helpers.rs`)
- New `parse_identifier_or_fallback_keyword()` helper; used for `CREATE INDEX` (both classic paths), `DROP INDEX`, and the arena CREATE INDEX name.
- `INDEXED BY` arms (classic + arena) widened from `can_be_identifier()` to include fallback keywords; names lowercased so catalog lookup matches `CREATE INDEX abort`.
- Bare `CREATE INDEX if` still errors (consumed by IF NOT EXISTS check), matching SQLite — the test quotes `"if"` there but uses bare `if` for `INDEXED BY`, which works.

**Bug 4 (additional) — expression/FROM-position denylist too broad** (`keywords.rs`, `from_clause.rs`)
- The test's `.1` shape needs `SELECT * FROM $kw ORDER BY $kw ASC` for every word. Removed `BY, END, LIKE, GLOB, OFFSET, PRAGMA, RECURSIVE, REPLACE, WITH` from the expression-position denylist: at operand start they are unambiguous column references (operator/clause roles only arise in operator or clause position, and `like(...)`/`replace(...)` function calls are claimed by the function-call parser first). `CAST`/`CURRENT_*` stay denied in expressions (SQLite rejects bare `ORDER BY cast` too — the test quotes them) but are accepted as FROM table names via new `can_be_identifier_in_table_position()` (`SELECT * FROM cast`).

**Bug 5 (additional) — CLI stdin splitter glued statements on identifier `begin`** (`cli/script.rs`)
- The statement splitter treated any non-transaction word `BEGIN` as a trigger-body opener, suppressing semicolon splitting. `CREATE TABLE begin(begin begin); INSERT INTO begin ...` became one giant statement (the TCL shim feeds SQL via stdin), failing keyword1-begin.1. BEGIN now only opens a body inside `CREATE TRIGGER/PROCEDURE/FUNCTION`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `make test-tcl-file FILE=keyword1.test` 116/116 | PASS | 116/116, 0 failed (was 0/116) |
| `CREATE TABLE abort(abort abort); INSERT ...; SELECT ... ORDER BY abort ASC` returns 99 | PASS | CLI returns 99 |
| Cross-process round-trip: `CREATE TABLE t(x banana)` visible in second CLI invocation | PASS | Second invocation returns the row; also `attach attach` type round-trips |
| `CREATE INDEX abort ON t1(a)` and `SELECT b FROM t1 INDEXED BY abort WHERE a=2` unquoted | PASS | Probed via CLI for all 58 words; executor index-hint validation passes (lowercased names) |
| No regressions: `a PRIMARY KEY`, `a NOT NULL`, `CREATE INDEX IF NOT EXISTS`, `VARYING CHARACTER` | PASS | Unit test `test_column_constraints_still_parse_after_keyword_relaxation` + full parser suite |
| `cargo test -p vibesql-parser -p vibesql-storage` passes | PASS | parser 1546, storage 779, cli 153 — all green (release profile) |

## Test Plan

- **sqlite3 oracle parity**: scripted all 58 kwlist words + reserved words against `sqlite3` — accept/reject matches exactly (bare `ORDER BY cast` and bare `DROP TABLE if` are rejected by both engines; the test quotes them).
- **New unit tests**: `tests/create_table/keyword_type_names.rs` (58-word accept loop, UserDefined mapping, reserved rejections, constraint regression guards, expression/FROM-position checks, operator/special-form preservation); `tests/index.rs` (fallback CREATE/DROP INDEX names, reserved rejections, INDEXED BY incl. bare `if`); `catalog.rs` UserDefined round-trip test; `script.rs` splitter tests (identifier `begin` splits, transaction BEGIN splits, trigger bodies still glue).
- **TCL regressions** (vs. results-DB baselines): keyword1 116/116; select1.test 188/188; table.test 64 passed (**baseline 61** — 3 tests newly pass); index.test 69 passed / 0 failed; insert.test 51 passed / 0 failed; trigger1.test 35 passed (= baseline); fkey6.test 25 passed (= baseline, exercises the splitter's transaction batching).

Closes #5816