### PR TITLE
test(tcl): add file-weighted pass rate and top-N monster-file view to status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,54 @@ ORDER BY failed DESC
 LIMIT 10;
 ```
 
+### Raw headline vs. file-weighted metrics (which number is epic-comparable?)
+
+The headline "current pass rate" above is a **raw per-test-row ratio**: passed rows over scored rows (passed + failed + marker rows), summed across every file in the run. This is *the* epic-comparable number. Epic #5779's baseline ("Raw pass rate: 72.3% — 116,719 passed / 44,624 failed" across 728 files) is itself a raw-row ratio with the same inclusion rules: files that produced detail rows in the latest run, with timeout/incomplete/error marker rows counted as failures and `skipped` rows excluded from the denominator. **Compare only raw-to-raw** — the raw headline is the one to hold against 72.3%. Its inclusion rules must never change, or the comparison silently breaks.
+
+The raw ratio has one interpretive hazard: it is dominated by whichever files emit the most rows. A handful of "monster" files (`fuzz.test` ~25k tests, `func.test` ~14.7k) that VibeSQL fails wholesale can drag the raw headline down to single digits even while normal SQL files pass 90-99%. To make that visible — *without* changing the raw headline — `make test-tcl-status` additionally reports two **supplementary** file-weighted metrics. These are reported *alongside* the raw number, never in place of it, and are **not** comparable to the epic's 72.3% (different weighting):
+
+**File-weighted metric — mean per-file pass rate + clean/dirty file counts.** Every file counts equally regardless of row count. `mean_per_file_pass_rate` is the average of each file's own pass rate; `clean_files` vs `files_with_failures` matches the epic's "315 clean / 413 with failures" framing (marker rows count as a failure, same as the raw headline):
+
+```sql
+WITH per_file AS (
+  SELECT
+    file_path,
+    SUM(CASE WHEN status='passed' THEN 1 ELSE 0 END) AS f_passed,
+    SUM(CASE WHEN status IN ('passed','failed','timeout','incomplete','error') THEN 1 ELSE 0 END) AS f_scored,
+    SUM(CASE WHEN status IN ('failed','timeout','incomplete','error') THEN 1 ELSE 0 END) AS f_failed
+  FROM tcl_test_results
+  WHERE run_id = (SELECT MAX(run_id) FROM tcl_test_results)
+  GROUP BY file_path
+)
+SELECT
+  COUNT(*) AS files,
+  ROUND(AVG(CASE WHEN f_scored > 0 THEN 100.0 * f_passed / f_scored END), 1) AS mean_per_file_pass_rate,
+  SUM(CASE WHEN f_failed = 0 THEN 1 ELSE 0 END) AS clean_files,
+  SUM(CASE WHEN f_failed > 0 THEN 1 ELSE 0 END) AS files_with_failures
+FROM per_file;
+```
+
+**Top-N files by test count — monster-file visibility.** Surfaces the high-volume files that dominate the raw aggregate, so a low raw headline can be attributed to a few monster files at a glance:
+
+```sql
+SELECT
+  file_path,
+  COUNT(*) AS tests,
+  SUM(CASE WHEN status='passed' THEN 1 ELSE 0 END) AS passed,
+  ROUND(
+    100.0 * SUM(CASE WHEN status='passed' THEN 1 ELSE 0 END)
+      / NULLIF(SUM(CASE WHEN status IN ('passed','failed','timeout','incomplete','error') THEN 1 ELSE 0 END), 0),
+    1
+  ) AS pass_rate
+FROM tcl_test_results
+WHERE run_id = (SELECT MAX(run_id) FROM tcl_test_results)
+GROUP BY file_path
+ORDER BY tests DESC
+LIMIT 10;
+```
+
+> **Which number do I quote?** For "how does VibeSQL compare to the epic baseline / to a previous run" use the **raw** headline (unchanged inclusion rules). For "how broad is our SQL coverage, ignoring monster-file domination" use the **file-weighted** mean and the clean/dirty file counts. Never quote the file-weighted number against 72.3% — they are different denominators.
+
 > **Source-of-truth note:** `make test-tcl-status` reads the `tcl_test_runs` summary table for the headline numbers. Any per-file or per-test analysis must query the `tcl_test_results` detail table using the queries above. The two reconcile because every run (native-TCL and static) now writes both. If a detail-row insert fails, `tcl_runner.py` logs it to stderr, counts it, and exits non-zero when more than 5% of inserts fail — so silent divergence between the tables cannot recur unnoticed.
 
 ### Exporting Results

--- a/scripts/tcltest
+++ b/scripts/tcltest
@@ -660,6 +660,65 @@ cmd_status() {
                 print_warning "File universe SHRANK: run $run_id covers $with_results file(s) vs $prev_files in previous run $prev_run. Cross-run pass-rate comparison is invalid (different universes)."
             fi
         fi
+
+        # File-weighted metrics (issue #6137): the raw pass rate above is a
+        # per-test-row ratio, so a few "monster" files (fuzz.test ~25k rows,
+        # func.test ~14.7k rows) that VibeSQL fails wholesale can drag the raw
+        # headline far below the rate normal SQL files actually achieve. These
+        # SUPPLEMENTARY metrics are pure read-side SQL over the same
+        # tcl_test_results rows (no execution/schema change) and are reported
+        # ALONGSIDE — never replacing — the raw headline, which stays
+        # inclusion-rule-compatible with epic #5779's 72.3% raw-row baseline.
+        #
+        # - mean per-file pass rate: average of each file's own pass rate, so
+        #   every file counts equally regardless of how many rows it emits.
+        # - clean vs dirty file counts: files with 0 failures vs files with >=1
+        #   failure (matches the epic's "315 clean / 413 with failures" framing).
+        # Marker statuses (timeout/incomplete/error) count as failures here, the
+        # same way they do in the raw headline.
+        echo ""
+        echo "=== File-weighted metrics (supplementary — raw headline above stays epic-comparable) ==="
+        "$VIBESQL_BIN" "$RESULTS_DB" -c "
+            WITH per_file AS (
+                SELECT
+                    file_path,
+                    SUM(CASE WHEN status = 'passed' THEN 1 ELSE 0 END) as f_passed,
+                    SUM(CASE WHEN status IN ('passed','failed','timeout','incomplete','error') THEN 1 ELSE 0 END) as f_scored,
+                    SUM(CASE WHEN status IN ('failed','timeout','incomplete','error') THEN 1 ELSE 0 END) as f_failed
+                FROM tcl_test_results
+                WHERE run_id = $run_id
+                GROUP BY file_path
+            )
+            SELECT
+                COUNT(*) as files,
+                ROUND(AVG(CASE WHEN f_scored > 0 THEN 100.0 * f_passed / f_scored END), 1) as mean_per_file_pass_rate,
+                SUM(CASE WHEN f_failed = 0 THEN 1 ELSE 0 END) as clean_files,
+                SUM(CASE WHEN f_failed > 0 THEN 1 ELSE 0 END) as files_with_failures
+            FROM per_file
+        " 2>/dev/null || true
+
+        # Top-N files by test-count (issue #6137): surface the high-volume files
+        # that dominate the raw per-row aggregate, so a low raw headline can be
+        # attributed at a glance to a handful of monster files rather than to
+        # broad SQL failure.
+        echo ""
+        echo "=== Top 10 files by test count (monster-file visibility) ==="
+        "$VIBESQL_BIN" "$RESULTS_DB" -c "
+            SELECT
+                file_path,
+                COUNT(*) as tests,
+                SUM(CASE WHEN status = 'passed' THEN 1 ELSE 0 END) as passed,
+                ROUND(
+                    100.0 * SUM(CASE WHEN status = 'passed' THEN 1 ELSE 0 END)
+                        / NULLIF(SUM(CASE WHEN status IN ('passed','failed','timeout','incomplete','error') THEN 1 ELSE 0 END), 0),
+                    1
+                ) as pass_rate
+            FROM tcl_test_results
+            WHERE run_id = $run_id
+            GROUP BY file_path
+            ORDER BY tests DESC
+            LIMIT 10
+        " 2>/dev/null || true
     fi
 }
 


### PR DESCRIPTION
## Summary

`make test-tcl-status` reports the TCL conformance number as a raw per-test-row ratio. Because a handful of "monster" files (`fuzz.test` ~25k tests, `func.test` ~14.7k) emit the bulk of all rows and fail wholesale, the raw headline collapses to single digits even while normal SQL files pass 90–99%. This makes the number look catastrophic and hard to compare against epic #5779's baseline.

This PR ADDS (does not replace) two supplementary, read-only file-level metrics so the reported number is meaningful and the monster-file domination is visible. The existing raw headline is left byte-for-byte unchanged so it stays inclusion-rule-compatible with the epic's 72.3% raw-row baseline.

## Changes

- `scripts/tcltest` `cmd_status`: after the existing raw pass-rate and run-universe output, additively print:
  - **File-weighted metrics** — mean per-file pass rate (`AVG` of each file's own pass rate) plus clean-file vs files-with-≥1-failure counts (matches the epic's "315 clean / 413 with failures" framing). Marker statuses count as failures, same as the raw headline.
  - **Top 10 files by test count** — surfaces the high-volume files that dominate the raw aggregate.
  - Both are pure SQL over the existing `tcl_test_results` columns (`file_path`, `status`), scoped to the same `$run_id` already used above. No changes to execution, the shim, or the schema.
- `CLAUDE.md`: extends the "Canonical Pass-Rate Query" section with the file-weighted query, the top-N-by-count query, and a paragraph stating explicitly which number is the epic-comparable raw headline vs. the new supplementary file-weighted number, so the two are never conflated.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Raw pass rate reported unchanged (same inclusion rules) | ✅ | The existing `tcl_test_runs` headline query and run-universe block are untouched; new output is appended after them. |
| Adds a file-weighted metric (mean per-file rate + clean/dirty counts) | ✅ | New "File-weighted metrics" section; on the monster scenario raw=4.8% while mean-per-file=72.6%. |
| Adds a top-N files-by-test-count list | ✅ | New "Top 10 files by test count" section flags `func.test` (14700) / `fuzz.test` at the top. |
| CLAUDE.md documents raw-vs-file-weighted and epic comparability | ✅ | New "Raw headline vs. file-weighted metrics" subsection with both queries + which-number-do-I-quote guidance. |
| No changes to `tcl_runner.py` / shim / schema | ✅ | `git diff --stat` shows only `CLAUDE.md` and `scripts/tcltest`. |
| Additive superset — existing printed fields not removed/renumbered | ✅ | Only new `echo`/query blocks appended; no existing field touched (downstream parsers keep working). |

## Test Plan

Built the release binary, initialized the `docs/reference/sqlite` submodule, and ran a mixed set through the runner into a scratch results DB (via `HOME` override — no real results DB touched).

Real mixed run (`select1.test`, `join.test`, `insert.test`, `fuzz.test`): the new sections render below the unchanged raw headline; top-N flags `fuzz.test` (11056 tests) as the dominant file.

Synthetic monster-file scenario (three normal files at 92.9–100% + `func.test` failing wholesale at 2.0%) — demonstrates the drag deterministically (the real `fuzz`/`func` runs time out under machine load, per the repo's quiet-machine caveat):

```
raw headline pass_rate:    4.8%   (dragged down by func.test's 14400 failing rows)
mean_per_file_pass_rate:  72.6%   (stays high — does NOT collapse to func's 2.0%)
clean_files / with_failures: 1 / 3
Top 10 by test count:  func.test 14700 (2.0%), select1 188, join 178, insert 70
```

This confirms (a) the raw rate is dragged down by the high-volume file while the file-weighted metric stays close to the small-files' average, and (b) the top-N list surfaces the monster file at the top by count.

Closes #6137