### PR TITLE
fix(alter): rewrite renamed column in CHECK/PK/FK clauses, child FKs, and views

### DIFF
--- a/crates/vibesql-catalog/src/store/advanced/views.rs
+++ b/crates/vibesql-catalog/src/store/advanced/views.rs
@@ -43,6 +43,19 @@ impl super::super::Catalog {
         self.views.get(&key)
     }
 
+    /// Get a mutable reference to a VIEW definition by name.
+    ///
+    /// Used by `ALTER TABLE ... RENAME COLUMN` to rewrite a view's stored
+    /// `sql_definition` text and its parsed `query` AST in place when a source
+    /// column it references is renamed (mirrors SQLite re-resolving dependent
+    /// views). Case-insensitivity follows the same key normalization as
+    /// [`get_view`](Self::get_view).
+    pub fn get_view_mut(&mut self, name: &str) -> Option<&mut ViewDefinition> {
+        let key =
+            if self.case_sensitive_identifiers { name.to_string() } else { name.to_uppercase() };
+        self.views.get_mut(&key)
+    }
+
     /// List all VIEW names (returns original names, not normalized keys)
     pub fn list_views(&self) -> Vec<String> {
         self.views.values().map(|v| v.name.clone()).collect()

--- a/crates/vibesql-executor/src/alter/columns.rs
+++ b/crates/vibesql-executor/src/alter/columns.rs
@@ -414,22 +414,50 @@ pub(super) fn execute_rename_column(
     // body, SQLite (legacy_alter_table=OFF) aborts the whole ALTER and leaves
     // the schema unchanged. Roll back the schema rename on that error so the
     // ALTER is atomic, matching SQLite.
+    // Rolls back the just-applied schema rename and returns the error, keeping the
+    // ALTER atomic when a dependent-object rewrite (trigger or view) aborts on a
+    // genuine ambiguity — matching SQLite, which leaves the schema unchanged.
+    let rollback = |database: &mut Database, err: ExecutorError| -> ExecutorError {
+        if let Some(table) = database.get_table_mut(&stmt.table_name) {
+            if let Some(idx) = table.schema.get_column_index(&stmt.new_column_name) {
+                let _ = table.schema_mut().rename_column(idx, &stmt.old_column_name);
+            }
+        }
+        database.invalidate_columnar_cache(&stmt.table_name);
+        err
+    };
+
     if let Err(err) = super::table_options::rewrite_triggers_for_column_rename(
         database,
         &stmt.table_name,
         &stmt.old_column_name,
         &stmt.new_column_name,
     ) {
-        if let Some(table) = database.get_table_mut(&stmt.table_name) {
-            if let Some(idx) = table.schema.get_column_index(&stmt.new_column_name) {
-                // Best-effort rollback; the column was just renamed so this
-                // restores the original name.
-                let _ = table.schema_mut().rename_column(idx, &stmt.old_column_name);
-            }
-        }
-        database.invalidate_columnar_cache(&stmt.table_name);
-        return Err(err);
+        return Err(rollback(database, err));
     }
+
+    // Propagate the rename into dependent VIEW definitions (verbatim
+    // `sql_definition` text + parsed `query` AST). Runs after the trigger rewrite
+    // so an ambiguous view aborts the whole ALTER before index/FK bookkeeping.
+    if let Err(err) = super::table_options::rewrite_views_for_column_rename(
+        database,
+        &stmt.table_name,
+        &stmt.old_column_name,
+        &stmt.new_column_name,
+    ) {
+        return Err(rollback(database, err));
+    }
+
+    // Propagate the rename into any child table's foreign key that references the
+    // renamed column of THIS (parent) table: rewrite the child's verbatim
+    // `REFERENCES <table>(<col_list>)` text and its in-memory FK parent-column
+    // metadata (altercol.test 4.1/4.4).
+    super::table_options::rewrite_child_foreign_keys_for_column_rename(
+        database,
+        &stmt.table_name,
+        &stmt.old_column_name,
+        &stmt.new_column_name,
+    );
 
     // Propagate the rename into dependent index metadata, in BOTH copies:
     // the catalog copy (drives sqlite_master rendering and planner/FK

--- a/crates/vibesql-executor/src/alter/mod.rs
+++ b/crates/vibesql-executor/src/alter/mod.rs
@@ -187,6 +187,7 @@ fn update_sql_source_after_alter(
             .and_then(|coldef| crate::alter_rewrite::append_column(&current, &coldef)),
         AlterTableStmt::RenameColumn(rename) => crate::alter_rewrite::rename_column(
             &current,
+            table_name,
             &rename.old_column_name,
             &rename.new_column_name,
         ),

--- a/crates/vibesql-executor/src/alter/table_options.rs
+++ b/crates/vibesql-executor/src/alter/table_options.rs
@@ -331,3 +331,170 @@ pub(super) fn rewrite_triggers_for_column_rename(
     }
     Ok(())
 }
+
+/// Propagate a *parent* table's column rename into every *child* table's foreign
+/// key that references it, when `ALTER TABLE <parent> RENAME <old_col> TO
+/// <new_col>` runs.
+///
+/// SQLite (`legacy_alter_table=OFF`) rewrites the referenced column name in each
+/// child's `REFERENCES <parent>(<col_list>)` clause — both the stored
+/// `sqlite_master.sql` text and the in-memory FK metadata — so FK enforcement and
+/// reload stay consistent (verified against sqlite3 3.51.0, altercol.test
+/// 4.1/4.4). Without the in-memory `parent_column_names` update, FK checks would
+/// keep matching on the old parent column; without the `sql_source` rewrite, a
+/// reload would rehydrate the stale reference (and the fail-closed open policy
+/// would reject the child table's checkpoint).
+///
+/// The renamed parent's *own* table (its PK/UNIQUE/FK-local column references) is
+/// handled separately by `update_sql_source_after_alter` +
+/// `alter_rewrite::rename_column`; this loop only touches *other* tables' FK
+/// references to it (a self-referential child FK is covered because the parent is
+/// just another table in the same loop).
+pub(super) fn rewrite_child_foreign_keys_for_column_rename(
+    database: &mut Database,
+    parent_table: &str,
+    old_column: &str,
+    new_column: &str,
+) {
+    for tbl in database.list_tables() {
+        let updated_schema = {
+            let Some(table) = database.get_table_mut(&tbl) else {
+                continue;
+            };
+            let mut changed = false;
+            for fk in table.schema_mut().foreign_keys.iter_mut() {
+                if !fk.parent_table.eq_ignore_ascii_case(parent_table) {
+                    continue;
+                }
+                for pcol in fk.parent_column_names.iter_mut() {
+                    if pcol.eq_ignore_ascii_case(old_column) {
+                        *pcol = new_column.to_string();
+                        changed = true;
+                    }
+                }
+            }
+            if !changed {
+                continue;
+            }
+            // Rewrite the verbatim `REFERENCES <parent>(<col_list>)` text. If the
+            // in-place edit cannot apply cleanly, invalidate so `sql_source` is
+            // reconstructed from the (already-updated) FK metadata — never left
+            // naming the old column.
+            let rewritten = table.schema.sql_source.as_deref().and_then(|sql| {
+                crate::alter_rewrite::rename_references_column(
+                    sql,
+                    parent_table,
+                    old_column,
+                    new_column,
+                )
+            });
+            match rewritten {
+                Some(text) => table.schema_mut().set_sql_source(text),
+                None => table.schema_mut().invalidate_sql_source(),
+            }
+            table.schema.clone()
+        };
+        database.catalog.replace_table_schema(&tbl, updated_schema);
+    }
+}
+
+/// Rewrite dependent VIEW definitions that reference a renamed column, when
+/// `ALTER TABLE <table> RENAME <old_column> TO <new_column>` runs.
+///
+/// SQLite (`legacy_alter_table=OFF`) rewrites references inside view bodies that
+/// resolve to `<table>.<old_column>` — both qualified (`t.col`) and unqualified —
+/// updating the `sqlite_master.sql` text and re-resolving the view (verified
+/// against sqlite3 3.51.0, altercol.test group 8). VibeSQL materializes views by
+/// executing their stored `query` AST, so both the verbatim `sql_definition` and
+/// the parsed `query` are rewritten here (the latter by re-parsing the rewritten
+/// text) so the view keeps working after the rename.
+///
+/// Reuses the trigger-body column resolver
+/// ([`rewrite_column_refs_in_trigger_sql`]), which is table-name-aware and
+/// aborts on a genuinely ambiguous unqualified reference. Two-phase (compute all
+/// rewrites, then commit) so an ambiguity in any view aborts the whole ALTER
+/// before any view is mutated, matching SQLite's atomic behavior.
+pub(super) fn rewrite_views_for_column_rename(
+    database: &mut Database,
+    table: &str,
+    old_column: &str,
+    new_column: &str,
+) -> Result<(), ExecutorError> {
+    // Snapshot table -> column-name set for the resolver (same pattern as the
+    // trigger rewrite). Reflects the post-rename schema, so the renamed table's
+    // pre-rename column is handled explicitly in the closure.
+    let schema: std::collections::HashMap<String, Vec<String>> = database
+        .list_tables()
+        .into_iter()
+        .filter_map(|name| {
+            database.get_table(&name).map(|tbl| {
+                (
+                    name.to_ascii_lowercase(),
+                    tbl.schema.columns.iter().map(|c| c.name.clone()).collect(),
+                )
+            })
+        })
+        .collect();
+
+    let renamed_table_lc = table.to_ascii_lowercase();
+    let old_column_owned = old_column.to_string();
+    let table_has_column = move |t: &str, c: &str| -> bool {
+        let t_lc = t.to_ascii_lowercase();
+        if t_lc == renamed_table_lc && c.eq_ignore_ascii_case(&old_column_owned) {
+            return true;
+        }
+        schema.get(&t_lc).is_some_and(|cols| cols.iter().any(|col| col.eq_ignore_ascii_case(c)))
+    };
+
+    // Phase 1: compute the rewritten verbatim text for each affected view. A
+    // genuine ambiguity aborts the whole ALTER (SQLite:
+    // "error in view <name>: ambiguous column name: <col>").
+    let view_names = database.catalog.list_views();
+    let mut pending: Vec<(String, String)> = Vec::new();
+    for name in view_names {
+        let Some(view) = database.catalog.get_view(&name) else {
+            continue;
+        };
+        // Prefer the verbatim `CREATE VIEW` text; fall back to reconstructing it
+        // from the parsed query when a view was stored without captured source,
+        // so a view still tracks the rename either way.
+        let old_text = view.sql_definition.clone().unwrap_or_else(|| {
+            use vibesql_ast::pretty_print::ToSql;
+            let cols = view
+                .columns
+                .as_ref()
+                .map(|c| format!("({})", c.join(", ")))
+                .unwrap_or_default();
+            format!("CREATE VIEW {}{} AS {}", view.name, cols, view.query.to_sql())
+        });
+        let new_text = rewrite_column_refs_in_trigger_sql(
+            &old_text,
+            table,
+            old_column,
+            new_column,
+            &table_has_column,
+        )
+        .map_err(|col| {
+            ExecutorError::Other(format!("error in view {}: ambiguous column name: {}", name, col))
+        })?;
+        if new_text != old_text {
+            pending.push((name, new_text));
+        }
+    }
+
+    // Phase 2: commit each update — re-parse the rewritten text into a fresh
+    // `query` AST (so view execution resolves the new column) and store both the
+    // AST and the verbatim `sql_definition`.
+    for (name, new_text) in pending {
+        let stmt = vibesql_parser::parse_with_arena_fallback(&new_text).map_err(|e| {
+            ExecutorError::Other(format!("error in view {}: {}", name, e))
+        })?;
+        if let vibesql_ast::Statement::CreateView(cv) = stmt {
+            if let Some(view) = database.catalog.get_view_mut(&name) {
+                view.query = *cv.query;
+                view.sql_definition = Some(new_text);
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/vibesql-executor/src/alter_rewrite.rs
+++ b/crates/vibesql-executor/src/alter_rewrite.rs
@@ -218,59 +218,195 @@ pub fn rename_references_parent(
     Some(out)
 }
 
-/// Rewrite a column name in its *definition position* within the verbatim
-/// `CREATE TABLE` text, matching SQLite's `ALTER TABLE ... RENAME COLUMN`.
+/// Emit `new_col` as an identifier, mirroring SQLite's `bQuote` rule during
+/// RENAME COLUMN: the replacement is double-quoted when the *replaced* token was
+/// itself a quoted (delimited) identifier, or when the new name is not a safe
+/// bare identifier; otherwise it is emitted bare. Verified against sqlite3
+/// 3.51.0 (altercol.test 1.2/1.9 — a quoted `"b"`/`"B"` becomes quoted `"d"`
+/// even though `d` is a safe bare name; 4.4 — a quoted `"silly name"` becomes
+/// quoted `"reasonable"`).
+fn emit_renamed_ident(new_col: &str, replaced_was_quoted: bool) -> String {
+    if replaced_was_quoted || !is_safe_bare_identifier(new_col) {
+        quote_ident(new_col)
+    } else {
+        new_col.to_string()
+    }
+}
+
+/// Rewrite *every* reference to `old_col` that resolves to `table_name`'s column
+/// within the verbatim `CREATE TABLE` text, matching SQLite's
+/// `ALTER TABLE ... RENAME COLUMN` (with `legacy_alter_table=OFF`).
 ///
-/// Only the identifier that names the column at the start of a column definition
-/// (the first token of the column list, or the first token after a top-level
-/// comma inside the column list) is rewritten — references elsewhere (e.g. in a
-/// table-level constraint) are conservatively left untouched. Returns `None`
-/// when the definition cannot be located unambiguously, so the caller falls back
-/// to reconstruction. `new_name` is emitted bare when it is a safe identifier,
-/// otherwise double-quoted.
-pub fn rename_column(create_sql: &str, old_col: &str, new_col: &str) -> Option<String> {
+/// SQLite does not rewrite only the definition-position token: it rewrites the
+/// column name everywhere it appears as a reference to the renamed column —
+/// inside `CHECK(...)` expressions (bare `b` and qualified `t1.b`), table-level
+/// `PRIMARY KEY(...)`, `UNIQUE(...)`, and `FOREIGN KEY (...)` column lists, and
+/// column-level constraints. Verified against sqlite3 3.51.0 (altercol.test
+/// group 1). Without this, the persisted `sql_source` keeps the stale column
+/// name in its constraints; a later checkpoint reload then fails the
+/// fail-closed FK/constraint rehydration ("FK column 'b' ... not found").
+///
+/// Column references inside a `REFERENCES <other>(<col_list>)` parent column list
+/// are left untouched when `<other>` is a *different* table — those names resolve
+/// to the parent and are rewritten from the parent side (see
+/// [`rename_references_column`]). A self-referential `REFERENCES <table>(...)`
+/// list *is* rewritten, since those columns resolve to the renamed table.
+///
+/// Quoting follows SQLite's `bQuote` rule via [`emit_renamed_ident`]. Returns
+/// `None` when `old_col` is not referenced (the caller then falls back to
+/// invalidate-and-reconstruct), preserving the re-parseable-on-reload invariant.
+pub fn rename_column(
+    create_sql: &str,
+    table_name: &str,
+    old_col: &str,
+    new_col: &str,
+) -> Option<String> {
     let tokens = tokenize(create_sql)?;
     let (open, close) = column_list_parens(&tokens)?;
 
-    // Walk the column list at paren depth 1, tracking the start of each
-    // definition (top-level comma boundaries).
+    // Byte spans of every identifier token to rewrite, paired with whether the
+    // replaced token was quoted (drives replacement quoting).
+    let mut targets: Vec<(Span, bool)> = Vec::new();
     let mut depth = 0usize;
-    let mut at_def_start = false;
-    let mut target: Option<usize> = None;
-    for (i, (tok, _)) in tokens.iter().enumerate().take(close).skip(open) {
+
+    // Parent-column-list skipping: after `REFERENCES <parent>` where `<parent>`
+    // is a *different* table, the immediately following `(<col_list>)` names the
+    // parent's columns — skip rewriting inside it. `skip_below` holds the depth
+    // outside that parenthesized list while it is active.
+    let mut expect_parent_table = false;
+    let mut skip_below: Option<usize> = None;
+
+    let mut idx = open;
+    while idx < close {
+        let (tok, span) = &tokens[idx];
         match tok {
-            Token::LParen => {
-                if depth == 1 {
-                    at_def_start = false;
-                }
-                depth += 1;
-                if depth == 1 {
-                    at_def_start = true; // first token inside the column list
-                }
-            }
-            Token::RParen => depth -= 1,
-            Token::Comma if depth == 1 => at_def_start = true,
-            _ if depth == 1 => {
-                if at_def_start {
-                    at_def_start = false;
-                    if ident_matches(tok, old_col) {
-                        if target.is_some() {
-                            // Two definitions match: ambiguous; bail.
-                            return None;
-                        }
-                        target = Some(i);
+            Token::LParen => depth += 1,
+            Token::RParen => {
+                if let Some(d) = skip_below {
+                    if depth == d + 1 {
+                        skip_below = None;
                     }
                 }
+                depth -= 1;
             }
-            _ => {}
+            Token::Keyword { keyword: Keyword::References, .. } => {
+                expect_parent_table = true;
+            }
+            Token::Identifier(_) | Token::DelimitedIdentifier(_) => {
+                if expect_parent_table {
+                    expect_parent_table = false;
+                    // This identifier names the parent table. When it is a
+                    // *different* table and introduces a `(col_list)`, skip that
+                    // list (those columns belong to the parent).
+                    if !ident_matches(tok, table_name)
+                        && matches!(tokens.get(idx + 1), Some((Token::LParen, _)))
+                    {
+                        skip_below = Some(depth);
+                    }
+                    idx += 1;
+                    continue;
+                }
+                if skip_below.is_some() {
+                    idx += 1;
+                    continue;
+                }
+                // An identifier immediately followed by `.` is a table qualifier
+                // (e.g. the `t1` in `t1.b`), not a column reference — never rewrite
+                // it. The column after the dot is handled on the next iteration.
+                if matches!(tokens.get(idx + 1), Some((Token::Symbol('.'), _))) {
+                    idx += 1;
+                    continue;
+                }
+                if ident_matches(tok, old_col) {
+                    targets.push((*span, matches!(tok, Token::DelimitedIdentifier(_))));
+                }
+            }
+            _ => {
+                expect_parent_table = false;
+            }
+        }
+        idx += 1;
+    }
+
+    if targets.is_empty() {
+        return None;
+    }
+
+    // Rewrite from the last span backward so earlier byte offsets stay valid.
+    let mut out = create_sql.to_string();
+    for (span, was_quoted) in targets.iter().rev() {
+        out.replace_range(span.start..span.end, &emit_renamed_ident(new_col, *was_quoted));
+    }
+    Some(out)
+}
+
+/// Rewrite the column name `old_col` -> `new_col` inside every
+/// `REFERENCES <parent_table>(<col_list>)` clause of a *child* table's verbatim
+/// `CREATE TABLE` text, matching SQLite's `sqlite_rename_column` propagation to
+/// child foreign keys when a *parent* table's column is renamed (verified against
+/// sqlite3 3.51.0, altercol.test 4.1/4.4).
+///
+/// Only column identifiers inside the parenthesized parent column list that
+/// immediately follows `REFERENCES <parent_table>` are considered, so a bare
+/// column reference elsewhere (the child's own columns, a `CHECK`, a string
+/// literal) is never touched. The parent-table match is quote-aware and
+/// case-insensitive (inherited from the lexer). Quoting of the replacement
+/// follows SQLite's `bQuote` rule via [`emit_renamed_ident`]. Returns `None` when
+/// no matching `REFERENCES <parent_table>(...)` column is present (the caller
+/// then invalidates and reconstructs).
+pub fn rename_references_column(
+    create_sql: &str,
+    parent_table: &str,
+    old_col: &str,
+    new_col: &str,
+) -> Option<String> {
+    let tokens = tokenize(create_sql)?;
+
+    let mut targets: Vec<(Span, bool)> = Vec::new();
+    for i in 0..tokens.len() {
+        if !matches!(tokens[i].0, Token::Keyword { keyword: Keyword::References, .. }) {
+            continue;
+        }
+        // The parent table follows REFERENCES; a `(` after it opens the col list.
+        match tokens.get(i + 1) {
+            Some((ptok, _)) if ident_matches(ptok, parent_table) => {}
+            _ => continue,
+        }
+        if !matches!(tokens.get(i + 2), Some((Token::LParen, _))) {
+            continue;
+        }
+        // Scan the balanced parent column list, rewriting matches at its top level.
+        let mut depth = 0usize;
+        let mut j = i + 2;
+        while j < tokens.len() {
+            match &tokens[j].0 {
+                Token::LParen => depth += 1,
+                Token::RParen => {
+                    depth -= 1;
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                Token::Identifier(_) | Token::DelimitedIdentifier(_)
+                    if depth == 1 && ident_matches(&tokens[j].0, old_col) =>
+                {
+                    targets.push((tokens[j].1, matches!(tokens[j].0, Token::DelimitedIdentifier(_))));
+                }
+                _ => {}
+            }
+            j += 1;
         }
     }
 
-    let idx = target?;
-    let span = tokens[idx].1;
-    let replacement =
-        if is_safe_bare_identifier(new_col) { new_col.to_string() } else { quote_ident(new_col) };
-    Some(replace_span(create_sql, span, &replacement))
+    if targets.is_empty() {
+        return None;
+    }
+
+    let mut out = create_sql.to_string();
+    for (span, was_quoted) in targets.iter().rev() {
+        out.replace_range(span.start..span.end, &emit_renamed_ident(new_col, *was_quoted));
+    }
+    Some(out)
 }
 
 /// The byte position where a top-level definition begins inside the column
@@ -609,28 +745,152 @@ mod tests {
     #[test]
     fn rename_column_in_definition_position() {
         let sql = "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  b   TEXT\n)";
-        let out = rename_column(sql, "b", "bb").unwrap();
+        let out = rename_column(sql, "t", "b", "bb").unwrap();
         assert_eq!(out, "CREATE TABLE t (\n  a   INTEGER PRIMARY KEY,\n  bb   TEXT\n)");
     }
 
     #[test]
     fn rename_column_first_column() {
         let sql = "CREATE TABLE t (a INTEGER, b TEXT)";
-        let out = rename_column(sql, "a", "aa").unwrap();
+        let out = rename_column(sql, "t", "a", "aa").unwrap();
         assert_eq!(out, "CREATE TABLE t (aa INTEGER, b TEXT)");
     }
 
     #[test]
     fn rename_column_quotes_unsafe_name() {
         let sql = "CREATE TABLE t (a INTEGER, b TEXT)";
-        let out = rename_column(sql, "b", "new col").unwrap();
+        let out = rename_column(sql, "t", "b", "new col").unwrap();
         assert_eq!(out, "CREATE TABLE t (a INTEGER, \"new col\" TEXT)");
     }
 
     #[test]
     fn rename_column_missing_returns_none() {
         let sql = "CREATE TABLE t (a INTEGER, b TEXT)";
-        assert!(rename_column(sql, "zzz", "qqq").is_none());
+        assert!(rename_column(sql, "t", "zzz", "qqq").is_none());
+    }
+
+    // Constraint-reference rewriting (altercol.test group 1, sqlite3 3.51.0).
+
+    #[test]
+    fn rename_column_preserves_quoted_def_position() {
+        // altercol 1.2: a quoted `"b"` def becomes quoted `"d"` (bQuote carries).
+        let sql = "CREATE TABLE t1(a INTEGER, x TEXT, \"b\" BLOB)";
+        let out = rename_column(sql, "t1", "b", "d").unwrap();
+        assert_eq!(out, "CREATE TABLE t1(a INTEGER, x TEXT, \"d\" BLOB)");
+    }
+
+    #[test]
+    fn rename_column_check_bare_ref() {
+        // altercol 1.3
+        let sql = "CREATE TABLE t1(a INTEGER, b TEXT, c BLOB, CHECK(b!=''))";
+        let out = rename_column(sql, "t1", "b", "d").unwrap();
+        assert_eq!(out, "CREATE TABLE t1(a INTEGER, d TEXT, c BLOB, CHECK(d!=''))");
+    }
+
+    #[test]
+    fn rename_column_check_qualified_ref() {
+        // altercol 1.4: qualified `t1.b` rewrites the column, not the qualifier.
+        let sql = "CREATE TABLE t1(a INTEGER, b TEXT, c BLOB, CHECK(t1.b!=''))";
+        let out = rename_column(sql, "t1", "b", "d").unwrap();
+        assert_eq!(out, "CREATE TABLE t1(a INTEGER, d TEXT, c BLOB, CHECK(t1.d!=''))");
+    }
+
+    #[test]
+    fn rename_column_check_nested_expr() {
+        // altercol 1.5
+        let sql = "CREATE TABLE t1(a INTEGER, b TEXT, c BLOB, CHECK( coalesce(b,c) ))";
+        let out = rename_column(sql, "t1", "b", "d").unwrap();
+        assert_eq!(out, "CREATE TABLE t1(a INTEGER, d TEXT, c BLOB, CHECK( coalesce(d,c) ))");
+    }
+
+    #[test]
+    fn rename_column_quoted_def_no_space_plus_check() {
+        // altercol 1.6: `"b"TEXT` (no space) + CHECK referencing bare b.
+        let sql = "CREATE TABLE t1(a INTEGER, \"b\"TEXT, c BLOB, CHECK( coalesce(b,c) ))";
+        let out = rename_column(sql, "t1", "b", "d").unwrap();
+        assert_eq!(out, "CREATE TABLE t1(a INTEGER, \"d\"TEXT, c BLOB, CHECK( coalesce(d,c) ))");
+    }
+
+    #[test]
+    fn rename_column_table_level_primary_key() {
+        // altercol 1.7
+        let sql = "CREATE TABLE t1(a INTEGER, b TEXT, c BLOB, PRIMARY KEY(b, c))";
+        let out = rename_column(sql, "t1", "b", "d").unwrap();
+        assert_eq!(out, "CREATE TABLE t1(a INTEGER, d TEXT, c BLOB, PRIMARY KEY(d, c))");
+    }
+
+    #[test]
+    fn rename_column_pk_and_unique_quoted() {
+        // altercol 1.9: PK list + UNIQUE("B") (quoted, case-insensitive match).
+        let sql = "CREATE TABLE t1(a, b TEXT, c, PRIMARY KEY(a, b), UNIQUE(\"B\"))";
+        let out = rename_column(sql, "t1", "b", "d").unwrap();
+        assert_eq!(out, "CREATE TABLE t1(a, d TEXT, c, PRIMARY KEY(a, d), UNIQUE(\"d\"))");
+    }
+
+    #[test]
+    fn rename_column_foreign_key_local_col_list() {
+        // altercol 1.13: the FK's own `(b)` list rewrites; parent name untouched.
+        let sql = "CREATE TABLE t1(a, b, c, FOREIGN KEY (b) REFERENCES t2)";
+        let out = rename_column(sql, "t1", "b", "d").unwrap();
+        assert_eq!(out, "CREATE TABLE t1(a, d, c, FOREIGN KEY (d) REFERENCES t2)");
+    }
+
+    #[test]
+    fn rename_column_skips_other_parent_col_list() {
+        // A `REFERENCES other(b)` parent column list belongs to `other`, not this
+        // table, so the parent-side `b` must NOT be rewritten — only this table's
+        // own column `b` (def position + local FK list).
+        let sql = "CREATE TABLE t1(a, b, FOREIGN KEY (b) REFERENCES other(b))";
+        let out = rename_column(sql, "t1", "b", "d").unwrap();
+        assert_eq!(out, "CREATE TABLE t1(a, d, FOREIGN KEY (d) REFERENCES other(b))");
+    }
+
+    #[test]
+    fn rename_column_big_fk_col_list() {
+        // altercol 2.x: many-column FK list, unquoted new name.
+        let sql = "CREATE TABLE t3(a, b, c, d, FOREIGN KEY (b, c, d) REFERENCES t4)";
+        let out = rename_column(sql, "t3", "b", "biglongname").unwrap();
+        assert_eq!(
+            out,
+            "CREATE TABLE t3(a, biglongname, c, d, FOREIGN KEY (biglongname, c, d) REFERENCES t4)"
+        );
+    }
+
+    // rename_references_column — child-table parent-column-list rewriting.
+
+    #[test]
+    fn rename_references_column_unsafe_new_name() {
+        // altercol 4.1: parent p1.d renamed to "silly name" -> child FK list.
+        let sql = "CREATE TABLE c1(a, b, FOREIGN KEY (a, b) REFERENCES p1(c, d))";
+        let out = rename_references_column(sql, "p1", "d", "silly name").unwrap();
+        assert_eq!(
+            out,
+            "CREATE TABLE c1(a, b, FOREIGN KEY (a, b) REFERENCES p1(c, \"silly name\"))"
+        );
+    }
+
+    #[test]
+    fn rename_references_column_quoted_old_stays_quoted() {
+        // altercol 4.4: "silly name" -> reasonable is emitted quoted (bQuote).
+        let sql = "CREATE TABLE c1(a, b, FOREIGN KEY (a, b) REFERENCES p1(c, \"silly name\"))";
+        let out = rename_references_column(sql, "p1", "silly name", "reasonable").unwrap();
+        assert_eq!(
+            out,
+            "CREATE TABLE c1(a, b, FOREIGN KEY (a, b) REFERENCES p1(c, \"reasonable\"))"
+        );
+    }
+
+    #[test]
+    fn rename_references_column_no_match_returns_none() {
+        // No parent column list after REFERENCES -> nothing to rewrite.
+        let sql = "CREATE TABLE c2(a, b, FOREIGN KEY (a, b) REFERENCES p1)";
+        assert!(rename_references_column(sql, "p1", "d", "reasonable").is_none());
+    }
+
+    #[test]
+    fn rename_references_column_ignores_other_parent() {
+        let sql = "CREATE TABLE c(a, FOREIGN KEY (a) REFERENCES q(d))";
+        assert!(rename_references_column(sql, "p1", "d", "x").is_none());
     }
 
     // DROP COLUMN — byte-for-byte against sqlite3 3.51.0 (verified manually).

--- a/crates/vibesql-executor/src/sqlite_schema.rs
+++ b/crates/vibesql-executor/src/sqlite_schema.rs
@@ -117,6 +117,31 @@ fn schema_row(obj_type: &str, name: &str, tbl_name: &str, sql: String) -> Row {
     ])
 }
 
+/// Build a `sqlite_master` row for an auto-created index (implicit PRIMARY KEY /
+/// UNIQUE index, named `sqlite_autoindex_*`). SQLite reports these with a NULL
+/// `sql` — the index is implied by its table's `CREATE TABLE` text and has no
+/// standalone `CREATE INDEX` statement — so the row still exists but is filtered
+/// out by the common `WHERE sql!=''` idiom (verified against sqlite3 3.51.0,
+/// altercol.test 1.7/1.8/1.9/1.14). Emitting a reconstructed `CREATE UNIQUE
+/// INDEX` here instead made the autoindex row leak into those schema queries.
+fn schema_row_autoindex(name: &str, tbl_name: &str) -> Row {
+    Row::new(vec![
+        SqlValue::Varchar(arcstr::ArcStr::from("index")),
+        SqlValue::Varchar(arcstr::ArcStr::from(name)),
+        SqlValue::Varchar(arcstr::ArcStr::from(tbl_name)),
+        SqlValue::Integer(0), // rootpage - always 0 for VibeSQL
+        SqlValue::Null,
+    ])
+}
+
+/// Whether `name` is an implicit PRIMARY KEY / UNIQUE auto-index (SQLite names
+/// these `sqlite_autoindex_<table>_<n>`); such indexes carry a NULL `sql` in
+/// `sqlite_master`.
+fn is_sqlite_autoindex(name: &str) -> bool {
+    name.len() >= "sqlite_autoindex_".len()
+        && name[.."sqlite_autoindex_".len()].eq_ignore_ascii_case("sqlite_autoindex_")
+}
+
 /// Execute a `sqlite_master` / `sqlite_schema` query.
 ///
 /// Lists **main-schema** objects only. Temp-schema objects (temp tables and
@@ -148,8 +173,12 @@ pub fn execute_sqlite_schema_query(
         if is_without_rowid_pk_autoindex(catalog, index) {
             continue;
         }
-        let sql = generate_create_index_sql(index);
-        rows.push(schema_row("index", &index.name, &index.table_name, sql));
+        if is_sqlite_autoindex(&index.name) {
+            rows.push(schema_row_autoindex(&index.name, &index.table_name));
+        } else {
+            let sql = generate_create_index_sql(index);
+            rows.push(schema_row("index", &index.name, &index.table_name, sql));
+        }
     }
 
     // Add views. Temp views are tagged with the `temp` schema (#5541) and
@@ -345,8 +374,12 @@ pub fn execute_sqlite_temp_schema_query(
         if is_without_rowid_pk_autoindex(catalog, index) {
             continue;
         }
-        let sql = generate_create_index_sql(index);
-        rows.push(schema_row("index", &index.name, &index.table_name, sql));
+        if is_sqlite_autoindex(&index.name) {
+            rows.push(schema_row_autoindex(&index.name, &index.table_name));
+        } else {
+            let sql = generate_create_index_sql(index);
+            rows.push(schema_row("index", &index.name, &index.table_name, sql));
+        }
     }
 
     // Add temp views. Views are stored flat in the catalog (not partitioned by
@@ -492,20 +525,38 @@ fn generate_create_index_sql(index: &vibesql_catalog::IndexMetadata) -> String {
         })
         .collect();
 
+    // Partial-index WHERE clause. SQLite renders the (rewritten) predicate after
+    // the column list, e.g. `CREATE INDEX i ON t(a) WHERE a>0`. The predicate is
+    // kept in sync with RENAME COLUMN via `rename_column_in_table_indexes`, so it
+    // already names the current column; render it verbatim from the AST. Without
+    // this the emitted `sqlite_master.sql` silently dropped the WHERE clause
+    // (altercol 1.12.4).
+    let where_str = index
+        .where_clause
+        .as_ref()
+        .map(|expr| format!(" WHERE {}", expr.to_sql()))
+        .unwrap_or_default();
+
     format!(
-        "CREATE {}INDEX {} ON {}({})",
+        "CREATE {}INDEX {} ON {}({}){}",
         unique_str,
         index.name,
         index.table_name,
-        columns.join(", ")
+        columns.join(", "),
+        where_str
     )
 }
 
 /// Generate CREATE VIEW SQL statement for a view
 fn generate_create_view_sql(view: &vibesql_catalog::ViewDefinition) -> String {
-    // Use stored SQL definition if available
+    // Use stored SQL definition if available. SQLite stores the statement text
+    // without a trailing `;` in `sqlite_master.sql`, so strip one if the captured
+    // verbatim text carried it (mirrors `generate_create_trigger_sql`; verified
+    // against sqlite3 3.51.0, altercol.test group 8).
     if let Some(ref sql) = view.sql_definition {
-        return sql.clone();
+        let trimmed = sql.trim_end();
+        let trimmed = trimmed.strip_suffix(';').unwrap_or(trimmed);
+        return trimmed.trim_end().to_string();
     }
 
     // Otherwise generate from the view definition

--- a/crates/vibesql-executor/tests/alter_rename_column_index_tests.rs
+++ b/crates/vibesql-executor/tests/alter_rename_column_index_tests.rs
@@ -10,13 +10,14 @@
 //! after its next checkpoint (the dominant altercol.test failure mode).
 
 use vibesql_executor::{
-    AlterTableExecutor, CreateIndexExecutor, CreateTableExecutor, SelectExecutor,
+    AlterTableExecutor, CreateIndexExecutor, CreateTableExecutor, SelectExecutor, ViewExecutor,
 };
 use vibesql_parser::Parser;
 use vibesql_storage::Database;
 use vibesql_types::SqlValue;
 
-/// Execute a single SQL statement (CREATE TABLE / CREATE INDEX / ALTER TABLE).
+/// Execute a single SQL statement (CREATE TABLE / CREATE INDEX / CREATE VIEW /
+/// ALTER TABLE / INSERT).
 fn exec(db: &mut Database, sql: &str) {
     let stmt = Parser::parse_sql(sql).expect("parse");
     match stmt {
@@ -26,6 +27,9 @@ fn exec(db: &mut Database, sql: &str) {
         vibesql_ast::Statement::CreateIndex(create) => {
             CreateIndexExecutor::execute(&create, db).expect("CREATE INDEX");
         }
+        vibesql_ast::Statement::CreateView(create) => {
+            ViewExecutor::execute_create_view(&create, db).expect("CREATE VIEW");
+        }
         vibesql_ast::Statement::AlterTable(alter) => {
             AlterTableExecutor::execute_with_source(&alter, db, Some(sql)).expect("ALTER TABLE");
         }
@@ -33,6 +37,16 @@ fn exec(db: &mut Database, sql: &str) {
             vibesql_executor::InsertExecutor::execute(db, &insert).expect("INSERT");
         }
         other => panic!("unsupported statement in test: {other:?}"),
+    }
+}
+
+/// Return the `sql` text for the named table/view from `sqlite_master`.
+fn object_sql(db: &Database, name: &str) -> String {
+    let rows = query(db, &format!("SELECT sql FROM sqlite_master WHERE name='{name}'"));
+    assert_eq!(rows.len(), 1, "expected one sqlite_master row for {name}");
+    match &rows[0][0] {
+        SqlValue::Varchar(s) | SqlValue::Character(s) => s.to_string(),
+        other => panic!("expected text, got {other:?}"),
     }
 }
 
@@ -229,4 +243,96 @@ fn rename_updates_unique_autoindex_from_primary_key() {
     // And the reload must not fail-closed on the autoindex.
     let reloaded = roundtrip_binary(&db, "autoindex");
     assert_eq!(query(&reloaded, "SELECT * FROM t1").len(), 1);
+}
+
+// --- Issue #5897: verbatim SQL text rewriting for CHECK/PK/FK clauses, child
+// foreign keys, views, and the partial-index WHERE render. ---
+
+#[test]
+fn rename_rewrites_own_constraint_refs_and_survives_reload() {
+    // altercol.test 1.3/1.7/1.13: the column name inside CHECK/PK/FK clauses in
+    // the table's own persisted sql_source must be rewritten. Before #5897 only
+    // the definition-position token changed, so a checkpoint reload later failed
+    // fail-closed on the stale FK/constraint column ("FK column 'b' ... not
+    // found").
+    let mut db = Database::new();
+    exec(
+        &mut db,
+        "CREATE TABLE t1(a INTEGER, b TEXT, c BLOB, CHECK(b!=''), PRIMARY KEY(b, c), FOREIGN KEY(b) REFERENCES t2)",
+    );
+    exec(&mut db, "INSERT INTO t1 VALUES(1, 'x', 2)");
+    exec(&mut db, "ALTER TABLE t1 RENAME COLUMN b TO d");
+
+    let expected =
+        "CREATE TABLE t1(a INTEGER, d TEXT, c BLOB, CHECK(d!=''), PRIMARY KEY(d, c), FOREIGN KEY(d) REFERENCES t2)";
+    assert_eq!(object_sql(&db, "t1"), expected);
+
+    // Constraints rehydrate from the rewritten sql_source on binary reload.
+    let reloaded = roundtrip_binary(&db, "constraints");
+    assert_eq!(object_sql(&reloaded, "t1"), expected);
+    assert_eq!(query(&reloaded, "SELECT d FROM t1"), vec![vec![SqlValue::Varchar("x".into())]]);
+}
+
+#[test]
+fn rename_preserves_quoted_column_and_renders_partial_index_where() {
+    // altercol.test 1.2 (quoted def stays quoted) + 1.12 (partial-index WHERE
+    // must appear in the rendered index sql).
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER, x TEXT, \"b\" BLOB)");
+    exec(&mut db, "CREATE INDEX t1i ON t1(a, x) WHERE a>0");
+    exec(&mut db, "ALTER TABLE t1 RENAME COLUMN b TO d");
+    // Quoted `"b"` def becomes quoted `"d"` (bQuote rule).
+    assert_eq!(object_sql(&db, "t1"), "CREATE TABLE t1(a INTEGER, x TEXT, \"d\" BLOB)");
+    // Rename the indexed column and confirm the WHERE clause renders.
+    exec(&mut db, "ALTER TABLE t1 RENAME COLUMN a TO aa");
+    assert_eq!(index_sql(&db, "t1i"), "CREATE INDEX t1i ON t1(aa, x) WHERE aa>0");
+}
+
+#[test]
+fn rename_parent_column_rewrites_child_foreign_key() {
+    // altercol.test 4.1/4.4: renaming a PARENT column rewrites the child's
+    // REFERENCES parent(col_list) text and the FK metadata, surviving reload.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE p1(c, d, PRIMARY KEY(c, d))");
+    exec(&mut db, "CREATE TABLE c1(a, b, FOREIGN KEY (a, b) REFERENCES p1(c, d))");
+    exec(&mut db, "ALTER TABLE p1 RENAME d TO reasonable");
+
+    assert_eq!(object_sql(&db, "p1"), "CREATE TABLE p1(c, reasonable, PRIMARY KEY(c, reasonable))");
+    assert_eq!(
+        object_sql(&db, "c1"),
+        "CREATE TABLE c1(a, b, FOREIGN KEY (a, b) REFERENCES p1(c, reasonable))"
+    );
+
+    // In-memory FK metadata now names the new parent column.
+    let c1 = db.get_table("c1").expect("c1");
+    assert!(
+        c1.schema.foreign_keys[0].parent_column_names.iter().any(|c| c == "reasonable"),
+        "child FK parent_column_names should be updated"
+    );
+
+    // Round-trip: both tables rehydrate from the rewritten sql_source.
+    let reloaded = roundtrip_binary(&db, "childfk");
+    assert_eq!(
+        object_sql(&reloaded, "c1"),
+        "CREATE TABLE c1(a, b, FOREIGN KEY (a, b) REFERENCES p1(c, reasonable))"
+    );
+}
+
+#[test]
+fn rename_rewrites_dependent_view_text_and_query() {
+    // altercol.test 8.1/8.5: a view referencing the renamed column has both its
+    // sqlite_master text and its executable query AST rewritten.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE a1(x INTEGER, y TEXT, z BLOB, PRIMARY KEY(x))");
+    exec(&mut db, "INSERT INTO a1 VALUES(1, 'hi', 2)");
+    exec(&mut db, "CREATE VIEW v1 AS SELECT x, y, z FROM a1");
+    exec(&mut db, "ALTER TABLE a1 RENAME y TO yyy");
+
+    // sqlite_master text is rewritten (and the trailing `;` stripped).
+    assert_eq!(object_sql(&db, "v1"), "CREATE VIEW v1 AS SELECT x, yyy, z FROM a1");
+    // The view still executes: its stored query AST now names the new column.
+    assert_eq!(
+        query(&db, "SELECT z FROM v1 WHERE yyy = 'hi'"),
+        vec![vec![SqlValue::Integer(2)]]
+    );
 }


### PR DESCRIPTION
## Summary

`ALTER TABLE ... RENAME COLUMN` only rewrote the column's definition-position token in the persisted `sql_source`. References to the renamed column inside `CHECK`/`PRIMARY KEY`/`UNIQUE`/`FOREIGN KEY` clauses, in child tables' `REFERENCES parent(col)` lists, and in dependent view bodies stayed stale. Consequences: a later checkpoint reload failed **fail-closed** ("FK column 'b' ... not found") and `sqlite_master.sql` showed the old name. This PR closes the four gaps from the curation comment plus two small SQLite-fidelity fixes needed to reach the acceptance IDs.

## Changes

- **Gap A — own constraint refs** (`alter_rewrite::rename_column`): rewrite *every* reference to the renamed column in the table's own verbatim `CREATE TABLE` text — bare and qualified (`t.col`) `CHECK` refs, and table-level `PRIMARY KEY`/`UNIQUE`/`FOREIGN KEY` column lists — while skipping `REFERENCES <other>(...)` parent lists (those resolve to the parent). Preserves SQLite's `bQuote` rule: a token that was quoted stays quoted (`"b"`→`"d"`, `"silly name"`→`"reasonable"`). This chose token-level rewriting over AST re-render to preserve verbatim CHECK source text (per #5868).
- **Gap B — child FKs** (`rename_references_column` + `rewrite_child_foreign_keys_for_column_rename`): when a parent column is renamed, rewrite each child's `REFERENCES parent(col_list)` text and its in-memory `ForeignKeyConstraint::parent_column_names`.
- **Gap C — views** (`rewrite_views_for_column_rename`): rewrite dependent view `sql_definition` text (reusing the table-aware trigger-body resolver) and re-parse the `query` AST so views keep executing; two-phase so an ambiguous view aborts the ALTER atomically. Falls back to reconstructing the text from the AST when a view has no captured source.
- **Gap D — partial index WHERE** (`generate_create_index_sql`): render the `WHERE` predicate.
- **SQLite fidelity** (`sqlite_schema.rs`): emit `NULL` `sql` for `sqlite_autoindex_*` rows and strip a trailing `;` from view `sql`, matching sqlite3 3.51.0.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| altercol residuals fixed (report IDs) | ✅ | `altercol.test` 70/86 → **84/86**. Fixed: 1.2.4, 1.3.4, 1.4.4, 1.5.4, 1.6.4, 1.7.4, 1.8.4, 1.9.4, 1.13.3, 1.13.4, 1.14.4, 1.15.4, 1.17.3, 1.17.4 |
| Gap B 4.1/4.4 child FK | ✅ | Verified via CLI vs sqlite3 (harness aborts pre-4.x on the `-db db2` shim gap); integration test `rename_parent_column_rewrites_child_foreign_key` |
| Gap C 8.x views | ✅ | Verified via CLI vs sqlite3 (8.1/8.2.3/8.5.1/8.5.2); integration test `rename_rewrites_dependent_view_text_and_query` |
| alterdropcol stays 96/100 | ✅ | Re-ran: **96/100**, no regression |
| Renamed-column DB round-trips reopen | ✅ | Integration tests reload from binary; CLI CHECK/PK/FK + child-FK reopen verified |
| No cross-cutting regressions | ✅ | 3198 executor lib tests + all integration tests pass; baseline diff of alter.test (44/117) and trigger1.test (36/84) identical before/after |

### Remaining 2 altercol failures are pre-existing and out of scope (not column-ref rewriting)

- **1.12.4**: expression-index column is reconstructed with wrapper parens (`(d+d+d+d)` vs verbatim `d+d+d+d`). The WHERE render (Gap D) is fixed; the paren divergence is a separate index-reconstruction-fidelity issue.
- **2.0**: the `CREATE TABLE` never parses — a pre-existing parser bug rejecting the identifier `m` inside a FOREIGN KEY column list ("Expected column name in FOREIGN KEY"). Unrelated to RENAME COLUMN.

Both warrant separate follow-up issues.

## Test Plan

- `make test-tcl-file FILE=altercol.test` → 84/86; `FILE=alterdropcol.test` → 96/100
- `cargo test -p vibesql-executor` (lib + all integration) and `-p vibesql-catalog`: green
- New unit tests in `alter_rewrite.rs` (CHECK/PK/UNIQUE/FK constraint refs, quoting fidelity, parent-col-list skip, child FK rewrite) and integration tests in `alter_rename_column_index_tests.rs` (constraint round-trip, partial-index WHERE, child FK, view rewrite)
- Round-trip save/reopen verified: CHECK/PK/FK constraints rehydrate from the rewritten `sql_source`

Closes #5897