### PR TITLE
fix(executor): row-value arity & misuse error-message parity (#6046)

### DIFF
--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -202,6 +202,14 @@ impl DeleteExecutor {
             return Err(ExecutorError::TableNotFound(stmt.table_name.clone()));
         }
 
+        // Prepare-time scalar-subquery arity validation (#6046). SQLite rejects
+        // a multi-column subquery compared in a WHERE predicate at prepare time,
+        // even when the table is empty so no row is ever scanned
+        // (rowvalue.test 15.4: `DELETE FROM x1 WHERE a<(SELECT * FROM (SELECT b,2))`).
+        if let Some(vibesql_ast::WhereClause::Condition(where_expr)) = &stmt.where_clause {
+            crate::select::validate_predicate_subquery_arity(where_expr, database)?;
+        }
+
         // Fast path: DELETE FROM table (no WHERE clause)
         // Use TRUNCATE-style optimization for 100-1000x performance improvement
         // Only use truncate if there's no ORDER BY or LIMIT (which would restrict which rows to
@@ -225,6 +233,21 @@ impl DeleteExecutor {
         // Use canonical table name from schema for all storage operations
         // This ensures case-sensitive tables (quoted identifiers) are accessed correctly
         let table_name = &schema.name;
+
+        // Validate DELETE trigger body statements for scalar-subquery arity at
+        // prepare time (#6046, rowvalue.test 28.10). SQLite resolves a trigger's
+        // body when the firing DELETE is prepared, so a body
+        // `SELECT (SELECT c0,c1 FROM t0) FROM t0` errors even when `t0` is empty
+        // and the trigger never fires. Only at the top level (not inside another
+        // trigger's body), matching SQLite's prepare of the outermost statement.
+        if trigger_context.is_none() {
+            crate::TriggerFirer::validate_trigger_bodies_for_event(
+                database,
+                table_name,
+                vibesql_ast::TriggerEvent::Delete,
+                None,
+            )?;
+        }
 
         // Fast path: Single-row PK delete without triggers/FKs
         // This avoids ExpressionEvaluator creation and row cloning

--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -109,6 +109,27 @@ pub enum ExecutorError {
         expected: usize,
         actual: usize,
     },
+    /// An IN(...) candidate row-value element has a different arity than the
+    /// left-hand tuple (SQLite-compatible error). Format:
+    /// "IN(...) element has N term(s) - expected M"
+    /// e.g. `(1,2) IN ((1,2),(3,4,5))` — the `(3,4,5)` element has 3 terms but
+    /// the LHS expects 2.
+    InElementArity {
+        /// The arity expected by the left-hand tuple.
+        expected: usize,
+        /// The arity of the offending candidate element.
+        actual: usize,
+    },
+    /// An UPDATE-SET tuple assignment `SET (a, b, ...) = (...)` has a different
+    /// number of target columns than RHS values (SQLite-compatible error).
+    /// Format: "N columns assigned M values"
+    /// e.g. `UPDATE t SET (c,d) = (SELECT x,y,z ...)` — 2 columns, 3 values.
+    ColumnsAssignedValues {
+        /// Number of target columns on the left of the assignment.
+        columns: usize,
+        /// Number of values produced by the RHS.
+        values: usize,
+    },
     /// Set operation (UNION, INTERSECT, EXCEPT) column count mismatch (SQLite-compatible)
     /// Format: "SELECTs to the left and right of {op} do not have the same number of result columns"
     SetOperationColumnMismatch {
@@ -717,6 +738,28 @@ impl std::fmt::Display for ExecutorError {
                         "executor-subquery-column-count-mismatch",
                         expected = *expected as i64,
                         actual = *actual as i64
+                    )
+                )
+            }
+            ExecutorError::InElementArity { expected, actual } => {
+                write!(
+                    f,
+                    "{}",
+                    vibe_msg!(
+                        "executor-in-element-arity",
+                        expected = *expected as i64,
+                        actual = *actual as i64
+                    )
+                )
+            }
+            ExecutorError::ColumnsAssignedValues { columns, values } => {
+                write!(
+                    f,
+                    "{}",
+                    vibe_msg!(
+                        "executor-columns-assigned-values",
+                        columns = *columns as i64,
+                        values = *values as i64
                     )
                 )
             }

--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -601,12 +601,18 @@ impl CombinedExpressionEvaluator<'_> {
 
         let mut found_unknown = false;
         for candidate in values {
+            // A non-row-value candidate (e.g. the bare `4` in
+            // `(1,2) IN ((1,2), 4, (5,6))`) has arity 1; SQLite reports the
+            // arity mismatch, not a generic misuse.
             let cand_exprs = match candidate {
-                vibesql_ast::Expression::RowValueConstructor(cand) => cand,
-                _ => return Err(ExecutorError::RowValueMisused),
+                vibesql_ast::Expression::RowValueConstructor(cand) => cand.as_slice(),
+                other => std::slice::from_ref(other),
             };
             if cand_exprs.len() != arity {
-                return Err(ExecutorError::RowValueMisused);
+                return Err(ExecutorError::InElementArity {
+                    expected: arity,
+                    actual: cand_exprs.len(),
+                });
             }
 
             // Per-element collation and affinity, mirroring row-value `=`.

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -516,19 +516,55 @@ impl ExpressionEvaluator<'_> {
         match expr {
             vibesql_ast::Expression::RowValueConstructor(elems) => {
                 if elems.len() != expected {
-                    return Err(ExecutorError::SubqueryColumnCountMismatch {
-                        expected,
-                        actual: elems.len(),
+                    // UPDATE-SET tuple arity mismatch: SQLite reports
+                    // "N columns assigned M values", not the sub-select arity
+                    // error (the RHS here is a literal row value, not a query).
+                    return Err(ExecutorError::ColumnsAssignedValues {
+                        columns: expected,
+                        values: elems.len(),
                     });
                 }
                 elems.iter().map(|e| self.eval(e, row)).collect()
             }
             vibesql_ast::Expression::ScalarSubquery(subquery) => {
-                self.eval_scalar_subquery_as_row(subquery, row, expected)
+                // The RHS is a `(SELECT ...)`. An arity mismatch here is still an
+                // UPDATE-SET "N columns assigned M values" error, not the generic
+                // "sub-select returns N columns - expected M" — SQLite distinguishes
+                // the assignment-target context from a scalar-subquery misuse.
+                self.eval_scalar_subquery_as_row(subquery, row, expected).map_err(|e| match e {
+                    ExecutorError::SubqueryColumnCountMismatch { expected, actual } => {
+                        ExecutorError::ColumnsAssignedValues { columns: expected, values: actual }
+                    }
+                    other => other,
+                })
             }
             // A non-row RHS for a multi-column target is a misuse per SQLite
             // (e.g. `SET (a, b) = 1`).
             _ => Err(ExecutorError::RowValueMisused),
+        }
+    }
+
+    /// Returns true when a scalar subquery's result has more than one column.
+    ///
+    /// Used to detect `(SELECT a, b) <op> scalar` comparison misuse, where SQLite
+    /// reports "row value misused". If the column count cannot be determined
+    /// statically (e.g. a wildcard over a not-yet-materialized CTE), we
+    /// conservatively return `false` and let ordinary scalar evaluation raise the
+    /// downstream "sub-select returns N columns - expected 1" error instead.
+    fn scalar_subquery_is_multi_column(
+        &self,
+        subquery: &vibesql_ast::SelectStmt,
+    ) -> Result<bool, ExecutorError> {
+        let Some(database) = self.database else {
+            return Ok(false);
+        };
+        match crate::evaluator::compute_select_list_column_count(
+            subquery,
+            database,
+            self.cte_context,
+        ) {
+            Ok(n) => Ok(n > 1),
+            Err(_) => Ok(false),
         }
     }
 
@@ -676,6 +712,19 @@ impl ExpressionEvaluator<'_> {
                                     if elems.len() > 1 =>
                                 {
                                     return Err(ExecutorError::RowValueMisused);
+                                }
+                                // A multi-column scalar subquery compared against
+                                // a plain scalar (not a row value or subquery),
+                                // e.g. `(SELECT * FROM (SELECT 1,2)) < 3`, is a
+                                // misuse per SQLite ("row value misused"), not a
+                                // scalar-subquery arity error. The other side is
+                                // known here to be neither a RowValueConstructor
+                                // nor a ScalarSubquery (those are matched above).
+                                (vibesql_ast::Expression::ScalarSubquery(subquery), _)
+                                | (_, vibesql_ast::Expression::ScalarSubquery(subquery)) => {
+                                    if self.scalar_subquery_is_multi_column(subquery)? {
+                                        return Err(ExecutorError::RowValueMisused);
+                                    }
                                 }
                                 _ => {}
                             }

--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -854,12 +854,18 @@ impl ExpressionEvaluator<'_> {
 
         let mut found_unknown = false;
         for candidate in values {
+            // A non-row-value candidate (e.g. the bare `4` in
+            // `(1,2) IN ((1,2), 4, (5,6))`) has arity 1; SQLite reports the
+            // arity mismatch, not a generic misuse.
             let cand_exprs = match candidate {
-                vibesql_ast::Expression::RowValueConstructor(cand) => cand,
-                _ => return Err(ExecutorError::RowValueMisused),
+                vibesql_ast::Expression::RowValueConstructor(cand) => cand.as_slice(),
+                other => std::slice::from_ref(other),
             };
             if cand_exprs.len() != arity {
-                return Err(ExecutorError::RowValueMisused);
+                return Err(ExecutorError::InElementArity {
+                    expected: arity,
+                    actual: cand_exprs.len(),
+                });
             }
 
             // Per-element collation and affinity, mirroring row-value `=`.

--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -65,6 +65,36 @@ impl SelectExecutor<'_> {
         // empty-table case (window9.test 3.4).
         super::validation::validate_in_subquery_column_counts(stmt, self.database)?;
 
+        // Validate a bare multi-column subquery used as a top-level SELECT-list
+        // item (#6046). `SELECT (SELECT c0,c1 FROM t0) FROM t0` is a prepare-time
+        // error in SQLite ("sub-select returns N columns - expected 1"), even
+        // when the outer table is empty so the subquery never executes
+        // (rowvalue.test 28.10 trigger body over an empty table). The runtime
+        // evaluator only catches this when a row is actually produced.
+        //
+        // Only the top-level statement is checked: a bare multi-column subquery
+        // is context-dependent (legal as a row-value comparison operand deeper
+        // in the tree), and nested SELECTs — including UPDATE `SET`-value
+        // subqueries — reach the correct check through their own execution path.
+        //
+        // Synthetic UPDATE…FROM SELECTs (see `update::from_clause`) project each
+        // tuple-assignment SET value as a `__set_N__`-aliased item; a
+        // multi-column subquery there is a legal row-value assignment, so those
+        // items are skipped.
+        if self.outer_schema.is_none() && self.subquery_depth == 0 {
+            for item in &stmt.select_list {
+                if let vibesql_ast::SelectItem::Expression { expr, alias, .. } = item {
+                    let is_synthetic_set_value =
+                        alias.as_deref().is_some_and(|a| a.starts_with("__set_"));
+                    if !is_synthetic_set_value {
+                        if let vibesql_ast::Expression::ScalarSubquery(_) = expr {
+                            super::validation::validate_value_subquery_arity(expr, self.database)?;
+                        }
+                    }
+                }
+            }
+        }
+
         // Validate SQLite index hints (issue #5235)
         // INDEXED BY must name an index that exists on that table; SQLite
         // reports "no such index: X" at prepare time. The hint is otherwise

--- a/crates/vibesql-executor/src/select/executor/validation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/mod.rs
@@ -18,6 +18,7 @@ mod in_subquery_columns;
 mod index_hints;
 mod join_limits;
 mod row_values;
+mod scalar_subquery_arity;
 mod schema;
 
 use std::collections::HashSet;
@@ -35,6 +36,10 @@ pub use in_subquery_columns::validate_in_subquery_column_counts;
 pub use index_hints::validate_index_hints;
 pub use join_limits::validate_join_table_limit;
 pub use row_values::validate_row_value_usage;
+pub use scalar_subquery_arity::{
+    validate_predicate_expr as validate_predicate_subquery_arity,
+    validate_value_expr as validate_value_subquery_arity,
+};
 pub use schema::validate_aggregate_subquery_outer_refs;
 use vibesql_ast::{Expression, SelectItem};
 

--- a/crates/vibesql-executor/src/select/executor/validation/row_values.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/row_values.rs
@@ -189,11 +189,22 @@ fn walk(expr: &Expression) -> Result<(), ExecutorError> {
                 if elems.len() > 1 {
                     validate_elements_scalar(elems)?;
                     for value in values {
-                        match value {
-                            Expression::RowValueConstructor(cand) if cand.len() == elems.len() => {
+                        // A candidate row value must have the same arity as the
+                        // LHS tuple; a mismatch (including a bare scalar, which
+                        // has arity 1) is SQLite's
+                        // "IN(...) element has N term(s) - expected M".
+                        let cand_arity = match value {
+                            Expression::RowValueConstructor(cand) => {
                                 validate_elements_scalar(cand)?;
+                                cand.len()
                             }
-                            _ => return Err(ExecutorError::RowValueMisused),
+                            _ => 1,
+                        };
+                        if cand_arity != elems.len() {
+                            return Err(ExecutorError::InElementArity {
+                                expected: elems.len(),
+                                actual: cand_arity,
+                            });
                         }
                     }
                     return Ok(());
@@ -400,9 +411,19 @@ mod tests {
     fn row_value_in_list_shapes() {
         let expr = where_expr_of("SELECT * FROM t WHERE (a,b) IN ((1,2),(3,4))");
         assert!(validate_row_value_usage(&expr).is_ok());
-        // Mismatched candidate arity
+        // Mismatched candidate arity: SQLite reports the element-arity error
+        // ("IN(...) element has N term(s) - expected M"), not a generic misuse.
         let expr = where_expr_of("SELECT * FROM t WHERE (a,b) IN ((1,2,3))");
-        assert!(matches!(validate_row_value_usage(&expr), Err(ExecutorError::RowValueMisused)));
+        assert!(matches!(
+            validate_row_value_usage(&expr),
+            Err(ExecutorError::InElementArity { expected: 2, actual: 3 })
+        ));
+        // A bare-scalar candidate has arity 1.
+        let expr = where_expr_of("SELECT * FROM t WHERE (a,b) IN ((1,2),4)");
+        assert!(matches!(
+            validate_row_value_usage(&expr),
+            Err(ExecutorError::InElementArity { expected: 2, actual: 1 })
+        ));
     }
 
     #[test]

--- a/crates/vibesql-executor/src/select/executor/validation/scalar_subquery_arity.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/scalar_subquery_arity.rs
@@ -1,0 +1,179 @@
+//! Prepare-time validation of bare scalar-subquery arity in scalar positions.
+//!
+//! SQLite validates at prepare time that a subquery used where a single value is
+//! required returns exactly one column, producing
+//! `sub-select returns N columns - expected 1`; and that a multi-column subquery
+//! compared against a plain scalar in a *value* position is
+//! `row value misused`.
+//!
+//! VibeSQL's expression evaluator performs equivalent checks, but only when the
+//! expression is actually evaluated against a row. When the target table is
+//! empty the expression never executes, so the malformed statement silently
+//! succeeds (`rowvalue.test` 15.2/15.3/15.4, and the `28.10` trigger body over
+//! an empty table). These validators inspect the specific top-level shapes that
+//! SQLite rejects at prepare time so the error is raised regardless of row
+//! count.
+//!
+//! Scope is deliberately narrow: only the *top-level* expression of a
+//! value-producing position (a SELECT-list item, an UPDATE `SET` value) or a
+//! boolean predicate (`WHERE`) is inspected, because that is the position that
+//! goes unevaluated when the table is empty. A multi-column subquery paired with
+//! a `RowValueConstructor` or another subquery is a legal row-value comparison
+//! and is left untouched (the evaluator and the `row_values` validator cover
+//! those shapes). Nested sub-expressions are left to the runtime check.
+//!
+//! ## Context-sensitive messages (matching SQLite 3.51)
+//!
+//! | Context                    | shape                       | message           |
+//! |----------------------------|-----------------------------|-------------------|
+//! | value (SELECT item, SET)   | bare `(SELECT a,b)`         | arity error       |
+//! |                            | `(SELECT a,b) <op> scalar`  | row value misused |
+//! |                            | `scalar <op> (SELECT a,b)`  | arity error       |
+//! | predicate (WHERE)          | `col <op> (SELECT a,b)`     | arity error       |
+//! |                            | `(SELECT a,b) <op> col`     | arity error       |
+
+use vibesql_ast::{BinaryOperator, Expression};
+
+use crate::errors::ExecutorError;
+
+fn is_comparison_op(op: &BinaryOperator) -> bool {
+    matches!(
+        op,
+        BinaryOperator::Equal
+            | BinaryOperator::NotEqual
+            | BinaryOperator::LessThan
+            | BinaryOperator::LessThanOrEqual
+            | BinaryOperator::GreaterThan
+            | BinaryOperator::GreaterThanOrEqual
+    )
+}
+
+/// Column count of a scalar subquery, if it can be determined statically.
+/// Returns `None` when the count cannot be computed (e.g. a wildcard over a
+/// not-yet-materialized CTE), in which case validation defers to the runtime
+/// check rather than guessing.
+fn subquery_column_count(
+    subquery: &vibesql_ast::SelectStmt,
+    database: &vibesql_storage::Database,
+) -> Option<usize> {
+    crate::evaluator::compute_select_list_column_count(subquery, database, None).ok()
+}
+
+/// If `expr` is a scalar subquery returning more than one column (statically
+/// determinable), return that column count; otherwise `None`.
+fn multi_col_subquery(expr: &Expression, database: &vibesql_storage::Database) -> Option<usize> {
+    if let Expression::ScalarSubquery(subquery) = expr {
+        match subquery_column_count(subquery, database) {
+            Some(n) if n > 1 => Some(n),
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+/// True when `expr` is a row value or a scalar subquery — the two operand
+/// shapes that make a comparison a legal *row-value* comparison (so a
+/// multi-column subquery on the other side is not a scalar misuse).
+fn is_row_value_or_subquery(expr: &Expression) -> bool {
+    matches!(expr, Expression::RowValueConstructor(e) if e.len() > 1)
+        || matches!(expr, Expression::ScalarSubquery(_))
+}
+
+fn arity_error(actual: usize) -> ExecutorError {
+    ExecutorError::SubqueryColumnCountMismatch { expected: 1, actual }
+}
+
+/// Validate scalar-subquery arity for an expression appearing in a
+/// value-producing position (a SELECT-list item or an UPDATE `SET` value).
+///
+/// * A bare multi-column subquery is `sub-select returns N columns - expected 1`.
+/// * A multi-column subquery on the **left** of a comparison against a plain
+///   scalar is `row value misused`; on the **right** it is the arity error.
+pub fn validate_value_expr(
+    expr: &Expression,
+    database: &vibesql_storage::Database,
+) -> Result<(), ExecutorError> {
+    match expr {
+        Expression::ScalarSubquery(subquery) => {
+            if let Some(n) = subquery_column_count(subquery, database) {
+                if n > 1 {
+                    return Err(arity_error(n));
+                }
+            }
+            Ok(())
+        }
+        Expression::BinaryOp { left, op, right } if is_comparison_op(op) => {
+            // Legal row-value comparison — leave to the evaluator / row_values.
+            if is_row_value_or_subquery(left) && is_row_value_or_subquery(right) {
+                return Ok(());
+            }
+            // `(SELECT a,b) <op> scalar` — subquery on the left of a value-
+            // context comparison against a plain scalar is `row value misused`.
+            if multi_col_subquery(left, database).is_some() && !is_row_value_or_subquery(right) {
+                return Err(ExecutorError::RowValueMisused);
+            }
+            // `scalar <op> (SELECT a,b)` — subquery on the right is the arity
+            // error.
+            if !is_row_value_or_subquery(left) {
+                if let Some(n) = multi_col_subquery(right, database) {
+                    return Err(arity_error(n));
+                }
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Validate scalar-subquery arity for an expression appearing in a boolean
+/// predicate position (UPDATE / DELETE `WHERE`).
+///
+/// A multi-column subquery compared against a plain scalar (column / literal)
+/// is `sub-select returns N columns - expected 1`, regardless of which side it
+/// is on. A subquery paired with a row value or another subquery is a legal
+/// row-value comparison and is left untouched. `AND` / `OR` chains are walked so
+/// each conjunct's top-level comparison is inspected.
+pub fn validate_predicate_expr(
+    expr: &Expression,
+    database: &vibesql_storage::Database,
+) -> Result<(), ExecutorError> {
+    match expr {
+        Expression::BinaryOp { left, op, right } if is_comparison_op(op) => {
+            // Legal row-value comparison — leave to the evaluator / row_values.
+            if is_row_value_or_subquery(left) && is_row_value_or_subquery(right) {
+                return Ok(());
+            }
+            // A multi-column subquery compared against a plain scalar on either
+            // side is the arity error in a WHERE predicate.
+            if !is_row_value_or_subquery(left) {
+                if let Some(n) = multi_col_subquery(right, database) {
+                    return Err(arity_error(n));
+                }
+            }
+            if !is_row_value_or_subquery(right) {
+                if let Some(n) = multi_col_subquery(left, database) {
+                    return Err(arity_error(n));
+                }
+            }
+            Ok(())
+        }
+        // Walk boolean combinators so each conjunct/disjunct is inspected.
+        Expression::Conjunction(children) | Expression::Disjunction(children) => {
+            for c in children {
+                validate_predicate_expr(c, database)?;
+            }
+            Ok(())
+        }
+        Expression::BinaryOp { left, op, right }
+            if matches!(op, BinaryOperator::And | BinaryOperator::Or) =>
+        {
+            validate_predicate_expr(left, database)?;
+            validate_predicate_expr(right, database)
+        }
+        Expression::UnaryOp { op: vibesql_ast::UnaryOperator::Not, expr: inner } => {
+            validate_predicate_expr(inner, database)
+        }
+        _ => Ok(()),
+    }
+}

--- a/crates/vibesql-executor/src/select/mod.rs
+++ b/crates/vibesql-executor/src/select/mod.rs
@@ -23,7 +23,10 @@ pub(crate) mod view_reference_guard;
 pub(crate) mod window;
 
 pub use cte::CteResult;
-pub use executor::validation::find_window_function_in_expression;
+pub use executor::validation::{
+    find_window_function_in_expression, validate_predicate_subquery_arity,
+    validate_value_subquery_arity,
+};
 pub use iterator::{RowIterator, TableScanIterator};
 pub use late_materialization::{
     gather_columns, gather_single_column, LazyMaterializedBatch, RowReference, SelectionVector,

--- a/crates/vibesql-executor/src/trigger_execution.rs
+++ b/crates/vibesql-executor/src/trigger_execution.rs
@@ -457,6 +457,49 @@ impl TriggerFirer {
         Ok(())
     }
 
+    /// Validate scalar-subquery arity inside trigger body statements at DML
+    /// prepare time (#6046).
+    ///
+    /// SQLite resolves and validates a trigger's body statements when the firing
+    /// DML statement is prepared, *before* deciding whether any row matches — so
+    /// a body `SELECT (SELECT c0,c1 FROM t0) FROM t0` (a multi-column subquery in
+    /// a scalar position) errors `sub-select returns 2 columns - expected 1` even
+    /// when the target table is empty and the trigger never actually fires
+    /// (rowvalue.test 28.10). VibeSQL only executes trigger bodies when the
+    /// trigger fires, so this pass reproduces the prepare-time check for the
+    /// SELECT statements in each matching trigger's body.
+    ///
+    /// Only errors that must surface with zero matched rows are propagated; any
+    /// other outcome (including subqueries whose arity cannot be determined
+    /// statically) is left to the per-row execution path.
+    pub fn validate_trigger_bodies_for_event(
+        db: &Database,
+        table_name: &str,
+        event: TriggerEvent,
+        dml_schema: Option<&str>,
+    ) -> Result<(), ExecutorError> {
+        let triggers = db
+            .catalog
+            .get_triggers_for_table_in_schema(table_name, Some(event), dml_schema)
+            .filter(|trigger| trigger.enabled)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        for trigger in &triggers {
+            let sql = match &trigger.triggered_action {
+                vibesql_ast::TriggerAction::RawSql(sql) => sql,
+            };
+            let statements = Self::parse_trigger_sql(sql)?;
+            for statement in &statements {
+                if let vibesql_ast::Statement::Select(select) = statement {
+                    validate_select_scalar_subquery_arity(select, db)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Check if an UPDATE OF trigger should fire based on which columns changed
     ///
     /// # Arguments
@@ -1112,4 +1155,29 @@ impl TriggerFirer {
 
         Ok(TriggerOutcome::Proceed)
     }
+}
+
+/// Validate scalar-subquery arity for a SELECT statement appearing in a trigger
+/// body (#6046). A bare multi-column subquery in the SELECT list, or a
+/// multi-column subquery compared against a scalar in the WHERE clause, is a
+/// prepare-time error in SQLite (`sub-select returns N columns - expected 1`).
+///
+/// This mirrors the top-level SELECT prepare-time check in
+/// `select::executor::execute`, but is applied to trigger-body statements up
+/// front so the error surfaces even when the trigger never fires (empty table).
+fn validate_select_scalar_subquery_arity(
+    select: &vibesql_ast::SelectStmt,
+    database: &Database,
+) -> Result<(), ExecutorError> {
+    for item in &select.select_list {
+        if let vibesql_ast::SelectItem::Expression { expr, .. } = item {
+            if let vibesql_ast::Expression::ScalarSubquery(_) = expr {
+                crate::select::validate_value_subquery_arity(expr, database)?;
+            }
+        }
+    }
+    if let Some(where_expr) = &select.where_clause {
+        crate::select::validate_predicate_subquery_arity(where_expr, database)?;
+    }
+    Ok(())
 }

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -98,6 +98,22 @@ pub(super) fn execute_internal(
     // This ensures case-sensitive tables (quoted identifiers) are accessed correctly
     let table_name = &schema_owned.name;
 
+    // Prepare-time scalar-subquery arity validation (#6046). SQLite rejects a
+    // multi-column subquery used where a single value is required at prepare
+    // time, even when the target table is empty so the per-row path never runs
+    // (rowvalue.test 15.2 SET value, 15.3 WHERE). A tuple assignment
+    // `(a, b) = (SELECT x, y)` is a legal row-value assignment (arity is checked
+    // by the SET-tuple path), so only single-column assignment values are
+    // validated in the scalar-value context here.
+    for assignment in &stmt.assignments {
+        if assignment.columns.is_empty() {
+            crate::select::validate_value_subquery_arity(&assignment.value, database)?;
+        }
+    }
+    if let Some(vibesql_ast::WhereClause::Condition(where_expr)) = &stmt.where_clause {
+        crate::select::validate_predicate_subquery_arity(where_expr, database)?;
+    }
+
     // Check if table has UPDATE triggers (check once, use multiple times).
     //
     // ROW-level triggers fire even when this UPDATE runs inside another

--- a/crates/vibesql-executor/tests/row_value_features_tests.rs
+++ b/crates/vibesql-executor/tests/row_value_features_tests.rs
@@ -116,6 +116,23 @@ fn assert_misused(db: &vibesql_storage::Database, sql: &str) {
     );
 }
 
+fn assert_in_element_arity(
+    db: &vibesql_storage::Database,
+    sql: &str,
+    expected: usize,
+    actual: usize,
+) {
+    let err = query_err(db, sql);
+    assert!(
+        matches!(err, ExecutorError::InElementArity { expected: e, actual: a } if e == expected && a == actual),
+        "Query: {} -- expected InElementArity {{ expected: {}, actual: {} }}, got {:?}",
+        sql,
+        expected,
+        actual,
+        err
+    );
+}
+
 const I: fn(i64) -> SqlValue = SqlValue::Integer;
 
 /// Build a text `SqlValue` matching how the executor materializes a string
@@ -166,10 +183,13 @@ fn tuple_in_list_column_affinity() {
 }
 
 #[test]
-fn tuple_in_list_arity_mismatch_is_misused() {
+fn tuple_in_list_arity_mismatch_reports_element_arity() {
     let db = vibesql_storage::Database::new();
-    assert_misused(&db, "SELECT (1,2) IN ((1,2,3))");
-    assert_misused(&db, "SELECT (1,2) IN ((1,2), 3)");
+    // SQLite reports the element-arity error for a mismatched IN candidate
+    // ("IN(...) element has N term(s) - expected M"), not a generic misuse.
+    assert_in_element_arity(&db, "SELECT (1,2) IN ((1,2,3))", 2, 3);
+    // A bare-scalar candidate has arity 1.
+    assert_in_element_arity(&db, "SELECT (1,2) IN ((1,2), 3)", 2, 1);
 }
 
 #[test]

--- a/crates/vibesql-l10n/resources/ar/executor.ftl
+++ b/crates/vibesql-l10n/resources/ar/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = خطأ في التحليل: { $message }
 executor-subquery-returned-multiple-rows = أعاد الاستعلام الفرعي القياسي { $actual } صف/صفوف، المتوقع { $expected }
 executor-subquery-column-count-mismatch = أعاد الاستعلام الفرعي { $actual } عمود/أعمدة، المتوقع { $expected }
 executor-column-count-mismatch = قائمة الأعمدة المشتقة تحتوي على { $provided } عمود/أعمدة لكن الاستعلام ينتج { $expected } عمود/أعمدة
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # Constraint Errors

--- a/crates/vibesql-l10n/resources/de/executor.ftl
+++ b/crates/vibesql-l10n/resources/de/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = Parserfehler: { $message }
 executor-subquery-returned-multiple-rows = Skalare Unterabfrage lieferte { $actual } Zeilen, erwartet wurden { $expected }
 executor-subquery-column-count-mismatch = Unterabfrage lieferte { $actual } Spalten, erwartet wurden { $expected }
 executor-column-count-mismatch = Abgeleitete Spaltenliste hat { $provided } Spalten, aber Abfrage erzeugt { $expected } Spalten
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # Constraint-Fehler

--- a/crates/vibesql-l10n/resources/en-US/executor.ftl
+++ b/crates/vibesql-l10n/resources/en-US/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = Parse error: { $message }
 executor-subquery-returned-multiple-rows = Scalar subquery returned { $actual } rows, expected { $expected }
 executor-subquery-column-count-mismatch = sub-select returns { $actual } columns - expected { $expected }
 executor-column-count-mismatch = Derived column list has { $provided } columns but query produces { $expected } columns
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # Constraint Errors

--- a/crates/vibesql-l10n/resources/es/executor.ftl
+++ b/crates/vibesql-l10n/resources/es/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = Error de análisis: { $message }
 executor-subquery-returned-multiple-rows = La subconsulta escalar devolvió { $actual } filas, se esperaba { $expected }
 executor-subquery-column-count-mismatch = La subconsulta devolvió { $actual } columnas, se esperaba { $expected }
 executor-column-count-mismatch = La lista de columnas derivadas tiene { $provided } columnas pero la consulta produce { $expected } columnas
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # Constraint Errors

--- a/crates/vibesql-l10n/resources/fr/executor.ftl
+++ b/crates/vibesql-l10n/resources/fr/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = Erreur d'analyse : { $message }
 executor-subquery-returned-multiple-rows = La sous-requête scalaire a retourné { $actual } lignes, { $expected } attendue
 executor-subquery-column-count-mismatch = La sous-requête a retourné { $actual } colonnes, { $expected } attendues
 executor-column-count-mismatch = La liste de colonnes dérivées a { $provided } colonnes mais la requête produit { $expected } colonnes
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # Erreurs de Contrainte

--- a/crates/vibesql-l10n/resources/hi/executor.ftl
+++ b/crates/vibesql-l10n/resources/hi/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = पार्स त्रुटि: { $message }
 executor-subquery-returned-multiple-rows = स्केलर सबक्वेरी ने { $actual } पंक्तियां लौटाईं, अपेक्षित { $expected }
 executor-subquery-column-count-mismatch = सबक्वेरी ने { $actual } कॉलम लौटाए, अपेक्षित { $expected }
 executor-column-count-mismatch = व्युत्पन्न कॉलम सूची में { $provided } कॉलम हैं लेकिन क्वेरी { $expected } कॉलम उत्पन्न करती है
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # Constraint Errors

--- a/crates/vibesql-l10n/resources/id/executor.ftl
+++ b/crates/vibesql-l10n/resources/id/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = Kesalahan parsing: { $message }
 executor-subquery-returned-multiple-rows = Subquery skalar mengembalikan { $actual } baris, diharapkan { $expected }
 executor-subquery-column-count-mismatch = Subquery mengembalikan { $actual } kolom, diharapkan { $expected }
 executor-column-count-mismatch = Daftar kolom turunan memiliki { $provided } kolom tetapi query menghasilkan { $expected } kolom
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # Constraint Errors

--- a/crates/vibesql-l10n/resources/it/executor.ftl
+++ b/crates/vibesql-l10n/resources/it/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = Errore di parsing: { $message }
 executor-subquery-returned-multiple-rows = La subquery scalare ha restituito { $actual } righe, prevista { $expected }
 executor-subquery-column-count-mismatch = La subquery ha restituito { $actual } colonne, previste { $expected }
 executor-column-count-mismatch = La lista colonne derivata ha { $provided } colonne ma la query produce { $expected } colonne
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # Constraint Errors

--- a/crates/vibesql-l10n/resources/ja/executor.ftl
+++ b/crates/vibesql-l10n/resources/ja/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = 解析エラー: { $message }
 executor-subquery-returned-multiple-rows = スカラーサブクエリが { $actual } 行を返しました（期待値: { $expected }）
 executor-subquery-column-count-mismatch = サブクエリが { $actual } カラムを返しました（期待値: { $expected }）
 executor-column-count-mismatch = 派生カラムリストには { $provided } カラムがありますが、クエリは { $expected } カラムを生成します
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # 制約エラー

--- a/crates/vibesql-l10n/resources/ko/executor.ftl
+++ b/crates/vibesql-l10n/resources/ko/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = 구문 분석 오류: { $message }
 executor-subquery-returned-multiple-rows = 스칼라 서브쿼리가 { $actual }개의 행을 반환했습니다. 예상: { $expected }개
 executor-subquery-column-count-mismatch = 서브쿼리가 { $actual }개의 컬럼을 반환했습니다. 예상: { $expected }개
 executor-column-count-mismatch = 파생 컬럼 목록에 { $provided }개의 컬럼이 있지만 쿼리는 { $expected }개의 컬럼을 생성합니다
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # Constraint Errors

--- a/crates/vibesql-l10n/resources/nl/executor.ftl
+++ b/crates/vibesql-l10n/resources/nl/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = Parseerfout: { $message }
 executor-subquery-returned-multiple-rows = Scalaire subquery retourneerde { $actual } rijen, verwacht { $expected }
 executor-subquery-column-count-mismatch = Subquery retourneerde { $actual } kolommen, verwacht { $expected }
 executor-column-count-mismatch = Afgeleide kolommenlijst heeft { $provided } kolommen maar query produceert { $expected } kolommen
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # Constraint Errors

--- a/crates/vibesql-l10n/resources/pl/executor.ftl
+++ b/crates/vibesql-l10n/resources/pl/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = Błąd parsowania: { $message }
 executor-subquery-returned-multiple-rows = Podzapytanie skalarne zwróciło { $actual } wierszy, oczekiwano { $expected }
 executor-subquery-column-count-mismatch = Podzapytanie zwróciło { $actual } kolumn, oczekiwano { $expected }
 executor-column-count-mismatch = Lista kolumn pochodnych ma { $provided } kolumn, ale zapytanie produkuje { $expected } kolumn
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # Constraint Errors

--- a/crates/vibesql-l10n/resources/pt-BR/executor.ftl
+++ b/crates/vibesql-l10n/resources/pt-BR/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = Erro de análise: { $message }
 executor-subquery-returned-multiple-rows = Subconsulta escalar retornou { $actual } linhas, esperada { $expected }
 executor-subquery-column-count-mismatch = Subconsulta retornou { $actual } colunas, esperadas { $expected }
 executor-column-count-mismatch = Lista de colunas derivadas possui { $provided } colunas, mas a consulta produz { $expected } colunas
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # Erros de Restrição

--- a/crates/vibesql-l10n/resources/ru/executor.ftl
+++ b/crates/vibesql-l10n/resources/ru/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = Ошибка разбора: { $message }
 executor-subquery-returned-multiple-rows = Скалярный подзапрос вернул { $actual } строк, ожидалось { $expected }
 executor-subquery-column-count-mismatch = Подзапрос вернул { $actual } столбцов, ожидалось { $expected }
 executor-column-count-mismatch = Производный список столбцов содержит { $provided } столбцов, но запрос возвращает { $expected } столбцов
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # Constraint Errors

--- a/crates/vibesql-l10n/resources/sv/executor.ftl
+++ b/crates/vibesql-l10n/resources/sv/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = Tolkningsfel: { $message }
 executor-subquery-returned-multiple-rows = Skalär underfråga returnerade { $actual } rader, förväntade { $expected }
 executor-subquery-column-count-mismatch = Underfråga returnerade { $actual } kolumner, förväntade { $expected }
 executor-column-count-mismatch = Härledd kolumnlista har { $provided } kolumner men frågan producerar { $expected } kolumner
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # Constraint Errors

--- a/crates/vibesql-l10n/resources/th/executor.ftl
+++ b/crates/vibesql-l10n/resources/th/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = ข้อผิดพลาดการแยกวิเ
 executor-subquery-returned-multiple-rows = Scalar subquery คืนค่า { $actual } แถว คาดหวัง { $expected }
 executor-subquery-column-count-mismatch = Subquery คืนค่า { $actual } คอลัมน์ คาดหวัง { $expected }
 executor-column-count-mismatch = Derived column list มี { $provided } คอลัมน์ แต่ query สร้าง { $expected } คอลัมน์
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # Constraint Errors

--- a/crates/vibesql-l10n/resources/tr/executor.ftl
+++ b/crates/vibesql-l10n/resources/tr/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = Ayrıştırma hatası: { $message }
 executor-subquery-returned-multiple-rows = Skaler alt sorgu { $actual } satır döndürdü, beklenen { $expected }
 executor-subquery-column-count-mismatch = Alt sorgu { $actual } sütun döndürdü, beklenen { $expected }
 executor-column-count-mismatch = Türetilmiş sütun listesi { $provided } sütun içeriyor ancak sorgu { $expected } sütun üretiyor
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # Kısıtlama Hataları

--- a/crates/vibesql-l10n/resources/uk/executor.ftl
+++ b/crates/vibesql-l10n/resources/uk/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = Помилка парсингу: { $message }
 executor-subquery-returned-multiple-rows = Скалярний підзапит повернув { $actual } рядків, очікувався { $expected }
 executor-subquery-column-count-mismatch = Підзапит повернув { $actual } колонок, очікувалось { $expected }
 executor-column-count-mismatch = Похідний список колонок має { $provided } колонок, але запит повертає { $expected } колонок
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # Constraint Errors

--- a/crates/vibesql-l10n/resources/vi/executor.ftl
+++ b/crates/vibesql-l10n/resources/vi/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = Lỗi phân tích cú pháp: { $message }
 executor-subquery-returned-multiple-rows = Subquery vô hướng trả về { $actual } hàng, mong đợi { $expected }
 executor-subquery-column-count-mismatch = Subquery trả về { $actual } cột, mong đợi { $expected }
 executor-column-count-mismatch = Danh sách cột dẫn xuất có { $provided } cột nhưng truy vấn tạo ra { $expected } cột
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # Constraint Errors

--- a/crates/vibesql-l10n/resources/zh-CN/executor.ftl
+++ b/crates/vibesql-l10n/resources/zh-CN/executor.ftl
@@ -79,6 +79,11 @@ executor-parse-error = 解析错误：{ $message }
 executor-subquery-returned-multiple-rows = 标量子查询返回了 { $actual } 行，预期为 { $expected } 行
 executor-subquery-column-count-mismatch = 子查询返回了 { $actual } 列，预期为 { $expected } 列
 executor-column-count-mismatch = 派生列列表有 { $provided } 列，但查询生成了 { $expected } 列
+executor-in-element-arity = IN(...) element has { $actual } { $actual ->
+    [one] term
+   *[other] terms
+} - expected { $expected }
+executor-columns-assigned-values = { $columns } columns assigned { $values } values
 
 # =============================================================================
 # 约束错误


### PR DESCRIPTION
## Summary

Stage 2 of the row-values conformance work (#6046). Aligns VibeSQL's error messages for malformed row-value **arity** and **misuse** with SQLite 3.51, and closes the empty-table **prepare-time gap** where a malformed scalar-subquery statement silently succeeded because the per-row runtime check never fired.

### Changes

1. **`IN(...)` element arity** — a candidate tuple whose arity differs from the LHS tuple (including a bare scalar, which has arity 1) now reports SQLite's `IN(...) element has N term(s) - expected M` (new `ExecutorError::InElementArity`, Fluent plural selector for term/terms) instead of the generic `row value misused`. Applied in the single-table evaluator, the combined/multi-table evaluator, and the `row_values` static validator. — `rowvalueA.test` 2.0/2.1/2.2

2. **UPDATE-SET tuple arity** — `SET (a,b,...) = (...)` whose value arity differs now reports `N columns assigned M values` (new `ExecutorError::ColumnsAssignedValues`) rather than reusing the sub-select arity error. — `rowvalue7.test` 2.1/2.2/3.0

3. **Empty-table prepare-time gap** — a new static validator (`select/executor/validation/scalar_subquery_arity.rs`) inspects the top-level scalar positions SQLite rejects at prepare time: a bare multi-column subquery in a value/SELECT-list position (arity error), and a multi-column subquery compared against a plain scalar in a WHERE/value position (`row value misused` on the value side, arity error otherwise). Wired into SELECT prepare, UPDATE, DELETE, and trigger-body validation so the error surfaces even when the target table is empty. — `rowvalue.test` 15.2/15.3/15.4/15.5 and 28.10 (trigger body over an empty table)

New Fluent keys `executor-in-element-arity` / `executor-columns-assigned-values` added to `en-US` and stubbed across all 19 locales so `check-translations` parity holds. (Three unrelated pre-existing locale gaps — `executor-no-such-column`, `executor-no-such-function`, `executor-join-using-column-not-present` — remain and are out of scope.)

### Test results

| File | Before | After |
|---|---|---|
| `rowvalueA.test` | 10/13 | **13/13** |
| `rowvalue7.test` | 5/8 | **8/8** |
| `rowvalue.test` | 284/297 | **289/297** |
| `rowvalue9.test` | 73/93 | 73/93 (no regression) |
| `rowvalue2.test` | 3834/3834 | 3834/3834 (no regression) |

- `cargo test -p vibesql-executor` green (updated one `row_values` unit test that asserted the old `RowValueMisused` behavior for a mismatched IN candidate; it now asserts `InElementArity`).
- `cargo clippy -p vibesql-executor` clean on touched files.
- `cargo run -p vibesql-l10n --bin check-translations` — only the three pre-existing gaps remain.
- Each of the 11 exact repros in the issue's acceptance table verified against the rebuilt binary and match SQLite 3.51 messages byte-for-byte (singular "term" vs plural "terms" included).

Closes #6046

🤖 Generated with [Claude Code](https://claude.com/claude-code)