### PR TITLE
fix(storage): adapt blob operator construction to opendal 0.58 API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,26 @@ jobs:
         run: cargo check -p vibesql-wasm-bindings --lib --target wasm32-unknown-unknown
 
   # ============================================================================
+  # Storage feature-matrix check - catches breakage in opendal-gated blob code
+  # that the default feature set never compiles (e.g., the opendal 0.58 bump
+  # removed Operator::finish). Cheap `cargo check` only, no build/test.
+  # See issue #6081 for the regression that motivated this job.
+  # ============================================================================
+  storage-features-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache-key-suffix: storage-features
+
+      - name: Check opendal-gated storage backends
+        run: cargo check -p vibesql-storage --features storage-all
+
+  # ============================================================================
   # Extended validation tests (TPC-DS, SQLLogicTest, PostgreSQL, TCL) have been
   # moved to ci-extended.yml for manual dispatch. Run before merging significant
   # PRs with: gh workflow run ci-extended.yml

--- a/crates/vibesql-storage/src/blob/service.rs
+++ b/crates/vibesql-storage/src/blob/service.rs
@@ -76,7 +76,7 @@ impl BlobStorageService {
 
         let builder = services::Fs::default().root(root);
 
-        Operator::new(builder).map(|op| op.finish()).map_err(|e| {
+        Operator::new(builder).map_err(|e| {
             StorageError::Other(format!("Failed to create filesystem operator: {}", e))
         })
     }
@@ -114,7 +114,6 @@ impl BlobStorageService {
         }
 
         Operator::new(builder)
-            .map(|op| op.finish())
             .map_err(|e| StorageError::Other(format!("Failed to create S3 operator: {}", e)))
     }
 
@@ -141,7 +140,6 @@ impl BlobStorageService {
         }
 
         Operator::new(builder)
-            .map(|op| op.finish())
             .map_err(|e| StorageError::Other(format!("Failed to create GCS operator: {}", e)))
     }
 
@@ -172,7 +170,6 @@ impl BlobStorageService {
         }
 
         Operator::new(builder)
-            .map(|op| op.finish())
             .map_err(|e| StorageError::Other(format!("Failed to create Azure operator: {}", e)))
     }
 
@@ -182,7 +179,6 @@ impl BlobStorageService {
         let builder = services::Memory::default();
 
         Operator::new(builder)
-            .map(|op| op.finish())
             .map_err(|e| StorageError::Other(format!("Failed to create memory operator: {}", e)))
     }
 

--- a/crates/vibesql-storage/src/statistics/sampling.rs
+++ b/crates/vibesql-storage/src/statistics/sampling.rs
@@ -146,7 +146,7 @@ pub fn sample_rows<T: Clone>(rows: &[T], config: &SamplingConfig, rng: &mut impl
 fn random_sample<T: Clone>(rows: &[T], n: usize, rng: &mut impl Rng) -> Vec<T> {
     let n = n.min(rows.len());
     let indices: Vec<usize> = (0..rows.len()).collect();
-    let sampled_indices = indices.choose_multiple(rng, n);
+    let sampled_indices = indices.sample(rng, n);
 
     sampled_indices.map(|&i| rows[i].clone()).collect()
 }

--- a/crates/vibesql-storage/src/statistics/table.rs
+++ b/crates/vibesql-storage/src/statistics/table.rs
@@ -3,7 +3,6 @@
 use std::collections::HashMap;
 
 use instant::SystemTime;
-use rand::RngExt;
 
 use super::{histogram::BucketStrategy, ColumnStatistics, SampleMetadata, SamplingConfig};
 


### PR DESCRIPTION
## Summary

The Dependabot opendal 0.57→0.58 bump (merged in #6068) broke the feature-gated storage build. In 0.58, `Operator::new(builder)` returns a ready-to-use `Operator` directly instead of an `OperatorBuilder` that needed `.finish()`, so `.map(|op| op.finish())` no longer compiles:

```
error[E0599]: no method named `finish` found for struct `opendal::Operator`
   --> crates/vibesql-storage/src/blob/service.rs:117:26
```

The default feature set never compiles the opendal-gated blob service, so CI missed it. This PR fixes the build and adds a cheap CI guard so the whole class of breakage fails CI next time.

## Changes

- **blob/service.rs**: dropped the removed `.map(|op| op.finish())` from all five backend constructors (fs, s3, gcs, azure, memory). `Operator::new(builder)` already returns the finished `Operator` in 0.58 — semantically identical, minimal change.
- **CI**: added a `storage-features-check` job to `ci.yml` (`cargo check -p vibesql-storage --features storage-all`) — modeled on the existing `wasm-check` dependency-bump guard. `check` only, no build/test, covers all five storage backends in one job.
- **statistics/sampling.rs**: `rand`'s deprecated `choose_multiple` → `sample` (pure rename, identical signature) surfaced by the feature build.
- **statistics/table.rs**: removed the now-unused `rand::RngExt` import.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `cargo build -p vibesql-storage --features storage-s3` compiles | ✅ | `cargo check` finishes clean, zero warnings |
| All opendal feature combos compile | ✅ | Checked storage-fs, storage-s3, storage-gcs, storage-azure, storage-memory, storage-all — all clean, zero warnings |
| Change is semantically identical | ✅ | opendal 0.58 `Operator::new` returns finished `Operator` (verified against opendal-core-0.58.0 source); blob memory-backend store/get/delete tests pass at runtime |
| Blob/storage tests pass under features | ✅ | `cargo test -p vibesql-storage --features storage-memory --lib blob` → 19 passed |
| Default-feature tests green | ✅ | `cargo test -p vibesql-storage` → 798+ passed, 0 failed |
| CI gap closed | ✅ | New `storage-features-check` job runs `cargo check --features storage-all`; YAML validated |
| Deprecation/unused warnings fixed | ✅ | `cargo check --features storage-all` emits zero warnings for vibesql-storage |

## Test Plan

- Feature-combo build matrix (all pass, zero warnings):

  | Feature combo | Result |
  |---|---|
  | `storage-s3` | ✅ Finished |
  | `storage-fs` | ✅ Finished |
  | `storage-gcs` | ✅ Finished |
  | `storage-azure` | ✅ Finished |
  | `storage-memory` | ✅ Finished |
  | `storage-all` | ✅ Finished |

- `cargo test -p vibesql-storage --features storage-memory --lib blob` → 19 passed (exercises operator store/get/exists/delete round-trip at runtime)
- `cargo test -p vibesql-storage --lib statistics` → 76 passed (exercises the `sample` rename)
- `cargo test -p vibesql-storage` (default) → 798+ passed, 0 failed
- `cargo +nightly fmt --check` clean on all touched files
- CI YAML validated with a YAML parser

Closes #6081