### PR TITLE
fix(storage): persist SQLite rowids across reload; make REPLACE INTO durable

### DIFF
--- a/crates/vibesql-cli/src/repl.rs
+++ b/crates/vibesql-cli/src/repl.rs
@@ -339,4 +339,7 @@ fn is_modification_statement(sql: &str) -> bool {
         || upper.starts_with("INSERT ")
         || upper.starts_with("UPDATE ")
         || upper.starts_with("DELETE ")
+        // REPLACE INTO is DML (delete conflicting rows + insert). Missing it
+        // meant a REPLACE-only session never checkpointed at exit (#5835).
+        || upper.starts_with("REPLACE ")
 }

--- a/crates/vibesql-cli/src/script.rs
+++ b/crates/vibesql-cli/src/script.rs
@@ -327,6 +327,9 @@ fn is_modification_statement(sql: &str) -> bool {
         || upper.starts_with("INSERT ")
         || upper.starts_with("UPDATE ")
         || upper.starts_with("DELETE ")
+        // REPLACE INTO is DML (delete conflicting rows + insert). Missing it
+        // meant a REPLACE-only session never checkpointed at exit (#5835).
+        || upper.starts_with("REPLACE ")
     {
         return true;
     }

--- a/crates/vibesql-cli/tests/wal_recovery_test.rs
+++ b/crates/vibesql-cli/tests/wal_recovery_test.rs
@@ -455,3 +455,75 @@ fn test_autocommit_writes_accumulate_across_separate_processes() {
         "committed UPDATE must persist across a process re-open; got:\n{updated}"
     );
 }
+
+/// End-to-end regression for issue #5835: INTEGER PRIMARY KEY ⇄ rowid
+/// aliasing must survive a cross-process reopen. Before the fix,
+/// `rowid_alias_column` was never rebuilt on load, so `WHERE rowid=5`
+/// returned zero rows and `DELETE ... WHERE rowid=N` removed the WRONG row
+/// (intpkey-2.6) after a restart.
+#[cfg(unix)]
+#[test]
+fn test_rowid_alias_survives_separate_process_reopen() {
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("rowid_alias.vbsql");
+    let bin = vibesql_binary();
+
+    run_script(
+        bin,
+        &db_path,
+        home.path(),
+        "CREATE TABLE p(a INTEGER PRIMARY KEY, b);\n\
+         INSERT INTO p VALUES(5,'five'),(7,'seven'),(9,'nine');\n",
+    );
+
+    // Process 2: rowid lookups must resolve through the IPK alias.
+    let out = run_script(bin, &db_path, home.path(), "SELECT b FROM p WHERE rowid=5;\n");
+    assert!(
+        out.contains("five"),
+        "WHERE rowid=5 must find the a=5 row after a process reopen; got:\n{out}"
+    );
+
+    // Process 3: DELETE by rowid must remove exactly the a=7 row.
+    run_script(bin, &db_path, home.path(), "DELETE FROM p WHERE rowid=7;\n");
+    let remaining = run_script(bin, &db_path, home.path(), "SELECT b FROM p ORDER BY a;\n");
+    assert!(
+        remaining.contains("five") && remaining.contains("nine") && !remaining.contains("seven"),
+        "DELETE WHERE rowid=7 must remove the a=7 row (and only it); got:\n{remaining}"
+    );
+}
+
+/// End-to-end regression for issues #5835 / #5871: a plain REPLACE INTO must
+/// be durable across a cross-process reopen. Before the fix the REPLACE's
+/// conflict-delete emitted no WAL op (and REPLACE never triggered the
+/// exit-time checkpoint), so the next process resurrected the old row next to
+/// the new one — two rows with the same INTEGER PRIMARY KEY.
+#[cfg(unix)]
+#[test]
+fn test_replace_into_durable_across_separate_process_reopen() {
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("replace_durable.vbsql");
+    let bin = vibesql_binary();
+
+    run_script(
+        bin,
+        &db_path,
+        home.path(),
+        "CREATE TABLE t1(aa INTEGER PRIMARY KEY, bb INT);\n\
+         INSERT INTO t1 VALUES(11,22);\nCREATE UNIQUE INDEX t1bb ON t1(bb);\n",
+    );
+
+    // Process 2: REPLACE the conflicting row (delete (11,22), insert (11,33)).
+    run_script(bin, &db_path, home.path(), "REPLACE INTO t1 VALUES(11,33);\n");
+
+    // Process 3: exactly one row, with the replaced value.
+    let count = run_script(bin, &db_path, home.path(), "SELECT count(*) AS n FROM t1;\n");
+    assert!(
+        count.contains('1') && !count.contains('2'),
+        "REPLACE must leave exactly one row after a process reopen; got:\n{count}"
+    );
+    let val = run_script(bin, &db_path, home.path(), "SELECT bb FROM t1 WHERE aa=11;\n");
+    assert!(
+        val.contains("33") && !val.contains("22"),
+        "the surviving row must be the REPLACEd one (bb=33); got:\n{val}"
+    );
+}

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -485,18 +485,18 @@ fn execute_insert_internal(
     // Get table's current max rowid for auto-assignment (SQLite semantics)
     // When inserting with explicit rowid column, NULL rowids should be assigned values
     // greater than both:
-    // 1. The table's current max rowid (`next_rowid() - 1`: covers both the
-    //    physical row count and every explicit rowid ever assigned — including
-    //    rowids reloaded from disk, which can exceed the compacted physical
-    //    count; issue #5835)
+    // 1. The table's current max *signed* rowid (`max_rowid_signed()`: covers
+    //    every effective rowid ever assigned — implicit positions AND explicit
+    //    rowids, including rowids reloaded from disk, which can exceed the
+    //    compacted physical count; issue #5835). SQLite rowids are signed:
+    //    a table whose only rowid is -1 auto-assigns 0 next (verified against
+    //    sqlite3), and `None` (no rows ever) auto-assigns 1.
     // 2. Explicit rowids processed so far in the batch (NOT future rows)
-    let table_max_rowid = db
-        .get_table(&storage_table_name)
-        .map(|t| t.next_rowid().saturating_sub(1))
-        .unwrap_or(0);
+    let table_max_rowid: Option<i64> =
+        db.get_table(&storage_table_name).and_then(|t| t.max_rowid_signed());
 
-    // Track maximum rowid seen so far (updated as we process each row)
-    let mut batch_max_rowid = table_max_rowid;
+    // Track maximum signed rowid seen so far (updated as we process each row)
+    let mut batch_max_rowid: Option<i64> = table_max_rowid;
 
     for value_exprs in &rows_to_insert {
         // Build a complete row with values for all columns
@@ -516,18 +516,23 @@ fn execute_insert_internal(
             // an integer is coerced (e.g. '45' -> 45, -42.0 -> -42), a value
             // with a fractional part (e.g. 42.4) or a non-numeric TEXT/BLOB
             // raises "datatype mismatch" (triggerC-4.1.x).
+            // Rowids are signed (issue #5835): explicit values are tracked
+            // under signed comparison (a negative rowid raises the max only
+            // if the max is even more negative, matching sqlite3's
+            // `max(existing) + 1` allocation), and NULL/DEFAULT auto-assigns
+            // signed-max + 1 (or 1 for a table that never held a row).
+            // The returned u64 is the two's-complement bit pattern stored in
+            // `Row::row_id`.
             let mut apply_affinity = |affinity: RowidAffinity| -> u64 {
                 match affinity {
                     RowidAffinity::Value(i) => {
-                        let rowid = i as u64;
-                        if i > 0 {
-                            batch_max_rowid = batch_max_rowid.max(rowid);
-                        }
-                        rowid
+                        batch_max_rowid = Some(batch_max_rowid.map_or(i, |m| m.max(i)));
+                        i as u64
                     }
                     RowidAffinity::Auto => {
-                        batch_max_rowid += 1;
-                        batch_max_rowid
+                        let next = batch_max_rowid.map_or(1, |m| m.saturating_add(1));
+                        batch_max_rowid = Some(next);
+                        next as u64
                     }
                 }
             };
@@ -1154,8 +1159,11 @@ fn execute_insert_internal(
                         )));
                     } else if explicit_rowid.is_none() {
                         // Explicit REPLACE rowid: auto-allocated trigger INSERT skips to next rowid
-                        // This approximates SQLite's rowid reuse behavior
-                        let new_rowid = reserved_rowid + 1;
+                        // This approximates SQLite's rowid reuse behavior.
+                        // Rowids are signed bit patterns (issue #5835): step
+                        // in signed space so a reserved rowid of -1
+                        // (u64::MAX) steps to 0, not past u64 range.
+                        let new_rowid = (reserved_rowid as i64).saturating_add(1) as u64;
                         final_explicit_rowid = Some(new_rowid);
 
                         // Also update the INTEGER PRIMARY KEY column value to match the new rowid

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -485,10 +485,15 @@ fn execute_insert_internal(
     // Get table's current max rowid for auto-assignment (SQLite semantics)
     // When inserting with explicit rowid column, NULL rowids should be assigned values
     // greater than both:
-    // 1. The table's current max rowid
+    // 1. The table's current max rowid (`next_rowid() - 1`: covers both the
+    //    physical row count and every explicit rowid ever assigned — including
+    //    rowids reloaded from disk, which can exceed the compacted physical
+    //    count; issue #5835)
     // 2. Explicit rowids processed so far in the batch (NOT future rows)
-    let table_max_rowid =
-        db.get_table(&storage_table_name).map(|t| t.row_count() as u64).unwrap_or(0);
+    let table_max_rowid = db
+        .get_table(&storage_table_name)
+        .map(|t| t.next_rowid().saturating_sub(1))
+        .unwrap_or(0);
 
     // Track maximum rowid seen so far (updated as we process each row)
     let mut batch_max_rowid = table_max_rowid;
@@ -1117,7 +1122,12 @@ fn execute_insert_internal(
                 .get_table(&storage_table_name)
                 .ok_or_else(|| ExecutorError::TableNotFound(full_table_name.clone()))?;
             let row_count_before = table_ref.row_count();
-            let physical_row_count_before = table_ref.physical_row_count();
+            // Collision-safe auto-rowid (issue #5835): identical to the old
+            // `physical_row_count + 1` for purely implicit tables, but also
+            // exceeds every explicit rowid ever assigned — required after a
+            // reload, where persisted rowids can exceed the compacted
+            // physical count.
+            let next_auto_rowid = table_ref.next_rowid();
 
             // SQLite REPLACE semantics: Check if the rowid we're about to use is reserved.
             // During REPLACE, the rowid for the new row is allocated BEFORE firing triggers.
@@ -1126,7 +1136,7 @@ fn execute_insert_internal(
             // - Explicit reservation: AFTER DELETE trigger auto-INSERTs skip to next rowid (SQLite
             //   reuses freed rowids, but VibeSQL doesn't, so we skip instead)
             let mut final_explicit_rowid = explicit_rowid;
-            let rowid_to_use = explicit_rowid.unwrap_or((physical_row_count_before + 1) as u64);
+            let rowid_to_use = explicit_rowid.unwrap_or(next_auto_rowid);
             if let Some((reserved_rowid, is_explicit_reservation)) =
                 db.get_reserved_rowid_info(&storage_table_name)
             {
@@ -1168,6 +1178,16 @@ fn execute_insert_internal(
                         )));
                     }
                 }
+            }
+
+            // Materialize the auto-allocated rowid on the stored row (issue
+            // #5835) so it persists across saves/reloads and can never be
+            // silently renumbered. Skip INTEGER PRIMARY KEY (rowid alias)
+            // tables: there the IPK column value IS the rowid and every
+            // rowid read resolves through the alias column, so stamping a
+            // physical-position-derived row_id could disagree with it.
+            if final_explicit_rowid.is_none() && ipk_col_idx.is_none() {
+                final_explicit_rowid = Some(rowid_to_use);
             }
 
             // Insert the row
@@ -1227,7 +1247,7 @@ fn execute_insert_internal(
                 // trigger body (#5485). For an explicit `INSERT INTO t(rowid,...)`
                 // the row already carries `row_id`; for an auto-allocated rowid
                 // the row was created with `row_id == None`, and the actual rowid
-                // is `rowid_to_use` (physical_row_count_before + 1).
+                // is `rowid_to_use` (the table's next auto-allocated rowid).
                 let after_row = {
                     let mut r = row.clone();
                     if r.row_id.is_none() {
@@ -1364,11 +1384,12 @@ fn resolve_replace_conflicts_for_row(
     let reserved_rowid = if let Some(rowid) = explicit_rowid {
         rowid
     } else {
-        // Auto-allocate: next available rowid is physical row count + 1
-        // (physical includes deleted rows since rowid is based on physical index)
-        let current_physical =
-            db.get_table(storage_table_name).map(|t| t.physical_row_count() as u64).unwrap_or(0);
-        current_physical + 1
+        // Auto-allocate the next available rowid. `next_rowid()` covers both
+        // the physical row count (implicit rowids, including deleted rows)
+        // and every explicit rowid ever assigned — required after a reload,
+        // where persisted rowids can exceed the compacted physical count
+        // (issue #5835).
+        db.get_table(storage_table_name).map(|t| t.next_rowid()).unwrap_or(1)
     };
 
     // Reserve the rowid before firing triggers

--- a/crates/vibesql-executor/src/insert/replace.rs
+++ b/crates/vibesql-executor/src/insert/replace.rs
@@ -207,6 +207,15 @@ pub fn handle_replace_conflicts(
     // For explicit reservations: AFTER DELETE trigger INSERTs will skip to next rowid.
     // The caller is responsible for releasing the reservation after the REPLACE INSERT.
 
+    // WAL-log the conflict deletes BEFORE applying them (issues #5835 /
+    // #5871), mirroring the DELETE executor. Without these ops the REPLACE's
+    // delete of the conflicting row is invisible to crash recovery: WAL
+    // replay re-inserts the new row next to the undeleted old one, yielding
+    // duplicate PRIMARY KEY rows after a restart (check-13.x, upsert5-3.x).
+    for (row_index, row) in &rows_to_delete {
+        db.emit_wal_delete(table_name, *row_index as u64, row.values.to_vec());
+    }
+
     // Remove entries from user-defined indexes BEFORE deleting rows
     // (while row indices are still valid)
     // Use batch method for better performance (pre-computes column indices once)

--- a/crates/vibesql-executor/src/memory/external_sort.rs
+++ b/crates/vibesql-executor/src/memory/external_sort.rs
@@ -161,8 +161,11 @@ impl SortKeyComparator {
         if key_cmp != Ordering::Equal {
             return key_cmp;
         }
-        // Use rowid as tie-breaker for deterministic ordering
-        a.0.row_id.cmp(&b.0.row_id)
+        // Use rowid as tie-breaker for deterministic ordering.
+        // Rowids are SIGNED (issue #5835): row_id stores the two's-complement
+        // bit pattern of an i64, so compare in signed space (-1 sorts before
+        // 0). Identical to u64 order for non-negative rowids.
+        a.0.row_id.map(|r| r as i64).cmp(&b.0.row_id.map(|r| r as i64))
     }
 }
 
@@ -415,8 +418,9 @@ impl Ord for MergeEntry {
             return key_cmp;
         }
         // Use rowid as tie-breaker for SQLite-compatible ordering (issue #4893)
-        // Note: reversed because we're in a max-heap (smaller rowid = higher priority)
-        other.row.row_id.cmp(&self.row.row_id)
+        // Note: reversed because we're in a max-heap (smaller rowid = higher priority).
+        // Signed comparison (issue #5835): row_id is an i64 bit pattern.
+        other.row.row_id.map(|r| r as i64).cmp(&self.row.row_id.map(|r| r as i64))
     }
 }
 

--- a/crates/vibesql-executor/src/select/executor/fast_path/helpers.rs
+++ b/crates/vibesql-executor/src/select/executor/fast_path/helpers.rs
@@ -377,7 +377,12 @@ impl SelectExecutor<'_> {
                                 }
                             }
                             (Some(id_a), Some(id_b)) => {
-                                let raw_cmp = id_a.cmp(&id_b);
+                                // Rowids are SIGNED (issue #5835): row_id is
+                                // the two's-complement bit pattern of an i64,
+                                // so compare in signed space — rowid -1
+                                // (u64::MAX) sorts before 0. Identical to
+                                // u64 order for non-negative rowids.
+                                let raw_cmp = (id_a as i64).cmp(&(id_b as i64));
                                 match dir {
                                     OrderDirection::Asc => raw_cmp,
                                     OrderDirection::Desc => raw_cmp.reverse(),

--- a/crates/vibesql-executor/src/select/order/parallel.rs
+++ b/crates/vibesql-executor/src/select/order/parallel.rs
@@ -35,8 +35,12 @@ pub(super) fn sort_rows(rows: &mut [RowWithSortKeys]) {
             return sort_cmp;
         }
         // Use rowid as tie-breaker for deterministic ordering matching SQLite behavior
-        // When sort keys are equal, order by rowid (insertion order) ascending
-        row_a.row_id.cmp(&row_b.row_id)
+        // When sort keys are equal, order by rowid (insertion order) ascending.
+        // Rowids are SIGNED (issue #5835): row_id stores the two's-complement
+        // bit pattern of an i64, so compare in signed space — a rowid of -1
+        // (u64::MAX) must sort before 0. Identical to u64 order for
+        // non-negative rowids.
+        row_a.row_id.map(|r| r as i64).cmp(&row_b.row_id.map(|r| r as i64))
     };
 
     #[cfg(feature = "parallel")]

--- a/crates/vibesql-executor/src/tests/rowid_tests.rs
+++ b/crates/vibesql-executor/src/tests/rowid_tests.rs
@@ -707,3 +707,113 @@ fn test_order_by_rowid_desc() {
     assert_eq!(result[1].values[0], vibesql_types::SqlValue::Integer(20));
     assert_eq!(result[2].values[0], vibesql_types::SqlValue::Integer(10));
 }
+
+// ---------------------------------------------------------------------------
+// Negative rowids (PR #5891 judge review) — rowids are SIGNED in SQLite
+// ---------------------------------------------------------------------------
+
+/// SQL-level helpers for the negative-rowid regressions below.
+mod negative_rowid_sql {
+    use vibesql_ast::Statement;
+    use vibesql_parser::Parser;
+
+    use super::super::super::*;
+
+    pub fn exec(db: &mut vibesql_storage::Database, sql: &str) {
+        match Parser::parse_sql(sql).unwrap() {
+            Statement::CreateTable(stmt) => {
+                CreateTableExecutor::execute(&stmt, db).unwrap();
+            }
+            Statement::Insert(stmt) => {
+                InsertExecutor::execute(db, &stmt).unwrap();
+            }
+            other => panic!("unsupported statement in test helper: {other:?}"),
+        }
+    }
+
+    /// Runs a SELECT and returns the rows.
+    pub fn query(db: &vibesql_storage::Database, sql: &str) -> Vec<vibesql_storage::Row> {
+        match Parser::parse_sql(sql).unwrap() {
+            Statement::Select(stmt) => SelectExecutor::new(db).execute(&stmt).unwrap(),
+            other => panic!("expected SELECT in test helper: {other:?}"),
+        }
+    }
+}
+
+/// Judge-review repro for PR #5891: an explicit NEGATIVE rowid must not
+/// poison rowid allocation. Previously `INSERT INTO t(rowid,x) VALUES(-1,5)`
+/// stored `-1` as `u64::MAX` and tracked it as an unsigned max, so the next
+/// implicit insert computed `u64::MAX + 1` — panic in debug builds,
+/// duplicate rowid 0 in release builds.
+///
+/// sqlite3-verified semantics: rowids are signed; allocation is
+/// `signed max + 1`, so after rowid -1 the next implicit rowid is 0.
+#[test]
+fn test_negative_explicit_rowid_then_implicit_insert() {
+    use negative_rowid_sql::{exec, query};
+
+    let mut db = vibesql_storage::Database::new();
+    exec(&mut db, "CREATE TABLE t(x INTEGER)");
+    exec(&mut db, "INSERT INTO t(rowid, x) VALUES(-1, 5)");
+    // This insert previously panicked (attempt to add with overflow).
+    exec(&mut db, "INSERT INTO t VALUES(6)");
+
+    // sqlite3: -1|5 then 0|6, ordered signed.
+    let rows = query(&db, "SELECT rowid, x FROM t ORDER BY rowid");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Bigint(-1));
+    assert_eq!(rows[0].values[1], vibesql_types::SqlValue::Integer(5));
+    assert_eq!(rows[1].values[0], vibesql_types::SqlValue::Bigint(0), "sqlite3 allocates 0 after -1");
+    assert_eq!(rows[1].values[1], vibesql_types::SqlValue::Integer(6));
+
+    // The negative rowid is addressable.
+    let by_rowid = query(&db, "SELECT x FROM t WHERE rowid = -1");
+    assert_eq!(by_rowid.len(), 1);
+    assert_eq!(by_rowid[0].values[0], vibesql_types::SqlValue::Integer(5));
+}
+
+/// Batch variant (sqlite3-verified): a NULL rowid in the same INSERT as a
+/// negative explicit rowid auto-assigns signed-max + 1.
+#[test]
+fn test_negative_rowid_batch_null_autoassign() {
+    use negative_rowid_sql::{exec, query};
+
+    let mut db = vibesql_storage::Database::new();
+    exec(&mut db, "CREATE TABLE t(x INTEGER)");
+    // sqlite3: -1|1 then 0|2.
+    exec(&mut db, "INSERT INTO t(rowid, x) VALUES(-1, 1), (NULL, 2)");
+
+    let rows = query(&db, "SELECT rowid, x FROM t ORDER BY rowid");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Bigint(-1));
+    assert_eq!(rows[1].values[0], vibesql_types::SqlValue::Bigint(0));
+
+    // Deeply negative variant (sqlite3: after -5, the next implicit is -4).
+    let mut db2 = vibesql_storage::Database::new();
+    exec(&mut db2, "CREATE TABLE t(x INTEGER)");
+    exec(&mut db2, "INSERT INTO t(rowid, x) VALUES(-5, 1)");
+    exec(&mut db2, "INSERT INTO t VALUES(2)");
+    let rows2 = query(&db2, "SELECT rowid, x FROM t ORDER BY rowid");
+    assert_eq!(rows2[0].values[0], vibesql_types::SqlValue::Bigint(-5));
+    assert_eq!(rows2[1].values[0], vibesql_types::SqlValue::Bigint(-4), "sqlite3 allocates -4 after -5");
+}
+
+/// REPLACE INTO on a negative INTEGER PRIMARY KEY (the rowid alias) must not
+/// hit the poisoned `next_rowid()` reservation path (judge-review poisoning
+/// path 2: same-session variant; the cross-reload variant lives in
+/// vibesql-storage's binary_persistence tests).
+#[test]
+fn test_replace_into_with_negative_integer_primary_key() {
+    use negative_rowid_sql::{exec, query};
+
+    let mut db = vibesql_storage::Database::new();
+    exec(&mut db, "CREATE TABLE t(a INTEGER PRIMARY KEY, b INTEGER)");
+    exec(&mut db, "INSERT INTO t VALUES(-5, 1)");
+    exec(&mut db, "REPLACE INTO t VALUES(-5, 2)");
+
+    // sqlite3: exactly one row, -5|2.
+    let rows = query(&db, "SELECT a, b FROM t");
+    assert_eq!(rows.len(), 1, "REPLACE must not duplicate the negative-IPK row");
+    assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Integer(-5));
+    assert_eq!(rows[0].values[1], vibesql_types::SqlValue::Integer(2));
+}

--- a/crates/vibesql-executor/tests/rowid_reload_tests.rs
+++ b/crates/vibesql-executor/tests/rowid_reload_tests.rs
@@ -1,0 +1,293 @@
+//! End-to-end regression tests for issue #5835: SQLite rowid semantics must
+//! be stable across a binary `.vbsql` save/reload (the cross-process reopen
+//! path used by the CLI and the TCL harness) and across WAL crash recovery.
+//!
+//! Before the fix:
+//!   * `TableSchema::rowid_alias_column` was not rebuilt on load, so after a
+//!     reopen `WHERE rowid=N` on an INTEGER PRIMARY KEY table returned zero
+//!     rows — and `DELETE ... WHERE rowid=N` deleted the WRONG row
+//!     (intpkey-2.6).
+//!   * `Row::row_id` was not persisted (format v12), so explicit rowids were
+//!     lost and implicit rowids were renumbered whenever tombstones were
+//!     dropped at save time.
+//!   * WAL `Insert` replay dropped the rowid, and the REPLACE conflict-delete
+//!     emitted no WAL op at all — REPLACE resurrected the old conflicting row
+//!     next to the new one after a restart (check-13.x, issue #5871).
+
+use vibesql_ast::Statement;
+use vibesql_executor::{
+    CreateIndexExecutor, CreateTableExecutor, DeleteExecutor, InsertExecutor, SelectExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::{
+    wal::{PersistenceConfig, PersistenceEngine, RecoveryManager},
+    Database,
+};
+use vibesql_types::SqlValue;
+
+/// Create a table preserving the verbatim source text (issue #5619), the way
+/// the CLI/load paths capture it. `sql_source` is what the reload path
+/// re-parses to rehydrate the rowid alias, so tests must use this entry point.
+fn create_with_source(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse CREATE");
+    let Statement::CreateTable(create) = stmt else {
+        panic!("expected CREATE TABLE");
+    };
+    CreateTableExecutor::execute_with_source(&create, db, Some(sql)).expect("CREATE TABLE");
+}
+
+/// Execute an INSERT / REPLACE / DELETE statement.
+fn exec(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse DML");
+    match stmt {
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).map(|_| ()).expect("INSERT/REPLACE");
+        }
+        Statement::Delete(s) => {
+            DeleteExecutor::execute(&s, db).map(|_| ()).expect("DELETE");
+        }
+        Statement::CreateIndex(s) => {
+            CreateIndexExecutor::execute(&s, db).expect("CREATE INDEX");
+        }
+        other => panic!("unsupported statement in test: {other:?}"),
+    }
+}
+
+/// Run a SELECT and return the result rows as `Vec<Vec<SqlValue>>`.
+///
+/// `rowid` on non-aliased tables surfaces as `Bigint`; normalize integer-family
+/// values to `Integer` so assertions compare by value, not by width.
+fn query(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = Parser::parse_sql(sql).expect("parse SELECT");
+    let Statement::Select(select) = stmt else {
+        panic!("expected SELECT");
+    };
+    let result = SelectExecutor::new(db).execute_with_columns(&select).expect("SELECT");
+    result
+        .rows
+        .iter()
+        .map(|r| {
+            r.values
+                .iter()
+                .map(|v| match v {
+                    SqlValue::Bigint(n) => SqlValue::Integer(*n),
+                    SqlValue::Smallint(n) => SqlValue::Integer(*n as i64),
+                    other => other.clone(),
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// Save to a binary `.vbsql` file and reload — the cross-process reopen path.
+fn reopen_binary(db: &Database, tag: &str) -> Database {
+    let path =
+        std::env::temp_dir().join(format!("vibesql_5835_{tag}_{}.vbsql", std::process::id()));
+    db.save_binary(&path).expect("save_binary");
+    let reloaded = Database::load_binary(&path).expect("load_binary");
+    std::fs::remove_file(&path).ok();
+    reloaded
+}
+
+fn int(v: i64) -> SqlValue {
+    SqlValue::Integer(v)
+}
+
+// ---------------------------------------------------------------------------
+// INTEGER PRIMARY KEY rowid aliasing across reload
+// ---------------------------------------------------------------------------
+
+/// The headline reproducer: `WHERE rowid=5` on an INTEGER PRIMARY KEY table
+/// must keep returning the same row after a reopen.
+#[test]
+fn rowid_alias_survives_binary_reload() {
+    let mut db = Database::new();
+    create_with_source(&mut db, "CREATE TABLE p(a INTEGER PRIMARY KEY, b INTEGER)");
+    exec(&mut db, "INSERT INTO p VALUES(5, 50), (7, 70)");
+
+    // Sanity: aliasing works in-memory before the reload.
+    assert_eq!(query(&db, "SELECT b FROM p WHERE rowid=5"), vec![vec![int(50)]]);
+
+    let reloaded = reopen_binary(&db, "alias");
+
+    // The schema must remember the alias...
+    assert_eq!(
+        reloaded.get_table("p").expect("table p").schema.rowid_alias_column,
+        Some(0),
+        "rowid_alias_column must be rehydrated on binary load"
+    );
+
+    // ...and every rowid read must resolve through it.
+    assert_eq!(query(&reloaded, "SELECT b FROM p WHERE rowid=5"), vec![vec![int(50)]]);
+    assert_eq!(query(&reloaded, "SELECT b FROM p WHERE rowid=7"), vec![vec![int(70)]]);
+    assert_eq!(
+        query(&reloaded, "SELECT rowid FROM p ORDER BY a"),
+        vec![vec![int(5)], vec![int(7)]],
+        "SELECT rowid must return the IPK values, not physical positions"
+    );
+}
+
+/// intpkey-2.6 shape: `DELETE ... WHERE rowid=N` after a reload must delete
+/// the row whose rowid is N — before the fix it deleted the row at physical
+/// position N instead (wrong-row DML, corruption class).
+#[test]
+fn delete_by_rowid_after_reload_targets_correct_row() {
+    let mut db = Database::new();
+    create_with_source(&mut db, "CREATE TABLE t(a INTEGER PRIMARY KEY, b INTEGER)");
+    exec(&mut db, "INSERT INTO t VALUES(5, 50), (7, 70), (9, 90)");
+
+    let mut reloaded = reopen_binary(&db, "delete_by_rowid");
+    exec(&mut reloaded, "DELETE FROM t WHERE rowid=7");
+
+    assert_eq!(
+        query(&reloaded, "SELECT a FROM t ORDER BY a"),
+        vec![vec![int(5)], vec![int(9)]],
+        "DELETE WHERE rowid=7 must remove exactly the a=7 row"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Implicit-rowid tables across reload
+// ---------------------------------------------------------------------------
+
+/// Implicit rowids must not be renumbered when a reload drops tombstoned
+/// rows, and new inserts must not collide with (or reuse) surviving rowids.
+#[test]
+fn implicit_rowids_stable_across_reload_after_delete() {
+    let mut db = Database::new();
+    create_with_source(&mut db, "CREATE TABLE u(x INTEGER)");
+    exec(&mut db, "INSERT INTO u VALUES(100), (200), (300)");
+    exec(&mut db, "DELETE FROM u WHERE x=200"); // tombstones rowid 2
+
+    let mut reloaded = reopen_binary(&db, "implicit");
+
+    assert_eq!(
+        query(&reloaded, "SELECT rowid FROM u ORDER BY rowid"),
+        vec![vec![int(1)], vec![int(3)]],
+        "surviving implicit rowids must not shift down after the tombstone is dropped"
+    );
+
+    // SQLite allocates max(rowid)+1 = 4 here; before the fix the live-count
+    // based allocation would hand out 3 — colliding with the existing row.
+    exec(&mut reloaded, "INSERT INTO u VALUES(400)");
+    assert_eq!(
+        query(&reloaded, "SELECT rowid FROM u WHERE x=400"),
+        vec![vec![int(4)]],
+        "new insert must get a fresh rowid, not collide with the surviving rowid 3"
+    );
+}
+
+/// Explicit rowids (INSERT INTO t(rowid, ...)) survive the reload, and the
+/// next auto-allocated rowid continues past them (SQLite max+1 semantics).
+#[test]
+fn explicit_rowid_survives_reload_and_allocation_continues_past_it() {
+    let mut db = Database::new();
+    create_with_source(&mut db, "CREATE TABLE w(x INTEGER)");
+    exec(&mut db, "INSERT INTO w(rowid, x) VALUES(10, 1)");
+
+    let mut reloaded = reopen_binary(&db, "explicit");
+
+    assert_eq!(query(&reloaded, "SELECT rowid FROM w"), vec![vec![int(10)]]);
+
+    exec(&mut reloaded, "INSERT INTO w VALUES(2)");
+    assert_eq!(
+        query(&reloaded, "SELECT rowid FROM w WHERE x=2"),
+        vec![vec![int(11)]],
+        "auto rowid must continue past the reloaded explicit rowid 10"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// REPLACE INTO durability across WAL crash recovery (issues #5835 / #5871)
+// ---------------------------------------------------------------------------
+
+/// The #5871 reproducer, driven through the crash-recovery path: a REPLACE
+/// whose conflict-delete is only in the WAL (no checkpoint) must recover to a
+/// single row — before the fix the delete was never WAL-logged, so replay
+/// resurrected the old row next to the new one (duplicate INTEGER PRIMARY
+/// KEY).
+#[test]
+fn replace_conflict_delete_survives_crash_via_wal_replay() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let wal_path = dir.path().join("replace_crash.wal");
+    let checkpoint_dir = dir.path().join("replace_crash-checkpoints");
+
+    // --- Session 1: run the REPLACE against a WAL-backed database, flush the
+    // WAL, then "crash" (drop without ever writing a checkpoint).
+    {
+        let mut db = Database::new();
+        let engine = PersistenceEngine::new(&wal_path, PersistenceConfig::default())
+            .expect("persistence engine");
+        db.enable_persistence(engine);
+
+        create_with_source(&mut db, "CREATE TABLE t1(aa INTEGER PRIMARY KEY, bb INT)");
+        exec(&mut db, "INSERT INTO t1 VALUES(11, 22)");
+        exec(&mut db, "CREATE UNIQUE INDEX t1bb ON t1(bb)");
+        exec(&mut db, "REPLACE INTO t1 VALUES(11, 33)");
+
+        // In-memory state is correct: exactly one row.
+        assert_eq!(query(&db, "SELECT aa, bb FROM t1"), vec![vec![int(11), int(33)]]);
+
+        db.sync_persistence().expect("sync WAL");
+        // `db` drops here — crash simulation: WAL only, no checkpoint.
+    }
+
+    // --- Session 2: recover purely from the WAL.
+    let manager = RecoveryManager::new(&checkpoint_dir).with_wal(&wal_path);
+    let (recovered, _stats) = manager.recover().expect("recover");
+
+    let table_name = recovered
+        .list_tables()
+        .into_iter()
+        .find(|t| t.to_lowercase().contains("t1"))
+        .expect("t1 must exist after recovery");
+    let table = recovered.get_table(&table_name).expect("recovered table");
+
+    let live: Vec<Vec<SqlValue>> =
+        table.scan_live().map(|(_, r)| r.values.to_vec()).collect();
+    assert_eq!(
+        live,
+        vec![vec![int(11), int(33)]],
+        "REPLACE must recover to exactly one row — the conflict-delete must be \
+         WAL-logged and replayed (issues #5835 / #5871)"
+    );
+
+    // The replayed row must also carry its rowid (WAL format v3).
+    let rowid = table.scan_live().next().and_then(|(_, r)| r.row_id);
+    assert_eq!(rowid, Some(11), "WAL replay must restore the row's effective rowid");
+}
+
+/// Plain inserts replayed from the WAL keep their explicit rowids too.
+#[test]
+fn insert_rowids_survive_crash_via_wal_replay() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let wal_path = dir.path().join("insert_rowid_crash.wal");
+    let checkpoint_dir = dir.path().join("insert_rowid_crash-checkpoints");
+
+    {
+        let mut db = Database::new();
+        let engine = PersistenceEngine::new(&wal_path, PersistenceConfig::default())
+            .expect("persistence engine");
+        db.enable_persistence(engine);
+
+        create_with_source(&mut db, "CREATE TABLE w(x INTEGER)");
+        exec(&mut db, "INSERT INTO w(rowid, x) VALUES(10, 1)");
+        db.sync_persistence().expect("sync WAL");
+    }
+
+    let manager = RecoveryManager::new(&checkpoint_dir).with_wal(&wal_path);
+    let (recovered, _stats) = manager.recover().expect("recover");
+
+    let table_name = recovered
+        .list_tables()
+        .into_iter()
+        .find(|t| t.to_lowercase().contains('w'))
+        .expect("w must exist after recovery");
+    let table = recovered.get_table(&table_name).expect("recovered table");
+    let rowid = table.scan_live().next().and_then(|(_, r)| r.row_id);
+    assert_eq!(
+        rowid,
+        Some(10),
+        "explicit rowid must survive WAL crash recovery (WAL format v3, issue #5835)"
+    );
+}

--- a/crates/vibesql-storage/src/database/table_api.rs
+++ b/crates/vibesql-storage/src/database/table_api.rs
@@ -387,6 +387,9 @@ impl Database {
                 table_name: table_name.to_string(),
                 row_id: row_index as u64,
                 values: row.values.to_vec(),
+                // Effective SQLite rowid (issue #5835): explicit when the row
+                // carries one, else the implicit physical position + 1.
+                rowid: Some(row.row_id.unwrap_or(row_index as u64 + 1)),
             });
         }
 
@@ -492,6 +495,8 @@ impl Database {
                     table_name: table_name.to_string(),
                     row_id: row_index as u64,
                     values: row.values.to_vec(),
+                    // Effective SQLite rowid (issue #5835).
+                    rowid: Some(row.row_id.unwrap_or(row_index as u64 + 1)),
                 });
             }
 

--- a/crates/vibesql-storage/src/lib.rs
+++ b/crates/vibesql-storage/src/lib.rs
@@ -413,4 +413,50 @@ mod tests {
         // (shrunken) physical count + 1 (which would collide with rowid 7).
         assert_eq!(table.next_rowid(), 11);
     }
+
+    /// Rowids are signed (SQLite model): a negative explicit rowid is stored
+    /// as its two's-complement u64 bit pattern and must never poison
+    /// allocation. Judge-review regression for PR #5891: previously
+    /// `INSERT INTO t(rowid,x) VALUES(-1,5)` set `max_assigned_rowid` to
+    /// `u64::MAX`, so the next implicit insert computed `u64::MAX + 1` —
+    /// panic in debug builds, duplicate rowid 0 in release builds.
+    ///
+    /// sqlite3-verified allocation: next implicit rowid = signed max + 1
+    /// (only -1 present → 0; only -5 present → -4), or 1 for an empty table.
+    #[test]
+    fn test_negative_explicit_rowid_does_not_poison_allocation() {
+        let mut table = rowid_test_table();
+
+        // Explicit rowid -1 (stored as u64::MAX bit pattern).
+        table.insert(Row::with_row_id(vec![SqlValue::Integer(5)], (-1i64) as u64)).unwrap();
+        assert_eq!(table.max_rowid_signed(), Some(-1));
+        assert_eq!(table.next_rowid_signed(), 0, "sqlite3: after rowid -1, next is 0");
+        assert_eq!(table.next_rowid(), 0u64);
+
+        // The implicit insert that previously panicked: stamp the allocated
+        // rowid (as the executor does) and continue allocating past it.
+        let next = table.next_rowid();
+        table.insert(Row::with_row_id(vec![SqlValue::Integer(6)], next)).unwrap();
+        assert_eq!(table.max_rowid_signed(), Some(0));
+        assert_eq!(table.next_rowid_signed(), 1);
+
+        // Deeply negative maxima allocate signed max + 1 (sqlite3: -5 → -4).
+        let mut table2 = rowid_test_table();
+        table2.insert(Row::with_row_id(vec![SqlValue::Integer(1)], (-5i64) as u64)).unwrap();
+        assert_eq!(table2.next_rowid_signed(), -4, "sqlite3: after rowid -5, next is -4");
+
+        // A positive rowid still dominates a negative one (signed max).
+        table2.insert(Row::with_row_id(vec![SqlValue::Integer(2)], 3)).unwrap();
+        assert_eq!(table2.next_rowid_signed(), 4, "sqlite3: max(-5, 3) + 1 = 4");
+    }
+
+    /// `next_rowid` saturates instead of overflowing when the max rowid is
+    /// `i64::MAX` (SQLite reports SQLITE_FULL; a duplicate-rowid conflict is
+    /// the closest safe behavior — never a wrap to a bogus rowid).
+    #[test]
+    fn test_next_rowid_saturates_at_i64_max() {
+        let mut table = rowid_test_table();
+        table.insert(Row::with_row_id(vec![SqlValue::Integer(1)], i64::MAX as u64)).unwrap();
+        assert_eq!(table.next_rowid_signed(), i64::MAX);
+    }
 }

--- a/crates/vibesql-storage/src/lib.rs
+++ b/crates/vibesql-storage/src/lib.rs
@@ -343,4 +343,74 @@ mod tests {
         assert_eq!(row1.get(1), row2.get(1));
         assert_eq!(row1.get(2), row2.get(2));
     }
+
+    // -----------------------------------------------------------------------
+    // Rowid stability (issue #5835)
+    // -----------------------------------------------------------------------
+
+    fn rowid_test_table() -> Table {
+        let schema = TableSchema::new(
+            "t".to_string(),
+            vec![ColumnSchema::new("x".to_string(), DataType::Integer, true)],
+        );
+        Table::new(schema)
+    }
+
+    /// `next_rowid` covers both the physical row count (implicit rowids) and
+    /// the largest explicit rowid ever assigned, so allocation never collides
+    /// after explicit rowids (e.g. reloaded from a v13 snapshot) exceed the
+    /// physical count.
+    #[test]
+    fn test_next_rowid_tracks_explicit_rowids() {
+        let mut table = rowid_test_table();
+
+        // Empty table: next rowid is 1.
+        assert_eq!(table.next_rowid(), 1);
+
+        // Implicit rows: next rowid stays physical_count + 1.
+        table.insert(Row::new(vec![SqlValue::Integer(10)])).unwrap();
+        assert_eq!(table.next_rowid(), 2);
+
+        // Explicit rowid larger than the physical count (the reload shape:
+        // live rows persisted with rowids 1 and 7).
+        table.insert(Row::with_row_id(vec![SqlValue::Integer(20)], 7)).unwrap();
+        assert_eq!(
+            table.next_rowid(),
+            8,
+            "must exceed the explicit rowid 7, not physical count 2"
+        );
+
+        // Deletes never decrease it (monotone).
+        assert!(table.mark_deleted_inplace(1));
+        assert_eq!(table.next_rowid(), 8);
+    }
+
+    /// Compaction physically shifts row positions; surviving implicit rowids
+    /// must be materialized before the shift so `WHERE rowid=N` still targets
+    /// the same row afterwards.
+    #[test]
+    fn test_compact_materializes_implicit_rowids() {
+        let mut table = rowid_test_table();
+        for i in 1..=10i64 {
+            table.insert(Row::new(vec![SqlValue::Integer(i)])).unwrap();
+        }
+
+        // Tombstone rows at physical indices 0..=5 (implicit rowids 1..=6) —
+        // over 50%, so compact_if_needed compacts.
+        for idx in 0..6 {
+            assert!(table.mark_deleted_inplace(idx));
+        }
+        assert!(table.compact_if_needed(), "expected compaction with 60% deleted");
+
+        // Survivors were at physical indices 6..=9 → implicit rowids 7..=10.
+        let rowids: Vec<u64> = table
+            .scan_live()
+            .map(|(_, row)| row.row_id.expect("materialized rowid"))
+            .collect();
+        assert_eq!(rowids, vec![7, 8, 9, 10]);
+
+        // Allocation continues past the materialized max, not at the
+        // (shrunken) physical count + 1 (which would collide with rowid 7).
+        assert_eq!(table.next_rowid(), 11);
+    }
 }

--- a/crates/vibesql-storage/src/persistence/binary/constraints.rs
+++ b/crates/vibesql-storage/src/persistence/binary/constraints.rs
@@ -105,8 +105,10 @@ fn resolve_parent_columns(
     (references_columns.to_vec(), indices)
 }
 
-/// Rebuild `check_constraints` and `foreign_keys` on a freshly loaded
-/// `TableSchema` by re-parsing its persisted `sql_source`.
+/// Rebuild `check_constraints`, `foreign_keys`, and the INTEGER PRIMARY KEY
+/// rowid alias (`rowid_alias_column` + `is_exact_integer_type`, issue #5835)
+/// on a freshly loaded `TableSchema` by re-parsing its persisted
+/// `sql_source`.
 ///
 /// No-op when the schema has no `sql_source` (pre-v9 files, or tables whose
 /// source was invalidated by ALTER TABLE — those fall back to the previous
@@ -143,6 +145,38 @@ pub(super) fn rehydrate_constraints_from_sql_source(
     // CREATE TABLE ... AS SELECT carries no constraint clauses.
     if create.as_query.is_some() {
         return Ok(());
+    }
+
+    // ---- INTEGER PRIMARY KEY rowid aliasing (issue #5835) ----
+    // Neither `TableSchema::rowid_alias_column` nor
+    // `ColumnSchema::is_exact_integer_type` is serialized as a dedicated
+    // binary field, so before this rehydration every reloaded schema forgot
+    // that its INTEGER PRIMARY KEY column aliases the rowid. All rowid
+    // reads/writes (`WHERE rowid=N`, `SELECT rowid`, `DELETE ... WHERE
+    // rowid=N`, `RETURNING rowid`) then fell back to physical row numbering
+    // — returning zero rows or, worse, targeting the WRONG row after a
+    // process restart (intpkey-2.6).
+    //
+    // Rebuild both from the re-parsed source, mirroring the CREATE TABLE
+    // execution path (`create_table.rs`): a single-column PRIMARY KEY whose
+    // column was declared with the exact keyword "INTEGER" (not "INT")
+    // aliases the rowid.
+    for col_def in &create.columns {
+        if let Some(idx) = schema.get_column_index(&col_def.name) {
+            schema.columns[idx].is_exact_integer_type = col_def.is_exact_integer_type;
+        }
+    }
+    if let Some(pk_cols) = schema.primary_key.clone() {
+        if pk_cols.len() == 1 {
+            if let Some(col_idx) = schema.get_column_index(&pk_cols[0]) {
+                let col = &schema.columns[col_idx];
+                if matches!(col.data_type, vibesql_types::DataType::Integer)
+                    && col.is_exact_integer_type
+                {
+                    schema.set_rowid_alias_column(Some(col_idx));
+                }
+            }
+        }
     }
 
     // ---- CHECK constraints (column-level first, then table-level) ----

--- a/crates/vibesql-storage/src/persistence/binary/data.rs
+++ b/crates/vibesql-storage/src/persistence/binary/data.rs
@@ -102,6 +102,15 @@ pub fn write_data<W: Write>(writer: &mut W, db: &Database) -> Result<(), Storage
             // rowid, else the implicit physical position + 1. Persisting it
             // keeps `WHERE rowid=N` stable across reloads even when live
             // rows shift physical positions (tombstones are dropped here).
+            //
+            // Rowids are signed (SQLite model): the u64 written here is the
+            // two's-complement bit pattern of the i64 rowid, so a negative
+            // rowid (e.g. an IPK of -5, written via `*v as u64`) round-trips
+            // exactly — the reader restores the same bit pattern into
+            // `Row::row_id`, and every consumer reinterprets it via
+            // `as i64`. Allocation tracking (`Table::max_assigned_rowid`)
+            // also compares in signed space, so reloading a negative rowid
+            // can never poison `next_rowid()`.
             for (idx, row) in table.scan_live() {
                 write_row_version_prefix(writer, row)?;
                 let effective_rowid = alias_idx

--- a/crates/vibesql-storage/src/persistence/binary/data.rs
+++ b/crates/vibesql-storage/src/persistence/binary/data.rs
@@ -87,15 +87,31 @@ pub fn write_data<W: Write>(writer: &mut W, db: &Database) -> Result<(), Storage
             // Write row count
             write_u64(writer, table.row_count() as u64)?;
 
+            // Rowid-alias column (INTEGER PRIMARY KEY), if any: for aliased
+            // tables the column value IS the rowid, so persist that (v13).
+            let alias_idx = table.schema.rowid_alias_column;
+
             // Write each row (only live/non-deleted rows)
             // Using scan_live() to skip rows marked as deleted in the deletion bitmap.
             // This fixes a bug where deleted rows were being persisted to disk.
             //
-            // v7 layout: per-row MVCC prefix (xmin + xmax) followed by column values.
-            // For Phase 1a most rows will have the pre-MVCC sentinel xmin/xmax;
-            // executor write paths in Phase 1c will start stamping real txn ids.
-            for (_idx, row) in table.scan_live() {
+            // v13 layout: per-row MVCC prefix (xmin + xmax), then the row's
+            // effective rowid (u64), then column values. The effective rowid
+            // is materialized at write time (issue #5835): the rowid-alias
+            // IPK value when the table has one, else the row's explicit
+            // rowid, else the implicit physical position + 1. Persisting it
+            // keeps `WHERE rowid=N` stable across reloads even when live
+            // rows shift physical positions (tombstones are dropped here).
+            for (idx, row) in table.scan_live() {
                 write_row_version_prefix(writer, row)?;
+                let effective_rowid = alias_idx
+                    .and_then(|i| match row.values.get(i) {
+                        Some(vibesql_types::SqlValue::Integer(v)) => Some(*v as u64),
+                        _ => None,
+                    })
+                    .or(row.row_id)
+                    .unwrap_or((idx + 1) as u64);
+                write_u64(writer, effective_rowid)?;
                 for value in &row.values {
                     write_sql_value(writer, value)?;
                 }
@@ -113,6 +129,10 @@ pub fn write_data<W: Write>(writer: &mut W, db: &Database) -> Result<(), Storage
 ///   the "always committed, visible to all snapshots" sentinel.
 /// - For `version >= 7`: each row begins with the MVCC version prefix
 ///   documented in the module-level doc comment.
+/// - For `version >= 13`: each row additionally carries its effective rowid
+///   (u64) between the MVCC prefix and the column values (issue #5835).
+///   Older files reconstruct rows with `row_id = None` (the pre-fix
+///   physical-position renumbering).
 pub fn read_data<R: Read>(
     reader: &mut R,
     db: &mut Database,
@@ -124,6 +144,7 @@ pub fn read_data<R: Read>(
     let mut loaded_tables = Vec::with_capacity(table_count);
 
     let has_mvcc_prefix = version >= 7;
+    let has_rowid = version >= 13;
 
     for _ in 0..table_count {
         // Read table name from file (don't rely on list_tables() ordering)
@@ -146,6 +167,9 @@ pub fn read_data<R: Read>(
                     (PRE_MVCC_TXN_ID, None)
                 };
 
+                // Read the persisted effective rowid on v13+ (issue #5835).
+                let row_id = if has_rowid { Some(read_u64(reader)?) } else { None };
+
                 let mut values = Vec::with_capacity(column_count);
                 for _ in 0..column_count {
                     values.push(read_sql_value(reader)?);
@@ -154,6 +178,7 @@ pub fn read_data<R: Read>(
                 let mut row = Row::from_vec(values);
                 row.xmin = xmin;
                 row.xmax = xmax;
+                row.row_id = row_id;
 
                 table.insert(row).map_err(|e| {
                     StorageError::NotImplemented(format!("Failed to insert row: {}", e))

--- a/crates/vibesql-storage/src/persistence/binary/format.rs
+++ b/crates/vibesql-storage/src/persistence/binary/format.rs
@@ -58,7 +58,19 @@ pub const MAGIC: &[u8; 5] = b"VBSQL";
 ///        v11 and earlier files remain readable: the read path is gated on
 ///        `version >= 12` and treats absence as `without_rowid = false`
 ///        (prior behavior). Issue #5796.
-pub const VERSION: u8 = 12;
+/// - v13: Added per-row rowid persistence (one u64 per row, after the MVCC
+///        version prefix and before the column values). Without it, every
+///        reloaded row lost its SQLite rowid and was silently renumbered by
+///        physical position, so `WHERE rowid=N` / `DELETE ... WHERE rowid=N`
+///        targeted different rows before and after a process restart, and
+///        new inserts could collide with reloaded explicit rowids. The write
+///        path materializes each live row's effective rowid (the rowid-alias
+///        INTEGER PRIMARY KEY value when the table has one, else the row's
+///        explicit rowid, else its implicit physical position + 1). v12 and
+///        earlier files remain readable: the read path is gated on
+///        `version >= 13` and treats absence as "no explicit rowid" (prior
+///        renumbering behavior). Issue #5835.
+pub const VERSION: u8 = 13;
 
 /// Type tags for binary serialization
 #[repr(u8)]

--- a/crates/vibesql-storage/src/persistence/tests/binary_persistence.rs
+++ b/crates/vibesql-storage/src/persistence/tests/binary_persistence.rs
@@ -837,6 +837,88 @@ fn test_row_id_roundtrip_v13() {
     assert_eq!(loaded.next_rowid(), 43);
 }
 
+/// Negative rowids round-trip and never poison allocation (PR #5891 judge
+/// review). Rowids are signed (SQLite model): `-1` is stored as the
+/// two's-complement bit pattern `u64::MAX`. Before the fix, reload tracked
+/// that bit pattern as an *unsigned* max, so the next `next_rowid()` call
+/// computed `u64::MAX + 1` — a debug panic / a wrap to duplicate rowid 0 in
+/// release builds.
+#[test]
+fn test_negative_row_id_roundtrip_does_not_poison_allocation() {
+    let mut db = Database::new();
+
+    let schema = TableSchema::new(
+        "neg_rowid".to_string(),
+        vec![ColumnSchema::new("x".to_string(), DataType::Integer, true)],
+    );
+    db.create_table(schema).unwrap();
+
+    let table = db.get_table_mut("neg_rowid").unwrap();
+    table.insert(crate::Row::with_row_id(vec![SqlValue::Integer(5)], (-1i64) as u64)).unwrap();
+
+    let path = format!("/tmp/test_negative_row_id_roundtrip_{}.vbsql", std::process::id());
+    db.save_binary(&path).unwrap();
+    let loaded_db = Database::load_binary(&path).unwrap();
+    std::fs::remove_file(&path).ok();
+
+    let loaded = loaded_db.get_table("neg_rowid").unwrap();
+
+    // Bit-pattern-faithful round-trip: the reloaded row still carries -1.
+    let rowids: Vec<i64> =
+        loaded.scan_live().map(|(_, r)| r.row_id.expect("persisted rowid") as i64).collect();
+    assert_eq!(rowids, vec![-1], "negative rowid must survive a binary reload");
+
+    // Allocation is signed (sqlite3-verified): after rowid -1 the next
+    // implicit rowid is 0 — NOT u64::MAX + 1 (panic) and NOT a positional
+    // renumber.
+    assert_eq!(loaded.max_rowid_signed(), Some(-1));
+    assert_eq!(loaded.next_rowid_signed(), 0, "sqlite3: after rowid -1, next implicit rowid is 0");
+}
+
+/// A negative INTEGER PRIMARY KEY value is the rowid (alias) and is written
+/// via `*v as u64`; reloading it must keep allocation sane so a REPLACE INTO
+/// (which reserves `next_rowid()`) cannot hit the `u64::MAX + 1` panic path
+/// (PR #5891 judge review, poisoning path 1).
+#[test]
+fn test_negative_ipk_alias_reload_keeps_next_rowid_sane() {
+    let mut db = Database::new();
+
+    let mut schema = TableSchema::with_primary_key(
+        "neg_ipk".to_string(),
+        vec![
+            ColumnSchema::new("a".to_string(), DataType::Integer, false),
+            ColumnSchema::new("b".to_string(), DataType::Integer, true),
+        ],
+        vec!["a".to_string()],
+    );
+    schema.set_rowid_alias_column(Some(0));
+    schema.set_sql_source("CREATE TABLE neg_ipk(a INTEGER PRIMARY KEY, b INTEGER)".to_string());
+    db.create_table(schema).unwrap();
+
+    let table = db.get_table_mut("neg_ipk").unwrap();
+    table
+        .insert(crate::Row::new(vec![SqlValue::Integer(-5), SqlValue::Integer(50)]))
+        .unwrap();
+
+    let path = format!("/tmp/test_negative_ipk_reload_{}.vbsql", std::process::id());
+    db.save_binary(&path).unwrap();
+    let loaded_db = Database::load_binary(&path).unwrap();
+    std::fs::remove_file(&path).ok();
+
+    let loaded = loaded_db.get_table("neg_ipk").unwrap();
+
+    // The persisted rowid is the (negative) IPK value, bit-pattern faithful.
+    let rowids: Vec<i64> =
+        loaded.scan_live().map(|(_, r)| r.row_id.expect("persisted rowid") as i64).collect();
+    assert_eq!(rowids, vec![-5]);
+
+    // Signed allocation: next rowid is -4 (sqlite3: signed max + 1), and in
+    // particular next_rowid() is safe to call (no overflow panic).
+    assert_eq!(loaded.max_rowid_signed(), Some(-5));
+    assert_eq!(loaded.next_rowid_signed(), -4);
+    let _ = loaded.next_rowid();
+}
+
 /// The rowid-alias INTEGER PRIMARY KEY column value IS the rowid; the v13
 /// writer persists the alias value so the on-disk rowid stays meaningful.
 #[test]

--- a/crates/vibesql-storage/src/persistence/tests/binary_persistence.rs
+++ b/crates/vibesql-storage/src/persistence/tests/binary_persistence.rs
@@ -783,3 +783,128 @@ fn test_load_binary_repopulates_catalog_for_all_indexes() {
     assert!(!m2.is_partial());
     assert_eq!(m2.table_name, "t");
 }
+
+// ---------------------------------------------------------------------------
+// Per-row rowid persistence (format v13, issue #5835)
+// ---------------------------------------------------------------------------
+
+/// Round-trip: explicit rowids survive a save/load, and implicit rowids are
+/// materialized from the row's physical position at save time. Before v13
+/// every reloaded row had `row_id = None` and was silently renumbered by
+/// physical position, so `WHERE rowid=N` targeted different rows across a
+/// process restart.
+#[test]
+fn test_row_id_roundtrip_v13() {
+    let mut db = Database::new();
+
+    let schema = TableSchema::new(
+        "rowid_rt".to_string(),
+        vec![ColumnSchema::new("x".to_string(), DataType::Integer, true)],
+    );
+    db.create_table(schema).unwrap();
+
+    let table = db.get_table_mut("rowid_rt").unwrap();
+    // Implicit rowid (physical position 0 → rowid 1).
+    table.insert(crate::Row::new(vec![SqlValue::Integer(10)])).unwrap();
+    // Explicit rowid well past the physical count.
+    table.insert(crate::Row::with_row_id(vec![SqlValue::Integer(20)], 42)).unwrap();
+    // Tombstoned row: dropped at save, but the following row's implicit
+    // rowid (physical position 3 → rowid 4) must NOT shift down to 3.
+    table.insert(crate::Row::new(vec![SqlValue::Integer(30)])).unwrap();
+    table.insert(crate::Row::new(vec![SqlValue::Integer(40)])).unwrap();
+    assert!(table.mark_deleted_inplace(2));
+
+    let path = format!("/tmp/test_row_id_roundtrip_v13_{}.vbsql", std::process::id());
+    db.save_binary(&path).unwrap();
+    let loaded_db = Database::load_binary(&path).unwrap();
+    std::fs::remove_file(&path).ok();
+
+    let loaded = loaded_db.get_table("rowid_rt").unwrap();
+    assert_eq!(loaded.row_count(), 3);
+
+    let rowid_of = |x: i64| -> u64 {
+        loaded
+            .scan_live()
+            .find(|(_, r)| matches!(r.values[0], SqlValue::Integer(v) if v == x))
+            .and_then(|(_, r)| r.row_id)
+            .unwrap_or_else(|| panic!("row x={x} must carry a persisted rowid after reload"))
+    };
+    assert_eq!(rowid_of(10), 1, "implicit rowid materialized from physical position");
+    assert_eq!(rowid_of(20), 42, "explicit rowid preserved");
+    assert_eq!(rowid_of(40), 4, "rowid must not shift when a tombstone is dropped at save");
+
+    // Allocation continuity: the next rowid must exceed every persisted one.
+    assert_eq!(loaded.next_rowid(), 43);
+}
+
+/// The rowid-alias INTEGER PRIMARY KEY column value IS the rowid; the v13
+/// writer persists the alias value so the on-disk rowid stays meaningful.
+#[test]
+fn test_row_id_persists_ipk_alias_value() {
+    let mut db = Database::new();
+
+    let mut schema = TableSchema::with_primary_key(
+        "ipk_alias".to_string(),
+        vec![
+            ColumnSchema::new("a".to_string(), DataType::Integer, false),
+            ColumnSchema::new("b".to_string(), DataType::Integer, true),
+        ],
+        vec!["a".to_string()],
+    );
+    schema.set_rowid_alias_column(Some(0));
+    schema.set_sql_source("CREATE TABLE ipk_alias(a INTEGER PRIMARY KEY, b INTEGER)".to_string());
+    db.create_table(schema).unwrap();
+
+    let table = db.get_table_mut("ipk_alias").unwrap();
+    table
+        .insert(crate::Row::new(vec![SqlValue::Integer(5), SqlValue::Integer(50)]))
+        .unwrap();
+    table
+        .insert(crate::Row::new(vec![SqlValue::Integer(7), SqlValue::Integer(70)]))
+        .unwrap();
+
+    let path = format!("/tmp/test_row_id_ipk_alias_{}.vbsql", std::process::id());
+    db.save_binary(&path).unwrap();
+    let loaded_db = Database::load_binary(&path).unwrap();
+    std::fs::remove_file(&path).ok();
+
+    let loaded = loaded_db.get_table("ipk_alias").unwrap();
+
+    // The alias itself must be rehydrated from sql_source (issue #5835).
+    assert_eq!(
+        loaded.schema.rowid_alias_column,
+        Some(0),
+        "INTEGER PRIMARY KEY rowid alias must survive a binary reload"
+    );
+
+    // And each persisted rowid is the IPK value, not the physical position.
+    let rowids: Vec<u64> =
+        loaded.scan_live().map(|(_, r)| r.row_id.expect("persisted rowid")).collect();
+    assert_eq!(rowids, vec![5, 7]);
+}
+
+/// "INT PRIMARY KEY" (not the exact keyword "INTEGER") is NOT a rowid alias
+/// in SQLite; rehydration must not invent one.
+#[test]
+fn test_int_primary_key_is_not_rehydrated_as_rowid_alias() {
+    let mut db = Database::new();
+
+    let mut schema = TableSchema::with_primary_key(
+        "int_pk".to_string(),
+        vec![ColumnSchema::new("a".to_string(), DataType::Integer, false)],
+        vec!["a".to_string()],
+    );
+    schema.set_sql_source("CREATE TABLE int_pk(a INT PRIMARY KEY)".to_string());
+    db.create_table(schema).unwrap();
+
+    let path = format!("/tmp/test_int_pk_no_alias_{}.vbsql", std::process::id());
+    db.save_binary(&path).unwrap();
+    let loaded_db = Database::load_binary(&path).unwrap();
+    std::fs::remove_file(&path).ok();
+
+    assert_eq!(
+        loaded_db.get_table("int_pk").unwrap().schema.rowid_alias_column,
+        None,
+        "INT PRIMARY KEY must not become a rowid alias on reload"
+    );
+}

--- a/crates/vibesql-storage/src/table/mod.rs
+++ b/crates/vibesql-storage/src/table/mod.rs
@@ -203,15 +203,24 @@ pub struct Table {
     /// Counter for modifications since last statistics update
     modifications_since_stats: usize,
 
-    /// Largest explicit rowid ever assigned in this table (issue #5835).
+    /// Largest *signed* effective rowid ever assigned in this table
+    /// (issue #5835). `None` until the first row is inserted.
     ///
-    /// Updated whenever a row carrying an explicit `Row::row_id` is inserted
-    /// or updated (including rows reloaded from a v13+ snapshot or replayed
-    /// from a v3+ WAL). Monotone: deletes never decrease it, so rowid
-    /// allocation via [`Table::next_rowid`] can never collide with a rowid
-    /// that is (or was) in use. Not serialized — rebuilt naturally on load
-    /// because every reloaded row passes through `insert`.
-    max_assigned_rowid: u64,
+    /// SQLite rowids are signed 64-bit integers (they can be negative), and
+    /// `Row::row_id` stores the two's-complement bit pattern of that i64.
+    /// This field tracks the maximum under *signed* interpretation:
+    /// - explicit rowids contribute `row_id as i64` (so `-1`, stored as
+    ///   `u64::MAX`, contributes `-1` — it can never poison allocation);
+    /// - implicit rows (no `row_id`) contribute their effective rowid,
+    ///   `physical position + 1`.
+    ///
+    /// Updated on `insert` / `insert_batch` / `update_row` (including rows
+    /// reloaded from a v13+ snapshot or replayed from a v3+ WAL). Monotone:
+    /// deletes never decrease it, so rowid allocation via
+    /// [`Table::next_rowid`] can never collide with a rowid that is (or was)
+    /// in use. Not serialized — rebuilt naturally on load because every
+    /// reloaded row passes through `insert`.
+    max_assigned_rowid: Option<i64>,
     // Note: Table-level columnar caching was removed in #3892 to eliminate duplicate
     // caching with Database::columnar_cache. All columnar caching now goes through
     // Database::get_columnar() which provides LRU eviction and Arc-based sharing.
@@ -267,8 +276,24 @@ impl Table {
             append_tracker: AppendModeTracker::new(),
             statistics: None,
             modifications_since_stats: 0,
-            max_assigned_rowid: 0,
+            max_assigned_rowid: None,
         }
+    }
+
+    /// Track a row's effective *signed* rowid for allocation (issue #5835).
+    ///
+    /// `row_id` is the explicit rowid bit pattern if the row carries one;
+    /// `position` is the physical index the row occupies, from which an
+    /// implicit rowid (`position + 1`) is derived otherwise.
+    #[inline]
+    fn track_effective_rowid(&mut self, row_id: Option<u64>, position: usize) {
+        let effective: i64 = match row_id {
+            // SQLite rowids are signed; reinterpret the stored bit pattern.
+            Some(rid) => rid as i64,
+            None => position as i64 + 1,
+        };
+        self.max_assigned_rowid =
+            Some(self.max_assigned_rowid.map_or(effective, |m| m.max(effective)));
     }
 
     /// Check if this table uses native columnar storage
@@ -294,11 +319,9 @@ impl Table {
             self.append_tracker.update(&pk_values);
         }
 
-        // Track the largest explicit rowid ever assigned (issue #5835) so
+        // Track the largest effective rowid ever assigned (issue #5835) so
         // future implicit-rowid allocation never collides with it.
-        if let Some(rid) = normalized_row.row_id {
-            self.max_assigned_rowid = self.max_assigned_rowid.max(rid);
-        }
+        self.track_effective_rowid(normalized_row.row_id, self.rows.len());
 
         // Add row to table (always stored for indexing and potential row access)
         let row_index = self.rows.len();
@@ -411,10 +434,8 @@ impl Table {
 
         // Phase 3: Insert all rows into storage
         for row in normalized_rows {
-            // Track the largest explicit rowid ever assigned (issue #5835).
-            if let Some(rid) = row.row_id {
-                self.max_assigned_rowid = self.max_assigned_rowid.max(rid);
-            }
+            // Track the largest effective rowid ever assigned (issue #5835).
+            self.track_effective_rowid(row.row_id, self.rows.len());
             self.rows.push(row);
             self.deleted.push(false);
         }
@@ -795,19 +816,48 @@ impl Table {
         self.rows.len()
     }
 
-    /// Next rowid to allocate for an implicit-rowid insert (issue #5835).
+    /// Largest *signed* effective rowid ever assigned, or `None` if no row
+    /// was ever inserted (issue #5835).
     ///
-    /// `max(physical_row_count, max_assigned_rowid) + 1`:
-    /// - `physical_row_count` covers implicit rowids (a row's implicit rowid
-    ///   is its physical position + 1), preserving the pre-existing
-    ///   `physical_row_count + 1` allocation for purely implicit tables.
-    /// - `max_assigned_rowid` covers explicit rowids — including rows
-    ///   reloaded from disk, whose persisted rowids can exceed the (compacted)
-    ///   physical count. Without it, a reloaded table with rowids {1, 3}
-    ///   would hand out rowid 3 again.
+    /// SQLite rowids are signed 64-bit integers; `Row::row_id` stores the
+    /// two's-complement bit pattern. This is the signed maximum over every
+    /// effective rowid ever assigned (explicit rowids as `row_id as i64`,
+    /// implicit rows as `physical position + 1`). Monotone across deletes.
+    #[inline]
+    pub fn max_rowid_signed(&self) -> Option<i64> {
+        self.max_assigned_rowid
+    }
+
+    /// Next rowid to allocate for an implicit-rowid insert, as a *signed*
+    /// value (issue #5835).
+    ///
+    /// SQLite semantics (verified against sqlite3): the next implicit rowid
+    /// is the signed maximum existing rowid + 1, or 1 for a table that never
+    /// held a row. Negative maxima yield negative-or-zero allocations (after
+    /// `INSERT INTO t(rowid,x) VALUES(-1,5)`, the next implicit rowid is 0),
+    /// exactly matching sqlite3.
+    ///
+    /// `max_assigned_rowid` covers both implicit rowids (tracked as
+    /// physical position + 1 at insert time, preserving the pre-existing
+    /// `physical_row_count + 1` allocation for purely implicit tables) and
+    /// explicit rowids — including rows reloaded from disk, whose persisted
+    /// rowids can exceed the (compacted) physical count. Without the latter,
+    /// a reloaded table with rowids {1, 3} would hand out rowid 3 again.
+    ///
+    /// Saturating: a table whose max rowid is `i64::MAX` allocates
+    /// `i64::MAX` again rather than overflowing (SQLite reports SQLITE_FULL
+    /// here; a duplicate-rowid error is the closest safe behavior).
+    #[inline]
+    pub fn next_rowid_signed(&self) -> i64 {
+        self.max_assigned_rowid.map_or(1, |m| m.saturating_add(1))
+    }
+
+    /// [`Table::next_rowid_signed`] as the u64 bit pattern stored in
+    /// `Row::row_id` (two's complement — e.g. an allocation of `-4` is
+    /// returned as `(-4i64) as u64`).
     #[inline]
     pub fn next_rowid(&self) -> u64 {
-        (self.rows.len() as u64).max(self.max_assigned_rowid) + 1
+        self.next_rowid_signed() as u64
     }
 
     /// Get count of deleted (logically removed) rows
@@ -891,8 +941,11 @@ impl Table {
         let normalized_row = normalizer.normalize_and_validate(row)?;
 
         // Track the largest explicit rowid ever assigned (issue #5835).
+        // Only explicit rowids are tracked here: an UPDATE replaces a row in
+        // place, so a `None` row_id cannot introduce a new effective rowid
+        // beyond what its insert already tracked.
         if let Some(rid) = normalized_row.row_id {
-            self.max_assigned_rowid = self.max_assigned_rowid.max(rid);
+            self.track_effective_rowid(Some(rid), index);
         }
 
         // Get old row for index updates (clone to avoid borrow issues)
@@ -1360,15 +1413,21 @@ impl Table {
         // surviving implicit rowid BEFORE the shift — otherwise `WHERE
         // rowid=N` would silently target a different row after compaction.
         let mut new_rows = Vec::with_capacity(self.rows.len() - self.deleted_count);
+        let mut max_effective: Option<i64> = self.max_assigned_rowid;
         for (idx, row) in self.rows.iter().enumerate() {
             if !self.deleted[idx] {
                 let mut row = row.clone();
                 let effective = row.row_id.unwrap_or(idx as u64 + 1);
                 row.row_id = Some(effective);
-                self.max_assigned_rowid = self.max_assigned_rowid.max(effective);
+                // Signed interpretation (issue #5835): negative rowids are
+                // stored as two's-complement bit patterns and must never
+                // poison allocation tracking.
+                let signed = effective as i64;
+                max_effective = Some(max_effective.map_or(signed, |m| m.max(signed)));
                 new_rows.push(row);
             }
         }
+        self.max_assigned_rowid = max_effective;
 
         // Replace old vectors with compacted ones
         self.rows = new_rows;

--- a/crates/vibesql-storage/src/table/mod.rs
+++ b/crates/vibesql-storage/src/table/mod.rs
@@ -202,6 +202,16 @@ pub struct Table {
 
     /// Counter for modifications since last statistics update
     modifications_since_stats: usize,
+
+    /// Largest explicit rowid ever assigned in this table (issue #5835).
+    ///
+    /// Updated whenever a row carrying an explicit `Row::row_id` is inserted
+    /// or updated (including rows reloaded from a v13+ snapshot or replayed
+    /// from a v3+ WAL). Monotone: deletes never decrease it, so rowid
+    /// allocation via [`Table::next_rowid`] can never collide with a rowid
+    /// that is (or was) in use. Not serialized — rebuilt naturally on load
+    /// because every reloaded row passes through `insert`.
+    max_assigned_rowid: u64,
     // Note: Table-level columnar caching was removed in #3892 to eliminate duplicate
     // caching with Database::columnar_cache. All columnar caching now goes through
     // Database::get_columnar() which provides LRU eviction and Arc-based sharing.
@@ -220,6 +230,7 @@ impl Clone for Table {
             append_tracker: self.append_tracker.clone(),
             statistics: self.statistics.clone(),
             modifications_since_stats: self.modifications_since_stats,
+            max_assigned_rowid: self.max_assigned_rowid,
         }
     }
 }
@@ -256,6 +267,7 @@ impl Table {
             append_tracker: AppendModeTracker::new(),
             statistics: None,
             modifications_since_stats: 0,
+            max_assigned_rowid: 0,
         }
     }
 
@@ -280,6 +292,12 @@ impl Table {
             let pk_values: Vec<SqlValue> =
                 pk_indices.iter().map(|&idx| normalized_row.values[idx].clone()).collect();
             self.append_tracker.update(&pk_values);
+        }
+
+        // Track the largest explicit rowid ever assigned (issue #5835) so
+        // future implicit-rowid allocation never collides with it.
+        if let Some(rid) = normalized_row.row_id {
+            self.max_assigned_rowid = self.max_assigned_rowid.max(rid);
         }
 
         // Add row to table (always stored for indexing and potential row access)
@@ -393,6 +411,10 @@ impl Table {
 
         // Phase 3: Insert all rows into storage
         for row in normalized_rows {
+            // Track the largest explicit rowid ever assigned (issue #5835).
+            if let Some(rid) = row.row_id {
+                self.max_assigned_rowid = self.max_assigned_rowid.max(rid);
+            }
             self.rows.push(row);
             self.deleted.push(false);
         }
@@ -773,6 +795,21 @@ impl Table {
         self.rows.len()
     }
 
+    /// Next rowid to allocate for an implicit-rowid insert (issue #5835).
+    ///
+    /// `max(physical_row_count, max_assigned_rowid) + 1`:
+    /// - `physical_row_count` covers implicit rowids (a row's implicit rowid
+    ///   is its physical position + 1), preserving the pre-existing
+    ///   `physical_row_count + 1` allocation for purely implicit tables.
+    /// - `max_assigned_rowid` covers explicit rowids — including rows
+    ///   reloaded from disk, whose persisted rowids can exceed the (compacted)
+    ///   physical count. Without it, a reloaded table with rowids {1, 3}
+    ///   would hand out rowid 3 again.
+    #[inline]
+    pub fn next_rowid(&self) -> u64 {
+        (self.rows.len() as u64).max(self.max_assigned_rowid) + 1
+    }
+
     /// Get count of deleted (logically removed) rows
     ///
     /// This is used for DML cost estimation, as tables with many deleted rows
@@ -852,6 +889,11 @@ impl Table {
         // Normalize and validate row
         let normalizer = RowNormalizer::new(&self.schema);
         let normalized_row = normalizer.normalize_and_validate(row)?;
+
+        // Track the largest explicit rowid ever assigned (issue #5835).
+        if let Some(rid) = normalized_row.row_id {
+            self.max_assigned_rowid = self.max_assigned_rowid.max(rid);
+        }
 
         // Get old row for index updates (clone to avoid borrow issues)
         let old_row = self.rows[index].clone();
@@ -1310,11 +1352,21 @@ impl Table {
             return;
         }
 
-        // Build new vectors with only live rows
+        // Build new vectors with only live rows.
+        //
+        // Rowid stability (issue #5835): a row without an explicit rowid
+        // derives its implicit rowid from its physical position (idx + 1).
+        // Compaction shifts physical positions, so materialize each
+        // surviving implicit rowid BEFORE the shift — otherwise `WHERE
+        // rowid=N` would silently target a different row after compaction.
         let mut new_rows = Vec::with_capacity(self.rows.len() - self.deleted_count);
         for (idx, row) in self.rows.iter().enumerate() {
             if !self.deleted[idx] {
-                new_rows.push(row.clone());
+                let mut row = row.clone();
+                let effective = row.row_id.unwrap_or(idx as u64 + 1);
+                row.row_id = Some(effective);
+                self.max_assigned_rowid = self.max_assigned_rowid.max(effective);
+                new_rows.push(row);
             }
         }
 

--- a/crates/vibesql-storage/src/wal/engine.rs
+++ b/crates/vibesql-storage/src/wal/engine.rs
@@ -1035,6 +1035,7 @@ mod tests {
                 table_name: "main.t".to_string(),
                 row_id: 100,
                 values: vec![SqlValue::Integer(42)],
+                rowid: None,
             })
             .unwrap();
 
@@ -1059,6 +1060,7 @@ mod tests {
                     table_name: "main.t".to_string(),
                     row_id: i as u64,
                     values: vec![SqlValue::Integer(i)],
+                    rowid: None,
                 })
                 .unwrap();
             assert_eq!(lsn, i as u64);
@@ -1084,6 +1086,7 @@ mod tests {
                     table_name: "main.t".to_string(),
                     row_id: i as u64,
                     values: vec![SqlValue::Integer(i)],
+                    rowid: None,
                 })
                 .unwrap();
         }
@@ -1114,6 +1117,7 @@ mod tests {
                     table_name: "main.t".to_string(),
                     row_id: i as u64,
                     values: vec![SqlValue::Integer(i)],
+                    rowid: None,
                 })
                 .unwrap();
         }
@@ -1145,6 +1149,7 @@ mod tests {
                 table_name: "main.t".to_string(),
                 row_id: 1,
                 values: vec![SqlValue::Integer(1)],
+                rowid: None,
             })
             .unwrap();
 
@@ -1167,6 +1172,7 @@ mod tests {
                 table_name: "main.t".to_string(),
                 row_id: 1,
                 values: vec![SqlValue::Integer(1)],
+                rowid: None,
             })
             .unwrap();
 
@@ -1195,6 +1201,7 @@ mod tests {
                     table_name: "main.t".to_string(),
                     row_id: i as u64,
                     values: vec![SqlValue::Integer(i)],
+                    rowid: None,
                 })
                 .unwrap();
         }
@@ -1225,6 +1232,7 @@ mod tests {
                     table_name: "main.t".to_string(),
                     row_id: i as u64,
                     values: vec![SqlValue::Integer(i)],
+                    rowid: None,
                 })
                 .unwrap();
         }
@@ -1268,6 +1276,7 @@ mod tests {
                     table_name: "main.t".to_string(),
                     row_id: i as u64,
                     values: vec![SqlValue::Integer(i)],
+                    rowid: None,
                 })
                 .unwrap();
         }
@@ -1313,6 +1322,7 @@ mod tests {
                     table_name: "main.t".to_string(),
                     row_id: i as u64,
                     values: vec![SqlValue::Integer(i)],
+                    rowid: None,
                 })
                 .unwrap();
             // LSNs should still be assigned
@@ -1348,6 +1358,7 @@ mod tests {
                     table_name: "main.t".to_string(),
                     row_id: i as u64,
                     values: vec![SqlValue::Integer(i)],
+                    rowid: None,
                 })
                 .unwrap();
         }

--- a/crates/vibesql-storage/src/wal/entry.rs
+++ b/crates/vibesql-storage/src/wal/entry.rs
@@ -43,7 +43,21 @@ pub enum WalOp {
     // table during recovery: it lives in a different id space than the
     // monotonic `table_id` stored in `CreateTable`.
     /// Insert a row into a table
-    Insert { table_id: u32, table_name: String, row_id: u64, values: Vec<SqlValue> },
+    ///
+    /// `row_id` is the row's physical index at emit time (diagnostic only —
+    /// replay appends rows in LSN order, reproducing physical positions).
+    /// `rowid` (WAL format v3+, issue #5835) is the row's effective SQLite
+    /// rowid: the explicit `Row::row_id` when present, else the implicit
+    /// physical position + 1. Recovery stamps it back onto the replayed row
+    /// so rowid semantics survive a crash. `None` only when parsed from a
+    /// v2-or-earlier log.
+    Insert {
+        table_id: u32,
+        table_name: String,
+        row_id: u64,
+        values: Vec<SqlValue>,
+        rowid: Option<u64>,
+    },
     /// Update a row in a table
     Update {
         table_id: u32,
@@ -168,7 +182,7 @@ impl WalOp {
     /// Serialize the operation to bytes
     pub fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), StorageError> {
         match self {
-            WalOp::Insert { table_id, table_name, row_id, values } => {
+            WalOp::Insert { table_id, table_name, row_id, values, rowid } => {
                 writer
                     .write_all(&[WalOpTag::Insert as u8])
                     .map_err(|e| StorageError::IoError(e.to_string()))?;
@@ -176,6 +190,14 @@ impl WalOp {
                 write_string(writer, table_name)?;
                 write_u64(writer, *row_id)?;
                 write_sql_values(writer, values)?;
+                // WAL format v3 (issue #5835): effective rowid trailer.
+                match rowid {
+                    Some(r) => {
+                        write_bool(writer, true)?;
+                        write_u64(writer, *r)?;
+                    }
+                    None => write_bool(writer, false)?,
+                }
             }
             WalOp::Update { table_id, table_name, row_id, old_values, new_values } => {
                 writer
@@ -295,7 +317,19 @@ impl WalOp {
                     if dml_has_table_name { read_string(reader)? } else { String::new() };
                 let row_id = read_u64(reader)?;
                 let values = read_sql_values(reader)?;
-                Ok(WalOp::Insert { table_id, table_name, row_id, values })
+                // WAL format v3 (issue #5835): effective rowid trailer.
+                // Absent in v2-and-earlier logs — replay falls back to the
+                // legacy physical renumbering for such entries.
+                let rowid = if version >= 3 {
+                    if read_bool(reader)? {
+                        Some(read_u64(reader)?)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+                Ok(WalOp::Insert { table_id, table_name, row_id, values, rowid })
             }
             WalOpTag::Update => {
                 let table_id = read_u32(reader)?;
@@ -429,6 +463,7 @@ mod tests {
                     SqlValue::Varchar(arcstr::ArcStr::from("test")),
                     SqlValue::Boolean(true),
                 ],
+                rowid: Some(101),
             },
         );
 

--- a/crates/vibesql-storage/src/wal/format.rs
+++ b/crates/vibesql-storage/src/wal/format.rs
@@ -37,7 +37,12 @@ pub const WAL_MAGIC: &[u8; 4] = b"VWAL";
 /// - v2: DML ops carry an inline `table_name`, enabling correct DML replay.
 ///   Older v1 logs are still readable (the table name is parsed as absent and
 ///   such DML entries are skipped during replay).
-pub const WAL_VERSION: u32 = 2;
+/// - v3: `Insert` ops carry the row's effective SQLite rowid (present-flag +
+///   u64, after the values), so crash recovery can restore each replayed
+///   row's rowid instead of silently renumbering it by physical position
+///   (issue #5835). Older v2 logs are still readable (the rowid is parsed as
+///   absent and replayed rows fall back to physical renumbering).
+pub const WAL_VERSION: u32 = 3;
 
 /// Size of the WAL header in bytes
 pub const WAL_HEADER_SIZE: usize = 32;

--- a/crates/vibesql-storage/src/wal/reader.rs
+++ b/crates/vibesql-storage/src/wal/reader.rs
@@ -263,6 +263,7 @@ mod tests {
                     table_name: "main.t".to_string(),
                     row_id: i,
                     values: vec![SqlValue::Integer(i as i64)],
+                    rowid: None,
                 },
             );
             writer.append(&entry).unwrap();

--- a/crates/vibesql-storage/src/wal/recovery.rs
+++ b/crates/vibesql-storage/src/wal/recovery.rs
@@ -665,7 +665,7 @@ impl RecoveryManager {
         stats: &mut RecoveryStats,
     ) -> Result<(), StorageError> {
         match op {
-            WalOp::Insert { table_id: _, table_name, row_id, values } => {
+            WalOp::Insert { table_id: _, table_name, row_id, values, rowid } => {
                 // WAL format v2+ carries the fully-qualified table_name so the
                 // mutation can be routed to the correct table during replay.
                 // (v1 logs serialize an empty name; such DML is unroutable and
@@ -680,7 +680,13 @@ impl RecoveryManager {
                 }
                 match db.get_table_mut(&table_name) {
                     Some(table) => {
-                        let row = crate::row::Row::new(values);
+                        let mut row = crate::row::Row::new(values);
+                        // WAL format v3 records the row's effective SQLite
+                        // rowid; stamp it back so `WHERE rowid=N` targets the
+                        // same row after crash recovery (issue #5835). v2
+                        // logs carry no rowid — such rows fall back to the
+                        // legacy physical renumbering.
+                        row.row_id = rowid;
                         match table.insert(row) {
                             Ok(()) => stats.inserts_applied += 1,
                             Err(e) => log::warn!(
@@ -707,7 +713,11 @@ impl RecoveryManager {
                 }
                 match db.get_table_mut(&table_name) {
                     Some(table) => {
-                        let row = crate::row::Row::new(new_values);
+                        let mut row = crate::row::Row::new(new_values);
+                        // Preserve the target row's rowid across the replayed
+                        // update (issue #5835): an UPDATE never changes a
+                        // row's rowid, so the replacement row must keep it.
+                        row.row_id = table.get_row(row_id as usize).and_then(|r| r.row_id);
                         match table.update_row(row_id as usize, row) {
                             Ok(()) => stats.updates_applied += 1,
                             Err(e) => log::warn!(
@@ -1155,6 +1165,7 @@ mod tests {
                 table_name: "main.t".to_string(),
                 row_id: 0,
                 values: vec![SqlValue::Integer(42)],
+                rowid: None,
             },
         );
 
@@ -1177,6 +1188,7 @@ mod tests {
                 table_name: "main.t".to_string(),
                 row_id: 0,
                 values: vec![SqlValue::Integer(42)],
+                rowid: None,
             },
         );
 
@@ -1437,6 +1449,7 @@ mod tests {
                             SqlValue::Integer(i),
                             SqlValue::Varchar(arcstr::ArcStr::from(format!("v{i}"))),
                         ],
+                        rowid: None,
                     },
                     &mut lsn,
                 );
@@ -1793,11 +1806,12 @@ mod tests {
         let mut reader = &entry_buf[..];
         let entry = WalEntry::deserialize_versioned(&mut reader, 1).unwrap();
         match entry.op {
-            WalOp::Insert { table_id, table_name, row_id, values } => {
+            WalOp::Insert { table_id, table_name, row_id, values, rowid } => {
                 assert_eq!(table_id, 7);
                 assert!(table_name.is_empty(), "v1 op has no inline table_name");
                 assert_eq!(row_id, 0);
                 assert_eq!(values, vec![SqlValue::Integer(99)]);
+                assert_eq!(rowid, None, "v1 op has no rowid trailer");
             }
             other => panic!("expected Insert, got {:?}", other),
         }

--- a/crates/vibesql-storage/src/wal/truncate.rs
+++ b/crates/vibesql-storage/src/wal/truncate.rs
@@ -259,6 +259,7 @@ mod tests {
                     table_name: "main.t".to_string(),
                     row_id: i,
                     values: vec![SqlValue::Integer(i as i64)],
+                    rowid: None,
                 },
             );
             wal_writer.append(&entry).unwrap();

--- a/crates/vibesql-storage/src/wal/writer.rs
+++ b/crates/vibesql-storage/src/wal/writer.rs
@@ -201,6 +201,7 @@ mod tests {
                 table_name: "main.t".to_string(),
                 row_id: 100,
                 values: vec![SqlValue::Integer(42)],
+                rowid: None,
             },
         );
 
@@ -226,6 +227,7 @@ mod tests {
                     table_name: "main.t".to_string(),
                     row_id: i,
                     values: vec![SqlValue::Integer(i as i64)],
+                    rowid: None,
                 },
             );
             let lsn = writer.append(&entry).unwrap();
@@ -249,6 +251,7 @@ mod tests {
                 table_name: "main.t".to_string(),
                 row_id: 100,
                 values: vec![SqlValue::Varchar(arcstr::ArcStr::from("test"))],
+                rowid: None,
             })
             .unwrap();
 


### PR DESCRIPTION
Closes #5835
Closes #5871

## Problem (corruption class)

Rowid semantics silently changed across a process restart:

1. **INTEGER PRIMARY KEY rowid aliasing was lost after reload.** `TableSchema::rowid_alias_column` and `ColumnSchema::is_exact_integer_type` were never serialized nor rebuilt on load, so after a reopen `WHERE rowid=N` returned zero rows, `DELETE ... WHERE rowid=N` targeted the WRONG row (intpkey-2.6), and `RETURNING rowid` yielded NULL.
2. **`Row::row_id` was not persisted (binary v12) or WAL-replayed (WAL v2).** Explicit rowids were lost and implicit rowids were renumbered by physical position whenever tombstones were dropped at save/compaction, and new inserts could collide with reloaded rowids.
3. **REPLACE INTO was not durable (#5871).** The conflict-delete emitted no WAL op, and REPLACE didn't count as a modification for the CLI exit checkpoint — the next process resurrected the old row next to the new one (duplicate INTEGER PRIMARY KEY, check-13.x, upsert5-3.x).

All three verified as still reproducing on current main (9c76c1820) before this fix.

## Fix

- **Alias rehydration**: rebuild `rowid_alias_column` + `is_exact_integer_type` from the persisted `sql_source` on binary load, mirroring the CREATE TABLE path (exact keyword `INTEGER` single-column PK only; `INT PRIMARY KEY` correctly excluded).
- **Binary format v13**: persist each live row's effective rowid (alias IPK value, else explicit rowid, else physical position + 1). v12-and-earlier files remain readable (absence = legacy renumbering).
- **WAL format v3**: `Insert` ops carry the effective rowid (present-flag + u64 trailer); recovery stamps it back on replay, and replayed UPDATEs preserve the target row's rowid. v2 logs remain readable.
- **Allocation continuity**: `Table::next_rowid()` = `max(physical_row_count, max_assigned_rowid) + 1`, tracked monotonically across inserts/updates/reloads, so new auto-rowids never collide with reloaded ones. Compaction materializes surviving implicit rowids before shifting positions.
- **REPLACE durability**: `handle_replace_conflicts` WAL-logs each conflict delete before applying it (mirroring the DELETE executor), and the CLI treats `REPLACE` as a modification statement so a REPLACE-only session checkpoints at exit.

## #5871 coordination

**Same fix — this PR closes #5871.** Its exact three-process repro now yields a single row `11|33` with `PRAGMA integrity_check` ok, covered by `replace_conflict_delete_survives_crash_via_wal_replay` (WAL-replay of the delete, no checkpoint) and `test_replace_into_durable_across_separate_process_reopen` (cross-process CLI). The upsert5-3.x TCL tests additionally depend on #5817's clause-selection work, per that issue.

## Verification

Reproducers (all confirmed broken on main first, fixed after):

| Repro | main | this PR |
|---|---|---|
| `SELECT b FROM p WHERE rowid=5` after reopen | 0 rows | `five` |
| `DELETE FROM p WHERE rowid=7` after reopen | 0 rows deleted | deletes exactly a=7 |
| `INSERT ... RETURNING rowid` after reopen | NULL | 20 |
| REPLACE INTO across 3 processes (#5871) | 2 rows, dup PK | 1 row `11\|33`, integrity ok |
| implicit-rowid table: rowids after reload + new insert | renumbered/collision | survivors keep 1,3; new row gets 4 |

Tests:
- `cargo test -p vibesql-storage`: 810 passed, 0 failed (includes new v13 round-trip, IPK-alias, INT-PK-negative, next_rowid, compaction tests)
- `cargo test -p vibesql-executor --tests`: 4920 passed, 0 failed (includes new `rowid_reload_tests.rs`: 6 tests covering binary reload + WAL crash recovery). One skip: `test_deep_case_expressions` stack-overflows in debug on this machine — pre-existing, reproduced on clean main with this work stashed; unrelated (evaluator recursion depth).
- `cargo test -p vibesql-cli --test wal_recovery_test`: 9 passed (2 new cross-process subprocess tests)
- **intpkey.test: 52 passed / 32 failed → 84 passed / 0 failed**
- **check.test: 44 passed / 48 failed → 61 passed / 31 failed** — the 13.x REPLACE-durability cluster is fully clear; remaining failures are CHECK-constraint semantics (3.x/4.x/5.x), unrelated to this issue.
- `cargo fmt --check` clean. Clippy: one pre-existing `approx_constant` error in `evaluator/expressions/operators.rs:369` from #5884 (file untouched by this PR).

## Compatibility

Both format bumps are backward-readable (v12 binary files and v2 WAL logs parse with rowid = absent, falling back to the previous renumbering behavior). Forward reads of v13/v3 by old binaries are rejected by the existing version gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)