### PR TITLE
fix(storage): re-parse persisted views and index expressions with the full parser grammar

### DIFF
--- a/crates/vibesql-ast/src/pretty_print.rs
+++ b/crates/vibesql-ast/src/pretty_print.rs
@@ -864,10 +864,14 @@ impl ToSql for SelectStmt {
     fn to_sql(&self) -> String {
         let mut result = String::new();
 
-        // WITH clause
+        // WITH clause. The RECURSIVE keyword is declared once after WITH and
+        // the parser marks every CTE in the list recursive, so render it when
+        // any CTE carries the flag — dropping it would silently downgrade a
+        // recursive-CTE view on a persistence round-trip (issue #5833).
         if let Some(ctes) = &self.with_clause {
+            let recursive = if ctes.iter().any(|c| c.recursive) { "RECURSIVE " } else { "" };
             let cte_strs: Vec<String> = ctes.iter().map(|c| c.to_sql()).collect();
-            result.push_str(&format!("WITH {} ", cte_strs.join(", ")));
+            result.push_str(&format!("WITH {}{} ", recursive, cte_strs.join(", ")));
         }
 
         // Check if this is a VALUES statement

--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -190,6 +190,39 @@ impl Parser {
         parser.parse_statement()
     }
 
+    /// Parse a standalone SQL expression using the full main-parser grammar.
+    ///
+    /// Reload paths (binary catalog expression indexes, partial-index WHERE
+    /// clauses) persist expressions as `ToSql`-rendered text and must re-parse
+    /// them on load. The arena parser's `parse_expression_to_owned` covers a
+    /// smaller grammar (e.g. it rejects `COLLATE`), so anything the main
+    /// parser accepted at DDL time — and therefore anything `ToSql` can render
+    /// — must be re-parsed through this entry point, not the arena one
+    /// (issue #5833).
+    ///
+    /// Trailing tokens after the expression are an error: a partially-consumed
+    /// input means the rendered text did not round-trip as a single
+    /// expression.
+    pub fn parse_expression_sql(input: &str) -> Result<vibesql_ast::Expression, ParseError> {
+        let mut lexer = Lexer::new(input);
+        let tokens_with_spans = lexer
+            .tokenize_with_spans()
+            .map_err(|e| ParseError { message: format!("Lexer error: {}", e) })?;
+        let (tokens, spans): (Vec<Token>, Vec<Span>) = tokens_with_spans.into_iter().unzip();
+
+        let mut parser = Parser::new_with_source(tokens, spans, input.to_string());
+        let expr = parser.parse_expression()?;
+        match parser.peek() {
+            Token::Eof | Token::Semicolon => Ok(expr),
+            other => Err(ParseError {
+                message: format!(
+                    "Unexpected trailing token {:?} after expression in '{}'",
+                    other, input
+                ),
+            }),
+        }
+    }
+
     /// Parse a statement
     pub fn parse_statement(&mut self) -> Result<vibesql_ast::Statement, ParseError> {
         match self.peek() {

--- a/crates/vibesql-storage/src/persistence/binary/catalog.rs
+++ b/crates/vibesql-storage/src/persistence/binary/catalog.rs
@@ -578,15 +578,19 @@ pub fn read_catalog_v<R: Read>(reader: &mut R, version: u8) -> Result<Database, 
                         }
                     }
                     1 => {
-                        // Expression index - parse the SQL expression
-                        let expr =
-                            vibesql_parser::arena_parser::parse_expression_to_owned(&content)
-                                .map_err(|e| {
-                                    StorageError::NotImplemented(format!(
-                                        "Failed to parse expression index '{}': {}",
-                                        content, e
-                                    ))
-                                })?;
+                        // Expression index - parse the SQL expression. Use the
+                        // full main-parser grammar: the arena parser rejects
+                        // forms the main parser accepted at CREATE INDEX time
+                        // (e.g. COLLATE), which would drop the index on reload
+                        // (issue #5833).
+                        let expr = vibesql_parser::Parser::parse_expression_sql(&content).map_err(
+                            |e| {
+                                StorageError::NotImplemented(format!(
+                                    "Failed to parse expression index '{}': {}",
+                                    content, e
+                                ))
+                            },
+                        )?;
                         vibesql_ast::IndexColumn::Expression { expr: Box::new(expr), direction }
                     }
                     _ => {
@@ -622,13 +626,14 @@ pub fn read_catalog_v<R: Read>(reader: &mut R, version: u8) -> Result<Database, 
             let has_where = read_bool(reader)?;
             if has_where {
                 let sql = read_string(reader)?;
-                let parsed = vibesql_parser::arena_parser::parse_expression_to_owned(&sql)
-                    .map_err(|e| {
-                        StorageError::NotImplemented(format!(
-                            "Failed to parse partial-index WHERE expression '{}': {}",
-                            sql, e
-                        ))
-                    })?;
+                // Full main-parser grammar for the same reason as expression
+                // indexes above (issue #5833).
+                let parsed = vibesql_parser::Parser::parse_expression_sql(&sql).map_err(|e| {
+                    StorageError::NotImplemented(format!(
+                        "Failed to parse partial-index WHERE expression '{}': {}",
+                        sql, e
+                    ))
+                })?;
                 Some(parsed)
             } else {
                 None
@@ -719,15 +724,31 @@ pub fn read_catalog_v<R: Read>(reader: &mut R, version: u8) -> Result<Database, 
             // 4. with_check_option
             let with_check_option = read_bool(reader)?;
 
-            // 5. defining SELECT as SQL text — re-parse into a SelectStmt
+            // 5. defining SELECT as SQL text — re-parse into a SelectStmt.
+            //
+            // Must use the full main-parser grammar (`Parser::parse_sql`), not
+            // the arena parser's `parse_select_to_owned`: the arena parser
+            // covers a smaller grammar and rejects forms the main parser
+            // accepted at CREATE VIEW time — bare `VALUES(...)` bodies and
+            // `COLLATE` in the select list among them. Under fail-closed
+            // recovery a single such view made every subsequent open of the
+            // checkpoint fail (issue #5833; join7/join9, tkt-a7debbe0).
             let query_sql = read_string(reader)?;
-            let query =
-                vibesql_parser::arena_parser::parse_select_to_owned(&query_sql).map_err(|e| {
-                    StorageError::NotImplemented(format!(
+            let query = match vibesql_parser::Parser::parse_sql(&query_sql) {
+                Ok(vibesql_ast::Statement::Select(stmt)) => *stmt,
+                Ok(_) => {
+                    return Err(StorageError::NotImplemented(format!(
+                        "Persisted defining query for view '{}' is not a SELECT: '{}'",
+                        name, query_sql
+                    )))
+                }
+                Err(e) => {
+                    return Err(StorageError::NotImplemented(format!(
                         "Failed to parse view '{}' SELECT '{}': {}",
                         name, query_sql, e
-                    ))
-                })?;
+                    )))
+                }
+            };
 
             // 6. sql_definition (present-flag + string)
             let has_sql_def = read_bool(reader)?;
@@ -1272,6 +1293,226 @@ mod tests {
             v.query.to_sql().find("UNION").unwrap() < v.query.to_sql().find("ORDER BY").unwrap(),
             "ORDER BY must render after the set operation, got: {}",
             v.query.to_sql()
+        );
+    }
+
+    /// Issue #5833: the reload path must re-parse everything the main parser
+    /// accepted at CREATE VIEW time. The reader used the arena parser's
+    /// `parse_select_to_owned`, whose grammar is a strict subset — it rejects
+    /// bare `VALUES(...)` bodies and `COLLATE` anywhere in an expression — so
+    /// such views poisoned the checkpoint: under fail-closed recovery every
+    /// subsequent open failed (join7/join9: `CREATE VIEW dual(dummy) AS
+    /// VALUES('x')`; tkt-a7debbe0: COLLATE in the select list).
+    ///
+    /// Covers: a VALUES-body view, a COLLATE select-list view, a CTE view, a
+    /// RECURSIVE CTE view (RECURSIVE keyword must survive the ToSql render),
+    /// and an EXCEPT/INTERSECT compound view.
+    #[test]
+    fn test_binary_catalog_round_trips_full_select_grammar_views() {
+        use vibesql_ast::pretty_print::ToSql;
+
+        let mut db = Database::new();
+
+        // Backing table so the defining SELECTs reference something real.
+        let schema = vibesql_catalog::TableSchema::new(
+            "t1".to_string(),
+            vec![vibesql_catalog::ColumnSchema {
+                name: "a".to_string(),
+                data_type: vibesql_types::DataType::Integer,
+                nullable: true,
+                default_value: None,
+                generated_expr: None,
+                collation: None,
+                is_exact_integer_type: true,
+            }],
+        );
+        db.create_table_with_identifier(schema, vibesql_catalog::TableIdentifier::new("t1", false))
+            .unwrap();
+
+        // Parse through the MAIN parser — the same grammar CREATE VIEW uses at
+        // runtime — so the test exercises exactly what the writer serializes.
+        let parse = |sql: &str| match vibesql_parser::Parser::parse_sql(sql).unwrap() {
+            vibesql_ast::Statement::Select(s) => *s,
+            other => panic!("expected SELECT statement for '{}', got {:?}", sql, other),
+        };
+
+        // 1. Bare VALUES body (join7/join9's `dual` view).
+        db.catalog
+            .create_view(vibesql_catalog::ViewDefinition::new_with_sql(
+                "dual".to_string(),
+                Some(vec!["dummy".to_string()]),
+                parse("VALUES('x')"),
+                false,
+                "CREATE VIEW dual(dummy) AS VALUES('x')".to_string(),
+            ))
+            .unwrap();
+
+        // 2. COLLATE in the select list (tkt-a7debbe0's v2).
+        db.catalog
+            .create_view(vibesql_catalog::ViewDefinition::new(
+                "v_collate".to_string(),
+                Some(vec!["a".to_string(), "B".to_string()]),
+                parse("SELECT 'a', 'B' COLLATE NOCASE FROM t1"),
+                false,
+            ))
+            .unwrap();
+
+        // 3. CTE view.
+        db.catalog
+            .create_view(vibesql_catalog::ViewDefinition::new(
+                "v_cte".to_string(),
+                None,
+                parse("WITH c AS (SELECT a FROM t1) SELECT * FROM c"),
+                false,
+            ))
+            .unwrap();
+
+        // 4. RECURSIVE CTE view — ToSql must render the RECURSIVE keyword so
+        //    the flag survives the text round-trip.
+        db.catalog
+            .create_view(vibesql_catalog::ViewDefinition::new(
+                "v_rec".to_string(),
+                None,
+                parse(
+                    "WITH RECURSIVE c(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM c WHERE x<5) \
+                     SELECT x FROM c",
+                ),
+                false,
+            ))
+            .unwrap();
+
+        // 5. EXCEPT/INTERSECT compound view.
+        db.catalog
+            .create_view(vibesql_catalog::ViewDefinition::new(
+                "v_compound2".to_string(),
+                None,
+                parse("SELECT a FROM t1 EXCEPT SELECT a FROM t1 INTERSECT SELECT a FROM t1"),
+                false,
+            ))
+            .unwrap();
+
+        // Round-trip the catalog at the current version.
+        let mut buf = Vec::new();
+        write_catalog(&mut buf, &db).unwrap();
+        let reloaded = read_catalog_v(&mut &buf[..], VERSION).unwrap();
+
+        // VALUES body.
+        let v = reloaded.catalog.get_view("dual").expect("VALUES-body view must survive");
+        assert_eq!(v.columns.as_deref(), Some(&["dummy".to_string()][..]));
+        assert_eq!(v.query.to_sql(), parse("VALUES('x')").to_sql());
+        assert!(v.query.values.is_some(), "reloaded view must still be a VALUES statement");
+
+        // COLLATE select list.
+        let v = reloaded.catalog.get_view("v_collate").expect("COLLATE view must survive");
+        assert_eq!(v.query.to_sql(), parse("SELECT 'a', 'B' COLLATE NOCASE FROM t1").to_sql());
+        assert!(
+            v.query.to_sql().contains("COLLATE NOCASE"),
+            "COLLATE must survive the round-trip, got: {}",
+            v.query.to_sql()
+        );
+
+        // CTE view.
+        let v = reloaded.catalog.get_view("v_cte").expect("CTE view must survive");
+        assert_eq!(
+            v.query.to_sql(),
+            parse("WITH c AS (SELECT a FROM t1) SELECT * FROM c").to_sql()
+        );
+
+        // RECURSIVE CTE view: the recursive flag must survive.
+        let v = reloaded.catalog.get_view("v_rec").expect("recursive CTE view must survive");
+        let ctes = v.query.with_clause.as_ref().expect("WITH clause must survive");
+        assert!(
+            ctes.iter().all(|c| c.recursive),
+            "RECURSIVE flag must survive the round-trip, got: {}",
+            v.query.to_sql()
+        );
+
+        // EXCEPT/INTERSECT compound view.
+        let v = reloaded.catalog.get_view("v_compound2").expect("compound view must survive");
+        assert_eq!(
+            v.query.to_sql(),
+            parse("SELECT a FROM t1 EXCEPT SELECT a FROM t1 INTERSECT SELECT a FROM t1").to_sql()
+        );
+    }
+
+    /// Issue #5833 (expression sites): expression indexes and partial-index
+    /// WHERE clauses are also persisted as ToSql text and re-parsed on load
+    /// via the arena expression parser, which rejects `COLLATE`. They must go
+    /// through the main parser's expression grammar instead.
+    #[test]
+    fn test_binary_catalog_round_trips_collate_in_index_expressions() {
+        use vibesql_ast::pretty_print::ToSql;
+
+        let mut db = Database::new();
+        let schema = vibesql_catalog::TableSchema::new(
+            "t1".to_string(),
+            vec![vibesql_catalog::ColumnSchema {
+                name: "x".to_string(),
+                data_type: vibesql_types::DataType::Varchar { max_length: None },
+                nullable: true,
+                default_value: None,
+                generated_expr: None,
+                collation: None,
+                is_exact_integer_type: false,
+            }],
+        );
+        db.create_table_with_identifier(schema, vibesql_catalog::TableIdentifier::new("t1", false))
+            .unwrap();
+
+        // Expression index whose expression contains COLLATE.
+        let expr = vibesql_parser::Parser::parse_expression_sql("x COLLATE NOCASE").unwrap();
+        let columns = vec![vibesql_ast::IndexColumn::Expression {
+            expr: Box::new(expr),
+            direction: vibesql_ast::OrderDirection::Asc,
+        }];
+        db.create_index("i_collate".to_string(), "t1".to_string(), false, columns).unwrap();
+
+        // Partial index whose WHERE predicate contains COLLATE.
+        let where_expr =
+            vibesql_parser::Parser::parse_expression_sql("x COLLATE NOCASE = 'a'").unwrap();
+        let cols = vec![vibesql_ast::IndexColumn::new_column(
+            "x".to_string(),
+            vibesql_ast::OrderDirection::Asc,
+        )];
+        db.create_index("i_partial".to_string(), "t1".to_string(), false, cols).unwrap();
+        let catalog_meta = vibesql_catalog::IndexMetadata::new(
+            "i_partial".to_string(),
+            "t1".to_string(),
+            vibesql_catalog::IndexType::BTree,
+            vec![vibesql_catalog::IndexedColumn::new_column(
+                "x".to_string(),
+                vibesql_catalog::SortOrder::Ascending,
+            )],
+            false,
+        );
+        db.catalog.add_index(catalog_meta).unwrap();
+        assert!(db.catalog.set_index_where_clause("i_partial", Some(where_expr)));
+
+        let mut buf = Vec::new();
+        write_catalog(&mut buf, &db).unwrap();
+        let reloaded = read_catalog_v(&mut &buf[..], VERSION).unwrap();
+
+        let meta = reloaded.get_index("i_collate").expect("COLLATE expression index must survive");
+        match &meta.columns[0] {
+            vibesql_ast::IndexColumn::Expression { expr, .. } => {
+                assert!(
+                    expr.to_sql().contains("COLLATE NOCASE"),
+                    "COLLATE must survive in the index expression, got: {}",
+                    expr.to_sql()
+                );
+            }
+            other => panic!("expected expression index column, got {:?}", other),
+        }
+
+        let meta = reloaded
+            .catalog
+            .find_index_by_name("i_partial")
+            .expect("partial index metadata must survive");
+        let where_clause = meta.where_clause.as_ref().expect("partial-index WHERE must survive");
+        assert!(
+            where_clause.to_sql().contains("COLLATE NOCASE"),
+            "COLLATE must survive in the partial-index WHERE, got: {}",
+            where_clause.to_sql()
         );
     }
 


### PR DESCRIPTION
## Summary

The binary catalog reader re-parsed a view's persisted defining query with the **arena parser** (`parse_select_to_owned`), whose grammar is a strict subset of the **main parser** used at `CREATE VIEW` time: it rejects bare `VALUES(...)` bodies and `COLLATE` anywhere in an expression. Any view the main parser accepted but the arena parser could not re-parse poisoned the checkpoint, and under fail-closed recovery (#5850) every subsequent open of the database failed. This accounted for all 406 join7/join9 failures (#5815) and most of tkt-a7debbe0's 28.

**Which side was at fault: the reader.** Diagnosis: the stored SQL text (`ToSql` output) is correct and round-trips cleanly through the main parser for every form audited — the reader was simply using a weaker parser than the one that admitted the DDL. One writer-side fidelity bug was found in the audit and also fixed: `ToSql` dropped the `RECURSIVE` keyword from WITH clauses.

## Changes

- **Reader — views** (`persistence/binary/catalog.rs`): re-parse the persisted defining query via `Parser::parse_sql` (full main-parser grammar) and require a `Statement::Select`. Parse failures remain hard errors per #5850's fail-closed policy.
- **Reader — expression indexes and partial-index WHERE clauses**: re-parse via the new `Parser::parse_expression_sql` instead of the arena expression parser (which also rejects `COLLATE`).
- **Parser**: new `Parser::parse_expression_sql` — standalone-expression entry point over the main grammar; rejects trailing tokens.
- **Writer — `vibesql-ast` `ToSql`**: `SelectStmt`'s WITH clause now renders `WITH RECURSIVE` when any CTE carries the recursive flag, so a recursive-CTE view is not silently downgraded on a text round-trip.

### Grammar-form audit (reload path)

| Form | Before | After |
|---|---|---|
| Bare `VALUES(...)` view body | reload hard-failed | round-trips |
| `COLLATE` in select list / ORDER BY / any expression | reload hard-failed | round-trips |
| `COLLATE` in expression index / partial-index WHERE | reload hard-failed | round-trips |
| CTE view (`WITH c AS (...)`) | OK | OK (test added) |
| RECURSIVE CTE view | silently downgraded (RECURSIVE dropped by ToSql) | round-trips with flag |
| Compound selects (UNION/EXCEPT/INTERSECT, ORDER BY after set op) | OK (#5798) | OK (test added) |
| Window functions in views | OK (#5800) | OK (probed) |

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| COLLATE view reproducer round-trips | ✅ | CLI: create + reopen shows `t0` and `v2` in `sqlite_master`; `SELECT` through the view works |
| VALUES view reproducer (#5815 cross-ref) round-trips | ✅ | CLI: `CREATE VIEW dual(dummy) AS VALUES('x')` + reopen; `SELECT * FROM dual` returns `x` |
| Failed rehydration is a loud error, never a silent drop | ✅ | Reader keeps hard-error semantics (`StorageError::NotImplemented` on parse failure / non-SELECT), per #5850 |
| join7.test / join9.test | ✅ | **300/300 and 150/150** (previously 10/300 and 34/150 under default WAL-on) |
| tkt-a7debbe0.test passes | ⚠️ | 32/36. Remaining 4 (`1.1.2.3/4`, `2.1.2.3/4`) are a pre-existing COLLATE comparison-semantics gap that reproduces **in a single session on main @ e334d950b** (no persistence involved) — follow-up issue filed |
| No regression: view.test, window9.test | ✅ | 0 failures in both (24 passed/93 skipped; 38 passed/4 skipped — skips unchanged) |
| cargo test -p vibesql-storage | ✅ | All suites green (750 lib tests + integration), plus vibesql-parser and vibesql-ast suites |

## Test Plan

- New unit round-trip tests in `vibesql-storage` (`persistence::binary::catalog`): VALUES-body view, COLLATE select-list view, CTE view, RECURSIVE CTE view (flag asserted), EXCEPT/INTERSECT compound view, COLLATE expression index, COLLATE partial-index WHERE.
- Both issue reproducers exercised via CLI reopen (WAL-on default config).
- `make test-tcl-file` for join7, join9, tkt-a7debbe0, view, window9.
- `cargo check --workspace`, clippy clean on touched files.

Closes #5833