### PR TITLE
fix(executor): route REAL->TEXT rendering through the SQLite %!.15g path

### DIFF
--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/blob_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/blob_funcs.rs
@@ -273,7 +273,13 @@ fn format_float_for_quote(n: f64) -> String {
             "-9.0e+999".to_string()
         }
     } else {
-        n.to_string()
+        // Finite values must render through the SqlValue Display impl
+        // (format_f64), not the raw f64 `to_string()`. Rust's `f64::to_string`
+        // emits shortest-round-trip *fixed-point* text (e.g. a 300-digit
+        // expansion for 1e300), whereas SQLite's quote() uses %!.15g
+        // ("1.0e+300", "2.0"). Display already matches sqlite3 3.51, so route
+        // finite reals through it for parity.
+        SqlValue::Double(n).to_string()
     }
 }
 

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/pattern_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/pattern_funcs.rs
@@ -49,10 +49,13 @@ pub(crate) fn like(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         SqlValue::Bigint(i) => Cow::Owned(i.to_string()),
         SqlValue::Smallint(i) => Cow::Owned(i.to_string()),
         SqlValue::Unsigned(u) => Cow::Owned(u.to_string()),
-        SqlValue::Real(r) => Cow::Owned(r.to_string()),
-        SqlValue::Double(d) => Cow::Owned(d.to_string()),
-        SqlValue::Numeric(n) => Cow::Owned(n.to_string()),
-        SqlValue::Float(f) => Cow::Owned(f.to_string()),
+        // Floats coerce through the SqlValue Display impl (%!.15g), not the raw
+        // f64/f32 `to_string()`. SQLite compares against the %!.15g rendering, so
+        // `2.0 LIKE '2.0'` is true and `1e300 LIKE '1.0e+300'` is true.
+        SqlValue::Real(_)
+        | SqlValue::Double(_)
+        | SqlValue::Numeric(_)
+        | SqlValue::Float(_) => Cow::Owned(args[1].to_string()),
         SqlValue::Boolean(b) => Cow::Owned(if *b { "1".to_string() } else { "0".to_string() }),
         other => Cow::Owned(other.to_string()),
     };
@@ -127,10 +130,12 @@ pub(crate) fn glob(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         SqlValue::Bigint(i) => Cow::Owned(i.to_string()),
         SqlValue::Smallint(i) => Cow::Owned(i.to_string()),
         SqlValue::Unsigned(u) => Cow::Owned(u.to_string()),
-        SqlValue::Real(r) => Cow::Owned(r.to_string()),
-        SqlValue::Double(d) => Cow::Owned(d.to_string()),
-        SqlValue::Numeric(n) => Cow::Owned(n.to_string()),
-        SqlValue::Float(f) => Cow::Owned(f.to_string()),
+        // Floats coerce through the SqlValue Display impl (%!.15g), not the raw
+        // f64/f32 `to_string()`, matching SQLite's GLOB coercion.
+        SqlValue::Real(_)
+        | SqlValue::Double(_)
+        | SqlValue::Numeric(_)
+        | SqlValue::Float(_) => Cow::Owned(args[1].to_string()),
         SqlValue::Boolean(b) => Cow::Owned(if *b { "1".to_string() } else { "0".to_string() }),
         other => Cow::Owned(other.to_string()),
     };

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/simple.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/simple.rs
@@ -191,9 +191,18 @@ pub(super) fn evaluate(
                 vibesql_types::SqlValue::Null => return Ok(vibesql_types::SqlValue::Null),
                 vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
                 vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
-                vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
-                vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
-                vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+                // Floats render through the SqlValue Display impl (%!.15g), not
+                // the raw f64/f32 `to_string()`, so `1e300 LIKE '1.0e+300'`
+                // matches SQLite (fixed-point expansion would never match).
+                vibesql_types::SqlValue::Float(f) => {
+                    arcstr::ArcStr::from(vibesql_types::SqlValue::Float(f).to_string())
+                }
+                vibesql_types::SqlValue::Double(f) => {
+                    arcstr::ArcStr::from(vibesql_types::SqlValue::Double(f).to_string())
+                }
+                vibesql_types::SqlValue::Real(f) => {
+                    arcstr::ArcStr::from(vibesql_types::SqlValue::Real(f).to_string())
+                }
                 // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
                 vibesql_types::SqlValue::Boolean(b) => {
                     arcstr::ArcStr::from(if b { "1" } else { "0" })
@@ -217,9 +226,15 @@ pub(super) fn evaluate(
                 vibesql_types::SqlValue::Null => return Ok(vibesql_types::SqlValue::Null),
                 vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
                 vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
-                vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
-                vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
-                vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+                vibesql_types::SqlValue::Float(f) => {
+                    arcstr::ArcStr::from(vibesql_types::SqlValue::Float(f).to_string())
+                }
+                vibesql_types::SqlValue::Double(f) => {
+                    arcstr::ArcStr::from(vibesql_types::SqlValue::Double(f).to_string())
+                }
+                vibesql_types::SqlValue::Real(f) => {
+                    arcstr::ArcStr::from(vibesql_types::SqlValue::Real(f).to_string())
+                }
                 // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
                 vibesql_types::SqlValue::Boolean(b) => {
                     arcstr::ArcStr::from(if b { "1" } else { "0" })
@@ -321,9 +336,17 @@ pub(super) fn evaluate(
                 vibesql_types::SqlValue::Null => return Ok(vibesql_types::SqlValue::Null),
                 vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
                 vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
-                vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
-                vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
-                vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+                // Floats render through the SqlValue Display impl (%!.15g), not
+                // the raw f64/f32 `to_string()`, matching SQLite's GLOB coercion.
+                vibesql_types::SqlValue::Float(f) => {
+                    arcstr::ArcStr::from(vibesql_types::SqlValue::Float(*f).to_string())
+                }
+                vibesql_types::SqlValue::Double(f) => {
+                    arcstr::ArcStr::from(vibesql_types::SqlValue::Double(*f).to_string())
+                }
+                vibesql_types::SqlValue::Real(f) => {
+                    arcstr::ArcStr::from(vibesql_types::SqlValue::Real(*f).to_string())
+                }
                 vibesql_types::SqlValue::Boolean(b) => {
                     arcstr::ArcStr::from(if *b { "1" } else { "0" })
                 }
@@ -346,9 +369,15 @@ pub(super) fn evaluate(
                 vibesql_types::SqlValue::Null => return Ok(vibesql_types::SqlValue::Null),
                 vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
                 vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
-                vibesql_types::SqlValue::Float(f) => arcstr::ArcStr::from(f.to_string()),
-                vibesql_types::SqlValue::Double(f) => arcstr::ArcStr::from(f.to_string()),
-                vibesql_types::SqlValue::Real(f) => arcstr::ArcStr::from(f.to_string()),
+                vibesql_types::SqlValue::Float(f) => {
+                    arcstr::ArcStr::from(vibesql_types::SqlValue::Float(*f).to_string())
+                }
+                vibesql_types::SqlValue::Double(f) => {
+                    arcstr::ArcStr::from(vibesql_types::SqlValue::Double(*f).to_string())
+                }
+                vibesql_types::SqlValue::Real(f) => {
+                    arcstr::ArcStr::from(vibesql_types::SqlValue::Real(*f).to_string())
+                }
                 vibesql_types::SqlValue::Boolean(b) => {
                     arcstr::ArcStr::from(if *b { "1" } else { "0" })
                 }

--- a/crates/vibesql-executor/src/select/grouping/aggregates.rs
+++ b/crates/vibesql-executor/src/select/grouping/aggregates.rs
@@ -1454,10 +1454,16 @@ fn sql_value_to_string(value: &vibesql_types::SqlValue) -> String {
         vibesql_types::SqlValue::Bigint(i) => i.to_string(),
         vibesql_types::SqlValue::Smallint(i) => i.to_string(),
         vibesql_types::SqlValue::Unsigned(u) => u.to_string(),
-        vibesql_types::SqlValue::Numeric(n) => n.to_string(),
-        vibesql_types::SqlValue::Real(r) => r.to_string(),
-        vibesql_types::SqlValue::Double(d) => d.to_string(),
-        vibesql_types::SqlValue::Float(f) => f.to_string(),
+        // Floating-point values must render through the SqlValue Display impl
+        // (format_f64/format_f32), not the raw f64/f32 `to_string()`. Rust's
+        // `f64::to_string` emits shortest-round-trip *fixed-point* text
+        // (e.g. "2" for 2.0, a 300-digit expansion for 1e300), whereas SQLite's
+        // group_concat/TEXT rendering uses %!.15g ("2.0", "1.0e+300"). Display
+        // already matches sqlite3 3.51, so route floats through it for parity.
+        vibesql_types::SqlValue::Numeric(_)
+        | vibesql_types::SqlValue::Real(_)
+        | vibesql_types::SqlValue::Double(_)
+        | vibesql_types::SqlValue::Float(_) => value.to_string(),
         vibesql_types::SqlValue::Boolean(b) => {
             if *b {
                 "1".to_string()


### PR DESCRIPTION
## Summary

`group_concat()` and `quote()` rendered f64 values via raw `to_string()`, which emits Rust's shortest-round-trip **fixed-point** text (`2` for `2.0`, a 300-digit expansion for `1e300`). SQLite renders REAL→TEXT with `%!.15g` (`2.0`, `1.0e+300`). This routes both through the `SqlValue` Display impl (`format_f64`) that PR #6100 established for CAST, matching sqlite3 3.51 byte-for-byte.

While auditing raw-float `to_string()` stragglers in value-rendering contexts (per the issue's request), the same bug was found in the LIKE/GLOB **text coercion** paths and fixed there too, since #6100 only routed CAST (not the LIKE/GLOB function/aggregate coercion) through Display.

## Changes

- `select/grouping/aggregates.rs` — `sql_value_to_string` (the `group_concat` renderer, the latent copy #6049 flagged): route `Real`/`Double`/`Float`/`Numeric` through `value.to_string()` (Display / `format_f64`).
- `evaluator/functions/sqlite_compat/blob_funcs.rs` — `format_float_for_quote` (used by `quote()`): route finite reals through Display; infinity (`9.0e+999`/`-9.0e+999`) and NaN special-casing preserved.
- `evaluator/functions/sqlite_compat/pattern_funcs.rs` — `like()`/`glob()` text coercion: route floats through Display so `1e300 LIKE '1.0e+300'` matches SQLite.
- `select/executor/aggregation/evaluation/simple.rs` — aggregate/HAVING LIKE and GLOB coercion: same Display routing, fixing `... GROUP BY x HAVING x LIKE '1.0e+300'`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `SELECT group_concat(2.0)` → `2.0` | ✅ | Matches sqlite3 3.51 |
| `SELECT quote(1e300)` → `1.0e+300` | ✅ | Matches sqlite3 3.51 |
| Differential group_concat matrix (2.0/1e300/0.5/-0.0/1e-5) | ✅ | `2.0,1.0e+300,0.5,0.0,1.0e-05` byte-for-byte vs sqlite3 |
| Differential quote matrix (same values) | ✅ | `2.0 \| 1.0e+300 \| 0.5 \| 0.0 \| 1.0e-05` byte-for-byte vs sqlite3 |
| quote infinity | ✅ | `9.0e+999` / `-9.0e+999` preserved |
| atof1 stays 7/0 | ✅ | 7 passed, 0 failed |
| func/cast/expr TCL, no regressions | ✅ | cast 122/0, expr 638/0, func 14546/1 (only pre-existing func-7.1 `last_insert_rowid` harness quirk — unrelated; func's own `quote(4.2e+859)`/`group_concat` assertions all pass) |
| `cargo test -p vibesql-executor` green | ✅ | All test binaries pass, 0 failed |

## Test Plan

- 13-case differential spot-matrix vs `sqlite3` 3.51.0: all byte-for-byte identical (group_concat + quote of 2.0/1e300/0.5/-0.0/1e-5, quote ±inf, LIKE/GLOB coercion, HAVING LIKE).
- `cargo test -p vibesql-executor`: green (0 failed).
- TCL: atof1 7/0, cast 122/0, expr 638/0, func 14546/1 (pre-existing `func-7.1` `last_insert_rowid` shim quirk, not a regression).
- `cargo clippy -p vibesql-executor`: no new warnings in the four changed files.

Closes #6117