### PR TITLE
fix(executor): resolve unqualified subquery-WHERE columns inner-first (#5880)

### DIFF
--- a/crates/vibesql-executor/src/correlation.rs
+++ b/crates/vibesql-executor/src/correlation.rs
@@ -7,6 +7,28 @@ use vibesql_ast::{Expression, FromClause, SelectItem, SelectStmt};
 
 use crate::schema::CombinedSchema;
 
+/// Check whether an unqualified column resolves to one of the subquery's own
+/// inner tables by consulting the actual database schema.
+///
+/// SQL name resolution is innermost-scope-first: an unqualified column that
+/// exists on a table in the subquery's own FROM clause binds to that inner
+/// table, not to a same-named column in the outer query, so it is NOT a
+/// correlation reference. See issue #5880 — the outer-schema-only self-join
+/// heuristic below misses the case where the inner and outer tables are
+/// distinct tables that share a column name.
+fn unqualified_column_in_inner_tables(
+    database: Option<&vibesql_storage::Database>,
+    subquery_tables: &[String],
+    column: &str,
+) -> bool {
+    let Some(db) = database else {
+        return false;
+    };
+    subquery_tables.iter().any(|table_name| {
+        db.get_table(table_name).is_some_and(|table| table.schema.has_column(column))
+    })
+}
+
 /// Check if a subquery is correlated with the outer query
 ///
 /// A subquery is correlated if it references any columns from the outer schema
@@ -15,11 +37,18 @@ use crate::schema::CombinedSchema;
 /// # Arguments
 /// * `subquery` - The subquery to analyze
 /// * `outer_schema` - Schema of the outer query context
+/// * `database` - Optional database handle used to resolve unqualified column names against the
+///   subquery's own inner tables (innermost-scope-first, issue #5880). When `None`, falls back to
+///   the outer-schema-only self-join heuristic.
 ///
 /// # Returns
 /// * `true` if the subquery references outer columns (correlated)
 /// * `false` if the subquery is independent (non-correlated)
-pub fn is_correlated(subquery: &SelectStmt, outer_schema: &CombinedSchema) -> bool {
+pub fn is_correlated(
+    subquery: &SelectStmt,
+    outer_schema: &CombinedSchema,
+    database: Option<&vibesql_storage::Database>,
+) -> bool {
     // If there's no outer schema, the subquery can't be correlated
     if outer_schema.table_schemas.is_empty() {
         return false;
@@ -30,7 +59,7 @@ pub fn is_correlated(subquery: &SelectStmt, outer_schema: &CombinedSchema) -> bo
 
     // Check all expressions in the subquery for column references
     // that belong to the outer schema (excluding subquery's own tables)
-    is_select_stmt_correlated_impl(subquery, outer_schema, &subquery_tables)
+    is_select_stmt_correlated_impl(subquery, outer_schema, &subquery_tables, database)
 }
 
 /// Extract all table/alias names from a FROM clause
@@ -81,17 +110,18 @@ fn is_select_stmt_correlated_impl(
     stmt: &SelectStmt,
     outer_schema: &CombinedSchema,
     subquery_tables: &[String],
+    database: Option<&vibesql_storage::Database>,
 ) -> bool {
     // Check SELECT list
     for item in &stmt.select_list {
-        if is_select_item_correlated(item, outer_schema, subquery_tables) {
+        if is_select_item_correlated(item, outer_schema, subquery_tables, database) {
             return true;
         }
     }
 
     // Check WHERE clause
     if let Some(where_expr) = &stmt.where_clause {
-        if is_expression_correlated(where_expr, outer_schema, subquery_tables) {
+        if is_expression_correlated(where_expr, outer_schema, subquery_tables, database) {
             return true;
         }
     }
@@ -99,7 +129,7 @@ fn is_select_stmt_correlated_impl(
     // Check GROUP BY
     if let Some(group_by) = &stmt.group_by {
         for expr in group_by.all_expressions() {
-            if is_expression_correlated(expr, outer_schema, subquery_tables) {
+            if is_expression_correlated(expr, outer_schema, subquery_tables, database) {
                 return true;
             }
         }
@@ -107,7 +137,7 @@ fn is_select_stmt_correlated_impl(
 
     // Check HAVING
     if let Some(having) = &stmt.having {
-        if is_expression_correlated(having, outer_schema, subquery_tables) {
+        if is_expression_correlated(having, outer_schema, subquery_tables, database) {
             return true;
         }
     }
@@ -115,7 +145,7 @@ fn is_select_stmt_correlated_impl(
     // Check ORDER BY
     if let Some(order_by) = &stmt.order_by {
         for item in order_by {
-            if is_expression_correlated(&item.expr, outer_schema, subquery_tables) {
+            if is_expression_correlated(&item.expr, outer_schema, subquery_tables, database) {
                 return true;
             }
         }
@@ -123,7 +153,7 @@ fn is_select_stmt_correlated_impl(
 
     // Check FROM clause (subqueries in FROM can reference outer columns)
     if let Some(from) = &stmt.from {
-        if is_from_clause_correlated(from, outer_schema, subquery_tables) {
+        if is_from_clause_correlated(from, outer_schema, subquery_tables, database) {
             return true;
         }
     }
@@ -133,7 +163,7 @@ fn is_select_stmt_correlated_impl(
         for cte in with_clause {
             // CTEs have their own scope, so we need to extract their tables too
             let cte_tables = extract_table_names_from_from_clause(cte.query.from.as_ref());
-            if is_select_stmt_correlated_impl(&cte.query, outer_schema, &cte_tables) {
+            if is_select_stmt_correlated_impl(&cte.query, outer_schema, &cte_tables, database) {
                 return true;
             }
         }
@@ -147,7 +177,12 @@ fn is_select_stmt_correlated_impl(
         // Collect tables from the set operation's right side
         let mut all_subquery_tables = subquery_tables.to_vec();
         extract_table_names_recursive_from_select(&set_op.right, &mut all_subquery_tables);
-        if is_select_stmt_correlated_impl(&set_op.right, outer_schema, &all_subquery_tables) {
+        if is_select_stmt_correlated_impl(
+            &set_op.right,
+            outer_schema,
+            &all_subquery_tables,
+            database,
+        ) {
             return true;
         }
     }
@@ -160,10 +195,11 @@ fn is_select_item_correlated(
     item: &SelectItem,
     outer_schema: &CombinedSchema,
     subquery_tables: &[String],
+    database: Option<&vibesql_storage::Database>,
 ) -> bool {
     match item {
         SelectItem::Expression { expr, .. } => {
-            is_expression_correlated(expr, outer_schema, subquery_tables)
+            is_expression_correlated(expr, outer_schema, subquery_tables, database)
         }
         SelectItem::Wildcard { .. } | SelectItem::QualifiedWildcard { .. } => {
             // Wildcards expand to columns from the subquery's own FROM clause
@@ -178,19 +214,20 @@ fn is_from_clause_correlated(
     from: &FromClause,
     outer_schema: &CombinedSchema,
     subquery_tables: &[String],
+    database: Option<&vibesql_storage::Database>,
 ) -> bool {
     match from {
         FromClause::Table { .. } => false,
         FromClause::Join { left, right, condition, .. } => {
             // Check left and right sides of join
-            if is_from_clause_correlated(left, outer_schema, subquery_tables)
-                || is_from_clause_correlated(right, outer_schema, subquery_tables)
+            if is_from_clause_correlated(left, outer_schema, subquery_tables, database)
+                || is_from_clause_correlated(right, outer_schema, subquery_tables, database)
             {
                 return true;
             }
             // Check join condition
             if let Some(cond) = condition {
-                if is_expression_correlated(cond, outer_schema, subquery_tables) {
+                if is_expression_correlated(cond, outer_schema, subquery_tables, database) {
                     return true;
                 }
             }
@@ -200,12 +237,14 @@ fn is_from_clause_correlated(
             // Subqueries in FROM can be correlated with the outer query
             // Extract their tables and check recursively
             let nested_tables = extract_table_names_from_from_clause(query.from.as_ref());
-            is_select_stmt_correlated_impl(query, outer_schema, &nested_tables)
+            is_select_stmt_correlated_impl(query, outer_schema, &nested_tables, database)
         }
         FromClause::Values { rows, .. } => {
             // VALUES clauses can contain expressions that reference outer columns
             rows.iter().any(|row| {
-                row.iter().any(|expr| is_expression_correlated(expr, outer_schema, subquery_tables))
+                row.iter().any(|expr| {
+                    is_expression_correlated(expr, outer_schema, subquery_tables, database)
+                })
             })
         }
     }
@@ -216,6 +255,7 @@ fn is_expression_correlated(
     expr: &Expression,
     outer_schema: &CombinedSchema,
     subquery_tables: &[String],
+    database: Option<&vibesql_storage::Database>,
 ) -> bool {
     match expr {
         Expression::Literal(_)
@@ -248,9 +288,8 @@ fn is_expression_correlated(
                 // If so, assume unqualified columns belong to the subquery (NOT correlated).
                 // This enables caching optimization for self-join IN subqueries.
                 //
-                // Note: This is a heuristic. For true correlation detection, we would need
-                // the database schema to check if the column actually exists in each table.
-                // But for the common self-join case, this heuristic is correct.
+                // Note: The outer-schema check below is a heuristic that only
+                // catches the self-join case (inner table name == outer table name).
                 for subquery_table in subquery_tables {
                     // Check if this subquery table exists in outer schema
                     // Compare using case-insensitive matching (lowercase subquery table vs canonical outer)
@@ -265,6 +304,23 @@ fn is_expression_correlated(
                         return false;
                     }
                 }
+
+                // FIX for issue #5880: The self-join heuristic above misses the
+                // common case where the inner and outer tables are *distinct*
+                // tables that happen to share a column name (e.g.
+                // `SELECT MIN(x) FROM u WHERE u.y = y` with outer table `t`). The
+                // inner table `u` is never present in the outer schema, so the
+                // heuristic never fires and `y` is wrongly treated as correlated.
+                // Consult the real database schema: if the unqualified column
+                // exists on one of the subquery's own inner tables it resolves
+                // innermost-first and is NOT a correlation reference.
+                if unqualified_column_in_inner_tables(
+                    database,
+                    subquery_tables,
+                    col_id.column_canonical(),
+                ) {
+                    return false;
+                }
             }
 
             // Check if this column exists in outer schema
@@ -275,52 +331,53 @@ fn is_expression_correlated(
         }
 
         Expression::BinaryOp { left, right, .. } => {
-            is_expression_correlated(left, outer_schema, subquery_tables)
-                || is_expression_correlated(right, outer_schema, subquery_tables)
+            is_expression_correlated(left, outer_schema, subquery_tables, database)
+                || is_expression_correlated(right, outer_schema, subquery_tables, database)
         }
 
         Expression::UnaryOp { expr, .. } => {
-            is_expression_correlated(expr, outer_schema, subquery_tables)
+            is_expression_correlated(expr, outer_schema, subquery_tables, database)
         }
 
-        Expression::Function { args, .. } | Expression::AggregateFunction { args, .. } => {
-            args.iter().any(|arg| is_expression_correlated(arg, outer_schema, subquery_tables))
-        }
+        Expression::Function { args, .. } | Expression::AggregateFunction { args, .. } => args
+            .iter()
+            .any(|arg| is_expression_correlated(arg, outer_schema, subquery_tables, database)),
 
         Expression::IsNull { expr, .. } => {
-            is_expression_correlated(expr, outer_schema, subquery_tables)
+            is_expression_correlated(expr, outer_schema, subquery_tables, database)
         }
 
         Expression::IsDistinctFrom { left, right, .. } => {
-            is_expression_correlated(left, outer_schema, subquery_tables)
-                || is_expression_correlated(right, outer_schema, subquery_tables)
+            is_expression_correlated(left, outer_schema, subquery_tables, database)
+                || is_expression_correlated(right, outer_schema, subquery_tables, database)
         }
 
         Expression::IsTruthValue { expr, .. } => {
-            is_expression_correlated(expr, outer_schema, subquery_tables)
+            is_expression_correlated(expr, outer_schema, subquery_tables, database)
         }
 
         Expression::Case { operand, when_clauses, else_result } => {
             // Check operand
             if let Some(op) = operand {
-                if is_expression_correlated(op, outer_schema, subquery_tables) {
+                if is_expression_correlated(op, outer_schema, subquery_tables, database) {
                     return true;
                 }
             }
             // Check WHEN clauses
             for when in when_clauses {
                 for condition in &when.conditions {
-                    if is_expression_correlated(condition, outer_schema, subquery_tables) {
+                    if is_expression_correlated(condition, outer_schema, subquery_tables, database)
+                    {
                         return true;
                     }
                 }
-                if is_expression_correlated(&when.result, outer_schema, subquery_tables) {
+                if is_expression_correlated(&when.result, outer_schema, subquery_tables, database) {
                     return true;
                 }
             }
             // Check ELSE
             if let Some(else_expr) = else_result {
-                if is_expression_correlated(else_expr, outer_schema, subquery_tables) {
+                if is_expression_correlated(else_expr, outer_schema, subquery_tables, database) {
                     return true;
                 }
             }
@@ -329,67 +386,67 @@ fn is_expression_correlated(
 
         Expression::ScalarSubquery(subquery) => {
             let nested_tables = extract_table_names_from_from_clause(subquery.from.as_ref());
-            is_select_stmt_correlated_impl(subquery, outer_schema, &nested_tables)
+            is_select_stmt_correlated_impl(subquery, outer_schema, &nested_tables, database)
         }
 
         Expression::In { expr, subquery, .. } => {
-            if is_expression_correlated(expr, outer_schema, subquery_tables) {
+            if is_expression_correlated(expr, outer_schema, subquery_tables, database) {
                 return true;
             }
             let nested_tables = extract_table_names_from_from_clause(subquery.from.as_ref());
-            is_select_stmt_correlated_impl(subquery, outer_schema, &nested_tables)
+            is_select_stmt_correlated_impl(subquery, outer_schema, &nested_tables, database)
         }
 
         Expression::InList { expr, values, .. } => {
-            is_expression_correlated(expr, outer_schema, subquery_tables)
-                || values
-                    .iter()
-                    .any(|val| is_expression_correlated(val, outer_schema, subquery_tables))
+            is_expression_correlated(expr, outer_schema, subquery_tables, database)
+                || values.iter().any(|val| {
+                    is_expression_correlated(val, outer_schema, subquery_tables, database)
+                })
         }
 
         Expression::Between { expr, low, high, .. } => {
-            is_expression_correlated(expr, outer_schema, subquery_tables)
-                || is_expression_correlated(low, outer_schema, subquery_tables)
-                || is_expression_correlated(high, outer_schema, subquery_tables)
+            is_expression_correlated(expr, outer_schema, subquery_tables, database)
+                || is_expression_correlated(low, outer_schema, subquery_tables, database)
+                || is_expression_correlated(high, outer_schema, subquery_tables, database)
         }
 
         Expression::Like { expr, pattern, .. } | Expression::Glob { expr, pattern, .. } => {
-            is_expression_correlated(expr, outer_schema, subquery_tables)
-                || is_expression_correlated(pattern, outer_schema, subquery_tables)
+            is_expression_correlated(expr, outer_schema, subquery_tables, database)
+                || is_expression_correlated(pattern, outer_schema, subquery_tables, database)
         }
 
         Expression::Exists { subquery, .. } => {
             let nested_tables = extract_table_names_from_from_clause(subquery.from.as_ref());
-            is_select_stmt_correlated_impl(subquery, outer_schema, &nested_tables)
+            is_select_stmt_correlated_impl(subquery, outer_schema, &nested_tables, database)
         }
 
         Expression::QuantifiedComparison { expr, subquery, .. } => {
-            if is_expression_correlated(expr, outer_schema, subquery_tables) {
+            if is_expression_correlated(expr, outer_schema, subquery_tables, database) {
                 return true;
             }
             let nested_tables = extract_table_names_from_from_clause(subquery.from.as_ref());
-            is_select_stmt_correlated_impl(subquery, outer_schema, &nested_tables)
+            is_select_stmt_correlated_impl(subquery, outer_schema, &nested_tables, database)
         }
 
         Expression::Cast { expr, .. } => {
-            is_expression_correlated(expr, outer_schema, subquery_tables)
+            is_expression_correlated(expr, outer_schema, subquery_tables, database)
         }
 
         Expression::Position { substring, string, .. } => {
-            is_expression_correlated(substring, outer_schema, subquery_tables)
-                || is_expression_correlated(string, outer_schema, subquery_tables)
+            is_expression_correlated(substring, outer_schema, subquery_tables, database)
+                || is_expression_correlated(string, outer_schema, subquery_tables, database)
         }
 
         Expression::Trim { removal_char, string, .. } => {
             removal_char
                 .as_ref()
-                .map(|c| is_expression_correlated(c, outer_schema, subquery_tables))
+                .map(|c| is_expression_correlated(c, outer_schema, subquery_tables, database))
                 .unwrap_or(false)
-                || is_expression_correlated(string, outer_schema, subquery_tables)
+                || is_expression_correlated(string, outer_schema, subquery_tables, database)
         }
 
         Expression::Extract { expr, .. } => {
-            is_expression_correlated(expr, outer_schema, subquery_tables)
+            is_expression_correlated(expr, outer_schema, subquery_tables, database)
         }
 
         Expression::WindowFunction { function, over } => {
@@ -397,9 +454,9 @@ fn is_expression_correlated(
             let func_correlated = match function {
                 vibesql_ast::WindowFunctionSpec::Aggregate { args, .. }
                 | vibesql_ast::WindowFunctionSpec::Ranking { args, .. }
-                | vibesql_ast::WindowFunctionSpec::Value { args, .. } => args
-                    .iter()
-                    .any(|arg| is_expression_correlated(arg, outer_schema, subquery_tables)),
+                | vibesql_ast::WindowFunctionSpec::Value { args, .. } => args.iter().any(|arg| {
+                    is_expression_correlated(arg, outer_schema, subquery_tables, database)
+                }),
             };
 
             // Check PARTITION BY
@@ -407,7 +464,9 @@ fn is_expression_correlated(
                 .partition_by
                 .as_ref()
                 .map(|parts| {
-                    parts.iter().any(|p| is_expression_correlated(p, outer_schema, subquery_tables))
+                    parts.iter().any(|p| {
+                        is_expression_correlated(p, outer_schema, subquery_tables, database)
+                    })
                 })
                 .unwrap_or(false);
 
@@ -416,9 +475,9 @@ fn is_expression_correlated(
                 .order_by
                 .as_ref()
                 .map(|orders| {
-                    orders
-                        .iter()
-                        .any(|o| is_expression_correlated(&o.expr, outer_schema, subquery_tables))
+                    orders.iter().any(|o| {
+                        is_expression_correlated(&o.expr, outer_schema, subquery_tables, database)
+                    })
                 })
                 .unwrap_or(false);
 
@@ -426,22 +485,22 @@ fn is_expression_correlated(
         }
 
         Expression::Interval { value, .. } => {
-            is_expression_correlated(value, outer_schema, subquery_tables)
+            is_expression_correlated(value, outer_schema, subquery_tables, database)
         }
 
         Expression::Conjunction(children)
         | Expression::Disjunction(children)
         | Expression::RowValueConstructor(children) => children
             .iter()
-            .any(|child| is_expression_correlated(child, outer_schema, subquery_tables)),
+            .any(|child| is_expression_correlated(child, outer_schema, subquery_tables, database)),
 
         Expression::Collate { expr, .. } => {
-            is_expression_correlated(expr, outer_schema, subquery_tables)
+            is_expression_correlated(expr, outer_schema, subquery_tables, database)
         }
 
-        Expression::Raise { error_message, .. } => error_message
-            .as_ref()
-            .is_some_and(|msg| is_expression_correlated(msg, outer_schema, subquery_tables)),
+        Expression::Raise { error_message, .. } => error_message.as_ref().is_some_and(|msg| {
+            is_expression_correlated(msg, outer_schema, subquery_tables, database)
+        }),
 
         Expression::PseudoVariable { .. }
         | Expression::SessionVariable { .. }
@@ -552,7 +611,7 @@ mod tests {
 
         // With the fixed implementation, this is correctly detected as non-correlated
         // because both col0 and col4 exist in the subquery's own FROM clause (tab0)
-        assert!(!is_correlated(&subquery, &outer_schema));
+        assert!(!is_correlated(&subquery, &outer_schema, None));
     }
 
     #[test]
@@ -589,7 +648,7 @@ mod tests {
             values: None,
         };
 
-        assert!(is_correlated(&subquery, &outer_schema));
+        assert!(is_correlated(&subquery, &outer_schema, None));
     }
 
     #[test]
@@ -629,6 +688,6 @@ mod tests {
             values: None,
         };
 
-        assert!(!is_correlated(&subquery, &outer_schema));
+        assert!(!is_correlated(&subquery, &outer_schema, None));
     }
 }

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/correlation.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/correlation.rs
@@ -4,6 +4,34 @@
 //! references from subqueries. Correlated subqueries reference columns from
 //! outer queries, which affects caching and execution strategies.
 
+/// Check whether an unqualified column resolves to one of the subquery's own
+/// inner tables by consulting the actual database schema.
+///
+/// SQL name resolution is innermost-scope-first: an unqualified column that
+/// exists on a table in the subquery's own FROM clause binds to that inner
+/// table, NOT to a same-named column in the outer query. The correlation walk
+/// must therefore treat such a column as a local (non-correlation) reference.
+///
+/// Historically this check only consulted the *outer* schema (issue #4761),
+/// which handled the self-join case (inner table name == outer table name) but
+/// silently failed whenever the inner and outer tables were *different* tables:
+/// the inner table is never present in the outer schema, so the lookup always
+/// returned `None` and the column was misclassified as an outer correlation
+/// reference (issue #5880). Passing the `Database` lets us inspect the inner
+/// table's real column list and apply innermost-scope-first resolution.
+fn unqualified_column_in_inner_tables(
+    database: Option<&vibesql_storage::Database>,
+    subquery_tables: &[String],
+    column: &str,
+) -> bool {
+    let Some(db) = database else {
+        return false;
+    };
+    subquery_tables.iter().any(|table_name| {
+        db.get_table(table_name).is_some_and(|table| table.schema.has_column(column))
+    })
+}
+
 /// Extract correlation values from the current row for correlated subquery caching
 ///
 /// For correlated subqueries, we need to identify which columns from the outer query
@@ -15,6 +43,12 @@
 /// This function collects all column references in the subquery that belong to the
 /// outer schema (not the subquery's own FROM clause). The values of these columns
 /// from the current row are extracted and returned in a deterministic order.
+///
+/// The optional `database` is consulted to resolve unqualified column names
+/// against the subquery's own inner tables (innermost-scope-first resolution,
+/// issue #5880). When `None`, the function falls back to the outer-schema-only
+/// heuristic, which correctly handles self-joins but may over-report
+/// correlation for distinct inner/outer tables that share a column name.
 ///
 /// # Returns
 ///
@@ -36,13 +70,20 @@ pub(super) fn extract_correlation_values(
     subquery: &vibesql_ast::SelectStmt,
     row: &vibesql_storage::Row,
     outer_schema: &crate::schema::CombinedSchema,
+    database: Option<&vibesql_storage::Database>,
 ) -> Option<Vec<(String, vibesql_types::SqlValue)>> {
     // Get all tables in the subquery's FROM clause
     let subquery_tables = extract_table_names_from_from_clause(subquery.from.as_ref());
 
     // Collect correlation column references
     let mut correlation_refs = std::collections::BTreeSet::new(); // Use BTreeSet for deterministic ordering
-    collect_correlation_refs(subquery, outer_schema, &subquery_tables, &mut correlation_refs);
+    collect_correlation_refs(
+        subquery,
+        outer_schema,
+        &subquery_tables,
+        database,
+        &mut correlation_refs,
+    );
 
     // Extract values from the current row
     let mut correlation_values = Vec::new();
@@ -100,29 +141,36 @@ fn collect_correlation_refs(
     subquery: &vibesql_ast::SelectStmt,
     outer_schema: &crate::schema::CombinedSchema,
     subquery_tables: &[String],
+    database: Option<&vibesql_storage::Database>,
     refs: &mut std::collections::BTreeSet<(Option<String>, String)>,
 ) {
     // Check WHERE clause
     if let Some(where_clause) = &subquery.where_clause {
-        collect_correlation_refs_from_expr(where_clause, outer_schema, subquery_tables, refs);
+        collect_correlation_refs_from_expr(
+            where_clause,
+            outer_schema,
+            subquery_tables,
+            database,
+            refs,
+        );
     }
 
     // Check SELECT list
     for item in &subquery.select_list {
         if let vibesql_ast::SelectItem::Expression { expr, .. } = item {
-            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, refs);
+            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, database, refs);
         }
     }
 
     // Check HAVING clause
     if let Some(having) = &subquery.having {
-        collect_correlation_refs_from_expr(having, outer_schema, subquery_tables, refs);
+        collect_correlation_refs_from_expr(having, outer_schema, subquery_tables, database, refs);
     }
 
     // Check GROUP BY
     if let Some(group_by) = &subquery.group_by {
         for expr in group_by.all_expressions() {
-            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, refs);
+            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, database, refs);
         }
     }
 
@@ -132,7 +180,13 @@ fn collect_correlation_refs(
     // where 'a' in the JOIN condition references an outer table t1.
     // Without this check, the correlation values would be empty, causing incorrect caching.
     if let Some(from) = &subquery.from {
-        collect_correlation_refs_from_from_clause(from, outer_schema, subquery_tables, refs);
+        collect_correlation_refs_from_from_clause(
+            from,
+            outer_schema,
+            subquery_tables,
+            database,
+            refs,
+        );
     }
 
     // FIX for issue #4749: Also check set operations (INTERSECT, UNION, EXCEPT)
@@ -146,7 +200,7 @@ fn collect_correlation_refs(
         extract_table_names_recursive_from_select(&set_op.right, &mut all_subquery_tables);
 
         // Recursively collect correlation refs from the right side of the set operation
-        collect_correlation_refs(&set_op.right, outer_schema, &all_subquery_tables, refs);
+        collect_correlation_refs(&set_op.right, outer_schema, &all_subquery_tables, database, refs);
     }
 }
 
@@ -158,6 +212,7 @@ fn collect_correlation_refs_from_from_clause(
     from: &vibesql_ast::FromClause,
     outer_schema: &crate::schema::CombinedSchema,
     subquery_tables: &[String],
+    database: Option<&vibesql_storage::Database>,
     refs: &mut std::collections::BTreeSet<(Option<String>, String)>,
 ) {
     match from {
@@ -175,22 +230,46 @@ fn collect_correlation_refs_from_from_clause(
                 extract_table_names_recursive(nested_from, &mut nested_tables);
             }
             // Recursively collect correlation refs from the derived table
-            collect_correlation_refs(query, outer_schema, &nested_tables, refs);
+            collect_correlation_refs(query, outer_schema, &nested_tables, database, refs);
         }
         vibesql_ast::FromClause::Join { left, right, condition, .. } => {
             // Check both sides of the join
-            collect_correlation_refs_from_from_clause(left, outer_schema, subquery_tables, refs);
-            collect_correlation_refs_from_from_clause(right, outer_schema, subquery_tables, refs);
+            collect_correlation_refs_from_from_clause(
+                left,
+                outer_schema,
+                subquery_tables,
+                database,
+                refs,
+            );
+            collect_correlation_refs_from_from_clause(
+                right,
+                outer_schema,
+                subquery_tables,
+                database,
+                refs,
+            );
             // Check the join condition for correlation refs
             if let Some(cond) = condition {
-                collect_correlation_refs_from_expr(cond, outer_schema, subquery_tables, refs);
+                collect_correlation_refs_from_expr(
+                    cond,
+                    outer_schema,
+                    subquery_tables,
+                    database,
+                    refs,
+                );
             }
         }
         vibesql_ast::FromClause::Values { rows, .. } => {
             // Check VALUES expressions for correlation refs
             for row in rows {
                 for expr in row {
-                    collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, refs);
+                    collect_correlation_refs_from_expr(
+                        expr,
+                        outer_schema,
+                        subquery_tables,
+                        database,
+                        refs,
+                    );
                 }
             }
         }
@@ -216,6 +295,7 @@ fn collect_correlation_refs_from_expr(
     expr: &vibesql_ast::Expression,
     outer_schema: &crate::schema::CombinedSchema,
     subquery_tables: &[String],
+    database: Option<&vibesql_storage::Database>,
     refs: &mut std::collections::BTreeSet<(Option<String>, String)>,
 ) {
     match expr {
@@ -242,10 +322,19 @@ fn collect_correlation_refs_from_expr(
                 // a table that both the subquery and outer query reference (same table name),
                 // the column resolves to the subquery's scope first (innermost scope wins).
                 // We should NOT add it as a correlation reference.
-                let column_exists_in_subquery_tables = subquery_tables.iter().any(|t| {
-                    // Check if this table exists in outer_schema and has this column
-                    outer_schema.get_column_index(Some(t), column).is_some()
-                });
+                //
+                // FIX for issue #5880: The outer-schema-only check above only catches the
+                // self-join case (inner table name == outer table name). When the inner and
+                // outer tables are *different* tables that happen to share a column name
+                // (e.g. `SELECT MIN(x) FROM u WHERE u.y = y` with outer table `t`), the inner
+                // table `u` is never present in the outer schema, so the check misses it and
+                // `y` is wrongly reported as an outer correlation reference. Consult the actual
+                // database schema so an unqualified name that exists on an inner table resolves
+                // innermost-first and is NOT a correlation ref.
+                let column_exists_in_subquery_tables = subquery_tables
+                    .iter()
+                    .any(|t| outer_schema.get_column_index(Some(t), column).is_some())
+                    || unqualified_column_in_inner_tables(database, subquery_tables, column);
 
                 if !column_exists_in_subquery_tables {
                     // Column doesn't exist in any subquery table, might be from outer
@@ -258,24 +347,42 @@ fn collect_correlation_refs_from_expr(
             }
         }
         vibesql_ast::Expression::BinaryOp { left, right, .. } => {
-            collect_correlation_refs_from_expr(left, outer_schema, subquery_tables, refs);
-            collect_correlation_refs_from_expr(right, outer_schema, subquery_tables, refs);
+            collect_correlation_refs_from_expr(left, outer_schema, subquery_tables, database, refs);
+            collect_correlation_refs_from_expr(
+                right,
+                outer_schema,
+                subquery_tables,
+                database,
+                refs,
+            );
         }
         vibesql_ast::Expression::UnaryOp { expr, .. } => {
-            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, refs);
+            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, database, refs);
         }
         vibesql_ast::Expression::Function { args, .. }
         | vibesql_ast::Expression::AggregateFunction { args, .. } => {
             for arg in args {
-                collect_correlation_refs_from_expr(arg, outer_schema, subquery_tables, refs);
+                collect_correlation_refs_from_expr(
+                    arg,
+                    outer_schema,
+                    subquery_tables,
+                    database,
+                    refs,
+                );
             }
         }
         vibesql_ast::Expression::IsNull { expr, .. } => {
-            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, refs);
+            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, database, refs);
         }
         vibesql_ast::Expression::Case { operand, when_clauses, else_result } => {
             if let Some(op) = operand {
-                collect_correlation_refs_from_expr(op, outer_schema, subquery_tables, refs);
+                collect_correlation_refs_from_expr(
+                    op,
+                    outer_schema,
+                    subquery_tables,
+                    database,
+                    refs,
+                );
             }
             for when in when_clauses {
                 for condition in &when.conditions {
@@ -283,6 +390,7 @@ fn collect_correlation_refs_from_expr(
                         condition,
                         outer_schema,
                         subquery_tables,
+                        database,
                         refs,
                     );
                 }
@@ -290,43 +398,92 @@ fn collect_correlation_refs_from_expr(
                     &when.result,
                     outer_schema,
                     subquery_tables,
+                    database,
                     refs,
                 );
             }
             if let Some(else_expr) = else_result {
-                collect_correlation_refs_from_expr(else_expr, outer_schema, subquery_tables, refs);
+                collect_correlation_refs_from_expr(
+                    else_expr,
+                    outer_schema,
+                    subquery_tables,
+                    database,
+                    refs,
+                );
             }
         }
         vibesql_ast::Expression::InList { expr, values, .. } => {
-            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, refs);
+            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, database, refs);
             for val in values {
-                collect_correlation_refs_from_expr(val, outer_schema, subquery_tables, refs);
+                collect_correlation_refs_from_expr(
+                    val,
+                    outer_schema,
+                    subquery_tables,
+                    database,
+                    refs,
+                );
             }
         }
         vibesql_ast::Expression::Between { expr, low, high, .. } => {
-            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, refs);
-            collect_correlation_refs_from_expr(low, outer_schema, subquery_tables, refs);
-            collect_correlation_refs_from_expr(high, outer_schema, subquery_tables, refs);
+            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, database, refs);
+            collect_correlation_refs_from_expr(low, outer_schema, subquery_tables, database, refs);
+            collect_correlation_refs_from_expr(high, outer_schema, subquery_tables, database, refs);
         }
         vibesql_ast::Expression::Like { expr, pattern, .. } => {
-            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, refs);
-            collect_correlation_refs_from_expr(pattern, outer_schema, subquery_tables, refs);
+            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, database, refs);
+            collect_correlation_refs_from_expr(
+                pattern,
+                outer_schema,
+                subquery_tables,
+                database,
+                refs,
+            );
         }
         vibesql_ast::Expression::Cast { expr, .. } => {
-            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, refs);
+            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, database, refs);
         }
         vibesql_ast::Expression::Position { substring, string, .. } => {
-            collect_correlation_refs_from_expr(substring, outer_schema, subquery_tables, refs);
-            collect_correlation_refs_from_expr(string, outer_schema, subquery_tables, refs);
+            collect_correlation_refs_from_expr(
+                substring,
+                outer_schema,
+                subquery_tables,
+                database,
+                refs,
+            );
+            collect_correlation_refs_from_expr(
+                string,
+                outer_schema,
+                subquery_tables,
+                database,
+                refs,
+            );
         }
         vibesql_ast::Expression::Trim { removal_char, string, .. } => {
             if let Some(c) = removal_char {
-                collect_correlation_refs_from_expr(c, outer_schema, subquery_tables, refs);
+                collect_correlation_refs_from_expr(
+                    c,
+                    outer_schema,
+                    subquery_tables,
+                    database,
+                    refs,
+                );
             }
-            collect_correlation_refs_from_expr(string, outer_schema, subquery_tables, refs);
+            collect_correlation_refs_from_expr(
+                string,
+                outer_schema,
+                subquery_tables,
+                database,
+                refs,
+            );
         }
         vibesql_ast::Expression::Interval { value, .. } => {
-            collect_correlation_refs_from_expr(value, outer_schema, subquery_tables, refs);
+            collect_correlation_refs_from_expr(
+                value,
+                outer_schema,
+                subquery_tables,
+                database,
+                refs,
+            );
         }
         // Nested subqueries: recursively collect correlation refs from their contents
         // FIX for issue #4618: Previously we skipped nested subqueries, which caused
@@ -335,15 +492,15 @@ fn collect_correlation_refs_from_expr(
         vibesql_ast::Expression::ScalarSubquery(subq)
         | vibesql_ast::Expression::Exists { subquery: subq, .. } => {
             // Recursively collect correlation refs from the nested subquery
-            collect_correlation_refs(subq, outer_schema, subquery_tables, refs);
+            collect_correlation_refs(subq, outer_schema, subquery_tables, database, refs);
         }
         vibesql_ast::Expression::In { subquery: subq, expr, .. } => {
-            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, refs);
-            collect_correlation_refs(subq, outer_schema, subquery_tables, refs);
+            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, database, refs);
+            collect_correlation_refs(subq, outer_schema, subquery_tables, database, refs);
         }
         vibesql_ast::Expression::QuantifiedComparison { expr, subquery, .. } => {
-            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, refs);
-            collect_correlation_refs(subquery, outer_schema, subquery_tables, refs);
+            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, database, refs);
+            collect_correlation_refs(subquery, outer_schema, subquery_tables, database, refs);
         }
         // Window functions: check args, PARTITION BY, ORDER BY for outer column refs.
         // Without this, queries like `(SELECT min(a) OVER ())` over a correlated `a`
@@ -357,11 +514,23 @@ fn collect_correlation_refs_from_expr(
                 | vibesql_ast::WindowFunctionSpec::Value { args, .. } => args,
             };
             for arg in args {
-                collect_correlation_refs_from_expr(arg, outer_schema, subquery_tables, refs);
+                collect_correlation_refs_from_expr(
+                    arg,
+                    outer_schema,
+                    subquery_tables,
+                    database,
+                    refs,
+                );
             }
             if let Some(partition_by) = &over.partition_by {
                 for p in partition_by {
-                    collect_correlation_refs_from_expr(p, outer_schema, subquery_tables, refs);
+                    collect_correlation_refs_from_expr(
+                        p,
+                        outer_schema,
+                        subquery_tables,
+                        database,
+                        refs,
+                    );
                 }
             }
             if let Some(order_by) = &over.order_by {
@@ -370,6 +539,7 @@ fn collect_correlation_refs_from_expr(
                         &ob_item.expr,
                         outer_schema,
                         subquery_tables,
+                        database,
                         refs,
                     );
                 }

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/hoist.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/hoist.rs
@@ -119,7 +119,7 @@ impl CombinedExpressionEvaluator<'_> {
         // `None` (extraction failure against the empty probe row) means the
         // subquery might read the outer row, so we must not hoist.
         let probe_row = vibesql_storage::Row::new(Vec::<vibesql_types::SqlValue>::new());
-        match extract_correlation_values(subquery, &probe_row, self.schema) {
+        match extract_correlation_values(subquery, &probe_row, self.schema, self.database) {
             Some(refs) if refs.is_empty() => {}
             _ => return None,
         }

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/scalar.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/scalar.rs
@@ -142,7 +142,8 @@ impl CombinedExpressionEvaluator<'_> {
             self.compute_subquery_hash_cached(subquery)
         } else if !self.schema.table_schemas.is_empty() {
             // Has outer context: include correlation values in cache key for safety
-            if let Some(correlation_values) = extract_correlation_values(subquery, row, self.schema)
+            if let Some(correlation_values) =
+                extract_correlation_values(subquery, row, self.schema, self.database)
             {
                 // Hash is cached by AST pointer (issue #4142)
                 let subquery_hash = self.compute_subquery_hash_cached(subquery);

--- a/crates/vibesql-executor/src/evaluator/expressions/subqueries.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/subqueries.rs
@@ -81,7 +81,8 @@ impl ExpressionEvaluator<'_> {
             crate::schema::CombinedSchema::from_table(table_name_for_outer, self.schema.clone());
 
         // Check if this is a non-correlated subquery that can be cached
-        let is_correlated = crate::correlation::is_correlated(subquery, &outer_combined);
+        let is_correlated =
+            crate::correlation::is_correlated(subquery, &outer_combined, self.database);
 
         // Execute or retrieve from cache
         let rows = if !is_correlated {
@@ -330,7 +331,8 @@ impl ExpressionEvaluator<'_> {
 
         let rows = {
             // Check if this is a non-correlated subquery that can be cached
-            let is_correlated = crate::correlation::is_correlated(subquery, &outer_combined);
+            let is_correlated =
+                crate::correlation::is_correlated(subquery, &outer_combined, self.database);
 
             // Execute or retrieve from cache
             if !is_correlated {
@@ -421,7 +423,8 @@ impl ExpressionEvaluator<'_> {
             crate::schema::CombinedSchema::from_table(table_name_for_outer, self.schema.clone());
 
         // Check if this is a non-correlated subquery that can be cached
-        let is_correlated = crate::correlation::is_correlated(subquery, &outer_combined);
+        let is_correlated =
+            crate::correlation::is_correlated(subquery, &outer_combined, self.database);
 
         // Execute or retrieve from cache
         let rows = if !is_correlated {
@@ -515,7 +518,8 @@ impl ExpressionEvaluator<'_> {
             crate::schema::CombinedSchema::from_table(table_name_for_outer, self.schema.clone());
 
         // Check if this is a non-correlated subquery that can be cached
-        let is_correlated = crate::correlation::is_correlated(subquery, &outer_combined);
+        let is_correlated =
+            crate::correlation::is_correlated(subquery, &outer_combined, self.database);
 
         // Execute or retrieve from cache
         let rows = if !is_correlated {
@@ -603,7 +607,8 @@ impl ExpressionEvaluator<'_> {
             crate::schema::CombinedSchema::from_table(table_name_for_outer, self.schema.clone());
 
         // Check if this is a correlated subquery
-        let is_correlated = crate::correlation::is_correlated(subquery, &outer_combined);
+        let is_correlated =
+            crate::correlation::is_correlated(subquery, &outer_combined, self.database);
 
         // Execute the subquery
         let rows = if !is_correlated {

--- a/crates/vibesql-executor/src/optimizer/where_pushdown/table_refs.rs
+++ b/crates/vibesql-executor/src/optimizer/where_pushdown/table_refs.rs
@@ -122,7 +122,10 @@ fn extract_tables_recursive_branch(
             // SUM(l_quantity) > 300) The subquery is non-correlated, so this can be
             // pushed down to filter the orders table during the scan phase,
             // significantly reducing the join input size.
-            if !crate::correlation::is_correlated(subquery, schema) {
+            // This static optimizer pass has no live `Database` handle, so it
+            // uses the outer-schema-only self-join heuristic (issue #5880 fix
+            // applies only where a `Database` is threaded through at runtime).
+            if !crate::correlation::is_correlated(subquery, schema, None) {
                 // Non-correlated subquery: the predicate can be pushed down
                 // Extract table references from the left-hand expression only
                 // (the subquery is evaluated independently, so it doesn't add table references)

--- a/crates/vibesql-executor/tests/subquery_inner_scope_resolution_tests.rs
+++ b/crates/vibesql-executor/tests/subquery_inner_scope_resolution_tests.rs
@@ -1,0 +1,193 @@
+//! Regression tests for issue #5880
+//!
+//! SQL name resolution is innermost-scope-first: an unqualified column in a
+//! subquery's WHERE clause that exists on one of the subquery's own FROM tables
+//! binds to that *inner* table, NOT to a same-named column in the outer query.
+//!
+//! VibeSQL's correlation detection used to consult only the *outer* schema to
+//! decide whether an unqualified name belonged to an inner table. That check
+//! only ever succeeded for the self-join case (inner table name == outer table
+//! name); when the inner and outer tables were *distinct* tables that happened
+//! to share a column name, the inner table was never in the outer schema, so
+//! the column was misclassified as an outer correlation reference. The subquery
+//! was then run in the correlated branch, coupling its result to the outer
+//! row's value instead of the inner column's — producing wrong results.
+//!
+//! Canonical reproducer (returns 4 rows in sqlite3, used to return 0 here):
+//!
+//! ```sql
+//! CREATE TABLE t(id, x, y); CREATE TABLE u(x, y);
+//! SELECT id FROM t WHERE x > (SELECT MIN(x) FROM u WHERE u.y = y);
+//! ```
+//!
+//! `u.y = y` must resolve as `u.y = u.y` (an always-true tautology), NOT as
+//! `u.y = t.y`. The fix threads the `Database` into the correlation walk so the
+//! inner table's real column list can be consulted.
+//!
+//! All expected row sets below were verified against sqlite3 3.x.
+
+use vibesql_catalog::{ColumnSchema, TableSchema};
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::{Database, Row};
+use vibesql_types::{DataType, SqlValue};
+
+fn parse_select(sql: &str) -> vibesql_ast::SelectStmt {
+    match Parser::parse_sql(sql) {
+        Ok(vibesql_ast::Statement::Select(select_stmt)) => *select_stmt,
+        _ => panic!("Failed to parse SELECT statement: {}", sql),
+    }
+}
+
+fn run(db: &Database, sql: &str) -> Vec<Row> {
+    let select = parse_select(sql);
+    SelectExecutor::new(db).execute(&select).unwrap()
+}
+
+/// Collect the integer values of the first projected column, sorted ascending
+/// (row order is not significant for these assertions).
+fn ids(rows: &[Row]) -> Vec<i64> {
+    let mut out: Vec<i64> = rows
+        .iter()
+        .map(|r| match r.get(0) {
+            Some(SqlValue::Integer(n)) => *n,
+            Some(SqlValue::Bigint(n)) => *n,
+            other => panic!("expected integer at index 0, got {other:?}"),
+        })
+        .collect();
+    out.sort_unstable();
+    out
+}
+
+/// Build the canonical fixture:
+///
+/// ```sql
+/// CREATE TABLE t(id, x, y); CREATE TABLE u(x, y);
+/// INSERT INTO t VALUES(1,2,5),(2,7,5),(3,4,10),(4,9,10);
+/// INSERT INTO u VALUES(1,5),(3,5),(2,10),(6,10);
+/// ```
+fn setup_db() -> Database {
+    let mut db = Database::new();
+
+    let t_schema = TableSchema::new(
+        "t".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, true),
+            ColumnSchema::new("x".to_string(), DataType::Integer, true),
+            ColumnSchema::new("y".to_string(), DataType::Integer, true),
+        ],
+    );
+    db.create_table(t_schema).unwrap();
+
+    let u_schema = TableSchema::new(
+        "u".to_string(),
+        vec![
+            ColumnSchema::new("x".to_string(), DataType::Integer, true),
+            ColumnSchema::new("y".to_string(), DataType::Integer, true),
+        ],
+    );
+    db.create_table(u_schema).unwrap();
+
+    let mut ins_t = |id: i64, x: i64, y: i64| {
+        db.insert_row(
+            "t",
+            Row::new(vec![SqlValue::Integer(id), SqlValue::Integer(x), SqlValue::Integer(y)]),
+        )
+        .unwrap();
+    };
+    ins_t(1, 2, 5);
+    ins_t(2, 7, 5);
+    ins_t(3, 4, 10);
+    ins_t(4, 9, 10);
+
+    let mut ins_u = |x: i64, y: i64| {
+        db.insert_row("u", Row::new(vec![SqlValue::Integer(x), SqlValue::Integer(y)])).unwrap();
+    };
+    ins_u(1, 5);
+    ins_u(3, 5);
+    ins_u(2, 10);
+    ins_u(6, 10);
+
+    db
+}
+
+/// The canonical reproducer. `u.y = y` resolves inner-first as `u.y = u.y`, a
+/// tautology, so `MIN(x)` over all of `u` is 1 and every `t` row (x in
+/// {2,7,4,9}) qualifies. Expect all four ids.
+#[test]
+fn unqualified_inner_column_resolves_inner_first() {
+    let db = setup_db();
+    let rows = run(&db, "SELECT id FROM t WHERE x > (SELECT MIN(x) FROM u WHERE u.y = y)");
+    assert_eq!(ids(&rows), vec![1, 2, 3, 4]);
+}
+
+/// The fully-qualified tautology form must return exactly the same rows as the
+/// unqualified form above (acceptance criterion).
+#[test]
+fn qualified_tautology_matches_unqualified_form() {
+    let db = setup_db();
+    let unqualified =
+        ids(&run(&db, "SELECT id FROM t WHERE x > (SELECT MIN(x) FROM u WHERE u.y = y)"));
+    let qualified =
+        ids(&run(&db, "SELECT id FROM t WHERE x > (SELECT MIN(x) FROM u WHERE u.y = u.y)"));
+    assert_eq!(unqualified, qualified);
+    assert_eq!(qualified, vec![1, 2, 3, 4]);
+}
+
+/// A genuinely-correlated unqualified reference: `id` exists only in the outer
+/// table `t` (not in inner `u`), so it must still be detected as correlated and
+/// evaluated per outer row. For each row the inner `MIN(x)` is taken over
+/// `u.x = t.id`; only ids 1..3 have a matching `u.x` and pass `x > MIN`.
+#[test]
+fn genuine_outer_only_correlation_preserved() {
+    let db = setup_db();
+    let rows = run(&db, "SELECT id FROM t WHERE x > (SELECT MIN(x) FROM u WHERE u.x = id)");
+    assert_eq!(ids(&rows), vec![1, 2, 3]);
+}
+
+/// A qualified outer reference `u.y = t.y` is genuine cross-table equality and
+/// must be unaffected by the fix.
+#[test]
+fn qualified_outer_reference_unchanged() {
+    let db = setup_db();
+    let rows = run(&db, "SELECT id FROM t WHERE x > (SELECT MIN(x) FROM u WHERE u.y = t.y)");
+    assert_eq!(ids(&rows), vec![1, 2, 3, 4]);
+}
+
+/// Nested three levels deep, with the same-name unqualified `y` at each level.
+/// Every occurrence must resolve to its own innermost `u`, so the whole
+/// predicate reduces to a tautology and all four ids qualify.
+#[test]
+fn three_level_nesting_resolves_each_scope_inner_first() {
+    let db = setup_db();
+    let rows = run(
+        &db,
+        "SELECT id FROM t WHERE x > (SELECT MIN(x) FROM u WHERE u.y = y \
+         AND x >= (SELECT MIN(x) FROM u WHERE u.y = y))",
+    );
+    assert_eq!(ids(&rows), vec![1, 2, 3, 4]);
+}
+
+/// Control: an unqualified column that exists *only* in the inner table (`x`
+/// with a literal comparison) is trivially local. Guards against the fix
+/// accidentally treating clearly-inner columns as correlated.
+#[test]
+fn unqualified_inner_only_literal_predicate() {
+    let db = setup_db();
+    // Inner subquery selects MIN over u rows where u.x < 3 → {1, 2} → MIN = 1.
+    let rows = run(&db, "SELECT id FROM t WHERE x > (SELECT MIN(x) FROM u WHERE x < 3)");
+    assert_eq!(ids(&rows), vec![1, 2, 3, 4]);
+}
+
+/// Self-join control (issue #4761 path): the inner and outer tables are the
+/// same table `t`, so an unqualified column still resolves to the inner `t`.
+/// This is the case the old outer-schema heuristic already handled; verify it
+/// is not broken by the new database-backed check.
+#[test]
+fn self_join_unqualified_still_resolves_inner() {
+    let db = setup_db();
+    // `SELECT MIN(x) FROM t WHERE y = y` is a tautology → MIN(x) over t = 2.
+    // Outer rows with x > 2 are ids 2 (7), 3 (4), 4 (9).
+    let rows = run(&db, "SELECT id FROM t a WHERE a.x > (SELECT MIN(x) FROM t WHERE y = y)");
+    assert_eq!(ids(&rows), vec![2, 3, 4]);
+}


### PR DESCRIPTION
Closes #5880

## Problem

SQL name resolution is innermost-scope-first: an unqualified column in a subquery's WHERE clause that exists on one of the subquery's own FROM tables binds to that **inner** table, not to a same-named column in the outer query. VibeSQL's correlation detection consulted only the **outer** schema to decide whether an unqualified name belonged to an inner table — a check that only ever succeeded for the self-join case (inner table name == outer table name).

When the inner and outer tables are *distinct* tables that share a column name, the inner table is never present in the outer schema, so the check missed it and the column was wrongly recorded as an outer correlation reference. The subquery then ran in the correlated branch, coupling its result to the outer row's value instead of the inner column's:

```sql
CREATE TABLE t(id, x, y); CREATE TABLE u(x, y);
SELECT id FROM t WHERE x > (SELECT MIN(x) FROM u WHERE u.y = y);
-- sqlite3: 4 rows   VibeSQL (before): 0 rows
```

`u.y = y` must resolve as `u.y = u.y` (a tautology), not `u.y = t.y`.

## Fix

Thread an `Option<&vibesql_storage::Database>` into the two correlation-detection paths so an unqualified name that exists on an inner table resolves innermost-first and is **not** recorded as a correlation reference:

- `evaluator/combined/subqueries/correlation.rs` — `collect_correlation_refs_from_expr` / `extract_correlation_values` (scalar-subquery cache-key path + hoist gate 3)
- `correlation.rs` — `is_expression_correlated` / `is_correlated` (single-table `ExpressionEvaluator` path)

The runtime evaluators pass their live database handle (`self.database`). The static where-pushdown optimizer pass has no live handle and passes `None`, preserving its existing outer-schema-only heuristic. The self-join heuristic (issue #4761) is retained unchanged.

## Coordination

- After this fix the reproducer shape becomes genuinely uncorrelated, so hoist gate 3 (`hoist_uncorrelated_scalar_subqueries`, #5875) now fires for it. `extract_correlation_values` returns `Some(vec![])`, and the full `uncorrelated_subquery_hoist_tests` suite (14 tests) passes — hoisted result == per-row result.
- `optimizer/subquery_to_join/in_clause.rs` (PR #5926 / #5870) was **not** modified. Full `cargo test -p vibesql-executor` is green.

## Verification

Differential battery (`tests/subquery_inner_scope_resolution_tests.rs`, 7 tests) verified against sqlite3:

| case | expect | pass |
|------|--------|------|
| reproducer `u.y = y` | 1,2,3,4 | ✅ |
| qualified tautology `u.y = u.y` == unqualified | 1,2,3,4 | ✅ |
| genuine outer-only correlation `u.x = id` | 1,2,3 | ✅ |
| qualified cross-table `u.y = t.y` | 1,2,3,4 | ✅ |
| three-level nesting, `y` at each scope | 1,2,3,4 | ✅ |
| inner-only literal `x < 3` | 1,2,3,4 | ✅ |
| self-join control | 2,3,4 | ✅ |

- Full `cargo test -p vibesql-executor`: 153 test groups, 0 failures.
- TCL canary (before → after, same binary rebuilt each side): `subquery2.test` 18/18 → 18/18; `where.test` 168/307 → 168/307 (0 failures both). `subquery.test` is a whole-file capability skip, so `subquery2.test` was used as the nearest runnable canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)