### PR TITLE
fix(parser): bind bitwise & | << >> tighter than comparison

### DIFF
--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -55,7 +55,7 @@ impl Parser {
             {
                 // Restore position and let the other parsers handle it
                 self.position = saved_pos;
-                return self.parse_bitwise_or_expression();
+                return self.parse_comparison_expression();
             }
 
             // It's a unary NOT - parse the expression it applies to
@@ -67,53 +67,13 @@ impl Parser {
                 expr: Box::new(expr),
             })
         } else {
-            self.parse_bitwise_or_expression()
+            self.parse_comparison_expression()
         }
-    }
-
-    /// Parse bitwise OR expression (handles |)
-    /// Precedence: between NOT and bitwise AND
-    pub(super) fn parse_bitwise_or_expression(
-        &mut self,
-    ) -> Result<vibesql_ast::Expression, ParseError> {
-        let mut left = self.parse_bitwise_and_expression()?;
-
-        while self.peek() == &Token::Symbol('|') {
-            self.advance();
-            let right = self.parse_bitwise_and_expression()?;
-            left = vibesql_ast::Expression::BinaryOp {
-                op: vibesql_ast::BinaryOperator::BitwiseOr,
-                left: Box::new(left),
-                right: Box::new(right),
-            };
-        }
-
-        Ok(left)
-    }
-
-    /// Parse bitwise AND expression (handles &)
-    /// Precedence: between bitwise OR and comparison
-    pub(super) fn parse_bitwise_and_expression(
-        &mut self,
-    ) -> Result<vibesql_ast::Expression, ParseError> {
-        let mut left = self.parse_comparison_expression()?;
-
-        while self.peek() == &Token::Symbol('&') {
-            self.advance();
-            let right = self.parse_comparison_expression()?;
-            left = vibesql_ast::Expression::BinaryOp {
-                op: vibesql_ast::BinaryOperator::BitwiseAnd,
-                left: Box::new(left),
-                right: Box::new(right),
-            };
-        }
-
-        Ok(left)
     }
 
     // ------------------------------------------------------------------
     // Arithmetic tier functions, loosest -> tightest:
-    //   shift -> additive -> multiplicative -> concat/JSON-path -> unary
+    //   bitwise -> additive -> multiplicative -> concat/JSON-path -> unary
     // Per the SQLite grammar `||`, `->`, and `->>` share the tightest binary
     // tier (tighter than `* / %`); they live in parse_concat_json_expression.
     //
@@ -126,27 +86,35 @@ impl Parser {
     //   `_from` variant.
     //
     // Parallel-structure invariant (see arena_parser/expression.rs): the
-    // arena parser mirrors this decomposition minus the shift and bitwise
-    // tiers, which it deliberately lacks. The arena parser must produce ASTs
-    // equivalent to this parser for everything it accepts; anything it cannot
-    // express must fail arena parsing (triggering parse_with_arena_fallback),
-    // never silently truncate.
+    // arena parser mirrors this decomposition minus the bitwise tier
+    // (`| & << >>`), which it deliberately lacks. The arena parser must
+    // produce ASTs equivalent to this parser for everything it accepts;
+    // anything it cannot express must fail arena parsing (triggering
+    // parse_with_arena_fallback), never silently truncate.
     // ------------------------------------------------------------------
 
-    /// Parse shift expression (handles <<, >>)
-    /// Precedence: between comparison and additive
-    pub(super) fn parse_shift_expression(&mut self) -> Result<vibesql_ast::Expression, ParseError> {
+    /// Parse bitwise expression (handles `|`, `&`, `<<`, `>>`).
+    ///
+    /// Per SQLite (https://sqlite.org/lang_expr.html#operators) these four
+    /// operators form a *single flat left-to-right tier* that binds tighter
+    /// than the comparison operators (`= < > <= >= != IS IN LIKE BETWEEN ...`)
+    /// but looser than `+`/`-`. There is no C-style sub-ordering between `|`,
+    /// `&`, and the shifts: `5 | 3 & 1` parses as `((5 | 3) & 1)`, and
+    /// `5 & 3 << 1` parses as `((5 & 3) << 1)`.
+    pub(super) fn parse_bitwise_expression(
+        &mut self,
+    ) -> Result<vibesql_ast::Expression, ParseError> {
         let seed = self.parse_unary_expression()?;
-        self.parse_shift_expression_from(seed)
+        self.parse_bitwise_expression_from(seed)
     }
 
-    /// Shift tier (`<<`, `>>`) with an already-parsed left operand.
+    /// Bitwise tier (`|`, `&`, `<<`, `>>`) with an already-parsed left operand.
     ///
     /// The seed is first climbed through the tighter tiers
     /// (additive -> multiplicative -> concat/JSON-path), so this doubles as the
     /// seeded precedence-climbing entry point used by
     /// `continue_higher_precedence_ops`.
-    fn parse_shift_expression_from(
+    fn parse_bitwise_expression_from(
         &mut self,
         left: vibesql_ast::Expression,
     ) -> Result<vibesql_ast::Expression, ParseError> {
@@ -154,6 +122,8 @@ impl Parser {
 
         loop {
             let op = match self.peek() {
+                Token::Symbol('|') => vibesql_ast::BinaryOperator::BitwiseOr,
+                Token::Symbol('&') => vibesql_ast::BinaryOperator::BitwiseAnd,
                 Token::Operator(crate::token::MultiCharOperator::LeftShift) => {
                     vibesql_ast::BinaryOperator::LeftShift
                 }
@@ -315,7 +285,7 @@ impl Parser {
     pub(super) fn parse_comparison_expression(
         &mut self,
     ) -> Result<vibesql_ast::Expression, ParseError> {
-        let mut left = self.parse_shift_expression()?;
+        let mut left = self.parse_bitwise_expression()?;
 
         loop {
             // Check for IN operator (including NOT IN) and BETWEEN (including NOT BETWEEN)
@@ -444,9 +414,9 @@ impl Parser {
                     };
 
                     // Parse low AND high
-                    let low = self.parse_shift_expression()?;
+                    let low = self.parse_bitwise_expression()?;
                     self.consume_keyword(Keyword::And)?;
-                    let high = self.parse_shift_expression()?;
+                    let high = self.parse_bitwise_expression()?;
 
                     left = vibesql_ast::Expression::Between {
                         expr: Box::new(left),
@@ -461,12 +431,12 @@ impl Parser {
                     self.consume_keyword(Keyword::Like)?;
 
                     // Parse pattern expression
-                    let pattern = self.parse_shift_expression()?;
+                    let pattern = self.parse_bitwise_expression()?;
 
                     // Check for optional ESCAPE clause
                     let escape = if self.peek_keyword(Keyword::Escape) {
                         self.consume_keyword(Keyword::Escape)?;
-                        Some(Box::new(self.parse_shift_expression()?))
+                        Some(Box::new(self.parse_bitwise_expression()?))
                     } else {
                         None
                     };
@@ -483,12 +453,12 @@ impl Parser {
                     self.consume_keyword(Keyword::Glob)?;
 
                     // Parse pattern expression
-                    let pattern = self.parse_shift_expression()?;
+                    let pattern = self.parse_bitwise_expression()?;
 
                     // Check for optional ESCAPE clause
                     let escape = if self.peek_keyword(Keyword::Escape) {
                         self.consume_keyword(Keyword::Escape)?;
-                        Some(Box::new(self.parse_shift_expression()?))
+                        Some(Box::new(self.parse_bitwise_expression()?))
                     } else {
                         None
                     };
@@ -680,12 +650,12 @@ impl Parser {
                 };
 
                 // Parse low AND high
-                // Bounds parse at the shift tier (same as NOT BETWEEN): everything
-                // tighter than the comparison tier is allowed; only the boolean AND
-                // separating low/high must not be consumed.
-                let low = self.parse_shift_expression()?;
+                // Bounds parse at the bitwise tier (same as NOT BETWEEN): everything
+                // tighter than the comparison tier is allowed (including `& | << >>`);
+                // only the boolean AND separating low/high must not be consumed.
+                let low = self.parse_bitwise_expression()?;
                 self.consume_keyword(Keyword::And)?;
-                let high = self.parse_shift_expression()?;
+                let high = self.parse_bitwise_expression()?;
 
                 left = vibesql_ast::Expression::Between {
                     expr: Box::new(left),
@@ -699,13 +669,13 @@ impl Parser {
                 // It's LIKE (not negated)
                 self.consume_keyword(Keyword::Like)?;
 
-                // Parse pattern expression at the shift tier (same as NOT LIKE)
-                let pattern = self.parse_shift_expression()?;
+                // Parse pattern expression at the bitwise tier (same as NOT LIKE)
+                let pattern = self.parse_bitwise_expression()?;
 
                 // Check for optional ESCAPE clause
                 let escape = if self.peek_keyword(Keyword::Escape) {
                     self.consume_keyword(Keyword::Escape)?;
-                    Some(Box::new(self.parse_shift_expression()?))
+                    Some(Box::new(self.parse_bitwise_expression()?))
                 } else {
                     None
                 };
@@ -721,13 +691,13 @@ impl Parser {
                 // It's GLOB (SQLite) (not negated)
                 self.consume_keyword(Keyword::Glob)?;
 
-                // Parse pattern expression at the shift tier (same as NOT GLOB)
-                let pattern = self.parse_shift_expression()?;
+                // Parse pattern expression at the bitwise tier (same as NOT GLOB)
+                let pattern = self.parse_bitwise_expression()?;
 
                 // Check for optional ESCAPE clause
                 let escape = if self.peek_keyword(Keyword::Escape) {
                     self.consume_keyword(Keyword::Escape)?;
-                    Some(Box::new(self.parse_shift_expression()?))
+                    Some(Box::new(self.parse_bitwise_expression()?))
                 } else {
                     None
                 };
@@ -780,7 +750,7 @@ impl Parser {
                             }
                             // These operators bind tighter than comparison and
                             // are consumed at lower tiers (Concat at the concat
-                            // tier, shifts at the shift tier, and `->`/`->>` at
+                            // tier, shifts at the bitwise tier, and `->`/`->>` at
                             // the JSON-path tier), so reaching here means a
                             // genuinely misplaced operator.
                             MultiCharOperator::Concat
@@ -832,7 +802,7 @@ impl Parser {
                     continue;
                 }
 
-                let right = self.parse_shift_expression()?;
+                let right = self.parse_bitwise_expression()?;
                 left = vibesql_ast::Expression::BinaryOp {
                     op,
                     left: Box::new(left),
@@ -857,7 +827,7 @@ impl Parser {
                 if self.peek_keyword(Keyword::Distinct) {
                     self.consume_keyword(Keyword::Distinct)?;
                     self.expect_keyword(Keyword::From)?;
-                    let right = self.parse_shift_expression()?;
+                    let right = self.parse_bitwise_expression()?;
                     left = vibesql_ast::Expression::IsDistinctFrom {
                         left: Box::new(left),
                         right: Box::new(right),
@@ -891,7 +861,7 @@ impl Parser {
                 } else {
                     // SQLite compatibility: IS <expr> - compare using IS semantics (NULL-safe equals)
                     // This handles cases like `expr IS 0` or `expr IS 1`
-                    let right = self.parse_shift_expression()?;
+                    let right = self.parse_bitwise_expression()?;
                     left = vibesql_ast::Expression::IsDistinctFrom {
                         left: Box::new(left),
                         right: Box::new(right),
@@ -932,7 +902,7 @@ impl Parser {
     }
 
     /// Continue parsing tighter-binding binary operators (multiplicative, concat,
-    /// additive, shift) with an already-parsed left operand.
+    /// additive, bitwise) with an already-parsed left operand.
     ///
     /// Used after a syntactically-closed comparison-tier node — IN/NOT IN
     /// (right operand is a parenthesized list/subquery or a table name) and
@@ -950,15 +920,15 @@ impl Parser {
     /// relative precedence among these operators is preserved
     /// (e.g. `x IN (1) + 2 * 3` parses as `(x IN (1)) + (2 * 3)`).
     ///
-    /// Delegates to `parse_shift_expression_from`, which climbs the seeded
-    /// left operand through the multiplicative, concat, additive, and shift
+    /// Delegates to `parse_bitwise_expression_from`, which climbs the seeded
+    /// left operand through the multiplicative, concat, additive, and bitwise
     /// tiers using the canonical per-tier operator loops. The arena parser
-    /// has the same helper (minus the shift tier) in arena_parser/expression.rs.
+    /// has the same helper (minus the bitwise tier) in arena_parser/expression.rs.
     fn continue_higher_precedence_ops(
         &mut self,
         left: vibesql_ast::Expression,
     ) -> Result<vibesql_ast::Expression, ParseError> {
-        self.parse_shift_expression_from(left)
+        self.parse_bitwise_expression_from(left)
     }
 
     /// Parse unary expression (handles unary +, -, ~ operators)

--- a/crates/vibesql-parser/src/tests/arena_parser.rs
+++ b/crates/vibesql-parser/src/tests/arena_parser.rs
@@ -1086,3 +1086,87 @@ fn test_arena_concat_chain_then_multiply() {
         );
     });
 }
+
+// ============================================================================
+// Bitwise operators in comparison / bounds (issues #5848, #5851 Part A)
+//
+// The arena parser has no bitwise tier (`| & << >>`), so any expression that
+// mixes those operators must FAIL arena parsing (never silently truncate) and
+// route through parse_with_arena_fallback to the standard parser, which (post
+// #5848) binds bitwise tighter than comparison and admits it in BETWEEN/LIKE
+// bounds. All expected results were verified against sqlite3 3.51.0.
+// ============================================================================
+
+#[test]
+fn test_arena_bitwise_vs_comparison_fails_no_silent_truncation() {
+    // Must be a hard arena-parse error, NOT a successful parse of the truncated
+    // prefix "SELECT 2 = 2".
+    let arena = Bump::new();
+    let result = ArenaParser::parse_select_with_interner("SELECT 2 = 2 & 2", &arena);
+    assert!(
+        result.is_err(),
+        "arena parser has no bitwise tier; `2 = 2 & 2` must fail arena parse, got: {:?}",
+        result.map(|(stmt, _)| format!("{:?}", stmt.select_list[0]))
+    );
+}
+
+#[test]
+fn test_arena_between_bitwise_bound_fails_no_silent_truncation() {
+    let arena = Bump::new();
+    let result = ArenaParser::parse_select_with_interner("SELECT 2 BETWEEN 0 AND 3 & 1", &arena);
+    assert!(
+        result.is_err(),
+        "arena parser has no bitwise tier; BETWEEN with `& 1` bound must fail arena parse, got: {:?}",
+        result.map(|(stmt, _)| format!("{:?}", stmt.select_list[0]))
+    );
+}
+
+#[test]
+fn test_arena_fallback_bitwise_binds_tighter_than_comparison() {
+    // sqlite3: SELECT 2 = 2 & 2; -- 1, i.e. 2 = (2 & 2).
+    let stmt = crate::parse_with_arena_fallback("SELECT 2 = 2 & 2;")
+        .expect("fallback path should parse bitwise-vs-comparison expression");
+    let vibesql_ast::Statement::Select(select) = stmt else {
+        panic!("expected SELECT statement");
+    };
+    let vibesql_ast::SelectItem::Expression { expr, .. } = &select.select_list[0] else {
+        panic!("expected expression select item");
+    };
+    let vibesql_ast::Expression::BinaryOp { op, right, .. } = expr else {
+        panic!("expected top-level BinaryOp, got {:?}", expr);
+    };
+    assert_eq!(*op, vibesql_ast::BinaryOperator::Equal, "top level should be =");
+    assert!(
+        matches!(
+            **right,
+            vibesql_ast::Expression::BinaryOp { op: vibesql_ast::BinaryOperator::BitwiseAnd, .. }
+        ),
+        "RHS of = should be (2 & 2), got {:?}",
+        right
+    );
+}
+
+#[test]
+fn test_arena_fallback_between_bitwise_bound() {
+    // sqlite3: SELECT 2 BETWEEN 0 AND 3 & 1; -- 0  (high bound is 3 & 1 = 1).
+    let stmt = crate::parse_with_arena_fallback("SELECT 2 BETWEEN 0 AND 3 & 1;")
+        .expect("fallback path should parse BETWEEN with bitwise bound");
+    let vibesql_ast::Statement::Select(select) = stmt else {
+        panic!("expected SELECT statement");
+    };
+    let vibesql_ast::SelectItem::Expression { expr, .. } = &select.select_list[0] else {
+        panic!("expected expression select item");
+    };
+    let vibesql_ast::Expression::Between { high, negated, .. } = expr else {
+        panic!("expected Between expression, got {:?}", expr);
+    };
+    assert!(!negated);
+    assert!(
+        matches!(
+            **high,
+            vibesql_ast::Expression::BinaryOp { op: vibesql_ast::BinaryOperator::BitwiseAnd, .. }
+        ),
+        "high bound should be 3 & 1, got {:?}",
+        high
+    );
+}

--- a/crates/vibesql-parser/src/tests/predicates.rs
+++ b/crates/vibesql-parser/src/tests/predicates.rs
@@ -328,13 +328,14 @@ fn test_not_between_asymmetric() {
 }
 
 // ============================================================================
-// BETWEEN/LIKE/GLOB operands parse at the shift tier (issue #5813)
+// BETWEEN/LIKE/GLOB operands parse at the bitwise tier (issues #5813, #5848)
 //
 // Per SQLite, everything tighter than the comparison tier is allowed in
 // BETWEEN bounds and LIKE/GLOB patterns; only the boolean AND separating
-// BETWEEN's low/high must not be consumed. The negated forms (NOT BETWEEN,
-// NOT LIKE, NOT GLOB) already parsed at the shift tier, so the non-negated
-// forms must match. All expected results below were verified against sqlite3.
+// BETWEEN's low/high must not be consumed. Since #5848 merged the shift and
+// bitwise tiers, `<<`/`>>` (below) and `&`/`|` (see the bitwise section) are
+// all admitted; the negated and non-negated forms must match. All expected
+// results below were verified against sqlite3.
 // ============================================================================
 
 /// Parse a `SELECT <expr>;` statement and return the first select-list expression.
@@ -576,5 +577,261 @@ fn test_between_shift_bound_does_not_consume_boolean_and() {
             );
         }
         other => panic!("expected boolean AND of two Between expressions, got {:?}", other),
+    }
+}
+
+// ============================================================================
+// Bitwise operators bind tighter than comparison (issues #5848, #5851 Part A)
+//
+// Per SQLite (https://sqlite.org/lang_expr.html#operators), `|`, `&`, `<<`,
+// `>>` form a single flat left-to-right tier that binds TIGHTER than the
+// comparison operators (`= < > <= >= != IS IN LIKE GLOB BETWEEN ...`). There
+// is no C-style sub-ordering: `5 | 3 & 1` parses as `((5|3)&1)`, not
+// `(5|(3&1))`. Every expected result below was verified against sqlite3 3.51.0.
+// ============================================================================
+
+fn bin_op(expr: &vibesql_ast::Expression) -> vibesql_ast::BinaryOperator {
+    match expr {
+        vibesql_ast::Expression::BinaryOp { op, .. } => *op,
+        other => panic!("expected BinaryOp, got {:?}", other),
+    }
+}
+
+/// Assert `expr` is `BinaryOp { op }` and return its (left, right) children.
+fn expect_bin<'a>(
+    expr: &'a vibesql_ast::Expression,
+    op: vibesql_ast::BinaryOperator,
+    ctx: &str,
+) -> (&'a vibesql_ast::Expression, &'a vibesql_ast::Expression) {
+    match expr {
+        vibesql_ast::Expression::BinaryOp { op: got, left, right } => {
+            assert_eq!(*got, op, "{}: expected {:?}, got {:?}", ctx, op, got);
+            (left, right)
+        }
+        other => panic!("{}: expected BinaryOp {:?}, got {:?}", ctx, op, other),
+    }
+}
+
+#[test]
+fn test_equal_binds_looser_than_bitwise_and_rhs() {
+    // sqlite3: SELECT 2 = 2 & 2; -- 1, i.e. 2 = (2 & 2)
+    let expr = parse_select_expr("SELECT 2 = 2 & 2;");
+    let (_, right) = expect_bin(&expr, vibesql_ast::BinaryOperator::Equal, "top");
+    assert_eq!(
+        bin_op(right),
+        vibesql_ast::BinaryOperator::BitwiseAnd,
+        "RHS of = should be (2 & 2), got {:?}",
+        right
+    );
+}
+
+#[test]
+fn test_equal_binds_looser_than_bitwise_or_lhs() {
+    // sqlite3: SELECT 2 | 3 = 3; -- 1, i.e. (2 | 3) = 3
+    let expr = parse_select_expr("SELECT 2 | 3 = 3;");
+    let (left, _) = expect_bin(&expr, vibesql_ast::BinaryOperator::Equal, "top");
+    assert_eq!(
+        bin_op(left),
+        vibesql_ast::BinaryOperator::BitwiseOr,
+        "LHS of = should be (2 | 3), got {:?}",
+        left
+    );
+}
+
+#[test]
+fn test_less_than_binds_looser_than_bitwise_and() {
+    // sqlite3: SELECT 5 & 3 > 1; -- 0, i.e. (5 & 3) > 1
+    let expr = parse_select_expr("SELECT 5 & 3 > 1;");
+    let (left, _) = expect_bin(&expr, vibesql_ast::BinaryOperator::GreaterThan, "top");
+    assert_eq!(
+        bin_op(left),
+        vibesql_ast::BinaryOperator::BitwiseAnd,
+        "LHS of > should be (5 & 3), got {:?}",
+        left
+    );
+}
+
+#[test]
+fn test_bitwise_or_and_are_flat_left_to_right() {
+    // sqlite3: SELECT 5 | 3 & 1; -- 1, i.e. ((5 | 3) & 1), NOT (5 | (3 & 1)).
+    let expr = parse_select_expr("SELECT 5 | 3 & 1;");
+    let (left, _) = expect_bin(&expr, vibesql_ast::BinaryOperator::BitwiseAnd, "top");
+    assert_eq!(
+        bin_op(left),
+        vibesql_ast::BinaryOperator::BitwiseOr,
+        "flat L-to-R: left of & should be (5 | 3), got {:?}",
+        left
+    );
+}
+
+#[test]
+fn test_shift_is_same_tier_as_bitwise_and() {
+    // sqlite3: SELECT 5 & 3 << 1; -- 2, i.e. ((5 & 3) << 1) — shift NOT tighter than &.
+    let expr = parse_select_expr("SELECT 5 & 3 << 1;");
+    let (left, _) = expect_bin(&expr, vibesql_ast::BinaryOperator::LeftShift, "top");
+    assert_eq!(
+        bin_op(left),
+        vibesql_ast::BinaryOperator::BitwiseAnd,
+        "left of << should be (5 & 3), got {:?}",
+        left
+    );
+}
+
+#[test]
+fn test_shift_is_same_tier_as_bitwise_or() {
+    // sqlite3: SELECT 5 | 3 << 1; -- 14, i.e. ((5 | 3) << 1).
+    let expr = parse_select_expr("SELECT 5 | 3 << 1;");
+    let (left, _) = expect_bin(&expr, vibesql_ast::BinaryOperator::LeftShift, "top");
+    assert_eq!(
+        bin_op(left),
+        vibesql_ast::BinaryOperator::BitwiseOr,
+        "left of << should be (5 | 3), got {:?}",
+        left
+    );
+}
+
+#[test]
+fn test_multi_op_bitwise_chain_flat() {
+    // sqlite3: SELECT 1 | 6 & 4 << 1; -- 8, i.e. (((1 | 6) & 4) << 1).
+    let expr = parse_select_expr("SELECT 1 | 6 & 4 << 1;");
+    let (left, _) = expect_bin(&expr, vibesql_ast::BinaryOperator::LeftShift, "top <<");
+    let (inner_left, _) = expect_bin(left, vibesql_ast::BinaryOperator::BitwiseAnd, "inner &");
+    assert_eq!(
+        bin_op(inner_left),
+        vibesql_ast::BinaryOperator::BitwiseOr,
+        "innermost should be (1 | 6), got {:?}",
+        inner_left
+    );
+}
+
+#[test]
+fn test_bitwise_binds_looser_than_additive() {
+    // sqlite3: SELECT 4 & 6 + 1; -- 4, i.e. (4 & (6 + 1)) — `+` tighter than `&`.
+    let expr = parse_select_expr("SELECT 4 & 6 + 1;");
+    let (_, right) = expect_bin(&expr, vibesql_ast::BinaryOperator::BitwiseAnd, "top &");
+    assert_eq!(
+        bin_op(right),
+        vibesql_ast::BinaryOperator::Plus,
+        "RHS of & should be (6 + 1), got {:?}",
+        right
+    );
+}
+
+#[test]
+fn test_bitwise_binds_looser_than_concat() {
+    // sqlite3: SELECT 1 | 2 || 3; -- '23', i.e. (1 | (2 || 3)) — `||` binds
+    // TIGHTER than `|` (concat tier is tighter than the bitwise tier), so the
+    // RHS of `|` is the concatenation `2 || 3` = '23', and `1 | 23` = 23.
+    let expr = parse_select_expr("SELECT 1 | 2 || 3;");
+    let (_, right) = expect_bin(&expr, vibesql_ast::BinaryOperator::BitwiseOr, "top |");
+    assert_eq!(
+        bin_op(right),
+        vibesql_ast::BinaryOperator::Concat,
+        "RHS of | should be (2 || 3), got {:?}",
+        right
+    );
+}
+
+#[test]
+fn test_in_list_followed_by_bitwise_and() {
+    // sqlite3: SELECT 1 IN (1) & 3; -- 1, i.e. (1 IN (1)) & 3.
+    // continue_higher_precedence_ops must climb the new bitwise tier.
+    let expr = parse_select_expr("SELECT 1 IN (1) & 3;");
+    let (left, _) = expect_bin(&expr, vibesql_ast::BinaryOperator::BitwiseAnd, "top &");
+    assert!(
+        matches!(left, vibesql_ast::Expression::InList { .. }),
+        "LHS of & should be an IN list, got {:?}",
+        left
+    );
+}
+
+#[test]
+fn test_isnull_postfix_followed_by_bitwise_and() {
+    // sqlite3: SELECT 1 ISNULL & 3; -- 0, i.e. (1 ISNULL) & 3.
+    let expr = parse_select_expr("SELECT 1 ISNULL & 3;");
+    let (left, _) = expect_bin(&expr, vibesql_ast::BinaryOperator::BitwiseAnd, "top &");
+    assert!(
+        matches!(left, vibesql_ast::Expression::IsNull { negated: false, .. }),
+        "LHS of & should be (1 ISNULL), got {:?}",
+        left
+    );
+}
+
+// ----------------------------------------------------------------------------
+// Part A of #5851: `& | << >>` now admitted in BETWEEN bounds / LIKE-GLOB
+// patterns (bounds parse at the bitwise tier). Values verified against sqlite3.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn test_between_bitwise_and_in_high_bound() {
+    // sqlite3: SELECT 2 BETWEEN 0 AND 3 & 1; -- 0  (high bound is 3 & 1 = 1)
+    let expr = parse_select_expr("SELECT 2 BETWEEN 0 AND 3 & 1;");
+    match expr {
+        vibesql_ast::Expression::Between { high, negated, .. } => {
+            assert!(!negated);
+            assert_eq!(
+                bin_op(&high),
+                vibesql_ast::BinaryOperator::BitwiseAnd,
+                "high bound should be (3 & 1), got {:?}",
+                high
+            );
+        }
+        other => panic!("expected Between expression, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_between_bitwise_or_in_low_bound() {
+    // sqlite3: SELECT 7 BETWEEN 5 | 2 AND 10; -- 1  (low bound is 5 | 2 = 7)
+    let expr = parse_select_expr("SELECT 7 BETWEEN 5 | 2 AND 10;");
+    match expr {
+        vibesql_ast::Expression::Between { low, negated, .. } => {
+            assert!(!negated);
+            assert_eq!(
+                bin_op(&low),
+                vibesql_ast::BinaryOperator::BitwiseOr,
+                "low bound should be (5 | 2), got {:?}",
+                low
+            );
+        }
+        other => panic!("expected Between expression, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_between_bitwise_bound_negated_symmetry() {
+    // The negated and non-negated forms must produce identically shaped bounds.
+    // sqlite3: SELECT 2 BETWEEN 0 AND 3 & 1;     -- 0
+    // sqlite3: SELECT 2 NOT BETWEEN 0 AND 3 & 1; -- 1
+    let plain = parse_select_expr("SELECT 2 BETWEEN 0 AND 3 & 1;");
+    let negated = parse_select_expr("SELECT 2 NOT BETWEEN 0 AND 3 & 1;");
+    match (plain, negated) {
+        (
+            vibesql_ast::Expression::Between { high: h1, negated: n1, .. },
+            vibesql_ast::Expression::Between { high: h2, negated: n2, .. },
+        ) => {
+            assert!(!n1);
+            assert!(n2);
+            assert_eq!(h1, h2, "BETWEEN high bound must parse identically in both forms");
+        }
+        other => panic!("expected two Between expressions, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_like_bitwise_and_pattern() {
+    // sqlite3: SELECT 2 LIKE 1 & 3; -- 0  (pattern is 1 & 3 = 1)
+    let expr = parse_select_expr("SELECT 2 LIKE 1 & 3;");
+    match expr {
+        vibesql_ast::Expression::Like { pattern, negated, .. } => {
+            assert!(!negated);
+            assert_eq!(
+                bin_op(&pattern),
+                vibesql_ast::BinaryOperator::BitwiseAnd,
+                "LIKE pattern should be (1 & 3), got {:?}",
+                pattern
+            );
+        }
+        other => panic!("expected Like expression, got {:?}", other),
     }
 }


### PR DESCRIPTION
## Summary

VibeSQL's standard parser placed the bitwise operators `&` and `|` **looser** than the comparison operators, and gave `<<`/`>>` their own intermediate C-style tier. SQLite (https://sqlite.org/lang_expr.html#operators) instead binds all four bitwise operators (`| & << >>`) as a **single flat left-to-right tier that is tighter than comparison** (`= < > <= >= != IS IN LIKE GLOB BETWEEN ...`) and looser than `+`/`-`. As a result `SELECT 2 = 2 & 2` returned `0` (parsed `(2=2)&2`) instead of SQLite's `1` (parsed `2=(2&2)`).

Also lands Part A of #5851 (bitwise in BETWEEN/LIKE bounds); Part B (relational in bounds) remains open.

## Changes

- `crates/vibesql-parser/src/parser/expressions/operators.rs`
  - Merged `parse_bitwise_or_expression`, `parse_bitwise_and_expression`, and the shift tier (`parse_shift_expression`/`_from`) into a single flat `parse_bitwise_expression` / `parse_bitwise_expression_from` pair (matches on `|`, `&`, `<<`, `>>` in one left-associative loop).
  - Wired the new tier **below** comparison: `parse_not_expression` and `parse_comparison_expression`'s seed now call `parse_comparison_expression` / `parse_bitwise_expression`; every comparison RHS, `IS`/`IS DISTINCT FROM` operand, BETWEEN bound, and LIKE/GLOB pattern/escape call site moved from `parse_shift_expression` to `parse_bitwise_expression`.
  - `continue_higher_precedence_ops` now delegates to `parse_bitwise_expression_from`, so syntactically-closed nodes (IN, ISNULL/NOTNULL, NOT NULL) climb the bitwise tier (`1 IN (1) & 3` → `(1 IN (1)) & 3`).
  - Updated the tier-chain doc comments.
- `crates/vibesql-parser/src/tests/predicates.rs` — bitwise-vs-comparison precedence matrix, flat-tier ordering, IN/ISNULL climbing, and Part A bitwise-in-BETWEEN/LIKE-bound tests (all AST shapes verified against sqlite3 3.51.0).
- `crates/vibesql-parser/src/tests/arena_parser.rs` — assert the arena parser (no bitwise tier) fails without silent truncation and that `parse_with_arena_fallback` yields the correct precedence via the standard parser.

The arena parser is unchanged: it has no bitwise tier and correctly falls back to the standard parser for any `& | << >>` expression, so the parallel-structure invariant is preserved.

## Acceptance Criteria Verification

Every case run against `./target/release/vibesql` and confirmed equal to `sqlite3 :memory:`:

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `SELECT 2 = 2 & 2` → 1 | ✅ | vibesql=1 sqlite=1 |
| `SELECT 2 \| 3 = 3` → 1 | ✅ | vibesql=1 sqlite=1 |
| `SELECT 5 & 3 > 1` → 0 | ✅ | vibesql=0 sqlite=0 |
| `SELECT 5 \| 3 & 1` → 1 (flat tier) | ✅ | vibesql=1 sqlite=1 |
| `SELECT 5 & 3 << 1` → 2 (shift not tighter than &) | ✅ | vibesql=2 sqlite=2 |
| `SELECT 5 \| 3 << 1` → 14 | ✅ | vibesql=14 sqlite=14 |
| `SELECT 1 \| 6 & 4 << 1` → 8 | ✅ | vibesql=8 sqlite=8 |
| `SELECT 1 IN (1) & 3` → 1 | ✅ | vibesql=1 sqlite=1 |
| `SELECT 1 ISNULL & 3` → 0 | ✅ | vibesql=0 sqlite=0 |
| `SELECT 2 BETWEEN 0 AND 3 & 1` → 0 (Part A of #5851) | ✅ | vibesql=0 sqlite=0 |
| `SELECT 2 LIKE 1 & 3` → 0 (Part A of #5851) | ✅ | vibesql=0 sqlite=0 |
| `cargo test -p vibesql-parser` 0 failures | ✅ | 1664 passed + 8 doctests |
| `select1.test` canary no regression | ✅ | 188/188 |

## Test Plan

- 25-case differential battery (bitwise vs comparison, mixed with `+ - * / || <<`, `~`, `COLLATE`, BETWEEN/LIKE bounds, NOT BETWEEN symmetry) — all 25 match sqlite3 3.51.0.
- `cargo test -p vibesql-parser`: 1664 unit + 8 doctests, 0 failures.
- `cargo test -p vibesql-executor`: 0 failures.
- TCL, before → after: `e_expr.test` 374/374 → 374/374; `expr.test` 638/660 → 638/660; `select1.test` canary 188/188.

Closes #5848