### PR TITLE
fix(executor): SQLite truthiness for IS TRUE/text WHERE and REAL→text scientific rendering (atof1)

### DIFF
--- a/crates/vibesql-executor/src/evaluator/arena.rs
+++ b/crates/vibesql-executor/src/evaluator/arena.rs
@@ -555,22 +555,19 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
             // SQLite compatibility: integers are treated as booleans (0=FALSE, non-zero=TRUE)
             ArenaExpression::IsTruthValue { expr, truth_value, negated } => {
                 let val = self.eval_with_depth(expr, row)?;
+                // SQLite compatibility: coerce any value to a boolean via the
+                // shared truthiness rule (numeric prefix != 0), covering TEXT/BLOB
+                // (`'3' IS TRUE` -> 1, `'abc' IS TRUE` -> 0). NULL is UNKNOWN.
+                // See crate::evaluator::operators::is_truthy.
+                let is_null = matches!(val, SqlValue::Null);
                 let result = match truth_value {
-                    vibesql_ast::arena::TruthValue::True => match &val {
-                        SqlValue::Boolean(true) => true,
-                        SqlValue::Integer(n) => *n != 0,
-                        SqlValue::Bigint(n) => *n != 0,
-                        SqlValue::Smallint(n) => *n != 0,
-                        _ => false,
-                    },
-                    vibesql_ast::arena::TruthValue::False => matches!(
-                        val,
-                        SqlValue::Boolean(false)
-                            | SqlValue::Integer(0)
-                            | SqlValue::Bigint(0)
-                            | SqlValue::Smallint(0)
-                    ),
-                    vibesql_ast::arena::TruthValue::Unknown => matches!(val, SqlValue::Null),
+                    vibesql_ast::arena::TruthValue::True => {
+                        !is_null && crate::evaluator::operators::is_truthy(&val)
+                    }
+                    vibesql_ast::arena::TruthValue::False => {
+                        !is_null && !crate::evaluator::operators::is_truthy(&val)
+                    }
+                    vibesql_ast::arena::TruthValue::Unknown => is_null,
                 };
                 Ok(SqlValue::Boolean(if *negated { !result } else { result }))
             }
@@ -1059,9 +1056,13 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
             SqlValue::Varchar(s) | SqlValue::Character(s) => s.clone(),
             SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
-            SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
-            SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
-            SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // Render floats through the SqlValue Display impl (SQLite %!.15g
+            // scientific rendering), not raw f64/f32 `to_string()` (fixed-point).
+            // Display already matches SQLite 3.51; this keeps stored/CTE REAL
+            // values consistent with inline literals for LIKE/GLOB (fixes atof-3.1).
+            f @ (SqlValue::Float(_) | SqlValue::Double(_) | SqlValue::Real(_)) => {
+                arcstr::ArcStr::from(f.to_string())
+            }
             SqlValue::Blob(b) => arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned()),
             _ => {
                 return Err(ExecutorError::TypeError(format!(
@@ -1076,9 +1077,13 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
             SqlValue::Varchar(s) | SqlValue::Character(s) => s.clone(),
             SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
-            SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
-            SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
-            SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // Render floats through the SqlValue Display impl (SQLite %!.15g
+            // scientific rendering), not raw f64/f32 `to_string()` (fixed-point).
+            // Display already matches SQLite 3.51; this keeps stored/CTE REAL
+            // values consistent with inline literals for LIKE/GLOB (fixes atof-3.1).
+            f @ (SqlValue::Float(_) | SqlValue::Double(_) | SqlValue::Real(_)) => {
+                arcstr::ArcStr::from(f.to_string())
+            }
             _ => {
                 return Err(ExecutorError::TypeError(format!(
                     "LIKE requires string operands, got {:?} and {:?}",
@@ -1104,9 +1109,13 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
             SqlValue::Varchar(s) | SqlValue::Character(s) => s.clone(),
             SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
-            SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
-            SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
-            SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // Render floats through the SqlValue Display impl (SQLite %!.15g
+            // scientific rendering), not raw f64/f32 `to_string()` (fixed-point).
+            // Display already matches SQLite 3.51; this keeps stored/CTE REAL
+            // values consistent with inline literals for LIKE/GLOB (fixes atof-3.1).
+            f @ (SqlValue::Float(_) | SqlValue::Double(_) | SqlValue::Real(_)) => {
+                arcstr::ArcStr::from(f.to_string())
+            }
             SqlValue::Blob(b) => arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned()),
             _ => {
                 return Err(ExecutorError::TypeError(format!(
@@ -1121,9 +1130,13 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
             SqlValue::Varchar(s) | SqlValue::Character(s) => s.clone(),
             SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
-            SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
-            SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
-            SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // Render floats through the SqlValue Display impl (SQLite %!.15g
+            // scientific rendering), not raw f64/f32 `to_string()` (fixed-point).
+            // Display already matches SQLite 3.51; this keeps stored/CTE REAL
+            // values consistent with inline literals for LIKE/GLOB (fixes atof-3.1).
+            f @ (SqlValue::Float(_) | SqlValue::Double(_) | SqlValue::Real(_)) => {
+                arcstr::ArcStr::from(f.to_string())
+            }
             _ => {
                 return Err(ExecutorError::TypeError(format!(
                     "GLOB requires string operands, got {:?} and {:?}",

--- a/crates/vibesql-executor/src/evaluator/casting.rs
+++ b/crates/vibesql-executor/src/evaluator/casting.rs
@@ -530,10 +530,18 @@ pub(crate) fn cast_value(
                 SqlValue::Smallint(n) => arcstr::ArcStr::from(n.to_string().as_str()),
                 SqlValue::Bigint(n) => arcstr::ArcStr::from(n.to_string().as_str()),
                 SqlValue::Unsigned(n) => arcstr::ArcStr::from(n.to_string().as_str()),
-                SqlValue::Float(n) => arcstr::ArcStr::from(n.to_string().as_str()),
-                SqlValue::Real(n) => arcstr::ArcStr::from(n.to_string().as_str()),
-                SqlValue::Double(n) => arcstr::ArcStr::from(n.to_string().as_str()),
-                SqlValue::Numeric(n) => arcstr::ArcStr::from(n.to_string().as_str()),
+                // Floating-point values must render through the SqlValue Display
+                // impl, not the raw f64/f32 `to_string()`. Rust's `f64::to_string`
+                // emits shortest-round-trip *fixed-point* text
+                // (e.g. "18446744073709550000"), whereas SQLite's CAST(REAL AS TEXT)
+                // uses %!.15g-style scientific notation for large/small magnitudes
+                // ("1.84467440737095e+19"). Display (format_f64/format_f32) already
+                // matches SQLite 3.51 here, so route floats through it for parity
+                // (fixes atof-3.1 GLOB comparison against the scientific rendering).
+                SqlValue::Float(_)
+                | SqlValue::Real(_)
+                | SqlValue::Double(_)
+                | SqlValue::Numeric(_) => arcstr::ArcStr::from(value.to_string().as_str()),
                 SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "TRUE" } else { "FALSE" }),
                 SqlValue::Date(s) => arcstr::ArcStr::from(s.to_string().as_str()),
                 SqlValue::Time(s) => arcstr::ArcStr::from(s.to_string().as_str()),
@@ -649,10 +657,13 @@ pub(crate) fn cast_value(
                 SqlValue::Smallint(n) => arcstr::ArcStr::from(n.to_string().as_str()),
                 SqlValue::Bigint(n) => arcstr::ArcStr::from(n.to_string().as_str()),
                 SqlValue::Unsigned(n) => arcstr::ArcStr::from(n.to_string().as_str()),
-                SqlValue::Float(n) => arcstr::ArcStr::from(n.to_string().as_str()),
-                SqlValue::Real(n) => arcstr::ArcStr::from(n.to_string().as_str()),
-                SqlValue::Double(n) => arcstr::ArcStr::from(n.to_string().as_str()),
-                SqlValue::Numeric(n) => arcstr::ArcStr::from(n.to_string().as_str()),
+                // See the CAST-to-VARCHAR branch above: floats must render through
+                // the SqlValue Display impl (SQLite %!.15g scientific), not raw
+                // f64/f32 `to_string()` (fixed-point).
+                SqlValue::Float(_)
+                | SqlValue::Real(_)
+                | SqlValue::Double(_)
+                | SqlValue::Numeric(_) => arcstr::ArcStr::from(value.to_string().as_str()),
                 SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "TRUE" } else { "FALSE" }),
                 SqlValue::Blob(bytes) => {
                     // SQLite: CAST BLOB to TEXT interprets bytes as UTF-8

--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -1098,28 +1098,16 @@ impl CombinedExpressionEvaluator<'_> {
                 // - IS UNKNOWN: TRUE if expr is UNKNOWN (NULL), FALSE if expr is TRUE or FALSE
                 // - IS NOT X: negates the result
                 //
-                // SQLite compatibility: integers are treated as booleans
-                // - 0 is FALSE
-                // - Non-zero integers are TRUE
-                // - NULL is UNKNOWN
+                // SQLite compatibility: any value is coerced to a boolean via the
+                // shared truthiness rule (numeric prefix != 0), covering TEXT/BLOB
+                // operands too (`'3' IS TRUE` -> 1, `'abc' IS TRUE` -> 0). NULL is
+                // UNKNOWN. See crate::evaluator::operators::is_truthy.
+                use crate::evaluator::operators::is_truthy;
+                let is_null = matches!(val, vibesql_types::SqlValue::Null);
                 let result = match truth_value {
-                    vibesql_ast::TruthValue::True => match &val {
-                        vibesql_types::SqlValue::Boolean(true) => true,
-                        vibesql_types::SqlValue::Integer(n) => *n != 0,
-                        vibesql_types::SqlValue::Bigint(n) => *n != 0,
-                        vibesql_types::SqlValue::Smallint(n) => *n != 0,
-                        _ => false,
-                    },
-                    vibesql_ast::TruthValue::False => matches!(
-                        val,
-                        vibesql_types::SqlValue::Boolean(false)
-                            | vibesql_types::SqlValue::Integer(0)
-                            | vibesql_types::SqlValue::Bigint(0)
-                            | vibesql_types::SqlValue::Smallint(0)
-                    ),
-                    vibesql_ast::TruthValue::Unknown => {
-                        matches!(val, vibesql_types::SqlValue::Null)
-                    }
+                    vibesql_ast::TruthValue::True => !is_null && is_truthy(&val),
+                    vibesql_ast::TruthValue::False => !is_null && !is_truthy(&val),
+                    vibesql_ast::TruthValue::Unknown => is_null,
                 };
                 let final_result = if *negated { !result } else { result };
                 Ok(vibesql_types::SqlValue::Boolean(final_result))

--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -229,9 +229,12 @@ impl CombinedExpressionEvaluator<'_> {
             // SQLite coerces numeric types to strings for LIKE comparison
             vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
-            vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
-            vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
-            vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // Render floats through the SqlValue Display impl (SQLite %!.15g
+            // scientific rendering), not raw f64/f32 `to_string()` (fixed-point).
+            // Keeps stored/CTE REAL values consistent for LIKE/GLOB (fixes atof-3.1).
+            f @ (vibesql_types::SqlValue::Float(_)
+            | vibesql_types::SqlValue::Double(_)
+            | vibesql_types::SqlValue::Real(_)) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
             vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for LIKE comparison
@@ -255,9 +258,12 @@ impl CombinedExpressionEvaluator<'_> {
             // SQLite coerces numeric types to strings for LIKE comparison
             vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
-            vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
-            vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
-            vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // Render floats through the SqlValue Display impl (SQLite %!.15g
+            // scientific rendering), not raw f64/f32 `to_string()` (fixed-point).
+            // Keeps stored/CTE REAL values consistent for LIKE/GLOB (fixes atof-3.1).
+            f @ (vibesql_types::SqlValue::Float(_)
+            | vibesql_types::SqlValue::Double(_)
+            | vibesql_types::SqlValue::Real(_)) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
             vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for the LIKE pattern too:
@@ -350,9 +356,12 @@ impl CombinedExpressionEvaluator<'_> {
             // SQLite coerces numeric types to strings for GLOB comparison
             vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
-            vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
-            vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
-            vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // Render floats through the SqlValue Display impl (SQLite %!.15g
+            // scientific rendering), not raw f64/f32 `to_string()` (fixed-point).
+            // Keeps stored/CTE REAL values consistent for LIKE/GLOB (fixes atof-3.1).
+            f @ (vibesql_types::SqlValue::Float(_)
+            | vibesql_types::SqlValue::Double(_)
+            | vibesql_types::SqlValue::Real(_)) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
             vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for GLOB comparison
@@ -376,9 +385,12 @@ impl CombinedExpressionEvaluator<'_> {
             // SQLite coerces numeric types to strings for GLOB comparison
             vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
-            vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
-            vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
-            vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // Render floats through the SqlValue Display impl (SQLite %!.15g
+            // scientific rendering), not raw f64/f32 `to_string()` (fixed-point).
+            // Keeps stored/CTE REAL values consistent for LIKE/GLOB (fixes atof-3.1).
+            f @ (vibesql_types::SqlValue::Float(_)
+            | vibesql_types::SqlValue::Double(_)
+            | vibesql_types::SqlValue::Real(_)) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
             vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for the GLOB pattern too

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -966,38 +966,17 @@ impl ExpressionEvaluator<'_> {
                 // - IS UNKNOWN: TRUE if expr is UNKNOWN (NULL), FALSE if expr is TRUE or FALSE
                 // - IS NOT X: negates the result
                 //
-                // SQLite compatibility: integers are treated as booleans
-                // - 0 is FALSE
-                // - Non-zero integers are TRUE
-                // - NULL is UNKNOWN
+                // SQLite compatibility: any value is coerced to a boolean via the
+                // shared truthiness rule (numeric prefix != 0), which also covers
+                // TEXT and BLOB operands: `'3' IS TRUE` -> 1, `'3.5' IS TRUE` -> 1,
+                // `'abc' IS TRUE` -> 0, `x'00' IS TRUE` -> 0. NULL is UNKNOWN.
+                // See crate::evaluator::operators::is_truthy.
+                use crate::evaluator::operators::is_truthy;
+                let is_null = matches!(val, SqlValue::Null);
                 let result = match truth_value {
-                    vibesql_ast::TruthValue::True => match &val {
-                        SqlValue::Boolean(true) => true,
-                        SqlValue::Integer(n) => *n != 0,
-                        SqlValue::Bigint(n) => *n != 0,
-                        SqlValue::Smallint(n) => *n != 0,
-                        // REAL/floating values are truthy when non-zero (and not
-                        // NaN), matching SQLite: `0.5 IS TRUE` -> 1, `0.0 IS
-                        // TRUE` -> 0.
-                        SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f) => {
-                            *f != 0.0 && !f.is_nan()
-                        }
-                        SqlValue::Float(f) => *f != 0.0 && !f.is_nan(),
-                        _ => false,
-                    },
-                    vibesql_ast::TruthValue::False => match &val {
-                        SqlValue::Boolean(false)
-                        | SqlValue::Integer(0)
-                        | SqlValue::Bigint(0)
-                        | SqlValue::Smallint(0) => true,
-                        // A floating value equal to zero is FALSE.
-                        SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f) => {
-                            *f == 0.0
-                        }
-                        SqlValue::Float(f) => *f == 0.0,
-                        _ => false,
-                    },
-                    vibesql_ast::TruthValue::Unknown => matches!(val, SqlValue::Null),
+                    vibesql_ast::TruthValue::True => !is_null && is_truthy(&val),
+                    vibesql_ast::TruthValue::False => !is_null && !is_truthy(&val),
+                    vibesql_ast::TruthValue::Unknown => is_null,
                 };
                 let final_result = if *negated { !result } else { result };
                 Ok(SqlValue::Boolean(final_result))

--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -511,9 +511,14 @@ impl ExpressionEvaluator<'_> {
             // SQLite coerces numeric types to strings for LIKE comparison
             vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
-            vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
-            vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
-            vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // Render floats through the SqlValue Display impl, not raw f64/f32
+            // `to_string()`. Rust's `f64::to_string` emits fixed-point text
+            // ("18446744073709550000") while SQLite coerces REAL to its %!.15g
+            // scientific rendering ("1.84467440737095e+19") for LIKE/GLOB. Display
+            // already matches SQLite 3.51 (fixes atof-3.1's GLOB comparison).
+            f @ (vibesql_types::SqlValue::Float(_)
+            | vibesql_types::SqlValue::Double(_)
+            | vibesql_types::SqlValue::Real(_)) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
             vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for LIKE comparison
@@ -537,9 +542,14 @@ impl ExpressionEvaluator<'_> {
             // SQLite coerces numeric types to strings for LIKE comparison
             vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
-            vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
-            vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
-            vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // Render floats through the SqlValue Display impl, not raw f64/f32
+            // `to_string()`. Rust's `f64::to_string` emits fixed-point text
+            // ("18446744073709550000") while SQLite coerces REAL to its %!.15g
+            // scientific rendering ("1.84467440737095e+19") for LIKE/GLOB. Display
+            // already matches SQLite 3.51 (fixes atof-3.1's GLOB comparison).
+            f @ (vibesql_types::SqlValue::Float(_)
+            | vibesql_types::SqlValue::Double(_)
+            | vibesql_types::SqlValue::Real(_)) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
             vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for the LIKE pattern too:
@@ -629,9 +639,14 @@ impl ExpressionEvaluator<'_> {
             // SQLite coerces numeric types to strings for GLOB comparison
             vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
-            vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
-            vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
-            vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // Render floats through the SqlValue Display impl, not raw f64/f32
+            // `to_string()`. Rust's `f64::to_string` emits fixed-point text
+            // ("18446744073709550000") while SQLite coerces REAL to its %!.15g
+            // scientific rendering ("1.84467440737095e+19") for LIKE/GLOB. Display
+            // already matches SQLite 3.51 (fixes atof-3.1's GLOB comparison).
+            f @ (vibesql_types::SqlValue::Float(_)
+            | vibesql_types::SqlValue::Double(_)
+            | vibesql_types::SqlValue::Real(_)) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
             vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for GLOB comparison
@@ -655,9 +670,14 @@ impl ExpressionEvaluator<'_> {
             // SQLite coerces numeric types to strings for GLOB comparison
             vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
-            vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
-            vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
-            vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+            // Render floats through the SqlValue Display impl, not raw f64/f32
+            // `to_string()`. Rust's `f64::to_string` emits fixed-point text
+            // ("18446744073709550000") while SQLite coerces REAL to its %!.15g
+            // scientific rendering ("1.84467440737095e+19") for LIKE/GLOB. Display
+            // already matches SQLite 3.51 (fixes atof-3.1's GLOB comparison).
+            f @ (vibesql_types::SqlValue::Float(_)
+            | vibesql_types::SqlValue::Double(_)
+            | vibesql_types::SqlValue::Real(_)) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
             vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for the GLOB pattern too

--- a/crates/vibesql-executor/src/pipeline/native_columnar.rs
+++ b/crates/vibesql-executor/src/pipeline/native_columnar.rs
@@ -465,13 +465,14 @@ impl NativeColumnarPipeline {
         let mut filtered = Vec::with_capacity(rows.len());
         for row in rows {
             let value = evaluator.eval(predicate, &row)?;
-            let include = match value {
-                vibesql_types::SqlValue::Boolean(true) => true,
-                vibesql_types::SqlValue::Boolean(false) | vibesql_types::SqlValue::Null => false,
-                vibesql_types::SqlValue::Integer(0) => false,
-                vibesql_types::SqlValue::Integer(_) => true,
-                _ => false,
-            };
+            // Coerce the predicate result via the shared SQLite truthiness rule
+            // (numeric prefix != 0), which covers TEXT/BLOB/REAL operands too
+            // (`WHERE '3'` keeps the row, `WHERE '0'`/`WHERE 'abc'` drop it) and
+            // treats NULL as false. The previous `_ => false` arm silently dropped
+            // every text/real predicate result in this count/group-by fast path,
+            // diverging from the general filter paths and from SQLite (fixes
+            // atof1-2.30's `count(*) ... WHERE substr(a,',')`).
+            let include = crate::evaluator::operators::is_truthy(&value);
             if include {
                 filtered.push(row);
             }


### PR DESCRIPTION
## Summary

Fixes the 4 genuine engine bugs behind `atof1.test`'s failing non-loop tests (`atof1-2.10`, `atof1-2.20`, `atof1-2.30`, `atof-3.1`), split out of #6040 curation. Both root causes are reachable from plain UTF-8 SQL — the `PRAGMA encoding='UTF16be'` in the tests is incidental (VibeSQL stores UTF-8 throughout and `PRAGMA encoding` is a no-op), so **no UTF-16 support and no documented skip are needed**. All 7 non-loop tests now pass.

`atof1.test` summary: **3 pass / 4 fail / 39998 skip → 7 pass / 0 fail / 39998 skip** (the 39998 skips are the unchanged real2hex/hex2real loop).

## Root causes and fixes

### Bug 1 — Text/BLOB truthiness (atof1-2.10/2.20/2.30)

The tests do `SELECT substr(a,',') IS TRUE` and `count(*) ... WHERE substr(a,',')`, where `substr` returns text `'3'` for the integer row. Two truthiness gaps:

- **`IS TRUE` / `IS FALSE`** coerced only `Boolean`/`Integer`, returning `false` for any TEXT/BLOB/REAL. SQLite coerces via numeric-prefix truthiness: `'3' IS TRUE` → 1, `'3.5' IS TRUE` → 1, `'abc' IS TRUE` → 0, `x'00' IS TRUE` → 0. Unified all three `IsTruthValue` evaluators (`expressions/eval`, `combined/eval`, `arena`) onto the shared `is_truthy` helper with correct 3-valued logic.
- **The native-columnar `count(*)`/`GROUP BY` predicate fast path** had a `_ => false` arm that silently dropped every text/real WHERE result, diverging from the general filter paths. `count(*) FROM t WHERE '3'` returned 0 instead of 1. Routed through `is_truthy`.

### Bug 2 — REAL→TEXT scientific rendering (atof-3.1)

`CAST(REAL AS TEXT)` and the LIKE/GLOB float-to-text coercions used raw `f64::to_string()`, which emits fixed-point `18446744073709550000` instead of SQLite's `%!.15g` `1.84467440737095e+19`. This broke the test's `NOT GLOB '1.8446744073709[56]*'` filter. The `SqlValue` `Display` impl already matches SQLite 3.51, so floats now render through `Display` in `casting.rs` and in the LIKE/GLOB coercion blocks (`expressions/predicates`, `combined/predicates`, `arena`).

## Per-test disposition

| Test | Disposition |
|------|-------------|
| atof1-2.10 | **Fixed** (text/BLOB `IS TRUE`) |
| atof1-2.20 | **Fixed** (text/BLOB `IS TRUE`) |
| atof1-2.30 | **Fixed** (count/GROUP-BY WHERE fast-path truthiness) |
| atof-3.1   | **Fixed** (REAL→TEXT scientific rendering for CAST/GLOB) |

No test was reclassified or skipped.

## Verification

- IS TRUE/FALSE matrix and `CAST(REAL AS TEXT)` at **exact parity with `sqlite3 3.51.0`**.
- `make test-tcl-file FILE=atof1.test` → 7 passed / 0 failed / 39998 skipped.
- No regressions: cast.test (122), where.test (168), in.test (114), like.test (36), expr.test (638), between.test (12) all pass. `func.test`'s single failure (`func-7.1`, a `last_insert_rowid` harness-state artifact) is **pre-existing on baseline main** (verified).
- `cargo test -p vibesql-executor` (5627 passed) and `-p vibesql-types` (20 passed) green; `cargo fmt` + `clippy` clean on changed files.

Closes #6065

🤖 Generated with [Claude Code](https://claude.com/claude-code)