### PR TITLE
feat(parser): accept WITHIN GROUP (ORDER BY ...) ordered-set aggregate syntax

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -1222,13 +1222,68 @@ impl<'arena> ArenaParser<'arena> {
             let distinct = self.try_consume_keyword(Keyword::Distinct);
             self.try_consume_keyword(Keyword::All); // ALL is default
 
-            let args = if matches!(self.peek(), Token::RParen) {
+            let mut args = if matches!(self.peek(), Token::RParen) {
                 BumpVec::new_in(self.arena)
             } else {
                 self.parse_expression_list()?
             };
 
             self.expect_token(Token::RParen)?;
+
+            // Parse optional WITHIN GROUP (ORDER BY expr) — ordered-set aggregate
+            // syntax for the percentile family. `percentile(P) WITHIN GROUP
+            // (ORDER BY Y)` is rewritten to `percentile(Y, P)` and
+            // `median() WITHIN GROUP (ORDER BY Y)` to `median(Y)`; the ORDER BY
+            // expression becomes the leading Y argument. The executor's
+            // Percentile accumulator handles both calling conventions.
+            if self.peek_keyword(Keyword::Within) {
+                if !matches!(
+                    name_upper.as_str(),
+                    "MEDIAN" | "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC"
+                ) {
+                    return Err(ParseError {
+                        message: format!(
+                            "WITHIN GROUP may not be used with non-ordered-set aggregate {}()",
+                            name
+                        ),
+                    });
+                }
+                self.advance(); // consume WITHIN
+                self.expect_keyword(Keyword::Group)?;
+                self.expect_token(Token::LParen)?;
+                self.expect_keyword(Keyword::Order)?;
+                self.expect_keyword(Keyword::By)?;
+
+                // A single ordering expression. ASC/DESC and NULLS FIRST/LAST are
+                // accepted and ignored — the accumulator sorts values itself.
+                let within_expr = self.parse_expression()?;
+                if self.peek_keyword(Keyword::Desc) || self.peek_keyword(Keyword::Asc) {
+                    self.advance();
+                }
+                if self.try_consume_keyword(Keyword::Nulls)
+                    && !(self.try_consume_keyword(Keyword::First)
+                        || self.try_consume_keyword(Keyword::Last))
+                {
+                    return Err(ParseError {
+                        message: "Expected FIRST or LAST after NULLS".to_string(),
+                    });
+                }
+                self.expect_token(Token::RParen)?;
+
+                // DISTINCT is rejected on the ordered-set form; `median(DISTINCT x)`
+                // (the non-WITHIN-GROUP form) stays legal.
+                if distinct {
+                    return Err(ParseError {
+                        message: format!(
+                            "DISTINCT not allowed on ordered-set aggregate {}()",
+                            name.to_lowercase()
+                        ),
+                    });
+                }
+
+                // Rewrite: the ORDER BY expression becomes the leading Y argument.
+                args.insert(0, within_expr);
+            }
 
             // Check for OVER clause (window function)
             if self.peek_keyword(Keyword::Over) {

--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -98,6 +98,8 @@ pub enum Keyword {
     Others,
     Ties,
     Window,
+    // Ordered-set aggregate keyword: WITHIN GROUP (ORDER BY ...)
+    Within,
     // Note: Window function names (ROW_NUMBER, RANK, etc.) are identifiers, not keywords
     // Constraint keywords
     Primary,
@@ -409,6 +411,9 @@ impl Keyword {
             Keyword::Groups | Keyword::No | Keyword::Others | Keyword::Over |
             Keyword::Partition | Keyword::Preceding | Keyword::Range | Keyword::Ties |
             Keyword::Unbounded | Keyword::Window | Keyword::First | Keyword::Last |
+            // WITHIN is only contextual in the ordered-set aggregate clause
+            // (WITHIN GROUP), so it stays usable as an ordinary identifier.
+            Keyword::Within |
             // RETURNING is a "fallback" keyword in SQLite (3.35.0+): it is only
             // meaningful at the end of a DML statement and remains usable as an
             // ordinary identifier elsewhere.
@@ -743,6 +748,7 @@ impl fmt::Display for Keyword {
             Keyword::Others => "OTHERS",
             Keyword::Ties => "TIES",
             Keyword::Window => "WINDOW",
+            Keyword::Within => "WITHIN",
             Keyword::Primary => "PRIMARY",
             Keyword::Foreign => "FOREIGN",
             Keyword::Key => "KEY",

--- a/crates/vibesql-parser/src/lexer/keywords.rs
+++ b/crates/vibesql-parser/src/lexer/keywords.rs
@@ -105,6 +105,7 @@ static KEYWORDS: phf::Map<&'static str, Keyword> = phf_map! {
     "OTHERS" => Keyword::Others,
     "TIES" => Keyword::Ties,
     "WINDOW" => Keyword::Window,
+    "WITHIN" => Keyword::Within,
     "CURRENT_DATE" => Keyword::CurrentDate,
     "CURRENT_TIME" => Keyword::CurrentTime,
     "CURRENT_TIMESTAMP" => Keyword::CurrentTimestamp,

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -350,6 +350,69 @@ impl Parser {
             self.expect_token(Token::RParen)?;
         }
 
+        // Parse optional WITHIN GROUP (ORDER BY expr) — ordered-set aggregate
+        // syntax for the percentile family (SQLITE_ENABLE_ORDERED_SET_AGGREGATES).
+        // `percentile(P) WITHIN GROUP (ORDER BY Y)` is rewritten to the two-arg
+        // call `percentile(Y, P)`, and `median() WITHIN GROUP (ORDER BY Y)` to
+        // `median(Y)` — i.e. the ORDER BY expression becomes the leading Y
+        // argument. The executor's Percentile accumulator (#5818) handles both
+        // calling conventions, so no AST change is needed.
+        if matches!(self.peek(), Token::Keyword { keyword: Keyword::Within, .. }) {
+            if !matches!(
+                function_name_upper.as_str(),
+                "MEDIAN" | "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC"
+            ) {
+                return Err(ParseError {
+                    message: format!(
+                        "WITHIN GROUP may not be used with non-ordered-set aggregate {}()",
+                        first
+                    ),
+                });
+            }
+            self.advance(); // consume WITHIN
+            self.expect_keyword(Keyword::Group)?;
+            self.expect_token(Token::LParen)?;
+            self.expect_keyword(Keyword::Order)?;
+            self.expect_keyword(Keyword::By)?;
+
+            // A single ordering expression. ASC/DESC and NULLS FIRST/LAST are
+            // accepted and ignored — the accumulator sorts values itself.
+            let within_expr = self.parse_expression()?;
+            if matches!(self.peek(), Token::Keyword { keyword: Keyword::Asc, .. })
+                || matches!(self.peek(), Token::Keyword { keyword: Keyword::Desc, .. })
+            {
+                self.advance();
+            }
+            if matches!(self.peek(), Token::Keyword { keyword: Keyword::Nulls, .. }) {
+                self.advance(); // consume NULLS
+                if matches!(self.peek(), Token::Keyword { keyword: Keyword::First, .. })
+                    || matches!(self.peek(), Token::Keyword { keyword: Keyword::Last, .. })
+                {
+                    self.advance();
+                } else {
+                    return Err(ParseError {
+                        message: "Expected FIRST or LAST after NULLS".to_string(),
+                    });
+                }
+            }
+            self.expect_token(Token::RParen)?;
+
+            // DISTINCT is rejected on the ordered-set form (percentile-1.1.distinct.2).
+            // Note: `median(DISTINCT x)` (the non-WITHIN-GROUP form) stays legal.
+            if distinct {
+                return Err(ParseError {
+                    message: format!(
+                        "DISTINCT not allowed on ordered-set aggregate {}()",
+                        first.to_lowercase()
+                    ),
+                });
+            }
+
+            // Rewrite: the ORDER BY expression becomes the leading Y argument.
+            args.insert(0, within_expr);
+            order_by = None;
+        }
+
         // Parse optional FILTER clause (SQL:2003)
         // Syntax: aggregate(...) FILTER (WHERE condition) [OVER (...)]
         let filter = if matches!(self.peek(), Token::Keyword { keyword: Keyword::Filter, .. }) {

--- a/crates/vibesql-parser/src/tests/aggregates.rs
+++ b/crates/vibesql-parser/src/tests/aggregates.rs
@@ -350,3 +350,126 @@ fn test_order_by_not_allowed_on_non_aggregate() {
         "Unexpected error message: {msg}"
     );
 }
+
+// ========================================================================
+// WITHIN GROUP (ORDER BY ...) ordered-set aggregate tests (issue #5852)
+// ========================================================================
+
+/// Extract the single aggregate function from `SELECT <agg> FROM t1;`.
+fn parse_single_aggregate(sql: &str) -> (String, bool, Vec<vibesql_ast::Expression>) {
+    let stmt = Parser::parse_sql(sql).expect("expected successful parse");
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match &select.select_list[0] {
+            vibesql_ast::SelectItem::Expression { expr, .. } => match expr {
+                vibesql_ast::Expression::AggregateFunction { name, distinct, args, .. } => {
+                    (name.to_string(), *distinct, args.clone())
+                }
+                other => panic!("Expected aggregate function, got {other:?}"),
+            },
+            _ => panic!("Expected expression select item"),
+        },
+        _ => panic!("Expected SELECT"),
+    }
+}
+
+fn assert_column(expr: &vibesql_ast::Expression, expected: &str) {
+    match expr {
+        vibesql_ast::Expression::ColumnRef(col_id)
+            if col_id.column_canonical() == expected => {}
+        other => panic!("Expected column reference {expected}, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_within_group_percentile_cont_rewrite() {
+    // percentile_cont(0.5) WITHIN GROUP (ORDER BY x) rewrites to the two-arg
+    // form percentile_cont(x, 0.5): the ORDER BY expr becomes the leading Y arg.
+    let (name, distinct, args) =
+        parse_single_aggregate("SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY x) FROM t1;");
+    assert_eq!(name, "percentile_cont");
+    assert!(!distinct);
+    assert_eq!(args.len(), 2, "expected rewritten two-arg call");
+    assert_column(&args[0], "x");
+    // Second argument is the original fraction literal.
+    assert!(
+        matches!(&args[1], vibesql_ast::Expression::Literal(_)),
+        "expected fraction literal as second arg, got {:?}",
+        args[1]
+    );
+}
+
+#[test]
+fn test_within_group_percentile_rewrite() {
+    // percentile(25) WITHIN GROUP (ORDER BY x) rewrites to percentile(x, 25).
+    let (name, _distinct, args) =
+        parse_single_aggregate("SELECT percentile(25) WITHIN GROUP (ORDER BY x) FROM t1;");
+    assert_eq!(name, "percentile");
+    assert_eq!(args.len(), 2);
+    assert_column(&args[0], "x");
+}
+
+#[test]
+fn test_within_group_median_zero_arg_rewrite() {
+    // median() WITHIN GROUP (ORDER BY x) is the zero-arg outer form; it rewrites
+    // to the one-arg call median(x).
+    let (name, distinct, args) =
+        parse_single_aggregate("SELECT median() WITHIN GROUP (ORDER BY x) FROM t1;");
+    assert_eq!(name, "median");
+    assert!(!distinct);
+    assert_eq!(args.len(), 1, "expected rewritten one-arg call");
+    assert_column(&args[0], "x");
+}
+
+#[test]
+fn test_within_group_ignores_desc_and_nulls() {
+    // ASC/DESC and NULLS FIRST/LAST are accepted and ignored by the rewrite.
+    let (name, _distinct, args) = parse_single_aggregate(
+        "SELECT percentile_disc(0.9) WITHIN GROUP (ORDER BY x DESC NULLS LAST) FROM t1;",
+    );
+    assert_eq!(name, "percentile_disc");
+    assert_eq!(args.len(), 2);
+    assert_column(&args[0], "x");
+}
+
+#[test]
+fn test_within_group_distinct_rejected() {
+    // DISTINCT is not allowed on the ordered-set form (percentile-1.1.distinct.2).
+    // The function name is reported in lowercase: `percentile()`.
+    let result =
+        Parser::parse_sql("SELECT percentile(DISTINCT 50) WITHIN GROUP (ORDER BY x) FROM t1;");
+    assert!(result.is_err(), "Expected parse error for DISTINCT ordered-set aggregate");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("DISTINCT not allowed on ordered-set aggregate percentile()"),
+        "Unexpected error message: {msg}"
+    );
+}
+
+#[test]
+fn test_median_distinct_still_legal() {
+    // The non-WITHIN-GROUP form median(DISTINCT x) remains valid.
+    let (name, distinct, args) = parse_single_aggregate("SELECT median(DISTINCT x) FROM t1;");
+    assert_eq!(name, "median");
+    assert!(distinct);
+    assert_eq!(args.len(), 1);
+    assert_column(&args[0], "x");
+}
+
+#[test]
+fn test_within_still_usable_as_identifier() {
+    // WITHIN is a non-reserved keyword: it must remain usable as a plain
+    // column/table identifier (non-regression).
+    let result = Parser::parse_sql("SELECT within FROM within;");
+    assert!(result.is_ok(), "Expected `within` to parse as an identifier: {result:?}");
+
+    let result2 = Parser::parse_sql("SELECT within AS w FROM t1;");
+    assert!(result2.is_ok(), "Expected `within` column reference to parse: {result2:?}");
+}
+
+#[test]
+fn test_within_group_rejected_on_non_ordered_set_aggregate() {
+    // WITHIN GROUP is only meaningful for the percentile family; other
+    // aggregates reject it.
+    let result = Parser::parse_sql("SELECT sum(x) WITHIN GROUP (ORDER BY y) FROM t1;");
+    assert!(result.is_err(), "Expected parse error for WITHIN GROUP on sum()");
+}

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -567,6 +567,13 @@ proc translate_error_to_sqlite {vibesql_error} {
     if {[regexp -nocase {^Parse error: (DISTINCT aggregates must have exactly one argument)$} $error_msg -> parse_msg]} {
         return $parse_msg
     }
+    # DISTINCT on an ordered-set aggregate (percentile family WITHIN GROUP form).
+    # "Parse error: DISTINCT not allowed on ordered-set aggregate percentile()"
+    # -> "DISTINCT not allowed on ordered-set aggregate percentile()"
+    # (percentile-1.1.distinct.2)
+    if {[regexp -nocase {^Parse error: (DISTINCT not allowed on ordered-set aggregate .+\(\))$} $error_msg -> parse_msg]} {
+        return $parse_msg
+    }
     # ORDER BY without LIMIT on DELETE/UPDATE (SQLite-compatible error messages)
     if {[regexp -nocase {^Parse error: (ORDER BY without LIMIT on (?:DELETE|UPDATE))$} $error_msg -> parse_msg]} {
         return $parse_msg
@@ -5350,14 +5357,13 @@ proc check_single_capability {cap} {
     # errors with `no such column: rowid` (#5492). Marking it unsupported makes
     # `ifcapable !allow_rowid_in_view` blocks (e.g. trigger9-4.2/4.3) take their
     # error-expecting branch, matching real sqlite3 with the option off.
-    # `ordered_set_aggregates` is the SQLITE_ENABLE_ORDERED_SET_AGGREGATES
-    # compile-time option (percentile_cont(F) WITHIN GROUP (ORDER BY x)),
-    # which is OFF by default in SQLite. VibeSQL matches the default: the
-    # WITHIN GROUP syntax errors with `near "(": syntax error`, exactly like
-    # a stock sqlite3 build. Marking it unsupported makes percentile.test's
-    # `ifcapable ordered_set_aggregates` blocks (~89 tests) skip and its
-    # else-branch (expecting the syntax error) run (#5818, 2026-07-03).
-    # WITHIN GROUP parser support is tracked as a follow-up to #5818.
+    # `ordered_set_aggregates` (SQLITE_ENABLE_ORDERED_SET_AGGREGATES) is now
+    # SUPPORTED: VibeSQL's parser accepts the `agg(F) WITHIN GROUP (ORDER BY x)`
+    # ordered-set syntax for the percentile family and rewrites it to the
+    # two-arg calling convention handled by the executor's Percentile
+    # accumulator (#5852, follow-up to #5818). It is therefore no longer in
+    # unsupported_caps, so percentile.test's `ifcapable ordered_set_aggregates`
+    # blocks now execute their WITHIN GROUP tests against the parser.
     # `crashtest` gates SQLite's crash-recovery harness (crashsql + the
     # crash-test child process machinery in test6.c). The shim has no crashsql,
     # so crash*.test files must take their `ifcapable !crashtest { finish_test;
@@ -5365,7 +5371,7 @@ proc check_single_capability {cap} {
     # `fts3_unicode` is the FTS3/4 unicode61 tokenizer compile-time option; FTS
     # is unsupported in VibeSQL, so fts4unicode.test self-skips via its
     # `ifcapable !fts3_unicode` guard (#5843).
-    set unsupported_caps {wal vacuum_incr autovacuum stat4 stat3 tclvar vtab rtree fts3 fts4 fts5 fts3_unicode conflict hiddencolumns progress allow_rowid_in_view ordered_set_aggregates crashtest}
+    set unsupported_caps {wal vacuum_incr autovacuum stat4 stat3 tclvar vtab rtree fts3 fts4 fts5 fts3_unicode conflict hiddencolumns progress allow_rowid_in_view crashtest}
 
     # Handle negated capability (e.g., !autovacuum)
     set negate 0


### PR DESCRIPTION
## Summary

Adds parser support for the ordered-set aggregate syntax `agg(F) WITHIN GROUP (ORDER BY Y)` used by SQLite's percentile extension (`SQLITE_ENABLE_ORDERED_SET_AGGREGATES`). The clause is rewritten at parse time to the two-arg calling convention the executor's `AggregateAccumulator::Percentile` (from #5818) already handles, so **no AST change is needed**:

- `percentile(P) WITHIN GROUP (ORDER BY Y)` -> `percentile(Y, P)`
- `percentile_cont(F) WITHIN GROUP (ORDER BY Y)` -> `percentile_cont(Y, F)`
- `percentile_disc(F) WITHIN GROUP (ORDER BY Y)` -> `percentile_disc(Y, F)`
- `median() WITHIN GROUP (ORDER BY Y)` -> `median(Y)`

## Changes

- `keywords.rs` / `lexer/keywords.rs`: add `WITHIN` as a non-reserved keyword (in `can_be_identifier`, like `FILTER`/`OVER`) so it stays usable as an ordinary identifier.
- `parser/expressions/functions/mod.rs`: after the closing `)` of an aggregate call, detect `WITHIN GROUP (ORDER BY expr)`, prepend the ORDER BY expression as the leading Y argument, and reject `DISTINCT` on the ordered-set form. ASC/DESC and NULLS FIRST/LAST are accepted and ignored.
- `arena_parser/expression.rs`: the same rewrite for the arena parse path.
- `scripts/tester_vibesql.tcl`: remove `ordered_set_aggregates` from `unsupported_caps` so percentile.test's `ifcapable ordered_set_aggregates` blocks now execute; add a catchsql translation stripping the `Parse error:` prefix from the DISTINCT rejection.
- `tests/aggregates.rs`: 8 unit tests for the rewrite, the `median()` zero-arg form, the DISTINCT error, `median(DISTINCT x)` non-regression, and `WITHIN`-as-identifier.

Executor validation (`validation/aggregates.rs`) needed no change: after the rewrite, `median` receives 1 arg and the percentile family receives 2, matching the existing arg-count checks.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Remove `ordered_set_aggregates` from `unsupported_caps` | Done | Removed from list in `tester_vibesql.tcl` |
| `make test-tcl-file FILE=percentile.test` passes with WITHIN GROUP blocks enabled | Done | 190/209 pass, 0 fail, 19 skip (was 111/121, 10 skip) |
| `DISTINCT not allowed on ordered-set aggregate <name>()` error | Done | percentile-1.1.distinct.2 passes; unit test `test_within_group_distinct_rejected` |
| `median(DISTINCT x)` still returns median of distinct values | Done | percentile-1.1.distinct.1 passes (7.0); unit test `test_median_distinct_still_legal` |
| `median() WITHIN GROUP (ORDER BY x)` passes | Done | percentile-1.1.median passes; unit test `test_within_group_median_zero_arg_rewrite` |
| `percentile_cont(0.5) WITHIN GROUP (ORDER BY x)` rewrites to two-arg form | Done | unit test `test_within_group_percentile_cont_rewrite` |
| `WITHIN` remains usable as an identifier | Done | unit test `test_within_still_usable_as_identifier` |

## Test Plan

- `cargo test -p vibesql-parser` — 1672 pass, 0 fail (8 new tests)
- `cargo test -p vibesql-executor` — all pass, 0 fail
- `make test-tcl-file FILE=percentile.test` — 190 pass / 0 fail / 19 skip / 209 total (baseline before this change: 111 pass / 0 fail / 10 skip / 121 total)
- `cargo clippy -p vibesql-parser` — no new warnings from changed code

Closes #5852