### PR TITLE
fix(colname): short_column_names=ON overrides full_column_names=ON for wildcards

### DIFF
--- a/crates/vibesql-executor/src/select/executor/columns.rs
+++ b/crates/vibesql-executor/src/select/executor/columns.rs
@@ -16,6 +16,13 @@ pub(super) enum ColumnNamingMode {
 
 impl SelectExecutor<'_> {
     /// Determine the column naming mode from database PRAGMA settings
+    ///
+    /// This governs naming of *explicit* result columns (e.g. `SELECT a`,
+    /// `SELECT tabc.a`). For these, sqlite3 lets `full_column_names=ON` win
+    /// even when `short_column_names=ON` — i.e. `SELECT a FROM tabc` reports
+    /// `tabc.a` whenever full is ON, regardless of short. Wildcard expansion
+    /// (`SELECT *`) follows a different precedence; see
+    /// [`Self::get_wildcard_naming_mode`].
     fn get_column_naming_mode(&self) -> ColumnNamingMode {
         let full = self.database.full_column_names();
         let short = self.database.short_column_names();
@@ -33,6 +40,30 @@ impl SelectExecutor<'_> {
         }
     }
 
+    /// Determine the naming mode for wildcard (`SELECT *`) expansion.
+    ///
+    /// Unlike explicit column references, wildcard expansion lets
+    /// `short_column_names=ON` override `full_column_names=ON`: the
+    /// `table.column` prefix appears **only** when `short=OFF AND full=ON`.
+    /// Verified against sqlite3 3.51.0 (colname.test rules (3)/(5)):
+    ///
+    /// | short | full | `SELECT * FROM tabc` |
+    /// |-------|------|----------------------|
+    /// | ON    | ON   | `a` (short wins)     |
+    /// | ON    | OFF  | `a`                  |
+    /// | OFF   | ON   | `tabc.a`             |
+    /// | OFF   | OFF  | `a`                  |
+    fn get_wildcard_naming_mode(&self) -> ColumnNamingMode {
+        let mode = self.get_column_naming_mode();
+        // short_column_names=ON forces bare column names for wildcards, even
+        // when full_column_names=ON. Downgrade Full -> Short in that case.
+        if mode == ColumnNamingMode::Full && self.database.short_column_names() {
+            ColumnNamingMode::Short
+        } else {
+            mode
+        }
+    }
+
     /// Derive column names from SELECT list
     ///
     /// Column naming follows SQLite's PRAGMA settings:
@@ -47,7 +78,8 @@ impl SelectExecutor<'_> {
         from_result: Option<&FromResult>,
     ) -> Result<Vec<String>, ExecutorError> {
         let mode = self.get_column_naming_mode();
-        self.derive_column_names_internal(select_list, from_result, mode)
+        let wildcard_mode = self.get_wildcard_naming_mode();
+        self.derive_column_names_internal(select_list, from_result, mode, wildcard_mode)
     }
 
     /// Derive simple column names (without table prefix) for internal use
@@ -59,15 +91,26 @@ impl SelectExecutor<'_> {
         select_list: &[vibesql_ast::SelectItem],
         from_result: Option<&FromResult>,
     ) -> Result<Vec<String>, ExecutorError> {
-        self.derive_column_names_internal(select_list, from_result, ColumnNamingMode::Short)
+        self.derive_column_names_internal(
+            select_list,
+            from_result,
+            ColumnNamingMode::Short,
+            ColumnNamingMode::Short,
+        )
     }
 
-    /// Internal implementation with configurable naming mode
+    /// Internal implementation with configurable naming mode.
+    ///
+    /// `mode` governs explicit column references; `wildcard_mode` governs
+    /// `SELECT *` / `SELECT table.*` expansion. They differ only when
+    /// `short_column_names=ON AND full_column_names=ON`, where wildcards use
+    /// bare names but explicit references remain `table.column`.
     fn derive_column_names_internal(
         &self,
         select_list: &[vibesql_ast::SelectItem],
         from_result: Option<&FromResult>,
         mode: ColumnNamingMode,
+        wildcard_mode: ColumnNamingMode,
     ) -> Result<Vec<String>, ExecutorError> {
         let mut column_names = Vec::new();
         let schema = from_result.map(|fr| &fr.schema);
@@ -198,7 +241,7 @@ impl SelectExecutor<'_> {
                             // name in full_column_names mode, even for a single-table query
                             // (colname.test section 4: `SELECT * FROM tabc` -> tabc.a, ...).
                             for (_, col_name, effective_table_name) in table_columns {
-                                let display_name = match mode {
+                                let display_name = match wildcard_mode {
                                     ColumnNamingMode::Full => {
                                         format!("{}.{}", effective_table_name, col_name)
                                     }
@@ -239,7 +282,7 @@ impl SelectExecutor<'_> {
                                 // The prefix uses the schema's canonical table name, not the
                                 // qualifier as typed.
                                 for col_schema in &table_schema.columns {
-                                    let display_name = match mode {
+                                    let display_name = match wildcard_mode {
                                         ColumnNamingMode::Full => {
                                             format!("{}.{}", table_schema.name, col_schema.name)
                                         }

--- a/crates/vibesql-executor/tests/column_names_tests.rs
+++ b/crates/vibesql-executor/tests/column_names_tests.rs
@@ -82,12 +82,11 @@ fn test_column_names_star_expansion() {
     let stmt = vibesql_parser::Parser::parse_sql("SELECT * FROM employees").unwrap();
     if let vibesql_ast::Statement::Select(select_stmt) = stmt {
         let result = executor.execute_with_columns(&select_stmt).unwrap();
-        // With full_column_names=ON, SELECT * prefixes every column with its source
-        // table name, even for a single-table query (colname.test section 4.1).
-        assert_eq!(
-            result.columns,
-            vec!["employees.id", "employees.name", "employees.department", "employees.salary"]
-        );
+        // create_test_database sets full_column_names=ON but leaves
+        // short_column_names at its default (ON). Per sqlite3 3.51.0, short=ON
+        // overrides full=ON for wildcard expansion (issue #5974), so SELECT *
+        // yields bare column names here.
+        assert_eq!(result.columns, vec!["id", "name", "department", "salary"]);
         assert_eq!(result.rows.len(), 3);
     } else {
         panic!("Expected SELECT statement");
@@ -274,13 +273,33 @@ fn test_pragma_wildcard_short_column_names() {
 fn test_pragma_wildcard_full_column_names() {
     let mut db = create_test_database_default_settings();
     db.set_full_column_names(true);
+    // short_column_names is still ON (the default). Per sqlite3 3.51.0, short=ON
+    // overrides full=ON for wildcards (issue #5974): SELECT * -> bare names.
 
     let executor = SelectExecutor::new(&db);
 
     let stmt = vibesql_parser::Parser::parse_sql("SELECT * FROM employees").unwrap();
     if let vibesql_ast::Statement::Select(select_stmt) = stmt {
         let result = executor.execute_with_columns(&select_stmt).unwrap();
-        // full_column_names=ON: SELECT * uses table.column form (colname.test section 4.1)
+        assert_eq!(result.columns, vec!["id", "name"]);
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+#[test]
+fn test_pragma_wildcard_full_only_short_off() {
+    // The table-qualified wildcard form requires short=OFF AND full=ON.
+    let mut db = create_test_database_default_settings();
+    db.set_full_column_names(true);
+    db.set_short_column_names(false);
+
+    let executor = SelectExecutor::new(&db);
+
+    let stmt = vibesql_parser::Parser::parse_sql("SELECT * FROM employees").unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let result = executor.execute_with_columns(&select_stmt).unwrap();
+        // short=OFF, full=ON: SELECT * uses table.column form (colname.test section 4.1)
         assert_eq!(result.columns, vec!["employees.id", "employees.name"]);
     } else {
         panic!("Expected SELECT statement");
@@ -435,6 +454,102 @@ fn test_short_column_names_star_no_prefix() {
     } else {
         panic!("Expected SELECT statement");
     }
+}
+
+// ---------------------------------------------------------------------------
+// short_column_names=ON overrides full_column_names=ON for wildcards (issue
+// #5974). Verified against sqlite3 3.51.0 (colname.test rules (3)/(5)): the
+// `table.column` prefix appears for a wildcard ONLY when short=OFF AND full=ON.
+// Explicit column references are governed separately: full=ON keeps `table.col`
+// even when short=ON.
+//
+// Wildcard precedence matrix (SELECT * FROM tabc):
+//   | short | full | wildcard columns |
+//   |-------|------|------------------|
+//   | ON    | ON   | a, b, c          |  <- the case this issue fixes
+//   | ON    | OFF  | a, b, c          |
+//   | OFF   | ON   | tabc.a, ...      |
+//   | OFF   | OFF  | a, b, c          |
+// ---------------------------------------------------------------------------
+
+fn create_wildcard_matrix_database(short: bool, full: bool) -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    db.set_short_column_names(short);
+    db.set_full_column_names(full);
+
+    let create_stmt = vibesql_parser::Parser::parse_sql("CREATE TABLE tabc(a, b, c)").unwrap();
+    if let vibesql_ast::Statement::CreateTable(create_table) = create_stmt {
+        vibesql_executor::CreateTableExecutor::execute(&create_table, &mut db).unwrap();
+    }
+    let insert_stmt =
+        vibesql_parser::Parser::parse_sql("INSERT INTO tabc VALUES(1, 2, 3)").unwrap();
+    if let vibesql_ast::Statement::Insert(insert) = insert_stmt {
+        vibesql_executor::InsertExecutor::execute(&mut db, &insert).unwrap();
+    }
+    db
+}
+
+#[test]
+fn test_wildcard_matrix_short_on_full_on() {
+    // short=ON wins: SELECT * -> bare column names even with full=ON.
+    let db = create_wildcard_matrix_database(true, true);
+    let result = run_select(&db, "SELECT * FROM tabc").unwrap();
+    assert_eq!(result.columns, vec!["a", "b", "c"]);
+}
+
+#[test]
+fn test_wildcard_matrix_short_on_full_off() {
+    // Default-like: short=ON, full=OFF -> bare names.
+    let db = create_wildcard_matrix_database(true, false);
+    let result = run_select(&db, "SELECT * FROM tabc").unwrap();
+    assert_eq!(result.columns, vec!["a", "b", "c"]);
+}
+
+#[test]
+fn test_wildcard_matrix_short_off_full_on() {
+    // Only combination that prefixes wildcards: short=OFF, full=ON.
+    let db = create_wildcard_matrix_database(false, true);
+    let result = run_select(&db, "SELECT * FROM tabc").unwrap();
+    assert_eq!(result.columns, vec!["tabc.a", "tabc.b", "tabc.c"]);
+}
+
+#[test]
+fn test_wildcard_matrix_short_off_full_off() {
+    // Both off -> bare names for wildcards.
+    let db = create_wildcard_matrix_database(false, false);
+    let result = run_select(&db, "SELECT * FROM tabc").unwrap();
+    assert_eq!(result.columns, vec!["a", "b", "c"]);
+}
+
+#[test]
+fn test_wildcard_short_on_full_on_multi_table() {
+    // short=ON overrides full=ON for multi-table wildcards too: all bare.
+    let mut db = create_two_table_database_full_names();
+    db.set_short_column_names(true); // full stays ON
+    let result = run_select(&db, "SELECT * FROM tabc, txyz").unwrap();
+    assert_eq!(result.columns, vec!["a", "b", "c", "x", "y", "z"]);
+}
+
+#[test]
+fn test_wildcard_short_on_full_on_qualified() {
+    // Qualified wildcard (table.*) is always bare, unaffected by short/full.
+    let mut db = create_two_table_database_full_names();
+    db.set_short_column_names(true); // full stays ON
+    let result = run_select(&db, "SELECT tabc.* FROM tabc").unwrap();
+    assert_eq!(result.columns, vec!["a", "b", "c"]);
+}
+
+#[test]
+fn test_explicit_column_ref_short_on_full_on_keeps_prefix() {
+    // Regression guard: explicit column references follow full=ON regardless of
+    // short. sqlite3 3.51.0: `SELECT a FROM tabc` with short=ON, full=ON -> tabc.a.
+    let db = create_wildcard_matrix_database(true, true);
+    let result = run_select(&db, "SELECT a FROM tabc").unwrap();
+    assert_eq!(result.columns, vec!["tabc.a"]);
+
+    // Qualified explicit reference likewise stays table-qualified.
+    let result = run_select(&db, "SELECT tabc.a FROM tabc").unwrap();
+    assert_eq!(result.columns, vec!["tabc.a"]);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`get_column_naming_mode()` mapped `full_column_names=ON` to `ColumnNamingMode::Full` unconditionally, so `SELECT *` with both `short_column_names=ON` and `full_column_names=ON` produced `tabc.a, tabc.b, tabc.c`. sqlite3 3.51.0 lets `short_column_names=ON` win for wildcard expansion: the `table.column` prefix appears **only** when `short=OFF AND full=ON`. This PR fixes wildcard expansion to match sqlite3 while preserving the (also sqlite-correct) behavior that explicit column references still follow `full=ON` regardless of `short`.

## Precedence verified against sqlite3 3.51.0 (all four combinations)

`SELECT * FROM tabc` wildcard expansion:

| short | full | wildcard columns | explicit `SELECT a` |
|-------|------|------------------|---------------------|
| ON    | ON   | `a, b, c`        | `tabc.a`            |
| ON    | OFF  | `a, b, c`        | `a`                 |
| OFF   | ON   | `tabc.a, ...`    | `tabc.a`            |
| OFF   | OFF  | `a, b, c`        | `a` (bare col)      |

Key nuance confirmed against sqlite3: the `short=ON` override applies **only to wildcards**. For explicit references, `full=ON` still yields `tabc.a` even when `short=ON` — so the fix must be narrow, not a blanket change to `get_column_naming_mode()`.

## Changes

- Add `get_wildcard_naming_mode()` which downgrades `Full` -> `Short` when `short_column_names` is ON; `get_column_naming_mode()` (explicit refs) is unchanged.
- Thread a separate `wildcard_mode` through `derive_column_names_internal`; the `Wildcard` and `QualifiedWildcard` branches use it, expression naming keeps the original `mode`.
- `derive_simple_column_names` passes `Short` for both modes (unchanged behavior).
- Add unit tests covering the full four-combination matrix (wildcard + explicit ref, single- and multi-table, qualified wildcard).
- Correct two pre-existing wildcard tests (`test_column_names_star_expansion`, `test_pragma_wildcard_full_column_names`) that asserted the old buggy behavior (they set `full=ON` while `short` stayed at its default ON); added `test_pragma_wildcard_full_only_short_off` to keep coverage of the `short=OFF full=ON` prefixed form.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `short=ON full=ON` wildcard returns bare names | ✅ | `test_wildcard_matrix_short_on_full_on`, `test_wildcard_short_on_full_on_multi_table`, `test_wildcard_short_on_full_on_qualified` |
| Only `short=OFF full=ON` prefixes wildcards | ✅ | `test_wildcard_matrix_short_off_full_on`, `test_pragma_wildcard_full_only_short_off` |
| Explicit refs still follow `full=ON` under `short=ON` | ✅ | `test_explicit_column_ref_short_on_full_on_keeps_prefix` (returns `tabc.a`) |
| Full four-combination matrix verified vs sqlite3 3.51.0 | ✅ | Matrix above; unit tests mirror each cell |
| No colname.test regression | ✅ | `make test-tcl-file FILE=colname.test` -> 62/66, matches baseline |

## Test Plan

- `cargo test -p vibesql-executor` — all pass (3264 lib + integration suites, 0 failures); `column_names_tests` 30/30.
- `make test-tcl-file FILE=colname.test` — 62/66 passed, identical to the 62/66 baseline (4 pre-existing failures: colname-7.1, 9.410, 10.100, 10.110 — unrelated).
- `rustfmt --check` clean on both touched files.

Closes #5974