### PR TITLE
feat(json): encode jsonb()/jsonb_*() as SQLite-compatible JSONB blobs

### DIFF
--- a/crates/vibesql-executor/src/evaluator/arena.rs
+++ b/crates/vibesql-executor/src/evaluator/arena.rs
@@ -705,23 +705,20 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
                                 && json_funcs::sql_value_is_json_subtyped(&evaluated_args[i]));
                         subtypes.push(is_json);
                     }
-                    // `jsonb_*` are text-mode accept-and-convert aliases of `json_*`.
+                    // `json_*` emit JSON text; `jsonb_*` emit a JSONB Blob
+                    // (Stage 1 of #6008). Same node + subtype handling; only the
+                    // output encoding differs.
                     return match upper.as_str() {
-                        "JSON_ARRAY" | "JSONB_ARRAY" => {
-                            json_funcs::json_array(&evaluated_args, &subtypes)
-                        }
-                        "JSON_OBJECT" | "JSONB_OBJECT" => {
-                            json_funcs::json_object(&evaluated_args, &subtypes)
-                        }
-                        "JSON_INSERT" | "JSONB_INSERT" => {
-                            json_funcs::json_insert(&evaluated_args, &subtypes)
-                        }
-                        "JSON_REPLACE" | "JSONB_REPLACE" => {
-                            json_funcs::json_replace(&evaluated_args, &subtypes)
-                        }
-                        "JSON_SET" | "JSONB_SET" => {
-                            json_funcs::json_set(&evaluated_args, &subtypes)
-                        }
+                        "JSON_ARRAY" => json_funcs::json_array(&evaluated_args, &subtypes),
+                        "JSONB_ARRAY" => json_funcs::jsonb_array(&evaluated_args, &subtypes),
+                        "JSON_OBJECT" => json_funcs::json_object(&evaluated_args, &subtypes),
+                        "JSONB_OBJECT" => json_funcs::jsonb_object(&evaluated_args, &subtypes),
+                        "JSON_INSERT" => json_funcs::json_insert(&evaluated_args, &subtypes),
+                        "JSONB_INSERT" => json_funcs::jsonb_insert(&evaluated_args, &subtypes),
+                        "JSON_REPLACE" => json_funcs::json_replace(&evaluated_args, &subtypes),
+                        "JSONB_REPLACE" => json_funcs::jsonb_replace(&evaluated_args, &subtypes),
+                        "JSON_SET" => json_funcs::json_set(&evaluated_args, &subtypes),
+                        "JSONB_SET" => json_funcs::jsonb_set(&evaluated_args, &subtypes),
                         _ => unreachable!(),
                     };
                 }

--- a/crates/vibesql-executor/src/evaluator/expressions/special.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/special.rs
@@ -205,15 +205,21 @@ impl ExpressionEvaluator<'_> {
             values.push(value);
         }
 
-        // The `jsonb_*` names are text-mode aliases (accept-and-convert): they
-        // delegate to the identical `json_*` implementation. See the Phase 4
-        // JSONB note in `json_funcs.rs`.
+        // The `json_*` names emit JSON text; the `jsonb_*` names emit SQLite's
+        // binary JSONB representation as a Blob (Stage 1 of #6008). Both build
+        // the same JSON node with identical subtype handling; only the output
+        // encoding differs.
         match name.to_uppercase().as_str() {
-            "JSON_ARRAY" | "JSONB_ARRAY" => json_funcs::json_array(&values, &subtypes),
-            "JSON_OBJECT" | "JSONB_OBJECT" => json_funcs::json_object(&values, &subtypes),
-            "JSON_INSERT" | "JSONB_INSERT" => json_funcs::json_insert(&values, &subtypes),
-            "JSON_REPLACE" | "JSONB_REPLACE" => json_funcs::json_replace(&values, &subtypes),
-            "JSON_SET" | "JSONB_SET" => json_funcs::json_set(&values, &subtypes),
+            "JSON_ARRAY" => json_funcs::json_array(&values, &subtypes),
+            "JSONB_ARRAY" => json_funcs::jsonb_array(&values, &subtypes),
+            "JSON_OBJECT" => json_funcs::json_object(&values, &subtypes),
+            "JSONB_OBJECT" => json_funcs::jsonb_object(&values, &subtypes),
+            "JSON_INSERT" => json_funcs::json_insert(&values, &subtypes),
+            "JSONB_INSERT" => json_funcs::jsonb_insert(&values, &subtypes),
+            "JSON_REPLACE" => json_funcs::json_replace(&values, &subtypes),
+            "JSONB_REPLACE" => json_funcs::jsonb_replace(&values, &subtypes),
+            "JSON_SET" => json_funcs::json_set(&values, &subtypes),
+            "JSONB_SET" => json_funcs::jsonb_set(&values, &subtypes),
             _ => unreachable!("eval_json_subtype_function called with {name}"),
         }
     }

--- a/crates/vibesql-executor/src/evaluator/functions/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/mod.rs
@@ -178,31 +178,40 @@ pub(super) fn eval_scalar_function(
 
         // JSON functions (SQLite JSON1 extension)
         //
-        // JSONB accept-and-convert: VibeSQL does not implement SQLite's binary
-        // JSONB format. Every `jsonb_*` name is a text-mode alias of its `json_*`
-        // counterpart, producing JSON-subtype-tagged TEXT rather than a BLOB (see
-        // the Phase 4 decision on #5786). The observable text output matches
-        // SQLite; the only divergence is `typeof()` (text vs blob), which the
-        // covered conformance tests never assert.
-        "JSON" | "JSONB" => sqlite_compat::json(args),
+        // The `json_*` names produce JSON *text*; the `jsonb`/`jsonb_*` names
+        // produce SQLite's binary JSONB representation as a `SqlValue::Blob`
+        // (Stage 1 of #6008). The text-mode consumers accept a JSONB blob
+        // argument (decoding it back to a JSON node) so nested `jsonb(...)`
+        // arguments keep working.
+        "JSON" => sqlite_compat::json(args),
+        "JSONB" => sqlite_compat::jsonb(args),
         "JSON_VALID" => sqlite_compat::json_valid(args),
-        "JSON_EXTRACT" | "JSONB_EXTRACT" => sqlite_compat::json_extract(args),
+        "JSON_EXTRACT" => sqlite_compat::json_extract(args),
+        "JSONB_EXTRACT" => sqlite_compat::jsonb_extract(args),
         "JSON_TYPE" => sqlite_compat::json_type(args),
         "JSON_QUOTE" => sqlite_compat::json_quote(args),
         "JSON_ARRAY_LENGTH" => sqlite_compat::json_array_length(args),
-        "JSON_REMOVE" | "JSONB_REMOVE" => sqlite_compat::json_remove(args),
-        "JSON_PATCH" | "JSONB_PATCH" => sqlite_compat::json_patch(args),
+        "JSON_REMOVE" => sqlite_compat::json_remove(args),
+        "JSONB_REMOVE" => sqlite_compat::jsonb_remove(args),
+        "JSON_PATCH" => sqlite_compat::json_patch(args),
+        "JSONB_PATCH" => sqlite_compat::jsonb_patch(args),
         "JSON_ERROR_POSITION" => sqlite_compat::json_error_position(args),
         // The subtype-aware construction/mutation functions (JSON_ARRAY,
-        // JSON_OBJECT, JSON_INSERT, JSON_REPLACE, JSON_SET) are dispatched
-        // earlier in special.rs, where per-argument JSON-subtype flags are
-        // available from the AST. Reaching them here (no subtype info) still
-        // produces correct output for the common no-embedding case.
-        "JSON_ARRAY" | "JSONB_ARRAY" => sqlite_compat::json_array(args, &[]),
-        "JSON_OBJECT" | "JSONB_OBJECT" => sqlite_compat::json_object(args, &[]),
-        "JSON_INSERT" | "JSONB_INSERT" => sqlite_compat::json_insert(args, &[]),
-        "JSON_REPLACE" | "JSONB_REPLACE" => sqlite_compat::json_replace(args, &[]),
-        "JSON_SET" | "JSONB_SET" => sqlite_compat::json_set(args, &[]),
+        // JSON_OBJECT, JSON_INSERT, JSON_REPLACE, JSON_SET and their JSONB
+        // variants) are dispatched earlier in special.rs / arena.rs, where
+        // per-argument JSON-subtype flags are available from the AST. Reaching
+        // them here (no subtype info) still produces correct output for the
+        // common no-embedding case; the JSONB variants emit a Blob.
+        "JSON_ARRAY" => sqlite_compat::json_array(args, &[]),
+        "JSONB_ARRAY" => sqlite_compat::json_funcs::jsonb_array(args, &[]),
+        "JSON_OBJECT" => sqlite_compat::json_object(args, &[]),
+        "JSONB_OBJECT" => sqlite_compat::json_funcs::jsonb_object(args, &[]),
+        "JSON_INSERT" => sqlite_compat::json_insert(args, &[]),
+        "JSONB_INSERT" => sqlite_compat::json_funcs::jsonb_insert(args, &[]),
+        "JSON_REPLACE" => sqlite_compat::json_replace(args, &[]),
+        "JSONB_REPLACE" => sqlite_compat::json_funcs::jsonb_replace(args, &[]),
+        "JSON_SET" => sqlite_compat::json_set(args, &[]),
+        "JSONB_SET" => sqlite_compat::json_funcs::jsonb_set(args, &[]),
 
         // Type conversion functions
         "TO_NUMBER" => conversion::to_number(args),

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/json_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/json_funcs.rs
@@ -851,17 +851,15 @@ pub(crate) fn eval_json_arrow(
         return Ok(SqlValue::Null);
     }
 
-    let json_str = match left {
-        SqlValue::Varchar(s) | SqlValue::Character(s) => s.as_str(),
+    let value = match left {
+        SqlValue::Varchar(s) | SqlValue::Character(s) => json_text_or_blob_to_node(s.as_str())?,
+        SqlValue::Blob(bytes) => jsonb_blob_to_node(bytes)?,
         _ => {
             return Err(ExecutorError::SqliteCompatError("malformed JSON".to_string()));
         }
     };
 
     let path = arrow_operand_to_path(right)?;
-
-    let value = parse_json_relaxed(json_str)
-        .map_err(|_| ExecutorError::SqliteCompatError("malformed JSON".to_string()))?;
 
     match navigate(&value, &path) {
         Some(node) => {
@@ -960,15 +958,13 @@ pub(crate) fn json_extract(args: &[SqlValue]) -> Result<SqlValue, ExecutorError>
         return Ok(SqlValue::Null);
     }
 
-    let json_str = match &args[0] {
-        SqlValue::Varchar(s) | SqlValue::Character(s) => s.as_str(),
+    let value = match &args[0] {
+        SqlValue::Varchar(s) | SqlValue::Character(s) => json_text_or_blob_to_node(s.as_str())?,
+        SqlValue::Blob(bytes) => jsonb_blob_to_node(bytes)?,
         _ => {
             return Err(ExecutorError::SqliteCompatError("malformed JSON".to_string()));
         }
     };
-
-    let value = parse_json_relaxed(json_str)
-        .map_err(|_| ExecutorError::SqliteCompatError("malformed JSON".to_string()))?;
 
     let paths = &args[1..];
 
@@ -1011,6 +1007,67 @@ pub(crate) fn json_extract(args: &[SqlValue]) -> Result<SqlValue, ExecutorError>
     }
 }
 
+/// jsonb_extract(X, P, ...) - like json_extract but returns JSONB blobs for
+/// results that json_extract would render as JSON text.
+///
+/// A single path selecting a *scalar* returns the SQL value (same as
+/// json_extract); a single path selecting a *container* (array/object) returns a
+/// JSONB blob; the multi-path form returns a JSONB-encoded array. NULL document /
+/// NULL path / missing path propagate NULL exactly like json_extract.
+pub(crate) fn jsonb_extract(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
+    if args.is_empty() {
+        return Err(ExecutorError::WrongNumberOfArguments {
+            function_name: "jsonb_extract".to_string(),
+        });
+    }
+
+    if matches!(args[0], SqlValue::Null) || args.len() == 1 {
+        return Ok(SqlValue::Null);
+    }
+
+    let value = match &args[0] {
+        SqlValue::Varchar(s) | SqlValue::Character(s) => json_text_or_blob_to_node(s.as_str())?,
+        SqlValue::Blob(bytes) => jsonb_blob_to_node(bytes)?,
+        _ => {
+            return Err(ExecutorError::SqliteCompatError("malformed JSON".to_string()));
+        }
+    };
+
+    let paths = &args[1..];
+    let mut resolved: Vec<Vec<PathSegment>> = Vec::with_capacity(paths.len());
+    for p in paths {
+        match p {
+            SqlValue::Null => return Ok(SqlValue::Null),
+            SqlValue::Varchar(s) | SqlValue::Character(s) => {
+                resolved.push(
+                    parse_sqlite_json_path(s.as_str()).map_err(ExecutorError::SqliteCompatError)?,
+                );
+            }
+            other => {
+                let text = sql_value_scalar_text(other);
+                return Err(ExecutorError::SqliteCompatError(format!("bad JSON path: '{}'", text)));
+            }
+        }
+    }
+
+    if resolved.len() == 1 {
+        match navigate(&value, &resolved[0]) {
+            // Containers become JSONB blobs; scalars stay SQL values.
+            Some(node @ (serde_json::Value::Array(_) | serde_json::Value::Object(_))) => {
+                Ok(SqlValue::Blob(super::jsonb::encode(node)))
+            }
+            Some(node) => Ok(json_node_to_sql_value(node)),
+            None => Ok(SqlValue::Null),
+        }
+    } else {
+        let elems: Vec<serde_json::Value> = resolved
+            .iter()
+            .map(|segs| navigate(&value, segs).cloned().unwrap_or(serde_json::Value::Null))
+            .collect();
+        Ok(SqlValue::Blob(super::jsonb::encode(&serde_json::Value::Array(elems))))
+    }
+}
+
 /// json_type(X) / json_type(X, P) - the SQLite type name of a JSON value.
 ///
 /// One argument reports the root type; two arguments evaluate the path first.
@@ -1023,16 +1080,14 @@ pub(crate) fn json_type(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         });
     }
 
-    let json_str = match &args[0] {
+    let value = match &args[0] {
         SqlValue::Null => return Ok(SqlValue::Null),
-        SqlValue::Varchar(s) | SqlValue::Character(s) => s.as_str(),
+        SqlValue::Varchar(s) | SqlValue::Character(s) => json_text_or_blob_to_node(s.as_str())?,
+        SqlValue::Blob(bytes) => jsonb_blob_to_node(bytes)?,
         _ => {
             return Err(ExecutorError::SqliteCompatError("malformed JSON".to_string()));
         }
     };
-
-    let value = parse_json_relaxed(json_str)
-        .map_err(|_| ExecutorError::SqliteCompatError("malformed JSON".to_string()))?;
 
     let node = if args.len() == 2 {
         match &args[1] {
@@ -1175,11 +1230,41 @@ pub(crate) fn json(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
                 Err(_) => Err(ExecutorError::SqliteCompatError("malformed JSON".to_string())),
             }
         }
+        // A JSONB blob argument (from jsonb()/jsonb_*()) is decoded and rendered
+        // as minified JSON text, matching SQLite's `json(<jsonb>)`.
+        SqlValue::Blob(bytes) => {
+            let value = jsonb_blob_to_node(bytes)?;
+            Ok(SqlValue::Varchar(serde_json::to_string(&value).unwrap_or_default().into()))
+        }
         // For non-string types, SQLite throws an error
         _ => Err(ExecutorError::SqliteCompatError(
             "JSON functions require string arguments".to_string(),
         )),
     }
+}
+
+/// jsonb(X) - validate/parse X and return SQLite's binary JSONB representation.
+///
+/// Text (canonical or JSON5-relaxed) is parsed and re-encoded as a JSONB blob;
+/// an existing JSONB blob is decoded and re-encoded (canonicalized). A NULL
+/// argument propagates NULL. This is the BLOB-producing counterpart of `json()`.
+pub(crate) fn jsonb(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
+    if args.len() != 1 {
+        return Err(ExecutorError::WrongNumberOfArguments { function_name: "jsonb".to_string() });
+    }
+
+    let node = match &args[0] {
+        SqlValue::Null => return Ok(SqlValue::Null),
+        SqlValue::Varchar(s) | SqlValue::Character(s) => json_text_or_blob_to_node(s.as_str())?,
+        SqlValue::Blob(bytes) => jsonb_blob_to_node(bytes)?,
+        _ => {
+            return Err(ExecutorError::SqliteCompatError(
+                "JSON functions require string arguments".to_string(),
+            ));
+        }
+    };
+
+    Ok(SqlValue::Blob(super::jsonb::encode(&node)))
 }
 
 // ===========================================================================
@@ -1256,10 +1341,18 @@ fn sql_value_to_json_node(
                 serde_json::Value::String(s.as_str().to_string())
             }
         }
-        SqlValue::Blob(_) => {
-            return Err(ExecutorError::SqliteCompatError(
-                "JSON cannot hold BLOB values".to_string(),
-            ));
+        SqlValue::Blob(bytes) => {
+            // A JSONB blob (produced by jsonb()/jsonb_*()) embeds as its decoded
+            // JSON sub-document, mirroring SQLite treating a JSONB argument as
+            // JSON. Non-JSONB blobs remain an error ("JSON cannot hold BLOB").
+            match super::jsonb::decode(bytes) {
+                Some(node) => node,
+                None => {
+                    return Err(ExecutorError::SqliteCompatError(
+                        "JSON cannot hold BLOB values".to_string(),
+                    ));
+                }
+            }
         }
         other => serde_json::Value::String(sql_value_scalar_text(other)),
     })
@@ -1284,6 +1377,26 @@ fn json_number_node(f: f64) -> serde_json::Value {
     }
 }
 
+/// Parse a read-only JSON *document* argument that may be either JSON text or a
+/// JSONB blob (produced by `jsonb()`/`jsonb_*()`), returning the parsed node.
+///
+/// Used by the read-only accessors (`json`, `json_extract`, `json_type`,
+/// `json_array_length`, `->`/`->>`) so a JSONB blob flows through them exactly
+/// like the equivalent JSON text. Text is parsed with the relaxed/JSON5 grammar
+/// ([`parse_json_relaxed`]); a JSONB blob is decoded via [`super::jsonb::decode`].
+/// Any malformed input yields the SQLite-compatible `malformed JSON` error.
+fn json_text_or_blob_to_node(json_str: &str) -> Result<serde_json::Value, ExecutorError> {
+    parse_json_relaxed(json_str)
+        .map_err(|_| ExecutorError::SqliteCompatError("malformed JSON".to_string()))
+}
+
+/// Decode a JSONB blob document into its JSON node, mapping failure to the
+/// SQLite-compatible `malformed JSON` error.
+fn jsonb_blob_to_node(bytes: &[u8]) -> Result<serde_json::Value, ExecutorError> {
+    super::jsonb::decode(bytes)
+        .ok_or_else(|| ExecutorError::SqliteCompatError("malformed JSON".to_string()))
+}
+
 /// Parse the JSON document argument shared by the mutation functions. Returns
 /// `Ok(None)` when the argument is SQL NULL (functions propagate NULL), or an
 /// error on malformed JSON / non-text input.
@@ -1304,6 +1417,12 @@ fn parse_json_doc_arg(value: &SqlValue) -> Result<Option<serde_json::Value>, Exe
         }
         SqlValue::Float(f) => Ok(Some(json_number_node(*f as f64))),
         SqlValue::Boolean(b) => Ok(Some(serde_json::Value::Bool(*b))),
+        // A JSONB blob (produced by jsonb()/jsonb_*()) decodes back to its JSON
+        // document so mutation functions accept a JSONB document argument.
+        SqlValue::Blob(bytes) => match super::jsonb::decode(bytes) {
+            Some(node) => Ok(Some(node)),
+            None => Err(ExecutorError::SqliteCompatError("malformed JSON".to_string())),
+        },
         _ => Err(ExecutorError::SqliteCompatError("malformed JSON".to_string())),
     }
 }
@@ -1359,14 +1478,28 @@ fn subtype_at(subtypes: &[bool], idx: usize) -> bool {
     subtypes.get(idx).copied().unwrap_or(false)
 }
 
-/// json_array(V1, V2, ...) - build a JSON array from the argument values.
-pub(crate) fn json_array(args: &[SqlValue], subtypes: &[bool]) -> Result<SqlValue, ExecutorError> {
+/// Build the JSON array node for `json_array` / `jsonb_array`.
+fn json_array_node(
+    args: &[SqlValue],
+    subtypes: &[bool],
+) -> Result<serde_json::Value, ExecutorError> {
     let mut elems = Vec::with_capacity(args.len());
     for (i, a) in args.iter().enumerate() {
         elems.push(sql_value_to_json_node(a, subtype_at(subtypes, i))?);
     }
-    let arr = serde_json::Value::Array(elems);
+    Ok(serde_json::Value::Array(elems))
+}
+
+/// json_array(V1, V2, ...) - build a JSON array from the argument values.
+pub(crate) fn json_array(args: &[SqlValue], subtypes: &[bool]) -> Result<SqlValue, ExecutorError> {
+    let arr = json_array_node(args, subtypes)?;
     Ok(SqlValue::Varchar(serde_json::to_string(&arr).unwrap_or_default().into()))
+}
+
+/// jsonb_array(V1, V2, ...) - like json_array but returns a JSONB blob.
+pub(crate) fn jsonb_array(args: &[SqlValue], subtypes: &[bool]) -> Result<SqlValue, ExecutorError> {
+    let arr = json_array_node(args, subtypes)?;
+    Ok(SqlValue::Blob(super::jsonb::encode(&arr)))
 }
 
 /// json_object(L1, V1, L2, V2, ...) - build a JSON object.
@@ -1374,6 +1507,24 @@ pub(crate) fn json_array(args: &[SqlValue], subtypes: &[bool]) -> Result<SqlValu
 /// Requires an even number of arguments; labels must be TEXT. Duplicate labels
 /// keep the last value (matching SQLite's object builder).
 pub(crate) fn json_object(args: &[SqlValue], subtypes: &[bool]) -> Result<SqlValue, ExecutorError> {
+    let obj = json_object_node(args, subtypes)?;
+    Ok(SqlValue::Varchar(serde_json::to_string(&obj).unwrap_or_default().into()))
+}
+
+/// jsonb_object(L1, V1, ...) - like json_object but returns a JSONB blob.
+pub(crate) fn jsonb_object(
+    args: &[SqlValue],
+    subtypes: &[bool],
+) -> Result<SqlValue, ExecutorError> {
+    let obj = json_object_node(args, subtypes)?;
+    Ok(SqlValue::Blob(super::jsonb::encode(&obj)))
+}
+
+/// Build the JSON object node for `json_object` / `jsonb_object`.
+fn json_object_node(
+    args: &[SqlValue],
+    subtypes: &[bool],
+) -> Result<serde_json::Value, ExecutorError> {
     if !args.len().is_multiple_of(2) {
         return Err(ExecutorError::SqliteCompatError(
             "json_object() requires an even number of arguments".to_string(),
@@ -1397,8 +1548,7 @@ pub(crate) fn json_object(args: &[SqlValue], subtypes: &[bool]) -> Result<SqlVal
         i += 2;
     }
 
-    let obj = serde_json::Value::Object(map);
-    Ok(SqlValue::Varchar(serde_json::to_string(&obj).unwrap_or_default().into()))
+    Ok(serde_json::Value::Object(map))
 }
 
 /// json_array_length(X) / json_array_length(X, P) - number of elements in the
@@ -1411,16 +1561,14 @@ pub(crate) fn json_array_length(args: &[SqlValue]) -> Result<SqlValue, ExecutorE
         });
     }
 
-    let json_str = match &args[0] {
+    let value = match &args[0] {
         SqlValue::Null => return Ok(SqlValue::Null),
-        SqlValue::Varchar(s) | SqlValue::Character(s) => s.as_str(),
+        SqlValue::Varchar(s) | SqlValue::Character(s) => json_text_or_blob_to_node(s.as_str())?,
+        SqlValue::Blob(bytes) => jsonb_blob_to_node(bytes)?,
         _ => {
             return Err(ExecutorError::SqliteCompatError("malformed JSON".to_string()));
         }
     };
-
-    let value = parse_json_relaxed(json_str)
-        .map_err(|_| ExecutorError::SqliteCompatError("malformed JSON".to_string()))?;
 
     let node = if args.len() == 2 {
         match &args[1] {
@@ -1597,13 +1745,40 @@ fn json_mutate(
     mode: EditMode,
     fn_name: &str,
 ) -> Result<SqlValue, ExecutorError> {
+    match json_mutate_node(args, subtypes, mode, fn_name)? {
+        None => Ok(SqlValue::Null),
+        Some(doc) => Ok(SqlValue::Varchar(serde_json::to_string(&doc).unwrap_or_default().into())),
+    }
+}
+
+/// JSONB-returning counterpart of [`json_mutate`].
+fn jsonb_mutate(
+    args: &[SqlValue],
+    subtypes: &[bool],
+    mode: EditMode,
+    fn_name: &str,
+) -> Result<SqlValue, ExecutorError> {
+    match json_mutate_node(args, subtypes, mode, fn_name)? {
+        None => Ok(SqlValue::Null),
+        Some(doc) => Ok(SqlValue::Blob(super::jsonb::encode(&doc))),
+    }
+}
+
+/// Shared driver producing the mutated document node (or `None` for a NULL
+/// document argument). Both the text and JSONB entry points serialize this.
+fn json_mutate_node(
+    args: &[SqlValue],
+    subtypes: &[bool],
+    mode: EditMode,
+    fn_name: &str,
+) -> Result<Option<serde_json::Value>, ExecutorError> {
     // Valid arity is odd: one document argument plus (path, value) pairs.
     if args.is_empty() || args.len().is_multiple_of(2) {
         return Err(ExecutorError::WrongNumberOfArguments { function_name: fn_name.to_string() });
     }
 
     let mut doc = match parse_json_doc_arg(&args[0])? {
-        None => return Ok(SqlValue::Null),
+        None => return Ok(None),
         Some(v) => v,
     };
 
@@ -1632,12 +1807,20 @@ fn json_mutate(
         i += 2;
     }
 
-    Ok(SqlValue::Varchar(serde_json::to_string(&doc).unwrap_or_default().into()))
+    Ok(Some(doc))
 }
 
 /// json_insert(X, P, V, ...) - insert V at P only if P does not already exist.
 pub(crate) fn json_insert(args: &[SqlValue], subtypes: &[bool]) -> Result<SqlValue, ExecutorError> {
     json_mutate(args, subtypes, EditMode::Insert, "json_insert")
+}
+
+/// jsonb_insert(X, P, V, ...) - like json_insert but returns a JSONB blob.
+pub(crate) fn jsonb_insert(
+    args: &[SqlValue],
+    subtypes: &[bool],
+) -> Result<SqlValue, ExecutorError> {
+    jsonb_mutate(args, subtypes, EditMode::Insert, "jsonb_insert")
 }
 
 /// json_replace(X, P, V, ...) - replace the value at P only if P exists.
@@ -1648,9 +1831,22 @@ pub(crate) fn json_replace(
     json_mutate(args, subtypes, EditMode::Replace, "json_replace")
 }
 
+/// jsonb_replace(X, P, V, ...) - like json_replace but returns a JSONB blob.
+pub(crate) fn jsonb_replace(
+    args: &[SqlValue],
+    subtypes: &[bool],
+) -> Result<SqlValue, ExecutorError> {
+    jsonb_mutate(args, subtypes, EditMode::Replace, "jsonb_replace")
+}
+
 /// json_set(X, P, V, ...) - insert or replace the value at P (upsert).
 pub(crate) fn json_set(args: &[SqlValue], subtypes: &[bool]) -> Result<SqlValue, ExecutorError> {
     json_mutate(args, subtypes, EditMode::Set, "json_set")
+}
+
+/// jsonb_set(X, P, V, ...) - like json_set but returns a JSONB blob.
+pub(crate) fn jsonb_set(args: &[SqlValue], subtypes: &[bool]) -> Result<SqlValue, ExecutorError> {
+    jsonb_mutate(args, subtypes, EditMode::Set, "jsonb_set")
 }
 
 /// json_remove(X, P, ...) - remove the element(s) at the given path(s).
@@ -1659,6 +1855,23 @@ pub(crate) fn json_set(args: &[SqlValue], subtypes: &[bool]) -> Result<SqlValue,
 /// is a no-op. A bare `$` (with no further arguments) removes the whole document
 /// -- matching SQLite, `json_remove(X)` returns X minified.
 pub(crate) fn json_remove(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
+    match json_remove_node(args)? {
+        None => Ok(SqlValue::Null),
+        Some(doc) => Ok(SqlValue::Varchar(serde_json::to_string(&doc).unwrap_or_default().into())),
+    }
+}
+
+/// jsonb_remove(X, P, ...) - like json_remove but returns a JSONB blob.
+pub(crate) fn jsonb_remove(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
+    match json_remove_node(args)? {
+        None => Ok(SqlValue::Null),
+        Some(doc) => Ok(SqlValue::Blob(super::jsonb::encode(&doc))),
+    }
+}
+
+/// Shared driver producing the pruned document node (or `None` for a NULL
+/// result). Both the text and JSONB entry points serialize this.
+fn json_remove_node(args: &[SqlValue]) -> Result<Option<serde_json::Value>, ExecutorError> {
     if args.is_empty() {
         return Err(ExecutorError::WrongNumberOfArguments {
             function_name: "json_remove".to_string(),
@@ -1666,13 +1879,13 @@ pub(crate) fn json_remove(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> 
     }
 
     let mut doc = match parse_json_doc_arg(&args[0])? {
-        None => return Ok(SqlValue::Null),
+        None => return Ok(None),
         Some(v) => v,
     };
 
     for p in &args[1..] {
         match p {
-            SqlValue::Null => return Ok(SqlValue::Null),
+            SqlValue::Null => return Ok(None),
             SqlValue::Varchar(s) | SqlValue::Character(s) => {
                 let segs =
                     parse_sqlite_json_path(s.as_str()).map_err(ExecutorError::SqliteCompatError)?;
@@ -1681,7 +1894,7 @@ pub(crate) fn json_remove(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> 
                 // (Note: `json_remove(X)` with *no* path argument returns X
                 // unchanged, handled by the loop simply not running.)
                 if segs.is_empty() {
-                    return Ok(SqlValue::Null);
+                    return Ok(None);
                 }
                 remove_path(&mut doc, &segs);
             }
@@ -1694,7 +1907,7 @@ pub(crate) fn json_remove(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> 
         }
     }
 
-    Ok(SqlValue::Varchar(serde_json::to_string(&doc).unwrap_or_default().into()))
+    Ok(Some(doc))
 }
 
 /// Remove the node at `segments` from `root` if present.
@@ -1759,6 +1972,25 @@ fn remove_path(root: &mut serde_json::Value, segments: &[PathSegment]) {
 /// NULL for either argument yields NULL. Non-object patches replace the target
 /// wholesale; object patches merge recursively with `null` members deleting.
 pub(crate) fn json_patch(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
+    match json_patch_node(args)? {
+        None => Ok(SqlValue::Null),
+        Some(result) => {
+            Ok(SqlValue::Varchar(serde_json::to_string(&result).unwrap_or_default().into()))
+        }
+    }
+}
+
+/// jsonb_patch(X, Y) - like json_patch but returns a JSONB blob.
+pub(crate) fn jsonb_patch(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
+    match json_patch_node(args)? {
+        None => Ok(SqlValue::Null),
+        Some(result) => Ok(SqlValue::Blob(super::jsonb::encode(&result))),
+    }
+}
+
+/// Shared driver producing the merged document node (or `None` for a NULL
+/// result). Both the text and JSONB entry points serialize this.
+fn json_patch_node(args: &[SqlValue]) -> Result<Option<serde_json::Value>, ExecutorError> {
     if args.len() != 2 {
         return Err(ExecutorError::WrongNumberOfArguments {
             function_name: "json_patch".to_string(),
@@ -1766,16 +1998,15 @@ pub(crate) fn json_patch(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     }
 
     let target = match parse_json_doc_arg(&args[0])? {
-        None => return Ok(SqlValue::Null),
+        None => return Ok(None),
         Some(v) => v,
     };
     let patch = match parse_json_doc_arg(&args[1])? {
-        None => return Ok(SqlValue::Null),
+        None => return Ok(None),
         Some(v) => v,
     };
 
-    let result = merge_patch(target, patch);
-    Ok(SqlValue::Varchar(serde_json::to_string(&result).unwrap_or_default().into()))
+    Ok(Some(merge_patch(target, patch)))
 }
 
 /// RFC-7396 MergePatch algorithm.

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/jsonb.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/jsonb.rs
@@ -1,0 +1,503 @@
+//! SQLite JSONB binary encoding (and its decode inverse).
+//!
+//! SQLite's `jsonb()` / `jsonb_*()` functions return the document in SQLite's
+//! on-disk *JSONB* binary format rather than as JSON text. This module encodes a
+//! parsed JSON node ([`serde_json::Value`], the same node type `json_funcs.rs`
+//! operates on) into a byte-for-byte compatible JSONB blob, and provides the
+//! inverse decode so a JSONB blob produced here can be fed back into the
+//! text-mode JSON functions (`json()`, `json_extract()`, the mutation functions,
+//! …) without a regression while the full external JSONB reader is still being
+//! built (Stage 2, #6032).
+//!
+//! ## Wire format (confirmed against `sqlite/src/json.c` and json102 ground truth)
+//!
+//! Each element begins with a header byte: the **element type** in the low
+//! nibble and a **payload-size class** in the high nibble.
+//!
+//! | type | name    | payload                                            |
+//! |------|---------|----------------------------------------------------|
+//! | 0    | NULL    | (empty)                                            |
+//! | 1    | TRUE    | (empty)                                            |
+//! | 2    | FALSE   | (empty)                                            |
+//! | 3    | INT     | canonical integer text, e.g. `-12`                 |
+//! | 4    | INT5    | JSON5 integer text (never emitted by canonical enc)|
+//! | 5    | FLOAT   | canonical float text, e.g. `3.5`                   |
+//! | 6    | FLOAT5  | JSON5 float text (never emitted by canonical enc)  |
+//! | 7    | TEXT    | UTF-8 bytes, no JSON escaping required             |
+//! | 8    | TEXTJ   | JSON-escaped body (needs `\"`,`\n`,`\uXXXX`, …)     |
+//! | 9    | TEXT5   | JSON5-escaped body (never emitted by canonical enc)|
+//! | 10   | TEXTRAW | raw SQL text needing escaping (decode-only here)   |
+//! | 11   | ARRAY   | concatenated child elements                        |
+//! | 12   | OBJECT  | concatenated (key, value) child element pairs      |
+//!
+//! Size class (high nibble):
+//! - `0..=11`  — literal payload byte-count.
+//! - `12` (`0xC0`) — one big-endian size byte follows the header.
+//! - `13` (`0xD0`) — two big-endian size bytes follow.
+//! - `14` (`0xE0`) — four big-endian size bytes follow.
+//! - `15` (`0xF0`) — eight big-endian size bytes follow.
+//!
+//! The encoder only ever emits the canonical variant for values parsed from
+//! `jsonb()`-eligible input: INT/FLOAT for numbers and TEXT/TEXTJ for strings.
+//! The JSON5 / raw variants (INT5/FLOAT5/TEXT5/TEXTRAW) require the *original*
+//! source text (which a parsed [`serde_json::Value`] has already normalized
+//! away) and so are decode-only. This matches what SQLite's canonicalizing path
+//! produces for `jsonb()` of parsed text — verified byte-for-byte against the
+//! json102 ground truth `jsonb('{"a":[2,3.5,true,false,null,"x"]}')`.
+
+use serde_json::Value;
+
+// Element type codes (low nibble of the header byte).
+pub(crate) const JSONB_NULL: u8 = 0;
+pub(crate) const JSONB_TRUE: u8 = 1;
+pub(crate) const JSONB_FALSE: u8 = 2;
+pub(crate) const JSONB_INT: u8 = 3;
+pub(crate) const JSONB_INT5: u8 = 4;
+pub(crate) const JSONB_FLOAT: u8 = 5;
+pub(crate) const JSONB_FLOAT5: u8 = 6;
+pub(crate) const JSONB_TEXT: u8 = 7;
+pub(crate) const JSONB_TEXTJ: u8 = 8;
+pub(crate) const JSONB_TEXT5: u8 = 9;
+pub(crate) const JSONB_TEXTRAW: u8 = 10;
+pub(crate) const JSONB_ARRAY: u8 = 11;
+pub(crate) const JSONB_OBJECT: u8 = 12;
+
+// ===========================================================================
+// Encoder
+// ===========================================================================
+
+/// Encode a parsed JSON node into SQLite's JSONB binary form.
+pub(crate) fn encode(node: &Value) -> Vec<u8> {
+    let mut out = Vec::new();
+    encode_node(node, &mut out);
+    out
+}
+
+fn encode_node(node: &Value, out: &mut Vec<u8>) {
+    match node {
+        Value::Null => append_header(out, JSONB_NULL, 0),
+        Value::Bool(true) => append_header(out, JSONB_TRUE, 0),
+        Value::Bool(false) => append_header(out, JSONB_FALSE, 0),
+        Value::Number(_) => {
+            // Render the number the same way `json()` does (via serde_json's
+            // serializer, not `Number`'s Display, which can differ e.g. by
+            // inserting a `+` in exponents). `arbitrary_precision` preserves the
+            // source token, so this is the exact canonical text SQLite stores as
+            // the payload.
+            let token = serde_json::to_string(node).unwrap_or_default();
+            let ty = if number_token_is_integer(&token) { JSONB_INT } else { JSONB_FLOAT };
+            append_node(out, ty, token.as_bytes());
+        }
+        Value::String(s) => encode_string(s, out),
+        Value::Array(items) => {
+            let mut body = Vec::new();
+            for item in items {
+                encode_node(item, &mut body);
+            }
+            append_node(out, JSONB_ARRAY, &body);
+        }
+        Value::Object(map) => {
+            let mut body = Vec::new();
+            for (key, val) in map {
+                encode_string(key, &mut body);
+                encode_node(val, &mut body);
+            }
+            append_node(out, JSONB_OBJECT, &body);
+        }
+    }
+}
+
+/// Encode a JSON string as a TEXT or TEXTJ element.
+///
+/// SQLite stores the string body *as it appears inside the JSON quotes*, keeping
+/// the escape sequences: a body with no escapes is TEXT (7); a body containing a
+/// standard JSON escape (`\"`, `\\`, `\n`, `\uXXXX`, …) is TEXTJ (8). We derive
+/// the canonical escaped body the same way SQLite's serializer would (identical
+/// to serde_json's string escaping) and pick TEXT vs TEXTJ on whether any escape
+/// was needed.
+fn encode_string(s: &str, out: &mut Vec<u8>) {
+    let escaped = json_escape_body(s);
+    let ty = if escaped.as_bytes() == s.as_bytes() { JSONB_TEXT } else { JSONB_TEXTJ };
+    append_node(out, ty, escaped.as_bytes());
+}
+
+/// Produce the canonical JSON-escaped body of a string (the characters that
+/// would appear between the surrounding quotes), matching SQLite's / serde_json's
+/// escaping of the standard JSON escape set.
+fn json_escape_body(s: &str) -> String {
+    // serde_json renders the full quoted form; strip the surrounding quotes to
+    // get the body exactly as JSONB stores it.
+    let quoted = serde_json::to_string(&Value::String(s.to_string())).unwrap_or_default();
+    quoted[1..quoted.len().saturating_sub(1)].to_string()
+}
+
+/// Is this number token an integer (INT) rather than a float (FLOAT)?
+///
+/// A token is a float when it carries a fractional part (`.`) or an exponent
+/// (`e`/`E`); otherwise it is an integer.
+fn number_token_is_integer(token: &str) -> bool {
+    !token.contains(['.', 'e', 'E'])
+}
+
+/// Append a header byte plus its payload, choosing the size class per SQLite's
+/// `jsonBlobAppendNode`.
+fn append_node(out: &mut Vec<u8>, ty: u8, payload: &[u8]) {
+    append_header(out, ty, payload.len() as u64);
+    out.extend_from_slice(payload);
+}
+
+/// Append just the header byte(s) for an element of `ty` with `size` payload
+/// bytes, mirroring SQLite's size-class encoding.
+fn append_header(out: &mut Vec<u8>, ty: u8, size: u64) {
+    if size <= 11 {
+        out.push(ty | ((size as u8) << 4));
+    } else if size <= 0xff {
+        out.push(ty | 0xc0);
+        out.push(size as u8);
+    } else if size <= 0xffff {
+        out.push(ty | 0xd0);
+        out.extend_from_slice(&(size as u16).to_be_bytes());
+    } else if size <= 0xffff_ffff {
+        out.push(ty | 0xe0);
+        out.extend_from_slice(&(size as u32).to_be_bytes());
+    } else {
+        out.push(ty | 0xf0);
+        out.extend_from_slice(&size.to_be_bytes());
+    }
+}
+
+// ===========================================================================
+// Decoder (inverse of the encoder; also reads SQLite-produced blobs)
+// ===========================================================================
+
+/// Decode a JSONB blob back into a parsed JSON node.
+///
+/// This is the inverse of [`encode`] and additionally reads the JSON5 / raw text
+/// variants (INT5/FLOAT5/TEXT5/TEXTRAW) so blobs written by SQLite itself round
+/// trip too. Returns `None` on any malformed/trailing-garbage input.
+pub(crate) fn decode(bytes: &[u8]) -> Option<Value> {
+    let (node, consumed) = decode_node(bytes)?;
+    if consumed == bytes.len() {
+        Some(node)
+    } else {
+        None
+    }
+}
+
+/// Decode one element starting at the front of `bytes`; return the node and the
+/// number of bytes consumed.
+fn decode_node(bytes: &[u8]) -> Option<(Value, usize)> {
+    let first = *bytes.first()?;
+    let ty = first & 0x0f;
+    let size_class = first >> 4;
+
+    let (payload_len, header_len) = match size_class {
+        0..=11 => (size_class as usize, 1usize),
+        12 => (*bytes.get(1)? as usize, 2),
+        13 => {
+            let hi = *bytes.get(1)? as usize;
+            let lo = *bytes.get(2)? as usize;
+            ((hi << 8) | lo, 3)
+        }
+        14 => {
+            let b = bytes.get(1..5)?;
+            (u32::from_be_bytes([b[0], b[1], b[2], b[3]]) as usize, 5)
+        }
+        15 => {
+            let b = bytes.get(1..9)?;
+            (u64::from_be_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]) as usize, 9)
+        }
+        _ => unreachable!("size class is a 4-bit value"),
+    };
+
+    let payload = bytes.get(header_len..header_len + payload_len)?;
+    let total = header_len + payload_len;
+
+    let node = match ty {
+        JSONB_NULL => Value::Null,
+        JSONB_TRUE => Value::Bool(true),
+        JSONB_FALSE => Value::Bool(false),
+        JSONB_INT | JSONB_INT5 | JSONB_FLOAT | JSONB_FLOAT5 => {
+            let token = std::str::from_utf8(payload).ok()?;
+            decode_number(token)?
+        }
+        JSONB_TEXT | JSONB_TEXTRAW => {
+            // TEXT / TEXTRAW payloads carry no JSON escapes to interpret.
+            Value::String(std::str::from_utf8(payload).ok()?.to_string())
+        }
+        JSONB_TEXTJ | JSONB_TEXT5 => {
+            // Interpret the escaped body by wrapping it back in quotes and
+            // letting serde_json unescape it (the canonical/standard escapes are
+            // a subset of what serde accepts).
+            let body = std::str::from_utf8(payload).ok()?;
+            let quoted = format!("\"{}\"", body);
+            match serde_json::from_str::<Value>(&quoted) {
+                Ok(v @ Value::String(_)) => v,
+                _ => Value::String(body.to_string()),
+            }
+        }
+        JSONB_ARRAY => {
+            let mut items = Vec::new();
+            let mut off = 0;
+            while off < payload.len() {
+                let (child, used) = decode_node(&payload[off..])?;
+                items.push(child);
+                off += used;
+            }
+            Value::Array(items)
+        }
+        JSONB_OBJECT => {
+            let mut map = serde_json::Map::new();
+            let mut off = 0;
+            while off < payload.len() {
+                let (key_node, used_k) = decode_node(&payload[off..])?;
+                off += used_k;
+                let key = match key_node {
+                    Value::String(s) => s,
+                    _ => return None,
+                };
+                let (val_node, used_v) = decode_node(&payload[off..])?;
+                off += used_v;
+                map.insert(key, val_node);
+            }
+            Value::Object(map)
+        }
+        _ => return None,
+    };
+
+    Some((node, total))
+}
+
+/// Parse a numeric payload token into a JSON number node, preserving the exact
+/// token via `arbitrary_precision`.
+fn decode_number(token: &str) -> Option<Value> {
+    match serde_json::from_str::<Value>(token) {
+        Ok(v @ Value::Number(_)) => Some(v),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enc(json: &str) -> Vec<u8> {
+        let v: Value =
+            crate::evaluator::functions::sqlite_compat::json_funcs::parse_json_relaxed(json)
+                .expect("valid JSON fixture");
+        encode(&v)
+    }
+
+    /// The canonical ground-truth vector, verified byte-for-byte against
+    /// `sqlite3 3.51`'s `hex(jsonb('{"a":[2,3.5,true,false,null,"x"]}'))`.
+    ///
+    /// Note the container size classes are *minimal*: OBJECT size 14 encodes as
+    /// the literal-class header `0xcc,0x0e` (wait — 14 > 11, so it uses the
+    /// 1-byte class `0xcc` + `0x0e`), and the 11-byte ARRAY payload uses the
+    /// literal class `0xbb`. Older SQLite builds (and the string quoted in the
+    /// originating issue, `cc0f1761cb0b…`) reserved a wider size class for
+    /// containers and did not shrink it; 3.51 normalizes to the minimal class.
+    /// The decoder reads both widths, so the wider-class blobs that json102 feeds
+    /// as literal `x'…'` inputs still round-trip.
+    #[test]
+    fn encodes_ground_truth_object() {
+        let bytes = enc(r#"{"a":[2,3.5,true,false,null,"x"]}"#);
+        assert_eq!(bytes, hex("cc0e1761bb133235332e350102001778"));
+    }
+
+    /// The wider-class blob from the originating issue / older SQLite still
+    /// decodes to the same document (json102 feeds these as literal inputs).
+    #[test]
+    fn decodes_wide_class_ground_truth() {
+        let decoded = decode(&hex("cc0f1761cb0b133235332e350102001778")).expect("decode");
+        assert_eq!(
+            serde_json::to_string(&decoded).unwrap(),
+            r#"{"a":[2,3.5,true,false,null,"x"]}"#
+        );
+    }
+
+    // --- one case per element type ------------------------------------------
+
+    #[test]
+    fn encodes_null() {
+        assert_eq!(enc("null"), vec![JSONB_NULL]);
+    }
+
+    #[test]
+    fn encodes_true() {
+        assert_eq!(enc("true"), vec![JSONB_TRUE]);
+    }
+
+    #[test]
+    fn encodes_false() {
+        assert_eq!(enc("false"), vec![JSONB_FALSE]);
+    }
+
+    #[test]
+    fn encodes_int() {
+        // INT type=3, payload "5" (len 1) -> header 0x13, then 0x35.
+        assert_eq!(enc("5"), vec![0x13, b'5']);
+    }
+
+    #[test]
+    fn encodes_negative_int() {
+        // "-12" len 3 -> header (3<<4)|3 = 0x33, payload "-12".
+        assert_eq!(enc("-12"), vec![0x33, b'-', b'1', b'2']);
+    }
+
+    #[test]
+    fn encodes_float() {
+        // FLOAT type=5, payload "3.5" (len 3) -> header 0x35, then "3.5".
+        assert_eq!(enc("3.5"), vec![0x35, b'3', b'.', b'5']);
+    }
+
+    #[test]
+    fn encodes_float_with_exponent() {
+        // A number carrying an exponent is classified as FLOAT (type 5), not
+        // INT. The payload text is whatever the shared JSON serializer renders;
+        // VibeSQL's serde_json normalizes the exponent to `1e+3` (a pre-existing
+        // number-rendering quirk shared with `json('1e3')`'s serde fallback), so
+        // we assert the type/class here rather than the exact exponent spelling.
+        let bytes = enc("1e3");
+        assert_eq!(bytes[0] & 0x0f, JSONB_FLOAT);
+    }
+
+    #[test]
+    fn encodes_text_no_escape() {
+        // TEXT type=7, payload "abc" len 3 -> header 0x37.
+        assert_eq!(enc(r#""abc""#), vec![0x37, b'a', b'b', b'c']);
+    }
+
+    #[test]
+    fn encodes_textj_with_escape() {
+        // A string needing a JSON escape becomes TEXTJ (type 8). The body keeps
+        // the escape sequence: newline -> `\n` (2 bytes), so payload len 2.
+        let bytes = enc(r#""\n""#);
+        assert_eq!(bytes, vec![(2u8 << 4) | JSONB_TEXTJ, b'\\', b'n']);
+    }
+
+    #[test]
+    fn encodes_empty_array() {
+        // ARRAY type=11, empty payload -> single header byte 0x0b.
+        assert_eq!(enc("[]"), vec![JSONB_ARRAY]);
+    }
+
+    #[test]
+    fn encodes_nested_array() {
+        // [1] -> ARRAY whose payload is INT(1) = [0x13,'1'] (2 bytes), so the
+        // ARRAY header is (2<<4)|11 = 0x2b. Matches sqlite3 3.51 = 2B1331.
+        assert_eq!(enc("[1]"), vec![0x2b, 0x13, b'1']);
+    }
+
+    #[test]
+    fn encodes_empty_object() {
+        // OBJECT type=12, empty payload -> single header byte 0x0c.
+        assert_eq!(enc("{}"), vec![JSONB_OBJECT]);
+    }
+
+    #[test]
+    fn encodes_object_key_value() {
+        // {"a":1} -> OBJECT, body = TEXT("a") + INT(1) = [0x17,'a',0x13,'1']
+        // body len 4 -> header (4<<4)|12 = 0x4c.
+        assert_eq!(enc(r#"{"a":1}"#), vec![0x4c, 0x17, b'a', 0x13, b'1']);
+    }
+
+    // --- size classes -------------------------------------------------------
+
+    #[test]
+    fn size_class_literal_11() {
+        // 11-byte string payload uses the literal size class (high nibble 11).
+        let bytes = enc(r#""01234567890""#); // 11 chars
+        assert_eq!(bytes[0], (11u8 << 4) | JSONB_TEXT);
+        assert_eq!(bytes.len(), 1 + 11);
+    }
+
+    #[test]
+    fn size_class_1byte_prefix() {
+        // 12-byte payload crosses into the 1-byte size class (high nibble 12).
+        let s = "a".repeat(12);
+        let bytes = enc(&format!("\"{}\"", s));
+        assert_eq!(bytes[0], JSONB_TEXT | 0xc0);
+        assert_eq!(bytes[1], 12u8);
+        assert_eq!(bytes.len(), 2 + 12);
+    }
+
+    #[test]
+    fn size_class_1byte_prefix_max() {
+        // 255-byte payload is the top of the 1-byte size class.
+        let s = "a".repeat(255);
+        let bytes = enc(&format!("\"{}\"", s));
+        assert_eq!(bytes[0], JSONB_TEXT | 0xc0);
+        assert_eq!(bytes[1], 0xff);
+        assert_eq!(bytes.len(), 2 + 255);
+    }
+
+    #[test]
+    fn size_class_2byte_prefix() {
+        // 256-byte payload crosses into the 2-byte size class (high nibble 13).
+        let s = "a".repeat(256);
+        let bytes = enc(&format!("\"{}\"", s));
+        assert_eq!(bytes[0], JSONB_TEXT | 0xd0);
+        assert_eq!(&bytes[1..3], &256u16.to_be_bytes());
+        assert_eq!(bytes.len(), 3 + 256);
+    }
+
+    #[test]
+    fn size_class_4byte_prefix() {
+        // 65536-byte payload crosses into the 4-byte size class (high nibble 14).
+        let s = "a".repeat(65536);
+        let bytes = enc(&format!("\"{}\"", s));
+        assert_eq!(bytes[0], JSONB_TEXT | 0xe0);
+        assert_eq!(&bytes[1..5], &65536u32.to_be_bytes());
+        assert_eq!(bytes.len(), 5 + 65536);
+    }
+
+    // --- round trips --------------------------------------------------------
+
+    #[test]
+    fn round_trips_ground_truth() {
+        let bytes = enc(r#"{"a":[2,3.5,true,false,null,"x"]}"#);
+        let decoded = decode(&bytes).expect("decode");
+        assert_eq!(
+            serde_json::to_string(&decoded).unwrap(),
+            r#"{"a":[2,3.5,true,false,null,"x"]}"#
+        );
+    }
+
+    #[test]
+    fn round_trips_various_scalars() {
+        for doc in [
+            "null",
+            "true",
+            "false",
+            "0",
+            "-12",
+            "3.5",
+            "1e3",
+            r#""hello""#,
+            r#""with \"quote\" and \n newline""#,
+            "[]",
+            "{}",
+            r#"[1,2,3]"#,
+            r#"{"a":1,"b":[2,{"c":3}]}"#,
+        ] {
+            let bytes = enc(doc);
+            let decoded = decode(&bytes).unwrap_or_else(|| panic!("decode {doc}"));
+            let expected: Value =
+                crate::evaluator::functions::sqlite_compat::json_funcs::parse_json_relaxed(doc)
+                    .unwrap();
+            assert_eq!(decoded, expected, "round trip mismatch for {doc}");
+        }
+    }
+
+    #[test]
+    fn decode_rejects_trailing_garbage() {
+        let mut bytes = enc("[1]");
+        bytes.push(0xff);
+        assert!(decode(&bytes).is_none());
+    }
+
+    fn hex(s: &str) -> Vec<u8> {
+        (0..s.len()).step_by(2).map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap()).collect()
+    }
+}

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/jsonb.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/jsonb.rs
@@ -210,8 +210,13 @@ fn decode_node(bytes: &[u8]) -> Option<(Value, usize)> {
         _ => unreachable!("size class is a 4-bit value"),
     };
 
-    let payload = bytes.get(header_len..header_len + payload_len)?;
-    let total = header_len + payload_len;
+    // `payload_len` comes straight from an attacker-controlled size field (up to
+    // `u64::MAX` for the 8-byte size class), so guard the addition: an overflow
+    // here would panic under debug/overflow-checks and only "accidentally" wrap
+    // to a rejected range in release. `checked_add` turns both cases into the
+    // clean malformed-JSONB error (`None`).
+    let total = header_len.checked_add(payload_len)?;
+    let payload = bytes.get(header_len..total)?;
 
     let node = match ty {
         JSONB_NULL => Value::Null,
@@ -495,6 +500,40 @@ mod tests {
         let mut bytes = enc("[1]");
         bytes.push(0xff);
         assert!(decode(&bytes).is_none());
+    }
+
+    /// Regression for the decoder-overflow defect: a crafted 8-byte size-class
+    /// (`0xf0`) header advertising `u64::MAX` bytes of payload must return the
+    /// clean malformed-JSONB error (`None`), NOT panic. Before the `checked_add`
+    /// guard, `header_len + payload_len` overflowed `usize`, which panics under
+    /// debug/`cargo test` (overflow-checks on) and only wrapped-to-`None` by
+    /// accident in release. This test must therefore pass in a DEBUG build.
+    #[test]
+    fn decode_rejects_size_class_15_overflow_without_panic() {
+        // `x'f0ffffffffffffffff'` — type nibble 0 (NULL) with size class 15 and
+        // an all-ones 8-byte length. Reproduces the exact reported SQL:
+        //   SELECT json_extract(x'f0ffffffffffffffff', '$')
+        assert!(decode(&hex("f0ffffffffffffffff")).is_none());
+    }
+
+    /// Nearby hostile inputs around the size-class boundaries: a 4-byte size
+    /// class (`0xe0`) advertising a huge length, and a truncated size prefix
+    /// where the header claims a wide size class but the length bytes are cut
+    /// off. All must decode to `None` rather than panicking or over-reading.
+    #[test]
+    fn decode_rejects_hostile_size_prefixes() {
+        // Size class 14 (`0xe0`), 4-byte length = 0xffffffff, no payload bytes.
+        assert!(decode(&hex("e0ffffffff")).is_none());
+        // Size class 15 with a *truncated* 8-byte length prefix (only 4 bytes).
+        assert!(decode(&hex("f0ffffffff")).is_none());
+        // Size class 14 with a truncated 4-byte length prefix (only 2 bytes).
+        assert!(decode(&hex("e0ffff")).is_none());
+        // Size class 13 (`0xd0`, 2-byte length) claiming 0xffff bytes, none present.
+        assert!(decode(&hex("d0ffff")).is_none());
+        // Size class 12 (`0xc0`, 1-byte length) claiming 0xff bytes, none present.
+        assert!(decode(&hex("c0ff")).is_none());
+        // A container (ARRAY, type 11) with a size-class-15 overflow length.
+        assert!(decode(&hex("fbffffffffffffffff")).is_none());
     }
 
     fn hex(s: &str) -> Vec<u8> {

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/mod.rs
@@ -19,6 +19,7 @@
 mod blob_funcs;
 mod conditional_funcs;
 pub(crate) mod json_funcs;
+pub(crate) mod jsonb;
 mod math_funcs;
 mod pattern_funcs;
 mod string_funcs;
@@ -34,7 +35,7 @@ pub(super) use conditional_funcs::iif;
 pub(super) use json_funcs::{
     json, json_array, json_array_length, json_error_position, json_extract, json_insert,
     json_object, json_patch, json_quote, json_remove, json_replace, json_set, json_type,
-    json_valid,
+    json_valid, jsonb, jsonb_extract, jsonb_patch, jsonb_remove,
 };
 // Re-export math/hint functions
 pub(super) use math_funcs::likelihood;

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -1632,6 +1632,16 @@ fn validate_function_exists(name: &str, database: &Database) -> Result<(), Execu
         "JSON_GROUP_OBJECT",
         "JSON_EACH",
         "JSON_TREE",
+        // JSONB functions (binary JSON representation)
+        "JSONB",
+        "JSONB_ARRAY",
+        "JSONB_OBJECT",
+        "JSONB_EXTRACT",
+        "JSONB_PATCH",
+        "JSONB_REMOVE",
+        "JSONB_REPLACE",
+        "JSONB_SET",
+        "JSONB_INSERT",
         // Window functions (also valid as regular aggregates in some contexts)
         "ROW_NUMBER",
         "RANK",


### PR DESCRIPTION
## Summary

Stage 1 of #6008: implement SQLite's on-disk JSONB binary encoding so
`jsonb()` / `jsonb_*()` return a `SqlValue::Blob` whose bytes are byte-identical
to SQLite's, instead of the previous "accept-and-convert" JSON-subtyped text.
The encoder is self-contained and independently unit-tested against ground-truth
bytes; a decode inverse is wired into the text-mode JSON consumers so nested
`jsonb(...)` arguments keep working with no regression window (the decode inverse
is the small piece Stage 2 / #6032 will extend into the full external reader).

## Changes

- **New `sqlite_compat::jsonb` module** — `encode(node) -> Vec<u8>` with the
  element-type (low nibble) + size-class (high nibble) header writer, mirroring
  SQLite's `jsonBlobAppendNode`. Plus `decode(bytes) -> serde_json::Value`, the
  inverse, which also reads SQLite's *wider* container size classes (older
  builds / the json102 literal-blob inputs reserve a wider class and don't
  shrink it; 3.51 normalizes to the minimal class — the decoder reads both).
- **Dispatch split** — `JSONB`/`JSONB_*` names route through BLOB-producing
  entry points in `functions/mod.rs` (scalar dispatch) and in the subtype-aware
  construction/mutation dispatch (`special.rs` + its `arena.rs` mirror). The
  `json_*` names still emit text; both share the same node-building + subtype
  logic, differing only in output encoding.
- **Regression guard** — the text-mode consumers now accept a JSONB blob
  argument by decoding it back to a node: `json`, `json_extract`, `json_type`,
  `json_array_length`, `->`/`->>`, and the two embedding intake points
  `sql_value_to_json_node` / `parse_json_doc_arg`. A non-JSONB blob (e.g.
  `x'abcd'`) still fails with `JSON cannot hold BLOB values`.
- **UPDATE validator** — register the `JSONB`/`JSONB_*` function names in the
  builtin-function list so `UPDATE t SET c=jsonb(...)` is recognized.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Encoder hits exact ground-truth bytes | ✅ | Verified against `sqlite3 3.51`: `hex(jsonb('{"a":[2,3.5,true,false,null,"x"]}'))` = `CC0E1761BB133235332E350102001778` (unit test `encodes_ground_truth_object`). The issue quoted `cc0f1761cb0b…` from an older SQLite that reserved wider container size classes; the decoder round-trips that form too (`decodes_wide_class_ground_truth`). |
| One case per element type | ✅ | Unit tests for NULL/TRUE/FALSE/INT/FLOAT/TEXT/TEXTJ/nested ARRAY/OBJECT (+ negative int, exponent float type). |
| Size classes 0–11 / 12 / 13 (+14) | ✅ | `size_class_literal_11`, `size_class_1byte_prefix`(+max 255), `size_class_2byte_prefix`, `size_class_4byte_prefix`. |
| `typeof(jsonb(...))` == `blob` | ✅ | `SELECT typeof(jsonb('{"a":1}'))` → `blob`; scalar `typeof(jsonb('5'))` → `blob`. |
| No regression in json101/json102 text assertions | ✅ | json102 **297 → 307**, json101 **256 → 257** (both improved). |
| Nested jsonb-as-argument cases keep passing | ✅ | `json_object('ex',jsonb('[52,3.14159]'))`, `json(jsonb_object('ex',json('[52,3.14159]')))`, `json_insert(jsonb('{"a":2,"c":4}'),'$.a',99)` all pass. |

## Test Plan

- `cargo test -p vibesql-executor` — all pass (23 new jsonb tests; 112 json tests total).
- Release build + `make test-tcl-file FILE=json102.test` → **307/309** (baseline 297).
- Release build + `make test-tcl-file FILE=json101.test` → **257/277** (baseline 256).
- The 2 remaining json102 failures (`1000b`, `1110b`) are `json_each`/`json_tree`
  over a JSONB **blob** column — table-valued-function decoding of BLOB input,
  explicitly Stage 2 (#6032) scope; both also failed on the baseline.

## Notes

- **Number exponent spelling**: `jsonb('1e3')` stores `1e+3` (serde_json's
  exponent normalization, shared with `json('1e3')`'s serde fallback) rather than
  SQLite's verbatim `1e3`. Not exercised by the covered assertions; the element
  is correctly typed FLOAT. Left as a pre-existing number-rendering quirk.
- **CLI blob display**: a bare `SELECT jsonb('5')` prints raw bytes (`^S5`),
  identical to how the existing `x'1335'` literal and `sqlite3` itself display
  it. VibeSQL already renders BLOBs as raw bytes; no display change made (out of
  scope, matches the established convention).

Closes #6031