### PR TITLE
fix(parser): relational operators (< <= > >=) in BETWEEN bounds / LIKE-GLOB patterns (#5851 Part B)

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -91,17 +91,105 @@ impl<'arena> ArenaParser<'arena> {
         }
     }
 
+    /// Parse relational expression (handles `<`, `<=`, `>`, `>=`).
+    ///
+    /// Per SQLite the relational operators form their own tier that binds TIGHTER
+    /// than the equality / predicate tier (`= == != <> IS IN LIKE BETWEEN ...`)
+    /// but LOOSER than the arithmetic tiers. They are left-associative, so
+    /// `1 < 2 < 3` parses as `((1 < 2) < 3)`. Because this tier binds tighter
+    /// than the predicate tier, BETWEEN bounds and LIKE patterns parse here:
+    /// `2 BETWEEN 0 AND 3 < 3` has high bound `(3 < 3)`.
+    ///
+    /// The arena parser has no shift/bitwise tier, so this tier climbs the
+    /// additive tier directly (unlike the standard parser, which interposes the
+    /// bitwise tier). Expressions using `| & << >>` fail arena parsing and fall
+    /// back to the standard parser regardless.
+    fn parse_relational_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
+        let seed = self.parse_unary_expression()?;
+        self.parse_relational_expression_from(seed)
+    }
+
+    /// Relational tier (`<`, `<=`, `>`, `>=`) with an already-parsed left operand.
+    ///
+    /// The seed is first climbed through the tighter additive tier (which in turn
+    /// climbs multiplicative/concat), so this doubles as the seeded
+    /// precedence-climbing entry point used by `continue_higher_precedence_ops`.
+    fn parse_relational_expression_from(
+        &mut self,
+        left: Expression<'arena>,
+    ) -> Result<Expression<'arena>, ParseError> {
+        let mut left = self.parse_additive_expression_from(left)?;
+
+        loop {
+            let op = match self.peek() {
+                Token::Symbol('<') => BinaryOperator::LessThan,
+                Token::Symbol('>') => BinaryOperator::GreaterThan,
+                Token::Operator(MultiCharOperator::LessEqual) => {
+                    BinaryOperator::LessThanOrEqual
+                }
+                Token::Operator(MultiCharOperator::GreaterEqual) => {
+                    BinaryOperator::GreaterThanOrEqual
+                }
+                _ => break,
+            };
+            self.advance();
+
+            // Quantified comparison (ALL / ANY / SOME): `x < ALL (SELECT ...)`.
+            // The relational operators live in this tier, so the quantified form
+            // is recognized here (the outer equality tier handles `= ALL` etc.).
+            if self.peek_keyword(Keyword::All)
+                || self.peek_keyword(Keyword::Any)
+                || self.peek_keyword(Keyword::Some)
+            {
+                let quantifier = if self.try_consume_keyword(Keyword::All) {
+                    Quantifier::All
+                } else if self.try_consume_keyword(Keyword::Any) {
+                    Quantifier::Any
+                } else {
+                    self.consume_keyword(Keyword::Some)?;
+                    Quantifier::Some
+                };
+
+                self.expect_token(Token::LParen)?;
+                let subquery = self.parse_select_statement()?;
+                self.expect_token(Token::RParen)?;
+
+                let left_ref = self.arena.alloc(left);
+                left = Expression::Extended(self.arena.alloc(
+                    ExtendedExpr::QuantifiedComparison {
+                        expr: left_ref,
+                        op,
+                        quantifier,
+                        subquery,
+                    },
+                ));
+                continue;
+            }
+
+            let right = self.parse_additive_expression()?;
+            let left_ref = self.arena.alloc(left);
+            let right_ref = self.arena.alloc(right);
+            left = Expression::BinaryOp { op, left: left_ref, right: right_ref };
+        }
+
+        Ok(left)
+    }
+
     /// Parse comparison expression.
     ///
-    /// Per SQLite, all operators in this tier (=, <, >, IS, IN, BETWEEN, LIKE,
-    /// ISNULL, NOTNULL, ...) are left-associative and composable, so they chain:
-    /// `1 IN (1) NOT IN (SELECT 2)` parses as `(1 IN (1)) NOT IN (SELECT 2)`.
+    /// Per SQLite, the equality / predicate operators (=, ==, IS, IN, BETWEEN,
+    /// LIKE, ISNULL, NOTNULL, ...) form a tier that binds LOOSER than the
+    /// relational (`< <= > >=`) tier. They are left-associative and composable,
+    /// so they chain: `1 IN (1) NOT IN (SELECT 2)` parses as
+    /// `(1 IN (1)) NOT IN (SELECT 2)`. The seed and every operand within this
+    /// tier parse at the relational tier, so `1 < 2 = 1` parses as
+    /// `((1 < 2) = 1)` and `1 = 2 < 3` as `(1 = (2 < 3))`.
     /// Additionally, IN's right operand is syntactically closed (a parenthesized
     /// list/subquery), so a tighter-binding operator that follows an IN node takes
     /// the whole IN expression as its left operand:
     /// `1 IN (SELECT 1) + 1` parses as `(1 IN (SELECT 1)) + 1`.
     fn parse_comparison_expression(&mut self) -> Result<Expression<'arena>, ParseError> {
-        let mut left = self.parse_additive_expression()?;
+        let mut left = self.parse_relational_expression()?;
 
         loop {
             // Check for IN, BETWEEN, LIKE operators
@@ -162,9 +250,9 @@ impl<'arena> ArenaParser<'arena> {
                         self.try_consume_keyword(Keyword::Asymmetric);
                     }
 
-                    let low = self.parse_additive_expression()?;
+                    let low = self.parse_relational_expression()?;
                     self.consume_keyword(Keyword::And)?;
-                    let high = self.parse_additive_expression()?;
+                    let high = self.parse_relational_expression()?;
 
                     let left_ref = self.arena.alloc(left);
                     let low_ref = self.arena.alloc(low);
@@ -180,11 +268,11 @@ impl<'arena> ArenaParser<'arena> {
                     continue;
                 } else if self.peek_keyword(Keyword::Like) {
                     self.consume_keyword(Keyword::Like)?;
-                    let pattern = self.parse_additive_expression()?;
+                    let pattern = self.parse_relational_expression()?;
                     let escape: Option<&Expression<'arena>> = if self.peek_keyword(Keyword::Escape)
                     {
                         self.consume_keyword(Keyword::Escape)?;
-                        Some(self.arena.alloc(self.parse_additive_expression()?))
+                        Some(self.arena.alloc(self.parse_relational_expression()?))
                     } else {
                         None
                     };
@@ -264,9 +352,9 @@ impl<'arena> ArenaParser<'arena> {
                     self.try_consume_keyword(Keyword::Asymmetric);
                 }
 
-                let low = self.parse_additive_expression()?;
+                let low = self.parse_relational_expression()?;
                 self.consume_keyword(Keyword::And)?;
-                let high = self.parse_additive_expression()?;
+                let high = self.parse_relational_expression()?;
 
                 let left_ref = self.arena.alloc(left);
                 let low_ref = self.arena.alloc(low);
@@ -282,10 +370,10 @@ impl<'arena> ArenaParser<'arena> {
                 continue;
             } else if self.peek_keyword(Keyword::Like) {
                 self.consume_keyword(Keyword::Like)?;
-                let pattern = self.parse_additive_expression()?;
+                let pattern = self.parse_relational_expression()?;
                 let escape: Option<&Expression<'arena>> = if self.peek_keyword(Keyword::Escape) {
                     self.consume_keyword(Keyword::Escape)?;
-                    Some(self.arena.alloc(self.parse_additive_expression()?))
+                    Some(self.arena.alloc(self.parse_relational_expression()?))
                 } else {
                     None
                 };
@@ -300,14 +388,15 @@ impl<'arena> ArenaParser<'arena> {
                 continue;
             }
 
-            // Check for comparison operators
+            // Check for equality / predicate comparison operators.
+            // The relational operators (`< <= > >=`) are NOT handled here: they
+            // bind tighter and are consumed by the relational tier (the seed of
+            // this function and every operand within it).
             let is_comparison = match self.peek() {
-                Token::Symbol('=') | Token::Symbol('<') | Token::Symbol('>') => true,
+                Token::Symbol('=') => true,
                 Token::Operator(s) => matches!(
                     s,
-                    MultiCharOperator::LessEqual
-                        | MultiCharOperator::GreaterEqual
-                        | MultiCharOperator::NotEqual
+                    MultiCharOperator::NotEqual
                         | MultiCharOperator::NotEqualAlt
                         | MultiCharOperator::DoubleEqual
                         | MultiCharOperator::CosineDistance
@@ -320,11 +409,7 @@ impl<'arena> ArenaParser<'arena> {
             if is_comparison {
                 let op = match self.peek() {
                     Token::Symbol('=') => BinaryOperator::Equal,
-                    Token::Symbol('<') => BinaryOperator::LessThan,
-                    Token::Symbol('>') => BinaryOperator::GreaterThan,
                     Token::Operator(s) => match s {
-                        MultiCharOperator::LessEqual => BinaryOperator::LessThanOrEqual,
-                        MultiCharOperator::GreaterEqual => BinaryOperator::GreaterThanOrEqual,
                         MultiCharOperator::NotEqual | MultiCharOperator::NotEqualAlt => {
                             BinaryOperator::NotEqual
                         }
@@ -376,7 +461,8 @@ impl<'arena> ArenaParser<'arena> {
                     continue;
                 }
 
-                let right = self.parse_additive_expression()?;
+                // RHS parses at the relational tier, so `1 = 2 < 3` is `1 = (2 < 3)`.
+                let right = self.parse_relational_expression()?;
                 let left_ref = self.arena.alloc(left);
                 let right_ref = self.arena.alloc(right);
                 left = Expression::BinaryOp { op, left: left_ref, right: right_ref };
@@ -392,7 +478,7 @@ impl<'arena> ArenaParser<'arena> {
                 if self.peek_keyword(Keyword::Distinct) {
                     self.consume_keyword(Keyword::Distinct)?;
                     self.expect_keyword(Keyword::From)?;
-                    let right = self.parse_additive_expression()?;
+                    let right = self.parse_relational_expression()?;
                     let left_ref = self.arena.alloc(left);
                     let right_ref = self.arena.alloc(right);
                     left = Expression::IsDistinctFrom { left: left_ref, right: right_ref, negated };
@@ -428,7 +514,7 @@ impl<'arena> ArenaParser<'arena> {
                 } else {
                     // SQLite compatibility: IS <expr> - compare using IS semantics (NULL-safe equals)
                     // This handles cases like `expr IS 0` or `expr IS 1`
-                    let right = self.parse_additive_expression()?;
+                    let right = self.parse_relational_expression()?;
                     let left_ref = self.arena.alloc(left);
                     let right_ref = self.arena.alloc(right);
                     // IS is equivalent to IS NOT DISTINCT FROM (NULL-safe equals)
@@ -475,23 +561,26 @@ impl<'arena> ArenaParser<'arena> {
     }
 
     /// Continue parsing tighter-binding binary operators (multiplicative, concat,
-    /// additive) with an already-parsed left operand.
+    /// additive, relational) with an already-parsed left operand.
     ///
     /// Used after a syntactically-closed comparison-tier node — IN/NOT IN
     /// (right operand is a parenthesized list/subquery) and the postfix null
     /// tests ISNULL / NOTNULL / NOT NULL (no right operand at all). Per SQLite
     /// a tighter-binding operator that follows takes the entire node as its
-    /// left operand: `1 IN (SELECT 1) + 1` parses as `(1 IN (SELECT 1)) + 1`
-    /// and `1 ISNULL + 1` as `(1 ISNULL) + 1`.
+    /// left operand: `1 IN (SELECT 1) + 1` parses as `(1 IN (SELECT 1)) + 1`,
+    /// `1 IN (1) < 3` as `(1 IN (1)) < 3`, and `1 ISNULL + 1` as `(1 ISNULL) + 1`.
     ///
     /// Each operator's right operand is parsed at the next-tighter tier, so
     /// relative precedence among these operators is preserved
     /// (e.g. `x IN (1) + 2 * 3` parses as `(x IN (1)) + (2 * 3)`).
     ///
-    /// Delegates to `parse_additive_expression_from`, which climbs the seeded
-    /// left operand through the multiplicative, concat, and additive tiers
-    /// using the canonical per-tier operator loops. The standard parser has
-    /// the same helper (plus a shift tier) in parser/expressions/operators.rs.
+    /// Delegates to `parse_relational_expression_from`, which climbs the seeded
+    /// left operand through the multiplicative, concat, additive, and relational
+    /// tiers using the canonical per-tier operator loops. The relational tier is
+    /// the tightest tier still looser than the equality/predicate tier, so
+    /// climbing to it (and no further) leaves the outer equality loop to reduce
+    /// left. The standard parser has the same helper (plus a bitwise tier) in
+    /// parser/expressions/operators.rs.
     ///
     /// Note: the arena parser has no shift/bitwise tiers; expressions using
     /// those operators fail here and fall back to the standard parser.
@@ -499,7 +588,7 @@ impl<'arena> ArenaParser<'arena> {
         &mut self,
         left: Expression<'arena>,
     ) -> Result<Expression<'arena>, ParseError> {
-        self.parse_additive_expression_from(left)
+        self.parse_relational_expression_from(left)
     }
 
     // ------------------------------------------------------------------

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -272,12 +272,99 @@ impl Parser {
         Ok(left)
     }
 
-    /// Parse comparison expression (handles =, <, >, <=, >=, !=, <>, IN, BETWEEN, LIKE, IS NULL)
-    /// These operators have lower precedence than arithmetic operators
+    /// Parse relational expression (handles `<`, `<=`, `>`, `>=`).
     ///
-    /// Per SQLite, all operators in this tier (=, <, >, IS, IN, BETWEEN, LIKE, GLOB,
-    /// ISNULL, NOTNULL, ...) are left-associative and composable, so they chain:
+    /// Per SQLite (https://sqlite.org/lang_expr.html#operators) the relational
+    /// operators form their own tier that binds TIGHTER than the equality /
+    /// predicate tier (`= == != <> IS IN LIKE GLOB BETWEEN ...`) but LOOSER than
+    /// the bitwise tier (`| & << >>`). They are left-associative, so
+    /// `1 < 2 < 3` parses as `((1 < 2) < 3)`. Because this tier binds tighter
+    /// than the predicate tier, BETWEEN bounds and LIKE/GLOB patterns parse
+    /// here: `2 BETWEEN 0 AND 3 < 3` has high bound `(3 < 3)`, and
+    /// `2 LIKE 1 < 3` has pattern `(1 < 3)`.
+    pub(super) fn parse_relational_expression(
+        &mut self,
+    ) -> Result<vibesql_ast::Expression, ParseError> {
+        let seed = self.parse_unary_expression()?;
+        self.parse_relational_expression_from(seed)
+    }
+
+    /// Relational tier (`<`, `<=`, `>`, `>=`) with an already-parsed left operand.
+    ///
+    /// The seed is first climbed through the tighter bitwise tier (which in turn
+    /// climbs additive/multiplicative/concat), so this doubles as the seeded
+    /// precedence-climbing entry point used by `continue_higher_precedence_ops`.
+    fn parse_relational_expression_from(
+        &mut self,
+        left: vibesql_ast::Expression,
+    ) -> Result<vibesql_ast::Expression, ParseError> {
+        let mut left = self.parse_bitwise_expression_from(left)?;
+
+        loop {
+            let op = match self.peek() {
+                Token::Symbol('<') => vibesql_ast::BinaryOperator::LessThan,
+                Token::Symbol('>') => vibesql_ast::BinaryOperator::GreaterThan,
+                Token::Operator(crate::token::MultiCharOperator::LessEqual) => {
+                    vibesql_ast::BinaryOperator::LessThanOrEqual
+                }
+                Token::Operator(crate::token::MultiCharOperator::GreaterEqual) => {
+                    vibesql_ast::BinaryOperator::GreaterThanOrEqual
+                }
+                _ => break,
+            };
+            self.advance();
+
+            // Quantified comparison (ALL / ANY / SOME): `x < ALL (SELECT ...)`.
+            // The relational operators live in this tier, so the quantified form
+            // is recognized here (the outer equality tier handles `= ALL` etc.).
+            if self.peek_keyword(Keyword::All)
+                || self.peek_keyword(Keyword::Any)
+                || self.peek_keyword(Keyword::Some)
+            {
+                let quantifier = if self.peek_keyword(Keyword::All) {
+                    self.consume_keyword(Keyword::All)?;
+                    vibesql_ast::Quantifier::All
+                } else if self.peek_keyword(Keyword::Any) {
+                    self.consume_keyword(Keyword::Any)?;
+                    vibesql_ast::Quantifier::Any
+                } else {
+                    self.consume_keyword(Keyword::Some)?;
+                    vibesql_ast::Quantifier::Some
+                };
+
+                self.expect_token(Token::LParen)?;
+                let subquery = self.parse_select_statement()?;
+                self.expect_token(Token::RParen)?;
+
+                left = vibesql_ast::Expression::QuantifiedComparison {
+                    expr: Box::new(left),
+                    op,
+                    quantifier,
+                    subquery: Box::new(subquery),
+                };
+                continue;
+            }
+
+            let right = self.parse_bitwise_expression()?;
+            left = vibesql_ast::Expression::BinaryOp {
+                op,
+                left: Box::new(left),
+                right: Box::new(right),
+            };
+        }
+
+        Ok(left)
+    }
+
+    /// Parse comparison expression (handles =, ==, !=, <>, IN, BETWEEN, LIKE, GLOB, IS NULL)
+    /// These operators have lower precedence than the relational (`< <= > >=`) tier.
+    ///
+    /// Per SQLite, the equality / predicate operators (=, ==, IS, IN, BETWEEN,
+    /// LIKE, GLOB, ISNULL, NOTNULL, ...) form a tier that binds LOOSER than the
+    /// relational tier. They are left-associative and composable, so they chain:
     /// `1 IN (1) NOT IN (SELECT 2)` parses as `(1 IN (1)) NOT IN (SELECT 2)`.
+    /// The seed and every operand within this tier parse at the relational tier,
+    /// so `1 < 2 = 1` parses as `((1 < 2) = 1)` and `1 = 2 < 3` as `(1 = (2 < 3))`.
     /// Additionally, IN's right operand is syntactically closed (a parenthesized
     /// list/subquery or a table name), so a tighter-binding operator that follows an
     /// IN node takes the whole IN expression as its left operand:
@@ -285,7 +372,7 @@ impl Parser {
     pub(super) fn parse_comparison_expression(
         &mut self,
     ) -> Result<vibesql_ast::Expression, ParseError> {
-        let mut left = self.parse_bitwise_expression()?;
+        let mut left = self.parse_relational_expression()?;
 
         loop {
             // Check for IN operator (including NOT IN) and BETWEEN (including NOT BETWEEN)
@@ -413,10 +500,11 @@ impl Parser {
                         false
                     };
 
-                    // Parse low AND high
-                    let low = self.parse_bitwise_expression()?;
+                    // Parse low AND high at the relational tier (see BETWEEN
+                    // below for the tier rationale).
+                    let low = self.parse_relational_expression()?;
                     self.consume_keyword(Keyword::And)?;
-                    let high = self.parse_bitwise_expression()?;
+                    let high = self.parse_relational_expression()?;
 
                     left = vibesql_ast::Expression::Between {
                         expr: Box::new(left),
@@ -430,13 +518,13 @@ impl Parser {
                     // It's NOT LIKE
                     self.consume_keyword(Keyword::Like)?;
 
-                    // Parse pattern expression
-                    let pattern = self.parse_bitwise_expression()?;
+                    // Parse pattern expression at the relational tier
+                    let pattern = self.parse_relational_expression()?;
 
                     // Check for optional ESCAPE clause
                     let escape = if self.peek_keyword(Keyword::Escape) {
                         self.consume_keyword(Keyword::Escape)?;
-                        Some(Box::new(self.parse_bitwise_expression()?))
+                        Some(Box::new(self.parse_relational_expression()?))
                     } else {
                         None
                     };
@@ -452,13 +540,13 @@ impl Parser {
                     // It's NOT GLOB (SQLite)
                     self.consume_keyword(Keyword::Glob)?;
 
-                    // Parse pattern expression
-                    let pattern = self.parse_bitwise_expression()?;
+                    // Parse pattern expression at the relational tier
+                    let pattern = self.parse_relational_expression()?;
 
                     // Check for optional ESCAPE clause
                     let escape = if self.peek_keyword(Keyword::Escape) {
                         self.consume_keyword(Keyword::Escape)?;
-                        Some(Box::new(self.parse_bitwise_expression()?))
+                        Some(Box::new(self.parse_relational_expression()?))
                     } else {
                         None
                     };
@@ -650,12 +738,15 @@ impl Parser {
                 };
 
                 // Parse low AND high
-                // Bounds parse at the bitwise tier (same as NOT BETWEEN): everything
-                // tighter than the comparison tier is allowed (including `& | << >>`);
-                // only the boolean AND separating low/high must not be consumed.
-                let low = self.parse_bitwise_expression()?;
+                // Bounds parse at the relational tier (same as NOT BETWEEN):
+                // everything tighter than the equality/predicate tier is allowed,
+                // including the relational operators (`< <= > >=`) and the bitwise
+                // tier (`& | << >>`). Per SQLite `2 BETWEEN 0 AND 3 < 3` has high
+                // bound `(3 < 3)`. Only the boolean AND separating low/high must
+                // not be consumed.
+                let low = self.parse_relational_expression()?;
                 self.consume_keyword(Keyword::And)?;
-                let high = self.parse_bitwise_expression()?;
+                let high = self.parse_relational_expression()?;
 
                 left = vibesql_ast::Expression::Between {
                     expr: Box::new(left),
@@ -669,13 +760,13 @@ impl Parser {
                 // It's LIKE (not negated)
                 self.consume_keyword(Keyword::Like)?;
 
-                // Parse pattern expression at the bitwise tier (same as NOT LIKE)
-                let pattern = self.parse_bitwise_expression()?;
+                // Parse pattern expression at the relational tier (same as NOT LIKE)
+                let pattern = self.parse_relational_expression()?;
 
                 // Check for optional ESCAPE clause
                 let escape = if self.peek_keyword(Keyword::Escape) {
                     self.consume_keyword(Keyword::Escape)?;
-                    Some(Box::new(self.parse_bitwise_expression()?))
+                    Some(Box::new(self.parse_relational_expression()?))
                 } else {
                     None
                 };
@@ -691,13 +782,13 @@ impl Parser {
                 // It's GLOB (SQLite) (not negated)
                 self.consume_keyword(Keyword::Glob)?;
 
-                // Parse pattern expression at the bitwise tier (same as NOT GLOB)
-                let pattern = self.parse_bitwise_expression()?;
+                // Parse pattern expression at the relational tier (same as NOT GLOB)
+                let pattern = self.parse_relational_expression()?;
 
                 // Check for optional ESCAPE clause
                 let escape = if self.peek_keyword(Keyword::Escape) {
                     self.consume_keyword(Keyword::Escape)?;
-                    Some(Box::new(self.parse_bitwise_expression()?))
+                    Some(Box::new(self.parse_relational_expression()?))
                 } else {
                     None
                 };
@@ -711,28 +802,32 @@ impl Parser {
                 continue;
             }
 
-            // Check for comparison operators (both single-char and multi-char)
-            // Note: Exclude || (concat) operator which should be handled in additive expression
+            // Check for equality / predicate comparison operators.
+            // The relational operators (`< <= > >=`) are NOT handled here: they
+            // bind tighter and are consumed by the relational tier (the seed of
+            // this function and every operand within it). Concat / shift / JSON
+            // operators bind tighter still and are consumed at their own tiers.
             let is_comparison = match self.peek() {
-                Token::Symbol('=') | Token::Symbol('<') | Token::Symbol('>') => true,
-                Token::Operator(op) => !matches!(op, crate::token::MultiCharOperator::Concat),
+                Token::Symbol('=') => true,
+                Token::Operator(op) => !matches!(
+                    op,
+                    crate::token::MultiCharOperator::Concat
+                        | crate::token::MultiCharOperator::LessEqual
+                        | crate::token::MultiCharOperator::GreaterEqual
+                        | crate::token::MultiCharOperator::LeftShift
+                        | crate::token::MultiCharOperator::RightShift
+                        | crate::token::MultiCharOperator::JsonExtract
+                        | crate::token::MultiCharOperator::JsonExtractText
+                ),
                 _ => false,
             };
 
             if is_comparison {
                 let op = match self.peek() {
                     Token::Symbol('=') => vibesql_ast::BinaryOperator::Equal,
-                    Token::Symbol('<') => vibesql_ast::BinaryOperator::LessThan,
-                    Token::Symbol('>') => vibesql_ast::BinaryOperator::GreaterThan,
                     Token::Operator(op) => {
                         use crate::token::MultiCharOperator;
                         match op {
-                            MultiCharOperator::LessEqual => {
-                                vibesql_ast::BinaryOperator::LessThanOrEqual
-                            }
-                            MultiCharOperator::GreaterEqual => {
-                                vibesql_ast::BinaryOperator::GreaterThanOrEqual
-                            }
                             MultiCharOperator::NotEqual | MultiCharOperator::NotEqualAlt => {
                                 vibesql_ast::BinaryOperator::NotEqual
                             }
@@ -748,12 +843,15 @@ impl Parser {
                             MultiCharOperator::L2Distance => {
                                 vibesql_ast::BinaryOperator::L2Distance
                             }
-                            // These operators bind tighter than comparison and
-                            // are consumed at lower tiers (Concat at the concat
-                            // tier, shifts at the bitwise tier, and `->`/`->>` at
-                            // the JSON-path tier), so reaching here means a
-                            // genuinely misplaced operator.
-                            MultiCharOperator::Concat
+                            // These operators bind tighter than the equality tier
+                            // and are consumed at lower tiers (relational `< <= > >=`
+                            // at the relational tier, Concat at the concat tier,
+                            // shifts at the bitwise tier, and `->`/`->>` at the
+                            // JSON-path tier), so the is_comparison gate above
+                            // already excludes them; this arm is unreachable.
+                            MultiCharOperator::LessEqual
+                            | MultiCharOperator::GreaterEqual
+                            | MultiCharOperator::Concat
                             | MultiCharOperator::LeftShift
                             | MultiCharOperator::RightShift
                             | MultiCharOperator::JsonExtract
@@ -802,7 +900,8 @@ impl Parser {
                     continue;
                 }
 
-                let right = self.parse_bitwise_expression()?;
+                // RHS parses at the relational tier, so `1 = 2 < 3` is `1 = (2 < 3)`.
+                let right = self.parse_relational_expression()?;
                 left = vibesql_ast::Expression::BinaryOp {
                     op,
                     left: Box::new(left),
@@ -827,7 +926,7 @@ impl Parser {
                 if self.peek_keyword(Keyword::Distinct) {
                     self.consume_keyword(Keyword::Distinct)?;
                     self.expect_keyword(Keyword::From)?;
-                    let right = self.parse_bitwise_expression()?;
+                    let right = self.parse_relational_expression()?;
                     left = vibesql_ast::Expression::IsDistinctFrom {
                         left: Box::new(left),
                         right: Box::new(right),
@@ -861,7 +960,7 @@ impl Parser {
                 } else {
                     // SQLite compatibility: IS <expr> - compare using IS semantics (NULL-safe equals)
                     // This handles cases like `expr IS 0` or `expr IS 1`
-                    let right = self.parse_bitwise_expression()?;
+                    let right = self.parse_relational_expression()?;
                     left = vibesql_ast::Expression::IsDistinctFrom {
                         left: Box::new(left),
                         right: Box::new(right),
@@ -902,7 +1001,7 @@ impl Parser {
     }
 
     /// Continue parsing tighter-binding binary operators (multiplicative, concat,
-    /// additive, bitwise) with an already-parsed left operand.
+    /// additive, bitwise, relational) with an already-parsed left operand.
     ///
     /// Used after a syntactically-closed comparison-tier node — IN/NOT IN
     /// (right operand is a parenthesized list/subquery or a table name) and
@@ -910,7 +1009,8 @@ impl Parser {
     /// all). Per SQLite a tighter-binding operator that follows takes the
     /// entire node as its left operand: `1 IN (SELECT 1) + 1` parses as
     /// `(1 IN (SELECT 1)) + 1`, `1 NOT IN (SELECT 1) << 2` as
-    /// `(1 NOT IN (SELECT 1)) << 2`, and `1 ISNULL + 1` as `(1 ISNULL) + 1`.
+    /// `(1 NOT IN (SELECT 1)) << 2`, `1 IN (1) < 3` as `(1 IN (1)) < 3`, and
+    /// `1 ISNULL + 1` as `(1 ISNULL) + 1`.
     ///
     /// Note this does NOT apply to `IS NULL` / `IS [NOT] TRUE`: there SQLite
     /// treats NULL/TRUE as an ordinary expression operand of IS, so
@@ -920,15 +1020,18 @@ impl Parser {
     /// relative precedence among these operators is preserved
     /// (e.g. `x IN (1) + 2 * 3` parses as `(x IN (1)) + (2 * 3)`).
     ///
-    /// Delegates to `parse_bitwise_expression_from`, which climbs the seeded
-    /// left operand through the multiplicative, concat, additive, and bitwise
-    /// tiers using the canonical per-tier operator loops. The arena parser
-    /// has the same helper (minus the bitwise tier) in arena_parser/expression.rs.
+    /// Delegates to `parse_relational_expression_from`, which climbs the seeded
+    /// left operand through the multiplicative, concat, additive, bitwise, and
+    /// relational tiers using the canonical per-tier operator loops. The relational
+    /// tier is the tightest tier still looser than the equality/predicate tier, so
+    /// climbing to it (and no further) leaves the outer equality loop to reduce
+    /// left. The arena parser has the same helper (minus the bitwise tier) in
+    /// arena_parser/expression.rs.
     fn continue_higher_precedence_ops(
         &mut self,
         left: vibesql_ast::Expression,
     ) -> Result<vibesql_ast::Expression, ParseError> {
-        self.parse_bitwise_expression_from(left)
+        self.parse_relational_expression_from(left)
     }
 
     /// Parse unary expression (handles unary +, -, ~ operators)

--- a/crates/vibesql-parser/src/tests/arena_parser.rs
+++ b/crates/vibesql-parser/src/tests/arena_parser.rs
@@ -1170,3 +1170,178 @@ fn test_arena_fallback_between_bitwise_bound() {
         high
     );
 }
+
+// ============================================================================
+// Part B of #5851 (arena parser): relational operators (`< <= > >=`) form a
+// tier that binds TIGHTER than the equality/predicate tier. Unlike the bitwise
+// tier, relational operators ARE inside the arena grammar, so these expressions
+// parse directly through the arena parser (no fallback) and must produce the
+// same relational-tier bounds/patterns as the standard parser. Every expected
+// value below was verified against sqlite3 3.51.0.
+// ============================================================================
+
+/// Assert the arena expression is `Extended(Between { .. })` and hand the
+/// (low, high) bound expressions to the callback.
+fn with_arena_between<'a>(
+    expr: &'a vibesql_ast::arena::Expression<'a>,
+    check: impl FnOnce(&'a vibesql_ast::arena::Expression<'a>, &'a vibesql_ast::arena::Expression<'a>),
+) {
+    let vibesql_ast::arena::Expression::Extended(vibesql_ast::arena::ExtendedExpr::Between {
+        low,
+        high,
+        negated,
+        ..
+    }) = expr
+    else {
+        panic!("expected Between expression, got {:?}", expr);
+    };
+    assert!(!negated, "expected non-negated BETWEEN");
+    check(low, high);
+}
+
+#[test]
+fn test_arena_relational_in_between_high_bound() {
+    // sqlite3: SELECT 2 BETWEEN 0 AND 3 < 3; -- 0  (high bound is 3 < 3 = 0)
+    with_arena_select_expr("SELECT 2 BETWEEN 0 AND 3 < 3", |expr| {
+        with_arena_between(expr, |_low, high| {
+            assert!(
+                matches!(
+                    high,
+                    vibesql_ast::arena::Expression::BinaryOp {
+                        op: vibesql_ast::BinaryOperator::LessThan,
+                        ..
+                    }
+                ),
+                "high bound should be (3 < 3), got {:?}",
+                high
+            );
+        });
+    });
+}
+
+#[test]
+fn test_arena_relational_in_between_low_bound() {
+    // sqlite3: SELECT 2 BETWEEN 1 > 0 AND 3; -- 1  (low bound is 1 > 0 = 1)
+    with_arena_select_expr("SELECT 2 BETWEEN 1 > 0 AND 3", |expr| {
+        with_arena_between(expr, |low, _high| {
+            assert!(
+                matches!(
+                    low,
+                    vibesql_ast::arena::Expression::BinaryOp {
+                        op: vibesql_ast::BinaryOperator::GreaterThan,
+                        ..
+                    }
+                ),
+                "low bound should be (1 > 0), got {:?}",
+                low
+            );
+        });
+    });
+}
+
+#[test]
+fn test_arena_relational_in_like_pattern() {
+    // sqlite3: SELECT 2 LIKE 1 < 3; -- 0  (pattern is 1 < 3 = 1)
+    with_arena_select_expr("SELECT 2 LIKE 1 < 3", |expr| {
+        let vibesql_ast::arena::Expression::Extended(vibesql_ast::arena::ExtendedExpr::Like {
+            pattern,
+            negated,
+            ..
+        }) = expr
+        else {
+            panic!("expected Like expression, got {:?}", expr);
+        };
+        assert!(!negated);
+        assert!(
+            matches!(
+                pattern,
+                vibesql_ast::arena::Expression::BinaryOp {
+                    op: vibesql_ast::BinaryOperator::LessThan,
+                    ..
+                }
+            ),
+            "LIKE pattern should be (1 < 3), got {:?}",
+            pattern
+        );
+    });
+}
+
+#[test]
+fn test_arena_equality_reduces_left_over_between() {
+    // Equality binds looser than the relational tier and reduces left, so the
+    // trailing `= 1` takes the whole BETWEEN as its left operand.
+    // sqlite3: SELECT 2 BETWEEN 0 AND 3 = 1; -- 1, i.e. (2 BETWEEN 0 AND 3) = 1
+    with_arena_select_expr("SELECT 2 BETWEEN 0 AND 3 = 1", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, left, .. } = expr else {
+            panic!("expected BinaryOp Equal at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Equal);
+        assert!(
+            matches!(
+                left,
+                vibesql_ast::arena::Expression::Extended(
+                    vibesql_ast::arena::ExtendedExpr::Between { .. }
+                )
+            ),
+            "LHS of = should be the BETWEEN node, got {:?}",
+            left
+        );
+    });
+}
+
+#[test]
+fn test_arena_relational_tighter_than_equality() {
+    // sqlite3: SELECT 1 < 2 = 1; -- 1, i.e. (1 < 2) = 1 (relational reduces first).
+    with_arena_select_expr("SELECT 1 < 2 = 1", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, left, .. } = expr else {
+            panic!("expected BinaryOp Equal at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Equal);
+        assert!(
+            matches!(
+                left,
+                vibesql_ast::arena::Expression::BinaryOp {
+                    op: vibesql_ast::BinaryOperator::LessThan,
+                    ..
+                }
+            ),
+            "LHS of = should be (1 < 2), got {:?}",
+            left
+        );
+    });
+}
+
+#[test]
+fn test_arena_chained_relational_is_left_associative() {
+    // sqlite3: SELECT 1 < 2 < 3; -- 1, i.e. ((1 < 2) < 3).
+    with_arena_select_expr("SELECT 1 < 2 < 3", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, left, .. } = expr else {
+            panic!("expected BinaryOp LessThan at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::LessThan);
+        assert!(
+            matches!(
+                left,
+                vibesql_ast::arena::Expression::BinaryOp {
+                    op: vibesql_ast::BinaryOperator::LessThan,
+                    ..
+                }
+            ),
+            "left of < should be (1 < 2), got {:?}",
+            left
+        );
+    });
+}
+
+#[test]
+fn test_arena_in_list_followed_by_relational() {
+    // sqlite3: SELECT 1 IN (1) < 3; -- 1, i.e. (1 IN (1)) < 3.
+    // The arena continue_higher_precedence_ops must climb the relational tier.
+    with_arena_select_expr("SELECT 1 IN (1) < 3", |expr| {
+        let vibesql_ast::arena::Expression::BinaryOp { op, left, .. } = expr else {
+            panic!("expected BinaryOp LessThan at top level, got {:?}", expr);
+        };
+        assert_eq!(*op, vibesql_ast::BinaryOperator::LessThan);
+        assert_arena_in_list(left, "left operand of <");
+    });
+}

--- a/crates/vibesql-parser/src/tests/predicates.rs
+++ b/crates/vibesql-parser/src/tests/predicates.rs
@@ -835,3 +835,229 @@ fn test_like_bitwise_and_pattern() {
         other => panic!("expected Like expression, got {:?}", other),
     }
 }
+
+// ============================================================================
+// Part B of #5851: relational operators (`< <= > >=`) form a tier that binds
+// TIGHTER than the equality/predicate tier (`= == != <> IS IN LIKE GLOB
+// BETWEEN`) but LOOSER than the bitwise tier. So BETWEEN bounds and LIKE/GLOB
+// patterns parse at the relational tier, while `=`/`==`/IS reduce left. Every
+// expected value below was verified against sqlite3 3.51.0.
+// ============================================================================
+
+#[test]
+fn test_relational_lt_in_between_high_bound() {
+    // sqlite3: SELECT 2 BETWEEN 0 AND 3 < 3; -- 0  (high bound is 3 < 3 = 0)
+    let expr = parse_select_expr("SELECT 2 BETWEEN 0 AND 3 < 3;");
+    match expr {
+        vibesql_ast::Expression::Between { high, negated, .. } => {
+            assert!(!negated);
+            assert_eq!(
+                bin_op(&high),
+                vibesql_ast::BinaryOperator::LessThan,
+                "high bound should be (3 < 3), got {:?}",
+                high
+            );
+        }
+        other => panic!("expected Between expression, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_relational_le_in_between_high_bound() {
+    // sqlite3: SELECT 2 BETWEEN 0 AND 3 <= 3; -- 0  (high bound is 3 <= 3 = 1)
+    let expr = parse_select_expr("SELECT 2 BETWEEN 0 AND 3 <= 3;");
+    match expr {
+        vibesql_ast::Expression::Between { high, negated, .. } => {
+            assert!(!negated);
+            assert_eq!(
+                bin_op(&high),
+                vibesql_ast::BinaryOperator::LessThanOrEqual,
+                "high bound should be (3 <= 3), got {:?}",
+                high
+            );
+        }
+        other => panic!("expected Between expression, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_relational_gt_in_between_low_bound() {
+    // sqlite3: SELECT 2 BETWEEN 1 > 0 AND 3; -- 1  (low bound is 1 > 0 = 1)
+    let expr = parse_select_expr("SELECT 2 BETWEEN 1 > 0 AND 3;");
+    match expr {
+        vibesql_ast::Expression::Between { low, negated, .. } => {
+            assert!(!negated);
+            assert_eq!(
+                bin_op(&low),
+                vibesql_ast::BinaryOperator::GreaterThan,
+                "low bound should be (1 > 0), got {:?}",
+                low
+            );
+        }
+        other => panic!("expected Between expression, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_relational_lt_in_like_pattern() {
+    // sqlite3: SELECT 2 LIKE 1 < 3; -- 0  (pattern is 1 < 3 = 1)
+    let expr = parse_select_expr("SELECT 2 LIKE 1 < 3;");
+    match expr {
+        vibesql_ast::Expression::Like { pattern, negated, .. } => {
+            assert!(!negated);
+            assert_eq!(
+                bin_op(&pattern),
+                vibesql_ast::BinaryOperator::LessThan,
+                "LIKE pattern should be (1 < 3), got {:?}",
+                pattern
+            );
+        }
+        other => panic!("expected Like expression, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_relational_gt_in_like_pattern() {
+    // sqlite3: SELECT 2 LIKE 1 > 3; -- 0  (pattern is 1 > 3 = 0)
+    let expr = parse_select_expr("SELECT 2 LIKE 1 > 3;");
+    match expr {
+        vibesql_ast::Expression::Like { pattern, negated, .. } => {
+            assert!(!negated);
+            assert_eq!(
+                bin_op(&pattern),
+                vibesql_ast::BinaryOperator::GreaterThan,
+                "LIKE pattern should be (1 > 3), got {:?}",
+                pattern
+            );
+        }
+        other => panic!("expected Like expression, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_relational_in_glob_pattern() {
+    // sqlite3: SELECT 2 GLOB 1 < 3; -- 0  (pattern is 1 < 3 = 1)
+    let expr = parse_select_expr("SELECT 2 GLOB 1 < 3;");
+    match expr {
+        vibesql_ast::Expression::Glob { pattern, negated, .. } => {
+            assert!(!negated);
+            assert_eq!(
+                bin_op(&pattern),
+                vibesql_ast::BinaryOperator::LessThan,
+                "GLOB pattern should be (1 < 3), got {:?}",
+                pattern
+            );
+        }
+        other => panic!("expected Glob expression, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_equality_reduces_left_over_between() {
+    // Equality binds LOOSER than the relational tier and reduces left, so the
+    // trailing `= 1` takes the whole BETWEEN as its left operand (unchanged).
+    // sqlite3: SELECT 2 BETWEEN 0 AND 3 = 1; -- 1, i.e. (2 BETWEEN 0 AND 3) = 1
+    let expr = parse_select_expr("SELECT 2 BETWEEN 0 AND 3 = 1;");
+    let (left, _) = expect_bin(&expr, vibesql_ast::BinaryOperator::Equal, "top =");
+    assert!(
+        matches!(left, vibesql_ast::Expression::Between { negated: false, .. }),
+        "LHS of = should be the BETWEEN node, got {:?}",
+        left
+    );
+}
+
+#[test]
+fn test_relational_binds_tighter_than_equality_lhs() {
+    // sqlite3: SELECT 1 < 2 = 1; -- 1, i.e. (1 < 2) = 1 (relational reduces first)
+    let expr = parse_select_expr("SELECT 1 < 2 = 1;");
+    let (left, _) = expect_bin(&expr, vibesql_ast::BinaryOperator::Equal, "top =");
+    assert_eq!(
+        bin_op(left),
+        vibesql_ast::BinaryOperator::LessThan,
+        "LHS of = should be (1 < 2), got {:?}",
+        left
+    );
+}
+
+#[test]
+fn test_relational_binds_tighter_than_equality_rhs() {
+    // sqlite3: SELECT 1 = 2 < 3; -- 1, i.e. 1 = (2 < 3) (relational reduces first)
+    let expr = parse_select_expr("SELECT 1 = 2 < 3;");
+    let (_, right) = expect_bin(&expr, vibesql_ast::BinaryOperator::Equal, "top =");
+    assert_eq!(
+        bin_op(right),
+        vibesql_ast::BinaryOperator::LessThan,
+        "RHS of = should be (2 < 3), got {:?}",
+        right
+    );
+}
+
+#[test]
+fn test_chained_relational_is_left_associative() {
+    // sqlite3: SELECT 1 < 2 < 3; -- 1, i.e. ((1 < 2) < 3), NOT (1 < (2 < 3)).
+    let expr = parse_select_expr("SELECT 1 < 2 < 3;");
+    let (left, _) = expect_bin(&expr, vibesql_ast::BinaryOperator::LessThan, "top <");
+    assert_eq!(
+        bin_op(left),
+        vibesql_ast::BinaryOperator::LessThan,
+        "left of < should be (1 < 2), got {:?}",
+        left
+    );
+}
+
+#[test]
+fn test_in_list_followed_by_relational() {
+    // sqlite3: SELECT 1 IN (1) < 3; -- 1, i.e. (1 IN (1)) < 3.
+    // continue_higher_precedence_ops must climb the relational tier.
+    let expr = parse_select_expr("SELECT 1 IN (1) < 3;");
+    let (left, _) = expect_bin(&expr, vibesql_ast::BinaryOperator::LessThan, "top <");
+    assert!(
+        matches!(left, vibesql_ast::Expression::InList { .. }),
+        "LHS of < should be an IN list, got {:?}",
+        left
+    );
+}
+
+// ----------------------------------------------------------------------------
+// Symmetry: negated and non-negated forms must produce identically shaped
+// ASTs with relational bounds/patterns, differing only in the `negated` flag.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn test_between_relational_bound_negated_symmetry() {
+    // sqlite3: SELECT 2 BETWEEN 0 AND 3 < 3;     -- 0
+    // sqlite3: SELECT 2 NOT BETWEEN 0 AND 3 < 3; -- 1
+    let plain = parse_select_expr("SELECT 2 BETWEEN 0 AND 3 < 3;");
+    let negated = parse_select_expr("SELECT 2 NOT BETWEEN 0 AND 3 < 3;");
+    match (plain, negated) {
+        (
+            vibesql_ast::Expression::Between { low: l1, high: h1, negated: n1, .. },
+            vibesql_ast::Expression::Between { low: l2, high: h2, negated: n2, .. },
+        ) => {
+            assert!(!n1);
+            assert!(n2);
+            assert_eq!(l1, l2, "BETWEEN low bound must parse identically in both forms");
+            assert_eq!(h1, h2, "BETWEEN high bound must parse identically in both forms");
+        }
+        other => panic!("expected two Between expressions, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_like_relational_pattern_negated_symmetry() {
+    // sqlite3: SELECT 2 LIKE 1 < 3;     -- 0
+    // sqlite3: SELECT 2 NOT LIKE 1 < 3; -- 1
+    let plain = parse_select_expr("SELECT 2 LIKE 1 < 3;");
+    let negated = parse_select_expr("SELECT 2 NOT LIKE 1 < 3;");
+    match (plain, negated) {
+        (
+            vibesql_ast::Expression::Like { pattern: p1, negated: n1, .. },
+            vibesql_ast::Expression::Like { pattern: p2, negated: n2, .. },
+        ) => {
+            assert!(!n1);
+            assert!(n2);
+            assert_eq!(p1, p2, "LIKE pattern must parse identically in both forms");
+        }
+        other => panic!("expected two Like expressions, got {:?}", other),
+    }
+}


### PR DESCRIPTION
Closes #5851

## Summary

Part B of #5851. SQLite's grammar places the relational operators (`< <= > >=`) in a tier that binds **tighter** than the equality/predicate tier (`= == != <> IS IN LIKE GLOB BETWEEN ...`) but **looser** than the bitwise tier. VibeSQL merged relational and equality into a single comparison tier, so relational operators could not bind into BETWEEN bounds or LIKE/GLOB patterns.

Part A (bitwise `&`/`|`/`<<`/`>>` in bounds) already landed via #5917; this PR adds the missing relational tier.

## Fix

Introduce `parse_relational_expression` as a new tier between the equality/predicate tier and the bitwise tier, in **both** parser paths:
- `crates/vibesql-parser/src/parser/expressions/operators.rs` (standard parser)
- `crates/vibesql-parser/src/arena_parser/expression.rs` (arena parser — used for `SELECT`; it has no bitwise tier so the relational tier climbs additive directly)

Call-site changes within the comparison tier: BETWEEN low/high bounds, LIKE/GLOB patterns and ESCAPE expressions, the equality operator RHS, and the IS RHS now parse at the relational tier. Equality/predicate operators stay in the outer tier and reduce left. `continue_higher_precedence_ops` now climbs the relational tier so syntactically-closed nodes chain correctly (`1 IN (1) < 3` → `(1 IN (1)) < 3`). Quantified comparisons (`x < ALL (...)`) moved with the relational operators into the new tier.

## Verification battery (vs sqlite3 3.51.0)

| Expression | sqlite | vibesql | note |
|---|---|---|---|
| `2 BETWEEN 0 AND 3 < 3` | 0 | 0 | was 1 — relational high bound |
| `2 BETWEEN 0 AND 3 <= 3` | 0 | 0 | was 1 |
| `2 BETWEEN 1 > 0 AND 3` | 1 | 1 | was a **parse error** — relational low bound |
| `2 LIKE 1 < 3` | 0 | 0 | was 1 — relational LIKE pattern |
| `2 LIKE 1 > 3` | 0 | 0 | |
| `2 NOT BETWEEN 0 AND 3 < 3` | 1 | 1 | NOT form |
| `2 NOT LIKE 1 < 3` | 1 | 1 | NOT form |
| `2 NOT GLOB 1 < 3` | 1 | 1 | NOT form |
| `2 BETWEEN 0 AND 3 = 1` | 1 | 1 | equality still reduces left (**unchanged**) |
| `2 BETWEEN 0 AND 3 & 1` | 0 | 0 | Part A (#5917) regression check |
| `2 = 2 & 2` | 1 | 1 | #5917 regression check |
| `1 < 2 < 3` | 1 | 1 | chained relational, left-assoc |
| `1 < 2 = 1` | 1 | 1 | relational tighter than equality |
| `1 = 2 < 3` | 1 | 1 | equality RHS parses relational |
| `1 IN (1) < 3` | 1 | 1 | closed node chains into relational |

`SELECT 3 < ALL (...)` (quantified comparison) still returns 1 — a VibeSQL extension sqlite lacks; confirms the ALL/ANY/SOME path survived the tier split.

## Tests

- `cargo test -p vibesql-parser`: **1684 passed, 0 failed**
- New relational-precedence unit tests in `tests/predicates.rs` (standard parser) and `tests/arena_parser.rs` (arena parser), covering bounds/patterns, equality-reduces-left, chained relational, closed-node chaining, and negated symmetry.
- TCL (unchanged vs baseline): `e_expr.test` 374/374, `expr.test` 638 passed / 22 skipped / 0 failed, `select1.test` 188/188 canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)