### PR TITLE
fix(executor): let a real view shadow the synthetic pragma_compile_options table

### DIFF
--- a/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
@@ -234,7 +234,14 @@ fn compute_single_select_column_count(
                     continue;
                 }
                 // #6019: pragma_compile_options eponymous system table.
-                if is_pragma_compile_options_table(qualifier) {
+                // #6030/#6061: a real table or a real view of the same name
+                // takes precedence over the synthetic table, so only report the
+                // synthetic single-column shape when neither exists. This keeps
+                // the wildcard column count consistent with `execute_table_scan`.
+                if is_pragma_compile_options_table(qualifier)
+                    && database.get_table(qualifier).is_none()
+                    && database.catalog.get_view(qualifier).is_none()
+                {
                     count += get_pragma_compile_options_table_schema().columns.len();
                     continue;
                 }
@@ -282,7 +289,14 @@ fn count_columns_in_from_clause(
                 return Ok(get_sqlite_schema_table_schema().columns.len());
             }
             // #6019: pragma_compile_options eponymous system table.
-            if is_pragma_compile_options_table(name) {
+            // #6030/#6061: a real table or a real view of the same name takes
+            // precedence over the synthetic table, so only report the synthetic
+            // single-column shape when neither exists. This keeps the wildcard
+            // column count consistent with `execute_table_scan`.
+            if is_pragma_compile_options_table(name)
+                && database.get_table(name).is_none()
+                && database.catalog.get_view(name).is_none()
+            {
                 return Ok(get_pragma_compile_options_table_schema().columns.len());
             }
             // Check for views before regular tables

--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -396,11 +396,18 @@ pub(crate) fn execute_table_scan(
     //
     // A real user table of the same name takes precedence (#6030): SQLite's
     // eponymous virtual tables are shadowed by a same-named real table, and
-    // `pragma_*` names are not reserved at CREATE TABLE time. Probe the catalog
-    // first (case-insensitive, matching `is_pragma_compile_options_table`'s
-    // folding) and only fall through to the synthetic zero-row table when no
-    // real table exists.
-    if is_pragma_compile_options_table(table_name) && database.get_table(table_name).is_none() {
+    // `pragma_*` names are not reserved at CREATE TABLE time. A real view of
+    // the same name likewise wins (#6061): `CREATE VIEW pragma_compile_options`
+    // is allowed and SQLite resolves the view over the eponymous virtual table.
+    // Probe the catalog first (case-insensitive, matching
+    // `is_pragma_compile_options_table`'s folding, which `get_table`/`get_view`
+    // share) and only fall through to the synthetic zero-row table when neither
+    // a real table nor a real view exists. The view-resolution branch below
+    // then handles the view; keeping this guard in sync avoids shadowing it.
+    if is_pragma_compile_options_table(table_name)
+        && database.get_table(table_name).is_none()
+        && database.catalog.get_view(table_name).is_none()
+    {
         let result = execute_pragma_compile_options_query()?;
         let table_schema = get_pragma_compile_options_table_schema();
 

--- a/crates/vibesql-executor/src/tests/pragma_compile_options_shadowing_tests.rs
+++ b/crates/vibesql-executor/src/tests/pragma_compile_options_shadowing_tests.rs
@@ -1,19 +1,22 @@
-//! Tests for `pragma_compile_options` synthetic-table shadowing precedence (#6030)
+//! Tests for `pragma_compile_options` synthetic-table shadowing precedence
+//! (#6030 real tables, #6061 real views)
 //!
 //! `pragma_compile_options` is an eponymous system table VibeSQL synthesizes
 //! (single `compile_options TEXT` column, zero rows). Because `pragma_*` names
-//! are not reserved at `CREATE TABLE` time, a user may create a real table of
-//! the same name. In that case the real table must take precedence for
-//! `SELECT` (matching SQLite, where an eponymous virtual table is shadowed by a
-//! same-named real table). Once the real table is dropped, the synthetic table
-//! re-engages.
+//! are not reserved at `CREATE TABLE`/`CREATE VIEW` time, a user may create a
+//! real table or a real view of the same name. In that case the real object
+//! must take precedence for `SELECT` (matching SQLite, where an eponymous
+//! virtual table is shadowed by a same-named real table or view). Once the
+//! real object is dropped, the synthetic table re-engages.
 
 #[cfg(test)]
 mod tests {
     use vibesql_parser::Parser;
     use vibesql_storage::Database;
 
-    use crate::{CreateTableExecutor, DropTableExecutor, InsertExecutor, SelectExecutor};
+    use crate::{
+        CreateTableExecutor, DropTableExecutor, InsertExecutor, SelectExecutor, ViewExecutor,
+    };
 
     fn create_real_pragma_table(db: &mut Database) {
         let sql = "CREATE TABLE pragma_compile_options (x INTEGER)";
@@ -22,6 +25,24 @@ mod tests {
             CreateTableExecutor::execute(&create_stmt, db).expect("Failed to create table");
         } else {
             panic!("Expected CreateTable statement");
+        }
+    }
+
+    fn create_view(db: &mut Database, sql: &str) {
+        let stmt = Parser::parse_sql(sql).expect("Failed to parse CREATE VIEW");
+        if let vibesql_ast::Statement::CreateView(create_stmt) = stmt {
+            ViewExecutor::execute_create_view(&create_stmt, db).expect("Failed to create view");
+        } else {
+            panic!("Expected CreateView statement");
+        }
+    }
+
+    fn drop_view(db: &mut Database, sql: &str) {
+        let stmt = Parser::parse_sql(sql).expect("Failed to parse DROP VIEW");
+        if let vibesql_ast::Statement::DropView(drop_stmt) = stmt {
+            ViewExecutor::execute_drop_view(&drop_stmt, db).expect("Failed to drop view");
+        } else {
+            panic!("Expected DropView statement");
         }
     }
 
@@ -120,5 +141,73 @@ mod tests {
         // Synthetic fallback re-engages: zero rows again.
         let rows = run_select(&db, "SELECT * FROM pragma_compile_options");
         assert_eq!(rows.len(), 0, "after DROP, the synthetic zero-row table must return");
+    }
+
+    /// A real view named `pragma_compile_options` wins over the synthetic
+    /// eponymous table. This is the core repro from #6061: SQLite allows
+    /// `CREATE VIEW pragma_compile_options` and resolves the view for `SELECT`.
+    #[test]
+    fn test_real_view_shadows_synthetic() {
+        let mut db = Database::new();
+        create_view(&mut db, "CREATE VIEW pragma_compile_options AS SELECT 42 AS x");
+
+        let rows = run_select(&db, "SELECT * FROM pragma_compile_options");
+
+        // View wins: one row with value 42, not the synthetic zero-row table.
+        assert_eq!(rows.len(), 1, "expected the view's row, got the synthetic table");
+        assert_eq!(rows[0].values.len(), 1);
+        assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Integer(42));
+    }
+
+    /// Case-insensitive naming: the real view wins even when referenced with
+    /// different casing than it was created with. `get_view` folds identifiers
+    /// the same way `is_pragma_compile_options_table` does.
+    #[test]
+    fn test_real_view_shadows_synthetic_case_insensitive() {
+        let mut db = Database::new();
+        create_view(&mut db, "CREATE VIEW pragma_compile_options AS SELECT 7 AS x");
+
+        let rows = run_select(&db, "SELECT * FROM PRAGMA_COMPILE_OPTIONS");
+        assert_eq!(rows.len(), 1, "case-insensitive reference should still hit the real view");
+        assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Integer(7));
+    }
+
+    /// Dropping the real view re-engages the synthetic fallback.
+    #[test]
+    fn test_drop_real_view_reverts_to_synthetic() {
+        let mut db = Database::new();
+        create_view(&mut db, "CREATE VIEW pragma_compile_options AS SELECT 99 AS x");
+
+        // View wins while it exists.
+        let rows = run_select(&db, "SELECT * FROM pragma_compile_options");
+        assert_eq!(rows.len(), 1);
+
+        // Drop it.
+        drop_view(&mut db, "DROP VIEW pragma_compile_options");
+
+        // Synthetic fallback re-engages: zero rows again.
+        let rows = run_select(&db, "SELECT * FROM pragma_compile_options");
+        assert_eq!(rows.len(), 0, "after DROP VIEW, the synthetic zero-row table must return");
+    }
+
+    /// A multi-column view exercises the `validation.rs` `SELECT *` column-count
+    /// path (the second callsite fixed in #6061): the wildcard must expand to
+    /// the view's column count, not the synthetic single-column shape, so the
+    /// returned rows carry the view's full column set with no count mismatch.
+    #[test]
+    fn test_multi_column_view_shadows_synthetic_wildcard() {
+        let mut db = Database::new();
+        create_view(&mut db, "CREATE VIEW pragma_compile_options AS SELECT 1 AS a, 2 AS b, 3 AS c");
+
+        let rows = run_select(&db, "SELECT * FROM pragma_compile_options");
+        assert_eq!(rows.len(), 1, "expected the view's single row");
+        assert_eq!(
+            rows[0].values.len(),
+            3,
+            "wildcard must expand to the view's 3 columns, not the synthetic 1-column shape"
+        );
+        assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Integer(1));
+        assert_eq!(rows[0].values[1], vibesql_types::SqlValue::Integer(2));
+        assert_eq!(rows[0].values[2], vibesql_types::SqlValue::Integer(3));
     }
 }


### PR DESCRIPTION
## Summary

`CREATE VIEW pragma_compile_options AS SELECT 42 AS x; SELECT * FROM pragma_compile_options;` returned the synthetic zero-row `compile_options` table instead of the view's row. SQLite 3.51 allows the `CREATE VIEW` (`pragma_*` names are not reserved) and resolves the view for `SELECT`, so VibeSQL now does too.

The #6058 guard that lets a real *table* win over the synthetic eponymous table only probed for real tables (`database.get_table(...).is_none()`), so a same-named *view* was still shadowed. This PR extends the guard to also require the absence of a real view, and fixes the parallel `SELECT *` column-count validation sites so wildcard column counts stay consistent with the actual scan output.

Precedence is now: **real table > real view > synthetic table**.

## Changes

- `crates/vibesql-executor/src/select/scan/table.rs` — extend the `execute_table_scan` synthetic-dispatch guard (~line 403) with `&& database.catalog.get_view(table_name).is_none()`, letting execution fall through to the view-resolution branch later in the same function.
- `crates/vibesql-executor/src/select/executor/nonagg/validation.rs` — add the same real-table + real-view precedence to both `is_pragma_compile_options_table` dispatches (the `QualifiedWildcard` `table.*` site and the `count_columns_in_from_clause` bare-`*` site). These previously lacked even the #6058 real-table guard, so a multi-column view would have mis-counted columns.
- `crates/vibesql-executor/src/tests/pragma_compile_options_shadowing_tests.rs` — add 4 view-shadowing tests mirroring the #6058 table tests.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `CREATE VIEW pragma_compile_options ...; SELECT *` returns the view's row | ✅ | Release binary returns `42`; `test_real_view_shadows_synthetic` |
| A real table still wins (per #6058) | ✅ | Binary returns table row `5`; all 5 #6058 tests pass unmodified |
| Synthetic zero-row fallback when neither exists | ✅ | Binary returns zero-row `compile_options`; `test_synthetic_fallback_*` |
| Dropping the view re-engages synthetic fallback | ✅ | `test_drop_real_view_reverts_to_synthetic` |
| Case-insensitive view reference resolves to the view | ✅ | `test_real_view_shadows_synthetic_case_insensitive` (`PRAGMA_COMPILE_OPTIONS`) |
| `SELECT *` column-count consistent for a shadowing view | ✅ | Binary shows 3-column view under `a,b,c`; `test_multi_column_view_shadows_synthetic_wildcard` |
| All 5 existing #6058 regression tests pass | ✅ | `cargo test -p vibesql-executor pragma_compile_options` |

## Test Plan

- `cargo test -p vibesql-executor pragma_compile_options` — 9 shadowing tests pass (5 existing #6058 + 4 new view tests).
- `cargo test -p vibesql-executor` — 5606 passed, 0 failed.
- Release build (`cargo build --release --bin vibesql`) + manual repro of view-wins, multi-column-view, table-wins, and synthetic-fallback cases.
- TCL conformance on the release build: `json101` 277/277, `json102` 309/309 (unchanged, `json101-21.1` unregressed).
- `cargo fmt` and `cargo clippy -p vibesql-executor` clean on the three touched files.

Closes #6061