### PR TITLE
docs(tcl): record fuzz.test 33-failure classification as tracked-not-skipped

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -4738,6 +4738,46 @@ array set vibesql_skip_tests {
     indexexpr2-10.0 "Parser gap: 'IN'-clause form in this expression-index context is not parsed ('near \"IN\": syntax error') (out of scope for #5695)."
 }
 
+# -----------------------------------------------------------------------------
+# fuzz.test residual classification (#6041) — DO NOT SKIP-LIST THESE.
+#
+# The fuzz2-*/fuzz4-* entries in vibesql_skip_tests above are whole-file-differs
+# skips for the SIBLING files fuzz2.test / fuzz4.test. The DIFFERENT file
+# fuzz.test (35,031 tests, srand(0) deterministic corpus) has 33 residual
+# failures as of the #6041 classification pass, and — unlike fuzz2/fuzz4 —
+# EVERY ONE of those 33 is a REAL engine gap, not a harness artifact. Per the
+# #5779 epic's honest-framing rule, real failures are recorded by an OPEN
+# TRACKING ISSUE, never by a skip entry: they deliberately keep running and
+# reporting "failed" until the underlying engine bugs are fixed. This block is
+# the durable, greppable record (the #6066 partial-skip documentation
+# convention, applied here to a NON-skip: honest failures tracked by issue, not
+# silenced). NO vibesql_skip_tests entry is added for any of the 33.
+#
+# Canonical fuzz.test count on a QUIET machine (fresh release build):
+#   35031 run / 34998 pass / 33 fail / 0 skip.
+# (A LOADED machine can add a spurious 34th failure — fuzz-7.2.1267 fails with
+# "Too many open files in system (os error 23)" when the trial-DB checkpoint
+# copy path exhausts the system fd table; that is a transient machine-load
+# artifact, NOT one of the 33, and does not reproduce on a quiet machine.)
+#
+# The 33 real failures, 4 buckets (test name -> class -> tracking issue):
+#   Bucket A — GLOB in the simple (scalar) evaluator, non-literal operands (7)
+#     fuzz-3.2.1965, fuzz-3.2.2663, fuzz-3.2.2863, fuzz-4.2.586,
+#     fuzz-4.2.1633, fuzz-4.2.1896, fuzz-4.2.4455
+#     -> #6070  ("Unexpected expression in simple evaluator: Glob {...}")
+#   Bucket B — ORDER BY numeric-ordinal range validation, nested context (1)
+#     fuzz-1.18                                            -> #6071
+#   Bucket C — CAST(zeroblob(N) AS text) returns N NUL bytes, not "" (MEM_Zero) (1)
+#     fuzz-1.8                                             -> #6072
+#   Bucket D — fuzz-5.2/7.2 batched trial-check surfaces the generic CLI
+#     "N statements failed" (cli.ftl script-failed-error) instead of SQLite's
+#     specific allowlisted error text; error-allowlist mismatch
+#     (22 stmts + 2 downstream COMMIT sentinels fuzz-5.3 / fuzz-7.4):
+#       fuzz-5.2.2, fuzz-5.2.10,
+#       fuzz-7.2.{2,4,5,13,14,18,19,20,22,31,33,34,36,38,40,41,42,45,46,48}
+#     -> #6073
+# -----------------------------------------------------------------------------
+
 # Pattern-based skip list for tests with many numbered variants
 variable vibesql_skip_patterns {
     {select9-2.*.3 "user-defined COLLATE (C-API) not reachable from SQL CLI - harness limitation (issue #5720). These compound-SELECT ORDER BY ... COLLATE reverse cases depend on the 'reverse' collation registered via 'db collate reverse reverse', which the TCL shim cannot bridge to the VibeSQL CLI subprocess (same class as the sqlite3_create_aggregate stub in #5712). Covers select9-2.x.3 and its .flipped and limit/offset variants for all index loops."}


### PR DESCRIPTION
## Summary

Classification-recording issue (no engine fixes). Records the `fuzz.test` residual — **33 real engine-gap failures** — durably and files one open tracking issue per bucket, per the #5779 honest-framing rule. Nothing is skip-listed.

Fresh release build (`cargo build --release --bin vibesql`) + `./scripts/tcltest test fuzz.test --timeout 1800` reproduced the exact 33-test list from the curator. The `puts $::sql; puts $msg` failure output gave ground-truth SQL + VibeSQL error text for the bucket-D forensics the curator couldn't do.

## Changes

- `scripts/tester_vibesql.tcl`: a durable, greppable comment block (40 lines, all comments) between the `vibesql_skip_tests` and `vibesql_skip_patterns` arrays, summarizing 33 failures / 4 buckets / all real / tracked in #6070–#6073. Placed **outside** the array braces so TCL does not mis-parse `#` lines as key/value pairs (verified: `vibesql_skip_tests` parses with no stray keys). **No skip entries added.**

## Tracking issues filed

| Bucket | Class | Tests | Issue |
|--------|-------|-------|-------|
| A | GLOB in the simple (scalar) evaluator, non-literal operands | 7 (`fuzz-3.2.1965/2663/2863`, `fuzz-4.2.586/1633/1896/4455`) | #6070 |
| B | ORDER BY numeric-ordinal range validation, nested context | 1 (`fuzz-1.18`) | #6071 |
| C | `CAST(zeroblob(N) AS text)` returns N NUL bytes not `""` (MEM_Zero) | 1 (`fuzz-1.8`) | #6072 |
| D | fuzz-5.2/7.2 batched trial-check surfaces generic `"N statements failed"` instead of SQLite's allowlisted error text (+2 downstream COMMIT sentinels `fuzz-5.3`/`fuzz-7.4`) | 22 + 2 | #6073 |

Bucket A was confirmed **not** already covered by an open #5884/#5892-line issue (searched; none existed).

### Bucket D forensics (the part the curator couldn't do)

Captured VibeSQL's actual error text via the harness's on-failure `puts $msg`: for the failing fuzz-5.2/7.2 statements the message is the CLI script-mode batch summary `"N statements failed"` (`cli.ftl:189 script-failed-error`), which contains none of the allowlist substrings (`table`, `no such col`, `datatype mismatch`, ...). The specific per-statement error exists in CLI output but the batched `trial_check_incremental` path surfaces the summary line instead. Standalone replays of individual statements succeed (corpus-state-dependent), matching the curator's note. `fuzz-5.3`/`fuzz-7.4` confirmed downstream (COMMIT echoes trial/batch status), not independent. Full expected-vs-actual table in #6073.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| All 33 failures enumerated & classified into 4 buckets | ✅ | Fresh run `Failed tests:` block matches curator's list exactly |
| Open tracking issue per bucket | ✅ | #6070, #6071, #6072, #6073 (bucket A confirmed not pre-tracked) |
| Bucket-D forensics: actual error text captured | ✅ | `"N statements failed"` (cli.ftl) recorded in #6073 with expected-vs-actual |
| Durable record in tester shim | ✅ | Comment block near the fuzz precedent, #6066 convention |
| No skip entries added | ✅ | `git diff` = 40 comment/blank lines, 0 code lines; skip count unchanged |
| `verify_skips.py` passes | ✅ | `--list-categories` exits 0 |
| Classification posted on #6041 and #5779 | ✅ | Comments posted |
| fuzz.test numbers unchanged | ✅ | Comment-only change; 35031/34998/33 (quiet-machine) |

## Test Plan

- `cargo build --release --bin vibesql` (fresh) — done.
- `./scripts/tcltest test fuzz.test --timeout 1800` — 33 real failures matching the curator's list (a transient 34th, `fuzz-7.2.1267`, was a system fd-exhaustion artifact from concurrent agent load — documented, not a real failure).
- `python3 scripts/verify_skips.py --list-categories` — exits 0.
- TCL parse check: `vibesql_skip_tests` array parses with no stray comment keys.

Closes #6041