### PR TITLE
fix(json): recover subtype() across json_quote / CAST / scalar-subquery boundaries

### DIFF
--- a/crates/vibesql-executor/src/evaluator/arena.rs
+++ b/crates/vibesql-executor/src/evaluator/arena.rs
@@ -181,10 +181,14 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
             ArenaExpression::BinaryOp { op: BinaryOperator::JsonExtractText, .. } => false,
             ArenaExpression::Extended(ArenaExtendedExpr::Function { name, args, .. }) => {
                 let canon = self.resolve(*name).to_ascii_lowercase();
-                if self.arena_expr_has_json_subtype(expr) {
+                // `json_quote` always returns valid JSON text and SQLite tags it
+                // with subtype 74 unconditionally, so for `subtype()` recovery it
+                // is an unconditional producer. (It is deliberately not an
+                // *embedding* producer in `arena_expr_has_json_subtype`, so its
+                // quoted output keeps quoting when passed to another JSON func.)
+                if self.arena_expr_has_json_subtype(expr) || canon == "json_quote" {
                     !matches!(self.eval(expr, row)?, SqlValue::Null)
-                } else if matches!(canon.as_str(), "json_extract" | "jsonb_extract" | "json_quote")
-                {
+                } else if matches!(canon.as_str(), "json_extract" | "jsonb_extract") {
                     crate::evaluator::json_subtype::value_is_json_container(&self.eval(expr, row)?)
                 } else if matches!(canon.as_str(), "if" | "iif") {
                     match self.arena_selected_conditional_branch(args, row)? {
@@ -218,6 +222,27 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
                     row,
                 )? {
                     Some(branch) => self.arena_expr_json_subtype(branch, row)?,
+                    None => false,
+                }
+            }
+            // `CAST(inner AS <text type>)` preserves the JSON subtype of `inner`
+            // (`CAST(json('[1,2]') AS TEXT)` is still subtype 74). A non-text cast
+            // drops the subtype. Arena mirror of the standard evaluator.
+            ArenaExpression::Extended(ArenaExtendedExpr::Cast { expr: inner, data_type })
+                if crate::evaluator::json_subtype::data_type_is_string(data_type) =>
+            {
+                self.arena_expr_json_subtype(inner, row)?
+            }
+            // Scalar subquery with a single projected expression: recurse into
+            // that projected expression, so `subtype((SELECT json('[1,2]')))`
+            // reports the subtype of `json('[1,2]')`. Best-effort: an evaluation
+            // error on the projected expression yields no subtype rather than
+            // propagating.
+            ArenaExpression::Extended(ArenaExtendedExpr::ScalarSubquery(select)) => {
+                match self.arena_single_projected_expression(select) {
+                    Some(projected) => {
+                        self.arena_expr_json_subtype(projected, row).unwrap_or(false)
+                    }
                     None => false,
                 }
             }
@@ -279,6 +304,24 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
             }
         }
         Ok(else_result)
+    }
+
+    /// Return the single projected expression of an arena scalar subquery, or
+    /// `None` when the projection is not exactly one plain expression (a
+    /// wildcard, a set operation, or a multi-column projection all disqualify).
+    /// Arena mirror of
+    /// [`crate::evaluator::json_subtype`]'s `single_projected_expression`.
+    fn arena_single_projected_expression<'e>(
+        &self,
+        select: &'e arena_ast::SelectStmt<'arena>,
+    ) -> Option<&'e ArenaExpression<'arena>> {
+        if select.set_operation.is_some() {
+            return None;
+        }
+        match select.select_list.as_slice() {
+            [arena_ast::SelectItem::Expression { expr, .. }] => Some(expr),
+            _ => None,
+        }
     }
 
     /// Evaluate an arena-allocated expression against a row.

--- a/crates/vibesql-executor/src/evaluator/json_subtype.rs
+++ b/crates/vibesql-executor/src/evaluator/json_subtype.rs
@@ -10,12 +10,26 @@
 //!
 //! - `->` (`JsonExtract`): JSON subtype whenever the result is non-NULL.
 //! - `->>` (`JsonExtractText`): never JSON subtype.
-//! - `json()`, `json_array()`, `json_object()`, and the insert/replace/set/
-//!   remove/patch mutation functions (plus `jsonb_*` aliases): JSON subtype
-//!   whenever the result is non-NULL.
-//! - `json_extract()` / `json_quote()`: conditional — JSON subtype only when the
-//!   result is a JSON container (array/object), matching SQLite's behaviour of
-//!   tagging only container extractions.
+//! - `json()`, `json_array()`, `json_object()`, `json_quote()`, and the insert/
+//!   replace/set/remove/patch mutation functions (plus `jsonb_*` aliases): JSON
+//!   subtype whenever the result is non-NULL. `json_quote()` always returns valid
+//!   JSON text and SQLite tags it with subtype 74 unconditionally, so — for
+//!   `subtype()` purposes — it is an unconditional JSON producer here. (It is
+//!   deliberately *not* treated as an embedding producer in `special.rs` /
+//!   `arena.rs`, which keeps json_quote's quoted result quoting when passed into
+//!   another JSON function.)
+//! - `json_extract()`: conditional — JSON subtype only when the result is a JSON
+//!   container (array/object), matching SQLite's behaviour of tagging only
+//!   container extractions.
+//! - `CAST(inner AS <text type>)`: recurses into `inner`, so
+//!   `subtype(CAST(json('[1,2]') AS TEXT))` reports the subtype of `json('[1,2]')`
+//!   (SQLite preserves the JSON subtype across a text-typed CAST).
+//! - a scalar subquery `(SELECT expr ...)` with a single projected expression:
+//!   recurses into that projected expression, so `subtype((SELECT json('[1,2]')))`
+//!   reports the subtype of `json('[1,2]')`. The recursion is best-effort — if the
+//!   projected expression cannot be evaluated against the current row (e.g. it
+//!   references a subquery-local column) the recursion yields no subtype rather
+//!   than erroring.
 //! - `if()` / `iif()` / `coalesce()` / `ifnull()` / `nullif()` / `CASE`: the
 //!   subtype of the branch actually selected at runtime (recurses; covers
 //!   json102-1620's `subtype(if(json_valid(x), x->y))`).
@@ -31,7 +45,7 @@
 //! a closure that performs their own value evaluation, so the rules live in one
 //! place.
 
-use vibesql_ast::{BinaryOperator, CaseWhen, Expression};
+use vibesql_ast::{BinaryOperator, CaseWhen, Expression, SelectItem, SelectStmt};
 use vibesql_types::SqlValue;
 
 use crate::errors::ExecutorError;
@@ -41,13 +55,21 @@ use crate::evaluator::operators::is_truthy;
 /// SQLite's JSON subtype tag value (ASCII `'J'`).
 pub(crate) const JSON_SUBTYPE_TAG: i64 = 74;
 
-/// Function names whose result is *always* JSON-subtyped when non-NULL.
+/// Function names whose result is *always* JSON-subtyped when non-NULL (for
+/// `subtype()` recovery purposes).
+///
+/// `json_quote` is included: it always emits valid JSON text and SQLite tags it
+/// with subtype 74 unconditionally. Note this is broader than the *embedding*
+/// producer set in `special.rs` / `arena.rs` — json_quote is intentionally not an
+/// embedding producer there, so its quoted output keeps quoting when passed into
+/// another JSON function.
 fn is_unconditional_json_producer(name: &str) -> bool {
     matches!(
         name,
         "json"
             | "json_array"
             | "json_object"
+            | "json_quote"
             | "json_insert"
             | "json_replace"
             | "json_set"
@@ -62,6 +84,13 @@ fn is_unconditional_json_producer(name: &str) -> bool {
             | "jsonb_remove"
             | "jsonb_patch"
     )
+}
+
+/// Does this declared type qualify as a *text* target for the `CAST(inner AS
+/// <text type>)` subtype pass-through? SQLite preserves the JSON subtype across a
+/// text-typed CAST (`CAST(json('[1,2]') AS TEXT)` keeps subtype 74).
+fn data_type_is_text_cast_target(ty: &vibesql_types::DataType) -> bool {
+    data_type_is_string(ty)
 }
 
 /// Does this SQL text value hold a JSON *container* (array or object)? SQLite's
@@ -148,7 +177,21 @@ where
     Ok(SqlValue::Integer(if is_json { JSON_SUBTYPE_TAG } else { 0 }))
 }
 
+/// The evaluator closure the structural walk uses, as a trait object.
+///
+/// Using `&dyn Fn` (rather than a generic `F`) is deliberate: the scalar-subquery
+/// arm wraps `eval` in a fresh error-swallowing closure and recurses, which — with
+/// a generic parameter — would instantiate a new type on every recursion and blow
+/// the monomorphization recursion limit. A single trait-object instantiation
+/// recurses freely.
+type EvalFn<'a> = dyn Fn(&Expression) -> Result<SqlValue, ExecutorError> + 'a;
+/// The column-type resolver, as a trait object (see [`EvalFn`]).
+type ColumnIsStringFn<'a> = dyn Fn(Option<&str>, &str) -> bool + 'a;
+
 /// Structurally determine whether `expr` evaluates to a JSON-subtyped value.
+///
+/// Generic entry point: erases `eval` / `column_is_declared_string` to trait
+/// objects and delegates to [`expr_json_subtype_dyn`].
 fn expr_json_subtype<F, R>(
     expr: &Expression,
     eval: &F,
@@ -158,6 +201,16 @@ where
     F: Fn(&Expression) -> Result<SqlValue, ExecutorError>,
     R: Fn(Option<&str>, &str) -> bool,
 {
+    expr_json_subtype_dyn(expr, eval, column_is_declared_string)
+}
+
+/// Trait-object body of [`expr_json_subtype`] (single instantiation; see
+/// [`EvalFn`]).
+fn expr_json_subtype_dyn(
+    expr: &Expression,
+    eval: &EvalFn<'_>,
+    column_is_declared_string: &ColumnIsStringFn<'_>,
+) -> Result<bool, ExecutorError> {
     Ok(match expr {
         // `->` always yields the JSON subtype for a non-NULL result; `->>`
         // never does.
@@ -169,24 +222,24 @@ where
             let canon = name.canonical();
             if is_unconditional_json_producer(canon) {
                 !matches!(eval(expr)?, SqlValue::Null)
-            } else if matches!(canon, "json_extract" | "jsonb_extract" | "json_quote") {
+            } else if matches!(canon, "json_extract" | "jsonb_extract") {
                 value_is_json_container(&eval(expr)?)
             } else if matches!(canon, "if" | "iif") {
                 match selected_conditional_branch(args, eval)? {
-                    Some(branch) => expr_json_subtype(branch, eval, column_is_declared_string)?,
+                    Some(branch) => expr_json_subtype_dyn(branch, eval, column_is_declared_string)?,
                     None => false,
                 }
             } else if matches!(canon, "coalesce" | "ifnull") {
                 let mut result = false;
                 for arg in args {
                     if !matches!(eval(arg)?, SqlValue::Null) {
-                        result = expr_json_subtype(arg, eval, column_is_declared_string)?;
+                        result = expr_json_subtype_dyn(arg, eval, column_is_declared_string)?;
                         break;
                     }
                 }
                 result
             } else if canon == "nullif" && args.len() == 2 {
-                expr_json_subtype(&args[0], eval, column_is_declared_string)?
+                expr_json_subtype_dyn(&args[0], eval, column_is_declared_string)?
             } else {
                 false
             }
@@ -198,16 +251,41 @@ where
                 else_result.as_deref(),
                 eval,
             )? {
-                Some(branch) => expr_json_subtype(branch, eval, column_is_declared_string)?,
+                Some(branch) => expr_json_subtype_dyn(branch, eval, column_is_declared_string)?,
                 None => false,
             }
         }
+        // `CAST(inner AS <text type>)` preserves the JSON subtype of `inner`
+        // (e.g. `CAST(json('[1,2]') AS TEXT)` is still subtype 74). Recurse into
+        // `inner`; a non-text cast (INTEGER/REAL/...) drops the subtype.
+        Expression::Cast { expr: inner, data_type } if data_type_is_text_cast_target(data_type) => {
+            expr_json_subtype_dyn(inner, eval, column_is_declared_string)?
+        }
+        // Scalar subquery with a single projected expression: recurse into that
+        // projected expression, so `subtype((SELECT json('[1,2]')))` reports the
+        // subtype of `json('[1,2]')`. Best-effort: if the projected expression
+        // cannot be evaluated against the current row (e.g. it references a
+        // subquery-local column) the recursion yields no subtype rather than
+        // erroring.
+        Expression::ScalarSubquery(select) => match single_projected_expression(select) {
+            Some(projected) => {
+                let guarded = |e: &Expression| match eval(e) {
+                    Ok(v) => Ok(v),
+                    Err(_) => Ok(SqlValue::Null),
+                };
+                expr_json_subtype_dyn(projected, &guarded, column_is_declared_string)?
+            }
+            None => false,
+        },
         // A runtime value already carrying the subtype marker (a container
         // `value` column from json_each/json_tree reached via a column ref) —
         // but only when the argument expression is eligible, so a plain
         // `CHAR(n)` column read never reports the JSON subtype (issue #6007).
         _ => {
-            expr_runtime_json_subtype_eligible(expr, column_is_declared_string)
+            // `column_is_declared_string` is a `&dyn Fn`; a reference to it still
+            // implements `Fn`, so pass `&column_is_declared_string` to the
+            // generic helper.
+            expr_runtime_json_subtype_eligible(expr, &column_is_declared_string)
                 && json_funcs::sql_value_is_json_subtyped(&eval(expr)?)
         }
     })
@@ -217,13 +295,10 @@ where
 /// row (the value paired with the first truthy condition, or the trailing ELSE).
 /// Supports the 2-arg `if(X, Y)` form (implicit `ELSE NULL`) and odd-arity
 /// CASE-chains.
-fn selected_conditional_branch<'a, F>(
+fn selected_conditional_branch<'a>(
     args: &'a [Expression],
-    eval: &F,
-) -> Result<Option<&'a Expression>, ExecutorError>
-where
-    F: Fn(&Expression) -> Result<SqlValue, ExecutorError>,
-{
+    eval: &EvalFn<'_>,
+) -> Result<Option<&'a Expression>, ExecutorError> {
     let mut i = 0;
     while i + 1 < args.len() {
         if is_truthy(&eval(&args[i])?) {
@@ -240,15 +315,12 @@ where
 
 /// For a CASE expression, return the branch (THEN or ELSE) selected for the
 /// current row, or `None` when no branch matches and there is no ELSE.
-fn selected_case_branch<'a, F>(
+fn selected_case_branch<'a>(
     operand: Option<&'a Expression>,
     when_clauses: &'a [CaseWhen],
     else_result: Option<&'a Expression>,
-    eval: &F,
-) -> Result<Option<&'a Expression>, ExecutorError>
-where
-    F: Fn(&Expression) -> Result<SqlValue, ExecutorError>,
-{
+    eval: &EvalFn<'_>,
+) -> Result<Option<&'a Expression>, ExecutorError> {
     let operand_val = match operand {
         Some(op) => Some(eval(op)?),
         None => None,
@@ -270,6 +342,20 @@ where
     Ok(else_result)
 }
 
+/// Return the single projected expression of a scalar subquery, or `None` when
+/// the projection is not exactly one plain expression (a wildcard, a set
+/// operation, or a multi-column projection all disqualify — none can produce a
+/// scalar JSON value whose subtype we can recover structurally).
+fn single_projected_expression(select: &SelectStmt) -> Option<&Expression> {
+    if select.set_operation.is_some() {
+        return None;
+    }
+    match select.select_list.as_slice() {
+        [SelectItem::Expression { expr, .. }] => Some(expr),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use vibesql_ast::{BinaryOperator, Expression, FunctionIdentifier};
@@ -286,6 +372,38 @@ mod tests {
 
     fn arrow(op: BinaryOperator, left: Expression, right: Expression) -> Expression {
         Expression::BinaryOp { op, left: Box::new(left), right: Box::new(right) }
+    }
+
+    /// `CAST(inner AS <data_type>)`.
+    fn cast(inner: Expression, data_type: vibesql_types::DataType) -> Expression {
+        Expression::Cast { expr: Box::new(inner), data_type }
+    }
+
+    /// A scalar subquery whose sole projected item is `projected`
+    /// (`(SELECT projected)`), with no FROM/WHERE/etc.
+    fn scalar_subquery(projected: Expression) -> Expression {
+        let select = SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list: vec![SelectItem::Expression {
+                expr: projected,
+                alias: None,
+                source_text: None,
+            }],
+            into_table: None,
+            into_variables: None,
+            from: None,
+            where_clause: None,
+            group_by: None,
+            having: None,
+            window_definitions: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            set_operation: None,
+            values: None,
+        };
+        Expression::ScalarSubquery(Box::new(select))
     }
 
     /// A closure that evaluates literals and the JSON `->`/`->>` operators over
@@ -305,6 +423,7 @@ mod tests {
                     "json" => json_funcs::json(&vals),
                     "json_extract" => json_funcs::json_extract(&vals),
                     "json_valid" => json_funcs::json_valid(&vals),
+                    "json_quote" => json_funcs::json_quote(&vals),
                     "if" | "iif" => {
                         // Minimal 2/3-arg conditional for the tests.
                         if crate::evaluator::operators::is_truthy(&vals[0]) {
@@ -318,6 +437,16 @@ mod tests {
                     other => panic!("eval_expr: unhandled function {other}"),
                 }
             }
+            // Minimal CAST for the tests: a text-typed cast returns the inner
+            // value's text unchanged (identity for JSON string values); the
+            // structural subtype pass-through is what we actually exercise.
+            Expression::Cast { expr: inner, .. } => eval_expr(inner),
+            // Minimal scalar-subquery eval for the tests: evaluate the single
+            // projected expression against the (empty) outer row.
+            Expression::ScalarSubquery(select) => match single_projected_expression(select) {
+                Some(projected) => eval_expr(projected),
+                None => Ok(SqlValue::Null),
+            },
             other => panic!("eval_expr: unhandled expr {other:?}"),
         }
     }
@@ -391,6 +520,69 @@ mod tests {
     fn plain_text_and_number_not_json() {
         assert!(!is_json(lit(SqlValue::Varchar("[1,2]".into()))));
         assert!(!is_json(lit(SqlValue::Integer(5))));
+    }
+
+    // --- issue #6021 divergence table: each of these was `0`, SQLite reports 74 ---
+
+    #[test]
+    fn json_quote_is_unconditionally_json() {
+        // subtype(json_quote('[1,2]')) => 74 (SQLite tags json_quote output
+        // unconditionally). Previously container-only -> false negative.
+        assert!(is_json(func("json_quote", vec![lit(SqlValue::Varchar("[1,2]".into()))])));
+        // A scalar argument is still JSON-subtyped (json_quote always emits valid
+        // JSON text): subtype(json_quote('a')) => 74.
+        assert!(is_json(func("json_quote", vec![lit(SqlValue::Varchar("a".into()))])));
+        assert!(is_json(func("json_quote", vec![lit(SqlValue::Integer(5))])));
+    }
+
+    #[test]
+    fn cast_to_text_preserves_json_subtype() {
+        // subtype(CAST(json('[1,2]') AS TEXT)) => 74.
+        assert!(is_json(cast(
+            func("json", vec![lit(SqlValue::Varchar("[1,2]".into()))]),
+            vibesql_types::DataType::Varchar { max_length: None },
+        )));
+        // CAST(inner AS CHAR(n)) / CLOB / NAME all pass through too.
+        assert!(is_json(cast(
+            func("json", vec![lit(SqlValue::Varchar("[1,2]".into()))]),
+            vibesql_types::DataType::Character { length: 16 },
+        )));
+    }
+
+    #[test]
+    fn cast_to_non_text_drops_json_subtype() {
+        // A non-text CAST target is not a JSON producer: subtype drops to 0.
+        assert!(!is_json(cast(
+            func("json", vec![lit(SqlValue::Varchar("[1,2]".into()))]),
+            vibesql_types::DataType::Integer,
+        )));
+    }
+
+    #[test]
+    fn scalar_subquery_projected_expr_preserves_json_subtype() {
+        // subtype((SELECT json('[1,2]'))) => 74.
+        assert!(is_json(scalar_subquery(func(
+            "json",
+            vec![lit(SqlValue::Varchar("[1,2]".into()))],
+        ))));
+        // subtype((SELECT json_quote('[1,2]'))) => 74 (recursion reaches the new
+        // unconditional json_quote rule through the subquery boundary).
+        assert!(is_json(scalar_subquery(func(
+            "json_quote",
+            vec![lit(SqlValue::Varchar("[1,2]".into()))],
+        ))));
+        // A plain-text projection is not JSON-subtyped.
+        assert!(!is_json(scalar_subquery(lit(SqlValue::Varchar("[1,2]".into())))));
+    }
+
+    #[test]
+    fn nested_boundary_producers_compose() {
+        // subtype(CAST((SELECT json('[1,2]')) AS TEXT)) => 74: CAST and
+        // subquery recursion compose.
+        assert!(is_json(cast(
+            scalar_subquery(func("json", vec![lit(SqlValue::Varchar("[1,2]".into()))])),
+            vibesql_types::DataType::Varchar { max_length: None },
+        )));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up from the PR #6020 Judge review. VibeSQL recovers SQLite's JSON `subtype()` **structurally** from the argument expression + its evaluated value (`crates/vibesql-executor/src/evaluator/json_subtype.rs`). Three structural cases returned `0` where SQLite returns `74` — all **false negatives** (never a wrong embedding, so no data corruption), but they diverged from SQLite's `subtype()` output.

| Case | sqlite3 | VibeSQL (before) | VibeSQL (after) |
|---|---|---|---|
| `subtype(json_quote('[1,2]'))` | 74 | 0 | **74** |
| `subtype(CAST(json('[1,2]') AS TEXT))` | 74 | 0 | **74** |
| `subtype((SELECT json('[1,2]')))` | 74 | 0 | **74** |

## Changes

Each change is mirrored in the arena evaluator (`arena.rs`):

1. **json_quote is an unconditional JSON producer** for `subtype()` recovery — SQLite tags `json_quote` output with subtype 74 unconditionally (it always emits valid JSON text). Deliberately **not** added to the *embedding*-producer sets in `special.rs` / `arena.rs`, so json_quote's quoted output keeps quoting when passed into another JSON function. The module doc (which previously called json_quote container-only) is updated.
2. **Recurse through `CAST(inner AS <text type>)`** to `inner`. A non-text cast (INTEGER/REAL/…) still drops the subtype.
3. **Recurse into a scalar subquery's single projected expression**. Best-effort: an eval error on the projected expression yields no subtype rather than propagating.

The structural walk's `eval` closure is erased to a `&dyn Fn` trait object so the new subquery arm can wrap it in an error-swallowing closure and recurse without blowing the monomorphization recursion limit.

## No regressions

The correctly-matching cases still hold (verified by new differential unit tests **and** end-to-end against a real DB):

- `subtype(json_extract(x,'$.a'))` → `0` for scalar / `74` for container
- `subtype(column)` → `0` (plain string column)
- `subtype(json('...'))` → `74`
- `json_each`/`json_tree` container `value` → `74`
- `CAST(json(...) AS INTEGER)` → `0` (non-text cast drops)

## Testing

- 5 new differential unit tests in `json_subtype.rs` (`json_quote_is_unconditionally_json`, `cast_to_text_preserves_json_subtype`, `cast_to_non_text_drops_json_subtype`, `scalar_subquery_projected_expr_preserves_json_subtype`, `nested_boundary_producers_compose`).
- `cargo test -p vibesql-executor` — full suite passes, 0 failures.
- `cargo fmt` / `cargo clippy` clean on touched files (pre-existing crate warnings untouched).
- End-to-end verified with the release CLI on `:memory:`.

## Out of scope

The derived-table provenance-loss case noted in the issue comment (`subtype(v)` where `v` is a json_each container value aliased through a derived table) remains a `0` false negative — it is the harder same-class provenance-loss the issue flags as non-blocking and outside the three suggested-scope items.

Closes #6021

🤖 Generated with [Claude Code](https://claude.com/claude-code)