### PR TITLE
fix(executor): evaluate UPDATE...FROM tuple SET subquery once per row

### DIFF
--- a/crates/vibesql-executor/src/update/from_clause.rs
+++ b/crates/vibesql-executor/src/update/from_clause.rs
@@ -116,16 +116,70 @@ pub fn execute_update_from_join(
     // (a `RowValueConstructor` or a multi-column `ScalarSubquery`). Projecting
     // it as one `__set_i__` scalar item would route the row value through the
     // ordinary scalar evaluator, which correctly rejects a >1-column result
-    // ("sub-select returns N columns - expected 1"). Instead, expand a tuple
-    // assignment into one select item per target column so each output column
-    // is an ordinary scalar computed in the join context (correlation-safe:
-    // the subquery variant keeps its FROM/WHERE, only its select-list is
-    // narrowed to the single projected column). `set_values_per_assignment`
-    // records how many output columns each assignment contributes so the
-    // unpacking below (and `apply_update_from_matches`) can flatten positionally.
-    let mut set_values_per_assignment: Vec<usize> = Vec::with_capacity(stmt.assignments.len());
+    // ("sub-select returns N columns - expected 1").
+    //
+    // Direct row-value RHS (`RowValueConstructor`, or a non-row misuse) is
+    // expanded into one select item per target column: each output column is an
+    // ordinary scalar computed once in the join context, so `(t1.z, t1.x)` and
+    // `(7, 8)` are correct and single-pass.
+    //
+    // Issue #6086: a *subquery* RHS `(SELECT e0, e1, …)` must be evaluated
+    // ONCE per matched row (SQLite single-pass semantics). Splitting it into one
+    // narrowed scalar subquery per column re-executes the subquery per column;
+    // worse, two textually-identical narrowed subqueries (e.g. both `random()`)
+    // collapse through the subquery-result cache and yield equal values, so
+    // `SET (a, b) = (SELECT random(), random())` produced `a = b` instead of
+    // independent values. Instead we project the subquery's *outer* column
+    // references (its correlation inputs) into the synthetic SELECT, then in the
+    // result loop substitute those join-row values as literals and evaluate the
+    // now-uncorrelated multi-column subquery a single time via
+    // `ExpressionEvaluator::eval_row_value`, distributing its row tuple
+    // positionally to the target columns.
+    //
+    // `assignment_plans` records, per assignment, how its projected synthetic
+    // columns map to final SET values so the result loop can rebuild the
+    // positionally-flattened `set_values` (single-column assignments contribute
+    // one value; tuple assignments contribute one value per target column).
+    let outer_tables =
+        collect_outer_table_schemas(target_schema, &target_prefix, from_clauses, database);
+    let mut assignment_plans: Vec<AssignmentProjPlan> = Vec::with_capacity(stmt.assignments.len());
     for (i, assignment) in stmt.assignments.iter().enumerate() {
         if assignment.is_tuple() {
+            if let Expression::ScalarSubquery(sub) = &assignment.value {
+                // Single-evaluation subquery path (#6086). Collect the outer
+                // column references the subquery correlates on and project them
+                // as `__corr_i_k__` inputs; the subquery is evaluated once per
+                // matched row in the result loop.
+                let corr_refs = collect_outer_column_refs(sub, &outer_tables);
+                for (k, corr) in corr_refs.iter().enumerate() {
+                    let expr = match trigger_context {
+                        Some(ctx) => substitute_pseudo_vars(&corr.expr, ctx)?,
+                        None => corr.expr.clone(),
+                    };
+                    select_list.push(SelectItem::Expression {
+                        expr,
+                        alias: Some(format!("__corr_{}_{}__", i, k)),
+                        source_text: None,
+                    });
+                }
+                // The subquery may itself still reference OLD/NEW pseudo-vars
+                // (trigger body). Pre-resolve those to literals now; the
+                // remaining outer refs are substituted per-row below.
+                let subquery = match trigger_context {
+                    Some(ctx) => match substitute_pseudo_vars(&assignment.value, ctx)? {
+                        Expression::ScalarSubquery(s) => s,
+                        _ => sub.clone(),
+                    },
+                    None => sub.clone(),
+                };
+                assignment_plans.push(AssignmentProjPlan::SubqueryOnce {
+                    output_arity: assignment.columns.len(),
+                    corr_refs,
+                    subquery,
+                });
+                continue;
+            }
+            // Direct row-value RHS: one select item per target column.
             let col_exprs = tuple_assignment_column_exprs(assignment)?;
             for (j, expr) in col_exprs.into_iter().enumerate() {
                 let expr = match trigger_context {
@@ -138,7 +192,7 @@ pub fn execute_update_from_join(
                     source_text: None,
                 });
             }
-            set_values_per_assignment.push(assignment.columns.len());
+            assignment_plans.push(AssignmentProjPlan::DirectColumns(assignment.columns.len()));
         } else {
             let expr = match trigger_context {
                 Some(ctx) => substitute_pseudo_vars(&assignment.value, ctx)?,
@@ -149,10 +203,11 @@ pub fn execute_update_from_join(
                 alias: Some(format!("__set_{}__", i)),
                 source_text: None,
             });
-            set_values_per_assignment.push(1);
+            assignment_plans.push(AssignmentProjPlan::DirectColumns(1));
         }
     }
-    let total_set_columns: usize = set_values_per_assignment.iter().sum();
+    // Number of final SET values each assignment contributes (positional flatten).
+    let total_set_columns: usize = assignment_plans.iter().map(|p| p.output_columns()).sum();
 
     // Build FROM clause: target_table [alias], from_clause1, from_clause2, ...
     let target_from = FromClause::Table {
@@ -217,7 +272,19 @@ pub fn execute_update_from_join(
     // `set_values` is a positional flattening of every SET column: single-column
     // assignments contribute one value, tuple assignments contribute one value
     // per target column (issue #6047).
+    //
+    // The synthetic row layout is `[id columns][per-assignment projected
+    // columns]`. `DirectColumns` assignments project their final values
+    // directly; a `SubqueryOnce` assignment projects only its correlation
+    // inputs, so its final values are computed here by substituting those inputs
+    // into the subquery and evaluating it exactly once (issue #6086).
     let mut id_to_set_values: HashMap<Vec<SqlValue>, Vec<SqlValue>> = HashMap::new();
+    // Dummy schema/row for evaluating the (post-substitution) uncorrelated
+    // subquery: after correlation inputs are replaced with literals the subquery
+    // resolves purely against its own scope plus the database, so the outer
+    // schema/row are unused. `eval_row_value` needs a database-backed evaluator.
+    let eval_schema = target_schema;
+    let empty_row = Row::new(vec![]);
 
     for row in rows {
         // Extract identifier values (first num_id_columns values)
@@ -235,10 +302,46 @@ pub fn execute_update_from_join(
             continue;
         }
 
-        // Extract SET values (flattened across all assignments; see above)
-        let set_values: Vec<SqlValue> = (0..total_set_columns)
-            .map(|i| row.values.get(num_id_columns + i).cloned().unwrap_or(SqlValue::Null))
-            .collect();
+        // Walk each assignment's projected synthetic columns and produce the
+        // final positionally-flattened SET values.
+        let mut set_values: Vec<SqlValue> = Vec::with_capacity(total_set_columns);
+        let mut projected_offset = num_id_columns;
+        for plan in &assignment_plans {
+            match plan {
+                AssignmentProjPlan::DirectColumns(n) => {
+                    for k in 0..*n {
+                        set_values.push(
+                            row.values.get(projected_offset + k).cloned().unwrap_or(SqlValue::Null),
+                        );
+                    }
+                    projected_offset += n;
+                }
+                AssignmentProjPlan::SubqueryOnce { output_arity, corr_refs, subquery } => {
+                    // Substitute each projected correlation input as a literal.
+                    let mut literal_map: HashMap<CorrKey, SqlValue> =
+                        HashMap::with_capacity(corr_refs.len());
+                    for (k, corr) in corr_refs.iter().enumerate() {
+                        let value =
+                            row.values.get(projected_offset + k).cloned().unwrap_or(SqlValue::Null);
+                        literal_map.insert(corr.key.clone(), value);
+                    }
+                    projected_offset += corr_refs.len();
+
+                    let substituted = substitute_column_literals(
+                        &Expression::ScalarSubquery(subquery.clone()),
+                        &literal_map,
+                    );
+
+                    // Evaluate the now-uncorrelated multi-column subquery exactly
+                    // once, distributing its row tuple positionally (issue #6086).
+                    let evaluator =
+                        crate::evaluator::ExpressionEvaluator::with_database(eval_schema, database);
+                    let values =
+                        evaluator.eval_row_value(&substituted, &empty_row, *output_arity)?;
+                    set_values.extend(values);
+                }
+            }
+        }
 
         id_to_set_values.insert(id_values, set_values);
     }
@@ -301,13 +404,13 @@ pub fn execute_update_from_join(
 ///   Arity is validated against the column list here so a mismatch reports the
 ///   SQLite "N columns assigned M values" error rather than a downstream shape
 ///   error.
-/// - `ScalarSubquery(sub)` → one cloned subquery per column, each with its
-///   select-list narrowed to the single projected item. This preserves
-///   correlation (FROM/WHERE and the column expression are retained) and
-///   first-row semantics while yielding a single scalar column per output. A
-///   subquery whose select-list can't be split by simple index (e.g. it
-///   contains a `*` wildcard, or its arity can't be matched to the column
-///   count) is left intact so the ordinary evaluator raises the correct error.
+/// - Any other non-subquery RHS (e.g. `SET (a, b) = 1`) is projected once per
+///   column and the scalar evaluator surfaces the SQLite error.
+///
+/// A `ScalarSubquery` RHS is NOT handled here: it is intercepted earlier and
+/// evaluated once per matched row (issue #6086) so its columns keep SQLite's
+/// single-pass semantics. The `ScalarSubquery` arm below is retained only as a
+/// defensive fallback and is unreachable from the current caller.
 fn tuple_assignment_column_exprs(
     assignment: &Assignment,
 ) -> Result<Vec<Expression>, ExecutorError> {
@@ -348,6 +451,733 @@ fn tuple_assignment_column_exprs(
         // scalar evaluator handle it consistently with the non-FROM path.
         _ => Ok(vec![assignment.value.clone(); expected]),
     }
+}
+
+/// Canonical key identifying an outer column reference the subquery correlates
+/// on: `(optional-table, column)` (both lowercased). Distinct qualified/
+/// unqualified spellings of the same column collapse to distinct keys so
+/// substitution replaces exactly the spelling that appeared.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct CorrKey {
+    table: Option<String>,
+    column: String,
+}
+
+/// A single outer column reference of a tuple subquery, with the join-context
+/// expression to project (`__corr_i_k__`) and the key used to substitute it back
+/// as a literal at evaluation time.
+struct CorrRef {
+    key: CorrKey,
+    expr: Expression,
+}
+
+/// How an UPDATE…FROM assignment maps its projected synthetic columns to the
+/// final positionally-flattened SET values.
+enum AssignmentProjPlan {
+    /// The assignment projects `n` scalar columns directly usable as SET values
+    /// (single-column assignments contribute 1; direct row-value tuples
+    /// contribute one per target column).
+    DirectColumns(usize),
+    /// A tuple subquery assignment (issue #6086): it projects only its `corr_refs`
+    /// correlation inputs. The final `output_arity` SET values are produced by
+    /// substituting those inputs as literals into `subquery` and evaluating it
+    /// exactly once per matched row.
+    SubqueryOnce { output_arity: usize, corr_refs: Vec<CorrRef>, subquery: Box<SelectStmt> },
+}
+
+impl AssignmentProjPlan {
+    /// Number of final SET values this assignment contributes.
+    fn output_columns(&self) -> usize {
+        match self {
+            AssignmentProjPlan::DirectColumns(n) => *n,
+            AssignmentProjPlan::SubqueryOnce { output_arity, .. } => *output_arity,
+        }
+    }
+}
+
+/// Collect the lowercased names/aliases of the tables the UPDATE…FROM join binds
+/// in the *outer* scope: the target table (and its alias) plus every table named
+/// in the FROM clauses. A tuple subquery's column reference is treated as an
+/// outer (correlation) reference when it resolves to one of these tables and not
+/// to the subquery's own local scope.
+fn collect_outer_table_schemas(
+    target_schema: &TableSchema,
+    target_prefix: &str,
+    from_clauses: &[FromClause],
+    database: &Database,
+) -> HashMap<String, TableSchema> {
+    let mut out: HashMap<String, TableSchema> = HashMap::new();
+    out.insert(target_prefix.to_lowercase(), target_schema.clone());
+    out.insert(target_schema.name.to_lowercase(), target_schema.clone());
+    for fc in from_clauses {
+        collect_from_clause_tables(fc, database, &mut out);
+    }
+    out
+}
+
+/// Recursively register the base tables (with any alias) referenced by a FROM
+/// clause. Only plain `Table` sources contribute a resolvable schema; derived
+/// tables / VALUES / table-functions are skipped (their columns are handled by
+/// the synthetic SELECT's own correlation resolution when projected directly, and
+/// tuple subqueries correlating on them are uncommon).
+fn collect_from_clause_tables(
+    fc: &FromClause,
+    database: &Database,
+    out: &mut HashMap<String, TableSchema>,
+) {
+    match fc {
+        FromClause::Table { name, alias, .. } => {
+            if let Some(table) = database.get_table(name) {
+                let schema = table.schema.clone();
+                out.insert(name.to_lowercase(), schema.clone());
+                if let Some(a) = alias {
+                    out.insert(a.to_lowercase(), schema);
+                }
+            }
+        }
+        FromClause::Join { left, right, .. } => {
+            collect_from_clause_tables(left, database, out);
+            collect_from_clause_tables(right, database, out);
+        }
+        FromClause::Subquery { .. }
+        | FromClause::Values { .. }
+        | FromClause::TableFunction { .. } => {}
+    }
+}
+
+/// Collect the tuple subquery's *outer* column references — those correlating
+/// against the UPDATE…FROM join row rather than the subquery's own scope.
+///
+/// A reference is treated as outer when:
+/// - it is qualified (`t.c`) and `t` is one of the outer (target/FROM) tables and
+///   NOT a table bound locally inside the subquery, or
+/// - it is unqualified and matches a column of some outer table while not being a
+///   column of any table the subquery binds locally.
+///
+/// References that resolve to the subquery's own scope are left untouched so the
+/// subquery evaluator resolves them normally. Only the *top-level* subquery scope
+/// is analysed for local bindings; nested subqueries within it correlate through
+/// the same literal-substitution because their outer refs are a subset of these.
+fn collect_outer_column_refs(
+    subquery: &SelectStmt,
+    outer_tables: &HashMap<String, TableSchema>,
+) -> Vec<CorrRef> {
+    // Tables bound locally by this subquery's own FROM clause.
+    let mut local_tables: HashSet<String> = HashSet::new();
+    let mut local_columns: HashSet<String> = HashSet::new();
+    if let Some(from) = &subquery.from {
+        collect_local_bindings(from, &mut local_tables, &mut local_columns);
+    }
+
+    let mut seen: HashSet<CorrKey> = HashSet::new();
+    let mut refs: Vec<CorrRef> = Vec::new();
+    for item in &subquery.select_list {
+        if let SelectItem::Expression { expr, .. } = item {
+            collect_outer_refs_in_expr(
+                expr,
+                outer_tables,
+                &local_tables,
+                &local_columns,
+                &mut seen,
+                &mut refs,
+            );
+        }
+    }
+    // Also consider the subquery's WHERE clause and other clauses that may carry
+    // outer correlation (e.g. `(SELECT c FROM s WHERE s.k = t1.k LIMIT 1, ...)`).
+    if let Some(cond) = &subquery.where_clause {
+        collect_outer_refs_in_expr(
+            cond,
+            outer_tables,
+            &local_tables,
+            &local_columns,
+            &mut seen,
+            &mut refs,
+        );
+    }
+    refs
+}
+
+/// Register the table names/aliases and column names a subquery FROM clause binds
+/// locally. Used to distinguish inner references from outer correlation refs.
+fn collect_local_bindings(
+    from: &FromClause,
+    tables: &mut HashSet<String>,
+    columns: &mut HashSet<String>,
+) {
+    match from {
+        FromClause::Table { name, alias, column_aliases, .. } => {
+            tables.insert(name.to_lowercase());
+            if let Some(a) = alias {
+                tables.insert(a.to_lowercase());
+            }
+            if let Some(cols) = column_aliases {
+                for c in cols {
+                    columns.insert(c.to_lowercase());
+                }
+            }
+        }
+        FromClause::Join { left, right, .. } => {
+            collect_local_bindings(left, tables, columns);
+            collect_local_bindings(right, tables, columns);
+        }
+        FromClause::Subquery { alias, column_aliases, .. } => {
+            tables.insert(alias.to_lowercase());
+            if let Some(cols) = column_aliases {
+                for c in cols {
+                    columns.insert(c.to_lowercase());
+                }
+            }
+        }
+        FromClause::Values { alias, column_aliases, .. } => {
+            tables.insert(alias.to_lowercase());
+            if let Some(cols) = column_aliases {
+                for c in cols {
+                    columns.insert(c.to_lowercase());
+                }
+            }
+        }
+        FromClause::TableFunction { name, alias, column_aliases, .. } => {
+            tables.insert(name.to_lowercase());
+            if let Some(a) = alias {
+                tables.insert(a.to_lowercase());
+            }
+            if let Some(cols) = column_aliases {
+                for c in cols {
+                    columns.insert(c.to_lowercase());
+                }
+            }
+        }
+    }
+}
+
+/// Walk an expression, appending each distinct *outer* column reference to `refs`.
+///
+/// Nested subqueries ARE descended into, extending the local-binding scope with
+/// the nested subquery's own FROM tables/columns, so a correlation ref buried in
+/// a nested subquery (e.g. `sum((SELECT t1.y))`) is still collected while a name
+/// bound by the nested subquery's own FROM is not misclassified as outer. This
+/// matches SQLite's scoping: a ref is outer iff no enclosing scope up to (and
+/// including) the tuple subquery binds it.
+#[allow(clippy::only_used_in_recursion)]
+fn collect_outer_refs_in_expr(
+    expr: &Expression,
+    outer_tables: &HashMap<String, TableSchema>,
+    local_tables: &HashSet<String>,
+    local_columns: &HashSet<String>,
+    seen: &mut HashSet<CorrKey>,
+    refs: &mut Vec<CorrRef>,
+) {
+    match expr {
+        Expression::ColumnRef(id) => {
+            let column = id.column_canonical().to_string();
+            let table = id.table_canonical().map(|t| t.to_string());
+            let is_outer = match &table {
+                Some(t) => outer_tables.contains_key(t) && !local_tables.contains(t),
+                None => {
+                    // Unqualified: outer only if it names a column of some outer
+                    // table and is not locally bound.
+                    !local_columns.contains(&column)
+                        && outer_tables.values().any(|s| s.get_column_index(&column).is_some())
+                }
+            };
+            if is_outer {
+                let key = CorrKey { table: table.clone(), column: column.clone() };
+                if seen.insert(key.clone()) {
+                    refs.push(CorrRef { key, expr: expr.clone() });
+                }
+            }
+        }
+        Expression::BinaryOp { left, right, .. } => {
+            collect_outer_refs_in_expr(left, outer_tables, local_tables, local_columns, seen, refs);
+            collect_outer_refs_in_expr(
+                right,
+                outer_tables,
+                local_tables,
+                local_columns,
+                seen,
+                refs,
+            );
+        }
+        Expression::UnaryOp { expr, .. }
+        | Expression::Cast { expr, .. }
+        | Expression::Collate { expr, .. }
+        | Expression::IsNull { expr, .. } => {
+            collect_outer_refs_in_expr(expr, outer_tables, local_tables, local_columns, seen, refs);
+        }
+        Expression::Function { args, .. } | Expression::AggregateFunction { args, .. } => {
+            for a in args {
+                collect_outer_refs_in_expr(
+                    a,
+                    outer_tables,
+                    local_tables,
+                    local_columns,
+                    seen,
+                    refs,
+                );
+            }
+        }
+        Expression::Conjunction(parts) | Expression::Disjunction(parts) => {
+            for p in parts {
+                collect_outer_refs_in_expr(
+                    p,
+                    outer_tables,
+                    local_tables,
+                    local_columns,
+                    seen,
+                    refs,
+                );
+            }
+        }
+        Expression::Between { expr, low, high, .. } => {
+            collect_outer_refs_in_expr(expr, outer_tables, local_tables, local_columns, seen, refs);
+            collect_outer_refs_in_expr(low, outer_tables, local_tables, local_columns, seen, refs);
+            collect_outer_refs_in_expr(high, outer_tables, local_tables, local_columns, seen, refs);
+        }
+        Expression::InList { expr, values, .. } => {
+            collect_outer_refs_in_expr(expr, outer_tables, local_tables, local_columns, seen, refs);
+            for v in values {
+                collect_outer_refs_in_expr(
+                    v,
+                    outer_tables,
+                    local_tables,
+                    local_columns,
+                    seen,
+                    refs,
+                );
+            }
+        }
+        Expression::Like { expr, pattern, .. } | Expression::Glob { expr, pattern, .. } => {
+            collect_outer_refs_in_expr(expr, outer_tables, local_tables, local_columns, seen, refs);
+            collect_outer_refs_in_expr(
+                pattern,
+                outer_tables,
+                local_tables,
+                local_columns,
+                seen,
+                refs,
+            );
+        }
+        Expression::Case { operand, when_clauses, else_result } => {
+            if let Some(op) = operand {
+                collect_outer_refs_in_expr(
+                    op,
+                    outer_tables,
+                    local_tables,
+                    local_columns,
+                    seen,
+                    refs,
+                );
+            }
+            for clause in when_clauses {
+                for cond in &clause.conditions {
+                    collect_outer_refs_in_expr(
+                        cond,
+                        outer_tables,
+                        local_tables,
+                        local_columns,
+                        seen,
+                        refs,
+                    );
+                }
+                collect_outer_refs_in_expr(
+                    &clause.result,
+                    outer_tables,
+                    local_tables,
+                    local_columns,
+                    seen,
+                    refs,
+                );
+            }
+            if let Some(e) = else_result {
+                collect_outer_refs_in_expr(
+                    e,
+                    outer_tables,
+                    local_tables,
+                    local_columns,
+                    seen,
+                    refs,
+                );
+            }
+        }
+        Expression::RowValueConstructor(elems) => {
+            for e in elems {
+                collect_outer_refs_in_expr(
+                    e,
+                    outer_tables,
+                    local_tables,
+                    local_columns,
+                    seen,
+                    refs,
+                );
+            }
+        }
+        Expression::ScalarSubquery(sub) => {
+            collect_outer_refs_in_select(
+                sub,
+                outer_tables,
+                local_tables,
+                local_columns,
+                seen,
+                refs,
+            );
+        }
+        Expression::Exists { subquery, .. } => {
+            collect_outer_refs_in_select(
+                subquery,
+                outer_tables,
+                local_tables,
+                local_columns,
+                seen,
+                refs,
+            );
+        }
+        Expression::In { expr: inner, subquery, .. } => {
+            collect_outer_refs_in_expr(
+                inner,
+                outer_tables,
+                local_tables,
+                local_columns,
+                seen,
+                refs,
+            );
+            collect_outer_refs_in_select(
+                subquery,
+                outer_tables,
+                local_tables,
+                local_columns,
+                seen,
+                refs,
+            );
+        }
+        Expression::WindowFunction { function, over } => {
+            let (args, filter) = window_function_parts(function);
+            for a in args {
+                collect_outer_refs_in_expr(
+                    a,
+                    outer_tables,
+                    local_tables,
+                    local_columns,
+                    seen,
+                    refs,
+                );
+            }
+            if let Some(f) = filter {
+                collect_outer_refs_in_expr(
+                    f,
+                    outer_tables,
+                    local_tables,
+                    local_columns,
+                    seen,
+                    refs,
+                );
+            }
+            if let Some(pb) = &over.partition_by {
+                for e in pb {
+                    collect_outer_refs_in_expr(
+                        e,
+                        outer_tables,
+                        local_tables,
+                        local_columns,
+                        seen,
+                        refs,
+                    );
+                }
+            }
+            if let Some(ob) = &over.order_by {
+                for item in ob {
+                    collect_outer_refs_in_expr(
+                        &item.expr,
+                        outer_tables,
+                        local_tables,
+                        local_columns,
+                        seen,
+                        refs,
+                    );
+                }
+            }
+        }
+        // Do not descend into nested subqueries (see doc comment). Literals,
+        // placeholders, and other leaf/opaque forms carry no outer ref.
+        _ => {}
+    }
+}
+
+/// Descend into a nested SELECT, collecting its outer column references relative
+/// to the tuple subquery's join scope. The nested subquery's own FROM bindings
+/// are unioned into the local scope so its inner refs are not misclassified as
+/// outer correlation.
+fn collect_outer_refs_in_select(
+    select: &SelectStmt,
+    outer_tables: &HashMap<String, TableSchema>,
+    local_tables: &HashSet<String>,
+    local_columns: &HashSet<String>,
+    seen: &mut HashSet<CorrKey>,
+    refs: &mut Vec<CorrRef>,
+) {
+    let mut nested_tables = local_tables.clone();
+    let mut nested_columns = local_columns.clone();
+    if let Some(from) = &select.from {
+        collect_local_bindings(from, &mut nested_tables, &mut nested_columns);
+    }
+    for item in &select.select_list {
+        if let SelectItem::Expression { expr, .. } = item {
+            collect_outer_refs_in_expr(
+                expr,
+                outer_tables,
+                &nested_tables,
+                &nested_columns,
+                seen,
+                refs,
+            );
+        }
+    }
+    if let Some(cond) = &select.where_clause {
+        collect_outer_refs_in_expr(cond, outer_tables, &nested_tables, &nested_columns, seen, refs);
+    }
+    if let Some(having) = &select.having {
+        collect_outer_refs_in_expr(
+            having,
+            outer_tables,
+            &nested_tables,
+            &nested_columns,
+            seen,
+            refs,
+        );
+    }
+    if let Some(vibesql_ast::GroupByClause::Simple(exprs)) = &select.group_by {
+        for e in exprs {
+            collect_outer_refs_in_expr(
+                e,
+                outer_tables,
+                &nested_tables,
+                &nested_columns,
+                seen,
+                refs,
+            );
+        }
+    }
+}
+
+/// Borrow a window function's argument expressions and optional FILTER for
+/// outer-reference collection.
+fn window_function_parts(
+    spec: &vibesql_ast::WindowFunctionSpec,
+) -> (&[Expression], Option<&Expression>) {
+    match spec {
+        vibesql_ast::WindowFunctionSpec::Aggregate { args, filter, .. } => {
+            (args.as_slice(), filter.as_deref())
+        }
+        vibesql_ast::WindowFunctionSpec::Ranking { args, .. }
+        | vibesql_ast::WindowFunctionSpec::Value { args, .. } => (args.as_slice(), None),
+    }
+}
+
+/// Replace every `ColumnRef` matching a key in `literals` with the corresponding
+/// literal value. Nested subqueries are rewritten too, so a correlation ref used
+/// inside an inner subquery of the tuple RHS is also substituted.
+fn substitute_column_literals(
+    expr: &Expression,
+    literals: &HashMap<CorrKey, SqlValue>,
+) -> Expression {
+    use vibesql_ast::CaseWhen;
+    match expr {
+        Expression::ColumnRef(id) => {
+            let key = CorrKey {
+                table: id.table_canonical().map(|t| t.to_string()),
+                column: id.column_canonical().to_string(),
+            };
+            match literals.get(&key) {
+                Some(value) => Expression::Literal(value.clone()),
+                None => expr.clone(),
+            }
+        }
+        Expression::BinaryOp { op, left, right } => Expression::BinaryOp {
+            op: *op,
+            left: Box::new(substitute_column_literals(left, literals)),
+            right: Box::new(substitute_column_literals(right, literals)),
+        },
+        Expression::UnaryOp { op, expr: inner } => Expression::UnaryOp {
+            op: *op,
+            expr: Box::new(substitute_column_literals(inner, literals)),
+        },
+        Expression::Conjunction(parts) => Expression::Conjunction(
+            parts.iter().map(|p| substitute_column_literals(p, literals)).collect(),
+        ),
+        Expression::Disjunction(parts) => Expression::Disjunction(
+            parts.iter().map(|p| substitute_column_literals(p, literals)).collect(),
+        ),
+        Expression::Function { name, args, character_unit } => Expression::Function {
+            name: name.clone(),
+            args: args.iter().map(|a| substitute_column_literals(a, literals)).collect(),
+            character_unit: character_unit.clone(),
+        },
+        Expression::AggregateFunction { name, distinct, args, order_by, filter } => {
+            Expression::AggregateFunction {
+                name: name.clone(),
+                distinct: *distinct,
+                args: args.iter().map(|a| substitute_column_literals(a, literals)).collect(),
+                order_by: order_by.clone(),
+                filter: filter.as_ref().map(|f| Box::new(substitute_column_literals(f, literals))),
+            }
+        }
+        Expression::Cast { expr: inner, data_type } => Expression::Cast {
+            expr: Box::new(substitute_column_literals(inner, literals)),
+            data_type: data_type.clone(),
+        },
+        Expression::Collate { expr: inner, collation } => Expression::Collate {
+            expr: Box::new(substitute_column_literals(inner, literals)),
+            collation: collation.clone(),
+        },
+        Expression::IsNull { expr: inner, negated } => Expression::IsNull {
+            expr: Box::new(substitute_column_literals(inner, literals)),
+            negated: *negated,
+        },
+        Expression::Between { expr: inner, low, high, negated, symmetric } => Expression::Between {
+            expr: Box::new(substitute_column_literals(inner, literals)),
+            low: Box::new(substitute_column_literals(low, literals)),
+            high: Box::new(substitute_column_literals(high, literals)),
+            negated: *negated,
+            symmetric: *symmetric,
+        },
+        Expression::InList { expr: inner, values, negated } => Expression::InList {
+            expr: Box::new(substitute_column_literals(inner, literals)),
+            values: values.iter().map(|v| substitute_column_literals(v, literals)).collect(),
+            negated: *negated,
+        },
+        Expression::Like { expr: inner, pattern, negated, escape } => Expression::Like {
+            expr: Box::new(substitute_column_literals(inner, literals)),
+            pattern: Box::new(substitute_column_literals(pattern, literals)),
+            negated: *negated,
+            escape: escape.as_ref().map(|e| Box::new(substitute_column_literals(e, literals))),
+        },
+        Expression::Glob { expr: inner, pattern, negated, escape } => Expression::Glob {
+            expr: Box::new(substitute_column_literals(inner, literals)),
+            pattern: Box::new(substitute_column_literals(pattern, literals)),
+            negated: *negated,
+            escape: escape.as_ref().map(|e| Box::new(substitute_column_literals(e, literals))),
+        },
+        Expression::Case { operand, when_clauses, else_result } => Expression::Case {
+            operand: operand.as_ref().map(|o| Box::new(substitute_column_literals(o, literals))),
+            when_clauses: when_clauses
+                .iter()
+                .map(|w| CaseWhen {
+                    conditions: w
+                        .conditions
+                        .iter()
+                        .map(|c| substitute_column_literals(c, literals))
+                        .collect(),
+                    result: substitute_column_literals(&w.result, literals),
+                })
+                .collect(),
+            else_result: else_result
+                .as_ref()
+                .map(|e| Box::new(substitute_column_literals(e, literals))),
+        },
+        Expression::RowValueConstructor(elems) => Expression::RowValueConstructor(
+            elems.iter().map(|e| substitute_column_literals(e, literals)).collect(),
+        ),
+        Expression::ScalarSubquery(sub) => Expression::ScalarSubquery(Box::new(
+            substitute_column_literals_in_select(sub, literals),
+        )),
+        Expression::Exists { subquery, negated } => Expression::Exists {
+            subquery: Box::new(substitute_column_literals_in_select(subquery, literals)),
+            negated: *negated,
+        },
+        Expression::In { expr: inner, subquery, negated } => Expression::In {
+            expr: Box::new(substitute_column_literals(inner, literals)),
+            subquery: Box::new(substitute_column_literals_in_select(subquery, literals)),
+            negated: *negated,
+        },
+        Expression::WindowFunction { function, over } => Expression::WindowFunction {
+            function: substitute_column_literals_in_window_spec(function, literals),
+            over: substitute_column_literals_in_over(over, literals),
+        },
+        // Leaf / unsupported-here forms are returned unchanged.
+        _ => expr.clone(),
+    }
+}
+
+/// Substitute correlation literals inside a window function's args / FILTER.
+fn substitute_column_literals_in_window_spec(
+    spec: &vibesql_ast::WindowFunctionSpec,
+    literals: &HashMap<CorrKey, SqlValue>,
+) -> vibesql_ast::WindowFunctionSpec {
+    use vibesql_ast::WindowFunctionSpec;
+    match spec {
+        WindowFunctionSpec::Aggregate { name, args, filter } => WindowFunctionSpec::Aggregate {
+            name: name.clone(),
+            args: args.iter().map(|a| substitute_column_literals(a, literals)).collect(),
+            filter: filter.as_ref().map(|f| Box::new(substitute_column_literals(f, literals))),
+        },
+        WindowFunctionSpec::Ranking { name, args } => WindowFunctionSpec::Ranking {
+            name: name.clone(),
+            args: args.iter().map(|a| substitute_column_literals(a, literals)).collect(),
+        },
+        WindowFunctionSpec::Value { name, args } => WindowFunctionSpec::Value {
+            name: name.clone(),
+            args: args.iter().map(|a| substitute_column_literals(a, literals)).collect(),
+        },
+    }
+}
+
+/// Substitute correlation literals inside a window OVER clause's PARTITION BY /
+/// ORDER BY expressions. FRAME bounds and named-window inheritance are left
+/// as-is (they do not carry correlation refs for the shapes this path handles).
+fn substitute_column_literals_in_over(
+    over: &vibesql_ast::WindowSpec,
+    literals: &HashMap<CorrKey, SqlValue>,
+) -> vibesql_ast::WindowSpec {
+    let mut cloned = over.clone();
+    cloned.partition_by = over
+        .partition_by
+        .as_ref()
+        .map(|pb| pb.iter().map(|e| substitute_column_literals(e, literals)).collect());
+    cloned.order_by = over.order_by.as_ref().map(|ob| {
+        ob.iter()
+            .map(|item| vibesql_ast::OrderByItem {
+                expr: substitute_column_literals(&item.expr, literals),
+                direction: item.direction.clone(),
+                nulls_order: item.nulls_order,
+            })
+            .collect()
+    });
+    cloned
+}
+
+/// Apply `substitute_column_literals` across the correlation-bearing parts of a
+/// SELECT (select-list expressions, WHERE, HAVING). FROM/GROUP/ORDER are left
+/// intact — correlation into those is not expected for the tuple RHS shapes this
+/// path handles.
+fn substitute_column_literals_in_select(
+    select: &SelectStmt,
+    literals: &HashMap<CorrKey, SqlValue>,
+) -> SelectStmt {
+    let mut cloned = select.clone();
+    cloned.select_list = select
+        .select_list
+        .iter()
+        .map(|item| match item {
+            SelectItem::Expression { expr, alias, source_text } => SelectItem::Expression {
+                expr: substitute_column_literals(expr, literals),
+                alias: alias.clone(),
+                source_text: source_text.clone(),
+            },
+            other => other.clone(),
+        })
+        .collect();
+    if let Some(cond) = &select.where_clause {
+        cloned.where_clause = Some(substitute_column_literals(cond, literals));
+    }
+    if let Some(having) = &select.having {
+        cloned.having = Some(substitute_column_literals(having, literals));
+    }
+    if let Some(vibesql_ast::GroupByClause::Simple(exprs)) = &select.group_by {
+        cloned.group_by = Some(vibesql_ast::GroupByClause::Simple(
+            exprs.iter().map(|e| substitute_column_literals(e, literals)).collect(),
+        ));
+    }
+    cloned
 }
 
 /// Get the PRIMARY KEY column names for a table

--- a/crates/vibesql-executor/tests/tuple_set_assignment_tests.rs
+++ b/crates/vibesql-executor/tests/tuple_set_assignment_tests.rs
@@ -213,3 +213,91 @@ fn update_from_single_column_assignment_unaffected() {
     let r = t2_first_row(&db);
     assert_eq!(r[0], SqlValue::Integer(2000));
 }
+
+// ---------------------------------------------------------------------------
+// Single-evaluation semantics for a tuple *subquery* RHS (issue #6086).
+//
+// A splittable multi-column subquery must be evaluated ONCE per matched row and
+// its row tuple distributed positionally, not re-executed per target column.
+// Re-execution both diverged from SQLite for independent non-deterministic
+// projections (`SET (a,b)=(SELECT random(), random())` → a=b) and wasted work.
+// ---------------------------------------------------------------------------
+
+/// Run an arbitrary DDL/DML statement, panicking on any parse/exec error. Used
+/// to build the source tables the #6086 tests need beyond `setup_from`.
+fn exec(db: &mut Database, sql: &str) {
+    match Parser::parse_sql(sql).expect("parse") {
+        vibesql_ast::Statement::CreateTable(ct) => {
+            CreateTableExecutor::execute(&ct, db).expect("create");
+        }
+        vibesql_ast::Statement::Insert(ins) => {
+            InsertExecutor::execute(db, &ins).expect("insert");
+        }
+        vibesql_ast::Statement::Update(u) => {
+            UpdateExecutor::execute(&u, db).expect("update");
+        }
+        other => panic!("unexpected statement: {other:?}"),
+    }
+}
+
+/// `SET (a, b) = (SELECT random(), random())` must evaluate the subquery once,
+/// so the two independent `random()` calls yield different values (a != b),
+/// matching SQLite. Previously both narrowed subqueries collapsed through the
+/// result cache and produced a == b. Probabilistic but effectively certain for
+/// 64-bit random integers.
+#[test]
+fn update_from_tuple_set_subquery_random_is_evaluated_once() {
+    let mut db = setup_from();
+    run_update(&mut db, "UPDATE t2 SET (a, b) = (SELECT random(), random()) FROM t1")
+        .expect("update");
+    let r = t2_first_row(&db);
+    assert_ne!(r[0], r[1], "independent random() projections must differ (single-eval)");
+    assert_ne!(r[0], SqlValue::Null);
+    assert_ne!(r[1], SqlValue::Null);
+}
+
+/// A tuple subquery over a table with `ORDER BY ... LIMIT 1` returning a 2-tuple
+/// is evaluated once and both columns come from the SAME chosen row (single
+/// first-row semantics), matching SQLite (`10, 20`).
+#[test]
+fn update_from_tuple_set_subquery_ordered_limit_single_row() {
+    let mut db = setup_from();
+    exec(&mut db, "CREATE TABLE src(p, q)");
+    exec(&mut db, "INSERT INTO src VALUES(10, 20)");
+    exec(&mut db, "INSERT INTO src VALUES(30, 40)");
+    run_update(&mut db, "UPDATE t2 SET (a, b) = (SELECT p, q FROM src ORDER BY p LIMIT 1) FROM t1")
+        .expect("update");
+    let r = t2_first_row(&db);
+    assert_eq!(r[0], SqlValue::Integer(10));
+    assert_eq!(r[1], SqlValue::Integer(20));
+}
+
+/// A tuple subquery over a table whose WHERE correlates on a FROM-table column
+/// resolves against the join row, evaluated once. `t1.x = 1000` selects the
+/// matching `src` row `(30, 40)`; the subquery-local `src.k` refs are untouched.
+#[test]
+fn update_from_tuple_set_subquery_correlated_on_from_column() {
+    let mut db = setup_from();
+    exec(&mut db, "CREATE TABLE src(k, p, q)");
+    exec(&mut db, "INSERT INTO src VALUES(999, 10, 20)");
+    exec(&mut db, "INSERT INTO src VALUES(1000, 30, 40)");
+    run_update(&mut db, "UPDATE t2 SET (a, b) = (SELECT p, q FROM src WHERE src.k = t1.x) FROM t1")
+        .expect("update");
+    let r = t2_first_row(&db);
+    assert_eq!(r[0], SqlValue::Integer(30));
+    assert_eq!(r[1], SqlValue::Integer(40));
+}
+
+/// An empty correlated tuple subquery yields a row of NULLs (SQLite semantics),
+/// evaluated once.
+#[test]
+fn update_from_tuple_set_subquery_correlated_empty_yields_nulls() {
+    let mut db = setup_from();
+    exec(&mut db, "CREATE TABLE src(k, p, q)");
+    exec(&mut db, "INSERT INTO src VALUES(1, 10, 20)");
+    run_update(&mut db, "UPDATE t2 SET (a, b) = (SELECT p, q FROM src WHERE src.k = t1.x) FROM t1")
+        .expect("update");
+    let r = t2_first_row(&db);
+    assert_eq!(r[0], SqlValue::Null);
+    assert_eq!(r[1], SqlValue::Null);
+}


### PR DESCRIPTION
## Summary

`UPDATE t2 SET (a, b) = (SELECT e0, e1, ...) FROM ...` rewrote the multi-column
RHS subquery into one narrowed scalar subquery **per target column**, executing
the subquery once per column. Because two textually-identical narrowed
subqueries (e.g. both `random()`) collapse through the subquery-result cache,
`SET (a, b) = (SELECT random(), random())` produced `a = b` (VibeSQL) instead of
independent values (SQLite gives `a != b`). Expensive subqueries were also run
redundantly.

This PR gives the FROM-path SQLite's single-pass semantics: the multi-column
subquery is evaluated **once per matched outer row** and its row tuple is
distributed positionally to the target columns, mirroring the non-FROM UPDATE
tuple path.

## Changes

- `crates/vibesql-executor/src/update/from_clause.rs`
  - Replace the per-column `ScalarSubquery` split with a single-evaluation plan
    (`AssignmentProjPlan::SubqueryOnce`). For a tuple subquery RHS, the synthetic
    join SELECT now projects only the subquery's **outer correlation inputs**
    (`__corr_i_k__`); per matched row those join-row values are substituted as
    literals and the now-uncorrelated multi-column subquery is evaluated exactly
    once via `ExpressionEvaluator::eval_row_value`.
  - Correlation classification distinguishes outer (target/FROM) refs from the
    subquery's own local bindings, descending through nested subqueries and
    window functions (`max(t1.x) OVER (PARTITION BY sum((SELECT t1.y)))`) so
    refs buried there are still resolved and substituted.
  - Direct row-value RHS (`(t1.z, t1.x)`, `(7, 8)`) keeps the existing
    per-element projection (already single-pass).
- `crates/vibesql-executor/tests/tuple_set_assignment_tests.rs`
  - Add 4 tests: `random()` single-eval (`a != b`); ORDER/LIMIT 2-tuple
    single-row; FROM-correlated subquery-over-table; empty correlated subquery
    yields NULLs.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `SET (a,b)=(SELECT random(), random())` produces `a != b` | ✅ | New test `update_from_tuple_set_subquery_random_is_evaluated_once`; differential vs sqlite3 3.51 (`a=b` -> 0 both) |
| Single evaluation (subquery over table w/ ORDER/LIMIT returning 2-tuple) | ✅ | New test `...ordered_limit_single_row` -> `(10,20)`; matches sqlite3 |
| Correlation preserved against FROM join row | ✅ | `update_from_tuple_set_correlated_subquery` (`t1.x,t1.y`->1000,2000) + new `...correlated_on_from_column` (`WHERE src.k=t1.x`->30,40); matches sqlite3 |
| All #6085 tests keep passing (6 UPDATE-FROM tuple tests) | ✅ | 16/16 in `tuple_set_assignment_tests.rs` |
| rowvalue.test 291/297 baseline incl. §30.1/30.2 | ✅ | 291/298 pass; §30.1/30.2 pass; the 6 failures are the pre-existing out-of-scope ones (18.2, 18.5, 23.100, 23.110, 24.100, 34.5) |
| `cargo test -p vibesql-executor` green | ✅ | 5620 passed, 0 failed |

## Test Plan

- `cargo test -p vibesql-executor` -> 5620 passed, 0 failed.
- `./scripts/tcltest test rowvalue.test` -> 291/298 (§30.1/30.2 pass; only the 6
  pre-existing out-of-scope failures remain).
- Differential vs sqlite3 3.51 for the determinism/correlation cases (random,
  ORDER/LIMIT, `WHERE src.k=t1.x`, window+nested-subquery §30.1) — all match.
- `cargo clippy -p vibesql-executor` — no new warnings in changed code.

Closes #6086