### PR TITLE
fix(executor): NUL-terminate TEXT for length() and client rendering (MEM_Zero, fuzz-1.8)

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -130,6 +130,17 @@ fn format_sql_value(v: &SqlValue) -> String {
                 "0".to_string()
             }
         }
+        // TEXT values are rendered to the client like SQLite's
+        // sqlite3_column_text(): the returned string terminates at the first
+        // embedded NUL byte. This is the MEM_Zero / OP_ToText behavior that
+        // makes CAST(zeroblob(N) AS text) surface as an empty string and
+        // CAST(x'4142004344' AS text) surface as "AB" (fuzz-1.8). The stored
+        // value keeps all its bytes (hex()/quote() still see them); only this
+        // client text-rendering boundary truncates.
+        SqlValue::Varchar(s) | SqlValue::Character(s) => match s.find('\0') {
+            Some(nul_idx) => s[..nul_idx].to_string(),
+            None => s.to_string(),
+        },
         _ => format!("{}", v),
     }
 }

--- a/crates/vibesql-executor/src/evaluator/functions/string/length.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/string/length.rs
@@ -80,8 +80,18 @@ pub(in crate::evaluator::functions) fn length(
     match &args[0] {
         vibesql_types::SqlValue::Null => Ok(vibesql_types::SqlValue::Null),
         vibesql_types::SqlValue::Varchar(s) | vibesql_types::SqlValue::Character(s) => {
-            // Return character count, not byte count (SQLite behavior)
-            Ok(vibesql_types::SqlValue::Integer(s.chars().count() as i64))
+            // Return character count, not byte count (SQLite behavior).
+            //
+            // SQLite treats TEXT values as NUL-terminated C strings: LENGTH()
+            // counts characters only up to (and not including) the first
+            // embedded NUL byte. This is the historical MEM_Zero / OP_ToText
+            // behavior, e.g. LENGTH(CAST(zeroblob(1000) AS text)) == 0 and
+            // LENGTH(CAST(x'4142004344' AS text)) == 2 ("AB\0CD" -> "AB").
+            let text = match s.as_bytes().iter().position(|&b| b == 0) {
+                Some(nul_idx) => &s[..nul_idx],
+                None => s.as_str(),
+            };
+            Ok(vibesql_types::SqlValue::Integer(text.chars().count() as i64))
         }
         // SQLite converts non-string types to string first
         vibesql_types::SqlValue::Integer(n) => {
@@ -133,5 +143,72 @@ pub(in crate::evaluator::functions) fn length(
             // For blobs, return the number of bytes
             Ok(vibesql_types::SqlValue::Integer(b.len() as i64))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vibesql_types::SqlValue;
+
+    fn len_of(v: SqlValue) -> i64 {
+        match length(&[v]).unwrap() {
+            SqlValue::Integer(n) => n,
+            other => panic!("expected Integer, got {other:?}"),
+        }
+    }
+
+    fn text(s: &str) -> SqlValue {
+        SqlValue::Varchar(arcstr::ArcStr::from(s))
+    }
+
+    #[test]
+    fn test_length_plain_text() {
+        assert_eq!(len_of(text("hello")), 5);
+        assert_eq!(len_of(text("")), 0);
+        // Character count, not byte count.
+        assert_eq!(len_of(text("héllo")), 5);
+    }
+
+    #[test]
+    fn test_length_stops_at_embedded_nul() {
+        // SQLite TEXT length counts up to the first NUL byte.
+        // CAST(x'4142004344' AS text) -> "AB\0CD" -> length 2.
+        assert_eq!(len_of(text("AB\0CD")), 2);
+        // "a\0b" -> length 1.
+        assert_eq!(len_of(text("a\0b")), 1);
+        // Leading NUL -> length 0.
+        assert_eq!(len_of(text("\0AB")), 0);
+        // "abc\0" -> length 3.
+        assert_eq!(len_of(text("abc\0")), 3);
+    }
+
+    #[test]
+    fn test_length_zeroblob_as_text_is_zero() {
+        // The historical fuzz-1.8 / MEM_Zero case: CAST(zeroblob(N) AS text)
+        // yields a string of N NUL bytes whose LENGTH() is 0.
+        let zeros: String = std::iter::repeat('\0').take(1000).collect();
+        assert_eq!(len_of(text(&zeros)), 0);
+        // Multibyte char before a NUL is still counted once.
+        assert_eq!(len_of(text("é\0x")), 1);
+    }
+
+    #[test]
+    fn test_length_blob_counts_all_bytes() {
+        // BLOB length is the full byte count, including NUL bytes.
+        assert_eq!(len_of(SqlValue::Blob(vec![0, 0, 0, 0, 0])), 5);
+        assert_eq!(len_of(SqlValue::Blob(vec![0x41, 0x42, 0x00, 0x43, 0x44])), 5);
+        assert_eq!(len_of(SqlValue::Blob(vec![])), 0);
+    }
+
+    #[test]
+    fn test_length_null_is_null() {
+        assert!(matches!(length(&[SqlValue::Null]).unwrap(), SqlValue::Null));
+    }
+
+    #[test]
+    fn test_length_numeric_coercion() {
+        assert_eq!(len_of(SqlValue::Integer(12345)), 5);
+        assert_eq!(len_of(SqlValue::Integer(-42)), 3);
     }
 }


### PR DESCRIPTION
## Summary

Fixes `CAST(zeroblob(N) AS text)` surfacing as N NUL bytes instead of an empty string (fuzz.test **fuzz-1.8**, "OP_ToText did not account for MEM_Zero"), and the related `length()` mismatch on TEXT containing embedded NULs.

SQLite treats a TEXT value as a NUL-terminated C string **at the points where it is observed**: `length()` counts up to the first embedded NUL, and `sqlite3_column_text()` returns bytes up to the first NUL. The stored bytes are retained — `hex()`/`quote()` still see the full buffer — so the fix is applied only at those two observation boundaries, not in the cast itself (truncating the cast would wrongly break `hex(CAST(x'4142004344' AS text))`, which SQLite keeps as `4142004344`).

## Changes

- **`LENGTH()`** on `Varchar`/`Character` counts characters up to the first NUL byte (`crates/vibesql-executor/.../string/length.rs`). `BLOB` length unchanged (full byte count).
- **CLI text-rendering boundary** (`format_sql_value`, the `sqlite3_column_text` analog in `crates/vibesql-cli/src/executor/mod.rs`) truncates TEXT at the first NUL. `hex()`/`quote()` unaffected (their output is NUL-free).

## Differential matrix vs sqlite3 3.51 (all match exactly)

| Expression | SQLite | VibeSQL (after) |
|---|---|---|
| `length(CAST(zeroblob(1000) AS text))` | 0 | 0 |
| `length(CAST(x'4142004344' AS text))` ("AB\0CD") | 2 | 2 |
| `length(CAST(x'004142' AS text))` (leading NUL) | 0 | 0 |
| `length(CAST(x'6100' AS text))` ("a\0") | 1 | 1 |
| `length(x'4142004344')` / `length(zeroblob(5))` (BLOB) | 5 | 5 |
| `CAST(zeroblob(1000) AS text)` value | `{}` (empty) | `{}` (empty) |
| `hex(CAST(x'4142004344' AS text))` | 4142004344 | 4142004344 (unchanged) |

## Tests

- New `length.rs` unit tests: embedded/leading/trailing NUL, zeroblob-as-text, BLOB full-byte count, unicode-before-NUL, NULL, numeric coercion.
- `cargo test -p vibesql-executor` — 3471 passed.
- `cargo test -p vibesql-cli` — 150+ passed.
- TCL: `cast.test` 122/0, `func.test` 14546/**1**, `func2.test` 121/0, `func3.test` 25/0. The single `func.test` failure is **pre-existing** `func-7.1` (`last_insert_rowid()` cross-process shim state), unrelated to this change (returns an Integer).
- **fuzz-1.8** verified to flip to `{}` by running its exact statement through the CLI the way the shim does. (`fuzz.test` as a whole exceeds the runner's per-file timeout on its randomized loops, a known infra limitation — the target assertion is verified directly.)
- `cargo fmt --check` and `cargo clippy` clean on both edited files (0 new warnings).

Closes #6072

🤖 Generated with [Claude Code](https://claude.com/claude-code)