### PR TITLE
fix(executor): catch row-value arity misuse in SELECT WHERE at prepare time

### DIFF
--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -155,6 +155,17 @@ impl SelectExecutor<'_> {
         }
         if let Some(where_expr) = &stmt.where_clause {
             super::validation::validate_row_value_usage(where_expr)?;
+            // Scalar-subquery arity / row-value misuse in the SELECT WHERE
+            // clause. SQLite reports a scalar compared against a multi-column
+            // subquery here as `row value misused` (distinct from the arity
+            // error UPDATE/DELETE raise), and rejects nested scalar-vs-subquery
+            // arity misuse at prepare time even for empty tables (#6079,
+            // rowvalue4.test 8.2 / rowvalue9.test 8.2). Only inspect the
+            // top-level statement — nested subqueries reach their own checks
+            // through their execution path.
+            if self.outer_schema.is_none() && self.subquery_depth == 0 {
+                super::validation::validate_select_where_subquery_arity(where_expr, self.database)?;
+            }
         }
         if let Some(having_expr) = &stmt.having {
             super::validation::validate_row_value_usage(having_expr)?;

--- a/crates/vibesql-executor/src/select/executor/validation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/mod.rs
@@ -38,6 +38,7 @@ pub use join_limits::validate_join_table_limit;
 pub use row_values::validate_row_value_usage;
 pub use scalar_subquery_arity::{
     validate_predicate_expr as validate_predicate_subquery_arity,
+    validate_select_where_expr as validate_select_where_subquery_arity,
     validate_value_expr as validate_value_subquery_arity,
 };
 pub use schema::validate_aggregate_subquery_outer_refs;

--- a/crates/vibesql-executor/src/select/executor/validation/scalar_subquery_arity.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/scalar_subquery_arity.rs
@@ -177,3 +177,150 @@ pub fn validate_predicate_expr(
         _ => Ok(()),
     }
 }
+
+/// Static arity of an `IN` left-hand side, if it can be determined: a
+/// multi-element `RowValueConstructor` has that arity, a scalar subquery has its
+/// projected column count (a multi-column subquery LHS is a legal row value —
+/// e.g. `(SELECT a, b) IN (SELECT a, b FROM t)`), and any other expression is a
+/// scalar (arity 1). Returns `None` when a subquery's column count cannot be
+/// computed statically, in which case the arity check is skipped in favor of the
+/// runtime check.
+fn in_lhs_arity(expr: &Expression, database: &vibesql_storage::Database) -> Option<usize> {
+    match expr {
+        Expression::RowValueConstructor(elems) if elems.len() > 1 => Some(elems.len()),
+        Expression::ScalarSubquery(subquery) => subquery_column_count(subquery, database),
+        _ => Some(1),
+    }
+}
+
+/// Validate a `WHERE` predicate of a top-level `SELECT`.
+///
+/// SQLite's SELECT-WHERE handling differs from the UPDATE/DELETE WHERE rule
+/// covered by [`validate_predicate_expr`]: a scalar compared against a
+/// multi-column subquery in a SELECT WHERE is reported as `row value misused`,
+/// whereas the same shape in an UPDATE/DELETE WHERE is the arity error
+/// `sub-select returns N columns - expected 1`. (Verified against sqlite3 3.51:
+/// `SELECT * FROM t WHERE a < (SELECT b, 2)` → `row value misused`, while the
+/// UPDATE/DELETE forms give the arity error — see `rowvalue4.test` 8.2 and
+/// `rowvalue.test` 15.3/15.4.)
+///
+/// The check is a prepare-time walk so the misuse surfaces even when the target
+/// table is empty and the WHERE predicate is never evaluated. In addition to
+/// the top-level scalar-vs-subquery shape, the walk descends into nested
+/// scalar-subquery bodies so a deep arity misuse such as
+/// `(a,b) > (SELECT 2 IN (SELECT 2,2), 2)` (`rowvalue9.test` 8.2, where the
+/// inner `2 IN (SELECT 2,2)` compares a scalar against a 2-column subquery) is
+/// caught regardless of row count.
+pub fn validate_select_where_expr(
+    expr: &Expression,
+    database: &vibesql_storage::Database,
+) -> Result<(), ExecutorError> {
+    match expr {
+        Expression::BinaryOp { left, op, right } if is_comparison_op(op) => {
+            // Legal row-value comparison (row value / subquery on both sides):
+            // the arities are checked elsewhere; still descend into each operand
+            // so a nested subquery misuse is not missed.
+            if is_row_value_or_subquery(left) && is_row_value_or_subquery(right) {
+                validate_select_where_descend(left, database)?;
+                validate_select_where_descend(right, database)?;
+                return Ok(());
+            }
+            // A plain scalar compared against a multi-column subquery in a
+            // SELECT WHERE is `row value misused` (not the arity error).
+            if !is_row_value_or_subquery(left) && multi_col_subquery(right, database).is_some() {
+                return Err(ExecutorError::RowValueMisused);
+            }
+            if !is_row_value_or_subquery(right) && multi_col_subquery(left, database).is_some() {
+                return Err(ExecutorError::RowValueMisused);
+            }
+            // Otherwise descend into operands for nested subquery misuse.
+            validate_select_where_descend(left, database)?;
+            validate_select_where_descend(right, database)
+        }
+        Expression::Conjunction(children) | Expression::Disjunction(children) => {
+            for c in children {
+                validate_select_where_expr(c, database)?;
+            }
+            Ok(())
+        }
+        Expression::BinaryOp { left, right, .. } => {
+            validate_select_where_expr(left, database)?;
+            validate_select_where_expr(right, database)
+        }
+        Expression::UnaryOp { expr: inner, .. } => validate_select_where_expr(inner, database),
+        other => validate_select_where_descend(other, database),
+    }
+}
+
+/// Descend into an expression's nested subqueries looking for a scalar
+/// `IN (multi-column subquery)` misuse (arity error). This is the shape that
+/// escapes the top-level comparison check because it lives inside a subquery's
+/// projection (e.g. `(SELECT 2 IN (SELECT 2,2), 2)`), which is never evaluated
+/// when the outer table is empty.
+fn validate_select_where_descend(
+    expr: &Expression,
+    database: &vibesql_storage::Database,
+) -> Result<(), ExecutorError> {
+    match expr {
+        // `scalar IN (SELECT c1, c2, ...)` where the subquery returns more than
+        // one column is the arity error, independent of row count.
+        //
+        // The LHS may itself be a row value: a multi-element
+        // `RowValueConstructor`, or a *subquery* that projects multiple columns
+        // (`(SELECT a, b) IN (SELECT a, b FROM t)` is a legal row-value IN — see
+        // rowvalue.test 18.1/18.2/18.4/18.5). Only flag when the LHS is a genuine
+        // scalar (arity 1) and the IN subquery returns more than one column.
+        Expression::In { expr: lhs, subquery, .. } => {
+            if in_lhs_arity(lhs, database) == Some(1) {
+                if let Some(n) = subquery_column_count(subquery, database) {
+                    if n > 1 {
+                        return Err(arity_error(n));
+                    }
+                }
+            }
+            validate_select_where_descend(lhs, database)?;
+            validate_select_stmt(subquery, database)
+        }
+        Expression::ScalarSubquery(subquery) => validate_select_stmt(subquery, database),
+        Expression::BinaryOp { left, right, .. } => {
+            validate_select_where_descend(left, database)?;
+            validate_select_where_descend(right, database)
+        }
+        Expression::UnaryOp { expr: inner, .. } => validate_select_where_descend(inner, database),
+        Expression::Conjunction(children)
+        | Expression::Disjunction(children)
+        | Expression::RowValueConstructor(children) => {
+            for c in children {
+                validate_select_where_descend(c, database)?;
+            }
+            Ok(())
+        }
+        Expression::InList { expr: lhs, values, .. } => {
+            validate_select_where_descend(lhs, database)?;
+            for v in values {
+                validate_select_where_descend(v, database)?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Walk a nested `SELECT` body for scalar-subquery arity misuse: each
+/// projected item and its `WHERE` predicate are validated the same way the
+/// top-level SELECT is, so a misuse buried in a subquery's projection surfaces
+/// even when no row ever reaches it.
+fn validate_select_stmt(
+    stmt: &vibesql_ast::SelectStmt,
+    database: &vibesql_storage::Database,
+) -> Result<(), ExecutorError> {
+    for item in &stmt.select_list {
+        if let vibesql_ast::SelectItem::Expression { expr, .. } = item {
+            validate_select_where_descend(expr, database)?;
+        }
+    }
+    if let Some(where_expr) = &stmt.where_clause {
+        validate_select_where_descend(where_expr, database)?;
+    }
+    Ok(())
+}

--- a/crates/vibesql-executor/tests/row_value_features_tests.rs
+++ b/crates/vibesql-executor/tests/row_value_features_tests.rs
@@ -469,3 +469,90 @@ fn scalar_subquery_lhs_of_in_with_join() {
     );
     assert_eq!(rows, vec![vec![I(1), I(1), I(1)], vec![I(1), I(2), I(1)]]);
 }
+
+// ─── SELECT-WHERE row-value / subquery arity misuse (#6079) ──────────────────
+//
+// A row-value arity misuse in a top-level SELECT WHERE clause must error at
+// prepare time (even for an empty table) instead of silently returning 0 rows.
+// SQLite 3.51 parity verified: a scalar compared against a multi-column subquery
+// in a SELECT WHERE is `row value misused`; a nested scalar-vs-subquery arity
+// misuse is `sub-select returns N columns - expected 1`.
+
+fn assert_subquery_arity(
+    db: &vibesql_storage::Database,
+    sql: &str,
+    expected: usize,
+    actual: usize,
+) {
+    let err = query_err(db, sql);
+    assert!(
+        matches!(err, ExecutorError::SubqueryColumnCountMismatch { expected: e, actual: a } if e == expected && a == actual),
+        "Query: {} -- expected SubqueryColumnCountMismatch {{ expected: {}, actual: {} }}, got {:?}",
+        sql,
+        expected,
+        actual,
+        err
+    );
+}
+
+#[test]
+fn select_where_scalar_vs_multicol_subquery_is_misused() {
+    // Issue #6079 repro and rowvalue4.test 8.2: a plain scalar compared against a
+    // multi-column subquery in a SELECT WHERE is `row value misused`, on an empty
+    // table, regardless of operator or which side the subquery is on.
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(a, b)");
+    assert_misused(&db, "SELECT a FROM t WHERE a < (SELECT b, 2 FROM t)");
+    assert_misused(&db, "SELECT a FROM t WHERE a = (SELECT b, 2 FROM t)");
+    assert_misused(&db, "SELECT a FROM t WHERE (SELECT b, 2 FROM t) > a");
+    // rowvalue4.test 8.2 exact shape: the misuse is inside one OR/AND branch.
+    run_stmt(&mut db, "CREATE TABLE c1(x, y)");
+    run_stmt(&mut db, "CREATE TABLE c2(a, b, c)");
+    run_stmt(&mut db, "CREATE TABLE c3(d)");
+    assert_misused(
+        &db,
+        "SELECT * FROM c2 CROSS JOIN c3 WHERE \
+         ((a, b) == (SELECT x, y FROM c1) AND c3.d = c) OR \
+         (c == (SELECT x, y FROM c1) AND c3.d = c)",
+    );
+}
+
+#[test]
+fn select_where_nested_in_subquery_arity_misuse() {
+    // rowvalue9.test 8.2: the arity misuse lives inside the RHS subquery's
+    // projection (`2 IN (SELECT 2,2)`), which never executes for an empty table.
+    // It must still surface as `sub-select returns 2 columns - expected 1`.
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t1(a, b)");
+    assert_subquery_arity(
+        &db,
+        "SELECT a FROM t1 WHERE (a, b) > (SELECT 2 IN (SELECT 2, 2), 2)",
+        1,
+        2,
+    );
+}
+
+#[test]
+fn select_where_valid_row_value_comparisons_not_flagged() {
+    // No false positives: legal row-value / subquery WHERE comparisons keep
+    // working on a populated table.
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t(a, b, c)");
+    run_stmt(&mut db, "INSERT INTO t VALUES(1, 2, 3)");
+    run_stmt(&mut db, "INSERT INTO t VALUES(4, 5, 6)");
+    // row value vs matched-arity subquery / row value
+    assert_eq!(query_column(&db, "SELECT a FROM t WHERE (a, b) = (SELECT 1, 2)"), vec![I(1)]);
+    assert_eq!(query_column(&db, "SELECT a FROM t WHERE (a, b) < (2, 3)"), vec![I(1)]);
+    // scalar vs single-column subquery (arity 1) — legal
+    assert_eq!(query_column(&db, "SELECT a FROM t WHERE a = (SELECT 1)"), vec![I(1)]);
+    // multi-column subquery LHS of IN vs matched-arity IN subquery — legal
+    assert_eq!(
+        query_rows(&db, "SELECT a FROM t WHERE (SELECT a, b) IN (SELECT a, b FROM t)"),
+        vec![vec![I(1)], vec![I(4)]]
+    );
+    // row value IN subquery — legal
+    assert_eq!(
+        query_rows(&db, "SELECT a FROM t WHERE (a, b) IN (SELECT a, b FROM t)"),
+        vec![vec![I(1)], vec![I(4)]]
+    );
+}


### PR DESCRIPTION
## Summary

A top-level `SELECT` whose `WHERE` clause compared a plain scalar against a multi-column subquery silently returned **0 rows** instead of raising an error, even on a non-empty table:

```sql
SELECT a FROM t WHERE a < (SELECT b, 2 FROM t);   -- was: 0 rows; now: row value misused
```

Stage 2 (#6078) added prepare-time scalar-subquery arity validation and wired it into SELECT-list, UPDATE, DELETE, and trigger paths — but never into the **SELECT WHERE** clause, and the runtime evaluator did not catch the scalar-vs-subquery shape there either. So neither the prepare-time nor runtime path surfaced the misuse for SELECT.

## Changes

- **`validation/scalar_subquery_arity.rs`** — new `validate_select_where_expr`:
  - A plain scalar compared against a multi-column subquery in a SELECT WHERE now reports `row value misused` (matches sqlite3 3.51, which — verified — differs from the arity error UPDATE/DELETE WHERE raise for the same shape). Handles both operand sides and walks `AND`/`OR`/`NOT`.
  - Descends into nested subquery projections so a deep arity misuse such as `(a,b) > (SELECT 2 IN (SELECT 2,2), 2)` reports `sub-select returns 2 columns - expected 1` regardless of row count.
  - Recognizes a multi-column subquery on the LHS of `IN` (`(SELECT a,b) IN (SELECT a,b FROM t)`) as a legal row-value IN — no false positive (this was caught and fixed during testing against rowvalue.test 18.1/18.2/18.4/18.5).
- **`validation/mod.rs`** — export the new validator.
- **`select/executor/execute.rs`** — wire it into SELECT prepare for the top-level WHERE clause (gated on `outer_schema.is_none() && subquery_depth == 0`, mirroring the existing SELECT-list arity check).
- **`tests/row_value_features_tests.rs`** — 3 new tests (misuse + nested arity + no-false-positive battery).

Reuses the existing `RowValueMisused` / `SubqueryColumnCountMismatch` error variants — **no new strings or locale keys**, so `check-translations` is unaffected.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| rowvalue4 8.2 flips | ✅ | Errors `row value misused` (was 0 rows); rowvalue4.test 13/13. Direct binary test confirms main returned 0 rows, fix errors. |
| rowvalue9 8.2 flips (73→74/93) | ✅ | Errors `sub-select returns 2 columns - expected 1`; rowvalue9.test native 73→74 passing. |
| Issue repro errors with SQLite-parity text | ✅ | `SELECT a FROM t WHERE a < (SELECT b, 2 FROM t)` → `row value misused`, matching sqlite3 3.51. |
| No false positives | ✅ | Full rowvalue set: rowvalue.test stays 291/298 (no regression after fixing an initial 18.x false positive). where/in/subquery/select TCL sweep: 0 failures. |
| `cargo test -p vibesql-executor` green | ✅ | 3465 lib + all integration binaries pass; row_value_features_tests 24 passed. |
| check-translations | ✅ (n/a) | No locale strings touched. |

## Test Plan

- Differential vs `sqlite3 3.51.0` for all three repros — byte-parity on error text.
- `make test-tcl-file FILE=rowvalue4.test / rowvalue9.test / rowvalue.test` — targets flip, no regression.
- False-positive sweep across where/where2/where3/in/in2/in3/in4/subquery2/select1 TCL files — 0 failures.
- `cargo test -p vibesql-executor`, `cargo fmt`, `cargo clippy` clean (pre-existing warnings only).

Closes #6079