### PR TITLE
fix(ddl): rebind child foreign keys on ALTER TABLE RENAME TO (fkey2-14.2*)

### DIFF
--- a/crates/vibesql-executor/src/alter/table_options.rs
+++ b/crates/vibesql-executor/src/alter/table_options.rs
@@ -96,6 +96,17 @@ pub(super) fn execute_rename_table(
     // `sqlite_master.sql` text consistent. See `crate::trigger_rename`.
     rewrite_triggers_for_rename(database, &stmt.table_name, &stmt.new_table_name);
 
+    // Re-bind every child table's foreign key that referenced the old parent
+    // name, and rewrite its verbatim REFERENCES text. SQLite
+    // (legacy_alter_table=OFF) rewrites both the child's in-memory FK target and
+    // the stored `sqlite_master.sql` REFERENCES clause so cascade enforcement
+    // survives the rename. Without this, `fk.parent_table` keeps pointing at the
+    // now-nonexistent old name (silently severing enforcement) and a reload would
+    // resurrect the stale binding from the un-rewritten sql_source. Runs after
+    // the drop+create above, so the renamed table already exists under its new
+    // name — self-referential FKs on it are picked up by the same loop.
+    rebind_child_foreign_keys(database, &stmt.table_name, &stmt.new_table_name);
+
     // Invalidate the database-level columnar cache for both old and new table names.
     // The old table name's cache is invalidated since the table no longer exists,
     // and the new table name's cache is invalidated to ensure fresh columnar data.
@@ -103,6 +114,53 @@ pub(super) fn execute_rename_table(
     database.invalidate_columnar_cache(&stmt.new_table_name);
 
     Ok(format!("Table '{}' renamed to '{}'", stmt.table_name, stmt.new_table_name))
+}
+
+/// Re-bind foreign keys that referenced a just-renamed parent table.
+///
+/// For every table in the database, any `ForeignKeyConstraint` whose
+/// `parent_table` matches `old_name` (case-insensitively) is repointed to
+/// `new_name`, and the table's verbatim `sql_source` `REFERENCES <old_name>`
+/// text is rewritten to `REFERENCES "<new_name>"` so `sqlite_master.sql` and any
+/// future reload (which rehydrates constraints from `sql_source`) stay
+/// consistent. Mirrors SQLite's `sqlite_rename_parent` under
+/// `legacy_alter_table=OFF`.
+///
+/// The storage `Table` schema is the mutation target; the catalog copy is then
+/// re-synced from it (matching the `sync_catalog_schema_from_storage` pattern in
+/// `alter/mod.rs`). If the `REFERENCES` text cannot be rewritten cleanly, the
+/// stale `sql_source` is invalidated so it is reconstructed from the (already
+/// re-bound) schema on next serialization — never left pointing at the old name.
+fn rebind_child_foreign_keys(database: &mut Database, old_name: &str, new_name: &str) {
+    for tbl in database.list_tables() {
+        // Mutate the storage copy in place, returning the updated schema to sync
+        // into the catalog. The `continue` short-circuits tables with no matching
+        // FK so untouched tables are neither cloned nor re-inserted.
+        let updated_schema = {
+            let Some(table) = database.get_table_mut(&tbl) else {
+                continue;
+            };
+            let mut changed = false;
+            for fk in table.schema_mut().foreign_keys.iter_mut() {
+                if fk.parent_table.eq_ignore_ascii_case(old_name) {
+                    fk.parent_table = new_name.to_string();
+                    changed = true;
+                }
+            }
+            if !changed {
+                continue;
+            }
+            let rewritten = table.schema.sql_source.as_deref().and_then(|sql| {
+                crate::alter_rewrite::rename_references_parent(sql, old_name, new_name)
+            });
+            match rewritten {
+                Some(text) => table.schema_mut().set_sql_source(text),
+                None => table.schema_mut().invalidate_sql_source(),
+            }
+            table.schema.clone()
+        };
+        database.catalog.replace_table_schema(&tbl, updated_schema);
+    }
 }
 
 /// Rewrite all trigger definitions in the catalog that reference `old_name`,

--- a/crates/vibesql-executor/src/alter_rewrite.rs
+++ b/crates/vibesql-executor/src/alter_rewrite.rs
@@ -166,6 +166,58 @@ fn table_name_index(tokens: &[(Token, Span)]) -> Option<usize> {
     Some(i)
 }
 
+/// Rewrite every `REFERENCES <old_parent>` clause in the verbatim `CREATE TABLE`
+/// text of a *child* table to `REFERENCES "<new_parent>"`, matching SQLite's
+/// `sqlite_rename_parent` (invoked when the referenced parent table is renamed
+/// via `ALTER TABLE ... RENAME TO`, with `legacy_alter_table=OFF`).
+///
+/// Only the parent-table identifier that immediately follows a `REFERENCES`
+/// keyword is considered, so a bare `p` appearing elsewhere (inside a string
+/// literal, a column name, or an identifier that merely contains `p` as a
+/// substring) is never touched. Quote-awareness is inherited from the lexer,
+/// which normalizes `"p"`, `` `p` ``, and `[p]` all to a delimited-identifier
+/// token and emits string literals as a distinct token kind — so all quoted
+/// spellings of the parent match while string-literal look-alikes do not.
+///
+/// The replacement is emitted double-quoted (`"<new_parent>"`) to mirror
+/// SQLite's output style for renamed objects. Handles multiple matching FKs in a
+/// single `CREATE TABLE` (e.g. two columns each `REFERENCES p`). Returns `None`
+/// when no `REFERENCES <old_parent>` clause is present (the caller then
+/// invalidates and reconstructs), keeping the re-parseable-on-reload invariant.
+pub fn rename_references_parent(
+    create_sql: &str,
+    old_parent: &str,
+    new_parent: &str,
+) -> Option<String> {
+    let tokens = tokenize(create_sql)?;
+    let replacement = quote_ident(new_parent);
+
+    // Collect the byte spans of every parent-table identifier that immediately
+    // follows a `REFERENCES` keyword and matches `old_parent` (case-insensitively
+    // for bare and delimited identifiers, mirroring SQLite's name folding).
+    let mut spans: Vec<Span> = Vec::new();
+    for (i, (tok, _)) in tokens.iter().enumerate() {
+        if !matches!(tok, Token::Keyword { keyword: Keyword::References, .. }) {
+            continue;
+        }
+        if let Some((next_tok, next_span)) = tokens.get(i + 1) {
+            if ident_matches(next_tok, old_parent) {
+                spans.push(*next_span);
+            }
+        }
+    }
+    if spans.is_empty() {
+        return None;
+    }
+
+    // Replace from the last span backward so earlier byte offsets stay valid.
+    let mut out = create_sql.to_string();
+    for span in spans.iter().rev() {
+        out.replace_range(span.start..span.end, &replacement);
+    }
+    Some(out)
+}
+
 /// Rewrite a column name in its *definition position* within the verbatim
 /// `CREATE TABLE` text, matching SQLite's `ALTER TABLE ... RENAME COLUMN`.
 ///
@@ -458,6 +510,100 @@ mod tests {
         let sql = "CREATE TABLE IF NOT EXISTS t (x int)";
         let out = rename_table(sql, "t2").unwrap();
         assert_eq!(out, "CREATE TABLE IF NOT EXISTS \"t2\" (x int)");
+    }
+
+    // rename_references_parent — quote-aware child REFERENCES rewriter.
+
+    #[test]
+    fn rename_references_parent_bare_name() {
+        let sql = "CREATE TABLE c(x REFERENCES p(id) ON DELETE CASCADE)";
+        let out = rename_references_parent(sql, "p", "p_new").unwrap();
+        assert_eq!(out, "CREATE TABLE c(x REFERENCES \"p_new\"(id) ON DELETE CASCADE)");
+    }
+
+    #[test]
+    fn rename_references_parent_table_constraint_form() {
+        let sql = "CREATE TABLE c(x, FOREIGN KEY(x) REFERENCES p(id))";
+        let out = rename_references_parent(sql, "p", "p_new").unwrap();
+        assert_eq!(out, "CREATE TABLE c(x, FOREIGN KEY(x) REFERENCES \"p_new\"(id))");
+    }
+
+    #[test]
+    fn rename_references_parent_double_quoted_old_name() {
+        let sql = "CREATE TABLE c(x REFERENCES \"p\"(id))";
+        let out = rename_references_parent(sql, "p", "p_new").unwrap();
+        assert_eq!(out, "CREATE TABLE c(x REFERENCES \"p_new\"(id))");
+    }
+
+    #[test]
+    fn rename_references_parent_bracket_quoted_old_name() {
+        let sql = "CREATE TABLE c(x REFERENCES [p](id))";
+        let out = rename_references_parent(sql, "p", "p_new").unwrap();
+        assert_eq!(out, "CREATE TABLE c(x REFERENCES \"p_new\"(id))");
+    }
+
+    #[test]
+    fn rename_references_parent_backtick_quoted_old_name() {
+        let sql = "CREATE TABLE c(x REFERENCES `p`(id))";
+        let out = rename_references_parent(sql, "p", "p_new").unwrap();
+        assert_eq!(out, "CREATE TABLE c(x REFERENCES \"p_new\"(id))");
+    }
+
+    #[test]
+    fn rename_references_parent_case_insensitive() {
+        let sql = "CREATE TABLE c(x REFERENCES P(id))";
+        let out = rename_references_parent(sql, "p", "p_new").unwrap();
+        assert_eq!(out, "CREATE TABLE c(x REFERENCES \"p_new\"(id))");
+    }
+
+    #[test]
+    fn rename_references_parent_multiple_fks() {
+        let sql = "CREATE TABLE c(a REFERENCES p(id), b REFERENCES p(id))";
+        let out = rename_references_parent(sql, "p", "p_new").unwrap();
+        assert_eq!(out, "CREATE TABLE c(a REFERENCES \"p_new\"(id), b REFERENCES \"p_new\"(id))");
+    }
+
+    #[test]
+    fn rename_references_parent_self_referential() {
+        // After the header has already been rewritten to the new name, the inline
+        // self-reference still names the old table and must be rewritten too.
+        let sql = "CREATE TABLE \"p_new\"(id INTEGER PRIMARY KEY, pid REFERENCES p(id))";
+        let out = rename_references_parent(sql, "p", "p_new").unwrap();
+        assert_eq!(
+            out,
+            "CREATE TABLE \"p_new\"(id INTEGER PRIMARY KEY, pid REFERENCES \"p_new\"(id))"
+        );
+    }
+
+    #[test]
+    fn rename_references_parent_ignores_string_literal_lookalike() {
+        // A bare `p` inside a string literal default must not be rewritten.
+        let sql = "CREATE TABLE c(note TEXT DEFAULT 'see p for details', x REFERENCES p(id))";
+        let out = rename_references_parent(sql, "p", "p_new").unwrap();
+        assert_eq!(
+            out,
+            "CREATE TABLE c(note TEXT DEFAULT 'see p for details', x REFERENCES \"p_new\"(id))"
+        );
+    }
+
+    #[test]
+    fn rename_references_parent_ignores_substring_identifier() {
+        // `parent` merely contains `p`; only the exact REFERENCES target changes.
+        let sql = "CREATE TABLE c(parent TEXT, x REFERENCES p(id))";
+        let out = rename_references_parent(sql, "p", "p_new").unwrap();
+        assert_eq!(out, "CREATE TABLE c(parent TEXT, x REFERENCES \"p_new\"(id))");
+    }
+
+    #[test]
+    fn rename_references_parent_no_match_returns_none() {
+        let sql = "CREATE TABLE c(x REFERENCES other(id))";
+        assert!(rename_references_parent(sql, "p", "p_new").is_none());
+    }
+
+    #[test]
+    fn rename_references_parent_no_references_returns_none() {
+        let sql = "CREATE TABLE c(x INTEGER, y TEXT)";
+        assert!(rename_references_parent(sql, "p", "p_new").is_none());
     }
 
     #[test]

--- a/crates/vibesql-executor/tests/alter_rename_fk_rebind_tests.rs
+++ b/crates/vibesql-executor/tests/alter_rename_fk_rebind_tests.rs
@@ -1,0 +1,233 @@
+//! End-to-end regression tests for issue #5873: `ALTER TABLE <parent> RENAME TO
+//! <new>` must re-bind every child table's foreign key that referenced the old
+//! parent name — both the in-memory `ForeignKeyConstraint::parent_table` and the
+//! verbatim `sqlite_master.sql` `REFERENCES` clause — so cascade enforcement
+//! survives the rename and a save/reload round-trip.
+//!
+//! Before the fix, `execute_rename_table` rewrote only the renamed table's own
+//! `sql_source` and its trigger metadata; every child's FK kept pointing at the
+//! now-nonexistent old name, silently severing enforcement, and a reload (which
+//! rehydrates constraints from `sql_source`, see #5834/#5895) would resurrect the
+//! stale binding from the un-rewritten `REFERENCES` text.
+
+use vibesql_ast::Statement;
+use vibesql_executor::{
+    AlterTableExecutor, CreateTableExecutor, DeleteExecutor, InsertExecutor, SelectExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+/// Create a table preserving the verbatim source text (issue #5619). `sql_source`
+/// is what the reload path re-parses, so tests must go through this entry point.
+fn create_with_source(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse CREATE");
+    let Statement::CreateTable(create) = stmt else {
+        panic!("expected CREATE TABLE");
+    };
+    CreateTableExecutor::execute_with_source(&create, db, Some(sql)).expect("CREATE TABLE");
+}
+
+/// Run an ALTER, passing the verbatim statement text (the path the CLI uses).
+fn alter(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse ALTER");
+    let Statement::AlterTable(a) = stmt else {
+        panic!("expected ALTER TABLE");
+    };
+    AlterTableExecutor::execute_with_source(&a, db, Some(sql)).expect("ALTER TABLE");
+}
+
+/// Execute a DML statement, returning Ok(()) or the error's Display text.
+fn exec(db: &mut Database, sql: &str) -> Result<(), String> {
+    let stmt = Parser::parse_sql(sql).map_err(|e| format!("parse error: {e:?}"))?;
+    match stmt {
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).map(|_| ()).map_err(|e| e.to_string())
+        }
+        Statement::Delete(s) => {
+            DeleteExecutor::execute(&s, db).map(|_| ()).map_err(|e| e.to_string())
+        }
+        other => panic!("unsupported statement in test: {other:?}"),
+    }
+}
+
+/// COUNT(*) helper.
+fn count(db: &Database, table: &str) -> i64 {
+    let sql = format!("SELECT COUNT(*) FROM {table}");
+    let stmt = Parser::parse_sql(&sql).expect("parse SELECT");
+    let Statement::Select(select) = stmt else {
+        panic!("expected SELECT");
+    };
+    let result = SelectExecutor::new(db).execute_with_columns(&select).expect("SELECT");
+    match &result.rows[0].values[0] {
+        vibesql_types::SqlValue::Integer(n) => *n,
+        vibesql_types::SqlValue::Bigint(n) => *n,
+        other => panic!("unexpected COUNT value: {other:?}"),
+    }
+}
+
+/// Return the single `sql` text for the named table from `sqlite_master`.
+fn table_sql(db: &Database, table: &str) -> String {
+    let query =
+        format!("SELECT sql FROM sqlite_master WHERE type='table' AND name='{table}'");
+    let stmt = Parser::parse_sql(&query).expect("parse SELECT");
+    let Statement::Select(select) = stmt else {
+        panic!("expected SELECT");
+    };
+    let result = SelectExecutor::new(db).execute_with_columns(&select).expect("SELECT");
+    assert_eq!(result.rows.len(), 1, "expected one row for table {table}");
+    match &result.rows[0].values[0] {
+        vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
+            s.to_string()
+        }
+        other => panic!("expected text, got {other:?}"),
+    }
+}
+
+/// Save to a binary `.vbsql` file and reload — the cross-process reopen path.
+/// Re-enables FK enforcement on the reloaded handle, mirroring the TCL shim's
+/// per-invocation `PRAGMA foreign_keys=ON` replay (per-connection state).
+fn reopen_binary(db: &Database, tag: &str) -> Database {
+    let path =
+        std::env::temp_dir().join(format!("vibesql_5873_{tag}_{}.vbsql", std::process::id()));
+    db.save_binary(&path).expect("save_binary");
+    let mut reloaded = Database::load_binary(&path).expect("load_binary");
+    std::fs::remove_file(&path).ok();
+    reloaded.set_foreign_keys_enabled(true);
+    reloaded
+}
+
+#[test]
+fn rename_parent_rebinds_child_fk_metadata_and_sql_source() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    create_with_source(&mut db, "CREATE TABLE p(id INTEGER PRIMARY KEY)");
+    create_with_source(&mut db, "CREATE TABLE c(x REFERENCES p(id) ON DELETE CASCADE)");
+
+    alter(&mut db, "ALTER TABLE p RENAME TO p_new");
+
+    // In-memory FK metadata (what PRAGMA foreign_key_list reads) now points at
+    // the new name, in both the storage and catalog copies of the schema.
+    let schema = db.catalog.get_table("c").expect("c exists");
+    assert_eq!(schema.foreign_keys.len(), 1);
+    assert_eq!(
+        schema.foreign_keys[0].parent_table, "p_new",
+        "child FK parent_table must follow the rename"
+    );
+
+    // Verbatim sqlite_master.sql REFERENCES clause is rewritten to the
+    // double-quoted new name, matching sqlite3.
+    assert_eq!(
+        table_sql(&db, "c"),
+        "CREATE TABLE c(x REFERENCES \"p_new\"(id) ON DELETE CASCADE)"
+    );
+}
+
+#[test]
+fn rename_parent_cascade_fires_in_process() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    create_with_source(&mut db, "CREATE TABLE p(id INTEGER PRIMARY KEY)");
+    create_with_source(&mut db, "CREATE TABLE c(x REFERENCES p(id) ON DELETE CASCADE)");
+    exec(&mut db, "INSERT INTO p VALUES(1)").unwrap();
+    exec(&mut db, "INSERT INTO c VALUES(1)").unwrap();
+
+    alter(&mut db, "ALTER TABLE p RENAME TO p_new");
+
+    // Deleting the parent under its new name must cascade into the child; the
+    // pre-fix behavior left an orphan row (cascade lost, no error).
+    exec(&mut db, "DELETE FROM p_new WHERE id = 1").expect("parent delete");
+    assert_eq!(count(&db, "c"), 0, "ON DELETE CASCADE must fire after rename");
+}
+
+#[test]
+fn rename_parent_survives_binary_reload_and_cascades() {
+    // The reload path rehydrates FK constraints from sql_source; a stale
+    // REFERENCES text would resurrect the old binding. Verify the rewritten text
+    // round-trips and enforcement still fires in a fresh handle.
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    create_with_source(&mut db, "CREATE TABLE p(id INTEGER PRIMARY KEY)");
+    create_with_source(&mut db, "CREATE TABLE c(x REFERENCES p(id) ON DELETE CASCADE)");
+    exec(&mut db, "INSERT INTO p VALUES(1)").unwrap();
+    exec(&mut db, "INSERT INTO c VALUES(1)").unwrap();
+
+    alter(&mut db, "ALTER TABLE p RENAME TO p_new");
+
+    let mut db2 = reopen_binary(&db, "reload_cascade");
+
+    let schema = db2.catalog.get_table("c").expect("c exists after reload");
+    assert_eq!(
+        schema.foreign_keys[0].parent_table, "p_new",
+        "rehydrated FK must bind to the new parent name, not the stale old one"
+    );
+    assert_eq!(
+        table_sql(&db2, "c"),
+        "CREATE TABLE c(x REFERENCES \"p_new\"(id) ON DELETE CASCADE)"
+    );
+
+    exec(&mut db2, "DELETE FROM p_new WHERE id = 1").expect("parent delete after reopen");
+    assert_eq!(count(&db2, "c"), 0, "cascade must fire after rename + reopen");
+}
+
+#[test]
+fn rename_parent_rebinds_multiple_children() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    create_with_source(&mut db, "CREATE TABLE p(id INTEGER PRIMARY KEY)");
+    create_with_source(&mut db, "CREATE TABLE c1(x REFERENCES p(id))");
+    create_with_source(&mut db, "CREATE TABLE c2(y REFERENCES p(id))");
+
+    alter(&mut db, "ALTER TABLE p RENAME TO p_new");
+
+    for child in ["c1", "c2"] {
+        let schema = db.catalog.get_table(child).expect("child exists");
+        assert_eq!(
+            schema.foreign_keys[0].parent_table, "p_new",
+            "child {child} must be re-bound to the renamed parent"
+        );
+    }
+}
+
+#[test]
+fn rename_parent_rebinds_two_fks_in_one_child() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    create_with_source(&mut db, "CREATE TABLE p(id INTEGER PRIMARY KEY)");
+    create_with_source(&mut db, "CREATE TABLE c(a REFERENCES p(id), b REFERENCES p(id))");
+
+    alter(&mut db, "ALTER TABLE p RENAME TO p_new");
+
+    let schema = db.catalog.get_table("c").expect("c exists");
+    assert_eq!(schema.foreign_keys.len(), 2);
+    assert!(
+        schema.foreign_keys.iter().all(|fk| fk.parent_table == "p_new"),
+        "both FKs in the child must be re-bound"
+    );
+    assert_eq!(
+        table_sql(&db, "c"),
+        "CREATE TABLE c(a REFERENCES \"p_new\"(id), b REFERENCES \"p_new\"(id))"
+    );
+}
+
+#[test]
+fn rename_self_referential_fk_follows_rename() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    create_with_source(
+        &mut db,
+        "CREATE TABLE p(id INTEGER PRIMARY KEY, pid REFERENCES p(id))",
+    );
+
+    alter(&mut db, "ALTER TABLE p RENAME TO p_new");
+
+    // The renamed table's own self-referential FK must point at the new name,
+    // and its verbatim REFERENCES clause must be rewritten (the header was
+    // already rewritten by the table-name rename; the inline reference was not).
+    let schema = db.catalog.get_table("p_new").expect("p_new exists");
+    assert_eq!(schema.foreign_keys.len(), 1);
+    assert_eq!(schema.foreign_keys[0].parent_table, "p_new");
+    assert_eq!(
+        table_sql(&db, "p_new"),
+        "CREATE TABLE \"p_new\"(id INTEGER PRIMARY KEY, pid REFERENCES \"p_new\"(id))"
+    );
+}


### PR DESCRIPTION
## Summary

`ALTER TABLE <parent> RENAME TO <new>` updated the renamed table's own `sql_source` and trigger metadata but never touched sibling tables. Every child's `ForeignKeyConstraint::parent_table` kept the old name and its verbatim `REFERENCES` clause was never rewritten — silently severing cascade/RESTRICT enforcement (orphans, no error). Because constraints rehydrate from `sql_source` on reload (#5834/#5895), a stale `REFERENCES` text also resurrected the old binding after restart.

This PR fixes both, mirroring SQLite's `sqlite_rename_parent` (`legacy_alter_table=OFF`).

## Changes

**1. Metadata rebind loop** (`alter/table_options.rs`) — after trigger propagation, `execute_rename_table` iterates all tables; any FK whose `parent_table` matches the old name (case-insensitively) is repointed to the new name in the storage schema, then re-synced into the catalog copy (the `sync_catalog_schema_from_storage` pattern). Self-referential FKs on the renamed table are covered because it already exists under the new name at that point.

**2. Quote-aware rewriter** (`alter_rewrite.rs`) — new `rename_references_parent(sql, old, new) -> Option<String>` rewrites each affected child's `sql_source` `REFERENCES <old>` to `REFERENCES "<new>"` (double-quoted, matching sqlite3 output). It reuses the parser lexer, so all quoted spellings (`"p"`, `[p]`, `` `p` ``) match while string-literal look-alikes and substring identifiers do **not**. Falls back to invalidate-and-reconstruct when the text can't be rewritten cleanly.

## Reproducer (now matches sqlite3)

```
ALTER TABLE p RENAME TO p_new;
-- sqlite_master.sql for child c: CREATE TABLE c(x REFERENCES "p_new"(id) ON DELETE CASCADE)
-- PRAGMA foreign_key_list(c) -> p_new
DELETE FROM p_new WHERE id=1;  -- cascades: count(c)=0, no orphan
```
Verified byte-for-byte against the `fkey2-14.2.2.2` fixture (three tables incl. self-ref), and across a `.vbsql` save/reload.

## Test results

- `make test-tcl-file FILE=fkey2.test`: **863→867 passed**; the `14.2.2` enforcement cluster recovered — baseline failed `14.2.2.2/.3/.5/.6/.7`, now only `14.2.2.2` remains and **only on `sqlite_master` row ordering** (a pre-existing drop+create artifact, content is correct). Overall `14.2.*`: 46→38. Remaining `14.2.*` failures are the separate `sqlite_rename_table` internal-function and temp/attached-db gaps (out of scope). Both runs carry an `incomplete` marker (loaded machine), so absolute counts are indicative, not clean-baseline comparable.
- `make test-tcl-file FILE=fkey1.test`: **18→19/26** (no regression).
- New: 12 unit tests (`rename_references_parent` — quoted forms, multi-FK, self-ref, string-literal/substring false-positive guards) + 6 integration tests (`alter_rename_fk_rebind_tests.rs`: metadata + sql_source rebind, in-process cascade, binary reload round-trip, multi-child, two-FK-in-one-child, self-referential).
- Regression suites green: `alter_inplace_reload_tests`, `constraint_rehydration_reload_tests`, `foreign_key_tests`, `sqlite_schema_tests`, `alter_table_columnar_cache_tests`, executor lib `alter` tests.

Closes #5873

🤖 Generated with [Claude Code](https://claude.com/claude-code)