### PR TITLE
fix(parser): IS NULL / IS TRUE followed by a tighter operator is a syntax error

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -482,23 +482,9 @@ impl<'arena> ArenaParser<'arena> {
                     let left_ref = self.arena.alloc(left);
                     let right_ref = self.arena.alloc(right);
                     left = Expression::IsDistinctFrom { left: left_ref, right: right_ref, negated };
-                } else if self.peek_keyword(Keyword::True) {
-                    self.consume_keyword(Keyword::True)?;
-                    let left_ref = self.arena.alloc(left);
-                    left = Expression::IsTruthValue {
-                        expr: left_ref,
-                        truth_value: TruthValue::True,
-                        negated,
-                    };
-                } else if self.peek_keyword(Keyword::False) {
-                    self.consume_keyword(Keyword::False)?;
-                    let left_ref = self.arena.alloc(left);
-                    left = Expression::IsTruthValue {
-                        expr: left_ref,
-                        truth_value: TruthValue::False,
-                        negated,
-                    };
                 } else if self.peek_keyword(Keyword::Unknown) {
+                    // UNKNOWN is not a literal in the expression grammar, so it is
+                    // only recognized here as the fixed `IS [NOT] UNKNOWN` form.
                     self.consume_keyword(Keyword::Unknown)?;
                     let left_ref = self.arena.alloc(left);
                     left = Expression::IsTruthValue {
@@ -506,23 +492,46 @@ impl<'arena> ArenaParser<'arena> {
                         truth_value: TruthValue::Unknown,
                         negated,
                     };
-                } else if self.peek_keyword(Keyword::Null) {
-                    // IS NULL / IS NOT NULL
-                    self.consume_keyword(Keyword::Null)?;
-                    let left_ref = self.arena.alloc(left);
-                    left = Expression::IsNull { expr: left_ref, negated };
                 } else {
-                    // SQLite compatibility: IS <expr> - compare using IS semantics (NULL-safe equals)
-                    // This handles cases like `expr IS 0` or `expr IS 1`
+                    // SQLite parses the right side of `IS` as an ordinary expression,
+                    // and NULL/TRUE/FALSE are themselves expressions. Parse the full
+                    // relational-tier right operand so a tighter-binding operator that
+                    // follows binds to it (`1 IS NULL + 1` == `1 IS (NULL + 1)`), then
+                    // recover the specialized AST shapes for the plain-literal cases so
+                    // optimizers that rely on IsNull / IsTruthValue keep working.
                     let right = self.parse_relational_expression()?;
-                    let left_ref = self.arena.alloc(left);
-                    let right_ref = self.arena.alloc(right);
-                    // IS is equivalent to IS NOT DISTINCT FROM (NULL-safe equals)
-                    // IS NOT is equivalent to IS DISTINCT FROM (NULL-safe not equals)
-                    left = Expression::IsDistinctFrom {
-                        left: left_ref,
-                        right: right_ref,
-                        negated: !negated,
+                    left = match right {
+                        Expression::Literal(SqlValue::Null) => {
+                            let left_ref = self.arena.alloc(left);
+                            Expression::IsNull { expr: left_ref, negated }
+                        }
+                        Expression::Literal(SqlValue::Boolean(true)) => {
+                            let left_ref = self.arena.alloc(left);
+                            Expression::IsTruthValue {
+                                expr: left_ref,
+                                truth_value: TruthValue::True,
+                                negated,
+                            }
+                        }
+                        Expression::Literal(SqlValue::Boolean(false)) => {
+                            let left_ref = self.arena.alloc(left);
+                            Expression::IsTruthValue {
+                                expr: left_ref,
+                                truth_value: TruthValue::False,
+                                negated,
+                            }
+                        }
+                        // SQLite compatibility: `IS <expr>` compares with NULL-safe
+                        // equals. IS is IS NOT DISTINCT FROM; IS NOT is IS DISTINCT FROM.
+                        _ => {
+                            let left_ref = self.arena.alloc(left);
+                            let right_ref = self.arena.alloc(right);
+                            Expression::IsDistinctFrom {
+                                left: left_ref,
+                                right: right_ref,
+                                negated: !negated,
+                            }
+                        }
                     };
                 }
                 continue;

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -932,41 +932,48 @@ impl Parser {
                         right: Box::new(right),
                         negated,
                     };
-                } else if self.peek_keyword(Keyword::True) {
-                    self.consume_keyword(Keyword::True)?;
-                    left = vibesql_ast::Expression::IsTruthValue {
-                        expr: Box::new(left),
-                        truth_value: vibesql_ast::TruthValue::True,
-                        negated,
-                    };
-                } else if self.peek_keyword(Keyword::False) {
-                    self.consume_keyword(Keyword::False)?;
-                    left = vibesql_ast::Expression::IsTruthValue {
-                        expr: Box::new(left),
-                        truth_value: vibesql_ast::TruthValue::False,
-                        negated,
-                    };
                 } else if self.peek_keyword(Keyword::Unknown) {
+                    // UNKNOWN is not a literal in the expression grammar, so it is
+                    // only recognized here as the fixed `IS [NOT] UNKNOWN` form.
                     self.consume_keyword(Keyword::Unknown)?;
                     left = vibesql_ast::Expression::IsTruthValue {
                         expr: Box::new(left),
                         truth_value: vibesql_ast::TruthValue::Unknown,
                         negated,
                     };
-                } else if self.peek_keyword(Keyword::Null) {
-                    // IS NULL / IS NOT NULL
-                    self.consume_keyword(Keyword::Null)?;
-                    left = vibesql_ast::Expression::IsNull { expr: Box::new(left), negated };
                 } else {
-                    // SQLite compatibility: IS <expr> - compare using IS semantics (NULL-safe equals)
-                    // This handles cases like `expr IS 0` or `expr IS 1`
+                    // SQLite parses the right side of `IS` as an ordinary expression,
+                    // and NULL/TRUE/FALSE are themselves expressions. Parse the full
+                    // relational-tier right operand so a tighter-binding operator that
+                    // follows binds to it (`1 IS NULL + 1` == `1 IS (NULL + 1)`), then
+                    // recover the specialized AST shapes for the plain-literal cases so
+                    // optimizers that rely on IsNull / IsTruthValue keep working.
                     let right = self.parse_relational_expression()?;
-                    left = vibesql_ast::Expression::IsDistinctFrom {
-                        left: Box::new(left),
-                        right: Box::new(right),
-                        // IS is equivalent to IS NOT DISTINCT FROM (NULL-safe equals)
-                        // IS NOT is equivalent to IS DISTINCT FROM (NULL-safe not equals)
-                        negated: !negated,
+                    left = match right {
+                        vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null) => {
+                            vibesql_ast::Expression::IsNull { expr: Box::new(left), negated }
+                        }
+                        vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(true)) => {
+                            vibesql_ast::Expression::IsTruthValue {
+                                expr: Box::new(left),
+                                truth_value: vibesql_ast::TruthValue::True,
+                                negated,
+                            }
+                        }
+                        vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(false)) => {
+                            vibesql_ast::Expression::IsTruthValue {
+                                expr: Box::new(left),
+                                truth_value: vibesql_ast::TruthValue::False,
+                                negated,
+                            }
+                        }
+                        // SQLite compatibility: `IS <expr>` compares with NULL-safe
+                        // equals. IS is IS NOT DISTINCT FROM; IS NOT is IS DISTINCT FROM.
+                        _ => vibesql_ast::Expression::IsDistinctFrom {
+                            left: Box::new(left),
+                            right: Box::new(right),
+                            negated: !negated,
+                        },
                     };
                 }
                 continue;

--- a/crates/vibesql-parser/src/tests/isnull_postfix.rs
+++ b/crates/vibesql-parser/src/tests/isnull_postfix.rs
@@ -437,3 +437,200 @@ fn test_default_not_null_column_constraint_unaffected() {
     let result = Parser::parse_sql("CREATE TABLE t (a TEXT DEFAULT 'v' NOT NULL, b INT);");
     assert!(result.is_ok(), "DEFAULT <literal> NOT NULL constraint should parse: {:?}", result);
 }
+
+// ========================================================================
+// `IS` operand composability (issue #5889)
+//
+// Unlike the closed postfix operators ISNULL / NOTNULL / NOT NULL, SQLite's
+// `IS` takes an ordinary *expression* right operand, and NULL/TRUE/FALSE are
+// themselves expressions. So a tighter-binding operator that follows binds
+// to the right operand, not to the IS result:
+//
+//   SELECT 1 IS NULL + 1;      -- 0   i.e. 1 IS (NULL + 1)
+//   SELECT NULL IS NULL + 1;   -- 1   i.e. NULL IS (NULL + 1)
+//   SELECT 1 IS NOT NULL + 1;  -- 1   i.e. 1 IS NOT (NULL + 1)
+//   SELECT 1 IS TRUE + 1;      -- 0   i.e. 1 IS (TRUE + 1) = 1 IS 2
+//
+// When the right operand is a bare NULL/TRUE/FALSE literal we keep emitting
+// the specialized IsNull / IsTruthValue AST shape optimizers rely on; when it
+// is any other expression we emit IsDistinctFrom (NULL-safe equality), whose
+// `negated` field is the inverse of the surface IS/IS-NOT polarity.
+// ========================================================================
+
+/// Assert the expression is `IsDistinctFrom` with the given polarity and
+/// return `(left, right)` operands.
+fn unwrap_is_distinct_from(
+    expr: vibesql_ast::Expression,
+    expected_negated: bool,
+    context: &str,
+) -> (vibesql_ast::Expression, vibesql_ast::Expression) {
+    if let vibesql_ast::Expression::IsDistinctFrom { left, right, negated } = expr {
+        assert_eq!(negated, expected_negated, "{}: wrong IsDistinctFrom polarity", context);
+        (*left, *right)
+    } else {
+        panic!("{}: expected IsDistinctFrom node, got {:?}", context, expr);
+    }
+}
+
+/// Assert the expression is a `NULL + 1` additive BinaryOp.
+fn assert_null_plus_one(expr: &vibesql_ast::Expression, context: &str) {
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = expr {
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Plus, "{}: expected + operator", context);
+        assert!(
+            matches!(**left, vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null)),
+            "{}: expected NULL as left operand of +: {:?}",
+            context,
+            left
+        );
+    } else {
+        panic!("{}: expected BinaryOp Plus, got {:?}", context, expr);
+    }
+}
+
+#[test]
+fn test_is_null_plus_one_binds_to_operand() {
+    // sqlite3: SELECT 1 IS NULL + 1; -- 0, i.e. 1 IS (NULL + 1)
+    let expr = parse_select_expr("SELECT 1 IS NULL + 1;");
+    // IS (not negated) → IsDistinctFrom { negated: true } (NULL-safe equals).
+    let (_left, right) = unwrap_is_distinct_from(expr, true, "1 IS NULL + 1");
+    assert_null_plus_one(&right, "1 IS NULL + 1 right operand");
+}
+
+#[test]
+fn test_null_is_null_plus_one_binds_to_operand() {
+    // sqlite3: SELECT NULL IS NULL + 1; -- 1, i.e. NULL IS (NULL + 1)
+    let expr = parse_select_expr("SELECT NULL IS NULL + 1;");
+    let (left, right) = unwrap_is_distinct_from(expr, true, "NULL IS NULL + 1");
+    assert!(
+        matches!(left, vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null)),
+        "left operand should be NULL: {:?}",
+        left
+    );
+    assert_null_plus_one(&right, "NULL IS NULL + 1 right operand");
+}
+
+#[test]
+fn test_is_not_null_plus_one_binds_to_operand() {
+    // sqlite3: SELECT 1 IS NOT NULL + 1; -- 1, i.e. 1 IS NOT (NULL + 1)
+    let expr = parse_select_expr("SELECT 1 IS NOT NULL + 1;");
+    // IS NOT (negated) → IsDistinctFrom { negated: false } (NULL-safe not-equals).
+    let (_left, right) = unwrap_is_distinct_from(expr, false, "1 IS NOT NULL + 1");
+    assert_null_plus_one(&right, "1 IS NOT NULL + 1 right operand");
+}
+
+#[test]
+fn test_is_true_plus_one_binds_to_operand() {
+    // sqlite3: SELECT 1 IS TRUE + 1; -- 0, i.e. 1 IS (TRUE + 1) = 1 IS 2
+    let expr = parse_select_expr("SELECT 1 IS TRUE + 1;");
+    // TRUE + 1 is a BinaryOp, not a bare literal → IsDistinctFrom, not IsTruthValue.
+    let (_left, right) = unwrap_is_distinct_from(expr, true, "1 IS TRUE + 1");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = &right {
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Plus, "expected + operator");
+        assert!(
+            matches!(**left, vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(true))),
+            "expected TRUE as left operand of +: {:?}",
+            left
+        );
+    } else {
+        panic!("expected BinaryOp Plus, got {:?}", right);
+    }
+}
+
+// ------------------------------------------------------------------------
+// Non-regression: plain literal right operands keep their specialized shape
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_plain_is_null_still_is_null_node() {
+    // No trailing tighter operator → keep the IsNull AST optimizers rely on.
+    let expr = parse_select_expr("SELECT x IS NULL;");
+    unwrap_is_null(expr, false, "x IS NULL");
+}
+
+#[test]
+fn test_plain_is_not_null_still_is_null_node() {
+    let expr = parse_select_expr("SELECT x IS NOT NULL;");
+    unwrap_is_null(expr, true, "x IS NOT NULL");
+}
+
+#[test]
+fn test_plain_is_true_still_truth_value_node() {
+    let expr = parse_select_expr("SELECT x IS TRUE;");
+    assert!(
+        matches!(
+            expr,
+            vibesql_ast::Expression::IsTruthValue {
+                truth_value: vibesql_ast::TruthValue::True,
+                negated: false,
+                ..
+            }
+        ),
+        "x IS TRUE should be IsTruthValue(True): {:?}",
+        expr
+    );
+}
+
+#[test]
+fn test_plain_is_false_still_truth_value_node() {
+    let expr = parse_select_expr("SELECT x IS FALSE;");
+    assert!(
+        matches!(
+            expr,
+            vibesql_ast::Expression::IsTruthValue {
+                truth_value: vibesql_ast::TruthValue::False,
+                negated: false,
+                ..
+            }
+        ),
+        "x IS FALSE should be IsTruthValue(False): {:?}",
+        expr
+    );
+}
+
+#[test]
+fn test_plain_is_not_true_still_truth_value_node() {
+    let expr = parse_select_expr("SELECT x IS NOT TRUE;");
+    assert!(
+        matches!(
+            expr,
+            vibesql_ast::Expression::IsTruthValue {
+                truth_value: vibesql_ast::TruthValue::True,
+                negated: true,
+                ..
+            }
+        ),
+        "x IS NOT TRUE should be IsTruthValue(True, negated): {:?}",
+        expr
+    );
+}
+
+#[test]
+fn test_plain_is_unknown_still_truth_value_node() {
+    // UNKNOWN is not a literal in the expression grammar; the fixed IS-form
+    // must keep mapping to IsTruthValue(Unknown).
+    let expr = parse_select_expr("SELECT x IS UNKNOWN;");
+    assert!(
+        matches!(
+            expr,
+            vibesql_ast::Expression::IsTruthValue {
+                truth_value: vibesql_ast::TruthValue::Unknown,
+                negated: false,
+                ..
+            }
+        ),
+        "x IS UNKNOWN should be IsTruthValue(Unknown): {:?}",
+        expr
+    );
+}
+
+#[test]
+fn test_plain_is_literal_int_still_distinct_from() {
+    // sqlite3: SELECT 1 IS 1; -- 1. `IS <int-literal>` was already IsDistinctFrom.
+    let expr = parse_select_expr("SELECT 1 IS 1;");
+    let (_left, right) = unwrap_is_distinct_from(expr, true, "1 IS 1");
+    assert!(
+        matches!(right, vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1))),
+        "right operand should be integer 1: {:?}",
+        right
+    );
+}


### PR DESCRIPTION
## Summary

SQLite's `IS` takes an ordinary *expression* right operand, and `NULL`/`TRUE`/`FALSE` are themselves expressions. VibeSQL's two parsers special-cased `IS` + peeked `NULL`/`TRUE`/`FALSE`/`UNKNOWN` and consumed only that keyword, leaving any following tighter-binding operator (`+`, `-`, ...) unparseable at the comparison tier — a `near "+": syntax error`.

This merges the `NULL`/`TRUE`/`FALSE` branches into the existing fallback that already parses the right side at the relational tier, then pattern-matches the parsed operand:

- bare `Literal(Null)` → keep `IsNull { negated }`
- bare `Boolean(true/false)` → keep `IsTruthValue`
- anything else → `IsDistinctFrom { negated: !negated }` (NULL-safe equality)

So a tighter operator now binds to the operand: `1 IS NULL + 1` == `1 IS (NULL + 1)`. `UNKNOWN` stays a peek-guard because it is not a literal in the expression grammar. Plain `x IS NULL` / `IS NOT NULL` / `IS TRUE` still produce the specialized `IsNull` / `IsTruthValue` AST shape optimizers rely on. The arena parser mirrors the fix.

## Ground truth (verified against sqlite3)

| Statement | sqlite3 | VibeSQL (this PR) |
|-----------|---------|-------------------|
| `SELECT 1 IS NULL + 1;` | 0 | 0 |
| `SELECT NULL IS NULL + 1;` | 1 | 1 |
| `SELECT 1 IS NOT NULL + 1;` | 1 | 1 |
| `SELECT 1 IS TRUE + 1;` | 0 | 0 |

Non-regression spot checks: `1 ISNULL + 1` = 1 (postfix, #5857), `1 IS NULL` = 0, `NULL IS NULL` = 1, `1 IS NOT NULL` = 1, `1 IS TRUE` = 1, `1 IS 1` = 1, `1 IS UNKNOWN` = 0.

## Tests

- `crates/vibesql-parser/src/tests/isnull_postfix.rs`: 11 new tests (four ground-truth AST shapes + plain `IS NULL`/`IS NOT NULL`/`IS TRUE`/`IS FALSE`/`IS NOT TRUE`/`IS UNKNOWN`/`IS 1` non-regression).
- `cargo test -p vibesql-parser`: 1717 passed, 0 failed.
- TCL `e_expr.test`: 374/374. TCL `expr.test`: 638 passed, 0 failed, 22 skipped (baseline).

Closes #5889

🤖 Generated with [Claude Code](https://claude.com/claude-code)