### PR TITLE
fix(executor): treat out-of-i32-range ORDER BY ordinals as constant expressions

### DIFF
--- a/crates/vibesql-executor/src/select/executor/nonagg/without_from.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/without_from.rs
@@ -36,36 +36,30 @@ impl SelectExecutor<'_> {
         stmt: &vibesql_ast::SelectStmt,
         cte_results: &HashMap<String, CteResult>,
     ) -> Result<Vec<vibesql_storage::Row>, ExecutorError> {
-        // Validate ORDER BY column positions early (SQLite compatibility)
+        // Validate ORDER BY column positions early (SQLite compatibility).
+        //
+        // Route through the shared position classifier so numeric-ordinal range
+        // validation matches SQLite in every context: an integer literal is only
+        // a positional ordinal when it fits in a signed 32-bit int, otherwise it
+        // is a constant expression that never triggers a range error (#6071).
         if let Some(order_by) = &stmt.order_by {
+            use crate::select::order::{
+                extract_column_position, validate_column_position, ColumnPositionResult,
+            };
+            let column_count = stmt.select_list.len();
             for (term_index, order_item) in order_by.iter().enumerate() {
-                // Check for numeric column positions
-                if let vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(pos)) =
-                    &order_item.expr
-                {
-                    if *pos <= 0 || (*pos as usize) > stmt.select_list.len() {
+                match extract_column_position(&order_item.expr) {
+                    ColumnPositionResult::Position(pos) => {
+                        validate_column_position(pos, column_count, term_index)?;
+                    }
+                    ColumnPositionResult::Negative(pos) => {
                         return Err(ExecutorError::OrderByOutOfRange {
                             term_position: term_index + 1,
-                            column_number: *pos,
-                            select_list_len: stmt.select_list.len(),
+                            column_number: -pos,
+                            select_list_len: column_count,
                         });
                     }
-                }
-                // Check for negative column positions (parsed as UnaryOp { Minus, Integer })
-                if let vibesql_ast::Expression::UnaryOp {
-                    op: vibesql_ast::UnaryOperator::Minus,
-                    expr,
-                } = &order_item.expr
-                {
-                    if let vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(pos)) =
-                        expr.as_ref()
-                    {
-                        return Err(ExecutorError::OrderByOutOfRange {
-                            term_position: term_index + 1,
-                            column_number: -*pos,
-                            select_list_len: stmt.select_list.len(),
-                        });
-                    }
+                    ColumnPositionResult::NotAPosition => {}
                 }
             }
         }

--- a/crates/vibesql-executor/src/select/order/position.rs
+++ b/crates/vibesql-executor/src/select/order/position.rs
@@ -19,6 +19,23 @@ pub(crate) enum ColumnPositionResult {
     NotAPosition,
 }
 
+/// True when `value` can be a positional ORDER BY / GROUP BY column ordinal.
+///
+/// SQLite only treats an integer ORDER BY / GROUP BY term as a positional
+/// column ordinal when its magnitude fits in a signed 32-bit int — i.e.
+/// `-2147483647 ..= 2147483647` (`|value| <= i32::MAX`). A literal outside that
+/// range — e.g. `ORDER BY -2147483648`, `ORDER BY -2147483649`, or
+/// `ORDER BY 4294967296` — is parsed as an ordinary constant expression
+/// instead, so no positional range check applies and the query runs (ordering
+/// by a constant is a no-op). Note `i32::MIN` (`-2147483648`) is deliberately
+/// excluded: SQLite treats it as a constant, not an ordinal. This mirrors
+/// SQLite's `resolveOrderByTermToExprList` behaviour and keeps VibeSQL from
+/// raising a spurious "term out of range" error for out-of-range ordinals
+/// (#6071).
+fn fits_ordinal_width(value: i64) -> bool {
+    value.unsigned_abs() <= i32::MAX as u64
+}
+
 /// Extracts a numeric column position from an ORDER BY expression.
 ///
 /// Handles:
@@ -26,11 +43,20 @@ pub(crate) enum ColumnPositionResult {
 /// - `ORDER BY +N` - Unary plus with integer → Position(N) (#4418)
 /// - `ORDER BY -N` - Unary minus with integer → Negative(N)
 /// - Other expressions → NotAPosition
+///
+/// An integer literal whose value does not fit in a signed 32-bit int is NOT a
+/// column ordinal (SQLite treats it as a constant expression); such terms
+/// classify as [`ColumnPositionResult::NotAPosition`] so no range check runs
+/// (#6071).
 pub(crate) fn extract_column_position(expr: &vibesql_ast::Expression) -> ColumnPositionResult {
     match expr {
         // Direct integer literal: ORDER BY 1, ORDER BY 2, etc.
         vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Integer(pos)) => {
-            ColumnPositionResult::Position(*pos)
+            if fits_ordinal_width(*pos) {
+                ColumnPositionResult::Position(*pos)
+            } else {
+                ColumnPositionResult::NotAPosition
+            }
         }
         // Unary operator with integer
         vibesql_ast::Expression::UnaryOp { op, expr } => {
@@ -39,9 +65,16 @@ pub(crate) fn extract_column_position(expr: &vibesql_ast::Expression) -> ColumnP
             {
                 match op {
                     // ORDER BY +N: treat as ORDER BY N (#4418)
-                    vibesql_ast::UnaryOperator::Plus => ColumnPositionResult::Position(*pos),
-                    // ORDER BY -N: always invalid
-                    vibesql_ast::UnaryOperator::Minus => ColumnPositionResult::Negative(*pos),
+                    vibesql_ast::UnaryOperator::Plus if fits_ordinal_width(*pos) => {
+                        ColumnPositionResult::Position(*pos)
+                    }
+                    // ORDER BY -N: an in-range negative ordinal is always out
+                    // of range (< 1); a negative literal whose magnitude exceeds
+                    // i32::MAX (e.g. -2147483648, -2147483649) is a constant
+                    // expression, not an ordinal.
+                    vibesql_ast::UnaryOperator::Minus if fits_ordinal_width(*pos) => {
+                        ColumnPositionResult::Negative(*pos)
+                    }
                     _ => ColumnPositionResult::NotAPosition,
                 }
             } else {
@@ -324,4 +357,100 @@ pub(crate) fn count_select_columns(
         }
     }
     count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vibesql_ast::{Expression, UnaryOperator};
+    use vibesql_types::SqlValue;
+
+    fn int_lit(n: i64) -> Expression {
+        Expression::Literal(SqlValue::Integer(n))
+    }
+
+    fn unary(op: UnaryOperator, n: i64) -> Expression {
+        Expression::UnaryOp { op, expr: Box::new(int_lit(n)) }
+    }
+
+    #[test]
+    fn positive_literals_within_i32_are_positions() {
+        assert!(matches!(extract_column_position(&int_lit(1)), ColumnPositionResult::Position(1)));
+        assert!(matches!(
+            extract_column_position(&int_lit(i32::MAX as i64)),
+            ColumnPositionResult::Position(2147483647)
+        ));
+    }
+
+    #[test]
+    fn zero_is_a_position_and_validated_out_of_range() {
+        // ORDER BY 0 is an ordinal candidate; range validation rejects it.
+        assert!(matches!(extract_column_position(&int_lit(0)), ColumnPositionResult::Position(0)));
+    }
+
+    #[test]
+    fn unary_plus_within_i32_is_a_position() {
+        assert!(matches!(
+            extract_column_position(&unary(UnaryOperator::Plus, 2)),
+            ColumnPositionResult::Position(2)
+        ));
+    }
+
+    #[test]
+    fn small_negative_is_negative_ordinal() {
+        // ORDER BY -1 / -2 are in-range ordinal candidates (always invalid,
+        // reported as out of range by validation).
+        assert!(matches!(
+            extract_column_position(&unary(UnaryOperator::Minus, 1)),
+            ColumnPositionResult::Negative(1)
+        ));
+        assert!(matches!(
+            extract_column_position(&unary(UnaryOperator::Minus, i32::MAX as i64)),
+            ColumnPositionResult::Negative(2147483647)
+        ));
+    }
+
+    #[test]
+    fn positive_literal_above_i32_max_is_not_a_position() {
+        // 2147483648 exceeds i32::MAX: SQLite treats it as a constant
+        // expression, not an ordinal (#6071) — no range check applies.
+        assert!(matches!(
+            extract_column_position(&int_lit(i32::MAX as i64 + 1)),
+            ColumnPositionResult::NotAPosition
+        ));
+        assert!(matches!(
+            extract_column_position(&int_lit(4_294_967_297)),
+            ColumnPositionResult::NotAPosition
+        ));
+    }
+
+    #[test]
+    fn negative_literal_at_or_below_i32_min_is_not_a_position() {
+        // -2147483648 (i32::MIN) and -2147483649 exceed the ordinal magnitude
+        // (|value| > i32::MAX): constant expressions, not ordinals (#6071).
+        assert!(matches!(
+            extract_column_position(&unary(UnaryOperator::Minus, i32::MAX as i64 + 1)),
+            ColumnPositionResult::NotAPosition
+        ));
+        assert!(matches!(
+            extract_column_position(&unary(UnaryOperator::Minus, 2_147_483_649)),
+            ColumnPositionResult::NotAPosition
+        ));
+        assert!(matches!(
+            extract_column_position(&unary(UnaryOperator::Minus, 9_999_999_999_999)),
+            ColumnPositionResult::NotAPosition
+        ));
+    }
+
+    #[test]
+    fn fits_ordinal_width_boundaries() {
+        assert!(fits_ordinal_width(0));
+        assert!(fits_ordinal_width(1));
+        assert!(fits_ordinal_width(i32::MAX as i64)); // 2147483647
+        assert!(fits_ordinal_width(-(i32::MAX as i64))); // -2147483647
+        assert!(!fits_ordinal_width(i32::MAX as i64 + 1)); // 2147483648
+        assert!(!fits_ordinal_width(i32::MIN as i64)); // -2147483648
+        assert!(!fits_ordinal_width(i64::MAX));
+        assert!(!fits_ordinal_width(i64::MIN));
+    }
 }


### PR DESCRIPTION
## Summary

VibeSQL did not match SQLite's ORDER-BY numeric-ordinal range validation for out-of-range integer literals in nested/scalar-subquery contexts. `fuzz-1.18` contains `SELECT (SELECT ALL -1 ORDER BY -2147483649)`, which SQLite accepts (the huge negative literal is a constant expression, not a column ordinal) but VibeSQL rejected with `1st ORDER BY term out of range`.

SQLite treats a numeric ORDER BY term as a positional column ordinal **only when its magnitude fits a signed 32-bit int** (`|value| <= i32::MAX`, i.e. `-2147483647 ..= 2147483647`). A literal outside that range — `ORDER BY -2147483648`, `ORDER BY -2147483649`, `ORDER BY 4294967296` — is an ordinary constant expression, so no positional range check applies and the query runs (sorting by a constant is a no-op).

## Changes

- `select/order/position.rs`: add a `fits_ordinal_width` guard so `extract_column_position` classifies an integer literal (positive, `+N`, or `-N`) whose magnitude exceeds `i32::MAX` as `NotAPosition` instead of `Position`/`Negative`. `i32::MIN` (`-2147483648`) is deliberately excluded from the ordinal range, matching SQLite. This is the shared seam used by the aggregate/CTE/columnar ORDER-BY resolution paths, so the rule now applies uniformly.
- `select/executor/nonagg/without_from.rs`: replace the FROM-less SELECT's bespoke inline ordinal validator (which unconditionally errored on any negative integer term) with the shared `extract_column_position` + `validate_column_position` helpers, so the FROM-less/scalar-subquery context validates ordinals identically to every other context.
- Added unit tests for the boundary: `i32::MAX` ordinal vs `i32::MAX+1` constant, `i32::MIN`/below-min constant, small negatives still out-of-range.

No new user-facing message string was introduced — the existing `OrderByOutOfRange` Display (hardcoded, not routed through Fluent) is reused, so `check-translations` is unaffected.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| fuzz-1.18 flips FAIL→PASS | ✅ | `make test-tcl-file FILE=fuzz.test` — no `fuzz-1.x` entries in the failed list (was failing before) |
| Differential parity vs sqlite3 3.51 | ✅ | 31-case matrix (top-level, scalar subquery, FROM subquery, multi-column, boundary values, floats, `+N`) all match sqlite3 output/error |
| Error message matches SQLite (incl. ordinal spelling) | ✅ | `2nd ORDER BY term out of range - should be between 1 and 1` matches byte-for-byte |
| No regressions (orderby TCL) | ✅ | `make test-tcl-file FILE=orderby1.test` → 38/38 passed, 0 failed |
| `cargo test -p vibesql-executor` green | ✅ | lib: 3472 passed, 0 failed (7 new tests) |

## Test Plan

- Differential matrix against `sqlite3 3.51.0` across top-level, scalar-subquery, FROM-subquery, and multi-column contexts including the exact i32 boundaries — full parity.
- `cargo test -p vibesql-executor --lib`: 3472 passed / 0 failed.
- `make test-tcl-file FILE=orderby1.test`: 38 passed / 0 failed.
- `make test-tcl-file FILE=fuzz.test`: fuzz-1.18 no longer in the failed list.
- `cargo clippy` / `rustfmt --check` clean on both changed files.

Closes #6071