### PR TITLE
fix(insert): report last row's rowid for explicit out-of-order batch rowids

### DIFF
--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -942,6 +942,18 @@ fn execute_insert_internal(
             last_generated_id = Some(id);
         }
 
+        // For a non-IPK rowid table whose column list names the rowid
+        // pseudo-column, every validated row carries its exact per-row rowid in
+        // tuple field `.1` (`explicit_rowid`) — the supplied value, or the
+        // value auto-assigned for a NULL/DEFAULT rowid. Capture the LAST row's
+        // rowid now (before the batch insert consumes `validated_rows`) so the
+        // readback below can report SQLite's last-inserted-row semantics even
+        // when the batch supplies explicit, out-of-order rowids
+        // (e.g. VALUES(10,'a'),(5,'b') → 5, not the batch max 10; issue #5955).
+        // The stored u64 is the two's-complement bit pattern of a signed rowid.
+        let last_row_explicit_rowid: Option<i64> =
+            validated_rows.last().and_then(|t| t.1).map(|r| r as i64);
+
         // Use cost-based batch sizing to optimize for tables with many indexes
         let optimizer = DmlOptimizer::new(db, table_name);
         let optimal_batch_size = optimizer.optimal_insert_batch_size(validated_rows.len());
@@ -1038,15 +1050,25 @@ fn execute_insert_internal(
 
         // For a rowid table WITHOUT an INTEGER PRIMARY KEY the batch path
         // allocates implicit rowids inside the storage layer, so no candidate id
-        // surfaced above (last_generated_id is still None). Read the max rowid
-        // back after the batch insert so last_insert_rowid() tracks the last
-        // inserted row — implicit rowids ascend, so the max equals the final
-        // row's rowid (#5944). VibeSQL is single-threaded within a session, so
-        // nothing can insert between the batch and this readback. The WITHOUT
-        // ROWID guard at the `set_last_insert_rowid()` call below still excludes
-        // WITHOUT ROWID tables.
+        // surfaced above (last_generated_id is still None). Recover the last
+        // inserted row's rowid so last_insert_rowid() tracks it.
+        //
+        // Prefer the last validated row's exact per-row rowid (`explicit_rowid`,
+        // captured above) when the column list named the rowid pseudo-column:
+        // that yields SQLite's last-inserted-row semantics regardless of value
+        // ordering, so a batch supplying explicit out-of-order rowids reports
+        // the final row's value (VALUES(10,'a'),(5,'b') → 5), not the batch max
+        // (issue #5955). Only when no per-row rowid is available (the storage
+        // layer auto-allocated ascending implicit rowids) fall back to the max
+        // rowid readback — for that pure auto-allocated case the max equals the
+        // final row's rowid (#5944). VibeSQL is single-threaded within a
+        // session, so nothing can insert between the batch and this readback.
+        // The WITHOUT ROWID guard at the `set_last_insert_rowid()` call below
+        // still excludes WITHOUT ROWID tables.
         if ipk_col_idx.is_none() && last_generated_id.is_none() && !schema.without_rowid {
-            if let Some(max_rowid) =
+            if let Some(rowid) = last_row_explicit_rowid {
+                last_generated_id = Some(rowid);
+            } else if let Some(max_rowid) =
                 db.get_table(&storage_table_name).and_then(|t| t.max_rowid_signed())
             {
                 last_generated_id = Some(max_rowid);

--- a/crates/vibesql-executor/src/tests/auto_increment_tests.rs
+++ b/crates/vibesql-executor/src/tests/auto_increment_tests.rs
@@ -766,3 +766,97 @@ fn test_last_insert_rowid_without_rowid_unchanged() {
     exec_sql(&mut db, "INSERT INTO wr VALUES('y'),('x')");
     assert_eq!(db.last_insert_rowid(), 1);
 }
+
+/// A multi-row `INSERT ... VALUES` into a non-IPK rowid table that supplies
+/// EXPLICIT, out-of-order rowid pseudo-column values must report the LAST row's
+/// rowid, not the batch max. This exercises the fast batch path; the prior
+/// max-rowid readback (issue #5944) returned the batch max (10) here, which
+/// diverges from SQLite. Verified against sqlite3 3.51.0: returns 5 (issue
+/// #5955).
+#[test]
+fn test_last_insert_rowid_explicit_out_of_order_non_ipk() {
+    let mut db = Database::new();
+
+    exec_sql(&mut db, "CREATE TABLE t(x TEXT)");
+    // rowids 10 then 5 — the LAST inserted row's rowid is 5, below the max (10).
+    exec_sql(&mut db, "INSERT INTO t(rowid, x) VALUES(10, 'a'), (5, 'b')");
+
+    // sqlite3: last_insert_rowid() == 5 (rowid of the last row inserted)
+    assert_eq!(db.last_insert_rowid(), 5);
+}
+
+/// Three explicit out-of-order rowids (3, 1, 2) into a non-IPK rowid table:
+/// last_insert_rowid() must be the last row's rowid (2), neither the max (3)
+/// nor the min. Verified against sqlite3 3.51.0: returns 2 (issue #5955).
+#[test]
+fn test_last_insert_rowid_explicit_out_of_order_three_rows() {
+    let mut db = Database::new();
+
+    exec_sql(&mut db, "CREATE TABLE t(x TEXT)");
+    exec_sql(&mut db, "INSERT INTO t(rowid, x) VALUES(3, 'a'), (1, 'b'), (2, 'c')");
+
+    // sqlite3: last_insert_rowid() == 2 (rowid of the last row inserted)
+    assert_eq!(db.last_insert_rowid(), 2);
+}
+
+/// A negative explicit rowid on the LAST row of a non-IPK batch must be
+/// reported verbatim, even though it is below every other rowid in the batch
+/// (rowids are signed). Verified against sqlite3 3.51.0: returns -3 (issue
+/// #5955).
+#[test]
+fn test_last_insert_rowid_explicit_negative_last_row_non_ipk() {
+    let mut db = Database::new();
+
+    exec_sql(&mut db, "CREATE TABLE t(x TEXT)");
+    exec_sql(&mut db, "INSERT INTO t(rowid, x) VALUES(10, 'a'), (-3, 'b')");
+
+    // sqlite3: last_insert_rowid() == -3 (rowid of the last row inserted)
+    assert_eq!(db.last_insert_rowid(), -3);
+}
+
+/// Mixed batch into a non-IPK rowid table where the LAST row's rowid is NULL
+/// (auto-assigned). The auto-assigned rowid is max+1, so last_insert_rowid()
+/// must report the allocated value (11), matching the exact rowid the last row
+/// received. Verified against sqlite3 3.51.0: returns 11 (issue #5955).
+#[test]
+fn test_last_insert_rowid_explicit_then_null_non_ipk() {
+    let mut db = Database::new();
+
+    exec_sql(&mut db, "CREATE TABLE t(x TEXT)");
+    // rowid 10 then NULL -> the NULL row auto-assigns max+1 = 11.
+    exec_sql(&mut db, "INSERT INTO t(rowid, x) VALUES(10, 'a'), (NULL, 'b')");
+
+    // sqlite3: last_insert_rowid() == 11 (the auto-allocated rowid of the last row)
+    assert_eq!(db.last_insert_rowid(), 11);
+}
+
+/// Mixed batch into a non-IPK rowid table where the FIRST row's rowid is NULL
+/// (auto-assigned to 1) and the LAST row supplies an explicit, lower rowid (5,
+/// still above 1). last_insert_rowid() must report the last row's explicit
+/// value (5). Verified against sqlite3 3.51.0: returns 5 (issue #5955).
+#[test]
+fn test_last_insert_rowid_null_then_explicit_non_ipk() {
+    let mut db = Database::new();
+
+    exec_sql(&mut db, "CREATE TABLE t(x TEXT)");
+    // NULL (auto -> 1) then explicit 5 -> the last row's rowid is 5.
+    exec_sql(&mut db, "INSERT INTO t(rowid, x) VALUES(NULL, 'a'), (5, 'b')");
+
+    // sqlite3: last_insert_rowid() == 5 (rowid of the last row inserted)
+    assert_eq!(db.last_insert_rowid(), 5);
+}
+
+/// In-order explicit ascending rowids into a non-IPK rowid table: the last
+/// row's rowid IS the batch max, so the value is unchanged from the pre-#5955
+/// behavior — a guard that the fix does not regress the monotonic case.
+/// Verified against sqlite3 3.51.0: returns 10 (issue #5955).
+#[test]
+fn test_last_insert_rowid_explicit_in_order_non_ipk() {
+    let mut db = Database::new();
+
+    exec_sql(&mut db, "CREATE TABLE t(x TEXT)");
+    exec_sql(&mut db, "INSERT INTO t(rowid, x) VALUES(5, 'a'), (10, 'b')");
+
+    // sqlite3: last_insert_rowid() == 10 (rowid of the last row inserted == max)
+    assert_eq!(db.last_insert_rowid(), 10);
+}


### PR DESCRIPTION
## Summary

The fast batch `INSERT` path recovered `last_insert_rowid()` for a non-IPK rowid table by reading `Table::max_rowid_signed()` back after the batch insert (added in #5954 / #5944). That relies on the invariant "implicit rowids ascend, so the max equals the last inserted row's rowid" — which holds only for auto-allocated rowids. It breaks when a multi-row batch supplies **explicit, out-of-order** rowid pseudo-column values into a non-IPK table:

```sql
CREATE TABLE t(x TEXT);
INSERT INTO t(rowid, x) VALUES(10, 'a'), (5, 'b');
SELECT last_insert_rowid();
```

- sqlite3 3.51.0: `5` (rowid of the last row actually inserted)
- VibeSQL before this fix: `10` (the batch max)

## Changes

- `crates/vibesql-executor/src/insert/execution.rs`: in the fast batch path, capture the last validated row's exact per-row rowid (`explicit_rowid`, tuple field `.1`) **before** the batch insert consumes `validated_rows`, and prefer it over the `max_rowid_signed()` readback whenever the column list named the rowid pseudo-column. The max-rowid fallback is kept for the pure auto-allocated case (no rowid column in the column list), where implicit rowids ascend and the max does equal the final row's rowid (#5944).
- `crates/vibesql-executor/src/tests/auto_increment_tests.rs`: 6 new unit tests, all verified against sqlite3 3.51.0.

The suggested fix in the issue mentioned `bulk_transfer.rs` as possibly affected. Investigation showed it is **already correct** and needs no change: the bulk-transfer path builds destination rows with `Row::new(...)` (no explicit rowid), so a non-IPK destination always gets fresh ascending implicit rowids (max readback is correct), and an IPK destination uses `.max()` over the copied IPK values — which matches sqlite3's transfer-optimization semantics (it scans the source in ascending rowid order, so the last inserted row is the max). Both were verified against sqlite3 3.51.0.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `VALUES(10,'a'),(5,'b')` reports 5, not 10 | ✅ | `test_last_insert_rowid_explicit_out_of_order_non_ipk` |
| Three out-of-order rowids report the last | ✅ | `test_last_insert_rowid_explicit_out_of_order_three_rows` (3,1,2 → 2) |
| Mixed explicit/auto (last=NULL) reports allocated rowid | ✅ | `test_last_insert_rowid_explicit_then_null_non_ipk` (10,NULL → 11) |
| Mixed auto/explicit (first=NULL) reports last explicit | ✅ | `test_last_insert_rowid_null_then_explicit_non_ipk` (NULL,5 → 5) |
| Negative last rowid reported verbatim | ✅ | `test_last_insert_rowid_explicit_negative_last_row_non_ipk` (10,-3 → -3) |
| In-order monotonic case unchanged (no regression) | ✅ | `test_last_insert_rowid_explicit_in_order_non_ipk` (5,10 → 10) |
| Existing 16 last_insert_rowid tests stay green | ✅ | All 22 pass (16 existing + 6 new) |

## Test Plan

- `cargo test -p vibesql-executor --lib last_insert_rowid` → 22 passed, 0 failed (16 pre-existing + 6 new).
- `cargo test -p vibesql-executor --lib` → 3252 passed, 0 failed, 2 ignored.
- `cargo test -p vibesql-executor --tests` (integration binaries) → exit 0, no failures.
- All new expected values verified against `sqlite3 3.51.0`.
- `rustfmt --check` clean on both touched files.

Closes #5955