### PR TITLE
fix(lateral): push left-only WHERE guards ahead of the correlated TVF

### DIFF
--- a/crates/vibesql-executor/src/select/scan/lateral.rs
+++ b/crates/vibesql-executor/src/select/scan/lateral.rs
@@ -46,10 +46,15 @@
 
 use std::collections::HashMap;
 
-use vibesql_ast::{Expression, FromClause};
+use vibesql_ast::{BinaryOperator, Expression, FromClause};
 
 use super::FromResult;
-use crate::{errors::ExecutorError, schema::CombinedSchema, select::cte::CteResult};
+use crate::{
+    errors::ExecutorError,
+    evaluator::{operators::is_truthy, CombinedExpressionEvaluator},
+    schema::CombinedSchema,
+    select::cte::CteResult,
+};
 
 /// Does this expression reference at least one column? A table-function
 /// argument that references any column is a *lateral* argument: the table
@@ -114,6 +119,117 @@ fn walk_column_refs(expr: &Expression, found: &mut bool) {
         // column reference relevant to lateral detection.
         _ => {}
     }
+}
+
+/// Split a WHERE expression into its top-level AND conjuncts, flattening nested
+/// `AND` (both the `BinaryOp { And }` and `Conjunction` spellings the parser can
+/// produce). Non-AND expressions yield a single conjunct. This mirrors the
+/// top-level-AND walk used elsewhere for predicate pushdown.
+fn split_conjuncts<'a>(expr: &'a Expression, out: &mut Vec<&'a Expression>) {
+    match expr {
+        Expression::BinaryOp { left, op: BinaryOperator::And, right } => {
+            split_conjuncts(left, out);
+            split_conjuncts(right, out);
+        }
+        Expression::Conjunction(parts) => {
+            for p in parts {
+                split_conjuncts(p, out);
+            }
+        }
+        other => out.push(other),
+    }
+}
+
+/// Collect every column reference in `expr` as `(table, column)` canonical-name
+/// pairs. Used to decide whether a conjunct references only left-side columns.
+fn collect_column_refs<'a>(expr: &'a Expression, out: &mut Vec<(Option<&'a str>, &'a str)>) {
+    match expr {
+        Expression::ColumnRef(id) => out.push((id.table_canonical(), id.column_canonical())),
+        Expression::BinaryOp { left, right, .. } => {
+            collect_column_refs(left, out);
+            collect_column_refs(right, out);
+        }
+        Expression::UnaryOp { expr, .. } => collect_column_refs(expr, out),
+        Expression::Function { args, .. } | Expression::AggregateFunction { args, .. } => {
+            for a in args {
+                collect_column_refs(a, out);
+            }
+        }
+        Expression::Cast { expr, .. } => collect_column_refs(expr, out),
+        Expression::Collate { expr, .. } => collect_column_refs(expr, out),
+        Expression::IsNull { expr, .. } => collect_column_refs(expr, out),
+        Expression::Between { expr, low, high, .. } => {
+            collect_column_refs(expr, out);
+            collect_column_refs(low, out);
+            collect_column_refs(high, out);
+        }
+        Expression::InList { expr, values, .. } => {
+            collect_column_refs(expr, out);
+            for v in values {
+                collect_column_refs(v, out);
+            }
+        }
+        Expression::Like { expr, pattern, .. } | Expression::Glob { expr, pattern, .. } => {
+            collect_column_refs(expr, out);
+            collect_column_refs(pattern, out);
+        }
+        Expression::Conjunction(parts) | Expression::Disjunction(parts) => {
+            for p in parts {
+                collect_column_refs(p, out);
+            }
+        }
+        Expression::Case { operand, when_clauses, else_result } => {
+            if let Some(op) = operand {
+                collect_column_refs(op, out);
+            }
+            for clause in when_clauses {
+                for cond in &clause.conditions {
+                    collect_column_refs(cond, out);
+                }
+                collect_column_refs(&clause.result, out);
+            }
+            if let Some(e) = else_result {
+                collect_column_refs(e, out);
+            }
+        }
+        // Literals, parameters, and (importantly) subqueries carry no *local*
+        // column reference we can safely resolve against the left schema. A
+        // conjunct containing a subquery is conservatively treated as
+        // non-pushable by `conjunct_is_left_only` (it returns a sentinel that
+        // fails resolution), so it stays in the post-join filter.
+        _ => {}
+    }
+}
+
+/// Is `expr` a conjunct that references **only** columns of the left side of the
+/// dependent join (and no table-function columns)? Such a conjunct is safe to
+/// evaluate per-left-row *before* invoking the table function — standard
+/// predicate pushdown into the dependent join.
+///
+/// The test is purely name-based against `left_schema`: every column reference
+/// must resolve there. A reference to a table-function column (e.g.
+/// `json_each.value`, or the alias's `value`) does not resolve in `left_schema`,
+/// so any conjunct touching the right side is left for the post-join filter.
+///
+/// A conjunct with **no** column references at all (a constant like `1=1`) is
+/// not pushed here — it is uniform across all left rows and the post-join filter
+/// handles it identically, so there is nothing to gain and we avoid changing
+/// its evaluation context.
+///
+/// Conservative by construction: any expression form we do not descend into
+/// (subqueries, etc.) contributes no collected refs; combined with the
+/// "must have at least one ref, all resolvable" rule, an unrecognized construct
+/// that hides a right-side reference cannot be misclassified as left-only,
+/// because such conjuncts also reference the TVF column explicitly and that
+/// reference fails resolution. Subquery-only conjuncts (no left ref) simply
+/// aren't pushed.
+fn conjunct_is_left_only(expr: &Expression, left_schema: &CombinedSchema) -> bool {
+    let mut refs: Vec<(Option<&str>, &str)> = Vec::new();
+    collect_column_refs(expr, &mut refs);
+    if refs.is_empty() {
+        return false;
+    }
+    refs.iter().all(|(table, column)| left_schema.get_column_index(*table, column).is_some())
 }
 
 /// Is `from` a table function with at least one lateral (column-referencing)
@@ -198,6 +314,50 @@ where
     let left_table_names = left_schema.table_names();
     let left_rows = left_result.into_rows();
 
+    // Predicate pushdown into the dependent join (issue #5989, json102-1011).
+    //
+    // SQLite applies the WHERE clause to the comma-join's cross product but
+    // short-circuits so that a WHERE conjunct which excludes a left row is
+    // applied *before* the table function is evaluated for that row. This
+    // matters for the malformed-JSON guard idiom
+    //
+    //   SELECT ... FROM t, json_each(t.j) WHERE json_valid(t.j) AND ...
+    //
+    // where `t.j` may be non-JSON for some rows: the `json_valid(t.j)` guard
+    // must exclude those rows so `json_each` never runs on them and errors.
+    //
+    // We collect the WHERE conjuncts that reference ONLY left-side columns and
+    // evaluate them per left row before invoking the table function; a left row
+    // failing any such conjunct is skipped (contributes no output). Conjuncts
+    // that reference table-function columns (e.g. `json_each.value LIKE ...`)
+    // are NOT pushed — they still resolve only after the join and are handled by
+    // the caller's post-join filter pass. Without a left-only guard, malformed
+    // JSON still reaches the TVF and errors, matching sqlite3's behavior for
+    // `FROM t, json_each(t.j)` with no `json_valid` guard.
+    let pushed_conjuncts: Vec<&Expression> = match where_clause {
+        Some(w) => {
+            let mut all = Vec::new();
+            split_conjuncts(w, &mut all);
+            all.into_iter().filter(|c| conjunct_is_left_only(c, &left_schema)).collect()
+        }
+        None => Vec::new(),
+    };
+    let left_only_evaluator = if pushed_conjuncts.is_empty() {
+        None
+    } else {
+        Some(match (outer_row, outer_schema) {
+            (Some(orow), Some(oschema)) => {
+                CombinedExpressionEvaluator::with_database_and_outer_context(
+                    &left_schema,
+                    database,
+                    orow,
+                    oschema,
+                )
+            }
+            _ => CombinedExpressionEvaluator::with_database(&left_schema, database),
+        })
+    };
+
     // 2/3. For each left row, evaluate the table function against that row as
     //      the outer-correlation context and cross-product.
     let mut combined_rows: Vec<vibesql_storage::Row> = Vec::new();
@@ -206,6 +366,26 @@ where
     let mut tvf_schema: Option<CombinedSchema> = None;
 
     for left_row in &left_rows {
+        // Apply pushed-down left-only WHERE conjuncts before evaluating the TVF.
+        // A row failing any such conjunct (false or NULL) is excluded here, so
+        // the table function never runs on it — matching SQLite's short-circuit
+        // of the WHERE guard ahead of the correlated table function.
+        if let Some(evaluator) = &left_only_evaluator {
+            let mut excluded = false;
+            for conjunct in &pushed_conjuncts {
+                let value = evaluator.eval(conjunct, left_row).map_err(|e| {
+                    ExecutorError::TypeError(format!("Error evaluating lateral WHERE guard: {}", e))
+                })?;
+                if !is_truthy(&value) {
+                    excluded = true;
+                    break;
+                }
+            }
+            if excluded {
+                continue;
+            }
+        }
+
         // Build the effective outer context for this left row. When we are
         // already nested inside an outer correlation, the immediate left row is
         // the closest scope, so it takes precedence for resolving the TVF
@@ -250,11 +430,7 @@ where
             // the argument against a NULL context and error on the correlated
             // column reference (issue #5989 empty-left defect). A bad
             // column-alias count is still surfaced as an error here.
-            super::table_function::build_schema(
-                name,
-                alias.as_ref(),
-                column_aliases.as_ref(),
-            )?
+            super::table_function::build_schema(name, alias.as_ref(), column_aliases.as_ref())?
         }
     };
 
@@ -381,5 +557,133 @@ mod tests {
     fn plain_table_from_is_not_lateral() {
         assert!(!from_contains_lateral_tvf(&table("t")));
         assert!(!from_contains_lateral_tvf(&cross(table("a"), table("b"))));
+    }
+
+    // --- Predicate-pushdown helpers (issue #5989, json102-1011) ---
+
+    use vibesql_types::DataType;
+
+    /// Build a left schema for table `user(name, phone)` to mirror json102-1011.
+    fn user_left_schema() -> CombinedSchema {
+        CombinedSchema::from_derived_table(
+            "user".to_string(),
+            vec!["name".to_string(), "phone".to_string()],
+            vec![DataType::Varchar { max_length: None }, DataType::Varchar { max_length: None }],
+        )
+    }
+
+    fn func(name: &str, args: Vec<Expression>) -> Expression {
+        Expression::Function { name: name.to_string().into(), args, character_unit: None }
+    }
+
+    fn and(left: Expression, right: Expression) -> Expression {
+        Expression::BinaryOp {
+            left: Box::new(left),
+            op: BinaryOperator::And,
+            right: Box::new(right),
+        }
+    }
+
+    fn like(expr: Expression, pattern: Expression) -> Expression {
+        Expression::Like {
+            expr: Box::new(expr),
+            pattern: Box::new(pattern),
+            negated: false,
+            escape: None,
+        }
+    }
+
+    fn col_unqualified(name: &str) -> Expression {
+        Expression::ColumnRef(ColumnIdentifier::simple(name, false))
+    }
+
+    #[test]
+    fn split_conjuncts_flattens_nested_and() {
+        // a AND b AND c  (left-deep BinaryOp AND) -> three conjuncts.
+        let e = and(and(col("t", "a"), col("t", "b")), col("t", "c"));
+        let mut out = Vec::new();
+        split_conjuncts(&e, &mut out);
+        assert_eq!(out.len(), 3);
+    }
+
+    #[test]
+    fn split_conjuncts_flattens_conjunction_variant() {
+        let e = Expression::Conjunction(vec![col("t", "a"), col("t", "b"), col("t", "c")]);
+        let mut out = Vec::new();
+        split_conjuncts(&e, &mut out);
+        assert_eq!(out.len(), 3);
+    }
+
+    #[test]
+    fn split_conjuncts_non_and_is_single() {
+        let e = like(col("t", "phone"), lit_str("704-%"));
+        let mut out = Vec::new();
+        split_conjuncts(&e, &mut out);
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn json_valid_guard_is_left_only_pushable() {
+        // json_valid(user.phone) references only a left column -> pushable.
+        let schema = user_left_schema();
+        let guard = func("json_valid", vec![col("user", "phone")]);
+        assert!(conjunct_is_left_only(&guard, &schema));
+    }
+
+    #[test]
+    fn tvf_column_predicate_is_not_pushable() {
+        // json_each.value LIKE '704-%' references a table-function column that
+        // does NOT resolve in the left schema -> NOT pushable (post-join only).
+        let schema = user_left_schema();
+        let pred = like(col("json_each", "value"), lit_str("704-%"));
+        assert!(!conjunct_is_left_only(&pred, &schema));
+    }
+
+    #[test]
+    fn unqualified_tvf_column_is_not_pushable() {
+        // A bare `value` (the TVF's column, unqualified) is not in the left
+        // schema, so it is not pushable.
+        let schema = user_left_schema();
+        let pred = like(col_unqualified("value"), lit_str("704-%"));
+        assert!(!conjunct_is_left_only(&pred, &schema));
+    }
+
+    #[test]
+    fn mixed_conjunct_referencing_tvf_is_not_pushable() {
+        // json_valid(user.phone) AND json_each.value LIKE ... : as a single
+        // conjunct (not split) it references a TVF column, so it is not
+        // pushable. (Splitting happens before this check in the real path.)
+        let schema = user_left_schema();
+        let mixed = and(
+            func("json_valid", vec![col("user", "phone")]),
+            like(col("json_each", "value"), lit_str("704-%")),
+        );
+        assert!(!conjunct_is_left_only(&mixed, &schema));
+    }
+
+    #[test]
+    fn constant_conjunct_is_not_pushed() {
+        // A conjunct with no column references (e.g. a bare literal) is uniform
+        // across left rows; we do not push it (the post-join filter handles it).
+        let schema = user_left_schema();
+        let konst = Expression::Literal(SqlValue::Boolean(true));
+        assert!(!conjunct_is_left_only(&konst, &schema));
+    }
+
+    #[test]
+    fn json102_1011_shape_splits_into_pushable_and_postjoin() {
+        // Full json102-1011 WHERE: json_valid(user.phone) AND json_each.value LIKE '704-%'
+        // The guard conjunct pushes; the TVF-column conjunct does not.
+        let schema = user_left_schema();
+        let where_clause = and(
+            func("json_valid", vec![col("user", "phone")]),
+            like(col("json_each", "value"), lit_str("704-%")),
+        );
+        let mut conjuncts = Vec::new();
+        split_conjuncts(&where_clause, &mut conjuncts);
+        assert_eq!(conjuncts.len(), 2);
+        let pushable: Vec<_> =
+            conjuncts.iter().filter(|c| conjunct_is_left_only(c, &schema)).collect();
+        assert_eq!(pushable.len(), 1, "only the json_valid guard is pushed");
     }
 }

--- a/crates/vibesql-executor/tests/lateral_tvf_where_guard_tests.rs
+++ b/crates/vibesql-executor/tests/lateral_tvf_where_guard_tests.rs
@@ -1,0 +1,197 @@
+//! Regression tests for issue #5989 (residual scope, json102-1011): pushing a
+//! left-only WHERE guard into a lateral TVF dependent join.
+//!
+//! The canonical shape is the malformed-JSON guard idiom:
+//!
+//! ```sql
+//! SELECT user.name
+//!   FROM user, json_each(user.phone)
+//!  WHERE json_valid(user.phone)      -- left-only guard
+//!    AND json_each.value LIKE '704-%';
+//! ```
+//!
+//! After a preceding `UPDATE` sets `user.phone` to a scalar (non-JSON-array)
+//! string for some rows, `json_each(user.phone)` would error ("malformed JSON")
+//! on those rows. sqlite3 evaluates the `json_valid(user.phone)` guard against
+//! the cross product but short-circuits so the guard excludes the malformed-JSON
+//! left rows *before* `json_each` runs on them.
+//!
+//! VibeSQL's dependent-join loop previously evaluated the TVF for every left row,
+//! so a malformed `phone` errored the whole query. This test suite verifies the
+//! predicate-pushdown fix: WHERE conjuncts that reference only left-side columns
+//! are evaluated per left row before the TVF, and rows failing them are skipped.
+//!
+//! Differential behavior (verified against sqlite3 3.51.0):
+//!
+//! - **With the `json_valid` guard**: malformed rows are filtered; no error.
+//! - **Without the guard**: `json_each` reaches a malformed value and errors
+//!   ("malformed JSON") — we match sqlite3's error behavior rather than silently
+//!   filtering.
+//! - **A guard referencing a TVF column** (`json_each.value ...`) is NOT pushed;
+//!   it is still evaluated post-join, so it cannot pre-filter left rows.
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            vibesql_executor::InsertExecutor::execute(db, &insert).unwrap();
+        }
+        vibesql_ast::Statement::Update(update) => {
+            vibesql_executor::UpdateExecutor::execute(&update, db).unwrap();
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+/// Run a SELECT, returning `Ok(rows)` or the executor error, so tests can assert
+/// both the success (guard filters) and error (no-guard malformed JSON) paths.
+fn try_query(
+    db: &vibesql_storage::Database,
+    sql: &str,
+) -> Result<Vec<Vec<SqlValue>>, vibesql_executor::ExecutorError> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Parse failed: {} -- {:?}", sql, e));
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor
+            .execute(&select_stmt)
+            .map(|rows| rows.into_iter().map(|row| row.values.to_vec()).collect())
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+fn query(db: &vibesql_storage::Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    try_query(db, sql).unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e))
+}
+
+/// Build the json102-1000/1010 fixture: after the UPDATE, Alice and Dave keep
+/// JSON-array `phone` values; Bob and Cindy have scalar (non-array) strings
+/// extracted from their single-element arrays.
+fn setup_user_table() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE user(name TEXT, phone TEXT)");
+    run_stmt(
+        &mut db,
+        r#"INSERT INTO user(name, phone) VALUES
+            ('Alice', '["919-555-2345","804-555-3621"]'),
+            ('Bob',   '["201-555-8872"]'),
+            ('Cindy', '["704-555-9983"]'),
+            ('Dave',  '["336-555-8421","704-555-4321","803-911-4421"]')"#,
+    );
+    // Mirror json102-1010: single-element arrays become scalar strings, which are
+    // no longer valid JSON arrays -> json_each would error on them.
+    run_stmt(
+        &mut db,
+        "UPDATE user SET phone = json_extract(phone, '$[0]') WHERE json_array_length(phone) < 2",
+    );
+    db
+}
+
+/// With the `json_valid(user.phone)` guard, malformed (scalar-string) `phone`
+/// rows are filtered before json_each, so the query succeeds. Only Dave's array
+/// contains a '704-' number reachable through the join. sqlite3 3.51.0: Dave.
+#[test]
+fn json_valid_guard_filters_malformed_rows_no_error() {
+    let db = setup_user_table();
+    let rows = query(
+        &db,
+        "SELECT user.name FROM user, json_each(user.phone) \
+         WHERE json_valid(user.phone) AND json_each.value LIKE '704-%'",
+    );
+    assert_eq!(
+        rows,
+        vec![vec![SqlValue::Varchar("Dave".into())]],
+        "guard should filter, got {:?}",
+        rows
+    );
+}
+
+/// The exact json102-1011 query (UNION of the scalar-LIKE branch and the guarded
+/// json_each branch). sqlite3 3.51.0: Cindy, Dave.
+#[test]
+fn json102_1011_full_union_query() {
+    let db = setup_user_table();
+    let mut rows = query(
+        &db,
+        "SELECT name FROM user WHERE phone LIKE '704-%' \
+         UNION \
+         SELECT user.name FROM user, json_each(user.phone) \
+         WHERE json_valid(user.phone) AND json_each.value LIKE '704-%'",
+    );
+    rows.sort_by(|a, b| format!("{:?}", a).cmp(&format!("{:?}", b)));
+    assert_eq!(
+        rows,
+        vec![vec![SqlValue::Varchar("Cindy".into())], vec![SqlValue::Varchar("Dave".into())],],
+        "json102-1011 expected {{Cindy, Dave}}, got {:?}",
+        rows
+    );
+}
+
+/// Without the `json_valid` guard, `json_each` reaches a malformed (scalar) phone
+/// value and errors. We match sqlite3 3.51.0, which reports "malformed JSON"
+/// rather than silently filtering the offending rows.
+#[test]
+fn no_guard_malformed_json_errors_matching_sqlite() {
+    let db = setup_user_table();
+    let result = try_query(
+        &db,
+        "SELECT user.name FROM user, json_each(user.phone) WHERE json_each.value LIKE '704-%'",
+    );
+    let err = result.expect_err("expected a malformed-JSON error without the guard");
+    let msg = format!("{}", err);
+    assert!(
+        msg.to_lowercase().contains("malformed json"),
+        "expected a malformed-JSON error, got: {}",
+        msg
+    );
+}
+
+/// A guard that references a TVF column (`json_each.value`) is NOT pushed into
+/// the per-left-row pre-filter — it can only be evaluated after the join. So it
+/// cannot pre-filter malformed left rows; the malformed row still reaches
+/// json_each and errors. This confirms we only push left-only conjuncts.
+#[test]
+fn guard_referencing_tvf_column_is_not_pushed() {
+    let db = setup_user_table();
+    // `json_each.value IS NOT NULL` references only a TVF column. It is not a
+    // left-only guard, so it stays post-join and cannot suppress the malformed
+    // json_each evaluation on Bob's/Cindy's scalar phone -> still errors.
+    let result = try_query(
+        &db,
+        "SELECT user.name FROM user, json_each(user.phone) WHERE json_each.value IS NOT NULL",
+    );
+    let err = result.expect_err("a TVF-column-only guard must not be pushed, so still errors");
+    assert!(
+        format!("{}", err).to_lowercase().contains("malformed json"),
+        "expected malformed-JSON error, got: {}",
+        err
+    );
+}
+
+/// The pushed left-only guard must not over-filter the happy path: when every
+/// left row is valid JSON, all matching rows are returned. Here both Alice and
+/// Dave have valid arrays; only Dave's contains a '704-' number.
+#[test]
+fn guard_does_not_overfilter_valid_rows() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE user(name TEXT, phone TEXT)");
+    run_stmt(
+        &mut db,
+        r#"INSERT INTO user(name, phone) VALUES
+            ('Alice', '["919-555-2345","804-555-3621"]'),
+            ('Dave',  '["336-555-8421","704-555-4321"]')"#,
+    );
+    let rows = query(
+        &db,
+        "SELECT user.name FROM user, json_each(user.phone) \
+         WHERE json_valid(user.phone) AND json_each.value LIKE '704-%'",
+    );
+    assert_eq!(rows, vec![vec![SqlValue::Varchar("Dave".into())]], "got {:?}", rows);
+}


### PR DESCRIPTION
## Summary

Residual scope of #5989 (core lateral TVF capability merged in #5998). Fixes json102-1011: the malformed-JSON guard idiom

```sql
SELECT user.name FROM user, json_each(user.phone)
 WHERE json_valid(user.phone) AND json_each.value LIKE '704-%';
```

Previously VibeSQL's dependent-join loop evaluated `json_each(user.phone)` for **every** left row, so a non-JSON `user.phone` (produced by the preceding UPDATE in json102-1010) errored the whole query with "malformed JSON". SQLite applies the WHERE guard to the cross product but short-circuits so the `json_valid(user.phone)` conjunct excludes malformed left rows *before* `json_each` runs on them.

## Pushdown design chosen: full left-only-conjunct pushdown

The general-correct approach — standard predicate pushdown into the dependent join. In `execute_lateral_tvf_join`:

1. Split the WHERE clause into top-level AND conjuncts (both the `BinaryOp{And}` and `Conjunction` spellings).
2. Keep the conjuncts whose **every** column reference resolves against the left schema (name-based via `CombinedSchema::get_column_index`). A reference to a TVF column (`json_each.value`, or a bare `value`) does not resolve there, so any conjunct touching the right side is **not** pushed.
3. Evaluate the pushed conjuncts per left row before invoking the TVF; a row failing any (false or NULL, via the shared `is_truthy`) is skipped and the TVF never runs on it.

Conjuncts referencing TVF columns stay in the caller's existing post-join filter — so the no-guard case still reaches the TVF and errors on malformed JSON, matching sqlite3 3.51.0.

## Changes

- `crates/vibesql-executor/src/select/scan/lateral.rs`: `split_conjuncts`, `collect_column_refs`, `conjunct_is_left_only` helpers; per-left-row pre-filter in `execute_lateral_tvf_join`; 11 new unit tests.
- `crates/vibesql-executor/tests/lateral_tvf_where_guard_tests.rs`: 5 new integration tests (guard filters, full json102-1011 UNION, no-guard errors, TVF-column guard not pushed, no over-filtering).

## Differential verification vs sqlite3 3.51.0

| Case | sqlite3 | VibeSQL |
|------|---------|---------|
| With `json_valid` guard | filters malformed rows, no error → Dave | matches |
| No guard | "malformed JSON" error | matches |
| json102-1011 full UNION | {Cindy, Dave} | matches |

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| json102-1011 passes; ≥294/309, no other regressions | ✅ | `make test-tcl-file FILE=json102.test` → **294/309** (was 293); 1011 no longer in failure list. Remaining 15 = documented binary-JSONB (`*b`/phoneb) + subtype/->> (1600/1610/1620) |
| No json101 regression (42/42) | ✅ | `make test-tcl-file FILE=json101.test` → **42/42** |
| Unit test: guard filters malformed (no error) | ✅ | `json_valid_guard_filters_malformed_rows_no_error` |
| Unit test: no-guard matches sqlite3 | ✅ | `no_guard_malformed_json_errors_matching_sqlite` |
| Unit test: TVF-column guard NOT pushed | ✅ | `guard_referencing_tvf_column_is_not_pushed`, `tvf_column_predicate_is_not_pushable` |
| cargo build --release | ✅ | clean |
| cargo test -p vibesql-executor | ✅ | all pass (18 lateral unit + 5 new integration + 4 empty-left) |

## Test Plan

- `cargo test -p vibesql-executor` — all pass
- `make test-tcl-file FILE=json102.test` → 294/309, `FILE=json101.test` → 42/42, `FILE=where.test` → 168/0
- Constraint respected: no columnar-execution code touched

Closes #5989