### PR TITLE
refactor(tests): extract columnar path-assertion log-capture harness to tests/common

### DIFF
--- a/crates/vibesql-executor/tests/columnar_computed_predicate_path_assertion_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_computed_predicate_path_assertion_tests.rs
@@ -16,83 +16,11 @@
 //! This test installs a process-global `log` logger, so it lives in its own
 //! test binary to avoid clashing with other integration tests.
 
-use std::sync::{Mutex, OnceLock};
-
-use log::{Level, LevelFilter, Log, Metadata, Record};
-use vibesql_executor::{CreateTableExecutor, InsertExecutor};
-use vibesql_parser::Parser;
+use log::Level;
 use vibesql_storage::Database;
 
-struct CaptureLogger;
-
-static LOG_BUFFER: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
-
-fn buffer() -> &'static Mutex<Vec<String>> {
-    LOG_BUFFER.get_or_init(|| Mutex::new(Vec::new()))
-}
-
-impl Log for CaptureLogger {
-    fn enabled(&self, _metadata: &Metadata) -> bool {
-        true
-    }
-    fn log(&self, record: &Record) {
-        if record.level() <= Level::Info {
-            buffer().lock().unwrap().push(format!("{}", record.args()));
-        }
-    }
-    fn flush(&self) {}
-}
-
-static LOGGER: CaptureLogger = CaptureLogger;
-
-fn init_logger() {
-    let _ = log::set_logger(&LOGGER);
-    log::set_max_level(LevelFilter::Debug);
-}
-
-fn take_logs() -> Vec<String> {
-    std::mem::take(&mut *buffer().lock().unwrap())
-}
-
-/// Serializes every test in this binary. `VIBESQL_DISABLE_COLUMNAR` is a
-/// process-global env var and the `log` capture buffer is process-global, so
-/// concurrent tests would otherwise race: one test toggling
-/// `VIBESQL_DISABLE_COLUMNAR=1` for its row-path parity run could silently
-/// disable columnar in another test's columnar run (failing that test's path
-/// assertion), and their captured logs would interleave. Every test here either
-/// toggles the env var or reads the shared buffer, so each acquires this mutex
-/// for its whole body to keep its columnar run, row-path run, and captured logs
-/// isolated. Poisoned-lock recovery (`unwrap_or_else(|e| e.into_inner())`) keeps
-/// a panic in one test from cascading into spurious failures in the rest.
-static SERIAL: Mutex<()> = Mutex::new(());
-
-fn execute_sql(db: &mut Database, sql: &str) {
-    for sql_stmt in sql.split(';') {
-        let trimmed = sql_stmt.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
-        match stmt {
-            vibesql_ast::Statement::CreateTable(s) => {
-                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
-            }
-            vibesql_ast::Statement::Insert(s) => {
-                InsertExecutor::execute(db, &s).expect("INSERT failed");
-            }
-            other => panic!("Unsupported statement type: {:?}", other),
-        }
-    }
-}
-
-fn run_select(db: &Database, sql: &str) -> Vec<vibesql_storage::Row> {
-    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
-    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
-        vibesql_executor::SelectExecutor::new(db).execute(&select_stmt).expect("SELECT failed")
-    } else {
-        panic!("Expected SELECT");
-    }
-}
+mod common;
+use common::{execute_sql, init_logger, run_select, take_logs, SERIAL};
 
 /// Row-fallback marker: the WHERE clause could not be represented columnarly.
 const ROW_FALLBACK: &str = "WHERE clause contains unsupported predicates";
@@ -126,7 +54,7 @@ fn sum_result(rows: &[vibesql_storage::Row]) -> i64 {
 #[test]
 fn computed_predicate_mul_takes_columnar_path_and_matches_row_path() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Info);
 
     // Enough rows (>256) to exercise the SIMD streaming filter path.
     let mut db = Database::new();
@@ -163,7 +91,7 @@ fn computed_predicate_mul_takes_columnar_path_and_matches_row_path() {
 #[test]
 fn computed_predicate_sub_le_column_matches_row_path() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Info);
 
     let mut db = Database::new();
     setup(&mut db, 800);
@@ -197,7 +125,7 @@ fn computed_predicate_sub_le_column_matches_row_path() {
 #[test]
 fn computed_predicate_null_propagation_matches_row_path() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Info);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE u (a INTEGER, b INTEGER)");

--- a/crates/vibesql-executor/tests/columnar_group_by_expression_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_group_by_expression_tests.rs
@@ -26,83 +26,12 @@
 //! This test installs a process-global `log` logger, so it lives in its own
 //! test binary to avoid clashing with other integration tests.
 
-use std::sync::{Mutex, OnceLock};
-
-use log::{Level, LevelFilter, Log, Metadata, Record};
-use vibesql_executor::{CreateTableExecutor, InsertExecutor};
-use vibesql_parser::Parser;
+use log::Level;
 use vibesql_storage::Database;
 use vibesql_types::SqlValue;
 
-struct CaptureLogger;
-
-static LOG_BUFFER: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
-
-fn buffer() -> &'static Mutex<Vec<String>> {
-    LOG_BUFFER.get_or_init(|| Mutex::new(Vec::new()))
-}
-
-impl Log for CaptureLogger {
-    fn enabled(&self, _metadata: &Metadata) -> bool {
-        true
-    }
-    fn log(&self, record: &Record) {
-        // Capture Debug and above: the row-fallback marker is a debug! line.
-        if record.level() <= Level::Debug {
-            buffer().lock().unwrap().push(format!("{}", record.args()));
-        }
-    }
-    fn flush(&self) {}
-}
-
-static LOGGER: CaptureLogger = CaptureLogger;
-
-fn init_logger() {
-    let _ = log::set_logger(&LOGGER);
-    log::set_max_level(LevelFilter::Debug);
-}
-
-fn take_logs() -> Vec<String> {
-    std::mem::take(&mut *buffer().lock().unwrap())
-}
-
-/// Serializes the columnar-vs-row runs across tests. `VIBESQL_DISABLE_COLUMNAR`
-/// is a process-global env var and the `log` capture buffer is process-global,
-/// so concurrent tests would otherwise race (one test's row-path env var could
-/// disable columnar in another test's columnar run, and their logs would
-/// interleave). Holding this mutex for the whole `run_both` keeps each test's
-/// two runs and their captured logs isolated.
-static SERIAL: Mutex<()> = Mutex::new(());
-
-fn execute_sql(db: &mut Database, sql: &str) {
-    for sql_stmt in sql.split(';') {
-        let trimmed = sql_stmt.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
-        match stmt {
-            vibesql_ast::Statement::CreateTable(s) => {
-                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
-            }
-            vibesql_ast::Statement::Insert(s) => {
-                InsertExecutor::execute(db, &s).expect("INSERT failed");
-            }
-            other => panic!("Unsupported statement type: {:?}", other),
-        }
-    }
-}
-
-fn run_select(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
-    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
-    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
-        let rows =
-            vibesql_executor::SelectExecutor::new(db).execute(&select_stmt).expect("SELECT failed");
-        rows.into_iter().map(|r| r.values.to_vec()).collect()
-    } else {
-        panic!("Expected SELECT");
-    }
-}
+mod common;
+use common::{execute_sql, init_logger, run_select_values as run_select, take_logs, SERIAL};
 
 /// Run the same query on both the columnar path and the row path
 /// (`VIBESQL_DISABLE_COLUMNAR=1`) and return `(columnar_rows, row_rows, logs)`.
@@ -154,7 +83,7 @@ fn setup(db: &mut Database, n: i64) {
 /// the row path exactly. Runs both sides of the SIMD row threshold (256).
 #[test]
 fn group_by_sum_expression_takes_columnar_path_and_matches_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     for n in [50i64, 1000i64] {
         let mut db = Database::new();
@@ -172,7 +101,7 @@ fn group_by_sum_expression_takes_columnar_path_and_matches_row_path() {
 /// columnar and matches the row path.
 #[test]
 fn group_by_product_count_matches_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     setup(&mut db, 800);
@@ -189,7 +118,7 @@ fn group_by_product_count_matches_row_path() {
 /// the row path.
 #[test]
 fn group_by_expression_null_keys_match_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE u (a INTEGER, b INTEGER, c INTEGER)");
@@ -221,7 +150,7 @@ fn group_by_expression_null_keys_match_row_path() {
 /// so grouping is identical by construction. This asserts that parity holds.
 #[test]
 fn group_by_expression_overflow_keys_match_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE o (a BIGINT, b BIGINT, c INTEGER)");
@@ -253,7 +182,7 @@ fn group_by_expression_overflow_keys_match_row_path() {
 /// as the row path.
 #[test]
 fn group_by_expression_empty_table_matches_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE e (a INTEGER, b INTEGER, c INTEGER)");
@@ -269,7 +198,7 @@ fn group_by_expression_empty_table_matches_row_path() {
 /// (`GROUP BY a, b + c`) still runs columnar and matches the row path.
 #[test]
 fn group_by_mixed_column_and_expression_keys_match_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     setup(&mut db, 600);
@@ -311,7 +240,7 @@ fn assert_row_path_via_positional_decline(logs: &[String]) {
 /// We assert both the decline (via log) AND parity with `VIBESQL_DISABLE_COLUMNAR=1`.
 #[test]
 fn group_by_permuted_expression_keys_match_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     setup(&mut db, 1000);
@@ -337,7 +266,7 @@ fn group_by_permuted_expression_keys_match_row_path() {
 /// path. We assert the decline AND parity.
 #[test]
 fn group_by_permuted_bare_column_keys_match_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     setup(&mut db, 1000);
@@ -358,7 +287,7 @@ fn group_by_permuted_bare_column_keys_match_row_path() {
 /// equals GROUP BY key order, so it stays columnar and matches the row path.
 #[test]
 fn group_by_aligned_multi_expression_keys_stay_columnar() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     setup(&mut db, 1000);
@@ -378,7 +307,7 @@ fn group_by_aligned_multi_expression_keys_stay_columnar() {
 /// the row path (no silent wrong answer), and the fallback marker is emitted.
 #[test]
 fn group_by_unsupported_expression_falls_back() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE s (a INTEGER, b TEXT, c INTEGER)");

--- a/crates/vibesql-executor/tests/columnar_group_by_order_by_path_assertion_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_group_by_order_by_path_assertion_tests.rs
@@ -17,83 +17,16 @@
 //! binary. Every test acquires the `SERIAL` mutex (PR #6006 pattern) because
 //! `VIBESQL_DISABLE_COLUMNAR` and the log buffer are process-global.
 
-use std::sync::{Mutex, OnceLock};
-
-use log::{Level, LevelFilter, Log, Metadata, Record};
-use vibesql_executor::{CreateTableExecutor, InsertExecutor};
-use vibesql_parser::Parser;
+use log::Level;
 use vibesql_storage::Database;
 
-struct CaptureLogger;
-
-static LOG_BUFFER: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
-
-fn buffer() -> &'static Mutex<Vec<String>> {
-    LOG_BUFFER.get_or_init(|| Mutex::new(Vec::new()))
-}
-
-impl Log for CaptureLogger {
-    fn enabled(&self, _metadata: &Metadata) -> bool {
-        true
-    }
-    fn log(&self, record: &Record) {
-        if record.level() <= Level::Debug {
-            buffer().lock().unwrap().push(format!("{}", record.args()));
-        }
-    }
-    fn flush(&self) {}
-}
-
-static LOGGER: CaptureLogger = CaptureLogger;
-
-fn init_logger() {
-    let _ = log::set_logger(&LOGGER);
-    log::set_max_level(LevelFilter::Debug);
-}
-
-fn take_logs() -> Vec<String> {
-    std::mem::take(&mut *buffer().lock().unwrap())
-}
-
-/// Serializes every test in this binary: `VIBESQL_DISABLE_COLUMNAR` and the log
-/// capture buffer are both process-global, so concurrent tests would race
-/// (one test's row-path toggle could disable columnar in another's columnar
-/// run; captured logs would interleave). PR #6006 pattern. Poisoned-lock
-/// recovery keeps one panicking test from cascading failures.
-static SERIAL: Mutex<()> = Mutex::new(());
+mod common;
+use common::{execute_sql, init_logger, run_select, take_logs, SERIAL};
 
 /// Row-fallback marker (single-table path): the columnar runtime declined.
 const ROW_FALLBACK: &str = "Standard columnar runtime fallback to row-oriented";
 /// Positive marker emitted only when the native columnar path completes.
 const COLUMNAR_COMPLETED: &str = "Native columnar execution completed";
-
-fn execute_sql(db: &mut Database, sql: &str) {
-    for sql_stmt in sql.split(';') {
-        let trimmed = sql_stmt.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
-        match stmt {
-            vibesql_ast::Statement::CreateTable(s) => {
-                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
-            }
-            vibesql_ast::Statement::Insert(s) => {
-                InsertExecutor::execute(db, &s).expect("INSERT failed");
-            }
-            other => panic!("Unsupported statement type: {:?}", other),
-        }
-    }
-}
-
-fn run_select(db: &Database, sql: &str) -> Vec<vibesql_storage::Row> {
-    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
-    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
-        vibesql_executor::SelectExecutor::new(db).execute(&select_stmt).expect("SELECT failed")
-    } else {
-        panic!("Expected SELECT");
-    }
-}
 
 /// Compare two row sets in EMITTED ORDER (no sorting either side).
 fn assert_rows_eq_in_order(
@@ -160,7 +93,7 @@ fn setup(db: &mut Database, n: i64) {
 #[test]
 fn group_by_order_by_bare_key_asc() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     setup(&mut db, 600);
     columnar_matches_row_ordered(&db, "SELECT a, SUM(v) FROM t GROUP BY a ORDER BY a");
@@ -169,7 +102,7 @@ fn group_by_order_by_bare_key_asc() {
 #[test]
 fn group_by_order_by_bare_key_desc() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     setup(&mut db, 600);
     columnar_matches_row_ordered(&db, "SELECT a, SUM(v) FROM t GROUP BY a ORDER BY a DESC");
@@ -178,7 +111,7 @@ fn group_by_order_by_bare_key_desc() {
 #[test]
 fn group_by_order_by_aggregate_desc() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     setup(&mut db, 600);
     // ORDER BY an aggregate that appears in the SELECT list.
@@ -188,7 +121,7 @@ fn group_by_order_by_aggregate_desc() {
 #[test]
 fn group_by_order_by_ordinal_position() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     setup(&mut db, 600);
     // ORDER BY 2 references the aggregate (second output column).
@@ -198,7 +131,7 @@ fn group_by_order_by_ordinal_position() {
 #[test]
 fn group_by_order_by_multi_key() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     setup(&mut db, 900);
     // Two group keys, multi-key ORDER BY with mixed direction.
@@ -211,7 +144,7 @@ fn group_by_order_by_multi_key() {
 #[test]
 fn group_by_order_by_derived_key_expression() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     setup(&mut db, 900);
     // Derived-key GROUP BY (#6001-style): ORDER BY must resolve to the derived
@@ -225,7 +158,7 @@ fn group_by_order_by_derived_key_expression() {
 #[test]
 fn group_by_having_then_order_by() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     setup(&mut db, 900);
     // HAVING filters groups, then ORDER BY sorts the survivors — verifies the
@@ -251,7 +184,7 @@ fn group_by_having_then_order_by() {
 #[test]
 fn group_by_order_by_null_keys_first_ascending() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE n (k INTEGER, v INTEGER)");
     let mut ins = String::new();
@@ -302,7 +235,7 @@ fn group_by_order_by_null_keys_first_ascending() {
 #[test]
 fn group_by_order_by_text_affinity_key() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE tx (k TEXT, v INTEGER)");
     let keys = ["banana", "apple", "cherry", "Apple", "10", "2"];
@@ -323,7 +256,7 @@ fn group_by_order_by_text_affinity_key() {
 #[test]
 fn group_by_order_by_unresolvable_term_falls_back_and_is_correct() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     setup(&mut db, 600);
     let _ = take_logs();

--- a/crates/vibesql-executor/tests/columnar_is_null_path_assertion_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_is_null_path_assertion_tests.rs
@@ -12,80 +12,18 @@
 //! This test installs a process-global `log` logger, so it lives in its own
 //! test binary to avoid clashing with other integration tests.
 
-use std::sync::{Mutex, OnceLock};
-
-use log::{Level, LevelFilter, Log, Metadata, Record};
-use vibesql_executor::{CreateTableExecutor, InsertExecutor};
-use vibesql_parser::Parser;
+use log::Level;
 use vibesql_storage::Database;
 
-/// Captures every log message into a shared buffer.
-struct CaptureLogger;
-
-static LOG_BUFFER: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
-
-fn buffer() -> &'static Mutex<Vec<String>> {
-    LOG_BUFFER.get_or_init(|| Mutex::new(Vec::new()))
-}
-
-impl Log for CaptureLogger {
-    fn enabled(&self, _metadata: &Metadata) -> bool {
-        true
-    }
-    fn log(&self, record: &Record) {
-        if record.level() <= Level::Info {
-            buffer().lock().unwrap().push(format!("{}", record.args()));
-        }
-    }
-    fn flush(&self) {}
-}
-
-static LOGGER: CaptureLogger = CaptureLogger;
-
-fn init_logger() {
-    // set_logger is idempotent across the binary; ignore "already set".
-    let _ = log::set_logger(&LOGGER);
-    log::set_max_level(LevelFilter::Debug);
-}
-
-fn take_logs() -> Vec<String> {
-    std::mem::take(&mut *buffer().lock().unwrap())
-}
-
-fn execute_sql(db: &mut Database, sql: &str) {
-    for sql_stmt in sql.split(';') {
-        let trimmed = sql_stmt.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
-        match stmt {
-            vibesql_ast::Statement::CreateTable(s) => {
-                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
-            }
-            vibesql_ast::Statement::Insert(s) => {
-                InsertExecutor::execute(db, &s).expect("INSERT failed");
-            }
-            other => panic!("Unsupported statement type: {:?}", other),
-        }
-    }
-}
-
-fn run_select(db: &Database, sql: &str) -> Vec<vibesql_storage::Row> {
-    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
-    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
-        vibesql_executor::SelectExecutor::new(db).execute(&select_stmt).expect("SELECT failed")
-    } else {
-        panic!("Expected SELECT");
-    }
-}
+mod common;
+use common::{execute_sql, init_logger, run_select, take_logs};
 
 /// The retired guardrail's fallback marker (must never appear post-#5993).
 const GUARDRAIL_FALLBACK: &str = "IS NULL/IS NOT NULL in WHERE, falling back";
 
 #[test]
 fn anti_join_is_null_takes_columnar_path() {
-    init_logger();
+    init_logger(Level::Info);
 
     // Left ids 1..=600; right matches even ids only. Large enough to exercise
     // the columnar join + SIMD filter path.

--- a/crates/vibesql-executor/tests/columnar_join_group_by_expression_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_join_group_by_expression_tests.rs
@@ -30,83 +30,12 @@
 //! This test installs a process-global `log` logger, so it lives in its own
 //! test binary to avoid clashing with other integration tests.
 
-use std::sync::{Mutex, OnceLock};
-
-use log::{Level, LevelFilter, Log, Metadata, Record};
-use vibesql_executor::{CreateTableExecutor, InsertExecutor};
-use vibesql_parser::Parser;
+use log::Level;
 use vibesql_storage::Database;
 use vibesql_types::SqlValue;
 
-struct CaptureLogger;
-
-static LOG_BUFFER: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
-
-fn buffer() -> &'static Mutex<Vec<String>> {
-    LOG_BUFFER.get_or_init(|| Mutex::new(Vec::new()))
-}
-
-impl Log for CaptureLogger {
-    fn enabled(&self, _metadata: &Metadata) -> bool {
-        true
-    }
-    fn log(&self, record: &Record) {
-        // Capture Debug and above (in `log`'s ordering Debug > Info, so
-        // `<= Level::Debug` includes Info): the row-fallback and positional-
-        // decline markers are `debug!` lines; the positive "succeeded" marker is
-        // an `info!` line.
-        if record.level() <= Level::Debug {
-            buffer().lock().unwrap().push(format!("{}", record.args()));
-        }
-    }
-    fn flush(&self) {}
-}
-
-static LOGGER: CaptureLogger = CaptureLogger;
-
-fn init_logger() {
-    let _ = log::set_logger(&LOGGER);
-    log::set_max_level(LevelFilter::Debug);
-}
-
-fn take_logs() -> Vec<String> {
-    std::mem::take(&mut *buffer().lock().unwrap())
-}
-
-/// Serializes the columnar-vs-row runs across tests. `VIBESQL_DISABLE_COLUMNAR_JOIN`
-/// is a process-global env var and the `log` capture buffer is process-global,
-/// so concurrent tests would otherwise race.
-static SERIAL: Mutex<()> = Mutex::new(());
-
-fn execute_sql(db: &mut Database, sql: &str) {
-    for sql_stmt in sql.split(';') {
-        let trimmed = sql_stmt.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
-        match stmt {
-            vibesql_ast::Statement::CreateTable(s) => {
-                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
-            }
-            vibesql_ast::Statement::Insert(s) => {
-                InsertExecutor::execute(db, &s).expect("INSERT failed");
-            }
-            other => panic!("Unsupported statement type: {:?}", other),
-        }
-    }
-}
-
-fn run_select(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
-    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
-    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
-        let rows =
-            vibesql_executor::SelectExecutor::new(db).execute(&select_stmt).expect("SELECT failed");
-        rows.into_iter().map(|r| r.values.to_vec()).collect()
-    } else {
-        panic!("Expected SELECT");
-    }
-}
+mod common;
+use common::{execute_sql, init_logger, run_select_values as run_select, take_logs, SERIAL};
 
 /// Run the same query on both the columnar-join path and the row path
 /// (`VIBESQL_DISABLE_COLUMNAR_JOIN=1`) and return `(columnar_rows, row_rows, logs)`.
@@ -192,7 +121,7 @@ fn setup_inner(db: &mut Database, n: i64) {
 /// the row path exactly. Runs both sides of the SIMD row threshold.
 #[test]
 fn join_group_by_sum_expression_takes_columnar_path_and_matches_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     for n in [50i64, 1000i64] {
         let mut db = Database::new();
@@ -210,7 +139,7 @@ fn join_group_by_sum_expression_takes_columnar_path_and_matches_row_path() {
 /// — also runs columnar and matches the row path.
 #[test]
 fn join_group_by_product_count_matches_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     setup_inner(&mut db, 800);
@@ -227,7 +156,7 @@ fn join_group_by_product_count_matches_row_path() {
 /// correctly. This exercises the qualified-name -> joined-batch-index resolution.
 #[test]
 fn join_group_by_cross_table_expression_matches_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     setup_inner(&mut db, 600);
@@ -248,7 +177,7 @@ fn join_group_by_cross_table_expression_matches_row_path() {
 /// case from the acceptance criteria.
 #[test]
 fn join_group_by_left_outer_null_keys_match_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE l (k INTEGER, a INTEGER, c INTEGER)");
@@ -282,7 +211,7 @@ fn join_group_by_left_outer_null_keys_match_row_path() {
 /// grouping is identical by construction. This asserts that parity holds.
 #[test]
 fn join_group_by_overflow_keys_match_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE l (k INTEGER, a BIGINT, b BIGINT, c INTEGER)");
@@ -310,7 +239,7 @@ fn join_group_by_overflow_keys_match_row_path() {
 /// GROUP BY on an expression key returns no groups, same as the row path.
 #[test]
 fn join_group_by_empty_result_matches_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE l (k INTEGER, a INTEGER, b INTEGER, c INTEGER)");
@@ -330,7 +259,7 @@ fn join_group_by_empty_result_matches_row_path() {
 /// row path.
 #[test]
 fn join_group_by_mixed_column_and_expression_keys_match_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     setup_inner(&mut db, 600);
@@ -370,7 +299,7 @@ fn assert_row_path_via_positional_decline(logs: &[String]) {
 /// path (`a*b, a+b`). The positional check declines to the row path.
 #[test]
 fn join_group_by_permuted_expression_keys_match_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     setup_inner(&mut db, 1000);
@@ -393,7 +322,7 @@ fn join_group_by_permuted_expression_keys_match_row_path() {
 /// columnar path. The positional check now declines it to the row path.
 #[test]
 fn join_group_by_permuted_bare_column_keys_match_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     setup_inner(&mut db, 1000);
@@ -412,7 +341,7 @@ fn join_group_by_permuted_bare_column_keys_match_row_path() {
 /// fast path (the positional-check must not over-decline aligned queries).
 #[test]
 fn join_group_by_aligned_multi_expression_keys_stay_columnar() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     setup_inner(&mut db, 1000);
@@ -432,7 +361,7 @@ fn join_group_by_aligned_multi_expression_keys_stay_columnar() {
 /// fall back to the row path (no silent wrong answer).
 #[test]
 fn join_group_by_unsupported_expression_falls_back() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE l (k INTEGER, a INTEGER, b TEXT, c INTEGER)");
@@ -477,7 +406,7 @@ fn join_group_by_unsupported_expression_falls_back() {
 /// HAVING COUNT(*) > 1 must exclude it. Compare WITHOUT sorting.
 #[test]
 fn join_group_by_having_aggregate_runs_columnar_and_matches_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE l (k INTEGER, a INTEGER, c INTEGER)");
@@ -506,7 +435,7 @@ fn join_group_by_having_aggregate_runs_columnar_and_matches_row_path() {
 /// columnar path and matches the row path.
 #[test]
 fn join_group_by_having_expression_key_runs_columnar_and_matches_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE l (k INTEGER, a INTEGER, c INTEGER)");
@@ -531,7 +460,7 @@ fn join_group_by_having_expression_key_runs_columnar_and_matches_row_path() {
 /// it). Result must still be correct. Compare WITHOUT sorting.
 #[test]
 fn join_group_by_having_bare_column_declines_and_matches_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE l (k INTEGER, a INTEGER, c INTEGER)");
@@ -564,7 +493,7 @@ fn join_group_by_having_bare_column_declines_and_matches_row_path() {
 /// (no sort by the harness).
 #[test]
 fn join_group_by_order_by_expression_key_runs_columnar_and_matches_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE l (k INTEGER, a INTEGER, c INTEGER)");
@@ -604,7 +533,7 @@ fn join_group_by_order_by_expression_key_runs_columnar_and_matches_row_path() {
 /// columnar and matches emitted order.
 #[test]
 fn join_group_by_order_by_bare_column_runs_columnar_and_matches_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE l (k INTEGER, a INTEGER, c INTEGER)");
@@ -636,7 +565,7 @@ fn join_group_by_order_by_bare_column_runs_columnar_and_matches_row_path() {
 /// sorts the survivors, all on the columnar path.
 #[test]
 fn join_group_by_having_then_order_by_runs_columnar_and_matches_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     setup_inner(&mut db, 800);
@@ -657,7 +586,7 @@ fn join_group_by_having_then_order_by_runs_columnar_and_matches_row_path() {
 /// the row path in emitted order — NULL keys sort first ascending (SQLite).
 #[test]
 fn join_group_by_left_outer_null_keys_with_order_by_runs_columnar_and_matches_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE l (k INTEGER, a INTEGER, c INTEGER)");

--- a/crates/vibesql-executor/tests/columnar_join_stddev_variance_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_join_stddev_variance_tests.rs
@@ -6,81 +6,17 @@
 //! (`VIBESQL_DISABLE_COLUMNAR_JOIN=1`) within a float epsilon. Uses the PR #6006
 //! SERIAL-mutex pattern because the env var and the log buffer are process-global.
 
-use std::sync::{Mutex, OnceLock};
-
-use log::{Level, LevelFilter, Log, Metadata, Record};
-use vibesql_executor::{CreateTableExecutor, InsertExecutor};
-use vibesql_parser::Parser;
+use log::Level;
 use vibesql_storage::Database;
 use vibesql_types::SqlValue;
 
-struct CaptureLogger;
-
-static LOG_BUFFER: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
-
-fn buffer() -> &'static Mutex<Vec<String>> {
-    LOG_BUFFER.get_or_init(|| Mutex::new(Vec::new()))
-}
-
-impl Log for CaptureLogger {
-    fn enabled(&self, _metadata: &Metadata) -> bool {
-        true
-    }
-    fn log(&self, record: &Record) {
-        if record.level() <= Level::Debug {
-            buffer().lock().unwrap().push(format!("{}", record.args()));
-        }
-    }
-    fn flush(&self) {}
-}
-
-static LOGGER: CaptureLogger = CaptureLogger;
-
-fn init_logger() {
-    let _ = log::set_logger(&LOGGER);
-    log::set_max_level(LevelFilter::Debug);
-}
-
-fn take_logs() -> Vec<String> {
-    std::mem::take(&mut *buffer().lock().unwrap())
-}
-
-static SERIAL: Mutex<()> = Mutex::new(());
+mod common;
+use common::{execute_sql, init_logger, run_select_values as run_select, take_logs, SERIAL};
 
 /// Row-fallback marker: a joined GROUP BY key couldn't be resolved to a column.
 const ROW_FALLBACK: &str = "Columnar join: some GROUP BY columns couldn't be resolved";
 /// Positive marker emitted only when the columnar join path produced the result.
 const COLUMNAR_JOIN_SUCCEEDED: &str = "Columnar join execution succeeded";
-
-fn execute_sql(db: &mut Database, sql: &str) {
-    for sql_stmt in sql.split(';') {
-        let trimmed = sql_stmt.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
-        match stmt {
-            vibesql_ast::Statement::CreateTable(s) => {
-                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
-            }
-            vibesql_ast::Statement::Insert(s) => {
-                InsertExecutor::execute(db, &s).expect("INSERT failed");
-            }
-            other => panic!("Unsupported statement type: {:?}", other),
-        }
-    }
-}
-
-fn run_select(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
-    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
-    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
-        let rows =
-            vibesql_executor::SelectExecutor::new(db).execute(&select_stmt).expect("SELECT failed");
-        rows.into_iter().map(|r| r.values.to_vec()).collect()
-    } else {
-        panic!("Expected SELECT");
-    }
-}
 
 fn as_f64(v: &SqlValue) -> Option<f64> {
     match v {
@@ -170,7 +106,7 @@ const SPELLINGS: [&str; 6] =
 #[test]
 fn join_group_by_stddev_variance_all_spellings_match_row_path() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     setup_inner(&mut db, 800);
 
@@ -185,7 +121,7 @@ fn join_group_by_stddev_variance_all_spellings_match_row_path() {
 #[test]
 fn join_group_by_mixed_aggregates_match_row_path() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     setup_inner(&mut db, 800);
 
@@ -200,7 +136,7 @@ fn join_group_by_mixed_aggregates_match_row_path() {
 #[test]
 fn join_group_by_stddev_variance_null_values_match_row_path() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE l (k INTEGER, a INTEGER, v INTEGER)");
     execute_sql(&mut db, "CREATE TABLE r (k INTEGER, d INTEGER)");

--- a/crates/vibesql-executor/tests/columnar_like_general_path_assertion_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_like_general_path_assertion_tests.rs
@@ -30,82 +30,12 @@
 //! and the capture buffer are process-global, so a SERIAL mutex serializes the
 //! columnar-vs-row runs (PR #6006 precedent).
 
-use std::sync::{Mutex, OnceLock};
-
-use log::{Level, LevelFilter, Log, Metadata, Record};
-use vibesql_executor::{CreateTableExecutor, InsertExecutor};
-use vibesql_parser::Parser;
+use log::Level;
 use vibesql_storage::Database;
 use vibesql_types::SqlValue;
 
-struct CaptureLogger;
-
-static LOG_BUFFER: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
-
-fn buffer() -> &'static Mutex<Vec<String>> {
-    LOG_BUFFER.get_or_init(|| Mutex::new(Vec::new()))
-}
-
-impl Log for CaptureLogger {
-    fn enabled(&self, _metadata: &Metadata) -> bool {
-        true
-    }
-    fn log(&self, record: &Record) {
-        // Capture Debug and above: the fallback marker is a debug! line and the
-        // positive marker is an info! line.
-        if record.level() <= Level::Debug {
-            buffer().lock().unwrap().push(format!("{}", record.args()));
-        }
-    }
-    fn flush(&self) {}
-}
-
-static LOGGER: CaptureLogger = CaptureLogger;
-
-fn init_logger() {
-    let _ = log::set_logger(&LOGGER);
-    log::set_max_level(LevelFilter::Debug);
-}
-
-fn take_logs() -> Vec<String> {
-    std::mem::take(&mut *buffer().lock().unwrap())
-}
-
-/// Serializes the columnar-vs-row runs across tests. `VIBESQL_DISABLE_COLUMNAR`
-/// is a process-global env var and the `log` capture buffer is process-global,
-/// so concurrent tests would otherwise race. Holding this mutex for the whole
-/// `run_both` keeps each test's two runs and their captured logs isolated.
-static SERIAL: Mutex<()> = Mutex::new(());
-
-fn execute_sql(db: &mut Database, sql: &str) {
-    for sql_stmt in sql.split(';') {
-        let trimmed = sql_stmt.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
-        match stmt {
-            vibesql_ast::Statement::CreateTable(s) => {
-                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
-            }
-            vibesql_ast::Statement::Insert(s) => {
-                InsertExecutor::execute(db, &s).expect("INSERT failed");
-            }
-            other => panic!("Unsupported statement type: {:?}", other),
-        }
-    }
-}
-
-fn run_select(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
-    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
-    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
-        let rows =
-            vibesql_executor::SelectExecutor::new(db).execute(&select_stmt).expect("SELECT failed");
-        rows.into_iter().map(|r| r.values.to_vec()).collect()
-    } else {
-        panic!("Expected SELECT");
-    }
-}
+mod common;
+use common::{execute_sql, init_logger, run_select_values as run_select, take_logs, SERIAL};
 
 /// Run the same query on both the columnar path and the row path
 /// (`VIBESQL_DISABLE_COLUMNAR=1`) and return `(columnar_rows, row_rows, logs)`.
@@ -176,7 +106,7 @@ fn setup_words(db: &mut Database, n: usize) {
 /// row path exactly. Runs on both sides of the SIMD row threshold (256).
 #[test]
 fn general_like_takes_columnar_path_and_matches_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     // `%a%b%` (interior), `_`-bearing, and mixed `%_` — all classify General.
     // (Single-word `%x%` shapes classify as Contains and take a different
@@ -213,7 +143,7 @@ fn general_like_takes_columnar_path_and_matches_row_path() {
 /// NOT LIKE — identical to the row path.
 #[test]
 fn general_like_null_handling_matches_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE t (id INTEGER, s TEXT)");
@@ -242,7 +172,7 @@ fn general_like_null_handling_matches_row_path() {
 /// must all match the row path.
 #[test]
 fn general_like_edge_cases_match_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE t (id INTEGER, s TEXT)");
@@ -275,7 +205,7 @@ fn general_like_edge_cases_match_row_path() {
 /// `_` must consume exactly one (possibly multi-byte) Unicode character.
 #[test]
 fn general_like_non_ascii_matches_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE t (id INTEGER, s TEXT)");
@@ -304,7 +234,7 @@ fn general_like_non_ascii_matches_row_path() {
 /// the row path — it must not error.
 #[test]
 fn general_like_blob_affinity_matches_row_path() {
-    init_logger();
+    init_logger(Level::Debug);
 
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE b (id INTEGER, data BLOB)");

--- a/crates/vibesql-executor/tests/columnar_stddev_variance_path_assertion_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_stddev_variance_path_assertion_tests.rs
@@ -15,81 +15,17 @@
 //! `SERIAL` mutex (PR #6006 pattern) because `VIBESQL_DISABLE_COLUMNAR` and the
 //! log buffer are process-global.
 
-use std::sync::{Mutex, OnceLock};
-
-use log::{Level, LevelFilter, Log, Metadata, Record};
-use vibesql_executor::{CreateTableExecutor, InsertExecutor};
-use vibesql_parser::Parser;
+use log::Level;
 use vibesql_storage::Database;
 use vibesql_types::SqlValue;
 
-struct CaptureLogger;
-
-static LOG_BUFFER: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
-
-fn buffer() -> &'static Mutex<Vec<String>> {
-    LOG_BUFFER.get_or_init(|| Mutex::new(Vec::new()))
-}
-
-impl Log for CaptureLogger {
-    fn enabled(&self, _metadata: &Metadata) -> bool {
-        true
-    }
-    fn log(&self, record: &Record) {
-        if record.level() <= Level::Debug {
-            buffer().lock().unwrap().push(format!("{}", record.args()));
-        }
-    }
-    fn flush(&self) {}
-}
-
-static LOGGER: CaptureLogger = CaptureLogger;
-
-fn init_logger() {
-    let _ = log::set_logger(&LOGGER);
-    log::set_max_level(LevelFilter::Debug);
-}
-
-fn take_logs() -> Vec<String> {
-    std::mem::take(&mut *buffer().lock().unwrap())
-}
-
-/// Serializes every test in this binary: `VIBESQL_DISABLE_COLUMNAR` and the log
-/// capture buffer are both process-global. PR #6006 pattern.
-static SERIAL: Mutex<()> = Mutex::new(());
+mod common;
+use common::{execute_sql, init_logger, run_select, take_logs, SERIAL};
 
 /// Row-fallback marker (single-table path): the columnar runtime declined.
 const ROW_FALLBACK: &str = "Standard columnar runtime fallback to row-oriented";
 /// Positive marker emitted only when the native columnar path completes.
 const COLUMNAR_COMPLETED: &str = "Native columnar execution completed";
-
-fn execute_sql(db: &mut Database, sql: &str) {
-    for sql_stmt in sql.split(';') {
-        let trimmed = sql_stmt.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
-        match stmt {
-            vibesql_ast::Statement::CreateTable(s) => {
-                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
-            }
-            vibesql_ast::Statement::Insert(s) => {
-                InsertExecutor::execute(db, &s).expect("INSERT failed");
-            }
-            other => panic!("Unsupported statement type: {:?}", other),
-        }
-    }
-}
-
-fn run_select(db: &Database, sql: &str) -> Vec<vibesql_storage::Row> {
-    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
-    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
-        vibesql_executor::SelectExecutor::new(db).execute(&select_stmt).expect("SELECT failed")
-    } else {
-        panic!("Expected SELECT");
-    }
-}
 
 /// Coerce a numeric SqlValue to f64 for epsilon comparison; NULL → None.
 fn as_f64(v: &SqlValue) -> Option<f64> {
@@ -189,7 +125,7 @@ const SPELLINGS: [&str; 6] =
 #[test]
 fn flat_stddev_variance_all_spellings_columnar_parity() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     setup(&mut db, 600);
     for f in SPELLINGS {
@@ -201,7 +137,7 @@ fn flat_stddev_variance_all_spellings_columnar_parity() {
 #[test]
 fn mixed_select_list_removes_whole_query_drop() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     setup(&mut db, 600);
     // A SELECT list combining supported aggregates with a statistical aggregate
@@ -212,7 +148,7 @@ fn mixed_select_list_removes_whole_query_drop() {
 #[test]
 fn group_by_stddev_variance_all_spellings_columnar_parity() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     setup(&mut db, 900);
     for f in SPELLINGS {
@@ -223,7 +159,7 @@ fn group_by_stddev_variance_all_spellings_columnar_parity() {
 #[test]
 fn group_by_mixed_aggregates_columnar_parity() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     setup(&mut db, 900);
     columnar_matches_row(
@@ -235,7 +171,7 @@ fn group_by_mixed_aggregates_columnar_parity() {
 #[test]
 fn stddev_variance_with_where_filter_columnar_parity() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     setup(&mut db, 600);
     // WHERE filtering must apply before the statistical aggregate.
@@ -245,7 +181,7 @@ fn stddev_variance_with_where_filter_columnar_parity() {
 #[test]
 fn stddev_variance_single_value_group_edge_cases() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     // Each group has exactly one row: sample variants → NULL, population → 0.0.
     execute_sql(&mut db, "CREATE TABLE s (g INTEGER, v INTEGER)");
@@ -260,7 +196,7 @@ fn stddev_variance_single_value_group_edge_cases() {
 #[test]
 fn stddev_variance_null_handling_columnar_parity() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE nn (g INTEGER, v INTEGER)");
     let mut ins = String::new();
@@ -285,7 +221,7 @@ fn stddev_variance_null_handling_columnar_parity() {
 #[test]
 fn stddev_variance_large_magnitude_stability() {
     let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger();
+    init_logger(Level::Debug);
     let mut db = Database::new();
     execute_sql(&mut db, "CREATE TABLE big (v DOUBLE)");
     let mut ins = String::new();

--- a/crates/vibesql-executor/tests/common/mod.rs
+++ b/crates/vibesql-executor/tests/common/mod.rs
@@ -4,6 +4,136 @@ pub mod insert_constraint_fixtures;
 
 use vibesql_executor::ExpressionEvaluator;
 
+// ---------------------------------------------------------------------------
+// Columnar path-assertion log-capture harness (shared by the `columnar_*`
+// path-assertion / parity test binaries).
+//
+// IMPORTANT: `tests/common/mod.rs` is compiled independently into every test
+// binary that declares `mod common;`. Each test binary therefore gets its OWN
+// private copy of the `LOG_BUFFER`, `LOGGER`, `CAPTURE_LEVEL`, and `SERIAL`
+// statics below. This is the whole point of the "one path-assertion test per
+// binary" design: the process-global `log` logger and the process-global
+// `VIBESQL_DISABLE_COLUMNAR*` env vars never clash across binaries, and the
+// `SERIAL` mutex serializes the columnar-vs-row runs within a single binary so
+// env-var toggling and log capture do not race between that binary's tests.
+// ---------------------------------------------------------------------------
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+use log::{Level, LevelFilter, Log, Metadata, Record};
+use vibesql_storage::Database;
+
+/// Serializes the columnar-vs-row runs across tests within a single binary.
+/// `VIBESQL_DISABLE_COLUMNAR` / `VIBESQL_DISABLE_COLUMNAR_JOIN` are process-global
+/// env vars and the `log` capture buffer is process-global, so concurrent tests
+/// would otherwise race: one test toggling the disable env var for its row-path
+/// parity run could silently disable columnar in another test's columnar run
+/// (failing that test's path assertion), and their captured logs would
+/// interleave. Every path-assertion test either toggles the env var or reads the
+/// shared buffer, so each acquires this mutex for its whole body. Poisoned-lock
+/// recovery (`unwrap_or_else(|e| e.into_inner())`) keeps a panic in one test from
+/// cascading into spurious failures in the rest.
+#[allow(dead_code)] // Test helper - not every path-assertion binary toggles env vars.
+pub static SERIAL: Mutex<()> = Mutex::new(());
+
+/// Captures every log message at-or-below the configured level into a shared
+/// buffer. `log`'s `Level` ordering is `Error(1) < Warn(2) < Info(3) < Debug(4)
+/// < Trace(5)`, so `record.level() <= capture_upto` captures the configured
+/// level and everything more severe.
+struct CaptureLogger;
+
+static LOG_BUFFER: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+/// The configured capture level, stored as `Level as usize` (1..=5). Defaults to
+/// `Level::Debug` (4) until `init_logger` sets it. Runtime-configurable so Info-
+/// level and Debug-level callers share one `CaptureLogger` implementation.
+static CAPTURE_LEVEL: AtomicUsize = AtomicUsize::new(Level::Debug as usize);
+
+#[allow(dead_code)] // Test helper - available for all test modules.
+fn buffer() -> &'static Mutex<Vec<String>> {
+    LOG_BUFFER.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+impl Log for CaptureLogger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
+    fn log(&self, record: &Record) {
+        if (record.level() as usize) <= CAPTURE_LEVEL.load(Ordering::Relaxed) {
+            buffer().lock().unwrap().push(format!("{}", record.args()));
+        }
+    }
+    fn flush(&self) {}
+}
+
+static LOGGER: CaptureLogger = CaptureLogger;
+
+/// Install the process-global capture logger for this test binary and set the
+/// level below which messages are captured (`Level::Info` or `Level::Debug`).
+/// `set_logger` is idempotent across the binary; the "already set" error is
+/// ignored so every test may call this. The capture level is refreshed on each
+/// call, so all tests in a binary should pass the same level.
+#[allow(dead_code)] // Test helper - available for all test modules.
+pub fn init_logger(capture_upto: Level) {
+    CAPTURE_LEVEL.store(capture_upto as usize, Ordering::Relaxed);
+    let _ = log::set_logger(&LOGGER);
+    log::set_max_level(LevelFilter::Debug);
+}
+
+/// Drain and return every captured log line since the last call.
+#[allow(dead_code)] // Test helper - available for all test modules.
+pub fn take_logs() -> Vec<String> {
+    std::mem::take(&mut *buffer().lock().unwrap())
+}
+
+/// Execute a `;`-separated batch of `CREATE TABLE` / `INSERT` statements against
+/// `db`, panicking on any parse or execution error. Used to set up fixtures for
+/// the columnar path-assertion tests.
+#[allow(dead_code)] // Test helper - available for all test modules.
+pub fn execute_sql(db: &mut Database, sql: &str) {
+    use vibesql_executor::{CreateTableExecutor, InsertExecutor};
+    use vibesql_parser::Parser;
+
+    for sql_stmt in sql.split(';') {
+        let trimmed = sql_stmt.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
+        match stmt {
+            vibesql_ast::Statement::CreateTable(s) => {
+                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+            }
+            vibesql_ast::Statement::Insert(s) => {
+                InsertExecutor::execute(db, &s).expect("INSERT failed");
+            }
+            other => panic!("Unsupported statement type: {:?}", other),
+        }
+    }
+}
+
+/// Parse and execute a `SELECT`, returning the raw storage rows. Panics on a
+/// parse or execution error, or if `sql` is not a `SELECT`.
+#[allow(dead_code)] // Test helper - available for all test modules.
+pub fn run_select(db: &Database, sql: &str) -> Vec<vibesql_storage::Row> {
+    use vibesql_parser::Parser;
+
+    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        vibesql_executor::SelectExecutor::new(db).execute(&select_stmt).expect("SELECT failed")
+    } else {
+        panic!("Expected SELECT");
+    }
+}
+
+/// Like [`run_select`], but projects each row to its `Vec<SqlValue>` so callers
+/// can compare result sets by value (`Vec<Vec<SqlValue>>`).
+#[allow(dead_code)] // Test helper - available for all test modules.
+pub fn run_select_values(db: &Database, sql: &str) -> Vec<Vec<vibesql_types::SqlValue>> {
+    run_select(db, sql).into_iter().map(|r| r.values.to_vec()).collect()
+}
+
 /// Creates a test evaluator with a simple schema for testing.
 /// Returns an evaluator and a simple test row.
 #[allow(dead_code)] // Test helper - available for all test modules


### PR DESCRIPTION
## Summary

Closes #6010.

Eight `columnar_*` path-assertion / parity test binaries each carried a near-identical ~50-65 line copy of the process-global `log`-capture harness plus `execute_sql` / `run_select` boilerplate (and, in 7 of 8, the `SERIAL` env-var-toggling mutex). This extracts that duplicated harness into the shared `crates/vibesql-executor/tests/common/mod.rs`. ~620 lines of duplicated harness collapse into ~130 shared lines.

This is a pure dedup refactor — **no behavior change**.

## What was extracted into `tests/common/mod.rs`

- `CaptureLogger` + `LOG_BUFFER` / `buffer()` / `impl Log` / `static LOGGER` / `take_logs()`
- `init_logger(capture_upto: log::Level)` — parameterized (see below)
- `SERIAL: Mutex<()>` (`#[allow(dead_code)]`)
- `execute_sql(db, sql)`
- `run_select(db, sql) -> Vec<Row>` and `run_select_values(db, sql) -> Vec<Vec<SqlValue>>`

Because `tests/common/mod.rs` is compiled independently into every binary that declares `mod common;`, each of the 8 binaries still gets its **own private copy** of the `LOG_BUFFER` / `LOGGER` / `SERIAL` statics — the "one path-assertion test per binary" isolation the design relies on (no cross-binary logger or env-var clash) is preserved. The `SERIAL`-mutex semantics are identical, so env-var-toggling tests do not race.

## Design decisions (the two curator-flagged hazards)

1. **Capture level varies per file.** The two `Info`-level callers (is_null, computed_predicate) and the six `Debug`-level callers previously hard-coded `record.level() <= Level::Info` / `<= Level::Debug`. The shared `CaptureLogger` now reads a level stored in an `AtomicUsize` by `init_logger(capture_upto)`; each call site passes the exact level its inlined copy used. (Note: the curator table lists `group_by_order_by` as "Info", but its source actually captured at `Debug` — I preserved the *actual* source behavior, `Debug`, to guarantee zero behavior change.)

2. **Two incompatible `run_select` return types.** Four files used `Vec<vibesql_storage::Row>`, four used `Vec<Vec<SqlValue>>`. Rather than rewrite any call site's types (churn + regression risk), `common` exports **both** helpers. The four value-returning files import `run_select_values as run_select`, leaving every test body byte-identical. I kept both variants deliberately — consolidating to one signature would have forced edits into every assertion in half the files for no benefit.

## Test results

- All 8 refactored binaries pass individually (58 tests total).
- Two binaries run concurrently (`columnar_is_null_path_assertion_tests` + `columnar_join_stddev_variance_tests`) — no flakiness.
- Full targeted run across all 8 binaries: pass.
- Full crate regression `cargo test -p vibesql-executor`: **0 failures** (the other 18 binaries consuming `common` are unaffected — additions are additive).
- `cargo clippy -p vibesql-executor --tests`: no new warnings/errors on any touched file. (The 3 pre-existing `approximate value of PI` clippy errors are all in `src/`, on the base branch, unrelated to this PR.)
- `rustfmt` applied to touched files only.

## Scope guard

Out of scope, per the issue's non-goals (unchanged): the `FromClause::TableFunction` match-arm plumbing and the IS NULL/IS NOT NULL kernel-level match arms — both intentional, not duplication. No non-columnar test files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)