### PR TITLE
fix(constraints): preserve verbatim CHECK expression text in violation messages

### DIFF
--- a/crates/vibesql-ast/src/ddl/table.rs
+++ b/crates/vibesql-ast/src/ddl/table.rs
@@ -240,7 +240,20 @@ pub enum ColumnConstraintKind {
         /// Syntax: NOT NULL ON CONFLICT ROLLBACK|ABORT|FAIL|IGNORE|REPLACE
         on_conflict: Option<crate::ConflictClause>,
     },
-    Check(Box<Expression>),
+    /// CHECK constraint.
+    ///
+    /// `source_text` holds the verbatim source spelling of the expression
+    /// between the CHECK parentheses (interior whitespace preserved, outer
+    /// whitespace trimmed), exactly as SQLite echoes it in the
+    /// "CHECK constraint failed: <expr>" message for an unnamed constraint.
+    /// The parsed `expr` alone is lossy — re-rendering it via `ToSql` drops the
+    /// original operator spacing (`d > 0` becomes `d>0`). `None` when the AST
+    /// was built programmatically without source spans, in which case callers
+    /// fall back to `expr.to_sql()`.
+    Check {
+        expr: Box<Expression>,
+        source_text: Option<String>,
+    },
     References {
         table: String,
         /// Column in the referenced table. If None, defaults to the primary key.
@@ -294,6 +307,14 @@ pub enum TableConstraintKind {
     },
     Check {
         expr: Box<Expression>,
+        /// Verbatim source text of the CHECK expression between the
+        /// parentheses (interior whitespace preserved, outer whitespace
+        /// trimmed), matching what SQLite echoes in the
+        /// "CHECK constraint failed: <expr>" message for an unnamed
+        /// table-level constraint. `None` when the AST was built
+        /// programmatically without source spans; callers then fall back to
+        /// `expr.to_sql()`.
+        source_text: Option<String>,
     },
     /// FULLTEXT index constraint
     /// Example: FULLTEXT INDEX ft_search (title, body)

--- a/crates/vibesql-executor/src/alter/constraints.rs
+++ b/crates/vibesql-executor/src/alter/constraints.rs
@@ -74,7 +74,7 @@ pub(super) fn execute_add_constraint(
 
             Ok(format!("UNIQUE constraint added to table '{}'", stmt.table_name))
         }
-        TableConstraintKind::Check { expr } => {
+        TableConstraintKind::Check { expr, .. } => {
             let constraint_name = stmt
                 .constraint
                 .name

--- a/crates/vibesql-executor/src/alter/drop_column_checks.rs
+++ b/crates/vibesql-executor/src/alter/drop_column_checks.rs
@@ -490,7 +490,7 @@ fn check_constraint_missing_column(schema: &TableSchema, dropped: &str) -> Optio
 
     // Table-level CHECK constraints always survive the drop.
     for constraint in &create.table_constraints {
-        if let TableConstraintKind::Check { expr } = &constraint.kind {
+        if let TableConstraintKind::Check { expr, .. } = &constraint.kind {
             if let Some(display) = find_column_ref_display(expr, dropped) {
                 return Some(display);
             }
@@ -504,7 +504,7 @@ fn check_constraint_missing_column(schema: &TableSchema, dropped: &str) -> Optio
             continue;
         }
         for constraint in &column.constraints {
-            if let ColumnConstraintKind::Check(expr) = &constraint.kind {
+            if let ColumnConstraintKind::Check { expr, .. } = &constraint.kind {
                 if let Some(display) = find_column_ref_display(expr, dropped) {
                     return Some(display);
                 }

--- a/crates/vibesql-executor/src/constraint_validator.rs
+++ b/crates/vibesql-executor/src/constraint_validator.rs
@@ -93,11 +93,17 @@ impl ConstraintValidator {
                     ColumnConstraintKind::Unique { .. } => {
                         result.unique_constraints.push(vec![col_def.name.clone()]);
                     }
-                    ColumnConstraintKind::Check(expr) => {
-                        // Use explicit name if provided, otherwise use expression text
-                        // This matches SQLite's behavior for error messages
-                        let constraint_name =
-                            constraint.name.clone().unwrap_or_else(|| expr.to_sql());
+                    ColumnConstraintKind::Check { expr, source_text } => {
+                        // Use explicit name if provided; otherwise use the
+                        // verbatim CHECK source text (SQLite echoes the
+                        // original operator spacing in the violation message),
+                        // falling back to the re-rendered expression only when
+                        // no source span was captured.
+                        let constraint_name = constraint
+                            .name
+                            .clone()
+                            .or_else(|| source_text.clone())
+                            .unwrap_or_else(|| expr.to_sql());
                         result.check_constraints.push((constraint_name, (**expr).clone()));
                     }
                     ColumnConstraintKind::NotNull
@@ -159,11 +165,15 @@ impl ConstraintValidator {
                         columns.iter().map(|c| c.expect_column_name().to_string()).collect();
                     result.unique_constraints.push(column_names);
                 }
-                TableConstraintKind::Check { expr } => {
-                    // Use explicit name if provided, otherwise use expression text
-                    // This matches SQLite's behavior for error messages
-                    let constraint_name =
-                        table_constraint.name.clone().unwrap_or_else(|| expr.to_sql());
+                TableConstraintKind::Check { expr, source_text } => {
+                    // Use explicit name if provided; otherwise the verbatim
+                    // CHECK source text, falling back to the re-rendered
+                    // expression only when no source span was captured.
+                    let constraint_name = table_constraint
+                        .name
+                        .clone()
+                        .or_else(|| source_text.clone())
+                        .unwrap_or_else(|| expr.to_sql());
                     result.check_constraints.push((constraint_name, (**expr).clone()));
                 }
                 TableConstraintKind::ForeignKey { .. } => {
@@ -359,13 +369,69 @@ mod tests {
 
         let columns = vec![make_column_def(
             "age",
-            vec![ColumnConstraintKind::Check(Box::new(check_expr.clone()))],
+            // No source_text (programmatic AST) → name falls back to expr.to_sql().
+            vec![ColumnConstraintKind::Check {
+                expr: Box::new(check_expr.clone()),
+                source_text: None,
+            }],
         )];
 
         let result = ConstraintValidator::process_constraints("test_table", &columns, &[]).unwrap();
 
         assert_eq!(result.check_constraints.len(), 1);
         assert_eq!(result.check_constraints[0].1, check_expr);
+        // Programmatic AST carries no source span, so the name falls back to
+        // the re-rendered expression text.
+        assert_eq!(result.check_constraints[0].0, check_expr.to_sql());
+    }
+
+    #[test]
+    fn test_check_constraint_name_preserves_source_spacing() {
+        // When the parser captured verbatim source text, the constraint name
+        // (used in "CHECK constraint failed: <name>") echoes the original
+        // operator spacing rather than the whitespace-stripped `to_sql()`.
+        let check_expr = Expression::BinaryOp {
+            left: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
+                "d", false,
+            ))),
+            op: vibesql_ast::BinaryOperator::GreaterThan,
+            right: Box::new(Expression::Literal(vibesql_types::SqlValue::Integer(0))),
+        };
+
+        // Spaced source form is preserved verbatim.
+        let columns = vec![make_column_def(
+            "d",
+            vec![ColumnConstraintKind::Check {
+                expr: Box::new(check_expr.clone()),
+                source_text: Some("d > 0".to_string()),
+            }],
+        )];
+        let result = ConstraintValidator::process_constraints("t", &columns, &[]).unwrap();
+        assert_eq!(result.check_constraints[0].0, "d > 0");
+
+        // Unspaced source form is likewise preserved verbatim (SQLite echoes
+        // exactly what the user wrote).
+        let columns = vec![make_column_def(
+            "d",
+            vec![ColumnConstraintKind::Check {
+                expr: Box::new(check_expr.clone()),
+                source_text: Some("d>0".to_string()),
+            }],
+        )];
+        let result = ConstraintValidator::process_constraints("t", &columns, &[]).unwrap();
+        assert_eq!(result.check_constraints[0].0, "d>0");
+
+        // An explicit constraint name always wins over the source text.
+        let mut col = make_column_def("d", vec![]);
+        col.constraints.push(ColumnConstraint {
+            name: Some("chk_d".to_string()),
+            kind: ColumnConstraintKind::Check {
+                expr: Box::new(check_expr.clone()),
+                source_text: Some("d > 0".to_string()),
+            },
+        });
+        let result = ConstraintValidator::process_constraints("t", &[col], &[]).unwrap();
+        assert_eq!(result.check_constraints[0].0, "chk_d");
     }
 
     #[test]

--- a/crates/vibesql-executor/src/tests/create_table_constraints.rs
+++ b/crates/vibesql-executor/src/tests/create_table_constraints.rs
@@ -311,7 +311,10 @@ fn test_create_table_with_check_constraint() {
             nullable: false,
             constraints: vec![ColumnConstraint {
                 name: None,
-                kind: ColumnConstraintKind::Check(Box::new(check_expr.clone())),
+                kind: ColumnConstraintKind::Check {
+                    expr: Box::new(check_expr.clone()),
+                    source_text: None,
+                },
             }],
             default_value: None,
             comment: None,

--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -471,12 +471,22 @@ impl Parser {
                 }
                 Token::Keyword { keyword: Keyword::Check, .. } => {
                     self.advance(); // consume CHECK
+                    let lparen_pos = self.position;
                     self.expect_token(Token::LParen)?;
                     let expr = self.parse_expression()?;
+                    let rparen_pos = self.position;
                     self.expect_token(Token::RParen)?;
+                    // Preserve the verbatim CHECK expression text so the
+                    // "CHECK constraint failed: <expr>" message echoes the
+                    // original operator spacing (SQLite-compatible), not the
+                    // whitespace-stripped `expr.to_sql()` re-render.
+                    let source_text = self.source_inside_delimiters(lparen_pos, rparen_pos);
                     constraints.push(vibesql_ast::ColumnConstraint {
                         name,
-                        kind: vibesql_ast::ColumnConstraintKind::Check(Box::new(expr)),
+                        kind: vibesql_ast::ColumnConstraintKind::Check {
+                            expr: Box::new(expr),
+                            source_text,
+                        },
                     });
                 }
                 Token::Keyword { keyword: Keyword::References, .. } => {
@@ -700,10 +710,16 @@ impl Parser {
             }
             Token::Keyword { keyword: Keyword::Check, .. } => {
                 self.advance(); // consume CHECK
+                let lparen_pos = self.position;
                 self.expect_token(Token::LParen)?;
                 let expr = self.parse_expression()?;
+                let rparen_pos = self.position;
                 self.expect_token(Token::RParen)?;
-                vibesql_ast::TableConstraintKind::Check { expr: Box::new(expr) }
+                // Preserve the verbatim CHECK expression text (see the
+                // column-level CHECK arm) so the violation message echoes the
+                // original operator spacing.
+                let source_text = self.source_inside_delimiters(lparen_pos, rparen_pos);
+                vibesql_ast::TableConstraintKind::Check { expr: Box::new(expr), source_text }
             }
             Token::Keyword { keyword: Keyword::Fulltext, .. } => {
                 self.advance(); // consume FULLTEXT

--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -130,6 +130,28 @@ impl Parser {
         self.source.get(start_span.start..end_span.end).map(str::to_string)
     }
 
+    /// Return the verbatim source text that sits *between* the two delimiter
+    /// tokens at indices `open` and `close` (exclusive of both), trimmed of
+    /// leading and trailing ASCII whitespace but otherwise byte-for-byte from
+    /// the original source.
+    ///
+    /// This is used to recover a CHECK constraint expression's original
+    /// spelling from `CHECK ( <here> )`: SQLite echoes exactly these bytes
+    /// (interior spacing and comments preserved, outer whitespace trimmed) in
+    /// its "CHECK constraint failed: <expr>" message. Returns `None` when
+    /// span/source information is unavailable (parsers built via
+    /// [`Parser::new`]) or the delimiter indices are out of range.
+    pub(crate) fn source_inside_delimiters(&self, open: usize, close: usize) -> Option<String> {
+        if self.source.is_empty() || close <= open {
+            return None;
+        }
+        let open_span = self.spans.get(open)?;
+        let close_span = self.spans.get(close)?;
+        self.source
+            .get(open_span.end..close_span.start)
+            .map(|s| s.trim().to_string())
+    }
+
     /// Parse a comma-separated list of items using a provided parser function
     ///
     /// This is a generic helper that consolidates the common pattern of parsing

--- a/crates/vibesql-parser/src/tests/create_table/constraints_column.rs
+++ b/crates/vibesql-parser/src/tests/create_table/constraints_column.rs
@@ -63,7 +63,7 @@ fn test_parse_create_table_with_check_constraint() {
             assert!(matches!(
                 create.columns[0].constraints[0],
                 vibesql_ast::ColumnConstraint {
-                    kind: vibesql_ast::ColumnConstraintKind::Check(_),
+                    kind: vibesql_ast::ColumnConstraintKind::Check { .. },
                     ..
                 }
             ));
@@ -148,7 +148,7 @@ fn test_parse_create_table_with_multiple_constraints() {
             assert!(matches!(
                 create.columns[2].constraints[0],
                 vibesql_ast::ColumnConstraint {
-                    kind: vibesql_ast::ColumnConstraintKind::Check(_),
+                    kind: vibesql_ast::ColumnConstraintKind::Check { .. },
                     ..
                 }
             ));
@@ -585,7 +585,7 @@ fn test_parse_default_interleaved_with_constraints() {
             assert!(create.columns[0]
                 .constraints
                 .iter()
-                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::Check(_))));
+                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::Check { .. })));
         }
         _ => panic!("Expected CREATE TABLE statement"),
     }

--- a/crates/vibesql-parser/src/tests/create_table/typeless_columns.rs
+++ b/crates/vibesql-parser/src/tests/create_table/typeless_columns.rs
@@ -191,7 +191,7 @@ fn test_parse_create_table_typeless_with_check_constraint() {
             assert!(create.columns[0]
                 .constraints
                 .iter()
-                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::Check(_))));
+                .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::Check { .. })));
         }
         _ => panic!("Expected CREATE TABLE statement"),
     }

--- a/crates/vibesql-storage/src/persistence/binary/constraints.rs
+++ b/crates/vibesql-storage/src/persistence/binary/constraints.rs
@@ -218,17 +218,33 @@ pub(crate) fn rehydrate_constraints_from_sql_source(
     let mut check_constraints: Vec<(String, vibesql_ast::Expression)> = Vec::new();
     for col_def in &create.columns {
         for constraint in &col_def.constraints {
-            if let vibesql_ast::ColumnConstraintKind::Check(expr) = &constraint.kind {
+            if let vibesql_ast::ColumnConstraintKind::Check { expr, source_text } =
+                &constraint.kind
+            {
                 use vibesql_ast::pretty_print::ToSql;
-                let name = constraint.name.clone().unwrap_or_else(|| expr.to_sql());
+                // Prefer the explicit name, then the verbatim CHECK source
+                // text (preserves the original operator spacing that SQLite
+                // echoes in "CHECK constraint failed: <expr>"), falling back
+                // to the re-rendered expression only if no span was captured.
+                let name = constraint
+                    .name
+                    .clone()
+                    .or_else(|| source_text.clone())
+                    .unwrap_or_else(|| expr.to_sql());
                 check_constraints.push((name, (**expr).clone()));
             }
         }
     }
     for table_constraint in &create.table_constraints {
-        if let vibesql_ast::TableConstraintKind::Check { expr } = &table_constraint.kind {
+        if let vibesql_ast::TableConstraintKind::Check { expr, source_text } =
+            &table_constraint.kind
+        {
             use vibesql_ast::pretty_print::ToSql;
-            let name = table_constraint.name.clone().unwrap_or_else(|| expr.to_sql());
+            let name = table_constraint
+                .name
+                .clone()
+                .or_else(|| source_text.clone())
+                .unwrap_or_else(|| expr.to_sql());
             check_constraints.push((name, (**expr).clone()));
         }
     }
@@ -381,11 +397,31 @@ mod tests {
         rehydrate_constraints_from_sql_source(&mut schema, &HashMap::new()).unwrap();
 
         assert_eq!(schema.check_constraints.len(), 2);
-        // Unnamed column-level CHECK gets the expression's to_sql() text as
-        // its name (same derivation as ConstraintValidator at CREATE time).
-        assert_eq!(schema.check_constraints[0].0, "a>0");
+        // Unnamed column-level CHECK gets the verbatim CHECK source text as
+        // its name, preserving the original operator spacing (SQLite echoes
+        // exactly this in "CHECK constraint failed: a > 0"). Same derivation
+        // as ConstraintValidator at CREATE time.
+        assert_eq!(schema.check_constraints[0].0, "a > 0");
         // Named table-level CHECK keeps its explicit name.
         assert_eq!(schema.check_constraints[1].0, "b_pos");
+    }
+
+    #[test]
+    fn rehydrated_check_name_preserves_source_spacing() {
+        // Both spaced and unspaced CHECK forms round-trip verbatim through
+        // rehydration, matching SQLite's violation-message text byte-for-byte.
+        let mut spaced = schema_with_source(
+            "t",
+            vec![col("d")],
+            "CREATE TABLE t(d INTEGER, CHECK (d > 0))",
+        );
+        rehydrate_constraints_from_sql_source(&mut spaced, &HashMap::new()).unwrap();
+        assert_eq!(spaced.check_constraints[0].0, "d > 0");
+
+        let mut unspaced =
+            schema_with_source("t", vec![col("d")], "CREATE TABLE t(d INTEGER, CHECK(d>0))");
+        rehydrate_constraints_from_sql_source(&mut unspaced, &HashMap::new()).unwrap();
+        assert_eq!(unspaced.check_constraints[0].0, "d>0");
     }
 
     #[test]

--- a/crates/vibesql-storage/src/persistence/save.rs
+++ b/crates/vibesql-storage/src/persistence/save.rs
@@ -257,15 +257,24 @@ impl Database {
                 for (constraint_name, check_expr) in &schema.check_constraints {
                     use vibesql_ast::pretty_print::ToSql;
                     let expr_text = check_expr.to_sql();
-                    // Only output CONSTRAINT keyword if the name is different from expression
-                    // (i.e., it's a user-provided name)
-                    if constraint_name != &expr_text {
+                    // An unnamed CHECK's stored "name" is the verbatim source
+                    // text of its expression (whitespace preserved), so it
+                    // differs from `to_sql()` only by operator spacing (e.g.
+                    // `d > 0` vs `d>0`). Compare with all whitespace removed to
+                    // recognize that case; otherwise a spaced source form would
+                    // be misread as a user-provided name and emitted as a bogus
+                    // `CONSTRAINT d > 0` identifier.
+                    let strip_ws = |s: &str| s.split_whitespace().collect::<String>();
+                    if strip_ws(constraint_name) != strip_ws(&expr_text) {
+                        // User-provided name: emit it with the re-rendered expr.
                         write!(writer, ", CONSTRAINT {} CHECK ({})", constraint_name, expr_text)
                             .map_err(|e| {
                                 StorageError::NotImplemented(format!("Write error: {}", e))
                             })?;
                     } else {
-                        write!(writer, ", CHECK ({})", expr_text).map_err(|e| {
+                        // Unnamed: emit the verbatim source text so the reloaded
+                        // constraint's violation message round-trips byte-exact.
+                        write!(writer, ", CHECK ({})", constraint_name).map_err(|e| {
                             StorageError::NotImplemented(format!("Write error: {}", e))
                         })?;
                     }

--- a/crates/vibesql-storage/src/persistence/tests/sql_dump.rs
+++ b/crates/vibesql-storage/src/persistence/tests/sql_dump.rs
@@ -88,6 +88,88 @@ fn test_sql_dump_emits_verbatim_create_source() {
     std::fs::remove_file(path).ok();
 }
 
+/// Issue #5868: an unnamed CHECK constraint stores the verbatim source text of
+/// its expression as its "name" (preserving operator spacing, e.g. `d > 0`).
+/// When reconstructing DDL for a schema that has no verbatim `sql_source`, the
+/// dump must NOT mistake that spaced text for a user-provided constraint name
+/// and emit a bogus `CONSTRAINT d > 0` identifier; it must emit `CHECK (d > 0)`
+/// verbatim so the constraint round-trips.
+#[test]
+fn test_sql_dump_unnamed_check_preserves_source_spacing() {
+    use vibesql_ast::{BinaryOperator, ColumnIdentifier, Expression};
+
+    let check_expr = Expression::BinaryOp {
+        left: Box::new(Expression::ColumnRef(ColumnIdentifier::simple("d", false))),
+        op: BinaryOperator::GreaterThan,
+        right: Box::new(Expression::Literal(SqlValue::Integer(0))),
+    };
+
+    let mut db = Database::new();
+    let mut schema =
+        TableSchema::new("t".to_string(), vec![ColumnSchema::new(
+            "d".to_string(),
+            DataType::Integer,
+            true,
+        )]);
+    // No sql_source → the dump reconstructs the CREATE TABLE from fields,
+    // exercising the CHECK reconstruction branch in save.rs. The stored name
+    // is the verbatim (spaced) source text of the unnamed CHECK.
+    schema.check_constraints = vec![("d > 0".to_string(), check_expr.clone())];
+    db.create_table(schema).unwrap();
+
+    let path = "/tmp/test_db_5868_unnamed_check.sql";
+    db.save_sql_dump(path).unwrap();
+    let content = std::fs::read_to_string(path).unwrap();
+
+    assert!(
+        content.contains("CHECK (d > 0)"),
+        "unnamed CHECK must be emitted verbatim, got:\n{}",
+        content
+    );
+    assert!(
+        !content.contains("CONSTRAINT d > 0"),
+        "spaced source text must not be emitted as a bogus constraint name, got:\n{}",
+        content
+    );
+
+    std::fs::remove_file(path).ok();
+}
+
+/// A genuinely named CHECK must still emit its `CONSTRAINT <name> CHECK (...)`
+/// form in the reconstructed dump (issue #5868 regression guard).
+#[test]
+fn test_sql_dump_named_check_keeps_constraint_name() {
+    use vibesql_ast::{BinaryOperator, ColumnIdentifier, Expression};
+
+    let check_expr = Expression::BinaryOp {
+        left: Box::new(Expression::ColumnRef(ColumnIdentifier::simple("d", false))),
+        op: BinaryOperator::GreaterThan,
+        right: Box::new(Expression::Literal(SqlValue::Integer(0))),
+    };
+
+    let mut db = Database::new();
+    let mut schema =
+        TableSchema::new("t".to_string(), vec![ColumnSchema::new(
+            "d".to_string(),
+            DataType::Integer,
+            true,
+        )]);
+    schema.check_constraints = vec![("chk_d".to_string(), check_expr)];
+    db.create_table(schema).unwrap();
+
+    let path = "/tmp/test_db_5868_named_check.sql";
+    db.save_sql_dump(path).unwrap();
+    let content = std::fs::read_to_string(path).unwrap();
+
+    assert!(
+        content.contains("CONSTRAINT chk_d CHECK"),
+        "named CHECK must keep its constraint name, got:\n{}",
+        content
+    );
+
+    std::fs::remove_file(path).ok();
+}
+
 #[test]
 fn test_sql_value_to_literal() {
     use crate::persistence::save::sql_value_to_literal;

--- a/crates/vibesql-storage/src/wal/recovery.rs
+++ b/crates/vibesql-storage/src/wal/recovery.rs
@@ -2353,9 +2353,10 @@ mod tests {
         // rowids, and the alias makes `WHERE rowid=N` resolve through `id`).
         assert_eq!(child.rowid_alias_column, Some(0), "IPK rowid alias must be rebuilt");
 
-        // CHECK constraint survives.
+        // CHECK constraint survives, with its name preserving the original
+        // source spacing (`CHECK(z > 0)` → `z > 0`, SQLite-compatible).
         assert_eq!(child.check_constraints.len(), 1, "CHECK must be rehydrated");
-        assert_eq!(child.check_constraints[0].0, "z>0");
+        assert_eq!(child.check_constraints[0].0, "z > 0");
 
         // FK survives with its action and resolved parent columns (the
         // parent's CreateTable precedes the child's in the WAL).


### PR DESCRIPTION
## Summary

Closes #5868.

An unnamed CHECK constraint's violation message (`CHECK constraint failed: <expr>`) was re-rendering the parsed AST via `expr.to_sql()`, which strips whitespace around binary operators. VibeSQL emitted `d>0` where sqlite3 emits the original source text `d > 0`.

## Approach chosen: source-text capture (curator Option B/C), NOT Option A

Verified against sqlite3 that it preserves the **verbatim source bytes** of the CHECK expression, not a single canonical spacing:

| Source | sqlite3 message | VibeSQL (after) |
|--------|-----------------|-----------------|
| `CHECK (d > 0)` | `d > 0` | `d > 0` |
| `CHECK(d>0)` | `d>0` | `d>0` |
| `CHECK(d  >  0)` | `d  >  0` | `d  >  0` |
| `CHECK ( d > 0 )` | `d > 0` (outer trimmed) | `d > 0` |
| `CONSTRAINT chk_d CHECK (d > 0)` | `chk_d` | `chk_d` |
| table-level `CHECK (a + b > 0)` | `a + b > 0` | `a + b > 0` |

Because sqlite preserves the exact user bytes, **Option A** (adding single spaces in `pretty_print.rs` `to_sql`) could never match both `d > 0` and `d>0`, and would have changed every `to_sql` rendering (schema-text blast radius: `sqlite_master.sql`, catalog round-trips, TCL schema-text assertions). Option A was rejected. The chosen fix leaves `to_sql` untouched.

### Implementation
- New AST field `source_text: Option<String>` on `ColumnConstraintKind::Check` and `TableConstraintKind::Check`.
- Parser captures the verbatim slice between the CHECK parentheses (interior whitespace + comments preserved, outer trimmed) via a new `Parser::source_inside_delimiters` helper built on existing span tracking.
- Both the live `ConstraintValidator` path and the binary-catalog reload path (`rehydrate_constraints_from_sql_source`) prefer `source_text` over `expr.to_sql()` for the unnamed-constraint name. Reload re-parses the persisted `sql_source` through the same parser, so the message round-trips byte-exact across a restart.
- SQL-dump reconstruction previously detected "unnamed" via `name == to_sql()`; that heuristic now compares with whitespace removed and re-emits the verbatim text, so a spaced source form is not mistaken for a `CONSTRAINT` identifier.

The arena parser AST is a separate type and is not touched (DDL constraint rehydration does not use it).

## Evidence

- **End-to-end** (release binary) matches sqlite3 byte-exact for all forms above, including the issue's `ON CONFLICT ... DO UPDATE` reproducer.
- **Persistence round-trip**: file-backed `\save` + reload preserves both `d > 0` and `d>0`.
- **TCL `check.test`**: 61 → 63 passing (`check-12.31`/`check-12.32` `NOT(a=+a)` now match), **zero regressions** (diffed failing-test lists against the same main commit `66b888980`).
- **Unit tests added**: spacing preservation + named-wins in `constraint_validator`, spaced/unspaced rehydration in `binary/constraints`, and SQL-dump verbatim/named guards in `sql_dump`.
- Full lib suites green: ast (85), parser (1706), executor (3164), storage (789); executor integration tests 0 failed.

## Test plan
- [x] `INSERT` violating `CHECK (d > 0)` emits `d > 0` (with spaces)
- [x] `CHECK(d>0)` emits `d>0` (unspaced preserved)
- [x] Named constraint still uses its name
- [x] Table-level CHECK preserved
- [x] Consistent first-run vs after reload from binary catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)