### PR TITLE
test(tcl): record atof1 real2hex loop as a discoverable partial-file skip

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3088,6 +3088,25 @@ array set vibesql_skip_files {
     strict2 "Tests writable_schema + rootpage aliasing to plant an inconsistent schema that strict-mode validation must catch. Requires the writable_schema B-tree manipulation path that is out-of-scope for VibeSQL. (#5844.)"
 }
 
+# Test FILES that are only PARTIALLY skipped — a documented subset of the file's
+# tests is auto-skipped (see the regex detectors in vibesql_skip_test below),
+# but the rest of the file runs normally and its results (pass OR fail) are kept
+# visible. Unlike vibesql_skip_files (whole-file skips), these files CANNOT be
+# skipped wholesale without discarding legitimate SQL coverage.
+#
+# This array is a DISCOVERABILITY record, not an enforcement mechanism: the
+# actual skipping is performed by the regex detectors in vibesql_skip_test.
+# It exists so a skip audit (or a `grep -n <file> tester_vibesql.tcl`) can find
+# an intentional, reasoned partial-skip by FILE NAME — mirroring how the
+# vibesql_skip_files array makes whole-file skips (e.g. intreal) discoverable —
+# rather than only by grepping the regex-detector source. scripts/verify_skips.py
+# parses this array and reports it under the PARTIAL_FILE category.
+# Format: file_basename -> reason (which subset is skipped, why, and where enforced)
+variable vibesql_partial_skip_files
+array set vibesql_partial_skip_files {
+    atof1 "PARTIAL: the ~39,998 dynamically-named atof1-1.\$i.1/.2 loop tests are auto-skipped because they call real2hex()/hex2real() — SQLite C-test-harness functions (test_func.c) that expose raw IEEE-754 bit patterns and are unreachable from the SQL CLI. Same harness-artifact class as the intreal whole-file skip, but atof1 CANNOT be a whole-file skip: the ~7 non-loop atof1-2.x/atof-3.x tests are legitimate do_execsql_test coverage that must keep running. Enforced by the real2hex()/hex2real() regex detectors in vibesql_skip_test (search 'real2hex' below), NOT by a whole-file skip. Current non-loop status: atof1-2.40/atof-3.2/atof-3.3 pass; atof1-2.10/2.20/2.30 (UTF16be substr) and atof-3.1 (large-literal REAL precision) are REAL open engine bugs, tracked in #6065 — they must keep running and reporting 'failed', never reclassified as skipped."
+}
+
 # Tests to skip because they test SQLite-specific behavior that VibeSQL
 # intentionally does not implement or implements differently.
 # Format: test_name -> reason
@@ -5146,6 +5165,13 @@ proc uses_sqlite_internals {script} {
     # VibeSQL's user-facing float formatting is correct (SELECT 1.0e300, 0.1,
     # 2.0/3.0 => 1.0e+300, 0.1, 0.666666666666667 — matching SQLite), so these
     # are harness artifacts, the same class as the skipped intreal() tests.
+    #
+    # This is a PARTIAL-file skip, not a whole-file skip: only the atof1-1.$i.1/.2
+    # loop tests match here; the ~7 non-loop atof1-2.x/atof-3.x tests keep running.
+    # The intent is recorded discoverably by FILE NAME in the vibesql_partial_skip_files
+    # array above (search 'atof1'). The atof1-2.10/2.20/2.30 and atof-3.1 non-loop
+    # tests that currently FAIL are REAL engine bugs tracked in #6065 — they are
+    # deliberately left visible here and must NOT be reclassified as skipped.
     if {[regexp {real2hex[[:space:]]*\(} $script]} {
         return [list 1 "uses real2hex() (SQLite test function, test_func.c)"]
     }

--- a/scripts/verify_skips.py
+++ b/scripts/verify_skips.py
@@ -49,6 +49,39 @@ def parse_skip_list(shim_content: str) -> dict:
     return skips
 
 
+def parse_partial_skip_files(shim_content: str) -> dict:
+    """Extract partial-file documented-skip entries from the shim file.
+
+    These are files (keyed by basename) where a documented subset of tests is
+    auto-skipped by a regex detector while the rest of the file keeps running.
+    They are recorded in the vibesql_partial_skip_files array purely for
+    discoverability (audit-by-file-name); the actual skipping is done elsewhere,
+    so we only report them here rather than attempting to unskip-and-rerun.
+    """
+    partial = {}
+
+    match = re.search(
+        r'array set vibesql_partial_skip_files \{(.*?)\n\}',
+        shim_content,
+        re.DOTALL,
+    )
+    if not match:
+        # Not an error: the array is optional.
+        return partial
+
+    section = match.group(1)
+
+    # Each entry: file_basename "reason" — reason may contain escaped chars but
+    # no unescaped double-quote, matching the TCL array literal convention.
+    pattern = r'^\s*([a-zA-Z0-9_.-]+)\s+"([^"]+)"'
+    for line in section.split('\n'):
+        m = re.match(pattern, line.strip())
+        if m:
+            partial[m.group(1)] = m.group(2)
+
+    return partial
+
+
 def get_test_file(test_name: str) -> str:
     """Determine which test file contains a test based on naming convention."""
     # Test names follow pattern: filename-N.N or filename-N.N.N
@@ -220,6 +253,11 @@ def main():
     skips = parse_skip_list(shim_content)
     print(f"Found {len(skips)} skip entries")
 
+    # Parse partial-file documented skips (discoverability records; not rerun-verified)
+    partial_files = parse_partial_skip_files(shim_content)
+    if partial_files:
+        print(f"Found {len(partial_files)} partial-file documented skip(s)")
+
     # Categorize skips
     categories = categorize_skips(skips)
 
@@ -227,6 +265,12 @@ def main():
         print("\nSkip categories:")
         for cat, tests in sorted(categories.items(), key=lambda x: -len(x[1])):
             print(f"  {cat}: {len(tests)} tests")
+        if partial_files:
+            print(f"  PARTIAL_FILE: {len(partial_files)} files (documented per-test/regex subset skips)")
+            for fname, reason in sorted(partial_files.items()):
+                # Show a truncated reason so the record is auditable at a glance.
+                summary = reason if len(reason) <= 100 else reason[:97] + "..."
+                print(f"    - {fname}: {summary}")
         return 0
 
     # Determine which tests to check


### PR DESCRIPTION
## Summary

The atof1.test real2hex()/hex2real() loop (~39,998 tests) is already correctly auto-skipped by a regex detector in the TCL shim, but that skip was only discoverable by grepping the regex source — it did **not** appear in any skip-list array the way whole-file skips (e.g. `intreal`) do. This PR adds a discoverable, file-name-keyed documented-skip record for atof1 without changing the skip mechanism or any test outcome.

A whole-file skip (the `intreal` `vibesql_skip_files` convention) cannot be reused here: the loop tests are dynamically named (`atof1-1.$i.1/.2` inside a `for` loop), and a whole-file skip would discard the ~7 legitimate non-loop `atof1-2.x`/`atof-3.x` tests. So the record is a new `vibesql_partial_skip_files` array — a discoverability layer that documents *which* subset is skipped, *why*, and *where* it is enforced, while the actual skipping stays regex-based.

## Changes

- **`scripts/tester_vibesql.tcl`**: added a `vibesql_partial_skip_files` array (adjacent to `vibesql_skip_files`) with an `atof1` entry. The reason names the harness-artifact class (SQLite C-test-harness `real2hex`/`hex2real`, same class as `intreal`), states that the loop must stay a partial (regex) skip rather than a whole-file skip, and cross-references **#6065** for the 4 non-loop tests that genuinely fail. Strengthened the existing `real2hex`/`hex2real` regex-detector comment to point back to the array and #6065.
- **`scripts/verify_skips.py`**: added `parse_partial_skip_files()` and reporting under a new `PARTIAL_FILE` category in `--list-categories`, so a skip audit surfaces the atof1 record without reading the regex source. The array is optional (absence is not an error).

No change to the regex matching logic and no change to any other file's skip handling.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| atof1 numbers unchanged (3 pass, 4 fail, loop skipped) | ✅ | `make test-tcl-file FILE=atof1.test` (fresh release build): `Tests passed: 3`, `Tests failed: 4`, `Tests skipped: 39998` |
| 4 real failures NOT reclassified as skipped/passing | ✅ | Failed tests remain `atof1-2.10/2.20/2.30`, `atof-3.1` — unchanged |
| Skip record discoverable by file name + carries reason + #6065 xref | ✅ | `grep -n atof1 scripts/tester_vibesql.tcl` surfaces the `vibesql_partial_skip_files` entry (reason + #6065), mirroring `grep -n intreal` |
| verify_skips.py passes (and reports the documented auto-skip) | ✅ | `python3 scripts/verify_skips.py --list-categories` exits 0 and prints `PARTIAL_FILE: 1 files` with the atof1 entry |
| No other file's handling changes | ✅ | `git diff --stat` shows only `scripts/tester_vibesql.tcl` and `scripts/verify_skips.py` |

## Test Plan

- Fresh release binary rebuilt in the worktree (`cargo build --release --bin vibesql`) before testing.
- `make test-tcl-file FILE=atof1.test` → 3 passed / 4 failed / 39998 skipped (unchanged).
- `python3 scripts/verify_skips.py --list-categories` → exit 0, PARTIAL_FILE category lists atof1.
- TCL array literal validated by parsing (`atof1` key present, 844-char reason, contains `#6065`).
- `git diff --stat` confirms only the two intended files changed.

Closes #6040