### PR TITLE
fix(executor): last_insert_rowid() returns LAST inserted rowid after multi-row INSERT ... SELECT

### DIFF
--- a/crates/vibesql-executor/src/insert/bulk_transfer.rs
+++ b/crates/vibesql-executor/src/insert/bulk_transfer.rs
@@ -276,6 +276,29 @@ fn execute_bulk_transfer(
         validated_rows.push(vibesql_storage::Row::new(row_values));
     }
 
+    // last_insert_rowid() support. SQLite's transfer optimization scans the
+    // source b-tree in ascending rowid order and inserts each row, so the value
+    // it reports afterwards is the rowid of the highest source row copied. For a
+    // rowid destination whose INTEGER PRIMARY KEY is the copied rowid, that is
+    // the maximum IPK value among the transferred rows. We compute the max here
+    // (rather than the last scanned row) because VibeSQL scans the source in
+    // physical order, which may differ from rowid order. Mirror the row-by-row
+    // INSERT path, which only tracks the rowid for rowid tables with an INTEGER
+    // PRIMARY KEY. Capture before the batch insert consumes `validated_rows`.
+    let last_rowid = if dest_schema.without_rowid {
+        None
+    } else {
+        dest_schema.get_integer_primary_key_index().and_then(|idx| {
+            validated_rows
+                .iter()
+                .filter_map(|row| match row.values.get(idx) {
+                    Some(SqlValue::Integer(v)) => Some(*v),
+                    _ => None,
+                })
+                .max()
+        })
+    };
+
     // Batch insert all rows at once (much faster than row-by-row)
     // This reduces WAL operations, index rebuilds, and cache invalidations
     let inserted_count = if !validated_rows.is_empty() {
@@ -284,6 +307,13 @@ fn execute_bulk_transfer(
     } else {
         0
     };
+
+    // Update last_insert_rowid() only when rows were actually inserted.
+    if inserted_count > 0 {
+        if let Some(rowid) = last_rowid {
+            db.set_last_insert_rowid(rowid);
+        }
+    }
 
     // Invalidate the database-level columnar cache since table data changed.
     // Note: The table-level cache is already invalidated by insert_rows_batch().

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -405,12 +405,21 @@ fn execute_insert_internal(
 
     // For multi-row INSERT, validate all rows first, then insert all
     // This ensures atomicity: all rows succeed or all fail (unless IGNORE is used)
-    // Each entry is (row values, explicit rowid, ipk_auto_assigned). The
-    // `ipk_auto_assigned` flag records whether the row's INTEGER PRIMARY KEY
-    // (rowid alias) value was auto-allocated rather than supplied by the INSERT;
-    // it is used to present `NEW.<ipk>` as the unwritten-rowid sentinel (-1) to
-    // BEFORE INSERT triggers.
-    let mut validated_rows: Vec<(Vec<vibesql_types::SqlValue>, Option<u64>, bool)> = Vec::new();
+    // Each entry is (row values, explicit rowid, ipk_auto_assigned,
+    // candidate_last_id). The `ipk_auto_assigned` flag records whether the row's
+    // INTEGER PRIMARY KEY (rowid alias) value was auto-allocated rather than
+    // supplied by the INSERT; it is used to present `NEW.<ipk>` as the
+    // unwritten-rowid sentinel (-1) to BEFORE INSERT triggers.
+    //
+    // `candidate_last_id` is the value this row would contribute to
+    // last_insert_rowid() *if it is actually inserted* — the row's INTEGER
+    // PRIMARY KEY (rowid alias) value, or the first auto-generated sequence
+    // value for non-IPK tables. It is committed to `last_generated_id` only at
+    // the real insert call sites (below), so a row that takes the ON CONFLICT
+    // DO UPDATE arm — or is skipped by OR IGNORE / DO NOTHING — does not update
+    // last_insert_rowid() (SQLite excludes pure updates and skips; issue #5886).
+    let mut validated_rows: Vec<(Vec<vibesql_types::SqlValue>, Option<u64>, bool, Option<i64>)> =
+        Vec::new();
     let mut primary_key_values: Vec<Vec<vibesql_types::SqlValue>> = Vec::new(); // Track PK values for duplicate checking within batch
     let mut unique_constraint_values = if schema.get_unique_constraint_indices().is_empty() {
         Vec::new()
@@ -816,22 +825,31 @@ fn execute_insert_internal(
         // same batch (see fkey1-5.1 note above).
         batch_full_rows.push(full_row_values.clone());
 
-        // Track the rowid of this row for last_insert_rowid(). We do this here,
-        // after the OR IGNORE / DO NOTHING skip check, so only rows that are
-        // actually inserted count (SQLite: last inserted row wins). For rowid
-        // tables the final rowid is the INTEGER PRIMARY KEY value (whether
-        // explicit or auto-assigned); otherwise fall back to any auto-generated
-        // sequence value.
-        if let Some(idx) = ipk_col_idx {
-            if let Some(vibesql_types::SqlValue::Integer(val)) = full_row_values.get(idx) {
-                last_generated_id = Some(*val);
+        // Compute the value this row would contribute to last_insert_rowid()
+        // *if it is actually inserted*. We commit it to `last_generated_id` only
+        // at the real insert call sites below (never in this validation loop),
+        // so a row that later takes the ON CONFLICT DO UPDATE arm, is skipped by
+        // a DO NOTHING clause, or is dropped by OR IGNORE does NOT update
+        // last_insert_rowid() — SQLite excludes pure updates and skipped rows
+        // (issue #5886). For rowid tables the value is the INTEGER PRIMARY KEY
+        // (whether explicit or auto-assigned); otherwise fall back to any
+        // auto-generated sequence value.
+        let candidate_last_id = if let Some(idx) = ipk_col_idx {
+            match full_row_values.get(idx) {
+                Some(vibesql_types::SqlValue::Integer(val)) => Some(*val),
+                _ => None,
             }
-        } else if generated_id.is_some() {
-            last_generated_id = generated_id;
-        }
+        } else {
+            generated_id
+        };
 
         // Store validated row for insertion (with optional explicit rowid)
-        validated_rows.push((full_row_values, explicit_rowid, ipk_auto_assigned));
+        validated_rows.push((
+            full_row_values,
+            explicit_rowid,
+            ipk_auto_assigned,
+            candidate_last_id,
+        ));
     }
 
     // All rows validated successfully, now insert them
@@ -901,7 +919,14 @@ fn execute_insert_internal(
     };
 
     if use_batch_insert && validated_rows.len() > 1 {
-        // Fast path: Use batch insert for multiple rows without triggers
+        // Fast path: Use batch insert for multiple rows without triggers.
+        // Every validated row is inserted (the batch path never runs for the ON
+        // CONFLICT DO UPDATE / DO NOTHING dispatch or REPLACE), so the last row
+        // carrying a candidate id wins last_insert_rowid() (last inserted row).
+        if let Some(id) = validated_rows.iter().rev().find_map(|t| t.3) {
+            last_generated_id = Some(id);
+        }
+
         // Use cost-based batch sizing to optimize for tables with many indexes
         let optimizer = DmlOptimizer::new(db, table_name);
         let optimal_batch_size = optimizer.optimal_insert_batch_size(validated_rows.len());
@@ -916,7 +941,7 @@ fn execute_insert_internal(
             let mut row_offset = initial_row_count;
             for chunk in validated_rows.chunks(optimal_batch_size) {
                 let rows: Vec<vibesql_storage::Row> =
-                    chunk.iter().map(|(v, rowid, _)| make_row((v.clone(), *rowid))).collect();
+                    chunk.iter().map(|(v, rowid, _, _)| make_row((v.clone(), *rowid))).collect();
 
                 // Partial-aware unique-constraint check (storage skips
                 // partial UNIQUE indexes; the executor must do this itself).
@@ -958,7 +983,7 @@ fn execute_insert_internal(
         } else {
             // Single batch insert for low-cost tables
             let rows: Vec<vibesql_storage::Row> =
-                validated_rows.into_iter().map(|(v, rowid, _)| make_row((v, rowid))).collect();
+                validated_rows.into_iter().map(|(v, rowid, _, _)| make_row((v, rowid))).collect();
 
             // Partial-aware unique-constraint check (storage skips partial
             // UNIQUE indexes; the executor must do this itself).
@@ -997,7 +1022,9 @@ fn execute_insert_internal(
         }
     } else {
         // Slow path: Insert rows one by one (needed for triggers, special clauses)
-        for (mut full_row_values, mut explicit_rowid, ipk_auto_assigned) in validated_rows {
+        for (mut full_row_values, mut explicit_rowid, ipk_auto_assigned, candidate_last_id) in
+            validated_rows
+        {
             // Check if ON DUPLICATE KEY UPDATE is specified
             if let Some(ref assignments) = stmt.on_duplicate_key_update {
                 // Try to update an existing row if there's a conflict
@@ -1293,6 +1320,14 @@ fn execute_insert_internal(
                     Some(&after_row),
                     dml_schema.as_deref(),
                 )?;
+            }
+
+            // The row was genuinely inserted (not an ON CONFLICT DO UPDATE
+            // update, a DO NOTHING skip, or a RAISE(IGNORE) trigger skip — those
+            // paths `continue` above without reaching here), so it updates
+            // last_insert_rowid(). Last inserted row wins (issue #5886).
+            if let Some(id) = candidate_last_id {
+                last_generated_id = Some(id);
             }
 
             rows_inserted += 1;

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -470,10 +470,11 @@ fn execute_insert_internal(
             }]
         );
 
-    // Track the first auto-generated ID for LAST_INSERT_ROWID() support
-    // Per MySQL semantics, for multi-row inserts, LAST_INSERT_ID() returns
-    // the first auto-generated value, not the last
-    let mut first_generated_id: Option<i64> = None;
+    // Track the most recently generated ID for last_insert_rowid() support.
+    // SQLite semantics: last_insert_rowid() returns the rowid of the most
+    // recently inserted row, so for multi-row INSERT ... VALUES / INSERT ... SELECT
+    // the LAST row in the batch wins (last writer wins).
+    let mut last_generated_id: Option<i64> = None;
 
     // Track the maximum INTEGER PRIMARY KEY value assigned within this batch
     // to handle multi-row INSERTs with NULL values correctly (SQLite semantics)
@@ -720,22 +721,12 @@ fn execute_insert_internal(
         // Apply generated/computed column values (AS(expression) syntax)
         super::defaults::apply_generated_columns(&schema, &mut full_row_values, db)?;
 
-        // Track the first generated ID across all rows
-        if first_generated_id.is_none() {
-            first_generated_id = generated_id;
-        }
-
-        // Update batch_max_ipk if this row has an INTEGER PRIMARY KEY value
-        // Also track explicit INTEGER PRIMARY KEY values for last_insert_rowid()
-        // SQLite semantics: last_insert_rowid() returns the rowid of the most recently
-        // inserted row, whether auto-generated or explicitly provided
+        // Update batch_max_ipk if this row has an INTEGER PRIMARY KEY value.
+        // (last_insert_rowid() tracking happens later, only for rows that are
+        // actually inserted — a row skipped by OR IGNORE must not update it.)
         if let Some(idx) = ipk_col_idx {
             if let Some(vibesql_types::SqlValue::Integer(val)) = full_row_values.get(idx) {
                 batch_max_ipk = Some(batch_max_ipk.map_or(*val, |prev| prev.max(*val)));
-                // Track first explicit INTEGER PRIMARY KEY value for last_insert_rowid()
-                if first_generated_id.is_none() {
-                    first_generated_id = Some(*val);
-                }
             }
         }
 
@@ -824,6 +815,20 @@ fn execute_insert_internal(
         // Track row for self-referential FK lookups by later rows in the
         // same batch (see fkey1-5.1 note above).
         batch_full_rows.push(full_row_values.clone());
+
+        // Track the rowid of this row for last_insert_rowid(). We do this here,
+        // after the OR IGNORE / DO NOTHING skip check, so only rows that are
+        // actually inserted count (SQLite: last inserted row wins). For rowid
+        // tables the final rowid is the INTEGER PRIMARY KEY value (whether
+        // explicit or auto-assigned); otherwise fall back to any auto-generated
+        // sequence value.
+        if let Some(idx) = ipk_col_idx {
+            if let Some(vibesql_types::SqlValue::Integer(val)) = full_row_values.get(idx) {
+                last_generated_id = Some(*val);
+            }
+        } else if generated_id.is_some() {
+            last_generated_id = generated_id;
+        }
 
         // Store validated row for insertion (with optional explicit rowid)
         validated_rows.push((full_row_values, explicit_rowid, ipk_auto_assigned));
@@ -1310,7 +1315,7 @@ fn execute_insert_internal(
     // Update LAST_INSERT_ROWID if any auto-generated values were produced
     // SQLite: last_insert_rowid() is NOT updated for WITHOUT ROWID tables
     // (see SQLite documentation R-47220-63683)
-    if let Some(id) = first_generated_id {
+    if let Some(id) = last_generated_id {
         if !schema.without_rowid {
             db.set_last_insert_rowid(id);
         }

--- a/crates/vibesql-executor/src/tests/auto_increment_tests.rs
+++ b/crates/vibesql-executor/src/tests/auto_increment_tests.rs
@@ -631,6 +631,52 @@ fn test_last_insert_rowid_or_ignore_skips_last_row() {
     assert_eq!(db.last_insert_rowid(), 6);
 }
 
+/// Mixed-batch upsert: the LAST row takes the ON CONFLICT DO UPDATE arm (an
+/// update, not an insert) while an earlier row inserts. last_insert_rowid() must
+/// report the last row *actually inserted* (rowid 6), NOT the updated row's
+/// rowid (5). SQLite excludes pure updates from last_insert_rowid(); verified
+/// against sqlite3 3.51.0 (returns 6). Regression guard for issue #5886.
+#[test]
+fn test_last_insert_rowid_upsert_mixed_batch_excludes_update() {
+    let mut db = Database::new();
+
+    exec_sql(&mut db, "CREATE TABLE t(k INTEGER PRIMARY KEY, v INTEGER)");
+    exec_sql(&mut db, "INSERT INTO t VALUES(5,1)");
+    // (6,2) inserts (no conflict); (5,3) conflicts on k=5 and takes the DO
+    // UPDATE arm — an update, so it must not touch last_insert_rowid().
+    exec_sql(
+        &mut db,
+        "INSERT INTO t VALUES(6,2),(5,3) ON CONFLICT(k) DO UPDATE SET v=excluded.v",
+    );
+
+    // sqlite3: last_insert_rowid() == 6 (last row actually inserted, not 5)
+    assert_eq!(db.last_insert_rowid(), 6);
+}
+
+/// An upsert batch where EVERY row takes the DO UPDATE arm inserts nothing, so
+/// last_insert_rowid() must stay at its prior value (the rowid of the last row
+/// actually inserted by an earlier statement). Verified against sqlite3 3.51.0:
+/// after inserting rowid 9 then an all-update upsert, last_insert_rowid() == 9.
+/// Regression guard for issue #5886.
+#[test]
+fn test_last_insert_rowid_upsert_all_updates_keeps_prior() {
+    let mut db = Database::new();
+
+    exec_sql(&mut db, "CREATE TABLE t(k INTEGER PRIMARY KEY, v INTEGER)");
+    exec_sql(&mut db, "INSERT INTO t VALUES(5,1)");
+    exec_sql(&mut db, "INSERT INTO t VALUES(9,9)"); // last actual insert -> rowid 9
+    assert_eq!(db.last_insert_rowid(), 9);
+
+    // k=5 already exists -> DO UPDATE arm only; nothing inserted.
+    exec_sql(
+        &mut db,
+        "INSERT INTO t VALUES(5,3) ON CONFLICT(k) DO UPDATE SET v=excluded.v",
+    );
+
+    // sqlite3: last_insert_rowid() unchanged at 9 (no row inserted)
+    assert_eq!(db.last_insert_rowid(), 9);
+}
+
 /// The bulk-transfer fast path (`INSERT INTO t SELECT * FROM src`, no column
 /// list) must also report the last inserted rowid. Source rows are inserted out
 /// of rowid order so the value left by the last `INSERT INTO src` (200) differs

--- a/crates/vibesql-executor/src/tests/auto_increment_tests.rs
+++ b/crates/vibesql-executor/src/tests/auto_increment_tests.rs
@@ -312,7 +312,8 @@ fn test_last_insert_rowid_multi_row_insert() {
     let result = CreateTableExecutor::execute(&stmt, &mut db);
     assert!(result.is_ok(), "Failed to create table: {:?}", result.err());
 
-    // Multi-row insert - per MySQL semantics, LAST_INSERT_ID returns the FIRST generated ID
+    // Multi-row insert - per SQLite semantics, last_insert_rowid() returns the
+    // rowid of the LAST row inserted (not the first)
     let multi_insert = InsertStmt {
         with_clause: None,
         schema_name: None,
@@ -339,8 +340,8 @@ fn test_last_insert_rowid_multi_row_insert() {
     let result = InsertExecutor::execute(&mut db, &multi_insert);
     assert!(result.is_ok(), "Failed to multi-row insert: {:?}", result.err());
 
-    // LAST_INSERT_ROWID should be 1 (the first generated ID, not 3)
-    assert_eq!(db.last_insert_rowid(), 1);
+    // last_insert_rowid() should be 3 (the LAST generated ID, per sqlite3)
+    assert_eq!(db.last_insert_rowid(), 3);
 
     // Verify all rows were inserted with correct IDs
     let table = db.get_table("items").unwrap();
@@ -524,4 +525,129 @@ fn test_last_insert_rowid_via_select() {
     } else {
         panic!("Expected SELECT statement");
     }
+}
+
+/// Execute a single DDL/DML statement expressed as SQL text against `db`.
+///
+/// Small dispatch helper used by the INSERT ... SELECT tests below so they can
+/// reproduce the exact multi-statement scripts from issue #5886 without hand
+/// building every AST node.
+fn exec_sql(db: &mut Database, sql: &str) {
+    use vibesql_parser::Parser;
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse failed for {sql:?}: {e:?}"));
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create) => {
+            CreateTableExecutor::execute(&create, db)
+                .unwrap_or_else(|e| panic!("CREATE failed for {sql:?}: {e:?}"));
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            InsertExecutor::execute(db, &insert)
+                .unwrap_or_else(|e| panic!("INSERT failed for {sql:?}: {e:?}"));
+        }
+        other => panic!("unsupported statement in exec_sql: {other:?}"),
+    }
+}
+
+/// Reproduces the exact bug from issue #5886: after a multi-row
+/// `INSERT INTO ... SELECT`, `last_insert_rowid()` must return the rowid of the
+/// LAST row inserted (sqlite3 returns 2 here), not the first (which was 1).
+#[test]
+fn test_last_insert_rowid_insert_select() {
+    let mut db = Database::new();
+
+    exec_sql(&mut db, "CREATE TABLE src(a INTEGER)");
+    exec_sql(&mut db, "INSERT INTO src VALUES(10)");
+    exec_sql(&mut db, "INSERT INTO src VALUES(20)");
+    exec_sql(&mut db, "CREATE TABLE t1(k INTEGER PRIMARY KEY, v INTEGER)");
+
+    // Two source rows -> two inserted rows with rowids 1 and 2.
+    exec_sql(&mut db, "INSERT INTO t1(v) SELECT a FROM src");
+
+    // sqlite3: last_insert_rowid() == 2 (the LAST inserted row)
+    assert_eq!(db.last_insert_rowid(), 2);
+
+    // Sanity check: both rows landed with the expected rowids/values.
+    let table = db.get_table("t1").unwrap();
+    let rows = table.scan();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].values[0], SqlValue::Integer(1));
+    assert_eq!(rows[1].values[0], SqlValue::Integer(2));
+}
+
+/// Multi-row `INSERT ... VALUES` with explicit INTEGER PRIMARY KEY values must
+/// report the LAST explicit rowid (sqlite3 returns 3 here).
+#[test]
+fn test_last_insert_rowid_multi_values_explicit_key() {
+    let mut db = Database::new();
+
+    exec_sql(&mut db, "CREATE TABLE t(k INTEGER PRIMARY KEY, v INTEGER)");
+    exec_sql(&mut db, "INSERT INTO t VALUES(10,1),(20,2),(30,3)");
+
+    // sqlite3: last_insert_rowid() == 30 (rowid of the last row inserted)
+    assert_eq!(db.last_insert_rowid(), 30);
+}
+
+/// Single explicit-key insert must be unchanged: last_insert_rowid() == the key.
+#[test]
+fn test_last_insert_rowid_single_explicit_key() {
+    let mut db = Database::new();
+
+    exec_sql(&mut db, "CREATE TABLE t(k INTEGER PRIMARY KEY, v INTEGER)");
+    exec_sql(&mut db, "INSERT INTO t VALUES(100,999)");
+
+    // sqlite3: last_insert_rowid() == 100
+    assert_eq!(db.last_insert_rowid(), 100);
+}
+
+/// An INSERT ... SELECT that inserts zero rows must leave last_insert_rowid()
+/// at its previous value (sqlite3 semantics).
+#[test]
+fn test_last_insert_rowid_insert_select_zero_rows() {
+    let mut db = Database::new();
+
+    exec_sql(&mut db, "CREATE TABLE src(a INTEGER)");
+    exec_sql(&mut db, "CREATE TABLE t1(k INTEGER PRIMARY KEY, v INTEGER)");
+    exec_sql(&mut db, "INSERT INTO t1(v) VALUES(7)"); // rowid 1
+    assert_eq!(db.last_insert_rowid(), 1);
+
+    // src is empty -> zero rows inserted -> last_insert_rowid() unchanged.
+    exec_sql(&mut db, "INSERT INTO t1(v) SELECT a FROM src");
+    assert_eq!(db.last_insert_rowid(), 1);
+}
+
+/// INSERT OR IGNORE where the LAST row is skipped by a conflict: last_insert_rowid()
+/// must reflect the last row *actually inserted* (rowid 6), not the skipped one
+/// (sqlite3 returns 6 here).
+#[test]
+fn test_last_insert_rowid_or_ignore_skips_last_row() {
+    let mut db = Database::new();
+
+    exec_sql(&mut db, "CREATE TABLE t(k INTEGER PRIMARY KEY, v INTEGER)");
+    exec_sql(&mut db, "INSERT INTO t VALUES(5,1)");
+    // (6,2) inserts; (5,3) conflicts on the existing k=5 and is skipped.
+    exec_sql(&mut db, "INSERT OR IGNORE INTO t VALUES(6,2),(5,3)");
+
+    // sqlite3: last_insert_rowid() == 6 (last row actually inserted)
+    assert_eq!(db.last_insert_rowid(), 6);
+}
+
+/// The bulk-transfer fast path (`INSERT INTO t SELECT * FROM src`, no column
+/// list) must also report the last inserted rowid. Source rows are inserted out
+/// of rowid order so the value left by the last `INSERT INTO src` (200) differs
+/// from the last row copied into `t` in scan order (rowid 300) — sqlite3 == 300.
+#[test]
+fn test_last_insert_rowid_bulk_transfer() {
+    let mut db = Database::new();
+
+    exec_sql(&mut db, "CREATE TABLE src(k INTEGER PRIMARY KEY, v INTEGER)");
+    exec_sql(&mut db, "INSERT INTO src VALUES(300,3)");
+    exec_sql(&mut db, "INSERT INTO src VALUES(100,1)");
+    exec_sql(&mut db, "INSERT INTO src VALUES(200,2)");
+    assert_eq!(db.last_insert_rowid(), 200); // last src insert
+
+    exec_sql(&mut db, "CREATE TABLE t(k INTEGER PRIMARY KEY, v INTEGER)");
+    exec_sql(&mut db, "INSERT INTO t SELECT * FROM src");
+
+    // sqlite3: last_insert_rowid() == 300 (last row copied, in rowid scan order)
+    assert_eq!(db.last_insert_rowid(), 300);
 }


### PR DESCRIPTION
## Summary

Fixes #5886. After a multi-row `INSERT ... VALUES` or `INSERT ... SELECT`, `last_insert_rowid()` returned the rowid of the **first** row inserted instead of the last. The tracking variable `first_generated_id` in `execute_insert_internal` was guarded with `is_none()` at every update site, freezing on the first row — a deliberate MySQL `LAST_INSERT_ID()` choice that is wrong for SQLite, where `last_insert_rowid()` is the rowid of the *most recently inserted* row.

## Changes

- **`crates/vibesql-executor/src/insert/execution.rs`**
  - Rename `first_generated_id` -> `last_generated_id`; drop the `is_none()` guards so the last row wins.
  - Move rowid tracking to *after* the OR IGNORE / DO NOTHING skip check, so only rows **actually inserted** update `last_insert_rowid()` (a row skipped by `OR IGNORE` must not update it).
- **`crates/vibesql-executor/src/insert/bulk_transfer.rs`**
  - The bulk-transfer fast path (`INSERT INTO t SELECT * FROM src`, no column list) previously **never** updated `last_insert_rowid()` at all (returned a stale value). It now reports the highest copied INTEGER PRIMARY KEY value, matching SQLite's ascending-rowid transfer scan. (VibeSQL scans the source in physical order, which may differ from rowid order, so the max — not the last-scanned row — is used.)
- **`crates/vibesql-executor/src/tests/auto_increment_tests.rs`**
  - Fix the existing `test_last_insert_rowid_multi_row_insert` assertion (now `3`, not the incorrect `1`).
  - Add regression tests: `insert_select` (the exact issue reproducer), `multi_values_explicit_key`, `single_explicit_key`, `insert_select_zero_rows`, `or_ignore_skips_last_row`, and `bulk_transfer`.

## Test evidence

- `cargo test -p vibesql-executor --lib` — **3182 passed, 0 failed** (10 `last_insert_rowid` tests all pass).
- Direct comparison against `sqlite3` (all OK): the issue reproducer (INSERT...SELECT → 2), multi-VALUES explicit keys (30), single-row auto (1), single explicit key (100), REPLACE (5), bulk-transfer ordered (3) and reordered (300), INSERT...SELECT zero-rows (1), OR IGNORE skips last row (6).
- `lastinsert.test` TCL canary: **identical failure set** vs `main` (15 passed / 19 failed on both) — zero regressions. The remaining failures are pre-existing shim/infrastructure limitations (e.g. `db last_insert_rowid` capture, "table t2 already exists" setup errors), not the engine value this fix corrects.

## Notes / out of scope

Tables with an implicit rowid (no INTEGER PRIMARY KEY, e.g. `CREATE TABLE t(a)`) still do not update `last_insert_rowid()` — this is a **pre-existing** limitation in the non-bulk path (unrelated to the first-vs-last bug) and is left unchanged to keep this fix minimal. Worth a separate follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)