### PR TITLE
fix(parser): accept contextual keywords as column names in column-list positions

### DIFF
--- a/crates/vibesql-parser/src/parser/alter.rs
+++ b/crates/vibesql-parser/src/parser/alter.rs
@@ -403,9 +403,9 @@ fn parse_rename_column(
     parser: &mut crate::Parser,
     table_name: String,
 ) -> Result<AlterTableStmt, ParseError> {
-    let old_column_name = parser.parse_identifier()?;
+    let old_column_name = parser.parse_column_name()?;
     parser.expect_keyword(Keyword::To)?;
-    let new_column_name = parser.parse_identifier()?;
+    let new_column_name = parser.parse_column_name()?;
 
     Ok(AlterTableStmt::RenameColumn(RenameColumnStmt {
         table_name,

--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -103,7 +103,7 @@ impl Parser {
         // if this turns out to be an expression like abs(b) rather than a column name
         let saved_position = self.position;
 
-        let column_name = self.parse_identifier()?;
+        let column_name = self.parse_column_name()?;
 
         // Check for optional prefix length: column_name(length)
         // BUT: if the token after ( is not a number, this is likely a function call
@@ -500,7 +500,7 @@ impl Parser {
                     let column = if self.peek() == &Token::LParen {
                         self.advance(); // consume LParen
                                         // Accept both regular and quoted identifiers for column names
-                        let col_name = self.parse_identifier().map_err(|_| ParseError {
+                        let col_name = self.parse_column_name().map_err(|_| ParseError {
                             message: "Expected column name in REFERENCES".to_string(),
                         })?;
                         self.expect_token(Token::RParen)?;
@@ -632,7 +632,7 @@ impl Parser {
                 let mut columns = Vec::new();
                 loop {
                     // Accept both regular and quoted identifiers for column names
-                    let col = self.parse_identifier().map_err(|_| ParseError {
+                    let col = self.parse_column_name().map_err(|_| ParseError {
                         message: "Expected column name in FOREIGN KEY".to_string(),
                     })?;
                     columns.push(col);
@@ -659,7 +659,7 @@ impl Parser {
 
                     loop {
                         // Accept both regular and quoted identifiers for column names
-                        let col = self.parse_identifier().map_err(|_| ParseError {
+                        let col = self.parse_column_name().map_err(|_| ParseError {
                             message: "Expected column name in REFERENCES".to_string(),
                         })?;
                         references_columns.push(col);

--- a/crates/vibesql-parser/src/parser/helpers.rs
+++ b/crates/vibesql-parser/src/parser/helpers.rs
@@ -137,6 +137,38 @@ impl Parser {
         }
     }
 
+    /// Parse a column name, accepting contextual keywords (those accepted by
+    /// SQLite's fallback mechanism in expression/column-name position) in
+    /// addition to plain and delimited identifiers. This covers keywords like
+    /// `m` (HNSW parameter), `key`, `level`, `trigger`, `view`, etc. that
+    /// SQLite allows as unquoted column names, while still rejecting truly
+    /// reserved words (`SELECT`, `AND`, `NOT`, `NULL`, ...) that would create
+    /// grammar ambiguity.
+    ///
+    /// This mirrors the expression/column-ref position (`identifiers.rs`) and
+    /// SQLite's `%fallback ID` mechanism. Use it for column-list positions —
+    /// `FOREIGN KEY (…)`, `REFERENCES t(…)`, `PRIMARY KEY (…)`, `UNIQUE (…)`,
+    /// `USING (…)`, and `RENAME COLUMN` — where `parse_identifier()` would
+    /// otherwise reject a contextual keyword used as a column name.
+    ///
+    /// Keyword-derived names are lowercased, consistent with the lexer's
+    /// normalization of unquoted identifiers.
+    pub(super) fn parse_column_name(&mut self) -> Result<String, ParseError> {
+        match self.peek() {
+            Token::Identifier(name) | Token::DelimitedIdentifier(name) => {
+                let identifier = name.clone();
+                self.advance();
+                Ok(identifier)
+            }
+            Token::Keyword { keyword: kw, .. } if kw.can_be_identifier_in_expression() => {
+                let name = kw.to_string().to_lowercase();
+                self.advance();
+                Ok(name)
+            }
+            _ => Err(ParseError { message: self.peek().syntax_error() }),
+        }
+    }
+
     /// Parse an identifier or any keyword. Used for SQL positions where the grammar
     /// permits a name and the keyword/identifier distinction does not matter
     /// (e.g. PRAGMA schema/name parts: `PRAGMA temp.foreign_key_check`).

--- a/crates/vibesql-parser/src/parser/index.rs
+++ b/crates/vibesql-parser/src/parser/index.rs
@@ -143,7 +143,7 @@ impl Parser {
         self.expect_token(Token::LParen)?;
 
         // Parse column name
-        let column_name = self.parse_identifier()?;
+        let column_name = self.parse_column_name()?;
 
         // Parse optional operator class (vector_l2_ops, vector_cosine_ops, vector_ip_ops)
         let metric = if let Token::Identifier(ident) = self.peek().clone() {
@@ -247,7 +247,7 @@ impl Parser {
         self.expect_token(Token::LParen)?;
 
         // Parse column name
-        let column_name = self.parse_identifier()?;
+        let column_name = self.parse_column_name()?;
 
         // Parse optional operator class (vector_l2_ops, vector_cosine_ops, vector_ip_ops)
         let metric = if let Token::Identifier(ident) = self.peek().clone() {
@@ -823,7 +823,7 @@ impl Parser {
 
             let mut cols = Vec::new();
             loop {
-                cols.push(self.parse_identifier()?);
+                cols.push(self.parse_column_name()?);
 
                 if self.peek() == &Token::Comma {
                     self.advance(); // consume ','

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -63,7 +63,7 @@ impl Parser {
                         }
                         self.consume_keyword(Keyword::Using)?;
                         self.expect_token(Token::LParen)?;
-                        let columns = self.parse_comma_separated_list(|p| p.parse_identifier())?;
+                        let columns = self.parse_comma_separated_list(|p| p.parse_column_name())?;
                         self.expect_token(Token::RParen)?;
                         (None, Some(columns))
                     } else {

--- a/crates/vibesql-parser/src/tests/alter_table.rs
+++ b/crates/vibesql-parser/src/tests/alter_table.rs
@@ -420,9 +420,7 @@ fn test_parse_alter_table_add_column_bare_no_column_keyword_no_type() {
 fn test_parse_alter_table_add_generated_column_typed() {
     // `GENERATED ALWAYS AS (expr)` after an explicit type must populate
     // `generated_expr` on the ColumnDef (previously silently dropped).
-    let result = Parser::parse_sql(
-        "ALTER TABLE g ADD COLUMN y INTEGER GENERATED ALWAYS AS (x+1)",
-    );
+    let result = Parser::parse_sql("ALTER TABLE g ADD COLUMN y INTEGER GENERATED ALWAYS AS (x+1)");
     assert!(result.is_ok(), "err: {:?}", result);
     match result.unwrap() {
         vibesql_ast::Statement::AlterTable(vibesql_ast::AlterTableStmt::AddColumn(add)) => {
@@ -469,10 +467,7 @@ fn test_parse_alter_table_add_generated_column_typeless_short_form() {
                 "generated_expr must be populated for the typeless AS short form"
             );
             // No explicit type -> BLOB affinity, like a typeless column.
-            assert!(matches!(
-                add.column_def.data_type,
-                vibesql_types::DataType::BinaryLargeObject
-            ));
+            assert!(matches!(add.column_def.data_type, vibesql_types::DataType::BinaryLargeObject));
         }
         other => panic!("Expected ADD COLUMN, got {:?}", other),
     }
@@ -489,4 +484,55 @@ fn test_parse_alter_table_add_plain_column_has_no_generated_expr() {
         }
         other => panic!("Expected ADD COLUMN, got {:?}", other),
     }
+}
+
+// ========================================================================
+// RENAME COLUMN with contextual-keyword column names (issue #5945)
+//
+// SQLite accepts contextual/fallback keywords (`m`, `key`, `level`, ...) as
+// unquoted column names in `ALTER TABLE ... RENAME COLUMN <old> TO <new>`.
+// The old and new column names now parse via `parse_column_name()`.
+// ========================================================================
+
+#[test]
+fn test_parse_rename_column_with_contextual_keyword_m() {
+    let result = Parser::parse_sql("ALTER TABLE t1 RENAME COLUMN m TO n");
+    assert!(result.is_ok(), "RENAME COLUMN m TO n should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::AlterTable(alter) => match alter {
+            vibesql_ast::AlterTableStmt::RenameColumn(rename) => {
+                assert_eq!(rename.old_column_name, "m");
+                assert_eq!(rename.new_column_name, "n");
+            }
+            _ => panic!("Expected RENAME COLUMN statement"),
+        },
+        _ => panic!("Expected ALTER TABLE statement"),
+    }
+}
+
+#[test]
+fn test_parse_rename_column_contextual_keyword_to_contextual_keyword() {
+    // Both the old and new name may be contextual keywords.
+    for (old, new) in [("m", "level"), ("key", "m"), ("level", "key")] {
+        let sql = format!("ALTER TABLE t1 RENAME COLUMN {old} TO {new}");
+        let result = Parser::parse_sql(&sql);
+        assert!(result.is_ok(), "`{sql}` should parse: {:?}", result.err());
+        match result.unwrap() {
+            vibesql_ast::Statement::AlterTable(alter) => match alter {
+                vibesql_ast::AlterTableStmt::RenameColumn(rename) => {
+                    assert_eq!(rename.old_column_name, old);
+                    assert_eq!(rename.new_column_name, new);
+                }
+                _ => panic!("Expected RENAME COLUMN statement"),
+            },
+            _ => panic!("Expected ALTER TABLE statement"),
+        }
+    }
+}
+
+#[test]
+fn test_parse_rename_column_rejects_reserved_keyword() {
+    // Truly reserved words are still rejected as unquoted column names.
+    let result = Parser::parse_sql("ALTER TABLE t1 RENAME COLUMN select TO n");
+    assert!(result.is_err(), "reserved keyword `select` must be rejected as a column name");
 }

--- a/crates/vibesql-parser/src/tests/create_table/constraints_table.rs
+++ b/crates/vibesql-parser/src/tests/create_table/constraints_table.rs
@@ -745,3 +745,103 @@ fn test_parse_foreign_key_match_missing_name_is_error() {
     let result = Parser::parse_sql("CREATE TABLE c(a, FOREIGN KEY(a) REFERENCES p MATCH)");
     assert!(result.is_err(), "MATCH without a name must be a parse error");
 }
+
+// ========================================================================
+// Contextual-keyword column names in column-list positions (issue #5945)
+//
+// SQLite accepts contextual/fallback keywords such as `m` (an HNSW index
+// parameter), `key`, and `level` as unquoted column names inside FOREIGN
+// KEY / REFERENCES / PRIMARY KEY / UNIQUE column lists. VibeSQL previously
+// rejected them because those positions called `parse_identifier()`, which
+// refuses every keyword. They now call `parse_column_name()`.
+// ========================================================================
+
+#[test]
+fn test_altercol_2_0_foreign_key_with_contextual_keyword_m() {
+    // The altercol 2.0 primary case: column `m` (HNSW contextual keyword)
+    // used in a table-level FOREIGN KEY column list.
+    let result = Parser::parse_sql("CREATE TABLE t1(a, b, c, m, FOREIGN KEY (m) REFERENCES p(q))");
+    assert!(result.is_ok(), "altercol 2.0 CREATE TABLE should parse: {:?}", result.err());
+
+    match result.unwrap() {
+        vibesql_ast::Statement::CreateTable(create) => {
+            assert_eq!(create.table_constraints.len(), 1);
+            match &create.table_constraints[0].kind {
+                vibesql_ast::TableConstraintKind::ForeignKey {
+                    columns,
+                    references_table,
+                    references_columns,
+                    ..
+                } => {
+                    assert_eq!(columns, &vec!["m".to_string()]);
+                    assert_eq!(references_table, "p");
+                    assert_eq!(references_columns, &vec!["q".to_string()]);
+                }
+                _ => panic!("Expected FOREIGN KEY constraint"),
+            }
+        }
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_contextual_keyword_column_names_in_all_constraint_positions() {
+    // `m`, `key`, and `level` are all contextual keywords that must be usable
+    // as unquoted column names in every table-constraint column list.
+    for name in ["m", "key", "level"] {
+        let fk = format!("CREATE TABLE t(a, {name}, FOREIGN KEY ({name}) REFERENCES p({name}))");
+        assert!(
+            Parser::parse_sql(&fk).is_ok(),
+            "FOREIGN KEY/REFERENCES with column `{name}` should parse: {:?}",
+            Parser::parse_sql(&fk).err()
+        );
+
+        let pk = format!("CREATE TABLE t(a, {name}, PRIMARY KEY ({name}))");
+        assert!(
+            Parser::parse_sql(&pk).is_ok(),
+            "PRIMARY KEY with column `{name}` should parse: {:?}",
+            Parser::parse_sql(&pk).err()
+        );
+
+        let uniq = format!("CREATE TABLE t(a, {name}, UNIQUE ({name}))");
+        assert!(
+            Parser::parse_sql(&uniq).is_ok(),
+            "UNIQUE with column `{name}` should parse: {:?}",
+            Parser::parse_sql(&uniq).err()
+        );
+    }
+}
+
+#[test]
+fn test_contextual_keyword_column_name_quoted_form_still_works() {
+    // The quoted/delimited form must continue to parse and yield the same name.
+    let result =
+        Parser::parse_sql(r#"CREATE TABLE t1(a, "m", FOREIGN KEY ("m") REFERENCES p("q"))"#);
+    assert!(result.is_ok(), "quoted `m` FK column should parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::CreateTable(create) => match &create.table_constraints[0].kind {
+            vibesql_ast::TableConstraintKind::ForeignKey {
+                columns, references_columns, ..
+            } => {
+                assert_eq!(columns, &vec!["m".to_string()]);
+                assert_eq!(references_columns, &vec!["q".to_string()]);
+            }
+            _ => panic!("Expected FOREIGN KEY constraint"),
+        },
+        _ => panic!("Expected CREATE TABLE statement"),
+    }
+}
+
+#[test]
+fn test_reserved_keyword_rejected_as_unquoted_fk_column_name() {
+    // Truly reserved words must still be rejected as unquoted column names in
+    // these positions (they would create grammar ambiguity). Quoting is the
+    // documented escape hatch.
+    for reserved in ["select", "not", "and", "null"] {
+        let sql = format!("CREATE TABLE t(a, FOREIGN KEY ({reserved}) REFERENCES p(q))");
+        assert!(
+            Parser::parse_sql(&sql).is_err(),
+            "reserved keyword `{reserved}` must be rejected as an unquoted FK column name"
+        );
+    }
+}

--- a/crates/vibesql-parser/src/tests/joins.rs
+++ b/crates/vibesql-parser/src/tests/joins.rs
@@ -555,3 +555,24 @@ fn test_parse_comma_without_on_still_cross_join() {
         _ => panic!("Expected SELECT"),
     }
 }
+
+#[test]
+fn test_parse_join_using_contextual_keyword_column(/* issue #5945 */) {
+    // Contextual keywords (`m`, `key`, `level`) must be accepted as unquoted
+    // column names in a JOIN ... USING (...) list, matching SQLite.
+    for name in ["m", "key", "level"] {
+        let sql = format!("SELECT * FROM t1 JOIN t2 USING ({name});");
+        let result = Parser::parse_sql(&sql);
+        assert!(result.is_ok(), "USING ({name}) should parse: {:?}", result.err());
+        match result.unwrap() {
+            vibesql_ast::Statement::Select(select) => match select.from.as_ref().unwrap() {
+                vibesql_ast::FromClause::Join { using_columns, .. } => {
+                    let cols = using_columns.as_ref().expect("USING columns present");
+                    assert_eq!(cols, &vec![name.to_string()]);
+                }
+                _ => panic!("Expected JOIN"),
+            },
+            _ => panic!("Expected SELECT"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`parse_identifier()` in `helpers.rs` rejects **every** `Token::Keyword`, so contextual/fallback keywords such as `m` (an HNSW index parameter), `key`, and `level` could not be used as unquoted column names in column-list positions. This blocked altercol 2.0's

```sql
CREATE TABLE t1(a, b, c, m, FOREIGN KEY (m) REFERENCES p(q));  -- SQLite: ok; VibeSQL: parse error
```

The fix adds a `parse_column_name()` helper that accepts plain/delimited identifiers **plus** any keyword satisfying `can_be_identifier_in_expression()` — SQLite's `%fallback ID` boundary — while still rejecting truly reserved words (`SELECT`, `AND`, `NOT`, `NULL`). This mirrors the existing expression/column-ref position (`identifiers.rs`) and the alias position (`helpers.rs`).

## Changes

- **`helpers.rs`**: add `parse_column_name()` gating on `can_be_identifier_in_expression()`.
- Route the ten column-name parse sites through it:
  - `create/constraints.rs`: PRIMARY KEY / UNIQUE column spec, column-level `REFERENCES t(col)`, table-level `FOREIGN KEY (…)`, table-level `REFERENCES t(…)`.
  - `select/from_clause.rs`: `JOIN … USING (…)`.
  - `alter.rs`: `RENAME COLUMN <old> TO <new>` (both names).
  - `index.rs`: CREATE INDEX column lists (IVFFlat, HNSW, regular).
- Regression tests in `constraints_table.rs`, `alter_table.rs`, `joins.rs`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `CREATE TABLE t1(a, b, c, m, FOREIGN KEY (m) REFERENCES p(q))` parses | ✅ | New unit test + release binary + altercol.test **2.0** now passes |
| `m`/`level`/`key` accepted in FK / REFERENCES / PRIMARY KEY / UNIQUE / USING | ✅ | New unit tests in `constraints_table.rs` and `joins.rs` |
| `ALTER TABLE t1 RENAME COLUMN m TO newname` parses | ✅ | New unit test in `alter_table.rs` |
| Quoted forms still work: `FOREIGN KEY ("m") REFERENCES p("q")` | ✅ | New unit test asserts name round-trips |
| Reserved keywords (`SELECT`, `NOT`, `AND`, `NULL`) still rejected | ✅ | New negative unit tests + release binary check |
| No regressions in existing parser tests | ✅ | `cargo test -p vibesql-parser`: 1728 passed, 0 failed |

## Test Plan

- `cargo test -p vibesql-parser` — **1728 passed, 0 failed** (8 new tests added).
- Release binary: `CREATE TABLE t1(a, b, c, m, FOREIGN KEY (m) REFERENCES p(q))` succeeds; `FOREIGN KEY (select) …` still errors.
- `make test-tcl-file FILE=altercol.test`: the altercol 2.0 primary case (test **2.0**) now passes.

## Out of Scope

The second altercol residual from PR #5938 (test **1.12.4** — expression-index SQL reconstruction wraps `(d+d+d+d)` instead of preserving verbatim text) is a separate `sqlite_schema` rendering issue and remains failing; it should be tracked independently per the curator's guidance. The other altercol.test failures are pre-existing ALTER RENAME / trigger-rewrite / file-reopen semantics unrelated to this parser-acceptance fix.

Closes #5945