### PR TITLE
fix(executor): update last_insert_rowid() for implicit-rowid tables

### DIFF
--- a/crates/vibesql-executor/src/insert/bulk_transfer.rs
+++ b/crates/vibesql-executor/src/insert/bulk_transfer.rs
@@ -299,6 +299,13 @@ fn execute_bulk_transfer(
         })
     };
 
+    // Whether the destination is a rowid table WITHOUT an INTEGER PRIMARY KEY.
+    // For those, the implicit rowid is allocated by the storage layer during the
+    // batch insert below, so `last_rowid` above is None — we read the max rowid
+    // back after the insert instead (#5944).
+    let dest_is_implicit_rowid =
+        !dest_schema.without_rowid && dest_schema.get_integer_primary_key_index().is_none();
+
     // Batch insert all rows at once (much faster than row-by-row)
     // This reduces WAL operations, index rebuilds, and cache invalidations
     let inserted_count = if !validated_rows.is_empty() {
@@ -312,6 +319,13 @@ fn execute_bulk_transfer(
     if inserted_count > 0 {
         if let Some(rowid) = last_rowid {
             db.set_last_insert_rowid(rowid);
+        } else if dest_is_implicit_rowid {
+            // Non-IPK rowid destination: implicit rowids ascend, so the max
+            // rowid after the batch equals the last inserted row's rowid,
+            // matching SQLite's transfer-optimization last_insert_rowid() (#5944).
+            if let Some(rowid) = db.get_table(dest_table).and_then(|t| t.max_rowid_signed()) {
+                db.set_last_insert_rowid(rowid);
+            }
         }
     }
 

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -1035,6 +1035,23 @@ fn execute_insert_internal(
                 );
             }
         }
+
+        // For a rowid table WITHOUT an INTEGER PRIMARY KEY the batch path
+        // allocates implicit rowids inside the storage layer, so no candidate id
+        // surfaced above (last_generated_id is still None). Read the max rowid
+        // back after the batch insert so last_insert_rowid() tracks the last
+        // inserted row — implicit rowids ascend, so the max equals the final
+        // row's rowid (#5944). VibeSQL is single-threaded within a session, so
+        // nothing can insert between the batch and this readback. The WITHOUT
+        // ROWID guard at the `set_last_insert_rowid()` call below still excludes
+        // WITHOUT ROWID tables.
+        if ipk_col_idx.is_none() && last_generated_id.is_none() && !schema.without_rowid {
+            if let Some(max_rowid) =
+                db.get_table(&storage_table_name).and_then(|t| t.max_rowid_signed())
+            {
+                last_generated_id = Some(max_rowid);
+            }
+        }
     } else {
         // Slow path: Insert rows one by one (needed for triggers, special clauses)
         for (mut full_row_values, mut explicit_rowid, ipk_auto_assigned, candidate_last_id) in
@@ -1342,6 +1359,20 @@ fn execute_insert_internal(
                     dml_schema.as_deref(),
                 )?;
             }
+
+            // For a rowid table WITHOUT an INTEGER PRIMARY KEY, the implicit
+            // rowid is allocated above (materialized into `final_explicit_rowid`
+            // from `allocate_rowid_u64()`) and never flows through
+            // `candidate_last_id`, which only tracks explicit/auto IPK and
+            // sequence values. Feed the allocated rowid back so
+            // last_insert_rowid() matches sqlite3 for plain tables (#5944). The
+            // WITHOUT ROWID guard at the `set_last_insert_rowid()` call below
+            // still excludes WITHOUT ROWID tables.
+            let candidate_last_id = match candidate_last_id {
+                Some(id) => Some(id),
+                None if ipk_col_idx.is_none() => final_explicit_rowid.map(|r| r as i64),
+                None => None,
+            };
 
             // The row was genuinely inserted (not an ON CONFLICT DO UPDATE
             // update, a DO NOTHING skip, or a RAISE(IGNORE) trigger skip — those

--- a/crates/vibesql-executor/src/tests/auto_increment_tests.rs
+++ b/crates/vibesql-executor/src/tests/auto_increment_tests.rs
@@ -644,10 +644,7 @@ fn test_last_insert_rowid_upsert_mixed_batch_excludes_update() {
     exec_sql(&mut db, "INSERT INTO t VALUES(5,1)");
     // (6,2) inserts (no conflict); (5,3) conflicts on k=5 and takes the DO
     // UPDATE arm — an update, so it must not touch last_insert_rowid().
-    exec_sql(
-        &mut db,
-        "INSERT INTO t VALUES(6,2),(5,3) ON CONFLICT(k) DO UPDATE SET v=excluded.v",
-    );
+    exec_sql(&mut db, "INSERT INTO t VALUES(6,2),(5,3) ON CONFLICT(k) DO UPDATE SET v=excluded.v");
 
     // sqlite3: last_insert_rowid() == 6 (last row actually inserted, not 5)
     assert_eq!(db.last_insert_rowid(), 6);
@@ -668,10 +665,7 @@ fn test_last_insert_rowid_upsert_all_updates_keeps_prior() {
     assert_eq!(db.last_insert_rowid(), 9);
 
     // k=5 already exists -> DO UPDATE arm only; nothing inserted.
-    exec_sql(
-        &mut db,
-        "INSERT INTO t VALUES(5,3) ON CONFLICT(k) DO UPDATE SET v=excluded.v",
-    );
+    exec_sql(&mut db, "INSERT INTO t VALUES(5,3) ON CONFLICT(k) DO UPDATE SET v=excluded.v");
 
     // sqlite3: last_insert_rowid() unchanged at 9 (no row inserted)
     assert_eq!(db.last_insert_rowid(), 9);
@@ -696,4 +690,79 @@ fn test_last_insert_rowid_bulk_transfer() {
 
     // sqlite3: last_insert_rowid() == 300 (last row copied, in rowid scan order)
     assert_eq!(db.last_insert_rowid(), 300);
+}
+
+/// A single-row INSERT into a table WITHOUT an INTEGER PRIMARY KEY (implicit
+/// rowid) must update last_insert_rowid() with the allocated implicit rowid.
+/// sqlite3 returns 1 here; VibeSQL previously left it at 0 (issue #5944). This
+/// exercises the slow (row-by-row) insert path, which single-row inserts take.
+#[test]
+fn test_last_insert_rowid_implicit_rowid_table() {
+    let mut db = Database::new();
+
+    exec_sql(&mut db, "CREATE TABLE t(x TEXT)");
+    exec_sql(&mut db, "INSERT INTO t VALUES('a')");
+
+    // sqlite3: last_insert_rowid() == 1 (the allocated implicit rowid)
+    assert_eq!(db.last_insert_rowid(), 1);
+}
+
+/// A multi-row INSERT ... VALUES into an implicit-rowid table must report the
+/// rowid of the LAST inserted row. This exercises the fast batch insert path
+/// (more than one row, no triggers). sqlite3 returns 3 here (issue #5944).
+#[test]
+fn test_last_insert_rowid_implicit_rowid_multi_row() {
+    let mut db = Database::new();
+
+    exec_sql(&mut db, "CREATE TABLE t(x TEXT)");
+    exec_sql(&mut db, "INSERT INTO t VALUES('a')"); // rowid 1 (slow path)
+    assert_eq!(db.last_insert_rowid(), 1);
+
+    // Two more rows -> rowids 2 and 3 via the fast batch path.
+    exec_sql(&mut db, "INSERT INTO t VALUES('b'),('c')");
+
+    // sqlite3: last_insert_rowid() == 3 (last row inserted)
+    assert_eq!(db.last_insert_rowid(), 3);
+}
+
+/// The bulk-transfer fast path (`INSERT INTO t SELECT ...`) into an
+/// implicit-rowid destination must also update last_insert_rowid() with the
+/// last copied row's allocated rowid. sqlite3 returns 2 here (issue #5944).
+#[test]
+fn test_last_insert_rowid_implicit_rowid_bulk_transfer() {
+    let mut db = Database::new();
+
+    exec_sql(&mut db, "CREATE TABLE src(x TEXT)");
+    exec_sql(&mut db, "INSERT INTO src VALUES('d')"); // src rowid 1
+    exec_sql(&mut db, "INSERT INTO src VALUES('e')"); // src rowid 2
+    assert_eq!(db.last_insert_rowid(), 2);
+
+    exec_sql(&mut db, "CREATE TABLE t(x TEXT)");
+    exec_sql(&mut db, "INSERT INTO t SELECT x FROM src");
+
+    // Two rows copied into t get implicit rowids 1 and 2; the last is 2.
+    // sqlite3: last_insert_rowid() == 2.
+    assert_eq!(db.last_insert_rowid(), 2);
+}
+
+/// A WITHOUT ROWID table must NOT update last_insert_rowid() (SQLite
+/// R-47220-63683). Inserting into one leaves the prior value untouched.
+#[test]
+fn test_last_insert_rowid_without_rowid_unchanged() {
+    let mut db = Database::new();
+
+    // Establish a prior last_insert_rowid() from a normal rowid table.
+    exec_sql(&mut db, "CREATE TABLE r(x TEXT)");
+    exec_sql(&mut db, "INSERT INTO r VALUES('a')"); // rowid 1
+    assert_eq!(db.last_insert_rowid(), 1);
+
+    // Inserting into a WITHOUT ROWID table must leave last_insert_rowid() at 1.
+    exec_sql(&mut db, "CREATE TABLE wr(x TEXT PRIMARY KEY) WITHOUT ROWID");
+    exec_sql(&mut db, "INSERT INTO wr VALUES('z')");
+    assert_eq!(db.last_insert_rowid(), 1);
+
+    // A multi-row insert into the WITHOUT ROWID table (fast batch path) must
+    // also leave it unchanged.
+    exec_sql(&mut db, "INSERT INTO wr VALUES('y'),('x')");
+    assert_eq!(db.last_insert_rowid(), 1);
 }


### PR DESCRIPTION
## Summary

Tables without an INTEGER PRIMARY KEY (implicit-rowid tables, e.g. `CREATE TABLE t(x TEXT)`) left `last_insert_rowid()` at 0 (or a stale prior value). SQLite allocates and tracks an implicit rowid for every insert into a rowid table and always updates `last_insert_rowid()` accordingly. This threads the allocated implicit rowid back to the session at all three insert code sites, following the PR #5935 last-row / genuine-insert semantics.

## Changes

- **Slow (row-by-row) path** (`insert/execution.rs`): after the implicit rowid is materialized into `final_explicit_rowid` from `allocate_rowid_u64()`, feed it into `candidate_last_id` when the table has no IPK. Covers single-row inserts (which always take this path) and trigger/REPLACE/upsert inserts. The existing `continue` statements before the commit site keep OR IGNORE / DO NOTHING skips and pure upsert updates excluded.
- **Fast batch path** (`insert/execution.rs`): after `insert_rows_batch`, read the max rowid back via `Table::max_rowid_signed()` for non-IPK rowid tables. Implicit rowids ascend, so the max equals the last inserted row's rowid (last-row-wins).
- **Bulk-transfer path** (`insert/bulk_transfer.rs`): same max-rowid readback for non-IPK rowid destinations on `INSERT ... SELECT`.
- All three paths keep the `!schema.without_rowid` guard, so WITHOUT ROWID tables are untouched (SQLite R-47220-63683).
- Added tests in `auto_increment_tests.rs`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `last_insert_rowid()` returns 1 after insert into non-IPK table | ✅ | `test_last_insert_rowid_implicit_rowid_table` |
| Multi-row insert returns last row's rowid | ✅ | `test_last_insert_rowid_implicit_rowid_multi_row` (expects 3) |
| `INSERT INTO non_ipk SELECT ...` updates the value | ✅ | `test_last_insert_rowid_implicit_rowid_bulk_transfer` (expects 2) |
| WITHOUT ROWID tables leave value unchanged | ✅ | `test_last_insert_rowid_without_rowid_unchanged` |
| IPK tables continue to work (no regression) | ✅ | Existing `test_last_insert_rowid_*` suite (16/16 pass) |
| OR IGNORE / DO NOTHING skips do not update value | ✅ | Existing `test_last_insert_rowid_or_ignore_skips_last_row` + upsert tests still pass |

## Test Plan

- `cargo test -p vibesql-executor --lib last_insert_rowid`: 16 passed, 0 failed (12 pre-existing + 4 new).
- `cargo test -p vibesql-executor --lib`: 3202 passed, 0 failed, 2 ignored (full crate regression).
- Affected source files verified rustfmt-clean.

Closes #5944