### PR TITLE
fix(tcl-shim): don't attribute the CLI's "N statements failed" summary to a single statement

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -1754,6 +1754,27 @@ proc count_cli_statements {sql} {
     return $n
 }
 
+proc is_script_failed_summary {line} {
+    # True when $line is the CLI's aggregate script-mode summary error
+    # ("N statements failed" — the `script-failed-error` l10n string, emitted as
+    # the process-level "Error: N statements failed"), rather than a specific,
+    # per-statement failure. That summary is only a roll-up count of the
+    # "Error executing statement N: <msg>" lines above it; it carries none of the
+    # specific error text that the fuzz.test allowlist matches, so it must never
+    # be attributed to a single statement (#6073).
+    #
+    # The multi-process shim always runs the CLI under the default en-US locale,
+    # so the line is literally "Error: <digits> statements failed". We key on the
+    # locale-independent structural signature instead of the localized wording:
+    # the summary is the only "Error:" line whose message begins with a bare
+    # count digit. Every genuine unattributable error the CLI emits as "Error:"
+    # (parse errors, "no such table", etc.) begins with a letter, and specific
+    # per-statement failures use the distinct "Error executing statement N:"
+    # form — so "^Error:\s+\d" isolates the summary without false positives.
+    set line [string trim $line]
+    return [regexp {^Error:\s+[0-9]} $line]
+}
+
 proc select_error_line_for_stmt {output min_index} {
     # Return the first "Error executing statement N: ..." line whose N is >=
     # $min_index (the CLI index at which the NEW statement begins). Lower-N error
@@ -1884,9 +1905,27 @@ proc trial_check_in_transaction {new_sql} {
             # surface it. Otherwise only earlier statements re-fired and the new
             # statement ran cleanly: return without raising so the caller batches
             # it normally.
+            #
+            # EXCLUDE the CLI's aggregate summary line "Error: N statements
+            # failed" (the `script-failed-error` l10n string). That line is the
+            # roll-up count of the per-statement "Error executing statement N"
+            # failures already emitted above — NOT an independent, unattributable
+            # error. In the fuzz.test 5.2/7.2 transactions every already-batched
+            # statement re-fires its (already-attributed) error on trial replay,
+            # so the only "Error:" line left after the numbered lines is this
+            # summary. Treating it as a genuine new failure surfaced the generic
+            # "N statements failed" text to do_fuzzy_test's allowlist matcher,
+            # which contains none of SQLite's specific substrings ("table",
+            # "datatype mismatch", "no such col", ...) — so the harness recorded
+            # a spurious Got:0/Expected:1 for a statement that in fact ran cleanly
+            # on the trial DB (#6073). Skip it so the new statement batches
+            # normally, exactly as when no "Error:" line is present at all.
             foreach line [split $result "\n"] {
                 set line [string trim $line]
                 if {[regexp {^Error: } $line]} {
+                    if {[is_script_failed_summary $line]} {
+                        continue
+                    }
                     set new_err $line
                     break
                 }


### PR DESCRIPTION
## Summary

`fuzz-5.2`/`fuzz-7.2` in the SQLite TCL fuzz suite fed 22 degenerate DML/SELECT statements one at a time into a batched `BEGIN...COMMIT`. Each spuriously failed with `Got: 0 / Expected: 1` because the harness's error allowlist (`table`, `datatype mismatch`, `no such col`, ...) received the CLI's generic aggregate summary text **"N statements failed"** instead of a specific error — for statements that actually ran cleanly on the trial DB.

Root cause is in the multi-process TCL shim (`scripts/tester_vibesql.tcl`), not the engine or the CLI. The below-cap in-transaction trial check (`trial_check_in_transaction`) replays the accumulated batch on an isolated DB copy so the new statement's error surfaces at its own test boundary. When no numbered `Error executing statement N` line falls at/after the new statement, a fallback surfaces any bare `Error:` line as a genuine failure. That fallback wrongly grabbed the CLI's roll-up summary line `Error: N statements failed` (the `script-failed-error` l10n string) — which in the fuzz transactions is the ONLY `Error:` line left, because every already-batched corpus statement re-fires its already-attributed error on replay. The new statement had in fact succeeded on the trial DB.

## Changes

- Add `is_script_failed_summary` helper that recognizes the CLI's aggregate `Error: N statements failed` summary by its locale-independent structural signature (`Error:` immediately followed by a count digit; genuine `Error:` failures begin with a letter, specific failures use the `Error executing statement N:` form).
- In `trial_check_in_transaction`'s bare-`Error:` fallback, skip that summary line — so the new statement batches normally, exactly as when no `Error:` line is present.
- No CLI or l10n change: the `N statements failed` summary is legitimate CLI output for real users; only the shim's error attribution was wrong. The performance-motivated batching is preserved unchanged.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| The 22 fuzz-5.2.x/7.2.x statements surface specific text / flip to pass | ✅ | Full `fuzz.test` run: all 22 (fuzz-5.2.2, 5.2.10, fuzz-7.2.{2,4,5,13,14,18,19,20,22,31,33,34,36,38,40,41,42,45,46,48}) now pass |
| fuzz 5.x/7.x bucket delta (target 2–4 remaining) | ✅ | 5.x/7.x failures 24 → 2 (only the fuzz-5.3/7.4 COMMIT-flush sentinels remain) |
| Overall fuzz.test failures reduced | ✅ | 34 → 11 failures (Tests failed: 34 → 11) |
| No CLI behavior regression for normal scripts | ✅ | `cargo test -p vibesql-cli` green (18 tests); no Rust/CLI source changed |
| Changed l10n strings updated across all locales | ✅ (n/a) | No l10n string changed; `python3 scripts/check-translations.py` passes |

## Scope note

The two COMMIT sentinels (`fuzz-5.3`, `fuzz-7.4`) do NOT auto-resolve — verified explicitly (their Expected/Got are unchanged before vs after this fix). They are an independent shim result-echo bug: `execsql COMMIT` returns the replayed batch's row dump instead of `{}`. Filed as follow-up #6097 rather than expanded into this PR (out of scope for the error-text plumbing this issue tracks).

## Test Plan

- `tclsh scripts/tester_vibesql.tcl docs/reference/sqlite/test/fuzz.test` — 34 → 11 failures; all 22 target statements pass.
- Captured the exact trial-replay `$result` for the failing statements to confirm the new statement had no numbered error and only the summary line was being surfaced.
- `cargo test -p vibesql-cli` — green.
- `cargo fmt --check` — clean.
- `python3 scripts/check-translations.py` — all locales OK.
- Unit-tested `is_script_failed_summary` against summary lines vs genuine `Error:`/numbered-statement lines.

Closes #6073