### PR TITLE
fix(executor): propagate view column collation to outer comparisons (tkt-a7debbe0 1.1.2.3/4, 2.1.2.3/4)

### DIFF
--- a/crates/vibesql-executor/src/evaluator/collation.rs
+++ b/crates/vibesql-executor/src/evaluator/collation.rs
@@ -27,7 +27,7 @@
 //! *declared* collation, or `None` when the column has none (default
 //! BINARY).
 
-use vibesql_ast::{ColumnIdentifier, Expression, UnaryOperator};
+use vibesql_ast::{ColumnIdentifier, Expression, SelectItem, UnaryOperator};
 
 /// Find an *explicit* COLLATE operator anywhere within an expression's
 /// subtree (SQLite's `EP_Collate` propagation).
@@ -74,6 +74,38 @@ fn operand_column_collation(
         Expression::Cast { expr, .. } => operand_column_collation(expr, column_collation),
         _ => None,
     }
+}
+
+/// Derive the per-column collation of a view (or subquery) body's select list,
+/// positionally aligned with the result columns.
+///
+/// SQLite propagates a view column's collation to the outer query in two ways
+/// (ticket a7debbe0ad1, issue #5864):
+///  1. An explicit `COLLATE` operator anywhere in the defining expression's
+///     subtree — including through `||`, `CAST`, and unary `+` — wins
+///     (`explicit_collation_of`).
+///  2. Otherwise a bare column reference (optionally wrapped in unary `+` or
+///     `CAST`) to an underlying column with a *declared* collation propagates
+///     that collation, resolved via the `column_collation` callback.
+///
+/// Any other expression (bare literal, function result, a `||` of operands
+/// without an explicit `COLLATE`, ...) has no collating sequence — `None`,
+/// i.e. default BINARY. Non-expression select items (wildcards) yield a `None`
+/// placeholder; because a wildcard expands to a variable number of columns,
+/// callers must guard by comparing the returned length against the actual
+/// column count and fall back to all-`None` when they differ.
+pub(crate) fn view_select_list_collations(
+    select_list: &[SelectItem],
+    column_collation: &dyn Fn(&ColumnIdentifier) -> Option<String>,
+) -> Vec<Option<String>> {
+    select_list
+        .iter()
+        .map(|item| match item {
+            SelectItem::Expression { expr, .. } => explicit_collation_of(expr)
+                .or_else(|| operand_column_collation(expr, column_collation).flatten()),
+            _ => None,
+        })
+        .collect()
 }
 
 /// Resolve the effective collating sequence of a single expression.

--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -83,6 +83,103 @@ fn apply_column_aliases(
     Ok(schema)
 }
 
+/// Resolve a bare column reference in a view body to its source column's
+/// collation, walking the view's FROM clause (issue #5864).
+///
+/// Base-table sources contribute the column's declared collation; view sources
+/// recurse into the inner view body so collation propagates through arbitrarily
+/// nested views. Subqueries, table-valued functions, and other exotic sources
+/// yield `None` (default BINARY), matching the safe-degradation contract of
+/// `view_select_list_collations`.
+fn view_body_column_collation(
+    database: &vibesql_storage::Database,
+    from: Option<&vibesql_ast::FromClause>,
+    col_id: &vibesql_ast::ColumnIdentifier,
+) -> Option<String> {
+    let from = from?;
+    let column_name = col_id.column_canonical();
+    // A table-qualified reference resolves against that source directly.
+    if let Some(table_name) = col_id.table_canonical() {
+        return source_column_collation(database, table_name, column_name);
+    }
+    find_collation_in_from(database, from, column_name)
+}
+
+/// Search a FROM clause's table/join sources for a column's collation.
+fn find_collation_in_from(
+    database: &vibesql_storage::Database,
+    from: &vibesql_ast::FromClause,
+    column_name: &str,
+) -> Option<String> {
+    match from {
+        vibesql_ast::FromClause::Table { name, .. } => {
+            source_column_collation(database, name, column_name)
+        }
+        vibesql_ast::FromClause::Join { left, right, .. } => {
+            find_collation_in_from(database, left, column_name)
+                .or_else(|| find_collation_in_from(database, right, column_name))
+        }
+        _ => None,
+    }
+}
+
+/// Resolve `column_name` in a FROM source named `source_name`. A base table
+/// yields the column's declared collation; a view recurses into its defining
+/// body so an explicit COLLATE (or a base column's collation) propagates
+/// through nested views. Anything unresolved yields `None` (BINARY).
+fn source_column_collation(
+    database: &vibesql_storage::Database,
+    source_name: &str,
+    column_name: &str,
+) -> Option<String> {
+    if let Some(table) = database.get_table(source_name) {
+        return table
+            .schema
+            .columns
+            .iter()
+            .find(|c| c.name.eq_ignore_ascii_case(column_name))
+            .and_then(|c| c.collation.clone());
+    }
+    // View source: map the referenced column to its select-list position and
+    // resolve that item's collation against the inner view's own FROM clause.
+    let view = database.catalog.get_view(source_name)?;
+    let idx = view_output_column_index(view, column_name)?;
+    let inner_from = view.query.from.as_ref();
+    let resolver = |c: &vibesql_ast::ColumnIdentifier| -> Option<String> {
+        view_body_column_collation(database, inner_from, c)
+    };
+    let collations = crate::evaluator::collation::view_select_list_collations(
+        &view.query.select_list,
+        &resolver,
+    );
+    collations.get(idx).cloned().flatten()
+}
+
+/// Map a view's exposed column name to its select-list index. Uses the view's
+/// explicit column list when present, otherwise the select item's output name
+/// (an alias, or a bare column reference's name). Returns `None` when the name
+/// cannot be positioned (e.g. wildcard bodies) so collation degrades to BINARY.
+fn view_output_column_index(
+    view: &vibesql_catalog::ViewDefinition,
+    column_name: &str,
+) -> Option<usize> {
+    if let Some(cols) = &view.columns {
+        return cols.iter().position(|c| c.eq_ignore_ascii_case(column_name));
+    }
+    view.query.select_list.iter().position(|item| match item {
+        vibesql_ast::SelectItem::Expression { expr, alias, .. } => {
+            if let Some(a) = alias {
+                a.eq_ignore_ascii_case(column_name)
+            } else if let vibesql_ast::Expression::ColumnRef(c) = expr {
+                c.column_canonical().eq_ignore_ascii_case(column_name)
+            } else {
+                false
+            }
+        }
+        _ => false,
+    })
+}
+
 /// Sort rows by INTEGER PRIMARY KEY column value (Issue #4926)
 ///
 /// SQLite guarantees that tables with INTEGER PRIMARY KEY return rows in rowid order
@@ -352,6 +449,34 @@ pub(crate) fn execute_table_scan(
             select_result.columns.clone()
         };
 
+        // Propagate each view column's collation from the view body's select
+        // list so that comparisons in the outer query use the right collating
+        // sequence (ticket a7debbe0ad1, issue #5864). Without this, an outer
+        // `SELECT B < a FROM v` where the view defines `B` as
+        // `'B' COLLATE NOCASE` would compare BINARY instead of NOCASE.
+        //
+        // Only the (left) branch of the body's select list is inspected — for
+        // a UNION body SQLite likewise takes the collation from the first
+        // branch. The derived vector is applied only when it aligns 1:1 with
+        // the result columns, so wildcard-expanded bodies (whose select-item
+        // count differs from the column count) degrade safely to BINARY.
+        let view_from = view.query.from.as_ref();
+        let column_collation_fn = |col_id: &vibesql_ast::ColumnIdentifier| -> Option<String> {
+            view_body_column_collation(database, view_from, col_id)
+        };
+        let derived_collations = crate::evaluator::collation::view_select_list_collations(
+            &view.query.select_list,
+            &column_collation_fn,
+        );
+        let use_derived_collations = derived_collations.len() == column_names.len();
+        let collation_for = |idx: usize| -> Option<String> {
+            if use_derived_collations {
+                derived_collations.get(idx).cloned().flatten()
+            } else {
+                None
+            }
+        };
+
         // Since views can have arbitrary SELECT expressions, we derive column types from the first
         // row
         let columns = if !select_result.rows.is_empty() {
@@ -359,14 +484,15 @@ pub(crate) fn execute_table_scan(
             column_names
                 .iter()
                 .zip(&first_row.values)
-                .map(|(name, value)| {
+                .enumerate()
+                .map(|(idx, (name, value))| {
                     vibesql_catalog::ColumnSchema {
                         name: name.clone(),
                         data_type: value.get_type(),
                         nullable: true, // Views return nullable columns by default
                         default_value: None,
                         generated_expr: None, // Views don't have generated columns
-                        collation: None,      // Views don't preserve collation
+                        collation: collation_for(idx), // Propagate view body collation (#5864)
                         is_exact_integer_type: false, // Views don't preserve exact type
                     }
                 })
@@ -375,14 +501,15 @@ pub(crate) fn execute_table_scan(
             // For empty views, create columns without specific types
             // This is a limitation but views with no rows are edge cases
             column_names
-                .into_iter()
-                .map(|name| vibesql_catalog::ColumnSchema {
-                    name,
+                .iter()
+                .enumerate()
+                .map(|(idx, name)| vibesql_catalog::ColumnSchema {
+                    name: name.clone(),
                     data_type: vibesql_types::DataType::Varchar { max_length: None },
                     nullable: true,
                     default_value: None,
                     generated_expr: None, // Views don't have generated columns
-                    collation: None,      // Views don't preserve collation
+                    collation: collation_for(idx), // Propagate view body collation (#5864)
                     is_exact_integer_type: false, // Views don't preserve exact type
                 })
                 .collect()

--- a/crates/vibesql-executor/tests/comparison_collation_tests.rs
+++ b/crates/vibesql-executor/tests/comparison_collation_tests.rs
@@ -26,6 +26,9 @@ fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
         vibesql_ast::Statement::Insert(insert) => {
             vibesql_executor::InsertExecutor::execute(db, &insert).unwrap();
         }
+        vibesql_ast::Statement::CreateView(view) => {
+            vibesql_executor::advanced_objects::execute_create_view(&view, db).unwrap();
+        }
         other => panic!("Unsupported statement in test setup: {:?}", other),
     }
 }
@@ -45,6 +48,9 @@ fn query_ints(db: &vibesql_storage::Database, sql: &str) -> Vec<i64> {
                     SqlValue::Integer(i) => *i,
                     SqlValue::Bigint(i) => *i,
                     SqlValue::Smallint(i) => i64::from(*i),
+                    // A bare comparison (`B < a`) yields a Boolean; SQLite
+                    // surfaces these as 0/1 integers.
+                    SqlValue::Boolean(b) => i64::from(*b),
                     other => panic!("Expected integer result for {}: {:?}", sql, other),
                 }
             })
@@ -192,4 +198,99 @@ fn between_on_nocase_column_applies_collation() {
     // b BETWEEN 'XYZ' AND 'XYZ' is equivalent to b='XYZ' -> row 2 (nocase).
     let db = db_with_t4a();
     assert_rows(&db, "SELECT c FROM t4a WHERE b BETWEEN 'XYZ' AND 'XYZ' ORDER BY c", &[2]);
+}
+
+// ---------------------------------------------------------------------------
+// Issue #5864: view column collation must propagate to outer-query comparisons
+// (SQLite ticket a7debbe0ad1, `tkt-a7debbe0.test` subtests 1.2.3 / 1.2.4).
+//
+// A view materialized its runtime schema with `collation: None` for every
+// column, so `explicit COLLATE` (and an underlying column's declared
+// collation) in the view body was silently dropped. Expected values below
+// are all verified against sqlite3 3.51.0.
+// ---------------------------------------------------------------------------
+
+/// Base table the tkt-a7debbe0 views select from.
+fn db_with_t0() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t0(xyz INTEGER)");
+    run_stmt(&mut db, "INSERT INTO t0(xyz) VALUES(456)");
+    db
+}
+
+#[test]
+fn view_explicit_collate_left_operand_reproducer() {
+    // Reproducer from issue #5864 (tkt-a7debbe0 1.2.3):
+    //   CREATE VIEW v2(a,B) AS SELECT 'a','B' COLLATE NOCASE FROM t0;
+    //   SELECT B < a FROM v2  ->  0  (NOCASE: 'B' < 'a' is false)
+    // Before the fix VibeSQL returned 1 (BINARY: 0x42 < 0x61).
+    let mut db = db_with_t0();
+    run_stmt(&mut db, "CREATE VIEW v2(a, B) AS SELECT 'a', 'B' COLLATE NOCASE FROM t0");
+    assert_rows(&db, "SELECT B < a FROM v2", &[0]);
+    // And the symmetric >= comparison (tkt-a7debbe0 1.1.3) stays 1.
+    assert_rows(&db, "SELECT a >= B FROM v2", &[1]);
+}
+
+#[test]
+fn view_explicit_collate_both_operands() {
+    // tkt-a7debbe0 1.2.4:
+    //   CREATE VIEW v3(a,B) AS SELECT 'a' COLLATE BINARY, 'B' COLLATE NOCASE FROM t0;
+    //   SELECT B < a FROM v3  ->  0
+    let mut db = db_with_t0();
+    run_stmt(
+        &mut db,
+        "CREATE VIEW v3(a, B) AS SELECT 'a' COLLATE BINARY, 'B' COLLATE NOCASE FROM t0",
+    );
+    assert_rows(&db, "SELECT B < a FROM v3", &[0]);
+    assert_rows(&db, "SELECT a >= B FROM v3", &[1]);
+}
+
+#[test]
+fn view_explicit_collate_through_cast_and_concat() {
+    // Explicit COLLATE propagates out through unary `+`, CAST, and `||`
+    // (tkt-a7debbe0 v4/v5). With B on the left both must compare NOCASE -> 0.
+    let mut db = db_with_t0();
+    run_stmt(
+        &mut db,
+        "CREATE VIEW v4(a, B) AS SELECT 'a', +CAST('B' COLLATE NOCASE AS TEXT) FROM t0",
+    );
+    run_stmt(&mut db, "CREATE VIEW v5(a, B) AS SELECT 'a', ('B' COLLATE NOCASE) || '' FROM t0");
+    assert_rows(&db, "SELECT B < a FROM v4", &[0]);
+    assert_rows(&db, "SELECT B < a FROM v5", &[0]);
+    // Plain column `a` on the left blocks the right's NOCASE -> BINARY -> 0.
+    assert_rows(&db, "SELECT a < B FROM v4", &[0]);
+    assert_rows(&db, "SELECT a < B FROM v5", &[0]);
+}
+
+#[test]
+fn view_bare_column_ref_propagates_underlying_collation() {
+    // A bare column reference to an underlying NOCASE column carries that
+    // collation through the view (ticket a7debbe0ad1). Verified vs sqlite3:
+    //   CREATE TABLE t2(a, B COLLATE NOCASE); INSERT VALUES('a','B');
+    //   CREATE VIEW vc(a,B) AS SELECT a, B FROM t2;
+    //   SELECT B < a FROM vc  ->  0
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t2(a TEXT, B TEXT COLLATE NOCASE)");
+    run_stmt(&mut db, "INSERT INTO t2 VALUES('a', 'B')");
+    run_stmt(&mut db, "CREATE VIEW vc(a, B) AS SELECT a, B FROM t2");
+    assert_rows(&db, "SELECT B < a FROM vc", &[0]);
+    assert_rows(&db, "SELECT a >= B FROM vc", &[1]);
+}
+
+#[test]
+fn view_of_view_propagates_collation() {
+    // Collation survives a second layer of view materialization.
+    let mut db = db_with_t0();
+    run_stmt(&mut db, "CREATE VIEW v2(a, B) AS SELECT 'a', 'B' COLLATE NOCASE FROM t0");
+    run_stmt(&mut db, "CREATE VIEW v2b(a, B) AS SELECT a, B FROM v2");
+    assert_rows(&db, "SELECT B < a FROM v2b", &[0]);
+}
+
+#[test]
+fn view_plain_literal_column_is_binary() {
+    // Regression: a view column that is a bare literal (no COLLATE) still
+    // compares BINARY. 'A' = 'a' under BINARY is false -> 0.
+    let mut db = db_with_t0();
+    run_stmt(&mut db, "CREATE VIEW vlit(a, b) AS SELECT 'A', 'a' FROM t0");
+    assert_rows(&db, "SELECT a = b FROM vlit", &[0]);
 }


### PR DESCRIPTION
## Summary

View materialization built its runtime `TableSchema` with `collation: None` for every column (`crates/vibesql-executor/src/select/scan/table.rs`), so an explicit `COLLATE` (or an underlying base column's declared collation) in the view body was silently discarded. When the outer query referenced a view column, the comparison collation resolver saw BINARY and mis-compared.

Reproducer (now returns 0, matching sqlite3 3.51.0; previously 1):

```sql
CREATE TABLE t0(xyz INTEGER); INSERT INTO t0(xyz) VALUES(456);
CREATE VIEW v2(a,B) AS SELECT 'a','B' COLLATE NOCASE FROM t0;
SELECT B < a FROM v2;   -- 0 (NOCASE: 'B' < 'a' is false)
```

## Fix

- New `evaluator::collation::view_select_list_collations` derives a per-column collation vector from the view body's select list: an explicit `COLLATE` anywhere in the defining expression's subtree wins (including through `||`, `CAST`, unary `+`), otherwise a bare column reference propagates its source column's declared collation.
- `table.rs` applies the derived vector at both view-schema build sites, but only when it aligns 1:1 with the result columns — wildcard-expanded bodies degrade safely to BINARY. For a UNION body only the left branch's select list is inspected, matching SQLite.
- Source resolution walks the view's `FROM` clause: base-table sources contribute their declared collation; view sources recurse, so collation flows through arbitrarily nested views.

## Validation

- `make test-tcl-file FILE=tkt-a7debbe0.test`: **32/36 → 36/36**.
- `cargo test -p vibesql-executor --test comparison_collation_tests`: 20/20 (6 new view tests: reproducer, both-explicit, CAST/`||` propagation, bare-column-ref, view-of-view, plain-literal-is-BINARY — all sqlite3-verified).
- Canaries green: `equality_range_index_collation_tests` (10/10), `in_list_collation_tests` (15/15), `aggregate_collation_tests` (3/3).
- Full `vibesql-executor` suite green (60 result lines, 0 failures); `view.test` 24/24.

Closes #5864

🤖 Generated with [Claude Code](https://claude.com/claude-code)