### PR TITLE
fix(triggers): interleave REPLACE conflict deletes and preserve BEFORE-UPDATE same-row writes

### DIFF
--- a/crates/vibesql-executor/src/insert/replace.rs
+++ b/crates/vibesql-executor/src/insert/replace.rs
@@ -174,42 +174,130 @@ pub fn handle_replace_conflicts(
         .is_some()
         && db.recursive_triggers();
 
-    // Fire BEFORE DELETE triggers for each conflicting row
-    // This must happen BEFORE actual deletion (SQLite semantics)
-    // The reserved rowid is active during this phase, so trigger INSERTs that try
-    // to allocate the same rowid will fail.
+    // When DELETE triggers fire, SQLite processes the conflicting rows one at a
+    // time and INTERLEAVED: for each conflict row R it runs BEFORE DELETE on R,
+    // physically removes R, then runs AFTER DELETE on R, *before* moving to the
+    // next conflict row. A trigger body that reads the table mid-statement
+    // (e.g. `SELECT count(*) FROM t`) therefore sees the table shrink between
+    // conflict deletions — item 2b (#5840). The previous implementation fired
+    // ALL BEFORE triggers, then batch-deleted every row, then fired all AFTERs,
+    // which made every trigger body observe the same stale (pre-deletion) table
+    // state. Route the trigger case through the interleaved path below; the
+    // no-trigger case keeps the faster batch path that follows.
+    //
+    // The reserved rowid is active during this phase, so trigger INSERTs that
+    // try to allocate the same rowid will fail.
     //
     // RAISE(IGNORE) in a BEFORE DELETE trigger abandons the delete of that
-    // conflicting row (#5418). We drop the row from `rows_to_delete` so it is
-    // NOT deleted; the conflicting row then survives. Because the REPLACE
-    // caller re-validates PK/UNIQUE constraints after this function returns,
-    // a surviving conflict surfaces as a UNIQUE/PK error — matching sqlite3
-    // 3.51 with `recursive_triggers=ON`, where a BEFORE DELETE RAISE(IGNORE)
-    // during REPLACE leaves the row in place and the subsequent insert fails
-    // with "UNIQUE constraint failed".
+    // conflicting row (#5418): the row is not deleted and survives. Because the
+    // REPLACE caller re-validates PK/UNIQUE constraints after this function
+    // returns, a surviving conflict surfaces as a UNIQUE/PK error — matching
+    // sqlite3 3.51 with `recursive_triggers=ON`.
     if fire_delete_triggers {
-        let mut kept = Vec::with_capacity(rows_to_delete.len());
-        for (idx, row) in rows_to_delete {
+        // If an ancestor statement is already iterating this table (an outer
+        // interleaved DELETE/UPDATE/REPLACE loop), defer our final compaction to
+        // it so we never shift the ancestor's not-yet-processed row indices.
+        // Captured BEFORE we register our own guard below.
+        let defer_compaction = crate::compaction_guard::is_iterating(table_name);
+
+        // Defer compaction across the whole loop so each row's physical index
+        // stays valid until every conflict row is processed (mirrors the DELETE
+        // executor's interleaved path, #5486). A nested DELETE fired by a
+        // trigger body on this same table also defers compaction while the
+        // guard is live.
+        let _iter_guard = crate::compaction_guard::IterationGuard::new(table_name);
+
+        #[cfg(feature = "mvcc_enabled")]
+        let mvcc_delete_txn_id = db.transaction_id();
+
+        let mut any_deleted = false;
+        for (idx, row) in &rows_to_delete {
+            // BEFORE(R): a RAISE(IGNORE) abandons this row's delete.
             let outcome = TriggerFirer::execute_before_triggers(
                 db,
                 table_name,
                 vibesql_ast::TriggerEvent::Delete,
-                Some(&row),
+                Some(row),
                 None,
             )?;
-            if outcome != crate::trigger_execution::TriggerOutcome::SkipRow {
-                kept.push((idx, row));
+            if outcome == crate::trigger_execution::TriggerOutcome::SkipRow {
+                continue;
+            }
+
+            // A trigger body may have already deleted R (e.g. via a nested
+            // DELETE on this table). Skip R rather than double-deleting.
+            if db.get_table(table_name).map(|t| t.is_row_deleted(*idx)).unwrap_or(true) {
+                continue;
+            }
+
+            // WAL + index maintenance for this single row (indices are still
+            // valid: compaction is deferred to the end of the loop).
+            db.emit_wal_delete(table_name, *idx as u64, row.values.to_vec());
+            let rows_refs: Vec<(usize, &vibesql_storage::Row)> = vec![(*idx, row)];
+            db.batch_update_indexes_for_delete(table_name, &rows_refs);
+            expression_index_maintenance::maintain_expression_indexes_for_delete(
+                db, table_name, row, *idx,
+            );
+            partial_index_maintenance::maintain_partial_indexes_for_delete(
+                db, table_name, row, *idx,
+            );
+
+            // delete(R): flip the deletion bitmap for just this row so the AFTER
+            // trigger (and the next conflict row's BEFORE trigger) observes R as
+            // gone. Compaction is deferred to the end of the loop.
+            {
+                let table_mut = db
+                    .get_table_mut(table_name)
+                    .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+
+                #[cfg(feature = "mvcc_enabled")]
+                if let Some(id) = mvcc_delete_txn_id {
+                    table_mut.stamp_row_xmax_inplace(*idx, id);
+                }
+
+                if table_mut.mark_deleted_inplace(*idx) {
+                    any_deleted = true;
+                }
+            }
+
+            // Invalidate the database-level columnar cache NOW, between the
+            // bitmap delete and the AFTER trigger (#5523), so a trigger body's
+            // `SELECT count(*) FROM t` observes the live, decremented count
+            // rather than a stale pre-delete snapshot.
+            db.invalidate_columnar_cache(table_name);
+
+            // AFTER(R): the row is already deleted; a RAISE(IGNORE) cannot
+            // un-delete it, so SkipRow is a no-op.
+            let _after_outcome = TriggerFirer::execute_after_triggers(
+                db,
+                table_name,
+                vibesql_ast::TriggerEvent::Delete,
+                Some(row),
+                None,
+            )?;
+        }
+
+        // Compact once, after all conflict rows are processed (unless deferred
+        // to an ancestor interleaved loop). If it compacts, every row index
+        // changed and the indexes must be rebuilt.
+        if any_deleted && !defer_compaction {
+            if let Some(table_mut) = db.get_table_mut(table_name) {
+                if table_mut.compact_if_needed() {
+                    db.rebuild_indexes(table_name);
+                    expression_index_maintenance::rebuild_expression_indexes_after_compaction(
+                        db, table_name,
+                    );
+                    partial_index_maintenance::rebuild_partial_indexes_after_compaction(
+                        db, table_name,
+                    );
+                }
             }
         }
-        rows_to_delete = kept;
 
-        // Every conflicting row's delete was skipped by RAISE(IGNORE); there is
-        // nothing to delete. Return early so the caller's constraint
-        // re-validation runs against the still-conflicting table state.
-        if rows_to_delete.is_empty() {
-            return Ok(());
-        }
+        return Ok(());
     }
+
+    // ---- No DELETE triggers fire: fast batch-delete path ----
 
     // NOTE: The reserved rowid remains active during AFTER DELETE triggers.
     // For auto-allocated reservations: AFTER DELETE trigger INSERTs will fail on rowid conflict.
@@ -296,22 +384,10 @@ pub fn handle_replace_conflicts(
         db.invalidate_columnar_cache(table_name);
     }
 
-    // Fire AFTER DELETE triggers for each deleted row
-    // This must happen AFTER actual deletion (SQLite semantics)
-    if fire_delete_triggers {
-        for (_, row) in &rows_to_delete {
-            // AFTER DELETE fires once the row is already gone. A RAISE(IGNORE)
-            // here cannot un-delete it (sqlite3 3.51 leaves the row deleted),
-            // so SkipRow is a no-op — explicitly drop the must-use outcome.
-            let _after_outcome = TriggerFirer::execute_after_triggers(
-                db,
-                table_name,
-                vibesql_ast::TriggerEvent::Delete,
-                Some(row),
-                None,
-            )?;
-        }
-    }
+    // NOTE: No AFTER DELETE triggers fire on this batch path — it is only
+    // reached when `fire_delete_triggers` is false (no DELETE triggers, or
+    // `recursive_triggers` is OFF). The trigger-firing case is fully handled by
+    // the interleaved per-row path above, which returns before reaching here.
 
     Ok(())
 }

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -855,7 +855,7 @@ pub(super) fn execute_internal(
         // on it (fired by a row trigger below) defers compaction — compacting
         // would shift our not-yet-processed physical row indices (#5486).
         let _iter_guard = crate::compaction_guard::IterationGuard::new(table_name);
-        for u in &updates {
+        for u in &mut updates {
             // BEFORE(R): a RAISE(IGNORE) drops this row entirely.
             let before_outcome = crate::TriggerFirer::execute_before_triggers(
                 database,
@@ -880,6 +880,31 @@ pub(super) fn execute_internal(
                 .unwrap_or(true)
             {
                 continue;
+            }
+
+            // Item 3 (#5840): a BEFORE UPDATE trigger may have written to THIS
+            // same row (e.g. `UPDATE t SET c = ... WHERE id = old.id`). Those
+            // writes already landed in storage. `u.new_row` was snapshotted
+            // pre-trigger, so re-applying it verbatim would clobber the
+            // trigger's writes. SQLite instead re-reads the current row and
+            // applies only the parent statement's SET columns on top, so a
+            // trigger's write to a column the parent does NOT set survives —
+            // and is visible to AFTER triggers, RETURNING, and index
+            // maintenance (all of which consume `u.new_row` below). Merge the
+            // current stored values for every column outside
+            // `u.changed_columns` back into `u.new_row`.
+            if let Some(current) =
+                database.get_table(table_name).and_then(|t| t.get_row(u.row_index))
+            {
+                if current.values != u.old_row.values {
+                    for col_idx in 0..u.new_row.values.len() {
+                        if !u.changed_columns.contains(&col_idx) {
+                            if let Some(v) = current.values.get(col_idx) {
+                                u.new_row.values[col_idx] = v.clone();
+                            }
+                        }
+                    }
+                }
             }
 
             // apply(R): mutate just this row so the AFTER trigger (and the

--- a/crates/vibesql-executor/tests/changes_and_replace_trigger_semantics_tests.rs
+++ b/crates/vibesql-executor/tests/changes_and_replace_trigger_semantics_tests.rs
@@ -78,6 +78,18 @@ fn texts(db: &Database, sql: &str) -> Vec<String> {
         .collect()
 }
 
+/// Extract the first column of every row as an i64.
+fn ints(db: &Database, sql: &str) -> Vec<i64> {
+    query(db, sql)
+        .into_iter()
+        .map(|r| match &r[0] {
+            SqlValue::Bigint(n) => *n,
+            SqlValue::Integer(n) => *n,
+            other => panic!("expected integer, got {other:?}"),
+        })
+        .collect()
+}
+
 // ---------------------------------------------------------------------------
 // Item 2: REPLACE conflict-delete triggers gated on recursive_triggers.
 // ---------------------------------------------------------------------------
@@ -190,4 +202,128 @@ fn changes_inside_trigger_body_reflects_nested_dml_and_restores() {
     // The top-level statement's changes() is its own direct row count (1),
     // unaffected by the nested trigger DML.
     assert_eq!(db.last_changes_count(), 1, "outer INSERT changes() restored to 1");
+}
+
+// ---------------------------------------------------------------------------
+// Item 2b: a REPLACE whose single new row conflicts with MULTIPLE existing
+// rows deletes them one at a time. With recursive_triggers ON, each conflict
+// row's DELETE triggers fire interleaved (BEFORE R -> remove R -> AFTER R)
+// before the next conflict row, so a trigger body that reads the table sees
+// the row count DECREMENT between conflict deletions — it must not observe a
+// stale, frozen pre-deletion count. Verified against sqlite3 3.51.0.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn replace_multi_conflict_delete_triggers_see_decrementing_count() {
+    let mut db = Database::new();
+    db.set_recursive_triggers(true);
+    // A single inserted row (id=3) conflicts with id=1 on `a` AND id=2 on `b`,
+    // forcing two conflict deletions within one REPLACE.
+    exec(&mut db, "CREATE TABLE t(id INTEGER PRIMARY KEY, a UNIQUE, b UNIQUE)");
+    exec(&mut db, "CREATE TABLE log(cnt)");
+    exec(&mut db, "INSERT INTO t VALUES(1, 'a1', 'b1')");
+    exec(&mut db, "INSERT INTO t VALUES(2, 'a2', 'b2')");
+    exec(
+        &mut db,
+        "CREATE TRIGGER bd BEFORE DELETE ON t BEGIN \
+         INSERT INTO log VALUES((SELECT count(*) FROM t)); END",
+    );
+    exec(
+        &mut db,
+        "CREATE TRIGGER ad AFTER DELETE ON t BEGIN \
+         INSERT INTO log VALUES(-(SELECT count(*) FROM t)); END",
+    );
+
+    exec(&mut db, "INSERT OR REPLACE INTO t VALUES(3, 'a1', 'b2')");
+
+    // Interleaved: BEFORE(first)=2, AFTER(first)=1, BEFORE(second)=1,
+    // AFTER(second)=0. AFTER counts are stored negated to distinguish them.
+    // Stale-state behavior would instead log 2, -2, 2, -2 (all BEFOREs see the
+    // pre-deletion count and all AFTERs see the post-batch count).
+    assert_eq!(
+        ints(&db, "SELECT cnt FROM log"),
+        vec![2, -1, 1, 0],
+        "conflict-delete trigger bodies must see the table shrink between deletions"
+    );
+
+    // Exactly the new row survives.
+    assert_eq!(ints(&db, "SELECT id FROM t"), vec![3]);
+    assert_eq!(texts(&db, "SELECT a FROM t"), vec!["a1".to_string()]);
+    assert_eq!(texts(&db, "SELECT b FROM t"), vec!["b2".to_string()]);
+}
+
+// ---------------------------------------------------------------------------
+// Item 3: a BEFORE UPDATE trigger that writes to the SAME row the parent
+// statement is updating must not have its write clobbered. SQLite applies the
+// trigger's write, then overlays only the parent's SET columns — so a
+// trigger's write to a column the parent does NOT set survives, and IS visible
+// to AFTER triggers, RETURNING, and index maintenance. Verified against
+// sqlite3 3.51.0.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn before_update_trigger_same_row_write_survives_for_unset_column() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(id INTEGER PRIMARY KEY, a, b, c)");
+    exec(&mut db, "INSERT INTO t VALUES(1, 'a0', 'b0', 'c0')");
+    // BEFORE trigger writes column c; the parent statement only sets column a.
+    exec(
+        &mut db,
+        "CREATE TRIGGER trg BEFORE UPDATE ON t BEGIN \
+         UPDATE t SET c = 'trig_c' WHERE id = 1; END",
+    );
+
+    exec(&mut db, "UPDATE t SET a = 'a_parent' WHERE id = 1");
+
+    // Parent wins on the column it set (a); trigger's write to c survives; b is
+    // untouched by either.
+    assert_eq!(texts(&db, "SELECT a FROM t"), vec!["a_parent".to_string()]);
+    assert_eq!(texts(&db, "SELECT b FROM t"), vec!["b0".to_string()]);
+    assert_eq!(texts(&db, "SELECT c FROM t"), vec!["trig_c".to_string()]);
+}
+
+#[test]
+fn before_update_trigger_write_to_parent_column_is_overwritten() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(id INTEGER PRIMARY KEY, a, b)");
+    exec(&mut db, "INSERT INTO t VALUES(1, 'a0', 'b0')");
+    // Both the trigger and the parent write column a; the parent's value wins.
+    exec(
+        &mut db,
+        "CREATE TRIGGER trg BEFORE UPDATE ON t BEGIN \
+         UPDATE t SET a = 'trig_a' WHERE id = 1; END",
+    );
+
+    exec(&mut db, "UPDATE t SET a = 'a_parent' WHERE id = 1");
+
+    assert_eq!(texts(&db, "SELECT a FROM t"), vec!["a_parent".to_string()]);
+    assert_eq!(texts(&db, "SELECT b FROM t"), vec!["b0".to_string()]);
+}
+
+#[test]
+fn before_update_trigger_same_row_write_visible_to_after_trigger() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(id INTEGER PRIMARY KEY, a, c)");
+    exec(&mut db, "CREATE TABLE log(x)");
+    exec(&mut db, "INSERT INTO t VALUES(1, 'a0', 'c0')");
+    exec(
+        &mut db,
+        "CREATE TRIGGER b4 BEFORE UPDATE ON t BEGIN \
+         UPDATE t SET c = 'trig_c' WHERE id = 1; END",
+    );
+    // The AFTER trigger's NEW.c must reflect the BEFORE trigger's write.
+    exec(&mut db, "CREATE TRIGGER af AFTER UPDATE ON t BEGIN INSERT INTO log VALUES(new.c); END");
+
+    exec(&mut db, "UPDATE t SET a = 'a_parent' WHERE id = 1");
+
+    assert_eq!(texts(&db, "SELECT c FROM t"), vec!["trig_c".to_string()]);
+    // AFTER fires twice (verified against sqlite3 3.51.0): once for the BEFORE
+    // trigger's own nested `UPDATE t SET c` and once for the parent UPDATE. In
+    // both firings NEW.c must reflect the trigger's same-row write ('trig_c') —
+    // never the pre-trigger value 'c0'.
+    assert_eq!(
+        texts(&db, "SELECT x FROM log"),
+        vec!["trig_c".to_string(), "trig_c".to_string()],
+        "AFTER trigger NEW.* reflects the BEFORE trigger's same-row write"
+    );
 }


### PR DESCRIPTION
## Summary

Fixes the two remaining open items of the #5840 trigger-semantics batch (item 2b and item 3). Both were verified against sqlite3 3.51.0 with minimal repros before implementing, and anchored to failing tests in trigger1.test/triggerC.test.

Per the #5840 sweep note (2026-07-05), the other items are already resolved or out of scope: items 1, 2a, 5a, 5b landed in PR #5909; item 4 was fixed by #5741; item 6 residuals were assessed as unrelated parser/feature gaps; item 7 (TEMP schema separation) is epic-sized and tracked in #5940. This PR uses **Part of #5840** (not Closes) because items 6/7 keep the issue open.

## Changes

**Item 2b — stale table state between multi-row REPLACE conflict deletes** (`crates/vibesql-executor/src/insert/replace.rs`)
- When a single `INSERT OR REPLACE` row conflicts with multiple existing rows (e.g. one PK + one UNIQUE), `handle_replace_conflicts` fired ALL BEFORE DELETE triggers, then batch-deleted every conflicting row, then fired all AFTER DELETE triggers. A trigger body reading the table (`SELECT count(*) FROM t`) saw the same frozen pre-deletion count for every conflict row.
- SQLite processes conflict rows one at a time, interleaved: BEFORE R → remove R → AFTER R, before moving to the next conflict row, so the count decrements between deletions.
- The trigger-firing case now uses an interleaved per-row path (mirroring the DELETE executor's #5486 pattern): mark each row deleted in place, invalidate the columnar cache between the delete and the AFTER trigger, defer compaction to the end of the loop. The no-trigger case keeps the faster batch path.

**Item 3 — parent UPDATE clobbered BEFORE-trigger writes to the same row** (`crates/vibesql-executor/src/update/executor.rs`)
- `u.new_row` is snapshotted at statement-prep time. If a BEFORE UPDATE trigger wrote to the same row (via a nested UPDATE), that write landed in storage, but the parent re-applied the pre-trigger `u.new_row`, overwriting it.
- SQLite re-reads the current row and overlays only the parent's SET columns, so a trigger's write to a column the parent does NOT set survives — and is visible to AFTER triggers, RETURNING, and index maintenance.
- The per-row apply loop now merges the current stored values for every column outside the parent's `changed_columns` back into `u.new_row` after the BEFORE trigger fires.

**Tests** (`crates/vibesql-executor/tests/changes_and_replace_trigger_semantics_tests.rs`)
- `replace_multi_conflict_delete_triggers_see_decrementing_count` (item 2b)
- `before_update_trigger_same_row_write_survives_for_unset_column`, `before_update_trigger_write_to_parent_column_is_overwritten`, `before_update_trigger_same_row_write_visible_to_after_trigger` (item 3)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Item 2b: trigger bodies see table state decrement between conflict deletions | ✅ | sqlite3 3.51.0 repro (BEFORE=2/AFTER=1/BEFORE=1/AFTER=0) matches VibeSQL; unit test asserts `[2,-1,1,0]` |
| Item 3: BEFORE-trigger write to a non-parent column survives | ✅ | sqlite3 repro shows `c=trig_c`; VibeSQL now matches (was `c0`) |
| Item 3: parent wins on a column both write | ✅ | `a=a_parent` in both engines; unit test |
| Item 3: trigger write visible to AFTER trigger / RETURNING | ✅ | AFTER `new.c=trig_c`, RETURNING `c=trig_c` in both engines |
| No regressions | ✅ | Full `cargo test -p vibesql-executor` green (157 test binaries, 0 failures) |

## Test Plan

- Unit: `cargo test -p vibesql-executor` — all green, including 8 tests in `changes_and_replace_trigger_semantics_tests`.
- TCL conformance (before → after):
  - `trigger1.test`: 34/84 (40.5%) → 35/84 (41.7%)
  - `triggerC.test`: 97/119 (81.5%) → 101/119 (84.9%)
  - Net +5 passes, zero regressions.
- Regression sweep (unchanged vs baseline): trigger2 100%, trigger3/4/5 no failures, update.test 128/0, insert.test 1 pre-existing failure (confirmed present on main).

Part of #5840