### PR TITLE
perf(columnar): replace per-row DP matrix in general LIKE with allocation-free matcher

### DIFF
--- a/crates/vibesql-executor/Cargo.toml
+++ b/crates/vibesql-executor/Cargo.toml
@@ -29,6 +29,10 @@ log = "0.4"
 bumpalo = { version = "3.16", features = ["collections"] }
 ahash = "0.8"
 arcstr = "1.2"
+# SIMD-accelerated substring / byte search for the columnar general LIKE matcher
+# (literal-run search between wildcards). Already resolved transitively at 2.8.x;
+# promoted to a direct dependency here (issue #6011).
+memchr = "2.8"
 # The SQLite JSON1 functions (json_object/json_set/json_patch/...) need two
 # serde_json behaviors to match sqlite3 byte-for-byte:
 #   * preserve_order    - keep object keys in insertion order

--- a/crates/vibesql-executor/src/select/columnar/string_ops.rs
+++ b/crates/vibesql-executor/src/select/columnar/string_ops.rs
@@ -449,14 +449,347 @@ fn batch_string_prefix_suffix(
     result
 }
 
+/// A single fixed (non-`%`) segment of a general LIKE pattern.
+///
+/// A general pattern is decomposed into `%`-delimited segments. Each segment is
+/// a run of literal characters interleaved with `_` (match-any-single-char)
+/// wildcards. Because `%` matches zero-or-more characters, matching reduces to
+/// finding each successive segment somewhere at/after the current text cursor,
+/// with the first and last segments anchored to the ends when the pattern does
+/// not start/end with `%`.
+#[derive(Debug)]
+struct Segment {
+    /// The `_`-delimited literal chunks, in order. A segment like `a_bc_` has
+    /// chunks `["a", "bc", ""]` separated by two `_` wildcards. Chunks are byte
+    /// slices into the pattern; empty chunks are meaningful (they encode where a
+    /// `_` sits relative to literals).
+    chunks: Vec<Vec<u8>>,
+    /// Number of `_` wildcards in this segment (== `chunks.len() - 1`). Each `_`
+    /// consumes exactly one Unicode character of text.
+    underscores: usize,
+    /// Total number of literal bytes across all chunks. Used for the length
+    /// fast-reject: a segment needs at least `literal_bytes` bytes plus one byte
+    /// per `_` (a UTF-8 char is at least one byte) of text.
+    literal_bytes: usize,
+}
+
+/// Pre-parsed general LIKE pattern, built once per batch and reused for every
+/// row. This replaces the old per-row `pattern.chars().collect()` + DP matrix.
+#[derive(Debug)]
+struct GeneralMatcher {
+    /// The fixed segments between `%` wildcards, in order.
+    segments: Vec<Segment>,
+    /// True if the pattern begins with `%` (first segment is unanchored / may
+    /// match anywhere at or after the start).
+    leading_percent: bool,
+    /// True if the pattern ends with `%` (last segment need not reach the end).
+    trailing_percent: bool,
+    /// Minimum number of text bytes any match must contain: sum of every
+    /// segment's `literal_bytes` plus one byte per `_`. Rows shorter than this
+    /// are rejected without any character scanning.
+    min_len: usize,
+    /// True if the pattern contained at least one `%`. When there are no fixed
+    /// segments, this distinguishes a pattern that is purely `%` wildcards
+    /// (matches any text) from an empty pattern (matches only empty text).
+    has_percent: bool,
+}
+
+impl GeneralMatcher {
+    fn parse(pattern: &str) -> Self {
+        let bytes = pattern.as_bytes();
+        let leading_percent = bytes.first() == Some(&b'%');
+        let trailing_percent = bytes.last() == Some(&b'%');
+        let has_percent = bytes.contains(&b'%');
+
+        let mut segments = Vec::new();
+        // Split on `%` into segments; each segment is a run of literals and `_`.
+        for raw in bytes.split(|&b| b == b'%') {
+            // `split` yields an empty slice for the region before a leading `%`,
+            // after a trailing `%`, and between adjacent `%%`. An empty segment
+            // matches the empty string and imposes no constraint, so drop it —
+            // the leading/trailing flags already carry the anchoring semantics.
+            if raw.is_empty() {
+                continue;
+            }
+            let mut chunks: Vec<Vec<u8>> = Vec::new();
+            let mut literal_bytes = 0usize;
+            for chunk in raw.split(|&b| b == b'_') {
+                literal_bytes += chunk.len();
+                chunks.push(chunk.to_vec());
+            }
+            let underscores = chunks.len() - 1;
+            segments.push(Segment { chunks, underscores, literal_bytes });
+        }
+
+        let min_len: usize = segments.iter().map(|s| s.literal_bytes + s.underscores).sum();
+
+        GeneralMatcher { segments, leading_percent, trailing_percent, min_len, has_percent }
+    }
+
+    /// Match `text` against this pre-parsed pattern.
+    ///
+    /// Allocation-free: walks a byte cursor through `text`, matching each
+    /// segment in turn via a two-pointer scan (with `memchr::memmem` for the
+    /// literal-chunk search). SQLite LIKE semantics preserved: ASCII letters
+    /// case-fold (A-Z == a-z), non-ASCII bytes match exactly, `_` consumes
+    /// exactly one Unicode character, `%` consumes zero or more.
+    fn matches(&self, text: &str) -> bool {
+        let text = text.as_bytes();
+
+        // Length fast-reject: too short to possibly match.
+        if text.len() < self.min_len {
+            return false;
+        }
+
+        // No fixed segments. Either the pattern is purely `%` wildcards (matches
+        // any text) or it is the empty pattern (matches only the empty text).
+        if self.segments.is_empty() {
+            return self.has_percent || text.is_empty();
+        }
+
+        let seg_count = self.segments.len();
+
+        // Special case: a single segment with neither leading nor trailing `%`
+        // must match the entire text exactly (e.g. `appl_` or `a_c`).
+        if seg_count == 1 && !self.leading_percent && !self.trailing_percent {
+            return matches!(seg_match_at(text, 0, &self.segments[0]), Some(end) if end == text.len());
+        }
+
+        let mut pos = 0usize; // current byte cursor into text
+        let mut lo = 0usize; // first segment index still to place
+        let mut hi = seg_count; // one past the last segment still to place
+
+        // Anchor the first segment to the start when there is no leading `%`.
+        if !self.leading_percent {
+            match seg_match_at(text, 0, &self.segments[0]) {
+                Some(end) => {
+                    pos = end;
+                    lo = 1;
+                }
+                None => return false,
+            }
+        }
+
+        // Anchor the last segment to the end when there is no trailing `%`.
+        // `end_limit` is the exclusive upper bound the floating segments must
+        // finish before. (Guarded by `lo < seg_count` so the segment consumed by
+        // the start anchor is not also treated as the end anchor.)
+        let mut end_limit = text.len();
+        if !self.trailing_percent && lo < seg_count {
+            let last = &self.segments[seg_count - 1];
+            match seg_match_ending_before(text, pos, last, text.len()) {
+                Some(start) => {
+                    end_limit = start;
+                    hi = seg_count - 1;
+                }
+                None => return false,
+            }
+        }
+
+        // Remaining segments `[lo, hi)` are all floating: find each in turn,
+        // earliest-first, staying within `[pos, end_limit)`.
+        for seg in &self.segments[lo..hi] {
+            match seg_find(text, pos, seg) {
+                Some((_start, end)) if end <= end_limit => pos = end,
+                _ => return false,
+            }
+        }
+
+        true
+    }
+}
+
+/// Case-insensitive (ASCII) equality of two equal-length byte slices, matching
+/// SQLite LIKE literal semantics (ASCII letters fold, other bytes exact).
+#[inline]
+fn ascii_ci_eq(a: &[u8], b: &[u8]) -> bool {
+    a.len() == b.len()
+        && a.iter().zip(b.iter()).all(|(&x, &y)| {
+            if x.is_ascii_alphabetic() && y.is_ascii_alphabetic() {
+                x.eq_ignore_ascii_case(&y)
+            } else {
+                x == y
+            }
+        })
+}
+
+/// Number of bytes in the UTF-8 character starting at `text[pos]`.
+#[inline]
+fn utf8_char_len(byte: u8) -> usize {
+    if byte & 0x80 == 0 {
+        1
+    } else if byte & 0xE0 == 0xC0 {
+        2
+    } else if byte & 0xF0 == 0xE0 {
+        3
+    } else if byte & 0xF8 == 0xF0 {
+        4
+    } else {
+        1
+    }
+}
+
+/// Case-insensitive (ASCII) `memmem`-style search for `needle` in `haystack`,
+/// returning the byte offset of the first occurrence at or after offset 0.
+///
+/// Fast path: when `needle` is pure ASCII with no alphabetic bytes (no case
+/// folding needed) OR we simply want raw byte search, `memchr::memmem` gives a
+/// SIMD-accelerated scan. LIKE folds ASCII letters, so we anchor the search on
+/// the needle's first byte via `memchr` and verify with `ascii_ci_eq`.
+#[inline]
+fn ascii_ci_find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+    if needle.len() > haystack.len() {
+        return None;
+    }
+
+    let first = needle[0];
+    // If the needle contains no ASCII letters, case folding is a no-op and we
+    // can use memmem directly (SIMD-accelerated substring search).
+    if !needle.iter().any(|b| b.is_ascii_alphabetic()) {
+        return memchr::memmem::find(haystack, needle);
+    }
+
+    // Otherwise anchor on the first byte (folded to both cases if alphabetic)
+    // and verify candidates case-insensitively.
+    let last_start = haystack.len() - needle.len();
+    if first.is_ascii_alphabetic() {
+        let lower = first.to_ascii_lowercase();
+        let upper = first.to_ascii_uppercase();
+        let mut i = 0usize;
+        while i <= last_start {
+            // Find the next candidate first byte (either case) via memchr. No
+            // candidate anywhere in the remaining window means no match at all.
+            let rest = &haystack[i..=last_start];
+            let off = memchr::memchr2(lower, upper, rest)?;
+            let cand = i + off;
+            if ascii_ci_eq(&haystack[cand..cand + needle.len()], needle) {
+                return Some(cand);
+            }
+            i = cand + 1;
+        }
+        None
+    } else {
+        let mut i = 0usize;
+        while i <= last_start {
+            let rest = &haystack[i..=last_start];
+            let off = memchr::memchr(first, rest)?;
+            let cand = i + off;
+            if ascii_ci_eq(&haystack[cand..cand + needle.len()], needle) {
+                return Some(cand);
+            }
+            i = cand + 1;
+        }
+        None
+    }
+}
+
+/// Try to match `seg` starting exactly at byte offset `start` in `text`.
+/// Returns the byte offset immediately after the match on success.
+///
+/// A segment is `chunk_0 _ chunk_1 _ ... _ chunk_k`: literal chunks separated by
+/// single-character wildcards. The chunks are anchored relative to each other,
+/// so we match `chunk_0` at `start`, skip one UTF-8 char for the `_`, match
+/// `chunk_1` immediately after, etc.
+fn seg_match_at(text: &[u8], start: usize, seg: &Segment) -> Option<usize> {
+    let mut pos = start;
+    let last = seg.chunks.len() - 1;
+    for (i, chunk) in seg.chunks.iter().enumerate() {
+        if pos + chunk.len() > text.len() {
+            return None;
+        }
+        if !ascii_ci_eq(&text[pos..pos + chunk.len()], chunk) {
+            return None;
+        }
+        pos += chunk.len();
+        // A `_` follows every chunk except the last one.
+        if i != last {
+            if pos >= text.len() {
+                return None;
+            }
+            pos += utf8_char_len(text[pos]);
+        }
+    }
+    Some(pos)
+}
+
+/// Find the earliest position at or after `from` where `seg` matches, returning
+/// `(match_start, match_end)` byte offsets.
+fn seg_find(text: &[u8], from: usize, seg: &Segment) -> Option<(usize, usize)> {
+    let first_chunk = &seg.chunks[0];
+
+    // When the segment starts with an empty chunk (a leading `_`), there is no
+    // literal anchor to search for; probe each candidate start position.
+    if first_chunk.is_empty() {
+        let mut start = from;
+        while start <= text.len() {
+            if let Some(end) = seg_match_at(text, start, seg) {
+                return Some((start, end));
+            }
+            if start >= text.len() {
+                break;
+            }
+            start += utf8_char_len(text[start]);
+        }
+        return None;
+    }
+
+    // Otherwise, use the (SIMD-accelerated) substring search to jump to each
+    // candidate occurrence of the first literal chunk, then verify the rest.
+    let mut base = from;
+    while base <= text.len() {
+        let off = ascii_ci_find(&text[base..], first_chunk)?;
+        let cand = base + off;
+        if let Some(end) = seg_match_at(text, cand, seg) {
+            return Some((cand, end));
+        }
+        base = cand + 1;
+        if base > text.len() {
+            break;
+        }
+    }
+    None
+}
+
+/// Find the *latest* start position in `[from, end]` at which `seg` matches and
+/// ends exactly at byte offset `end`. Returns that start on success.
+///
+/// Used for the final, end-anchored segment (no trailing `%`): it must consume
+/// through the end of the text. Choosing the latest valid start maximizes the
+/// room `[from, start)` left for the floating segments that must fit before it.
+fn seg_match_ending_before(text: &[u8], from: usize, seg: &Segment, end: usize) -> Option<usize> {
+    let mut start = from;
+    let mut best: Option<usize> = None;
+    while start <= end {
+        if let Some(match_end) = seg_match_at(text, start, seg) {
+            if match_end == end {
+                best = Some(start);
+            }
+        }
+        if start >= end {
+            break;
+        }
+        start += utf8_char_len(text[start]);
+    }
+    best
+}
+
 /// General LIKE pattern matching (fallback for complex patterns)
 ///
 /// Handles patterns with `_` wildcards and complex `%` combinations.
+///
+/// The pattern is parsed once per batch into a [`GeneralMatcher`] (hoisting the
+/// old per-row `pattern.chars().collect()` out of the row loop), and each row is
+/// matched with an allocation-free two-pointer scan — replacing the previous
+/// per-row `O(m*n)` `Vec<Vec<bool>>` dynamic-programming matrix.
 fn batch_string_like_general(
     values: &[std::sync::Arc<str>],
     nulls: Option<&[bool]>,
     pattern: &str,
 ) -> Vec<bool> {
+    let matcher = GeneralMatcher::parse(pattern);
     let mut result = Vec::with_capacity(values.len());
 
     for (i, value) in values.iter().enumerate() {
@@ -468,63 +801,17 @@ fn batch_string_like_general(
             }
         }
 
-        result.push(like_match(value, pattern));
+        result.push(matcher.matches(value));
     }
 
     result
 }
 
-/// Match a string against a SQL LIKE pattern
-///
-/// Uses dynamic programming for pattern matching with `%` and `_` wildcards.
-/// SQLite LIKE is case-insensitive for ASCII letters (A-Z = a-z).
+/// Match a string against a SQL LIKE pattern (convenience wrapper used by
+/// in-module unit tests). Parses the pattern and matches a single string.
+#[cfg(test)]
 fn like_match(text: &str, pattern: &str) -> bool {
-    let text_chars: Vec<char> = text.chars().collect();
-    let pattern_chars: Vec<char> = pattern.chars().collect();
-
-    let m = text_chars.len();
-    let n = pattern_chars.len();
-
-    // dp[i][j] = true if text[0..i] matches pattern[0..j]
-    let mut dp = vec![vec![false; n + 1]; m + 1];
-
-    // Empty pattern matches empty text
-    dp[0][0] = true;
-
-    // Handle leading % in pattern (can match empty string)
-    for j in 1..=n {
-        if pattern_chars[j - 1] == '%' {
-            dp[0][j] = dp[0][j - 1];
-        }
-    }
-
-    // Fill the DP table
-    for i in 1..=m {
-        for j in 1..=n {
-            let pc = pattern_chars[j - 1];
-            let tc = text_chars[i - 1];
-
-            if pc == '%' {
-                // % matches zero or more characters
-                dp[i][j] = dp[i][j - 1] || dp[i - 1][j];
-            } else if pc == '_' {
-                // _ matches any single character
-                dp[i][j] = dp[i - 1][j - 1];
-            } else {
-                // SQLite LIKE is case-insensitive for ASCII letters
-                let matches = if pc.is_ascii_alphabetic() && tc.is_ascii_alphabetic() {
-                    pc.eq_ignore_ascii_case(&tc)
-                } else {
-                    pc == tc
-                };
-                if matches {
-                    dp[i][j] = dp[i - 1][j - 1];
-                }
-            }
-        }
-    }
-
-    dp[m][n]
+    GeneralMatcher::parse(pattern).matches(text)
 }
 
 /// Batch string less than comparison
@@ -881,5 +1168,163 @@ mod tests {
         let pattern = LikePattern::parse("%");
         let result = batch_string_like(&values, None, &pattern);
         assert_eq!(result, vec![true, true, true]);
+    }
+
+    /// Reference matcher: the row-path LIKE evaluator (case-insensitive, no
+    /// escape) — the ground truth the columnar `GeneralMatcher` must replicate.
+    fn reference(text: &str, pattern: &str) -> bool {
+        crate::evaluator::pattern::like_match(text, pattern, false, None)
+    }
+
+    /// Assert the new allocation-free matcher agrees with the row-path reference
+    /// for every (text, pattern) pair in the cartesian product.
+    fn assert_parity(texts: &[&str], patterns: &[&str]) {
+        for &p in patterns {
+            let matcher = GeneralMatcher::parse(p);
+            for &t in texts {
+                assert_eq!(
+                    matcher.matches(t),
+                    reference(t, p),
+                    "mismatch: text={t:?} pattern={p:?} (columnar={}, row={})",
+                    matcher.matches(t),
+                    reference(t, p),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn general_matcher_parity_interior_percent() {
+        // The TPC-H Q13 shape: `%special%requests%`.
+        let texts = &[
+            "special requests",
+            "the special requests here",
+            "specialrequests",
+            "special",
+            "requests special",
+            "no match at all",
+            "specialrequest",
+            "",
+        ];
+        let patterns =
+            &["%special%requests%", "special%requests", "%special%requests", "special%requests%"];
+        assert_parity(texts, patterns);
+    }
+
+    #[test]
+    fn general_matcher_parity_underscores() {
+        let texts = &["abc", "aXc", "abbc", "ac", "a_c", "abcd", "xabc", ""];
+        let patterns = &["a_c", "a__c", "_bc", "ab_", "___", "a_c_", "_a_c_"];
+        assert_parity(texts, patterns);
+    }
+
+    #[test]
+    fn general_matcher_parity_mixed_wildcards() {
+        // Q16 shape: `p_type LIKE 'MEDIUM%POLISHED%'` plus `_`/`%` mixes.
+        let texts = &[
+            "MEDIUM POLISHED BRASS",
+            "MEDIUM ANODIZED POLISHED STEEL",
+            "SMALL POLISHED COPPER",
+            "MEDIUMPOLISHED",
+            "medium polished tin",
+            "",
+        ];
+        let patterns = &[
+            "MEDIUM%POLISHED%",
+            "%MEDIUM%POLISHED%",
+            "M_DIUM%POLISHED%",
+            "%P_LISHED%",
+            "MEDIUM%P_LISHED%STEEL",
+        ];
+        assert_parity(texts, patterns);
+    }
+
+    #[test]
+    fn general_matcher_parity_adjacent_and_edge_wildcards() {
+        let texts = &["", "a", "ab", "abc", "aabbcc", "%literal%", "__"];
+        let patterns =
+            &["%%", "_%", "%_", "%_%", "_%_", "a%%b", "a__%b", "%", "%a%", "a%", "%a", "%%%"];
+        assert_parity(texts, patterns);
+    }
+
+    #[test]
+    fn general_matcher_parity_pattern_longer_than_rows() {
+        let texts = &["a", "ab", "", "xy"];
+        // Patterns whose minimum length exceeds short rows -> length fast-reject.
+        let patterns = &["a_c%def", "%abcdef%", "____", "a%bcdefghij"];
+        assert_parity(texts, patterns);
+    }
+
+    #[test]
+    fn general_matcher_parity_ascii_case_folding() {
+        // ASCII letters fold; digits/punctuation do not.
+        let texts = &["ABC", "abc", "AbC", "a1c", "A_C", "123"];
+        let patterns = &["a_c", "A%C", "%bC%", "a%C", "_2_"];
+        assert_parity(texts, patterns);
+    }
+
+    #[test]
+    fn general_matcher_parity_non_ascii_no_fold() {
+        // Non-ASCII text: ASCII case-fold must NOT fold non-ASCII bytes, and `_`
+        // consumes exactly one (possibly multi-byte) Unicode character.
+        let texts = &[
+            "café",
+            "CAFÉ",
+            "naïve",
+            "Ωmega",
+            "über",
+            "a\u{1234}c", // aሴc (3-byte char)
+            "a😀c",       // 4-byte char
+        ];
+        let patterns = &[
+            "caf_",
+            "caf%",
+            "%é",
+            "a_c",        // _ must match one whole Unicode char
+            "%\u{1234}%", // interior multi-byte literal
+            "a%c",
+        ];
+        assert_parity(texts, patterns);
+    }
+
+    /// Exhaustive deterministic fuzz: every text and pattern of length up to 4
+    /// over the alphabet {a, b, %, _} — the columnar matcher must agree with the
+    /// row path on every pair. This covers adjacency, ordering, and boundary
+    /// cases far beyond the hand-written matrices.
+    #[test]
+    fn general_matcher_exhaustive_small_alphabet_parity() {
+        let alphabet = ['a', 'b', '%', '_'];
+
+        // Build all strings of length 0..=max over `alphabet`.
+        fn all_strings(alphabet: &[char], max: usize) -> Vec<String> {
+            let mut out = vec![String::new()];
+            let mut frontier = vec![String::new()];
+            for _ in 0..max {
+                let mut next = Vec::new();
+                for s in &frontier {
+                    for &c in alphabet {
+                        let mut t = s.clone();
+                        t.push(c);
+                        next.push(t);
+                    }
+                }
+                out.extend(next.iter().cloned());
+                frontier = next;
+            }
+            out
+        }
+
+        // Texts use only {a, b} (no wildcards); patterns use the full alphabet.
+        let texts = all_strings(&['a', 'b'], 4);
+        let patterns = all_strings(&alphabet, 4);
+
+        for p in &patterns {
+            let matcher = GeneralMatcher::parse(p);
+            for t in &texts {
+                let got = matcher.matches(t);
+                let want = reference(t, p);
+                assert_eq!(got, want, "mismatch: text={t:?} pattern={p:?}");
+            }
+        }
     }
 }

--- a/crates/vibesql-executor/tests/columnar_like_general_path_assertion_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_like_general_path_assertion_tests.rs
@@ -1,0 +1,322 @@
+//! Path-assertion + parity tests for issue #6011: the columnar SIMD filter path
+//! must take the *general* LIKE matcher (multi-`%` / `_`-bearing patterns) — the
+//! rewrite that replaced the per-row `Vec<Vec<bool>>` dynamic-programming matrix
+//! with an allocation-free two-pointer matcher (and `memchr`-accelerated
+//! literal-run search).
+//!
+//! Per the acceptance criteria, wall-clock timing is NOT used (the machine is
+//! loaded). Instead we capture `log` output and assert:
+//!   - the row-fallback marker ("skipping - WHERE clause contains unsupported
+//!     predicates") must NOT appear;
+//!   - the positive marker "Native columnar execution completed" (an `info!`
+//!     emitted only once the native columnar filter+aggregate path commits)
+//!     proves the columnar SIMD filter path ran for the `General`-classified
+//!     LIKE.
+//!
+//! The queries are `COUNT(*)`/`SUM(id)` aggregates filtered by LIKE — that is
+//! the shape that reliably routes through the native columnar zero-copy path
+//! (`try_native_columnar_execution`), which applies the SIMD LIKE filter via
+//! `batch_string_like` (the code under test). Aggregate parity (matching count
+//! and id-sum) proves the underlying boolean mask matches the row path.
+//!
+//! Parity is checked by comparing the columnar result against the row path
+//! (`VIBESQL_DISABLE_COLUMNAR=1`) for a matrix of general LIKE patterns: leading/
+//! trailing/interior `%`, single and multiple `_`, adjacent wildcards, empty
+//! pattern-adjacent cases, patterns longer than all rows, non-ASCII text (ASCII
+//! case-fold must not fold non-ASCII), NULL handling, and BLOB affinity.
+//!
+//! This test installs a process-global `log` logger, so it lives in its own test
+//! binary to avoid clashing with other integration tests. `VIBESQL_DISABLE_COLUMNAR`
+//! and the capture buffer are process-global, so a SERIAL mutex serializes the
+//! columnar-vs-row runs (PR #6006 precedent).
+
+use std::sync::{Mutex, OnceLock};
+
+use log::{Level, LevelFilter, Log, Metadata, Record};
+use vibesql_executor::{CreateTableExecutor, InsertExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+struct CaptureLogger;
+
+static LOG_BUFFER: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+fn buffer() -> &'static Mutex<Vec<String>> {
+    LOG_BUFFER.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+impl Log for CaptureLogger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
+    fn log(&self, record: &Record) {
+        // Capture Debug and above: the fallback marker is a debug! line and the
+        // positive marker is an info! line.
+        if record.level() <= Level::Debug {
+            buffer().lock().unwrap().push(format!("{}", record.args()));
+        }
+    }
+    fn flush(&self) {}
+}
+
+static LOGGER: CaptureLogger = CaptureLogger;
+
+fn init_logger() {
+    let _ = log::set_logger(&LOGGER);
+    log::set_max_level(LevelFilter::Debug);
+}
+
+fn take_logs() -> Vec<String> {
+    std::mem::take(&mut *buffer().lock().unwrap())
+}
+
+/// Serializes the columnar-vs-row runs across tests. `VIBESQL_DISABLE_COLUMNAR`
+/// is a process-global env var and the `log` capture buffer is process-global,
+/// so concurrent tests would otherwise race. Holding this mutex for the whole
+/// `run_both` keeps each test's two runs and their captured logs isolated.
+static SERIAL: Mutex<()> = Mutex::new(());
+
+fn execute_sql(db: &mut Database, sql: &str) {
+    for sql_stmt in sql.split(';') {
+        let trimmed = sql_stmt.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
+        match stmt {
+            vibesql_ast::Statement::CreateTable(s) => {
+                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+            }
+            vibesql_ast::Statement::Insert(s) => {
+                InsertExecutor::execute(db, &s).expect("INSERT failed");
+            }
+            other => panic!("Unsupported statement type: {:?}", other),
+        }
+    }
+}
+
+fn run_select(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let rows =
+            vibesql_executor::SelectExecutor::new(db).execute(&select_stmt).expect("SELECT failed");
+        rows.into_iter().map(|r| r.values.to_vec()).collect()
+    } else {
+        panic!("Expected SELECT");
+    }
+}
+
+/// Run the same query on both the columnar path and the row path
+/// (`VIBESQL_DISABLE_COLUMNAR=1`) and return `(columnar_rows, row_rows, logs)`.
+fn run_both(db: &Database, sql: &str) -> (Vec<Vec<SqlValue>>, Vec<Vec<SqlValue>>, Vec<String>) {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+
+    let _ = take_logs(); // discard prior logs
+    let columnar = run_select(db, sql);
+    let logs = take_logs();
+
+    std::env::set_var("VIBESQL_DISABLE_COLUMNAR", "1");
+    let row = run_select(db, sql);
+    std::env::remove_var("VIBESQL_DISABLE_COLUMNAR");
+
+    (columnar, row, logs)
+}
+
+/// Row-fallback marker: the WHERE predicate could not be extracted for columnar.
+const ROW_FALLBACK: &str = "WHERE clause contains unsupported predicates";
+/// Positive marker: the native columnar filter+aggregate path completed.
+const COLUMNAR_COMPLETED: &str = "Native columnar execution completed";
+/// Adaptive-model fallback: the query was routed to row-oriented up front.
+const ADAPTIVE_ROW: &str = "adaptive model selected row-oriented";
+
+fn assert_columnar_filter_ran(logs: &[String]) {
+    let joined = logs.join("\n");
+    assert!(
+        !joined.contains(ROW_FALLBACK),
+        "row-fallback (unsupported predicate) line emitted; columnar LIKE filter skipped:\n{joined}"
+    );
+    assert!(
+        !joined.contains(ADAPTIVE_ROW),
+        "adaptive model routed to row-oriented; columnar LIKE filter skipped:\n{joined}"
+    );
+    assert!(
+        logs.iter().any(|l| l.contains(COLUMNAR_COMPLETED)),
+        "expected native columnar filter+aggregate path to run for the general LIKE:\n{joined}"
+    );
+}
+
+/// A mix of strings exercising general LIKE shapes, including the TPC-H Q13/Q16
+/// analytically-relevant patterns.
+fn setup_words(db: &mut Database, n: usize) {
+    execute_sql(db, "CREATE TABLE w (id INTEGER, s TEXT)");
+    let samples = [
+        "special requests here",
+        "the special package requests",
+        "MEDIUM POLISHED BRASS",
+        "MEDIUM ANODIZED POLISHED STEEL",
+        "SMALL POLISHED COPPER",
+        "no wildcards match this",
+        "specialrequests",
+        "requests special order",
+        "café au lait", // non-ASCII
+        "CAFÉ CLOSED",  // non-ASCII, uppercase
+        "a_literal_underscore",
+        "abcdefghij",
+    ];
+    let mut ins = String::new();
+    for i in 0..n {
+        let s = samples[i % samples.len()].replace('\'', "''");
+        ins.push_str(&format!("INSERT INTO w VALUES ({i}, '{s}');"));
+    }
+    execute_sql(db, &ins);
+}
+
+/// The core Q13/Q16 general shapes take the columnar filter path and match the
+/// row path exactly. Runs on both sides of the SIMD row threshold (256).
+#[test]
+fn general_like_takes_columnar_path_and_matches_row_path() {
+    init_logger();
+
+    // `%a%b%` (interior), `_`-bearing, and mixed `%_` — all classify General.
+    // (Single-word `%x%` shapes classify as Contains and take a different
+    // kernel, so they are intentionally excluded here.)
+    let patterns = [
+        "%special%requests%",   // Q13 shape (multi-interior %)
+        "MEDIUM%POLISHED%",     // Q16 shape (prefix%mid% -> General)
+        "M_DIUM%POLISHED%",     // mixed _ and %
+        "%P_LISHED%",           // interior _ inside %...%
+        "specialrequest_",      // trailing single _
+        "a_literal_underscore", // multiple _ , no %
+    ];
+
+    for n in [40usize, 600usize] {
+        let mut db = Database::new();
+        setup_words(&mut db, n);
+
+        for p in patterns {
+            // COUNT + SUM aggregate over the LIKE filter: routes through the
+            // native columnar path and exercises the SIMD LIKE mask directly.
+            let sql = format!("SELECT COUNT(*), SUM(id) FROM w WHERE s LIKE '{p}'");
+            let (columnar, row, logs) = run_both(&db, &sql);
+
+            assert_columnar_filter_ran(&logs);
+            assert_eq!(
+                columnar, row,
+                "columnar general-LIKE result must equal row path (pattern={p:?}, n={n})"
+            );
+        }
+    }
+}
+
+/// NULL handling: NULL rows must be false in the mask (LIKE) and stay false for
+/// NOT LIKE — identical to the row path.
+#[test]
+fn general_like_null_handling_matches_row_path() {
+    init_logger();
+
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE t (id INTEGER, s TEXT)");
+    let mut ins = String::new();
+    for i in 0..300i64 {
+        if i % 5 == 0 {
+            ins.push_str(&format!("INSERT INTO t VALUES ({i}, NULL);"));
+        } else {
+            ins.push_str(&format!("INSERT INTO t VALUES ({i}, 'a{i}b');"));
+        }
+    }
+    execute_sql(&mut db, &ins);
+
+    for sql in [
+        "SELECT COUNT(*), SUM(id) FROM t WHERE s LIKE '%a%b%'",
+        "SELECT COUNT(*), SUM(id) FROM t WHERE s NOT LIKE '%a_b%'",
+        "SELECT COUNT(*), SUM(id) FROM t WHERE s LIKE 'a_b'",
+    ] {
+        let (columnar, row, logs) = run_both(&db, sql);
+        assert_columnar_filter_ran(&logs);
+        assert_eq!(columnar, row, "NULL handling parity failed for: {sql}");
+    }
+}
+
+/// Patterns longer than every row, empty-ish, and adjacent-wildcard edge cases
+/// must all match the row path.
+#[test]
+fn general_like_edge_cases_match_row_path() {
+    init_logger();
+
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE t (id INTEGER, s TEXT)");
+    let mut ins = String::new();
+    let samples = ["", "a", "ab", "abc", "aabbcc", "xy", "underscore_here"];
+    for i in 0..350usize {
+        let s = samples[i % samples.len()];
+        ins.push_str(&format!("INSERT INTO t VALUES ({i}, '{s}');"));
+    }
+    execute_sql(&mut db, &ins);
+
+    let patterns = [
+        "%_%",                   // at least one char
+        "_%_",                   // at least two chars
+        "a%%b",                  // adjacent %
+        "a__%b",                 // multiple _ then %
+        "____",                  // exactly four chars, no %
+        "%abcdefghij_longtail%", // longer than every row -> length fast-reject
+        "under_core\\_here",     // (backslash is literal here, no ESCAPE clause)
+    ];
+    for p in patterns {
+        let sql = format!("SELECT COUNT(*), SUM(id) FROM t WHERE s LIKE '{p}'");
+        let (columnar, row, logs) = run_both(&db, &sql);
+        assert_columnar_filter_ran(&logs);
+        assert_eq!(columnar, row, "edge-case parity failed for pattern={p:?}");
+    }
+}
+
+/// Non-ASCII text: ASCII case folding must NOT fold non-ASCII characters, and
+/// `_` must consume exactly one (possibly multi-byte) Unicode character.
+#[test]
+fn general_like_non_ascii_matches_row_path() {
+    init_logger();
+
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE t (id INTEGER, s TEXT)");
+    let samples = ["café", "CAFÉ", "naïve", "Ωmega", "über", "aሴc", "a😀c", "cafe"];
+    let mut ins = String::new();
+    for i in 0..320usize {
+        let s = samples[i % samples.len()];
+        ins.push_str(&format!("INSERT INTO t VALUES ({i}, '{s}');"));
+    }
+    execute_sql(&mut db, &ins);
+
+    // Only `General`-classified patterns (each has a `_` and/or multiple
+    // interior `%`), so they route through the general matcher under test.
+    // (Single `%suffix` / `%sub%` shapes classify as Suffix/Contains and take
+    // different kernels, outside this issue's scope.)
+    let patterns = ["caf_", "a_c", "_mega", "%ሴ%é%", "caf_%", "%é%café%"];
+    for p in patterns {
+        let sql = format!("SELECT COUNT(*), SUM(id) FROM t WHERE s LIKE '{p}'");
+        let (columnar, row, logs) = run_both(&db, &sql);
+        assert_columnar_filter_ran(&logs);
+        assert_eq!(columnar, row, "non-ASCII parity failed for pattern={p:?}");
+    }
+}
+
+/// Type affinity: LIKE against a BLOB column returns false (per #5070), matching
+/// the row path — it must not error.
+#[test]
+fn general_like_blob_affinity_matches_row_path() {
+    init_logger();
+
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE b (id INTEGER, data BLOB)");
+    let mut ins = String::new();
+    for i in 0..200usize {
+        ins.push_str(&format!("INSERT INTO b VALUES ({i}, x'61{:02x}62');", i % 256));
+    }
+    execute_sql(&mut db, &ins);
+
+    let sql = "SELECT COUNT(*) FROM b WHERE data LIKE '%a%b%'";
+    // BLOB LIKE may or may not route columnar; the essential guarantee is
+    // result parity with the row path (and no error). Do not assert the path.
+    let (columnar, row, _logs) = run_both(&db, sql);
+    assert_eq!(columnar, row, "BLOB LIKE must match row path (returns false, not error)");
+}


### PR DESCRIPTION
## Summary

The columnar SIMD-filter **general** LIKE matcher (`_`-bearing and multi-`%`/inner-`%` patterns) allocated a fresh `O(m*n)` `Vec<Vec<bool>>` dynamic-programming matrix and two `Vec<char>` collections **per row**, making the general path an allocator microbenchmark rather than a matcher. This is exactly the LIKE shape TPC-H hits: Q13 (`c_comment LIKE '%special%requests%'`) and Q16 (`p_type` mixed `%`/`_`).

This PR replaces the per-row DP with an allocation-free two-pointer matcher and hoists all pattern-side parsing out of the row loop (Stage S + Stage M from the issue).

## Changes

- **`string_ops.rs`**: New `GeneralMatcher` parsed **once per batch** from the pattern into `%`-delimited segments (literal chunks interleaved with `_` wildcards), plus a precomputed `min_len`. Per-row matching is a zero-allocation byte-cursor scan:
  - first/last segments anchored to the ends when the pattern lacks leading/trailing `%`; interior segments matched earliest-first, end-anchor pinned to the latest valid tail placement.
  - literal-run search via `memchr::memmem` / `memchr2` (SIMD-accelerated); a length fast-reject rejects too-short rows before any character work.
  - SQLite LIKE semantics preserved byte-for-byte: ASCII letters case-fold (A-Z == a-z), non-ASCII bytes match exactly, `_` consumes exactly one Unicode char, `%` zero or more, NULL -> false. The old per-row `Vec<Vec<bool>>` + `Vec<char>` allocations are gone.
- **`Cargo.toml`**: `memchr` promoted from a transitive dep to a direct dependency of `vibesql-executor` (resolves to the already-present 2.8.x).
- **New `columnar_like_general_path_assertion_tests.rs`**: path-assertion + parity integration tests (debug-log based, no wall-clock timing).
- ESCAPE / `case_sensitive` LIKE continue to route to the full `evaluator::pattern::like_match` path — unchanged, out of scope.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Debug-log assertion columnar SIMD-filter path (not row fallback) taken for `%a%b%`, `_`-bearing, mixed `%_` | ✅ | `general_like_takes_columnar_path_and_matches_row_path` asserts "Native columnar execution completed" present and no "unsupported predicates" / adaptive-row fallback |
| Result parity vs row path across leading/trailing/interior `%`, single/multiple `_`, adjacent wildcards, empty-adjacent, pattern-longer-than-rows, Unicode (no non-ASCII fold) | ✅ | In-module matrices + `general_matcher_exhaustive_small_alphabet_parity` (exhaustive fuzz over {a,b,%,_} up to len 4) + integration `edge_cases` / `non_ascii` tests |
| NULL input -> false in mask; NOT LIKE keeps NULL false | ✅ | `general_like_null_handling_matches_row_path` |
| Type-affinity: BLOB LIKE returns false, not error (#5070) | ✅ | `general_like_blob_affinity_matches_row_path` |
| Semantics regression guard vs #5049 edge cases | ✅ | Full `cargo test -p vibesql-executor`: 5471 passed, 0 failed |
| `VIBESQL_DISABLE_COLUMNAR` toggles use SERIAL-mutex pattern (PR #6006) | ✅ | `run_both` holds `SERIAL` across both runs and log capture |
| Q13/Q16 byte-identical output | ✅ | `%special%requests%` and `MEDIUM%POLISHED%` shapes checked byte-identical vs row path (aggregate COUNT+SUM parity) |
| NO wall-clock timing tests | ✅ | All assertions are log-marker + result parity only |

## Test Plan

- `cargo test -p vibesql-executor --lib string_ops` — 25 passed (incl. exhaustive fuzz parity vs the row-path reference matcher).
- `cargo test -p vibesql-executor --test columnar_like_general_path_assertion_tests` — 5 passed.
- `cargo test -p vibesql-executor` — **5471 passed, 0 failed**.
- `cargo fmt` applied; `cargo clippy -p vibesql-executor` clean on all touched code (the 3 remaining `approx_constant` clippy errors are pre-existing in unrelated `operators.rs`/`json_funcs.rs` test modules, identical on `origin/main`).

Closes #6011