### PR TITLE
fix(dml): enforce UNIQUE/PK/NOT NULL constraints on the UPSERT DO UPDATE arm

### DIFF
--- a/crates/vibesql-executor/src/insert/on_conflict_update.rs
+++ b/crates/vibesql-executor/src/insert/on_conflict_update.rs
@@ -74,6 +74,11 @@ struct UniqueCandidate {
     parts: Vec<KeyPart>,
     /// Partial-index WHERE predicate; None for full indexes/constraints.
     predicate: Option<Expression>,
+    /// Name of the unique index this candidate came from; None for the
+    /// PRIMARY KEY and table-level UNIQUE constraints. Used for SQLite's
+    /// "UNIQUE constraint failed: index 'name'" message on expression
+    /// indexes.
+    index_name: Option<String>,
 }
 
 /// Collect every unique constraint/index that can act as an upsert conflict
@@ -90,6 +95,7 @@ fn collect_unique_candidates(
             candidates.push(UniqueCandidate {
                 parts: pk.into_iter().map(KeyPart::Column).collect(),
                 predicate: None,
+                index_name: None,
             });
         }
     }
@@ -99,6 +105,7 @@ fn collect_unique_candidates(
             candidates.push(UniqueCandidate {
                 parts: unique.into_iter().map(KeyPart::Column).collect(),
                 predicate: None,
+                index_name: None,
             });
         }
     }
@@ -133,8 +140,11 @@ fn collect_unique_candidates(
             }
         }
         if representable && !parts.is_empty() {
-            candidates
-                .push(UniqueCandidate { parts, predicate: meta.where_clause.as_deref().cloned() });
+            candidates.push(UniqueCandidate {
+                parts,
+                predicate: meta.where_clause.as_deref().cloned(),
+                index_name: Some(index_name.clone()),
+            });
         }
     }
 
@@ -335,6 +345,94 @@ fn find_conflicting_live_row(
     Ok(None)
 }
 
+/// SQLite-format violation message for a unique candidate: qualified column
+/// names for the PRIMARY KEY, table-level UNIQUE constraints, and plain
+/// column indexes (`UNIQUE constraint failed: t.x, t.y`); the index name for
+/// expression indexes (`UNIQUE constraint failed: index 'name'`).
+fn unique_violation_message(
+    schema: &vibesql_catalog::TableSchema,
+    table_name: &str,
+    candidate: &UniqueCandidate,
+) -> String {
+    let mut cols = Vec::with_capacity(candidate.parts.len());
+    for part in &candidate.parts {
+        match part {
+            KeyPart::Column(idx) => {
+                let name = schema.columns.get(*idx).map(|c| c.name.as_str()).unwrap_or("?");
+                cols.push(format!("{}.{}", table_name, name));
+            }
+            KeyPart::Expr(_) => {
+                // Expression components only occur for unique indexes.
+                return format!(
+                    "UNIQUE constraint failed: index '{}'",
+                    candidate.index_name.as_deref().unwrap_or("?")
+                );
+            }
+        }
+    }
+    format!("UNIQUE constraint failed: {}", cols.join(", "))
+}
+
+/// Enforce constraints on the row produced by the DO UPDATE arm — the same
+/// checks a normal UPDATE runs (issue #5836, upsert4 1.x.5):
+///
+/// - NOT NULL and CHECK constraints (per-row, via the shared UPDATE
+///   validator);
+/// - PRIMARY KEY / UNIQUE constraints / unique indexes, by scanning live
+///   rows directly. The scan excludes the row being updated (`row_id`) so a
+///   SET that leaves a key unchanged never conflicts with itself. Live-row
+///   scanning matches this module's conflict detection and does not depend
+///   on database-level index data, which the upsert arm does not maintain
+///   (issue #5269).
+///
+/// Errors use SQLite's exact wording, verified against sqlite3:
+/// `UNIQUE constraint failed: t.c` / `NOT NULL constraint failed: t.b` /
+/// `UNIQUE constraint failed: index 'name'` (expression indexes).
+fn validate_do_update_row(
+    db: &vibesql_storage::Database,
+    table_name: &str,
+    schema: &vibesql_catalog::TableSchema,
+    row_id: usize,
+    new_row: &vibesql_storage::Row,
+) -> Result<(), ExecutorError> {
+    // NOT NULL and CHECK — the per-row half of normal UPDATE validation.
+    crate::update::constraints::ConstraintValidator::new(schema)
+        .validate_row_skip_uniqueness(table_name, new_row)?;
+
+    // PRIMARY KEY, UNIQUE constraints, and unique indexes (including
+    // expression and partial indexes) — all candidates, not just the
+    // conflict target: SQLite aborts the statement when the update arm
+    // would violate ANY uniqueness constraint (upsert4 1.x.5).
+    let table = db
+        .get_table(table_name)
+        .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+    let evaluator = crate::evaluator::ExpressionEvaluator::new(schema);
+    for candidate in collect_unique_candidates(db, table_name, schema) {
+        let Some(new_key) = eval_candidate_key(&evaluator, &candidate, new_row) else {
+            continue;
+        };
+        if !row_in_candidate(&evaluator, &candidate, new_row) {
+            continue;
+        }
+        for (other_id, other_row) in table.scan_live() {
+            if other_id == row_id {
+                continue;
+            }
+            if !row_in_candidate(&evaluator, &candidate, other_row) {
+                continue;
+            }
+            if eval_candidate_key(&evaluator, &candidate, other_row).as_deref()
+                == Some(&new_key[..])
+            {
+                return Err(ExecutorError::ConstraintViolation(unique_violation_message(
+                    schema, table_name, &candidate,
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Would inserting `row_values` conflict on the explicit DO NOTHING conflict
 /// target? Used by the targeted `ON CONFLICT (cols) [WHERE ...] DO NOTHING`
 /// path: only conflicts on the *targeted* constraint are suppressed —
@@ -486,11 +584,18 @@ pub fn handle_on_conflict_update(
         new_values
     };
 
+    // Enforce constraints on the updated row BEFORE writing it back: the DO
+    // UPDATE arm runs the same checks as a normal UPDATE, so a SET that
+    // would duplicate a UNIQUE/PK key or null a NOT NULL column aborts the
+    // statement and leaves the table untouched (issue #5836, upsert4 1.x.5-6).
+    let new_row = vibesql_storage::Row::new(new_values);
+    validate_do_update_row(db, table_name, schema, row_id, &new_row)?;
+
     let table_mut = db
         .get_table_mut(table_name)
         .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
     table_mut
-        .update_row(row_id, vibesql_storage::Row::new(new_values))
+        .update_row(row_id, new_row)
         .map_err(|e| ExecutorError::UnsupportedExpression(format!("Storage error: {}", e)))?;
 
     // NOTE: database-level index data is not rebuilt here, matching the

--- a/crates/vibesql-executor/src/update/mod.rs
+++ b/crates/vibesql-executor/src/update/mod.rs
@@ -23,7 +23,7 @@
 //! - Uses single-pass execution instead of two-phase
 //! - Minimizes allocations
 
-mod constraints;
+pub(crate) mod constraints;
 mod executor;
 mod fast_path;
 mod foreign_keys;

--- a/crates/vibesql-executor/tests/upsert_do_update_constraint_tests.rs
+++ b/crates/vibesql-executor/tests/upsert_do_update_constraint_tests.rs
@@ -1,0 +1,220 @@
+//! Regression tests for issue #5836: the `ON CONFLICT ... DO UPDATE` arm
+//! must enforce the same constraints as a normal UPDATE (upsert4.test,
+//! 1.x.5-6).
+//!
+//! Before the fix, `INSERT ... ON CONFLICT(a) DO UPDATE SET c='one'` wrote
+//! duplicate values into a UNIQUE column instead of failing. SQLite aborts
+//! the statement and leaves the table untouched.
+//!
+//! Expected error wording verified against sqlite3:
+//! - `UNIQUE constraint failed: t1.c`             (UNIQUE column)
+//! - `UNIQUE constraint failed: t1.a`             (PRIMARY KEY)
+//! - `UNIQUE constraint failed: t5.x, t5.y`       (composite unique index)
+//! - `UNIQUE constraint failed: index 't6e'`      (expression index)
+//! - `NOT NULL constraint failed: t4.b`           (NOT NULL)
+//! - `CHECK constraint failed: <name-or-expr>`    (CHECK)
+
+use vibesql_executor::{CreateIndexExecutor, CreateTableExecutor, ExecutorError, InsertExecutor};
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Parse and execute a CREATE TABLE / CREATE INDEX / INSERT statement.
+fn run_stmt(db: &mut Database, sql: &str) -> Result<usize, ExecutorError> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            CreateTableExecutor::execute(&create_table, db).map(|_| 0)
+        }
+        vibesql_ast::Statement::CreateIndex(create_index) => {
+            CreateIndexExecutor::execute(&create_index, db).map(|_| 0)
+        }
+        vibesql_ast::Statement::Insert(insert) => InsertExecutor::execute(db, &insert),
+        other => panic!("Unsupported statement in test: {:?}", other),
+    }
+}
+
+fn setup(db: &mut Database, stmts: &[&str]) {
+    for sql in stmts {
+        run_stmt(db, sql).unwrap_or_else(|e| panic!("setup failed for {:?}: {}", sql, e));
+    }
+}
+
+/// Collect a column's values across all live rows (storage order).
+fn column_values(db: &Database, table: &str, col_idx: usize) -> Vec<SqlValue> {
+    db.get_table(table).unwrap().scan_live().map(|(_, row)| row.values[col_idx].clone()).collect()
+}
+
+/// upsert4 1.x.5: DO UPDATE that duplicates a UNIQUE column value must fail
+/// with SQLite's exact message, and 1.x.6: the table must be unchanged.
+#[test]
+fn do_update_violating_unique_column_fails() {
+    let mut db = Database::new();
+    setup(
+        &mut db,
+        &[
+            "CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, c TEXT UNIQUE)",
+            "INSERT INTO t1 VALUES(1, NULL, 'one')",
+            "INSERT INTO t1 VALUES(2, NULL, 'two')",
+        ],
+    );
+
+    let err = run_stmt(
+        &mut db,
+        "INSERT INTO t1 VALUES(2, NULL, 'zero') ON CONFLICT (a) DO UPDATE SET c = 'one'",
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: t1.c"),
+        "expected 'UNIQUE constraint failed: t1.c', got: {}",
+        err
+    );
+
+    // Statement aborted: row 2 keeps c='two' (upsert4 1.x.6).
+    assert_eq!(
+        column_values(&db, "t1", 2),
+        vec![SqlValue::Varchar("one".into()), SqlValue::Varchar("two".into())]
+    );
+}
+
+/// DO UPDATE that duplicates the PRIMARY KEY must fail (SQLite reports PK
+/// violations as UNIQUE constraint failures).
+#[test]
+fn do_update_violating_primary_key_fails() {
+    let mut db = Database::new();
+    setup(
+        &mut db,
+        &[
+            "CREATE TABLE t2(a INT PRIMARY KEY, b INTEGER, c TEXT UNIQUE)",
+            "INSERT INTO t2 VALUES(1, NULL, 'one')",
+            "INSERT INTO t2 VALUES(2, NULL, 'two')",
+        ],
+    );
+
+    let err = run_stmt(
+        &mut db,
+        "INSERT INTO t2 VALUES(9, NULL, 'two') ON CONFLICT (c) DO UPDATE SET a = 1",
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: t2.a"),
+        "expected 'UNIQUE constraint failed: t2.a', got: {}",
+        err
+    );
+
+    // Statement aborted: primary keys unchanged.
+    assert_eq!(column_values(&db, "t2", 0), vec![SqlValue::Integer(1), SqlValue::Integer(2)]);
+}
+
+/// DO UPDATE that nulls a NOT NULL column must fail.
+#[test]
+fn do_update_violating_not_null_fails() {
+    let mut db = Database::new();
+    setup(
+        &mut db,
+        &[
+            "CREATE TABLE t4(a INTEGER PRIMARY KEY, b INTEGER NOT NULL)",
+            "INSERT INTO t4 VALUES(1, 5)",
+        ],
+    );
+
+    let err =
+        run_stmt(&mut db, "INSERT INTO t4 VALUES(1, 7) ON CONFLICT (a) DO UPDATE SET b = NULL")
+            .unwrap_err();
+    assert!(
+        err.to_string().contains("NOT NULL constraint failed: t4.b"),
+        "expected 'NOT NULL constraint failed: t4.b', got: {}",
+        err
+    );
+
+    assert_eq!(column_values(&db, "t4", 1), vec![SqlValue::Integer(5)]);
+}
+
+/// DO UPDATE that duplicates a composite CREATE UNIQUE INDEX key must fail,
+/// reporting the index's columns.
+#[test]
+fn do_update_violating_unique_index_fails() {
+    let mut db = Database::new();
+    setup(
+        &mut db,
+        &[
+            "CREATE TABLE t5(a INTEGER PRIMARY KEY, x TEXT, y TEXT)",
+            "CREATE UNIQUE INDEX t5xy ON t5(x, y)",
+            "INSERT INTO t5 VALUES(1, 'p', 'q')",
+            "INSERT INTO t5 VALUES(2, 'r', 's')",
+        ],
+    );
+
+    let err = run_stmt(
+        &mut db,
+        "INSERT INTO t5 VALUES(2, 'z', 'z') ON CONFLICT (a) DO UPDATE SET x = 'p', y = 'q'",
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed: t5.x, t5.y"),
+        "expected 'UNIQUE constraint failed: t5.x, t5.y', got: {}",
+        err
+    );
+
+    assert_eq!(
+        column_values(&db, "t5", 1),
+        vec![SqlValue::Varchar("p".into()), SqlValue::Varchar("r".into())]
+    );
+}
+
+/// A DO UPDATE that leaves the unique key unchanged (or writes the
+/// conflicting row's own values back) must NOT self-conflict.
+#[test]
+fn do_update_keeping_own_key_succeeds() {
+    let mut db = Database::new();
+    setup(
+        &mut db,
+        &[
+            "CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, c TEXT UNIQUE)",
+            "INSERT INTO t1 VALUES(1, NULL, 'one')",
+            "INSERT INTO t1 VALUES(2, NULL, 'two')",
+        ],
+    );
+
+    // Rewrites c to its current value: no self-conflict (upsert4 1.x.3-4
+    // shape: only b changes; here c is explicitly set to itself too).
+    let n = run_stmt(
+        &mut db,
+        "INSERT INTO t1 VALUES(2, NULL, 'zero') ON CONFLICT (a) DO UPDATE SET b = 1, c = 'two'",
+    )
+    .unwrap();
+    assert_eq!(n, 1);
+
+    assert_eq!(column_values(&db, "t1", 1), vec![SqlValue::Null, SqlValue::Integer(1)]);
+    assert_eq!(
+        column_values(&db, "t1", 2),
+        vec![SqlValue::Varchar("one".into()), SqlValue::Varchar("two".into())]
+    );
+}
+
+/// A DO UPDATE moving the key to a genuinely fresh value succeeds (upsert4
+/// 1.x.8 shape: SET (c, a) = ('four', 4) — no other row holds those keys).
+#[test]
+fn do_update_moving_key_to_fresh_value_succeeds() {
+    let mut db = Database::new();
+    setup(
+        &mut db,
+        &[
+            "CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, c TEXT UNIQUE)",
+            "INSERT INTO t1 VALUES(1, NULL, 'one')",
+            "INSERT INTO t1 VALUES(2, NULL, 'two')",
+        ],
+    );
+
+    let n = run_stmt(
+        &mut db,
+        "INSERT INTO t1 VALUES(1, NULL, NULL) ON CONFLICT (a) DO UPDATE SET c = 'four', a = 4",
+    )
+    .unwrap();
+    assert_eq!(n, 1);
+
+    assert_eq!(column_values(&db, "t1", 0), vec![SqlValue::Integer(4), SqlValue::Integer(2)]);
+    assert_eq!(
+        column_values(&db, "t1", 2),
+        vec![SqlValue::Varchar("four".into()), SqlValue::Varchar("two".into())]
+    );
+}


### PR DESCRIPTION
## Summary

The `ON CONFLICT ... DO UPDATE` arm wrote the updated row back with no constraint validation, so `INSERT INTO t1 VALUES(2, NULL, 'zero') ON CONFLICT (a) DO UPDATE SET c = 'one'` silently produced duplicate values in the UNIQUE column `c` instead of failing. This is a P0 data-integrity bug (upsert4.test 1.x.5-6). The update arm now runs the same constraint checks as a normal UPDATE before writing the row back, and aborts the statement leaving the table untouched — matching SQLite exactly.

## Changes

- `crates/vibesql-executor/src/insert/on_conflict_update.rs`
  - New `validate_do_update_row()` called in `handle_on_conflict_update()` after SET evaluation and before `update_row()`:
    - NOT NULL + CHECK via the shared UPDATE `ConstraintValidator` (per-row half, same as the normal UPDATE path);
    - PRIMARY KEY, table-level UNIQUE constraints, and unique indexes (including expression and partial indexes) via a live-row scan reusing the module's existing `UniqueCandidate` machinery. The scan excludes the row being updated, so a SET that leaves a key unchanged never self-conflicts. Live-row scanning matches the module's conflict detection and does not depend on database-level index data, which the upsert arm does not maintain.
  - `UniqueCandidate` gains `index_name` so expression-index violations report SQLite's `UNIQUE constraint failed: index 'name'` form.
- `crates/vibesql-executor/src/update/mod.rs`: `mod constraints` -> `pub(crate) mod constraints` (one-line visibility change to share the validator).
- `crates/vibesql-executor/tests/upsert_do_update_constraint_tests.rs`: 6 regression tests (UNIQUE column, PK, NOT NULL, composite unique index, self-key no-conflict, key-move success).

All error wording verified against sqlite3: `UNIQUE constraint failed: t1.c`, `UNIQUE constraint failed: t5.x, t5.y`, `UNIQUE constraint failed: index 'name'`, `NOT NULL constraint failed: t4.b`.

Out of scope (per issue coordination with #5817): multi-clause UPSERT grammar/AST. Remaining upsert4 gaps (tuple `SET (a,b)=(...)` and lenient conflict-target analysis) are tracked in follow-up #5862.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `ON CONFLICT(a) DO UPDATE SET c='one'` raises `UNIQUE constraint failed: t1.c` | PASS | upsert4 1.x.5 now passes (all 3 schema variants); CLI smoke test shows exact message; unit test asserts wording |
| A DO UPDATE violating any UNIQUE/PK constraint errors and leaves table unchanged | PASS | upsert4 1.x.6 now passes (table state verified post-error); unit tests assert unchanged rows |
| upsert4.test improves; enforcement failures eliminated | PASS | 39/60 -> 45/60 (21 -> 15 failures). All 6 enforcement failures (1.x.5/1.x.6 x 3 variants) fixed; remaining 15 are unrelated features tracked in #5862 |
| No regressions in upsert1-3 | PASS | upsert1: 32 passed/0 failed/3 skipped; upsert2: 6 passed/8 failed; upsert3: 5 passed/2 failed — identical before and after (verified by rebuilding the unmodified baseline) |
| `cargo test -p vibesql-executor` passes | PASS | 4873 passed, 0 failed (136 suites). `deep_expression_tests` stack overflow is pre-existing on unmodified baseline (reproduced with changes stashed), environment-dependent |

## Test Plan

- `cargo test -p vibesql-executor --test upsert_do_update_constraint_tests` — 6/6 pass
- `make test-tcl-file FILE=upsert4.test` — before: 39/60 (21 failed); after: 45/60 (15 failed)
- `make test-tcl-file FILE=upsert1.test / upsert2.test / upsert3.test` — identical to pre-change baseline
- `cargo check` / `cargo clippy` / `cargo fmt` clean (remaining warnings pre-existing)
- sqlite3 cross-check of every error message shape

Closes #5836