### PR TITLE
fix(parser): reject tokens after trailing semicolon in parse_expression_sql

### DIFF
--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -226,8 +226,24 @@ impl Parser {
 
         let mut parser = Parser::new_with_source(tokens, spans, input.to_string());
         let expr = parser.parse_expression()?;
+        // A single trailing `;` is a benign terminator, but anything after it
+        // means the rendered text did not round-trip as one expression (e.g. a
+        // corrupt/hand-crafted catalog blob smuggling `x; DROP TABLE t`). Fail
+        // closed: consume one semicolon, then require EOF (issue #5866).
         match parser.peek() {
-            Token::Eof | Token::Semicolon => Ok(expr),
+            Token::Eof => Ok(expr),
+            Token::Semicolon => {
+                parser.advance(); // consume the terminating semicolon
+                match parser.peek() {
+                    Token::Eof => Ok(expr),
+                    other => Err(ParseError {
+                        message: format!(
+                            "Unexpected trailing token {:?} after expression in '{}'",
+                            other, input
+                        ),
+                    }),
+                }
+            }
             other => Err(ParseError {
                 message: format!(
                     "Unexpected trailing token {:?} after expression in '{}'",

--- a/crates/vibesql-parser/src/tests/mod.rs
+++ b/crates/vibesql-parser/src/tests/mod.rs
@@ -33,6 +33,7 @@ mod limit;
 mod literals;
 mod not_is_null_precedence;
 mod null_functions;
+mod parse_expression_sql;
 mod pragma;
 mod predicates;
 mod prepared;

--- a/crates/vibesql-parser/src/tests/parse_expression_sql.rs
+++ b/crates/vibesql-parser/src/tests/parse_expression_sql.rs
@@ -1,0 +1,46 @@
+//! Tests for `Parser::parse_expression_sql` trailing-token handling.
+//!
+//! `parse_expression_sql` re-parses catalog-persisted expression text
+//! (expression indexes, partial-index WHERE clauses). It must accept exactly
+//! one expression, tolerating a single trailing `;` terminator but rejecting
+//! anything smuggled after it — a fail-closed guard against corrupt or
+//! hand-crafted catalog blobs like `x; DROP TABLE t` (issue #5866).
+
+use crate::parser::Parser;
+
+#[test]
+fn test_bare_expression_ok() {
+    assert!(Parser::parse_expression_sql("x").is_ok());
+    assert!(Parser::parse_expression_sql("x = 1").is_ok());
+}
+
+#[test]
+fn test_single_trailing_semicolon_ok() {
+    assert!(Parser::parse_expression_sql("x;").is_ok());
+    assert!(Parser::parse_expression_sql("x = 1;").is_ok());
+}
+
+#[test]
+fn test_tokens_after_semicolon_error() {
+    assert!(Parser::parse_expression_sql("x; DROP TABLE t").is_err());
+    assert!(Parser::parse_expression_sql("x = 1; DELETE FROM t").is_err());
+}
+
+#[test]
+fn test_double_semicolon_error() {
+    // An empty statement after the terminator is still a trailing token.
+    assert!(Parser::parse_expression_sql("x;;").is_err());
+}
+
+#[test]
+fn test_semicolon_inside_string_literal_ok() {
+    // The `;` is lexed into the string token and never seen as a top-level
+    // `Token::Semicolon`, so the expression round-trips.
+    assert!(Parser::parse_expression_sql("x = 'a;b'").is_ok());
+}
+
+#[test]
+fn test_injection_style_trailing_paren_error() {
+    // Regression: pre-existing rejection of a trailing `)` stays intact.
+    assert!(Parser::parse_expression_sql("x); DROP TABLE t;--").is_err());
+}


### PR DESCRIPTION
## Summary

`Parser::parse_expression_sql` treated `Token::Semicolon` as a terminal token without verifying what followed it, so `parse_expression_sql("x; DROP TABLE t")` silently returned just `x` and discarded everything after the semicolon. This PR makes the trailing-token check fail closed: a single terminating `;` is consumed and then EOF is required; any remaining tokens produce the same "unexpected trailing token" error.

The only production callers re-parse catalog-persisted `ToSql` text (expression indexes and partial-index WHERE clauses in `crates/vibesql-storage/src/persistence/binary/catalog.rs`), which never renders a top-level semicolon. This aligns the entry point with the fail-closed policy (#5850) for corrupt or hand-crafted catalog blobs.

## Changes

- `crates/vibesql-parser/src/parser/mod.rs` — in `parse_expression_sql`, split the `Token::Eof | Token::Semicolon` arm so a semicolon is consumed and then EOF is required; otherwise the existing trailing-token error is returned.
- `crates/vibesql-parser/src/tests/parse_expression_sql.rs` — new test module covering the accepted and rejected cases.
- `crates/vibesql-parser/src/tests/mod.rs` — register the new test module.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `parse_expression_sql("x = 1;")` returns `Ok` | ✅ | `test_single_trailing_semicolon_ok` |
| `parse_expression_sql("x; DROP TABLE t")` returns `Err` | ✅ | `test_tokens_after_semicolon_error` |
| `parse_expression_sql("x = 1; DELETE FROM t")` returns `Err` | ✅ | `test_tokens_after_semicolon_error` |
| `x = 'a;b'` (semicolon inside string literal) still `Ok` | ✅ | `test_semicolon_inside_string_literal_ok` |
| `x;;` returns `Err` | ✅ | `test_double_semicolon_error` |
| All existing `vibesql-parser` tests pass | ✅ | 1706 passed, 0 failed |
| All existing `vibesql-storage` tests pass | ✅ | 786 passed, incl. `test_binary_catalog_round_trips_collate_in_index_expressions` |

## Test Plan

- `cargo test -p vibesql-parser` — 1706 passed, 0 failed (6 new tests in `parse_expression_sql`).
- `cargo test -p vibesql-storage` — 786 passed, 0 failed; the catalog re-parse round-trip test (`test_binary_catalog_round_trips_collate_in_index_expressions`) and `test_load_binary_repopulates_catalog_for_all_indexes` confirm no legitimate persisted expression breaks.

Closes #5866