### PR TITLE
fix(executor): validate COLLATE names and subquery arity in ORDER BY/GROUP BY/HAVING/JOIN ON

### DIFF
--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -169,6 +169,54 @@ impl SelectExecutor<'_> {
         }
         if let Some(having_expr) = &stmt.having {
             super::validation::validate_row_value_usage(having_expr)?;
+            // Scalar-subquery arity / row-value misuse in a HAVING clause
+            // behaves identically to the SELECT WHERE case: `a < (SELECT b,2)`
+            // is `row value misused` at prepare time even over an empty table
+            // (sqlite3 3.51). Mirror the WHERE walk (#6101). Only the top-level
+            // statement is inspected; nested subqueries reach their own check.
+            if self.outer_schema.is_none() && self.subquery_depth == 0 {
+                super::validation::validate_select_where_subquery_arity(
+                    having_expr,
+                    self.database,
+                )?;
+            }
+        }
+        // JOIN ... ON conditions share the SELECT-predicate arity rule: a scalar
+        // compared against a multi-column subquery is `row value misused` at
+        // prepare time even over an empty table (sqlite3 3.51, #6101). Walk every
+        // ON condition in the (possibly nested) FROM tree.
+        if self.outer_schema.is_none() && self.subquery_depth == 0 {
+            if let Some(from) = &stmt.from {
+                Self::for_each_join_condition(from, &mut |cond| {
+                    super::validation::validate_select_where_subquery_arity(cond, self.database)
+                })?;
+            }
+        }
+
+        // Validate COLLATE names in the remaining clauses (#6110): ORDER BY,
+        // GROUP BY, HAVING, and JOIN ... ON. The SELECT-list and WHERE clause
+        // are already validated in `validate_select_columns_with_context`, but
+        // an unknown collating sequence named in any other clause must likewise
+        // error at prepare time (`no such collation sequence: <name>`), even
+        // over an empty table. Each nested subquery validates its own clauses
+        // through its own `execute`, so this walks only this statement's clauses.
+        if let Some(order_by) = stmt.order_by.as_deref() {
+            for item in order_by {
+                super::validation::validate_collation_names(&item.expr)?;
+            }
+        }
+        if let Some(group_by) = &stmt.group_by {
+            for expr in group_by.all_expressions() {
+                super::validation::validate_collation_names(expr)?;
+            }
+        }
+        if let Some(having_expr) = &stmt.having {
+            super::validation::validate_collation_names(having_expr)?;
+        }
+        if let Some(from) = &stmt.from {
+            Self::for_each_join_condition(from, &mut |cond| {
+                super::validation::validate_collation_names(cond)
+            })?;
         }
         if let Some(order_by) = stmt.order_by.as_deref() {
             for item in order_by {
@@ -354,6 +402,26 @@ impl SelectExecutor<'_> {
         }
 
         Ok(result)
+    }
+
+    /// Invoke `f` on every `JOIN ... ON` condition reachable within a
+    /// (possibly nested) FROM clause. Used to run prepare-time predicate
+    /// validation over ON conditions the same way it runs over WHERE / HAVING.
+    fn for_each_join_condition<F>(
+        from: &vibesql_ast::FromClause,
+        f: &mut F,
+    ) -> Result<(), ExecutorError>
+    where
+        F: FnMut(&vibesql_ast::Expression) -> Result<(), ExecutorError>,
+    {
+        if let vibesql_ast::FromClause::Join { left, right, condition, .. } = from {
+            Self::for_each_join_condition(left, f)?;
+            Self::for_each_join_condition(right, f)?;
+            if let Some(cond) = condition {
+                f(cond)?;
+            }
+        }
+        Ok(())
     }
 
     /// Execute a SELECT statement and return an iterator over results

--- a/crates/vibesql-executor/src/select/executor/validation/collation_names.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/collation_names.rs
@@ -10,12 +10,21 @@
 //! returned a row instead of erroring (rowvalue4 §7.3/§7.4, rowvalue §23.100
 //! adjacent COLLATE cases).
 //!
-//! This walks the SELECT list and WHERE clause expressions and raises on the
-//! first unknown COLLATE name it finds. It intentionally recurses only through
-//! the *directly evaluated* expression subtree; nested subqueries carry their
-//! own COLLATE nodes but are validated when that subquery is itself prepared, so
-//! recursing into them here would either duplicate work or, worse, evaluate a
-//! COLLATE against a schema it does not belong to.
+//! This walks an expression subtree and raises on the first unknown COLLATE
+//! name it finds. It is invoked for every clause of a top-level `SELECT` that
+//! can carry a COLLATE node: the SELECT list and WHERE clause (from
+//! `validate_select_columns_with_context`), and — added in #6110 — the
+//! ORDER BY, GROUP BY, HAVING, and JOIN ... ON clauses (from
+//! `SelectExecutor::execute`). Before #6110 the latter four were silently
+//! accepted, so `SELECT a FROM t ORDER BY a COLLATE nose` returned rows instead
+//! of erroring; SQLite reports `no such collation sequence: nose` at prepare
+//! time in every one of these positions.
+//!
+//! It intentionally recurses only through the *directly evaluated* expression
+//! subtree; nested subqueries carry their own COLLATE nodes but are validated
+//! when that subquery is itself prepared, so recursing into them here would
+//! either duplicate work or, worse, evaluate a COLLATE against a schema it does
+//! not belong to.
 
 use vibesql_ast::Expression;
 

--- a/crates/vibesql-executor/src/select/executor/validation/scalar_subquery_arity.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/scalar_subquery_arity.rs
@@ -22,15 +22,50 @@
 //! and is left untouched (the evaluator and the `row_values` validator cover
 //! those shapes). Nested sub-expressions are left to the runtime check.
 //!
-//! ## Context-sensitive messages (matching SQLite 3.51)
+//! ## Shape-based messages (matching SQLite 3.51)
+//!
+//! SQLite chooses between the two error messages by the *shape* of the
+//! expression, not by the statement type. The distinction is comparison vs
+//! `IN`: a plain scalar on one side of a *comparison* against a multi-column
+//! subquery is `row value misused`, whereas a scalar on the left of an `IN`
+//! whose subquery projects more than one column is the arity error
+//! `sub-select returns N columns - expected 1`. A bare multi-column subquery
+//! standing alone in a value position is likewise the arity error.
+//!
+//! Crucially, the *comparison* shape reports `row value misused` in **both**
+//! SELECT WHERE and UPDATE/DELETE WHERE — there is no SELECT-vs-DML split.
+//! Verified against sqlite3 3.51.0:
+//!
+//! ```text
+//! SELECT * FROM t WHERE a < (SELECT b, 2 FROM t);   -- row value misused
+//! UPDATE t SET a=1  WHERE a < (SELECT b, 2 FROM t);  -- row value misused
+//! DELETE FROM t     WHERE a < (SELECT b, 2 FROM t);  -- row value misused
+//! UPDATE t SET a=1  WHERE a IN (SELECT b, 2 FROM t); -- sub-select returns 2 columns
+//! ```
+//!
+//! The table below records what each validator *currently emits*. The
+//! predicate (WHERE/HAVING/ON) and `IN` rows are byte-parity with sqlite3 3.51;
+//! two value-position and one DML-predicate row are marked `[divergent]` — they
+//! reflect VibeSQL's present behavior, which does not yet match SQLite's
+//! `row value misused` for that sub-shape. Those divergences are pre-existing
+//! and out of scope here (the SELECT WHERE / HAVING / ON walk added below is
+//! sqlite-faithful).
 //!
 //! | Context                    | shape                       | message           |
 //! |----------------------------|-----------------------------|-------------------|
 //! | value (SELECT item, SET)   | bare `(SELECT a,b)`         | arity error       |
 //! |                            | `(SELECT a,b) <op> scalar`  | row value misused |
-//! |                            | `scalar <op> (SELECT a,b)`  | arity error       |
-//! | predicate (WHERE)          | `col <op> (SELECT a,b)`     | arity error       |
-//! |                            | `(SELECT a,b) <op> col`     | arity error       |
+//! |                            | `scalar <op> (SELECT a,b)`  | arity error `[divergent: sqlite says row value misused]` |
+//! | comparison (WHERE/HAVING/ON) | `scalar <op> (SELECT a,b)` | row value misused |
+//! |                            | `(SELECT a,b) <op> scalar`  | row value misused |
+//! | `IN` (any WHERE)           | `scalar IN (SELECT a,b)`    | arity error       |
+//!
+//! Note: [`validate_predicate_expr`] (the UPDATE/DELETE WHERE walker) still
+//! raises the *arity* error for the comparison shape rather than
+//! `row value misused` `[divergent]`; aligning that DML path (and the value
+//! sub-shape above) with SQLite's `row value misused` is a separate,
+//! pre-existing question tracked outside this module (it does not affect the
+//! SELECT WHERE / HAVING / ON walk below).
 
 use vibesql_ast::{BinaryOperator, Expression};
 
@@ -193,20 +228,28 @@ fn in_lhs_arity(expr: &Expression, database: &vibesql_storage::Database) -> Opti
     }
 }
 
-/// Validate a `WHERE` predicate of a top-level `SELECT`.
+/// Validate a boolean predicate of a top-level `SELECT` — a `WHERE`, `HAVING`,
+/// or `JOIN ... ON` condition.
 ///
-/// SQLite's SELECT-WHERE handling differs from the UPDATE/DELETE WHERE rule
-/// covered by [`validate_predicate_expr`]: a scalar compared against a
-/// multi-column subquery in a SELECT WHERE is reported as `row value misused`,
-/// whereas the same shape in an UPDATE/DELETE WHERE is the arity error
-/// `sub-select returns N columns - expected 1`. (Verified against sqlite3 3.51:
-/// `SELECT * FROM t WHERE a < (SELECT b, 2)` → `row value misused`, while the
-/// UPDATE/DELETE forms give the arity error — see `rowvalue4.test` 8.2 and
-/// `rowvalue.test` 15.3/15.4.)
+/// For the *comparison* shape (`scalar <op> (SELECT a,b)`), SQLite reports
+/// `row value misused`. This is **not** a SELECT-vs-DML distinction: the same
+/// comparison shape reports `row value misused` in an UPDATE/DELETE WHERE too
+/// (verified against sqlite3 3.51 — see the module header). The arity error
+/// `sub-select returns N columns - expected 1` comes from the `IN` shape
+/// (`scalar IN (SELECT a,b)`), which this walk detects while descending.
+///
+/// All three SELECT predicate positions behave identically (verified against
+/// sqlite3 3.51.0, all over an empty table):
+///
+/// ```text
+/// SELECT a FROM t WHERE  a < (SELECT b, 2 FROM t);                 -- row value misused
+/// SELECT a FROM t GROUP BY a HAVING a < (SELECT b, 2 FROM t);       -- row value misused
+/// SELECT t.a FROM t JOIN u ON t.a < (SELECT b, 2 FROM t);           -- row value misused
+/// ```
 ///
 /// The check is a prepare-time walk so the misuse surfaces even when the target
-/// table is empty and the WHERE predicate is never evaluated. In addition to
-/// the top-level scalar-vs-subquery shape, the walk descends into nested
+/// table is empty and the predicate is never evaluated. In addition to the
+/// top-level scalar-vs-subquery shape, the walk descends into nested
 /// scalar-subquery bodies so a deep arity misuse such as
 /// `(a,b) > (SELECT 2 IN (SELECT 2,2), 2)` (`rowvalue9.test` 8.2, where the
 /// inner `2 IN (SELECT 2,2)` compares a scalar against a 2-column subquery) is

--- a/crates/vibesql-executor/tests/validation_clause_coverage_tests.rs
+++ b/crates/vibesql-executor/tests/validation_clause_coverage_tests.rs
@@ -1,0 +1,144 @@
+//! Prepare-time validation clause coverage (issues #6101 and #6110).
+//!
+//! Two validators that previously covered only the SELECT-list and WHERE
+//! clauses are extended to the remaining SELECT clauses:
+//!
+//! * #6110 — COLLATE-name validation (`no such collation sequence: <name>`)
+//!   now also walks ORDER BY, GROUP BY, HAVING, and JOIN ... ON. Before the
+//!   fix an unknown collation named there was silently accepted (a false
+//!   negative); the three built-ins (BINARY/NOCASE/RTRIM, any case-spelling)
+//!   must keep passing in every clause (no false positives).
+//! * #6101 — the SELECT-predicate scalar-subquery arity / row-value-misuse
+//!   walk now also runs over HAVING and JOIN ... ON, matching SQLite's
+//!   prepare-time rejection over an empty table.
+//!
+//! All expected results verified against sqlite3 3.51.0.
+
+use vibesql_executor::SelectExecutor;
+
+fn run_ddl(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            vibesql_executor::InsertExecutor::execute(db, &insert).unwrap();
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+/// Execute a SELECT, returning Ok(row_count) or Err(error message string).
+fn try_select(db: &vibesql_storage::Database, sql: &str) -> Result<usize, String> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor.execute(&select_stmt).map(|rows| rows.len()).map_err(|e| format!("{e}"))
+    } else {
+        panic!("Expected SELECT statement: {sql}");
+    }
+}
+
+fn two_col_db() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    run_ddl(&mut db, "CREATE TABLE t(a TEXT, b TEXT)");
+    run_ddl(&mut db, "CREATE TABLE u(c TEXT, d TEXT)");
+    db
+}
+
+// ---------------------------------------------------------------------------
+// #6110 — COLLATE-name validation across ORDER BY / GROUP BY / HAVING / JOIN ON
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unknown_collation_in_order_by_errors() {
+    let db = two_col_db();
+    let err = try_select(&db, "SELECT a FROM t ORDER BY a COLLATE nose").unwrap_err();
+    assert!(err.contains("no such collation sequence: nose"), "got: {err}");
+}
+
+#[test]
+fn unknown_collation_in_group_by_errors() {
+    let db = two_col_db();
+    let err = try_select(&db, "SELECT a FROM t GROUP BY a COLLATE nose").unwrap_err();
+    assert!(err.contains("no such collation sequence: nose"), "got: {err}");
+}
+
+#[test]
+fn unknown_collation_in_having_errors() {
+    let db = two_col_db();
+    let err =
+        try_select(&db, "SELECT a FROM t GROUP BY a HAVING a COLLATE nose > 'x'").unwrap_err();
+    assert!(err.contains("no such collation sequence: nose"), "got: {err}");
+}
+
+#[test]
+fn unknown_collation_in_join_on_errors() {
+    let db = two_col_db();
+    let err = try_select(&db, "SELECT a FROM t JOIN u ON a COLLATE nose = c").unwrap_err();
+    assert!(err.contains("no such collation sequence: nose"), "got: {err}");
+}
+
+#[test]
+fn builtin_collations_pass_in_every_clause_and_spelling() {
+    // Every built-in in every case-spelling in every newly-covered clause must
+    // be accepted (no false positives). Empty tables → 0 rows, never an error.
+    let db = two_col_db();
+    for name in ["binary", "BINARY", "nocase", "NOCASE", "rtrim", "RTRIM"] {
+        for sql in [
+            format!("SELECT a FROM t ORDER BY a COLLATE {name}"),
+            format!("SELECT a FROM t GROUP BY a COLLATE {name}"),
+            format!("SELECT a FROM t GROUP BY a HAVING a COLLATE {name} > 'x'"),
+            format!("SELECT a FROM t JOIN u ON a COLLATE {name} = c"),
+        ] {
+            let res = try_select(&db, &sql);
+            assert!(res.is_ok(), "built-in {name} must pass: {sql} -- got {res:?}");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #6101 — scalar-subquery arity / row-value misuse across HAVING and JOIN ON
+// ---------------------------------------------------------------------------
+
+#[test]
+fn comparison_multicol_subquery_in_having_is_row_value_misused() {
+    let db = two_col_db();
+    let err =
+        try_select(&db, "SELECT a FROM t GROUP BY a HAVING a < (SELECT b, 2 FROM t)").unwrap_err();
+    assert!(err.to_lowercase().contains("row value misused"), "got: {err}");
+}
+
+#[test]
+fn comparison_multicol_subquery_in_join_on_is_row_value_misused() {
+    let db = two_col_db();
+    let err = try_select(&db, "SELECT a FROM t JOIN u ON a < (SELECT b, 2 FROM t)").unwrap_err();
+    assert!(err.to_lowercase().contains("row value misused"), "got: {err}");
+}
+
+#[test]
+fn in_multicol_subquery_in_having_is_arity_error() {
+    let db = two_col_db();
+    let err =
+        try_select(&db, "SELECT a FROM t GROUP BY a HAVING a IN (SELECT b, 2 FROM t)").unwrap_err();
+    assert!(err.contains("sub-select returns 2 columns"), "got: {err}");
+}
+
+#[test]
+fn in_multicol_subquery_in_join_on_is_arity_error() {
+    let db = two_col_db();
+    let err = try_select(&db, "SELECT a FROM t JOIN u ON a IN (SELECT b, 2 FROM t)").unwrap_err();
+    assert!(err.contains("sub-select returns 2 columns"), "got: {err}");
+}
+
+#[test]
+fn valid_single_column_subquery_in_having_and_join_on_passes() {
+    // No false positives: a single-column subquery and plain predicates are
+    // legal in HAVING and JOIN ON.
+    let db = two_col_db();
+    assert!(try_select(&db, "SELECT a FROM t GROUP BY a HAVING a < (SELECT b FROM t)").is_ok());
+    assert!(try_select(&db, "SELECT a FROM t JOIN u ON a < (SELECT b FROM t)").is_ok());
+    assert!(try_select(&db, "SELECT a FROM t JOIN u ON a = c").is_ok());
+    assert!(try_select(&db, "SELECT a FROM t GROUP BY a HAVING count(*) > 1").is_ok());
+}


### PR DESCRIPTION
## Summary

Extends two prepare-time validation walks — COLLATE-name validation and the SELECT-predicate scalar-subquery arity walk — from SELECT-list/WHERE-only coverage to the remaining SELECT clauses, and corrects inaccurate doc comments in the arity validator. All new behavior differential-verified against sqlite3 3.51.0.

Implements two judge-filed follow-ups in one PR (same validation module):
- #6110: `validate_collation_names` missed ORDER BY / GROUP BY / HAVING / JOIN ON (false negatives only).
- #6101: doc comments claimed a SELECT-vs-DML error split that sqlite does not have (the real split is by expression shape: comparison → `row value misused`, IN → arity error), plus the HAVING/ON empty-table arity gap.

## Changes

- `crates/vibesql-executor/src/select/executor/execute.rs`
  - New `for_each_join_condition` helper: walks every `JOIN ... ON` condition in a (possibly nested) FROM tree.
  - COLLATE-name validation (#6110) now runs over ORDER BY items, all GROUP BY expressions (`GroupByClause::all_expressions`, so ROLLUP/CUBE/GROUPING SETS are covered), HAVING, and every JOIN ON condition.
  - The SELECT-predicate arity walk (`validate_select_where_subquery_arity`, #6101) now also runs over HAVING and JOIN ON (same top-level gating as the existing WHERE call: `outer_schema.is_none() && subquery_depth == 0`; nested subqueries validate via their own execute).
- `crates/vibesql-executor/src/select/executor/validation/scalar_subquery_arity.rs` (docs only)
  - Module header and `validate_select_where_expr` doc rewritten: the error-message distinction is by expression SHAPE (comparison vs IN), not statement type; both SELECT and DML WHERE report `row value misused` for the comparison shape (verified vs sqlite3 3.51.0).
  - Known pre-existing divergences (the DML `validate_predicate_expr` comparison shape and one value-position sub-shape still emit the arity error where sqlite says `row value misused`) are explicitly marked `[divergent]` and left out of scope per the judge's note on #6101.
- `crates/vibesql-executor/src/select/executor/validation/collation_names.rs` (docs only): module header documents the extended clause coverage.
- `crates/vibesql-executor/tests/validation_clause_coverage_tests.rs` (new): 10 integration tests covering both issues (error cases per clause + no-false-positive cases).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Doc comments accurate (shape-based split, no SELECT-vs-DML claim) | ✅ | Rewrote module header + fn doc; every claim re-verified against sqlite3 3.51.0 (`UPDATE/DELETE ... WHERE a < (SELECT b,2)` → `row value misused`; `... IN (SELECT b,2)` → arity error) |
| COLLATE validation covers ORDER BY / GROUP BY / HAVING / JOIN ON | ✅ | `COLLATE nose` errors `no such collation sequence: nose` in all four clauses (matches sqlite3 3.51) |
| Zero COLLATE false positives | ✅ | All three builtins × both case-spellings (binary/BINARY/nocase/NOCASE/rtrim/RTRIM) × all four clauses = 24 probes, all pass; UNION ORDER BY and nested FROM-subquery ORDER BY edge cases also match sqlite |
| HAVING/ON arity extension differential-verified | ✅ | Comparison shape → `row value misused`, IN shape → `sub-select returns 2 columns - expected 1` in both HAVING and JOIN ON, over empty tables — byte-parity with sqlite3 3.51.0; valid single-column subqueries/plain predicates unaffected |
| No TCL regressions | ✅ | rowvalue, rowvalue2–9, rowvalueA: all pass 0 failed; select1.test 188/188; where.test 168 pass 0 fail; expr.test 638 pass 0 fail; join.test 7 failures identical to main baseline (pre-existing: test-state + EQP pattern, unrelated) |
| cargo test -p vibesql-executor green | ✅ | 177 test binaries, 5670 tests passed, 0 failed (includes 10 new tests) |
| clippy / fmt | ✅ | No new clippy warnings on changed code; changed files rustfmt-clean (out-of-scope fmt drift in untouched files reverted) |

## Per-Clause Differential Results (vs sqlite3 3.51.0)

| Clause | `COLLATE nose` | builtins (6 spellings) | `a < (SELECT b,2)` | `a IN (SELECT b,2)` |
|--------|----------------|------------------------|---------------------|----------------------|
| WHERE (pre-existing) | error ✅ | pass ✅ | row value misused ✅ | arity error ✅ |
| ORDER BY | error ✅ (new) | pass ✅ | n/a | n/a |
| GROUP BY | error ✅ (new) | pass ✅ | n/a | n/a |
| HAVING | error ✅ (new) | pass ✅ | row value misused ✅ (new) | arity error ✅ (new) |
| JOIN ON | error ✅ (new) | pass ✅ | row value misused ✅ (new) | arity error ✅ (new) |

## Test Plan

- `cargo test -p vibesql-executor` — 5670 passed / 0 failed
- `cargo test -p vibesql-executor --test validation_clause_coverage_tests` — 10/10
- TCL: rowvalue set + select1 + where + expr (all 0 failed), join.test failures identical to main
- Manual differential probes of every clause/shape against sqlite3 3.51.0 via CLI

Closes #6101
Closes #6110

🤖 Generated with [Claude Code](https://claude.com/claude-code)