### PR TITLE
perf(columnar): vectorize IS NULL / IS NOT NULL predicates from the null bitmap

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/batch/operations.rs
+++ b/crates/vibesql-executor/src/select/columnar/batch/operations.rs
@@ -301,6 +301,35 @@ impl ColumnArray {
         self.len() == 0
     }
 
+    /// Return the column's null bitmap, if one is present.
+    ///
+    /// A `Some(slice)` gives per-row null-ness (`slice[i] == true` ⇒ row `i` is
+    /// NULL). `None` means the column has no null bitmap, i.e. no row is NULL.
+    /// `Mixed` columns carry per-value `SqlValue::Null`s instead of a bitmap and
+    /// so return `None` here — callers that must treat them faithfully fall back
+    /// to `get_value`.
+    pub fn null_bitmap(&self) -> Option<&[bool]> {
+        match self {
+            Self::Int64(_, nulls) | Self::Timestamp(_, nulls) => {
+                nulls.as_ref().map(|n| n.as_slice())
+            }
+            Self::Int32(_, nulls) | Self::Date(_, nulls) => nulls.as_ref().map(|n| n.as_slice()),
+            Self::Float64(_, nulls) => nulls.as_ref().map(|n| n.as_slice()),
+            Self::Float32(_, nulls) => nulls.as_ref().map(|n| n.as_slice()),
+            Self::String(_, nulls) | Self::FixedString(_, nulls) => {
+                nulls.as_ref().map(|n| n.as_slice())
+            }
+            Self::Boolean(_, nulls) => nulls.as_ref().map(|n| n.as_slice()),
+            Self::Mixed(_) => None,
+        }
+    }
+
+    /// Whether this column stores values inline as `SqlValue` (the `Mixed`
+    /// fallback), where NULLs live in the values rather than a null bitmap.
+    pub fn is_mixed(&self) -> bool {
+        matches!(self, Self::Mixed(_))
+    }
+
     /// Get a value at the specified index as SqlValue
     pub fn get_value(&self, index: usize) -> Result<SqlValue, ExecutorError> {
         match self {

--- a/crates/vibesql-executor/src/select/columnar/filter/evaluation.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/evaluation.rs
@@ -153,6 +153,20 @@ where
                 return evaluate_column_compare(*op, left_val, right_val);
             }
 
+            // Handle null tests specially - they read null-ness directly instead
+            // of failing on NULL like value comparisons do. `get_value` returns
+            // None for an absent value and Some(SqlValue::Null) for a stored
+            // NULL; both are NULL for the purpose of IS [NOT] NULL.
+            match predicate {
+                ColumnPredicate::IsNull { column_idx } => {
+                    return value_is_null(get_value(*column_idx));
+                }
+                ColumnPredicate::IsNotNull { column_idx } => {
+                    return !value_is_null(get_value(*column_idx));
+                }
+                _ => {}
+            }
+
             // Get the column value and evaluate the leaf predicate
             let column_idx = match predicate {
                 ColumnPredicate::LessThan { column_idx, .. }
@@ -164,7 +178,10 @@ where
                 | ColumnPredicate::Between { column_idx, .. }
                 | ColumnPredicate::Like { column_idx, .. }
                 | ColumnPredicate::InList { column_idx, .. } => *column_idx,
-                ColumnPredicate::ColumnCompare { .. } => unreachable!(), // Handled above
+                // Handled above.
+                ColumnPredicate::ColumnCompare { .. }
+                | ColumnPredicate::IsNull { .. }
+                | ColumnPredicate::IsNotNull { .. } => unreachable!(),
             };
 
             if let Some(value) = get_value(column_idx) {
@@ -332,6 +349,11 @@ pub fn evaluate_predicate(predicate: &ColumnPredicate, value: &SqlValue) -> bool
                 matches
             }
         }
+        // Null tests read null-ness, not the value. A non-NULL `value` reaches
+        // this arm (the caller resolved it), so IS NULL is false and IS NOT
+        // NULL is true; a stored NULL is still handled defensively.
+        ColumnPredicate::IsNull { .. } => matches!(value, SqlValue::Null),
+        ColumnPredicate::IsNotNull { .. } => !matches!(value, SqlValue::Null),
         // ColumnCompare should be handled by evaluate_column_compare, not here
         // This case is included for exhaustiveness but shouldn't be reached in normal use
         ColumnPredicate::ColumnCompare { .. } => {
@@ -340,6 +362,14 @@ pub fn evaluate_predicate(predicate: &ColumnPredicate, value: &SqlValue) -> bool
             false
         }
     }
+}
+
+/// Whether a resolved column value represents SQL NULL.
+///
+/// `None` (the value is absent from the row) and `Some(SqlValue::Null)` (a
+/// stored NULL) are both NULL for the purpose of IS [NOT] NULL.
+fn value_is_null(value: Option<&SqlValue>) -> bool {
+    matches!(value, None | Some(SqlValue::Null))
 }
 
 // NOTE: The old like_match() function was removed in favor of

--- a/crates/vibesql-executor/src/select/columnar/filter/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/mod.rs
@@ -108,6 +108,24 @@ where
                 continue;
             }
 
+            // Handle null tests specially - they read null-ness directly instead
+            // of failing on NULL like value comparisons do. `get_value` returns
+            // None for an absent value and Some(SqlValue::Null) for a stored NULL.
+            if let ColumnPredicate::IsNull { column_idx }
+            | ColumnPredicate::IsNotNull { column_idx } = predicate
+            {
+                let is_null = matches!(
+                    get_value(row_idx, *column_idx),
+                    None | Some(vibesql_types::SqlValue::Null)
+                );
+                let want_null = matches!(predicate, ColumnPredicate::IsNull { .. });
+                if is_null != want_null {
+                    bitmap[row_idx] = false;
+                    break;
+                }
+                continue;
+            }
+
             let column_idx = match predicate {
                 ColumnPredicate::LessThan { column_idx, .. } => *column_idx,
                 ColumnPredicate::GreaterThan { column_idx, .. } => *column_idx,
@@ -118,7 +136,10 @@ where
                 ColumnPredicate::Between { column_idx, .. } => *column_idx,
                 ColumnPredicate::Like { column_idx, .. } => *column_idx,
                 ColumnPredicate::InList { column_idx, .. } => *column_idx,
-                ColumnPredicate::ColumnCompare { .. } => unreachable!(), // Handled above
+                // Handled above.
+                ColumnPredicate::ColumnCompare { .. }
+                | ColumnPredicate::IsNull { .. }
+                | ColumnPredicate::IsNotNull { .. } => unreachable!(),
             };
 
             if let Some(value) = get_value(row_idx, column_idx) {

--- a/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/predicates.rs
@@ -89,6 +89,19 @@ pub enum ColumnPredicate {
     /// column1 op column2 (column-to-column comparison)
     /// Used for predicates like `l_commitdate < l_receiptdate` in TPC-H Q4
     ColumnCompare { left_column_idx: usize, op: CompareOp, right_column_idx: usize },
+
+    /// column IS NULL — the row matches iff the column value is NULL.
+    ///
+    /// Evaluated directly from the column's null bitmap (the mask is exactly
+    /// the bitmap; an absent bitmap yields an all-false mask), so no value
+    /// comparison is performed. See `evaluate_null_predicate_range`.
+    IsNull { column_idx: usize },
+
+    /// column IS NOT NULL — the row matches iff the column value is non-NULL.
+    ///
+    /// The complement of `IsNull`: the mask is the negation of the null bitmap
+    /// (an absent bitmap yields an all-true mask).
+    IsNotNull { column_idx: usize },
 }
 
 impl ColumnPredicate {
@@ -106,7 +119,9 @@ impl ColumnPredicate {
             | ColumnPredicate::NotEqual { column_idx, .. }
             | ColumnPredicate::Between { column_idx, .. }
             | ColumnPredicate::Like { column_idx, .. }
-            | ColumnPredicate::InList { column_idx, .. } => vec![*column_idx],
+            | ColumnPredicate::InList { column_idx, .. }
+            | ColumnPredicate::IsNull { column_idx }
+            | ColumnPredicate::IsNotNull { column_idx } => vec![*column_idx],
             ColumnPredicate::ColumnCompare { left_column_idx, right_column_idx, .. } => {
                 vec![*left_column_idx, *right_column_idx]
             }
@@ -221,6 +236,12 @@ fn remap_predicate(predicate: &ColumnPredicate, column_mapping: &[usize]) -> Col
                 right_column_idx: find_new_idx(*right_column_idx),
             }
         }
+        ColumnPredicate::IsNull { column_idx } => {
+            ColumnPredicate::IsNull { column_idx: find_new_idx(*column_idx) }
+        }
+        ColumnPredicate::IsNotNull { column_idx } => {
+            ColumnPredicate::IsNotNull { column_idx: find_new_idx(*column_idx) }
+        }
     }
 }
 
@@ -316,6 +337,10 @@ fn predicate_supported_by_columnar(predicate: &ColumnPredicate, schema: &Combine
         }
         // LIKE patterns are strings; existing comparator behavior applies
         ColumnPredicate::Like { .. } => true,
+        // IS NULL / IS NOT NULL read only the column's null bitmap, so they are
+        // faithful for every column type and unaffected by collation or type
+        // affinity — always supported by the columnar path.
+        ColumnPredicate::IsNull { .. } | ColumnPredicate::IsNotNull { .. } => true,
         ColumnPredicate::ColumnCompare { left_column_idx, right_column_idx, .. } => {
             // Issue #5792: see above — collated columns need the full evaluator.
             !schema.column_has_non_binary_collation(*left_column_idx)
@@ -882,6 +907,25 @@ fn extract_tree_recursive(
             None
         }
 
+        // IS NULL / IS NOT NULL on a bare column: read the null bitmap directly.
+        // `negated` distinguishes the two (false = IS NULL, true = IS NOT NULL),
+        // which drives the choice of predicate variant (three-valued logic).
+        // A non-column operand has no null bitmap to consume, so decline it.
+        Expression::IsNull { expr: inner, negated } => {
+            if let Expression::ColumnRef(col_id) = inner.as_ref() {
+                let table = col_id.table_canonical();
+                let column = col_id.column_canonical();
+                let column_idx = schema.get_column_index(table, column)?;
+                let predicate = if *negated {
+                    ColumnPredicate::IsNotNull { column_idx }
+                } else {
+                    ColumnPredicate::IsNull { column_idx }
+                };
+                return Some(PredicateTree::Leaf(predicate));
+            }
+            None
+        }
+
         _ => None,
     }
 }
@@ -1116,6 +1160,24 @@ fn extract_predicates_recursive(
                 return Some(());
             }
             // Skip non-column IN expressions
+            Some(())
+        }
+
+        // IS NULL / IS NOT NULL on a bare column: read the null bitmap directly.
+        // Skip (don't fail) if the column is not in this scan's schema, matching
+        // the cross-table-predicate handling of the other arms.
+        Expression::IsNull { expr: inner, negated } => {
+            if let Expression::ColumnRef(col_id) = inner.as_ref() {
+                let table = col_id.table_canonical();
+                let column = col_id.column_canonical();
+                if let Some(column_idx) = schema.get_column_index(table, column) {
+                    predicates.push(if *negated {
+                        ColumnPredicate::IsNotNull { column_idx }
+                    } else {
+                        ColumnPredicate::IsNull { column_idx }
+                    });
+                }
+            }
             Some(())
         }
 
@@ -1655,5 +1717,114 @@ mod tests {
             }
             _ => panic!("Expected GreaterThan predicate"),
         }
+    }
+
+    fn is_null_expr(column: &str, negated: bool) -> Expression {
+        Expression::IsNull {
+            expr: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
+                column, false,
+            ))),
+            negated,
+        }
+    }
+
+    #[test]
+    fn test_extract_is_null_tree() {
+        let schema = create_test_schema();
+
+        // col0 IS NULL -> IsNull { column_idx: 0 }
+        let tree = extract_predicate_tree(&is_null_expr("col0", false), &schema, false)
+            .expect("IS NULL should be columnar-convertible");
+        match tree {
+            PredicateTree::Leaf(ColumnPredicate::IsNull { column_idx }) => {
+                assert_eq!(column_idx, 0)
+            }
+            other => panic!("expected IsNull leaf, got {other:?}"),
+        }
+
+        // col1 IS NOT NULL -> IsNotNull { column_idx: 1 } (negated flag drives choice)
+        let tree = extract_predicate_tree(&is_null_expr("col1", true), &schema, false)
+            .expect("IS NOT NULL should be columnar-convertible");
+        match tree {
+            PredicateTree::Leaf(ColumnPredicate::IsNotNull { column_idx }) => {
+                assert_eq!(column_idx, 1)
+            }
+            other => panic!("expected IsNotNull leaf, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_extract_is_null_non_column_declined() {
+        let schema = create_test_schema();
+
+        // (1 + 2) IS NULL — non-column operand has no null bitmap to consume.
+        let expr = Expression::IsNull {
+            expr: Box::new(Expression::Literal(SqlValue::Integer(1))),
+            negated: false,
+        };
+        assert!(extract_predicate_tree(&expr, &schema, false).is_none());
+    }
+
+    #[test]
+    fn test_extract_is_null_compound_and() {
+        let schema = create_test_schema();
+
+        // col0 IS NULL AND col1 > 5
+        let expr = Expression::BinaryOp {
+            left: Box::new(is_null_expr("col0", false)),
+            op: BinaryOperator::And,
+            right: Box::new(comparison_expr(
+                "col1",
+                BinaryOperator::GreaterThan,
+                SqlValue::Integer(5),
+            )),
+        };
+        let tree = extract_predicate_tree(&expr, &schema, false)
+            .expect("compound IS NULL AND compare should be columnar-convertible");
+        match tree {
+            PredicateTree::And(children) => {
+                assert_eq!(children.len(), 2);
+                assert!(matches!(
+                    children[0],
+                    PredicateTree::Leaf(ColumnPredicate::IsNull { column_idx: 0 })
+                ));
+                assert!(matches!(
+                    children[1],
+                    PredicateTree::Leaf(ColumnPredicate::GreaterThan { column_idx: 1, .. })
+                ));
+            }
+            other => panic!("expected And node, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_extract_is_null_legacy_and_extractor() {
+        let schema = create_test_schema();
+
+        // Legacy AND-only extractor: col0 IS NULL AND col1 IS NOT NULL
+        let expr = Expression::BinaryOp {
+            left: Box::new(is_null_expr("col0", false)),
+            op: BinaryOperator::And,
+            right: Box::new(is_null_expr("col1", true)),
+        };
+        let predicates = extract_column_predicates(&expr, &schema, false)
+            .expect("legacy extractor should return both null-test predicates");
+        assert_eq!(predicates.len(), 2);
+        assert!(matches!(predicates[0], ColumnPredicate::IsNull { column_idx: 0 }));
+        assert!(matches!(predicates[1], ColumnPredicate::IsNotNull { column_idx: 1 }));
+    }
+
+    #[test]
+    fn test_is_null_referenced_columns_and_remap() {
+        let is_null = ColumnPredicate::IsNull { column_idx: 7 };
+        let is_not_null = ColumnPredicate::IsNotNull { column_idx: 3 };
+        assert_eq!(is_null.referenced_columns(), vec![7]);
+        assert_eq!(is_not_null.referenced_columns(), vec![3]);
+
+        // Remap against a sparse column mapping [3, 7] -> new indices 0, 1.
+        let mapping = vec![3usize, 7usize];
+        let remapped = remap_predicates(&[is_null, is_not_null], &mapping);
+        assert!(matches!(remapped[0], ColumnPredicate::IsNull { column_idx: 1 }));
+        assert!(matches!(remapped[1], ColumnPredicate::IsNotNull { column_idx: 0 }));
     }
 }

--- a/crates/vibesql-executor/src/select/columnar/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/mod.rs
@@ -390,6 +390,18 @@ fn evaluate_predicate(row: &Row, predicate: &ColumnPredicate) -> bool {
         );
     }
 
+    // Null tests read null-ness directly. `row.get` returns None for an absent
+    // column and Some(SqlValue::Null) for a stored NULL; both are NULL here.
+    if let ColumnPredicate::IsNull { column_idx } | ColumnPredicate::IsNotNull { column_idx } =
+        predicate
+    {
+        let is_null = matches!(row.get(*column_idx), None | Some(SqlValue::Null));
+        return match predicate {
+            ColumnPredicate::IsNull { .. } => is_null,
+            _ => !is_null,
+        };
+    }
+
     let column_idx = match predicate {
         ColumnPredicate::LessThan { column_idx, .. }
         | ColumnPredicate::GreaterThan { column_idx, .. }
@@ -400,7 +412,10 @@ fn evaluate_predicate(row: &Row, predicate: &ColumnPredicate) -> bool {
         | ColumnPredicate::Between { column_idx, .. }
         | ColumnPredicate::Like { column_idx, .. }
         | ColumnPredicate::InList { column_idx, .. } => *column_idx,
-        ColumnPredicate::ColumnCompare { .. } => unreachable!(), // Handled above
+        // Handled above.
+        ColumnPredicate::ColumnCompare { .. }
+        | ColumnPredicate::IsNull { .. }
+        | ColumnPredicate::IsNotNull { .. } => unreachable!(),
     };
 
     match row.get(column_idx) {

--- a/crates/vibesql-executor/src/select/columnar/simd_filter/comparison.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter/comparison.rs
@@ -286,8 +286,11 @@ pub fn evaluate_predicate_i64_simd(
             result
         }
 
-        // ColumnCompare is handled at higher level in simd_filter/mod.rs
-        ColumnPredicate::ColumnCompare { .. } => {
+        // ColumnCompare and null tests are handled at a higher level in
+        // simd_filter/mod.rs; reaching a value kernel with one is a bug.
+        ColumnPredicate::ColumnCompare { .. }
+        | ColumnPredicate::IsNull { .. }
+        | ColumnPredicate::IsNotNull { .. } => {
             return Err(ExecutorError::ColumnarTypeMismatch {
                 operation: "column-to-column comparison".to_string(),
                 left_type: "Int64".to_string(),
@@ -447,8 +450,11 @@ pub fn evaluate_predicate_timestamp_simd(
                 right_type: Some("String pattern".to_string()),
             });
         }
-        // ColumnCompare is handled at higher level in simd_filter/mod.rs
-        ColumnPredicate::ColumnCompare { .. } => {
+        // ColumnCompare and null tests are handled at a higher level in
+        // simd_filter/mod.rs; reaching a value kernel with one is a bug.
+        ColumnPredicate::ColumnCompare { .. }
+        | ColumnPredicate::IsNull { .. }
+        | ColumnPredicate::IsNotNull { .. } => {
             return Err(ExecutorError::ColumnarTypeMismatch {
                 operation: "column-to-column comparison".to_string(),
                 left_type: "Timestamp".to_string(),
@@ -595,8 +601,11 @@ pub fn evaluate_predicate_i32_simd(
             result
         }
 
-        // ColumnCompare is handled at higher level in simd_filter/mod.rs
-        ColumnPredicate::ColumnCompare { .. } => {
+        // ColumnCompare and null tests are handled at a higher level in
+        // simd_filter/mod.rs; reaching a value kernel with one is a bug.
+        ColumnPredicate::ColumnCompare { .. }
+        | ColumnPredicate::IsNull { .. }
+        | ColumnPredicate::IsNotNull { .. } => {
             return Err(ExecutorError::ColumnarTypeMismatch {
                 operation: "column-to-column comparison".to_string(),
                 left_type: "Date".to_string(),
@@ -799,8 +808,11 @@ pub fn evaluate_predicate_f64_simd(
             result
         }
 
-        // ColumnCompare is handled at higher level in simd_filter/mod.rs
-        ColumnPredicate::ColumnCompare { .. } => {
+        // ColumnCompare and null tests are handled at a higher level in
+        // simd_filter/mod.rs; reaching a value kernel with one is a bug.
+        ColumnPredicate::ColumnCompare { .. }
+        | ColumnPredicate::IsNull { .. }
+        | ColumnPredicate::IsNotNull { .. } => {
             return Err(ExecutorError::ColumnarTypeMismatch {
                 operation: "column-to-column comparison".to_string(),
                 left_type: "Float64".to_string(),
@@ -1099,8 +1111,11 @@ pub fn evaluate_predicate_i64_packed(
             result
         }
 
-        // ColumnCompare is handled at higher level in simd_filter/mod.rs
-        ColumnPredicate::ColumnCompare { .. } => {
+        // ColumnCompare and null tests are handled at a higher level in
+        // simd_filter/mod.rs; reaching a value kernel with one is a bug.
+        ColumnPredicate::ColumnCompare { .. }
+        | ColumnPredicate::IsNull { .. }
+        | ColumnPredicate::IsNotNull { .. } => {
             return Err(ExecutorError::ColumnarTypeMismatch {
                 operation: "column-to-column comparison".to_string(),
                 left_type: "Int64".to_string(),
@@ -1233,8 +1248,11 @@ pub fn evaluate_predicate_i32_packed(
             result
         }
 
-        // ColumnCompare is handled at higher level in simd_filter/mod.rs
-        ColumnPredicate::ColumnCompare { .. } => {
+        // ColumnCompare and null tests are handled at a higher level in
+        // simd_filter/mod.rs; reaching a value kernel with one is a bug.
+        ColumnPredicate::ColumnCompare { .. }
+        | ColumnPredicate::IsNull { .. }
+        | ColumnPredicate::IsNotNull { .. } => {
             return Err(ExecutorError::ColumnarTypeMismatch {
                 operation: "column-to-column comparison".to_string(),
                 left_type: "Date".to_string(),
@@ -1435,8 +1453,11 @@ pub fn evaluate_predicate_f64_packed(
             result
         }
 
-        // ColumnCompare is handled at higher level in simd_filter/mod.rs
-        ColumnPredicate::ColumnCompare { .. } => {
+        // ColumnCompare and null tests are handled at a higher level in
+        // simd_filter/mod.rs; reaching a value kernel with one is a bug.
+        ColumnPredicate::ColumnCompare { .. }
+        | ColumnPredicate::IsNull { .. }
+        | ColumnPredicate::IsNotNull { .. } => {
             return Err(ExecutorError::ColumnarTypeMismatch {
                 operation: "column-to-column comparison".to_string(),
                 left_type: "Float64".to_string(),

--- a/crates/vibesql-executor/src/select/columnar/simd_filter/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter/mod.rs
@@ -62,7 +62,56 @@ fn predicate_contains_null(predicate: &ColumnPredicate) -> bool {
         // Column-to-column comparisons don't have literal NULLs
         // (NULL columns are handled during evaluation)
         ColumnPredicate::ColumnCompare { .. } => false,
+        // Null tests carry no literal; they are evaluated from the null bitmap
+        // and must NOT be short-circuited to an all-false mask.
+        ColumnPredicate::IsNull { .. } | ColumnPredicate::IsNotNull { .. } => false,
     }
+}
+
+/// If `predicate` is a null test (`IS NULL` / `IS NOT NULL`), evaluate it
+/// directly from the referenced column's null bitmap over `[start, end)` and
+/// return the resulting boolean mask. Returns `None` for any other predicate.
+///
+/// The mask is derived entirely from the null bitmap — no value comparison is
+/// performed. A column with no null bitmap has no NULLs, so `IS NULL` yields an
+/// all-false mask and `IS NOT NULL` an all-true mask. `Mixed` columns store
+/// NULLs inline as `SqlValue::Null` (no bitmap), so they are resolved via
+/// `get_value` to preserve correctness.
+fn evaluate_null_predicate_range(
+    batch: &ColumnarBatch,
+    predicate: &ColumnPredicate,
+    start: usize,
+    end: usize,
+) -> Result<Option<Vec<bool>>, ExecutorError> {
+    let (column_idx, want_null) = match predicate {
+        ColumnPredicate::IsNull { column_idx } => (*column_idx, true),
+        ColumnPredicate::IsNotNull { column_idx } => (*column_idx, false),
+        _ => return Ok(None),
+    };
+
+    let column = batch.column(column_idx).ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+        column_index: column_idx,
+        batch_columns: batch.column_count(),
+    })?;
+
+    let range_len = end - start;
+
+    if column.is_mixed() {
+        // Mixed columns keep NULLs inline; consult get_value per row.
+        let mut mask = Vec::with_capacity(range_len);
+        for row_idx in start..end {
+            let is_null = batch.get_value(row_idx, column_idx)? == SqlValue::Null;
+            mask.push(is_null == want_null);
+        }
+        return Ok(Some(mask));
+    }
+
+    let mask = match column.null_bitmap() {
+        // No null bitmap ⇒ no NULLs: IS NULL is all-false, IS NOT NULL all-true.
+        None => vec![!want_null; range_len],
+        Some(bitmap) => bitmap[start..end].iter().map(|&is_null| is_null == want_null).collect(),
+    };
+    Ok(Some(mask))
 }
 
 /// Apply SIMD-accelerated filtering to a columnar batch
@@ -349,6 +398,11 @@ fn evaluate_predicate_for_range(
     start: usize,
     end: usize,
 ) -> Result<Vec<bool>, ExecutorError> {
+    // Handle null tests directly from the null bitmap.
+    if let Some(mask) = evaluate_null_predicate_range(batch, predicate, start, end)? {
+        return Ok(mask);
+    }
+
     // Handle ColumnCompare specially
     if let ColumnPredicate::ColumnCompare { left_column_idx, op, right_column_idx } = predicate {
         return evaluate_column_compare_range(
@@ -371,7 +425,9 @@ fn evaluate_predicate_for_range(
         | ColumnPredicate::Between { column_idx, .. }
         | ColumnPredicate::Like { column_idx, .. }
         | ColumnPredicate::InList { column_idx, .. } => *column_idx,
-        ColumnPredicate::ColumnCompare { .. } => unreachable!(),
+        ColumnPredicate::ColumnCompare { .. }
+        | ColumnPredicate::IsNull { .. }
+        | ColumnPredicate::IsNotNull { .. } => unreachable!(),
     };
 
     let column = batch.column(column_idx).ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
@@ -617,6 +673,12 @@ fn evaluate_predicate_simd_packed(
         return Ok(PackedMask::new_all_clear(batch.row_count()));
     }
 
+    // Handle null tests directly from the null bitmap.
+    if let Some(bool_mask) = evaluate_null_predicate_range(batch, predicate, 0, batch.row_count())?
+    {
+        return Ok(PackedMask::from_bool_slice(&bool_mask));
+    }
+
     // Handle ColumnCompare specially - needs two columns
     if let ColumnPredicate::ColumnCompare { left_column_idx, op, right_column_idx } = predicate {
         let bool_mask =
@@ -634,7 +696,9 @@ fn evaluate_predicate_simd_packed(
         | ColumnPredicate::Between { column_idx, .. }
         | ColumnPredicate::Like { column_idx, .. }
         | ColumnPredicate::InList { column_idx, .. } => *column_idx,
-        ColumnPredicate::ColumnCompare { .. } => unreachable!(), // Handled above
+        ColumnPredicate::ColumnCompare { .. }
+        | ColumnPredicate::IsNull { .. }
+        | ColumnPredicate::IsNotNull { .. } => unreachable!(), // Handled above
     };
 
     let column = batch.column(column_idx).ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
@@ -685,6 +749,12 @@ fn evaluate_predicate_simd(
         return Ok(vec![false; batch.row_count()]);
     }
 
+    // Handle null tests directly from the null bitmap.
+    if let Some(bool_mask) = evaluate_null_predicate_range(batch, predicate, 0, batch.row_count())?
+    {
+        return Ok(bool_mask);
+    }
+
     // Handle ColumnCompare specially - needs two columns
     if let ColumnPredicate::ColumnCompare { left_column_idx, op, right_column_idx } = predicate {
         return evaluate_column_compare_simd(batch, *left_column_idx, *op, *right_column_idx);
@@ -700,7 +770,9 @@ fn evaluate_predicate_simd(
         | ColumnPredicate::Between { column_idx, .. }
         | ColumnPredicate::Like { column_idx, .. }
         | ColumnPredicate::InList { column_idx, .. } => *column_idx,
-        ColumnPredicate::ColumnCompare { .. } => unreachable!(), // Handled above
+        ColumnPredicate::ColumnCompare { .. }
+        | ColumnPredicate::IsNull { .. }
+        | ColumnPredicate::IsNotNull { .. } => unreachable!(), // Handled above
     };
 
     let column = batch.column(column_idx).ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
@@ -1597,5 +1669,166 @@ mod tests {
         }];
         let filtered = simd_filter_batch(&batch, &predicates).unwrap();
         assert_eq!(filtered.row_count(), 2); // Rows 0 and 2
+    }
+
+    // ── IS NULL / IS NOT NULL vectorized mask tests ─────────────────────────
+
+    /// Scalar reference: evaluate a null test row-by-row via `get_value`.
+    fn scalar_null_mask(batch: &ColumnarBatch, column_idx: usize, want_null: bool) -> Vec<bool> {
+        (0..batch.row_count())
+            .map(|row_idx| {
+                let is_null = batch.get_value(row_idx, column_idx).unwrap() == SqlValue::Null;
+                is_null == want_null
+            })
+            .collect()
+    }
+
+    fn assert_null_masks_match_scalar(batch: &ColumnarBatch, column_idx: usize) {
+        let is_null_pred = ColumnPredicate::IsNull { column_idx };
+        let is_not_null_pred = ColumnPredicate::IsNotNull { column_idx };
+
+        // Vectorized (non-packed), packed, and auto paths must all agree with
+        // the scalar reference over the null bitmap.
+        let vec_is_null = simd_create_filter_mask(batch, &[is_null_pred.clone()]).unwrap();
+        let vec_is_not_null = simd_create_filter_mask(batch, &[is_not_null_pred.clone()]).unwrap();
+        assert_eq!(vec_is_null, scalar_null_mask(batch, column_idx, true));
+        assert_eq!(vec_is_not_null, scalar_null_mask(batch, column_idx, false));
+
+        let packed_is_null =
+            simd_create_filter_mask_packed(batch, &[is_null_pred]).unwrap().to_bool_vec();
+        let packed_is_not_null =
+            simd_create_filter_mask_packed(batch, &[is_not_null_pred]).unwrap().to_bool_vec();
+        assert_eq!(&packed_is_null[..batch.row_count()], &vec_is_null[..]);
+        assert_eq!(&packed_is_not_null[..batch.row_count()], &vec_is_not_null[..]);
+
+        // IS NULL and IS NOT NULL must be exact complements.
+        for (a, b) in vec_is_null.iter().zip(vec_is_not_null.iter()) {
+            assert_ne!(a, b);
+        }
+    }
+
+    #[test]
+    fn test_is_null_sparse_bitmap() {
+        // First row concrete so the column infers Int64 (not Mixed), giving a
+        // dense/sparse null bitmap with a mix of null and non-null rows.
+        let rows = vec![
+            Row::new(vec![SqlValue::Integer(1)]),
+            Row::new(vec![SqlValue::Null]),
+            Row::new(vec![SqlValue::Integer(3)]),
+            Row::new(vec![SqlValue::Null]),
+            Row::new(vec![SqlValue::Integer(5)]),
+        ];
+        let batch = ColumnarBatch::from_rows(&rows).unwrap();
+
+        let is_null =
+            simd_create_filter_mask(&batch, &[ColumnPredicate::IsNull { column_idx: 0 }]).unwrap();
+        assert_eq!(is_null, vec![false, true, false, true, false]);
+        assert_null_masks_match_scalar(&batch, 0);
+    }
+
+    #[test]
+    fn test_is_null_absent_bitmap() {
+        // No NULLs at all: from_rows produces a None null bitmap. IS NULL must be
+        // all-false and IS NOT NULL all-true, computed without touching values.
+        let rows: Vec<Row> = (0..8).map(|i| Row::new(vec![SqlValue::Integer(i)])).collect();
+        let batch = ColumnarBatch::from_rows(&rows).unwrap();
+        assert!(batch.column(0).unwrap().null_bitmap().is_none());
+
+        let is_null =
+            simd_create_filter_mask(&batch, &[ColumnPredicate::IsNull { column_idx: 0 }]).unwrap();
+        let is_not_null =
+            simd_create_filter_mask(&batch, &[ColumnPredicate::IsNotNull { column_idx: 0 }])
+                .unwrap();
+        assert_eq!(is_null, vec![false; 8]);
+        assert_eq!(is_not_null, vec![true; 8]);
+        assert_null_masks_match_scalar(&batch, 0);
+    }
+
+    #[test]
+    fn test_is_null_all_null_bitmap() {
+        // Dense (all-true) bitmap: first row concrete then all NULL forces a
+        // bitmap; use a wider column so column 0 stays Int64.
+        let rows = vec![
+            Row::new(vec![SqlValue::Integer(1)]),
+            Row::new(vec![SqlValue::Null]),
+            Row::new(vec![SqlValue::Null]),
+        ];
+        let batch = ColumnarBatch::from_rows(&rows).unwrap();
+        let is_null =
+            simd_create_filter_mask(&batch, &[ColumnPredicate::IsNull { column_idx: 0 }]).unwrap();
+        assert_eq!(is_null, vec![false, true, true]);
+        assert_null_masks_match_scalar(&batch, 0);
+    }
+
+    #[test]
+    fn test_is_null_string_column() {
+        let rows = vec![
+            Row::new(vec![SqlValue::Varchar(arcstr::ArcStr::from("a"))]),
+            Row::new(vec![SqlValue::Null]),
+            Row::new(vec![SqlValue::Varchar(arcstr::ArcStr::from("c"))]),
+        ];
+        let batch = ColumnarBatch::from_rows(&rows).unwrap();
+        assert_null_masks_match_scalar(&batch, 0);
+    }
+
+    #[test]
+    fn test_is_null_mixed_column() {
+        // Heterogeneous values force a Mixed column (no null bitmap). The mask
+        // must still be correct via the per-row get_value path.
+        let rows = vec![
+            Row::new(vec![SqlValue::Integer(1)]),
+            Row::new(vec![SqlValue::Varchar(arcstr::ArcStr::from("two"))]),
+            Row::new(vec![SqlValue::Null]),
+        ];
+        let batch = ColumnarBatch::from_rows(&rows).unwrap();
+        assert!(batch.column(0).unwrap().is_mixed());
+        let is_null =
+            simd_create_filter_mask(&batch, &[ColumnPredicate::IsNull { column_idx: 0 }]).unwrap();
+        assert_eq!(is_null, vec![false, false, true]);
+        assert_null_masks_match_scalar(&batch, 0);
+    }
+
+    #[test]
+    fn test_is_null_compound_and_with_value_compare() {
+        // col0 IS NOT NULL AND col1 > 10 — the null-test mask must AND with the
+        // value-comparison mask (which already treats null as non-matching).
+        let rows = vec![
+            Row::new(vec![SqlValue::Integer(1), SqlValue::Integer(20)]), // notnull & 20>10 -> T
+            Row::new(vec![SqlValue::Null, SqlValue::Integer(30)]),       // null      -> F
+            Row::new(vec![SqlValue::Integer(3), SqlValue::Integer(5)]),  // notnull & 5>10  -> F
+            Row::new(vec![SqlValue::Integer(4), SqlValue::Null]),        // col1 null -> F
+        ];
+        let batch = ColumnarBatch::from_rows(&rows).unwrap();
+        let predicates = vec![
+            ColumnPredicate::IsNotNull { column_idx: 0 },
+            ColumnPredicate::GreaterThan { column_idx: 1, value: SqlValue::Integer(10) },
+        ];
+        let mask = simd_create_filter_mask(&batch, &predicates).unwrap();
+        assert_eq!(mask, vec![true, false, false, false]);
+    }
+
+    #[test]
+    fn test_is_null_full_filter_roundtrip() {
+        // simd_filter_batch (packed auto path) must materialize exactly the
+        // NULL rows for IS NULL and the non-NULL rows for IS NOT NULL.
+        let rows = vec![
+            Row::new(vec![SqlValue::Integer(1)]),
+            Row::new(vec![SqlValue::Null]),
+            Row::new(vec![SqlValue::Integer(3)]),
+            Row::new(vec![SqlValue::Null]),
+        ];
+        let batch = ColumnarBatch::from_rows(&rows).unwrap();
+
+        let only_null =
+            simd_filter_batch(&batch, &[ColumnPredicate::IsNull { column_idx: 0 }]).unwrap();
+        assert_eq!(only_null.row_count(), 2);
+        assert_eq!(only_null.get_value(0, 0).unwrap(), SqlValue::Null);
+        assert_eq!(only_null.get_value(1, 0).unwrap(), SqlValue::Null);
+
+        let only_non_null =
+            simd_filter_batch(&batch, &[ColumnPredicate::IsNotNull { column_idx: 0 }]).unwrap();
+        assert_eq!(only_non_null.row_count(), 2);
+        assert_eq!(only_non_null.get_value(0, 0).unwrap(), SqlValue::Integer(1));
+        assert_eq!(only_non_null.get_value(1, 0).unwrap(), SqlValue::Integer(3));
     }
 }

--- a/crates/vibesql-executor/src/select/columnar/simd_filter/string.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_filter/string.rs
@@ -305,9 +305,11 @@ pub fn evaluate_predicate_string_batch(
             result
         }
 
-        // ColumnCompare is not supported for string columns in this path
-        // It's handled at a higher level in simd_filter/mod.rs
-        ColumnPredicate::ColumnCompare { .. } => {
+        // ColumnCompare and null tests are handled at a higher level in
+        // simd_filter/mod.rs; reaching a value kernel with one is a bug.
+        ColumnPredicate::ColumnCompare { .. }
+        | ColumnPredicate::IsNull { .. }
+        | ColumnPredicate::IsNotNull { .. } => {
             return Err(ExecutorError::ColumnarTypeMismatch {
                 operation: "column-to-column comparison".to_string(),
                 left_type: "String".to_string(),

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
@@ -9,12 +9,11 @@ use std::sync::OnceLock;
 use vibesql_ast::{FromClause, JoinType, SelectItem};
 
 use super::join_helpers::{
-    build_combined_schema, expression_has_is_null, extract_equijoin_conditions,
-    extract_join_conditions, extract_non_join_predicates, flatten_join_tree_simple,
-    flatten_join_tree_with_types, has_cross_join_with_on_condition, has_outer_join,
-    is_column_in_table, is_column_in_tables, is_columnar_supported_join,
-    join_tree_has_residual_on_conjuncts, resolve_join_column_indices, where_clause_fully_covered,
-    EquiJoinCondition,
+    build_combined_schema, extract_equijoin_conditions, extract_join_conditions,
+    extract_non_join_predicates, flatten_join_tree_simple, flatten_join_tree_with_types,
+    has_cross_join_with_on_condition, is_column_in_table, is_column_in_tables,
+    is_columnar_supported_join, join_tree_has_residual_on_conjuncts, resolve_join_column_indices,
+    where_clause_fully_covered, EquiJoinCondition,
 };
 use crate::{
     errors::ExecutorError,
@@ -137,21 +136,14 @@ impl SelectExecutor<'_> {
             return Ok(None);
         }
 
-        // Outer joins with IS NULL / IS NOT NULL in WHERE clause need row-oriented execution.
-        // The columnar SIMD filter does not support null-testing predicates (IS NULL / IS NOT NULL),
-        // so they are silently dropped during predicate extraction. For outer joins this causes
-        // incorrect results — e.g., anti-join pattern `LEFT JOIN ... WHERE t2.col IS NULL` would
-        // return all rows instead of only unmatched rows.
-        if has_outer_join(from_clause) {
-            if let Some(ref where_clause) = stmt.where_clause {
-                if expression_has_is_null(where_clause) {
-                    log::debug!(
-                        "Columnar join: outer join with IS NULL/IS NOT NULL in WHERE, falling back"
-                    );
-                    return Ok(None);
-                }
-            }
-        }
+        // Null-testing WHERE predicates (IS NULL / IS NOT NULL) on outer joins —
+        // e.g. the anti-join pattern `LEFT JOIN ... WHERE r.col IS NULL` — are
+        // now vectorized by the columnar filter (issue #5993). They round-trip
+        // through `extract_column_predicates` into `ColumnPredicate::IsNull` /
+        // `IsNotNull`, which read the joined batch's null bitmap (NULL-padded
+        // unmatched rows included), so no guardrail fallback is needed here.
+        // `where_clause_fully_covered` below still forces the row path for any
+        // WHERE shape the columnar pipeline cannot fully consume.
 
         // Flatten the join tree to get all tables with their join types
         let mut table_refs_with_types = Vec::new();

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
@@ -33,42 +33,6 @@ pub(super) fn is_columnar_supported_join(from: &FromClause) -> bool {
     }
 }
 
-/// Check if a FROM clause contains any outer join (LEFT, RIGHT, or FULL OUTER)
-///
-/// Used to detect when WHERE clause predicates like IS NULL / IS NOT NULL
-/// need special handling, since the columnar SIMD filter doesn't support
-/// null-testing predicates and would silently drop them.
-pub(super) fn has_outer_join(from: &FromClause) -> bool {
-    match from {
-        FromClause::Table { .. }
-        | FromClause::Subquery { .. }
-        | FromClause::Values { .. }
-        | FromClause::TableFunction { .. } => false,
-        FromClause::Join { left, right, join_type, .. } => {
-            matches!(join_type, JoinType::LeftOuter | JoinType::RightOuter | JoinType::FullOuter)
-                || has_outer_join(left)
-                || has_outer_join(right)
-        }
-    }
-}
-
-/// Check if an expression contains IS NULL or IS NOT NULL predicates
-///
-/// The columnar SIMD filter path does not support IS NULL / IS NOT NULL predicates,
-/// so they are silently dropped. For outer joins this produces incorrect results
-/// because post-join null-testing (e.g., anti-join pattern `LEFT JOIN ... WHERE right.col IS NULL`)
-/// is essential for correctness.
-pub(super) fn expression_has_is_null(expr: &Expression) -> bool {
-    match expr {
-        Expression::IsNull { .. } => true,
-        Expression::BinaryOp { left, right, .. } => {
-            expression_has_is_null(left) || expression_has_is_null(right)
-        }
-        Expression::UnaryOp { expr, .. } => expression_has_is_null(expr),
-        _ => false,
-    }
-}
-
 /// Check if a FROM clause contains a CROSS JOIN with a join condition
 ///
 /// CROSS JOIN with ON condition is semantically invalid SQL.
@@ -114,9 +78,7 @@ pub(super) fn flatten_join_tree_simple(from: &FromClause, tables: &mut Vec<Simpl
         FromClause::TableFunction { .. } => {
             // Guarded by is_columnar_supported_join (returns false for TVFs), so
             // the columnar flatten path is never reached with a table function.
-            unreachable!(
-                "table functions are not executable via the columnar path (JSON1 Phase 3)"
-            )
+            unreachable!("table functions are not executable via the columnar path (JSON1 Phase 3)")
         }
         FromClause::Join { left, right, .. } => {
             flatten_join_tree_simple(left, tables);
@@ -149,9 +111,7 @@ pub(super) fn flatten_join_tree_with_types(
             tables.push(((alias.clone(), Some(alias.clone()), true), None));
         }
         FromClause::TableFunction { .. } => {
-            unreachable!(
-                "table functions are not executable via the columnar path (JSON1 Phase 3)"
-            )
+            unreachable!("table functions are not executable via the columnar path (JSON1 Phase 3)")
         }
         FromClause::Join { left, right, join_type, .. } => {
             flatten_join_tree_with_types(left, tables);

--- a/crates/vibesql-executor/tests/columnar_is_null_path_assertion_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_is_null_path_assertion_tests.rs
@@ -1,0 +1,126 @@
+//! Path-assertion test for issue #5993: confirm `WHERE col IS NULL` and the
+//! anti-join `LEFT JOIN ... WHERE r.col IS NULL` take the columnar filter/join
+//! path rather than falling back to row-oriented execution.
+//!
+//! Per the acceptance criteria, wall-clock timing is NOT used (the machine is
+//! loaded). Instead we capture the `log` output and assert on the debug/info
+//! lines emitted by the columnar pipeline: the columnar join emits
+//! `"Columnar join: N rows after join and filter"` only on its own path, and
+//! the retired guardrail's `"... IS NULL/IS NOT NULL in WHERE, falling back"`
+//! line must never appear.
+//!
+//! This test installs a process-global `log` logger, so it lives in its own
+//! test binary to avoid clashing with other integration tests.
+
+use std::sync::{Mutex, OnceLock};
+
+use log::{Level, LevelFilter, Log, Metadata, Record};
+use vibesql_executor::{CreateTableExecutor, InsertExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+/// Captures every log message into a shared buffer.
+struct CaptureLogger;
+
+static LOG_BUFFER: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+fn buffer() -> &'static Mutex<Vec<String>> {
+    LOG_BUFFER.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+impl Log for CaptureLogger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
+    fn log(&self, record: &Record) {
+        if record.level() <= Level::Info {
+            buffer().lock().unwrap().push(format!("{}", record.args()));
+        }
+    }
+    fn flush(&self) {}
+}
+
+static LOGGER: CaptureLogger = CaptureLogger;
+
+fn init_logger() {
+    // set_logger is idempotent across the binary; ignore "already set".
+    let _ = log::set_logger(&LOGGER);
+    log::set_max_level(LevelFilter::Debug);
+}
+
+fn take_logs() -> Vec<String> {
+    std::mem::take(&mut *buffer().lock().unwrap())
+}
+
+fn execute_sql(db: &mut Database, sql: &str) {
+    for sql_stmt in sql.split(';') {
+        let trimmed = sql_stmt.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
+        match stmt {
+            vibesql_ast::Statement::CreateTable(s) => {
+                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+            }
+            vibesql_ast::Statement::Insert(s) => {
+                InsertExecutor::execute(db, &s).expect("INSERT failed");
+            }
+            other => panic!("Unsupported statement type: {:?}", other),
+        }
+    }
+}
+
+fn run_select(db: &Database, sql: &str) -> Vec<vibesql_storage::Row> {
+    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        vibesql_executor::SelectExecutor::new(db).execute(&select_stmt).expect("SELECT failed")
+    } else {
+        panic!("Expected SELECT");
+    }
+}
+
+/// The retired guardrail's fallback marker (must never appear post-#5993).
+const GUARDRAIL_FALLBACK: &str = "IS NULL/IS NOT NULL in WHERE, falling back";
+
+#[test]
+fn anti_join_is_null_takes_columnar_path() {
+    init_logger();
+
+    // Left ids 1..=600; right matches even ids only. Large enough to exercise
+    // the columnar join + SIMD filter path.
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE l (id INTEGER PRIMARY KEY)");
+    execute_sql(&mut db, "CREATE TABLE r (id INTEGER PRIMARY KEY, tag INTEGER)");
+    let mut l = String::new();
+    let mut r = String::new();
+    for id in 1..=600i64 {
+        l.push_str(&format!("INSERT INTO l VALUES ({id});"));
+        if id % 2 == 0 {
+            r.push_str(&format!("INSERT INTO r VALUES ({id}, {});", id * 10));
+        }
+    }
+    execute_sql(&mut db, &l);
+    execute_sql(&mut db, &r);
+
+    let _ = take_logs(); // discard setup logs
+
+    let rows = run_select(&db, "SELECT l.id FROM l LEFT JOIN r ON l.id = r.id WHERE r.id IS NULL");
+    assert_eq!(rows.len(), 300, "anti-join must return the 300 unmatched left rows");
+
+    let logs = take_logs();
+    let joined = logs.join("\n");
+
+    // The retired guardrail must not fire.
+    assert!(
+        !joined.contains(GUARDRAIL_FALLBACK),
+        "guardrail fallback line was emitted for the anti-join; columnar path was skipped:\n{joined}"
+    );
+
+    // The columnar join path emits this info line only when it actually runs
+    // the join + filter (join.rs). Its presence proves the columnar path.
+    assert!(
+        logs.iter().any(|l| l.contains("rows after join and filter")),
+        "expected the columnar join path to run (missing 'rows after join and filter' log):\n{joined}"
+    );
+}

--- a/crates/vibesql-executor/tests/columnar_is_null_predicate_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_is_null_predicate_tests.rs
@@ -1,0 +1,263 @@
+//! Integration tests for vectorized `IS NULL` / `IS NOT NULL` predicates on the
+//! columnar full-scan filter path (issue #5993).
+//!
+//! Before this change the columnar SIMD filter had no representation for null
+//! tests, so every `WHERE col IS [NOT] NULL` was forced back to row-at-a-time
+//! execution. The `ColumnPredicate::IsNull`/`IsNotNull` variants evaluate the
+//! test directly from the column's null bitmap.
+//!
+//! Correctness is cross-checked two ways:
+//!  1. Every `WHERE <pred>` result is compared against a per-row projection of
+//!     the same predicate (`SELECT id, <pred>`), which runs the expression
+//!     evaluator — the canonical, row-path semantics.
+//!  2. Literal expectations are pinned and were verified against sqlite3.
+//!
+//! The matrix runs at two table sizes — 2 rows (scalar columnar path, below the
+//! SIMD threshold of 500) and 600 rows (SIMD / cached-columnar path) — so the
+//! two paths must agree across the threshold.
+
+use vibesql_executor::{CreateTableExecutor, InsertExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Execute one or more non-SELECT SQL statements separated by ';'.
+fn execute_sql(db: &mut Database, sql: &str) {
+    for sql_stmt in sql.split(';') {
+        let trimmed = sql_stmt.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
+        match stmt {
+            vibesql_ast::Statement::CreateTable(s) => {
+                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+            }
+            vibesql_ast::Statement::Insert(s) => {
+                InsertExecutor::execute(db, &s).expect("INSERT failed");
+            }
+            other => panic!("Unsupported statement type: {:?}", other),
+        }
+    }
+}
+
+fn select_rows(db: &Database, sql: &str) -> Result<Vec<vibesql_storage::Row>, String> {
+    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = vibesql_executor::SelectExecutor::new(db);
+        executor.execute(&select_stmt).map_err(|e| e.to_string())
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+fn select_ints(db: &Database, sql: &str) -> Result<Vec<i64>, String> {
+    let rows = select_rows(db, sql)?;
+    let mut out: Vec<i64> = rows
+        .iter()
+        .map(|row| match &row.values[0] {
+            SqlValue::Integer(i) => *i,
+            other => panic!("expected integer, got {:?}", other),
+        })
+        .collect();
+    out.sort_unstable();
+    Ok(out)
+}
+
+fn is_sql_true(v: &SqlValue) -> bool {
+    match v {
+        SqlValue::Boolean(b) => *b,
+        SqlValue::Integer(i) => *i != 0,
+        SqlValue::Null => false,
+        other => panic!("expected boolean-ish predicate value, got {:?}", other),
+    }
+}
+
+/// Assert `WHERE <pred>` returns exactly the rows for which the per-row
+/// projection `SELECT id, <pred>` (expression evaluator) is true.
+fn assert_where_matches_projection(db: &Database, table: &str, pred: &str) -> Vec<i64> {
+    let where_sql = format!("SELECT id FROM {table} WHERE {pred}");
+    let where_ids = select_ints(db, &where_sql)
+        .unwrap_or_else(|e| panic!("WHERE query failed: {e}\n  sql: {where_sql}"));
+
+    let proj_sql = format!("SELECT id, {pred} FROM {table}");
+    let proj_rows = select_rows(db, &proj_sql)
+        .unwrap_or_else(|e| panic!("projection query failed: {e}\n  sql: {proj_sql}"));
+    let mut proj_ids: Vec<i64> = proj_rows
+        .iter()
+        .filter(|row| is_sql_true(&row.values[1]))
+        .map(|row| match &row.values[0] {
+            SqlValue::Integer(i) => *i,
+            other => panic!("expected integer id, got {:?}", other),
+        })
+        .collect();
+    proj_ids.sort_unstable();
+
+    assert_eq!(
+        where_ids, proj_ids,
+        "WHERE filtering diverged from per-row projection for predicate: {pred}\n  WHERE:      {where_ids:?}\n  projection: {proj_ids:?}"
+    );
+    where_ids
+}
+
+/// Table `t(id, v)` with `rows` rows. Even ids get a NULL `v`; odd ids get
+/// `v = id`. id 1 is always non-null so the column infers a typed (Int64)
+/// array with a null bitmap rather than the Mixed fallback.
+fn null_db(rows: usize) -> Database {
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)");
+    let mut inserts = String::new();
+    for id in 1..=rows as i64 {
+        if id % 2 == 0 {
+            inserts.push_str(&format!("INSERT INTO t VALUES ({id}, NULL);"));
+        } else {
+            inserts.push_str(&format!("INSERT INTO t VALUES ({id}, {id});"));
+        }
+    }
+    execute_sql(&mut db, &inserts);
+    db
+}
+
+fn expected_is_null(rows: usize) -> Vec<i64> {
+    (1..=rows as i64).filter(|id| id % 2 == 0).collect()
+}
+
+fn expected_is_not_null(rows: usize) -> Vec<i64> {
+    (1..=rows as i64).filter(|id| id % 2 == 1).collect()
+}
+
+fn run_matrix(rows: usize) {
+    let db = null_db(rows);
+
+    // Bare IS NULL / IS NOT NULL against row-path projection + pinned literals.
+    let is_null = assert_where_matches_projection(&db, "t", "v IS NULL");
+    assert_eq!(is_null, expected_is_null(rows), "IS NULL literal mismatch (rows={rows})");
+
+    let is_not_null = assert_where_matches_projection(&db, "t", "v IS NOT NULL");
+    assert_eq!(
+        is_not_null,
+        expected_is_not_null(rows),
+        "IS NOT NULL literal mismatch (rows={rows})"
+    );
+
+    // count(*) form from the acceptance criteria.
+    let cnt_null = select_ints(&db, "SELECT count(*) FROM t WHERE v IS NULL").unwrap();
+    assert_eq!(cnt_null, vec![expected_is_null(rows).len() as i64]);
+    let cnt_not_null = select_ints(&db, "SELECT count(*) FROM t WHERE v IS NOT NULL").unwrap();
+    assert_eq!(cnt_not_null, vec![expected_is_not_null(rows).len() as i64]);
+
+    // Compound predicates mixing a null test with a value comparison. The
+    // null-test mask must AND / OR correctly with the value mask (which treats
+    // NULL as non-matching). All cross-checked against the row path.
+    assert_where_matches_projection(&db, "t", "v IS NOT NULL AND id > 3");
+    assert_where_matches_projection(&db, "t", "v IS NULL AND id < 5");
+    assert_where_matches_projection(&db, "t", "v IS NULL OR id = 3");
+    assert_where_matches_projection(&db, "t", "v IS NOT NULL OR id = 2");
+
+    // NOT (v IS NULL) is equivalent to v IS NOT NULL (IS NULL never yields
+    // UNKNOWN, so three-valued NOT collapses cleanly).
+    assert_where_matches_projection(&db, "t", "NOT (v IS NULL)");
+}
+
+#[test]
+fn is_null_scalar_path_2_rows() {
+    // 2 rows: below the SIMD threshold, exercises the scalar columnar path.
+    run_matrix(2);
+}
+
+#[test]
+fn is_null_simd_path_600_rows() {
+    // 600 rows: above the SIMD threshold, exercises the SIMD / cached path.
+    run_matrix(600);
+}
+
+#[test]
+fn is_null_string_column() {
+    // A NULLable TEXT column: IS NULL must consult the string column's null
+    // bitmap, not attempt a value comparison.
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE ts (id INTEGER PRIMARY KEY, s TEXT)");
+    execute_sql(
+        &mut db,
+        "INSERT INTO ts VALUES (1, 'a');
+         INSERT INTO ts VALUES (2, NULL);
+         INSERT INTO ts VALUES (3, 'c');
+         INSERT INTO ts VALUES (4, NULL)",
+    );
+    let is_null = assert_where_matches_projection(&db, "ts", "s IS NULL");
+    assert_eq!(is_null, vec![2, 4]);
+    let is_not_null = assert_where_matches_projection(&db, "ts", "s IS NOT NULL");
+    assert_eq!(is_not_null, vec![1, 3]);
+}
+
+/// Anti-join fixture: `l(id)` has ids 1..=n; `r(id, tag)` has a matching row
+/// only for even ids. `l LEFT JOIN r ON l.id = r.id WHERE r.id IS NULL` is the
+/// classic anti-join — it must return exactly the odd (unmatched) left ids.
+fn anti_join_db(n: usize) -> Database {
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE l (id INTEGER PRIMARY KEY)");
+    execute_sql(&mut db, "CREATE TABLE r (id INTEGER PRIMARY KEY, tag INTEGER)");
+    let mut l_inserts = String::new();
+    let mut r_inserts = String::new();
+    for id in 1..=n as i64 {
+        l_inserts.push_str(&format!("INSERT INTO l VALUES ({id});"));
+        if id % 2 == 0 {
+            r_inserts.push_str(&format!("INSERT INTO r VALUES ({id}, {});", id * 10));
+        }
+    }
+    execute_sql(&mut db, &l_inserts);
+    execute_sql(&mut db, &r_inserts);
+    db
+}
+
+fn assert_anti_join(n: usize) {
+    let db = anti_join_db(n);
+    let unmatched: Vec<i64> = (1..=n as i64).filter(|id| id % 2 == 1).collect();
+
+    // Anti-join: unmatched (odd) left ids only.
+    let got = select_ints(&db, "SELECT l.id FROM l LEFT JOIN r ON l.id = r.id WHERE r.id IS NULL")
+        .unwrap();
+    assert_eq!(got, unmatched, "anti-join (r.id IS NULL) mismatch (n={n})");
+
+    // Complementary semi-join: matched (even) left ids only.
+    let matched: Vec<i64> = (1..=n as i64).filter(|id| id % 2 == 0).collect();
+    let got =
+        select_ints(&db, "SELECT l.id FROM l LEFT JOIN r ON l.id = r.id WHERE r.id IS NOT NULL")
+            .unwrap();
+    assert_eq!(got, matched, "semi-join (r.id IS NOT NULL) mismatch (n={n})");
+
+    // IS NULL on a non-key right column of the padded row is equally NULL.
+    let got = select_ints(&db, "SELECT l.id FROM l LEFT JOIN r ON l.id = r.id WHERE r.tag IS NULL")
+        .unwrap();
+    assert_eq!(got, unmatched, "anti-join on r.tag IS NULL mismatch (n={n})");
+}
+
+#[test]
+fn anti_join_is_null_scalar_path() {
+    // Small tables: scalar columnar path.
+    assert_anti_join(6);
+}
+
+#[test]
+fn anti_join_is_null_simd_path() {
+    // Large left side crosses the SIMD threshold on the joined batch.
+    assert_anti_join(600);
+}
+
+#[test]
+fn is_null_no_nulls_present() {
+    // Column with no NULLs at all (absent null bitmap): IS NULL is empty, IS NOT
+    // NULL returns every row.
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE tn (id INTEGER PRIMARY KEY, v INTEGER)");
+    let mut inserts = String::new();
+    for id in 1..=600i64 {
+        inserts.push_str(&format!("INSERT INTO tn VALUES ({id}, {id});"));
+    }
+    execute_sql(&mut db, &inserts);
+
+    let is_null = select_ints(&db, "SELECT id FROM tn WHERE v IS NULL").unwrap();
+    assert!(is_null.is_empty());
+    let is_not_null = select_ints(&db, "SELECT id FROM tn WHERE v IS NOT NULL").unwrap();
+    assert_eq!(is_not_null.len(), 600);
+}


### PR DESCRIPTION
## Summary

The columnar SIMD filter had no representation for `IS NULL` / `IS NOT NULL`, so every WHERE clause containing a null test was forced back to row-at-a-time execution — and for outer joins a guardrail deliberately bailed to the row path (an anti-join like `LEFT JOIN ... WHERE r.col IS NULL` could otherwise silently over-return). This PR adds `ColumnPredicate::IsNull` / `IsNotNull` and evaluates them directly from each column's already-materialized null bitmap, then retires the guardrail. All three staged steps (S1/S2/S3) landed.

## Changes

- **S1 — predicate + mask evaluation:** New `ColumnPredicate::IsNull` / `IsNotNull` variants with `referenced_columns` / `remap_predicate` plumbing and an always-supported classification (null tests are collation/affinity-agnostic). Added `ColumnArray::null_bitmap()` / `is_mixed()`. A shared `evaluate_null_predicate_range` derives the mask entirely from the null bitmap: it is exactly the bitmap (IS NULL) or its complement (IS NOT NULL); an **absent** bitmap yields all-false / all-true without touching values; `Mixed` columns fall back to per-row `get_value`. The null test is intercepted at every SIMD/scalar/packed/parallel dispatch site *before* the value kernels, which now reject null tests defensively (same pattern as `ColumnCompare`). The scalar/row and legacy AND-only paths handle it too.
- **S2 — AST wiring:** `Expression::IsNull { expr, negated }` arm added to both the tree extractor and the legacy AND-only extractor; a bare `ColumnRef` operand maps to the predicate and `negated` selects IsNull vs IsNotNull (three-valued logic). Non-column operands still decline.
- **S3 — retire the guardrail:** Removed `expression_has_is_null` (and the now-dead `has_outer_join`) plus the outer-join bail in `join.rs`. Null tests now round-trip through `extract_column_predicates` → `where_clause_fully_covered` / `extract_non_join_predicates` → `simd_filter_batch` on the NULL-padded joined batch, so the anti-join takes the columnar join+filter path.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Vectorized IsNull/IsNotNull masks match a scalar reference over dense, sparse, and absent null bitmaps | ✅ | `simd_filter` unit tests `test_is_null_{sparse,absent,all_null}_bitmap`, `_string_column`, `_mixed_column` compare non-packed + packed masks against a `get_value` scalar reference |
| `count(*) ... WHERE c IS [NOT] NULL` matches the row path on mixed nulls | ✅ | Integration `run_matrix` cross-checks WHERE vs per-row projection (expression evaluator) and pins sqlite-verified counts at 2 and 600 rows |
| Path assertion: `WHERE col IS NULL` / anti-join no longer fall back to row execution | ✅ | `columnar_is_null_path_assertion_tests`: log capture asserts the columnar `"rows after join and filter"` line IS emitted and the retired guardrail fallback line is NOT, with a correct 300-row result. No wall-clock timing used. |
| Compound AND/OR mixing null tests and value comparisons correct | ✅ | Unit `test_is_null_compound_and_with_value_compare` + integration AND/OR/`NOT (v IS NULL)` cases |
| `NOT (col IS NULL)` vs `col IS NOT NULL` distinguished via `negated` | ✅ | Extractor unit test `test_extract_is_null_tree`; integration `NOT (v IS NULL)` parity |
| No regression in columnar filter tests or TCL suite | ✅ | Full `vibesql-executor` suite (60 binaries) green; `null.test` 39/39, `where.test` / `where2.test` 0 failures |

## Test Plan

- `cargo build --release` — clean; `cargo clippy -p vibesql-executor` — no errors/related warnings.
- `cargo test -p vibesql-executor` — all lib + integration tests pass (3301 lib tests; 60 test binaries exit 0).
- New tests: `columnar_is_null_predicate_tests` (6), `columnar_is_null_path_assertion_tests` (1), plus unit tests in `predicates.rs` and `simd_filter/mod.rs`.
- TCL smoke: `null.test` 39/39 pass; `where.test` (168 pass / 0 fail), `where2.test` (30 pass / 0 fail).
- Disjoint from in-flight JSON1 work — no `json_each`/`json_tree` or parser changes.

Closes #5993