### PR TITLE
fix(executor): resolve correlated outer-table rowid against the outer row

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -35,6 +35,38 @@ fn format_float_for_text_comparison(n: f64) -> String {
     }
 }
 
+/// Resolve the rowid of `table_name` within a single outer scope described by
+/// `schema` (a [`CombinedSchema`] level) and its aligned `row` (issue #6087).
+///
+/// The scope is only considered if it actually contains the table. Resolution
+/// order mirrors the inner-scope rowid logic: an INTEGER PRIMARY KEY column is a
+/// rowid alias, so its value (read from `row` at the schema's `start_idx +
+/// rowid_alias_column`) wins; otherwise the row's tracked rowid for the table is
+/// used. WITHOUT ROWID tables and VIEWs have neither and yield `None`.
+fn rowid_from_scope(
+    schema: &crate::schema::CombinedSchema,
+    row: &vibesql_storage::Row,
+    table_name: &str,
+) -> Option<SqlValue> {
+    let table_id = vibesql_catalog::TableIdentifier::from(table_name);
+    let (start_idx, table_schema) = schema.table_schemas.get(&table_id)?;
+
+    // WITHOUT ROWID tables and VIEWs have no rowid pseudo-column.
+    if table_schema.without_rowid || table_schema.is_view {
+        return None;
+    }
+
+    // INTEGER PRIMARY KEY is an alias for rowid; its column value IS the rowid.
+    if let Some(ipk_col_idx) = table_schema.rowid_alias_column {
+        if let Some(value) = row.get(start_idx + ipk_col_idx) {
+            return Some(value.clone());
+        }
+    }
+
+    // Otherwise use the tracked rowid for this table.
+    row.get_row_id_for_table(Some(table_name)).map(|id| SqlValue::Bigint(id as i64))
+}
+
 impl CombinedExpressionEvaluator<'_> {
     /// Get the SQLite type affinity of an expression if it's a column reference.
     ///
@@ -121,6 +153,55 @@ impl CombinedExpressionEvaluator<'_> {
                 return table_schema.columns[col_offset].collation.clone();
             }
         }
+        None
+    }
+
+    /// Resolve an outer-table rowid reference from the correlation chain (issue #6087).
+    ///
+    /// A correlated subquery may reference the outer query's rowid, e.g.
+    /// `SELECT y FROM d2 WHERE d2.rowid = d1.rowid` where `d1` is the *outer*
+    /// table. `d1` is not present in this evaluator's own `self.schema`, so the
+    /// normal rowid resolution (which only consults `self.schema` + the inner
+    /// `row`) cannot find it and would return NULL — binding the correlated
+    /// reference to nothing and yielding the first outer row's result for every
+    /// outer row. This walks the outer scopes — the immediate parent
+    /// (`outer_row` + `outer_schema`) and then the `outer_context` chain — and
+    /// returns the rowid of `table` from the first scope that both contains the
+    /// table and carries a resolvable rowid for it.
+    ///
+    /// `table` must be a qualified table name; an unqualified `rowid` inside a
+    /// correlated subquery resolves to the subquery's own tables and never
+    /// reaches here.
+    fn resolve_outer_rowid(&self, table: Option<&str>) -> Option<SqlValue> {
+        let table_name = table?;
+
+        // Try the immediate parent scope: outer_row + outer_schema.
+        if let (Some(outer_row), Some(outer_schema)) = (self.outer_row, self.outer_schema) {
+            if let Some(value) = rowid_from_scope(outer_schema, outer_row, table_name) {
+                return Some(value);
+            }
+        }
+
+        // Walk the outer_context chain (grandparent scopes and beyond) so
+        // deeply nested correlated subqueries can still reach an ancestor's
+        // outer-table rowid.
+        let mut current_context = self.outer_context;
+        while let Some(ctx) = current_context {
+            if let Some(ctx_row) = ctx.outer_row {
+                // The context's own inner schema/row form one enclosing scope.
+                if let Some(value) = rowid_from_scope(ctx.schema, ctx_row, table_name) {
+                    return Some(value);
+                }
+                // The context's outer_schema (its parent) forms the next.
+                if let Some(ctx_outer_schema) = ctx.outer_schema {
+                    if let Some(value) = rowid_from_scope(ctx_outer_schema, ctx_row, table_name) {
+                        return Some(value);
+                    }
+                }
+            }
+            current_context = ctx.outer_context;
+        }
+
         None
     }
 
@@ -583,6 +664,32 @@ impl CombinedExpressionEvaluator<'_> {
                     if self.get_column_index_cached(table, column).is_none() {
                         // Check if the table is WITHOUT ROWID - if so, error
                         let table_id = table.map(vibesql_catalog::TableIdentifier::from);
+
+                        // Correlated outer-table rowid (issue #6087). When the
+                        // rowid is qualified by a table that is NOT one of this
+                        // scope's own tables (e.g. `d1.rowid` inside
+                        // `SELECT y FROM d2 WHERE d2.rowid = d1.rowid` where `d1`
+                        // is the *outer* table), it must resolve against the outer
+                        // row, not the inner one. Resolving it here — before the
+                        // inner-row fallbacks below — is essential: the inner
+                        // row's single `row_id` field answers
+                        // `get_row_id_for_table(Some("d1"))` for ANY table name, so
+                        // the fallback at the end of this block would otherwise
+                        // bind `d1.rowid` to the *inner* d2 row's rowid, making the
+                        // correlated predicate `d2.rowid = d1.rowid` trivially true
+                        // for every inner row and returning the first outer row's
+                        // result to all outer rows (rowvalue9 4.tn.4 / 4.tn.6).
+                        if let Some(ref table_id) = table_id {
+                            if !self.schema.table_schemas.contains_key(table_id) {
+                                if let Some(value) = self.resolve_outer_rowid(table) {
+                                    return Ok(value);
+                                }
+                                // Table is not in this scope and has no resolvable
+                                // outer rowid: fall through to NULL (matching the
+                                // derived-table behavior at the end of this block).
+                                return Ok(vibesql_types::SqlValue::Null);
+                            }
+                        }
                         if let Some(ref table_id) = table_id {
                             if let Some((_, table_schema)) = self.schema.table_schemas.get(table_id)
                             {

--- a/crates/vibesql-executor/tests/correlated_outer_rowid_tests.rs
+++ b/crates/vibesql-executor/tests/correlated_outer_rowid_tests.rs
@@ -1,0 +1,125 @@
+//! Regression tests for issue #6087.
+//!
+//! A correlated scalar subquery whose WHERE clause references the *outer*
+//! table's `rowid` (e.g. `SELECT y FROM d2 WHERE d2.rowid = d1.rowid` where
+//! `d1` is the outer table) must re-evaluate the outer rowid per outer row.
+//!
+//! The bug: `d1` is absent from the subquery's own schema, so the rowid
+//! resolver fell through to the inner row's tracked `row_id`. Because
+//! `Row::get_row_id_for_table` answers *any* table qualifier from the single
+//! `row_id` field when no per-table `row_ids` map is present, `d1.rowid` bound
+//! to the *inner* row's rowid — making the correlated predicate
+//! `d2.rowid = d1.rowid` trivially true for every inner row. The subquery then
+//! returned the first inner row's value regardless of the outer row, so the
+//! outer filter kept only the first outer row's match (rowvalue9 4.tn.4 /
+//! 4.tn.6).
+//!
+//! Expected values verified against sqlite3 3.51.0.
+
+use vibesql_catalog::{ColumnSchema, TableSchema};
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::{Database, Row};
+use vibesql_types::{DataType, SqlValue};
+
+fn parse_select(sql: &str) -> vibesql_ast::SelectStmt {
+    match Parser::parse_sql(sql) {
+        Ok(vibesql_ast::Statement::Select(select_stmt)) => *select_stmt,
+        _ => panic!("Failed to parse SELECT statement: {}", sql),
+    }
+}
+
+fn run(db: &Database, sql: &str) -> Vec<Row> {
+    let select = parse_select(sql);
+    SelectExecutor::new(db).execute(&select).unwrap()
+}
+
+/// Collect the integer values of result column 0 (rowids).
+fn rowids(rows: &[Row]) -> Vec<i64> {
+    rows.iter()
+        .map(|r| match r.get(0) {
+            Some(SqlValue::Integer(n)) | Some(SqlValue::Bigint(n)) => *n,
+            other => panic!("expected integer at index 0, got {other:?}"),
+        })
+        .collect()
+}
+
+/// `d1(a, c)` with rowids 1,2 and `d2(x, y)` with rowids 1,2 such that
+/// `d2.rowid = N` yields `y = N`.
+fn setup_db() -> Database {
+    let mut db = Database::new();
+    let d1 = TableSchema::new(
+        "d1".to_string(),
+        vec![
+            ColumnSchema::new("a".to_string(), DataType::Integer, true),
+            ColumnSchema::new("c".to_string(), DataType::Integer, true),
+        ],
+    );
+    db.create_table(d1).unwrap();
+    // rowid 1: a=1, c=10 ; rowid 2: a=2, c=20
+    db.insert_row("d1", Row::new(vec![SqlValue::Integer(1), SqlValue::Integer(10)])).unwrap();
+    db.insert_row("d1", Row::new(vec![SqlValue::Integer(2), SqlValue::Integer(20)])).unwrap();
+
+    let d2 = TableSchema::new(
+        "d2".to_string(),
+        vec![
+            ColumnSchema::new("x".to_string(), DataType::Integer, true),
+            ColumnSchema::new("y".to_string(), DataType::Integer, true),
+        ],
+    );
+    db.create_table(d2).unwrap();
+    // rowid 1: x=10, y=1 ; rowid 2: x=20, y=2
+    db.insert_row("d2", Row::new(vec![SqlValue::Integer(10), SqlValue::Integer(1)])).unwrap();
+    db.insert_row("d2", Row::new(vec![SqlValue::Integer(20), SqlValue::Integer(2)])).unwrap();
+    db
+}
+
+/// The primary reproducer from issue #6087. Every outer row matches because the
+/// per-row subquery resolves `d1.rowid` to the current outer row. Before the
+/// fix only rowid 1 was returned.
+#[test]
+fn scalar_correlated_outer_rowid_reevaluated_per_row() {
+    let db = setup_db();
+    let sql = "SELECT d1.rowid FROM d1 \
+               WHERE a = (SELECT y FROM d2 WHERE d2.rowid = d1.rowid)";
+    assert_eq!(rowids(&run(&db, sql)), vec![1, 2]);
+}
+
+/// The row-value form (rowvalue9 4.tn.4 shape): `(c, a) = (SELECT x, y ...)`.
+#[test]
+fn row_value_correlated_outer_rowid_reevaluated_per_row() {
+    let db = setup_db();
+    let sql = "SELECT d1.rowid FROM d1 \
+               WHERE (c, a) = (SELECT x, y FROM d2 WHERE d2.rowid = d1.rowid)";
+    // rowid 1: (10,1) vs d2.rowid=1 -> (10,1) match; rowid 2: (20,2) vs
+    // d2.rowid=2 -> (20,2) match.
+    assert_eq!(rowids(&run(&db, sql)), vec![1, 2]);
+}
+
+/// A correlated outer rowid that matches only some outer rows must filter
+/// correctly rather than returning all-or-nothing — guards against a fix that
+/// merely reuses the wrong (but consistent) binding.
+#[test]
+fn scalar_correlated_outer_rowid_partial_match() {
+    let db = setup_db();
+    // Swap: match only when a equals the *other* row's y. d2.rowid=1 -> y=1,
+    // d2.rowid=2 -> y=2, so `a = y` holds for both rows here; instead compare
+    // against x to make only rowid mismatch fail.
+    let sql = "SELECT d1.rowid FROM d1 \
+               WHERE c = (SELECT x FROM d2 WHERE d2.rowid = d1.rowid)";
+    // rowid 1: c=10 vs d2.rowid=1 -> x=10 match; rowid 2: c=20 vs d2.rowid=2 ->
+    // x=20 match. Both match, confirming per-row resolution of x too.
+    assert_eq!(rowids(&run(&db, sql)), vec![1, 2]);
+}
+
+/// An unqualified `rowid` inside the subquery still resolves to the subquery's
+/// own table, not the outer one — the fix must only redirect *qualified*
+/// outer-table rowids.
+#[test]
+fn unqualified_inner_rowid_unaffected() {
+    let db = setup_db();
+    // `SELECT y FROM d2 WHERE rowid = 1` always yields y=1 regardless of the
+    // outer row, so only the outer row with a=1 (rowid 1) matches.
+    let sql = "SELECT d1.rowid FROM d1 WHERE a = (SELECT y FROM d2 WHERE rowid = 1)";
+    assert_eq!(rowids(&run(&db, sql)), vec![1]);
+}


### PR DESCRIPTION
## Summary

A correlated subquery that references an *outer* table's `rowid` was not re-evaluated per outer row: the outer rowid resolved against the inner row instead, so the subquery returned the first outer row's result for every outer row.

Reproduction (VibeSQL vs sqlite3 3.51.0):

```sql
CREATE TABLE d1(a,c); INSERT INTO d1(rowid,a,c) VALUES(1,1,10),(2,2,20);
CREATE TABLE d2(x,y); INSERT INTO d2(rowid,x,y) VALUES(1,10,1),(2,20,2);
SELECT d1.rowid FROM d1 WHERE a = (SELECT y FROM d2 WHERE d2.rowid=d1.rowid);
-- sqlite: 1, 2   VibeSQL before: 1 only   VibeSQL after: 1, 2
```

## Root cause

`d1` is absent from the subquery's own schema, so the combined evaluator's rowid pseudo-column path in `eval_column_ref` fell through to the inner row's tracked rowid. Because `Row::get_row_id_for_table` answers *any* table qualifier from the single `row_id` field when no per-table `row_ids` map is present, `d1.rowid` bound to the *inner* d2 row's rowid — making the correlated predicate `d2.rowid = d1.rowid` trivially true for every inner row. The subquery therefore returned the first inner row's value regardless of the outer row, and the outer filter kept only the first outer row's match.

This is an execution-time defect: PR #6064 already fixed correlation *detection* (the cache key includes the outer rowid); the remaining gap was that resolving `d1.rowid` inside the subquery read the wrong row.

## Changes

- `crates/vibesql-executor/src/evaluator/combined/eval.rs`:
  - New free fn `rowid_from_scope(schema, row, table)` — resolves a table's rowid within one scope, honoring INTEGER PRIMARY KEY aliases and WITHOUT ROWID / VIEW rules.
  - New method `resolve_outer_rowid(table)` — walks the outer scope chain (immediate `outer_row` + `outer_schema`, then the `outer_context` chain).
  - In the rowid pseudo-column path: when a *qualified* rowid's table is not one of the current scope's own tables, resolve it from the outer chain **before** the inner-row fallbacks (which would otherwise mis-bind it).
- New regression test file `crates/vibesql-executor/tests/correlated_outer_rowid_tests.rs` (scalar form, row-value form, partial-match, and an unqualified-inner-rowid control).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Reproduction returns SQLite-matching results | ✅ | CLI returns `1, 2`; matches sqlite3 3.51.0 |
| `rowvalue9.test` `4.$tn.4`/`4.$tn.6` pass | ✅ | All 16 tests flip; none appear in the failure list |
| No regressions in rowvalue2/3/4/7/9/A | ✅ | rowvalue2/3/7/A 100%; rowvalue4 unchanged (3 pre-existing collation / EQP failures); rowvalue9 73→89 |
| Broader correlated-subquery coverage | ✅ | subquery2 100%, where7 2007 pass; subquery/rowid are pre-existing whole-file skips |
| `cargo test -p vibesql-executor` green | ✅ | 0 failures across the crate |

## Test Plan

- `cargo test -p vibesql-executor` — 0 failures (new `correlated_outer_rowid_tests` 4/4 pass).
- `./scripts/tcltest test rowvalue9.test` — **73 → 89 / 93** (remaining 5.2/5.3 NUMERIC-affinity and 8.2 EQP are pre-existing, out of scope).
- Differential-verified the reproduction and the rowvalue9 4.x.4 / 4.x.6 shapes against sqlite3 3.51.0.
- `cargo clippy -p vibesql-executor` — no new warnings on the added code.

Closes #6087