### PR TITLE
fix(rowid): match sqlite3 at i64::MAX and for negative IPK auto-assign (#5894)

### DIFF
--- a/crates/vibesql-executor/src/insert/defaults.rs
+++ b/crates/vibesql-executor/src/insert/defaults.rs
@@ -378,7 +378,7 @@ pub fn apply_default_values_with_batch_context(
     if let Some(ipk_idx) = schema.get_integer_primary_key_index() {
         if row_values[ipk_idx] == vibesql_types::SqlValue::Null {
             // Auto-generate: max(existing_pk, batch_max) + 1, or 1 if table is empty
-            let table_max = compute_next_integer_pk_value(database, storage_table_name, ipk_idx)?;
+            let table_max = compute_next_integer_pk_value(database, storage_table_name)?;
             // The next value should be max of (table_max, batch_max_ipk + 1)
             let next_val = match batch_max_ipk {
                 Some(batch_max) => table_max.max(batch_max + 1),
@@ -429,43 +429,30 @@ pub fn apply_default_values_with_batch_context(
     Ok(first_generated_id)
 }
 
-/// Compute the next INTEGER PRIMARY KEY value for auto-generation
+/// Compute the next INTEGER PRIMARY KEY value for auto-generation.
 ///
-/// Returns max(existing_pk_values) + 1, or 1 if the table is empty.
-/// This implements SQLite's behavior where inserting NULL into an INTEGER PRIMARY KEY
-/// column auto-generates the next available value.
+/// An `INTEGER PRIMARY KEY` column is an alias for the rowid, so this simply
+/// delegates to the storage-layer rowid allocator ([`Table::allocate_rowid`]),
+/// which is the single source of truth for both plain-rowid and IPK inserts
+/// (issue #5894). That matches sqlite3 exactly and, unlike the old O(n) column
+/// scan, correctly handles:
+///
+/// - negative existing IPKs (max `-5` allocates `-4`, not `1`), and
+/// - saturation at `i64::MAX` (random unused rowid, then `SQLITE_FULL` — never
+///   a debug panic or a release wrap to `i64::MIN`).
+///
+/// Returns `1` when the table does not yet exist in storage.
 fn compute_next_integer_pk_value(
     database: &vibesql_storage::Database,
     table_name: &str,
-    pk_col_idx: usize,
 ) -> Result<i64, ExecutorError> {
-    let table = match database.get_table(table_name) {
-        Some(t) => t,
-        None => {
-            // Table doesn't exist in storage yet, start at 1
-            return Ok(1);
-        }
-    };
-
-    // Find the maximum value in the PRIMARY KEY column
-    let mut max_val: i64 = 0;
-
-    for row in table.scan() {
-        if let Some(value) = row.get(pk_col_idx) {
-            let int_val = match value {
-                vibesql_types::SqlValue::Integer(i) => *i,
-                vibesql_types::SqlValue::Bigint(i) => *i,
-                vibesql_types::SqlValue::Null => continue, // Skip NULL values
-                _ => continue, // Skip non-integer values (shouldn't happen)
-            };
-            if int_val > max_val {
-                max_val = int_val;
-            }
+    match database.get_table(table_name) {
+        // Table doesn't exist in storage yet, start at 1.
+        None => Ok(1),
+        Some(table) => {
+            table.allocate_rowid().map_err(|e| ExecutorError::StorageError(e.to_string()))
         }
     }
-
-    // Return max + 1 (or 1 if table was empty, since max_val starts at 0)
-    Ok(max_val + 1)
 }
 
 #[cfg(test)]

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -533,16 +533,30 @@ fn execute_insert_internal(
             // signed-max + 1 (or 1 for a table that never held a row).
             // The returned u64 is the two's-complement bit pattern stored in
             // `Row::row_id`.
-            let mut apply_affinity = |affinity: RowidAffinity| -> u64 {
+            let mut apply_affinity = |affinity: RowidAffinity| -> Result<u64, ExecutorError> {
                 match affinity {
                     RowidAffinity::Value(i) => {
                         batch_max_rowid = Some(batch_max_rowid.map_or(i, |m| m.max(i)));
-                        i as u64
+                        Ok(i as u64)
                     }
                     RowidAffinity::Auto => {
-                        let next = batch_max_rowid.map_or(1, |m| m.saturating_add(1));
+                        // sqlite3 parity (issue #5894): max rowid + 1, but when the
+                        // running max is already i64::MAX, delegate to the storage
+                        // allocator's random-probe / SQLITE_FULL fallback instead of
+                        // saturating (which would silently reuse i64::MAX — a
+                        // duplicate rowid). The table is only consulted in that
+                        // saturated corner, so the common path stays allocation-free.
+                        let next = match batch_max_rowid {
+                            None => 1,
+                            Some(m) if m < i64::MAX => m + 1,
+                            Some(_) => db
+                                .get_table(&storage_table_name)
+                                .map(|t| t.allocate_rowid())
+                                .unwrap_or(Ok(1))
+                                .map_err(|e| ExecutorError::StorageError(e.to_string()))?,
+                        };
                         batch_max_rowid = Some(next);
-                        next as u64
+                        Ok(next as u64)
                     }
                 }
             };
@@ -550,10 +564,10 @@ fn execute_insert_internal(
             match rowid_expr {
                 // Literal value: apply rowid (INTEGER) affinity directly.
                 vibesql_ast::Expression::Literal(val) => {
-                    Some(apply_affinity(coerce_rowid_affinity(val)?))
+                    Some(apply_affinity(coerce_rowid_affinity(val)?)?)
                 }
                 // DEFAULT means auto-assign, like NULL.
-                vibesql_ast::Expression::Default => Some(apply_affinity(RowidAffinity::Auto)),
+                vibesql_ast::Expression::Default => Some(apply_affinity(RowidAffinity::Auto)?),
                 // Negative numeric literal (parsed as unary minus over a literal):
                 // negate, then apply rowid affinity. This handles -42 (integer)
                 // AND -42.0 (real) uniformly (triggerC-4.1.4).
@@ -584,7 +598,7 @@ fn execute_insert_internal(
                             ));
                         }
                     };
-                    Some(apply_affinity(coerce_rowid_affinity(&negated)?))
+                    Some(apply_affinity(coerce_rowid_affinity(&negated)?)?)
                 }
                 _ => {
                     // For complex expressions (CASE, functions, subqueries, trigger
@@ -620,7 +634,7 @@ fn execute_insert_internal(
 
                     // Apply rowid (INTEGER) affinity to the evaluated value,
                     // matching the literal path (triggerC-4.1.x).
-                    Some(apply_affinity(coerce_rowid_affinity(&val)?))
+                    Some(apply_affinity(coerce_rowid_affinity(&val)?)?)
                 }
             }
         } else {
@@ -1171,12 +1185,6 @@ fn execute_insert_internal(
                 .get_table(&storage_table_name)
                 .ok_or_else(|| ExecutorError::TableNotFound(full_table_name.clone()))?;
             let row_count_before = table_ref.row_count();
-            // Collision-safe auto-rowid (issue #5835): identical to the old
-            // `physical_row_count + 1` for purely implicit tables, but also
-            // exceeds every explicit rowid ever assigned — required after a
-            // reload, where persisted rowids can exceed the compacted
-            // physical count.
-            let next_auto_rowid = table_ref.next_rowid();
 
             // SQLite REPLACE semantics: Check if the rowid we're about to use is reserved.
             // During REPLACE, the rowid for the new row is allocated BEFORE firing triggers.
@@ -1185,7 +1193,19 @@ fn execute_insert_internal(
             // - Explicit reservation: AFTER DELETE trigger auto-INSERTs skip to next rowid (SQLite
             //   reuses freed rowids, but VibeSQL doesn't, so we skip instead)
             let mut final_explicit_rowid = explicit_rowid;
-            let rowid_to_use = explicit_rowid.unwrap_or(next_auto_rowid);
+            // Collision-safe auto-rowid (issue #5835, #5894): only allocated when
+            // the row has no explicit rowid. `allocate_rowid_u64()` matches sqlite3
+            // — the max rowid + 1 (identical to the old `physical_row_count + 1`
+            // for purely implicit tables, but also exceeding every explicit rowid
+            // ever assigned, required after a reload), a random *unused* rowid when
+            // the max is already `i64::MAX`, or `SQLITE_FULL` if the rowid space is
+            // exhausted — never a silent reuse of `i64::MAX` (a duplicate rowid).
+            let rowid_to_use = match explicit_rowid {
+                Some(r) => r,
+                None => table_ref
+                    .allocate_rowid_u64()
+                    .map_err(|e| ExecutorError::StorageError(e.to_string()))?,
+            };
             if let Some((reserved_rowid, is_explicit_reservation)) =
                 db.get_reserved_rowid_info(&storage_table_name)
             {
@@ -1444,12 +1464,18 @@ fn resolve_replace_conflicts_for_row(
     let reserved_rowid = if let Some(rowid) = explicit_rowid {
         rowid
     } else {
-        // Auto-allocate the next available rowid. `next_rowid()` covers both
-        // the physical row count (implicit rowids, including deleted rows)
+        // Auto-allocate the next available rowid. `allocate_rowid_u64()` covers
+        // both the physical row count (implicit rowids, including deleted rows)
         // and every explicit rowid ever assigned — required after a reload,
         // where persisted rowids can exceed the compacted physical count
-        // (issue #5835).
-        db.get_table(storage_table_name).map(|t| t.next_rowid()).unwrap_or(1)
+        // (issue #5835) — and matches sqlite3 at `i64::MAX` (random unused rowid,
+        // then `SQLITE_FULL`) instead of silently reusing it (issue #5894).
+        match db.get_table(storage_table_name) {
+            None => 1,
+            Some(t) => {
+                t.allocate_rowid_u64().map_err(|e| ExecutorError::StorageError(e.to_string()))?
+            }
+        }
     };
 
     // Reserve the rowid before firing triggers

--- a/crates/vibesql-executor/tests/rowid_saturation_tests.rs
+++ b/crates/vibesql-executor/tests/rowid_saturation_tests.rs
@@ -1,0 +1,164 @@
+//! Regression tests for issue #5894: rowid allocation edge cases at the signed
+//! 64-bit boundary and with negative INTEGER PRIMARY KEY values.
+//!
+//! Two allocation paths previously diverged from sqlite3 3.51.0:
+//!
+//!  1. Plain-rowid saturation: `Table::next_rowid_signed()` saturated at
+//!     `i64::MAX`, so a table whose max rowid was `i64::MAX` silently allocated
+//!     `i64::MAX` again — a *duplicate* rowid. sqlite3 instead picks a random
+//!     unused rowid (returning SQLITE_FULL only if probing fails).
+//!
+//!  2. INTEGER PRIMARY KEY NULL auto-assign (`compute_next_integer_pk_value`)
+//!     floored the max at 0 (ignoring negative IPKs → allocated `1` instead of
+//!     `max + 1`) and did an unchecked `max + 1` that panicked in debug / wrapped
+//!     to `i64::MIN` in release when the max was `i64::MAX`.
+//!
+//! Both now delegate to `Table::allocate_rowid`, matching sqlite3 exactly. The
+//! random-probe fallback is inherently nondeterministic, so the saturation tests
+//! assert uniqueness + success, not specific rowid values.
+
+use vibesql_executor::{InsertExecutor, SelectExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn exec(db: &mut Database, sql: &str) -> Result<(), vibesql_executor::ExecutorError> {
+    match Parser::parse_sql(sql).expect("test SQL should parse") {
+        vibesql_ast::Statement::CreateTable(s) => {
+            vibesql_executor::CreateTableExecutor::execute(&s, db)?;
+        }
+        vibesql_ast::Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s)?;
+        }
+        other => panic!("unexpected statement in test: {other:?}"),
+    }
+    Ok(())
+}
+
+/// Reinterpret an integer-ish SqlValue as i64 (rowids are stored as the u64 bit
+/// pattern and surface as Bigint; IPK columns surface as Integer).
+fn as_i64(v: &SqlValue) -> i64 {
+    match v {
+        SqlValue::Integer(i) => *i,
+        SqlValue::Bigint(i) => *i,
+        other => panic!("expected an integer value, got {other:?}"),
+    }
+}
+
+/// Collect one integer column across all rows, reinterpreted as i64.
+fn column_i64(db: &Database, sql: &str) -> Vec<i64> {
+    match Parser::parse_sql(sql).expect("select should parse") {
+        vibesql_ast::Statement::Select(s) => SelectExecutor::new(db)
+            .execute(&s)
+            .expect("select should succeed")
+            .into_iter()
+            .map(|r| as_i64(&r.values[0]))
+            .collect(),
+        _ => panic!("expected SELECT"),
+    }
+}
+
+/// Bug 1: a plain-rowid table saturated at `i64::MAX` allocates a *distinct*
+/// random rowid on the next insert — never a silent duplicate `i64::MAX`.
+#[test]
+fn plain_rowid_at_i64_max_allocates_unique_rowid() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(x INTEGER)").unwrap();
+    exec(&mut db, "INSERT INTO t(rowid, x) VALUES(9223372036854775807, 1)").unwrap();
+    // Previously: silent duplicate rowid = i64::MAX.
+    exec(&mut db, "INSERT INTO t VALUES(2)").unwrap();
+
+    let rowids = column_i64(&db, "SELECT rowid FROM t ORDER BY x");
+    assert_eq!(rowids.len(), 2, "both rows present");
+    assert_eq!(rowids[0], i64::MAX, "explicit MAX row unchanged");
+    assert_ne!(rowids[1], i64::MAX, "second rowid must NOT duplicate i64::MAX");
+    assert_ne!(rowids[0], rowids[1], "rowids must be unique");
+    assert!(rowids[1] > 0, "sqlite3 probes positive rowids");
+}
+
+/// Bug 2a: NULL INTEGER PRIMARY KEY auto-assign on a table whose only rows are
+/// negative allocates `max + 1` (sqlite3: after `-5`, next is `-4`), not `1`.
+#[test]
+fn ipk_negative_only_auto_assign_matches_sqlite() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(a INTEGER PRIMARY KEY, b INTEGER)").unwrap();
+    exec(&mut db, "INSERT INTO t VALUES(-5, 1)").unwrap();
+    exec(&mut db, "INSERT INTO t(b) VALUES(2)").unwrap();
+
+    let a = column_i64(&db, "SELECT a FROM t ORDER BY b");
+    assert_eq!(a, vec![-5, -4], "sqlite3: max(-5) + 1 = -4, not 1");
+}
+
+/// Bug 2a (edge): after rowid `-1`, the next auto-assigned IPK is `0`.
+#[test]
+fn ipk_negative_one_auto_assign_yields_zero() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(a INTEGER PRIMARY KEY, b INTEGER)").unwrap();
+    exec(&mut db, "INSERT INTO t VALUES(-1, 1)").unwrap();
+    exec(&mut db, "INSERT INTO t(b) VALUES(2)").unwrap();
+
+    let a = column_i64(&db, "SELECT a FROM t ORDER BY b");
+    assert_eq!(a, vec![-1, 0], "sqlite3: max(-1) + 1 = 0");
+}
+
+/// Bug 2a: a mix of negative and positive IPKs allocates `max_positive + 1`.
+#[test]
+fn ipk_mixed_sign_auto_assign_uses_max() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(a INTEGER PRIMARY KEY, b INTEGER)").unwrap();
+    exec(&mut db, "INSERT INTO t VALUES(-5, 1)").unwrap();
+    exec(&mut db, "INSERT INTO t VALUES(10, 2)").unwrap();
+    exec(&mut db, "INSERT INTO t(b) VALUES(3)").unwrap();
+
+    let a = column_i64(&db, "SELECT a FROM t ORDER BY b");
+    assert_eq!(a, vec![-5, 10, 11], "sqlite3: max(-5, 10) + 1 = 11");
+}
+
+/// Bug 2b: NULL INTEGER PRIMARY KEY auto-assign when the max IPK is `i64::MAX`
+/// must NOT panic (debug) or wrap to `i64::MIN` (release) — it allocates a
+/// distinct random rowid, matching sqlite3.
+#[test]
+fn ipk_at_i64_max_auto_assign_no_panic_no_wrap() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(a INTEGER PRIMARY KEY, b INTEGER)").unwrap();
+    exec(&mut db, "INSERT INTO t VALUES(9223372036854775807, 1)").unwrap();
+    // Previously: debug panic ("attempt to add with overflow") / release wrap.
+    exec(&mut db, "INSERT INTO t(b) VALUES(2)").unwrap();
+
+    let a = column_i64(&db, "SELECT a FROM t ORDER BY b");
+    assert_eq!(a.len(), 2, "both rows present");
+    assert_eq!(a[0], i64::MAX, "explicit MAX row unchanged");
+    assert_ne!(a[1], i64::MAX, "auto-assigned IPK must not duplicate i64::MAX");
+    assert_ne!(a[1], i64::MIN, "auto-assigned IPK must not wrap to i64::MIN");
+    assert!(a[1] > 0, "sqlite3 probes positive rowids");
+}
+
+/// Normal sequential allocation is unchanged for both plain-rowid and IPK
+/// tables — the common path must not regress.
+#[test]
+fn sequential_allocation_unchanged() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE p(x INTEGER)").unwrap();
+    exec(&mut db, "INSERT INTO p VALUES(10), (20), (30)").unwrap();
+    assert_eq!(column_i64(&db, "SELECT rowid FROM p ORDER BY x"), vec![1, 2, 3]);
+
+    exec(&mut db, "CREATE TABLE k(a INTEGER PRIMARY KEY, b INTEGER)").unwrap();
+    exec(&mut db, "INSERT INTO k(b) VALUES(1)").unwrap();
+    exec(&mut db, "INSERT INTO k(b) VALUES(2)").unwrap();
+    exec(&mut db, "INSERT INTO k VALUES(100, 3)").unwrap();
+    exec(&mut db, "INSERT INTO k(b) VALUES(4)").unwrap();
+    assert_eq!(column_i64(&db, "SELECT a FROM k ORDER BY b"), vec![1, 2, 100, 101]);
+}
+
+/// A table one below the ceiling still allocates `i64::MAX` itself — the
+/// boundary is exclusive, so this is NOT an error case.
+#[test]
+fn rowid_just_below_max_allocates_max() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(x INTEGER)").unwrap();
+    exec(&mut db, "INSERT INTO t(rowid, x) VALUES(9223372036854775806, 1)").unwrap();
+    exec(&mut db, "INSERT INTO t VALUES(2)").unwrap();
+
+    let rowids = column_i64(&db, "SELECT rowid FROM t ORDER BY x");
+    assert_eq!(rowids, vec![i64::MAX - 1, i64::MAX]);
+}

--- a/crates/vibesql-storage/src/lib.rs
+++ b/crates/vibesql-storage/src/lib.rs
@@ -60,7 +60,7 @@ pub use query_buffer_pool::{
 };
 pub use row::{Row, RowValues, TxnId, PRE_MVCC_TXN_ID, ROW_INLINE_CAPACITY};
 pub use statistics::{ColumnStatistics, TableIndexInfo, TableStatistics};
-pub use table::{DeleteResult, Table};
+pub use table::{DeleteResult, RowidExhausted, Table};
 pub use wal::{
     DurabilityConfig, DurabilityMode, Lsn, PersistenceConfig, PersistenceEngine, PersistenceStats,
     TransactionDurability, WalEntry, WalOp, WalOpTag,
@@ -450,13 +450,73 @@ mod tests {
         assert_eq!(table2.next_rowid_signed(), 4, "sqlite3: max(-5, 3) + 1 = 4");
     }
 
-    /// `next_rowid` saturates instead of overflowing when the max rowid is
-    /// `i64::MAX` (SQLite reports SQLITE_FULL; a duplicate-rowid conflict is
-    /// the closest safe behavior — never a wrap to a bogus rowid).
+    /// `next_rowid_signed` is the infallible *peek* helper: it saturates at
+    /// `i64::MAX` rather than overflowing. The fallible sqlite3-parity allocator
+    /// [`Table::allocate_rowid`] is what insert paths use for stored rowids
+    /// (see the tests below); this only guards the peek's saturation.
     #[test]
     fn test_next_rowid_saturates_at_i64_max() {
         let mut table = rowid_test_table();
         table.insert(Row::with_row_id(vec![SqlValue::Integer(1)], i64::MAX as u64)).unwrap();
         assert_eq!(table.next_rowid_signed(), i64::MAX);
+    }
+
+    /// `allocate_rowid` matches sqlite3's `max(rowid) + 1` in the ordinary
+    /// (non-saturated) range, including negative maxima — the same values the
+    /// plain-rowid and INTEGER PRIMARY KEY NULL-assign paths must agree on
+    /// (issue #5894).
+    #[test]
+    fn test_allocate_rowid_matches_sqlite_normal_range() {
+        // Empty table: first allocation is 1.
+        let table = rowid_test_table();
+        assert_eq!(table.allocate_rowid(), Ok(1));
+
+        // Only negative rowids present: next is signed max + 1, NOT 1
+        // (sqlite3: after rowid -5, next is -4; after -1, next is 0).
+        let mut neg = rowid_test_table();
+        neg.insert(Row::with_row_id(vec![SqlValue::Integer(1)], (-5i64) as u64)).unwrap();
+        assert_eq!(neg.allocate_rowid(), Ok(-4));
+
+        let mut neg1 = rowid_test_table();
+        neg1.insert(Row::with_row_id(vec![SqlValue::Integer(1)], (-1i64) as u64)).unwrap();
+        assert_eq!(neg1.allocate_rowid(), Ok(0));
+
+        // Mixed negative/positive: the positive max dominates.
+        neg.insert(Row::with_row_id(vec![SqlValue::Integer(2)], 10)).unwrap();
+        assert_eq!(neg.allocate_rowid(), Ok(11));
+
+        // A table one below the ceiling allocates i64::MAX itself (no error).
+        let mut near = rowid_test_table();
+        near.insert(Row::with_row_id(vec![SqlValue::Integer(1)], (i64::MAX - 1) as u64)).unwrap();
+        assert_eq!(near.allocate_rowid(), Ok(i64::MAX));
+    }
+
+    /// At `i64::MAX`, sqlite3 does NOT reuse the max (a silent duplicate) or
+    /// overflow — it probes a random *unused* rowid. `allocate_rowid` must
+    /// return a fresh, in-range, not-in-use rowid (issue #5894). The value is
+    /// nondeterministic, so we assert uniqueness and validity, not a specific
+    /// number.
+    #[test]
+    fn test_allocate_rowid_at_i64_max_probes_unused() {
+        let mut table = rowid_test_table();
+        table.insert(Row::with_row_id(vec![SqlValue::Integer(1)], i64::MAX as u64)).unwrap();
+
+        let in_use: std::collections::HashSet<i64> =
+            table.scan_live().map(|(_, r)| r.row_id.unwrap() as i64).collect();
+
+        // 20 draws must all be positive, in range, and unused — never i64::MAX.
+        for _ in 0..20 {
+            let allocated = table.allocate_rowid().expect("random probe should find a free rowid");
+            assert!(allocated > 0, "probed rowid must be positive: {allocated}");
+            assert!(allocated < i64::MAX, "probed rowid must be below the ceiling");
+            assert!(!in_use.contains(&allocated), "probed rowid must be unused: {allocated}");
+        }
+    }
+
+    /// The exhaustion marker mirrors sqlite3's SQLITE_FULL text so callers can
+    /// surface it verbatim (issue #5894).
+    #[test]
+    fn test_rowid_exhausted_display() {
+        assert_eq!(crate::RowidExhausted.to_string(), "database or disk is full");
     }
 }

--- a/crates/vibesql-storage/src/table/mod.rs
+++ b/crates/vibesql-storage/src/table/mod.rs
@@ -244,6 +244,24 @@ impl Clone for Table {
     }
 }
 
+/// Rowid allocation exhausted the signed 64-bit rowid space (issue #5894).
+///
+/// sqlite3 surfaces this as `SQLITE_FULL` ("database or disk is full"): when
+/// the maximum rowid is already `i64::MAX`, sqlite3 probes random unused
+/// rowids rather than reusing `i64::MAX` (a silent duplicate) or overflowing;
+/// if every probe collides with an existing rowid it gives up with this error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RowidExhausted;
+
+impl std::fmt::Display for RowidExhausted {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Matches sqlite3's SQLITE_FULL text so callers can surface it verbatim.
+        write!(f, "database or disk is full")
+    }
+}
+
+impl std::error::Error for RowidExhausted {}
+
 impl Table {
     /// Create a new empty table with given schema
     ///
@@ -860,6 +878,63 @@ impl Table {
         self.next_rowid_signed() as u64
     }
 
+    /// Allocate the next rowid for an auto-assigned insert, matching sqlite3
+    /// exactly — including the `i64::MAX` corner that [`Table::next_rowid_signed`]
+    /// only saturates over (issue #5894).
+    ///
+    /// This is the fallible allocator that insert paths must use for any rowid
+    /// that gets *stored* (implicit rowids, explicit NULL/DEFAULT rowids, and
+    /// `INTEGER PRIMARY KEY` NULL auto-assign). Semantics:
+    ///
+    /// - empty table (never held a row): `1`;
+    /// - otherwise the signed maximum rowid `+ 1` (negative maxima included —
+    ///   a table whose max rowid is `-5` allocates `-4`, matching sqlite3);
+    /// - when the maximum rowid is already `i64::MAX`, sqlite3 does not reuse it
+    ///   (a silent duplicate) or overflow — it probes up to 100 random positive
+    ///   rowids for one not currently in use, returning [`RowidExhausted`]
+    ///   (`SQLITE_FULL`) only if every probe collides.
+    ///
+    /// The random-probe fallback is inherently nondeterministic (as it is in
+    /// sqlite3): callers get *some* unused rowid, not a predictable one.
+    pub fn allocate_rowid(&self) -> Result<i64, RowidExhausted> {
+        match self.max_assigned_rowid {
+            None => Ok(1),
+            // `m < i64::MAX` guarantees `m + 1` cannot overflow.
+            Some(m) if m < i64::MAX => Ok(m + 1),
+            Some(_) => self.probe_random_rowid(),
+        }
+    }
+
+    /// [`Table::allocate_rowid`] as the u64 bit pattern stored in `Row::row_id`
+    /// (two's complement — an allocation of `-4` is returned as `(-4i64) as u64`).
+    #[inline]
+    pub fn allocate_rowid_u64(&self) -> Result<u64, RowidExhausted> {
+        self.allocate_rowid().map(|r| r as u64)
+    }
+
+    /// sqlite3's random-rowid fallback: probe positive rowids in `[1, i64::MAX)`
+    /// for one not currently in use, giving up after 100 attempts (issue #5894).
+    ///
+    /// The set of in-use effective rowids is snapshotted once (live rows only —
+    /// deleted rowids are free) so each probe is an O(1) membership test.
+    fn probe_random_rowid(&self) -> Result<i64, RowidExhausted> {
+        use rand::RngExt;
+
+        let in_use: std::collections::HashSet<i64> = self
+            .scan_live()
+            .map(|(pos, row)| row.row_id.map_or(pos as i64 + 1, |rid| rid as i64))
+            .collect();
+
+        let mut rng = rand::rng();
+        for _ in 0..100 {
+            let candidate = rng.random_range(1..i64::MAX);
+            if !in_use.contains(&candidate) {
+                return Ok(candidate);
+            }
+        }
+        Err(RowidExhausted)
+    }
+
     /// Get count of deleted (logically removed) rows
     ///
     /// This is used for DML cost estimation, as tables with many deleted rows
@@ -905,10 +980,19 @@ impl Table {
     }
 
     /// Clear all rows
+    ///
+    /// Used by the full-table clear paths (`TRUNCATE TABLE` and the no-`WHERE`
+    /// `DELETE FROM t` fast path). Resets rowid allocation: an emptied table's
+    /// next rowid is `1`, matching sqlite3 (`max(rowid)` of an empty table is
+    /// NULL, so allocation restarts at 1) and the AUTO_INCREMENT-reset contract
+    /// (issue #5894). Since `allocate_rowid` now reads `max_assigned_rowid`, the
+    /// counter must be cleared here — otherwise a truncated table would keep
+    /// allocating past its pre-truncate maximum.
     pub fn clear(&mut self) {
         self.rows.clear();
         self.deleted.clear();
         self.deleted_count = 0;
+        self.max_assigned_rowid = None;
         // Clear indexes (delegate to IndexManager)
         self.indexes.clear();
         // Reset append mode tracking


### PR DESCRIPTION
Closes #5894

## Summary

Two rowid-allocation paths diverged from sqlite3 3.51.0 in extreme/deliberate corners. Both now delegate to a single storage allocator, `Table::allocate_rowid()`, which matches sqlite3 exactly.

### Bug 1 — plain-rowid saturation (silent duplicate rowid)
`Table::next_rowid_signed()` saturated at `i64::MAX`, so a table whose max rowid was `i64::MAX` silently allocated a **duplicate** `i64::MAX` — breaking `WHERE rowid=...` and `DELETE ... WHERE rowid=...`. sqlite3 instead probes a random unused rowid.

### Bug 2 — IPK NULL auto-assign (`compute_next_integer_pk_value`)
- **Negative-IPK floor**: the running max floored at `0`, so a table whose max IPK was `-5` allocated `1` instead of `-4`.
- **Unchecked `max + 1`**: at `i64::MAX` this panicked in debug ("attempt to add with overflow") and wrapped to `i64::MIN` in release.

## Fix

`Table::allocate_rowid() -> Result<i64, RowidExhausted>` is now the single source of truth for both plain-rowid and IPK inserts:
- empty table -> `1`;
- otherwise signed `max + 1` (negatives included, so `-5 -> -4`, `-1 -> 0`);
- at `i64::MAX`: bounded 100-attempt random probe for an unused rowid, then `RowidExhausted` ("database or disk is full", = `SQLITE_FULL`).

The IPK path no longer runs an O(n) column scan per insert (delegates to the allocator, which reads the already-tracked `max_assigned_rowid`).

`Table::clear()` (TRUNCATE / no-`WHERE` `DELETE FROM t` fast path) now resets `max_assigned_rowid`, so an emptied table restarts allocation at `1` — matching sqlite3 (`max(rowid)` of an empty table is NULL) and the existing AUTO_INCREMENT-reset tests, which now depend on the counter rather than a live-row scan.

## sqlite3-parity evidence (release CLI vs sqlite3 3.51.0)

| Case | sqlite3 | this branch |
|------|---------|-------------|
| plain rowid at `i64::MAX`, then `INSERT` | random unused rowid | random unused rowid (unique, positive, != MAX) |
| IPK `-5`, then NULL auto-assign | `-4` | `-4` |
| IPK `-1`, then NULL auto-assign | `0` | `0` |
| IPK mix `-5,10`, then NULL | `11` | `11` |
| IPK at `i64::MAX`, then NULL | random unused rowid (no panic/wrap) | random unused rowid (no panic/wrap) |
| rowid `i64::MAX - 1`, then `INSERT` | `i64::MAX` (no error) | `i64::MAX` (no error) |
| normal sequential | `1,2,3` | `1,2,3` |

## Tests

- `crates/vibesql-storage/src/lib.rs`: `allocate_rowid` unit tests (normal range incl. negatives, the `i64::MAX` random-probe returning a fresh unused rowid, `RowidExhausted` display).
- `crates/vibesql-executor/tests/rowid_saturation_tests.rs` (new): end-to-end coverage of every edge case. Nondeterministic random-probe cases assert uniqueness + success, not specific values.
- Full `vibesql-storage` + `vibesql-executor` suites pass (60 test binaries, 0 failures), including PR #5935's 12 `last_insert_rowid` tests and the AUTO_INCREMENT/TRUNCATE tests.
- TCL `intpkey.test`: 84 passed, 0 failed. (`rowid.test` hits a pre-existing per-file timeout on this loaded machine — confirmed identical on the unchanged `main` binary, not a regression.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)