### PR TITLE
fix(storage): carry PK/sql_source in WAL CreateTable ops and rehydrate constraints on log replay

### DIFF
--- a/crates/vibesql-cli/tests/wal_recovery_test.rs
+++ b/crates/vibesql-cli/tests/wal_recovery_test.rs
@@ -492,6 +492,171 @@ fn test_rowid_alias_survives_separate_process_reopen() {
     );
 }
 
+/// Like `run_script`, but returns the full process `Output` (status + stderr)
+/// for sessions that are expected to fail.
+#[cfg(unix)]
+fn run_script_output(binary: &str, db: &Path, home: &Path, script: &str) -> std::process::Output {
+    use std::io::Write;
+
+    let mut child = Command::new(binary)
+        .arg(db)
+        .env("HOME", home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn vibesql");
+    {
+        let mut stdin = child.stdin.take().expect("child stdin");
+        stdin.write_all(script.as_bytes()).unwrap();
+        stdin.flush().unwrap();
+    }
+    child.wait_with_output().expect("vibesql did not exit")
+}
+
+/// End-to-end regression for issue #5883: PK, FK (with ON DELETE CASCADE),
+/// CHECK, and rowid-alias semantics must survive crash recovery when the
+/// CREATE TABLE lives only in the WAL — i.e. it was logged AFTER the last
+/// checkpoint. Checkpoint-based recovery was fixed by #5878; this covers the
+/// log-replay path (`WalOp::CreateTable`).
+///
+/// The crash is injected deterministically: after a healthy session seeds
+/// the checkpoint archive, the checkpoint directory is made read-only so
+/// every subsequent checkpoint attempt fails while the WAL keeps absorbing
+/// the ops (the CLI flushes the WAL before attempting the checkpoint and
+/// never truncates it on failure — issue #5832). The resulting on-disk state
+/// is byte-for-byte what a SIGKILL between WAL append and checkpoint leaves
+/// behind, without the scheduling races of an actual kill.
+#[cfg(unix)]
+#[test]
+fn test_constraints_survive_crash_replay_of_create_table() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("constraints_crash.vbsql");
+    let bin = vibesql_binary();
+    let (wal_path, checkpoint_dir) = wal_paths(&db_path);
+
+    // --- Session 1 (healthy): seed the checkpoint archive so we can chmod it.
+    run_script(bin, &db_path, home.path(), "CREATE TABLE seed(a INTEGER);\n");
+    assert!(checkpoint_dir.is_dir(), "checkpoint dir should exist after session 1");
+
+    // Inject the "crash": checkpoint dir read-only.
+    let orig_perms = fs::metadata(&checkpoint_dir).unwrap().permissions();
+    fs::set_permissions(&checkpoint_dir, fs::Permissions::from_mode(0o555)).unwrap();
+
+    // Skip when running as root (root bypasses permission checks).
+    if fs::File::create(checkpoint_dir.join(".probe")).is_ok() {
+        let _ = fs::remove_file(checkpoint_dir.join(".probe"));
+        fs::set_permissions(&checkpoint_dir, orig_perms).unwrap();
+        eprintln!("skipping: running as root, cannot inject a permission failure");
+        return;
+    }
+
+    // --- Session 2: DDL with PK + FK + CHECK, plus committed rows. Every
+    // checkpoint attempt fails, so all of this lands ONLY in the WAL. The
+    // process exits non-zero (fail-closed persistence policy) — that is the
+    // simulated crash.
+    let output = run_script_output(
+        bin,
+        &db_path,
+        home.path(),
+        "CREATE TABLE crash_parent(px INTEGER PRIMARY KEY);\n\
+         CREATE TABLE crash_child(id INTEGER PRIMARY KEY, \
+         py INTEGER REFERENCES crash_parent(px) ON DELETE CASCADE, \
+         amount INTEGER CHECK(amount > 0));\n\
+         INSERT INTO crash_parent VALUES(1);\n\
+         INSERT INTO crash_child VALUES(10, 1, 5);\n",
+    );
+    assert!(
+        !output.status.success(),
+        "session 2 must exit non-zero on checkpoint failure (WAL-only state)"
+    );
+    assert!(wal_path.exists(), "the WAL must hold the un-checkpointed CreateTable ops");
+
+    // Clear the injected failure: from here on, reopening replays the
+    // CreateTable + Insert ops from the WAL (RecoveryManager log replay).
+    fs::set_permissions(&checkpoint_dir, orig_perms).unwrap();
+
+    // --- Reopen A: FK metadata and rowid-alias reads on the crash-replayed
+    // state. Before the fix, foreign_key_list was empty and the schema had
+    // no PK.
+    let out = run_script(
+        bin,
+        &db_path,
+        home.path(),
+        "PRAGMA foreign_key_list(crash_child);\n\
+         SELECT amount FROM crash_child WHERE rowid = 10;\n",
+    );
+    assert!(
+        out.contains("crash_parent") && out.contains("CASCADE"),
+        "PRAGMA foreign_key_list must show the FK (with CASCADE) after crash replay; got:\n{out}"
+    );
+    assert!(
+        out.contains('5'),
+        "rowid must alias the INTEGER PRIMARY KEY after crash replay; got:\n{out}"
+    );
+
+    // --- Reopen B: an FK-violating insert must FAIL and change nothing.
+    let output = run_script_output(
+        bin,
+        &db_path,
+        home.path(),
+        "PRAGMA foreign_keys=ON;\nINSERT INTO crash_child VALUES(11, 99, 5);\n",
+    );
+    assert!(
+        !output.status.success(),
+        "FK-violating insert must fail after crash replay; stdout: {} stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // --- Reopen C: a CHECK-violating insert must FAIL.
+    let output = run_script_output(
+        bin,
+        &db_path,
+        home.path(),
+        "INSERT INTO crash_child VALUES(12, 1, -5);\n",
+    );
+    assert!(
+        !output.status.success(),
+        "CHECK-violating insert must fail after crash replay; stdout: {} stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // --- Reopen D: a duplicate-PK insert must FAIL.
+    let output = run_script_output(
+        bin,
+        &db_path,
+        home.path(),
+        "INSERT INTO crash_child VALUES(10, 1, 7);\n",
+    );
+    assert!(
+        !output.status.success(),
+        "duplicate-PK insert must fail after crash replay; stdout: {} stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // None of the violating inserts may have landed.
+    let out = run_script(bin, &db_path, home.path(), "SELECT count(*) AS n FROM crash_child;\n");
+    assert!(out.contains('1'), "exactly the one committed row must remain; got:\n{out}");
+
+    // --- Reopen E+F: ON DELETE CASCADE must actually fire.
+    run_script(
+        bin,
+        &db_path,
+        home.path(),
+        "PRAGMA foreign_keys=ON;\nDELETE FROM crash_parent WHERE px = 1;\n",
+    );
+    let out = run_script(bin, &db_path, home.path(), "SELECT count(*) AS n FROM crash_child;\n");
+    assert!(
+        out.contains('0'),
+        "ON DELETE CASCADE must remove the child row after crash replay; got:\n{out}"
+    );
+}
+
 /// End-to-end regression for issues #5835 / #5871: a plain REPLACE INTO must
 /// be durable across a cross-process reopen. Before the fix the REPLACE's
 /// conflict-delete emitted no WAL op (and REPLACE never triggered the

--- a/crates/vibesql-storage/src/database/mod.rs
+++ b/crates/vibesql-storage/src/database/mod.rs
@@ -26,6 +26,11 @@ pub mod transactions;
 mod tests;
 
 pub use core::{Database, ExportedSpatialIndexMetadata as SpatialIndexMetadata};
+// The WAL recovery path (`wal::recovery`) shares the CreateTable schema-blob
+// layout with the emit path here; its tests round-trip through the real
+// serializer (issue #5883). Test-only: production replay only deserializes.
+#[cfg(test)]
+pub(crate) use table_api::serialize_table_schema;
 
 pub use config::{DatabaseConfig, SpillPolicy, DEFAULT_COLUMNAR_CACHE_BUDGET};
 pub use index_ops::{

--- a/crates/vibesql-storage/src/database/table_api.rs
+++ b/crates/vibesql-storage/src/database/table_api.rs
@@ -733,9 +733,31 @@ impl Database {
 
 /// Serialize a TableSchema to bytes for WAL storage
 ///
-/// Uses a simple format: JSON serialization of the schema.
-/// This is for WAL recovery purposes and doesn't need to be maximally efficient.
-pub(super) fn serialize_table_schema(schema: &vibesql_catalog::TableSchema) -> Vec<u8> {
+/// Base layout: `table_name\0`, column count (u32 LE), then per column
+/// `name\0`, `Debug(data_type)\0`, nullable byte.
+///
+/// A constraint/durability **trailer** (issue #5883) follows the column list,
+/// carrying the same per-table durability fields the checkpoint catalog
+/// persists — primary key, WITHOUT ROWID flag, and the verbatim CREATE TABLE
+/// `sql_source`. Crash recovery (`wal::recovery::deserialize_table_schema`)
+/// restores these and then rebuilds CHECK/FK constraints and the INTEGER
+/// PRIMARY KEY rowid alias by re-parsing `sql_source`, exactly like the
+/// checkpoint load path (issue #5834 / PR #5878). Without the trailer, a
+/// table whose CREATE TABLE was logged after the last checkpoint came back
+/// from a crash with no PK, no constraints, and no rowid alias.
+///
+/// Trailer layout (versioned, append-only):
+///   `[trailer_version: u8 = 1]`
+///   `[has_pk: u8]` — if 1: `[pk_count: u32 LE]` then `pk_count ×  name\0`
+///   `[without_rowid: u8]`
+///   `[has_sql_source: u8]` — if 1: `[len: u32 LE][utf8 bytes]`
+///
+/// Compatibility: the blob is length-prefixed inside the WAL entry, and the
+/// legacy deserializer stops after the column list (ignoring trailing bytes),
+/// so old binaries read new blobs fine; new binaries treat a blob ending at
+/// the column list as trailer-absent (legacy) and fall back to the old
+/// behavior. No WAL format version bump is required.
+pub(crate) fn serialize_table_schema(schema: &vibesql_catalog::TableSchema) -> Vec<u8> {
     // Simple approach: serialize the table name and column info as text
     // Format: table_name\0col1_name\0col1_type\0nullable\0...
     let mut data = Vec::new();
@@ -760,6 +782,32 @@ pub(super) fn serialize_table_schema(schema: &vibesql_catalog::TableSchema) -> V
 
         // Nullable flag
         data.push(if col.nullable { 1 } else { 0 });
+    }
+
+    // ---- Constraint/durability trailer, version 1 (issue #5883) ----
+    data.push(1); // trailer version
+
+    match &schema.primary_key {
+        Some(pk_cols) => {
+            data.push(1);
+            data.extend_from_slice(&(pk_cols.len() as u32).to_le_bytes());
+            for col_name in pk_cols {
+                data.extend_from_slice(col_name.as_bytes());
+                data.push(0);
+            }
+        }
+        None => data.push(0),
+    }
+
+    data.push(if schema.without_rowid { 1 } else { 0 });
+
+    match &schema.sql_source {
+        Some(src) => {
+            data.push(1);
+            data.extend_from_slice(&(src.len() as u32).to_le_bytes());
+            data.extend_from_slice(src.as_bytes());
+        }
+        None => data.push(0),
     }
 
     data

--- a/crates/vibesql-storage/src/persistence/binary/constraints.rs
+++ b/crates/vibesql-storage/src/persistence/binary/constraints.rs
@@ -49,7 +49,10 @@ use crate::StorageError;
 /// Column-name lookup for every table present in the catalog being loaded,
 /// keyed by lowercased table name. Used to resolve FK parent column indices
 /// regardless of the (arbitrary) order tables appear in the file.
-pub(super) type ParentColumnLookup = HashMap<String, Vec<String>>;
+///
+/// `pub(crate)`: the WAL crash-recovery path (`wal::recovery`) routes replayed
+/// `CreateTable` ops through the same rehydration (issue #5883).
+pub(crate) type ParentColumnLookup = HashMap<String, Vec<String>>;
 
 /// Convert an AST referential action (optional; absent = NO ACTION) into the
 /// catalog representation. Mirrors `convert_action` in the executor's CREATE
@@ -114,7 +117,7 @@ fn resolve_parent_columns(
 /// source was invalidated by ALTER TABLE — those fall back to the previous
 /// behavior). Errors when the source no longer parses or disagrees with the
 /// stored column set, so constraint loss is never silent.
-pub(super) fn rehydrate_constraints_from_sql_source(
+pub(crate) fn rehydrate_constraints_from_sql_source(
     schema: &mut vibesql_catalog::TableSchema,
     parents: &ParentColumnLookup,
 ) -> Result<(), StorageError> {

--- a/crates/vibesql-storage/src/wal/recovery.rs
+++ b/crates/vibesql-storage/src/wal/recovery.rs
@@ -38,7 +38,10 @@ use std::{
 };
 
 use crate::{
-    persistence::binary::{read_catalog_v, read_data, read_header},
+    persistence::binary::{
+        constraints::{rehydrate_constraints_from_sql_source, ParentColumnLookup},
+        read_catalog_v, read_data, read_header,
+    },
     wal::{
         checkpoint::{read_checkpoint_data, CheckpointInfo, CheckpointWriter},
         entry::{Lsn, WalOp},
@@ -765,8 +768,22 @@ impl RecoveryManager {
             WalOp::CreateTable { table_id: _, table_name, schema_data } => {
                 // Deserialize schema and create table
                 match deserialize_table_schema(&schema_data) {
-                    Ok(schema) => {
+                    Ok(mut schema) => {
                         if db.get_table(&table_name).is_none() {
+                            // Rebuild CHECK/FK constraints and the INTEGER
+                            // PRIMARY KEY rowid alias from the sql_source
+                            // carried in the schema-blob trailer (issue
+                            // #5883), routing through the SAME rehydration
+                            // the checkpoint load path uses (issue #5834 /
+                            // PR #5878). Without this, a table whose CREATE
+                            // TABLE was logged after the last checkpoint
+                            // came back from a crash with none of its
+                            // constraints enforced. Rehydration failure is a
+                            // hard recovery error — constraint loss must
+                            // never be silent (recovery-failure policy).
+                            let parents = parent_column_lookup(db, &schema, &table_name);
+                            rehydrate_constraints_from_sql_source(&mut schema, &parents)?;
+
                             if let Err(e) = db.create_table(schema) {
                                 log::warn!(
                                     "Failed to create table {} during recovery: {}",
@@ -875,7 +892,138 @@ fn deserialize_table_schema(data: &[u8]) -> Result<vibesql_catalog::TableSchema,
         columns.push(ColumnSchema::new(column_name, data_type, nullable));
     }
 
-    Ok(TableSchema::new(table_name, columns))
+    // ---- Constraint/durability trailer (issue #5883) ----
+    //
+    // Blobs written before the trailer existed end exactly after the column
+    // list; their tables come back without PK/sql_source (the pre-#5883
+    // behavior). Newer blobs carry a versioned trailer with the primary key,
+    // the WITHOUT ROWID flag, and the verbatim CREATE TABLE sql_source —
+    // mirroring the per-table durability fields of the checkpoint catalog so
+    // the replay path can rehydrate constraints identically.
+    let mut primary_key: Option<Vec<String>> = None;
+    let mut without_rowid = false;
+    let mut sql_source: Option<String> = None;
+
+    if pos < data.len() {
+        let trailer_version = data[pos];
+        pos += 1;
+        if trailer_version < 1 {
+            return Err(StorageError::IoError(format!(
+                "Invalid schema data: unsupported trailer version {}",
+                trailer_version
+            )));
+        }
+
+        // Version 1 fields. Future trailer versions append fields after
+        // these, so a v1 reader parses what it knows and ignores the rest.
+        if read_trailer_u8(data, &mut pos, "primary-key flag")? != 0 {
+            let pk_count = read_trailer_u32(data, &mut pos, "primary-key column count")? as usize;
+            let mut pk_cols = Vec::with_capacity(pk_count);
+            for _ in 0..pk_count {
+                pk_cols.push(read_trailer_cstr(data, &mut pos, "primary-key column name")?);
+            }
+            primary_key = Some(pk_cols);
+        }
+
+        without_rowid = read_trailer_u8(data, &mut pos, "WITHOUT ROWID flag")? != 0;
+
+        if read_trailer_u8(data, &mut pos, "sql_source flag")? != 0 {
+            let len = read_trailer_u32(data, &mut pos, "sql_source length")? as usize;
+            if pos + len > data.len() {
+                return Err(StorageError::IoError(
+                    "Invalid schema data: truncated sql_source".to_string(),
+                ));
+            }
+            let src = String::from_utf8(data[pos..pos + len].to_vec()).map_err(|e| {
+                StorageError::IoError(format!("Invalid UTF-8 in sql_source: {}", e))
+            })?;
+            sql_source = Some(src);
+        }
+    }
+
+    let mut schema = match primary_key {
+        Some(pk_cols) => TableSchema::with_primary_key(table_name, columns, pk_cols),
+        None => TableSchema::new(table_name, columns),
+    };
+    schema.without_rowid = without_rowid;
+    if let Some(src) = sql_source {
+        schema.set_sql_source(src);
+    }
+
+    Ok(schema)
+}
+
+/// Read a single byte from the schema-blob trailer.
+fn read_trailer_u8(data: &[u8], pos: &mut usize, what: &str) -> Result<u8, StorageError> {
+    if *pos >= data.len() {
+        return Err(StorageError::IoError(format!("Invalid schema data: missing {}", what)));
+    }
+    let b = data[*pos];
+    *pos += 1;
+    Ok(b)
+}
+
+/// Read a little-endian u32 from the schema-blob trailer.
+fn read_trailer_u32(data: &[u8], pos: &mut usize, what: &str) -> Result<u32, StorageError> {
+    if *pos + 4 > data.len() {
+        return Err(StorageError::IoError(format!("Invalid schema data: missing {}", what)));
+    }
+    let v = u32::from_le_bytes([data[*pos], data[*pos + 1], data[*pos + 2], data[*pos + 3]]);
+    *pos += 4;
+    Ok(v)
+}
+
+/// Read a null-terminated UTF-8 string from the schema-blob trailer.
+fn read_trailer_cstr(data: &[u8], pos: &mut usize, what: &str) -> Result<String, StorageError> {
+    let end = data[*pos..]
+        .iter()
+        .position(|&b| b == 0)
+        .ok_or_else(|| StorageError::IoError(format!("Invalid schema data: missing {}", what)))?;
+    let s = String::from_utf8(data[*pos..*pos + end].to_vec())
+        .map_err(|e| StorageError::IoError(format!("Invalid UTF-8 in {}: {}", what, e)))?;
+    *pos += end + 1;
+    Ok(s)
+}
+
+/// Build the FK parent-column lookup for rehydrating a table replayed from a
+/// WAL `CreateTable` op (issue #5883).
+///
+/// Covers every table already recovered (from the checkpoint base and from
+/// earlier WAL entries — a parent's CreateTable precedes its child's in LSN
+/// order) plus the table being created itself (self-referential FKs). Keys
+/// are lowercased, both schema-qualified ("main.p") and bare ("p"), because
+/// FK clauses reference parents by whatever name the user wrote. A missing
+/// parent degrades to placeholder indices, exactly like the checkpoint path
+/// (enforcement resolves parents by name at runtime).
+fn parent_column_lookup(
+    db: &Database,
+    schema: &vibesql_catalog::TableSchema,
+    qualified_name: &str,
+) -> ParentColumnLookup {
+    let mut parents: ParentColumnLookup = HashMap::new();
+
+    let insert_keys =
+        |parents: &mut HashMap<String, Vec<String>>, name: &str, cols: &Vec<String>| {
+            parents.insert(name.to_lowercase(), cols.clone());
+            if let Some((_, bare)) = name.split_once('.') {
+                parents.entry(bare.to_lowercase()).or_insert_with(|| cols.clone());
+            }
+        };
+
+    for name in db.list_tables() {
+        if let Some(table) = db.get_table(&name) {
+            let cols: Vec<String> = table.schema.columns.iter().map(|c| c.name.clone()).collect();
+            insert_keys(&mut parents, &name, &cols);
+        }
+    }
+
+    // The table being created: cover self-referential FKs under both its
+    // schema name and the qualified WAL name.
+    let own_cols: Vec<String> = schema.columns.iter().map(|c| c.name.clone()).collect();
+    insert_keys(&mut parents, &schema.name, &own_cols);
+    insert_keys(&mut parents, qualified_name, &own_cols);
+
+    parents
 }
 
 /// Parse a DataType from its debug string representation
@@ -1336,10 +1484,12 @@ mod tests {
         db.get_table(qualified).map(|t| t.scan_live().count()).unwrap_or(0)
     }
 
-    /// Serialize a schema into the WAL `CreateTable.schema_data` layout that
-    /// `deserialize_table_schema` (in this module) expects. Mirrors the
-    /// production `serialize_table_schema` helper, kept local to avoid reaching
-    /// into the private `database::table_api` module from a test.
+    /// Serialize a schema into the LEGACY (pre-#5883, trailer-less) WAL
+    /// `CreateTable.schema_data` layout: name/columns only. Kept as the
+    /// backward-compatibility fixture — blobs written by older binaries end
+    /// exactly after the column list, and `deserialize_table_schema` must
+    /// still accept them. New-format round-trips go through the production
+    /// `crate::database::serialize_table_schema` instead.
     fn serialize_schema_for_test(schema: &TableSchema) -> Vec<u8> {
         let mut data = Vec::new();
         data.extend_from_slice(schema.name.as_bytes());
@@ -2084,5 +2234,220 @@ mod tests {
             .unwrap();
         assert!(db.get_table("main.checkpointed").is_some());
         assert!(db.get_table("main.legacy_snapshot").is_none());
+    }
+
+    // ------------------------------------------------------------------
+    // Issue #5883: CreateTable log replay must not drop PK / constraints
+    // ------------------------------------------------------------------
+
+    /// The schema-blob trailer round-trips PK, WITHOUT ROWID, and sql_source
+    /// through the PRODUCTION serializer + this module's deserializer.
+    #[test]
+    fn test_schema_blob_trailer_roundtrip() {
+        let mut schema = TableSchema::with_primary_key(
+            "wr".to_string(),
+            vec![
+                ColumnSchema::new("a".to_string(), DataType::Integer, false),
+                ColumnSchema::new("b".to_string(), DataType::Integer, false),
+            ],
+            vec!["a".to_string(), "b".to_string()],
+        );
+        schema.without_rowid = true;
+        schema.set_sql_source(
+            "CREATE TABLE wr(a INTEGER, b INTEGER, PRIMARY KEY(a,b)) WITHOUT ROWID".to_string(),
+        );
+
+        let blob = crate::database::serialize_table_schema(&schema);
+        let out = deserialize_table_schema(&blob).unwrap();
+
+        assert_eq!(out.primary_key, Some(vec!["a".to_string(), "b".to_string()]));
+        assert!(out.without_rowid, "WITHOUT ROWID must survive the blob round-trip");
+        assert_eq!(out.sql_source, schema.sql_source);
+    }
+
+    /// A legacy blob (no trailer) still deserializes, with the pre-#5883
+    /// defaults: no PK, no sql_source, rowid table.
+    #[test]
+    fn test_schema_blob_without_trailer_still_parses() {
+        let schema = simple_schema("legacy");
+        let blob = serialize_schema_for_test(&schema);
+        let out = deserialize_table_schema(&blob).unwrap();
+
+        assert_eq!(out.name, "legacy");
+        assert_eq!(out.columns.len(), 2);
+        assert_eq!(out.primary_key, None);
+        assert!(!out.without_rowid);
+        assert_eq!(out.sql_source, None);
+    }
+
+    /// End-to-end crash replay: a parent + child created AFTER the last
+    /// checkpoint (WAL-only, like the executor does — PK and sql_source set
+    /// on the schema before `create_table`) must come back from recovery
+    /// with PK, CHECK, FK (with actions), and the INTEGER PRIMARY KEY rowid
+    /// alias intact. This was the #5883 gap: checkpoint-based recovery
+    /// rehydrated all of these (#5878), but log replay dropped every one.
+    #[test]
+    fn test_create_table_replay_restores_pk_constraints_and_rowid_alias() {
+        let temp_dir = TempDir::new().unwrap();
+        let checkpoint_dir = temp_dir.path().join("checkpoints");
+        let wal_path = temp_dir.path().join("test.wal");
+
+        // --- Session 1: create parent + child with constraints, flush the
+        // WAL, then "crash" (no checkpoint is ever written).
+        {
+            let mut db = Database::new();
+            let engine = PersistenceEngine::new(&wal_path, PersistenceConfig::default()).unwrap();
+            db.enable_persistence(engine);
+
+            let mut parent = TableSchema::with_primary_key(
+                "p".to_string(),
+                vec![ColumnSchema::new("x".to_string(), DataType::Integer, false)],
+                vec!["x".to_string()],
+            );
+            parent.set_sql_source("CREATE TABLE p(x INTEGER PRIMARY KEY)".to_string());
+            db.create_table(parent).unwrap();
+
+            let mut child = TableSchema::with_primary_key(
+                "c".to_string(),
+                vec![
+                    ColumnSchema::new("id".to_string(), DataType::Integer, false),
+                    ColumnSchema::new("y".to_string(), DataType::Integer, true),
+                    ColumnSchema::new("z".to_string(), DataType::Integer, true),
+                ],
+                vec!["id".to_string()],
+            );
+            child.set_sql_source(
+                "CREATE TABLE c(id INTEGER PRIMARY KEY, \
+                 y INTEGER REFERENCES p(x) ON DELETE CASCADE, \
+                 z INTEGER CHECK(z > 0))"
+                    .to_string(),
+            );
+            db.create_table(child).unwrap();
+
+            db.insert_row("main.p", crate::row::Row::new(vec![SqlValue::Integer(1)])).unwrap();
+            db.insert_row(
+                "main.c",
+                crate::row::Row::new(vec![
+                    SqlValue::Integer(10),
+                    SqlValue::Integer(1),
+                    SqlValue::Integer(5),
+                ]),
+            )
+            .unwrap();
+
+            db.sync_persistence().unwrap();
+        }
+
+        // --- Session 2: recover from the WAL alone.
+        let manager = RecoveryManager::new(&checkpoint_dir).with_wal(&wal_path);
+        let (db, stats) = manager.recover().unwrap();
+        assert_eq!(stats.tables_created, 2);
+
+        let child = &db.get_table("main.c").expect("child table recovered").schema;
+
+        // PK survives (was: None after log replay).
+        assert_eq!(child.primary_key, Some(vec!["id".to_string()]));
+
+        // INTEGER PRIMARY KEY rowid alias survives (interacts with the WAL
+        // v3 rowid trailers from #5835/#5891: replayed rows carry their
+        // rowids, and the alias makes `WHERE rowid=N` resolve through `id`).
+        assert_eq!(child.rowid_alias_column, Some(0), "IPK rowid alias must be rebuilt");
+
+        // CHECK constraint survives.
+        assert_eq!(child.check_constraints.len(), 1, "CHECK must be rehydrated");
+        assert_eq!(child.check_constraints[0].0, "z>0");
+
+        // FK survives with its action and resolved parent columns (the
+        // parent's CreateTable precedes the child's in the WAL).
+        assert_eq!(child.foreign_keys.len(), 1, "FK must be rehydrated");
+        let fk = &child.foreign_keys[0];
+        assert_eq!(fk.parent_table, "p");
+        assert_eq!(fk.column_names, vec!["y".to_string()]);
+        assert_eq!(fk.parent_column_names, vec!["x".to_string()]);
+        assert_eq!(fk.parent_column_indices, vec![0]);
+        assert_eq!(fk.on_delete, vibesql_catalog::ReferentialAction::Cascade);
+
+        // Parent PK also survives.
+        let parent = &db.get_table("main.p").expect("parent table recovered").schema;
+        assert_eq!(parent.primary_key, Some(vec!["x".to_string()]));
+        assert_eq!(parent.rowid_alias_column, Some(0));
+
+        // Row data replays alongside the constraint state.
+        assert_eq!(live_row_count(&db, "main.p"), 1);
+        assert_eq!(live_row_count(&db, "main.c"), 1);
+    }
+
+    /// A WAL-replayed table whose schema blob has no trailer (written by an
+    /// older binary) still recovers — without constraints, as before #5883.
+    #[test]
+    fn test_create_table_replay_accepts_legacy_blob() {
+        use crate::wal::entry::WalEntry;
+        use crate::wal::writer::WalWriter;
+
+        let temp_dir = TempDir::new().unwrap();
+        let checkpoint_dir = temp_dir.path().join("checkpoints");
+        let wal_path = temp_dir.path().join("test.wal");
+
+        let schema = simple_schema("old");
+        let schema_data = serialize_schema_for_test(&schema);
+        {
+            let file = std::fs::File::create(&wal_path).unwrap();
+            let mut writer = WalWriter::create(file).unwrap();
+            writer
+                .append(&WalEntry::new(
+                    1,
+                    0,
+                    WalOp::CreateTable { table_id: 0, table_name: "main.old".into(), schema_data },
+                ))
+                .unwrap();
+            writer.flush().unwrap();
+        }
+
+        let manager = RecoveryManager::new(&checkpoint_dir).with_wal(&wal_path);
+        let (db, stats) = manager.recover().unwrap();
+        assert_eq!(stats.tables_created, 1);
+        let schema = &db.get_table("main.old").expect("legacy table recovered").schema;
+        assert_eq!(schema.primary_key, None);
+        assert!(schema.check_constraints.is_empty());
+        assert!(schema.foreign_keys.is_empty());
+    }
+
+    /// An unparseable sql_source in a replayed CreateTable is a HARD recovery
+    /// error — constraint loss must never be silent (same policy as the
+    /// checkpoint load path, #5833/#5834).
+    #[test]
+    fn test_create_table_replay_bad_sql_source_fails_loudly() {
+        use crate::wal::entry::WalEntry;
+        use crate::wal::writer::WalWriter;
+
+        let temp_dir = TempDir::new().unwrap();
+        let checkpoint_dir = temp_dir.path().join("checkpoints");
+        let wal_path = temp_dir.path().join("test.wal");
+
+        let mut schema = simple_schema("broken");
+        schema.set_sql_source("CREATE GIBBERISH broken(".to_string());
+        let schema_data = crate::database::serialize_table_schema(&schema);
+        {
+            let file = std::fs::File::create(&wal_path).unwrap();
+            let mut writer = WalWriter::create(file).unwrap();
+            writer
+                .append(&WalEntry::new(
+                    1,
+                    0,
+                    WalOp::CreateTable {
+                        table_id: 0,
+                        table_name: "main.broken".into(),
+                        schema_data,
+                    },
+                ))
+                .unwrap();
+            writer.flush().unwrap();
+        }
+
+        let manager = RecoveryManager::new(&checkpoint_dir).with_wal(&wal_path);
+        assert!(
+            manager.recover().is_err(),
+            "an unparseable sql_source must fail recovery loudly, never load unenforced"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`WalOp::CreateTable.schema_data` carried only the table name plus column name/type/nullable triples. On the crash-recovery path (a `CREATE TABLE` logged to the WAL after the last checkpoint), replay rebuilt the table with **no primary key, no CHECK constraints, no foreign keys, no INTEGER PRIMARY KEY rowid alias, and no WITHOUT ROWID flag** — violating inserts succeeded, cascades never fired, and `PRAGMA foreign_key_list` was empty. PR #5878 fixed the checkpoint load path; this PR closes the log-replay half by carrying the same durability fields in the WAL blob and routing replay through the same rehydration helper.

## Changes

- `database/table_api.rs` — `serialize_table_schema` appends a versioned trailer after the column list: primary key columns, WITHOUT ROWID flag, and the verbatim CREATE TABLE `sql_source` (exactly the per-table fields the checkpoint catalog persists). **No WAL format version bump**: the blob is length-prefixed inside the entry and the legacy parser stops after the column list, so old binaries read new blobs and new binaries treat trailer-less blobs as legacy.
- `wal/recovery.rs` — `deserialize_table_schema` parses the trailer (restoring `primary_key`, `without_rowid`, `sql_source`); the `CreateTable` replay arm builds an FK parent-column lookup from already-recovered tables (parents precede children in LSN order) and calls `rehydrate_constraints_from_sql_source` — the identical helper the checkpoint path uses (#5834/#5878) — rebuilding CHECK, FK (with referential actions and deferrability), and the IPK rowid alias. An unparseable `sql_source` is a **hard recovery error** (never a silently-unenforced constraint), matching the #5833 recovery-failure policy.
- `persistence/binary/constraints.rs` — `rehydrate_constraints_from_sql_source` and `ParentColumnLookup` widened from `pub(super)` to `pub(crate)` so the WAL module can reuse them.
- `database/mod.rs` — test-only `pub(crate)` re-export of the serializer so recovery tests round-trip through the production blob layout.
- `crates/vibesql-cli/tests/wal_recovery_test.rs` — end-to-end subprocess regression test.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| PK survives crash replay | ✅ | `test_create_table_replay_restores_pk_constraints_and_rowid_alias` asserts `primary_key == Some(["id"])`; CLI test rejects duplicate-PK insert after reopen |
| CHECK survives crash replay | ✅ | Same tests: `check_constraints == [("z>0", …)]`; CLI test rejects `amount = -5` insert after reopen |
| FK survives crash replay (with actions) | ✅ | FK rebuilt with `ON DELETE CASCADE`, resolved parent columns; CLI test: `PRAGMA foreign_key_list` shows the FK, violating insert fails, `DELETE` cascades |
| Rowid alias / WAL v3 interaction (#5891) | ✅ | `rowid_alias_column == Some(0)` after replay; CLI test `SELECT … WHERE rowid = 10` resolves through the IPK on crash-replayed rows |
| WITHOUT ROWID survives | ✅ | `test_schema_blob_trailer_roundtrip` asserts `without_rowid == true` round-trips through the production serializer |
| Backward compatibility (old WAL blobs) | ✅ | `test_schema_blob_without_trailer_still_parses` + `test_create_table_replay_accepts_legacy_blob` (trailer-less blob replays with pre-#5883 defaults) |
| Constraint loss never silent | ✅ | `test_create_table_replay_bad_sql_source_fails_loudly` — recovery errors instead of loading unenforced |
| Subprocess crash test | ✅ | `test_constraints_survive_crash_replay_of_create_table` — deterministic crash injection (read-only checkpoint dir, same technique as `checkpoint_failure_test.rs`) leaves exactly the SIGKILL-between-WAL-append-and-checkpoint on-disk state; reopen verifies FK metadata, PK/CHECK/FK enforcement, rowid reads, and cascade |

## Test Plan

- `cargo test -p vibesql-storage` — 782 passed, 0 failed
- `cargo test -p vibesql-cli` — all suites green, incl. `wal_recovery_test` (10/10, 1 new)
- `cargo test -p vibesql-executor --test constraint_rehydration_reload_tests --test rowid_reload_tests` — 18 passed (no regression to the #5878 checkpoint path)
- `cargo check` / `cargo clippy` — no new warnings in touched files

Closes #5883