### PR TITLE
feat(json): accept JSONB blobs in json_each/json_tree, json_valid flags, and json_quote

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/json_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/json_funcs.rs
@@ -879,15 +879,15 @@ pub(crate) fn eval_json_arrow(
 /// `legacy_json_valid` build returned 0).
 ///
 /// The optional FLAGS argument (SQLite 3.45+) selects which representations
-/// count as valid (<https://sqlite.org/json1.html#jvalid>). We honor the
-/// text-JSON bits:
+/// count as valid (<https://sqlite.org/json1.html#jvalid>). We honor:
 ///   - `0x01`: canonical RFC-8259 JSON text
 ///   - `0x02`: JSON5 text
-/// The JSONB-blob bits (`0x04`/`0x08`) never match because VibeSQL does not
-/// implement SQLite's binary JSONB representation (accept-and-convert keeps
-/// everything as text — see the Phase 4 JSONB note). Default FLAGS is `1`
-/// (canonical text only), so a JSON5 input like `{a:5}` validates as 0 unless
-/// bit `0x02` is set.
+///   - `0x04`/`0x08`: JSONB blob (a BLOB argument validates when it decodes as a
+///     well-formed JSONB document via [`super::jsonb::decode`])
+/// Default FLAGS is `1` (canonical text only), so a JSON5 input like `{a:5}`
+/// validates as 0 unless bit `0x02` is set, and a JSONB blob validates as 0
+/// unless bit `0x04` or `0x08` is set (SQLite's documented default-flags
+/// semantics).
 pub(crate) fn json_valid(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.is_empty() || args.len() > 2 {
         return Err(ExecutorError::WrongNumberOfArguments {
@@ -909,6 +909,9 @@ pub(crate) fn json_valid(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     };
     let accept_canonical = flags & 0x01 != 0;
     let accept_json5 = flags & 0x02 != 0;
+    // Bits 0x04 and 0x08 both select JSONB-blob validation (SQLite: "The input is
+    // JSONB" / "The input is text or JSONB").
+    let accept_jsonb = flags & 0x0c != 0;
 
     let valid = match &args[0] {
         SqlValue::Null => return Ok(SqlValue::Null),
@@ -932,7 +935,9 @@ pub(crate) fn json_valid(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         | SqlValue::Float(_)
         | SqlValue::Real(_)
         | SqlValue::Double(_) => accept_canonical || accept_json5,
-        // Blobs would only be valid under the JSONB bits, which we never accept.
+        // A BLOB validates only under the JSONB bits, and only when it decodes as
+        // a well-formed JSONB document (a non-JSONB blob like x'abcd' is invalid).
+        SqlValue::Blob(bytes) => accept_jsonb && super::jsonb::decode(bytes).is_some(),
         _ => false,
     };
 
@@ -1115,7 +1120,10 @@ pub(crate) fn json_type(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
 /// json_quote(X) - render a SQL scalar as a JSON value.
 ///
 /// Strings are double-quoted with interior characters escaped; numbers render
-/// as-is; SQL NULL becomes the unquoted text `null`; BLOBs are an error.
+/// as-is; SQL NULL becomes the unquoted text `null`. A JSONB blob (produced by
+/// jsonb()/jsonb_*()) is decoded and rendered as its canonical JSON text
+/// (SQLite: `json_quote(jsonb('[1,2]'))` -> `[1,2]`); any other (non-JSONB) blob
+/// is an error.
 pub(crate) fn json_quote(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     if args.len() != 1 {
         return Err(ExecutorError::WrongNumberOfArguments {
@@ -1141,11 +1149,16 @@ pub(crate) fn json_quote(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
             serde_json::to_string(&serde_json::Value::String(s.as_str().to_string()))
                 .unwrap_or_default()
         }
-        SqlValue::Blob(_) => {
-            return Err(ExecutorError::SqliteCompatError(
-                "JSON cannot hold BLOB values".to_string(),
-            ));
-        }
+        SqlValue::Blob(bytes) => match super::jsonb::decode(bytes) {
+            // A well-formed JSONB blob decodes and re-renders as canonical JSON
+            // text (SQLite: `json_quote(jsonb('[1,2]'))` -> `[1,2]`).
+            Some(node) => json_node_to_json_text(&node),
+            None => {
+                return Err(ExecutorError::SqliteCompatError(
+                    "JSON cannot hold BLOB values".to_string(),
+                ));
+            }
+        },
         other => {
             // Fall back to a textual scalar rendering for remaining types.
             sql_value_scalar_text(other)
@@ -2454,6 +2467,32 @@ mod tests {
         assert_eq!(json_valid(&[json5, SqlValue::Integer(1)]).unwrap(), SqlValue::Integer(0));
     }
 
+    #[test]
+    fn test_json_valid_jsonb_blob_flags() {
+        let node: serde_json::Value = serde_json::from_str(r#"{"a":1}"#).unwrap();
+        let blob = SqlValue::Blob(super::super::jsonb::encode(&node));
+        // Default flags (canonical text only): a JSONB blob validates as 0,
+        // matching SQLite's documented default-flags semantics.
+        assert_eq!(json_valid(&[blob.clone()]).unwrap(), SqlValue::Integer(0));
+        // Flag bit 0x04 selects JSONB validation -> 1.
+        assert_eq!(
+            json_valid(&[blob.clone(), SqlValue::Integer(4)]).unwrap(),
+            SqlValue::Integer(1)
+        );
+        // Flag 5 (0x01 | 0x04) also accepts the JSONB blob (json101-5.2b).
+        assert_eq!(
+            json_valid(&[blob.clone(), SqlValue::Integer(5)]).unwrap(),
+            SqlValue::Integer(1)
+        );
+        // Flag bit 0x08 selects JSONB validation too.
+        assert_eq!(json_valid(&[blob, SqlValue::Integer(8)]).unwrap(), SqlValue::Integer(1));
+        // A non-JSONB blob is invalid even with the JSONB bit set.
+        assert_eq!(
+            json_valid(&[SqlValue::Blob(vec![0xab, 0xcd]), SqlValue::Integer(5)]).unwrap(),
+            SqlValue::Integer(0)
+        );
+    }
+
     /// Removing the root path ($) discards the whole document -> NULL, while
     /// json_remove with no path argument returns the document unchanged.
     #[test]
@@ -2896,10 +2935,39 @@ mod tests {
     }
 
     #[test]
-    fn test_json_quote_blob_errors() {
+    fn test_json_quote_non_jsonb_blob_errors() {
+        // A blob that does not decode as JSONB is still an error.
         let e = json_quote(&[SqlValue::Blob(vec![0x30, 0x31])]);
         assert!(
             matches!(e, Err(ExecutorError::SqliteCompatError(ref m)) if m == "JSON cannot hold BLOB values")
+        );
+    }
+
+    #[test]
+    fn test_json_quote_jsonb_blob_renders_canonical_text() {
+        // A JSONB blob decodes and renders as its canonical JSON text (matching
+        // SQLite: json_quote(jsonb('[1,2]')) -> [1,2]).
+        let arr: serde_json::Value = serde_json::from_str("[1,2]").unwrap();
+        assert_eq!(
+            json_quote(&[SqlValue::Blob(super::super::jsonb::encode(&arr))]).unwrap(),
+            SqlValue::Varchar("[1,2]".into())
+        );
+        let obj: serde_json::Value = serde_json::from_str(r#"{"a":1}"#).unwrap();
+        assert_eq!(
+            json_quote(&[SqlValue::Blob(super::super::jsonb::encode(&obj))]).unwrap(),
+            SqlValue::Varchar(r#"{"a":1}"#.into())
+        );
+        // A JSONB scalar string re-renders as a quoted JSON string.
+        let s: serde_json::Value = serde_json::Value::String("hello".into());
+        assert_eq!(
+            json_quote(&[SqlValue::Blob(super::super::jsonb::encode(&s))]).unwrap(),
+            SqlValue::Varchar(r#""hello""#.into())
+        );
+        // A JSONB scalar number re-renders bare.
+        let n: serde_json::Value = serde_json::from_str("5").unwrap();
+        assert_eq!(
+            json_quote(&[SqlValue::Blob(super::super::jsonb::encode(&n))]).unwrap(),
+            SqlValue::Varchar("5".into())
         );
     }
 

--- a/crates/vibesql-executor/src/select/scan/table_function.rs
+++ b/crates/vibesql-executor/src/select/scan/table_function.rs
@@ -32,9 +32,12 @@
 use crate::{
     errors::ExecutorError,
     evaluator::{
-        functions::sqlite_compat::json_funcs::{
-            json_node_to_json_text, json_node_to_sql_value, json_node_type_name, navigate,
-            parse_json_relaxed, parse_sqlite_json_path,
+        functions::sqlite_compat::{
+            json_funcs::{
+                json_node_to_json_text, json_node_to_sql_value, json_node_type_name, navigate,
+                parse_json_relaxed, parse_sqlite_json_path,
+            },
+            jsonb::decode as decode_jsonb_blob,
         },
         CombinedExpressionEvaluator,
     },
@@ -128,17 +131,23 @@ pub(crate) fn execute_table_function(
 
     // A NULL json argument yields zero rows (SQLite: `json_each(NULL)` -> 0
     // rows). Same for a NULL path.
-    let json_str = match &json_value {
+    //
+    // A BLOB argument is a JSONB document (produced by jsonb()/jsonb_*()): decode
+    // it directly into the expansion root. A malformed/non-JSONB blob is an error
+    // (SQLite: `json_each(x'abcd')` -> "malformed JSON"), never silent zero rows.
+    let root = match &json_value {
         SqlValue::Null => return Ok(super::FromResult::from_rows(schema, vec![])),
-        other => sqlvalue_as_json_text(other),
+        SqlValue::Blob(bytes) => decode_jsonb_blob(bytes)
+            .ok_or_else(|| ExecutorError::SqliteCompatError("malformed JSON".to_string()))?,
+        other => {
+            let json_str = match sqlvalue_as_json_text(other) {
+                Some(s) => s,
+                None => return Ok(super::FromResult::from_rows(schema, vec![])),
+            };
+            parse_json_relaxed(&json_str)
+                .map_err(|_| ExecutorError::SqliteCompatError("malformed JSON".to_string()))?
+        }
     };
-    let json_str = match json_str {
-        Some(s) => s,
-        None => return Ok(super::FromResult::from_rows(schema, vec![])),
-    };
-
-    let root = parse_json_relaxed(&json_str)
-        .map_err(|_| ExecutorError::SqliteCompatError("malformed JSON".to_string()))?;
 
     // Resolve the optional path argument. The path is applied to the root; the
     // referenced node becomes the expansion root. The `base_path` string is the


### PR DESCRIPTION
## Summary

Stage 2 of the JSONB work (#6032, re-scoped by the Curator against post-#6035 main). Stage 1 (#6035) already landed the JSONB encoder/decoder and wired most JSON readers to accept a `SqlValue::Blob` document; this PR closes the three reader paths that were still text-only, all verified against `sqlite3` 3.51.0.

## Changes

- **json_each / json_tree over a JSONB blob** (`select/scan/table_function.rs`): a `SqlValue::Blob` argument now decodes via `jsonb::decode` straight into the expansion root instead of falling through `sqlvalue_as_json_text` to a silent zero rows. A malformed/non-JSONB blob raises `"malformed JSON"` (matching `json_each(x'abcd')` in SQLite), never a panic or empty result. The lateral/dependent-join TVF path routes through this same entry point, so it is fixed too (verified with a lateral query over a JSONB column).
- **json_valid(X, FLAGS)** (`json_funcs.rs`): honor flag bits `0x04`/`0x08` (JSONB validation). A well-formed JSONB blob now returns `1` under flags 4/5/8; default flags still return `0`, and a non-JSONB blob returns `0`. Updated the stale doc comment that predated the JSONB encoder.
- **json_quote(X)** (`json_funcs.rs`): a JSONB blob decodes and re-renders as its canonical JSON text (`json_quote(jsonb('[1,2]'))` -> `[1,2]`, matching SQLite — not a re-quoted string literal). A non-JSONB blob still errors `"JSON cannot hold BLOB values"`.
- Added unit tests: `test_json_valid_jsonb_blob_flags`, `test_json_quote_jsonb_blob_renders_canonical_text`, and renamed/kept `test_json_quote_non_jsonb_blob_errors`.

Out of scope (Curator-flagged for a separate follow-up): `json_group_array`/`json_group_object` blob mangling in `aggregates.rs`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| json102 -> 309/309 (1000b/1110b close) | ✅ | `make test-tcl-file FILE=json102.test`: 309/309 (was 307/309) |
| json_each/json_tree decode Blob; malformed -> "malformed JSON", no panic/zero rows | ✅ | Release CLI: `json_each(jsonb('[1,2,3]'))` = 3 rows; `json_each(x'abcd')` = malformed JSON error |
| json_valid(X, FLAGS) honors 0x04; jsonb+5 = 1, default = 0 | ✅ | `json_valid(jsonb('{"a":1}'),5)` = 1; `json_valid(jsonb('{"a":1}'))` = 0; unit test |
| json101-5.2b passes | ✅ | 5.2b (`json_valid(json,5)` over JSONB) no longer in failure list; json101 258/277 (was 257) |
| json_quote decodes JSONB, matches SQLite | ✅ | `json_quote(jsonb('[1,2]'))` = `[1,2]`; non-JSONB blob still errors; unit test |
| No regression in json102 (307) / json101 (257) | ✅ | json102 309/309; json101 258/277; the other 19 json101 failures are pre-existing, unrelated (json_group_*, deep-nesting, Inf, hidden-column, nested-path auto-vivify) |
| json_group_array/object out of scope | ✅ | Not touched; recommend separate follow-up |

## Test Plan

- `cargo test -p vibesql-executor`: green (40 test-result lines, 0 failed).
- `make test-tcl-file FILE=json102.test`: **309/309** (before: 307/309).
- `make test-tcl-file FILE=json101.test`: **258/277** (before: 257/277; +1 = 5.2b).
- Release-CLI spot checks all match `sqlite3` 3.51.0, including a lateral `json_each` over a JSONB column and malformed-blob error paths.
- `cargo clippy -p vibesql-executor`: clean on touched files; `cargo fmt` applied (out-of-scope drift reverted).

Closes #6032