### PR TITLE
feat(ast): add FromClause::TableFunction variant for JSON1 table functions

### DIFF
--- a/crates/vibesql-ast/src/arena/convert.rs
+++ b/crates/vibesql-ast/src/arena/convert.rs
@@ -538,6 +538,16 @@ impl<'a, 'arena> Converter<'a, 'arena> {
                         .map(|cols| cols.iter().map(|s| self.resolve(*s)).collect()),
                 }
             }
+            arena_select::FromClause::TableFunction { name, args, alias, column_aliases } => {
+                FromClause::TableFunction {
+                    name: self.resolve(*name),
+                    args: args.iter().map(|e| self.convert_expression(e)).collect(),
+                    alias: self.resolve_opt(*alias),
+                    column_aliases: column_aliases
+                        .as_ref()
+                        .map(|cols| cols.iter().map(|s| self.resolve(*s)).collect()),
+                }
+            }
         }
     }
 
@@ -1072,5 +1082,52 @@ mod tests {
         }
 
         assert_eq!(count_left_depth(&result), 3, "Expected 3 levels of nesting for 4 elements");
+    }
+
+    /// Verify the arena `FromClause::TableFunction` variant converts to the
+    /// standard variant with name, args, alias, and column aliases preserved.
+    #[test]
+    fn test_table_function_from_clause_round_trips() {
+        let arena = Bump::new();
+        let mut interner = ArenaInterner::new(&arena);
+        let name = interner.intern("json_tree");
+        let alias = interner.intern("jt");
+        let col_k = interner.intern("k");
+        let col_v = interner.intern("v");
+        let converter = Converter::new(&interner);
+
+        let mut args = BumpVec::new_in(&arena);
+        args.push(arena_expr::Expression::Literal(vibesql_types::SqlValue::Integer(1)));
+        args.push(arena_expr::Expression::Literal(vibesql_types::SqlValue::Integer(2)));
+
+        let mut column_aliases = BumpVec::new_in(&arena);
+        column_aliases.push(col_k);
+        column_aliases.push(col_v);
+
+        let from = arena_select::FromClause::TableFunction {
+            name,
+            args,
+            alias: Some(alias),
+            column_aliases: Some(column_aliases),
+        };
+
+        let result = converter.convert_from_clause(&from);
+        match result {
+            FromClause::TableFunction { name, args, alias, column_aliases } => {
+                assert_eq!(name, "json_tree");
+                assert_eq!(args.len(), 2);
+                assert!(matches!(
+                    args[0],
+                    Expression::Literal(vibesql_types::SqlValue::Integer(1))
+                ));
+                assert!(matches!(
+                    args[1],
+                    Expression::Literal(vibesql_types::SqlValue::Integer(2))
+                ));
+                assert_eq!(alias, Some("jt".to_string()));
+                assert_eq!(column_aliases, Some(vec!["k".to_string(), "v".to_string()]));
+            }
+            other => panic!("expected TableFunction, got {other:?}"),
+        }
     }
 }

--- a/crates/vibesql-ast/src/arena/select.rs
+++ b/crates/vibesql-ast/src/arena/select.rs
@@ -140,6 +140,18 @@ pub enum FromClause<'arena> {
         /// SQL:1999 Feature E051-09: Optional column renaming for derived tables
         column_aliases: Option<BumpVec<'arena, Symbol>>,
     },
+    /// Table-valued function call in the FROM clause (SQLite JSON1 TVFs).
+    /// Example: `FROM json_each('[1,2,3]')`, `FROM json_tree(x, '$.a') AS jt(k, v)`
+    TableFunction {
+        /// Function name, normalized to lowercase (e.g. `"json_each"`).
+        name: Symbol,
+        /// Argument expressions (JSON1 TVFs take 1 or 2: value, optional path).
+        args: BumpVec<'arena, Expression<'arena>>,
+        /// Optional table alias, e.g. `FROM json_each(x) AS je`.
+        alias: Option<Symbol>,
+        /// Optional column renaming, e.g. `AS je(k, v)`.
+        column_aliases: Option<BumpVec<'arena, Symbol>>,
+    },
 }
 
 /// JOIN types

--- a/crates/vibesql-ast/src/pretty_print.rs
+++ b/crates/vibesql-ast/src/pretty_print.rs
@@ -1083,6 +1083,17 @@ impl ToSql for FromClause {
                 }
                 result
             }
+            FromClause::TableFunction { name, args, alias, column_aliases } => {
+                let args_sql: Vec<String> = args.iter().map(|e| e.to_sql()).collect();
+                let mut result = format!("{}({})", name, args_sql.join(", "));
+                if let Some(alias) = alias {
+                    result.push_str(&format!(" AS {}", format_identifier(alias)));
+                }
+                if let Some(cols) = column_aliases {
+                    result.push_str(&format!(" ({})", cols.join(", ")));
+                }
+                result
+            }
         }
     }
 }
@@ -1480,6 +1491,31 @@ mod tests {
 
         // Compact format: no spaces around symbolic operators
         assert_eq!(from.to_sql(), "orders AS o INNER JOIN customers AS c ON o.customer_id=c.id");
+    }
+
+    #[test]
+    fn test_table_function_bare() {
+        let from = FromClause::TableFunction {
+            name: "json_each".to_string(),
+            args: vec![Expression::Literal(SqlValue::Integer(123))],
+            alias: None,
+            column_aliases: None,
+        };
+        assert_eq!(from.to_sql(), "json_each(123)");
+    }
+
+    #[test]
+    fn test_table_function_with_alias_and_columns() {
+        let from = FromClause::TableFunction {
+            name: "json_tree".to_string(),
+            args: vec![
+                Expression::Literal(SqlValue::Integer(1)),
+                Expression::Literal(SqlValue::Integer(2)),
+            ],
+            alias: Some("jt".to_string()),
+            column_aliases: Some(vec!["k".to_string(), "v".to_string()]),
+        };
+        assert_eq!(from.to_sql(), "json_tree(1, 2) AS jt (k, v)");
     }
 
     #[test]

--- a/crates/vibesql-ast/src/select.rs
+++ b/crates/vibesql-ast/src/select.rs
@@ -355,6 +355,24 @@ pub enum FromClause {
         /// Optional column renaming
         column_aliases: Option<Vec<String>>,
     },
+    /// Table-valued function call in the FROM clause (SQLite JSON1 TVFs).
+    /// Example: `FROM json_each('[1,2,3]')`, `FROM json_tree(x, '$.a') AS jt(k, v)`
+    ///
+    /// A table-valued function produces a relation rather than a scalar value.
+    /// The `args` are ordinary expressions; whether an argument references a
+    /// preceding FROM sibling (the LATERAL form `FROM t, json_each(t.j)`) is an
+    /// execution concern, not a parse concern — such a reference is simply a
+    /// column-reference `Expression` here.
+    TableFunction {
+        /// Function name, normalized to lowercase (e.g. `"json_each"`).
+        name: String,
+        /// Argument expressions (JSON1 TVFs take 1 or 2: value, optional path).
+        args: Vec<Expression>,
+        /// Optional table alias, e.g. `FROM json_each(x) AS je`.
+        alias: Option<String>,
+        /// Optional column renaming, e.g. `AS je(k, v)`.
+        column_aliases: Option<Vec<String>>,
+    },
 }
 
 /// JOIN types

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -982,6 +982,11 @@ fn walk_from_clause<V: ExpressionVisitor>(visitor: &mut V, from: &FromClause) {
                 }
             }
         }
+        FromClause::TableFunction { args, .. } => {
+            for expr in args {
+                walk_expression(visitor, expr);
+            }
+        }
     }
 }
 
@@ -1250,6 +1255,14 @@ fn transform_from_clause<V: ExpressionMutVisitor>(visitor: &mut V, from: FromCla
             alias,
             column_aliases,
         },
+        FromClause::TableFunction { name, args, alias, column_aliases } => {
+            FromClause::TableFunction {
+                name,
+                args: args.into_iter().map(|e| transform_expression(visitor, e)).collect(),
+                alias,
+                column_aliases,
+            }
+        }
     }
 }
 

--- a/crates/vibesql-catalog/src/store/advanced/views.rs
+++ b/crates/vibesql-catalog/src/store/advanced/views.rs
@@ -198,6 +198,9 @@ impl super::super::Catalog {
             FromClause::Subquery { query, .. } => self.select_references_table(query, table_name),
             // VALUES clauses don't reference any tables
             FromClause::Values { .. } => false,
+            // Table-valued functions (json_each/json_tree) don't reference a
+            // named base table or view.
+            FromClause::TableFunction { .. } => false,
         }
     }
 }

--- a/crates/vibesql-consensus/src/freeze.rs
+++ b/crates/vibesql-consensus/src/freeze.rs
@@ -1130,9 +1130,11 @@ impl<'a> Scope<'a> {
                 self.add_from(left, db);
                 self.add_from(right, db);
             }
-            // Derived tables and VALUES constructors expose columns whose
-            // types are not in the catalog.
-            FromClause::Subquery { .. } | FromClause::Values { .. } => self.opaque = true,
+            // Derived tables, VALUES constructors, and table-valued functions
+            // expose columns whose types are not in the catalog.
+            FromClause::Subquery { .. }
+            | FromClause::Values { .. }
+            | FromClause::TableFunction { .. } => self.opaque = true,
         }
     }
 
@@ -1242,7 +1244,9 @@ fn from_subquery_time_cast_violation(
     db: &vibesql_storage::Database,
 ) -> Option<String> {
     match from {
-        FromClause::Table { .. } | FromClause::Values { .. } => None,
+        FromClause::Table { .. }
+        | FromClause::Values { .. }
+        | FromClause::TableFunction { .. } => None,
         FromClause::Subquery { query, .. } => query_body_time_cast_violation(query, db),
         FromClause::Join { left, right, condition, .. } => from_subquery_time_cast_violation(left, db)
             .or_else(|| from_subquery_time_cast_violation(right, db))
@@ -2176,6 +2180,12 @@ fn check_from_volatile_free(from: &FromClause) -> Result<(), String> {
                 for expr in row {
                     check_expr_volatile_free(expr, "FROM VALUES")?;
                 }
+            }
+            Ok(())
+        }
+        FromClause::TableFunction { args, .. } => {
+            for expr in args {
+                check_expr_volatile_free(expr, "FROM table function")?;
             }
             Ok(())
         }

--- a/crates/vibesql-executor/src/alter/drop_column_checks.rs
+++ b/crates/vibesql-executor/src/alter/drop_column_checks.rs
@@ -268,7 +268,9 @@ fn collect_from_sources(
         FromClause::Join { left, right, .. } => {
             collect_from_sources(left, sim, out) && collect_from_sources(right, sim, out)
         }
-        FromClause::Subquery { .. } | FromClause::Values { .. } => false,
+        FromClause::Subquery { .. }
+        | FromClause::Values { .. }
+        | FromClause::TableFunction { .. } => false,
     }
 }
 

--- a/crates/vibesql-executor/src/cache/parameterized.rs
+++ b/crates/vibesql-executor/src/cache/parameterized.rs
@@ -270,6 +270,12 @@ impl LiteralExtractor {
                     }
                 }
             }
+            vibesql_ast::FromClause::TableFunction { args, .. } => {
+                // Extract literals from table function arguments
+                for expr in args {
+                    Self::extract_from_expression(expr, literals);
+                }
+            }
         }
     }
 

--- a/crates/vibesql-executor/src/cache/prepared_statement/arena_prepared.rs
+++ b/crates/vibesql-executor/src/cache/prepared_statement/arena_prepared.rs
@@ -278,6 +278,11 @@ where
                 visit_arena_expression(cond, visitor);
             }
         }
+        vibesql_ast::arena::FromClause::TableFunction { args, .. } => {
+            for expr in args.iter() {
+                visit_arena_expression(expr, visitor);
+            }
+        }
     }
 }
 
@@ -299,6 +304,9 @@ fn visit_arena_from_clause(
         vibesql_ast::arena::FromClause::Join { left, right, .. } => {
             visit_arena_from_clause(Some(left), tables, interner);
             visit_arena_from_clause(Some(right), tables, interner);
+        }
+        vibesql_ast::arena::FromClause::TableFunction { .. } => {
+            // Table functions do not reference any base tables
         }
     }
 }

--- a/crates/vibesql-executor/src/cache/prepared_statement/bind/mutation.rs
+++ b/crates/vibesql-executor/src/cache/prepared_statement/bind/mutation.rs
@@ -222,6 +222,12 @@ fn bind_from_clause_mut(from: &mut FromClause, params: &[SqlValue]) {
                 }
             }
         }
+        FromClause::TableFunction { args, .. } => {
+            // Bind parameters in table function arguments
+            for expr in args {
+                bind_expression_mut(expr, params);
+            }
+        }
     }
 }
 
@@ -619,6 +625,12 @@ fn bind_from_clause_named_mut(from: &mut FromClause, params: &HashMap<String, Sq
                 for expr in row {
                     bind_expression_named_mut(expr, params);
                 }
+            }
+        }
+        FromClause::TableFunction { args, .. } => {
+            // Bind parameters in table-valued function arguments
+            for expr in args {
+                bind_expression_named_mut(expr, params);
             }
         }
     }

--- a/crates/vibesql-executor/src/cache/query_signature.rs
+++ b/crates/vibesql-executor/src/cache/query_signature.rs
@@ -230,6 +230,16 @@ impl QuerySignature {
                 alias.hash(hasher);
                 column_aliases.hash(hasher);
             }
+            vibesql_ast::FromClause::TableFunction { name, args, alias, column_aliases } => {
+                "TABLE_FUNCTION".hash(hasher);
+                name.hash(hasher);
+                args.len().hash(hasher);
+                for expr in args {
+                    Self::hash_expression(expr, hasher);
+                }
+                alias.hash(hasher);
+                column_aliases.hash(hasher);
+            }
         }
     }
 
@@ -707,6 +717,16 @@ impl QuerySignature {
                 "SUBQUERY".hash(hasher);
                 Self::hash_arena_select(query, hasher);
                 alias.hash(hasher);
+            }
+            ArenaFromClause::TableFunction { name, args, alias, column_aliases } => {
+                "TABLE_FUNCTION".hash(hasher);
+                name.hash(hasher);
+                args.len().hash(hasher);
+                for expr in args.iter() {
+                    Self::hash_arena_expression(expr, hasher);
+                }
+                alias.hash(hasher);
+                column_aliases.hash(hasher);
             }
         }
     }

--- a/crates/vibesql-executor/src/cache/table_extractor.rs
+++ b/crates/vibesql-executor/src/cache/table_extractor.rs
@@ -81,6 +81,9 @@ fn extract_from_from_clause(from: &vibesql_ast::FromClause, tables: &mut HashSet
         vibesql_ast::FromClause::Values { .. } => {
             // VALUES clauses don't reference any tables
         }
+        vibesql_ast::FromClause::TableFunction { .. } => {
+            // Table functions (e.g. json_each) don't reference any base tables
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/correlation.rs
+++ b/crates/vibesql-executor/src/correlation.rs
@@ -90,6 +90,12 @@ fn extract_table_names_recursive(from: &FromClause, tables: &mut Vec<String>) {
             // VALUES clauses are referenced by their alias
             tables.push(alias.clone());
         }
+        FromClause::TableFunction { alias, .. } => {
+            // Table functions are referenced by their alias when present
+            if let Some(a) = alias {
+                tables.push(a.clone());
+            }
+        }
     }
 }
 
@@ -245,6 +251,12 @@ fn is_from_clause_correlated(
                 row.iter().any(|expr| {
                     is_expression_correlated(expr, outer_schema, subquery_tables, database)
                 })
+            })
+        }
+        FromClause::TableFunction { args, .. } => {
+            // Table function args (e.g. json_each(t.j)) can reference outer columns
+            args.iter().any(|expr| {
+                is_expression_correlated(expr, outer_schema, subquery_tables, database)
             })
         }
     }

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -1078,6 +1078,13 @@ impl CreateTableExecutor {
                     alias
                 )));
             }
+            Some(vibesql_ast::FromClause::TableFunction { name, .. }) => {
+                // Table function - can't determine column names from schema
+                return Err(ExecutorError::UnsupportedFeature(format!(
+                    "CREATE TABLE AS SELECT * from table function '{}' not supported - please specify columns explicitly",
+                    name
+                )));
+            }
         }
 
         Ok(names)

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/correlation.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/correlation.rs
@@ -133,6 +133,11 @@ fn extract_table_names_recursive(from: &vibesql_ast::FromClause, tables: &mut Ve
         vibesql_ast::FromClause::Values { alias, .. } => {
             tables.push(alias.clone());
         }
+        vibesql_ast::FromClause::TableFunction { alias, .. } => {
+            if let Some(a) = alias {
+                tables.push(a.clone());
+            }
+        }
     }
 }
 
@@ -271,6 +276,18 @@ fn collect_correlation_refs_from_from_clause(
                         refs,
                     );
                 }
+            }
+        }
+        vibesql_ast::FromClause::TableFunction { args, .. } => {
+            // Check table function arguments for correlation refs
+            for expr in args {
+                collect_correlation_refs_from_expr(
+                    expr,
+                    outer_schema,
+                    subquery_tables,
+                    database,
+                    refs,
+                );
             }
         }
     }

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs
@@ -310,8 +310,10 @@ fn find_column_affinity_in_from_clause(
             find_column_affinity_in_from_clause(column_name, left, database)
                 .or_else(|| find_column_affinity_in_from_clause(column_name, right, database))
         }
-        vibesql_ast::FromClause::Subquery { .. } | vibesql_ast::FromClause::Values { .. } => {
-            // Subqueries and VALUES don't preserve affinity easily
+        vibesql_ast::FromClause::Subquery { .. }
+        | vibesql_ast::FromClause::Values { .. }
+        | vibesql_ast::FromClause::TableFunction { .. } => {
+            // Subqueries, VALUES, and table functions don't preserve affinity easily
             None
         }
     }
@@ -364,6 +366,18 @@ fn count_columns_in_from_clause(
                 Ok(first_row.len())
             } else {
                 Ok(0) // Empty VALUES clause
+            }
+        }
+        vibesql_ast::FromClause::TableFunction { name, column_aliases, .. } => {
+            // Table function column count: use column_aliases if provided.
+            // Otherwise the schema is defined by the (not-yet-executable) function.
+            if let Some(aliases) = column_aliases {
+                Ok(aliases.len())
+            } else {
+                Err(ExecutorError::UnsupportedFeature(format!(
+                    "table function '{}' is not yet executable (JSON1 Phase 3)",
+                    name
+                )))
             }
         }
     }

--- a/crates/vibesql-executor/src/explain.rs
+++ b/crates/vibesql-executor/src/explain.rs
@@ -2090,6 +2090,22 @@ impl ExplainExecutor {
 
                 Ok(values_node)
             }
+            vibesql_ast::FromClause::TableFunction { name, args, alias, column_aliases } => {
+                let mut tvf_node = PlanNode::new("TableFunction");
+                if let Some(a) = alias {
+                    tvf_node.object = Some(format!("{} AS {}", name, a));
+                } else {
+                    tvf_node.object = Some(name.clone());
+                }
+
+                tvf_node.details.push(format!("{} arg(s)", args.len()));
+
+                if let Some(aliases) = column_aliases {
+                    tvf_node.details.push(format!("Columns: {}", aliases.join(", ")));
+                }
+
+                Ok(tvf_node)
+            }
         }
     }
 

--- a/crates/vibesql-executor/src/insert/bulk_transfer.rs
+++ b/crates/vibesql-executor/src/insert/bulk_transfer.rs
@@ -70,6 +70,7 @@ fn extract_simple_table_select(select_stmt: &SelectStmt) -> Option<String> {
         FromClause::Join { .. } => return None, // No joins
         FromClause::Subquery { .. } => return None, // No subqueries
         FromClause::Values { .. } => return None, // No VALUES clauses
+        FromClause::TableFunction { .. } => return None, // No table functions
     };
 
     // No WHERE, GROUP BY, HAVING, DISTINCT, LIMIT, OFFSET

--- a/crates/vibesql-executor/src/insert/on_conflict_update.rs
+++ b/crates/vibesql-executor/src/insert/on_conflict_update.rs
@@ -533,6 +533,7 @@ impl TargetTableChecker<'_> {
             }
             FromClause::Subquery { query, .. } => self.check_select(query),
             FromClause::Values { .. } => {}
+            FromClause::TableFunction { .. } => {}
         }
     }
 }
@@ -966,6 +967,9 @@ fn from_binds_excluded(from: &FromClause) -> bool {
         }
         FromClause::Subquery { alias, .. } | FromClause::Values { alias, .. } => {
             alias.eq_ignore_ascii_case("excluded")
+        }
+        FromClause::TableFunction { alias, .. } => {
+            alias.as_ref().is_some_and(|a| a.eq_ignore_ascii_case("excluded"))
         }
     }
 }

--- a/crates/vibesql-executor/src/optimizer/adaptive/query.rs
+++ b/crates/vibesql-executor/src/optimizer/adaptive/query.rs
@@ -89,7 +89,8 @@ pub(super) fn is_single_table(query: &SelectStmt) -> bool {
         Some(FromClause::Table { .. }) => true,
         Some(FromClause::Join { .. })
         | Some(FromClause::Subquery { .. })
-        | Some(FromClause::Values { .. }) => false,
+        | Some(FromClause::Values { .. })
+        | Some(FromClause::TableFunction { .. }) => false,
         None => false, // No FROM clause (e.g., SELECT 1)
     }
 }

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/correlation.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/correlation.rs
@@ -280,6 +280,11 @@ fn extract_table_prefixes(from: &vibesql_ast::FromClause) -> Vec<char> {
                     prefixes.push(c.to_ascii_lowercase());
                 }
             }
+            vibesql_ast::FromClause::TableFunction { alias, .. } => {
+                if let Some(c) = alias.as_ref().and_then(|a| a.chars().next()) {
+                    prefixes.push(c.to_ascii_lowercase());
+                }
+            }
         }
     }
     let mut prefixes = Vec::new();
@@ -319,6 +324,10 @@ pub(crate) fn from_clause_has_external_refs(
             // Check if any expression in VALUES references external columns
             rows.iter().any(|row| row.iter().any(|expr| has_external_column_refs(expr, subquery)))
         }
+        vibesql_ast::FromClause::TableFunction { args, .. } => {
+            // Check if any table function argument references external columns
+            args.iter().any(|expr| has_external_column_refs(expr, subquery))
+        }
     }
 }
 
@@ -345,5 +354,8 @@ fn from_clause_contains_table(from: &vibesql_ast::FromClause, table_name: &str) 
         }
         vibesql_ast::FromClause::Subquery { alias, .. } => alias == table_name,
         vibesql_ast::FromClause::Values { alias, .. } => alias == table_name,
+        vibesql_ast::FromClause::TableFunction { alias, .. } => {
+            alias.as_ref().is_some_and(|a| a.eq_ignore_ascii_case(table_name))
+        }
     }
 }

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/detection.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/detection.rs
@@ -129,5 +129,9 @@ fn from_clause_has_in_subquery(from: &vibesql_ast::FromClause) -> bool {
             // Check if any expressions in VALUES rows contain IN subqueries
             rows.iter().any(|row| row.iter().any(expression_has_in_subquery))
         }
+        vibesql_ast::FromClause::TableFunction { args, .. } => {
+            // Check if any table function argument contains IN subqueries
+            args.iter().any(expression_has_in_subquery)
+        }
     }
 }

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/expression.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/expression.rs
@@ -543,5 +543,17 @@ pub(super) fn rewrite_from_clause(
                 column_aliases: column_aliases.clone(),
             }
         }
+        vibesql_ast::FromClause::TableFunction { name, args, alias, column_aliases } => {
+            // Rewrite expressions in table function arguments
+            vibesql_ast::FromClause::TableFunction {
+                name: name.clone(),
+                args: args
+                    .iter()
+                    .map(|expr| rewrite_expression(expr, rewrite_subquery_fn))
+                    .collect(),
+                alias: alias.clone(),
+                column_aliases: column_aliases.clone(),
+            }
+        }
     }
 }

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/mod.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/mod.rs
@@ -191,6 +191,11 @@ fn extract_table_names(from: &Option<vibesql_ast::FromClause>) -> Vec<String> {
             vibesql_ast::FromClause::Values { alias, .. } => {
                 tables.push(alias.clone());
             }
+            vibesql_ast::FromClause::TableFunction { alias, .. } => {
+                if let Some(a) = alias {
+                    tables.push(a.clone());
+                }
+            }
         }
     }
 

--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/helpers.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/helpers.rs
@@ -88,6 +88,18 @@ fn collect_outer_sources(from: &FromClause, out: &mut Vec<OuterSource>) {
                 out.push(OuterSource::Opaque);
             }
         }
+        FromClause::TableFunction { alias, column_aliases, .. } => {
+            // A table function's exposed columns are only statically known from
+            // an explicit column-alias list; otherwise its output is opaque
+            // here (the function is not yet executable).
+            match (alias, column_aliases) {
+                (Some(effective), Some(cols)) => out.push(OuterSource::Columns {
+                    effective: effective.clone(),
+                    columns: cols.clone(),
+                }),
+                _ => out.push(OuterSource::Opaque),
+            }
+        }
     }
 }
 
@@ -298,6 +310,11 @@ pub(super) fn collect_table_names(from: &FromClause, names: &mut Vec<String>) {
         }
         FromClause::Values { alias, .. } => {
             names.push(alias.clone());
+        }
+        FromClause::TableFunction { alias, .. } => {
+            if let Some(a) = alias {
+                names.push(a.clone());
+            }
         }
     }
 }

--- a/crates/vibesql-executor/src/optimizer/table_elimination/join_analysis.rs
+++ b/crates/vibesql-executor/src/optimizer/table_elimination/join_analysis.rs
@@ -53,6 +53,9 @@ fn extract_join_on_tables(
         FromClause::Values { .. } => {
             // VALUES clauses are opaque - don't examine their internals
         }
+        FromClause::TableFunction { .. } => {
+            // Table functions are opaque - don't examine their internals
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/optimizer/table_elimination/prefix.rs
+++ b/crates/vibesql-executor/src/optimizer/table_elimination/prefix.rs
@@ -120,6 +120,7 @@ fn collect_qualified_columns_from_from(
         FromClause::Table { .. } => {}
         FromClause::Subquery { .. } => {}
         FromClause::Values { .. } => {}
+        FromClause::TableFunction { .. } => {}
         FromClause::Join { left, right, condition, .. } => {
             collect_qualified_columns_from_from(left, table_columns);
             collect_qualified_columns_from_from(right, table_columns);

--- a/crates/vibesql-executor/src/optimizer/table_elimination/transform.rs
+++ b/crates/vibesql-executor/src/optimizer/table_elimination/transform.rs
@@ -21,9 +21,10 @@ pub(super) fn flatten_from_clause(from: &FromClause, tables: &mut Vec<TableInfo>
             flatten_from_clause(left, tables);
             flatten_from_clause(right, tables);
         }
-        // Skip subqueries and VALUES - they can't be eliminated
+        // Skip subqueries, VALUES, and table functions - they can't be eliminated
         FromClause::Subquery { .. } => {}
         FromClause::Values { .. } => {}
+        FromClause::TableFunction { .. } => {}
     }
 }
 

--- a/crates/vibesql-executor/src/select/cte.rs
+++ b/crates/vibesql-executor/src/select/cte.rs
@@ -641,6 +641,11 @@ fn collect_from_table_refs(
                 }
             }
         }
+        vibesql_ast::FromClause::TableFunction { args, .. } => {
+            for expr in args {
+                collect_expr_table_refs(expr, shadowed, out);
+            }
+        }
     }
 }
 
@@ -1067,6 +1072,18 @@ fn collect_from_sources(
                 qualifier: alias.clone(),
                 columns: visible_columns(columns),
             }])
+        }
+        vibesql_ast::FromClause::TableFunction { alias, column_aliases, .. } => {
+            // Only statically resolvable when both an alias and an explicit
+            // column-alias list are present; otherwise fall back to legacy
+            // naming (the function is not yet executable to derive columns).
+            match (alias, column_aliases) {
+                (Some(qualifier), Some(aliases)) => Some(vec![WildcardSource {
+                    qualifier: qualifier.clone(),
+                    columns: visible_columns(aliases.clone()),
+                }]),
+                _ => None,
+            }
         }
     }
 }
@@ -1693,6 +1710,9 @@ fn from_clause_references_table(from: &vibesql_ast::FromClause, table_name: &str
                 || condition.as_ref().map_or(false, |c| expr_references_table(c, table_name))
         }
         vibesql_ast::FromClause::Values { .. } => false,
+        vibesql_ast::FromClause::TableFunction { args, .. } => {
+            args.iter().any(|expr| expr_references_table(expr, table_name))
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
@@ -250,6 +250,18 @@ fn columns_from_from_clause(
                 None
             }
         }
+        FromClause::TableFunction { column_aliases, .. } => {
+            if let Some(aliases) = column_aliases {
+                for a in aliases {
+                    out.insert(a.to_ascii_lowercase());
+                }
+                Some(out)
+            } else {
+                // Table-function columns can't be resolved by name without
+                // execution. Conservative: unresolved.
+                None
+            }
+        }
     }
 }
 
@@ -349,7 +361,9 @@ fn from_clause_has_outer_correlated_aggregate(
     use vibesql_ast::FromClause;
 
     match from {
-        FromClause::Table { .. } | FromClause::Values { .. } => false,
+        FromClause::Table { .. }
+        | FromClause::Values { .. }
+        | FromClause::TableFunction { .. } => false,
         FromClause::Join { left, right, condition, .. } => {
             from_clause_has_outer_correlated_aggregate(left, inner_scopes, database)
                 || from_clause_has_outer_correlated_aggregate(right, inner_scopes, database)
@@ -1124,6 +1138,7 @@ impl SelectExecutor<'_> {
             Some(vibesql_ast::FromClause::Join { .. }) => return None, // JOIN not allowed
             Some(vibesql_ast::FromClause::Subquery { .. }) => return None, // Subquery not allowed
             Some(vibesql_ast::FromClause::Values { .. }) => return None, // VALUES not allowed
+            Some(vibesql_ast::FromClause::TableFunction { .. }) => return None, // Table function not allowed
             None => return None,                                       // No FROM clause
         };
 

--- a/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
@@ -1048,8 +1048,11 @@ pub(crate) fn build_early_schema(
             Some(combined)
         }
 
-        // Subqueries, VALUES, etc. - can't easily determine schema without execution
-        vibesql_ast::FromClause::Subquery { .. } | vibesql_ast::FromClause::Values { .. } => None,
+        // Subqueries, VALUES, table functions, etc. - can't easily determine
+        // schema without execution
+        vibesql_ast::FromClause::Subquery { .. }
+        | vibesql_ast::FromClause::Values { .. }
+        | vibesql_ast::FromClause::TableFunction { .. } => None,
     }
 }
 

--- a/crates/vibesql-executor/src/select/executor/arena_execution.rs
+++ b/crates/vibesql-executor/src/select/executor/arena_execution.rs
@@ -182,6 +182,11 @@ impl SelectExecutor<'_> {
                     "Arena execution does not support subqueries in FROM".to_string(),
                 ));
             }
+            FromClause::TableFunction { .. } => {
+                return Err(ExecutorError::UnsupportedExpression(
+                    "Arena execution does not support table functions in FROM".to_string(),
+                ));
+            }
         };
 
         // Resolve table name symbol to string

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
@@ -21,6 +21,8 @@ use crate::{errors::ExecutorError, schema::CombinedSchema, select::columnar};
 pub(super) fn is_columnar_supported_join(from: &FromClause) -> bool {
     match from {
         FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => true,
+        // Table functions are not yet executable via the columnar path.
+        FromClause::TableFunction { .. } => false,
         FromClause::Join { left, right, join_type, .. } => {
             matches!(
                 join_type,
@@ -38,7 +40,10 @@ pub(super) fn is_columnar_supported_join(from: &FromClause) -> bool {
 /// null-testing predicates and would silently drop them.
 pub(super) fn has_outer_join(from: &FromClause) -> bool {
     match from {
-        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => false,
+        FromClause::Table { .. }
+        | FromClause::Subquery { .. }
+        | FromClause::Values { .. }
+        | FromClause::TableFunction { .. } => false,
         FromClause::Join { left, right, join_type, .. } => {
             matches!(join_type, JoinType::LeftOuter | JoinType::RightOuter | JoinType::FullOuter)
                 || has_outer_join(left)
@@ -73,7 +78,10 @@ pub(super) fn expression_has_is_null(expr: &Expression) -> bool {
 /// We detect these cases to fall back to regular execution which handles them correctly.
 pub(super) fn has_cross_join_with_on_condition(from: &FromClause) -> bool {
     match from {
-        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => false,
+        FromClause::Table { .. }
+        | FromClause::Subquery { .. }
+        | FromClause::Values { .. }
+        | FromClause::TableFunction { .. } => false,
         FromClause::Join { left, right, join_type, condition, using_columns, natural, .. } => {
             // CROSS JOIN with any join condition (ON, USING, or NATURAL) should fall back
             // to regular execution path which handles filtering and column deduplication
@@ -102,6 +110,13 @@ pub(super) fn flatten_join_tree_simple(from: &FromClause, tables: &mut Vec<Simpl
         }
         FromClause::Values { alias, .. } => {
             tables.push((alias.clone(), Some(alias.clone()), true));
+        }
+        FromClause::TableFunction { .. } => {
+            // Guarded by is_columnar_supported_join (returns false for TVFs), so
+            // the columnar flatten path is never reached with a table function.
+            unreachable!(
+                "table functions are not executable via the columnar path (JSON1 Phase 3)"
+            )
         }
         FromClause::Join { left, right, .. } => {
             flatten_join_tree_simple(left, tables);
@@ -133,6 +148,11 @@ pub(super) fn flatten_join_tree_with_types(
         FromClause::Values { alias, .. } => {
             tables.push(((alias.clone(), Some(alias.clone()), true), None));
         }
+        FromClause::TableFunction { .. } => {
+            unreachable!(
+                "table functions are not executable via the columnar path (JSON1 Phase 3)"
+            )
+        }
         FromClause::Join { left, right, join_type, .. } => {
             flatten_join_tree_with_types(left, tables);
             // The right side of this join node gets the join type
@@ -151,6 +171,11 @@ pub(super) fn flatten_join_tree_with_types(
                         (alias.clone(), Some(alias.clone()), true),
                         Some(join_type.clone()),
                     ));
+                }
+                FromClause::TableFunction { .. } => {
+                    unreachable!(
+                        "table functions are not executable via the columnar path (JSON1 Phase 3)"
+                    )
                 }
                 FromClause::Join { .. } => {
                     // Nested join on the right side - flatten it but mark the first
@@ -179,7 +204,10 @@ pub(super) struct EquiJoinCondition {
 /// Extract join conditions from a FROM clause (ON conditions)
 pub(super) fn extract_join_conditions(from: &FromClause, conditions: &mut Vec<EquiJoinCondition>) {
     match from {
-        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => {}
+        FromClause::Table { .. }
+        | FromClause::Subquery { .. }
+        | FromClause::Values { .. }
+        | FromClause::TableFunction { .. } => {}
         FromClause::Join { left, right, condition, join_type, .. } => {
             // Handle INNER, CROSS, LEFT OUTER, and RIGHT OUTER joins in columnar path
             // FULL OUTER, SEMI, and ANTI joins are not supported
@@ -222,7 +250,10 @@ pub(super) fn extract_join_conditions(from: &FromClause, conditions: &mut Vec<Eq
 /// on the columnar fast path.
 pub(super) fn join_tree_has_residual_on_conjuncts(from: &FromClause) -> bool {
     match from {
-        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => false,
+        FromClause::Table { .. }
+        | FromClause::Subquery { .. }
+        | FromClause::Values { .. }
+        | FromClause::TableFunction { .. } => false,
         FromClause::Join { left, right, condition, join_type, .. } => {
             // Only the join types handled by the columnar path matter here;
             // unsupported types bail out earlier via is_columnar_supported_join.
@@ -534,6 +565,7 @@ pub(super) fn extract_single_table_name(from_clause: &FromClause) -> Option<Stri
         FromClause::Join { .. } => None, // JOINs not supported in native columnar path
         FromClause::Subquery { .. } => None, // Subqueries not supported
         FromClause::Values { .. } => None, // VALUES not supported
+        FromClause::TableFunction { .. } => None, // Table functions not supported
     }
 }
 
@@ -553,6 +585,7 @@ pub(super) fn extract_table_name_and_alias(
         FromClause::Join { .. } => None, // JOINs not supported in native columnar path
         FromClause::Subquery { .. } => None, // Subqueries not supported
         FromClause::Values { .. } => None, // VALUES not supported
+        FromClause::TableFunction { .. } => None, // Table functions not supported
     }
 }
 

--- a/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
@@ -309,6 +309,18 @@ fn count_columns_in_from_clause(
                 Ok(0) // Empty VALUES clause
             }
         }
+        vibesql_ast::FromClause::TableFunction { name, column_aliases, .. } => {
+            // Table function column count: use column_aliases if provided.
+            // Otherwise the schema is defined by the (not-yet-executable) function.
+            if let Some(aliases) = column_aliases {
+                Ok(aliases.len())
+            } else {
+                Err(ExecutorError::UnsupportedFeature(format!(
+                    "table function '{}' is not yet executable (JSON1 Phase 3)",
+                    name
+                )))
+            }
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/select/executor/set_operations.rs
+++ b/crates/vibesql-executor/src/select/executor/set_operations.rs
@@ -499,6 +499,9 @@ pub(super) fn extract_column_names_from_from(
             vibesql_ast::FromClause::Values { .. } => {
                 // VALUES clause doesn't have named columns
             }
+            vibesql_ast::FromClause::TableFunction { .. } => {
+                // Table functions have no statically known named columns here
+            }
         }
     }
 

--- a/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
@@ -1213,8 +1213,11 @@ fn collect_from_columns_recursive(
             collect_from_columns_recursive(left, database, columns)
                 && collect_from_columns_recursive(right, database, columns)
         }
-        // Subqueries / VALUES in FROM: too complex to resolve here. Bail.
-        FromClause::Subquery { .. } | FromClause::Values { .. } => false,
+        // Subqueries / VALUES / table functions in FROM: too complex to
+        // resolve here. Bail.
+        FromClause::Subquery { .. }
+        | FromClause::Values { .. }
+        | FromClause::TableFunction { .. } => false,
     }
 }
 
@@ -1934,6 +1937,12 @@ fn walk_from_for_subquery_group_by(from: &vibesql_ast::FromClause) -> Result<(),
                 for expr in row {
                     walk_expr_for_subquery_group_by(expr)?;
                 }
+            }
+            Ok(())
+        }
+        vibesql_ast::FromClause::TableFunction { args, .. } => {
+            for expr in args {
+                walk_expr_for_subquery_group_by(expr)?;
             }
             Ok(())
         }

--- a/crates/vibesql-executor/src/select/executor/validation/index_hints.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/index_hints.rs
@@ -92,6 +92,7 @@ fn validate_from_clause(
         }
         FromClause::Subquery { query, .. } => validate_select(query, cte_names, database),
         FromClause::Values { .. } => Ok(()),
+        FromClause::TableFunction { .. } => Ok(()),
     }
 }
 

--- a/crates/vibesql-executor/src/select/executor/validation/join_limits.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/join_limits.rs
@@ -20,6 +20,7 @@ fn count_tables_in_from_clause(from: &FromClause) -> usize {
         }
         FromClause::Subquery { .. } => 1, // Subquery counts as 1 table
         FromClause::Values { .. } => 1,   // VALUES clause counts as 1 table
+        FromClause::TableFunction { .. } => 1, // Table function counts as 1 table
     }
 }
 

--- a/crates/vibesql-executor/src/select/executor/validation/schema.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/schema.rs
@@ -434,6 +434,11 @@ fn extract_table_names_recursive(from: &vibesql_ast::FromClause, tables: &mut Ve
         vibesql_ast::FromClause::Values { alias, .. } => {
             tables.push(alias.clone());
         }
+        vibesql_ast::FromClause::TableFunction { alias, .. } => {
+            if let Some(a) = alias {
+                tables.push(a.clone());
+            }
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/select/scan/join_scan/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/join_scan/mod.rs
@@ -1615,6 +1615,11 @@ fn collect_tables_from_from_clause_inner(
         vibesql_ast::FromClause::Values { alias, .. } => {
             tables.insert(alias.to_lowercase());
         }
+        vibesql_ast::FromClause::TableFunction { alias, .. } => {
+            if let Some(a) = alias {
+                tables.insert(a.to_lowercase());
+            }
+        }
     }
 }
 
@@ -1651,10 +1656,12 @@ fn collect_columns_from_from_clause_inner(
             collect_columns_from_from_clause_inner(left, all_db_columns, columns);
             collect_columns_from_from_clause_inner(right, all_db_columns, columns);
         }
-        vibesql_ast::FromClause::Subquery { .. } | vibesql_ast::FromClause::Values { .. } => {
-            // For subqueries and VALUES, we don't know the columns statically
-            // But any column reference will be validated when the subquery executes
-            // So we just pass through - this is permissive but safe
+        vibesql_ast::FromClause::Subquery { .. }
+        | vibesql_ast::FromClause::Values { .. }
+        | vibesql_ast::FromClause::TableFunction { .. } => {
+            // For subqueries, VALUES, and table functions, we don't know the
+            // columns statically. But any column reference will be validated
+            // when they execute. So we just pass through - permissive but safe.
         }
     }
 }
@@ -1778,5 +1785,6 @@ fn from_clause_references_unknown_table(
             )
         }
         vibesql_ast::FromClause::Values { .. } => false,
+        vibesql_ast::FromClause::TableFunction { .. } => false,
     }
 }

--- a/crates/vibesql-executor/src/select/scan/join_scan/predicates.rs
+++ b/crates/vibesql-executor/src/select/scan/join_scan/predicates.rs
@@ -30,6 +30,12 @@ fn collect_table_names(from: &vibesql_ast::FromClause, tables: &mut Vec<String>)
             // VALUES alias is required (String, not Option<String>)
             tables.push(alias.clone());
         }
+        vibesql_ast::FromClause::TableFunction { alias, .. } => {
+            // Table function alias is optional; push it only if present
+            if let Some(a) = alias {
+                tables.push(a.clone());
+            }
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/select/scan/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/mod.rs
@@ -188,5 +188,11 @@ where
             Some(database),
             Some(cte_results),
         ),
+        vibesql_ast::FromClause::TableFunction { name, .. } => {
+            Err(ExecutorError::UnsupportedFeature(format!(
+                "table function '{}' in FROM is not yet executable (JSON1 Phase 3)",
+                name
+            )))
+        }
     }
 }

--- a/crates/vibesql-executor/src/select/scan/reorder/graph.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/graph.rs
@@ -59,6 +59,19 @@ pub(super) fn flatten_join_tree(from: &FromClause, tables: &mut Vec<TableRef>) {
                 column_aliases: column_aliases.clone(),
             });
         }
+        FromClause::TableFunction { name, alias, column_aliases, .. } => {
+            // The binding identity is the alias when present, otherwise the
+            // function name itself.
+            let bound = alias.clone().unwrap_or_else(|| name.clone());
+            tables.push(TableRef {
+                name: bound,
+                alias: alias.clone(),
+                is_cte: false,
+                is_subquery: false,
+                subquery: None,
+                column_aliases: column_aliases.clone(),
+            });
+        }
         FromClause::Join { left, right, .. } => {
             flatten_join_tree(left, tables);
             flatten_join_tree(right, tables);
@@ -69,7 +82,10 @@ pub(super) fn flatten_join_tree(from: &FromClause, tables: &mut Vec<TableRef>) {
 /// Extract all join conditions and WHERE predicates from a FROM clause
 pub(super) fn extract_all_conditions(from: &FromClause, conditions: &mut Vec<Expression>) {
     match from {
-        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => {
+        FromClause::Table { .. }
+        | FromClause::Subquery { .. }
+        | FromClause::Values { .. }
+        | FromClause::TableFunction { .. } => {
             // No conditions in simple table refs
         }
         FromClause::Join { left, right, condition, .. } => {
@@ -90,7 +106,10 @@ pub(super) fn extract_conditions_with_types(
     conditions: &mut Vec<JoinConditionWithType>,
 ) {
     match from {
-        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => {
+        FromClause::Table { .. }
+        | FromClause::Subquery { .. }
+        | FromClause::Values { .. }
+        | FromClause::TableFunction { .. } => {
             // No conditions in simple table refs
         }
         FromClause::Join { left, right, join_type, condition, .. } => {

--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -97,6 +97,7 @@ pub(crate) fn count_tables_in_from(from: &FromClause) -> usize {
         FromClause::Table { .. } => 1,
         FromClause::Subquery { .. } => 1,
         FromClause::Values { .. } => 1,
+        FromClause::TableFunction { .. } => 1,
         FromClause::Join { left, right, .. } => {
             count_tables_in_from(left) + count_tables_in_from(right)
         }
@@ -114,7 +115,10 @@ pub(crate) fn count_tables_in_from(from: &FromClause) -> usize {
 /// where the appropriate error is raised (CROSS JOIN does not support ON clause).
 pub(crate) fn all_joins_are_cross(from: &FromClause) -> bool {
     match from {
-        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => true,
+        FromClause::Table { .. }
+        | FromClause::Subquery { .. }
+        | FromClause::Values { .. }
+        | FromClause::TableFunction { .. } => true,
         FromClause::Join { left, right, join_type, condition, natural, using_columns, .. } => {
             // Must be CROSS join type AND have no ON condition AND not NATURAL AND no USING
             // CROSS JOIN with ON clause is invalid and should not be reordered

--- a/crates/vibesql-executor/src/select/view_reference_guard.rs
+++ b/crates/vibesql-executor/src/select/view_reference_guard.rs
@@ -250,6 +250,11 @@ fn collect_from_view_refs(
                 }
             }
         }
+        FromClause::TableFunction { args, .. } => {
+            for expr in args {
+                collect_expr_view_refs(expr, database, out);
+            }
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/update/from_clause.rs
+++ b/crates/vibesql-executor/src/update/from_clause.rs
@@ -269,7 +269,10 @@ fn get_pk_column_names(schema: &TableSchema) -> Vec<String> {
 fn combine_with_from_clause(accumulated: FromClause, from_clause: FromClause) -> FromClause {
     match from_clause {
         // For a simple table, just cross join
-        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => {
+        FromClause::Table { .. }
+        | FromClause::Subquery { .. }
+        | FromClause::Values { .. }
+        | FromClause::TableFunction { .. } => {
             FromClause::Join {
                 left: Box::new(accumulated),
                 right: Box::new(from_clause),

--- a/crates/vibesql-executor/src/update/triggers.rs
+++ b/crates/vibesql-executor/src/update/triggers.rs
@@ -396,7 +396,10 @@ fn collect_view_updates_with_from(
 /// `(view CROSS JOIN t1) LEFT JOIN t2`).
 fn combine_with_from_clause(accumulated: FromClause, from_clause: FromClause) -> FromClause {
     match from_clause {
-        FromClause::Table { .. } | FromClause::Subquery { .. } | FromClause::Values { .. } => {
+        FromClause::Table { .. }
+        | FromClause::Subquery { .. }
+        | FromClause::Values { .. }
+        | FromClause::TableFunction { .. } => {
             FromClause::Join {
                 left: Box::new(accumulated),
                 right: Box::new(from_clause),

--- a/crates/vibesql-server/src/subscription/pk_detector.rs
+++ b/crates/vibesql-server/src/subscription/pk_detector.rs
@@ -218,6 +218,7 @@ fn extract_single_table(from: &FromClause) -> Option<(String, Option<String>)> {
         FromClause::Join { .. } => None, // Join means multiple tables
         FromClause::Subquery { .. } => None, // Subquery is complex
         FromClause::Values { .. } => None, // VALUES is complex
+        FromClause::TableFunction { .. } => None, // Table-valued function is complex
     }
 }
 
@@ -339,6 +340,10 @@ fn collect_join_tables_recursive(
         }
         FromClause::Values { .. } => {
             // Can't easily extract table info from VALUES
+            *has_subquery = true;
+        }
+        FromClause::TableFunction { .. } => {
+            // Can't easily extract table info from a table-valued function
             *has_subquery = true;
         }
     }

--- a/crates/vibesql-server/src/subscription/table_dependencies.rs
+++ b/crates/vibesql-server/src/subscription/table_dependencies.rs
@@ -129,6 +129,12 @@ fn visit_from_clause(from: &FromClause, tables: &mut HashSet<String>) {
                 }
             }
         }
+        FromClause::TableFunction { args, .. } => {
+            // Table-valued function args may contain subqueries in expressions
+            for expr in args {
+                visit_expression(expr, tables);
+            }
+        }
     }
 }
 

--- a/crates/vibesql-server/src/subscription/table_extract.rs
+++ b/crates/vibesql-server/src/subscription/table_extract.rs
@@ -54,6 +54,12 @@ impl TableExtractor {
                     }
                 }
             }
+            FromClause::TableFunction { args, .. } => {
+                // Table-valued function args may contain subqueries in expressions
+                for expr in args {
+                    walk_expression(self, expr);
+                }
+            }
         }
     }
 

--- a/tests/sqllogictest/db_adapter/executor.rs
+++ b/tests/sqllogictest/db_adapter/executor.rs
@@ -761,5 +761,8 @@ fn extract_table_names_from_from(from: &vibesql_ast::FromClause, tables: &mut Ha
         vibesql_ast::FromClause::Values { .. } => {
             // VALUES clause doesn't reference tables
         }
+        vibesql_ast::FromClause::TableFunction { .. } => {
+            // Table-valued function (json_each/json_tree) references no base table
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds a fifth `FromClause` variant — `TableFunction { name, args, alias, column_aliases }` — to both the standard AST and the arena mirror, so a table-valued-function call in FROM position (SQLite's `json_each` / `json_tree`) is representable in the AST.

This is **step 1 of the ADR-0005 decomposition** (`docs/decisions/0005-json-table-valued-functions.md`) and the foundational, blocking piece of JSON1 Phase 3 (the last remaining JSON1 surface — Phases 1/2/4 are already merged). It is **pure AST plumbing**: the parser does not yet construct the variant (follow-up #5987), so this PR changes no runtime behavior.

## Changes

- **`crates/vibesql-ast`**: new `FromClause::TableFunction` on both `select.rs` (std) and `arena/select.rs` (arena); arms added to `arena/convert.rs`, `pretty_print.rs` (renders `name(args) [AS alias(cols)]`), and both `visitor.rs` walks (recurse into `args`, since a correlated arg like `json_each(t.j)` is a real expression that analyses must observe). New unit tests: pretty-print (bare + alias/columns) and an arena→std convert round-trip.
- **`crates/vibesql-executor`** (~64 match sites): correlation detection and cache/signature/bind walks iterate `args`; table-name collectors push the optional alias (or nothing, for base-table collectors); aggregation/validation/table-elimination mirror the trivial `Values` behavior; EXPLAIN renders a plan node. Execution/planning paths that would materialize rows return an `UnsupportedFeature` error or are `unreachable!` (guarded via `is_columnar_supported_join` returning false) — safe because the variant is never constructed yet; real row production lands in the executor step (#5988).
- **`crates/vibesql-server`** (subscription table extraction / dependencies / PK detection), **`crates/vibesql-consensus`** (`freeze` scope + volatility / time-cast checks), **`crates/vibesql-catalog`** (view-reference guard), and one **sqllogictest** test helper: mechanical arms mirroring `Values`/`Subquery` semantics.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `cargo build --release` succeeds with the new variant and all match arms | ✅ | Release build finished; only pre-existing unrelated warnings |
| `cargo test -p vibesql-ast` passes (arena convert round-trips; pretty-print emits `name(args) [AS alias(cols)]`) | ✅ | ast lib 88 passed incl. `test_table_function_*` + `test_table_function_from_clause_round_trips` |
| No behavior change: parser/executor suites unchanged (nothing constructs the variant) | ✅ | executor lib 3289 passed / 0 failed; parser 1744 passed; server 463; consensus 178; catalog 58 |
| No regressions in existing json101/json102 TCL results | ✅ | json101 42/42 (100%); json102 285/298 — identical to documented baseline |

## Test Plan

- `cargo build --release` (workspace) — succeeds.
- `cargo test` lib suites: ast, parser, executor (3289), server, consensus, catalog — all green.
- `make test-tcl-file FILE=json101.test` → 42/42; `FILE=json102.test` → 285/298 (unchanged from baseline).

## Note on a pre-existing failure

`tests/storage/update_pk_performance.rs` fails to compile (`missing field columns in Assignment`). This is **pre-existing and unrelated**: the `Assignment.columns` field was added on 2026-07-05 (#5922) but that test's struct literal was last touched 2026-06-22 (#5735) and was never updated. Left untouched per scope discipline; not introduced by this PR.

Closes #5986