### PR TITLE
feat(executor): implement STDDEV / VARIANCE aggregates (row + columnar)

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/aggregate/expression/batch.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/expression/batch.rs
@@ -416,6 +416,11 @@ fn aggregate_f64_array(
             let max = non_null_values.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
             Ok(SqlValue::Double(max))
         }
+        AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => {
+            Err(crate::errors::ExecutorError::UnsupportedExpression(
+                "STDDEV/VARIANCE are not supported on this columnar path".to_string(),
+            ))
+        }
     }
 }
 
@@ -463,6 +468,11 @@ fn aggregate_i64_array(
         AggregateOp::Max => {
             let max = *non_null_values.iter().max().unwrap();
             Ok(SqlValue::Integer(max))
+        }
+        AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => {
+            Err(crate::errors::ExecutorError::UnsupportedExpression(
+                "STDDEV/VARIANCE are not supported on this columnar path".to_string(),
+            ))
         }
     }
 }

--- a/crates/vibesql-executor/src/select/columnar/aggregate/expression/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/expression/mod.rs
@@ -91,6 +91,13 @@ pub fn extract_aggregates(
                     "AVG" => AggregateOp::Avg,
                     "MIN" => AggregateOp::Min,
                     "MAX" => AggregateOp::Max,
+                    // STDDEV / VARIANCE statistical aggregates. Bare STDDEV /
+                    // VARIANCE default to the sample estimator, matching the
+                    // row-path `AggregateAccumulator`; only *_POP is population.
+                    "VARIANCE" | "VAR_SAMP" => AggregateOp::Variance { sample: true },
+                    "VAR_POP" => AggregateOp::Variance { sample: false },
+                    "STDDEV" | "STDDEV_SAMP" => AggregateOp::StdDev { sample: true },
+                    "STDDEV_POP" => AggregateOp::StdDev { sample: false },
                     _ => return None, // Unsupported aggregate function
                 };
 

--- a/crates/vibesql-executor/src/select/columnar/aggregate/expression/simd.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/expression/simd.rs
@@ -55,6 +55,11 @@ pub fn try_simd_aggregate(
         AggregateOp::Avg => aggregate_avg(rows, expr, schema),
         AggregateOp::Min => aggregate_min(&result_array),
         AggregateOp::Max => aggregate_max(&result_array),
+        AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => {
+            Err(crate::errors::ExecutorError::UnsupportedExpression(
+                "STDDEV/VARIANCE are not supported on this columnar path".to_string(),
+            ))
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/select/columnar/aggregate/expression/vectorized.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/expression/vectorized.rs
@@ -363,5 +363,10 @@ fn compute_scalar_aggregate(
 
             Ok(result_value.unwrap_or(SqlValue::Null))
         }
+        AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => {
+            Err(crate::errors::ExecutorError::UnsupportedExpression(
+                "STDDEV/VARIANCE are not supported on this columnar path".to_string(),
+            ))
+        }
     }
 }

--- a/crates/vibesql-executor/src/select/columnar/aggregate/functions.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/functions.rs
@@ -358,6 +358,55 @@ pub(super) fn compare_for_min_max(a: &SqlValue, b: &SqlValue) -> bool {
     ordering == Ordering::Less
 }
 
+/// Convert a numeric [`SqlValue`] to `f64` for statistical aggregation.
+///
+/// Returns `None` for NULL and non-numeric values, which are skipped (matching
+/// the AVG / row-path STDDEV semantics).
+#[inline]
+fn stat_value_as_f64(value: &SqlValue) -> Option<f64> {
+    match value {
+        SqlValue::Integer(v) => Some(*v as f64),
+        SqlValue::Bigint(v) => Some(*v as f64),
+        SqlValue::Smallint(v) => Some(*v as f64),
+        SqlValue::Unsigned(v) => Some(*v as f64),
+        SqlValue::Float(v) => Some(*v as f64),
+        SqlValue::Real(v) => Some(*v),
+        SqlValue::Double(v) => Some(*v),
+        SqlValue::Numeric(v) => Some(*v),
+        _ => None,
+    }
+}
+
+/// Compute STDDEV / VARIANCE on a column using Welford's online algorithm.
+///
+/// Shares the exact accumulate/finalize math with the row path
+/// (`select::grouping::welford_update` / `welford_finalize`) so the columnar
+/// and row results agree bit-for-bit. NULL / non-numeric values are skipped.
+pub(super) fn compute_variance(
+    scan: &ColumnarScan,
+    column_idx: usize,
+    is_stddev: bool,
+    sample: bool,
+    filter_bitmap: Option<&[bool]>,
+) -> Result<SqlValue, ExecutorError> {
+    use crate::select::grouping::{welford_finalize, welford_update};
+
+    let (mut count, mut mean, mut m2) = (0i64, 0.0f64, 0.0f64);
+    for (row_idx, value_opt) in scan.column(column_idx).enumerate() {
+        if let Some(bitmap) = filter_bitmap {
+            if !bitmap.get(row_idx).copied().unwrap_or(false) {
+                continue;
+            }
+        }
+        if let Some(value) = value_opt {
+            if let Some(x) = stat_value_as_f64(value) {
+                welford_update(&mut count, &mut mean, &mut m2, x);
+            }
+        }
+    }
+    Ok(welford_finalize(count, m2, is_stddev, sample))
+}
+
 /// Compute an aggregate on a column (dispatcher for all aggregate types)
 pub(super) fn compute_columnar_aggregate_impl(
     scan: &ColumnarScan,
@@ -371,6 +420,12 @@ pub(super) fn compute_columnar_aggregate_impl(
         AggregateOp::Avg => compute_avg(scan, column_idx, filter_bitmap),
         AggregateOp::Min => compute_min(scan, column_idx, filter_bitmap),
         AggregateOp::Max => compute_max(scan, column_idx, filter_bitmap),
+        AggregateOp::Variance { sample } => {
+            compute_variance(scan, column_idx, false, sample, filter_bitmap)
+        }
+        AggregateOp::StdDev { sample } => {
+            compute_variance(scan, column_idx, true, sample, filter_bitmap)
+        }
     }
 }
 
@@ -666,6 +721,79 @@ pub(super) fn compute_batch_max(
     }
 }
 
+/// Compute STDDEV / VARIANCE directly on a ColumnarBatch column.
+///
+/// Uses Welford's algorithm (shared with the row path) over the non-NULL
+/// numeric values of the column. Int64 / Float64 / Int32 / Float32 arrays and
+/// the Mixed fallback are supported; other column types report an unsupported
+/// error so the caller declines to the row path.
+pub(crate) fn compute_batch_variance(
+    batch: &ColumnarBatch,
+    column_idx: usize,
+    is_stddev: bool,
+    sample: bool,
+) -> Result<SqlValue, ExecutorError> {
+    use crate::select::grouping::{welford_finalize, welford_update};
+
+    let column = batch.column(column_idx).ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
+        column_index: column_idx,
+        batch_columns: batch.column_count(),
+    })?;
+
+    let (mut count, mut mean, mut m2) = (0i64, 0.0f64, 0.0f64);
+    let mut fold = |x: f64| welford_update(&mut count, &mut mean, &mut m2, x);
+
+    match column {
+        ColumnArray::Int64(values, nulls) => match nulls {
+            Some(mask) => values.iter().zip(mask.iter()).for_each(|(&v, &is_null)| {
+                if !is_null {
+                    fold(v as f64);
+                }
+            }),
+            None => values.iter().for_each(|&v| fold(v as f64)),
+        },
+        ColumnArray::Int32(values, nulls) => match nulls {
+            Some(mask) => values.iter().zip(mask.iter()).for_each(|(&v, &is_null)| {
+                if !is_null {
+                    fold(v as f64);
+                }
+            }),
+            None => values.iter().for_each(|&v| fold(v as f64)),
+        },
+        ColumnArray::Float64(values, nulls) => match nulls {
+            Some(mask) => values.iter().zip(mask.iter()).for_each(|(&v, &is_null)| {
+                if !is_null {
+                    fold(v);
+                }
+            }),
+            None => values.iter().for_each(|&v| fold(v)),
+        },
+        ColumnArray::Float32(values, nulls) => match nulls {
+            Some(mask) => values.iter().zip(mask.iter()).for_each(|(&v, &is_null)| {
+                if !is_null {
+                    fold(v as f64);
+                }
+            }),
+            None => values.iter().for_each(|&v| fold(v as f64)),
+        },
+        ColumnArray::Mixed(values) => {
+            for value in values.iter() {
+                if let Some(x) = stat_value_as_f64(value) {
+                    fold(x);
+                }
+            }
+        }
+        _ => {
+            return Err(ExecutorError::UnsupportedExpression(format!(
+                "Cannot compute STDDEV/VARIANCE on column type: {:?}",
+                column.data_type()
+            )));
+        }
+    }
+
+    Ok(welford_finalize(count, m2, is_stddev, sample))
+}
+
 /// Compute batch aggregate (dispatcher for all aggregate types)
 pub(super) fn compute_batch_aggregate(
     batch: &ColumnarBatch,
@@ -678,6 +806,10 @@ pub(super) fn compute_batch_aggregate(
         AggregateOp::Avg => compute_batch_avg(batch, column_idx),
         AggregateOp::Min => compute_batch_min(batch, column_idx),
         AggregateOp::Max => compute_batch_max(batch, column_idx),
+        AggregateOp::Variance { sample } => {
+            compute_batch_variance(batch, column_idx, false, sample)
+        }
+        AggregateOp::StdDev { sample } => compute_batch_variance(batch, column_idx, true, sample),
     }
 }
 

--- a/crates/vibesql-executor/src/select/columnar/aggregate/group_by.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/group_by.rs
@@ -238,6 +238,26 @@ fn max_f64_indexed(values: &[f64], indices: &[usize], nulls: Option<&[bool]>) ->
     }
 }
 
+/// Welford STDDEV/VARIANCE over `f64`-projected values at specific indices.
+///
+/// `project` maps each index to `Some(x)` for a non-NULL numeric value or
+/// `None` to skip it. Shares the finalize math with the row path so per-group
+/// columnar variance matches the row path bit-for-bit.
+#[inline]
+fn variance_indexed<F>(indices: &[usize], is_stddev: bool, sample: bool, mut project: F) -> SqlValue
+where
+    F: FnMut(usize) -> Option<f64>,
+{
+    use crate::select::grouping::{welford_finalize, welford_update};
+    let (mut count, mut mean, mut m2) = (0i64, 0.0f64, 0.0f64);
+    for &idx in indices {
+        if let Some(x) = project(idx) {
+            welford_update(&mut count, &mut mean, &mut m2, x);
+        }
+    }
+    welford_finalize(count, m2, is_stddev, sample)
+}
+
 /// Compute aggregate using indices (O(group_size) instead of O(total_rows))
 fn compute_group_aggregate_indexed(
     batch: &ColumnarBatch,
@@ -283,6 +303,24 @@ fn compute_group_aggregate_indexed(
                         operation: "MAX".to_string(),
                         reason: "empty group".to_string(),
                     }),
+                AggregateOp::Variance { sample } => {
+                    Ok(variance_indexed(indices, false, sample, |i| {
+                        if null_slice.is_some_and(|ns| ns[i]) {
+                            None
+                        } else {
+                            Some(values[i] as f64)
+                        }
+                    }))
+                }
+                AggregateOp::StdDev { sample } => {
+                    Ok(variance_indexed(indices, true, sample, |i| {
+                        if null_slice.is_some_and(|ns| ns[i]) {
+                            None
+                        } else {
+                            Some(values[i] as f64)
+                        }
+                    }))
+                }
             }
         }
 
@@ -318,6 +356,24 @@ fn compute_group_aggregate_indexed(
                         operation: "MAX".to_string(),
                         reason: "empty group".to_string(),
                     }),
+                AggregateOp::Variance { sample } => {
+                    Ok(variance_indexed(indices, false, sample, |i| {
+                        if null_slice.is_some_and(|ns| ns[i]) {
+                            None
+                        } else {
+                            Some(values[i])
+                        }
+                    }))
+                }
+                AggregateOp::StdDev { sample } => {
+                    Ok(variance_indexed(indices, true, sample, |i| {
+                        if null_slice.is_some_and(|ns| ns[i]) {
+                            None
+                        } else {
+                            Some(values[i])
+                        }
+                    }))
+                }
             }
         }
 
@@ -391,6 +447,12 @@ fn compute_group_aggregate_indexed(
                         }
                     }
                     Ok(max_val.map(SqlValue::Double).unwrap_or(SqlValue::Null))
+                }
+                AggregateOp::Variance { sample } => {
+                    Ok(variance_indexed(indices, false, sample, |i| sqlvalue_to_f64(&values[i])))
+                }
+                AggregateOp::StdDev { sample } => {
+                    Ok(variance_indexed(indices, true, sample, |i| sqlvalue_to_f64(&values[i])))
                 }
             }
         }
@@ -487,6 +549,24 @@ fn compute_group_aggregate_indexed(
                         operation: "MAX".to_string(),
                         reason: "empty group".to_string(),
                     }),
+                AggregateOp::Variance { sample } => {
+                    Ok(variance_indexed(indices, false, sample, |i| {
+                        if null_slice.is_some_and(|ns| ns[i]) {
+                            None
+                        } else {
+                            Some(values[i] as f64)
+                        }
+                    }))
+                }
+                AggregateOp::StdDev { sample } => {
+                    Ok(variance_indexed(indices, true, sample, |i| {
+                        if null_slice.is_some_and(|ns| ns[i]) {
+                            None
+                        } else {
+                            Some(values[i] as f64)
+                        }
+                    }))
+                }
             }
         }
 
@@ -539,6 +619,24 @@ fn compute_group_aggregate_indexed(
                         operation: "MAX".to_string(),
                         reason: "empty group".to_string(),
                     }),
+                AggregateOp::Variance { sample } => {
+                    Ok(variance_indexed(indices, false, sample, |i| {
+                        if null_slice.is_some_and(|ns| ns[i]) {
+                            None
+                        } else {
+                            Some(values[i] as f64)
+                        }
+                    }))
+                }
+                AggregateOp::StdDev { sample } => {
+                    Ok(variance_indexed(indices, true, sample, |i| {
+                        if null_slice.is_some_and(|ns| ns[i]) {
+                            None
+                        } else {
+                            Some(values[i] as f64)
+                        }
+                    }))
+                }
             }
         }
 

--- a/crates/vibesql-executor/src/select/columnar/aggregate/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/mod.rs
@@ -19,6 +19,7 @@ pub use expression::{
     evaluate_expression_to_column, evaluate_expression_with_cached_column, extract_aggregates,
     materialize_derived_column,
 };
+pub(crate) use functions::compute_batch_variance;
 pub use group_by::columnar_group_by;
 // SIMD-accelerated GROUP BY for ColumnarBatch - used in native columnar execution path
 pub use group_by::columnar_group_by_batch;
@@ -37,6 +38,16 @@ pub enum AggregateOp {
     Avg,
     Min,
     Max,
+    /// VARIANCE / VAR_SAMP (sample: true) or VAR_POP (sample: false).
+    /// Computed with Welford's algorithm to match the row path bit-for-bit.
+    Variance {
+        sample: bool,
+    },
+    /// STDDEV / STDDEV_SAMP (sample: true) or STDDEV_POP (sample: false).
+    /// The square root of the corresponding [`AggregateOp::Variance`].
+    StdDev {
+        sample: bool,
+    },
 }
 
 /// Source of data for an aggregate - either a simple column or an expression
@@ -81,8 +92,12 @@ pub fn compute_columnar_aggregate(
     op: AggregateOp,
     filter_bitmap: Option<&[bool]>,
 ) -> Result<SqlValue, ExecutorError> {
-    // Try SIMD path for numeric columns (5-10x speedup via LLVM auto-vectorization)
-    {
+    // Try SIMD path for numeric columns (5-10x speedup via LLVM auto-vectorization).
+    //
+    // Welford-style STDDEV/VARIANCE is not handled by the SIMD kernels (they
+    // only implement SUM/AVG/MIN/MAX/COUNT), so those ops always take the
+    // scalar path below, which carries the numerically-stable accumulator.
+    if !matches!(op, AggregateOp::Variance { .. } | AggregateOp::StdDev { .. }) {
         use super::simd_aggregate::{
             can_use_simd_for_column, simd_aggregate_f64, simd_aggregate_i64,
         };

--- a/crates/vibesql-executor/src/select/columnar/executor/aggregate.rs
+++ b/crates/vibesql-executor/src/select/columnar/executor/aggregate.rs
@@ -78,6 +78,16 @@ pub fn compute_column_aggregate(
     col_idx: usize,
     op: AggregateOp,
 ) -> Result<SqlValue, ExecutorError> {
+    // STDDEV/VARIANCE use the shared Welford kernel (which handles every
+    // supported column type) so the columnar result matches the row path
+    // bit-for-bit; the SIMD i64/f64 helpers below only cover SUM/AVG/MIN/MAX.
+    if let AggregateOp::Variance { sample } = op {
+        return super::super::aggregate::compute_batch_variance(batch, col_idx, false, sample);
+    }
+    if let AggregateOp::StdDev { sample } = op {
+        return super::super::aggregate::compute_batch_variance(batch, col_idx, true, sample);
+    }
+
     let column = batch.column(col_idx).ok_or_else(|| ExecutorError::ColumnarColumnNotFound {
         column_index: col_idx,
         batch_columns: batch.column_count(),
@@ -141,6 +151,11 @@ pub fn compute_i64_aggregate(
                     reason: "empty set".to_string(),
                 }
             }),
+            AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => {
+                Err(crate::errors::ExecutorError::UnsupportedExpression(
+                    "STDDEV/VARIANCE are not supported on this columnar path".to_string(),
+                ))
+            }
         };
     }
 
@@ -195,6 +210,11 @@ pub fn compute_i64_aggregate(
             }
             Ok(max.map(SqlValue::Integer).unwrap_or(SqlValue::Null))
         }
+        AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => {
+            Err(crate::errors::ExecutorError::UnsupportedExpression(
+                "STDDEV/VARIANCE are not supported on this columnar path".to_string(),
+            ))
+        }
     }
 }
 
@@ -239,6 +259,11 @@ pub fn compute_f64_aggregate(
                     reason: "empty set".to_string(),
                 }
             }),
+            AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => {
+                Err(crate::errors::ExecutorError::UnsupportedExpression(
+                    "STDDEV/VARIANCE are not supported on this columnar path".to_string(),
+                ))
+            }
         };
     }
 
@@ -291,6 +316,11 @@ pub fn compute_f64_aggregate(
                 }
             }
             Ok(max.map(SqlValue::Double).unwrap_or(SqlValue::Null))
+        }
+        AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => {
+            Err(crate::errors::ExecutorError::UnsupportedExpression(
+                "STDDEV/VARIANCE are not supported on this columnar path".to_string(),
+            ))
         }
     }
 }
@@ -375,6 +405,11 @@ pub fn compute_mixed_aggregate(
                 });
             }
             Ok(result.unwrap_or(SqlValue::Null))
+        }
+        AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => {
+            Err(crate::errors::ExecutorError::UnsupportedExpression(
+                "STDDEV/VARIANCE are not supported on this columnar path".to_string(),
+            ))
         }
     }
 }

--- a/crates/vibesql-executor/src/select/columnar/executor/expression.rs
+++ b/crates/vibesql-executor/src/select/columnar/executor/expression.rs
@@ -126,6 +126,11 @@ pub fn compute_expression_aggregate_batch(
             Ok(if count > 0 { SqlValue::Double(sum / count as f64) } else { SqlValue::Null })
         }
         AggregateOp::Min | AggregateOp::Max => Ok(min_max.unwrap_or(SqlValue::Null)),
+        AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => {
+            Err(crate::errors::ExecutorError::UnsupportedExpression(
+                "STDDEV/VARIANCE are not supported on this columnar path".to_string(),
+            ))
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/select/columnar/executor/fused.rs
+++ b/crates/vibesql-executor/src/select/columnar/executor/fused.rs
@@ -194,6 +194,11 @@ fn compute_fused_i64_aggregate(
                 operation: "MAX".to_string(),
                 reason: "no rows pass filter".to_string(),
             }),
+        AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => {
+            Err(crate::errors::ExecutorError::UnsupportedExpression(
+                "STDDEV/VARIANCE are not supported on this columnar path".to_string(),
+            ))
+        }
     }
 }
 
@@ -234,6 +239,11 @@ fn compute_fused_f64_aggregate(
                 operation: "MAX".to_string(),
                 reason: "no rows pass filter".to_string(),
             }),
+        AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => {
+            Err(crate::errors::ExecutorError::UnsupportedExpression(
+                "STDDEV/VARIANCE are not supported on this columnar path".to_string(),
+            ))
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/select/columnar/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/mod.rs
@@ -367,6 +367,8 @@ pub fn fast_aggregate_on_rows(
                     acc.max_f64.map(SqlValue::Double).unwrap_or(SqlValue::Null)
                 }
             }
+            // STDDEV/VARIANCE unsupported on the bench-only fast path
+            AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => SqlValue::Null,
         })
         .collect();
 

--- a/crates/vibesql-executor/src/select/columnar/simd_aggregate.rs
+++ b/crates/vibesql-executor/src/select/columnar/simd_aggregate.rs
@@ -63,6 +63,15 @@ pub fn simd_aggregate_i64(
     op: AggregateOp,
     filter_bitmap: Option<&[bool]>,
 ) -> Result<SqlValue, ExecutorError> {
+    // STDDEV/VARIANCE are not SIMD-vectorized (Welford is inherently serial);
+    // the dispatcher in `aggregate::compute_columnar_aggregate` routes them to
+    // the scalar path, so they must never reach the SIMD kernels.
+    if matches!(op, AggregateOp::Variance { .. } | AggregateOp::StdDev { .. }) {
+        return Err(ExecutorError::UnsupportedExpression(
+            "STDDEV/VARIANCE are not supported on the SIMD aggregate path".to_string(),
+        ));
+    }
+
     // DEFAULT_BATCH_SIZE (1024) provides good SIMD throughput while fitting in cache
     let mut batch = Vec::with_capacity(DEFAULT_BATCH_SIZE);
     let mut original_type: Option<SqlValue> = None;
@@ -131,6 +140,8 @@ pub fn simd_aggregate_i64(
                         }
                     }
                     AggregateOp::Count => {} // Just count, no SIMD needed
+                    // Unreachable: guarded at fn entry.
+                    AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => {}
                 }
                 batch.clear();
             }
@@ -154,6 +165,8 @@ pub fn simd_aggregate_i64(
                 }
             }
             AggregateOp::Count => {}
+            // Unreachable: guarded at fn entry.
+            AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => {}
         }
     }
 
@@ -183,6 +196,12 @@ pub fn simd_aggregate_i64(
             _ => SqlValue::Bigint(max),
         }),
         AggregateOp::Count => Ok(SqlValue::Integer(count)),
+        // Unreachable: guarded at fn entry.
+        AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => {
+            Err(ExecutorError::UnsupportedExpression(
+                "STDDEV/VARIANCE are not supported on the SIMD aggregate path".to_string(),
+            ))
+        }
     }
 }
 
@@ -206,6 +225,14 @@ pub fn simd_aggregate_f64(
     op: AggregateOp,
     filter_bitmap: Option<&[bool]>,
 ) -> Result<SqlValue, ExecutorError> {
+    // STDDEV/VARIANCE are not SIMD-vectorized (see `simd_aggregate_i64`); they
+    // are dispatched to the scalar path and must never reach the SIMD kernels.
+    if matches!(op, AggregateOp::Variance { .. } | AggregateOp::StdDev { .. }) {
+        return Err(ExecutorError::UnsupportedExpression(
+            "STDDEV/VARIANCE are not supported on the SIMD aggregate path".to_string(),
+        ));
+    }
+
     // DEFAULT_BATCH_SIZE (1024) provides good SIMD throughput while fitting in cache
     let mut batch = Vec::with_capacity(DEFAULT_BATCH_SIZE);
     let mut count = 0i64;
@@ -261,6 +288,8 @@ pub fn simd_aggregate_f64(
                         }
                     }
                     AggregateOp::Count => {} // Just count, no SIMD needed
+                    // Unreachable: guarded at fn entry.
+                    AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => {}
                 }
                 batch.clear();
             }
@@ -284,6 +313,8 @@ pub fn simd_aggregate_f64(
                 }
             }
             AggregateOp::Count => {}
+            // Unreachable: guarded at fn entry.
+            AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => {}
         }
     }
 
@@ -302,6 +333,12 @@ pub fn simd_aggregate_f64(
         AggregateOp::Min => Ok(SqlValue::Double(min)),
         AggregateOp::Max => Ok(SqlValue::Double(max)),
         AggregateOp::Count => Ok(SqlValue::Integer(count)),
+        // Unreachable: guarded at fn entry.
+        AggregateOp::Variance { .. } | AggregateOp::StdDev { .. } => {
+            Err(ExecutorError::UnsupportedExpression(
+                "STDDEV/VARIANCE are not supported on the SIMD aggregate path".to_string(),
+            ))
+        }
     }
 }
 

--- a/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
@@ -447,6 +447,12 @@ fn expression_in_scope_chain_has_outer_correlated_aggregate(
                     | "PERCENTILE"
                     | "PERCENTILE_CONT"
                     | "PERCENTILE_DISC"
+                    | "STDDEV"
+                    | "STDDEV_SAMP"
+                    | "STDDEV_POP"
+                    | "VARIANCE"
+                    | "VAR_SAMP"
+                    | "VAR_POP"
             ) =>
         {
             let upper = name.to_uppercase();
@@ -784,6 +790,12 @@ fn expr_has_column_referencing_aggregate(expr: &vibesql_ast::Expression) -> bool
                     | "PERCENTILE"
                     | "PERCENTILE_CONT"
                     | "PERCENTILE_DISC"
+                    | "STDDEV"
+                    | "STDDEV_SAMP"
+                    | "STDDEV_POP"
+                    | "VARIANCE"
+                    | "VAR_SAMP"
+                    | "VAR_POP"
             ) =>
         {
             // Old Function variant aggregate. min/max with >1 args are scalar.
@@ -946,7 +958,8 @@ impl SelectExecutor<'_> {
                 let is_aggregate = match name_upper.as_str() {
                     "COUNT" | "SUM" | "AVG" | "TOTAL" | "GROUP_CONCAT" | "STRING_AGG"
                     | "JSON_GROUP_ARRAY" | "MD5SUM" | "MEDIAN" | "PERCENTILE"
-                    | "PERCENTILE_CONT" | "PERCENTILE_DISC" => true,
+                    | "PERCENTILE_CONT" | "PERCENTILE_DISC" | "STDDEV" | "STDDEV_SAMP"
+                    | "STDDEV_POP" | "VARIANCE" | "VAR_SAMP" | "VAR_POP" => true,
                     "MIN" | "MAX" => args.len() <= 1, // multi-arg min/max are scalar functions
                     _ => false,
                 };

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/function.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/function.rs
@@ -27,7 +27,8 @@ pub(super) fn evaluate(
     let name_upper = name.to_uppercase();
     let is_aggregate = match name_upper.as_str() {
         "COUNT" | "SUM" | "AVG" | "TOTAL" | "GROUP_CONCAT" | "STRING_AGG" | "JSON_GROUP_ARRAY"
-        | "MD5SUM" | "MEDIAN" | "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC" => true,
+        | "MD5SUM" | "MEDIAN" | "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC" | "STDDEV"
+        | "STDDEV_SAMP" | "STDDEV_POP" | "VARIANCE" | "VAR_SAMP" | "VAR_POP" => true,
         "MIN" | "MAX" => args.len() <= 1, // multi-arg min/max are scalar functions
         _ => false,
     };

--- a/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
@@ -27,6 +27,12 @@ pub fn is_aggregate_function(name: &str) -> bool {
             | "PERCENTILE"
             | "PERCENTILE_CONT"
             | "PERCENTILE_DISC"
+            | "STDDEV"
+            | "STDDEV_SAMP"
+            | "STDDEV_POP"
+            | "VARIANCE"
+            | "VAR_SAMP"
+            | "VAR_POP"
     )
 }
 

--- a/crates/vibesql-executor/src/select/grouping/aggregates.rs
+++ b/crates/vibesql-executor/src/select/grouping/aggregates.rs
@@ -74,6 +74,35 @@ pub enum AggregateAccumulator {
     },
     /// MD5SUM - Compute MD5 hash of concatenated values (SQLite TCL test compatible)
     Md5sum { values: Vec<String>, distinct: bool, seen: Option<HashSet<String>> },
+    /// STDDEV / VARIANCE family - statistical dispersion aggregates.
+    ///
+    /// Computed with Welford's online algorithm for numerical stability
+    /// (avoids the catastrophic cancellation of the naive sum-of-squares
+    /// approach on large-magnitude / near-constant columns).
+    ///
+    /// Semantics (matching PostgreSQL/MySQL/Oracle and the six SQL spellings):
+    /// - `VARIANCE` / `VAR_SAMP` / `STDDEV` / `STDDEV_SAMP` use the sample
+    ///   estimator (divisor `n - 1`); bare `STDDEV`/`VARIANCE` default to the
+    ///   sample form, consistent with the common SQL-engine convention.
+    /// - `VAR_POP` / `STDDEV_POP` use the population estimator (divisor `n`).
+    /// - NULL and non-numeric inputs are skipped (do not affect `n`).
+    /// - Result is NULL when there are no non-NULL inputs; sample variants are
+    ///   additionally NULL when `n < 2` (population variants yield 0.0 at n == 1).
+    /// - `is_stddev` selects the square-root (STDDEV) vs raw-variance result.
+    Variance {
+        /// Count of non-NULL numeric values seen so far.
+        count: i64,
+        /// Running mean (Welford).
+        mean: f64,
+        /// Running sum of squares of differences from the mean (Welford M2).
+        m2: f64,
+        /// true = STDDEV (sqrt of variance); false = VARIANCE.
+        is_stddev: bool,
+        /// true = sample estimator (n-1); false = population estimator (n).
+        sample: bool,
+        distinct: bool,
+        seen: Option<HashSet<vibesql_types::SqlValue>>,
+    },
     /// PERCENTILE family - median(Y), percentile(Y,P), percentile_cont(Y,F),
     /// percentile_disc(Y,F). Semantics match SQLite's percentile.c extension:
     /// collect all non-NULL Y values, sort, then interpolate at
@@ -148,6 +177,23 @@ impl AggregateAccumulator {
                 distinct,
                 seen: if distinct { Some(HashSet::new()) } else { None },
             }),
+            "STDDEV" | "STDDEV_SAMP" | "STDDEV_POP" | "VARIANCE" | "VAR_SAMP" | "VAR_POP" => {
+                let upper = function_name.to_uppercase();
+                let is_stddev = upper.starts_with("STDDEV");
+                // Bare STDDEV/VARIANCE default to the sample estimator (n-1),
+                // matching PostgreSQL/MySQL/Oracle. Only the explicit *_POP
+                // spellings use the population estimator (n).
+                let sample = !upper.ends_with("_POP");
+                Ok(AggregateAccumulator::Variance {
+                    count: 0,
+                    mean: 0.0,
+                    m2: 0.0,
+                    is_stddev,
+                    sample,
+                    distinct,
+                    seen,
+                })
+            }
             "MEDIAN" | "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC" => {
                 let upper = function_name.to_uppercase();
                 let (mx_frac, discrete, is_median, name) = match upper.as_str() {
@@ -420,6 +466,33 @@ impl AggregateAccumulator {
                 self.accumulate_percentile(value, None);
             }
 
+            // STDDEV / VARIANCE - Welford's online algorithm over non-NULL
+            // numeric values (NULL / non-numeric inputs are skipped).
+            AggregateAccumulator::Variance {
+                ref mut count,
+                ref mut mean,
+                ref mut m2,
+                distinct,
+                seen,
+                ..
+            } => {
+                if value.is_null() {
+                    return;
+                }
+                let Some(x) = sql_value_to_f64(value) else {
+                    // Non-numeric values are skipped (same as AVG).
+                    return;
+                };
+                if *distinct {
+                    let seen_set = seen.as_mut().unwrap();
+                    if seen_set.contains(value) {
+                        return;
+                    }
+                    seen_set.insert(value.clone());
+                }
+                welford_update(count, mean, m2, x);
+            }
+
             // MD5SUM - collects string values for MD5 hashing (like GROUP_CONCAT)
             AggregateAccumulator::Md5sum { ref mut values, distinct, seen } => {
                 // Skip NULL values like GROUP_CONCAT
@@ -681,6 +754,9 @@ impl AggregateAccumulator {
                     v1 + (v2 - v1) * (ix - i1 as f64)
                 };
                 Ok(vibesql_types::SqlValue::Double(vx))
+            }
+            AggregateAccumulator::Variance { count, mean: _, m2, is_stddev, sample, .. } => {
+                Ok(welford_finalize(*count, *m2, *is_stddev, *sample))
             }
             AggregateAccumulator::Md5sum { values, .. } => {
                 use md5::{Digest, Md5};
@@ -1017,6 +1093,56 @@ impl AggregateAccumulator {
                 v1.extend(v2);
             }
 
+            // STDDEV / VARIANCE: merge two Welford accumulators using the
+            // parallel-combination formula (Chan et al.). For DISTINCT, merge
+            // the seen sets and recompute from scratch to keep semantics exact.
+            (
+                AggregateAccumulator::Variance {
+                    count: c1,
+                    mean: mean1,
+                    m2: m2_1,
+                    distinct: d1,
+                    seen: seen1,
+                    ..
+                },
+                AggregateAccumulator::Variance {
+                    count: c2,
+                    mean: mean2,
+                    m2: m2_2,
+                    distinct: d2,
+                    seen: seen2,
+                    ..
+                },
+            ) => {
+                if *d1 != d2 {
+                    return Err(crate::errors::ExecutorError::UnsupportedExpression(
+                        "Cannot combine STDDEV/VARIANCE with different DISTINCT flags".into(),
+                    ));
+                }
+
+                if *d1 {
+                    // DISTINCT: merge seen sets, then recompute (count, mean, m2)
+                    // over the deduplicated union so no value is counted twice.
+                    if let (Some(s1_set), Some(s2_set)) = (seen1, seen2) {
+                        s1_set.extend(s2_set);
+                        let (mut nc, mut nmean, mut nm2) = (0i64, 0.0f64, 0.0f64);
+                        for val in s1_set.iter() {
+                            if let Some(x) = sql_value_to_f64(val) {
+                                welford_update(&mut nc, &mut nmean, &mut nm2, x);
+                            }
+                        }
+                        *c1 = nc;
+                        *mean1 = nmean;
+                        *m2_1 = nm2;
+                    }
+                } else {
+                    let (nc, nmean, nm2) = welford_merge(*c1, *mean1, *m2_1, c2, mean2, m2_2);
+                    *c1 = nc;
+                    *mean1 = nmean;
+                    *m2_1 = nm2;
+                }
+            }
+
             // MD5SUM: Merge value lists
             (
                 AggregateAccumulator::Md5sum { values: v1, distinct: d1, seen: seen1 },
@@ -1082,6 +1208,76 @@ fn add_sql_values(
     use crate::evaluator::operators::OperatorRegistry;
 
     OperatorRegistry::eval_binary_op(a, &BinaryOperator::Plus, b, vibesql_types::SqlMode::default())
+}
+
+/// One step of Welford's online mean/variance algorithm.
+///
+/// Updates `(count, mean, m2)` in place with a new observation `x`, where `m2`
+/// is the running sum of squared deviations from the mean. Numerically stable
+/// for large-magnitude and near-constant inputs (unlike naive sum-of-squares).
+///
+/// Shared by the row-path `AggregateAccumulator::Variance` and the columnar
+/// STDDEV/VARIANCE kernels so both paths agree bit-for-bit.
+#[inline]
+pub(crate) fn welford_update(count: &mut i64, mean: &mut f64, m2: &mut f64, x: f64) {
+    *count += 1;
+    let delta = x - *mean;
+    *mean += delta / *count as f64;
+    let delta2 = x - *mean;
+    *m2 += delta * delta2;
+}
+
+/// Merge two independent Welford accumulators (Chan et al. parallel formula).
+///
+/// Returns the combined `(count, mean, m2)`. Used to fold per-partition or
+/// per-thread partial variance state into a single result.
+#[inline]
+fn welford_merge(
+    c1: i64,
+    mean1: f64,
+    m2_1: f64,
+    c2: i64,
+    mean2: f64,
+    m2_2: f64,
+) -> (i64, f64, f64) {
+    if c1 == 0 {
+        return (c2, mean2, m2_2);
+    }
+    if c2 == 0 {
+        return (c1, mean1, m2_1);
+    }
+    let n = c1 + c2;
+    let delta = mean2 - mean1;
+    let mean = mean1 + delta * (c2 as f64) / (n as f64);
+    let m2 = m2_1 + m2_2 + delta * delta * (c1 as f64) * (c2 as f64) / (n as f64);
+    (n, mean, m2)
+}
+
+/// Turn a completed Welford `(count, m2)` state into the final STDDEV/VARIANCE
+/// `SqlValue`, honoring sample-vs-population and stddev-vs-variance semantics.
+///
+/// - No non-NULL inputs (`count == 0`) → NULL.
+/// - Sample estimator with `count < 2` → NULL (undefined `n - 1` divisor).
+/// - Population estimator with `count == 1` → 0.0.
+/// - Result is always REAL (`SqlValue::Double`), matching AVG.
+#[inline]
+pub(crate) fn welford_finalize(
+    count: i64,
+    m2: f64,
+    is_stddev: bool,
+    sample: bool,
+) -> vibesql_types::SqlValue {
+    if count == 0 {
+        return vibesql_types::SqlValue::Null;
+    }
+    let divisor = if sample { count - 1 } else { count };
+    if divisor <= 0 {
+        // Sample variance/stddev of a single value is undefined → NULL.
+        return vibesql_types::SqlValue::Null;
+    }
+    let variance = m2 / divisor as f64;
+    let result = if is_stddev { variance.sqrt() } else { variance };
+    vibesql_types::SqlValue::Double(result)
 }
 
 /// Convert SqlValue to f64 for numeric operations
@@ -1963,5 +2159,180 @@ mod tests {
                 pair[1]
             );
         }
+    }
+
+    // ===================================================================
+    // STDDEV / VARIANCE (row-path AggregateAccumulator) tests
+    // ===================================================================
+
+    /// Finalize an aggregate over the given values and extract the Double result
+    /// (or None when the result is NULL).
+    fn stat(function_name: &str, values: &[SqlValue]) -> Option<f64> {
+        let mut acc = AggregateAccumulator::new(function_name, false).unwrap();
+        for v in values {
+            acc.accumulate(v);
+        }
+        match acc.finalize().unwrap() {
+            SqlValue::Double(d) => Some(d),
+            SqlValue::Null => None,
+            other => panic!("unexpected result {other:?} for {function_name}"),
+        }
+    }
+
+    fn ints(vs: &[i64]) -> Vec<SqlValue> {
+        vs.iter().map(|&v| SqlValue::Integer(v)).collect()
+    }
+
+    #[test]
+    fn test_variance_known_values() {
+        // Classic reference dataset {2,4,4,4,5,5,7,9}:
+        //   population variance = 4.0, sample variance = 32/7 ≈ 4.571428...
+        let data = ints(&[2, 4, 4, 4, 5, 5, 7, 9]);
+
+        let var_pop = stat("VAR_POP", &data).unwrap();
+        assert!((var_pop - 4.0).abs() < 1e-9, "VAR_POP = {var_pop}");
+
+        let var_samp = stat("VAR_SAMP", &data).unwrap();
+        assert!((var_samp - (32.0 / 7.0)).abs() < 1e-9, "VAR_SAMP = {var_samp}");
+
+        // Bare VARIANCE defaults to sample.
+        let variance = stat("VARIANCE", &data).unwrap();
+        assert!((variance - var_samp).abs() < 1e-12, "VARIANCE must equal VAR_SAMP");
+
+        let std_pop = stat("STDDEV_POP", &data).unwrap();
+        assert!((std_pop - 2.0).abs() < 1e-9, "STDDEV_POP = {std_pop}");
+
+        let std_samp = stat("STDDEV_SAMP", &data).unwrap();
+        assert!((std_samp - (32.0f64 / 7.0).sqrt()).abs() < 1e-9, "STDDEV_SAMP = {std_samp}");
+
+        // Bare STDDEV defaults to sample.
+        let stddev = stat("STDDEV", &data).unwrap();
+        assert!((stddev - std_samp).abs() < 1e-12, "STDDEV must equal STDDEV_SAMP");
+    }
+
+    #[test]
+    fn test_variance_empty_is_null() {
+        for f in ["STDDEV", "STDDEV_SAMP", "STDDEV_POP", "VARIANCE", "VAR_SAMP", "VAR_POP"] {
+            assert_eq!(stat(f, &[]), None, "{f} over empty set must be NULL");
+        }
+    }
+
+    #[test]
+    fn test_variance_single_value() {
+        let data = ints(&[42]);
+        // Sample variants: undefined at n=1 → NULL.
+        assert_eq!(stat("VAR_SAMP", &data), None);
+        assert_eq!(stat("STDDEV_SAMP", &data), None);
+        assert_eq!(stat("VARIANCE", &data), None);
+        assert_eq!(stat("STDDEV", &data), None);
+        // Population variants: 0.0 at n=1.
+        assert_eq!(stat("VAR_POP", &data), Some(0.0));
+        assert_eq!(stat("STDDEV_POP", &data), Some(0.0));
+    }
+
+    #[test]
+    fn test_variance_skips_nulls() {
+        // NULLs must not affect the count or the result.
+        let with_nulls = vec![
+            SqlValue::Integer(2),
+            SqlValue::Null,
+            SqlValue::Integer(4),
+            SqlValue::Null,
+            SqlValue::Integer(4),
+            SqlValue::Integer(4),
+            SqlValue::Integer(5),
+            SqlValue::Integer(5),
+            SqlValue::Integer(7),
+            SqlValue::Integer(9),
+        ];
+        let clean = ints(&[2, 4, 4, 4, 5, 5, 7, 9]);
+        assert_eq!(stat("VAR_POP", &with_nulls), stat("VAR_POP", &clean));
+        assert_eq!(stat("STDDEV_SAMP", &with_nulls), stat("STDDEV_SAMP", &clean));
+    }
+
+    #[test]
+    fn test_variance_all_null_is_null() {
+        let data = vec![SqlValue::Null, SqlValue::Null, SqlValue::Null];
+        assert_eq!(stat("VAR_POP", &data), None);
+        assert_eq!(stat("STDDEV_POP", &data), None);
+        assert_eq!(stat("VAR_SAMP", &data), None);
+    }
+
+    #[test]
+    fn test_variance_real_and_mixed_numeric_inputs() {
+        // Real / Double / Numeric all fold into the same f64 accumulator.
+        let data = vec![
+            SqlValue::Double(1.0),
+            SqlValue::Real(2.0),
+            SqlValue::Numeric(3.0),
+            SqlValue::Integer(4),
+        ];
+        // Population variance of {1,2,3,4}: mean 2.5, m2 = 5.0, /4 = 1.25.
+        let var_pop = stat("VAR_POP", &data).unwrap();
+        assert!((var_pop - 1.25).abs() < 1e-9, "VAR_POP = {var_pop}");
+        // Sample variance: 5.0 / 3 ≈ 1.6666...
+        let var_samp = stat("VAR_SAMP", &data).unwrap();
+        assert!((var_samp - (5.0 / 3.0)).abs() < 1e-9, "VAR_SAMP = {var_samp}");
+    }
+
+    #[test]
+    fn test_variance_numerical_stability_large_offset() {
+        // Welford avoids catastrophic cancellation: adding a large constant
+        // offset to every value must not change the variance.
+        let base = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let offset = 1.0e9_f64;
+        let plain: Vec<SqlValue> = base.iter().map(|&v| SqlValue::Double(v)).collect();
+        let shifted: Vec<SqlValue> = base.iter().map(|&v| SqlValue::Double(v + offset)).collect();
+
+        let v_plain = stat("VAR_POP", &plain).unwrap();
+        let v_shifted = stat("VAR_POP", &shifted).unwrap();
+        assert!(
+            (v_plain - v_shifted).abs() < 1e-6,
+            "variance must be shift-invariant: {v_plain} vs {v_shifted}"
+        );
+    }
+
+    #[test]
+    fn test_variance_combine_matches_single_pass() {
+        // The parallel Welford merge (combine) must agree with a single-pass
+        // accumulation over the concatenated data.
+        let left = ints(&[10, 12, 23, 23]);
+        let right = ints(&[16, 23, 21, 16]);
+
+        let mut acc_all = AggregateAccumulator::new("VAR_SAMP", false).unwrap();
+        for v in left.iter().chain(right.iter()) {
+            acc_all.accumulate(v);
+        }
+        let single = acc_all.finalize().unwrap();
+
+        let mut acc_l = AggregateAccumulator::new("VAR_SAMP", false).unwrap();
+        for v in &left {
+            acc_l.accumulate(v);
+        }
+        let mut acc_r = AggregateAccumulator::new("VAR_SAMP", false).unwrap();
+        for v in &right {
+            acc_r.accumulate(v);
+        }
+        acc_l.combine(acc_r).unwrap();
+        let merged = acc_l.finalize().unwrap();
+
+        match (single, merged) {
+            (SqlValue::Double(a), SqlValue::Double(b)) => {
+                assert!((a - b).abs() < 1e-9, "combine {b} != single-pass {a}");
+            }
+            other => panic!("unexpected results: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_variance_distinct_dedups() {
+        // VAR_POP(DISTINCT ...) over {2,2,4,4,4} == VAR_POP over {2,4}.
+        let mut acc = AggregateAccumulator::new("VAR_POP", true).unwrap();
+        for v in ints(&[2, 2, 4, 4, 4]) {
+            acc.accumulate(&v);
+        }
+        let distinct = acc.finalize().unwrap();
+        // Population variance of {2,4}: mean 3, m2 = 2, /2 = 1.0.
+        assert!(matches!(distinct, SqlValue::Double(d) if (d - 1.0).abs() < 1e-9));
     }
 }

--- a/crates/vibesql-executor/src/select/grouping/mod.rs
+++ b/crates/vibesql-executor/src/select/grouping/mod.rs
@@ -17,7 +17,8 @@ mod parallel_sink;
 
 // Re-export public API
 pub(crate) use aggregates::{
-    compare_sql_values, compare_sql_values_with_collation, AggregateAccumulator,
+    compare_sql_values, compare_sql_values_with_collation, welford_finalize, welford_update,
+    AggregateAccumulator,
 };
 pub(crate) use grouping_sets::expressions_equal;
 pub(super) use grouping_sets::{

--- a/crates/vibesql-executor/tests/columnar_join_stddev_variance_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_join_stddev_variance_tests.rs
@@ -1,0 +1,226 @@
+//! Join-path parity tests for issue #6012: STDDEV / VARIANCE over an INNER JOIN
+//! with GROUP BY, on the columnar join path.
+//!
+//! Confirms the columnar join GROUP BY path is taken (positive log marker) and
+//! that its statistical-aggregate results match the row path
+//! (`VIBESQL_DISABLE_COLUMNAR_JOIN=1`) within a float epsilon. Uses the PR #6006
+//! SERIAL-mutex pattern because the env var and the log buffer are process-global.
+
+use std::sync::{Mutex, OnceLock};
+
+use log::{Level, LevelFilter, Log, Metadata, Record};
+use vibesql_executor::{CreateTableExecutor, InsertExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+struct CaptureLogger;
+
+static LOG_BUFFER: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+fn buffer() -> &'static Mutex<Vec<String>> {
+    LOG_BUFFER.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+impl Log for CaptureLogger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
+    fn log(&self, record: &Record) {
+        if record.level() <= Level::Debug {
+            buffer().lock().unwrap().push(format!("{}", record.args()));
+        }
+    }
+    fn flush(&self) {}
+}
+
+static LOGGER: CaptureLogger = CaptureLogger;
+
+fn init_logger() {
+    let _ = log::set_logger(&LOGGER);
+    log::set_max_level(LevelFilter::Debug);
+}
+
+fn take_logs() -> Vec<String> {
+    std::mem::take(&mut *buffer().lock().unwrap())
+}
+
+static SERIAL: Mutex<()> = Mutex::new(());
+
+/// Row-fallback marker: a joined GROUP BY key couldn't be resolved to a column.
+const ROW_FALLBACK: &str = "Columnar join: some GROUP BY columns couldn't be resolved";
+/// Positive marker emitted only when the columnar join path produced the result.
+const COLUMNAR_JOIN_SUCCEEDED: &str = "Columnar join execution succeeded";
+
+fn execute_sql(db: &mut Database, sql: &str) {
+    for sql_stmt in sql.split(';') {
+        let trimmed = sql_stmt.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
+        match stmt {
+            vibesql_ast::Statement::CreateTable(s) => {
+                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+            }
+            vibesql_ast::Statement::Insert(s) => {
+                InsertExecutor::execute(db, &s).expect("INSERT failed");
+            }
+            other => panic!("Unsupported statement type: {:?}", other),
+        }
+    }
+}
+
+fn run_select(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let rows =
+            vibesql_executor::SelectExecutor::new(db).execute(&select_stmt).expect("SELECT failed");
+        rows.into_iter().map(|r| r.values.to_vec()).collect()
+    } else {
+        panic!("Expected SELECT");
+    }
+}
+
+fn as_f64(v: &SqlValue) -> Option<f64> {
+    match v {
+        SqlValue::Null => None,
+        SqlValue::Integer(x) => Some(*x as f64),
+        SqlValue::Bigint(x) => Some(*x as f64),
+        SqlValue::Smallint(x) => Some(*x as f64),
+        SqlValue::Double(x) => Some(*x),
+        SqlValue::Float(x) => Some(*x as f64),
+        SqlValue::Real(x) => Some(*x),
+        SqlValue::Numeric(x) => Some(*x),
+        other => panic!("non-numeric aggregate result: {other:?}"),
+    }
+}
+
+/// Assert two (already sorted) row sets are equal, with a float epsilon on
+/// numeric cells and exact equality on everything else.
+fn assert_rows_close(columnar: &[Vec<SqlValue>], row: &[Vec<SqlValue>], ctx: &str) {
+    assert_eq!(columnar.len(), row.len(), "row count differs for {ctx}");
+    for (i, (c, r)) in columnar.iter().zip(row.iter()).enumerate() {
+        assert_eq!(c.len(), r.len(), "column count differs at row {i} for {ctx}");
+        for (j, (cv, rv)) in c.iter().zip(r.iter()).enumerate() {
+            match (as_f64(cv), as_f64(rv)) {
+                (Some(a), Some(b)) => {
+                    let tol = 1e-9 * (1.0 + a.abs().max(b.abs()));
+                    assert!(
+                        (a - b).abs() <= tol,
+                        "row {i} col {j} numeric mismatch for {ctx}: columnar={a} row={b}"
+                    );
+                }
+                (None, None) => {}
+                _ => assert_eq!(cv, rv, "row {i} col {j} mismatch for {ctx}"),
+            }
+        }
+    }
+}
+
+/// Run the query on both the columnar-join path and the row path
+/// (`VIBESQL_DISABLE_COLUMNAR_JOIN=1`); returns `(columnar, row, logs)` with both
+/// result sets sorted (parity is order-independent here).
+fn run_both(db: &Database, sql: &str) -> (Vec<Vec<SqlValue>>, Vec<Vec<SqlValue>>, Vec<String>) {
+    let _ = take_logs();
+    let mut columnar = run_select(db, sql);
+    let logs = take_logs();
+
+    std::env::set_var("VIBESQL_DISABLE_COLUMNAR_JOIN", "1");
+    let mut row = run_select(db, sql);
+    std::env::remove_var("VIBESQL_DISABLE_COLUMNAR_JOIN");
+
+    columnar.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
+    row.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
+    (columnar, row, logs)
+}
+
+fn assert_columnar_join_ran(logs: &[String]) {
+    let joined = logs.join("\n");
+    assert!(
+        !joined.contains(ROW_FALLBACK),
+        "row-fallback line emitted; columnar join path skipped:\n{joined}"
+    );
+    assert!(
+        logs.iter().any(|l| l.contains(COLUMNAR_JOIN_SUCCEEDED)),
+        "expected columnar join GROUP BY to run:\n{joined}"
+    );
+}
+
+/// `l(k, a, v)` fact table joined to `r(k, d)` dim table on `k`.
+fn setup_inner(db: &mut Database, n: i64) {
+    execute_sql(db, "CREATE TABLE l (k INTEGER, a INTEGER, v INTEGER)");
+    execute_sql(db, "CREATE TABLE r (k INTEGER, d INTEGER)");
+    let mut ins = String::new();
+    for i in 0..n {
+        let k = i % 4;
+        let a = i % 3;
+        let v = (i % 17) + 1;
+        ins.push_str(&format!("INSERT INTO l VALUES ({k}, {a}, {v});"));
+    }
+    for k in 0..4 {
+        ins.push_str(&format!("INSERT INTO r VALUES ({k}, {});", k * 10));
+    }
+    execute_sql(db, &ins);
+}
+
+const SPELLINGS: [&str; 6] =
+    ["STDDEV", "STDDEV_SAMP", "STDDEV_POP", "VARIANCE", "VAR_SAMP", "VAR_POP"];
+
+#[test]
+fn join_group_by_stddev_variance_all_spellings_match_row_path() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    init_logger();
+    let mut db = Database::new();
+    setup_inner(&mut db, 800);
+
+    for f in SPELLINGS {
+        let sql = format!("SELECT l.a, {f}(l.v) FROM l JOIN r ON l.k = r.k GROUP BY l.a");
+        let (columnar, row, logs) = run_both(&db, &sql);
+        assert_columnar_join_ran(&logs);
+        assert_rows_close(&columnar, &row, &sql);
+    }
+}
+
+#[test]
+fn join_group_by_mixed_aggregates_match_row_path() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    init_logger();
+    let mut db = Database::new();
+    setup_inner(&mut db, 800);
+
+    // A SUM/COUNT alongside a statistical aggregate must all run columnar.
+    let sql = "SELECT l.a, SUM(l.v), VAR_POP(l.v), STDDEV_SAMP(l.v), COUNT(*) \
+               FROM l JOIN r ON l.k = r.k GROUP BY l.a";
+    let (columnar, row, logs) = run_both(&db, sql);
+    assert_columnar_join_ran(&logs);
+    assert_rows_close(&columnar, &row, sql);
+}
+
+#[test]
+fn join_group_by_stddev_variance_null_values_match_row_path() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    init_logger();
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE l (k INTEGER, a INTEGER, v INTEGER)");
+    execute_sql(&mut db, "CREATE TABLE r (k INTEGER, d INTEGER)");
+    let mut ins = String::new();
+    for i in 0..500i64 {
+        let k = i % 3;
+        let a = i % 4;
+        if i % 6 == 0 {
+            ins.push_str(&format!("INSERT INTO l VALUES ({k}, {a}, NULL);"));
+        } else {
+            ins.push_str(&format!("INSERT INTO l VALUES ({k}, {a}, {});", (i % 13) + 1));
+        }
+    }
+    for k in 0..3 {
+        ins.push_str(&format!("INSERT INTO r VALUES ({k}, {});", k));
+    }
+    execute_sql(&mut db, &ins);
+
+    let sql = "SELECT l.a, VAR_POP(l.v), STDDEV_SAMP(l.v) FROM l JOIN r ON l.k = r.k GROUP BY l.a";
+    let (columnar, row, logs) = run_both(&db, sql);
+    assert_columnar_join_ran(&logs);
+    assert_rows_close(&columnar, &row, sql);
+}

--- a/crates/vibesql-executor/tests/columnar_stddev_variance_path_assertion_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_stddev_variance_path_assertion_tests.rs
@@ -1,0 +1,299 @@
+//! Path-assertion + parity tests for issue #6012: STDDEV / VARIANCE aggregates
+//! on the native columnar path.
+//!
+//! Coverage:
+//!   - The native columnar path (not row fallback) is taken for flat
+//!     `STDDEV/VARIANCE`, a mixed SELECT list combining `SUM/AVG` with a
+//!     statistical aggregate (proves the whole-query drop is gone), and
+//!     `GROUP BY` with a statistical aggregate.
+//!   - Result parity vs the row path (`VIBESQL_DISABLE_COLUMNAR=1`) for all six
+//!     spellings, within a float epsilon.
+//!
+//! Wall-clock timing is NOT used (the machine is loaded). We capture `log`
+//! output and assert the positive marker "Native columnar execution completed"
+//! appears and the row-fallback marker does NOT. Every test acquires the
+//! `SERIAL` mutex (PR #6006 pattern) because `VIBESQL_DISABLE_COLUMNAR` and the
+//! log buffer are process-global.
+
+use std::sync::{Mutex, OnceLock};
+
+use log::{Level, LevelFilter, Log, Metadata, Record};
+use vibesql_executor::{CreateTableExecutor, InsertExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+struct CaptureLogger;
+
+static LOG_BUFFER: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+fn buffer() -> &'static Mutex<Vec<String>> {
+    LOG_BUFFER.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+impl Log for CaptureLogger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
+    fn log(&self, record: &Record) {
+        if record.level() <= Level::Debug {
+            buffer().lock().unwrap().push(format!("{}", record.args()));
+        }
+    }
+    fn flush(&self) {}
+}
+
+static LOGGER: CaptureLogger = CaptureLogger;
+
+fn init_logger() {
+    let _ = log::set_logger(&LOGGER);
+    log::set_max_level(LevelFilter::Debug);
+}
+
+fn take_logs() -> Vec<String> {
+    std::mem::take(&mut *buffer().lock().unwrap())
+}
+
+/// Serializes every test in this binary: `VIBESQL_DISABLE_COLUMNAR` and the log
+/// capture buffer are both process-global. PR #6006 pattern.
+static SERIAL: Mutex<()> = Mutex::new(());
+
+/// Row-fallback marker (single-table path): the columnar runtime declined.
+const ROW_FALLBACK: &str = "Standard columnar runtime fallback to row-oriented";
+/// Positive marker emitted only when the native columnar path completes.
+const COLUMNAR_COMPLETED: &str = "Native columnar execution completed";
+
+fn execute_sql(db: &mut Database, sql: &str) {
+    for sql_stmt in sql.split(';') {
+        let trimmed = sql_stmt.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
+        match stmt {
+            vibesql_ast::Statement::CreateTable(s) => {
+                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+            }
+            vibesql_ast::Statement::Insert(s) => {
+                InsertExecutor::execute(db, &s).expect("INSERT failed");
+            }
+            other => panic!("Unsupported statement type: {:?}", other),
+        }
+    }
+}
+
+fn run_select(db: &Database, sql: &str) -> Vec<vibesql_storage::Row> {
+    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        vibesql_executor::SelectExecutor::new(db).execute(&select_stmt).expect("SELECT failed")
+    } else {
+        panic!("Expected SELECT");
+    }
+}
+
+/// Coerce a numeric SqlValue to f64 for epsilon comparison; NULL → None.
+fn as_f64(v: &SqlValue) -> Option<f64> {
+    match v {
+        SqlValue::Null => None,
+        SqlValue::Integer(x) => Some(*x as f64),
+        SqlValue::Bigint(x) => Some(*x as f64),
+        SqlValue::Smallint(x) => Some(*x as f64),
+        SqlValue::Double(x) => Some(*x),
+        SqlValue::Float(x) => Some(*x as f64),
+        SqlValue::Real(x) => Some(*x),
+        SqlValue::Numeric(x) => Some(*x),
+        other => panic!("non-numeric aggregate result: {other:?}"),
+    }
+}
+
+/// Compare two row sets in emitted order, cell by cell, with a float epsilon for
+/// numeric cells (statistical aggregates are REAL, so exact equality is brittle).
+fn assert_rows_close_in_order(
+    columnar: &[vibesql_storage::Row],
+    row: &[vibesql_storage::Row],
+    ctx: &str,
+) {
+    assert_eq!(
+        columnar.len(),
+        row.len(),
+        "row count differs for {ctx}: columnar={} row={}",
+        columnar.len(),
+        row.len()
+    );
+    for (i, (c, r)) in columnar.iter().zip(row.iter()).enumerate() {
+        assert_eq!(c.values.len(), r.values.len(), "column count differs at row {i} for {ctx}");
+        for (j, (cv, rv)) in c.values.iter().zip(r.values.iter()).enumerate() {
+            match (as_f64(cv), as_f64(rv)) {
+                (Some(a), Some(b)) => {
+                    let tol = 1e-9 * (1.0 + a.abs().max(b.abs()));
+                    assert!(
+                        (a - b).abs() <= tol,
+                        "row {i} col {j} numeric mismatch for {ctx}: columnar={a} row={b}"
+                    );
+                }
+                (None, None) => {} // both NULL — OK
+                _ => {
+                    assert_eq!(
+                        cv, rv,
+                        "row {i} col {j} mismatch for {ctx}: columnar={cv:?} row={rv:?}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Run `sql` on the columnar path (asserting it is taken) and on the row path,
+/// then assert epsilon parity. Returns the columnar rows for extra checks.
+fn columnar_matches_row(db: &Database, sql: &str) -> Vec<vibesql_storage::Row> {
+    let _ = take_logs(); // discard prior logs
+
+    let columnar = run_select(db, sql);
+    let logs = take_logs();
+    let joined = logs.join("\n");
+
+    assert!(
+        !joined.contains(ROW_FALLBACK),
+        "row-fallback marker emitted for `{sql}`; columnar path was skipped:\n{joined}"
+    );
+    assert!(
+        logs.iter().any(|l| l.contains(COLUMNAR_COMPLETED)),
+        "expected native columnar execution to run for `{sql}`:\n{joined}"
+    );
+
+    std::env::set_var("VIBESQL_DISABLE_COLUMNAR", "1");
+    let row = run_select(db, sql);
+    std::env::remove_var("VIBESQL_DISABLE_COLUMNAR");
+
+    assert_rows_close_in_order(&columnar, &row, sql);
+    columnar
+}
+
+/// Populate `t(g INTEGER, v INTEGER, r DOUBLE)` with `n` rows. `g` is a
+/// low-cardinality group key, `v`/`r` are aggregated measures.
+fn setup(db: &mut Database, n: i64) {
+    execute_sql(db, "CREATE TABLE t (g INTEGER, v INTEGER, r DOUBLE)");
+    let mut ins = String::new();
+    for i in 0..n {
+        let g = i % 5;
+        let v = (i % 17) + 1;
+        let r = (i as f64 % 13.0) * 1.5 + 0.25;
+        ins.push_str(&format!("INSERT INTO t VALUES ({g}, {v}, {r});"));
+    }
+    execute_sql(db, &ins);
+}
+
+const SPELLINGS: [&str; 6] =
+    ["STDDEV", "STDDEV_SAMP", "STDDEV_POP", "VARIANCE", "VAR_SAMP", "VAR_POP"];
+
+#[test]
+fn flat_stddev_variance_all_spellings_columnar_parity() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    init_logger();
+    let mut db = Database::new();
+    setup(&mut db, 600);
+    for f in SPELLINGS {
+        columnar_matches_row(&db, &format!("SELECT {f}(v) FROM t"));
+        columnar_matches_row(&db, &format!("SELECT {f}(r) FROM t"));
+    }
+}
+
+#[test]
+fn mixed_select_list_removes_whole_query_drop() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    init_logger();
+    let mut db = Database::new();
+    setup(&mut db, 600);
+    // A SELECT list combining supported aggregates with a statistical aggregate
+    // must take the columnar path as a whole (no fallback for the entire query).
+    columnar_matches_row(&db, "SELECT SUM(v), AVG(v), STDDEV(v), VAR_POP(v), COUNT(*) FROM t");
+}
+
+#[test]
+fn group_by_stddev_variance_all_spellings_columnar_parity() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    init_logger();
+    let mut db = Database::new();
+    setup(&mut db, 900);
+    for f in SPELLINGS {
+        columnar_matches_row(&db, &format!("SELECT g, {f}(v) FROM t GROUP BY g ORDER BY g"));
+    }
+}
+
+#[test]
+fn group_by_mixed_aggregates_columnar_parity() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    init_logger();
+    let mut db = Database::new();
+    setup(&mut db, 900);
+    columnar_matches_row(
+        &db,
+        "SELECT g, SUM(v), STDDEV_SAMP(v), VAR_POP(r) FROM t GROUP BY g ORDER BY g",
+    );
+}
+
+#[test]
+fn stddev_variance_with_where_filter_columnar_parity() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    init_logger();
+    let mut db = Database::new();
+    setup(&mut db, 600);
+    // WHERE filtering must apply before the statistical aggregate.
+    columnar_matches_row(&db, "SELECT VAR_POP(v), STDDEV_POP(v) FROM t WHERE v > 5");
+}
+
+#[test]
+fn stddev_variance_single_value_group_edge_cases() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    init_logger();
+    let mut db = Database::new();
+    // Each group has exactly one row: sample variants → NULL, population → 0.0.
+    execute_sql(&mut db, "CREATE TABLE s (g INTEGER, v INTEGER)");
+    execute_sql(&mut db, "INSERT INTO s VALUES (1, 10), (2, 20), (3, 30)");
+    columnar_matches_row(
+        &db,
+        "SELECT g, VAR_SAMP(v), VAR_POP(v), STDDEV_SAMP(v), STDDEV_POP(v) \
+         FROM s GROUP BY g ORDER BY g",
+    );
+}
+
+#[test]
+fn stddev_variance_null_handling_columnar_parity() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    init_logger();
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE nn (g INTEGER, v INTEGER)");
+    let mut ins = String::new();
+    for i in 0..400i64 {
+        let g = i % 4;
+        if i % 5 == 0 {
+            ins.push_str(&format!("INSERT INTO nn VALUES ({g}, NULL);"));
+        } else {
+            ins.push_str(&format!("INSERT INTO nn VALUES ({g}, {});", (i % 11) + 1));
+        }
+    }
+    execute_sql(&mut db, &ins);
+    // NULLs skipped; result parity per group across all spellings.
+    columnar_matches_row(
+        &db,
+        "SELECT g, VAR_POP(v), STDDEV_SAMP(v), VARIANCE(v) FROM nn GROUP BY g ORDER BY g",
+    );
+}
+
+/// Numerical stability: a near-constant, large-magnitude column must not diverge
+/// from the row path (guards against naive sum-of-squares cancellation).
+#[test]
+fn stddev_variance_large_magnitude_stability() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    init_logger();
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE big (v DOUBLE)");
+    let mut ins = String::new();
+    for i in 0..500i64 {
+        // Values clustered tightly around 1e9.
+        let v = 1.0e9 + (i % 7) as f64 * 0.5;
+        ins.push_str(&format!("INSERT INTO big VALUES ({v});"));
+    }
+    execute_sql(&mut db, &ins);
+    columnar_matches_row(&db, "SELECT VAR_POP(v), STDDEV_POP(v), VAR_SAMP(v) FROM big");
+}

--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -1318,6 +1318,12 @@ impl<'arena> ArenaParser<'arena> {
                 | "PERCENTILE"
                 | "PERCENTILE_CONT"
                 | "PERCENTILE_DISC"
+                | "STDDEV"
+                | "STDDEV_SAMP"
+                | "STDDEV_POP"
+                | "VARIANCE"
+                | "VAR_SAMP"
+                | "VAR_POP"
         );
 
         if might_be_aggregate {
@@ -1399,6 +1405,10 @@ impl<'arena> ArenaParser<'arena> {
             // GROUP_CONCAT accepts 1 or 2 arguments (expr, separator)
             let is_aggregate = match name_upper.as_str() {
                 "COUNT" | "SUM" | "AVG" | "TOTAL" => true,
+                // STDDEV / VARIANCE statistical aggregates (all six SQL spellings).
+                "STDDEV" | "STDDEV_SAMP" | "STDDEV_POP" | "VARIANCE" | "VAR_SAMP" | "VAR_POP" => {
+                    true
+                }
                 "GROUP_CONCAT" | "STRING_AGG" => args.len() <= 2, // 1 or 2 args
                 // percentile.c family - arg counts validated by the executor
                 "MEDIAN" | "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC" => true,

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -165,6 +165,12 @@ impl Parser {
                 | "PERCENTILE"
                 | "PERCENTILE_CONT"
                 | "PERCENTILE_DISC"
+                | "STDDEV"
+                | "STDDEV_SAMP"
+                | "STDDEV_POP"
+                | "VARIANCE"
+                | "VAR_SAMP"
+                | "VAR_POP"
         );
 
         // Parse optional DISTINCT or ALL for potential aggregate functions
@@ -471,6 +477,8 @@ impl Parser {
         // GROUP_CONCAT accepts 1 or 2 arguments (expr, separator)
         let is_aggregate = match function_name_upper.as_str() {
             "COUNT" | "SUM" | "AVG" | "TOTAL" => true,
+            // STDDEV / VARIANCE statistical aggregates (all six SQL spellings).
+            "STDDEV" | "STDDEV_SAMP" | "STDDEV_POP" | "VARIANCE" | "VAR_SAMP" | "VAR_POP" => true,
             "GROUP_CONCAT" | "STRING_AGG" => args.len() <= 2, // 1 or 2 args
             "JSON_GROUP_ARRAY" => true,                       // JSON aggregate function
             // percentile.c family - arg counts validated by the executor so


### PR DESCRIPTION
## Summary

Implements the STDDEV / VARIANCE aggregate family end-to-end. Verified against `main`, these functions did not previously exist anywhere in VibeSQL — `SELECT STDDEV(x) ...` returned `no such function: STDDEV`. This PR adds them on both the row-at-a-time path and the vectorized columnar path, with the two agreeing bit-for-bit (shared Welford kernel).

All six SQL spellings: `STDDEV`, `STDDEV_SAMP`, `STDDEV_POP`, `VARIANCE`, `VAR_SAMP`, `VAR_POP`. Bare `STDDEV`/`VARIANCE` default to the **sample** estimator (n-1), matching PostgreSQL/MySQL/Oracle; only `*_POP` uses the population estimator (n). This default is decided once in the row-path accumulator and the columnar path is required to match it.

## Changes

- **Row path** (`grouping/aggregates.rs`): new `AggregateAccumulator::Variance` variant using Welford's online algorithm (numerically stable vs naive sum-of-squares), a Chan-parallel `combine()` merge, and DISTINCT dedup. Shared `welford_update` / `welford_finalize` helpers exported for the columnar path.
- **Columnar path**: `Variance { sample }` / `StdDev { sample }` added to `AggregateOp`; routed through the shared Welford kernel in `aggregate/functions.rs`, per-group `aggregate/group_by.rs`, and `executor/aggregate.rs`. The SIMD kernels (`simd_aggregate.rs`) deliberately decline these ops (Welford is inherently serial) and the scalar dispatcher never sends them to SIMD — documented, not a silent no-op. All other exhaustive `match op` sites across the columnar executor got explicit arms (compiler-enforced).
- **Whole-query drop removed**: a mixed SELECT list combining `SUM`/`AVG` with `STDDEV`/`VARIANCE` now stays fully on the columnar path instead of dropping the entire query to the row path.
- **Parser + aggregate-name recognition** (`arena_parser/expression.rs`, `parser/expressions/functions/mod.rs`, `aggregation/detection.rs`, `aggregation/evaluation/function.rs`, `validation/aggregates.rs`): the six spellings are recognized as aggregate functions.

## Semantics (documented in the row-path doc comment)

- NULL / non-numeric inputs are skipped (do not affect `n`), same as AVG.
- Result is NULL when `n == 0`; sample variants are additionally NULL when `n < 2`; population variants yield `0.0` at `n == 1`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Row path implements all six spellings + unit tests (NULL, count<2, single-value, all-NULL) | ✅ | 9 unit tests in `grouping/aggregates.rs`, all pass |
| Debug-log assertion columnar path taken (flat, mixed SELECT, GROUP BY) | ✅ | `columnar_stddev_variance_path_assertion_tests.rs` asserts the `Native columnar execution completed` marker and absence of the row-fallback marker |
| Result parity vs row path for all six spellings (epsilon) | ✅ | Parity tests toggle `VIBESQL_DISABLE_COLUMNAR=1`; single-table + join |
| NULL / cardinality parity (all-NULL, single-value, count-0, mixed) | ✅ | Dedicated tests; single-value group → pop 0.0 / sample NULL |
| Numerical stability (large-magnitude / near-constant) | ✅ | `stddev_variance_large_magnitude_stability` (values ~1e9) + row-path shift-invariance test |
| Type affinity (int / real / numeric) | ✅ | `test_variance_real_and_mixed_numeric_inputs`; columnar Int64/Int32/Float64/Float32/Mixed arms |
| SERIAL-mutex pattern (PR #6006) | ✅ | Both integration test files acquire a `SERIAL` mutex |
| Join path parity (`VIBESQL_DISABLE_COLUMNAR_JOIN=1`) | ✅ | `columnar_join_stddev_variance_tests.rs` |

Values validated against Python's `statistics` module (stock sqlite3 lacks stddev): reference set `{2,4,4,4,5,5,7,9}` → VAR_POP `4.0`, VAR_SAMP `32/7`, STDDEV_POP `2.0`, STDDEV_SAMP `√(32/7)`.

## TPC-DS Q17/Q36/Q86 note

The `sqlite_should_skip` / `SQLITE_SKIP_QUERIES` lists in `benches/tpcds_benchmark.rs` and `benches/tpcds/queries.rs` are **SQLite-comparison-engine** skip lists (SQLite genuinely lacks `STDDEV_SAMP`, and Q36/Q86 additionally use ROLLUP/GROUPING). The VibeSQL bench loop already runs every query unconditionally, so no un-skipping is required for VibeSQL. Q17's `STDDEV_SAMP` now parses and executes on VibeSQL (verified manually via the CLI); Q36/Q86 remain blocked on the unrelated ROLLUP/CUBE/GROUPING gap. The skip lists were left unchanged because removing Q17 would break the SQLite comparison run (SQLite still has no STDDEV).

## Test Plan

- `cargo test -p vibesql-executor --lib` → 3365 passed, 0 failed
- `cargo test -p vibesql-executor --tests` → 30 integration binaries, 0 failed (incl. the 11 new STDDEV/VARIANCE parity + path-assertion tests)
- `cargo test -p vibesql-parser` (+ `--lib`) → all pass
- `cargo clippy -p vibesql-executor -p vibesql-parser` → no errors, no new warnings in added code
- Manual CLI verification of flat, GROUP BY, single-value, and all-NULL cases; results match Python `statistics`.

No wall-clock timing tests (loaded-machine guidance).

Closes #6012