### PR TITLE
feat(dml): tuple SET assignment + full-index WHERE conflict-target leniency (upsert4 45->57)

### DIFF
--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -690,7 +690,11 @@ impl<'a, 'arena> Converter<'a, 'arena> {
     }
 
     fn convert_assignment(&self, a: &arena_dml::Assignment<'arena>) -> Assignment {
-        Assignment { column: self.resolve(a.column), value: self.convert_expression(&a.value) }
+        Assignment {
+            column: self.resolve(a.column),
+            columns: Vec::new(),
+            value: self.convert_expression(&a.value),
+        }
     }
 
     /// Convert an arena UpdateStmt to an owned UpdateStmt.

--- a/crates/vibesql-ast/src/dml.rs
+++ b/crates/vibesql-ast/src/dml.rs
@@ -215,11 +215,43 @@ pub struct UpdateStmt {
     pub returning: Option<Vec<SelectItem>>,
 }
 
-/// Column assignment (column = value)
+/// Column assignment (`column = value`, or the tuple form
+/// `(col-a, col-b, ...) = (row-value | scalar-subquery)`).
+///
+/// SQLite allows the left-hand side of an `UPDATE`/`DO UPDATE` assignment to be
+/// a parenthesized column list, e.g.
+/// `SET (b, c) = (SELECT 'x', 'y')` or `SET (c, a) = ('four', 4)`.
+/// For an ordinary single-column assignment `columns` is empty and `column`
+/// is authoritative. For a tuple assignment `columns` holds the full ordered
+/// column list (length >= 2), `column` mirrors `columns[0]` so naive
+/// single-column readers still see a real target, and the single `value` is a
+/// row-valued expression (a `RowValueConstructor` or a multi-column
+/// `ScalarSubquery`) whose elements map positionally to `columns`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Assignment {
     pub column: String,
+    /// Tuple-assignment column list; empty for a single-column assignment.
+    pub columns: Vec<String>,
     pub value: Expression,
+}
+
+impl Assignment {
+    /// Construct an ordinary single-column assignment (`column = value`).
+    pub fn single(column: String, value: Expression) -> Self {
+        Assignment { column, columns: Vec::new(), value }
+    }
+
+    /// Construct a tuple assignment (`(cols) = value`). `columns` must contain
+    /// at least two names; `column` mirrors the first for single-column readers.
+    pub fn tuple(columns: Vec<String>, value: Expression) -> Self {
+        let column = columns.first().cloned().unwrap_or_default();
+        Assignment { column, columns, value }
+    }
+
+    /// True when this is a tuple/row assignment (`(a, b) = ...`).
+    pub fn is_tuple(&self) -> bool {
+        self.columns.len() >= 2
+    }
 }
 
 // ============================================================================

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -1390,6 +1390,7 @@ pub fn transform_insert<V: ExpressionMutVisitor>(visitor: &mut V, stmt: InsertSt
                                 .into_iter()
                                 .map(|a| Assignment {
                                     column: a.column,
+                                    columns: a.columns,
                                     value: transform_expression(visitor, a.value),
                                 })
                                 .collect(),
@@ -1404,6 +1405,7 @@ pub fn transform_insert<V: ExpressionMutVisitor>(visitor: &mut V, stmt: InsertSt
                 .into_iter()
                 .map(|a| Assignment {
                     column: a.column,
+                    columns: a.columns,
                     value: transform_expression(visitor, a.value),
                 })
                 .collect()
@@ -1445,7 +1447,11 @@ pub fn transform_update<V: ExpressionMutVisitor>(visitor: &mut V, stmt: UpdateSt
         assignments: stmt
             .assignments
             .into_iter()
-            .map(|a| Assignment { column: a.column, value: transform_expression(visitor, a.value) })
+            .map(|a| Assignment {
+                column: a.column,
+                columns: a.columns,
+                value: transform_expression(visitor, a.value),
+            })
             .collect(),
         from_clause: stmt
             .from_clause

--- a/crates/vibesql-ast/tests/statements.rs
+++ b/crates/vibesql-ast/tests/statements.rs
@@ -65,6 +65,7 @@ fn test_create_update_statement() {
         alias: None,
         assignments: vec![Assignment {
             column: "name".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Varchar(StringValue::from("Bob"))),
         }],
         from_clause: None,

--- a/crates/vibesql-executor/benches/sysbench_benchmark.rs
+++ b/crates/vibesql-executor/benches/sysbench_benchmark.rs
@@ -200,6 +200,7 @@ fn bind_update(stmt: &UpdateStmt, params: &[SqlValue]) -> UpdateStmt {
             .iter()
             .map(|a| Assignment {
                 column: a.column.clone(),
+                columns: Vec::new(),
                 value: bind_expression(&a.value, params),
             })
             .collect(),

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -437,6 +437,40 @@ impl ExpressionEvaluator<'_> {
         self.with_incremented_depth(|evaluator| evaluator.eval_impl(expr, row))
     }
 
+    /// Evaluate the right-hand side of a tuple/row assignment
+    /// (`SET (a, b, ...) = value`) into exactly `expected` values.
+    ///
+    /// The RHS is either a `RowValueConstructor` (a parenthesized value list,
+    /// e.g. `('four', 4)`) or a multi-column `ScalarSubquery`
+    /// (e.g. `(SELECT 'x', 'y')`). Both map positionally onto the target
+    /// columns. SQLite semantics: a subquery that returns no rows yields a row
+    /// of NULLs, a subquery that returns several rows uses the first, and an
+    /// arity mismatch is an error.
+    pub fn eval_row_value(
+        &self,
+        expr: &vibesql_ast::Expression,
+        row: &vibesql_storage::Row,
+        expected: usize,
+    ) -> Result<Vec<vibesql_types::SqlValue>, ExecutorError> {
+        match expr {
+            vibesql_ast::Expression::RowValueConstructor(elems) => {
+                if elems.len() != expected {
+                    return Err(ExecutorError::SubqueryColumnCountMismatch {
+                        expected,
+                        actual: elems.len(),
+                    });
+                }
+                elems.iter().map(|e| self.eval(e, row)).collect()
+            }
+            vibesql_ast::Expression::ScalarSubquery(subquery) => {
+                self.eval_scalar_subquery_as_row(subquery, row, expected)
+            }
+            // A non-row RHS for a multi-column target is a misuse per SQLite
+            // (e.g. `SET (a, b) = 1`).
+            _ => Err(ExecutorError::RowValueMisused),
+        }
+    }
+
     /// Internal implementation of eval with depth already incremented
     #[inline]
     fn eval_impl(

--- a/crates/vibesql-executor/src/insert/on_conflict_update.rs
+++ b/crates/vibesql-executor/src/insert/on_conflict_update.rs
@@ -325,15 +325,23 @@ fn resolve_target_items<'a>(
 /// (order-insensitive). Column items match resolved column indices;
 /// expression items match expression components structurally
 /// (`expressions_equal`, so `a+(+b)` does NOT match `a+b` — upsert1-210).
-/// The target-level WHERE must structurally equal the index predicate:
-/// a bare target never matches a partial index (upsert1-300) and a
-/// mismatched predicate never matches (upsert1-310).
+/// The target-level WHERE is matched against the index predicate with SQLite's
+/// asymmetric rule:
+/// - against a **partial** index (`candidate.predicate = Some`), the target
+///   WHERE must structurally equal the index predicate: a bare target never
+///   matches a partial index (upsert1-300) and a mismatched predicate never
+///   matches (upsert1-310);
+/// - against a **full** (non-partial) index (`candidate.predicate = None`), a
+///   target WHERE clause is parsed and validated but ignored for matching, so
+///   `ON CONFLICT(b,c,d) WHERE a!=0` still matches a full index on
+///   `(d,c,b)` (upsert4 2.x.2.6 / 2.x.2.9).
 fn candidate_matches_target(
     candidate: &UniqueCandidate,
     target: &[ResolvedTargetItem<'_>],
     target_where: Option<&Expression>,
 ) -> bool {
-    // Partial-index predicate must match structurally.
+    // Partial-index predicate must match structurally; a full index ignores
+    // any target WHERE.
     match (target_where, candidate.predicate.as_ref()) {
         (None, None) => {}
         (Some(tw), Some(pred)) => {
@@ -341,7 +349,10 @@ fn candidate_matches_target(
                 return false;
             }
         }
-        _ => return false,
+        // Full index (no predicate) with a target WHERE: accepted, WHERE ignored.
+        (Some(_), None) => {}
+        // Bare target against a partial index never matches.
+        (None, Some(_)) => return false,
     }
 
     if candidate.parts.len() != target.len() {
@@ -782,12 +793,34 @@ pub fn handle_on_conflict_update(
         // Apply SET assignments against a copy of the existing row.
         let mut new_values = existing_row.values.clone();
         for assignment in assignments {
-            let col_idx = schema.get_column_index(&assignment.column).ok_or_else(|| {
-                ExecutorError::SqliteCompatError(format!("no such column: {}", assignment.column))
-            })?;
             let substituted =
                 substitute_excluded_refs(assignment.value.clone(), schema, row_values)?;
-            new_values[col_idx] = evaluator.eval(&substituted, &existing_row)?;
+            if assignment.is_tuple() {
+                // Tuple assignment `SET (a, b, ...) = (row-value | subquery)`:
+                // evaluate the RHS to one value per target column, positionally.
+                let col_indices = assignment
+                    .columns
+                    .iter()
+                    .map(|name| {
+                        schema.get_column_index(name).ok_or_else(|| {
+                            ExecutorError::SqliteCompatError(format!("no such column: {}", name))
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let values =
+                    evaluator.eval_row_value(&substituted, &existing_row, col_indices.len())?;
+                for (col_idx, value) in col_indices.into_iter().zip(values) {
+                    new_values[col_idx] = value;
+                }
+            } else {
+                let col_idx = schema.get_column_index(&assignment.column).ok_or_else(|| {
+                    ExecutorError::SqliteCompatError(format!(
+                        "no such column: {}",
+                        assignment.column
+                    ))
+                })?;
+                new_values[col_idx] = evaluator.eval(&substituted, &existing_row)?;
+            }
         }
         new_values
     };
@@ -943,4 +976,77 @@ fn substitute_excluded_refs(
         return Err(err);
     }
     Ok(result)
+}
+
+#[cfg(test)]
+mod candidate_match_tests {
+    use super::*;
+
+    fn full_index() -> UniqueCandidate {
+        UniqueCandidate { parts: vec![KeyPart::Column(0)], predicate: None, index_name: None }
+    }
+
+    fn partial_index(pred: Expression) -> UniqueCandidate {
+        UniqueCandidate {
+            parts: vec![KeyPart::Column(0)],
+            predicate: Some(pred),
+            index_name: None,
+        }
+    }
+
+    // `a != 0`, matching the upsert4 2.x.2.6 target WHERE.
+    fn pred_a_ne_0() -> Expression {
+        Expression::BinaryOp {
+            left: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
+                "a", false,
+            ))),
+            op: vibesql_ast::BinaryOperator::NotEqual,
+            right: Box::new(Expression::Literal(SqlValue::Integer(0))),
+        }
+    }
+
+    fn target() -> Vec<ResolvedTargetItem<'static>> {
+        vec![ResolvedTargetItem::Column(0)]
+    }
+
+    #[test]
+    fn full_index_bare_target_matches() {
+        assert!(candidate_matches_target(&full_index(), &target(), None));
+    }
+
+    #[test]
+    fn full_index_ignores_target_where() {
+        // upsert4 2.x.2.6 / 2.x.2.9: a target WHERE against a full (non-partial)
+        // index is parsed and validated but ignored for matching.
+        let where_clause = pred_a_ne_0();
+        assert!(candidate_matches_target(&full_index(), &target(), Some(&where_clause)));
+    }
+
+    #[test]
+    fn partial_index_rejects_bare_target() {
+        // upsert1-300: a bare target must not match a partial index.
+        let cand = partial_index(pred_a_ne_0());
+        assert!(!candidate_matches_target(&cand, &target(), None));
+    }
+
+    #[test]
+    fn partial_index_matches_equal_predicate() {
+        let cand = partial_index(pred_a_ne_0());
+        let where_clause = pred_a_ne_0();
+        assert!(candidate_matches_target(&cand, &target(), Some(&where_clause)));
+    }
+
+    #[test]
+    fn partial_index_rejects_mismatched_predicate() {
+        // upsert1-310: a mismatched predicate must not match a partial index.
+        let cand = partial_index(pred_a_ne_0());
+        let different = Expression::BinaryOp {
+            left: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
+                "a", false,
+            ))),
+            op: vibesql_ast::BinaryOperator::GreaterThan,
+            right: Box::new(Expression::Literal(SqlValue::Integer(0))),
+        };
+        assert!(!candidate_matches_target(&cand, &target(), Some(&different)));
+    }
 }

--- a/crates/vibesql-executor/src/tests/triggers/update.rs
+++ b/crates/vibesql-executor/src/tests/triggers/update.rs
@@ -66,6 +66,7 @@ fn test_after_update_trigger_fires() {
         table_name: "USERS".to_string(),
         assignments: vec![vibesql_ast::Assignment {
             column: "username".to_string(),
+            columns: Vec::new(),
             value: vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("alice_updated"),
             )),
@@ -148,6 +149,7 @@ fn test_before_update_trigger_fires() {
         table_name: "USERS".to_string(),
         assignments: vec![vibesql_ast::Assignment {
             column: "username".to_string(),
+            columns: Vec::new(),
             value: vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
                 arcstr::ArcStr::from("alice_updated"),
             )),
@@ -235,6 +237,7 @@ fn test_update_of_fires_only_for_listed_column() {
             table_name: "USERS".to_string(),
             assignments: vec![vibesql_ast::Assignment {
                 column: column.to_string(),
+                columns: Vec::new(),
                 value: vibesql_ast::Expression::Literal(value),
             }],
             from_clause: None,

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -364,6 +364,14 @@ pub(super) fn execute_internal(
         // Check if primary key is being updated
         let updates_pk = if let Some(ref pk_idx) = pk_indices {
             stmt.assignments.iter().any(|a| {
+                // Tuple assignment `SET (a, b, ...) = ...`: any listed column may
+                // be part of the primary key.
+                if a.is_tuple() {
+                    return a.columns.iter().any(|name| {
+                        schema.get_column_index(name).is_some_and(|idx| pk_idx.contains(&idx))
+                    });
+                }
+
                 // Check if this is a rowid assignment
                 let col_name_lower = a.column.to_lowercase();
                 let is_rowid = col_name_lower == "rowid"
@@ -1170,6 +1178,18 @@ fn validate_set_expressions(
     database: &Database,
 ) -> Result<(), ExecutorError> {
     for assignment in assignments {
+        // Tuple assignment `SET (a, b, ...) = ...`: validate every target
+        // column in the list, then the shared RHS expression.
+        if assignment.is_tuple() {
+            for name in &assignment.columns {
+                if schema.get_column_index(name).is_none() {
+                    return Err(ExecutorError::NoSuchColumn { column_ref: name.clone() });
+                }
+            }
+            validate_expression(&assignment.value, schema, database)?;
+            continue;
+        }
+
         // Validate target column exists (LHS of assignment)
         // Special case: rowid is a virtual column that always exists (SQLite compatibility)
         let col_name_lower = assignment.column.to_lowercase();

--- a/crates/vibesql-executor/src/update/fast_path.rs
+++ b/crates/vibesql-executor/src/update/fast_path.rs
@@ -40,6 +40,12 @@ pub(super) fn try_fast_path_update(
     // Use canonical table name from schema for all storage operations
     let table_name = &schema.name;
 
+    // Tuple/row assignments (`SET (a, b) = ...`) need the row-value unpacking
+    // in the main path; the fast paths evaluate each assignment as a scalar.
+    if stmt.assignments.iter().any(|a| a.is_tuple()) {
+        return Ok(None);
+    }
+
     // Check if we have a simple PK lookup in WHERE clause
     let where_clause = match &stmt.where_clause {
         Some(vibesql_ast::WhereClause::Condition(expr)) => expr,

--- a/crates/vibesql-executor/src/update/mod.rs
+++ b/crates/vibesql-executor/src/update/mod.rs
@@ -125,10 +125,10 @@ impl UpdateExecutor {
     ///     quoted: false,
     ///     alias: None,
     ///     index_hint: None,
-    ///     assignments: vec![Assignment {
-    ///         column: "salary".to_string(),
-    ///         value: Expression::Literal(SqlValue::Integer(60000)),
-    ///     }],
+    ///     assignments: vec![Assignment::single(
+    ///         "salary".to_string(),
+    ///         Expression::Literal(SqlValue::Integer(60000)),
+    ///     )],
     ///     from_clause: None,
     ///     where_clause: None,
     ///     order_by: None,

--- a/crates/vibesql-executor/src/update/value_updater.rs
+++ b/crates/vibesql-executor/src/update/value_updater.rs
@@ -38,6 +38,45 @@ impl<'a> ValueUpdater<'a> {
 
         // Apply each assignment
         for assignment in assignments {
+            // Tuple assignment `SET (a, b, ...) = (row-value | subquery)`:
+            // evaluate the RHS to one value per target column (positionally),
+            // then coerce and store each. Evaluated against the ORIGINAL row
+            // (two-phase semantics), like single-column assignments.
+            if assignment.is_tuple() {
+                let col_indices = assignment
+                    .columns
+                    .iter()
+                    .map(|name| {
+                        self.schema.get_column_index(name).ok_or_else(|| {
+                            ExecutorError::NoSuchColumn { column_ref: name.clone() }
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let values = self.evaluator.eval_row_value(
+                    &assignment.value,
+                    original_row,
+                    col_indices.len(),
+                )?;
+                for (col_index, new_value) in col_indices.into_iter().zip(values) {
+                    let column = &self.schema.columns[col_index];
+                    let coerced_value = if let Some(st) = self.schema.strict_type_of(col_index) {
+                        crate::strict::enforce_strict_type(
+                            new_value,
+                            st,
+                            &self.schema.name,
+                            &column.name,
+                        )?
+                    } else {
+                        coerce_value(new_value, &column.data_type)?
+                    };
+                    new_row
+                        .set(col_index, coerced_value)
+                        .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+                    changed_columns.insert(col_index);
+                }
+                continue;
+            }
+
             // Check if this is a rowid assignment (SQLite compatibility)
             let col_name_lower = assignment.column.to_lowercase();
             let is_rowid =

--- a/crates/vibesql-executor/tests/conflict_resolution_tests.rs
+++ b/crates/vibesql-executor/tests/conflict_resolution_tests.rs
@@ -236,6 +236,7 @@ fn test_update_or_ignore_primary_key_conflict() {
         alias: None,
         assignments: vec![Assignment {
             column: "id".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(2)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
@@ -288,6 +289,7 @@ fn test_update_or_ignore_unique_constraint_conflict() {
         alias: None,
         assignments: vec![Assignment {
             column: "email".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("bob@test.com"))),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
@@ -330,6 +332,7 @@ fn test_update_or_ignore_no_conflict() {
         alias: None,
         assignments: vec![Assignment {
             column: "name".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice Updated"))),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
@@ -378,6 +381,7 @@ fn test_update_or_replace_primary_key_conflict() {
         alias: None,
         assignments: vec![Assignment {
             column: "id".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(2)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
@@ -427,6 +431,7 @@ fn test_update_or_replace_unique_constraint_conflict() {
         alias: None,
         assignments: vec![Assignment {
             column: "email".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("bob@test.com"))),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
@@ -477,6 +482,7 @@ fn test_update_or_replace_no_conflict() {
         alias: None,
         assignments: vec![Assignment {
             column: "name".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice Updated"))),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
@@ -553,6 +559,7 @@ fn test_update_or_ignore_not_null_violation() {
         alias: None,
         assignments: vec![Assignment {
             column: "email".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Null),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {

--- a/crates/vibesql-executor/tests/duplicate_key_update_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/duplicate_key_update_columnar_cache_tests.rs
@@ -66,10 +66,12 @@ fn upsert_product(db: &mut Database, id: i64, name: &str, stock: i64) {
         on_duplicate_key_update: Some(vec![
             vibesql_ast::Assignment {
                 column: "name".to_string(),
+                columns: Vec::new(),
                 value: vibesql_ast::Expression::DuplicateKeyValue { column: "name".to_string() },
             },
             vibesql_ast::Assignment {
                 column: "stock".to_string(),
+                columns: Vec::new(),
                 value: vibesql_ast::Expression::DuplicateKeyValue { column: "stock".to_string() },
             },
         ]),
@@ -257,6 +259,7 @@ fn test_on_duplicate_key_update_unique_constraint_invalidates_cache() {
         on_conflict: vec![],
         on_duplicate_key_update: Some(vec![vibesql_ast::Assignment {
             column: "score".to_string(),
+            columns: Vec::new(),
             value: vibesql_ast::Expression::DuplicateKeyValue { column: "score".to_string() },
         }]),
         returning: None,
@@ -344,6 +347,7 @@ fn test_on_duplicate_key_update_arithmetic_invalidates_cache() {
         on_conflict: vec![],
         on_duplicate_key_update: Some(vec![vibesql_ast::Assignment {
             column: "stock".to_string(),
+            columns: Vec::new(),
             value: vibesql_ast::Expression::BinaryOp {
                 op: vibesql_ast::BinaryOperator::Plus,
                 left: Box::new(vibesql_ast::Expression::ColumnRef(

--- a/crates/vibesql-executor/tests/insert_duplicate_key_update_tests.rs
+++ b/crates/vibesql-executor/tests/insert_duplicate_key_update_tests.rs
@@ -76,6 +76,7 @@ fn test_on_duplicate_key_update_basic() {
         on_conflict: vec![],
         on_duplicate_key_update: Some(vec![vibesql_ast::Assignment {
             column: "stock".to_string(),
+            columns: Vec::new(),
             value: vibesql_ast::Expression::DuplicateKeyValue { column: "stock".to_string() },
         }]),
         returning: None,
@@ -142,6 +143,7 @@ fn test_on_duplicate_key_update_with_arithmetic() {
         on_conflict: vec![],
         on_duplicate_key_update: Some(vec![vibesql_ast::Assignment {
             column: "stock".to_string(),
+            columns: Vec::new(),
             value: vibesql_ast::Expression::BinaryOp {
                 op: vibesql_ast::BinaryOperator::Plus,
                 left: Box::new(vibesql_ast::Expression::ColumnRef(
@@ -190,6 +192,7 @@ fn test_on_duplicate_key_update_no_conflict() {
         on_conflict: vec![],
         on_duplicate_key_update: Some(vec![vibesql_ast::Assignment {
             column: "stock".to_string(),
+            columns: Vec::new(),
             value: vibesql_ast::Expression::DuplicateKeyValue { column: "stock".to_string() },
         }]),
         returning: None,

--- a/crates/vibesql-executor/tests/tuple_set_assignment_tests.rs
+++ b/crates/vibesql-executor/tests/tuple_set_assignment_tests.rs
@@ -1,0 +1,127 @@
+//! End-to-end tests for SQLite tuple/row SET assignments (issue #5862).
+//!
+//! Covers `SET (a, b, ...) = (row-value | scalar-subquery)` in both the
+//! regular UPDATE path and the ON CONFLICT ... DO UPDATE arm, including the
+//! NULL-when-empty subquery semantics and the arity-mismatch error.
+
+use vibesql_executor::{CreateTableExecutor, InsertExecutor, UpdateExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn setup() -> Database {
+    let mut db = Database::new();
+    for sql in [
+        "CREATE TABLE t(a INTEGER PRIMARY KEY, b, c)",
+        "INSERT INTO t VALUES(1, 10, 'one')",
+        "INSERT INTO t VALUES(2, 20, 'two')",
+    ] {
+        let stmt = Parser::parse_sql(sql).expect("parse");
+        match stmt {
+            vibesql_ast::Statement::CreateTable(ct) => {
+                CreateTableExecutor::execute(&ct, &mut db).expect("create");
+            }
+            vibesql_ast::Statement::Insert(ins) => {
+                InsertExecutor::execute(&mut db, &ins).expect("insert");
+            }
+            _ => panic!("unexpected setup statement"),
+        }
+    }
+    db
+}
+
+fn run_update(db: &mut Database, sql: &str) -> Result<(), vibesql_executor::ExecutorError> {
+    match Parser::parse_sql(sql).expect("parse") {
+        vibesql_ast::Statement::Update(u) => UpdateExecutor::execute(&u, db).map(|_| ()),
+        vibesql_ast::Statement::Insert(i) => InsertExecutor::execute(db, &i).map(|_| ()),
+        _ => panic!("expected UPDATE/INSERT"),
+    }
+}
+
+fn row(db: &Database, key: i64) -> Vec<SqlValue> {
+    let table = db.get_table("t").expect("table");
+    table
+        .scan()
+        .iter()
+        .find(|r| r.values[0] == SqlValue::Integer(key))
+        .map(|r| r.values.to_vec())
+        .unwrap_or_default()
+}
+
+#[test]
+fn update_tuple_set_row_value() {
+    let mut db = setup();
+    run_update(&mut db, "UPDATE t SET (b, c) = (99, 'x') WHERE a = 1").expect("update");
+    let r = row(&db, 1);
+    assert_eq!(r[1], SqlValue::Integer(99));
+    assert_eq!(r[2], SqlValue::Varchar("x".into()));
+}
+
+#[test]
+fn update_tuple_set_reorders_columns() {
+    // Column list order drives the mapping: `(c, b)` swaps the targets.
+    let mut db = setup();
+    run_update(&mut db, "UPDATE t SET (c, b) = ('z', 77) WHERE a = 2").expect("update");
+    let r = row(&db, 2);
+    assert_eq!(r[1], SqlValue::Integer(77));
+    assert_eq!(r[2], SqlValue::Varchar("z".into()));
+}
+
+#[test]
+fn update_tuple_set_subquery() {
+    let mut db = setup();
+    run_update(&mut db, "UPDATE t SET (b, c) = (SELECT 5, 'q') WHERE a = 1").expect("update");
+    let r = row(&db, 1);
+    assert_eq!(r[1], SqlValue::Integer(5));
+    assert_eq!(r[2], SqlValue::Varchar("q".into()));
+}
+
+#[test]
+fn update_tuple_set_subquery_empty_yields_nulls() {
+    // SQLite: a subquery that returns no rows assigns NULL to every target.
+    let mut db = setup();
+    run_update(
+        &mut db,
+        "UPDATE t SET (b, c) = (SELECT b, c FROM t WHERE a = 999) WHERE a = 1",
+    )
+    .expect("update");
+    let r = row(&db, 1);
+    assert_eq!(r[1], SqlValue::Null);
+    assert_eq!(r[2], SqlValue::Null);
+}
+
+#[test]
+fn update_tuple_set_arity_mismatch_is_error() {
+    // Two target columns but a three-element row value is an arity error.
+    let mut db = setup();
+    let err = run_update(&mut db, "UPDATE t SET (b, c) = (1, 2, 3) WHERE a = 1");
+    assert!(err.is_err(), "arity mismatch must be rejected");
+}
+
+#[test]
+fn on_conflict_do_update_tuple_set() {
+    // upsert4 1.x.8 shape: DO UPDATE SET (c, a) = ('four', 4).
+    let mut db = setup();
+    run_update(
+        &mut db,
+        "INSERT INTO t VALUES(2, NULL, 'zero') ON CONFLICT (a) DO UPDATE SET (c, b) = ('four', 44)",
+    )
+    .expect("upsert");
+    let r = row(&db, 2);
+    assert_eq!(r[1], SqlValue::Integer(44));
+    assert_eq!(r[2], SqlValue::Varchar("four".into()));
+}
+
+#[test]
+fn on_conflict_do_update_tuple_set_subquery() {
+    // upsert4 1.x.7 shape: DO UPDATE SET (b, c) = (SELECT 'x', 'y').
+    let mut db = setup();
+    run_update(
+        &mut db,
+        "INSERT INTO t VALUES(1, NULL, 'zero') ON CONFLICT (a) DO UPDATE SET (b, c) = (SELECT 7, 'y')",
+    )
+    .expect("upsert");
+    let r = row(&db, 1);
+    assert_eq!(r[1], SqlValue::Integer(7));
+    assert_eq!(r[2], SqlValue::Varchar("y".into()));
+}

--- a/crates/vibesql-executor/tests/update_basic_tests.rs
+++ b/crates/vibesql-executor/tests/update_basic_tests.rs
@@ -20,6 +20,7 @@ fn test_update_all_rows() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "salary".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(50000)),
         }],
         where_clause: None,
@@ -54,6 +55,7 @@ fn test_update_with_where_clause() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "salary".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(60000)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
@@ -103,10 +105,12 @@ fn test_update_multiple_columns() {
         assignments: vec![
             Assignment {
                 column: "salary".to_string(),
+                columns: Vec::new(),
                 value: Expression::Literal(SqlValue::Integer(55000)),
             },
             Assignment {
                 column: "department".to_string(),
+                columns: Vec::new(),
                 value: Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Sales"))),
             },
         ],
@@ -149,6 +153,7 @@ fn test_update_with_expression() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "salary".to_string(),
+            columns: Vec::new(),
             value: Expression::BinaryOp {
                 left: Box::new(Expression::BinaryOp {
                     left: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
@@ -220,6 +225,7 @@ fn test_update_column_not_found() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "nonexistent_column".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(123)),
         }],
         where_clause: None,
@@ -249,6 +255,7 @@ fn test_update_no_matching_rows() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "salary".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(99999)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {

--- a/crates/vibesql-executor/tests/update_columnar_cache_tests.rs
+++ b/crates/vibesql-executor/tests/update_columnar_cache_tests.rs
@@ -60,6 +60,7 @@ fn test_update_invalidates_columnar_cache() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "salary".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(55000)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
@@ -136,6 +137,7 @@ fn test_update_invalidates_prewarmed_cache() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "salary".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(75000)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
@@ -186,6 +188,7 @@ fn test_update_all_rows_invalidates_cache() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "salary".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(60000)),
         }],
         where_clause: None,
@@ -228,6 +231,7 @@ fn test_update_no_match_does_not_invalidate_cache() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "salary".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(999999)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
@@ -277,6 +281,7 @@ fn test_multiple_updates_invalidate_cache() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "salary".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(50000)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
@@ -312,6 +317,7 @@ fn test_multiple_updates_invalidate_cache() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "salary".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(55000)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
@@ -364,10 +370,12 @@ fn test_update_multiple_columns_invalidates_cache() {
         assignments: vec![
             Assignment {
                 column: "salary".to_string(),
+                columns: Vec::new(),
                 value: Expression::Literal(SqlValue::Integer(70000)),
             },
             Assignment {
                 column: "department".to_string(),
+                columns: Vec::new(),
                 value: Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Management"))),
             },
         ],

--- a/crates/vibesql-executor/tests/update_constraint_tests/check_constraints.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/check_constraints.rs
@@ -26,6 +26,7 @@ fn test_update_check_constraint_passes() {
         table_name: "products".to_string(),
         assignments: vec![Assignment {
             column: "price".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(100)),
         }],
         where_clause: None,
@@ -58,6 +59,7 @@ fn test_update_check_constraint_violation() {
         table_name: "products".to_string(),
         assignments: vec![Assignment {
             column: "price".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(-10)),
         }],
         where_clause: None,
@@ -98,6 +100,7 @@ fn test_update_check_constraint_with_null() {
         table_name: "products".to_string(),
         assignments: vec![Assignment {
             column: "price".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Null),
         }],
         where_clause: None,
@@ -134,6 +137,7 @@ fn test_update_check_constraint_with_expression() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "bonus".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(15000)),
         }],
         where_clause: None,
@@ -156,6 +160,7 @@ fn test_update_check_constraint_with_expression() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "bonus".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(60000)),
         }],
         where_clause: None,

--- a/crates/vibesql-executor/tests/update_constraint_tests/constraint_test_utils.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/constraint_test_utils.rs
@@ -182,6 +182,7 @@ pub fn create_update_with_id_clause(
         table_name: table_name.to_string(),
         assignments: vec![Assignment {
             column: column.to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(value),
         }],
         from_clause: None,

--- a/crates/vibesql-executor/tests/update_constraint_tests/unique_constraints.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/unique_constraints.rs
@@ -169,10 +169,12 @@ fn test_update_unique_constraint_composite() {
         assignments: vec![
             Assignment {
                 column: "first_name".to_string(),
+                columns: Vec::new(),
                 value: Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Alice"))),
             },
             Assignment {
                 column: "last_name".to_string(),
+                columns: Vec::new(),
                 value: Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Smith"))),
             },
         ],

--- a/crates/vibesql-executor/tests/update_default_tests.rs
+++ b/crates/vibesql-executor/tests/update_default_tests.rs
@@ -35,7 +35,7 @@ fn test_update_with_default_value() {
         quoted: false,
         alias: None,
         table_name: "users".to_string(),
-        assignments: vec![Assignment { column: "name".to_string(), value: Expression::Default }],
+        assignments: vec![Assignment::single("name".to_string(), Expression::Default)],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
@@ -92,7 +92,7 @@ fn test_update_default_no_default_value_defined() {
         quoted: false,
         alias: None,
         table_name: "users".to_string(),
-        assignments: vec![Assignment { column: "name".to_string(), value: Expression::Default }],
+        assignments: vec![Assignment::single("name".to_string(), Expression::Default)],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
             op: BinaryOperator::Equal,
             left: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(

--- a/crates/vibesql-executor/tests/update_onepass_tests.rs
+++ b/crates/vibesql-executor/tests/update_onepass_tests.rs
@@ -110,14 +110,17 @@ fn test_onepass_multiple_literal_assignments() {
         assignments: vec![
             Assignment {
                 column: "name".to_string(),
+                columns: Vec::new(),
                 value: Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("Updated"))),
             },
             Assignment {
                 column: "price".to_string(),
+                columns: Vec::new(),
                 value: Expression::Literal(SqlValue::Integer(999)),
             },
             Assignment {
                 column: "quantity".to_string(),
+                columns: Vec::new(),
                 value: Expression::Literal(SqlValue::Integer(50)),
             },
         ],
@@ -166,6 +169,7 @@ fn test_onepass_single_literal_assignment() {
         table_name: "items".to_string(),
         assignments: vec![Assignment {
             column: "price".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(777)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
@@ -205,6 +209,7 @@ fn test_onepass_pk_not_found_returns_zero() {
         table_name: "items".to_string(),
         assignments: vec![Assignment {
             column: "price".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(999)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
@@ -253,6 +258,7 @@ fn test_onepass_not_null_constraint_enforced() {
         table_name: "required".to_string(),
         assignments: vec![Assignment {
             column: "required_field".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Null),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
@@ -293,6 +299,7 @@ fn test_composite_pk_update_both_columns_specified() {
         table_name: "order_items".to_string(),
         assignments: vec![Assignment {
             column: "quantity".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(99)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
@@ -349,6 +356,7 @@ fn test_composite_pk_update_reversed_order() {
         table_name: "order_items".to_string(),
         assignments: vec![Assignment {
             column: "price".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(500)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
@@ -400,6 +408,7 @@ fn test_composite_pk_partial_match_uses_scan() {
         table_name: "order_items".to_string(),
         assignments: vec![Assignment {
             column: "quantity".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(1)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
@@ -442,6 +451,7 @@ fn test_composite_pk_not_found_returns_zero() {
         table_name: "order_items".to_string(),
         assignments: vec![Assignment {
             column: "quantity".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(999)),
         }],
         where_clause: Some(WhereClause::Condition(Expression::BinaryOp {
@@ -488,10 +498,12 @@ fn test_composite_pk_multiple_columns_updated() {
         assignments: vec![
             Assignment {
                 column: "quantity".to_string(),
+                columns: Vec::new(),
                 value: Expression::Literal(SqlValue::Integer(100)),
             },
             Assignment {
                 column: "price".to_string(),
+                columns: Vec::new(),
                 value: Expression::Literal(SqlValue::Integer(1000)),
             },
         ],

--- a/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/error_cases.rs
@@ -74,6 +74,7 @@ fn test_update_with_subquery_multiple_rows_uses_first() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "salary".to_string(),
+            columns: Vec::new(),
             value: Expression::ScalarSubquery(subquery),
         }],
         where_clause: None,
@@ -175,6 +176,7 @@ fn test_update_with_subquery_multiple_columns_error() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "salary".to_string(),
+            columns: Vec::new(),
             value: Expression::ScalarSubquery(subquery),
         }],
         where_clause: None,

--- a/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/simple_scalar_subqueries.rs
@@ -134,7 +134,7 @@ fn create_update_stmt(
         quoted: false,
         alias: None,
         table_name: table_name.to_string(),
-        assignments: vec![Assignment { column: column.to_string(), value }],
+        assignments: vec![Assignment::single(column.to_string(), value)],
         from_clause: None,
         where_clause,
         order_by: None,
@@ -157,7 +157,7 @@ fn create_multi_column_update_stmt(
         table_name: table_name.to_string(),
         assignments: assignments
             .into_iter()
-            .map(|(col, val)| Assignment { column: col.to_string(), value: val })
+            .map(|(col, val)| Assignment::single(col.to_string(), val))
             .collect(),
         from_clause: None,
         where_clause: None,

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_comparison_subqueries.rs
@@ -70,6 +70,7 @@ fn test_update_where_scalar_subquery_equal() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "salary".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(55000)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
@@ -166,6 +167,7 @@ fn test_update_where_scalar_subquery_less_than() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "bonus".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(5000)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
@@ -254,6 +256,7 @@ fn test_update_where_subquery_returns_null() {
         alias: None,
         assignments: vec![Assignment {
             column: "salary".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(60000)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
@@ -354,6 +357,7 @@ fn test_update_where_subquery_with_aggregate() {
         table_name: "items".to_string(),
         assignments: vec![Assignment {
             column: "discounted".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Boolean(true)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::BinaryOp {
@@ -491,6 +495,7 @@ fn test_update_where_and_set_both_use_subqueries() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "salary".to_string(),
+            columns: Vec::new(),
             value: Expression::ScalarSubquery(set_subquery),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::In {

--- a/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
+++ b/crates/vibesql-executor/tests/update_subquery_tests/where_in_subqueries.rs
@@ -85,6 +85,7 @@ fn test_update_where_in_subquery() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "salary".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(80000)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::In {
@@ -185,6 +186,7 @@ fn test_update_where_not_in_subquery() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "active".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Boolean(false)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::In {
@@ -278,6 +280,7 @@ fn test_update_where_subquery_empty_result() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "active".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Boolean(false)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::In {
@@ -388,6 +391,7 @@ fn test_update_where_complex_subquery_condition() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "salary".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Integer(70000)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::In {
@@ -492,6 +496,7 @@ fn test_update_where_multiple_rows_in_subquery() {
         table_name: "employees".to_string(),
         assignments: vec![Assignment {
             column: "active".to_string(),
+            columns: Vec::new(),
             value: Expression::Literal(SqlValue::Boolean(false)),
         }],
         where_clause: Some(vibesql_ast::WhereClause::Condition(Expression::In {

--- a/crates/vibesql-parser/src/parser/insert.rs
+++ b/crates/vibesql-parser/src/parser/insert.rs
@@ -578,7 +578,7 @@ impl Parser {
                 self.expect_token(Token::Symbol('='))?;
                 let value = self.parse_expression()?;
 
-                assignments.push(vibesql_ast::Assignment { column, value });
+                assignments.push(vibesql_ast::Assignment::single(column, value));
 
                 if matches!(self.peek(), Token::Comma) {
                     self.advance();
@@ -596,23 +596,28 @@ impl Parser {
     ) -> Result<Vec<vibesql_ast::Assignment>, ParseError> {
         let mut assignments = Vec::new();
         loop {
-            let column = match self.peek() {
-                Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
-                    let column_name = col.clone();
-                    self.advance();
-                    column_name
-                }
-                _ => {
-                    return Err(ParseError {
-                        message: "Expected column name in ON CONFLICT UPDATE".to_string(),
-                    })
-                }
-            };
+            // SQLite tuple assignment: `SET (b, c) = (row-value | subquery)`.
+            if matches!(self.peek(), Token::LParen) {
+                assignments.push(self.parse_tuple_assignment()?);
+            } else {
+                let column = match self.peek() {
+                    Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
+                        let column_name = col.clone();
+                        self.advance();
+                        column_name
+                    }
+                    _ => {
+                        return Err(ParseError {
+                            message: "Expected column name in ON CONFLICT UPDATE".to_string(),
+                        })
+                    }
+                };
 
-            self.expect_token(Token::Symbol('='))?;
-            let value = self.parse_expression()?;
+                self.expect_token(Token::Symbol('='))?;
+                let value = self.parse_expression()?;
 
-            assignments.push(vibesql_ast::Assignment { column, value });
+                assignments.push(vibesql_ast::Assignment::single(column, value));
+            }
 
             if matches!(self.peek(), Token::Comma) {
                 self.advance();
@@ -621,5 +626,53 @@ impl Parser {
             }
         }
         Ok(assignments)
+    }
+
+    /// Parse a tuple/row SET assignment `(col, col, ...) = (row-value |
+    /// scalar-subquery)`. The current token must be `(`.
+    ///
+    /// A single-element list `(a) = v` collapses to an ordinary `a = v`
+    /// assignment; a list of two or more columns produces a tuple assignment
+    /// whose single RHS `value` is unpacked positionally by the executor.
+    pub(crate) fn parse_tuple_assignment(
+        &mut self,
+    ) -> Result<vibesql_ast::Assignment, ParseError> {
+        self.expect_token(Token::LParen)?; // consume '('
+        let mut columns = Vec::new();
+        loop {
+            match self.peek() {
+                Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
+                    columns.push(col.clone());
+                    self.advance();
+                }
+                Token::Keyword { keyword: kw, .. } => {
+                    columns.push(format!("{}", kw).to_lowercase());
+                    self.advance();
+                }
+                _ => {
+                    return Err(ParseError {
+                        message: "Expected column name in SET (column-list) assignment"
+                            .to_string(),
+                    })
+                }
+            }
+            if matches!(self.peek(), Token::Comma) {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+        self.expect_token(Token::RParen)?;
+        self.expect_token(Token::Symbol('='))?;
+        let value = self.parse_expression()?;
+
+        if columns.len() == 1 {
+            Ok(vibesql_ast::Assignment::single(
+                columns.into_iter().next().expect("len checked"),
+                value,
+            ))
+        } else {
+            Ok(vibesql_ast::Assignment::tuple(columns, value))
+        }
     }
 }

--- a/crates/vibesql-parser/src/parser/update.rs
+++ b/crates/vibesql-parser/src/parser/update.rs
@@ -71,38 +71,43 @@ impl Parser {
         // Parse assignments
         let mut assignments = Vec::new();
         loop {
-            // Parse column name (support regular, delimited identifiers, and rowid keyword)
-            let column = match self.peek() {
-                Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
-                    let c = col.clone();
-                    self.advance();
-                    c
-                }
-                // SQLite allows updating the virtual rowid column
-                // SQLite compatibility: the left-hand side of a SET assignment is an
-                // unambiguous column-name position (it is followed by `=`), so any
-                // keyword here is an unquoted column name. This covers the virtual ROWID
-                // column and otherwise-reserved words like RELEASE used as column names
-                // (see table.test table-7.3). Normalize to lowercase.
-                Token::Keyword { keyword: kw, .. } => {
-                    let col_name = format!("{}", kw).to_lowercase();
-                    self.advance();
-                    col_name
-                }
-                _ => {
-                    return Err(ParseError {
-                        message: "Expected column name in SET clause".to_string(),
-                    })
-                }
-            };
+            // SQLite tuple assignment: `SET (a, b) = (row-value | subquery)`.
+            if matches!(self.peek(), Token::LParen) {
+                assignments.push(self.parse_tuple_assignment()?);
+            } else {
+                // Parse column name (support regular, delimited identifiers, and rowid keyword)
+                let column = match self.peek() {
+                    Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
+                        let c = col.clone();
+                        self.advance();
+                        c
+                    }
+                    // SQLite allows updating the virtual rowid column
+                    // SQLite compatibility: the left-hand side of a SET assignment is an
+                    // unambiguous column-name position (it is followed by `=`), so any
+                    // keyword here is an unquoted column name. This covers the virtual ROWID
+                    // column and otherwise-reserved words like RELEASE used as column names
+                    // (see table.test table-7.3). Normalize to lowercase.
+                    Token::Keyword { keyword: kw, .. } => {
+                        let col_name = format!("{}", kw).to_lowercase();
+                        self.advance();
+                        col_name
+                    }
+                    _ => {
+                        return Err(ParseError {
+                            message: "Expected column name in SET clause".to_string(),
+                        })
+                    }
+                };
 
-            // Expect =
-            self.expect_token(Token::Symbol('='))?;
+                // Expect =
+                self.expect_token(Token::Symbol('='))?;
 
-            // Parse value expression
-            let value = self.parse_expression()?;
+                // Parse value expression
+                let value = self.parse_expression()?;
 
-            assignments.push(vibesql_ast::Assignment { column, value });
+                assignments.push(vibesql_ast::Assignment::single(column, value));
+            }
 
             if matches!(self.peek(), Token::Comma) {
                 self.advance();
@@ -236,33 +241,38 @@ impl Parser {
         // Parse assignments
         let mut assignments = Vec::new();
         loop {
-            let column = match self.peek() {
-                Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
-                    let c = col.clone();
-                    self.advance();
-                    c
-                }
-                // SQLite compatibility: the left-hand side of a SET assignment is an
-                // unambiguous column-name position (it is followed by `=`), so any
-                // keyword here is an unquoted column name. This covers the virtual ROWID
-                // column and otherwise-reserved words like RELEASE used as column names
-                // (see table.test table-7.3). Normalize to lowercase.
-                Token::Keyword { keyword: kw, .. } => {
-                    let col_name = format!("{}", kw).to_lowercase();
-                    self.advance();
-                    col_name
-                }
-                _ => {
-                    return Err(ParseError {
-                        message: "Expected column name in SET clause".to_string(),
-                    })
-                }
-            };
+            // SQLite tuple assignment: `SET (a, b) = (row-value | subquery)`.
+            if matches!(self.peek(), Token::LParen) {
+                assignments.push(self.parse_tuple_assignment()?);
+            } else {
+                let column = match self.peek() {
+                    Token::Identifier(col) | Token::DelimitedIdentifier(col) => {
+                        let c = col.clone();
+                        self.advance();
+                        c
+                    }
+                    // SQLite compatibility: the left-hand side of a SET assignment is an
+                    // unambiguous column-name position (it is followed by `=`), so any
+                    // keyword here is an unquoted column name. This covers the virtual ROWID
+                    // column and otherwise-reserved words like RELEASE used as column names
+                    // (see table.test table-7.3). Normalize to lowercase.
+                    Token::Keyword { keyword: kw, .. } => {
+                        let col_name = format!("{}", kw).to_lowercase();
+                        self.advance();
+                        col_name
+                    }
+                    _ => {
+                        return Err(ParseError {
+                            message: "Expected column name in SET clause".to_string(),
+                        })
+                    }
+                };
 
-            self.expect_token(Token::Symbol('='))?;
-            let value = self.parse_expression()?;
+                self.expect_token(Token::Symbol('='))?;
+                let value = self.parse_expression()?;
 
-            assignments.push(vibesql_ast::Assignment { column, value });
+                assignments.push(vibesql_ast::Assignment::single(column, value));
+            }
 
             if matches!(self.peek(), Token::Comma) {
                 self.advance();

--- a/crates/vibesql-parser/src/tests/update.rs
+++ b/crates/vibesql-parser/src/tests/update.rs
@@ -22,6 +22,79 @@ fn test_parse_update_basic() {
 }
 
 #[test]
+fn test_parse_update_tuple_set_row_value() {
+    // SQLite tuple assignment: `SET (a, b) = (row-value)`.
+    let result = Parser::parse_sql("UPDATE t SET (b, c) = (1, 'x') WHERE a = 2;");
+    assert!(result.is_ok(), "tuple SET should parse: {result:?}");
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(update) => {
+            assert_eq!(update.assignments.len(), 1);
+            let a = &update.assignments[0];
+            assert!(a.is_tuple(), "expected a tuple assignment");
+            assert_eq!(a.columns, vec!["b".to_string(), "c".to_string()]);
+            // `column` mirrors the first target for single-column readers.
+            assert_eq!(a.column, "b");
+            assert!(matches!(a.value, vibesql_ast::Expression::RowValueConstructor(_)));
+        }
+        other => panic!("Expected UPDATE statement, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_parse_update_tuple_set_subquery() {
+    // SQLite tuple assignment with a scalar subquery RHS.
+    let result = Parser::parse_sql("UPDATE t SET (b, c) = (SELECT 'x', 'y') WHERE a = 2;");
+    assert!(result.is_ok(), "tuple SET subquery should parse: {result:?}");
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(update) => {
+            let a = &update.assignments[0];
+            assert!(a.is_tuple());
+            assert_eq!(a.columns, vec!["b".to_string(), "c".to_string()]);
+            assert!(matches!(a.value, vibesql_ast::Expression::ScalarSubquery(_)));
+        }
+        other => panic!("Expected UPDATE statement, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_parse_update_single_element_paren_collapses() {
+    // A one-column parenthesized list `(a) = v` is an ordinary single assignment.
+    let result = Parser::parse_sql("UPDATE t SET (b) = 5 WHERE a = 2;");
+    assert!(result.is_ok(), "single-element paren SET should parse: {result:?}");
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(update) => {
+            let a = &update.assignments[0];
+            assert!(!a.is_tuple(), "single-element list must collapse to single");
+            assert_eq!(a.column, "b");
+        }
+        other => panic!("Expected UPDATE statement, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_parse_on_conflict_do_update_tuple_set() {
+    // Tuple assignment inside a DO UPDATE arm (upsert4 1.x.7 / 1.x.8 shape).
+    let result = Parser::parse_sql(
+        "INSERT INTO t VALUES(2, NULL, 'zero') ON CONFLICT (a) DO UPDATE SET (c, a) = ('four', 4);",
+    );
+    assert!(result.is_ok(), "DO UPDATE tuple SET should parse: {result:?}");
+    match result.unwrap() {
+        vibesql_ast::Statement::Insert(insert) => {
+            let clause = &insert.on_conflict[0];
+            match &clause.action {
+                vibesql_ast::OnConflictAction::DoUpdate { assignments, .. } => {
+                    let a = &assignments[0];
+                    assert!(a.is_tuple());
+                    assert_eq!(a.columns, vec!["c".to_string(), "a".to_string()]);
+                }
+                other => panic!("Expected DO UPDATE, got {other:?}"),
+            }
+        }
+        other => panic!("Expected INSERT statement, got {other:?}"),
+    }
+}
+
+#[test]
 fn test_parse_update_indexed_by() {
     // SQLite INDEXED BY hint on UPDATE (issue #5734, where9-6.8.x).
     let result = Parser::parse_sql("UPDATE t1 INDEXED BY t1b SET a = a + 100 WHERE a = 1;");


### PR DESCRIPTION
## Summary

Implements two of the three sub-problems in #5862, taking `upsert4.test` from **45/60 to 57/60** with no regressions. The third sub-problem (COLLATE conflict-target matching, 3 tests) is split into follow-up #5921 because it requires pervasive index-collation storage (index AST / CreateIndexStmt / storage IndexMetadata / persistence formats) that is out of scope for a focused diff.

Part of #5862. Closes #5921 is **not** implied — that is the tracked remainder.

### 1. Tuple SET assignment (fixes upsert4 1.x.7 / 1.x.8 — 6 tests)

`SET (a, b, ...) = (row-value | scalar-subquery)` in both the regular UPDATE path and the `ON CONFLICT ... DO UPDATE` arm.

- `vibesql_ast::Assignment` gains `columns: Vec<String>` (empty for an ordinary single-column assignment; `column` mirrors `columns[0]` so single-column readers are unaffected) plus `single` / `tuple` / `is_tuple` helpers. Existing call sites keep working via the `single` constructor; only mechanical `columns` additions were needed at literal sites.
- Parsers (`insert.rs`, `update.rs`) parse the tuple LHS via a shared `parse_tuple_assignment`; a one-column list `(a) = v` collapses to a plain assignment.
- Executor unpacks the RHS positionally via new `ExpressionEvaluator::eval_row_value` (a `RowValueConstructor` or a multi-column `ScalarSubquery`), reusing `eval_scalar_subquery_as_row` for SQLite's **NULL-when-empty** and **arity-mismatch** semantics — applied in both `on_conflict_update.rs` and `value_updater.rs`. The UPDATE fast paths bail to the main path for tuple assignments; PK-change detection and SET validation are made tuple-aware.

### 2. Full-index WHERE conflict-target leniency (fixes upsert4 2.x.2.6 / 2.x.2.9 — 6 tests)

`candidate_matches_target` now accepts a target `WHERE` clause against a **full** (non-partial) index (SQLite parses/validates but ignores it). Partial-index strictness is preserved: a bare target still never matches a partial index (upsert1-300) and a mismatched predicate still never matches (upsert1-310).

## Before / after (TCL)

| file | before | after |
|------|--------|-------|
| upsert4 | 45/60 | **57/60** |
| upsert1 | 34/35 | 34/35 |
| upsert2 | 6/14 | 6/14 |
| upsert3 | 5/7 | 5/7 |

The 3 remaining upsert4 failures are exactly `2.x.2.1` (COLLATE), tracked in #5921. update.test 128/0; the single insert.test failure (`insert-16.1`, a rowid vs c0 message) is pre-existing and unrelated.

## Tests added

- Parser: tuple SET row-value / subquery / single-element collapse / DO UPDATE (`crates/vibesql-parser/src/tests/update.rs`).
- `candidate_matches_target` unit tests: full-index leniency + partial-index rejection (`on_conflict_update.rs`).
- End-to-end `tuple_set_assignment_tests`: row-value, column reordering, subquery, NULL-when-empty, arity error, DO UPDATE (+ subquery).

## Scope note

No changes to persistence formats, `IndexColumn`, consensus, or server. The AST field addition propagates as mechanical `columns: Vec::new()` at existing single-column construction sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)