### PR TITLE
fix(executor): row-value/scalar comparison affinity + COLLATE-name validation (#6089)

### DIFF
--- a/crates/vibesql-executor/src/evaluator/collation.rs
+++ b/crates/vibesql-executor/src/evaluator/collation.rs
@@ -62,11 +62,13 @@ pub(crate) fn explicit_collation_of(expr: &Expression) -> Option<String> {
 /// Returns `None` when the expression is not a column operand at all
 /// (literal, `||`, function call, ...), in which case a comparison falls
 /// through to the other operand.
-fn operand_column_collation(
+pub(crate) fn operand_column_collation(
     expr: &Expression,
     column_collation: &dyn Fn(&ColumnIdentifier) -> Option<String>,
 ) -> Option<Option<String>> {
     match expr {
+        // An explicit COLLATE makes this a collating operand carrying that name.
+        Expression::Collate { collation, .. } => Some(Some(collation.clone())),
         Expression::ColumnRef(col_id) => Some(column_collation(col_id)),
         Expression::UnaryOp { op: UnaryOperator::Plus, expr } => {
             operand_column_collation(expr, column_collation)
@@ -177,6 +179,31 @@ pub(crate) fn comparison_collation(
         return coll;
     }
     None
+}
+
+/// Resolve the datatype3 §7.1 comparison collation for a single element pair from
+/// the operands' collating contributions (as returned by
+/// [`operand_column_collation`]): `Some(Some(coll))` = column operand with
+/// declared collation, `Some(None)` = column operand with default BINARY (which
+/// still blocks the other side), `None` = not a column operand.
+///
+/// Precedence: the left operand wins if it is a column operand (rule 2 — its
+/// default BINARY blocks fallback to the right); otherwise the right operand's
+/// collation; otherwise `None` (BINARY). An explicit COLLATE is surfaced as
+/// `Some(Some(coll))` by `operand_column_collation`, so rule-1 precedence falls
+/// out of the left-first ordering for the common single-explicit case.
+///
+/// This is used where one side of the comparison is an already-evaluated value
+/// (a scalar-subquery row), so its collating contribution is supplied directly
+/// rather than derived from a live `Expression`.
+pub(crate) fn comparison_collation_of_operands(
+    left_operand: Option<Option<String>>,
+    right_operand: Option<Option<String>>,
+) -> Option<String> {
+    match left_operand {
+        Some(coll) => coll,
+        None => right_operand.flatten(),
+    }
 }
 
 #[cfg(test)]

--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -78,6 +78,26 @@ impl CombinedExpressionEvaluator<'_> {
             }
             // For COLLATE expressions, get affinity of the inner expression
             vibesql_ast::Expression::Collate { expr, .. } => self.get_expression_affinity(expr),
+            // A CAST to a *numeric* type carries that numeric affinity (SQLite's
+            // `sqlite3ExprAffinity` TK_CAST case, issue #6089). A TEXT-affinity
+            // column compared to `CAST(0 AS REAL)` must route through the
+            // numeric-affinity coercion path rather than treating the CAST as an
+            // affinity-less literal (which would wrongly coerce the column value
+            // to text). This affects only how the OTHER operand is coerced.
+            //
+            // TEXT / BLOB casts are deliberately reported as affinity-less
+            // (`None`), matching the prior behaviour: surfacing TEXT affinity for
+            // `CAST(x AS text)` here would make an IN-list element look like a
+            // TEXT column and wrongly coerce a numeric LHS literal to text
+            // (`1 IN (CAST('1' AS text))` must stay 0 — in-17.3/17.4).
+            vibesql_ast::Expression::Cast { data_type, .. } => {
+                match data_type.sqlite_affinity() {
+                    affinity @ (vibesql_types::TypeAffinity::Numeric
+                    | vibesql_types::TypeAffinity::Integer
+                    | vibesql_types::TypeAffinity::Real) => Some(affinity),
+                    _ => None,
+                }
+            }
             // A scalar subquery carries the affinity of its (single) result
             // column, so `col = (SELECT y FROM blob_table)` compares by the
             // real column affinity of `y` (NONE for a BLOB column) rather than
@@ -1447,9 +1467,9 @@ impl CombinedExpressionEvaluator<'_> {
         for (left_expr, right_expr) in left_exprs.iter().zip(right_exprs.iter()) {
             let left_val = self.eval(left_expr, row)?;
             let right_val = self.eval(right_expr, row)?;
-            let collation = self
-                .get_expression_collation(left_expr)
-                .or_else(|| self.get_expression_collation(right_expr));
+            // datatype3 §7.1 comparison collation (issue #6089): left column
+            // collation, including default BINARY, blocks the right operand.
+            let collation = self.comparison_collation(left_expr, right_expr);
             let (left_val, right_val) = crate::evaluator::row_value::apply_collation_to_pair(
                 left_val,
                 right_val,
@@ -1492,7 +1512,7 @@ impl CombinedExpressionEvaluator<'_> {
         }
 
         let (tuple_values, subquery_values) =
-            self.eval_row_value_tuple_and_subquery(tuple_exprs, subquery, row)?;
+            self.eval_row_value_tuple_and_subquery(tuple_exprs, subquery, row, tuple_on_left)?;
 
         // Always evaluate with the tuple on the left. `subquery OP tuple` is
         // equivalent to `tuple flip(OP) subquery`, so only the operator flips.
@@ -1528,7 +1548,7 @@ impl CombinedExpressionEvaluator<'_> {
         }
 
         let (tuple_values, subquery_values) =
-            self.eval_row_value_tuple_and_subquery(tuple_exprs, subquery, row)?;
+            self.eval_row_value_tuple_and_subquery(tuple_exprs, subquery, row, true)?;
 
         Ok(crate::evaluator::row_value::row_values_is_distinct(
             &tuple_values,
@@ -1545,6 +1565,7 @@ impl CombinedExpressionEvaluator<'_> {
         tuple_exprs: &[vibesql_ast::Expression],
         subquery: &vibesql_ast::SelectStmt,
         row: &vibesql_storage::Row,
+        tuple_on_left: bool,
     ) -> Result<(Vec<SqlValue>, Vec<SqlValue>), ExecutorError> {
         let arity = tuple_exprs.len();
         let subquery_values = self.eval_scalar_subquery_as_row(subquery, row, arity)?;
@@ -1565,13 +1586,46 @@ impl CombinedExpressionEvaluator<'_> {
             })
             .collect();
 
+        // Per-position collating contribution of the subquery's result columns
+        // (`Some(Some(coll))` = column with declared collation, `Some(None)` =
+        // column with default BINARY that still blocks, `None` = not a column
+        // operand), so a row-value comparison against a scalar subquery applies
+        // the datatype3 §7.1 comparison collation with correct left-operand
+        // precedence (rowvalue §23.110, issue #6089). `(SELECT +bb, 1) >=
+        // (aa, 1)` compares element 0 with the *subquery* column `+bb` as the
+        // left operand, whose default BINARY blocks the tuple's NOCASE `aa`.
+        let sub_collations: Vec<Option<Option<String>>> = (0..arity)
+            .map(|i| {
+                self.database.and_then(|db| {
+                    crate::evaluator::combined::subqueries::schema_utils::get_subquery_column_collation_at(
+                        subquery, i, db,
+                    )
+                })
+            })
+            .collect();
+
         let mut tuple_values = Vec::with_capacity(arity);
         let mut other_values = Vec::with_capacity(arity);
         for (idx, (tuple_expr, sub_val)) in tuple_exprs.iter().zip(subquery_values).enumerate() {
             let tuple_val = self.eval(tuple_expr, row)?;
-            // Per-element collation from the tuple side (explicit COLLATE or
-            // column-declared collation), e.g. `(a COLLATE nocase, b) = (SELECT ...)`.
-            let collation = self.get_expression_collation(tuple_expr);
+            // datatype3 §7.1 comparison collation: the *left* operand's column
+            // collation (including its default BINARY) blocks fallback to the
+            // right; an explicit COLLATE on either side wins first (rule 1).
+            // `tuple_on_left` decides which side is the left operand.
+            let tuple_operand = crate::evaluator::collation::operand_column_collation(
+                tuple_expr,
+                &|col_id| self.column_collation_of(col_id),
+            );
+            let sub_operand = sub_collations[idx].clone();
+            let (left_operand, right_operand) = if tuple_on_left {
+                (tuple_operand, sub_operand)
+            } else {
+                (sub_operand, tuple_operand)
+            };
+            let collation = crate::evaluator::collation::comparison_collation_of_operands(
+                left_operand,
+                right_operand,
+            );
             let (tuple_val, sub_val) = crate::evaluator::row_value::apply_collation_to_pair(
                 tuple_val,
                 sub_val,
@@ -1707,9 +1761,9 @@ impl CombinedExpressionEvaluator<'_> {
             _ => {
                 let left_val = self.eval(left_expr, row)?;
                 let right_val = self.eval(right_expr, row)?;
-                let collation = self
-                    .get_expression_collation(left_expr)
-                    .or_else(|| self.get_expression_collation(right_expr));
+                // datatype3 §7.1 comparison collation (issue #6089): left column
+                // collation, including default BINARY, blocks the right operand.
+                let collation = self.comparison_collation(left_expr, right_expr);
                 let (left_val, right_val) = crate::evaluator::row_value::apply_collation_to_pair(
                     left_val,
                     right_val,

--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -622,9 +622,9 @@ impl CombinedExpressionEvaluator<'_> {
                 elem_exprs.iter().zip(left_vals.iter()).zip(cand_exprs.iter())
             {
                 let r_val = self.eval(r_expr, row)?;
-                let collation = self
-                    .get_expression_collation(l_expr)
-                    .or_else(|| self.get_expression_collation(r_expr));
+                // datatype3 §7.1 comparison collation (issue #6089): left column
+                // collation, including default BINARY, blocks the right operand.
+                let collation = self.comparison_collation(l_expr, r_expr);
                 let (l_val, r_val) = crate::evaluator::row_value::apply_collation_to_pair(
                     l_val.clone(),
                     r_val,

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs
@@ -280,6 +280,75 @@ pub fn get_subquery_column_affinity_at(
     get_expression_affinity_from_from_clause(expr, &stmt.from, database)
 }
 
+/// Resolve the collating-sequence contribution of a subquery's `idx`-th result
+/// column for a datatype3 §7.1 comparison.
+///
+/// Returns:
+/// - `Some(Some(coll))` — the column position is a §7.1 "column operand" with a
+///   declared collation `coll` (an explicit COLLATE, or a bare column /
+///   unary-`+` / CAST wrapping a column declared `COLLATE coll`);
+/// - `Some(None)` — a column operand with the default BINARY collation, which
+///   still *blocks* fallback to the other operand's collation;
+/// - `None` — not a column operand (literal, `||`, function, …), so it does not
+///   contribute a collation and the comparison falls through to the other side.
+///
+/// This distinction (column-with-BINARY vs not-a-column) is what makes
+/// `(SELECT +bb, 1) >= (aa, 1)` compare element 0 as BINARY: `+bb` is a BINARY
+/// column operand that blocks the tuple's NOCASE `aa` (rowvalue §23.110,
+/// issue #6089).
+pub fn get_subquery_column_collation_at(
+    stmt: &vibesql_ast::SelectStmt,
+    idx: usize,
+    database: &vibesql_storage::Database,
+) -> Option<Option<String>> {
+    let item = stmt.select_list.get(idx)?;
+    let expr = match item {
+        vibesql_ast::SelectItem::Expression { expr, .. } => expr,
+        _ => return None,
+    };
+    crate::evaluator::collation::operand_column_collation(expr, &|col_id| {
+        get_column_collation_from_from_clause(col_id, &stmt.from, database)
+    })
+}
+
+/// Resolve a column reference's declared collation within a FROM clause.
+fn get_column_collation_from_from_clause(
+    col_id: &vibesql_ast::ColumnIdentifier,
+    from: &Option<vibesql_ast::FromClause>,
+    database: &vibesql_storage::Database,
+) -> Option<String> {
+    let column_name = col_id.column_canonical();
+    if let Some(table) = col_id.table_canonical() {
+        let tbl = database.get_table(table)?;
+        let col_idx = tbl.schema.get_column_index(column_name)?;
+        return tbl.schema.columns[col_idx].collation.clone();
+    }
+    let from_clause = from.as_ref()?;
+    find_column_collation_in_from_clause(column_name, from_clause, database)
+}
+
+/// Search a FROM clause for a column and return its declared collation.
+fn find_column_collation_in_from_clause(
+    column_name: &str,
+    from: &vibesql_ast::FromClause,
+    database: &vibesql_storage::Database,
+) -> Option<String> {
+    match from {
+        vibesql_ast::FromClause::Table { name, .. } => {
+            let table = database.get_table(name)?;
+            let col_idx = table.schema.get_column_index(column_name)?;
+            table.schema.columns[col_idx].collation.clone()
+        }
+        vibesql_ast::FromClause::Join { left, right, .. } => {
+            find_column_collation_in_from_clause(column_name, left, database)
+                .or_else(|| find_column_collation_in_from_clause(column_name, right, database))
+        }
+        vibesql_ast::FromClause::Subquery { .. }
+        | vibesql_ast::FromClause::Values { .. }
+        | vibesql_ast::FromClause::TableFunction { .. } => None,
+    }
+}
+
 /// Get the type affinity of an expression given a FROM clause context
 ///
 /// This resolves column references by looking up the table schema.

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -62,6 +62,22 @@ impl ExpressionEvaluator<'_> {
             }
             // For COLLATE expressions, get affinity of the inner expression
             vibesql_ast::Expression::Collate { expr, .. } => self.get_expression_affinity(expr),
+            // A CAST to a *numeric* type carries that numeric affinity (SQLite's
+            // `sqlite3ExprAffinity` TK_CAST case, issue #6089). This matters so
+            // that e.g. a TEXT-affinity column compared to `CAST(0 AS REAL)`
+            // routes through the numeric-affinity coercion path rather than
+            // treating the CAST as an affinity-less literal (which would
+            // wrongly coerce the column value to text). TEXT / BLOB casts stay
+            // affinity-less (`None`) to avoid making a CAST-to-text look like a
+            // TEXT column in the IN-list path (in-17.3/17.4).
+            vibesql_ast::Expression::Cast { data_type, .. } => {
+                match data_type.sqlite_affinity() {
+                    affinity @ (vibesql_types::TypeAffinity::Numeric
+                    | vibesql_types::TypeAffinity::Integer
+                    | vibesql_types::TypeAffinity::Real) => Some(affinity),
+                    _ => None,
+                }
+            }
             // Literals, functions, and other expressions don't have column affinity
             _ => None,
         }
@@ -1550,12 +1566,16 @@ impl ExpressionEvaluator<'_> {
         for (left_expr, right_expr) in left_exprs.iter().zip(right_exprs.iter()) {
             let left_val = self.eval(left_expr, row)?;
             let right_val = self.eval(right_expr, row)?;
-            // Per-element collation, mirroring the scalar comparison path:
-            // explicit COLLATE or column-declared collation on either element
-            // (left side takes priority) applies to that element pair only.
-            let collation = self
-                .get_expression_collation(left_expr)
-                .or_else(|| self.get_expression_collation(right_expr));
+            // Per-element collation, mirroring the scalar comparison path via
+            // the datatype3 §7.1 comparison rules (issue #6089): an explicit
+            // COLLATE wins, else the *left* operand's column collation applies
+            // — including its default BINARY, which blocks fallback to the
+            // right operand — else the right operand's column collation. Using
+            // the plain single-expression resolver here (left `.or_else` right)
+            // was wrong: for `(+bb, 1) >= (aa, 1)` it wrongly picked `aa`'s
+            // NOCASE even though the left element `+bb` is a BINARY column
+            // (rowvalue §23.100/§23.110).
+            let collation = self.comparison_collation(left_expr, right_expr);
             let (left_val, right_val) = crate::evaluator::row_value::apply_collation_to_pair(
                 left_val,
                 right_val,
@@ -1596,7 +1616,7 @@ impl ExpressionEvaluator<'_> {
         }
 
         let (tuple_values, subquery_values) =
-            self.eval_row_value_tuple_and_subquery(tuple_exprs, subquery, row)?;
+            self.eval_row_value_tuple_and_subquery(tuple_exprs, subquery, row, tuple_on_left)?;
 
         // Always evaluate with the tuple on the left. When the subquery was the
         // original left-hand operand (`subquery OP tuple`), that is equivalent to
@@ -1631,7 +1651,7 @@ impl ExpressionEvaluator<'_> {
         }
 
         let (tuple_values, subquery_values) =
-            self.eval_row_value_tuple_and_subquery(tuple_exprs, subquery, row)?;
+            self.eval_row_value_tuple_and_subquery(tuple_exprs, subquery, row, true)?;
 
         Ok(crate::evaluator::row_value::row_values_is_distinct(
             &tuple_values,
@@ -1649,17 +1669,44 @@ impl ExpressionEvaluator<'_> {
         tuple_exprs: &[vibesql_ast::Expression],
         subquery: &vibesql_ast::SelectStmt,
         row: &vibesql_storage::Row,
+        tuple_on_left: bool,
     ) -> Result<(Vec<SqlValue>, Vec<SqlValue>), ExecutorError> {
         let arity = tuple_exprs.len();
         let subquery_values = self.eval_scalar_subquery_as_row(subquery, row, arity)?;
 
+        // Per-position collating contribution of the subquery's result columns
+        // for the datatype3 §7.1 comparison collation (rowvalue §23.110, issue
+        // #6089); see the combined-evaluator twin for the full rationale.
+        let sub_collations: Vec<Option<Option<String>>> = (0..arity)
+            .map(|i| {
+                self.database.and_then(|db| {
+                    crate::evaluator::combined::subqueries::schema_utils::get_subquery_column_collation_at(
+                        subquery, i, db,
+                    )
+                })
+            })
+            .collect();
+
         let mut tuple_values = Vec::with_capacity(arity);
         let mut other_values = Vec::with_capacity(arity);
-        for (tuple_expr, sub_val) in tuple_exprs.iter().zip(subquery_values) {
+        for (idx, (tuple_expr, sub_val)) in tuple_exprs.iter().zip(subquery_values).enumerate() {
             let tuple_val = self.eval(tuple_expr, row)?;
-            // Per-element collation from the tuple side (explicit COLLATE or
-            // column-declared collation), e.g. `(a COLLATE nocase, b) = (SELECT ...)`.
-            let collation = self.get_expression_collation(tuple_expr);
+            // datatype3 §7.1 comparison collation with correct left-operand
+            // precedence (`tuple_on_left` selects the left side).
+            let tuple_operand = crate::evaluator::collation::operand_column_collation(
+                tuple_expr,
+                &|col_id| self.column_collation_of(col_id),
+            );
+            let sub_operand = sub_collations[idx].clone();
+            let (left_operand, right_operand) = if tuple_on_left {
+                (tuple_operand, sub_operand)
+            } else {
+                (sub_operand, tuple_operand)
+            };
+            let collation = crate::evaluator::collation::comparison_collation_of_operands(
+                left_operand,
+                right_operand,
+            );
             let (tuple_val, sub_val) = crate::evaluator::row_value::apply_collation_to_pair(
                 tuple_val,
                 sub_val,
@@ -1807,9 +1854,10 @@ impl ExpressionEvaluator<'_> {
             _ => {
                 let left_val = self.eval(left_expr, row)?;
                 let right_val = self.eval(right_expr, row)?;
-                let collation = self
-                    .get_expression_collation(left_expr)
-                    .or_else(|| self.get_expression_collation(right_expr));
+                // datatype3 §7.1 comparison collation (left column collation,
+                // including default BINARY, blocks fallback to the right) —
+                // issue #6089.
+                let collation = self.comparison_collation(left_expr, right_expr);
                 let (left_val, right_val) = crate::evaluator::row_value::apply_collation_to_pair(
                     left_val,
                     right_val,

--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -875,9 +875,9 @@ impl ExpressionEvaluator<'_> {
                 elem_exprs.iter().zip(left_vals.iter()).zip(cand_exprs.iter())
             {
                 let r_val = self.eval(r_expr, row)?;
-                let collation = self
-                    .get_expression_collation(l_expr)
-                    .or_else(|| self.get_expression_collation(r_expr));
+                // datatype3 §7.1 comparison collation (issue #6089): left column
+                // collation, including default BINARY, blocks the right operand.
+                let collation = self.comparison_collation(l_expr, r_expr);
                 let (l_val, r_val) = crate::evaluator::row_value::apply_collation_to_pair(
                     l_val.clone(),
                     r_val,

--- a/crates/vibesql-executor/src/optimizer/expressions.rs
+++ b/crates/vibesql-executor/src/optimizer/expressions.rs
@@ -350,24 +350,55 @@ pub fn optimize_expression(
         Expression::Cast { expr: inner_expr, data_type } => {
             let expr_opt = optimize_expression(inner_expr, evaluator)?;
 
-            // If the operand is a literal, we can evaluate the cast at plan time
+            // A CAST to a *numeric* type is not collapsed to a bare literal even
+            // when its operand is constant. Such a CAST node carries NUMERIC /
+            // INTEGER / REAL affinity (SQLite's `sqlite3ExprAffinity` TK_CAST
+            // case), which the comparison machinery reads to decide coercion:
+            // `t0.c0 > CAST(0 AS REAL)` on a TEXT column compares by storage
+            // class (→ 1), whereas the plain literal `t0.c0 > 0.0` applies TEXT
+            // affinity to the literal (→ 0). Folding `CAST(0 AS REAL)` down to
+            // `Literal(Real(0.0))` erased that distinction, so a WHERE-clause
+            // comparison (which runs constant folding, unlike the SELECT list)
+            // returned the wrong result (rowvalue §24.100, issue #6089).
+            //
+            // Casts to TEXT / BLOB affinity are affinity-safe to fold: a folded
+            // text/blob literal already triggers the same coercion a CAST would
+            // (a numeric-affinity operand coerces the text either way; a text
+            // operand never coerces), so those keep the folding optimization.
+            let target_affinity = data_type.sqlite_affinity();
+            let is_numeric_affinity = matches!(
+                target_affinity,
+                vibesql_types::TypeAffinity::Numeric
+                    | vibesql_types::TypeAffinity::Integer
+                    | vibesql_types::TypeAffinity::Real
+            );
+
             if let Expression::Literal(val) = &expr_opt {
-                // Get sql_mode from the evaluator's database if available
-                let sql_mode = evaluator.database().map(|db| db.sql_mode()).unwrap_or_default();
-                match cast_value(val, data_type, &sql_mode) {
-                    Ok(result) => Ok(Expression::Literal(result)),
-                    Err(_) => {
-                        // If cast fails, keep the CAST expression to fail at runtime with proper
-                        // error
-                        Ok(Expression::Cast {
-                            expr: Box::new(expr_opt),
-                            data_type: data_type.clone(),
-                        })
+                // Folding is affinity-safe when either the target affinity is
+                // not numeric (text/blob casts coerce identically to a folded
+                // literal) or the constant is NULL (comparisons against NULL are
+                // NULL regardless of affinity). Numeric-affinity casts of a
+                // non-NULL constant must retain the CAST wrapper.
+                if !is_numeric_affinity || matches!(val, SqlValue::Null) {
+                    let sql_mode =
+                        evaluator.database().map(|db| db.sql_mode()).unwrap_or_default();
+                    match cast_value(val, data_type, &sql_mode) {
+                        Ok(result) => return Ok(Expression::Literal(result)),
+                        Err(_) => {
+                            // Keep the CAST to fail at runtime with the proper error.
+                            return Ok(Expression::Cast {
+                                expr: Box::new(expr_opt),
+                                data_type: data_type.clone(),
+                            });
+                        }
                     }
                 }
-            } else {
-                Ok(Expression::Cast { expr: Box::new(expr_opt), data_type: data_type.clone() })
             }
+
+            // Numeric-affinity cast (or non-constant operand): preserve the
+            // `Cast` wrapper so affinity is not lost. Re-running `cast_value`
+            // per row is negligible next to a correct affinity result.
+            Ok(Expression::Cast { expr: Box::new(expr_opt), data_type: data_type.clone() })
         }
 
         // String functions - cannot optimize generally
@@ -486,7 +517,10 @@ mod tests {
 
     #[test]
     fn test_cast_folding_varchar_to_integer() {
-        // CAST('123' AS INTEGER) should fold to 123
+        // CAST('123' AS INTEGER) is a numeric-affinity cast: it is NOT collapsed
+        // to a bare literal, because the CAST node's INTEGER affinity must be
+        // preserved for comparisons (issue #6089). Its constant operand is still
+        // optimized, so the result is `Cast { Literal('123'), INTEGER }`.
         let expr = Expression::Cast {
             expr: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("123")))),
             data_type: DataType::Integer,
@@ -500,15 +534,19 @@ mod tests {
         let optimized = optimize_expression(&expr, &evaluator).unwrap();
 
         match optimized {
-            Expression::Literal(SqlValue::Integer(n)) => assert_eq!(n, 123),
-            _ => panic!("Expected folded INTEGER literal, got {:?}", optimized),
+            Expression::Cast { expr: inner, data_type: DataType::Integer } => match &*inner {
+                Expression::Literal(SqlValue::Varchar(s)) => assert_eq!(s.as_str(), "123"),
+                other => panic!("Expected inner literal '123', got {other:?}"),
+            },
+            _ => panic!("Expected preserved INTEGER CAST, got {optimized:?}"),
         }
     }
 
     #[test]
     fn test_cast_folding_permissive_string_to_integer() {
-        // SQLite-compatible behavior: CAST('abc' AS INTEGER) returns 0
-        // Non-numeric strings convert to 0 (permissive conversion)
+        // A numeric-affinity cast of a non-NULL constant retains its CAST wrapper
+        // (issue #6089); the permissive 'abc' -> 0 conversion still happens at
+        // evaluation time, not at fold time.
         let expr = Expression::Cast {
             expr: Box::new(Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("abc")))),
             data_type: DataType::Integer,
@@ -521,12 +559,9 @@ mod tests {
 
         let optimized = optimize_expression(&expr, &evaluator).unwrap();
 
-        // SQLite: non-numeric string converts to 0, so CAST is folded to literal
         match optimized {
-            Expression::Literal(SqlValue::Integer(0)) => {} // Good, folded to 0
-            _ => {
-                panic!("Expected CAST('abc' AS INTEGER) to fold to Integer(0), got {:?}", optimized)
-            }
+            Expression::Cast { data_type: DataType::Integer, .. } => {} // preserved
+            _ => panic!("Expected preserved INTEGER CAST, got {optimized:?}"),
         }
     }
 

--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -1102,6 +1102,8 @@ impl SelectExecutor<'_> {
                     None,
                     Some(self.database),
                     cte_ctx,
+                    self.outer_row,
+                    self.outer_schema,
                 )?;
                 from_result.into_rows()
             };

--- a/crates/vibesql-executor/src/select/executor/set_operations.rs
+++ b/crates/vibesql-executor/src/select/executor/set_operations.rs
@@ -204,6 +204,8 @@ impl SelectExecutor<'_> {
                 None,
                 Some(self.database),
                 cte_ctx,
+                self.outer_row,
+                self.outer_schema,
             )?;
             from_result.into_rows()
         } else {

--- a/crates/vibesql-executor/src/select/executor/validation/collation_names.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/collation_names.rs
@@ -1,0 +1,217 @@
+//! COLLATE-name validation (issue #6089).
+//!
+//! SQLite raises `no such collation sequence: <name>` at prepare time when a
+//! query names a collating sequence that is not registered, and it does so even
+//! when the target table is empty. VibeSQL only implements the three built-in
+//! collations (`BINARY`, `NOCASE`, `RTRIM`); any other name is invalid.
+//!
+//! Prior to this validation an unknown COLLATE name was silently ignored — the
+//! collation transform fell through to a no-op — so `SELECT a COLLATE nose FROM t`
+//! returned a row instead of erroring (rowvalue4 §7.3/§7.4, rowvalue §23.100
+//! adjacent COLLATE cases).
+//!
+//! This walks the SELECT list and WHERE clause expressions and raises on the
+//! first unknown COLLATE name it finds. It intentionally recurses only through
+//! the *directly evaluated* expression subtree; nested subqueries carry their
+//! own COLLATE nodes but are validated when that subquery is itself prepared, so
+//! recursing into them here would either duplicate work or, worse, evaluate a
+//! COLLATE against a schema it does not belong to.
+
+use vibesql_ast::Expression;
+
+use crate::errors::ExecutorError;
+
+/// Return `true` if `name` is a collating sequence VibeSQL implements.
+///
+/// The three SQLite built-ins are the only registered collations; matching is
+/// case-insensitive (`COLLATE nocase` and `COLLATE NOCASE` are identical).
+pub fn is_known_collation(name: &str) -> bool {
+    name.eq_ignore_ascii_case("binary")
+        || name.eq_ignore_ascii_case("nocase")
+        || name.eq_ignore_ascii_case("rtrim")
+}
+
+/// Validate every COLLATE name reachable within `expr`'s directly-evaluated
+/// subtree, returning `no such collation sequence: <name>` on the first
+/// unknown one.
+pub fn validate_collation_names(expr: &Expression) -> Result<(), ExecutorError> {
+    match expr {
+        Expression::Collate { expr: inner, collation } => {
+            if !is_known_collation(collation) {
+                return Err(ExecutorError::SqliteCompatError(format!(
+                    "no such collation sequence: {collation}"
+                )));
+            }
+            validate_collation_names(inner)
+        }
+        Expression::BinaryOp { left, right, .. }
+        | Expression::IsDistinctFrom { left, right, .. } => {
+            validate_collation_names(left)?;
+            validate_collation_names(right)
+        }
+        Expression::UnaryOp { expr, .. }
+        | Expression::IsNull { expr, .. }
+        | Expression::IsTruthValue { expr, .. }
+        | Expression::Cast { expr, .. }
+        | Expression::Extract { expr, .. }
+        | Expression::QuantifiedComparison { expr, .. }
+        | Expression::Interval { value: expr, .. } => validate_collation_names(expr),
+        Expression::Function { args, .. } | Expression::AggregateFunction { args, .. } => {
+            for arg in args {
+                validate_collation_names(arg)?;
+            }
+            Ok(())
+        }
+        Expression::Case { operand, when_clauses, else_result } => {
+            if let Some(op) = operand {
+                validate_collation_names(op)?;
+            }
+            for case_when in when_clauses {
+                for cond in &case_when.conditions {
+                    validate_collation_names(cond)?;
+                }
+                validate_collation_names(&case_when.result)?;
+            }
+            if let Some(else_expr) = else_result {
+                validate_collation_names(else_expr)?;
+            }
+            Ok(())
+        }
+        Expression::Between { expr, low, high, .. } => {
+            validate_collation_names(expr)?;
+            validate_collation_names(low)?;
+            validate_collation_names(high)
+        }
+        Expression::InList { expr, values, .. } => {
+            validate_collation_names(expr)?;
+            for val in values {
+                validate_collation_names(val)?;
+            }
+            Ok(())
+        }
+        // For IN / EXISTS / scalar subqueries, only the directly-evaluated
+        // left-hand expression is validated here; the subquery body is
+        // validated when that subquery is prepared.
+        Expression::In { expr, .. } => validate_collation_names(expr),
+        Expression::Like { expr, pattern, .. } | Expression::Glob { expr, pattern, .. } => {
+            validate_collation_names(expr)?;
+            validate_collation_names(pattern)
+        }
+        Expression::Position { substring, string, .. } => {
+            validate_collation_names(substring)?;
+            validate_collation_names(string)
+        }
+        Expression::Trim { removal_char, string, .. } => {
+            if let Some(char_expr) = removal_char {
+                validate_collation_names(char_expr)?;
+            }
+            validate_collation_names(string)
+        }
+        Expression::WindowFunction { function, over } => {
+            match function {
+                vibesql_ast::WindowFunctionSpec::Aggregate { args, .. }
+                | vibesql_ast::WindowFunctionSpec::Ranking { args, .. }
+                | vibesql_ast::WindowFunctionSpec::Value { args, .. } => {
+                    for arg in args {
+                        validate_collation_names(arg)?;
+                    }
+                }
+            }
+            if let Some(partition) = &over.partition_by {
+                for expr in partition {
+                    validate_collation_names(expr)?;
+                }
+            }
+            if let Some(order) = &over.order_by {
+                for item in order {
+                    validate_collation_names(&item.expr)?;
+                }
+            }
+            Ok(())
+        }
+        Expression::MatchAgainst { search_modifier, .. } => {
+            validate_collation_names(search_modifier)
+        }
+        Expression::Conjunction(children)
+        | Expression::Disjunction(children)
+        | Expression::RowValueConstructor(children) => {
+            for child in children {
+                validate_collation_names(child)?;
+            }
+            Ok(())
+        }
+        Expression::Raise { error_message, .. } => {
+            if let Some(msg) = error_message {
+                validate_collation_names(msg)?;
+            }
+            Ok(())
+        }
+        // Terminals and subquery-bearing nodes (validated on their own prepare):
+        // no directly-evaluated COLLATE to check here.
+        Expression::ColumnRef(_)
+        | Expression::Literal(_)
+        | Expression::Wildcard
+        | Expression::Exists { .. }
+        | Expression::ScalarSubquery(_)
+        | Expression::CurrentDate
+        | Expression::CurrentTime { .. }
+        | Expression::CurrentTimestamp { .. }
+        | Expression::Default
+        | Expression::DuplicateKeyValue { .. }
+        | Expression::NextValue { .. }
+        | Expression::SessionVariable { .. }
+        | Expression::PseudoVariable { .. }
+        | Expression::Placeholder(_)
+        | Expression::NumberedPlaceholder(_)
+        | Expression::NamedPlaceholder(_) => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vibesql_ast::{ColumnIdentifier, Expression};
+
+    use super::*;
+
+    fn col(name: &str) -> Expression {
+        Expression::ColumnRef(ColumnIdentifier::unquoted(name))
+    }
+
+    fn collate(inner: Expression, name: &str) -> Expression {
+        Expression::Collate { expr: Box::new(inner), collation: name.to_string() }
+    }
+
+    #[test]
+    fn known_collations_pass() {
+        for name in ["binary", "BINARY", "nocase", "NOCASE", "rtrim", "RTRIM"] {
+            assert!(is_known_collation(name), "{name} should be known");
+            assert!(validate_collation_names(&collate(col("a"), name)).is_ok());
+        }
+    }
+
+    #[test]
+    fn unknown_collation_errors() {
+        let expr = collate(col("a"), "nose");
+        let err = validate_collation_names(&expr).unwrap_err();
+        assert_eq!(
+            err,
+            ExecutorError::SqliteCompatError("no such collation sequence: nose".to_string())
+        );
+    }
+
+    #[test]
+    fn unknown_collation_nested_in_row_value_errors() {
+        // (a COLLATE nose, b) — mirrors rowvalue4 §7.3.
+        let expr = Expression::RowValueConstructor(vec![collate(col("a"), "nose"), col("b")]);
+        let err = validate_collation_names(&expr).unwrap_err();
+        assert_eq!(
+            err,
+            ExecutorError::SqliteCompatError("no such collation sequence: nose".to_string())
+        );
+    }
+
+    #[test]
+    fn bare_column_without_collate_passes() {
+        assert!(validate_collation_names(&col("a")).is_ok());
+    }
+}

--- a/crates/vibesql-executor/src/select/executor/validation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/mod.rs
@@ -13,6 +13,7 @@
 #![allow(clippy::collapsible_if)]
 
 mod aggregates;
+mod collation_names;
 mod column_refs;
 mod in_subquery_columns;
 mod index_hints;
@@ -31,6 +32,7 @@ pub use aggregates::{
     validate_order_by_aliased_window_functions, validate_subquery_context_misuse,
     validate_window_query_order_by_aggregates, SubqueryContext,
 };
+pub use collation_names::validate_collation_names;
 pub use column_refs::{extract_column_refs, validate_column_ref};
 pub use in_subquery_columns::validate_in_subquery_column_counts;
 pub use index_hints::validate_index_hints;
@@ -94,6 +96,9 @@ pub fn validate_select_columns_with_context(
     for item in select_list {
         match item {
             SelectItem::Expression { expr, .. } => {
+                // Validate COLLATE names at prepare time (issue #6089): an
+                // unknown collating sequence must error even on an empty table.
+                validate_collation_names(expr)?;
                 extract_column_refs(expr, &mut column_refs);
             }
             SelectItem::Wildcard { .. } => {
@@ -125,6 +130,9 @@ pub fn validate_select_columns_with_context(
 
     // Extract column references from WHERE clause (tracked separately for alias resolution)
     if let Some(where_expr) = where_clause {
+        // Validate COLLATE names at prepare time (issue #6089): rowvalue4 §7.4
+        // `... WHERE (?, ? COLLATE nose) > (a, b)` must error at prepare time.
+        validate_collation_names(where_expr)?;
         extract_column_refs(where_expr, &mut where_column_refs);
 
         // Check for wrong argument count FIRST (takes priority over misuse)

--- a/crates/vibesql-executor/src/select/scan/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/mod.rs
@@ -217,6 +217,11 @@ where
             column_aliases.as_ref(),
             Some(database),
             Some(cte_results),
+            // Thread outer context so a correlated VALUES row-value LHS
+            // (`(VALUES(b3.a, b3.b)) IN (...)`) can resolve outer columns
+            // (rowvalue §18.2/§18.5, issue #6089).
+            outer_row,
+            outer_schema,
         ),
         vibesql_ast::FromClause::TableFunction { name, args, alias, column_aliases } => {
             table_function::execute_table_function(

--- a/crates/vibesql-executor/src/select/scan/values.rs
+++ b/crates/vibesql-executor/src/select/scan/values.rs
@@ -23,12 +23,19 @@ use crate::{
 ///   function calls, subqueries, etc.)
 /// * `cte_results` - Optional CTE context so subqueries inside VALUES rows can
 ///   reference names bound by an enclosing WITH clause (issue #5353)
+/// * `outer_row` / `outer_schema` - Optional outer-query context so a VALUES row
+///   used as a correlated row-value LHS (`(VALUES(b3.a, b3.b)) IN (...)`) can
+///   resolve outer column references. Without this the VALUES expressions are
+///   evaluated against an empty schema and `b3.a` raises "no such column"
+///   (rowvalue §18.2/§18.5, issue #6089).
 pub(crate) fn execute_values(
     rows: &[Vec<vibesql_ast::Expression>],
     alias: &str,
     column_aliases: Option<&Vec<String>>,
     database: Option<&vibesql_storage::Database>,
     cte_results: Option<&std::collections::HashMap<String, crate::select::cte::CteResult>>,
+    outer_row: Option<&vibesql_storage::Row>,
+    outer_schema: Option<&CombinedSchema>,
 ) -> Result<super::FromResult, ExecutorError> {
     // Handle empty VALUES - return empty result with appropriate schema
     if rows.is_empty() {
@@ -45,25 +52,51 @@ pub(crate) fn execute_values(
     // Determine expected column count from first row
     let expected_columns = rows[0].len();
 
-    // Create an empty schema and row for expression evaluation
-    // VALUES expressions should not reference columns, so this is safe
+    // Create an empty schema and row as the *primary* evaluation context. A
+    // bare VALUES row references no local columns; outer references (issue
+    // #6089) resolve through the evaluator's outer_schema/outer_row chain.
     let empty_schema = CombinedSchema::empty();
     let empty_row = vibesql_storage::Row::new(vec![]);
 
-    // Create evaluator - use database if available for function calls, subqueries, etc.
-    let mut evaluator = if let Some(db) = database {
-        CombinedExpressionEvaluator::with_database(&empty_schema, db)
-    } else {
-        CombinedExpressionEvaluator::new(&empty_schema)
-    };
+    // Non-empty CTE context so subqueries in VALUES rows can reference names
+    // bound by an enclosing WITH clause (issue #5353).
+    let cte_ctx = cte_results.filter(|ctes| !ctes.is_empty());
 
-    // Thread CTE context so subqueries in VALUES rows can reference names
-    // bound by an enclosing WITH clause (issue #5353)
-    if let Some(ctes) = cte_results {
-        if !ctes.is_empty() {
-            evaluator = evaluator.with_cte_context(ctes);
+    // Create evaluator - use database if available for function calls,
+    // subqueries, etc. When outer context is supplied (a correlated VALUES
+    // row-value LHS, issue #6089), build with it so `b3.a` resolves against
+    // the enclosing query row rather than raising "no such column".
+    let evaluator = match (database, outer_row, outer_schema) {
+        (Some(db), Some(orow), Some(oschema)) => match cte_ctx {
+            Some(ctes) => CombinedExpressionEvaluator::with_database_and_outer_context_and_cte(
+                &empty_schema,
+                db,
+                orow,
+                oschema,
+                ctes,
+            ),
+            None => CombinedExpressionEvaluator::with_database_and_outer_context(
+                &empty_schema,
+                db,
+                orow,
+                oschema,
+            ),
+        },
+        (Some(db), _, _) => {
+            let mut ev = CombinedExpressionEvaluator::with_database(&empty_schema, db);
+            if let Some(ctes) = cte_ctx {
+                ev = ev.with_cte_context(ctes);
+            }
+            ev
         }
-    }
+        (None, _, _) => {
+            let mut ev = CombinedExpressionEvaluator::new(&empty_schema);
+            if let Some(ctes) = cte_ctx {
+                ev = ev.with_cte_context(ctes);
+            }
+            ev
+        }
+    };
 
     // Evaluate all rows and collect results
     let mut result_rows = Vec::with_capacity(rows.len());


### PR DESCRIPTION
Closes #6089.

Resolves the shared-machinery defects traced from `rowvalue.test` / `rowvalue4.test` during #6048 (part of #5779). Each reproduces in the plain scalar path, not just row-values, and is differential-verified against sqlite3 3.51.0.

## Defects fixed

### 1. COLLATE-name validation (rowvalue4 §7.3/§7.4, rowvalue §23.100/§23.110)
An unknown collating sequence was silently ignored (`SELECT a COLLATE nose FROM t` returned a row). New `validate_collation_names` (validation/collation_names.rs) walks the directly-evaluated SELECT-list and WHERE subtree at prepare time and raises `no such collation sequence: <name>` — even on an empty table. Only the three registered built-ins (BINARY/NOCASE/RTRIM) pass.

### 2. datatype3 §7.1 comparison collation for row-value element pairs
Per-element collation now applies the left-operand-precedence rule (a left column's default BINARY blocks fallback to the right) instead of a plain left-`.or_else`-right. The tuple-vs-scalar-subquery path resolves the subquery column's collating contribution from its FROM schema (`get_subquery_column_collation_at`). `(+bb,1)>=(aa,1)` now compares element 0 as BINARY (→ `0|1`).

### 3. TEXT-affinity vs numeric-CAST comparison (rowvalue §24.100)
A CAST to a numeric type now carries its numeric affinity (SQLite's TK_CAST), and the optimizer no longer folds a numeric-affinity CAST of a constant down to a bare literal (which had erased that affinity in the WHERE constant-folding path). `t0.c0 > CAST(0 AS REAL)` on a TEXT column now → 1. TEXT/BLOB casts stay affinity-less, so `1 IN (CAST('1' AS text))` stays 0 (in-17.3/17.4).

### 4. VALUES-as-row-value-LHS outer-column resolution (rowvalue §18.2/§18.5)
Traced (not assumed) to `execute_values`, which built its evaluator against an empty schema and ignored outer context. Now threads `outer_row`/`outer_schema` so a correlated `(VALUES(b3.a, b3.b)) IN (...)` resolves outer columns instead of raising `no such column: b3.a`.

## Verification
- rowvalue §18.2/§18.5/§23.100/§23.110/§24.100 pass; rowvalue4 §7.3/§7.4 pass.
- Zero regressions across rowvalue/rowvalue2/rowvalue4/in/in2/cast/expr/where/select1 TCL suites (a mid-work regression in in-17.3/17.4 was caught and fixed by restricting CAST affinity to numeric target types).
- `cargo test -p vibesql-executor` — 3482 passed, 0 failed.
- clippy clean on all touched lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)