### PR TITLE
feat(catalog): enumerate schema tables in creation order via IndexMap

### DIFF
--- a/crates/vibesql-catalog/src/schema.rs
+++ b/crates/vibesql-catalog/src/schema.rs
@@ -1,24 +1,30 @@
 //! Schema - Named collection of database objects
 
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 use crate::{errors::CatalogError, table::TableSchema, TableIdentifier};
 
 /// A schema - named collection of database objects (tables, views, etc.)
+///
+/// Tables are stored in an `IndexMap` (not a `HashMap`) so enumeration order
+/// tracks creation order. SQLite returns `sqlite_schema` rows in rowid
+/// (creation) order, so `list_tables()` must preserve insertion order to
+/// match. See issue #5826.
 #[derive(Debug, Clone)]
 pub struct Schema {
     pub name: String,
-    /// Tables stored with canonical name as key (lowercase for unquoted, exact for quoted)
-    tables: HashMap<String, TableSchema>,
+    /// Tables stored with canonical name as key (lowercase for unquoted, exact for quoted).
+    /// `IndexMap` preserves creation order for `list_tables()` enumeration.
+    tables: IndexMap<String, TableSchema>,
     /// Track which tables were created with quoted identifiers
-    table_identifiers: HashMap<String, TableIdentifier>,
+    table_identifiers: IndexMap<String, TableIdentifier>,
     // Future: views, functions, sequences, etc.
 }
 
 impl Schema {
     /// Create a new empty schema
     pub fn new(name: String) -> Self {
-        Schema { name, tables: HashMap::new(), table_identifiers: HashMap::new() }
+        Schema { name, tables: IndexMap::new(), table_identifiers: IndexMap::new() }
     }
 
     /// Create a table in this schema using SQL:1999 identifier semantics.
@@ -88,8 +94,12 @@ impl Schema {
         identifier: &TableIdentifier,
     ) -> Result<(), CatalogError> {
         let canonical = identifier.canonical();
-        if self.tables.remove(canonical).is_some() {
-            self.table_identifiers.remove(canonical);
+        // Use `shift_remove` (not the default `swap_remove`) so the remaining
+        // tables keep their creation order. `swap_remove` would move the last
+        // table into the removed slot, corrupting `list_tables()` ordering
+        // (e.g. after DROP TABLE + re-CREATE). See issue #5826.
+        if self.tables.shift_remove(canonical).is_some() {
+            self.table_identifiers.shift_remove(canonical);
             Ok(())
         } else {
             Err(CatalogError::TableNotFound { table_name: identifier.display().to_string() })

--- a/crates/vibesql-catalog/src/tests.rs
+++ b/crates/vibesql-catalog/src/tests.rs
@@ -157,6 +157,69 @@ mod catalog_tests {
         assert_eq!(tables, vec!["orders".to_string(), "users".to_string()]);
     }
 
+    /// `list_tables()` must enumerate tables in creation order (not hash or
+    /// sorted order) so `sqlite_schema` rows come out in rowid order. See #5826.
+    #[test]
+    fn test_list_tables_creation_order() {
+        let mut catalog = Catalog::new();
+        // Deliberately non-alphabetical creation order so a sort would reorder.
+        for name in ["zebra", "apple", "mango", "cherry"] {
+            let schema = TableSchema::new(
+                name.to_string(),
+                vec![ColumnSchema::new("id".to_string(), vibesql_types::DataType::Integer, false)],
+            );
+            catalog.create_table(schema).unwrap();
+        }
+
+        assert_eq!(
+            catalog.list_tables(),
+            vec![
+                "zebra".to_string(),
+                "apple".to_string(),
+                "mango".to_string(),
+                "cherry".to_string()
+            ],
+            "list_tables() must preserve creation order, not sort or hash-order"
+        );
+    }
+
+    /// Dropping a table then re-creating it must place the re-created table at
+    /// the END of the enumeration (SQLite assigns a new, larger rowid), and the
+    /// surviving tables must keep their original relative order. This guards
+    /// against `IndexMap::swap_remove` (which would move the last table into the
+    /// dropped slot). See #5826.
+    #[test]
+    fn test_list_tables_order_after_drop_and_recreate() {
+        let mut catalog = Catalog::new();
+        for name in ["a", "b", "c", "d"] {
+            let schema = TableSchema::new(
+                name.to_string(),
+                vec![ColumnSchema::new("id".to_string(), vibesql_types::DataType::Integer, false)],
+            );
+            catalog.create_table(schema).unwrap();
+        }
+
+        // Drop a middle table; survivors keep relative order.
+        catalog.drop_table("b").unwrap();
+        assert_eq!(
+            catalog.list_tables(),
+            vec!["a".to_string(), "c".to_string(), "d".to_string()],
+            "drop must not reorder surviving tables (shift_remove, not swap_remove)"
+        );
+
+        // Re-create the dropped table; it goes to the end (new rowid).
+        let schema = TableSchema::new(
+            "b".to_string(),
+            vec![ColumnSchema::new("id".to_string(), vibesql_types::DataType::Integer, false)],
+        );
+        catalog.create_table(schema).unwrap();
+        assert_eq!(
+            catalog.list_tables(),
+            vec!["a".to_string(), "c".to_string(), "d".to_string(), "b".to_string()],
+            "re-created table must enumerate last, matching SQLite rowid semantics"
+        );
+    }
+
     #[test]
     fn test_error_display_table_already_exists() {
         let error = CatalogError::TableAlreadyExists("customers".to_string());

--- a/crates/vibesql-storage/src/persistence/tests/binary_persistence.rs
+++ b/crates/vibesql-storage/src/persistence/tests/binary_persistence.rs
@@ -48,6 +48,45 @@ fn test_quoted_table_identifier_roundtrip() {
     std::fs::remove_file(path).ok();
 }
 
+/// Issue #5826: table creation order must survive the binary save/load
+/// round-trip. The TCL shim runs each SQL batch in a fresh CLI process, so the
+/// `CREATE TABLE` order established in one process must be reconstructed when a
+/// later process opens the file and answers `SELECT ... FROM sqlite_schema`.
+/// `list_tables()` returns creation (insertion) order; the writer serializes in
+/// that order and the reader re-inserts in file order, so the order is
+/// preserved end-to-end.
+#[test]
+fn test_binary_roundtrip_preserves_table_creation_order() {
+    let mut db = Database::new();
+
+    // Non-alphabetical creation order so a sort or hash-order would differ.
+    let creation_order = ["zebra", "apple", "mango", "cherry", "delta"];
+    for name in creation_order {
+        let schema = TableSchema::new(
+            name.to_string(),
+            vec![ColumnSchema::new("id".to_string(), DataType::Integer, false)],
+        );
+        db.create_table_with_identifier(schema, TableIdentifier::new(name, false)).unwrap();
+    }
+    assert_eq!(
+        db.catalog.list_tables(),
+        creation_order.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+        "precondition: in-memory catalog enumerates in creation order"
+    );
+
+    let path = "/tmp/test_table_creation_order_roundtrip.vbsql";
+    db.save_binary(path).unwrap();
+    let loaded_db = Database::load_binary(path).unwrap();
+
+    assert_eq!(
+        loaded_db.catalog.list_tables(),
+        creation_order.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+        "creation order must survive the binary save/load round-trip"
+    );
+
+    std::fs::remove_file(path).ok();
+}
+
 /// Issue #5619: the verbatim original `CREATE TABLE` source text must survive a
 /// full file-level `save_binary` → `load_binary` round-trip (header + catalog +
 /// data sections), not just the in-memory catalog encoder. This is the actual


### PR DESCRIPTION
## Summary

`sqlite_schema` rows were enumerated in arbitrary `HashMap` iteration order instead of SQLite's creation (rowid) order, causing `alterdropcol.test` 5.1 to fail on row ordering (VibeSQL returned `c2` before `c1`).

Fix: store `Schema.tables` and `Schema.table_identifiers` in an `IndexMap` (already a `vibesql-catalog` dependency, already used for `indexes`) so `list_tables()` returns creation order. This is the same order-preserving-map pattern the catalog already uses for indexes.

## Changes

- `crates/vibesql-catalog/src/schema.rs`: `tables` and `table_identifiers` changed from `HashMap` to `IndexMap`; `drop_table_by_identifier` uses `shift_remove` (not the default `swap_remove`) so surviving tables keep their relative order and a DROP + re-CREATE re-appends the table at the end (matching SQLite's monotonic rowid).
- `crates/vibesql-catalog/src/tests.rs`: added `test_list_tables_creation_order` and `test_list_tables_order_after_drop_and_recreate`.
- `crates/vibesql-storage/src/persistence/tests/binary_persistence.rs`: added `test_binary_roundtrip_preserves_table_creation_order` (order must survive the binary save/load cycle because the TCL shim runs each SQL batch in a fresh CLI process).

No changes were needed in `sqlite_schema.rs`, `store/tables.rs`, or `binary/catalog.rs`: they already read/serialize in `list_tables()` order, so creation order now flows through end-to-end.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `alterdropcol.test` 5.1 passes | ✅ | `make test-tcl-file FILE=alterdropcol.test`: 5.1 in the passed set |
| No regressions in `alterdropcol.test` | ✅ | Improved vs baseline; only 8.1/8.2 (writable_schema `PRAGMA writable_schema=1` + `UPDATE sqlite_schema`) remain — orthogonal, pre-existing |
| No regressions in `alter.test` | ✅ | 40 passed / 61 failed — identical to the pre-change baseline in the TCL results DB |
| No regressions in `altertab.test` | ✅ | 0 failures (27 pass / 85 skip) |
| Order survives binary save/load round-trip | ✅ | `test_binary_roundtrip_preserves_table_creation_order` |
| DROP + re-CREATE places table last | ✅ | `test_list_tables_order_after_drop_and_recreate` (guards against `swap_remove`) |

## Test Plan

- `cargo test -p vibesql-catalog`: 58 passed, 0 failed (incl. 3 list_tables tests).
- `cargo test -p vibesql-storage`: exit 0, no failures (incl. new round-trip test).
- `cargo test -p vibesql-executor --lib`: passes (the only failure is `deep_expression_tests::test_deep_case_expressions`, a pre-existing debug-build stack overflow on `main`, unrelated to this change).
- Issue reproducer now returns `c1` before `c2`:

```
CREATE TABLE p1(...); CREATE TABLE c1(...); CREATE TABLE c2(...);
ALTER TABLE c1 DROP COLUMN z; ALTER TABLE c2 DROP COLUMN z;
SELECT name FROM sqlite_schema WHERE name IN ('c1','c2');
-- name: c1, then c2  (creation order)
```

Closes #5826