### PR TITLE
fix(executor): json_group_array/object real formatting, register json_group_object, and BLOB handling

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/json_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/json_funcs.rs
@@ -1170,7 +1170,12 @@ pub(crate) fn json_quote(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
 
 /// Render an f64 the way SQLite renders JSON reals (keeps a fractional part,
 /// e.g. `2.0`), by round-tripping through serde_json's number formatter.
-fn render_json_number(f: f64) -> String {
+///
+/// Negative zero is normalized to `0.0` to match SQLite, which renders both
+/// `0.0` and `-0.0` as `0.0` in JSON output.
+pub(crate) fn render_json_number(f: f64) -> String {
+    // Normalize -0.0 to 0.0 (SQLite: json_group_array(-0.0) -> [0.0]).
+    let f = if f == 0.0 { 0.0 } else { f };
     match serde_json::Number::from_f64(f) {
         Some(n) => n.to_string(),
         None => f.to_string(),

--- a/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
@@ -957,9 +957,9 @@ impl SelectExecutor<'_> {
                 // Check if this is an aggregate function name
                 let is_aggregate = match name_upper.as_str() {
                     "COUNT" | "SUM" | "AVG" | "TOTAL" | "GROUP_CONCAT" | "STRING_AGG"
-                    | "JSON_GROUP_ARRAY" | "MD5SUM" | "MEDIAN" | "PERCENTILE"
-                    | "PERCENTILE_CONT" | "PERCENTILE_DISC" | "STDDEV" | "STDDEV_SAMP"
-                    | "STDDEV_POP" | "VARIANCE" | "VAR_SAMP" | "VAR_POP" => true,
+                    | "JSON_GROUP_ARRAY" | "JSON_GROUP_OBJECT" | "MD5SUM" | "MEDIAN"
+                    | "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC" | "STDDEV"
+                    | "STDDEV_SAMP" | "STDDEV_POP" | "VARIANCE" | "VAR_SAMP" | "VAR_POP" => true,
                     "MIN" | "MAX" => args.len() <= 1, // multi-arg min/max are scalar functions
                     _ => false,
                 };

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/aggregate_function.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/aggregate_function.rs
@@ -292,6 +292,15 @@ fn validate_aggregate_args(
             }
             Ok(())
         }
+        "JSON_GROUP_OBJECT" => {
+            // json_group_object(key, value) requires exactly 2 arguments
+            if has_wildcard || arg_count != 2 {
+                return Err(ExecutorError::WrongNumberOfArguments {
+                    function_name: name.display().to_string(),
+                });
+            }
+            Ok(())
+        }
         "MEDIAN" => {
             // median(Y) requires exactly 1 argument (percentile.c)
             if has_wildcard || arg_count != 1 {
@@ -700,6 +709,76 @@ pub(super) fn evaluate(
             }
             let value = evaluator.eval(&args[0], row)?;
             acc.accumulate(&value);
+        }
+
+        let result = acc.finalize()?;
+        executor.get_aggregate_cache().borrow_mut().insert(cache_key, result.clone());
+        return Ok(result);
+    }
+
+    // Handle JSON_GROUP_OBJECT(key, value) - collects key/value pairs into a
+    // JSON object. NULL-keyed pairs are dropped at finalize (SQLite semantics).
+    if name_upper == "JSON_GROUP_OBJECT" {
+        if args.len() != 2 {
+            return Err(ExecutorError::WrongNumberOfArguments {
+                function_name: name.display().to_string(),
+            });
+        }
+
+        let mut acc = AggregateAccumulator::new(name.canonical(), distinct)?;
+
+        // Optional ORDER BY within the aggregate: collect (key, value, sort_keys)
+        // then emit in sorted order.
+        if let Some(order_items) = order_by {
+            let collations = extract_collations(order_items);
+            let mut rows_with_keys: Vec<(
+                vibesql_types::SqlValue,
+                vibesql_types::SqlValue,
+                Vec<SortKey>,
+            )> = Vec::with_capacity(group_rows.len());
+
+            for row in group_rows {
+                evaluator.clear_cse_cache();
+                if !passes_filter(row, evaluator)? {
+                    continue;
+                }
+                let key = evaluator.eval(&args[0], row)?;
+                let value = evaluator.eval(&args[1], row)?;
+
+                let mut sort_keys = Vec::with_capacity(order_items.len());
+                for item in order_items {
+                    let sort_value = evaluator.eval(&item.expr, row)?;
+                    let is_desc = item.direction == vibesql_ast::OrderDirection::Desc;
+                    let nulls_first = item
+                        .nulls_order
+                        .as_ref()
+                        .map(|no| matches!(no, vibesql_ast::NullsOrder::First));
+                    sort_keys.push((sort_value, is_desc, nulls_first));
+                }
+
+                rows_with_keys.push((key, value, sort_keys));
+            }
+
+            rows_with_keys.sort_by(|a, b| compare_sort_keys(&a.2, &b.2, &collations));
+
+            for (key, value, _) in rows_with_keys {
+                acc.accumulate_json_object_pair(key, value);
+            }
+
+            let result = acc.finalize()?;
+            executor.get_aggregate_cache().borrow_mut().insert(cache_key, result.clone());
+            return Ok(result);
+        }
+
+        // No ORDER BY - accumulate in row order.
+        for row in group_rows {
+            evaluator.clear_cse_cache();
+            if !passes_filter(row, evaluator)? {
+                continue;
+            }
+            let key = evaluator.eval(&args[0], row)?;
+            let value = evaluator.eval(&args[1], row)?;
+            acc.accumulate_json_object_pair(key, value);
         }
 
         let result = acc.finalize()?;

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/function.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/function.rs
@@ -27,8 +27,9 @@ pub(super) fn evaluate(
     let name_upper = name.to_uppercase();
     let is_aggregate = match name_upper.as_str() {
         "COUNT" | "SUM" | "AVG" | "TOTAL" | "GROUP_CONCAT" | "STRING_AGG" | "JSON_GROUP_ARRAY"
-        | "MD5SUM" | "MEDIAN" | "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC" | "STDDEV"
-        | "STDDEV_SAMP" | "STDDEV_POP" | "VARIANCE" | "VAR_SAMP" | "VAR_POP" => true,
+        | "JSON_GROUP_OBJECT" | "MD5SUM" | "MEDIAN" | "PERCENTILE" | "PERCENTILE_CONT"
+        | "PERCENTILE_DISC" | "STDDEV" | "STDDEV_SAMP" | "STDDEV_POP" | "VARIANCE" | "VAR_SAMP"
+        | "VAR_POP" => true,
         "MIN" | "MAX" => args.len() <= 1, // multi-arg min/max are scalar functions
         _ => false,
     };

--- a/crates/vibesql-executor/src/select/grouping/aggregates.rs
+++ b/crates/vibesql-executor/src/select/grouping/aggregates.rs
@@ -72,6 +72,9 @@ pub enum AggregateAccumulator {
         distinct: bool,
         seen: Option<HashSet<vibesql_types::SqlValue>>,
     },
+    /// JSON_GROUP_OBJECT - Collects (key, value) pairs into a JSON object
+    /// (SQLite compatible). Pairs with a NULL key are dropped at finalize time.
+    JsonGroupObject { pairs: Vec<(vibesql_types::SqlValue, vibesql_types::SqlValue)> },
     /// MD5SUM - Compute MD5 hash of concatenated values (SQLite TCL test compatible)
     Md5sum { values: Vec<String>, distinct: bool, seen: Option<HashSet<String>> },
     /// STDDEV / VARIANCE family - statistical dispersion aggregates.
@@ -172,6 +175,7 @@ impl AggregateAccumulator {
             "JSON_GROUP_ARRAY" => {
                 Ok(AggregateAccumulator::JsonGroupArray { values: Vec::new(), distinct, seen })
             }
+            "JSON_GROUP_OBJECT" => Ok(AggregateAccumulator::JsonGroupObject { pairs: Vec::new() }),
             "MD5SUM" => Ok(AggregateAccumulator::Md5sum {
                 values: Vec::new(),
                 distinct,
@@ -510,6 +514,10 @@ impl AggregateAccumulator {
                     values.push(str_value);
                 }
             }
+
+            // JSON_GROUP_OBJECT accumulates (key, value) pairs via
+            // `accumulate_json_object_pair`, not the single-value path.
+            AggregateAccumulator::JsonGroupObject { .. } => {}
         }
     }
 
@@ -554,6 +562,20 @@ impl AggregateAccumulator {
                 // Other aggregates don't support multi-argument form
                 // This should be caught earlier by validation
             }
+        }
+    }
+
+    /// Accumulate one (key, value) pair for JSON_GROUP_OBJECT.
+    ///
+    /// Pairs are stored verbatim; NULL-keyed pairs are dropped at finalize time
+    /// (matching SQLite, which silently skips them).
+    pub fn accumulate_json_object_pair(
+        &mut self,
+        key: vibesql_types::SqlValue,
+        value: vibesql_types::SqlValue,
+    ) {
+        if let AggregateAccumulator::JsonGroupObject { pairs } = self {
+            pairs.push((key, value));
         }
     }
 
@@ -712,8 +734,13 @@ impl AggregateAccumulator {
             }
             AggregateAccumulator::JsonGroupArray { values, .. } => {
                 // Convert values to JSON array string
-                let json_array = sql_values_to_json_array(values);
+                let json_array = sql_values_to_json_array(values)?;
                 Ok(vibesql_types::SqlValue::Varchar(json_array.into()))
+            }
+            AggregateAccumulator::JsonGroupObject { pairs, .. } => {
+                // Convert (key, value) pairs to a JSON object string
+                let json_object = sql_pairs_to_json_object(pairs)?;
+                Ok(vibesql_types::SqlValue::Varchar(json_object.into()))
             }
             AggregateAccumulator::Percentile {
                 values,
@@ -1464,20 +1491,34 @@ fn escape_json_string(s: &str) -> String {
     escaped
 }
 
-/// Convert a single SqlValue to a JSON value representation
-fn sql_value_to_json(value: &vibesql_types::SqlValue) -> String {
+/// Convert a single SqlValue to a JSON value representation.
+///
+/// Real numbers are rendered through the canonical JSON number formatter
+/// (`render_json_number`) so that integral doubles keep their fractional
+/// spelling (`2.0`, not `2`), matching SQLite's `json_group_array` /
+/// `json()` output. BLOB values are routed through the shared JSONB decoder:
+/// a well-formed JSONB blob is embedded as its decoded JSON text, while any
+/// other blob raises the SQLite-exact "JSON cannot hold BLOB values" error
+/// (never a mangled byte-string).
+fn sql_value_to_json(
+    value: &vibesql_types::SqlValue,
+) -> Result<String, crate::errors::ExecutorError> {
+    use crate::evaluator::functions::sqlite_compat::{
+        json_funcs::{json_node_to_json_text, render_json_number},
+        jsonb,
+    };
     use vibesql_types::SqlValue;
-    match value {
+    let rendered = match value {
         SqlValue::Null => "null".to_string(),
         SqlValue::Boolean(b) => if *b { "true" } else { "false" }.to_string(),
         SqlValue::Integer(i) => i.to_string(),
         SqlValue::Bigint(i) => i.to_string(),
         SqlValue::Smallint(i) => i.to_string(),
         SqlValue::Unsigned(u) => u.to_string(),
-        SqlValue::Numeric(n) => n.to_string(),
-        SqlValue::Real(r) => r.to_string(),
-        SqlValue::Double(d) => d.to_string(),
-        SqlValue::Float(f) => f.to_string(),
+        SqlValue::Numeric(n) => render_json_number(*n),
+        SqlValue::Real(r) => render_json_number(*r),
+        SqlValue::Double(d) => render_json_number(*d),
+        SqlValue::Float(f) => render_json_number(*f as f64),
         SqlValue::Varchar(s) | SqlValue::Character(s) => {
             let trimmed = s.trim();
             // If the value is already a JSON object or array, embed it directly
@@ -1489,17 +1530,61 @@ fn sql_value_to_json(value: &vibesql_types::SqlValue) -> String {
                 format!("\"{}\"", escape_json_string(s))
             }
         }
+        SqlValue::Blob(bytes) => match jsonb::decode(bytes) {
+            // A well-formed JSONB blob decodes and re-renders as canonical JSON
+            // text (SQLite: `json_group_array(jsonb('[1]'))` -> `[[1]]`).
+            Some(node) => json_node_to_json_text(&node),
+            None => {
+                return Err(crate::errors::ExecutorError::SqliteCompatError(
+                    "JSON cannot hold BLOB values".to_string(),
+                ));
+            }
+        },
         _ => {
             // For other types, convert to string and quote
             format!("\"{}\"", escape_json_string(&value.to_string()))
         }
-    }
+    };
+    Ok(rendered)
 }
 
 /// Convert a vector of SqlValues to a JSON array string
-fn sql_values_to_json_array(values: &[vibesql_types::SqlValue]) -> String {
-    let elements: Vec<String> = values.iter().map(sql_value_to_json).collect();
-    format!("[{}]", elements.join(","))
+fn sql_values_to_json_array(
+    values: &[vibesql_types::SqlValue],
+) -> Result<String, crate::errors::ExecutorError> {
+    let mut elements: Vec<String> = Vec::with_capacity(values.len());
+    for value in values {
+        elements.push(sql_value_to_json(value)?);
+    }
+    Ok(format!("[{}]", elements.join(",")))
+}
+
+/// Convert a vector of (key, value) pairs to a JSON object string for
+/// `json_group_object`.
+///
+/// Keys are rendered as JSON strings (labels are TEXT in SQLite). Pairs whose
+/// key is NULL are dropped entirely, matching SQLite which silently skips
+/// NULL-keyed pairs. Values go through [`sql_value_to_json`], so real numbers
+/// keep their fractional spelling, JSONB blobs embed as decoded JSON, and
+/// non-JSONB blobs raise "JSON cannot hold BLOB values".
+fn sql_pairs_to_json_object(
+    pairs: &[(vibesql_types::SqlValue, vibesql_types::SqlValue)],
+) -> Result<String, crate::errors::ExecutorError> {
+    use vibesql_types::SqlValue;
+    let mut entries: Vec<String> = Vec::with_capacity(pairs.len());
+    for (key, value) in pairs {
+        // SQLite silently drops pairs with a NULL key.
+        if matches!(key, SqlValue::Null) {
+            continue;
+        }
+        let key_str = match key {
+            SqlValue::Varchar(s) | SqlValue::Character(s) => s.to_string(),
+            other => sql_value_to_string(other),
+        };
+        let value_json = sql_value_to_json(value)?;
+        entries.push(format!("\"{}\":{}", escape_json_string(&key_str), value_json));
+    }
+    Ok(format!("{{{}}}", entries.join(",")))
 }
 
 /// Divide a SqlValue by an integer count, handling all numeric types
@@ -2334,5 +2419,95 @@ mod tests {
         let distinct = acc.finalize().unwrap();
         // Population variance of {2,4}: mean 3, m2 = 2, /2 = 1.0.
         assert!(matches!(distinct, SqlValue::Double(d) if (d - 1.0).abs() < 1e-9));
+    }
+
+    // ----- JSON aggregate real formatting / BLOB handling (issue #6049) -----
+
+    fn json_array_text(acc: AggregateAccumulator) -> String {
+        match acc.finalize().unwrap() {
+            SqlValue::Varchar(s) => s.to_string(),
+            other => panic!("expected Varchar, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_json_group_array_real_keeps_fractional_spelling() {
+        // Integral doubles must render as `2.0`/`5.0`, not `2`/`5` (SQLite parity).
+        let mut acc = AggregateAccumulator::new("JSON_GROUP_ARRAY", false).unwrap();
+        acc.accumulate(&SqlValue::Integer(1));
+        acc.accumulate(&SqlValue::Real(2.0));
+        acc.accumulate(&SqlValue::Null);
+        acc.accumulate(&SqlValue::Varchar("three".into()));
+        assert_eq!(json_array_text(acc), r#"[1,2.0,null,"three"]"#);
+    }
+
+    #[test]
+    fn test_json_group_array_real_various() {
+        let mut acc = AggregateAccumulator::new("JSON_GROUP_ARRAY", false).unwrap();
+        acc.accumulate(&SqlValue::Real(3.14));
+        acc.accumulate(&SqlValue::Real(5.0));
+        acc.accumulate(&SqlValue::Real(-0.0));
+        // -0.0 normalizes to 0.0, matching SQLite's json_group_array(-0.0) -> [0.0].
+        assert_eq!(json_array_text(acc), "[3.14,5.0,0.0]");
+    }
+
+    #[test]
+    fn test_json_group_array_jsonb_blob_embeds() {
+        // A well-formed JSONB blob embeds as its decoded JSON: json_group_array(jsonb('[1]')) -> [[1]].
+        use crate::evaluator::functions::sqlite_compat::jsonb;
+        let blob = jsonb::encode(&serde_json::json!([1]));
+        let mut acc = AggregateAccumulator::new("JSON_GROUP_ARRAY", false).unwrap();
+        acc.accumulate(&SqlValue::Blob(blob));
+        assert_eq!(json_array_text(acc), "[[1]]");
+    }
+
+    #[test]
+    fn test_json_group_array_non_jsonb_blob_errors() {
+        // Arbitrary bytes that do not decode as JSONB must raise the SQLite error,
+        // never a mangled string.
+        let mut acc = AggregateAccumulator::new("JSON_GROUP_ARRAY", false).unwrap();
+        acc.accumulate(&SqlValue::Blob(vec![0xab, 0xcd, 0xef, 0xff]));
+        let err = acc.finalize().unwrap_err();
+        assert!(
+            format!("{err}").contains("JSON cannot hold BLOB values"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_json_group_object_basic_and_null_key_skipped() {
+        // json_group_object(x, y): NULL key drops the pair; NULL value passes through.
+        let mut acc = AggregateAccumulator::new("JSON_GROUP_OBJECT", false).unwrap();
+        acc.accumulate_json_object_pair(SqlValue::Varchar("a".into()), SqlValue::Integer(1));
+        acc.accumulate_json_object_pair(SqlValue::Varchar("b".into()), SqlValue::Real(2.0));
+        acc.accumulate_json_object_pair(SqlValue::Varchar("c".into()), SqlValue::Null);
+        acc.accumulate_json_object_pair(SqlValue::Null, SqlValue::Varchar("three".into()));
+        acc.accumulate_json_object_pair(
+            SqlValue::Varchar("e".into()),
+            SqlValue::Varchar("four".into()),
+        );
+        assert_eq!(json_array_text(acc), r#"{"a":1,"b":2.0,"c":null,"e":"four"}"#);
+    }
+
+    #[test]
+    fn test_json_group_object_jsonb_value_embeds_and_blob_errors() {
+        use crate::evaluator::functions::sqlite_compat::jsonb;
+        // JSONB value embeds as raw JSON.
+        let blob = jsonb::encode(&serde_json::json!([1]));
+        let mut acc = AggregateAccumulator::new("JSON_GROUP_OBJECT", false).unwrap();
+        acc.accumulate_json_object_pair(SqlValue::Varchar("k".into()), SqlValue::Blob(blob));
+        assert_eq!(json_array_text(acc), r#"{"k":[1]}"#);
+
+        // Non-JSONB blob value errors.
+        let mut acc2 = AggregateAccumulator::new("JSON_GROUP_OBJECT", false).unwrap();
+        acc2.accumulate_json_object_pair(
+            SqlValue::Varchar("k".into()),
+            SqlValue::Blob(vec![0xab, 0xcd]),
+        );
+        let err = acc2.finalize().unwrap_err();
+        assert!(
+            format!("{err}").contains("JSON cannot hold BLOB values"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -1314,6 +1314,7 @@ impl<'arena> ArenaParser<'arena> {
                 | "GROUP_CONCAT"
                 | "STRING_AGG"
                 | "TOTAL"
+                | "JSON_GROUP_OBJECT"
                 | "MEDIAN"
                 | "PERCENTILE"
                 | "PERCENTILE_CONT"
@@ -1410,6 +1411,7 @@ impl<'arena> ArenaParser<'arena> {
                     true
                 }
                 "GROUP_CONCAT" | "STRING_AGG" => args.len() <= 2, // 1 or 2 args
+                "JSON_GROUP_OBJECT" => true,                      // JSON aggregate function
                 // percentile.c family - arg counts validated by the executor
                 "MEDIAN" | "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC" => true,
                 "MIN" | "MAX" => args.len() <= 1 && !distinct,

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -161,6 +161,7 @@ impl Parser {
                 | "STRING_AGG"
                 | "TOTAL"
                 | "JSON_GROUP_ARRAY"
+                | "JSON_GROUP_OBJECT"
                 | "MEDIAN"
                 | "PERCENTILE"
                 | "PERCENTILE_CONT"
@@ -481,6 +482,7 @@ impl Parser {
             "STDDEV" | "STDDEV_SAMP" | "STDDEV_POP" | "VARIANCE" | "VAR_SAMP" | "VAR_POP" => true,
             "GROUP_CONCAT" | "STRING_AGG" => args.len() <= 2, // 1 or 2 args
             "JSON_GROUP_ARRAY" => true,                       // JSON aggregate function
+            "JSON_GROUP_OBJECT" => true,                      // JSON aggregate function
             // percentile.c family - arg counts validated by the executor so
             // it can emit SQLite-exact "wrong number of arguments" errors
             "MEDIAN" | "PERCENTILE" | "PERCENTILE_CONT" | "PERCENTILE_DISC" => true,


### PR DESCRIPTION
## Summary
Fixes three defects on the JSON-aggregate path that shared a local, diverging value converter: `json_group_array` dropped the fractional part of real numbers, `json_group_object` was unregistered (`no such function`), and BLOB elements were stringified as raw bytes instead of being JSONB-decoded or rejected.

## Changes
- **Real formatting** — `sql_value_to_json` now renders reals via the canonical `render_json_number` (made `pub(crate)`), so integral doubles keep their fractional spelling (`2.0`, not `2`); `-0.0` is normalized to `0.0`, matching SQLite.
- **BLOB handling** — new `Blob` arm decodes JSONB blobs (via the shared `jsonb::decode` from #6035) and embeds them as raw JSON; non-JSONB blobs raise SQLite's exact `JSON cannot hold BLOB values` error rather than mangling bytes. `sql_value_to_json` / `sql_values_to_json_array` are now fallible to propagate this.
- **`json_group_object` registration** — new `JsonGroupObject` accumulator + `accumulate_json_object_pair`, a dedicated 2-arg evaluation block in `aggregate_function.rs` (with ORDER BY support and arg-count validation), and aggregate recognition added to both parsers (`parser/expressions/functions/mod.rs` `might_be_aggregate` + `is_aggregate`, `arena_parser/expression.rs` `might_be_aggregate` + `is_aggregate`) and the executor `detection.rs` / `function.rs` sites. NULL-keyed pairs are dropped to match SQLite.
- **Tests** — unit tests in `aggregates.rs` for real formatting (`2.0`/`3.14`/`5.0`/`-0.0`), NULL-key dropping, NULL-value passthrough, JSONB embedding, and the non-JSONB blob error.

Out of scope (curator-flagged, left untouched): the second latent `r.to_string()` copy in `sql_value_to_string` (GROUP_CONCAT) and the `detection.rs` correlated-subquery-collapse arms missing `JSON_GROUP_ARRAY`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| json101-21.26 and 21.27 pass | ✅ | Both absent from json101 failure list; passed 258 → 260/277 |
| json_group_object recognized, NULL keys skipped | ✅ | `{"a":1,"b":2.0,"c":null,"e":"four"}` (NULL-keyed pair dropped) — matches sqlite3 3.51 |
| json_group_array(jsonb('[1]')) → [[1]] | ✅ | Differential-verified against sqlite3 3.51 |
| json_group_array(x'abcd') → "JSON cannot hold BLOB values" | ✅ | Errors, never mangled/panic |
| Real formatting matches SQLite generally | ✅ | `2.0`, `3.14`, `5.0`, `-0.0`→`0.0` all match sqlite3 |
| No json102 regression (309/309) | ✅ | json102 = 309/309 |
| No regression in json101's 258 passing tests | ✅ | Full json101 re-run; only 21.26/21.27 flipped, no new failures |
| cargo test -p vibesql-executor / -p vibesql-parser green | ✅ | executor 3424 lib + integration pass; parser 1759 pass |

## Test Plan
- `cargo test -p vibesql-executor` — all green (3424 lib tests + integration; new aggregate tests pass).
- `cargo test -p vibesql-parser` — 1759 pass.
- `./scripts/tcltest test json101.test` — 260/277 (was 258); 21.26/21.27 flipped to pass, no new failures.
- `./scripts/tcltest test json102.test` — 309/309 (no regression).
- Manual differential checks vs `sqlite3 3.51.0` for all repros in the issue (release binary built in-worktree): real formatting, NULL-key drop, JSONB embed, non-JSONB blob error — all match.
- `cargo clippy` / `cargo fmt` on touched crates — clean (no new warnings in touched files).

Closes #6049