### PR TITLE
fix(storage): cover checkpoint header with CRC (v2) and guard stale checkpoint selection

### DIFF
--- a/crates/vibesql-cli/tests/recovery_failure_test.rs
+++ b/crates/vibesql-cli/tests/recovery_failure_test.rs
@@ -25,7 +25,10 @@ use std::{
 };
 
 use vibesql_catalog::{ColumnSchema, TableSchema};
-use vibesql_storage::{wal::CheckpointWriter, Database, Row};
+use vibesql_storage::{
+    wal::{CheckpointHeader, CheckpointWriter},
+    Database, Row,
+};
 use vibesql_types::{DataType, SqlValue};
 
 fn vibesql_binary() -> &'static str {
@@ -67,34 +70,18 @@ fn write_checkpoint(db_path: &Path, lsn: u64, table_name: &str) -> PathBuf {
     writer.create_checkpoint(lsn, &data, 1).unwrap().path
 }
 
-/// CRC-32 (IEEE, same polynomial as the checkpoint writer) — reimplemented
-/// here because the storage-internal helper is `pub(crate)`.
-fn crc32(data: &[u8]) -> u32 {
-    let mut crc = 0xFFFF_FFFFu32;
-    for &byte in data {
-        crc ^= byte as u32;
-        for _ in 0..8 {
-            if crc & 1 != 0 {
-                crc = (crc >> 1) ^ 0xEDB8_8320;
-            } else {
-                crc >>= 1;
-            }
-        }
-    }
-    crc ^ 0xFFFF_FFFF
-}
-
 /// Patch a checkpoint's *embedded* VBSQL snapshot version byte (file offset
 /// 37, after the 32-byte envelope header + 5-byte "VBSQL" magic) to 255 and
-/// re-stamp the envelope CRC (bytes 28..32, over the payload) so the envelope
-/// is fully valid — exactly what a checkpoint written by a newer VibeSQL
-/// binary looks like to this one.
+/// re-stamp the envelope CRC (bytes 28..32; for v2 envelopes it covers the
+/// 28-byte header prefix + payload) so the envelope is fully valid — exactly
+/// what a checkpoint written by a newer VibeSQL binary looks like to this one.
 fn bump_embedded_format_version(path: &Path) {
     let mut bytes = fs::read(path).unwrap();
     assert_eq!(&bytes[..4], b"VCHK", "not a checkpoint envelope");
     assert_eq!(&bytes[32..37], b"VBSQL", "payload is not a binary snapshot");
     bytes[37] = 255;
-    let crc = crc32(&bytes[32..]);
+    let header = CheckpointHeader::read(&mut &bytes[..]).unwrap();
+    let crc = header.expected_checksum(&bytes[32..]);
     bytes[28..32].copy_from_slice(&crc.to_le_bytes());
     fs::write(path, bytes).unwrap();
 }
@@ -247,6 +234,143 @@ fn test_legacy_snapshot_only_file_opens_with_data() {
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(out.status.success());
     assert!(stdout.contains("42"), "legacy data must survive reopen; stdout: {stdout}");
+}
+
+/// Issue #5855 gap 2: flipping ANY byte of the newest checkpoint — header
+/// fields (LSN at 8..16, timestamp at 16..24, num_tables at 24..28, checksum
+/// at 28..32) or body (catalog region, data region, tail) — must refuse to
+/// open by default. Before the v2 envelope checksum, header-field flips
+/// passed verification: a flipped LSN silently changed checkpoint selection
+/// and WAL replay with exit 0.
+#[test]
+fn test_checkpoint_byte_flip_sweep_refuses_to_open() {
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("flip.vbsql");
+
+    let checkpoint = write_checkpoint(&db_path, 5, "precious_data");
+    let original = fs::read(&checkpoint).unwrap();
+    assert!(original.len() > 64, "need a body to corrupt; got {} bytes", original.len());
+
+    // Sanity: the pristine checkpoint opens with its data.
+    let out = run_cli(home.path(), &db_path, &[], "SELECT id FROM precious_data");
+    assert!(
+        out.status.success() && String::from_utf8_lossy(&out.stdout).contains('1'),
+        "pristine checkpoint must open; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Representative offsets: every header field + body start / middle / tail.
+    let offsets = [4usize, 8, 12, 16, 20, 24, 28, 32, 40, original.len() / 2, original.len() - 1];
+    for offset in offsets {
+        let mut corrupted = original.clone();
+        corrupted[offset] ^= 0xFF;
+        fs::write(&checkpoint, &corrupted).unwrap();
+
+        let out = run_cli(home.path(), &db_path, &[], "SELECT id FROM precious_data");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            !out.status.success(),
+            "byte flip at offset {offset} must refuse to open; stdout: {stdout}"
+        );
+    }
+
+    // Restore: still opens (the sweep failures came from the flips alone).
+    fs::write(&checkpoint, &original).unwrap();
+    let out = run_cli(home.path(), &db_path, &[], "SELECT id FROM precious_data");
+    assert!(out.status.success(), "restored checkpoint must open again");
+}
+
+/// Issue #5855 gap 2 (stale-selection variant): flip the newest checkpoint's
+/// header LSN so a STALE checkpoint sorts newest. The corrupt file itself is
+/// never the one loaded, so only the creation-order guard stands between the
+/// user and a silent stale open. Default: hard error naming the suspect
+/// file; `--recover-fallback`: opens the older state loudly.
+#[test]
+fn test_header_lsn_flip_stale_selection_default_error_fallback_loud() {
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("lsnflip.vbsql");
+
+    write_checkpoint(&db_path, 10, "older_state");
+    let newest = write_checkpoint(&db_path, 20, "newest_state");
+
+    // Zero the newest checkpoint's header LSN (bytes 8..16) so it sorts as
+    // the oldest; everything else, including the stored checksum, is intact.
+    let mut bytes = fs::read(&newest).unwrap();
+    bytes[8..16].copy_from_slice(&0u64.to_le_bytes());
+    fs::write(&newest, &bytes).unwrap();
+
+    // Default: refuse to open, naming the suspect checkpoint.
+    let out = run_cli(home.path(), &db_path, &[], "SELECT name FROM sqlite_master");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "LSN-flipped newest checkpoint must refuse to open by default; stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    assert!(
+        stderr.contains(&newest.display().to_string()),
+        "stderr must name the suspect checkpoint; was: {stderr}"
+    );
+    assert!(stderr.contains("recover-fallback"), "must mention the opt-in; was: {stderr}");
+
+    // Opt-in: opens the older state, loudly naming the suspect file.
+    let out =
+        run_cli(home.path(), &db_path, &["--recover-fallback"], "SELECT name FROM sqlite_master");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "opt-in fallback must open; stderr: {stderr}");
+    assert!(stdout.contains("older_state"), "older state must be visible; stdout: {stdout}");
+    assert!(
+        stderr.contains("WARNING") && stderr.contains(&newest.display().to_string()),
+        "fallback must be loud and name the suspect checkpoint; was: {stderr}"
+    );
+}
+
+/// Issue #5855 gap 1 (regression): SQLite-style user-defined column type
+/// names (`banana`, quoted names, parameterized forms, fallback keywords)
+/// must round-trip through save + reopen. The reload used to error on the
+/// unknown name and the open path swallowed it, presenting an empty database
+/// with exit 0.
+#[test]
+fn test_userdefined_column_types_roundtrip_on_reopen() {
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("udt.vbsql");
+
+    let out = run_cli(
+        home.path(),
+        &db_path,
+        &[],
+        "CREATE TABLE t(a banana, b \"my weird type\", c fruit(8), d nvarchar(70), \
+         e counter(+5,-6), f attach); \
+         INSERT INTO t VALUES (1,'x',2.5,'y',9,'z');",
+    );
+    assert!(
+        out.status.success(),
+        "create must succeed; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Reopen in a fresh process: the table (and its rows) must still exist.
+    let out = run_cli(home.path(), &db_path, &[], "SELECT a, f FROM t");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "reopen must not error; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains('1') && stdout.contains('z'),
+        "row data must survive reopen; stdout: {stdout}"
+    );
+
+    // The verbatim CREATE source must survive too.
+    let out = run_cli(home.path(), &db_path, &[], "SELECT sql FROM sqlite_master WHERE name='t'");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(out.status.success());
+    assert!(
+        stdout.contains("banana") && stdout.contains("my weird type"),
+        "original type names must survive reopen; stdout: {stdout}"
+    );
 }
 
 /// A fresh, nonexistent database file still opens as an empty database — the

--- a/crates/vibesql-storage/src/wal/checkpoint.rs
+++ b/crates/vibesql-storage/src/wal/checkpoint.rs
@@ -23,6 +23,20 @@
 //
 // The checkpoint file reuses the existing binary format (.vbsql) for table
 // data serialization, prefixed with a checkpoint-specific header.
+//
+// ## Checksum coverage (issue #5855)
+//
+// * **Version 2 (current)**: the CRC32 at bytes 28..32 covers the first 28
+//   header bytes (magic, version, LSN, timestamp, num_tables) followed by the
+//   entire payload. Flipping ANY bit in the file — header field or body —
+//   fails verification. This matters because the header LSN drives both
+//   checkpoint selection (newest-by-LSN) and WAL replay (entries at or below
+//   the checkpoint LSN are skipped): an unprotected LSN flip could silently
+//   open stale state or silently drop committed WAL entries.
+// * **Version 1 (legacy, read-only)**: the CRC covers only the payload; the
+//   header fields are NOT integrity-protected. Existing v1 files remain
+//   readable; the cross-file creation-order guard in `recovery.rs` limits the
+//   stale-selection blast radius for them.
 
 use std::{
     fs::{self, File},
@@ -32,18 +46,26 @@ use std::{
 
 use crate::{
     persistence::binary::io::{read_u32, read_u64, write_u32, write_u64},
-    wal::{entry::Lsn, writer::verify_checksum},
+    wal::entry::Lsn,
     StorageError,
 };
 
 /// Magic number for checkpoint files: "VCHK"
 pub const CHECKPOINT_MAGIC: &[u8; 4] = b"VCHK";
 
-/// Current checkpoint format version
-pub const CHECKPOINT_VERSION: u32 = 1;
+/// Current checkpoint format version.
+///
+/// * v1: CRC32 covers the payload only (header fields unprotected).
+/// * v2: CRC32 covers the first 28 header bytes + payload (issue #5855).
+pub const CHECKPOINT_VERSION: u32 = 2;
 
 /// Size of the checkpoint header in bytes
 pub const CHECKPOINT_HEADER_SIZE: usize = 32;
+
+/// Number of leading header bytes covered by the v2 checksum (everything
+/// before the checksum field itself: magic, version, LSN, timestamp,
+/// num_tables).
+pub const CHECKSUMMED_HEADER_PREFIX_SIZE: usize = 28;
 
 /// Checkpoint file header
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -89,6 +111,37 @@ impl CheckpointHeader {
         write_u32(writer, self.checksum)?;
 
         Ok(())
+    }
+
+    /// Serialize the CRC-covered header prefix (bytes 0..28: magic, version,
+    /// LSN, timestamp, num_tables) exactly as `write` lays them out on disk.
+    ///
+    /// Used to compute/verify the v2 checksum, which covers this prefix
+    /// followed by the payload (issue #5855).
+    pub fn checksummed_prefix(&self) -> [u8; CHECKSUMMED_HEADER_PREFIX_SIZE] {
+        let mut prefix = [0u8; CHECKSUMMED_HEADER_PREFIX_SIZE];
+        prefix[0..4].copy_from_slice(CHECKPOINT_MAGIC);
+        prefix[4..8].copy_from_slice(&self.version.to_le_bytes());
+        prefix[8..16].copy_from_slice(&self.lsn.to_le_bytes());
+        prefix[16..24].copy_from_slice(&self.timestamp_ms.to_le_bytes());
+        prefix[24..28].copy_from_slice(&self.num_tables.to_le_bytes());
+        prefix
+    }
+
+    /// Compute the checksum this header *should* carry for `data`, per the
+    /// header's own format version:
+    ///
+    /// * v1 (legacy): CRC32 of the payload only.
+    /// * v2+: CRC32 of the 28-byte header prefix followed by the payload.
+    pub fn expected_checksum(&self, data: &[u8]) -> u32 {
+        if self.version >= 2 {
+            let mut hasher = Crc32::new();
+            hasher.update(&self.checksummed_prefix());
+            hasher.update(data);
+            hasher.finalize()
+        } else {
+            crc32(data)
+        }
     }
 
     /// Read and validate checkpoint header from a reader
@@ -206,7 +259,13 @@ impl CheckpointWriter {
         self.next_checkpoint_id += 1;
 
         let timestamp_ms = current_timestamp_ms();
-        let checksum = crc32(data);
+
+        // v2 checksum: covers the 28-byte header prefix + the payload, so a
+        // bit flip anywhere in the file (header LSN included) fails
+        // verification on read (issue #5855). Computed in one streaming pass;
+        // the payload is never re-read or copied.
+        let mut header = CheckpointHeader::new(lsn, timestamp_ms, num_tables, 0);
+        header.checksum = header.expected_checksum(data);
 
         // Create temp file path
         let temp_path = self.checkpoint_dir.join(format!("checkpoint_{}.tmp", checkpoint_id));
@@ -220,7 +279,6 @@ impl CheckpointWriter {
             let mut writer = BufWriter::new(file);
 
             // Write header
-            let header = CheckpointHeader::new(lsn, timestamp_ms, num_tables, checksum);
             header.write(&mut writer)?;
 
             // Write data
@@ -362,14 +420,64 @@ pub fn read_checkpoint_data(path: &Path) -> Result<(CheckpointHeader, Vec<u8>), 
         .read_to_end(&mut data)
         .map_err(|e| StorageError::IoError(format!("Failed to read checkpoint data: {}", e)))?;
 
-    // Verify checksum
-    if !verify_checksum(&data, header.checksum) {
+    // Verify checksum per the header's format version:
+    //   v1 (legacy): payload only — header fields are unprotected.
+    //   v2+: header prefix + payload — any bit flip in the file fails here
+    //        (issue #5855).
+    if header.expected_checksum(&data) != header.checksum {
         return Err(StorageError::IoError(
-            "Checkpoint data checksum mismatch - file may be corrupted".to_string(),
+            "Checkpoint checksum mismatch - header or data corrupted".to_string(),
         ));
     }
 
     Ok((header, data))
+}
+
+const CRC32_TABLE: [u32; 256] = {
+    let mut table = [0u32; 256];
+    let mut i = 0;
+    while i < 256 {
+        let mut crc = i as u32;
+        let mut j = 0;
+        while j < 8 {
+            if crc & 1 != 0 {
+                crc = (crc >> 1) ^ 0xEDB88320;
+            } else {
+                crc >>= 1;
+            }
+            j += 1;
+        }
+        table[i] = crc;
+        i += 1;
+    }
+    table
+};
+
+/// Incremental CRC-32 (IEEE) hasher — same polynomial/table as `crc32` and
+/// `writer.rs`, but streamable so the v2 checkpoint checksum can cover the
+/// header prefix followed by the payload in a single pass without
+/// concatenating them into a temporary buffer (issue #5855).
+pub(crate) struct Crc32 {
+    state: u32,
+}
+
+impl Crc32 {
+    pub(crate) fn new() -> Self {
+        Self { state: 0xFFFFFFFF }
+    }
+
+    pub(crate) fn update(&mut self, data: &[u8]) {
+        let mut crc = self.state;
+        for &byte in data {
+            let index = ((crc ^ byte as u32) & 0xFF) as usize;
+            crc = (crc >> 8) ^ CRC32_TABLE[index];
+        }
+        self.state = crc;
+    }
+
+    pub(crate) fn finalize(self) -> u32 {
+        self.state ^ 0xFFFFFFFF
+    }
 }
 
 /// CRC-32 implementation (same as in writer.rs for consistency)
@@ -377,32 +485,9 @@ pub fn read_checkpoint_data(path: &Path) -> Result<(CheckpointHeader, Vec<u8>), 
 /// `pub(crate)` so recovery tests can re-stamp a checkpoint envelope checksum
 /// after deliberately patching the payload (issue #5807 forward-version tests).
 pub(crate) fn crc32(data: &[u8]) -> u32 {
-    const CRC32_TABLE: [u32; 256] = {
-        let mut table = [0u32; 256];
-        let mut i = 0;
-        while i < 256 {
-            let mut crc = i as u32;
-            let mut j = 0;
-            while j < 8 {
-                if crc & 1 != 0 {
-                    crc = (crc >> 1) ^ 0xEDB88320;
-                } else {
-                    crc >>= 1;
-                }
-                j += 1;
-            }
-            table[i] = crc;
-            i += 1;
-        }
-        table
-    };
-
-    let mut crc = 0xFFFFFFFF;
-    for &byte in data {
-        let index = ((crc ^ byte as u32) & 0xFF) as usize;
-        crc = (crc >> 8) ^ CRC32_TABLE[index];
-    }
-    crc ^ 0xFFFFFFFF
+    let mut hasher = Crc32::new();
+    hasher.update(data);
+    hasher.finalize()
 }
 
 /// Get current timestamp in milliseconds since epoch
@@ -587,5 +672,147 @@ mod tests {
         // Test vectors
         assert_eq!(crc32(b"123456789"), 0xCBF43926);
         assert_eq!(crc32(b""), 0x00000000);
+    }
+
+    #[test]
+    fn test_crc32_incremental_matches_oneshot() {
+        let data = b"the quick brown fox jumps over the lazy dog";
+        let mut hasher = Crc32::new();
+        hasher.update(&data[..10]);
+        hasher.update(&data[10..]);
+        assert_eq!(hasher.finalize(), crc32(data));
+    }
+
+    /// Issue #5855: flipping ANY byte of a checkpoint file — header fields
+    /// (version, LSN, timestamp, num_tables, checksum) or payload — must fail
+    /// verification. Before v2 the CRC covered only the payload, so a bit
+    /// flip in the header LSN silently changed checkpoint selection and WAL
+    /// replay while the file still "verified".
+    #[test]
+    fn test_any_byte_flip_fails_checksum() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut writer = CheckpointWriter::new(temp_dir.path()).unwrap();
+
+        let data = b"payload bytes that stand in for a binary snapshot";
+        let info = writer.create_checkpoint(42, data, 3).unwrap();
+        let original = fs::read(&info.path).unwrap();
+
+        // Sanity: pristine file verifies.
+        read_checkpoint_data(&info.path).unwrap();
+
+        for offset in 0..original.len() {
+            let mut corrupted = original.clone();
+            corrupted[offset] ^= 0xFF;
+            fs::write(&info.path, &corrupted).unwrap();
+
+            assert!(
+                read_checkpoint_data(&info.path).is_err(),
+                "byte flip at offset {} must fail verification",
+                offset
+            );
+        }
+
+        // Restore and confirm it verifies again (the loop's failures came
+        // from the flips, not from the write cycle).
+        fs::write(&info.path, &original).unwrap();
+        read_checkpoint_data(&info.path).unwrap();
+    }
+
+    /// Legacy v1 checkpoints (checksum over payload only) must remain
+    /// readable: existing databases carry them and a hard error on every
+    /// pre-upgrade checkpoint would brick every existing DB.
+    #[test]
+    fn test_v1_legacy_checkpoint_still_reads() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("checkpoint_1.vchk");
+
+        let data = b"legacy v1 payload";
+        // Hand-write a v1 envelope: checksum = crc32(payload) only.
+        let header = CheckpointHeader {
+            version: 1,
+            lsn: 7,
+            timestamp_ms: 123,
+            num_tables: 1,
+            checksum: crc32(data),
+        };
+        let mut bytes = Vec::new();
+        header.write(&mut bytes).unwrap();
+        bytes.extend_from_slice(data);
+        fs::write(&path, &bytes).unwrap();
+
+        let (read_header, read_data) = read_checkpoint_data(&path).unwrap();
+        assert_eq!(read_header.version, 1);
+        assert_eq!(read_header.lsn, 7);
+        assert_eq!(read_data, data);
+
+        // v1 payload corruption is still caught.
+        let mut corrupted = bytes.clone();
+        *corrupted.last_mut().unwrap() ^= 0xFF;
+        fs::write(&path, &corrupted).unwrap();
+        assert!(read_checkpoint_data(&path).is_err(), "v1 payload flip must fail");
+    }
+
+    /// A v2 checkpoint whose version byte is rolled back to 1 must not verify
+    /// under the (weaker) v1 rule: the stored checksum was computed over
+    /// prefix+payload, so the v1 payload-only check fails. No downgrade path
+    /// re-opens the header-unprotected hole.
+    #[test]
+    fn test_version_rollback_flip_fails() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut writer = CheckpointWriter::new(temp_dir.path()).unwrap();
+        let info = writer.create_checkpoint(42, b"some payload", 1).unwrap();
+
+        let mut bytes = fs::read(&info.path).unwrap();
+        bytes[4..8].copy_from_slice(&1u32.to_le_bytes());
+        fs::write(&info.path, &bytes).unwrap();
+
+        assert!(read_checkpoint_data(&info.path).is_err());
+    }
+
+    /// Perf sanity for the v2 checksum (issue #5855): write + read a ~50MB
+    /// checkpoint and print timings. The v2 change adds only 28 extra bytes
+    /// to the CRC input, so the delta vs v1 must be noise. Run with:
+    /// `cargo test -p vibesql-storage --release bench_checkpoint_50mb -- --ignored --nocapture`
+    #[test]
+    #[ignore]
+    fn bench_checkpoint_50mb_write_read() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut writer = CheckpointWriter::new(temp_dir.path()).unwrap();
+
+        // ~50MB of non-trivial bytes.
+        let data: Vec<u8> =
+            (0..50_000_000usize).map(|i| (i.wrapping_mul(2654435761) >> 16) as u8).collect();
+
+        let t0 = std::time::Instant::now();
+        let info = writer.create_checkpoint(1, &data, 10).unwrap();
+        let write_elapsed = t0.elapsed();
+
+        let t1 = std::time::Instant::now();
+        let (_, read_back) = read_checkpoint_data(&info.path).unwrap();
+        let read_elapsed = t1.elapsed();
+
+        assert_eq!(read_back.len(), data.len());
+        println!(
+            "checkpoint 50MB: write {:?} (checksum+IO), read {:?} (IO+verify)",
+            write_elapsed, read_elapsed
+        );
+    }
+
+    /// Forward envelope versions stay a hard error (fail closed, #5807).
+    #[test]
+    fn test_forward_envelope_version_is_error() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut writer = CheckpointWriter::new(temp_dir.path()).unwrap();
+        let info = writer.create_checkpoint(42, b"some payload", 1).unwrap();
+
+        let mut bytes = fs::read(&info.path).unwrap();
+        bytes[4..8].copy_from_slice(&(CHECKPOINT_VERSION + 1).to_le_bytes());
+        fs::write(&info.path, &bytes).unwrap();
+
+        let err = read_checkpoint_data(&info.path).unwrap_err();
+        assert!(
+            err.to_string().contains("Unsupported checkpoint version"),
+            "expected version error, got: {err}"
+        );
     }
 }

--- a/crates/vibesql-storage/src/wal/recovery.rs
+++ b/crates/vibesql-storage/src/wal/recovery.rs
@@ -346,6 +346,61 @@ impl RecoveryManager {
             stats.skipped_checkpoints.extend(unreadable);
         }
 
+        // Creation-order sanity check (issue #5855): checkpoint ids strictly
+        // increase per write and the live WAL LSN counter never moves
+        // backwards across sessions (#5766), so the newest checkpoint by
+        // (LSN, id) must also be the highest-id one. If a higher-id file
+        // claims an older LSN, its header LSN is almost certainly corrupt —
+        // v1 envelope headers carry no checksum over the LSN field, so a bit
+        // flip there would otherwise make recovery silently open an older
+        // (stale) checkpoint with exit 0. Fail closed by default; the
+        // explicit fallback opt-in proceeds loudly in LSN order.
+        if let (Some(newest), Some(max_id)) =
+            (checkpoints.last(), checkpoints.iter().max_by_key(|c| c.id))
+        {
+            if max_id.id != newest.id {
+                if !fallback {
+                    return Err(StorageError::IoError(format!(
+                        "refusing to open: checkpoint LSN order disagrees with creation order \
+                         in {}: {} (id {}) was written after {} (id {}) but claims an older \
+                         LSN ({} < {}) — its header is likely corrupt. The database was NOT \
+                         modified. Re-run with --recover-fallback to recover from the newest \
+                         checkpoint by LSN (changes committed after it may be missing).",
+                        self.checkpoint_dir.display(),
+                        max_id.path.display(),
+                        max_id.id,
+                        newest.path.display(),
+                        newest.id,
+                        max_id.lsn,
+                        newest.lsn,
+                    )));
+                }
+                log::warn!(
+                    "checkpoint LSN order disagrees with creation order: {} (id {}, LSN {}) \
+                     vs {} (id {}, LSN {}); proceeding in LSN order per --recover-fallback",
+                    max_id.path.display(),
+                    max_id.id,
+                    max_id.lsn,
+                    newest.path.display(),
+                    newest.id,
+                    newest.lsn,
+                );
+                stats.corruption_detected = true;
+                stats.skipped_checkpoints.push(SkippedCheckpoint {
+                    path: max_id.path.clone(),
+                    error: format!(
+                        "written after {} (id {} > id {}) but claims an older LSN ({} < {}) — \
+                         header likely corrupt; recovery proceeded in LSN order",
+                        newest.path.display(),
+                        max_id.id,
+                        newest.id,
+                        max_id.lsn,
+                        newest.lsn
+                    ),
+                });
+            }
+        }
+
         // Try checkpoints from newest to oldest
         let mut retries = 0;
         let mut failures: Vec<String> = Vec::new();
@@ -1755,8 +1810,6 @@ mod tests {
     // then every skipped file is recorded in `RecoveryStats`.
     // ------------------------------------------------------------------
 
-    use crate::wal::checkpoint::crc32;
-
     /// Write a real checkpoint for `db` at `lsn` and return its path.
     fn write_db_checkpoint(dir: &Path, lsn: Lsn, db: &Database) -> PathBuf {
         let mut writer = CheckpointWriter::new(dir).unwrap();
@@ -1785,7 +1838,10 @@ mod tests {
         assert_eq!(&bytes[..4], b"VCHK", "not a checkpoint envelope");
         assert_eq!(&bytes[32..37], b"VBSQL", "payload is not a binary snapshot");
         bytes[37] = crate::persistence::binary::format::VERSION + 1;
-        let crc = crc32(&bytes[32..]);
+        // Re-stamp the envelope CRC per the envelope's own format version
+        // (v2 covers the 28-byte header prefix + payload; v1 payload only).
+        let header = crate::wal::CheckpointHeader::read(&mut &bytes[..]).unwrap();
+        let crc = header.expected_checksum(&bytes[32..]);
         bytes[28..32].copy_from_slice(&crc.to_le_bytes());
         fs::write(path, bytes).unwrap();
     }
@@ -1920,6 +1976,76 @@ mod tests {
         assert!(stats.corruption_detected);
         assert_eq!(stats.skipped_checkpoints.len(), 1);
         assert_eq!(stats.skipped_checkpoints[0].path, garbage);
+    }
+
+    /// Issue #5855: a higher-id (written-later) checkpoint claiming an OLDER
+    /// LSN than an earlier one means its header LSN is likely corrupt — v1
+    /// envelopes carry no header checksum, so a bit-flipped LSN would
+    /// otherwise make recovery silently open the older (stale) checkpoint
+    /// with exit 0. Default: hard error naming both files. Fallback: proceed
+    /// in LSN order, loudly, recording the suspect file.
+    #[test]
+    fn test_lsn_order_vs_creation_order_disagreement() {
+        let temp_dir = TempDir::new().unwrap();
+        let dir = temp_dir.path().join("checkpoints");
+
+        // id 1 at LSN 20, then id 2 at LSN 5: creation order says id 2 is
+        // newest, LSN order says id 1 is. (In a healthy archive the WAL LSN
+        // counter never moves backwards across sessions — #5766.)
+        let older_by_id = write_db_checkpoint(&dir, 20, &db_with_table("lsn20_state"));
+        let newer_by_id = write_db_checkpoint(&dir, 5, &db_with_table("lsn5_state"));
+
+        let err = RecoveryManager::new(&dir).recover().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&newer_by_id.display().to_string())
+                && msg.contains(&older_by_id.display().to_string()),
+            "error must name both disagreeing checkpoints; was: {msg}"
+        );
+        assert!(msg.contains("recover-fallback"), "must mention the opt-in; was: {msg}");
+
+        // Fallback: recovers newest-by-LSN, loudly recording the suspect file.
+        let (db, stats) = RecoveryManager::with_config(&dir, fallback_config()).recover().unwrap();
+        assert!(db.get_table("main.lsn20_state").is_some());
+        assert!(stats.corruption_detected);
+        assert!(
+            stats.skipped_checkpoints.iter().any(|s| s.path == newer_by_id),
+            "the suspect checkpoint must be reported: {:?}",
+            stats.skipped_checkpoints
+        );
+    }
+
+    /// Issue #5855 gap 2 (integrated): flip the LSN field inside the newest
+    /// checkpoint's header so it sorts as the OLDEST. The v2 checksum covers
+    /// the header, so the file no longer verifies — but selection never even
+    /// loads it (a stale checkpoint sorts newest). The creation-order guard
+    /// must fail closed by default.
+    #[test]
+    fn test_header_lsn_byte_flip_never_opens_stale_silently() {
+        let temp_dir = TempDir::new().unwrap();
+        let dir = temp_dir.path().join("checkpoints");
+
+        write_db_checkpoint(&dir, 10, &db_with_table("stale_state"));
+        let newest = write_db_checkpoint(&dir, 20, &db_with_table("newest_state"));
+
+        // Zero the newest checkpoint's header LSN (bytes 8..16), leaving
+        // everything else — including the stored checksum — intact.
+        let mut bytes = fs::read(&newest).unwrap();
+        bytes[8..16].copy_from_slice(&0u64.to_le_bytes());
+        fs::write(&newest, &bytes).unwrap();
+
+        let err = RecoveryManager::new(&dir).recover().unwrap_err();
+        assert!(
+            err.to_string().contains(&newest.display().to_string()),
+            "default open must fail naming the suspect file; was: {err}"
+        );
+
+        // Fallback: the stale state is recovered — loudly — and the corrupt
+        // file is reported (its v2 checksum no longer verifies either).
+        let (db, stats) = RecoveryManager::with_config(&dir, fallback_config()).recover().unwrap();
+        assert!(db.get_table("main.stale_state").is_some());
+        assert!(stats.corruption_detected);
+        assert!(stats.skipped_checkpoints.iter().any(|s| s.path == newest));
     }
 
     /// `recover_with_base` seeds from the provided base only when no


### PR DESCRIPTION
## Summary

Closes the remaining silent-open gaps from #5855 (post-#5850). Checkpoint envelope v1's CRC32 covered only the payload — the header fields (LSN, timestamp, num_tables at bytes 8..28) were unprotected, so a bit flip there opened with exit 0 while silently changing WAL replay and checkpoint selection. Gap 1 (unknown column type emptying the DB on reopen) was re-verified as already fixed on current main; a CLI regression test now pins it.

## Changes

- **Checkpoint format v2** (`crates/vibesql-storage/src/wal/checkpoint.rs`): the envelope CRC32 now covers the 28-byte header prefix (magic, version, LSN, timestamp, num_tables) plus the payload, computed and verified in a single streaming pass via a new incremental `Crc32` hasher — the payload is never re-read or concatenated. Any single-byte flip anywhere in a v2 file now fails verification.
- **Backward/forward compatibility**: legacy v1 checkpoints stay readable (payload-only checksum rule, version-dispatched); a v2 file with its version byte rolled back to 1 fails verification (no downgrade hole); forward envelope versions remain a hard error (fail-closed, #5807 policy — old binaries refuse v2 files rather than misread them).
- **Stale-selection guard** (`crates/vibesql-storage/src/wal/recovery.rs`): checkpoint ids strictly increase in creation order and the WAL LSN counter never moves backwards (#5766), so the newest checkpoint by (LSN, id) must also be the highest-id file. Disagreement — e.g. a bit-flipped LSN in a legacy v1 header making a stale checkpoint sort newest — is now a hard open error by default; `--recover-fallback` proceeds loudly in LSN order and records the suspect file in the skipped-checkpoint report.
- **Tests**: exhaustive per-byte flip sweep (every offset of a checkpoint file) at the storage level; CLI subprocess sweep across header/catalog/data/tail offsets; stale-LSN-flip scenario at both levels (default hard error naming the file, fallback loud); v1 legacy readability; version-rollback rejection; gap-1 UserDefined round-trip regression (banana, quoted, parameterized, keyword type names); `#[ignore]`d 50MB write+read perf probe.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `CREATE TABLE t(x banana)` round-trips (SQLite affinity semantics) | Already fixed on main | Re-verified manually with `banana`, `"my weird type"`, `fruit(8)`, `nvarchar(70)`, `counter(+5,-6)`, `attach` — all reopen with data and verbatim `sqlite_master.sql`; pinned by new `test_userdefined_column_types_roundtrip_on_reopen` |
| Genuinely unparseable catalog hard-errors | Already fixed on main | #5878 made unparseable `sql_source` a hard error; `parse_data_type` falls back to `UserDefined` so type names can no longer fail parse |
| Byte-flipped checkpoint body → checksum failure → hard error (or `--recover-fallback`) | Fixed | Body flips already failed on main; the real residual gap was header bytes 8..27 which opened exit-0. Post-fix manual sweep: offsets 0,4,8,12,16,20,24,28,32,40,60,100,130,200,tail ALL exit 1; storage test flips every byte of the file |
| `--recover-fallback` falls back loudly | Verified | `test_header_lsn_flip_stale_selection_default_error_fallback_loud` asserts WARNING + suspect file name on stderr; existing fallback tests still green |
| Clean checkpoints unaffected | Verified | Full round-trip suite green; sweep tests restore the pristine file and assert it opens again |
| keyword1.test UserDefined-keyword tests | Already passing | keyword1 fallback-keyword support landed via #5859 (116/116 per its PR); `attach` as column name+type covered in the new regression test |

## Perf (50MB checkpoint write+read, medians of 5, release)

| | write (checksum+IO) | read (IO+verify) |
|---|---|---|
| before (main, v1) | 173.3 ms | 123.8 ms |
| after (branch, v2) | 177.2 ms | 124.9 ms |

Delta is within run-to-run noise (write ranged 171–225 ms in both configs on a non-quiet machine); the change adds 28 bytes to the CRC input and keeps the existing single-pass structure — no double read.

## Test Plan

- `cargo test -p vibesql-storage -p vibesql-cli` — all green (768 storage lib + 139 CLI lib + all integration suites, 0 failures)
- `cargo test -p vibesql-cli --test recovery_failure_test` — 8/8 including the three new tests
- Manual CLI byte-flip sweep with the release binary (all offsets exit 1; pristine restore opens with data)
- Before/after 50MB perf probes built against main and this branch

Closes #5855