### PR TITLE
refactor(parser): deduplicate seeded-LHS tier logic via seeded _from tier variants

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -473,58 +473,56 @@ impl<'arena> ArenaParser<'arena> {
     /// relative precedence among these operators is preserved
     /// (e.g. `x IN (1) + 2 * 3` parses as `(x IN (1)) + (2 * 3)`).
     ///
+    /// Delegates to `parse_additive_expression_from`, which climbs the seeded
+    /// left operand through the multiplicative, concat, and additive tiers
+    /// using the canonical per-tier operator loops. The standard parser has
+    /// the same helper (plus a shift tier) in parser/expressions/operators.rs.
+    ///
     /// Note: the arena parser has no shift/bitwise tiers; expressions using
     /// those operators fail here and fall back to the standard parser.
     fn continue_higher_precedence_ops(
         &mut self,
-        mut left: Expression<'arena>,
+        left: Expression<'arena>,
     ) -> Result<Expression<'arena>, ParseError> {
-        loop {
-            let (op, right) = match self.peek() {
-                // Multiplicative tier: right operand at unary tier
-                Token::Symbol('*') => {
-                    self.advance();
-                    (BinaryOperator::Multiply, self.parse_unary_expression()?)
-                }
-                Token::Symbol('/') => {
-                    self.advance();
-                    (BinaryOperator::Divide, self.parse_unary_expression()?)
-                }
-                Token::Symbol('%') => {
-                    self.advance();
-                    (BinaryOperator::Modulo, self.parse_unary_expression()?)
-                }
-                Token::Keyword { keyword: Keyword::Div, .. } => {
-                    self.advance();
-                    (BinaryOperator::IntegerDivide, self.parse_unary_expression()?)
-                }
-                // Concat tier: right operand at multiplicative tier
-                Token::Operator(MultiCharOperator::Concat) => {
-                    self.advance();
-                    (BinaryOperator::Concat, self.parse_multiplicative_expression()?)
-                }
-                // Additive tier: right operand at concat tier
-                Token::Symbol('+') => {
-                    self.advance();
-                    (BinaryOperator::Plus, self.parse_concat_expression()?)
-                }
-                Token::Symbol('-') => {
-                    self.advance();
-                    (BinaryOperator::Minus, self.parse_concat_expression()?)
-                }
-                _ => break,
-            };
-            let left_ref = self.arena.alloc(left);
-            let right_ref = self.arena.alloc(right);
-            left = Expression::BinaryOp { op, left: left_ref, right: right_ref };
-        }
-        Ok(left)
+        self.parse_additive_expression_from(left)
     }
+
+    // ------------------------------------------------------------------
+    // Arithmetic tier functions (additive -> concat -> multiplicative)
+    //
+    // Each tier comes in two forms:
+    // - `parse_<tier>_expression()` parses a fresh operand (starting at the
+    //   unary tier) and then climbs from that seed.
+    // - `parse_<tier>_expression_from(left)` takes an already-parsed left
+    //   operand, first runs it through all tighter tiers, then applies this
+    //   tier's operator loop. Each operator loop exists exactly once, in the
+    //   `_from` variant.
+    //
+    // Parallel-structure invariant (see parser/expressions/operators.rs): the
+    // standard parser has the same decomposition plus shift and bitwise
+    // tiers, which the arena parser deliberately lacks. The arena parser must
+    // produce ASTs equivalent to the standard parser for everything it
+    // accepts; anything it cannot express must fail arena parsing (triggering
+    // parse_with_arena_fallback), never silently truncate.
+    // ------------------------------------------------------------------
 
     /// Parse additive expression (handles +, -).
     /// Per SQLite, || has higher precedence than + and -, so it's handled in parse_concat_expression.
     fn parse_additive_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
-        let mut left = self.parse_concat_expression()?;
+        let seed = self.parse_unary_expression()?;
+        self.parse_additive_expression_from(seed)
+    }
+
+    /// Additive tier (`+`, `-`) with an already-parsed left operand.
+    ///
+    /// The seed is first climbed through the tighter tiers
+    /// (multiplicative -> concat), so this doubles as the seeded
+    /// precedence-climbing entry point used by `continue_higher_precedence_ops`.
+    fn parse_additive_expression_from(
+        &mut self,
+        left: Expression<'arena>,
+    ) -> Result<Expression<'arena>, ParseError> {
+        let mut left = self.parse_concat_expression_from(left)?;
 
         loop {
             let op = match self.peek() {
@@ -546,7 +544,16 @@ impl<'arena> ArenaParser<'arena> {
     /// Parse string concatenation expression (handles ||).
     /// Per SQLite, || has higher precedence than + and -, but lower than * / %.
     fn parse_concat_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
-        let mut left = self.parse_multiplicative_expression()?;
+        let seed = self.parse_unary_expression()?;
+        self.parse_concat_expression_from(seed)
+    }
+
+    /// Concat tier (`||`) with an already-parsed left operand.
+    fn parse_concat_expression_from(
+        &mut self,
+        left: Expression<'arena>,
+    ) -> Result<Expression<'arena>, ParseError> {
+        let mut left = self.parse_multiplicative_expression_from(left)?;
 
         while self.peek() == &Token::Operator(MultiCharOperator::Concat) {
             self.advance();
@@ -565,8 +572,15 @@ impl<'arena> ArenaParser<'arena> {
 
     /// Parse multiplicative expression.
     fn parse_multiplicative_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
-        let mut left = self.parse_unary_expression()?;
+        let seed = self.parse_unary_expression()?;
+        self.parse_multiplicative_expression_from(seed)
+    }
 
+    /// Multiplicative tier (`*`, `/`, `%`, `DIV`) with an already-parsed left operand.
+    fn parse_multiplicative_expression_from(
+        &mut self,
+        mut left: Expression<'arena>,
+    ) -> Result<Expression<'arena>, ParseError> {
         loop {
             let op = match self.peek() {
                 Token::Symbol('*') => BinaryOperator::Multiply,

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -111,10 +111,42 @@ impl Parser {
         Ok(left)
     }
 
+    // ------------------------------------------------------------------
+    // Arithmetic tier functions (shift -> additive -> concat -> multiplicative)
+    //
+    // Each tier comes in two forms:
+    // - `parse_<tier>_expression()` parses a fresh operand (starting at the
+    //   unary tier) and then climbs from that seed.
+    // - `parse_<tier>_expression_from(left)` takes an already-parsed left
+    //   operand, first runs it through all tighter tiers, then applies this
+    //   tier's operator loop. Each operator loop exists exactly once, in the
+    //   `_from` variant.
+    //
+    // Parallel-structure invariant (see arena_parser/expression.rs): the
+    // arena parser mirrors this decomposition minus the shift and bitwise
+    // tiers, which it deliberately lacks. The arena parser must produce ASTs
+    // equivalent to this parser for everything it accepts; anything it cannot
+    // express must fail arena parsing (triggering parse_with_arena_fallback),
+    // never silently truncate.
+    // ------------------------------------------------------------------
+
     /// Parse shift expression (handles <<, >>)
     /// Precedence: between comparison and additive
     pub(super) fn parse_shift_expression(&mut self) -> Result<vibesql_ast::Expression, ParseError> {
-        let mut left = self.parse_additive_expression()?;
+        let seed = self.parse_unary_expression()?;
+        self.parse_shift_expression_from(seed)
+    }
+
+    /// Shift tier (`<<`, `>>`) with an already-parsed left operand.
+    ///
+    /// The seed is first climbed through the tighter tiers
+    /// (multiplicative -> concat -> additive), so this doubles as the seeded
+    /// precedence-climbing entry point used by `continue_higher_precedence_ops`.
+    fn parse_shift_expression_from(
+        &mut self,
+        left: vibesql_ast::Expression,
+    ) -> Result<vibesql_ast::Expression, ParseError> {
+        let mut left = self.parse_additive_expression_from(left)?;
 
         loop {
             let op = match self.peek() {
@@ -144,7 +176,16 @@ impl Parser {
     pub(super) fn parse_additive_expression(
         &mut self,
     ) -> Result<vibesql_ast::Expression, ParseError> {
-        let mut left = self.parse_concat_expression()?;
+        let seed = self.parse_unary_expression()?;
+        self.parse_additive_expression_from(seed)
+    }
+
+    /// Additive tier (`+`, `-`) with an already-parsed left operand.
+    fn parse_additive_expression_from(
+        &mut self,
+        left: vibesql_ast::Expression,
+    ) -> Result<vibesql_ast::Expression, ParseError> {
+        let mut left = self.parse_concat_expression_from(left)?;
 
         loop {
             let op = match self.peek() {
@@ -170,7 +211,16 @@ impl Parser {
     pub(super) fn parse_concat_expression(
         &mut self,
     ) -> Result<vibesql_ast::Expression, ParseError> {
-        let mut left = self.parse_multiplicative_expression()?;
+        let seed = self.parse_unary_expression()?;
+        self.parse_concat_expression_from(seed)
+    }
+
+    /// Concat tier (`||`) with an already-parsed left operand.
+    fn parse_concat_expression_from(
+        &mut self,
+        left: vibesql_ast::Expression,
+    ) -> Result<vibesql_ast::Expression, ParseError> {
+        let mut left = self.parse_multiplicative_expression_from(left)?;
 
         while self.peek() == &Token::Operator(crate::token::MultiCharOperator::Concat) {
             self.advance();
@@ -189,8 +239,15 @@ impl Parser {
     pub(super) fn parse_multiplicative_expression(
         &mut self,
     ) -> Result<vibesql_ast::Expression, ParseError> {
-        let mut left = self.parse_unary_expression()?;
+        let seed = self.parse_unary_expression()?;
+        self.parse_multiplicative_expression_from(seed)
+    }
 
+    /// Multiplicative tier (`*`, `/`, `%`, `DIV`) with an already-parsed left operand.
+    fn parse_multiplicative_expression_from(
+        &mut self,
+        mut left: vibesql_ast::Expression,
+    ) -> Result<vibesql_ast::Expression, ParseError> {
         loop {
             let op = match self.peek() {
                 Token::Symbol('*') => vibesql_ast::BinaryOperator::Multiply,
@@ -838,62 +895,16 @@ impl Parser {
     /// Each operator's right operand is parsed at the next-tighter tier, so
     /// relative precedence among these operators is preserved
     /// (e.g. `x IN (1) + 2 * 3` parses as `(x IN (1)) + (2 * 3)`).
+    ///
+    /// Delegates to `parse_shift_expression_from`, which climbs the seeded
+    /// left operand through the multiplicative, concat, additive, and shift
+    /// tiers using the canonical per-tier operator loops. The arena parser
+    /// has the same helper (minus the shift tier) in arena_parser/expression.rs.
     fn continue_higher_precedence_ops(
         &mut self,
-        mut left: vibesql_ast::Expression,
+        left: vibesql_ast::Expression,
     ) -> Result<vibesql_ast::Expression, ParseError> {
-        use crate::token::MultiCharOperator;
-        loop {
-            let (op, right) = match self.peek() {
-                // Multiplicative tier: right operand at unary tier
-                Token::Symbol('*') => {
-                    self.advance();
-                    (vibesql_ast::BinaryOperator::Multiply, self.parse_unary_expression()?)
-                }
-                Token::Symbol('/') => {
-                    self.advance();
-                    (vibesql_ast::BinaryOperator::Divide, self.parse_unary_expression()?)
-                }
-                Token::Symbol('%') => {
-                    self.advance();
-                    (vibesql_ast::BinaryOperator::Modulo, self.parse_unary_expression()?)
-                }
-                Token::Keyword { keyword: Keyword::Div, .. } => {
-                    self.advance();
-                    (vibesql_ast::BinaryOperator::IntegerDivide, self.parse_unary_expression()?)
-                }
-                // Concat tier: right operand at multiplicative tier
-                Token::Operator(MultiCharOperator::Concat) => {
-                    self.advance();
-                    (vibesql_ast::BinaryOperator::Concat, self.parse_multiplicative_expression()?)
-                }
-                // Additive tier: right operand at concat tier
-                Token::Symbol('+') => {
-                    self.advance();
-                    (vibesql_ast::BinaryOperator::Plus, self.parse_concat_expression()?)
-                }
-                Token::Symbol('-') => {
-                    self.advance();
-                    (vibesql_ast::BinaryOperator::Minus, self.parse_concat_expression()?)
-                }
-                // Shift tier: right operand at additive tier
-                Token::Operator(MultiCharOperator::LeftShift) => {
-                    self.advance();
-                    (vibesql_ast::BinaryOperator::LeftShift, self.parse_additive_expression()?)
-                }
-                Token::Operator(MultiCharOperator::RightShift) => {
-                    self.advance();
-                    (vibesql_ast::BinaryOperator::RightShift, self.parse_additive_expression()?)
-                }
-                _ => break,
-            };
-            left = vibesql_ast::Expression::BinaryOp {
-                op,
-                left: Box::new(left),
-                right: Box::new(right),
-            };
-        }
-        Ok(left)
+        self.parse_shift_expression_from(left)
     }
 
     /// Parse unary expression (handles unary +, -, ~ operators)

--- a/crates/vibesql-parser/src/tests/arena_parser.rs
+++ b/crates/vibesql-parser/src/tests/arena_parser.rs
@@ -618,3 +618,214 @@ fn test_arena_fallback_like_shift_pattern() {
         pattern
     );
 }
+
+// ============================================================================
+// Mirrored chained-IN matrix (issue #5812)
+//
+// This matrix mirrors tests/in_list.rs (test_matrix_*): the arena parser must
+// produce ASTs equivalent to the standard parser for everything it accepts.
+// Shift-tier cases (<<) are outside the arena parser's grammar and must fail
+// arena parsing (never silently truncate) and succeed end-to-end through
+// parse_with_arena_fallback. All expected values were verified against sqlite3.
+// ============================================================================
+
+/// Assert the arena expression is `Extended(InList { .. })`.
+fn assert_arena_in_list(expr: &vibesql_ast::arena::Expression<'_>, context: &str) {
+    assert!(
+        matches!(
+            expr,
+            vibesql_ast::arena::Expression::Extended(
+                vibesql_ast::arena::ExtendedExpr::InList { .. }
+            )
+        ),
+        "{}: expected IN list node, got {:?}",
+        context,
+        expr
+    );
+}
+
+#[test]
+fn test_arena_matrix_in_list_plus_literal() {
+    // sqlite3: SELECT 1 IN (1) + 1; -- 2
+    with_arena_select_expr("SELECT 1 IN (1) + 1", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, left, .. } = expr else {
+            panic!("expected BinaryOp Plus at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Plus);
+        assert_arena_in_list(left, "left operand of +");
+    });
+}
+
+#[test]
+fn test_arena_matrix_in_plus_then_multiply() {
+    // sqlite3: SELECT 1 IN (1) + 2 * 3; -- 7, i.e. (x IN (1)) + (2 * 3)
+    with_arena_select_expr("SELECT x IN (1) + 2 * 3", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, left, right } = expr else {
+            panic!("expected BinaryOp Plus at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Plus);
+        assert_arena_in_list(left, "left operand of +");
+        assert!(
+            matches!(
+                right,
+                vibesql_ast::arena::Expression::BinaryOp {
+                    op: vibesql_ast::BinaryOperator::Multiply,
+                    ..
+                }
+            ),
+            "right operand of + should be (2 * 3): {:?}",
+            right
+        );
+    });
+}
+
+#[test]
+fn test_arena_matrix_in_concat() {
+    // sqlite3: SELECT 1 IN (1) || 'x'; -- '1x'
+    with_arena_select_expr("SELECT 1 IN (1) || 'x'", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, left, .. } = expr else {
+            panic!("expected BinaryOp Concat at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Concat);
+        assert_arena_in_list(left, "left operand of ||");
+    });
+}
+
+#[test]
+fn test_arena_matrix_in_multiply_then_plus() {
+    // sqlite3: SELECT 1 IN (1) * 2 + 3; -- 5, i.e. ((1 IN (1)) * 2) + 3
+    with_arena_select_expr("SELECT 1 IN (1) * 2 + 3", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, left, .. } = expr else {
+            panic!("expected BinaryOp Plus at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Plus);
+        let vibesql_ast::arena::Expression::BinaryOp { op: inner_op, left: inner_left, .. } = left
+        else {
+            panic!("left operand of + should be ((1 IN (1)) * 2): {:?}", left);
+        };
+        assert_eq!(*inner_op, vibesql_ast::BinaryOperator::Multiply);
+        assert_arena_in_list(inner_left, "innermost left");
+    });
+}
+
+#[test]
+fn test_arena_matrix_in_plus_minus_chain() {
+    // sqlite3: SELECT 5 IN (5) + 10 - 3; -- 8, i.e. ((5 IN (5)) + 10) - 3
+    with_arena_select_expr("SELECT 5 IN (5) + 10 - 3", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, left, .. } = expr else {
+            panic!("expected BinaryOp Minus at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Minus);
+        let vibesql_ast::arena::Expression::BinaryOp { op: inner_op, left: inner_left, .. } = left
+        else {
+            panic!("left operand of - should be ((5 IN (5)) + 10): {:?}", left);
+        };
+        assert_eq!(*inner_op, vibesql_ast::BinaryOperator::Plus);
+        assert_arena_in_list(inner_left, "innermost left");
+    });
+}
+
+#[test]
+fn test_arena_matrix_not_in_subquery_shift_falls_back() {
+    // sqlite3: SELECT 1 NOT IN (SELECT 1) << 2; -- 0
+    // The arena parser has no shift tier: it must fail (never silently
+    // truncate to just the NOT IN node), and the fallback path must produce
+    // the standard parser's AST.
+    let arena = Bump::new();
+    let result = ArenaParser::parse_select_with_interner("SELECT 1 NOT IN (SELECT 1) << 2", &arena);
+    assert!(
+        result.is_err(),
+        "arena parser has no shift tier; << after NOT IN must fail arena parse, got: {:?}",
+        result.map(|(stmt, _)| format!("{:?}", stmt.select_list[0]))
+    );
+
+    let stmt = crate::parse_with_arena_fallback("SELECT 1 NOT IN (SELECT 1) << 2;")
+        .expect("fallback path should parse NOT IN followed by <<");
+    let vibesql_ast::Statement::Select(select) = stmt else {
+        panic!("expected SELECT statement");
+    };
+    let vibesql_ast::SelectItem::Expression { expr, .. } = &select.select_list[0] else {
+        panic!("expected expression select item");
+    };
+    let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr else {
+        panic!("expected BinaryOp LeftShift at top level, got {:?}", expr);
+    };
+    assert_eq!(*op, vibesql_ast::BinaryOperator::LeftShift);
+    assert!(
+        matches!(**left, vibesql_ast::Expression::In { negated: true, .. }),
+        "left operand of << should be the NOT IN node: {:?}",
+        left
+    );
+}
+
+#[test]
+fn test_arena_matrix_in_shift_falls_back() {
+    // sqlite3: SELECT 1 IN (1) << 2; -- 4
+    let arena = Bump::new();
+    let result = ArenaParser::parse_select_with_interner("SELECT 1 IN (1) << 2", &arena);
+    assert!(
+        result.is_err(),
+        "arena parser has no shift tier; << after IN must fail arena parse, got: {:?}",
+        result.map(|(stmt, _)| format!("{:?}", stmt.select_list[0]))
+    );
+
+    let stmt = crate::parse_with_arena_fallback("SELECT 1 IN (1) << 2;")
+        .expect("fallback path should parse IN followed by <<");
+    let vibesql_ast::Statement::Select(select) = stmt else {
+        panic!("expected SELECT statement");
+    };
+    let vibesql_ast::SelectItem::Expression { expr, .. } = &select.select_list[0] else {
+        panic!("expected expression select item");
+    };
+    let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr else {
+        panic!("expected BinaryOp LeftShift at top level, got {:?}", expr);
+    };
+    assert_eq!(*op, vibesql_ast::BinaryOperator::LeftShift);
+    assert!(
+        matches!(**left, vibesql_ast::Expression::InList { .. }),
+        "left operand of << should be the IN list node: {:?}",
+        left
+    );
+}
+
+#[test]
+fn test_arena_matrix_in_between_shift_bound_falls_back() {
+    // sqlite3: SELECT 1 IN (1) BETWEEN 0 AND 1<<2; -- 1
+    // Chained-IN with a shift-tier BETWEEN bound (post-#5813): the arena
+    // parser must fail on the << bound, and the fallback must produce
+    // Between { expr: InList, high: (1 << 2) }.
+    let arena = Bump::new();
+    let result =
+        ArenaParser::parse_select_with_interner("SELECT 1 IN (1) BETWEEN 0 AND 1<<2", &arena);
+    assert!(
+        result.is_err(),
+        "arena parser has no shift tier; BETWEEN with << bound must fail arena parse, got: {:?}",
+        result.map(|(stmt, _)| format!("{:?}", stmt.select_list[0]))
+    );
+
+    let stmt = crate::parse_with_arena_fallback("SELECT 1 IN (1) BETWEEN 0 AND 1<<2;")
+        .expect("fallback path should parse chained IN with shift BETWEEN bound");
+    let vibesql_ast::Statement::Select(select) = stmt else {
+        panic!("expected SELECT statement");
+    };
+    let vibesql_ast::SelectItem::Expression { expr, .. } = &select.select_list[0] else {
+        panic!("expected expression select item");
+    };
+    let vibesql_ast::Expression::Between { expr: inner, high, negated, .. } = expr else {
+        panic!("expected Between at top level, got {:?}", expr);
+    };
+    assert!(!negated);
+    assert!(
+        matches!(**inner, vibesql_ast::Expression::InList { .. }),
+        "BETWEEN subject should be the IN list node: {:?}",
+        inner
+    );
+    assert!(
+        matches!(
+            **high,
+            vibesql_ast::Expression::BinaryOp { op: vibesql_ast::BinaryOperator::LeftShift, .. }
+        ),
+        "high bound should be (1 << 2): {:?}",
+        high
+    );
+}

--- a/crates/vibesql-parser/src/tests/in_list.rs
+++ b/crates/vibesql-parser/src/tests/in_list.rs
@@ -530,3 +530,176 @@ fn test_in_followed_by_isnull() {
         panic!("expected IsNull at top level");
     }
 }
+
+// ========================================================================
+// Mirrored chained-IN matrix (issue #5812)
+//
+// This matrix is mirrored in tests/arena_parser.rs (test_arena_matrix_*):
+// the arena parser must produce equivalent ASTs for everything it accepts,
+// and expressions it cannot express (shift tier) must fail arena parsing
+// and route through parse_with_arena_fallback to this parser.
+// All expected values below were verified against sqlite3.
+// ========================================================================
+
+#[test]
+fn test_matrix_in_list_plus_literal() {
+    // sqlite3: SELECT 1 IN (1) + 1; -- 2
+    let expr = parse_select_expr("SELECT 1 IN (1) + 1;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Plus);
+        assert!(
+            matches!(*left, vibesql_ast::Expression::InList { negated: false, .. }),
+            "left operand of + should be the IN list node: {:?}",
+            left
+        );
+    } else {
+        panic!("expected BinaryOp Plus at top level");
+    }
+}
+
+#[test]
+fn test_matrix_not_in_subquery_shift() {
+    // sqlite3: SELECT 1 NOT IN (SELECT 1) << 2; -- 0
+    // Shift-tier case: standard parser only; the arena parser must fail and
+    // fall back (see test_arena_matrix_not_in_subquery_shift_falls_back).
+    let expr = parse_select_expr("SELECT 1 NOT IN (SELECT 1) << 2;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::LeftShift);
+        assert!(
+            matches!(*left, vibesql_ast::Expression::In { negated: true, .. }),
+            "left operand of << should be the NOT IN node: {:?}",
+            left
+        );
+    } else {
+        panic!("expected BinaryOp LeftShift at top level");
+    }
+}
+
+#[test]
+fn test_matrix_in_plus_then_multiply() {
+    // sqlite3: SELECT 1 IN (1) + 2 * 3; -- 7, i.e. (x IN (1)) + (2 * 3)
+    let expr = parse_select_expr("SELECT x IN (1) + 2 * 3;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, right } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Plus);
+        assert!(
+            matches!(*left, vibesql_ast::Expression::InList { .. }),
+            "left operand of + should be the IN list node: {:?}",
+            left
+        );
+        assert!(
+            matches!(
+                *right,
+                vibesql_ast::Expression::BinaryOp { op: vibesql_ast::BinaryOperator::Multiply, .. }
+            ),
+            "right operand of + should be (2 * 3): {:?}",
+            right
+        );
+    } else {
+        panic!("expected BinaryOp Plus at top level");
+    }
+}
+
+#[test]
+fn test_matrix_in_concat() {
+    // sqlite3: SELECT 1 IN (1) || 'x'; -- '1x'
+    let expr = parse_select_expr("SELECT 1 IN (1) || 'x';");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Concat);
+        assert!(
+            matches!(*left, vibesql_ast::Expression::InList { .. }),
+            "left operand of || should be the IN list node: {:?}",
+            left
+        );
+    } else {
+        panic!("expected BinaryOp Concat at top level");
+    }
+}
+
+#[test]
+fn test_matrix_in_multiply_then_plus() {
+    // sqlite3: SELECT 1 IN (1) * 2 + 3; -- 5, i.e. ((1 IN (1)) * 2) + 3
+    let expr = parse_select_expr("SELECT 1 IN (1) * 2 + 3;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Plus);
+        if let vibesql_ast::Expression::BinaryOp { op: inner_op, left: inner_left, .. } = *left {
+            assert_eq!(inner_op, vibesql_ast::BinaryOperator::Multiply);
+            assert!(
+                matches!(*inner_left, vibesql_ast::Expression::InList { .. }),
+                "innermost left should be the IN list node: {:?}",
+                inner_left
+            );
+        } else {
+            panic!("left operand of + should be ((1 IN (1)) * 2): {:?}", left);
+        }
+    } else {
+        panic!("expected BinaryOp Plus at top level");
+    }
+}
+
+#[test]
+fn test_matrix_in_plus_minus_chain() {
+    // sqlite3: SELECT 5 IN (5) + 10 - 3; -- 8, i.e. ((5 IN (5)) + 10) - 3
+    let expr = parse_select_expr("SELECT 5 IN (5) + 10 - 3;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Minus);
+        if let vibesql_ast::Expression::BinaryOp { op: inner_op, left: inner_left, .. } = *left {
+            assert_eq!(inner_op, vibesql_ast::BinaryOperator::Plus);
+            assert!(
+                matches!(*inner_left, vibesql_ast::Expression::InList { .. }),
+                "innermost left should be the IN list node: {:?}",
+                inner_left
+            );
+        } else {
+            panic!("left operand of - should be ((5 IN (5)) + 10): {:?}", left);
+        }
+    } else {
+        panic!("expected BinaryOp Minus at top level");
+    }
+}
+
+#[test]
+fn test_matrix_in_shift() {
+    // sqlite3: SELECT 1 IN (1) << 2; -- 4
+    // Shift-tier case: standard parser only; the arena parser must fail and
+    // fall back (see test_arena_matrix_in_shift_falls_back).
+    let expr = parse_select_expr("SELECT 1 IN (1) << 2;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::LeftShift);
+        assert!(
+            matches!(*left, vibesql_ast::Expression::InList { .. }),
+            "left operand of << should be the IN list node: {:?}",
+            left
+        );
+    } else {
+        panic!("expected BinaryOp LeftShift at top level");
+    }
+}
+
+#[test]
+fn test_matrix_in_between_shift_bound() {
+    // sqlite3: SELECT 1 IN (1) BETWEEN 0 AND 1<<2; -- 1
+    // Combines chained-IN with a shift-tier BETWEEN bound (post-#5813 the
+    // non-negated BETWEEN bounds parse at the shift tier).
+    let expr = parse_select_expr("SELECT 1 IN (1) BETWEEN 0 AND 1<<2;");
+    if let vibesql_ast::Expression::Between { expr: inner, high, negated, .. } = expr {
+        assert!(!negated);
+        assert!(
+            matches!(*inner, vibesql_ast::Expression::InList { .. }),
+            "BETWEEN subject should be the IN list node: {:?}",
+            inner
+        );
+        assert!(
+            matches!(
+                *high,
+                vibesql_ast::Expression::BinaryOp {
+                    op: vibesql_ast::BinaryOperator::LeftShift,
+                    ..
+                }
+            ),
+            "high bound should be (1 << 2): {:?}",
+            high
+        );
+    } else {
+        panic!("expected Between at top level");
+    }
+}


### PR DESCRIPTION
Closes #5812

## Summary

PR #5811 added `continue_higher_precedence_ops` helpers in both parsers so tighter-binding operators after an IN/NOT IN node take the whole IN expression as their left operand. Each helper re-encoded the operator-to-tier mapping that already lives in the dedicated tier functions, so the mapping existed in **three places per parser** (tier functions, the helper, and implicitly in the tier-chain ordering). This PR removes the duplication with the within-parser decomposition recommended by the Curator — **no cross-parser code sharing, no Pratt rewrite, zero behavior change**.

## Decomposition structure

**Standard parser** (`crates/vibesql-parser/src/parser/expressions/operators.rs`):
- New seeded variants `parse_shift_expression_from` -> `parse_additive_expression_from` -> `parse_concat_expression_from` -> `parse_multiplicative_expression_from`, each taking an already-parsed left operand, climbing it through the tighter tiers, then applying its own operator loop. **Each operator loop now exists exactly once**, in the `_from` variant.
- The plain tier functions become thin wrappers: parse a unary seed, then delegate to the `_from` variant.
- `continue_higher_precedence_ops` is now a one-line delegation to `parse_shift_expression_from(left)` (doc comment on the IN-node closure property retained).

**Arena parser** (`crates/vibesql-parser/src/arena_parser/expression.rs`):
- Same decomposition **minus the shift tier**, which the arena parser deliberately lacks; the seeded entry point is `parse_additive_expression_from`. Shift-containing input still fails arena parse and routes through `parse_with_arena_fallback` (covered by tests — never silently truncates).

**Documented parallel structure**: both files carry a cross-referencing comment block naming the counterpart file and stating the invariant: the arena parser must produce ASTs equivalent to the standard parser for everything it accepts; anything it cannot express must fail arena parsing (triggering fallback), never silently truncate.

## Mirrored test matrices (new tests only; zero existing tests modified)

- `tests/in_list.rs` — 8 `test_matrix_*` tests: `1 IN (1) + 1`, `1 NOT IN (SELECT 1) << 2`, `x IN (1) + 2 * 3`, `1 IN (1) || 'x'`, `1 IN (1) * 2 + 3`, `5 IN (5) + 10 - 3`, `1 IN (1) << 2`, and `1 IN (1) BETWEEN 0 AND 1<<2` (post-#5813/#5849 shift-tier BETWEEN bound).
- `tests/arena_parser.rs` — 8 `test_arena_matrix_*` tests mirroring the above: AST-equivalence assertions for what the arena parser accepts, plus explicit fail-then-fallback assertions for the three shift-tier cases (arena parse must error, `parse_with_arena_fallback` must produce the standard parser's AST).

## Test evidence

- `cargo test -p vibesql-parser`: **1554 passed, 0 failed** (+ 8 doc-tests) — existing tests untouched
- `cargo clippy -p vibesql-parser --all-targets`: no new warnings (2 pre-existing warnings in files this PR does not touch)
- Behavior-identity CLI spot check (release build, `:memory:`) on the PR #5811 reproducer set + composed-IN set — **12/12 match sqlite3**, e.g.:
  - `SELECT 1 IN (SELECT 1) + 1;` -> 2
  - `SELECT lower(1 NOT IN (SELECT 1) << 2);` -> 0
  - `SELECT 1 IN (1) << 2;` -> 4 (via arena fallback)
  - `SELECT 1 IN (1) BETWEEN 0 AND 1<<2;` -> 1
- TCL regression at baseline, zero failures: `expr.test` 638/0, `in.test` 114/0, `between.test` 12/0, `in4.test` 61/0

## Out of scope (per Curator)

- No cross-parser abstraction (different AST types; not worth the complexity)
- No Pratt/min-binding-power rewrite (the `_from` decomposition is a stepping stone toward it)
- #5851 and #5848 not addressed here
- Pre-existing bitwise `&`/`|` tier divergence vs SQLite flagged by the Curator remains untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)