### PR TITLE
fix(cte): make DML WITH-clause CTEs visible to scalar subqueries in UPDATE SET and trigger bodies

### DIFF
--- a/crates/vibesql-executor/src/evaluator/expressions/subqueries.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/subqueries.rs
@@ -323,8 +323,18 @@ impl ExpressionEvaluator<'_> {
         // through to the unchanged cached/correlated paths below.
         if let Some(trigger_ctx) = self.trigger_context {
             let substituted = substitute_trigger_pseudo_vars(subquery, trigger_ctx)?;
-            let select_executor =
-                crate::select::SelectExecutor::new_with_depth(database, self.depth);
+            // After pseudo-var substitution the subquery no longer needs the
+            // trigger context, but it may still reference a CTE declared on the
+            // enclosing DML statement (e.g. a trigger body
+            // `INSERT INTO log WITH map(k,v) AS (...) SELECT (SELECT v FROM map ...)`).
+            // Thread `cte_context` into the executor so `map` resolves to the CTE
+            // rather than failing / resolving to a same-named catalog table
+            // (with1.test 27.1).
+            let select_executor = if let Some(cte_ctx) = self.cte_context {
+                crate::select::SelectExecutor::new_with_cte_and_depth(database, cte_ctx, self.depth)
+            } else {
+                crate::select::SelectExecutor::new_with_depth(database, self.depth)
+            };
             let rows = select_executor.execute(&substituted)?;
             return Ok(rows);
         }
@@ -364,12 +374,29 @@ impl ExpressionEvaluator<'_> {
             } else {
                 // Correlated subquery - execute with outer context (can't cache)
                 let select_executor = if !outer_combined.table_schemas.is_empty() {
-                    crate::select::SelectExecutor::new_with_outer_context_and_depth(
-                        database,
-                        row,
-                        &outer_combined,
-                        self.depth,
-                    )
+                    // The subquery is correlated to the DML target row AND may
+                    // reference a CTE declared on the enclosing statement (e.g.
+                    // `WITH uset(a,b) AS (...) UPDATE t1 SET x =
+                    //  COALESCE((SELECT b FROM uset WHERE a=x), x)`). Passing only
+                    // the outer context drops `cte_context`, so `uset` fails with
+                    // "no such table". Use the combined outer+CTE executor when a
+                    // CTE context is present (with1.test 4.3).
+                    if let Some(cte_ctx) = self.cte_context {
+                        crate::select::SelectExecutor::new_with_outer_and_cte_and_depth(
+                            database,
+                            row,
+                            &outer_combined,
+                            cte_ctx,
+                            self.depth,
+                        )
+                    } else {
+                        crate::select::SelectExecutor::new_with_outer_context_and_depth(
+                            database,
+                            row,
+                            &outer_combined,
+                            self.depth,
+                        )
+                    }
                 } else if let Some(cte_ctx) = self.cte_context {
                     crate::select::SelectExecutor::new_with_cte_and_depth(
                         database, cte_ctx, self.depth,

--- a/crates/vibesql-executor/src/tests/cte_dml_subquery_visibility_tests.rs
+++ b/crates/vibesql-executor/src/tests/cte_dml_subquery_visibility_tests.rs
@@ -1,0 +1,148 @@
+//! Tests for CTE visibility inside DML sub-contexts (Gap 1 of issue #5941).
+//!
+//! A `WITH` clause attached to an UPDATE/INSERT/DELETE statement must be
+//! visible to scalar subqueries evaluated while executing that DML — including
+//! correlated subqueries in `UPDATE ... SET` expressions and scalar subqueries
+//! inside a trigger body's `INSERT ... WITH ... SELECT`.
+//!
+//! Previously the correlated-subquery path and the trigger early-return path in
+//! `ExpressionEvaluator::execute_scalar_subquery_rows` built their inner
+//! `SelectExecutor` without threading the enclosing `cte_context`, so the CTE
+//! table was invisible ("no such table") or silently resolved to a same-named
+//! catalog table. These tests reproduce with1.test 4.3 and 27.1.
+
+use vibesql_ast::Statement;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Parse and execute a single DDL/DML statement.
+fn exec(db: &mut Database, sql: &str) -> Result<String, String> {
+    let stmt =
+        vibesql_parser::Parser::parse_sql(sql).map_err(|e| format!("Parse error: {:?}", e))?;
+    match stmt {
+        Statement::CreateTable(s) => {
+            crate::CreateTableExecutor::execute(&s, db).map_err(|e| e.to_string())
+        }
+        Statement::CreateTrigger(s) => {
+            crate::TriggerExecutor::create_trigger(db, &s).map_err(|e| e.to_string())
+        }
+        Statement::Insert(s) => crate::InsertExecutor::execute(db, &s)
+            .map(|count| format!("{} row(s) inserted", count))
+            .map_err(|e| e.to_string()),
+        Statement::Delete(s) => crate::delete::DeleteExecutor::execute(&s, db)
+            .map(|count| format!("{} row(s) deleted", count))
+            .map_err(|e| e.to_string()),
+        Statement::Update(s) => crate::update::UpdateExecutor::execute(&s, db)
+            .map(|count| format!("{} row(s) updated", count))
+            .map_err(|e| e.to_string()),
+        other => Err(format!("Unsupported statement type: {:?}", other)),
+    }
+}
+
+/// Run a SELECT and return every row's values as `Vec<Vec<SqlValue>>`.
+fn query_rows(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).expect("parse select");
+    let select = match stmt {
+        Statement::Select(s) => s,
+        other => panic!("expected SELECT, got {:?}", other),
+    };
+    let result = crate::SelectExecutor::new(db).execute(&select).expect("run select");
+    result.iter().map(|r| r.values.to_vec()).collect()
+}
+
+fn int(n: i64) -> SqlValue {
+    SqlValue::Integer(n)
+}
+
+fn text(s: &str) -> SqlValue {
+    SqlValue::Varchar(arcstr::ArcStr::from(s))
+}
+
+/// with1.test 4.3 — a WITH clause on an UPDATE must be visible to a correlated
+/// scalar subquery in the SET expression.
+///
+/// `WITH uset(a,b) AS (...) UPDATE t1 SET x = COALESCE((SELECT b FROM uset WHERE a=x), x)`
+/// The subquery is correlated to the UPDATE target column `x` AND references the
+/// CTE `uset`. Before the fix the correlated path dropped `cte_context`, so
+/// `uset` failed to resolve. Expected result: {1 3 8 9}.
+#[test]
+fn cte_visible_to_correlated_subquery_in_update_set() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(x)").unwrap();
+    // Mirror with1.test state after tests 4.1/4.2: rows 1,3,2,4.
+    exec(&mut db, "INSERT INTO t1 VALUES(1)").unwrap();
+    exec(&mut db, "INSERT INTO t1 VALUES(3)").unwrap();
+    exec(&mut db, "INSERT INTO t1 VALUES(2)").unwrap();
+    exec(&mut db, "INSERT INTO t1 VALUES(4)").unwrap();
+
+    exec(
+        &mut db,
+        "WITH uset(a, b) AS ( SELECT 2, 8 UNION ALL SELECT 4, 9 ) \
+         UPDATE t1 SET x = COALESCE( (SELECT b FROM uset WHERE a=x), x )",
+    )
+    .expect("UPDATE with CTE-referencing correlated subquery should succeed");
+
+    let rows = query_rows(&db, "SELECT x FROM t1");
+    let got: Vec<SqlValue> = rows.into_iter().map(|mut r| r.remove(0)).collect();
+    // 1 unchanged, 3 unchanged, 2->8, 4->9
+    assert_eq!(got, vec![int(1), int(3), int(8), int(9)]);
+}
+
+/// A non-correlated scalar subquery referencing the UPDATE's WITH clause must
+/// also resolve (guards the else-branch of the correlated path).
+#[test]
+fn cte_visible_to_noncorrelated_subquery_in_update_set() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t2(x)").unwrap();
+    exec(&mut db, "INSERT INTO t2 VALUES(1)").unwrap();
+    exec(&mut db, "INSERT INTO t2 VALUES(2)").unwrap();
+
+    exec(
+        &mut db,
+        "WITH c(v) AS ( SELECT 100 ) \
+         UPDATE t2 SET x = x + (SELECT v FROM c)",
+    )
+    .expect("UPDATE with CTE-referencing non-correlated subquery should succeed");
+
+    let rows = query_rows(&db, "SELECT x FROM t2 ORDER BY x");
+    let got: Vec<SqlValue> = rows.into_iter().map(|mut r| r.remove(0)).collect();
+    assert_eq!(got, vec![int(101), int(102)]);
+}
+
+/// with1.test 27.1 — inside a trigger body, an `INSERT ... WITH map(k,v) AS (...)
+/// SELECT ..., (SELECT v FROM map WHERE k=new.k) ...` must resolve `map` to the
+/// CTE, not to the real catalog table of the same name.
+///
+/// Before the fix the trigger early-return path in the scalar-subquery evaluator
+/// dropped `cte_context`, so `(SELECT v FROM map ...)` resolved against the real
+/// `map` table (values 'main1'/'main2') instead of the CTE ('cte1'/'cte2').
+#[test]
+fn cte_visible_to_scalar_subquery_in_trigger_body_insert() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(k)").unwrap();
+    exec(&mut db, "CREATE TABLE log(k, cte_map, main_map)").unwrap();
+    exec(&mut db, "CREATE TABLE map(k, v)").unwrap();
+    exec(&mut db, "INSERT INTO map VALUES(1, 'main1'), (2, 'main2')").unwrap();
+
+    exec(
+        &mut db,
+        "CREATE TRIGGER tr1 AFTER INSERT ON t1 BEGIN \
+           INSERT INTO log \
+             WITH map(k,v) AS (VALUES(1,'cte1'),(2,'cte2')) \
+             SELECT \
+               new.k, \
+               (SELECT v FROM map WHERE k=new.k), \
+               (SELECT v FROM main.map WHERE k=new.k); \
+         END",
+    )
+    .expect("create trigger");
+
+    exec(&mut db, "INSERT INTO t1 VALUES(1)").unwrap();
+    exec(&mut db, "INSERT INTO t1 VALUES(2)").unwrap();
+
+    let rows = query_rows(&db, "SELECT k, cte_map, main_map FROM log ORDER BY k");
+    assert_eq!(
+        rows,
+        vec![vec![int(1), text("cte1"), text("main1")], vec![int(2), text("cte2"), text("main2")],]
+    );
+}

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -77,6 +77,7 @@ mod count_star_fast_path;
 mod covering_index_tests;
 mod create_table_constraints;
 mod create_table_tests;
+mod cte_dml_subquery_visibility_tests;
 mod cte_scalar_subquery_tests;
 mod delete_returning;
 mod error_display;

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -209,10 +209,27 @@ pub(super) fn execute_internal(
     // Step 3: Create expression evaluator with database reference for subquery support
     //         and optional procedural/trigger context for variable resolution
     let mut evaluator = if let Some(ctx) = trigger_context {
-        // Trigger context takes precedence (trigger statements can't have procedural context)
-        ExpressionEvaluator::with_trigger_context(schema, database, ctx)
+        // Trigger context takes precedence (trigger statements can't have procedural context).
+        // When the UPDATE also carries a WITH clause (e.g. a trigger body
+        // `WITH uset(a,b) AS (...) UPDATE t SET x=(SELECT b FROM uset WHERE a=x)`),
+        // the trigger-context constructor alone would drop `cte_results`, so the
+        // scalar subquery could not resolve the CTE. Chain the CTE context on so
+        // both trigger pseudo-vars and CTE references resolve (Gap 1 of #5941).
+        let e = ExpressionEvaluator::with_trigger_context(schema, database, ctx);
+        if let Some(ref cte_ctx) = cte_results {
+            e.with_cte_context(cte_ctx)
+        } else {
+            e
+        }
     } else if let Some(ctx) = procedural_context {
-        ExpressionEvaluator::with_procedural_context(schema, database, ctx)
+        // Likewise preserve any WITH-clause CTE context alongside the procedural
+        // context so scalar subqueries in SET expressions can reference the CTE.
+        let e = ExpressionEvaluator::with_procedural_context(schema, database, ctx);
+        if let Some(ref cte_ctx) = cte_results {
+            e.with_cte_context(cte_ctx)
+        } else {
+            e
+        }
     } else if let Some(ref cte_ctx) = cte_results {
         // Use CTE context for WITH clause support
         ExpressionEvaluator::with_database_and_cte(schema, database, cte_ctx)


### PR DESCRIPTION
## Summary

Implements **Gap 1** of #5941: CTEs declared by a `WITH` clause on a DML
statement were invisible to scalar subqueries evaluated during that DML. The
main SELECT path already threaded CTE context; two DML sub-context paths did
not. This PR fixes those three sites so a WITH-clause CTE resolves correctly.

Gaps 2 (lazy recursion under LIMIT) and 3 (ORDER BY in recursive term) are
**out of scope** per the curator's decomposition recommendation and remain
open on #5941.

## Changes

- `crates/vibesql-executor/src/evaluator/expressions/subqueries.rs`
  - **Correlated path**: when the subquery is correlated to the DML target row
    AND a CTE context is present, build the inner executor with
    `new_with_outer_and_cte_and_depth` instead of `new_with_outer_context_and_depth`
    (which dropped `cte_context`). Fixes with1.test 4.3.
  - **Trigger early-return path**: after NEW/OLD pseudo-var substitution, thread
    `cte_context` into the executor via `new_with_cte_and_depth` when present,
    instead of always using `new_with_depth`. Fixes with1.test 27.1.
- `crates/vibesql-executor/src/update/executor.rs`
  - When building the UPDATE expression evaluator, preserve any WITH-clause CTE
    context alongside `trigger_context`/`procedural_context` by chaining
    `.with_cte_context()` — previously the if-else chain silently dropped the CTE
    when a trigger/procedural context was also present.
- `crates/vibesql-executor/src/tests/cte_dml_subquery_visibility_tests.rs` (new)
  - Reproduces with1.test 4.3 (correlated subquery in UPDATE SET referencing a
    CTE), a non-correlated variant, and with1.test 27.1 (trigger-body INSERT
    scalar subquery distinguishing the CTE `map` from the real table `map`).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| with1.test 4.3: `WITH uset(a,b) AS (...) UPDATE t1 SET x = COALESCE((SELECT b FROM uset WHERE a=x), x)` yields `{1 3 8 9}` | Passing | Unit test `cte_visible_to_correlated_subquery_in_update_set` reproduces the exact SQL and asserts `[1,3,8,9]` |
| with1.test 27.1: trigger-body INSERT scalar subquery reads from the CTE `map` (`cte1`/`cte2`), not the real `map` (`main1`/`main2`) | Passing | Unit test `cte_visible_to_scalar_subquery_in_trigger_body_insert` reproduces the exact SQL, including the `main.map` schema-qualified reference, and asserts CTE vs catalog values |
| No regression in vibesql-executor suite | Passing | Full `cargo test -p vibesql-executor` green (0 failures) |

## Test Plan

- `cargo test -p vibesql-executor --lib cte_dml_subquery_visibility` — 3/3 pass.
- `cargo test -p vibesql-executor` — full suite green, no regressions.
- The two new unit tests reproduce the exact SQL of with1.test 4.3 and 27.1
  (including the schema-qualified `main.map` reference), so they are faithful
  standalone equivalents of those TCL cases.

Part of #5941 (Gap 1). Does not close the issue — Gaps 2 and 3 remain.