### PR TITLE
docs(json): update stale JSONB module doc for finished Stage 1-4 work

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/jsonb.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/jsonb.rs
@@ -1,13 +1,18 @@
-//! SQLite JSONB binary encoding (and its decode inverse).
+//! SQLite JSONB binary encoding and decoding.
 //!
 //! SQLite's `jsonb()` / `jsonb_*()` functions return the document in SQLite's
 //! on-disk *JSONB* binary format rather than as JSON text. This module encodes a
 //! parsed JSON node ([`serde_json::Value`], the same node type `json_funcs.rs`
-//! operates on) into a byte-for-byte compatible JSONB blob, and provides the
-//! inverse decode so a JSONB blob produced here can be fed back into the
+//! operates on) into a byte-for-byte compatible JSONB blob (bit-compatible with
+//! SQLite 3.51's on-disk format), and provides the inverse decode so JSONB
+//! blobs — whether produced here or supplied externally (e.g. read back from a
+//! column, or passed as a function argument) — feed cleanly into the
 //! text-mode JSON functions (`json()`, `json_extract()`, the mutation functions,
-//! …) without a regression while the full external JSONB reader is still being
-//! built (Stage 2, #6032).
+//! `json_each()`/`json_tree()`, …). JSONB round-trips byte-identically through
+//! WAL/checkpoint persistence and columnar storage, and `subtype()` on
+//! BLOB-emitting `jsonb*` functions matches SQLite (no text-JSON subtype).
+//! This closes out the JSONB binary-format work tracked by the parent decision
+//! (#6008) across Stages 1-4 (#6035, #6036, #6037).
 //!
 //! ## Wire format (confirmed against `sqlite/src/json.c` and json102 ground truth)
 //!


### PR DESCRIPTION
## Summary

Closes #6034.

Stage 4 of the JSONB conformance work (curator re-scoped, see issue comment) was found to be a single stale docs location. This PR fixes it: the module doc comment at the top of `crates/vibesql-executor/src/evaluator/functions/sqlite_compat/jsonb.rs` still described the JSONB decode path as a stopgap "while the full external JSONB reader is still being built (Stage 2, #6032)". Stages 1-3 (#6035, #6036, #6037) have since shipped, so this framing is stale and misleading.

The doc now states:
- `jsonb()`/`jsonb_*()` emit SQLite 3.51 bit-compatible JSONB BLOBs (encoder).
- Every JSON reader accepts JSONB BLOB input end-to-end (decoder), including `json_each()`/`json_tree()`.
- JSONB persists byte-identically through WAL/checkpoint and columnar storage.
- `subtype()` semantics match SQLite: BLOB-emitting `jsonb*` functions carry no text-JSON subtype.
- References the stage PRs (#6035, #6036, #6037) and the parent decision (#6008).

The wire-format table below the doc comment (verified against `sqlite/src/json.c` and json102 ground truth) was already accurate and is unchanged.

## Stage 4 verification (from curator re-scope, cited here as closure evidence)

Per the curator's re-scope comment on #6034 (verified against `origin/main` @ `26dd67235` on a **freshly rebuilt** release binary, per the project's stale-binary hazard note):

- **Skip-list / shim audit — clean.** No whole-file skip for `json101`/`json102` in `vibesql_skip_files`, no per-test skip for any jsonb-related assertion in `vibesql_skip_tests`. The only json101/json102-specific logic in `scripts/tester_vibesql.tcl` is a `vtab`-capability un-gate (added for #5989/#6007) that *enables* TVF test blocks — it does not mask any assertions.
- **`json102.test`: 309/309 passed, 0 skipped** — all 309 tests actually executed on the fresh build (not a phantom/stale-binary count).
- **`json101.test`: 258/277 passed, 0 skipped**, 19 failures, matching the issue's cited baseline exactly. Remaining failures (`json101-5.x`, `11.x`, `15.1xx`, `20.x`, `21.2x`, `24.x`) are pre-existing tail gaps unrelated to the jsonb binary format, out of scope for this issue.
- **Docs audit — exactly one stale location found** (this PR fixes it). Searched all of `docs/` (excluding vendored `docs/reference/sqlite/`) and non-test `crates/` source; no other stale JSONB divergence claims exist.

Out of scope for this issue (per curator re-scope): re-baselining epic #5779's summary table (orchestrator/human bookkeeping after merge) and a full Priority-1/2 canonical quiet-machine TCL re-baseline (deferred to a separate quiet-machine session).

## Test plan

- [x] `cargo build -p vibesql-executor` — compiles clean (doc-only change).
- [x] `cargo fmt` applied to the changed file (unrelated pre-existing formatting drift in other files was reverted to keep this PR scoped).
- [x] json102.test / json101.test verified by curator on fresh build (see above) — no functional changes in this PR, doc-comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)