### PR TITLE
fix(tcl): guard $::errorInfo read in shim mid-file-abort handler

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -7436,7 +7436,7 @@ proc run_test_file {filename} {
         # tallied (real pass/fail) and the summary is emitted. This does not
         # fake any passes: the aborting statement is reported below.
         puts "Setup error (file evaluation aborted mid-file): $err"
-        puts "Error info: $::errorInfo"
+        puts "Error info: [expr {[info exists ::errorInfo] ? $::errorInfo : {(none)}}]"
         # Emit an 'incomplete' marker so the runner sees the file was truncated
         # (#5845). Without this the partial run looks clean to tcl_runner.py:
         # finish_test still prints the "Tests run:" trailer and exits 0, so the


### PR DESCRIPTION
## Summary

The TCL shim's mid-file-abort handler (`scripts/tester_vibesql.tcl:7439`) read `$::errorInfo` **unguarded**. When that variable is unset (e.g. a non-error caught condition / custom return path), the `puts` itself threw `can't read "::errorInfo": no such variable`. That throw was not wrapped in `catch`, so it propagated out of `run_test_file` and crashed the whole `tclsh` worker (`rc=1`, no `"Tests run:"` trailer). `tcl_runner.py` then marked the file `incomplete` and discarded all of its results — reintroducing the exact `exit 1`-discards-everything failure this handler was written to prevent.

## Changes

- `scripts/tester_vibesql.tcl` (line 7439): guard the `errorInfo` read so the diagnostic can never crash the worker:
  ```tcl
  puts "Error info: [expr {[info exists ::errorInfo] ? $::errorInfo : {(none)}}]"
  ```
  The subsequent `incomplete`-marker emission and `finish_test` call are unchanged, so partial results are still tallied and the trailer is emitted (exit 0).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `alias.test --emit-detail` runs to completion (emits `"Tests run:"` trailer, exits 0, records setup-error detail) instead of dying rc=1 with zero rows | ✅ | Before: `rc=1`, zero `Tests run:` lines. After: `rc=0`, `Tests run:` trailer present, `Error info: (none)` printed, `##TCLTEST## incomplete ABORTED_MID_FILE:` detail row recorded |
| No behavior change for files that abort mid-file **with** `::errorInfo` set (message still prints stack info) | ✅ | The `info exists` ternary returns `$::errorInfo` verbatim when set; only the unset case now prints `(none)` instead of throwing |

## Test Plan

Ran the reproduction from the issue against the shim in a fresh worktree with the `docs/reference/sqlite` submodule initialized:

Before fix:
```
$ tclsh scripts/tester_vibesql.tcl docs/reference/sqlite/test/alias.test --emit-detail; echo "rc=$?"
Setup error (file evaluation aborted mid-file):
can't read "::errorInfo": no such variable
    while executing "puts "Error info: $::errorInfo""
    (procedure "run_test_file" line 118)
    (file "scripts/tester_vibesql.tcl" line 7455)
rc=1
# no "Tests run:" trailer  ->  file recorded as incomplete, all rows lost
```

After fix:
```
$ tclsh scripts/tester_vibesql.tcl docs/reference/sqlite/test/alias.test --emit-detail; echo "rc=$?"
Setup error (file evaluation aborted mid-file):
Error info: (none)
##TCLTEST## incomplete	ABORTED_MID_FILE:
======================================
Tests run:    0
Tests passed: 0
Tests failed: 0
Tests skipped: 0
======================================
rc=0
```

The worker now completes cleanly, emits the trailer, and records the `incomplete` setup-error detail row instead of crashing and discarding everything.

Part of epic #5779 (TCL conformance).

Closes #6131