### PR TITLE
fix(returning): recompute RETURNING subqueries per row as each row is mutated

### DIFF
--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -525,6 +525,19 @@ impl DeleteExecutor {
         // than any ancestor is iterating compacts normally.
         let defer_compaction = crate::compaction_guard::is_iterating(table_name);
         let deleted_count: usize;
+
+        // When a RETURNING expression contains a subquery, that subquery must be
+        // recomputed per row as each row is deleted (it observes the incremental
+        // post-DELETE table state), matching SQLite's correlated-subquery
+        // treatment (returning1.test section 20). We detect this case up front so
+        // the common subquery-free RETURNING keeps the cheap batch path below
+        // with zero behavior change. `per_row_returning`, when `Some`, holds the
+        // fully projected RETURNING result and suppresses the statement-end
+        // projection.
+        let returning_needs_per_row =
+            stmt.returning.as_deref().is_some_and(crate::dml_returning::returning_has_subquery);
+        let mut per_row_returning: Option<crate::select::SelectResult> = None;
+
         if has_delete_triggers {
             #[cfg(feature = "mvcc_enabled")]
             let mvcc_delete_txn_id = database.transaction_id();
@@ -665,6 +678,100 @@ impl DeleteExecutor {
             // are excluded).
             rows_and_indices_to_delete = applied_rows;
             deleted_count = deleted;
+        } else if returning_needs_per_row {
+            // Per-row RETURNING path (no triggers): delete each row, then
+            // project its RETURNING row against the now-updated table state so
+            // subqueries recompute after each step. Deletions use the bitmap
+            // (`mark_deleted_inplace`) so physical indices stay valid across the
+            // loop; compaction and any index rebuild happen once at the end,
+            // mirroring the trigger path above.
+            #[cfg(feature = "mvcc_enabled")]
+            let mvcc_delete_txn_id = database.transaction_id();
+
+            let _iter_guard = crate::compaction_guard::IterationGuard::new(table_name);
+
+            let items = stmt.returning.as_deref().expect("returning present");
+            let visible_columns = crate::dml_returning::visible_columns(&schema);
+            let columns = crate::dml_returning::derive_returning_columns(
+                items,
+                &schema,
+                None,
+                &visible_columns,
+            )?;
+            let mut result_rows: Vec<vibesql_storage::Row> =
+                Vec::with_capacity(rows_and_indices_to_delete.len());
+
+            let mut deleted = 0usize;
+            let mut compacted = false;
+
+            for (idx, row) in rows_and_indices_to_delete.iter() {
+                // Referential integrity for this row (CASCADE / SET NULL / etc.)
+                check_no_child_references(database, table_name, row)?;
+
+                // WAL + index maintenance for this single row (indices stay
+                // valid: compaction is deferred to the end of the loop).
+                database.emit_wal_delete(table_name, *idx as u64, row.values.to_vec());
+                let rows_refs: Vec<(usize, &vibesql_storage::Row)> = vec![(*idx, row)];
+                database.batch_update_indexes_for_delete(table_name, &rows_refs);
+                expression_index_maintenance::maintain_expression_indexes_for_delete(
+                    database, table_name, row, *idx,
+                );
+                partial_index_maintenance::maintain_partial_indexes_for_delete(
+                    database, table_name, row, *idx,
+                );
+
+                {
+                    let table_mut = database
+                        .get_table_mut(table_name)
+                        .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
+
+                    #[cfg(feature = "mvcc_enabled")]
+                    if let Some(id) = mvcc_delete_txn_id {
+                        table_mut.stamp_row_xmax_inplace(*idx, id);
+                    }
+
+                    if table_mut.mark_deleted_inplace(*idx) {
+                        deleted += 1;
+                    }
+                }
+
+                // Drop the stale row-oriented columnar snapshot so the RETURNING
+                // subquery sees this row's deletion (mirrors the trigger path).
+                database.invalidate_columnar_cache(table_name);
+
+                // Project this row's RETURNING against the now-updated state.
+                let projected = crate::dml_returning::project_returning_row(
+                    items,
+                    &columns,
+                    &schema,
+                    database,
+                    row,
+                    &visible_columns,
+                    cte_results.as_ref(),
+                )?;
+                result_rows.push(projected);
+            }
+
+            if deleted > 0 {
+                if !defer_compaction {
+                    if let Some(table_mut) = database.get_table_mut(table_name) {
+                        compacted = table_mut.compact_if_needed();
+                    }
+                    if compacted {
+                        database.rebuild_indexes(table_name);
+                        expression_index_maintenance::rebuild_expression_indexes_after_compaction(
+                            database, table_name,
+                        );
+                        partial_index_maintenance::rebuild_partial_indexes_after_compaction(
+                            database, table_name,
+                        );
+                    }
+                }
+                database.invalidate_columnar_cache(table_name);
+            }
+
+            deleted_count = deleted;
+            per_row_returning = Some(crate::select::SelectResult { columns, rows: result_rows });
         } else {
             // Fast path: no DELETE triggers — batch delete as before.
 
@@ -777,7 +884,10 @@ impl DeleteExecutor {
         // Rows are projected in collection order (ORDER BY/LIMIT already
         // applied); zero deleted rows yields an empty result whose column
         // names are still derived from the RETURNING items.
-        let returning = if let Some(items) = &stmt.returning {
+        let returning = if let Some(per_row) = per_row_returning {
+            // Already projected per row (subquery-bearing RETURNING).
+            Some(per_row)
+        } else if let Some(items) = &stmt.returning {
             let old_rows: Vec<&vibesql_storage::Row> =
                 rows_and_indices_to_delete.iter().map(|(_, row)| row).collect();
             Some(crate::dml_returning::project_returning(

--- a/crates/vibesql-executor/src/dml_returning.rs
+++ b/crates/vibesql-executor/src/dml_returning.rs
@@ -13,6 +13,7 @@
 use vibesql_ast::{Expression, SelectItem};
 use vibesql_catalog::TableSchema;
 use vibesql_storage::{Database, Row};
+use vibesql_types::SqlValue;
 
 use crate::{errors::ExecutorError, evaluator::ExpressionEvaluator, select::SelectResult};
 
@@ -50,17 +51,49 @@ pub(crate) fn project_returning(
         evaluator.set_table_alias(alias.to_string());
     }
 
-    // Indices of columns expanded by `*` (hidden `__hidden__*` view columns
-    // are excluded, matching SQLite's hidden-column convention).
-    let visible_columns: Vec<usize> = schema
+    let visible_columns = visible_columns(schema);
+    let columns = derive_returning_columns(items, schema, table_alias, &visible_columns)?;
+
+    // Evaluate each item against each row.
+    let mut result_rows: Vec<Row> = Vec::with_capacity(rows.len());
+    for row in rows {
+        // Clear the CSE cache so expression results from the previous row
+        // are not replayed for this one.
+        evaluator.clear_cse_cache();
+        let values = project_returning_row_with(
+            &mut evaluator,
+            items,
+            &visible_columns,
+            columns.len(),
+            row,
+        )?;
+        result_rows.push(Row::new(values));
+    }
+
+    Ok(SelectResult { columns, rows: result_rows })
+}
+
+/// Indices of columns expanded by `*` (hidden `__hidden__*` view columns are
+/// excluded, matching SQLite's hidden-column convention).
+pub(crate) fn visible_columns(schema: &TableSchema) -> Vec<usize> {
+    schema
         .columns
         .iter()
         .enumerate()
         .filter(|(_, c)| !c.name.starts_with("__hidden__"))
         .map(|(i, _)| i)
-        .collect();
+        .collect()
+}
 
-    // Derive result column names (computable even with zero updated rows).
+/// Derive RETURNING result column names (computable even with zero affected
+/// rows: aliases win, then a bare column's canonical name, then the source
+/// text, then a debug fallback).
+pub(crate) fn derive_returning_columns(
+    items: &[SelectItem],
+    schema: &TableSchema,
+    table_alias: Option<&str>,
+    visible_columns: &[usize],
+) -> Result<Vec<String>, ExecutorError> {
     let mut columns: Vec<String> = Vec::new();
     for item in items {
         match item {
@@ -85,35 +118,137 @@ pub(crate) fn project_returning(
             }
         }
     }
+    Ok(columns)
+}
 
-    // Evaluate each item against each row.
-    let mut result_rows: Vec<Row> = Vec::with_capacity(rows.len());
-    for row in rows {
-        // Clear the CSE cache so expression results from the previous row
-        // are not replayed for this one.
-        evaluator.clear_cse_cache();
-        let mut values = Vec::with_capacity(columns.len());
-        for item in items {
-            match item {
-                SelectItem::Wildcard { .. } | SelectItem::QualifiedWildcard { .. } => {
-                    for &i in &visible_columns {
-                        values.push(
-                            row.values
-                                .get(i)
-                                .cloned()
-                                .ok_or(ExecutorError::ColumnIndexOutOfBounds { index: i })?,
-                        );
-                    }
-                }
-                SelectItem::Expression { expr, .. } => {
-                    values.push(evaluator.eval(expr, row)?);
+/// Project a single RETURNING result row using an already-configured
+/// evaluator. Shared by the batch path and the per-row (subquery) path.
+fn project_returning_row_with(
+    evaluator: &mut ExpressionEvaluator,
+    items: &[SelectItem],
+    visible_columns: &[usize],
+    column_count: usize,
+    row: &Row,
+) -> Result<Vec<SqlValue>, ExecutorError> {
+    let mut values = Vec::with_capacity(column_count);
+    for item in items {
+        match item {
+            SelectItem::Wildcard { .. } | SelectItem::QualifiedWildcard { .. } => {
+                for &i in visible_columns {
+                    values.push(
+                        row.values
+                            .get(i)
+                            .cloned()
+                            .ok_or(ExecutorError::ColumnIndexOutOfBounds { index: i })?,
+                    );
                 }
             }
+            SelectItem::Expression { expr, .. } => {
+                values.push(evaluator.eval(expr, row)?);
+            }
         }
-        result_rows.push(Row::new(values));
     }
+    Ok(values)
+}
 
-    Ok(SelectResult { columns, rows: result_rows })
+/// Project one RETURNING result row against the *current* database state.
+///
+/// Unlike [`project_returning`] (which evaluates every row against a single
+/// database snapshot), this evaluates a single affected row against the
+/// database as it stands right now — the caller invokes it once per row,
+/// interleaved with the incremental mutation of each row, so subqueries in
+/// RETURNING expressions observe the per-row post-mutation state. This matches
+/// SQLite, where a subquery referencing the table being modified is treated as
+/// correlated and recomputed after each step (returning1.test section 20).
+///
+/// A fresh evaluator is built per call so the subquery sees the live database;
+/// this is only used on the subquery-bearing slow path, so the extra cost is
+/// confined to that case.
+pub(crate) fn project_returning_row(
+    items: &[SelectItem],
+    columns: &[String],
+    schema: &TableSchema,
+    database: &Database,
+    row: &Row,
+    visible_columns: &[usize],
+    cte_results: Option<&std::collections::HashMap<String, crate::select::cte::CteResult>>,
+) -> Result<Row, ExecutorError> {
+    let mut evaluator = ExpressionEvaluator::with_database(schema, database);
+    if let Some(ctes) = cte_results {
+        evaluator = evaluator.with_cte_context(ctes);
+    }
+    let values =
+        project_returning_row_with(&mut evaluator, items, visible_columns, columns.len(), row)?;
+    Ok(Row::new(values))
+}
+
+/// True if any RETURNING expression contains a subquery. Subquery-bearing
+/// RETURNING must be projected per row as each row is mutated (so the subquery
+/// recomputes against the incremental table state); subquery-free RETURNING
+/// keeps the cheaper statement-end batch path with zero behavior change.
+pub(crate) fn returning_has_subquery(items: &[SelectItem]) -> bool {
+    items.iter().any(|item| match item {
+        SelectItem::Expression { expr, .. } => expression_has_subquery(expr),
+        _ => false,
+    })
+}
+
+/// Recursively test whether an expression contains any subquery form
+/// (scalar subquery, IN (SELECT), EXISTS, or a quantified comparison).
+fn expression_has_subquery(expr: &Expression) -> bool {
+    use Expression::*;
+    match expr {
+        ScalarSubquery(_) | Exists { .. } => true,
+        In { expr, .. } => {
+            // `IN (SELECT ...)` always carries a subquery.
+            let _ = expr;
+            true
+        }
+        QuantifiedComparison { .. } => true,
+        InList { expr, values, .. } => {
+            expression_has_subquery(expr) || values.iter().any(expression_has_subquery)
+        }
+        BinaryOp { left, right, .. } | IsDistinctFrom { left, right, .. } => {
+            expression_has_subquery(left) || expression_has_subquery(right)
+        }
+        Conjunction(exprs) | Disjunction(exprs) => exprs.iter().any(expression_has_subquery),
+        UnaryOp { expr, .. } | IsNull { expr, .. } | IsTruthValue { expr, .. } => {
+            expression_has_subquery(expr)
+        }
+        Cast { expr, .. } => expression_has_subquery(expr),
+        Extract { expr, .. } => expression_has_subquery(expr),
+        Between { expr, low, high, .. } => {
+            expression_has_subquery(expr)
+                || expression_has_subquery(low)
+                || expression_has_subquery(high)
+        }
+        Like { expr, pattern, escape, .. } | Glob { expr, pattern, escape, .. } => {
+            expression_has_subquery(expr)
+                || expression_has_subquery(pattern)
+                || escape.as_deref().is_some_and(expression_has_subquery)
+        }
+        Position { substring, string, .. } => {
+            expression_has_subquery(substring) || expression_has_subquery(string)
+        }
+        Trim { removal_char, string, .. } => {
+            removal_char.as_deref().is_some_and(expression_has_subquery)
+                || expression_has_subquery(string)
+        }
+        Function { args, .. } => args.iter().any(expression_has_subquery),
+        AggregateFunction { args, filter, .. } => {
+            args.iter().any(expression_has_subquery)
+                || filter.as_deref().is_some_and(expression_has_subquery)
+        }
+        Case { operand, when_clauses, else_result } => {
+            operand.as_deref().is_some_and(expression_has_subquery)
+                || when_clauses.iter().any(|w| {
+                    w.conditions.iter().any(expression_has_subquery)
+                        || expression_has_subquery(&w.result)
+                })
+                || else_result.as_deref().is_some_and(expression_has_subquery)
+        }
+        _ => false,
+    }
 }
 
 /// Validate that a qualified wildcard (`t.*`) refers to the target table.

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -850,6 +850,18 @@ pub(super) fn execute_internal(
     // updated; a RAISE(IGNORE) there cannot revert it (sqlite3 3.51 keeps the
     // modified row), so SkipRow is a no-op for AFTER.
     let mut index_updates = Vec::new();
+
+    // When a RETURNING expression contains a subquery, that subquery must be
+    // recomputed per row as each row's NEW state is applied (it observes the
+    // incremental post-UPDATE table state), matching SQLite's correlated-
+    // subquery treatment (returning1.test section 20). Detect this up front so
+    // the common subquery-free RETURNING keeps the cheap batch path with zero
+    // behavior change. `per_row_returning`, when `Some`, holds the fully
+    // projected RETURNING result and suppresses the statement-end projection.
+    let returning_needs_per_row =
+        stmt.returning.as_deref().is_some_and(crate::dml_returning::returning_has_subquery);
+    let mut per_row_returning: Option<crate::select::SelectResult> = None;
+
     if has_triggers {
         // Register this table as under interleaved iteration so a nested DELETE
         // on it (fired by a row trigger below) defers compaction — compacting
@@ -957,6 +969,52 @@ pub(super) fn execute_internal(
         // dropped) so RETURNING / change-count reflect SQLite semantics.
         let applied: HashSet<usize> = index_updates.iter().map(|(idx, ..)| *idx).collect();
         updates.retain(|u| applied.contains(&u.row_index));
+    } else if returning_needs_per_row {
+        // No triggers, but RETURNING contains a subquery: apply each row's NEW
+        // state, then project that row's RETURNING against the now-updated table
+        // so subqueries recompute after each step. Applying and projecting are
+        // interleaved (the batch fast path below cannot express this because it
+        // projects only once, after every row is already updated).
+        let items = stmt.returning.as_deref().expect("returning present");
+        let visible_columns = crate::dml_returning::visible_columns(schema);
+        let columns =
+            crate::dml_returning::derive_returning_columns(items, schema, None, &visible_columns)?;
+        let mut result_rows: Vec<Row> = Vec::with_capacity(updates.len());
+
+        for u in &updates {
+            {
+                let table_mut = database
+                    .get_table_mut(table_name)
+                    .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
+                table_mut
+                    .update_row_selective(u.row_index, u.new_row.clone(), &u.changed_columns)
+                    .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+            }
+
+            // Drop the stale database-level columnar snapshot so the RETURNING
+            // subquery sees this row's applied NEW values.
+            database.invalidate_columnar_cache(table_name);
+
+            let projected = crate::dml_returning::project_returning_row(
+                items,
+                &columns,
+                schema,
+                database,
+                &u.new_row,
+                &visible_columns,
+                cte_results.as_ref(),
+            )?;
+            result_rows.push(projected);
+
+            index_updates.push((
+                u.row_index,
+                u.old_row.clone(),
+                u.new_row.clone(),
+                u.changed_columns.clone(),
+            ));
+        }
+
+        per_row_returning = Some(crate::select::SelectResult { columns, rows: result_rows });
     } else {
         // No triggers: apply all updates in one batch borrow.
         let table_mut = database
@@ -1050,7 +1108,10 @@ pub(super) fn execute_internal(
     // succeeds — the opposite of WHERE/SET resolution (see returning1.test
     // 7.7/7.8, issue #5840 item 6). Pass `None` so RETURNING resolves
     // qualified references against the real table name, not the alias.
-    let returning = if let Some(items) = &stmt.returning {
+    let returning = if let Some(per_row) = per_row_returning {
+        // Already projected per row (subquery-bearing RETURNING).
+        Some(per_row)
+    } else if let Some(items) = &stmt.returning {
         let new_rows: Vec<&Row> = updates.iter().map(|u| &u.new_row).collect();
         Some(crate::dml_returning::project_returning(
             items,

--- a/crates/vibesql-executor/tests/returning_per_row_subquery_tests.rs
+++ b/crates/vibesql-executor/tests/returning_per_row_subquery_tests.rs
@@ -1,0 +1,238 @@
+//! Regression tests for issue #5972
+//!
+//! A subquery inside a RETURNING expression must be recomputed **per row, as
+//! each affected row is mutated** — it sees the incremental post-DML table
+//! state, not a single snapshot taken after the whole statement completes.
+//! SQLite documents this (returning1.test section 20): a subquery that
+//! references the table being modified is treated as correlated and recomputed
+//! after each step.
+//!
+//! Previously VibeSQL collected all affected rows, then projected RETURNING
+//! once at statement end, so every RETURNING row observed the same final
+//! database state. This module pins the per-row behavior for both DELETE and
+//! UPDATE. Subquery-free RETURNING keeps the statement-end batch path (also
+//! covered here to guard against a regression in the common case).
+//!
+//! All expected values were verified against sqlite3 3.51.0.
+
+use vibesql_executor::{DeleteExecutor, InsertExecutor, SelectResult, UpdateExecutor};
+use vibesql_types::SqlValue;
+
+fn setup(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Parse failed: {} -- {:?}", sql, e));
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            InsertExecutor::execute(db, &insert)
+                .unwrap_or_else(|e| panic!("Insert failed: {} -- {:?}", sql, e));
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+fn delete_returning(db: &mut vibesql_storage::Database, sql: &str) -> SelectResult {
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Parse failed: {} -- {:?}", sql, e));
+    let vibesql_ast::Statement::Delete(delete) = stmt else {
+        panic!("Expected DELETE: {}", sql);
+    };
+    let (_count, returning) = DeleteExecutor::execute_returning(&delete, db)
+        .unwrap_or_else(|e| panic!("Delete failed: {} -- {:?}", sql, e));
+    returning.expect("RETURNING result present")
+}
+
+fn update_returning(db: &mut vibesql_storage::Database, sql: &str) -> SelectResult {
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Parse failed: {} -- {:?}", sql, e));
+    let vibesql_ast::Statement::Update(update) = stmt else {
+        panic!("Expected UPDATE: {}", sql);
+    };
+    let (_count, returning) = UpdateExecutor::execute_returning(&update, db)
+        .unwrap_or_else(|e| panic!("Update failed: {} -- {:?}", sql, e));
+    returning.expect("RETURNING result present")
+}
+
+/// A variant-agnostic cell used for comparisons: any SQL float variant
+/// (`Real`/`Double`/`Float`/`Numeric`) collapses to `Float(f64)` so the tests
+/// pin the *numeric* result without depending on which float variant a given
+/// expression happens to produce (e.g. `round(avg(...))` yields `Double`,
+/// while `round(avg(...)) + int*100` yields `Float`). Integers and NULL stay
+/// exact.
+#[derive(Debug)]
+enum Cell {
+    Int(i64),
+    Float(f64),
+    Null,
+}
+
+impl PartialEq for Cell {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Cell::Int(a), Cell::Int(b)) => a == b,
+            // Compare floats with a tolerance: the correlated subquery arm
+            // yields an `f32` (`SqlValue::Float`), so 104.6 round-trips as
+            // 104.5999984741211. sqlite3 3.51.0 displays 104.6; the values are
+            // equal to f32 precision.
+            (Cell::Float(a), Cell::Float(b)) => (a - b).abs() < 1e-3,
+            (Cell::Null, Cell::Null) => true,
+            _ => false,
+        }
+    }
+}
+
+fn int(v: i64) -> Cell {
+    Cell::Int(v)
+}
+
+fn real(v: f64) -> Cell {
+    Cell::Float(v)
+}
+
+const NULL: Cell = Cell::Null;
+
+fn normalize(v: &SqlValue) -> Cell {
+    match v {
+        SqlValue::Integer(i) | SqlValue::Bigint(i) => Cell::Int(*i),
+        SqlValue::Smallint(i) => Cell::Int(*i as i64),
+        SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f) => Cell::Float(*f),
+        SqlValue::Float(f) => Cell::Float(*f as f64),
+        SqlValue::Null => Cell::Null,
+        other => panic!("unexpected value in RETURNING result: {:?}", other),
+    }
+}
+
+fn rows(result: &SelectResult) -> Vec<Vec<Cell>> {
+    result.rows.iter().map(|r| r.values.iter().map(normalize).collect()).collect()
+}
+
+fn seed(db: &mut vibesql_storage::Database) {
+    setup(db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT)");
+    setup(db, "INSERT INTO t1 VALUES(1,10),(2,20),(3,30),(4,40),(6,60),(8,80)");
+}
+
+/// returning1.test 20.1 — DELETE ... WHERE with min/max/avg subqueries.
+/// Each returned row observes the table *after* that row is deleted.
+#[test]
+fn delete_returning_subquery_recomputes_per_row() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+    let result = delete_returning(
+        &mut db,
+        "DELETE FROM t1 WHERE a<>3 RETURNING a,\
+         (SELECT min(a) FROM t1),(SELECT max(a) FROM t1),(SELECT round(avg(a),2) FROM t1)",
+    );
+    assert_eq!(
+        rows(&result),
+        vec![
+            vec![int(1), int(2), int(8), real(4.6)],
+            vec![int(2), int(3), int(8), real(5.25)],
+            vec![int(4), int(3), int(8), real(5.67)],
+            vec![int(6), int(3), int(8), real(5.5)],
+            vec![int(8), int(3), int(3), real(3.0)],
+        ]
+    );
+}
+
+/// returning1.test 20.2 — DELETE the whole table; the last row's subqueries
+/// see an empty table and return NULL.
+#[test]
+fn delete_returning_subquery_full_table_last_row_sees_empty() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+    let result = delete_returning(
+        &mut db,
+        "DELETE FROM t1 RETURNING a,\
+         (SELECT min(a) FROM t1),(SELECT max(a) FROM t1),(SELECT round(avg(a),2) FROM t1)",
+    );
+    assert_eq!(
+        rows(&result),
+        vec![
+            vec![int(1), int(2), int(8), real(4.6)],
+            vec![int(2), int(3), int(8), real(5.25)],
+            vec![int(3), int(4), int(8), real(6.0)],
+            vec![int(4), int(6), int(8), real(7.0)],
+            vec![int(6), int(8), int(8), real(8.0)],
+            vec![int(8), NULL, NULL, NULL],
+        ]
+    );
+}
+
+/// returning1.test 20.3 — the subquery is correlated to the per-row value
+/// (`t1.a` inside the subquery), and must still recompute per row.
+#[test]
+fn delete_returning_correlated_subquery_recomputes_per_row() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+    let result = delete_returning(
+        &mut db,
+        "DELETE FROM t1 RETURNING a,\
+         (SELECT min(t2.a)+t1.a*100 FROM t1 AS t2),\
+         (SELECT max(t2.a)+t1.a*100 FROM t1 AS t2),\
+         (SELECT round(avg(t2.a),2)+t1.a*100 FROM t1 AS t2)",
+    );
+    assert_eq!(
+        rows(&result),
+        vec![
+            vec![int(1), int(102), int(108), real(104.6)],
+            vec![int(2), int(203), int(208), real(205.25)],
+            vec![int(3), int(304), int(308), real(306.0)],
+            vec![int(4), int(406), int(408), real(407.0)],
+            vec![int(6), int(608), int(608), real(608.0)],
+            vec![int(8), NULL, NULL, NULL],
+        ]
+    );
+}
+
+/// UPDATE ... RETURNING with a subquery: each row's NEW state is applied
+/// incrementally, so `SELECT sum(b)` grows by one per row.
+#[test]
+fn update_returning_subquery_sees_incremental_new_state() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+    // Base sum(b) = 240; each row adds 1, so row N sees 240+N.
+    let result =
+        update_returning(&mut db, "UPDATE t1 SET b=b+1 RETURNING a, b, (SELECT sum(b) FROM t1)");
+    assert_eq!(
+        rows(&result),
+        vec![
+            vec![int(1), int(11), int(241)],
+            vec![int(2), int(21), int(242)],
+            vec![int(3), int(31), int(243)],
+            vec![int(4), int(41), int(244)],
+            vec![int(6), int(61), int(245)],
+            vec![int(8), int(81), int(246)],
+        ]
+    );
+}
+
+/// Subquery-free RETURNING on DELETE keeps the statement-end batch path: the
+/// projected columns are just the OLD row values, unaffected by the fix.
+#[test]
+fn delete_returning_without_subquery_unchanged() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+    let result = delete_returning(&mut db, "DELETE FROM t1 WHERE a<>3 RETURNING a, b");
+    assert_eq!(
+        rows(&result),
+        vec![
+            vec![int(1), int(10)],
+            vec![int(2), int(20)],
+            vec![int(4), int(40)],
+            vec![int(6), int(60)],
+            vec![int(8), int(80)],
+        ]
+    );
+}
+
+/// Subquery-free RETURNING on UPDATE keeps the statement-end batch path: the
+/// projected columns are the NEW row values.
+#[test]
+fn update_returning_without_subquery_unchanged() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+    let result = update_returning(&mut db, "UPDATE t1 SET b=b+1 WHERE a<3 RETURNING a, b");
+    assert_eq!(rows(&result), vec![vec![int(1), int(11)], vec![int(2), int(21)]]);
+}


### PR DESCRIPTION
## Summary

A subquery inside a `RETURNING` expression must be recomputed **per row, as each affected row is mutated** — each returned row observes the incremental post-DML table state, not a single snapshot taken after the whole statement completes. This is SQLite's correlated-subquery treatment (returning1.test section 20). VibeSQL called `project_returning` once at statement end, so every returned row saw the final database state.

Ground truth (sqlite3 3.51.0) was reproduced locally for both DELETE and UPDATE variants before implementing.

## Changes

- `dml_returning.rs`: split the batch projector into reusable pieces (`visible_columns`, `derive_returning_columns`, single-row projection) and add:
  - `project_returning_row` — projects one row against the *current* database state (fresh evaluator so the subquery sees the live table).
  - `returning_has_subquery` — recursively detects any subquery form (scalar subquery, `IN (SELECT)`, `EXISTS`, quantified comparison) anywhere in a RETURNING expression.
- `delete/executor.rs`: when RETURNING contains a subquery, add a per-row path (no triggers) that bitmap-deletes each row, invalidates the columnar snapshot, then projects that row's RETURNING — mirroring the existing trigger loop (deferred compaction / index rebuild). Subquery-free RETURNING keeps the batch fast path unchanged.
- `update/executor.rs`: analogous per-row path — apply each row's NEW state, invalidate the snapshot, project that row.
- New test file `returning_per_row_subquery_tests.rs` pinning 20.1/20.2/20.3 plus an UPDATE subquery case and two subquery-free regression guards.

Only subquery-bearing RETURNING switches paths, so the common case has zero perf/behavior change.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| returning1.test 20.1, 20.2, 20.3 pass | ✅ | Before: 9 failed (incl. 20.1/20.2/20.3). After: 6 failed (20.x recovered) |
| DELETE ... RETURNING subqueries recompute per row | ✅ | Unit test + CLI output matches sqlite3 3.51.0 (`min` per-row: 2,3,3,3,3) |
| UPDATE ... RETURNING sees incremental NEW state | ✅ | `SELECT sum(b)` yields 241..246 per row, matching sqlite3 |
| Correlated subqueries (referencing per-row `t1.a`) work | ✅ | 20.3 passes (correlated `(SELECT min(t2.a)+t1.a*100 ...)`) |
| No regressions in executor suite or other returning1 sections | ✅ | Full `cargo test -p vibesql-executor` green; the other 6 returning1 failures are pre-existing and unrelated (DEFAULT keyword, sqlite_temp_schema, sqlite_master) |

## Test Plan

- `cargo test -p vibesql-executor` — all green (incl. new `returning_per_row_subquery_tests`, delete/update/CTE suites).
- `make test-tcl-file FILE=returning1.test` — before: 70 passed / 9 failed; after: 73 passed / 6 failed. The 3 recovered are exactly 20.1/20.2/20.3.
- Verified DELETE and UPDATE variants against `sqlite3 3.51.0` directly.

Closes #5972