### PR TITLE
fix(parser): treat UNKNOWN as an identifier in IS operands, matching sqlite3

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -124,9 +124,7 @@ impl<'arena> ArenaParser<'arena> {
             let op = match self.peek() {
                 Token::Symbol('<') => BinaryOperator::LessThan,
                 Token::Symbol('>') => BinaryOperator::GreaterThan,
-                Token::Operator(MultiCharOperator::LessEqual) => {
-                    BinaryOperator::LessThanOrEqual
-                }
+                Token::Operator(MultiCharOperator::LessEqual) => BinaryOperator::LessThanOrEqual,
                 Token::Operator(MultiCharOperator::GreaterEqual) => {
                     BinaryOperator::GreaterThanOrEqual
                 }
@@ -155,14 +153,12 @@ impl<'arena> ArenaParser<'arena> {
                 self.expect_token(Token::RParen)?;
 
                 let left_ref = self.arena.alloc(left);
-                left = Expression::Extended(self.arena.alloc(
-                    ExtendedExpr::QuantifiedComparison {
-                        expr: left_ref,
-                        op,
-                        quantifier,
-                        subquery,
-                    },
-                ));
+                left = Expression::Extended(self.arena.alloc(ExtendedExpr::QuantifiedComparison {
+                    expr: left_ref,
+                    op,
+                    quantifier,
+                    subquery,
+                }));
                 continue;
             }
 
@@ -482,16 +478,6 @@ impl<'arena> ArenaParser<'arena> {
                     let left_ref = self.arena.alloc(left);
                     let right_ref = self.arena.alloc(right);
                     left = Expression::IsDistinctFrom { left: left_ref, right: right_ref, negated };
-                } else if self.peek_keyword(Keyword::Unknown) {
-                    // UNKNOWN is not a literal in the expression grammar, so it is
-                    // only recognized here as the fixed `IS [NOT] UNKNOWN` form.
-                    self.consume_keyword(Keyword::Unknown)?;
-                    let left_ref = self.arena.alloc(left);
-                    left = Expression::IsTruthValue {
-                        expr: left_ref,
-                        truth_value: TruthValue::Unknown,
-                        negated,
-                    };
                 } else {
                     // SQLite parses the right side of `IS` as an ordinary expression,
                     // and NULL/TRUE/FALSE are themselves expressions. Parse the full
@@ -499,6 +485,12 @@ impl<'arena> ArenaParser<'arena> {
                     // follows binds to it (`1 IS NULL + 1` == `1 IS (NULL + 1)`), then
                     // recover the specialized AST shapes for the plain-literal cases so
                     // optimizers that rely on IsNull / IsTruthValue keep working.
+                    //
+                    // UNKNOWN is intentionally handled by this generic branch: SQLite
+                    // has no `IS UNKNOWN` truth-value predicate, so `UNKNOWN` parses as
+                    // an ordinary identifier (column reference) and `x IS UNKNOWN`
+                    // becomes NULL-safe equality against a column named `unknown`
+                    // (erroring at runtime if no such column is in scope).
                     let right = self.parse_relational_expression()?;
                     left = match right {
                         Expression::Literal(SqlValue::Null) => {

--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -455,7 +455,11 @@ impl Keyword {
     ///    (`SELECT by FROM t ORDER BY by`, keyword1.test).
     /// 3. **Special primary forms / literals** that have dedicated parsing
     ///    (`CASE`/`WHEN`/`THEN`/`ELSE`, `CAST`, `EXISTS`, `NULL`, `TRUE`,
-    ///    `FALSE`, `UNKNOWN`, the `CURRENT_*` constants, `DISTINCT`). `END` is
+    ///    `FALSE`, the `CURRENT_*` constants, `DISTINCT`). `UNKNOWN` is NOT
+    ///    denied: SQLite has no `IS UNKNOWN` truth-value predicate and treats
+    ///    `UNKNOWN` in expression position as an ordinary identifier / column
+    ///    reference (`SELECT 1 IS UNKNOWN` errors with "no such column:
+    ///    UNKNOWN"), so it round-trips as a column name here. `END` is
     ///    NOT denied: it is only meaningful *after* a complete CASE body, where
     ///    the CASE parser consumes it at clause level before expression
     ///    parsing resumes; at operand start SQLite treats it as a column
@@ -526,7 +530,6 @@ impl Keyword {
                 | Keyword::Null
                 | Keyword::True
                 | Keyword::False
-                | Keyword::Unknown
                 | Keyword::Distinct
                 | Keyword::CurrentDate
                 | Keyword::CurrentTime

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -932,15 +932,6 @@ impl Parser {
                         right: Box::new(right),
                         negated,
                     };
-                } else if self.peek_keyword(Keyword::Unknown) {
-                    // UNKNOWN is not a literal in the expression grammar, so it is
-                    // only recognized here as the fixed `IS [NOT] UNKNOWN` form.
-                    self.consume_keyword(Keyword::Unknown)?;
-                    left = vibesql_ast::Expression::IsTruthValue {
-                        expr: Box::new(left),
-                        truth_value: vibesql_ast::TruthValue::Unknown,
-                        negated,
-                    };
                 } else {
                     // SQLite parses the right side of `IS` as an ordinary expression,
                     // and NULL/TRUE/FALSE are themselves expressions. Parse the full
@@ -948,25 +939,31 @@ impl Parser {
                     // follows binds to it (`1 IS NULL + 1` == `1 IS (NULL + 1)`), then
                     // recover the specialized AST shapes for the plain-literal cases so
                     // optimizers that rely on IsNull / IsTruthValue keep working.
+                    //
+                    // UNKNOWN is intentionally handled by this generic branch: SQLite
+                    // has no `IS UNKNOWN` truth-value predicate, so `UNKNOWN` parses as
+                    // an ordinary identifier (column reference) and `x IS UNKNOWN`
+                    // becomes NULL-safe equality against a column named `unknown`
+                    // (erroring at runtime if no such column is in scope).
                     let right = self.parse_relational_expression()?;
                     left = match right {
                         vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null) => {
                             vibesql_ast::Expression::IsNull { expr: Box::new(left), negated }
                         }
-                        vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(true)) => {
-                            vibesql_ast::Expression::IsTruthValue {
-                                expr: Box::new(left),
-                                truth_value: vibesql_ast::TruthValue::True,
-                                negated,
-                            }
-                        }
-                        vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(false)) => {
-                            vibesql_ast::Expression::IsTruthValue {
-                                expr: Box::new(left),
-                                truth_value: vibesql_ast::TruthValue::False,
-                                negated,
-                            }
-                        }
+                        vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(
+                            true,
+                        )) => vibesql_ast::Expression::IsTruthValue {
+                            expr: Box::new(left),
+                            truth_value: vibesql_ast::TruthValue::True,
+                            negated,
+                        },
+                        vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(
+                            false,
+                        )) => vibesql_ast::Expression::IsTruthValue {
+                            expr: Box::new(left),
+                            truth_value: vibesql_ast::TruthValue::False,
+                            negated,
+                        },
                         // SQLite compatibility: `IS <expr>` compares with NULL-safe
                         // equals. IS is IS NOT DISTINCT FROM; IS NOT is IS DISTINCT FROM.
                         _ => vibesql_ast::Expression::IsDistinctFrom {

--- a/crates/vibesql-parser/src/tests/isnull_postfix.rs
+++ b/crates/vibesql-parser/src/tests/isnull_postfix.rs
@@ -527,7 +527,10 @@ fn test_is_true_plus_one_binds_to_operand() {
     if let vibesql_ast::Expression::BinaryOp { op, left, .. } = &right {
         assert_eq!(*op, vibesql_ast::BinaryOperator::Plus, "expected + operator");
         assert!(
-            matches!(**left, vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(true))),
+            matches!(
+                **left,
+                vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(true))
+            ),
             "expected TRUE as left operand of +: {:?}",
             left
         );
@@ -604,23 +607,67 @@ fn test_plain_is_not_true_still_truth_value_node() {
     );
 }
 
+// ------------------------------------------------------------------------
+// IS UNKNOWN — SQLite alignment (issue #5948)
+//
+// SQLite has no SQL:1999 `IS UNKNOWN` truth-value predicate. `UNKNOWN` in
+// expression position is an ordinary identifier / column reference:
+//   sqlite3> SELECT 1 IS UNKNOWN;                -- Error: no such column: UNKNOWN
+//   sqlite3> SELECT x IS UNKNOWN
+//            FROM (SELECT 1 AS x, 1 AS unknown); -- 1  (NULL-safe equals x == unknown)
+// So `x IS UNKNOWN` is `x IS <column unknown>` == IsDistinctFrom{negated:true}
+// (IS is NULL-safe equals; IS NOT is the distinct form) and UNKNOWN binds
+// following tighter operators like any identifier: `1 IS UNKNOWN + 1` is
+// `1 IS (unknown + 1)`.
+// ------------------------------------------------------------------------
+
+/// Assert the expression is a bare unqualified column reference with the given
+/// canonical name.
+fn assert_column_ref(expr: &vibesql_ast::Expression, expected: &str, context: &str) {
+    if let vibesql_ast::Expression::ColumnRef(col_id) = expr {
+        assert_eq!(col_id.column_canonical(), expected, "{}: wrong column name", context);
+        assert!(col_id.table_canonical().is_none(), "{}: expected unqualified column", context);
+    } else {
+        panic!("{}: expected ColumnRef({:?}), got {:?}", context, expected, expr);
+    }
+}
+
 #[test]
-fn test_plain_is_unknown_still_truth_value_node() {
-    // UNKNOWN is not a literal in the expression grammar; the fixed IS-form
-    // must keep mapping to IsTruthValue(Unknown).
+fn test_is_unknown_is_column_reference_null_safe_equals() {
+    // sqlite3 treats UNKNOWN as an identifier, so `x IS UNKNOWN` is NULL-safe
+    // equality against a column named `unknown`: IsDistinctFrom { negated: true }.
     let expr = parse_select_expr("SELECT x IS UNKNOWN;");
-    assert!(
-        matches!(
-            expr,
-            vibesql_ast::Expression::IsTruthValue {
-                truth_value: vibesql_ast::TruthValue::Unknown,
-                negated: false,
-                ..
-            }
-        ),
-        "x IS UNKNOWN should be IsTruthValue(Unknown): {:?}",
-        expr
-    );
+    let (_left, right) = unwrap_is_distinct_from(expr, true, "x IS UNKNOWN");
+    assert_column_ref(&right, "unknown", "x IS UNKNOWN right operand");
+}
+
+#[test]
+fn test_is_not_unknown_is_negated_null_safe_equals() {
+    // `x IS NOT UNKNOWN` is the distinct form: IsDistinctFrom { negated: false }.
+    let expr = parse_select_expr("SELECT x IS NOT UNKNOWN;");
+    let (_left, right) = unwrap_is_distinct_from(expr, false, "x IS NOT UNKNOWN");
+    assert_column_ref(&right, "unknown", "x IS NOT UNKNOWN right operand");
+}
+
+#[test]
+fn test_is_unknown_plus_one_binds_to_operand() {
+    // sqlite3: `1 IS UNKNOWN + 1` parses as `1 IS (unknown + 1)`, i.e. the `+`
+    // binds to the identifier operand, not the IS node.
+    let expr = parse_select_expr("SELECT 1 IS UNKNOWN + 1;");
+    let (_left, right) = unwrap_is_distinct_from(expr, true, "1 IS UNKNOWN + 1");
+    if let vibesql_ast::Expression::BinaryOp { op, left, .. } = &right {
+        assert_eq!(*op, vibesql_ast::BinaryOperator::Plus, "expected + operator");
+        assert_column_ref(left, "unknown", "1 IS UNKNOWN + 1 left operand of +");
+    } else {
+        panic!("expected BinaryOp Plus as IS right operand, got {:?}", right);
+    }
+}
+
+#[test]
+fn test_bare_unknown_is_column_reference() {
+    // In expression position UNKNOWN is a plain identifier.
+    let expr = parse_select_expr("SELECT unknown;");
+    assert_column_ref(&expr, "unknown", "bare unknown");
 }
 
 #[test]

--- a/tests/sqllogictest-files/select/is_truth_value.slt
+++ b/tests/sqllogictest-files/select/is_truth_value.slt
@@ -1,4 +1,11 @@
-# IS TRUE / IS FALSE / IS UNKNOWN boolean test predicates (SQL:1999)
+# IS TRUE / IS FALSE boolean test predicates (SQL:1999)
+#
+# NOTE: SQLite (and VibeSQL, per issue #5948) has no `IS UNKNOWN` truth-value
+# predicate. Unlike TRUE/FALSE, UNKNOWN is not a literal: in expression
+# position it is an ordinary identifier, so `x IS UNKNOWN` is NULL-safe
+# equality against a column named `unknown` and errors ("no such column:
+# UNKNOWN") when no such column is in scope. The IS UNKNOWN cases below reflect
+# that SQLite-aligned behavior.
 
 # Basic IS TRUE tests
 query B
@@ -32,21 +39,27 @@ SELECT NULL IS FALSE
 ----
 0
 
-# Basic IS UNKNOWN tests (UNKNOWN is NULL in boolean context)
-query B
+# Basic IS UNKNOWN tests: UNKNOWN is an identifier, not a truth-value keyword.
+# With no column named `unknown` in scope, these error (sqlite3-aligned).
+statement error
 SELECT TRUE IS UNKNOWN
-----
-0
 
-query B
+statement error
 SELECT FALSE IS UNKNOWN
-----
-0
 
-query B
+statement error
 SELECT NULL IS UNKNOWN
+
+# With a column named `unknown` in scope, `x IS UNKNOWN` is NULL-safe equality.
+query B
+SELECT val IS UNKNOWN FROM (SELECT NULL AS val, NULL AS unknown)
 ----
 1
+
+query B
+SELECT val IS UNKNOWN FROM (SELECT 1 AS val, NULL AS unknown)
+----
+0
 
 # IS NOT TRUE tests
 query B
@@ -80,21 +93,24 @@ SELECT NULL IS NOT FALSE
 ----
 1
 
-# IS NOT UNKNOWN tests
-query B
+# IS NOT UNKNOWN tests: UNKNOWN is an identifier, so with no column named
+# `unknown` in scope these error (sqlite3-aligned). `x IS NOT UNKNOWN` is the
+# NULL-safe distinct form against a column named `unknown`.
+statement error
 SELECT TRUE IS NOT UNKNOWN
-----
-1
 
-query B
-SELECT FALSE IS NOT UNKNOWN
-----
-1
-
-query B
+statement error
 SELECT NULL IS NOT UNKNOWN
+
+query B
+SELECT val IS NOT UNKNOWN FROM (SELECT NULL AS val, NULL AS unknown)
 ----
 0
+
+query B
+SELECT val IS NOT UNKNOWN FROM (SELECT 1 AS val, NULL AS unknown)
+----
+1
 
 # Test with expressions that evaluate to boolean
 query B
@@ -138,12 +154,9 @@ SELECT id, val IS FALSE FROM bool_test
 2 1
 3 0
 
-query IB rowsort
+# bool_test has no column named `unknown`, so `val IS UNKNOWN` errors.
+statement error
 SELECT id, val IS UNKNOWN FROM bool_test
-----
-1 0
-2 0
-3 1
 
 query IB rowsort
 SELECT id, val IS NOT TRUE FROM bool_test
@@ -163,10 +176,8 @@ SELECT id FROM bool_test WHERE val IS FALSE
 ----
 2
 
-query I
+statement error
 SELECT id FROM bool_test WHERE val IS UNKNOWN
-----
-3
 
 query I rowsort
 SELECT id FROM bool_test WHERE val IS NOT TRUE


### PR DESCRIPTION
## Summary

SQLite has no SQL:1999 `IS UNKNOWN` truth-value predicate. In expression
position `UNKNOWN` is an ordinary identifier / column reference, so
`SELECT 1 IS UNKNOWN` errors with "no such column: UNKNOWN" and `x IS UNKNOWN`
is NULL-safe equality against a column named `unknown`. VibeSQL previously
diverged via a keyword peek-guard that special-cased `UNKNOWN` in both `IS`
handlers, emitting `IsTruthValue { truth_value: Unknown }` and consuming the
token without parsing a following expression (so `1 IS UNKNOWN + 1` left
`+ 1` unconsumed). This PR aligns both parser paths with sqlite3 3.51.0
(Option A from the curator analysis).

## Changes

- `crates/vibesql-parser/src/keywords.rs`: remove `Keyword::Unknown` from the
  `can_be_identifier_in_expression()` deny-list (and update the doc comment) so
  `unknown` parses as a column reference in expression position.
- `crates/vibesql-parser/src/parser/expressions/operators.rs`: remove the
  `peek_keyword(Keyword::Unknown)` guard from the `IS` handler; `IS UNKNOWN`
  now falls through the generic relational-operand branch.
- `crates/vibesql-parser/src/arena_parser/expression.rs`: mirror the same
  removal in the arena parser.
- `crates/vibesql-parser/src/tests/isnull_postfix.rs`: replace
  `test_plain_is_unknown_still_truth_value_node` with SQLite-aligned tests
  (identifier fall-through, negation, operator binding, bare identifier).
- `tests/sqllogictest-files/select/is_truth_value.slt`: update the
  `IS UNKNOWN` / `IS NOT UNKNOWN` cases (which asserted the old SQL:1999
  semantics) to the new SQLite-aligned behavior.

The `IsTruthValue { truth_value: Unknown }` AST node and its executor
evaluation paths are intentionally left in place; their cleanup is out of
scope per the issue's scope guard.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `SELECT 1 IS UNKNOWN;` errors ("no such column: unknown") | ✅ | Debug CLI: `Error executing statement 1: no such column: unknown` |
| `SELECT x IS UNKNOWN FROM (SELECT 1 AS x, 1 AS unknown);` → NULL-safe equality | ✅ | Debug CLI returns `1` |
| `SELECT 1 IS UNKNOWN + 1;` parses as `1 IS (unknown + 1)`, errors at runtime | ✅ | Debug CLI: `no such column: unknown`; unit test asserts `+` binds to `unknown` |
| `SELECT 1 IS NOT UNKNOWN;` (negated form) | ✅ | Debug CLI: `no such column: unknown` (identifier path) |
| Both parser paths aligned | ✅ | Removed peek-guard from operators.rs and arena_parser/expression.rs |
| `test_plain_is_unknown_still_truth_value_node` replaced | ✅ | New tests in isnull_postfix.rs |
| `cargo test -p vibesql-parser` passes | ✅ | 1720 + 8 doctests pass, 0 failed |

## Test Plan

- `cargo build -p vibesql-parser` — clean.
- `cargo test -p vibesql-parser` — 1720 unit tests + 8 doctests pass, 0 failed.
- `cargo fmt -p vibesql-parser`; `cargo clippy -p vibesql-parser` — no new warnings (one pre-existing warning in unrelated alias-parsing code).
- Manual end-to-end with a debug `vibesql` build confirming each acceptance-criterion query above (errors and NULL-safe-equality results match sqlite3 3.51.0).

Closes #5948