### PR TITLE
fix(conformance): don't burn autoindex ordinal on WITHOUT ROWID PK (#5882)

### DIFF
--- a/crates/vibesql-catalog/src/lib.rs
+++ b/crates/vibesql-catalog/src/lib.rs
@@ -12,6 +12,19 @@ pub const DEFAULT_SCHEMA: &str = "main";
 /// Temp tables are not persisted and have session scope.
 pub const TEMP_SCHEMA: &str = "temp";
 
+/// Name prefix for the internal unique index materialized for a WITHOUT ROWID
+/// table's PRIMARY KEY.
+///
+/// In SQLite the PRIMARY KEY of a WITHOUT ROWID table *is* the table B-tree and
+/// gets no separate `sqlite_autoindex_*` entry, so a `UNIQUE` constraint on the
+/// same table is the first real index and is named `sqlite_autoindex_<t>_1`.
+/// VibeSQL still materializes a real unique index to enforce/plan the PK, but
+/// names it `<prefix><table>` — outside the `sqlite_autoindex_` namespace — so
+/// it neither consumes an autoindex ordinal nor surfaces in `sqlite_master`.
+/// The index is regenerated from DDL on reload, so persistence layers skip it
+/// on save (see issue #5882).
+pub const WITHOUT_ROWID_PK_INDEX_PREFIX: &str = "_withoutrowidinternalpk_";
+
 mod advanced_objects;
 mod column;
 mod domain;

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -674,8 +674,18 @@ impl CreateTableExecutor {
         // and doesn't need a separate B-tree index (matches SQLite behavior)
         if let Some(pk_cols) = &table_schema.primary_key {
             if table_schema.rowid_alias_column.is_none() {
-                let index_name = format!("sqlite_autoindex_{}_{}", table_name, autoindex_counter);
-                autoindex_counter += 1;
+                // WITHOUT ROWID tables: the PK *is* the table B-tree in SQLite and
+                // gets no `sqlite_autoindex_*` slot. We still materialize a real
+                // unique index to enforce/plan the PK, but give it an internal name
+                // outside the autoindex namespace and do NOT consume an ordinal, so
+                // UNIQUE constraints on the same table start at `_1` (issue #5882).
+                let index_name = if table_schema.without_rowid {
+                    format!("{}{}", vibesql_catalog::WITHOUT_ROWID_PK_INDEX_PREFIX, table_name)
+                } else {
+                    let name = format!("sqlite_autoindex_{}_{}", table_name, autoindex_counter);
+                    autoindex_counter += 1;
+                    name
+                };
 
                 // Create IndexColumn specs for the PRIMARY KEY columns
                 let index_columns: Vec<IndexColumn> = pk_cols

--- a/crates/vibesql-executor/src/select/executor/fast_path/pk_lookup.rs
+++ b/crates/vibesql-executor/src/select/executor/fast_path/pk_lookup.rs
@@ -235,9 +235,16 @@ impl SelectExecutor<'_> {
 
         let is_desc = order_by[0].direction == vibesql_ast::OrderDirection::Desc;
 
-        // Get PK index from database's index infrastructure (sqlite_autoindex_{table_name}_1)
-        // Primary key index is always the first auto-index created
-        let pk_index_name = format!("sqlite_autoindex_{}_1", table_name);
+        // Get PK index from database's index infrastructure. For a rowid table the
+        // PK is the first auto-index (`sqlite_autoindex_{table}_1`); for a WITHOUT
+        // ROWID table the PK index is materialized under an internal name outside
+        // the autoindex namespace so it does not consume an ordinal (issue #5882).
+        // Selecting the right name here keeps the fast path engaged for both.
+        let pk_index_name = if table.schema.without_rowid {
+            format!("{}{}", vibesql_catalog::WITHOUT_ROWID_PK_INDEX_PREFIX, table_name)
+        } else {
+            format!("sqlite_autoindex_{}_1", table_name)
+        };
         let pk_index_data = match self.database.get_index_data(&pk_index_name) {
             Some(idx) => idx,
             None => return Ok(None),

--- a/crates/vibesql-executor/src/sqlite_schema.rs
+++ b/crates/vibesql-executor/src/sqlite_schema.rs
@@ -79,41 +79,31 @@ pub fn get_sqlite_schema_table_schema() -> TableSchema {
     )
 }
 
-/// Whether `index` is the implicit PRIMARY KEY autoindex of a WITHOUT ROWID
-/// table and must therefore be hidden from `sqlite_master` listings.
+/// Whether `index` is the implicit PRIMARY KEY index of a WITHOUT ROWID table
+/// and must therefore be hidden from `sqlite_master` listings.
 ///
 /// In SQLite, the PRIMARY KEY of a WITHOUT ROWID table *is* the table's B-tree
 /// — no separate `sqlite_autoindex_*` entry exists for it in `sqlite_master`
 /// (verified against sqlite3 3.51.0: `CREATE TABLE t(a, b, PRIMARY KEY(a))
 /// WITHOUT ROWID` yields only the `table` row; a `UNIQUE` constraint on the
-/// same table still gets its autoindex row). VibeSQL materializes a real
-/// unique index for the WITHOUT ROWID PK internally (uniqueness enforcement
-/// and planning), so we filter it out at listing time instead. Covers
-/// alterdropcol 7.2, where `SELECT sql FROM sqlite_schema` must return only
-/// the CREATE TABLE row.
+/// same table still gets its autoindex row, named `sqlite_autoindex_<t>_1`).
+/// VibeSQL materializes a real unique index for the WITHOUT ROWID PK internally
+/// (uniqueness enforcement and planning) under the
+/// [`WITHOUT_ROWID_PK_INDEX_PREFIX`] name — outside the `sqlite_autoindex_`
+/// namespace so it consumes no autoindex ordinal (issue #5882) — and we filter
+/// it out at listing time here. Covers alterdropcol 7.2, where `SELECT sql FROM
+/// sqlite_schema` must return only the CREATE TABLE row.
+///
+/// [`WITHOUT_ROWID_PK_INDEX_PREFIX`]: vibesql_catalog::WITHOUT_ROWID_PK_INDEX_PREFIX
 fn is_without_rowid_pk_autoindex(
     catalog: &vibesql_catalog::Catalog,
     index: &vibesql_catalog::IndexMetadata,
 ) -> bool {
-    if !index.name.starts_with("sqlite_autoindex_") {
+    if !index.name.starts_with(vibesql_catalog::WITHOUT_ROWID_PK_INDEX_PREFIX) {
         return false;
     }
-    let Some(table) = catalog.get_table(&index.table_name) else {
-        return false;
-    };
-    if !table.without_rowid {
-        return false;
-    }
-    let Some(pk_cols) = &table.primary_key else {
-        return false;
-    };
-    // Match the index column list against the PK column list (a UNIQUE
-    // autoindex on the same WITHOUT ROWID table keeps its listing).
-    pk_cols.len() == index.columns.len()
-        && pk_cols
-            .iter()
-            .zip(index.columns.iter())
-            .all(|(pk, ic)| ic.column_name().is_some_and(|name| name.eq_ignore_ascii_case(pk)))
+    // Defensive: the internal PK index only ever exists on a WITHOUT ROWID table.
+    catalog.get_table(&index.table_name).is_some_and(|table| table.without_rowid)
 }
 
 /// Build a single sqlite_master-format row.
@@ -1208,14 +1198,17 @@ mod tests {
             ]
         };
 
-        // WITHOUT ROWID table with PK(a) and UNIQUE(b).
+        // WITHOUT ROWID table with PK(a) and UNIQUE(b). The PK materializes an
+        // internal index outside the autoindex namespace (issue #5882), so the
+        // UNIQUE constraint is the first real index and gets the `_1` ordinal.
+        let wr_pk_index = format!("{}t_wr", vibesql_catalog::WITHOUT_ROWID_PK_INDEX_PREFIX);
         let mut wr =
             TableSchema::with_primary_key("t_wr".to_string(), make_cols(), vec!["a".to_string()]);
         wr.without_rowid = true;
         catalog.create_table(wr).unwrap();
         catalog
             .add_index(IndexMetadata::new(
-                "sqlite_autoindex_t_wr_1".to_string(),
+                wr_pk_index.clone(),
                 "t_wr".to_string(),
                 IndexType::BTree,
                 vec![IndexedColumn::new_column("a".to_string(), SortOrder::Ascending)],
@@ -1224,7 +1217,7 @@ mod tests {
             .unwrap();
         catalog
             .add_index(IndexMetadata::new(
-                "sqlite_autoindex_t_wr_2".to_string(),
+                "sqlite_autoindex_t_wr_1".to_string(),
                 "t_wr".to_string(),
                 IndexType::BTree,
                 vec![IndexedColumn::new_column("b".to_string(), SortOrder::Ascending)],
@@ -1261,12 +1254,16 @@ mod tests {
             .collect();
 
         assert!(
-            !index_names.contains(&"sqlite_autoindex_t_wr_1".to_string()),
-            "WITHOUT ROWID PK autoindex must be hidden, got {index_names:?}"
+            !index_names.contains(&wr_pk_index),
+            "WITHOUT ROWID PK internal index must be hidden, got {index_names:?}"
         );
         assert!(
-            index_names.contains(&"sqlite_autoindex_t_wr_2".to_string()),
-            "UNIQUE autoindex on WITHOUT ROWID table must stay listed, got {index_names:?}"
+            index_names.contains(&"sqlite_autoindex_t_wr_1".to_string()),
+            "UNIQUE autoindex on WITHOUT ROWID table must stay listed as _1, got {index_names:?}"
+        );
+        assert!(
+            !index_names.contains(&"sqlite_autoindex_t_wr_2".to_string()),
+            "UNIQUE autoindex must not be bumped to _2 by the hidden PK, got {index_names:?}"
         );
         assert!(
             index_names.contains(&"sqlite_autoindex_t_rowid_1".to_string()),

--- a/crates/vibesql-executor/tests/without_rowid_autoindex_numbering_tests.rs
+++ b/crates/vibesql-executor/tests/without_rowid_autoindex_numbering_tests.rs
@@ -1,0 +1,211 @@
+//! End-to-end regression tests for issue #5882: autoindex ordinal numbering on
+//! WITHOUT ROWID tables must match SQLite.
+//!
+//! In SQLite the PRIMARY KEY of a WITHOUT ROWID table *is* the table B-tree and
+//! gets no `sqlite_autoindex_*` entry, so a `UNIQUE` constraint on the same
+//! table is the first real index and is named `sqlite_autoindex_<t>_1`:
+//!
+//! ```sql
+//! CREATE TABLE t(a, b, UNIQUE(b), PRIMARY KEY(a)) WITHOUT ROWID;
+//! SELECT type, name FROM sqlite_master;
+//! -- sqlite3 3.51.0: table|t , index|sqlite_autoindex_t_1
+//! ```
+//!
+//! Before the fix, VibeSQL materialized the WITHOUT ROWID PK as
+//! `sqlite_autoindex_t_1` (later hidden from sqlite_master by #5879) but still
+//! burned the `_1` ordinal, so the UNIQUE index landed on `_2`. The fix names
+//! the internal PK index outside the autoindex namespace and does not consume
+//! an ordinal.
+
+use vibesql_ast::Statement;
+use vibesql_executor::{CreateTableExecutor, InsertExecutor, SelectExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Create a table, preserving verbatim source text so the binary reload path
+/// can re-derive the schema (and its implicit indexes) by re-parsing the DDL.
+fn create(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse CREATE");
+    let Statement::CreateTable(create) = stmt else {
+        panic!("expected CREATE TABLE, got: {sql}");
+    };
+    CreateTableExecutor::execute_with_source(&create, db, Some(sql)).expect("CREATE TABLE");
+}
+
+fn insert(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse INSERT");
+    let Statement::Insert(ins) = stmt else {
+        panic!("expected INSERT, got: {sql}");
+    };
+    InsertExecutor::execute(db, &ins).expect("INSERT");
+}
+
+/// Index names reported by `sqlite_master`, in listing order.
+fn index_names(db: &Database) -> Vec<String> {
+    let stmt =
+        Parser::parse_sql("SELECT name FROM sqlite_master WHERE type='index'").expect("parse");
+    let Statement::Select(select) = stmt else { panic!("expected SELECT") };
+    SelectExecutor::new(db)
+        .execute(&select)
+        .expect("sqlite_master query")
+        .into_iter()
+        .map(|row| match &row.values[0] {
+            SqlValue::Varchar(s) => s.to_string(),
+            other => panic!("expected VARCHAR index name, got {other:?}"),
+        })
+        .collect()
+}
+
+/// Rows of a SELECT as raw value vectors.
+fn query(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = Parser::parse_sql(sql).expect("parse SELECT");
+    let Statement::Select(select) = stmt else { panic!("expected SELECT") };
+    SelectExecutor::new(db)
+        .execute(&select)
+        .unwrap_or_else(|e| panic!("query failed: {sql} -- {e:?}"))
+        .into_iter()
+        .map(|row| row.values.to_vec())
+        .collect()
+}
+
+/// Save to a binary `.vbsql` and reload — the cross-process reopen path.
+fn reopen_binary(db: &Database, tag: &str) -> Database {
+    let path =
+        std::env::temp_dir().join(format!("vibesql_5882_{tag}_{}.vbsql", std::process::id()));
+    db.save_binary(&path).expect("save_binary");
+    let reloaded = Database::load_binary(&path).expect("load_binary");
+    std::fs::remove_file(&path).ok();
+    reloaded
+}
+
+/// The exact reproducer from the issue: the UNIQUE index must be `_1`, not `_2`.
+#[test]
+fn without_rowid_pk_does_not_consume_autoindex_ordinal() {
+    let mut db = Database::new();
+    create(&mut db, "CREATE TABLE t(a, b, UNIQUE(b), PRIMARY KEY(a)) WITHOUT ROWID");
+
+    let names = index_names(&db);
+    assert!(
+        names.contains(&"sqlite_autoindex_t_1".to_string()),
+        "UNIQUE index must be sqlite_autoindex_t_1, got {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n == "sqlite_autoindex_t_2"),
+        "no _2 ordinal should exist (PK must not burn _1), got {names:?}"
+    );
+    // Exactly one visible index (the UNIQUE); the internal PK index is hidden.
+    assert_eq!(names.len(), 1, "expected only the UNIQUE index visible, got {names:?}");
+}
+
+/// A WITHOUT ROWID table with two UNIQUE constraints numbers them `_1`, `_2`.
+#[test]
+fn without_rowid_multiple_unique_number_from_one() {
+    let mut db = Database::new();
+    create(&mut db, "CREATE TABLE t2(a, b, c, UNIQUE(b), UNIQUE(c), PRIMARY KEY(a)) WITHOUT ROWID");
+
+    let names = index_names(&db);
+    assert!(
+        names.contains(&"sqlite_autoindex_t2_1".to_string()),
+        "first UNIQUE must be _1, got {names:?}"
+    );
+    assert!(
+        names.contains(&"sqlite_autoindex_t2_2".to_string()),
+        "second UNIQUE must be _2, got {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n == "sqlite_autoindex_t2_3"),
+        "no _3 ordinal should exist, got {names:?}"
+    );
+    assert_eq!(names.len(), 2, "expected exactly two visible UNIQUE indexes, got {names:?}");
+}
+
+/// A WITHOUT ROWID table with only a PK produces no `sqlite_autoindex_*` at all.
+#[test]
+fn without_rowid_pk_only_produces_no_visible_autoindex() {
+    let mut db = Database::new();
+    create(&mut db, "CREATE TABLE t3(a, b, PRIMARY KEY(a)) WITHOUT ROWID");
+    assert!(index_names(&db).is_empty(), "PK-only WITHOUT ROWID table must list no index");
+}
+
+/// Regression guard: an ordinary rowid table with a non-alias (TEXT) PK plus a
+/// UNIQUE still names them `_1` (PK) and `_2` (UNIQUE).
+#[test]
+fn rowid_text_pk_plus_unique_numbering_unchanged() {
+    let mut db = Database::new();
+    create(&mut db, "CREATE TABLE r(a TEXT PRIMARY KEY, b, UNIQUE(b))");
+
+    let names = index_names(&db);
+    assert!(
+        names.contains(&"sqlite_autoindex_r_1".to_string()),
+        "TEXT PK autoindex must be _1, got {names:?}"
+    );
+    assert!(
+        names.contains(&"sqlite_autoindex_r_2".to_string()),
+        "UNIQUE autoindex must be _2, got {names:?}"
+    );
+}
+
+/// Regression guard: an INTEGER PRIMARY KEY (rowid alias) produces no autoindex.
+#[test]
+fn integer_pk_produces_no_autoindex() {
+    let mut db = Database::new();
+    create(&mut db, "CREATE TABLE ipk(a INTEGER PRIMARY KEY, b)");
+    assert!(index_names(&db).is_empty(), "INTEGER PRIMARY KEY must produce no autoindex");
+}
+
+/// The PK-prefix fast path (`WHERE a=? ORDER BY b DESC LIMIT 1`) must still
+/// return correct results on a WITHOUT ROWID table whose multi-column PK index
+/// was renamed out of the autoindex namespace (issue #5882 sneaky regression).
+#[test]
+fn without_rowid_pk_prefix_lookup_still_correct() {
+    let mut db = Database::new();
+    create(&mut db, "CREATE TABLE wr(a, b, v, PRIMARY KEY(a, b)) WITHOUT ROWID");
+    insert(&mut db, "INSERT INTO wr VALUES (1, 10, 'x'), (1, 20, 'y'), (1, 30, 'z'), (2, 5, 'q')");
+
+    // DESC LIMIT 1 -> largest b for a=1 is 30 ('z'); this drives the fast path.
+    let desc = query(&db, "SELECT v FROM wr WHERE a = 1 ORDER BY b DESC LIMIT 1");
+    assert_eq!(desc, vec![vec![SqlValue::Varchar("z".into())]], "DESC prefix lookup wrong");
+
+    // ASC LIMIT 1 -> smallest b for a=1 is 10 ('x').
+    let asc = query(&db, "SELECT v FROM wr WHERE a = 1 ORDER BY b ASC LIMIT 1");
+    assert_eq!(asc, vec![vec![SqlValue::Varchar("x".into())]], "ASC prefix lookup wrong");
+
+    // Full equality on the whole PK still resolves the right row.
+    let both = query(&db, "SELECT v FROM wr WHERE a = 2 AND b = 5");
+    assert_eq!(both, vec![vec![SqlValue::Varchar("q".into())]], "full PK lookup wrong");
+}
+
+/// Numbering, hiding, and PK lookups all survive a binary save/reload, since
+/// the internal PK index is regenerated from the persisted DDL.
+#[test]
+fn without_rowid_numbering_survives_reload() {
+    let mut db = Database::new();
+    create(&mut db, "CREATE TABLE t(a, b, v, UNIQUE(b), PRIMARY KEY(a)) WITHOUT ROWID");
+    insert(&mut db, "INSERT INTO t VALUES (1, 100, 'one'), (2, 200, 'two')");
+
+    let before = index_names(&db);
+    assert_eq!(before, vec!["sqlite_autoindex_t_1".to_string()], "pre-reload names: {before:?}");
+
+    let reloaded = reopen_binary(&db, "numbering");
+
+    let after = index_names(&reloaded);
+    assert_eq!(
+        after,
+        vec!["sqlite_autoindex_t_1".to_string()],
+        "UNIQUE index must still be _1 after reload, got {after:?}"
+    );
+
+    // Data + PK/UNIQUE lookups still work after reload.
+    let rows = query(&reloaded, "SELECT v FROM t WHERE a = 2");
+    assert_eq!(rows, vec![vec![SqlValue::Varchar("two".into())]], "PK lookup broke after reload");
+
+    // The UNIQUE constraint is still enforced after reload.
+    let dup = Parser::parse_sql("INSERT INTO t VALUES (3, 100, 'dup')").expect("parse");
+    let Statement::Insert(ins) = dup else { panic!("expected INSERT") };
+    let mut reloaded = reloaded;
+    assert!(
+        InsertExecutor::execute(&mut reloaded, &ins).is_err(),
+        "UNIQUE(b) must still reject duplicate after reload"
+    );
+}

--- a/crates/vibesql-storage/src/persistence/json.rs
+++ b/crates/vibesql-storage/src/persistence/json.rs
@@ -275,8 +275,12 @@ impl Database {
                 // - "pk_<table_name>" indexes are created by PRIMARY KEY constraints
                 // - "sqlite_autoindex_<table>_<n>" indexes are created by PRIMARY KEY/UNIQUE
                 //   constraints (follows SQLite naming convention for implicit indexes)
+                // - the WITHOUT ROWID PK internal index (issue #5882) is regenerated from the
+                //   CREATE TABLE DDL on reload, so it must not be dumped
                 let lower_name = index_name.to_lowercase();
-                !lower_name.starts_with("pk_") && !lower_name.starts_with("sqlite_autoindex_")
+                !lower_name.starts_with("pk_")
+                    && !lower_name.starts_with("sqlite_autoindex_")
+                    && !lower_name.starts_with(vibesql_catalog::WITHOUT_ROWID_PK_INDEX_PREFIX)
             })
             .filter_map(|index_name| {
                 self.get_index(&index_name).map(|metadata| JsonIndex {

--- a/crates/vibesql-storage/src/persistence/save.rs
+++ b/crates/vibesql-storage/src/persistence/save.rs
@@ -420,8 +420,13 @@ impl Database {
             // - "pk_<table_name>" indexes are created by PRIMARY KEY constraints
             // - "sqlite_autoindex_<table>_<n>" indexes are created by PRIMARY KEY/UNIQUE constraints
             //   (follows SQLite naming convention for implicit indexes)
+            // - the WITHOUT ROWID PK internal index (issue #5882) is regenerated from the
+            //   CREATE TABLE DDL on reload, so it must not be dumped as a CREATE INDEX
             let lower_name = index_name.to_lowercase();
-            if lower_name.starts_with("pk_") || lower_name.starts_with("sqlite_autoindex_") {
+            if lower_name.starts_with("pk_")
+                || lower_name.starts_with("sqlite_autoindex_")
+                || lower_name.starts_with(vibesql_catalog::WITHOUT_ROWID_PK_INDEX_PREFIX)
+            {
                 continue;
             }
             let metadata = self.get_index(&index_name).unwrap();


### PR DESCRIPTION
## Summary

`CREATE TABLE t(a, b, UNIQUE(b), PRIMARY KEY(a)) WITHOUT ROWID` named the UNIQUE index `sqlite_autoindex_t_2` in VibeSQL vs `sqlite_autoindex_t_1` in SQLite. In SQLite the WITHOUT ROWID PK *is* the table B-tree and gets no `sqlite_autoindex_*` slot, so the UNIQUE constraint is the first real index (`_1`). VibeSQL materialized the PK as `sqlite_autoindex_t_1` (hidden from `sqlite_master` by #5879) but still consumed the `_1` ordinal, bumping UNIQUE to `_2`.

## Fix

The WITHOUT ROWID PK index is now materialized under an internal name (`_withoutrowidinternalpk_<table>`, a new shared `vibesql_catalog` const) outside the `sqlite_autoindex_` namespace, and no longer advances the autoindex counter — so UNIQUE constraints correctly start at `_1`.

- **create_table.rs** `create_implicit_indexes`: WITHOUT ROWID PK uses the internal name; the counter only advances for real `sqlite_autoindex_*` indexes.
- **sqlite_schema.rs** `is_without_rowid_pk_autoindex`: detects the internal prefix; the hiding unit test now asserts `_1` (was `_2`).
- **pk_lookup.rs** prefix fast path: resolves the internal PK index name for WITHOUT ROWID tables so the fast path keeps engaging (avoids the sneaky silent-miss regression).
- **persistence save.rs / json.rs**: skip the internal PK index on dump; it is regenerated from the CREATE TABLE DDL on reload.

## Test evidence

- New `tests/without_rowid_autoindex_numbering_tests.rs` (7 tests, all pass): reproducer (`_1` not `_2`), multiple UNIQUEs (`_1`/`_2`), PK-only (no visible autoindex), rowid `TEXT PRIMARY KEY` + UNIQUE unchanged, INTEGER PK produces no autoindex, WITHOUT ROWID PK-prefix fast-path correctness (ASC/DESC/full-PK), and numbering/enforcement surviving a binary save+reload.
- Updated `sqlite_schema` hiding unit test + `create_table`/persistence lib tests pass.
- Reproducer matches sqlite3 3.51.0: `SELECT type,name FROM sqlite_master` -> `index|sqlite_autoindex_t_1`.
- `alterdropcol.test`: 96/100 (only pre-existing 8.1/8.2 AUTOINCREMENT failures; 7.2 still passes).
- `without_rowid3.test`: failure set byte-identical vs `main` (163 failures both, all pre-existing/unrelated) — no regressions.

Closes #5882

🤖 Generated with [Claude Code](https://claude.com/claude-code)