### PR TITLE
fix(executor): preserve outer column collation through UPDATE...FROM tuple SET substitution

### DIFF
--- a/crates/vibesql-ast/src/expression.rs
+++ b/crates/vibesql-ast/src/expression.rs
@@ -11,6 +11,32 @@ pub enum Expression {
     /// Literal value (42, 'hello', TRUE, NULL)
     Literal(SqlValue),
 
+    /// A literal value that carries an *implicit* collating sequence, as if it
+    /// were a column reference with that declared collation.
+    ///
+    /// This variant is produced internally (never by the parser) when an outer
+    /// column reference is substituted as a literal into an uncorrelated
+    /// subquery — e.g. the single-evaluation `UPDATE … SET (a,b) = (SELECT …)`
+    /// tuple path (issues #6086/#6099/#6105). A bare [`Expression::Literal`]
+    /// carries no collation, so substituting a `COLLATE NOCASE` column as a
+    /// plain literal would silently revert collation-sensitive comparisons to
+    /// BINARY.
+    ///
+    /// Crucially the collation is **implicit** (column-like), *not* an explicit
+    /// `COLLATE` operator: it participates in SQLite's datatype3 §7.1 rule 2
+    /// (left-operand precedence, default BINARY of a left column blocks
+    /// fallback to the right) rather than rule 1 (explicit COLLATE anywhere
+    /// wins). Wrapping the literal in [`Expression::Collate`] instead would
+    /// wrongly flip left-precedence comparisons such as
+    /// `inner_binary_col = outer_nocase_col`, which SQLite compares as BINARY.
+    ///
+    /// It evaluates exactly to `value`; only its collation contribution differs
+    /// from a bare literal.
+    CollatedLiteral {
+        value: SqlValue,
+        collation: String,
+    },
+
     /// Parameter placeholder (?) for prepared statements
     /// The index is 0-based and assigned in order of appearance in the SQL
     /// Example: WHERE id = ? AND name = ? -> Placeholder(0), Placeholder(1)

--- a/crates/vibesql-ast/src/pretty_print.rs
+++ b/crates/vibesql-ast/src/pretty_print.rs
@@ -279,6 +279,11 @@ impl ToSql for Expression {
     fn to_sql(&self) -> String {
         match self {
             Expression::Literal(value) => value.to_sql(),
+            // Internal-only node (see Expression::CollatedLiteral). Its collation
+            // is implicit, but for display we render it like an explicit COLLATE.
+            Expression::CollatedLiteral { value, collation } => {
+                format!("{} COLLATE {}", value.to_sql(), collation)
+            }
 
             Expression::Placeholder(_) => "?".to_string(),
 

--- a/crates/vibesql-ast/src/visitor.rs
+++ b/crates/vibesql-ast/src/visitor.rs
@@ -218,6 +218,9 @@ pub fn walk_expression<V: ExpressionVisitor>(visitor: &mut V, expr: &Expression)
     let result = match expr {
         Expression::Literal(value) => visitor.visit_literal(value),
 
+        // Internal-only node carrying an implicit collation; visit its value.
+        Expression::CollatedLiteral { value, .. } => visitor.visit_literal(value),
+
         Expression::Placeholder(index) => visitor.visit_placeholder(*index),
 
         Expression::NumberedPlaceholder(number) => visitor.visit_numbered_placeholder(*number),
@@ -576,6 +579,7 @@ pub fn transform_expression<V: ExpressionMutVisitor>(
     let transformed = match expr {
         // Leaf nodes - no children to transform
         Expression::Literal(_)
+        | Expression::CollatedLiteral { .. }
         | Expression::Placeholder(_)
         | Expression::NumberedPlaceholder(_)
         | Expression::NamedPlaceholder(_)

--- a/crates/vibesql-catalog/src/table.rs
+++ b/crates/vibesql-catalog/src/table.rs
@@ -857,6 +857,7 @@ impl TableSchema {
                 Self::expression_references_column(value, column_name)
             }
             vibesql_ast::Expression::Literal(_)
+            | vibesql_ast::Expression::CollatedLiteral { .. }
             | vibesql_ast::Expression::Placeholder(_)
             | vibesql_ast::Expression::NumberedPlaceholder(_)
             | vibesql_ast::Expression::NamedPlaceholder(_)

--- a/crates/vibesql-executor/src/cache/parameterized.rs
+++ b/crates/vibesql-executor/src/cache/parameterized.rs
@@ -350,6 +350,12 @@ impl LiteralExtractor {
                 literals.push(LiteralValue::from_sql_value(value));
             }
 
+            // Internal collation-carrying literal (issue #6105): treat its value
+            // like a plain literal for extraction purposes.
+            Expression::CollatedLiteral { value, .. } => {
+                literals.push(LiteralValue::from_sql_value(value));
+            }
+
             Expression::BinaryOp { left, right, .. } => {
                 Self::extract_from_expression(left, literals);
                 Self::extract_from_expression(right, literals);

--- a/crates/vibesql-executor/src/cache/prepared_statement/bind/mutation.rs
+++ b/crates/vibesql-executor/src/cache/prepared_statement/bind/mutation.rs
@@ -256,6 +256,7 @@ fn bind_expression_mut(expr: &mut Expression, params: &[SqlValue]) {
 
         // Leaf nodes: nothing to do
         Expression::Literal(_)
+        | Expression::CollatedLiteral { .. }
         | Expression::ColumnRef(_)
         | Expression::Wildcard
         | Expression::CurrentDate
@@ -652,6 +653,7 @@ fn bind_expression_named_mut(expr: &mut Expression, params: &HashMap<String, Sql
 
         // Leaf nodes: nothing to do
         Expression::Literal(_)
+        | Expression::CollatedLiteral { .. }
         | Expression::ColumnRef(_)
         | Expression::Wildcard
         | Expression::CurrentDate

--- a/crates/vibesql-executor/src/cache/query_signature.rs
+++ b/crates/vibesql-executor/src/cache/query_signature.rs
@@ -328,6 +328,14 @@ impl QuerySignature {
             | Expression::NumberedPlaceholder(_)
             | Expression::NamedPlaceholder(_) => "LITERAL_PLACEHOLDER".hash(hasher),
 
+            // Internal collation-carrying literal (issue #6105): the collation
+            // is semantically significant, so it hashes distinctly rather than
+            // collapsing into the parameterizable literal bucket.
+            Expression::CollatedLiteral { collation, .. } => {
+                "COLLATED_LITERAL".hash(hasher);
+                collation.hash(hasher);
+            }
+
             Expression::ColumnRef(col_id) => {
                 "COLUMN".hash(hasher);
                 col_id.table_canonical().hash(hasher);

--- a/crates/vibesql-executor/src/cache/table_extractor.rs
+++ b/crates/vibesql-executor/src/cache/table_extractor.rs
@@ -197,6 +197,7 @@ fn extract_from_expression(expr: &vibesql_ast::Expression, tables: &mut HashSet<
 
         // Leaf expressions - no tables to extract
         vibesql_ast::Expression::Literal(_)
+        | vibesql_ast::Expression::CollatedLiteral { .. }
         | vibesql_ast::Expression::Placeholder(_)
         | vibesql_ast::Expression::NumberedPlaceholder(_)
         | vibesql_ast::Expression::NamedPlaceholder(_)

--- a/crates/vibesql-executor/src/correlation.rs
+++ b/crates/vibesql-executor/src/correlation.rs
@@ -270,6 +270,7 @@ fn is_expression_correlated(
 ) -> bool {
     match expr {
         Expression::Literal(_)
+        | Expression::CollatedLiteral { .. }
         | Expression::Placeholder(_)
         | Expression::NumberedPlaceholder(_)
         | Expression::NamedPlaceholder(_)

--- a/crates/vibesql-executor/src/evaluator/collation.rs
+++ b/crates/vibesql-executor/src/evaluator/collation.rs
@@ -70,6 +70,15 @@ pub(crate) fn operand_column_collation(
         // An explicit COLLATE makes this a collating operand carrying that name.
         Expression::Collate { collation, .. } => Some(Some(collation.clone())),
         Expression::ColumnRef(col_id) => Some(column_collation(col_id)),
+        // A substituted outer column (issue #6105) is a collating operand
+        // carrying the column's *implicit* declared collation — it behaves like
+        // a `ColumnRef`, participating in rule 2 (left-operand precedence),
+        // NOT like an explicit COLLATE (rule 1). A BINARY collation is surfaced
+        // as `Some(None)` so a left-operand's default BINARY still blocks the
+        // right operand, mirroring a real column.
+        Expression::CollatedLiteral { collation, .. } => {
+            Some((!collation.eq_ignore_ascii_case("binary")).then(|| collation.clone()))
+        }
         Expression::UnaryOp { op: UnaryOperator::Plus, expr } => {
             operand_column_collation(expr, column_collation)
         }
@@ -133,6 +142,11 @@ pub(crate) fn resolve_expression_collation(
         Expression::Collate { collation, .. } => Some(collation.clone()),
         // Column reference - the column's declared collation (implicit).
         Expression::ColumnRef(col_id) => column_collation(col_id),
+        // A substituted outer column (issue #6105) carries the column's
+        // implicit declared collation (BINARY reported as `None`).
+        Expression::CollatedLiteral { collation, .. } => {
+            (!collation.eq_ignore_ascii_case("binary")).then(|| collation.clone())
+        }
         // Unary `+` and CAST are transparent: `+a` and `CAST(a AS TEXT)`
         // are still "a column" for collation purposes (datatype3 §7.1 rule 2).
         Expression::UnaryOp { op: UnaryOperator::Plus, expr } => {

--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -592,6 +592,10 @@ impl CombinedExpressionEvaluator<'_> {
             // Literals - just return the value
             vibesql_ast::Expression::Literal(val) => Ok(val.clone()),
 
+            // A collation-carrying literal (issue #6105) evaluates to its value;
+            // its implicit collation only affects comparison resolution.
+            vibesql_ast::Expression::CollatedLiteral { value, .. } => Ok(value.clone()),
+
             // DEFAULT keyword - not allowed in UPDATE/SELECT expressions
             // DEFAULT is only valid in INSERT VALUES and UPDATE SET
             // This evaluator is used for SELECT and WHERE clauses where DEFAULT is invalid

--- a/crates/vibesql-executor/src/evaluator/expression_hash.rs
+++ b/crates/vibesql-executor/src/evaluator/expression_hash.rs
@@ -188,6 +188,7 @@ impl ExpressionHasher {
 
             // Literals and placeholders are deterministic
             vibesql_ast::Expression::Literal(_)
+            | vibesql_ast::Expression::CollatedLiteral { .. }
             | vibesql_ast::Expression::Placeholder(_)
             | vibesql_ast::Expression::NumberedPlaceholder(_)
             | vibesql_ast::Expression::NamedPlaceholder(_) => true,
@@ -244,6 +245,14 @@ impl ExpressionHasher {
             vibesql_ast::Expression::Literal(val) => {
                 // Hash the SQL value
                 Self::hash_sql_value(val, hasher);
+            }
+
+            // Internal collation-carrying literal (issue #6105): hash both the
+            // value and the collation so two CollatedLiterals differing only in
+            // collation compare unequal.
+            vibesql_ast::Expression::CollatedLiteral { value, collation } => {
+                Self::hash_sql_value(value, hasher);
+                collation.hash(hasher);
             }
 
             vibesql_ast::Expression::ColumnRef(col_id) => {

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -595,6 +595,10 @@ impl ExpressionEvaluator<'_> {
             // Literals - just return the value
             vibesql_ast::Expression::Literal(val) => Ok(val.clone()),
 
+            // A collation-carrying literal (issue #6105) evaluates to its value;
+            // its implicit collation only affects comparison resolution.
+            vibesql_ast::Expression::CollatedLiteral { value, .. } => Ok(value.clone()),
+
             // DEFAULT keyword - not allowed in SELECT/WHERE expressions
             vibesql_ast::Expression::Default => Err(ExecutorError::UnsupportedExpression(
                 "DEFAULT keyword is only valid in INSERT VALUES and UPDATE SET clauses".to_string(),

--- a/crates/vibesql-executor/src/optimizer/column_pruning.rs
+++ b/crates/vibesql-executor/src/optimizer/column_pruning.rs
@@ -379,6 +379,7 @@ pub fn collect_columns_from_expr(expr: &Expression, columns: &mut HashSet<Column
 
         // Expressions that don't reference columns
         Expression::Literal(_)
+        | Expression::CollatedLiteral { .. }
         | Expression::Placeholder(_)
         | Expression::NumberedPlaceholder(_)
         | Expression::NamedPlaceholder(_)

--- a/crates/vibesql-executor/src/optimizer/expressions.rs
+++ b/crates/vibesql-executor/src/optimizer/expressions.rs
@@ -129,8 +129,10 @@ pub fn optimize_expression(
     evaluator: &CombinedExpressionEvaluator,
 ) -> Result<Expression, ExecutorError> {
     match expr {
-        // Literals are already optimized
-        Expression::Literal(_) => Ok(expr.clone()),
+        // Literals are already optimized. A CollatedLiteral (issue #6105)
+        // carries a semantically significant implicit collation, so leave it
+        // intact rather than folding it into a bare literal.
+        Expression::Literal(_) | Expression::CollatedLiteral { .. } => Ok(expr.clone()),
 
         // Column references, pseudo-variables, and session variables cannot be optimized
         Expression::ColumnRef(_)

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/correlation.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/correlation.rs
@@ -231,6 +231,7 @@ pub(crate) fn has_external_column_refs(expr: &Expression, subquery: &SelectStmt)
 
         // Literals and special expressions don't reference columns
         Expression::Literal(_)
+        | Expression::CollatedLiteral { .. }
         | Expression::Wildcard
         | Expression::CurrentDate
         | Expression::CurrentTime { .. }

--- a/crates/vibesql-executor/src/optimizer/subquery_rewrite/expression.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_rewrite/expression.rs
@@ -471,6 +471,7 @@ pub(super) fn rewrite_expression_with_context(
 
         // Literals, column refs, and special expressions don't need rewriting
         Expression::Literal(_)
+        | Expression::CollatedLiteral { .. }
         | Expression::ColumnRef(_)
         | Expression::Wildcard
         | Expression::CurrentDate

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
@@ -89,6 +89,7 @@ impl SelectExecutor<'_> {
 
             // Truly simple expressions: Literal, ColumnRef (cannot contain aggregates)
             vibesql_ast::Expression::Literal(_)
+            | vibesql_ast::Expression::CollatedLiteral { .. }
             | vibesql_ast::Expression::ColumnRef(_)
             | vibesql_ast::Expression::Wildcard
             | vibesql_ast::Expression::CurrentDate

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/join.rs
@@ -860,6 +860,7 @@ fn expression_has_rowid(expr: &vibesql_ast::Expression) -> bool {
         }
         // These variants don't contain column references that could be ROWID
         vibesql_ast::Expression::Literal(_)
+        | vibesql_ast::Expression::CollatedLiteral { .. }
         | vibesql_ast::Expression::Placeholder(_)
         | vibesql_ast::Expression::NumberedPlaceholder(_)
         | vibesql_ast::Expression::NamedPlaceholder(_)
@@ -968,7 +969,9 @@ fn is_columnar_join_disabled() -> bool {
 /// resolved shape turns out to be unsupported.
 fn group_by_key_shape_maybe_columnar(expr: &vibesql_ast::Expression) -> bool {
     match expr {
-        vibesql_ast::Expression::ColumnRef(_) | vibesql_ast::Expression::Literal(_) => true,
+        vibesql_ast::Expression::ColumnRef(_)
+        | vibesql_ast::Expression::Literal(_)
+        | vibesql_ast::Expression::CollatedLiteral { .. } => true,
         vibesql_ast::Expression::BinaryOp { left, op, right } => {
             matches!(
                 op,

--- a/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
+++ b/crates/vibesql-executor/src/select/executor/nonagg/validation.rs
@@ -684,6 +684,7 @@ fn validate_expression_column_refs(
 
         // Literals and other simple expressions - no column refs to validate
         Expression::Literal(_)
+        | Expression::CollatedLiteral { .. }
         | Expression::Wildcard
         | Expression::CurrentDate
         | Expression::CurrentTime { .. }

--- a/crates/vibesql-executor/src/select/executor/utils.rs
+++ b/crates/vibesql-executor/src/select/executor/utils.rs
@@ -115,6 +115,7 @@ fn find_from_less_column_ref(expr: &vibesql_ast::Expression, count_pseudo: bool)
 
         // These don't contain column references:
         vibesql_ast::Expression::Literal(_) => None,
+        vibesql_ast::Expression::CollatedLiteral { .. } => None,
         vibesql_ast::Expression::Wildcard => None,
         vibesql_ast::Expression::ScalarSubquery(_) => None, // Subquery has its own scope
         vibesql_ast::Expression::Exists { .. } => None,     // Subquery has its own scope

--- a/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/aggregates.rs
@@ -165,6 +165,7 @@ fn walk_first<T>(expr: &Expression, f: &impl Fn(&Expression) -> WalkAction<T>) -
         Expression::ScalarSubquery(_)
         | Expression::Exists { .. }
         | Expression::Literal(_)
+        | Expression::CollatedLiteral { .. }
         | Expression::Placeholder(_)
         | Expression::NumberedPlaceholder(_)
         | Expression::NamedPlaceholder(_)

--- a/crates/vibesql-executor/src/select/executor/validation/collation_names.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/collation_names.rs
@@ -150,6 +150,7 @@ pub fn validate_collation_names(expr: &Expression) -> Result<(), ExecutorError> 
         // no directly-evaluated COLLATE to check here.
         Expression::ColumnRef(_)
         | Expression::Literal(_)
+        | Expression::CollatedLiteral { .. }
         | Expression::Wildcard
         | Expression::Exists { .. }
         | Expression::ScalarSubquery(_)

--- a/crates/vibesql-executor/src/select/executor/validation/column_refs.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/column_refs.rs
@@ -170,6 +170,7 @@ pub fn extract_column_refs(expr: &Expression, refs: &mut Vec<ColumnReference>) {
 
         // Terminals with no column references
         Expression::Literal(_)
+        | Expression::CollatedLiteral { .. }
         | Expression::Wildcard
         | Expression::CurrentDate
         | Expression::CurrentTime { .. }

--- a/crates/vibesql-executor/src/select/join/expression_mapper.rs
+++ b/crates/vibesql-executor/src/select/join/expression_mapper.rs
@@ -274,6 +274,7 @@ impl ExpressionMapper {
             }
             // Literals and other terminal expressions don't reference columns
             Expression::Literal(_)
+            | Expression::CollatedLiteral { .. }
             | Expression::Wildcard
             | Expression::CurrentDate
             | Expression::CurrentTime { .. }

--- a/crates/vibesql-executor/src/select/order/resolution.rs
+++ b/crates/vibesql-executor/src/select/order/resolution.rs
@@ -1528,6 +1528,7 @@ fn resolve_where_expression_with_schema(
 
         // Expressions that don't need alias resolution (pass through)
         Expression::Literal(_)
+        | Expression::CollatedLiteral { .. }
         | Expression::Wildcard
         | Expression::CurrentDate
         | Expression::CurrentTime { .. }
@@ -1778,6 +1779,7 @@ fn collect_aggregates_from_expr(
 
         // Leaf expressions - nothing to extract
         Expression::Literal(_)
+        | Expression::CollatedLiteral { .. }
         | Expression::ColumnRef(_)
         | Expression::Wildcard
         | Expression::CurrentDate

--- a/crates/vibesql-executor/src/select/window/order_by.rs
+++ b/crates/vibesql-executor/src/select/window/order_by.rs
@@ -114,6 +114,7 @@ fn collect_window_functions_from_expression(
             // Wildcard doesn't contain window functions
         }
         Expression::Literal(_)
+        | Expression::CollatedLiteral { .. }
         | Expression::ColumnRef(_)
         | Expression::PseudoVariable { .. }
         | Expression::SessionVariable { .. } => {

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -1465,6 +1465,7 @@ fn validate_expression(
 
         // Expressions that don't need validation (literals, special keywords, etc.)
         Expression::Literal(_)
+        | Expression::CollatedLiteral { .. }
         | Expression::Default
         | Expression::CurrentDate
         | Expression::CurrentTime { .. }

--- a/crates/vibesql-executor/src/update/from_clause.rs
+++ b/crates/vibesql-executor/src/update/from_clause.rs
@@ -317,13 +317,17 @@ pub fn execute_update_from_join(
                     projected_offset += n;
                 }
                 AssignmentProjPlan::SubqueryOnce { output_arity, corr_refs, subquery } => {
-                    // Substitute each projected correlation input as a literal.
-                    let mut literal_map: HashMap<CorrKey, SqlValue> =
+                    // Substitute each projected correlation input as a literal,
+                    // carrying the outer column's declared collation (issue #6105)
+                    // so collation-sensitive comparisons inside the now-uncorrelated
+                    // subquery still use that collation rather than reverting to
+                    // BINARY.
+                    let mut literal_map: HashMap<CorrKey, (SqlValue, Option<String>)> =
                         HashMap::with_capacity(corr_refs.len());
                     for (k, corr) in corr_refs.iter().enumerate() {
                         let value =
                             row.values.get(projected_offset + k).cloned().unwrap_or(SqlValue::Null);
-                        literal_map.insert(corr.key.clone(), value);
+                        literal_map.insert(corr.key.clone(), (value, corr.collation.clone()));
                     }
                     projected_offset += corr_refs.len();
 
@@ -469,6 +473,13 @@ struct CorrKey {
 struct CorrRef {
     key: CorrKey,
     expr: Expression,
+    /// The outer column's *declared* collating sequence, if any (issue #6105).
+    /// When the substituted value replaces this ref as a literal, this collation
+    /// is carried on the resulting node so collation-sensitive comparisons inside
+    /// the (now uncorrelated) subquery still use the column's collation rather
+    /// than silently reverting to BINARY. `None` (and an explicit `"BINARY"`)
+    /// means default BINARY — a plain literal is emitted.
+    collation: Option<String>,
 }
 
 /// How an UPDATE…FROM assignment maps its projected synthetic columns to the
@@ -492,6 +503,32 @@ impl AssignmentProjPlan {
             AssignmentProjPlan::DirectColumns(n) => *n,
             AssignmentProjPlan::SubqueryOnce { output_arity, .. } => *output_arity,
         }
+    }
+}
+
+/// Resolve the *declared* collating sequence of an outer column reference
+/// (issue #6105) so it can be carried on the substituted literal.
+///
+/// - Qualified (`t.c`): looks the column up in table `t`'s schema.
+/// - Unqualified (`c`): finds the first outer table declaring a column `c`
+///   (mirroring the resolution used to classify the ref as outer above).
+///
+/// Returns the column's declared collation (`None` = default BINARY). A collation
+/// that names BINARY is treated as BINARY by the caller (a plain literal).
+fn outer_column_collation(
+    table: &Option<String>,
+    column: &str,
+    outer_tables: &HashMap<String, TableSchema>,
+) -> Option<String> {
+    match table {
+        Some(t) => outer_tables
+            .get(&t.to_lowercase())
+            .and_then(|schema| schema.get_column(column))
+            .and_then(|col| col.collation.clone()),
+        None => outer_tables
+            .values()
+            .find_map(|schema| schema.get_column(column))
+            .and_then(|col| col.collation.clone()),
     }
 }
 
@@ -684,7 +721,8 @@ fn collect_outer_refs_in_expr(
             if is_outer {
                 let key = CorrKey { table: table.clone(), column: column.clone() };
                 if seen.insert(key.clone()) {
-                    refs.push(CorrRef { key, expr: expr.clone() });
+                    let collation = outer_column_collation(&table, &column, outer_tables);
+                    refs.push(CorrRef { key, expr: expr.clone(), collation });
                 }
             }
         }
@@ -978,7 +1016,7 @@ fn window_function_parts(
 /// inside an inner subquery of the tuple RHS is also substituted.
 fn substitute_column_literals(
     expr: &Expression,
-    literals: &HashMap<CorrKey, SqlValue>,
+    literals: &HashMap<CorrKey, (SqlValue, Option<String>)>,
 ) -> Expression {
     use vibesql_ast::CaseWhen;
     match expr {
@@ -988,7 +1026,24 @@ fn substitute_column_literals(
                 column: id.column_canonical().to_string(),
             };
             match literals.get(&key) {
-                Some(value) => Expression::Literal(value.clone()),
+                // Carry the outer column's collation onto the substituted value
+                // (issue #6105). The result is a `CollatedLiteral` — an
+                // *implicit* collating operand behaving exactly like the original
+                // column reference under datatype3 §7.1 rule 2 (left-operand
+                // precedence), NOT an explicit `COLLATE` (rule 1).
+                //
+                // This holds even for a BINARY column (no declared collation):
+                // a `CollatedLiteral{collation:"BINARY"}` is still a *collating
+                // operand*, so when it is the left operand its default BINARY
+                // blocks the right operand's implicit collation — exactly as a
+                // real column would. Emitting a bare `Expression::Literal` here
+                // (which is NOT a collating operand) would wrongly let the right
+                // operand's collation win, e.g. `outer_binary_col = inner_nocase`
+                // would compare NOCASE instead of SQLite's BINARY.
+                Some((value, declared)) => Expression::CollatedLiteral {
+                    value: value.clone(),
+                    collation: declared.clone().unwrap_or_else(|| "BINARY".to_string()),
+                },
                 None => expr.clone(),
             }
         }
@@ -1101,7 +1156,7 @@ fn substitute_column_literals(
 /// Substitute correlation literals inside a window function's args / FILTER.
 fn substitute_column_literals_in_window_spec(
     spec: &vibesql_ast::WindowFunctionSpec,
-    literals: &HashMap<CorrKey, SqlValue>,
+    literals: &HashMap<CorrKey, (SqlValue, Option<String>)>,
 ) -> vibesql_ast::WindowFunctionSpec {
     use vibesql_ast::WindowFunctionSpec;
     match spec {
@@ -1126,7 +1181,7 @@ fn substitute_column_literals_in_window_spec(
 /// as-is (they do not carry correlation refs for the shapes this path handles).
 fn substitute_column_literals_in_over(
     over: &vibesql_ast::WindowSpec,
-    literals: &HashMap<CorrKey, SqlValue>,
+    literals: &HashMap<CorrKey, (SqlValue, Option<String>)>,
 ) -> vibesql_ast::WindowSpec {
     let mut cloned = over.clone();
     cloned.partition_by = over
@@ -1151,7 +1206,7 @@ fn substitute_column_literals_in_over(
 /// path handles.
 fn substitute_column_literals_in_select(
     select: &SelectStmt,
-    literals: &HashMap<CorrKey, SqlValue>,
+    literals: &HashMap<CorrKey, (SqlValue, Option<String>)>,
 ) -> SelectStmt {
     let mut cloned = select.clone();
     cloned.select_list = select
@@ -1370,6 +1425,7 @@ fn substitute_pseudo_vars(
             Expression::Literal(value)
         }
         Expression::Literal(_)
+        | Expression::CollatedLiteral { .. }
         | Expression::Placeholder(_)
         | Expression::NumberedPlaceholder(_)
         | Expression::NamedPlaceholder(_)

--- a/crates/vibesql-executor/tests/tuple_set_assignment_tests.rs
+++ b/crates/vibesql-executor/tests/tuple_set_assignment_tests.rs
@@ -301,3 +301,122 @@ fn update_from_tuple_set_subquery_correlated_empty_yields_nulls() {
     assert_eq!(r[0], SqlValue::Null);
     assert_eq!(r[1], SqlValue::Null);
 }
+
+// ---------------------------------------------------------------------------
+// Collation preservation across literal substitution (issue #6105).
+//
+// #6099's single-evaluation path substitutes an outer column reference into the
+// (now uncorrelated) tuple subquery as a literal. That substituted value must
+// carry the outer column's *implicit* declared collation so collation-sensitive
+// comparisons inside the subquery match SQLite 3.51 rather than reverting to
+// BINARY. The collation is IMPLICIT (like a column ref, datatype3 §7.1 rule 2 —
+// left-operand precedence), NOT explicit COLLATE (rule 1 — wins anywhere).
+//
+// All expected values were confirmed against sqlite3 3.51.0.
+// ---------------------------------------------------------------------------
+
+/// Sets up a target `dst(id, s, n)` driven by UPDATE…FROM `o` (outer) with a
+/// declared-NOCASE column `o.nc` and a plain-BINARY column `o.bc`, plus an
+/// `inner_t` whose rows exercise case sensitivity. Each test issues its own
+/// UPDATE and reads `dst.s` (sum) / `dst.n` (count).
+fn setup_collation() -> Database {
+    let mut db = Database::new();
+    for sql in [
+        "CREATE TABLE o(id INTEGER PRIMARY KEY, nc TEXT COLLATE NOCASE, bc TEXT)",
+        "INSERT INTO o VALUES(1, 'Foo', 'Foo')",
+        "CREATE TABLE inner_t(bin_col TEXT, nocase_col TEXT COLLATE NOCASE, v INTEGER)",
+        "INSERT INTO inner_t VALUES('foo', 'foo', 100)",
+        "INSERT INTO inner_t VALUES('FOO', 'FOO', 200)",
+        "INSERT INTO inner_t VALUES('bar', 'bar', 300)",
+        "CREATE TABLE dst(id INTEGER, s INTEGER, n INTEGER)",
+        "INSERT INTO dst VALUES(1, -1, -1)",
+    ] {
+        exec(&mut db, sql);
+    }
+    db
+}
+
+fn dst_row(db: &Database) -> Vec<SqlValue> {
+    let table = db.get_table("dst").expect("dst");
+    table.scan().iter().next().map(|r| r.values.to_vec()).unwrap_or_default()
+}
+
+fn run_collation_update(where_clause: &str) -> Vec<SqlValue> {
+    let mut db = setup_collation();
+    let sql = format!(
+        "UPDATE dst SET (s, n) = (SELECT sum(v), count(*) FROM inner_t WHERE {where_clause}) \
+         FROM o WHERE dst.id = o.id"
+    );
+    run_update(&mut db, &sql).expect("update");
+    dst_row(&db)
+}
+
+/// Left = inner BINARY column, right = substituted NOCASE outer column.
+/// Rule 2: the left operand's declared BINARY collation wins → BINARY compare,
+/// so 'Foo' matches neither 'foo' nor 'FOO' → no rows → sum NULL, count 0.
+#[test]
+fn collation_bin_lhs_vs_nocase_outer_rhs_binary() {
+    let r = run_collation_update("inner_t.bin_col = o.nc");
+    assert_eq!(r[1], SqlValue::Null);
+    assert_eq!(r[2], SqlValue::Integer(0));
+}
+
+/// Left = substituted NOCASE outer column, right = inner BINARY column.
+/// The left operand carries the outer column's implicit NOCASE → NOCASE compare,
+/// so 'Foo' matches 'foo' and 'FOO' → sum 300, count 2.
+#[test]
+fn collation_nocase_outer_lhs_vs_bin_rhs_nocase() {
+    let r = run_collation_update("o.nc = inner_t.bin_col");
+    assert_eq!(r[1], SqlValue::Integer(300));
+    assert_eq!(r[2], SqlValue::Integer(2));
+}
+
+/// The critical BINARY caveat: left = inner NOCASE column, right = substituted
+/// BINARY outer column. The substituted BINARY outer column is still a
+/// *collating operand* (a real column would be), but here the left operand's
+/// NOCASE wins → NOCASE compare → sum 300, count 2.
+#[test]
+fn collation_nocase_col_lhs_vs_bin_outer_rhs_nocase() {
+    let r = run_collation_update("inner_t.nocase_col = o.bc");
+    assert_eq!(r[1], SqlValue::Integer(300));
+    assert_eq!(r[2], SqlValue::Integer(2));
+}
+
+/// The critical BINARY caveat, reversed operands: left = substituted BINARY
+/// outer column, right = inner NOCASE column. Because the substituted BINARY
+/// column is a collating operand (NOT a bare literal), its left-operand default
+/// BINARY BLOCKS fallthrough to the right's NOCASE → BINARY compare → no rows.
+/// A naive plain-literal substitution would wrongly compare NOCASE here.
+#[test]
+fn collation_bin_outer_lhs_blocks_nocase_rhs_binary() {
+    let r = run_collation_update("o.bc = inner_t.nocase_col");
+    assert_eq!(r[1], SqlValue::Null);
+    assert_eq!(r[2], SqlValue::Integer(0));
+}
+
+/// Explicit `COLLATE BINARY` on the substituted NOCASE outer column overrides
+/// its implicit collation (rule 1) → BINARY compare → no rows.
+#[test]
+fn collation_explicit_binary_override() {
+    let r = run_collation_update("inner_t.bin_col = o.nc COLLATE BINARY");
+    assert_eq!(r[1], SqlValue::Null);
+    assert_eq!(r[2], SqlValue::Integer(0));
+}
+
+/// Explicit `COLLATE NOCASE` on the substituted BINARY outer column overrides
+/// its implicit BINARY (rule 1) → NOCASE compare → sum 300, count 2.
+#[test]
+fn collation_explicit_nocase_override() {
+    let r = run_collation_update("inner_t.bin_col = o.bc COLLATE NOCASE");
+    assert_eq!(r[1], SqlValue::Integer(300));
+    assert_eq!(r[2], SqlValue::Integer(2));
+}
+
+/// Two implicit NOCASE operands: left inner NOCASE column, right substituted
+/// NOCASE outer column → NOCASE compare → sum 300, count 2.
+#[test]
+fn collation_nocase_col_vs_nocase_outer() {
+    let r = run_collation_update("inner_t.nocase_col = o.nc");
+    assert_eq!(r[1], SqlValue::Integer(300));
+    assert_eq!(r[2], SqlValue::Integer(2));
+}

--- a/crates/vibesql-storage/src/persistence/binary/expression/mod.rs
+++ b/crates/vibesql-storage/src/persistence/binary/expression/mod.rs
@@ -145,6 +145,14 @@ pub fn write_expression<W: Write>(writer: &mut W, expr: &Expression) -> Result<(
             write_tag!(writer, ExprTag::Literal);
             write_sql_value(writer, value)?;
         }
+        // `CollatedLiteral` is an internal-only transient node produced during
+        // UPDATE tuple-subquery substitution (issue #6105); it is never part of
+        // a persisted schema/expression. Serialize it as a plain literal so the
+        // exhaustive match compiles without introducing a new on-disk tag.
+        Expression::CollatedLiteral { value, .. } => {
+            write_tag!(writer, ExprTag::Literal);
+            write_sql_value(writer, value)?;
+        }
         Expression::ColumnRef(col_id) => {
             write_tag!(writer, ExprTag::ColumnRef);
             // Write schema (optional)


### PR DESCRIPTION
## Summary

The #6099 single-evaluation path for `UPDATE ... SET (a,b) = (SELECT ...) FROM ...` substitutes each outer correlation column into the (now uncorrelated) tuple subquery as a literal. A bare `Expression::Literal` carries no collation, so a `COLLATE NOCASE` outer column substituted into a collation-sensitive comparison silently reverted to BINARY (issue #6105).

This PR carries the outer column's *declared* collation onto the substituted node via a new internal-only `Expression::CollatedLiteral` AST variant, so the comparison inside the subquery resolves collation exactly as SQLite 3.51 does.

## Approach: implicit collation, not explicit COLLATE

`CollatedLiteral { value, collation }` evaluates exactly to `value` but participates in collation resolution as an **implicit** collating operand — like a column reference (datatype3 §7.1 **rule 2**, left-operand precedence), **NOT** an explicit COLLATE (rule 1, wins anywhere). This distinction is load-bearing:

- A substituted **BINARY** outer column is still a *collating operand* (a real column would be), so when it is the left operand its default BINARY **blocks** fallthrough to the right operand's collation. Wrapping in `Expression::Collate` instead would wrongly flip `outer_binary_col = inner_nocase_col` from BINARY (correct) to NOCASE.
- An explicit `COLLATE` on either operand still overrides (rule 1), unchanged.

## Changes

- **`vibesql-ast`**: new internal-only `Expression::CollatedLiteral { value, collation }` variant (never produced by the parser); threaded through `pretty_print` and `visitor`.
- **`vibesql-executor/update/from_clause.rs`**: `substitute_column_literals` now emits `CollatedLiteral` carrying the outer column's declared collation (resolved via `outer_column_collation`); `CorrRef` gains a `collation` field.
- **`vibesql-executor/evaluator/collation.rs`**: `operand_column_collation` / `resolve_expression_collation` treat `CollatedLiteral` as an implicit column-like operand (BINARY surfaced as `None`/`Some(None)` so left-operand BINARY blocks the right).
- **Evaluation**: both evaluators return the inner value for `CollatedLiteral`; the collation only affects comparison resolution.
- **Exhaustive-match coverage**: the new variant is added to every `Expression` match across the executor, catalog, hashing/signature, and binary serialization (serialized as a plain literal since it is a transient node that never persists).
- **Tests**: 7 new sqlite3-3.51-verified collation matrix tests in `tuple_set_assignment_tests.rs`.

## Differential matrix (vs sqlite3 3.51.0)

Target `dst` driven by `UPDATE dst SET (s,n) = (SELECT sum(v), count(*) FROM inner_t WHERE <pred>) FROM o WHERE dst.id = o.id`, with `o.nc TEXT COLLATE NOCASE = 'Foo'`, `o.bc TEXT = 'Foo'`, and `inner_t` rows `foo/foo/100`, `FOO/FOO/200`, `bar/bar/300`.

| Predicate | Effective collation | sum,count | Matches sqlite3 |
|-----------|--------------------|-----------|-----------------|
| `inner_t.bin_col = o.nc` | BINARY (left col BINARY wins) | NULL, 0 | ✅ |
| `o.nc = inner_t.bin_col` | NOCASE (left = outer NOCASE) | 300, 2 | ✅ |
| `inner_t.nocase_col = o.bc` | NOCASE (left col NOCASE wins) | 300, 2 | ✅ |
| `o.bc = inner_t.nocase_col` | BINARY (left = outer BINARY blocks right) | NULL, 0 | ✅ |
| `inner_t.bin_col = o.nc COLLATE BINARY` | BINARY (explicit rule 1) | NULL, 0 | ✅ |
| `inner_t.bin_col = o.bc COLLATE NOCASE` | NOCASE (explicit rule 1) | 300, 2 | ✅ |
| `inner_t.nocase_col = o.nc` | NOCASE (two-sided implicit) | 300, 2 | ✅ |

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Differential matrix matches sqlite3 3.51 | ✅ | 7 new tests, expected values confirmed against sqlite3 3.51.0 |
| #6099's 16 tuple tests pass | ✅ | `tuple_set_assignment_tests`: 23 pass (16 original + 7 new) |
| #6108 collation tests pass | ✅ | all `collation` executor tests pass |
| rowvalue set unregressed | ✅ | `row_value` tests: 16 pass |
| `cargo test -p vibesql-executor` green | ✅ | 3487 lib tests + all integration suites pass, 0 failures |
| `cargo test -p vibesql-ast` green | ✅ | 88 lib + 14 doctests pass |
| Precedence faithful (implicit, not explicit) | ✅ | `CollatedLiteral` resolves as rule-2 implicit operand; BINARY-caveat tests both directions pass |

## Test Plan

- `cargo test -p vibesql-executor --test tuple_set_assignment_tests` — 23 pass
- `cargo test -p vibesql-executor` — 3487 lib + all integration tests pass
- `cargo test -p vibesql-ast` — pass
- `cargo clippy` on touched crates — no new warnings

## Scope note

This PR fixes the **literal-substitution** path named in the issue's root-cause section (`substitute_column_literals`, the UPDATE...FROM #6099 path). The issue's bare reproduction (`UPDATE t1 SET (a,b) = (SELECT (x='abc'), x)` with **no** FROM clause) exercises a *different* mechanism: that path does not substitute — it executes a correlated subquery, and the same collation loss occurs even for a single-column correlated scalar subquery (`UPDATE t1 SET a = (SELECT (x='abc'))`). That is a broader, pre-existing correlated-subquery collation-resolution gap unrelated to literal substitution and is left for a separate issue to avoid scope creep and the risk of threading declared collation through the entire correlated-scan machinery.

Closes #6105