### PR TITLE
fix(tcl): isolate each native-tcl worker in a per-file temp cwd

### DIFF
--- a/scripts/tcl_runner.py
+++ b/scripts/tcl_runner.py
@@ -15,6 +15,7 @@ import argparse
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -971,16 +972,34 @@ def run_native_tcl(test_file: str, shim_path: str, verbose: bool = False, timeou
 
     Returns: (passed, failed, skipped, failed_test_names, per_test_results)
     """
-    cmd = ["tclsh", shim_path, test_file, "--emit-detail"]
+    # Isolate each file's worker in its own throwaway working directory. The
+    # shim's sqlite3 command only pid-isolates the filenames ":memory:" and
+    # "test.db"; every other DB filename the suite uses (test2.db, corrupt.db,
+    # bak.db, ...) resolves via `file normalize` against the worker's cwd. If
+    # all files shared the caller's cwd, one file's leftover DB/WAL/lock/
+    # checkpoint siblings could contaminate a later file's fresh open and cause
+    # spurious worker deaths (issue #6132). A fresh per-file tmpdir gives those
+    # non-isolated filenames a private namespace.
+    #
+    # test_file arrives repo-root-RELATIVE (TCL_TEST_DIR is a relative path), so
+    # it must be absolutized before we hand it to a worker running in a
+    # different cwd — otherwise `source $testdir/...` and the file open in the
+    # shim (which derives testdir from this argument) would fail to resolve. The
+    # VibeSQL binary path is already cwd-independent (derived from the shim's own
+    # [info script]), so it is unaffected.
+    abs_test_file = os.path.abspath(test_file)
+    cmd = ["tclsh", shim_path, abs_test_file, "--emit-detail"]
     if verbose:
         cmd.append("--verbose")
 
+    workdir = tempfile.mkdtemp(prefix="vibesql_tcl_")
     try:
         result = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
             timeout=timeout,
+            cwd=workdir,
         )
         output = result.stdout + result.stderr
 
@@ -1080,6 +1099,12 @@ def run_native_tcl(test_file: str, shim_path: str, verbose: bool = False, timeou
             error_message=str(e)[:500],
         )
         return 0, 1, 0, [f"RUNNER ERROR: {e}"], [error_result]
+
+    finally:
+        # Always remove the per-file working directory, on every exit path
+        # (success, timeout, incomplete, exception). ignore_errors keeps a
+        # stubborn leftover file from masking the real result.
+        shutil.rmtree(workdir, ignore_errors=True)
 
 
 def main():


### PR DESCRIPTION
## Summary

`run_native_tcl` in `scripts/tcl_runner.py` invoked `tclsh` with **no `cwd=`**, so every test file's worker shared the caller's working directory. The shim's `sqlite3` command only pid-isolates the filenames `:memory:` and `test.db`; every other DB filename the suite uses (`test2.db`, `corrupt.db`, `bak.db`, `test.db2`, …) falls into the shim's `else` branch and resolves via `file normalize` against that shared cwd. One file's leftover DB/WAL/lock/checkpoint siblings can then contaminate a later file's fresh open, causing spurious worker deaths (spurious `incomplete` markers).

This gives each file's worker its own throwaway working directory so those non-pid-isolated filenames get a private namespace.

## Changes

- `run_native_tcl`: create a fresh `tempfile.mkdtemp()` per file and pass it as `cwd=` to `subprocess.run(...)`.
- Absolutize `test_file` with `os.path.abspath(...)` before building the `tclsh` command. `TCL_TEST_DIR` is repo-root-relative, so a relative `test_file` would no longer resolve once the worker's cwd is a throwaway tmpdir. The shim derives `set testdir [file dirname $filename]` from this argument, so absolutizing it keeps both the file open and `source $testdir/...` (permutation dispatchers) resolving correctly. The VibeSQL binary path is derived from the shim's own `[info script]` and is already cwd-independent, so it is unaffected.
- Remove the tmpdir on **every** exit path (success, timeout, incomplete, exception) via a `try/finally` with `shutil.rmtree(workdir, ignore_errors=True)`.
- Add `import shutil`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Fresh `mkdtemp()` per invocation, passed as `cwd=`, removed on all exit paths via `try/finally` | ✅ | `workdir = tempfile.mkdtemp(...)`; `cwd=workdir`; `finally: shutil.rmtree(workdir, ignore_errors=True)` covers success/timeout/incomplete/exception |
| `test_file` absolutized before entering the `tclsh` cmd | ✅ | `abs_test_file = os.path.abspath(test_file)` used in `cmd` |
| Batch-of-50 marker count within 1 of isolated per-file baseline | ✅ | Both are exactly **12** on current `main` (delta 0). See note below. |
| No regression in per-file passed/failed/skipped | ✅ | `select1.test` still passes 188/188 (100%), NOT incomplete — proving absolute-path resolution works from the throwaway tmpdir cwd |

## Test Plan

Built the release binary (`cargo build --release`), tclsh available (`/usr/bin/tclsh`), submodule initialized.

- **Batch of 50** (first 50 files alphabetically) via `tcl_runner.py --native-tcl --timeout 120`: **Files incomplete: 12**.
- **Isolated baseline** (each of the same 50 files run in its own separate `tcl_runner.py` invocation): **12 incomplete**, identical set of files.
- **Single-file resolution check**: `--files docs/reference/sqlite/test/select1.test` → 188/188 passed, 0 incomplete (absolute-path resolution from tmpdir confirmed working).

**Note on the incomplete count:** On the current `main` repo state the batch count (12) already equals the isolated-per-file baseline (12), so this fix eliminates any environmental cross-file-contamination delta (batch now exactly matches isolation) with no regressions. The 12 remaining incompletes are genuine per-file mid-file evaluation aborts (e.g. `attach.test` → "file evaluation aborted mid-file: no such table: temp.sqlite_master") that reproduce identically whether a file is run in a batch or in complete isolation — i.e. they are the shim-crash class targeted by the sibling PR #6133 (issue #6131), not the environmental cwd-contamination class this PR fixes. The "12 vs 1" environmental delta cited in the issue's evidence table does not reproduce against current `main` because those genuine per-file deaths dominate; once #6133 lands to clear them, this cwd isolation prevents them from recurring as environmental cross-contamination.

Closes #6132