### PR TITLE
fix(parser): accept multi-char operators in CREATE INDEX expression columns (#5841)

### DIFF
--- a/crates/vibesql-parser/src/parser/index.rs
+++ b/crates/vibesql-parser/src/parser/index.rs
@@ -494,8 +494,12 @@ impl Parser {
                 // SQLite allows: CREATE INDEX i1xy ON t1(`x`,'y' ASC); -- 'y' is a column name
                 let column_name = self.parse_alias_name()?;
 
-                // Check if this is actually an expression (has arithmetic operator after identifier)
-                // Examples: b+1, a*2, x-y are expressions, not column names
+                // Check if this is actually an expression (has an operator after identifier)
+                // Examples: b+1, a*2, x-y, z||w are expressions, not column names.
+                // Both single-char operators (Token::Symbol) and multi-char operators
+                // (Token::Operator, e.g. `||`, `<<`, `<=`, `!=`) must be detected here so
+                // an indexed expression like `CREATE INDEX i ON t(z||w)` is parsed as an
+                // expression rather than choking on the trailing operator token.
                 if matches!(
                     self.peek(),
                     Token::Symbol('+')
@@ -508,6 +512,7 @@ impl Parser {
                         | Token::Symbol('<')
                         | Token::Symbol('>')
                         | Token::Symbol('=')
+                        | Token::Operator(_)
                 ) || matches!(self.peek(), Token::Keyword { keyword: kw, .. } if matches!(kw,
                     crate::keywords::Keyword::And
                     | crate::keywords::Keyword::Or

--- a/crates/vibesql-parser/src/tests/index.rs
+++ b/crates/vibesql-parser/src/tests/index.rs
@@ -503,6 +503,86 @@ fn test_create_index_mixed_expression_no_parens_and_columns() {
     }
 }
 
+// Multi-char operators (||, <<, <=, !=, etc.) in an index column expression
+// must be detected so the column identifier is re-parsed as an expression rather
+// than choking on the trailing operator token (issue #5841). Ground truth:
+// sqlite3 3.51 accepts all of `CREATE INDEX i ON t(z||abc)`, `t(a<<2)`,
+// `t(a<=2)`, `t(a!=2)`.
+#[test]
+fn test_create_index_expression_concat_operator() {
+    let sql = "CREATE INDEX idx ON t(z||abc)";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        Statement::CreateIndex(stmt) => {
+            assert_eq!(stmt.columns.len(), 1);
+            assert!(stmt.columns[0].is_expression());
+        }
+        other => panic!("Expected CreateIndex, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_index_expression_concat_string_literal() {
+    // z||'abc' — right operand is a string literal
+    let sql = "CREATE INDEX idx ON t(z||'abc')";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        Statement::CreateIndex(stmt) => {
+            assert_eq!(stmt.columns.len(), 1);
+            assert!(stmt.columns[0].is_expression());
+        }
+        other => panic!("Expected CreateIndex, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_index_expression_multichar_operators() {
+    // Each of these leads with a bare column identifier followed by a multi-char
+    // operator token (Token::Operator), which previously was not detected as an
+    // expression and produced `near "<op>": syntax error`.
+    for sql in [
+        "CREATE INDEX idx ON t(a<<2)",
+        "CREATE INDEX idx ON t(a>>2)",
+        "CREATE INDEX idx ON t(a<=2)",
+        "CREATE INDEX idx ON t(a>=2)",
+        "CREATE INDEX idx ON t(a!=2)",
+        "CREATE INDEX idx ON t(a<>2)",
+    ] {
+        let result = Parser::parse_sql(sql);
+        assert!(result.is_ok(), "Failed to parse `{sql}`: {:?}", result.err());
+        match result.unwrap() {
+            Statement::CreateIndex(stmt) => {
+                assert_eq!(stmt.columns.len(), 1, "for `{sql}`");
+                assert!(stmt.columns[0].is_expression(), "for `{sql}`");
+            }
+            other => panic!("Expected CreateIndex for `{sql}`, got: {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn test_create_index_concat_expression_mixed_with_columns() {
+    // z||w expression followed by a plain DESC column must both parse.
+    let sql = "CREATE INDEX idx ON t(a||b, c DESC)";
+    let result = Parser::parse_sql(sql);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    match result.unwrap() {
+        Statement::CreateIndex(stmt) => {
+            assert_eq!(stmt.columns.len(), 2);
+            assert!(stmt.columns[0].is_expression());
+            assert!(!stmt.columns[1].is_expression());
+            assert_eq!(stmt.columns[1].expect_column_name(), "c");
+            assert_eq!(stmt.columns[1].direction(), vibesql_ast::OrderDirection::Desc);
+        }
+        other => panic!("Expected CreateIndex, got: {:?}", other),
+    }
+}
+
 #[test]
 fn test_create_index_prefix_length_still_works() {
     // Ensure prefix length syntax still works: column_name(integer)


### PR DESCRIPTION
## Summary

Batch acceptance issue #5841 was largely delivered by prior PRs **#5908** (Tier 1 + Tier 2 + numeric tokenizer) and **#5965** (single-quoted DDL/DML identifiers, COLLATE after IS TRUE). This PR closes out the issue by:

1. **Shipping one genuine, self-contained parser acceptance bug** found during verification: multi-char operators (`||`, `<<`, `<=`, `!=`, …) were not detected in `CREATE INDEX` expression column lists.
2. **Verifying all 7 originally-specified items are already correct** on current `origin/main` (against sqlite3 3.51 ground truth).
3. **Documenting the remaining TCL failures as out-of-scope semantic/architectural work** (the issue explicitly says to ship solid items and not force epic-sized work).

Closes #5841

## What this PR changes

`crates/vibesql-parser/src/parser/index.rs` — the index-column-list parser decided "is this bare identifier actually the start of an expression?" by peeking for single-char `Token::Symbol` operators only. Multi-char operators tokenized as `Token::Operator` (`||`, `<<`, `>>`, `<=`, `>=`, `!=`, `<>`) were missed, so `CREATE INDEX i ON t(z||abc)` re-parsed `z` as a plain column name and then choked on `||` with `near "||": syntax error`. Added a `Token::Operator(_)` arm to the expression-detection peek set.

- Only the **classic** parser handles CREATE INDEX (the arena parser is SELECT-only), so no arena change is needed.
- Verified against **sqlite3 3.51** ground truth: `t(z||abc)`, `t(z||'abc')`, `t(z||"abc")`, `t(a<<2)`, `t(a<=2)`, `t(a!=2)` all accepted.
- **indexexpr2.test now passes 87/87** (contains `||` index expressions). Added 4 pinned parser unit tests.

## Verification of the 7 originally-specified items (all already landed)

Each verified against the freshly-built binary + sqlite3:

| Item | Behavior | Status |
|------|----------|--------|
| 1. `ROLLBACK TO name` / `RELEASE name` w/o SAVEPOINT | works | ✅ #5908 |
| 2. `ALTER TABLE t ADD COLUMN x` w/o type | works | ✅ #5908 |
| 3a. underscore in fraction `1.1_1` | → `1.11` | ✅ #5908 |
| 3b. `SELECT 123a456` | errors (not split) | ✅ #5908 |
| 3c. unterminated blob `x'4869` | errors | ✅ #5908 |
| 4. TRUE/FALSE/`rows` CTE/`DROP TRIGGER 'name'` | works | ✅ #5908 |
| 5. `0.5 IS TRUE` → 1, `0.0 IS FALSE` → 1 | works | ✅ #5908 |
| 6. COLLATE after IS TRUE | works | ✅ #5965 |
| 7. column-level `DEFERRABLE` | works | ✅ #5908 |

## Out of scope (documented for future decomposition)

The remaining failures in the named TCL files are **not parser acceptance** — they are semantic/architectural work the issue explicitly flags as "needing separate investigation / don't force":

- **quote.test (14 fail)** — the full DQS double-quote→string-literal fallback feature: per-connection `SQLITE_DBCONFIG_DQS_DDL/DML` config, DDL-time CHECK/index column resolution, `PRAGMA writable_schema` bypass, multi-connection shim support. Epic-sized (see the prior builder investigation comment on #5841, items A–E).
- **memjournal2.test (368 fail)** — savepoint-outside-transaction storage semantics ("No active transaction"); an executor/storage bug, not parser. The ROLLBACK TO *parser* fix (item 1) already landed.
- **literal.test (20 fail), istrue.test (21 fail)** — residual semantic mismatches (qualified `false.false` name resolution, DDL-time CHECK resolution, expected-output diffs).

The `||`-in-index fix here is the one piece of the deferred scope that stands alone as a real, ground-truth-verified parser acceptance win.

## Test results

- `cargo test -p vibesql-parser`: **1744 passed, 0 failed** (+4 new pinned tests)
- TCL (no regressions; recovery from the new fix): indexexpr2.test **87/87**, indexexpr1.test 48/1-fail; quote/literal/istrue/memjournal2 unchanged at baseline (their remaining failures are the out-of-scope items above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)