### PR TITLE
fix(executor): row-value IN/= affinity and correlated-subquery caching (Stage 1)

### DIFF
--- a/crates/vibesql-executor/src/correlation.rs
+++ b/crates/vibesql-executor/src/correlation.rs
@@ -662,6 +662,91 @@ mod tests {
         assert!(is_correlated(&subquery, &outer_schema, None));
     }
 
+    /// Regression test for issue #6045 (Root Cause #2): a scalar subquery whose
+    /// WHERE clause compares a 2-element row-value against outer columns must be
+    /// detected as correlated. Previously such a subquery was treated as
+    /// non-correlated and cached, so every outer row received the first row's
+    /// result.
+    ///
+    /// Models: `SELECT (SELECT rowid FROM a1 WHERE (a,b) = (x,y)) FROM a2`
+    /// where `a1(a,b)` is the inner table and the outer schema is `a2(x,y)`.
+    #[test]
+    fn test_row_value_where_clause_is_correlated() {
+        // Outer schema: table "a2" with columns x, y
+        let outer_columns = vec![
+            vibesql_catalog::ColumnSchema {
+                name: "x".to_string(),
+                data_type: vibesql_types::DataType::Integer,
+                nullable: true,
+                default_value: None,
+                generated_expr: None,
+                is_exact_integer_type: false,
+                collation: None,
+            },
+            vibesql_catalog::ColumnSchema {
+                name: "y".to_string(),
+                data_type: vibesql_types::DataType::Integer,
+                nullable: true,
+                default_value: None,
+                generated_expr: None,
+                is_exact_integer_type: false,
+                collation: None,
+            },
+        ];
+        let outer_schema = CombinedSchema::from_table(
+            "a2".to_string(),
+            vibesql_catalog::TableSchema::new("a2".to_string(), outer_columns),
+        );
+
+        // Inner subquery: SELECT 1 FROM a1 WHERE (a, b) = (x, y)
+        // a, b are the inner table's columns; x, y are the outer table's columns.
+        let where_clause = Expression::BinaryOp {
+            op: BinaryOperator::Equal,
+            left: Box::new(Expression::RowValueConstructor(vec![
+                Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("a", false)),
+                Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("b", false)),
+            ])),
+            right: Box::new(Expression::RowValueConstructor(vec![
+                Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("x", false)),
+                Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("y", false)),
+            ])),
+        };
+
+        let subquery = SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list: vec![SelectItem::Expression {
+                expr: Expression::Literal(vibesql_types::SqlValue::Integer(1)),
+                alias: None,
+                source_text: None,
+            }],
+            into_table: None,
+            into_variables: None,
+            from: Some(FromClause::Table {
+                index_hint: None,
+                name: "a1".to_string(),
+                alias: None,
+                column_aliases: None,
+                quoted: false,
+            }),
+            where_clause: Some(where_clause),
+            group_by: None,
+            having: None,
+            window_definitions: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            set_operation: None,
+            values: None,
+        };
+
+        // x and y are outer columns, so this subquery IS correlated.
+        assert!(
+            is_correlated(&subquery, &outer_schema, None),
+            "row-value WHERE clause referencing outer columns must be correlated"
+        );
+    }
+
     #[test]
     fn test_empty_outer_schema() {
         let outer_schema = CombinedSchema {

--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -78,6 +78,18 @@ impl CombinedExpressionEvaluator<'_> {
             }
             // For COLLATE expressions, get affinity of the inner expression
             vibesql_ast::Expression::Collate { expr, .. } => self.get_expression_affinity(expr),
+            // A scalar subquery carries the affinity of its (single) result
+            // column, so `col = (SELECT y FROM blob_table)` compares by the
+            // real column affinity of `y` (NONE for a BLOB column) rather than
+            // treating the produced value as an affinity-less literal. Without
+            // this, `text_col = (SELECT blob_int_col)` wrongly coerced the
+            // integer to text and matched (rowvalue9 3.5/3.6/4.tn.4/4.tn.6,
+            // issue #6045).
+            vibesql_ast::Expression::ScalarSubquery(subquery) => self.database.and_then(|db| {
+                crate::evaluator::combined::subqueries::schema_utils::get_subquery_first_column_affinity(
+                    subquery, db,
+                )
+            }),
             // Literals, functions, and other expressions don't have column affinity
             _ => None,
         }
@@ -1529,9 +1541,25 @@ impl CombinedExpressionEvaluator<'_> {
         let arity = tuple_exprs.len();
         let subquery_values = self.eval_scalar_subquery_as_row(subquery, row, arity)?;
 
+        // Per-position affinity of the subquery's result columns, so a BLOB
+        // (NONE-affinity) subquery column suppresses TEXT coercion of the tuple
+        // side — matching `(c, a) = (SELECT x, y FROM blob_table)` in SQLite
+        // (rowvalue9 3.6 / 4.tn.4, issue #6045). Falls back to treating the
+        // value as an affinity-less literal when the column affinity can't be
+        // resolved.
+        let sub_affinities: Vec<Option<vibesql_types::TypeAffinity>> = (0..arity)
+            .map(|i| {
+                self.database.and_then(|db| {
+                    crate::evaluator::combined::subqueries::schema_utils::get_subquery_column_affinity_at(
+                        subquery, i, db,
+                    )
+                })
+            })
+            .collect();
+
         let mut tuple_values = Vec::with_capacity(arity);
         let mut other_values = Vec::with_capacity(arity);
-        for (tuple_expr, sub_val) in tuple_exprs.iter().zip(subquery_values) {
+        for (idx, (tuple_expr, sub_val)) in tuple_exprs.iter().zip(subquery_values).enumerate() {
             let tuple_val = self.eval(tuple_expr, row)?;
             // Per-element collation from the tuple side (explicit COLLATE or
             // column-declared collation), e.g. `(a COLLATE nocase, b) = (SELECT ...)`.
@@ -1541,9 +1569,13 @@ impl CombinedExpressionEvaluator<'_> {
                 sub_val,
                 collation.as_deref(),
             );
-            let synthetic = vibesql_ast::Expression::Literal(sub_val.clone());
-            let (tuple_val, sub_val) =
-                self.apply_affinity_for_comparison(tuple_expr, tuple_val, &synthetic, sub_val);
+            let tuple_affinity = self.get_expression_affinity(tuple_expr);
+            let (tuple_val, sub_val) = ExpressionEvaluator::apply_affinity_for_comparison_values(
+                tuple_val,
+                tuple_affinity,
+                sub_val,
+                sub_affinities[idx],
+            );
             tuple_values.push(tuple_val);
             other_values.push(sub_val);
         }

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/correlation.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/correlation.rs
@@ -32,6 +32,20 @@ fn unqualified_column_in_inner_tables(
     })
 }
 
+/// Whether `column` names a rowid pseudo-column (`rowid`, `_rowid_`, `oid`).
+///
+/// A correlated subquery may reference the *outer* table's rowid, e.g.
+/// `(SELECT y FROM d2 WHERE d2.rowid = d1.rowid)`. The outer `d1.rowid` is not a
+/// real column in the outer schema, so `get_column_index` returns `None` and the
+/// naive walk drops it — producing an empty correlation set, an identical cache
+/// key for every outer row, and thus the first row's result for all rows
+/// (rowvalue9 4.tn.4 / 4.tn.6, issue #6045). Rowid correlation refs are tracked
+/// separately and resolved from the outer `Row`'s `row_id` / `row_ids`.
+fn is_rowid_alias(column: &str) -> bool {
+    let c = column.to_ascii_lowercase();
+    c == "rowid" || c == "_rowid_" || c == "oid"
+}
+
 /// Extract correlation values from the current row for correlated subquery caching
 ///
 /// For correlated subqueries, we need to identify which columns from the outer query
@@ -101,7 +115,37 @@ pub(super) fn extract_correlation_values(
                     return None; // Column index out of bounds
                 }
             }
-            None => return None, // Column not found in outer schema
+            None => {
+                // A rowid correlation ref to the outer table isn't a real column,
+                // so it has no schema index — resolve it from the outer row's
+                // tracked row-id instead (issue #6045). Per-table `row_ids` win
+                // for joined outer rows; a single-table outer row uses `row_id`.
+                if is_rowid_alias(&column) {
+                    let rowid = table
+                        .as_deref()
+                        .and_then(|t| {
+                            row.row_ids.as_ref().and_then(|m| m.get(&t.to_lowercase()).copied())
+                        })
+                        .or(row.row_id);
+                    match rowid {
+                        Some(id) => {
+                            let full_name = if let Some(t) = &table {
+                                format!("{}.{}", t, column)
+                            } else {
+                                column.clone()
+                            };
+                            correlation_values
+                                .push((full_name, vibesql_types::SqlValue::Integer(id as i64)));
+                        }
+                        // Correlated on a rowid we can't resolve for this row:
+                        // return None so the caller skips caching rather than
+                        // caching under a colliding key.
+                        None => return None,
+                    }
+                } else {
+                    return None; // Column not found in outer schema
+                }
+            }
         }
     }
 
@@ -326,6 +370,13 @@ fn collect_correlation_refs_from_expr(
                     // Not in subquery's tables, check if in outer schema
                     if outer_schema.get_column_index(Some(table_name), column).is_some() {
                         refs.insert((Some(table_name.to_string()), column.to_string()));
+                    } else if is_rowid_alias(column)
+                        && outer_schema.table_schemas.keys().any(|t| t.canonical() == table_lower)
+                    {
+                        // Outer-table rowid correlation (e.g. `d2.rowid = d1.rowid`
+                        // where d1 is the outer table). Track it so its per-row
+                        // value goes into the cache key (issue #6045).
+                        refs.insert((Some(table_name.to_string()), column.to_string()));
                     }
                 }
             } else {
@@ -375,6 +426,52 @@ fn collect_correlation_refs_from_expr(
         }
         vibesql_ast::Expression::UnaryOp { expr, .. } => {
             collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, database, refs);
+        }
+        // Row-value constructors, conjunctions, and disjunctions are flat lists of
+        // sub-expressions; without recursing into them a correlated column buried
+        // in `(a, b) = (x, y)` (or `a = x AND b = y` normalized to a Conjunction)
+        // is never collected. That produces an empty correlation set and thus an
+        // identical cache key for every outer row, so a correlated scalar subquery
+        // returns the first outer row's result to all rows (issue #6045).
+        vibesql_ast::Expression::RowValueConstructor(children)
+        | vibesql_ast::Expression::Conjunction(children)
+        | vibesql_ast::Expression::Disjunction(children) => {
+            for child in children {
+                collect_correlation_refs_from_expr(
+                    child,
+                    outer_schema,
+                    subquery_tables,
+                    database,
+                    refs,
+                );
+            }
+        }
+        vibesql_ast::Expression::Collate { expr, .. } => {
+            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, database, refs);
+        }
+        vibesql_ast::Expression::IsDistinctFrom { left, right, .. } => {
+            collect_correlation_refs_from_expr(left, outer_schema, subquery_tables, database, refs);
+            collect_correlation_refs_from_expr(
+                right,
+                outer_schema,
+                subquery_tables,
+                database,
+                refs,
+            );
+        }
+        vibesql_ast::Expression::IsTruthValue { expr, .. }
+        | vibesql_ast::Expression::Extract { expr, .. } => {
+            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, database, refs);
+        }
+        vibesql_ast::Expression::Glob { expr, pattern, .. } => {
+            collect_correlation_refs_from_expr(expr, outer_schema, subquery_tables, database, refs);
+            collect_correlation_refs_from_expr(
+                pattern,
+                outer_schema,
+                subquery_tables,
+                database,
+                refs,
+            );
         }
         vibesql_ast::Expression::Function { args, .. }
         | vibesql_ast::Expression::AggregateFunction { args, .. } => {
@@ -564,5 +661,133 @@ fn collect_correlation_refs_from_expr(
         }
         // Literals and other expressions don't contribute to correlation
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::CombinedSchema;
+    use vibesql_ast::{BinaryOperator, Expression, FromClause, SelectItem, SelectStmt};
+
+    fn col(name: &str) -> Expression {
+        Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(name, false))
+    }
+
+    fn outer_schema_xy() -> CombinedSchema {
+        let columns = vec![
+            vibesql_catalog::ColumnSchema {
+                name: "x".to_string(),
+                data_type: vibesql_types::DataType::Integer,
+                nullable: true,
+                default_value: None,
+                generated_expr: None,
+                is_exact_integer_type: false,
+                collation: None,
+            },
+            vibesql_catalog::ColumnSchema {
+                name: "y".to_string(),
+                data_type: vibesql_types::DataType::Integer,
+                nullable: true,
+                default_value: None,
+                generated_expr: None,
+                is_exact_integer_type: false,
+                collation: None,
+            },
+        ];
+        CombinedSchema::from_table(
+            "a2".to_string(),
+            vibesql_catalog::TableSchema::new("a2".to_string(), columns),
+        )
+    }
+
+    fn subquery_with_where(where_clause: Expression) -> SelectStmt {
+        SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list: vec![SelectItem::Expression {
+                expr: Expression::Literal(vibesql_types::SqlValue::Integer(1)),
+                alias: None,
+                source_text: None,
+            }],
+            into_table: None,
+            into_variables: None,
+            from: Some(FromClause::Table {
+                index_hint: None,
+                name: "a1".to_string(),
+                alias: None,
+                column_aliases: None,
+                quoted: false,
+            }),
+            where_clause: Some(where_clause),
+            group_by: None,
+            having: None,
+            window_definitions: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            set_operation: None,
+            values: None,
+        }
+    }
+
+    /// Root Cause #2 (issue #6045): a row-value `(a, b) = (x, y)` WHERE clause
+    /// must have BOTH outer columns (x, y) collected as correlation values.
+    /// Previously `RowValueConstructor` fell through the match and neither was
+    /// collected, producing an identical cache key for every outer row.
+    #[test]
+    fn row_value_where_extracts_both_outer_columns() {
+        let outer = outer_schema_xy();
+        // (a, b) = (x, y): a,b are inner (a1); x,y are outer (a2).
+        let where_clause = Expression::BinaryOp {
+            op: BinaryOperator::Equal,
+            left: Box::new(Expression::RowValueConstructor(vec![col("a"), col("b")])),
+            right: Box::new(Expression::RowValueConstructor(vec![col("x"), col("y")])),
+        };
+        let subquery = subquery_with_where(where_clause);
+
+        // Outer row a2: x=10, y=20.
+        let row = vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Integer(10),
+            vibesql_types::SqlValue::Integer(20),
+        ]);
+
+        let values = extract_correlation_values(&subquery, &row, &outer, None)
+            .expect("correlation values should extract");
+        // Both x and y must be present with their per-row values.
+        assert!(
+            values.iter().any(|(n, v)| n == "x" && *v == vibesql_types::SqlValue::Integer(10)),
+            "x correlation value missing: {:?}",
+            values
+        );
+        assert!(
+            values.iter().any(|(n, v)| n == "y" && *v == vibesql_types::SqlValue::Integer(20)),
+            "y correlation value missing: {:?}",
+            values
+        );
+    }
+
+    /// A conjunction `a = x AND b = y` (the non-row-value equivalent) also
+    /// collects both outer columns — guards the Conjunction arm added alongside
+    /// the RowValueConstructor arm.
+    #[test]
+    fn conjunction_where_extracts_both_outer_columns() {
+        let outer = outer_schema_xy();
+        let eq = |l: Expression, r: Expression| Expression::BinaryOp {
+            op: BinaryOperator::Equal,
+            left: Box::new(l),
+            right: Box::new(r),
+        };
+        let where_clause =
+            Expression::Conjunction(vec![eq(col("a"), col("x")), eq(col("b"), col("y"))]);
+        let subquery = subquery_with_where(where_clause);
+        let row = vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Integer(7),
+            vibesql_types::SqlValue::Integer(9),
+        ]);
+        let values = extract_correlation_values(&subquery, &row, &outer, None)
+            .expect("correlation values should extract");
+        assert!(values.iter().any(|(n, _)| n == "x"));
+        assert!(values.iter().any(|(n, _)| n == "y"));
     }
 }

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/in_subquery.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/in_subquery.rs
@@ -16,7 +16,7 @@ use super::{
     super::super::core::{CombinedExpressionEvaluator, ExpressionEvaluator},
     schema_utils::{
         build_merged_outer_row, build_merged_outer_schema, compute_select_list_column_count,
-        get_subquery_first_column_affinity,
+        get_subquery_column_affinity_at, get_subquery_first_column_affinity,
     },
 };
 use crate::errors::ExecutorError;
@@ -522,6 +522,19 @@ impl CombinedExpressionEvaluator<'_> {
         }
 
         let sql_mode = database.sql_mode();
+
+        // Per-position affinity for IN-subquery comparison (issue #6045).
+        // Each tuple position `i` compares the left element against the
+        // subquery's i-th column, so we coerce with that column's affinity
+        // before the raw comparison. Mirrors the scalar IN-subquery path
+        // which applies `apply_in_subquery_affinity_coercion` keyed off the
+        // subquery column affinity.
+        let left_affinities: Vec<Option<TypeAffinity>> =
+            expr_elements.iter().map(|e| self.get_expression_affinity(e)).collect();
+        let right_affinities: Vec<Option<TypeAffinity>> = (0..expected_columns)
+            .map(|i| get_subquery_column_affinity_at(subquery, i, database))
+            .collect();
+
         // Whether any row compared as UNKNOWN (all non-NULL elements equal,
         // but at least one element comparison involved NULL). Rows that are
         // definitively FALSE (some element definitively unequal) do NOT make
@@ -547,10 +560,23 @@ impl CombinedExpressionEvaluator<'_> {
                     continue;
                 }
 
+                // Apply per-position affinity coercion before comparison (#6045),
+                // using the subquery column's real affinity so a TEXT column vs a
+                // BLOB/NONE subquery column compares by storage class while a
+                // NUMERIC column coerces a TEXT subquery value — matching
+                // SQLite's row-value `=` semantics (rowvalue9 1.6.1).
+                let (coerced_left, coerced_right) =
+                    ExpressionEvaluator::apply_affinity_for_comparison_values(
+                        expr_val.clone(),
+                        left_affinities[i],
+                        subquery_val.clone(),
+                        right_affinities[i],
+                    );
+
                 let eq_result = ExpressionEvaluator::eval_binary_op_static(
-                    expr_val,
+                    &coerced_left,
                     &vibesql_ast::BinaryOperator::Equal,
-                    subquery_val,
+                    &coerced_right,
                     sql_mode.clone(),
                 )?;
 

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs
@@ -253,6 +253,33 @@ pub fn get_subquery_first_column_affinity(
     get_expression_affinity_from_from_clause(expr, &stmt.from, database)
 }
 
+/// Get the type affinity of the subquery's SELECT expression at position `idx`.
+///
+/// This is the per-position sibling of [`get_subquery_first_column_affinity`],
+/// needed by row-value `IN (subquery)` comparisons where each tuple position is
+/// compared against a different subquery column and therefore needs that
+/// column's affinity (issue #6045). Position 0 is equivalent to
+/// `get_subquery_first_column_affinity`.
+///
+/// # Returns
+/// - `Some(TypeAffinity)` if the expression at `idx` is a column reference (or a
+///   CAST/COLLATE thereof) with a determinable affinity.
+/// - `None` if the position is out of range, is a wildcard, or the expression
+///   does not carry a column affinity (e.g. a literal, function call, or an
+///   affinity-stripping expression like `+col`).
+pub fn get_subquery_column_affinity_at(
+    stmt: &vibesql_ast::SelectStmt,
+    idx: usize,
+    database: &vibesql_storage::Database,
+) -> Option<vibesql_types::TypeAffinity> {
+    let item = stmt.select_list.get(idx)?;
+    let expr = match item {
+        vibesql_ast::SelectItem::Expression { expr, .. } => expr,
+        _ => return None, // Wildcards don't have a single per-position affinity
+    };
+    get_expression_affinity_from_from_clause(expr, &stmt.from, database)
+}
+
 /// Get the type affinity of an expression given a FROM clause context
 ///
 /// This resolves column references by looking up the table schema.

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -182,6 +182,67 @@ impl ExpressionEvaluator<'_> {
         }
     }
 
+    /// Apply SQLite affinity rules to a column-vs-column comparison given the
+    /// resolved affinity of each side (issue #6045).
+    ///
+    /// This is the value-level core used by row-value `IN (subquery)`, where the
+    /// right-hand operands are *subquery columns* (their affinity resolved via
+    /// [`schema_utils::get_subquery_column_affinity_at`]) rather than
+    /// expressions available on the current evaluator. It mirrors the
+    /// column-vs-column cases of [`Self::apply_affinity_for_comparison`]:
+    ///
+    /// - A NUMERIC/INTEGER/REAL side coerces a TEXT *value* on the other side to
+    ///   numeric (SQLite datatype3 §4.2 — NUMERIC applied to the other operand).
+    /// - TEXT-vs-NONE (or NONE-vs-NONE, TEXT-vs-TEXT) column comparisons perform
+    ///   NO coercion: they compare by storage class, so `'1'` (TEXT) does not
+    ///   equal `1` (INTEGER stored in a BLOB/NONE column). This is what makes
+    ///   `(a, b) IN (SELECT x, y FROM blob_table)` match SQLite (rowvalue9 1.6.1).
+    ///
+    /// A `None` affinity (a non-column expression such as `+col`, matching
+    /// SQLite's rule that unary `+` strips affinity to NONE) behaves like a real
+    /// NONE-affinity column here: it never triggers TEXT coercion of a numeric on
+    /// the other side, only numeric coercion of a TEXT value against a numeric
+    /// affinity.
+    pub(crate) fn apply_affinity_for_comparison_values(
+        left_val: SqlValue,
+        left_affinity: Option<TypeAffinity>,
+        right_val: SqlValue,
+        right_affinity: Option<TypeAffinity>,
+    ) -> (SqlValue, SqlValue) {
+        let is_numeric_affinity = |a: Option<TypeAffinity>| {
+            matches!(
+                a,
+                Some(TypeAffinity::Numeric)
+                    | Some(TypeAffinity::Integer)
+                    | Some(TypeAffinity::Real)
+            )
+        };
+        let left_numeric = is_numeric_affinity(left_affinity);
+        let right_numeric = is_numeric_affinity(right_affinity);
+
+        // Left numeric affinity vs a TEXT value on the right → coerce the TEXT to
+        // numeric (mirrors apply_affinity_for_comparison Case 5).
+        if left_numeric
+            && !right_numeric
+            && matches!(right_val, SqlValue::Varchar(_) | SqlValue::Character(_))
+        {
+            return (left_val, Self::try_coerce_string_to_numeric(&right_val));
+        }
+
+        // Right numeric affinity vs a TEXT value on the left → coerce (Case 6).
+        if right_numeric
+            && !left_numeric
+            && matches!(left_val, SqlValue::Varchar(_) | SqlValue::Character(_))
+        {
+            return (Self::try_coerce_string_to_numeric(&left_val), right_val);
+        }
+
+        // TEXT vs NONE, NONE vs NONE, TEXT vs TEXT: no coercion, storage-class
+        // comparison (SQLite type ordering). A numeric value compared against a
+        // TEXT/NONE-affinity column stays as-is, so TEXT '1' != INTEGER 1.
+        (left_val, right_val)
+    }
+
     /// Apply SQLite affinity rules for comparisons.
     ///
     /// When comparing a TEXT-affinity column to an INTEGER literal, SQLite:
@@ -1710,5 +1771,106 @@ impl ExpressionEvaluator<'_> {
                 Ok(super::super::core::values_are_distinct(&left_val, &right_val))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod affinity_values_tests {
+    use super::ExpressionEvaluator;
+    use vibesql_types::{SqlValue, TypeAffinity};
+
+    // Regression tests for issue #6045: the value-level affinity core used by
+    // row-value `IN (subquery)` and `= (SELECT ...)` comparisons. It must match
+    // SQLite's row-value comparison semantics where a NONE-affinity (BLOB)
+    // subquery column suppresses TEXT coercion.
+
+    fn text(s: &str) -> SqlValue {
+        SqlValue::Varchar(arcstr::ArcStr::from(s))
+    }
+
+    #[test]
+    fn text_column_vs_none_blob_integer_does_not_coerce() {
+        // `a TEXT ('1') IN (SELECT x BLOB (1))`: '1' must NOT equal 1 (rowvalue9
+        // 1.6.1 / 2.3). NONE-affinity right side → no coercion.
+        let (l, r) = ExpressionEvaluator::apply_affinity_for_comparison_values(
+            text("1"),
+            Some(TypeAffinity::Text),
+            SqlValue::Integer(1),
+            Some(TypeAffinity::None),
+        );
+        assert_eq!(l, text("1"));
+        assert_eq!(r, SqlValue::Integer(1));
+        assert_ne!(l, r);
+    }
+
+    #[test]
+    fn numeric_column_vs_none_text_coerces_text_to_numeric() {
+        // `b INTEGER (4) = y BLOB ('4')`: NUMERIC affinity coerces the TEXT
+        // value '4' to 4, so they compare equal (rowvalue9 4.tn.1 position 1).
+        let (l, r) = ExpressionEvaluator::apply_affinity_for_comparison_values(
+            SqlValue::Integer(4),
+            Some(TypeAffinity::Integer),
+            text("4"),
+            Some(TypeAffinity::None),
+        );
+        assert_eq!(l, SqlValue::Integer(4));
+        assert_eq!(r, SqlValue::Integer(4));
+        assert_eq!(l, r);
+    }
+
+    #[test]
+    fn numeric_left_vs_none_right_numeric_stays() {
+        // NUMERIC vs NONE where the NONE value is already an integer: no change.
+        let (l, r) = ExpressionEvaluator::apply_affinity_for_comparison_values(
+            SqlValue::Integer(3),
+            Some(TypeAffinity::Numeric),
+            SqlValue::Integer(3),
+            Some(TypeAffinity::None),
+        );
+        assert_eq!(l, SqlValue::Integer(3));
+        assert_eq!(r, SqlValue::Integer(3));
+    }
+
+    #[test]
+    fn none_vs_none_text_and_int_do_not_coerce() {
+        // Two BLOB columns: '3' (text) vs 3 (int) compare by storage class.
+        let (l, r) = ExpressionEvaluator::apply_affinity_for_comparison_values(
+            text("3"),
+            Some(TypeAffinity::None),
+            SqlValue::Integer(3),
+            Some(TypeAffinity::None),
+        );
+        assert_eq!(l, text("3"));
+        assert_eq!(r, SqlValue::Integer(3));
+        assert_ne!(l, r);
+    }
+
+    #[test]
+    fn unary_plus_strips_affinity_to_none() {
+        // `+col` yields affinity None (SQLite strips affinity). A None-affinity
+        // left vs a TEXT subquery value must not numeric-coerce, and a None
+        // left vs numeric right must not TEXT-coerce — behaves like NONE.
+        // Here: `(+c) INTEGER-valued (2) IN (SELECT x TEXT '2')` — +c has None
+        // affinity, x is TEXT, neither numeric affinity → no coercion, 2 != '2'.
+        let (l, r) = ExpressionEvaluator::apply_affinity_for_comparison_values(
+            SqlValue::Integer(2),
+            None, // +c strips affinity
+            text("2"),
+            Some(TypeAffinity::Text),
+        );
+        assert_eq!(l, SqlValue::Integer(2));
+        assert_eq!(r, text("2"));
+        assert_ne!(l, r);
+    }
+
+    #[test]
+    fn text_vs_text_no_coercion() {
+        let (l, r) = ExpressionEvaluator::apply_affinity_for_comparison_values(
+            text("4"),
+            Some(TypeAffinity::Text),
+            text("4"),
+            Some(TypeAffinity::None),
+        );
+        assert_eq!(l, r);
     }
 }

--- a/crates/vibesql-executor/src/evaluator/expressions/subqueries.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/subqueries.rs
@@ -693,6 +693,22 @@ impl ExpressionEvaluator<'_> {
             return Ok(SqlValue::Boolean(negated));
         }
 
+        // Per-position affinity for IN-subquery comparison (issue #6045).
+        // Each tuple position `i` compares the left element against the
+        // subquery's i-th column, so we need the affinity of *that* column
+        // (not just the first). Mirrors the scalar IN-subquery path
+        // (`eval_in_subquery`) which applies `apply_in_subquery_affinity_coercion`
+        // keyed off `get_subquery_first_column_affinity`.
+        let left_affinities: Vec<Option<vibesql_types::TypeAffinity>> =
+            expr_elements.iter().map(|e| self.get_expression_affinity(e)).collect();
+        let right_affinities: Vec<Option<vibesql_types::TypeAffinity>> = (0..expected_columns)
+            .map(|i| {
+                crate::evaluator::combined::subqueries::schema_utils::get_subquery_column_affinity_at(
+                    subquery, i, database,
+                )
+            })
+            .collect();
+
         // Whether any row compared as UNKNOWN (all non-NULL elements equal,
         // but at least one element comparison involved NULL). Rows that are
         // definitively FALSE (some element definitively unequal) do NOT make
@@ -720,11 +736,25 @@ impl ExpressionEvaluator<'_> {
                     continue;
                 }
 
+                // Apply per-position affinity coercion before comparison
+                // (issue #6045), using the subquery column's real affinity so a
+                // TEXT column vs a BLOB/NONE subquery column compares by storage
+                // class (no coercion), while a NUMERIC column vs a TEXT subquery
+                // value coerces the TEXT to numeric — matching SQLite's row-value
+                // `=` semantics (rowvalue9 1.6.1).
+                let (coerced_left, coerced_right) =
+                    ExpressionEvaluator::apply_affinity_for_comparison_values(
+                        expr_val.clone(),
+                        left_affinities[i],
+                        subquery_val.clone(),
+                        right_affinities[i],
+                    );
+
                 // Compare values
                 let eq_result = self.eval_binary_op(
-                    expr_val,
+                    &coerced_left,
                     &vibesql_ast::BinaryOperator::Equal,
-                    subquery_val,
+                    &coerced_right,
                 )?;
 
                 match eq_result {


### PR DESCRIPTION
## Summary

Row-value comparisons against subqueries in VibeSQL skipped SQLite's type-affinity rules and mis-cached correlated scalar subqueries, producing 42 `rowvalue9.test` failures. This fixes the two curator-verified root causes, taking `rowvalue9.test` from **51/93 to 73/93** (42 → 20 failures) with no regressions.

## Changes

**Root Cause #1 — IN-subquery affinity gap**
- Added `get_subquery_column_affinity_at` (per-position sibling of `get_subquery_first_column_affinity`) in `schema_utils.rs`.
- Added `ExpressionEvaluator::apply_affinity_for_comparison_values` — a value-level affinity core that mirrors SQLite's row-value `=` semantics: a NUMERIC/INTEGER/REAL side coerces a TEXT value; a NONE-affinity (BLOB) subquery column suppresses TEXT coercion (so `'1'` TEXT ≠ `1` INTEGER-in-BLOB). A `None` affinity (`+col`) behaves like NONE.
- Routed `eval_row_value_in_subquery` (both the plain `ExpressionEvaluator` and the combined-evaluator mirror) through it per tuple position.
- Routed the row-value `= (SELECT ...)` path (`eval_row_value_tuple_and_subquery`) through the same core using the subquery columns' real affinities, and taught the combined `get_expression_affinity` to resolve a `ScalarSubquery` to its first result column's affinity, so `text_col = (SELECT blob_int_col)` no longer wrongly coerces.

**Root Cause #2 — correlated-subquery caching**
- `collect_correlation_refs_from_expr` never recursed into `RowValueConstructor` / `Conjunction` / `Disjunction` (nor `Collate` / `IsDistinctFrom` / `IsTruthValue` / `Glob` / `Extract`), so a `(a,b) = (x,y)` WHERE clause produced an empty correlation set → an identical cache key for every outer row → every row got the first row's result. Added the missing arms.
- Resolved outer-table `rowid` correlation refs from the row's tracked `row_id` / `row_ids` (they have no schema column index), so rowid-correlated subqueries key the cache per row.

**Tests**
- `apply_affinity_for_comparison_values`: TEXT-vs-BLOB, NUMERIC-vs-BLOB, NONE-vs-NONE, unary-plus stripping.
- `extract_correlation_values`: `(a,b)=(x,y)` and `a=x AND b=y` collect both outer columns.
- `is_correlated`: a 2-column row-value WHERE clause is detected as correlated.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| §4 `.1/.2` affinity variants pass | ✅ | `4.1.1`–`4.8.2` now pass (were 16 failures) |
| `.3/.5` sub-tests not regressed | ✅ | still passing |
| `1.6.1` (IN-subquery affinity) | ✅ | passes; repro `(a,c) IN (SELECT x,y)` → `{3 4}` |
| `1.1.2`, `1.5.2`, `1.5.3` (row-value WHERE caching) | ✅ | pass; repro `(SELECT rowid FROM a1 WHERE (a,b)=(x,y))` → `1, 2` |
| `3.5`, `3.6` (`= (SELECT ...)` affinity) | ✅ | now pass |
| No regressions | ✅ | rowvalue2 3834/3834, rowvalue7 5/8, rowvalueA 10/13, json101 267/10, json102 309/309 (all unchanged vs main) |
| `cargo test -p vibesql-executor` | ✅ | 3445 passed, 0 failed |

## Residual failures (20) — all pre-existing, unrelated to the two root causes

Each was reproduced on `main` (commit `3a77f8f68`) to confirm it is not introduced here:

- **`4.tn.4`, `4.tn.6` (16 tests)** — a correlated subquery's reference to the **outer table's `rowid`** (`WHERE d2.rowid = d1.rowid`) is not resolved during subquery *execution*: inside the subquery `d1.rowid` evaluates as a constant, so every row returns the first row's value. This reproduces on `main` even with a plain-column correlation (`d2.r = d1.rowid`), independent of row-values and affinity. The correlation-*extraction* side is fixed here (distinct cache keys), but the *execution*-side outer-rowid resolution is a separate SelectExecutor defect and needs its own issue.
- **`5.2`, `5.3`** — scalar (non-row-value) `rowid IN (SELECT +c / 0+c FROM e1)` in a **WHERE** clause returns empty. The SELECT-list form (`rowid IN (...)` as a value) evaluates correctly, so this is a WHERE-path `rowid IN (subquery)` filter bug, unrelated to row-values. Reproduces on `main`.
- **`8.2`** — expects the prepare-time arity error `sub-select returns 2 columns - expected 1` for `... WHERE (a,b) > (SELECT 2 IN (SELECT 2,2), 2)`. The table is empty, so VibeSQL's runtime validation never fires. This requires prepare-time subquery arity checking, a structural change out of Stage 1's scope.
- **`1.6.2`** — an unordered `EXISTS` join. The result **values** are correct (`3 14 15 92` each twice); only the join **iteration order** differs from SQLite (`3 3 14 14 …` vs `3 14 … 3 14 …`). Pre-existing nested-loop ordering artifact on `main`.

## Test Plan

- `make test-tcl-file FILE=rowvalue9.test` → 73/93 (was 51/93).
- `make test-tcl-file FILE={rowvalue2,rowvalue7,rowvalueA,json101,json102}.test` → baselines unchanged.
- `cargo test -p vibesql-executor` → green (3445 passed).
- Manual differential vs `sqlite3`: affinity repro `(a,c) IN (SELECT x,y FROM d2)` → `{3 4}`; caching repro `(SELECT rowid FROM a1 WHERE (a,b)=(x,y))` → `1, 2`; NULL-in-RHS → NULL; empty subquery IN → FALSE / NOT IN → TRUE.

Closes #6045