### PR TITLE
fix(executor): recover outer column collation in no-FROM correlated subquery

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -158,7 +158,7 @@ impl CombinedExpressionEvaluator<'_> {
         let table = col_id.table_canonical();
         let column = col_id.column_canonical();
 
-        // Look up the column in the combined schema
+        // Look up the column in the combined schema (the subquery's own tables).
         for (_start_idx, table_schema) in self.schema.table_schemas.values() {
             // If table qualifier is specified, check if this is the right table
             if let Some(t) = table {
@@ -173,6 +173,41 @@ impl CombinedExpressionEvaluator<'_> {
                 return table_schema.columns[col_offset].collation.clone();
             }
         }
+
+        // Not found in this evaluator's own schema. A correlated reference to
+        // an outer column (e.g. a no-FROM `UPDATE t1 SET a = (SELECT (x='abc'))`
+        // where `x` is the outer `t1.x COLLATE NOCASE`) must still honor the
+        // outer column's *declared* collation; otherwise the comparison inside
+        // the subquery silently reverts to BINARY (issue #6115). Mirror the
+        // outer-scope value resolution walk: the immediate parent
+        // (`outer_schema`, including its own chain) first, then the
+        // `outer_context` chain for grandparent scopes and beyond.
+        if let Some(outer_schema) = self.outer_schema {
+            if let Some(collation) = outer_schema.get_column_collation_in_chain(table, column) {
+                return Some(collation);
+            }
+            // `get_column_collation_in_chain` returns `None` for a resolved
+            // column with default BINARY collation as well as for an unresolved
+            // column, so continuing to the context chain below is safe: an
+            // ancestor scope that *declares* a non-BINARY collation on the same
+            // name is only consulted when the nearer scopes have none.
+        }
+
+        let mut current_context = self.outer_context;
+        while let Some(ctx) = current_context {
+            if let Some(collation) = ctx.schema.get_column_collation_in_chain(table, column) {
+                return Some(collation);
+            }
+            if let Some(ctx_outer_schema) = ctx.outer_schema {
+                if let Some(collation) =
+                    ctx_outer_schema.get_column_collation_in_chain(table, column)
+                {
+                    return Some(collation);
+                }
+            }
+            current_context = ctx.outer_context;
+        }
+
         None
     }
 

--- a/crates/vibesql-executor/src/schema.rs
+++ b/crates/vibesql-executor/src/schema.rs
@@ -723,6 +723,54 @@ impl CombinedSchema {
         )
     }
 
+    /// Resolve a column's *declared* collation by name (optionally qualified
+    /// with a table/alias), searching this schema level first and then
+    /// following the `outer_schema` chain to enclosing scopes.
+    ///
+    /// This mirrors [`get_column_index`](Self::get_column_index): a correlated
+    /// subquery may reference an outer column whose declared `COLLATE` must be
+    /// honored inside the subquery's comparisons. The outer column is not in
+    /// this level's `table_schemas`, so a lookup restricted to the current
+    /// level would incorrectly report the default BINARY collation and a
+    /// `COLLATE NOCASE` outer column would compare BINARY (issue #6115).
+    ///
+    /// Returns `None` when the column has no declared collation (default
+    /// BINARY) or cannot be resolved anywhere in the chain.
+    pub fn get_column_collation_in_chain(
+        &self,
+        table: Option<&str>,
+        column: &str,
+    ) -> Option<String> {
+        // Try the current level first.
+        if let Some(table_name) = table {
+            // Qualified column reference (table.column).
+            let table_id = TableIdentifier::unquoted(table_name);
+            if let Some((_start_index, schema)) = self.table_schemas.get(&table_id) {
+                if let Some(col_idx) = schema.get_column_index(column) {
+                    return schema.columns[col_idx].collation.clone();
+                }
+            }
+        } else {
+            // Unqualified column reference - search all non-alias tables.
+            for (table_id, (_start_index, schema)) in &self.table_schemas {
+                if self.alias_tables.contains(table_id) {
+                    continue;
+                }
+                if let Some(col_idx) = schema.get_column_index(column) {
+                    return schema.columns[col_idx].collation.clone();
+                }
+            }
+        }
+
+        // Not found at this level - follow the outer_schema chain so a
+        // correlated reference reaches the enclosing scope that declares it.
+        if let Some(outer) = &self.outer_schema {
+            return outer.get_column_collation_in_chain(table, column);
+        }
+
+        None
+    }
+
     /// Get the type affinity for a column by name
     ///
     /// Returns the SQLite type affinity for the column, which determines how

--- a/crates/vibesql-executor/tests/tuple_set_assignment_tests.rs
+++ b/crates/vibesql-executor/tests/tuple_set_assignment_tests.rs
@@ -420,3 +420,121 @@ fn collation_nocase_col_vs_nocase_outer() {
     assert_eq!(r[1], SqlValue::Integer(300));
     assert_eq!(r[2], SqlValue::Integer(2));
 }
+
+// ---------------------------------------------------------------------------
+// No-FROM correlated subquery: outer column collation (issue #6115).
+//
+// `UPDATE t1 SET a = (SELECT (x='abc'))` and its tuple form execute a
+// *correlated* subquery per outer row WITHOUT literal substitution (the #6114
+// CollatedLiteral path only covers UPDATE…FROM). The subquery evaluator
+// resolves the outer column `x` through the outer-schema chain, but previously
+// resolved its *value* while dropping its *declared collation*, so a
+// `COLLATE NOCASE` outer column compared BINARY. `column_collation_of` now
+// walks the outer-schema / outer-context chain to recover the declared
+// collation. All expected values confirmed against sqlite3 3.51.
+// ---------------------------------------------------------------------------
+
+/// Target `t1(x TEXT COLLATE NOCASE, y TEXT, a, b)` with a single row
+/// `('ABC','ABC',0,0)`. Runs `stmt` then returns `(a, b)`.
+fn nofrom_ab(stmt: &str) -> (SqlValue, SqlValue) {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(x TEXT COLLATE NOCASE, y TEXT, a, b)");
+    exec(&mut db, "INSERT INTO t1 VALUES('ABC','ABC',0,0)");
+    run_update(&mut db, stmt).expect("update");
+    let table = db.get_table("t1").expect("t1");
+    let r = table.scan().iter().next().map(|r| r.values.to_vec()).expect("row");
+    (r[2].clone(), r[3].clone())
+}
+
+/// The issue's scalar repro: outer NOCASE column left operand → NOCASE → true.
+/// (The `=` comparison yields a Boolean at the value layer; the CLI renders it
+/// as `1`, which is what the issue quotes.)
+#[test]
+fn nofrom_scalar_nocase_outer_lhs() {
+    let (a, _) = nofrom_ab("UPDATE t1 SET a = (SELECT (x = 'abc'))");
+    assert_eq!(a, SqlValue::Boolean(true));
+}
+
+/// Outer NOCASE column right operand (literal left) → NOCASE → true.
+#[test]
+fn nofrom_scalar_nocase_outer_rhs() {
+    let (a, _) = nofrom_ab("UPDATE t1 SET a = (SELECT ('abc' = x))");
+    assert_eq!(a, SqlValue::Boolean(true));
+}
+
+/// Outer BINARY column must stay BINARY → false (no over-application of NOCASE).
+#[test]
+fn nofrom_scalar_binary_outer_stays_binary() {
+    let (a, _) = nofrom_ab("UPDATE t1 SET a = (SELECT (y = 'abc'))");
+    assert_eq!(a, SqlValue::Boolean(false));
+}
+
+/// Explicit `COLLATE BINARY` on the outer NOCASE column overrides → false.
+#[test]
+fn nofrom_scalar_explicit_binary_override() {
+    let (a, _) = nofrom_ab("UPDATE t1 SET a = (SELECT (x COLLATE BINARY = 'abc'))");
+    assert_eq!(a, SqlValue::Boolean(false));
+}
+
+/// Explicit `COLLATE NOCASE` on the outer BINARY column overrides → true.
+#[test]
+fn nofrom_scalar_explicit_nocase_override() {
+    let (a, _) = nofrom_ab("UPDATE t1 SET a = (SELECT (y COLLATE NOCASE = 'abc'))");
+    assert_eq!(a, SqlValue::Boolean(true));
+}
+
+/// The issue's tuple repro: `(a,b) = (SELECT (x='abc'), (y='abc'))` →
+/// NOCASE `x` compares true, BINARY `y` compares false.
+#[test]
+fn nofrom_tuple_mixed_collations() {
+    let (a, b) = nofrom_ab("UPDATE t1 SET (a,b) = (SELECT (x='abc'), (y='abc'))");
+    assert_eq!(a, SqlValue::Boolean(true));
+    assert_eq!(b, SqlValue::Boolean(false));
+}
+
+/// Correlated subquery WHERE clause: outer NOCASE column as the *right* operand
+/// (inner BINARY column left) → left BINARY blocks → 0 matches.
+#[test]
+fn nofrom_where_inner_bin_lhs_blocks_outer_nocase() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(x TEXT COLLATE NOCASE, a)");
+    exec(&mut db, "INSERT INTO t1 VALUES('ABC', 0)");
+    exec(&mut db, "CREATE TABLE inner_t(v TEXT)");
+    exec(&mut db, "INSERT INTO inner_t VALUES('abc')");
+    exec(&mut db, "INSERT INTO inner_t VALUES('XYZ')");
+    run_update(&mut db, "UPDATE t1 SET a = (SELECT count(*) FROM inner_t WHERE v = x)")
+        .expect("update");
+    let table = db.get_table("t1").expect("t1");
+    let r = table.scan().iter().next().map(|r| r.values.to_vec()).expect("row");
+    assert_eq!(r[1], SqlValue::Integer(0));
+}
+
+/// Correlated subquery WHERE clause: outer NOCASE column as the *left* operand
+/// → NOCASE compare → matches 'abc' case-insensitively → 1 match.
+#[test]
+fn nofrom_where_outer_nocase_lhs_matches() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(x TEXT COLLATE NOCASE, a)");
+    exec(&mut db, "INSERT INTO t1 VALUES('ABC', 0)");
+    exec(&mut db, "CREATE TABLE inner_t(v TEXT)");
+    exec(&mut db, "INSERT INTO inner_t VALUES('abc')");
+    exec(&mut db, "INSERT INTO inner_t VALUES('XYZ')");
+    run_update(&mut db, "UPDATE t1 SET a = (SELECT count(*) FROM inner_t WHERE x = v)")
+        .expect("update");
+    let table = db.get_table("t1").expect("t1");
+    let r = table.scan().iter().next().map(|r| r.values.to_vec()).expect("row");
+    assert_eq!(r[1], SqlValue::Integer(1));
+}
+
+/// Nested two-level correlated subquery: the outer NOCASE column is referenced
+/// two scopes deep and its declared collation must still be recovered → 1.
+#[test]
+fn nofrom_nested_two_level_correlated() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t2(z TEXT COLLATE NOCASE, m)");
+    exec(&mut db, "INSERT INTO t2 VALUES('ABC', 0)");
+    run_update(&mut db, "UPDATE t2 SET m = (SELECT (SELECT (z = 'abc')))").expect("update");
+    let table = db.get_table("t2").expect("t2");
+    let r = table.scan().iter().next().map(|r| r.values.to_vec()).expect("row");
+    assert_eq!(r[1], SqlValue::Boolean(true));
+}


### PR DESCRIPTION
## Summary

`UPDATE t1 SET a = (SELECT (x = 'abc'))` where `x` is `t1.x COLLATE NOCASE` returned `0` in vibesql versus sqlite3 3.51's `1`. The no-FROM correlated subquery is evaluated per outer row (no literal substitution), and the outer column's declared collation was lost inside the subquery's comparisons, which reverted to BINARY.

Root cause: `CombinedExpressionEvaluator::column_collation_of` only searched the subquery's *own* `schema.table_schemas`. A correlated reference to an outer column (present only in `outer_schema` / `outer_context`) resolved its *value* through the outer-scope chain but its *collation* fell through to `None` (BINARY). This is a different mechanism from #6114's `CollatedLiteral` (the UPDATE...FROM literal-substitution path) — the no-FROM path never substitutes.

## Changes

- **`schema.rs`**: new `CombinedSchema::get_column_collation_in_chain(table, column)` resolving a column's declared collation by name, following the `outer_schema` chain — mirrors `get_column_index`.
- **`evaluator/combined/eval.rs`**: `column_collation_of` now, after missing in the local schema, walks `outer_schema` and then the `outer_context` chain (mirroring the existing outer-scope *value* resolution walk at lines 877–911) to recover the outer column's declared collation.
- **`tuple_set_assignment_tests.rs`**: 9 new sqlite3-3.51-verified regression tests.

## Differential matrix (vs sqlite3 3.51.0)

| # | Statement | sqlite3 | vibesql | Note |
|---|-----------|---------|---------|------|
| c1 | `SELECT (x='abc')`, x NOCASE (lhs) | 1 | 1 | NOCASE |
| c2 | `SELECT ('abc'=x)`, x NOCASE (rhs) | 1 | 1 | NOCASE |
| c3 | `SELECT (y='abc')`, y BINARY | 0 | 0 | stays BINARY |
| c4 | `SELECT (x COLLATE BINARY='abc')` | 0 | 0 | explicit override |
| c5 | `SELECT (y COLLATE NOCASE='abc')` | 1 | 1 | explicit override |
| c6 | tuple `(x='abc'),(y='abc')` | 1,0 | 1,0 | mixed |
| c7 | WHERE `inner_t.v = x` (qualified) | 0 | 0 | inner BINARY lhs blocks |
| c8 | WHERE `v = x` | 0 | 0 | inner BINARY lhs blocks |
| c9 | WHERE `x = v` | 1 | 1 | outer NOCASE lhs |
| c10 | nested two-level `(SELECT (SELECT (z='abc')))` | 1 | 1 | correlated 2 levels deep |

All 10 match sqlite3 exactly.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Issue's repro returns 1 | ✅ | CLI: `1\|ABC` and `1` (was `0\|ABC` / `0`) |
| Matrix matches sqlite3 3.51 | ✅ | 10/10 cases above |
| #6114's tuple tests keep passing | ✅ | `tuple_set_assignment_tests`: 32 pass (23 prior + 9 new) |
| #6108 collation tests pass | ✅ | `collation::` lib tests: 11 pass |
| #6112 nested-rowid tests pass | ✅ | `correlated_outer_rowid_nested_tests` 6, `correlated_outer_rowid_tests` 4 pass |
| `cargo test -p vibesql-executor` green | ✅ | full suite exit 0, 0 failures |

## Test Plan

- `cargo test -p vibesql-executor --test tuple_set_assignment_tests` — 32 pass
- `cargo test -p vibesql-executor` — all pass, 0 failures
- `cargo clippy -p vibesql-executor` — no new warnings in touched regions
- Differential matrix vs sqlite3 3.51.0 — 10/10 match

## Scope note

Fix is confined to the `CombinedExpressionEvaluator` collation lookup + one new `CombinedSchema` helper. BINARY-outer non-regression (c3) and explicit-COLLATE precedence (c4/c5) are covered so the change does not over-apply NOCASE.

Closes #6115