### PR TITLE
fix(types): reject calendar-invalid dates at Date::new() choke point

### DIFF
--- a/crates/vibesql-executor/src/memory/row_serialization.rs
+++ b/crates/vibesql-executor/src/memory/row_serialization.rs
@@ -234,10 +234,12 @@ pub fn deserialize_value<R: Read>(reader: &mut R) -> io::Result<SqlValue> {
             let year = i32::from_le_bytes(year_buf);
             let month = month_buf[0];
             let day = day_buf[0];
-            Ok(SqlValue::Date(
-                vibesql_types::Date::new(year, month, day)
-                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
-            ))
+            // Lenient deserialization: reconstruct exactly what was stored.
+            // Databases written before Date::new() became calendar-strict may
+            // contain invalid dates (e.g. 2024-02-30); routing through the
+            // strict Date::new() here would make those files unreadable on
+            // recovery. See Date::from_parts_unchecked for the full rationale.
+            Ok(SqlValue::Date(vibesql_types::Date::from_parts_unchecked(year, month, day)))
         }
         tags::TIME => {
             let mut hour_buf = [0u8; 1];
@@ -273,9 +275,13 @@ pub fn deserialize_value<R: Read>(reader: &mut R) -> io::Result<SqlValue> {
             reader.read_exact(&mut minute_buf)?;
             reader.read_exact(&mut second_buf)?;
             reader.read_exact(&mut nano_buf)?;
-            let date =
-                vibesql_types::Date::new(i32::from_le_bytes(year_buf), month_buf[0], day_buf[0])
-                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            // Lenient deserialization for stored bytes; see the DATE arm above
+            // and Date::from_parts_unchecked for the compatibility rationale.
+            let date = vibesql_types::Date::from_parts_unchecked(
+                i32::from_le_bytes(year_buf),
+                month_buf[0],
+                day_buf[0],
+            );
             let time = vibesql_types::Time::new(
                 hour_buf[0],
                 minute_buf[0],

--- a/crates/vibesql-executor/tests/insert_invalid_date_tests.rs
+++ b/crates/vibesql-executor/tests/insert_invalid_date_tests.rs
@@ -1,0 +1,77 @@
+//! Regression tests for issue #6022: calendar-invalid dates must be rejected
+//! at INSERT / coercion time with a clean, per-row SQL error — not silently
+//! accepted and later blown up inside DATE_ADD / DATEDIFF as a
+//! statement-aborting error.
+//!
+//! `Date::new()` (in `vibesql-types`) is the single construction choke point and
+//! now validates calendar validity (days-per-month + leap years). These tests
+//! confirm the fix surfaces correctly through the full INSERT path
+//! (`insert/validation.rs` -> `s.parse::<Date>()` -> `FromStr` -> `Date::new()`).
+
+use vibesql_executor::{CreateTableExecutor, InsertExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+/// Execute a single statement, returning the `Result` so the test can inspect
+/// errors instead of panicking.
+fn exec(db: &mut Database, sql: &str) -> Result<(), String> {
+    let stmt = Parser::parse_sql(sql).map_err(|e| format!("parse error: {e:?}"))?;
+    match stmt {
+        vibesql_ast::Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).map_err(|e| format!("{e:?}")).map(|_| ())
+        }
+        vibesql_ast::Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).map_err(|e| format!("{e:?}")).map(|_| ())
+        }
+        other => panic!("unexpected statement: {other:?}"),
+    }
+}
+
+fn setup(db: &mut Database) {
+    exec(db, "CREATE TABLE t (d DATE)").expect("create table");
+}
+
+#[test]
+fn insert_feb30_is_rejected_at_insert_time() {
+    let mut db = Database::new();
+    setup(&mut db);
+
+    let result = exec(&mut db, "INSERT INTO t (d) VALUES ('2024-02-30')");
+    assert!(result.is_err(), "Feb 30 must be rejected at INSERT time, got: {result:?}");
+    // The error is a clean parse/coercion error, not a deferred DATE_ADD crash.
+    let msg = result.unwrap_err();
+    assert!(
+        msg.contains("2024-02-30") || msg.to_lowercase().contains("date"),
+        "error should reference the offending date value, got: {msg}"
+    );
+}
+
+#[test]
+fn insert_feb29_non_leap_year_is_rejected() {
+    let mut db = Database::new();
+    setup(&mut db);
+
+    // 2023 is not a leap year.
+    let result = exec(&mut db, "INSERT INTO t (d) VALUES ('2023-02-29')");
+    assert!(result.is_err(), "Feb 29 in non-leap 2023 must be rejected, got: {result:?}");
+}
+
+#[test]
+fn insert_apr31_is_rejected() {
+    let mut db = Database::new();
+    setup(&mut db);
+
+    // April has 30 days.
+    let result = exec(&mut db, "INSERT INTO t (d) VALUES ('2024-04-31')");
+    assert!(result.is_err(), "Apr 31 must be rejected, got: {result:?}");
+}
+
+#[test]
+fn insert_valid_leap_day_succeeds() {
+    let mut db = Database::new();
+    setup(&mut db);
+
+    // 2024 is a leap year: Feb 29 is valid and must still be accepted.
+    let result = exec(&mut db, "INSERT INTO t (d) VALUES ('2024-02-29')");
+    assert!(result.is_ok(), "valid leap day must be accepted, got: {result:?}");
+}

--- a/crates/vibesql-types/src/temporal/date.rs
+++ b/crates/vibesql-types/src/temporal/date.rs
@@ -14,7 +14,19 @@ pub struct Date {
 }
 
 impl Date {
-    /// Create a new Date (validation is basic)
+    /// Create a new Date with full calendar validation.
+    ///
+    /// Rejects not only out-of-range months/days but also calendar-impossible
+    /// combinations such as `2024-02-30`, `2023-02-29` (non-leap February 29),
+    /// and `2024-04-31` (a 31st in a 30-day month). This is the single
+    /// construction choke point for user-facing input (`FromStr`, INSERT
+    /// validation, CAST, and columnar filter string parsing all route through
+    /// here), so validating here fixes every user-facing path at once.
+    ///
+    /// For the persistence/deserialization path (WAL/checkpoint replay), which
+    /// must accept whatever was previously written, use
+    /// [`Date::from_parts_unchecked`] instead — see its docs for the
+    /// compatibility rationale.
     pub fn new(year: i32, month: u8, day: u8) -> Result<Self, String> {
         if !(1..=12).contains(&month) {
             return Err(format!("Invalid month: {}", month));
@@ -22,8 +34,57 @@ impl Date {
         if !(1..=31).contains(&day) {
             return Err(format!("Invalid day: {}", day));
         }
+        let max_day = days_in_month(year, month);
+        if day > max_day {
+            return Err(format!(
+                "Invalid date: {:04}-{:02}-{:02} (month {} has {} day(s) in year {})",
+                year, month, day, month, max_day, year
+            ));
+        }
         Ok(Date { year, month, day })
     }
+
+    /// Construct a `Date` from raw components **without calendar validation**.
+    ///
+    /// This exists solely for the persistence/deserialization path
+    /// (`row_serialization.rs`, WAL/checkpoint replay, in-memory row
+    /// round-trips). Older VibeSQL builds — or the pre-fix version of this
+    /// crate — accepted calendar-invalid dates such as `2024-02-30` at INSERT
+    /// time and persisted them to disk. If deserialization routed through the
+    /// now-strict [`Date::new`], those already-persisted databases would become
+    /// unreadable (a hard recovery failure) after upgrading. To preserve
+    /// backward read compatibility we deliberately keep the stored-byte path
+    /// lenient: previously-written invalid dates load exactly as they were
+    /// stored, while every *new* user-facing construction is rejected by
+    /// [`Date::new`].
+    ///
+    /// Do not use this for user-facing input — only for reconstructing a value
+    /// that was already validated (or intentionally tolerated) at write time.
+    pub fn from_parts_unchecked(year: i32, month: u8, day: u8) -> Self {
+        Date { year, month, day }
+    }
+}
+
+/// Return the number of days in the given month of the given (proleptic
+/// Gregorian) year. `month` must be 1..=12; callers range-check before calling.
+fn days_in_month(year: i32, month: u8) -> u8 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 => {
+            if is_leap_year(year) {
+                29
+            } else {
+                28
+            }
+        }
+        _ => 0,
+    }
+}
+
+/// Proleptic Gregorian leap-year rule (matches `chrono::NaiveDate`).
+fn is_leap_year(year: i32) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
 }
 
 impl FromStr for Date {
@@ -69,5 +130,52 @@ impl Ord for Date {
             .cmp(&other.year)
             .then_with(|| self.month.cmp(&other.month))
             .then_with(|| self.day.cmp(&other.day))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leap_year_rule() {
+        assert!(is_leap_year(2024)); // divisible by 4
+        assert!(is_leap_year(2000)); // divisible by 400
+        assert!(!is_leap_year(1900)); // divisible by 100, not 400
+        assert!(!is_leap_year(2023)); // not divisible by 4
+    }
+
+    #[test]
+    fn days_per_month() {
+        assert_eq!(days_in_month(2024, 1), 31);
+        assert_eq!(days_in_month(2024, 4), 30);
+        assert_eq!(days_in_month(2024, 2), 29); // leap
+        assert_eq!(days_in_month(2023, 2), 28); // non-leap
+        assert_eq!(days_in_month(2024, 12), 31);
+    }
+
+    #[test]
+    fn new_rejects_calendar_invalid_dates() {
+        assert!(Date::new(2024, 2, 30).is_err());
+        assert!(Date::new(2023, 2, 29).is_err());
+        assert!(Date::new(2024, 4, 31).is_err());
+        assert!(Date::new(2024, 13, 1).is_err());
+        assert!(Date::new(2024, 1, 0).is_err());
+    }
+
+    #[test]
+    fn new_accepts_valid_dates() {
+        assert!(Date::new(2024, 2, 29).is_ok());
+        assert!(Date::new(2023, 2, 28).is_ok());
+        assert!(Date::new(2024, 12, 31).is_ok());
+        assert!(Date::new(1970, 1, 1).is_ok());
+    }
+
+    #[test]
+    fn from_parts_unchecked_is_lenient() {
+        // The persistence/deserialization path must reconstruct whatever was
+        // stored, including calendar-invalid dates written by older builds.
+        let d = Date::from_parts_unchecked(2024, 2, 30);
+        assert_eq!((d.year, d.month, d.day), (2024, 2, 30));
     }
 }

--- a/crates/vibesql-types/tests/timestamp_parsing_tests.rs
+++ b/crates/vibesql-types/tests/timestamp_parsing_tests.rs
@@ -211,6 +211,60 @@ fn test_invalid_date_component() {
     assert!(result.is_err());
 }
 
+// ----------------------------------------------------------------------------
+// Calendar-invalid dates (issue #6022)
+// Date::new() must reject dates that are in-range component-wise but do not
+// exist on the calendar (wrong day-for-month, non-leap Feb 29). These must be
+// rejected both via Date::new() directly and via the FromStr / Timestamp paths.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn test_invalid_date_feb30() {
+    // February never has 30 days, in any year.
+    assert!(Date::new(2024, 2, 30).is_err());
+    assert!(Date::new(2023, 2, 30).is_err());
+    assert!("2024-02-30".parse::<Date>().is_err());
+    assert!("2024-02-30T12:00:00".parse::<Timestamp>().is_err());
+}
+
+#[test]
+fn test_invalid_date_feb29_non_leap_year() {
+    // 2023 is not a leap year, so Feb 29 does not exist.
+    assert!(Date::new(2023, 2, 29).is_err());
+    assert!("2023-02-29".parse::<Date>().is_err());
+    assert!("2023-02-29T12:00:00".parse::<Timestamp>().is_err());
+
+    // 1900 is divisible by 100 but not 400 -> not a leap year.
+    assert!(Date::new(1900, 2, 29).is_err());
+    assert!("1900-02-29".parse::<Date>().is_err());
+
+    // Sanity: 2000 IS a leap year (divisible by 400).
+    assert!(Date::new(2000, 2, 29).is_ok());
+}
+
+#[test]
+fn test_invalid_date_apr31() {
+    // April has 30 days, so the 31st does not exist. Same for the other
+    // 30-day months (Jun, Sep, Nov).
+    assert!(Date::new(2024, 4, 31).is_err());
+    assert!(Date::new(2024, 6, 31).is_err());
+    assert!(Date::new(2024, 9, 31).is_err());
+    assert!(Date::new(2024, 11, 31).is_err());
+    assert!("2024-04-31".parse::<Date>().is_err());
+    assert!("2024-04-31T00:00:00".parse::<Timestamp>().is_err());
+
+    // Sanity: 31-day months still accept the 31st.
+    assert!(Date::new(2024, 1, 31).is_ok());
+    assert!(Date::new(2024, 12, 31).is_ok());
+}
+
+#[test]
+fn test_valid_leap_day_via_date_new() {
+    // Direct Date::new() confirmation that a valid leap day is accepted
+    // (complements test_leap_year_date which goes through the Timestamp path).
+    assert!(Date::new(2024, 2, 29).is_ok());
+}
+
 #[test]
 fn test_invalid_time_component() {
     let result = "2025-11-10T25:00:00".parse::<Timestamp>();


### PR DESCRIPTION
Closes #6022

## Problem

`Date::new()` (`crates/vibesql-types/src/temporal/date.rs`) only range-checked `month` (1..=12) and `day` (1..=31) — it never validated days-per-month or leap years. `FromStr` delegates to `Date::new()`, so it inherited the gap. As a result, calendar-impossible dates such as `2024-02-30`, `2023-02-29` (Feb 29 in a non-leap year), and `2024-04-31` were **silently accepted at INSERT** and only blew up later inside `DATE_ADD`/`DATEDIFF` as a statement-aborting `ExecutorError::UnsupportedFeature`, rather than a clean per-row rejection at write time.

## Fix

`Date::new()` — the single construction choke point — now validates calendar validity (days-per-month + proleptic-Gregorian leap years, matching `chrono::NaiveDate` and the check already used in `arithmetic.rs`). Because `FromStr`, INSERT validation (`insert/validation.rs` -> `s.parse::<Date>()`), CAST/coercion, and the columnar filter string-parse path (`comparison.rs::parse_date_string`) all route through `Date::new()`, the fix surfaces on every user-facing path at once:

- **INSERT** (`INSERT INTO t VALUES ('2024-02-30')`) now fails at INSERT time with a clean per-row `Cannot parse '...' as DATE` error (not a deferred crash, not a whole-statement abort).
- **CAST / coercion** paths reject invalid dates through the same choke point.
- **Columnar/SIMD filter** (`WHERE date_col = '2024-02-30'`): `parse_date_string` already delegates to `Date::new(...).ok()` and returns `None` on failure, so it now consistently treats invalid date literals as unparseable and falls back to string comparison per its documented `Option` contract — no behavior split from the INSERT path.

### Why inline validation instead of `chrono`

`vibesql-types` deliberately keeps a minimal dependency set (`arcstr`, `ryu`). Rather than pull `chrono` into this foundational crate for a trivial check, the days-per-month/leap-year logic is implemented inline (`days_in_month` + `is_leap_year`), with unit tests confirming it matches the Gregorian rule (2000 leap, 1900 not, etc.).

## Deserialization compatibility decision (curator-flagged)

`crates/vibesql-executor/src/memory/row_serialization.rs` deserializes previously-**stored** row bytes (WAL/checkpoint replay, in-memory row round-trips). If those sites routed through the now-strict `Date::new()`, any database that already persisted an invalid date (written by a pre-fix build) would become **unreadable** on recovery — a hard open failure instead of loading.

**Decision:** keep the persistence/deserialization path **lenient**, keep user-facing construction **strict**. A new `Date::from_parts_unchecked(year, month, day)` constructor reconstructs stored bytes exactly as written (no calendar validation), and `row_serialization.rs` (both the DATE and TIMESTAMP arms) now uses it. `Date::new()` remains strict for all user-facing input. This preserves backward read compatibility: previously-written invalid dates load exactly as stored, while every new user-facing construction is rejected.

## Tests

- `crates/vibesql-types/tests/timestamp_parsing_tests.rs`: new `test_invalid_date_feb30`, `test_invalid_date_feb29_non_leap_year` (2023 and 1900), `test_invalid_date_apr31`, `test_valid_leap_day_via_date_new`; existing `test_leap_year_date` (2024-02-29 accepted) and `test_invalid_date_component` (month 13 rejected) still pass.
- `crates/vibesql-types/src/temporal/date.rs`: unit tests for `is_leap_year`, `days_in_month`, strict `Date::new()` rejection/acceptance, and lenient `from_parts_unchecked`.
- `crates/vibesql-executor/tests/insert_invalid_date_tests.rs` (new): end-to-end INSERT-path tests confirming Feb 30 / non-leap Feb 29 / Apr 31 are rejected at INSERT time and valid leap day (2024-02-29) is accepted.

### Results
- `cargo test -p vibesql-types`: all pass (new + existing).
- `cargo test -p vibesql-executor --lib`: 3377 passed, 0 failed.
- `insert_invalid_date_tests`, `date_arithmetic_tests`, `date_time_function_tests`, `insert_basic/constraint_tests`, `temporal_index_probe_tests`, `columnar_filter_type_pairs_tests`: all pass.
- `cargo fmt` (my files clean) + `cargo clippy` on both crates: no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)