### PR TITLE
fix(cli): make checkpoint/save failures loud, non-zero, and WAL-preserving

### DIFF
--- a/crates/vibesql-cli/src/executor/wal.rs
+++ b/crates/vibesql-cli/src/executor/wal.rs
@@ -189,6 +189,14 @@ impl WalState {
     ///   2. Serializes the in-memory database to uncompressed binary bytes.
     ///   3. Writes a checkpoint at the engine's current LSN.
     ///   4. Truncates the WAL up to that LSN.
+    ///
+    /// **Fail-safe invariant (issue #5832):** the WAL is truncated in step 4
+    /// only after steps 1–3 all succeed. Any failure — serialization error,
+    /// unwritable checkpoint directory, I/O error — propagates immediately and
+    /// leaves the WAL untouched, so committed changes are always recoverable
+    /// on the next open. Callers must surface the error loudly and exit
+    /// non-zero (see `crate::util::report_save_failure`); a checkpoint failure
+    /// must never be silent (cross-link #5807 / PR #5850's fail-closed policy).
     pub fn checkpoint(&mut self, db: &Database) -> Result<(), StorageError> {
         // 1. Make sure everything already emitted is on disk before we snapshot.
         db.sync_persistence()?;
@@ -265,5 +273,67 @@ mod tests {
         // The WAL on disk must now be a valid header-bearing (or empty) file that
         // recovery can reopen without error.
         let (_db2, _stats) = WalState::open(&db_path_str).expect("reopen after checkpoint");
+    }
+
+    /// Regression for issue #5832: a checkpoint-write failure must NEVER
+    /// truncate the WAL. We force `create_checkpoint` to fail by making the
+    /// checkpoint directory read-only, then assert (a) `checkpoint()` returns
+    /// an error and (b) the on-disk WAL bytes are unchanged, so every
+    /// committed change is still recoverable on the next open.
+    #[cfg(unix)]
+    #[test]
+    fn test_failed_checkpoint_leaves_wal_intact() {
+        use std::os::unix::fs::PermissionsExt;
+
+        use vibesql_catalog::{ColumnSchema, TableSchema};
+        use vibesql_types::DataType;
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("failsafe.vbsql");
+        let db_path_str = db_path.to_string_lossy().to_string();
+
+        let (mut db, mut wal_state) = WalState::open(&db_path_str).unwrap();
+
+        // Write some committed DDL so the WAL has real content.
+        db.create_table(TableSchema::new(
+            "survivors".to_string(),
+            vec![ColumnSchema::new("id".to_string(), DataType::Integer, true)],
+        ))
+        .unwrap();
+        db.sync_persistence().unwrap();
+
+        let paths = wal_state.paths.clone();
+        let wal_before = std::fs::read(&paths.wal_path).unwrap();
+        assert!(!wal_before.is_empty(), "WAL must contain the CreateTable op");
+
+        // Inject the failure: make the checkpoint directory unwritable.
+        let dir = &paths.checkpoint_dir;
+        let orig_perms = std::fs::metadata(dir).unwrap().permissions();
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        // Skip when running as root (root bypasses permission checks).
+        if std::fs::File::create(dir.join(".probe")).is_ok() {
+            let _ = std::fs::remove_file(dir.join(".probe"));
+            std::fs::set_permissions(dir, orig_perms).unwrap();
+            eprintln!("skipping test_failed_checkpoint_leaves_wal_intact: running as root");
+            return;
+        }
+
+        let result = wal_state.checkpoint(&db);
+        assert!(result.is_err(), "checkpoint into a read-only directory must fail");
+
+        // THE invariant: the WAL was not truncated (bytes are unchanged).
+        let wal_after = std::fs::read(&paths.wal_path).unwrap();
+        assert_eq!(wal_before, wal_after, "a failed checkpoint must leave the WAL byte-identical");
+
+        // Restore permissions and prove the data is still recoverable.
+        std::fs::set_permissions(dir, orig_perms).unwrap();
+        drop(db);
+        drop(wal_state);
+        let (db2, _state2) = WalState::open(&db_path_str).expect("reopen after failed checkpoint");
+        assert!(
+            db2.list_tables().iter().any(|t| t == "survivors"),
+            "committed DDL must be recovered from the intact WAL"
+        );
     }
 }

--- a/crates/vibesql-cli/src/repl.rs
+++ b/crates/vibesql-cli/src/repl.rs
@@ -111,12 +111,15 @@ impl Repl {
                                     if should_save || is_txn_end {
                                         self.has_modifications = true;
                                         if let Err(e) = self.executor.save_database(path) {
-                                            eprintln!(
-                                                "{}",
-                                                vibe_msg!(
-                                                    "warning-auto-save-failed",
-                                                    error = e.to_string()
-                                                )
+                                            // Loud, fail-closed error (issue
+                                            // #5832). `has_modifications` stays
+                                            // true, so the exit-time save
+                                            // retries; if that also fails the
+                                            // REPL exits non-zero.
+                                            crate::util::report_save_failure(
+                                                path,
+                                                self.executor.wal_active(),
+                                                &e,
                                             );
                                         }
                                     } else if is_modification_statement(&line) {
@@ -148,14 +151,21 @@ impl Repl {
             }
         }
 
-        // Save database on exit if modifications occurred
+        // Save database on exit if modifications occurred.
+        //
+        // Fail-closed (issue #5832): a checkpoint/save failure at exit must
+        // never be a quiet warning + exit 0. `WalState::checkpoint` never
+        // truncates the WAL unless the checkpoint file was durably written, so
+        // committed changes are still recoverable — but the user must be told
+        // loudly and the process must exit non-zero.
         if self.has_modifications {
             if let Some(ref path) = self.database_path {
                 if let Err(e) = self.executor.save_database(path) {
-                    eprintln!(
-                        "{}",
-                        vibe_msg!("warning-save-on-exit-failed", error = e.to_string())
-                    );
+                    crate::util::report_save_failure(path, self.executor.wal_active(), &e);
+                    self.print_goodbye();
+                    return Err(anyhow::anyhow!(
+                        "failed to persist database on exit; see the ERROR output above"
+                    ));
                 }
             }
         }

--- a/crates/vibesql-cli/src/script.rs
+++ b/crates/vibesql-cli/src/script.rs
@@ -82,6 +82,11 @@ impl ScriptExecutor {
 
         let mut success_count = 0;
         let mut error_count = 0;
+        // Fail-closed persistence tracking (issue #5832): a checkpoint/save
+        // failure must never end in exit 0. A later *successful* save clears
+        // the flag because every checkpoint/snapshot captures the full
+        // database state, superseding the earlier failure.
+        let mut persist_failed = false;
 
         for (idx, stmt) in statements.iter().enumerate() {
             if self.verbose {
@@ -100,7 +105,15 @@ impl ScriptExecutor {
                 match self.handle_meta_command(meta_cmd) {
                     Ok(should_exit) => {
                         if should_exit {
-                            // .quit/.exit in script mode - stop processing
+                            // .quit/.exit in script mode - stop processing.
+                            // A pending persistence failure must still surface
+                            // as a non-zero exit (issue #5832).
+                            if persist_failed {
+                                return Err(anyhow::anyhow!(
+                                    "failed to persist database changes; \
+                                     see the ERROR output above"
+                                ));
+                            }
                             return Ok(());
                         }
                         success_count += 1;
@@ -150,11 +163,19 @@ impl ScriptExecutor {
                                 || upper.starts_with("ROLLBACK")
                                 || upper.starts_with("END"));
                         if should_save || is_txn_end {
-                            if let Err(e) = self.executor.save_database(path) {
-                                eprintln!(
-                                    "{}",
-                                    vibe_msg!("warning-auto-save-failed", error = e.to_string())
-                                );
+                            match self.executor.save_database(path) {
+                                Ok(()) => persist_failed = false,
+                                Err(e) => {
+                                    // Loud + fail-closed (issue #5832): the WAL
+                                    // is never truncated on a failed checkpoint,
+                                    // and the process must exit non-zero.
+                                    persist_failed = true;
+                                    crate::util::report_save_failure(
+                                        path,
+                                        self.executor.wal_active(),
+                                        &e,
+                                    );
+                                }
                             }
                         }
                     }
@@ -197,6 +218,11 @@ impl ScriptExecutor {
 
         if error_count > 0 {
             Err(anyhow::anyhow!("{}", vibe_msg!("script-failed-error", count = error_count as i64)))
+        } else if persist_failed {
+            // Issue #5832: a persistence failure must never exit 0, even when
+            // every statement itself succeeded. The detailed ERROR lines were
+            // already printed at failure time by `report_save_failure`.
+            Err(anyhow::anyhow!("failed to persist database changes; see the ERROR output above"))
         } else {
             Ok(())
         }

--- a/crates/vibesql-cli/src/util.rs
+++ b/crates/vibesql-cli/src/util.rs
@@ -4,6 +4,30 @@ pub fn is_memory_database(path: &str) -> bool {
     path == ":memory:" || path == "file::memory:" || path.starts_with("file::memory:?")
 }
 
+/// Print a loud, fail-closed error when persisting the database fails.
+///
+/// Invariant (issues #5832, #5807 / PR #5850): a checkpoint/save failure must
+/// NEVER be a quiet warning followed by exit 0. `WalState::checkpoint` only
+/// truncates the WAL *after* the checkpoint file is durably written, so on
+/// failure the WAL still holds every committed change — tell the user that
+/// loudly, and the caller must propagate a non-zero exit code.
+pub fn report_save_failure(path: &str, wal_active: bool, error: &anyhow::Error) {
+    eprintln!("ERROR: failed to persist database to '{path}': {error}");
+    if wal_active {
+        let wal_path = crate::executor::wal::WalPaths::derive(path).wal_path;
+        eprintln!(
+            "ERROR: the write-ahead log at '{}' was left intact; committed changes \
+             will be recovered on the next open. Do NOT delete the .wal file.",
+            wal_path.display()
+        );
+    } else {
+        eprintln!(
+            "ERROR: recent changes are NOT durable on disk; the previous snapshot at \
+             '{path}' was left untouched."
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/vibesql-cli/tests/checkpoint_failure_test.rs
+++ b/crates/vibesql-cli/tests/checkpoint_failure_test.rs
@@ -1,0 +1,208 @@
+// Integration tests for issue #5832:
+//
+//   P0 fix(storage): NUMBER-typed column silently destroys the entire database
+//   on clean exit.
+//
+// Two guarantees are asserted end-to-end against a real `vibesql` subprocess:
+//
+//   1. The original reproducer round-trips: `NUMBER` (any spelling — bare,
+//      `NUMBER(5)`, `NUMBER(5,10)`) is accepted like SQLite accepts any type
+//      name, the column is usable, and — critically — *unrelated tables in the
+//      same database survive* a clean exit + reopen.
+//
+//   2. THE INVARIANT: a checkpoint-write failure at exit must NEVER truncate
+//      the WAL or exit 0. It must print a loud ERROR on stderr, leave the WAL
+//      intact (committed changes recoverable on next open), and exit non-zero.
+//      (Cross-link #5807 / PR #5850's fail-closed recovery policy.)
+
+use std::{fs, path::Path, process::Command};
+
+use tempfile::TempDir;
+
+fn vibesql_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_vibesql")
+}
+
+/// Create a temp `$HOME` with no `.vibesqlrc`, so subprocesses run with the
+/// shipping defaults (WAL on) and are unaffected by the developer's real
+/// config.
+fn default_home() -> TempDir {
+    tempfile::tempdir().expect("create temp home")
+}
+
+/// Run `vibesql <db> -c <sql>` with WAL-default settings.
+fn run_cli(home: &TempDir, db: &Path, sql: &str) -> std::process::Output {
+    Command::new(vibesql_binary())
+        .args([db.to_str().unwrap(), "-c", sql])
+        .env("HOME", home.path())
+        .output()
+        .expect("failed to execute vibesql")
+}
+
+fn stdout_of(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn stderr_of(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+// ----------------------------------------------------------------------------
+// Part 1: the issue reproducer round-trips
+// ----------------------------------------------------------------------------
+
+/// The exact reproducer from issue #5832: a NUMBER-typed column must not
+/// destroy the database on clean exit. Both tables survive reopen, and the
+/// unrelated table's data is intact.
+#[test]
+fn test_number_typed_column_does_not_destroy_database() {
+    let home = default_home();
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("db.vbsql");
+
+    let output = run_cli(
+        &home,
+        &db,
+        "CREATE TABLE zz(b number); CREATE TABLE ok(a int); INSERT INTO ok VALUES(1);",
+    );
+    assert!(output.status.success(), "session 1 should succeed; stderr: {}", stderr_of(&output));
+    assert!(
+        stderr_of(&output).is_empty(),
+        "session 1 must not warn/error; stderr: {}",
+        stderr_of(&output)
+    );
+
+    // Reopen: BOTH tables must exist and the data must be intact.
+    let output = run_cli(&home, &db, "SELECT name FROM sqlite_master;");
+    assert!(output.status.success(), "reopen failed; stderr: {}", stderr_of(&output));
+    let names = stdout_of(&output);
+    assert!(names.contains("zz"), "table zz missing after reopen: {names}");
+    assert!(names.contains("ok"), "table ok missing after reopen: {names}");
+
+    let output = run_cli(&home, &db, "SELECT a FROM ok;");
+    assert!(output.status.success());
+    assert!(stdout_of(&output).contains('1'), "row in ok lost: {}", stdout_of(&output));
+}
+
+/// The NUMBER column itself must be usable (SQLite treats any type name via
+/// affinity; NUMBER gets NUMERIC affinity), and values must survive reopen.
+#[test]
+fn test_number_column_is_usable_and_round_trips() {
+    let home = default_home();
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("num.vbsql");
+
+    let output = run_cli(&home, &db, "CREATE TABLE zz(b number); INSERT INTO zz VALUES(3.14);");
+    assert!(output.status.success(), "stderr: {}", stderr_of(&output));
+
+    let output = run_cli(&home, &db, "SELECT b FROM zz;");
+    assert!(output.status.success(), "stderr: {}", stderr_of(&output));
+    assert!(
+        stdout_of(&output).contains("3.14"),
+        "NUMBER value lost across reopen: {}",
+        stdout_of(&output)
+    );
+}
+
+/// All spellings from the issue: `number`, `number(5)`, `number(5,10)` — none
+/// may wipe the database (`decimal(5,10)` was always fine).
+#[test]
+fn test_number_precision_variants_round_trip() {
+    let home = default_home();
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("variants.vbsql");
+
+    let output = run_cli(
+        &home,
+        &db,
+        "CREATE TABLE t1(b number(5)); CREATE TABLE t2(c number(5,10)); \
+         CREATE TABLE t3(d decimal(5,10)); CREATE TABLE ok(a int); INSERT INTO ok VALUES(1);",
+    );
+    assert!(output.status.success(), "stderr: {}", stderr_of(&output));
+
+    let output = run_cli(&home, &db, "SELECT name FROM sqlite_master; SELECT a FROM ok;");
+    assert!(output.status.success(), "stderr: {}", stderr_of(&output));
+    let out = stdout_of(&output);
+    for table in ["t1", "t2", "t3", "ok"] {
+        assert!(out.contains(table), "table {table} missing after reopen: {out}");
+    }
+    assert!(out.contains('1'), "row in ok lost after reopen: {out}");
+}
+
+// ----------------------------------------------------------------------------
+// Part 2: THE INVARIANT — checkpoint failure is loud, non-zero, WAL-preserving
+// ----------------------------------------------------------------------------
+
+/// Force the checkpoint write to fail (read-only checkpoint directory) and
+/// assert the fail-safe invariant of issue #5832:
+///
+///   * exit code is non-zero (never a silent exit 0),
+///   * a loud ERROR is printed on stderr,
+///   * the WAL is NOT truncated — after clearing the failure, the committed
+///     change is recovered on the next open.
+#[cfg(unix)]
+#[test]
+fn test_checkpoint_write_failure_is_loud_nonzero_and_preserves_wal() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let home = default_home();
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("failsafe.vbsql");
+    let checkpoint_dir = dir.path().join("failsafe-checkpoints");
+    let wal_path = dir.path().join("failsafe.wal");
+
+    // Session 1: healthy — creates the table and the checkpoint archive.
+    let output = run_cli(&home, &db, "CREATE TABLE t(a int); INSERT INTO t VALUES(1);");
+    assert!(output.status.success(), "setup failed; stderr: {}", stderr_of(&output));
+    assert!(checkpoint_dir.is_dir(), "checkpoint dir should exist after session 1");
+
+    // Inject the failure: checkpoint directory becomes unwritable.
+    let orig_perms = fs::metadata(&checkpoint_dir).unwrap().permissions();
+    fs::set_permissions(&checkpoint_dir, fs::Permissions::from_mode(0o555)).unwrap();
+
+    // Skip when running as root (root bypasses permission checks).
+    if fs::File::create(checkpoint_dir.join(".probe")).is_ok() {
+        let _ = fs::remove_file(checkpoint_dir.join(".probe"));
+        fs::set_permissions(&checkpoint_dir, orig_perms).unwrap();
+        eprintln!("skipping: running as root, cannot inject a permission failure");
+        return;
+    }
+
+    let wal_size_before = fs::metadata(&wal_path).map(|m| m.len()).unwrap_or(0);
+
+    // Session 2: the INSERT commits to the WAL, but the checkpoint at exit
+    // fails. This must be LOUD and the process must exit non-zero.
+    let output = run_cli(&home, &db, "INSERT INTO t VALUES(2);");
+    assert!(
+        !output.status.success(),
+        "checkpoint failure must exit non-zero (issue #5832); stdout: {} stderr: {}",
+        stdout_of(&output),
+        stderr_of(&output)
+    );
+    let stderr = stderr_of(&output);
+    assert!(
+        stderr.contains("ERROR"),
+        "checkpoint failure must print a loud ERROR on stderr, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("left intact"),
+        "stderr must state the WAL was left intact, got: {stderr}"
+    );
+
+    // The WAL must NOT have been truncated: the committed INSERT was appended,
+    // so it can only have grown.
+    let wal_size_after = fs::metadata(&wal_path).map(|m| m.len()).unwrap_or(0);
+    assert!(
+        wal_size_after >= wal_size_before,
+        "WAL was truncated after a failed checkpoint ({wal_size_before} -> {wal_size_after})"
+    );
+
+    // Clear the failure: BOTH rows must be present — the committed INSERT is
+    // recovered from the intact WAL.
+    fs::set_permissions(&checkpoint_dir, orig_perms).unwrap();
+    let output = run_cli(&home, &db, "SELECT a FROM t ORDER BY a;");
+    assert!(output.status.success(), "reopen failed; stderr: {}", stderr_of(&output));
+    let out = stdout_of(&output);
+    assert!(out.contains('1'), "row 1 lost after failed checkpoint: {out}");
+    assert!(out.contains('2'), "committed row 2 lost after failed checkpoint: {out}");
+}


### PR DESCRIPTION
Closes #5832

## Summary

The NUMBER-typed-column wipe from the issue no longer reproduces on main: PR #5859 made unknown type names round-trip as `DataType::UserDefined` in the binary catalog (`parse_data_type` fallback), so `CREATE TABLE zz(b number)` survives reopen. What remained was the broader P0 invariant from the issue: **a checkpoint/save failure at exit must be loud, must never truncate the WAL, and must never exit 0.** Before this PR, a failed save printed a quiet localized warning and the process exited 0 — silent non-durability (same family as #5807 / PR #5850).

## Changes

- **`crates/vibesql-cli/src/util.rs`** — new `report_save_failure`: loud `ERROR:` lines on stderr stating explicitly that the WAL was left intact (WAL mode) or that recent changes are not durable (snapshot mode).
- **`crates/vibesql-cli/src/script.rs`** — script mode (`-c` / `-f` / stdin): a failed save sets a `persist_failed` flag and the process exits non-zero, including through the `.quit`/`.exit` early return. A later successful save clears the flag (each checkpoint captures full DB state).
- **`crates/vibesql-cli/src/repl.rs`** — per-statement save failures report loudly and the exit-time save retries; if the exit-time save also fails, `run()` returns `Err` so the process exits non-zero.
- **`crates/vibesql-cli/src/executor/wal.rs`** — documents the fail-safe invariant `WalState::checkpoint` already enforced (WAL truncated only after the checkpoint file is durably written) + a unit test that injects a checkpoint failure and asserts the WAL is byte-identical and recoverable.
- **`crates/vibesql-cli/tests/checkpoint_failure_test.rs`** — new integration suite against a real `vibesql` subprocess: the issue reproducer round-trips (`number`, `number(5)`, `number(5,10)`, unrelated-table data), and an injected checkpoint failure exits non-zero, prints `ERROR` on stderr, does not truncate the WAL, and the committed row is recovered once the failure is cleared.

## Verification

- Issue reproducer with the release binary: `CREATE TABLE zz(b number); CREATE TABLE ok(a int); INSERT INTO ok VALUES(1);` then reopen — `sqlite_master` shows both `zz` and `ok`, row intact, NUMBER column usable (`3.14` round-trips).
- Forced failure (read-only checkpoint dir): exit code 1; stderr shows `ERROR: failed to persist database ... Permission denied` and `ERROR: the write-ahead log at 'db.wal' was left intact ... Do NOT delete the .wal file.`; WAL grew 32 → 88 bytes (not truncated); after clearing the failure both committed rows recovered.
- `cargo test -p vibesql-storage` (761+ tests) and `cargo test -p vibesql-cli` (139 unit + all integration suites incl. the 4 new tests): all green.
- TCL: select1.test 188/188; table.test 64 passed / 18 failed — identical to post-#5859 main (the NUMBER-related failures were regained by #5859; remaining failures are pre-existing).
- Clippy on vibesql-cli: only one pre-existing warning in untouched `sqlite_io.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
