### PR TITLE
fix(parser): make ISNULL/NOTNULL/NOT NULL postfix results composable operands

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -202,6 +202,10 @@ impl<'arena> ArenaParser<'arena> {
                     self.consume_keyword(Keyword::Null)?;
                     let left_ref = self.arena.alloc(left);
                     left = Expression::IsNull { expr: left_ref, negated: true };
+                    // NOT NULL is syntactically closed, so tighter-binding operators
+                    // that follow take the whole node as their left operand
+                    // (SQLite: `1 NOT NULL + 1` = `(1 NOT NULL) + 1` = 2).
+                    left = self.continue_higher_precedence_ops(left)?;
                     continue;
                 } else {
                     self.position = saved_pos;
@@ -441,16 +445,25 @@ impl<'arena> ArenaParser<'arena> {
             // SQLite compatibility: ISNULL and NOTNULL as postfix operators
             // These are equivalent to IS NULL and IS NOT NULL respectively
             // The enclosing loop supports chaining: `x NOTNULL NOTNULL`
+            //
+            // Like IN, these postfix operators are syntactically closed (no right
+            // operand to consume), so a tighter-binding operator that follows takes
+            // the whole node as its left operand (SQLite: `1 ISNULL + 1` = 1, i.e.
+            // `(1 ISNULL) + 1`), hence continue_higher_precedence_ops. Shift-tier
+            // operators (`<<`, `>>`) are outside the arena grammar and must fail
+            // arena parsing, routing through parse_with_arena_fallback.
             if self.peek_keyword(Keyword::Isnull) {
                 self.consume_keyword(Keyword::Isnull)?;
                 let left_ref = self.arena.alloc(left);
                 left = Expression::IsNull { expr: left_ref, negated: false };
+                left = self.continue_higher_precedence_ops(left)?;
                 continue;
             }
             if self.peek_keyword(Keyword::Notnull) {
                 self.consume_keyword(Keyword::Notnull)?;
                 let left_ref = self.arena.alloc(left);
                 left = Expression::IsNull { expr: left_ref, negated: true };
+                left = self.continue_higher_precedence_ops(left)?;
                 continue;
             }
 
@@ -464,10 +477,12 @@ impl<'arena> ArenaParser<'arena> {
     /// Continue parsing tighter-binding binary operators (multiplicative, concat,
     /// additive) with an already-parsed left operand.
     ///
-    /// Used after an IN/NOT IN node: its right operand is syntactically closed
-    /// (a parenthesized list/subquery), so per SQLite a tighter-binding operator
-    /// that follows takes the entire IN expression as its left operand:
-    /// `1 IN (SELECT 1) + 1` parses as `(1 IN (SELECT 1)) + 1`.
+    /// Used after a syntactically-closed comparison-tier node — IN/NOT IN
+    /// (right operand is a parenthesized list/subquery) and the postfix null
+    /// tests ISNULL / NOTNULL / NOT NULL (no right operand at all). Per SQLite
+    /// a tighter-binding operator that follows takes the entire node as its
+    /// left operand: `1 IN (SELECT 1) + 1` parses as `(1 IN (SELECT 1)) + 1`
+    /// and `1 ISNULL + 1` as `(1 ISNULL) + 1`.
     ///
     /// Each operator's right operand is parsed at the next-tighter tier, so
     /// relative precedence among these operators is preserved

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -516,6 +516,11 @@ impl Parser {
                         // General case: expr NOT NULL is an operator
                         left =
                             vibesql_ast::Expression::IsNull { expr: Box::new(left), negated: true };
+                        // NOT NULL's right side is syntactically closed (NULL is part
+                        // of the operator token sequence), so tighter-binding operators
+                        // that follow take the whole node as their left operand
+                        // (SQLite: `1 NOT NULL + 1` = `(1 NOT NULL) + 1` = 2).
+                        left = self.continue_higher_precedence_ops(left)?;
                         continue;
                     }
                 } else {
@@ -865,14 +870,21 @@ impl Parser {
             // SQLite compatibility: ISNULL and NOTNULL as postfix operators
             // These are equivalent to IS NULL and IS NOT NULL respectively
             // The enclosing loop supports chaining: `x NOTNULL NOTNULL`
+            //
+            // Like IN, these postfix operators are syntactically closed (no right
+            // operand to consume), so a tighter-binding operator that follows takes
+            // the whole node as its left operand (SQLite: `1 ISNULL + 1` = 1, i.e.
+            // `(1 ISNULL) + 1`), hence continue_higher_precedence_ops.
             if self.peek_keyword(Keyword::Isnull) {
                 self.consume_keyword(Keyword::Isnull)?;
                 left = vibesql_ast::Expression::IsNull { expr: Box::new(left), negated: false };
+                left = self.continue_higher_precedence_ops(left)?;
                 continue;
             }
             if self.peek_keyword(Keyword::Notnull) {
                 self.consume_keyword(Keyword::Notnull)?;
                 left = vibesql_ast::Expression::IsNull { expr: Box::new(left), negated: true };
+                left = self.continue_higher_precedence_ops(left)?;
                 continue;
             }
 
@@ -886,11 +898,17 @@ impl Parser {
     /// Continue parsing tighter-binding binary operators (multiplicative, concat,
     /// additive, shift) with an already-parsed left operand.
     ///
-    /// Used after an IN/NOT IN node: its right operand is syntactically closed
-    /// (a parenthesized list/subquery or a table name), so per SQLite a
-    /// tighter-binding operator that follows takes the entire IN expression as
-    /// its left operand: `1 IN (SELECT 1) + 1` parses as `(1 IN (SELECT 1)) + 1`
-    /// and `1 NOT IN (SELECT 1) << 2` as `(1 NOT IN (SELECT 1)) << 2`.
+    /// Used after a syntactically-closed comparison-tier node — IN/NOT IN
+    /// (right operand is a parenthesized list/subquery or a table name) and
+    /// the postfix null tests ISNULL / NOTNULL / NOT NULL (no right operand at
+    /// all). Per SQLite a tighter-binding operator that follows takes the
+    /// entire node as its left operand: `1 IN (SELECT 1) + 1` parses as
+    /// `(1 IN (SELECT 1)) + 1`, `1 NOT IN (SELECT 1) << 2` as
+    /// `(1 NOT IN (SELECT 1)) << 2`, and `1 ISNULL + 1` as `(1 ISNULL) + 1`.
+    ///
+    /// Note this does NOT apply to `IS NULL` / `IS [NOT] TRUE`: there SQLite
+    /// treats NULL/TRUE as an ordinary expression operand of IS, so
+    /// `1 IS NULL + 1` parses as `1 IS (NULL + 1)`.
     ///
     /// Each operator's right operand is parsed at the next-tighter tier, so
     /// relative precedence among these operators is preserved

--- a/crates/vibesql-parser/src/tests/arena_parser.rs
+++ b/crates/vibesql-parser/src/tests/arena_parser.rs
@@ -829,3 +829,158 @@ fn test_arena_matrix_in_between_shift_bound_falls_back() {
         high
     );
 }
+
+// ============================================================================
+// ISNULL / NOTNULL / NOT NULL postfix composability (issue #5857)
+//
+// Mirrors tests/isnull_postfix.rs: the arena parser must produce ASTs
+// equivalent to the standard parser for everything it accepts. Shift-tier
+// cases (<<) are outside the arena parser's grammar and must fail arena
+// parsing (never silently truncate) and succeed end-to-end through
+// parse_with_arena_fallback. All expected values were verified against sqlite3.
+// ============================================================================
+
+/// Assert the arena expression is `IsNull` with the given polarity.
+fn assert_arena_is_null<'a>(
+    expr: &'a vibesql_ast::arena::Expression<'a>,
+    expected_negated: bool,
+    context: &str,
+) -> &'a vibesql_ast::arena::Expression<'a> {
+    if let vibesql_ast::arena::Expression::IsNull { expr: inner, negated } = expr {
+        assert_eq!(*negated, expected_negated, "{}: wrong IsNull polarity", context);
+        inner
+    } else {
+        panic!("{}: expected IsNull node, got {:?}", context, expr);
+    }
+}
+
+#[test]
+fn test_arena_isnull_followed_by_plus() {
+    // sqlite3: SELECT 1 ISNULL + 1; -- 1, i.e. ((1 ISNULL) + 1)
+    with_arena_select_expr("SELECT 1 ISNULL + 1", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, left, .. } = expr else {
+            panic!("expected BinaryOp Plus at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Plus);
+        assert_arena_is_null(left, false, "left operand of +");
+    });
+}
+
+#[test]
+fn test_arena_notnull_followed_by_concat() {
+    // sqlite3: SELECT 4 NOTNULL || 'x'; -- '1x'
+    with_arena_select_expr("SELECT 4 NOTNULL || 'x'", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, left, .. } = expr else {
+            panic!("expected BinaryOp Concat at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Concat);
+        assert_arena_is_null(left, true, "left operand of ||");
+    });
+}
+
+#[test]
+fn test_arena_not_null_followed_by_plus() {
+    // sqlite3: SELECT 1 NOT NULL + 1; -- 2, i.e. ((1 NOT NULL) + 1)
+    with_arena_select_expr("SELECT 1 NOT NULL + 1", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, left, .. } = expr else {
+            panic!("expected BinaryOp Plus at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Plus);
+        assert_arena_is_null(left, true, "left operand of +");
+    });
+}
+
+#[test]
+fn test_arena_notnull_plus_then_multiply() {
+    // sqlite3: SELECT 1 NOTNULL + 2 * 3; -- 7, i.e. (1 NOTNULL) + (2 * 3)
+    with_arena_select_expr("SELECT 1 NOTNULL + 2 * 3", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, left, right } = expr else {
+            panic!("expected BinaryOp Plus at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Plus);
+        assert_arena_is_null(left, true, "left operand of +");
+        assert!(
+            matches!(
+                right,
+                vibesql_ast::arena::Expression::BinaryOp {
+                    op: vibesql_ast::BinaryOperator::Multiply,
+                    ..
+                }
+            ),
+            "right operand of + should be (2 * 3): {:?}",
+            right
+        );
+    });
+}
+
+#[test]
+fn test_arena_isnull_chained_notnull() {
+    // sqlite3: SELECT 1 ISNULL NOTNULL; -- 1, i.e. ((1 ISNULL) NOTNULL)
+    with_arena_select_expr("SELECT 1 ISNULL NOTNULL", |expr| {
+        let inner = assert_arena_is_null(expr, true, "outer NOTNULL");
+        assert_arena_is_null(inner, false, "inner ISNULL");
+    });
+}
+
+#[test]
+fn test_arena_isnull_shift_falls_back() {
+    // sqlite3: SELECT 1 ISNULL << 2; -- 0
+    // The arena parser has no shift tier: it must fail (never silently
+    // truncate to just the ISNULL node), and the fallback path must produce
+    // the standard parser's AST.
+    let arena = Bump::new();
+    let result = ArenaParser::parse_select_with_interner("SELECT 1 ISNULL << 2", &arena);
+    assert!(
+        result.is_err(),
+        "arena parser has no shift tier; << after ISNULL must fail arena parse, got: {:?}",
+        result.map(|(stmt, _)| format!("{:?}", stmt.select_list[0]))
+    );
+
+    let stmt = crate::parse_with_arena_fallback("SELECT 1 ISNULL << 2;")
+        .expect("fallback path should parse ISNULL followed by <<");
+    let vibesql_ast::Statement::Select(select) = stmt else {
+        panic!("expected SELECT statement");
+    };
+    let vibesql_ast::SelectItem::Expression { expr, .. } = &select.select_list[0] else {
+        panic!("expected expression select item");
+    };
+    let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr else {
+        panic!("expected BinaryOp LeftShift at top level, got {:?}", expr);
+    };
+    assert_eq!(*op, vibesql_ast::BinaryOperator::LeftShift);
+    assert!(
+        matches!(**left, vibesql_ast::Expression::IsNull { negated: false, .. }),
+        "left operand of << should be the ISNULL node: {:?}",
+        left
+    );
+}
+
+#[test]
+fn test_arena_not_null_shift_falls_back() {
+    // sqlite3: SELECT 1 NOT NULL << 3; -- 8
+    let arena = Bump::new();
+    let result = ArenaParser::parse_select_with_interner("SELECT 1 NOT NULL << 3", &arena);
+    assert!(
+        result.is_err(),
+        "arena parser has no shift tier; << after NOT NULL must fail arena parse, got: {:?}",
+        result.map(|(stmt, _)| format!("{:?}", stmt.select_list[0]))
+    );
+
+    let stmt = crate::parse_with_arena_fallback("SELECT 1 NOT NULL << 3;")
+        .expect("fallback path should parse NOT NULL followed by <<");
+    let vibesql_ast::Statement::Select(select) = stmt else {
+        panic!("expected SELECT statement");
+    };
+    let vibesql_ast::SelectItem::Expression { expr, .. } = &select.select_list[0] else {
+        panic!("expected expression select item");
+    };
+    let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr else {
+        panic!("expected BinaryOp LeftShift at top level, got {:?}", expr);
+    };
+    assert_eq!(*op, vibesql_ast::BinaryOperator::LeftShift);
+    assert!(
+        matches!(**left, vibesql_ast::Expression::IsNull { negated: true, .. }),
+        "left operand of << should be the NOT NULL node: {:?}",
+        left
+    );
+}

--- a/crates/vibesql-parser/src/tests/isnull_postfix.rs
+++ b/crates/vibesql-parser/src/tests/isnull_postfix.rs
@@ -1,0 +1,439 @@
+use super::*;
+
+// ========================================================================
+// ISNULL / NOTNULL / NOT NULL postfix composability tests (issue #5857)
+//
+// Per SQLite, ISNULL, NOTNULL, and postfix NOT NULL are left-associative
+// comparison-tier postfix operators whose result composes as an operand.
+// They are syntactically closed (no right operand), so — exactly like IN
+// (issue #5801 / PR #5811) — a tighter-binding operator (+, -, *, /, %,
+// ||, <<, >>) that follows takes the whole null-test node as its left
+// operand: `1 ISNULL + 1` parses as `(1 ISNULL) + 1` = 1.
+//
+// Contrast with `IS NULL`: there SQLite treats NULL as an ordinary
+// expression operand of IS, so `1 IS NULL + 1` parses as `1 IS (NULL + 1)`
+// (that IS-operand shape is out of scope here).
+//
+// All expected values in the comments below were verified against sqlite3.
+// ========================================================================
+
+/// Parse a `SELECT <expr>;` statement and return the first select-list expression.
+fn parse_select_expr(sql: &str) -> vibesql_ast::Expression {
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("should parse: {}: {:?}", sql, e));
+    if let vibesql_ast::Statement::Select(select) = stmt {
+        if let vibesql_ast::SelectItem::Expression { expr, .. } = &select.select_list[0] {
+            return expr.clone();
+        }
+    }
+    panic!("expected SELECT with expression select list: {}", sql);
+}
+
+/// Assert the expression is `IsNull` with the given polarity and return its operand.
+fn unwrap_is_null(
+    expr: vibesql_ast::Expression,
+    expected_negated: bool,
+    context: &str,
+) -> vibesql_ast::Expression {
+    if let vibesql_ast::Expression::IsNull { expr: inner, negated } = expr {
+        assert_eq!(negated, expected_negated, "{}: wrong IsNull polarity", context);
+        *inner
+    } else {
+        panic!("{}: expected IsNull node", context);
+    }
+}
+
+// ------------------------------------------------------------------------
+// Chaining within the comparison tier
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_isnull_chained_notnull() {
+    // sqlite3: SELECT 1 ISNULL NOTNULL; -- 1, i.e. ((1 ISNULL) NOTNULL)
+    let expr = parse_select_expr("SELECT 1 ISNULL NOTNULL;");
+    let inner = unwrap_is_null(expr, true, "outer NOTNULL");
+    unwrap_is_null(inner, false, "inner ISNULL");
+}
+
+#[test]
+fn test_not_null_chained_not_null() {
+    // sqlite3: SELECT 1 NOT NULL NOT NULL; -- 1
+    let expr = parse_select_expr("SELECT 1 NOT NULL NOT NULL;");
+    let inner = unwrap_is_null(expr, true, "outer NOT NULL");
+    unwrap_is_null(inner, true, "inner NOT NULL");
+}
+
+#[test]
+fn test_isnull_chained_not_null() {
+    // sqlite3: SELECT 1 ISNULL NOT NULL; -- 1
+    let expr = parse_select_expr("SELECT 1 ISNULL NOT NULL;");
+    let inner = unwrap_is_null(expr, true, "outer NOT NULL");
+    unwrap_is_null(inner, false, "inner ISNULL");
+}
+
+#[test]
+fn test_not_null_chained_isnull() {
+    // sqlite3: SELECT 1 NOT NULL ISNULL; -- 0
+    let expr = parse_select_expr("SELECT 1 NOT NULL ISNULL;");
+    let inner = unwrap_is_null(expr, false, "outer ISNULL");
+    unwrap_is_null(inner, true, "inner NOT NULL");
+}
+
+// ------------------------------------------------------------------------
+// Tighter-binding operators after the closed postfix node
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_isnull_followed_by_plus() {
+    // sqlite3: SELECT 1 ISNULL + 1; -- 1, i.e. ((1 ISNULL) + 1)
+    let expr = parse_select_expr("SELECT 1 ISNULL + 1;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Plus);
+        unwrap_is_null(*left, false, "left operand of +");
+    } else {
+        panic!("expected BinaryOp Plus at top level");
+    }
+}
+
+#[test]
+fn test_isnull_followed_by_minus() {
+    // sqlite3: SELECT 1 ISNULL - 1; -- -1
+    let expr = parse_select_expr("SELECT 1 ISNULL - 1;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Minus);
+        unwrap_is_null(*left, false, "left operand of -");
+    } else {
+        panic!("expected BinaryOp Minus at top level");
+    }
+}
+
+#[test]
+fn test_isnull_followed_by_multiply() {
+    // sqlite3: SELECT NULL ISNULL * 3; -- 3
+    let expr = parse_select_expr("SELECT NULL ISNULL * 3;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Multiply);
+        unwrap_is_null(*left, false, "left operand of *");
+    } else {
+        panic!("expected BinaryOp Multiply at top level");
+    }
+}
+
+#[test]
+fn test_isnull_followed_by_divide() {
+    // sqlite3: SELECT 1 ISNULL / 1; -- 0
+    let expr = parse_select_expr("SELECT 1 ISNULL / 1;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Divide);
+        unwrap_is_null(*left, false, "left operand of /");
+    } else {
+        panic!("expected BinaryOp Divide at top level");
+    }
+}
+
+#[test]
+fn test_notnull_followed_by_modulo() {
+    // sqlite3: SELECT 3 NOTNULL % 2; -- 1
+    let expr = parse_select_expr("SELECT 3 NOTNULL % 2;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Modulo);
+        unwrap_is_null(*left, true, "left operand of %");
+    } else {
+        panic!("expected BinaryOp Modulo at top level");
+    }
+}
+
+#[test]
+fn test_notnull_followed_by_concat() {
+    // sqlite3: SELECT 4 NOTNULL || 'x'; -- '1x'
+    let expr = parse_select_expr("SELECT 4 NOTNULL || 'x';");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Concat);
+        unwrap_is_null(*left, true, "left operand of ||");
+    } else {
+        panic!("expected BinaryOp Concat at top level");
+    }
+}
+
+#[test]
+fn test_isnull_followed_by_shift() {
+    // sqlite3: SELECT 1 ISNULL << 2; -- 0
+    let expr = parse_select_expr("SELECT 1 ISNULL << 2;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::LeftShift);
+        unwrap_is_null(*left, false, "left operand of <<");
+    } else {
+        panic!("expected BinaryOp LeftShift at top level");
+    }
+}
+
+#[test]
+fn test_not_null_followed_by_plus() {
+    // sqlite3: SELECT 1 NOT NULL + 1; -- 2, i.e. ((1 NOT NULL) + 1)
+    let expr = parse_select_expr("SELECT 1 NOT NULL + 1;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Plus);
+        unwrap_is_null(*left, true, "left operand of +");
+    } else {
+        panic!("expected BinaryOp Plus at top level");
+    }
+}
+
+#[test]
+fn test_not_null_followed_by_shift() {
+    // sqlite3: SELECT 1 NOT NULL << 3; -- 8
+    let expr = parse_select_expr("SELECT 1 NOT NULL << 3;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::LeftShift);
+        unwrap_is_null(*left, true, "left operand of <<");
+    } else {
+        panic!("expected BinaryOp LeftShift at top level");
+    }
+}
+
+#[test]
+fn test_not_null_followed_by_concat() {
+    // sqlite3: SELECT NULL NOT NULL || 'x'; -- '0x'
+    let expr = parse_select_expr("SELECT NULL NOT NULL || 'x';");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Concat);
+        unwrap_is_null(*left, true, "left operand of ||");
+    } else {
+        panic!("expected BinaryOp Concat at top level");
+    }
+}
+
+#[test]
+fn test_isnull_inside_function_call() {
+    // sqlite3: SELECT lower(1 NOTNULL << 2); -- '4'
+    let result = Parser::parse_sql("SELECT lower(1 NOTNULL << 2);");
+    assert!(
+        result.is_ok(),
+        "NOTNULL followed by << inside function args should parse: {:?}",
+        result
+    );
+}
+
+// ------------------------------------------------------------------------
+// Relative precedence among the continued tighter tiers is preserved
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_notnull_plus_then_multiply() {
+    // sqlite3: SELECT 1 NOTNULL + 2 * 3; -- 7, i.e. (1 NOTNULL) + (2 * 3)
+    let expr = parse_select_expr("SELECT 1 NOTNULL + 2 * 3;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, right } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Plus);
+        unwrap_is_null(*left, true, "left operand of +");
+        assert!(
+            matches!(
+                *right,
+                vibesql_ast::Expression::BinaryOp { op: vibesql_ast::BinaryOperator::Multiply, .. }
+            ),
+            "right operand of + should be (2 * 3): {:?}",
+            right
+        );
+    } else {
+        panic!("expected BinaryOp Plus at top level");
+    }
+}
+
+#[test]
+fn test_notnull_multiply_then_plus() {
+    // sqlite3: SELECT 1 NOTNULL * 2 + 3; -- 5, i.e. ((1 NOTNULL) * 2) + 3
+    let expr = parse_select_expr("SELECT 1 NOTNULL * 2 + 3;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Plus);
+        if let vibesql_ast::Expression::BinaryOp { op: inner_op, left: inner_left, .. } = *left {
+            assert_eq!(inner_op, vibesql_ast::BinaryOperator::Multiply);
+            unwrap_is_null(*inner_left, true, "innermost left");
+        } else {
+            panic!("left operand of + should be ((1 NOTNULL) * 2): {:?}", left);
+        }
+    } else {
+        panic!("expected BinaryOp Plus at top level");
+    }
+}
+
+#[test]
+fn test_notnull_plus_minus_chain() {
+    // sqlite3: SELECT 5 NOTNULL + 10 - 3; -- 8, i.e. ((5 NOTNULL) + 10) - 3
+    let expr = parse_select_expr("SELECT 5 NOTNULL + 10 - 3;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Minus);
+        if let vibesql_ast::Expression::BinaryOp { op: inner_op, left: inner_left, .. } = *left {
+            assert_eq!(inner_op, vibesql_ast::BinaryOperator::Plus);
+            unwrap_is_null(*inner_left, true, "innermost left");
+        } else {
+            panic!("left operand of - should be ((5 NOTNULL) + 10): {:?}", left);
+        }
+    } else {
+        panic!("expected BinaryOp Minus at top level");
+    }
+}
+
+#[test]
+fn test_isnull_isnull_then_plus() {
+    // sqlite3: SELECT 1 ISNULL ISNULL + 1; -- 1, i.e. ((1 ISNULL) ISNULL) + 1
+    let expr = parse_select_expr("SELECT 1 ISNULL ISNULL + 1;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Plus);
+        let inner = unwrap_is_null(*left, false, "left operand of +");
+        unwrap_is_null(inner, false, "inner ISNULL");
+    } else {
+        panic!("expected BinaryOp Plus at top level");
+    }
+}
+
+// ------------------------------------------------------------------------
+// Comparison-tier operators after the postfix node (loop chaining)
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_isnull_followed_by_less_than() {
+    // sqlite3: SELECT 1 ISNULL < 2; -- 1
+    let expr = parse_select_expr("SELECT 1 ISNULL < 2;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::LessThan);
+        unwrap_is_null(*left, false, "left operand of <");
+    } else {
+        panic!("expected BinaryOp LessThan at top level");
+    }
+}
+
+#[test]
+fn test_isnull_followed_by_equal() {
+    // sqlite3: SELECT NULL ISNULL = 1; -- 1
+    let expr = parse_select_expr("SELECT NULL ISNULL = 1;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Equal);
+        unwrap_is_null(*left, false, "left operand of =");
+    } else {
+        panic!("expected BinaryOp Equal at top level");
+    }
+}
+
+#[test]
+fn test_equal_followed_by_isnull() {
+    // sqlite3: SELECT 5 = 5 ISNULL; -- 0, i.e. ((5 = 5) ISNULL)
+    let expr = parse_select_expr("SELECT 5 = 5 ISNULL;");
+    let inner = unwrap_is_null(expr, false, "outer ISNULL");
+    assert!(
+        matches!(
+            inner,
+            vibesql_ast::Expression::BinaryOp { op: vibesql_ast::BinaryOperator::Equal, .. }
+        ),
+        "ISNULL operand should be (5 = 5): {:?}",
+        inner
+    );
+}
+
+#[test]
+fn test_isnull_followed_by_between() {
+    // sqlite3: SELECT 1 ISNULL BETWEEN -1 AND 1; -- 1
+    let expr = parse_select_expr("SELECT 1 ISNULL BETWEEN -1 AND 1;");
+    if let vibesql_ast::Expression::Between { expr: inner, negated, .. } = expr {
+        assert!(!negated);
+        unwrap_is_null(*inner, false, "BETWEEN subject");
+    } else {
+        panic!("expected Between at top level");
+    }
+}
+
+#[test]
+fn test_in_followed_by_isnull() {
+    // sqlite3: SELECT 2 IN (0,1) ISNULL; -- 0
+    let expr = parse_select_expr("SELECT 2 IN (0,1) ISNULL;");
+    let inner = unwrap_is_null(expr, false, "outer ISNULL");
+    assert!(
+        matches!(inner, vibesql_ast::Expression::InList { .. }),
+        "ISNULL operand should be the IN list node: {:?}",
+        inner
+    );
+}
+
+#[test]
+fn test_isnull_followed_by_in() {
+    // sqlite3: SELECT 1 ISNULL IN (0,1); -- 1
+    let expr = parse_select_expr("SELECT 1 ISNULL IN (0,1);");
+    if let vibesql_ast::Expression::InList { expr: inner, negated, .. } = expr {
+        assert!(!negated);
+        unwrap_is_null(*inner, false, "IN subject");
+    } else {
+        panic!("expected InList at top level");
+    }
+}
+
+#[test]
+fn test_isnull_followed_by_like() {
+    // sqlite3: SELECT NULL ISNULL LIKE '1'; -- 1
+    let expr = parse_select_expr("SELECT NULL ISNULL LIKE '1';");
+    if let vibesql_ast::Expression::Like { expr: inner, negated, .. } = expr {
+        assert!(!negated);
+        unwrap_is_null(*inner, false, "LIKE subject");
+    } else {
+        panic!("expected Like at top level");
+    }
+}
+
+// ------------------------------------------------------------------------
+// Boolean tier and surrounding constructs still behave
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_isnull_followed_by_and() {
+    // sqlite3: SELECT 1 ISNULL AND 1; -- 0, i.e. ((1 ISNULL) AND 1)
+    let expr = parse_select_expr("SELECT 1 ISNULL AND 1;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::And);
+        unwrap_is_null(*left, false, "left operand of AND");
+    } else {
+        panic!("expected BinaryOp And at top level");
+    }
+}
+
+#[test]
+fn test_parenthesized_isnull_plus_still_works() {
+    // sqlite3: SELECT (1 ISNULL) + 1; -- 1 (worked before the fix)
+    let expr = parse_select_expr("SELECT (1 ISNULL) + 1;");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(op, vibesql_ast::BinaryOperator::Plus);
+        unwrap_is_null(*left, false, "left operand of +");
+    } else {
+        panic!("expected BinaryOp Plus at top level");
+    }
+}
+
+#[test]
+fn test_lhs_precedence_preserved() {
+    // sqlite3: SELECT 2 + 1 ISNULL; -- 0, i.e. ((2 + 1) ISNULL)
+    // + binds tighter than ISNULL on the LEFT side.
+    let expr = parse_select_expr("SELECT 2 + 1 ISNULL;");
+    let inner = unwrap_is_null(expr, false, "outer ISNULL");
+    assert!(
+        matches!(
+            inner,
+            vibesql_ast::Expression::BinaryOp { op: vibesql_ast::BinaryOperator::Plus, .. }
+        ),
+        "ISNULL operand should be (2 + 1): {:?}",
+        inner
+    );
+}
+
+#[test]
+fn test_continuation_stops_at_select_list_comma() {
+    // sqlite3: SELECT 1 NOTNULL * 2, 2 ISNULL + 5; -- 2|5
+    let stmt = Parser::parse_sql("SELECT 1 NOTNULL * 2, 2 ISNULL + 5;").expect("should parse");
+    if let vibesql_ast::Statement::Select(select) = stmt {
+        assert_eq!(select.select_list.len(), 2, "continuation must not consume the comma");
+    } else {
+        panic!("expected SELECT statement");
+    }
+}
+
+#[test]
+fn test_default_not_null_column_constraint_unaffected() {
+    // The column-definition heuristic (DEFAULT 'v' NOT NULL is a constraint,
+    // not the postfix operator) must be unaffected by the continuation.
+    let result = Parser::parse_sql("CREATE TABLE t (a TEXT DEFAULT 'v' NOT NULL, b INT);");
+    assert!(result.is_ok(), "DEFAULT <literal> NOT NULL constraint should parse: {:?}", result);
+}

--- a/crates/vibesql-parser/src/tests/mod.rs
+++ b/crates/vibesql-parser/src/tests/mod.rs
@@ -24,6 +24,7 @@ mod in_list;
 mod index;
 mod insert;
 mod introspection;
+mod isnull_postfix;
 mod joins;
 mod lexer;
 mod like;


### PR DESCRIPTION
Closes #5857

## Problem

ISNULL, NOTNULL, and postfix NOT NULL were terminal within the comparison tier in both parsers: any tighter-binding operator (`+`, `-`, `*`, `/`, `%`, `||`, `<<`, `>>`) that followed produced `near "X": syntax error`. This was the remaining 82-failure fuzz.test syntax-error class found by the #5804 curator — the same terminal-expression bug class as #5801's IN/NOT IN, which PR #5811 fixed for IN only.

## Fix

Per SQLite, these postfix null tests are syntactically closed (no right operand), so a tighter-binding operator that follows takes the whole null-test node as its left operand: `1 ISNULL + 1` parses as `(1 ISNULL) + 1` = 1, `1 NOT NULL << 3` = 8.

Reuses the #5811/#5869 seeded-tier structure — call `continue_higher_precedence_ops` after building the IsNull node, exactly as after IN/NOT IN:

- **Standard parser** (`parser/expressions/operators.rs`): ISNULL, NOTNULL, and the general-case postfix NOT NULL now seed the shift tier (which recursively covers additive/concat/multiplicative).
- **Arena parser** (`arena_parser/expression.rs`): mirrors the fix for its tiers (multiplicative/concat/additive). Shift-tier continuations are outside the arena grammar and must **fail** arena parsing (never silently truncate), routing through `parse_with_arena_fallback` — covered by dedicated tests.
- The `IS NULL` / `IS [NOT] TRUE` shape is intentionally untouched: SQLite treats NULL/TRUE there as an ordinary IS operand (`1 IS NULL + 1` parses as `1 IS (NULL + 1)`), documented in the helper docs and verified pre-existing (fails identically at the parent commit).

## Tests

- `tests/isnull_postfix.rs` (new, 30 tests): tier chaining (`1 ISNULL NOTNULL`, `1 NOT NULL ISNULL`), every tighter-binding operator after each postfix form, relative precedence preservation (`1 NOTNULL + 2 * 3` = 7, `1 NOTNULL * 2 + 3` = 5), comparison/BETWEEN/IN/LIKE/AND after the node, LHS precedence (`2 + 1 ISNULL` = `(2+1) ISNULL`), select-list comma boundary, and the `DEFAULT 'v' NOT NULL` column-constraint heuristic.
- `tests/arena_parser.rs` (7 new tests, pure append): arena AST equivalence plus explicit arena-must-fail + fallback-must-succeed coverage for `<<` after ISNULL / NOT NULL.
- All expected values in test comments were independently re-verified against sqlite3 (31/31 match).
- Zero modifications to existing tests (pure additions; doc-comment updates only in source).

## Verification

- `cargo test -p vibesql-parser`: 1603 passed, 0 failed (+8 doc-tests).
- CLI vs sqlite3 spot checks: 13 composed forms match exactly (`1 ISNULL NOTNULL`→1, `1 ISNULL + 1`→1, `NULL ISNULL * 3`→3, `4 NOTNULL || 'x'`→1x, `1 ISNULL << 2`→0, `1 NOT NULL + 1`→2, `1 NOT NULL << 3`→8, `1 NOTNULL + 2 * 3`→7, `1 ISNULL ISNULL + 1`→1, `2 + 1 ISNULL`→0, `5 = 5 ISNULL`→0, `lower(1 NOTNULL << 2)`→4, `SELECT 1 NOTNULL * 2, 2 ISNULL + 5`→2|5).
- Baseline binary (parent commit 9c76c1820) rejects `1 ISNULL + 1` and `1 NOT NULL << 3` with syntax errors — confirming the fix, and that `1 IS NULL + 1` failing is pre-existing/out of scope.
- TCL `expr.test`: 638 passed, 0 failed. TCL `in4.test`: 61 passed, 0 failed.
- TCL `fuzz.test` before/after on the same machine: **93 failed (82 `near "X": syntax error`) → 11 failed (0 syntax errors)** — the syntax-error class is fully eliminated and the 11 remaining failures are pre-existing executor-level classes (GLOB in the simple evaluator, ORDER BY term range), untouched by this change.
- `cargo fmt --check` clean; the one clippy warning in the crate is pre-existing in `from_clause.rs` (untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
