### PR TITLE
feat(sql): support variadic if()/iif() and non-boolean conditions

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/control.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/control.rs
@@ -1,29 +1,162 @@
 //! Control flow functions (IF)
 
 use crate::errors::ExecutorError;
+use crate::evaluator::operators::is_truthy;
 
-/// IF(condition, true_value, false_value) - MySQL-style conditional
-/// Returns true_value if condition is true, otherwise returns false_value
+/// IF(...) - MySQL-style / SQLite 3.48+ variadic conditional
+///
+/// Two supported forms:
+/// - `IF(condition, true_value, false_value)` — ternary; returns `true_value`
+///   if `condition` is truthy, otherwise `false_value`.
+/// - `IF(c1, v1, c2, v2, ..., else)` — CASE-chain form (odd argument count,
+///   `>= 3`). Evaluates each condition in order and returns the value paired
+///   with the first truthy condition; if none match, returns the trailing
+///   `else` argument.
+///
+/// Conditions use SQLite truthiness rules (see
+/// `crate::evaluator::operators::is_truthy`): `NULL` and numeric zero are
+/// false, non-zero numerics are true, and strings coerce via their leading
+/// numeric portion. This matches `IIF` and CASE/WHERE semantics.
 pub(super) fn if_func(
     args: &[vibesql_types::SqlValue],
 ) -> Result<vibesql_types::SqlValue, ExecutorError> {
-    if args.len() != 3 {
+    variadic_conditional("IF", args)
+}
+
+/// Shared CASE-chain evaluation for the variadic `IF`/`IIF` forms.
+///
+/// Requires an odd argument count `>= 3`. Iterates over `(condition, value)`
+/// pairs, returning the value for the first truthy condition; if no condition
+/// is truthy, returns the trailing else argument.
+pub(crate) fn variadic_conditional(
+    fn_name: &str,
+    args: &[vibesql_types::SqlValue],
+) -> Result<vibesql_types::SqlValue, ExecutorError> {
+    if args.len() < 3 || args.len() % 2 == 0 {
         return Err(ExecutorError::UnsupportedFeature(format!(
-            "IF requires exactly 3 arguments, got {}",
+            "{fn_name} requires an odd number of arguments (>= 3), got {}",
             args.len()
         )));
     }
 
-    // Evaluate condition
-    let condition = &args[0];
-    match condition {
-        vibesql_types::SqlValue::Boolean(true) => Ok(args[1].clone()),
-        vibesql_types::SqlValue::Boolean(false) | vibesql_types::SqlValue::Null => {
-            Ok(args[2].clone())
+    // Evaluate (condition, value) pairs in order; the final argument is the
+    // else value returned when no condition matches.
+    let mut i = 0;
+    while i + 1 < args.len() {
+        if is_truthy(&args[i]) {
+            return Ok(args[i + 1].clone());
         }
-        _ => Err(ExecutorError::UnsupportedFeature(format!(
-            "IF condition must be boolean, got {:?}",
-            condition
-        ))),
+        i += 2;
+    }
+
+    // No condition matched — return the trailing else argument.
+    Ok(args[args.len() - 1].clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use vibesql_types::SqlValue;
+
+    use super::*;
+
+    #[test]
+    fn test_if_ternary_boolean() {
+        assert_eq!(
+            if_func(&[SqlValue::Boolean(true), SqlValue::Integer(1), SqlValue::Integer(2)])
+                .unwrap(),
+            SqlValue::Integer(1)
+        );
+        assert_eq!(
+            if_func(&[SqlValue::Boolean(false), SqlValue::Integer(1), SqlValue::Integer(2)])
+                .unwrap(),
+            SqlValue::Integer(2)
+        );
+    }
+
+    #[test]
+    fn test_if_ternary_integer_condition() {
+        // Non-boolean conditions previously errored; now use SQLite truthiness.
+        assert_eq!(
+            if_func(&[
+                SqlValue::Integer(1),
+                SqlValue::Varchar(arcstr::ArcStr::from("yes")),
+                SqlValue::Varchar(arcstr::ArcStr::from("no")),
+            ])
+            .unwrap(),
+            SqlValue::Varchar(arcstr::ArcStr::from("yes"))
+        );
+        assert_eq!(
+            if_func(&[
+                SqlValue::Integer(0),
+                SqlValue::Varchar(arcstr::ArcStr::from("yes")),
+                SqlValue::Varchar(arcstr::ArcStr::from("no")),
+            ])
+            .unwrap(),
+            SqlValue::Varchar(arcstr::ArcStr::from("no"))
+        );
+    }
+
+    #[test]
+    fn test_if_ternary_float_condition() {
+        assert_eq!(
+            if_func(&[SqlValue::Real(1.5), SqlValue::Integer(1), SqlValue::Integer(2)]).unwrap(),
+            SqlValue::Integer(1)
+        );
+        assert_eq!(
+            if_func(&[SqlValue::Real(0.0), SqlValue::Integer(1), SqlValue::Integer(2)]).unwrap(),
+            SqlValue::Integer(2)
+        );
+    }
+
+    #[test]
+    fn test_if_null_condition_is_false() {
+        assert_eq!(
+            if_func(&[
+                SqlValue::Null,
+                SqlValue::Varchar(arcstr::ArcStr::from("a")),
+                SqlValue::Varchar(arcstr::ArcStr::from("b")),
+            ])
+            .unwrap(),
+            SqlValue::Varchar(arcstr::ArcStr::from("b"))
+        );
+    }
+
+    #[test]
+    fn test_if_variadic_case_chain() {
+        // if(0, 'a', 0.0, 'b', 'c') -> 'c'
+        assert_eq!(
+            if_func(&[
+                SqlValue::Integer(0),
+                SqlValue::Varchar(arcstr::ArcStr::from("a")),
+                SqlValue::Real(0.0),
+                SqlValue::Varchar(arcstr::ArcStr::from("b")),
+                SqlValue::Varchar(arcstr::ArcStr::from("c")),
+            ])
+            .unwrap(),
+            SqlValue::Varchar(arcstr::ArcStr::from("c"))
+        );
+
+        // Mirrors strict1.test: if(k=11,1.5, k=12,2, k=13,'x', 0.0)
+        // with k=12 -> second condition true -> 2
+        assert_eq!(
+            if_func(&[
+                SqlValue::Boolean(false),
+                SqlValue::Real(1.5),
+                SqlValue::Boolean(true),
+                SqlValue::Integer(2),
+                SqlValue::Boolean(false),
+                SqlValue::Varchar(arcstr::ArcStr::from("x")),
+                SqlValue::Real(0.0),
+            ])
+            .unwrap(),
+            SqlValue::Integer(2)
+        );
+    }
+
+    #[test]
+    fn test_if_invalid_arity() {
+        // Even argument counts are rejected.
+        assert!(if_func(&[SqlValue::Boolean(true), SqlValue::Integer(1)]).is_err());
+        assert!(if_func(&[]).is_err());
     }
 }

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/conditional_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/conditional_funcs.rs
@@ -8,41 +8,22 @@ use vibesql_types::SqlValue;
 
 use crate::errors::ExecutorError;
 
-/// IIF(condition, true_value, false_value) - Inline if (SQLite ternary)
+/// IIF(...) - Inline if (SQLite ternary / 3.48+ variadic)
 ///
-/// Equivalent to CASE WHEN condition THEN true_value ELSE false_value END
-/// Also equivalent to IF(condition, true_value, false_value)
+/// Two supported forms:
+/// - `IIF(condition, true_value, false_value)` — equivalent to
+///   `CASE WHEN condition THEN true_value ELSE false_value END`.
+/// - `IIF(c1, v1, c2, v2, ..., else)` — CASE-chain form (odd argument count,
+///   `>= 3`); returns the value paired with the first truthy condition, or the
+///   trailing `else` argument if none match.
+///
+/// Conditions use SQLite truthiness rules
+/// (`crate::evaluator::operators::is_truthy`): `NULL` and numeric zero are
+/// false, non-zero numerics are true, and strings coerce via their leading
+/// numeric portion. This shares the exact implementation used by `IF` and
+/// CASE/WHERE so all conditional paths agree.
 pub(crate) fn iif(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
-    if args.len() != 3 {
-        return Err(ExecutorError::UnsupportedFeature(format!(
-            "IIF requires exactly 3 arguments, got {}",
-            args.len()
-        )));
-    }
-
-    // SQLite's IIF treats any non-zero, non-NULL value as true
-    let condition = &args[0];
-    let is_true = match condition {
-        SqlValue::Null => false,
-        SqlValue::Boolean(b) => *b,
-        SqlValue::Integer(i) => *i != 0,
-        SqlValue::Bigint(i) => *i != 0,
-        SqlValue::Smallint(i) => *i != 0,
-        SqlValue::Unsigned(u) => *u != 0,
-        SqlValue::Real(r) => *r != 0.0,
-        SqlValue::Double(d) => *d != 0.0,
-        SqlValue::Numeric(n) => *n != 0.0,
-        SqlValue::Float(f) => *f != 0.0,
-        // Non-empty strings are truthy in SQLite
-        SqlValue::Varchar(s) | SqlValue::Character(s) => !s.is_empty(),
-        _ => true, // Other non-null values are truthy
-    };
-
-    if is_true {
-        Ok(args[1].clone())
-    } else {
-        Ok(args[2].clone())
-    }
+    crate::evaluator::functions::control::variadic_conditional("IIF", args)
 }
 
 /// IFNULL(x, y) - Return y if x is NULL, otherwise return x
@@ -98,6 +79,110 @@ mod tests {
             iif(&[SqlValue::Integer(0), SqlValue::Integer(1), SqlValue::Integer(2)]).unwrap(),
             SqlValue::Integer(2)
         );
+
+        // String condition uses leading-numeric coercion (SQLite truthiness)
+        assert_eq!(
+            iif(&[
+                SqlValue::Varchar(arcstr::ArcStr::from("1abc")),
+                SqlValue::Integer(1),
+                SqlValue::Integer(2)
+            ])
+            .unwrap(),
+            SqlValue::Integer(1)
+        );
+        assert_eq!(
+            iif(&[
+                SqlValue::Varchar(arcstr::ArcStr::from("abc")),
+                SqlValue::Integer(1),
+                SqlValue::Integer(2)
+            ])
+            .unwrap(),
+            SqlValue::Integer(2)
+        );
+    }
+
+    #[test]
+    fn test_iif_variadic() {
+        // First branch true -> first value
+        assert_eq!(
+            iif(&[
+                SqlValue::Boolean(true),
+                SqlValue::Integer(1),
+                SqlValue::Boolean(true),
+                SqlValue::Integer(2),
+                SqlValue::Integer(99),
+            ])
+            .unwrap(),
+            SqlValue::Integer(1)
+        );
+
+        // First branch false, second branch true -> second value
+        assert_eq!(
+            iif(&[
+                SqlValue::Boolean(false),
+                SqlValue::Integer(1),
+                SqlValue::Boolean(true),
+                SqlValue::Integer(2),
+                SqlValue::Integer(99),
+            ])
+            .unwrap(),
+            SqlValue::Integer(2)
+        );
+
+        // No branch true -> trailing else value
+        assert_eq!(
+            iif(&[
+                SqlValue::Boolean(false),
+                SqlValue::Integer(1),
+                SqlValue::Boolean(false),
+                SqlValue::Integer(2),
+                SqlValue::Integer(99),
+            ])
+            .unwrap(),
+            SqlValue::Integer(99)
+        );
+
+        // NULL condition is falsy and skips its branch
+        assert_eq!(
+            iif(&[
+                SqlValue::Null,
+                SqlValue::Integer(1),
+                SqlValue::Integer(0),
+                SqlValue::Integer(2),
+                SqlValue::Integer(99),
+            ])
+            .unwrap(),
+            SqlValue::Integer(99)
+        );
+
+        // 5-arg mixed-type CASE chain (mirrors strict1.test usage):
+        // iif(0, 'a', 0.0, 'b', 'c') -> 'c'
+        assert_eq!(
+            iif(&[
+                SqlValue::Integer(0),
+                SqlValue::Varchar(arcstr::ArcStr::from("a")),
+                SqlValue::Real(0.0),
+                SqlValue::Varchar(arcstr::ArcStr::from("b")),
+                SqlValue::Varchar(arcstr::ArcStr::from("c")),
+            ])
+            .unwrap(),
+            SqlValue::Varchar(arcstr::ArcStr::from("c"))
+        );
+    }
+
+    #[test]
+    fn test_iif_invalid_arity() {
+        // Even argument count is rejected
+        assert!(iif(&[SqlValue::Boolean(true), SqlValue::Integer(1)]).is_err());
+        assert!(iif(&[
+            SqlValue::Boolean(true),
+            SqlValue::Integer(1),
+            SqlValue::Boolean(true),
+            SqlValue::Integer(2),
+        ])
+        .is_err());
+        // Fewer than 3 arguments is rejected
+        assert!(iif(&[SqlValue::Boolean(true)]).is_err());
     }
 
     #[test]

--- a/crates/vibesql-executor/tests/advanced_function_tests/conditional_functions.rs
+++ b/crates/vibesql-executor/tests/advanced_function_tests/conditional_functions.rs
@@ -135,3 +135,147 @@ fn test_if_null_condition() {
     assert_eq!(result, vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("no")));
     // NULL treated as false
 }
+
+#[test]
+fn test_if_integer_condition_truthy() {
+    let (evaluator, row) = create_test_evaluator();
+
+    // if(1, 'yes', 'no') -> 'yes' (integer condition, SQLite truthiness)
+    let expr = vibesql_ast::Expression::Function {
+        name: vibesql_ast::FunctionIdentifier::new("IF"),
+        args: vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("yes"),
+            )),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("no"),
+            )),
+        ],
+        character_unit: None,
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("yes")));
+}
+
+#[test]
+fn test_if_integer_condition_falsy() {
+    let (evaluator, row) = create_test_evaluator();
+
+    // if(0, 'yes', 'no') -> 'no'
+    let expr = vibesql_ast::Expression::Function {
+        name: vibesql_ast::FunctionIdentifier::new("IF"),
+        args: vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(0)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("yes"),
+            )),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("no"),
+            )),
+        ],
+        character_unit: None,
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("no")));
+}
+
+#[test]
+fn test_if_variadic_case_chain() {
+    let (evaluator, row) = create_test_evaluator();
+
+    // if(false, 'a', true, 'b', 'else') -> 'b' (second branch matches)
+    let expr = vibesql_ast::Expression::Function {
+        name: vibesql_ast::FunctionIdentifier::new("IF"),
+        args: vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(false)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("a"),
+            )),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(true)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("b"),
+            )),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("else"),
+            )),
+        ],
+        character_unit: None,
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("b")));
+}
+
+#[test]
+fn test_if_variadic_falls_through_to_else() {
+    let (evaluator, row) = create_test_evaluator();
+
+    // if(false, 'a', false, 'b', 'else') -> 'else' (no branch matches)
+    let expr = vibesql_ast::Expression::Function {
+        name: vibesql_ast::FunctionIdentifier::new("IF"),
+        args: vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(false)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("a"),
+            )),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(false)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("b"),
+            )),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("else"),
+            )),
+        ],
+        character_unit: None,
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("else")));
+}
+
+#[test]
+fn test_iif_ternary() {
+    let (evaluator, row) = create_test_evaluator();
+
+    // iif(1, 'x', 'y') -> 'x'
+    let expr = vibesql_ast::Expression::Function {
+        name: vibesql_ast::FunctionIdentifier::new("IIF"),
+        args: vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(1)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("x"),
+            )),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("y"),
+            )),
+        ],
+        character_unit: None,
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("x")));
+}
+
+#[test]
+fn test_iif_variadic_case_chain() {
+    let (evaluator, row) = create_test_evaluator();
+
+    // iif(0, 'a', 5, 'b', 'else') -> 'b' (second condition non-zero -> truthy)
+    let expr = vibesql_ast::Expression::Function {
+        name: vibesql_ast::FunctionIdentifier::new("IIF"),
+        args: vec![
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(0)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("a"),
+            )),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(5)),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("b"),
+            )),
+            vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("else"),
+            )),
+        ],
+        character_unit: None,
+    };
+    let result = evaluator.eval(&expr, &row).unwrap();
+    assert_eq!(result, vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("b")));
+}

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -30,8 +30,9 @@ impl Parser {
                 name
             }
             // Allow LEFT, RIGHT, REPLACE, SCHEMA, GROUPING, GROUPING_ID, GLOB, LIKE, MATCH,
-            // DATE, and TIME keywords as function names. These are reserved keywords but
-            // can also be functions (DATE/TIME: SQLite date('now')/time('now'), #5307).
+            // DATE, TIME, and IF keywords as function names. These are reserved keywords but
+            // can also be functions (DATE/TIME: SQLite date('now')/time('now'), #5307;
+            // IF: SQLite/MySQL if(cond, x, y) and variadic if(c1, v1, ..., else), #5942).
             Token::Keyword { keyword: Keyword::Left, .. }
             | Token::Keyword { keyword: Keyword::Right, .. }
             | Token::Keyword { keyword: Keyword::Replace, .. }
@@ -42,7 +43,8 @@ impl Parser {
             | Token::Keyword { keyword: Keyword::Like, .. }
             | Token::Keyword { keyword: Keyword::Match, .. }
             | Token::Keyword { keyword: Keyword::Date, .. }
-            | Token::Keyword { keyword: Keyword::Time, .. } => {
+            | Token::Keyword { keyword: Keyword::Time, .. }
+            | Token::Keyword { keyword: Keyword::If, .. } => {
                 // Peek ahead to see if this is followed by '('
                 // Don't consume the keyword unless we're sure it's a function
                 // SQL:1999 normalizes unquoted identifiers (including function names) to lowercase
@@ -58,6 +60,7 @@ impl Parser {
                     Token::Keyword { keyword: Keyword::Match, .. } => "match",
                     Token::Keyword { keyword: Keyword::Date, .. } => "date",
                     Token::Keyword { keyword: Keyword::Time, .. } => "time",
+                    Token::Keyword { keyword: Keyword::If, .. } => "if",
                     _ => unreachable!(),
                 };
 


### PR DESCRIPTION
## Summary

Extends the `if()` and `iif()` conditional scalar functions to support the SQLite 3.48+ variadic CASE-chain form (odd argument count `>= 3`), e.g. `if(k=11,1.5, k=12,2, k=13,'x', 0.0)`, in addition to the classic 3-arg ternary. Also fixes `if()`'s 3-arg form to accept integer/float/string conditions (it previously errored on anything but `Boolean`), and teaches the parser to accept `if(...)` as a function call.

## Changes

- **`control.rs`**: `if_func` now delegates to a shared `variadic_conditional` helper and evaluates conditions with the shared `operators::is_truthy` instead of matching only `SqlValue::Boolean`. Integer/float/string conditions previously returned `"IF condition must be boolean"`; they now follow the same SQLite truthiness rules as CASE/WHERE (NULL and numeric zero false, non-zero true, strings coerce via leading numeric).
- **`sqlite_compat/conditional_funcs.rs`**: `iif` reuses the same helper, gaining the variadic form and unifying its inline truthiness logic with `is_truthy`.
- **`parser/expressions/functions/mod.rs`**: allow the `IF` keyword as a function name when immediately followed by `(` (same mechanism already used for `LEFT`/`RIGHT`/`DATE`/`TIME`). `IF` is a reserved keyword, so `if(...)` previously raised a parse error; `iif(...)` already parsed as a plain identifier. This is a minimal, lookahead-guarded change — `IF NOT EXISTS` / `IF EXISTS` DDL is unaffected because those are not followed by `(`.
- **Tests**: unit tests for variadic + non-boolean forms in both function modules, and executor integration tests exercising the full parse-to-eval path for `if()`/`iif()`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `iif(cond,x,y)` 3-arg remains correct | ✅ | Existing `test_iif` passes unchanged |
| Variadic `if()`/`iif()` CASE-chain (odd N ≥ 3) | ✅ | New unit + integration tests; `if(1=2,1.5,1=1,2,'x')` → `2` via CLI |
| `if()` accepts integer/float/string conditions | ✅ | `test_if_ternary_integer_condition`/`_float_condition`; reuses `is_truthy` |
| Shared `is_truthy` reused (no reimplementation) | ✅ | Both functions call `operators::is_truthy` |
| strict1.test failures attributable to `if()`/`iif()` resolved | ✅ | `strict1-9.1` and `strict1-9.3` (do_execsql + integrity_check) now pass |
| No regression on existing conditional tests | ✅ | Full `vibesql-executor` (3219) + `vibesql-parser` (1728) suites green |

## Test Plan

- `cargo test -p vibesql-executor` — 3219 passed, 0 failed (incl. new conditional unit + integration tests).
- `cargo test -p vibesql-parser` — 1728 passed, 0 failed (no regression from the new keyword arm).
- `make test-tcl-file FILE=strict1.test` — `strict1-9.1` and `strict1-9.3` now pass (were failing on the `if(...)` parse error).
- `make test-tcl-file FILE=expr.test` — 0 failures. `make test-tcl-file FILE=func.test` — 1 failure (`func-7.1`, a pre-existing `last_insert_rowid()` harness artifact, unrelated to this change).

## Scope note for reviewer

The issue title anticipated "~20 remaining strict1 failures". In practice, `if()`/`iif()` was a *prerequisite* (the 9-arg `if()` caused a hard parse error, so the STRICT generated-column table could not even be created). With this PR the table builds and evaluates correctly, so the `do_execsql` cases (`9.1`, `9.3`) pass. The remaining `strict1-9.2.x` / `9.4.x` `do_catchsql` cases assert STRICT type enforcement on generated columns (e.g. `cannot store TEXT value in REAL column`) — VibeSQL currently stores the generated value without STRICT type checking. That is a separate feature (the STRICT-enforcement track, #5837), explicitly called out as "independent of STRICT enforcement" in this issue, and is intentionally left out of scope. `strict1-7.1` is likewise an unrelated chained generated-column case. Recommend a follow-up issue for STRICT type enforcement on STORED/VIRTUAL generated columns.

Closes #5942