### PR TITLE
fix(executor): SQLite truthiness/coercion in grouped CASE, unary +/- on Boolean, blob arithmetic and AND/OR (#5856)

### DIFF
--- a/crates/vibesql-executor/src/evaluator/casting.rs
+++ b/crates/vibesql-executor/src/evaluator/casting.rs
@@ -67,16 +67,6 @@ pub(crate) fn to_f64(value: &vibesql_types::SqlValue) -> Result<f64, ExecutorErr
     }
 }
 
-/// Convert Boolean to i64 (TRUE = 1, FALSE = 0)
-/// Used for implicit type coercion in arithmetic operations
-pub(crate) fn boolean_to_i64(value: &vibesql_types::SqlValue) -> Option<i64> {
-    match value {
-        vibesql_types::SqlValue::Boolean(true) => Some(1),
-        vibesql_types::SqlValue::Boolean(false) => Some(0),
-        _ => None,
-    }
-}
-
 /// SQLite-compatible string-to-number coercion for arithmetic operations
 ///
 /// SQLite rules for implicit string-to-number conversion:

--- a/crates/vibesql-executor/src/evaluator/combined/special.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/special.rs
@@ -80,29 +80,11 @@ impl CombinedExpressionEvaluator<'_> {
                     for condition_expr in &when_clause.conditions {
                         let condition_result = self.eval(condition_expr, row)?;
 
-                        // In SQLite, truthiness is:
-                        // - Boolean(true) => true
-                        // - Integer/Bigint non-zero => true
-                        // - Float/Real/Double/Numeric non-zero => true
-                        // - Strings: parse leading numeric, non-zero => true
-                        // - Null, zero => false
-                        let is_truthy = match &condition_result {
-                            vibesql_types::SqlValue::Boolean(b) => *b,
-                            vibesql_types::SqlValue::Integer(n) => *n != 0,
-                            vibesql_types::SqlValue::Bigint(n) => *n != 0,
-                            vibesql_types::SqlValue::Smallint(n) => *n != 0,
-                            vibesql_types::SqlValue::Unsigned(n) => *n != 0,
-                            vibesql_types::SqlValue::Double(n) => *n != 0.0,
-                            vibesql_types::SqlValue::Float(n) => *n != 0.0,
-                            vibesql_types::SqlValue::Real(n) => *n != 0.0,
-                            vibesql_types::SqlValue::Numeric(n) => *n != 0.0,
-                            // SQLite parses leading numeric from strings
-                            vibesql_types::SqlValue::Varchar(s)
-                            | vibesql_types::SqlValue::Character(s) => {
-                                super::super::operators::is_truthy_string(s)
-                            }
-                            _ => false,
-                        };
+                        // Delegate to the shared SQLite truthiness helper
+                        // (numerics non-zero, strings/blobs via the
+                        // leading-numeric parse, NULL falsy). (#5856)
+                        let is_truthy =
+                            super::super::operators::is_truthy(&condition_result);
                         if is_truthy {
                             return self.eval(&when_clause.result, row);
                         }

--- a/crates/vibesql-executor/src/evaluator/expressions/operators.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/operators.rs
@@ -44,6 +44,13 @@ pub(crate) fn eval_unary_op(
         // NULL propagation - unary operations on NULL return NULL
         (Plus | Minus, SqlValue::Null) => Ok(SqlValue::Null),
 
+        // Boolean (EXISTS/IN/comparison results) — SQLite has no boolean
+        // storage class; those expressions produce the integers 0/1, so
+        // unary +/- treats a Boolean as its integer value (#5856):
+        //   SELECT - EXISTS (SELECT 1) → -1;  SELECT + (5 > 3) → 1
+        (Plus, SqlValue::Boolean(b)) => Ok(SqlValue::Integer(*b as i64)),
+        (Minus, SqlValue::Boolean(b)) => Ok(SqlValue::Integer(-(*b as i64))),
+
         // Unary plus on text types - identity operation (SQLite behavior)
         // In SQLite, unary + on text returns the text unchanged
         (Plus, SqlValue::Character(s)) => Ok(SqlValue::Character(s.clone())),

--- a/crates/vibesql-executor/src/evaluator/expressions/special.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/special.rs
@@ -76,29 +76,11 @@ impl ExpressionEvaluator<'_> {
                     for condition_expr in &when_clause.conditions {
                         let condition_result = self.eval(condition_expr, row)?;
 
-                        // In SQLite, truthiness is:
-                        // - Boolean(true) => true
-                        // - Integer/Bigint non-zero => true
-                        // - Float/Real/Double/Numeric non-zero => true
-                        // - Strings: parse leading numeric, non-zero => true
-                        // - Null, zero => false
-                        let is_truthy = match &condition_result {
-                            vibesql_types::SqlValue::Boolean(b) => *b,
-                            vibesql_types::SqlValue::Integer(n) => *n != 0,
-                            vibesql_types::SqlValue::Bigint(n) => *n != 0,
-                            vibesql_types::SqlValue::Smallint(n) => *n != 0,
-                            vibesql_types::SqlValue::Unsigned(n) => *n != 0,
-                            vibesql_types::SqlValue::Double(n) => *n != 0.0,
-                            vibesql_types::SqlValue::Float(n) => *n != 0.0,
-                            vibesql_types::SqlValue::Real(n) => *n != 0.0,
-                            vibesql_types::SqlValue::Numeric(n) => *n != 0.0,
-                            // SQLite parses leading numeric from strings
-                            vibesql_types::SqlValue::Varchar(s)
-                            | vibesql_types::SqlValue::Character(s) => {
-                                super::super::operators::is_truthy_string(s)
-                            }
-                            _ => false,
-                        };
+                        // Delegate to the shared SQLite truthiness helper
+                        // (numerics non-zero, strings/blobs via the
+                        // leading-numeric parse, NULL falsy). (#5856)
+                        let is_truthy =
+                            super::super::operators::is_truthy(&condition_result);
                         if is_truthy {
                             return self.eval(&when_clause.result, row);
                         }

--- a/crates/vibesql-executor/src/evaluator/operators/arithmetic/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/arithmetic/mod.rs
@@ -46,7 +46,7 @@ pub(super) fn nan_to_null(value: SqlValue) -> SqlValue {
 use crate::{
     errors::ExecutorError,
     evaluator::casting::{
-        boolean_to_i64, is_approximate_numeric, is_exact_numeric, string_to_number, to_f64, to_i64,
+        is_approximate_numeric, is_exact_numeric, string_to_number, to_f64, to_i64,
     },
 };
 
@@ -74,6 +74,14 @@ fn coerce_single_value(value: &SqlValue) -> Option<(i64, f64, bool)> {
             let (i, f, is_float) = string_to_number(s);
             Some((i, f, is_float))
         }
+        // BLOB: SQLite coerces the bytes as text, then applies the same
+        // leading-numeric parse (#5856):
+        //   x'313233' + 1 → 124;  x'2E35' + 0 → 0.5;  x'AB' + 1 → 1
+        SqlValue::Blob(b) => {
+            let s = String::from_utf8_lossy(b);
+            let (i, f, is_float) = string_to_number(&s);
+            Some((i, f, is_float))
+        }
         _ => None,
     }
 }
@@ -86,30 +94,15 @@ pub(super) fn coerce_numeric_values(
 ) -> Result<CoercedValues, ExecutorError> {
     use SqlValue::*;
 
-    // Handle Boolean coercion first
-    if matches!(left, Boolean(_)) || matches!(right, Boolean(_)) {
-        let left_i64 = boolean_to_i64(left).or_else(|| to_i64(left).ok()).ok_or_else(|| {
-            ExecutorError::TypeMismatch {
-                left: left.clone(),
-                op: op.to_string(),
-                right: right.clone(),
-            }
-        })?;
-
-        let right_i64 = boolean_to_i64(right).or_else(|| to_i64(right).ok()).ok_or_else(|| {
-            ExecutorError::TypeMismatch {
-                left: left.clone(),
-                op: op.to_string(),
-                right: right.clone(),
-            }
-        })?;
-
-        return Ok(CoercedValues::ExactNumeric(left_i64, right_i64));
-    }
-
-    // Handle string coercion (SQLite compatibility)
-    // When either operand is a string, coerce it to a number
-    if matches!(left, Varchar(_) | Character(_)) || matches!(right, Varchar(_) | Character(_)) {
+    // Handle Boolean / string / BLOB coercion (SQLite compatibility).
+    // SQLite has no boolean storage class (comparison/EXISTS results are the
+    // integers 0/1), strings coerce via the leading-numeric parse, and BLOBs
+    // coerce via bytes → text → number (#5856). When any operand is one of
+    // these, coerce both sides to a common numeric type:
+    //   (1 > 0) + 'injection' → 1;  x'313233' + 1 → 124;  (1 > 0) + 0.5 → 1.5
+    if matches!(left, Boolean(_) | Varchar(_) | Character(_) | Blob(_))
+        || matches!(right, Boolean(_) | Varchar(_) | Character(_) | Blob(_))
+    {
         let left_coerced =
             coerce_single_value(left).ok_or_else(|| ExecutorError::TypeMismatch {
                 left: left.clone(),

--- a/crates/vibesql-executor/src/evaluator/operators/logical.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/logical.rs
@@ -144,6 +144,10 @@ fn to_boolean(value: &SqlValue) -> Result<Option<bool>, ExecutorError> {
             let numeric_value = parse_leading_numeric(trimmed);
             Ok(Some(numeric_value != 0.0))
         }
+        // BLOB: SQLite reads the bytes as text and applies the same
+        // leading-numeric coercion (#5856):
+        //   x'31' AND 1 → 1;  zeroblob(4) AND 1 → 0
+        Blob(b) => Ok(Some(is_truthy_string(&String::from_utf8_lossy(b)))),
         // Other types are not supported in boolean context
         _ => Err(ExecutorError::TypeMismatch {
             left: value.clone(),

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/case.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/case.rs
@@ -76,32 +76,13 @@ pub(super) fn evaluate(
                         evaluator,
                     )?;
 
-                    // Check if condition is TRUE (not FALSE or NULL)
-                    let is_true = match condition_value {
-                        vibesql_types::SqlValue::Boolean(true) => true,
-                        vibesql_types::SqlValue::Boolean(false) | vibesql_types::SqlValue::Null => {
-                            false
-                        }
-                        // SQLLogicTest compatibility: treat integers as truthy/falsy
-                        vibesql_types::SqlValue::Integer(0) => false,
-                        vibesql_types::SqlValue::Integer(_) => true,
-                        vibesql_types::SqlValue::Smallint(0) => false,
-                        vibesql_types::SqlValue::Smallint(_) => true,
-                        vibesql_types::SqlValue::Bigint(0) => false,
-                        vibesql_types::SqlValue::Bigint(_) => true,
-                        vibesql_types::SqlValue::Float(0.0) => false,
-                        vibesql_types::SqlValue::Float(_) => true,
-                        vibesql_types::SqlValue::Real(0.0) => false,
-                        vibesql_types::SqlValue::Real(_) => true,
-                        vibesql_types::SqlValue::Double(0.0) => false,
-                        vibesql_types::SqlValue::Double(_) => true,
-                        other => {
-                            return Err(ExecutorError::UnsupportedExpression(format!(
-                                "CASE condition must evaluate to boolean, got: {:?}",
-                                other
-                            )))
-                        }
-                    };
+                    // Check if condition is truthy. Delegate to the shared
+                    // SQLite truthiness helper so any expression is accepted
+                    // (strings/blobs coerce via the leading-numeric parse)
+                    // instead of erroring on non-boolean conditions — this
+                    // was the last grouped-aggregation path rejecting
+                    // non-boolean expressions (#5856).
+                    let is_true = crate::evaluator::operators::is_truthy(&condition_value);
 
                     if is_true {
                         // Evaluate result (may contain aggregates)

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
@@ -587,14 +587,12 @@ impl SelectExecutor<'_> {
                                     grouping_context,
                                 )?;
 
-                                let is_true = match condition_value {
-                                    vibesql_types::SqlValue::Boolean(true) => true,
-                                    vibesql_types::SqlValue::Boolean(false)
-                                    | vibesql_types::SqlValue::Null => false,
-                                    vibesql_types::SqlValue::Integer(0) => false,
-                                    vibesql_types::SqlValue::Integer(_) => true,
-                                    _ => false,
-                                };
+                                // Delegate to the shared SQLite truthiness
+                                // helper (numerics non-zero, strings/blobs
+                                // via the leading-numeric parse, NULL
+                                // falsy). (#5856)
+                                let is_true =
+                                    crate::evaluator::operators::is_truthy(&condition_value);
 
                                 if is_true {
                                     return self.evaluate_with_aggregates_and_grouping(

--- a/crates/vibesql-executor/tests/having_truthiness_coercion_tests.rs
+++ b/crates/vibesql-executor/tests/having_truthiness_coercion_tests.rs
@@ -1,0 +1,270 @@
+//! Differential tests vs sqlite3 for the grouped/HAVING fuzz class (#5856).
+//!
+//! The fuzz.test corpus (deterministic, srand(0)) generates grouped queries of
+//! the shape `SELECT ... FROM (...) GROUP BY <expr> HAVING <expr>`, frequently
+//! wrapped in expressions that SQLite evaluates via numeric coercion because
+//! it has no boolean storage class. Every expected value in this file was
+//! verified against sqlite3.
+//!
+//! The failing shapes this file locks in:
+//! - unary `+`/`-` on a Boolean (e.g. `- EXISTS (SELECT ... HAVING ...)`)
+//! - arithmetic with Boolean or BLOB operands (bytes → text → number)
+//! - BLOB operands of AND/OR (boolean context)
+//! - non-boolean CASE WHEN conditions in the grouped-aggregation evaluator
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+/// abc(a, b, c) with the fuzz-4.1 data: (1,2,3), (4,5,6), (7,8,9)
+fn setup_abc() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    let schema = vibesql_catalog::TableSchema::new(
+        "ABC".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new(
+                "A".to_string(),
+                vibesql_types::DataType::Integer,
+                true,
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "B".to_string(),
+                vibesql_types::DataType::Integer,
+                true,
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "C".to_string(),
+                vibesql_types::DataType::Integer,
+                true,
+            ),
+        ],
+    );
+    db.create_table(schema).unwrap();
+    for (a, b, c) in [(1, 2, 3), (4, 5, 6), (7, 8, 9)] {
+        db.insert_row(
+            "ABC",
+            vibesql_storage::Row::new(vec![
+                SqlValue::Integer(a),
+                SqlValue::Integer(b),
+                SqlValue::Integer(c),
+            ]),
+        )
+        .unwrap();
+    }
+    db
+}
+
+fn run_query(db: &vibesql_storage::Database, sql: &str) -> Vec<vibesql_storage::Row> {
+    let executor = SelectExecutor::new(db);
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("parse failed for {sql}: {e:?}"));
+    let vibesql_ast::Statement::Select(select_stmt) = stmt else {
+        panic!("Expected SELECT statement: {sql}");
+    };
+    executor.execute(&select_stmt).unwrap_or_else(|e| panic!("execute failed for {sql}: {e:?}"))
+}
+
+fn single_value(db: &vibesql_storage::Database, sql: &str) -> SqlValue {
+    let rows = run_query(db, sql);
+    assert_eq!(rows.len(), 1, "expected 1 row for {sql}");
+    rows[0].values[0].clone()
+}
+
+fn assert_i64(db: &vibesql_storage::Database, sql: &str, expected: i64) {
+    let v = single_value(db, sql);
+    let got = match v {
+        SqlValue::Integer(n) => n,
+        SqlValue::Smallint(n) => n as i64,
+        SqlValue::Bigint(n) => n,
+        SqlValue::Boolean(b) => b as i64,
+        other => panic!("expected integer {expected} for {sql}, got {other:?}"),
+    };
+    assert_eq!(got, expected, "wrong value for {sql}");
+}
+
+// ---------------------------------------------------------------------------
+// Unary +/- on Boolean (sqlite3: SELECT - EXISTS (SELECT 1) → -1)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_unary_minus_on_exists() {
+    let db = setup_abc();
+    assert_i64(&db, "SELECT - EXISTS (SELECT 1)", -1);
+    assert_i64(&db, "SELECT - EXISTS (SELECT 1 WHERE 0)", 0);
+}
+
+#[test]
+fn test_unary_plus_on_exists_and_comparison() {
+    let db = setup_abc();
+    assert_i64(&db, "SELECT + EXISTS (SELECT 1)", 1);
+    assert_i64(&db, "SELECT - (5 > 3)", -1);
+    assert_i64(&db, "SELECT + (5 > 3)", 1);
+}
+
+/// The dominant fuzz shape: unary minus on an EXISTS whose subquery is a
+/// grouped query with a non-boolean HAVING. sqlite3:
+///   SELECT - EXISTS (SELECT b FROM (SELECT 1 AS b) GROUP BY b HAVING 'first' NOT IN (SELECT -1))
+///   → -1
+#[test]
+fn test_unary_minus_exists_grouped_having() {
+    let db = setup_abc();
+    assert_i64(
+        &db,
+        "SELECT - EXISTS ( SELECT a FROM abc GROUP BY a HAVING 'first' NOT IN (SELECT -1) )",
+        -1,
+    );
+    // HAVING NULL filters every group → EXISTS is false → 0
+    assert_i64(&db, "SELECT - EXISTS ( SELECT a FROM abc GROUP BY a HAVING NULL )", 0);
+}
+
+// ---------------------------------------------------------------------------
+// Arithmetic coercion with Boolean / BLOB operands
+// (sqlite3: x'313233' + 1 → 124; (1>0) + 'injection' → 1; (1>0) + 0.5 → 1.5)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_boolean_plus_text() {
+    let db = setup_abc();
+    // 'injection' coerces to 0; (1>0) coerces to 1
+    assert_i64(&db, "SELECT (1 > 0) + 'injection'", 1);
+    assert_i64(&db, "SELECT 'injection' - (1 > 0)", -1);
+    assert_i64(&db, "SELECT (1 > 0) * 'hardware'", 0);
+    // '7The' coerces to 7; (1=2) coerces to 0; 0 % 7 = 0
+    assert_i64(&db, "SELECT (1 = 2) % '7The'", 0);
+}
+
+#[test]
+fn test_boolean_plus_float_promotes() {
+    let db = setup_abc();
+    let v = single_value(&db, "SELECT (1 > 0) + 0.5");
+    let got = match v {
+        SqlValue::Real(f) => f,
+        SqlValue::Double(f) => f,
+        SqlValue::Float(f) => f as f64,
+        SqlValue::Numeric(f) => f,
+        other => panic!("expected float 1.5, got {other:?}"),
+    };
+    assert!((got - 1.5).abs() < 1e-9, "expected 1.5, got {got}");
+}
+
+#[test]
+fn test_blob_arithmetic() {
+    let db = setup_abc();
+    // x'313233' is the bytes "123"
+    assert_i64(&db, "SELECT x'313233' + 1", 124);
+    assert_i64(&db, "SELECT x'32' * 3", 6);
+    assert_i64(&db, "SELECT x'' - 5", -5);
+    // non-numeric bytes coerce to 0
+    assert_i64(&db, "SELECT 1 + zeroblob(16)", 1);
+    assert_i64(&db, "SELECT 1 % x'32'", 1);
+}
+
+// ---------------------------------------------------------------------------
+// BLOB in boolean context (AND/OR) — sqlite3: x'31' AND 1 → 1; zeroblob(4) AND 1 → 0
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_blob_in_logical_operators() {
+    let db = setup_abc();
+    assert_i64(&db, "SELECT x'31' AND 1", 1);
+    assert_i64(&db, "SELECT zeroblob(4) AND 1", 0);
+    assert_i64(&db, "SELECT x'00' OR 0", 0);
+    assert_i64(&db, "SELECT x'31' OR 0", 1);
+}
+
+/// Blob AND/OR inside a HAVING clause of a grouped query.
+/// sqlite3: SELECT count(*) FROM abc GROUP BY a HAVING x'31' AND 1 → three rows of 1
+#[test]
+fn test_blob_logical_in_having() {
+    let db = setup_abc();
+    let rows = run_query(&db, "SELECT count(*) FROM abc GROUP BY a HAVING x'31' AND 1");
+    assert_eq!(rows.len(), 3);
+    let rows = run_query(&db, "SELECT count(*) FROM abc GROUP BY a HAVING zeroblob(4) AND 1");
+    assert_eq!(rows.len(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// CASE WHEN condition truthiness in the grouped-aggregation evaluator.
+// sqlite3 evaluates any CASE condition for truthiness; the aggregation path
+// used to error with "CASE condition must evaluate to boolean".
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_case_text_condition_with_aggregates() {
+    let db = setup_abc();
+    // Text condition, aggregate in THEN — forces the aggregation CASE path.
+    // '1x' parses to 1 (truthy); 'x' parses to 0 (falsy). Verified in sqlite3.
+    let rows = run_query(
+        &db,
+        "SELECT CASE WHEN '1x' THEN count(*) ELSE -1 END FROM abc GROUP BY a",
+    );
+    assert_eq!(rows.len(), 3);
+    for row in &rows {
+        assert_eq!(row.values[0], SqlValue::Integer(1));
+    }
+
+    let rows = run_query(
+        &db,
+        "SELECT CASE WHEN 'x' THEN count(*) ELSE -1 END FROM abc GROUP BY a",
+    );
+    assert_eq!(rows.len(), 3);
+    for row in &rows {
+        assert_eq!(row.values[0], SqlValue::Integer(-1));
+    }
+}
+
+#[test]
+fn test_case_numeric_and_blob_condition_with_aggregates() {
+    let db = setup_abc();
+    // Numeric (real) condition — previously unhandled in the aggregation CASE match
+    let rows = run_query(
+        &db,
+        "SELECT CASE WHEN 56.1 THEN count(*) ELSE -1 END FROM abc GROUP BY a",
+    );
+    for row in &rows {
+        assert_eq!(row.values[0], SqlValue::Integer(1));
+    }
+    // Blob condition: x'31' ("1") is truthy in sqlite3
+    let rows = run_query(
+        &db,
+        "SELECT CASE WHEN x'31' THEN count(*) ELSE -1 END FROM abc GROUP BY a",
+    );
+    for row in &rows {
+        assert_eq!(row.values[0], SqlValue::Integer(1));
+    }
+}
+
+#[test]
+fn test_case_text_condition_in_having() {
+    let db = setup_abc();
+    // sqlite3: HAVING CASE WHEN 'text' … END with aggregates
+    let rows = run_query(
+        &db,
+        "SELECT a FROM abc GROUP BY a HAVING CASE WHEN 'first' THEN count(*) ELSE 0 END",
+    );
+    assert_eq!(rows.len(), 0);
+    let rows = run_query(
+        &db,
+        "SELECT a FROM abc GROUP BY a HAVING CASE WHEN '1st' THEN count(*) ELSE 0 END",
+    );
+    assert_eq!(rows.len(), 3);
+}
+
+// ---------------------------------------------------------------------------
+// Non-boolean HAVING acceptance in grouped queries (regression guard for the
+// paths unified by #5829; sqlite3 accepts any expression in HAVING)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_having_nonboolean_shapes() {
+    let db = setup_abc();
+    // HAVING 'text' → falsy for all groups
+    assert_eq!(run_query(&db, "SELECT count(*) FROM abc GROUP BY a HAVING 'text'").len(), 0);
+    // HAVING 123 → truthy
+    assert_eq!(run_query(&db, "SELECT count(*) FROM abc GROUP BY a HAVING 123").len(), 3);
+    // HAVING x'31' → truthy blob
+    assert_eq!(run_query(&db, "SELECT count(*) FROM abc GROUP BY a HAVING x'31'").len(), 3);
+    // HAVING sum(b) → numeric truthiness
+    assert_eq!(run_query(&db, "SELECT count(*) FROM abc GROUP BY a HAVING sum(b)").len(), 3);
+    // HAVING NULL → falsy
+    assert_eq!(run_query(&db, "SELECT count(*) FROM abc GROUP BY a HAVING NULL").len(), 0);
+}


### PR DESCRIPTION
Closes #5856

## Diagnosis first (what the 454-failure class actually is)

The issue described 454 fuzz.test failures with the message `HAVING must evaluate to boolean`. **That error string was removed from the codebase by PR #5829** (`git log -S` confirms `02e035f62` deleted it) — the curator's 2026-07-03 fuzz run was made with a stale pre-#5829 binary (the known stale-binary hazard). On a current binary, plain non-boolean HAVING (`HAVING 'text'`, `HAVING 123`, `HAVING x'31'`, `HAVING sum(y)`, `HAVING NULL`, subquery-FROM variants) already passes on every path.

To find what *actually* still fails, I regenerated the deterministic fuzz corpus (`srand(0)`, sections fuzz-2/3.2/4.2/6.1/7.2 — 35,000 statements, of which 16,065 contain HAVING) with a TCL harness sourcing `fuzz_common.tcl`, ran every HAVING-containing statement against the fuzz-4.1 schema/data, applied the same allowed-error classification as `do_fuzzy_test` plus the TCL shim's error translation, and cross-checked divergences against sqlite3.

**Result: 240 genuinely-failing HAVING-containing statements**, decomposing into:

| Class | Count | Example |
|---|---|---|
| unary `+`/`-` on Boolean | 101 | `SELECT - EXISTS (SELECT a FROM t GROUP BY a HAVING 'first' NOT IN (SELECT -1))` → `Type mismatch: Boolean(true) unary - Null` |
| Boolean/BLOB arithmetic | ~35 | `(1>0) + 'injection'`, `x'313233' + 1` |
| parser gaps (`(SELECT..)*x`, `<<`, `>>`, `\|\|`…) | ~64 | pre-existing, separate class |
| Glob in aggregation simple evaluator | ~13 | pre-existing, separate class |
| CASE condition truthiness (aggregation path) | 2 | `CASE condition must evaluate to boolean, got: Varchar("first")` |
| BLOB in AND/OR | 2 | `Type mismatch: Blob(...) boolean context Null` |
| LIKE/GLOB numeric operands + misc | ~6 | pre-existing, separate class |

The dominant fuzz shape wraps a grouped subquery with non-boolean HAVING in `- EXISTS (...)` — the HAVING itself was fine; the unary minus on the Boolean EXISTS result was the rejection.

## Which paths were rejecting, and the fixes

All expected values below verified against sqlite3 (no boolean storage class — EXISTS/comparison results are integers 0/1; strings and blob-bytes coerce via the leading-numeric parse):

1. **`evaluator/expressions/operators.rs` (`eval_unary_op`)** — the shared unary evaluator had no Boolean arm for `+`/`-` and fell into the type-error arms. Now `- EXISTS (SELECT 1)` → `-1`, `+ (5>3)` → `1`.
2. **`evaluator/operators/arithmetic/mod.rs` (`coerce_numeric_values`)** — Boolean operands paired with text errored, and BLOB operands always errored. Any Boolean/text/BLOB operand now coerces via `coerce_single_value` (BLOB gains bytes→text→number): `x'313233' + 1` → `124`, `(1>0) + 'injection'` → `1`. Also fixes float truncation: `(1>0) + 0.5` → `1.5` (was `1`). `boolean_to_i64` became dead and is removed. All five arithmetic ops route through this one helper.
3. **`evaluator/operators/logical.rs` (`to_boolean`)** — AND/OR errored on BLOB operands. Now `x'31' AND 1` → `1`, `zeroblob(4) AND 1` → `0`.
4. **Searched-CASE condition truthiness — the "one more evaluation path with a pre-truthiness type check" the issue predicted**: `select/executor/aggregation/evaluation/case.rs` *errored* on non-boolean conditions (and didn't even handle `Numeric`); its grouping-context twin in `evaluation/mod.rs` and the scalar/combined evaluators (`expressions/special.rs`, `combined/special.rs`) silently treated text/blob conditions as false (full-parse instead of leading-numeric, no blob). All four now delegate to the shared `crate::evaluator::operators::is_truthy` — net −63 lines of hand-rolled truthiness.

## Fuzz-class evidence

Re-running the identical corpus analysis after the fix: **240 → 84 failing**, and **zero remaining failures are truthiness/boolean-coercion** — the residue is exactly the pre-existing separate classes (parser gaps ~70, Glob-in-simple-evaluator 8, LIKE/GLOB numeric coercion 6), most of which sqlite itself fails-allowed on (ORDER-BY-term-out-of-range validation vibesql doesn't perform). The HAVING-truthiness class per this issue's acceptance criterion is ~0.

Honest scope note: I did **not** run the full ~30-min fuzz.test via the TCL runner on this loaded machine (per repo quiet-machine guidance); the corpus reproduction above is deterministic (`srand(0)`) and covers all 16,065 HAVING-containing generated statements with the same pass/fail classification as `do_fuzzy_test`.

## Tests

- New `crates/vibesql-executor/tests/having_truthiness_coercion_tests.rs` — 12 differential tests vs sqlite3 covering every fixed shape: unary ± on EXISTS/comparisons (incl. the grouped-HAVING fuzz shape), Boolean/BLOB arithmetic incl. float promotion, BLOB AND/OR (top level and inside HAVING), CASE text/Numeric/blob conditions under aggregation and in HAVING, plus the non-boolean HAVING acceptance shapes as a regression guard.
- `cargo test --release -p vibesql-executor` — full suite passes (0 failures).
- TCL having-adjacent files: `aggnested` 0 failed, `distinctagg` 41 passed/0 failed, `select3` 63 passed/0 failed, `having` 0 failed, `select5` 34 passed (100%)/0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)