### PR TITLE
fix(alter): propagate RENAME COLUMN into dependent index metadata

### DIFF
--- a/crates/vibesql-ast/src/lib.rs
+++ b/crates/vibesql-ast/src/lib.rs
@@ -36,6 +36,7 @@
 
 pub mod arena;
 pub mod pretty_print;
+pub mod rename;
 pub mod visitor;
 pub mod volatility;
 

--- a/crates/vibesql-ast/src/rename.rs
+++ b/crates/vibesql-ast/src/rename.rs
@@ -1,0 +1,253 @@
+//! Column-rename rewriting for expression trees.
+//!
+//! `ALTER TABLE ... RENAME COLUMN old TO new` must rewrite every dependent
+//! object that references the renamed column (SQLite rewrites indexes, views,
+//! triggers, and foreign keys). Index metadata stores the column list and the
+//! expression / partial-index WHERE predicates as ASTs, so the rename has to
+//! walk those ASTs and rewrite matching [`Expression::ColumnRef`] nodes in
+//! place. Without this, the stale metadata is persisted to the next checkpoint
+//! and the database refuses to reopen ("Column 'old' not found in table ...",
+//! issue #5877).
+//!
+//! The walker deliberately does **not** descend into subqueries
+//! (`ScalarSubquery`, `EXISTS`, `IN (SELECT ...)`, quantified comparisons) or
+//! window specifications: those forms are not allowed in index expressions or
+//! partial-index predicates, which are the only ASTs this rewriter is applied
+//! to. The immediate left-hand operand of `IN`/quantified comparisons is still
+//! rewritten.
+
+use crate::{expression::Expression, identifier::ColumnIdentifier};
+
+/// Rewrite every reference to column `old` in `expr` to `new`, in place.
+///
+/// Matching is case-insensitive on the column part of the identifier (SQLite
+/// folds identifiers regardless of quoting); any schema/table qualifiers are
+/// preserved unchanged. Callers apply this only to expressions that belong to
+/// the table whose column is being renamed (an index expression or
+/// partial-index predicate can only reference its own table's columns), so no
+/// table-qualifier check is needed.
+///
+/// Returns `true` if at least one reference was rewritten.
+pub fn rename_column_in_expression(expr: &mut Expression, old: &str, new: &str) -> bool {
+    let mut changed = false;
+    rename_walk(expr, old, new, &mut changed);
+    changed
+}
+
+/// Build a copy of `col_id` with the column part replaced by `new`, keeping
+/// any schema/table qualifiers (and their quoting) intact.
+fn renamed_column_identifier(col_id: &ColumnIdentifier, new: &str) -> ColumnIdentifier {
+    // Preserve the original quoting flag: quoting does not affect canonical
+    // case-folding (SQLite folds regardless), and display text stores the raw
+    // name either way.
+    let quoted = col_id.is_column_quoted();
+    match (col_id.schema_display(), col_id.table_display()) {
+        (Some(schema), Some(table)) => ColumnIdentifier::fully_qualified(
+            schema,
+            col_id.is_schema_quoted(),
+            table,
+            col_id.is_table_quoted(),
+            new,
+            quoted,
+        ),
+        (None, Some(table)) => {
+            ColumnIdentifier::qualified(table, col_id.is_table_quoted(), new, quoted)
+        }
+        _ => ColumnIdentifier::simple(new, quoted),
+    }
+}
+
+fn rename_walk(expr: &mut Expression, old: &str, new: &str, changed: &mut bool) {
+    match expr {
+        Expression::ColumnRef(col_id) => {
+            if col_id.column_canonical().eq_ignore_ascii_case(old) {
+                *col_id = renamed_column_identifier(col_id, new);
+                *changed = true;
+            }
+        }
+        Expression::BinaryOp { left, right, .. }
+        | Expression::IsDistinctFrom { left, right, .. } => {
+            rename_walk(left, old, new, changed);
+            rename_walk(right, old, new, changed);
+        }
+        Expression::Conjunction(children)
+        | Expression::Disjunction(children)
+        | Expression::RowValueConstructor(children) => {
+            for child in children {
+                rename_walk(child, old, new, changed);
+            }
+        }
+        Expression::UnaryOp { expr: inner, .. }
+        | Expression::IsNull { expr: inner, .. }
+        | Expression::IsTruthValue { expr: inner, .. }
+        | Expression::Cast { expr: inner, .. }
+        | Expression::Extract { expr: inner, .. }
+        | Expression::Collate { expr: inner, .. }
+        | Expression::Interval { value: inner, .. } => {
+            rename_walk(inner, old, new, changed);
+        }
+        Expression::Function { args, .. } => {
+            for arg in args {
+                rename_walk(arg, old, new, changed);
+            }
+        }
+        Expression::AggregateFunction { args, order_by, filter, .. } => {
+            for arg in args {
+                rename_walk(arg, old, new, changed);
+            }
+            if let Some(items) = order_by {
+                for item in items {
+                    rename_walk(&mut item.expr, old, new, changed);
+                }
+            }
+            if let Some(f) = filter {
+                rename_walk(f, old, new, changed);
+            }
+        }
+        Expression::Case { operand, when_clauses, else_result } => {
+            if let Some(op) = operand {
+                rename_walk(op, old, new, changed);
+            }
+            for clause in when_clauses {
+                for cond in &mut clause.conditions {
+                    rename_walk(cond, old, new, changed);
+                }
+                rename_walk(&mut clause.result, old, new, changed);
+            }
+            if let Some(e) = else_result {
+                rename_walk(e, old, new, changed);
+            }
+        }
+        Expression::InList { expr: inner, values, .. } => {
+            rename_walk(inner, old, new, changed);
+            for value in values {
+                rename_walk(value, old, new, changed);
+            }
+        }
+        Expression::Between { expr: inner, low, high, .. } => {
+            rename_walk(inner, old, new, changed);
+            rename_walk(low, old, new, changed);
+            rename_walk(high, old, new, changed);
+        }
+        Expression::Position { substring, string, .. } => {
+            rename_walk(substring, old, new, changed);
+            rename_walk(string, old, new, changed);
+        }
+        Expression::Trim { removal_char, string, .. } => {
+            if let Some(rc) = removal_char {
+                rename_walk(rc, old, new, changed);
+            }
+            rename_walk(string, old, new, changed);
+        }
+        Expression::Like { expr: inner, pattern, escape, .. }
+        | Expression::Glob { expr: inner, pattern, escape, .. } => {
+            rename_walk(inner, old, new, changed);
+            rename_walk(pattern, old, new, changed);
+            if let Some(esc) = escape {
+                rename_walk(esc, old, new, changed);
+            }
+        }
+        // Subquery-bearing forms: only the immediate scalar operand is
+        // rewritten; the subquery body is out of scope (not legal in index
+        // expressions / partial-index predicates).
+        Expression::In { expr: inner, .. }
+        | Expression::QuantifiedComparison { expr: inner, .. } => {
+            rename_walk(inner, old, new, changed);
+        }
+        Expression::MatchAgainst { search_modifier, .. } => {
+            rename_walk(search_modifier, old, new, changed);
+        }
+        Expression::Raise { error_message, .. } => {
+            if let Some(msg) = error_message {
+                rename_walk(msg, old, new, changed);
+            }
+        }
+        // Leaf / out-of-scope forms: literals, placeholders, wildcard,
+        // current date/time, DEFAULT, sequence refs, pseudo/session variables,
+        // subqueries, EXISTS, and window functions carry no rewritable
+        // column reference for index metadata.
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{pretty_print::ToSql, BinaryOperator};
+    use vibesql_types::SqlValue;
+
+    fn col(name: &str) -> Expression {
+        Expression::ColumnRef(ColumnIdentifier::simple(name, false))
+    }
+
+    #[test]
+    fn renames_simple_column_ref() {
+        let mut expr = col("b");
+        assert!(rename_column_in_expression(&mut expr, "b", "d"));
+        assert_eq!(expr.to_sql(), "d");
+    }
+
+    #[test]
+    fn rename_is_case_insensitive() {
+        let mut expr = col("B");
+        assert!(rename_column_in_expression(&mut expr, "b", "d"));
+        assert_eq!(expr.to_sql(), "d");
+    }
+
+    #[test]
+    fn leaves_other_columns_untouched() {
+        let mut expr = col("c");
+        assert!(!rename_column_in_expression(&mut expr, "b", "d"));
+        assert_eq!(expr.to_sql(), "c");
+    }
+
+    #[test]
+    fn renames_inside_binary_chain() {
+        // b + b + b + b (the altercol.test 1.12 expression-index shape)
+        let mut expr = Expression::BinaryOp {
+            op: BinaryOperator::Plus,
+            left: Box::new(Expression::BinaryOp {
+                op: BinaryOperator::Plus,
+                left: Box::new(col("b")),
+                right: Box::new(col("b")),
+            }),
+            right: Box::new(col("b")),
+        };
+        assert!(rename_column_in_expression(&mut expr, "b", "d"));
+        assert!(!expr.to_sql().contains('b'), "sql: {}", expr.to_sql());
+        assert!(expr.to_sql().contains('d'));
+    }
+
+    #[test]
+    fn renames_inside_function_args_and_where_shape() {
+        // coalesce(b, c) AND b > 0
+        let mut expr = Expression::Conjunction(vec![
+            Expression::Function {
+                name: crate::identifier::FunctionIdentifier::new("coalesce"),
+                args: vec![col("b"), col("c")],
+                character_unit: None,
+            },
+            Expression::BinaryOp {
+                op: BinaryOperator::GreaterThan,
+                left: Box::new(col("b")),
+                right: Box::new(Expression::Literal(SqlValue::Integer(0))),
+            },
+        ]);
+        assert!(rename_column_in_expression(&mut expr, "b", "d"));
+        let sql = expr.to_sql();
+        assert!(sql.contains("d, c") && sql.contains("d>0"), "sql: {}", sql);
+    }
+
+    #[test]
+    fn preserves_table_qualifier() {
+        let mut expr = Expression::ColumnRef(ColumnIdentifier::qualified("t1", false, "b", false));
+        assert!(rename_column_in_expression(&mut expr, "b", "d"));
+        match &expr {
+            Expression::ColumnRef(c) => {
+                assert_eq!(c.table_canonical(), Some("t1"));
+                assert_eq!(c.column_canonical(), "d");
+            }
+            _ => unreachable!(),
+        }
+    }
+}

--- a/crates/vibesql-catalog/src/store/indexes.rs
+++ b/crates/vibesql-catalog/src/store/indexes.rs
@@ -201,6 +201,56 @@ impl Catalog {
         }
     }
 
+    /// Propagate `ALTER TABLE <table> RENAME COLUMN old TO new` into the
+    /// metadata of every index on `table_name` (matched case-insensitively,
+    /// across schemas — index metadata rides with its table).
+    ///
+    /// Rewrites plain column-name entries, column references inside
+    /// expression-index ASTs, and partial-index WHERE predicates. Without
+    /// this, `sqlite_master` keeps rendering the old column name and the next
+    /// binary checkpoint persists index metadata that no longer resolves
+    /// against the renamed table, making the database unopenable (issue
+    /// #5877).
+    ///
+    /// Returns the number of indexes whose metadata changed.
+    pub fn rename_column_in_table_indexes(
+        &mut self,
+        table_name: &str,
+        old_column: &str,
+        new_column: &str,
+    ) -> usize {
+        use vibesql_ast::rename::rename_column_in_expression;
+
+        use crate::index::IndexedColumn;
+
+        let table_lc = table_name.to_lowercase();
+        let mut updated = 0;
+        for index in self.indexes.values_mut().filter(|i| i.table_name.to_lowercase() == table_lc)
+        {
+            let mut changed = false;
+            for col in index.columns.iter_mut() {
+                match col {
+                    IndexedColumn::Column { column_name, .. } => {
+                        if column_name.eq_ignore_ascii_case(old_column) {
+                            *column_name = new_column.to_string();
+                            changed = true;
+                        }
+                    }
+                    IndexedColumn::Expression { expr, .. } => {
+                        changed |= rename_column_in_expression(expr, old_column, new_column);
+                    }
+                }
+            }
+            if let Some(where_expr) = index.where_clause.as_deref_mut() {
+                changed |= rename_column_in_expression(where_expr, old_column, new_column);
+            }
+            if changed {
+                updated += 1;
+            }
+        }
+        updated
+    }
+
     /// List all indexes in the catalog
     pub fn list_all_indexes(&self) -> Vec<&IndexMetadata> {
         self.indexes.values().collect()

--- a/crates/vibesql-executor/src/alter/columns.rs
+++ b/crates/vibesql-executor/src/alter/columns.rs
@@ -364,6 +364,27 @@ pub(super) fn execute_rename_column(
         return Err(err);
     }
 
+    // Propagate the rename into dependent index metadata, in BOTH copies:
+    // the catalog copy (drives sqlite_master rendering and planner/FK
+    // checks) and the storage copy (drives index maintenance and binary
+    // persistence). This covers plain column lists, expression-index ASTs,
+    // and partial-index WHERE predicates — SQLite rewrites all index
+    // references on RENAME COLUMN. Without this the next checkpoint
+    // persists index metadata naming a column that no longer exists in the
+    // table, and the fail-closed open policy makes the database unopenable
+    // (issue #5877). Runs after the trigger rewrite so a trigger-side abort
+    // leaves the index metadata untouched.
+    database.catalog.rename_column_in_table_indexes(
+        &stmt.table_name,
+        &stmt.old_column_name,
+        &stmt.new_column_name,
+    );
+    database.rename_column_in_table_indexes(
+        &stmt.table_name,
+        &stmt.old_column_name,
+        &stmt.new_column_name,
+    );
+
     Ok(format!(
         "Column '{}' renamed to '{}' in table '{}'",
         stmt.old_column_name, stmt.new_column_name, stmt.table_name

--- a/crates/vibesql-executor/tests/alter_rename_column_index_tests.rs
+++ b/crates/vibesql-executor/tests/alter_rename_column_index_tests.rs
@@ -1,0 +1,232 @@
+//! End-to-end regression tests for issue #5877: `ALTER TABLE ... RENAME
+//! COLUMN` must propagate the rename into dependent index metadata — plain
+//! column lists, expression-index ASTs, and partial-index WHERE predicates —
+//! in both the catalog copy and the storage copy.
+//!
+//! Before the fix, the index metadata written to the binary snapshot still
+//! named the old column, so the next open failed fail-closed with
+//! `Failed to create index: Column '<old>' not found in table '<t>'` — any
+//! file-backed database that renamed an indexed column became unopenable
+//! after its next checkpoint (the dominant altercol.test failure mode).
+
+use vibesql_executor::{
+    AlterTableExecutor, CreateIndexExecutor, CreateTableExecutor, SelectExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Execute a single SQL statement (CREATE TABLE / CREATE INDEX / ALTER TABLE).
+fn exec(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse");
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            CreateTableExecutor::execute_with_source(&create, db, Some(sql)).expect("CREATE TABLE");
+        }
+        vibesql_ast::Statement::CreateIndex(create) => {
+            CreateIndexExecutor::execute(&create, db).expect("CREATE INDEX");
+        }
+        vibesql_ast::Statement::AlterTable(alter) => {
+            AlterTableExecutor::execute_with_source(&alter, db, Some(sql)).expect("ALTER TABLE");
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            vibesql_executor::InsertExecutor::execute(db, &insert).expect("INSERT");
+        }
+        other => panic!("unsupported statement in test: {other:?}"),
+    }
+}
+
+/// Run a SELECT and return the resulting rows.
+fn query(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = Parser::parse_sql(sql).expect("parse SELECT");
+    let vibesql_ast::Statement::Select(select) = stmt else {
+        panic!("expected SELECT");
+    };
+    let result = SelectExecutor::new(db).execute_with_columns(&select).expect("SELECT");
+    result.rows.into_iter().map(|r| r.values.to_vec()).collect()
+}
+
+/// Return the `sql` text for the named index from `sqlite_master`.
+fn index_sql(db: &Database, index: &str) -> String {
+    let rows =
+        query(db, &format!("SELECT sql FROM sqlite_master WHERE type='index' AND name='{index}'"));
+    assert_eq!(rows.len(), 1, "expected one sqlite_master row for index {index}");
+    match &rows[0][0] {
+        SqlValue::Varchar(s) | SqlValue::Character(s) => s.to_string(),
+        other => panic!("expected text, got {other:?}"),
+    }
+}
+
+/// Save to the binary `.vbsql` format and reload. Pre-#5877 this is exactly
+/// the step that failed after renaming an indexed column.
+fn roundtrip_binary(db: &Database, tag: &str) -> Database {
+    let path =
+        std::env::temp_dir().join(format!("vibesql_5877_{tag}_{}.vbsql", std::process::id()));
+    db.save_binary(&path).expect("save_binary");
+    let reloaded = Database::load_binary(&path)
+        .expect("load_binary must succeed after RENAME COLUMN of an indexed column (#5877)");
+    std::fs::remove_file(&path).ok();
+    reloaded
+}
+
+#[test]
+fn rename_indexed_column_updates_metadata_and_survives_binary_reload() {
+    // The exact reproducer from issue #5877.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a, b)");
+    exec(&mut db, "CREATE INDEX i1 ON t1(b)");
+    exec(&mut db, "INSERT INTO t1 VALUES(1, 2)");
+    exec(&mut db, "ALTER TABLE t1 RENAME b TO z");
+
+    // Catalog metadata now names the new column (drives sqlite_master).
+    assert_eq!(index_sql(&db, "i1"), "CREATE INDEX i1 ON t1(z)");
+    let meta = db.catalog.find_index_by_name("i1").expect("catalog index");
+    assert_eq!(meta.columns[0].column_name(), Some("z"));
+
+    // Storage metadata names the new column (drives persistence/maintenance).
+    let storage_meta = db.get_index("i1").expect("storage index");
+    match &storage_meta.columns[0] {
+        vibesql_ast::IndexColumn::Column { column_name, .. } => assert_eq!(column_name, "z"),
+        other => panic!("expected plain column, got {other:?}"),
+    }
+
+    // The reproducer's failing step: reopen from a binary snapshot.
+    let reloaded = roundtrip_binary(&db, "plain");
+    assert_eq!(index_sql(&reloaded, "i1"), "CREATE INDEX i1 ON t1(z)");
+    assert_eq!(query(&reloaded, "SELECT z FROM t1"), vec![vec![SqlValue::Integer(2)]]);
+
+    // The index keeps working after the rename + reload.
+    let mut reloaded = reloaded;
+    exec(&mut reloaded, "INSERT INTO t1 VALUES(3, 4)");
+    assert_eq!(query(&reloaded, "SELECT a FROM t1 WHERE z = 4"), vec![vec![SqlValue::Integer(3)]]);
+}
+
+#[test]
+fn rename_leaves_indexes_on_other_columns_untouched() {
+    // altercol.test 1.10: index on (a, c), rename b — index must not change.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a, b, c)");
+    exec(&mut db, "CREATE INDEX t1i ON t1(a, c)");
+    exec(&mut db, "ALTER TABLE t1 RENAME COLUMN b TO d");
+
+    assert_eq!(index_sql(&db, "t1i"), "CREATE INDEX t1i ON t1(a, c)");
+    let reloaded = roundtrip_binary(&db, "untouched");
+    assert_eq!(index_sql(&reloaded, "t1i"), "CREATE INDEX t1i ON t1(a, c)");
+}
+
+#[test]
+fn rename_updates_composite_index_column_list() {
+    // altercol.test 1.11: index on (b, c), rename b → d.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a, b, c)");
+    exec(&mut db, "CREATE INDEX t1i ON t1(b, c)");
+    exec(&mut db, "ALTER TABLE t1 RENAME COLUMN b TO d");
+
+    assert_eq!(index_sql(&db, "t1i"), "CREATE INDEX t1i ON t1(d, c)");
+    let reloaded = roundtrip_binary(&db, "composite");
+    assert_eq!(index_sql(&reloaded, "t1i"), "CREATE INDEX t1i ON t1(d, c)");
+}
+
+#[test]
+fn rename_updates_expression_index_and_partial_where() {
+    // altercol.test 1.12 shape: expression index with a partial WHERE.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a, b, c)");
+    exec(&mut db, "CREATE INDEX t1i ON t1(b+b+b+b, c) WHERE b>0");
+    exec(&mut db, "ALTER TABLE t1 RENAME COLUMN b TO d");
+
+    // Catalog: expression AST and WHERE predicate both renamed.
+    let meta = db.catalog.find_index_by_name("t1i").expect("catalog index");
+    use vibesql_ast::pretty_print::ToSql;
+    let expr_sql = meta.columns[0].get_expression().expect("expression column").to_sql();
+    assert!(
+        expr_sql.contains('d') && !expr_sql.contains('b'),
+        "expression not renamed: {expr_sql}"
+    );
+    let where_sql = meta.where_clause.as_ref().expect("partial predicate").to_sql();
+    assert!(where_sql.contains('d') && !where_sql.contains('b'), "WHERE not renamed: {where_sql}");
+
+    // Storage copy: expression AST renamed too. (The storage copy of an
+    // expression index does not carry the WHERE predicate — persistence
+    // reads it from the catalog — so only the expression is checked here;
+    // the storage-side WHERE is covered by the plain-partial test below.)
+    let storage_meta = db.get_index("t1i").expect("storage index");
+    match &storage_meta.columns[0] {
+        vibesql_ast::IndexColumn::Expression { expr, .. } => {
+            let sql = expr.to_sql();
+            assert!(sql.contains('d') && !sql.contains('b'), "storage expr not renamed: {sql}");
+        }
+        other => panic!("expected expression column, got {other:?}"),
+    }
+
+    // Persisted metadata parses and re-binds against the renamed table.
+    let reloaded = roundtrip_binary(&db, "expr_partial");
+    let meta = reloaded.catalog.find_index_by_name("t1i").expect("reloaded catalog index");
+    let where_sql = meta.where_clause.as_ref().expect("reloaded predicate").to_sql();
+    assert!(where_sql.contains('d') && !where_sql.contains('b'));
+}
+
+#[test]
+fn rename_updates_plain_partial_index_where_in_both_copies() {
+    // Plain (non-expression) partial index: the storage copy carries the
+    // WHERE predicate (used by DML partial-index maintenance) and must be
+    // renamed alongside the catalog copy.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a, b, c)");
+    exec(&mut db, "CREATE INDEX t1p ON t1(b) WHERE b>0");
+    exec(&mut db, "ALTER TABLE t1 RENAME COLUMN b TO d");
+
+    use vibesql_ast::pretty_print::ToSql;
+    let meta = db.catalog.find_index_by_name("t1p").expect("catalog index");
+    assert_eq!(meta.columns[0].column_name(), Some("d"));
+    let where_sql = meta.where_clause.as_ref().expect("catalog predicate").to_sql();
+    assert!(where_sql.contains('d') && !where_sql.contains('b'), "WHERE not renamed: {where_sql}");
+
+    let storage_meta = db.get_index("t1p").expect("storage index");
+    let storage_where =
+        storage_meta.where_clause.as_ref().expect("storage partial predicate").to_sql();
+    assert!(
+        storage_where.contains('d') && !storage_where.contains('b'),
+        "storage WHERE not renamed: {storage_where}"
+    );
+
+    let reloaded = roundtrip_binary(&db, "plain_partial");
+    let meta = reloaded.catalog.find_index_by_name("t1p").expect("reloaded catalog index");
+    let where_sql = meta.where_clause.as_ref().expect("reloaded predicate").to_sql();
+    assert!(where_sql.contains('d') && !where_sql.contains('b'));
+}
+
+#[test]
+fn rename_updates_unique_autoindex_from_primary_key() {
+    // altercol.test 1.7 shape: PRIMARY KEY(b, c) creates an implicit
+    // sqlite_autoindex whose column list must follow the rename too.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER, b TEXT, c BLOB, PRIMARY KEY(b, c))");
+    exec(&mut db, "INSERT INTO t1 VALUES(1, 2, 3)");
+    exec(&mut db, "ALTER TABLE t1 RENAME COLUMN b TO d");
+
+    // Every index on t1 (implicit autoindexes included) must reference `d`,
+    // never `b`, in both metadata copies.
+    for meta in db.catalog.get_table_indexes("t1") {
+        for col in &meta.columns {
+            if let Some(name) = col.column_name() {
+                assert_ne!(name, "b", "catalog index {} still names old column", meta.name);
+            }
+        }
+    }
+    for index_name in db.list_indexes() {
+        let meta = db.get_index(&index_name).expect("storage index");
+        if !meta.table_name.eq_ignore_ascii_case("t1") {
+            continue;
+        }
+        for col in &meta.columns {
+            if let vibesql_ast::IndexColumn::Column { column_name, .. } = col {
+                assert_ne!(column_name, "b", "storage index {index_name} still names old column");
+            }
+        }
+    }
+
+    // And the reload must not fail-closed on the autoindex.
+    let reloaded = roundtrip_binary(&db, "autoindex");
+    assert_eq!(query(&reloaded, "SELECT * FROM t1").len(), 1);
+}

--- a/crates/vibesql-storage/src/database/index_ops.rs
+++ b/crates/vibesql-storage/src/database/index_ops.rs
@@ -328,6 +328,21 @@ impl Database {
         self.operations.set_index_where_clause(index_name, where_clause)
     }
 
+    /// Propagate `ALTER TABLE <table> RENAME COLUMN old TO new` into the
+    /// storage-side metadata of every index on `table_name`: plain column
+    /// names, expression-index ASTs, and partial-index WHERE predicates. The
+    /// index bodies are untouched (a rename does not change key values).
+    /// Returns the number of indexes whose metadata changed. See issue #5877.
+    pub fn rename_column_in_table_indexes(
+        &mut self,
+        table_name: &str,
+        old_column: &str,
+        new_column: &str,
+    ) -> usize {
+        self.snapshot_operations_for_mutation();
+        self.operations.rename_column_in_table_indexes(table_name, old_column, new_column)
+    }
+
     /// List all indexes
     pub fn list_indexes(&self) -> Vec<String> {
         self.operations.list_indexes()

--- a/crates/vibesql-storage/src/database/indexes/index_manager.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_manager.rs
@@ -546,6 +546,65 @@ impl IndexManager {
         }
     }
 
+    /// Propagate `ALTER TABLE <table> RENAME COLUMN old TO new` into the
+    /// storage-side metadata of every index on `table_name`.
+    ///
+    /// Rewrites plain column-name entries, column references inside
+    /// expression-index ASTs, and partial-index WHERE predicates. The index
+    /// *body* (stored keys) is untouched — a column rename does not change any
+    /// key values. Without this, index maintenance keeps resolving the old
+    /// column name and binary persistence writes stale metadata that fails
+    /// fail-closed validation on the next open (issue #5877).
+    ///
+    /// Table-name matching is case-insensitive and, like
+    /// [`Self::has_indexes_for_table`], compares the last component of a
+    /// possibly schema-qualified name. Returns the number of indexes whose
+    /// metadata changed.
+    pub fn rename_column_in_table_indexes(
+        &mut self,
+        table_name: &str,
+        old_column: &str,
+        new_column: &str,
+    ) -> usize {
+        use vibesql_ast::rename::rename_column_in_expression;
+        use vibesql_ast::IndexColumn;
+
+        let search_name_lower = table_name.to_lowercase();
+        let search_table_only = search_name_lower.rsplit('.').next().unwrap_or(&search_name_lower);
+
+        let mut updated = 0;
+        for metadata in self.indexes.values_mut() {
+            let stored_name_lower = metadata.table_name.to_lowercase();
+            let stored_table_only =
+                stored_name_lower.rsplit('.').next().unwrap_or(&stored_name_lower);
+            if stored_table_only != search_table_only {
+                continue;
+            }
+
+            let mut changed = false;
+            for col in metadata.columns.iter_mut() {
+                match col {
+                    IndexColumn::Column { column_name, .. } => {
+                        if column_name.eq_ignore_ascii_case(old_column) {
+                            *column_name = new_column.to_string();
+                            changed = true;
+                        }
+                    }
+                    IndexColumn::Expression { expr, .. } => {
+                        changed |= rename_column_in_expression(expr, old_column, new_column);
+                    }
+                }
+            }
+            if let Some(where_expr) = metadata.where_clause.as_deref_mut() {
+                changed |= rename_column_in_expression(where_expr, old_column, new_column);
+            }
+            if changed {
+                updated += 1;
+            }
+        }
+        updated
+    }
+
     // ========================================================================
     // Resource Budget and Eviction Methods
     // ========================================================================

--- a/crates/vibesql-storage/src/database/operations.rs
+++ b/crates/vibesql-storage/src/database/operations.rs
@@ -964,6 +964,19 @@ impl Operations {
         self.index_manager.set_index_where_clause(index_name, where_clause)
     }
 
+    /// Propagate a column rename into the storage-side metadata of every
+    /// index on `table_name`. See
+    /// `IndexManager::rename_column_in_table_indexes` for details (issue
+    /// #5877). Returns the number of indexes whose metadata changed.
+    pub fn rename_column_in_table_indexes(
+        &mut self,
+        table_name: &str,
+        old_column: &str,
+        new_column: &str,
+    ) -> usize {
+        self.index_manager.rename_column_in_table_indexes(table_name, old_column, new_column)
+    }
+
     /// List all indexes
     pub fn list_indexes(&self) -> Vec<String> {
         self.index_manager.list_indexes()


### PR DESCRIPTION
## Summary

`ALTER TABLE ... RENAME COLUMN` renamed the column in the table schema but left every index on the table still naming the old column — in both the catalog metadata (drives `sqlite_master` rendering and planner/FK checks) and the storage metadata (drives index maintenance and binary persistence). The next checkpoint then persisted index metadata that no longer resolved against the renamed table, and the fail-closed open policy (#5850) made the database unopenable:

```
Error: Failed to open WAL-backed database at rc.vbsql: I/O error: refusing to open:
newest checkpoint ... is unreadable
(Not implemented: Failed to create index: Column 'b' not found in table 't1').
```

This PR makes RENAME COLUMN rewrite all dependent index metadata, matching SQLite (which rewrites index references on RENAME COLUMN).

## Changes

- **`vibesql-ast`**: new `rename` module with `rename_column_in_expression`, an in-place `ColumnRef` rewriter over expression trees. Preserves schema/table qualifiers and quoting; deliberately does not descend into subquery bodies (not legal in index expressions / partial-index predicates, the only ASTs it is applied to).
- **`vibesql-catalog`**: `Catalog::rename_column_in_table_indexes` — rewrites plain column-name entries, expression-index ASTs, and partial-index WHERE predicates for every index on the table (implicit `sqlite_autoindex_*` entries included).
- **`vibesql-storage`**: `IndexManager::rename_column_in_table_indexes` (+ `Operations`/`Database` delegations) — same rewrite for the storage-side copy. Index *bodies* are untouched (a rename changes no key values).
- **`vibesql-executor`**: `execute_rename_column` invokes both rewrites after the trigger rewrite succeeds, so a trigger-side abort leaves index metadata untouched (ALTER stays atomic).
- New integration test suite `alter_rename_column_index_tests.rs` (6 tests): the exact issue reproducer with binary round-trip, composite index, untouched-other-index, expression index, plain partial index (storage-side WHERE), and PRIMARY KEY autoindex.

## Scope decisions

- **In scope**: index metadata (column lists, expression ASTs, partial WHERE) in both copies. This is the failure mode that makes checkpoints unopenable and the dominant altercol.test failure.
- **Already handled elsewhere**: the table's own PK/UNIQUE/FK column lists (`TableSchema::rename_column`), trigger-body rewriting (#5602), verbatim table `sql_source` (#5625).
- **Out of scope** (different root cause — verbatim `sqlite_master` *text* rewriting, not metadata): renaming inside CHECK/PK/FK clauses of the verbatim CREATE TABLE text (altercol 1.x.4 residuals), child-table FK text when a *parent* column is renamed (altercol 4.x), view SQL rewriting (altercol 8.x), and partial-index WHERE rendering in `generate_create_index_sql`. `CHANGE COLUMN` (MySQL rename+modify) has the same latent gap and can share these helpers. These remaining altercol failures are 16 tests (counts below).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Reproducer round-trips (rename, exit, reopen, index targets new name) | ✅ | CLI reproducer: second invocation opens cleanly and `sqlite_schema` shows `CREATE INDEX i1 ON t1(z)`; also covered by `rename_indexed_column_updates_metadata_and_survives_binary_reload` |
| Expression + partial indexes | ✅ | `rename_updates_expression_index_and_partial_where`, `rename_updates_plain_partial_index_where_in_both_copies` |
| `make test-tcl-file FILE=altercol.test` before/after | ✅ | Before (same worktree, pre-fix build): **64 pass / 22 fail**. After: **70 pass / 16 fail**. Fixes 1.7.3, 1.8.3, 1.9.3, 1.11.3, 1.11.4, 1.14.3 (the reload-failure mode). |
| alterdropcol stays at baseline | ✅ | 8.1/8.2 fail identically pre- and post-fix (pre-existing writable_schema gap). 5.1 flakes 95↔96 on **both** the pre-fix and post-fix binaries (sqlite_schema row-ordering nondeterminism, verified with 6 baseline runs) — not a regression. |
| `cargo test -p vibesql-storage -p vibesql-executor` | ✅ | Both suites pass (storage lib: 777 passed; executor: full suite exit 0). `vibesql-ast` and `vibesql-catalog` suites also pass. |

## Test Plan

- `cargo test -p vibesql-ast rename` — 6 unit tests for the expression rewriter
- `cargo test -p vibesql-executor --test alter_rename_column_index_tests` — 6 integration tests incl. binary round-trips
- `cargo test -p vibesql-storage -p vibesql-executor -p vibesql-catalog -p vibesql-ast` — green
- `make test-tcl-file FILE=altercol.test` — 64/22 → 70/16
- `make test-tcl-file FILE=alterdropcol.test` — unchanged vs pre-fix baseline
- Manual CLI reproducer from the issue — fixed

Closes #5877

🤖 Generated with [Claude Code](https://claude.com/claude-code)