### PR TITLE
fix(executor): observe C-string NUL-termination in substr() and quote()

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/blob_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/blob_funcs.rs
@@ -302,8 +302,19 @@ pub(crate) fn quote(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         SqlValue::Float(f) => Ok(SqlValue::Varchar(format_float_for_quote(*f as f64).into())),
         SqlValue::Boolean(b) => Ok(SqlValue::Varchar(if *b { "1" } else { "0" }.into())),
         SqlValue::Varchar(s) | SqlValue::Character(s) => {
+            // SQLite observes TEXT values as NUL-terminated C strings: quote()
+            // renders the observed string, stopping at the first embedded NUL
+            // (consistent with LENGTH() in length.rs). e.g.
+            // CAST(x'4142004344' AS text) is "AB\0CD" but quote() emits 'AB',
+            // not a literal containing an embedded NUL. This also keeps CLI
+            // rendering balanced (PR #6093's format_sql_value truncation no
+            // longer drops the closing quote).
+            let observed = match s.as_bytes().iter().position(|&b| b == 0) {
+                Some(nul_idx) => &s[..nul_idx],
+                None => s.as_str(),
+            };
             // Escape single quotes by doubling them
-            let escaped = s.replace('\'', "''");
+            let escaped = observed.replace('\'', "''");
             Ok(SqlValue::Varchar(format!("'{}'", escaped).into()))
         }
         SqlValue::Vector(floats) => {
@@ -438,5 +449,26 @@ mod tests {
 
         // Empty string
         assert_eq!(quote(&[SqlValue::Varchar("".into())]).unwrap(), SqlValue::Varchar("''".into()));
+    }
+
+    #[test]
+    fn test_quote_observes_embedded_nul() {
+        // SQLite observes TEXT as a NUL-terminated C string. CAST(x'4142004344'
+        // AS text) is "AB\0CD" but quote() emits 'AB' (no embedded NUL), so
+        // hex(quote(...)) is 27414227 rather than 27414200434427.
+        assert_eq!(
+            quote(&[SqlValue::Varchar("AB\0CD".into())]).unwrap(),
+            SqlValue::Varchar("'AB'".into())
+        );
+        // Leading NUL -> observed empty string -> ''
+        assert_eq!(
+            quote(&[SqlValue::Varchar("\0AB".into())]).unwrap(),
+            SqlValue::Varchar("''".into())
+        );
+        // Interior single quote before a NUL is still escaped.
+        assert_eq!(
+            quote(&[SqlValue::Varchar("it's\0X".into())]).unwrap(),
+            SqlValue::Varchar("'it''s'".into())
+        );
     }
 }

--- a/crates/vibesql-executor/src/evaluator/functions/string/substring.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/string/substring.rs
@@ -58,6 +58,16 @@ pub(in crate::evaluator::functions) fn substring(
         None => return Ok(vibesql_types::SqlValue::Null),
     };
 
+    // SQLite observes TEXT values as NUL-terminated C strings: substr() operates
+    // on the observed string, stopping at the first embedded NUL byte (consistent
+    // with LENGTH() in length.rs). e.g. CAST(x'4142004344' AS text) is "AB\0CD"
+    // but substr sees only "AB", so substr(x,3,2) is empty and substr(x,1,5) is
+    // "AB". Numeric coercions never contain NULs, so this is a no-op for them.
+    let s = match s.as_bytes().iter().position(|&b| b == 0) {
+        Some(nul_idx) => &s[..nul_idx],
+        None => s.as_str(),
+    };
+
     // Work with characters (not bytes) for proper UTF-8 handling
     let chars: Vec<char> = s.chars().collect();
     let char_count = chars.len() as i64;
@@ -382,5 +392,62 @@ pub(in crate::evaluator::functions) fn right(
             "RIGHT requires string and integer arguments, got {:?} and {:?}",
             a, b
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vibesql_types::SqlValue;
+
+    fn text(s: &str) -> SqlValue {
+        SqlValue::Varchar(arcstr::ArcStr::from(s))
+    }
+
+    fn substr_text(v: SqlValue, start: i64, len: Option<i64>) -> String {
+        let mut args = vec![v, SqlValue::Integer(start)];
+        if let Some(l) = len {
+            args.push(SqlValue::Integer(l));
+        }
+        match substring(&args).unwrap() {
+            SqlValue::Varchar(s) => s.to_string(),
+            other => panic!("expected Varchar, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_substr_plain_text() {
+        assert_eq!(substr_text(text("hello"), 2, Some(3)), "ell");
+        assert_eq!(substr_text(text("hello"), 1, None), "hello");
+        assert_eq!(substr_text(text("hello"), -2, Some(2)), "lo");
+    }
+
+    #[test]
+    fn test_substr_observes_embedded_nul() {
+        // SQLite observes TEXT as a NUL-terminated C string. CAST(x'4142004344'
+        // AS text) is "AB\0CD" but substr() sees only the observed "AB".
+        let v = text("AB\0CD");
+        // hex(substr(x,1,5)) -> "4142" (only "AB"); we assert the observed chars.
+        assert_eq!(substr_text(v.clone(), 1, Some(5)), "AB");
+        assert_eq!(substr_text(v.clone(), 1, Some(2)), "AB");
+        assert_eq!(substr_text(v.clone(), 1, Some(10)), "AB");
+        // position 3 is past the observed 2-char string -> empty.
+        assert_eq!(substr_text(v.clone(), 3, Some(2)), "");
+        assert_eq!(substr_text(v.clone(), 2, None), "B");
+        // negative start counts from the end of the observed string.
+        assert_eq!(substr_text(v.clone(), -2, Some(2)), "AB");
+    }
+
+    #[test]
+    fn test_substr_leading_nul_is_empty() {
+        // "\0AB" observed as "" -> any substr is empty.
+        assert_eq!(substr_text(text("\0AB"), 1, Some(5)), "");
+        assert_eq!(substr_text(text("\0AB"), 1, None), "");
+    }
+
+    #[test]
+    fn test_substr_numeric_coercion_unaffected() {
+        // Numeric coercions never contain NULs; behavior is unchanged.
+        assert_eq!(substr_text(SqlValue::Integer(12345), 2, Some(3)), "234");
     }
 }


### PR DESCRIPTION
## Summary

SQLite treats a TEXT value as a NUL-terminated C string at observation points. PR #6093 established this model at `length()` and CLI rendering (`format_sql_value`); during its Judge review, differential probing against sqlite3 3.51 surfaced two pre-existing divergences at `substr()` and `quote()` (issue #6096). Both consumed the entire stored byte buffer instead of the observed (NUL-terminated) string.

This PR truncates the input TEXT at the first embedded NUL before `substr()` and `quote()` operate, matching sqlite3 3.51 byte-for-byte via `hex()`.

## Semantics map (probed against sqlite3 3.51, `CAST(x'4142004344' AS text)` = `AB\0CD`)

| Function | Observes NUL? | Fixed here |
|---|---|---|
| `substr()` | yes — sees observed `"AB"` (`substr(x,3,2)` empty, `substr(x,1,5)`=`AB`) | yes |
| `quote()` | yes — emits `'AB'` | yes |
| `upper()` / `lower()` | no — preserves full buffer incl. NUL + tail | left unchanged (verified) |
| `replace()` | no — reaches past NUL | left unchanged (verified) |
| `trim()` / `ltrim()` / `rtrim()` | no — preserves tail past NUL | left unchanged (verified) |
| `length()` | yes (already correct via #6093) | untouched |

Only `substr()` and `quote()` observe NUL-termination; the rest operate on the full byte buffer. The fix is scoped to exactly those two functions.

## Changes

- `substring.rs`: truncate the coerced TEXT input at the first embedded NUL before character extraction (numeric coercions never contain NULs, so no-op for them). Added a unit-test module.
- `blob_funcs.rs` (`quote`): truncate the `Varchar`/`Character` input at the first embedded NUL before escaping/quoting. Added `test_quote_observes_embedded_nul`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `hex(substr(CAST(x'4142004344' AS text),1,5))` = `4142` | ✅ | CLI diff vs sqlite3 3.51: both `4142` |
| `hex(quote(CAST(x'4142004344' AS text)))` = `27414227` | ✅ | CLI diff vs sqlite3 3.51: both `27414227` |
| CLI renders `quote(...)` as balanced `'AB'` | ✅ | CLI output `'AB'` (closing quote no longer dropped) |
| #6093 model preserved (`length()` = 2, CLI truncation) | ✅ | `length()` = 2 in both; length.rs tests pass |
| No regressions in func/cast TCL files | ✅ | cast.test 0 failures; func.test/func2/func3 only pre-existing `func-7.1` (`last_insert_rowid`, unrelated) |
| No regressions in executor suite | ✅ | `cargo test -p vibesql-executor --lib`: 3483 passed, 0 failed |
| upper/lower/replace/trim unchanged | ✅ | CLI diff vs sqlite3 3.51: all match, full buffer preserved |

## Test Plan

- `cargo test -p vibesql-executor --lib` → 3483 passed, 0 failed (new NUL tests included).
- End-to-end CLI diff of the divergence cases + non-diverging functions against sqlite3 3.51.0 → byte-for-byte match.
- `cast.test` (100% pass), `func.test`/`func2.test`/`func3.test` (only the pre-existing unrelated `func-7.1` `last_insert_rowid` failure).
- `cargo fmt` + `cargo clippy` (no new warnings from the two changed files).

Closes #6096