### PR TITLE
feat(tcl): parallelize native-TCL file loop with --jobs N

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,10 +289,19 @@ test-tcl:
 # shared run_id (#6136), so a killed full run is durable at batch granularity
 # and the canonical `WHERE run_id = MAX(run_id)` status query still covers the
 # whole suite. Override the batch size with TCL_BATCH_SIZE=<n> (0 disables).
+#
+# TCL_JOBS controls native-TCL file concurrency (#6141): up to N test files run
+# at once, one isolated tclsh worker per job, cutting full-suite wall-clock
+# ~linearly with cores. Defaults to 1 (sequential, today's behavior) — set
+# TCL_JOBS=$(nproc) (or a specific core count) to parallelize. Full canonical
+# runs still require a quiet machine (see CLAUDE.md): parallelism only speeds up
+# an otherwise-idle box; on a loaded machine it produces timeout/incomplete
+# markers instead.
 TCL_BATCH_SIZE ?= 50
+TCL_JOBS ?= 1
 test-tcl-all:
 	@echo "Running full SQLite TCL test suite (all 1174 files)..."
-	./scripts/tcltest run --timeout $(TCL_TIMEOUT) --batch-size $(TCL_BATCH_SIZE)
+	./scripts/tcltest run --timeout $(TCL_TIMEOUT) --batch-size $(TCL_BATCH_SIZE) --jobs $(TCL_JOBS)
 
 # Run specific TCL test file
 test-tcl-file:

--- a/scripts/tcl_runner.py
+++ b/scripts/tcl_runner.py
@@ -1166,6 +1166,14 @@ def main():
                              "N files under one shared run_id, making a killed "
                              "run durable at batch granularity (default: 50; "
                              "<=0 disables batching and saves once at the end)")
+    parser.add_argument("--jobs", "-j", type=int, default=1,
+                        help="Native-TCL mode: run up to N test files "
+                             "concurrently (one tclsh worker per job). Each file "
+                             "already runs in its own isolated temp cwd (#6132), "
+                             "so files are independent units of work. Defaults to "
+                             "1 (sequential — no behavior change). Use "
+                             "--jobs $(nproc) to parallelize across cores. Values "
+                             "<1 are clamped to 1.")
 
     args = parser.parse_args()
 
@@ -1279,13 +1287,29 @@ def main():
                 )
                 results_pending_persist.clear()
 
-        for file_path in file_paths:
-            if args.verbose:
-                print(f"\nRunning: {file_path}")
+        # Number of files to run concurrently. Each file's tclsh worker runs in
+        # its own isolated temp cwd (#6132), so files are independent units of
+        # work and safe to run in parallel. jobs<=1 preserves the original
+        # strictly-sequential control flow (default, no behavior change).
+        jobs = max(1, args.jobs)
 
-            passed, failed, skipped, failed_tests, results = run_native_tcl(
-                file_path, shim_path, verbose=args.verbose, timeout=args.timeout
-            )
+        def process_completed_file(file_path: str, result_tuple) -> None:
+            """Fold one file's completed results into the shared run accounting.
+
+            Runs on ONE thread (the driver): in sequential mode it is called
+            inline, and in parallel mode it is called from the single
+            `as_completed` drain loop — never concurrently. All shared-state
+            mutation (counters, pending-persist buffer, checkpointing) therefore
+            stays single-threaded and lock-free, exactly as in the original
+            sequential loop. Result rows carry `file_path`, so folding files in
+            completion order (which differs from input order under --jobs>1)
+            yields the same totals and the same set of detail rows.
+            """
+            nonlocal total_passed, total_failed, total_skipped
+            nonlocal files_with_results, files_timeout, files_incomplete
+            nonlocal files_error, files_self_skipped, files_processed
+
+            passed, failed, skipped, failed_tests, results = result_tuple
             total_passed += passed
             total_failed += failed
             total_skipped += skipped
@@ -1309,8 +1333,11 @@ def main():
             if results and statuses == {"skipped"}:
                 files_self_skipped += 1
 
-            # Checkpoint after every `batch_size` files. Batching disabled
-            # (batch_size <= 0) falls through to the single end-of-run save.
+            # Checkpoint after every `batch_size` COMPLETED files (completion
+            # order, not dispatch order — under --jobs>1 files finish out of
+            # order but each checkpoint still reflects exactly files_processed
+            # completed files). Batching disabled (batch_size <= 0) falls
+            # through to the single end-of-run save.
             if run_id is not None and batch_size > 0 and files_processed % batch_size == 0:
                 persist_batch()
                 print(
@@ -1330,6 +1357,57 @@ def main():
                         file=sys.stderr,
                     )
                     os._exit(137)
+
+        if jobs <= 1:
+            # Sequential execution (default): identical control flow to the
+            # pre-parallel implementation.
+            for file_path in file_paths:
+                if args.verbose:
+                    print(f"\nRunning: {file_path}")
+
+                result_tuple = run_native_tcl(
+                    file_path, shim_path, verbose=args.verbose, timeout=args.timeout
+                )
+                process_completed_file(file_path, result_tuple)
+        else:
+            # Parallel execution: dispatch up to `jobs` tclsh workers at once.
+            # run_native_tcl is 100% subprocess-bound (subprocess.run releases
+            # the GIL during the blocking wait), so threads give real wall-clock
+            # concurrency. The as_completed drain runs on this (driver) thread,
+            # so process_completed_file — and thus every checkpoint under the
+            # single shared run_id — stays single-threaded and order-independent.
+            if args.verbose:
+                print(f"\nRunning {files_attempted} file(s) with up to {jobs} concurrent worker(s)")
+            with ThreadPoolExecutor(max_workers=jobs) as executor:
+                futures = {
+                    executor.submit(
+                        run_native_tcl,
+                        file_path,
+                        shim_path,
+                        verbose=args.verbose,
+                        timeout=args.timeout,
+                    ): file_path
+                    for file_path in file_paths
+                }
+                for future in as_completed(futures):
+                    file_path = futures[future]
+                    try:
+                        result_tuple = future.result()
+                    except Exception as e:
+                        # Runner-level failure that escaped run_native_tcl's own
+                        # guard: keep the file in the universe with an error
+                        # marker row so it never silently vanishes (#5821).
+                        print(f"Error running {file_path}: {e}")
+                        error_result = TestResult(
+                            test_name="RUNNER ERROR",
+                            file_path=file_path,
+                            test_type="native-tcl",
+                            status="error",
+                            sql="",
+                            error_message=str(e)[:500],
+                        )
+                        result_tuple = (0, 1, 0, [f"RUNNER ERROR: {e}"], [error_result])
+                    process_completed_file(file_path, result_tuple)
 
         # Print summary
         total_tests = total_passed + total_failed + total_skipped

--- a/scripts/tcltest
+++ b/scripts/tcltest
@@ -418,6 +418,10 @@ cmd_run() {
     # shared run_id, making a killed run durable at batch granularity (#6136).
     # Empty -> use tcl_runner.py's own default (50); a value is passed through.
     local batch_size=""
+    # Native-TCL concurrency: run up to N test files at once (one tclsh worker
+    # per job). Empty -> use tcl_runner.py's own default (1, sequential); a
+    # value is passed through. Distinct from --parallel (static-path boolean).
+    local jobs=""
     while [[ $# -gt 0 ]]; do
         case $1 in
             --help)
@@ -439,6 +443,9 @@ Options:
   --batch-size N           Native mode: persist results every N files under one
                            shared run_id, so a killed run is durable at batch
                            granularity (default: 50; 0 disables batching)
+  --jobs, -j N             Native mode: run up to N test files concurrently
+                           (one tclsh worker per job; default: 1 = sequential).
+                           Use -j "$(nproc)" to parallelize across cores.
 
 Examples:
   # Run Priority 1 tests (core SQL)
@@ -489,6 +496,10 @@ EOF
                 ;;
             --batch-size)
                 batch_size="$2"
+                shift 2
+                ;;
+            --jobs|-j)
+                jobs="$2"
                 shift 2
                 ;;
             *)
@@ -575,6 +586,10 @@ EOF
 
     if [ -n "$batch_size" ]; then
         py_args+=("--batch-size" "$batch_size")
+    fi
+
+    if [ -n "$jobs" ]; then
+        py_args+=("--jobs" "$jobs")
     fi
 
     # Add files


### PR DESCRIPTION
## Summary
Parallelizes the native-TCL runner's per-file loop in `scripts/tcl_runner.py` so up to N test files run concurrently (one isolated `tclsh` worker per job), cutting full-suite wall-clock ~linearly with cores. Safe because each file already runs in its own throwaway temp cwd (#6132), making files independent units of work; the shim's per-statement subprocess model is intentionally left untouched (separate, deeper perf issue).

## Changes
- **`scripts/tcl_runner.py`**: New `--jobs N` int flag (native-TCL branch, default `1`). Per-file result folding is extracted into a single-threaded driver closure `process_completed_file`, shared by both paths:
  - `--jobs 1` (default) keeps the exact original sequential control flow — no behavior change unless opted in.
  - `--jobs N>1` dispatches `run_native_tcl` via `ThreadPoolExecutor(max_workers=N)` and drains `as_completed` on the driver thread. All shared state (counters, `results_pending_persist`, every `persist_batch()` checkpoint) stays lock-free and order-independent. Exactly ONE `run_id` is allocated up front; checkpoints still fire every `--batch-size` **completed** files, and the `VIBESQL_TCL_TEST_ABORT_AFTER_FILES` kill seam is preserved. Threads are correct here because `run_native_tcl` is 100% `subprocess.run`-bound (releases the GIL).
  - Mirrors the proven `ThreadPoolExecutor`/`as_completed` pattern already used on the static-parse path. Distinct from the pre-existing boolean `--parallel` (static path) — no overload.
- **`scripts/tcltest`**: Matching `--jobs`/`-j N` passthrough, mirroring the existing `--batch-size` plumbing.
- **`Makefile`**: New `TCL_JOBS ?= 1` var threaded into `test-tcl-all` (conservative default; opt-in via `TCL_JOBS=$(nproc)`).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--jobs N` int flag, native-TCL branch, default 1 | ✅ | `python3 scripts/tcl_runner.py --help` shows `--jobs, -j JOBS`; default 1 |
| `--jobs 1` reproduces sequential control flow | ✅ | `jobs<=1` branch runs the original inline `for` loop; folding logic identical |
| `--jobs N>1` runs via `ThreadPoolExecutor(max_workers=N)` + `as_completed`, no 2nd run_id | ✅ | `COUNT(DISTINCT run_id)=1` after `--jobs 28` run |
| **Determinism** | ✅ | 12-file set: `--jobs 1` and `--jobs 28` both = total 1048 / passed 887 / failed 5 / skipped 156 / 0 markers; per-file rows **byte-identical** (`diff` clean) |
| **One coherent run_id** | ✅ | `tcl_test_runs` summary reconciles detail sum: total_files=12, total_tests=1048, passed=887, failed=5, skipped=156 |
| **Durability under concurrency** | ✅ | `VIBESQL_TCL_TEST_ABORT_AFTER_FILES=5 --jobs 4 --batch-size 5` → runner `os._exit(137)`; 5 distinct files (455 rows) survived under one run_id; summary reconciles (total_files=5, passed=374, failed=5, skipped=76) |
| **Checkpoint cadence on completed files** | ✅ | `[checkpoint] Persisted N/…` + `[test-abort] Simulating kill after 5 files` fired at expected cadence under `--jobs 4 --batch-size 5` |
| **Measurable speedup** | ✅ | 12-file set: `--jobs 1` = 15.78s vs `--jobs 28` = 3.91s wall-clock → **~4.0x** (bounded by largest single file per Amdahl) |
| `scripts/tcltest` `--jobs`/`-j` passthrough | ✅ | Added, mirrors `--batch-size`; `bash -n` clean |
| Locally verifiable, no AWS / full-suite run | ✅ | All checks above on ≤20 files, local release binary |
| Out of scope untouched (shim per-statement model; #6140) | ✅ | Only the file loop + flag plumbing changed |

## Test Plan
Built the release binary and initialized the `docs/reference/sqlite` submodule, then on small deterministic file sets:
1. **Determinism** (12 fast files, marker-free): `--jobs 1` vs `--jobs 28` → identical totals + byte-identical per-file `tcl_test_results` rows.
2. **One run_id / reconciliation**: `COUNT(DISTINCT run_id)=1`; `tcl_test_runs` summary matches the detail-table sum for that run.
3. **Durability**: `VIBESQL_TCL_TEST_ABORT_AFTER_FILES=5 --jobs 4 --batch-size 5` → completed-batch rows (5 files) durably survive the simulated `os._exit(137)` kill.
4. **Speedup**: 15.78s → 3.91s (~4x) on the 12-file set.

Note: a separate 20-file run that included the huge auto-generated `select2.test` timed out identically in **both** `--jobs 1` and `--jobs 4` (a pre-existing per-file-timeout artifact under machine load, not caused by this change), and even then the two runs produced identical markers/totals/per-file rows — reinforcing order-independence. The clean speedup number above uses a marker-free fast-file set per CLAUDE.md's quiet-machine guidance.

Part of epic #5779. Composes with (does not depend on) #6140.

Closes #6141