### PR TITLE
fix(columnar): detect ambiguous unqualified WHERE column on columnar join path

### DIFF
--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
@@ -318,6 +318,27 @@ impl SelectExecutor<'_> {
             }
         };
 
+        // Issue #5927: validate WHERE clause column refs against the combined schema
+        // before applying the SIMD filter. The row-oriented path does this via
+        // validate_select_columns_with_context at execute.rs:1280. The columnar path
+        // skipped it, silently resolving ambiguous unqualified refs left-to-right.
+        //
+        // This runs AFTER execute_columnar_join_chain: USING/NATURAL joins produce
+        // no equijoin conditions, so the chain returns Ok(None) and we fall back to
+        // the row path (which coalesces the join keys and validates correctly)
+        // before reaching this point. Only equijoin columnar joins get here, where
+        // combined_schema.joined_columns is correctly empty and an unqualified ref
+        // matching two tables is genuinely ambiguous.
+        if let Some(ref where_expr) = stmt.where_clause {
+            super::super::validation::validate_select_columns_with_context(
+                &stmt.select_list,
+                Some(where_expr),
+                &combined_schema,
+                self.procedural_context,
+                self.outer_schema,
+            )?;
+        }
+
         // Apply remaining WHERE predicates (non-join conditions) using SIMD filtering
         // First, constant-fold the WHERE clause to handle expressions like `BETWEEN 1 AND 1+2`
         // which need to become `BETWEEN 1 AND 3` for the predicate extractor to recognize them

--- a/crates/vibesql-executor/tests/columnar_join_ambiguous_where_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_join_ambiguous_where_tests.rs
@@ -1,0 +1,201 @@
+//! Regression tests for issue #5927
+//!
+//! An ambiguous unqualified column reference used in a **non-equijoin WHERE
+//! predicate** (e.g. `WHERE id > 0`) on the columnar explicit-JOIN path was
+//! silently resolved to the leftmost table instead of erroring.
+//!
+//! Root cause: the columnar join path
+//! (`columnar_execution::join::try_columnar_join_execution`) applied the
+//! residual WHERE via SIMD without running `validate_select_columns_with_context`
+//! against the combined schema. The single-table columnar path and the
+//! row-oriented path both run that validation; the columnar join path did not.
+//! Because the ambiguous `id` in `id > 0` is not an equijoin key, it was never
+//! extracted as a join condition and never hit the ambiguity guard added in
+//! #5870 — the SIMD WHERE filter then resolved it leftmost.
+//!
+//! The row-oriented path (`VIBESQL_DISABLE_COLUMNAR_JOIN=1`) was always correct;
+//! these tests pin the fixed behavior on the columnar (default) path.
+
+use vibesql_catalog::{ColumnSchema, TableSchema};
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::{Database, Row};
+use vibesql_types::{DataType, SqlValue};
+
+fn parse_select(sql: &str) -> vibesql_ast::SelectStmt {
+    match Parser::parse_sql(sql) {
+        Ok(vibesql_ast::Statement::Select(select_stmt)) => *select_stmt,
+        _ => panic!("Failed to parse SELECT statement: {}", sql),
+    }
+}
+
+fn run(db: &Database, sql: &str) -> Vec<Row> {
+    let select = parse_select(sql);
+    SelectExecutor::new(db).execute(&select).unwrap()
+}
+
+fn run_err(db: &Database, sql: &str) -> String {
+    let select = parse_select(sql);
+    match SelectExecutor::new(db).execute(&select) {
+        Ok(rows) => {
+            panic!("expected an error for `{}`, but query returned {} row(s)", sql, rows.len())
+        }
+        Err(e) => e.to_string(),
+    }
+}
+
+/// Schema/data from the issue #5927 reproduction, extended with a third table
+/// so the 3-table join case can be exercised.
+///
+/// ```sql
+/// CREATE TABLE a1(id INTEGER PRIMARY KEY, v);
+/// CREATE TABLE b1(id INTEGER PRIMARY KEY, aid, v);
+/// CREATE TABLE c1(id INTEGER PRIMARY KEY, bid, v);
+/// INSERT INTO a1 VALUES(1,'a1'),(2,'a2');
+/// INSERT INTO b1 VALUES(10,1,'b1'),(11,2,'b2');
+/// INSERT INTO c1 VALUES(100,10,'c1');
+/// ```
+///
+/// Every table has an `id` column, so an unqualified `id` in a WHERE predicate
+/// is ambiguous across a1/b1(/c1).
+fn setup_issue_5927_db() -> Database {
+    let mut db = Database::new();
+
+    let a1_schema = TableSchema::with_primary_key(
+        "A1".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, false),
+            ColumnSchema::new("v".to_string(), DataType::Varchar { max_length: None }, true),
+        ],
+        vec!["id".to_string()],
+    );
+    db.create_table(a1_schema).unwrap();
+
+    let b1_schema = TableSchema::with_primary_key(
+        "B1".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, false),
+            ColumnSchema::new("aid".to_string(), DataType::Integer, true),
+            ColumnSchema::new("v".to_string(), DataType::Varchar { max_length: None }, true),
+        ],
+        vec!["id".to_string()],
+    );
+    db.create_table(b1_schema).unwrap();
+
+    let c1_schema = TableSchema::with_primary_key(
+        "C1".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, false),
+            ColumnSchema::new("bid".to_string(), DataType::Integer, true),
+            ColumnSchema::new("v".to_string(), DataType::Varchar { max_length: None }, true),
+        ],
+        vec!["id".to_string()],
+    );
+    db.create_table(c1_schema).unwrap();
+
+    for (id, v) in [(1, "a1"), (2, "a2")] {
+        db.insert_row("A1", Row::new(vec![SqlValue::Integer(id), SqlValue::Varchar(v.into())]))
+            .unwrap();
+    }
+    for (id, aid, v) in [(10, 1, "b1"), (11, 2, "b2")] {
+        db.insert_row(
+            "B1",
+            Row::new(vec![
+                SqlValue::Integer(id),
+                SqlValue::Integer(aid),
+                SqlValue::Varchar(v.into()),
+            ]),
+        )
+        .unwrap();
+    }
+    db.insert_row(
+        "C1",
+        Row::new(vec![
+            SqlValue::Integer(100),
+            SqlValue::Integer(10),
+            SqlValue::Varchar("c1".into()),
+        ]),
+    )
+    .unwrap();
+
+    db
+}
+
+/// Primary reproduction: ambiguous unqualified `id` in a non-equijoin WHERE
+/// predicate must error on the columnar (default) path, matching sqlite3 and
+/// the row path.
+#[test]
+fn test_ambiguous_unqualified_where_errors() {
+    let db = setup_issue_5927_db();
+
+    let sql = "SELECT a1.id FROM a1 JOIN b1 ON b1.aid=a1.id WHERE id>0";
+    let err = run_err(&db, sql);
+
+    assert!(
+        err.contains("ambiguous column name: id"),
+        "expected `ambiguous column name: id`, got: {}",
+        err
+    );
+}
+
+/// Qualified reference in the WHERE predicate is unambiguous and must still
+/// work correctly.
+#[test]
+fn test_qualified_where_still_works() {
+    let db = setup_issue_5927_db();
+
+    let sql = "SELECT a1.id FROM a1 JOIN b1 ON b1.aid=a1.id WHERE a1.id>0 ORDER BY 1";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 2, "both a1 rows join and satisfy a1.id > 0");
+    assert_eq!(result[0].values[0], SqlValue::Integer(1));
+    assert_eq!(result[1].values[0], SqlValue::Integer(2));
+}
+
+/// Unqualified reference to a column that exists in only one table is
+/// unambiguous and must still work correctly.
+#[test]
+fn test_unambiguous_unqualified_where_still_works() {
+    let db = setup_issue_5927_db();
+
+    // `aid` exists only in b1, so it is unambiguous even unqualified.
+    let sql = "SELECT a1.id FROM a1 JOIN b1 ON b1.aid=a1.id WHERE aid>0 ORDER BY 1";
+    let result = run(&db, sql);
+
+    assert_eq!(result.len(), 2, "both rows join and satisfy aid > 0");
+    assert_eq!(result[0].values[0], SqlValue::Integer(1));
+    assert_eq!(result[1].values[0], SqlValue::Integer(2));
+}
+
+/// 3-table join: the ambiguous unqualified `id` in the WHERE predicate must
+/// error on the columnar path.
+#[test]
+fn test_ambiguous_unqualified_where_three_table_join_errors() {
+    let db = setup_issue_5927_db();
+
+    let sql = "SELECT a1.id FROM a1 JOIN b1 ON b1.aid=a1.id \
+               JOIN c1 ON c1.bid=b1.id WHERE id>0";
+    let err = run_err(&db, sql);
+
+    assert!(
+        err.contains("ambiguous column name: id"),
+        "expected `ambiguous column name: id`, got: {}",
+        err
+    );
+}
+
+/// A non-equijoin WHERE predicate after a LEFT JOIN must also error when the
+/// unqualified reference is ambiguous.
+#[test]
+fn test_ambiguous_unqualified_where_after_left_join_errors() {
+    let db = setup_issue_5927_db();
+
+    let sql = "SELECT a1.id FROM a1 LEFT JOIN b1 ON b1.aid=a1.id WHERE id>0";
+    let err = run_err(&db, sql);
+
+    assert!(
+        err.contains("ambiguous column name: id"),
+        "expected `ambiguous column name: id`, got: {}",
+        err
+    );
+}


### PR DESCRIPTION
## Summary

An ambiguous unqualified column reference used in a non-equijoin WHERE predicate (e.g. `WHERE id > 0`) on the columnar explicit-JOIN path was silently resolved to the leftmost table instead of erroring. The row-oriented path and sqlite3 both report `ambiguous column name`. This closes that conformance gap on the default (columnar) path.

## Changes

- `crates/vibesql-executor/src/select/executor/columnar_execution/join.rs`: In `try_columnar_join_execution`, call `validate_select_columns_with_context` on the WHERE clause against the combined schema. The check is placed **after** `execute_columnar_join_chain` so USING/NATURAL joins (which return `Ok(None)` and fall back to the row path) are never wrongly flagged — only genuine equijoin columnar joins reach it, where an unqualified ref matching two tables is truly ambiguous. The `?` propagates `AmbiguousColumnName`, matching the row path.
- `crates/vibesql-executor/tests/columnar_join_ambiguous_where_tests.rs`: New regression test file (5 tests).

### Placement note

The curator comment suggested inserting the check immediately after `build_combined_schema` (before the join chain runs). That placement broke `test_empty_result_natural_join_cte_exposes_names` because a `NATURAL JOIN ... WHERE id > 100` reaches the check before the chain has a chance to fall back, and `build_combined_schema` builds an empty `joined_columns` set — so the coalesced NATURAL key `id` was wrongly flagged. Moving the check to after the chain (where NATURAL/USING have already returned `Ok(None)`) fixes this without needing to populate `joined_columns` in `join_helpers.rs`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Ambiguous unqualified col in non-equijoin WHERE errors on columnar path | ✅ | `test_ambiguous_unqualified_where_errors` |
| USING/NATURAL join keys unqualified in WHERE NOT flagged ambiguous | ✅ | `test_empty_result_natural_join_cte_exposes_names` (pre-existing) stays green |
| Behavior identical with `VIBESQL_DISABLE_COLUMNAR_JOIN=1` | ✅ | Fix aligns columnar path with the already-correct row path |
| Qualified ref still works | ✅ | `test_qualified_where_still_works` |
| Unambiguous unqualified ref still works | ✅ | `test_unambiguous_unqualified_where_still_works` |
| 3-table join ambiguous ref errors | ✅ | `test_ambiguous_unqualified_where_three_table_join_errors` |
| Ambiguous ref after LEFT JOIN errors | ✅ | `test_ambiguous_unqualified_where_after_left_join_errors` |

## Test Plan

- New file: 5/5 tests pass.
- Full `cargo test -p vibesql-executor`: all pass, no regressions (the NATURAL join CTE test that the naive placement broke is green).
- Scope: only `join.rs` (+21 lines) and the new test file changed.

Closes #5927