### PR TITLE
fix(errors): emit SQLite-exact wording for multiple-PK, view-exists, LIMIT/OFFSET, and bare-column errors

### DIFF
--- a/crates/vibesql-executor/src/constraint_validator.rs
+++ b/crates/vibesql-executor/src/constraint_validator.rs
@@ -46,6 +46,7 @@ impl ConstraintValidator {
     ///
     /// # Arguments
     ///
+    /// * `table_name` - The table name (used in SQLite-compatible error messages)
     /// * `columns` - The column definitions from the DDL statement
     /// * `table_constraints` - The table-level constraints
     ///
@@ -57,6 +58,7 @@ impl ConstraintValidator {
     ///
     /// Returns `ExecutorError::MultiplePrimaryKeys` if multiple PRIMARY KEY constraints are defined
     pub fn process_constraints(
+        table_name: &str,
         columns: &[ColumnDef],
         table_constraints: &[TableConstraint],
     ) -> Result<ConstraintResult, ExecutorError> {
@@ -71,10 +73,14 @@ impl ConstraintValidator {
                 match &constraint.kind {
                     ColumnConstraintKind::PrimaryKey { .. } => {
                         if has_column_level_pk {
-                            return Err(ExecutorError::MultiplePrimaryKeys);
+                            return Err(ExecutorError::MultiplePrimaryKeys {
+                                table_name: table_name.to_string(),
+                            });
                         }
                         if result.primary_key.is_some() {
-                            return Err(ExecutorError::MultiplePrimaryKeys);
+                            return Err(ExecutorError::MultiplePrimaryKeys {
+                                table_name: table_name.to_string(),
+                            });
                         }
                         result.primary_key = Some(vec![col_def.name.clone()]);
                         // SQLite quirk: only INTEGER PRIMARY KEY has implicit NOT NULL
@@ -127,7 +133,9 @@ impl ConstraintValidator {
                 TableConstraintKind::PrimaryKey { columns: pk_cols, .. } => {
                     // Only allow one PRIMARY KEY constraint total (column-level OR table-level)
                     if result.primary_key.is_some() {
-                        return Err(ExecutorError::MultiplePrimaryKeys);
+                        return Err(ExecutorError::MultiplePrimaryKeys {
+                            table_name: table_name.to_string(),
+                        });
                     }
                     // Extract column names from IndexColumn structs
                     let column_names: Vec<String> =
@@ -249,7 +257,7 @@ mod tests {
             "id",
             vec![ColumnConstraintKind::PrimaryKey { on_conflict: None }],
         )];
-        let result = ConstraintValidator::process_constraints(&columns, &[]).unwrap();
+        let result = ConstraintValidator::process_constraints("test_table", &columns, &[]).unwrap();
 
         assert_eq!(result.primary_key, Some(vec!["id".to_string()]));
         assert!(result.not_null_columns.contains(&"id".to_string()));
@@ -277,7 +285,8 @@ mod tests {
             },
         }];
 
-        let result = ConstraintValidator::process_constraints(&columns, &constraints).unwrap();
+        let result =
+            ConstraintValidator::process_constraints("test_table", &columns, &constraints).unwrap();
 
         assert_eq!(result.primary_key, Some(vec!["id".to_string(), "tenant_id".to_string()]));
         assert!(result.not_null_columns.contains(&"id".to_string()));
@@ -302,8 +311,11 @@ mod tests {
             },
         }];
 
-        let result = ConstraintValidator::process_constraints(&columns, &constraints);
-        assert!(matches!(result, Err(ExecutorError::MultiplePrimaryKeys)));
+        let result = ConstraintValidator::process_constraints("test_table", &columns, &constraints);
+        assert!(matches!(result, Err(ExecutorError::MultiplePrimaryKeys { .. })));
+        // SQLite-compatible wording (misc1-7.1/7.2, fuzz-8.1)
+        let err = result.err().expect("expected MultiplePrimaryKeys error");
+        assert_eq!(err.to_string(), "table \"test_table\" has more than one primary key");
     }
 
     #[test]
@@ -324,7 +336,8 @@ mod tests {
             },
         }];
 
-        let result = ConstraintValidator::process_constraints(&columns, &constraints).unwrap();
+        let result =
+            ConstraintValidator::process_constraints("test_table", &columns, &constraints).unwrap();
 
         assert_eq!(result.unique_constraints.len(), 2);
         assert!(result.unique_constraints.contains(&vec!["email".to_string()]));
@@ -348,7 +361,7 @@ mod tests {
             vec![ColumnConstraintKind::Check(Box::new(check_expr.clone()))],
         )];
 
-        let result = ConstraintValidator::process_constraints(&columns, &[]).unwrap();
+        let result = ConstraintValidator::process_constraints("test_table", &columns, &[]).unwrap();
 
         assert_eq!(result.check_constraints.len(), 1);
         assert_eq!(result.check_constraints[0].1, check_expr);
@@ -384,7 +397,7 @@ mod tests {
             DataType::Varchar { max_length: None },
             vec![ColumnConstraintKind::PrimaryKey { on_conflict: None }],
         )];
-        let result = ConstraintValidator::process_constraints(&columns, &[]).unwrap();
+        let result = ConstraintValidator::process_constraints("test_table", &columns, &[]).unwrap();
 
         assert_eq!(result.primary_key, Some(vec!["name".to_string()]));
         // NOT NULL should NOT be added for non-INTEGER PRIMARY KEY
@@ -399,7 +412,7 @@ mod tests {
             DataType::Varchar { max_length: None },
             vec![ColumnConstraintKind::PrimaryKey { on_conflict: None }],
         )];
-        let result = ConstraintValidator::process_constraints(&columns, &[]).unwrap();
+        let result = ConstraintValidator::process_constraints("test_table", &columns, &[]).unwrap();
 
         assert_eq!(result.primary_key, Some(vec!["c".to_string()]));
         assert!(!result.not_null_columns.contains(&"c".to_string()));
@@ -413,7 +426,7 @@ mod tests {
             DataType::Integer,
             vec![ColumnConstraintKind::PrimaryKey { on_conflict: None }],
         )];
-        let result = ConstraintValidator::process_constraints(&columns, &[]).unwrap();
+        let result = ConstraintValidator::process_constraints("test_table", &columns, &[]).unwrap();
 
         assert_eq!(result.primary_key, Some(vec!["id".to_string()]));
         assert!(result.not_null_columns.contains(&"id".to_string()));
@@ -445,7 +458,8 @@ mod tests {
             },
         }];
 
-        let result = ConstraintValidator::process_constraints(&columns, &constraints).unwrap();
+        let result =
+            ConstraintValidator::process_constraints("test_table", &columns, &constraints).unwrap();
 
         assert_eq!(result.primary_key, Some(vec!["id".to_string(), "code".to_string()]));
         // Only the INTEGER column should have NOT NULL
@@ -461,7 +475,7 @@ mod tests {
             DataType::Real,
             vec![ColumnConstraintKind::PrimaryKey { on_conflict: None }],
         )];
-        let result = ConstraintValidator::process_constraints(&columns, &[]).unwrap();
+        let result = ConstraintValidator::process_constraints("test_table", &columns, &[]).unwrap();
 
         assert_eq!(result.primary_key, Some(vec!["value".to_string()]));
         assert!(!result.not_null_columns.contains(&"value".to_string()));
@@ -475,7 +489,7 @@ mod tests {
             DataType::Bigint,
             vec![ColumnConstraintKind::PrimaryKey { on_conflict: None }],
         )];
-        let result = ConstraintValidator::process_constraints(&columns, &[]).unwrap();
+        let result = ConstraintValidator::process_constraints("test_table", &columns, &[]).unwrap();
 
         assert_eq!(result.primary_key, Some(vec!["big_id".to_string()]));
         // SQLite only treats INTEGER (not INT, BIGINT, etc.) specially

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -262,9 +262,7 @@ impl CreateTableExecutor {
         // sqlite3 still raises `there is already an index named X` (verified
         // against 3.51.0). IF NOT EXISTS only silences a same-type (table)
         // collision, handled above.
-        if database
-            .catalog
-            .index_name_exists_in_schema(&schema_name, identifier.table_canonical())
+        if database.catalog.index_name_exists_in_schema(&schema_name, identifier.table_canonical())
         {
             // Echo the name as the user spelled it (sqlite3 prints the bare
             // index name without schema qualification).
@@ -334,8 +332,11 @@ impl CreateTableExecutor {
             .collect();
 
         // Process constraints using the constraint validator
-        let constraint_result =
-            ConstraintValidator::process_constraints(&stmt.columns, &stmt.table_constraints)?;
+        let constraint_result = ConstraintValidator::process_constraints(
+            &table_name,
+            &stmt.columns,
+            &stmt.table_constraints,
+        )?;
 
         // Apply constraint results to columns (updates nullability)
         ConstraintValidator::apply_to_columns(&mut columns, &constraint_result);
@@ -781,10 +782,7 @@ impl CreateTableExecutor {
         // Cross-type namespace collision: a CTAS name already used by an index
         // must fail with `there is already an index named <name>`, just like the
         // bare CREATE TABLE path. Keeps the schema reloadable (issue #5613).
-        if database
-            .catalog
-            .index_name_exists_in_schema(schema_name, identifier.table_canonical())
-        {
+        if database.catalog.index_name_exists_in_schema(schema_name, identifier.table_canonical()) {
             return Err(ExecutorError::SqliteCompatError(format!(
                 "there is already an index named {}",
                 table_name

--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -176,7 +176,11 @@ pub enum ExecutorError {
         child: String,
         parent: String,
     },
-    MultiplePrimaryKeys,
+    /// More than one PRIMARY KEY defined for a table (SQLite-compatible error).
+    /// Format: `table "<name>" has more than one primary key`
+    MultiplePrimaryKeys {
+        table_name: String,
+    },
     CannotDropColumn(String),
     ConstraintNotFound {
         constraint_name: String,
@@ -803,8 +807,11 @@ impl std::fmt::Display for ExecutorError {
                 // SQLite-compatible error format from fkey.c::sqlite3FkLocateIndex.
                 write!(f, "foreign key mismatch - \"{}\" referencing \"{}\"", child, parent)
             }
-            ExecutorError::MultiplePrimaryKeys => {
-                write!(f, "{}", vibe_msg!("executor-multiple-primary-keys"))
+            ExecutorError::MultiplePrimaryKeys { table_name } => {
+                // SQLite-compatible error format from build.c (misc1-7.1/7.2,
+                // fuzz-8.1). Hardcoded (not localized) to stay byte-identical
+                // to SQLite, matching InsertNoSuchColumn / ForeignKeyMismatch.
+                write!(f, "table \"{}\" has more than one primary key", table_name)
             }
             ExecutorError::CannotDropColumn(msg) => {
                 write!(f, "{}", vibe_msg!("executor-cannot-drop-column", message = msg.as_str()))
@@ -1578,7 +1585,9 @@ impl From<vibesql_catalog::CatalogError> for ExecutorError {
                 ExecutorError::Other(format!("Translation '{}' not found", name))
             }
             vibesql_catalog::CatalogError::ViewAlreadyExists(name) => {
-                ExecutorError::Other(format!("View '{}' already exists", name))
+                // SQLite-compatible wording (view1.test, fuzz-8.1):
+                // `view v already exists` — lowercase, unquoted name.
+                ExecutorError::Other(format!("view {} already exists", name))
             }
             vibesql_catalog::CatalogError::ViewNotFound(name) => {
                 ExecutorError::Other(format!("View '{}' not found", name))

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs
@@ -192,9 +192,9 @@ fn compute_single_select_column_count(
                 if let Some(from_clause) = from {
                     count += count_columns_in_from_clause(from_clause, database, cte_results)?;
                 } else {
-                    // SELECT * without FROM is an error (should be caught earlier)
-                    return Err(ExecutorError::UnsupportedFeature(
-                        "SELECT * requires FROM clause".to_string(),
+                    // SELECT * without FROM: SQLite-exact wording (#5804)
+                    return Err(ExecutorError::SqliteCompatError(
+                        "no tables specified".to_string(),
                     ));
                 }
             }

--- a/crates/vibesql-executor/src/select/executor/arena_execution.rs
+++ b/crates/vibesql-executor/src/select/executor/arena_execution.rs
@@ -385,7 +385,13 @@ impl SelectExecutor<'_> {
         expr: &vibesql_ast::arena::Expression,
     ) -> Result<i64, ExecutorError> {
         match expr {
-            vibesql_ast::arena::Expression::Literal(vibesql_types::SqlValue::Integer(n)) => Ok(*n),
+            // Literal values go through the shared SQLite LIMIT/OFFSET
+            // affinity coercion (integers, booleans as 0/1, integral reals,
+            // full-string numeric text); non-coercible values error with
+            // SQLite's exact `datatype mismatch` wording (#5804).
+            vibesql_ast::arena::Expression::Literal(value) => {
+                crate::select::helpers::coerce_limit_offset_to_i64(value.clone())
+            }
             _ => Err(ExecutorError::InvalidLimitOffset {
                 clause: "LIMIT/OFFSET".to_string(),
                 value: "<expression>".to_string(),

--- a/crates/vibesql-executor/src/select/executor/columns.rs
+++ b/crates/vibesql-executor/src/select/executor/columns.rs
@@ -208,8 +208,9 @@ impl SelectExecutor<'_> {
                             }
                         }
                     } else {
-                        return Err(ExecutorError::UnsupportedFeature(
-                            "SELECT * requires FROM clause".to_string(),
+                        // SELECT * without FROM: SQLite-exact wording (#5804)
+                        return Err(ExecutorError::SqliteCompatError(
+                            "no tables specified".to_string(),
                         ));
                     }
                 }

--- a/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
@@ -204,9 +204,9 @@ fn compute_single_select_column_count(
                 if let Some(from) = &stmt.from {
                     count += count_columns_in_from_clause(from, database, cte_results)?;
                 } else {
-                    // SELECT * without FROM is an error (should be caught earlier)
-                    return Err(ExecutorError::UnsupportedFeature(
-                        "SELECT * requires FROM clause".to_string(),
+                    // SELECT * without FROM: SQLite-exact wording (#5804)
+                    return Err(ExecutorError::SqliteCompatError(
+                        "no tables specified".to_string(),
                     ));
                 }
             }

--- a/crates/vibesql-executor/src/select/executor/nonagg/without_from.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/without_from.rs
@@ -171,8 +171,9 @@ impl SelectExecutor<'_> {
             match item {
                 vibesql_ast::SelectItem::Wildcard { .. }
                 | vibesql_ast::SelectItem::QualifiedWildcard { .. } => {
-                    return Err(ExecutorError::UnsupportedFeature(
-                        "SELECT * and qualified wildcards require FROM clause".to_string(),
+                    // SQLite-exact wording for `SELECT *` without FROM (#5804)
+                    return Err(ExecutorError::SqliteCompatError(
+                        "no tables specified".to_string(),
                     ));
                 }
                 vibesql_ast::SelectItem::Expression { expr, .. } => {
@@ -185,15 +186,17 @@ impl SelectExecutor<'_> {
                     // resolvable from the firing row's context, so they must not be
                     // rejected here. A plain (non-pseudo) column reference still
                     // requires a FROM clause — it has nothing to bind to.
-                    let column_check_fails = if self.trigger_context.is_some() {
-                        self.expression_references_non_pseudo_column(expr)
+                    // SQLite reports this as `no such column: X` (#5804), with
+                    // the reference's source case preserved.
+                    let unresolved_ref = if self.trigger_context.is_some() {
+                        self.find_non_pseudo_column_ref(expr)
                     } else {
-                        self.expression_references_column(expr)
+                        self.find_column_ref(expr)
                     };
-                    if !has_outer_context && column_check_fails {
-                        return Err(ExecutorError::UnsupportedFeature(
-                            "Column reference requires FROM clause".to_string(),
-                        ));
+                    if !has_outer_context {
+                        if let Some(column_ref) = unresolved_ref {
+                            return Err(ExecutorError::NoSuchColumn { column_ref });
+                        }
                     }
 
                     // Evaluate the expression
@@ -226,7 +229,9 @@ impl SelectExecutor<'_> {
                                 self.database,
                                 trigger_ctx,
                             ),
-                            None => ExpressionEvaluator::with_database(&empty_schema, self.database),
+                            None => {
+                                ExpressionEvaluator::with_database(&empty_schema, self.database)
+                            }
                         };
                         if let Some(cte) = cte_ctx {
                             evaluator = evaluator.with_cte_context(cte);
@@ -275,15 +280,15 @@ impl SelectExecutor<'_> {
             match item {
                 vibesql_ast::SelectItem::Wildcard { .. }
                 | vibesql_ast::SelectItem::QualifiedWildcard { .. } => {
-                    return Err(ExecutorError::UnsupportedFeature(
-                        "SELECT * and qualified wildcards require FROM clause".to_string(),
+                    // SQLite-exact wording for `SELECT *` without FROM (#5804)
+                    return Err(ExecutorError::SqliteCompatError(
+                        "no tables specified".to_string(),
                     ));
                 }
                 vibesql_ast::SelectItem::Expression { expr, alias, .. } => {
-                    if self.expression_references_column(expr) {
-                        return Err(ExecutorError::UnsupportedFeature(
-                            "Column reference requires FROM clause".to_string(),
-                        ));
+                    if let Some(column_ref) = self.find_column_ref(expr) {
+                        // SQLite-exact wording (#5804), source case preserved
+                        return Err(ExecutorError::NoSuchColumn { column_ref });
                     }
                     let value = evaluator.eval(expr, &empty_row)?;
                     let column_name = alias.clone().unwrap_or_default();
@@ -389,8 +394,9 @@ impl SelectExecutor<'_> {
             match item {
                 vibesql_ast::SelectItem::Wildcard { .. }
                 | vibesql_ast::SelectItem::QualifiedWildcard { .. } => {
-                    return Err(ExecutorError::UnsupportedFeature(
-                        "SELECT * and qualified wildcards require FROM clause".to_string(),
+                    // SQLite-exact wording for `SELECT *` without FROM (#5804)
+                    return Err(ExecutorError::SqliteCompatError(
+                        "no tables specified".to_string(),
                     ));
                 }
                 vibesql_ast::SelectItem::Expression { expr, .. } => {

--- a/crates/vibesql-executor/src/select/executor/utils.rs
+++ b/crates/vibesql-executor/src/select/executor/utils.rs
@@ -2,150 +2,148 @@
 
 use super::builder::SelectExecutor;
 
-/// Check if an expression references a column (which requires FROM clause).
+/// Find the first column reference in an expression that would require a FROM
+/// clause to resolve, returning its display text (source case preserved) for
+/// use in SQLite-compatible `no such column: X` errors (#5804).
 ///
 /// `count_pseudo` controls whether NEW/OLD pseudo-variables (`NEW.x`, `OLD.x`)
 /// count as column references. They do for a plain from-less SELECT (which has
 /// no row to resolve them from), but inside a trigger body (#5445) the firing
 /// row's NEW/OLD context resolves them, so callers there pass `false`.
-fn expression_references_column_inner(expr: &vibesql_ast::Expression, count_pseudo: bool) -> bool {
-    let expression_references_column =
-        |e: &vibesql_ast::Expression| expression_references_column_inner(e, count_pseudo);
+///
+/// Returns `None` when the expression contains no such reference. Subqueries
+/// (scalar subqueries, EXISTS) have their own scope and are not descended into.
+fn find_from_less_column_ref(expr: &vibesql_ast::Expression, count_pseudo: bool) -> Option<String> {
+    let find = |e: &vibesql_ast::Expression| find_from_less_column_ref(e, count_pseudo);
     match expr {
-        vibesql_ast::Expression::ColumnRef(_) => true,
-        vibesql_ast::Expression::PseudoVariable { .. } => count_pseudo, /* Pseudo-variables */
-        // reference columns (OLD.x, NEW.x)
-        vibesql_ast::Expression::Default => false, // DEFAULT doesn't reference columns
-        vibesql_ast::Expression::DuplicateKeyValue { .. } => false, /* DuplicateKeyValue doesn't */
+        vibesql_ast::Expression::ColumnRef(col_id) => Some(col_id.display().to_string()),
+        vibesql_ast::Expression::PseudoVariable { pseudo_table, column } => {
+            // Pseudo-variables reference columns (OLD.x, NEW.x)
+            if count_pseudo {
+                use vibesql_ast::pretty_print::ToSql;
+                Some(format!("{}.{}", pseudo_table.to_sql(), column))
+            } else {
+                None
+            }
+        }
+        vibesql_ast::Expression::Default => None, // DEFAULT doesn't reference columns
+        vibesql_ast::Expression::DuplicateKeyValue { .. } => None, /* DuplicateKeyValue doesn't */
         // reference columns
-        vibesql_ast::Expression::BinaryOp { left, right, .. } => {
-            expression_references_column(left) || expression_references_column(right)
-        }
+        vibesql_ast::Expression::BinaryOp { left, right, .. } => find(left).or_else(|| find(right)),
 
-        vibesql_ast::Expression::UnaryOp { expr, .. } => expression_references_column(expr),
+        vibesql_ast::Expression::UnaryOp { expr, .. } => find(expr),
 
-        vibesql_ast::Expression::Function { args, .. } => {
-            args.iter().any(expression_references_column)
-        }
+        vibesql_ast::Expression::Function { args, .. } => args.iter().find_map(find),
 
-        vibesql_ast::Expression::AggregateFunction { args, .. } => {
-            args.iter().any(expression_references_column)
-        }
+        vibesql_ast::Expression::AggregateFunction { args, .. } => args.iter().find_map(find),
 
-        vibesql_ast::Expression::IsNull { expr, .. } => expression_references_column(expr),
+        vibesql_ast::Expression::IsNull { expr, .. } => find(expr),
 
         vibesql_ast::Expression::IsDistinctFrom { left, right, .. } => {
-            expression_references_column(left) || expression_references_column(right)
+            find(left).or_else(|| find(right))
         }
 
-        vibesql_ast::Expression::IsTruthValue { expr, .. } => expression_references_column(expr),
+        vibesql_ast::Expression::IsTruthValue { expr, .. } => find(expr),
 
         vibesql_ast::Expression::InList { expr, values, .. } => {
-            expression_references_column(expr) || values.iter().any(expression_references_column)
+            find(expr).or_else(|| values.iter().find_map(find))
         }
 
         vibesql_ast::Expression::Between { expr, low, high, .. } => {
-            expression_references_column(expr)
-                || expression_references_column(low)
-                || expression_references_column(high)
+            find(expr).or_else(|| find(low)).or_else(|| find(high))
         }
 
-        vibesql_ast::Expression::Cast { expr, .. } => expression_references_column(expr),
+        vibesql_ast::Expression::Cast { expr, .. } => find(expr),
 
-        vibesql_ast::Expression::Interval { value, .. } => expression_references_column(value),
+        vibesql_ast::Expression::Interval { value, .. } => find(value),
 
         vibesql_ast::Expression::Position { substring, string, character_unit: _ } => {
-            expression_references_column(substring) || expression_references_column(string)
+            find(substring).or_else(|| find(string))
         }
 
         vibesql_ast::Expression::Trim { removal_char, string, .. } => {
-            removal_char.as_ref().is_some_and(|e| expression_references_column(e))
-                || expression_references_column(string)
+            removal_char.as_ref().and_then(|e| find(e)).or_else(|| find(string))
         }
 
-        vibesql_ast::Expression::Extract { expr, .. } => expression_references_column(expr),
+        vibesql_ast::Expression::Extract { expr, .. } => find(expr),
 
         vibesql_ast::Expression::Like { expr, pattern, .. }
         | vibesql_ast::Expression::Glob { expr, pattern, .. } => {
-            expression_references_column(expr) || expression_references_column(pattern)
+            find(expr).or_else(|| find(pattern))
         }
 
         vibesql_ast::Expression::In { expr, .. } => {
             // Note: subquery could reference outer columns but that's a different case
-            expression_references_column(expr)
+            find(expr)
         }
 
-        vibesql_ast::Expression::QuantifiedComparison { expr, .. } => {
-            expression_references_column(expr)
-        }
+        vibesql_ast::Expression::QuantifiedComparison { expr, .. } => find(expr),
 
-        vibesql_ast::Expression::Case { operand, when_clauses, else_result } => {
-            operand.as_ref().is_some_and(|e| expression_references_column(e))
-                || when_clauses.iter().any(|when_clause| {
-                    when_clause.conditions.iter().any(expression_references_column)
-                        || expression_references_column(&when_clause.result)
+        vibesql_ast::Expression::Case { operand, when_clauses, else_result } => operand
+            .as_ref()
+            .and_then(|e| find(e))
+            .or_else(|| {
+                when_clauses.iter().find_map(|when_clause| {
+                    when_clause
+                        .conditions
+                        .iter()
+                        .find_map(find)
+                        .or_else(|| find(&when_clause.result))
                 })
-                || else_result.as_ref().is_some_and(|e| expression_references_column(e))
-        }
+            })
+            .or_else(|| else_result.as_ref().and_then(|e| find(e))),
 
         vibesql_ast::Expression::WindowFunction { function, over } => {
             // Check window function arguments
-            let args_reference_column = match function {
+            let args_reference = match function {
                 vibesql_ast::WindowFunctionSpec::Aggregate { args, .. }
                 | vibesql_ast::WindowFunctionSpec::Ranking { args, .. }
-                | vibesql_ast::WindowFunctionSpec::Value { args, .. } => {
-                    args.iter().any(expression_references_column)
-                }
+                | vibesql_ast::WindowFunctionSpec::Value { args, .. } => args.iter().find_map(find),
             };
 
             // Check PARTITION BY and ORDER BY clauses
-            let partition_references = over
-                .partition_by
-                .as_ref()
-                .is_some_and(|exprs| exprs.iter().any(expression_references_column));
-
-            let order_references = over.order_by.as_ref().is_some_and(|items| {
-                items.iter().any(|item| expression_references_column(&item.expr))
-            });
-
-            args_reference_column || partition_references || order_references
+            args_reference
+                .or_else(|| {
+                    over.partition_by.as_ref().and_then(|exprs| exprs.iter().find_map(find))
+                })
+                .or_else(|| {
+                    over.order_by
+                        .as_ref()
+                        .and_then(|items| items.iter().find_map(|item| find(&item.expr)))
+                })
         }
 
         // These don't contain column references:
-        vibesql_ast::Expression::Literal(_) => false,
-        vibesql_ast::Expression::Wildcard => false,
-        vibesql_ast::Expression::ScalarSubquery(_) => false, // Subquery has its own scope
-        vibesql_ast::Expression::Exists { .. } => false,     // Subquery has its own scope
-        vibesql_ast::Expression::CurrentDate => false,
-        vibesql_ast::Expression::CurrentTime { .. } => false,
-        vibesql_ast::Expression::CurrentTimestamp { .. } => false,
-        vibesql_ast::Expression::NextValue { .. } => false, // Sequence reference, not column
-        vibesql_ast::Expression::SessionVariable { .. } => false, // Session variable, not column
+        vibesql_ast::Expression::Literal(_) => None,
+        vibesql_ast::Expression::Wildcard => None,
+        vibesql_ast::Expression::ScalarSubquery(_) => None, // Subquery has its own scope
+        vibesql_ast::Expression::Exists { .. } => None,     // Subquery has its own scope
+        vibesql_ast::Expression::CurrentDate => None,
+        vibesql_ast::Expression::CurrentTime { .. } => None,
+        vibesql_ast::Expression::CurrentTimestamp { .. } => None,
+        vibesql_ast::Expression::NextValue { .. } => None, // Sequence reference, not column
+        vibesql_ast::Expression::SessionVariable { .. } => None, // Session variable, not column
         vibesql_ast::Expression::MatchAgainst { columns, search_modifier, .. } => {
             // MATCH AGAINST references columns and the search term
-            !columns.is_empty() || expression_references_column(search_modifier)
+            columns.first().cloned().or_else(|| find(search_modifier))
         }
 
         // Placeholders don't reference columns (they're parameter markers)
         vibesql_ast::Expression::Placeholder(_)
         | vibesql_ast::Expression::NumberedPlaceholder(_)
-        | vibesql_ast::Expression::NamedPlaceholder(_) => false,
+        | vibesql_ast::Expression::NamedPlaceholder(_) => None,
 
         // Conjunction and Disjunction - check all children
         vibesql_ast::Expression::Conjunction(children)
-        | vibesql_ast::Expression::Disjunction(children) => {
-            children.iter().any(expression_references_column)
-        }
+        | vibesql_ast::Expression::Disjunction(children) => children.iter().find_map(find),
 
         // Row value constructor - check all values
-        vibesql_ast::Expression::RowValueConstructor(values) => {
-            values.iter().any(expression_references_column)
-        }
+        vibesql_ast::Expression::RowValueConstructor(values) => values.iter().find_map(find),
 
-        vibesql_ast::Expression::Collate { expr, .. } => expression_references_column(expr),
+        vibesql_ast::Expression::Collate { expr, .. } => find(expr),
 
         vibesql_ast::Expression::Raise { error_message, .. } => {
-            error_message.as_ref().is_some_and(|msg| expression_references_column(msg))
+            error_message.as_ref().and_then(|msg| find(msg))
         }
     }
 }
@@ -155,7 +153,7 @@ impl SelectExecutor<'_> {
     ///
     /// NEW/OLD pseudo-variables count as column references here.
     pub(super) fn expression_references_column(&self, expr: &vibesql_ast::Expression) -> bool {
-        expression_references_column_inner(expr, true)
+        find_from_less_column_ref(expr, true).is_some()
     }
 
     /// Check if an expression references a *non-pseudo* column (i.e. a real
@@ -168,7 +166,27 @@ impl SelectExecutor<'_> {
         &self,
         expr: &vibesql_ast::Expression,
     ) -> bool {
-        expression_references_column_inner(expr, false)
+        find_from_less_column_ref(expr, false).is_some()
+    }
+
+    /// Find the first column reference in an expression that a from-less
+    /// SELECT cannot resolve, returning its display text (source case
+    /// preserved) for SQLite's `no such column: X` error (#5804).
+    ///
+    /// NEW/OLD pseudo-variables count as unresolvable references here.
+    pub(super) fn find_column_ref(&self, expr: &vibesql_ast::Expression) -> Option<String> {
+        find_from_less_column_ref(expr, true)
+    }
+
+    /// Like [`Self::find_column_ref`], but ignores NEW/OLD pseudo-variables.
+    ///
+    /// Used inside a trigger body (#5445), where the firing row's NEW/OLD
+    /// context resolves pseudo-variables.
+    pub(super) fn find_non_pseudo_column_ref(
+        &self,
+        expr: &vibesql_ast::Expression,
+    ) -> Option<String> {
+        find_from_less_column_ref(expr, false)
     }
 
     /// Evaluate a LIMIT or OFFSET expression and convert to usize
@@ -220,7 +238,7 @@ impl SelectExecutor<'_> {
         // Convert to integer using the shared SQLite LIMIT/OFFSET affinity
         // rules (integers, booleans as 0/1, integral reals, full-string
         // numeric text — see select::helpers::coerce_limit_offset_to_i64).
-        let n = crate::select::helpers::coerce_limit_offset_to_i64(value, clause_name)?;
+        let n = crate::select::helpers::coerce_limit_offset_to_i64(value)?;
 
         // SQLite compatibility: negative values have special meanings
         if n < 0 {

--- a/crates/vibesql-executor/src/select/helpers.rs
+++ b/crates/vibesql-executor/src/select/helpers.rs
@@ -74,7 +74,7 @@ pub(crate) fn evaluate_limit_offset_expr(
     database: &vibesql_storage::Database,
     clause_name: &str,
 ) -> Result<usize, crate::ExecutorError> {
-    let raw = evaluate_limit_offset_expr_raw(expr, database, clause_name)?;
+    let raw = evaluate_limit_offset_expr_raw(expr, database)?;
     if clause_name == "OFFSET" {
         // Negative offset is treated as 0
         Ok(if raw < 0 { 0 } else { raw as usize })
@@ -92,7 +92,6 @@ pub(crate) fn evaluate_limit_offset_expr(
 fn evaluate_limit_offset_expr_raw(
     expr: &vibesql_ast::Expression,
     database: &vibesql_storage::Database,
-    clause_name: &str,
 ) -> Result<i64, crate::ExecutorError> {
     use crate::evaluator::ExpressionEvaluator;
 
@@ -125,7 +124,7 @@ fn evaluate_limit_offset_expr_raw(
     let value = evaluator.eval(expr, &empty_row)?;
 
     // Convert to integer using SQLite's LIMIT/OFFSET affinity rules
-    coerce_limit_offset_to_i64(value, clause_name)
+    coerce_limit_offset_to_i64(value)
 }
 
 /// Coerce an evaluated LIMIT/OFFSET value to i64 using SQLite semantics.
@@ -141,11 +140,9 @@ fn evaluate_limit_offset_expr_raw(
 ///   representing an integral value: `'2'`, `' 2 '`, `'+2'`, `'2.0'` are accepted; `'The'`,
 ///   `'2abc'`, `'2.5'` error. Note this is deliberately NOT the leading-prefix parse used for
 ///   truthiness — SQLite raises "datatype mismatch" for partial parses here
-/// - NULL, BLOB and everything else keep erroring (SQLite's "datatype mismatch" wording is tracked
-///   separately in #5804)
+/// - NULL, BLOB and everything else error with SQLite's exact wording `datatype mismatch` (#5804)
 pub(in crate::select) fn coerce_limit_offset_to_i64(
     value: vibesql_types::SqlValue,
-    clause_name: &str,
 ) -> Result<i64, crate::ExecutorError> {
     use vibesql_types::SqlValue;
 
@@ -157,36 +154,35 @@ pub(in crate::select) fn coerce_limit_offset_to_i64(
         }
     }
 
-    let err = |shown: String| crate::ExecutorError::InvalidLimitOffset {
-        clause: clause_name.to_string(),
-        value: shown,
-        reason: "must be an integer".to_string(),
-    };
+    // SQLite raises exactly `datatype mismatch` (SQLITE_MISMATCH) for a
+    // non-integral LIMIT/OFFSET value. SqliteCompatError renders verbatim,
+    // with no prefix (#5804).
+    let err = || crate::ExecutorError::SqliteCompatError("datatype mismatch".to_string());
 
     match &value {
         SqlValue::Integer(n) => Ok(*n),
         SqlValue::Smallint(n) => Ok(*n as i64),
         SqlValue::Bigint(n) => Ok(*n),
-        SqlValue::Unsigned(n) => i64::try_from(*n).map_err(|_| err(format!("{:?}", value))),
+        SqlValue::Unsigned(n) => i64::try_from(*n).map_err(|_| err()),
         // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
         // e.g. SELECT 1 LIMIT EXISTS(SELECT 1) returns one row
         SqlValue::Boolean(b) => Ok(i64::from(*b)),
-        SqlValue::Float(f) => integral_f64(*f as f64).ok_or_else(|| err(format!("{:?}", value))),
+        SqlValue::Float(f) => integral_f64(*f as f64).ok_or_else(err),
         SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f) => {
-            integral_f64(*f).ok_or_else(|| err(format!("{:?}", value)))
+            integral_f64(*f).ok_or_else(err)
         }
         SqlValue::Varchar(s) | SqlValue::Character(s) => {
             let trimmed = s.trim();
             if let Ok(n) = trimmed.parse::<i64>() {
                 Ok(n)
             } else if let Ok(f) = trimmed.parse::<f64>() {
-                integral_f64(f).ok_or_else(|| err(format!("{:?}", value)))
+                integral_f64(f).ok_or_else(err)
             } else {
-                Err(err(format!("{:?}", value)))
+                Err(err())
             }
         }
-        SqlValue::Null => Err(err("NULL".to_string())),
-        _ => Err(err(format!("{:?}", value))),
+        SqlValue::Null => Err(err()),
+        _ => Err(err()),
     }
 }
 
@@ -196,11 +192,7 @@ pub(super) fn evaluate_limit(
     limit: &Option<vibesql_ast::Expression>,
     database: &vibesql_storage::Database,
 ) -> Result<Option<usize>, crate::ExecutorError> {
-    match limit
-        .as_ref()
-        .map(|e| evaluate_limit_offset_expr_raw(e, database, "LIMIT"))
-        .transpose()?
-    {
+    match limit.as_ref().map(|e| evaluate_limit_offset_expr_raw(e, database)).transpose()? {
         Some(n) if n < 0 => Ok(None), // Any negative value means unlimited
         Some(n) => Ok(Some(n as usize)),
         None => Ok(None),
@@ -213,11 +205,7 @@ pub(super) fn evaluate_offset(
     offset: &Option<vibesql_ast::Expression>,
     database: &vibesql_storage::Database,
 ) -> Result<Option<usize>, crate::ExecutorError> {
-    match offset
-        .as_ref()
-        .map(|e| evaluate_limit_offset_expr_raw(e, database, "OFFSET"))
-        .transpose()?
-    {
+    match offset.as_ref().map(|e| evaluate_limit_offset_expr_raw(e, database)).transpose()? {
         Some(n) if n < 0 => Ok(Some(0)), // Negative offset treated as 0
         Some(n) => Ok(Some(n as usize)),
         None => Ok(None),
@@ -285,7 +273,7 @@ mod tests {
     use super::coerce_limit_offset_to_i64;
 
     fn coerce(value: SqlValue) -> Result<i64, crate::ExecutorError> {
-        coerce_limit_offset_to_i64(value, "LIMIT")
+        coerce_limit_offset_to_i64(value)
     }
 
     fn text(s: &str) -> SqlValue {
@@ -340,5 +328,14 @@ mod tests {
         assert!(coerce(SqlValue::Null).is_err());
         // LIMIT X'32' keeps erroring (SQLite: datatype mismatch)
         assert!(coerce(SqlValue::Blob(b"2".to_vec())).is_err());
+    }
+
+    #[test]
+    fn rejection_uses_sqlite_exact_wording() {
+        // #5804: SQLite raises exactly `datatype mismatch` (no prefix) for a
+        // non-integral LIMIT/OFFSET value.
+        for v in [SqlValue::Double(56.1), text("The"), SqlValue::Null] {
+            assert_eq!(coerce(v).unwrap_err().to_string(), "datatype mismatch");
+        }
     }
 }

--- a/crates/vibesql-executor/src/tests/create_table_constraints.rs
+++ b/crates/vibesql-executor/src/tests/create_table_constraints.rs
@@ -157,7 +157,10 @@ fn test_create_table_with_multiple_primary_keys_fails() {
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
-    assert!(matches!(result, Err(ExecutorError::MultiplePrimaryKeys)));
+    assert!(matches!(result, Err(ExecutorError::MultiplePrimaryKeys { .. })));
+    // SQLite-exact wording (misc1-7.1/7.2, fuzz-8.1): table name quoted with
+    // double quotes, lowercase phrasing.
+    assert_eq!(result.unwrap_err().to_string(), "table \"users\" has more than one primary key");
 }
 
 #[test]

--- a/crates/vibesql-executor/src/tests/select_without_from.rs
+++ b/crates/vibesql-executor/src/tests/select_without_from.rs
@@ -225,12 +225,8 @@ fn test_select_star_without_from_fails() {
 
     let result = executor.execute(&stmt);
     assert!(result.is_err());
-    match result {
-        Err(ExecutorError::UnsupportedFeature(msg)) => {
-            assert!(msg.contains("require FROM clause") || msg.contains("requires FROM clause"));
-        }
-        _ => panic!("Expected UnsupportedFeature error"),
-    }
+    // SQLite-exact wording for `SELECT *` without FROM (#5804)
+    assert_eq!(result.err().expect("expected error").to_string(), "no tables specified");
 }
 
 #[test]
@@ -266,10 +262,11 @@ fn test_column_reference_without_from_fails() {
     let result = executor.execute(&stmt);
     assert!(result.is_err());
     match result {
-        Err(ExecutorError::UnsupportedFeature(msg)) => {
-            assert!(msg.contains("Column reference requires FROM clause"));
+        Err(ExecutorError::NoSuchColumn { column_ref }) => {
+            // SQLite-exact wording (#5804): `no such column: some_column`
+            assert_eq!(column_ref, "some_column");
         }
-        _ => panic!("Expected UnsupportedFeature error"),
+        other => panic!("Expected NoSuchColumn error, got {:?}", other),
     }
 }
 
@@ -308,10 +305,11 @@ fn test_is_null_with_column_reference_fails() {
     let result = executor.execute(&stmt);
     assert!(result.is_err());
     match result {
-        Err(ExecutorError::UnsupportedFeature(msg)) => {
-            assert!(msg.contains("Column reference requires FROM clause"));
+        Err(ExecutorError::NoSuchColumn { column_ref }) => {
+            // SQLite-exact wording (#5804): `no such column: id`
+            assert_eq!(column_ref, "id");
         }
-        _ => panic!("Expected UnsupportedFeature error"),
+        other => panic!("Expected NoSuchColumn error, got {:?}", other),
     }
 }
 
@@ -357,10 +355,11 @@ fn test_between_with_column_reference_fails() {
     let result = executor.execute(&stmt);
     assert!(result.is_err());
     match result {
-        Err(ExecutorError::UnsupportedFeature(msg)) => {
-            assert!(msg.contains("Column reference requires FROM clause"));
+        Err(ExecutorError::NoSuchColumn { column_ref }) => {
+            // SQLite-exact wording (#5804): `no such column: price`
+            assert_eq!(column_ref, "price");
         }
-        _ => panic!("Expected UnsupportedFeature error"),
+        other => panic!("Expected NoSuchColumn error, got {:?}", other),
     }
 }
 
@@ -399,10 +398,11 @@ fn test_cast_with_column_reference_fails() {
     let result = executor.execute(&stmt);
     assert!(result.is_err());
     match result {
-        Err(ExecutorError::UnsupportedFeature(msg)) => {
-            assert!(msg.contains("Column reference requires FROM clause"));
+        Err(ExecutorError::NoSuchColumn { column_ref }) => {
+            // SQLite-exact wording (#5804): `no such column: id`
+            assert_eq!(column_ref, "id");
         }
-        _ => panic!("Expected UnsupportedFeature error"),
+        other => panic!("Expected NoSuchColumn error, got {:?}", other),
     }
 }
 
@@ -445,10 +445,11 @@ fn test_like_with_column_reference_fails() {
     let result = executor.execute(&stmt);
     assert!(result.is_err());
     match result {
-        Err(ExecutorError::UnsupportedFeature(msg)) => {
-            assert!(msg.contains("Column reference requires FROM clause"));
+        Err(ExecutorError::NoSuchColumn { column_ref }) => {
+            // SQLite-exact wording (#5804): `no such column: name`
+            assert_eq!(column_ref, "name");
         }
-        _ => panic!("Expected UnsupportedFeature error"),
+        other => panic!("Expected NoSuchColumn error, got {:?}", other),
     }
 }
 
@@ -492,11 +493,47 @@ fn test_in_list_with_column_reference_fails() {
     let result = executor.execute(&stmt);
     assert!(result.is_err());
     match result {
-        Err(ExecutorError::UnsupportedFeature(msg)) => {
-            assert!(msg.contains("Column reference requires FROM clause"));
+        Err(ExecutorError::NoSuchColumn { column_ref }) => {
+            // SQLite-exact wording (#5804): `no such column: id`
+            assert_eq!(column_ref, "id");
         }
-        _ => panic!("Expected UnsupportedFeature error"),
+        other => panic!("Expected NoSuchColumn error, got {:?}", other),
     }
+}
+
+/// #5804: `SELECT X` (FROM-less bare column ref) must produce SQLite's exact
+/// `no such column: X` error with the reference's source case preserved.
+#[test]
+fn test_bare_column_ref_error_preserves_source_case() {
+    let db = vibesql_storage::Database::new();
+    let executor = SelectExecutor::new(&db);
+
+    let stmt = vibesql_ast::SelectStmt {
+        into_table: None,
+        into_variables: None,
+        with_clause: None,
+        set_operation: None,
+        values: None,
+        distinct: false,
+        select_list: vec![vibesql_ast::SelectItem::Expression {
+            expr: vibesql_ast::Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
+                "X", false,
+            )),
+            alias: None,
+            source_text: None,
+        }],
+        from: None,
+        where_clause: None,
+        group_by: None,
+        having: None,
+        window_definitions: None,
+        order_by: None,
+        limit: None,
+        offset: None,
+    };
+
+    let err = executor.execute(&stmt).expect_err("SELECT X without FROM must fail");
+    assert_eq!(err.to_string(), "no such column: X");
 }
 
 #[test]

--- a/crates/vibesql-executor/src/tests/view_tests.rs
+++ b/crates/vibesql-executor/src/tests/view_tests.rs
@@ -273,4 +273,29 @@ mod tests {
         assert!(db.catalog.get_view("ALL_USERS").is_none());
         assert!(db.catalog.get_view("active_users").is_none());
     }
+
+    #[test]
+    fn test_create_duplicate_view_uses_sqlite_exact_wording() {
+        // #5804: SQLite reports `view v already exists` (lowercase wrapper,
+        // unquoted name) for a duplicate CREATE VIEW without IF NOT EXISTS.
+        let mut db = create_test_db();
+
+        let sql = "CREATE VIEW v AS SELECT id FROM users";
+        let stmt = Parser::parse_sql(sql).expect("Failed to parse CREATE VIEW");
+        if let vibesql_ast::Statement::CreateView(view_stmt) = stmt {
+            advanced_objects::execute_create_view(&view_stmt, &mut db)
+                .expect("Failed to create view");
+        } else {
+            panic!("Expected CreateView statement");
+        }
+
+        let stmt = Parser::parse_sql(sql).expect("Failed to parse CREATE VIEW");
+        if let vibesql_ast::Statement::CreateView(view_stmt) = stmt {
+            let err = advanced_objects::execute_create_view(&view_stmt, &mut db)
+                .expect_err("Duplicate CREATE VIEW must fail");
+            assert_eq!(err.to_string(), "view v already exists");
+        } else {
+            panic!("Expected CreateView statement");
+        }
+    }
 }

--- a/crates/vibesql-l10n/resources/ar/executor.ftl
+++ b/crates/vibesql-l10n/resources/ar/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = قائمة الأعمدة المشتقة تحت
 # =============================================================================
 
 executor-constraint-violation = انتهاك القيد: { $message }
-executor-multiple-primary-keys = لا يُسمح بقيود PRIMARY KEY متعددة
 executor-cannot-drop-column = لا يمكن حذف العمود: { $message }
 executor-constraint-not-found = القيد '{ $constraint_name }' غير موجود في الجدول '{ $table_name }'
 

--- a/crates/vibesql-l10n/resources/de/executor.ftl
+++ b/crates/vibesql-l10n/resources/de/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = Abgeleitete Spaltenliste hat { $provided } Spal
 # =============================================================================
 
 executor-constraint-violation = Constraint-Verletzung: { $message }
-executor-multiple-primary-keys = Mehrere PRIMARY KEY-Constraints sind nicht erlaubt
 executor-cannot-drop-column = Spalte kann nicht gelöscht werden: { $message }
 executor-constraint-not-found = Constraint '{ $constraint_name }' in Tabelle '{ $table_name }' nicht gefunden
 

--- a/crates/vibesql-l10n/resources/en-US/executor.ftl
+++ b/crates/vibesql-l10n/resources/en-US/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = Derived column list has { $provided } columns b
 # =============================================================================
 
 executor-constraint-violation = Constraint violation: { $message }
-executor-multiple-primary-keys = Multiple PRIMARY KEY constraints are not allowed
 executor-cannot-drop-column = Cannot drop column: { $message }
 executor-constraint-not-found = Constraint '{ $constraint_name }' not found in table '{ $table_name }'
 

--- a/crates/vibesql-l10n/resources/es/executor.ftl
+++ b/crates/vibesql-l10n/resources/es/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = La lista de columnas derivadas tiene { $provide
 # =============================================================================
 
 executor-constraint-violation = Violación de restricción: { $message }
-executor-multiple-primary-keys = No se permiten múltiples restricciones PRIMARY KEY
 executor-cannot-drop-column = No se puede eliminar la columna: { $message }
 executor-constraint-not-found = Restricción '{ $constraint_name }' no encontrada en la tabla '{ $table_name }'
 

--- a/crates/vibesql-l10n/resources/fr/executor.ftl
+++ b/crates/vibesql-l10n/resources/fr/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = La liste de colonnes dérivées a { $provided }
 # =============================================================================
 
 executor-constraint-violation = Violation de contrainte : { $message }
-executor-multiple-primary-keys = Les contraintes PRIMARY KEY multiples ne sont pas autorisées
 executor-cannot-drop-column = Impossible de supprimer la colonne : { $message }
 executor-constraint-not-found = Contrainte '{ $constraint_name }' introuvable dans la table '{ $table_name }'
 

--- a/crates/vibesql-l10n/resources/hi/executor.ftl
+++ b/crates/vibesql-l10n/resources/hi/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = व्युत्पन्न कॉलम स
 # =============================================================================
 
 executor-constraint-violation = कॉन्स्ट्रेंट उल्लंघन: { $message }
-executor-multiple-primary-keys = एकाधिक PRIMARY KEY कॉन्स्ट्रेंट की अनुमति नहीं है
 executor-cannot-drop-column = कॉलम हटाया नहीं जा सकता: { $message }
 executor-constraint-not-found = कॉन्स्ट्रेंट '{ $constraint_name }' टेबल '{ $table_name }' में नहीं मिला
 

--- a/crates/vibesql-l10n/resources/id/executor.ftl
+++ b/crates/vibesql-l10n/resources/id/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = Daftar kolom turunan memiliki { $provided } kol
 # =============================================================================
 
 executor-constraint-violation = Pelanggaran batasan: { $message }
-executor-multiple-primary-keys = Batasan PRIMARY KEY ganda tidak diperbolehkan
 executor-cannot-drop-column = Tidak dapat menghapus kolom: { $message }
 executor-constraint-not-found = Batasan '{ $constraint_name }' tidak ditemukan dalam tabel '{ $table_name }'
 

--- a/crates/vibesql-l10n/resources/it/executor.ftl
+++ b/crates/vibesql-l10n/resources/it/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = La lista colonne derivata ha { $provided } colo
 # =============================================================================
 
 executor-constraint-violation = Violazione del vincolo: { $message }
-executor-multiple-primary-keys = Non sono ammessi vincoli PRIMARY KEY multipli
 executor-cannot-drop-column = Impossibile eliminare la colonna: { $message }
 executor-constraint-not-found = Vincolo '{ $constraint_name }' non trovato nella tabella '{ $table_name }'
 

--- a/crates/vibesql-l10n/resources/ja/executor.ftl
+++ b/crates/vibesql-l10n/resources/ja/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = 派生カラムリストには { $provided } �
 # =============================================================================
 
 executor-constraint-violation = 制約違反: { $message }
-executor-multiple-primary-keys = 複数のPRIMARY KEY制約は許可されていません
 executor-cannot-drop-column = カラムを削除できません: { $message }
 executor-constraint-not-found = テーブル '{ $table_name }' に制約 '{ $constraint_name }' が見つかりません
 

--- a/crates/vibesql-l10n/resources/ko/executor.ftl
+++ b/crates/vibesql-l10n/resources/ko/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = 파생 컬럼 목록에 { $provided }개의 컬
 # =============================================================================
 
 executor-constraint-violation = 제약 조건 위반: { $message }
-executor-multiple-primary-keys = 여러 PRIMARY KEY 제약 조건은 허용되지 않습니다
 executor-cannot-drop-column = 컬럼을 삭제할 수 없습니다: { $message }
 executor-constraint-not-found = 테이블 '{ $table_name }'에서 제약 조건 '{ $constraint_name }'을(를) 찾을 수 없습니다
 

--- a/crates/vibesql-l10n/resources/nl/executor.ftl
+++ b/crates/vibesql-l10n/resources/nl/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = Afgeleide kolommenlijst heeft { $provided } kol
 # =============================================================================
 
 executor-constraint-violation = Constraintschending: { $message }
-executor-multiple-primary-keys = Meerdere PRIMARY KEY-constraints zijn niet toegestaan
 executor-cannot-drop-column = Kan kolom niet verwijderen: { $message }
 executor-constraint-not-found = Constraint '{ $constraint_name }' niet gevonden in tabel '{ $table_name }'
 

--- a/crates/vibesql-l10n/resources/pl/executor.ftl
+++ b/crates/vibesql-l10n/resources/pl/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = Lista kolumn pochodnych ma { $provided } kolumn
 # =============================================================================
 
 executor-constraint-violation = Naruszenie ograniczenia: { $message }
-executor-multiple-primary-keys = Wiele ograniczeń PRIMARY KEY jest niedozwolonych
 executor-cannot-drop-column = Nie można usunąć kolumny: { $message }
 executor-constraint-not-found = Nie znaleziono ograniczenia '{ $constraint_name }' w tabeli '{ $table_name }'
 

--- a/crates/vibesql-l10n/resources/pt-BR/executor.ftl
+++ b/crates/vibesql-l10n/resources/pt-BR/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = Lista de colunas derivadas possui { $provided }
 # =============================================================================
 
 executor-constraint-violation = Violação de restrição: { $message }
-executor-multiple-primary-keys = Múltiplas restrições PRIMARY KEY não são permitidas
 executor-cannot-drop-column = Não é possível remover coluna: { $message }
 executor-constraint-not-found = Restrição '{ $constraint_name }' não encontrada na tabela '{ $table_name }'
 

--- a/crates/vibesql-l10n/resources/ru/executor.ftl
+++ b/crates/vibesql-l10n/resources/ru/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = Производный список столб�
 # =============================================================================
 
 executor-constraint-violation = Нарушение ограничения: { $message }
-executor-multiple-primary-keys = Несколько ограничений PRIMARY KEY не допускается
 executor-cannot-drop-column = Невозможно удалить столбец: { $message }
 executor-constraint-not-found = Ограничение '{ $constraint_name }' не найдено в таблице '{ $table_name }'
 

--- a/crates/vibesql-l10n/resources/sv/executor.ftl
+++ b/crates/vibesql-l10n/resources/sv/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = Härledd kolumnlista har { $provided } kolumner
 # =============================================================================
 
 executor-constraint-violation = Villkorsöverträdelse: { $message }
-executor-multiple-primary-keys = Flera PRIMARY KEY-villkor är inte tillåtna
 executor-cannot-drop-column = Kan inte ta bort kolumn: { $message }
 executor-constraint-not-found = Villkoret '{ $constraint_name }' hittades inte i tabellen '{ $table_name }'
 

--- a/crates/vibesql-l10n/resources/th/executor.ftl
+++ b/crates/vibesql-l10n/resources/th/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = Derived column list มี { $provided } คอ
 # =============================================================================
 
 executor-constraint-violation = ละเมิด Constraint: { $message }
-executor-multiple-primary-keys = ไม่อนุญาตให้มี PRIMARY KEY constraints หลายตัว
 executor-cannot-drop-column = ไม่สามารถลบคอลัมน์: { $message }
 executor-constraint-not-found = ไม่พบ Constraint '{ $constraint_name }' ในตาราง '{ $table_name }'
 

--- a/crates/vibesql-l10n/resources/tr/executor.ftl
+++ b/crates/vibesql-l10n/resources/tr/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = Türetilmiş sütun listesi { $provided } sütu
 # =============================================================================
 
 executor-constraint-violation = Kısıtlama ihlali: { $message }
-executor-multiple-primary-keys = Birden fazla PRIMARY KEY kısıtlamasına izin verilmez
 executor-cannot-drop-column = Sütun silinemez: { $message }
 executor-constraint-not-found = '{ $table_name }' tablosunda '{ $constraint_name }' kısıtlaması bulunamadı
 

--- a/crates/vibesql-l10n/resources/uk/executor.ftl
+++ b/crates/vibesql-l10n/resources/uk/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = Похідний список колонок м
 # =============================================================================
 
 executor-constraint-violation = Порушення обмеження: { $message }
-executor-multiple-primary-keys = Декілька обмежень PRIMARY KEY не дозволено
 executor-cannot-drop-column = Неможливо видалити колонку: { $message }
 executor-constraint-not-found = Обмеження '{ $constraint_name }' не знайдено в таблиці '{ $table_name }'
 

--- a/crates/vibesql-l10n/resources/vi/executor.ftl
+++ b/crates/vibesql-l10n/resources/vi/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = Danh sách cột dẫn xuất có { $provided }
 # =============================================================================
 
 executor-constraint-violation = Vi phạm ràng buộc: { $message }
-executor-multiple-primary-keys = Không cho phép nhiều ràng buộc PRIMARY KEY
 executor-cannot-drop-column = Không thể xóa cột: { $message }
 executor-constraint-not-found = Không tìm thấy ràng buộc '{ $constraint_name }' trong bảng '{ $table_name }'
 

--- a/crates/vibesql-l10n/resources/zh-CN/executor.ftl
+++ b/crates/vibesql-l10n/resources/zh-CN/executor.ftl
@@ -85,7 +85,6 @@ executor-column-count-mismatch = 派生列列表有 { $provided } 列，但查�
 # =============================================================================
 
 executor-constraint-violation = 违反约束：{ $message }
-executor-multiple-primary-keys = 不允许多个 PRIMARY KEY 约束
 executor-cannot-drop-column = 无法删除列：{ $message }
 executor-constraint-not-found = 在表 '{ $table_name }' 中未找到约束 '{ $constraint_name }'
 

--- a/crates/vibesql-parser/src/parser/create/types.rs
+++ b/crates/vibesql-parser/src/parser/create/types.rs
@@ -60,6 +60,13 @@ impl Parser {
             Token::Keyword { keyword, .. } if keyword.is_sqlite_fallback_keyword() => {
                 keyword.to_string().to_lowercase()
             }
+            // SQLite accepts arbitrary type names, including the TYPE keyword
+            // itself (misc1-7.1: `CREATE TABLE error1(a TYPE PRIMARY KEY, ...)`).
+            // TYPE is a VibeSQL-only keyword (CREATE TYPE, GRANT) not in the
+            // SQLite fallback set above, so it needs its own arm; it falls
+            // through to the UserDefined catch-all below and is stored by
+            // affinity (#5804).
+            Token::Keyword { keyword: Keyword::Type, .. } => "type".to_string(),
             _ => return Err(ParseError { message: "Expected data type".to_string() }),
         };
         self.advance();

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -487,6 +487,15 @@ proc translate_error_to_sqlite {vibesql_error} {
         return "ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint"
     }
 
+    # Multiple PRIMARY KEY declarations (#5804): the engine emits SQLite's
+    # exact wording `table "X" has more than one primary key` (misc1-7.1/7.2,
+    # fuzz-8.1). Pass it through verbatim BEFORE the UNIQUE-constraint fallback
+    # below so that fallback can never mistranslate it into "UNIQUE constraint
+    # failed" again.
+    if {[regexp -nocase {has more than one primary key} $error_msg]} {
+        return $error_msg
+    }
+
     # Constraint violations - VibeSQL now outputs SQLite-compatible format directly
     # Format: "UNIQUE constraint failed: table.column" or "UNIQUE constraint failed: table.col1, table.col2"
     if {[regexp -nocase {UNIQUE constraint failed: (.+)$} $error_msg -> col_spec]} {
@@ -583,14 +592,10 @@ proc translate_error_to_sqlite {vibesql_error} {
         return "datatype mismatch"
     }
 
-    # LIMIT/OFFSET value must be integer
-    # "LIMIT value ... must be an integer" -> "datatype mismatch"
-    if {[regexp -nocase {LIMIT value.*must be an integer} $error_msg]} {
-        return "datatype mismatch"
-    }
-    if {[regexp -nocase {OFFSET value.*must be an integer} $error_msg]} {
-        return "datatype mismatch"
-    }
+    # NOTE (#5804): the engine now emits SQLite's exact `datatype mismatch`
+    # wording for non-coercible LIMIT/OFFSET values, so the former
+    # "LIMIT/OFFSET value ... must be an integer" -> "datatype mismatch"
+    # translation rules were deleted; the engine message is load-bearing.
 
     # If no specific translation, return original (without prefix)
     return $error_msg
@@ -3827,8 +3832,6 @@ array set vibesql_skip_tests {
     misc1-5.1 "Parser accepts invalid syntax WHEREwww"
     misc1-5.2 "Cascades from misc1-5.1"
     misc1-6.1 "Parser accepts invalid syntax WHEREwww"
-    misc1-7.1 "Error message format differs - multiple primary key"
-    misc1-7.2 "Error message format differs - multiple primary key"
     misc1-8.2 "Error message format differs"
     misc-8.1 "Table not found after failed statement"
     misc-8.2 "Cascades from misc-8.1"


### PR DESCRIPTION
## Summary

Aligns four error-message classes with SQLite byte-for-byte, so fuzz.test's allowlist and other SQLite test files' catchsql assertions match the engine's output directly instead of relying on shim translation. Also removes the shim rules made dead by the engine changes and un-skips misc1-7.1/7.2.

## Changes

**Engine (vibesql-executor):**
- `MultiplePrimaryKeys` now carries the table name; Display is SQLite's exact `table "X" has more than one primary key` (hardcoded, matching the `InsertNoSuchColumn`/`ForeignKeyMismatch` precedent). Table name threaded through `ConstraintValidator::process_constraints`; sole non-test caller in `create_table.rs` supplies the verbatim statement name.
- `CatalogError::ViewAlreadyExists` conversion now formats SQLite's `view v already exists` (was `View 'v' already exists`).
- `coerce_limit_offset_to_i64` (single choke point for both LIMIT/OFFSET evaluation sites) now raises `SqliteCompatError("datatype mismatch")` — SQLite's exact wording, no prefix. The arena fast-path routes literal values through the same shared coercion (also fixing arena `LIMIT 2.0`/`LIMIT '2'` inconsistency).
- FROM-less bare column refs raise `NoSuchColumn` (`no such column: x`) with **source case preserved**: the boolean expression walker in `select/executor/utils.rs` was refactored into `find_from_less_column_ref` returning the offending ref's display text (traversal semantics preserved one-to-one; subqueries still not descended). Trigger-context NEW/OLD handling (#5445) unchanged.
- FROM-less `SELECT *` raises SQLite's `no tables specified` (5 sites).

**Parser (vibesql-parser):**
- `TYPE` keyword accepted as a column type name (SQLite accepts any type name; needed for misc1-7.1's `a TYPE PRIMARY KEY`). Unambiguous: `TYPE` is only significant at statement level (CREATE TYPE, GRANT/REVOKE).

**l10n:** orphaned `executor-multiple-primary-keys` key removed from all 20 locales (`check-ftl` and `check-translations.py` pass).

**Shim (`scripts/tester_vibesql.tcl`):**
- New pass-through for `has more than one primary key` placed before the UNIQUE-constraint fallback (line ~496) so that fallback can never again mistranslate the multiple-PK message into `UNIQUE constraint failed`.
- Deleted the dead `LIMIT/OFFSET value ... must be an integer` → `datatype mismatch` rules — the engine message is now load-bearing.
- Un-skipped `misc1-7.1` / `misc1-7.2`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `CREATE TABLE just(analysis INTEGER PRIMARY KEY, also PRIMARY KEY)` → `table "just" has more than one primary key` | PASS | CLI output byte-identical to sqlite3 3.x; source case preserved (`T1` → `table "T1" ...`) |
| Duplicate `CREATE VIEW v ...` → `view v already exists` | PASS | CLI output byte-identical to sqlite3 |
| `SELECT 1 LIMIT 56.1` / `LIMIT 'The'` / `UNION ... LIMIT 3.5` / `OFFSET 'x'` → `datatype mismatch` | PASS | CLI output byte-identical to sqlite3; `LIMIT '2.0'` still accepted (#5829 semantics) |
| `SELECT x` / `SELECT x, y` → `no such column: x`; `SELECT X` → `no such column: X` | PASS | CLI verified, source case preserved |
| Dead shim rules removed; line-496 fallback cannot catch the new PK message | PASS | LIMIT/OFFSET rules deleted; explicit verbatim pass-through added before the fallback |
| misc1-7.1 / misc1-7.2 un-skipped and passing | PASS | `make test-tcl-file FILE=misc1.test`: both pass (remaining misc1-6.2/6.3/6.4 failures reproduce identically with the main-branch binary — pre-existing keyword-as-identifier gap, sibling of #5816) |
| fuzz.test failures drop by ~210; zero multiple-PK / view-exists failures remain | PASS | Full clean run (quiet machine, 0 skips, 0 timeout markers): **35,031 tests, 92 failed (99.7%)** vs 795 failed at curation time. **Zero fuzz-8.x failures** — the multiple-PK and view-exists classes (both live in fuzz-8.1) are fully recovered. Residue is in fuzz-1/2/3.2/6.1/7.2 (out-of-scope classes per the issue: parser composability, evaluator gaps) |

## Test Plan

- `cargo test -p vibesql-executor --lib`: 3096 passed, 0 failed (includes new exact-wording tests for each aligned message: multiple-PK, view-exists, datatype-mismatch, no-such-column case preservation, no-tables-specified)
- `cargo test -p vibesql-parser`: 1536 passed
- `cargo test -p vibesql-l10n` + `check-ftl` + `check-translations.py`: pass
- TCL: `select1.test` 188/188 (100%), `view.test` 0 failed, `misc1.test` 7.1/7.2 now pass, `fuzz.test` 92 failed / 35,031 (from 795)
- Edge cases verified: `LIMIT '2.0'` accepted; `SELECT X` preserves case; trigger-body FROM-less SELECT with NEW/OLD refs (#5445 tests pass)

Note: pre-existing local-only stack overflow in `test_deep_case_expressions` (reproduces on unmodified main in debug builds with default test-thread stacks; ran suite with `RUST_MIN_STACK=16M`) — unrelated to this change.

Closes #5804

🤖 Generated with [Claude Code](https://claude.com/claude-code)