### PR TITLE
fix(json): emit SQLite 9.0e+999 infinity sentinel in JSON serialization

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/json_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/json_funcs.rs
@@ -1267,12 +1267,30 @@ pub(crate) fn json_quote(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     Ok(SqlValue::Varchar(rendered.into()))
 }
 
+/// Render `±Infinity` as SQLite's JSON infinity sentinel, or `None` for finite
+/// (or NaN) inputs. SQLite serializes an infinite JSON real as the literal token
+/// `9.0e+999` / `-9.0e+999` (see `quote()` in `blob_funcs.rs`), which round-trips
+/// back to `±inf` on extraction. NaN never reaches the JSON layer as a value
+/// (it is SQL NULL first), so it is intentionally not given a sentinel here.
+fn json_infinity_sentinel(f: f64) -> Option<&'static str> {
+    if f.is_infinite() {
+        Some(if f > 0.0 { "9.0e+999" } else { "-9.0e+999" })
+    } else {
+        None
+    }
+}
+
 /// Render an f64 the way SQLite renders JSON reals (keeps a fractional part,
 /// e.g. `2.0`), by round-tripping through serde_json's number formatter.
 ///
 /// Negative zero is normalized to `0.0` to match SQLite, which renders both
-/// `0.0` and `-0.0` as `0.0` in JSON output.
+/// `0.0` and `-0.0` as `0.0` in JSON output. `±Infinity` renders as SQLite's
+/// `9.0e+999` / `-9.0e+999` sentinel (serde_json's `Number::from_f64` returns
+/// `None` for non-finite values, so this must be handled explicitly).
 pub(crate) fn render_json_number(f: f64) -> String {
+    if let Some(sentinel) = json_infinity_sentinel(f) {
+        return sentinel.to_string();
+    }
     // Normalize -0.0 to 0.0 (SQLite: json_group_array(-0.0) -> [0.0]).
     let f = if f == 0.0 { 0.0 } else { f };
     match serde_json::Number::from_f64(f) {
@@ -1483,15 +1501,21 @@ fn sql_value_to_json_node(
 /// SQLite renders JSON reals (keeps ".0", uses `1.0e+99`-style scientific form).
 ///
 /// We rely on `arbitrary_precision`: the node stores the exact SQLite-formatted
-/// token, so `serde_json::to_string` reproduces it verbatim. Non-finite values
-/// (which SQLite rejects, and which the covered surface never produces here)
-/// fall back to a JSON null.
+/// token, so `serde_json::to_string` reproduces it verbatim. `±Infinity` is
+/// emitted as SQLite's `9.0e+999` / `-9.0e+999` sentinel token, which
+/// `json_node_to_sql_value` round-trips back to `±inf` on extraction. NaN
+/// (which reaches this helper only defensively, since NaN is SQL NULL before
+/// the JSON layer) falls back to a JSON null.
 fn json_number_node(f: f64) -> serde_json::Value {
-    if !f.is_finite() {
-        return serde_json::Value::Null;
-    }
-    // SqlValue::Real's Display is SQLite's JSON real format.
-    let token = SqlValue::Real(f).to_string();
+    // SQLite serializes ±Infinity as the `9.0e+999` sentinel; store it as a raw
+    // number token (arbitrary_precision) so `serde_json::to_string` reproduces
+    // it verbatim and `->>` decodes it back to ±inf.
+    let token = match json_infinity_sentinel(f) {
+        Some(sentinel) => sentinel.to_string(),
+        None if f.is_nan() => return serde_json::Value::Null,
+        // SqlValue::Real's Display is SQLite's JSON real format.
+        None => SqlValue::Real(f).to_string(),
+    };
     match serde_json::from_str::<serde_json::Value>(&token) {
         Ok(v @ serde_json::Value::Number(_)) => v,
         _ => serde_json::Value::Null,
@@ -3416,6 +3440,80 @@ mod tests {
         assert_eq!(
             txt(json_array(&[SqlValue::Boolean(true), SqlValue::Boolean(false)], &[]).unwrap()),
             "[1,0]"
+        );
+    }
+
+    #[test]
+    fn test_json_infinity_sentinel_across_surface() {
+        // json_array / json_object emit SQLite's 9.0e+999 sentinel for ±Inf
+        // (json101-20.1). Previously these collapsed to `null`.
+        assert_eq!(txt(json_array(&[SqlValue::Real(f64::INFINITY)], &[]).unwrap()), "[9.0e+999]");
+        assert_eq!(
+            txt(json_array(&[SqlValue::Real(f64::NEG_INFINITY)], &[]).unwrap()),
+            "[-9.0e+999]"
+        );
+        assert_eq!(
+            txt(json_object(&[v("a"), SqlValue::Real(f64::INFINITY)], &[]).unwrap()),
+            r#"{"a":9.0e+999}"#
+        );
+        assert_eq!(
+            txt(json_object(
+                &[v("a"), SqlValue::Real(f64::INFINITY), v("b"), SqlValue::Real(f64::NEG_INFINITY)],
+                &[]
+            )
+            .unwrap()),
+            r#"{"a":9.0e+999,"b":-9.0e+999}"#
+        );
+
+        // json_quote renders the sentinel too (previously rendered bare "inf").
+        assert_eq!(
+            json_quote(&[SqlValue::Real(f64::INFINITY)]).unwrap(),
+            SqlValue::Varchar("9.0e+999".into())
+        );
+        assert_eq!(
+            json_quote(&[SqlValue::Real(f64::NEG_INFINITY)]).unwrap(),
+            SqlValue::Varchar("-9.0e+999".into())
+        );
+
+        // render_json_number (shared with json_group_array/object) helper check.
+        assert_eq!(render_json_number(f64::INFINITY), "9.0e+999");
+        assert_eq!(render_json_number(f64::NEG_INFINITY), "-9.0e+999");
+
+        // NaN stays NULL at the node level (SQLite never emits a NaN sentinel).
+        assert_eq!(json_number_node(f64::NAN), serde_json::Value::Null);
+    }
+
+    #[test]
+    fn test_json_infinity_extract_round_trips_to_inf() {
+        // The 9.0e+999 sentinel decodes back to ±inf via json_node_to_sql_value,
+        // driving json101-20.2/20.3 (->> of an infinite field yields Inf/-Inf).
+        let obj = txt(json_object(
+            &[v("a"), SqlValue::Real(f64::INFINITY), v("b"), SqlValue::Real(f64::NEG_INFINITY)],
+            &[],
+        )
+        .unwrap());
+        assert_eq!(
+            json_extract(&[SqlValue::Varchar(obj.clone().into()), v("$.a")]).unwrap(),
+            SqlValue::Real(f64::INFINITY)
+        );
+        assert_eq!(
+            json_extract(&[SqlValue::Varchar(obj.into()), v("$.b")]).unwrap(),
+            SqlValue::Real(f64::NEG_INFINITY)
+        );
+    }
+
+    #[test]
+    fn test_json_insert_infinity_sentinel() {
+        // The mutation helpers (json_insert/json_set/...) share json_number_node,
+        // so an infinite value argument stores the sentinel too.
+        assert_eq!(
+            txt(json_insert(&[v("{}"), v("$.a"), SqlValue::Real(f64::INFINITY)], &[]).unwrap()),
+            r#"{"a":9.0e+999}"#
+        );
+        assert_eq!(
+            txt(json_set(&[v(r#"{"a":1}"#), v("$.a"), SqlValue::Real(f64::NEG_INFINITY)], &[])
+                .unwrap()),
+            r#"{"a":-9.0e+999}"#
         );
     }
 

--- a/crates/vibesql-executor/src/select/grouping/aggregates.rs
+++ b/crates/vibesql-executor/src/select/grouping/aggregates.rs
@@ -2452,6 +2452,29 @@ mod tests {
     }
 
     #[test]
+    fn test_json_group_array_infinity_sentinel() {
+        // ±Inf must render as SQLite's 9.0e+999 sentinel, not Rust's bare "inf".
+        let mut acc = AggregateAccumulator::new("JSON_GROUP_ARRAY", false).unwrap();
+        acc.accumulate(&SqlValue::Real(f64::INFINITY));
+        acc.accumulate(&SqlValue::Real(f64::NEG_INFINITY));
+        assert_eq!(json_array_text(acc), "[9.0e+999,-9.0e+999]");
+    }
+
+    #[test]
+    fn test_json_group_object_infinity_sentinel() {
+        let mut acc = AggregateAccumulator::new("JSON_GROUP_OBJECT", false).unwrap();
+        acc.accumulate_json_object_pair(
+            SqlValue::Varchar("a".into()),
+            SqlValue::Real(f64::INFINITY),
+        );
+        let text = match acc.finalize().unwrap() {
+            SqlValue::Varchar(s) | SqlValue::Character(s) => s.as_str().to_string(),
+            other => panic!("expected text, got {other:?}"),
+        };
+        assert_eq!(text, r#"{"a":9.0e+999}"#);
+    }
+
+    #[test]
     fn test_json_group_array_jsonb_blob_embeds() {
         // A well-formed JSONB blob embeds as its decoded JSON: json_group_array(jsonb('[1]')) -> [[1]].
         use crate::evaluator::functions::sqlite_compat::jsonb;


### PR DESCRIPTION
Closes #6053

## Summary

`json101-20.1/20.2/20.3` failed because two explicit `!is_finite()` guards in the JSON serializer dropped infinite reals: `json_number_node()` returned `Value::Null` (so `json_object`/`json_array`/`jsonb_*`/`json_insert`/`set`/`replace`/`patch` produced `null`), and `render_json_number()` fell through to `f.to_string()` producing Rust's bare `inf` token (so `json_quote`/`json_group_array`/`json_group_object` produced `inf`).

Both sites now emit SQLite's canonical infinity sentinel — `9.0e+999` / `-9.0e+999` — via a shared `json_infinity_sentinel()` helper, mirroring the existing `QUOTE()` sentinel in `blob_funcs.rs`. The sentinel round-trips back to `±inf` on extraction through the already-present (previously dead) branch in `json_node_to_sql_value()`, so `->>`/`json_extract` now return `Inf`/`-Inf` with no extraction-side change. NaN keeps mapping to JSON `null`, matching SQLite (NaN is SQL NULL before ever reaching the JSON layer).

Followed the curator verification: the issue's original "serde silently coerces to Null" theory was incorrect; the actual culprits were the two explicit guards.

## Differential parity vs sqlite3 3.51.0 (release binary)

| Expression | SQLite 3.51.0 | VibeSQL (after fix) |
|---|---|---|
| `json_object('a',2e370,'b',-3e380)` | `{"a":9.0e+999,"b":-9.0e+999}` | `{"a":9.0e+999,"b":-9.0e+999}` |
| `json_quote(9e999)` | `9.0e+999` | `9.0e+999` |
| `json_array(-9e999)` | `[-9.0e+999]` | `[-9.0e+999]` |
| `...->>'a'` / `...->>'b'` | `Inf` / `-Inf` | `Inf` / `-Inf` |
| `json_object('a', 0.0/0.0)` | `{"a":null}` | `{"a":null}` (unchanged) |

## Tests

- New unit tests: `json_object`/`json_array`/`json_quote`/`json_insert`/`json_set` over `±Inf`, the `->>` round-trip to `±inf`, NaN-stays-null, plus `json_group_array`/`json_group_object` aggregate cases in `aggregates.rs`.
- `cargo test -p vibesql-executor` green.
- `make test-tcl-file FILE=json101.test`: 20.1/20.2/20.3 dropped off the failure list (12 pre-existing unrelated failures remain, down from 15 baseline).
- `make test-tcl-file FILE=json102.test`: 309/309 unchanged.
- `cargo fmt` + `cargo clippy -p vibesql-executor` clean on touched code.

## Out of scope (curator-excluded)

`json(9e999)` on a bare numeric-literal document argument still errors ("JSON functions require string arguments") instead of returning `9e999` as text — a distinct gap, not part of the 20.x acceptance criteria. Worth a follow-up issue against epic #5779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)