### PR TITLE
fix(cli): prune WAL checkpoint archive on save (keep_checkpoints)

### DIFF
--- a/.vibesqlrc.example
+++ b/.vibesqlrc.example
@@ -33,6 +33,26 @@ format = "table"
 # Default: true
 auto_save = true
 
+# Write-Ahead Log (WAL) durability for file-backed databases.
+# When true, committed DDL and DML survive an unclean shutdown (crash, SIGKILL,
+# power loss) by replaying the WAL from the last checkpoint on open.
+# Default: true
+# wal = true
+
+# Busy timeout (milliseconds) for the exclusive inter-process database lock.
+# A second session opening the same file-backed database waits up to this long
+# before failing with "database is locked". 0 = fail immediately.
+# Default: 5000
+# lock_timeout_ms = 5000
+
+# Number of checkpoint files to retain in <stem>-checkpoints/ after each save.
+# Each \save / clean exit writes a new checkpoint; the oldest are pruned so the
+# archive does not grow unboundedly. Keeping more than 1 lets --recover-fallback
+# fall back to an older checkpoint. A value of 0 is clamped to 1 so the newest
+# checkpoint always survives.
+# Default: 2
+# keep_checkpoints = 2
+
 # ============================================================================
 # History Settings
 # ============================================================================

--- a/crates/vibesql-cli/Cargo.toml
+++ b/crates/vibesql-cli/Cargo.toml
@@ -36,6 +36,7 @@ toml = "1.1"
 dirs = "6.0"
 regex = "1.10"
 rusqlite = { workspace = true }
+log = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/vibesql-cli/src/config.rs
+++ b/crates/vibesql-cli/src/config.rs
@@ -65,6 +65,23 @@ pub struct DatabaseConfig {
     /// SQLite-compatible error `database is locked`. `0` = fail immediately.
     #[serde(default = "default_lock_timeout_ms")]
     pub lock_timeout_ms: u64,
+
+    /// Number of checkpoint files to retain in `<stem>-checkpoints/` after a
+    /// successful `\save` / clean-exit checkpoint (issue #6023).
+    ///
+    /// Each checkpoint on save writes a new `checkpoint_*.vchk`; without
+    /// pruning the archive grows unboundedly (thousands of files over a long
+    /// session). After the new checkpoint is durably written and the WAL is
+    /// truncated, the CLI removes the oldest checkpoints so at most
+    /// `keep_checkpoints` (plus the one just written) remain.
+    ///
+    /// Defaults to `2` (matching
+    /// `vibesql_storage::wal::scheduler::DEFAULT_KEEP_CHECKPOINTS`). Keeping
+    /// more than 1 lets `--recover-fallback` fall back to an older checkpoint
+    /// when the newest is unreadable. A configured value of `0` is clamped to
+    /// `1` so the newest checkpoint always survives.
+    #[serde(default = "default_keep_checkpoints")]
+    pub keep_checkpoints: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -114,6 +131,11 @@ fn default_lock_timeout_ms() -> u64 {
     5000
 }
 
+fn default_keep_checkpoints() -> usize {
+    // Matches vibesql_storage::wal::scheduler::DEFAULT_KEEP_CHECKPOINTS.
+    2
+}
+
 impl Default for DisplayConfig {
     fn default() -> Self {
         DisplayConfig { format: default_format() }
@@ -128,6 +150,7 @@ impl Default for DatabaseConfig {
             sql_mode: default_sql_mode(),
             wal: default_true(),
             lock_timeout_ms: default_lock_timeout_ms(),
+            keep_checkpoints: default_keep_checkpoints(),
         }
     }
 }
@@ -235,6 +258,29 @@ lock_timeout_ms = 250
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.database.lock_timeout_ms, 250);
+    }
+
+    #[test]
+    fn test_keep_checkpoints_defaults_when_unspecified() {
+        // A config that omits `keep_checkpoints` must parse with the default of
+        // 2 (issue #6023), matching DEFAULT_KEEP_CHECKPOINTS in vibesql-storage.
+        let toml_str = r#"
+[database]
+wal = true
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.database.keep_checkpoints, 2);
+        assert_eq!(Config::default().database.keep_checkpoints, 2);
+    }
+
+    #[test]
+    fn test_keep_checkpoints_override_parses() {
+        let toml_str = r#"
+[database]
+keep_checkpoints = 5
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.database.keep_checkpoints, 5);
     }
 
     #[test]

--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -197,11 +197,22 @@ pub struct DbOpenOptions {
     /// to this long before failing with `database is locked`. `0` = fail
     /// immediately.
     pub lock_timeout_ms: u64,
+    /// Number of checkpoint files to retain after a successful checkpoint
+    /// (`[database] keep_checkpoints`, default 2). After each `\save` /
+    /// clean-exit checkpoint the oldest archived checkpoints are pruned so the
+    /// `<stem>-checkpoints/` directory does not grow unboundedly (issue #6023).
+    /// Clamped to a minimum of 1 so the newest checkpoint always survives.
+    pub keep_checkpoints: usize,
 }
 
 impl Default for DbOpenOptions {
     fn default() -> Self {
-        DbOpenOptions { wal: false, recover_fallback: false, lock_timeout_ms: 5000 }
+        DbOpenOptions {
+            wal: false,
+            recover_fallback: false,
+            lock_timeout_ms: 5000,
+            keep_checkpoints: 2,
+        }
     }
 }
 
@@ -300,15 +311,15 @@ impl SqlExecutor {
                     None
                 };
 
-                let (mut db, wal_state) =
-                    wal::WalState::open_with_base(db_path, base, options.recover_fallback)
-                        .map_err(|e| {
-                            anyhow::anyhow!(
-                                "Failed to open WAL-backed database at {}: {}",
-                                db_path,
-                                e
-                            )
-                        })?;
+                let (mut db, wal_state) = wal::WalState::open_with_base(
+                    db_path,
+                    base,
+                    options.recover_fallback,
+                    options.keep_checkpoints,
+                )
+                .map_err(|e| {
+                    anyhow::anyhow!("Failed to open WAL-backed database at {}: {}", db_path, e)
+                })?;
                 // Rebuild expression-index bodies that the snapshot loader left
                 // empty (it cannot evaluate index expressions). Without this an
                 // expression index would silently return zero rows after reopen.

--- a/crates/vibesql-cli/src/executor/wal.rs
+++ b/crates/vibesql-cli/src/executor/wal.rs
@@ -38,7 +38,7 @@ use std::path::{Path, PathBuf};
 use vibesql_storage::{
     wal::{
         truncate_wal, CheckpointWriter, PersistenceConfig, PersistenceEngine, RecoveryConfig,
-        RecoveryManager,
+        RecoveryManager, DEFAULT_KEEP_CHECKPOINTS,
     },
     Database, StorageError,
 };
@@ -94,6 +94,10 @@ impl WalPaths {
 pub struct WalState {
     paths: WalPaths,
     checkpoint_writer: CheckpointWriter,
+    /// Number of checkpoint files to retain after each successful checkpoint
+    /// (issue #6023). Clamped to a minimum of 1 at construction so the newest
+    /// checkpoint always survives pruning.
+    keep_checkpoints: usize,
 }
 
 impl WalState {
@@ -107,7 +111,7 @@ impl WalState {
     /// wrapper is used by the in-crate tests.)
     #[allow(dead_code)]
     pub fn open(db_path: &str) -> Result<(Database, WalState), StorageError> {
-        Self::open_with_base(db_path, None, false)
+        Self::open_with_base(db_path, None, false, DEFAULT_KEEP_CHECKPOINTS)
     }
 
     /// Like [`WalState::open`], with two additions for issue #5807:
@@ -124,6 +128,7 @@ impl WalState {
         db_path: &str,
         base: Option<Database>,
         recover_fallback: bool,
+        keep_checkpoints: usize,
     ) -> Result<(Database, WalState), StorageError> {
         let paths = WalPaths::derive(db_path);
 
@@ -178,7 +183,14 @@ impl WalState {
 
         let checkpoint_writer = CheckpointWriter::new(&paths.checkpoint_dir)?;
 
-        Ok((db, WalState { paths, checkpoint_writer }))
+        // Clamp to a minimum of 1: `keep_checkpoints = 0` would otherwise prune
+        // every checkpoint (including the newest) after a save, leaving nothing
+        // for recovery to load. Keeping at least the newest checkpoint upholds
+        // the fail-closed recovery policy (#5807/#5850). Documented for the CLI
+        // knob in `.vibesqlrc.example` and `DatabaseConfig::keep_checkpoints`.
+        let keep_checkpoints = keep_checkpoints.max(1);
+
+        Ok((db, WalState { paths, checkpoint_writer, keep_checkpoints }))
     }
 
     /// Create a checkpoint of the current database state and truncate the WAL
@@ -189,6 +201,10 @@ impl WalState {
     ///   2. Serializes the in-memory database to uncompressed binary bytes.
     ///   3. Writes a checkpoint at the engine's current LSN.
     ///   4. Truncates the WAL up to that LSN.
+    ///   5. Prunes old checkpoints, keeping the `keep_checkpoints` most recent
+    ///      (issue #6023) so the archive does not grow unboundedly. This runs
+    ///      only after steps 1–4 succeed; a pruning failure is logged, not
+    ///      propagated, so a successful checkpoint is never reported as failed.
     ///
     /// **Fail-safe invariant (issue #5832):** the WAL is truncated in step 4
     /// only after steps 1–3 all succeed. Any failure — serialization error,
@@ -216,6 +232,40 @@ impl WalState {
         //    zero safety buffer: the checkpoint fully captures state at this LSN.
         if self.paths.wal_path.exists() {
             truncate_wal(&self.paths.wal_path, checkpoint_lsn, Some(0))?;
+        }
+
+        // 5. Prune old checkpoints (issue #6023). This runs ONLY after the new
+        //    checkpoint is durably written AND the WAL has been truncated, so
+        //    pruning can never remove a checkpoint the WAL still depends on and
+        //    the newest checkpoint is always present (fail-closed recovery,
+        //    #5807/#5850). `keep_checkpoints` is clamped to >= 1 at construction.
+        //
+        //    A cleanup failure is a logged warning, NOT a checkpoint failure:
+        //    the durable checkpoint + truncated WAL already succeeded, so the
+        //    save must still return Ok.
+        //
+        //    Success is logged via `log::debug!` (not stderr): a routine save
+        //    must stay silent on stderr — an existing contract that other tests
+        //    rely on — and the CLI installs no `log` backend, so this is a
+        //    no-op for end users but observable if one is attached. A *failure*
+        //    is surfaced loudly on stderr, since the CLI would otherwise discard
+        //    a `log::warn!` and the operator must know pruning did not happen.
+        match self.checkpoint_writer.cleanup_old_checkpoints(self.keep_checkpoints) {
+            Ok(removed) if removed > 0 => {
+                log::debug!(
+                    "Pruned {removed} old checkpoint(s), keeping the {} most recent in {}",
+                    self.keep_checkpoints,
+                    self.paths.checkpoint_dir.display()
+                );
+            }
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!(
+                    "WARNING: failed to prune old checkpoints in {} (checkpoint itself succeeded): {}",
+                    self.paths.checkpoint_dir.display(),
+                    e
+                );
+            }
         }
 
         Ok(())

--- a/crates/vibesql-cli/src/main.rs
+++ b/crates/vibesql-cli/src/main.rs
@@ -268,6 +268,11 @@ fn main() -> anyhow::Result<()> {
         // the same file-backed database waits up to this long, then fails
         // with the SQLite-compatible `database is locked`.
         lock_timeout_ms: config.database.lock_timeout_ms,
+        // Checkpoint archive retention (issue #6023): after each successful
+        // save-time checkpoint, prune the oldest checkpoints so the
+        // `<stem>-checkpoints/` directory does not grow unboundedly. Clamped to
+        // a minimum of 1 downstream so the newest checkpoint always survives.
+        keep_checkpoints: config.database.keep_checkpoints,
     };
 
     if let Some(cmd) = args.command {

--- a/crates/vibesql-cli/tests/checkpoint_retention_test.rs
+++ b/crates/vibesql-cli/tests/checkpoint_retention_test.rs
@@ -1,0 +1,178 @@
+// Integration tests for issue #6023:
+//
+//   WAL checkpoint archive grows unboundedly: cleanup_old_checkpoints is never
+//   called.
+//
+// Every `\save` / clean exit writes a fresh `checkpoint_*.vchk`. Before the
+// fix, nothing pruned the archive, so a long-lived workflow (e.g. the TCL test
+// suite) accumulated thousands of checkpoint files. These tests drive a real
+// `vibesql` subprocess through many clean-exit save cycles and assert the
+// checkpoint directory stabilizes at the configured retention count.
+//
+// Invariants asserted end-to-end:
+//
+//   1. With `keep_checkpoints = N`, repeated saves leave at most `N` checkpoint
+//      files (cleanup runs AFTER the new checkpoint is written, so the newest
+//      one is always among the survivors).
+//   2. Recovery is unaffected: after many prune cycles, the latest data is
+//      still recovered on reopen (pruning never removes the newest checkpoint).
+//   3. The `keep_checkpoints = 0` edge case is clamped to "keep at least 1" so
+//      recovery can never be left with an empty archive (fail-closed, #5807).
+
+use std::{fs, path::Path, process::Command};
+
+use tempfile::TempDir;
+
+fn vibesql_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_vibesql")
+}
+
+/// Create a temp `$HOME` containing a `.vibesqlrc` with the given
+/// `keep_checkpoints` value (WAL stays on by default). Returns the temp dir
+/// that must be kept alive for the duration of the test.
+fn home_with_keep_checkpoints(keep: usize) -> TempDir {
+    let home = tempfile::tempdir().expect("create temp home");
+    let rc = format!("[database]\nwal = true\nkeep_checkpoints = {keep}\n");
+    fs::write(home.path().join(".vibesqlrc"), rc).expect("write .vibesqlrc");
+    home
+}
+
+/// Run `vibesql <db> -c <sql>` as a full open + save + clean-exit cycle.
+fn run_cli(home: &TempDir, db: &Path, sql: &str) -> std::process::Output {
+    Command::new(vibesql_binary())
+        .args([db.to_str().unwrap(), "-c", sql])
+        .env("HOME", home.path())
+        .output()
+        .expect("failed to execute vibesql")
+}
+
+fn stdout_of(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn stderr_of(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+/// Count `checkpoint_*.vchk` files in the archive directory.
+fn count_checkpoints(checkpoint_dir: &Path) -> usize {
+    fs::read_dir(checkpoint_dir)
+        .map(|entries| {
+            entries
+                .flatten()
+                .filter(|e| e.path().extension().is_some_and(|ext| ext == "vchk"))
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+/// Core repro: repeated clean-exit saves must NOT accumulate checkpoints
+/// without bound. With `keep_checkpoints = 2`, the archive must never exceed 2
+/// `.vchk` files no matter how many save cycles run.
+#[test]
+fn test_repeated_saves_prune_to_keep_checkpoints() {
+    let keep = 2;
+    let home = home_with_keep_checkpoints(keep);
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("retain.vbsql");
+    let checkpoint_dir = dir.path().join("retain-checkpoints");
+
+    // Session 1: create the table and the checkpoint archive.
+    let output = run_cli(&home, &db, "CREATE TABLE t(a int); INSERT INTO t VALUES(0);");
+    assert!(output.status.success(), "setup failed; stderr: {}", stderr_of(&output));
+
+    // Many more clean-exit save cycles. Each writes a fresh checkpoint then
+    // prunes. The count must stabilize at `keep`, never grow unboundedly.
+    for i in 1..=10 {
+        let output = run_cli(&home, &db, &format!("INSERT INTO t VALUES({i});"));
+        assert!(output.status.success(), "session {i} failed; stderr: {}", stderr_of(&output));
+
+        let n = count_checkpoints(&checkpoint_dir);
+        assert!(
+            n <= keep,
+            "after save cycle {i}, checkpoint count {n} exceeds keep_checkpoints={keep} \
+             (archive is growing unboundedly — issue #6023)"
+        );
+    }
+
+    // Final state: exactly `keep` checkpoints retained (not fewer, not more).
+    let final_count = count_checkpoints(&checkpoint_dir);
+    assert_eq!(
+        final_count, keep,
+        "expected exactly {keep} checkpoints retained, found {final_count}"
+    );
+
+    // Recovery is unaffected: the latest data survives (pruning never removes
+    // the newest checkpoint).
+    let output = run_cli(&home, &db, "SELECT count(*) FROM t;");
+    assert!(output.status.success(), "reopen failed; stderr: {}", stderr_of(&output));
+    // 11 rows: the initial 0 plus 10 inserts.
+    assert!(
+        stdout_of(&output).contains("11"),
+        "row count wrong after pruning cycles: {}",
+        stdout_of(&output)
+    );
+}
+
+/// Edge case: `keep_checkpoints = 0` must be clamped to "keep at least 1" so
+/// recovery is never left with an empty archive (fail-closed recovery, #5807).
+#[test]
+fn test_keep_checkpoints_zero_is_clamped_to_one() {
+    let home = home_with_keep_checkpoints(0);
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("clamp.vbsql");
+    let checkpoint_dir = dir.path().join("clamp-checkpoints");
+
+    let output = run_cli(&home, &db, "CREATE TABLE t(a int); INSERT INTO t VALUES(1);");
+    assert!(output.status.success(), "setup failed; stderr: {}", stderr_of(&output));
+
+    for i in 2..=5 {
+        let output = run_cli(&home, &db, &format!("INSERT INTO t VALUES({i});"));
+        assert!(output.status.success(), "session {i} failed; stderr: {}", stderr_of(&output));
+    }
+
+    // Clamped to 1 — never 0. At least the newest checkpoint always survives.
+    let n = count_checkpoints(&checkpoint_dir);
+    assert_eq!(
+        n, 1,
+        "keep_checkpoints=0 must clamp to 1 (never prune the newest checkpoint), found {n}"
+    );
+
+    // And the data is still recoverable from that single surviving checkpoint.
+    let output = run_cli(&home, &db, "SELECT count(*) FROM t;");
+    assert!(output.status.success(), "reopen failed; stderr: {}", stderr_of(&output));
+    assert!(
+        stdout_of(&output).contains('5'),
+        "data lost after clamped pruning: {}",
+        stdout_of(&output)
+    );
+}
+
+/// A larger retention value keeps more history — confirms the knob actually
+/// varies retention rather than being hard-coded.
+#[test]
+fn test_larger_keep_checkpoints_retains_more() {
+    let keep = 4;
+    let home = home_with_keep_checkpoints(keep);
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("more.vbsql");
+    let checkpoint_dir = dir.path().join("more-checkpoints");
+
+    let output = run_cli(&home, &db, "CREATE TABLE t(a int); INSERT INTO t VALUES(0);");
+    assert!(output.status.success(), "setup failed; stderr: {}", stderr_of(&output));
+
+    for i in 1..=8 {
+        let output = run_cli(&home, &db, &format!("INSERT INTO t VALUES({i});"));
+        assert!(output.status.success(), "session {i} failed; stderr: {}", stderr_of(&output));
+        assert!(
+            count_checkpoints(&checkpoint_dir) <= keep,
+            "count exceeded keep_checkpoints={keep} at cycle {i}"
+        );
+    }
+
+    assert_eq!(
+        count_checkpoints(&checkpoint_dir),
+        keep,
+        "expected {keep} checkpoints retained with a larger retention value"
+    );
+}


### PR DESCRIPTION
## Summary

WAL-backed databases wrote a fresh `checkpoint_*.vchk` on every `\save` / clean exit but never pruned old ones, so the `<stem>-checkpoints/` archive grew unboundedly (the reported repro accumulated 3,087 files over a long TCL run). The storage primitive `CheckpointWriter::cleanup_old_checkpoints` was already implemented and correct but had **zero production callers** — this PR wires it in.

## What changed

- **`WalState::checkpoint`** (`crates/vibesql-cli/src/executor/wal.rs`) now calls `cleanup_old_checkpoints(keep)` as step 5, **after** the new checkpoint is durably written and the WAL is truncated. Pruning can therefore never remove a checkpoint recovery still depends on, and the newest checkpoint always survives (fail-closed recovery policy, #5807 / #5850).
- A **failed prune is a logged warning on stderr, not a checkpoint failure** — `checkpoint()` still returns `Ok(())` if checkpoint-write + WAL-truncate succeeded. The number removed is logged via `log::debug!` so routine saves stay silent on stderr (preserving the existing clean-save contract that `checkpoint_failure_test` relies on).
- **Retention is configurable** via `[database] keep_checkpoints` in `~/.vibesqlrc` (default `2`, matching `vibesql_storage::wal::scheduler::DEFAULT_KEEP_CHECKPOINTS`). Threaded end-to-end exactly like the `lock_timeout_ms` precedent: `DatabaseConfig` -> `DbOpenOptions` -> `main.rs` -> `WalState::open_with_base` -> stored on `WalState`.
- **`keep_checkpoints = 0` edge case**: clamped to a minimum of `1` at construction so the newest checkpoint is never pruned (documented in the config doc comment and `.vibesqlrc.example`).
- Documented the new knob (plus the previously-undocumented `wal` / `lock_timeout_ms`) in `.vibesqlrc.example`.

## Tests

- New `crates/vibesql-cli/tests/checkpoint_retention_test.rs` (3 tests, all passing): repeated clean-exit saves stabilize at the retention count and never grow unboundedly; recovery is unaffected after many prune cycles; `keep_checkpoints = 0` clamps to 1 and data is still recoverable; a larger retention value keeps more.
- New `config.rs` unit tests for `keep_checkpoints` default + override parsing.
- Full `vibesql-cli` suite green (9 test binaries), including `checkpoint_failure_test`, `recovery_failure_test`, `wal_recovery_test` — `--recover-fallback` and recovery-from-newest behavior unchanged.
- `vibesql-storage` checkpoint tests green (existing `cleanup_old_checkpoints` unit test unchanged).

Closes #6023

🤖 Generated with [Claude Code](https://claude.com/claude-code)