### PR TITLE
fix(triggers): OFF-by-default recursive_triggers, REPLACE conflict-delete gating, changes() semantics

### DIFF
--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -1233,7 +1233,6 @@ fn execute_delete_on_view(
     // following the first-SkipRow-wins convention of the primary DML loops
     // (#5415). The common single-trigger case matches sqlite3 3.51 exactly —
     // the row's operation is skipped.
-    let rows_processed = rows_to_delete.len();
     for old_row in &rows_to_delete {
         for trigger in &triggers {
             if crate::TriggerFirer::execute_trigger(database, trigger, Some(old_row), None)?
@@ -1261,7 +1260,10 @@ fn execute_delete_on_view(
         None
     };
 
-    Ok((rows_processed, returning))
+    // changes() after a DELETE on a view is always zero — no physical table
+    // rows were modified by the statement itself (SQLite R-09813-48563;
+    // e_changes-4.4.2, #5840).
+    Ok((0, returning))
 }
 
 /// Build a pseudo TableSchema from a view definition

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -1796,7 +1796,6 @@ fn execute_insert_on_view(
     // following the first-SkipRow-wins convention of the primary DML loops
     // (#5415). Verified against sqlite3 3.51: a RAISE(IGNORE) before the body's
     // `INSERT INTO base` skips that base insert while later rows proceed.
-    let rows_processed = new_rows.len();
     for row in new_rows {
         for trigger in &triggers {
             if crate::TriggerFirer::execute_trigger(db, trigger, None, Some(&row))?
@@ -1807,7 +1806,12 @@ fn execute_insert_on_view(
         }
     }
 
-    Ok((rows_processed, returning_result))
+    // changes() after an INSERT/UPDATE/DELETE on a view is always zero: no
+    // physical table rows were modified by the statement itself (only the
+    // INSTEAD OF trigger body touches real tables, and those changes are
+    // saved/restored around the trigger program). SQLite evidence
+    // R-09813-48563; e_changes-4.2.2 (#5840).
+    Ok((0, returning_result))
 }
 
 /// Build a pseudo TableSchema from a view definition

--- a/crates/vibesql-executor/src/insert/replace.rs
+++ b/crates/vibesql-executor/src/insert/replace.rs
@@ -158,12 +158,21 @@ pub fn handle_replace_conflicts(
         return Ok(());
     }
 
-    // Check if any DELETE triggers exist for this table
-    let has_delete_triggers = db
+    // Check if any DELETE triggers exist for this table.
+    //
+    // SQLite rule (lang_conflict.html): "When the REPLACE conflict resolution
+    // strategy deletes rows in order to satisfy a constraint, delete triggers
+    // fire if and only if recursive triggers are enabled." A plain `DELETE`
+    // statement always fires its triggers, but the *implicit* deletes REPLACE
+    // performs to clear a PK/UNIQUE conflict are gated on `recursive_triggers`.
+    // With the default (OFF), these conflict-deletes are silent (triggerC-5.3,
+    // #5840).
+    let fire_delete_triggers = db
         .catalog
         .get_triggers_for_table(table_name, Some(vibesql_ast::TriggerEvent::Delete))
         .next()
-        .is_some();
+        .is_some()
+        && db.recursive_triggers();
 
     // Fire BEFORE DELETE triggers for each conflicting row
     // This must happen BEFORE actual deletion (SQLite semantics)
@@ -178,7 +187,7 @@ pub fn handle_replace_conflicts(
     // 3.51 with `recursive_triggers=ON`, where a BEFORE DELETE RAISE(IGNORE)
     // during REPLACE leaves the row in place and the subsequent insert fails
     // with "UNIQUE constraint failed".
-    if has_delete_triggers {
+    if fire_delete_triggers {
         let mut kept = Vec::with_capacity(rows_to_delete.len());
         for (idx, row) in rows_to_delete {
             let outcome = TriggerFirer::execute_before_triggers(
@@ -289,7 +298,7 @@ pub fn handle_replace_conflicts(
 
     // Fire AFTER DELETE triggers for each deleted row
     // This must happen AFTER actual deletion (SQLite semantics)
-    if has_delete_triggers {
+    if fire_delete_triggers {
         for (_, row) in &rows_to_delete {
             // AFTER DELETE fires once the row is already gone. A RAISE(IGNORE)
             // here cannot un-delete it (sqlite3 3.51 leaves the row deleted),

--- a/crates/vibesql-executor/src/tests/delete_returning.rs
+++ b/crates/vibesql-executor/src/tests/delete_returning.rs
@@ -219,7 +219,9 @@ fn test_delete_returning_through_instead_of_trigger() {
 
     let (count, returning) =
         execute_delete_returning(&mut db, "DELETE FROM v1 WHERE b=4 RETURNING *");
-    assert_eq!(count, 2);
+    // changes() after DML on a view is always 0 (SQLite R-09813-48563, #5840);
+    // the INSTEAD OF trigger's fire count is still verified via RETURNING below.
+    assert_eq!(count, 0);
     let returning = returning.expect("RETURNING clause should produce a result");
     assert_eq!(returning.columns, vec!["b".to_string(), "c".to_string()]);
     assert_eq!(int_rows(&returning), vec![vec![4, 8], vec![4, 9]]);

--- a/crates/vibesql-executor/src/tests/insert_returning.rs
+++ b/crates/vibesql-executor/src/tests/insert_returning.rs
@@ -309,7 +309,9 @@ fn test_insert_returning_through_instead_of_trigger() {
         &mut db,
         "INSERT INTO v1 VALUES (1, 'x'), (2, 'y') RETURNING a, b",
     );
-    assert_eq!(count, 2);
+    // changes() after DML on a view is always 0 (SQLite R-09813-48563, #5840);
+    // the two INSTEAD OF trigger fires are verified via RETURNING below.
+    assert_eq!(count, 0);
     let returning = returning.expect("RETURNING clause should produce a result");
     assert_eq!(returning.columns, vec!["a".to_string(), "b".to_string()]);
     assert_eq!(returning.rows.len(), 2, "one RETURNING row per INSTEAD OF trigger fire");

--- a/crates/vibesql-executor/src/tests/raise_trigger_tests.rs
+++ b/crates/vibesql-executor/src/tests/raise_trigger_tests.rs
@@ -669,6 +669,10 @@ fn raise_abort_in_insert_trigger_aborts() {
 #[test]
 fn raise_ignore_in_before_delete_blocks_replace_conflict() {
     let mut db = vibesql_storage::Database::new();
+    // REPLACE fires conflict-delete triggers only with recursive_triggers ON
+    // (SQLite lang_conflict.html; default is now OFF, #5840). Enable it so the
+    // BEFORE DELETE trigger runs and its RAISE(IGNORE) can block the conflict.
+    db.set_recursive_triggers(true);
     exec_ok(&mut db, "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)");
     exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (1, 10)");
     exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (2, 20)");
@@ -1093,6 +1097,9 @@ fn replace_with_when_false_before_delete_trigger_leaves_one_row() {
 #[test]
 fn replace_with_non_raise_before_delete_trigger_fires_once_and_replaces() {
     let mut db = vibesql_storage::Database::new();
+    // REPLACE fires conflict-delete triggers only with recursive_triggers ON
+    // (SQLite lang_conflict.html; default is now OFF, #5840).
+    db.set_recursive_triggers(true);
     exec_ok(&mut db, "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)");
     exec_ok(&mut db, "CREATE TABLE log (n INTEGER)");
     exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (1, 10), (2, 20)");
@@ -1197,6 +1204,9 @@ fn replace_without_trigger_leaves_one_row() {
 #[test]
 fn replace_with_raise_ignore_before_delete_errors_and_leaves_table_unchanged() {
     let mut db = vibesql_storage::Database::new();
+    // REPLACE fires conflict-delete triggers only with recursive_triggers ON
+    // (SQLite lang_conflict.html; default is now OFF, #5840).
+    db.set_recursive_triggers(true);
     exec_ok(&mut db, "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)");
     exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (1, 10), (2, 20)");
     exec_ok(&mut db, "CREATE TRIGGER bd BEFORE DELETE ON t BEGIN SELECT raise(IGNORE); END");
@@ -1221,6 +1231,9 @@ fn replace_with_raise_ignore_before_delete_errors_and_leaves_table_unchanged() {
 #[test]
 fn replace_with_raise_abort_before_delete_aborts() {
     let mut db = vibesql_storage::Database::new();
+    // REPLACE fires conflict-delete triggers only with recursive_triggers ON
+    // (SQLite lang_conflict.html; default is now OFF, #5840).
+    db.set_recursive_triggers(true);
     exec_ok(&mut db, "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)");
     exec_ok(&mut db, "INSERT INTO t (id, v) VALUES (1, 10), (2, 20)");
     exec_ok(

--- a/crates/vibesql-executor/src/tests/triggers/error_handling.rs
+++ b/crates/vibesql-executor/src/tests/triggers/error_handling.rs
@@ -100,6 +100,10 @@ fn test_recursion_prevention() {
         .stack_size(96 * 1024 * 1024)
         .spawn(|| {
             let mut db = Database::new();
+            // Recursion only happens with recursive_triggers ON; the default is
+            // now OFF (SQLite default, #5840), which would suppress the re-entry
+            // and let the insert succeed. Enable it to exercise the depth cap.
+            db.set_recursive_triggers(true);
             create_users_table(&mut db);
 
             // Create trigger that inserts into the same table (infinite loop)

--- a/crates/vibesql-executor/src/tests/triggers/update.rs
+++ b/crates/vibesql-executor/src/tests/triggers/update.rs
@@ -353,8 +353,9 @@ fn test_update_from_on_view_with_instead_of_trigger() {
         .expect("UPDATE v1 SET a=map.v FROM map WHERE v1.k=map.k should succeed");
 
     // Two view rows match (k='b' and k='d'), so two INSTEAD OF triggers
-    // should fire.
-    assert_eq!(row_count, 2, "Expected 2 rows processed (k='b' and k='d')");
+    // should fire — but changes() after DML on a view is always 0 (SQLite
+    // R-09813-48563, #5840). The two fires are verified via the log table below.
+    assert_eq!(row_count, 0, "changes() is 0 for a view UPDATE");
 
     // Verify the log table received the expected entries.
     let select_log = "SELECT x FROM log ORDER BY x";

--- a/crates/vibesql-executor/src/tests/update_returning.rs
+++ b/crates/vibesql-executor/src/tests/update_returning.rs
@@ -93,7 +93,9 @@ fn test_instead_of_update_view_where_comparison_fires() {
     // Comparison results surface as Integer(1) in this evaluator context;
     // before the fix the trigger fired 0 times (Boolean-only match arm).
     let (count, _) = execute_update_returning(&mut db, "UPDATE v3 SET b=9 WHERE b=4");
-    assert_eq!(count, 1, "exactly one view row matches b=4");
+    // changes() after DML on a view is always 0 (SQLite R-09813-48563, #5840);
+    // the single INSTEAD OF fire is verified via the log table below.
+    assert_eq!(count, 0, "changes() is 0 for a view UPDATE");
 
     let log = execute_sql(&mut db, "SELECT x FROM log");
     assert_eq!(log.len(), 1, "INSTEAD OF trigger should fire once for WHERE b=4");
@@ -121,7 +123,9 @@ fn test_instead_of_update_view_from_fires_per_join_match() {
     // SQLite fires the INSTEAD OF trigger once per join match (3 times).
     // The previous implementation deduped to one fire per view row.
     let (count, _) = execute_update_returning(&mut db, "UPDATE v2 SET c=99 FROM m WHERE b=4");
-    assert_eq!(count, 3, "one view row x three FROM rows = 3 trigger fires");
+    // changes() after DML on a view is always 0 (SQLite R-09813-48563, #5840);
+    // the three per-join-match fires are verified via the log table below.
+    assert_eq!(count, 0, "changes() is 0 for a view UPDATE");
 
     let log = execute_sql(&mut db, "SELECT x FROM log");
     assert_eq!(log.len(), 3, "INSTEAD OF trigger should fire once per join match");
@@ -188,7 +192,9 @@ fn test_update_returning_through_instead_of_trigger() {
 
     let (count, returning) =
         execute_update_returning(&mut db, "UPDATE t2 SET c=99 WHERE b=4 RETURNING *");
-    assert_eq!(count, 3);
+    // changes() after DML on a view is always 0 (SQLite R-09813-48563, #5840);
+    // the three fires are verified via the RETURNING rows below.
+    assert_eq!(count, 0);
     let returning = returning.expect("RETURNING clause should produce a result");
     assert_eq!(returning.columns, vec!["b".to_string(), "c".to_string()]);
     assert_eq!(int_rows(&returning), vec![vec![4, 99], vec![4, 99], vec![4, 99]]);
@@ -212,7 +218,9 @@ fn test_update_returning_through_instead_of_trigger_with_from() {
 
     let (count, returning) =
         execute_update_returning(&mut db, "UPDATE t2 SET c=15 FROM m WHERE b=4 RETURNING *");
-    assert_eq!(count, 3);
+    // changes() after DML on a view is always 0 (SQLite R-09813-48563, #5840);
+    // the three per-join-match fires are verified via the RETURNING rows below.
+    assert_eq!(count, 0);
     let returning = returning.expect("RETURNING clause should produce a result");
     assert_eq!(int_rows(&returning), vec![vec![4, 15], vec![4, 15], vec![4, 15]]);
 }

--- a/crates/vibesql-executor/src/trigger_execution.rs
+++ b/crates/vibesql-executor/src/trigger_execution.rs
@@ -656,19 +656,40 @@ impl TriggerFirer {
         // Create trigger context for OLD/NEW pseudo-variable resolution
         let trigger_context = TriggerContext { old_row, new_row, table_schema: &schema, is_view };
 
+        // changes() save/restore around the trigger program (SQLite
+        // R-32918-61474, #5840): before entering a trigger body the value
+        // returned by changes() is saved, and after the body finishes the
+        // original value is restored. Within the body, each INSERT/UPDATE/DELETE
+        // sets changes() to the rows *it* modified (handled in
+        // `execute_statement`), so the first body statement sees the caller's
+        // value and later statements see the previous nested statement's value.
+        // Restoring afterward keeps a sub-trigger's nested DML from leaking into
+        // the changes() the calling statement observes (e_changes-5.2/6.x/7.x).
+        let saved_changes = db.last_changes_count();
+
         // Execute each statement in the trigger body with trigger context.
         // A RAISE(IGNORE) inside any statement abandons the rest of this
         // trigger's action for the current row and asks the caller to skip the
         // row (SQLite semantics), without raising a user-visible error.
+        let mut outcome = TriggerOutcome::Proceed;
         for statement in statements {
             match Self::execute_statement(db, &statement, &trigger_context) {
                 Ok(()) => {}
-                Err(ExecutorError::RaiseIgnore) => return Ok(TriggerOutcome::SkipRow),
-                Err(e) => return Err(e),
+                Err(ExecutorError::RaiseIgnore) => {
+                    outcome = TriggerOutcome::SkipRow;
+                    break;
+                }
+                Err(e) => {
+                    // Restore before propagating so a failed trigger body does
+                    // not corrupt the caller's changes() value.
+                    db.set_last_changes_count(saved_changes);
+                    return Err(e);
+                }
             }
         }
 
-        Ok(TriggerOutcome::Proceed)
+        db.set_last_changes_count(saved_changes);
+        Ok(outcome)
     }
 
     /// Resolve the schema used for OLD/NEW column resolution when a trigger fires.
@@ -783,32 +804,44 @@ impl TriggerFirer {
     ) -> Result<(), ExecutorError> {
         use vibesql_ast::Statement;
 
+        // Each INSERT/UPDATE/DELETE inside a trigger body sets changes() to the
+        // number of rows *it* directly modified, upon completion, exactly as a
+        // top-level statement does (SQLite R-17146-37073, #5840). This makes
+        // changes() observable to later statements in the same trigger body.
+        // The enclosing trigger program (`execute_trigger_action`) saves and
+        // restores changes() so these nested updates do not leak to the caller.
         match statement {
             Statement::Insert(insert_stmt) => {
                 // Execute INSERT with trigger context support
-                crate::insert::execute_insert_with_trigger_context(
+                let count = crate::insert::execute_insert_with_trigger_context(
                     db,
                     insert_stmt,
                     trigger_context,
                 )?;
+                db.set_last_changes_count(count);
+                db.increment_total_changes_count(count);
                 Ok(())
             }
             Statement::Update(update_stmt) => {
                 // Execute UPDATE with trigger context support
-                crate::update::execute_update_with_trigger_context(
+                let count = crate::update::execute_update_with_trigger_context(
                     db,
                     update_stmt,
                     trigger_context,
                 )?;
+                db.set_last_changes_count(count);
+                db.increment_total_changes_count(count);
                 Ok(())
             }
             Statement::Delete(delete_stmt) => {
                 // Execute DELETE with trigger context support
-                crate::delete::execute_delete_with_trigger_context(
+                let count = crate::delete::execute_delete_with_trigger_context(
                     db,
                     delete_stmt,
                     trigger_context,
                 )?;
+                db.set_last_changes_count(count);
+                db.increment_total_changes_count(count);
                 Ok(())
             }
             Statement::Select(select_stmt) => {

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -591,17 +591,24 @@ pub(super) fn execute_internal(
             // (`insert/replace.rs`). Without this, a WITHOUT ROWID `UPDATE OR
             // REPLACE` that resolves a PRIMARY KEY conflict silently dropped the
             // replaced row's DELETE trigger (triggerF.test 1.2/1.3/1.4).
-            let has_delete_triggers = database
+            //
+            // These conflict-deletes are gated on `recursive_triggers`: SQLite
+            // fires REPLACE conflict-resolution DELETE triggers "if and only if
+            // recursive triggers are enabled" (lang_conflict.html). The row is
+            // still removed either way; only the trigger firing is suppressed
+            // when recursive_triggers is OFF (triggerC-5.3, #5840).
+            let fire_delete_triggers = database
                 .catalog
                 .get_triggers_for_table(table_name, Some(vibesql_ast::TriggerEvent::Delete))
                 .next()
-                .is_some();
+                .is_some()
+                && database.recursive_triggers();
 
             // Fire BEFORE DELETE triggers for each conflicting row before it is
             // removed. A RAISE(IGNORE) in a BEFORE DELETE trigger abandons that
             // row's deletion (#5418 parity): drop it from the to-delete set so
             // the conflicting row survives.
-            if has_delete_triggers {
+            if fire_delete_triggers {
                 let mut kept = Vec::with_capacity(rows_for_index.len());
                 // Rows whose deletion was abandoned by a BEFORE DELETE
                 // RAISE(IGNORE) — they stay live and may still collide with the
@@ -714,7 +721,7 @@ pub(super) fn execute_internal(
             // `(SELECT count(*) FROM t1)` — matching sqlite3. A RAISE(IGNORE)
             // here cannot un-delete the row (sqlite3 3.51 keeps it deleted), so
             // the outcome is a no-op.
-            if has_delete_triggers {
+            if fire_delete_triggers {
                 for (_, row) in &rows_for_index {
                     let _after_outcome = crate::TriggerFirer::execute_after_triggers(
                         database,
@@ -1849,14 +1856,18 @@ fn execute_update_from(
                 // Issue #5490: UPDATE OR REPLACE ... FROM removes the conflicting
                 // row(s) too, so fire the replaced row's DELETE triggers (BEFORE
                 // before removal, AFTER once gone) — matching the non-FROM path
-                // above and INSERT OR REPLACE.
-                let has_delete_triggers = database
+                // above and INSERT OR REPLACE. Gated on `recursive_triggers`:
+                // REPLACE conflict-resolution DELETE triggers fire only when
+                // recursive triggers are enabled (lang_conflict.html;
+                // triggerC-5.3, #5840). The row is removed regardless.
+                let fire_delete_triggers = database
                     .catalog
                     .get_triggers_for_table(table_name, Some(vibesql_ast::TriggerEvent::Delete))
                     .next()
-                    .is_some();
+                    .is_some()
+                    && database.recursive_triggers();
 
-                if has_delete_triggers {
+                if fire_delete_triggers {
                     let mut kept = Vec::with_capacity(rows_for_index.len());
                     // Conflict rows whose deletion was abandoned by a BEFORE
                     // DELETE RAISE(IGNORE) — they stay live.
@@ -1956,7 +1967,7 @@ fn execute_update_from(
 
                 // Fire AFTER DELETE triggers now that the conflicting rows are
                 // gone (issue #5490).
-                if has_delete_triggers {
+                if fire_delete_triggers {
                     for (_, row) in &rows_for_index {
                         let _after_outcome = crate::TriggerFirer::execute_after_triggers(
                             database,

--- a/crates/vibesql-executor/src/update/triggers.rs
+++ b/crates/vibesql-executor/src/update/triggers.rs
@@ -103,7 +103,6 @@ pub(super) fn execute_update_on_view(
     // same row after an earlier one IGNOREs, but that multi-trigger-per-view
     // case is rare; the common single-trigger case matches sqlite3 exactly —
     // the row's operation is skipped.)
-    let rows_processed = updates.len();
     for (old_row, new_row) in &updates {
         for trigger in &triggers {
             if crate::TriggerFirer::execute_trigger(database, trigger, Some(old_row), Some(new_row))?
@@ -130,7 +129,10 @@ pub(super) fn execute_update_on_view(
         None
     };
 
-    Ok((rows_processed, returning))
+    // changes() after an UPDATE on a view is always zero — no physical table
+    // rows were modified by the statement itself (SQLite R-09813-48563;
+    // e_changes-4.3.2, #5840).
+    Ok((0, returning))
 }
 
 /// Build (old_row, new_row) update pairs for an UPDATE on a view WITHOUT a FROM

--- a/crates/vibesql-executor/tests/changes_and_replace_trigger_semantics_tests.rs
+++ b/crates/vibesql-executor/tests/changes_and_replace_trigger_semantics_tests.rs
@@ -1,0 +1,193 @@
+//! Trigger/DML semantics from the #5840 batch, verified against sqlite3 3.51.0:
+//!
+//! * Item 2 — REPLACE conflict-resolution DELETE triggers fire *iff*
+//!   `recursive_triggers` is ON (SQLite lang_conflict.html). With the default
+//!   (OFF) the implicit conflict-delete is silent; the row is still removed.
+//! * Item 5a — `changes()` immediately after an INSERT/UPDATE/DELETE on a view
+//!   is always 0 (SQLite R-09813-48563), because no physical table rows were
+//!   modified by the statement itself.
+//! * Item 5b — inside a trigger body each INSERT/UPDATE/DELETE sets `changes()`
+//!   to the rows *it* modified, and the value is saved before the body runs and
+//!   restored afterward, so a sub-trigger's nested DML never leaks into the
+//!   caller's `changes()` (SQLite R-32918-61474 / R-17146-37073).
+
+use vibesql_executor::{
+    CreateTableExecutor, DeleteExecutor, InsertExecutor, SelectExecutor, TriggerExecutor,
+    UpdateExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Parse and execute a single statement, preserving the raw SQL for triggers.
+fn exec(db: &mut Database, sql: &str) {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e:?}"));
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+        }
+        Statement::CreateView(s) => {
+            vibesql_executor::advanced_objects::execute_create_view(&s, db)
+                .expect("CREATE VIEW failed");
+        }
+        Statement::CreateTrigger(s) => {
+            TriggerExecutor::create_trigger_with_sql(db, &s, Some(sql))
+                .expect("CREATE TRIGGER failed");
+        }
+        // Mirror what the session layer does after a top-level DML statement:
+        // publish the executor's returned row count as changes(). For a view
+        // DML the executor returns 0 (Item 5a), so changes() lands at 0.
+        Statement::Insert(s) => {
+            let n = InsertExecutor::execute(db, &s).expect("INSERT failed");
+            db.set_last_changes_count(n);
+        }
+        Statement::Update(s) => {
+            let n = UpdateExecutor::execute(&s, db).expect("UPDATE failed");
+            db.set_last_changes_count(n);
+        }
+        Statement::Delete(s) => {
+            let n = DeleteExecutor::execute(&s, db).expect("DELETE failed");
+            db.set_last_changes_count(n);
+        }
+        other => panic!("unsupported statement in test helper: {other:?}"),
+    }
+}
+
+/// Run a SELECT and return rows as `Vec<Vec<SqlValue>>` (live rows only).
+fn query(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    use vibesql_ast::Statement;
+    let Statement::Select(select) = Parser::parse_sql(sql).expect("parse failed") else {
+        panic!("expected SELECT");
+    };
+    SelectExecutor::new(db)
+        .execute(&select)
+        .expect("SELECT failed")
+        .into_iter()
+        .map(|row| row.values.to_vec())
+        .collect()
+}
+
+fn texts(db: &Database, sql: &str) -> Vec<String> {
+    query(db, sql)
+        .into_iter()
+        .map(|r| match &r[0] {
+            SqlValue::Varchar(s) => s.to_string(),
+            other => panic!("expected text, got {other:?}"),
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Item 2: REPLACE conflict-delete triggers gated on recursive_triggers.
+// ---------------------------------------------------------------------------
+
+/// With the default `recursive_triggers = OFF`, an INSERT OR REPLACE that clears
+/// a conflicting row does NOT fire that row's DELETE trigger, but the row is
+/// still replaced (triggerC-5.3 shape).
+#[test]
+fn replace_conflict_delete_trigger_suppressed_when_recursion_off() {
+    let mut db = Database::new();
+    assert!(!db.recursive_triggers(), "default is OFF");
+    exec(&mut db, "CREATE TABLE t(a INTEGER PRIMARY KEY, b)");
+    exec(&mut db, "CREATE TABLE log(x)");
+    exec(&mut db, "INSERT INTO t VALUES(1, 'a')");
+    exec(
+        &mut db,
+        "CREATE TRIGGER t_del AFTER DELETE ON t BEGIN INSERT INTO log VALUES(old.b); END",
+    );
+
+    exec(&mut db, "INSERT OR REPLACE INTO t VALUES(1, 'b')");
+
+    assert!(query(&db, "SELECT x FROM log").is_empty(), "conflict-delete trigger must not fire");
+    assert_eq!(texts(&db, "SELECT b FROM t"), vec!["b".to_string()], "row was still replaced");
+}
+
+/// With `recursive_triggers = ON`, the same REPLACE fires the conflict row's
+/// DELETE trigger (triggerC-5.2 shape).
+#[test]
+fn replace_conflict_delete_trigger_fires_when_recursion_on() {
+    let mut db = Database::new();
+    db.set_recursive_triggers(true);
+    exec(&mut db, "CREATE TABLE t(a INTEGER PRIMARY KEY, b)");
+    exec(&mut db, "CREATE TABLE log(x)");
+    exec(&mut db, "INSERT INTO t VALUES(1, 'a')");
+    exec(
+        &mut db,
+        "CREATE TRIGGER t_del AFTER DELETE ON t BEGIN INSERT INTO log VALUES(old.b); END",
+    );
+
+    exec(&mut db, "INSERT OR REPLACE INTO t VALUES(1, 'b')");
+
+    assert_eq!(texts(&db, "SELECT x FROM log"), vec!["a".to_string()], "trigger fires for old row");
+}
+
+// ---------------------------------------------------------------------------
+// Item 5a: changes() is 0 after DML on a view.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn changes_is_zero_after_instead_of_view_dml() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE base(x, y)");
+    exec(&mut db, "CREATE TABLE log(x)");
+    exec(&mut db, "INSERT INTO base VALUES(1, 2), (3, 4)");
+    exec(&mut db, "CREATE VIEW v AS SELECT * FROM base");
+    exec(
+        &mut db,
+        "CREATE TRIGGER v_i INSTEAD OF INSERT ON v BEGIN INSERT INTO log VALUES('i'); END",
+    );
+
+    // A real-table insert sets changes() to its row count...
+    exec(&mut db, "INSERT INTO base VALUES(5, 6)");
+    assert_eq!(db.last_changes_count(), 1);
+
+    // ...but a view insert leaves changes() at 0 even though the INSTEAD OF
+    // trigger fired (verified via the log table).
+    exec(&mut db, "INSERT INTO v VALUES(7, 8)");
+    assert_eq!(db.last_changes_count(), 0, "changes() is 0 for a view INSERT");
+    assert_eq!(texts(&db, "SELECT x FROM log"), vec!["i".to_string()], "trigger still fired");
+}
+
+// ---------------------------------------------------------------------------
+// Item 5b: changes() inside a trigger body reflects the nested DML and is
+// saved/restored around the trigger program.
+// ---------------------------------------------------------------------------
+
+/// e_changes-6.1 shape: nested INSERTs inside trigger bodies each update
+/// changes(); after a sub-trigger runs the value is restored so the enclosing
+/// statement observes only its own row count.
+#[test]
+fn changes_inside_trigger_body_reflects_nested_dml_and_restores() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a, b)");
+    exec(&mut db, "CREATE TABLE t2(a, b)");
+    exec(&mut db, "CREATE TABLE t3(a, b)");
+    exec(&mut db, "CREATE TABLE log(x)");
+    exec(
+        &mut db,
+        "CREATE TRIGGER t1_i BEFORE INSERT ON t1 BEGIN \
+         INSERT INTO t2 VALUES(new.a, new.b), (new.a, new.b); \
+         INSERT INTO log VALUES('t2->' || changes()); END",
+    );
+    exec(
+        &mut db,
+        "CREATE TRIGGER t2_i AFTER INSERT ON t2 BEGIN \
+         INSERT INTO t3 VALUES(new.a, new.b), (new.a, new.b), (new.a, new.b); \
+         INSERT INTO log VALUES('t3->' || changes()); END",
+    );
+
+    exec(&mut db, "INSERT INTO t1 VALUES('+', 'o')");
+
+    // Each t2 insert (2 of them) fires t2_i, which inserts 3 t3 rows and logs
+    // 't3->3'; the enclosing t1_i then logs 't2->2' (its own 2-row t2 insert,
+    // not the sub-trigger's t3 rows).
+    assert_eq!(
+        texts(&db, "SELECT x FROM log"),
+        vec!["t3->3".to_string(), "t3->3".to_string(), "t2->2".to_string()],
+    );
+
+    // The top-level statement's changes() is its own direct row count (1),
+    // unaffected by the nested trigger DML.
+    assert_eq!(db.last_changes_count(), 1, "outer INSERT changes() restored to 1");
+}

--- a/crates/vibesql-executor/tests/recursive_triggers_pragma_tests.rs
+++ b/crates/vibesql-executor/tests/recursive_triggers_pragma_tests.rs
@@ -4,9 +4,9 @@
 //! not re-fired by DML performed within its own body — directly- and
 //! mutually-recursive trigger firing is suppressed. A *different* trigger
 //! reached via nested DML still fires, and a trigger fired at the top level
-//! still fires (it is not yet on the stack). With `recursive_triggers = ON`
-//! (VibeSQL's default, matching modern SQLite), triggers recurse up to the depth
-//! cap (#5479).
+//! still fires (it is not yet on the stack). With `recursive_triggers = ON`,
+//! triggers recurse up to the depth cap (#5479). OFF is the default, matching
+//! SQLite's `pragma.c` (#5840).
 //!
 //! Every expectation below was verified against sqlite3 3.51.0. The headline
 //! case (`off_suppresses_self_refiring_trigger3_6_shape`) reproduces the exact
@@ -176,8 +176,9 @@ fn off_suppresses_mutual_recursion() {
 #[test]
 fn on_recurses_to_completion() {
     let mut db = Database::new();
-    // Default is ON; assert that and do not change it.
-    assert!(db.recursive_triggers(), "recursive_triggers must default to ON");
+    // Default is OFF (matches SQLite); enable recursion explicitly for this case.
+    db.set_recursive_triggers(true);
+    assert!(db.recursive_triggers(), "recursive_triggers explicitly enabled");
 
     exec(&mut db, "CREATE TABLE t(a INTEGER PRIMARY KEY)");
     exec(
@@ -221,8 +222,9 @@ fn toggle_mid_session_takes_effect() {
          INSERT INTO t VALUES(new.a - 1); END",
     );
 
-    // ON (default): inserting 5 recurses to 5,4,3,2,1 = 5 rows.
-    assert!(db.recursive_triggers(), "recursive_triggers must default to ON");
+    // ON (explicitly enabled): inserting 5 recurses to 5,4,3,2,1 = 5 rows.
+    db.set_recursive_triggers(true);
+    assert!(db.recursive_triggers(), "recursive_triggers explicitly enabled");
     exec(&mut db, "INSERT INTO t VALUES(5)");
     assert_eq!(query(&db, "SELECT a FROM t").len(), 5, "ON: 5,4,3,2,1");
 

--- a/crates/vibesql-executor/tests/trigger_depth_limit_tests.rs
+++ b/crates/vibesql-executor/tests/trigger_depth_limit_tests.rs
@@ -122,6 +122,11 @@ fn default_limit_allows_recursion_blocked_by_a_low_runtime_limit() {
 #[test]
 fn runtime_limit_above_cap_does_not_raise_the_stack_safe_cap() {
     let mut db = Database::new();
+    // This test relies on unbounded self-recursion reaching the compile-time
+    // cap; the default recursive_triggers is now OFF (SQLite default, #5840),
+    // which would suppress the self-re-entry after one level. Enable recursion
+    // so the depth cap — not the suppression — is what stops the loop.
+    db.set_recursive_triggers(true);
     db.set_trigger_depth_limit(100_000);
 
     // Recursion still aborts at the compile-time cap, not at 100_000 — proven by

--- a/crates/vibesql-executor/tests/trigger_recursion_stack.rs
+++ b/crates/vibesql-executor/tests/trigger_recursion_stack.rs
@@ -93,6 +93,10 @@ fn count_rows(db: &Database, table: &str) -> usize {
 /// producing rows `start..=0`, unless it first hits the recursion cap.
 fn run_countdown(start: i64) -> (Database, Result<(), vibesql_executor::ExecutorError>) {
     let mut db = Database::new();
+    // These tests exercise deep native trigger recursion, which requires
+    // recursive_triggers ON. The default is now OFF (SQLite default, #5840),
+    // which would suppress the self-re-entry after one level, so enable it here.
+    db.set_recursive_triggers(true);
     exec(&mut db, "CREATE TABLE t2(a INTEGER PRIMARY KEY)").unwrap();
     exec(
         &mut db,

--- a/crates/vibesql-executor/tests/update_or_replace_without_rowid_delete_trigger_tests.rs
+++ b/crates/vibesql-executor/tests/update_or_replace_without_rowid_delete_trigger_tests.rs
@@ -103,6 +103,10 @@ fn text_column(db: &Database, sql: &str) -> Vec<String> {
 #[test]
 fn after_delete_trigger_fires_for_or_replace_conflicts_without_rowid() {
     let mut db = Database::new();
+    // REPLACE conflict-resolution DELETE triggers fire only with
+    // recursive_triggers ON (SQLite lang_conflict.html; #5840). triggerF.test
+    // sets it on; match that here since these tests assert the trigger fires.
+    db.set_recursive_triggers(true);
     exec(&mut db, "CREATE TABLE t1(a INT PRIMARY KEY, b) WITHOUT ROWID");
     exec(&mut db, "CREATE TABLE log(t)");
     exec(
@@ -137,6 +141,7 @@ fn after_delete_trigger_fires_for_or_replace_conflicts_without_rowid() {
 #[test]
 fn before_delete_trigger_fires_for_or_replace_conflicts_without_rowid() {
     let mut db = Database::new();
+    db.set_recursive_triggers(true); // REPLACE conflict DELETE triggers fire only with recursion on (#5840)
     exec(&mut db, "CREATE TABLE t1(a INT PRIMARY KEY, b) WITHOUT ROWID");
     exec(&mut db, "CREATE TABLE log(t)");
     exec(
@@ -167,6 +172,7 @@ fn before_delete_trigger_fires_for_or_replace_conflicts_without_rowid() {
 #[test]
 fn update_or_replace_multi_unique_conflict_without_rowid() {
     let mut db = Database::new();
+    db.set_recursive_triggers(true); // REPLACE conflict DELETE triggers fire only with recursion on (#5840)
     exec(&mut db, "CREATE TABLE t(a INT PRIMARY KEY, b UNIQUE, c UNIQUE) WITHOUT ROWID");
     exec(&mut db, "CREATE TABLE log(t)");
     exec(
@@ -201,6 +207,7 @@ fn update_or_replace_multi_unique_conflict_without_rowid() {
 #[test]
 fn update_or_replace_rowid_table_still_resolves_and_fires_delete_trigger() {
     let mut db = Database::new();
+    db.set_recursive_triggers(true); // REPLACE conflict DELETE triggers fire only with recursion on (#5840)
     exec(&mut db, "CREATE TABLE t(a INTEGER PRIMARY KEY, b)");
     exec(&mut db, "CREATE TABLE log(t)");
     exec(
@@ -238,6 +245,7 @@ fn text(s: &str) -> SqlValue {
 #[test]
 fn update_or_replace_before_delete_ignore_raises_unique_and_leaves_table_unchanged() {
     let mut db = Database::new();
+    db.set_recursive_triggers(true); // REPLACE conflict DELETE triggers fire only with recursion on (#5840)
     exec(&mut db, "CREATE TABLE t1(a INT PRIMARY KEY, b) WITHOUT ROWID");
     // RAISE(IGNORE) only for the conflicting row (a=3), so the deletion that
     // UPDATE OR REPLACE wants to perform is abandoned.
@@ -269,6 +277,7 @@ fn update_or_replace_before_delete_ignore_raises_unique_and_leaves_table_unchang
 #[test]
 fn update_or_replace_from_before_delete_ignore_raises_unique_and_leaves_table_unchanged() {
     let mut db = Database::new();
+    db.set_recursive_triggers(true); // REPLACE conflict DELETE triggers fire only with recursion on (#5840)
     exec(&mut db, "CREATE TABLE t1(a INT PRIMARY KEY, b) WITHOUT ROWID");
     exec(
         &mut db,

--- a/crates/vibesql-storage/src/database/session.rs
+++ b/crates/vibesql-storage/src/database/session.rs
@@ -146,13 +146,14 @@ impl Database {
 
     /// Get the recursive_triggers PRAGMA setting (SQLite compatibility).
     ///
-    /// When ON (VibeSQL default, matching modern SQLite's documented behavior),
-    /// a trigger's body may fire further triggers — including, indirectly,
-    /// itself — up to `MAX_TRIGGER_RECURSION_DEPTH`. When OFF, a trigger that is
-    /// already executing is not re-fired by DML performed within its own body
-    /// (directly- or mutually-recursive trigger firing is suppressed). This is
-    /// the historical SQLite behavior that pre-recursion tests such as
-    /// `trigger3.test` rely on (see #5535).
+    /// When ON, a trigger's body may fire further triggers — including,
+    /// indirectly, itself — up to `MAX_TRIGGER_RECURSION_DEPTH`. When OFF
+    /// (VibeSQL default, matching SQLite's `pragma.c` default of 0), a trigger
+    /// that is already executing is not re-fired by DML performed within its own
+    /// body (directly- or mutually-recursive trigger firing is suppressed). This
+    /// is the historical SQLite behavior that pre-recursion tests such as
+    /// `trigger1.test`, `triggerC.test`, and `trigger3.test` rely on (see #5535,
+    /// #5840).
     ///
     /// Suppression is *per trigger*: a nested DML statement still fires any
     /// trigger that is not already on the execution stack — only a re-entry into
@@ -161,7 +162,7 @@ impl Database {
     pub fn recursive_triggers(&self) -> bool {
         match self.get_session_variable("RECURSIVE_TRIGGERS") {
             Some(vibesql_types::SqlValue::Integer(n)) => *n != 0,
-            _ => true, // Default: ON (modern SQLite default; keeps recursive-trigger tests green)
+            _ => false, // Default: OFF (matches SQLite's pragma.c default of 0)
         }
     }
 

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -129,7 +129,7 @@ set ::pragma_prefix_skip_count_changes 0 ;# Per-block: suppress count_changes pr
 set ::pragma_reverse_unordered_selects 0  ;# Default: OFF (normal row order)
 set ::pragma_foreign_keys 0              ;# Default: OFF (SQLite default)
 set ::pragma_defer_foreign_keys 0        ;# Default: OFF; auto-resets at COMMIT/ROLLBACK
-set ::pragma_recursive_triggers 1        ;# Default: ON (VibeSQL default; #5535)
+set ::pragma_recursive_triggers 0        ;# Default: OFF (VibeSQL/SQLite default; #5535, #5840)
 set ::pragma_trigger_depth_limit 0       ;# 0 = default cap; >0 = per-connection SQLITE_LIMIT_TRIGGER_DEPTH (#5536)
 
 # DQS (Double-Quoted Strings) mode tracking
@@ -1122,12 +1122,12 @@ proc build_pragma_prefix {} {
     if {$::pragma_defer_foreign_keys != 0} {
         append prefix "PRAGMA defer_foreign_keys=$::pragma_defer_foreign_keys;\n"
     }
-    # Include recursive_triggers if it's been set to OFF. VibeSQL (like modern
-    # SQLite) defaults this pragma to ON, and the multi-process shim starts each
-    # CLI process at that default, so we only need to re-apply the non-default
-    # OFF state. Tests such as trigger3.test set it off for the whole file
-    # (#5535).
-    if {$::pragma_recursive_triggers != 1} {
+    # Include recursive_triggers if it's been set to ON. VibeSQL (like SQLite's
+    # pragma.c) defaults this pragma to OFF, and the multi-process shim starts
+    # each CLI process at that default, so we only need to re-apply the
+    # non-default ON state. Tests such as triggerC.test set it on for the whole
+    # file (#5535, #5840).
+    if {$::pragma_recursive_triggers != 0} {
         append prefix "PRAGMA recursive_triggers=$::pragma_recursive_triggers;\n"
     }
     # Carry the per-connection trigger-depth limit forward (#5536). SQLite sets


### PR DESCRIPTION
## Summary

Aligns several trigger/DML semantics with SQLite, landing the tractable items from the #5840 batch (curation triage of 2026-07-05). Four target TCL files improve by **+15 passing tests** with **zero regressions** across the trigger/fkey canaries.

| File | Before | After |
|------|--------|-------|
| trigger1 | 35 passed / 35 failed | 36 passed / 34 failed |
| triggerC | 89 passed / 30 failed | 95 passed / 24 failed |
| e_changes | 44 passed / 27 failed | 52 passed / 19 failed |
| returning1 | 68 passed / 11 failed | 68 passed / 11 failed |

## Changes

- **Item 1 — `recursive_triggers` default OFF** (`session.rs`): flipped from ON to OFF to match SQLite's `pragma.c` default. The multi-process TCL shim (`tester_vibesql.tcl`) replay model is inverted to match: it now re-applies the *ON* state (the non-default), so files that `PRAGMA recursive_triggers = on` (e.g. triggerC) still recurse. Without the shim fix triggerC regressed 22 tests; with it, no regression.
- **Item 2 (sub-bug A) — REPLACE conflict-delete trigger gating** (`insert/replace.rs`, `update/executor.rs`): REPLACE / UPDATE OR REPLACE conflict-resolution DELETE triggers now fire *iff* `recursive_triggers` is ON (SQLite lang_conflict.html). The conflicting row is still removed either way; only the trigger firing is gated. Fixes triggerC-5.3.2–5.3.7.
- **Item 5a — `changes()` == 0 after view DML** (`insert/execution.rs`, `update/triggers.rs`, `delete/executor.rs`): the INSTEAD OF view paths now report 0 rows-changed (SQLite R-09813-48563). Fixes e_changes-4.2.2/4.3.2/4.4.2.
- **Item 5b — `changes()` inside trigger bodies** (`trigger_execution.rs`): each nested INSERT/UPDATE/DELETE now sets `changes()` to the rows it directly modified, and the value is saved before the trigger program and restored after, so a sub-trigger's DML never leaks into the caller's `changes()` (SQLite R-32918-61474 / R-17146-37073). Fixes e_changes sections 6 and 7.
- **Tests**: in-tree tests that relied on the old default-ON behavior now enable `recursive_triggers` explicitly (recursion-depth, mutual-recursion, REPLACE-with-DELETE-trigger cases). INSTEAD OF view-DML tests assert `changes()==0` (fire counts still verified via `log`/RETURNING). New integration test `changes_and_replace_trigger_semantics_tests.rs` covers the REPLACE gate and both `changes()` rules.

## Acceptance Criteria Verification

| Item | Status | Verification |
|------|--------|--------------|
| 1: recursive_triggers default ON→OFF | ✅ landed | `PRAGMA recursive_triggers` reads 0 by default; unit + TCL green |
| 2: REPLACE conflict-deletions fire DELETE triggers with recursion off | ✅ sub-bug A landed | triggerC-5.3.x pass; conflict-delete gated on recursion |
| 2: stale table state (count between multi-row conflict deletes) | ⏳ deferred | triggerC-5.1.6/5.1.7/5.2.6/5.2.7 — needs interleaved per-row delete across two REPLACE paths (compaction/index-shift hazard); deferred to avoid regression |
| 3: parent UPDATE clobbers BEFORE-trigger same-row writes | ⏳ deferred | no failing case among the four target files; risky UPDATE-executor re-read left out of this focused PR |
| 4: `new.rowid = -1` in BEFORE INSERT | ✅ already fixed | verified fixed by #5741 (no change needed) |
| 5: changes() frozen in trigger body + non-zero after INSTEAD OF | ✅ landed | e_changes 4.x/6.x/7.x pass; new unit test |
| 6: RETURNING alias / per-row subqueries | ⏳ deferred | returning1 failures are parser/feature gaps (`WITH…INSERT`, multi-connection, custom SQL funcs), not alias/subquery; no tractable in-scope fix confirmed |
| 7: TEMP schema separation (~30 failures) | 📌 split out | EPIC-sized; should be its own issue (the remaining trigger1 failures — 6.x/8.x "temp_table"/"temp_trig" leakage, multi-connection `db2`, error-message wording — are TEMP-schema or shim limitations, not items 1–6) |

## Test Plan

- `cargo test -p vibesql-executor` and `-p vibesql-storage`: green (updated the default-ON-dependent tests; added a focused integration test).
- `make test-tcl-file` on the four target files: before/after in the table above.
- Canary sweep (no regressions): triggerF 100%, trigger2 100%, trigger3 0 failed, trigger4 100%, upsert1 97%, triggerA 94%. Remaining canary failures (trigger7/triggerB/fkey1) are pre-existing error-message/feature gaps unrelated to these changes.

## Notes

This lands items 1, 2a, 5a, 5b. Items 2b (stale count), 3, and 6 are deferred with rationale above; **item 7 (TEMP schema separation) should be split to its own issue** as the issue body anticipated. Using `Part of #5840` so the issue stays open for the remaining items.

Part of #5840