### PR TITLE
fix(json): runtime JSON subtype propagation for subtype(), ->/->> and TVF atoms

### DIFF
--- a/crates/vibesql-executor/src/evaluator/arena.rs
+++ b/crates/vibesql-executor/src/evaluator/arena.rs
@@ -144,6 +144,121 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
         }
     }
 
+    /// Structurally determine whether an arena expression evaluates to a
+    /// JSON-subtyped value in the current row. Arena mirror of
+    /// [`crate::evaluator::json_subtype`]; see that module for the rules.
+    fn arena_expr_json_subtype(
+        &self,
+        expr: &ArenaExpression<'arena>,
+        row: &Row,
+    ) -> Result<bool, ExecutorError> {
+        use vibesql_ast::BinaryOperator;
+        Ok(match expr {
+            ArenaExpression::BinaryOp { op: BinaryOperator::JsonExtract, .. } => {
+                !matches!(self.eval(expr, row)?, SqlValue::Null)
+            }
+            ArenaExpression::BinaryOp { op: BinaryOperator::JsonExtractText, .. } => false,
+            ArenaExpression::Extended(ArenaExtendedExpr::Function { name, args, .. }) => {
+                let canon = self.resolve(*name).to_ascii_lowercase();
+                if self.arena_expr_has_json_subtype(expr) {
+                    !matches!(self.eval(expr, row)?, SqlValue::Null)
+                } else if matches!(canon.as_str(), "json_extract" | "jsonb_extract" | "json_quote")
+                {
+                    crate::evaluator::json_subtype::value_is_json_container(&self.eval(expr, row)?)
+                } else if matches!(canon.as_str(), "if" | "iif") {
+                    match self.arena_selected_conditional_branch(args, row)? {
+                        Some(branch) => self.arena_expr_json_subtype(branch, row)?,
+                        None => false,
+                    }
+                } else if matches!(canon.as_str(), "coalesce" | "ifnull") {
+                    let mut result = false;
+                    for arg in args.iter() {
+                        if !matches!(self.eval(arg, row)?, SqlValue::Null) {
+                            result = self.arena_expr_json_subtype(arg, row)?;
+                            break;
+                        }
+                    }
+                    result
+                } else if canon == "nullif" && args.len() == 2 {
+                    self.arena_expr_json_subtype(&args[0], row)?
+                } else {
+                    false
+                }
+            }
+            ArenaExpression::Extended(ArenaExtendedExpr::Case {
+                operand,
+                when_clauses,
+                else_result,
+            }) => {
+                match self.arena_selected_case_branch(
+                    operand.as_deref(),
+                    when_clauses,
+                    else_result.as_deref(),
+                    row,
+                )? {
+                    Some(branch) => self.arena_expr_json_subtype(branch, row)?,
+                    None => false,
+                }
+            }
+            _ => {
+                crate::evaluator::functions::sqlite_compat::json_funcs::sql_value_is_json_subtyped(
+                    &self.eval(expr, row)?,
+                )
+            }
+        })
+    }
+
+    /// Arena mirror of the `if`/`iif` branch-selection used by subtype recovery.
+    fn arena_selected_conditional_branch<'e>(
+        &self,
+        args: &'e [ArenaExpression<'arena>],
+        row: &Row,
+    ) -> Result<Option<&'e ArenaExpression<'arena>>, ExecutorError> {
+        use crate::evaluator::operators::is_truthy;
+        let mut i = 0;
+        while i + 1 < args.len() {
+            if is_truthy(&self.eval(&args[i], row)?) {
+                return Ok(Some(&args[i + 1]));
+            }
+            i += 2;
+        }
+        if !args.len().is_multiple_of(2) {
+            Ok(Some(&args[args.len() - 1]))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Arena mirror of the CASE branch-selection used by subtype recovery.
+    fn arena_selected_case_branch<'e>(
+        &self,
+        operand: Option<&'e ArenaExpression<'arena>>,
+        when_clauses: &'e [arena_ast::CaseWhen<'arena>],
+        else_result: Option<&'e ArenaExpression<'arena>>,
+        row: &Row,
+    ) -> Result<Option<&'e ArenaExpression<'arena>>, ExecutorError> {
+        use crate::evaluator::operators::is_truthy;
+        let operand_val = match operand {
+            Some(op) => Some(self.eval(op, row)?),
+            None => None,
+        };
+        for wc in when_clauses.iter() {
+            for cond in wc.conditions.iter() {
+                let matched = match &operand_val {
+                    Some(ov) => {
+                        let cv = self.eval(cond, row)?;
+                        crate::evaluator::core::values_are_equal(ov, &cv)
+                    }
+                    None => is_truthy(&self.eval(cond, row)?),
+                };
+                if matched {
+                    return Ok(Some(&wc.result));
+                }
+            }
+        }
+        Ok(else_result)
+    }
+
     /// Evaluate an arena-allocated expression against a row.
     ///
     /// # Arguments
@@ -403,6 +518,22 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
                 // subtype-aware implementations. (Mirrors special.rs for the
                 // non-arena evaluator.)
                 let upper = name_str.to_uppercase();
+                // subtype(X): runtime JSON subtype probe, computed structurally
+                // from the argument expression + its evaluated value. Mirrors
+                // crate::evaluator::json_subtype for the arena AST.
+                if upper == "SUBTYPE" {
+                    if args.len() != 1 {
+                        return Err(ExecutorError::WrongNumberOfArguments {
+                            function_name: "subtype".to_string(),
+                        });
+                    }
+                    let is_json = self.arena_expr_json_subtype(&args[0], row)?;
+                    return Ok(SqlValue::Integer(if is_json {
+                        crate::evaluator::json_subtype::JSON_SUBTYPE_TAG
+                    } else {
+                        0
+                    }));
+                }
                 if matches!(
                     upper.as_str(),
                     "JSON_ARRAY"

--- a/crates/vibesql-executor/src/evaluator/arena.rs
+++ b/crates/vibesql-executor/src/evaluator/arena.rs
@@ -144,6 +144,27 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
         }
     }
 
+    /// Is this arena argument expression eligible to carry the *runtime* JSON
+    /// subtype marker? A bare read of a column declared with a real string type
+    /// (CHAR/VARCHAR) is not eligible — its container-shaped text quotes rather
+    /// than embedding (issue #6007). Arena mirror of
+    /// [`crate::evaluator::json_subtype::expr_runtime_json_subtype_eligible`].
+    fn arena_expr_runtime_json_subtype_eligible(&self, expr: &ArenaExpression<'arena>) -> bool {
+        if let ArenaExpression::ColumnRef { table, column, .. } = expr {
+            let column_str = self.resolve(*column);
+            let table_str = table.map(|t| self.resolve(t));
+            let declared_string = self
+                .schema
+                .get_column_index(table_str, column_str)
+                .and_then(|idx| self.schema.get_column_type_by_index(idx))
+                .map(crate::evaluator::json_subtype::data_type_is_string)
+                .unwrap_or(false);
+            !declared_string
+        } else {
+            true
+        }
+    }
+
     /// Structurally determine whether an arena expression evaluates to a
     /// JSON-subtyped value in the current row. Arena mirror of
     /// [`crate::evaluator::json_subtype`]; see that module for the rules.
@@ -201,9 +222,10 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
                 }
             }
             _ => {
-                crate::evaluator::functions::sqlite_compat::json_funcs::sql_value_is_json_subtyped(
-                    &self.eval(expr, row)?,
-                )
+                self.arena_expr_runtime_json_subtype_eligible(expr)
+                    && crate::evaluator::functions::sqlite_compat::json_funcs::sql_value_is_json_subtyped(
+                        &self.eval(expr, row)?,
+                    )
             }
         })
     }
@@ -547,9 +569,16 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
                         | "JSONB_REPLACE"
                         | "JSONB_SET"
                 ) {
-                    let subtypes: Vec<bool> =
-                        args.iter().map(|a| self.arena_expr_has_json_subtype(a)).collect();
                     use super::functions::sqlite_compat::json_funcs;
+                    // AST-derived subtype OR a runtime container marker on an
+                    // eligible (non-string-column) argument (issue #6007).
+                    let mut subtypes: Vec<bool> = Vec::with_capacity(args.len());
+                    for (i, a) in args.iter().enumerate() {
+                        let is_json = self.arena_expr_has_json_subtype(a)
+                            || (self.arena_expr_runtime_json_subtype_eligible(a)
+                                && json_funcs::sql_value_is_json_subtyped(&evaluated_args[i]));
+                        subtypes.push(is_json);
+                    }
                     // `jsonb_*` are text-mode accept-and-convert aliases of `json_*`.
                     return match upper.as_str() {
                         "JSON_ARRAY" | "JSONB_ARRAY" => {

--- a/crates/vibesql-executor/src/evaluator/combined/special.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/special.rs
@@ -192,6 +192,11 @@ impl CombinedExpressionEvaluator<'_> {
         match name.to_uppercase().as_str() {
             "COALESCE" => return self.eval_coalesce_lazy(args, row),
             "NULLIF" => return self.eval_nullif_lazy(args, row),
+            // subtype(X): runtime JSON subtype probe (see
+            // crate::evaluator::json_subtype).
+            "SUBTYPE" => {
+                return crate::evaluator::json_subtype::eval_subtype(args, &|e| self.eval(e, row));
+            }
             // JSON construction/mutation functions honoring the JSON subtype:
             // detect JSON-producing argument expressions from the AST so nested
             // json()/json_array()/... results embed as sub-documents rather than

--- a/crates/vibesql-executor/src/evaluator/combined/special.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/special.rs
@@ -195,7 +195,19 @@ impl CombinedExpressionEvaluator<'_> {
             // subtype(X): runtime JSON subtype probe (see
             // crate::evaluator::json_subtype).
             "SUBTYPE" => {
-                return crate::evaluator::json_subtype::eval_subtype(args, &|e| self.eval(e, row));
+                use crate::evaluator::json_subtype::data_type_is_string;
+                let column_is_declared_string = |table: Option<&str>, column: &str| -> bool {
+                    self.schema
+                        .get_column_index(table, column)
+                        .and_then(|idx| self.schema.get_column_type_by_index(idx))
+                        .map(data_type_is_string)
+                        .unwrap_or(false)
+                };
+                return crate::evaluator::json_subtype::eval_subtype(
+                    args,
+                    &|e| self.eval(e, row),
+                    &column_is_declared_string,
+                );
             }
             // JSON construction/mutation functions honoring the JSON subtype:
             // detect JSON-producing argument expressions from the AST so nested
@@ -203,14 +215,36 @@ impl CombinedExpressionEvaluator<'_> {
             // quoted strings. Mirrors expressions/special.rs.
             "JSON_ARRAY" | "JSON_OBJECT" | "JSON_INSERT" | "JSON_REPLACE" | "JSON_SET"
             | "JSONB_ARRAY" | "JSONB_OBJECT" | "JSONB_INSERT" | "JSONB_REPLACE" | "JSONB_SET" => {
+                use super::super::functions::sqlite_compat::json_funcs;
+                use crate::evaluator::json_subtype::{
+                    data_type_is_string, expr_runtime_json_subtype_eligible,
+                };
+
+                // A bare read of a declared CHAR/VARCHAR column must never pick
+                // up the runtime JSON subtype marker (issue #6007); a
+                // dynamically-typed json_each / json_tree `value` column stays
+                // eligible (json101-5.10).
+                let column_is_declared_string = |table: Option<&str>, column: &str| -> bool {
+                    self.schema
+                        .get_column_index(table, column)
+                        .and_then(|idx| self.schema.get_column_type_by_index(idx))
+                        .map(data_type_is_string)
+                        .unwrap_or(false)
+                };
+
                 let mut values = Vec::with_capacity(args.len());
                 let mut subtypes = Vec::with_capacity(args.len());
                 for arg in args {
-                    values.push(self.eval(arg, row)?);
-                    subtypes
-                        .push(crate::evaluator::expressions::special::expr_has_json_subtype(arg));
+                    let value = self.eval(arg, row)?;
+                    let is_json =
+                        crate::evaluator::expressions::special::expr_has_json_subtype(arg)
+                            || (expr_runtime_json_subtype_eligible(
+                                arg,
+                                &column_is_declared_string,
+                            ) && json_funcs::sql_value_is_json_subtyped(&value));
+                    subtypes.push(is_json);
+                    values.push(value);
                 }
-                use super::super::functions::sqlite_compat::json_funcs;
                 // `jsonb_*` are text-mode accept-and-convert aliases of `json_*`.
                 return match name.to_uppercase().as_str() {
                     "JSON_ARRAY" | "JSONB_ARRAY" => json_funcs::json_array(&values, &subtypes),

--- a/crates/vibesql-executor/src/evaluator/expressions/special.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/special.rs
@@ -196,6 +196,16 @@ impl ExpressionEvaluator<'_> {
         }
     }
 
+    /// Evaluate `subtype(X)` — SQLite's runtime JSON subtype probe. Delegates
+    /// the structural subtype rules to [`crate::evaluator::json_subtype`].
+    pub(crate) fn eval_subtype(
+        &self,
+        args: &[vibesql_ast::Expression],
+        row: &vibesql_storage::Row,
+    ) -> Result<vibesql_types::SqlValue, ExecutorError> {
+        crate::evaluator::json_subtype::eval_subtype(args, &|e| self.eval(e, row))
+    }
+
     /// Evaluate function call
     pub(super) fn eval_function(
         &self,
@@ -208,6 +218,9 @@ impl ExpressionEvaluator<'_> {
         match name.to_uppercase().as_str() {
             "COALESCE" => return self.eval_coalesce_lazy(args, row),
             "NULLIF" => return self.eval_nullif_lazy(args, row),
+            // subtype(X): runtime JSON subtype probe, computed structurally from
+            // the argument expression + its evaluated value.
+            "SUBTYPE" => return self.eval_subtype(args, row),
             // JSON construction/mutation functions that honor the JSON subtype:
             // an argument that is itself a call to a JSON-producing function
             // embeds as a sub-document rather than a quoted string. We compute

--- a/crates/vibesql-executor/src/evaluator/expressions/special.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/special.rs
@@ -175,14 +175,36 @@ impl ExpressionEvaluator<'_> {
         args: &[vibesql_ast::Expression],
         row: &vibesql_storage::Row,
     ) -> Result<vibesql_types::SqlValue, ExecutorError> {
+        use super::super::functions::sqlite_compat::json_funcs;
+        use crate::evaluator::json_subtype::{
+            data_type_is_string, expr_runtime_json_subtype_eligible,
+        };
+
+        // Resolve whether a bare column reference is declared with a real string
+        // type (CHAR/VARCHAR). Such reads must never pick up the runtime JSON
+        // subtype marker (issue #6007): a `CHAR(n)` column holding
+        // container-shaped text quotes, while a dynamically-typed json_each /
+        // json_tree `value` column stays eligible (json101-5.10).
+        let column_is_declared_string = |_table: Option<&str>, column: &str| -> bool {
+            self.schema
+                .get_column(column)
+                .map(|c| data_type_is_string(&c.data_type))
+                .unwrap_or(false)
+        };
+
         let mut values = Vec::with_capacity(args.len());
         let mut subtypes = Vec::with_capacity(args.len());
         for arg in args {
-            values.push(self.eval(arg, row)?);
-            subtypes.push(expr_has_json_subtype(arg));
+            let value = self.eval(arg, row)?;
+            // AST-derived subtype OR a runtime container marker on an eligible
+            // (non-string-column) argument.
+            let is_json = expr_has_json_subtype(arg)
+                || (expr_runtime_json_subtype_eligible(arg, &column_is_declared_string)
+                    && json_funcs::sql_value_is_json_subtyped(&value));
+            subtypes.push(is_json);
+            values.push(value);
         }
 
-        use super::super::functions::sqlite_compat::json_funcs;
         // The `jsonb_*` names are text-mode aliases (accept-and-convert): they
         // delegate to the identical `json_*` implementation. See the Phase 4
         // JSONB note in `json_funcs.rs`.
@@ -203,7 +225,18 @@ impl ExpressionEvaluator<'_> {
         args: &[vibesql_ast::Expression],
         row: &vibesql_storage::Row,
     ) -> Result<vibesql_types::SqlValue, ExecutorError> {
-        crate::evaluator::json_subtype::eval_subtype(args, &|e| self.eval(e, row))
+        use crate::evaluator::json_subtype::data_type_is_string;
+        let column_is_declared_string = |_table: Option<&str>, column: &str| -> bool {
+            self.schema
+                .get_column(column)
+                .map(|c| data_type_is_string(&c.data_type))
+                .unwrap_or(false)
+        };
+        crate::evaluator::json_subtype::eval_subtype(
+            args,
+            &|e| self.eval(e, row),
+            &column_is_declared_string,
+        )
     }
 
     /// Evaluate function call

--- a/crates/vibesql-executor/src/evaluator/functions/control.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/control.rs
@@ -3,9 +3,11 @@
 use crate::errors::ExecutorError;
 use crate::evaluator::operators::is_truthy;
 
-/// IF(...) - MySQL-style / SQLite 3.48+ variadic conditional
+/// IF(...) - MySQL-style / SQLite variadic conditional
 ///
-/// Two supported forms:
+/// Supported forms:
+/// - `IF(condition, true_value)` — 2-argument form (SQLite `if(X,Y)`): returns
+///   `true_value` if `condition` is truthy, otherwise `NULL` (implicit ELSE).
 /// - `IF(condition, true_value, false_value)` — ternary; returns `true_value`
 ///   if `condition` is truthy, otherwise `false_value`.
 /// - `IF(c1, v1, c2, v2, ..., else)` — CASE-chain form (odd argument count,
@@ -25,22 +27,21 @@ pub(super) fn if_func(
 
 /// Shared CASE-chain evaluation for the variadic `IF`/`IIF` forms.
 ///
-/// Requires an odd argument count `>= 3`. Iterates over `(condition, value)`
-/// pairs, returning the value for the first truthy condition; if no condition
-/// is truthy, returns the trailing else argument.
+/// Accepts the 2-argument `if(X, Y)` form (implicit `ELSE NULL`, matching
+/// SQLite) and any odd argument count `>= 3` (CASE-chain). Iterates over
+/// `(condition, value)` pairs, returning the value for the first truthy
+/// condition; if no condition is truthy, returns the trailing else argument
+/// (or `NULL` when there is no trailing else, i.e. the 2-arg form).
 pub(crate) fn variadic_conditional(
     fn_name: &str,
     args: &[vibesql_types::SqlValue],
 ) -> Result<vibesql_types::SqlValue, ExecutorError> {
-    if args.len() < 3 || args.len() % 2 == 0 {
-        return Err(ExecutorError::UnsupportedFeature(format!(
-            "{fn_name} requires an odd number of arguments (>= 3), got {}",
-            args.len()
-        )));
+    // Valid arities: exactly 2 (implicit ELSE NULL) or any odd count >= 3.
+    if args.len() < 2 || (args.len() > 2 && args.len().is_multiple_of(2)) {
+        return Err(ExecutorError::WrongNumberOfArguments { function_name: fn_name.to_string() });
     }
 
-    // Evaluate (condition, value) pairs in order; the final argument is the
-    // else value returned when no condition matches.
+    // Evaluate (condition, value) pairs in order.
     let mut i = 0;
     while i + 1 < args.len() {
         if is_truthy(&args[i]) {
@@ -49,8 +50,13 @@ pub(crate) fn variadic_conditional(
         i += 2;
     }
 
-    // No condition matched — return the trailing else argument.
-    Ok(args[args.len() - 1].clone())
+    // Odd-arity forms carry a trailing else argument; the 2-arg form does not
+    // (its implicit else is NULL).
+    if !args.len().is_multiple_of(2) {
+        Ok(args[args.len() - 1].clone())
+    } else {
+        Ok(vibesql_types::SqlValue::Null)
+    }
 }
 
 #[cfg(test)]
@@ -154,9 +160,34 @@ mod tests {
     }
 
     #[test]
+    fn test_if_two_arg_form() {
+        // SQLite `if(X, Y)` — implicit ELSE NULL.
+        // Truthy condition returns Y.
+        assert_eq!(
+            if_func(&[SqlValue::Integer(1), SqlValue::Varchar(arcstr::ArcStr::from("y"))]).unwrap(),
+            SqlValue::Varchar(arcstr::ArcStr::from("y"))
+        );
+        // Falsy condition returns NULL.
+        assert_eq!(
+            if_func(&[SqlValue::Integer(0), SqlValue::Varchar(arcstr::ArcStr::from("y"))]).unwrap(),
+            SqlValue::Null
+        );
+        // NULL condition is falsy -> NULL.
+        assert_eq!(if_func(&[SqlValue::Null, SqlValue::Integer(5)]).unwrap(), SqlValue::Null);
+    }
+
+    #[test]
     fn test_if_invalid_arity() {
-        // Even argument counts are rejected.
-        assert!(if_func(&[SqlValue::Boolean(true), SqlValue::Integer(1)]).is_err());
+        // Even argument counts >= 4 are rejected (CASE-chain must be odd).
+        assert!(if_func(&[
+            SqlValue::Boolean(true),
+            SqlValue::Integer(1),
+            SqlValue::Boolean(false),
+            SqlValue::Integer(2),
+        ])
+        .is_err());
+        // One argument and zero arguments are rejected.
+        assert!(if_func(&[SqlValue::Integer(1)]).is_err());
         assert!(if_func(&[]).is_err());
     }
 }

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/conditional_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/conditional_funcs.rs
@@ -171,9 +171,18 @@ mod tests {
     }
 
     #[test]
+    fn test_iif_two_arg_form() {
+        // SQLite `iif(X, Y)` — implicit ELSE NULL (2-arg form is valid).
+        assert_eq!(
+            iif(&[SqlValue::Boolean(true), SqlValue::Integer(1)]).unwrap(),
+            SqlValue::Integer(1)
+        );
+        assert_eq!(iif(&[SqlValue::Boolean(false), SqlValue::Integer(1)]).unwrap(), SqlValue::Null);
+    }
+
+    #[test]
     fn test_iif_invalid_arity() {
-        // Even argument count is rejected
-        assert!(iif(&[SqlValue::Boolean(true), SqlValue::Integer(1)]).is_err());
+        // Even argument counts >= 4 are rejected (CASE-chain must be odd).
         assert!(iif(&[
             SqlValue::Boolean(true),
             SqlValue::Integer(1),
@@ -181,8 +190,9 @@ mod tests {
             SqlValue::Integer(2),
         ])
         .is_err());
-        // Fewer than 3 arguments is rejected
+        // One argument and zero arguments are rejected.
         assert!(iif(&[SqlValue::Boolean(true)]).is_err());
+        assert!(iif(&[]).is_err());
     }
 
     #[test]

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/json_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/json_funcs.rs
@@ -1213,18 +1213,30 @@ pub(crate) fn json(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
 // embedding, which is what the covered conformance tests expect.
 
 /// Encode a single SQL argument as a JSON node for a construction/mutation
-/// function. `is_json` is the argument's AST-derived subtype flag (see the
-/// module note): a TEXT value with the flag set is parsed as an embedded JSON
-/// sub-document. A value that already carries the JSON subtype at runtime —
-/// signalled by [`SqlValue::Character`], see [`sql_value_is_json_subtyped`] —
-/// embeds as JSON regardless of the AST flag, so a container `value` column
-/// from json_each/json_tree round-trips through an opaque column reference
-/// (json101-5.10).
+/// function. `is_json` is the argument's subtype flag (see the module note): a
+/// TEXT value with the flag set is parsed as an embedded JSON sub-document.
+///
+/// The flag combines two sources, both computed by the caller before dispatch
+/// (see the per-front-end `eval_json_subtype_function` helpers):
+///
+/// 1. an *AST-derived* flag — the argument expression is itself a call to a
+///    JSON-producing function whose output is always well-formed JSON; and
+/// 2. a *runtime* flag — the evaluated value already carries the JSON subtype
+///    marker ([`sql_value_is_json_subtyped`]) **and** the argument expression is
+///    eligible to carry it (it is not a read of a declared CHAR/VARCHAR column;
+///    see `expr_runtime_json_subtype_eligible`). This lets a container `value`
+///    column from json_each/json_tree embed through an opaque column reference
+///    (json101-5.10) without an ordinary fixed-width `CHAR(n)` column whose text
+///    happens to parse as a JSON container being silently embedded unquoted
+///    (issue #6007 regression).
+///
+/// Because the eligibility gate lives at the call site (where the argument
+/// expression is available), this function no longer inspects the value's
+/// runtime marker itself — the caller has already folded it into `is_json`.
 fn sql_value_to_json_node(
     value: &SqlValue,
     is_json: bool,
 ) -> Result<serde_json::Value, ExecutorError> {
-    let is_json = is_json || sql_value_is_json_subtyped(value);
     Ok(match value {
         SqlValue::Null => serde_json::Value::Null,
         // SQLite encodes SQL booleans as JSON integers 1/0 (json_array(true)
@@ -1306,12 +1318,25 @@ fn parse_json_doc_arg(value: &SqlValue) -> Result<Option<serde_json::Value>, Exe
 /// everywhere else, so only the JSON construction/mutation functions read this
 /// marker.
 ///
-/// To keep the marker from mis-firing on an ordinary fixed-width `CHAR(n)`
-/// column (which also materialises as [`SqlValue::Character`]), the value must
-/// *also* be well-formed JSON of container type (array/object) — exactly the
-/// nodes json_each/json_tree tag. This distinguishes json101-5.10
-/// (`json_tree('[1,2,3]')`.value, a container -> `{"a":[1,2,3]}`) from
-/// json101-5.11 (a JSON string atom -> `{"a":"[1,2,3]"}`, still quoted).
+/// The `Character` variant is also how an ordinary fixed-width `CHAR(n)` column
+/// materialises, so this predicate alone cannot tell a TVF container apart from
+/// a CHAR column holding container-shaped text (issue #6007). Two guards keep
+/// the marker from mis-firing:
+///
+/// 1. the value must be well-formed JSON of container type (array/object) —
+///    exactly the nodes json_each/json_tree tag (checked here); and
+/// 2. the *argument expression* must be eligible — it must not be a read of a
+///    column declared with a real string type (CHAR/VARCHAR). That gate lives
+///    at the call site in `expr_runtime_json_subtype_eligible`, because only
+///    there is the argument expression (and its declared schema type) known.
+///    A `CHAR(20)` (or snug `CHAR(7)`) column read is therefore *not* eligible
+///    and its container-shaped text quotes as SQLite does, while a json_tree
+///    `value` column (declared dynamic/NULL type) stays eligible.
+///
+/// This distinguishes json101-5.10 (`json_tree('[1,2,3]')`.value, a container ->
+/// `{"a":[1,2,3]}`) from json101-5.11 (a JSON string atom -> `{"a":"[1,2,3]"}`,
+/// still quoted) and from `SELECT json_insert('{}','$.a',c) FROM t` over a CHAR
+/// column (`{"a":"[1,2,3]"}`, quoted — matching SQLite 3.51).
 pub(crate) fn sql_value_is_json_subtyped(value: &SqlValue) -> bool {
     match value {
         SqlValue::Character(s) => {
@@ -2824,21 +2849,31 @@ mod tests {
     }
 
     #[test]
-    fn test_json_insert_embeds_runtime_subtyped_value() {
-        // json101-5.10: a container `value` column (Character marker) embeds as
-        // JSON even though its AST subtype flag is false (opaque column ref).
+    fn test_json_insert_embeds_when_subtype_flag_set() {
+        // The low-level `json_insert` embeds a TEXT argument as a JSON
+        // sub-document exactly when its subtype flag is `true`, and quotes it
+        // otherwise — the flag is the single source of truth.
+        //
+        // Deciding whether a runtime `SqlValue::Character` container marker sets
+        // that flag is now the caller's job (the evaluator folds
+        // `sql_value_is_json_subtyped` into the flag *only* for eligible
+        // argument expressions, so a `CHAR(n)` column read never embeds — see
+        // issue #6007 and `tests/json_char_column_subtype_tests.rs`). This unit
+        // test therefore drives the flag explicitly.
         let doc = v("{}");
         let path = v("$.a");
+        // json101-5.10 shape: flag set (a container value column) -> embed.
         let container = SqlValue::Character("[1,2,3]".into());
         assert_eq!(
-            txt(json_insert(&[doc.clone(), path.clone(), container], &[false, false, false])
+            txt(json_insert(&[doc.clone(), path.clone(), container], &[false, false, true])
                 .unwrap()),
             r#"{"a":[1,2,3]}"#
         );
-        // json101-5.11: a plain-text (Varchar) string value stays quoted.
-        let string_val = v("[1,2,3]");
+        // json101-5.11 shape / CHAR-column shape: flag clear -> quote, even for a
+        // `Character` value whose text parses as a JSON container.
+        let char_container = SqlValue::Character("[1,2,3]".into());
         assert_eq!(
-            txt(json_insert(&[doc, path, string_val], &[false, false, false]).unwrap()),
+            txt(json_insert(&[doc, path, char_container], &[false, false, false]).unwrap()),
             r#"{"a":"[1,2,3]"}"#
         );
     }

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/json_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/json_funcs.rs
@@ -1213,12 +1213,18 @@ pub(crate) fn json(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
 // embedding, which is what the covered conformance tests expect.
 
 /// Encode a single SQL argument as a JSON node for a construction/mutation
-/// function. `is_json` is the argument's subtype flag (see the module note): a
-/// TEXT value with the flag set is parsed as an embedded JSON sub-document.
+/// function. `is_json` is the argument's AST-derived subtype flag (see the
+/// module note): a TEXT value with the flag set is parsed as an embedded JSON
+/// sub-document. A value that already carries the JSON subtype at runtime —
+/// signalled by [`SqlValue::Character`], see [`sql_value_is_json_subtyped`] —
+/// embeds as JSON regardless of the AST flag, so a container `value` column
+/// from json_each/json_tree round-trips through an opaque column reference
+/// (json101-5.10).
 fn sql_value_to_json_node(
     value: &SqlValue,
     is_json: bool,
 ) -> Result<serde_json::Value, ExecutorError> {
+    let is_json = is_json || sql_value_is_json_subtyped(value);
     Ok(match value {
         SqlValue::Null => serde_json::Value::Null,
         // SQLite encodes SQL booleans as JSON integers 1/0 (json_array(true)
@@ -1290,8 +1296,40 @@ fn parse_json_doc_arg(value: &SqlValue) -> Result<Option<serde_json::Value>, Exe
     }
 }
 
-/// Fetch the subtype flag for the argument at `idx`, defaulting to `false` when
-/// the caller passed no (or a shorter) subtype slice.
+/// Does this runtime value already carry SQLite's JSON "J" subtype?
+///
+/// VibeSQL does not add a distinct subtype tag to [`SqlValue`]; instead the
+/// json_each/json_tree table functions signal the JSON subtype on TEXT
+/// container values (arrays/objects) by emitting them as [`SqlValue::Character`]
+/// rather than [`SqlValue::Varchar`] (see `node_value_column` in
+/// `select/scan/table_function.rs`). The two text variants are interoperable
+/// everywhere else, so only the JSON construction/mutation functions read this
+/// marker.
+///
+/// To keep the marker from mis-firing on an ordinary fixed-width `CHAR(n)`
+/// column (which also materialises as [`SqlValue::Character`]), the value must
+/// *also* be well-formed JSON of container type (array/object) — exactly the
+/// nodes json_each/json_tree tag. This distinguishes json101-5.10
+/// (`json_tree('[1,2,3]')`.value, a container -> `{"a":[1,2,3]}`) from
+/// json101-5.11 (a JSON string atom -> `{"a":"[1,2,3]"}`, still quoted).
+pub(crate) fn sql_value_is_json_subtyped(value: &SqlValue) -> bool {
+    match value {
+        SqlValue::Character(s) => {
+            matches!(
+                parse_json_relaxed(s.as_str()),
+                Ok(serde_json::Value::Array(_)) | Ok(serde_json::Value::Object(_))
+            )
+        }
+        _ => false,
+    }
+}
+
+/// Fetch the subtype flag for the argument at `idx`, OR-ing the AST-derived flag
+/// (the caller's `subtypes` slice) with a runtime check on the evaluated value:
+/// a value that already carries the JSON subtype (see
+/// [`sql_value_is_json_subtyped`]) embeds as JSON even when the argument
+/// expression is an opaque column reference. Defaults to `false` when the
+/// caller passed no (or a shorter) subtype slice.
 fn subtype_at(subtypes: &[bool], idx: usize) -> bool {
     subtypes.get(idx).copied().unwrap_or(false)
 }
@@ -2768,6 +2806,41 @@ mod tests {
         assert_eq!(txt(json_array(&args, &subs).unwrap()), r#"[1,null,"3",[4,5],{"six":7.7}]"#);
         // Without the subtype flag, the same text quotes as a string.
         assert_eq!(txt(json_array(&[v("[4,5]")], &[false]).unwrap()), r#"["[4,5]"]"#);
+    }
+
+    #[test]
+    fn test_sql_value_is_json_subtyped_marker() {
+        // A Character container value carries the runtime JSON subtype.
+        assert!(sql_value_is_json_subtyped(&SqlValue::Character("[1,2,3]".into())));
+        assert!(sql_value_is_json_subtyped(&SqlValue::Character(r#"{"a":1}"#.into())));
+        // A Character scalar string does NOT (json101-5.11: "[1,2,3]" atom).
+        assert!(!sql_value_is_json_subtyped(&SqlValue::Character("hello".into())));
+        assert!(!sql_value_is_json_subtyped(&SqlValue::Character("123".into())));
+        // Varchar never carries the marker (plain text).
+        assert!(!sql_value_is_json_subtyped(&SqlValue::Varchar("[1,2,3]".into())));
+        // Non-text values never carry it.
+        assert!(!sql_value_is_json_subtyped(&SqlValue::Integer(1)));
+        assert!(!sql_value_is_json_subtyped(&SqlValue::Null));
+    }
+
+    #[test]
+    fn test_json_insert_embeds_runtime_subtyped_value() {
+        // json101-5.10: a container `value` column (Character marker) embeds as
+        // JSON even though its AST subtype flag is false (opaque column ref).
+        let doc = v("{}");
+        let path = v("$.a");
+        let container = SqlValue::Character("[1,2,3]".into());
+        assert_eq!(
+            txt(json_insert(&[doc.clone(), path.clone(), container], &[false, false, false])
+                .unwrap()),
+            r#"{"a":[1,2,3]}"#
+        );
+        // json101-5.11: a plain-text (Varchar) string value stays quoted.
+        let string_val = v("[1,2,3]");
+        assert_eq!(
+            txt(json_insert(&[doc, path, string_val], &[false, false, false]).unwrap()),
+            r#"{"a":"[1,2,3]"}"#
+        );
     }
 
     #[test]

--- a/crates/vibesql-executor/src/evaluator/json_subtype.rs
+++ b/crates/vibesql-executor/src/evaluator/json_subtype.rs
@@ -1,0 +1,357 @@
+//! Runtime JSON subtype recovery for `subtype(X)`.
+//!
+//! SQLite tags values produced by JSON functions with an internal *JSON
+//! subtype* (the integer 74, ASCII `'J'`). `subtype(X)` returns that tag, and
+//! several conformance tests gate on it (json102-1600/1610/1620). VibeSQL does
+//! not store the subtype on the [`SqlValue`] itself (that would be a pervasive
+//! change to a type matched in hundreds of places), so this module recovers the
+//! subtype *structurally* from the argument expression combined with its
+//! evaluated value:
+//!
+//! - `->` (`JsonExtract`): JSON subtype whenever the result is non-NULL.
+//! - `->>` (`JsonExtractText`): never JSON subtype.
+//! - `json()`, `json_array()`, `json_object()`, and the insert/replace/set/
+//!   remove/patch mutation functions (plus `jsonb_*` aliases): JSON subtype
+//!   whenever the result is non-NULL.
+//! - `json_extract()` / `json_quote()`: conditional — JSON subtype only when the
+//!   result is a JSON container (array/object), matching SQLite's behaviour of
+//!   tagging only container extractions.
+//! - `if()` / `iif()` / `coalesce()` / `ifnull()` / `nullif()` / `CASE`: the
+//!   subtype of the branch actually selected at runtime (recurses; covers
+//!   json102-1620's `subtype(if(json_valid(x), x->y))`).
+//! - anything else: the value's own runtime subtype marker (see
+//!   [`json_funcs::sql_value_is_json_subtyped`]), which lets a container `value`
+//!   column from json_each/json_tree keep its subtype through an opaque column
+//!   reference (json101-5.10).
+//!
+//! The three evaluator front-ends (`ExpressionEvaluator`,
+//! `CombinedExpressionEvaluator`, and the arena evaluator) all delegate here via
+//! a closure that performs their own value evaluation, so the rules live in one
+//! place.
+
+use vibesql_ast::{BinaryOperator, CaseWhen, Expression};
+use vibesql_types::SqlValue;
+
+use crate::errors::ExecutorError;
+use crate::evaluator::functions::sqlite_compat::json_funcs;
+use crate::evaluator::operators::is_truthy;
+
+/// SQLite's JSON subtype tag value (ASCII `'J'`).
+pub(crate) const JSON_SUBTYPE_TAG: i64 = 74;
+
+/// Function names whose result is *always* JSON-subtyped when non-NULL.
+fn is_unconditional_json_producer(name: &str) -> bool {
+    matches!(
+        name,
+        "json"
+            | "json_array"
+            | "json_object"
+            | "json_insert"
+            | "json_replace"
+            | "json_set"
+            | "json_remove"
+            | "json_patch"
+            | "jsonb"
+            | "jsonb_array"
+            | "jsonb_object"
+            | "jsonb_insert"
+            | "jsonb_replace"
+            | "jsonb_set"
+            | "jsonb_remove"
+            | "jsonb_patch"
+    )
+}
+
+/// Does this SQL text value hold a JSON *container* (array or object)? SQLite's
+/// conditional-subtype producers (`json_extract`, `->`) carry the JSON subtype
+/// only for container results, never for extracted scalars.
+pub(crate) fn value_is_json_container(value: &SqlValue) -> bool {
+    match value {
+        SqlValue::Varchar(s) | SqlValue::Character(s) => {
+            matches!(
+                json_funcs::parse_json_relaxed(s.as_str()),
+                Ok(serde_json::Value::Array(_)) | Ok(serde_json::Value::Object(_))
+            )
+        }
+        _ => false,
+    }
+}
+
+/// Evaluate `subtype(X)`: `Integer(74)` when the argument carries the JSON
+/// subtype at runtime, `Integer(0)` otherwise. `eval` evaluates a sub-expression
+/// against the current row using the caller's evaluator.
+pub(crate) fn eval_subtype<F>(args: &[Expression], eval: &F) -> Result<SqlValue, ExecutorError>
+where
+    F: Fn(&Expression) -> Result<SqlValue, ExecutorError>,
+{
+    if args.len() != 1 {
+        return Err(ExecutorError::WrongNumberOfArguments { function_name: "subtype".to_string() });
+    }
+    let is_json = expr_json_subtype(&args[0], eval)?;
+    Ok(SqlValue::Integer(if is_json { JSON_SUBTYPE_TAG } else { 0 }))
+}
+
+/// Structurally determine whether `expr` evaluates to a JSON-subtyped value.
+fn expr_json_subtype<F>(expr: &Expression, eval: &F) -> Result<bool, ExecutorError>
+where
+    F: Fn(&Expression) -> Result<SqlValue, ExecutorError>,
+{
+    Ok(match expr {
+        // `->` always yields the JSON subtype for a non-NULL result; `->>`
+        // never does.
+        Expression::BinaryOp { op: BinaryOperator::JsonExtract, .. } => {
+            !matches!(eval(expr)?, SqlValue::Null)
+        }
+        Expression::BinaryOp { op: BinaryOperator::JsonExtractText, .. } => false,
+        Expression::Function { name, args, .. } => {
+            let canon = name.canonical();
+            if is_unconditional_json_producer(canon) {
+                !matches!(eval(expr)?, SqlValue::Null)
+            } else if matches!(canon, "json_extract" | "jsonb_extract" | "json_quote") {
+                value_is_json_container(&eval(expr)?)
+            } else if matches!(canon, "if" | "iif") {
+                match selected_conditional_branch(args, eval)? {
+                    Some(branch) => expr_json_subtype(branch, eval)?,
+                    None => false,
+                }
+            } else if matches!(canon, "coalesce" | "ifnull") {
+                let mut result = false;
+                for arg in args {
+                    if !matches!(eval(arg)?, SqlValue::Null) {
+                        result = expr_json_subtype(arg, eval)?;
+                        break;
+                    }
+                }
+                result
+            } else if canon == "nullif" && args.len() == 2 {
+                expr_json_subtype(&args[0], eval)?
+            } else {
+                false
+            }
+        }
+        Expression::Case { operand, when_clauses, else_result } => {
+            match selected_case_branch(
+                operand.as_deref(),
+                when_clauses,
+                else_result.as_deref(),
+                eval,
+            )? {
+                Some(branch) => expr_json_subtype(branch, eval)?,
+                None => false,
+            }
+        }
+        // A runtime value already carrying the subtype marker (a container
+        // `value` column from json_each/json_tree reached via a column ref).
+        _ => json_funcs::sql_value_is_json_subtyped(&eval(expr)?),
+    })
+}
+
+/// For an `if`/`iif` call, return the branch expression selected for the current
+/// row (the value paired with the first truthy condition, or the trailing ELSE).
+/// Supports the 2-arg `if(X, Y)` form (implicit `ELSE NULL`) and odd-arity
+/// CASE-chains.
+fn selected_conditional_branch<'a, F>(
+    args: &'a [Expression],
+    eval: &F,
+) -> Result<Option<&'a Expression>, ExecutorError>
+where
+    F: Fn(&Expression) -> Result<SqlValue, ExecutorError>,
+{
+    let mut i = 0;
+    while i + 1 < args.len() {
+        if is_truthy(&eval(&args[i])?) {
+            return Ok(Some(&args[i + 1]));
+        }
+        i += 2;
+    }
+    if !args.len().is_multiple_of(2) {
+        Ok(Some(&args[args.len() - 1]))
+    } else {
+        Ok(None)
+    }
+}
+
+/// For a CASE expression, return the branch (THEN or ELSE) selected for the
+/// current row, or `None` when no branch matches and there is no ELSE.
+fn selected_case_branch<'a, F>(
+    operand: Option<&'a Expression>,
+    when_clauses: &'a [CaseWhen],
+    else_result: Option<&'a Expression>,
+    eval: &F,
+) -> Result<Option<&'a Expression>, ExecutorError>
+where
+    F: Fn(&Expression) -> Result<SqlValue, ExecutorError>,
+{
+    let operand_val = match operand {
+        Some(op) => Some(eval(op)?),
+        None => None,
+    };
+    for wc in when_clauses {
+        for cond in &wc.conditions {
+            let matched = match &operand_val {
+                Some(ov) => {
+                    let cv = eval(cond)?;
+                    crate::evaluator::core::values_are_equal(ov, &cv)
+                }
+                None => is_truthy(&eval(cond)?),
+            };
+            if matched {
+                return Ok(Some(&wc.result));
+            }
+        }
+    }
+    Ok(else_result)
+}
+
+#[cfg(test)]
+mod tests {
+    use vibesql_ast::{BinaryOperator, Expression, FunctionIdentifier};
+
+    use super::*;
+
+    fn lit(v: SqlValue) -> Expression {
+        Expression::Literal(v)
+    }
+
+    fn func(name: &str, args: Vec<Expression>) -> Expression {
+        Expression::Function { name: FunctionIdentifier::new(name), args, character_unit: None }
+    }
+
+    fn arrow(op: BinaryOperator, left: Expression, right: Expression) -> Expression {
+        Expression::BinaryOp { op, left: Box::new(left), right: Box::new(right) }
+    }
+
+    /// A closure that evaluates literals and the JSON `->`/`->>` operators over
+    /// a fixed document, standing in for a real evaluator. This lets us exercise
+    /// the structural subtype rules without a full executor.
+    fn eval_expr(expr: &Expression) -> Result<SqlValue, ExecutorError> {
+        match expr {
+            Expression::Literal(v) => Ok(v.clone()),
+            Expression::BinaryOp { op, left, right } => {
+                let l = eval_expr(left)?;
+                let r = eval_expr(right)?;
+                json_funcs::eval_json_arrow(&l, &r, matches!(op, BinaryOperator::JsonExtractText))
+            }
+            Expression::Function { name, args, .. } => {
+                let vals: Vec<SqlValue> = args.iter().map(eval_expr).collect::<Result<_, _>>()?;
+                match name.canonical() {
+                    "json" => json_funcs::json(&vals),
+                    "json_extract" => json_funcs::json_extract(&vals),
+                    "json_valid" => json_funcs::json_valid(&vals),
+                    "if" | "iif" => {
+                        // Minimal 2/3-arg conditional for the tests.
+                        if crate::evaluator::operators::is_truthy(&vals[0]) {
+                            Ok(vals[1].clone())
+                        } else if vals.len() >= 3 {
+                            Ok(vals[2].clone())
+                        } else {
+                            Ok(SqlValue::Null)
+                        }
+                    }
+                    other => panic!("eval_expr: unhandled function {other}"),
+                }
+            }
+            other => panic!("eval_expr: unhandled expr {other:?}"),
+        }
+    }
+
+    fn is_json(expr: Expression) -> bool {
+        matches!(eval_subtype(&[expr], &eval_expr).unwrap(), SqlValue::Integer(74))
+    }
+
+    #[test]
+    fn arrow_operator_is_json_when_non_null() {
+        // '[7,8]' -> 0  => JSON subtype (container)
+        assert!(is_json(arrow(
+            BinaryOperator::JsonExtract,
+            lit(SqlValue::Varchar("[7,8]".into())),
+            lit(SqlValue::Integer(0)),
+        )));
+        // '[7,8]' -> 5  => NULL result => not JSON
+        assert!(!is_json(arrow(
+            BinaryOperator::JsonExtract,
+            lit(SqlValue::Varchar("[7,8]".into())),
+            lit(SqlValue::Integer(5)),
+        )));
+    }
+
+    #[test]
+    fn arrow_text_operator_never_json() {
+        assert!(!is_json(arrow(
+            BinaryOperator::JsonExtractText,
+            lit(SqlValue::Varchar(r#"{"a":[1,2]}"#.into())),
+            lit(SqlValue::Varchar("$.a".into())),
+        )));
+    }
+
+    #[test]
+    fn json_producer_is_json() {
+        assert!(is_json(func("json", vec![lit(SqlValue::Varchar("[1,2]".into()))])));
+    }
+
+    #[test]
+    fn json_extract_is_json_only_for_containers() {
+        // json_extract('{"a":[1,2]}','$.a') -> [1,2] (container) => JSON
+        assert!(is_json(func(
+            "json_extract",
+            vec![
+                lit(SqlValue::Varchar(r#"{"a":[1,2]}"#.into())),
+                lit(SqlValue::Varchar("$.a".into())),
+            ],
+        )));
+        // json_extract('{"a":123}','$.a') -> 123 (scalar) => not JSON
+        assert!(!is_json(func(
+            "json_extract",
+            vec![
+                lit(SqlValue::Varchar(r#"{"a":123}"#.into())),
+                lit(SqlValue::Varchar("$.a".into())),
+            ],
+        )));
+    }
+
+    #[test]
+    fn plain_text_and_number_not_json() {
+        assert!(!is_json(lit(SqlValue::Varchar("[1,2]".into()))));
+        assert!(!is_json(lit(SqlValue::Integer(5))));
+    }
+
+    #[test]
+    fn if_recurses_into_selected_branch() {
+        // json102-1620 shape: subtype(if(json_valid(x), x->y)).
+        // Truthy condition -> recurse into the `->` branch (container -> JSON).
+        assert!(is_json(func(
+            "if",
+            vec![
+                func("json_valid", vec![lit(SqlValue::Varchar("[1,2]".into()))]),
+                arrow(
+                    BinaryOperator::JsonExtract,
+                    lit(SqlValue::Varchar("[1,2]".into())),
+                    lit(SqlValue::Integer(0)),
+                ),
+            ],
+        )));
+        // Falsy condition, 2-arg form -> implicit ELSE NULL -> not JSON.
+        assert!(!is_json(func(
+            "if",
+            vec![
+                lit(SqlValue::Integer(0)),
+                func("json", vec![lit(SqlValue::Varchar("[1,2]".into()))]),
+            ],
+        )));
+    }
+
+    #[test]
+    fn character_marker_is_json() {
+        // A container `value` column reaching subtype() as a bare value.
+        assert!(is_json(lit(SqlValue::Character("[1,2,3]".into()))));
+        // A scalar-string Character (json101-5.11 atom) is not.
+        assert!(!is_json(lit(SqlValue::Character("hello".into()))));
+    }
+
+    #[test]
+    fn subtype_wrong_arity_errors() {
+        assert!(eval_subtype(&[], &eval_expr).is_err());
+        assert!(eval_subtype(&[lit(SqlValue::Integer(1)), lit(SqlValue::Integer(2))], &eval_expr)
+            .is_err());
+    }
+}

--- a/crates/vibesql-executor/src/evaluator/json_subtype.rs
+++ b/crates/vibesql-executor/src/evaluator/json_subtype.rs
@@ -20,9 +20,11 @@
 //!   subtype of the branch actually selected at runtime (recurses; covers
 //!   json102-1620's `subtype(if(json_valid(x), x->y))`).
 //! - anything else: the value's own runtime subtype marker (see
-//!   [`json_funcs::sql_value_is_json_subtyped`]), which lets a container `value`
-//!   column from json_each/json_tree keep its subtype through an opaque column
-//!   reference (json101-5.10).
+//!   [`json_funcs::sql_value_is_json_subtyped`]) — but only when the argument
+//!   expression is *eligible* (see [`expr_runtime_json_subtype_eligible`]). This
+//!   lets a container `value` column from json_each/json_tree keep its subtype
+//!   through an opaque column reference (json101-5.10) while an ordinary
+//!   `CHAR(n)` column read never picks it up (issue #6007).
 //!
 //! The three evaluator front-ends (`ExpressionEvaluator`,
 //! `CombinedExpressionEvaluator`, and the arena evaluator) all delegate here via
@@ -77,24 +79,84 @@ pub(crate) fn value_is_json_container(value: &SqlValue) -> bool {
     }
 }
 
+/// Is the argument expression eligible to carry the *runtime* JSON subtype
+/// marker (see [`json_funcs::sql_value_is_json_subtyped`])?
+///
+/// The runtime marker rides on [`SqlValue::Character`], which is also how an
+/// ordinary fixed-width `CHAR(n)` column materialises. To keep the marker from
+/// mis-firing on a CHAR column holding container-shaped text (issue #6007), a
+/// bare read of a column declared with a real string type (CHAR/VARCHAR) is
+/// *not* eligible: its value quotes even when it parses as a JSON container,
+/// matching SQLite. Everything else — literals, function results, arithmetic,
+/// and dynamically-typed columns such as a json_each/json_tree `value` column
+/// (declared `DataType::Null`) — stays eligible, so json101-5.10 still embeds
+/// the container.
+///
+/// `column_is_declared_string` resolves a column reference (by its optional
+/// table qualifier + canonical name) to `true` when the column's *declared*
+/// type is a real string type. It returns `false` for dynamically-typed
+/// (TVF/derived) columns and for unresolved references, both of which remain
+/// eligible.
+pub(crate) fn expr_runtime_json_subtype_eligible<R>(
+    expr: &Expression,
+    column_is_declared_string: &R,
+) -> bool
+where
+    R: Fn(Option<&str>, &str) -> bool,
+{
+    match expr {
+        Expression::ColumnRef(col) => {
+            !column_is_declared_string(col.table_canonical(), col.column_canonical())
+        }
+        _ => true,
+    }
+}
+
+/// Does this declared column type quote container-shaped text (i.e. is it a real
+/// string type: CHAR/VARCHAR/CLOB)? A `CHAR(n)` column read must never pick up
+/// the runtime JSON subtype marker (issue #6007).
+pub(crate) fn data_type_is_string(ty: &vibesql_types::DataType) -> bool {
+    use vibesql_types::DataType;
+    matches!(
+        ty,
+        DataType::Character { .. }
+            | DataType::Varchar { .. }
+            | DataType::CharacterLargeObject
+            | DataType::Name
+    )
+}
+
 /// Evaluate `subtype(X)`: `Integer(74)` when the argument carries the JSON
 /// subtype at runtime, `Integer(0)` otherwise. `eval` evaluates a sub-expression
 /// against the current row using the caller's evaluator.
-pub(crate) fn eval_subtype<F>(args: &[Expression], eval: &F) -> Result<SqlValue, ExecutorError>
+/// `column_is_declared_string` resolves whether a column reference is declared
+/// with a real string type (used to gate the runtime marker; see
+/// [`expr_runtime_json_subtype_eligible`] and issue #6007).
+pub(crate) fn eval_subtype<F, R>(
+    args: &[Expression],
+    eval: &F,
+    column_is_declared_string: &R,
+) -> Result<SqlValue, ExecutorError>
 where
     F: Fn(&Expression) -> Result<SqlValue, ExecutorError>,
+    R: Fn(Option<&str>, &str) -> bool,
 {
     if args.len() != 1 {
         return Err(ExecutorError::WrongNumberOfArguments { function_name: "subtype".to_string() });
     }
-    let is_json = expr_json_subtype(&args[0], eval)?;
+    let is_json = expr_json_subtype(&args[0], eval, column_is_declared_string)?;
     Ok(SqlValue::Integer(if is_json { JSON_SUBTYPE_TAG } else { 0 }))
 }
 
 /// Structurally determine whether `expr` evaluates to a JSON-subtyped value.
-fn expr_json_subtype<F>(expr: &Expression, eval: &F) -> Result<bool, ExecutorError>
+fn expr_json_subtype<F, R>(
+    expr: &Expression,
+    eval: &F,
+    column_is_declared_string: &R,
+) -> Result<bool, ExecutorError>
 where
     F: Fn(&Expression) -> Result<SqlValue, ExecutorError>,
+    R: Fn(Option<&str>, &str) -> bool,
 {
     Ok(match expr {
         // `->` always yields the JSON subtype for a non-NULL result; `->>`
@@ -111,20 +173,20 @@ where
                 value_is_json_container(&eval(expr)?)
             } else if matches!(canon, "if" | "iif") {
                 match selected_conditional_branch(args, eval)? {
-                    Some(branch) => expr_json_subtype(branch, eval)?,
+                    Some(branch) => expr_json_subtype(branch, eval, column_is_declared_string)?,
                     None => false,
                 }
             } else if matches!(canon, "coalesce" | "ifnull") {
                 let mut result = false;
                 for arg in args {
                     if !matches!(eval(arg)?, SqlValue::Null) {
-                        result = expr_json_subtype(arg, eval)?;
+                        result = expr_json_subtype(arg, eval, column_is_declared_string)?;
                         break;
                     }
                 }
                 result
             } else if canon == "nullif" && args.len() == 2 {
-                expr_json_subtype(&args[0], eval)?
+                expr_json_subtype(&args[0], eval, column_is_declared_string)?
             } else {
                 false
             }
@@ -136,13 +198,18 @@ where
                 else_result.as_deref(),
                 eval,
             )? {
-                Some(branch) => expr_json_subtype(branch, eval)?,
+                Some(branch) => expr_json_subtype(branch, eval, column_is_declared_string)?,
                 None => false,
             }
         }
         // A runtime value already carrying the subtype marker (a container
-        // `value` column from json_each/json_tree reached via a column ref).
-        _ => json_funcs::sql_value_is_json_subtyped(&eval(expr)?),
+        // `value` column from json_each/json_tree reached via a column ref) —
+        // but only when the argument expression is eligible, so a plain
+        // `CHAR(n)` column read never reports the JSON subtype (issue #6007).
+        _ => {
+            expr_runtime_json_subtype_eligible(expr, column_is_declared_string)
+                && json_funcs::sql_value_is_json_subtyped(&eval(expr)?)
+        }
     })
 }
 
@@ -255,8 +322,19 @@ mod tests {
         }
     }
 
+    /// Test stub: no column is treated as declared-string, so every argument
+    /// stays eligible for the runtime marker. The CHAR-column disqualification
+    /// is exercised end-to-end by the executor integration tests instead
+    /// (`json_char_column_subtype_tests.rs`).
+    fn no_string_columns(_table: Option<&str>, _column: &str) -> bool {
+        false
+    }
+
     fn is_json(expr: Expression) -> bool {
-        matches!(eval_subtype(&[expr], &eval_expr).unwrap(), SqlValue::Integer(74))
+        matches!(
+            eval_subtype(&[expr], &eval_expr, &no_string_columns).unwrap(),
+            SqlValue::Integer(74)
+        )
     }
 
     #[test]
@@ -350,8 +428,12 @@ mod tests {
 
     #[test]
     fn subtype_wrong_arity_errors() {
-        assert!(eval_subtype(&[], &eval_expr).is_err());
-        assert!(eval_subtype(&[lit(SqlValue::Integer(1)), lit(SqlValue::Integer(2))], &eval_expr)
-            .is_err());
+        assert!(eval_subtype(&[], &eval_expr, &no_string_columns).is_err());
+        assert!(eval_subtype(
+            &[lit(SqlValue::Integer(1)), lit(SqlValue::Integer(2))],
+            &eval_expr,
+            &no_string_columns
+        )
+        .is_err());
     }
 }

--- a/crates/vibesql-executor/src/evaluator/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/mod.rs
@@ -14,6 +14,7 @@ pub mod date_format;
 pub(crate) mod expression_hash;
 pub(crate) mod expressions;
 pub(crate) mod functions;
+pub(crate) mod json_subtype;
 pub(crate) mod operators;
 #[cfg(feature = "parallel")]
 pub(crate) mod parallel;

--- a/crates/vibesql-executor/src/select/scan/table_function.rs
+++ b/crates/vibesql-executor/src/select/scan/table_function.rs
@@ -249,9 +249,20 @@ fn is_container(node: &serde_json::Value) -> bool {
 
 /// The `value` column rendering for a node: scalars use SQLite's `->>`-style
 /// scalar value; containers use their minified JSON text.
+///
+/// A container's `value` carries SQLite's JSON "J" subtype (per the 2024-02-16
+/// json_tree/json_each regression fix, sqlite.org forumpost/ecb94cd210): when
+/// such a value is fed to a JSON construction function it embeds as a
+/// sub-document rather than being quoted as a string (json101-5.10 vs 5.11).
+/// VibeSQL does not carry a distinct subtype tag on `SqlValue`, so it signals
+/// the JSON subtype on TEXT container values by emitting them as
+/// [`SqlValue::Character`] instead of [`SqlValue::Varchar`]. Both variants are
+/// interoperable text everywhere else (display, comparison, `typeof`), so the
+/// marker is invisible to all other consumers; only the JSON construction
+/// functions read it (see `json_funcs::sql_value_is_json_subtyped`).
 fn node_value_column(node: &serde_json::Value) -> SqlValue {
     if is_container(node) {
-        SqlValue::Varchar(json_node_to_json_text(node).into())
+        SqlValue::Character(json_node_to_json_text(node).into())
     } else {
         json_node_to_sql_value(node)
     }

--- a/crates/vibesql-executor/tests/json_char_column_subtype_tests.rs
+++ b/crates/vibesql-executor/tests/json_char_column_subtype_tests.rs
@@ -1,0 +1,159 @@
+//! Regression tests for issue #6007: the JSON "J" subtype marker used to tag
+//! json_each / json_tree container `value` columns must NOT mis-fire on ordinary
+//! fixed-width `CHAR(n)` columns.
+//!
+//! The subtype is carried on [`SqlValue::Character`] (see `node_value_column` in
+//! `select/scan/table_function.rs`), which is also how a `CHAR(n)` column
+//! materialises. A CHAR column holding container-shaped text (e.g. `'[1,2,3]'`)
+//! must still QUOTE when fed to a JSON construction function, matching sqlite3
+//! 3.51, while a genuine json_tree container `value` embeds as a sub-document.
+//!
+//! The fix gates the runtime marker on the argument expression: a bare read of a
+//! column declared with a real string type (CHAR/VARCHAR) is not eligible. The
+//! json_each / json_tree `value` column is declared dynamic (`DataType::Null`),
+//! so it stays eligible.
+//!
+//! Differential expectations verified against sqlite3 3.51:
+//!
+//! | Query                                                  | sqlite3 / VibeSQL     |
+//! |--------------------------------------------------------|-----------------------|
+//! | `json_insert('{}','$.a',c)` over `CHAR(20)` `'[1,2,3]'`| `{"a":"[1,2,3]   ..."}`|
+//! | `json_insert('{}','$.a',c)` over `CHAR(7)`  `'[1,2,3]'`| `{"a":"[1,2,3]"}`      |
+//! | `json_insert('{}','$.a',c)` over `VARCHAR`  `'[1,2,3]'`| `{"a":"[1,2,3]"}`      |
+//! | `json_insert('{}','$.a',value)` FROM json_tree(array)  | `{"a":[1,2,3]}`        |
+//! | `subtype(c)` over a CHAR column                        | `0`                   |
+//! | `subtype(value)` for a json_tree container            | `74`                  |
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            vibesql_executor::InsertExecutor::execute(db, &insert).unwrap();
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+/// Run a single-column, single-row SELECT and return the scalar value.
+fn scalar(db: &vibesql_storage::Database, sql: &str) -> SqlValue {
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Parse failed: {} -- {:?}", sql, e));
+    let vibesql_ast::Statement::Select(select_stmt) = stmt else {
+        panic!("Expected SELECT statement: {}", sql);
+    };
+    let executor = SelectExecutor::new(db);
+    let rows = executor
+        .execute(&select_stmt)
+        .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e));
+    assert_eq!(rows.len(), 1, "expected exactly one row for: {}", sql);
+    let values = rows.into_iter().next().unwrap().values;
+    assert_eq!(values.len(), 1, "expected exactly one column for: {}", sql);
+    values.into_iter().next().unwrap()
+}
+
+fn text(v: &SqlValue) -> String {
+    match v {
+        SqlValue::Varchar(s) | SqlValue::Character(s) => s.to_string(),
+        other => panic!("expected text value, got {:?}", other),
+    }
+}
+
+// --- CHAR(n): container-shaped text must QUOTE (never embed) -----------------
+
+#[test]
+fn json_insert_char20_column_quotes_container_text() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(c CHAR(20))");
+    run_stmt(&mut db, "INSERT INTO t VALUES('[1,2,3]')");
+    // CHAR(20) space-pads to width 20 (SQLite likewise); the value is a quoted
+    // string, NOT an embedded array.
+    let got = text(&scalar(&db, "SELECT json_insert('{}','$.a',c) FROM t"));
+    assert_eq!(got, "{\"a\":\"[1,2,3]             \"}");
+}
+
+#[test]
+fn json_insert_char7_snug_column_quotes_container_text() {
+    // A snug CHAR(7) holding exactly '[1,2,3]' has no padding, so it is byte-for
+    // byte identical to a TVF container marker — the discriminator must be the
+    // column's declared type, not the value's content.
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(c CHAR(7))");
+    run_stmt(&mut db, "INSERT INTO t VALUES('[1,2,3]')");
+    let got = text(&scalar(&db, "SELECT json_insert('{}','$.a',c) FROM t"));
+    assert_eq!(got, "{\"a\":\"[1,2,3]\"}");
+}
+
+#[test]
+fn json_object_and_array_char_column_quote_container_text() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(c CHAR(7))");
+    run_stmt(&mut db, "INSERT INTO t VALUES('[1,2,3]')");
+    assert_eq!(text(&scalar(&db, "SELECT json_object('k', c) FROM t")), "{\"k\":\"[1,2,3]\"}");
+    assert_eq!(text(&scalar(&db, "SELECT json_array(c) FROM t")), "[\"[1,2,3]\"]");
+}
+
+#[test]
+fn subtype_of_char_column_is_zero() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(c CHAR(7))");
+    run_stmt(&mut db, "INSERT INTO t VALUES('[1,2,3]')");
+    assert_eq!(scalar(&db, "SELECT subtype(c) FROM t"), SqlValue::Integer(0));
+}
+
+// --- VARCHAR sibling: identical content also QUOTES -------------------------
+
+#[test]
+fn json_insert_varchar_column_quotes_container_text() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(c VARCHAR(20))");
+    run_stmt(&mut db, "INSERT INTO t VALUES('[1,2,3]')");
+    let got = text(&scalar(&db, "SELECT json_insert('{}','$.a',c) FROM t"));
+    assert_eq!(got, "{\"a\":\"[1,2,3]\"}");
+}
+
+#[test]
+fn subtype_of_varchar_column_is_zero() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(c VARCHAR(20))");
+    run_stmt(&mut db, "INSERT INTO t VALUES('[1,2,3]')");
+    assert_eq!(scalar(&db, "SELECT subtype(c) FROM t"), SqlValue::Integer(0));
+}
+
+// --- json_tree container value must still EMBED (json101-5.10) --------------
+
+#[test]
+fn json_insert_json_tree_container_value_embeds() {
+    let db = vibesql_storage::Database::new();
+    // json101-5.10: the `value` column of a container node carries the J subtype
+    // and embeds as a sub-document.
+    let got = text(&scalar(
+        &db,
+        "SELECT json_insert('{}','$.a',value) FROM json_tree('[1,2,3]') WHERE atom IS NULL",
+    ));
+    assert_eq!(got, "{\"a\":[1,2,3]}");
+}
+
+#[test]
+fn json_insert_json_tree_scalar_string_atom_quotes() {
+    let db = vibesql_storage::Database::new();
+    // json101-5.11: a JSON *string* atom is a scalar, not a container, so it
+    // quotes.
+    let got =
+        text(&scalar(&db, "SELECT json_insert('{}','$.a',value) FROM json_tree('\"[1,2,3]\"')"));
+    assert_eq!(got, "{\"a\":\"[1,2,3]\"}");
+}
+
+#[test]
+fn subtype_of_json_tree_container_value_is_json() {
+    let db = vibesql_storage::Database::new();
+    assert_eq!(
+        scalar(&db, "SELECT subtype(value) FROM json_tree('[1,2,3]') WHERE atom IS NULL"),
+        SqlValue::Integer(74)
+    );
+}

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -5746,20 +5746,25 @@ proc check_single_capability {cap} {
     # Check if capability is supported
     set is_supported [expr {$cap ni $unsupported_caps}]
 
-    # json102 special case (#5989): the JSON table-valued-function block
-    #   ifcapable vtab { ... FROM t, json_each(t.j) ... }
-    # is gated on `vtab` purely because SQLite implements json_each/json_tree
+    # json101/json102 special case (#5989, #6007): the JSON
+    # table-valued-function blocks
+    #   ifcapable vtab { ... FROM t, json_each(t.j) ... }   (json102)
+    #   ifcapable !vtab { finish_test; return }             (json101, line 330)
+    # are gated on `vtab` purely because SQLite implements json_each/json_tree
     # as eponymous virtual tables. VibeSQL implements them natively as
     # FROM-clause functions (non-correlated in #5988, lateral/dependent-join in
-    # #5989), so the block's queries — `FROM user, json_each(user.phone)`,
-    # `FROM big, json_tree(big.json[,'$.path'])`, etc. — run without any real
-    # virtual-table machinery. The block contains NO `CREATE VIRTUAL TABLE` /
-    # fts / rtree / wholenumber usage, so treating `vtab` as capable for this
-    # one file un-gates the JSON TVF tests without enabling genuinely
-    # unsupported vtab features elsewhere. Mirrors the file-scoped where4
-    # `ifcapable` exception above.
+    # #5989), so the guarded queries — `FROM t, json_each(t.j)`,
+    # `FROM j2, json_tree(j2.json)`, etc. — run without any real virtual-table
+    # machinery. Neither guarded region contains `CREATE VIRTUAL TABLE` / fts /
+    # rtree / wholenumber usage, so treating `vtab` as capable for these files
+    # un-gates the JSON TVF tests without enabling genuinely unsupported vtab
+    # features elsewhere. In json101 the `ifcapable !vtab` guard at line 330
+    # otherwise truncates the file after test 5.2b, silently skipping the entire
+    # json_each/json_tree tail (including json101-5.10). Mirrors the file-scoped
+    # where4 `ifcapable` exception above.
     if {$cap eq "vtab" && [info exists ::current_test_file_basename] \
-            && $::current_test_file_basename eq "json102"} {
+            && ($::current_test_file_basename eq "json102" \
+                || $::current_test_file_basename eq "json101")} {
         set is_supported 1
     }
 


### PR DESCRIPTION
## Summary

Implements SQLite's runtime JSON subtype semantics without adding a pervasive subtype tag to `SqlValue` (matched in 128+ exhaustive sites across the workspace — out of scope to touch). The subtype is recovered structurally from the argument expression plus its evaluated runtime value, and container `value` columns from `json_each`/`json_tree` carry the subtype via an interoperable text-variant marker.

Fixes json102-1600/1610/1620 and json101-5.10, plus the two extra root causes the curator identified (2-arg `if(X,Y)`, and json101's harness truncation).

## Changes

- **`subtype(X)` scalar** (was `no such function: subtype`). New shared `evaluator/json_subtype.rs` module computes the subtype structurally; wired into all three evaluator front-ends (`ExpressionEvaluator`, `CombinedExpressionEvaluator`, arena). Rules: `->` is JSON when non-NULL, `->>` never, `json()`/`json_array()`/… always when non-NULL, `json_extract()`/`json_quote()` only for containers, and `if`/`iif`/`coalesce`/`nullif`/`CASE` recurse into the branch actually taken (covers `subtype(if(json_valid(x), x->y))`).
- **2-arg `if(X, Y)` / `iif(X, Y)`** (implicit `ELSE NULL`) in `variadic_conditional` — the second, distinct root cause of json102-1620 (`wrong number of arguments to function if()`).
- **TVF container-value subtype propagation.** `json_each`/`json_tree` emit container `value` columns as `SqlValue::Character` (interoperable with `Varchar` for display/comparison/`typeof`); the JSON construction functions read this marker (validated to be a JSON container so it never mis-fires on an ordinary `CHAR(n)` column) and embed the value as a sub-document (json101-5.10) while a scalar-string atom still quotes (json101-5.11).
- **Harness un-gating.** `scripts/tester_vibesql.tcl` now treats `vtab` as capable for `json101.test` too (mirroring the existing json102 exception), so the `ifcapable !vtab` guard no longer silently truncates the file after test 5.2b — json101-5.10 and the rest of the TVF tail now actually run.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| json102-1600/1610/1620 pass | ✅ | `##TCLTEST## passed json102-1600/1610/1620`; json102 now 297/309 (was 293), remaining failures all binary-JSONB (#6008) |
| json101-5.10 divergence resolved | ✅ | `##TCLTEST## passed json101-5.10` and `json101-5.11`; file now runs 222 tests (was truncated at 42) |
| Differential vs sqlite3 for subtype() | ✅ | literal text `0`, `json()` `74`, `json_extract` container `74` / scalar `0`, table-column `x->'a'` `74` — all match sqlite3 3.51 |
| 2-arg `if(X,Y)` implemented | ✅ | `if(1,'yes')`→`yes`, `if(0,'yes')`→`NULL`; unit tests in control.rs / conditional_funcs.rs |
| No regressions (cargo) | ✅ | `cargo test -p vibesql-executor` → 3377 passed, 0 failed |
| No regressions (func.test) | ✅ | func.test 14546/14749; the single failure (`func-7.1`, `last_insert_rowid()`) is pre-existing and unrelated |

## Test Plan

- `make test-tcl-file FILE=json102.test` → 297/309, json102-1600/1610/1620 pass.
- `tclsh scripts/tester_vibesql.tcl docs/reference/sqlite/test/json101.test --emit-detail` → json101-5.10/5.11 pass, file runs past 5.2b to completion.
- `cargo test -p vibesql-executor` → 3377 passed. New unit tests: structural subtype rules (`json_subtype`), the `Character` runtime marker and `json_insert` embedding (`json_funcs`), and 2-arg `if`/`iif` (`control`/`conditional_funcs`).
- Differential `subtype()` and json101-5.10/5.11 checks vs `sqlite3` 3.51 — all match.

## Note on newly-surfaced json101 failures

Un-gating json101's TVF tail exposes ~18 **pre-existing, unrelated** failures that the `ifcapable !vtab` guard was masking (implicit `rowid` pseudo-column, `pragma_compile_options`, `json_each` id numbering, jsonb BLOBs). These were never executed before, so they are not regressions from this change. Tracked in **#6019**.

Closes #6007