### PR TITLE
test(tcl): add drop_all_indexes shim proc + document rowvalue EQP/join-order skips

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -4741,6 +4741,8 @@ array set vibesql_skip_tests {
     indexexpr2-8.5.25.2 "Result gap downstream of indexexpr2-8.5.25.1 coercion gap (out of scope for #5695)."
     indexexpr2-9.0 "Expression-index aggregate result is empty where SQLite returns rows (expression-index execution gap unrelated to plan selection, out of scope for #5695)."
     indexexpr2-10.0 "Parser gap: 'IN'-clause form in this expression-index context is not parsed ('near \"IN\": syntax error') (out of scope for #5695)."
+    rowvalue-34.5 "SQLite-implementation-defined EQP text (row-value Stage 4, #6048, part of #5779). Correctness is identical — both VibeSQL and sqlite3 3.51.0 return {} for the underlying query. Only the query-plan SHAPE differs: SQLite pushes t2.id>999 into a covering-index search on t1a(a,id); VibeSQL does a rowid=?/rowid>? PK search plus a separate scan and a temp-B-tree sort. The root cause is a composite-index join-predicate-pushdown optimizer capability gap, out of scope for a row-value correctness stage — recommended as a separate optimizer-track follow-up in #6048's curation. Skipped as an EQP-text-only mismatch, not a correctness defect."
+    rowvalue9-1.6.2 "SQLite-implementation-defined join iteration order (row-value Stage 4, #6048, part of #5779). VibeSQL returns the correct value set (3 14 15 92, each twice) but in a different nested-loop join order than SQLite for this unordered EXISTS join (no ORDER BY). Pre-existing nested-loop ordering artifact documented in PR #6064; values match, only row order differs. Skipped rather than chased since the query has no ORDER BY and the result set is correct."
 }
 
 # -----------------------------------------------------------------------------
@@ -7110,6 +7112,28 @@ proc drop_all_tables {} {
         foreach table $tables {
             catch {execsql "DROP TABLE IF EXISTS $table"}
         }
+    }
+    return
+}
+
+proc drop_all_indexes {{db db}} {
+    # Drop all auxiliary (CREATE INDEX) indexes from the database.
+    # Ported from the canonical SQLite harness
+    # (docs/reference/sqlite/test/tester.tcl:2284) but expressed via the shim's
+    # execsql idiom (matching drop_all_tables above) rather than a raw [$db eval].
+    #
+    # The `sql LIKE 'create%'` filter naturally excludes auto-indexes (which
+    # have sql IS NULL), so only user-created indexes are dropped. Used by tests
+    # such as rowvalue3/rowvalue4 to reset index state between blocks; without
+    # it those files abort mid-run with `invalid command name "drop_all_indexes"`.
+    if {$::db_file eq ""} {
+        return
+    }
+    set indexes [execsql {
+        SELECT name FROM sqlite_master WHERE type='index' AND sql LIKE 'create%'
+    }]
+    foreach idx $indexes {
+        catch {execsql "DROP INDEX $idx"}
     }
     return
 }


### PR DESCRIPTION
## Summary

Row-value Stage 4 harness closure (part of #5779). Adds the `drop_all_indexes` proc to the VibeSQL TCL shim — a curator-verified pure harness unlock that was blocking `rowvalue3.test` and `rowvalue4.test` from running to completion — plus two documented skip entries for SQLite-implementation-defined mismatches (correctness identical, only plan text / row order differs).

The remaining row-value **correctness** residuals were each traced and found to be shared-machinery defects (not contained in `row_value.rs`) that overlap executor code owned by other in-flight builders (casting/collation, order-validation). Per this issue's scope directive — keep executor changes minimal, defer any fixable-now item that collides — they were filed as follow-ups (#6087, #6088, #6089) rather than fixed here, so nothing is lost.

## Changes

- **`scripts/tester_vibesql.tcl`**:
  - Added `proc drop_all_indexes {{db db}}`, ported from `docs/reference/sqlite/test/tester.tcl:2284` and expressed via the shim's existing `execsql` idiom (matching `drop_all_tables`). `sql LIKE 'create%'` excludes auto-indexes. Without it, rowvalue3/4 aborted with `invalid command name "drop_all_indexes"`.
  - Added `vibesql_skip_tests` entries `rowvalue-34.5` (EQP-text-only optimizer-plan mismatch; both engines return `{}`) and `rowvalue9-1.6.2` (unordered EXISTS join iteration order; value set matches), each with a justification comment cross-referencing #6048 / #5779.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| rowvalue3.test 111/111 | ✅ | `make test-tcl-file FILE=rowvalue3.test` → 111 passed, 0 failed (was aborting at 35/50) |
| rowvalue4.test 288/291 or better, 3 residuals documented | ✅ | 288 passed, 3 failed (was aborting at 13). Residuals: 7.3/7.4 → #6089; 8.2 → #6079 |
| No regression: rowvalue 291 passing | ✅ | 291 passed, 5 failed, 2 skipped (34.5 now a documented skip) |
| No regression: rowvalue9 73 passing | ✅ | 73 passed, 19 failed, 1 skipped (1.6.2 now a documented skip) |
| No regression: rowvalueA 13/13, rowvalue7 8/8, rowvalue2 3834/3834 | ✅ | 13/13, 8/8, 3834/3834 — unchanged |
| verify_skips.py exits 0 | ✅ | `python3 scripts/verify_skips.py` → exit 0, 0 outdated skips |
| Two follow-up issues filed | ✅ | #6087 (outer-rowid correlation), #6088 (WHERE-path rowid IN) |

## Per-file before → after

| File | Before | After |
|------|--------|-------|
| rowvalue3.test | 35/50 then **abort** (`drop_all_indexes` undefined) | **111/111** |
| rowvalue4.test | 13/? then **abort** | **288/291** (3 residuals) |
| rowvalue.test | 291/297 (6 fail, 1 skip) | 291 pass, 5 fail, **2 skip** (34.5 → documented skip) |
| rowvalue9.test | 73/93 (20 fail) | 73 pass, 19 fail, **1 skip** (1.6.2 → documented skip) |
| rowvalueA.test | 13/13 | 13/13 |
| rowvalue7.test | 8/8 | 8/8 |
| rowvalue2.test | 3834/3834 | 3834/3834 |

## Scope note: deferred correctness fixes

The curator classified rowvalue §18.2/18.5/23.100/23.110/24.100 and rowvalue4 §7.3/7.4 as "fixable-now" in `row_value.rs`. On tracing, each turned out to be a **shared-machinery** defect that reproduces outside the row-value path and overlaps concurrent builders' executor code:

- **COLLATE-name validation** (§23.100/110, rowvalue4 §7.3/7.4): unknown collation names are silently ignored even in the plain scalar path — `SELECT a COLLATE nose FROM t` succeeds instead of raising `no such collation sequence: nose`. Global collation-resolution fix, high regression surface, overlaps casting/collation-owned code.
- **TEXT-affinity coercion** (§24.100): `t0.c0 > CAST(0 AS REAL)` returns the wrong result in the **scalar** path too, so the fix site is the shared comparison/affinity machinery (casting-owned), not `row_value.rs`.
- **VALUES-as-LHS outer-column resolution** (§18.2/18.5): correlated-subquery execution defect (correlation *detection* already works; the gap is downstream schema-building — curator said "trace, don't assume").

All deferred to **#6089** (with differential repros) to avoid regressions colliding with three concurrent executor builders. §8.2 arity residuals remain tracked by **#6079**.

## Follow-up issues filed

- **#6087** — correlated subquery reference to outer `rowid` not re-evaluated per outer row (rowvalue9 `4.$tn.4`/`.6`, 16 tests).
- **#6088** — WHERE-path `rowid IN (subquery)` returns empty when SELECT-list form works (rowvalue9 `5.2`/`5.3`).
- **#6089** — row-value/scalar comparison affinity + COLLATE-name validation gaps (rowvalue §18/23/24, rowvalue4 §7.3/7.4) — deferred correctness fixes.

## Test Plan

1. `make test-tcl-file FILE=rowvalue3.test` → 111/111.
2. `make test-tcl-file FILE=rowvalue4.test` → 288/291.
3. `make test-tcl-file FILE={rowvalue,rowvalue9,rowvalueA,rowvalue7,rowvalue2}.test` → no regressions (skips honored).
4. `python3 scripts/verify_skips.py` → exit 0.
5. Differential repros vs sqlite3 3.51.0 captured in each follow-up issue.

Closes #6048