### PR TITLE
fix(executor): let a real table shadow the pragma_compile_options synthetic table

### DIFF
--- a/crates/vibesql-executor/src/pragma_compile_options.rs
+++ b/crates/vibesql-executor/src/pragma_compile_options.rs
@@ -20,6 +20,18 @@
 //! `else` branch, which is the expected behavior since VibeSQL does not define
 //! the legacy JSON compile options). See issue #6019.
 //!
+//! ## Precedence: a real user table shadows the synthetic table (#6030)
+//!
+//! `pragma_*` identifiers are **not** reserved at `CREATE TABLE` time (only
+//! `sqlite_*` names are), so a user may legally create a real table named
+//! `pragma_compile_options`. When such a table exists, it takes precedence over
+//! the synthetic eponymous table — matching SQLite's semantics, where an
+//! eponymous virtual table is shadowed by a same-named real table. The dispatch
+//! in [`crate::select::scan::table::execute_table_scan`] therefore probes the
+//! catalog (`database.get_table`) first and only falls through to the synthetic
+//! zero-row table when no real table exists. The synthetic table re-engages
+//! automatically once the real table is dropped.
+//!
 //! Reference: <https://www.sqlite.org/pragma.html#pragma_compile_options>
 
 use vibesql_catalog::{ColumnSchema, TableSchema};

--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -393,7 +393,14 @@ pub(crate) fn execute_table_scan(
     // Referenced with bare-identifier FROM syntax; VibeSQL advertises no
     // compile-time options, so this yields the correct single-column shape with
     // zero rows.
-    if is_pragma_compile_options_table(table_name) {
+    //
+    // A real user table of the same name takes precedence (#6030): SQLite's
+    // eponymous virtual tables are shadowed by a same-named real table, and
+    // `pragma_*` names are not reserved at CREATE TABLE time. Probe the catalog
+    // first (case-insensitive, matching `is_pragma_compile_options_table`'s
+    // folding) and only fall through to the synthetic zero-row table when no
+    // real table exists.
+    if is_pragma_compile_options_table(table_name) && database.get_table(table_name).is_none() {
         let result = execute_pragma_compile_options_query()?;
         let table_schema = get_pragma_compile_options_table_schema();
 

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -104,6 +104,7 @@ mod operator_edge_cases;
 mod order_by_compaction_tests;
 mod order_by_index_optimization_tests;
 mod phase3_join_optimization;
+mod pragma_compile_options_shadowing_tests;
 mod predicate_pushdown;
 mod predicate_tests;
 mod prefix_index_tests;

--- a/crates/vibesql-executor/src/tests/pragma_compile_options_shadowing_tests.rs
+++ b/crates/vibesql-executor/src/tests/pragma_compile_options_shadowing_tests.rs
@@ -1,0 +1,124 @@
+//! Tests for `pragma_compile_options` synthetic-table shadowing precedence (#6030)
+//!
+//! `pragma_compile_options` is an eponymous system table VibeSQL synthesizes
+//! (single `compile_options TEXT` column, zero rows). Because `pragma_*` names
+//! are not reserved at `CREATE TABLE` time, a user may create a real table of
+//! the same name. In that case the real table must take precedence for
+//! `SELECT` (matching SQLite, where an eponymous virtual table is shadowed by a
+//! same-named real table). Once the real table is dropped, the synthetic table
+//! re-engages.
+
+#[cfg(test)]
+mod tests {
+    use vibesql_parser::Parser;
+    use vibesql_storage::Database;
+
+    use crate::{CreateTableExecutor, DropTableExecutor, InsertExecutor, SelectExecutor};
+
+    fn create_real_pragma_table(db: &mut Database) {
+        let sql = "CREATE TABLE pragma_compile_options (x INTEGER)";
+        let stmt = Parser::parse_sql(sql).expect("Failed to parse CREATE TABLE");
+        if let vibesql_ast::Statement::CreateTable(create_stmt) = stmt {
+            CreateTableExecutor::execute(&create_stmt, db).expect("Failed to create table");
+        } else {
+            panic!("Expected CreateTable statement");
+        }
+    }
+
+    fn insert_row(db: &mut Database, sql: &str) {
+        let stmt = Parser::parse_sql(sql).expect("Failed to parse INSERT");
+        if let vibesql_ast::Statement::Insert(insert_stmt) = stmt {
+            InsertExecutor::execute(db, &insert_stmt).expect("Failed to insert row");
+        } else {
+            panic!("Expected Insert statement");
+        }
+    }
+
+    fn run_select(db: &Database, sql: &str) -> Vec<vibesql_storage::Row> {
+        let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
+        if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+            let executor = SelectExecutor::new(db);
+            executor.execute(&select_stmt).expect("Failed to execute SELECT")
+        } else {
+            panic!("Expected Select statement");
+        }
+    }
+
+    /// A real user table named `pragma_compile_options` wins over the synthetic
+    /// eponymous table. This is the core repro from #6030.
+    #[test]
+    fn test_real_table_shadows_synthetic() {
+        let mut db = Database::new();
+        create_real_pragma_table(&mut db);
+        insert_row(&mut db, "INSERT INTO pragma_compile_options VALUES (42)");
+
+        let rows = run_select(&db, "SELECT * FROM pragma_compile_options");
+
+        // Real table wins: one row with the user's value 42, not the synthetic
+        // zero-row table.
+        assert_eq!(rows.len(), 1, "expected the real user table's row, got the synthetic table");
+        assert_eq!(rows[0].values.len(), 1);
+        assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Integer(42));
+    }
+
+    /// Case-insensitive naming: the real table wins even when referenced with
+    /// different casing than it was created with. `get_table` folds identifiers
+    /// the same way `is_pragma_compile_options_table` does.
+    #[test]
+    fn test_real_table_shadows_synthetic_case_insensitive() {
+        let mut db = Database::new();
+        create_real_pragma_table(&mut db);
+        insert_row(&mut db, "INSERT INTO pragma_compile_options VALUES (7)");
+
+        let rows = run_select(&db, "SELECT * FROM PRAGMA_COMPILE_OPTIONS");
+        assert_eq!(rows.len(), 1, "case-insensitive reference should still hit the real table");
+        assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Integer(7));
+    }
+
+    /// With no real table present, the synthetic zero-row, single-`compile_options`
+    /// -column table is returned (fallback intact).
+    #[test]
+    fn test_synthetic_fallback_when_no_real_table() {
+        let db = Database::new();
+
+        let rows = run_select(&db, "SELECT * FROM pragma_compile_options");
+        assert_eq!(rows.len(), 0, "synthetic pragma_compile_options table must have zero rows");
+    }
+
+    /// The `db exists {SELECT 1 FROM pragma_compile_options WHERE compile_options=...}`
+    /// probe json101.test relies on still routes to an empty result on a fresh db.
+    #[test]
+    fn test_synthetic_fallback_where_probe_empty() {
+        let db = Database::new();
+
+        let rows = run_select(
+            &db,
+            "SELECT 1 FROM pragma_compile_options WHERE compile_options = 'ENABLE_JSON1'",
+        );
+        assert_eq!(rows.len(), 0, "synthetic table has no rows, so the WHERE probe is empty");
+    }
+
+    /// Dropping the real table re-engages the synthetic fallback.
+    #[test]
+    fn test_drop_real_table_reverts_to_synthetic() {
+        let mut db = Database::new();
+        create_real_pragma_table(&mut db);
+        insert_row(&mut db, "INSERT INTO pragma_compile_options VALUES (99)");
+
+        // Real table wins while it exists.
+        let rows = run_select(&db, "SELECT * FROM pragma_compile_options");
+        assert_eq!(rows.len(), 1);
+
+        // Drop it.
+        let drop_stmt = vibesql_ast::DropTableStmt {
+            table_name: "pragma_compile_options".to_string(),
+            if_exists: false,
+            quoted: false,
+        };
+        DropTableExecutor::execute(&drop_stmt, &mut db).expect("Failed to drop table");
+
+        // Synthetic fallback re-engages: zero rows again.
+        let rows = run_select(&db, "SELECT * FROM pragma_compile_options");
+        assert_eq!(rows.len(), 0, "after DROP, the synthetic zero-row table must return");
+    }
+}


### PR DESCRIPTION
## Summary

`pragma_compile_options` is an eponymous system table VibeSQL synthesizes (single `compile_options TEXT` column, zero rows). Its dispatch in `execute_table_scan` ran **unconditionally before** the real-table catalog lookup, so a user table named `pragma_compile_options` was unreachable via `SELECT` — the synthetic empty table always won and silently discarded the user's rows.

sqlite3 3.51 allows `CREATE TABLE pragma_compile_options(x INTEGER)` (only `sqlite_*` names are reserved; `pragma_*` names are not) and returns the real table's rows. This PR makes VibeSQL match that: a real table shadows the synthetic eponymous table.

## Changes

- `crates/vibesql-executor/src/select/scan/table.rs`: guard the synthetic dispatch with `&& database.get_table(table_name).is_none()`, so the catalog is probed first and the synthetic zero-row table is only used when no real table exists. `get_table` folds identifiers case-insensitively, matching `is_pragma_compile_options_table`.
- `crates/vibesql-executor/src/pragma_compile_options.rs`: doc-comment documenting the precedence rule (no functional change).
- `crates/vibesql-executor/src/tests/pragma_compile_options_shadowing_tests.rs` (new) + `mod.rs` registration: regression tests.

DML paths (INSERT/UPDATE/DELETE) never carried the synthetic dispatch — they resolve table names directly through the catalog — so they already targeted the real table (grep confirmed no `pragma_compile_options`/`is_sqlite_*` references in the insert/update/delete executors). The bug was `SELECT`-only.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Real user table wins for SELECT (returns 42) | ✅ | Manual repro against release binary returns the 42 row; `test_real_table_shadows_synthetic` |
| INSERT/UPDATE/DELETE resolve to the real table (no same shadowing) | ✅ | DML executors have no synthetic dispatch (grep); INSERT into the real table then SELECT returns the row |
| Synthetic fallback still works with no user table | ✅ | Fresh-db manual repro returns 0-row `compile_options` table; `test_synthetic_fallback_when_no_real_table` + WHERE-probe test |
| DROP reverts to synthetic table | ✅ | `test_drop_real_table_reverts_to_synthetic` |
| `sqlite_master`/`sqlite_schema`/`sqlite_stat*` unchanged | ✅ | Out of scope — untouched; still reserved-name-blocked at CREATE |
| `json101-21.1-correct` keeps passing; json101 baseline unregressed | ✅ | `json101.test` 262/277 (94.6%) — matches curator baseline; `json101-21.1` not in failed set |
| json102 unregressed | ✅ | `json102.test` 309/309 (100%) |
| `cargo test -p vibesql-executor` green | ✅ | Full suite passes; 8 pragma tests (5 new + 3 existing) pass |

## Test Plan

- `cargo test -p vibesql-executor` — full suite green, 0 failures.
- Release build in worktree + manual repro: real table returns `42`; fresh db returns the synthetic zero-row `compile_options` table.
- `make test-tcl-file FILE=json101.test` → 262/277 (baseline, no regression; `json101-21.1` passes).
- `make test-tcl-file FILE=json102.test` → 309/309.

Closes #6030