### PR TITLE
fix(parser): accept quoted strings as DDL/DML identifiers and COLLATE after IS TRUE/FALSE

### DIFF
--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -379,7 +379,10 @@ impl Parser {
             let name = if self.peek_keyword(Keyword::Constraint) {
                 self.advance(); // consume CONSTRAINT
                 match self.peek() {
-                    Token::Identifier(n) => {
+                    // SQLite accepts identifiers, double-quoted identifiers, and
+                    // single-quoted string literals as constraint names
+                    // (e.g. `CONSTRAINT 'c1' NOT NULL`).
+                    Token::Identifier(n) | Token::DelimitedIdentifier(n) | Token::String(n) => {
                         let constraint_name = n.clone();
                         self.advance();
                         Some(constraint_name)
@@ -588,7 +591,10 @@ impl Parser {
         let name = if self.peek_keyword(Keyword::Constraint) {
             self.advance(); // consume CONSTRAINT
             match self.peek() {
-                Token::Identifier(n) => {
+                // SQLite accepts identifiers, double-quoted identifiers, and
+                // single-quoted string literals as constraint names
+                // (e.g. `CONSTRAINT 'c1' CHECK(...)`).
+                Token::Identifier(n) | Token::DelimitedIdentifier(n) | Token::String(n) => {
                     let constraint_name = n.clone();
                     self.advance();
                     Some(constraint_name)

--- a/crates/vibesql-parser/src/parser/create/table.rs
+++ b/crates/vibesql-parser/src/parser/create/table.rs
@@ -118,6 +118,16 @@ impl Parser {
                     self.advance();
                     col_name
                 }
+                // SQLite compatibility: a single-quoted string literal is accepted
+                // as a column name in a column-definition position (quote.test
+                // quote-1.0: `CREATE TABLE '@abc'('#xyz' int, '!pqr' text)`).
+                // In DDL name position there is no string-literal-vs-identifier
+                // ambiguity, so we take the string verbatim as the column name.
+                Token::String(col) => {
+                    let c = col.clone();
+                    self.advance();
+                    c
+                }
                 _ => return Err(ParseError { message: "Expected column name".to_string() }),
             };
 

--- a/crates/vibesql-parser/src/parser/expressions/identifiers.rs
+++ b/crates/vibesql-parser/src/parser/expressions/identifiers.rs
@@ -20,6 +20,16 @@ impl Parser {
                 self.advance();
                 (name, true)
             }
+            // SQLite compatibility: a single-quoted string used as the qualifier
+            // of a dotted name is an identifier, not a string literal
+            // (quote.test quote-1.3: `'@abc'.'!pqr'`). `parse_literal` defers to
+            // us in this case; only accept it when a `.` actually follows so an
+            // ordinary bare string is never mistaken for a column reference.
+            Token::String(id) if matches!(self.peek_next(), Token::Symbol('.')) => {
+                let name = id.clone();
+                self.advance();
+                (name, true)
+            }
             Token::Keyword { keyword: kw, .. } if kw.can_be_identifier_in_expression() => {
                 // SQLite compatibility: in expression / primary position, a keyword that
                 // is not a reserved operator, clause-structure word, or special primary
@@ -146,6 +156,13 @@ impl Parser {
                     self.advance();
                     (name, true)
                 }
+                // SQLite compatibility: single-quoted string as a qualified name
+                // part (quote.test quote-1.3: `'@abc'.'!pqr'`).
+                Token::String(id) => {
+                    let name = id.clone();
+                    self.advance();
+                    (name, true)
+                }
                 Token::Keyword { keyword: kw, .. } => {
                     // Allow keywords as column names when qualified (e.g., table.year)
                     // SQL:1999 normalizes unquoted identifiers to lowercase
@@ -184,6 +201,13 @@ impl Parser {
                         (name, false)
                     }
                     Token::DelimitedIdentifier(id) => {
+                        let name = id.clone();
+                        self.advance();
+                        (name, true)
+                    }
+                    // SQLite compatibility: single-quoted string as a qualified
+                    // name part (schema.table.column with quoted parts).
+                    Token::String(id) => {
                         let name = id.clone();
                         self.advance();
                         (name, true)

--- a/crates/vibesql-parser/src/parser/expressions/literals.rs
+++ b/crates/vibesql-parser/src/parser/expressions/literals.rs
@@ -24,6 +24,13 @@ impl Parser {
                 }
             }
             Token::String(s) => {
+                // SQLite compatibility: a single-quoted string immediately
+                // followed by `.` is a qualified name, not a string literal
+                // (quote.test quote-1.3: `'@abc'.'!pqr'`). Defer to
+                // `parse_identifier_expression`, which builds the ColumnRef.
+                if matches!(self.peek_next(), Token::Symbol('.')) {
+                    return Ok(None);
+                }
                 let string_val = arcstr::ArcStr::from(s.as_str());
                 self.advance();
                 Ok(Some(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -946,27 +946,54 @@ impl Parser {
                     // becomes NULL-safe equality against a column named `unknown`
                     // (erroring at runtime if no such column is in scope).
                     let right = self.parse_relational_expression()?;
-                    left = match right {
+
+                    // A COLLATE postfix on the right operand of `IS TRUE/FALSE/NULL`
+                    // is a no-op: the predicate tests truthiness / null-ness, which
+                    // no collation can change. SQLite parses `0.5 IS TRUE COLLATE
+                    // NOCASE` as `0.5 IS (TRUE COLLATE NOCASE)` and returns 1 (the
+                    // COLLATE is discarded). Look through the wrapper so the
+                    // specialized IsTruthValue / IsNull AST is still produced; for
+                    // any other right operand the COLLATE is preserved in the
+                    // IsDistinctFrom comparison below.
+                    enum RhsKind {
+                        Null,
+                        True,
+                        False,
+                        Other,
+                    }
+                    let unwrapped = match &right {
+                        vibesql_ast::Expression::Collate { expr, .. } => expr.as_ref(),
+                        other => other,
+                    };
+                    let kind = match unwrapped {
                         vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Null) => {
-                            vibesql_ast::Expression::IsNull { expr: Box::new(left), negated }
+                            RhsKind::Null
                         }
                         vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(
                             true,
-                        )) => vibesql_ast::Expression::IsTruthValue {
+                        )) => RhsKind::True,
+                        vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(
+                            false,
+                        )) => RhsKind::False,
+                        _ => RhsKind::Other,
+                    };
+                    left = match kind {
+                        RhsKind::Null => {
+                            vibesql_ast::Expression::IsNull { expr: Box::new(left), negated }
+                        }
+                        RhsKind::True => vibesql_ast::Expression::IsTruthValue {
                             expr: Box::new(left),
                             truth_value: vibesql_ast::TruthValue::True,
                             negated,
                         },
-                        vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(
-                            false,
-                        )) => vibesql_ast::Expression::IsTruthValue {
+                        RhsKind::False => vibesql_ast::Expression::IsTruthValue {
                             expr: Box::new(left),
                             truth_value: vibesql_ast::TruthValue::False,
                             negated,
                         },
                         // SQLite compatibility: `IS <expr>` compares with NULL-safe
                         // equals. IS is IS NOT DISTINCT FROM; IS NOT is IS DISTINCT FROM.
-                        _ => vibesql_ast::Expression::IsDistinctFrom {
+                        RhsKind::Other => vibesql_ast::Expression::IsDistinctFrom {
                             left: Box::new(left),
                             right: Box::new(right),
                             negated: !negated,

--- a/crates/vibesql-parser/src/parser/update.rs
+++ b/crates/vibesql-parser/src/parser/update.rs
@@ -93,6 +93,15 @@ impl Parser {
                         self.advance();
                         col_name
                     }
+                    // SQLite compatibility: a single-quoted string is accepted as
+                    // a column name on the left of a SET assignment (it is
+                    // followed by `=`, so there is no literal-vs-identifier
+                    // ambiguity). quote.test quote-1.4: `UPDATE '@abc' SET '#xyz'=11`.
+                    Token::String(col) => {
+                        let c = col.clone();
+                        self.advance();
+                        c
+                    }
                     _ => {
                         return Err(ParseError {
                             message: "Expected column name in SET clause".to_string(),
@@ -260,6 +269,13 @@ impl Parser {
                         let col_name = format!("{}", kw).to_lowercase();
                         self.advance();
                         col_name
+                    }
+                    // SQLite compatibility: single-quoted string as a SET-clause
+                    // column name (quote.test quote-1.4).
+                    Token::String(col) => {
+                        let c = col.clone();
+                        self.advance();
+                        c
                     }
                     _ => {
                         return Err(ParseError {

--- a/crates/vibesql-parser/src/tests/mod.rs
+++ b/crates/vibesql-parser/src/tests/mod.rs
@@ -38,6 +38,7 @@ mod pragma;
 mod predicates;
 mod prepared;
 mod quantified;
+mod quoted_identifiers;
 mod raise;
 mod revoke;
 mod role;

--- a/crates/vibesql-parser/src/tests/quoted_identifiers.rs
+++ b/crates/vibesql-parser/src/tests/quoted_identifiers.rs
@@ -1,0 +1,191 @@
+//! Tests for SQLite-compatible acceptance of single-quoted strings as
+//! identifiers in DDL/DML name positions, string/double-quoted constraint
+//! names, and the `IS TRUE/FALSE` truth-value predicate with a trailing
+//! COLLATE postfix (issue #5841, quote.test / istrue.test recovery).
+
+use crate::Parser;
+
+// --- Single-quoted strings as identifiers (quote.test quote-1.x) ---
+
+#[test]
+fn test_create_table_single_quoted_name_and_columns() {
+    // quote-1.0: CREATE TABLE '@abc' ( '#xyz' int, '!pqr' text )
+    let sql = "CREATE TABLE '@abc' ( '#xyz' int, '!pqr' text )";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        vibesql_ast::Statement::CreateTable(stmt) => {
+            assert_eq!(stmt.table_name, "@abc");
+            assert_eq!(stmt.columns.len(), 2);
+            assert_eq!(stmt.columns[0].name, "#xyz");
+            assert_eq!(stmt.columns[1].name, "!pqr");
+        }
+        other => panic!("Expected CreateTable, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_qualified_single_quoted_name_in_select() {
+    // quote-1.3: SELECT '@abc'.'!pqr' FROM '@abc'
+    let sql = "SELECT '@abc'.'!pqr' FROM '@abc'";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+    assert!(matches!(result.unwrap(), vibesql_ast::Statement::Select(_)));
+}
+
+#[test]
+fn test_bare_single_quoted_string_stays_a_literal() {
+    // A single-quoted string NOT followed by `.` must remain a string literal,
+    // never be reinterpreted as a column reference.
+    let sql = "SELECT '!pqr'";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Select(select) => {
+            let e = match &select.select_list[0] {
+                vibesql_ast::SelectItem::Expression { expr, .. } => expr,
+                other => panic!("Expected expression projection, got: {:?}", other),
+            };
+            assert!(
+                matches!(e, vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Varchar(_))),
+                "Expected string literal, got: {:?}",
+                e
+            );
+        }
+        other => panic!("Expected Select, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_update_set_single_quoted_column() {
+    // quote-1.4: UPDATE '@abc' SET '#xyz'=11
+    let sql = "UPDATE '@abc' SET '#xyz'=11";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::Update(stmt) => {
+            assert_eq!(stmt.assignments[0].column, "#xyz");
+        }
+        other => panic!("Expected Update, got: {:?}", other),
+    }
+}
+
+// --- Constraint names: string literal and double-quoted (item 4) ---
+
+#[test]
+fn test_column_constraint_string_name() {
+    let sql = "CREATE TABLE t ( x INTEGER CONSTRAINT 'c1' NOT NULL )";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::CreateTable(stmt) => {
+            let c = &stmt.columns[0].constraints[0];
+            assert_eq!(c.name.as_deref(), Some("c1"));
+        }
+        other => panic!("Expected CreateTable, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_column_constraint_double_quoted_name() {
+    let sql = "CREATE TABLE t ( x INTEGER CONSTRAINT \"c1\" NOT NULL )";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::CreateTable(stmt) => {
+            let c = &stmt.columns[0].constraints[0];
+            assert_eq!(c.name.as_deref(), Some("c1"));
+        }
+        other => panic!("Expected CreateTable, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_table_constraint_string_name() {
+    let sql = "CREATE TABLE t ( x, CONSTRAINT 'ck' CHECK (x > 0) )";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::CreateTable(stmt) => {
+            assert_eq!(stmt.table_constraints[0].name.as_deref(), Some("ck"));
+        }
+        other => panic!("Expected CreateTable, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_table_constraint_double_quoted_name() {
+    let sql = "CREATE TABLE t ( x, CONSTRAINT \"ck\" CHECK (x > 0) )";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+    match result.unwrap() {
+        vibesql_ast::Statement::CreateTable(stmt) => {
+            assert_eq!(stmt.table_constraints[0].name.as_deref(), Some("ck"));
+        }
+        other => panic!("Expected CreateTable, got: {:?}", other),
+    }
+}
+
+// --- IS TRUE/FALSE with a trailing COLLATE postfix (item 6) ---
+
+fn parse_single_select_expr(sql: &str) -> vibesql_ast::Expression {
+    match Parser::parse_sql(sql).expect("parse ok") {
+        vibesql_ast::Statement::Select(select) => match &select.select_list[0] {
+            vibesql_ast::SelectItem::Expression { expr, .. } => expr.clone(),
+            other => panic!("Expected expression projection, got: {:?}", other),
+        },
+        other => panic!("Expected Select, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_is_true_collate_parses_as_truth_value() {
+    // istrue-710: `0.5 IS TRUE COLLATE NOCASE` == `0.5 IS TRUE` (COLLATE on the
+    // boolean operand is a no-op for the truth-value predicate). It must parse
+    // (not error) and produce IsTruthValue(TRUE), not an equality comparison.
+    let expr = parse_single_select_expr("SELECT 0.5 IS TRUE COLLATE NOCASE");
+    match expr {
+        vibesql_ast::Expression::IsTruthValue { truth_value, negated, .. } => {
+            assert_eq!(truth_value, vibesql_ast::TruthValue::True);
+            assert!(!negated);
+        }
+        other => panic!("Expected IsTruthValue(True), got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_is_false_collate_parses_as_truth_value() {
+    let expr = parse_single_select_expr("SELECT 0.0 IS FALSE COLLATE RTRIM");
+    match expr {
+        vibesql_ast::Expression::IsTruthValue { truth_value, negated, .. } => {
+            assert_eq!(truth_value, vibesql_ast::TruthValue::False);
+            assert!(!negated);
+        }
+        other => panic!("Expected IsTruthValue(False), got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_is_not_true_collate_parses_as_negated_truth_value() {
+    let expr = parse_single_select_expr("SELECT 1 IS NOT TRUE COLLATE BINARY");
+    match expr {
+        vibesql_ast::Expression::IsTruthValue { truth_value, negated, .. } => {
+            assert_eq!(truth_value, vibesql_ast::TruthValue::True);
+            assert!(negated);
+        }
+        other => panic!("Expected IsTruthValue(True, negated), got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_is_column_collate_still_a_comparison() {
+    // COLLATE on a non-literal right operand must be preserved as an ordinary
+    // NULL-safe comparison (IsDistinctFrom), not folded into a truth predicate.
+    let expr = parse_single_select_expr("SELECT a IS b COLLATE NOCASE FROM t");
+    assert!(
+        matches!(expr, vibesql_ast::Expression::IsDistinctFrom { .. }),
+        "Expected IsDistinctFrom, got: {:?}",
+        expr
+    );
+}


### PR DESCRIPTION
## Summary

Recovers the remaining parser acceptance gaps from the #5841 batch that PR #5908 left open. Per the issue's sweep note (2026-07-05), #5908 already landed Tier 1 + Tier 2 + the numeric tokenizer (items 1, 2, 3, 5, 7 and the TRUE/FALSE/CTE/DROP-TRIGGER parts of item 4). This PR takes the two flagged-as-remaining pieces:

- **Single-quoted strings as identifiers in DDL/DML name positions** and **string / double-quoted constraint names** (item 4 remainder, quote.test).
- **COLLATE postfix after `IS TRUE/FALSE`** (item 6, istrue.test istrue-710).

Each item was verified against `sqlite3` 3.51.0 before implementing.

## Changes

- **CREATE TABLE column names**: a single-quoted string is accepted as a column name in a column-definition position (`CREATE TABLE '@abc'('#xyz' int, '!pqr' text)`).
- **Qualified names with quoted parts**: `'tbl'.'col'` now parses as a column reference. `parse_literal` defers a string immediately followed by `.` to the identifier path; a bare string with no following `.` stays a string literal. Second/third qualified-name parts also accept string parts.
- **UPDATE ... SET**: a single-quoted string is accepted as the assigned column name (`UPDATE '@abc' SET '#xyz'=11`) — unambiguous since it is followed by `=`.
- **Constraint names**: both column- and table-constraint `CONSTRAINT <name>` positions accept `Token::Identifier`, `Token::DelimitedIdentifier` (double-quoted), and `Token::String` (single-quoted).
- **`IS TRUE/FALSE/NULL COLLATE <name>`**: now parses (previously errored) and produces the specialized `IsTruthValue` / `IsNull` AST. The COLLATE postfix on the literal operand is a no-op for the truth/null test (SQLite: `0.5 IS TRUE COLLATE NOCASE` -> 1). A COLLATE on a non-literal right operand is still preserved as an ordinary NULL-safe comparison (`IsDistinctFrom`).

The arena parser has no `Collate` variant, so COLLATE expressions always fall back to the classic parser — no arena change was needed for item 6. The classic parser is the unit under test for all new tests.

## Acceptance Criteria Verification

| Criterion (from issue) | Status | Verification |
|---|---|---|
| Single-quoted strings as identifiers in DDL contexts (quote.test) | ✅ | quote.test 2 -> 15 passing; all quote-1.x recovered |
| String-literal constraint names (`CONSTRAINT 'name'`) | ✅ | Unit tests + verified vs sqlite3 |
| COLLATE postfix unparseable after IS TRUE (item 6) | ✅ | istrue-710 recovers; `0.5 IS TRUE COLLATE NOCASE` -> 1 (was syntax error) |
| Verify each item against sqlite3 first | ✅ | Checked against sqlite3 3.51.0 |
| Add parser tests per item | ✅ | New `quoted_identifiers.rs` (12 tests) |

## Deferred (still "Part of #5841", not closed)

- **Double-quote -> string-literal fallback (`SQLITE_DBCONFIG_DQS_DDL`)**: quote.test 2.x / 3.x require the per-connection DQS config and its specific `no such column: "X" - should this be a string literal in single-quotes?` error text plus ALTER-DROP-COLUMN index-rebuild diagnostics. The curator flagged this as needing separate investigation; it is a substantial standalone feature, not a parser tweak.
- **istrue.test 600.x / 800-850**: TRUE/FALSE-as-column-name and `false.false` no-such-column error-message specifics — these belong to already-landed item-4 work and error-message shaping, outside this PR's scope.

## Test Plan

- `cargo test -p vibesql-parser` — 1740 passed, 0 failed (includes 12 new tests in `quoted_identifiers.rs`).
- `make test-tcl-file FILE=quote.test` — 15/29 (all quote-1.x recovered; remaining are DQS_DDL feature).
- `make test-tcl-file FILE=istrue.test` — istrue-710 recovered; remaining failures are pre-existing out-of-scope cases.
- Regression: `select1.test` 188/188, `expr.test` 0 failed, `where.test` 0 failed.

Part of #5841