### PR TITLE
test(tcl): stub libversion/profile/bind_fallback + audit whole-file skips

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -6182,6 +6182,22 @@ proc sqlite3_connection_pointer {db} {
     return "0x12345678"
 }
 
+proc sqlite3_libversion_number {args} {
+    # SQLite's C-API SQLITE_VERSION_NUMBER: the library version encoded as
+    # (major*1000000 + minor*1000 + patch). tclsqlite.test group 12 (tcl-12.1)
+    # scans `[db version]` back into that integer and asserts it equals
+    # [sqlite3_libversion_number]. Without this proc the file aborts mid-evaluation
+    # on the result-expression, before the SQL-reachable tail (17.x quote(),
+    # 18.120 typeof) ever runs.
+    #
+    # Return value MUST match the shim's reported version string ("3.46.0" from
+    # both `sqlite3 -version` and the `db version` method) so tcl-12.1 passes:
+    #   3*1000000 + 46*1000 + 0 = 3046000
+    # Same command-form-gap class as the -has-codec / do_not_use_codec stubs
+    # (#5289, PR #6080).
+    return 3046000
+}
+
 proc load_static_extension {db args} {
     # SQLite's test harness statically links a handful of test extensions
     # (totype, wholenumber, etc.) and loads them into a connection via
@@ -6605,6 +6621,39 @@ proc db {cmd args} {
         progress {
             # Set progress callback - not supported
             return
+        }
+        profile {
+            # Register an SQL profiler callback (db profile ?SCRIPT?). VibeSQL has
+            # no profiler; registering one is a pure side effect that the callee's
+            # own tests don't observe. Silently accept it so files that register a
+            # profiler and then keep testing (tclsqlite.test tcl-15.x) continue
+            # past the registration instead of aborting mid-file on an unknown
+            # db command. Same no-op class as authorizer/progress/trace.
+            return
+        }
+        bind_fallback {
+            # db bind_fallback ?CALLBACK?  (SQLite 3.28+): register a Tcl script
+            # invoked for otherwise-unbound SQL parameters, or (no args) query the
+            # currently-registered callback. VibeSQL's shim does not route unbound
+            # $params through a fallback during `db eval`, so we cannot honor the
+            # substitution semantics (tclsqlite.test 18.100/18.110/18.300 depend on
+            # that and fail as shim-gaps). But we can honor the *registration*
+            # surface so the file no longer aborts mid-evaluation and the
+            # SQL-reachable tail (18.120 `SELECT typeof($mno)`) runs:
+            #   - no args         -> return the stored callback (test 18.140)
+            #   - one arg         -> store it, return "" (18.200/18.910 register)
+            #   - two or more args-> the documented arg-count error (test 18.900)
+            if {[llength $args] == 0} {
+                if {[info exists ::db_bind_fallback]} {
+                    return $::db_bind_fallback
+                }
+                return ""
+            }
+            if {[llength $args] > 1} {
+                error "wrong # args: should be \"db bind_fallback ?CALLBACK?\""
+            }
+            set ::db_bind_fallback [lindex $args 0]
+            return ""
         }
         busy {
             # Set busy callback - not supported

--- a/scripts/verify_skips.py
+++ b/scripts/verify_skips.py
@@ -82,6 +82,70 @@ def parse_partial_skip_files(shim_content: str) -> dict:
     return partial
 
 
+def parse_whole_file_skips(shim_content: str) -> dict:
+    """Extract whole-file skip entries from the shim file.
+
+    These are the vibesql_skip_files array entries: test FILES (keyed by
+    basename, e.g. ``intreal``, ``capi3``) that are skipped in their entirety
+    because every test in them exercises a SQLite-internal / C-API surface with
+    no SQL-CLI-reachable coverage. This is the largest skip category and, until
+    now, was invisible to the audit (only vibesql_skip_tests and, since #6066,
+    vibesql_partial_skip_files were parsed).
+
+    Like parse_partial_skip_files, this is a DISCOVERABILITY report: the actual
+    skipping is enforced elsewhere in the shim, so we only surface the entries
+    rather than unskip-and-rerun them.
+
+    Resilient parsing (matching the #6066 partial-skip style):
+      * The array literal closes with a bare ``}`` at the start of a line, so we
+        capture up to ``\\n}`` rather than the first ``}`` (reasons contain
+        braces, e.g. ``{ run_test_suite fts3 }``).
+      * A reason may embed an escaped double-quote (``\\"sqlite3_shutdown\\"`` in
+        the sort2 entry), so the value pattern accepts escaped characters
+        instead of stopping at the first quote.
+    """
+    files = {}
+
+    match = re.search(
+        r'array set vibesql_skip_files \{(.*?)\n\}',
+        shim_content,
+        re.DOTALL,
+    )
+    if not match:
+        # Not an error: the array is optional (mirrors parse_partial_skip_files).
+        return files
+
+    section = match.group(1)
+
+    # Each entry: file_basename "reason". The reason is a TCL double-quoted
+    # string whose only escaped metacharacter of concern is an embedded \" —
+    # (?:[^"\\]|\\.)* consumes any escaped char (\", \\, ...) without terminating
+    # the value early. Anchored per-line so a stray brace inside a reason (e.g.
+    # "{ run_test_suite fts3 }") does not split an entry.
+    pattern = r'^\s*([a-zA-Z0-9_.-]+)\s+"((?:[^"\\]|\\.)*)"'
+    for line in section.split('\n'):
+        m = re.match(pattern, line.strip())
+        if m:
+            # Unescape \" so the reported reason reads naturally.
+            files[m.group(1)] = m.group(2).replace('\\"', '"')
+
+    return files
+
+
+def find_stale_whole_file_skips(file_skips: dict) -> list:
+    """Return skip-file basenames whose <basename>.test no longer exists.
+
+    A whole-file skip names a test FILE by basename; if the referenced
+    ``<basename>.test`` is gone from the test tree, the entry is stale and can be
+    removed. Cheap check: one filesystem stat per entry, no test execution.
+    """
+    stale = []
+    for basename in sorted(file_skips):
+        if not (TCL_TEST_DIR / f"{basename}.test").exists():
+            stale.append(basename)
+    return stale
+
+
 def get_test_file(test_name: str) -> str:
     """Determine which test file contains a test based on naming convention."""
     # Test names follow pattern: filename-N.N or filename-N.N.N
@@ -258,6 +322,18 @@ def main():
     if partial_files:
         print(f"Found {len(partial_files)} partial-file documented skip(s)")
 
+    # Parse whole-file skips (vibesql_skip_files) — the largest skip category.
+    # Discoverability record; enforced elsewhere in the shim, so not rerun-verified.
+    whole_files = parse_whole_file_skips(shim_content)
+    if whole_files:
+        print(f"Found {len(whole_files)} whole-file documented skip(s)")
+    stale_whole_files = find_stale_whole_file_skips(whole_files)
+    if stale_whole_files:
+        print(
+            f"WARNING: {len(stale_whole_files)} whole-file skip(s) reference a "
+            f".test file that no longer exists: {', '.join(stale_whole_files)}"
+        )
+
     # Categorize skips
     categories = categorize_skips(skips)
 
@@ -271,6 +347,13 @@ def main():
                 # Show a truncated reason so the record is auditable at a glance.
                 summary = reason if len(reason) <= 100 else reason[:97] + "..."
                 print(f"    - {fname}: {summary}")
+        if whole_files:
+            print(f"  WHOLE_FILE: {len(whole_files)} files (documented whole-file skips)")
+            for fname, reason in sorted(whole_files.items()):
+                # Show a truncated reason so the record is auditable at a glance.
+                summary = reason if len(reason) <= 100 else reason[:97] + "..."
+                flag = " [STALE: .test file missing]" if fname in stale_whole_files else ""
+                print(f"    - {fname}: {summary}{flag}")
         return 0
 
     # Determine which tests to check


### PR DESCRIPTION
## Summary

Two scripts-side TCL-conformance hygiene items (Part of #5779), both confined to `scripts/`:

1. **tclsqlite.test** aborted at group 11 on `sqlite3_libversion_number` (after PR #6080's `-has-codec` stub got it to 79 tests). Added the next round of harmless shims until the file runs to completion and its SQL-visible tail (17.x `quote()`, 18.120 `typeof`) executes.
2. **verify_skips.py** did not audit the largest skip category — the whole-file `vibesql_skip_files` array. Extended the parser to report it as a `WHOLE_FILE` category and flag stale entries.

## Changes

`scripts/tester_vibesql.tcl` (additive shims only):
- `sqlite3_libversion_number` proc returning **3046000** — matches the shim's `"3.46.0"` version string, so `tcl-12.1` (which scans `[db version]` into the integer and compares) **passes**.
- `db profile` — no-op callback registration (same class as `authorizer`/`progress`).
- `db bind_fallback` — honors the registration surface (store/return callback; documented arg-count error) so the file stops aborting mid-evaluation. The shim does not route unbound `$params` through the callback, so the substitution tests stay visible as shim-gap failures.

`scripts/verify_skips.py`:
- `parse_whole_file_skips()` — resilient parser for `vibesql_skip_files` (bare-brace close + embedded escaped quotes, matching the #6066 partial-skip style), surfaced as a new `WHOLE_FILE` category in `--list-categories`.
- `find_stale_whole_file_skips()` — flags entries whose `<basename>.test` no longer exists (one `stat` per entry, no test execution).

## tclsqlite.test before → after

| | Runs | Passed | Failed | Skipped | Terminal state |
|---|---|---|---|---|---|
| Before (main) | 72 | 23 | 49 | 7 | `incomplete` — ABORTED at group 11 (`sqlite3_libversion_number`) |
| After | 107 | 31 | 76 | 11 | runs to completion, **no marker** |

**SQL-visible tail now runs:** 17.0–17.5 (`quote()`) execute; **18.120 (`SELECT typeof($mno)` → null) PASSES**; `tcl-12.1`, `18.900`, `18.910`, `21.0` also pass. The file now reaches group 22.

### Remaining-failure classification (all shim-gap; no real SQL-reachable engine bug)

| Failure signature | Tests | Class |
|---|---|---|
| `no such function: add_i/ret_i/xCall/banu` | 17.0–17.5, 14.2, 9.5 | shim-gap — custom TCL SQL functions (`db func`) not registered by the shim |
| `near "@def"` / `near "-": syntax error` | 18.110, 18.300, 16.103, 20.0, 20.2 | shim-gap — unhandled `db eval` flags (`-withoutnulls`/`-asdict`) and `@param` bind-fallback substitution leak into SQL |
| `Unknown db command: onecolumn/erroroffset` | 3.2, 15.3, 22.1 | shim-gap — db methods intentionally out of this stub round |
| `no such table: t4` / `table t1 already exists` / transaction-state errors | 10.x, 11.x, 15.0, 16.100 | shim-gap — process-per-statement model can't hold TCL-driven cross-statement DB/transaction state |
| `invalid command name "tcl_objproc"` / `can't unset "D"` | 11.3.1, 20.1 | shim-gap — test-helper proc / `-asdict` not provided |
| assertion mismatches (tcl-1.x binding mechanics) | tcl-1.x | shim-gap — TCL result-form/binding emulation |

The `bind_fallback` substitution semantics (18.100/18.110/18.300) are deliberately **not** implemented — routing unbound params through a Tcl callback during `db eval` is a harness-emulation feature, not a stub, and out of scope. No new issues filed (per issue instructions: file only if a real SQL-reachable engine bug appears; none did).

## verify_skips.py output summary

`python3 scripts/verify_skips.py --list-categories` → **exit 0**:
```
Found 1392 skip entries
Found 1 partial-file documented skip(s)
Found 57 whole-file documented skip(s)
...
  PARTIAL_FILE: 1 files
  WHOLE_FILE: 57 files (documented whole-file skips)
    - all: ...  (57 entries, e.g. intreal, capi2..capi3e, fts3/rtree, incrblob*, sort2)
```
- All 57 `vibesql_skip_files` entries parsed, including the `sort2` entry whose reason embeds an escaped `\"sqlite3_shutdown\"` (correctly unescaped).
- No stale entries (all 57 `<basename>.test` files exist → no false WARNING). Stale detector verified to fire on a fabricated missing basename.
- Pre-existing categories unchanged (OTHER 1042, SQLITE_API 204, EXPLAIN 70, CASCADE 35, TEMP_TABLE 21, DB_CHANGES 14, EXPRESSION_INDEX 5, GLOB 1) and the `--category`/`--test` verification paths still work.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| tclsqlite.test runs past group 11 with the SQL tail executing | ✅ | Runs to completion (no marker); 17.x + 18.120 execute, 18.120 passes |
| Per-test results classified in the PR body | ✅ | Table above; all remaining failures shim-gap |
| verify_skips.py exits 0, reports WHOLE_FILE with current entries | ✅ | Exit 0; 57 WHOLE_FILE entries listed |
| Pre-existing categories unchanged | ✅ | Counts unchanged; `--category`/`--test` paths intact |
| No other file's handling changes | ✅ | Diff touches only `scripts/tester_vibesql.tcl` + `scripts/verify_skips.py`; changes are purely additive |
| select1.test regression-clean | ✅ | 188/188 pass, no aborts |

## Test Plan
- `tclsh scripts/tester_vibesql.tcl docs/reference/sqlite/test/tclsqlite.test --emit-detail` (before/after breakdown above)
- `tclsh scripts/tester_vibesql.tcl docs/reference/sqlite/test/select1.test --emit-detail` → 188/188
- `python3 scripts/verify_skips.py --list-categories` (exit 0, WHOLE_FILE reported)
- `python3 scripts/verify_skips.py --category GLOB` (pre-existing verification path intact)
- `cargo build --release -p vibesql-cli --bin vibesql` (green)

Closes #6120
Closes #6121