### PR TITLE
fix(sql): gate equality/range/composite index probes on column collation (#5823)

### DIFF
--- a/crates/vibesql-executor/src/optimizer/index_planner.rs
+++ b/crates/vibesql-executor/src/optimizer/index_planner.rs
@@ -262,6 +262,27 @@ impl<'a> IndexPlanner<'a> {
                     continue;
                 }
 
+                // Issue #5823: skip-scan builds a raw equality/range probe for
+                // the skipped filter column and seeks raw prefix keys. A
+                // non-BINARY collation (e.g. NOCASE) on any of the index's key
+                // columns makes those raw probes silently lose rows, so decline
+                // skip-scan for such indexes and let the collation-aware scan
+                // path compute the result. BINARY/undeclared columns are
+                // unaffected.
+                let covers_nonbinary_collation =
+                    index_metadata.columns.iter().filter_map(|c| c.column_name()).any(|col_name| {
+                        table
+                            .schema
+                            .columns
+                            .iter()
+                            .find(|c| c.name.eq_ignore_ascii_case(col_name))
+                            .and_then(|c| c.collation.as_deref())
+                            .is_some_and(|coll| !coll.eq_ignore_ascii_case("binary"))
+                    });
+                if covers_nonbinary_collation {
+                    continue;
+                }
+
                 let first_col = &index_metadata.columns[0];
 
                 // Check if WHERE clause filters on the first column

--- a/crates/vibesql-executor/src/select/executor/fast_path/index_lookup.rs
+++ b/crates/vibesql-executor/src/select/executor/fast_path/index_lookup.rs
@@ -122,6 +122,13 @@ impl SelectExecutor<'_> {
             let index_columns: Vec<&str> =
                 metadata.columns.iter().map(|c| c.expect_column_name()).collect();
 
+            // Issue #5823: skip indexes covering a non-BINARY-collated column;
+            // the raw prefix probe would lose rows. The standard scan path
+            // applies the collation-aware WHERE filter instead.
+            if index_covers_nonbinary_collation(&table.schema, &index_columns) {
+                continue;
+            }
+
             // Need at least 2 columns for prefix + ORDER BY pattern
             if index_columns.len() < 2 {
                 continue;
@@ -320,6 +327,13 @@ impl SelectExecutor<'_> {
             // Get index column names in order
             let index_columns: Vec<&str> =
                 metadata.columns.iter().map(|c| c.expect_column_name()).collect();
+
+            // Issue #5823: skip indexes covering a non-BINARY-collated column;
+            // a raw equality/prefix probe would silently lose rows. The
+            // standard scan path applies the collation-aware WHERE filter.
+            if index_covers_nonbinary_collation(&table.schema, &index_columns) {
+                continue;
+            }
 
             // Try to extract equality values from WHERE clause
             let index_values = match self.extract_pk_values(where_clause, &index_columns) {
@@ -537,6 +551,13 @@ impl SelectExecutor<'_> {
             let index_column_names: Vec<&str> =
                 metadata.columns.iter().map(|c| c.expect_column_name()).collect();
 
+            // Issue #5823: skip indexes covering a non-BINARY-collated column;
+            // a raw covering probe would silently lose rows. The standard scan
+            // path applies the collation-aware WHERE filter.
+            if index_covers_nonbinary_collation(&table.schema, &index_column_names) {
+                continue;
+            }
+
             // Check if this index covers all needed columns
             if check_covering_index(&index_column_names, &needed_columns).is_none() {
                 continue; // Index doesn't cover all needed columns
@@ -569,6 +590,27 @@ impl SelectExecutor<'_> {
         // No suitable covering index found
         Ok(None)
     }
+}
+
+/// Issue #5823: raw index probes compare BINARY-ordered key bytes and thus
+/// silently lose rows on a column declared with a non-BINARY collation (e.g.
+/// NOCASE) — the post-lookup WHERE filter can only remove rows, never restore
+/// missed ones. Return true when any of `index_columns` resolves to a column
+/// with a declared non-BINARY collation, so the fast index path can skip that
+/// index and let the standard scan path apply the collation-aware WHERE
+/// evaluator. BINARY/undeclared collations keep the fast path.
+fn index_covers_nonbinary_collation(
+    schema: &vibesql_catalog::TableSchema,
+    index_columns: &[&str],
+) -> bool {
+    index_columns.iter().any(|col_name| {
+        schema
+            .columns
+            .iter()
+            .find(|c| c.name.eq_ignore_ascii_case(col_name))
+            .and_then(|c| c.collation.as_deref())
+            .is_some_and(|coll| !coll.eq_ignore_ascii_case("binary"))
+    })
 }
 
 /// Coerce string equality lookup keys to the stored temporal key type

--- a/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
@@ -19,6 +19,24 @@ use crate::{
     errors::ExecutorError, optimizer::PredicatePlan, schema::CombinedSchema, select::cte::CteResult,
 };
 
+/// Issue #5823: an index probe looks up raw (BINARY-ordered) key bytes, but a
+/// column declared with a non-BINARY collation (e.g. NOCASE) must match per
+/// that collation (`'XYZ'` must find stored `'xyz'`). Probing raw literals
+/// against such a column silently loses rows, and the WHERE post-filter can
+/// only remove rows, never restore missed ones. Return true when `col_name`
+/// resolves to a column with a declared non-BINARY collation, so callers can
+/// decline the probe and fall back to the full-index-scan + collation-aware
+/// WHERE-filter path (correct, just slower). BINARY/undeclared collations keep
+/// the fast probe.
+fn column_has_nonbinary_collation(schema: &vibesql_catalog::TableSchema, col_name: &str) -> bool {
+    schema
+        .columns
+        .iter()
+        .find(|c| c.name.eq_ignore_ascii_case(col_name))
+        .and_then(|c| c.collation.as_deref())
+        .is_some_and(|coll| !coll.eq_ignore_ascii_case("binary"))
+}
+
 /// Execute an index scan
 ///
 /// Uses the specified index to retrieve matching rows, then fetches full rows from the table.
@@ -95,6 +113,15 @@ pub(crate) fn execute_index_scan(
         None
     };
 
+    // Issue #5823: a composite-key probe compares raw (BINARY-ordered) key
+    // bytes, so decline it when ANY covered index column has a non-BINARY
+    // collation — fall back to the collation-aware WHERE path below.
+    // `extract_composite_predicates_with_in` only succeeds when EVERY index
+    // column is covered, so checking all index columns is exact here.
+    let composite_predicates = composite_predicates.filter(|_| {
+        !index_column_names.iter().any(|col| column_has_nonbinary_collation(&table.schema, col))
+    });
+
     // Generate composite keys (handles both single key and multiple keys for IN predicates)
     let composite_keys: Option<Vec<Vec<vibesql_types::SqlValue>>> =
         composite_predicates.as_ref().map(|preds| generate_composite_keys(preds));
@@ -118,6 +145,14 @@ pub(crate) fn execute_index_scan(
         None
     };
 
+    // Issue #5823: decline the prefix+range probe when any covered column has a
+    // non-BINARY collation (a raw-key probe would lose collated rows). The
+    // `covered_columns` set is uppercase; `column_has_nonbinary_collation`
+    // matches case-insensitively.
+    let prefix_with_range_result = prefix_with_range_result.filter(|r| {
+        !r.covered_columns.iter().any(|col| column_has_nonbinary_collation(&table.schema, col))
+    });
+
     let use_prefix_bounded_lookup = prefix_with_range_result.is_some();
 
     // Try prefix lookup if full composite key not available (for partial prefix matches)
@@ -130,6 +165,12 @@ pub(crate) fn execute_index_scan(
         } else {
             None
         };
+
+    // Issue #5823: decline the prefix-equality probe when any covered column
+    // has a non-BINARY collation (raw-key probe would lose collated rows).
+    let prefix_result = prefix_result.filter(|r| {
+        !r.covered_columns.iter().any(|col| column_has_nonbinary_collation(&table.schema, col))
+    });
 
     // Check if we're using prefix lookup (partial composite key match)
     let use_prefix_lookup =
@@ -146,22 +187,22 @@ pub(crate) fn execute_index_scan(
         })
     };
 
-    // Issue #5806: an IN-list probe looks up the raw literal values in the
-    // index, but the index stores raw (BINARY-ordered) keys while IN on a
-    // non-BINARY-collated column (e.g. NOCASE) must match per the LHS
-    // collation ('XYZ' must find stored 'xyz'). Such a probe silently loses
-    // rows, and the WHERE post-filter can only remove rows, never restore
-    // missed ones. Decline the probe so we fall back to the
-    // full-index-scan + collation-aware WHERE-filter path below (correct,
-    // just slower). BINARY/undeclared collations keep the fast probe.
-    let index_predicate = if matches!(index_predicate, Some(IndexPredicate::In(_)))
-        && first_indexed_column
-            .and_then(|idx_col| idx_col.column_name())
-            .and_then(|col_name| {
-                table.schema.columns.iter().find(|c| c.name.eq_ignore_ascii_case(col_name))
-            })
-            .and_then(|c| c.collation.as_deref())
-            .is_some_and(|coll| !coll.eq_ignore_ascii_case("binary"))
+    // Issue #5806 / #5823: an equality/range/IN-list probe looks up the raw
+    // literal values in the index, but the index stores raw (BINARY-ordered)
+    // keys while a predicate on a non-BINARY-collated column (e.g. NOCASE) must
+    // match per the column collation ('XYZ' must find stored 'xyz'). Such a
+    // probe silently loses rows, and the WHERE post-filter can only remove
+    // rows, never restore missed ones. Decline the probe so we fall back to
+    // the full-index-scan + collation-aware WHERE-filter path below (correct,
+    // just slower). #5806 first added this gate for `IndexPredicate::In`;
+    // #5823 extends it to `IndexPredicate::Range` (which backs `=`, `<`, `<=`,
+    // `>`, `>=`, BETWEEN). BINARY/undeclared collations keep the fast probe.
+    let index_predicate = if matches!(
+        index_predicate,
+        Some(IndexPredicate::In(_)) | Some(IndexPredicate::Range(_))
+    ) && first_indexed_column
+        .and_then(|idx_col| idx_col.column_name())
+        .is_some_and(|col_name| column_has_nonbinary_collation(&table.schema, col_name))
     {
         None
     } else {

--- a/crates/vibesql-executor/src/select/scan/index_scan/predicate/in_list.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/predicate/in_list.rs
@@ -54,6 +54,16 @@ pub(crate) fn extract_index_predicate(
 
         // Check for range + IN combined predicates (e.g., col IN (64, 4) AND col > 75)
         // Filter IN values by the range predicate and return the filtered list
+        //
+        // Issue #5823: `value_satisfies_range` compares with BINARY ordering and
+        // is therefore NOT collation-aware. This is safe here because the result
+        // only ever *narrows* the IN-list used as an index-probe hint — it can
+        // drop the probe to a smaller/empty set but never fabricates rows. On a
+        // non-BINARY-collated column the raw probe is already declined upstream
+        // (execution.rs gates `IndexPredicate::In`/`Range`), so the query falls
+        // back to the collation-aware full-scan WHERE evaluator regardless of any
+        // over-filtering here. Do not treat this filtered list as a correct
+        // collation-aware result on its own.
         if let (Some(in_vals), Some(ref range)) = (&in_values, &range_pred) {
             let satisfying_values: Vec<SqlValue> =
                 in_vals.iter().filter(|v| value_satisfies_range(v, range)).cloned().collect();

--- a/crates/vibesql-executor/tests/equality_range_index_collation_tests.rs
+++ b/crates/vibesql-executor/tests/equality_range_index_collation_tests.rs
@@ -1,0 +1,208 @@
+//! Regression tests for issue #5823: equality/range index probes must respect
+//! the indexed column's declared collation.
+//!
+//! Sibling of #5806 (IN-list index probe). Index keys are stored raw
+//! (BINARY-ordered), so a probe built from a raw literal against a column with
+//! a non-BINARY collation (e.g. NOCASE) silently loses rows — the WHERE
+//! post-filter can only remove rows, never restore missed ones. The fix
+//! declines the probe/fast-path for non-BINARY-collated columns and falls back
+//! to the collation-aware full-scan WHERE evaluator (#5805).
+//!
+//! Code paths covered:
+//! - single-column equality probe (`IndexPredicate::Range` equality form)
+//! - single-column range probes (`>`, `>=`, `<`, `<=`, BETWEEN)
+//! - composite-key lookup with a NOCASE column
+//! - prefix-equality lookup with a leading NOCASE column
+//! - prefix + trailing-range lookup with a NOCASE range column
+//! - BINARY / undeclared columns keep the fast probe (regression guard)
+//!
+//! Every expected value was verified against sqlite3 3.x with the same fixture.
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::CreateIndex(create_index) => {
+            vibesql_executor::CreateIndexExecutor::execute(&create_index, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            vibesql_executor::InsertExecutor::execute(db, &insert).unwrap();
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+/// Run a single-column SELECT and collect the integer results.
+fn query_ints(db: &vibesql_storage::Database, sql: &str) -> Vec<i64> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        let rows = executor
+            .execute(&select_stmt)
+            .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e));
+        rows.iter()
+            .map(|row| {
+                assert_eq!(row.values.len(), 1, "Expected one column for: {}", sql);
+                match &row.values[0] {
+                    SqlValue::Integer(i) => *i,
+                    SqlValue::Bigint(i) => *i,
+                    SqlValue::Smallint(i) => i64::from(*i),
+                    other => panic!("Expected integer result for {}: {:?}", sql, other),
+                }
+            })
+            .collect()
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+fn assert_rows(db: &vibesql_storage::Database, sql: &str, expected: &[i64]) {
+    let actual = query_ints(db, sql);
+    assert_eq!(actual, expected, "Query: {} -- expected {:?}, got {:?}", sql, expected, actual);
+}
+
+/// The `t4a` fixture from `in4.test`: `a` has default BINARY collation,
+/// `b` is declared NOCASE.
+fn db_with_t4a() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t4a(a TEXT, b TEXT COLLATE nocase, c)");
+    run_stmt(&mut db, "INSERT INTO t4a VALUES('ABC','abc',1)");
+    run_stmt(&mut db, "INSERT INTO t4a VALUES('def','xyz',2)");
+    run_stmt(&mut db, "INSERT INTO t4a VALUES('ghi','ghi',3)");
+    db
+}
+
+/// Same fixture with a single-column index on the NOCASE column (the exact
+/// reproducer from the issue body).
+fn db_with_t4a_indexed() -> vibesql_storage::Database {
+    let mut db = db_with_t4a();
+    run_stmt(&mut db, "CREATE INDEX i4ab ON t4a(b)");
+    db
+}
+
+// ---------------------------------------------------------------------------
+// Equality probe — the exact reproducer, with and without the index
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nocase_equality_without_index() {
+    // Ground truth (#5805 full-scan collation-aware path).
+    let db = db_with_t4a();
+    assert_rows(&db, "SELECT c FROM t4a WHERE b = 'XYZ'", &[2]);
+}
+
+#[test]
+fn nocase_equality_with_index_returns_row() {
+    // The reproducer: with the index present, the equality probe must not lose
+    // the row. Before #5823 this returned 0 rows.
+    let db = db_with_t4a_indexed();
+    assert_rows(&db, "SELECT c FROM t4a WHERE b = 'XYZ'", &[2]);
+}
+
+// ---------------------------------------------------------------------------
+// Range probes on the indexed NOCASE column (>, >=, <, <=, BETWEEN)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nocase_range_probes_with_index() {
+    let db = db_with_t4a_indexed();
+    assert_rows(&db, "SELECT c FROM t4a WHERE b >= 'xyz' ORDER BY c", &[2]);
+    assert_rows(&db, "SELECT c FROM t4a WHERE b <= 'XYZ' ORDER BY c", &[1, 2, 3]);
+    assert_rows(&db, "SELECT c FROM t4a WHERE b > 'GHI' ORDER BY c", &[2]);
+    assert_rows(&db, "SELECT c FROM t4a WHERE b < 'GHI' ORDER BY c", &[1]);
+    assert_rows(&db, "SELECT c FROM t4a WHERE b BETWEEN 'ABC' AND 'XYZ' ORDER BY c", &[1, 2, 3]);
+}
+
+#[test]
+fn nocase_range_probes_match_unindexed_oracle() {
+    // The indexed result must equal the (correct) full-scan result.
+    let indexed = db_with_t4a_indexed();
+    let unindexed = db_with_t4a();
+    for sql in [
+        "SELECT c FROM t4a WHERE b >= 'xyz' ORDER BY c",
+        "SELECT c FROM t4a WHERE b <= 'XYZ' ORDER BY c",
+        "SELECT c FROM t4a WHERE b > 'GHI' ORDER BY c",
+        "SELECT c FROM t4a WHERE b < 'GHI' ORDER BY c",
+        "SELECT c FROM t4a WHERE b BETWEEN 'ABC' AND 'XYZ' ORDER BY c",
+        "SELECT c FROM t4a WHERE b = 'XYZ' ORDER BY c",
+    ] {
+        assert_eq!(
+            query_ints(&indexed, sql),
+            query_ints(&unindexed, sql),
+            "indexed vs unindexed mismatch for: {}",
+            sql
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Composite / prefix paths involving a NOCASE column
+// ---------------------------------------------------------------------------
+
+#[test]
+fn composite_lookup_with_nocase_first_column() {
+    // Index (b, a): b is NOCASE. Full composite key `b = 'XYZ' AND a = 'def'`.
+    let mut db = db_with_t4a();
+    run_stmt(&mut db, "CREATE INDEX i4ba ON t4a(b, a)");
+    assert_rows(&db, "SELECT c FROM t4a WHERE b = 'XYZ' AND a = 'def'", &[2]);
+}
+
+#[test]
+fn prefix_lookup_with_nocase_first_column() {
+    // Index (b, a): b is NOCASE. Prefix equality on b only.
+    let mut db = db_with_t4a();
+    run_stmt(&mut db, "CREATE INDEX i4ba ON t4a(b, a)");
+    assert_rows(&db, "SELECT c FROM t4a WHERE b = 'XYZ' ORDER BY c", &[2]);
+}
+
+#[test]
+fn composite_lookup_with_nocase_trailing_column() {
+    // Index (a, b): b (second column) is NOCASE. Full composite key.
+    let mut db = db_with_t4a();
+    run_stmt(&mut db, "CREATE INDEX i4ab2 ON t4a(a, b)");
+    assert_rows(&db, "SELECT c FROM t4a WHERE a = 'def' AND b = 'XYZ'", &[2]);
+}
+
+#[test]
+fn prefix_with_trailing_range_on_nocase_column() {
+    // Index (a, b): equality on a (BINARY prefix) + range on b (NOCASE).
+    let mut db = db_with_t4a();
+    run_stmt(&mut db, "CREATE INDEX i4ab2 ON t4a(a, b)");
+    assert_rows(&db, "SELECT c FROM t4a WHERE a = 'def' AND b > 'AAA' ORDER BY c", &[2]);
+}
+
+// ---------------------------------------------------------------------------
+// BINARY / undeclared columns keep the fast probe (regression guard)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn binary_column_equality_stays_case_sensitive_with_index() {
+    // Column a is BINARY with an index: the raw probe stays valid and
+    // case-sensitive.
+    let mut db = db_with_t4a();
+    run_stmt(&mut db, "CREATE INDEX i4aa ON t4a(a)");
+    assert_rows(&db, "SELECT c FROM t4a WHERE a = 'abc'", &[]);
+    assert_rows(&db, "SELECT c FROM t4a WHERE a = 'ABC'", &[1]);
+    assert_rows(&db, "SELECT c FROM t4a WHERE a >= 'ABC' AND a < 'ghi' ORDER BY c", &[1, 2]);
+}
+
+#[test]
+fn binary_composite_index_keeps_fast_path() {
+    // Two BINARY columns with a composite index: correctness preserved and the
+    // fast path remains eligible (no non-BINARY column to gate on).
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t7(x TEXT, y TEXT, z)");
+    run_stmt(&mut db, "INSERT INTO t7 VALUES('AA','BB',1)");
+    run_stmt(&mut db, "INSERT INTO t7 VALUES('AA','cc',2)");
+    run_stmt(&mut db, "INSERT INTO t7 VALUES('dd','ee',3)");
+    run_stmt(&mut db, "CREATE INDEX i7xy ON t7(x, y)");
+    assert_rows(&db, "SELECT z FROM t7 WHERE x = 'AA' AND y = 'BB'", &[1]);
+    // Case-sensitive: 'bb' must not match 'BB'.
+    assert_rows(&db, "SELECT z FROM t7 WHERE x = 'AA' AND y = 'bb'", &[]);
+    assert_rows(&db, "SELECT z FROM t7 WHERE x = 'AA' ORDER BY z", &[1, 2]);
+}


### PR DESCRIPTION
Closes #5823

## Problem

Sibling of #5806. Index keys are stored raw (BINARY-ordered), so an equality/range index probe built from a raw literal against a column with a non-BINARY collation (e.g. `NOCASE`) silently loses rows. The WHERE post-filter can only remove rows, never restore missed ones.

Verified reproducer (from the issue body):

```sql
CREATE TABLE t4a(a TEXT, b TEXT COLLATE nocase, c);
INSERT INTO t4a VALUES('ABC','abc',1);
INSERT INTO t4a VALUES('def','xyz',2);
INSERT INTO t4a VALUES('ghi','ghi',3);
CREATE INDEX i4ab ON t4a(b);
SELECT c FROM t4a WHERE b = 'XYZ';  -- sqlite: 2 | vibesql before: 0 rows | vibesql after: 2
```

## Fix

Mirror the #5806 gate: when a probed / covered index column has a declared non-BINARY collation, decline the probe/fast-path and fall back to the collation-aware full-scan WHERE evaluator (#5805). Collation-aware index keys remain a separate longer-term effort (explicitly out of scope).

Sites changed:

- **`select/scan/index_scan/execution.rs`** — the existing In-gate now also matches `IndexPredicate::Range` (which backs `=`, `<`, `<=`, `>`, `>=`, BETWEEN). New gates clear the composite-key, prefix-equality, and prefix+trailing-range results when any covered column has a non-BINARY collation. Shared helper `column_has_nonbinary_collation`.
- **`select/executor/fast_path/index_lookup.rs`** — the three fast-path lookups (`try_secondary_index_prefix_with_limit_fast`, `try_secondary_index_lookup_fast`, `try_covering_index_scan_fast`) skip any index covering a non-BINARY-collated column.
- **`optimizer/index_planner.rs`** — `plan_skip_scan` declines any index whose key columns carry a non-BINARY collation (the raw filter-column/prefix probes would lose rows).
- **`select/scan/index_scan/predicate/in_list.rs`** — comment-only note that `value_satisfies_range` is BINARY-only and safe only as a narrowing probe hint (correctness now guaranteed by the upstream execution.rs gate).

## Tests

New `crates/vibesql-executor/tests/equality_range_index_collation_tests.rs` (10 tests), all expected values verified against sqlite3 3.x:

- reproducer `b = 'XYZ'` returns `[2]` with **and** without the index
- range/BETWEEN variants on the indexed NOCASE column, plus an indexed-vs-unindexed oracle check
- composite (leading + trailing NOCASE), prefix-equality (leading NOCASE), and prefix+trailing-range NOCASE variants
- BINARY-column regression guards (equality/range stay case-sensitive; composite BINARY index keeps the fast path)

## Validation

| Check | Result |
|-------|--------|
| `cargo test -p vibesql-executor --test equality_range_index_collation_tests` | 10/10 pass |
| `cargo test` sibling `in_list_collation_tests` + `comparison_collation_tests` | 15/15 pass |
| index/planner lib tests (`--lib -- index_scan index_planner`) | 112/112 pass |
| index integration tests (skip_scan / index_ordering / temporal_index_probe / partial_index / multi_index_or) | all pass |
| `make test-tcl-file FILE=in4.test` | 61/61 (unchanged) |
| `collate*` TCL spot-check (collate1-5/A skipped; collate6 = 12 pass / 3 fail) | unchanged — the 3 collate6 failures are trigger/DISTINCT tests with **zero** `CREATE INDEX`, pre-existing and untouchable by an index-probe gate |

Note: a pre-existing unrelated `--lib` stack overflow (`evaluator::tests::deep_expression_tests::test_deep_case_expressions`, a debug-build deep-recursion test) is not affected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)