### PR TITLE
fix(parser): acceptance batch — ROLLBACK TO/RELEASE shorthand, ADD COLUMN without type, numeric tokenizer, identifier edge cases

### DIFF
--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -832,15 +832,27 @@ impl ExpressionEvaluator<'_> {
                         SqlValue::Integer(n) => *n != 0,
                         SqlValue::Bigint(n) => *n != 0,
                         SqlValue::Smallint(n) => *n != 0,
+                        // REAL/floating values are truthy when non-zero (and not
+                        // NaN), matching SQLite: `0.5 IS TRUE` -> 1, `0.0 IS
+                        // TRUE` -> 0.
+                        SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f) => {
+                            *f != 0.0 && !f.is_nan()
+                        }
+                        SqlValue::Float(f) => *f != 0.0 && !f.is_nan(),
                         _ => false,
                     },
-                    vibesql_ast::TruthValue::False => matches!(
-                        val,
+                    vibesql_ast::TruthValue::False => match &val {
                         SqlValue::Boolean(false)
-                            | SqlValue::Integer(0)
-                            | SqlValue::Bigint(0)
-                            | SqlValue::Smallint(0)
-                    ),
+                        | SqlValue::Integer(0)
+                        | SqlValue::Bigint(0)
+                        | SqlValue::Smallint(0) => true,
+                        // A floating value equal to zero is FALSE.
+                        SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f) => {
+                            *f == 0.0
+                        }
+                        SqlValue::Float(f) => *f == 0.0,
+                        _ => false,
+                    },
                     vibesql_ast::TruthValue::Unknown => matches!(val, SqlValue::Null),
                 };
                 let final_result = if *negated { !result } else { result };

--- a/crates/vibesql-executor/tests/is_truthvalue_real_tests.rs
+++ b/crates/vibesql-executor/tests/is_truthvalue_real_tests.rs
@@ -1,0 +1,72 @@
+//! Regression tests for issue #5841 (item 5): `x IS TRUE` / `x IS FALSE`
+//! must apply SQLite truthiness to REAL / floating-point values.
+//!
+//! SQLite treats any non-zero, non-NULL numeric value (including REAL) as
+//! TRUE, and zero as FALSE:
+//!
+//! - `0.5 IS TRUE`  -> 1
+//! - `0.0 IS TRUE`  -> 0
+//! - `0.5 IS FALSE` -> 0
+//! - `0.0 IS FALSE` -> 1
+//!
+//! Expected values below were verified against sqlite3.
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+fn query_scalar(db: &vibesql_storage::Database, sql: &str) -> SqlValue {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        let rows = executor
+            .execute(&select_stmt)
+            .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e));
+        assert_eq!(rows.len(), 1, "Expected exactly one row for: {}", sql);
+        assert_eq!(rows[0].values.len(), 1, "Expected exactly one column for: {}", sql);
+        match &rows[0].values[0] {
+            SqlValue::Boolean(b) => SqlValue::Integer(*b as i64),
+            other => other.clone(),
+        }
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+fn assert_query(db: &vibesql_storage::Database, sql: &str, expected: SqlValue) {
+    let actual = query_scalar(db, sql);
+    assert_eq!(actual, expected, "Query: {} -- expected {:?}, got {:?}", sql, expected, actual);
+}
+
+#[test]
+fn real_nonzero_is_true() {
+    let db = vibesql_storage::Database::new();
+    assert_query(&db, "SELECT 0.5 IS TRUE", SqlValue::Integer(1));
+    assert_query(&db, "SELECT 1.0 IS TRUE", SqlValue::Integer(1));
+    assert_query(&db, "SELECT -2.5 IS TRUE", SqlValue::Integer(1));
+}
+
+#[test]
+fn real_zero_is_not_true() {
+    let db = vibesql_storage::Database::new();
+    assert_query(&db, "SELECT 0.0 IS TRUE", SqlValue::Integer(0));
+}
+
+#[test]
+fn real_zero_is_false() {
+    let db = vibesql_storage::Database::new();
+    assert_query(&db, "SELECT 0.0 IS FALSE", SqlValue::Integer(1));
+}
+
+#[test]
+fn real_nonzero_is_not_false() {
+    let db = vibesql_storage::Database::new();
+    assert_query(&db, "SELECT 0.5 IS FALSE", SqlValue::Integer(0));
+}
+
+#[test]
+fn real_is_not_true_negation() {
+    let db = vibesql_storage::Database::new();
+    // 0.5 IS NOT TRUE -> 0 ; 0.0 IS NOT TRUE -> 1
+    assert_query(&db, "SELECT 0.5 IS NOT TRUE", SqlValue::Integer(0));
+    assert_query(&db, "SELECT 0.0 IS NOT TRUE", SqlValue::Integer(1));
+}

--- a/crates/vibesql-parser/src/arena_parser/ddl.rs
+++ b/crates/vibesql-parser/src/arena_parser/ddl.rs
@@ -100,7 +100,8 @@ impl<'arena> ArenaParser<'arena> {
     ) -> Result<RollbackToSavepointStmt, ParseError> {
         self.consume_keyword(Keyword::Rollback)?;
         self.consume_keyword(Keyword::To)?;
-        self.consume_keyword(Keyword::Savepoint)?;
+        // SAVEPOINT keyword is optional in SQLite: `ROLLBACK TO <name>`.
+        self.try_consume_keyword(Keyword::Savepoint);
         let name = self.parse_arena_identifier()?;
         Ok(RollbackToSavepointStmt { name })
     }
@@ -117,7 +118,8 @@ impl<'arena> ArenaParser<'arena> {
         &mut self,
     ) -> Result<ReleaseSavepointStmt, ParseError> {
         self.consume_keyword(Keyword::Release)?;
-        self.consume_keyword(Keyword::Savepoint)?;
+        // SAVEPOINT keyword is optional in SQLite: `RELEASE <name>`.
+        self.try_consume_keyword(Keyword::Savepoint);
         let name = self.parse_arena_identifier()?;
         Ok(ReleaseSavepointStmt { name })
     }

--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -315,8 +315,11 @@ impl<'arena> ArenaParser<'arena> {
                 self.advance();
                 self.intern(&name)
             }
-            // Allow unreserved keywords (like NULLS, TIMESTAMP, etc.) as CTE names
-            Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+            // Allow unreserved keywords (like NULLS, TIMESTAMP, etc.) and SQLite
+            // fallback keywords (like ROWS) as CTE names.
+            Token::Keyword { keyword: kw, .. }
+                if kw.can_be_identifier() || kw.is_sqlite_fallback_keyword() =>
+            {
                 let name = format!("{}", kw).to_lowercase();
                 self.advance();
                 self.intern(&name)

--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -607,6 +607,7 @@ impl Keyword {
                 | Keyword::Instead
                 | Keyword::Key
                 | Keyword::Last
+                | Keyword::Level
                 | Keyword::Like
                 | Keyword::Match
                 | Keyword::Materialized
@@ -636,6 +637,8 @@ impl Keyword {
                 | Keyword::Temporary
                 | Keyword::Ties
                 | Keyword::Trigger
+                | Keyword::True
+                | Keyword::False
                 | Keyword::Unbounded
                 | Keyword::Vacuum
                 | Keyword::View

--- a/crates/vibesql-parser/src/lexer/numbers.rs
+++ b/crates/vibesql-parser/src/lexer/numbers.rs
@@ -31,12 +31,19 @@ impl<'a> Lexer<'a> {
             let ch = self.current_char();
             if ch.is_ascii_digit() {
                 self.advance();
-            } else if ch == '_' && !has_dot {
-                // SQLite 3.46+ supports underscores as digit separators in integer literals
-                // e.g., 1_000_000_000, 10_000
-                // Only allowed between digits, not in decimal/float parts
-                has_underscore = true;
-                self.advance();
+            } else if ch == '_' {
+                // SQLite 3.46+ supports underscores as digit separators in
+                // numeric literals (e.g. 1_000_000, 1.1_1). An underscore is
+                // only valid when surrounded on both sides by digits — this
+                // holds in both the integer and fractional parts. When it is
+                // not between two digits (e.g. `1_.5`) we stop here and let the
+                // trailing-character check below reject the malformed token.
+                if self.underscore_between_digits(start) {
+                    has_underscore = true;
+                    self.advance();
+                } else {
+                    break;
+                }
             } else if ch == '.' && !has_dot {
                 has_dot = true;
                 self.advance();
@@ -59,10 +66,20 @@ impl<'a> Lexer<'a> {
                     }
                 }
 
-                // Exponent digits (required)
+                // Exponent digits (required). Underscore separators are also
+                // permitted here as long as they sit between two digits
+                // (e.g. `1e1_0`).
                 let exp_start = self.position();
-                while !self.is_eof() && self.current_char().is_ascii_digit() {
-                    self.advance();
+                while !self.is_eof() {
+                    let ch = self.current_char();
+                    if ch.is_ascii_digit() {
+                        self.advance();
+                    } else if ch == '_' && self.underscore_between_digits(start) {
+                        has_underscore = true;
+                        self.advance();
+                    } else {
+                        break;
+                    }
                 }
 
                 // Verify we got at least one exponent digit
@@ -78,6 +95,13 @@ impl<'a> Lexer<'a> {
             }
         }
 
+        // A numeric literal that runs directly into an identifier character
+        // (letter or underscore) is a malformed token, not a value followed by
+        // an alias. SQLite rejects these: `123a456`, `1FROM`, `1.5x` all raise
+        // "unrecognized token". Previously the lexer split them into a number
+        // plus an identifier, silently changing the meaning.
+        self.reject_trailing_identifier_char(start)?;
+
         let number = self.slice_from(start).to_string();
         // Strip underscores from the token value so downstream sees a plain number
         if has_underscore {
@@ -86,6 +110,38 @@ impl<'a> Lexer<'a> {
         } else {
             Ok(Token::Number(number))
         }
+    }
+
+    /// Whether the underscore at the current position sits directly between two
+    /// digits. `start` is the byte offset where the number literal began, used
+    /// to guard against reading before the token.
+    #[inline]
+    fn underscore_between_digits(&self, start: usize) -> bool {
+        let prev_is_digit =
+            self.position() > start && self.input.as_bytes()[self.position() - 1].is_ascii_digit();
+        let next_is_digit = self.peek_byte(1).map(|b| b.is_ascii_digit()).unwrap_or(false);
+        prev_is_digit && next_is_digit
+    }
+
+    /// Reject a numeric literal that is immediately followed by an identifier
+    /// character (an ASCII/Unicode letter or an underscore). SQLite treats
+    /// `123a456` and friends as a single unrecognized token rather than a
+    /// number adjacent to an identifier.
+    fn reject_trailing_identifier_char(&self, start: usize) -> Result<(), LexerError> {
+        if self.is_eof() {
+            return Ok(());
+        }
+        let ch = self.current_char();
+        if ch.is_alphabetic() || ch == '_' {
+            // Capture the full offending run for a helpful error message.
+            let bad = self.slice_from(start);
+            return Err(LexerError {
+                message: format!("unrecognized token: \"{}\"", bad),
+                position: self.position(),
+                near_token: Some(bad.to_string()),
+            });
+        }
+        Ok(())
     }
 
     /// Tokenize a hexadecimal literal (0x... or 0X...).
@@ -116,6 +172,10 @@ impl<'a> Lexer<'a> {
                 near_token: Some("0x".to_string()),
             });
         }
+
+        // A hex literal running directly into an identifier character (e.g.
+        // `0x1Ag`) is a malformed token in SQLite, not a value plus alias.
+        self.reject_trailing_identifier_char(hex_start)?;
 
         // Parse the hex string to a number and convert to decimal string
         // SQLite treats hex literals as 64-bit signed integers
@@ -271,6 +331,59 @@ mod tests {
             let mut lexer = Lexer::new(input);
             let result = lexer.tokenize();
             assert!(result.is_err(), "Expected error for input: {}", input);
+        }
+    }
+
+    #[test]
+    fn test_underscore_in_fraction_and_exponent() {
+        // SQLite 3.46+ allows underscore separators after the decimal point and
+        // inside the exponent, as long as each underscore sits between digits.
+        let test_cases = vec![
+            ("1.1_1", "1.11"),
+            ("1_000.5", "1000.5"),
+            ("1.000_5", "1.0005"),
+            ("1e1_0", "1e10"),
+            ("1.5e1_0", "1.5e10"),
+        ];
+
+        for (input, expected) in test_cases {
+            let mut lexer = Lexer::new(input);
+            let tokens = lexer
+                .tokenize()
+                .unwrap_or_else(|e| panic!("Failed to tokenize {}: {:?}", input, e));
+            assert_eq!(tokens.len(), 2, "Input: {}", input);
+            match &tokens[0] {
+                Token::Number(n) => assert_eq!(n, expected, "Input: {}", input),
+                other => panic!("Expected Number token for {}, got {:?}", input, other),
+            }
+        }
+    }
+
+    #[test]
+    fn test_underscore_not_between_digits_errors() {
+        // Underscore not surrounded by digits is a malformed token in SQLite.
+        for input in ["1_.5", "1._5"] {
+            let mut lexer = Lexer::new(input);
+            assert!(lexer.tokenize().is_err(), "Expected error for input: {}", input);
+        }
+    }
+
+    #[test]
+    fn test_number_followed_by_identifier_char_errors() {
+        // A number running into an identifier character is a single malformed
+        // token, not `<number> AS <alias>`.
+        for input in ["123a456", "1FROM", "1.5x", "0x1Ag", "42abc"] {
+            let mut lexer = Lexer::new(input);
+            assert!(lexer.tokenize().is_err(), "Expected error for input: {}", input);
+        }
+    }
+
+    #[test]
+    fn test_number_followed_by_operator_ok() {
+        // Numbers adjacent to operators / punctuation must still tokenize.
+        for input in ["1+2", "3.14*2", "5,6", "(7)", "8;"] {
+            let mut lexer = Lexer::new(input);
+            assert!(lexer.tokenize().is_ok(), "Expected ok for input: {}", input);
         }
     }
 

--- a/crates/vibesql-parser/src/lexer/strings.rs
+++ b/crates/vibesql-parser/src/lexer/strings.rs
@@ -10,10 +10,12 @@ impl<'a> Lexer<'a> {
         self.advance(); // Skip opening single quote
 
         let mut hex_chars = String::new();
+        let mut terminated = false;
         while !self.is_eof() {
             let ch = self.current_char();
             if ch == '\'' {
                 self.advance();
+                terminated = true;
                 break;
             } else if ch.is_ascii_hexdigit() {
                 hex_chars.push(ch);
@@ -28,6 +30,16 @@ impl<'a> Lexer<'a> {
                     near_token: Some(format!("x'{}", hex_chars)),
                 });
             }
+        }
+
+        // An unterminated blob literal (EOF before the closing quote, e.g.
+        // `x'4869`) is an error in SQLite, not a valid empty/partial blob.
+        if !terminated {
+            return Err(LexerError {
+                message: "unterminated blob literal".to_string(),
+                position: self.position(),
+                near_token: Some(format!("x'{}", hex_chars)),
+            });
         }
 
         // Check for even number of hex digits

--- a/crates/vibesql-parser/src/parser/alter.rs
+++ b/crates/vibesql-parser/src/parser/alter.rs
@@ -87,11 +87,21 @@ fn parse_add_column(
 ) -> Result<AlterTableStmt, ParseError> {
     let column_name = parser.parse_identifier()?;
     let type_start = parser.current_position();
-    let (data_type, is_exact_integer_type) = parser.parse_data_type_with_integer_flag()?;
-    // Capture the verbatim declared type text for STRICT-table validation
-    // (issue #5837): ALTER TABLE <strict> ADD COLUMN must reject non-strict
-    // datatypes just like CREATE TABLE.
-    let type_source = parser.source_between(type_start, parser.current_position());
+    // The data type is optional in SQLite: `ALTER TABLE t ADD COLUMN x` (no
+    // type) creates a column with BLOB/no-affinity, exactly like a typeless
+    // column in CREATE TABLE. When the token following the column name is a
+    // column constraint keyword, a DEFAULT clause, or end-of-statement, there
+    // is no type to parse — default to BLOB affinity.
+    let (data_type, is_exact_integer_type, type_source) = if is_add_column_type_absent(parser) {
+        (vibesql_types::DataType::BinaryLargeObject, false, None)
+    } else {
+        let (dt, is_int) = parser.parse_data_type_with_integer_flag()?;
+        // Capture the verbatim declared type text for STRICT-table validation
+        // (issue #5837): ALTER TABLE <strict> ADD COLUMN must reject non-strict
+        // datatypes just like CREATE TABLE.
+        let src = parser.source_between(type_start, parser.current_position());
+        (dt, is_int, src)
+    };
 
     // Parse optional DEFAULT clause
     let default_value = if parser.peek_keyword(Keyword::Default) {
@@ -167,6 +177,35 @@ fn parse_add_column(
     };
 
     Ok(AlterTableStmt::AddColumn(AddColumnStmt { table_name, column_def }))
+}
+
+/// Determine whether the token following an ADD COLUMN column name signals
+/// that no data type was declared. SQLite permits typeless columns (BLOB
+/// affinity), so `ALTER TABLE t ADD COLUMN x`, `... ADD COLUMN x NOT NULL`,
+/// `... ADD COLUMN x DEFAULT 0`, etc. are all valid with no explicit type.
+fn is_add_column_type_absent(parser: &crate::Parser) -> bool {
+    matches!(
+        parser.peek(),
+        // End of the statement — a bare `ADD COLUMN x`.
+        Token::Eof
+            | Token::Semicolon
+            | Token::Comma
+            | Token::RParen
+            // Column constraint / modifier keywords that follow the (absent) type.
+            | Token::Keyword { keyword: Keyword::Not, .. }
+            | Token::Keyword { keyword: Keyword::Null, .. }
+            | Token::Keyword { keyword: Keyword::Primary, .. }
+            | Token::Keyword { keyword: Keyword::Unique, .. }
+            | Token::Keyword { keyword: Keyword::Check, .. }
+            | Token::Keyword { keyword: Keyword::References, .. }
+            | Token::Keyword { keyword: Keyword::Default, .. }
+            | Token::Keyword { keyword: Keyword::Collate, .. }
+            | Token::Keyword { keyword: Keyword::Constraint, .. }
+            | Token::Keyword { keyword: Keyword::Key, .. }
+            | Token::Keyword { keyword: Keyword::AutoIncrement, .. }
+            | Token::Keyword { keyword: Keyword::Generated, .. }
+            | Token::Keyword { keyword: Keyword::As, .. }
+    )
 }
 
 /// Parse DROP COLUMN

--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -416,12 +416,31 @@ impl Parser {
                                     // This is a no-op - nullable is the default
                 }
                 Token::Keyword { keyword: Keyword::Not, .. } => {
-                    self.advance(); // consume NOT
-                    self.expect_keyword(Keyword::Null)?;
-                    constraints.push(vibesql_ast::ColumnConstraint {
-                        name,
-                        kind: vibesql_ast::ColumnConstraintKind::NotNull,
-                    });
+                    // Disambiguate NOT NULL from the `NOT DEFERRABLE` deferral
+                    // clause, which SQLite also permits as a standalone
+                    // column-level constraint (it is ignored for non-FK
+                    // columns but must parse without error).
+                    let next_is_deferrable = matches!(
+                        self.tokens.get(self.position + 1),
+                        Some(Token::Keyword { keyword: Keyword::Deferrable, .. })
+                    );
+                    if next_is_deferrable {
+                        // NOT DEFERRABLE [INITIALLY ...] — parsed and ignored.
+                        let _ = self.parse_constraint_deferral()?;
+                    } else {
+                        self.advance(); // consume NOT
+                        self.expect_keyword(Keyword::Null)?;
+                        constraints.push(vibesql_ast::ColumnConstraint {
+                            name,
+                            kind: vibesql_ast::ColumnConstraintKind::NotNull,
+                        });
+                    }
+                }
+                Token::Keyword { keyword: Keyword::Deferrable, .. } => {
+                    // Standalone column-level DEFERRABLE [INITIALLY DEFERRED |
+                    // IMMEDIATE]. SQLite ignores deferral on non-FK columns but
+                    // accepts the syntax; parse it and drop the result.
+                    let _ = self.parse_constraint_deferral()?;
                 }
                 Token::Keyword { keyword: Keyword::Primary, .. } => {
                     self.advance(); // consume PRIMARY

--- a/crates/vibesql-parser/src/parser/select/statement.rs
+++ b/crates/vibesql-parser/src/parser/select/statement.rs
@@ -484,8 +484,11 @@ impl Parser {
                 self.advance();
                 name
             }
-            // Allow unreserved keywords (like NULLS, TIMESTAMP, etc.) as CTE names
-            Token::Keyword { keyword: kw, .. } if kw.can_be_identifier() => {
+            // Allow unreserved keywords (like NULLS, TIMESTAMP, etc.) and SQLite
+            // fallback keywords (like ROWS) as CTE names.
+            Token::Keyword { keyword: kw, .. }
+                if kw.can_be_identifier() || kw.is_sqlite_fallback_keyword() =>
+            {
                 let name = format!("{}", kw).to_lowercase();
                 self.advance();
                 name
@@ -670,8 +673,8 @@ impl Parser {
         // error with a bogus "near ORDER: syntax error" (issue #5714). The
         // nested set-operation right-side calls always pass
         // `validate_end_tokens=true`, so they are unaffected.
-        let allow_order_limit = allow_order_limit
-            || (!validate_end_tokens && set_operation.is_some());
+        let allow_order_limit =
+            allow_order_limit || (!validate_end_tokens && set_operation.is_some());
 
         // Parse ORDER BY (only if allowed)
         let order_by = if allow_order_limit && self.peek_keyword(Keyword::Order) {

--- a/crates/vibesql-parser/src/parser/transaction.rs
+++ b/crates/vibesql-parser/src/parser/transaction.rs
@@ -139,8 +139,9 @@ pub(super) fn parse_rollback_to_savepoint_statement(
     // Consume TO
     parser.consume_keyword(Keyword::To)?;
 
-    // Consume SAVEPOINT
-    parser.consume_keyword(Keyword::Savepoint)?;
+    // SAVEPOINT keyword is optional in SQLite: `ROLLBACK TO <name>` is
+    // equivalent to `ROLLBACK TO SAVEPOINT <name>`.
+    parser.try_consume_keyword(Keyword::Savepoint);
 
     // Parse savepoint name (identifier, normalized to uppercase if unquoted)
     let name = parse_savepoint_name(parser)?;
@@ -155,8 +156,9 @@ pub(super) fn parse_release_savepoint_statement(
     // Consume RELEASE
     parser.consume_keyword(Keyword::Release)?;
 
-    // Consume SAVEPOINT
-    parser.consume_keyword(Keyword::Savepoint)?;
+    // SAVEPOINT keyword is optional in SQLite: `RELEASE <name>` is
+    // equivalent to `RELEASE SAVEPOINT <name>`.
+    parser.try_consume_keyword(Keyword::Savepoint);
 
     // Parse savepoint name (identifier, normalized to uppercase if unquoted)
     let name = parse_savepoint_name(parser)?;

--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -517,8 +517,16 @@ impl Parser {
             false
         };
 
-        // Parse trigger name
-        let trigger_name = self.parse_identifier()?;
+        // Parse trigger name. SQLite accepts a single-quoted string literal as
+        // the trigger name in DROP TRIGGER (e.g. `DROP TRIGGER 'tr'`), so accept
+        // a string token in addition to bare / delimited identifiers.
+        let trigger_name = if let Token::String(s) = self.peek() {
+            let name = s.clone();
+            self.advance();
+            name
+        } else {
+            self.parse_identifier()?
+        };
 
         // Parse optional CASCADE or RESTRICT
         let cascade = if self.try_consume_keyword(Keyword::Cascade) {

--- a/crates/vibesql-parser/src/tests/alter_table.rs
+++ b/crates/vibesql-parser/src/tests/alter_table.rs
@@ -359,3 +359,55 @@ fn test_alter_table_add_column_keyword_still_works() {
         _ => panic!("Expected ALTER TABLE statement"),
     }
 }
+
+#[test]
+fn test_parse_alter_table_add_column_without_type() {
+    // SQLite allows a typeless column: ADD COLUMN x (BLOB/no affinity).
+    let result = Parser::parse_sql("ALTER TABLE t ADD COLUMN x;");
+    assert!(result.is_ok(), "err: {:?}", result);
+    match result.unwrap() {
+        vibesql_ast::Statement::AlterTable(vibesql_ast::AlterTableStmt::AddColumn(add)) => {
+            assert_eq!(add.column_def.name, "x");
+            assert!(matches!(add.column_def.data_type, vibesql_types::DataType::BinaryLargeObject));
+            assert!(add.column_def.nullable);
+        }
+        other => panic!("Expected ADD COLUMN, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_alter_table_add_column_without_type_with_constraint() {
+    // Typeless column followed directly by a constraint / default.
+    for sql in [
+        "ALTER TABLE t ADD COLUMN x NOT NULL",
+        "ALTER TABLE t ADD COLUMN x DEFAULT 0",
+        "ALTER TABLE t ADD COLUMN x UNIQUE",
+    ] {
+        let result = Parser::parse_sql(sql);
+        assert!(result.is_ok(), "{sql} -> err: {:?}", result);
+        match result.unwrap() {
+            vibesql_ast::Statement::AlterTable(vibesql_ast::AlterTableStmt::AddColumn(add)) => {
+                assert_eq!(add.column_def.name, "x");
+                assert!(matches!(
+                    add.column_def.data_type,
+                    vibesql_types::DataType::BinaryLargeObject
+                ));
+            }
+            other => panic!("{sql} -> Expected ADD COLUMN, got {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn test_parse_alter_table_add_column_bare_no_column_keyword_no_type() {
+    // ADD <name> without the COLUMN keyword and without a type.
+    let result = Parser::parse_sql("ALTER TABLE t ADD x");
+    assert!(result.is_ok(), "err: {:?}", result);
+    match result.unwrap() {
+        vibesql_ast::Statement::AlterTable(vibesql_ast::AlterTableStmt::AddColumn(add)) => {
+            assert_eq!(add.column_def.name, "x");
+            assert!(matches!(add.column_def.data_type, vibesql_types::DataType::BinaryLargeObject));
+        }
+        other => panic!("Expected ADD COLUMN, got {:?}", other),
+    }
+}

--- a/crates/vibesql-parser/src/tests/create_table/basic.rs
+++ b/crates/vibesql-parser/src/tests/create_table/basic.rs
@@ -333,3 +333,22 @@ fn test_parse_create_table_number_precision_scale() {
         _ => panic!("Expected CREATE TABLE statement"),
     }
 }
+
+#[test]
+fn test_true_false_as_column_names() {
+    // SQLite treats TRUE/FALSE as fallback keywords usable as identifiers.
+    let result = Parser::parse_sql("CREATE TABLE t(\"true\" INTEGER, \"false\" INTEGER)");
+    assert!(result.is_ok(), "quoted true/false columns: {:?}", result);
+
+    let result = Parser::parse_sql("CREATE TABLE t(true INTEGER, false INTEGER)");
+    assert!(result.is_ok(), "bare true/false columns: {:?}", result);
+}
+
+#[test]
+fn test_true_false_level_as_table_names() {
+    for name in ["true", "false", "level"] {
+        let sql = format!("CREATE TABLE {name}(a INTEGER)");
+        let result = Parser::parse_sql(&sql);
+        assert!(result.is_ok(), "{sql} should parse: {:?}", result);
+    }
+}

--- a/crates/vibesql-parser/src/tests/create_table/constraints_column.rs
+++ b/crates/vibesql-parser/src/tests/create_table/constraints_column.rs
@@ -597,3 +597,19 @@ fn test_parse_default_double_rejected() {
     let result = Parser::parse_sql("CREATE TABLE t(c INT DEFAULT 0 UNIQUE DEFAULT 1)");
     assert!(result.is_err(), "Should reject two DEFAULT clauses on the same column");
 }
+
+#[test]
+fn test_parse_column_standalone_deferrable() {
+    // SQLite accepts a standalone column-level DEFERRABLE clause (ignored for
+    // non-FK columns, but must parse).
+    for sql in [
+        "CREATE TABLE t(a INTEGER DEFERRABLE)",
+        "CREATE TABLE t(a INTEGER DEFERRABLE INITIALLY DEFERRED)",
+        "CREATE TABLE t(a INTEGER DEFERRABLE INITIALLY IMMEDIATE)",
+        "CREATE TABLE t(a INTEGER NOT DEFERRABLE)",
+        "CREATE TABLE t(a INTEGER NOT NULL DEFERRABLE)",
+    ] {
+        let result = Parser::parse_sql(sql);
+        assert!(result.is_ok(), "{sql} should parse: {:?}", result);
+    }
+}

--- a/crates/vibesql-parser/src/tests/cte.rs
+++ b/crates/vibesql-parser/src/tests/cte.rs
@@ -380,3 +380,16 @@ fn test_parse_with_values_missing_rows_errors() {
     let result = Parser::parse_sql("WITH c AS (SELECT 1) VALUES;");
     assert!(result.is_err(), "WITH ... VALUES without rows should not parse");
 }
+
+#[test]
+fn test_parse_cte_named_rows() {
+    // `ROWS` is a SQLite fallback keyword and must be usable as a CTE name.
+    let result = Parser::parse_sql("WITH rows AS (SELECT 1) SELECT * FROM rows;");
+    assert!(result.is_ok(), "CTE named `rows` should parse: {:?}", result);
+}
+
+#[test]
+fn test_parse_cte_named_level() {
+    let result = Parser::parse_sql("WITH level AS (SELECT 1) SELECT * FROM level;");
+    assert!(result.is_ok(), "CTE named `level` should parse: {:?}", result);
+}

--- a/crates/vibesql-parser/src/tests/lexer/strings.rs
+++ b/crates/vibesql-parser/src/tests/lexer/strings.rs
@@ -69,3 +69,20 @@ fn test_tokenize_empty_string_not_confused_with_escaped_quote() {
 }
 
 // ============================================================================
+
+#[test]
+fn test_tokenize_blob_literal() {
+    let mut lexer = Lexer::new("x'4869'");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[0], Token::BlobLiteral(vec![0x48, 0x69]));
+}
+
+#[test]
+fn test_unterminated_blob_literal_errors() {
+    // Missing closing quote (EOF reached first) must be an error, not a valid
+    // partial blob (SQLite: `unrecognized token: "x'4869"`).
+    for input in ["x'4869", "X'ABCD", "x'"] {
+        let mut lexer = Lexer::new(input);
+        assert!(lexer.tokenize().is_err(), "Expected error for input: {}", input);
+    }
+}

--- a/crates/vibesql-parser/src/tests/transaction.rs
+++ b/crates/vibesql-parser/src/tests/transaction.rs
@@ -186,3 +186,46 @@ fn test_parse_begin_invalid_durability_mode() {
     let result = Parser::parse_sql("BEGIN WITH DURABILITY = INVALID");
     assert!(result.is_err());
 }
+
+#[test]
+fn test_parse_rollback_to_savepoint_keyword() {
+    // Full form with SAVEPOINT keyword.
+    let result = Parser::parse_sql("ROLLBACK TO SAVEPOINT sp1");
+    assert!(result.is_ok(), "err: {:?}", result);
+    match result.unwrap() {
+        vibesql_ast::Statement::RollbackToSavepoint(stmt) => assert_eq!(stmt.name, "sp1"),
+        other => panic!("Expected RollbackToSavepoint, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_rollback_to_without_savepoint_keyword() {
+    // SQLite shorthand: ROLLBACK TO <name> (SAVEPOINT keyword omitted).
+    let result = Parser::parse_sql("ROLLBACK TO sp1");
+    assert!(result.is_ok(), "err: {:?}", result);
+    match result.unwrap() {
+        vibesql_ast::Statement::RollbackToSavepoint(stmt) => assert_eq!(stmt.name, "sp1"),
+        other => panic!("Expected RollbackToSavepoint, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_release_with_savepoint_keyword() {
+    let result = Parser::parse_sql("RELEASE SAVEPOINT sp1");
+    assert!(result.is_ok(), "err: {:?}", result);
+    match result.unwrap() {
+        vibesql_ast::Statement::ReleaseSavepoint(stmt) => assert_eq!(stmt.name, "sp1"),
+        other => panic!("Expected ReleaseSavepoint, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_release_without_savepoint_keyword() {
+    // SQLite shorthand: RELEASE <name> (SAVEPOINT keyword omitted).
+    let result = Parser::parse_sql("RELEASE sp1");
+    assert!(result.is_ok(), "err: {:?}", result);
+    match result.unwrap() {
+        vibesql_ast::Statement::ReleaseSavepoint(stmt) => assert_eq!(stmt.name, "sp1"),
+        other => panic!("Expected ReleaseSavepoint, got {:?}", other),
+    }
+}

--- a/crates/vibesql-parser/src/tests/trigger.rs
+++ b/crates/vibesql-parser/src/tests/trigger.rs
@@ -1119,3 +1119,30 @@ fn test_name_source_backtick_quoted() {
     assert_eq!(name, "tr1");
     assert_eq!(source.as_deref(), Some("`tr1`"));
 }
+
+#[test]
+fn test_drop_trigger_single_quoted_name() {
+    // SQLite accepts a single-quoted string literal as the trigger name.
+    let sql = "DROP TRIGGER 'my_trigger';";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+    match result.unwrap() {
+        Statement::DropTrigger(drop_trigger) => {
+            assert_eq!(drop_trigger.trigger_name, "my_trigger");
+        }
+        _ => panic!("Expected DropTrigger statement"),
+    }
+}
+
+#[test]
+fn test_drop_trigger_if_exists_single_quoted_name() {
+    let result = Parser::parse_sql("DROP TRIGGER IF EXISTS 'tr';");
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+    match result.unwrap() {
+        Statement::DropTrigger(drop_trigger) => {
+            assert_eq!(drop_trigger.trigger_name, "tr");
+            assert!(drop_trigger.if_exists);
+        }
+        _ => panic!("Expected DropTrigger statement"),
+    }
+}


### PR DESCRIPTION
Part of #5841 — implements the high-ROI Tier 1 + Tier 2 items plus the Tier 3 numeric tokenizer, from the #5787 long-tail parser/tokenizer acceptance batch. Each sub-item was verified against `sqlite3` (3.51.0) before implementing.

## Landed

### Tier 1
- **ROLLBACK TO <name> / RELEASE <name>** without the `SAVEPOINT` keyword (SQLite shorthand). Fixed in both classic (`transaction.rs`) and arena (`arena_parser/ddl.rs`) parsers.
- **ALTER TABLE t ADD COLUMN x** without a datatype → typeless column with BLOB/no affinity, mirroring CREATE TABLE typeless columns (`alter.rs`).
- **x IS TRUE / IS FALSE for REAL/floating values** → `0.5 IS TRUE` = 1, `0.0 IS FALSE` = 1 (`eval.rs`).
- **Standalone column-level DEFERRABLE / NOT DEFERRABLE [INITIALLY ...]** now parse (ignored for non-FK columns, as SQLite does) (`constraints.rs`).

### Tier 2 (identifier acceptance)
- **TRUE / FALSE / LEVEL** added to the SQLite fallback-keyword set so they work as table/column/identifier names. Boolean literals remain literals in expression position (that parse path takes precedence, so `SELECT TRUE` is unaffected).
- **CTE names accept fallback keywords** such as `rows` (classic + arena).
- **DROP TRIGGER 'name'** accepts a single-quoted string literal name.

### Tier 3 (numeric tokenizer / lexer)
- Underscore digit separators in the fraction/exponent (`1.1_1`, `1e1_0`), only between two digits (`1_.5` / `1._5` error).
- A numeric literal running directly into an identifier character now errors as one malformed token (`123a456`, `1FROM`, `1.5x`, `0x1Ag`) instead of silently splitting into value + alias.
- Unterminated blob literal (`x'4869` with no closing quote) now errors instead of succeeding.

## Deferred (issue stays open)
- Single-quoted strings as DDL identifiers / string-literal constraint names (the remaining `quote.test` recovery) — flagged risky in the curation analysis (touches `parse_identifier`); left for a focused follow-up.
- Item 6: COLLATE binding tighter than IS TRUE — needs expression-precedence surgery with tiny test impact and high regression risk.

## Tests
- New parser unit tests: savepoint shorthand, ADD COLUMN typeless (+constraint/bare forms), standalone DEFERRABLE, TRUE/FALSE/LEVEL identifiers, CTE `rows`/`level`, DROP TRIGGER string name, numeric underscore/error/blob lexer cases.
- New executor test `is_truthvalue_real_tests.rs` for IS TRUE/FALSE REAL semantics (verified against sqlite3).
- `cargo test -p vibesql-parser`: 1643 passed, 0 failed. `cargo test -p vibesql-executor`: passed. No regressions.

## TCL before/after (targeted files)
| File | Before | After |
|------|--------|-------|
| literal.test | 44/96 passed | **76/96 passed (+32)** |
| istrue.test | 28/56 | 28/56 (remaining failures are DEFAULT-expression / unrelated gaps) |
| quote.test | 1/29 | 1/29 (needs the deferred single-quoted-identifier work) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)