### PR TITLE
fix(executor): resolve correlated outer-table rowid through nested subquery scopes

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -195,10 +195,22 @@ impl CombinedExpressionEvaluator<'_> {
     fn resolve_outer_rowid(&self, table: Option<&str>) -> Option<SqlValue> {
         let table_name = table?;
 
-        // Try the immediate parent scope: outer_row + outer_schema.
-        if let (Some(outer_row), Some(outer_schema)) = (self.outer_row, self.outer_schema) {
-            if let Some(value) = rowid_from_scope(outer_schema, outer_row, table_name) {
-                return Some(value);
+        // Try the immediate parent scope and every enclosing scope reachable
+        // through the `outer_schema` chain. For a doubly-nested correlated
+        // subquery the outer table lives several levels up: `self.outer_schema`
+        // is a merged schema whose own `outer_schema` field links to the real
+        // outer table (built by `build_merged_outer_schema`), and the merged
+        // `outer_row` carries every scope's rowid (see `build_merged_outer_row`).
+        // Walking only the immediate level missed the grandparent, so e.g.
+        // `d1.rowid` referenced two levels below d1 fell through to NULL and the
+        // subquery returned no rows (issue #6107).
+        if let Some(outer_row) = self.outer_row {
+            let mut current_schema = self.outer_schema;
+            while let Some(schema) = current_schema {
+                if let Some(value) = rowid_from_scope(schema, outer_row, table_name) {
+                    return Some(value);
+                }
+                current_schema = schema.outer_schema.as_deref();
             }
         }
 

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/exists.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/exists.rs
@@ -45,7 +45,7 @@ impl CombinedExpressionEvaluator<'_> {
         };
 
         let merged_row = if merged_schema.is_some() {
-            Some(build_merged_outer_row(row, self.outer_row))
+            Some(build_merged_outer_row(row, self.schema, self.outer_row, self.outer_schema))
         } else {
             None
         };

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/in_subquery.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/in_subquery.rs
@@ -265,7 +265,12 @@ impl CombinedExpressionEvaluator<'_> {
                         };
 
                         let merged_row = if merged_schema.is_some() {
-                            Some(build_merged_outer_row(row, self.outer_row))
+                            Some(build_merged_outer_row(
+                                row,
+                                self.schema,
+                                self.outer_row,
+                                self.outer_schema,
+                            ))
                         } else {
                             None
                         };
@@ -360,7 +365,7 @@ impl CombinedExpressionEvaluator<'_> {
         };
 
         let merged_row = if merged_schema.is_some() {
-            Some(build_merged_outer_row(row, self.outer_row))
+            Some(build_merged_outer_row(row, self.schema, self.outer_row, self.outer_schema))
         } else {
             None
         };
@@ -464,7 +469,7 @@ impl CombinedExpressionEvaluator<'_> {
             None
         };
         let merged_row = if merged_schema.is_some() {
-            Some(build_merged_outer_row(row, self.outer_row))
+            Some(build_merged_outer_row(row, self.schema, self.outer_row, self.outer_schema))
         } else {
             None
         };

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/quantified.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/quantified.rs
@@ -51,7 +51,7 @@ impl CombinedExpressionEvaluator<'_> {
         };
 
         let merged_row = if merged_schema.is_some() {
-            Some(build_merged_outer_row(row, self.outer_row))
+            Some(build_merged_outer_row(row, self.schema, self.outer_row, self.outer_schema))
         } else {
             None
         };

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/scalar.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/scalar.rs
@@ -153,7 +153,8 @@ impl CombinedExpressionEvaluator<'_> {
                 // This can happen if correlation columns aren't in outer schema
                 // Fall through to execute without caching
                 let merged_schema = build_merged_outer_schema(self.schema, self.outer_schema);
-                let merged_row = build_merged_outer_row(row, self.outer_row);
+                let merged_row =
+                    build_merged_outer_row(row, self.schema, self.outer_row, self.outer_schema);
                 let select_executor = if let Some(outer_rows) = self.outer_rows {
                     // Pass outer_rows for outer-correlated aggregates (issue #4930)
                     if let Some(cte_ctx) = self.cte_context {
@@ -199,7 +200,8 @@ impl CombinedExpressionEvaluator<'_> {
             // where the middle SELECT has no FROM but needs to pass outer context to innermost.
             // FIX for issue #4618 (subquery-3.3.4)
             let merged_schema = build_merged_outer_schema(self.schema, self.outer_schema);
-            let merged_row = build_merged_outer_row(row, self.outer_row);
+            let merged_row =
+                build_merged_outer_row(row, self.schema, self.outer_row, self.outer_schema);
             let select_executor = if let Some(outer_rows) = self.outer_rows {
                 // Pass outer_rows for outer-correlated aggregates (issue #4930)
                 if let Some(cte_ctx) = self.cte_context {
@@ -263,7 +265,7 @@ impl CombinedExpressionEvaluator<'_> {
             };
 
             let merged_row = if has_outer_context {
-                Some(build_merged_outer_row(row, self.outer_row))
+                Some(build_merged_outer_row(row, self.schema, self.outer_row, self.outer_schema))
             } else {
                 None
             };

--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/schema_utils.rs
@@ -94,17 +94,58 @@ pub(super) fn build_merged_outer_schema<'a>(
 /// A merged row with values from both rows, or just the current row if no outer row exists
 pub(super) fn build_merged_outer_row<'a>(
     current_row: &'a vibesql_storage::Row,
+    current_schema: &crate::schema::CombinedSchema,
     outer_row: Option<&'a vibesql_storage::Row>,
+    outer_schema: Option<&crate::schema::CombinedSchema>,
 ) -> std::borrow::Cow<'a, vibesql_storage::Row> {
     if let Some(outer) = outer_row {
         // Merge: current row values + outer row values (current is the prefix)
         let mut merged_values = current_row.values.clone();
         merged_values.extend(outer.values.iter().cloned());
 
-        std::borrow::Cow::Owned(vibesql_storage::Row::new(merged_values))
+        // Preserve per-table rowids across the merge (issue #6107). A correlated
+        // reference to an *outer* table's `rowid` (e.g. `d1.rowid` from two
+        // levels below) resolves via `Row::get_row_id_for_table(Some("d1"))`,
+        // which reads the row's tracked rowids. `Row::new` alone drops those, so
+        // a doubly-nested correlated `d1.rowid` bound to NULL and the subquery
+        // returned no rows. Rebuild a table-keyed rowid map from both sides so
+        // every enclosing scope's rowid survives the merge. The outer row is
+        // itself a merged row by induction, so its whole chain is carried along.
+        let mut row_ids: std::collections::HashMap<String, u64> = std::collections::HashMap::new();
+        collect_row_ids(current_row, current_schema, &mut row_ids);
+        if let Some(outer_schema) = outer_schema {
+            collect_row_ids(outer, outer_schema, &mut row_ids);
+        }
+
+        if row_ids.is_empty() {
+            std::borrow::Cow::Owned(vibesql_storage::Row::new(merged_values))
+        } else {
+            std::borrow::Cow::Owned(vibesql_storage::Row::with_row_ids(merged_values, row_ids))
+        }
     } else {
         // No outer row to merge, just use current row
         std::borrow::Cow::Borrowed(current_row)
+    }
+}
+
+/// Collect each table's tracked rowid from `row` into `row_ids`, walking the
+/// full `outer_schema` chain of `schema` so a merged row carries the rowids of
+/// every scope it represents. Table names use the schema's canonical form to
+/// match `Row::get_row_id_for_table`'s case-insensitive (lowercased) lookup.
+fn collect_row_ids(
+    row: &vibesql_storage::Row,
+    schema: &crate::schema::CombinedSchema,
+    row_ids: &mut std::collections::HashMap<String, u64>,
+) {
+    let mut cur = Some(schema);
+    while let Some(s) = cur {
+        for table_id in s.table_schemas.keys() {
+            let name = table_id.canonical().to_string();
+            if let Some(id) = row.get_row_id_for_table(Some(&name)) {
+                row_ids.entry(name).or_insert(id);
+            }
+        }
+        cur = s.outer_schema.as_deref();
     }
 }
 

--- a/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
@@ -499,8 +499,18 @@ fn validate_expression_column_refs(
                     let qualifier_lower = qualifier.to_lowercase();
                     let table_exists =
                         schema.table_schemas.keys().any(|k| k.canonical() == qualifier_lower);
+                    // Walk the FULL outer_schema chain, not just its immediate
+                    // level. For a doubly-nested correlated subquery the innermost
+                    // scope's `outer_schema` is a merged schema whose own
+                    // `outer_schema` field links to the real outer table several
+                    // levels up, so a single-level check spuriously reported the
+                    // table missing and raised ColumnNotFound for e.g. `d1.rowid`
+                    // referenced two levels below d1. Mirrors the qualified-column
+                    // chain-walk in `validation/column_refs.rs`. Issue #6107.
                     let table_in_outer = outer_schema.is_some_and(|outer| {
-                        outer.table_schemas.keys().any(|k| k.canonical() == qualifier_lower)
+                        outer.contains_table_in_chain(&vibesql_catalog::TableIdentifier::from(
+                            qualifier,
+                        ))
                     });
                     if table_exists || table_in_outer {
                         return Ok(());

--- a/crates/vibesql-executor/src/select/executor/validation/column_refs.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/column_refs.rs
@@ -240,8 +240,18 @@ pub fn validate_column_ref(
 
             let table_exists =
                 schema.table_schemas.keys().any(|k| k.canonical() == qualifier_lower);
+            // Walk the FULL outer_schema chain, not just its immediate level. For
+            // a doubly-nested correlated subquery the innermost scope's
+            // `outer_schema` is a merged schema whose own `outer_schema` field
+            // links to the real outer table several levels up, so a single-level
+            // check spuriously reported the table missing and raised
+            // ColumnNotFound for e.g. `d1.rowid` referenced two levels below d1.
+            // This mirrors the qualified-column fix in #6047 (which routes
+            // through the chain-walking `get_column_index`). Issue #6107.
             let table_in_outer = outer_schema.is_some_and(|outer| {
-                outer.table_schemas.keys().any(|k| k.canonical() == qualifier_lower)
+                outer.contains_table_in_chain(&vibesql_catalog::TableIdentifier::from(
+                    qualifier.as_str(),
+                ))
             });
             if table_exists || table_in_outer {
                 return Ok(());

--- a/crates/vibesql-executor/tests/correlated_outer_rowid_nested_tests.rs
+++ b/crates/vibesql-executor/tests/correlated_outer_rowid_nested_tests.rs
@@ -1,0 +1,148 @@
+//! Regression tests for issue #6107.
+//!
+//! PR #6104 (issue #6087) resolved a *single-level* correlated reference to an
+//! outer table's `rowid`. A **doubly**- (and more deeply) nested correlated
+//! reference still failed: for `d1.rowid` referenced from inside an innermost
+//! subquery two levels below `d1`, the enclosing `d1` scope was not reached and
+//! the reference bound to NULL, so the whole query returned no rows.
+//!
+//! Two gaps were closed:
+//!   1. `resolve_outer_rowid` now walks the full `outer_schema` chain (not just
+//!      the immediate parent), reaching an ancestor scope several levels up.
+//!   2. `build_merged_outer_row` now preserves each enclosing scope's tracked
+//!      rowid in a table-keyed `row_ids` map (it previously dropped them via
+//!      `Row::new`), so `d1.rowid` resolves against the correct outer row.
+//!   3. The prepare-time validators (`validation/column_refs.rs` and
+//!      `nonagg/validation.rs`) walk the `outer_schema` chain so a qualified
+//!      `d1.rowid` several levels below `d1` is not rejected as unknown.
+//!
+//! Expected values verified against sqlite3 3.51.0.
+
+use vibesql_catalog::{ColumnSchema, TableSchema};
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::{Database, Row};
+use vibesql_types::{DataType, SqlValue};
+
+fn parse_select(sql: &str) -> vibesql_ast::SelectStmt {
+    match Parser::parse_sql(sql) {
+        Ok(vibesql_ast::Statement::Select(select_stmt)) => *select_stmt,
+        _ => panic!("Failed to parse SELECT statement: {}", sql),
+    }
+}
+
+fn run(db: &Database, sql: &str) -> Vec<Row> {
+    let select = parse_select(sql);
+    SelectExecutor::new(db).execute(&select).unwrap()
+}
+
+/// Collect the integer values of result column 0 (rowids).
+fn rowids(rows: &[Row]) -> Vec<i64> {
+    rows.iter()
+        .map(|r| match r.get(0) {
+            Some(SqlValue::Integer(n)) | Some(SqlValue::Bigint(n)) => *n,
+            other => panic!("expected integer at index 0, got {other:?}"),
+        })
+        .collect()
+}
+
+fn int_table(db: &mut Database, name: &str, cols: [&str; 2], rows: [[i64; 2]; 2]) {
+    let schema = TableSchema::new(
+        name.to_string(),
+        vec![
+            ColumnSchema::new(cols[0].to_string(), DataType::Integer, true),
+            ColumnSchema::new(cols[1].to_string(), DataType::Integer, true),
+        ],
+    );
+    db.create_table(schema).unwrap();
+    for r in rows {
+        db.insert_row(name, Row::new(vec![SqlValue::Integer(r[0]), SqlValue::Integer(r[1])]))
+            .unwrap();
+    }
+}
+
+/// Four tables, each with rowids 1,2, mirroring the issue's reproduction:
+///   d1(a,c): (1,10),(2,20)     d2(x,y): (10,1),(20,2)
+///   d3(p,q): (1,1),(2,2)       d4(m,n): (1,1),(2,2)
+fn setup_db() -> Database {
+    let mut db = Database::new();
+    int_table(&mut db, "d1", ["a", "c"], [[1, 10], [2, 20]]);
+    int_table(&mut db, "d2", ["x", "y"], [[10, 1], [20, 2]]);
+    int_table(&mut db, "d3", ["p", "q"], [[1, 1], [2, 2]]);
+    int_table(&mut db, "d4", ["m", "n"], [[1, 1], [2, 2]]);
+    db
+}
+
+/// The judge's reproducer: two-level nesting where the innermost subquery
+/// references `d1.rowid` two scopes up, and the intermediate scope (d2) does NOT
+/// itself reference d1. Before the fix this returned 0 rows.
+#[test]
+fn doubly_nested_correlated_outer_rowid() {
+    let db = setup_db();
+    let sql = "SELECT d1.rowid FROM d1 \
+               WHERE a = (SELECT y FROM d2 \
+                          WHERE d2.rowid = (SELECT q FROM d3 WHERE d3.rowid = d1.rowid))";
+    assert_eq!(rowids(&run(&db, sql)), vec![1, 2]);
+}
+
+/// Two-level nesting where the intermediate scope (d2) ALSO references the outer
+/// `d1.rowid` — both the immediate and the two-levels-up correlated references
+/// must resolve against the same outer row.
+#[test]
+fn doubly_nested_intermediate_also_references_outer() {
+    let db = setup_db();
+    let sql = "SELECT d1.rowid FROM d1 \
+               WHERE a = (SELECT y FROM d2 \
+                          WHERE d2.rowid = d1.rowid \
+                            AND d2.rowid = (SELECT q FROM d3 WHERE d3.rowid = d1.rowid))";
+    assert_eq!(rowids(&run(&db, sql)), vec![1, 2]);
+}
+
+/// Three-level nesting: the innermost (d4) subquery references `d1.rowid` three
+/// scopes up, threaded through two intermediate subqueries.
+#[test]
+fn triply_nested_correlated_outer_rowid() {
+    let db = setup_db();
+    let sql = "SELECT d1.rowid FROM d1 \
+               WHERE a = (SELECT y FROM d2 \
+                          WHERE d2.rowid = (SELECT q FROM d3 \
+                                            WHERE d3.rowid = (SELECT n FROM d4 \
+                                                              WHERE d4.rowid = d1.rowid)))";
+    assert_eq!(rowids(&run(&db, sql)), vec![1, 2]);
+}
+
+/// Three-level nesting where the innermost references `d1.rowid` but the
+/// intermediate d3 scope does not use its own correlation on d1 — exercises the
+/// chain walk skipping a non-correlating level.
+#[test]
+fn triply_nested_innermost_references_outermost() {
+    let db = setup_db();
+    let sql = "SELECT d1.rowid FROM d1 \
+               WHERE a = (SELECT y FROM d2 \
+                          WHERE d2.rowid = (SELECT q FROM d3 \
+                                            WHERE q = (SELECT m FROM d4 \
+                                                       WHERE d4.rowid = d1.rowid)))";
+    assert_eq!(rowids(&run(&db, sql)), vec![1, 2]);
+}
+
+/// The innermost subquery references BOTH an intermediate outer rowid
+/// (`d2.rowid`) and the outermost one (`d1.rowid`), confirming that every
+/// enclosing scope's rowid survives the merged-row layout.
+#[test]
+fn nested_references_intermediate_and_outermost_rowid() {
+    let db = setup_db();
+    let sql = "SELECT d1.rowid FROM d1 \
+               WHERE a = (SELECT y FROM d2 \
+                          WHERE d2.rowid = (SELECT q FROM d3 \
+                                            WHERE d3.rowid = d2.rowid AND d3.rowid = d1.rowid))";
+    assert_eq!(rowids(&run(&db, sql)), vec![1, 2]);
+}
+
+/// The single-level case (#6104) must remain correct — guards against the chain
+/// walk breaking the immediate-parent resolution.
+#[test]
+fn single_level_still_resolves() {
+    let db = setup_db();
+    let sql = "SELECT d1.rowid FROM d1 WHERE a = (SELECT y FROM d2 WHERE d2.rowid = d1.rowid)";
+    assert_eq!(rowids(&run(&db, sql)), vec![1, 2]);
+}


### PR DESCRIPTION
## Summary

A doubly- (or more deeply) nested correlated reference to an outer table's `rowid` resolved to NULL, so the query returned no rows where SQLite returns the full set. PR #6104 (issue #6087) fixed only the single-level case; the outer scope for a reference two levels down was never reached.

Repro (matches sqlite3 3.51.0, which returns `1, 2`; VibeSQL previously returned 0 rows):

```sql
SELECT d1.rowid FROM d1
WHERE a = (SELECT y FROM d2
           WHERE d2.rowid = (SELECT q FROM d3 WHERE d3.rowid = d1.rowid));
```

## Changes

- `evaluator/combined/eval.rs` — `resolve_outer_rowid` walks the full `outer_schema` chain instead of only checking the immediate `outer_row`/`outer_schema`, reaching an ancestor scope several levels up.
- `evaluator/combined/subqueries/schema_utils.rs` — `build_merged_outer_row` preserves each enclosing scope's tracked rowid in a table-keyed `row_ids` map (it previously dropped them via `Row::new`), so an outer rowid resolves against the correct outer row after the merge. New `collect_row_ids` helper gathers rowids across both sides' `outer_schema` chains, keyed by the schema's canonical (lowercase) table name to match `Row::get_row_id_for_table`.
- `subqueries/{exists,in_subquery,quantified,scalar}.rs` — updated the 5 `build_merged_outer_row` call sites for the new `(current_schema, outer_schema)` parameters.
- `select/executor/validation/column_refs.rs`, `select/executor/nonagg/validation.rs` — prepare-time validators walk the `outer_schema` chain via `contains_table_in_chain` so a qualified outer rowid several levels down is not rejected as an unknown column.
- New `tests/correlated_outer_rowid_nested_tests.rs` — 6 regression tests.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Judge's doubly-nested repro returns 1,2 (was 0 rows) | ✅ | `doubly_nested_correlated_outer_rowid` passes; differential check against sqlite3 3.51.0 returns `1, 2` |
| 2-level nesting, intermediate scope both using and not using the outer table | ✅ | `doubly_nested_correlated_outer_rowid` (intermediate does not correlate) + `doubly_nested_intermediate_also_references_outer` |
| 3-level nesting | ✅ | `triply_nested_correlated_outer_rowid`, `triply_nested_innermost_references_outermost`; differential check vs sqlite3 returns `1, 2` |
| #6104's 4 tests hold | ✅ | `correlated_outer_rowid_tests` — 4 passed |
| rowvalue9 baseline holds | ✅ | `rowvalue9.test` — 92/92 passed, 0 failed (1 EQP skip, pre-existing) |

## Test Plan

- `cargo test -p vibesql-executor` — all suites pass, 0 failures (including new `correlated_outer_rowid_nested_tests`: 6/6 and `correlated_outer_rowid_tests`: 4/4).
- `./scripts/tcltest test rowvalue9.test` — 92 passed, 0 failed.
- Differential validation of 2- and 3-level nesting against sqlite3 3.51.0 (both return `1, 2`).
- `cargo fmt` clean; `cargo clippy -p vibesql-executor` produces no new warnings in touched files (`build_merged_outer_row`/`collect_row_ids` and validators are warning-free).

Closes #6107