### PR TITLE
feat(parser): recognize json_each/json_tree table functions in FROM position

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -651,6 +651,18 @@ impl<'arena> ArenaParser<'arena> {
             return Ok(FromClause::Subquery { query, alias, column_aliases });
         }
 
+        // Table-valued function in FROM position (JSON1 TVFs: json_each,
+        // json_tree). An unquoted identifier immediately followed by `(` is a TVF
+        // call only if the name is allow-listed; any other `ident(` in FROM remains
+        // a parse error (preserving prior behavior). Mirrors the standard parser.
+        if let Token::Identifier(name) = self.peek() {
+            if matches!(self.peek_next(), Token::LParen)
+                && crate::table_functions::is_table_valued_function(name)
+            {
+                return self.parse_table_function();
+            }
+        }
+
         // Regular table reference - check for both regular and delimited identifiers
         let (name, quoted) = match self.peek() {
             Token::Identifier(name) => {
@@ -716,6 +728,55 @@ impl<'arena> ArenaParser<'arena> {
         let index_hint = self.parse_index_hint()?;
 
         Ok(FromClause::Table { name, alias, column_aliases, quoted, index_hint })
+    }
+
+    /// Parse a table-valued function reference in FROM position, e.g.
+    /// `json_each('[1,2,3]')`, `json_tree(x, '$.a')`, or
+    /// `json_each(x) AS je(k, v)`.
+    ///
+    /// The caller has already verified (via lookahead) that the current token is
+    /// an allow-listed identifier immediately followed by `(`. This mirrors the
+    /// standard parser's `parse_table_function`, producing
+    /// [`vibesql_ast::arena::FromClause::TableFunction`] with the name normalized
+    /// to lowercase. No executor support exists yet.
+    fn parse_table_function(&mut self) -> Result<FromClause<'arena>, ParseError> {
+        // Consume the function name (already known to be an allow-listed identifier).
+        let name = match self.peek() {
+            Token::Identifier(raw) => {
+                let raw = raw.clone();
+                let normalized = crate::table_functions::normalized_table_valued_function(&raw)
+                    .unwrap_or_else(|| raw.to_lowercase());
+                self.advance();
+                self.intern(&normalized)
+            }
+            // Unreachable in practice: caller only dispatches here after confirming
+            // an allow-listed identifier. Guard defensively anyway.
+            _ => return Err(ParseError { message: self.peek().syntax_error() }),
+        };
+
+        // Parse the parenthesized, comma-separated argument list.
+        self.expect_token(Token::LParen)?;
+        let args = self.parse_expression_list()?;
+        self.expect_token(Token::RParen)?;
+
+        // Optional alias: `AS je` or bare `je`.
+        let has_as = self.try_consume_keyword(Keyword::As);
+        let alias = if let Token::Identifier(a) = self.peek() {
+            let a = a.clone();
+            self.advance();
+            Some(self.intern(&a))
+        } else if has_as {
+            // AS was present but no plain identifier follows - use the shared
+            // alias helper to handle keywords / quoted strings, or error.
+            Some(self.parse_alias_name_symbol()?)
+        } else {
+            None
+        };
+
+        // Optional column-alias list: `AS je(k, v)`. Only meaningful with an alias.
+        let column_aliases = if alias.is_some() { self.parse_column_alias_list()? } else { None };
+
+        Ok(FromClause::TableFunction { name, args, alias, column_aliases })
     }
 
     /// Check if the upcoming tokens form a SQLite index hint:

--- a/crates/vibesql-parser/src/lib.rs
+++ b/crates/vibesql-parser/src/lib.rs
@@ -27,6 +27,7 @@ pub mod arena_parser;
 mod keywords;
 mod lexer;
 mod parser;
+mod table_functions;
 #[cfg(test)]
 mod tests;
 mod token;

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -328,6 +328,17 @@ impl Parser {
 
                 Ok(result)
             }
+            // Table-valued function in FROM position (JSON1 TVFs: json_each,
+            // json_tree). An unquoted identifier immediately followed by `(` is a
+            // TVF call only if the name is allow-listed; any other `ident(` in FROM
+            // remains a parse error (preserving prior behavior). Delimited/quoted
+            // identifiers are never TVFs — a quoted `"json_each"` is a table name.
+            Token::Identifier(name)
+                if matches!(self.peek_next(), Token::LParen)
+                    && crate::table_functions::is_table_valued_function(name) =>
+            {
+                self.parse_table_function()
+            }
             // SQLite compatibility: single-quoted strings can be used as table names
             Token::Identifier(_) | Token::DelimitedIdentifier(_) | Token::String(_) => {
                 let table = self.parse_table_ref()?;
@@ -444,6 +455,58 @@ impl Parser {
             // (trigger1-2.1 / 2.2).
             _ => Err(ParseError { message: self.peek().syntax_error() }),
         }
+    }
+
+    /// Parse a table-valued function reference in FROM position, e.g.
+    /// `json_each('[1,2,3]')`, `json_tree(x, '$.a')`, or
+    /// `json_each(x) AS je(k, v)`.
+    ///
+    /// The caller has already verified (via lookahead) that the current token is
+    /// an allow-listed identifier immediately followed by `(`. This method
+    /// consumes the name, the parenthesized comma-separated argument list, and an
+    /// optional `AS`-alias with an optional column-alias list. It produces
+    /// [`vibesql_ast::FromClause::TableFunction`] with the name normalized to
+    /// lowercase. No executor support exists yet — a parsed TableFunction errors
+    /// or no-ops at execution until the executor phase lands.
+    pub(crate) fn parse_table_function(&mut self) -> Result<vibesql_ast::FromClause, ParseError> {
+        // Consume the function name (already known to be an allow-listed identifier).
+        let name = match self.peek() {
+            Token::Identifier(name) => {
+                let normalized = crate::table_functions::normalized_table_valued_function(name)
+                    .unwrap_or_else(|| name.to_lowercase());
+                self.advance();
+                normalized
+            }
+            // Unreachable in practice: the caller only dispatches here after
+            // confirming an allow-listed identifier. Guard defensively anyway.
+            _ => return Err(ParseError { message: self.peek().syntax_error() }),
+        };
+
+        // Parse the parenthesized, comma-separated argument list.
+        self.expect_token(Token::LParen)?;
+        let args = if self.peek() == &Token::RParen {
+            Vec::new()
+        } else {
+            self.parse_comma_separated_list(|p| p.parse_expression())?
+        };
+        self.expect_token(Token::RParen)?;
+
+        // Optional alias: `AS je` or bare `je`, reusing the shared alias helper.
+        let alias = if self.peek_keyword(Keyword::As) {
+            self.consume_keyword(Keyword::As)?;
+            Some(self.parse_alias_name()?)
+        } else if matches!(self.peek(), Token::Identifier(_) | Token::DelimitedIdentifier(_))
+            && !self.is_join_keyword()
+        {
+            Some(self.parse_alias_name()?)
+        } else {
+            None
+        };
+
+        // Optional column-alias list: `AS je(k, v)`. Only meaningful with an alias.
+        let column_aliases = if alias.is_some() { self.parse_column_alias_list()? } else { None };
+
+        Ok(vibesql_ast::FromClause::TableFunction { name, args, alias, column_aliases })
     }
 
     /// Check if the upcoming tokens form a SQLite index hint:

--- a/crates/vibesql-parser/src/table_functions.rs
+++ b/crates/vibesql-parser/src/table_functions.rs
@@ -1,0 +1,59 @@
+//! Allow-list of table-valued functions (TVFs) recognized in FROM position.
+//!
+//! SQLite's JSON1 extension exposes two table-valued functions that appear in
+//! the FROM clause rather than as scalar expressions: `json_each` and
+//! `json_tree` (see ADR-0005). When the parser encounters an identifier
+//! immediately followed by `(` in FROM position, it produces a
+//! [`vibesql_ast::FromClause::TableFunction`] **only** for names on this
+//! allow-list. Any other `ident(` in FROM remains a parse error, preserving
+//! the pre-existing behavior for everything else.
+//!
+//! The comparison is case-insensitive; the AST stores the normalized lowercase
+//! name.
+
+/// The set of table-valued function names recognized in FROM position.
+///
+/// Kept lowercase; callers compare case-insensitively via
+/// [`is_table_valued_function`].
+pub(crate) const TABLE_VALUED_FUNCTIONS: [&str; 2] = ["json_each", "json_tree"];
+
+/// Returns `true` if `name` (compared case-insensitively) is an allow-listed
+/// table-valued function that may appear in FROM position.
+pub(crate) fn is_table_valued_function(name: &str) -> bool {
+    TABLE_VALUED_FUNCTIONS.iter().any(|tvf| name.eq_ignore_ascii_case(tvf))
+}
+
+/// Returns the normalized (lowercase) TVF name if `name` is allow-listed,
+/// otherwise `None`.
+pub(crate) fn normalized_table_valued_function(name: &str) -> Option<String> {
+    TABLE_VALUED_FUNCTIONS
+        .iter()
+        .find(|tvf| name.eq_ignore_ascii_case(tvf))
+        .map(|tvf| (*tvf).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_allow_listed_names_case_insensitively() {
+        assert!(is_table_valued_function("json_each"));
+        assert!(is_table_valued_function("JSON_EACH"));
+        assert!(is_table_valued_function("Json_Tree"));
+    }
+
+    #[test]
+    fn rejects_non_allow_listed_names() {
+        assert!(!is_table_valued_function("foo"));
+        assert!(!is_table_valued_function("json_extract"));
+        assert!(!is_table_valued_function("generate_series"));
+    }
+
+    #[test]
+    fn normalizes_to_lowercase() {
+        assert_eq!(normalized_table_valued_function("JSON_EACH").as_deref(), Some("json_each"));
+        assert_eq!(normalized_table_valued_function("Json_Tree").as_deref(), Some("json_tree"));
+        assert_eq!(normalized_table_valued_function("foo"), None);
+    }
+}

--- a/crates/vibesql-parser/src/tests/mod.rs
+++ b/crates/vibesql-parser/src/tests/mod.rs
@@ -50,6 +50,7 @@ mod set_operations;
 mod set_statements;
 mod string_functions;
 mod subquery;
+mod table_functions;
 mod transaction;
 mod translation;
 mod trigger;

--- a/crates/vibesql-parser/src/tests/table_functions.rs
+++ b/crates/vibesql-parser/src/tests/table_functions.rs
@@ -1,0 +1,187 @@
+//! Tests for table-valued functions (`json_each` / `json_tree`) in FROM
+//! position (JSON1 Phase 3, ADR-0005 step 2).
+//!
+//! These cover the standard parser, the arena parser, and std/arena parity.
+//! No executor support exists yet — these tests assert only on the parsed AST
+//! shape (`FromClause::TableFunction`).
+
+use bumpalo::Bump;
+use vibesql_ast::{arena::Converter, Expression, FromClause, Statement};
+
+use crate::arena_parser::ArenaParser;
+use crate::Parser;
+
+/// Parse `sql` with the standard parser and return its FROM clause.
+fn std_from(sql: &str) -> FromClause {
+    match Parser::parse_sql(sql).expect("standard parse should succeed") {
+        Statement::Select(select) => select.from.expect("SELECT should have a FROM clause"),
+        other => panic!("expected SELECT, got {other:?}"),
+    }
+}
+
+/// Parse `sql` with the arena parser, convert to the standard AST, and return
+/// its FROM clause. This exercises the arena `parse_table_function` path and
+/// the arena→standard `TableFunction` conversion.
+fn arena_from(sql: &str) -> FromClause {
+    let arena = Bump::new();
+    let (stmt, interner) =
+        ArenaParser::parse_select_with_interner(sql, &arena).expect("arena parse should succeed");
+    let converter = Converter::new(&interner);
+    let std_stmt = converter.convert_select(stmt);
+    std_stmt.from.expect("SELECT should have a FROM clause")
+}
+
+// ============================================================================
+// Standard parser
+// ============================================================================
+
+#[test]
+fn std_json_each_single_literal_arg() {
+    let from = std_from("SELECT * FROM json_each('[1,2,3]')");
+    match from {
+        FromClause::TableFunction { name, args, alias, column_aliases } => {
+            assert_eq!(name, "json_each");
+            assert_eq!(args.len(), 1);
+            assert!(matches!(args[0], Expression::Literal(_)));
+            assert_eq!(alias, None);
+            assert_eq!(column_aliases, None);
+        }
+        other => panic!("expected TableFunction, got {other:?}"),
+    }
+}
+
+#[test]
+fn std_json_tree_single_literal_arg() {
+    let from = std_from(r#"SELECT * FROM json_tree('{"a":1}')"#);
+    match from {
+        FromClause::TableFunction { name, args, .. } => {
+            assert_eq!(name, "json_tree");
+            assert_eq!(args.len(), 1);
+        }
+        other => panic!("expected TableFunction, got {other:?}"),
+    }
+}
+
+#[test]
+fn std_json_each_two_args_value_and_path() {
+    // FROM json_each(x, '$.a') — column-ref value + literal path.
+    let from = std_from("SELECT * FROM json_each(x, '$.a')");
+    match from {
+        FromClause::TableFunction { name, args, .. } => {
+            assert_eq!(name, "json_each");
+            assert_eq!(args.len(), 2);
+            assert!(matches!(args[0], Expression::ColumnRef(_)));
+            assert!(matches!(args[1], Expression::Literal(_)));
+        }
+        other => panic!("expected TableFunction, got {other:?}"),
+    }
+}
+
+#[test]
+fn std_alias_and_column_alias_list() {
+    // ... AS je(k, v)
+    let from = std_from("SELECT * FROM json_each('[1,2,3]') AS je(k, v)");
+    match from {
+        FromClause::TableFunction { name, alias, column_aliases, .. } => {
+            assert_eq!(name, "json_each");
+            assert_eq!(alias.as_deref(), Some("je"));
+            assert_eq!(column_aliases, Some(vec!["k".to_string(), "v".to_string()]));
+        }
+        other => panic!("expected TableFunction, got {other:?}"),
+    }
+}
+
+#[test]
+fn std_bare_alias_without_as() {
+    let from = std_from("SELECT * FROM json_each('[1,2,3]') je");
+    match from {
+        FromClause::TableFunction { alias, .. } => {
+            assert_eq!(alias.as_deref(), Some("je"));
+        }
+        other => panic!("expected TableFunction, got {other:?}"),
+    }
+}
+
+#[test]
+fn std_name_normalized_to_lowercase() {
+    let from = std_from("SELECT * FROM JSON_EACH('[1]')");
+    match from {
+        FromClause::TableFunction { name, .. } => assert_eq!(name, "json_each"),
+        other => panic!("expected TableFunction, got {other:?}"),
+    }
+}
+
+#[test]
+fn std_non_allow_listed_function_still_errors() {
+    // A non-allow-listed `ident(` in FROM must remain a parse error, exactly as
+    // before this feature landed.
+    assert!(Parser::parse_sql("SELECT * FROM foo('[1,2,3]')").is_err());
+    assert!(Parser::parse_sql("SELECT * FROM generate_series(1, 10)").is_err());
+    // json_extract is a scalar JSON function, not a TVF — not allow-listed.
+    assert!(Parser::parse_sql("SELECT * FROM json_extract('{}', '$.a')").is_err());
+}
+
+#[test]
+fn std_quoted_name_is_a_table_not_a_tvf() {
+    // A delimited/quoted identifier is a table name, never a TVF. `"json_each"`
+    // followed by `(` should not be treated as a table-valued function; without
+    // an executor it simply parses as a plain table reference (the `(` starts
+    // the next token which is not consumed here — so this must NOT be a
+    // TableFunction).
+    let from = std_from(r#"SELECT * FROM "json_each""#);
+    assert!(matches!(from, FromClause::Table { .. }));
+}
+
+// ============================================================================
+// Arena parser
+// ============================================================================
+
+#[test]
+fn arena_json_each_single_literal_arg() {
+    let from = arena_from("SELECT * FROM json_each('[1,2,3]')");
+    match from {
+        FromClause::TableFunction { name, args, alias, column_aliases } => {
+            assert_eq!(name, "json_each");
+            assert_eq!(args.len(), 1);
+            assert_eq!(alias, None);
+            assert_eq!(column_aliases, None);
+        }
+        other => panic!("expected TableFunction, got {other:?}"),
+    }
+}
+
+#[test]
+fn arena_non_allow_listed_function_still_errors() {
+    let arena = Bump::new();
+    assert!(ArenaParser::parse_select_with_interner("SELECT * FROM foo('[1]')", &arena).is_err());
+}
+
+// ============================================================================
+// std / arena parity
+// ============================================================================
+
+/// Every acceptance form must parse identically under both parsers (compared
+/// after arena→standard conversion).
+#[test]
+fn std_arena_parity_across_acceptance_forms() {
+    let cases = [
+        "SELECT * FROM json_each('[1,2,3]')",
+        r#"SELECT * FROM json_tree('{"a":1}')"#,
+        "SELECT * FROM json_each(x, '$.a')",
+        "SELECT * FROM json_each('[1,2,3]') AS je(k, v)",
+        "SELECT * FROM json_tree(x, '$.a') AS jt(k, v)",
+        "SELECT * FROM json_each('[1]') je",
+    ];
+    for sql in cases {
+        assert_eq!(std_from(sql), arena_from(sql), "parser mismatch for: {sql}");
+    }
+}
+
+#[test]
+fn std_arena_parity_negative_case() {
+    // Both parsers reject a non-allow-listed `ident(` in FROM.
+    let sql = "SELECT * FROM foo('[1,2,3]')";
+    let arena = Bump::new();
+    assert!(Parser::parse_sql(sql).is_err());
+    assert!(ArenaParser::parse_select_with_interner(sql, &arena).is_err());
+}


### PR DESCRIPTION
## Summary
Implements step 2 of the ADR-0005 decomposition (JSON1 Phase 3). With `FromClause::TableFunction` now in the AST (#5986 / #5991), the parser recognizes an allow-listed identifier immediately followed by `(` in FROM position and produces that variant. No executor changes — a parsed `TableFunction` has no execution path yet (that lands in step 3).

## Changes
- New crate-internal `table_functions` module holding the allow-list (`json_each`, `json_tree`) plus case-insensitive lookup and lowercase-normalization helpers, shared by both parsers.
- Standard parser (`parser/select/from_clause.rs`): in `parse_table_reference`, an unquoted `Identifier` that is allow-listed and immediately followed by `LParen` dispatches to a new `parse_table_function` — parses the comma-separated `Expression` arg list, then reuses `parse_alias_name` / `parse_column_alias_list` for `AS je(k, v)`.
- Arena parser (`arena_parser/select.rs`): mirror change with an equivalent `parse_table_function` producing `arena::FromClause::TableFunction`.
- Name is normalized to lowercase in the AST. Delimited/quoted identifiers are never treated as TVFs. Non-allow-listed `ident(` in FROM still errors exactly as before.
- New test module `tests/table_functions.rs` (15 tests) covering every acceptance bullet across the standard parser, the arena parser, and std/arena parity (arena parsed then converted to the standard AST for comparison).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `FROM json_each('[1,2,3]')` parses to TableFunction | Pass | `std_json_each_single_literal_arg` |
| `FROM json_tree('{...}')` parses to TableFunction | Pass | `std_json_tree_single_literal_arg` |
| `FROM json_each(x, '$.a')` (value + path) parses | Pass | `std_json_each_two_args_value_and_path` |
| `... AS je(k,v)` alias + column aliases | Pass | `std_alias_and_column_alias_list` |
| Non-allow-listed `foo(...)` in FROM still errors | Pass | `std_non_allow_listed_function_still_errors`, `arena_non_allow_listed_function_still_errors` |
| Both parsers behave identically | Pass | `std_arena_parity_across_acceptance_forms`, `std_arena_parity_negative_case` |
| `cargo build --release` passes | Pass | Clean release build (warnings only in unrelated crates) |
| `cargo test -p vibesql-parser` passes | Pass | 1759 unit + 8 doctests pass |

## Test Plan
- `cargo test -p vibesql-parser` — 1759 tests pass (15 new).
- `cargo test -p vibesql-ast` — passes (sanity check for the AST variant fan-out).
- `cargo build --release` — succeeds.
- `cargo clippy -p vibesql-parser` — no new warnings from the changed code.
- Out-of-scope `cargo fmt` reformatting of unrelated files was reverted; only the six in-scope files are touched.

Closes #5987