### PR TITLE
test(columnar): serialize env-var-toggling tests to fix flaky path assertion

### DIFF
--- a/crates/vibesql-executor/tests/columnar_computed_predicate_path_assertion_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_computed_predicate_path_assertion_tests.rs
@@ -54,6 +54,18 @@ fn take_logs() -> Vec<String> {
     std::mem::take(&mut *buffer().lock().unwrap())
 }
 
+/// Serializes every test in this binary. `VIBESQL_DISABLE_COLUMNAR` is a
+/// process-global env var and the `log` capture buffer is process-global, so
+/// concurrent tests would otherwise race: one test toggling
+/// `VIBESQL_DISABLE_COLUMNAR=1` for its row-path parity run could silently
+/// disable columnar in another test's columnar run (failing that test's path
+/// assertion), and their captured logs would interleave. Every test here either
+/// toggles the env var or reads the shared buffer, so each acquires this mutex
+/// for its whole body to keep its columnar run, row-path run, and captured logs
+/// isolated. Poisoned-lock recovery (`unwrap_or_else(|e| e.into_inner())`) keeps
+/// a panic in one test from cascading into spurious failures in the rest.
+static SERIAL: Mutex<()> = Mutex::new(());
+
 fn execute_sql(db: &mut Database, sql: &str) {
     for sql_stmt in sql.split(';') {
         let trimmed = sql_stmt.trim();
@@ -113,6 +125,7 @@ fn sum_result(rows: &[vibesql_storage::Row]) -> i64 {
 
 #[test]
 fn computed_predicate_mul_takes_columnar_path_and_matches_row_path() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     init_logger();
 
     // Enough rows (>256) to exercise the SIMD streaming filter path.
@@ -149,6 +162,7 @@ fn computed_predicate_mul_takes_columnar_path_and_matches_row_path() {
 
 #[test]
 fn computed_predicate_sub_le_column_matches_row_path() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     init_logger();
 
     let mut db = Database::new();
@@ -182,6 +196,7 @@ fn computed_predicate_sub_le_column_matches_row_path() {
 /// the row path exactly.
 #[test]
 fn computed_predicate_null_propagation_matches_row_path() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     init_logger();
 
     let mut db = Database::new();

--- a/crates/vibesql-executor/tests/join_ambiguous_column_tests.rs
+++ b/crates/vibesql-executor/tests/join_ambiguous_column_tests.rs
@@ -19,11 +19,27 @@
 //! columnar path first (it falls back to the row-oriented path on the ambiguity
 //! error), so they pin the fixed behavior regardless of which path is chosen.
 
+use std::sync::Mutex;
+
 use vibesql_catalog::{ColumnSchema, TableSchema};
 use vibesql_executor::{ExecutorError, SelectExecutor};
 use vibesql_parser::Parser;
 use vibesql_storage::{Database, Row};
 use vibesql_types::{DataType, SqlValue};
+
+/// Serializes every test in this binary. Several tests toggle the process-global
+/// `VIBESQL_DISABLE_COLUMNAR_JOIN` env var to force the row-oriented join path,
+/// while the other tests run queries through `SelectExecutor`, which reads that
+/// same env var to choose columnar vs row execution. Running in parallel, one
+/// test's transient `set_var` could flip another test's execution path mid-query.
+/// The assertions here are path-invariant (both paths return the same result or
+/// the same ambiguity error), so this has not produced wrong answers, but the
+/// env race is the same hazard class that made the columnar path-assertion tests
+/// flaky (#6005). Every test acquires this mutex for its whole body so the env
+/// var is only ever mutated by one test at a time. Poisoned-lock recovery
+/// (`unwrap_or_else(|e| e.into_inner())`) keeps a panic in one test from
+/// cascading into spurious failures in the rest.
+static SERIAL: Mutex<()> = Mutex::new(());
 
 fn parse_select(sql: &str) -> vibesql_ast::SelectStmt {
     match Parser::parse_sql(sql) {
@@ -136,6 +152,7 @@ fn setup_db() -> Database {
 /// (Was: silently resolved to a1.id and returned 2 rows.)
 #[test]
 fn test_ambiguous_unqualified_id_in_on_two_tables() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_db();
     assert_ambiguous(&db, "SELECT a1.id FROM a1 JOIN b1 ON id=aid", "id");
 }
@@ -144,6 +161,7 @@ fn test_ambiguous_unqualified_id_in_on_two_tables() {
 /// (Was: silently resolved to a1.id and returned 0 rows.)
 #[test]
 fn test_ambiguous_unqualified_id_in_on_three_tables() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_db();
     assert_ambiguous(
         &db,
@@ -155,6 +173,7 @@ fn test_ambiguous_unqualified_id_in_on_three_tables() {
 /// Predicate written in flipped order (`aid=id`) must be caught too.
 #[test]
 fn test_ambiguous_unqualified_id_in_on_flipped() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_db();
     assert_ambiguous(&db, "SELECT a1.id FROM a1 JOIN b1 ON aid=id", "id");
 }
@@ -164,6 +183,7 @@ fn test_ambiguous_unqualified_id_in_on_flipped() {
 /// row path which raises the same error.
 #[test]
 fn test_ambiguous_unqualified_id_in_comma_join_where() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_db();
     assert_ambiguous(&db, "SELECT a1.id FROM a1, b1 WHERE id=aid", "id");
 }
@@ -171,6 +191,7 @@ fn test_ambiguous_unqualified_id_in_comma_join_where() {
 /// Qualified refs in the ON clause are never ambiguous — must keep working.
 #[test]
 fn test_qualified_refs_in_on_not_ambiguous() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_db();
     let rows = run(&db, "SELECT a1.id FROM a1 JOIN b1 ON b1.aid=a1.id ORDER BY 1");
     assert_eq!(rows.len(), 2);
@@ -182,6 +203,7 @@ fn test_qualified_refs_in_on_not_ambiguous() {
 /// resolves correctly (`aid` lives only on b1).
 #[test]
 fn test_unqualified_single_table_column_not_ambiguous() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_db();
     let rows = run(&db, "SELECT a1.id FROM a1 JOIN b1 ON aid=a1.id ORDER BY 1");
     assert_eq!(rows.len(), 2);
@@ -192,6 +214,7 @@ fn test_unqualified_single_table_column_not_ambiguous() {
 /// Unambiguous 3-table chain (all predicates qualified/single-table) still works.
 #[test]
 fn test_unambiguous_three_table_chain() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_db();
     let rows = run(
         &db,
@@ -207,6 +230,7 @@ fn test_unambiguous_three_table_chain() {
 /// resolves to the coalesced join column, not an ambiguity error.
 #[test]
 fn test_using_join_key_not_ambiguous() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let mut db = Database::new();
     for t in ["A", "B"] {
         let schema = TableSchema::new(
@@ -238,6 +262,7 @@ fn test_using_join_key_not_ambiguous() {
 /// NATURAL-join key columns are NOT ambiguous (issue #4517).
 #[test]
 fn test_natural_join_key_not_ambiguous() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let mut db = Database::new();
     for t in ["A", "B"] {
         let schema = TableSchema::new(
@@ -265,6 +290,7 @@ fn test_natural_join_key_not_ambiguous() {
 /// is ambiguous.
 #[test]
 fn test_self_join_unqualified_key_ambiguous() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let mut db = Database::new();
     let t = TableSchema::with_primary_key(
         "T".to_string(),
@@ -303,6 +329,7 @@ fn test_self_join_unqualified_key_ambiguous() {
 /// column name used unqualified in an ON clause is ambiguous too.
 #[test]
 fn test_duplicate_non_pk_column_unqualified_ambiguous() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let mut db = Database::new();
     for (table, cols) in [("TA", vec!["w", "v"]), ("TB", vec!["w", "aw", "v"])] {
         let schema = TableSchema::new(
@@ -408,6 +435,7 @@ fn first_col_ints(db: &Database, sql: &str) -> Vec<i64> {
 /// `customers.id` in its own scope. SQLite returns {1, 2}.
 #[test]
 fn test_in_subquery_semi_join_outer_ref_not_ambiguous() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_semi_join_db();
     assert_eq!(
         first_col_ints(
@@ -432,6 +460,7 @@ fn test_in_subquery_semi_join_outer_ref_not_ambiguous() {
 /// SQLite returns {3}. Must not raise an ambiguity error on the outer `id`.
 #[test]
 fn test_not_in_subquery_anti_join_outer_ref_not_ambiguous() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_semi_join_db();
     assert_eq!(
         first_col_ints(
@@ -449,6 +478,7 @@ fn test_not_in_subquery_anti_join_outer_ref_not_ambiguous() {
 /// the same error on either path, so a transient flip cannot break them.
 #[test]
 fn test_in_and_not_in_subquery_outer_ref_row_path() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     std::env::set_var("VIBESQL_DISABLE_COLUMNAR_JOIN", "1");
     let db = setup_semi_join_db();
     let in_ids = first_col_ints(
@@ -470,6 +500,7 @@ fn test_in_and_not_in_subquery_outer_ref_row_path() {
 /// subquery-flattened tables, not real joined tables).
 #[test]
 fn test_explicit_join_still_ambiguous_after_semi_join_fix() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_semi_join_db();
     assert_ambiguous(
         &db,
@@ -583,6 +614,7 @@ fn setup_multi_table_outer_ambiguous_db() -> Database {
 /// rows and match sqlite3 `{10,10,20,20}`, NOT raise an ambiguity error.
 #[test]
 fn test_multi_table_outer_in_subquery_unique_column_not_ambiguous() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_multi_table_outer_db();
     assert_eq!(
         first_col_ints(&db, "SELECT t1.v FROM t1, t2 WHERE a IN (SELECT a FROM t3)"),
@@ -595,6 +627,7 @@ fn test_multi_table_outer_in_subquery_unique_column_not_ambiguous() {
 /// rows 1 and 2 (each × 2 t2 rows). NOT IN keeps t1 row 3 (× 2). sqlite3: `30,30`.
 #[test]
 fn test_multi_table_outer_not_in_subquery_unique_column_not_ambiguous() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_multi_table_outer_db();
     assert_eq!(
         first_col_ints(&db, "SELECT t1.v FROM t1, t2 WHERE a NOT IN (SELECT a FROM t3)"),
@@ -606,6 +639,7 @@ fn test_multi_table_outer_not_in_subquery_unique_column_not_ambiguous() {
 /// Same multi-table shape on the row-oriented path (columnar join disabled).
 #[test]
 fn test_multi_table_outer_in_subquery_row_path() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     std::env::set_var("VIBESQL_DISABLE_COLUMNAR_JOIN", "1");
     let db = setup_multi_table_outer_db();
     let in_vs = first_col_ints(&db, "SELECT t1.v FROM t1, t2 WHERE a IN (SELECT a FROM t3)");
@@ -621,6 +655,7 @@ fn test_multi_table_outer_in_subquery_row_path() {
 /// and `t2`. sqlite3 3.51.0: `Error: ambiguous column name: a`.
 #[test]
 fn test_multi_table_outer_genuinely_ambiguous_column_errors() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_multi_table_outer_ambiguous_db();
     assert_ambiguous(&db, "SELECT t1.v FROM t1, t2 WHERE a IN (SELECT a FROM t3)", "a");
 }
@@ -628,6 +663,7 @@ fn test_multi_table_outer_genuinely_ambiguous_column_errors() {
 /// The genuine-ambiguity error must also fire on the row-oriented path.
 #[test]
 fn test_multi_table_outer_genuinely_ambiguous_column_errors_row_path() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     std::env::set_var("VIBESQL_DISABLE_COLUMNAR_JOIN", "1");
     let db = setup_multi_table_outer_ambiguous_db();
     let select = parse_select("SELECT t1.v FROM t1, t2 WHERE a IN (SELECT a FROM t3)");
@@ -701,6 +737,7 @@ fn setup_cte_outer_db() -> Database {
 /// it is unambiguous. sqlite3 3.51.0: `10,20`.
 #[test]
 fn test_cte_outer_in_subquery_shared_column_not_ambiguous() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_cte_outer_db();
     assert_eq!(
         first_col_ints(
@@ -717,6 +754,7 @@ fn test_cte_outer_in_subquery_shared_column_not_ambiguous() {
 /// sqlite3 3.51.0: `10,20`.
 #[test]
 fn test_view_outer_in_subquery_shared_column_not_ambiguous() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_view_outer_db();
     assert_eq!(
         first_col_ints(&db, "SELECT t1.v FROM t1 WHERE a IN (SELECT a FROM t3)"),
@@ -728,6 +766,7 @@ fn test_view_outer_in_subquery_shared_column_not_ambiguous() {
 /// Both CTE and VIEW shapes must hold on the row-oriented path too.
 #[test]
 fn test_cte_and_view_outer_in_subquery_row_path() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     std::env::set_var("VIBESQL_DISABLE_COLUMNAR_JOIN", "1");
     let cte_db = setup_cte_outer_db();
     let cte_vs = first_col_ints(
@@ -748,6 +787,7 @@ fn test_cte_and_view_outer_in_subquery_row_path() {
 /// `ambiguous column name: a`.
 #[test]
 fn test_cte_outer_genuinely_ambiguous_column_errors() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let mut db = setup_cte_outer_db();
     exec_setup(&mut db, "CREATE TABLE t2(a INTEGER, w INTEGER)");
     exec_setup(&mut db, "INSERT INTO t2 VALUES(1,100),(2,200)");
@@ -764,6 +804,7 @@ fn test_cte_outer_genuinely_ambiguous_column_errors() {
 /// `ambiguous column name: a`.
 #[test]
 fn test_view_outer_genuinely_ambiguous_column_errors() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let mut db = setup_view_outer_db();
     exec_setup(&mut db, "CREATE TABLE t2(a INTEGER, w INTEGER)");
     exec_setup(&mut db, "INSERT INTO t2 VALUES(1,100),(2,200)");
@@ -813,6 +854,7 @@ fn setup_derived_outer_db() -> Database {
 /// 3.51.0: `10,20`. (Judge's reproducer, fourth-cycle.)
 #[test]
 fn test_derived_outer_in_subquery_shared_column_not_ambiguous() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_derived_outer_db();
     assert_eq!(
         first_col_ints(
@@ -828,6 +870,7 @@ fn test_derived_outer_in_subquery_shared_column_not_ambiguous() {
 /// base.a=1,2; NOT IN keeps the derived row with a=3. sqlite3 3.51.0: `30`.
 #[test]
 fn test_derived_outer_not_in_subquery_shared_column_not_ambiguous() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_derived_outer_db();
     assert_eq!(
         first_col_ints(
@@ -842,6 +885,7 @@ fn test_derived_outer_not_in_subquery_shared_column_not_ambiguous() {
 /// Both derived-table shapes must hold on the row-oriented path too.
 #[test]
 fn test_derived_outer_in_and_not_in_subquery_row_path() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     std::env::set_var("VIBESQL_DISABLE_COLUMNAR_JOIN", "1");
     let db = setup_derived_outer_db();
     let in_vs = first_col_ints(
@@ -863,6 +907,7 @@ fn test_derived_outer_in_and_not_in_subquery_row_path() {
 /// 3.51.0: `10,20`.
 #[test]
 fn test_values_outer_in_subquery_positional_columns_not_ambiguous() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_derived_outer_db();
     assert_eq!(
         first_col_ints(
@@ -878,6 +923,7 @@ fn test_values_outer_in_subquery_positional_columns_not_ambiguous() {
 /// VALUES-as-FROM NOT IN variant. sqlite3 3.51.0: `30`. Also on the row path.
 #[test]
 fn test_values_outer_not_in_subquery_positional_columns_row_path() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_derived_outer_db();
     assert_eq!(
         first_col_ints(
@@ -905,6 +951,7 @@ fn test_values_outer_not_in_subquery_positional_columns_row_path() {
 /// 3.51.0: `10,20`.
 #[test]
 fn test_opaque_derived_outer_select_star_falls_back_not_ambiguous() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let db = setup_derived_outer_db();
     assert_eq!(
         first_col_ints(
@@ -931,6 +978,7 @@ fn test_opaque_derived_outer_select_star_falls_back_not_ambiguous() {
 /// sqlite3 3.51.0: `ambiguous column name: a`.
 #[test]
 fn test_derived_outer_genuinely_ambiguous_column_errors() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     let mut db = setup_derived_outer_db();
     exec_setup(&mut db, "CREATE TABLE t2(a INTEGER, w INTEGER)");
     exec_setup(&mut db, "INSERT INTO t2 VALUES(1,100),(2,200)");
@@ -944,6 +992,7 @@ fn test_derived_outer_genuinely_ambiguous_column_errors() {
 /// The derived-table genuine-ambiguity error must also fire on the row path.
 #[test]
 fn test_derived_outer_genuinely_ambiguous_column_errors_row_path() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     std::env::set_var("VIBESQL_DISABLE_COLUMNAR_JOIN", "1");
     let mut db = setup_derived_outer_db();
     exec_setup(&mut db, "CREATE TABLE t2(a INTEGER, w INTEGER)");


### PR DESCRIPTION
## Summary

Fixes the flaky CI failure in `columnar_computed_predicate_path_assertion_tests.rs` (failed twice on PR #6002's runs). Its 3 tests run in parallel threads while several toggle the process-global `VIBESQL_DISABLE_COLUMNAR` env var and all share one process-global log-capture buffer. If one test sets `VIBESQL_DISABLE_COLUMNAR=1` for its row-path parity run while another test executes its columnar query, that query silently takes the row path and the path assertion fails ("expected native columnar execution to run for 'a * b > 100'").

Test-only change; no production code touched.

## Changes

- `crates/vibesql-executor/tests/columnar_computed_predicate_path_assertion_tests.rs`: added a file-scoped `static SERIAL: Mutex<()>` acquired at the top of every test (all 3 either toggle the env var or read the shared log buffer). Exact pattern PR #6001 established in `columnar_group_by_expression_tests.rs`, including poisoned-lock recovery via `unwrap_or_else(|e| e.into_inner())`.
- `crates/vibesql-executor/tests/join_ambiguous_column_tests.rs`: same hazard found during the audit — 33 parallel tests, 7 of which toggle the process-global `VIBESQL_DISABLE_COLUMNAR_JOIN` var while every other test runs queries whose execution path reads it. Its assertions are path-invariant (both paths return the same rows or the same ambiguity error), so it had not misfired yet, but it is the same race class; applied the same SERIAL mutex to all 33 tests.

## Audit of sibling binaries (per issue instruction)

| File | Verdict |
|------|---------|
| `columnar_computed_predicate_path_assertion_tests.rs` | FIXED (primary; 3 tests toggle `VIBESQL_DISABLE_COLUMNAR` + shared log buffer) |
| `join_ambiguous_column_tests.rs` | FIXED (7 of 33 tests toggle `VIBESQL_DISABLE_COLUMNAR_JOIN`; no serialization existed) |
| `columnar_is_null_path_assertion_tests.rs` | CLEAN (single `#[test]`, no env toggling; no intra-binary parallelism) |
| `columnar_is_null_predicate_tests.rs` | CLEAN (no env toggling, no log buffer; pure result-parity tests) |
| `lateral_tvf_where_guard_tests.rs` | CLEAN (merged in #6004; no env toggling, no log buffer) |
| `columnar_join_ambiguous_where_tests.rs` | CLEAN (`VIBESQL_DISABLE_COLUMNAR_JOIN` appears only in a doc comment; no `std::env` calls) |
| `columnar_group_by_expression_tests.rs` | CLEAN (already serialized by PR #6001; reference pattern) |

Audit method: `grep -rl` for `VIBESQL_DISABLE_COLUMNAR` / `VIBESQL_DISABLE_COLUMNAR_JOIN` across all of `crates/vibesql-executor/tests/`; the four hits above are exhaustive.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| SERIAL mutex in primary file, acquired at top of every test | Done | All 3 tests acquire it as their first statement; pattern mirrors PR #6001 including poisoned-lock recovery |
| Audit sibling binaries and fix where present | Done | 7 binaries audited (table above); 1 additional fix applied |
| Primary binary 20x loop all green | Done | 20/20 `test result: ok` |
| Each other fixed binary at least 5x | Done | `join_ambiguous_column_tests` 8/8 green |
| Full `cargo test -p vibesql-executor` once | Done | Exit code 0; 60 test-binary result lines, all ok, 0 failed |

## Test Plan

- `for i in $(seq 20); do cargo test -p vibesql-executor --test columnar_computed_predicate_path_assertion_tests || break; done` -> 20/20 green
- `cargo test -p vibesql-executor --test join_ambiguous_column_tests` x8 -> 8/8 green
- `cargo test -p vibesql-executor` -> full suite green (exit 0, no failures)

Closes #6005

🤖 Generated with [Claude Code](https://claude.com/claude-code)