### PR TITLE
fix(colname): full_column_names=ON prefixes wildcard columns with table name

### DIFF
--- a/crates/vibesql-executor/src/select/executor/columns.rs
+++ b/crates/vibesql-executor/src/select/executor/columns.rs
@@ -193,13 +193,13 @@ impl SelectExecutor<'_> {
                             }
                             column_names.extend(derived_cols.clone());
                         } else {
-                            // SELECT * uses table prefix when full_column_names=ON
-                            // BUT only when there's ambiguity (multiple tables or explicit alias)
-                            let has_multiple_tables = from_res.schema.table_schemas.len() > 1;
-
+                            // SELECT * uses table prefix when full_column_names=ON.
+                            // SQLite prefixes every column with its source table (or view)
+                            // name in full_column_names mode, even for a single-table query
+                            // (colname.test section 4: `SELECT * FROM tabc` -> tabc.a, ...).
                             for (_, col_name, effective_table_name) in table_columns {
                                 let display_name = match mode {
-                                    ColumnNamingMode::Full if has_multiple_tables => {
+                                    ColumnNamingMode::Full => {
                                         format!("{}.{}", effective_table_name, col_name)
                                     }
                                     _ => col_name,
@@ -233,12 +233,19 @@ impl SelectExecutor<'_> {
                                 }
                                 column_names.extend(derived_cols.clone());
                             } else {
-                                // SELECT table.* always uses just the column name, never
-                                // table-qualified This matches
-                                // SQLite behavior where full_column_names PRAGMA
-                                // does not affect wildcard expansion
+                                // SELECT table.* uses just the column name in short/expression
+                                // mode, but table-qualified (`table.column`) when
+                                // full_column_names=ON (colname.test section 4.6).
+                                // The prefix uses the schema's canonical table name, not the
+                                // qualifier as typed.
                                 for col_schema in &table_schema.columns {
-                                    column_names.push(col_schema.name.clone());
+                                    let display_name = match mode {
+                                        ColumnNamingMode::Full => {
+                                            format!("{}.{}", table_schema.name, col_schema.name)
+                                        }
+                                        _ => col_schema.name.clone(),
+                                    };
+                                    column_names.push(display_name);
                                 }
                             }
                         } else {

--- a/crates/vibesql-executor/tests/column_names_tests.rs
+++ b/crates/vibesql-executor/tests/column_names_tests.rs
@@ -82,9 +82,12 @@ fn test_column_names_star_expansion() {
     let stmt = vibesql_parser::Parser::parse_sql("SELECT * FROM employees").unwrap();
     if let vibesql_ast::Statement::Select(select_stmt) = stmt {
         let result = executor.execute_with_columns(&select_stmt).unwrap();
-        // SQLite quirk: SELECT * always uses short column names, even with full_column_names=ON
-        // This matches SQLite behavior where wildcards ignore the PRAGMA setting
-        assert_eq!(result.columns, vec!["id", "name", "department", "salary"]);
+        // With full_column_names=ON, SELECT * prefixes every column with its source
+        // table name, even for a single-table query (colname.test section 4.1).
+        assert_eq!(
+            result.columns,
+            vec!["employees.id", "employees.name", "employees.department", "employees.salary"]
+        );
         assert_eq!(result.rows.len(), 3);
     } else {
         panic!("Expected SELECT statement");
@@ -277,8 +280,8 @@ fn test_pragma_wildcard_full_column_names() {
     let stmt = vibesql_parser::Parser::parse_sql("SELECT * FROM employees").unwrap();
     if let vibesql_ast::Statement::Select(select_stmt) = stmt {
         let result = executor.execute_with_columns(&select_stmt).unwrap();
-        // SQLite quirk: SELECT * ignores full_column_names PRAGMA (always uses short names)
-        assert_eq!(result.columns, vec!["id", "name"]);
+        // full_column_names=ON: SELECT * uses table.column form (colname.test section 4.1)
+        assert_eq!(result.columns, vec!["employees.id", "employees.name"]);
     } else {
         panic!("Expected SELECT statement");
     }
@@ -341,6 +344,97 @@ fn test_pragma_set_and_get() {
     // Set short_column_names ON
     db.set_short_column_names(true);
     assert!(db.short_column_names());
+}
+
+// ---------------------------------------------------------------------------
+// full_column_names=ON table-prefix behavior for wildcards (issue #5842 item 3c,
+// colname.test section 4). SQLite prefixes every wildcard-expanded column with
+// its source table name when short_column_names=OFF and full_column_names=ON.
+// ---------------------------------------------------------------------------
+
+fn create_two_table_database_full_names() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    db.set_short_column_names(false);
+    db.set_full_column_names(true);
+
+    for ddl in ["CREATE TABLE tabc(a, b, c)", "CREATE TABLE txyz(x, y, z)"] {
+        let stmt = vibesql_parser::Parser::parse_sql(ddl).unwrap();
+        if let vibesql_ast::Statement::CreateTable(create_table) = stmt {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, &mut db).unwrap();
+        }
+    }
+    for dml in ["INSERT INTO tabc VALUES(1, 2, 3)", "INSERT INTO txyz VALUES(4, 5, 6)"] {
+        let stmt = vibesql_parser::Parser::parse_sql(dml).unwrap();
+        if let vibesql_ast::Statement::Insert(insert) = stmt {
+            vibesql_executor::InsertExecutor::execute(&mut db, &insert).unwrap();
+        }
+    }
+    db
+}
+
+#[test]
+fn test_full_column_names_single_table_star() {
+    // colname-4.1: SELECT * FROM tabc -> tabc.a, tabc.b, tabc.c
+    let db = create_two_table_database_full_names();
+    let executor = SelectExecutor::new(&db);
+    let stmt = vibesql_parser::Parser::parse_sql("SELECT * FROM tabc").unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let result = executor.execute_with_columns(&select_stmt).unwrap();
+        assert_eq!(result.columns, vec!["tabc.a", "tabc.b", "tabc.c"]);
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+#[test]
+fn test_full_column_names_qualified_wildcards() {
+    // colname-4.6: SELECT tabc.*, txyz.* -> tabc.a..tabc.c, txyz.x..txyz.z
+    let db = create_two_table_database_full_names();
+    let executor = SelectExecutor::new(&db);
+    let stmt = vibesql_parser::Parser::parse_sql("SELECT tabc.*, txyz.* FROM tabc, txyz").unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let result = executor.execute_with_columns(&select_stmt).unwrap();
+        assert_eq!(
+            result.columns,
+            vec!["tabc.a", "tabc.b", "tabc.c", "txyz.x", "txyz.y", "txyz.z"]
+        );
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+#[test]
+fn test_full_column_names_multi_table_star() {
+    // colname-4.5 tail: SELECT * FROM tabc, txyz -> all columns table-qualified
+    let db = create_two_table_database_full_names();
+    let executor = SelectExecutor::new(&db);
+    let stmt = vibesql_parser::Parser::parse_sql("SELECT * FROM tabc, txyz").unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let result = executor.execute_with_columns(&select_stmt).unwrap();
+        assert_eq!(
+            result.columns,
+            vec!["tabc.a", "tabc.b", "tabc.c", "txyz.x", "txyz.y", "txyz.z"]
+        );
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+#[test]
+fn test_short_column_names_star_no_prefix() {
+    // Regression guard: with short_column_names=ON (default), SELECT * stays unprefixed
+    // even across multiple tables.
+    let mut db = create_two_table_database_full_names();
+    db.set_full_column_names(false);
+    db.set_short_column_names(true);
+    let executor = SelectExecutor::new(&db);
+    let stmt = vibesql_parser::Parser::parse_sql("SELECT tabc.*, txyz.* FROM tabc, txyz").unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let result = executor.execute_with_columns(&select_stmt).unwrap();
+        assert_eq!(result.columns, vec!["a", "b", "c", "x", "y", "z"]);
+    } else {
+        panic!("Expected SELECT statement");
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the sole remaining sub-item of #5842 — **item 3c: `full_column_names` / `short_column_names` pragma table-prefix behavior** (colname.test section 4). With `PRAGMA short_column_names=OFF` and `full_column_names=ON`, SQLite names every wildcard-expanded result column as `table.column`. VibeSQL previously only applied the prefix when the FROM clause had more than one table, so single-table `SELECT *`, qualified `table.*`, and `SELECT * FROM <view>` all returned bare column names.

The other items of #5842 were already merged: items 1/3b/4 via #5912, items 2/3a via #5966.

## Changes

- `crates/vibesql-executor/src/select/executor/columns.rs`
  - Drop the `has_multiple_tables` guard in the `SELECT *` branch so Full mode always prefixes with each column's source table/view name (already tracked per-column). Fixes single-table `SELECT *` and view `SELECT *` (view name prefixes the `:N`-suffixed columns, e.g. `v1.a:1`).
  - Prefix qualified-wildcard (`table.*`) columns with the schema's canonical table name in Full mode.
- `crates/vibesql-executor/tests/column_names_tests.rs`
  - Correct two existing unit tests that asserted the old, non-SQLite "wildcards ignore full_column_names" behavior.
  - Add four tests: single-table `SELECT *`, multi-table `SELECT *`, qualified `table.*`, and a short-mode regression guard.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| colname.test section 4 attributable failures pass | ✅ | 4.1, 4.6, 4.8–4.13 now pass (were the section-4 failures); verified against sqlite3 3.51.0 expectations encoded in colname.test |
| Sections 1–3 do not regress | ✅ | All section 1/2/3 tests still pass; colname-3.7 regression guard intact |
| Verified against sqlite3 | ✅ | Expected column names taken verbatim from SQLite's canonical colname.test (v1.a, v1.x, v1.a:1, tabc.a, …) |

## Test Plan

- `make test-tcl-file FILE=colname.test`: **54 → 62 passing** (of 66).
  - Now-passing section-4 tests: 4.1, 4.6, 4.8, 4.9, 4.10, 4.11, 4.12, 4.13.
  - The 4 remaining failures (colname-7.1 rowid aliasing, 9.410 RAISE-in-CTAS, 10.100/10.110 CTAS quote-stripping) are pre-existing, unrelated to the full/short-column-names pragma (item 3c), and were failing before this change.
- `cargo test -p vibesql-executor`: all pass (3262 + suites, 0 failures), including the 22 tests in `column_names_tests.rs`.

## Scope note

This PR uses **"Part of #5842"** (not "Closes") because a few general colname.test failures remain (7.1, 9.410, 10.100/10.110). These fall under rowid/RAISE/CTAS-quote-stripping, not item 3c (the pragma table-prefix behavior), which is the only remaining scope this issue was reopened for. The issue is being returned to `loom:issue` for that residual follow-on work.

Part of #5842