### PR TITLE
fix(tcl_parser): split exact-stem file skips from broad family patterns

### DIFF
--- a/scripts/tcl_parser.py
+++ b/scripts/tcl_parser.py
@@ -147,7 +147,10 @@ class TclTestParser:
         r'catchsql',        # Nested catchsql
     ]
 
-    # Patterns to skip entire test files
+    # Intentionally-broad family patterns: skip an entire file *family* by
+    # unanchored substring match. VibeSQL does not share SQLite's storage layer,
+    # so skipping the whole WAL/journal/vacuum/etc. family is a deliberate choice.
+    # These predate #5844 and MUST stay broad — do not narrow them.
     SKIP_FILE_PATTERNS = [
         r'malloc',          # Memory allocation tests
         r'corrupt',         # Corruption tests
@@ -162,26 +165,40 @@ class TclTestParser:
         r'attach',          # Attach database
         r'vtab',            # Virtual tables
         r'intarray',        # Int array extension
-        # C-API / pager / extension-internals files (#5844 long-tail triage).
-        # These have no SQL-reachable surface; keep static-parser mode consistent
-        # with the vibesql_skip_files list in tester_vibesql.tcl.
-        r'manydb',          # ~116 concurrent named connections
-        r'varint',          # btree_varint_test C extension
-        r'quota',           # quota-VFS C API (quota-glob)
-        r'jrnlmode',        # rollback-journal pager modes (jrnlmode, jrnlmode3)
-        r'pagesize',        # PRAGMA page_size + exact file-byte assertions
-        r'snapshot',        # sqlite3_snapshot_* C API
-        r'lock',            # file-locking / locking-style VFS C API (lock, lock5)
-        r'symlink',         # sqlite3_db_filename C API
-        r'filefmt',         # hexio raw-byte db file manipulation
-        r'colmeta',         # sqlite3_column_* metadata C API
-        r'tableapi',        # sqlite3_get_table_printf C API
-        r'bind',            # sqlite3_bind_* C API
-        r'ptrchng',         # sqlite3_value_pointer / sqlite3_result_pointer C API
-        r'badutf',          # invalid-UTF-8 injection via C API (badutf, badutf2)
-        r'strict2',         # writable_schema + rootpage aliasing
-        r'ieee754',         # unguarded load_static_extension db ieee754
     ]
+
+    # Exact-stem skips: mirror the native `vibesql_skip_files` array keys in
+    # scripts/tester_vibesql.tcl, which are matched with an exact hash lookup
+    # (`[info exists vibesql_skip_files($basename)]`, run_test_file). These are
+    # per-file C-API / pager / extension-internals entries (#5844 long-tail
+    # triage) with no SQL-reachable surface. They MUST NOT be substring patterns:
+    # an unanchored `lock` wrongly swallows lock2..lock7/nolock/sharedlock, etc.
+    # Match the file stem exactly (case-sensitive, like the TCL `file rootname`)
+    # so static-parser mode agrees with native exact-match semantics.
+    SKIP_FILE_EXACT = frozenset({
+        'manydb',           # ~116 concurrent named connections
+        'varint',           # btree_varint_test C extension
+        'quota-glob',       # quota_file_size()/quota_glob() C-only VFS quota API
+        'jrnlmode',         # rollback-journal pager modes
+        'jrnlmode3',        # journal mode x multi-database transactions
+        'pagesize',         # PRAGMA page_size + exact file-byte assertions
+        'snapshot',         # sqlite3_snapshot_* C API
+        'lock',             # file-locking VFS C API (lock_status/fcntl_lockstate)
+        'lock5',            # locking-style VFS + sqlite3_unlock_notify callbacks
+        'shared6',          # sqlite3_enable_shared_cache C API
+        'symlink',          # sqlite3_db_filename C API
+        'filefmt',          # hexio raw-byte db file manipulation
+        'corruptL',         # sqlite3_deserialize corrupted-page injection
+        'colmeta',          # sqlite3_column_* metadata C API
+        'tableapi',         # sqlite3_get_table_printf C API
+        'bind',             # sqlite3_bind_* C API
+        'ptrchng',          # sqlite3_value_pointer / sqlite3_result_pointer C API
+        'badutf',           # invalid-UTF-8 injection via C API
+        'badutf2',          # invalid-UTF-8 injection via C API
+        'ieee754',          # unguarded load_static_extension db ieee754
+        'trustschema1',     # trusted_schema pragma + TCL-registered UDFs
+        'strict2',          # writable_schema + rootpage aliasing
+    })
 
     def __init__(self, verbose: bool = False):
         self.verbose = verbose
@@ -189,9 +206,20 @@ class TclTestParser:
         self._skip_file_regex = re.compile('|'.join(self.SKIP_FILE_PATTERNS), re.IGNORECASE)
 
     def should_skip_file(self, file_path: str) -> Optional[str]:
-        """Check if entire file should be skipped based on filename."""
-        filename = Path(file_path).stem.lower()
-        match = self._skip_file_regex.search(filename)
+        """Check if entire file should be skipped based on filename.
+
+        Two independent mechanisms, mirroring tester_vibesql.tcl:
+        - Exact-stem skips (SKIP_FILE_EXACT) mirror the native
+          `vibesql_skip_files` array's exact hash lookup — per-file entries only.
+        - Broad family patterns (SKIP_FILE_PATTERNS) skip whole file families by
+          unanchored substring (WAL/journal/vacuum/etc.).
+        """
+        stem = Path(file_path).stem
+        # Exact-stem match first (case-sensitive, like the native `file rootname`).
+        if stem in self.SKIP_FILE_EXACT:
+            return f"File '{stem}' not applicable to VibeSQL (exact skip)"
+        # Fall back to the intentionally-broad family patterns.
+        match = self._skip_file_regex.search(stem.lower())
         if match:
             return f"File type '{match.group()}' not applicable to VibeSQL"
         return None

--- a/scripts/test_tcl_parser.py
+++ b/scripts/test_tcl_parser.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/tcl_parser.py file-skip logic.
+
+Focus: TclTestParser.should_skip_file must mirror the native
+`vibesql_skip_files` exact-match semantics in scripts/tester_vibesql.tcl,
+rather than over-matching sibling files via unanchored substring regexes
+(regression guard for issue #5911).
+
+Run with:  python3 -m pytest scripts/test_tcl_parser.py
+       or:  python3 scripts/test_tcl_parser.py
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tcl_parser import TclTestParser  # noqa: E402
+
+
+# --- Acceptance criteria from issue #5911 -----------------------------------
+
+# (filename, should_be_skipped) — exact per-file entries that MUST be skipped,
+# and their sibling files that MUST NOT be skipped (the #5911 over-match bug).
+EXACT_SKIP_CASES = [
+    # lock family: only `lock` and `lock5` are native skip entries.
+    ("lock.test", True),
+    ("lock5.test", True),
+    ("lock2.test", False),
+    ("lock3.test", False),
+    ("lock4.test", False),
+    ("lock6.test", False),
+    ("lock7.test", False),
+    ("nolock.test", False),
+    ("sharedlock.test", False),
+    ("shmlock.test", False),
+    ("superlock.test", False),
+    # jrnlmode family: `jrnlmode` and `jrnlmode3` skip; `jrnlmode2` does not.
+    ("jrnlmode.test", True),
+    ("jrnlmode3.test", True),
+    ("jrnlmode2.test", False),
+    # quota family: only `quota-glob` skips; `quota`/`quota2` do not.
+    ("quota-glob.test", True),
+    ("quota.test", False),
+    ("quota2.test", False),
+    # snapshot family: only `snapshot` skips; numbered/fault siblings do not.
+    ("snapshot.test", True),
+    ("snapshot2.test", False),
+    ("snapshot3.test", False),
+    ("snapshot4.test", False),
+    ("snapshot_fault.test", False),
+    ("snapshot_up.test", False),
+    # bind family: only `bind` skips; `bind2`/`bindxfer` do not.
+    ("bind.test", True),
+    ("bind2.test", False),
+    ("bindxfer.test", False),
+    # symlink family: only `symlink` skips; `symlink2` does not.
+    ("symlink.test", True),
+    ("symlink2.test", False),
+    # badutf: both `badutf` and `badutf2` are native skip entries.
+    ("badutf.test", True),
+    ("badutf2.test", True),
+    # shared: only `shared6` skips; other shared* files do not.
+    ("shared6.test", True),
+    ("shared.test", False),
+    ("shared2.test", False),
+    ("shared7.test", False),
+    # strict: `strict2` skips; `strict1` does not.
+    ("strict2.test", True),
+    ("strict1.test", False),
+    # single-file C-API entries with no siblings.
+    ("manydb.test", True),
+    ("varint.test", True),
+    ("pagesize.test", True),
+    ("filefmt.test", True),
+    ("colmeta.test", True),
+    ("tableapi.test", True),
+    ("ptrchng.test", True),
+    ("ieee754.test", True),
+    ("trustschema1.test", True),
+]
+
+# Intentionally-broad family patterns (pre-existing, deliberately unanchored).
+# These MUST continue to skip the whole family.
+BROAD_SKIP_CASES = [
+    ("wal.test", True),
+    ("wal2.test", True),
+    ("walcrash.test", True),
+    ("journal1.test", True),
+    ("memjournal.test", True),
+    ("vacuum.test", True),
+    ("vacuum2.test", True),
+    ("autovacuum.test", True),
+    ("attach.test", True),
+    ("attach2.test", True),
+    ("malloc.test", True),
+    ("corrupt.test", True),
+    ("corruptL.test", True),  # exact entry AND caught by broad `corrupt`
+    ("crash.test", True),
+    ("fts3.test", True),
+    ("rtree.test", True),
+    # Core SQL files that must NOT be skipped.
+    ("select1.test", False),
+    ("where.test", False),
+    ("join.test", False),
+    ("insert.test", False),
+    ("index.test", False),
+]
+
+
+def _skipped(name: str) -> bool:
+    return TclTestParser().should_skip_file(name) is not None
+
+
+def test_exact_skip_semantics():
+    failures = []
+    for name, expected in EXACT_SKIP_CASES:
+        actual = _skipped(name)
+        if actual != expected:
+            failures.append(
+                f"{name}: expected skip={expected}, got skip={actual}"
+            )
+    assert not failures, "Exact-skip mismatches:\n  " + "\n  ".join(failures)
+
+
+def test_broad_family_skip_semantics():
+    failures = []
+    for name, expected in BROAD_SKIP_CASES:
+        actual = _skipped(name)
+        if actual != expected:
+            failures.append(
+                f"{name}: expected skip={expected}, got skip={actual}"
+            )
+    assert not failures, "Broad-skip mismatches:\n  " + "\n  ".join(failures)
+
+
+def test_all_native_exact_entries_have_a_stem_entry():
+    """Every SKIP_FILE_EXACT stem must actually be skipped as `<stem>.test`."""
+    parser = TclTestParser()
+    for stem in TclTestParser.SKIP_FILE_EXACT:
+        assert parser.should_skip_file(f"{stem}.test") is not None, (
+            f"exact entry {stem!r} unexpectedly not skipped"
+        )
+
+
+def test_no_broad_pattern_over_matches_removed_5844_entries():
+    """The #5844 per-file stems must no longer live in the broad regex."""
+    over_match_probes = [
+        "lock2", "lock7", "jrnlmode2", "quota", "quota2",
+        "snapshot2", "bind2", "symlink2",
+    ]
+    parser = TclTestParser()
+    for stem in over_match_probes:
+        assert parser.should_skip_file(f"{stem}.test") is None, (
+            f"{stem}.test should NOT be skipped after #5911 fix"
+        )
+
+
+if __name__ == "__main__":
+    tests = [
+        test_exact_skip_semantics,
+        test_broad_family_skip_semantics,
+        test_all_native_exact_entries_have_a_stem_entry,
+        test_no_broad_pattern_over_matches_removed_5844_entries,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"FAIL  {t.__name__}\n{exc}")
+    if failed:
+        print(f"\n{failed} test(s) failed")
+        sys.exit(1)
+    print(f"\nAll {len(tests)} tests passed")


### PR DESCRIPTION
## Summary

`TclTestParser.should_skip_file` compiled a single unanchored `re.search`
regex from `SKIP_FILE_PATTERNS`, so the per-file C-API/pager entries added in
#5844 over-matched sibling files that were never authorized. The native shim
(`tester_vibesql.tcl`) instead uses an exact hash lookup
(`[info exists vibesql_skip_files($basename)]`), so static-parser mode
(`--no-native-tcl`) silently diverged from native canonical runs.

This splits the skip logic into two structures that mirror native semantics:
an exact-stem `SKIP_FILE_EXACT` frozenset for the per-file entries, and the
intentionally-broad `SKIP_FILE_PATTERNS` substring regex for the WAL / journal
/ vacuum / attach / etc. families (left unchanged per the scope guard).

Debug-mode only: `should_skip_file` is reached solely from `parse_file`, which
runs only under `--no-native-tcl`. Native canonical pass-rate numbers are
unaffected, and `tester_vibesql.tcl` is not modified.

## Changes

- `scripts/tcl_parser.py`: introduce `SKIP_FILE_EXACT` (exact case-sensitive
  stem match, mirroring the native `file rootname` + array-key lookup); remove
  the #5844 per-file substrings from `SKIP_FILE_PATTERNS`; `should_skip_file`
  now checks the exact set first, then falls back to the broad family regex.
- `scripts/test_tcl_parser.py`: new unit tests covering the full over-match
  inventory (both "should skip" and "should not skip" cases) and broad-family
  regressions.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `should_skip_file("lock2.test")` returns None | ✅ | unit test + `tcltest parse lock2.test` extracts tests |
| `should_skip_file("lock.test")` still skips | ✅ | unit test + smoke test (`File 'lock' ... exact skip`) |
| `should_skip_file("lock5.test")` still skips | ✅ | unit test (`lock5` in SKIP_FILE_EXACT) |
| `should_skip_file("jrnlmode2.test")` returns None | ✅ | unit test |
| `should_skip_file("quota.test")` returns None | ✅ | unit test + `tcltest parse quota.test` extracts tests |
| `should_skip_file("snapshot2.test")` returns None | ✅ | unit test |
| `should_skip_file("bind2.test")` returns None | ✅ | unit test |
| `should_skip_file("symlink2.test")` returns None | ✅ | unit test |
| Native skip entries with a test file still skipped | ✅ | `test_all_native_exact_entries_have_a_stem_entry` |
| wal/journal/vacuum/attach families still skipped | ✅ | `test_broad_family_skip_semantics` + `tcltest parse wal2.test` |
| No change to native-mode behavior | ✅ | `tester_vibesql.tcl` untouched |
| `quota-glob.test` still skipped | ✅ | unit test + smoke test (exact skip) |

## Test Plan

- `python3 -m pytest scripts/test_tcl_parser.py` — 4 passed.
- Smoke tests (`--no-native-tcl` static mode):
  - `tcltest parse lock2.test` / `quota.test` — now extract tests (previously silently empty).
  - `tcltest parse lock.test` / `quota-glob.test` — exact-skip with new reason.
  - `tcltest parse wal2.test` — still skipped via broad family pattern.
  - `tcltest parse select1.test` — unaffected (212 tests).

Closes #5911