### PR TITLE
feat(sql): generalized UPSERT — multiple ON CONFLICT clauses with leftmost-match selection (upsert5)

### DIFF
--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -625,7 +625,11 @@ impl<'a, 'arena> Converter<'a, 'arena> {
             columns: stmt.columns.iter().map(|s| self.resolve(*s)).collect(),
             source: self.convert_insert_source(&stmt.source),
             conflict_clause: stmt.conflict_clause.map(ConflictClause::from),
-            on_conflict: stmt.on_conflict.as_ref().map(|c| self.convert_on_conflict_clause(c)),
+            on_conflict: stmt
+                .on_conflict
+                .iter()
+                .map(|c| self.convert_on_conflict_clause(c))
+                .collect(),
             on_duplicate_key_update: stmt.on_duplicate_key_update.as_ref().map(|assignments| {
                 assignments.iter().map(|a| self.convert_assignment(a)).collect()
             }),

--- a/crates/vibesql-ast/src/arena/dml.rs
+++ b/crates/vibesql-ast/src/arena/dml.rs
@@ -130,9 +130,13 @@ pub struct InsertStmt<'arena> {
     /// Conflict resolution strategy (None = fail on conflict)
     /// Used for INSERT OR REPLACE/IGNORE/etc. syntax
     pub conflict_clause: Option<ConflictClause>,
-    /// ON CONFLICT clause (SQLite upsert)
-    /// Used for INSERT ... ON CONFLICT (cols) DO NOTHING/UPDATE syntax
-    pub on_conflict: Option<OnConflictClause<'arena>>,
+    /// ON CONFLICT clauses (SQLite upsert). Empty = no upsert.
+    ///
+    /// SQLite's generalized UPSERT allows multiple ON CONFLICT clauses
+    /// (upsert5.test): the leftmost clause whose conflict target matches the
+    /// actual conflict fires; a target-less clause matches any conflict and
+    /// must be the last clause (enforced by the parser).
+    pub on_conflict: BumpVec<'arena, OnConflictClause<'arena>>,
     /// ON DUPLICATE KEY UPDATE clause (MySQL-style upsert)
     pub on_duplicate_key_update: Option<BumpVec<'arena, Assignment<'arena>>>,
     /// Optional RETURNING clause (SQLite 3.35.0+)

--- a/crates/vibesql-ast/src/dml.rs
+++ b/crates/vibesql-ast/src/dml.rs
@@ -145,9 +145,13 @@ pub struct InsertStmt {
     /// Conflict resolution strategy (None = fail on conflict)
     /// Used for INSERT OR REPLACE/IGNORE/etc. syntax
     pub conflict_clause: Option<ConflictClause>,
-    /// ON CONFLICT clause (SQLite upsert)
-    /// Used for INSERT ... ON CONFLICT (cols) DO NOTHING/UPDATE syntax
-    pub on_conflict: Option<OnConflictClause>,
+    /// ON CONFLICT clauses (SQLite upsert). Empty = no upsert.
+    ///
+    /// SQLite's generalized UPSERT allows multiple ON CONFLICT clauses
+    /// (upsert5.test): the leftmost clause whose conflict target matches the
+    /// actual conflict fires; a target-less clause matches any conflict and
+    /// must be the last clause (enforced by the parser).
+    pub on_conflict: Vec<OnConflictClause>,
     /// ON DUPLICATE KEY UPDATE clause (MySQL-style upsert)
     pub on_duplicate_key_update: Option<Vec<Assignment>>,
     /// Optional RETURNING clause (SQLite 3.35.0+)

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -1361,40 +1361,44 @@ pub fn transform_insert<V: ExpressionMutVisitor>(visitor: &mut V, stmt: InsertSt
             InsertSource::DefaultValues => InsertSource::DefaultValues,
         },
         conflict_clause: stmt.conflict_clause,
-        on_conflict: stmt.on_conflict.map(|clause| crate::OnConflictClause {
-            conflict_target: clause.conflict_target.map(|items| {
-                items
-                    .into_iter()
-                    .map(|item| match item {
-                        crate::ConflictTargetItem::Column(name) => {
-                            crate::ConflictTargetItem::Column(name)
+        on_conflict: stmt
+            .on_conflict
+            .into_iter()
+            .map(|clause| crate::OnConflictClause {
+                conflict_target: clause.conflict_target.map(|items| {
+                    items
+                        .into_iter()
+                        .map(|item| match item {
+                            crate::ConflictTargetItem::Column(name) => {
+                                crate::ConflictTargetItem::Column(name)
+                            }
+                            crate::ConflictTargetItem::Expression(expr) => {
+                                crate::ConflictTargetItem::Expression(transform_expression(
+                                    visitor, expr,
+                                ))
+                            }
+                        })
+                        .collect()
+                }),
+                target_where: clause.target_where.map(|e| transform_expression(visitor, e)),
+                target_inexact: clause.target_inexact,
+                action: match clause.action {
+                    crate::OnConflictAction::DoNothing => crate::OnConflictAction::DoNothing,
+                    crate::OnConflictAction::DoUpdate { assignments, where_clause } => {
+                        crate::OnConflictAction::DoUpdate {
+                            assignments: assignments
+                                .into_iter()
+                                .map(|a| Assignment {
+                                    column: a.column,
+                                    value: transform_expression(visitor, a.value),
+                                })
+                                .collect(),
+                            where_clause: where_clause.map(|e| transform_expression(visitor, e)),
                         }
-                        crate::ConflictTargetItem::Expression(expr) => {
-                            crate::ConflictTargetItem::Expression(transform_expression(
-                                visitor, expr,
-                            ))
-                        }
-                    })
-                    .collect()
-            }),
-            target_where: clause.target_where.map(|e| transform_expression(visitor, e)),
-            target_inexact: clause.target_inexact,
-            action: match clause.action {
-                crate::OnConflictAction::DoNothing => crate::OnConflictAction::DoNothing,
-                crate::OnConflictAction::DoUpdate { assignments, where_clause } => {
-                    crate::OnConflictAction::DoUpdate {
-                        assignments: assignments
-                            .into_iter()
-                            .map(|a| Assignment {
-                                column: a.column,
-                                value: transform_expression(visitor, a.value),
-                            })
-                            .collect(),
-                        where_clause: where_clause.map(|e| transform_expression(visitor, e)),
                     }
-                }
-            },
-        }),
+                },
+            })
+            .collect(),
         on_duplicate_key_update: stmt.on_duplicate_key_update.map(|updates| {
             updates
                 .into_iter()

--- a/crates/vibesql-ast/tests/statements.rs
+++ b/crates/vibesql-ast/tests/statements.rs
@@ -44,7 +44,7 @@ fn test_create_insert_statement() {
             StringValue::from("Alice"),
         ))]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     });

--- a/crates/vibesql-consensus/src/freeze.rs
+++ b/crates/vibesql-consensus/src/freeze.rs
@@ -641,7 +641,7 @@ fn transform_insert_default_sites(
         }
     }
 
-    if let Some(on_conflict) = &mut stmt.on_conflict {
+    for on_conflict in &mut stmt.on_conflict {
         if let OnConflictAction::DoUpdate { assignments, .. } = &mut on_conflict.action {
             transform_assignment_default_sites(assignments, schema, mode)?;
         }
@@ -973,7 +973,7 @@ pub fn time_cast_violation(
     };
     match statement {
         Statement::Insert(stmt) => {
-            if let Some(on_conflict) = &stmt.on_conflict {
+            for on_conflict in &stmt.on_conflict {
                 if let OnConflictAction::DoUpdate { assignments, where_clause } =
                     &on_conflict.action
                 {
@@ -1891,7 +1891,7 @@ fn check_trigger_body_statement(statement: &Statement) -> Result<(), String> {
                 }
                 InsertSource::DefaultValues => {}
             }
-            if let Some(on_conflict) = &stmt.on_conflict {
+            for on_conflict in &stmt.on_conflict {
                 if let Some(items) = &on_conflict.conflict_target {
                     for item in items {
                         if let ConflictTargetItem::Expression(expr) = item {
@@ -1974,7 +1974,7 @@ fn validate_insert(stmt: &InsertStmt) -> Result<(), String> {
         InsertSource::Select(query) => check_query_volatile_free(query, "INSERT … SELECT")?,
         InsertSource::DefaultValues => {}
     }
-    if let Some(on_conflict) = &stmt.on_conflict {
+    for on_conflict in &stmt.on_conflict {
         // Conflict targets are matched *structurally* against index
         // definitions — they must never be rewritten, so volatile calls
         // there are rejected rather than frozen.
@@ -2331,16 +2331,21 @@ fn transform_statement_sites(statement: Statement, visitor: &mut SiteTransformer
                         .collect(),
                 );
             }
-            if let Some(mut on_conflict) = stmt.on_conflict.take() {
-                if let OnConflictAction::DoUpdate { assignments, where_clause } = on_conflict.action
-                {
-                    on_conflict.action = OnConflictAction::DoUpdate {
-                        assignments: transform_assignments(assignments, visitor),
-                        where_clause: where_clause.map(|e| transform_expression(visitor, e)),
-                    };
-                }
-                stmt.on_conflict = Some(on_conflict);
-            }
+            stmt.on_conflict = stmt
+                .on_conflict
+                .into_iter()
+                .map(|mut on_conflict| {
+                    if let OnConflictAction::DoUpdate { assignments, where_clause } =
+                        on_conflict.action
+                    {
+                        on_conflict.action = OnConflictAction::DoUpdate {
+                            assignments: transform_assignments(assignments, visitor),
+                            where_clause: where_clause.map(|e| transform_expression(visitor, e)),
+                        };
+                    }
+                    on_conflict
+                })
+                .collect();
             if let Some(assignments) = stmt.on_duplicate_key_update.take() {
                 stmt.on_duplicate_key_update = Some(transform_assignments(assignments, visitor));
             }

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -189,7 +189,7 @@ fn execute_insert_internal(
     if let Some(view_def) = db.catalog.get_view(&stmt.table_name).cloned() {
         // SQLite: the upsert syntax cannot target a view, even when INSTEAD
         // OF INSERT triggers exist (upsert1-910).
-        if stmt.on_conflict.is_some() {
+        if !stmt.on_conflict.is_empty() {
             return Err(ExecutorError::SqliteCompatError("cannot UPSERT a view".to_string()));
         }
         return execute_insert_on_view(
@@ -245,12 +245,14 @@ fn execute_insert_internal(
     // which case firing falls back to the legacy schema-unaware match.
     let dml_schema: Option<String> = db.catalog.resolve_table_schema_name(&full_table_name);
 
-    // Validate an explicit ON CONFLICT (cols) target up front. SQLite does
-    // this at prepare time, even when no row actually conflicts: unknown
-    // columns raise "no such column" and known columns without a matching
-    // PRIMARY KEY / UNIQUE constraint / unique index raise the canonical
-    // "ON CONFLICT clause does not match..." error (upsert1-110/120/300).
-    if let Some(ref on_conflict) = stmt.on_conflict {
+    // Validate every explicit ON CONFLICT (cols) target up front. SQLite
+    // does this at prepare time, even when no row actually conflicts:
+    // unknown columns raise "no such column" and known columns without a
+    // matching PRIMARY KEY / UNIQUE constraint / unique index raise the
+    // canonical "ON CONFLICT clause does not match..." error
+    // (upsert1-110/120/300). With multiple clauses (generalized UPSERT,
+    // upsert5), each clause's target is validated in order.
+    for on_conflict in &stmt.on_conflict {
         // Targets the AST cannot represent exactly (currently non-BINARY
         // COLLATE) never match (upsert1-130; see issue #5269).
         if on_conflict.target_inexact {
@@ -421,15 +423,18 @@ fn execute_insert_internal(
     let mut batch_full_rows: Vec<Vec<vibesql_types::SqlValue>> = Vec::new();
 
     // Check if IGNORE conflict clause is set - if so, skip rows with constraint violations
-    // Also treat ON CONFLICT ... DO NOTHING as equivalent to IGNORE
+    // Also treat a single-clause ON CONFLICT ... DO NOTHING as equivalent to
+    // IGNORE. Multi-clause statements (generalized UPSERT, upsert5) resolve
+    // conflicts per row in the slow path instead, because clause selection
+    // depends on WHICH constraint each row violates.
     let or_ignore = matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Ignore));
     let use_ignore = or_ignore
         || matches!(
-            &stmt.on_conflict,
-            Some(vibesql_ast::OnConflictClause {
+            stmt.on_conflict.as_slice(),
+            [vibesql_ast::OnConflictClause {
                 action: vibesql_ast::OnConflictAction::DoNothing,
                 ..
-            })
+            }]
         );
 
     // `ON CONFLICT (cols) [WHERE ...] DO NOTHING` with an explicit target
@@ -440,15 +445,30 @@ fn execute_insert_internal(
     let do_nothing_target: Option<(
         &[vibesql_ast::ConflictTargetItem],
         Option<&vibesql_ast::Expression>,
-    )> = match &stmt.on_conflict {
-        Some(vibesql_ast::OnConflictClause {
+    )> = match stmt.on_conflict.as_slice() {
+        [vibesql_ast::OnConflictClause {
             conflict_target: Some(items),
             target_where,
             action: vibesql_ast::OnConflictAction::DoNothing,
             ..
-        }) if !or_ignore => Some((items.as_slice(), target_where.as_ref())),
+        }] if !or_ignore => Some((items.as_slice(), target_where.as_ref())),
         _ => None,
     };
+
+    // Statements whose ON CONFLICT clauses cannot be fully resolved in the
+    // validation loop below need per-row clause dispatch in the slow path:
+    // any DO UPDATE clause, and any multi-clause statement (leftmost-match
+    // clause selection against the violated constraint — upsert5). A single
+    // DO NOTHING clause is fully handled by use_ignore / do_nothing_target
+    // above and keeps the batch-insert fast path.
+    let on_conflict_needs_row_dispatch = !stmt.on_conflict.is_empty()
+        && !matches!(
+            stmt.on_conflict.as_slice(),
+            [vibesql_ast::OnConflictClause {
+                action: vibesql_ast::OnConflictAction::DoNothing,
+                ..
+            }]
+        );
 
     // Track the first auto-generated ID for LAST_INSERT_ROWID() support
     // Per MySQL semantics, for multi-row inserts, LAST_INSERT_ID() returns
@@ -711,7 +731,7 @@ fn execute_insert_internal(
             matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Replace))
                 || matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Ignore))
                 || stmt.on_duplicate_key_update.is_some()
-                || (stmt.on_conflict.is_some() && do_nothing_target.is_none());
+                || (!stmt.on_conflict.is_empty() && do_nothing_target.is_none());
         let validator = super::row_validator::RowValidator::new(
             db,
             &schema,
@@ -844,13 +864,7 @@ fn execute_insert_internal(
 
     let use_batch_insert = stmt.on_duplicate_key_update.is_none()
         && !matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Replace))
-        && !matches!(
-            &stmt.on_conflict,
-            Some(vibesql_ast::OnConflictClause {
-                action: vibesql_ast::OnConflictAction::DoUpdate { .. },
-                ..
-            })
-        )
+        && !on_conflict_needs_row_dispatch
         && !has_insert_triggers;
 
     // Helper to create a Row with optional explicit rowid
@@ -985,27 +999,20 @@ fn execute_insert_internal(
                     continue;
                 }
                 // No conflict, fall through to insert
-            } else if let Some(vibesql_ast::OnConflictClause {
-                ref conflict_target,
-                ref target_where,
-                action:
-                    vibesql_ast::OnConflictAction::DoUpdate { ref assignments, ref where_clause },
-                ..
-            }) = stmt.on_conflict
-            {
-                // SQLite upsert: ON CONFLICT [(cols)] DO UPDATE SET ... [WHERE ...]
-                match super::on_conflict_update::handle_on_conflict_update(
+            } else if on_conflict_needs_row_dispatch {
+                // SQLite generalized upsert (upsert5): select the leftmost
+                // ON CONFLICT clause whose target matches a constraint this
+                // row actually violates (a target-less clause matches any),
+                // then apply that clause's DO NOTHING / DO UPDATE action.
+                match super::on_conflict_update::dispatch_on_conflict_clauses(
                     db,
                     table_name,
                     &schema,
                     &full_row_values,
-                    conflict_target.as_deref(),
-                    target_where.as_ref(),
-                    assignments,
-                    where_clause.as_ref(),
+                    &stmt.on_conflict,
                     cte_results.as_ref(),
                 )? {
-                    super::on_conflict_update::UpsertAction::Updated(updated_row_id) => {
+                    super::on_conflict_update::ClauseDispatch::Updated(updated_row_id) => {
                         // Row was updated, count it toward affected rows
                         rows_inserted += 1;
                         upsert_updated_rows += 1;
@@ -1022,98 +1029,47 @@ fn execute_insert_internal(
                         }
                         continue;
                     }
-                    super::on_conflict_update::UpsertAction::Skipped => {
-                        // DO UPDATE ... WHERE was false/NULL: the row is
-                        // neither inserted nor updated (SQLite semantics).
+                    super::on_conflict_update::ClauseDispatch::SkipRow => {
+                        // A DO NOTHING clause fired, or DO UPDATE ... WHERE
+                        // was false/NULL: the row is neither inserted nor
+                        // updated (SQLite semantics).
                         continue;
                     }
-                    super::on_conflict_update::UpsertAction::NoConflict => {
-                        // No conflict on the targeted constraint; fall through
-                        // to a normal insert. Conflicts on OTHER constraints
-                        // still surface as UNIQUE errors (upsert1-201).
+                    super::on_conflict_update::ClauseDispatch::NoConflict => {
+                        // No unique constraint violated; fall through to a
+                        // normal insert.
+                    }
+                    super::on_conflict_update::ClauseDispatch::UnmatchedConflict(message) => {
+                        // The row conflicts, but no clause's target matches
+                        // the violated constraint: the statement's conflict
+                        // resolution algorithm still applies (upsert5
+                        // section 3 — REPLACE must delete the conflicting
+                        // rows rather than insert a duplicate key).
+                        match stmt.conflict_clause {
+                            Some(vibesql_ast::ConflictClause::Replace) => {
+                                explicit_rowid = Some(resolve_replace_conflicts_for_row(
+                                    db,
+                                    table_name,
+                                    &storage_table_name,
+                                    &schema,
+                                    &full_row_values,
+                                    explicit_rowid,
+                                )?);
+                            }
+                            Some(vibesql_ast::ConflictClause::Ignore) => continue,
+                            _ => return Err(ExecutorError::ConstraintViolation(message)),
+                        }
                     }
                 }
             } else if matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Replace)) {
-                // SQLite REPLACE semantics: allocate the rowid for the new row BEFORE firing
-                // BEFORE DELETE triggers. This ensures that any INSERT within those triggers
-                // that tries to allocate the same rowid will fail with a UNIQUE constraint
-                // violation on rowid.
-                //
-                // Compute the rowid for the new row and reserve it.
-                // Track whether the rowid is explicitly specified (INTEGER PRIMARY KEY)
-                // or auto-allocated, as this affects how conflicts are handled.
-                let is_explicit = explicit_rowid.is_some();
-                let reserved_rowid = if let Some(rowid) = explicit_rowid {
-                    rowid
-                } else {
-                    // Auto-allocate: next available rowid is physical row count + 1
-                    // (physical includes deleted rows since rowid is based on physical index)
-                    let current_physical = db
-                        .get_table(&storage_table_name)
-                        .map(|t| t.physical_row_count() as u64)
-                        .unwrap_or(0);
-                    current_physical + 1
-                };
-
-                // Reserve the rowid before firing triggers
-                db.reserve_rowid(&storage_table_name, reserved_rowid, is_explicit);
-
-                // If REPLACE conflict clause, delete conflicting rows first
-                // This also fires DELETE triggers which may create new constraints violations.
-                // handle_replace_conflicts() releases the reserved rowid after BEFORE DELETE
-                // triggers but before AFTER DELETE triggers.
-                let replace_result = super::replace::handle_replace_conflicts(
+                explicit_rowid = Some(resolve_replace_conflicts_for_row(
                     db,
                     table_name,
                     &storage_table_name,
                     &schema,
                     &full_row_values,
-                );
-
-                // On error, ensure the reserved rowid is released and propagate the error.
-                // Note: The reserved rowid may already be released if the error occurred
-                // after BEFORE DELETE triggers, but release_reserved_rowid is idempotent.
-                if let Err(e) = replace_result {
-                    db.release_reserved_rowid(&storage_table_name);
-                    return Err(e);
-                }
-
-                // After REPLACE conflict handling (which fires triggers), re-validate constraints.
-                // Triggers may have inserted new rows that conflict with the row we want to insert.
-                // Pass empty batch values since we're only checking against existing table data.
-                // Note: The reserved rowid has already been released by handle_replace_conflicts()
-                // after BEFORE DELETE triggers, so no need to release on error here.
-                super::constraints::enforce_primary_key_constraint(
-                    db,
-                    &schema,
-                    table_name,
-                    &full_row_values,
-                    &[], // No batch values to check against
-                )?;
-
-                super::constraints::enforce_unique_constraints(
-                    db,
-                    &schema,
-                    table_name,
-                    &full_row_values,
-                    &[], // No batch values to check against
-                )?;
-
-                super::constraints::enforce_unique_indexes(
-                    db,
-                    &schema,
-                    table_name,
-                    &full_row_values,
-                )?;
-
-                // Use the reserved rowid for the REPLACE INSERT to match SQLite semantics.
-                // This ensures the new row gets the rowid that was reserved before triggers fired.
-                explicit_rowid = Some(reserved_rowid);
-
-                // Release the reservation now that all delete triggers have fired.
-                // The REPLACE INSERT will use explicit_rowid which already has the reserved value.
-                // This prevents the REPLACE INSERT from failing on its own reservation.
-                db.release_reserved_rowid(&storage_table_name);
+                    explicit_rowid,
+                )?);
             }
 
             // Fire BEFORE INSERT triggers only if triggers exist.
@@ -1379,6 +1335,94 @@ fn execute_insert_internal(
         upsert_updated_rows,
         returning: returning_result,
     })
+}
+
+/// SQLite REPLACE conflict resolution for one candidate row.
+///
+/// Allocates and reserves the new row's rowid BEFORE firing BEFORE DELETE
+/// triggers (so a trigger INSERT that grabs the same rowid fails with a
+/// UNIQUE error), deletes the conflicting rows (firing DELETE triggers),
+/// re-validates constraints against post-trigger table state, and returns
+/// the reserved rowid the REPLACE insert must use as its explicit rowid.
+///
+/// Called from the plain `INSERT OR REPLACE` / `REPLACE INTO` path, and from
+/// the generalized-upsert fallback when a `REPLACE INTO ... ON CONFLICT ...`
+/// statement hits a conflict that no ON CONFLICT clause matches (upsert5
+/// section 3): REPLACE resolution still applies to unmatched conflicts.
+fn resolve_replace_conflicts_for_row(
+    db: &mut vibesql_storage::Database,
+    table_name: &str,
+    storage_table_name: &str,
+    schema: &vibesql_catalog::TableSchema,
+    full_row_values: &[vibesql_types::SqlValue],
+    explicit_rowid: Option<u64>,
+) -> Result<u64, ExecutorError> {
+    // Compute the rowid for the new row and reserve it.
+    // Track whether the rowid is explicitly specified (INTEGER PRIMARY KEY)
+    // or auto-allocated, as this affects how conflicts are handled.
+    let is_explicit = explicit_rowid.is_some();
+    let reserved_rowid = if let Some(rowid) = explicit_rowid {
+        rowid
+    } else {
+        // Auto-allocate: next available rowid is physical row count + 1
+        // (physical includes deleted rows since rowid is based on physical index)
+        let current_physical =
+            db.get_table(storage_table_name).map(|t| t.physical_row_count() as u64).unwrap_or(0);
+        current_physical + 1
+    };
+
+    // Reserve the rowid before firing triggers
+    db.reserve_rowid(storage_table_name, reserved_rowid, is_explicit);
+
+    // Delete conflicting rows first. This also fires DELETE triggers which
+    // may create new constraint violations. handle_replace_conflicts()
+    // releases the reserved rowid after BEFORE DELETE triggers but before
+    // AFTER DELETE triggers.
+    let replace_result = super::replace::handle_replace_conflicts(
+        db,
+        table_name,
+        storage_table_name,
+        schema,
+        full_row_values,
+    );
+
+    // On error, ensure the reserved rowid is released and propagate the error.
+    // Note: The reserved rowid may already be released if the error occurred
+    // after BEFORE DELETE triggers, but release_reserved_rowid is idempotent.
+    if let Err(e) = replace_result {
+        db.release_reserved_rowid(storage_table_name);
+        return Err(e);
+    }
+
+    // After REPLACE conflict handling (which fires triggers), re-validate constraints.
+    // Triggers may have inserted new rows that conflict with the row we want to insert.
+    // Pass empty batch values since we're only checking against existing table data.
+    // Note: The reserved rowid has already been released by handle_replace_conflicts()
+    // after BEFORE DELETE triggers, so no need to release on error here.
+    super::constraints::enforce_primary_key_constraint(
+        db,
+        schema,
+        table_name,
+        full_row_values,
+        &[], // No batch values to check against
+    )?;
+
+    super::constraints::enforce_unique_constraints(
+        db,
+        schema,
+        table_name,
+        full_row_values,
+        &[], // No batch values to check against
+    )?;
+
+    super::constraints::enforce_unique_indexes(db, schema, table_name, full_row_values)?;
+
+    // Release the reservation now that all delete triggers have fired.
+    // The REPLACE INSERT uses the returned rowid as its explicit rowid, so it
+    // will not fail on its own reservation.
+    db.release_reserved_rowid(storage_table_name);
+
+    Ok(reserved_rowid)
 }
 
 /// Check if inserting a row would violate any constraints (for IGNORE conflict resolution)

--- a/crates/vibesql-executor/src/insert/on_conflict_update.rs
+++ b/crates/vibesql-executor/src/insert/on_conflict_update.rs
@@ -39,12 +39,141 @@
 use crate::errors::ExecutorError;
 use vibesql_ast::{
     visitor::{transform_expression, ExpressionMutVisitor, VisitResult},
-    Assignment, ConflictTargetItem, Expression, FromClause, SelectStmt,
+    Assignment, ConflictTargetItem, Expression, FromClause, OnConflictAction, OnConflictClause,
+    SelectStmt,
 };
 use vibesql_types::SqlValue;
 
 use crate::partial_index_maintenance::is_predicate_truthy;
 use crate::select::grouping::expressions_equal;
+
+/// Outcome of per-row clause selection across a statement's ON CONFLICT
+/// clauses (generalized UPSERT, upsert5).
+pub enum ClauseDispatch {
+    /// The row violates no unique constraint: insert normally.
+    NoConflict,
+    /// A clause fired and resolved to dropping the candidate row: a DO
+    /// NOTHING clause, or a DO UPDATE clause whose WHERE was false/NULL.
+    SkipRow,
+    /// A DO UPDATE clause fired and updated this physical row id.
+    Updated(usize),
+    /// The row conflicts, but no clause's target matches the violated
+    /// constraint. Carries the SQLite-format UNIQUE violation message; the
+    /// caller applies the statement's conflict resolution algorithm
+    /// (REPLACE / IGNORE / default ABORT — upsert5 section 3).
+    UnmatchedConflict(String),
+}
+
+/// Per-row clause selection for generalized UPSERT (multiple ON CONFLICT
+/// clauses, upsert5): compute which unique constraints the candidate row
+/// violates against live table rows, then fire the leftmost clause whose
+/// conflict target matches a violated constraint. A target-less clause
+/// matches any conflict (the parser guarantees it is the last clause);
+/// duplicate targets fire the first occurrence (upsert5 1.x.300).
+///
+/// Earlier rows of the same multi-row INSERT are already inserted when this
+/// runs (the slow path inserts row by row), so the live-row scan covers
+/// intra-batch conflicts.
+pub fn dispatch_on_conflict_clauses(
+    db: &mut vibesql_storage::Database,
+    table_name: &str,
+    schema: &vibesql_catalog::TableSchema,
+    row_values: &[SqlValue],
+    clauses: &[OnConflictClause],
+    cte_results: Option<&std::collections::HashMap<String, crate::select::cte::CteResult>>,
+) -> Result<ClauseDispatch, ExecutorError> {
+    let candidates = collect_unique_candidates(db, table_name, schema);
+    let evaluator = crate::evaluator::ExpressionEvaluator::new(schema);
+    let candidate_row = vibesql_storage::Row::new(row_values.to_vec());
+
+    // Which unique constraints does this row violate?
+    let violated: Vec<usize> = {
+        let table = db
+            .get_table(table_name)
+            .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+        candidates
+            .iter()
+            .enumerate()
+            .filter(|(_, candidate)| {
+                let Some(new_key) = eval_candidate_key(&evaluator, candidate, &candidate_row)
+                else {
+                    return false;
+                };
+                if !row_in_candidate(&evaluator, candidate, &candidate_row) {
+                    return false;
+                }
+                table.scan_live().any(|(_, row)| {
+                    row_in_candidate(&evaluator, candidate, row)
+                        && eval_candidate_key(&evaluator, candidate, row).as_deref()
+                            == Some(&new_key[..])
+                })
+            })
+            .map(|(i, _)| i)
+            .collect()
+    };
+
+    if violated.is_empty() {
+        return Ok(ClauseDispatch::NoConflict);
+    }
+
+    // Leftmost-match clause selection (verified against sqlite3 3.51,
+    // upsert5 section 1).
+    for clause in clauses {
+        let fires = match &clause.conflict_target {
+            // A target-less clause is the catch-all.
+            None => true,
+            Some(target) => {
+                // Targets the AST cannot represent exactly never match
+                // (upsert1-130; see issue #5269).
+                !clause.target_inexact && {
+                    let resolved = resolve_target_items(schema, target)?;
+                    violated.iter().any(|&i| {
+                        candidate_matches_target(
+                            &candidates[i],
+                            &resolved,
+                            clause.target_where.as_ref(),
+                        )
+                    })
+                }
+            }
+        };
+        if !fires {
+            continue;
+        }
+        return match &clause.action {
+            OnConflictAction::DoNothing => Ok(ClauseDispatch::SkipRow),
+            OnConflictAction::DoUpdate { assignments, where_clause } => {
+                match handle_on_conflict_update(
+                    db,
+                    table_name,
+                    schema,
+                    row_values,
+                    clause.conflict_target.as_deref(),
+                    clause.target_where.as_ref(),
+                    assignments,
+                    where_clause.as_ref(),
+                    cte_results,
+                )? {
+                    UpsertAction::Updated(row_id) => Ok(ClauseDispatch::Updated(row_id)),
+                    UpsertAction::Skipped => Ok(ClauseDispatch::SkipRow),
+                    // Defensive: the violated-set computation above found a
+                    // conflict on this clause's constraint, so the update arm
+                    // should re-find it; fall back to a normal insert if not.
+                    UpsertAction::NoConflict => Ok(ClauseDispatch::NoConflict),
+                }
+            }
+        };
+    }
+
+    // The row conflicts but no clause matched the violated constraint(s):
+    // report the first violated constraint in SQLite's wording and let the
+    // caller apply the statement-level conflict resolution.
+    Ok(ClauseDispatch::UnmatchedConflict(unique_violation_message(
+        schema,
+        table_name,
+        &candidates[violated[0]],
+    )))
+}
 
 /// Outcome of attempting the DO UPDATE arm for one candidate row.
 pub enum UpsertAction {
@@ -259,6 +388,14 @@ pub fn validate_conflict_target(
     target: &[ConflictTargetItem],
     target_where: Option<&Expression>,
 ) -> Result<(), ExecutorError> {
+    // SQLite resolves names inside conflict-target expressions at prepare
+    // time: `ON CONFLICT((SELECT x FROM nosuchtable))` raises
+    // "no such table: nosuchtable" before target matching (upsert5 2.1).
+    for item in target {
+        if let ConflictTargetItem::Expression(expr) = item {
+            check_target_expression_tables(db, expr)?;
+        }
+    }
     let resolved = resolve_target_items(schema, target)?;
     let matched = collect_unique_candidates(db, table_name, schema)
         .iter()
@@ -270,6 +407,77 @@ pub fn validate_conflict_target(
         Err(ExecutorError::SqliteCompatError(
             "ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint".to_string(),
         ))
+    }
+}
+
+/// Resolve table names referenced by subqueries inside a conflict-target
+/// expression (prepare-time name resolution, upsert5 2.1). Reports the
+/// SQLite error `no such table: <name>` for an unknown table.
+fn check_target_expression_tables(
+    db: &vibesql_storage::Database,
+    expr: &Expression,
+) -> Result<(), ExecutorError> {
+    let mut checker = TargetTableChecker { db, error: None };
+    // The transform visitor is used read-only here: the expression clone is
+    // discarded; only the collected error matters.
+    let _ = transform_expression(&mut checker, expr.clone());
+    match checker.error {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
+}
+
+/// Visitor that checks FROM-clause table names in subqueries against the
+/// catalog. Only base-table references are checked; derived tables recurse.
+struct TargetTableChecker<'a> {
+    db: &'a vibesql_storage::Database,
+    error: Option<ExecutorError>,
+}
+
+impl TargetTableChecker<'_> {
+    fn check_select(&mut self, select: &SelectStmt) {
+        if let Some(from) = &select.from {
+            self.check_from(from);
+        }
+    }
+
+    fn check_from(&mut self, from: &FromClause) {
+        if self.error.is_some() {
+            return;
+        }
+        match from {
+            FromClause::Table { name, .. } => {
+                if !self.db.catalog.table_exists(name) && self.db.catalog.get_view(name).is_none() {
+                    self.error =
+                        Some(ExecutorError::SqliteCompatError(format!("no such table: {}", name)));
+                }
+            }
+            FromClause::Join { left, right, .. } => {
+                self.check_from(left);
+                self.check_from(right);
+            }
+            FromClause::Subquery { query, .. } => self.check_select(query),
+            FromClause::Values { .. } => {}
+        }
+    }
+}
+
+impl ExpressionMutVisitor for TargetTableChecker<'_> {
+    fn pre_visit_expression(&mut self, expr: &Expression) -> VisitResult {
+        if self.error.is_some() {
+            return VisitResult::Skip;
+        }
+        let subquery = match expr {
+            Expression::ScalarSubquery(select) => Some(select.as_ref()),
+            Expression::Exists { subquery, .. } => Some(subquery.as_ref()),
+            Expression::In { subquery, .. } => Some(subquery.as_ref()),
+            Expression::QuantifiedComparison { subquery, .. } => Some(subquery.as_ref()),
+            _ => None,
+        };
+        if let Some(select) = subquery {
+            self.check_select(select);
+        }
+        VisitResult::Continue
     }
 }
 

--- a/crates/vibesql-executor/src/tests/auto_increment_tests.rs
+++ b/crates/vibesql-executor/src/tests/auto_increment_tests.rs
@@ -68,7 +68,7 @@ fn test_auto_increment_basic_inserts() {
             SqlValue::Varchar(arcstr::ArcStr::from("alice")),
         )]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -87,7 +87,7 @@ fn test_auto_increment_basic_inserts() {
             SqlValue::Varchar(arcstr::ArcStr::from("bob")),
         )]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -219,7 +219,7 @@ fn test_last_insert_rowid_basic() {
             SqlValue::Varchar(arcstr::ArcStr::from("alice")),
         )]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -241,7 +241,7 @@ fn test_last_insert_rowid_basic() {
             SqlValue::Varchar(arcstr::ArcStr::from("bob")),
         )]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -320,7 +320,7 @@ fn test_last_insert_rowid_multi_row_insert() {
             )))],
         ]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -397,7 +397,7 @@ fn test_last_insert_rowid_no_auto_increment() {
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("test"))),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -472,7 +472,7 @@ fn test_last_insert_rowid_via_select() {
             SqlValue::Varchar(arcstr::ArcStr::from("alice")),
         )]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/src/tests/transaction_tests.rs
+++ b/crates/vibesql-executor/src/tests/transaction_tests.rs
@@ -135,7 +135,7 @@ fn test_transaction_insert_commit() {
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice"))),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -176,7 +176,7 @@ fn test_transaction_insert_rollback() {
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice"))),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -213,7 +213,7 @@ fn test_transaction_multiple_operations_commit() {
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice"))),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -236,7 +236,7 @@ fn test_transaction_multiple_operations_commit() {
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Bob"))),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -272,7 +272,7 @@ fn test_transaction_multiple_operations_rollback() {
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice"))),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -295,7 +295,7 @@ fn test_transaction_multiple_operations_rollback() {
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Bob"))),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -339,7 +339,7 @@ fn test_transaction_isolation() {
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice"))),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -386,7 +386,7 @@ fn test_transaction_nested_operations() {
                 )))),
             ]]),
             conflict_clause: None,
-            on_conflict: None,
+            on_conflict: vec![],
             on_duplicate_key_update: None,
             returning: None,
         };
@@ -423,7 +423,7 @@ fn test_transaction_empty_rollback() {
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice"))),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -461,7 +461,7 @@ fn test_multiple_transactions() {
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice"))),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -483,7 +483,7 @@ fn test_multiple_transactions() {
             vibesql_ast::Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Bob"))),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/src/tests/triggers/conditions.rs
+++ b/crates/vibesql-executor/src/tests/triggers/conditions.rs
@@ -89,7 +89,7 @@ fn test_when_clause_filters_firing() {
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(50)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -111,7 +111,7 @@ fn test_when_clause_filters_firing() {
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(150)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/src/tests/triggers/coordination.rs
+++ b/crates/vibesql-executor/src/tests/triggers/coordination.rs
@@ -65,7 +65,7 @@ fn test_multiple_triggers_fire_in_order() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -115,7 +115,7 @@ fn test_trigger_with_multiple_statements() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -166,7 +166,7 @@ fn test_before_trigger_executes_first() {
             vibesql_types::SqlValue::Integer(0),
         )]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -203,7 +203,7 @@ fn test_before_trigger_executes_first() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/src/tests/triggers/delete.rs
+++ b/crates/vibesql-executor/src/tests/triggers/delete.rs
@@ -29,7 +29,7 @@ fn test_after_delete_trigger_fires() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -104,7 +104,7 @@ fn test_before_delete_trigger_fires() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/src/tests/triggers/error_handling.rs
+++ b/crates/vibesql-executor/src/tests/triggers/error_handling.rs
@@ -46,7 +46,7 @@ fn test_trigger_failure_causes_rollback() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -135,7 +135,7 @@ fn test_recursion_prevention() {
                     )),
                 ]]),
                 conflict_clause: None,
-                on_conflict: None,
+                on_conflict: vec![],
                 on_duplicate_key_update: None,
                 returning: None,
             };

--- a/crates/vibesql-executor/src/tests/triggers/insert.rs
+++ b/crates/vibesql-executor/src/tests/triggers/insert.rs
@@ -47,7 +47,7 @@ fn test_after_insert_trigger_fires() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -110,7 +110,7 @@ fn test_after_insert_trigger_fires_for_each_row() {
             ],
         ]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -159,7 +159,7 @@ fn test_before_insert_trigger_fires() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -233,7 +233,7 @@ fn test_insert_trigger_body_semicolon_inside_string_literal_is_not_split() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -285,7 +285,7 @@ fn test_insert_trigger_body_escaped_quote_with_semicolon_is_intact() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -339,7 +339,7 @@ fn test_insert_trigger_multi_statement_body_with_semicolon_string() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/src/tests/triggers/update.rs
+++ b/crates/vibesql-executor/src/tests/triggers/update.rs
@@ -33,7 +33,7 @@ fn test_after_update_trigger_fires() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -115,7 +115,7 @@ fn test_before_update_trigger_fires() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -204,7 +204,7 @@ fn test_update_of_fires_only_for_listed_column() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/src/tests/truncate_cascade_tests.rs
+++ b/crates/vibesql-executor/src/tests/truncate_cascade_tests.rs
@@ -136,7 +136,7 @@ fn insert_row(db: &mut Database, table_name: &str, values: Vec<SqlValue>) {
         columns: vec![],
         source: InsertSource::Values(vec![values.into_iter().map(Expression::Literal).collect()]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/src/tests/truncate_table_tests.rs
+++ b/crates/vibesql-executor/src/tests/truncate_table_tests.rs
@@ -418,7 +418,7 @@ fn test_truncate_resets_auto_increment() {
                 arcstr::ArcStr::from(val),
             ))]]),
             conflict_clause: None,
-            on_conflict: None,
+            on_conflict: vec![],
             on_duplicate_key_update: None,
             returning: None,
         };
@@ -452,7 +452,7 @@ fn test_truncate_resets_auto_increment() {
             arcstr::ArcStr::from("d"),
         ))]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -533,7 +533,7 @@ fn test_truncate_resets_auto_increment_multiple_inserts() {
                 i * 100,
             ))]]),
             conflict_clause: None,
-            on_conflict: None,
+            on_conflict: vec![],
             on_duplicate_key_update: None,
             returning: None,
         };
@@ -563,7 +563,7 @@ fn test_truncate_resets_auto_increment_multiple_inserts() {
         columns: vec!["value".to_string()],
         source: InsertSource::Values(vec![vec![Expression::Literal(SqlValue::Integer(9999))]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/alter_table_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/alter_table_columnar_cache_tests.rs
@@ -44,7 +44,7 @@ fn insert_row(db: &mut Database, id: i64, name: &str, value: i64) {
             vibesql_ast::Expression::Literal(SqlValue::Integer(value)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -362,7 +362,7 @@ fn test_alter_column_drop_not_null_invalidates_cache() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(100)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -456,7 +456,7 @@ fn test_alter_column_drop_default_invalidates_cache() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(100)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/common/insert_constraint_fixtures.rs
+++ b/crates/vibesql-executor/tests/common/insert_constraint_fixtures.rs
@@ -309,7 +309,7 @@ pub fn build_insert_values(
             .map(vibesql_ast::Expression::Literal)
             .collect()]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     }
@@ -334,7 +334,7 @@ pub fn build_insert_columns(
             .map(vibesql_ast::Expression::Literal)
             .collect()]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     }

--- a/crates/vibesql-executor/tests/conflict_resolution_tests.rs
+++ b/crates/vibesql-executor/tests/conflict_resolution_tests.rs
@@ -46,7 +46,7 @@ fn insert_user(db: &mut Database, id: i64, email: &str, name: &str) {
             Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from(name))),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -79,7 +79,7 @@ fn test_insert_or_ignore_primary_key_conflict() {
             Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Bob"))),
         ]]),
         conflict_clause: Some(ConflictClause::Ignore),
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -117,7 +117,7 @@ fn test_insert_or_ignore_unique_constraint_conflict() {
             Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice 2"))),
         ]]),
         conflict_clause: Some(ConflictClause::Ignore),
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -169,7 +169,7 @@ fn test_insert_or_ignore_multi_row() {
             ],
         ]),
         conflict_clause: Some(ConflictClause::Ignore),
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -201,7 +201,7 @@ fn test_insert_or_ignore_no_conflict() {
             Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice"))),
         ]]),
         conflict_clause: Some(ConflictClause::Ignore),
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -524,7 +524,7 @@ fn test_insert_or_ignore_not_null_violation() {
             Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice"))),
         ]]),
         conflict_clause: Some(ConflictClause::Ignore),
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -606,12 +606,12 @@ fn test_insert_on_conflict_do_nothing_primary_key() {
             Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Duplicate"))),
         ]]),
         conflict_clause: None,
-        on_conflict: Some(OnConflictClause {
+        on_conflict: vec![OnConflictClause {
             conflict_target: Some(vec![vibesql_ast::ConflictTargetItem::Column("id".to_string())]),
             target_where: None,
             target_inexact: false,
             action: OnConflictAction::DoNothing,
-        }),
+        }],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -651,12 +651,12 @@ fn test_insert_on_conflict_do_nothing_without_target() {
             Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Dup"))),
         ]]),
         conflict_clause: None,
-        on_conflict: Some(OnConflictClause {
+        on_conflict: vec![OnConflictClause {
             conflict_target: None, // No specific conflict target
             target_where: None,
             target_inexact: false,
             action: OnConflictAction::DoNothing,
-        }),
+        }],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -690,12 +690,12 @@ fn test_insert_on_conflict_do_nothing_no_conflict() {
             Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice"))),
         ]]),
         conflict_clause: None,
-        on_conflict: Some(OnConflictClause {
+        on_conflict: vec![OnConflictClause {
             conflict_target: Some(vec![vibesql_ast::ConflictTargetItem::Column("id".to_string())]),
             target_where: None,
             target_inexact: false,
             action: OnConflictAction::DoNothing,
-        }),
+        }],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/duplicate_key_update_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/duplicate_key_update_columnar_cache_tests.rs
@@ -40,7 +40,7 @@ fn insert_product(db: &mut Database, id: i64, name: &str, stock: i64) {
             vibesql_ast::Expression::Literal(SqlValue::Integer(stock)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -62,7 +62,7 @@ fn upsert_product(db: &mut Database, id: i64, name: &str, stock: i64) {
             vibesql_ast::Expression::Literal(SqlValue::Integer(stock)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: Some(vec![
             vibesql_ast::Assignment {
                 column: "name".to_string(),
@@ -227,7 +227,7 @@ fn test_on_duplicate_key_update_unique_constraint_invalidates_cache() {
                 vibesql_ast::Expression::Literal(SqlValue::Integer(score)),
             ]]),
             conflict_clause: None,
-            on_conflict: None,
+            on_conflict: vec![],
             on_duplicate_key_update: None,
             returning: None,
         };
@@ -254,7 +254,7 @@ fn test_on_duplicate_key_update_unique_constraint_invalidates_cache() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(999)), // New score
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: Some(vec![vibesql_ast::Assignment {
             column: "score".to_string(),
             value: vibesql_ast::Expression::DuplicateKeyValue { column: "score".to_string() },
@@ -341,7 +341,7 @@ fn test_on_duplicate_key_update_arithmetic_invalidates_cache() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(30)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: Some(vec![vibesql_ast::Assignment {
             column: "stock".to_string(),
             value: vibesql_ast::Expression::BinaryOp {

--- a/crates/vibesql-executor/tests/index_ordering_tests.rs
+++ b/crates/vibesql-executor/tests/index_ordering_tests.rs
@@ -73,7 +73,7 @@ fn test_index_ordering() {
             ],
         ]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/insert_basic_tests.rs
+++ b/crates/vibesql-executor/tests/insert_basic_tests.rs
@@ -23,7 +23,7 @@ fn test_basic_insert() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -64,7 +64,7 @@ fn test_multi_row_insert() {
             ],
         ]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -96,7 +96,7 @@ fn test_insert_with_column_list() {
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -144,7 +144,7 @@ fn test_insert_null_value() {
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -180,7 +180,7 @@ fn test_insert_sqlite_type_affinity() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -208,7 +208,7 @@ fn test_insert_column_count_mismatch() {
             vibesql_types::SqlValue::Integer(1),
         )]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -236,7 +236,7 @@ fn test_insert_table_not_found() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -266,7 +266,7 @@ fn test_insert_column_not_found() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -298,7 +298,7 @@ fn test_insert_not_null_constraint_violation() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/insert_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/insert_columnar_cache_tests.rs
@@ -40,7 +40,7 @@ fn insert_product(db: &mut Database, id: i64, name: &str, price: i64) {
             vibesql_ast::Expression::Literal(SqlValue::Integer(price)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -190,7 +190,7 @@ fn test_multi_row_insert_invalidates_cache() {
             ],
         ]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -256,7 +256,7 @@ fn test_insert_select_invalidates_cache() {
                 vibesql_ast::Expression::Literal(SqlValue::Integer(price)),
             ]]),
             conflict_clause: None,
-            on_conflict: None,
+            on_conflict: vec![],
             on_duplicate_key_update: None,
             returning: None,
         };
@@ -304,7 +304,7 @@ fn test_insert_select_invalidates_cache() {
         columns: vec![],
         source: vibesql_ast::InsertSource::Select(Box::new(select_stmt)),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/insert_default_tests.rs
+++ b/crates/vibesql-executor/tests/insert_default_tests.rs
@@ -39,7 +39,7 @@ fn test_character_varying_column_with_length() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -89,7 +89,7 @@ fn test_character_varying_column_without_length() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -143,7 +143,7 @@ fn test_insert_with_default_value() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -195,7 +195,7 @@ fn test_insert_default_no_default_value_defined() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -260,7 +260,7 @@ fn test_insert_default_values_syntax() {
         columns: vec![], // No column list
         source: vibesql_ast::InsertSource::DefaultValues,
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -319,7 +319,7 @@ fn test_insert_default_values_with_integer_primary_key() {
             columns: vec![],
             source: vibesql_ast::InsertSource::DefaultValues,
             conflict_clause: None,
-            on_conflict: None,
+            on_conflict: vec![],
             on_duplicate_key_update: None,
             returning: None,
         };
@@ -380,7 +380,7 @@ fn test_integer_primary_key_null_autogen_empty_table() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -434,7 +434,7 @@ fn test_integer_primary_key_null_autogen_sequential() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -455,7 +455,7 @@ fn test_integer_primary_key_null_autogen_sequential() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -507,7 +507,7 @@ fn test_integer_primary_key_null_autogen_after_explicit() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -528,7 +528,7 @@ fn test_integer_primary_key_null_autogen_after_explicit() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -585,7 +585,7 @@ fn test_bigint_primary_key_no_autogen() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -650,7 +650,7 @@ fn test_integer_primary_key_null_autogen_multirow() {
             ],
         ]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -717,7 +717,7 @@ fn test_composite_primary_key_no_autogen() {
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/insert_duplicate_key_update_tests.rs
+++ b/crates/vibesql-executor/tests/insert_duplicate_key_update_tests.rs
@@ -48,7 +48,7 @@ fn test_on_duplicate_key_update_basic() {
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(10)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -73,7 +73,7 @@ fn test_on_duplicate_key_update_basic() {
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(20)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: Some(vec![vibesql_ast::Assignment {
             column: "stock".to_string(),
             value: vibesql_ast::Expression::DuplicateKeyValue { column: "stock".to_string() },
@@ -116,7 +116,7 @@ fn test_on_duplicate_key_update_with_arithmetic() {
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(10)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -139,7 +139,7 @@ fn test_on_duplicate_key_update_with_arithmetic() {
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(30)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: Some(vec![vibesql_ast::Assignment {
             column: "stock".to_string(),
             value: vibesql_ast::Expression::BinaryOp {
@@ -187,7 +187,7 @@ fn test_on_duplicate_key_update_no_conflict() {
             vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(10)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: Some(vec![vibesql_ast::Assignment {
             column: "stock".to_string(),
             value: vibesql_ast::Expression::DuplicateKeyValue { column: "stock".to_string() },

--- a/crates/vibesql-executor/tests/insert_multi_row_tests.rs
+++ b/crates/vibesql-executor/tests/insert_multi_row_tests.rs
@@ -38,7 +38,7 @@ fn test_multi_row_insert_atomic_success() {
             ],
         ]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -85,7 +85,7 @@ fn test_multi_row_insert_atomic_failure() {
             ],
         ]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -133,7 +133,7 @@ fn test_multi_row_insert_with_column_list() {
             ],
         ]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -179,7 +179,7 @@ fn test_multi_row_insert_sqlite_type_affinity() {
             ],
         ]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -262,7 +262,7 @@ fn test_multi_row_insert_various_data_types() {
             ],
         ]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -321,7 +321,7 @@ fn test_multi_row_insert_primary_key_violation() {
             ],
         ]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -361,7 +361,7 @@ fn test_single_row_insert_no_transaction() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/insert_on_conflict_update_tests.rs
+++ b/crates/vibesql-executor/tests/insert_on_conflict_update_tests.rs
@@ -669,3 +669,193 @@ fn test_targeted_do_nothing_other_plain_constraint_still_errors() {
         .expect_err("conflict on the non-targeted UNIQUE column must error");
     assert!(format!("{err:?}").contains("UNIQUE constraint failed"), "got: {err:?}");
 }
+
+// ========================================================================
+// Generalized UPSERT: multiple ON CONFLICT clauses (upsert5, issue #5817)
+// ========================================================================
+
+fn str_val(s: &str) -> SqlValue {
+    SqlValue::Varchar(arcstr::ArcStr::from(s))
+}
+
+/// upsert5 1.x.100: leftmost clause whose target matches a violated
+/// constraint fires (conflict on all of a,c,d,e; clause order a,c,d,e).
+#[test]
+fn test_multi_clause_leftmost_match_fires() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b, c UNIQUE, d UNIQUE, e UNIQUE)")
+        .unwrap();
+    exec(&mut db, "INSERT INTO t1(a,b,c,d,e) VALUES(1,2,3,4,5)").unwrap();
+    exec(
+        &mut db,
+        "INSERT INTO t1(a,b,c,d,e) VALUES(1,NULL,3,4,5) \
+         ON CONFLICT(a) DO UPDATE SET b='a' \
+         ON CONFLICT(c) DO UPDATE SET b='c' \
+         ON CONFLICT(d) DO UPDATE SET b='d' \
+         ON CONFLICT(e) DO UPDATE SET b='e'",
+    )
+    .unwrap();
+    assert_eq!(rows(&db, "t1"), vec![vec![int(1), str_val("a"), int(3), int(4), int(5)]]);
+}
+
+/// upsert5 1.x.203: clause order c,a,d,e with conflicts only on {a,e}:
+/// clause c does not fire (c not violated); clause a does.
+#[test]
+fn test_multi_clause_skips_non_violated_targets() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b, c UNIQUE, d UNIQUE, e UNIQUE)")
+        .unwrap();
+    exec(&mut db, "INSERT INTO t1(a,b,c,d,e) VALUES(1,2,3,4,5)").unwrap();
+    exec(
+        &mut db,
+        "INSERT INTO t1(a,b,c,d,e) VALUES(1,NULL,93,94,5) \
+         ON CONFLICT(c) DO UPDATE SET b='c' \
+         ON CONFLICT(a) DO UPDATE SET b='a' \
+         ON CONFLICT(d) DO UPDATE SET b='d' \
+         ON CONFLICT(e) DO UPDATE SET b='e'",
+    )
+    .unwrap();
+    assert_eq!(rows(&db, "t1"), vec![vec![int(1), str_val("a"), int(3), int(4), int(5)]]);
+}
+
+/// upsert5 1.x.300: duplicate targets fire the first occurrence.
+#[test]
+fn test_multi_clause_duplicate_targets_fire_first() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b, c UNIQUE)").unwrap();
+    exec(&mut db, "INSERT INTO t1(a,b,c) VALUES(1,2,3)").unwrap();
+    exec(
+        &mut db,
+        "INSERT INTO t1(a,b,c) VALUES(1,NULL,93) \
+         ON CONFLICT(c) DO UPDATE SET b='c' \
+         ON CONFLICT(a) DO UPDATE SET b='a1' \
+         ON CONFLICT(a) DO UPDATE SET b='a2'",
+    )
+    .unwrap();
+    assert_eq!(rows(&db, "t1"), vec![vec![int(1), str_val("a1"), int(3)]]);
+}
+
+/// upsert5 1.x.400: a terminal target-less DO UPDATE is the catch-all for
+/// conflicts no earlier clause matched.
+#[test]
+fn test_multi_clause_targetless_catch_all() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b, c UNIQUE, d UNIQUE)").unwrap();
+    exec(&mut db, "INSERT INTO t1(a,b,c,d) VALUES(1,2,3,4)").unwrap();
+    exec(
+        &mut db,
+        "INSERT INTO t1(a,b,c,d) VALUES(1,NULL,93,94) \
+         ON CONFLICT(c) DO UPDATE SET b='c' \
+         ON CONFLICT(d) DO UPDATE SET b='d' \
+         ON CONFLICT DO UPDATE SET b='x'",
+    )
+    .unwrap();
+    assert_eq!(rows(&db, "t1"), vec![vec![int(1), str_val("x"), int(3), int(4)]]);
+}
+
+/// upsert5 1.x.422: a targeted DO NOTHING fires when its constraint is
+/// violated even if a later catch-all DO UPDATE exists.
+#[test]
+fn test_multi_clause_do_nothing_beats_later_catch_all() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b, c UNIQUE, d UNIQUE)").unwrap();
+    exec(&mut db, "INSERT INTO t1(a,b,c,d) VALUES(1,2,3,4)").unwrap();
+    let n = exec(
+        &mut db,
+        "INSERT INTO t1(a,b,c,d) VALUES(91,NULL,93,4) \
+         ON CONFLICT(c) DO NOTHING \
+         ON CONFLICT(d) DO NOTHING \
+         ON CONFLICT DO UPDATE SET b='x'",
+    )
+    .unwrap();
+    assert_eq!(n, 0, "DO NOTHING drops the row");
+    assert_eq!(rows(&db, "t1"), vec![vec![int(1), int(2), int(3), int(4)]]);
+}
+
+/// Multi-clause statement where the conflict matches no clause: the default
+/// ABORT resolution raises the UNIQUE error.
+#[test]
+fn test_multi_clause_unmatched_conflict_aborts() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b, c UNIQUE, d UNIQUE)").unwrap();
+    exec(&mut db, "INSERT INTO t1(a,b,c,d) VALUES(1,2,3,4)").unwrap();
+    let err = exec(
+        &mut db,
+        "INSERT INTO t1(a,b,c,d) VALUES(91,NULL,93,4) \
+         ON CONFLICT(c) DO UPDATE SET b='c'",
+    )
+    .expect_err("conflict on d does not match target c");
+    assert!(
+        format!("{err}").contains("UNIQUE constraint failed: t1.d"),
+        "expected UNIQUE error on t1.d, got: {err}"
+    );
+    assert_eq!(rows(&db, "t1"), vec![vec![int(1), int(2), int(3), int(4)]]);
+}
+
+/// upsert5 3.0/3.1 regression (curator finding on issue #5817): REPLACE INTO
+/// with an ON CONFLICT clause whose target does NOT match the violated
+/// constraint must still apply REPLACE resolution — previously the row was
+/// inserted with no enforcement at all, leaving two rows with the same
+/// INTEGER PRIMARY KEY.
+#[test]
+fn test_replace_fallback_when_clause_target_unmatched_single_clause() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(aa INTEGER PRIMARY KEY, bb INT)").unwrap();
+    exec(&mut db, "INSERT INTO t1 VALUES(11,22)").unwrap();
+    exec(&mut db, "CREATE UNIQUE INDEX t1bb ON t1(bb)").unwrap();
+    exec(&mut db, "REPLACE INTO t1 VALUES(11,33) ON CONFLICT(bb) DO UPDATE SET aa = 44").unwrap();
+    assert_eq!(
+        rows(&db, "t1"),
+        vec![vec![int(11), int(33)]],
+        "REPLACE must resolve the unmatched PK conflict (one row, not a duplicate PK)"
+    );
+}
+
+/// upsert5 3.0: same with redundant duplicate clauses.
+#[test]
+fn test_replace_fallback_with_redundant_clauses() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(aa INTEGER PRIMARY KEY, bb INT)").unwrap();
+    exec(&mut db, "INSERT INTO t1 VALUES(11,22)").unwrap();
+    exec(&mut db, "CREATE UNIQUE INDEX t1bb ON t1(bb)").unwrap();
+    exec(
+        &mut db,
+        "REPLACE INTO t1 VALUES(11,33) \
+         ON CONFLICT(bb) DO UPDATE SET aa = 44 \
+         ON CONFLICT(bb) DO UPDATE SET aa = 44",
+    )
+    .unwrap();
+    assert_eq!(rows(&db, "t1"), vec![vec![int(11), int(33)]]);
+}
+
+/// upsert5 3.3: three-row table, REPLACE with unmatched targets replaces the
+/// PK-conflicting row only.
+#[test]
+fn test_replace_fallback_three_rows() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(aa INTEGER PRIMARY KEY, bb INT, cc INT)").unwrap();
+    exec(&mut db, "INSERT INTO t1 VALUES(10,21,32),(11,22,33),(12,23,34)").unwrap();
+    exec(&mut db, "CREATE UNIQUE INDEX t1bb ON t1(bb)").unwrap();
+    exec(&mut db, "CREATE UNIQUE INDEX t1cc ON t1(cc)").unwrap();
+    exec(
+        &mut db,
+        "REPLACE INTO t1 VALUES(11,44,55) \
+         ON CONFLICT(bb) DO UPDATE SET aa = 99 \
+         ON CONFLICT(cc) DO UPDATE SET aa = 99 \
+         ON CONFLICT(bb) DO UPDATE SET aa = 99",
+    )
+    .unwrap();
+    let mut got = rows(&db, "t1");
+    got.sort_by_key(|r| match r[0] {
+        SqlValue::Integer(v) => v,
+        _ => 0,
+    });
+    assert_eq!(
+        got,
+        vec![
+            vec![int(10), int(21), int(32)],
+            vec![int(11), int(44), int(55)],
+            vec![int(12), int(23), int(34)],
+        ]
+    );
+}

--- a/crates/vibesql-executor/tests/insert_select_tests.rs
+++ b/crates/vibesql-executor/tests/insert_select_tests.rs
@@ -23,7 +23,7 @@ fn test_insert_from_select_basic() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -81,7 +81,7 @@ fn test_insert_from_select_basic() {
         columns: vec![], // No explicit columns, use all
         source: vibesql_ast::InsertSource::Select(Box::new(select_stmt)),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -121,7 +121,7 @@ fn test_insert_from_select_with_where() {
             ],
         ]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -185,7 +185,7 @@ fn test_insert_from_select_with_where() {
         columns: vec![],
         source: vibesql_ast::InsertSource::Select(Box::new(select_stmt)),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -217,7 +217,7 @@ fn test_insert_from_select_column_mismatch() {
             )),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -280,7 +280,7 @@ fn test_insert_from_select_column_mismatch() {
         columns: vec![], // Should match all columns
         source: vibesql_ast::InsertSource::Select(Box::new(select_stmt)),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -331,7 +331,7 @@ fn test_insert_from_select_with_aggregates() {
             ],
         ]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -410,7 +410,7 @@ fn test_insert_from_select_with_aggregates() {
         columns: vec![],
         source: vibesql_ast::InsertSource::Select(Box::new(select_stmt)),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/replace_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/replace_columnar_cache_tests.rs
@@ -40,7 +40,7 @@ fn insert_product(db: &mut Database, id: i64, name: &str, price: i64) {
             vibesql_ast::Expression::Literal(SqlValue::Integer(price)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -62,7 +62,7 @@ fn replace_product(db: &mut Database, id: i64, name: &str, price: i64) {
             vibesql_ast::Expression::Literal(SqlValue::Integer(price)),
         ]]),
         conflict_clause: Some(vibesql_ast::ConflictClause::Replace),
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -216,7 +216,7 @@ fn test_replace_unique_constraint_invalidates_cache() {
                 vibesql_ast::Expression::Literal(SqlValue::Integer(score)),
             ]]),
             conflict_clause: None,
-            on_conflict: None,
+            on_conflict: vec![],
             on_duplicate_key_update: None,
             returning: None,
         };
@@ -243,7 +243,7 @@ fn test_replace_unique_constraint_invalidates_cache() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(999)), // New score
         ]]),
         conflict_clause: Some(vibesql_ast::ConflictClause::Replace),
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/transaction_tests.rs
+++ b/crates/vibesql-executor/tests/transaction_tests.rs
@@ -38,7 +38,7 @@ fn test_basic_savepoint() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(1000)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -61,7 +61,7 @@ fn test_basic_savepoint() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(500)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -115,7 +115,7 @@ fn test_nested_savepoints() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(1000)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -138,7 +138,7 @@ fn test_nested_savepoints() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(500)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -161,7 +161,7 @@ fn test_nested_savepoints() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(200)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-executor/tests/truncate_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/truncate_columnar_cache_tests.rs
@@ -41,7 +41,7 @@ fn insert_product(db: &mut Database, id: i64, name: &str, price: i64) {
             vibesql_ast::Expression::Literal(SqlValue::Integer(price)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -270,7 +270,7 @@ fn test_truncate_cascade_invalidates_columnar_cache() {
             ))),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -290,7 +290,7 @@ fn test_truncate_cascade_invalidates_columnar_cache() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(500)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };
@@ -309,7 +309,7 @@ fn test_truncate_cascade_invalidates_columnar_cache() {
             vibesql_ast::Expression::Literal(SqlValue::Integer(300)),
         ]]),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };

--- a/crates/vibesql-parser/src/arena_parser/insert.rs
+++ b/crates/vibesql-parser/src/arena_parser/insert.rs
@@ -254,78 +254,90 @@ impl<'arena> ArenaParser<'arena> {
     }
 
     /// Parse ON clause for INSERT statements (handles both ON CONFLICT and ON DUPLICATE KEY UPDATE)
+    ///
+    /// SQLite's generalized UPSERT accepts multiple `ON CONFLICT` clauses
+    /// (upsert5.test). A target-less clause matches any conflict, so it must
+    /// be the *last* clause — a non-terminal target-less clause is a syntax
+    /// error (`near "ON": syntax error`, matching sqlite3).
     fn parse_on_clause_for_insert(
         &mut self,
     ) -> Result<
-        (Option<OnConflictClause<'arena>>, Option<BumpVec<'arena, Assignment<'arena>>>),
+        (BumpVec<'arena, OnConflictClause<'arena>>, Option<BumpVec<'arena, Assignment<'arena>>>),
         ParseError,
     > {
-        if !self.try_consume_keyword(Keyword::On) {
-            return Ok((None, None));
+        let mut clauses: BumpVec<'arena, OnConflictClause<'arena>> = BumpVec::new_in(self.arena);
+
+        while self.try_consume_keyword(Keyword::On) {
+            if self.try_consume_keyword(Keyword::Conflict) {
+                // A target-less clause is a catch-all: SQLite only allows it
+                // in the terminal position.
+                if clauses.last().is_some_and(|c| c.conflict_target.is_none()) {
+                    return Err(ParseError { message: "near \"ON\": syntax error".to_string() });
+                }
+                clauses.push(self.parse_one_on_conflict_clause()?);
+            } else if self.try_consume_keyword(Keyword::Duplicate) {
+                // MySQL: ON DUPLICATE KEY UPDATE ... (cannot be mixed with
+                // SQLite ON CONFLICT clauses).
+                if !clauses.is_empty() {
+                    return Err(ParseError { message: "near \"ON\": syntax error".to_string() });
+                }
+                self.consume_keyword(Keyword::Key)?;
+                self.consume_keyword(Keyword::Update)?;
+                let assignments = self.parse_assignments()?;
+                return Ok((clauses, Some(assignments)));
+            } else {
+                return Err(ParseError {
+                    message: "Expected CONFLICT or DUPLICATE after ON".to_string(),
+                });
+            }
         }
 
-        if self.try_consume_keyword(Keyword::Conflict) {
-            // SQLite/PostgreSQL: ON CONFLICT [(cols)] DO {NOTHING | UPDATE SET ...}
+        Ok((clauses, None))
+    }
 
-            // Parse optional conflict target (column list).
-            //
-            // The arena parser only supports plain column-name targets;
-            // expression targets, COLLATE, and target-level WHERE predicates
-            // fail here and fall back to the standard parser (which retains
-            // them — see parser/insert.rs).
-            let conflict_target = if self.try_consume(&Token::LParen) {
-                let cols = self.parse_identifier_list()?;
-                self.expect_token(Token::RParen)?;
-                let mut items = BumpVec::new_in(self.arena);
-                for col in cols {
-                    items.push(vibesql_ast::arena::ConflictTargetItem::Column(col));
-                }
-                Some(items)
+    /// Parse a single `ON CONFLICT [(target)] DO {NOTHING | UPDATE ...}`
+    /// clause. The `ON CONFLICT` keywords have already been consumed.
+    fn parse_one_on_conflict_clause(&mut self) -> Result<OnConflictClause<'arena>, ParseError> {
+        // Parse optional conflict target (column list).
+        //
+        // The arena parser only supports plain column-name targets;
+        // expression targets, COLLATE, and target-level WHERE predicates
+        // fail here and fall back to the standard parser (which retains
+        // them — see parser/insert.rs).
+        let conflict_target = if self.try_consume(&Token::LParen) {
+            let cols = self.parse_identifier_list()?;
+            self.expect_token(Token::RParen)?;
+            let mut items = BumpVec::new_in(self.arena);
+            for col in cols {
+                items.push(vibesql_ast::arena::ConflictTargetItem::Column(col));
+            }
+            Some(items)
+        } else {
+            None
+        };
+
+        self.consume_keyword(Keyword::Do)?;
+
+        let action = if self.try_consume_keyword(Keyword::Nothing) {
+            OnConflictAction::DoNothing
+        } else if self.try_consume_keyword(Keyword::Update) {
+            self.consume_keyword(Keyword::Set)?;
+
+            // Parse assignment list
+            let assignments = self.parse_assignments()?;
+
+            // Parse optional WHERE clause
+            let where_clause = if self.try_consume_keyword(Keyword::Where) {
+                Some(self.parse_expression()?)
             } else {
                 None
             };
 
-            self.consume_keyword(Keyword::Do)?;
-
-            let action = if self.try_consume_keyword(Keyword::Nothing) {
-                OnConflictAction::DoNothing
-            } else if self.try_consume_keyword(Keyword::Update) {
-                self.consume_keyword(Keyword::Set)?;
-
-                // Parse assignment list
-                let assignments = self.parse_assignments()?;
-
-                // Parse optional WHERE clause
-                let where_clause = if self.try_consume_keyword(Keyword::Where) {
-                    Some(self.parse_expression()?)
-                } else {
-                    None
-                };
-
-                OnConflictAction::DoUpdate { assignments, where_clause }
-            } else {
-                return Err(ParseError {
-                    message: "Expected NOTHING or UPDATE after DO".to_string(),
-                });
-            };
-
-            Ok((
-                Some(OnConflictClause {
-                    conflict_target,
-                    target_where: None,
-                    target_inexact: false,
-                    action,
-                }),
-                None,
-            ))
-        } else if self.try_consume_keyword(Keyword::Duplicate) {
-            // MySQL: ON DUPLICATE KEY UPDATE ...
-            self.consume_keyword(Keyword::Key)?;
-            self.consume_keyword(Keyword::Update)?;
-            let assignments = self.parse_assignments()?;
-            Ok((None, Some(assignments)))
+            OnConflictAction::DoUpdate { assignments, where_clause }
         } else {
-            Err(ParseError { message: "Expected CONFLICT or DUPLICATE after ON".to_string() })
-        }
+            return Err(ParseError { message: "Expected NOTHING or UPDATE after DO".to_string() });
+        };
+
+        Ok(OnConflictClause { conflict_target, target_where: None, target_inexact: false, action })
     }
 }

--- a/crates/vibesql-parser/src/parser/insert.rs
+++ b/crates/vibesql-parser/src/parser/insert.rs
@@ -381,19 +381,55 @@ impl Parser {
     }
 
     /// Parse ON clause for INSERT statements (handles both ON CONFLICT and ON DUPLICATE KEY UPDATE)
+    ///
+    /// SQLite's generalized UPSERT accepts multiple `ON CONFLICT` clauses
+    /// (upsert5.test). A target-less clause (`ON CONFLICT DO ...`) matches any
+    /// conflict, so it must be the *last* clause — a non-terminal target-less
+    /// clause is a syntax error (`near "ON": syntax error`, verified against
+    /// sqlite3 3.51).
     fn parse_on_clause_for_insert(
         &mut self,
     ) -> Result<
-        (Option<vibesql_ast::OnConflictClause>, Option<Vec<vibesql_ast::Assignment>>),
+        (Vec<vibesql_ast::OnConflictClause>, Option<Vec<vibesql_ast::Assignment>>),
         ParseError,
     > {
-        if !self.peek_keyword(Keyword::On) {
-            return Ok((None, None));
+        let mut clauses: Vec<vibesql_ast::OnConflictClause> = Vec::new();
+
+        while self.peek_keyword(Keyword::On) {
+            self.advance(); // consume ON
+
+            if self.peek_keyword(Keyword::Conflict) {
+                // A target-less clause is a catch-all: SQLite only allows it
+                // in the terminal position.
+                if clauses.last().is_some_and(|c| c.conflict_target.is_none()) {
+                    return Err(ParseError { message: "near \"ON\": syntax error".to_string() });
+                }
+                clauses.push(self.parse_one_on_conflict_clause()?);
+            } else if self.peek_keyword(Keyword::Duplicate) {
+                // MySQL: ON DUPLICATE KEY UPDATE ... (cannot be mixed with
+                // SQLite ON CONFLICT clauses).
+                if !clauses.is_empty() {
+                    return Err(ParseError { message: "near \"ON\": syntax error".to_string() });
+                }
+                let assignments = self.parse_on_duplicate_key_update_clause()?;
+                return Ok((clauses, Some(assignments)));
+            } else {
+                return Err(ParseError {
+                    message: "Expected CONFLICT or DUPLICATE after ON".to_string(),
+                });
+            }
         }
 
-        self.advance(); // consume ON
+        Ok((clauses, None))
+    }
 
-        if self.peek_keyword(Keyword::Conflict) {
+    /// Parse a single `ON CONFLICT [(target)] DO {NOTHING | UPDATE ...}`
+    /// clause. The leading `ON` keyword has already been consumed; the next
+    /// token is `CONFLICT`.
+    fn parse_one_on_conflict_clause(
+        &mut self,
+    ) -> Result<vibesql_ast::OnConflictClause, ParseError> {
+        {
             // SQLite/PostgreSQL: ON CONFLICT [(cols)] DO {NOTHING | UPDATE SET ...}
             self.advance(); // consume CONFLICT
 
@@ -503,17 +539,22 @@ impl Parser {
                 });
             };
 
-            Ok((
-                Some(vibesql_ast::OnConflictClause {
-                    conflict_target,
-                    target_where,
-                    target_inexact,
-                    action,
-                }),
-                None,
-            ))
-        } else if self.peek_keyword(Keyword::Duplicate) {
-            // MySQL: ON DUPLICATE KEY UPDATE ...
+            Ok(vibesql_ast::OnConflictClause {
+                conflict_target,
+                target_where,
+                target_inexact,
+                action,
+            })
+        }
+    }
+
+    /// Parse the MySQL-style `ON DUPLICATE KEY UPDATE ...` clause. The
+    /// leading `ON` keyword has already been consumed; the next token is
+    /// `DUPLICATE`.
+    fn parse_on_duplicate_key_update_clause(
+        &mut self,
+    ) -> Result<Vec<vibesql_ast::Assignment>, ParseError> {
+        {
             self.advance(); // consume DUPLICATE
             self.expect_keyword(Keyword::Key)?;
             self.expect_keyword(Keyword::Update)?;
@@ -545,9 +586,7 @@ impl Parser {
                     break;
                 }
             }
-            Ok((None, Some(assignments)))
-        } else {
-            Err(ParseError { message: "Expected CONFLICT or DUPLICATE after ON".to_string() })
+            Ok(assignments)
         }
     }
 

--- a/crates/vibesql-parser/src/tests/insert.rs
+++ b/crates/vibesql-parser/src/tests/insert.rs
@@ -283,7 +283,7 @@ fn test_parse_insert_returning_after_on_conflict() {
     assert!(result.is_ok(), "RETURNING after ON CONFLICT should parse: {:?}", result.err());
     match result.unwrap() {
         vibesql_ast::Statement::Insert(insert) => {
-            assert!(insert.on_conflict.is_some());
+            assert_eq!(insert.on_conflict.len(), 1);
             let returning = insert.returning.expect("returning clause should be captured");
             assert_eq!(returning.len(), 1);
         }
@@ -440,4 +440,106 @@ fn test_parse_insert_compound_values_order_by() {
         },
         _ => panic!("Expected INSERT statement"),
     }
+}
+
+// ========================================================================
+// Generalized UPSERT: multiple ON CONFLICT clauses (upsert5, issue #5817)
+// ========================================================================
+
+/// Parse a statement and return the INSERT's ON CONFLICT clause list.
+fn parse_on_conflict_clauses(sql: &str) -> Vec<vibesql_ast::OnConflictClause> {
+    match Parser::parse_sql(sql) {
+        Ok(vibesql_ast::Statement::Insert(insert)) => insert.on_conflict,
+        Ok(other) => panic!("Expected INSERT statement, got {:?}", other),
+        Err(e) => panic!("Statement should parse: {:?}", e),
+    }
+}
+
+#[test]
+fn test_parse_insert_two_on_conflict_clauses() {
+    let clauses = parse_on_conflict_clauses(
+        "INSERT INTO t1(a,b) VALUES(1,2) \
+         ON CONFLICT(a) DO UPDATE SET b='a' \
+         ON CONFLICT(b) DO NOTHING;",
+    );
+    assert_eq!(clauses.len(), 2);
+    assert!(clauses[0].conflict_target.is_some());
+    assert!(matches!(clauses[0].action, vibesql_ast::OnConflictAction::DoUpdate { .. }));
+    assert!(clauses[1].conflict_target.is_some());
+    assert!(matches!(clauses[1].action, vibesql_ast::OnConflictAction::DoNothing));
+}
+
+#[test]
+fn test_parse_insert_many_on_conflict_clauses() {
+    let clauses = parse_on_conflict_clauses(
+        "INSERT INTO t1(a,b,c,d,e) VALUES(1,NULL,3,4,5) \
+         ON CONFLICT(a) DO UPDATE SET b='a' \
+         ON CONFLICT(c) DO UPDATE SET b='c' \
+         ON CONFLICT(d) DO UPDATE SET b='d' \
+         ON CONFLICT(e) DO UPDATE SET b='e';",
+    );
+    assert_eq!(clauses.len(), 4);
+    for clause in &clauses {
+        assert!(clause.conflict_target.is_some());
+        assert!(matches!(clause.action, vibesql_ast::OnConflictAction::DoUpdate { .. }));
+    }
+}
+
+#[test]
+fn test_parse_insert_targetless_terminal_clause_ok() {
+    // A target-less clause is the catch-all and is allowed in the terminal
+    // position (upsert5 1.x.400).
+    let clauses = parse_on_conflict_clauses(
+        "INSERT INTO t1(a,b) VALUES(1,2) \
+         ON CONFLICT(a) DO UPDATE SET b='a' \
+         ON CONFLICT DO UPDATE SET b='x';",
+    );
+    assert_eq!(clauses.len(), 2);
+    assert!(clauses[1].conflict_target.is_none());
+}
+
+#[test]
+fn test_parse_insert_targetless_non_terminal_clause_is_error() {
+    // sqlite3 3.51: a target-less ON CONFLICT clause must be the LAST
+    // clause; a following ON CONFLICT is a syntax error.
+    let result = Parser::parse_sql(
+        "INSERT INTO t1(a,b) VALUES(1,2) \
+         ON CONFLICT DO NOTHING \
+         ON CONFLICT(a) DO UPDATE SET b='a';",
+    );
+    let err = result.expect_err("non-terminal target-less clause must be a syntax error");
+    assert!(
+        err.message.contains("near \"ON\": syntax error"),
+        "expected SQLite's near-ON syntax error, got: {:?}",
+        err
+    );
+}
+
+#[test]
+fn test_parse_replace_into_with_on_conflict_clauses() {
+    // upsert5 section 3: REPLACE INTO with (redundant) ON CONFLICT clauses.
+    let result = Parser::parse_sql(
+        "REPLACE INTO t1 VALUES(11,33) \
+         ON CONFLICT(bb) DO UPDATE SET aa = 44 \
+         ON CONFLICT(bb) DO UPDATE SET aa = 44;",
+    );
+    match result.expect("REPLACE INTO with ON CONFLICT clauses should parse") {
+        vibesql_ast::Statement::Insert(insert) => {
+            assert!(matches!(insert.conflict_clause, Some(vibesql_ast::ConflictClause::Replace)));
+            assert_eq!(insert.on_conflict.len(), 2);
+        }
+        other => panic!("Expected INSERT statement, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_insert_on_conflict_then_on_duplicate_is_error() {
+    // MySQL's ON DUPLICATE KEY UPDATE cannot be mixed with SQLite ON
+    // CONFLICT clauses.
+    let result = Parser::parse_sql(
+        "INSERT INTO t1(a,b) VALUES(1,2) \
+         ON CONFLICT(a) DO NOTHING \
+         ON DUPLICATE KEY UPDATE b = 3;",
+    );
+    assert!(result.is_err(), "mixing ON CONFLICT and ON DUPLICATE KEY UPDATE must not parse");
 }

--- a/tests/storage/insert_constraint_performance.rs
+++ b/tests/storage/insert_constraint_performance.rs
@@ -53,7 +53,7 @@ fn test_insert_with_merged_constraint_validation() {
                 Expression::Literal(SqlValue::Varchar(format!("user{}@example.com", i).into())),
             ]]),
             conflict_clause: None,
-            on_conflict: None,
+            on_conflict: vec![],
             on_duplicate_key_update: None,
             returning: None,
         };
@@ -121,7 +121,7 @@ fn test_insert_multi_row_with_constraints() {
         columns: vec![],
         source: InsertSource::Values(rows),
         conflict_clause: None,
-        on_conflict: None,
+        on_conflict: vec![],
         on_duplicate_key_update: None,
         returning: None,
     };


### PR DESCRIPTION
Closes #5817

## Summary

Implements SQLite's generalized UPSERT (3.35+): a single INSERT may carry multiple `ON CONFLICT` clauses, each UNIQUE constraint separately addressable, with per-row **leftmost-match clause selection** (semantics verified against sqlite3 3.51 per the curator's enrichment).

### Parser + AST (Phase A)
- `InsertStmt.on_conflict: Option<OnConflictClause>` → `Vec<OnConflictClause>` (empty = no upsert), mirrored in the arena AST and plumbed through `arena/convert.rs`, `visitor.rs`, and all `vibesql-consensus/src/freeze.rs` transform/validation sites (every clause is now visited/validated/re-frozen).
- Both parsers (standard + arena) loop over `ON CONFLICT` clauses at all INSERT entry points (including `REPLACE INTO`). A target-less clause is the catch-all and must be **terminal** — a non-terminal one raises SQLite's exact `near "ON": syntax error`. Mixing with MySQL `ON DUPLICATE KEY UPDATE` is rejected.

### Executor (Phase B)
- New `dispatch_on_conflict_clauses` (`insert/on_conflict_update.rs`): per candidate row, compute which unique constraints (PK, table-level UNIQUE, unique/expression/partial indexes) the row violates against live rows, then fire the **leftmost clause whose target matches a violated constraint**. Target-less matches any conflict; duplicate targets fire the first (upsert5 1.x.300). DO NOTHING drops the row; DO UPDATE reuses the existing single-clause update arm (including its `WHERE`, `excluded.` handling, and the #5836/#5865 constraint enforcement).
- **Unmatched conflicts fall back to the statement's conflict resolution**: REPLACE deletes the conflicting rows — fixing the duplicate-INTEGER-PRIMARY-KEY data-integrity bug from upsert5 section 3 that the curator found (reproducible with a single clause); IGNORE skips the row; default ABORT raises the UNIQUE error with SQLite wording. The REPLACE resolution block was factored verbatim into `resolve_replace_conflicts_for_row` so both paths share it.
- Prepare-time validation runs for **every** clause, and conflict-target expressions now resolve table names: `ON CONFLICT((SELECT x FROM nosuchtable))` reports `no such table: nosuchtable` (upsert5 test 2.1).
- Single-clause DO NOTHING statements keep the existing validation-loop fast path (`use_ignore` / `do_nothing_target`) and batch inserts — no perf change for the common case.

## Results

| File | main baseline | this PR |
|---|---|---|
| upsert5.test | **25/237** | **232/237** |
| upsert1.test | 32 passed / 0 failed / 3 skipped | identical |
| upsert2.test | 6/14 | identical |
| upsert3.test | 5/7 | identical |
| upsert4.test | 45/60 | identical |
| insert.test / insert2 / insert3 | 51, 16, 16 passed / 0 failed | identical |

All baselines re-measured with a freshly built main binary on this machine.

### Residual (5 failures, documented root cause)
upsert5 tests **3.1, 3.2, 3.4, 3.5, 3.6** fail due to a **pre-existing WAL persistence bug**, not upsert semantics: plain `REPLACE INTO` (no upsert syntax at all) loses the conflicting-row delete across CLI process restarts on a file-backed DB, verified on main @ 02fc850be. The TCL harness runs one process per statement, so the section-3 SELECTs observe the stale row even though the in-process result is correct (3.0/3.3 `PRAGMA integrity_check` — same process as the REPLACE — pass). Filed as **#5871** with a 3-command repro; once fixed, these 5 tests should pass with no further upsert work.

## Testing
- New parser unit tests: 2-clause, N-clause, target-less terminal ok / non-terminal syntax error, `REPLACE INTO` + clauses, ON CONFLICT × ON DUPLICATE mixing rejected.
- New executor integration tests: leftmost-match ordering, non-violated targets skipped, duplicate targets, target-less catch-all, DO NOTHING vs later catch-all, unmatched-conflict ABORT, and three REPLACE-fallback regression tests for the curator's section-3 duplicate-PK finding.
- `cargo test -p vibesql-parser -p vibesql-ast -p vibesql-consensus`: all pass. `cargo test -p vibesql-executor`: all pass (`--lib` needs `RUST_MIN_STACK=33554432` for the pre-existing `test_deep_case_expressions` debug-build stack overflow, which fails identically on an unmodified checkout).

## Not in scope
- Tuple SET and lenient targets (#5862).
- The #5871 WAL/REPLACE persistence bug (pre-existing, reproduces without upsert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)