### PR TITLE
fix(collation): propagate underlying column collation through wildcard view bodies

### DIFF
--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -143,16 +143,27 @@ fn source_column_collation(
     // View source: map the referenced column to its select-list position and
     // resolve that item's collation against the inner view's own FROM clause.
     let view = database.catalog.get_view(source_name)?;
-    let idx = view_output_column_index(view, column_name)?;
     let inner_from = view.query.from.as_ref();
-    let resolver = |c: &vibesql_ast::ColumnIdentifier| -> Option<String> {
-        view_body_column_collation(database, inner_from, c)
-    };
-    let collations = crate::evaluator::collation::view_select_list_collations(
-        &view.query.select_list,
-        &resolver,
-    );
-    collations.get(idx).cloned().flatten()
+    if let Some(idx) = view_output_column_index(view, column_name) {
+        let resolver = |c: &vibesql_ast::ColumnIdentifier| -> Option<String> {
+            view_body_column_collation(database, inner_from, c)
+        };
+        let collations = crate::evaluator::collation::view_select_list_collations(
+            &view.query.select_list,
+            &resolver,
+        );
+        if let Some(result) = collations.get(idx).cloned().flatten() {
+            return Some(result);
+        }
+    }
+    // Wildcard fallback (issue #5925): `view_output_column_index` returns `None`
+    // for a wildcard body (`SELECT * FROM ...`) because the output column's
+    // select-list position is unknowable. It can also position the column via an
+    // explicit view column list while the wildcard body still yields no derived
+    // collation. In both cases resolve the column by name directly against the
+    // inner view's FROM sources so collation propagates through nested wildcard
+    // views.
+    find_collation_in_from(database, inner_from?, column_name)
 }
 
 /// Map a view's exposed column name to its select-list index. Uses the view's
@@ -458,8 +469,7 @@ pub(crate) fn execute_table_scan(
         // Only the (left) branch of the body's select list is inspected — for
         // a UNION body SQLite likewise takes the collation from the first
         // branch. The derived vector is applied only when it aligns 1:1 with
-        // the result columns, so wildcard-expanded bodies (whose select-item
-        // count differs from the column count) degrade safely to BINARY.
+        // the result columns.
         let view_from = view.query.from.as_ref();
         let column_collation_fn = |col_id: &vibesql_ast::ColumnIdentifier| -> Option<String> {
             view_body_column_collation(database, view_from, col_id)
@@ -469,11 +479,28 @@ pub(crate) fn execute_table_scan(
             &column_collation_fn,
         );
         let use_derived_collations = derived_collations.len() == column_names.len();
+        // Wildcard fallback (issue #5925): a `SELECT *` (or `SELECT t.*`) body
+        // yields a select-item count that differs from the expanded output
+        // column count, so `view_select_list_collations` cannot align 1:1.
+        // Instead of degrading every column to BINARY, resolve each output
+        // column by name against the view's FROM sources. `find_collation_in_from`
+        // recurses through JOINs and delegates to base tables / nested views, so
+        // multi-table wildcard bodies (`SELECT * FROM t1 JOIN t2 ...`) are
+        // covered. A body with no FROM clause (e.g. `SELECT * FROM (VALUES ...)`)
+        // resolves to `None` and degrades gracefully.
+        let wildcard_collations: Vec<Option<String>> = if use_derived_collations {
+            Vec::new()
+        } else {
+            column_names
+                .iter()
+                .map(|name| view_from.and_then(|from| find_collation_in_from(database, from, name)))
+                .collect()
+        };
         let collation_for = |idx: usize| -> Option<String> {
             if use_derived_collations {
                 derived_collations.get(idx).cloned().flatten()
             } else {
-                None
+                wildcard_collations.get(idx).cloned().flatten()
             }
         };
 

--- a/crates/vibesql-executor/tests/comparison_collation_tests.rs
+++ b/crates/vibesql-executor/tests/comparison_collation_tests.rs
@@ -294,3 +294,113 @@ fn view_plain_literal_column_is_binary() {
     run_stmt(&mut db, "CREATE VIEW vlit(a, b) AS SELECT 'A', 'a' FROM t0");
     assert_rows(&db, "SELECT a = b FROM vlit", &[0]);
 }
+
+// ---------------------------------------------------------------------------
+// Issue #5925: wildcard (`SELECT *`) view bodies must propagate the underlying
+// column's declared collation to outer-query comparisons. Follow-up to #5864,
+// which only aligned collation when the body's select-item count matched the
+// output column count (explicit select lists). Expected values verified against
+// sqlite3 3.51.0 (see the oracle in the issue body).
+// ---------------------------------------------------------------------------
+
+/// `t2(a TEXT, B TEXT COLLATE NOCASE)` seeded with one row `('a','B')` — the
+/// fixture used by the sqlite3 oracle in issue #5925.
+fn db_with_t2_nocase() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t2(a TEXT, B TEXT COLLATE NOCASE)");
+    run_stmt(&mut db, "INSERT INTO t2 VALUES('a', 'B')");
+    db
+}
+
+#[test]
+fn view_wildcard_propagates_underlying_collation() {
+    // Bare wildcard body: `SELECT * FROM t2`. The oracle:
+    //   SELECT B < a FROM vstar  ->  0  (NOCASE: 'B' < 'a' is false)
+    //   SELECT a >= B FROM vstar ->  1
+    // Before this fix VibeSQL degraded every wildcard column to BINARY and
+    // returned 1 / 0 respectively.
+    let mut db = db_with_t2_nocase();
+    run_stmt(&mut db, "CREATE VIEW vstar AS SELECT * FROM t2");
+    assert_rows(&db, "SELECT B < a FROM vstar", &[0]);
+    assert_rows(&db, "SELECT a >= B FROM vstar", &[1]);
+}
+
+#[test]
+fn view_qualified_wildcard_propagates_underlying_collation() {
+    // Qualified wildcard body: `SELECT t2.* FROM t2` behaves identically.
+    let mut db = db_with_t2_nocase();
+    run_stmt(&mut db, "CREATE VIEW vqstar AS SELECT t2.* FROM t2");
+    assert_rows(&db, "SELECT B < a FROM vqstar", &[0]);
+    assert_rows(&db, "SELECT a >= B FROM vqstar", &[1]);
+}
+
+#[test]
+fn view_of_wildcard_view_propagates_collation() {
+    // Two levels of nesting: an explicit-select view over a wildcard view.
+    // NOCASE must still reach the outer comparison.
+    let mut db = db_with_t2_nocase();
+    run_stmt(&mut db, "CREATE VIEW vstar AS SELECT * FROM t2");
+    run_stmt(&mut db, "CREATE VIEW vstar2 AS SELECT a, B FROM vstar");
+    assert_rows(&db, "SELECT B < a FROM vstar2", &[0]);
+    assert_rows(&db, "SELECT a >= B FROM vstar2", &[1]);
+}
+
+#[test]
+fn view_of_wildcard_of_wildcard_view_propagates_collation() {
+    // Three levels: wildcard over wildcard over base table.
+    let mut db = db_with_t2_nocase();
+    run_stmt(&mut db, "CREATE VIEW vstar AS SELECT * FROM t2");
+    run_stmt(&mut db, "CREATE VIEW vstar2 AS SELECT * FROM vstar");
+    assert_rows(&db, "SELECT B < a FROM vstar2", &[0]);
+    assert_rows(&db, "SELECT a >= B FROM vstar2", &[1]);
+}
+
+#[test]
+fn view_explicit_column_list_over_wildcard_body_propagates_collation() {
+    // Explicit view column list + wildcard body. `view_output_column_index`
+    // positions the column via `view.columns`, but the derived collation is
+    // `[None]`; the Path 2 fallback resolves it by name from the inner FROM.
+    let mut db = db_with_t2_nocase();
+    run_stmt(&mut db, "CREATE VIEW vstar (a, B) AS SELECT * FROM t2");
+    assert_rows(&db, "SELECT B < a FROM vstar", &[0]);
+    assert_rows(&db, "SELECT a >= B FROM vstar", &[1]);
+}
+
+#[test]
+fn view_multi_join_wildcard_propagates_single_collated_column() {
+    // Multi-table wildcard body where only one joined table has a collated
+    // column. `find_collation_in_from` recurses through the JOIN and resolves
+    // `B` from t2 while `x`/`y` stay BINARY.
+    let mut db = db_with_t2_nocase();
+    run_stmt(&mut db, "CREATE TABLE t1(x TEXT, y TEXT)");
+    run_stmt(&mut db, "INSERT INTO t1 VALUES('a', 'a')");
+    run_stmt(&mut db, "CREATE VIEW vjoin AS SELECT * FROM t1 JOIN t2 ON t1.x = t2.a");
+    // B (NOCASE) vs a (from t2) -> NOCASE -> 0.
+    assert_rows(&db, "SELECT B < a FROM vjoin", &[0]);
+    // x and y are plain BINARY columns from t1: 'a' = 'a' -> 1.
+    assert_rows(&db, "SELECT x = y FROM vjoin", &[1]);
+}
+
+#[test]
+fn view_wildcard_simple_retrieval_unchanged() {
+    // Plain row retrieval from a wildcard view (no outer comparison) still
+    // returns the stored values unchanged.
+    let mut db = db_with_t2_nocase();
+    run_stmt(&mut db, "CREATE VIEW vstar AS SELECT * FROM t2");
+    let stmt = vibesql_parser::Parser::parse_sql("SELECT a, B FROM vstar").unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(&db);
+        let rows = executor.execute(&select_stmt).unwrap();
+        assert_eq!(rows.len(), 1);
+        let as_str = |v: &SqlValue| -> String {
+            match v {
+                SqlValue::Varchar(s) | SqlValue::Character(s) => s.to_string(),
+                other => panic!("Expected text value, got {:?}", other),
+            }
+        };
+        assert_eq!(as_str(&rows[0].values[0]), "a");
+        assert_eq!(as_str(&rows[0].values[1]), "B");
+    } else {
+        panic!("Expected SELECT");
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #5924 / #5864. A view whose body is a bare wildcard (`SELECT *`) or qualified wildcard (`SELECT t.*`) produced a select-item count that differed from its expanded output column count, so `view_select_list_collations` could not align 1:1 with the result columns and every column silently degraded to BINARY. Outer comparisons over collated underlying columns then diverged from sqlite3 3.51.0 (`SELECT B < a FROM vstar` returned `1` instead of `0`).

This PR recovers the underlying column collation for wildcard view bodies via the existing `find_collation_in_from` walker (no changes to `collation.rs`).

## Changes

- `crates/vibesql-executor/src/select/scan/table.rs`
  - **Path 1 (`execute_table_scan`)**: when the derived-collation vector length diverges from the output column count (the wildcard case), resolve each output column by name against the view's FROM sources with `find_collation_in_from`. This recurses through JOINs and delegates to base tables / nested views, so multi-table wildcard bodies are covered. A body with no FROM clause degrades gracefully to BINARY.
  - **Path 2 (`source_column_collation`)**: when `view_output_column_index` returns `None` for a wildcard body — or positions the column via an explicit view column list but the wildcard body yields no derived collation — fall back to `find_collation_in_from` on the inner view's FROM clause, so collation propagates through nested wildcard views.
- `crates/vibesql-executor/tests/comparison_collation_tests.rs`: 7 new tests (14 assertions) covering bare/qualified wildcards, two- and three-level nested wildcard views, explicit view column list over a wildcard body, multi-join wildcard, and unchanged plain row retrieval.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `SELECT B < a FROM vstar` returns `0` (NOCASE) for `CREATE VIEW vstar AS SELECT * FROM t2` | ✅ | `view_wildcard_propagates_underlying_collation` |
| Reversed operands `SELECT a >= B FROM vstar` returns `1` | ✅ | same test, second assertion |
| View-of-wildcard-view (`SELECT a, B FROM vstar`) propagates NOCASE | ✅ | `view_of_wildcard_view_propagates_collation` (+ 3-level `view_of_wildcard_of_wildcard_view_propagates_collation`) |
| `CREATE VIEW vstar (a, B) AS SELECT * FROM t2` (explicit column list + wildcard body) propagates collation | ✅ | `view_explicit_column_list_over_wildcard_body_propagates_collation` |
| `SELECT * FROM vstar` with no outer comparison works unchanged | ✅ | `view_wildcard_simple_retrieval_unchanged` |
| Existing `comparison_collation_tests.rs` (#5864) all pass — no regression | ✅ | all 20 prior tests pass; full `-p vibesql-executor` suite 5211 passed / 0 failed |

Additional coverage beyond the checklist: qualified wildcard (`SELECT t2.*`) and multi-join wildcard where only one joined table has a collated column.

## Test Plan

- `cargo test -p vibesql-executor --test comparison_collation_tests` — 27 passed / 0 failed (7 new + 20 existing).
- `cargo test -p vibesql-executor` — 5211 passed / 0 failed across the whole crate (no regressions).

Closes #5925