### PR TITLE
fix(json): report subtype 0 for BLOB-emitting jsonb functions

### DIFF
--- a/crates/vibesql-cli/tests/jsonb_persistence_test.rs
+++ b/crates/vibesql-cli/tests/jsonb_persistence_test.rs
@@ -1,0 +1,183 @@
+// ============================================================================
+// JSONB BLOB durability integration tests — issue #6033 (Stage 3)
+// ============================================================================
+//
+// Since Stage 1 (#6035), `jsonb()` / `jsonb_*()` emit real `SqlValue::Blob`
+// output rather than JSON text. Stage 3 verifies that a JSONB BLOB column
+// survives the full file-backed durability path — WAL write + checkpoint
+// (`\save`, i.e. a clean exit that writes a checkpoint and truncates the WAL) +
+// reopen — byte-for-byte identical, and that `json_each` / `json_tree` over the
+// re-loaded blob still decode correctly (mirrors json102-1000/1000b against real
+// file storage rather than the in-memory TCL harness).
+//
+// The shared value codec (`persistence/binary/value.rs`) is used by both the WAL
+// entry codec and the btree/checkpoint page format, so these tests exercise the
+// one path that both durability mechanisms share. See the curator re-scope on
+// issue #6033 for the storage-layer analysis.
+
+#![cfg(unix)]
+
+use std::{
+    io::Write,
+    path::Path,
+    process::{Command, Stdio},
+};
+
+fn vibesql_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_vibesql")
+}
+
+/// Run a one-shot `vibesql <db> < script` invocation to completion (clean exit).
+///
+/// A clean exit in script mode writes a checkpoint and truncates the WAL on the
+/// way out — the CLI's `\save` equivalent — so a subsequent invocation on the
+/// same file re-opens from the checkpoint + any residual WAL.
+fn run_script(binary: &str, db: &Path, home: &Path, script: &str) -> String {
+    let mut child = Command::new(binary)
+        .arg(db)
+        .env("HOME", home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn vibesql");
+    {
+        let mut stdin = child.stdin.take().expect("child stdin");
+        stdin.write_all(script.as_bytes()).unwrap();
+        stdin.flush().unwrap();
+        // Drop stdin (EOF) → script mode runs to completion and exits cleanly.
+    }
+    let out = child.wait_with_output().expect("vibesql did not exit");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+/// Extract the `hex(col)` uppercase-hex tokens (one per data row) from a
+/// pretty-printed `SELECT name, hex(col) ...` table, keyed by the name column.
+/// Returns `(name, hexbytes)` pairs in table order. The parser is deliberately
+/// simple: it keys off the fact that a JSONB blob renders as a long run of
+/// `[0-9A-F]` and the name is a plain word in the first cell.
+fn parse_name_hex_rows(table: &str) -> Vec<(String, String)> {
+    let mut rows = Vec::new();
+    for line in table.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('|') {
+            continue;
+        }
+        let cells: Vec<&str> = trimmed.trim_matches('|').split('|').map(str::trim).collect();
+        if cells.len() != 2 {
+            continue;
+        }
+        let (name, hex) = (cells[0], cells[1]);
+        // Skip the header row and the hex-column header.
+        if hex.eq_ignore_ascii_case("hex(phoneb)") || name == "name" {
+            continue;
+        }
+        // A data row's second cell must be pure uppercase hex.
+        if !hex.is_empty() && hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+            rows.push((name.to_string(), hex.to_string()));
+        }
+    }
+    rows
+}
+
+/// A `jsonb()`-produced BLOB column survives WAL write + checkpoint (`\save`
+/// equivalent) + reopen byte-for-byte, and `json_each` over the reloaded blob
+/// still decodes correctly (mirrors json102-1000b against real file storage).
+#[test]
+fn test_jsonb_blob_survives_checkpoint_reopen_byte_identical() {
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("jsonb_durable.vbsql");
+    let bin = vibesql_binary();
+
+    // Process 1: build the table, materialise JSONB blobs via UPDATE ... SET
+    // col=jsonb(other_col), and record the pre-checkpoint hex.
+    let seed = "CREATE TABLE user(name,phone,phoneb);\n\
+         INSERT INTO user(name,phone) VALUES\n\
+           ('Alice','[\"604-555\"]'),\n\
+           ('Bob','[\"604-666\"]'),\n\
+           ('Cindy','[\"704-111\"]'),\n\
+           ('Dave','[\"704-222\"]');\n\
+         UPDATE user SET phoneb=jsonb(phone);\n\
+         SELECT name, hex(phoneb) FROM user ORDER BY name;\n";
+    let before = run_script(bin, &db_path, home.path(), seed);
+    let before_rows = parse_name_hex_rows(&before);
+    assert_eq!(
+        before_rows.len(),
+        4,
+        "expected 4 JSONB blob rows before checkpoint; got:\n{before}"
+    );
+    // Sanity: the blobs are non-trivial (a JSONB blob is more than a couple of
+    // bytes) so the byte-comparison is meaningful.
+    assert!(
+        before_rows.iter().all(|(_, h)| h.len() >= 4),
+        "JSONB blobs should be non-trivial; got:\n{before}"
+    );
+
+    // Process 2: re-open the checkpointed file and re-read the hex — must be
+    // byte-identical to the pre-checkpoint values.
+    let after = run_script(
+        bin,
+        &db_path,
+        home.path(),
+        "SELECT name, hex(phoneb) FROM user ORDER BY name;\n",
+    );
+    let after_rows = parse_name_hex_rows(&after);
+    assert_eq!(
+        before_rows, after_rows,
+        "JSONB blob bytes must survive checkpoint + reopen byte-identically.\n\
+         before:\n{before}\nafter:\n{after}"
+    );
+
+    // Process 3: json_each over the reloaded JSONB blob still decodes correctly.
+    // Mirrors json102-1000b: only the 704-* numbers match.
+    let each = run_script(
+        bin,
+        &db_path,
+        home.path(),
+        "SELECT DISTINCT user.name FROM user, json_each(user.phoneb)\n\
+           WHERE json_each.value LIKE '704-%' ORDER BY 1;\n",
+    );
+    assert!(
+        each.contains("Cindy") && each.contains("Dave"),
+        "json_each over a reloaded JSONB blob must still decode (expect Cindy, Dave); got:\n{each}"
+    );
+    assert!(
+        !each.contains("Alice") && !each.contains("Bob"),
+        "json_each filter must exclude the 604-* rows; got:\n{each}"
+    );
+}
+
+/// `json_tree` over a reloaded JSONB blob decodes the nested structure
+/// correctly (companion to the `json_each` read-back; mirrors json102-1000).
+#[test]
+fn test_jsonb_blob_json_tree_reads_back_after_reopen() {
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("jsonb_tree.vbsql");
+    let bin = vibesql_binary();
+
+    // Store a nested JSONB document, checkpoint on exit.
+    run_script(
+        bin,
+        &db_path,
+        home.path(),
+        "CREATE TABLE t(id, doc);\n\
+         INSERT INTO t(id) VALUES (1);\n\
+         UPDATE t SET doc=jsonb('{\"a\":[10,20],\"b\":{\"c\":30}}');\n",
+    );
+
+    // Re-open and walk the tree: the leaf integer values must all be present.
+    let out = run_script(
+        bin,
+        &db_path,
+        home.path(),
+        "SELECT json_tree.value FROM t, json_tree(t.doc)\n\
+           WHERE json_tree.type NOT IN ('object','array')\n\
+           ORDER BY CAST(json_tree.value AS INTEGER);\n",
+    );
+    for leaf in ["10", "20", "30"] {
+        assert!(
+            out.contains(leaf),
+            "json_tree over a reloaded JSONB blob must yield leaf {leaf}; got:\n{out}"
+        );
+    }
+}

--- a/crates/vibesql-executor/src/evaluator/arena.rs
+++ b/crates/vibesql-executor/src/evaluator/arena.rs
@@ -113,10 +113,14 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
         self.interner.resolve(symbol)
     }
 
-    /// Does this arena expression carry SQLite's JSON subtype? True when it is a
-    /// direct call to a JSON function whose output is always well-formed JSON
-    /// (see `special.rs::expr_has_json_subtype` and the module note in
-    /// `json_funcs.rs`). Such results embed as JSON sub-documents.
+    /// Does this arena expression's result embed as a JSON sub-document when
+    /// passed to another JSON function? True when it is a direct call to a JSON
+    /// function whose output is a well-formed JSON document — JSON text or a JSONB
+    /// blob (which decodes back to the same document when embedded). This
+    /// *embedding* signal is distinct from `subtype()` reporting: a JSONB blob
+    /// embeds correctly yet reports `subtype()` 0 (see
+    /// `special.rs::expr_has_json_subtype`, `json_subtype.rs`, and the module note
+    /// in `json_funcs.rs`).
     fn arena_expr_has_json_subtype(&self, expr: &ArenaExpression<'arena>) -> bool {
         if let ArenaExpression::Extended(ArenaExtendedExpr::Function { name, .. }) = expr {
             matches!(
@@ -129,7 +133,9 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
                     | "json_set"
                     | "json_remove"
                     | "json_patch"
-                    // JSONB accept-and-convert aliases produce the same JSON text.
+                    // JSONB functions emit a real BLOB (Stage 1, #6035) that
+                    // decodes back to the same JSON document when embedded — so
+                    // they embed correctly here, though `subtype()` on them is 0.
                     | "jsonb"
                     | "jsonb_array"
                     | "jsonb_object"

--- a/crates/vibesql-executor/src/evaluator/expressions/special.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/special.rs
@@ -381,14 +381,19 @@ impl ExpressionEvaluator<'_> {
     }
 }
 
-/// Does this expression carry SQLite's JSON subtype?
+/// Does this expression's result embed as a JSON sub-document when passed to
+/// another JSON function?
 ///
-/// True when the expression is a direct call to a JSON function whose result is
-/// always well-formed JSON text (json, json_array, json_object, and the
-/// insert/replace/set/remove/patch mutation functions). Such results embed as
-/// JSON sub-documents when passed to another JSON function. Producers with a
-/// *conditional* subtype (json_extract / json_quote / `->`) are intentionally
-/// excluded — see the module note in `json_funcs.rs`.
+/// True when the expression is a direct call to a JSON function whose result is a
+/// well-formed JSON document — either JSON *text* (`json`, `json_array`,
+/// `json_object`, and the text insert/replace/set/remove/patch mutation
+/// functions) or a JSONB *blob* (`jsonb*`), which decodes back to the same JSON
+/// document when embedded. Such results embed as JSON sub-documents when passed to
+/// another JSON function. This *embedding* signal is distinct from `subtype()`
+/// reporting (`json_subtype.rs`): a JSONB blob embeds correctly here yet reports
+/// `subtype()` 0. Producers with a *conditional* subtype (json_extract /
+/// json_quote / `->`) are intentionally excluded — see the module note in
+/// `json_funcs.rs`.
 pub(crate) fn expr_has_json_subtype(expr: &vibesql_ast::Expression) -> bool {
     if let vibesql_ast::Expression::Function { name, .. } = expr {
         matches!(
@@ -401,8 +406,12 @@ pub(crate) fn expr_has_json_subtype(expr: &vibesql_ast::Expression) -> bool {
                 | "json_set"
                 | "json_remove"
                 | "json_patch"
-                // JSONB accept-and-convert aliases produce the same JSON text and
-                // so carry the JSON subtype too.
+                // JSONB functions emit real `SqlValue::Blob` output (Stage 1,
+                // #6035); that blob decodes back to the same JSON document when
+                // embedded as an argument to another JSON function, so they carry
+                // the JSON subtype for *embedding* purposes here. (This is a
+                // distinct mechanism from `subtype()` reporting in
+                // `json_subtype.rs`, where the BLOB producers are 0.)
                 | "jsonb"
                 | "jsonb_array"
                 | "jsonb_object"

--- a/crates/vibesql-executor/src/evaluator/json_subtype.rs
+++ b/crates/vibesql-executor/src/evaluator/json_subtype.rs
@@ -10,14 +10,22 @@
 //!
 //! - `->` (`JsonExtract`): JSON subtype whenever the result is non-NULL.
 //! - `->>` (`JsonExtractText`): never JSON subtype.
-//! - `json()`, `json_array()`, `json_object()`, `json_quote()`, and the insert/
-//!   replace/set/remove/patch mutation functions (plus `jsonb_*` aliases): JSON
+//! - `json()`, `json_array()`, `json_object()`, `json_quote()`, and the text
+//!   insert/replace/set/remove/patch mutation functions, plus the two
+//!   pure-construction `jsonb` builders `jsonb_array()` / `jsonb_object()`: JSON
 //!   subtype whenever the result is non-NULL. `json_quote()` always returns valid
 //!   JSON text and SQLite tags it with subtype 74 unconditionally, so — for
 //!   `subtype()` purposes — it is an unconditional JSON producer here. (It is
 //!   deliberately *not* treated as an embedding producer in `special.rs` /
 //!   `arena.rs`, which keeps json_quote's quoted result quoting when passed into
 //!   another JSON function.)
+//!   The BLOB-emitting `jsonb()` / `jsonb_insert/replace/set/remove/patch()`
+//!   functions are deliberately *excluded*: since Stage 1 they emit real
+//!   `SqlValue::Blob` output, and SQLite does not tag a JSONB BLOB result with the
+//!   JSON subtype the way it tags their text counterparts — `subtype()` on any of
+//!   them is `0` (matching sqlite3 3.51). `jsonb_array()` / `jsonb_object()` are
+//!   the sole exceptions: they take no BLOB input and SQLite keeps their subtype
+//!   at 74.
 //! - `json_extract()`: conditional — JSON subtype only when the result is a JSON
 //!   container (array/object), matching SQLite's behaviour of tagging only
 //!   container extractions.
@@ -63,6 +71,13 @@ pub(crate) const JSON_SUBTYPE_TAG: i64 = 74;
 /// producer set in `special.rs` / `arena.rs` — json_quote is intentionally not an
 /// embedding producer there, so its quoted output keeps quoting when passed into
 /// another JSON function.
+///
+/// The BLOB-emitting `jsonb()` / `jsonb_insert/replace/set/remove/patch()`
+/// functions are intentionally absent: since Stage 1 (#6035) they emit real
+/// `SqlValue::Blob` output, and SQLite does not tag a JSONB BLOB result with the
+/// runtime JSON subtype — `subtype()` on any of them is `0`, matching sqlite3
+/// 3.51. Only the two pure-construction builders that take no BLOB input,
+/// `jsonb_array()` / `jsonb_object()`, keep subtype 74, so they remain listed.
 fn is_unconditional_json_producer(name: &str) -> bool {
     matches!(
         name,
@@ -75,14 +90,8 @@ fn is_unconditional_json_producer(name: &str) -> bool {
             | "json_set"
             | "json_remove"
             | "json_patch"
-            | "jsonb"
             | "jsonb_array"
             | "jsonb_object"
-            | "jsonb_insert"
-            | "jsonb_replace"
-            | "jsonb_set"
-            | "jsonb_remove"
-            | "jsonb_patch"
     )
 }
 
@@ -616,6 +625,28 @@ mod tests {
         assert!(is_json(lit(SqlValue::Character("[1,2,3]".into()))));
         // A scalar-string Character (json101-5.11 atom) is not.
         assert!(!is_json(lit(SqlValue::Character("hello".into()))));
+    }
+
+    #[test]
+    fn blob_jsonb_functions_are_not_unconditional_producers() {
+        // Issue #6033: since Stage 1 these emit real SqlValue::Blob and sqlite3
+        // 3.51 reports subtype 0 for them, so they must NOT be classified as
+        // unconditional JSON producers.
+        for name in
+            ["jsonb", "jsonb_insert", "jsonb_replace", "jsonb_set", "jsonb_remove", "jsonb_patch"]
+        {
+            assert!(
+                !is_unconditional_json_producer(name),
+                "{name} should not be an unconditional JSON producer (BLOB output => subtype 0)"
+            );
+        }
+        // The two pure-construction builders take no BLOB input and keep subtype
+        // 74, so they remain producers.
+        assert!(is_unconditional_json_producer("jsonb_array"));
+        assert!(is_unconditional_json_producer("jsonb_object"));
+        // Text-JSON producers are unaffected.
+        assert!(is_unconditional_json_producer("json"));
+        assert!(is_unconditional_json_producer("json_insert"));
     }
 
     #[test]

--- a/crates/vibesql-storage/src/columnar/data.rs
+++ b/crates/vibesql-storage/src/columnar/data.rs
@@ -726,3 +726,107 @@ impl ColumnData {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod blob_roundtrip_tests {
+    //! Issue #6033 (Stage 3): JSONB blobs are stored as `SqlValue::Blob` and the
+    //! columnar path must preserve their bytes exactly through scan (and, by
+    //! extension, checkpoint reload, which serializes `ColumnData` through the
+    //! same `Vec<u8>` representation with no text coercion). These tests encode
+    //! the byte-exactness the curator verified manually with a 2000-row table.
+
+    use super::*;
+    use crate::columnar::builder::ColumnBuilder;
+    use crate::columnar::table::ColumnarTable;
+    use crate::columnar::types::ColumnTypeClass;
+    use crate::Row;
+
+    /// A representative spread of blob payloads, including a JSONB-style header
+    /// byte (0x8B) as produced by `jsonb('[...]')`, an empty blob, and a blob
+    /// containing embedded NUL and high bytes that a text codec would mangle.
+    fn sample_blobs(n: usize) -> Vec<Vec<u8>> {
+        (0..n)
+            .map(|i| {
+                let b = (i % 256) as u8;
+                vec![0x8B, b, 0x00, 0xFF, b.wrapping_add(1), b.wrapping_mul(3)]
+            })
+            .collect()
+    }
+
+    /// Direct `ColumnData::Blob` scan path: bytes pushed through the builder come
+    /// back out of `ColumnData::get` byte-identical (no re-encode; `get` clones
+    /// the stored `Vec<u8>`).
+    #[test]
+    fn column_data_blob_scan_is_byte_identical() {
+        let blobs = sample_blobs(2000);
+        let mut builder = ColumnBuilder::new(ColumnTypeClass::Blob, blobs.len());
+        for b in &blobs {
+            builder.push(&SqlValue::Blob(b.clone())).unwrap();
+        }
+        let column = builder.build();
+        assert_eq!(column.len(), blobs.len());
+
+        for (i, expected) in blobs.iter().enumerate() {
+            assert!(!column.is_null(i), "row {i} must be non-null");
+            match column.get(i) {
+                SqlValue::Blob(got) => assert_eq!(
+                    &got, expected,
+                    "blob bytes at row {i} must survive the columnar scan byte-identically"
+                ),
+                other => panic!("row {i}: expected Blob, got {other:?}"),
+            }
+        }
+    }
+
+    /// A NULL blob round-trips as NULL, and a zero-length blob stays a
+    /// zero-length blob (not conflated with NULL).
+    #[test]
+    fn column_data_blob_null_and_empty_are_distinct() {
+        let mut builder = ColumnBuilder::new(ColumnTypeClass::Blob, 3);
+        builder.push(&SqlValue::Blob(vec![0x8B, 0x01])).unwrap();
+        builder.push(&SqlValue::Null).unwrap();
+        builder.push(&SqlValue::Blob(Vec::new())).unwrap();
+        let column = builder.build();
+
+        assert!(!column.is_null(0));
+        assert_eq!(column.get(0), SqlValue::Blob(vec![0x8B, 0x01]));
+        assert!(column.is_null(1), "explicit NULL blob must stay NULL");
+        assert!(!column.is_null(2), "empty blob is not NULL");
+        assert_eq!(column.get(2), SqlValue::Blob(Vec::new()));
+    }
+
+    /// Full `ColumnarTable::from_rows` -> `to_rows` round-trip over a
+    /// columnar-sized table (2000 rows) with a Blob column: every blob comes back
+    /// byte-identical. This exercises the same conversion path a large table
+    /// takes on the way into columnar storage.
+    #[test]
+    fn columnar_table_blob_column_roundtrip_2000_rows() {
+        let blobs = sample_blobs(2000);
+        let rows: Vec<Row> = blobs
+            .iter()
+            .enumerate()
+            .map(|(i, b)| Row::new(vec![SqlValue::Integer(i as i64), SqlValue::Blob(b.clone())]))
+            .collect();
+        let names = vec!["id".to_string(), "doc".to_string()];
+
+        let table = ColumnarTable::from_rows(&rows, &names).unwrap();
+
+        // The inferred column type must be Blob (not String/text).
+        match table.get_column("doc") {
+            Some(ColumnData::Blob { .. }) => {}
+            other => panic!("expected a Blob column for 'doc', got {other:?}"),
+        }
+
+        let out = table.to_rows();
+        assert_eq!(out.len(), rows.len());
+        for (i, (row, expected)) in out.iter().zip(blobs.iter()).enumerate() {
+            match row.get(1) {
+                Some(SqlValue::Blob(got)) => assert_eq!(
+                    got, expected,
+                    "blob bytes at row {i} must survive from_rows/to_rows byte-identically"
+                ),
+                other => panic!("row {i}: expected Blob, got {other:?}"),
+            }
+        }
+    }
+}

--- a/crates/vibesql-storage/src/persistence/binary/value.rs
+++ b/crates/vibesql-storage/src/persistence/binary/value.rs
@@ -209,6 +209,12 @@ mod tests {
             SqlValue::Varchar(arcstr::ArcStr::from("test")),
             SqlValue::Boolean(true),
             SqlValue::Float(3.14),
+            // Issue #6033: JSONB blobs are stored as SqlValue::Blob and must
+            // round-trip through the shared codec byte-for-byte (a JSONB-style
+            // header byte plus embedded NUL / high bytes a text codec would
+            // mangle), including the empty-blob edge case.
+            SqlValue::Blob(vec![0x8B, 0x00, 0xFF, 0x77, 0x36]),
+            SqlValue::Blob(Vec::new()),
         ];
 
         let mut buf = Vec::new();


### PR DESCRIPTION
## Summary

Since Stage 1 (#6035), `jsonb()` and `jsonb_insert/replace/set/remove/patch()` emit real `SqlValue::Blob` output. sqlite3 3.51 does **not** tag a JSONB BLOB result with the runtime JSON subtype the way it tags their text counterparts, so `subtype()` on any of them is `0` — but VibeSQL still reported `74` because `is_unconditional_json_producer` still listed the six `jsonb*` mutation/decode names (correct back when Stage-0 `jsonb()` was a text-emitting alias, stale now). This PR fixes that one real subtype-reporting bug and adds regression tests for the storage round-trip that was already correct but untested (per the curator re-scope on #6033).

## Changes

- **json_subtype.rs**: remove the six BLOB-emitting `jsonb*` names (`jsonb`, `jsonb_insert`, `jsonb_replace`, `jsonb_set`, `jsonb_remove`, `jsonb_patch`) from `is_unconditional_json_producer`. `jsonb_array()` / `jsonb_object()` (pure construction, no BLOB input) stay listed and keep subtype 74. Module doc and function doc updated. Added a unit test asserting the classification.
- **special.rs / arena.rs**: refresh the stale "JSONB accept-and-convert aliases produce the same JSON text" comments to describe blob-decode embedding. The embedding-producer lists themselves are functionally correct and unchanged (a JSONB blob decodes back to the same JSON document when embedded as an argument to another JSON function — verified matching sqlite3).
- **jsonb_persistence_test.rs** (new, vibesql-cli): file-backed DB integration test — a `jsonb()`-produced BLOB column survives WAL write + checkpoint (`\save` equivalent) + reopen byte-identically, with `json_each` / `json_tree` read-back post-reopen (mirrors json102-1000/1000b against real file storage).
- **columnar/data.rs**: `ColumnData::Blob` byte-exact preservation tests through the scan and `from_rows`/`to_rows` path (2000 rows), plus NULL/empty-blob distinctness.
- **persistence/binary/value.rs**: added `SqlValue::Blob` cases (JSONB-style header + embedded NUL/high bytes, and empty blob) to the shared-codec roundtrip test.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `subtype(jsonb(X))` and `subtype(jsonb_insert/replace/set/remove/patch(...))` return 0 | ✅ | Differential vs sqlite3 3.51: all 6 now return 0 (matched) |
| `subtype(jsonb_array/jsonb_object(...))` stay 74 | ✅ | Differential: both return 74, matching sqlite3 |
| Stale `special.rs`/`arena.rs` comment reworded, embedding list unchanged | ✅ | Comments describe blob-decode embedding; matches! arms unchanged |
| New file-backed WAL/checkpoint durability test (byte-identical + json_each/json_tree read-back) | ✅ | `test_jsonb_blob_survives_checkpoint_reopen_byte_identical`, `..._json_tree_reads_back_after_reopen` pass |
| New columnar Blob preservation test | ✅ | `column_data_blob_scan_is_byte_identical`, `columnar_table_blob_column_roundtrip_2000_rows`, null/empty test pass |
| json102 stays 309/309 | ✅ | `make test-tcl-file FILE=json102.test` → 309/309 |
| json101 stays 258/277 (5.10/5.11 + 16xx unaffected) | ✅ | `make test-tcl-file FILE=json101.test` → 258/277; 5.10/5.11 not in failure list; no 16xx failures |
| `cargo test -p vibesql-executor` clean | ✅ | 172 test suites green, 0 failures |

## Test Plan

- `cargo build --release` (fresh, in-worktree) then differential `subtype()` vs sqlite3 3.51 for all `jsonb*` functions — all 10 checked cases match.
- `cargo test -p vibesql-executor` (full crate) — all green.
- `cargo test -p vibesql-storage --lib` (blob roundtrip + value codec) — green.
- `cargo test -p vibesql-cli --test jsonb_persistence_test` — green.
- `make test-tcl-file FILE=json102.test` → 309/309; `FILE=json101.test` → 258/277 (pre-existing baseline, unchanged).

Closes #6033