### PR TITLE
fix(tcl-shim): count synthetic self-skip row in nSkip so summary matches detail

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -6199,6 +6199,7 @@ proc finish_test {} {
     if {$::nTest == 0 && $::nSkip == 0 && !$::file_marker_emitted} {
         set self_skip_base [file rootname [file tail [lindex $::argv 0]]]
         emit_test_detail skipped "$self_skip_base (capability self-skip)"
+        incr ::nSkip
         set ::file_marker_emitted 1
     }
 


### PR DESCRIPTION
## Summary

The `finish_test` capability-self-skip block in `scripts/tester_vibesql.tcl` synthesizes a `status='skipped'` detail row for files that self-skip at their capability guard (`ifcapable !cap { finish_test; return }`), so the file never vanishes from `tcl_test_results`. But it never incremented `::nSkip`, so the shim's `Tests skipped:` trailer reported `0`. `tcl_runner.py` derives the run's `skipped` count from that trailer, so `tcl_test_runs.skipped` undercounted by one per self-skip file while `tcl_test_results` correctly held the row — violating the documented invariant that the summary and detail tables reconcile on the `skipped` column.

## Changes

- `scripts/tester_vibesql.tcl`: add `incr ::nSkip` inside the `finish_test` self-skip block, alongside the existing `emit_test_detail skipped`. This matches the well-formed `omit_test` reference, which already increments `::nSkip` before emitting.

No `tcl_runner.py` change is needed — it already propagates the trailer value correctly once the shim emits `Tests skipped: 1`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Self-skip file's trailer reports `Tests skipped: 1` (not `0`) | Done | Ran shim on `crash8.test` (`ifcapable !crashtest`): trailer now shows `Tests skipped: 1`; pre-fix shim showed `0` |
| `tcl_test_runs.skipped` reconciles with `tcl_test_results` skipped rows | Done | Trailer now equals the one emitted `##TCLTEST## skipped` detail row; runner derives summary from the trailer |
| `pass_rate` unaffected | Done | Skipped is excluded from the canonical pass-rate denominator; only skipped counting changed |
| Marker-guarantee behavior unchanged | Done | Guard conditions untouched; only adds the increment inside the already-fired block |
| No regressions | Done | Ran `tkt2832.test` (normal file): `Tests run: 6, skipped: 0` — self-skip block correctly does not fire (nTest>0) |
| No double-count of whole-file skips | Done | By construction: whole-file skip path sets `file_marker_emitted=1` and increments `nSkip`, so the `nTest==0 && nSkip==0 && !file_marker_emitted` guard cannot fire for those files |

## Test Plan

- Ran the shim directly on `docs/reference/sqlite/test/crash8.test` (a `crashtest` self-skip file) before and after the change:
  - Before: `Tests skipped: 0`
  - After: `Tests skipped: 1`, with the `##TCLTEST## skipped crash8 (capability self-skip)` detail row still emitted.
- Ran the shim on `docs/reference/sqlite/test/tkt2832.test` (a normal file): `Tests run: 6, Tests passed: 6, Tests skipped: 0` — no regression, self-skip block not triggered.

Closes #5915