### PR TITLE
fix(executor): honor table qualifiers when resolving columnar join keys (3+-table joins with duplicate column names)

### DIFF
--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
@@ -613,13 +613,39 @@ impl SelectExecutor<'_> {
             };
 
             // Determine which side of the condition refers to the current batch vs new table
-            let (left_col_idx, right_col_idx) = resolve_join_column_indices(
+            let (left_col_idx, right_col_idx) = match resolve_join_column_indices(
                 join_cond,
                 &joined_tables,
                 table_ref,
                 schema,
                 combined_schema,
-            )?;
+            ) {
+                Ok(indices) => indices,
+                Err(e) => {
+                    // Resolution failure (e.g. a qualifier that doesn't match the
+                    // expected side) means this chain can't safely run columnar.
+                    // Fall back to the row-oriented path instead of erroring.
+                    log::debug!(
+                        "Columnar join: failed to resolve join columns for '{}': {:?}, falling back",
+                        table_ref,
+                        e
+                    );
+                    return Ok(None);
+                }
+            };
+
+            // Sanity check (#5819): the joined-side index must lie within the
+            // current batch. An unqualified join column that resolves into a
+            // not-yet-joined table's slot in the full combined schema would
+            // otherwise index out of range (or into the wrong column).
+            if left_col_idx >= current_batch.columns.len() {
+                log::debug!(
+                    "Columnar join: resolved left column index {} exceeds current batch width {}, falling back",
+                    left_col_idx,
+                    current_batch.columns.len()
+                );
+                return Ok(None);
+            }
 
             log::debug!(
                 "Columnar join: {:?} joining '{}' (col {}) with '{}' (col {})",

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
@@ -446,26 +446,58 @@ pub(super) fn resolve_join_column_indices(
     // Determine which side refers to joined tables vs new table
     let left_in_joined = cond.left_table.as_deref().map_or_else(
         || is_column_in_tables(&cond.left_column, joined_tables, combined_schema),
-        |t| joined_tables.contains(&t),
+        |t| joined_tables.iter().any(|jt| jt.eq_ignore_ascii_case(t)),
     );
 
-    let (left_col, right_col) = if left_in_joined {
-        (&cond.left_column, &cond.right_column)
+    // Keep each column's table qualifier paired with it through the swap
+    let ((left_table, left_col), (right_table, right_col)) = if left_in_joined {
+        (
+            (cond.left_table.as_deref(), &cond.left_column),
+            (cond.right_table.as_deref(), &cond.right_column),
+        )
     } else {
-        (&cond.right_column, &cond.left_column)
+        (
+            (cond.right_table.as_deref(), &cond.right_column),
+            (cond.left_table.as_deref(), &cond.left_column),
+        )
     };
 
-    // Find left column index in the current (joined) batch
-    let left_idx = combined_schema.get_column_index(None, left_col).ok_or_else(|| {
+    // Find the joined-side column index in the combined schema.
+    //
+    // Issue #5819: the table qualifier MUST be passed through here. Dropping it
+    // (a `None` qualifier) made `get_column_index` fall back to leftmost-name
+    // matching, so a qualified ref like `b1.id` in a 3+-table join resolved to
+    // the FIRST table's `id` column whenever the first table shared the column
+    // name — silently joining on the wrong column (0 rows for inner joins,
+    // dropped matches for LEFT JOIN chains).
+    let left_idx = combined_schema.get_column_index(left_table, left_col).ok_or_else(|| {
         ExecutorError::ColumnNotFound {
             column_name: left_col.clone(),
-            table_name: String::new(),
+            table_name: left_table.unwrap_or("").to_string(),
             searched_tables: joined_tables.iter().map(|s| s.to_string()).collect(),
             available_columns: vec![],
         }
     })?;
 
-    // Find right column index in the new table
+    // Find right column index in the new table.
+    //
+    // When the right side carries a qualifier, it must actually refer to the
+    // new table; otherwise the condition was mis-classified (e.g. both sides
+    // belong to already-joined tables) and joining on it would be incorrect.
+    if let Some(rt) = right_table {
+        if !rt.eq_ignore_ascii_case(new_table) {
+            return Err(ExecutorError::ColumnNotFound {
+                column_name: right_col.clone(),
+                table_name: rt.to_string(),
+                searched_tables: vec![new_table.to_string()],
+                available_columns: new_table_schema
+                    .columns
+                    .iter()
+                    .map(|c| c.name.clone())
+                    .collect(),
+            });
+        }
+    }
     let right_idx = new_table_schema
         .columns
         .iter()

--- a/crates/vibesql-executor/tests/columnar_join_qualified_column_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_join_qualified_column_tests.rs
@@ -1,0 +1,390 @@
+//! Regression tests for issue #5819
+//!
+//! In a join of 3+ tables, a qualified column reference (`b1.id`) used in a
+//! join predicate between the 2nd and 3rd tables resolved to the FIRST table's
+//! same-named column when the first table also had a column of that name.
+//!
+//! Root cause: the columnar join fast path
+//! (`columnar_execution::join_helpers::resolve_join_column_indices`) dropped
+//! the table qualifier and resolved the joined-side join column with
+//! `CombinedSchema::get_column_index(None, col)`, which falls back to
+//! leftmost-name matching. With the ubiquitous `id`-on-every-table schema
+//! shape, `b1.id` resolved to `a1.id`, silently joining on the wrong column:
+//! inner/comma joins returned 0 rows and LEFT JOIN chains lost matches
+//! (NULL-padded rows that should have matched).
+//!
+//! The row-oriented join path was always correct; these tests pin the fixed
+//! behavior regardless of which execution path is chosen.
+
+use vibesql_catalog::{ColumnSchema, TableSchema};
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::{Database, Row};
+use vibesql_types::{DataType, SqlValue};
+
+fn parse_select(sql: &str) -> vibesql_ast::SelectStmt {
+    match Parser::parse_sql(sql) {
+        Ok(vibesql_ast::Statement::Select(select_stmt)) => *select_stmt,
+        _ => panic!("Failed to parse SELECT statement: {}", sql),
+    }
+}
+
+fn run(db: &Database, sql: &str) -> Vec<Row> {
+    let select = parse_select(sql);
+    SelectExecutor::new(db).execute(&select).unwrap()
+}
+
+/// Build the schema/data from the issue #5819 reproduction.
+///
+/// ```sql
+/// CREATE TABLE a1(id INTEGER PRIMARY KEY, v);
+/// CREATE TABLE b1(id INTEGER PRIMARY KEY, aid, v);
+/// CREATE TABLE c1(id INTEGER PRIMARY KEY, bid, v);
+/// INSERT INTO a1 VALUES(1,'a1'),(2,'a2'),(3,'a3');
+/// INSERT INTO b1 VALUES(10,1,'b1'),(11,2,'b2');
+/// INSERT INTO c1 VALUES(100,10,'c1');
+/// ```
+///
+/// Every table has an `id` column, so a qualified `b1.id` in the second join
+/// predicate used to misresolve to `a1.id`.
+fn setup_issue_5819_db() -> Database {
+    let mut db = Database::new();
+
+    let a1_schema = TableSchema::with_primary_key(
+        "A1".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, false),
+            ColumnSchema::new("v".to_string(), DataType::Varchar { max_length: None }, true),
+        ],
+        vec!["id".to_string()],
+    );
+    db.create_table(a1_schema).unwrap();
+
+    let b1_schema = TableSchema::with_primary_key(
+        "B1".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, false),
+            ColumnSchema::new("aid".to_string(), DataType::Integer, true),
+            ColumnSchema::new("v".to_string(), DataType::Varchar { max_length: None }, true),
+        ],
+        vec!["id".to_string()],
+    );
+    db.create_table(b1_schema).unwrap();
+
+    let c1_schema = TableSchema::with_primary_key(
+        "C1".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, false),
+            ColumnSchema::new("bid".to_string(), DataType::Integer, true),
+            ColumnSchema::new("v".to_string(), DataType::Varchar { max_length: None }, true),
+        ],
+        vec!["id".to_string()],
+    );
+    db.create_table(c1_schema).unwrap();
+
+    for (id, v) in [(1, "a1"), (2, "a2"), (3, "a3")] {
+        db.insert_row("A1", Row::new(vec![SqlValue::Integer(id), SqlValue::Varchar(v.into())]))
+            .unwrap();
+    }
+    for (id, aid, v) in [(10, 1, "b1"), (11, 2, "b2")] {
+        db.insert_row(
+            "B1",
+            Row::new(vec![
+                SqlValue::Integer(id),
+                SqlValue::Integer(aid),
+                SqlValue::Varchar(v.into()),
+            ]),
+        )
+        .unwrap();
+    }
+    db.insert_row(
+        "C1",
+        Row::new(vec![
+            SqlValue::Integer(100),
+            SqlValue::Integer(10),
+            SqlValue::Varchar("c1".into()),
+        ]),
+    )
+    .unwrap();
+
+    db
+}
+
+/// Q1 from the issue: LEFT JOIN chain. The bug NULL-padded the c1 columns of
+/// the first row (b1.id=10 matched c1.bid=10, but the misresolved key a1.id=1
+/// found no match).
+///
+/// sqlite3 reference:
+/// ```
+/// 1|10|100
+/// 2|11|NULL
+/// 3|NULL|NULL
+/// ```
+#[test]
+fn test_left_join_chain_qualified_id_keeps_match() {
+    let db = setup_issue_5819_db();
+
+    let sql = "SELECT a1.id, b1.id, c1.id FROM a1 LEFT JOIN b1 ON b1.aid=a1.id \
+               LEFT JOIN c1 ON c1.bid=b1.id ORDER BY 1";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 3, "LEFT JOIN chain must preserve all 3 a1 rows");
+
+    assert_eq!(result[0].values[0], SqlValue::Integer(1));
+    assert_eq!(result[0].values[1], SqlValue::Integer(10));
+    assert_eq!(
+        result[0].values[2],
+        SqlValue::Integer(100),
+        "c1 match must not be lost (bug: c1.bid=b1.id misresolved b1.id to a1.id)"
+    );
+
+    assert_eq!(result[1].values[0], SqlValue::Integer(2));
+    assert_eq!(result[1].values[1], SqlValue::Integer(11));
+    assert_eq!(result[1].values[2], SqlValue::Null);
+
+    assert_eq!(result[2].values[0], SqlValue::Integer(3));
+    assert_eq!(result[2].values[1], SqlValue::Null);
+    assert_eq!(result[2].values[2], SqlValue::Null);
+}
+
+/// Q2 from the issue: explicit INNER JOIN chain. The bug returned 0 rows.
+///
+/// sqlite3 reference: `1|10|100`
+#[test]
+fn test_inner_join_chain_qualified_id() {
+    let db = setup_issue_5819_db();
+
+    let sql = "SELECT a1.id, b1.id, c1.id FROM a1 JOIN b1 ON b1.aid=a1.id \
+               JOIN c1 ON c1.bid=b1.id";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 1, "inner join chain must return exactly 1 row (bug: 0 rows)");
+    assert_eq!(result[0].values[0], SqlValue::Integer(1));
+    assert_eq!(result[0].values[1], SqlValue::Integer(10));
+    assert_eq!(result[0].values[2], SqlValue::Integer(100));
+}
+
+/// Q2 with the join predicate written in the flipped order (`b1.id=c1.bid`).
+/// Both orders must resolve the qualifier correctly.
+#[test]
+fn test_inner_join_chain_qualified_id_flipped_predicate() {
+    let db = setup_issue_5819_db();
+
+    let sql = "SELECT a1.id, b1.id, c1.id FROM a1 JOIN b1 ON a1.id=b1.aid \
+               JOIN c1 ON b1.id=c1.bid";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].values[0], SqlValue::Integer(1));
+    assert_eq!(result[0].values[1], SqlValue::Integer(10));
+    assert_eq!(result[0].values[2], SqlValue::Integer(100));
+}
+
+/// Q3 from the issue: comma join + WHERE (reorder path). The bug returned 0 rows.
+///
+/// sqlite3 reference: `1|10|100`
+#[test]
+fn test_comma_join_where_qualified_id() {
+    let db = setup_issue_5819_db();
+
+    let sql = "SELECT a1.id, b1.id, c1.id FROM a1, b1, c1 \
+               WHERE b1.aid=a1.id AND c1.bid=b1.id";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 1, "comma join must return exactly 1 row (bug: 0 rows)");
+    assert_eq!(result[0].values[0], SqlValue::Integer(1));
+    assert_eq!(result[0].values[1], SqlValue::Integer(10));
+    assert_eq!(result[0].values[2], SqlValue::Integer(100));
+}
+
+/// The misresolution proof from the issue: with an extra a1 row whose id equals
+/// c1.bid (10), the buggy path paired a1.id=10 with c1.bid=10 while every b1
+/// column was effectively unmatched. After the fix the only row is the correct
+/// one.
+///
+/// sqlite3 reference: `1|10|100|10`
+#[test]
+fn test_inner_join_chain_with_decoy_a1_row() {
+    let mut db = setup_issue_5819_db();
+    db.insert_row("A1", Row::new(vec![SqlValue::Integer(10), SqlValue::Varchar("a10".into())]))
+        .unwrap();
+
+    let sql = "SELECT a1.id, b1.id, c1.id, c1.bid FROM a1 JOIN b1 ON b1.aid=a1.id \
+               JOIN c1 ON c1.bid=b1.id";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].values[0], SqlValue::Integer(1), "must join via b1.id, not a1.id=10");
+    assert_eq!(result[0].values[1], SqlValue::Integer(10));
+    assert_eq!(result[0].values[2], SqlValue::Integer(100));
+    assert_eq!(result[0].values[3], SqlValue::Integer(10));
+}
+
+/// Aliased tables: the qualifier is the alias, not the base table name.
+#[test]
+fn test_inner_join_chain_with_aliases() {
+    let db = setup_issue_5819_db();
+
+    let sql = "SELECT x.id, y.id, z.id FROM a1 x JOIN b1 y ON y.aid=x.id \
+               JOIN c1 z ON z.bid=y.id";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].values[0], SqlValue::Integer(1));
+    assert_eq!(result[0].values[1], SqlValue::Integer(10));
+    assert_eq!(result[0].values[2], SqlValue::Integer(100));
+}
+
+/// Duplicate NON-primary-key column name (`w` on all three tables): the fix
+/// must not be specific to rowid-alias `id` columns.
+#[test]
+fn test_duplicate_non_pk_column_name() {
+    let mut db = Database::new();
+
+    for (table, cols) in
+        [("TA", vec!["w", "v"]), ("TB", vec!["w", "aw", "v"]), ("TC", vec!["w", "bw", "v"])]
+    {
+        let schema = TableSchema::new(
+            table.to_string(),
+            cols.iter()
+                .map(|c| {
+                    if *c == "v" {
+                        ColumnSchema::new(
+                            c.to_string(),
+                            DataType::Varchar { max_length: None },
+                            true,
+                        )
+                    } else {
+                        ColumnSchema::new(c.to_string(), DataType::Integer, true)
+                    }
+                })
+                .collect(),
+        );
+        db.create_table(schema).unwrap();
+    }
+
+    for (w, v) in [(1, "a1"), (2, "a2"), (3, "a3")] {
+        db.insert_row("TA", Row::new(vec![SqlValue::Integer(w), SqlValue::Varchar(v.into())]))
+            .unwrap();
+    }
+    for (w, aw, v) in [(10, 1, "b1"), (11, 2, "b2")] {
+        db.insert_row(
+            "TB",
+            Row::new(vec![
+                SqlValue::Integer(w),
+                SqlValue::Integer(aw),
+                SqlValue::Varchar(v.into()),
+            ]),
+        )
+        .unwrap();
+    }
+    db.insert_row(
+        "TC",
+        Row::new(vec![
+            SqlValue::Integer(100),
+            SqlValue::Integer(10),
+            SqlValue::Varchar("c1".into()),
+        ]),
+    )
+    .unwrap();
+
+    let sql = "SELECT ta.w, tb.w, tc.w FROM ta JOIN tb ON tb.aw=ta.w \
+               JOIN tc ON tc.bw=tb.w";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 1, "duplicate non-PK column names must resolve by qualifier");
+    assert_eq!(result[0].values[0], SqlValue::Integer(1));
+    assert_eq!(result[0].values[1], SqlValue::Integer(10));
+    assert_eq!(result[0].values[2], SqlValue::Integer(100));
+}
+
+/// Control case that already worked pre-fix (duplicate name only on tables 2
+/// and 3; table 1 lacks it): must keep working.
+#[test]
+fn test_duplicate_only_on_tables_2_and_3_still_correct() {
+    let mut db = Database::new();
+
+    let t1 = TableSchema::new(
+        "T1".to_string(),
+        vec![
+            ColumnSchema::new("k".to_string(), DataType::Integer, true),
+            ColumnSchema::new("v".to_string(), DataType::Varchar { max_length: None }, true),
+        ],
+    );
+    db.create_table(t1).unwrap();
+    let t2 = TableSchema::new(
+        "T2".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, true),
+            ColumnSchema::new("kref".to_string(), DataType::Integer, true),
+        ],
+    );
+    db.create_table(t2).unwrap();
+    let t3 = TableSchema::new(
+        "T3".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, true),
+            ColumnSchema::new("t2ref".to_string(), DataType::Integer, true),
+        ],
+    );
+    db.create_table(t3).unwrap();
+
+    db.insert_row("T1", Row::new(vec![SqlValue::Integer(1), SqlValue::Varchar("x".into())]))
+        .unwrap();
+    db.insert_row("T2", Row::new(vec![SqlValue::Integer(10), SqlValue::Integer(1)])).unwrap();
+    db.insert_row("T3", Row::new(vec![SqlValue::Integer(100), SqlValue::Integer(10)])).unwrap();
+
+    let sql = "SELECT t1.k, t2.id, t3.id FROM t1 JOIN t2 ON t2.kref=t1.k \
+               JOIN t3 ON t3.t2ref=t2.id";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].values[0], SqlValue::Integer(1));
+    assert_eq!(result[0].values[1], SqlValue::Integer(10));
+    assert_eq!(result[0].values[2], SqlValue::Integer(100));
+}
+
+/// 4-table chain where every table has an `id` column: each hop's qualified
+/// join key must resolve against the correct table.
+#[test]
+fn test_four_table_chain_shared_id() {
+    let mut db = setup_issue_5819_db();
+    let d1_schema = TableSchema::with_primary_key(
+        "D1".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, false),
+            ColumnSchema::new("cid".to_string(), DataType::Integer, true),
+        ],
+        vec!["id".to_string()],
+    );
+    db.create_table(d1_schema).unwrap();
+    db.insert_row("D1", Row::new(vec![SqlValue::Integer(1000), SqlValue::Integer(100)])).unwrap();
+
+    let sql = "SELECT a1.id, b1.id, c1.id, d1.id FROM a1 JOIN b1 ON b1.aid=a1.id \
+               JOIN c1 ON c1.bid=b1.id JOIN d1 ON d1.cid=c1.id";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 1, "4-table chain must return exactly 1 row");
+    assert_eq!(result[0].values[0], SqlValue::Integer(1));
+    assert_eq!(result[0].values[1], SqlValue::Integer(10));
+    assert_eq!(result[0].values[2], SqlValue::Integer(100));
+    assert_eq!(result[0].values[3], SqlValue::Integer(1000));
+}
+
+/// Comma-join spelled with qualifiers on both sides in mixed order, plus the
+/// decoy row, exercising the WHERE-equijoin extraction on the reorder path.
+#[test]
+fn test_comma_join_with_decoy_row() {
+    let mut db = setup_issue_5819_db();
+    db.insert_row("A1", Row::new(vec![SqlValue::Integer(10), SqlValue::Varchar("a10".into())]))
+        .unwrap();
+
+    let sql = "SELECT a1.id, b1.id, c1.id FROM a1, b1, c1 \
+               WHERE a1.id=b1.aid AND b1.id=c1.bid";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].values[0], SqlValue::Integer(1));
+    assert_eq!(result[0].values[1], SqlValue::Integer(10));
+    assert_eq!(result[0].values[2], SqlValue::Integer(100));
+}


### PR DESCRIPTION
Closes #5819

## Problem

In a join of 3+ tables, a qualified column ref like `b1.id` used in the 2nd/3rd-table join predicate resolved to the **first** table's same-named column whenever the first table also had a column of that name. With the ubiquitous `id`-on-every-table schema shape this silently returned wrong results:

- inner / comma joins: **0 rows** instead of the matching rows
- LEFT JOIN chains: matches silently dropped (NULL-padded)

All three reproducers from the issue (Q1/Q2/Q3, plus the decoy-row proof variant) confirmed against sqlite3.

## Root cause

Not in the row-oriented join machinery (which the issue initially pointed at) — instrumentation showed `nested_loop_join`, `join_analyzer::extract_column_index`, `CombinedSchema::get_column_index`, and the reorder optimizer all resolve correctly and the row path produces byte-correct results (`VIBESQL_DISABLE_COLUMNAR_JOIN=1` masks the bug entirely).

The defect is in the **columnar join fast path**, which intercepts eligible multi-table joins before the row path runs:

`crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs` — `resolve_join_column_indices` dropped the table qualifier when resolving the joined-side key:

```rust
let left_idx = combined_schema.get_column_index(None, left_col)...
```

`get_column_index(None, "id")` falls back to leftmost-name matching, so `b1.id` resolved to `a1.id` (index 0) and the chain joined `a1.id = c1.bid` — exactly the misresolution the curator proved with the decoy `a1 VALUES(10,'a10')` row.

## Fix

- `resolve_join_column_indices` keeps each column's table qualifier paired with it through the joined-side/new-table swap and passes it to `CombinedSchema::get_column_index`, so qualified refs (including aliases, which are the combined-schema keys) resolve against the correct table's slot.
- The new-table side rejects a qualifier that doesn't match the new table (mis-classified condition) instead of joining on a wrong column by name.
- `execute_columnar_join_chain` treats resolution failure as *fall back to the row-oriented path* rather than erroring, and sanity-checks the resolved joined-side index against the current batch width.

The fix keeps the columnar path active (verified via probe: `joining c1 left_col=2` = b1.id, previously `left_col=0` = a1.id) — no performance regression from falling back; this preserves the PR #5810 / #5702 columnar-join behavior.

## Test evidence

- **New integration suite** `crates/vibesql-executor/tests/columnar_join_qualified_column_tests.rs` (10 tests): LEFT JOIN chain, INNER JOIN chain in both predicate orders, comma join + WHERE (reorder path), decoy-row misresolution proof (inner + comma), aliased tables, duplicate **non-PK** column names, 4-table chain, and the previously-correct control case (duplicate only on tables 2+3). **9/10 fail before the fix; all 10 pass after.**
- Manual: reproducer output now byte-identical to `sqlite3` for Q1–Q4.
- `make test-tcl-file FILE=where3.test`: **84 passed / 0 failed / 19 skipped** (unchanged, matches acceptance criteria).
- `join.test` (166/11/1 — the 11 failures verified **pre-existing**, identical with fix stashed), `join2` 46/0, `join5` 39/0, `join6` 16/0, `where.test` 168/0, `where2.test` 30/0 — no regressions.
- `cargo test -p vibesql-executor --release`: 80 test targets, all green (includes the #5702 compound-ON columnar tests).
- `cargo clippy -p vibesql-executor`: no new warnings in changed code; changed/added files rustfmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)