### PR TITLE
fix(executor): advance row-path LIKE '%' skip loop by whole UTF-8 characters

### DIFF
--- a/crates/vibesql-executor/src/evaluator/pattern.rs
+++ b/crates/vibesql-executor/src/evaluator/pattern.rs
@@ -158,17 +158,32 @@ fn like_match_with_elements(
 
     match &pattern[pattern_pos] {
         PatternElement::AnySequence => {
-            // % matches zero or more characters
-            for skip in 0..=(text.len() - text_pos) {
+            // % matches zero or more characters.
+            //
+            // The skip cursor must advance one whole UTF-8 character at a time so
+            // that every recursive attempt starts on a character boundary. Stepping
+            // by raw byte offsets (0..=len) can leave the cursor mid-character on a
+            // continuation byte; a following `_` (AnyChar) would then call
+            // utf8_char_len on that continuation byte, which falls through to its
+            // "advance by 1" fallback and manufactures fake 1-byte "characters" out
+            // of continuation bytes, producing spurious matches (issue #6016).
+            let mut skip_pos = text_pos;
+            loop {
                 if like_match_with_elements(
                     text,
                     pattern,
-                    text_pos + skip,
+                    skip_pos,
                     pattern_pos + 1,
                     case_sensitive,
                 ) {
                     return true;
                 }
+                if skip_pos >= text.len() {
+                    break;
+                }
+                // Advance by one whole UTF-8 character to keep the cursor on a
+                // character boundary.
+                skip_pos += utf8_char_len(text[skip_pos]);
             }
             false
         }
@@ -417,18 +432,28 @@ fn like_match_recursive(
 
     match pattern_char {
         b'%' => {
-            // % matches zero or more characters
-            // Try matching with % consuming 0 chars, 1 char, 2 chars, etc.
-            for skip in 0..=(text.len() - text_pos) {
-                if like_match_recursive(
-                    text,
-                    pattern,
-                    text_pos + skip,
-                    pattern_pos + 1,
-                    case_sensitive,
-                ) {
+            // % matches zero or more characters.
+            //
+            // The skip cursor must advance one whole UTF-8 character at a time so
+            // that every recursive attempt starts on a character boundary. Stepping
+            // by raw byte offsets (0..=len) can leave the cursor mid-character on a
+            // continuation byte; a following `_` would then call utf8_char_len on
+            // that continuation byte, which falls through to its "advance by 1"
+            // fallback and manufactures fake 1-byte "characters" out of continuation
+            // bytes, producing spurious matches (issue #6016). Advancing whole
+            // characters here restores the "cursor always on a char boundary"
+            // invariant that the columnar GeneralMatcher already upholds.
+            let mut skip_pos = text_pos;
+            loop {
+                if like_match_recursive(text, pattern, skip_pos, pattern_pos + 1, case_sensitive) {
                     return true;
                 }
+                if skip_pos >= text.len() {
+                    break;
+                }
+                // Advance by one whole UTF-8 character to keep the cursor on a
+                // character boundary.
+                skip_pos += utf8_char_len(text[skip_pos]);
             }
             false
         }
@@ -574,6 +599,154 @@ mod tests {
         let escape_char = '\u{1234}';
         let pattern = "a\u{1234}_c";
         assert!(like_match("a_c", pattern, false, Some(escape_char)));
+    }
+
+    #[test]
+    fn test_like_match_multibyte_percent_underscore_issue_6016() {
+        // Issue #6016: row-path LIKE mishandled '%' + multi-byte char + trailing '_'.
+        // 'ሴ' (U+1234) is a single 3-byte UTF-8 character (0xE1 0x88 0xB4).
+        // The '%' skip loop used raw byte offsets, so it could land mid-character
+        // on a continuation byte; a following '_' then treated that continuation
+        // byte as a whole 1-byte "character", so 'ሴ' spuriously satisfied '__'.
+        //
+        // The divergence table from the issue (SQLite ground truth in comments):
+        let s = "\u{1234}"; // "ሴ"
+        assert!(!like_match(s, "%__", false, None), "'ሴ' LIKE '%__' must be false");
+        assert!(!like_match(s, "%___", false, None), "'ሴ' LIKE '%___' must be false");
+        assert!(!like_match(s, "__", false, None), "'ሴ' LIKE '__' must be false");
+        assert!(like_match(s, "_", false, None), "'ሴ' LIKE '_' must be true");
+
+        // A single '%' plus one '_' correctly matches the one-character string.
+        assert!(like_match(s, "%_", false, None), "'ሴ' LIKE '%_' must be true");
+        assert!(like_match(s, "%", false, None), "'ሴ' LIKE '%' must be true");
+        assert!(like_match(s, "_%", false, None), "'ሴ' LIKE '_%' must be true");
+    }
+
+    #[test]
+    fn test_like_match_multibyte_percent_underscore_escape_path_issue_6016() {
+        // Route the same cases through the escape-aware code path
+        // (like_match_with_elements / PatternElement::AnySequence), which had an
+        // identical byte-skip loop. Supplying an escape char that never appears in
+        // the pattern exercises that path without changing wildcard semantics.
+        let s = "\u{1234}"; // "ሴ"
+        let esc = Some('\\');
+        assert!(!like_match(s, "%__", false, esc), "escape-path 'ሴ' LIKE '%__' must be false");
+        assert!(!like_match(s, "%___", false, esc), "escape-path 'ሴ' LIKE '%___' must be false");
+        assert!(!like_match(s, "__", false, esc), "escape-path 'ሴ' LIKE '__' must be false");
+        assert!(like_match(s, "_", false, esc), "escape-path 'ሴ' LIKE '_' must be true");
+        assert!(like_match(s, "%_", false, esc), "escape-path 'ሴ' LIKE '%_' must be true");
+
+        // Escaped wildcard interacting with multi-byte text: a\_ where _ is a
+        // literal underscore should NOT match a multi-byte char after 'a'.
+        assert!(like_match("a_", r"a\_", false, esc));
+        assert!(!like_match("a\u{1234}", r"a\_", false, esc));
+        // But '%' + escaped-literal '_' against multi-byte-then-underscore text.
+        assert!(like_match("\u{1234}_", r"%\_", false, esc));
+        assert!(!like_match("\u{1234}\u{1234}", r"%\_", false, esc));
+    }
+
+    /// A reference LIKE matcher operating on whole Unicode `char`s. This encodes
+    /// the SQLite semantics ('%' = zero-or-more chars, '_' = exactly one char,
+    /// case-insensitive for ASCII letters) directly over `char`s so it cannot
+    /// suffer the byte-boundary bug. Used as ground truth for the parity sweep.
+    fn reference_like(text: &str, pattern: &str) -> bool {
+        let t: Vec<char> = text.chars().collect();
+        let p: Vec<char> = pattern.chars().collect();
+        fn rec(t: &[char], p: &[char], ti: usize, pi: usize) -> bool {
+            if pi >= p.len() {
+                return ti >= t.len();
+            }
+            match p[pi] {
+                '%' => {
+                    let mut k = ti;
+                    loop {
+                        if rec(t, p, k, pi + 1) {
+                            return true;
+                        }
+                        if k >= t.len() {
+                            return false;
+                        }
+                        k += 1;
+                    }
+                }
+                '_' => {
+                    if ti >= t.len() {
+                        return false;
+                    }
+                    rec(t, p, ti + 1, pi + 1)
+                }
+                pc => {
+                    if ti >= t.len() {
+                        return false;
+                    }
+                    let tc = t[ti];
+                    let matches = if pc.is_ascii_alphabetic() && tc.is_ascii_alphabetic() {
+                        pc.eq_ignore_ascii_case(&tc)
+                    } else {
+                        pc == tc
+                    };
+                    matches && rec(t, p, ti + 1, pi + 1)
+                }
+            }
+        }
+        rec(&t, &p, 0, 0)
+    }
+
+    #[test]
+    fn test_like_match_bounded_parity_sweep_issue_6016() {
+        // Bounded parity sweep: alphabet of 1/2/3/4-byte UTF-8 representatives,
+        // crossed with the wildcard pattern alphabet {%, _}, patterns up to
+        // length 3, over text strings up to length 3. Assert the row path agrees
+        // with the char-based reference matcher (SQLite semantics) everywhere.
+        let text_alphabet = ['a', '\u{00E9}', '\u{1234}', '\u{1F600}']; // a é ሴ 😀
+        let pattern_alphabet = ['%', '_'];
+
+        // Build all text strings of length 0..=3 over the text alphabet.
+        let mut texts: Vec<String> = vec![String::new()];
+        for _ in 0..3 {
+            let mut next = Vec::new();
+            for base in &texts {
+                for &c in &text_alphabet {
+                    let mut s = base.clone();
+                    s.push(c);
+                    next.push(s);
+                }
+            }
+            texts.extend(next);
+        }
+
+        // Build all wildcard patterns of length 0..=3 over {%, _}.
+        let mut patterns: Vec<String> = vec![String::new()];
+        for _ in 0..3 {
+            let mut next = Vec::new();
+            for base in &patterns {
+                for &c in &pattern_alphabet {
+                    let mut s = base.clone();
+                    s.push(c);
+                    next.push(s);
+                }
+            }
+            patterns.extend(next);
+        }
+
+        let mut mismatches = Vec::new();
+        for pat in &patterns {
+            for txt in &texts {
+                let got = like_match(txt, pat, false, None);
+                let expected = reference_like(txt, pat);
+                if got != expected {
+                    mismatches.push(format!(
+                        "text={txt:?} pattern={pat:?}: row-path={got} expected={expected}"
+                    ));
+                }
+            }
+        }
+        assert!(
+            mismatches.is_empty(),
+            "row-path LIKE diverged from reference on {} case(s):\n{}",
+            mismatches.len(),
+            mismatches.join("\n")
+        );
     }
 
     #[test]

--- a/crates/vibesql-executor/src/tests/predicate_tests/like_predicate.rs
+++ b/crates/vibesql-executor/src/tests/predicate_tests/like_predicate.rs
@@ -353,3 +353,73 @@ fn test_like_null_value() {
         vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("Alice"))
     );
 }
+
+/// Issue #6016: end-to-end row-path check that a single multi-byte character
+/// does not spuriously satisfy `%__`. Previously the '%' skip loop landed
+/// mid-UTF-8-character, letting a following `_` "eat" a continuation byte as a
+/// whole character, so 'ሴ' matched '%__'. The divergence table (SQLite ground
+/// truth): '%__' -> 0, '%___' -> 0, '__' -> 0, '_' -> 1.
+#[test]
+fn test_like_multibyte_percent_underscore_row_path_issue_6016() {
+    fn count_matching(pattern: &str) -> usize {
+        let mut db = vibesql_storage::Database::new();
+        let schema = vibesql_catalog::TableSchema::new(
+            "test".to_string(),
+            vec![vibesql_catalog::ColumnSchema::new(
+                "s".to_string(),
+                vibesql_types::DataType::Varchar { max_length: Some(50) },
+                false,
+            )],
+        );
+        db.create_table(schema).unwrap();
+        // "ሴ" (U+1234) is a single 3-byte UTF-8 character.
+        db.insert_row(
+            "test",
+            vibesql_storage::Row::new(vec![vibesql_types::SqlValue::Varchar(
+                arcstr::ArcStr::from("\u{1234}"),
+            )]),
+        )
+        .unwrap();
+
+        let executor = SelectExecutor::new(&db);
+        let stmt = vibesql_ast::SelectStmt {
+            with_clause: None,
+            set_operation: None,
+            values: None,
+            distinct: false,
+            select_list: vec![vibesql_ast::SelectItem::Wildcard { alias: None }],
+            from: Some(vibesql_ast::FromClause::Table {
+                index_hint: None,
+                quoted: false,
+                name: "test".to_string(),
+                alias: None,
+                column_aliases: None,
+            }),
+            where_clause: Some(vibesql_ast::Expression::Like {
+                expr: Box::new(vibesql_ast::Expression::ColumnRef(
+                    vibesql_ast::ColumnIdentifier::simple("s", false),
+                )),
+                pattern: Box::new(vibesql_ast::Expression::Literal(
+                    vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from(pattern)),
+                )),
+                negated: false,
+                escape: None,
+            }),
+            group_by: None,
+            having: None,
+            window_definitions: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            into_table: None,
+            into_variables: None,
+        };
+        executor.execute(&stmt).unwrap().len()
+    }
+
+    assert_eq!(count_matching("%__"), 0, "'ሴ' LIKE '%__' must not match");
+    assert_eq!(count_matching("%___"), 0, "'ሴ' LIKE '%___' must not match");
+    assert_eq!(count_matching("__"), 0, "'ሴ' LIKE '__' must not match");
+    assert_eq!(count_matching("_"), 1, "'ሴ' LIKE '_' must match");
+    assert_eq!(count_matching("%_"), 1, "'ሴ' LIKE '%_' must match");
+}

--- a/crates/vibesql-executor/tests/columnar_like_general_path_assertion_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_like_general_path_assertion_tests.rs
@@ -250,3 +250,48 @@ fn general_like_blob_affinity_matches_row_path() {
     let (columnar, row, _logs) = run_both(&db, sql);
     assert_eq!(columnar, row, "BLOB LIKE must match row path (returns false, not error)");
 }
+
+/// Issue #6016: `%` + multi-byte character + trailing `_` must agree between the
+/// row and columnar paths, and match SQLite. Previously the row path's `%` skip
+/// loop landed mid-UTF-8-character so a single 'ሴ' spuriously satisfied `%__`
+/// (row said 1, columnar/SQLite say 0). This asserts cross-path parity for the
+/// full divergence table plus a bounded sweep of `%`/`_` patterns over 1/2/3/4-
+/// byte text characters.
+#[test]
+fn multibyte_percent_underscore_matches_row_path_issue_6016() {
+    init_logger(Level::Debug);
+
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE t (id INTEGER, s TEXT)");
+    // Single-character rows for each of the 1/2/3/4-byte UTF-8 representatives,
+    // plus a couple of two-character strings to exercise `%` skipping across a
+    // whole multi-byte character.
+    let samples = ["a", "é", "ሴ", "😀", "aሴ", "ሴ😀", "aé"];
+    let mut ins = String::new();
+    for (i, s) in samples.iter().enumerate() {
+        ins.push_str(&format!("INSERT INTO t VALUES ({i}, '{s}');"));
+    }
+    execute_sql(&mut db, &ins);
+
+    // The exact divergence table (against single-char 'ሴ' row) plus general
+    // `_`/`%` shapes. Each pattern carries a `_` and/or multiple `%`, so it
+    // classifies General and routes through the matcher under test.
+    let patterns = [
+        "%__",   // divergence-table case: must be 0 for single-char rows
+        "%___",  //
+        "%_",    // one-or-more, then exactly one char
+        "_%",    // exactly one char, then anything
+        "%_%",   // at least one char anywhere
+        "_%_",   // at least two chars
+        "%ሴ%_",  // literal multi-byte char, then trailing _
+        "a%_",   // ASCII prefix then %_ (aሴ etc.)
+        "%😀%_", // 4-byte literal then trailing _
+    ];
+    for p in patterns {
+        let sql = format!("SELECT COUNT(*), SUM(id) FROM t WHERE s LIKE '{p}'");
+        let (columnar, row, _logs) = run_both(&db, &sql);
+        // The essential guarantee is cross-path parity; do not assert the path
+        // (some short patterns may classify differently), only that results agree.
+        assert_eq!(columnar, row, "multibyte %/_ parity failed for pattern={p:?} (issue #6016)");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes issue #6016: on the row path, `'ሴ' LIKE '%__'` returned true (SQLite says false). The `%` skip loop in `like_match_recursive` (and the escape-aware `like_match_with_elements`) advanced the text cursor over raw byte offsets (`0..=(text.len() - text_pos)`), so it could stop mid-UTF-8-character on a continuation byte. A following `_` then called `utf8_char_len` on that continuation byte, hit its `else => 1` fallback, and manufactured a fake 1-byte "character" — letting a single 3-byte `ሴ` satisfy `__`.

The fix advances the `%` skip cursor one whole UTF-8 character at a time so every recursive attempt starts on a character boundary — the same "cursor always on a char boundary" invariant the columnar `GeneralMatcher` already upholds. This is a targeted row-path fix (no unification with the columnar matcher, which has a different perf contract and no escape preprocessing), as recommended by the curator.

## Changes

- `crates/vibesql-executor/src/evaluator/pattern.rs`
  - `like_match_recursive` `%` arm: replace the byte-offset skip loop with a loop that advances `skip_pos` by `utf8_char_len(text[skip_pos])`.
  - `like_match_with_elements` `PatternElement::AnySequence` (escape-aware path) arm: identical byte-skip bug, same fix.
  - Added unit tests: divergence table (plain + escape-aware paths), escape/`_` interaction with multi-byte text, and a bounded row-path parity sweep over `{a, é, ሴ, 😀} × {%, _}` patterns/strings up to length 3 vs a char-based reference matcher.
- `crates/vibesql-executor/src/tests/predicate_tests/like_predicate.rs`: end-to-end row-path regression test asserting the divergence table through the full executor.
- `crates/vibesql-executor/tests/columnar_like_general_path_assertion_tests.rs`: cross-path (row vs columnar) parity test over multi-byte `%`/`_` patterns.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `'ሴ' LIKE '%__'` false on row path; full divergence table matches SQLite (`%__`→0, `%___`→0, `__`→0, `_`→1) | ✅ | `test_like_match_multibyte_percent_underscore_issue_6016` + e2e `test_like_multibyte_percent_underscore_row_path_issue_6016` |
| Row and columnar paths agree | ✅ | `multibyte_percent_underscore_matches_row_path_issue_6016` + `test_like_match_bounded_parity_sweep_issue_6016` |
| Escape-char path (`AnySequence`) checked/fixed for the same bug | ✅ | `test_like_match_multibyte_percent_underscore_escape_path_issue_6016` |
| No regression in existing LIKE tests | ✅ | Full `vibesql-executor` lib suite: 3386 passed; columnar assertion tests: 6 passed |
| Fix scoped to row path; columnar treated as reference-correct (unchanged) | ✅ | Only `pattern.rs` logic changed; columnar `string_ops.rs` untouched |

## Test Plan

- `cargo test -p vibesql-executor --lib` → 3386 passed, 0 failed
- `cargo test -p vibesql-executor --test columnar_like_general_path_assertion_tests` → 6 passed, 0 failed
- `cargo fmt` + `cargo clippy -p vibesql-executor` clean on touched files

Closes #6016