### PR TITLE
fix(division): derive result type from coerced operands in SQLite mode

### DIFF
--- a/crates/vibesql-executor/src/evaluator/operators/arithmetic/division.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/arithmetic/division.rs
@@ -75,8 +75,44 @@ impl Division {
             return Ok(Null); // Non-strict mode: division by zero returns NULL
         }
 
-        // Use TypeBehavior trait to determine result type based on original operands
-        let result_type = sql_mode.division_result_type(left, right);
+        // Determine the result type.
+        //
+        // In SQLite mode (and the mysql_slt compatibility variant), integer vs
+        // float division is a property of the *coerced* operands, not the
+        // original SqlValue types. `division_result_type` inspects the original
+        // operands via `is_float_value`, which returns `false` for a text
+        // operand — so `'2245'/3` and `'2245.5'/3` would both be classified by
+        // their surface type rather than their numeric affinity. That produced
+        // two bugs:
+        //   1. text-integer operands like `'2245'/3` yielded float in MySQL mode
+        //      (`division_result_type` always returns Numeric there), diverging
+        //      from sqlite3's integer division (748.33 vs 748).
+        //   2. `'2245.5'/3` in SQLite mode hit the `(ApproximateNumeric, Integer)`
+        //      unreachable! panic, because coercion says float but
+        //      `division_result_type` says Integer for a Varchar operand.
+        //
+        // Mirror how Modulo derives its result type: use the CoercedValues
+        // variant directly to pick Integer vs Float in SQLite-semantics modes.
+        // MySQL mode without sqlite_division_semantics is unchanged (always
+        // Numeric), preserving SQLLogicTest expectations.
+        let result_type = match (&coerced, &sql_mode) {
+            (super::CoercedValues::ExactNumeric(_, _), vibesql_types::SqlMode::SQLite) => {
+                ValueType::Integer
+            }
+            (super::CoercedValues::ApproximateNumeric(_, _), vibesql_types::SqlMode::SQLite) => {
+                ValueType::Float
+            }
+            (super::CoercedValues::ExactNumeric(_, _), vibesql_types::SqlMode::MySQL { flags })
+                if flags.sqlite_division_semantics =>
+            {
+                ValueType::Integer
+            }
+            (
+                super::CoercedValues::ApproximateNumeric(_, _),
+                vibesql_types::SqlMode::MySQL { flags },
+            ) if flags.sqlite_division_semantics => ValueType::Float,
+            _ => sql_mode.division_result_type(left, right),
+        };
 
         // Perform division based on coerced values and convert to determined type
         // Apply nan_to_null for SQLite compatibility (infinity/infinity = NaN → NULL)

--- a/crates/vibesql-executor/src/evaluator/operators/arithmetic/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/arithmetic/mod.rs
@@ -777,6 +777,148 @@ mod tests {
         assert_eq!(result, SqlValue::Integer(5));
     }
 
+    // --- Division affinity matrix (issue #5943) ---
+    //
+    // In SQLite semantics the result type of `/` follows the numeric affinity
+    // of the *coerced* operands, not their surface SqlValue type. A text
+    // operand that parses to an integer must divide as an integer (matching
+    // sqlite3), and a text operand that parses to a real must divide as a real.
+    // These verify the four affinity cases plus the previously latent panic.
+
+    #[test]
+    fn test_division_affinity_int_int_sqlite() {
+        // 2245 / 3 = 748 (integer division), matches sqlite3
+        let result = ArithmeticOps::divide(
+            &SqlValue::Integer(2245),
+            &SqlValue::Integer(3),
+            vibesql_types::SqlMode::SQLite,
+        )
+        .unwrap();
+        assert_eq!(result, SqlValue::Integer(748));
+    }
+
+    #[test]
+    fn test_division_affinity_text_int_int_sqlite() {
+        // '2245' / 3 = 748 (integer division). This is the core issue #5943
+        // reproducer: previously yielded a float because the result type was
+        // derived from the Varchar surface type rather than the coerced value.
+        let result = ArithmeticOps::divide(
+            &SqlValue::Varchar(arcstr::ArcStr::from("2245")),
+            &SqlValue::Integer(3),
+            vibesql_types::SqlMode::SQLite,
+        )
+        .unwrap();
+        assert_eq!(result, SqlValue::Integer(748));
+    }
+
+    #[test]
+    fn test_division_affinity_real_int_sqlite() {
+        // 2245.0 / 3 = 748.333... (real division), matches sqlite3 typeof=real
+        let result = ArithmeticOps::divide(
+            &SqlValue::Real(2245.0),
+            &SqlValue::Integer(3),
+            vibesql_types::SqlMode::SQLite,
+        )
+        .unwrap();
+        match result {
+            SqlValue::Real(f) => assert!((f - 748.333_333).abs() < 1e-3),
+            other => panic!("Expected Real result, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_division_affinity_text_real_int_sqlite() {
+        // '2245.0' / 3 = 748.333... (real division). Text that parses to a real
+        // divides as a real, matching sqlite3 typeof=real.
+        let result = ArithmeticOps::divide(
+            &SqlValue::Varchar(arcstr::ArcStr::from("2245.0")),
+            &SqlValue::Integer(3),
+            vibesql_types::SqlMode::SQLite,
+        )
+        .unwrap();
+        match result {
+            SqlValue::Real(f) => assert!((f - 748.333_333).abs() < 1e-3),
+            other => panic!("Expected Real result, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_string_float_division_sqlite_no_panic() {
+        // '2245.5' / 3 = 748.5 (Real). Previously hit the
+        // `(ApproximateNumeric, Integer)` unreachable! panic in SQLite mode
+        // because is_float_value(Varchar) is false. Must not panic.
+        let result = ArithmeticOps::divide(
+            &SqlValue::Varchar(arcstr::ArcStr::from("2245.5")),
+            &SqlValue::Integer(3),
+            vibesql_types::SqlMode::SQLite,
+        )
+        .unwrap();
+        match result {
+            SqlValue::Real(f) => assert!((f - 748.5).abs() < 1e-6),
+            other => panic!("Expected Real result, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_string_division_non_numeric_sqlite() {
+        // 'abc' / 3 = 0 (non-numeric string → 0, integer division), matches sqlite3
+        let result = ArithmeticOps::divide(
+            &SqlValue::Varchar(arcstr::ArcStr::from("abc")),
+            &SqlValue::Integer(3),
+            vibesql_types::SqlMode::SQLite,
+        )
+        .unwrap();
+        assert_eq!(result, SqlValue::Integer(0));
+    }
+
+    #[test]
+    fn test_string_exponent_division_sqlite() {
+        // '2e2' / 3 → real 66.666... Exponent notation parses to real 200.0, so
+        // the division is real. Verified against sqlite3 3.51.0:
+        //   SELECT typeof('2e2'/3), '2e2'/3;  -- real|66.6666666666667
+        let result = ArithmeticOps::divide(
+            &SqlValue::Varchar(arcstr::ArcStr::from("2e2")),
+            &SqlValue::Integer(3),
+            vibesql_types::SqlMode::SQLite,
+        )
+        .unwrap();
+        match result {
+            SqlValue::Real(f) => assert!((f - 66.666_666).abs() < 1e-3),
+            other => panic!("Expected Real result, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_division_affinity_text_int_mysql_slt() {
+        // mysql_slt (MySQL syntax + SQLite division semantics): '2245'/3 = 748.
+        // The TCL runner uses this mode; verify text-int coercion is integer.
+        let mode: vibesql_types::SqlMode = "mysql_slt".parse().unwrap();
+        let result = ArithmeticOps::divide(
+            &SqlValue::Varchar(arcstr::ArcStr::from("2245")),
+            &SqlValue::Integer(3),
+            mode,
+        )
+        .unwrap();
+        assert_eq!(result, SqlValue::Integer(748));
+    }
+
+    #[test]
+    fn test_division_text_int_mysql_default_numeric() {
+        // Default MySQL mode is unchanged: '2245'/3 → Numeric (float), preserving
+        // SQLLogicTest expectations (INTEGER/INTEGER → DECIMAL).
+        let mode = vibesql_types::SqlMode::MySQL { flags: Default::default() };
+        let result = ArithmeticOps::divide(
+            &SqlValue::Varchar(arcstr::ArcStr::from("2245")),
+            &SqlValue::Integer(3),
+            mode,
+        )
+        .unwrap();
+        match result {
+            SqlValue::Numeric(f) => assert!((f - 748.333_333).abs() < 1e-3),
+            other => panic!("Expected Numeric result in MySQL mode, got {other:?}"),
+        }
+    }
+
     #[test]
     fn test_string_modulo() {
         // '17' % 5 = 2


### PR DESCRIPTION
## Summary

`SELECT 22||45/3` returned `748.33` instead of sqlite3's `748`. In SQLite-semantics modes the result type of `/` (integer vs real) is a property of the *coerced* operands, not the original `SqlValue` types. `Division::divide()` called `sql_mode.division_result_type()` with the **original** operands, which route text through `is_float_value` (false for `Varchar`). This caused two bugs:

1. Text-integer operands like `'2245'/3` (and `22||45/3`, whose concat yields `'2245'`) produced float instead of integer division, diverging from sqlite3.
2. Float-valued text like `'2245.5'/3` hit the `(ApproximateNumeric, Integer)` `unreachable!` panic in SQLite mode (latent because the CLI defaults to MySQL mode).

The fix mirrors how `Modulo` already works: derive the result type from the `CoercedValues` variant (`ExactNumeric → Integer`, `ApproximateNumeric → Float`), scoped to SQLite and `mysql_slt` (`sqlite_division_semantics`) modes. Default MySQL mode is untouched (always `Numeric`), so SQLLogicTest expectations are preserved.

## Changes

- `crates/vibesql-executor/src/evaluator/operators/arithmetic/division.rs`: replace the single `division_result_type` call in the coerced-operand path with a match on `(CoercedValues, sql_mode)` that picks Integer/Float from the coerced variant in SQLite-semantics modes; falls back to `division_result_type` otherwise. Eliminates the latent `(ApproximateNumeric, Integer)` `unreachable!`.
- `crates/vibesql-executor/src/evaluator/operators/arithmetic/mod.rs`: add unit tests for the affinity matrix and the previously-panicking case.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `SELECT 22||45/3` returns 748 | done | CLI (SQLite mode) returns `748`, matches `sqlite3 :memory:` |
| Affinity matrix matches sqlite3 (int/int, text-int/int, real/int, text-real/int) | done | Unit tests + CLI vs sqlite3 3.51.0 |
| No regression in `cargo test -p vibesql-executor` | done | 3207 passed, 0 failed |
| Latent `(ApproximateNumeric, Integer)` panic eliminated | done | `test_string_float_division_sqlite_no_panic`: `'2245.5'/3 = 748.5`, no panic |
| Edge cases (`'abc'/3=0`, `'2e2'/3` real) match sqlite3 | done | Unit tests; sqlite3 confirms `'2e2'/3 → real 66.666` |

## Test Plan

Ground truth from `sqlite3 3.51.0`:
```
'2245'/3    → 748          '2245.0'/3 → 748.333333333333
'2245.5'/3  → 748.5        'abc'/3    → 0
'2e2'/3     → 66.666...    22||45/3   → 748
```

VibeSQL CLI (`SET sql_mode='sqlite'`) now matches all of the above. Default MySQL mode still returns `748.33` for `22||45/3` (unchanged, preserves SQLLogicTest DECIMAL semantics). Added tests: `test_division_affinity_{int_int,text_int_int,real_int,text_real_int}_sqlite`, `test_string_float_division_sqlite_no_panic`, `test_string_division_non_numeric_sqlite`, `test_string_exponent_division_sqlite`, `test_division_affinity_text_int_mysql_slt`, `test_division_text_int_mysql_default_numeric`. `cargo test -p vibesql-executor`: 3207 passed, 0 failed.

Closes #5943

🤖 Generated with [Claude Code](https://claude.com/claude-code)