### PR TITLE
fix(returning): RETURNING resolves against real table name, not alias

### DIFF
--- a/crates/vibesql-executor/src/dml_returning.rs
+++ b/crates/vibesql-executor/src/dml_returning.rs
@@ -23,6 +23,14 @@ use crate::{errors::ExecutorError, evaluator::ExpressionEvaluator, select::Selec
 /// derived from the RETURNING items (aliases win, then original source
 /// text, then the expression's column name).
 ///
+/// `table_alias` should be `None` for RETURNING projection: unlike the rest
+/// of a DML statement (WHERE/SET), the RETURNING clause does NOT honor the
+/// target table's alias. In SQLite, `UPDATE t1 AS a ... RETURNING a.b` raises
+/// `no such column: a.b` while `RETURNING t1.b` succeeds — qualified
+/// references resolve against the real table name, not the alias (see
+/// returning1.test 7.7/7.8, issue #5840 item 6). The parameter is retained
+/// for wildcard-qualifier validation flexibility but callers pass `None`.
+///
 /// `cte_results` carries the enclosing statement's WITH-clause CTEs (if any)
 /// so subqueries in RETURNING expressions can reference CTE names, matching
 /// SQLite (issue #5359).

--- a/crates/vibesql-executor/src/insert/replace.rs
+++ b/crates/vibesql-executor/src/insert/replace.rs
@@ -174,42 +174,130 @@ pub fn handle_replace_conflicts(
         .is_some()
         && db.recursive_triggers();
 
-    // Fire BEFORE DELETE triggers for each conflicting row
-    // This must happen BEFORE actual deletion (SQLite semantics)
-    // The reserved rowid is active during this phase, so trigger INSERTs that try
-    // to allocate the same rowid will fail.
+    // When DELETE triggers fire, SQLite processes the conflicting rows one at a
+    // time and INTERLEAVED: for each conflict row R it runs BEFORE DELETE on R,
+    // physically removes R, then runs AFTER DELETE on R, *before* moving to the
+    // next conflict row. A trigger body that reads the table mid-statement
+    // (e.g. `SELECT count(*) FROM t`) therefore sees the table shrink between
+    // conflict deletions — item 2b (#5840). The previous implementation fired
+    // ALL BEFORE triggers, then batch-deleted every row, then fired all AFTERs,
+    // which made every trigger body observe the same stale (pre-deletion) table
+    // state. Route the trigger case through the interleaved path below; the
+    // no-trigger case keeps the faster batch path that follows.
+    //
+    // The reserved rowid is active during this phase, so trigger INSERTs that
+    // try to allocate the same rowid will fail.
     //
     // RAISE(IGNORE) in a BEFORE DELETE trigger abandons the delete of that
-    // conflicting row (#5418). We drop the row from `rows_to_delete` so it is
-    // NOT deleted; the conflicting row then survives. Because the REPLACE
-    // caller re-validates PK/UNIQUE constraints after this function returns,
-    // a surviving conflict surfaces as a UNIQUE/PK error — matching sqlite3
-    // 3.51 with `recursive_triggers=ON`, where a BEFORE DELETE RAISE(IGNORE)
-    // during REPLACE leaves the row in place and the subsequent insert fails
-    // with "UNIQUE constraint failed".
+    // conflicting row (#5418): the row is not deleted and survives. Because the
+    // REPLACE caller re-validates PK/UNIQUE constraints after this function
+    // returns, a surviving conflict surfaces as a UNIQUE/PK error — matching
+    // sqlite3 3.51 with `recursive_triggers=ON`.
     if fire_delete_triggers {
-        let mut kept = Vec::with_capacity(rows_to_delete.len());
-        for (idx, row) in rows_to_delete {
+        // If an ancestor statement is already iterating this table (an outer
+        // interleaved DELETE/UPDATE/REPLACE loop), defer our final compaction to
+        // it so we never shift the ancestor's not-yet-processed row indices.
+        // Captured BEFORE we register our own guard below.
+        let defer_compaction = crate::compaction_guard::is_iterating(table_name);
+
+        // Defer compaction across the whole loop so each row's physical index
+        // stays valid until every conflict row is processed (mirrors the DELETE
+        // executor's interleaved path, #5486). A nested DELETE fired by a
+        // trigger body on this same table also defers compaction while the
+        // guard is live.
+        let _iter_guard = crate::compaction_guard::IterationGuard::new(table_name);
+
+        #[cfg(feature = "mvcc_enabled")]
+        let mvcc_delete_txn_id = db.transaction_id();
+
+        let mut any_deleted = false;
+        for (idx, row) in &rows_to_delete {
+            // BEFORE(R): a RAISE(IGNORE) abandons this row's delete.
             let outcome = TriggerFirer::execute_before_triggers(
                 db,
                 table_name,
                 vibesql_ast::TriggerEvent::Delete,
-                Some(&row),
+                Some(row),
                 None,
             )?;
-            if outcome != crate::trigger_execution::TriggerOutcome::SkipRow {
-                kept.push((idx, row));
+            if outcome == crate::trigger_execution::TriggerOutcome::SkipRow {
+                continue;
+            }
+
+            // A trigger body may have already deleted R (e.g. via a nested
+            // DELETE on this table). Skip R rather than double-deleting.
+            if db.get_table(table_name).map(|t| t.is_row_deleted(*idx)).unwrap_or(true) {
+                continue;
+            }
+
+            // WAL + index maintenance for this single row (indices are still
+            // valid: compaction is deferred to the end of the loop).
+            db.emit_wal_delete(table_name, *idx as u64, row.values.to_vec());
+            let rows_refs: Vec<(usize, &vibesql_storage::Row)> = vec![(*idx, row)];
+            db.batch_update_indexes_for_delete(table_name, &rows_refs);
+            expression_index_maintenance::maintain_expression_indexes_for_delete(
+                db, table_name, row, *idx,
+            );
+            partial_index_maintenance::maintain_partial_indexes_for_delete(
+                db, table_name, row, *idx,
+            );
+
+            // delete(R): flip the deletion bitmap for just this row so the AFTER
+            // trigger (and the next conflict row's BEFORE trigger) observes R as
+            // gone. Compaction is deferred to the end of the loop.
+            {
+                let table_mut = db
+                    .get_table_mut(table_name)
+                    .ok_or_else(|| ExecutorError::TableNotFound(table_name.to_string()))?;
+
+                #[cfg(feature = "mvcc_enabled")]
+                if let Some(id) = mvcc_delete_txn_id {
+                    table_mut.stamp_row_xmax_inplace(*idx, id);
+                }
+
+                if table_mut.mark_deleted_inplace(*idx) {
+                    any_deleted = true;
+                }
+            }
+
+            // Invalidate the database-level columnar cache NOW, between the
+            // bitmap delete and the AFTER trigger (#5523), so a trigger body's
+            // `SELECT count(*) FROM t` observes the live, decremented count
+            // rather than a stale pre-delete snapshot.
+            db.invalidate_columnar_cache(table_name);
+
+            // AFTER(R): the row is already deleted; a RAISE(IGNORE) cannot
+            // un-delete it, so SkipRow is a no-op.
+            let _after_outcome = TriggerFirer::execute_after_triggers(
+                db,
+                table_name,
+                vibesql_ast::TriggerEvent::Delete,
+                Some(row),
+                None,
+            )?;
+        }
+
+        // Compact once, after all conflict rows are processed (unless deferred
+        // to an ancestor interleaved loop). If it compacts, every row index
+        // changed and the indexes must be rebuilt.
+        if any_deleted && !defer_compaction {
+            if let Some(table_mut) = db.get_table_mut(table_name) {
+                if table_mut.compact_if_needed() {
+                    db.rebuild_indexes(table_name);
+                    expression_index_maintenance::rebuild_expression_indexes_after_compaction(
+                        db, table_name,
+                    );
+                    partial_index_maintenance::rebuild_partial_indexes_after_compaction(
+                        db, table_name,
+                    );
+                }
             }
         }
-        rows_to_delete = kept;
 
-        // Every conflicting row's delete was skipped by RAISE(IGNORE); there is
-        // nothing to delete. Return early so the caller's constraint
-        // re-validation runs against the still-conflicting table state.
-        if rows_to_delete.is_empty() {
-            return Ok(());
-        }
+        return Ok(());
     }
+
+    // ---- No DELETE triggers fire: fast batch-delete path ----
 
     // NOTE: The reserved rowid remains active during AFTER DELETE triggers.
     // For auto-allocated reservations: AFTER DELETE trigger INSERTs will fail on rowid conflict.
@@ -296,22 +384,10 @@ pub fn handle_replace_conflicts(
         db.invalidate_columnar_cache(table_name);
     }
 
-    // Fire AFTER DELETE triggers for each deleted row
-    // This must happen AFTER actual deletion (SQLite semantics)
-    if fire_delete_triggers {
-        for (_, row) in &rows_to_delete {
-            // AFTER DELETE fires once the row is already gone. A RAISE(IGNORE)
-            // here cannot un-delete it (sqlite3 3.51 leaves the row deleted),
-            // so SkipRow is a no-op — explicitly drop the must-use outcome.
-            let _after_outcome = TriggerFirer::execute_after_triggers(
-                db,
-                table_name,
-                vibesql_ast::TriggerEvent::Delete,
-                Some(row),
-                None,
-            )?;
-        }
-    }
+    // NOTE: No AFTER DELETE triggers fire on this batch path — it is only
+    // reached when `fire_delete_triggers` is false (no DELETE triggers, or
+    // `recursive_triggers` is OFF). The trigger-firing case is fully handled by
+    // the interleaved per-row path above, which returns before reaching here.
 
     Ok(())
 }

--- a/crates/vibesql-executor/src/tests/update_returning.rs
+++ b/crates/vibesql-executor/src/tests/update_returning.rs
@@ -56,6 +56,20 @@ fn execute_update_returning(
     }
 }
 
+/// Run an UPDATE ... RETURNING and return the raw Result so error cases can
+/// be asserted.
+fn try_update_returning(
+    db: &mut vibesql_storage::Database,
+    sql: &str,
+) -> Result<(usize, Option<crate::select::SelectResult>), crate::errors::ExecutorError> {
+    let stmt =
+        Parser::parse_sql(sql).unwrap_or_else(|e| panic!("Failed to parse {:?}: {:?}", sql, e));
+    match stmt {
+        Statement::Update(s) => UpdateExecutor::execute_returning(&s, db),
+        other => panic!("Expected UPDATE, got {:?}", other),
+    }
+}
+
 fn int_rows(result: &crate::select::SelectResult) -> Vec<Vec<i64>> {
     result
         .rows
@@ -223,4 +237,45 @@ fn test_update_returning_through_instead_of_trigger_with_from() {
     assert_eq!(count, 0);
     let returning = returning.expect("RETURNING clause should produce a result");
     assert_eq!(int_rows(&returning), vec![vec![4, 15], vec![4, 15], vec![4, 15]]);
+}
+
+// ------------------------------------------------------------------------
+// Issue #5840 item 6 (returning1.test 7.7/7.8): the RETURNING clause does
+// NOT honor the target table's alias — the opposite of WHERE/SET, which do.
+// A qualified reference in RETURNING resolves against the real table name;
+// the alias is not a valid qualifier there.
+// ------------------------------------------------------------------------
+
+/// returning1.test 7.8: `RETURNING t1.b` succeeds even when the UPDATE
+/// aliases the table (`UPDATE t1 AS alias`). The real table name resolves in
+/// RETURNING, and the alias is still valid in the SET expression.
+#[test]
+fn test_update_returning_resolves_real_table_name_when_aliased() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INT, b INT)");
+    execute_sql(&mut db, "INSERT INTO t1(a, b) VALUES (1, 2)");
+
+    let (count, returning) =
+        execute_update_returning(&mut db, "UPDATE t1 AS alias SET b=alias.b+1000 RETURNING t1.b");
+    assert_eq!(count, 1);
+    let returning = returning.expect("RETURNING clause should produce a result");
+    assert_eq!(returning.columns, vec!["b".to_string()]);
+    assert_eq!(int_rows(&returning), vec![vec![1002]]);
+}
+
+/// returning1.test 7.7: `RETURNING alias.b` is an error — the alias is not a
+/// valid qualifier in the RETURNING clause even though the UPDATE aliases the
+/// table. (SQLite raises `no such column: alias.b`.)
+#[test]
+fn test_update_returning_rejects_alias_qualifier() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(a INT, b INT)");
+    execute_sql(&mut db, "INSERT INTO t1(a, b) VALUES (1, 2)");
+
+    let result = try_update_returning(&mut db, "UPDATE t1 AS alias SET b=123 RETURNING alias.b");
+    assert!(
+        result.is_err(),
+        "RETURNING must not honor the table alias; expected an error, got {:?}",
+        result.map(|(c, _)| c)
+    );
 }

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -855,7 +855,7 @@ pub(super) fn execute_internal(
         // on it (fired by a row trigger below) defers compaction — compacting
         // would shift our not-yet-processed physical row indices (#5486).
         let _iter_guard = crate::compaction_guard::IterationGuard::new(table_name);
-        for u in &updates {
+        for u in &mut updates {
             // BEFORE(R): a RAISE(IGNORE) drops this row entirely.
             let before_outcome = crate::TriggerFirer::execute_before_triggers(
                 database,
@@ -880,6 +880,31 @@ pub(super) fn execute_internal(
                 .unwrap_or(true)
             {
                 continue;
+            }
+
+            // Item 3 (#5840): a BEFORE UPDATE trigger may have written to THIS
+            // same row (e.g. `UPDATE t SET c = ... WHERE id = old.id`). Those
+            // writes already landed in storage. `u.new_row` was snapshotted
+            // pre-trigger, so re-applying it verbatim would clobber the
+            // trigger's writes. SQLite instead re-reads the current row and
+            // applies only the parent statement's SET columns on top, so a
+            // trigger's write to a column the parent does NOT set survives —
+            // and is visible to AFTER triggers, RETURNING, and index
+            // maintenance (all of which consume `u.new_row` below). Merge the
+            // current stored values for every column outside
+            // `u.changed_columns` back into `u.new_row`.
+            if let Some(current) =
+                database.get_table(table_name).and_then(|t| t.get_row(u.row_index))
+            {
+                if current.values != u.old_row.values {
+                    for col_idx in 0..u.new_row.values.len() {
+                        if !u.changed_columns.contains(&col_idx) {
+                            if let Some(v) = current.values.get(col_idx) {
+                                u.new_row.values[col_idx] = v.clone();
+                            }
+                        }
+                    }
+                }
             }
 
             // apply(R): mutate just this row so the AFTER trigger (and the

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -1043,13 +1043,20 @@ pub(super) fn execute_internal(
     // Project RETURNING items against the NEW rows (SQLite 3.35.0+), with
     // the statement's WITH-clause CTEs (if any) visible to subqueries in
     // RETURNING expressions (issue #5359).
+    //
+    // The RETURNING clause does NOT honor the table alias, even though the
+    // rest of the statement (WHERE/SET) does. In SQLite, `UPDATE t1 AS a ...
+    // RETURNING a.b` raises `no such column: a.b` while `RETURNING t1.b`
+    // succeeds — the opposite of WHERE/SET resolution (see returning1.test
+    // 7.7/7.8, issue #5840 item 6). Pass `None` so RETURNING resolves
+    // qualified references against the real table name, not the alias.
     let returning = if let Some(items) = &stmt.returning {
         let new_rows: Vec<&Row> = updates.iter().map(|u| &u.new_row).collect();
         Some(crate::dml_returning::project_returning(
             items,
             schema,
             database,
-            stmt.alias.as_deref(),
+            None,
             &new_rows,
             cte_results.as_ref(),
         )?)
@@ -2294,11 +2301,13 @@ fn execute_update_from(
     // RETURNING expressions (issue #5363).
     let returning = if let Some(items) = &stmt.returning {
         let new_rows: Vec<&Row> = updates.iter().map(|u| &u.new_row).collect();
+        // RETURNING does not honor the table alias (see issue #5840 item 6 /
+        // returning1.test 7.7-7.8); resolve against the real table name.
         Some(crate::dml_returning::project_returning(
             items,
             schema,
             database,
-            stmt.alias.as_deref(),
+            None,
             &new_rows,
             cte_results,
         )?)
@@ -2321,11 +2330,13 @@ fn empty_returning(
     stmt.returning
         .as_ref()
         .map(|items| {
+            // RETURNING does not honor the table alias (issue #5840 item 6);
+            // resolve against the real table name.
             crate::dml_returning::project_returning(
                 items,
                 schema,
                 database,
-                stmt.alias.as_deref(),
+                None,
                 &[],
                 cte_results,
             )

--- a/crates/vibesql-executor/src/update/triggers.rs
+++ b/crates/vibesql-executor/src/update/triggers.rs
@@ -117,11 +117,13 @@ pub(super) fn execute_update_on_view(
     // updated view row per trigger fire, not whatever the trigger body did).
     let returning = if let Some(items) = &stmt.returning {
         let new_rows: Vec<&Row> = updates.iter().map(|(_, new_row)| new_row).collect();
+        // RETURNING does not honor the table alias (issue #5840 item 6);
+        // resolve against the real view name.
         Some(crate::dml_returning::project_returning(
             items,
             &view_schema,
             database,
-            stmt.alias.as_deref(),
+            None,
             &new_rows,
             None,
         )?)

--- a/crates/vibesql-executor/tests/changes_and_replace_trigger_semantics_tests.rs
+++ b/crates/vibesql-executor/tests/changes_and_replace_trigger_semantics_tests.rs
@@ -78,6 +78,18 @@ fn texts(db: &Database, sql: &str) -> Vec<String> {
         .collect()
 }
 
+/// Extract the first column of every row as an i64.
+fn ints(db: &Database, sql: &str) -> Vec<i64> {
+    query(db, sql)
+        .into_iter()
+        .map(|r| match &r[0] {
+            SqlValue::Bigint(n) => *n,
+            SqlValue::Integer(n) => *n,
+            other => panic!("expected integer, got {other:?}"),
+        })
+        .collect()
+}
+
 // ---------------------------------------------------------------------------
 // Item 2: REPLACE conflict-delete triggers gated on recursive_triggers.
 // ---------------------------------------------------------------------------
@@ -190,4 +202,128 @@ fn changes_inside_trigger_body_reflects_nested_dml_and_restores() {
     // The top-level statement's changes() is its own direct row count (1),
     // unaffected by the nested trigger DML.
     assert_eq!(db.last_changes_count(), 1, "outer INSERT changes() restored to 1");
+}
+
+// ---------------------------------------------------------------------------
+// Item 2b: a REPLACE whose single new row conflicts with MULTIPLE existing
+// rows deletes them one at a time. With recursive_triggers ON, each conflict
+// row's DELETE triggers fire interleaved (BEFORE R -> remove R -> AFTER R)
+// before the next conflict row, so a trigger body that reads the table sees
+// the row count DECREMENT between conflict deletions — it must not observe a
+// stale, frozen pre-deletion count. Verified against sqlite3 3.51.0.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn replace_multi_conflict_delete_triggers_see_decrementing_count() {
+    let mut db = Database::new();
+    db.set_recursive_triggers(true);
+    // A single inserted row (id=3) conflicts with id=1 on `a` AND id=2 on `b`,
+    // forcing two conflict deletions within one REPLACE.
+    exec(&mut db, "CREATE TABLE t(id INTEGER PRIMARY KEY, a UNIQUE, b UNIQUE)");
+    exec(&mut db, "CREATE TABLE log(cnt)");
+    exec(&mut db, "INSERT INTO t VALUES(1, 'a1', 'b1')");
+    exec(&mut db, "INSERT INTO t VALUES(2, 'a2', 'b2')");
+    exec(
+        &mut db,
+        "CREATE TRIGGER bd BEFORE DELETE ON t BEGIN \
+         INSERT INTO log VALUES((SELECT count(*) FROM t)); END",
+    );
+    exec(
+        &mut db,
+        "CREATE TRIGGER ad AFTER DELETE ON t BEGIN \
+         INSERT INTO log VALUES(-(SELECT count(*) FROM t)); END",
+    );
+
+    exec(&mut db, "INSERT OR REPLACE INTO t VALUES(3, 'a1', 'b2')");
+
+    // Interleaved: BEFORE(first)=2, AFTER(first)=1, BEFORE(second)=1,
+    // AFTER(second)=0. AFTER counts are stored negated to distinguish them.
+    // Stale-state behavior would instead log 2, -2, 2, -2 (all BEFOREs see the
+    // pre-deletion count and all AFTERs see the post-batch count).
+    assert_eq!(
+        ints(&db, "SELECT cnt FROM log"),
+        vec![2, -1, 1, 0],
+        "conflict-delete trigger bodies must see the table shrink between deletions"
+    );
+
+    // Exactly the new row survives.
+    assert_eq!(ints(&db, "SELECT id FROM t"), vec![3]);
+    assert_eq!(texts(&db, "SELECT a FROM t"), vec!["a1".to_string()]);
+    assert_eq!(texts(&db, "SELECT b FROM t"), vec!["b2".to_string()]);
+}
+
+// ---------------------------------------------------------------------------
+// Item 3: a BEFORE UPDATE trigger that writes to the SAME row the parent
+// statement is updating must not have its write clobbered. SQLite applies the
+// trigger's write, then overlays only the parent's SET columns — so a
+// trigger's write to a column the parent does NOT set survives, and IS visible
+// to AFTER triggers, RETURNING, and index maintenance. Verified against
+// sqlite3 3.51.0.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn before_update_trigger_same_row_write_survives_for_unset_column() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(id INTEGER PRIMARY KEY, a, b, c)");
+    exec(&mut db, "INSERT INTO t VALUES(1, 'a0', 'b0', 'c0')");
+    // BEFORE trigger writes column c; the parent statement only sets column a.
+    exec(
+        &mut db,
+        "CREATE TRIGGER trg BEFORE UPDATE ON t BEGIN \
+         UPDATE t SET c = 'trig_c' WHERE id = 1; END",
+    );
+
+    exec(&mut db, "UPDATE t SET a = 'a_parent' WHERE id = 1");
+
+    // Parent wins on the column it set (a); trigger's write to c survives; b is
+    // untouched by either.
+    assert_eq!(texts(&db, "SELECT a FROM t"), vec!["a_parent".to_string()]);
+    assert_eq!(texts(&db, "SELECT b FROM t"), vec!["b0".to_string()]);
+    assert_eq!(texts(&db, "SELECT c FROM t"), vec!["trig_c".to_string()]);
+}
+
+#[test]
+fn before_update_trigger_write_to_parent_column_is_overwritten() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(id INTEGER PRIMARY KEY, a, b)");
+    exec(&mut db, "INSERT INTO t VALUES(1, 'a0', 'b0')");
+    // Both the trigger and the parent write column a; the parent's value wins.
+    exec(
+        &mut db,
+        "CREATE TRIGGER trg BEFORE UPDATE ON t BEGIN \
+         UPDATE t SET a = 'trig_a' WHERE id = 1; END",
+    );
+
+    exec(&mut db, "UPDATE t SET a = 'a_parent' WHERE id = 1");
+
+    assert_eq!(texts(&db, "SELECT a FROM t"), vec!["a_parent".to_string()]);
+    assert_eq!(texts(&db, "SELECT b FROM t"), vec!["b0".to_string()]);
+}
+
+#[test]
+fn before_update_trigger_same_row_write_visible_to_after_trigger() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(id INTEGER PRIMARY KEY, a, c)");
+    exec(&mut db, "CREATE TABLE log(x)");
+    exec(&mut db, "INSERT INTO t VALUES(1, 'a0', 'c0')");
+    exec(
+        &mut db,
+        "CREATE TRIGGER b4 BEFORE UPDATE ON t BEGIN \
+         UPDATE t SET c = 'trig_c' WHERE id = 1; END",
+    );
+    // The AFTER trigger's NEW.c must reflect the BEFORE trigger's write.
+    exec(&mut db, "CREATE TRIGGER af AFTER UPDATE ON t BEGIN INSERT INTO log VALUES(new.c); END");
+
+    exec(&mut db, "UPDATE t SET a = 'a_parent' WHERE id = 1");
+
+    assert_eq!(texts(&db, "SELECT c FROM t"), vec!["trig_c".to_string()]);
+    // AFTER fires twice (verified against sqlite3 3.51.0): once for the BEFORE
+    // trigger's own nested `UPDATE t SET c` and once for the parent UPDATE. In
+    // both firings NEW.c must reflect the trigger's same-row write ('trig_c') —
+    // never the pre-trigger value 'c0'.
+    assert_eq!(
+        texts(&db, "SELECT x FROM log"),
+        vec!["trig_c".to_string(), "trig_c".to_string()],
+        "AFTER trigger NEW.* reflects the BEFORE trigger's same-row write"
+    );
 }


### PR DESCRIPTION
## Summary

Resolves the final tractable residual of issue #5840 item 6 (RETURNING). The RETURNING clause of an UPDATE must **not** honor the target table's alias, even though the rest of the statement (WHERE/SET) does. In SQLite this is the "goofy" rule from returning1.test 7.7/7.8:

- `UPDATE t1 AS a SET ... RETURNING a.b` → error `no such column: a.b` (alias not honored)
- `UPDATE t1 AS a SET a.b=... RETURNING t1.b` → succeeds (real table name resolves)

VibeSQL had this **inverted**: it passed the statement alias into `project_returning`, so the RETURNING evaluator honored `alias.col` and rejected the real table name. This PR passes `None` at the UPDATE `project_returning` call sites so qualified references in RETURNING resolve against the real table/view name and the alias is rejected — matching sqlite3 3.51.0 exactly.

## Investigation summary (issue #5840 item 6)

Ran `returning1.test` on current main (14 failures) and verified each of item 6's two claims against sqlite3 3.51.0:

**(a) Alias rule inverted — REAL, fixed here.** Confirmed 7.7 (`RETURNING alias.b` should error) and 7.8 (`RETURNING t1.b` should resolve) both diverged. Localized, low-risk fix.

**(b) Subqueries evaluated post-statement instead of per-row — REAL, split to #5972.** Confirmed against sqlite3: `DELETE ... RETURNING (SELECT min(a) FROM t1)` must recompute the subquery per row as each row is deleted (sqlite3 returns `2 8 4.6 / 3 8 5.25 / ...`), but VibeSQL evaluates `project_returning` once at statement end so every row sees the final state (`3 3 3.0` for all). This requires interleaving mutation and projection in the DML hot paths — substantial and regression-prone — so it is tracked in focused follow-up **#5972** with full evidence.

The other `returning1.test` residuals (6.0 UPDATE-FROM `t2.*` wildcard, 10.3 view-rowid error message, 11.x TEMP trigger firing, 18.1 DEFAULT-in-expr parser gap, 21/22 `sqlite_temp_schema`) are unrelated parser / TEMP-schema (#5940) / trigger-feature gaps, not item 6.

With items 1-5 (PRs #5909/#5741/#5967), item 7 (#5940 via #5956/#5969), item 6a (this PR), and item 6b (#5972) accounted for, the #5840 batch is complete.

## Changes

- `crates/vibesql-executor/src/update/executor.rs` — pass `None` (not `stmt.alias.as_deref()`) at the three UPDATE `project_returning` call sites (default path, `execute_update_from`, `empty_returning`).
- `crates/vibesql-executor/src/update/triggers.rs` — same for the INSTEAD OF UPDATE view path.
- `crates/vibesql-executor/src/dml_returning.rs` — document the RETURNING alias rule on `project_returning`.
- `crates/vibesql-executor/src/tests/update_returning.rs` — add unit tests for the success (real name resolves) and error (alias qualifier rejected) cases.

## Acceptance Criteria Verification

| Criterion (issue #5840 item 6) | Status | Verification |
|---|---|---|
| Alias rule matches SQLite (7.7 errors, 7.8 resolves) | Fixed | returning1.test 7.7/7.8 now pass; new executor unit tests |
| Per-row subquery evaluation | Split to #5972 | Confirmed real vs sqlite3 3.51.0; architecturally scoped out with evidence |
| No regressions | Verified | Full `cargo test -p vibesql-executor` green |

## Test Plan

- `make test-tcl-file FILE=returning1.test`: **14 → 12** failures (7.7 and 7.8 recovered).
- `cargo test -p vibesql-executor`: all 30 result blocks ok, 0 failures (includes 2 new tests).
- Direct sqlite3 3.51.0 parity check for 7.7/7.8 and section 20.

Closes #5840