### PR TITLE
fix(sql): min/max honor COLLATE + preserve keyword-alias case + PRAGMA gaps (#5842)

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -1191,6 +1191,22 @@ impl SqlExecutor {
             "TABLE_INFO" => {
                 return self.execute_pragma_table_info(stmt);
             }
+            "INTEGRITY_CHECK" | "QUICK_CHECK" => {
+                // SQLite compatibility: `PRAGMA integrity_check` and the
+                // table-scoped form `PRAGMA integrity_check('t1')` both report
+                // "ok" when no corruption is found. The table-argument form
+                // arrives as `stmt.value = Some(...)`, which would otherwise be
+                // misrouted to the SET branch and silently ignored (returning an
+                // empty result). Handle both forms here, before the set/query
+                // split, so any argument is accepted and "ok" is returned.
+                return Ok(QueryResult {
+                    columns: vec![pragma_name.to_lowercase()],
+                    rows: vec![vec![Some("ok".to_string())]],
+                    row_count: 1,
+                    execution_time_ms: None,
+                    message: None,
+                });
+            }
             _ => {}
         }
 
@@ -1391,13 +1407,14 @@ impl SqlExecutor {
                         message: None,
                     })
                 }
-                "INTEGRITY_CHECK" => {
-                    // SQLite compatibility: Return "ok" if no corruption detected
-                    // Since we're in-memory and don't have B-tree corruption scenarios,
-                    // we always return "ok"
+                "JOURNAL_MODE" => {
+                    // SQLite compatibility: report the active journaling mode as a
+                    // single-row result. VibeSQL runs its own always-on WAL, so it
+                    // reports "wal" (the SET form, `PRAGMA journal_mode = X`, is a
+                    // silently-accepted no-op handled by the catch-all above).
                     Ok(QueryResult {
-                        columns: vec!["integrity_check".to_string()],
-                        rows: vec![vec![Some("ok".to_string())]],
+                        columns: vec!["journal_mode".to_string()],
+                        rows: vec![vec![Some("wal".to_string())]],
                         row_count: 1,
                         execution_time_ms: None,
                         message: None,

--- a/crates/vibesql-cli/src/executor/tests.rs
+++ b/crates/vibesql-cli/src/executor/tests.rs
@@ -581,3 +581,50 @@ fn test_question_numbered_placeholder_upsert_inexact_target() {
         "unexpected error: {msg}"
     );
 }
+
+// Issue #5842 sub-item 4: PRAGMA gaps.
+
+#[test]
+fn test_pragma_journal_mode_echoes_wal() {
+    // PRAGMA journal_mode (query form) must return a single row reporting the
+    // active journaling mode. VibeSQL runs its own always-on WAL, so it reports
+    // "wal" instead of silently returning an empty result.
+    let mut executor = SqlExecutor::new(None).unwrap();
+    let result = executor.execute("PRAGMA journal_mode").unwrap();
+    assert_eq!(result.row_count, 1);
+    assert_eq!(result.columns, vec!["journal_mode".to_string()]);
+    assert_eq!(result.rows[0][0].as_deref(), Some("wal"));
+}
+
+#[test]
+fn test_pragma_journal_mode_set_is_accepted() {
+    // The SET form is a silently-accepted no-op (VibeSQL's WAL is always on).
+    let mut executor = SqlExecutor::new(None).unwrap();
+    // Must not error.
+    executor.execute("PRAGMA journal_mode = WAL").unwrap();
+}
+
+#[test]
+fn test_pragma_integrity_check_no_argument() {
+    let mut executor = SqlExecutor::new(None).unwrap();
+    let result = executor.execute("PRAGMA integrity_check").unwrap();
+    assert_eq!(result.row_count, 1);
+    assert_eq!(result.rows[0][0].as_deref(), Some("ok"));
+}
+
+#[test]
+fn test_pragma_integrity_check_with_table_argument() {
+    // The table-scoped form `PRAGMA integrity_check('t1')` previously fell into
+    // the SET branch and was silently ignored (empty result). It must report
+    // "ok" for any table argument.
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor.execute("CREATE TABLE t1(a INT)").unwrap();
+    let result = executor.execute("PRAGMA integrity_check('t1')").unwrap();
+    assert_eq!(result.row_count, 1, "integrity_check(table) should return one row");
+    assert_eq!(result.rows[0][0].as_deref(), Some("ok"));
+
+    // Unquoted identifier argument form as well.
+    let result = executor.execute("PRAGMA integrity_check(t1)").unwrap();
+    assert_eq!(result.row_count, 1);
+    assert_eq!(result.rows[0][0].as_deref(), Some("ok"));
+}

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/aggregate_function.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/aggregate_function.rs
@@ -368,6 +368,16 @@ pub(super) fn evaluate(
 
     let mut acc = AggregateAccumulator::new(name.canonical(), distinct)?;
 
+    // Thread an explicit COLLATE on the aggregate argument into MIN/MAX so
+    // `min(x COLLATE nocase)` / `max(x COLLATE rtrim)` order by the requested
+    // collation instead of raw binary bytes (minmax3 §4). No-op for every other
+    // aggregate kind. This top-level `acc` is the one used by the plain MIN/MAX
+    // path; the specialized GROUP_CONCAT/JSON/PERCENTILE/MD5SUM branches build
+    // their own accumulators and are unaffected.
+    if args.len() == 1 {
+        acc.set_min_max_collation(crate::evaluator::collation::explicit_collation_of(&args[0]));
+    }
+
     // Special handling for COUNT(*)
     if name.to_uppercase() == "COUNT" && args.len() == 1 {
         let is_count_star = matches!(args[0], vibesql_ast::Expression::Wildcard)
@@ -790,17 +800,13 @@ pub(super) fn evaluate(
                 // outer schema; on failure (e.g. references inner columns),
                 // fall back to skipping the filter (no rows to filter from).
                 if let Some(filter_expr) = filter {
-                    let filter_val = evaluate_expr_against_outer_row(
-                        filter_expr,
-                        outer_row,
-                        outer_schema,
-                    )?;
+                    let filter_val =
+                        evaluate_expr_against_outer_row(filter_expr, outer_row, outer_schema)?;
                     if !executor.is_truthy(&filter_val)? {
                         continue;
                     }
                 }
-                let value =
-                    evaluate_expr_against_outer_row(&args[0], outer_row, outer_schema)?;
+                let value = evaluate_expr_against_outer_row(&args[0], outer_row, outer_schema)?;
                 acc.accumulate(&value);
             }
             let result = acc.finalize()?;

--- a/crates/vibesql-executor/src/select/grouping/aggregates.rs
+++ b/crates/vibesql-executor/src/select/grouping/aggregates.rs
@@ -45,11 +45,17 @@ pub enum AggregateAccumulator {
         value: Option<vibesql_types::SqlValue>,
         distinct: bool,
         seen: Option<HashSet<vibesql_types::SqlValue>>,
+        /// Optional COLLATE sequence applied to the aggregate argument
+        /// (e.g. `min(x COLLATE nocase)`). `None` = default BINARY comparison.
+        collation: Option<String>,
     },
     Max {
         value: Option<vibesql_types::SqlValue>,
         distinct: bool,
         seen: Option<HashSet<vibesql_types::SqlValue>>,
+        /// Optional COLLATE sequence applied to the aggregate argument
+        /// (e.g. `max(x COLLATE nocase)`). `None` = default BINARY comparison.
+        collation: Option<String>,
     },
     /// GROUP_CONCAT - Concatenate values with separator (SQLite compatible)
     GroupConcat {
@@ -125,8 +131,8 @@ impl AggregateAccumulator {
                 distinct,
                 seen,
             }),
-            "MIN" => Ok(AggregateAccumulator::Min { value: None, distinct, seen }),
-            "MAX" => Ok(AggregateAccumulator::Max { value: None, distinct, seen }),
+            "MIN" => Ok(AggregateAccumulator::Min { value: None, distinct, seen, collation: None }),
+            "MAX" => Ok(AggregateAccumulator::Max { value: None, distinct, seen, collation: None }),
             "GROUP_CONCAT" | "STRING_AGG" => Ok(AggregateAccumulator::GroupConcat {
                 values: Vec::new(),
                 separator: separator.to_string(),
@@ -165,6 +171,19 @@ impl AggregateAccumulator {
                 "Unknown aggregate function: {}",
                 function_name
             ))),
+        }
+    }
+
+    /// Attach a COLLATE sequence to a MIN/MAX accumulator so its comparisons
+    /// honor `min(x COLLATE nocase)` / `max(x COLLATE rtrim)`. No-op for every
+    /// other aggregate kind (collation only affects ordering).
+    pub fn set_min_max_collation(&mut self, new_collation: Option<String>) {
+        match self {
+            AggregateAccumulator::Min { collation, .. }
+            | AggregateAccumulator::Max { collation, .. } => {
+                *collation = new_collation;
+            }
+            _ => {}
         }
     }
 
@@ -290,7 +309,7 @@ impl AggregateAccumulator {
             }
 
             // MIN - finds minimum value, ignores NULLs
-            AggregateAccumulator::Min { value: ref mut current_min, distinct, seen } => {
+            AggregateAccumulator::Min { value: ref mut current_min, distinct, seen, collation } => {
                 if value.is_null() || !is_comparable_value(value) {
                     return; // Skip NULL and unsupported types
                 }
@@ -304,9 +323,11 @@ impl AggregateAccumulator {
                     seen_set.insert(value.clone());
                 }
 
-                // Update minimum if needed
+                // Update minimum if needed (honoring any COLLATE clause)
                 if let Some(ref current) = current_min {
-                    if compare_sql_values(value, current) == Ordering::Less {
+                    if compare_sql_values_with_collation(value, current, collation.as_deref())
+                        == Ordering::Less
+                    {
                         *current_min = Some(value.clone());
                     }
                 } else {
@@ -315,7 +336,7 @@ impl AggregateAccumulator {
             }
 
             // MAX - finds maximum value, ignores NULLs
-            AggregateAccumulator::Max { value: ref mut current_max, distinct, seen } => {
+            AggregateAccumulator::Max { value: ref mut current_max, distinct, seen, collation } => {
                 if value.is_null() || !is_comparable_value(value) {
                     return; // Skip NULL and unsupported types
                 }
@@ -329,9 +350,11 @@ impl AggregateAccumulator {
                     seen_set.insert(value.clone());
                 }
 
-                // Update maximum if needed
+                // Update maximum if needed (honoring any COLLATE clause)
                 if let Some(ref current) = current_max {
-                    if compare_sql_values(value, current) == Ordering::Greater {
+                    if compare_sql_values_with_collation(value, current, collation.as_deref())
+                        == Ordering::Greater
+                    {
                         *current_max = Some(value.clone());
                     }
                 } else {
@@ -619,7 +642,14 @@ impl AggregateAccumulator {
                 let json_array = sql_values_to_json_array(values);
                 Ok(vibesql_types::SqlValue::Varchar(json_array.into()))
             }
-            AggregateAccumulator::Percentile { values, fraction, discrete, error, distinct, .. } => {
+            AggregateAccumulator::Percentile {
+                values,
+                fraction,
+                discrete,
+                error,
+                distinct,
+                ..
+            } => {
                 // Deferred step errors surface at finalize time with the
                 // SQLite-exact message (SqliteCompatError displays as-is).
                 if let Some(msg) = error {
@@ -811,8 +841,13 @@ impl AggregateAccumulator {
 
             // MIN: Take minimum of minimums
             (
-                AggregateAccumulator::Min { value: v1, distinct: d1, seen: seen1 },
-                AggregateAccumulator::Min { value: v2, distinct: d2, seen: seen2 },
+                AggregateAccumulator::Min {
+                    value: v1,
+                    distinct: d1,
+                    seen: seen1,
+                    collation: coll1,
+                },
+                AggregateAccumulator::Min { value: v2, distinct: d2, seen: seen2, .. },
             ) => {
                 if *d1 != d2 {
                     return Err(crate::errors::ExecutorError::UnsupportedExpression(
@@ -820,17 +855,23 @@ impl AggregateAccumulator {
                     ));
                 }
 
+                let coll = coll1.clone();
                 if *d1 {
                     // DISTINCT: Merge seen sets, find minimum from merged set
                     if let (Some(s1_set), Some(s2_set)) = (seen1, seen2) {
                         s1_set.extend(s2_set);
                         // Find minimum from merged set
-                        *v1 = s1_set.iter().min_by(|a, b| compare_sql_values(a, b)).cloned();
+                        *v1 = s1_set
+                            .iter()
+                            .min_by(|a, b| compare_sql_values_with_collation(a, b, coll.as_deref()))
+                            .cloned();
                     }
                 } else {
                     match (v1.as_ref(), v2) {
                         (Some(current), Some(new_val)) => {
-                            if compare_sql_values(&new_val, current) == Ordering::Less {
+                            if compare_sql_values_with_collation(&new_val, current, coll.as_deref())
+                                == Ordering::Less
+                            {
                                 *v1 = Some(new_val);
                             }
                         }
@@ -842,8 +883,13 @@ impl AggregateAccumulator {
 
             // MAX: Take maximum of maximums
             (
-                AggregateAccumulator::Max { value: v1, distinct: d1, seen: seen1 },
-                AggregateAccumulator::Max { value: v2, distinct: d2, seen: seen2 },
+                AggregateAccumulator::Max {
+                    value: v1,
+                    distinct: d1,
+                    seen: seen1,
+                    collation: coll1,
+                },
+                AggregateAccumulator::Max { value: v2, distinct: d2, seen: seen2, .. },
             ) => {
                 if *d1 != d2 {
                     return Err(crate::errors::ExecutorError::UnsupportedExpression(
@@ -851,17 +897,23 @@ impl AggregateAccumulator {
                     ));
                 }
 
+                let coll = coll1.clone();
                 if *d1 {
                     // DISTINCT: Merge seen sets, find maximum from merged set
                     if let (Some(s1_set), Some(s2_set)) = (seen1, seen2) {
                         s1_set.extend(s2_set);
                         // Find maximum from merged set
-                        *v1 = s1_set.iter().max_by(|a, b| compare_sql_values(a, b)).cloned();
+                        *v1 = s1_set
+                            .iter()
+                            .max_by(|a, b| compare_sql_values_with_collation(a, b, coll.as_deref()))
+                            .cloned();
                     }
                 } else {
                     match (v1.as_ref(), v2) {
                         (Some(current), Some(new_val)) => {
-                            if compare_sql_values(&new_val, current) == Ordering::Greater {
+                            if compare_sql_values_with_collation(&new_val, current, coll.as_deref())
+                                == Ordering::Greater
+                            {
                                 *v1 = Some(new_val);
                             }
                         }
@@ -935,15 +987,9 @@ impl AggregateAccumulator {
             // and enforce fraction consistency across the two halves.
             (
                 AggregateAccumulator::Percentile {
-                    values: v1,
-                    fraction: f1,
-                    error: e1,
-                    name,
-                    ..
+                    values: v1, fraction: f1, error: e1, name, ..
                 },
-                AggregateAccumulator::Percentile {
-                    values: v2, fraction: f2, error: e2, ..
-                },
+                AggregateAccumulator::Percentile { values: v2, fraction: f2, error: e2, .. },
             ) => {
                 if e1.is_none() {
                     if let Some(msg) = e2 {
@@ -1519,11 +1565,13 @@ mod tests {
             value: Some(SqlValue::Integer(5)),
             distinct: false,
             seen: None,
+            collation: None,
         };
         let acc2 = AggregateAccumulator::Min {
             value: Some(SqlValue::Integer(3)),
             distinct: false,
             seen: None,
+            collation: None,
         };
 
         acc1.combine(acc2).unwrap();
@@ -1542,11 +1590,13 @@ mod tests {
             value: Some(SqlValue::Integer(5)),
             distinct: false,
             seen: None,
+            collation: None,
         };
         let acc2 = AggregateAccumulator::Max {
             value: Some(SqlValue::Integer(10)),
             distinct: false,
             seen: None,
+            collation: None,
         };
 
         acc1.combine(acc2).unwrap();

--- a/crates/vibesql-executor/src/select/grouping/parallel_sink.rs
+++ b/crates/vibesql-executor/src/select/grouping/parallel_sink.rs
@@ -134,7 +134,14 @@ pub fn parallel_group_aggregate<'a>(
                 let accumulators = state.groups.entry(key).or_insert_with(|| {
                     aggregate_infos
                         .iter()
-                        .map(|info| AggregateAccumulator::new(&info.function_name, info.distinct))
+                        .map(|info| {
+                            AggregateAccumulator::new(&info.function_name, info.distinct).map(
+                                |mut acc| {
+                                    acc.set_min_max_collation(info.collation.clone());
+                                    acc
+                                },
+                            )
+                        })
                         .collect::<Result<Vec<_>, _>>()
                         .unwrap_or_default()
                 });
@@ -224,7 +231,12 @@ fn sequential_group_aggregate<'a>(
         let accumulators = groups.entry(key).or_insert_with(|| {
             aggregate_infos
                 .iter()
-                .map(|info| AggregateAccumulator::new(&info.function_name, info.distinct))
+                .map(|info| {
+                    AggregateAccumulator::new(&info.function_name, info.distinct).map(|mut acc| {
+                        acc.set_min_max_collation(info.collation.clone());
+                        acc
+                    })
+                })
                 .collect::<Result<Vec<_>, _>>()
                 .unwrap_or_default()
         });
@@ -259,13 +271,17 @@ pub struct AggregateInfo {
     pub expr: vibesql_ast::Expression,
     /// Whether DISTINCT modifier is applied
     pub distinct: bool,
+    /// Explicit COLLATE on the aggregate argument, if any (used by MIN/MAX so
+    /// `min(x COLLATE nocase)` orders by the requested collation).
+    pub collation: Option<String>,
 }
 
 #[allow(dead_code)] // WIP: Will be used when parallel aggregation is integrated
 impl AggregateInfo {
     /// Create a new AggregateInfo
     pub fn new(function_name: String, expr: vibesql_ast::Expression, distinct: bool) -> Self {
-        Self { function_name, expr, distinct }
+        let collation = crate::evaluator::collation::explicit_collation_of(&expr);
+        Self { function_name, expr, distinct, collation }
     }
 }
 

--- a/crates/vibesql-executor/tests/aggregate_collation_tests.rs
+++ b/crates/vibesql-executor/tests/aggregate_collation_tests.rs
@@ -1,0 +1,86 @@
+//! Tests for COLLATE handling in MIN/MAX aggregates.
+//!
+//! Regression coverage for issue #5842 sub-item 1: `min(x COLLATE nocase)` /
+//! `max(x COLLATE ...)` must order their operands by the requested collation
+//! instead of raw binary bytes. Expected values verified against sqlite3
+//! (minmax3 §4).
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+fn text(s: &str) -> SqlValue {
+    SqlValue::Varchar(arcstr::ArcStr::from(s))
+}
+
+/// Build a database with `t4(x)` holding the minmax3 §4 fixture rows
+/// ('abc' and 'BCD'). Under BINARY collation uppercase sorts before lowercase,
+/// so max('abc','BCD')='abc'; under NOCASE, max='BCD'.
+fn make_db() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+
+    let create = vibesql_parser::Parser::parse_sql("CREATE TABLE t4(x)").unwrap();
+    if let vibesql_ast::Statement::CreateTable(ct) = create {
+        vibesql_executor::CreateTableExecutor::execute(&ct, &mut db).unwrap();
+    } else {
+        panic!("expected CREATE TABLE");
+    }
+
+    let insert =
+        vibesql_parser::Parser::parse_sql("INSERT INTO t4(x) VALUES ('abc'), ('BCD')").unwrap();
+    if let vibesql_ast::Statement::Insert(ins) = insert {
+        vibesql_executor::InsertExecutor::execute(&mut db, &ins).unwrap();
+    } else {
+        panic!("expected INSERT");
+    }
+
+    db
+}
+
+fn eval_single(db: &vibesql_storage::Database, sql: &str) -> SqlValue {
+    let executor = SelectExecutor::new(db);
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select) = stmt {
+        let result = executor.execute_with_columns(&select).unwrap();
+        assert_eq!(result.rows.len(), 1, "expected exactly one row for `{sql}`");
+        result.rows[0].values[0].clone()
+    } else {
+        panic!("expected SELECT for `{sql}`");
+    }
+}
+
+#[test]
+fn test_max_binary_vs_nocase_collation() {
+    let db = make_db();
+    // Default (BINARY): 'a' (0x61) > 'B' (0x42), so max is 'abc'.
+    assert_eq!(eval_single(&db, "SELECT max(x) FROM t4"), text("abc"));
+    // NOCASE: case-insensitively 'BCD' > 'abc', so max is 'BCD'.
+    assert_eq!(eval_single(&db, "SELECT max(x COLLATE nocase) FROM t4"), text("BCD"));
+    // An explicit BINARY collation matches the default.
+    assert_eq!(eval_single(&db, "SELECT max(x COLLATE binary) FROM t4"), text("abc"));
+}
+
+#[test]
+fn test_min_binary_vs_nocase_collation() {
+    let db = make_db();
+    // Default (BINARY): 'B' < 'a', so min is 'BCD'.
+    assert_eq!(eval_single(&db, "SELECT min(x) FROM t4"), text("BCD"));
+    // NOCASE: case-insensitively 'abc' < 'BCD', so min is 'abc'.
+    assert_eq!(eval_single(&db, "SELECT min(x COLLATE nocase) FROM t4"), text("abc"));
+}
+
+#[test]
+fn test_collation_does_not_leak_between_aggregates() {
+    let db = make_db();
+    // A collated and an uncollated aggregate in the same SELECT must each use
+    // their own comparison (minmax3-4.3 / 4.6).
+    let executor = SelectExecutor::new(&db);
+    let stmt =
+        vibesql_parser::Parser::parse_sql("SELECT max(x), max(x COLLATE nocase) FROM t4").unwrap();
+    if let vibesql_ast::Statement::Select(select) = stmt {
+        let result = executor.execute_with_columns(&select).unwrap();
+        assert_eq!(result.rows[0].values[0], text("abc"));
+        assert_eq!(result.rows[0].values[1], text("BCD"));
+    } else {
+        panic!("expected SELECT");
+    }
+}

--- a/crates/vibesql-parser/src/arena_parser/mod.rs
+++ b/crates/vibesql-parser/src/arena_parser/mod.rs
@@ -697,9 +697,14 @@ impl<'arena> ArenaParser<'arena> {
                 self.advance();
                 Ok(self.intern(&name))
             }
-            Token::Keyword { keyword: kw, .. } => {
-                // Allow keywords as alias names
-                let name = kw.to_string();
+            Token::Keyword { original, .. } => {
+                // Allow keywords as alias names. Preserve the original source-text
+                // case rather than the keyword's canonical uppercase form: SQLite
+                // names the column exactly as written, so `SELECT max(a) AS m`
+                // yields column `m`, not `M` (colname-6.11..6.19). `m`/`M` is a
+                // contextual keyword (HNSW parameter), which is why an unquoted
+                // `m` alias reached this arm at all.
+                let name = original.clone();
                 self.advance();
                 Ok(self.intern(&name))
             }

--- a/crates/vibesql-parser/src/parser/helpers.rs
+++ b/crates/vibesql-parser/src/parser/helpers.rs
@@ -187,9 +187,14 @@ impl Parser {
                 self.advance();
                 Ok(identifier)
             }
-            Token::Keyword { keyword: kw, .. } => {
-                // Allow keywords as alias names - convert to uppercase string
-                let name = kw.to_string();
+            Token::Keyword { original, .. } => {
+                // Allow keywords as alias names. Preserve the original source-text
+                // case rather than the keyword's canonical uppercase form: SQLite
+                // names the column exactly as written, so `SELECT max(a) AS m`
+                // yields column `m`, not `M` (colname-6.11..6.19). `m`/`M` is a
+                // contextual keyword (HNSW parameter), which is why an unquoted
+                // `m` alias reached this arm at all.
+                let name = original.clone();
                 self.advance();
                 Ok(name)
             }

--- a/crates/vibesql-parser/src/tests/select/keyword_as_identifier.rs
+++ b/crates/vibesql-parser/src/tests/select/keyword_as_identifier.rs
@@ -65,6 +65,47 @@ fn test_column_m_uppercase() {
     assert!(result.is_ok(), "Failed to parse SELECT M FROM t: {:?}", result);
 }
 
+/// Issue #5842 sub-item 3: an unquoted alias that happens to be a contextual
+/// keyword (`m`, the HNSW parameter) must preserve its original source-text
+/// case, not be canonicalized to the keyword's uppercase form. SQLite names the
+/// column exactly as written: `SELECT max(a) AS m` yields column `m`, not `M`
+/// (colname-6.11..6.19). Cover both the standard and arena parser paths since
+/// they have independent alias-parsing routines.
+fn alias_of_first_select_item(stmt: vibesql_ast::Statement) -> Option<String> {
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match &select.select_list[0] {
+            vibesql_ast::SelectItem::Expression { alias, .. } => alias.clone(),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+#[test]
+fn test_keyword_alias_preserves_case_standard_parser() {
+    let stmt = Parser::parse_sql("SELECT max(a) AS m FROM t").unwrap();
+    assert_eq!(alias_of_first_select_item(stmt).as_deref(), Some("m"));
+
+    let stmt = Parser::parse_sql("SELECT 1 AS m").unwrap();
+    assert_eq!(alias_of_first_select_item(stmt).as_deref(), Some("m"));
+
+    // Uppercase spelling is preserved as written too.
+    let stmt = Parser::parse_sql("SELECT 1 AS M").unwrap();
+    assert_eq!(alias_of_first_select_item(stmt).as_deref(), Some("M"));
+}
+
+#[test]
+fn test_keyword_alias_preserves_case_arena_parser() {
+    let stmt = crate::parse_with_arena_fallback("SELECT max(a) AS m FROM t").unwrap();
+    assert_eq!(alias_of_first_select_item(stmt).as_deref(), Some("m"));
+
+    let stmt = crate::parse_with_arena_fallback("SELECT 1 AS m").unwrap();
+    assert_eq!(alias_of_first_select_item(stmt).as_deref(), Some("m"));
+
+    let stmt = crate::parse_with_arena_fallback("SELECT 1 AS M").unwrap();
+    assert_eq!(alias_of_first_select_item(stmt).as_deref(), Some("M"));
+}
+
 #[test]
 fn test_column_m_in_expression() {
     let result = Parser::parse_sql("SELECT m + 1 FROM t;");
@@ -189,15 +230,12 @@ fn test_reserved_keywords_in_operand_position_still_error() {
     // A reserved clause/operator keyword where an operand is expected must remain
     // a syntax error — it must NOT be silently accepted as a column reference.
     for sql in [
-        "SELECT FROM t;",       // FROM where a select item is expected
-        "SELECT a, FROM t;",    // trailing comma then FROM
-        "SELECT select FROM t;", // SELECT in operand position
-        "SELECT a FROM t WHERE and b;", // AND with no left operand
+        "SELECT FROM t;",                   // FROM where a select item is expected
+        "SELECT a, FROM t;",                // trailing comma then FROM
+        "SELECT select FROM t;",            // SELECT in operand position
+        "SELECT a FROM t WHERE and b;",     // AND with no left operand
         "SELECT a FROM t WHERE a = where;", // WHERE in operand position
     ] {
-        assert!(
-            Parser::parse_sql(sql).is_err(),
-            "expected a syntax error for: {sql}"
-        );
+        assert!(Parser::parse_sql(sql).is_err(), "expected a syntax error for: {sql}");
     }
 }


### PR DESCRIPTION
Part of #5842 — the small-batch long-tail triage. This PR lands the well-tested, low-risk sub-items and clearly defers the two format/dedup sub-items that turned out to be larger than a shared PR should carry.

## Landed

### Item 1 — min/max ignore COLLATE (minmax3 §4)
`min(x COLLATE nocase)` / `max(x COLLATE rtrim)` compared operands byte-wise, ignoring the COLLATE clause.

- `AggregateAccumulator::Min`/`Max` now carry an optional `collation` field.
- The aggregate evaluator threads any explicit COLLATE on the argument (via the existing `explicit_collation_of` helper) into the accumulator; `accumulate` and the parallel `combine`/merge path now call `compare_sql_values_with_collation`.
- When no COLLATE is present the comparator is byte-identical to the old path, so non-collated MIN/MAX is unchanged.
- `AggregateInfo` (parallel_sink) carries the collation too.

**minmax3.test: 19 → 29 passed** (the ten §4 COLLATE tests; the residual failures are the `hexio_render_int32` shim gap in §1, unrelated).

### Item 3 (alias case) — `AS m` → column `M`
An unquoted alias that is a *contextual* keyword (`m`, the HNSW parameter) was canonicalized to the keyword's uppercase form, so `SELECT max(a) AS m` produced column `M`. Both parser paths — standard `parse_alias_name` and arena `parse_alias_name_symbol` — now use the token's original source text, matching SQLite (colname-6.11..6.19).

**colname.test: 39 → 48 passed.**

### Item 4 — PRAGMA gaps
- `PRAGMA journal_mode` now reports the active mode (`wal`) instead of an empty result; the SET form stays a silently-accepted no-op (VibeSQL's WAL is always on).
- `PRAGMA integrity_check('t1')` (table-argument form, previously misrouted to the SET branch and silently ignored) now returns `ok` for any table argument, handled before the set/query split alongside the existing no-argument form.

## Deferred (Part of #5842, follow-ups)

- **Item 2 — CTAS `sqlite_master.sql` fidelity.** table-8.1.1 / 8.3.1 require affinity-derived type codes (`boolean`→`NUM`, `blob`→empty) plus exact whitespace — a SQLite affinity-mapping detail worth its own PR. Investigation confirmed the CTAS **data** already round-trips correctly, including the apostrophe-alias case (`CREATE TABLE t2 AS SELECT a AS 'it''s' FROM t1`): it does **not** create an empty table in either the in-memory or the binary checkpoint/reload path — the only residual is the un-reparseable `sqlite_master.sql` text.
- **Item 3a — duplicate view-column `:N` suffixes.** Must apply only to view-sourced `SELECT *`, not base-table `SELECT *` (a blanket second pass would regress colname-3.7, which currently passes). Belongs in view-column-name computation, not the generic derive path.

## Tests
- `crates/vibesql-executor/tests/aggregate_collation_tests.rs` — min/max BINARY vs NOCASE, no cross-aggregate collation leak (sqlite3-verified).
- Parser alias-case tests for both parser paths.
- CLI pragma tests (journal_mode query/set, integrity_check no-arg and table-arg).

Full `-p vibesql-parser` suite green (1645 passed); aggregates unit tests green; minmax.test canary unchanged (95/109, residual failures pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)