### PR TITLE
feat(sql): enforce STRICT tables (strict1: 2→27 passing)

### DIFF
--- a/crates/vibesql-ast/src/ddl/table.rs
+++ b/crates/vibesql-ast/src/ddl/table.rs
@@ -176,6 +176,11 @@ pub struct CreateTableStmt {
     /// WITHOUT ROWID tables have no implicit rowid column and last_insert_rowid()
     /// is not updated when inserting into them.
     pub without_rowid: bool,
+    /// If true, table was created with the STRICT clause (SQLite compatibility).
+    /// STRICT tables require every column to declare one of the allowed datatypes
+    /// (INT, INTEGER, REAL, TEXT, BLOB, ANY) and enforce those types on
+    /// INSERT/UPDATE. See <https://sqlite.org/stricttables.html>.
+    pub strict: bool,
 }
 
 /// Column definition
@@ -196,6 +201,14 @@ pub struct ColumnDef {
     /// In SQLite, only `INTEGER PRIMARY KEY` is a rowid alias, not `INT PRIMARY KEY`.
     /// This distinguishes between INT and INTEGER which both parse to DataType::Integer.
     pub is_exact_integer_type: bool,
+    /// Verbatim source text of the column's declared datatype, exactly as written
+    /// (e.g. `"INT"`, `"INTEGER"`, `"TEXT(50)"`, `"DOUBLE PRECISION"`, `"BANJO"`).
+    /// `None` when the column has no declared type (typeless column) or when the
+    /// AST was built programmatically without source spans. Used by STRICT tables
+    /// to validate the datatype and echo it verbatim in error messages; the parsed
+    /// `data_type` alone is lossy (it discards `TEXT(50)`'s size and cannot
+    /// distinguish `ANY` from `BLOB`).
+    pub type_source: Option<String>,
 }
 
 /// Column-level constraint

--- a/crates/vibesql-ast/tests/ddl.rs
+++ b/crates/vibesql-ast/tests/ddl.rs
@@ -20,6 +20,7 @@ fn test_create_table_statement() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "name".to_string(),
@@ -30,6 +31,7 @@ fn test_create_table_statement() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -38,6 +40,7 @@ fn test_create_table_statement() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     });
 
     match stmt {
@@ -57,6 +60,7 @@ fn test_column_def() {
         comment: None,
         generated_expr: None,
         is_exact_integer_type: false,
+        type_source: None,
     };
     assert_eq!(col.name, "email");
     assert!(!col.nullable);

--- a/crates/vibesql-catalog/src/lib.rs
+++ b/crates/vibesql-catalog/src/lib.rs
@@ -40,7 +40,7 @@ pub use index::{IndexMetadata, IndexType, IndexedColumn, SortOrder, VectorDistan
 pub use privilege::PrivilegeGrant;
 pub use schema::Schema;
 pub use store::{Catalog, ViewDropBehavior};
-pub use table::{StorageFormat, TableSchema};
+pub use table::{StorageFormat, StrictType, TableSchema};
 pub use trigger::TriggerDefinition;
 pub use type_definition::{TypeAttribute, TypeDefinition, TypeDefinitionKind};
 pub use vibesql_ast::{ColumnIdentifier, Identifier, TableIdentifier};

--- a/crates/vibesql-catalog/src/table.rs
+++ b/crates/vibesql-catalog/src/table.rs
@@ -8,6 +8,65 @@ pub use vibesql_ast::StorageFormat;
 
 use crate::{column::ColumnSchema, foreign_key::ForeignKeyConstraint};
 
+/// The storage-type classification of a column in a SQLite STRICT table.
+///
+/// STRICT tables (<https://sqlite.org/stricttables.html>) allow exactly six
+/// declared datatypes. Each maps to a rigid runtime type that INSERT/UPDATE
+/// values must match (after the documented lossless coercions). This is kept
+/// distinct from [`vibesql_types::DataType`] because the two ends of the map
+/// are lossy: `ANY` and `BLOB` both parse to `DataType::BinaryLargeObject`, and
+/// `INT` vs `INTEGER` both parse to `DataType::Integer` — yet STRICT must treat
+/// each pair differently (ANY accepts everything; the error message echoes the
+/// exact declared keyword).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StrictType {
+    /// `INT`
+    Int,
+    /// `INTEGER`
+    Integer,
+    /// `REAL`
+    Real,
+    /// `TEXT`
+    Text,
+    /// `BLOB`
+    Blob,
+    /// `ANY` — accepts any value, stored as-is (no type check, no coercion).
+    Any,
+}
+
+impl StrictType {
+    /// The canonical declared keyword for this strict type, used verbatim in
+    /// SQLite's `cannot store <T> value in <KEYWORD> column <tbl>.<col>` errors.
+    pub fn keyword(self) -> &'static str {
+        match self {
+            StrictType::Int => "INT",
+            StrictType::Integer => "INTEGER",
+            StrictType::Real => "REAL",
+            StrictType::Text => "TEXT",
+            StrictType::Blob => "BLOB",
+            StrictType::Any => "ANY",
+        }
+    }
+
+    /// Classify a declared datatype's verbatim source text for a STRICT table.
+    ///
+    /// Returns `Some(strict_type)` only for the six allowed datatypes (matched
+    /// case-insensitively, with no size/precision specifier). Any other spelling
+    /// — including a parameterized form like `TEXT(50)` — returns `None`, which
+    /// the DDL layer reports as `unknown datatype for <tbl>.<col>: "<text>"`.
+    pub fn classify(declared_type: &str) -> Option<StrictType> {
+        match declared_type.trim().to_ascii_uppercase().as_str() {
+            "INT" => Some(StrictType::Int),
+            "INTEGER" => Some(StrictType::Integer),
+            "REAL" => Some(StrictType::Real),
+            "TEXT" => Some(StrictType::Text),
+            "BLOB" => Some(StrictType::Blob),
+            "ANY" => Some(StrictType::Any),
+            _ => None,
+        }
+    }
+}
+
 /// Table schema definition.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TableSchema {
@@ -32,6 +91,17 @@ pub struct TableSchema {
     pub rowid_alias_column: Option<usize>,
     /// If true, table was created with WITHOUT ROWID clause (SQLite compatibility).
     pub without_rowid: bool,
+    /// If true, table was created with the STRICT clause (SQLite compatibility).
+    /// STRICT tables enforce rigid per-column datatypes on INSERT/UPDATE. See
+    /// <https://sqlite.org/stricttables.html>.
+    pub strict: bool,
+    /// Per-column STRICT storage-type classification, parallel to `columns`.
+    /// Empty when the table is not STRICT. When non-empty, `strict_types[i]` is
+    /// the declared strict type of `columns[i]` (validated at CREATE time to be
+    /// one of INT/INTEGER/REAL/TEXT/BLOB/ANY). Not serialized in the binary
+    /// catalog — it is rederived from `sql_source` on load (see the storage
+    /// crate's constraint rehydration), so no binary format bump is needed.
+    pub strict_types: Vec<StrictType>,
     /// If true, this schema is a pseudo-schema standing in for a VIEW rather than
     /// a base table. Views have no implicit rowid, so references to the
     /// `rowid`/`oid`/`_rowid_` pseudo-columns against a view must error with
@@ -88,7 +158,19 @@ impl TableSchema {
             without_rowid: false,
             is_view: false,
             sql_source: None,
+            strict: false,
+            strict_types: Vec::new(),
         }
+    }
+
+    /// The STRICT storage type of the column at `col_idx`, or `None` when the
+    /// table is not STRICT (or `col_idx` is out of range). Callers use this to
+    /// gate STRICT type enforcement on INSERT/UPDATE.
+    pub fn strict_type_of(&self, col_idx: usize) -> Option<StrictType> {
+        if !self.strict {
+            return None;
+        }
+        self.strict_types.get(col_idx).copied()
     }
 
     /// Create a table schema with a primary key
@@ -112,6 +194,8 @@ impl TableSchema {
             without_rowid: false,
             is_view: false,
             sql_source: None,
+            strict: false,
+            strict_types: Vec::new(),
         }
     }
 
@@ -136,6 +220,8 @@ impl TableSchema {
             without_rowid: false,
             is_view: false,
             sql_source: None,
+            strict: false,
+            strict_types: Vec::new(),
         }
     }
 
@@ -160,6 +246,8 @@ impl TableSchema {
             without_rowid: false,
             is_view: false,
             sql_source: None,
+            strict: false,
+            strict_types: Vec::new(),
         }
     }
 
@@ -185,6 +273,8 @@ impl TableSchema {
             without_rowid: false,
             is_view: false,
             sql_source: None,
+            strict: false,
+            strict_types: Vec::new(),
         }
     }
 
@@ -212,6 +302,8 @@ impl TableSchema {
             without_rowid: false,
             is_view: false,
             sql_source: None,
+            strict: false,
+            strict_types: Vec::new(),
         }
     }
 
@@ -236,6 +328,8 @@ impl TableSchema {
             without_rowid: false,
             is_view: false,
             sql_source: None,
+            strict: false,
+            strict_types: Vec::new(),
         }
     }
 

--- a/crates/vibesql-executor/src/alter/columns.rs
+++ b/crates/vibesql-executor/src/alter/columns.rs
@@ -30,6 +30,28 @@ pub(super) fn execute_add_column(
         return Err(ExecutorError::ColumnAlreadyExists(stmt.column_def.name.clone()));
     }
 
+    // STRICT tables (issue #5837) reject a non-strict datatype on the added
+    // column, wrapping the strict error with SQLite's ALTER-context prefix:
+    // `error in table <t> after add column: <strict error>`.
+    let added_strict_type = if table.schema.strict {
+        match crate::strict::classify_strict_column(
+            &stmt.table_name,
+            &stmt.column_def.name,
+            stmt.column_def.type_source.as_deref(),
+        ) {
+            Ok(st) => Some(st),
+            Err(ExecutorError::SqliteCompatError(msg)) => {
+                return Err(ExecutorError::SqliteCompatError(format!(
+                    "error in table {} after add column: {}",
+                    stmt.table_name, msg
+                )));
+            }
+            Err(e) => return Err(e),
+        }
+    } else {
+        None
+    };
+
     // Add column to schema
     let mut new_column = ColumnSchema::new(
         stmt.column_def.name.clone(),
@@ -43,6 +65,11 @@ pub(super) fn execute_add_column(
     }
 
     table.schema_mut().add_column(new_column)?;
+
+    // Keep the parallel STRICT type vector aligned with the new column set.
+    if let Some(st) = added_strict_type {
+        table.schema_mut().strict_types.push(st);
+    }
 
     // Add default value (or NULL) to all existing rows
     let default_value = if let Some(ref default_expr) = stmt.column_def.default_value {

--- a/crates/vibesql-executor/src/constraint_validator.rs
+++ b/crates/vibesql-executor/src/constraint_validator.rs
@@ -248,6 +248,7 @@ mod tests {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }
     }
 

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -354,6 +354,17 @@ impl CreateTableExecutor {
         // Apply WITHOUT ROWID flag from AST (SQLite compatibility)
         table_schema.without_rowid = stmt.without_rowid;
 
+        // Apply STRICT flag + per-column strict types (SQLite STRICT tables,
+        // issue #5837). Validation errors (missing / unknown datatype) fire here
+        // — before the table is inserted into the catalog — so an invalid STRICT
+        // CREATE never leaves a half-formed table behind.
+        if stmt.strict {
+            let strict_types =
+                crate::strict::classify_strict_columns(&table_name, &stmt.columns)?;
+            table_schema.strict = true;
+            table_schema.strict_types = strict_types;
+        }
+
         // Apply constraint results to schema (sets PK, unique, and check constraints)
         ConstraintValidator::apply_to_schema(&mut table_schema, &constraint_result);
 

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -45,7 +45,7 @@ impl CreateTableExecutor {
     ///             constraints: vec![],
     ///             default_value: None,
     ///             comment: None,
-    ///             generated_expr: None, is_exact_integer_type: false,
+    ///             generated_expr: None, is_exact_integer_type: false, type_source: None,
     ///         },
     ///         ColumnDef {
     ///             name: "name".to_string(),
@@ -54,14 +54,14 @@ impl CreateTableExecutor {
     ///             constraints: vec![],
     ///             default_value: None,
     ///             comment: None,
-    ///             generated_expr: None, is_exact_integer_type: false,
+    ///             generated_expr: None, is_exact_integer_type: false, type_source: None,
     ///         },
     ///     ],
     ///     table_constraints: vec![],
     ///     table_options: vec![],
     ///     quoted: false,
     ///     name_source: None,
-    ///     as_query: None, without_rowid: false,
+    ///     as_query: None, without_rowid: false, strict: false,
     /// };
     ///
     /// let result = CreateTableExecutor::execute(&stmt, &mut db);

--- a/crates/vibesql-executor/src/drop_table.rs
+++ b/crates/vibesql-executor/src/drop_table.rs
@@ -39,13 +39,13 @@ impl DropTableExecutor {
     ///         constraints: vec![],
     ///         default_value: None,
     ///         comment: None,
-    ///         generated_expr: None, is_exact_integer_type: false,
+    ///         generated_expr: None, is_exact_integer_type: false, type_source: None,
     ///     }],
     ///     table_constraints: vec![],
     ///     table_options: vec![],
     ///     quoted: false,
     ///     name_source: None,
-    ///     as_query: None, without_rowid: false,
+    ///     as_query: None, without_rowid: false, strict: false,
     /// };
     /// CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
     ///

--- a/crates/vibesql-executor/src/drop_table.rs
+++ b/crates/vibesql-executor/src/drop_table.rs
@@ -165,6 +165,7 @@ mod tests {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             }],
             table_constraints: vec![],
             table_options: vec![],
@@ -172,6 +173,7 @@ mod tests {
             name_source: None,
             as_query: None,
             without_rowid: false,
+            strict: false,
         };
         CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
         assert!(db.catalog.table_exists("users"));
@@ -234,6 +236,7 @@ mod tests {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             }],
             table_constraints: vec![],
             table_options: vec![],
@@ -241,6 +244,7 @@ mod tests {
             name_source: None,
             as_query: None,
             without_rowid: false,
+            strict: false,
         };
         CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
 
@@ -275,6 +279,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
                 ColumnDef {
                     name: "name".to_string(),
@@ -285,6 +290,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
             ],
             table_constraints: vec![],
@@ -293,6 +299,7 @@ mod tests {
             name_source: None,
             as_query: None,
             without_rowid: false,
+            strict: false,
         };
         CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
 
@@ -336,6 +343,7 @@ mod tests {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             }],
             table_constraints: vec![],
             table_options: vec![],
@@ -343,6 +351,7 @@ mod tests {
             name_source: None,
             as_query: None,
             without_rowid: false,
+            strict: false,
         };
         CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
 
@@ -376,6 +385,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 }],
                 table_constraints: vec![],
                 table_options: vec![],
@@ -383,6 +393,7 @@ mod tests {
                 name_source: None,
                 as_query: None,
                 without_rowid: false,
+                strict: false,
             };
             CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
         }
@@ -418,6 +429,7 @@ mod tests {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             }],
             table_constraints: vec![],
             table_options: vec![],
@@ -425,6 +437,7 @@ mod tests {
             name_source: None,
             as_query: None,
             without_rowid: false,
+            strict: false,
         };
         CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
 
@@ -458,6 +471,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
                 ColumnDef {
                     name: "email".to_string(),
@@ -468,6 +482,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
             ],
             table_constraints: vec![],
@@ -476,6 +491,7 @@ mod tests {
             name_source: None,
             as_query: None,
             without_rowid: false,
+            strict: false,
         };
         CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
 
@@ -549,6 +565,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
                 ColumnDef {
                     name: "name".to_string(),
@@ -559,6 +576,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
             ],
             table_constraints: vec![],
@@ -567,6 +585,7 @@ mod tests {
             name_source: None,
             as_query: None,
             without_rowid: false,
+            strict: false,
         };
         CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
 
@@ -624,6 +643,7 @@ mod tests {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             }],
             table_constraints: vec![],
             table_options: vec![],
@@ -631,6 +651,7 @@ mod tests {
             name_source: None,
             as_query: None,
             without_rowid: false,
+            strict: false,
         };
         CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
 

--- a/crates/vibesql-executor/src/index_ddl/analyze.rs
+++ b/crates/vibesql-executor/src/index_ddl/analyze.rs
@@ -137,6 +137,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
                 ColumnDef {
                     name: "name".to_string(),
@@ -147,6 +148,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
                 ColumnDef {
                     name: "age".to_string(),
@@ -157,6 +159,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
             ],
             table_constraints: vec![],
@@ -165,6 +168,7 @@ mod tests {
             name_source: None,
             as_query: None,
             without_rowid: false,
+            strict: false,
         };
 
         CreateTableExecutor::execute(&stmt, db).unwrap();

--- a/crates/vibesql-executor/src/index_ddl/create_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/create_index.rs
@@ -156,6 +156,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
                 ColumnDef {
                     name: "email".to_string(),
@@ -166,6 +167,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
                 ColumnDef {
                     name: "name".to_string(),
@@ -176,6 +178,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
             ],
             table_constraints: vec![],
@@ -184,6 +187,7 @@ mod tests {
             name_source: None,
             as_query: None,
             without_rowid: false,
+            strict: false,
         };
 
         CreateTableExecutor::execute(&stmt, db).unwrap();
@@ -455,6 +459,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
                 ColumnDef {
                     name: "b".to_string(),
@@ -465,6 +470,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
             ],
             table_constraints: vec![],
@@ -473,6 +479,7 @@ mod tests {
             name_source: None,
             as_query: None,
             without_rowid: false,
+            strict: false,
         }
     }
 
@@ -593,6 +600,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
                 ColumnDef {
                     name: "embedding".to_string(),
@@ -603,6 +611,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
                 ColumnDef {
                     name: "content".to_string(),
@@ -613,6 +622,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
             ],
             table_constraints: vec![],
@@ -621,6 +631,7 @@ mod tests {
             name_source: None,
             as_query: None,
             without_rowid: false,
+            strict: false,
         };
 
         CreateTableExecutor::execute(&stmt, db).unwrap();
@@ -1018,6 +1029,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
                 vibesql_ast::ColumnDef {
                     name: "price".to_string(),
@@ -1028,6 +1040,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
                 vibesql_ast::ColumnDef {
                     name: "discount".to_string(),
@@ -1038,6 +1051,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
             ],
             table_constraints: vec![],
@@ -1046,6 +1060,7 @@ mod tests {
             name_source: None,
             as_query: None,
             without_rowid: false,
+            strict: false,
         };
         crate::CreateTableExecutor::execute(&table_stmt, &mut db).unwrap();
 

--- a/crates/vibesql-executor/src/index_ddl/drop_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/drop_index.rs
@@ -126,6 +126,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
                 ColumnDef {
                     name: "email".to_string(),
@@ -136,6 +137,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
                 ColumnDef {
                     name: "name".to_string(),
@@ -146,6 +148,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
             ],
             table_constraints: vec![],
@@ -154,6 +157,7 @@ mod tests {
             name_source: None,
             as_query: None,
             without_rowid: false,
+            strict: false,
         };
 
         CreateTableExecutor::execute(&stmt, db).unwrap();

--- a/crates/vibesql-executor/src/index_ddl/reindex.rs
+++ b/crates/vibesql-executor/src/index_ddl/reindex.rs
@@ -88,6 +88,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
                 ColumnDef {
                     name: "email".to_string(),
@@ -98,6 +99,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
                 ColumnDef {
                     name: "name".to_string(),
@@ -108,6 +110,7 @@ mod tests {
                     comment: None,
                     generated_expr: None,
                     is_exact_integer_type: false,
+                    type_source: None,
                 },
             ],
             table_constraints: vec![],
@@ -116,6 +119,7 @@ mod tests {
             name_source: None,
             as_query: None,
             without_rowid: false,
+            strict: false,
         };
 
         CreateTableExecutor::execute(&stmt, db).unwrap();

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -655,8 +655,20 @@ fn execute_insert_internal(
                 cte_results.as_ref(),
             )?;
 
-            // Type check and coerce: ensure value matches column type
-            let coerced_value = super::validation::coerce_value(value, data_type)?;
+            // Type check and coerce: ensure value matches column type.
+            // STRICT tables (issue #5837) apply SQLite's rigid strict-datatype
+            // rules (with lossless coercions) in place of the default affinity
+            // coercion, erroring with `cannot store <T> value in <T> column ...`.
+            let coerced_value = if let Some(st) = schema.strict_type_of(*col_idx) {
+                crate::strict::enforce_strict_type(
+                    value,
+                    st,
+                    &schema.name,
+                    &schema.columns[*col_idx].name,
+                )?
+            } else {
+                super::validation::coerce_value(value, data_type)?
+            };
 
             // INTEGER PRIMARY KEY validation: only accept Integer or Null (for auto-generation)
             // SQLite rejects non-integer values with "datatype mismatch"

--- a/crates/vibesql-executor/src/lib.rs
+++ b/crates/vibesql-executor/src/lib.rs
@@ -48,6 +48,7 @@ mod select_into;
 pub mod session;
 pub mod sqlite_schema;
 pub mod sqlite_stat;
+pub mod strict;
 pub mod timeout;
 mod transaction;
 mod trigger_ddl;

--- a/crates/vibesql-executor/src/select_into.rs
+++ b/crates/vibesql-executor/src/select_into.rs
@@ -61,6 +61,7 @@ impl SelectIntoExecutor {
             name_source: None,
             as_query: None,
             without_rowid: false,
+            strict: false,
         };
 
         crate::CreateTableExecutor::execute(&create_stmt, database)?;
@@ -113,6 +114,7 @@ impl SelectIntoExecutor {
                         comment: None,
                         generated_expr: None,
                         is_exact_integer_type: false, // SELECT INTO doesn't preserve exact type
+                        type_source: None,
                     });
                 }
             }

--- a/crates/vibesql-executor/src/strict.rs
+++ b/crates/vibesql-executor/src/strict.rs
@@ -1,0 +1,350 @@
+//! STRICT table enforcement (SQLite compatibility).
+//!
+//! Implements the datatype rules for SQLite STRICT tables
+//! (<https://sqlite.org/stricttables.html>):
+//!
+//! - **DDL**: every column of a STRICT table must declare exactly one of the six allowed datatypes
+//!   — `INT`, `INTEGER`, `REAL`, `TEXT`, `BLOB`, `ANY` — with no size/precision specifier. A
+//!   missing type is `missing datatype for <tbl>.<col>`; any other spelling (including `TEXT(50)`)
+//!   is `unknown datatype for <tbl>.<col>: "<text>"`.
+//! - **DML**: on INSERT/UPDATE the supplied value must match the column's strict type after the
+//!   documented lossless coercions, otherwise `cannot store <VALUE_CLASS> value in <COLUMN_KEYWORD>
+//!   column <tbl>.<col>`.
+//!
+//! The DDL layer (CREATE TABLE / ALTER TABLE ADD COLUMN) lives in
+//! `create_table.rs` / `alter.rs`; this module provides the shared helpers.
+
+use vibesql_catalog::StrictType;
+use vibesql_types::SqlValue;
+
+use crate::errors::ExecutorError;
+
+/// Validate the declared datatypes of every column of a STRICT table and return
+/// the per-column [`StrictType`] classification (parallel to `columns`).
+///
+/// Errors with the verbatim SQLite messages for a missing or unknown datatype.
+pub fn classify_strict_columns(
+    table_name: &str,
+    columns: &[vibesql_ast::ColumnDef],
+) -> Result<Vec<StrictType>, ExecutorError> {
+    let mut types = Vec::with_capacity(columns.len());
+    for col in columns {
+        types.push(classify_strict_column(table_name, &col.name, col.type_source.as_deref())?);
+    }
+    Ok(types)
+}
+
+/// Validate a single column's declared datatype for a STRICT table.
+pub fn classify_strict_column(
+    table_name: &str,
+    column_name: &str,
+    type_source: Option<&str>,
+) -> Result<StrictType, ExecutorError> {
+    match type_source {
+        None => Err(ExecutorError::SqliteCompatError(format!(
+            "missing datatype for {}.{}",
+            table_name, column_name
+        ))),
+        Some(declared) => StrictType::classify(declared).ok_or_else(|| {
+            ExecutorError::SqliteCompatError(format!(
+                "unknown datatype for {}.{}: \"{}\"",
+                table_name, column_name, declared
+            ))
+        }),
+    }
+}
+
+/// The SQLite storage-class name of `value` as it appears in the STRICT
+/// `cannot store <CLASS> value in ...` error message.
+fn value_class_name(value: &SqlValue) -> &'static str {
+    match value {
+        SqlValue::Integer(_)
+        | SqlValue::Smallint(_)
+        | SqlValue::Bigint(_)
+        | SqlValue::Unsigned(_)
+        | SqlValue::Boolean(_) => "INT",
+        SqlValue::Real(_) | SqlValue::Float(_) | SqlValue::Double(_) | SqlValue::Numeric(_) => {
+            "REAL"
+        }
+        SqlValue::Character(_) | SqlValue::Varchar(_) => "TEXT",
+        SqlValue::Blob(_) | SqlValue::Vector(_) => "BLOB",
+        // Temporal types have no native SQLite storage class; they surface as
+        // TEXT to the strict checker (they never coerce into a strict column
+        // other than ANY, so the exact label only appears in an error).
+        SqlValue::Date(_) | SqlValue::Time(_) | SqlValue::Timestamp(_) | SqlValue::Interval(_) => {
+            "TEXT"
+        }
+        SqlValue::Null => "NULL",
+    }
+}
+
+fn mismatch(value: &SqlValue, st: StrictType, table: &str, col: &str) -> ExecutorError {
+    ExecutorError::SqliteCompatError(format!(
+        "cannot store {} value in {} column {}.{}",
+        value_class_name(value),
+        st.keyword(),
+        table,
+        col
+    ))
+}
+
+/// Coerce/validate `value` for storage in a STRICT column of type `st`.
+///
+/// Returns the (possibly coerced) value to store, or a `cannot store ...`
+/// error. NULL is always accepted. `ANY` accepts and stores everything as-is.
+pub fn enforce_strict_type(
+    value: SqlValue,
+    st: StrictType,
+    table: &str,
+    col: &str,
+) -> Result<SqlValue, ExecutorError> {
+    if value.is_null() {
+        return Ok(value);
+    }
+    match st {
+        // ANY imposes no constraint and performs no coercion.
+        StrictType::Any => Ok(value),
+        StrictType::Int | StrictType::Integer => coerce_to_int(value, st, table, col),
+        StrictType::Real => coerce_to_real(value, st, table, col),
+        StrictType::Text => coerce_to_text(value, st, table, col),
+        StrictType::Blob => coerce_to_blob(value, st, table, col),
+    }
+}
+
+/// Is `f` an integer value representable in `i64` without loss?
+fn real_is_lossless_int(f: f64) -> Option<i64> {
+    if f.is_finite() && f.fract() == 0.0 && f >= i64::MIN as f64 && f <= i64::MAX as f64 {
+        Some(f as i64)
+    } else {
+        None
+    }
+}
+
+fn coerce_to_int(
+    value: SqlValue,
+    st: StrictType,
+    table: &str,
+    col: &str,
+) -> Result<SqlValue, ExecutorError> {
+    match &value {
+        SqlValue::Integer(i) => Ok(SqlValue::Integer(*i)),
+        SqlValue::Bigint(i) => Ok(SqlValue::Integer(*i)),
+        SqlValue::Smallint(i) => Ok(SqlValue::Integer(*i as i64)),
+        SqlValue::Unsigned(u) => Ok(SqlValue::Integer(*u as i64)),
+        SqlValue::Boolean(b) => Ok(SqlValue::Integer(*b as i64)),
+        // A REAL is accepted only when it has no fractional part (lossless).
+        SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f) => real_is_lossless_int(*f)
+            .map(SqlValue::Integer)
+            .ok_or_else(|| mismatch(&value, st, table, col)),
+        SqlValue::Float(f) => real_is_lossless_int(*f as f64)
+            .map(SqlValue::Integer)
+            .ok_or_else(|| mismatch(&value, st, table, col)),
+        // A TEXT value is accepted only if it losslessly represents an integer.
+        SqlValue::Varchar(s) | SqlValue::Character(s) => {
+            let t = s.trim();
+            if let Ok(i) = t.parse::<i64>() {
+                Ok(SqlValue::Integer(i))
+            } else if let Some(i) = t.parse::<f64>().ok().and_then(real_is_lossless_int) {
+                Ok(SqlValue::Integer(i))
+            } else {
+                Err(mismatch(&value, st, table, col))
+            }
+        }
+        _ => Err(mismatch(&value, st, table, col)),
+    }
+}
+
+fn coerce_to_real(
+    value: SqlValue,
+    st: StrictType,
+    table: &str,
+    col: &str,
+) -> Result<SqlValue, ExecutorError> {
+    match &value {
+        SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f) => Ok(SqlValue::Real(*f)),
+        SqlValue::Float(f) => Ok(SqlValue::Real(*f as f64)),
+        SqlValue::Integer(i) | SqlValue::Bigint(i) => Ok(SqlValue::Real(*i as f64)),
+        SqlValue::Smallint(i) => Ok(SqlValue::Real(*i as f64)),
+        SqlValue::Unsigned(u) => Ok(SqlValue::Real(*u as f64)),
+        SqlValue::Boolean(b) => Ok(SqlValue::Real(*b as i64 as f64)),
+        // TEXT accepted only if it losslessly represents a number.
+        SqlValue::Varchar(s) | SqlValue::Character(s) => match s.trim().parse::<f64>() {
+            Ok(f) => Ok(SqlValue::Real(f)),
+            Err(_) => Err(mismatch(&value, st, table, col)),
+        },
+        _ => Err(mismatch(&value, st, table, col)),
+    }
+}
+
+fn coerce_to_text(
+    value: SqlValue,
+    st: StrictType,
+    table: &str,
+    col: &str,
+) -> Result<SqlValue, ExecutorError> {
+    match &value {
+        SqlValue::Varchar(_) => Ok(value),
+        SqlValue::Character(s) => Ok(SqlValue::Varchar(s.clone())),
+        // Integers and reals coerce to their SQLite text representation.
+        SqlValue::Integer(_)
+        | SqlValue::Bigint(_)
+        | SqlValue::Smallint(_)
+        | SqlValue::Unsigned(_)
+        | SqlValue::Real(_)
+        | SqlValue::Double(_)
+        | SqlValue::Numeric(_)
+        | SqlValue::Float(_)
+        | SqlValue::Boolean(_) => {
+            Ok(SqlValue::Varchar(arcstr::ArcStr::from(value.to_string().as_str())))
+        }
+        _ => Err(mismatch(&value, st, table, col)),
+    }
+}
+
+fn coerce_to_blob(
+    value: SqlValue,
+    st: StrictType,
+    table: &str,
+    col: &str,
+) -> Result<SqlValue, ExecutorError> {
+    match &value {
+        SqlValue::Blob(_) => Ok(value),
+        _ => Err(mismatch(&value, st, table, col)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v_ok(value: SqlValue, st: StrictType) -> SqlValue {
+        enforce_strict_type(value, st, "t", "c").unwrap()
+    }
+
+    fn v_err(value: SqlValue, st: StrictType) -> String {
+        match enforce_strict_type(value, st, "t", "c") {
+            Err(ExecutorError::SqliteCompatError(m)) => m,
+            other => panic!("expected strict error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn null_always_accepted() {
+        for st in [
+            StrictType::Int,
+            StrictType::Integer,
+            StrictType::Real,
+            StrictType::Text,
+            StrictType::Blob,
+            StrictType::Any,
+        ] {
+            assert!(matches!(v_ok(SqlValue::Null, st), SqlValue::Null));
+        }
+    }
+
+    #[test]
+    fn any_passes_everything_unchanged() {
+        assert!(matches!(v_ok(SqlValue::Blob(vec![1, 2]), StrictType::Any), SqlValue::Blob(_)));
+        assert!(matches!(v_ok(SqlValue::Integer(7), StrictType::Any), SqlValue::Integer(7)));
+        assert!(matches!(
+            v_ok(SqlValue::Varchar("x".into()), StrictType::Any),
+            SqlValue::Varchar(_)
+        ));
+    }
+
+    #[test]
+    fn int_column_coercions() {
+        assert!(matches!(v_ok(SqlValue::Integer(1), StrictType::Int), SqlValue::Integer(1)));
+        // Lossless TEXT -> INT
+        assert!(matches!(
+            v_ok(SqlValue::Varchar("3".into()), StrictType::Int),
+            SqlValue::Integer(3)
+        ));
+        // Lossless REAL -> INT
+        assert!(matches!(v_ok(SqlValue::Real(6.0), StrictType::Integer), SqlValue::Integer(6)));
+        // Fractional REAL rejected
+        assert_eq!(
+            v_err(SqlValue::Real(1.2), StrictType::Int),
+            "cannot store REAL value in INT column t.c"
+        );
+        // Non-numeric TEXT rejected
+        assert_eq!(
+            v_err(SqlValue::Varchar("xyz".into()), StrictType::Int),
+            "cannot store TEXT value in INT column t.c"
+        );
+        // BLOB rejected
+        assert_eq!(
+            v_err(SqlValue::Blob(vec![1]), StrictType::Int),
+            "cannot store BLOB value in INT column t.c"
+        );
+    }
+
+    #[test]
+    fn real_column_coercions() {
+        assert!(
+            matches!(v_ok(SqlValue::Integer(1), StrictType::Real), SqlValue::Real(f) if f == 1.0)
+        );
+        assert!(
+            matches!(v_ok(SqlValue::Varchar("3".into()), StrictType::Real), SqlValue::Real(f) if f == 3.0)
+        );
+        assert!(
+            matches!(v_ok(SqlValue::Varchar("4.5".into()), StrictType::Real), SqlValue::Real(f) if f == 4.5)
+        );
+        assert_eq!(
+            v_err(SqlValue::Varchar("xyz".into()), StrictType::Real),
+            "cannot store TEXT value in REAL column t.c"
+        );
+        assert_eq!(
+            v_err(SqlValue::Blob(vec![1]), StrictType::Real),
+            "cannot store BLOB value in REAL column t.c"
+        );
+    }
+
+    #[test]
+    fn text_column_coercions() {
+        assert!(matches!(
+            v_ok(SqlValue::Varchar("x".into()), StrictType::Text),
+            SqlValue::Varchar(_)
+        ));
+        assert_eq!(v_ok(SqlValue::Integer(4), StrictType::Text).to_string(), "4");
+        assert_eq!(v_ok(SqlValue::Real(5.5), StrictType::Text).to_string(), "5.5");
+        assert_eq!(
+            v_err(SqlValue::Blob(vec![1]), StrictType::Text),
+            "cannot store BLOB value in TEXT column t.c"
+        );
+    }
+
+    #[test]
+    fn blob_column_only_accepts_blob() {
+        assert!(matches!(v_ok(SqlValue::Blob(vec![1, 2, 3]), StrictType::Blob), SqlValue::Blob(_)));
+        assert_eq!(
+            v_err(SqlValue::Integer(2), StrictType::Blob),
+            "cannot store INT value in BLOB column t.c"
+        );
+        assert_eq!(
+            v_err(SqlValue::Real(1.5), StrictType::Blob),
+            "cannot store REAL value in BLOB column t.c"
+        );
+        assert_eq!(
+            v_err(SqlValue::Varchar("x".into()), StrictType::Blob),
+            "cannot store TEXT value in BLOB column t.c"
+        );
+    }
+
+    #[test]
+    fn classify_reports_missing_and_unknown() {
+        let missing = classify_strict_column("t1", "a", None);
+        assert!(
+            matches!(missing, Err(ExecutorError::SqliteCompatError(m)) if m == "missing datatype for t1.a")
+        );
+        let unknown = classify_strict_column("t1", "f", Some("TEXT(50)"));
+        assert!(
+            matches!(unknown, Err(ExecutorError::SqliteCompatError(m)) if m == "unknown datatype for t1.f: \"TEXT(50)\"")
+        );
+        assert_eq!(
+            classify_strict_column("t1", "a", Some("integer")).unwrap(),
+            StrictType::Integer
+        );
+        assert_eq!(classify_strict_column("t1", "a", Some("any")).unwrap(), StrictType::Any);
+    }
+}

--- a/crates/vibesql-executor/src/tests/auto_increment_tests.rs
+++ b/crates/vibesql-executor/src/tests/auto_increment_tests.rs
@@ -33,6 +33,7 @@ fn test_auto_increment_basic_inserts() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "username".to_string(),
@@ -43,6 +44,7 @@ fn test_auto_increment_basic_inserts() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -51,6 +53,7 @@ fn test_auto_increment_basic_inserts() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -127,6 +130,7 @@ fn test_multiple_auto_increment_error() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "id2".to_string(),
@@ -140,6 +144,7 @@ fn test_multiple_auto_increment_error() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -148,6 +153,7 @@ fn test_multiple_auto_increment_error() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -181,6 +187,7 @@ fn test_last_insert_rowid_basic() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "username".to_string(),
@@ -191,6 +198,7 @@ fn test_last_insert_rowid_basic() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -199,6 +207,7 @@ fn test_last_insert_rowid_basic() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -277,6 +286,7 @@ fn test_last_insert_rowid_multi_row_insert() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "name".to_string(),
@@ -287,6 +297,7 @@ fn test_last_insert_rowid_multi_row_insert() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -295,6 +306,7 @@ fn test_last_insert_rowid_multi_row_insert() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -361,6 +373,7 @@ fn test_last_insert_rowid_no_auto_increment() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "name".to_string(),
@@ -371,6 +384,7 @@ fn test_last_insert_rowid_no_auto_increment() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -379,6 +393,7 @@ fn test_last_insert_rowid_no_auto_increment() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -437,6 +452,7 @@ fn test_last_insert_rowid_via_select() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "name".to_string(),
@@ -447,6 +463,7 @@ fn test_last_insert_rowid_via_select() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -455,6 +472,7 @@ fn test_last_insert_rowid_via_select() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);

--- a/crates/vibesql-executor/src/tests/create_table_constraints.rs
+++ b/crates/vibesql-executor/src/tests/create_table_constraints.rs
@@ -27,6 +27,7 @@ fn test_create_table_with_column_primary_key() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "name".to_string(),
@@ -37,6 +38,7 @@ fn test_create_table_with_column_primary_key() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -45,6 +47,7 @@ fn test_create_table_with_column_primary_key() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -72,6 +75,7 @@ fn test_create_table_with_table_primary_key() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "tenant_id".to_string(),
@@ -82,6 +86,7 @@ fn test_create_table_with_table_primary_key() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![TableConstraint {
@@ -107,6 +112,7 @@ fn test_create_table_with_table_primary_key() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -137,6 +143,7 @@ fn test_create_table_with_multiple_primary_keys_fails() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![TableConstraint {
             name: None,
@@ -154,6 +161,7 @@ fn test_create_table_with_multiple_primary_keys_fails() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -180,6 +188,7 @@ fn test_create_table_with_column_unique_constraint() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "email".to_string(),
@@ -193,6 +202,7 @@ fn test_create_table_with_column_unique_constraint() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -201,6 +211,7 @@ fn test_create_table_with_column_unique_constraint() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -228,6 +239,7 @@ fn test_create_table_with_table_unique_constraint() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "last_name".to_string(),
@@ -238,6 +250,7 @@ fn test_create_table_with_table_unique_constraint() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![TableConstraint {
@@ -263,6 +276,7 @@ fn test_create_table_with_table_unique_constraint() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -303,6 +317,7 @@ fn test_create_table_with_check_constraint() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -310,6 +325,7 @@ fn test_create_table_with_check_constraint() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -346,6 +362,7 @@ fn test_auto_index_for_single_column_primary_key() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -353,6 +370,7 @@ fn test_auto_index_for_single_column_primary_key() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -395,6 +413,7 @@ fn test_integer_primary_key_no_autoindex() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: true, // Must be true for INTEGER PRIMARY KEY rowid aliasing
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -402,6 +421,7 @@ fn test_integer_primary_key_no_autoindex() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -436,6 +456,7 @@ fn test_auto_index_for_composite_primary_key() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "b".to_string(),
@@ -446,6 +467,7 @@ fn test_auto_index_for_composite_primary_key() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![TableConstraint {
@@ -471,6 +493,7 @@ fn test_auto_index_for_composite_primary_key() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -506,6 +529,7 @@ fn test_auto_index_for_single_unique_constraint() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "email".to_string(),
@@ -519,6 +543,7 @@ fn test_auto_index_for_single_unique_constraint() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -527,6 +552,7 @@ fn test_auto_index_for_single_unique_constraint() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -563,6 +589,7 @@ fn test_auto_index_for_multiple_unique_constraints() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "email".to_string(),
@@ -576,6 +603,7 @@ fn test_auto_index_for_multiple_unique_constraints() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "phone".to_string(),
@@ -589,6 +617,7 @@ fn test_auto_index_for_multiple_unique_constraints() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -597,6 +626,7 @@ fn test_auto_index_for_multiple_unique_constraints() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -630,6 +660,7 @@ fn test_auto_index_for_composite_unique_constraint() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "b".to_string(),
@@ -640,6 +671,7 @@ fn test_auto_index_for_composite_unique_constraint() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![TableConstraint {
@@ -665,6 +697,7 @@ fn test_auto_index_for_composite_unique_constraint() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -705,6 +738,7 @@ fn test_auto_index_for_primary_key_plus_unique() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "email".to_string(),
@@ -718,6 +752,7 @@ fn test_auto_index_for_primary_key_plus_unique() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -726,6 +761,7 @@ fn test_auto_index_for_primary_key_plus_unique() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -765,6 +801,7 @@ fn test_auto_index_visible_in_catalog() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "email".to_string(),
@@ -778,6 +815,7 @@ fn test_auto_index_visible_in_catalog() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -786,6 +824,7 @@ fn test_auto_index_visible_in_catalog() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);

--- a/crates/vibesql-executor/src/tests/create_table_tests.rs
+++ b/crates/vibesql-executor/src/tests/create_table_tests.rs
@@ -35,6 +35,7 @@ fn test_create_simple_table() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "name".to_string(),
@@ -45,6 +46,7 @@ fn test_create_simple_table() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -53,6 +55,7 @@ fn test_create_simple_table() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -90,6 +93,7 @@ fn test_create_table_with_multiple_types() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "name".to_string(),
@@ -100,6 +104,7 @@ fn test_create_table_with_multiple_types() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "price".to_string(),
@@ -111,6 +116,7 @@ fn test_create_table_with_multiple_types() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "in_stock".to_string(),
@@ -121,6 +127,7 @@ fn test_create_table_with_multiple_types() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "description".to_string(),
@@ -131,6 +138,7 @@ fn test_create_table_with_multiple_types() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -139,6 +147,7 @@ fn test_create_table_with_multiple_types() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -170,6 +179,7 @@ fn test_create_table_already_exists() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -177,6 +187,7 @@ fn test_create_table_already_exists() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     // First creation succeeds
@@ -294,6 +305,7 @@ fn test_create_table_with_nullable_columns() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "middle_name".to_string(),
@@ -304,6 +316,7 @@ fn test_create_table_with_nullable_columns() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "manager_id".to_string(),
@@ -314,6 +327,7 @@ fn test_create_table_with_nullable_columns() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -322,6 +336,7 @@ fn test_create_table_with_nullable_columns() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -349,6 +364,7 @@ fn test_create_table_empty_columns_list() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     // Should succeed (though not very useful)
@@ -377,6 +393,7 @@ fn test_create_multiple_tables() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -384,6 +401,7 @@ fn test_create_multiple_tables() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&stmt1, &mut db).unwrap();
 
@@ -401,6 +419,7 @@ fn test_create_multiple_tables() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -408,6 +427,7 @@ fn test_create_multiple_tables() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&stmt2, &mut db).unwrap();
 
@@ -435,6 +455,7 @@ fn test_create_table_with_special_characters_in_name() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -442,6 +463,7 @@ fn test_create_table_with_special_characters_in_name() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -464,6 +486,7 @@ fn create_table_stmt(name: &str, quoted: bool) -> CreateTableStmt {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -471,6 +494,7 @@ fn create_table_stmt(name: &str, quoted: bool) -> CreateTableStmt {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     }
 }
 
@@ -536,6 +560,7 @@ fn test_create_table_with_spatial_types() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "location".to_string(),
@@ -546,6 +571,7 @@ fn test_create_table_with_spatial_types() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "area".to_string(),
@@ -556,6 +582,7 @@ fn test_create_table_with_spatial_types() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "regions".to_string(),
@@ -566,6 +593,7 @@ fn test_create_table_with_spatial_types() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -574,6 +602,7 @@ fn test_create_table_with_spatial_types() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);
@@ -610,6 +639,7 @@ fn test_create_table_multipolygon_sqllogictest() {
                 comment: Some("text155459".to_string()),
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "c2".to_string(),
@@ -620,6 +650,7 @@ fn test_create_table_multipolygon_sqllogictest() {
                 comment: Some("text155461".to_string()),
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -628,6 +659,7 @@ fn test_create_table_multipolygon_sqllogictest() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     let result = CreateTableExecutor::execute(&stmt, &mut db);

--- a/crates/vibesql-executor/src/tests/select_into_tests.rs
+++ b/crates/vibesql-executor/src/tests/select_into_tests.rs
@@ -21,6 +21,7 @@ fn test_select_into_single_row() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             vibesql_ast::ColumnDef {
                 name: "name".to_string(),
@@ -31,6 +32,7 @@ fn test_select_into_single_row() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -39,6 +41,7 @@ fn test_select_into_single_row() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
 
@@ -147,6 +150,7 @@ fn test_select_into_no_rows_error() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -154,6 +158,7 @@ fn test_select_into_no_rows_error() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
 
@@ -218,6 +223,7 @@ fn test_select_into_multiple_rows_error() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -225,6 +231,7 @@ fn test_select_into_multiple_rows_error() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
 
@@ -299,6 +306,7 @@ fn test_select_into_with_expressions() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -306,6 +314,7 @@ fn test_select_into_with_expressions() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
 

--- a/crates/vibesql-executor/src/tests/triggers/conditions.rs
+++ b/crates/vibesql-executor/src/tests/triggers/conditions.rs
@@ -27,6 +27,7 @@ fn test_when_clause_filters_firing() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             vibesql_ast::ColumnDef {
                 name: "amount".to_string(),
@@ -37,6 +38,7 @@ fn test_when_clause_filters_firing() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -45,6 +47,7 @@ fn test_when_clause_filters_firing() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&table_stmt, &mut db)
         .expect("Failed to create transactions table");

--- a/crates/vibesql-executor/src/tests/triggers/coordination.rs
+++ b/crates/vibesql-executor/src/tests/triggers/coordination.rs
@@ -144,6 +144,7 @@ fn test_before_trigger_executes_first() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -151,6 +152,7 @@ fn test_before_trigger_executes_first() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&counter_stmt, &mut db).expect("Failed to create counter table");
 

--- a/crates/vibesql-executor/src/tests/triggers/mod.rs
+++ b/crates/vibesql-executor/src/tests/triggers/mod.rs
@@ -42,6 +42,7 @@ pub(super) fn create_audit_table(db: &mut Database) {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -49,6 +50,7 @@ pub(super) fn create_audit_table(db: &mut Database) {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&stmt, db).expect("Failed to create audit_log table");
 }
@@ -69,6 +71,7 @@ pub(super) fn create_users_table(db: &mut Database) {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             vibesql_ast::ColumnDef {
                 name: "username".to_string(),
@@ -79,6 +82,7 @@ pub(super) fn create_users_table(db: &mut Database) {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -87,6 +91,7 @@ pub(super) fn create_users_table(db: &mut Database) {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&stmt, db).expect("Failed to create users table");
 }

--- a/crates/vibesql-executor/src/tests/truncate_cascade_tests.rs
+++ b/crates/vibesql-executor/src/tests/truncate_cascade_tests.rs
@@ -33,6 +33,7 @@ fn create_table_with_pk(db: &mut Database, table_name: &str, pk_column: &str) {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![TableConstraint {
             name: None,
@@ -50,6 +51,7 @@ fn create_table_with_pk(db: &mut Database, table_name: &str, pk_column: &str) {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&stmt, db).unwrap();
 }
@@ -78,6 +80,7 @@ fn create_table_with_fk(
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: fk_column.to_string(),
@@ -88,6 +91,7 @@ fn create_table_with_fk(
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![
@@ -121,6 +125,7 @@ fn create_table_with_fk(
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&stmt, db).unwrap();
 }

--- a/crates/vibesql-executor/src/tests/truncate_table_tests.rs
+++ b/crates/vibesql-executor/src/tests/truncate_table_tests.rs
@@ -25,6 +25,7 @@ fn test_truncate_single_table() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "NAME".to_string(),
@@ -35,6 +36,7 @@ fn test_truncate_single_table() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -43,6 +45,7 @@ fn test_truncate_single_table() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
 
@@ -95,6 +98,7 @@ fn test_truncate_multiple_tables() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -102,6 +106,7 @@ fn test_truncate_multiple_tables() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&create_stmt1, &mut db).unwrap();
 
@@ -119,6 +124,7 @@ fn test_truncate_multiple_tables() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -126,6 +132,7 @@ fn test_truncate_multiple_tables() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&create_stmt2, &mut db).unwrap();
 
@@ -143,6 +150,7 @@ fn test_truncate_multiple_tables() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -150,6 +158,7 @@ fn test_truncate_multiple_tables() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&create_stmt3, &mut db).unwrap();
 
@@ -233,6 +242,7 @@ fn test_truncate_multiple_tables_if_exists_mixed() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -240,6 +250,7 @@ fn test_truncate_multiple_tables_if_exists_mixed() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
 
@@ -281,6 +292,7 @@ fn test_truncate_multiple_tables_all_or_nothing_validation() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -288,6 +300,7 @@ fn test_truncate_multiple_tables_all_or_nothing_validation() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
 
@@ -327,6 +340,7 @@ fn test_truncate_empty_table() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         }],
         table_constraints: vec![],
         table_options: vec![],
@@ -334,6 +348,7 @@ fn test_truncate_empty_table() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
 
@@ -384,6 +399,7 @@ fn test_truncate_resets_auto_increment() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "data".to_string(),
@@ -394,6 +410,7 @@ fn test_truncate_resets_auto_increment() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -402,6 +419,7 @@ fn test_truncate_resets_auto_increment() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&stmt, &mut db).unwrap();
 
@@ -499,6 +517,7 @@ fn test_truncate_resets_auto_increment_multiple_inserts() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "value".to_string(),
@@ -509,6 +528,7 @@ fn test_truncate_resets_auto_increment_multiple_inserts() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -517,6 +537,7 @@ fn test_truncate_resets_auto_increment_multiple_inserts() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&stmt, &mut db).unwrap();
 
@@ -598,6 +619,7 @@ fn test_truncate_without_auto_increment() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "data".to_string(),
@@ -608,6 +630,7 @@ fn test_truncate_without_auto_increment() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -616,6 +639,7 @@ fn test_truncate_without_auto_increment() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
 

--- a/crates/vibesql-executor/src/truncate/mod.rs
+++ b/crates/vibesql-executor/src/truncate/mod.rs
@@ -60,13 +60,13 @@ impl TruncateTableExecutor {
     ///         constraints: vec![],
     ///         default_value: None,
     ///         comment: None,
-    ///         generated_expr: None, is_exact_integer_type: false,
+    ///         generated_expr: None, is_exact_integer_type: false, type_source: None,
     ///     }],
     ///     table_constraints: vec![],
     ///     table_options: vec![],
     ///     quoted: false,
     ///     name_source: None,
-    ///     as_query: None, without_rowid: false,
+    ///     as_query: None, without_rowid: false, strict: false,
     /// };
     /// CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
     ///

--- a/crates/vibesql-executor/src/update/value_updater.rs
+++ b/crates/vibesql-executor/src/update/value_updater.rs
@@ -124,9 +124,15 @@ impl<'a> ValueUpdater<'a> {
 
             // Apply type affinity coercion (SQLite compatibility)
             // This ensures UPDATE applies the same type conversion as INSERT
-            // e.g., UPDATE t SET r='5' on a REAL column stores 5.0, not '5'
+            // e.g., UPDATE t SET r='5' on a REAL column stores 5.0, not '5'.
+            // STRICT tables (issue #5837) apply the rigid strict-datatype rules
+            // instead, matching the INSERT strict gate.
             let column = &self.schema.columns[col_index];
-            let coerced_value = coerce_value(new_value, &column.data_type)?;
+            let coerced_value = if let Some(st) = self.schema.strict_type_of(col_index) {
+                crate::strict::enforce_strict_type(new_value, st, &self.schema.name, &column.name)?
+            } else {
+                coerce_value(new_value, &column.data_type)?
+            };
 
             // Update column in new row
             new_row

--- a/crates/vibesql-executor/tests/alter_table_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/alter_table_columnar_cache_tests.rs
@@ -87,6 +87,7 @@ fn test_add_column_invalidates_columnar_cache() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         },
     });
     AlterTableExecutor::execute(&add_col_stmt, &mut db).unwrap();
@@ -198,6 +199,7 @@ fn test_modify_column_invalidates_columnar_cache() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         },
     });
     AlterTableExecutor::execute(&modify_col_stmt, &mut db).unwrap();
@@ -261,6 +263,7 @@ fn test_change_column_invalidates_columnar_cache() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         },
     });
     AlterTableExecutor::execute(&change_col_stmt, &mut db).unwrap();
@@ -510,6 +513,7 @@ fn test_multiple_alter_operations_invalidate_cache() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         },
     });
     AlterTableExecutor::execute(&add_stmt, &mut db).unwrap();
@@ -612,6 +616,7 @@ fn test_alter_invalidates_prewarmed_cache() {
             comment: None,
             generated_expr: None,
             is_exact_integer_type: false,
+            type_source: None,
         },
     });
     AlterTableExecutor::execute(&add_stmt, &mut db).unwrap();

--- a/crates/vibesql-executor/tests/index_ordering_tests.rs
+++ b/crates/vibesql-executor/tests/index_ordering_tests.rs
@@ -22,6 +22,7 @@ fn test_index_ordering() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             vibesql_ast::ColumnDef {
                 name: "name".to_string(),
@@ -32,6 +33,7 @@ fn test_index_ordering() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -40,6 +42,7 @@ fn test_index_ordering() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     vibesql_executor::CreateTableExecutor::execute(&create_table_stmt, &mut db).unwrap();

--- a/crates/vibesql-executor/tests/spatial_index_tests.rs
+++ b/crates/vibesql-executor/tests/spatial_index_tests.rs
@@ -27,6 +27,7 @@ fn test_create_spatial_index_basic() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "location".to_string(),
@@ -37,6 +38,7 @@ fn test_create_spatial_index_basic() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -45,6 +47,7 @@ fn test_create_spatial_index_basic() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     CreateTableExecutor::execute(&create_table_stmt, &mut db).unwrap();
@@ -87,6 +90,7 @@ fn test_spatial_index_multiple_columns_error() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "location1".to_string(),
@@ -97,6 +101,7 @@ fn test_spatial_index_multiple_columns_error() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "location2".to_string(),
@@ -107,6 +112,7 @@ fn test_spatial_index_multiple_columns_error() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -115,6 +121,7 @@ fn test_spatial_index_multiple_columns_error() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     CreateTableExecutor::execute(&create_table_stmt, &mut db).unwrap();
@@ -163,6 +170,7 @@ fn test_drop_spatial_index() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "location".to_string(),
@@ -173,6 +181,7 @@ fn test_drop_spatial_index() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -181,6 +190,7 @@ fn test_drop_spatial_index() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     CreateTableExecutor::execute(&create_table_stmt, &mut db).unwrap();
@@ -230,6 +240,7 @@ fn test_spatial_index_if_not_exists() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "location".to_string(),
@@ -240,6 +251,7 @@ fn test_spatial_index_if_not_exists() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -248,6 +260,7 @@ fn test_spatial_index_if_not_exists() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
 
     CreateTableExecutor::execute(&create_table_stmt, &mut db).unwrap();

--- a/crates/vibesql-executor/tests/truncate_tests.rs
+++ b/crates/vibesql-executor/tests/truncate_tests.rs
@@ -35,6 +35,7 @@ fn create_test_table(db: &mut Database, table_name: &str) {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "data".to_string(),
@@ -45,6 +46,7 @@ fn create_test_table(db: &mut Database, table_name: &str) {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -53,6 +55,7 @@ fn create_test_table(db: &mut Database, table_name: &str) {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&create_stmt, db).unwrap();
 }
@@ -516,6 +519,7 @@ fn test_truncate_preserves_table_structure() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "email".to_string(),
@@ -526,6 +530,7 @@ fn test_truncate_preserves_table_structure() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
             ColumnDef {
                 name: "age".to_string(),
@@ -536,6 +541,7 @@ fn test_truncate_preserves_table_structure() {
                 comment: None,
                 generated_expr: None,
                 is_exact_integer_type: false,
+                type_source: None,
             },
         ],
         table_constraints: vec![],
@@ -544,6 +550,7 @@ fn test_truncate_preserves_table_structure() {
         name_source: None,
         as_query: None,
         without_rowid: false,
+        strict: false,
     };
     CreateTableExecutor::execute(&create_stmt, &mut db).unwrap();
 

--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -261,6 +261,7 @@ pub enum Keyword {
     Generated,
     Always,
     Stored,
+    Strict,
     Virtual,
     // CURSOR keywords
     Declare,
@@ -630,6 +631,7 @@ impl Keyword {
                 | Keyword::Row
                 | Keyword::Rows
                 | Keyword::Savepoint
+                | Keyword::Strict
                 | Keyword::Temp
                 | Keyword::Temporary
                 | Keyword::Ties
@@ -871,6 +873,7 @@ impl fmt::Display for Keyword {
             Keyword::Generated => "GENERATED",
             Keyword::Always => "ALWAYS",
             Keyword::Stored => "STORED",
+            Keyword::Strict => "STRICT",
             Keyword::Virtual => "VIRTUAL",
             Keyword::Declare => "DECLARE",
             Keyword::Cursor => "CURSOR",

--- a/crates/vibesql-parser/src/lexer/keywords.rs
+++ b/crates/vibesql-parser/src/lexer/keywords.rs
@@ -256,6 +256,7 @@ static KEYWORDS: phf::Map<&'static str, Keyword> = phf_map! {
     "GENERATED" => Keyword::Generated,
     "ALWAYS" => Keyword::Always,
     "STORED" => Keyword::Stored,
+    "STRICT" => Keyword::Strict,
     "VIRTUAL" => Keyword::Virtual,
     // CURSOR keywords
     "DECLARE" => Keyword::Declare,

--- a/crates/vibesql-parser/src/parser/alter.rs
+++ b/crates/vibesql-parser/src/parser/alter.rs
@@ -86,7 +86,12 @@ fn parse_add_column(
     table_name: String,
 ) -> Result<AlterTableStmt, ParseError> {
     let column_name = parser.parse_identifier()?;
+    let type_start = parser.current_position();
     let (data_type, is_exact_integer_type) = parser.parse_data_type_with_integer_flag()?;
+    // Capture the verbatim declared type text for STRICT-table validation
+    // (issue #5837): ALTER TABLE <strict> ADD COLUMN must reject non-strict
+    // datatypes just like CREATE TABLE.
+    let type_source = parser.source_between(type_start, parser.current_position());
 
     // Parse optional DEFAULT clause
     let default_value = if parser.peek_keyword(Keyword::Default) {
@@ -158,6 +163,7 @@ fn parse_add_column(
         comment: None,
         generated_expr: None,
         is_exact_integer_type,
+        type_source,
     };
 
     Ok(AlterTableStmt::AddColumn(AddColumnStmt { table_name, column_def }))
@@ -386,6 +392,7 @@ fn parse_modify_column(
         comment: None,
         generated_expr: None,
         is_exact_integer_type,
+        type_source: None,
     };
 
     Ok(AlterTableStmt::ModifyColumn(ModifyColumnStmt { table_name, column_name, new_column_def }))
@@ -475,6 +482,7 @@ fn parse_change_column(
         comment: None,
         generated_expr: None,
         is_exact_integer_type,
+        type_source: None,
     };
 
     Ok(AlterTableStmt::ChangeColumn(ChangeColumnStmt {

--- a/crates/vibesql-parser/src/parser/create/table.rs
+++ b/crates/vibesql-parser/src/parser/create/table.rs
@@ -71,6 +71,7 @@ impl Parser {
                 name_source,
                 as_query: Some(Box::new(select_stmt)),
                 without_rowid: false, // CREATE TABLE AS SELECT cannot be WITHOUT ROWID
+                strict: false,        // CREATE TABLE AS SELECT cannot be STRICT
             });
         }
 
@@ -123,7 +124,11 @@ impl Parser {
             // Parse data type (optional for SQLite compatibility)
             // SQLite allows typeless columns with BLOB affinity
             // Also check for generated column syntax: AS(expression) or GENERATED ALWAYS AS(expression)
-            let (data_type, is_exact_integer_type, mut generated_expr) =
+            // Record the token index at the start of the (optional) datatype so
+            // we can capture its verbatim source spelling for STRICT-table
+            // validation (`type_source`).
+            let type_start = self.current_position();
+            let (data_type, is_exact_integer_type, mut generated_expr, type_source) =
                 if self.peek_keyword(Keyword::As) {
                     // Generated column (short form): AS(expression)
                     self.advance(); // consume AS
@@ -136,13 +141,14 @@ impl Parser {
                     }
                     // Generated columns have the type inferred from the expression
                     // For now, use BLOB affinity (will be refined by type inference)
-                    (DataType::BinaryLargeObject, false, Some(Box::new(expr)))
+                    (DataType::BinaryLargeObject, false, Some(Box::new(expr)), None)
                 } else if self.is_column_constraint_or_separator() {
                     // No data type specified - use BLOB affinity (SQLite default)
-                    (DataType::BinaryLargeObject, false, None)
+                    (DataType::BinaryLargeObject, false, None, None)
                 } else {
                     let (dt, is_int) = self.parse_data_type_with_integer_flag()?;
-                    (dt, is_int, None)
+                    let src = self.source_between(type_start, self.current_position());
+                    (dt, is_int, None, src)
                 };
 
             // Check for GENERATED ALWAYS AS (expression) [STORED|VIRTUAL] after data type
@@ -228,6 +234,7 @@ impl Parser {
                 comment,
                 generated_expr,
                 is_exact_integer_type,
+                type_source,
             });
 
             if matches!(self.peek(), Token::Comma) {
@@ -242,23 +249,44 @@ impl Parser {
         // Parse optional table options (MySQL extensions)
         let table_options = self.parse_table_options()?;
 
-        // Parse optional WITH OIDS / WITHOUT OIDS clause (PostgreSQL)
-        // or WITHOUT ROWID clause (SQLite)
+        // Parse optional trailing table-option clauses:
+        //   WITH OIDS / WITHOUT OIDS (PostgreSQL), WITHOUT ROWID (SQLite),
+        //   and STRICT (SQLite). SQLite accepts STRICT and WITHOUT ROWID in
+        //   either order, separated by commas:
+        //     CREATE TABLE t(a INTEGER) STRICT;
+        //     CREATE TABLE t(a INTEGER) STRICT, WITHOUT ROWID;
+        //     CREATE TABLE t(a INTEGER) WITHOUT ROWID, STRICT;
         let mut without_rowid = false;
-        if self.peek_keyword(Keyword::With) {
-            self.advance(); // consume WITH
-            self.expect_keyword(Keyword::Oids)?;
-        } else if self.peek_keyword(Keyword::Without) {
-            self.advance(); // consume WITHOUT
-            if self.peek_keyword(Keyword::Oids) {
-                self.advance(); // consume OIDS
-            } else if self.peek_keyword(Keyword::Rowid) {
-                self.advance(); // consume ROWID (SQLite WITHOUT ROWID tables)
-                without_rowid = true;
+        let mut strict = false;
+        loop {
+            if self.peek_keyword(Keyword::With) {
+                self.advance(); // consume WITH
+                self.expect_keyword(Keyword::Oids)?;
+            } else if self.peek_keyword(Keyword::Without) {
+                self.advance(); // consume WITHOUT
+                if self.peek_keyword(Keyword::Oids) {
+                    self.advance(); // consume OIDS
+                } else if self.peek_keyword(Keyword::Rowid) {
+                    self.advance(); // consume ROWID (SQLite WITHOUT ROWID tables)
+                    without_rowid = true;
+                } else {
+                    return Err(ParseError {
+                        message: "Expected OIDS or ROWID after WITHOUT".to_string(),
+                    });
+                }
+            } else if self.peek_keyword(Keyword::Strict) {
+                self.advance(); // consume STRICT (SQLite STRICT tables)
+                strict = true;
             } else {
-                return Err(ParseError {
-                    message: "Expected OIDS or ROWID after WITHOUT".to_string(),
-                });
+                break;
+            }
+
+            // Table-option clauses are comma-separated; stop when the comma is
+            // absent so a trailing semicolon / EOF ends the statement.
+            if matches!(self.peek(), Token::Comma) {
+                self.advance();
+            } else {
+                break;
             }
         }
 
@@ -278,6 +306,7 @@ impl Parser {
             name_source,
             as_query: None,
             without_rowid,
+            strict,
         })
     }
 

--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -116,6 +116,20 @@ impl Parser {
         self.source.get(span.start..span.end)
     }
 
+    /// Return the verbatim source text spanning the tokens in the half-open
+    /// index range `[start, end)`, preserving the original spelling, casing, and
+    /// any embedded whitespace (e.g. `TEXT(50)`, `DOUBLE PRECISION`). Returns
+    /// `None` when span/source information is unavailable (parsers built via
+    /// [`Parser::new`]) or the range is empty/out of bounds.
+    pub(crate) fn source_between(&self, start: usize, end: usize) -> Option<String> {
+        if self.source.is_empty() || end <= start {
+            return None;
+        }
+        let start_span = self.spans.get(start)?;
+        let end_span = self.spans.get(end - 1)?;
+        self.source.get(start_span.start..end_span.end).map(str::to_string)
+    }
+
     /// Parse a comma-separated list of items using a provided parser function
     ///
     /// This is a generic helper that consolidates the common pattern of parsing

--- a/crates/vibesql-storage/src/persistence/binary/catalog.rs
+++ b/crates/vibesql-storage/src/persistence/binary/catalog.rs
@@ -1233,6 +1233,67 @@ mod tests {
         );
     }
 
+    /// Issue #5837: a STRICT table's `strict` flag and per-column strict types
+    /// must survive a binary catalog round-trip. Neither is serialized as a
+    /// dedicated field — both are rederived from the persisted `sql_source` on
+    /// load — so no binary format bump was required. ANY must remain
+    /// distinguishable from BLOB after reload.
+    #[test]
+    fn test_binary_catalog_strict_round_trip() {
+        let mut db = Database::new();
+        let make_col = |name: &str, dt: vibesql_types::DataType| {
+            let is_exact = matches!(dt, vibesql_types::DataType::Integer);
+            vibesql_catalog::ColumnSchema {
+                name: name.to_string(),
+                data_type: dt,
+                nullable: true,
+                default_value: None,
+                generated_expr: None,
+                collation: None,
+                is_exact_integer_type: is_exact,
+            }
+        };
+
+        let mut strict_schema = vibesql_catalog::TableSchema::new(
+            "t_strict".to_string(),
+            vec![
+                make_col("a", vibesql_types::DataType::Integer),
+                make_col("b", vibesql_types::DataType::BinaryLargeObject), // BLOB
+                make_col("c", vibesql_types::DataType::BinaryLargeObject), // ANY (same DataType!)
+            ],
+        );
+        strict_schema.strict = true;
+        strict_schema.strict_types = vec![
+            vibesql_catalog::StrictType::Int,
+            vibesql_catalog::StrictType::Blob,
+            vibesql_catalog::StrictType::Any,
+        ];
+        // The strict flag/types are rederived from sql_source on load.
+        strict_schema
+            .set_sql_source("CREATE TABLE t_strict(a INT, b BLOB, c ANY) STRICT".to_string());
+        db.create_table_with_identifier(
+            strict_schema,
+            vibesql_catalog::TableIdentifier::new("t_strict", false),
+        )
+        .unwrap();
+
+        let mut buf = Vec::new();
+        write_catalog(&mut buf, &db).unwrap();
+        let reloaded = read_catalog_v(&mut &buf[..], VERSION).unwrap();
+
+        let schema = &reloaded.get_table("t_strict").expect("t_strict must survive").schema;
+        assert!(schema.strict, "STRICT flag must survive binary persistence (issue #5837)");
+        assert_eq!(
+            schema.strict_types,
+            vec![
+                vibesql_catalog::StrictType::Int,
+                vibesql_catalog::StrictType::Blob,
+                vibesql_catalog::StrictType::Any,
+            ],
+            "per-column strict types (incl. ANY vs BLOB) must survive reload"
+        );
+    }
+
     /// Issue #5771: views must survive a binary catalog round-trip. Before v10
     /// the serializer had no views section at all, so every `CREATE VIEW` was
     /// silently dropped when a file-backed DB reopened from a checkpoint under

--- a/crates/vibesql-storage/src/persistence/binary/constraints.rs
+++ b/crates/vibesql-storage/src/persistence/binary/constraints.rs
@@ -147,6 +147,37 @@ pub(super) fn rehydrate_constraints_from_sql_source(
         return Ok(());
     }
 
+    // ---- STRICT flag + per-column strict types (issue #5837) ----
+    // Neither `TableSchema::strict` nor `strict_types` is serialized as a
+    // dedicated binary field; both are rederived here from the re-parsed
+    // `sql_source`, exactly like CHECK/FK constraints below. This keeps STRICT
+    // enforcement alive across a process restart without a binary format bump.
+    // A column that no longer classifies (should be impossible for a table that
+    // was accepted at CREATE time) leaves the table non-strict rather than
+    // failing the load.
+    if create.strict {
+        let mut strict_types = Vec::with_capacity(schema.columns.len());
+        let mut all_classified = true;
+        for col in &schema.columns {
+            let declared = create
+                .columns
+                .iter()
+                .find(|c| c.name.eq_ignore_ascii_case(&col.name))
+                .and_then(|c| c.type_source.as_deref());
+            match declared.and_then(vibesql_catalog::StrictType::classify) {
+                Some(st) => strict_types.push(st),
+                None => {
+                    all_classified = false;
+                    break;
+                }
+            }
+        }
+        if all_classified {
+            schema.strict = true;
+            schema.strict_types = strict_types;
+        }
+    }
+
     // ---- INTEGER PRIMARY KEY rowid aliasing (issue #5835) ----
     // Neither `TableSchema::rowid_alias_column` nor
     // `ColumnSchema::is_exact_integer_type` is serialized as a dedicated
@@ -485,6 +516,40 @@ mod tests {
         assert_eq!(fk.parent_table, "t");
         assert_eq!(fk.column_indices, vec![1]);
         assert_eq!(fk.parent_column_indices, vec![0]);
+    }
+
+    #[test]
+    fn rehydrates_strict_flag_and_per_column_types() {
+        // A STRICT table's `strict` flag and per-column strict types are not
+        // serialized as binary fields — they are rederived from `sql_source`
+        // on load (issue #5837). ANY must be distinguished from BLOB.
+        let mut schema = schema_with_source(
+            "t",
+            vec![col("a"), col("b"), col("c"), col("d")],
+            "CREATE TABLE t(a INT, b TEXT, c BLOB, d ANY) STRICT",
+        );
+        assert!(!schema.strict, "precondition: not yet rehydrated");
+        rehydrate_constraints_from_sql_source(&mut schema, &HashMap::new()).unwrap();
+
+        assert!(schema.strict);
+        assert_eq!(
+            schema.strict_types,
+            vec![
+                vibesql_catalog::StrictType::Int,
+                vibesql_catalog::StrictType::Text,
+                vibesql_catalog::StrictType::Blob,
+                vibesql_catalog::StrictType::Any,
+            ]
+        );
+    }
+
+    #[test]
+    fn non_strict_table_stays_non_strict_on_rehydrate() {
+        let mut schema =
+            schema_with_source("t", vec![col("a")], "CREATE TABLE t(a INTEGER)");
+        rehydrate_constraints_from_sql_source(&mut schema, &HashMap::new()).unwrap();
+        assert!(!schema.strict);
+        assert!(schema.strict_types.is_empty());
     }
 
     #[test]

--- a/crates/vibesql-storage/src/persistence/save.rs
+++ b/crates/vibesql-storage/src/persistence/save.rs
@@ -376,9 +376,16 @@ impl Database {
                 write!(writer, ")")
                     .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
 
-                // Add WITHOUT ROWID clause for SQLite compatibility (Issue #4803)
+                // Add WITHOUT ROWID / STRICT clauses for SQLite compatibility
+                // (Issue #4803, #5837). SQLite accepts both together, comma-
+                // separated: `) WITHOUT ROWID, STRICT`.
                 if schema.without_rowid {
                     write!(writer, " WITHOUT ROWID")
+                        .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
+                }
+                if schema.strict {
+                    let sep = if schema.without_rowid { "," } else { "" };
+                    write!(writer, "{} STRICT", sep)
                         .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
                 }
 


### PR DESCRIPTION
## Summary

SQLite `STRICT` tables were parsed but entirely unenforced (issue #5837): no DDL datatype validation, no INSERT/UPDATE type checking, and the flag was silently dropped on `CREATE`. This PR implements the full layer stack per https://sqlite.org/stricttables.html, modeled on the existing `without_rowid` flag.

**strict1.test: 2 → 27 of 49 passing.**

## What changed

**Parser / AST**
- `STRICT` added as a *non-reserved* (fallback) keyword, so `CREATE TABLE strict(...)` and `strict` as an identifier still work.
- Trailing table-options parsed as a comma-separated loop accepting `STRICT` and `WITHOUT ROWID` in **either order** (`STRICT, WITHOUT ROWID` and `WITHOUT ROWID, STRICT`).
- Each column's verbatim declared-type text is captured (`ColumnDef.type_source`). The parsed `DataType` is lossy: it discards `TEXT(50)`'s size and maps both `ANY` and `BLOB` to `BinaryLargeObject`. Added `CreateTableStmt.strict`.

**Catalog**
- New `StrictType` enum (`INT/INTEGER/REAL/TEXT/BLOB/ANY`) with `classify()`/`keyword()`. `TableSchema` gains `strict` + a parallel `strict_types` vector and a `strict_type_of()` accessor.

**Executor** (`crates/vibesql-executor/src/strict.rs`)
- **DDL**: every STRICT column must declare one of the six types → `missing datatype for t.c` / `unknown datatype for t.c: "TEXT(50)"`.
- **DML**: INSERT + UPDATE run values through the strict rules with the documented lossless coercions (`TEXT`/`REAL`→INT, `INT`/`TEXT`→REAL, `INT`/`REAL`→TEXT), `ANY` passthrough, else `cannot store <T> value in <T> column t.c`.
- **ALTER ADD COLUMN** on a STRICT table validates the new column with SQLite's `error in table t after add column:` prefix.

**Persistence — no binary format bump (per the issue body, over the curator's v14 proposal)**
- The `strict` flag + per-column types are **rederived from the persisted `sql_source`** on load, mirroring the CHECK/FK rehydration path (PR #5878). This is workable and preferable here because DDL round-trips through the full parser and `sql_source` is already persisted (v9+). Verified end-to-end: STRICT enforcement (and `ANY` vs `BLOB`) survives a save + reopen in a **fresh process**. Avoids a format bump entirely.
- SQL dump emits ` STRICT` (and `WITHOUT ROWID, STRICT` together).

## Tests
- Parser round-trips; executor strict unit matrix (each column type × value type incl. coercions, checked against sqlite3); catalog binary round-trip; `sql_source` rehydration.
- `cargo test -p vibesql-parser/-catalog/-storage/-executor` all green (3132 executor lib tests pass; the pre-existing `deep_expression` debug-stack-overflow test is unrelated).

## Before / after (strict1.test)
| | passed | failed |
|---|---|---|
| before | 2 | 47 |
| after | **27** | 22 |

Remaining 22 failures are **out of scope** and documented:
- **9.1–9.4.x (~20)** need a variadic `if()` / `iif()` conditional function (`if(...)` is currently a parse error; `iif` is 3-arg only) — a separate parser + function feature, plus strict enforcement of *generated* columns.
- **7.1** hits a pre-existing VIRTUAL generated-column evaluation bug (computes `NULL`).
- **7.3** needs typeless `ALTER ... ADD COLUMN` parsing.

`strict2.test` stays skipped (writable_schema internals), per the issue.

Closes #5837

🤖 Generated with [Claude Code](https://claude.com/claude-code)