### PR TITLE
fix(executor): resolve qualified columns via full outer_schema chain and expand UPDATE...FROM tuple SET

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -551,9 +551,17 @@ impl CombinedExpressionEvaluator<'_> {
                     // Create TableIdentifier for lookup (handles case-insensitive comparison)
                     let table_id = vibesql_catalog::TableIdentifier::from(table_name);
                     let inner_has_table = self.schema.table_schemas.contains_key(&table_id);
+                    // Walk the FULL outer_schema chain, not just its immediate level.
+                    // For a doubly-nested correlated subquery the innermost
+                    // evaluator's `outer_schema` is an empty merged schema whose own
+                    // `outer_schema` field links to the real outer table, so a
+                    // single-level check spuriously reported the table missing and
+                    // raised NoSuchColumn even though `get_column_index` (which walks
+                    // the chain) would have resolved it. Issue #6047 (follow-up to the
+                    // unqualified-column fix in #4618).
                     let outer_has_table = self
                         .outer_schema
-                        .is_some_and(|outer| outer.table_schemas.contains_key(&table_id));
+                        .is_some_and(|outer| outer.contains_table_in_chain(&table_id));
                     if !inner_has_table && !outer_has_table {
                         // Table qualifier doesn't exist in query - return "no such column" error
                         return Err(ExecutorError::NoSuchColumn {

--- a/crates/vibesql-executor/src/schema.rs
+++ b/crates/vibesql-executor/src/schema.rs
@@ -853,6 +853,29 @@ impl CombinedSchema {
         self.table_schemas.contains_key(&TableIdentifier::unquoted(table_name))
     }
 
+    /// Check if a table exists at this schema level or anywhere in the
+    /// `outer_schema` chain (case-insensitive lookup).
+    ///
+    /// Unlike [`contains_table`], this walks the full chain of enclosing
+    /// scopes exactly like [`get_column_index`] does (see lines around #4493),
+    /// so a qualified column reference in a doubly-nested correlated subquery
+    /// can find its outer table even when that table lives several levels up
+    /// the chain. The single-level check missed this: for an N-level-nested
+    /// subquery the innermost evaluator's immediate `outer_schema` is an empty
+    /// merged schema whose own `outer_schema` field links to the real outer
+    /// table (built by `build_merged_outer_schema`). Issue #6047 (follow-up to
+    /// the unqualified-column fix in #4618).
+    pub fn contains_table_in_chain(&self, table_id: &TableIdentifier) -> bool {
+        let mut cur = Some(self);
+        while let Some(schema) = cur {
+            if schema.table_schemas.contains_key(table_id) {
+                return true;
+            }
+            cur = schema.outer_schema.as_deref();
+        }
+        false
+    }
+
     /// Get all table names as strings (using display form)
     pub fn table_names(&self) -> Vec<String> {
         self.table_schemas.keys().map(|table_id| table_id.display().to_string()).collect()

--- a/crates/vibesql-executor/src/update/from_clause.rs
+++ b/crates/vibesql-executor/src/update/from_clause.rs
@@ -110,17 +110,49 @@ pub fn execute_update_from_join(
     // firing row. This avoids needing to thread trigger context through the
     // entire scan/join expression-evaluation stack — the synthetic SELECT
     // sees only literal values plus column refs from the joined tables.
+    //
+    // Issue #6047: a *tuple* assignment `SET (a, b, …) = (row-value | subquery)`
+    // is a single AST `Assignment` whose `value` is a row-valued expression
+    // (a `RowValueConstructor` or a multi-column `ScalarSubquery`). Projecting
+    // it as one `__set_i__` scalar item would route the row value through the
+    // ordinary scalar evaluator, which correctly rejects a >1-column result
+    // ("sub-select returns N columns - expected 1"). Instead, expand a tuple
+    // assignment into one select item per target column so each output column
+    // is an ordinary scalar computed in the join context (correlation-safe:
+    // the subquery variant keeps its FROM/WHERE, only its select-list is
+    // narrowed to the single projected column). `set_values_per_assignment`
+    // records how many output columns each assignment contributes so the
+    // unpacking below (and `apply_update_from_matches`) can flatten positionally.
+    let mut set_values_per_assignment: Vec<usize> = Vec::with_capacity(stmt.assignments.len());
     for (i, assignment) in stmt.assignments.iter().enumerate() {
-        let expr = match trigger_context {
-            Some(ctx) => substitute_pseudo_vars(&assignment.value, ctx)?,
-            None => assignment.value.clone(),
-        };
-        select_list.push(SelectItem::Expression {
-            expr,
-            alias: Some(format!("__set_{}__", i)),
-            source_text: None,
-        });
+        if assignment.is_tuple() {
+            let col_exprs = tuple_assignment_column_exprs(assignment)?;
+            for (j, expr) in col_exprs.into_iter().enumerate() {
+                let expr = match trigger_context {
+                    Some(ctx) => substitute_pseudo_vars(&expr, ctx)?,
+                    None => expr,
+                };
+                select_list.push(SelectItem::Expression {
+                    expr,
+                    alias: Some(format!("__set_{}_{}__", i, j)),
+                    source_text: None,
+                });
+            }
+            set_values_per_assignment.push(assignment.columns.len());
+        } else {
+            let expr = match trigger_context {
+                Some(ctx) => substitute_pseudo_vars(&assignment.value, ctx)?,
+                None => assignment.value.clone(),
+            };
+            select_list.push(SelectItem::Expression {
+                expr,
+                alias: Some(format!("__set_{}__", i)),
+                source_text: None,
+            });
+            set_values_per_assignment.push(1);
+        }
     }
+    let total_set_columns: usize = set_values_per_assignment.iter().sum();
 
     // Build FROM clause: target_table [alias], from_clause1, from_clause2, ...
     let target_from = FromClause::Table {
@@ -181,8 +213,10 @@ pub fn execute_update_from_join(
     let rows = executor.execute(&select_stmt)?;
 
     // Build a map from identifier values to SET values
-    // Key: either rowid (as single-element vec) or PK column values
-    let num_assignments = stmt.assignments.len();
+    // Key: either rowid (as single-element vec) or PK column values.
+    // `set_values` is a positional flattening of every SET column: single-column
+    // assignments contribute one value, tuple assignments contribute one value
+    // per target column (issue #6047).
     let mut id_to_set_values: HashMap<Vec<SqlValue>, Vec<SqlValue>> = HashMap::new();
 
     for row in rows {
@@ -201,8 +235,8 @@ pub fn execute_update_from_join(
             continue;
         }
 
-        // Extract SET values
-        let set_values: Vec<SqlValue> = (0..num_assignments)
+        // Extract SET values (flattened across all assignments; see above)
+        let set_values: Vec<SqlValue> = (0..total_set_columns)
             .map(|i| row.values.get(num_id_columns + i).cloned().unwrap_or(SqlValue::Null))
             .collect();
 
@@ -252,6 +286,68 @@ pub fn execute_update_from_join(
     }
 
     Ok(UpdateFromJoinResult { matched_rows })
+}
+
+/// Expand a tuple assignment's row-valued RHS into one scalar expression per
+/// target column, for projection into the synthetic UPDATE…FROM SELECT
+/// (issue #6047).
+///
+/// A tuple assignment `SET (a, b, …) = value` has a single row-valued `value`
+/// whose elements map positionally onto `assignment.columns`. To evaluate each
+/// target column as an ordinary scalar in the join context we need a per-column
+/// expression:
+///
+/// - `RowValueConstructor([e0, e1, …])` → the elements directly (`e0`, `e1`, …).
+///   Arity is validated against the column list here so a mismatch reports the
+///   SQLite "N columns assigned M values" error rather than a downstream shape
+///   error.
+/// - `ScalarSubquery(sub)` → one cloned subquery per column, each with its
+///   select-list narrowed to the single projected item. This preserves
+///   correlation (FROM/WHERE and the column expression are retained) and
+///   first-row semantics while yielding a single scalar column per output. A
+///   subquery whose select-list can't be split by simple index (e.g. it
+///   contains a `*` wildcard, or its arity can't be matched to the column
+///   count) is left intact so the ordinary evaluator raises the correct error.
+fn tuple_assignment_column_exprs(
+    assignment: &Assignment,
+) -> Result<Vec<Expression>, ExecutorError> {
+    let expected = assignment.columns.len();
+    match &assignment.value {
+        Expression::RowValueConstructor(elems) => {
+            if elems.len() != expected {
+                return Err(ExecutorError::ColumnsAssignedValues {
+                    columns: expected,
+                    values: elems.len(),
+                });
+            }
+            Ok(elems.clone())
+        }
+        Expression::ScalarSubquery(sub) => {
+            // Only split when the select-list is a plain list of expressions
+            // matching the target arity (no wildcards). Otherwise leave the
+            // subquery whole in every slot and let the scalar evaluator report
+            // the arity mismatch (matching the non-split fallback below).
+            let can_split = sub.select_list.len() == expected
+                && sub.select_list.iter().all(|item| matches!(item, SelectItem::Expression { .. }));
+            if can_split {
+                Ok((0..expected)
+                    .map(|j| {
+                        let mut narrowed = (**sub).clone();
+                        narrowed.select_list = vec![sub.select_list[j].clone()];
+                        Expression::ScalarSubquery(Box::new(narrowed))
+                    })
+                    .collect())
+            } else {
+                // Fall back to projecting the whole subquery for each column;
+                // the scalar evaluator will surface the correct arity error.
+                Ok(vec![assignment.value.clone(); expected])
+            }
+        }
+        // Any other RHS for a multi-column target is a misuse per SQLite
+        // (e.g. `SET (a, b) = 1`). Project it once per column and let the
+        // scalar evaluator handle it consistently with the non-FROM path.
+        _ => Ok(vec![assignment.value.clone(); expected]),
+    }
 }
 
 /// Get the PRIMARY KEY column names for a table
@@ -315,7 +411,43 @@ pub(super) fn apply_update_from_matches(
         let mut changed_columns = HashSet::new();
         let mut updates_pk = false;
 
-        for (i, assignment) in assignments.iter().enumerate() {
+        // `m.set_values` is a positional flattening of every SET column: a
+        // single-column assignment consumes one value, a tuple assignment
+        // consumes one value per target column (issue #6047). Track the running
+        // offset into `set_values` as we walk assignments.
+        let mut value_offset = 0usize;
+
+        for assignment in assignments {
+            // Tuple assignment `(a, b, …) = (row-value | subquery)`: consume one
+            // computed value per target column, in order.
+            if assignment.is_tuple() {
+                for col_name in &assignment.columns {
+                    let value = m.set_values.get(value_offset).cloned().unwrap_or(SqlValue::Null);
+                    value_offset += 1;
+
+                    let col_index = target_schema.get_column_index(col_name).ok_or_else(|| {
+                        ExecutorError::NoSuchColumn { column_ref: col_name.clone() }
+                    })?;
+                    let coerced_value = crate::insert::validation::coerce_value(
+                        value,
+                        &target_schema.columns[col_index].data_type,
+                    )?;
+                    new_row
+                        .set(col_index, coerced_value)
+                        .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+                    changed_columns.insert(col_index);
+                    if let Some(ref pk) = pk_indices {
+                        if pk.contains(&col_index) {
+                            updates_pk = true;
+                        }
+                    }
+                }
+                continue;
+            }
+
+            let value = m.set_values.get(value_offset).cloned().unwrap_or(SqlValue::Null);
+            value_offset += 1;
+
             // Handle rowid assignment specially
             let col_name_lower = assignment.column.to_lowercase();
             let is_rowid =
@@ -325,7 +457,7 @@ pub(super) fn apply_update_from_matches(
                 // Handle rowid update
                 if let Some(ipk_col_idx) = target_schema.rowid_alias_column {
                     new_row
-                        .set(ipk_col_idx, m.set_values[i].clone())
+                        .set(ipk_col_idx, value)
                         .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
                     changed_columns.insert(ipk_col_idx);
                     if pk_indices.as_ref().is_some_and(|pk| pk.contains(&ipk_col_idx)) {
@@ -333,7 +465,7 @@ pub(super) fn apply_update_from_matches(
                     }
                 } else {
                     // Update virtual rowid
-                    let new_rowid = match &m.set_values[i] {
+                    let new_rowid = match &value {
                         SqlValue::Integer(id) => *id as u64,
                         SqlValue::Bigint(id) => *id as u64,
                         other => {
@@ -356,7 +488,7 @@ pub(super) fn apply_update_from_matches(
 
             // Coerce value to column type
             let coerced_value = crate::insert::validation::coerce_value(
-                m.set_values[i].clone(),
+                value,
                 &target_schema.columns[col_index].data_type,
             )?;
 

--- a/crates/vibesql-executor/tests/nested_qualified_correlated_subquery_tests.rs
+++ b/crates/vibesql-executor/tests/nested_qualified_correlated_subquery_tests.rs
@@ -1,0 +1,105 @@
+//! Regression tests for issue #6047 (root cause 1).
+//!
+//! A qualified column reference (`t1.y`) inside a *doubly*-nested correlated
+//! scalar subquery must resolve against the outer table even when that table
+//! lives several levels up the `outer_schema` chain.
+//!
+//! The single-level table-existence pre-check in the combined evaluator
+//! (`eval_column_ref`, added for issue #4510) only inspected the *immediate*
+//! `outer_schema`'s `table_schemas` map. For an N-level-nested subquery the
+//! innermost evaluator's immediate outer schema is an empty merged schema whose
+//! own `outer_schema` field links to the real outer table, so the pre-check
+//! spuriously raised `no such column: t1.y` — even though the actual column
+//! resolver (`CombinedSchema::get_column_index`) walks the whole chain and would
+//! have found it. This is the qualified-column analogue of #4618 (which fixed
+//! the *unqualified* double-nesting case).
+//!
+//! Expected values verified against sqlite3 3.51.
+
+use vibesql_catalog::{ColumnSchema, TableSchema};
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::{Database, Row};
+use vibesql_types::{DataType, SqlValue};
+
+fn parse_select(sql: &str) -> vibesql_ast::SelectStmt {
+    match Parser::parse_sql(sql) {
+        Ok(vibesql_ast::Statement::Select(select_stmt)) => *select_stmt,
+        _ => panic!("Failed to parse SELECT statement: {}", sql),
+    }
+}
+
+fn run(db: &Database, sql: &str) -> Vec<Row> {
+    let select = parse_select(sql);
+    SelectExecutor::new(db).execute(&select).unwrap()
+}
+
+/// One scalar integer from the single result row/column.
+fn scalar(rows: &[Row]) -> i64 {
+    assert_eq!(rows.len(), 1, "expected exactly one result row");
+    match rows[0].get(0) {
+        Some(SqlValue::Integer(n)) => *n,
+        Some(SqlValue::Bigint(n)) => *n,
+        other => panic!("expected integer at index 0, got {other:?}"),
+    }
+}
+
+/// `CREATE TABLE t1(x, y, z); INSERT INTO t1 VALUES(1000, 2000, 3000);`
+fn setup_db() -> Database {
+    let mut db = Database::new();
+    let t1 = TableSchema::new(
+        "t1".to_string(),
+        vec![
+            ColumnSchema::new("x".to_string(), DataType::Integer, true),
+            ColumnSchema::new("y".to_string(), DataType::Integer, true),
+            ColumnSchema::new("z".to_string(), DataType::Integer, true),
+        ],
+    );
+    db.create_table(t1).unwrap();
+    db.insert_row(
+        "t1",
+        Row::new(vec![SqlValue::Integer(1000), SqlValue::Integer(2000), SqlValue::Integer(3000)]),
+    )
+    .unwrap();
+    db
+}
+
+/// Single-level nesting already worked before the fix — keep it as a control.
+#[test]
+fn single_level_qualified_correlation() {
+    let db = setup_db();
+    assert_eq!(scalar(&run(&db, "SELECT (SELECT t1.y) FROM t1")), 2000);
+}
+
+/// The primary reproducer: two-level nesting with a qualified outer reference.
+/// Used to fail with `no such column: t1.y`.
+#[test]
+fn double_nested_qualified_correlation() {
+    let db = setup_db();
+    assert_eq!(scalar(&run(&db, "SELECT (SELECT (SELECT t1.y)) FROM t1")), 2000);
+}
+
+/// Three levels deep resolves through the full chain.
+#[test]
+fn triple_nested_qualified_correlation() {
+    let db = setup_db();
+    assert_eq!(scalar(&run(&db, "SELECT (SELECT (SELECT (SELECT t1.y))) FROM t1")), 2000);
+}
+
+/// The nested reference can point at any column of the outer table.
+#[test]
+fn double_nested_qualified_correlation_other_column() {
+    let db = setup_db();
+    assert_eq!(scalar(&run(&db, "SELECT (SELECT (SELECT t1.x)) FROM t1")), 1000);
+    assert_eq!(scalar(&run(&db, "SELECT (SELECT (SELECT t1.z)) FROM t1")), 3000);
+}
+
+/// A genuinely-missing qualified table still errors — the chain walk must not
+/// mask an out-of-scope reference.
+#[test]
+fn missing_qualified_table_still_errors() {
+    let db = setup_db();
+    let select = parse_select("SELECT (SELECT (SELECT nosuch.y)) FROM t1");
+    let result = SelectExecutor::new(&db).execute(&select);
+    assert!(result.is_err(), "reference to a non-existent table must error");
+}

--- a/crates/vibesql-executor/tests/tuple_set_assignment_tests.rs
+++ b/crates/vibesql-executor/tests/tuple_set_assignment_tests.rs
@@ -122,3 +122,94 @@ fn on_conflict_do_update_tuple_set_subquery() {
     assert_eq!(r[1], SqlValue::Integer(7));
     assert_eq!(r[2], SqlValue::Varchar("y".into()));
 }
+
+// ============================================================================
+// UPDATE ... FROM tuple/row SET assignments (issue #6047, root cause 2)
+//
+// `UPDATE t2 SET (a, b) = (...) FROM src` rewrites into a synthetic SELECT.
+// A tuple assignment's RHS is a *row value*, not a scalar, in this position;
+// projecting it as a single scalar column would wrongly raise
+// "sub-select returns 2 columns - expected 1". Each target column must be
+// projected as its own scalar in the join context.
+// ============================================================================
+
+/// Fixture for UPDATE…FROM: a target `t2(a, b)` and a source `t1(x, y, z)`.
+fn setup_from() -> Database {
+    let mut db = Database::new();
+    for sql in [
+        "CREATE TABLE t1(x, y, z)",
+        "CREATE TABLE t2(a, b)",
+        "INSERT INTO t1 VALUES(1000, 2000, 3000)",
+        "INSERT INTO t2 VALUES(NULL, NULL)",
+    ] {
+        match Parser::parse_sql(sql).expect("parse") {
+            vibesql_ast::Statement::CreateTable(ct) => {
+                CreateTableExecutor::execute(&ct, &mut db).expect("create");
+            }
+            vibesql_ast::Statement::Insert(ins) => {
+                InsertExecutor::execute(&mut db, &ins).expect("insert");
+            }
+            _ => panic!("unexpected setup statement"),
+        }
+    }
+    db
+}
+
+fn t2_first_row(db: &Database) -> Vec<SqlValue> {
+    let table = db.get_table("t2").expect("t2");
+    table.scan().iter().next().map(|r| r.values.to_vec()).unwrap_or_default()
+}
+
+/// The minimized root-cause-2 reproducer: a bare (FROM-less) subquery RHS with
+/// a target tuple, driven by an UPDATE…FROM. Used to fail with
+/// "sub-select returns 2 columns - expected 1".
+#[test]
+fn update_from_tuple_set_bare_subquery() {
+    let mut db = setup_from();
+    run_update(&mut db, "UPDATE t2 SET (a, b) = (SELECT 1, 2) FROM t1").expect("update");
+    let r = t2_first_row(&db);
+    assert_eq!(r[0], SqlValue::Integer(1));
+    assert_eq!(r[1], SqlValue::Integer(2));
+}
+
+/// A literal row-value RHS (no subquery) driven by UPDATE…FROM.
+#[test]
+fn update_from_tuple_set_row_value() {
+    let mut db = setup_from();
+    run_update(&mut db, "UPDATE t2 SET (a, b) = (7, 8) FROM t1").expect("update");
+    let r = t2_first_row(&db);
+    assert_eq!(r[0], SqlValue::Integer(7));
+    assert_eq!(r[1], SqlValue::Integer(8));
+}
+
+/// A correlated tuple RHS that references the FROM table's columns. The subquery
+/// projects `t1.x, t1.y`, so `t2` should receive `(1000, 2000)`.
+#[test]
+fn update_from_tuple_set_correlated_subquery() {
+    let mut db = setup_from();
+    run_update(&mut db, "UPDATE t2 SET (a, b) = (SELECT t1.x, t1.y) FROM t1").expect("update");
+    let r = t2_first_row(&db);
+    assert_eq!(r[0], SqlValue::Integer(1000));
+    assert_eq!(r[1], SqlValue::Integer(2000));
+}
+
+/// The FROM table's columns can be referenced directly (not via subquery) in the
+/// tuple RHS.
+#[test]
+fn update_from_tuple_set_direct_column_refs() {
+    let mut db = setup_from();
+    run_update(&mut db, "UPDATE t2 SET (a, b) = (t1.z, t1.x) FROM t1").expect("update");
+    let r = t2_first_row(&db);
+    assert_eq!(r[0], SqlValue::Integer(3000));
+    assert_eq!(r[1], SqlValue::Integer(1000));
+}
+
+/// A single-column assignment under UPDATE…FROM must still work (no regression
+/// to the ordinary non-tuple synthetic-SELECT path).
+#[test]
+fn update_from_single_column_assignment_unaffected() {
+    let mut db = setup_from();
+    run_update(&mut db, "UPDATE t2 SET a = t1.y FROM t1").expect("update");
+    let r = t2_first_row(&db);
+    assert_eq!(r[0], SqlValue::Integer(2000));
+}


### PR DESCRIPTION
## Summary

Fixes two independent nested-subquery / row-value bugs surfaced by
`rowvalue.test` §30.1/§30.2 (Stage 3 of the row-values track, #6047). Both
verified against `sqlite3 3.51`.

1. **Qualified column in a doubly-nested correlated scalar subquery** raised
   `no such column: t1.y`. The combined evaluator's table-existence pre-check
   (added for #4510) only inspected the *immediate* `outer_schema`'s
   `table_schemas` map, while for an N-level-nested subquery the outer table
   lives several links up the `outer_schema` chain. The actual resolver
   (`CombinedSchema::get_column_index`) already walks the chain, so the guard
   spuriously rejected a reference the resolver would have found. This is the
   qualified-column analogue of #4618 (which fixed the unqualified case).

2. **`UPDATE t2 SET (a,b)=(SELECT 1,2) FROM t1`** (masked by bug 1) failed with
   "sub-select returns 2 columns - expected 1". The `UPDATE ... FROM` rewrite
   projected each tuple assignment as a single `__set_i__` scalar select item,
   routing a row-valued RHS through the scalar-arity-enforcing evaluator. A
   tuple assignment's RHS is legitimately a row value in this position.

## Changes

- `schema.rs`: add `CombinedSchema::contains_table_in_chain`, which walks the
  full `outer_schema` chain (mirroring `get_column_index`).
- `evaluator/combined/eval.rs`: the qualified-`ColumnRef` table-existence
  pre-check now uses `contains_table_in_chain` instead of a one-level check.
- `update/from_clause.rs`: expand a tuple assignment into one scalar select
  item per target column — row-value elements directly; a splittable
  multi-column subquery narrowed to one projected column per item (correlation
  and first-row semantics preserved). Track per-assignment column counts and
  flatten them positionally in both the id→set-values map and
  `apply_update_from_matches`. Single-column assignments and the trigger-body
  path are unchanged.
- New unit tests: `nested_qualified_correlated_subquery_tests.rs` (single /
  double / triple-nested qualified correlation + missing-table error) and
  additions to `tuple_set_assignment_tests.rs` (`UPDATE ... FROM` tuple
  assignment: bare subquery, literal row value, correlated subquery, direct
  column refs, single-column control).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `rowvalue.test` 30.1/30.2 pass; file reaches 291/297 | ✅ | 291 passed; the 6 remaining failures are exactly the pre-existing out-of-scope ones (18.2, 18.5, 23.100, 23.110, 24.100, 34.5) |
| Differential parity with sqlite3 3.51 for curator repros | ✅ | `SELECT (SELECT (SELECT t1.y)) FROM t1`→2000; 3-level→2000; `UPDATE t2 SET (a,b)=(SELECT 1,2) FROM t1; SELECT * FROM t2`→`1\|2`; full §30.1/30.2 window case→`1000\|2` |
| No regressions: rowvalue7 8/8, rowvalue9 73/93, rowvalueA 13/13, rowvalue2 3834/3834 | ✅ | 8/8, 73/93, 13/13, 3834/3834 |
| Root-cause-1 correlated-subquery files unregressed | ✅ | select1 188/188, window1 270 (only pre-existing 10.8 fails — confirmed identical on clean base), window4 216/225; subquery.test & aggnested.test whole-file self-skip (unchanged) |
| Unit tests for both fixes (incl. 3-level qualified; UPDATE-FROM tuple) | ✅ | 5 + 12 new tests pass |
| `cargo test -p vibesql-executor` green | ✅ | Full crate test suite exits 0 |

## Test Plan

- `cargo test -p vibesql-executor` — green (incl. 17 new tests).
- Release CLI binary built (`-p vibesql-cli`); manual differential repros match sqlite3 3.51.
- TCL: `rowvalue.test` 291/297 (Δ+2), rowvalue7/9/A/2 baselines held, select1/window1/window4 unregressed.

Note: `cargo build --release` for the *whole workspace* currently fails in
`vibesql-storage`'s blob/opendal service (`Operator::finish` removed by an
opendal 0.58 minor bump in `Cargo.lock`) — a pre-existing break on the base
commit, in code untouched by this PR and gated behind the `storage-*` features.
The `vibesql` CLI binary (used by the TCL runner) builds cleanly.

Closes #6047