### PR TITLE
feat(executor): expose json_each/json_tree hidden json/root columns

### DIFF
--- a/crates/vibesql-executor/src/correlation.rs
+++ b/crates/vibesql-executor/src/correlation.rs
@@ -668,6 +668,7 @@ mod tests {
             table_schemas: std::collections::HashMap::new(),
             total_columns: 0,
             hidden_columns: std::collections::HashSet::new(),
+            always_hidden_columns: std::collections::HashSet::new(),
             outer_schema: None,
             duplicate_aliases: std::collections::HashSet::new(),
             joined_columns: std::collections::HashSet::new(),

--- a/crates/vibesql-executor/src/optimizer/column_pruning.rs
+++ b/crates/vibesql-executor/src/optimizer/column_pruning.rs
@@ -539,6 +539,7 @@ pub fn remap_schema(
         table_schemas: new_table_schemas,
         total_columns: projection_indices.len(),
         hidden_columns: std::collections::HashSet::new(),
+        always_hidden_columns: std::collections::HashSet::new(),
         outer_schema: None,
         duplicate_aliases: std::collections::HashSet::new(),
         joined_columns: std::collections::HashSet::new(),

--- a/crates/vibesql-executor/src/schema.rs
+++ b/crates/vibesql-executor/src/schema.rs
@@ -115,6 +115,18 @@ pub struct CombinedSchema {
     /// This allows `SELECT t1.*` to return all columns from t1, while `SELECT *`
     /// correctly deduplicates columns for NATURAL JOIN.
     pub hidden_columns: HashSet<usize>,
+    /// Columns that are ALWAYS hidden from `SELECT *` / `table.*` expansion,
+    /// with no replacement or COALESCE partner (unlike `hidden_columns`, which is
+    /// join-deduplication and always pairs the hidden column with a replacement).
+    ///
+    /// This models SQLite's `SQLITE_HIDDEN` virtual-table columns: the `json` and
+    /// `root` columns of `json_each`/`json_tree` are resolvable by explicit
+    /// reference (`jx.json`, `WHERE root = '$'`) but are excluded from wildcard
+    /// expansion and `pragma_table_info`. The three `SELECT *` expansion call
+    /// sites short-circuit these to *excluded* unconditionally, distinct from the
+    /// join-dedup `hidden_columns` fallback that treats a no-replacement hidden
+    /// column as visible (issue #6050).
+    pub always_hidden_columns: HashSet<usize>,
     /// Reference to outer scope schema for nested subquery column resolution (issue #4493)
     /// Forms a linked-list chain similar to SQLite's NameContext.pNext
     /// Enables resolution of columns from multiple nesting levels
@@ -167,6 +179,7 @@ impl CombinedSchema {
             table_schemas: HashMap::new(),
             total_columns: 0,
             hidden_columns: HashSet::new(),
+            always_hidden_columns: HashSet::new(),
             outer_schema: None,
             duplicate_aliases: HashSet::new(),
             joined_columns: HashSet::new(),
@@ -190,6 +203,7 @@ impl CombinedSchema {
             table_schemas,
             total_columns,
             hidden_columns: HashSet::new(),
+            always_hidden_columns: HashSet::new(),
             outer_schema: None,
             duplicate_aliases: HashSet::new(),
             joined_columns: HashSet::new(),
@@ -238,6 +252,7 @@ impl CombinedSchema {
             table_schemas,
             total_columns,
             hidden_columns: HashSet::new(),
+            always_hidden_columns: HashSet::new(),
             outer_schema: None,
             duplicate_aliases: HashSet::new(),
             joined_columns: HashSet::new(),
@@ -289,6 +304,7 @@ impl CombinedSchema {
             table_schemas,
             total_columns,
             hidden_columns: HashSet::new(),
+            always_hidden_columns: HashSet::new(),
             outer_schema: None,
             duplicate_aliases: HashSet::new(),
             joined_columns: HashSet::new(),
@@ -433,6 +449,7 @@ impl CombinedSchema {
             table_schemas,
             total_columns: left_total + right_columns,
             hidden_columns: left.hidden_columns,
+            always_hidden_columns: left.always_hidden_columns,
             outer_schema: left.outer_schema,
             duplicate_aliases,
             joined_columns: left.joined_columns,
@@ -492,6 +509,12 @@ impl CombinedSchema {
             hidden_columns.insert(left_total + idx);
         }
 
+        // Merge always-hidden (TVF SQLITE_HIDDEN) columns, adjusting right indices
+        let mut always_hidden_columns = left.always_hidden_columns;
+        for idx in right.always_hidden_columns {
+            always_hidden_columns.insert(left_total + idx);
+        }
+
         // Merge duplicate aliases from both sides
         duplicate_aliases.extend(right.duplicate_aliases);
 
@@ -528,6 +551,7 @@ impl CombinedSchema {
             table_schemas,
             total_columns: left_total + right.total_columns,
             hidden_columns,
+            always_hidden_columns,
             outer_schema: left.outer_schema,
             duplicate_aliases,
             joined_columns,
@@ -962,6 +986,24 @@ impl CombinedSchema {
         self.hidden_columns.insert(idx);
     }
 
+    /// Is this column ALWAYS hidden from `SELECT *` / `table.*` expansion?
+    ///
+    /// True for `SQLITE_HIDDEN`-style TVF columns (`json`/`root` of
+    /// `json_each`/`json_tree`) that must be excluded from wildcard expansion
+    /// unconditionally — no replacement or COALESCE partner exists. Distinct from
+    /// [`is_column_hidden`], which is join-deduplication and pairs the hidden
+    /// column with a replacement (issue #6050).
+    #[inline]
+    pub fn is_column_always_hidden(&self, idx: usize) -> bool {
+        self.always_hidden_columns.contains(&idx)
+    }
+
+    /// Mark a column as always-hidden from `SELECT *` expansion (see
+    /// [`is_column_always_hidden`]).
+    pub fn always_hide_column(&mut self, idx: usize) {
+        self.always_hidden_columns.insert(idx);
+    }
+
     /// Mark a column name as a "joined column" from NATURAL JOIN or USING clause.
     ///
     /// Joined columns exist in multiple tables but should NOT be considered ambiguous
@@ -1176,6 +1218,13 @@ impl CombinedSchema {
                     continue;
                 }
 
+                // Always-hidden (SQLITE_HIDDEN-style TVF) columns are excluded
+                // from wildcard expansion unconditionally — no replacement or
+                // COALESCE partner exists (issue #6050).
+                if self.is_column_always_hidden(abs_idx) {
+                    continue;
+                }
+
                 let should_include = if self.is_column_hidden(abs_idx) {
                     self.get_column_replacement(abs_idx).is_some()
                         || self.get_using_coalesce_right_for_left(abs_idx).is_some()
@@ -1277,6 +1326,7 @@ pub struct SchemaBuilder {
     table_schemas: HashMap<TableIdentifier, (usize, vibesql_catalog::TableSchema)>,
     column_offset: usize,
     hidden_columns: HashSet<usize>,
+    always_hidden_columns: HashSet<usize>,
     duplicate_aliases: HashSet<TableIdentifier>,
     joined_columns: HashSet<String>,
     using_coalesce_indices: HashMap<String, Vec<usize>>,
@@ -1292,6 +1342,7 @@ impl SchemaBuilder {
             table_schemas: HashMap::new(),
             column_offset: 0,
             hidden_columns: HashSet::new(),
+            always_hidden_columns: HashSet::new(),
             duplicate_aliases: HashSet::new(),
             joined_columns: HashSet::new(),
             using_coalesce_indices: HashMap::new(),
@@ -1310,6 +1361,7 @@ impl SchemaBuilder {
             table_schemas: schema.table_schemas,
             column_offset,
             hidden_columns: schema.hidden_columns,
+            always_hidden_columns: schema.always_hidden_columns,
             duplicate_aliases: schema.duplicate_aliases,
             joined_columns: schema.joined_columns,
             using_coalesce_indices: schema.using_coalesce_indices,
@@ -1350,6 +1402,7 @@ impl SchemaBuilder {
             table_schemas: self.table_schemas,
             total_columns: self.column_offset,
             hidden_columns: self.hidden_columns,
+            always_hidden_columns: self.always_hidden_columns,
             outer_schema: None,
             duplicate_aliases: self.duplicate_aliases,
             joined_columns: self.joined_columns,

--- a/crates/vibesql-executor/src/select/executor/aggregation/window.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/window.rs
@@ -1111,6 +1111,7 @@ fn build_aggregate_result_schema(
         table_schemas,
         total_columns: table_schema.columns.len(),
         hidden_columns: std::collections::HashSet::new(),
+        always_hidden_columns: std::collections::HashSet::new(),
         outer_schema: None,
         duplicate_aliases: std::collections::HashSet::new(),
         joined_columns: std::collections::HashSet::new(),

--- a/crates/vibesql-executor/src/select/executor/arena_execution.rs
+++ b/crates/vibesql-executor/src/select/executor/arena_execution.rs
@@ -126,6 +126,7 @@ impl SelectExecutor<'_> {
             table_schemas: HashMap::new(),
             total_columns: 0,
             hidden_columns: HashSet::new(),
+            always_hidden_columns: HashSet::new(),
             outer_schema: None,
             duplicate_aliases: HashSet::new(),
             joined_columns: HashSet::new(),

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join_helpers.rs
@@ -393,6 +393,7 @@ pub(super) fn build_combined_schema(
         table_schemas: HashMap::new(),
         total_columns: 0,
         hidden_columns: HashSet::new(),
+        always_hidden_columns: HashSet::new(),
         outer_schema: None,
         duplicate_aliases: HashSet::new(),
         joined_columns: HashSet::new(),

--- a/crates/vibesql-executor/src/select/executor/columns.rs
+++ b/crates/vibesql-executor/src/select/executor/columns.rs
@@ -202,6 +202,14 @@ impl SelectExecutor<'_> {
                                         continue;
                                     }
 
+                                    // Always-hidden (SQLITE_HIDDEN-style TVF) columns
+                                    // are excluded from wildcard expansion
+                                    // unconditionally, with no replacement lookup
+                                    // (issue #6050).
+                                    if from_res.schema.is_column_always_hidden(abs_idx) {
+                                        continue;
+                                    }
+
                                     // For hidden columns, check if they have a replacement or coalesce
                                     if from_res.schema.is_column_hidden(abs_idx) {
                                         let has_replacement = from_res
@@ -265,12 +273,24 @@ impl SelectExecutor<'_> {
                         // TableKey lookup is case-insensitive
                         let result = from_res.schema.get_table(qualifier).cloned();
 
-                        if let Some((_start_index, table_schema)) = result {
+                        if let Some((start_index, table_schema)) = result {
+                            // Always-hidden (SQLITE_HIDDEN-style TVF) columns are
+                            // excluded from `table.*` expansion too, matching SQLite
+                            // (issue #6050). Count only the visible columns for the
+                            // derived-column-list arity check.
+                            let visible_count = table_schema
+                                .columns
+                                .iter()
+                                .enumerate()
+                                .filter(|(col_idx, _)| {
+                                    !from_res.schema.is_column_always_hidden(start_index + col_idx)
+                                })
+                                .count();
                             // Apply derived column list if present
                             if let Some(derived_cols) = alias {
-                                if derived_cols.len() != table_schema.columns.len() {
+                                if derived_cols.len() != visible_count {
                                     return Err(ExecutorError::ColumnCountMismatch {
-                                        expected: table_schema.columns.len(),
+                                        expected: visible_count,
                                         provided: derived_cols.len(),
                                     });
                                 }
@@ -281,7 +301,14 @@ impl SelectExecutor<'_> {
                                 // full_column_names=ON (colname.test section 4.6).
                                 // The prefix uses the schema's canonical table name, not the
                                 // qualifier as typed.
-                                for col_schema in &table_schema.columns {
+                                for (col_idx, col_schema) in table_schema.columns.iter().enumerate()
+                                {
+                                    if from_res
+                                        .schema
+                                        .is_column_always_hidden(start_index + col_idx)
+                                    {
+                                        continue;
+                                    }
                                     let display_name = match wildcard_mode {
                                         ColumnNamingMode::Full => {
                                             format!("{}.{}", table_schema.name, col_schema.name)

--- a/crates/vibesql-executor/src/select/executor/validation/schema.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/schema.rs
@@ -474,6 +474,7 @@ fn build_schema_from_tables(
             table_schemas,
             total_columns,
             hidden_columns: HashSet::new(),
+            always_hidden_columns: HashSet::new(),
             outer_schema: None,
             duplicate_aliases: HashSet::new(),
             joined_columns: HashSet::new(),

--- a/crates/vibesql-executor/src/select/iterator/join.rs
+++ b/crates/vibesql-executor/src/select/iterator/join.rs
@@ -126,6 +126,12 @@ impl<'schema, I: RowIterator> LazyNestedLoopJoin<'schema, I> {
             hidden_columns.insert(left_total + idx);
         }
 
+        // Merge always-hidden (TVF SQLITE_HIDDEN) columns, adjusting right indices
+        let mut always_hidden_columns = left_schema.always_hidden_columns.clone();
+        for idx in right_schema.always_hidden_columns.iter() {
+            always_hidden_columns.insert(left_total + idx);
+        }
+
         // Merge joined_columns from both sides
         // These track columns from NATURAL/USING joins that shouldn't be considered ambiguous
         let mut joined_columns = left_schema.joined_columns.clone();
@@ -160,6 +166,7 @@ impl<'schema, I: RowIterator> LazyNestedLoopJoin<'schema, I> {
             table_schemas,
             total_columns: left_total + right_total,
             hidden_columns,
+            always_hidden_columns,
             outer_schema: None,
             duplicate_aliases: HashSet::new(),
             joined_columns,

--- a/crates/vibesql-executor/src/select/iterator/tests/phase_c.rs
+++ b/crates/vibesql-executor/src/select/iterator/tests/phase_c.rs
@@ -205,6 +205,7 @@ fn test_phase_c_proof_of_concept_join_pipeline() {
         table_schemas: combined_tables,
         total_columns: orders_combined.total_columns + customers_combined.total_columns,
         hidden_columns: std::collections::HashSet::new(),
+        always_hidden_columns: std::collections::HashSet::new(),
         outer_schema: None,
         duplicate_aliases: std::collections::HashSet::new(),
         joined_columns: std::collections::HashSet::new(),

--- a/crates/vibesql-executor/src/select/projection.rs
+++ b/crates/vibesql-executor/src/select/projection.rs
@@ -110,6 +110,13 @@ pub(crate) fn project_row_combined(
                                     continue;
                                 }
 
+                                // Always-hidden (SQLITE_HIDDEN-style TVF) columns are
+                                // excluded from wildcard expansion unconditionally,
+                                // with no replacement lookup (issue #6050).
+                                if schema.is_column_always_hidden(abs_idx) {
+                                    continue;
+                                }
+
                                 // Check if column should be included
                                 let should_include = if schema.is_column_hidden(abs_idx) {
                                     schema.get_column_replacement(abs_idx).is_some()
@@ -246,9 +253,16 @@ pub(crate) fn project_row_combined(
                             end_index
                         };
 
-                        // Extract the columns for this table
+                        // Extract the columns for this table, skipping always-hidden
+                        // (SQLITE_HIDDEN-style TVF) columns so `table.*` excludes
+                        // json/root just like `SELECT *` does (issue #6050).
                         if start_index < effective_end && effective_end <= row.values.len() {
-                            values.extend(row.values[start_index..effective_end].iter().cloned());
+                            for abs_idx in start_index..effective_end {
+                                if schema.is_column_always_hidden(abs_idx) {
+                                    continue;
+                                }
+                                values.push(row.values[abs_idx].clone());
+                            }
                         }
                         // If indices are out of bounds, this might be an error, but we'll be silent
                         // for now

--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -168,6 +168,7 @@ pub(super) fn build_reordered_schema(
         table_schemas: new_table_schemas,
         total_columns: current_position,
         hidden_columns: std::collections::HashSet::new(),
+        always_hidden_columns: std::collections::HashSet::new(),
         outer_schema: None,
         duplicate_aliases: std::collections::HashSet::new(),
         joined_columns: std::collections::HashSet::new(),

--- a/crates/vibesql-executor/src/select/scan/table_function.rs
+++ b/crates/vibesql-executor/src/select/scan/table_function.rs
@@ -9,6 +9,11 @@
 //! key, value, type, atom, id, parent, fullkey, path
 //! ```
 //!
+//! plus two `SQLITE_HIDDEN` columns — `json` (the original input document,
+//! echoed verbatim on every row) and `root` (the path argument, default `"$"`).
+//! Both are resolvable by explicit reference (`jx.json`, `WHERE root = '$'`) but
+//! excluded from `SELECT *` / `pragma_table_info` (issue #6050).
+//!
 //! - `json_each` yields one row per *immediate* child of the (possibly
 //!   path-navigated) value; a scalar value yields exactly one row.
 //! - `json_tree` performs a depth-first walk emitting one row per node,
@@ -45,8 +50,15 @@ use crate::{
 };
 use vibesql_types::{DataType, SqlValue};
 
-/// The eight columns exposed by `json_each` / `json_tree`, in order.
+/// The eight *visible* columns exposed by `json_each` / `json_tree`, in order.
+/// The two trailing hidden columns (`json`, `root`) are appended by
+/// [`build_schema`] and are not part of this array so the `#[cfg(test)]`
+/// column-index constants (KEY..PATH) and `column_aliases` arity remain unchanged.
 const TVF_COLUMNS: [&str; 8] = ["key", "value", "type", "atom", "id", "parent", "fullkey", "path"];
+
+/// The two trailing `SQLITE_HIDDEN` columns (`json`, `root`) appended after the
+/// eight visible columns. Their absolute indices in the emitted rows are 8 and 9.
+const TVF_HIDDEN_COLUMNS: [&str; 2] = ["json", "root"];
 
 /// Execute a JSON table-valued function (`json_each` / `json_tree`) in FROM
 /// position, returning the expanded 8-column relation.
@@ -135,17 +147,33 @@ pub(crate) fn execute_table_function(
     // A BLOB argument is a JSONB document (produced by jsonb()/jsonb_*()): decode
     // it directly into the expansion root. A malformed/non-JSONB blob is an error
     // (SQLite: `json_each(x'abcd')` -> "malformed JSON"), never silent zero rows.
+    // The `json` hidden column echoes the *original* input document verbatim
+    // (issue #6050). SQLite returns the input argument as-supplied — for a TEXT
+    // argument this preserves the original whitespace/formatting exactly, so
+    // `json_each(t.j).json == t.j` byte-for-byte (json101-5.5/5.6 compare with
+    // `<>`). For a JSONB blob the text form of the decoded document is used; for
+    // a non-text scalar its JSON scalar token is used.
+    let mut json_column_text: Option<String> = None;
     let root = match &json_value {
         SqlValue::Null => return Ok(super::FromResult::from_rows(schema, vec![])),
-        SqlValue::Blob(bytes) => decode_jsonb_blob(bytes)
-            .ok_or_else(|| ExecutorError::SqliteCompatError("malformed JSON".to_string()))?,
+        SqlValue::Blob(bytes) => {
+            let node = decode_jsonb_blob(bytes)
+                .ok_or_else(|| ExecutorError::SqliteCompatError("malformed JSON".to_string()))?;
+            // JSONB blob: echo the decoded document as normalized JSON text
+            // (the raw blob is not valid text to echo).
+            json_column_text = Some(json_node_to_json_text(&node));
+            node
+        }
         other => {
             let json_str = match sqlvalue_as_json_text(other) {
                 Some(s) => s,
                 None => return Ok(super::FromResult::from_rows(schema, vec![])),
             };
-            parse_json_relaxed(&json_str)
-                .map_err(|_| ExecutorError::SqliteCompatError("malformed JSON".to_string()))?
+            let node = parse_json_relaxed(&json_str)
+                .map_err(|_| ExecutorError::SqliteCompatError("malformed JSON".to_string()))?;
+            // Echo the input text verbatim (preserves original whitespace).
+            json_column_text = Some(json_str);
+            node
         }
     };
 
@@ -190,23 +218,44 @@ pub(crate) fn execute_table_function(
         );
     }
 
+    // Append the two hidden columns to every emitted row. Both are loop-invariant
+    // per TVF call (issue #6050):
+    // - `json`: the *original outer* input document, echoed verbatim on every row
+    //   regardless of any path navigation (SQLite echoes the outer input, not the
+    //   navigated subtree). Captured above so original whitespace is preserved.
+    // - `root`: the path argument string as given (default `"$"` when omitted).
+    let json_text = match json_column_text {
+        Some(s) => SqlValue::Varchar(s.into()),
+        None => SqlValue::Null,
+    };
+    let root_path = SqlValue::Varchar(base_path.as_str().into());
+    for row in &mut rows {
+        row.values.push(json_text.clone());
+        row.values.push(root_path.clone());
+    }
+
     Ok(super::FromResult::from_rows(schema, rows))
 }
 
-/// Build the derived-table schema (8 fixed columns, optionally renamed).
+/// Build the derived-table schema: 8 visible columns (optionally renamed) plus
+/// the two trailing `SQLITE_HIDDEN` columns `json`/`root`.
 ///
-/// Known follow-ups surfaced once json101.test's tail runs (#6019), tracked
-/// separately and intentionally NOT addressed here:
-/// - The hidden `json` input column of json_each/json_tree is not exposed, so
-///   `jx.json` fails (json101-5.5/5.6).
+/// The `json`/`root` columns are marked always-hidden on the schema so they are
+/// excluded from `SELECT *` / `table.*` / `pragma_table_info` but remain
+/// resolvable via explicit reference — matching SQLite's virtual-table hidden
+/// columns (issue #6050). Their names are fixed (`json`, `root`) even when a
+/// `column_aliases` list renames the eight visible columns; `column_aliases`
+/// only counts against the eight visible columns, so its arity check is
+/// unchanged.
+///
+/// Remaining known follow-up (tracked separately, NOT addressed here):
 /// - `id`/`parent` numbering diverges from SQLite (json101-15.100..130).
-/// See the issue's follow-up list for details.
 pub(crate) fn build_schema(
     name: &str,
     alias: Option<&String>,
     column_aliases: Option<&Vec<String>>,
 ) -> Result<CombinedSchema, ExecutorError> {
-    let column_names: Vec<String> = match column_aliases {
+    let mut column_names: Vec<String> = match column_aliases {
         Some(aliases) => {
             if aliases.len() != TVF_COLUMNS.len() {
                 return Err(ExecutorError::ColumnCountMismatch {
@@ -218,10 +267,12 @@ pub(crate) fn build_schema(
         }
         None => TVF_COLUMNS.iter().map(|s| s.to_string()).collect(),
     };
+    // Append the fixed hidden-column names (not affected by `column_aliases`).
+    column_names.extend(TVF_HIDDEN_COLUMNS.iter().map(|s| s.to_string()));
 
     // Column types mirror SQLite: key/value/atom are dynamic (declared NULL so
     // the derived schema treats them permissively), type/fullkey/path are text,
-    // id/parent are integers.
+    // id/parent are integers. The trailing json/root hidden columns are text.
     let column_types = vec![
         DataType::Null,                         // key
         DataType::Null,                         // value
@@ -231,6 +282,8 @@ pub(crate) fn build_schema(
         DataType::Bigint,                       // parent
         DataType::Varchar { max_length: None }, // fullkey
         DataType::Varchar { max_length: None }, // path
+        DataType::Null,                         // json (hidden; echoes input document)
+        DataType::Varchar { max_length: None }, // root (hidden; path argument)
     ];
 
     // Table name defaults to the function name so `json_each.value` resolves
@@ -239,7 +292,12 @@ pub(crate) fn build_schema(
     // Use the TVF constructor (not `from_derived_table`) so the implicit `rowid`
     // pseudo-column resolves to NULL instead of erroring like a FROM-subquery
     // (#6019).
-    Ok(CombinedSchema::from_table_function(table_name, column_names, column_types))
+    let mut schema = CombinedSchema::from_table_function(table_name, column_names, column_types);
+    // Mark json (index 8) and root (index 9) as always-hidden from SELECT *.
+    for hidden_idx in TVF_COLUMNS.len()..TVF_COLUMNS.len() + TVF_HIDDEN_COLUMNS.len() {
+        schema.always_hide_column(hidden_idx);
+    }
+    Ok(schema)
 }
 
 /// Coerce a non-NULL SQL value into the JSON *text* it represents for TVF input


### PR DESCRIPTION
## Summary

`json_each`/`json_tree` now expose the two `SQLITE_HIDDEN` columns `json` (the original input document, echoed verbatim on every row) and `root` (the path argument, default `"$"`), matching SQLite's virtual-table hidden-column semantics. Both are resolvable by explicit or alias-qualified reference (`jx.json`, `WHERE root = '$'`) but excluded from `SELECT *` / `table.*` / `pragma_table_info`. This fixes `json101-5.5`/`5.6`, which compare `json_each(t.j).json` against the original document.

## Design choice (Option A — recommended by curator)

VibeSQL's existing `hidden_columns` machinery is join-dedup only: every hidden column is paired with a replacement/COALESCE partner, and the three `SELECT *` call sites treat a *no-replacement* hidden column as **visible**. TVF hidden columns need the opposite. Rather than flip that fallback (Option B, which risks silently dropping columns from existing join `SELECT *`), I added a separate `always_hidden_columns: HashSet<usize>` set with "always exclude, no replacement" semantics. The wildcard call sites check `is_column_always_hidden` and short-circuit to *excluded* **before** the replacement/coalesce fallback, so NATURAL/USING JOIN dedup is completely untouched (empty set for all non-TVF schemas → strict no-op).

## Changes

- `schema.rs`: add `always_hidden_columns` field + `is_column_always_hidden`/`always_hide_column` accessors; propagate through `combine`/`merge`/`SchemaBuilder`; short-circuit always-hidden columns to excluded in `wildcard_output_chains`.
- `select/iterator/join.rs`: propagate `always_hidden_columns` in the join-schema merge.
- `select/executor/columns.rs` + `select/projection.rs`: exclude always-hidden columns from both unqualified `SELECT *` **and** qualified `table.*` header/value expansion.
- `select/scan/table_function.rs`: append `json`/`root` to the schema (indices 8/9) marked always-hidden; append the two values once per row in a post-pass (make_row + recursive expand_* chain unchanged). `json` echoes the original input text verbatim (whitespace preserved; JSONB blobs echo decoded text form); `root` is the path argument string.
- 7 other files: add `always_hidden_columns: HashSet::new()` to their `CombinedSchema` struct literals.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| json101-5.5 / 5.6 pass | ✅ | `make test-tcl-file FILE=json101.test`: 262→264/277; both no longer in failure list |
| `json` echoes input document | ✅ | `SELECT value, json FROM json_each('{"a":1}')` → `{"a":1}`; array/nested cases verified |
| Nested path: `root='$.a'`, `json`=full outer doc | ✅ | `json_each('{"a":{"b":1}}', '$.a')` → root `$.a`, json `{"a":{"b":1}}` (not subtree) |
| `SELECT *` unchanged (8 cols) | ✅ | `SELECT * FROM json_each('[1,2]')` returns exactly 8 columns |
| `table.*` excludes json/root | ✅ | `SELECT xyz.* FROM json_each('[1,2]') AS xyz` returns 8 columns |
| Explicit / alias-qualified selectable | ✅ | `jx.json`, `jx.root`, `WHERE root = '$'` all resolve |
| No NATURAL/USING JOIN regression | ✅ | `join2.test` 46/0; `join.test` failures unchanged (14.x/15.x, pre-existing, non-TVF); `cargo test schema::` 60/0 |
| json102 stays 309/309 | ✅ | `make test-tcl-file FILE=json102.test`: 309/309 |
| `cargo test -p vibesql-executor` green | ✅ | lib 3426/0, doctests 31/0; table_function 16/0 |

## Test Plan

- `cargo test -p vibesql-executor --lib`: 3426 passed, 0 failed
- `make test-tcl-file FILE=json101.test`: 264/277 (remaining 13 = 15.100/110/120/130, 20.x, 24.x — out of scope, tracked in #6051/#6030/#6054)
- `make test-tcl-file FILE=json102.test`: 309/309
- `make test-tcl-file FILE=join2.test`: 46/0; `join.test` unchanged (pre-existing 14.x/15.x failures, no TVF involvement)
- Manual: verified verbatim echo, nested-path outer-doc echo, `SELECT *`/`table.*` exclusion, `WHERE root=` on the worktree release binary
- `cargo clippy -p vibesql-executor`: no new warnings on touched files; `cargo fmt` clean

Closes #6050