### PR TITLE
fix(storage): rehydrate CHECK and FK constraints from sql_source on binary catalog load

### DIFF
--- a/crates/vibesql-executor/tests/constraint_rehydration_reload_tests.rs
+++ b/crates/vibesql-executor/tests/constraint_rehydration_reload_tests.rs
@@ -1,0 +1,345 @@
+//! End-to-end regression tests for issue #5834: CHECK constraints and
+//! FOREIGN KEY constraints (including referential actions) must enforce
+//! identically before and after a binary `.vbsql` save/reload — the
+//! cross-process reopen path used by the CLI and the TCL harness.
+//!
+//! Before the fix, the binary catalog load path rebuilt only columns +
+//! primary key + `sql_source`, silently dropping
+//! `TableSchema::check_constraints` and `TableSchema::foreign_keys`:
+//! violating INSERTs succeeded after reopen, `PRAGMA foreign_key_list`
+//! returned nothing, and ON DELETE/UPDATE actions never fired — while
+//! `sqlite_master.sql` still showed the constraint text. The load path now
+//! rehydrates both by re-parsing the persisted `sql_source`.
+
+use vibesql_ast::Statement;
+use vibesql_catalog::ReferentialAction;
+use vibesql_executor::{
+    CreateTableExecutor, DeleteExecutor, InsertExecutor, SelectExecutor, UpdateExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+/// Create a table preserving the verbatim source text (issue #5619), the way
+/// the CLI/load paths capture it. sql_source is what the reload path
+/// re-parses, so tests must go through this entry point.
+fn create_with_source(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse CREATE");
+    let Statement::CreateTable(create) = stmt else {
+        panic!("expected CREATE TABLE");
+    };
+    CreateTableExecutor::execute_with_source(&create, db, Some(sql)).expect("CREATE TABLE");
+}
+
+/// Execute a DML statement, returning Ok(()) or the error's Display text.
+fn exec(db: &mut Database, sql: &str) -> Result<(), String> {
+    let stmt = Parser::parse_sql(sql).map_err(|e| format!("parse error: {e:?}"))?;
+    match stmt {
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).map(|_| ()).map_err(|e| e.to_string())
+        }
+        Statement::Delete(s) => {
+            DeleteExecutor::execute(&s, db).map(|_| ()).map_err(|e| e.to_string())
+        }
+        Statement::Update(s) => {
+            UpdateExecutor::execute(&s, db).map(|_| ()).map_err(|e| e.to_string())
+        }
+        other => panic!("unsupported statement in test: {other:?}"),
+    }
+}
+
+/// COUNT(*) helper.
+fn count(db: &Database, table: &str) -> i64 {
+    let sql = format!("SELECT COUNT(*) FROM {table}");
+    let stmt = Parser::parse_sql(&sql).expect("parse SELECT");
+    let Statement::Select(select) = stmt else {
+        panic!("expected SELECT");
+    };
+    let result = SelectExecutor::new(db).execute_with_columns(&select).expect("SELECT");
+    match &result.rows[0].values[0] {
+        vibesql_types::SqlValue::Integer(n) => *n,
+        vibesql_types::SqlValue::Bigint(n) => *n,
+        other => panic!("unexpected COUNT value: {other:?}"),
+    }
+}
+
+/// Save to a binary `.vbsql` file and reload — the cross-process reopen path.
+/// Re-enables FK enforcement on the reloaded handle, mirroring the TCL shim's
+/// per-invocation `PRAGMA foreign_keys=ON` replay (the pragma itself is
+/// per-connection state in SQLite, not part of the file).
+fn reopen_binary(db: &Database, tag: &str) -> Database {
+    let path =
+        std::env::temp_dir().join(format!("vibesql_5834_{tag}_{}.vbsql", std::process::id()));
+    db.save_binary(&path).expect("save_binary");
+    let mut reloaded = Database::load_binary(&path).expect("load_binary");
+    std::fs::remove_file(&path).ok();
+    reloaded.set_foreign_keys_enabled(true);
+    reloaded
+}
+
+// ---------------------------------------------------------------------------
+// FK enforcement after reopen
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fk_insert_violation_errors_after_reopen() {
+    // The exact two-process repro from issue #5834 / the #5783 curator probe.
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    create_with_source(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER)");
+    create_with_source(&mut db, "CREATE TABLE t2(c INTEGER REFERENCES t1(a), d INTEGER)");
+
+    let mut db2 = reopen_binary(&db, "insert_violation");
+
+    // Constraint metadata must survive the reload (what PRAGMA
+    // foreign_key_list reads).
+    let schema = db2.catalog.get_table("t2").expect("t2 exists after reload");
+    assert_eq!(schema.foreign_keys.len(), 1, "FK must be rehydrated on reload");
+    assert_eq!(schema.foreign_keys[0].parent_table, "t1");
+    assert_eq!(schema.foreign_keys[0].parent_column_names, vec!["a".to_string()]);
+
+    // Violating insert must error in the fresh process (SQLite errors here;
+    // pre-fix VibeSQL accepted the row).
+    let err = exec(&mut db2, "INSERT INTO t2 VALUES(1, 3)")
+        .expect_err("orphan insert must fail after reopen");
+    assert!(
+        err.to_uppercase().contains("FOREIGN KEY"),
+        "expected FK violation wording, got: {err}"
+    );
+
+    // A satisfying parent row makes the same insert succeed.
+    exec(&mut db2, "INSERT INTO t1 VALUES(1, 0)").expect("parent insert");
+    exec(&mut db2, "INSERT INTO t2 VALUES(1, 3)").expect("child insert with parent present");
+}
+
+#[test]
+fn fk_on_delete_cascade_fires_after_reopen() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    create_with_source(&mut db, "CREATE TABLE p(x INTEGER PRIMARY KEY)");
+    create_with_source(
+        &mut db,
+        "CREATE TABLE c(y INTEGER REFERENCES p(x) ON DELETE CASCADE, z INTEGER)",
+    );
+    exec(&mut db, "INSERT INTO p VALUES(1)").unwrap();
+    exec(&mut db, "INSERT INTO p VALUES(2)").unwrap();
+    exec(&mut db, "INSERT INTO c VALUES(1, 10)").unwrap();
+    exec(&mut db, "INSERT INTO c VALUES(2, 20)").unwrap();
+
+    let mut db2 = reopen_binary(&db, "cascade");
+
+    // NOTE: deliberately no COUNT(*) on `c` before the DELETE. FK cascade
+    // actions mutate the child table without invalidating the columnar
+    // cache, so a pre-primed cached COUNT would read stale data. That is a
+    // pre-existing in-process bug (present without any save/reload),
+    // tracked separately as issue #5876 — this test targets reopen
+    // enforcement only.
+    exec(&mut db2, "DELETE FROM p WHERE x = 1").expect("parent delete");
+    assert_eq!(count(&db2, "c"), 1, "ON DELETE CASCADE must fire after reopen");
+    assert_eq!(count(&db2, "p"), 1);
+}
+
+#[test]
+fn fk_parent_delete_restricted_after_reopen() {
+    // Default NO ACTION: deleting a referenced parent row must error.
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    create_with_source(&mut db, "CREATE TABLE p(x INTEGER PRIMARY KEY)");
+    create_with_source(&mut db, "CREATE TABLE c(y INTEGER REFERENCES p(x))");
+    exec(&mut db, "INSERT INTO p VALUES(1)").unwrap();
+    exec(&mut db, "INSERT INTO c VALUES(1)").unwrap();
+
+    let mut db2 = reopen_binary(&db, "restrict");
+    let err = exec(&mut db2, "DELETE FROM p WHERE x = 1")
+        .expect_err("referenced parent delete must fail after reopen");
+    assert!(
+        err.to_uppercase().contains("FOREIGN KEY"),
+        "expected FK violation wording, got: {err}"
+    );
+}
+
+#[test]
+fn fk_on_update_set_null_fires_after_reopen() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    create_with_source(&mut db, "CREATE TABLE p(x INTEGER PRIMARY KEY)");
+    create_with_source(&mut db, "CREATE TABLE c(y INTEGER REFERENCES p(x) ON UPDATE SET NULL)");
+    exec(&mut db, "INSERT INTO p VALUES(1)").unwrap();
+    exec(&mut db, "INSERT INTO c VALUES(1)").unwrap();
+
+    let mut db2 = reopen_binary(&db, "set_null");
+    exec(&mut db2, "UPDATE p SET x = 5 WHERE x = 1").expect("parent update");
+
+    let sql = "SELECT COUNT(*) FROM c WHERE y IS NULL";
+    let Statement::Select(select) = Parser::parse_sql(sql).unwrap() else { unreachable!() };
+    let result = SelectExecutor::new(&db2).execute_with_columns(&select).expect("SELECT");
+    assert_eq!(
+        result.rows[0].values[0],
+        vibesql_types::SqlValue::Integer(1),
+        "ON UPDATE SET NULL must fire after reopen"
+    );
+}
+
+#[test]
+fn all_referential_actions_round_trip_in_metadata() {
+    let actions = [
+        ("CASCADE", ReferentialAction::Cascade),
+        ("SET NULL", ReferentialAction::SetNull),
+        ("SET DEFAULT", ReferentialAction::SetDefault),
+        ("RESTRICT", ReferentialAction::Restrict),
+        ("NO ACTION", ReferentialAction::NoAction),
+    ];
+
+    let mut db = Database::new();
+    create_with_source(&mut db, "CREATE TABLE p(x INTEGER PRIMARY KEY)");
+    for (i, (sql_action, _)) in actions.iter().enumerate() {
+        create_with_source(
+            &mut db,
+            &format!(
+                "CREATE TABLE c{i}(y INTEGER REFERENCES p(x) \
+                 ON DELETE {sql_action} ON UPDATE {sql_action})"
+            ),
+        );
+    }
+
+    let db2 = reopen_binary(&db, "actions");
+    for (i, (sql_action, expected)) in actions.iter().enumerate() {
+        let schema = db2.catalog.get_table(&format!("c{i}")).expect("child table");
+        assert_eq!(schema.foreign_keys.len(), 1, "c{i} must keep its FK");
+        let fk = &schema.foreign_keys[0];
+        assert_eq!(&fk.on_delete, expected, "ON DELETE {sql_action} must survive reload");
+        assert_eq!(&fk.on_update, expected, "ON UPDATE {sql_action} must survive reload");
+    }
+}
+
+#[test]
+fn composite_fk_enforces_after_reopen() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    create_with_source(&mut db, "CREATE TABLE p(a INTEGER, b INTEGER, PRIMARY KEY(a, b))");
+    create_with_source(
+        &mut db,
+        "CREATE TABLE c(x INTEGER, y INTEGER, FOREIGN KEY(x, y) REFERENCES p(a, b))",
+    );
+    exec(&mut db, "INSERT INTO p VALUES(1, 2)").unwrap();
+
+    let mut db2 = reopen_binary(&db, "composite");
+
+    let schema = db2.catalog.get_table("c").expect("c exists");
+    assert_eq!(schema.foreign_keys.len(), 1);
+    assert_eq!(schema.foreign_keys[0].column_names, vec!["x".to_string(), "y".to_string()]);
+
+    exec(&mut db2, "INSERT INTO c VALUES(1, 2)").expect("matching composite key");
+    let err = exec(&mut db2, "INSERT INTO c VALUES(1, 3)")
+        .expect_err("non-matching composite key must fail after reopen");
+    assert!(err.to_uppercase().contains("FOREIGN KEY"), "got: {err}");
+}
+
+#[test]
+fn self_referential_fk_enforces_after_reopen() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    create_with_source(
+        &mut db,
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES t(id))",
+    );
+    exec(&mut db, "INSERT INTO t VALUES(1, NULL)").unwrap();
+
+    let mut db2 = reopen_binary(&db, "self_ref");
+    exec(&mut db2, "INSERT INTO t VALUES(2, 1)").expect("valid self-ref");
+    let err = exec(&mut db2, "INSERT INTO t VALUES(3, 99)")
+        .expect_err("dangling self-ref must fail after reopen");
+    assert!(err.to_uppercase().contains("FOREIGN KEY"), "got: {err}");
+}
+
+#[test]
+fn deferrable_initially_deferred_survives_reopen() {
+    let mut db = Database::new();
+    create_with_source(&mut db, "CREATE TABLE p(x INTEGER PRIMARY KEY)");
+    create_with_source(
+        &mut db,
+        "CREATE TABLE c(y INTEGER REFERENCES p(x) DEFERRABLE INITIALLY DEFERRED)",
+    );
+
+    let db2 = reopen_binary(&db, "deferred");
+    let fk = &db2.catalog.get_table("c").expect("c exists").foreign_keys[0];
+    assert!(fk.is_deferrable, "DEFERRABLE must survive reload");
+    assert!(fk.initially_deferred, "INITIALLY DEFERRED must survive reload");
+}
+
+#[test]
+fn child_stored_before_parent_still_resolves_after_reopen() {
+    // Table order in the binary file is not creation order; parent column
+    // indices must resolve even when the child precedes its parent. Creating
+    // the child first also exercises the SQLite behavior of storing FK
+    // metadata before the parent exists.
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    create_with_source(&mut db, "CREATE TABLE child(y INTEGER REFERENCES parent(x))");
+    create_with_source(&mut db, "CREATE TABLE parent(pad INTEGER, x INTEGER PRIMARY KEY)");
+    exec(&mut db, "INSERT INTO parent VALUES(0, 7)").unwrap();
+
+    let mut db2 = reopen_binary(&db, "order");
+    exec(&mut db2, "INSERT INTO child VALUES(7)").expect("valid child row");
+    let err = exec(&mut db2, "INSERT INTO child VALUES(8)")
+        .expect_err("orphan child row must fail after reopen");
+    assert!(err.to_uppercase().contains("FOREIGN KEY"), "got: {err}");
+}
+
+// ---------------------------------------------------------------------------
+// CHECK enforcement after reopen
+// ---------------------------------------------------------------------------
+
+#[test]
+fn column_level_check_enforces_after_reopen() {
+    // Mirrors the istrue-521..524 failure class: CHECK silently dropped on
+    // reload, so violating inserts succeeded in a fresh process.
+    let mut db = Database::new();
+    create_with_source(&mut db, "CREATE TABLE t(a INTEGER CHECK(a > 0))");
+    exec(&mut db, "INSERT INTO t VALUES(1)").unwrap();
+
+    let mut db2 = reopen_binary(&db, "check_col");
+    let schema = db2.catalog.get_table("t").expect("t exists");
+    assert_eq!(schema.check_constraints.len(), 1, "CHECK must be rehydrated on reload");
+
+    exec(&mut db2, "INSERT INTO t VALUES(2)").expect("passing row");
+    let err = exec(&mut db2, "INSERT INTO t VALUES(-1)")
+        .expect_err("CHECK violation must fail after reopen");
+    assert!(err.to_uppercase().contains("CHECK"), "got: {err}");
+    assert_eq!(count(&db2, "t"), 2);
+}
+
+#[test]
+fn named_table_level_check_enforces_after_reopen() {
+    let mut db = Database::new();
+    create_with_source(
+        &mut db,
+        "CREATE TABLE t(a INTEGER, b INTEGER, CONSTRAINT ab_sum CHECK(a + b < 100))",
+    );
+
+    let mut db2 = reopen_binary(&db, "check_table");
+    let schema = db2.catalog.get_table("t").expect("t exists");
+    assert_eq!(schema.check_constraints.len(), 1);
+    assert_eq!(schema.check_constraints[0].0, "ab_sum", "explicit CHECK name must survive");
+
+    exec(&mut db2, "INSERT INTO t VALUES(1, 2)").expect("passing row");
+    let err = exec(&mut db2, "INSERT INTO t VALUES(60, 60)")
+        .expect_err("named CHECK violation must fail after reopen");
+    assert!(
+        err.to_uppercase().contains("CHECK") && err.contains("ab_sum"),
+        "error should name the constraint, got: {err}"
+    );
+}
+
+#[test]
+fn check_enforcement_matches_before_and_after_reopen() {
+    // Acceptance criterion: identical enforcement pre/post reopen.
+    let mut db = Database::new();
+    create_with_source(&mut db, "CREATE TABLE t(a INTEGER CHECK(a BETWEEN 1 AND 10))");
+
+    let before = exec(&mut db, "INSERT INTO t VALUES(11)").expect_err("violates before save");
+
+    let mut db2 = reopen_binary(&db, "check_parity");
+    let after = exec(&mut db2, "INSERT INTO t VALUES(11)").expect_err("violates after reload");
+
+    assert_eq!(before, after, "CHECK errors must be identical before and after reopen");
+}

--- a/crates/vibesql-storage/src/persistence/binary/catalog.rs
+++ b/crates/vibesql-storage/src/persistence/binary/catalog.rs
@@ -526,6 +526,16 @@ pub fn read_catalog_v<R: Read>(reader: &mut R, version: u8) -> Result<Database, 
         table_schemas.push((table_name, columns, primary_key, quoted, sql_source, without_rowid));
     }
 
+    // Build a column-name lookup covering EVERY table in the file, so FK
+    // parent column indices can be resolved during rehydration regardless of
+    // the order tables appear in (a child may be stored before its parent).
+    let parent_lookup: super::constraints::ParentColumnLookup = table_schemas
+        .iter()
+        .map(|(name, columns, ..)| {
+            (name.to_lowercase(), columns.iter().map(|c| c.name.clone()).collect())
+        })
+        .collect();
+
     // Create tables
     for (table_name, columns, primary_key, quoted, sql_source, without_rowid) in table_schemas {
         let mut schema = if let Some(pk_cols) = primary_key {
@@ -543,6 +553,14 @@ pub fn read_catalog_v<R: Read>(reader: &mut R, version: u8) -> Result<Database, 
 
         // Restore the WITHOUT ROWID flag (v12+, issue #5796).
         schema.without_rowid = without_rowid;
+
+        // Rebuild CHECK and FOREIGN KEY constraint state from the persisted
+        // CREATE TABLE source (issue #5834). The binary format has no
+        // dedicated fields for these; without this re-parse every reloaded
+        // schema silently stopped enforcing them. Must run BEFORE
+        // create_table_with_identifier so both schema copies (catalog +
+        // storage Table) carry the constraints, matching CREATE TABLE.
+        super::constraints::rehydrate_constraints_from_sql_source(&mut schema, &parent_lookup)?;
 
         // Use TableIdentifier to preserve case-sensitivity semantics
         let identifier = vibesql_catalog::TableIdentifier::from_canonical(table_name, quoted);

--- a/crates/vibesql-storage/src/persistence/binary/constraints.rs
+++ b/crates/vibesql-storage/src/persistence/binary/constraints.rs
@@ -1,0 +1,463 @@
+// ============================================================================
+// Constraint Rehydration for the Binary Catalog Load Path (issue #5834)
+// ============================================================================
+//
+// The binary catalog persists each table's columns, primary key, and the
+// verbatim `CREATE TABLE` source text (`sql_source`, format v9+), but it does
+// NOT serialize `TableSchema::check_constraints` or
+// `TableSchema::foreign_keys` as dedicated fields. Before this module
+// existed, a reloaded schema silently dropped both: violating INSERTs
+// succeeded after a process restart, `PRAGMA foreign_key_list` returned no
+// rows, and ON DELETE/UPDATE actions (CASCADE etc.) never fired — even
+// though `sqlite_master.sql` still showed the constraint text.
+//
+// Fix: re-parse the persisted `sql_source` with the full main-parser grammar
+// (the same grammar that accepted it at CREATE TABLE time — DDL never goes
+// through the arena parser) and map the parsed CHECK and FOREIGN KEY clauses
+// back onto the loaded `TableSchema`. This mirrors how views, expression
+// indexes, and partial-index WHERE clauses already persist-as-SQL and
+// re-parse on load (issues #5619 / #5833 / PR #5863), and requires no binary
+// format bump.
+//
+// The mapping below intentionally replicates the semantics of the CREATE
+// TABLE execution path (`vibesql-executor/src/create_table.rs` +
+// `ConstraintValidator::process_constraints`), which cannot be called from
+// this crate (the executor depends on storage, not vice versa):
+//
+// - CHECK constraint names: explicit `CONSTRAINT <name>` when given,
+//   otherwise the expression's SQL text (SQLite-compatible error messages).
+//   Column-level CHECKs are collected first (in column order), then
+//   table-level CHECKs, matching `ConstraintValidator`.
+// - FK ordering: table-level constraints in declaration order, then
+//   column-level `REFERENCES` constraints in REVERSE column order (SQLite's
+//   FK id assignment, mirrored from `create_table.rs`).
+// - Implicit parent keys (`REFERENCES p` with no column list): parent column
+//   names are stored as empty strings and indices as 0, exactly like the
+//   CREATE path; enforcement resolves the parent's PK by name at runtime.
+// - Unknown parent tables keep placeholder indices (SQLite stores FK
+//   metadata even when the parent doesn't exist yet).
+//
+// A `sql_source` that fails to re-parse, or that is not a CREATE TABLE
+// statement, is a hard load error — never a silently-unenforced constraint —
+// following the recovery-failure policy established for expression indexes
+// (issue #5833).
+
+use std::collections::HashMap;
+
+use crate::StorageError;
+
+/// Column-name lookup for every table present in the catalog being loaded,
+/// keyed by lowercased table name. Used to resolve FK parent column indices
+/// regardless of the (arbitrary) order tables appear in the file.
+pub(super) type ParentColumnLookup = HashMap<String, Vec<String>>;
+
+/// Convert an AST referential action (optional; absent = NO ACTION) into the
+/// catalog representation. Mirrors `convert_action` in the executor's CREATE
+/// TABLE path.
+fn convert_action(
+    action: &Option<vibesql_ast::ReferentialAction>,
+) -> vibesql_catalog::ReferentialAction {
+    match action.as_ref().unwrap_or(&vibesql_ast::ReferentialAction::NoAction) {
+        vibesql_ast::ReferentialAction::Cascade => vibesql_catalog::ReferentialAction::Cascade,
+        vibesql_ast::ReferentialAction::SetNull => vibesql_catalog::ReferentialAction::SetNull,
+        vibesql_ast::ReferentialAction::SetDefault => {
+            vibesql_catalog::ReferentialAction::SetDefault
+        }
+        vibesql_ast::ReferentialAction::Restrict => vibesql_catalog::ReferentialAction::Restrict,
+        vibesql_ast::ReferentialAction::NoAction => vibesql_catalog::ReferentialAction::NoAction,
+    }
+}
+
+/// Resolve a column name to its index within `columns`, matching
+/// `TableSchema::get_column_index` semantics: exact match first, then
+/// case-insensitive fallback.
+fn find_column_index(columns: &[String], name: &str) -> Option<usize> {
+    if let Some(idx) = columns.iter().position(|c| c == name) {
+        return Some(idx);
+    }
+    let lower = name.to_lowercase();
+    columns.iter().position(|c| c.to_lowercase() == lower)
+}
+
+/// Resolve the parent-side column names/indices for one FK clause.
+///
+/// When no parent column list was given (`REFERENCES p`), SQLite stores an
+/// empty "to" name per FK column and the enforcement layer resolves the
+/// parent's PRIMARY KEY at runtime; we replicate that with empty strings and
+/// placeholder 0 indices. When the parent table is not in the lookup (it may
+/// legitimately not exist), indices fall back to placeholder 0 — the runtime
+/// resolver in the executor prefers name-based resolution anyway.
+fn resolve_parent_columns(
+    parent_table: &str,
+    references_columns: &[String],
+    fk_column_count: usize,
+    parents: &ParentColumnLookup,
+) -> (Vec<String>, Vec<usize>) {
+    if references_columns.is_empty() {
+        return (vec![String::new(); fk_column_count], vec![0; fk_column_count]);
+    }
+
+    let parent_cols = parents.get(&parent_table.to_lowercase());
+    let indices: Vec<usize> = references_columns
+        .iter()
+        .map(|name| parent_cols.and_then(|cols| find_column_index(cols, name)).unwrap_or(0))
+        .collect();
+    (references_columns.to_vec(), indices)
+}
+
+/// Rebuild `check_constraints` and `foreign_keys` on a freshly loaded
+/// `TableSchema` by re-parsing its persisted `sql_source`.
+///
+/// No-op when the schema has no `sql_source` (pre-v9 files, or tables whose
+/// source was invalidated by ALTER TABLE — those fall back to the previous
+/// behavior). Errors when the source no longer parses or disagrees with the
+/// stored column set, so constraint loss is never silent.
+pub(super) fn rehydrate_constraints_from_sql_source(
+    schema: &mut vibesql_catalog::TableSchema,
+    parents: &ParentColumnLookup,
+) -> Result<(), StorageError> {
+    let Some(src) = schema.sql_source.clone() else {
+        return Ok(());
+    };
+
+    let stmt = vibesql_parser::Parser::parse_sql(&src).map_err(|e| {
+        StorageError::NotImplemented(format!(
+            "Failed to re-parse CREATE TABLE source for table '{}' while rehydrating \
+             constraints: {} (source: {})",
+            schema.name, e, src
+        ))
+    })?;
+
+    let create = match stmt {
+        vibesql_ast::Statement::CreateTable(create) => create,
+        other => {
+            return Err(StorageError::NotImplemented(format!(
+                "Persisted sql_source for table '{}' is not a CREATE TABLE statement \
+                 (parsed as {:?})",
+                schema.name,
+                std::mem::discriminant(&other)
+            )));
+        }
+    };
+
+    // CREATE TABLE ... AS SELECT carries no constraint clauses.
+    if create.as_query.is_some() {
+        return Ok(());
+    }
+
+    // ---- CHECK constraints (column-level first, then table-level) ----
+    // Matches ConstraintValidator::process_constraints ordering and naming.
+    let mut check_constraints: Vec<(String, vibesql_ast::Expression)> = Vec::new();
+    for col_def in &create.columns {
+        for constraint in &col_def.constraints {
+            if let vibesql_ast::ColumnConstraintKind::Check(expr) = &constraint.kind {
+                use vibesql_ast::pretty_print::ToSql;
+                let name = constraint.name.clone().unwrap_or_else(|| expr.to_sql());
+                check_constraints.push((name, (**expr).clone()));
+            }
+        }
+    }
+    for table_constraint in &create.table_constraints {
+        if let vibesql_ast::TableConstraintKind::Check { expr } = &table_constraint.kind {
+            use vibesql_ast::pretty_print::ToSql;
+            let name = table_constraint.name.clone().unwrap_or_else(|| expr.to_sql());
+            check_constraints.push((name, (**expr).clone()));
+        }
+    }
+    schema.check_constraints = check_constraints;
+
+    // ---- FOREIGN KEY constraints ----
+    let mut foreign_keys: Vec<vibesql_catalog::ForeignKeyConstraint> = Vec::new();
+
+    // Table-level FKs, in declaration order.
+    for constraint in &create.table_constraints {
+        if let vibesql_ast::TableConstraintKind::ForeignKey {
+            columns: fk_columns,
+            references_table,
+            references_columns,
+            on_delete,
+            on_update,
+            deferral,
+        } = &constraint.kind
+        {
+            let column_indices: Vec<usize> = fk_columns
+                .iter()
+                .map(|col_name| {
+                    schema.get_column_index(col_name).ok_or_else(|| {
+                        StorageError::NotImplemented(format!(
+                            "FK column '{}' from persisted sql_source not found in loaded \
+                             schema for table '{}'",
+                            col_name, schema.name
+                        ))
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let (parent_column_names, parent_column_indices) = resolve_parent_columns(
+                references_table,
+                references_columns,
+                fk_columns.len(),
+                parents,
+            );
+
+            let (is_deferrable, initially_deferred) =
+                deferral.map(|d| (d.is_deferrable, d.initially_deferred)).unwrap_or((false, false));
+
+            foreign_keys.push(vibesql_catalog::ForeignKeyConstraint {
+                name: constraint.name.clone(),
+                column_names: fk_columns.clone(),
+                column_indices,
+                parent_table: references_table.clone(),
+                parent_column_names,
+                parent_column_indices,
+                on_delete: convert_action(on_delete),
+                on_update: convert_action(on_update),
+                is_deferrable,
+                initially_deferred,
+            });
+        }
+    }
+
+    // Column-level REFERENCES, added in REVERSE column order to match
+    // SQLite's FK id assignment (mirrored from create_table.rs).
+    let mut column_level_fks: Vec<vibesql_catalog::ForeignKeyConstraint> = Vec::new();
+    for col_def in &create.columns {
+        for constraint in &col_def.constraints {
+            if let vibesql_ast::ColumnConstraintKind::References {
+                table: ref_table,
+                column: ref_column,
+                on_delete,
+                on_update,
+                deferral,
+            } = &constraint.kind
+            {
+                let col_idx = schema.get_column_index(&col_def.name).ok_or_else(|| {
+                    StorageError::NotImplemented(format!(
+                        "FK column '{}' from persisted sql_source not found in loaded \
+                         schema for table '{}'",
+                        col_def.name, schema.name
+                    ))
+                })?;
+
+                let (parent_col_name, parent_col_idx) = if let Some(col) = ref_column {
+                    let idx = parents
+                        .get(&ref_table.to_lowercase())
+                        .and_then(|cols| find_column_index(cols, col))
+                        .unwrap_or(0);
+                    (col.clone(), idx)
+                } else {
+                    // Implicit parent PK: empty name + placeholder index,
+                    // resolved by the enforcement layer at runtime.
+                    (String::new(), 0)
+                };
+
+                let (is_deferrable, initially_deferred) = deferral
+                    .map(|d| (d.is_deferrable, d.initially_deferred))
+                    .unwrap_or((false, false));
+
+                column_level_fks.push(vibesql_catalog::ForeignKeyConstraint {
+                    name: constraint.name.clone(),
+                    column_names: vec![col_def.name.clone()],
+                    column_indices: vec![col_idx],
+                    parent_table: ref_table.clone(),
+                    parent_column_names: vec![parent_col_name],
+                    parent_column_indices: vec![parent_col_idx],
+                    on_delete: convert_action(on_delete),
+                    on_update: convert_action(on_update),
+                    is_deferrable,
+                    initially_deferred,
+                });
+            }
+        }
+    }
+    foreign_keys.extend(column_level_fks.into_iter().rev());
+
+    schema.foreign_keys = foreign_keys;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use vibesql_catalog::{ColumnSchema, ReferentialAction, TableSchema};
+    use vibesql_types::DataType;
+
+    use super::*;
+
+    fn col(name: &str) -> ColumnSchema {
+        ColumnSchema::new(name.to_string(), DataType::Integer, true)
+    }
+
+    fn schema_with_source(name: &str, columns: Vec<ColumnSchema>, src: &str) -> TableSchema {
+        let mut schema = TableSchema::new(name.to_string(), columns);
+        schema.set_sql_source(src.to_string());
+        schema
+    }
+
+    #[test]
+    fn no_sql_source_is_a_noop() {
+        let mut schema = TableSchema::new("t".to_string(), vec![col("a")]);
+        rehydrate_constraints_from_sql_source(&mut schema, &HashMap::new()).unwrap();
+        assert!(schema.check_constraints.is_empty());
+        assert!(schema.foreign_keys.is_empty());
+    }
+
+    #[test]
+    fn rehydrates_column_and_table_level_checks() {
+        let mut schema = schema_with_source(
+            "t",
+            vec![col("a"), col("b")],
+            "CREATE TABLE t(a INTEGER CHECK(a > 0), b INTEGER, \
+             CONSTRAINT b_pos CHECK(b > 0))",
+        );
+        rehydrate_constraints_from_sql_source(&mut schema, &HashMap::new()).unwrap();
+
+        assert_eq!(schema.check_constraints.len(), 2);
+        // Unnamed column-level CHECK gets the expression's to_sql() text as
+        // its name (same derivation as ConstraintValidator at CREATE time).
+        assert_eq!(schema.check_constraints[0].0, "a>0");
+        // Named table-level CHECK keeps its explicit name.
+        assert_eq!(schema.check_constraints[1].0, "b_pos");
+    }
+
+    #[test]
+    fn rehydrates_column_level_fk_with_actions() {
+        let mut parents = HashMap::new();
+        parents.insert("p".to_string(), vec!["x".to_string(), "y".to_string()]);
+
+        let mut schema = schema_with_source(
+            "c",
+            vec![col("a"), col("b")],
+            "CREATE TABLE c(a INTEGER REFERENCES p(y) ON DELETE CASCADE ON UPDATE SET NULL, \
+             b INTEGER)",
+        );
+        rehydrate_constraints_from_sql_source(&mut schema, &parents).unwrap();
+
+        assert_eq!(schema.foreign_keys.len(), 1);
+        let fk = &schema.foreign_keys[0];
+        assert_eq!(fk.column_names, vec!["a".to_string()]);
+        assert_eq!(fk.column_indices, vec![0]);
+        assert_eq!(fk.parent_table, "p");
+        assert_eq!(fk.parent_column_names, vec!["y".to_string()]);
+        assert_eq!(fk.parent_column_indices, vec![1]);
+        assert_eq!(fk.on_delete, ReferentialAction::Cascade);
+        assert_eq!(fk.on_update, ReferentialAction::SetNull);
+    }
+
+    #[test]
+    fn rehydrates_composite_table_level_fk() {
+        let mut parents = HashMap::new();
+        parents.insert("p".to_string(), vec!["x".to_string(), "y".to_string()]);
+
+        let mut schema = schema_with_source(
+            "c",
+            vec![col("a"), col("b")],
+            "CREATE TABLE c(a INTEGER, b INTEGER, \
+             FOREIGN KEY(b, a) REFERENCES p(y, x) ON DELETE RESTRICT)",
+        );
+        rehydrate_constraints_from_sql_source(&mut schema, &parents).unwrap();
+
+        assert_eq!(schema.foreign_keys.len(), 1);
+        let fk = &schema.foreign_keys[0];
+        assert_eq!(fk.column_names, vec!["b".to_string(), "a".to_string()]);
+        assert_eq!(fk.column_indices, vec![1, 0]);
+        assert_eq!(fk.parent_column_names, vec!["y".to_string(), "x".to_string()]);
+        assert_eq!(fk.parent_column_indices, vec![1, 0]);
+        assert_eq!(fk.on_delete, ReferentialAction::Restrict);
+        assert_eq!(fk.on_update, ReferentialAction::NoAction);
+    }
+
+    #[test]
+    fn implicit_parent_pk_stores_empty_names_and_placeholder_indices() {
+        let mut parents = HashMap::new();
+        parents.insert("p".to_string(), vec!["x".to_string()]);
+
+        let mut schema =
+            schema_with_source("c", vec![col("a")], "CREATE TABLE c(a INTEGER REFERENCES p)");
+        rehydrate_constraints_from_sql_source(&mut schema, &parents).unwrap();
+
+        assert_eq!(schema.foreign_keys.len(), 1);
+        let fk = &schema.foreign_keys[0];
+        // SQLite stores an empty "to" name for implicit PK references;
+        // enforcement resolves the parent PK at runtime.
+        assert_eq!(fk.parent_column_names, vec![String::new()]);
+        assert_eq!(fk.parent_column_indices, vec![0]);
+    }
+
+    #[test]
+    fn missing_parent_table_keeps_placeholder_indices() {
+        let mut schema = schema_with_source(
+            "c",
+            vec![col("a")],
+            "CREATE TABLE c(a INTEGER REFERENCES nowhere(z))",
+        );
+        rehydrate_constraints_from_sql_source(&mut schema, &HashMap::new()).unwrap();
+
+        assert_eq!(schema.foreign_keys.len(), 1);
+        let fk = &schema.foreign_keys[0];
+        assert_eq!(fk.parent_table, "nowhere");
+        assert_eq!(fk.parent_column_names, vec!["z".to_string()]);
+        assert_eq!(fk.parent_column_indices, vec![0]);
+    }
+
+    #[test]
+    fn column_level_fks_are_added_in_reverse_order() {
+        // Mirrors SQLite's FK id assignment, and the executor CREATE path.
+        let mut parents = HashMap::new();
+        parents.insert("p".to_string(), vec!["x".to_string()]);
+
+        let mut schema = schema_with_source(
+            "c",
+            vec![col("a"), col("b")],
+            "CREATE TABLE c(a INTEGER REFERENCES p(x), b INTEGER REFERENCES p(x))",
+        );
+        rehydrate_constraints_from_sql_source(&mut schema, &parents).unwrap();
+
+        assert_eq!(schema.foreign_keys.len(), 2);
+        assert_eq!(schema.foreign_keys[0].column_names, vec!["b".to_string()]);
+        assert_eq!(schema.foreign_keys[1].column_names, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn deferrable_initially_deferred_survives() {
+        let mut parents = HashMap::new();
+        parents.insert("p".to_string(), vec!["x".to_string()]);
+
+        let mut schema = schema_with_source(
+            "c",
+            vec![col("a")],
+            "CREATE TABLE c(a INTEGER REFERENCES p(x) DEFERRABLE INITIALLY DEFERRED)",
+        );
+        rehydrate_constraints_from_sql_source(&mut schema, &parents).unwrap();
+
+        let fk = &schema.foreign_keys[0];
+        assert!(fk.is_deferrable);
+        assert!(fk.initially_deferred);
+    }
+
+    #[test]
+    fn self_referential_fk_resolves_against_own_columns() {
+        let mut parents = HashMap::new();
+        parents.insert("t".to_string(), vec!["id".to_string(), "parent_id".to_string()]);
+
+        let mut schema = schema_with_source(
+            "t",
+            vec![col("id"), col("parent_id")],
+            "CREATE TABLE t(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES t(id))",
+        );
+        rehydrate_constraints_from_sql_source(&mut schema, &parents).unwrap();
+
+        let fk = &schema.foreign_keys[0];
+        assert_eq!(fk.parent_table, "t");
+        assert_eq!(fk.column_indices, vec![1]);
+        assert_eq!(fk.parent_column_indices, vec![0]);
+    }
+
+    #[test]
+    fn unparseable_sql_source_is_a_hard_error() {
+        let mut schema = TableSchema::new("t".to_string(), vec![col("a")]);
+        schema.set_sql_source("CREATE GIBBERISH t(".to_string());
+        let err = rehydrate_constraints_from_sql_source(&mut schema, &HashMap::new());
+        assert!(err.is_err(), "constraint loss must never be silent");
+    }
+}

--- a/crates/vibesql-storage/src/persistence/binary/mod.rs
+++ b/crates/vibesql-storage/src/persistence/binary/mod.rs
@@ -21,6 +21,7 @@ use crate::{Database, StorageError};
 
 // Public submodules
 pub mod catalog;
+pub(crate) mod constraints;
 pub mod data;
 pub mod expression;
 pub mod format;


### PR DESCRIPTION
## Summary

The binary `.vbsql` catalog never serialized `TableSchema::check_constraints` or `TableSchema::foreign_keys`, and the load path (`read_catalog_v`) rebuilt only columns + primary key + `sql_source`. Every fresh process therefore silently lost constraint enforcement: violating INSERTs succeeded after reopen, `PRAGMA foreign_key_list` returned no rows, and ON DELETE/UPDATE actions (CASCADE etc.) never fired — while `sqlite_master.sql` still showed the constraint text. Since the TCL harness runs each test in a fresh CLI process against a persisted DB, this one bug dominated the FK failure clusters (`e_fkey-11.*` alone ~128 failures). This is Phase 1 of the #5783 FK conformance plan.

**Fix:** on catalog load, re-parse the persisted `sql_source` with the full main-parser grammar (the same grammar that accepted it at CREATE TABLE time — DDL never goes through the arena parser) and map the parsed CHECK and FOREIGN KEY clauses back onto the loaded `TableSchema`. This is the persist-as-SQL/re-parse-on-load pattern already used for views, expression indexes, and partial-index WHERE clauses (#5619/#5833, PRs #5828/#5863). **No binary format bump.**

## Changes

- **New: `crates/vibesql-storage/src/persistence/binary/constraints.rs`** — `rehydrate_constraints_from_sql_source`, replicating the executor CREATE TABLE semantics (which cannot be called from storage due to crate dependency direction):
  - CHECK names: explicit `CONSTRAINT <name>`, else the expression's `to_sql()` text; column-level first, then table-level (matches `ConstraintValidator`)
  - FKs: table-level in declaration order, then column-level REFERENCES in reverse column order (SQLite FK id assignment); referential actions, DEFERRABLE/INITIALLY DEFERRED, composite keys, and implicit-parent-PK (empty "to" + placeholder index) all preserved
  - Parent column indices resolve against a lookup covering every table in the file, so a child stored before its parent still resolves; genuinely missing parents keep placeholder indices (CREATE-time behavior; the executor resolves by name at runtime)
  - An unparseable / non-CREATE-TABLE `sql_source` is a **hard load error** — never a silently-unenforced constraint (#5833 recovery-failure policy). No `sql_source` (pre-v9 file, ALTER-invalidated source) keeps prior behavior.
- **`crates/vibesql-storage/src/persistence/binary/catalog.rs`** — call rehydration in the table-create loop, *before* `create_table_with_identifier`, so both schema copies (catalog + storage `Table`) carry the constraints, exactly like CREATE TABLE. WAL checkpoint recovery reads through the same `read_catalog_v` (`crates/vibesql-storage/src/wal/recovery.rs:468`), so it is covered automatically — verified via the CLI repros below, which run with WAL-active mode (the default).
- **New: `crates/vibesql-executor/tests/constraint_rehydration_reload_tests.rs`** — 12 end-to-end save/reload tests (details below)
- 10 unit tests in the new storage module

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Issue's two-process repro errors in process 2 | ✅ | CLI: `INSERT INTO t2 VALUES(1,3)` after reopen → `FOREIGN KEY constraint ... violated` (exit 1); pre-fix it succeeded |
| `PRAGMA foreign_key_list` non-empty after reopen | ✅ | CLI: returns the `t2→t1(a)` row after reopen |
| ON DELETE CASCADE fires after reopen | ✅ | CLI: `DELETE FROM p WHERE x=1` in a fresh process cascades child (2→1 rows); also integration test |
| CHECK enforces identically before/after reopen | ✅ | CLI: column-level (`CHECK constraint failed: a>0`) and named table-level (`... failed: bsum`) both error after reopen; `check_enforcement_matches_before_and_after_reopen` asserts identical error text pre/post |
| FK enforces identically before/after reopen | ✅ | Integration tests: insert violation, parent-delete restriction, ON UPDATE SET NULL, composite FK, self-ref FK, all five referential actions' metadata, DEFERRABLE INITIALLY DEFERRED, child-stored-before-parent ordering |
| Regression tests covering the reopen path | ✅ | 12 integration tests + 10 unit tests, all passing |

## Test Plan

- `cargo test -p vibesql-storage`: **804 passed, 0 failed** (760 lib + 3 integration targets)
- `cargo test -p vibesql-executor`: **138 targets, 4906 passed, 0 failed**, with two pre-existing non-mine exclusions, both reproduced independent of this change:
  - `deep_expression_tests::test_deep_case_expressions` — stack overflow, fails identically on the main checkout
  - `test_parallel_nested_loop_large_dataset` — 300s query-timeout only under heavy machine load; passes in 60s on this branch on a quiet machine (baseline without my change: 62s — indistinguishable)
- `make test-tcl-file FILE=fkey1.test`: **19 passed / 1 failed / 6 skipped** vs baseline 18/2/6 — only `fkey1-8.1` remains (known Phase-3 partial-index straggler from the #5783 decomposition)
- `make test-tcl-file FILE=e_fkey.test`: first run hit the 1200s per-file timeout on a **loaded machine** (a concurrent TCL run from another session was active): salvaged partial = 739 passed / 165 failed / 21 skipped of 925 attempted (baseline for the full file: 137 failed). A quiet-machine rerun with a raised timeout is in progress; I will post the full numbers and the `e_fkey-11.*` cluster delta as a follow-up comment. Cross-process CLI probes (the exact mechanism e_fkey-11 detects) all pass.

## Out-of-scope findings (filed separately)

- **#5876** — pre-existing, reload-independent: FK cascade actions don't invalidate the columnar cache, so a COUNT primed before an ON DELETE CASCADE reads stale data. Discovered while writing these tests; reproduced without any save/reload.
- WAL **log replay** of `WalOp::CreateTable` (crash recovery between checkpoints, `deserialize_table_schema`) carries only name+columns — it drops PK and constraints and predates this PR; checkpoint-based recovery (the normal path) is fixed by this PR.

Closes #5834

🤖 Generated with [Claude Code](https://claude.com/claude-code)