### PR TITLE
feat(sql): COLLATE in table PK/UNIQUE key lists + minimal writable_schema UPDATE (alterdropcol 7.x/8.x)

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -1299,6 +1299,20 @@ impl SqlExecutor {
                         message: None,
                     })
                 }
+                "WRITABLE_SCHEMA" => {
+                    // SQLite-compatible PRAGMA writable_schema: when ON,
+                    // UPDATE sqlite_master/sqlite_schema SET sql = ... may
+                    // rewrite the stored CREATE TABLE source text (issue
+                    // #5796; alterdropcol 8.x). Session-scoped, default OFF.
+                    self.db.set_writable_schema(bool_value);
+                    Ok(QueryResult {
+                        rows: Vec::new(),
+                        columns: Vec::new(),
+                        row_count: 0,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
                 "DEFER_FOREIGN_KEYS" => {
                     // SQLite-compatible PRAGMA defer_foreign_keys.
                     // Phase C1 of #5085: store/read the flag and auto-reset
@@ -1405,6 +1419,18 @@ impl SqlExecutor {
                     let value = if self.db.recursive_triggers() { "1" } else { "0" };
                     Ok(QueryResult {
                         columns: vec!["recursive_triggers".to_string()],
+                        rows: vec![vec![Some(value.to_string())]],
+                        row_count: 1,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
+                "WRITABLE_SCHEMA" => {
+                    // SQLite-compatible PRAGMA writable_schema read.
+                    // Defaults to 0 (OFF).
+                    let value = if self.db.writable_schema() { "1" } else { "0" };
+                    Ok(QueryResult {
+                        columns: vec!["writable_schema".to_string()],
                         rows: vec![vec![Some(value.to_string())]],
                         row_count: 1,
                         execution_time_ms: None,

--- a/crates/vibesql-executor/src/sqlite_schema.rs
+++ b/crates/vibesql-executor/src/sqlite_schema.rs
@@ -79,6 +79,43 @@ pub fn get_sqlite_schema_table_schema() -> TableSchema {
     )
 }
 
+/// Whether `index` is the implicit PRIMARY KEY autoindex of a WITHOUT ROWID
+/// table and must therefore be hidden from `sqlite_master` listings.
+///
+/// In SQLite, the PRIMARY KEY of a WITHOUT ROWID table *is* the table's B-tree
+/// — no separate `sqlite_autoindex_*` entry exists for it in `sqlite_master`
+/// (verified against sqlite3 3.51.0: `CREATE TABLE t(a, b, PRIMARY KEY(a))
+/// WITHOUT ROWID` yields only the `table` row; a `UNIQUE` constraint on the
+/// same table still gets its autoindex row). VibeSQL materializes a real
+/// unique index for the WITHOUT ROWID PK internally (uniqueness enforcement
+/// and planning), so we filter it out at listing time instead. Covers
+/// alterdropcol 7.2, where `SELECT sql FROM sqlite_schema` must return only
+/// the CREATE TABLE row.
+fn is_without_rowid_pk_autoindex(
+    catalog: &vibesql_catalog::Catalog,
+    index: &vibesql_catalog::IndexMetadata,
+) -> bool {
+    if !index.name.starts_with("sqlite_autoindex_") {
+        return false;
+    }
+    let Some(table) = catalog.get_table(&index.table_name) else {
+        return false;
+    };
+    if !table.without_rowid {
+        return false;
+    }
+    let Some(pk_cols) = &table.primary_key else {
+        return false;
+    };
+    // Match the index column list against the PK column list (a UNIQUE
+    // autoindex on the same WITHOUT ROWID table keeps its listing).
+    pk_cols.len() == index.columns.len()
+        && pk_cols
+            .iter()
+            .zip(index.columns.iter())
+            .all(|(pk, ic)| ic.column_name().is_some_and(|name| name.eq_ignore_ascii_case(pk)))
+}
+
 /// Build a single sqlite_master-format row.
 fn schema_row(obj_type: &str, name: &str, tbl_name: &str, sql: String) -> Row {
     Row::new(vec![
@@ -118,6 +155,9 @@ pub fn execute_sqlite_schema_query(
     // Add indexes owned by the main schema. Temp-table indexes are tagged with
     // their temp schema (#5513) and surface only via sqlite_temp_master.
     for index in catalog.get_schema_indexes(vibesql_catalog::DEFAULT_SCHEMA) {
+        if is_without_rowid_pk_autoindex(catalog, index) {
+            continue;
+        }
         let sql = generate_create_index_sql(index);
         rows.push(schema_row("index", &index.name, &index.table_name, sql));
     }
@@ -148,6 +188,135 @@ pub fn execute_sqlite_schema_query(
     }
 
     Ok(SelectResult { columns: column_names, rows })
+}
+
+/// SQLite WHERE-clause truthiness for schema-row selection: booleans as-is,
+/// non-zero numerics true, everything else (including NULL) false.
+fn schema_where_is_truthy(value: &SqlValue) -> bool {
+    match value {
+        SqlValue::Boolean(b) => *b,
+        SqlValue::Integer(n) => *n != 0,
+        SqlValue::Smallint(n) => *n != 0,
+        SqlValue::Bigint(n) => *n != 0,
+        SqlValue::Unsigned(n) => *n != 0,
+        SqlValue::Float(f) => *f != 0.0,
+        SqlValue::Real(f) => *f != 0.0,
+        SqlValue::Double(f) => *f != 0.0,
+        SqlValue::Numeric(f) => *f != 0.0,
+        _ => false,
+    }
+}
+
+/// Execute an `UPDATE sqlite_master` / `UPDATE sqlite_schema` statement under
+/// `PRAGMA writable_schema=ON`.
+///
+/// SQLite's writable_schema lets a connection rewrite `sqlite_master.sql`
+/// directly; the modified text becomes the object's schema on the next reload.
+/// VibeSQL implements the minimal subset the conformance suite exercises
+/// (alterdropcol 8.x, issue #5796):
+///
+/// - Only assignments to the `sql` column are supported, and the assigned
+///   value must evaluate to a string.
+/// - Only `table` rows are rewritten: the new text replaces the table's
+///   verbatim `sql_source`, which is what `SELECT sql FROM sqlite_schema`
+///   echoes and what ALTER TABLE's textual schema rewrites operate on. The
+///   structured (parsed) schema is NOT re-derived from the new text — like
+///   SQLite, writable_schema trades integrity checking for direct access, so
+///   callers can make the stored text diverge from the live schema.
+/// - Matching `index`/`view`/`trigger` rows are left untouched (their `sql`
+///   is reconstructed from catalog metadata, not stored verbatim).
+///
+/// The row count returned is the number of schema rows matched by the WHERE
+/// clause, mirroring SQLite's changes() semantics.
+pub fn execute_sqlite_schema_update(
+    stmt: &vibesql_ast::UpdateStmt,
+    database: &mut vibesql_storage::Database,
+) -> Result<usize, ExecutorError> {
+    if stmt.from_clause.is_some() {
+        return Err(ExecutorError::UnsupportedFeature(
+            "UPDATE ... FROM is not supported on sqlite_master".to_string(),
+        ));
+    }
+
+    // Only `SET sql = <expr>` is supported in the writable_schema subset.
+    for assignment in &stmt.assignments {
+        if !assignment.column.eq_ignore_ascii_case("sql") {
+            return Err(ExecutorError::UnsupportedFeature(format!(
+                "writable_schema UPDATE supports only the sql column, not '{}'",
+                assignment.column
+            )));
+        }
+    }
+
+    let schema = get_sqlite_schema_table_schema();
+    let evaluator = crate::evaluator::ExpressionEvaluator::new(&schema);
+    let current = execute_sqlite_schema_query(&database.catalog)?;
+
+    // Collect (table_name, new_sql) updates first, then apply: applying while
+    // iterating would alias the catalog borrow held by the row snapshot.
+    let mut matched = 0usize;
+    let mut table_updates: Vec<(String, String)> = Vec::new();
+    for row in &current.rows {
+        if let Some(where_clause) = &stmt.where_clause {
+            let matches = match where_clause {
+                vibesql_ast::WhereClause::Condition(expr) => {
+                    schema_where_is_truthy(&evaluator.eval(expr, row)?)
+                }
+                vibesql_ast::WhereClause::CurrentOf(_) => {
+                    return Err(ExecutorError::UnsupportedFeature(
+                        "WHERE CURRENT OF is not supported on sqlite_master".to_string(),
+                    ));
+                }
+            };
+            if !matches {
+                continue;
+            }
+        }
+        matched += 1;
+
+        let (SqlValue::Varchar(obj_type), SqlValue::Varchar(name)) =
+            (&row.values[0], &row.values[1])
+        else {
+            continue;
+        };
+        if obj_type.as_str() != "table" {
+            // Index/view/trigger sql is reconstructed from catalog metadata;
+            // rewriting it verbatim is outside the supported subset.
+            continue;
+        }
+
+        for assignment in &stmt.assignments {
+            let value = evaluator.eval(&assignment.value, row)?;
+            let new_sql = match value {
+                SqlValue::Varchar(s) | SqlValue::Character(s) => s.to_string(),
+                other => {
+                    return Err(ExecutorError::UnsupportedFeature(format!(
+                        "writable_schema UPDATE requires a string value for sql, got {:?}",
+                        other
+                    )));
+                }
+            };
+            table_updates.push((name.to_string(), new_sql));
+        }
+    }
+
+    for (table_name, new_sql) in table_updates {
+        // Update the storage-side schema, then mirror it into the catalog —
+        // the two hold separate copies that must stay identical (same pattern
+        // as ALTER TABLE's sync_catalog_schema_from_storage, issue #5625).
+        let synced = match database.get_table_mut(&table_name) {
+            Some(table) => {
+                table.schema_mut().set_sql_source(new_sql);
+                Some(table.schema.clone())
+            }
+            None => None,
+        };
+        if let Some(schema) = synced {
+            database.catalog.replace_table_schema(&table_name, schema);
+        }
+    }
+
+    Ok(matched)
 }
 
 /// Execute a `sqlite_temp_master` / `sqlite_temp_schema` query.
@@ -183,6 +352,9 @@ pub fn execute_sqlite_temp_schema_query(
 
     // Add indexes owned by the temp schema.
     for index in catalog.get_schema_indexes(temp_schema) {
+        if is_without_rowid_pk_autoindex(catalog, index) {
+            continue;
+        }
         let sql = generate_create_index_sql(index);
         rows.push(schema_row("index", &index.name, &index.table_name, sql));
     }
@@ -1019,5 +1191,189 @@ mod tests {
         assert!(sql.contains("CREATE VIEW test_view"));
         // With column list specified
         assert!(sql.contains("(col1)"));
+    }
+
+    /// Issue #5796 (alterdropcol 7.2): the implicit PRIMARY KEY autoindex of a
+    /// WITHOUT ROWID table must be hidden from sqlite_master (in SQLite the PK
+    /// *is* the table b-tree), while a UNIQUE-constraint autoindex on the same
+    /// table and a PK autoindex on an ordinary rowid table stay listed.
+    #[test]
+    fn test_without_rowid_pk_autoindex_hidden_from_sqlite_master() {
+        let mut catalog = Catalog::new();
+
+        let make_cols = || {
+            vec![
+                ColumnSchema::new("a".to_string(), DataType::Integer, true),
+                ColumnSchema::new("b".to_string(), DataType::Integer, true),
+            ]
+        };
+
+        // WITHOUT ROWID table with PK(a) and UNIQUE(b).
+        let mut wr =
+            TableSchema::with_primary_key("t_wr".to_string(), make_cols(), vec!["a".to_string()]);
+        wr.without_rowid = true;
+        catalog.create_table(wr).unwrap();
+        catalog
+            .add_index(IndexMetadata::new(
+                "sqlite_autoindex_t_wr_1".to_string(),
+                "t_wr".to_string(),
+                IndexType::BTree,
+                vec![IndexedColumn::new_column("a".to_string(), SortOrder::Ascending)],
+                true,
+            ))
+            .unwrap();
+        catalog
+            .add_index(IndexMetadata::new(
+                "sqlite_autoindex_t_wr_2".to_string(),
+                "t_wr".to_string(),
+                IndexType::BTree,
+                vec![IndexedColumn::new_column("b".to_string(), SortOrder::Ascending)],
+                true,
+            ))
+            .unwrap();
+
+        // Ordinary rowid table with a (non-INTEGER-PK-alias) PK autoindex.
+        let rowid = TableSchema::with_primary_key(
+            "t_rowid".to_string(),
+            make_cols(),
+            vec!["a".to_string()],
+        );
+        catalog.create_table(rowid).unwrap();
+        catalog
+            .add_index(IndexMetadata::new(
+                "sqlite_autoindex_t_rowid_1".to_string(),
+                "t_rowid".to_string(),
+                IndexType::BTree,
+                vec![IndexedColumn::new_column("a".to_string(), SortOrder::Ascending)],
+                true,
+            ))
+            .unwrap();
+
+        let result = execute_sqlite_schema_query(&catalog).unwrap();
+        let index_names: Vec<String> = result
+            .rows
+            .iter()
+            .filter(|r| matches!(&r.values[0], SqlValue::Varchar(s) if s.as_str() == "index"))
+            .map(|r| match &r.values[1] {
+                SqlValue::Varchar(s) => s.to_string(),
+                other => panic!("Expected VARCHAR index name, got {other:?}"),
+            })
+            .collect();
+
+        assert!(
+            !index_names.contains(&"sqlite_autoindex_t_wr_1".to_string()),
+            "WITHOUT ROWID PK autoindex must be hidden, got {index_names:?}"
+        );
+        assert!(
+            index_names.contains(&"sqlite_autoindex_t_wr_2".to_string()),
+            "UNIQUE autoindex on WITHOUT ROWID table must stay listed, got {index_names:?}"
+        );
+        assert!(
+            index_names.contains(&"sqlite_autoindex_t_rowid_1".to_string()),
+            "rowid-table PK autoindex must stay listed, got {index_names:?}"
+        );
+    }
+
+    fn parse_update(sql: &str) -> vibesql_ast::UpdateStmt {
+        match vibesql_parser::Parser::parse_sql(sql).unwrap() {
+            vibesql_ast::Statement::Update(stmt) => stmt,
+            other => panic!("Expected UPDATE statement, got {other:?}"),
+        }
+    }
+
+    fn writable_schema_test_db() -> vibesql_storage::Database {
+        let mut db = vibesql_storage::Database::new();
+        for name in ["t1", "t2"] {
+            let mut schema = TableSchema::new(
+                name.to_string(),
+                vec![ColumnSchema::new("a".to_string(), DataType::Integer, true)],
+            );
+            schema.set_sql_source(format!("CREATE TABLE {name}(a)"));
+            db.create_table_with_identifier(
+                schema,
+                vibesql_catalog::TableIdentifier::new(name, false),
+            )
+            .unwrap();
+        }
+        db
+    }
+
+    /// Issue #5796 (alterdropcol 8.x): under writable_schema, UPDATE
+    /// sqlite_schema SET sql = '...' rewrites the stored CREATE TABLE source
+    /// text of the matching table rows.
+    #[test]
+    fn test_writable_schema_update_rewrites_sql_source_with_where() {
+        let mut db = writable_schema_test_db();
+        let stmt = parse_update(
+            "UPDATE sqlite_schema SET sql = 'CREATE TABLE t2(a, b)' WHERE name = 't2'",
+        );
+
+        let matched = execute_sqlite_schema_update(&stmt, &mut db).unwrap();
+        assert_eq!(matched, 1);
+        assert_eq!(
+            db.catalog.get_table("t2").unwrap().sql_source.as_deref(),
+            Some("CREATE TABLE t2(a, b)")
+        );
+        // Non-matching row untouched.
+        assert_eq!(
+            db.catalog.get_table("t1").unwrap().sql_source.as_deref(),
+            Some("CREATE TABLE t1(a)")
+        );
+    }
+
+    /// A WHERE-less UPDATE (alterdropcol 8.0 form) matches every schema row.
+    #[test]
+    fn test_writable_schema_update_without_where_matches_all_tables() {
+        let mut db = writable_schema_test_db();
+        let stmt = parse_update("UPDATE sqlite_schema SET sql = 'CREATE TABLE x(a)'");
+
+        let matched = execute_sqlite_schema_update(&stmt, &mut db).unwrap();
+        assert_eq!(matched, 2);
+        for name in ["t1", "t2"] {
+            assert_eq!(
+                db.catalog.get_table(name).unwrap().sql_source.as_deref(),
+                Some("CREATE TABLE x(a)"),
+                "table {name} must be rewritten"
+            );
+        }
+    }
+
+    /// Assignments to columns other than `sql` are outside the supported
+    /// writable_schema subset and must be rejected, not silently ignored.
+    #[test]
+    fn test_writable_schema_update_rejects_non_sql_column() {
+        let mut db = writable_schema_test_db();
+        let stmt = parse_update("UPDATE sqlite_schema SET name = 'oops'");
+
+        let err = execute_sqlite_schema_update(&stmt, &mut db).unwrap_err();
+        assert!(matches!(err, ExecutorError::UnsupportedFeature(_)), "got {err:?}");
+    }
+
+    /// The UPDATE executor keeps rejecting schema-table writes when
+    /// writable_schema is OFF (the default) and routes them to the
+    /// writable_schema path when ON.
+    #[test]
+    fn test_update_executor_gates_sqlite_schema_on_writable_schema_pragma() {
+        let mut db = writable_schema_test_db();
+        let stmt = parse_update(
+            "UPDATE sqlite_schema SET sql = 'CREATE TABLE t1(a, b)' WHERE name = 't1'",
+        );
+
+        // Default: read-only error.
+        let err = crate::UpdateExecutor::execute(&stmt, &mut db).unwrap_err();
+        assert!(matches!(err, ExecutorError::SqliteSystemTableReadOnly { .. }), "got {err:?}");
+        assert_eq!(
+            db.catalog.get_table("t1").unwrap().sql_source.as_deref(),
+            Some("CREATE TABLE t1(a)")
+        );
+
+        // With PRAGMA writable_schema=ON: the rewrite goes through.
+        db.set_writable_schema(true);
+        let matched = crate::UpdateExecutor::execute(&stmt, &mut db).unwrap();
+        assert_eq!(matched, 1);
+        assert_eq!(
+            db.catalog.get_table("t1").unwrap().sql_source.as_deref(),
+            Some("CREATE TABLE t1(a, b)")
+        );
     }
 }

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -46,8 +46,14 @@ pub(super) fn execute_internal(
     procedural_context: Option<&crate::procedural::ExecutionContext>,
     trigger_context: Option<&crate::trigger_execution::TriggerContext>,
 ) -> Result<(usize, Option<crate::select::SelectResult>), ExecutorError> {
-    // Check if target is sqlite_master/sqlite_schema (read-only system table)
+    // Check if target is sqlite_master/sqlite_schema. Read-only by default;
+    // under PRAGMA writable_schema=ON, a supported subset of UPDATEs rewrites
+    // the stored CREATE TABLE source text (issue #5796; alterdropcol 8.x).
     if is_sqlite_schema_table(&stmt.table_name) {
+        if database.writable_schema() {
+            let matched = crate::sqlite_schema::execute_sqlite_schema_update(stmt, database)?;
+            return Ok((matched, None));
+        }
         return Err(ExecutorError::SqliteSystemTableReadOnly {
             table_name: stmt.table_name.clone(),
             operation: "modified".to_string(),

--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -170,6 +170,34 @@ impl Parser {
             None
         };
 
+        // Optional COLLATE clause (SQLite grammar allows a per-column collation
+        // inside table-level PRIMARY KEY / UNIQUE column lists, e.g.
+        // `PRIMARY KEY(a COLLATE nocase, a)` — verified against sqlite3 3.51.0).
+        // Parsed and accepted for grammar compatibility; the collation is not
+        // yet carried into `IndexColumn`, matching the CREATE INDEX column-list
+        // behavior in `parser/index.rs` which also parses and discards it.
+        if self.peek_keyword(crate::keywords::Keyword::Collate) {
+            self.advance(); // consume COLLATE
+            let _collation = match self.peek() {
+                Token::Identifier(name) | Token::DelimitedIdentifier(name) => {
+                    let name = name.clone();
+                    self.advance();
+                    name
+                }
+                Token::Keyword { keyword: kw, .. } => {
+                    // Allow keywords like BINARY, NOCASE, RTRIM as collation names
+                    let name = kw.to_string();
+                    self.advance();
+                    name
+                }
+                _ => {
+                    return Err(ParseError {
+                        message: "Expected collation name after COLLATE".to_string(),
+                    })
+                }
+            };
+        }
+
         // Check for optional ASC/DESC
         let direction = if self.peek_keyword(crate::keywords::Keyword::Asc) {
             self.advance();

--- a/crates/vibesql-parser/src/tests/create_table/constraints_table.rs
+++ b/crates/vibesql-parser/src/tests/create_table/constraints_table.rs
@@ -610,3 +610,75 @@ fn test_parse_foreign_key_deferrable_with_actions() {
         _ => panic!("Expected CREATE TABLE statement"),
     }
 }
+
+// ========================================================================
+// COLLATE inside table-level PRIMARY KEY / UNIQUE column lists (issue #5796)
+//
+// SQLite's grammar allows a per-column COLLATE (and ASC/DESC) inside the
+// table-constraint key column list, e.g.
+//   CREATE TABLE t1(a, b, c, PRIMARY KEY(a COLLATE nocase, a)) WITHOUT ROWID
+// (verified against sqlite3 3.51.0; exercised by alterdropcol 7.0-7.3).
+// ========================================================================
+
+#[test]
+fn test_parse_table_level_primary_key_with_collate() {
+    let result = Parser::parse_sql(
+        "CREATE TABLE t1(a, b, c, PRIMARY KEY(a COLLATE nocase, a)) WITHOUT ROWID",
+    );
+    assert!(result.is_ok(), "Should parse PRIMARY KEY(a COLLATE nocase, a): {:?}", result.err());
+
+    match result.unwrap() {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_constraints.len(), 1);
+            match &create.table_constraints[0].kind {
+                vibesql_ast::TableConstraintKind::PrimaryKey { columns, .. } => {
+                    assert_eq!(columns.len(), 2);
+                    assert_eq!(columns[0].expect_column_name(), "a");
+                    assert_eq!(columns[1].expect_column_name(), "a");
+                }
+                _ => panic!("Expected PRIMARY KEY constraint"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_table_level_primary_key_with_collate_and_direction() {
+    // COLLATE precedes ASC/DESC in SQLite's indexed-column grammar.
+    let result =
+        Parser::parse_sql("CREATE TABLE t1(a, b, PRIMARY KEY(a COLLATE nocase DESC, b ASC))");
+    assert!(result.is_ok(), "Should parse COLLATE followed by DESC: {:?}", result.err());
+
+    match result.unwrap() {
+        vibesql_ast::Statement::CreateTable(create) => match &create.table_constraints[0].kind {
+            vibesql_ast::TableConstraintKind::PrimaryKey { columns, .. } => {
+                assert_eq!(columns.len(), 2);
+                assert_eq!(columns[0].direction(), vibesql_ast::OrderDirection::Desc);
+                assert_eq!(columns[1].direction(), vibesql_ast::OrderDirection::Asc);
+            }
+            _ => panic!("Expected PRIMARY KEY constraint"),
+        },
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_table_level_unique_with_collate() {
+    // The same indexed-column grammar backs UNIQUE table constraints.
+    let result = Parser::parse_sql("CREATE TABLE t1(a, b, UNIQUE(a COLLATE rtrim))");
+    assert!(result.is_ok(), "Should parse UNIQUE(a COLLATE rtrim): {:?}", result.err());
+}
+
+#[test]
+fn test_parse_table_level_primary_key_collate_keyword_collation_name() {
+    // BINARY is a keyword but must be accepted as a collation name.
+    let result = Parser::parse_sql("CREATE TABLE t1(a, b, PRIMARY KEY(a COLLATE BINARY))");
+    assert!(result.is_ok(), "Should accept keyword collation name: {:?}", result.err());
+}
+
+#[test]
+fn test_parse_table_level_primary_key_collate_missing_name_is_error() {
+    let result = Parser::parse_sql("CREATE TABLE t1(a, b, PRIMARY KEY(a COLLATE))");
+    assert!(result.is_err(), "COLLATE without a collation name must be a parse error");
+}

--- a/crates/vibesql-storage/src/database/session.rs
+++ b/crates/vibesql-storage/src/database/session.rs
@@ -228,6 +228,28 @@ impl Database {
         );
     }
 
+    /// Get the writable_schema PRAGMA setting (SQLite compatibility).
+    ///
+    /// When ON, `UPDATE sqlite_master/sqlite_schema SET sql = ...` is allowed
+    /// to rewrite the stored `CREATE TABLE` source text of schema objects (see
+    /// `vibesql-executor::sqlite_schema::execute_sqlite_schema_update`).
+    /// Defaults to OFF, matching SQLite; when OFF, all writes to the schema
+    /// tables are rejected with "table sqlite_master may not be modified".
+    pub fn writable_schema(&self) -> bool {
+        match self.get_session_variable("WRITABLE_SCHEMA") {
+            Some(vibesql_types::SqlValue::Integer(n)) => *n != 0,
+            _ => false, // Default: OFF (SQLite compatibility)
+        }
+    }
+
+    /// Set the writable_schema PRAGMA setting (SQLite compatibility).
+    pub fn set_writable_schema(&mut self, value: bool) {
+        self.set_session_variable(
+            "WRITABLE_SCHEMA",
+            vibesql_types::SqlValue::Integer(if value { 1 } else { 0 }),
+        );
+    }
+
     /// Get the defer_foreign_keys PRAGMA setting (SQLite compatibility).
     ///
     /// When ON, enforcement of all foreign key constraints is delayed until

--- a/crates/vibesql-storage/src/persistence/binary/catalog.rs
+++ b/crates/vibesql-storage/src/persistence/binary/catalog.rs
@@ -129,6 +129,11 @@ pub fn write_catalog<W: Write>(writer: &mut W, db: &Database) -> Result<(), Stor
                     write_bool(writer, false)?;
                 }
             }
+
+            // Write the WITHOUT ROWID flag (v12+, issue #5796). Reloaded
+            // schemas need it so sqlite_master keeps hiding the implicit
+            // PRIMARY KEY autoindex of a WITHOUT ROWID table across processes.
+            write_bool(writer, table.schema.without_rowid)?;
         }
     }
 
@@ -514,11 +519,15 @@ pub fn read_catalog_v<R: Read>(reader: &mut R, version: u8) -> Result<Database, 
             None
         };
 
-        table_schemas.push((table_name, columns, primary_key, quoted, sql_source));
+        // Read the WITHOUT ROWID flag (v12+, issue #5796). v11-and-earlier
+        // files do not include it; default to false (prior behavior).
+        let without_rowid = if version >= 12 { read_bool(reader)? } else { false };
+
+        table_schemas.push((table_name, columns, primary_key, quoted, sql_source, without_rowid));
     }
 
     // Create tables
-    for (table_name, columns, primary_key, quoted, sql_source) in table_schemas {
+    for (table_name, columns, primary_key, quoted, sql_source, without_rowid) in table_schemas {
         let mut schema = if let Some(pk_cols) = primary_key {
             vibesql_catalog::TableSchema::with_primary_key(table_name.clone(), columns, pk_cols)
         } else {
@@ -531,6 +540,9 @@ pub fn read_catalog_v<R: Read>(reader: &mut R, version: u8) -> Result<Database, 
         if let Some(src) = sql_source {
             schema.set_sql_source(src);
         }
+
+        // Restore the WITHOUT ROWID flag (v12+, issue #5796).
+        schema.without_rowid = without_rowid;
 
         // Use TableIdentifier to preserve case-sensitivity semantics
         let identifier = vibesql_catalog::TableIdentifier::from_canonical(table_name, quoted);
@@ -1146,6 +1158,61 @@ mod tests {
 
         let table = reloaded.get_table("t2").expect("t2 must survive the round-trip");
         assert_eq!(table.schema.sql_source, None);
+    }
+
+    /// Issue #5796 (v12): the WITHOUT ROWID flag must survive a binary catalog
+    /// round-trip. Before v12 the flag was not serialized, so a reloaded
+    /// WITHOUT ROWID table forgot it was rowid-less and `sqlite_master`
+    /// wrongly listed its implicit PRIMARY KEY autoindex across processes
+    /// (alterdropcol 7.2).
+    #[test]
+    fn test_binary_catalog_without_rowid_round_trip() {
+        let mut db = Database::new();
+        let make_col = |name: &str| vibesql_catalog::ColumnSchema {
+            name: name.to_string(),
+            data_type: vibesql_types::DataType::Integer,
+            nullable: true,
+            default_value: None,
+            generated_expr: None,
+            collation: None,
+            is_exact_integer_type: true,
+        };
+
+        let mut wr_schema = vibesql_catalog::TableSchema::with_primary_key(
+            "t_wr".to_string(),
+            vec![make_col("a"), make_col("b")],
+            vec!["a".to_string()],
+        );
+        wr_schema.without_rowid = true;
+        db.create_table_with_identifier(
+            wr_schema,
+            vibesql_catalog::TableIdentifier::new("t_wr", false),
+        )
+        .unwrap();
+
+        let rowid_schema = vibesql_catalog::TableSchema::with_primary_key(
+            "t_rowid".to_string(),
+            vec![make_col("a"), make_col("b")],
+            vec!["a".to_string()],
+        );
+        db.create_table_with_identifier(
+            rowid_schema,
+            vibesql_catalog::TableIdentifier::new("t_rowid", false),
+        )
+        .unwrap();
+
+        let mut buf = Vec::new();
+        write_catalog(&mut buf, &db).unwrap();
+        let reloaded = read_catalog_v(&mut &buf[..], VERSION).unwrap();
+
+        assert!(
+            reloaded.get_table("t_wr").expect("t_wr must survive").schema.without_rowid,
+            "WITHOUT ROWID flag must survive binary persistence (issue #5796)"
+        );
+        assert!(
+            !reloaded.get_table("t_rowid").expect("t_rowid must survive").schema.without_rowid,
+            "rowid table must stay rowid after reload"
+        );
     }
 
     /// Issue #5771: views must survive a binary catalog round-trip. Before v10

--- a/crates/vibesql-storage/src/persistence/binary/format.rs
+++ b/crates/vibesql-storage/src/persistence/binary/format.rs
@@ -50,7 +50,15 @@ pub const MAGIC: &[u8; 5] = b"VBSQL";
 ///        earlier files remain readable: the read path is gated on
 ///        `version >= 11` and treats absence as `generated_expr = None`
 ///        (prior behavior). Issue #5794.
-pub const VERSION: u8 = 11;
+/// - v12: Added `TableSchema::without_rowid` persistence per table (one bool
+///        after `sql_source`). Without it, a reloaded WITHOUT ROWID table
+///        forgets it is rowid-less, so `sqlite_master` wrongly lists its
+///        implicit PRIMARY KEY autoindex (SQLite never lists a WITHOUT ROWID
+///        PK autoindex — the PK *is* the table b-tree; alterdropcol 7.2).
+///        v11 and earlier files remain readable: the read path is gated on
+///        `version >= 12` and treats absence as `without_rowid = false`
+///        (prior behavior). Issue #5796.
+pub const VERSION: u8 = 12;
 
 /// Type tags for binary serialization
 #[repr(u8)]

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -4163,6 +4163,18 @@ variable vibesql_skip_patterns {
     {date4- "compares VibeSQL strftime against the C library strftime; shim only stubs the TCL strftime command via clock format, so expected values are computed by the stub rather than libc (harness limitation)"}
 }
 
+# Tests allowed through the blanket "modifies sqlite_schema" skip in
+# uses_sqlite_internals. VibeSQL supports a minimal PRAGMA writable_schema
+# subset (UPDATE sqlite_schema SET sql = '<CREATE TABLE text>' rewrites the
+# table's stored source text — issue #5796), which is exactly what these
+# tests exercise. The blanket skip stays in place for everything else because
+# most writable_schema tests inject corruption and assert recovery behavior
+# VibeSQL does not implement. Keyed by testprefix-qualified test name.
+variable vibesql_writable_schema_ok
+array set vibesql_writable_schema_ok {
+    alterdropcol-8.0 1
+}
+
 # Check if a test should be skipped based on VibeSQL-specific exclusions
 # Returns a list: {should_skip reason} where should_skip is 0/1
 proc vibesql_should_skip {name} {
@@ -4702,7 +4714,21 @@ proc do_test {name script expected} {
             [string match "*conflict resolution clause*" $reason]
             && [string trim $expected] eq ""
         }]
-        if {!$is_conflict_setup} {
+        # writable_schema allowlist: VibeSQL supports the minimal
+        # UPDATE-sqlite_schema-under-writable_schema subset these specific
+        # tests need (issue #5796), so let them run instead of skipping.
+        set is_writable_schema_ok 0
+        if {[string match "*modifies sqlite_schema*" $reason]} {
+            variable vibesql_writable_schema_ok
+            set ws_name $name
+            if {[info exists ::testprefix] && $::testprefix ne ""} {
+                set ws_name "${::testprefix}-${name}"
+            }
+            if {[info exists vibesql_writable_schema_ok($ws_name)]} {
+                set is_writable_schema_ok 1
+            }
+        }
+        if {!$is_conflict_setup && !$is_writable_schema_ok} {
             reconcile_skipped_txn_state $script
             omit_test $name $reason
             return


### PR DESCRIPTION
## Summary

Fixes the six remaining `alterdropcol.test` failures (7.0-7.3, 8.1, 8.2) — Phase 3 of #5784. Two features: SQLite's per-column `COLLATE` inside table-level `PRIMARY KEY(...)`/`UNIQUE(...)` column lists, and a minimal `PRAGMA writable_schema` subset that lets `UPDATE sqlite_schema SET sql = '<text>'` rewrite a table's stored CREATE TABLE source text.

**alterdropcol.test: 91 passed / 6 failed / 3 skipped before → 98 passed / 0 failed / 2 skipped after.**

## Changes

- **parser** (`create/constraints.rs`): `parse_index_column_spec` accepts an optional `COLLATE <name>` after the column name (before ASC/DESC), matching sqlite3 3.51.0 grammar (`PRIMARY KEY(a COLLATE nocase, a)`). Follows the existing CREATE INDEX column-list precedent (parse and accept; collation not yet carried into `IndexColumn`).
- **sqlite_master listing** (`sqlite_schema.rs`): hide the implicit PRIMARY KEY autoindex of WITHOUT ROWID tables (in SQLite the PK *is* the table b-tree — no `sqlite_autoindex_*` row; verified against sqlite3). UNIQUE autoindexes on the same table and PK autoindexes on rowid tables stay listed.
- **storage** (binary format **v12**): persist `TableSchema::without_rowid` (one bool per table after `sql_source`). Backward compatible: v11-and-earlier files read fine (absence = false); forward-version files are rejected by the existing `read_header` guard.
- **executor + CLI**: `PRAGMA writable_schema` get/set (session variable, default OFF) and `execute_sqlite_schema_update` — supports `SET sql = <string>` (only) with optional WHERE, rewrites `sql_source` of matching **table** rows, syncing storage + catalog copies (same pattern as ALTER's schema sync). With the pragma OFF, schema-table writes keep the existing "may not be modified" error.
- **TCL shim** (`tester_vibesql.tcl`): name-keyed allowlist (`vibesql_writable_schema_ok`, currently only `alterdropcol-8.0`) through the blanket "modifies sqlite_schema" skip. All other writable_schema tests across the suite remain skipped, so there is no suite-wide blast radius.

## What was deliberately NOT done (issue asked for evaluation)

- `alterdropcol` **6.0/6.1** remain skipped: they inject a corrupt schema (a table row whose `sql` is a CREATE INDEX/CREATE VIEW text) and assert `database disk image is malformed` from the next ALTER. That requires corruption detection on schema reload, which VibeSQL's structured catalog doesn't do — out of the minimal subset. They stay skip-listed (status quo; they were already skipped and not counted as failures).
- Test **5.1** (sqlite_schema row ordering) is out of scope — tracked by #5826; it passed in the final runs here.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Parser accepts `PRIMARY KEY(col COLLATE name [ASC\|DESC])` | ✅ | 5 new parser unit tests (incl. keyword collation names + missing-name error); verified `CREATE TABLE t(a,b,PRIMARY KEY(a COLLATE nocase)) WITHOUT ROWID` matches sqlite3 |
| alterdropcol 7.0-7.3 pass | ✅ | `make test-tcl-file FILE=alterdropcol.test`: 98 passed / 0 failed |
| alterdropcol 8.1/8.2 pass (writable_schema residuals) | ✅ | Same run; verified persistence across process reopen manually (`db close; sqlite3 db test.db` shape) |
| No regressions in create-table TCL files | ✅ | `altertab.test` 27/0 and `alter.test` 40 passed / 61 failed match prior baseline exactly; `index.test` 69/0; `table.test` partial run (timed out at 1200s on a loaded machine) shows the same failure set as baseline, no new failures; `altercol.test` failures verified **pre-existing** on the main-branch binary (RENAME COLUMN index-metadata bug — filed #5877) |
| `cargo test -p vibesql-parser -p vibesql-executor` green | ✅ | Full release-mode suites for parser + executor + storage all pass (0 failed) |

## Test Plan

- `make test-tcl-file FILE=alterdropcol.test` → 98 passed / 0 failed / 2 skipped (6.0/6.1 by design)
- `cargo test --release -p vibesql-parser -p vibesql-executor -p vibesql-storage` → all green
- New unit tests: 5 parser (COLLATE grammar), 5 executor (autoindex filter + writable_schema update/gating), 1 storage (v12 without_rowid round-trip)
- Manual cross-process checks of sections 7 and 8 against file-backed DBs (WAL + checkpoint reload)

Closes #5796

🤖 Generated with [Claude Code](https://claude.com/claude-code)