### PR TITLE
fix(test-harness): close marker-guarantee holes for mid-file aborts and capability self-skips

### DIFF
--- a/scripts/tcl_runner.py
+++ b/scripts/tcl_runner.py
@@ -1128,6 +1128,12 @@ def main():
         files_timeout = 0
         files_incomplete = 0
         files_error = 0
+        # Files that ran to completion but produced only skipped rows: a
+        # capability self-skip (`ifcapable !cap { finish_test; return }`) or a
+        # whole-file vibesql_skip_files skip. These are clean, intentional
+        # skips — NOT compromised runs — so they are reported separately and do
+        # not trigger the "did not run to completion" warning (#5887).
+        files_self_skipped = 0
 
         for file_path in file_paths:
             if args.verbose:
@@ -1151,6 +1157,11 @@ def main():
                 files_incomplete += 1
             if "error" in statuses:
                 files_error += 1
+            # A file whose only rows are 'skipped' ran cleanly to completion
+            # and intentionally skipped everything (capability self-skip or
+            # whole-file skip); count it separately from compromised files.
+            if results and statuses == {"skipped"}:
+                files_self_skipped += 1
 
         # Print summary
         total_tests = total_passed + total_failed + total_skipped
@@ -1164,6 +1175,8 @@ def main():
         print("-" * 50)
         print(f"Files attempted:    {files_attempted}")
         print(f"Files with results: {files_with_results}")
+        if files_self_skipped > 0:
+            print(f"Files self-skipped: {files_self_skipped} (capability/whole-file skip; marked status='skipped')")
         if files_timeout > 0:
             print(f"Files timed out:    {files_timeout} (marked status='timeout')")
         if files_incomplete > 0:
@@ -1172,12 +1185,28 @@ def main():
             print(f"Files runner-error: {files_error} (marked status='error')")
         print("=" * 50)
 
-        if files_compromised > 0 or files_with_results < files_attempted:
+        # Only warn about a compromised run when real marker rows were written
+        # (#5887). A clean capability self-skip leaves files_with_results <
+        # files_attempted historically; that alone must not read like a
+        # compromised run. After the shim's zero-test marker fix every completed
+        # file emits at least one row, so a genuine shortfall only happens with
+        # a marker (which sets files_compromised > 0).
+        if files_compromised > 0:
             print(
                 f"\nWARNING: {files_compromised} of {files_attempted} attempted file(s) "
                 f"did not run to completion (timeout/kill/error markers written). "
                 f"Totals from this run are NOT comparable to a clean-run baseline. "
                 f"Re-run the affected files on a quiet machine.",
+                file=sys.stderr,
+            )
+        elif files_with_results < files_attempted:
+            # No markers, yet some file produced zero rows — after the marker
+            # guarantee this should not happen; surface it distinctly rather
+            # than mislabeling it a compromised run.
+            print(
+                f"\nWARNING: {files_attempted - files_with_results} of {files_attempted} "
+                f"attempted file(s) produced no detail rows and no marker "
+                f"(unexpected — the shim should emit a row for every completed file).",
                 file=sys.stderr,
             )
 

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -40,6 +40,13 @@ set ::nFail 0
 set ::nSkip 0
 set ::failList {}
 
+# Set to 1 once a whole-file marker/skip detail row has been emitted for the
+# current file (the mid-file 'incomplete' abort row, or the whole-file
+# 'skipped' row from the vibesql_skip_files path). finish_test consults this
+# to avoid double-emitting a synthetic zero-test 'skipped' row (#5845/#5887).
+# One test file is evaluated per tclsh process, so a top-level init suffices.
+set ::file_marker_emitted 0
+
 # Emit a structured per-test detail line consumed by tcl_runner.py.
 #
 # Format: "##TCLTEST## <status>\t<name>"
@@ -5930,6 +5937,20 @@ proc finish_test {} {
         }
     }
 
+    # If the file ran to completion but emitted zero detail rows of any kind
+    # (nTest==0 => no passed/failed rows, nSkip==0 => no skipped rows) and no
+    # whole-file marker was already emitted, synthesize a 'skipped' row so the
+    # file never vanishes from tcl_test_results (#5887). This is the capability
+    # self-skip case: `ifcapable !cap { finish_test; return }` at the top of a
+    # file exits cleanly with nothing run. The guards prevent double-emitting
+    # for the vibesql_skip_files whole-file skip (nSkip>0) and the mid-file
+    # abort path (file_marker_emitted==1), both of which already emitted a row.
+    if {$::nTest == 0 && $::nSkip == 0 && !$::file_marker_emitted} {
+        set self_skip_base [file rootname [file tail [lindex $::argv 0]]]
+        emit_test_detail skipped "$self_skip_base (capability self-skip)"
+        set ::file_marker_emitted 1
+    }
+
     # Print summary
     puts ""
     puts "======================================"
@@ -6493,6 +6514,7 @@ proc run_test_file {filename} {
         # shim completed, including the skip-entire-file path.
         incr ::nSkip
         emit_test_detail skipped "$basename (entire file)"
+        set ::file_marker_emitted 1
         finish_test
     }
 
@@ -6588,6 +6610,15 @@ proc run_test_file {filename} {
         # fake any passes: the aborting statement is reported below.
         puts "Setup error (file evaluation aborted mid-file): $err"
         puts "Error info: $::errorInfo"
+        # Emit an 'incomplete' marker so the runner sees the file was truncated
+        # (#5845). Without this the partial run looks clean to tcl_runner.py:
+        # finish_test still prints the "Tests run:" trailer and exits 0, so the
+        # runner's incomplete-detection (returncode<0 OR not saw_summary) never
+        # fires and the N tests that ran before the abort are silently treated
+        # as the file's complete result. The row keeps the tests that DID run
+        # (they are already emitted) and marks the file compromised in the DB.
+        emit_test_detail incomplete "ABORTED_MID_FILE: $err"
+        set ::file_marker_emitted 1
     }
 
     finish_test


### PR DESCRIPTION
## Summary

Closes two adjacent gaps in the TCL-harness marker guarantee (#5821) where test files could silently lose tests or vanish from `tcl_test_results` without a marker row. Both fixes live in the two harness scripts only.

Closes #5845
Closes #5887

## #5845 — mid-file abort truncation was silent

`run_test_file` wraps file evaluation in `catch`. When a top-level statement throws after N tests have already emitted `##TCLTEST##` rows, `finish_test` still prints the `Tests run:` trailer and exits 0, so the runner's incomplete-detection (`returncode<0 OR not saw_summary`) never fires and the partial run is treated as complete.

**Fix:** the catch block now emits `emit_test_detail incomplete "ABORTED_MID_FILE: $err"`. The tests that ran are kept and the file is marked compromised (`status='incomplete'`), which the runner already counts.

## #5887 — capability self-skips left 0 rows + a misleading warning

`ifcapable !cap { finish_test; return }` runs to completion with 0 tests, leaving no detail row (the file vanished from the DB) while the runner printed a `did not run to completion` warning despite nothing being compromised.

**Fix:**
- `finish_test` emits a synthetic `skipped` row (`"$base (capability self-skip)"`) when the file produced no detail rows of any kind.
- `tcl_runner.py` reports these as `Files self-skipped: N` and only prints the compromised-run warning when real marker rows were actually written (`files_compromised > 0`).

## Double-emit guard

A `::file_marker_emitted` flag (plus the `nSkip==0` guard) prevents the new zero-test synthetic skip from double-emitting for the `vibesql_skip_files` whole-file path and the mid-file abort path, both of which already emit their own row.

## Validation evidence

Run in the worktree via `tcl_runner.py --native-tcl` against the release binary.

| Scenario | Before | After |
|----------|--------|-------|
| Mid-file top-level error after 1 `do_test` | 1 passed row, **no marker** (silent truncation) | `passed midfileerr-1.1` + `incomplete ABORTED_MID_FILE: synthetic mid-file error`; `Files incomplete: 1` |
| Capability self-skip (`ifcapable !fts5 { finish_test; return }`) | 0 rows, misleading compromised-run warning | `skipped capskip (capability self-skip)`; `Files self-skipped: 1`; **no warning** |
| vacuum3.test (re-measured after #5908) | 29 of ~59 tests, **no marker** | still aborts at 29 (`can't read "blob": no such variable`) but now emits `incomplete` marker; `Files incomplete: 1` |
| `vibesql_skip_files` whole-file (insert4) | single `(entire file)` row | single `insert4 (entire file)` row — **no double-emit** |
| Normal 2-test file | 2 passed rows | 2 passed rows, no synthetic row, no warning (unchanged) |

vacuum3's abort (`can't read "blob"`, a TCL variable issue) is unaffected by #5908's parser fix, confirming the structural marker fix is required regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)