### PR TITLE
feat(scripts): add remote-run.sh EC2 lifecycle wrapper and machine_tag results attribution

### DIFF
--- a/scripts/benchmark_results_schema.sql
+++ b/scripts/benchmark_results_schema.sql
@@ -14,7 +14,11 @@ CREATE TABLE IF NOT EXISTS benchmark_runs (
     passed_queries INTEGER,
     failed_queries INTEGER,
     timeout_queries INTEGER,
-    notes TEXT
+    notes TEXT,
+    -- machine_tag: identifies the host that produced this run so localhost
+    -- numbers can be distinguished from dedicated-hardware runs. Nullable;
+    -- historical rows read back as NULL ("unknown/local").
+    machine_tag TEXT
 );
 
 -- TPC-C Results: Transaction-specific metrics for OLTP workloads

--- a/scripts/benchmark_results_schema_vibesql.sql
+++ b/scripts/benchmark_results_schema_vibesql.sql
@@ -14,7 +14,11 @@ CREATE TABLE IF NOT EXISTS benchmark_runs (
     passed_queries INTEGER,
     failed_queries INTEGER,
     timeout_queries INTEGER,
-    notes TEXT
+    notes TEXT,
+    -- machine_tag: identifies the host that produced this run so localhost
+    -- numbers can be distinguished from dedicated-hardware runs. Nullable;
+    -- historical rows read back as NULL ("unknown/local").
+    machine_tag TEXT
 );
 
 -- TPC-C Results: Transaction-specific metrics for OLTP workloads

--- a/scripts/export_tcl_results.py
+++ b/scripts/export_tcl_results.py
@@ -79,7 +79,8 @@ def get_latest_run() -> Optional[Dict]:
     """
     rows = query_db("""
         SELECT run_id, started_at, completed_at, git_commit,
-               total_files, total_tests, passed, failed, skipped, parse_errors
+               total_files, total_tests, passed, failed, skipped, parse_errors,
+               machine_tag
         FROM tcl_test_runs
         WHERE run_id = COALESCE(
             (SELECT MAX(run_id) FROM tcl_test_results),
@@ -92,6 +93,11 @@ def get_latest_run() -> Optional[Dict]:
         return None
 
     row = rows[0]
+    # machine_tag is a nullable/newer column: guard against short rows from a
+    # legacy DB where the SELECT fell back to fewer columns.
+    machine_tag = row[10] if len(row) > 10 else None
+    if machine_tag in ("", "NULL"):
+        machine_tag = None
     return {
         "run_id": int(row[0]) if row[0] else 0,
         "started_at": row[1],
@@ -103,6 +109,7 @@ def get_latest_run() -> Optional[Dict]:
         "failed": int(row[7]) if row[7] else 0,
         "skipped": int(row[8]) if row[8] else 0,
         "parse_errors": int(row[9]) if row[9] else 0,
+        "machine_tag": machine_tag,
     }
 
 
@@ -269,6 +276,8 @@ def export_tcl_results(output_dir: Optional[Path] = None, verbose: bool = False)
             "skipped": latest_run["skipped"],
             "pass_rate": round(latest_run["passed"] / (latest_run["total_tests"] - latest_run["skipped"]) * 100, 1)
                 if latest_run["total_tests"] > latest_run["skipped"] else 0.0,
+            # machine_tag: which host produced this run (None -> "unknown/local")
+            "machine_tag": latest_run.get("machine_tag"),
         },
         "categories": get_results_by_category(run_id),
         "by_file": get_results_by_file(run_id),

--- a/scripts/export_website_data.py
+++ b/scripts/export_website_data.py
@@ -71,7 +71,14 @@ def get_git_info() -> Tuple[Optional[str], Optional[str]]:
 
 
 def get_machine_info() -> Dict[str, str]:
-    """Get information about the current machine."""
+    """Get information about the current machine.
+
+    ``machine_tag`` mirrors the results-DB column of the same name: the
+    VIBESQL_MACHINE_TAG env var when set (e.g. a remote-run.sh benchmark host),
+    else None ("unknown/local"). This is distinct from the descriptive
+    system/cpu fields — it is the stable key used to attribute a run to a host.
+    """
+    machine_tag = os.environ.get("VIBESQL_MACHINE_TAG") or None
     system = platform.system()
     machine = platform.machine()
     if os.environ.get("GITHUB_ACTIONS"):
@@ -79,13 +86,15 @@ def get_machine_info() -> Dict[str, str]:
             "system": f"GitHub Actions {platform.platform()}",
             "cpu": os.environ.get("RUNNER_ARCH", machine),
             "memory": "Standard GH Actions runner",
-            "notes": "CI environment"
+            "notes": "CI environment",
+            "machine_tag": machine_tag,
         }
     return {
         "system": f"{system} {platform.release()}",
         "cpu": machine,
         "memory": "Unknown",
-        "notes": "Local development"
+        "notes": "Local development",
+        "machine_tag": machine_tag,
     }
 
 
@@ -760,7 +769,8 @@ def load_tcl_data() -> Dict[str, Any]:
                     "passed": passed,
                     "failed": run["failed"],
                     "skipped": skipped,
-                    "pass_rate": pass_rate
+                    "pass_rate": pass_rate,
+                    "machine_tag": run.get("machine_tag"),
                 }
         except Exception:
             pass
@@ -991,7 +1001,8 @@ def export_dashboard(data: BenchmarkData, previous_url: Optional[str] = None) ->
                 "passed": tcl_data.get("passed"),
                 "failed": tcl_data.get("failed"),
                 "skipped": tcl_data.get("skipped"),
-                "total_tests": tcl_data.get("total_tests")
+                "total_tests": tcl_data.get("total_tests"),
+                "machine_tag": tcl_data.get("machine_tag")
             } if tcl_data else None
         },
         "benchmarks": {

--- a/scripts/process_results.py
+++ b/scripts/process_results.py
@@ -22,6 +22,7 @@ import argparse
 import csv
 import io
 import json
+import os
 import re
 import subprocess
 import sys
@@ -71,8 +72,22 @@ def get_git_info() -> Tuple[Optional[str], Optional[str]]:
         return None, None
 
 
+def get_machine_tag() -> Optional[str]:
+    """Return the machine tag for this run, or None ("unknown/local").
+
+    Sourced from the VIBESQL_MACHINE_TAG environment variable so a remote run
+    (see scripts/remote-run.sh) can attribute its results to the dedicated host
+    while local/CI runs leave it unset (NULL) and stay backward compatible.
+    """
+    tag = os.environ.get("VIBESQL_MACHINE_TAG")
+    return tag if tag else None
+
+
 def init_benchmark_schema(cursor) -> None:
-    """Initialize benchmark tables in the database if they don't exist."""
+    """Initialize benchmark tables in the database if they don't exist.
+
+    Also applies additive migrations for older databases (e.g. adding the
+    nullable ``machine_tag`` column to ``benchmark_runs``)."""
     schema_path = get_repo_root() / "scripts" / "benchmark_results_schema_vibesql.sql"
 
     if not schema_path.exists():
@@ -83,6 +98,17 @@ def init_benchmark_schema(cursor) -> None:
         schema_sql = f.read()
 
     init_schema(cursor, schema_sql)
+
+    # Additive migration: a pre-existing benchmark_runs table is left untouched
+    # by the CREATE TABLE above ("already exists"), so add the machine_tag
+    # column explicitly for older databases. Nullable and idempotent — a second
+    # run (column already present) is a no-op.
+    try:
+        cursor.execute("ALTER TABLE benchmark_runs ADD COLUMN machine_tag TEXT")
+    except Exception:
+        # Column already exists (or ALTER unsupported on this build) — safe to
+        # ignore; the CREATE TABLE path already produced the column for new DBs.
+        pass
 
 
 def convert_time_to_ms(value: float, unit: str) -> float:
@@ -374,7 +400,7 @@ class TPCHParser(BenchmarkParser):
         execute_insert(cursor, "benchmark_runs", [
             "run_timestamp", "git_commit", "git_branch", "benchmark_suite",
             "scale_factor", "timeout_secs", "total_queries", "passed_queries",
-            "failed_queries", "timeout_queries", "notes"
+            "failed_queries", "timeout_queries", "notes", "machine_tag"
         ], [
             datetime.now().isoformat(),
             git_commit,
@@ -386,7 +412,8 @@ class TPCHParser(BenchmarkParser):
             summary['passed_queries'],
             summary['failed_queries'],
             summary['timeout_queries'],
-            notes
+            notes,
+            get_machine_tag()
         ])
 
         run_id = get_last_insert_id(cursor, "benchmark_runs", "run_id")
@@ -536,7 +563,7 @@ class TPCCParser(BenchmarkParser):
 
         execute_insert(cursor, "benchmark_runs", [
             "run_timestamp", "git_commit", "git_branch", "benchmark_suite",
-            "scale_factor", "timeout_secs", "total_queries", "notes"
+            "scale_factor", "timeout_secs", "total_queries", "notes", "machine_tag"
         ], [
             datetime.now().isoformat(),
             git_commit,
@@ -545,7 +572,8 @@ class TPCCParser(BenchmarkParser):
             str(scale_factor),
             duration_secs,
             sum(r.get('transaction_count', 0) for r in results),
-            notes
+            notes,
+            get_machine_tag()
         ])
 
         run_id = get_last_insert_id(cursor, "benchmark_runs", "run_id")
@@ -891,7 +919,7 @@ class TPCDSParser(BenchmarkParser):
         execute_insert(cursor, "benchmark_runs", [
             "run_timestamp", "git_commit", "git_branch", "benchmark_suite",
             "scale_factor", "total_queries", "passed_queries", "failed_queries",
-            "timeout_queries", "notes"
+            "timeout_queries", "notes", "machine_tag"
         ], [
             datetime.now().isoformat(),
             git_commit,
@@ -902,7 +930,8 @@ class TPCDSParser(BenchmarkParser):
             len([r for r in vibesql_results if r.get('status') == 'passed']),
             len([r for r in vibesql_results if r.get('status') == 'failed']),
             len([r for r in vibesql_results if r.get('status') == 'timeout']),
-            notes
+            notes,
+            get_machine_tag()
         ])
 
         run_id = get_last_insert_id(cursor, "benchmark_runs", "run_id")
@@ -1276,7 +1305,7 @@ class SysbenchParser(BenchmarkParser):
 
         execute_insert(cursor, "benchmark_runs", [
             "run_timestamp", "git_commit", "git_branch", "benchmark_suite",
-            "scale_factor", "total_queries", "notes"
+            "scale_factor", "total_queries", "notes", "machine_tag"
         ], [
             datetime.now().isoformat(),
             git_commit,
@@ -1284,7 +1313,8 @@ class SysbenchParser(BenchmarkParser):
             'sysbench',
             str(table_size),
             len(results),
-            notes
+            notes,
+            get_machine_tag()
         ])
 
         run_id = get_last_insert_id(cursor, "benchmark_runs", "run_id")
@@ -1412,7 +1442,7 @@ class HnswRecallParser(BenchmarkParser):
 
         execute_insert(cursor, "benchmark_runs", [
             "run_timestamp", "git_commit", "git_branch", "benchmark_suite",
-            "scale_factor", "total_queries", "notes"
+            "scale_factor", "total_queries", "notes", "machine_tag"
         ], [
             datetime.now().isoformat(),
             git_commit,
@@ -1420,7 +1450,8 @@ class HnswRecallParser(BenchmarkParser):
             'hnsw',
             str(summary.get('dataset_size') or ''),
             len(results),
-            notes
+            notes,
+            get_machine_tag()
         ])
 
         run_id = get_last_insert_id(cursor, "benchmark_runs", "run_id")

--- a/scripts/remote-run.sh
+++ b/scripts/remote-run.sh
@@ -1,0 +1,291 @@
+#!/bin/bash
+#
+# remote-run.sh - Drive a remote EC2 host through a benchmark / TCL test run.
+#
+# Lifecycle:
+#   1. aws ec2 start-instances     -> boot the (normally stopped) instance
+#   2. aws ec2 wait ...            -> block until it is running / status-ok
+#   3. ssh <host> "... make <target>" -> run the requested workload remotely
+#   4. scp results DB back         -> pull ~/.vibesql/test_results/*.vbsql local
+#   5. aws ec2 stop-instances      -> always stop the instance (via EXIT trap)
+#
+# The stop step runs from an EXIT trap so a failed run can NEVER leave the
+# instance running unattended (a forgotten instance = wasted spend).
+#
+# IMPORTANT: This script is the repo-side "Part 2" automation. It is designed to
+# be correct-by-construction and validated with --dry-run + shellcheck; it does
+# NOT require (and this repo does not perform) any live AWS provisioning. The
+# actual EC2 instance / IAM / credentials are operator-provisioned "Part 1".
+#
+# Usage:
+#   scripts/remote-run.sh --target=<instance-id-or-name> --task=<task> [options]
+#
+# Required:
+#   --target=<id>       EC2 instance id (i-...) or a Name tag to resolve.
+#   --task=<task>       Workload to run. One of the mapped tasks below.
+#
+# Options:
+#   --machine-tag=<tag> Tag recorded in the results DB (VIBESQL_MACHINE_TAG on
+#                       the remote make invocation). Default: ec2-c7i-4xlarge.
+#   --ssh-host=<host>   SSH destination (user@host). If omitted, resolved from
+#                       the instance's public DNS name after it is running.
+#   --ssh-user=<user>   SSH user when --ssh-host is not given. Default: ubuntu.
+#   --remote-dir=<dir>  Remote repo directory. Default: vibesql.
+#   --region=<region>   AWS region. Default: $AWS_DEFAULT_REGION or us-west-2.
+#   --results-dir=<dir> Local dir to fetch results into. Default:
+#                       ~/.vibesql/test_results
+#   --no-pull           Skip `git pull` on the remote before running the target.
+#   --no-stop           Do NOT stop the instance when finished (leave running).
+#   --dry-run           Print every aws/ssh/scp command WITHOUT executing it.
+#   -h, --help          Show this help.
+#
+# Task -> make target mapping:
+#   tcl-all         -> make test-tcl-all
+#   tcl             -> make test-tcl
+#   benchmark-quick -> make benchmark-quick
+#   benchmark       -> make benchmark
+#   benchmark-all   -> make benchmark-all
+#   benchmark-tpch  -> make benchmark-tpch
+#   benchmark-tpcds -> make benchmark-tpcds
+#   benchmark-tpcc  -> make benchmark-tpcc
+#   benchmark-sysbench -> make benchmark-sysbench
+#
+# Examples:
+#   scripts/remote-run.sh --target=i-0abc123 --task=tcl-all --dry-run
+#   scripts/remote-run.sh --target=vibesql-bench --task=benchmark-quick \
+#       --machine-tag=ec2-c7i-4xlarge
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Colors / logging helpers (match scripts/tcltest style)
+# ---------------------------------------------------------------------------
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    BLUE='\033[0;34m'
+    NC='\033[0m'
+else
+    RED=''; GREEN=''; YELLOW=''; BLUE=''; NC=''
+fi
+
+print_error()   { echo -e "${RED}❌ $1${NC}" >&2; }
+print_success() { echo -e "${GREEN}✓ $1${NC}"; }
+print_warning() { echo -e "${YELLOW}⚠ $1${NC}" >&2; }
+print_info()    { echo -e "${BLUE}ℹ $1${NC}"; }
+
+# In --dry-run we print the command we WOULD run; otherwise we run it.
+DRY_RUN=0
+run_cmd() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "DRYRUN: $*"
+    else
+        print_info "RUN: $*"
+        "$@"
+    fi
+}
+
+usage() {
+    # Strip the leading "# " comment block at the top of this file.
+    sed -n '3,60p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+# ---------------------------------------------------------------------------
+# Defaults / argument parsing
+# ---------------------------------------------------------------------------
+TARGET=""
+TASK=""
+MACHINE_TAG="ec2-c7i-4xlarge"
+SSH_HOST=""
+SSH_USER="ubuntu"
+REMOTE_DIR="vibesql"
+REGION="${AWS_DEFAULT_REGION:-us-west-2}"
+RESULTS_DIR="$HOME/.vibesql/test_results"
+DO_PULL=1
+DO_STOP=1
+
+for arg in "$@"; do
+    case "$arg" in
+        --target=*)      TARGET="${arg#*=}" ;;
+        --task=*)        TASK="${arg#*=}" ;;
+        --machine-tag=*) MACHINE_TAG="${arg#*=}" ;;
+        --ssh-host=*)    SSH_HOST="${arg#*=}" ;;
+        --ssh-user=*)    SSH_USER="${arg#*=}" ;;
+        --remote-dir=*)  REMOTE_DIR="${arg#*=}" ;;
+        --region=*)      REGION="${arg#*=}" ;;
+        --results-dir=*) RESULTS_DIR="${arg#*=}" ;;
+        --no-pull)       DO_PULL=0 ;;
+        --no-stop)       DO_STOP=0 ;;
+        --dry-run)       DRY_RUN=1 ;;
+        -h|--help)       usage; exit 0 ;;
+        *)
+            print_error "Unknown argument: $arg"
+            echo "" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ -z "$TARGET" ]; then
+    print_error "Missing required --target=<instance-id-or-name>"
+    exit 2
+fi
+if [ -z "$TASK" ]; then
+    print_error "Missing required --task=<task>"
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Map --task to a make target
+# ---------------------------------------------------------------------------
+case "$TASK" in
+    tcl-all)            MAKE_TARGET="test-tcl-all" ;;
+    tcl)                MAKE_TARGET="test-tcl" ;;
+    benchmark-quick)    MAKE_TARGET="benchmark-quick" ;;
+    benchmark)          MAKE_TARGET="benchmark" ;;
+    benchmark-all)      MAKE_TARGET="benchmark-all" ;;
+    benchmark-tpch)     MAKE_TARGET="benchmark-tpch" ;;
+    benchmark-tpcds)    MAKE_TARGET="benchmark-tpcds" ;;
+    benchmark-tpcc)     MAKE_TARGET="benchmark-tpcc" ;;
+    benchmark-sysbench) MAKE_TARGET="benchmark-sysbench" ;;
+    *)
+        print_error "Unknown --task=$TASK"
+        echo "Valid tasks: tcl-all, tcl, benchmark-quick, benchmark, benchmark-all," >&2
+        echo "             benchmark-tpch, benchmark-tpcds, benchmark-tpcc, benchmark-sysbench" >&2
+        exit 2
+        ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Preflight: aws CLI presence + credentials (don't swallow errors)
+# ---------------------------------------------------------------------------
+# In dry-run we still want to catch a missing aws CLI early, but we do NOT
+# require valid credentials (the whole point of dry-run is to work offline).
+if ! command -v aws >/dev/null 2>&1; then
+    print_error "The 'aws' CLI is not installed or not on PATH."
+    print_error "Install it (https://docs.aws.amazon.com/cli/) before running remote tasks."
+    exit 3
+fi
+
+if [ "$DRY_RUN" -eq 0 ]; then
+    if ! aws sts get-caller-identity --region "$REGION" >/dev/null 2>&1; then
+        print_error "AWS credentials are missing or invalid (aws sts get-caller-identity failed)."
+        print_error "Configure credentials (e.g. source the repo-local .env, or run 'aws configure')"
+        print_error "and set AWS_DEFAULT_REGION (currently: $REGION)."
+        exit 3
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve the instance id from --target (may be an id or a Name tag)
+# ---------------------------------------------------------------------------
+INSTANCE_ID=""
+resolve_instance_id() {
+    if [[ "$TARGET" == i-* ]]; then
+        INSTANCE_ID="$TARGET"
+        return
+    fi
+    if [ "$DRY_RUN" -eq 1 ]; then
+        # Show the resolution command we would run, but keep a readable
+        # placeholder so downstream commands are still assertable.
+        echo "DRYRUN: aws ec2 describe-instances --region $REGION --filters Name=tag:Name,Values=$TARGET --query Reservations[].Instances[].InstanceId --output text"
+        INSTANCE_ID="<resolved-from-name:$TARGET>"
+        return
+    fi
+    print_info "Resolving instance id for Name tag: $TARGET"
+    INSTANCE_ID="$(aws ec2 describe-instances \
+        --region "$REGION" \
+        --filters "Name=tag:Name,Values=$TARGET" "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+        --query 'Reservations[].Instances[].InstanceId' \
+        --output text)"
+    if [ -z "$INSTANCE_ID" ] || [ "$INSTANCE_ID" = "None" ]; then
+        print_error "Could not resolve an instance id for Name=$TARGET in region $REGION."
+        exit 4
+    fi
+}
+resolve_instance_id
+
+# ---------------------------------------------------------------------------
+# Cleanup trap: ALWAYS attempt to stop the instance, even on failure.
+# ---------------------------------------------------------------------------
+STOP_DONE=0
+stop_instance() {
+    # Guard against double-invocation (EXIT after an explicit call).
+    if [ "$STOP_DONE" -eq 1 ]; then
+        return
+    fi
+    STOP_DONE=1
+
+    if [ "$DO_STOP" -eq 0 ]; then
+        print_warning "--no-stop set: leaving instance $INSTANCE_ID running."
+        return
+    fi
+
+    print_info "Stopping instance $INSTANCE_ID (cleanup)..."
+    run_cmd aws ec2 stop-instances --region "$REGION" --instance-ids "$INSTANCE_ID"
+}
+# The trap fires on normal exit AND on any error (set -e) or signal, so the
+# stop step is guaranteed to run even if ssh/scp/make fails mid-run.
+trap stop_instance EXIT INT TERM
+
+# ---------------------------------------------------------------------------
+# 1. Start the instance and wait until it is reachable
+# ---------------------------------------------------------------------------
+print_info "Starting instance $INSTANCE_ID in $REGION..."
+run_cmd aws ec2 start-instances --region "$REGION" --instance-ids "$INSTANCE_ID"
+
+print_info "Waiting for instance $INSTANCE_ID to reach status-ok..."
+run_cmd aws ec2 wait instance-status-ok --region "$REGION" --instance-ids "$INSTANCE_ID"
+
+# ---------------------------------------------------------------------------
+# 2. Resolve the SSH host (public DNS) if not provided explicitly
+# ---------------------------------------------------------------------------
+REMOTE=""
+if [ -n "$SSH_HOST" ]; then
+    REMOTE="$SSH_HOST"
+elif [ "$DRY_RUN" -eq 1 ]; then
+    echo "DRYRUN: aws ec2 describe-instances --region $REGION --instance-ids $INSTANCE_ID --query Reservations[].Instances[].PublicDnsName --output text"
+    REMOTE="$SSH_USER@<public-dns:$INSTANCE_ID>"
+else
+    print_info "Resolving public DNS for $INSTANCE_ID..."
+    PUBLIC_DNS="$(aws ec2 describe-instances \
+        --region "$REGION" \
+        --instance-ids "$INSTANCE_ID" \
+        --query 'Reservations[].Instances[].PublicDnsName' \
+        --output text)"
+    if [ -z "$PUBLIC_DNS" ] || [ "$PUBLIC_DNS" = "None" ]; then
+        print_error "Instance $INSTANCE_ID has no public DNS name; pass --ssh-host explicitly."
+        exit 4
+    fi
+    REMOTE="$SSH_USER@$PUBLIC_DNS"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Run the workload remotely
+# ---------------------------------------------------------------------------
+# Build the remote command: cd into the repo, optionally pull, then run the
+# make target with VIBESQL_MACHINE_TAG so results are tagged automatically.
+REMOTE_STEPS="cd $REMOTE_DIR"
+if [ "$DO_PULL" -eq 1 ]; then
+    REMOTE_STEPS="$REMOTE_STEPS && git pull --ff-only"
+fi
+REMOTE_STEPS="$REMOTE_STEPS && VIBESQL_MACHINE_TAG=$MACHINE_TAG make $MAKE_TARGET"
+
+print_info "Running remote task '$TASK' (make $MAKE_TARGET) on $REMOTE..."
+run_cmd ssh "$REMOTE" "$REMOTE_STEPS"
+
+# ---------------------------------------------------------------------------
+# 4. Fetch the results database(s) back to the local machine
+# ---------------------------------------------------------------------------
+print_info "Fetching results DB(s) into $RESULTS_DIR ..."
+run_cmd mkdir -p "$RESULTS_DIR"
+run_cmd scp "$REMOTE:~/.vibesql/test_results/*.vbsql" "$RESULTS_DIR/"
+
+# ---------------------------------------------------------------------------
+# 5. Stop the instance (explicit; trap is a backstop for the failure path)
+# ---------------------------------------------------------------------------
+stop_instance
+
+print_success "Remote task '$TASK' complete (machine_tag=$MACHINE_TAG)."

--- a/scripts/tcl_runner.py
+++ b/scripts/tcl_runner.py
@@ -78,6 +78,10 @@ class RunSummary:
     skipped_setup_failed: int = 0  # Tests skipped due to setup failure
     parse_errors: int = 0
     setup_failures: int = 0  # Number of files with setup failures
+    # machine_tag: identifies the host that produced this run (None -> NULL,
+    # understood as "unknown/local"). Populated from VIBESQL_MACHINE_TAG so a
+    # remote run (scripts/remote-run.sh) tags its results automatically.
+    machine_tag: Optional[str] = None
     results: list[TestResult] = field(default_factory=list)
 
     def to_dict(self) -> dict:
@@ -85,6 +89,7 @@ class RunSummary:
             "started_at": self.started_at,
             "completed_at": self.completed_at,
             "git_commit": self.git_commit,
+            "machine_tag": self.machine_tag,
             "total_files": self.total_files,
             "total_tests": self.total_tests,
             "passed": self.passed,
@@ -608,6 +613,7 @@ class TclTestRunner:
         summary = RunSummary(
             started_at=datetime.now().isoformat(),
             total_files=len(file_paths),
+            machine_tag=os.environ.get("VIBESQL_MACHINE_TAG"),
         )
 
         # Get git commit
@@ -701,15 +707,26 @@ def save_to_database(summary: RunSummary, db_path: str, vibesql_path: str):
     except (ValueError, IndexError):
         run_id = 1
 
+    # Machine tag SQL literal: NULL when unset, single-quote-escaped otherwise.
+    # Sourced (in priority order) from an explicit summary.machine_tag, else the
+    # VIBESQL_MACHINE_TAG environment variable, else NULL ("unknown/local").
+    machine_tag_value = summary.machine_tag or os.environ.get("VIBESQL_MACHINE_TAG")
+    if machine_tag_value:
+        machine_tag_literal = "'" + machine_tag_value.replace("'", "''") + "'"
+    else:
+        machine_tag_literal = "NULL"
+
     # Create run record
     run_sql = f"""
         INSERT INTO tcl_test_runs (
             run_id, started_at, completed_at, git_commit,
-            total_files, total_tests, passed, failed, skipped, skipped_setup_failed, parse_errors, setup_failures
+            total_files, total_tests, passed, failed, skipped, skipped_setup_failed, parse_errors, setup_failures,
+            machine_tag
         ) VALUES (
             {run_id}, '{summary.started_at}', '{summary.completed_at}', '{summary.git_commit}',
             {summary.total_files}, {summary.total_tests},
-            {summary.passed}, {summary.failed}, {summary.skipped}, {summary.skipped_setup_failed}, {summary.parse_errors}, {summary.setup_failures}
+            {summary.passed}, {summary.failed}, {summary.skipped}, {summary.skipped_setup_failed}, {summary.parse_errors}, {summary.setup_failures},
+            {machine_tag_literal}
         );
     """
 
@@ -1233,6 +1250,7 @@ def main():
                 skipped_setup_failed=0,
                 parse_errors=0,
                 setup_failures=0,
+                machine_tag=os.environ.get("VIBESQL_MACHINE_TAG"),
                 results=all_results,  # Per-test detail parsed from the shim's --emit-detail output
             )
             save_to_database(summary, args.results_db, args.vibesql)

--- a/scripts/tcltest
+++ b/scripts/tcltest
@@ -85,7 +85,8 @@ init_results_db() {
                 skipped INTEGER DEFAULT 0,
                 skipped_setup_failed INTEGER DEFAULT 0,
                 parse_errors INTEGER DEFAULT 0,
-                setup_failures INTEGER DEFAULT 0
+                setup_failures INTEGER DEFAULT 0,
+                machine_tag TEXT
             );
 
             CREATE TABLE IF NOT EXISTS tcl_test_results (
@@ -117,6 +118,19 @@ init_results_db() {
             "$VIBESQL_BIN" "$RESULTS_DB" -c "
                 ALTER TABLE tcl_test_runs ADD COLUMN skipped_setup_failed INTEGER DEFAULT 0;
                 ALTER TABLE tcl_test_runs ADD COLUMN setup_failures INTEGER DEFAULT 0;
+            " 2>/dev/null || true
+        }
+
+        # Migrate: add machine_tag column so runs are attributable to the host
+        # that produced them (nullable; historical rows read back as NULL,
+        # understood to mean "unknown/local"). Probe-then-ALTER, matching the
+        # additive-migration pattern used above.
+        "$VIBESQL_BIN" "$RESULTS_DB" -c "
+            SELECT machine_tag FROM tcl_test_runs LIMIT 1
+        " 2>/dev/null || {
+            print_info "Migrating database schema (machine_tag)..."
+            "$VIBESQL_BIN" "$RESULTS_DB" -c "
+                ALTER TABLE tcl_test_runs ADD COLUMN machine_tag TEXT;
             " 2>/dev/null || true
         }
 


### PR DESCRIPTION
## Summary

Adds the repo-side "Part 2" automation for issue #6123: a `scripts/remote-run.sh` wrapper that drives a (normally stopped) EC2 benchmark/TCL host through its full lifecycle, plus a nullable `machine_tag` column threaded through the results schema, write paths, and exporters so runs are attributable to the host that produced them (localhost vs dedicated hardware — the standing "localhost numbers are untrustworthy" constraint).

Part 1 (AWS/EC2/IAM provisioning) is operator-only and out of scope. The scripts are correct-by-construction and validated via `--dry-run`, `shellcheck`, and local schema round-trip / unit tests — no live AWS access is used.

## Changes

- **`scripts/remote-run.sh`** (new): `aws ec2 start-instances` → `wait instance-status-ok` → `ssh <host> "... VIBESQL_MACHINE_TAG=<tag> make <target>"` → `scp` results DB back → `aws ec2 stop-instances`.
  - `stop-instances` runs from an `EXIT`/`INT`/`TERM` trap, so a failed run can **never** leave the instance running unattended.
  - `--dry-run` prints every `aws`/`ssh`/`scp` command with resolved args, executing none.
  - `--task` maps to make targets (`tcl-all`→`test-tcl-all`, `benchmark-quick`, `benchmark-all`, `benchmark-tpch`, …); `--machine-tag` (default `ec2-c7i-4xlarge`) is threaded into the remote `make` via `VIBESQL_MACHINE_TAG`.
  - Missing `aws` CLI / invalid credentials produce clear, non-swallowed errors.
- **`machine_tag TEXT` (nullable, additive)**:
  - `tcl_test_runs`: added to `CREATE TABLE` + probe-then-`ALTER TABLE ADD COLUMN` migration in `scripts/tcltest` `init_results_db()`.
  - `benchmark_runs`: added to both `benchmark_results_schema.sql` and `benchmark_results_schema_vibesql.sql`, plus an additive `ALTER` migration in `process_results.init_benchmark_schema()`.
  - `scripts/tcl_runner.py` `save_to_database()` reads `VIBESQL_MACHINE_TAG` (or a `RunSummary.machine_tag` field) and persists it (`NULL` when unset).
  - `scripts/process_results.py`: `get_machine_tag()` helper threaded into all five `benchmark_runs` inserts.
  - `scripts/export_tcl_results.py` and `scripts/export_website_data.py` propagate `machine_tag` into exported JSON alongside existing git metadata.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `remote-run.sh` start→ssh→make→fetch→stop lifecycle | ✅ | Dry-run prints full ordered command sequence |
| `--dry-run` prints commands without executing | ✅ | `--target=i-fake123 --task=tcl-all --dry-run` output shows `DRYRUN:` lines only |
| `stop-instances` runs on failure (trap) | ✅ | Fake failing `ssh` (exit 42) test: `stop-instances` still invoked, script exits 42 |
| `--machine-tag` threaded via `VIBESQL_MACHINE_TAG` | ✅ | Dry-run shows `VIBESQL_MACHINE_TAG=ec2-c7i-4xlarge make …` |
| Clear errors on missing aws CLI/creds | ✅ | Preflight checks `command -v aws` and `aws sts get-caller-identity` |
| `shellcheck scripts/remote-run.sh` passes | ✅ | Clean, no findings |
| `machine_tag` added to `tcl_test_runs` + benchmark schemas | ✅ | Both `.sql` files + `tcltest` migration |
| Migration probe-then-ALTER pattern | ✅ | Round-trip test: legacy DB probe fails → ALTER adds column → old rows read `NULL` |
| Write paths persist the tag | ✅ | `save_to_database` test: tagged run → `ec2-c7i-4xlarge`, untagged → `NULL` |
| Exporters propagate `machine_tag` | ✅ | `get_latest_run` returns tag; tagged→value, untagged→`None` |
| Additive only, no behavior change when unset | ✅ | Legacy rows read `NULL`; env-unset path unchanged |
| Live AWS execution out of scope | ✅ | No live AWS used; dry-run/shellcheck/unit only |

## Test Plan

- `shellcheck scripts/remote-run.sh` — clean.
- `python3 -m py_compile` on all four touched Python scripts — clean; `bash -n` on `tcltest` and `remote-run.sh` — clean.
- Dry-run: `--task=tcl-all` and `--task=benchmark-quick --machine-tag=ec2-c7i-4xlarge` produce the expected `start-instances` / `ssh …VIBESQL_MACHINE_TAG=…` / `scp` / `stop-instances` sequence.
- Trap test: stubbed failing `ssh` (exit 42) → `aws ec2 stop-instances` still invoked, script propagates exit 42.
- Schema round-trip (real `vibesql` binary): legacy `tcl_test_runs`/`benchmark_runs` without `machine_tag` → probe fails → `ALTER ADD COLUMN` → old rows read `NULL`, new tagged rows persist and read back.
- `save_to_database()` integration: tagged run persists `machine_tag='test-tag'`, untagged run persists `NULL`.
- Exporter: `get_latest_run()` selects and returns `machine_tag` (tagged→value, untagged→`None`).

Closes #6123