### PR TITLE
fix(ctas,views): SQLite-faithful CTAS sqlite_master.sql + duplicate view-column :N suffixes

### DIFF
--- a/crates/vibesql-executor/src/advanced_objects/views.rs
+++ b/crates/vibesql-executor/src/advanced_objects/views.rs
@@ -40,52 +40,60 @@ pub fn execute_create_view(stmt: &CreateViewStmt, db: &mut Database) -> Result<(
     let columns = if stmt.columns.is_some() {
         stmt.columns.clone()
     } else {
-        let body_is_expensive =
-            crate::select::view_reference_guard::max_view_reference_count(&stmt.query, db)
-                > STATIC_COLUMN_DERIVATION_THRESHOLD;
+        let derived = {
+            let body_is_expensive =
+                crate::select::view_reference_guard::max_view_reference_count(&stmt.query, db)
+                    > STATIC_COLUMN_DERIVATION_THRESHOLD;
 
-        // Static fast path for expensive bodies only (avoids exponential
-        // re-materialization of deep view nests).
-        let static_cols = if body_is_expensive {
-            crate::select::cte::try_static_select_columns(&stmt.query, db)
-        } else {
-            None
-        };
+            // Static fast path for expensive bodies only (avoids exponential
+            // re-materialization of deep view nests).
+            let static_cols = if body_is_expensive {
+                crate::select::cte::try_static_select_columns(&stmt.query, db)
+            } else {
+                None
+            };
 
-        if let Some(cols) = static_cols {
-            Some(cols)
-        } else {
-            // Execute the query once to derive column names.
-            //
-            // SQLite-compatible error prefixing: in SQLite the "error in view <name>: "
-            // prefix is exclusively an ALTER-time schema-reparse phenomenon (alter.c);
-            // query-time view expansion errors are bare. VibeSQL compiles views eagerly,
-            // so both error classes surface here at CREATE VIEW time. We allow-list the
-            // prefix to OrderByTermNotInResultSet only — the sole class the TCL suite
-            // expects prefixed (window1.test 32.10, altertab.test). All other variants
-            // (notably SetOperationColumnMismatch, see select7.test 8.2) pass through
-            // bare, matching SQLite's query-time messages.
-            use crate::select::SelectExecutor;
-            let executor = SelectExecutor::new(db);
-            match executor.execute_with_simple_columns(&stmt.query) {
-                Ok(result) => Some(result.columns),
-                Err(e @ ExecutorError::OrderByTermNotInResultSet { .. }) => {
-                    return Err(ExecutorError::SqliteCompatError(format!(
-                        "error in view {}: {}",
-                        stmt.view_name, e
-                    )));
+            if let Some(cols) = static_cols {
+                Some(cols)
+            } else {
+                // Execute the query once to derive column names.
+                //
+                // SQLite-compatible error prefixing: in SQLite the "error in view <name>: "
+                // prefix is exclusively an ALTER-time schema-reparse phenomenon (alter.c);
+                // query-time view expansion errors are bare. VibeSQL compiles views eagerly,
+                // so both error classes surface here at CREATE VIEW time. We allow-list the
+                // prefix to OrderByTermNotInResultSet only — the sole class the TCL suite
+                // expects prefixed (window1.test 32.10, altertab.test). All other variants
+                // (notably SetOperationColumnMismatch, see select7.test 8.2) pass through
+                // bare, matching SQLite's query-time messages.
+                use crate::select::SelectExecutor;
+                let executor = SelectExecutor::new(db);
+                match executor.execute_with_simple_columns(&stmt.query) {
+                    Ok(result) => Some(result.columns),
+                    Err(e @ ExecutorError::OrderByTermNotInResultSet { .. }) => {
+                        return Err(ExecutorError::SqliteCompatError(format!(
+                            "error in view {}: {}",
+                            stmt.view_name, e
+                        )));
+                    }
+                    // Lax view creation (SQLite semantics, issue #5795 /
+                    // alterdropcol.test 5.2.1): a view whose SELECT names a column
+                    // that does not (yet) resolve is still created — SQLite defers
+                    // column resolution to query time. The view is stored with no
+                    // derived column list; querying it re-runs the SELECT and
+                    // surfaces the resolution error then, and ALTER-time schema
+                    // re-parses report it as `error in view <name>: ...`.
+                    Err(ExecutorError::ColumnNotFound { .. }) => None,
+                    Err(other) => return Err(other),
                 }
-                // Lax view creation (SQLite semantics, issue #5795 /
-                // alterdropcol.test 5.2.1): a view whose SELECT names a column
-                // that does not (yet) resolve is still created — SQLite defers
-                // column resolution to query time. The view is stored with no
-                // derived column list; querying it re-runs the SELECT and
-                // surfaces the resolution error then, and ALTER-time schema
-                // re-parses report it as `error in view <name>: ...`.
-                Err(ExecutorError::ColumnNotFound { .. }) => None,
-                Err(other) => return Err(other),
             }
-        }
+        };
+        // SQLite disambiguates duplicate *derived* view-column names by
+        // appending `:1`, `:2`, ... in order of appearance (colname.test
+        // 2.8/2.9). This dedup lives here, at view-column derivation, so a plain
+        // multi-table `SELECT *` (colname-3.7) keeps its unsuffixed duplicate
+        // names — only a view's stored column list is disambiguated.
+        derived.map(dedup_view_column_names)
     };
 
     // Tag temp views with the `temp` schema so they surface via
@@ -124,6 +132,60 @@ pub fn execute_create_view(stmt: &CreateViewStmt, db: &mut Database) -> Result<(
     Ok(())
 }
 
+/// Disambiguate duplicate column names in a view's derived column list by
+/// appending `:1`, `:2`, ... — SQLite's `sqlite3ColumnsFromExprList` algorithm
+/// (see colname.test 2.8/2.9).
+///
+/// The first occurrence of a name is kept verbatim; every later collision (case
+/// insensitive, matching SQLite's case-insensitive name hash) gets the lowest
+/// `:N` suffix that is not already taken. If a name already ends in `:<digits>`
+/// that suffix is stripped before a fresh counter is applied, so the generated
+/// names stay stable and re-collision-free.
+fn dedup_view_column_names(cols: Vec<String>) -> Vec<String> {
+    use std::collections::HashSet;
+
+    let mut used: HashSet<String> = HashSet::with_capacity(cols.len());
+    let mut out = Vec::with_capacity(cols.len());
+
+    for name in cols {
+        let mut candidate = name;
+        if used.contains(&candidate.to_lowercase()) {
+            let base = strip_colon_digits(&candidate).to_string();
+            let mut cnt: u32 = 0;
+            loop {
+                cnt += 1;
+                candidate = format!("{}:{}", base, cnt);
+                if !used.contains(&candidate.to_lowercase()) {
+                    break;
+                }
+            }
+        }
+        used.insert(candidate.to_lowercase());
+        out.push(candidate);
+    }
+
+    out
+}
+
+/// Strip a trailing `:<digits>` suffix from `name` (matching SQLite's base-name
+/// recovery in the dedup loop). Returns `name` unchanged when there is no such
+/// suffix or the `:` would be the first character.
+fn strip_colon_digits(name: &str) -> &str {
+    let bytes = name.as_bytes();
+    if bytes.is_empty() {
+        return name;
+    }
+    let mut j = bytes.len() - 1;
+    while j > 0 && bytes[j].is_ascii_digit() {
+        j -= 1;
+    }
+    if j > 0 && bytes[j] == b':' {
+        &name[..j]
+    } else {
+        name
+    }
+}
+
 /// Execute DROP VIEW statement
 pub fn execute_drop_view(stmt: &DropViewStmt, db: &mut Database) -> Result<(), ExecutorError> {
     // Check if view exists
@@ -159,4 +221,72 @@ pub fn execute_drop_view(stmt: &DropViewStmt, db: &mut Database) -> Result<(), E
     // `Catalog::drop_view_triggers` (view analogue of the table path in #5597).
     db.catalog.drop_view_triggers(&stmt.view_name, view_is_temp);
     Ok(())
+}
+
+#[cfg(test)]
+mod dedup_tests {
+    use super::{dedup_view_column_names, strip_colon_digits};
+
+    fn dedup(names: &[&str]) -> Vec<String> {
+        dedup_view_column_names(names.iter().map(|s| s.to_string()).collect())
+    }
+
+    #[test]
+    fn colname_2_8_view_v1() {
+        // SELECT tabc.a, txyz.x, * FROM tabc, txyz  → a,x,a,b,c,x,y,z
+        assert_eq!(
+            dedup(&["a", "x", "a", "b", "c", "x", "y", "z"]),
+            vec!["a", "x", "a:1", "b", "c", "x:1", "y", "z"]
+        );
+    }
+
+    #[test]
+    fn colname_2_9_view_v2() {
+        // a,x,a,x,a,b,c,x,y,z,a,b,c,x,y,z
+        assert_eq!(
+            dedup(&[
+                "a", "x", "a", "x", "a", "b", "c", "x", "y", "z", "a", "b", "c", "x", "y", "z"
+            ]),
+            vec![
+                "a", "x", "a:1", "x:1", "a:2", "b", "c", "x:2", "y", "z", "a:3", "b:1", "c:1",
+                "x:3", "y:1", "z:1"
+            ]
+        );
+    }
+
+    #[test]
+    fn no_duplicates_unchanged() {
+        assert_eq!(dedup(&["a", "b", "c"]), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn case_insensitive_collision() {
+        // SQLite's name hash is case-insensitive: A collides with a.
+        assert_eq!(dedup(&["a", "A"]), vec!["a", "A:1"]);
+    }
+
+    #[test]
+    fn non_colliding_colon_suffix_is_left_alone() {
+        // "x:1" does not collide with "x" (names must match exactly), so it is
+        // kept verbatim. Verified against sqlite3.
+        assert_eq!(dedup(&["x", "x:1"]), vec!["x", "x:1"]);
+    }
+
+    #[test]
+    fn existing_colon_suffix_is_stripped_before_recounting() {
+        // Two source columns literally named "x:1" collide; the second re-bases
+        // on "x" and skips the taken "x:1" to land on "x:2". Verified against
+        // sqlite3.
+        assert_eq!(dedup(&["x:1", "x:1"]), vec!["x:1", "x:2"]);
+    }
+
+    #[test]
+    fn strip_colon_digits_cases() {
+        assert_eq!(strip_colon_digits("x"), "x");
+        assert_eq!(strip_colon_digits("x:1"), "x");
+        assert_eq!(strip_colon_digits("x:12"), "x");
+        assert_eq!(strip_colon_digits("abc"), "abc");
+        assert_eq!(strip_colon_digits(":1"), ":1"); // colon at start not stripped
+        assert_eq!(strip_colon_digits(""), "");
+    }
 }

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -3,7 +3,7 @@
 use vibesql_ast::{CreateTableStmt, IndexColumn, OrderDirection};
 use vibesql_catalog::{ColumnSchema, TableIdentifier, TableSchema};
 use vibesql_storage::Database;
-use vibesql_types::DataType;
+use vibesql_types::{DataType, TypeAffinity};
 
 use crate::{
     constraint_validator::ConstraintValidator, errors::ExecutorError,
@@ -359,8 +359,7 @@ impl CreateTableExecutor {
         // — before the table is inserted into the catalog — so an invalid STRICT
         // CREATE never leaves a half-formed table behind.
         if stmt.strict {
-            let strict_types =
-                crate::strict::classify_strict_columns(&table_name, &stmt.columns)?;
+            let strict_types = crate::strict::classify_strict_columns(&table_name, &stmt.columns)?;
             table_schema.strict = true;
             table_schema.strict_types = strict_types;
         }
@@ -815,15 +814,19 @@ impl CreateTableExecutor {
         // Execute the SELECT query to get results
         let rows = SelectExecutor::new(database).execute(query)?;
 
-        // Derive column names from the SELECT list (expanding wildcards if needed)
-        let column_names =
-            Self::derive_column_names_from_select_list(&query.select_list, &query.from, database)?;
+        // Derive column names + SQLite type affinities from the SELECT list
+        // (expanding wildcards if needed). The affinity is taken from the source
+        // column for a direct column reference and is BLOB/None for any other
+        // expression (function, arithmetic, literal, ...). This mirrors how
+        // SQLite stamps the generated `sqlite_master.sql` for CREATE TABLE AS
+        // SELECT.
+        let column_info = Self::derive_ctas_columns(&query.select_list, &query.from, database)?;
 
         // Derive column schema from the first row (if any) or default to BLOB
-        let columns: Vec<ColumnSchema> = column_names
+        let columns: Vec<ColumnSchema> = column_info
             .iter()
             .enumerate()
-            .map(|(idx, col_name)| {
+            .map(|(idx, (col_name, _affinity))| {
                 // Try to infer data type from the first row if available
                 let data_type = if !rows.is_empty() && idx < rows[0].values.len() {
                     Self::infer_data_type(&rows[0].values[idx])
@@ -844,8 +847,13 @@ impl CreateTableExecutor {
             })
             .collect();
 
-        // Create the table schema
-        let table_schema = TableSchema::new(table_name.to_string(), columns);
+        // Create the table schema, stamping the SQLite-faithful
+        // `sqlite_master.sql` text. Without this the schema falls back to the
+        // auto-generated form which emits unquoted, un-reparseable identifiers
+        // (e.g. keyword or apostrophe-bearing column names) and inferred, rather
+        // than affinity-derived, type codes.
+        let mut table_schema = TableSchema::new(table_name.to_string(), columns);
+        table_schema.set_sql_source(Self::generate_ctas_sql_source(table_name, &column_info));
 
         // Create the table
         database
@@ -866,13 +874,19 @@ impl CreateTableExecutor {
         ))
     }
 
-    /// Derive column names from a SELECT list, expanding wildcards using the database schema
-    fn derive_column_names_from_select_list(
+    /// Derive `(column name, SQLite type affinity)` pairs from a CTAS SELECT
+    /// list, expanding wildcards using the database schema.
+    ///
+    /// The affinity drives the type code emitted into `sqlite_master.sql`:
+    /// a direct column reference (including a wildcard-expanded one) carries the
+    /// source column's affinity; every other expression carries BLOB/None
+    /// affinity (SQLite emits no type at all for non-column expressions).
+    fn derive_ctas_columns(
         select_list: &[vibesql_ast::SelectItem],
         from: &Option<vibesql_ast::FromClause>,
         database: &Database,
-    ) -> Result<Vec<String>, ExecutorError> {
-        let mut names = Vec::new();
+    ) -> Result<Vec<(String, TypeAffinity)>, ExecutorError> {
+        let mut columns = Vec::new();
         let mut counter = 0;
 
         for item in select_list {
@@ -883,7 +897,7 @@ impl CreateTableExecutor {
                     for table_name in table_names {
                         if let Some(schema) = database.catalog.get_table(&table_name) {
                             for col in &schema.columns {
-                                names.push(col.name.clone());
+                                columns.push((col.name.clone(), col.data_type.sqlite_affinity()));
                             }
                         } else {
                             return Err(ExecutorError::TableNotFound(table_name));
@@ -894,7 +908,7 @@ impl CreateTableExecutor {
                     // Expand table.* using the specific table's schema
                     if let Some(schema) = database.catalog.get_table(qualifier) {
                         for col in &schema.columns {
-                            names.push(col.name.clone());
+                            columns.push((col.name.clone(), col.data_type.sqlite_affinity()));
                         }
                     } else {
                         return Err(ExecutorError::TableNotFound(qualifier.clone()));
@@ -910,12 +924,122 @@ impl CreateTableExecutor {
                         // (e.g. `max(b+c)`, `b+c`) rather than `column1`.
                         Self::derive_column_name_from_expr(expr, source_text, &mut counter)
                     };
-                    names.push(name);
+                    let affinity = Self::resolve_ctas_affinity(expr, from, database);
+                    columns.push((name, affinity));
                 }
             }
         }
 
-        Ok(names)
+        Ok(columns)
+    }
+
+    /// Determine the SQLite type affinity a CTAS result column inherits.
+    ///
+    /// Only a bare column reference (optionally aliased) inherits its source
+    /// column's affinity; SQLite assigns no declared type — hence BLOB/None
+    /// affinity — to any other expression. When the reference cannot be resolved
+    /// (unknown table/alias, computed source) we also fall back to None.
+    fn resolve_ctas_affinity(
+        expr: &vibesql_ast::Expression,
+        from: &Option<vibesql_ast::FromClause>,
+        database: &Database,
+    ) -> TypeAffinity {
+        let vibesql_ast::Expression::ColumnRef(col_id) = expr else {
+            return TypeAffinity::None;
+        };
+        let column = col_id.column_canonical();
+
+        let table_names = Self::get_table_names_from_from(from).unwrap_or_default();
+        // Prefer the qualifier's table when present, but fall back to a scan of
+        // every FROM table (handles table aliases, which the qualifier names but
+        // the catalog does not).
+        for table_name in &table_names {
+            if let Some(schema) = database.catalog.get_table(table_name) {
+                if let Some(col) = schema.columns.iter().find(|c| c.name == column) {
+                    return col.data_type.sqlite_affinity();
+                }
+            }
+        }
+        TypeAffinity::None
+    }
+
+    /// Build the `sqlite_master.sql` text for a CREATE TABLE ... AS SELECT,
+    /// replicating SQLite's `createTableStmt`: identifiers are double-quoted
+    /// only when required, each column carries an affinity-derived type code
+    /// (`""`/`TEXT`/`NUM`/`INT`/`REAL`), and the layout is compact or pretty
+    /// depending on a length heuristic.
+    fn generate_ctas_sql_source(table_name: &str, columns: &[(String, TypeAffinity)]) -> String {
+        // Length heuristic (SQLite: n<50 → single line, else one column per
+        // line). `ctas_ident_length` matches SQLite's `identLength`, which
+        // always budgets for surrounding quotes plus any doubled `"`.
+        let mut n = 0usize;
+        for (name, _) in columns {
+            n += Self::ctas_ident_length(name) + 5;
+        }
+        n += Self::ctas_ident_length(table_name);
+        let (sep_first, sep_rest, end) =
+            if n < 50 { ("", ",", ")") } else { ("\n  ", ",\n  ", "\n)") };
+
+        let mut sql = String::from("CREATE TABLE ");
+        Self::ctas_ident_put(&mut sql, table_name);
+        sql.push('(');
+        for (i, (name, affinity)) in columns.iter().enumerate() {
+            sql.push_str(if i == 0 { sep_first } else { sep_rest });
+            Self::ctas_ident_put(&mut sql, name);
+            sql.push_str(Self::ctas_affinity_type(*affinity));
+        }
+        sql.push_str(end);
+        sql
+    }
+
+    /// SQLite `azType[]`: the type token (with its leading space) emitted for a
+    /// CTAS column of the given affinity. BLOB/None emits no type.
+    fn ctas_affinity_type(affinity: TypeAffinity) -> &'static str {
+        match affinity {
+            TypeAffinity::None => "",
+            TypeAffinity::Text => " TEXT",
+            TypeAffinity::Numeric => " NUM",
+            TypeAffinity::Integer => " INT",
+            TypeAffinity::Real => " REAL",
+        }
+    }
+
+    /// SQLite `identLength`: char count + one per embedded `"` (doubled on
+    /// output) + 2 for the surrounding quotes (always budgeted).
+    fn ctas_ident_length(name: &str) -> usize {
+        name.chars().count() + name.chars().filter(|c| *c == '"').count() + 2
+    }
+
+    /// SQLite `identPut`: append `name`, double-quoting it only when required —
+    /// empty, starts with a digit, contains a non alphanumeric/underscore
+    /// character, or is a reserved keyword.
+    fn ctas_ident_put(out: &mut String, name: &str) {
+        if Self::ctas_needs_quote(name) {
+            out.push('"');
+            for c in name.chars() {
+                out.push(c);
+                if c == '"' {
+                    out.push('"');
+                }
+            }
+            out.push('"');
+        } else {
+            out.push_str(name);
+        }
+    }
+
+    /// Whether `name` must be double-quoted to survive a re-parse as an
+    /// identifier (see `ctas_ident_put`).
+    fn ctas_needs_quote(name: &str) -> bool {
+        match name.chars().next() {
+            None => return true,
+            Some(c) if c.is_ascii_digit() => return true,
+            Some(_) => {}
+        }
+        if name.chars().any(|c| !(c.is_ascii_alphanumeric() || c == '_')) {
+            return true;
+        }
+        vibesql_parser::is_keyword(name)
     }
 
     /// Extract table names from a FROM clause
@@ -1023,5 +1147,88 @@ impl CreateTableExecutor {
             SqlValue::Vector(v) => DataType::Vector { dimensions: v.len() as u32 },
             SqlValue::Blob(_) => DataType::BinaryLargeObject,
         }
+    }
+}
+
+#[cfg(test)]
+mod ctas_sql_source_tests {
+    use super::CreateTableExecutor as E;
+    use vibesql_types::TypeAffinity::{Integer, None as Blob, Numeric, Real, Text};
+
+    fn col(name: &str, aff: vibesql_types::TypeAffinity) -> (String, vibesql_types::TypeAffinity) {
+        (name.to_string(), aff)
+    }
+
+    #[test]
+    fn compact_layout_matches_sqlite() {
+        // Short schema (n < 50) → single line, no spaces after commas, affinity
+        // type codes, BLOB affinity emits no type. Verified against sqlite3.
+        let cols = vec![
+            col("a", Integer),
+            col("b", Text),
+            col("c", Real),
+            col("d", Blob),
+            col("e", Numeric),
+        ];
+        assert_eq!(
+            E::generate_ctas_sql_source("t2s", &cols),
+            "CREATE TABLE t2s(a INT,b TEXT,c REAL,d,e NUM)"
+        );
+    }
+
+    #[test]
+    fn pretty_layout_quotes_keywords_and_digits() {
+        // Long schema (n >= 50) → one column per line, keyword/digit-leading
+        // identifiers double-quoted. Matches sqlite3 table-8.1.1.
+        let cols = vec![
+            col("desc", Text),
+            col("asc", Text),
+            col("key", Integer),
+            col("14_vac", Numeric),
+            col("fuzzy_dog_12", Text),
+            col("begin", Blob),
+            col("end", Text),
+        ];
+        let expected = "CREATE TABLE t2(\n  \"desc\" TEXT,\n  \"asc\" TEXT,\n  \"key\" INT,\n  \"14_vac\" NUM,\n  fuzzy_dog_12 TEXT,\n  \"begin\",\n  \"end\" TEXT\n)";
+        assert_eq!(E::generate_ctas_sql_source("t2", &cols), expected);
+    }
+
+    #[test]
+    fn quotes_table_name_and_expression_columns() {
+        // Embedded double-quote in the table name is doubled; an expression
+        // column name with special chars is quoted and carries no type.
+        // Matches sqlite3 table-8.3.1.
+        let cols = vec![col("cnt", Blob), col("max(b+c)", Blob)];
+        assert_eq!(
+            E::generate_ctas_sql_source("t4\"abc", &cols),
+            "CREATE TABLE \"t4\"\"abc\"(cnt,\"max(b+c)\")"
+        );
+    }
+
+    #[test]
+    fn apostrophe_alias_is_quoted_not_dropped() {
+        // Apostrophe-bearing alias must round-trip as a double-quoted
+        // identifier (data-loss-adjacent regression guard).
+        let cols = vec![col("it's", Integer)];
+        assert_eq!(E::generate_ctas_sql_source("t5", &cols), "CREATE TABLE t5(\"it's\" INT)");
+    }
+
+    #[test]
+    fn dotted_column_name_is_quoted() {
+        // A `.` forces quoting; single short column stays compact. table-8.9.
+        let cols = vec![col("col.1", Text)];
+        assert_eq!(E::generate_ctas_sql_source("t11", &cols), "CREATE TABLE t11(\"col.1\" TEXT)");
+    }
+
+    #[test]
+    fn needs_quote_rules() {
+        assert!(!E::ctas_needs_quote("fuzzy_dog_12"));
+        assert!(!E::ctas_needs_quote("_x"));
+        assert!(E::ctas_needs_quote("key")); // keyword
+        assert!(E::ctas_needs_quote("desc")); // keyword
+        assert!(E::ctas_needs_quote("14_vac")); // leading digit
+        assert!(E::ctas_needs_quote("col.1")); // dot
+        assert!(E::ctas_needs_quote("it's")); // apostrophe
+        assert!(E::ctas_needs_quote("")); // empty
     }
 }


### PR DESCRIPTION
## Summary

Closes two of the remaining sub-items in the #5842 small-batch (items 1, 3b, and 4 were already merged in #5912). Both fixes are verified byte-for-byte against `sqlite3` 3.51.0.

**Item 2 — CTAS `sqlite_master.sql` fidelity.** `CREATE TABLE ... AS SELECT` previously stored no verbatim SQL, so `SELECT sql FROM sqlite_master` fell back to an auto-generated form that emitted **unquoted, un-reparseable identifiers** (keyword/apostrophe/digit-leading column names) and value-inferred, mostly-`BLOB` type codes. It now stamps a `sqlite_master.sql` string built exactly the way SQLite's `createTableStmt` does.

**Item 3a — duplicate view-column `:N` suffixes.** A view whose derived column list has duplicate names now disambiguates them with `:1`, `:2`, ... in order of appearance (SQLite's `sqlite3ColumnsFromExprList`). The dedup lives in view-column derivation **only**, so a plain multi-table `SELECT *` keeps its unsuffixed duplicate columns.

## Changes

- `crates/vibesql-executor/src/create_table.rs`
  - CTAS derives `(name, affinity)` per column: a direct column reference inherits its source column's SQLite affinity; every other expression gets BLOB/None (no type), matching SQLite.
  - New `generate_ctas_sql_source` replicates `createTableStmt`: `identLength`/`identPut` quoting (double-quote only when required — keyword, digit-leading, special char, apostrophe; embedded `"` doubled), affinity type codes (`""`/`TEXT`/`NUM`/`INT`/`REAL`), and the `n<50` compact-vs-pretty layout heuristic. Stamped via `set_sql_source`.
- `crates/vibesql-executor/src/advanced_objects/views.rs`
  - New `dedup_view_column_names` (+ `strip_colon_digits`) applied to the derived view column list; explicit `CREATE VIEW v(...)` column lists and plain SELECTs are untouched.
- Unit tests for both (CTAS layout/quoting/apostrophe, dedup ordering/case-insensitivity/colon-suffix rebasing).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| minmax3 §4 passes | ✅ | Already fixed in #5912; re-confirmed `minmax3.test` 0 failed |
| CTAS cases in table.test pass | ✅ | table-8.1.1, 8.3.1, 8.9, 8.10, 12.2 now pass (table.test 67→72 passed); each output diffed against sqlite3 3.51.0 |
| colname.test attributable failures pass | ✅ | colname-2.8/2.9 (+ dependent 3.8-3.11) now pass; colname-3.7 (plain-select regression guard) still passes |
| Apostrophe alias not data-loss | ✅ | `CREATE TABLE t5 AS SELECT a AS 'it''s'` → `CREATE TABLE t5("it's" INT)`, matches sqlite3, row preserved |

## Test Plan

- `cargo test -p vibesql-executor` — all pass (157 test binaries, incl. new unit tests), no regressions.
- `make test-tcl-file FILE=table.test` — 72 passed / 10 failed (was 67/15); all 5 CTAS failures fixed. Remaining failures are out of scope: 8.4/8.7/8.8 (TEMP tables), 10.9-10.13 (FK arity validation), 14.2 (locking), 18.1 (zeroblob size).
- `make test-tcl-file FILE=colname.test` — the `:N` view cases fixed; `SELECT *`-across-tables (3.7) unaffected.
- Manual diff of every CTAS/view output above against `sqlite3` 3.51.0.

## Deferred (why "Part of", not "Closes")

Item 3c — the `full_column_names` / `short_column_names` pragma table-prefix behavior (colname section 4: `v1.a`, `v1.x`, ...) — remains unimplemented. The curator's analysis explicitly scoped this as a follow-on ("fix only the failures attributable to the `:N` suffix and alias-case gaps; `full_column_names` edge cases are a follow-on"). Those colname section-4/7/9/10 failures are not addressed here.

Part of #5842