### PR TITLE
test(columnar): cover ComputedCompare <> with NULL-derived div-by-zero value

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/filter/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/filter/mod.rs
@@ -704,6 +704,61 @@ mod tests {
         }
     }
 
+    /// A NULL derived value (from `a / 0`) must be excluded under `<>`
+    /// (NotEqual), not treated as "not equal to the constant" (issue #6000).
+    /// `evaluate_computed_compare_value` short-circuits a NULL derived value to
+    /// non-matching *before* the operator is considered, so `a / b <> 5` must
+    /// drop the div-by-zero rows just like `>=` does. Exercised on both sides of
+    /// the 256-row SIMD threshold.
+    #[test]
+    fn test_computed_compare_not_equal_division_by_zero_non_matching() {
+        // col0 / col1: col1 is 0 for every 5th row (=> NULL derived value),
+        // and 2 otherwise (=> 10 / 2 = 5).
+        let make_rows = |n: usize| -> Vec<Row> {
+            (0..n)
+                .map(|i| {
+                    let denom = if i % 5 == 0 { 0 } else { 2 };
+                    Row::new(vec![SqlValue::Integer(10), SqlValue::Integer(denom)])
+                })
+                .collect()
+        };
+        let div_pred = |op: CompareOp, value: SqlValue| ColumnPredicate::ComputedCompare {
+            expr: DerivedExpr::BinaryOp {
+                left: Box::new(DerivedExpr::Column(0)),
+                op: vibesql_ast::BinaryOperator::Divide,
+                right: Box::new(DerivedExpr::Column(1)),
+            },
+            op,
+            value,
+            columns: vec![0, 1],
+        };
+
+        for n in [40usize, 500usize] {
+            let rows = make_rows(n);
+            // 10 / 2 = 5, which is NOT `<> 5` (equal => excluded); 10 / 0 = NULL,
+            // which is non-matching under every operator (excluded). So no row
+            // satisfies `a / b <> 5` — crucially, the NULL div-by-zero rows are
+            // NOT swept in by `<>`.
+            let predicates = vec![div_pred(CompareOp::NotEqual, SqlValue::Integer(5))];
+            let got = apply_columnar_filter(&rows, &predicates).unwrap();
+            assert!(
+                got.is_empty(),
+                "NotEqual div-by-zero: NULL rows must be excluded, got {got:?} at n={n}"
+            );
+
+            // Sanity check that `<>` does discriminate: against a different
+            // constant, only the well-defined `5` rows match; the NULL
+            // (div-by-zero) rows stay excluded.
+            let predicates = vec![div_pred(CompareOp::NotEqual, SqlValue::Integer(999))];
+            let got = apply_columnar_filter(&rows, &predicates).unwrap();
+            let want: Vec<usize> = (0..n).filter(|i| i % 5 != 0).collect();
+            assert_eq!(
+                got, want,
+                "NotEqual should match well-defined rows only, excluding NULL div-by-zero rows at n={n}"
+            );
+        }
+    }
+
     #[test]
     fn test_filter_bitmap() {
         use vibesql_storage::Row;


### PR DESCRIPTION
## Summary

Adds a unit test closing a coverage gap identified during PR #5999 review: no explicit test exercised the columnar SIMD filter's `<>` (NotEqual) operator against a NULL-derived value produced by division by zero (`a / b <> 5` where some `b = 0`).

The correctness is guaranteed by construction — `evaluate_computed_compare_value` (crates/vibesql-executor/src/select/columnar/filter/evaluation.rs:389-399) short-circuits a NULL derived value to non-matching *before* the operator is considered — so this is a **test-coverage addition, not a defect fix**. No production code changes.

## Changes

- Add `test_computed_compare_not_equal_division_by_zero_non_matching` in `crates/vibesql-executor/src/select/columnar/filter/mod.rs`, mirroring the existing `test_computed_compare_division_by_zero_non_matching` (which only covered `>=`).
- Builds `ComputedCompare { op: CompareOp::NotEqual, .. }` over `a / b` with every 5th row having `b = 0`.
- Runs at n=40 and n=500 to cover both sides of `SIMD_THRESHOLD = 256`.
- Asserts `a / b <> 5` returns no rows (the `= 5` rows are excluded as equal, the div-by-zero NULL rows are excluded as non-matching — crucially NOT swept in by `<>`).
- Adds a discriminating check against a different constant (`<> 999`) confirming `<>` still matches the well-defined rows while continuing to exclude the NULL div-by-zero rows.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Test builds `ComputedCompare { op: CompareOp::NotEqual, .. }` over `a / b` with some `b = 0` | ✅ | See added test in filter/mod.rs |
| Covers both sides of the 256-row SIMD threshold | ✅ | `for n in [40usize, 500usize]` |
| Asserts NULL-derived (div-by-zero) rows are excluded under `<>` | ✅ | `assert!(got.is_empty(), ...)` plus discriminating `<> 999` check |
| No production code changes | ✅ | Diff is 1 file, +55 lines, test module only |

## Test Plan

- `cargo test -p vibesql-executor --lib filter::tests::test_computed_compare` — 5 passed, 0 failed (includes the new test).
- `cargo test -p vibesql-executor --lib` — 3339 passed, 0 failed, 2 ignored (was 3338; +1 new test).

Closes #6000