### PR TITLE
fix(parser): make || bind tighter than * / % (SQLite precedence)

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -503,7 +503,11 @@ impl<'arena> ArenaParser<'arena> {
     }
 
     // ------------------------------------------------------------------
-    // Arithmetic tier functions (additive -> concat -> multiplicative)
+    // Arithmetic tier functions, loosest -> tightest:
+    //   additive -> multiplicative -> concat -> unary
+    // Per the SQLite grammar `||` binds tighter than `* / %`. (The arena
+    // parser has no JSON-path tier; expressions using `->` / `->>` fall back
+    // to the standard parser, which places `||`/`->`/`->>` in one shared tier.)
     //
     // Each tier comes in two forms:
     // - `parse_<tier>_expression()` parses a fresh operand (starting at the
@@ -522,7 +526,8 @@ impl<'arena> ArenaParser<'arena> {
     // ------------------------------------------------------------------
 
     /// Parse additive expression (handles +, -).
-    /// Per SQLite, || has higher precedence than + and -, so it's handled in parse_concat_expression.
+    /// Per SQLite, `+` and `-` are the loosest arithmetic operators; `* / %`
+    /// and `||` all bind tighter and are handled in the tighter tiers.
     fn parse_additive_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
         let seed = self.parse_unary_expression()?;
         self.parse_additive_expression_from(seed)
@@ -537,12 +542,48 @@ impl<'arena> ArenaParser<'arena> {
         &mut self,
         left: Expression<'arena>,
     ) -> Result<Expression<'arena>, ParseError> {
-        let mut left = self.parse_concat_expression_from(left)?;
+        let mut left = self.parse_multiplicative_expression_from(left)?;
 
         loop {
             let op = match self.peek() {
                 Token::Symbol('+') => BinaryOperator::Plus,
                 Token::Symbol('-') => BinaryOperator::Minus,
+                _ => break,
+            };
+            self.advance();
+
+            let right = self.parse_multiplicative_expression()?;
+            let left_ref = self.arena.alloc(left);
+            let right_ref = self.arena.alloc(right);
+            left = Expression::BinaryOp { op, left: left_ref, right: right_ref };
+        }
+
+        Ok(left)
+    }
+
+    /// Parse multiplicative expression.
+    fn parse_multiplicative_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
+        let seed = self.parse_unary_expression()?;
+        self.parse_multiplicative_expression_from(seed)
+    }
+
+    /// Multiplicative tier (`*`, `/`, `%`, `DIV`) with an already-parsed left operand.
+    ///
+    /// The seed is first climbed through the tighter concat tier, and each RHS
+    /// operand is parsed at the concat tier, so `||` binds tighter than
+    /// `* / % DIV`.
+    fn parse_multiplicative_expression_from(
+        &mut self,
+        left: Expression<'arena>,
+    ) -> Result<Expression<'arena>, ParseError> {
+        let mut left = self.parse_concat_expression_from(left)?;
+
+        loop {
+            let op = match self.peek() {
+                Token::Symbol('*') => BinaryOperator::Multiply,
+                Token::Symbol('/') => BinaryOperator::Divide,
+                Token::Symbol('%') => BinaryOperator::Modulo,
+                Token::Keyword { keyword: Keyword::Div, .. } => BinaryOperator::IntegerDivide,
                 _ => break,
             };
             self.advance();
@@ -557,22 +598,22 @@ impl<'arena> ArenaParser<'arena> {
     }
 
     /// Parse string concatenation expression (handles ||).
-    /// Per SQLite, || has higher precedence than + and -, but lower than * / %.
+    /// Per SQLite, `||` binds tighter than `* / %` and `+ -`.
     fn parse_concat_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
         let seed = self.parse_unary_expression()?;
         self.parse_concat_expression_from(seed)
     }
 
-    /// Concat tier (`||`) with an already-parsed left operand.
+    /// Concat tier (`||`) with an already-parsed left operand. This is the
+    /// tightest binary tier in the arena parser, so operands are parsed at the
+    /// unary tier.
     fn parse_concat_expression_from(
         &mut self,
-        left: Expression<'arena>,
+        mut left: Expression<'arena>,
     ) -> Result<Expression<'arena>, ParseError> {
-        let mut left = self.parse_multiplicative_expression_from(left)?;
-
         while self.peek() == &Token::Operator(MultiCharOperator::Concat) {
             self.advance();
-            let right = self.parse_multiplicative_expression()?;
+            let right = self.parse_unary_expression()?;
             let left_ref = self.arena.alloc(left);
             let right_ref = self.arena.alloc(right);
             left = Expression::BinaryOp {
@@ -580,36 +621,6 @@ impl<'arena> ArenaParser<'arena> {
                 left: left_ref,
                 right: right_ref,
             };
-        }
-
-        Ok(left)
-    }
-
-    /// Parse multiplicative expression.
-    fn parse_multiplicative_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
-        let seed = self.parse_unary_expression()?;
-        self.parse_multiplicative_expression_from(seed)
-    }
-
-    /// Multiplicative tier (`*`, `/`, `%`, `DIV`) with an already-parsed left operand.
-    fn parse_multiplicative_expression_from(
-        &mut self,
-        mut left: Expression<'arena>,
-    ) -> Result<Expression<'arena>, ParseError> {
-        loop {
-            let op = match self.peek() {
-                Token::Symbol('*') => BinaryOperator::Multiply,
-                Token::Symbol('/') => BinaryOperator::Divide,
-                Token::Symbol('%') => BinaryOperator::Modulo,
-                Token::Keyword { keyword: Keyword::Div, .. } => BinaryOperator::IntegerDivide,
-                _ => break,
-            };
-            self.advance();
-
-            let right = self.parse_unary_expression()?;
-            let left_ref = self.arena.alloc(left);
-            let right_ref = self.arena.alloc(right);
-            left = Expression::BinaryOp { op, left: left_ref, right: right_ref };
         }
 
         Ok(left)

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -112,7 +112,10 @@ impl Parser {
     }
 
     // ------------------------------------------------------------------
-    // Arithmetic tier functions (shift -> additive -> concat -> multiplicative)
+    // Arithmetic tier functions, loosest -> tightest:
+    //   shift -> additive -> multiplicative -> concat/JSON-path -> unary
+    // Per the SQLite grammar `||`, `->`, and `->>` share the tightest binary
+    // tier (tighter than `* / %`); they live in parse_concat_json_expression.
     //
     // Each tier comes in two forms:
     // - `parse_<tier>_expression()` parses a fresh operand (starting at the
@@ -140,8 +143,9 @@ impl Parser {
     /// Shift tier (`<<`, `>>`) with an already-parsed left operand.
     ///
     /// The seed is first climbed through the tighter tiers
-    /// (multiplicative -> concat -> additive), so this doubles as the seeded
-    /// precedence-climbing entry point used by `continue_higher_precedence_ops`.
+    /// (additive -> multiplicative -> concat/JSON-path), so this doubles as the
+    /// seeded precedence-climbing entry point used by
+    /// `continue_higher_precedence_ops`.
     fn parse_shift_expression_from(
         &mut self,
         left: vibesql_ast::Expression,
@@ -172,7 +176,8 @@ impl Parser {
     }
 
     /// Parse additive expression (handles +, -)
-    /// Per SQLite, || has higher precedence than + and -, so it's handled in parse_concat_expression
+    /// Per SQLite, `+` and `-` are the loosest arithmetic operators; `* / %`,
+    /// `||`, and `-> ->>` all bind tighter and are handled in the tighter tiers.
     pub(super) fn parse_additive_expression(
         &mut self,
     ) -> Result<vibesql_ast::Expression, ParseError> {
@@ -185,7 +190,7 @@ impl Parser {
         &mut self,
         left: vibesql_ast::Expression,
     ) -> Result<vibesql_ast::Expression, ParseError> {
-        let mut left = self.parse_concat_expression_from(left)?;
+        let mut left = self.parse_multiplicative_expression_from(left)?;
 
         loop {
             let op = match self.peek() {
@@ -195,38 +200,9 @@ impl Parser {
             };
             self.advance();
 
-            let right = self.parse_concat_expression()?;
-            left = vibesql_ast::Expression::BinaryOp {
-                op,
-                left: Box::new(left),
-                right: Box::new(right),
-            };
-        }
-
-        Ok(left)
-    }
-
-    /// Parse string concatenation expression (handles ||)
-    /// Per SQLite, || has higher precedence than + and -, but lower than * / %
-    pub(super) fn parse_concat_expression(
-        &mut self,
-    ) -> Result<vibesql_ast::Expression, ParseError> {
-        let seed = self.parse_unary_expression()?;
-        self.parse_concat_expression_from(seed)
-    }
-
-    /// Concat tier (`||`) with an already-parsed left operand.
-    fn parse_concat_expression_from(
-        &mut self,
-        left: vibesql_ast::Expression,
-    ) -> Result<vibesql_ast::Expression, ParseError> {
-        let mut left = self.parse_multiplicative_expression_from(left)?;
-
-        while self.peek() == &Token::Operator(crate::token::MultiCharOperator::Concat) {
-            self.advance();
             let right = self.parse_multiplicative_expression()?;
             left = vibesql_ast::Expression::BinaryOp {
-                op: vibesql_ast::BinaryOperator::Concat,
+                op,
                 left: Box::new(left),
                 right: Box::new(right),
             };
@@ -248,10 +224,10 @@ impl Parser {
         &mut self,
         left: vibesql_ast::Expression,
     ) -> Result<vibesql_ast::Expression, ParseError> {
-        // The JSON `->` / `->>` operators bind tighter than `* / % DIV`
-        // (per the SQLite grammar), so every multiplicative operand is first
-        // parsed at the JSON-path tier.
-        let mut left = self.parse_json_path_expression_from(left)?;
+        // The `||`, `->`, and `->>` operators share a single tier that binds
+        // tighter than `* / % DIV` (per the SQLite grammar), so every
+        // multiplicative operand is first parsed at that concat/JSON-path tier.
+        let mut left = self.parse_concat_json_expression_from(left)?;
 
         loop {
             let op = match self.peek() {
@@ -265,7 +241,7 @@ impl Parser {
             };
             self.advance();
 
-            let right = self.parse_json_path_expression()?;
+            let right = self.parse_concat_json_expression()?;
             left = vibesql_ast::Expression::BinaryOp {
                 op,
                 left: Box::new(left),
@@ -276,25 +252,31 @@ impl Parser {
         Ok(left)
     }
 
-    /// Parse a JSON path expression (handles the `->` and `->>` operators).
+    /// Parse a concat / JSON-path expression (handles `||`, `->`, and `->>`).
     ///
-    /// Per the SQLite grammar these bind one tier tighter than `* / % DIV`
-    /// and one tier looser than unary operators. They are left-associative,
-    /// so `a -> b -> c` parses as `(a -> b) -> c`.
-    pub(super) fn parse_json_path_expression(
+    /// Per the SQLite grammar these three operators share the tightest binary
+    /// tier: they bind tighter than `* / % DIV` and looser than unary
+    /// operators. They are left-associative and freely composable, so
+    /// `a || b -> c` parses as `(a || b) -> c` and `22 || 45 * 66` parses as
+    /// `(22 || 45) * 66`.
+    pub(super) fn parse_concat_json_expression(
         &mut self,
     ) -> Result<vibesql_ast::Expression, ParseError> {
         let seed = self.parse_unary_expression()?;
-        self.parse_json_path_expression_from(seed)
+        self.parse_concat_json_expression_from(seed)
     }
 
-    /// JSON path tier (`->`, `->>`) with an already-parsed left operand.
-    fn parse_json_path_expression_from(
+    /// Concat / JSON-path tier (`||`, `->`, `->>`) with an already-parsed left
+    /// operand.
+    fn parse_concat_json_expression_from(
         &mut self,
         mut left: vibesql_ast::Expression,
     ) -> Result<vibesql_ast::Expression, ParseError> {
         loop {
             let op = match self.peek() {
+                Token::Operator(crate::token::MultiCharOperator::Concat) => {
+                    vibesql_ast::BinaryOperator::Concat
+                }
                 Token::Operator(crate::token::MultiCharOperator::JsonExtract) => {
                     vibesql_ast::BinaryOperator::JsonExtract
                 }
@@ -305,9 +287,10 @@ impl Parser {
             };
             self.advance();
 
-            // The right operand is a unary expression; SQLite additionally
-            // allows an integer literal here as array-index shorthand, which
-            // the unary tier already accepts as a numeric literal.
+            // The right operand is a unary expression; for `->` / `->>` SQLite
+            // additionally allows an integer literal here as array-index
+            // shorthand, which the unary tier already accepts as a numeric
+            // literal.
             let right = self.parse_unary_expression()?;
             left = vibesql_ast::Expression::BinaryOp {
                 op,

--- a/crates/vibesql-parser/src/tests/arena_parser.rs
+++ b/crates/vibesql-parser/src/tests/arena_parser.rs
@@ -984,3 +984,105 @@ fn test_arena_not_null_shift_falls_back() {
         left
     );
 }
+
+// ============================================================================
+// `||` (Concat) precedence tests (issue #5839)
+//
+// Mirror of the standard-parser tests in tests/json_operators.rs: the arena
+// parser must agree with the standard parser so the arena fast path never
+// diverges (parse_with_arena_fallback would otherwise silently fall back).
+// Per SQLite, `||` binds TIGHTER than `* / %` and `+ -`; the canonical
+// reproducer `SELECT 22||45*66` must parse as `(22||45)*66 = 148170`.
+// ============================================================================
+
+#[test]
+fn test_arena_concat_binds_tighter_than_multiply() {
+    // 22 || 45 * 66 parses as (22 || 45) * 66
+    with_arena_select_expr("SELECT 22 || 45 * 66", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, left, .. } = expr else {
+            panic!("expected BinaryOp Multiply at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Multiply);
+        assert!(
+            matches!(
+                left,
+                vibesql_ast::arena::Expression::BinaryOp {
+                    op: vibesql_ast::BinaryOperator::Concat,
+                    ..
+                }
+            ),
+            "left operand of * should be the (22 || 45) concat node: {:?}",
+            left
+        );
+    });
+}
+
+#[test]
+fn test_arena_concat_binds_tighter_than_multiply_on_rhs() {
+    // 22 * 45 || 66 parses as 22 * (45 || 66)
+    with_arena_select_expr("SELECT 22 * 45 || 66", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, right, .. } = expr else {
+            panic!("expected BinaryOp Multiply at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Multiply);
+        assert!(
+            matches!(
+                right,
+                vibesql_ast::arena::Expression::BinaryOp {
+                    op: vibesql_ast::BinaryOperator::Concat,
+                    ..
+                }
+            ),
+            "right operand of * should be the (45 || 66) concat node: {:?}",
+            right
+        );
+    });
+}
+
+#[test]
+fn test_arena_concat_binds_tighter_than_plus() {
+    // 22 || 45 + 66 parses as (22 || 45) + 66
+    with_arena_select_expr("SELECT 22 || 45 + 66", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, left, .. } = expr else {
+            panic!("expected BinaryOp Plus at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Plus);
+        assert!(
+            matches!(
+                left,
+                vibesql_ast::arena::Expression::BinaryOp {
+                    op: vibesql_ast::BinaryOperator::Concat,
+                    ..
+                }
+            ),
+            "left operand of + should be the (22 || 45) concat node: {:?}",
+            left
+        );
+    });
+}
+
+#[test]
+fn test_arena_concat_chain_then_multiply() {
+    // 1 || 2 || 3 * 4 parses as ((1 || 2 || 3) * 4)
+    with_arena_select_expr("SELECT 1 || 2 || 3 * 4", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, left, .. } = expr else {
+            panic!("expected BinaryOp Multiply at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Multiply);
+        let vibesql_ast::arena::Expression::BinaryOp { op: cop, left: cleft, .. } = left else {
+            panic!("expected outer Concat as left operand of *, got {:?}", left);
+        };
+        assert_eq!(*cop, vibesql_ast::BinaryOperator::Concat);
+        assert!(
+            matches!(
+                cleft,
+                vibesql_ast::arena::Expression::BinaryOp {
+                    op: vibesql_ast::BinaryOperator::Concat,
+                    ..
+                }
+            ),
+            "concat chain must be left-associative: {:?}",
+            cleft
+        );
+    });
+}

--- a/crates/vibesql-parser/src/tests/json_operators.rs
+++ b/crates/vibesql-parser/src/tests/json_operators.rs
@@ -82,3 +82,84 @@ fn test_json_operator_looser_than_comparison() {
     let (inner_op, _, _) = unwrap_binop(left, "inner ->");
     assert_eq!(inner_op, vibesql_ast::BinaryOperator::JsonExtract);
 }
+
+// ========================================================================
+// `||` (Concat) precedence tests (issue #5839)
+//
+// Per the SQLite grammar `||`, `->`, and `->>` share the tightest binary
+// tier, so `||` binds TIGHTER than `* / %` and `+ -`. The canonical
+// reproducer is `SELECT 22||45*66` which must parse as `(22||45)*66` and
+// evaluate to `"2245"*66 = 148170` (not `22||(45*66) = 222970`).
+// ========================================================================
+
+#[test]
+fn test_concat_binds_tighter_than_multiply() {
+    // 22 || 45 * 66 parses as (22 || 45) * 66
+    let expr = parse_select_expr("SELECT 22 || 45 * 66;");
+    let (op, left, _) = unwrap_binop(expr, "outer *");
+    assert_eq!(op, vibesql_ast::BinaryOperator::Multiply);
+    let (inner_op, _, _) = unwrap_binop(left, "inner ||");
+    assert_eq!(inner_op, vibesql_ast::BinaryOperator::Concat);
+}
+
+#[test]
+fn test_concat_binds_tighter_than_multiply_on_rhs() {
+    // 22 * 45 || 66 parses as 22 * (45 || 66)
+    let expr = parse_select_expr("SELECT 22 * 45 || 66;");
+    let (op, _, right) = unwrap_binop(expr, "outer *");
+    assert_eq!(op, vibesql_ast::BinaryOperator::Multiply);
+    let (inner_op, _, _) = unwrap_binop(right, "inner ||");
+    assert_eq!(inner_op, vibesql_ast::BinaryOperator::Concat);
+}
+
+#[test]
+fn test_concat_binds_tighter_than_divide_and_modulo() {
+    // 22 || 45 / 3 parses as (22 || 45) / 3
+    let expr = parse_select_expr("SELECT 22 || 45 / 3;");
+    let (op, left, _) = unwrap_binop(expr, "outer /");
+    assert_eq!(op, vibesql_ast::BinaryOperator::Divide);
+    let (inner_op, _, _) = unwrap_binop(left, "inner ||");
+    assert_eq!(inner_op, vibesql_ast::BinaryOperator::Concat);
+
+    // 22 || 45 % 7 parses as (22 || 45) % 7
+    let expr = parse_select_expr("SELECT 22 || 45 % 7;");
+    let (op, left, _) = unwrap_binop(expr, "outer %");
+    assert_eq!(op, vibesql_ast::BinaryOperator::Modulo);
+    let (inner_op, _, _) = unwrap_binop(left, "inner ||");
+    assert_eq!(inner_op, vibesql_ast::BinaryOperator::Concat);
+}
+
+#[test]
+fn test_concat_binds_tighter_than_plus() {
+    // 22 || 45 + 66 parses as (22 || 45) + 66
+    let expr = parse_select_expr("SELECT 22 || 45 + 66;");
+    let (op, left, _) = unwrap_binop(expr, "outer +");
+    assert_eq!(op, vibesql_ast::BinaryOperator::Plus);
+    let (inner_op, _, _) = unwrap_binop(left, "inner ||");
+    assert_eq!(inner_op, vibesql_ast::BinaryOperator::Concat);
+}
+
+#[test]
+fn test_concat_chain_then_multiply() {
+    // 1 || 2 || 3 * 4 parses as ((1 || 2 || 3) * 4); the left-associative
+    // concat chain is the tighter operand of the multiply.
+    let expr = parse_select_expr("SELECT 1 || 2 || 3 * 4;");
+    let (op, left, _) = unwrap_binop(expr, "outer *");
+    assert_eq!(op, vibesql_ast::BinaryOperator::Multiply);
+    let (concat_op, concat_left, _) = unwrap_binop(left, "outer ||");
+    assert_eq!(concat_op, vibesql_ast::BinaryOperator::Concat);
+    // Left of the outer || is itself a || (left-associative chain).
+    let (inner_op, _, _) = unwrap_binop(concat_left, "inner ||");
+    assert_eq!(inner_op, vibesql_ast::BinaryOperator::Concat);
+}
+
+#[test]
+fn test_concat_and_json_share_tier_left_associative() {
+    // a -> 'k' || 'x' parses as (a -> 'k') || 'x' — `||` and `->` share one
+    // left-associative tier.
+    let expr = parse_select_expr("SELECT a -> 'k' || 'x';");
+    let (op, left, _) = unwrap_binop(expr, "outer ||");
+    assert_eq!(op, vibesql_ast::BinaryOperator::Concat);
+    let (inner_op, _, _) = unwrap_binop(left, "inner ->");
+    assert_eq!(inner_op, vibesql_ast::BinaryOperator::JsonExtract);
+}


### PR DESCRIPTION
## Summary

Per the SQLite grammar, `||`, `->`, and `->>` share the **tightest** binary operator tier — tighter than `* / %` and `+ -`. VibeSQL parsed `||` one tier *looser* than `* / %`, so `SELECT 22||45*66` evaluated as `22||(45*66) = 222970` instead of the SQLite-correct `(22||45)*66 = '2245'*66 = 148170`.

Closes #5839

## Changes

Both parser paths are fixed:

- **Standard parser** (`crates/vibesql-parser/src/parser/expressions/operators.rs`): fold `Concat` into the JSON-path tier introduced by #5903 (renamed to `parse_concat_json_expression`) so `||`/`->`/`->>` share one left-associative tier tighter than `* / %`. The additive tier now delegates straight to the multiplicative tier; the dead standalone concat tier is removed.
- **Arena parser** (`crates/vibesql-parser/src/arena_parser/expression.rs`): tier-swap to `additive -> multiplicative -> concat -> unary`. The arena parser has no JSON-path tier (`->`/`->>` fall back to the standard parser).

No AST changes — the `Concat` operator already existed; only the precedence nesting moved.

## Verification

Battery of mixed-precedence expressions verified equal to `sqlite3`:

| Expression | VibeSQL | sqlite3 |
|---|---|---|
| `22\|\|45*66` | 148170 | 148170 |
| `22\|\|45/3` | 748 | 748 |
| `22\|\|45%7` | 5 | 5 |
| `22\|\|45+66` | 2311 | 2311 |
| `22*45\|\|66` | 100452 | 100452 |
| `1\|\|2\|\|3*4` | 492 | 492 |
| `2*3\|\|4*5` | 340 | 340 |

## Test results

- **e_expr.test**: **345/374 -> 374/374** (all 29 concat-precedence failures fixed)
- `cargo test -p vibesql-parser`: 1623 passed, 0 failed (adds standard + arena precedence unit tests in `tests/json_operators.rs` and `tests/arena_parser.rs`)
- `cargo test -p vibesql-executor`: 0 failed
- **select1.test** canary: 188/188 (no regression)
- JSON operator tests (same tier as this change): unchanged / passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)