### PR TITLE
fix(where): use SQLite truthiness for string/blob WHERE clauses

### DIFF
--- a/crates/vibesql-executor/src/select/executor/arena_execution.rs
+++ b/crates/vibesql-executor/src/select/executor/arena_execution.rs
@@ -220,12 +220,9 @@ impl SelectExecutor<'_> {
                     SqlValue::Numeric(f) => f != 0.0,
                     // String types (SQLite coerces strings to numeric for boolean context)
                     SqlValue::Varchar(ref s) | SqlValue::Character(ref s) => string_to_truthy(s),
-                    other => {
-                        return Err(ExecutorError::TypeError(format!(
-                            "WHERE clause must evaluate to boolean, got {:?}",
-                            other
-                        )));
-                    }
+                    // Blob and any remaining scalar types: delegate to the shared
+                    // helper so BLOBs coerce via their leading-numeric prefix (#5830).
+                    ref other => crate::evaluator::operators::is_truthy(other),
                 };
                 if !is_truthy {
                     continue;

--- a/crates/vibesql-executor/src/select/executor/nonagg/without_from.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/without_from.rs
@@ -138,19 +138,12 @@ impl SelectExecutor<'_> {
                 evaluator.eval(where_clause, &empty_row)?
             };
 
-            // Check if WHERE condition is truthy (SQLite boolean semantics)
-            let is_truthy = match &where_result {
-                vibesql_types::SqlValue::Boolean(b) => *b,
-                vibesql_types::SqlValue::Null => false,
-                vibesql_types::SqlValue::Integer(n) => *n != 0,
-                vibesql_types::SqlValue::Smallint(n) => *n != 0,
-                vibesql_types::SqlValue::Bigint(n) => *n != 0,
-                vibesql_types::SqlValue::Float(f) => *f != 0.0,
-                vibesql_types::SqlValue::Real(f) => *f != 0.0,
-                vibesql_types::SqlValue::Double(f) => *f != 0.0,
-                vibesql_types::SqlValue::Numeric(n) => *n != 0.0,
-                _ => true, // Non-numeric values are truthy
-            };
+            // Check if WHERE condition is truthy (SQLite boolean semantics).
+            // Delegate to the shared helper so string/blob values coerce via
+            // their leading-numeric prefix (SQLite: `WHERE 'first'` → 0 → falsy,
+            // `WHERE '1first'` → 1 → truthy) instead of being unconditionally
+            // treated as truthy (#5830).
+            let is_truthy = crate::evaluator::operators::is_truthy(&where_result);
 
             if !is_truthy {
                 // WHERE clause is false - return empty result
@@ -312,23 +305,9 @@ impl SelectExecutor<'_> {
         let result_row = vibesql_storage::Row::new(values);
         let where_result = where_evaluator.eval(where_clause, &result_row)?;
 
-        let is_truthy = match &where_result {
-            vibesql_types::SqlValue::Boolean(b) => *b,
-            vibesql_types::SqlValue::Null => false,
-            vibesql_types::SqlValue::Integer(n) => *n != 0,
-            vibesql_types::SqlValue::Smallint(n) => *n != 0,
-            vibesql_types::SqlValue::Bigint(n) => *n != 0,
-            vibesql_types::SqlValue::Float(f) => *f != 0.0,
-            vibesql_types::SqlValue::Real(f) => *f != 0.0,
-            vibesql_types::SqlValue::Double(f) => *f != 0.0,
-            vibesql_types::SqlValue::Numeric(n) => *n != 0.0,
-            // Non-numeric, non-NULL values follow SQLite numeric coercion:
-            // strings coerce to their numeric prefix (0 when non-numeric)
-            vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
-                crate::evaluator::casting::string_to_number(s).1 != 0.0
-            }
-            _ => true,
-        };
+        // Delegate to the shared truthiness helper so string/blob values coerce
+        // via their leading-numeric prefix, matching SQLite (#5830).
+        let is_truthy = crate::evaluator::operators::is_truthy(&where_result);
 
         if !is_truthy {
             return Ok(vec![]);

--- a/crates/vibesql-executor/src/select/filter.rs
+++ b/crates/vibesql-executor/src/select/filter.rs
@@ -98,11 +98,9 @@ fn is_truthy_combined(value: &vibesql_types::SqlValue) -> Result<bool, ExecutorE
         // String types (SQLite coerces strings to numeric for boolean context)
         SqlValue::Varchar(s) | SqlValue::Character(s) => Ok(string_to_truthy(&s)),
 
-        // Error case (should be rare)
-        other => Err(ExecutorError::InvalidWhereClause(format!(
-            "WHERE clause must evaluate to boolean, got: {:?}",
-            other
-        ))),
+        // Blob and any remaining scalar types: delegate to the shared helper so
+        // BLOBs coerce via their leading-numeric prefix, matching SQLite (#5830).
+        other => Ok(crate::evaluator::operators::is_truthy(other)),
     }
 }
 
@@ -132,11 +130,9 @@ fn is_truthy_basic(value: &vibesql_types::SqlValue) -> Result<bool, ExecutorErro
         // String types (SQLite coerces strings to numeric for boolean context)
         SqlValue::Varchar(s) | SqlValue::Character(s) => Ok(string_to_truthy(&s)),
 
-        // Error case (should be rare)
-        other => Err(ExecutorError::InvalidWhereClause(format!(
-            "WHERE must evaluate to boolean, got: {:?}",
-            other
-        ))),
+        // Blob and any remaining scalar types: delegate to the shared helper so
+        // BLOBs coerce via their leading-numeric prefix, matching SQLite (#5830).
+        other => Ok(crate::evaluator::operators::is_truthy(other)),
     }
 }
 
@@ -222,12 +218,9 @@ pub(super) fn apply_where_filter_combined<'a>(
                 // String types (SQLite coerces strings to numeric for boolean context)
                 vibesql_types::SqlValue::Varchar(ref s)
                 | vibesql_types::SqlValue::Character(ref s) => string_to_truthy(s),
-                other => {
-                    return Err(ExecutorError::InvalidWhereClause(format!(
-                        "WHERE clause must evaluate to boolean, got: {:?}",
-                        other
-                    )))
-                }
+                // Blob and any remaining scalar types: delegate to the shared
+                // helper so BLOBs coerce via their leading-numeric prefix (#5830).
+                ref other => crate::evaluator::operators::is_truthy(other),
             };
 
             if include_row {

--- a/crates/vibesql-executor/src/select/iterator/filter.rs
+++ b/crates/vibesql-executor/src/select/iterator/filter.rs
@@ -78,10 +78,10 @@ impl<'a, I: RowIterator> FilterIterator<'a, I> {
                 Ok(false)
             }
             vibesql_types::SqlValue::Real(_) | vibesql_types::SqlValue::Double(_) => Ok(true),
-            other => Err(ExecutorError::InvalidWhereClause(format!(
-                "Filter expression must evaluate to boolean, got: {:?}",
-                other
-            ))),
+            // Numeric/string/blob and any remaining scalar types: delegate to the
+            // shared helper so SQLite truthiness (leading-numeric coercion) applies
+            // to text and BLOBs (#5830).
+            other => Ok(crate::evaluator::operators::is_truthy(other)),
         }
     }
 }

--- a/crates/vibesql-executor/src/select/iterator/join.rs
+++ b/crates/vibesql-executor/src/select/iterator/join.rs
@@ -264,10 +264,10 @@ impl<'schema, I: RowIterator> LazyNestedLoopJoin<'schema, I> {
                     }
                     vibesql_types::SqlValue::Double(0.0) => Ok(false),
                     vibesql_types::SqlValue::Double(_) => Ok(true),
-                    other => Err(ExecutorError::InvalidWhereClause(format!(
-                        "Join condition must evaluate to boolean, got: {:?}",
-                        other
-                    ))),
+                    // String, blob, and any remaining scalar types: delegate to
+                    // the shared helper so text/BLOBs coerce via their
+                    // leading-numeric prefix, matching SQLite (#5830).
+                    ref other => Ok(crate::evaluator::operators::is_truthy(other)),
                 }
             }
         }

--- a/crates/vibesql-executor/src/select/join/mod.rs
+++ b/crates/vibesql-executor/src/select/join/mod.rs
@@ -441,11 +441,13 @@ fn apply_post_join_filter(
             vibesql_types::SqlValue::Real(_) => filtered_rows.push(row),
             vibesql_types::SqlValue::Double(0.0) => {} // Skip 0.0
             vibesql_types::SqlValue::Double(_) => filtered_rows.push(row),
-            other => {
-                return Err(ExecutorError::InvalidWhereClause(format!(
-                    "Filter expression must evaluate to boolean, got: {:?}",
-                    other
-                )))
+            // String, blob, and any remaining scalar types: delegate to the
+            // shared helper so text/BLOBs coerce via their leading-numeric
+            // prefix, matching SQLite (#5830).
+            ref other => {
+                if crate::evaluator::operators::is_truthy(other) {
+                    filtered_rows.push(row);
+                }
             }
         }
     }

--- a/crates/vibesql-executor/src/select/join/nested_loop/condition.rs
+++ b/crates/vibesql-executor/src/select/join/nested_loop/condition.rs
@@ -29,17 +29,17 @@ pub enum EquijoinEvalStrategy {
 /// - Null -> false
 /// - Integer(0) -> false
 /// - Integer(non-zero) -> true
-/// - Other types -> error
+/// - Strings/BLOBs -> SQLite leading-numeric coercion (non-zero prefix is true)
 pub fn eval_join_condition_to_bool(value: vibesql_types::SqlValue) -> Result<bool, ExecutorError> {
     match value {
         vibesql_types::SqlValue::Boolean(b) => Ok(b),
         vibesql_types::SqlValue::Null => Ok(false),
         // SQLite treats integer 0 as false, non-zero as true
         vibesql_types::SqlValue::Integer(i) => Ok(i != 0),
-        other => Err(ExecutorError::InvalidWhereClause(format!(
-            "JOIN condition must evaluate to boolean, got: {:?}",
-            other
-        ))),
+        // Float/string/blob and any remaining scalar types: delegate to the
+        // shared helper so SQLite truthiness (leading-numeric coercion) applies
+        // (#5830).
+        ref other => Ok(crate::evaluator::operators::is_truthy(other)),
     }
 }
 

--- a/crates/vibesql-executor/src/select/join/nested_loop/mod.rs
+++ b/crates/vibesql-executor/src/select/join/nested_loop/mod.rs
@@ -567,12 +567,10 @@ pub(in crate::select::join) fn nested_loop_semi_join(
                     match value {
                         vibesql_types::SqlValue::Boolean(b) => b,
                         vibesql_types::SqlValue::Null => false,
-                        _ => {
-                            return Err(ExecutorError::InvalidWhereClause(format!(
-                                "Join condition must evaluate to boolean, got: {:?}",
-                                value
-                            )))
-                        }
+                        // Numeric/string/blob and any remaining scalar types:
+                        // delegate to the shared helper so SQLite truthiness
+                        // (leading-numeric coercion) applies (#5830).
+                        ref other => crate::evaluator::operators::is_truthy(other),
                     }
                 }
             };
@@ -689,12 +687,10 @@ pub(in crate::select::join) fn nested_loop_anti_join(
                     match value {
                         vibesql_types::SqlValue::Boolean(b) => b,
                         vibesql_types::SqlValue::Null => false,
-                        _ => {
-                            return Err(ExecutorError::InvalidWhereClause(format!(
-                                "Join condition must evaluate to boolean, got: {:?}",
-                                value
-                            )))
-                        }
+                        // Numeric/string/blob and any remaining scalar types:
+                        // delegate to the shared helper so SQLite truthiness
+                        // (leading-numeric coercion) applies (#5830).
+                        ref other => crate::evaluator::operators::is_truthy(other),
                     }
                 }
             };

--- a/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
+++ b/crates/vibesql-executor/src/select/scan/index_scan/execution.rs
@@ -990,12 +990,9 @@ fn apply_where_filter_zerocopy<'a>(
             vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
                 string_to_truthy(&s)
             }
-            other => {
-                return Err(ExecutorError::InvalidWhereClause(format!(
-                    "WHERE clause must evaluate to boolean, got: {:?}",
-                    other
-                )))
-            }
+            // Blob and any remaining scalar types: delegate to the shared helper
+            // so BLOBs coerce via their leading-numeric prefix (#5830).
+            other => crate::evaluator::operators::is_truthy(&other),
         };
 
         if include_row {
@@ -1101,12 +1098,9 @@ fn apply_where_filter_zerocopy_parallel<'a>(
                 vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
                     string_to_truthy(&s)
                 }
-                other => {
-                    return Err(ExecutorError::InvalidWhereClause(format!(
-                        "WHERE clause must evaluate to boolean, got: {:?}",
-                        other
-                    )))
-                }
+                // Blob and any remaining scalar types: delegate to the shared
+                // helper so BLOBs coerce via their leading-numeric prefix (#5830).
+                other => crate::evaluator::operators::is_truthy(&other),
             };
 
             if include_row {

--- a/crates/vibesql-executor/src/select/scan/predicates.rs
+++ b/crates/vibesql-executor/src/select/scan/predicates.rs
@@ -159,12 +159,9 @@ pub(crate) fn apply_table_local_predicates(
                 vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
                     string_to_truthy(&s)
                 }
-                other => {
-                    return Err(ExecutorError::InvalidWhereClause(format!(
-                        "WHERE clause must evaluate to boolean, got: {:?}",
-                        other
-                    )))
-                }
+                // Blob and any remaining scalar types: delegate to the shared
+                // helper so BLOBs coerce via their leading-numeric prefix (#5830).
+                other => crate::evaluator::operators::is_truthy(&other),
             };
 
             if include_row {
@@ -233,12 +230,9 @@ fn apply_predicates_parallel(
                 vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
                     string_to_truthy(&s)
                 }
-                other => {
-                    return Err(ExecutorError::InvalidWhereClause(format!(
-                        "WHERE clause must evaluate to boolean, got: {:?}",
-                        other
-                    )))
-                }
+                // Blob and any remaining scalar types: delegate to the shared
+                // helper so BLOBs coerce via their leading-numeric prefix (#5830).
+                other => crate::evaluator::operators::is_truthy(&other),
             };
 
             if include_row {
@@ -399,12 +393,9 @@ pub(crate) fn filter_and_clone_rows(
             vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
                 string_to_truthy(&s)
             }
-            other => {
-                return Err(ExecutorError::InvalidWhereClause(format!(
-                    "WHERE clause must evaluate to boolean, got: {:?}",
-                    other
-                )))
-            }
+            // Blob and any remaining scalar types: delegate to the shared helper
+            // so BLOBs coerce via their leading-numeric prefix (#5830).
+            other => crate::evaluator::operators::is_truthy(&other),
         };
 
         if include_row {

--- a/crates/vibesql-executor/src/select/vectorized/predicate.rs
+++ b/crates/vibesql-executor/src/select/vectorized/predicate.rs
@@ -186,11 +186,9 @@ fn is_truthy(value: &vibesql_types::SqlValue) -> Result<bool, ExecutorError> {
         // String types (SQLite coerces strings to numeric for boolean context)
         SqlValue::Varchar(s) | SqlValue::Character(s) => Ok(string_to_truthy(&s)),
 
-        // Error case (should be rare)
-        other => Err(ExecutorError::InvalidWhereClause(format!(
-            "WHERE clause must evaluate to boolean, got: {:?}",
-            other
-        ))),
+        // Blob and any remaining scalar types: delegate to the shared helper so
+        // BLOBs coerce via their leading-numeric prefix, matching SQLite (#5830).
+        other => Ok(crate::evaluator::operators::is_truthy(other)),
     }
 }
 

--- a/crates/vibesql-executor/tests/where_truthiness_coercion_tests.rs
+++ b/crates/vibesql-executor/tests/where_truthiness_coercion_tests.rs
@@ -1,0 +1,184 @@
+//! Differential tests vs sqlite3 for WHERE/JOIN truthiness coercion (#5830).
+//!
+//! SQLite has no boolean storage class, so a WHERE (or JOIN ON) predicate that
+//! evaluates to a non-boolean scalar is coerced to a truth value:
+//! - numbers: zero is falsy, non-zero is truthy
+//! - text/BLOB: the leading-numeric prefix is parsed (bytes read as text for
+//!   BLOBs); non-zero prefix is truthy, otherwise falsy. `'first'` → 0 (falsy),
+//!   `'1first'` → 1 (truthy).
+//!
+//! Before #5830, VibeSQL raised "Filter expression must evaluate to boolean"
+//! for string/blob WHERE values on the FROM-table paths, and the no-FROM path
+//! (`SELECT 1 WHERE 'first'`) treated any non-numeric value as truthy. Both now
+//! delegate to the shared `crate::evaluator::operators::is_truthy` helper (the
+//! same helper #5803 used to unify HAVING).
+//!
+//! Every expected value in this file was verified against sqlite3.
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+/// t(x) with a single row (1), matching the issue's reproducers.
+fn setup_t() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    let schema = vibesql_catalog::TableSchema::new(
+        "T".to_string(),
+        vec![vibesql_catalog::ColumnSchema::new(
+            "X".to_string(),
+            vibesql_types::DataType::Integer,
+            true,
+        )],
+    );
+    db.create_table(schema).unwrap();
+    db.insert_row("T", vibesql_storage::Row::new(vec![SqlValue::Integer(1)])).unwrap();
+    db
+}
+
+/// t3(x) with three rows (1),(2),(3) to exercise the multi-row filter paths.
+fn setup_t3() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    let schema = vibesql_catalog::TableSchema::new(
+        "T3".to_string(),
+        vec![vibesql_catalog::ColumnSchema::new(
+            "X".to_string(),
+            vibesql_types::DataType::Integer,
+            true,
+        )],
+    );
+    db.create_table(schema).unwrap();
+    for x in [1, 2, 3] {
+        db.insert_row("T3", vibesql_storage::Row::new(vec![SqlValue::Integer(x)])).unwrap();
+    }
+    db
+}
+
+fn run_query(db: &vibesql_storage::Database, sql: &str) -> Vec<vibesql_storage::Row> {
+    let executor = SelectExecutor::new(db);
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("parse failed for {sql}: {e:?}"));
+    let vibesql_ast::Statement::Select(select_stmt) = stmt else {
+        panic!("Expected SELECT statement: {sql}");
+    };
+    executor.execute(&select_stmt).unwrap_or_else(|e| panic!("execute failed for {sql}: {e:?}"))
+}
+
+fn row_count(db: &vibesql_storage::Database, sql: &str) -> usize {
+    run_query(db, sql).len()
+}
+
+// ---------------------------------------------------------------------------
+// Path A — FROM-table WHERE with string values (the primary reproducers)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_where_string_falsy_returns_no_rows() {
+    let db = setup_t();
+    // sqlite3: 'first' → 0 → falsy → 0 rows (previously errored)
+    assert_eq!(row_count(&db, "SELECT x FROM t WHERE 'first'"), 0);
+    // Empty and purely non-numeric strings are also falsy
+    assert_eq!(row_count(&db, "SELECT x FROM t WHERE ''"), 0);
+    assert_eq!(row_count(&db, "SELECT x FROM t WHERE 'abc'"), 0);
+    // '0' parses to 0 → falsy
+    assert_eq!(row_count(&db, "SELECT x FROM t WHERE '0'"), 0);
+}
+
+#[test]
+fn test_where_string_truthy_returns_rows() {
+    let db = setup_t();
+    // sqlite3: '1first' → 1 → truthy → the row (previously errored)
+    assert_eq!(row_count(&db, "SELECT x FROM t WHERE '1first'"), 1);
+    assert_eq!(row_count(&db, "SELECT x FROM t WHERE '1'"), 1);
+    // leading whitespace then a signed number is still parsed
+    assert_eq!(row_count(&db, "SELECT x FROM t WHERE ' -3xyz'"), 1);
+    assert_eq!(row_count(&db, "SELECT x FROM t WHERE '0.5abc'"), 1);
+}
+
+#[test]
+fn test_where_numeric_regressions() {
+    let db = setup_t();
+    // Regression guard: numeric truthiness must be unchanged.
+    assert_eq!(row_count(&db, "SELECT x FROM t WHERE 0.5"), 1);
+    assert_eq!(row_count(&db, "SELECT x FROM t WHERE 0"), 0);
+    assert_eq!(row_count(&db, "SELECT x FROM t WHERE 1"), 1);
+    assert_eq!(row_count(&db, "SELECT x FROM t WHERE 0.0"), 0);
+    // NULL is falsy
+    assert_eq!(row_count(&db, "SELECT x FROM t WHERE NULL"), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Path A — BLOB WHERE values (bytes read as text, same leading-numeric parse)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_where_blob_truthiness() {
+    let db = setup_t();
+    // x'31' is the byte "1" → truthy
+    assert_eq!(row_count(&db, "SELECT x FROM t WHERE x'31'"), 1);
+    // x'3100' is "1\0" → leading-numeric 1 → truthy (verified in sqlite3)
+    assert_eq!(row_count(&db, "SELECT x FROM t WHERE x'3100'"), 1);
+    // x'00' is a NUL byte → 0 → falsy
+    assert_eq!(row_count(&db, "SELECT x FROM t WHERE x'00'"), 0);
+    // zeroblob(4) is four NUL bytes → 0 → falsy
+    assert_eq!(row_count(&db, "SELECT x FROM t WHERE zeroblob(4)"), 0);
+    // x'6162' is "ab" → non-numeric → 0 → falsy
+    assert_eq!(row_count(&db, "SELECT x FROM t WHERE x'6162'"), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Path A — multi-row filter path (sequential FROM-table scan)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_where_string_multi_row_scan() {
+    let db = setup_t3();
+    // Constant string predicate applies to every row uniformly.
+    assert_eq!(row_count(&db, "SELECT x FROM t3 WHERE 'first'"), 0);
+    assert_eq!(row_count(&db, "SELECT x FROM t3 WHERE '1first'"), 3);
+    assert_eq!(row_count(&db, "SELECT x FROM t3 WHERE zeroblob(2)"), 0);
+    assert_eq!(row_count(&db, "SELECT x FROM t3 WHERE x'31'"), 3);
+    // Column-dependent predicate still works alongside the coercion change.
+    assert_eq!(row_count(&db, "SELECT x FROM t3 WHERE x > 1"), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Path B — no-FROM WHERE (synthetic single row)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_no_from_string_falsy_returns_no_rows() {
+    let db = setup_t();
+    // sqlite3: SELECT 1 WHERE 'first' → 0 rows (previously returned a row)
+    assert_eq!(row_count(&db, "SELECT 1 WHERE 'first'"), 0);
+    assert_eq!(row_count(&db, "SELECT 1 WHERE ''"), 0);
+    assert_eq!(row_count(&db, "SELECT 1 WHERE '0'"), 0);
+    assert_eq!(row_count(&db, "SELECT 1 WHERE zeroblob(4)"), 0);
+    assert_eq!(row_count(&db, "SELECT 1 WHERE x'00'"), 0);
+}
+
+#[test]
+fn test_no_from_string_truthy_returns_row() {
+    let db = setup_t();
+    // sqlite3: SELECT 1 WHERE '1' → 1 row
+    assert_eq!(row_count(&db, "SELECT 1 WHERE '1'"), 1);
+    assert_eq!(row_count(&db, "SELECT 1 WHERE '1first'"), 1);
+    assert_eq!(row_count(&db, "SELECT 1 WHERE x'31'"), 1);
+    // numeric regressions on the no-FROM path
+    assert_eq!(row_count(&db, "SELECT 1 WHERE 0"), 0);
+    assert_eq!(row_count(&db, "SELECT 1 WHERE 0.5"), 1);
+    assert_eq!(row_count(&db, "SELECT 1 WHERE NULL"), 0);
+}
+
+// ---------------------------------------------------------------------------
+// JOIN ON condition truthiness (same coercion class as WHERE, #5830)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_join_condition_string_truthiness() {
+    let db = setup_t();
+    // Cross join of t with itself is a single combined row; the ON predicate is
+    // coerced the same way as WHERE.
+    assert_eq!(row_count(&db, "SELECT a.x FROM t a JOIN t b ON 'first'"), 0);
+    assert_eq!(row_count(&db, "SELECT a.x FROM t a JOIN t b ON '1first'"), 1);
+    assert_eq!(row_count(&db, "SELECT a.x FROM t a JOIN t b ON x'31'"), 1);
+    assert_eq!(row_count(&db, "SELECT a.x FROM t a JOIN t b ON zeroblob(4)"), 0);
+}


### PR DESCRIPTION
## Summary

`SELECT x FROM t WHERE 'first'` used to raise *"Filter expression must evaluate to boolean, got: Varchar(\"first\")"*, and the no-FROM path `SELECT 1 WHERE 'first'` returned a row instead of none. SQLite has no boolean storage class and coerces a string/blob WHERE (or JOIN ON) predicate via a leading-numeric parse (bytes read as text for BLOBs):

| predicate | SQLite | now |
|-----------|--------|-----|
| `WHERE 'first'` | 0 rows | 0 rows |
| `WHERE '1first'` | all rows | all rows |
| `SELECT 1 WHERE 'first'` | 0 rows | 0 rows |
| `WHERE zeroblob(4)` | 0 rows | 0 rows |
| `WHERE x'31'` | all rows | all rows |

## Approach

Two divergent bug paths, both fixed by delegating to the shared `crate::evaluator::operators::is_truthy` helper (the same helper #5803 used to unify HAVING; it already handles `Blob`) instead of duplicating a partial, `Blob`-absent match block:

- **Path A** — every FROM-table / JOIN truthiness site replaced its `other => Err(...)` / `_ => return Err(...)` fallback arm with a delegation to `is_truthy`: `filter.rs` (3 sites), `scan/predicates.rs` (3), `scan/index_scan/execution.rs` (2), `join/mod.rs`, `join/nested_loop/mod.rs` (2), `join/nested_loop/condition.rs`, `iterator/filter.rs`, `iterator/join.rs`, `vectorized/predicate.rs`, `executor/arena_execution.rs`.
- **Path B** — `executor/nonagg/without_from.rs` (the no-FROM synthetic-row path) evaluated the WHERE predicate but its inline truthiness match had `_ => true`, so any string/blob was treated as truthy. Both variants (plain and alias-WHERE) now delegate to `is_truthy`.

Net −50 lines (duplicated match arms removed). Error-wording concerns (#5804) are explicitly untouched.

## Testing

- New `crates/vibesql-executor/tests/where_truthiness_coercion_tests.rs` — 8 tests covering the three issue reproducers plus blob and JOIN-condition variants; every expected value verified against `sqlite3`.
- `cargo test -p vibesql-executor --lib -- --skip deep_expression_tests` → 3096 passed, 0 failed (the skipped `deep_expression_tests` is the pre-existing debug stack-overflow, tracked as #5831).
- Filter/join integration binaries (predicate_pushdown, outer_join_predicate, group_by_always_false_where, union_branch_where_affinity, timestamp_fullscan_filter, columnar_*) all green.
- `make test-tcl-file FILE=where.test` → 168/168 passed; `where2.test` → 30/30 passed.
- Release binary spot-check of all reproducers matches sqlite3.

Closes #5830

🤖 Generated with [Claude Code](https://claude.com/claude-code)