### PR TITLE
perf(executor): hoist uncorrelated scalar subqueries in WHERE to literals before per-row filtering

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/hoist.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/hoist.rs
@@ -1,0 +1,306 @@
+//! Hoisting of uncorrelated scalar subqueries out of per-row predicates
+//!
+//! ## Problem (issue #5809)
+//!
+//! A query like:
+//!
+//! ```sql
+//! SELECT ... FROM t WHERE run_id = (SELECT MAX(run_id) FROM t)
+//! ```
+//!
+//! contains an *uncorrelated* scalar subquery: its value does not depend on the
+//! outer row, so it must be evaluated exactly once per statement (this is also
+//! what SQLite does, including for non-deterministic functions like
+//! `random()`).
+//!
+//! The sequential evaluator already achieves "evaluate once" through the
+//! per-evaluator LRU `subquery_cache`. However, the parallel filter paths
+//! (morsel-driven WHERE filtering, parallel predicate pushdown) construct a
+//! **fresh thread-local evaluator per row** via `from_parallel_components`,
+//! each with an empty cache — so the subquery's full table scan re-executes
+//! for every candidate row, turning an O(n) filter into an O(n²) blowup
+//! (413k rows × 413k-row scan on the canonical CLAUDE.md pass-rate query).
+//!
+//! ## Fix
+//!
+//! Before per-row filtering begins, rewrite the predicate expression once,
+//! replacing each provably-uncorrelated single-column scalar subquery with the
+//! `Expression::Literal` value it evaluates to. Downstream filtering (parallel
+//! or sequential) then sees a plain literal comparison, which additionally
+//! unlocks the compiled-predicate fast paths.
+//!
+//! ## Safety conditions
+//!
+//! A `ScalarSubquery` node is hoisted only when ALL of the following hold:
+//!
+//! 1. The evaluator has no outer context of any kind (no outer row/schema,
+//!    no chained outer evaluator, no trigger or procedural context). This is
+//!    the top-level-query case; nested evaluation contexts fall back to the
+//!    existing cached per-row path.
+//! 2. The syntactic correlation check (`is_correlated_cached`) reports the
+//!    subquery as uncorrelated.
+//! 3. The correlation-reference extraction used by the caching layer
+//!    (`extract_correlation_values`) finds **zero** outer column references.
+//!    This catches unqualified column names that the syntactic check can miss
+//!    (the aggnested-1.4 / select1-18.x hazard).
+//! 4. The subquery's select list is statically known to produce exactly one
+//!    column — multi-column `ScalarSubquery` nodes participate in row-value
+//!    comparisons like `(a, b) = (SELECT x, y ...)` and must not be folded to
+//!    a scalar literal.
+//! 5. The one-shot evaluation succeeds. On error the node is left untouched so
+//!    the per-row path preserves lazy error semantics (e.g. a subquery inside
+//!    a CASE branch that is never taken).
+//!
+//! The traversal never descends into nested `SelectStmt` bodies (`IN`,
+//! `EXISTS`, quantified comparisons, or the subquery's own AST): expressions
+//! inside those bodies are scoped to the inner query and may be correlated to
+//! intermediate scopes this evaluator cannot see.
+
+use super::{
+    super::super::core::CombinedExpressionEvaluator, correlation::extract_correlation_values,
+};
+
+impl CombinedExpressionEvaluator<'_> {
+    /// Rewrite `expr`, replacing each provably-uncorrelated scalar subquery
+    /// with the literal value it evaluates to (evaluated exactly once).
+    ///
+    /// Returns `Some(rewritten)` if at least one subquery was hoisted, or
+    /// `None` if the expression is unchanged (caller keeps the original).
+    /// Never returns an error: any subquery that cannot be safely or
+    /// successfully evaluated is simply left in place for the per-row path.
+    pub(crate) fn hoist_uncorrelated_scalar_subqueries(
+        &self,
+        expr: &vibesql_ast::Expression,
+    ) -> Option<vibesql_ast::Expression> {
+        // Only safe in a top-level evaluation context (see module docs).
+        if self.database.is_none()
+            || self.outer_row.is_some()
+            || self.outer_schema.is_some()
+            || self.outer_rows.is_some()
+            || self.outer_context.is_some()
+            || self.trigger_context.is_some()
+            || self.procedural_context.is_some()
+        {
+            return None;
+        }
+
+        // Cheap pre-scan: the vast majority of WHERE clauses contain no scalar
+        // subquery. Avoid cloning the expression tree for those.
+        if !contains_hoistable_position(expr) {
+            return None;
+        }
+
+        let mut rewritten = expr.clone();
+        let mut changed = false;
+        self.hoist_expr_mut(&mut rewritten, &mut changed);
+        if changed {
+            Some(rewritten)
+        } else {
+            None
+        }
+    }
+
+    /// Attempt to evaluate a single scalar subquery once, returning its value
+    /// if all safety conditions hold (see module docs).
+    fn try_hoist_scalar_subquery(
+        &self,
+        subquery: &vibesql_ast::SelectStmt,
+    ) -> Option<vibesql_types::SqlValue> {
+        let database = self.database?;
+
+        // Condition 2: syntactically uncorrelated.
+        if self.is_correlated_cached(subquery) {
+            return None;
+        }
+
+        // Condition 3: the caching layer's correlation-reference walk must
+        // find zero outer references. `extract_correlation_values` returns
+        // `Some(vec![])` exactly when no outer refs exist; a non-empty vec or
+        // `None` (extraction failure against the empty probe row) means the
+        // subquery might read the outer row, so we must not hoist.
+        let probe_row = vibesql_storage::Row::new(Vec::<vibesql_types::SqlValue>::new());
+        match extract_correlation_values(subquery, &probe_row, self.schema) {
+            Some(refs) if refs.is_empty() => {}
+            _ => return None,
+        }
+
+        // Condition 4: genuine single-column scalar subquery.
+        match super::schema_utils::compute_select_list_column_count(
+            subquery,
+            database,
+            self.cte_context,
+        ) {
+            Ok(1) => {}
+            _ => return None,
+        }
+
+        // Condition 5: evaluate once; on error fall back to the per-row path.
+        // The empty probe row is safe because conditions 2+3 guarantee the
+        // subquery never reads outer row values.
+        self.eval_scalar_subquery(subquery, &probe_row).ok()
+    }
+
+    /// Recursively rewrite hoistable scalar subqueries in place.
+    ///
+    /// Recurses only through scalar expression positions; never descends into
+    /// nested `SelectStmt` bodies.
+    fn hoist_expr_mut(&self, expr: &mut vibesql_ast::Expression, changed: &mut bool) {
+        use vibesql_ast::Expression;
+
+        match expr {
+            Expression::ScalarSubquery(subquery) => {
+                if let Some(value) = self.try_hoist_scalar_subquery(subquery) {
+                    *expr = Expression::Literal(value);
+                    *changed = true;
+                }
+                // If not hoistable, leave the node fully intact (do not
+                // descend into the subquery body).
+            }
+            Expression::BinaryOp { left, right, .. } => {
+                self.hoist_expr_mut(left, changed);
+                self.hoist_expr_mut(right, changed);
+            }
+            Expression::Conjunction(exprs) | Expression::Disjunction(exprs) => {
+                for e in exprs {
+                    self.hoist_expr_mut(e, changed);
+                }
+            }
+            Expression::UnaryOp { expr: inner, .. } => self.hoist_expr_mut(inner, changed),
+            Expression::Function { args, .. } => {
+                for arg in args {
+                    self.hoist_expr_mut(arg, changed);
+                }
+            }
+            Expression::IsNull { expr: inner, .. } => self.hoist_expr_mut(inner, changed),
+            Expression::IsDistinctFrom { left, right, .. } => {
+                self.hoist_expr_mut(left, changed);
+                self.hoist_expr_mut(right, changed);
+            }
+            Expression::IsTruthValue { expr: inner, .. } => self.hoist_expr_mut(inner, changed),
+            Expression::Case { operand, when_clauses, else_result } => {
+                if let Some(op) = operand {
+                    self.hoist_expr_mut(op, changed);
+                }
+                for when in when_clauses {
+                    for condition in &mut when.conditions {
+                        self.hoist_expr_mut(condition, changed);
+                    }
+                    self.hoist_expr_mut(&mut when.result, changed);
+                }
+                if let Some(else_expr) = else_result {
+                    self.hoist_expr_mut(else_expr, changed);
+                }
+            }
+            // For IN / quantified comparisons, only the scalar LHS is in this
+            // scope; the subquery body is not descended into.
+            Expression::In { expr: inner, .. } => self.hoist_expr_mut(inner, changed),
+            Expression::QuantifiedComparison { expr: inner, .. } => {
+                self.hoist_expr_mut(inner, changed)
+            }
+            Expression::InList { expr: inner, values, .. } => {
+                self.hoist_expr_mut(inner, changed);
+                for v in values {
+                    self.hoist_expr_mut(v, changed);
+                }
+            }
+            Expression::Between { expr: inner, low, high, .. } => {
+                self.hoist_expr_mut(inner, changed);
+                self.hoist_expr_mut(low, changed);
+                self.hoist_expr_mut(high, changed);
+            }
+            Expression::Cast { expr: inner, .. } => self.hoist_expr_mut(inner, changed),
+            Expression::Position { substring, string, .. } => {
+                self.hoist_expr_mut(substring, changed);
+                self.hoist_expr_mut(string, changed);
+            }
+            Expression::Trim { removal_char, string, .. } => {
+                if let Some(c) = removal_char {
+                    self.hoist_expr_mut(c, changed);
+                }
+                self.hoist_expr_mut(string, changed);
+            }
+            Expression::Extract { expr: inner, .. } => self.hoist_expr_mut(inner, changed),
+            Expression::Like { expr: inner, pattern, escape, .. }
+            | Expression::Glob { expr: inner, pattern, escape, .. } => {
+                self.hoist_expr_mut(inner, changed);
+                self.hoist_expr_mut(pattern, changed);
+                if let Some(esc) = escape {
+                    self.hoist_expr_mut(esc, changed);
+                }
+            }
+            Expression::Interval { value, .. } => self.hoist_expr_mut(value, changed),
+            Expression::RowValueConstructor(elements) => {
+                for e in elements {
+                    self.hoist_expr_mut(e, changed);
+                }
+            }
+            Expression::Collate { expr: inner, .. } => self.hoist_expr_mut(inner, changed),
+            // Leaves and constructs whose bodies are out of scope
+            // (EXISTS, aggregate functions, window functions, literals,
+            // column refs, placeholders, ...): nothing to do.
+            _ => {}
+        }
+    }
+}
+
+/// Cheap pre-scan: does the expression contain a `ScalarSubquery` node in a
+/// position the rewriter would visit? Mirrors `hoist_expr_mut`'s traversal.
+fn contains_hoistable_position(expr: &vibesql_ast::Expression) -> bool {
+    use vibesql_ast::Expression;
+
+    match expr {
+        Expression::ScalarSubquery(_) => true,
+        Expression::BinaryOp { left, right, .. } => {
+            contains_hoistable_position(left) || contains_hoistable_position(right)
+        }
+        Expression::Conjunction(exprs) | Expression::Disjunction(exprs) => {
+            exprs.iter().any(contains_hoistable_position)
+        }
+        Expression::UnaryOp { expr: inner, .. } => contains_hoistable_position(inner),
+        Expression::Function { args, .. } => args.iter().any(contains_hoistable_position),
+        Expression::IsNull { expr: inner, .. } => contains_hoistable_position(inner),
+        Expression::IsDistinctFrom { left, right, .. } => {
+            contains_hoistable_position(left) || contains_hoistable_position(right)
+        }
+        Expression::IsTruthValue { expr: inner, .. } => contains_hoistable_position(inner),
+        Expression::Case { operand, when_clauses, else_result } => {
+            operand.as_deref().is_some_and(contains_hoistable_position)
+                || when_clauses.iter().any(|w| {
+                    w.conditions.iter().any(contains_hoistable_position)
+                        || contains_hoistable_position(&w.result)
+                })
+                || else_result.as_deref().is_some_and(contains_hoistable_position)
+        }
+        Expression::In { expr: inner, .. } => contains_hoistable_position(inner),
+        Expression::QuantifiedComparison { expr: inner, .. } => contains_hoistable_position(inner),
+        Expression::InList { expr: inner, values, .. } => {
+            contains_hoistable_position(inner) || values.iter().any(contains_hoistable_position)
+        }
+        Expression::Between { expr: inner, low, high, .. } => {
+            contains_hoistable_position(inner)
+                || contains_hoistable_position(low)
+                || contains_hoistable_position(high)
+        }
+        Expression::Cast { expr: inner, .. } => contains_hoistable_position(inner),
+        Expression::Position { substring, string, .. } => {
+            contains_hoistable_position(substring) || contains_hoistable_position(string)
+        }
+        Expression::Trim { removal_char, string, .. } => {
+            removal_char.as_deref().is_some_and(contains_hoistable_position)
+                || contains_hoistable_position(string)
+        }
+        Expression::Extract { expr: inner, .. } => contains_hoistable_position(inner),
+        Expression::Like { expr: inner, pattern, escape, .. }
+        | Expression::Glob { expr: inner, pattern, escape, .. } => {
+            contains_hoistable_position(inner)
+                || contains_hoistable_position(pattern)
+                || escape.as_deref().is_some_and(contains_hoistable_position)
+        }
+        Expression::Interval { value, .. } => contains_hoistable_position(value),
+        Expression::RowValueConstructor(elements) => {
+            elements.iter().any(contains_hoistable_position)
+        }
+        Expression::Collate { expr: inner, .. } => contains_hoistable_position(inner),
+        _ => false,
+    }
+}

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/mod.rs
@@ -16,6 +16,7 @@ pub mod schema_utils;
 
 // Evaluator modules (private - methods defined on CombinedExpressionEvaluator)
 mod exists;
+mod hoist;
 mod in_subquery;
 mod quantified;
 mod scalar;

--- a/crates/vibesql-executor/src/select/filter.rs
+++ b/crates/vibesql-executor/src/select/filter.rs
@@ -451,6 +451,18 @@ pub(crate) fn apply_where_filter_combined_auto<'a>(
         return Ok(rows);
     }
 
+    // Issue #5809: evaluate uncorrelated scalar subqueries exactly once and
+    // substitute their literal values before per-row filtering begins. The
+    // parallel paths below build fresh thread-local evaluators (with empty
+    // subquery caches) per row, so without this hoist an uncorrelated
+    // subquery like `WHERE x = (SELECT MAX(x) FROM t)` re-executes its full
+    // scan for every row — an O(n²) blowup.
+    let hoisted = where_expr.and_then(|expr| evaluator.hoist_uncorrelated_scalar_subqueries(expr));
+    let where_expr = match hoisted.as_ref() {
+        Some(rewritten) => Some(rewritten),
+        None => where_expr,
+    };
+
     // For very large datasets, use parallel execution
     #[cfg(feature = "parallel")]
     {

--- a/crates/vibesql-executor/src/select/scan/predicates.rs
+++ b/crates/vibesql-executor/src/select/scan/predicates.rs
@@ -114,6 +114,15 @@ pub(crate) fn apply_table_local_predicates(
             _ => CombinedExpressionEvaluator::with_database(&schema, database),
         };
 
+        // Issue #5809: evaluate uncorrelated scalar subqueries exactly once and
+        // substitute their literal values before per-row filtering. The parallel
+        // path below creates a fresh thread-local evaluator (with an empty
+        // subquery cache) per row, which would otherwise re-execute the
+        // subquery's full scan for every row — an O(n²) blowup.
+        let combined_where = evaluator
+            .hoist_uncorrelated_scalar_subqueries(&combined_where)
+            .unwrap_or(combined_where);
+
         // Check if we should use parallel filtering
         #[cfg(feature = "parallel")]
         {

--- a/crates/vibesql-executor/tests/uncorrelated_subquery_hoist_tests.rs
+++ b/crates/vibesql-executor/tests/uncorrelated_subquery_hoist_tests.rs
@@ -1,0 +1,379 @@
+//! Regression tests for issue #5809
+//!
+//! An *uncorrelated* scalar subquery in WHERE, e.g.
+//!
+//! ```sql
+//! SELECT ... FROM t WHERE run_id = (SELECT MAX(run_id) FROM t)
+//! ```
+//!
+//! was re-evaluated for every candidate row on the parallel filter paths:
+//! `apply_where_filter_combined_parallel` (morsel slow path) and
+//! `apply_predicates_parallel` construct a fresh thread-local evaluator —
+//! with an empty subquery cache — per row, so the subquery's full table scan
+//! re-executed n times, an O(n²) blowup (the canonical CLAUDE.md pass-rate
+//! query burned 822 CPU-minutes at 21 GB RSS without completing).
+//!
+//! The fix hoists provably-uncorrelated single-column scalar subqueries out
+//! of the predicate before per-row filtering begins: each is evaluated
+//! exactly once and replaced by its literal value
+//! (`CombinedExpressionEvaluator::hoist_uncorrelated_scalar_subqueries`).
+//!
+//! These tests cover:
+//! - the O(n²) perf regression itself (100k rows under a wall-clock budget)
+//! - correctness of the hoisted uncorrelated form (incl. the same-table,
+//!   unqualified-column canonical shape)
+//! - correlated subqueries, which must still be evaluated per row
+//! - NULL-returning / empty-result subqueries
+//! - multi-column subqueries in row-value comparisons (must NOT be folded)
+//! - scalar subqueries in the SELECT list and HAVING (shared eval path)
+
+use std::time::{Duration, Instant};
+
+use vibesql_catalog::{ColumnSchema, TableSchema};
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::{Database, Row};
+use vibesql_types::{DataType, SqlValue};
+
+fn parse_select(sql: &str) -> vibesql_ast::SelectStmt {
+    match Parser::parse_sql(sql) {
+        Ok(vibesql_ast::Statement::Select(select_stmt)) => *select_stmt,
+        _ => panic!("Failed to parse SELECT statement: {}", sql),
+    }
+}
+
+fn run(db: &Database, sql: &str) -> Vec<Row> {
+    let select = parse_select(sql);
+    SelectExecutor::new(db).execute(&select).unwrap()
+}
+
+fn int(row: &Row, idx: usize) -> i64 {
+    match row.get(idx) {
+        Some(SqlValue::Integer(n)) => *n,
+        Some(SqlValue::Bigint(n)) => *n,
+        other => panic!("expected integer at index {idx}, got {other:?}"),
+    }
+}
+
+/// Small correctness fixture:
+///
+/// ```sql
+/// CREATE TABLE a (id INTEGER, grp INTEGER, val INTEGER);
+/// -- (1,1,10),(2,1,20),(3,2,30),(4,2,40),(5,3,NULL),(6,3,60)
+/// CREATE TABLE b (grp INTEGER, cap INTEGER);
+/// -- (1,15),(2,35),(3,100)
+/// ```
+fn setup_small_db() -> Database {
+    let mut db = Database::new();
+
+    let schema_a = TableSchema::new(
+        "A".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, true),
+            ColumnSchema::new("grp".to_string(), DataType::Integer, true),
+            ColumnSchema::new("val".to_string(), DataType::Integer, true),
+        ],
+    );
+    db.create_table(schema_a).unwrap();
+
+    let rows_a: [(i64, i64, Option<i64>); 6] = [
+        (1, 1, Some(10)),
+        (2, 1, Some(20)),
+        (3, 2, Some(30)),
+        (4, 2, Some(40)),
+        (5, 3, None),
+        (6, 3, Some(60)),
+    ];
+    for (id, grp, val) in rows_a {
+        db.insert_row(
+            "A",
+            Row::new(vec![
+                SqlValue::Integer(id),
+                SqlValue::Integer(grp),
+                val.map(SqlValue::Integer).unwrap_or(SqlValue::Null),
+            ]),
+        )
+        .unwrap();
+    }
+
+    let schema_b = TableSchema::new(
+        "B".to_string(),
+        vec![
+            ColumnSchema::new("grp".to_string(), DataType::Integer, true),
+            ColumnSchema::new("cap".to_string(), DataType::Integer, true),
+        ],
+    );
+    db.create_table(schema_b).unwrap();
+
+    for (grp, cap) in [(1i64, 15i64), (2, 35), (3, 100)] {
+        db.insert_row("B", Row::new(vec![SqlValue::Integer(grp), SqlValue::Integer(cap)])).unwrap();
+    }
+
+    db
+}
+
+// ---------------------------------------------------------------------------
+// Perf regression: O(n²) blowup
+// ---------------------------------------------------------------------------
+
+/// The canonical issue #5809 shape on a table large enough that the parallel
+/// filter path is taken (>10k rows) and O(n²) behavior cannot hide:
+/// 100k rows × 100k-row subquery scans would be 10^10 row visits (hours even
+/// in release; the original report burned 822 CPU-minutes on 413k rows).
+/// With the hoist the query is two linear passes. The generous budget keeps
+/// the test robust on loaded CI machines while still being orders of
+/// magnitude below the O(n²) runtime.
+#[test]
+fn uncorrelated_scalar_subquery_where_is_not_quadratic() {
+    let mut db = Database::new();
+
+    let schema = TableSchema::new(
+        "T".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, true),
+            ColumnSchema::new("run_id".to_string(), DataType::Integer, true),
+        ],
+    );
+    db.create_table(schema).unwrap();
+
+    const N: i64 = 100_000;
+    for i in 1..=N {
+        db.insert_row("T", Row::new(vec![SqlValue::Integer(i), SqlValue::Integer(i % 5 + 1)]))
+            .unwrap();
+    }
+
+    let start = Instant::now();
+    let rows = run(
+        &db,
+        "SELECT run_id, COUNT(*) FROM t \
+         WHERE run_id = (SELECT MAX(run_id) FROM t) \
+         GROUP BY run_id",
+    );
+    let elapsed = start.elapsed();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(int(&rows[0], 0), 5);
+    assert_eq!(int(&rows[0], 1), 20_000);
+
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "uncorrelated scalar subquery in WHERE took {elapsed:?}; \
+         re-evaluation per row (O(n²)) suspected (issue #5809)"
+    );
+}
+
+/// Same guard for the non-aggregate path (no GROUP BY), which filters through
+/// the materialized non-aggregate executor.
+#[test]
+fn uncorrelated_scalar_subquery_where_nonaggregate_is_not_quadratic() {
+    let mut db = Database::new();
+
+    let schema = TableSchema::new(
+        "T".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, true),
+            ColumnSchema::new("run_id".to_string(), DataType::Integer, true),
+        ],
+    );
+    db.create_table(schema).unwrap();
+
+    const N: i64 = 50_000;
+    for i in 1..=N {
+        db.insert_row("T", Row::new(vec![SqlValue::Integer(i), SqlValue::Integer(i % 5 + 1)]))
+            .unwrap();
+    }
+
+    let start = Instant::now();
+    let rows =
+        run(&db, "SELECT id FROM t WHERE run_id = (SELECT MAX(run_id) FROM t) ORDER BY id LIMIT 3");
+    let elapsed = start.elapsed();
+
+    assert_eq!(rows.len(), 3);
+    // run_id = 5 <=> i % 5 == 4; smallest ids are 4, 9, 14
+    assert_eq!(int(&rows[0], 0), 4);
+    assert_eq!(int(&rows[1], 0), 9);
+    assert_eq!(int(&rows[2], 0), 14);
+
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "uncorrelated scalar subquery in WHERE (non-aggregate) took {elapsed:?}; \
+         re-evaluation per row (O(n²)) suspected (issue #5809)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Correctness: uncorrelated forms (hoisted)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn uncorrelated_max_same_table() {
+    let db = setup_small_db();
+    // MAX(val) = 60 -> only id 6
+    let rows = run(&db, "SELECT id FROM a WHERE val = (SELECT MAX(val) FROM a) ORDER BY id");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(int(&rows[0], 0), 6);
+}
+
+#[test]
+fn uncorrelated_subquery_inside_arithmetic() {
+    let db = setup_small_db();
+    // val >= 60 - 30 = 30 -> ids 3, 4, 6
+    let rows = run(&db, "SELECT id FROM a WHERE val >= (SELECT MAX(val) FROM a) - 30 ORDER BY id");
+    let ids: Vec<i64> = rows.iter().map(|r| int(r, 0)).collect();
+    assert_eq!(ids, vec![3, 4, 6]);
+}
+
+#[test]
+fn uncorrelated_subqueries_as_between_bounds() {
+    let db = setup_small_db();
+    // MIN(val)=10, AVG(val)=32 -> val in [10, 32] -> ids 1, 2, 3
+    let rows = run(
+        &db,
+        "SELECT id FROM a \
+         WHERE val BETWEEN (SELECT MIN(val) FROM a) AND (SELECT AVG(val) FROM a) \
+         ORDER BY id",
+    );
+    let ids: Vec<i64> = rows.iter().map(|r| int(r, 0)).collect();
+    assert_eq!(ids, vec![1, 2, 3]);
+}
+
+#[test]
+fn uncorrelated_subquery_against_other_table() {
+    let db = setup_small_db();
+    // MAX(cap) = 100 -> no val reaches it
+    let rows = run(&db, "SELECT id FROM a WHERE val > (SELECT MAX(cap) FROM b) ORDER BY id");
+    assert!(rows.is_empty());
+    // MIN(cap) = 15 -> ids 2, 3, 4, 6
+    let rows = run(&db, "SELECT id FROM a WHERE val > (SELECT MIN(cap) FROM b) ORDER BY id");
+    let ids: Vec<i64> = rows.iter().map(|r| int(r, 0)).collect();
+    assert_eq!(ids, vec![2, 3, 4, 6]);
+}
+
+// ---------------------------------------------------------------------------
+// Correctness: NULL / empty subquery results
+// ---------------------------------------------------------------------------
+
+#[test]
+fn null_returning_subquery_filters_all_rows() {
+    let db = setup_small_db();
+    // Empty result set -> scalar subquery is NULL -> comparison is NULL -> 0 rows
+    let rows = run(&db, "SELECT id FROM a WHERE val = (SELECT val FROM a WHERE id = 999)");
+    assert!(rows.is_empty());
+    // Explicit NULL
+    let rows = run(&db, "SELECT id FROM a WHERE val = (SELECT NULL)");
+    assert!(rows.is_empty());
+    // IS NULL over a NULL-valued subquery must keep all rows
+    let rows = run(&db, "SELECT COUNT(*) FROM a WHERE (SELECT NULL) IS NULL");
+    assert_eq!(int(&rows[0], 0), 6);
+}
+
+// ---------------------------------------------------------------------------
+// Correctness: correlated subqueries must still evaluate per row
+// ---------------------------------------------------------------------------
+
+#[test]
+fn correlated_subquery_still_per_row_two_tables() {
+    let db = setup_small_db();
+    // Per-row cap from b: grp 1 -> 15 (20 > 15: id 2), grp 2 -> 35 (40 > 35: id 4),
+    // grp 3 -> 100 (none). Matches sqlite3.
+    let rows = run(
+        &db,
+        "SELECT id FROM a WHERE val > (SELECT cap FROM b WHERE b.grp = a.grp) ORDER BY id",
+    );
+    let ids: Vec<i64> = rows.iter().map(|r| int(r, 0)).collect();
+    assert_eq!(ids, vec![2, 4]);
+}
+
+#[test]
+fn correlated_subquery_still_per_row_same_table_alias() {
+    let db = setup_small_db();
+    // Per-group max: grp 1 -> 20 (id 2), grp 2 -> 40 (id 4), grp 3 -> 60 (id 6).
+    // Matches sqlite3.
+    let rows = run(
+        &db,
+        "SELECT id FROM a x \
+         WHERE val = (SELECT MAX(val) FROM a y WHERE y.grp = x.grp) \
+         ORDER BY id",
+    );
+    let ids: Vec<i64> = rows.iter().map(|r| int(r, 0)).collect();
+    assert_eq!(ids, vec![2, 4, 6]);
+}
+
+// ---------------------------------------------------------------------------
+// Correctness: multi-column subqueries in row-value comparisons are NOT folded
+// ---------------------------------------------------------------------------
+
+#[test]
+fn row_value_subquery_comparison_still_works() {
+    let db = setup_small_db();
+    // (grp, val) of id 4 is (2, 40); subquery returns (2, 40)
+    let rows = run(
+        &db,
+        "SELECT id FROM a \
+         WHERE (grp, val) = (SELECT grp, val FROM a WHERE id = 4) \
+         ORDER BY id",
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(int(&rows[0], 0), 4);
+}
+
+// ---------------------------------------------------------------------------
+// Correctness: SELECT list and HAVING share the scalar-subquery path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn uncorrelated_subquery_in_select_list() {
+    let db = setup_small_db();
+    let rows = run(&db, "SELECT id, (SELECT MIN(val) FROM a) FROM a WHERE id <= 2 ORDER BY id");
+    assert_eq!(rows.len(), 2);
+    for row in &rows {
+        assert_eq!(int(row, 1), 10);
+    }
+}
+
+#[test]
+fn uncorrelated_subquery_in_having() {
+    let db = setup_small_db();
+    // AVG(val) = 32; group sums: grp1=30, grp2=70, grp3=60 -> grp 2 and 3
+    let rows = run(
+        &db,
+        "SELECT grp, SUM(val) FROM a GROUP BY grp \
+         HAVING SUM(val) > (SELECT AVG(val) FROM a) ORDER BY grp",
+    );
+    let grps: Vec<i64> = rows.iter().map(|r| int(r, 0)).collect();
+    assert_eq!(grps, vec![2, 3]);
+}
+
+// ---------------------------------------------------------------------------
+// Correctness: hoist interacts safely with other WHERE conjuncts
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hoisted_subquery_anded_with_plain_predicate() {
+    let db = setup_small_db();
+    // grp = MAX(grp) = 3 AND val IS NOT NULL -> id 6
+    let rows = run(
+        &db,
+        "SELECT id FROM a \
+         WHERE grp = (SELECT MAX(grp) FROM a) AND val IS NOT NULL \
+         ORDER BY id",
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(int(&rows[0], 0), 6);
+}
+
+#[test]
+fn hoisted_and_correlated_subqueries_mixed() {
+    let db = setup_small_db();
+    // Correlated per-group max AND uncorrelated global min:
+    // per-group maxes are ids 2 (20), 4 (40), 6 (60); all > MIN(val)=10 except none excluded
+    let rows = run(
+        &db,
+        "SELECT id FROM a x \
+         WHERE val = (SELECT MAX(val) FROM a y WHERE y.grp = x.grp) \
+           AND val > (SELECT MIN(val) FROM a) \
+         ORDER BY id",
+    );
+    let ids: Vec<i64> = rows.iter().map(|r| int(r, 0)).collect();
+    assert_eq!(ids, vec![2, 4, 6]);
+}


### PR DESCRIPTION
## Summary

An uncorrelated scalar subquery in WHERE — the canonical CLAUDE.md pass-rate shape `WHERE run_id = (SELECT MAX(run_id) FROM tcl_test_results)` — was re-executed for **every candidate row**, an O(n²) blowup (822 CPU-minutes / 21 GB RSS on 413k rows in the original report).

**Root cause**: the sequential evaluator caches uncorrelated subquery results in its per-statement LRU `subquery_cache`, but the parallel filter paths (`apply_where_filter_combined_parallel` morsel slow path in `select/filter.rs`, and `apply_predicates_parallel` in `select/scan/predicates.rs`) construct a **fresh thread-local evaluator per row** via `from_parallel_components` — each with an empty cache — so the subquery's full table scan re-ran n times.

**Fix**: before per-row filtering begins, rewrite the predicate once via a new `CombinedExpressionEvaluator::hoist_uncorrelated_scalar_subqueries`, replacing each provably-uncorrelated single-column scalar subquery with the literal value it evaluates to. This matches SQLite's once-per-statement evaluation of uncorrelated scalar subqueries (including for non-deterministic functions), and additionally unlocks the compiled-predicate fast paths downstream.

**Safety conditions** (all required; otherwise the node is left untouched for the existing per-row cached path):
1. No outer/trigger/procedural evaluation context (top-level query only)
2. Syntactic correlation check (`is_correlated_cached`) reports uncorrelated
3. The caching layer's correlation-reference walk (`extract_correlation_values`) finds **zero** outer refs — guards the unqualified-column hazard documented in aggnested-1.4 / select1-18.x
4. Select list is statically exactly one column (multi-column `ScalarSubquery` nodes in row-value comparisons like `(a,b) = (SELECT x,y)` are not folded)
5. The one-shot evaluation succeeds (errors fall back to per-row, preserving lazy error semantics)

The traversal never descends into nested `SelectStmt` bodies (IN / EXISTS / quantified / subquery ASTs), so inner subqueries correlated to intermediate scopes are never touched.

## Changes

- `crates/vibesql-executor/src/evaluator/combined/subqueries/hoist.rs` (new): the hoist rewrite + safety conditions
- `crates/vibesql-executor/src/select/filter.rs`: apply hoist at the top of `apply_where_filter_combined_auto` (covers aggregation + non-aggregate materialized WHERE paths and everything auto dispatches to)
- `crates/vibesql-executor/src/select/scan/predicates.rs`: apply hoist in `apply_table_local_predicates` before the parallel per-row filter
- `crates/vibesql-executor/tests/uncorrelated_subquery_hoist_tests.rs` (new): 14 regression + correctness tests

## Before / after (100k-row table, release build)

| Query form | Before | After |
|---|---|---|
| `WHERE run_id = 5` (literal) | 0.06s wall | 0.06s wall |
| `WHERE run_id = (SELECT MAX(run_id) FROM t)` | **killed at 60s cap, 1,230 CPU-s at 2071% CPU, 0 rows** | **0.19s wall, 0.23s user** |

The remaining delta vs the literal form is the single aggregate scan the subquery legitimately costs.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Uncorrelated scalar subqueries in WHERE evaluated once (hoisted/cached) | ✅ | 100k-row reproducer: 0.19s wall vs killed-at-60s before; hoist replaces the node with a literal before any per-row work |
| Form B within ~2× of form A | ✅ | 0.23s user vs 0.04s + one unavoidable MAX scan; on absolute terms both are sub-0.2s wall vs 822 CPU-min hang before |
| Regression test on a table large enough to catch O(n²) (100k rows, time budget) | ✅ | `uncorrelated_scalar_subquery_where_is_not_quadratic` (100k rows, GROUP BY path) and `..._nonaggregate_is_not_quadratic` (50k rows), both under a 30s budget that O(n²) exceeds by orders of magnitude |
| Correlated subqueries still evaluate per row | ✅ | Two tests (two-table and same-table alias); all 10 correctness queries byte-compared against sqlite3 — identical |
| NULL-returning subquery | ✅ | `null_returning_subquery_filters_all_rows` (empty result → NULL, explicit NULL, IS NULL) |
| Subquery in HAVING / SELECT-list | ✅ | `uncorrelated_subquery_in_having`, `uncorrelated_subquery_in_select_list` |
| SQLite once-per-statement semantics for non-deterministic functions | ✅ | Hoist evaluates exactly once per statement, matching SQLite; previously the cache already gave once-per-statement on the sequential path |
| CLAUDE.md workaround note obsolete | ✅ | CLAUDE.md never gained a workaround note; its canonical queries use the subquery form, which now works — no doc change needed |

## Test Plan

- `cargo test --release -p vibesql-executor` — full suite, exit 0, zero failures
- New test file: 14/14 pass in 0.28s
- TCL conformance, worktree vs main baseline (identical): subquery2.test 18/18, select1.test 188/188, select4.test 123/123, in.test 114 pass/9 skip, where.test 168 pass/139 skip, subquery.test 81 skip (pre-existing), aggnested.test 5 skip (pre-existing)
- Manual CLI: 10-query correctness script (uncorrelated, correlated, NULL, BETWEEN bounds, row-value, HAVING, SELECT-list, mixed AND) diffed against sqlite3 — identical output
- `cargo check` / `cargo clippy` — no new warnings (6 pre-existing clippy notes in touched files confirmed present on main)

Closes #5809