### PR TITLE
fix(executor): qualify bare rowid LHS in IN→SEMI/ANTI-join rewrite (#6088)

### DIFF
--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/in_clause.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/in_clause.rs
@@ -77,6 +77,30 @@ fn qualify_outer_expr_in_scope(
 ) -> Option<Expression> {
     if let Expression::ColumnRef(col_id) = expr {
         if col_id.schema_canonical().is_none() && col_id.table_canonical().is_none() {
+            // The bare `rowid`/`_rowid_`/`oid` pseudo-column is not a real column
+            // on any outer source, so `resolve_outer_column_qualifier` finds zero
+            // matches and returns `LeaveUnqualified`. Folding a bare `rowid` into
+            // the synthesized SEMI/ANTI-join ON condition then breaks: in the
+            // join's combined schema (outer table + subquery table) an unqualified
+            // `rowid` no longer resolves to the outer table's rowid and evaluates
+            // to NULL, so the predicate never matches and the whole IN filter
+            // drops every row (issue #6088; rowvalue9 5.2/5.3).
+            //
+            // Qualify it against the single outer table that actually owns a
+            // rowid. If the outer scope is anything other than exactly one
+            // rowid-bearing base table (multiple tables, a WITHOUT ROWID table, a
+            // view, or a derived/VALUES source), abort the transform and fall back
+            // to row-by-row `eval_in_subquery`, which resolves the bare rowid
+            // against the scanned table correctly.
+            if is_rowid_pseudo_column(col_id.column_canonical()) {
+                return match single_outer_rowid_table(from, database) {
+                    Some(table) => {
+                        Some(rewrite_column_refs_with_alias(expr, &table, &table))
+                    }
+                    None => None,
+                };
+            }
+
             match resolve_outer_column_qualifier(
                 from,
                 database,
@@ -92,6 +116,39 @@ fn qualify_outer_expr_in_scope(
         }
     }
     Some(expr.clone())
+}
+
+/// Whether `column` is one of SQLite's rowid pseudo-column spellings.
+fn is_rowid_pseudo_column(column: &str) -> bool {
+    column.eq_ignore_ascii_case("rowid")
+        || column.eq_ignore_ascii_case("_rowid_")
+        || column.eq_ignore_ascii_case("oid")
+}
+
+/// Resolve the effective name of the single outer-FROM base table that owns a
+/// rowid, or `None` if the outer scope is not exactly one rowid-bearing base
+/// table.
+///
+/// Used to qualify a bare `rowid` LHS before it becomes the left side of a
+/// synthesized SEMI/ANTI-join predicate (issue #6088). Returns `None` — signaling
+/// the caller to abort the IN→join transform and fall back to row-by-row
+/// evaluation — when the outer FROM is a join/multiple tables (a bare rowid would
+/// be ambiguous), a WITHOUT ROWID table or a view (no rowid pseudo-column), or a
+/// derived/VALUES source (no rowid, and its effective name is not a base table).
+fn single_outer_rowid_table(from: &FromClause, database: &Database) -> Option<String> {
+    match from {
+        FromClause::Table { name, alias, .. } => {
+            let table = database.get_table(name)?;
+            // WITHOUT ROWID tables and views have no rowid pseudo-column.
+            if table.schema.without_rowid || table.schema.is_view {
+                return None;
+            }
+            Some(alias.clone().unwrap_or_else(|| name.clone()))
+        }
+        // Joins/multiple tables → a bare rowid is ambiguous; derived/VALUES
+        // sources have no rowid. In all these cases fall back to row-by-row.
+        _ => None,
+    }
 }
 
 /// Try to convert an IN subquery to a SEMI or ANTI join

--- a/crates/vibesql-executor/tests/where_rowid_in_subquery_tests.rs
+++ b/crates/vibesql-executor/tests/where_rowid_in_subquery_tests.rs
@@ -1,0 +1,142 @@
+//! Regression tests for issue #6088.
+//!
+//! A WHERE-clause `rowid IN (SELECT ...)` filter returned an empty result set
+//! even though the equivalent SELECT-list projection of the same predicate
+//! (and the scalar `rowid = (SELECT ...)` form) worked:
+//!
+//! ```sql
+//! CREATE TABLE e1(a TEXT, c NUMERIC); INSERT INTO e1 VALUES(2, 2);
+//! CREATE TABLE e2(x BLOB, y BLOB); INSERT INTO e2 VALUES('2',2),('2','2'),('2','2.0');
+//! SELECT rowid FROM e2 WHERE rowid IN (SELECT +c FROM e1);  -- rowvalue9 5.2 → 2
+//! ```
+//!
+//! Root cause: the IN→SEMI/ANTI-join rewrite (`subquery_to_join`) folded the
+//! outer LHS `rowid` verbatim into the synthesized join ON condition
+//! (`e2 SEMI JOIN e1 ON rowid = e1.c`). In the join's combined schema
+//! (`e2` + `e1`) a *bare* `rowid` no longer resolves to `e2`'s rowid — it
+//! evaluated to NULL, so the predicate never matched and the filter dropped
+//! every row. Qualifying the bare rowid to its single outer table
+//! (`e2.rowid = e1.c`) — or aborting the transform and falling back to
+//! row-by-row evaluation when that is not safely possible — fixes it.
+//!
+//! Expected values verified against sqlite3 3.51.0.
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::CreateIndex(create_index) => {
+            vibesql_executor::CreateIndexExecutor::execute(&create_index, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            vibesql_executor::InsertExecutor::execute(db, &insert).unwrap();
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+/// Run a SELECT and return the integer value of result column 0 for each row.
+fn query_col0_ints(db: &vibesql_storage::Database, sql: &str) -> Vec<i64> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    let vibesql_ast::Statement::Select(select_stmt) = stmt else {
+        panic!("Expected SELECT statement: {}", sql);
+    };
+    SelectExecutor::new(db)
+        .execute(&select_stmt)
+        .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e))
+        .into_iter()
+        .map(|row| match row.get(0) {
+            Some(SqlValue::Integer(n)) | Some(SqlValue::Bigint(n)) => *n,
+            other => panic!("expected integer at index 0, got {other:?}"),
+        })
+        .collect()
+}
+
+/// Build the rowvalue9 §5 fixture: `e1(a TEXT, c NUMERIC)` with one row and
+/// `e2(x BLOB, y BLOB)` with three rows (rowids 1,2,3), plus the `e1(c)` index.
+fn setup_db() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE e1(a TEXT, c NUMERIC)");
+    run_stmt(&mut db, "CREATE TABLE e2(x BLOB, y BLOB)");
+    run_stmt(&mut db, "INSERT INTO e1 VALUES(2, 2)");
+    run_stmt(&mut db, "INSERT INTO e2 VALUES ('2', 2)");
+    run_stmt(&mut db, "INSERT INTO e2 VALUES ('2', '2')");
+    run_stmt(&mut db, "INSERT INTO e2 VALUES ('2', '2.0')");
+    run_stmt(&mut db, "CREATE INDEX e1c ON e1(c)");
+    db
+}
+
+/// rowvalue9 5.2: `rowid IN (SELECT +c FROM e1)` → 2.
+#[test]
+fn rowid_in_subquery_unary_plus() {
+    let db = setup_db();
+    let sql = "SELECT rowid FROM e2 WHERE rowid IN (SELECT +c FROM e1)";
+    assert_eq!(query_col0_ints(&db, sql), vec![2]);
+}
+
+/// rowvalue9 5.3: `rowid IN (SELECT 0+c FROM e1)` → 2.
+#[test]
+fn rowid_in_subquery_zero_plus() {
+    let db = setup_db();
+    let sql = "SELECT rowid FROM e2 WHERE rowid IN (SELECT 0+c FROM e1)";
+    assert_eq!(query_col0_ints(&db, sql), vec![2]);
+}
+
+/// The plain column form `rowid IN (SELECT c FROM e1)` also matched the scalar
+/// `=` path but not the WHERE-path IN filter before the fix.
+#[test]
+fn rowid_in_subquery_plain_column() {
+    let db = setup_db();
+    let sql = "SELECT rowid FROM e2 WHERE rowid IN (SELECT c FROM e1)";
+    assert_eq!(query_col0_ints(&db, sql), vec![2]);
+}
+
+/// The `oid` and `_rowid_` spellings of the pseudo-column behave identically.
+#[test]
+fn rowid_aliases_in_subquery() {
+    let db = setup_db();
+    assert_eq!(
+        query_col0_ints(&db, "SELECT rowid FROM e2 WHERE oid IN (SELECT c FROM e1)"),
+        vec![2]
+    );
+    assert_eq!(
+        query_col0_ints(&db, "SELECT rowid FROM e2 WHERE _rowid_ IN (SELECT c FROM e1)"),
+        vec![2]
+    );
+}
+
+/// `NOT IN` (the ANTI-join path) keeps the complementary rows: {1, 3}.
+#[test]
+fn rowid_not_in_subquery_anti_join() {
+    let db = setup_db();
+    let sql = "SELECT rowid FROM e2 WHERE rowid NOT IN (SELECT c FROM e1)";
+    assert_eq!(query_col0_ints(&db, sql), vec![1, 3]);
+}
+
+/// An INTEGER PRIMARY KEY table exposes its rowid via the alias column; the
+/// bare-rowid qualification must resolve there too.
+#[test]
+fn rowid_in_subquery_integer_primary_key_table() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE e1(a TEXT, c NUMERIC)");
+    run_stmt(&mut db, "INSERT INTO e1 VALUES(2, 2)");
+    run_stmt(&mut db, "CREATE TABLE p(id INTEGER PRIMARY KEY, v TEXT)");
+    run_stmt(&mut db, "INSERT INTO p VALUES(2, 'x')");
+    run_stmt(&mut db, "INSERT INTO p VALUES(5, 'y')");
+    let sql = "SELECT id FROM p WHERE rowid IN (SELECT c FROM e1)";
+    assert_eq!(query_col0_ints(&db, sql), vec![2]);
+}
+
+/// A qualified outer rowid across multiple outer tables never hit the bug and
+/// must keep working (it does not use the bare-rowid qualification path).
+#[test]
+fn qualified_rowid_multi_table_outer() {
+    let db = setup_db();
+    let sql = "SELECT e2.rowid FROM e2, e1 WHERE e2.rowid IN (SELECT c FROM e1)";
+    assert_eq!(query_col0_ints(&db, sql), vec![2]);
+}


### PR DESCRIPTION
## Summary

`SELECT ... WHERE rowid IN (SELECT ...)` returned an **empty result set** while equivalent forms (SELECT-list projection of the same predicate, and scalar `rowid = (SELECT ...)`) worked correctly (rowvalue9 tests 5.2 / 5.3).

## Root cause

The IN→SEMI/ANTI-join optimizer (`crates/vibesql-executor/src/optimizer/subquery_to_join/in_clause.rs`) folded the outer LHS verbatim into the synthesized join `ON` condition, so a bare `rowid` became:

```sql
e2 SEMI JOIN e1 ON rowid = e1.c
```

In the join's **combined** schema (`e2` + `e1`), an unqualified `rowid` no longer resolves to the outer table's rowid — it evaluated to NULL, the predicate never matched, and the filter dropped every row.

## Fix

In `qualify_outer_expr_in_scope`, detect a bare rowid pseudo-column (`rowid` / `_rowid_` / `oid`) LHS and qualify it against the single outer base table that owns a rowid, yielding `e2.rowid = e1.c`.

When the outer scope is **not** exactly one rowid-bearing base table, abort the transform and fall back to row-by-row `eval_in_subquery` (which resolves the bare rowid against the scanned table correctly). This covers:
- a join / multiple tables (bare rowid would be ambiguous)
- a `WITHOUT ROWID` table or a view (no rowid pseudo-column)
- a derived / `VALUES` source (no rowid)

## Verification — differential vs sqlite3 3.51.0

| rowvalue9 | query | before | after | sqlite3 3.51 |
|-----------|-------|--------|-------|--------------|
| 5.2 | `rowid IN (SELECT +c FROM e1)`  | `0 rows` | `2` | `2` |
| 5.3 | `rowid IN (SELECT 0+c FROM e1)` | `0 rows` | `2` | `2` |
| —   | `rowid IN (SELECT c FROM e1)`   | `0 rows` | `2` | `2` |
| —   | `rowid NOT IN (SELECT c FROM e1)` | — | `1, 3` | `1, 3` |

## Tests

New regression suite `crates/vibesql-executor/tests/where_rowid_in_subquery_tests.rs` (7 tests): unary-plus, `0+`, plain column, `oid`/`_rowid_` aliases, NOT IN (ANTI), INTEGER PRIMARY KEY table, and qualified-rowid multi-table outer. All pass.

## No regressions

- `cargo test -p vibesql-executor`: **5457 passed, 0 failed**
- TCL `in.test` (114 pass, 0 fail), `where.test` (168 pass, 0 fail), `rowvalue2.test` (3834 pass, 0 fail) — all clean
- `rowvalue9.test`: the 16 remaining failures (4.x affinity/index index-scan variants, 9.4e/9.5e `EXPLAIN QUERY PLAN` shape assertions) are **pre-existing on `main`** (verified by stashing the fix) and unrelated to this seam — the affinity remainder is tracked in #6089.

Closes #6088

🤖 Generated with [Claude Code](https://claude.com/claude-code)