### PR TITLE
fix(returning): recompute INSERT RETURNING subqueries per row

### DIFF
--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -908,6 +908,29 @@ fn execute_insert_internal(
     let mut returned_rows: Vec<vibesql_storage::Row> = Vec::new();
     let capture_returning = stmt.returning.is_some();
 
+    // Per-row RETURNING subquery path (parity with DELETE/UPDATE, #5972/#5976).
+    // A subquery in a RETURNING expression is treated as correlated with the
+    // table being modified: it must recompute against the incremental table
+    // state after each row is inserted, so every returned row observes the
+    // count/sum/etc. as of its own insertion (returning1.test section 20).
+    // Subquery-free RETURNING keeps the cheaper statement-end batch projection
+    // with zero behavior change.
+    let returning_needs_per_row =
+        stmt.returning.as_deref().is_some_and(crate::dml_returning::returning_has_subquery);
+    // Columns and the visible-column set are derivable once (before the loop):
+    // they do not depend on per-row table state.
+    let (per_row_returning_columns, per_row_visible_columns) = if returning_needs_per_row {
+        let items = stmt.returning.as_deref().expect("returning present");
+        let visible_columns = crate::dml_returning::visible_columns(&schema);
+        let columns =
+            crate::dml_returning::derive_returning_columns(items, &schema, None, &visible_columns)?;
+        (columns, visible_columns)
+    } else {
+        (Vec::new(), Vec::new())
+    };
+    // Collected per-row projections (one per inserted row, in insertion order).
+    let mut per_row_returning_rows: Vec<vibesql_storage::Row> = Vec::new();
+
     // Check if any assertions exist - needed for rollback support
     let has_assertions = db.catalog.get_all_assertions().next().is_some();
 
@@ -925,7 +948,12 @@ fn execute_insert_internal(
     let use_batch_insert = stmt.on_duplicate_key_update.is_none()
         && !matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Replace))
         && !on_conflict_needs_row_dispatch
-        && !has_insert_triggers;
+        && !has_insert_triggers
+        // A RETURNING subquery must recompute per row against the incremental
+        // table state, which the batch path (all rows inserted at once) cannot
+        // provide. Force the row-by-row slow path so each row's RETURNING is
+        // projected immediately after that row is inserted.
+        && !returning_needs_per_row;
 
     // Helper to create a Row with optional explicit rowid
     let make_row = |(values, rowid): (Vec<vibesql_types::SqlValue>, Option<u64>)| match rowid {
@@ -1321,6 +1349,26 @@ fn execute_insert_internal(
                 returned_rows.push(row.clone());
             }
 
+            // Per-row RETURNING subquery projection: drop the stale row-oriented
+            // columnar snapshot so a RETURNING subquery sees this row's insertion,
+            // then project this row's RETURNING against the now-updated table
+            // state. Each returned row thus observes the incremental count/sum/etc.
+            // as of its own insertion, matching sqlite3 (returning1.test §20).
+            if returning_needs_per_row {
+                db.invalidate_columnar_cache(&storage_table_name);
+                let items = stmt.returning.as_deref().expect("returning present");
+                let projected = crate::dml_returning::project_returning_row(
+                    items,
+                    &per_row_returning_columns,
+                    &schema,
+                    db,
+                    &row,
+                    &per_row_visible_columns,
+                    cte_results.as_ref(),
+                )?;
+                per_row_returning_rows.push(projected);
+            }
+
             // Maintain expression indexes for this insert
             expression_index_maintenance::maintain_expression_indexes_for_insert(
                 db,
@@ -1470,7 +1518,19 @@ fn execute_insert_internal(
     // Project the RETURNING clause against the rows actually inserted/updated
     // (one result row per affected row, in insertion order). Zero affected
     // rows still yield an empty result with the derived column headers.
-    let returning_result = if let Some(items) = &stmt.returning {
+    let returning_result = if returning_needs_per_row {
+        // Slow path: each row was already projected against its own incremental
+        // table state inside the insert loop. Assemble the collected rows with
+        // the columns derived up front (so zero inserted rows still yields the
+        // correct empty header set).
+        Some(crate::select::SelectResult {
+            columns: per_row_returning_columns,
+            rows: per_row_returning_rows,
+        })
+    } else if let Some(items) = &stmt.returning {
+        // Fast path (subquery-free RETURNING): batch-project once against the
+        // final post-INSERT state — every row sees the same snapshot, which is
+        // correct when no subquery observes the table.
         let row_refs: Vec<&vibesql_storage::Row> = returned_rows.iter().collect();
         Some(crate::dml_returning::project_returning(
             items,

--- a/crates/vibesql-executor/tests/returning_per_row_subquery_tests.rs
+++ b/crates/vibesql-executor/tests/returning_per_row_subquery_tests.rs
@@ -1,4 +1,4 @@
-//! Regression tests for issue #5972
+//! Regression tests for issues #5972 (DELETE/UPDATE) and #5977 (INSERT)
 //!
 //! A subquery inside a RETURNING expression must be recomputed **per row, as
 //! each affected row is mutated** — it sees the incremental post-DML table
@@ -9,8 +9,8 @@
 //!
 //! Previously VibeSQL collected all affected rows, then projected RETURNING
 //! once at statement end, so every RETURNING row observed the same final
-//! database state. This module pins the per-row behavior for both DELETE and
-//! UPDATE. Subquery-free RETURNING keeps the statement-end batch path (also
+//! database state. This module pins the per-row behavior for DELETE, UPDATE,
+//! and INSERT. Subquery-free RETURNING keeps the statement-end batch path (also
 //! covered here to guard against a regression in the common case).
 //!
 //! All expected values were verified against sqlite3 3.51.0.
@@ -53,6 +53,17 @@ fn update_returning(db: &mut vibesql_storage::Database, sql: &str) -> SelectResu
     let (_count, returning) = UpdateExecutor::execute_returning(&update, db)
         .unwrap_or_else(|e| panic!("Update failed: {} -- {:?}", sql, e));
     returning.expect("RETURNING result present")
+}
+
+fn insert_returning(db: &mut vibesql_storage::Database, sql: &str) -> SelectResult {
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Parse failed: {} -- {:?}", sql, e));
+    let vibesql_ast::Statement::Insert(insert) = stmt else {
+        panic!("Expected INSERT: {}", sql);
+    };
+    let outcome = InsertExecutor::execute_returning(db, &insert)
+        .unwrap_or_else(|e| panic!("Insert failed: {} -- {:?}", sql, e));
+    outcome.returning.expect("RETURNING result present")
 }
 
 /// A variant-agnostic cell used for comparisons: any SQL float variant
@@ -235,4 +246,89 @@ fn update_returning_without_subquery_unchanged() {
     seed(&mut db);
     let result = update_returning(&mut db, "UPDATE t1 SET b=b+1 WHERE a<3 RETURNING a, b");
     assert_eq!(rows(&result), vec![vec![int(1), int(11)], vec![int(2), int(21)]]);
+}
+
+/// Seed a table with three base rows for the INSERT variants: subsequent
+/// multi-row INSERTs then observe the table growing one row at a time.
+fn seed_insert(db: &mut vibesql_storage::Database) {
+    setup(db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT)");
+    setup(db, "INSERT INTO t1 VALUES(1,10),(2,20),(3,30)");
+}
+
+/// Issue #5977 reproduction — INSERT ... RETURNING with scalar subqueries.
+/// Each inserted row observes the table (count/sum) as of its own insertion,
+/// so count/sum grow one row at a time rather than all seeing the final state.
+///
+/// sqlite3 3.51.0 ground truth:
+///   4|4|100
+///   6|5|160
+///   8|6|240
+#[test]
+fn insert_returning_subquery_recomputes_per_row() {
+    let mut db = vibesql_storage::Database::new();
+    seed_insert(&mut db);
+    let result = insert_returning(
+        &mut db,
+        "INSERT INTO t1 VALUES(4,40),(6,60),(8,80) \
+         RETURNING a, (SELECT count(*) FROM t1), (SELECT sum(b) FROM t1)",
+    );
+    assert_eq!(
+        rows(&result),
+        vec![
+            vec![int(4), int(4), int(100)],
+            vec![int(6), int(5), int(160)],
+            vec![int(8), int(6), int(240)],
+        ]
+    );
+}
+
+/// INSERT ... RETURNING with a correlated subquery referencing the inserted
+/// value: `SELECT count(*) FROM t1 WHERE t1.a <= a` must still recompute per
+/// row against the incremental table state.
+///
+/// sqlite3 3.51.0 ground truth:
+///   4|4
+///   6|5
+///   8|6
+#[test]
+fn insert_returning_correlated_subquery_recomputes_per_row() {
+    let mut db = vibesql_storage::Database::new();
+    seed_insert(&mut db);
+    let result = insert_returning(
+        &mut db,
+        "INSERT INTO t1 VALUES(4,40),(6,60),(8,80) \
+         RETURNING a, (SELECT count(*) FROM t1 WHERE t1.a <= a)",
+    );
+    assert_eq!(
+        rows(&result),
+        vec![vec![int(4), int(4)], vec![int(6), int(5)], vec![int(8), int(6)]]
+    );
+}
+
+/// Single-row INSERT ... RETURNING with a subquery: the one returned row sees
+/// the post-insert state (count grows from 3 to 4).
+#[test]
+fn insert_returning_single_row_subquery() {
+    let mut db = vibesql_storage::Database::new();
+    seed_insert(&mut db);
+    let result = insert_returning(
+        &mut db,
+        "INSERT INTO t1 VALUES(4,40) RETURNING a, (SELECT count(*) FROM t1)",
+    );
+    assert_eq!(rows(&result), vec![vec![int(4), int(4)]]);
+}
+
+/// Subquery-free INSERT ... RETURNING keeps the statement-end batch fast path:
+/// the projected columns are just the inserted row values, unaffected by the
+/// per-row machinery (regression guard for the common case).
+#[test]
+fn insert_returning_without_subquery_unchanged() {
+    let mut db = vibesql_storage::Database::new();
+    seed_insert(&mut db);
+    let result =
+        insert_returning(&mut db, "INSERT INTO t1 VALUES(4,40),(6,60),(8,80) RETURNING a, b");
+    assert_eq!(
+        rows(&result),
+        vec![vec![int(4), int(40)], vec![int(6), int(60)], vec![int(8), int(80)]]
+    );
 }


### PR DESCRIPTION
## Summary

INSERT ... RETURNING subqueries were projected once in batch after the whole INSERT completed, so every returned row observed the final post-INSERT table state. SQLite treats a subquery referencing the table being modified as correlated and recomputes it after each row is inserted (returning1.test §20). This PR makes INSERT match, mirroring the DELETE/UPDATE fix from #5972/#5976.

Before: `INSERT INTO t1 VALUES(4,40),(6,60),(8,80) RETURNING a, (SELECT count(*) FROM t1), (SELECT sum(b) FROM t1)` returned count=6/sum=240 for every row.

After (matches sqlite3 3.51.0):
```
4|4|100
6|5|160
8|6|240
```

## Changes

- `crates/vibesql-executor/src/insert/execution.rs` (`execute_insert_internal`):
  - Gate on `dml_returning::returning_has_subquery`; derive RETURNING columns/visible-columns once up front.
  - When a RETURNING subquery is present, exclude the batch fast path (`use_batch_insert`) so rows flow through the row-by-row slow path.
  - After each row is physically inserted, invalidate the columnar cache and project that row's RETURNING via `project_returning_row` against the live database, collecting per-row results.
  - At statement end, assemble the collected per-row rows; the subquery-free path still uses the batch `project_returning` (zero behavior change).
- `crates/vibesql-executor/tests/returning_per_row_subquery_tests.rs`: extended the existing #5976 test file with 4 INSERT variants pinned to sqlite3 3.51.0 ground truth.

## View path (execute_insert_on_view, ~line 1898)

The curator flagged the view/INSTEAD-OF call site as having distinct semantics. I ground-truthed it against sqlite3 3.51.0:

```sql
CREATE VIEW v(a,b) AS SELECT a,b FROM base;
CREATE TRIGGER v_ins INSTEAD OF INSERT ON v BEGIN INSERT INTO base VALUES(NEW.a, NEW.b); END;
INSERT INTO v VALUES(4,40),(6,60),(8,80) RETURNING a, (SELECT count(*) FROM base), (SELECT sum(b) FROM base);
-- 4|4|100
-- 6|4|100
-- 8|4|100
```

sqlite3 does **not** recompute per row on the view path — all returned rows see the same state (the RETURNING row is projected before the INSTEAD OF triggers run). Applying per-row projection there would *diverge* from SQLite. The view path is therefore intentionally left on the existing batch projection (unchanged); it is out of scope for this fix.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| INSERT ... RETURNING subqueries recompute per row | ✅ | `insert_returning_subquery_recomputes_per_row` / `..._correlated_...` pass; manual repro via CLI matches sqlite3 (`4\|4\|100`, `6\|5\|160`, `8\|6\|240`) |
| Subquery-free INSERT RETURNING keeps batch fast path (zero behavior change) | ✅ | `insert_returning_without_subquery_unchanged` passes; `use_batch_insert` only disabled when a subquery is present |
| Regression test pinned against sqlite3 3.51.0 | ✅ | 4 new tests with expected values from sqlite3 3.51.0 |

## Test Plan

- `cargo test -p vibesql-executor --test returning_per_row_subquery_tests` — 10/10 pass (4 new INSERT + 6 existing DELETE/UPDATE).
- Insert-adjacent suites green: `insert_basic_tests`, `insert_multi_row_tests`, `insert_select_tests`, `insert_columnar_cache_tests`, `insert_duplicate_key_update_tests`, `insert_on_conflict_update_tests`, `with_insert_cte_tests`, `conflict_resolution_tests`, `rowid_reload_tests`.
- `make test-tcl-file FILE=returning1.test`: section 20 (per-row subquery) passes; 6 unrelated pre-existing failures (6.0 TABLE.* wildcard message, 10.3a/b new.rowid view semantics, 18.1 collation, 21.1/22.1 sqlite_temp_schema) — none involve INSERT RETURNING subquery projection.
- Manual reproduction against the built CLI binary matches sqlite3 3.51.0.

Closes #5977