### PR TITLE
fix(executor): evaluate GLOB with non-literal operands in the aggregation simple evaluator

### DIFF
--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/simple.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/simple.rs
@@ -295,6 +295,81 @@ pub(super) fn evaluate(
             Ok(vibesql_types::SqlValue::Boolean(result))
         }
 
+        // GLOB: expr GLOB pattern
+        //
+        // Mirrors the scalar-evaluator path (evaluator/expressions/predicates.rs
+        // eval_glob) but evaluates both operands with aggregate support so that
+        // non-literal operands (columns, subqueries, IN, IsNull, Cast, function
+        // calls, NULL/numeric literals) work in the simple/scalar evaluator
+        // instead of raising "Unexpected expression in simple evaluator". (#6070)
+        //
+        // GLOB is always case-sensitive and does not take an ESCAPE clause,
+        // which is why it uses glob_match rather than like_match.
+        vibesql_ast::Expression::Glob { expr: test_expr, pattern, negated, .. } => {
+            let test_val =
+                executor.evaluate_with_aggregates(test_expr, group_rows, group_key, evaluator)?;
+            let pattern_val =
+                executor.evaluate_with_aggregates(pattern, group_rows, group_key, evaluator)?;
+
+            // Coerce operands to text, mirroring eval_glob's rules: SQLite
+            // renders numerics as text, booleans (EXISTS/IN results) as 0/1,
+            // and blob bytes as raw text; NULL on either side yields NULL.
+            let text = match &test_val {
+                vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
+                    s.clone()
+                }
+                vibesql_types::SqlValue::Null => return Ok(vibesql_types::SqlValue::Null),
+                vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
+                vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+                vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
+                vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
+                vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+                vibesql_types::SqlValue::Boolean(b) => {
+                    arcstr::ArcStr::from(if *b { "1" } else { "0" })
+                }
+                vibesql_types::SqlValue::Blob(b) => {
+                    arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned())
+                }
+                _ => {
+                    return Err(ExecutorError::TypeMismatch {
+                        left: test_val,
+                        op: "GLOB".to_string(),
+                        right: pattern_val,
+                    })
+                }
+            };
+
+            let pattern_str = match &pattern_val {
+                vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
+                    s.clone()
+                }
+                vibesql_types::SqlValue::Null => return Ok(vibesql_types::SqlValue::Null),
+                vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
+                vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+                vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
+                vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
+                vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+                vibesql_types::SqlValue::Boolean(b) => {
+                    arcstr::ArcStr::from(if *b { "1" } else { "0" })
+                }
+                vibesql_types::SqlValue::Blob(b) => {
+                    arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned())
+                }
+                _ => {
+                    return Err(ExecutorError::TypeMismatch {
+                        left: test_val,
+                        op: "GLOB".to_string(),
+                        right: pattern_val,
+                    })
+                }
+            };
+
+            let matches = pattern::glob_match(&text, &pattern_str);
+            let result = if *negated { !matches } else { matches };
+
+            Ok(vibesql_types::SqlValue::Boolean(result))
+        }
+
         // IS NULL / IS NOT NULL
         vibesql_ast::Expression::IsNull { expr: test_expr, negated } => {
             let value =

--- a/crates/vibesql-executor/tests/glob_simple_evaluator_tests.rs
+++ b/crates/vibesql-executor/tests/glob_simple_evaluator_tests.rs
@@ -1,0 +1,217 @@
+//! Tests for GLOB in the simple (scalar) evaluator with non-literal operands (Issue #6070)
+//!
+//! The scalar "simple evaluator" used inside the aggregation path
+//! (`select::executor::aggregation::evaluation::simple`) previously had no
+//! `Glob` arm, so any GLOB expression that reached it — even one with plain
+//! literal operands — failed with:
+//!
+//! ```text
+//! Unsupported expression: Unexpected expression in simple evaluator: Glob { ... }
+//! ```
+//!
+//! This is the #5884/#5892 class: GLOB works on the row/columnar scalar path
+//! but blew up on the aggregation simple-evaluator path. These tests drive
+//! GLOB (and NOT GLOB) with literal, column, expression, subquery, CAST, IN,
+//! IS NULL, function, NULL, and numeric operands through a GROUP BY query so
+//! the expression is routed through the simple evaluator.
+
+use vibesql_executor::SelectExecutor;
+
+/// Build a one-row table so a GROUP BY query routes non-aggregate SELECT-list
+/// expressions through the aggregation simple evaluator.
+fn setup_db() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+
+    let schema = vibesql_catalog::TableSchema::new(
+        "T".to_string(),
+        vec![
+            vibesql_catalog::ColumnSchema::new(
+                "G".to_string(),
+                vibesql_types::DataType::Integer,
+                false,
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "NAME".to_string(),
+                vibesql_types::DataType::Varchar { max_length: Some(64) },
+                true,
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "PAT".to_string(),
+                vibesql_types::DataType::Varchar { max_length: Some(64) },
+                true,
+            ),
+            vibesql_catalog::ColumnSchema::new(
+                "NUM".to_string(),
+                vibesql_types::DataType::Integer,
+                true,
+            ),
+        ],
+    );
+    db.create_table(schema).unwrap();
+
+    db.insert_row(
+        "T",
+        vibesql_storage::Row::new(vec![
+            vibesql_types::SqlValue::Integer(1),
+            vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("abc")),
+            vibesql_types::SqlValue::Varchar(arcstr::ArcStr::from("a*")),
+            vibesql_types::SqlValue::Integer(12),
+        ]),
+    )
+    .unwrap();
+
+    db
+}
+
+/// Run a single-column, single-row SELECT and return the scalar result.
+fn eval_scalar(db: &vibesql_storage::Database, sql: &str) -> vibesql_types::SqlValue {
+    let executor = SelectExecutor::new(db);
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e:?}"));
+    let vibesql_ast::Statement::Select(select_stmt) = stmt else {
+        panic!("Expected SELECT statement for `{sql}`");
+    };
+    let rows = executor
+        .execute(&select_stmt)
+        .unwrap_or_else(|e| panic!("execute failed for `{sql}`: {e:?}"));
+    assert_eq!(rows.len(), 1, "expected exactly one row for `{sql}`");
+    rows[0].values[0].clone()
+}
+
+/// SQLite renders GLOB match results as integers 0/1; VibeSQL uses Boolean.
+/// Accept either representation of a truthy/falsy scalar.
+fn assert_bool(value: &vibesql_types::SqlValue, expected: bool, sql: &str) {
+    match value {
+        vibesql_types::SqlValue::Boolean(b) => {
+            assert_eq!(*b, expected, "`{sql}` -> {value:?}, expected {expected}")
+        }
+        vibesql_types::SqlValue::Integer(i) => {
+            assert_eq!(*i, expected as i64, "`{sql}` -> {value:?}, expected {expected}")
+        }
+        other => panic!("`{sql}` -> {other:?}, expected boolean {expected}"),
+    }
+}
+
+fn assert_null(value: &vibesql_types::SqlValue, sql: &str) {
+    assert!(matches!(value, vibesql_types::SqlValue::Null), "`{sql}` -> {value:?}, expected NULL");
+}
+
+/// Literal operands on both sides (regression: previously errored even for
+/// pure literals — mirrors fuzz-4.2.4455 `Glob { Literal(Null), Literal }`).
+#[test]
+fn glob_literal_operands() {
+    let db = setup_db();
+
+    assert_bool(
+        &eval_scalar(&db, "SELECT 'abc' GLOB 'a*' FROM t GROUP BY g"),
+        true,
+        "literal match",
+    );
+    assert_bool(
+        &eval_scalar(&db, "SELECT 'abc' GLOB 'x*' FROM t GROUP BY g"),
+        false,
+        "literal non-match",
+    );
+    assert_bool(
+        &eval_scalar(&db, "SELECT 'abc' NOT GLOB 'x*' FROM t GROUP BY g"),
+        true,
+        "literal NOT GLOB",
+    );
+    // NULL literal on the left yields NULL (fuzz-4.2.4455 shape).
+    assert_null(&eval_scalar(&db, "SELECT NULL GLOB 'abc' FROM t GROUP BY g"), "NULL GLOB literal");
+    // NULL pattern yields NULL.
+    assert_null(&eval_scalar(&db, "SELECT 'abc' GLOB NULL FROM t GROUP BY g"), "literal GLOB NULL");
+}
+
+/// GLOB is case-sensitive (unlike default LIKE).
+#[test]
+fn glob_is_case_sensitive() {
+    let db = setup_db();
+    assert_bool(
+        &eval_scalar(&db, "SELECT 'ABC' GLOB 'abc' FROM t GROUP BY g"),
+        false,
+        "GLOB case sensitivity",
+    );
+    assert_bool(
+        &eval_scalar(&db, "SELECT 'ABC' GLOB 'ABC' FROM t GROUP BY g"),
+        true,
+        "GLOB exact case",
+    );
+}
+
+/// Column operands on both the value and pattern side.
+#[test]
+fn glob_column_operands() {
+    let db = setup_db();
+    assert_bool(
+        &eval_scalar(&db, "SELECT name GLOB pat FROM t GROUP BY g"),
+        true,
+        "column GLOB column ('abc' GLOB 'a*')",
+    );
+    assert_bool(
+        &eval_scalar(&db, "SELECT name GLOB 'x*' FROM t GROUP BY g"),
+        false,
+        "column GLOB literal (non-match)",
+    );
+    assert_bool(
+        &eval_scalar(&db, "SELECT 'abc' GLOB pat FROM t GROUP BY g"),
+        true,
+        "literal GLOB column",
+    );
+}
+
+/// Arbitrary expression operands (function, CAST, IN, IS NULL, NULL, numeric)
+/// — the exact non-literal shapes enumerated in the issue.
+#[test]
+fn glob_expression_operands() {
+    let db = setup_db();
+
+    // Function operand: upper('abc') -> 'ABC'
+    assert_bool(
+        &eval_scalar(&db, "SELECT upper(name) GLOB 'ABC' FROM t GROUP BY g"),
+        true,
+        "function operand",
+    );
+
+    // CAST operand: numeric coerced to text for GLOB.
+    assert_bool(
+        &eval_scalar(&db, "SELECT CAST(num AS TEXT) GLOB '1*' FROM t GROUP BY g"),
+        true,
+        "CAST operand ('12' GLOB '1*')",
+    );
+
+    // Numeric literal coerced to text on both sides.
+    assert_bool(
+        &eval_scalar(&db, "SELECT 12 GLOB '1*' FROM t GROUP BY g"),
+        true,
+        "numeric value coerced to text",
+    );
+
+    // IN expression as operand (boolean 1/0 rendered as text).
+    assert_bool(
+        &eval_scalar(&db, "SELECT (g IN (1,2)) GLOB '1' FROM t GROUP BY g"),
+        true,
+        "IN result GLOB '1'",
+    );
+
+    // IS NULL expression as operand.
+    assert_bool(
+        &eval_scalar(&db, "SELECT (name IS NULL) GLOB '0' FROM t GROUP BY g"),
+        true,
+        "IS NULL result GLOB '0'",
+    );
+
+    // Scalar subquery as pattern operand.
+    assert_bool(
+        &eval_scalar(&db, "SELECT name GLOB (SELECT pat FROM t) FROM t GROUP BY g"),
+        true,
+        "subquery pattern",
+    );
+
+    // NOT GLOB with an expression operand.
+    assert_bool(
+        &eval_scalar(&db, "SELECT upper(name) NOT GLOB 'zzz' FROM t GROUP BY g"),
+        true,
+        "NOT GLOB expression operand",
+    );
+}

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -4748,28 +4748,33 @@ array set vibesql_skip_tests {
 #
 # The fuzz2-*/fuzz4-* entries in vibesql_skip_tests above are whole-file-differs
 # skips for the SIBLING files fuzz2.test / fuzz4.test. The DIFFERENT file
-# fuzz.test (35,031 tests, srand(0) deterministic corpus) has 33 residual
+# fuzz.test (35,031 tests, srand(0) deterministic corpus) had 33 residual
 # failures as of the #6041 classification pass, and — unlike fuzz2/fuzz4 —
-# EVERY ONE of those 33 is a REAL engine gap, not a harness artifact. Per the
+# EVERY ONE of those is a REAL engine gap, not a harness artifact. Per the
 # #5779 epic's honest-framing rule, real failures are recorded by an OPEN
 # TRACKING ISSUE, never by a skip entry: they deliberately keep running and
 # reporting "failed" until the underlying engine bugs are fixed. This block is
 # the durable, greppable record (the #6066 partial-skip documentation
 # convention, applied here to a NON-skip: honest failures tracked by issue, not
-# silenced). NO vibesql_skip_tests entry is added for any of the 33.
+# silenced). NO vibesql_skip_tests entry is added for any of these.
 #
 # Canonical fuzz.test count on a QUIET machine (fresh release build):
-#   35031 run / 34998 pass / 33 fail / 0 skip.
-# (A LOADED machine can add a spurious 34th failure — fuzz-7.2.1267 fails with
+#   35031 run / 35005 pass / 26 fail / 0 skip.
+# (Was 33 fail before #6070 fixed Bucket A's 7 GLOB simple-evaluator cases.)
+# (A LOADED machine can add a spurious extra failure — fuzz-7.2.1267 fails with
 # "Too many open files in system (os error 23)" when the trial-DB checkpoint
 # copy path exhausts the system fd table; that is a transient machine-load
-# artifact, NOT one of the 33, and does not reproduce on a quiet machine.)
+# artifact, NOT one of the residual failures, and does not reproduce on a quiet
+# machine.)
 #
-# The 33 real failures, 4 buckets (test name -> class -> tracking issue):
+# The residual real failures, by bucket (test name -> class -> tracking issue):
 #   Bucket A — GLOB in the simple (scalar) evaluator, non-literal operands (7)
 #     fuzz-3.2.1965, fuzz-3.2.2663, fuzz-3.2.2863, fuzz-4.2.586,
 #     fuzz-4.2.1633, fuzz-4.2.1896, fuzz-4.2.4455
-#     -> #6070  ("Unexpected expression in simple evaluator: Glob {...}")
+#     -> #6070  FIXED: the aggregation simple evaluator now has a Glob arm that
+#        evaluates both operands with aggregate support (mirroring the scalar
+#        eval_glob coercion) instead of raising
+#        "Unexpected expression in simple evaluator: Glob {...}".
 #   Bucket B — ORDER BY numeric-ordinal range validation, nested context (1)
 #     fuzz-1.18                                            -> #6071
 #   Bucket C — CAST(zeroblob(N) AS text) returns N NUL bytes, not "" (MEM_Zero) (1)


### PR DESCRIPTION
## Summary

The scalar "simple evaluator" used inside the aggregation path (`select::executor::aggregation::evaluation::simple`) had no `Glob` arm. Any GLOB expression routed there fell through to the catch-all and failed with:

```
Unsupported expression: Unexpected expression in simple evaluator: Glob { ... }
```

This is the #5884/#5892 class explicitly deferred as "GLOB in the simple evaluator". GLOB works on the row/columnar scalar path (`eval_glob`) but blew up on the aggregation simple-evaluator path — which is reached whenever a GLOB appears in a query that goes through aggregation (e.g. `GROUP BY`). Because there was no arm at all, even pure-literal GLOB (fuzz-4.2.4455 `Glob { Literal(Null), Literal }`) failed there.

## Changes

- Add a `Glob` arm to `simple::evaluate`, placed next to the existing `Like` arm. It evaluates both operands with aggregate support (`evaluate_with_aggregates`) and mirrors the scalar `eval_glob` coercion rules: numerics/booleans (EXISTS/IN → 0/1)/blob bytes render as text, NULL on either side yields NULL, and matching uses the case-sensitive `pattern::glob_match` (GLOB takes no ESCAPE clause). This single arm also covers the `evaluate_with_aggregates_and_grouping` path, whose catch-all delegates to `evaluate_with_aggregates`.
- Add `crates/vibesql-executor/tests/glob_simple_evaluator_tests.rs` — GLOB / NOT GLOB with literal, column, expression, subquery, CAST, IN, IS NULL, function, NULL, and numeric operands, all routed through a `GROUP BY` query so they hit the simple evaluator. Expected values were verified against `sqlite3 3.51.0`.
- Update the greppable fuzz.test residual-classification comment in `scripts/tester_vibesql.tcl`: Bucket A is now fixed; canonical count updated 33 → 26 fail. No skip-list entry was added (honest-failure policy preserved).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| The 7 Bucket-A fuzz tests flip (33 → 26 failures) | ✅ | `make test-tcl-file FILE=fuzz.test --timeout 1800` on a fresh release build: `35031 run / 35005 pass / 26 fail`; none of fuzz-3.2.1965/2663/2863, fuzz-4.2.586/1633/1896/4455 appear in the failure list |
| Differential parity vs sqlite3 for the repro matrix | ✅ | 14-case matrix (literal, NULL, case-sensitivity, column, function, CAST, numeric, IN, IS NULL, subquery, NOT GLOB) matches `sqlite3 3.51.0` exactly |
| No regressions in existing GLOB/LIKE tests | ✅ | Remaining 26 fuzz failures are unrelated buckets (fuzz-1.x, fuzz-5.x, fuzz-7.2.x); `cargo test -p vibesql-executor` green |
| `cargo test -p vibesql-executor` green | ✅ | Full suite passes (exit 0); new test binary: 4 passed / 0 failed |

## Test Plan

- `cargo test -p vibesql-executor --test glob_simple_evaluator_tests` → 4 passed.
- `cargo test -p vibesql-executor` → green (exit 0).
- `make test-tcl-file FILE=fuzz.test --timeout 1800` (fresh release build) → 26 failures (was 33); all 7 target tests pass.
- Differential vs `sqlite3 3.51.0` on the repro matrix → exact parity.

Note: `cargo clippy -p vibesql-executor --tests` reports 4 pre-existing `approx_constant` errors in unrelated files (`operators.rs`, `json_funcs.rs`, `aggregates.rs`) on `3.14`/`3.14159` literals — not introduced by this PR and out of scope.

Closes #6070