### PR TITLE
fix(tcl-shim): mask string literals before counting CLI statements

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -1436,13 +1436,73 @@ proc trial_check_incremental {new_sql} {
     }
 }
 
+proc mask_string_literals {sql} {
+    # Blank out the interior of single-quoted string literals with spaces so
+    # that ';' characters inside string data (e.g. INSERT INTO t VALUES('a;b'))
+    # are not miscounted as statement separators by count_cli_statements. See
+    # #5947.
+    #
+    # The transformation is length-preserving by construction: only the interior
+    # bytes are replaced (each with a single space) and the surrounding ' quote
+    # characters are kept in place, so every character offset in the result maps
+    # 1:1 to the input. count_cli_statements slices the ORIGINAL $sql using the
+    # masked ';' offsets, so this length invariance is required for correct
+    # segment boundaries.
+    #
+    # The SQL doubled-quote escape ('') is the way a literal single-quote is
+    # written inside a string; it is treated as string interior (both quotes
+    # blanked) and does NOT terminate the string. An unterminated opening quote
+    # blanks to end-of-input (still length-preserving). Scanning style mirrors
+    # convert_dqs_to_single_quotes (single-quote branch) above.
+    set result ""
+    set len [string length $sql]
+    set i 0
+    while {$i < $len} {
+        set char [string index $sql $i]
+        if {$char eq "'"} {
+            # Opening quote — keep it, then blank the interior until the real
+            # closing quote (a ' that is not part of a '' escape).
+            append result "'"
+            incr i
+            while {$i < $len} {
+                set c [string index $sql $i]
+                if {$c eq "'"} {
+                    if {[expr {$i + 1}] < $len && [string index $sql [expr {$i + 1}]] eq "'"} {
+                        # '' escape — part of the string interior. Blank both
+                        # quotes and stay in string mode.
+                        append result "  "
+                        incr i 2
+                    } else {
+                        # Real closing quote — keep it and exit string mode.
+                        append result "'"
+                        incr i
+                        break
+                    }
+                } else {
+                    append result " "
+                    incr i
+                }
+            }
+        } else {
+            append result $char
+            incr i
+        }
+    }
+    return $result
+}
+
 proc count_cli_statements {sql} {
     # Count statements the way the VibeSQL CLI numbers them for its
     # "Error executing statement N" output: every ';'-separated top-level
     # statement, counted from 1, with CREATE TRIGGER ... END bodies treated as a
     # single statement (their internal ';' do not delimit statements). A trailing
     # empty segment after the final ';' is not counted. See #5853.
-    set masked [mask_trigger_bodies $sql]
+    #
+    # Mask trigger bodies first (so their internal ';' are blanked), then mask
+    # single-quoted string literals (so ';' inside string data is blanked too);
+    # both masks are length-preserving so the ';' offsets in $masked line up with
+    # $sql for the segment slice below. See #5947.
+    set masked [mask_string_literals [mask_trigger_bodies $sql]]
     set n 0
     set start 0
     set len [string length $masked]


### PR DESCRIPTION
## Summary

`count_cli_statements` in `scripts/tester_vibesql.tcl` computes the CLI statement index used by `trial_check_in_transaction` to attribute trial-check errors to the right test statement. It masked `CREATE TRIGGER ... END` bodies (so their internal `;` are not counted as separators) but had no awareness of SQL string quoting. A statement like `INSERT INTO t VALUES('a;b')` left a visible `;` inside the string literal after masking, over-counting the total and shifting `new_stmt_index` forward — causing `select_error_line_for_stmt` to skip the real error line or pick up an unrelated one. This was a latent misattribution hazard for future test files with `;` in string data.

## Changes

- Add `mask_string_literals {sql}` — a length-preserving, character-by-character scanner that keeps the surrounding `'` quotes but blanks the string interior with spaces. It handles the SQL doubled-quote escape (`''`) as string interior (does not terminate the string) and blanks an unterminated opening quote to end-of-input. Scanning style mirrors the single-quote branch of the existing `convert_dqs_to_single_quotes`.
- Chain it after `mask_trigger_bodies` in `count_cli_statements`: `set masked [mask_string_literals [mask_trigger_bodies $sql]]`. Both masks are length-preserving so the `;` offsets in the masked text still line up with the original `$sql` used for segment slicing. No other logic changed.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `;` inside a string literal is not counted as a statement boundary | ✅ | Unit test: `count_cli_statements "INSERT INTO t VALUES('a;b')"` == 1; `"...('a;b'); SELECT 1"` == 2 |
| `''` escape handled (`VALUES('it''s fine;')` counts as one statement) | ✅ | Unit test returns 1 |
| `mask_string_literals` is length-preserving for all inputs | ✅ | Verified across 10 inputs incl. empty, no-quotes, unterminated, `''`, multiple segments |
| `percentile.test` passes with 0 failures | ✅ | 190 passed, 0 failed, 19 skipped |
| No regression in `fkey6.test` | ✅ | 33 passed, 0 failed |
| No regression in `select3.test` | ✅ | 90 passed, 0 failed |
| No regression in `trigger3.test` | ✅ | 17 passed, 0 failed |

## Test Plan

- Standalone TCL unit tests over the two procs: length-preservation invariant, `;`-in-literal counting, `''` escape, multiple quoted segments, plain multi-statement, trailing-empty-segment — all pass.
- `make test-tcl-file` for `percentile.test`, `fkey6.test`, `select3.test`, `trigger3.test` — all 0 failures.

Note: the change is confined to the TCL shim (no Rust change), so tests were run against the current release binary.

Closes #5947