### PR TITLE
fix(executor): place NULL aggregate group keys first ASC / last DESC

### DIFF
--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
@@ -315,60 +315,12 @@ impl SelectExecutor<'_> {
             rows_with_keys.push((row, sort_keys));
         }
 
-        // Sort using the sort keys with NULLS FIRST/LAST handling
+        // Sort using the shared ORDER BY comparator so NULL placement, collation, and
+        // direction handling stay consistent with the non-aggregate and join paths.
+        // The default (no explicit NULLS clause) rule is SQLite's: NULL is the smallest
+        // value, so it sorts first for ASC and last for DESC (#6014).
         rows_with_keys.sort_by(|(_, keys_a), (_, keys_b)| {
-            use vibesql_types::SqlValue;
-
-            use crate::select::grouping::compare_sql_values_with_collation;
-
-            for ((val_a, dir, nulls_order, collation), (val_b, _, _, _)) in
-                keys_a.iter().zip(keys_b.iter())
-            {
-                // Handle NULLS FIRST/LAST
-                let (a_is_null, b_is_null) =
-                    (matches!(val_a, SqlValue::Null), matches!(val_b, SqlValue::Null));
-                if a_is_null || b_is_null {
-                    if a_is_null && b_is_null {
-                        continue; // Both null, consider equal for this key
-                    }
-                    // Determine if nulls should sort first or last based on NULLS order and
-                    // direction
-                    let nulls_first = match nulls_order {
-                        Some(vibesql_ast::NullsOrder::First) => true,
-                        Some(vibesql_ast::NullsOrder::Last) => false,
-                        None => {
-                            // Default: NULLS LAST for ASC, NULLS FIRST for DESC
-                            matches!(dir, vibesql_ast::OrderDirection::Desc)
-                        }
-                    };
-                    return if a_is_null {
-                        if nulls_first {
-                            std::cmp::Ordering::Less
-                        } else {
-                            std::cmp::Ordering::Greater
-                        }
-                    } else if nulls_first {
-                        std::cmp::Ordering::Greater
-                    } else {
-                        std::cmp::Ordering::Less
-                    };
-                }
-
-                let collation_str = collation.as_deref();
-                let cmp = match dir {
-                    vibesql_ast::OrderDirection::Asc => {
-                        compare_sql_values_with_collation(val_a, val_b, collation_str)
-                    }
-                    vibesql_ast::OrderDirection::Desc => {
-                        compare_sql_values_with_collation(val_a, val_b, collation_str).reverse()
-                    }
-                };
-
-                if cmp != std::cmp::Ordering::Equal {
-                    return cmp;
-                }
-            }
-            std::cmp::Ordering::Equal
+            crate::select::order::compare_rows_by_sort_keys(keys_a, keys_b)
         });
 
         // Extract rows without sort keys

--- a/crates/vibesql-executor/src/select/order/comparison.rs
+++ b/crates/vibesql-executor/src/select/order/comparison.rs
@@ -56,7 +56,10 @@ fn apply_collation<'a>(
 /// - ASC/DESC direction handling
 ///
 /// Returns `Ordering::Less`, `Equal`, or `Greater` for use with sort functions.
-pub(super) fn compare_rows_by_sort_keys(keys_a: &[SortKey], keys_b: &[SortKey]) -> Ordering {
+pub(in crate::select) fn compare_rows_by_sort_keys(
+    keys_a: &[SortKey],
+    keys_b: &[SortKey],
+) -> Ordering {
     for ((val_a, dir, nulls_order, collation), (val_b, _, _, _)) in keys_a.iter().zip(keys_b.iter())
     {
         // Determine NULL ordering:

--- a/crates/vibesql-executor/src/select/order/mod.rs
+++ b/crates/vibesql-executor/src/select/order/mod.rs
@@ -18,6 +18,7 @@ use super::grouping;
 use crate::{errors::ExecutorError, evaluator::CombinedExpressionEvaluator};
 
 // Re-export public API
+pub(in crate::select) use comparison::compare_rows_by_sort_keys;
 pub(crate) use position::{
     extract_column_position, validate_column_position, ColumnPositionResult,
 };
@@ -28,7 +29,7 @@ pub(crate) use resolution::{
 };
 
 /// Sort key for ORDER BY: (value, direction, nulls_order, collation)
-pub(super) type SortKey = (
+pub(in crate::select) type SortKey = (
     vibesql_types::SqlValue,
     vibesql_ast::OrderDirection,
     Option<vibesql_ast::NullsOrder>,

--- a/crates/vibesql-executor/tests/columnar_group_by_order_by_path_assertion_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_group_by_order_by_path_assertion_tests.rs
@@ -169,24 +169,10 @@ fn group_by_having_then_order_by() {
     );
 }
 
-/// NULL group key ordering. The columnar GROUP BY + ORDER BY path must place a
-/// NULL group key FIRST for `ORDER BY k ASC`, matching SQLite (NULLs are the
-/// smallest value).
-///
-/// NOTE ON PARITY: the *row-oriented* aggregate ORDER BY path has a PRE-EXISTING
-/// bug where it places NULL group keys LAST for ASC (verified: a plain
-/// non-aggregate `ORDER BY k ASC` correctly puts NULL first, but the GROUP BY
-/// aggregate ORDER BY path puts NULL last — non-SQLite). This is independent of
-/// the columnar work here and is NOT fixed by this PR (out of scope). Because the
-/// row path is wrong for this case, we assert the columnar path against the
-/// SQLite-correct order directly rather than blind row-path parity. Filed as a
-/// follow-up (see PR description).
-#[test]
-fn group_by_order_by_null_keys_first_ascending() {
-    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-    init_logger(Level::Debug);
-    let mut db = Database::new();
-    execute_sql(&mut db, "CREATE TABLE n (k INTEGER, v INTEGER)");
+/// Populate `n(k INTEGER, v INTEGER)` with 400 rows where `k` is NULL every 7th
+/// row (the data shape from issue #6014's repro), then GROUP BY `k`.
+fn setup_null_keyed(db: &mut Database) {
+    execute_sql(db, "CREATE TABLE n (k INTEGER, v INTEGER)");
     let mut ins = String::new();
     for i in 0..400i64 {
         if i % 7 == 0 {
@@ -195,22 +181,26 @@ fn group_by_order_by_null_keys_first_ascending() {
             ins.push_str(&format!("INSERT INTO n VALUES ({}, {});", i % 4, (i % 11) + 1));
         }
     }
-    execute_sql(&mut db, &ins);
+    execute_sql(db, &ins);
     let _ = take_logs();
+}
 
-    // Path assertion: columnar path is taken.
-    let sql = "SELECT k, SUM(v) FROM n GROUP BY k ORDER BY k ASC";
-    let cols = run_select(&db, sql);
-    let logs = take_logs();
-    let joined = logs.join("\n");
-    assert!(
-        !joined.contains(ROW_FALLBACK),
-        "row-fallback marker emitted for NULL-key GROUP BY ORDER BY:\n{joined}"
-    );
-    assert!(
-        logs.iter().any(|l| l.contains(COLUMNAR_COMPLETED)),
-        "expected native columnar execution for NULL-key GROUP BY ORDER BY:\n{joined}"
-    );
+/// NULL group key ordering, ASC (#6014). The columnar and row-oriented aggregate
+/// GROUP BY + ORDER BY paths must BOTH place a NULL group key FIRST for
+/// `ORDER BY k ASC`, matching SQLite (NULL is the smallest value). Prior to the
+/// #6014 fix the row path inverted the default NULL placement (NULL last on ASC);
+/// this now asserts row/columnar parity in emitted order rather than documenting
+/// the discrepancy.
+#[test]
+fn group_by_order_by_null_keys_first_ascending() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    init_logger(Level::Debug);
+    let mut db = Database::new();
+    setup_null_keyed(&mut db);
+
+    // Row/columnar parity in emitted order (both must match SQLite semantics).
+    let cols =
+        columnar_matches_row_ordered(&db, "SELECT k, SUM(v) FROM n GROUP BY k ORDER BY k ASC");
 
     // SQLite-correct order: NULL group key sorts first ascending.
     assert_eq!(
@@ -230,6 +220,41 @@ fn group_by_order_by_null_keys_first_ascending() {
     let mut sorted = non_null_keys.clone();
     sorted.sort();
     assert_eq!(non_null_keys, sorted, "non-NULL group keys must be ascending: {non_null_keys:?}");
+}
+
+/// NULL group key ordering, DESC (#6014). Mirror of the ASC test: both paths must
+/// place a NULL group key LAST for `ORDER BY k DESC`, matching SQLite (NULL is the
+/// smallest value, so it sorts last under DESC). Prior to the #6014 fix the row
+/// path put NULL first on DESC (direction-inverted default placement).
+#[test]
+fn group_by_order_by_null_keys_last_descending() {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    init_logger(Level::Debug);
+    let mut db = Database::new();
+    setup_null_keyed(&mut db);
+
+    // Row/columnar parity in emitted order (both must match SQLite semantics).
+    let cols =
+        columnar_matches_row_ordered(&db, "SELECT k, SUM(v) FROM n GROUP BY k ORDER BY k DESC");
+
+    // SQLite-correct order: NULL group key sorts last descending.
+    assert_eq!(
+        cols.last().map(|r| &r.values[0]),
+        Some(&vibesql_types::SqlValue::Null),
+        "expected NULL group key to sort last descending (SQLite semantics); got {cols:?}"
+    );
+    // The leading group keys (before the trailing NULL) must be in descending order.
+    let non_null_keys: Vec<i64> = cols
+        .iter()
+        .take(cols.len().saturating_sub(1))
+        .map(|r| match &r.values[0] {
+            vibesql_types::SqlValue::Integer(v) => *v,
+            other => panic!("unexpected non-integer group key: {other:?}"),
+        })
+        .collect();
+    let mut sorted = non_null_keys.clone();
+    sorted.sort_by(|a, b| b.cmp(a));
+    assert_eq!(non_null_keys, sorted, "non-NULL group keys must be descending: {non_null_keys:?}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The single-table row-oriented aggregate `ORDER BY` path placed NULL group keys in the wrong position: NULL **last** on `ORDER BY k ASC` and **first** on `ORDER BY k DESC` — direction-inverted relative to SQLite, which treats NULL as the smallest value (first for ASC, last for DESC). The columnar path was already correct, so the two paths disagreed for `GROUP BY k ORDER BY k` with NULL group keys.

Root cause: `apply_order_by_to_aggregates` in `aggregation/evaluation/mod.rs` used a hand-rolled comparator whose default (no explicit `NULLS` clause) branch computed `nulls_first = matches!(dir, OrderDirection::Desc)`, the inverse of the shared `compare_rows_by_sort_keys` rule (`matches!(dir, OrderDirection::Asc)`). The inline comment stated the wrong rule outright.

## Changes

- **Delete the duplicated comparator** in `apply_order_by_to_aggregates` and delegate to the shared `crate::select::order::compare_rows_by_sort_keys`, so NULL placement, collation, and direction handling can no longer drift between the row aggregate path and the rest of ORDER BY (the preferred fix per the curator).
- Loosen visibility of `compare_rows_by_sort_keys` and the structurally-identical `SortKey` type alias from `pub(super)` to `pub(in crate::select)`, and re-export the comparator from `select::order`.
- Update `group_by_order_by_null_keys_first_ascending` to assert row/columnar emitted-order parity via `columnar_matches_row_ordered` (removing the stale "pre-existing bug, out of scope" doc comment).
- Add `group_by_order_by_null_keys_last_descending` (DESC counterpart, NULL last, row/columnar parity).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Row path emits NULL group key first for `ORDER BY k ASC` | ✅ | `group_by_order_by_null_keys_first_ascending` asserts NULL first + row/columnar parity |
| Row path emits NULL group key last for `ORDER BY k DESC` | ✅ | New `group_by_order_by_null_keys_last_descending` asserts NULL last + parity |
| Explicit `NULLS FIRST`/`NULLS LAST` still override default | ✅ | Now handled by shared `compare_rows_by_sort_keys` (only the `None` default branch differed); full suite passes |
| Row and columnar paths agree exactly (single-table + join) | ✅ | Parity tests pass; `join_group_by_left_outer_null_keys_with_order_by_...` unmodified and passing |
| ASC test asserts parity via `columnar_matches_row_ordered` | ✅ | Rewritten; stale doc comment removed |
| DESC counterpart test added | ✅ | `group_by_order_by_null_keys_last_descending` |
| Join row path unregressed | ✅ | `columnar_join_group_by_expression_tests` all 18 pass unmodified |
| Full `cargo test -p vibesql-executor` passes | ✅ | 80 test-result lines, all `ok`, 0 failed |

## Test Plan

- `cargo test -p vibesql-executor --test columnar_group_by_order_by_path_assertion_tests --test columnar_join_group_by_expression_tests` — 11 + 18 pass.
- `cargo test -p vibesql-executor` — full suite, all 80 result lines `ok`, exit 0.
- `cargo build -p vibesql-executor`, `cargo fmt`, `cargo clippy -p vibesql-executor --tests` on touched files — clean.

Closes #6014