### PR TITLE
fix(executor): honor per-key-part COLLATE in PK/UNIQUE INSERT uniqueness

### DIFF
--- a/crates/vibesql-catalog/src/table.rs
+++ b/crates/vibesql-catalog/src/table.rs
@@ -79,6 +79,17 @@ pub struct TableSchema {
     /// Unique constraints - each inner vec represents a unique constraint (can be single or
     /// composite)
     pub unique_constraints: Vec<Vec<String>>,
+    /// Explicit per-key-part collation for each PRIMARY KEY column, parallel to
+    /// `primary_key`. `Some(vec)` mirrors the PK column list; each element is the
+    /// key-part `COLLATE` name (`PRIMARY KEY(a COLLATE nocase)`), or `None` to
+    /// fall back to the column's declared collation, then BINARY. Not serialized
+    /// in the binary catalog — rederived from `sql_source` on load (like
+    /// `strict_types`), so no format bump is needed. Issue #5881.
+    pub primary_key_collations: Option<Vec<Option<String>>>,
+    /// Explicit per-key-part collation for each UNIQUE constraint, parallel to
+    /// `unique_constraints` (outer + inner index alignment). Same fallback and
+    /// persistence semantics as `primary_key_collations`. Issue #5881.
+    pub unique_constraint_collations: Vec<Vec<Option<String>>>,
     /// Check constraints - each tuple is (constraint_name, check_expression)
     pub check_constraints: Vec<(String, vibesql_ast::Expression)>,
     /// Foreign key constraints
@@ -160,6 +171,8 @@ impl TableSchema {
             sql_source: None,
             strict: false,
             strict_types: Vec::new(),
+            primary_key_collations: None,
+            unique_constraint_collations: Vec::new(),
         }
     }
 
@@ -196,6 +209,8 @@ impl TableSchema {
             sql_source: None,
             strict: false,
             strict_types: Vec::new(),
+            primary_key_collations: None,
+            unique_constraint_collations: Vec::new(),
         }
     }
 
@@ -222,6 +237,8 @@ impl TableSchema {
             sql_source: None,
             strict: false,
             strict_types: Vec::new(),
+            primary_key_collations: None,
+            unique_constraint_collations: Vec::new(),
         }
     }
 
@@ -248,6 +265,8 @@ impl TableSchema {
             sql_source: None,
             strict: false,
             strict_types: Vec::new(),
+            primary_key_collations: None,
+            unique_constraint_collations: Vec::new(),
         }
     }
 
@@ -275,6 +294,8 @@ impl TableSchema {
             sql_source: None,
             strict: false,
             strict_types: Vec::new(),
+            primary_key_collations: None,
+            unique_constraint_collations: Vec::new(),
         }
     }
 
@@ -304,6 +325,8 @@ impl TableSchema {
             sql_source: None,
             strict: false,
             strict_types: Vec::new(),
+            primary_key_collations: None,
+            unique_constraint_collations: Vec::new(),
         }
     }
 
@@ -330,6 +353,8 @@ impl TableSchema {
             sql_source: None,
             strict: false,
             strict_types: Vec::new(),
+            primary_key_collations: None,
+            unique_constraint_collations: Vec::new(),
         }
     }
 
@@ -429,6 +454,71 @@ impl TableSchema {
             .collect()
     }
 
+    /// Effective per-key-part collation for the PRIMARY KEY, aligned with
+    /// [`get_primary_key_indices`](Self::get_primary_key_indices).
+    ///
+    /// Resolution per key part follows SQLite semantics (issue #5881):
+    /// explicit key-part `COLLATE` (`PRIMARY KEY(a COLLATE nocase)`), else the
+    /// column's declared collation, else `None` (BINARY, case-sensitive). The
+    /// key-part vector is looked up by position with a safe fallback so a stale
+    /// or short `primary_key_collations` (e.g. after DROP COLUMN) degrades to
+    /// the column's declared collation rather than panicking.
+    ///
+    /// Returns `None` when the table has no primary key.
+    pub fn primary_key_effective_collations(&self) -> Option<Vec<Option<String>>> {
+        let pk_cols = self.primary_key.as_ref()?;
+        Some(
+            pk_cols
+                .iter()
+                .enumerate()
+                .map(|(i, col_name)| {
+                    let key_part = self
+                        .primary_key_collations
+                        .as_ref()
+                        .and_then(|v| v.get(i).cloned().flatten());
+                    self.resolve_key_part_collation(key_part, col_name)
+                })
+                .collect(),
+        )
+    }
+
+    /// Effective per-key-part collation for the UNIQUE constraint at
+    /// `constraint_idx`, aligned with its entry in
+    /// [`get_unique_constraint_indices`](Self::get_unique_constraint_indices).
+    /// Same key-part → column → BINARY resolution as
+    /// [`primary_key_effective_collations`](Self::primary_key_effective_collations).
+    pub fn unique_constraint_effective_collations(
+        &self,
+        constraint_idx: usize,
+    ) -> Vec<Option<String>> {
+        let Some(cols) = self.unique_constraints.get(constraint_idx) else {
+            return Vec::new();
+        };
+        cols.iter()
+            .enumerate()
+            .map(|(i, col_name)| {
+                let key_part = self
+                    .unique_constraint_collations
+                    .get(constraint_idx)
+                    .and_then(|v| v.get(i).cloned().flatten());
+                self.resolve_key_part_collation(key_part, col_name)
+            })
+            .collect()
+    }
+
+    /// Resolve a single key part's effective collation: the explicit key-part
+    /// `COLLATE` if present, otherwise the named column's declared collation,
+    /// otherwise `None` (BINARY).
+    fn resolve_key_part_collation(
+        &self,
+        key_part: Option<String>,
+        col_name: &str,
+    ) -> Option<String> {
+        key_part.or_else(|| {
+            self.get_column_index(col_name).and_then(|idx| self.columns[idx].collation.clone())
+        })
+    }
+
     /// Add a column to the table schema
     pub fn add_column(&mut self, column: ColumnSchema) -> Result<(), crate::CatalogError> {
         if self.get_column(&column.name).is_some() {
@@ -463,6 +553,14 @@ impl TableSchema {
                 self.primary_key = None;
             }
         }
+
+        // The per-key-part collation vectors (issue #5881) are positionally
+        // aligned with `primary_key` / `unique_constraints`; a column removal
+        // shifts those lists, so drop the explicit key-part collations rather
+        // than risk stale misalignment. Enforcement then falls back to each
+        // column's declared collation, which remains correct.
+        self.primary_key_collations = None;
+        self.unique_constraint_collations = Vec::new();
 
         // Remove from unique constraints
         self.unique_constraints = self

--- a/crates/vibesql-executor/src/constraint_validator.rs
+++ b/crates/vibesql-executor/src/constraint_validator.rs
@@ -18,8 +18,15 @@ use crate::errors::ExecutorError;
 pub struct ConstraintResult {
     /// Primary key column names (if any)
     pub primary_key: Option<Vec<String>>,
+    /// Explicit per-key-part `COLLATE` for the PRIMARY KEY, parallel to
+    /// `primary_key`. `None` for a key part with no explicit collation (falls
+    /// back to the column's declared collation, then BINARY). Issue #5881.
+    pub primary_key_collations: Option<Vec<Option<String>>>,
     /// UNIQUE constraints (each Vec<String> is a set of columns)
     pub unique_constraints: Vec<Vec<String>>,
+    /// Explicit per-key-part `COLLATE` for each UNIQUE constraint, parallel to
+    /// `unique_constraints`. Issue #5881.
+    pub unique_constraint_collations: Vec<Vec<Option<String>>>,
     /// CHECK constraints (name, expression pairs)
     pub check_constraints: Vec<(String, Expression)>,
     /// Columns that should be marked as NOT NULL
@@ -31,11 +38,27 @@ impl ConstraintResult {
     pub fn new() -> Self {
         Self {
             primary_key: None,
+            primary_key_collations: None,
             unique_constraints: Vec::new(),
+            unique_constraint_collations: Vec::new(),
             check_constraints: Vec::new(),
             not_null_columns: Vec::new(),
         }
     }
+}
+
+/// Extract the explicit key-part `COLLATE` names from a table-level
+/// PRIMARY KEY / UNIQUE column list, positionally aligned with the columns.
+/// Expression key parts (which cannot appear in these constraints today)
+/// contribute `None`. Issue #5881.
+fn key_part_collations(columns: &[vibesql_ast::IndexColumn]) -> Vec<Option<String>> {
+    columns
+        .iter()
+        .map(|c| match c {
+            vibesql_ast::IndexColumn::Column { collation, .. } => collation.clone(),
+            vibesql_ast::IndexColumn::Expression { .. } => None,
+        })
+        .collect()
 }
 
 /// Constraint validator for table creation and alteration
@@ -83,6 +106,10 @@ impl ConstraintValidator {
                             });
                         }
                         result.primary_key = Some(vec![col_def.name.clone()]);
+                        // Column-level PK carries no key-part COLLATE (any COLLATE
+                        // is a separate column constraint that sets the column's
+                        // declared collation); enforcement falls back to that.
+                        result.primary_key_collations = Some(vec![None]);
                         // SQLite quirk: only INTEGER PRIMARY KEY has implicit NOT NULL
                         // Other types (TEXT, REAL, BLOB, etc.) can have NULL in PRIMARY KEY
                         if col_def.data_type == DataType::Integer {
@@ -92,6 +119,9 @@ impl ConstraintValidator {
                     }
                     ColumnConstraintKind::Unique { .. } => {
                         result.unique_constraints.push(vec![col_def.name.clone()]);
+                        // Column-level UNIQUE carries no key-part COLLATE; fall
+                        // back to the column's declared collation at enforcement.
+                        result.unique_constraint_collations.push(vec![None]);
                     }
                     ColumnConstraintKind::Check { expr, source_text } => {
                         // Use explicit name if provided; otherwise use the
@@ -147,6 +177,9 @@ impl ConstraintValidator {
                     let column_names: Vec<String> =
                         pk_cols.iter().map(|c| c.expect_column_name().to_string()).collect();
                     result.primary_key = Some(column_names.clone());
+                    // Carry the explicit per-key-part COLLATE so INSERT uniqueness
+                    // enforcement can honor `PRIMARY KEY(a COLLATE nocase)` (#5881).
+                    result.primary_key_collations = Some(key_part_collations(pk_cols));
                     // SQLite quirk: only INTEGER PRIMARY KEY has implicit NOT NULL
                     // For table-level constraints, check each column's type
                     for col_name in &column_names {
@@ -164,6 +197,9 @@ impl ConstraintValidator {
                     let column_names: Vec<String> =
                         columns.iter().map(|c| c.expect_column_name().to_string()).collect();
                     result.unique_constraints.push(column_names);
+                    // Carry the explicit per-key-part COLLATE so INSERT uniqueness
+                    // enforcement can honor `UNIQUE(a COLLATE nocase)` (#5881).
+                    result.unique_constraint_collations.push(key_part_collations(columns));
                 }
                 TableConstraintKind::Check { expr, source_text } => {
                     // Use explicit name if provided; otherwise the verbatim
@@ -220,10 +256,14 @@ impl ConstraintValidator {
         // Set primary key
         if let Some(pk) = &constraint_result.primary_key {
             table_schema.primary_key = Some(pk.clone());
+            // Key-part collations are aligned with the PK column list (#5881).
+            table_schema.primary_key_collations = constraint_result.primary_key_collations.clone();
         }
 
         // Set unique constraints
         table_schema.unique_constraints = constraint_result.unique_constraints.clone();
+        table_schema.unique_constraint_collations =
+            constraint_result.unique_constraint_collations.clone();
 
         // Set check constraints
         table_schema.check_constraints = constraint_result.check_constraints.clone();
@@ -567,5 +607,125 @@ mod tests {
         assert_eq!(result.primary_key, Some(vec!["big_id".to_string()]));
         // SQLite only treats INTEGER (not INT, BIGINT, etc.) specially
         assert!(!result.not_null_columns.contains(&"big_id".to_string()));
+    }
+
+    // -----------------------------------------------------------------------
+    // Per-key-part COLLATE collection + effective resolution (issue #5881)
+    // -----------------------------------------------------------------------
+
+    fn index_col_with_collation(name: &str, collation: Option<&str>) -> vibesql_ast::IndexColumn {
+        vibesql_ast::IndexColumn::Column {
+            column_name: name.to_string(),
+            direction: vibesql_ast::OrderDirection::Asc,
+            prefix_length: None,
+            collation: collation.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn test_table_level_pk_collects_key_part_collation() {
+        let columns =
+            vec![make_column_def_with_type("a", DataType::Varchar { max_length: None }, vec![])];
+        let constraints = vec![TableConstraint {
+            name: None,
+            kind: TableConstraintKind::PrimaryKey {
+                columns: vec![index_col_with_collation("a", Some("nocase"))],
+                on_conflict: None,
+            },
+        }];
+        let result = ConstraintValidator::process_constraints("t", &columns, &constraints).unwrap();
+        assert_eq!(result.primary_key_collations, Some(vec![Some("nocase".to_string())]));
+    }
+
+    #[test]
+    fn test_table_level_unique_collects_key_part_collation() {
+        let columns = vec![
+            make_column_def_with_type("a", DataType::Varchar { max_length: None }, vec![]),
+            make_column_def_with_type("b", DataType::Varchar { max_length: None }, vec![]),
+        ];
+        let constraints = vec![TableConstraint {
+            name: None,
+            kind: TableConstraintKind::Unique {
+                columns: vec![
+                    index_col_with_collation("a", Some("rtrim")),
+                    index_col_with_collation("b", None),
+                ],
+                on_conflict: None,
+            },
+        }];
+        let result = ConstraintValidator::process_constraints("t", &columns, &constraints).unwrap();
+        assert_eq!(
+            result.unique_constraint_collations,
+            vec![vec![Some("rtrim".to_string()), None]]
+        );
+    }
+
+    #[test]
+    fn test_column_level_pk_has_no_key_part_collation() {
+        // A column-level PRIMARY KEY carries no key-part COLLATE; any collation
+        // is a separate column constraint that lives on the column itself.
+        let columns = vec![make_column_def_with_type(
+            "id",
+            DataType::Varchar { max_length: None },
+            vec![ColumnConstraintKind::PrimaryKey { on_conflict: None }],
+        )];
+        let result = ConstraintValidator::process_constraints("t", &columns, &[]).unwrap();
+        assert_eq!(result.primary_key_collations, Some(vec![None]));
+    }
+
+    #[test]
+    fn test_apply_to_schema_effective_collation_prefers_key_part() {
+        // Key-part COLLATE nocase on column `a` (which itself has no declared
+        // collation) → effective PK collation is nocase.
+        use vibesql_catalog::{ColumnSchema, TableSchema};
+        let columns =
+            vec![make_column_def_with_type("a", DataType::Varchar { max_length: None }, vec![])];
+        let constraints = vec![TableConstraint {
+            name: None,
+            kind: TableConstraintKind::PrimaryKey {
+                columns: vec![index_col_with_collation("a", Some("NOCASE"))],
+                on_conflict: None,
+            },
+        }];
+        let result = ConstraintValidator::process_constraints("t", &columns, &constraints).unwrap();
+
+        let mut schema = TableSchema::new(
+            "t".to_string(),
+            vec![ColumnSchema::new("a".to_string(), DataType::Varchar { max_length: None }, true)],
+        );
+        ConstraintValidator::apply_to_schema(&mut schema, &result);
+
+        assert_eq!(
+            schema.primary_key_effective_collations(),
+            Some(vec![Some("NOCASE".to_string())])
+        );
+    }
+
+    #[test]
+    fn test_effective_collation_falls_back_to_column_collation() {
+        // No key-part COLLATE, but the column is declared NOCASE → effective PK
+        // collation falls back to the column's declared collation.
+        use vibesql_catalog::{ColumnSchema, TableSchema};
+        let columns =
+            vec![make_column_def_with_type("a", DataType::Varchar { max_length: None }, vec![])];
+        let constraints = vec![TableConstraint {
+            name: None,
+            kind: TableConstraintKind::PrimaryKey {
+                columns: vec![index_col_with_collation("a", None)],
+                on_conflict: None,
+            },
+        }];
+        let result = ConstraintValidator::process_constraints("t", &columns, &constraints).unwrap();
+
+        let mut col =
+            ColumnSchema::new("a".to_string(), DataType::Varchar { max_length: None }, true);
+        col.collation = Some("nocase".to_string());
+        let mut schema = TableSchema::new("t".to_string(), vec![col]);
+        ConstraintValidator::apply_to_schema(&mut schema, &result);
+
+        assert_eq!(
+            schema.primary_key_effective_collations(),
+            Some(vec![Some("nocase".to_string())])
+        );
     }
 }

--- a/crates/vibesql-executor/src/insert/constraints.rs
+++ b/crates/vibesql-executor/src/insert/constraints.rs
@@ -1,5 +1,84 @@
 use crate::errors::ExecutorError;
 
+/// The text behind a `SqlValue`, for collation-aware comparison. Only the
+/// string variants carry a collating sequence; everything else compares by
+/// exact `SqlValue` equality regardless of the declared collation.
+pub(crate) fn sql_value_text(v: &vibesql_types::SqlValue) -> Option<&str> {
+    match v {
+        vibesql_types::SqlValue::Character(s) | vibesql_types::SqlValue::Varchar(s) => {
+            Some(s.as_str())
+        }
+        _ => None,
+    }
+}
+
+/// Collation-aware equality for a single key value pair, layered on top of the
+/// strict `SqlValue` equality used for BINARY key comparisons (issue #5881).
+///
+/// Only text operands under NOCASE / RTRIM diverge from raw equality; BINARY, an
+/// unrecognized collation name, or a non-text operand all fall back to `a == b`
+/// (preserving the pre-existing exact-match semantics). This intentionally does
+/// NOT apply the numeric coercion that FK comparison uses — PK/UNIQUE keys are
+/// compared by strict typed equality, exactly as before.
+pub(crate) fn value_eq_with_collation(
+    a: &vibesql_types::SqlValue,
+    b: &vibesql_types::SqlValue,
+    collation: Option<&str>,
+) -> bool {
+    if a == b {
+        return true;
+    }
+    let Some(name) = collation else {
+        return false;
+    };
+    let (Some(sa), Some(sb)) = (sql_value_text(a), sql_value_text(b)) else {
+        return false;
+    };
+    match name.to_ascii_lowercase().as_str() {
+        "nocase" => sa.eq_ignore_ascii_case(sb),
+        "rtrim" => sa.trim_end_matches(' ') == sb.trim_end_matches(' '),
+        _ => false,
+    }
+}
+
+/// Collation-aware equality for a whole key tuple, applying each key part's
+/// effective collation (aligned positionally with the key columns).
+pub(crate) fn key_eq_with_collations(
+    a: &[vibesql_types::SqlValue],
+    b: &[vibesql_types::SqlValue],
+    collations: &[Option<String>],
+) -> bool {
+    a.len() == b.len()
+        && a.iter().zip(b.iter()).enumerate().all(|(i, (x, y))| {
+            value_eq_with_collation(x, y, collations.get(i).and_then(|c| c.as_deref()))
+        })
+}
+
+/// True when any key part resolves to a non-BINARY collation. In that case the
+/// raw hash indexes (keyed on exact `SqlValue`) would miss collated duplicates
+/// — e.g. `'a'` and `'A'` hash to different buckets under NOCASE — so the caller
+/// must fall back to a collation-aware scan instead of the O(1) hash lookup.
+pub(crate) fn has_non_binary_collation(collations: &[Option<String>]) -> bool {
+    collations
+        .iter()
+        .any(|c| matches!(c.as_deref(), Some(name) if !name.eq_ignore_ascii_case("binary")))
+}
+
+/// Build the SQLite-compatible "UNIQUE constraint failed: t.a, t.b" error for a
+/// PRIMARY KEY violation.
+pub(crate) fn primary_key_violation(
+    schema: &vibesql_catalog::TableSchema,
+    table_name: &str,
+) -> ExecutorError {
+    let pk_col_names: Vec<String> = schema.primary_key.clone().unwrap_or_default();
+    let qualified_cols: Vec<String> =
+        pk_col_names.iter().map(|col| format!("{}.{}", table_name, col)).collect();
+    ExecutorError::SqliteCompatError(format!(
+        "UNIQUE constraint failed: {}",
+        qualified_cols.join(", ")
+    ))
+}
+
 /// Enforce PRIMARY KEY constraint (uniqueness)
 /// Returns Ok if constraint is satisfied
 pub fn enforce_primary_key_constraint(
@@ -20,17 +99,20 @@ pub fn enforce_primary_key_constraint(
             return Ok(());
         }
 
+        // Effective per-key-part collation (key-part COLLATE → column collation →
+        // BINARY). Under any non-BINARY collation we must compare with the
+        // collation, and the raw hash index cannot be used (issue #5881).
+        let collations = schema.primary_key_effective_collations().unwrap_or_default();
+        let collated = has_non_binary_collation(&collations);
+
         // Check for duplicates within the batch of rows being inserted
-        if batch_pk_values.contains(&new_pk_values) {
-            let pk_col_names: Vec<String> = schema.primary_key.as_ref().unwrap().clone();
-            // SQLite uses "UNIQUE constraint failed" for PRIMARY KEY violations
-            let qualified_cols: Vec<String> =
-                pk_col_names.iter().map(|col| format!("{}.{}", table_name, col)).collect();
-            // SQLite-compatible: output the message as-is without prefix
-            return Err(ExecutorError::SqliteCompatError(format!(
-                "UNIQUE constraint failed: {}",
-                qualified_cols.join(", ")
-            )));
+        let dup_in_batch = if collated {
+            batch_pk_values.iter().any(|b| key_eq_with_collations(&new_pk_values, b, &collations))
+        } else {
+            batch_pk_values.contains(&new_pk_values)
+        };
+        if dup_in_batch {
+            return Err(primary_key_violation(schema, table_name));
         }
 
         // Check if any existing row has the same primary key using the hash index
@@ -52,19 +134,27 @@ pub fn enforce_primary_key_constraint(
         // reduces to the existing not-bitmap-deleted check.
         let snapshot = crate::mvcc::read_snapshot(db);
 
-        // Use the primary key index for O(1) lookup instead of O(n) scan
-        if let Some(pk_index) = table.primary_key_index() {
+        if collated {
+            // Collation-aware existing-row scan. The primary-key hash index is
+            // keyed on exact `SqlValue` bytes, so it would never surface a
+            // case-variant duplicate under NOCASE (or a trailing-space variant
+            // under RTRIM); we must compare every visible row with the key-part
+            // collation instead (issue #5881).
+            for (_idx, existing_row) in table.scan_visible(&snapshot) {
+                let existing_pk_values: Vec<vibesql_types::SqlValue> =
+                    pk_indices.iter().filter_map(|&idx| existing_row.get(idx).cloned()).collect();
+                if existing_pk_values.contains(&vibesql_types::SqlValue::Null) {
+                    continue;
+                }
+                if key_eq_with_collations(&new_pk_values, &existing_pk_values, &collations) {
+                    return Err(primary_key_violation(schema, table_name));
+                }
+            }
+        } else if let Some(pk_index) = table.primary_key_index() {
+            // BINARY fast path: O(1) hash lookup on exact key bytes.
             if let Some(&row_idx) = pk_index.get(&new_pk_values) {
                 if table.is_row_visible(row_idx, &snapshot) {
-                    let pk_col_names: Vec<String> = schema.primary_key.as_ref().unwrap().clone();
-                    // SQLite uses "UNIQUE constraint failed" for PRIMARY KEY violations
-                    let qualified_cols: Vec<String> =
-                        pk_col_names.iter().map(|col| format!("{}.{}", table_name, col)).collect();
-                    // SQLite-compatible: output the message as-is without prefix
-                    return Err(ExecutorError::SqliteCompatError(format!(
-                        "UNIQUE constraint failed: {}",
-                        qualified_cols.join(", ")
-                    )));
+                    return Err(primary_key_violation(schema, table_name));
                 }
             }
         } else {
@@ -75,21 +165,30 @@ pub fn enforce_primary_key_constraint(
                     pk_indices.iter().filter_map(|&idx| existing_row.get(idx).cloned()).collect();
 
                 if new_pk_values == existing_pk_values {
-                    let pk_col_names: Vec<String> = schema.primary_key.as_ref().unwrap().clone();
-                    // SQLite uses "UNIQUE constraint failed" for PRIMARY KEY violations
-                    let qualified_cols: Vec<String> =
-                        pk_col_names.iter().map(|col| format!("{}.{}", table_name, col)).collect();
-                    // SQLite-compatible: output the message as-is without prefix
-                    return Err(ExecutorError::SqliteCompatError(format!(
-                        "UNIQUE constraint failed: {}",
-                        qualified_cols.join(", ")
-                    )));
+                    return Err(primary_key_violation(schema, table_name));
                 }
             }
         }
     }
 
     Ok(())
+}
+
+/// Build the SQLite-compatible "UNIQUE constraint failed: t.a, t.b" error for
+/// the UNIQUE constraint at `constraint_idx`.
+pub(crate) fn unique_constraint_violation(
+    schema: &vibesql_catalog::TableSchema,
+    table_name: &str,
+    constraint_idx: usize,
+) -> ExecutorError {
+    let unique_col_names: Vec<String> =
+        schema.unique_constraints.get(constraint_idx).cloned().unwrap_or_default();
+    let qualified_cols: Vec<String> =
+        unique_col_names.iter().map(|col| format!("{}.{}", table_name, col)).collect();
+    ExecutorError::SqliteCompatError(format!(
+        "UNIQUE constraint failed: {}",
+        qualified_cols.join(", ")
+    ))
 }
 
 /// Enforce UNIQUE constraints on a row
@@ -114,20 +213,25 @@ pub fn enforce_unique_constraints(
             continue;
         }
 
+        // Effective per-key-part collation (key-part COLLATE → column collation →
+        // BINARY). A non-BINARY collation forces a collation-aware scan because
+        // the unique hash index is keyed on exact `SqlValue` bytes (issue #5881).
+        let collations = schema.unique_constraint_effective_collations(constraint_idx);
+        let collated = has_non_binary_collation(&collations);
+
         // Check for duplicates within the batch of rows being inserted
         // (skip if batch_unique_values is empty or doesn't have this constraint)
-        if constraint_idx < batch_unique_values.len()
-            && batch_unique_values[constraint_idx].contains(&new_unique_values)
-        {
-            let unique_col_names: Vec<String> = schema.unique_constraints[constraint_idx].clone();
-            // Format: "UNIQUE constraint failed: table.col1, table.col2" (SQLite-compatible)
-            let qualified_cols: Vec<String> =
-                unique_col_names.iter().map(|col| format!("{}.{}", table_name, col)).collect();
-            // SQLite-compatible: output the message as-is without prefix
-            return Err(ExecutorError::SqliteCompatError(format!(
-                "UNIQUE constraint failed: {}",
-                qualified_cols.join(", ")
-            )));
+        if constraint_idx < batch_unique_values.len() {
+            let dup_in_batch = if collated {
+                batch_unique_values[constraint_idx]
+                    .iter()
+                    .any(|b| key_eq_with_collations(&new_unique_values, b, &collations))
+            } else {
+                batch_unique_values[constraint_idx].contains(&new_unique_values)
+            };
+            if dup_in_batch {
+                return Err(unique_constraint_violation(schema, table_name, constraint_idx));
+            }
         }
 
         // Check if any existing row has the same unique constraint values using hash index
@@ -140,23 +244,28 @@ pub fn enforce_unique_constraints(
         // `is_row_visible` is the existing not-bitmap-deleted check.
         let snapshot = crate::mvcc::read_snapshot(db);
 
-        // Use the unique constraint index for O(1) lookup instead of O(n) scan
-        if constraint_idx < table.unique_indexes().len() {
+        if collated {
+            // Collation-aware existing-row scan (the unique hash index cannot
+            // surface collated duplicates — see the PK path above, #5881).
+            for (_idx, existing_row) in table.scan_visible(&snapshot) {
+                let existing_unique_values: Vec<vibesql_types::SqlValue> = unique_indices
+                    .iter()
+                    .filter_map(|&idx| existing_row.get(idx).cloned())
+                    .collect();
+                if existing_unique_values.contains(&vibesql_types::SqlValue::Null) {
+                    continue;
+                }
+                if key_eq_with_collations(&new_unique_values, &existing_unique_values, &collations)
+                {
+                    return Err(unique_constraint_violation(schema, table_name, constraint_idx));
+                }
+            }
+        } else if constraint_idx < table.unique_indexes().len() {
+            // BINARY fast path: O(1) hash lookup on exact key bytes.
             let unique_index = &table.unique_indexes()[constraint_idx];
             if let Some(&row_idx) = unique_index.get(&new_unique_values) {
                 if table.is_row_visible(row_idx, &snapshot) {
-                    let unique_col_names: Vec<String> =
-                        schema.unique_constraints[constraint_idx].clone();
-                    // Format: "UNIQUE constraint failed: table.col1, table.col2" (SQLite-compatible)
-                    let qualified_cols: Vec<String> = unique_col_names
-                        .iter()
-                        .map(|col| format!("{}.{}", table_name, col))
-                        .collect();
-                    // SQLite-compatible: output the message as-is without prefix
-                    return Err(ExecutorError::SqliteCompatError(format!(
-                        "UNIQUE constraint failed: {}",
-                        qualified_cols.join(", ")
-                    )));
+                    return Err(unique_constraint_violation(schema, table_name, constraint_idx));
                 }
             }
         } else {
@@ -174,19 +283,7 @@ pub fn enforce_unique_constraints(
                 }
 
                 if new_unique_values == existing_unique_values {
-                    let unique_col_names: Vec<String> =
-                        schema.unique_constraints[constraint_idx].clone();
-                    // Format: "UNIQUE constraint failed: table.col1, table.col2"
-                    // (SQLite-compatible)
-                    let qualified_cols: Vec<String> = unique_col_names
-                        .iter()
-                        .map(|col| format!("{}.{}", table_name, col))
-                        .collect();
-                    // SQLite-compatible: output the message as-is without prefix
-                    return Err(ExecutorError::SqliteCompatError(format!(
-                        "UNIQUE constraint failed: {}",
-                        qualified_cols.join(", ")
-                    )));
+                    return Err(unique_constraint_violation(schema, table_name, constraint_idx));
                 }
             }
         }

--- a/crates/vibesql-executor/src/insert/row_validator.rs
+++ b/crates/vibesql-executor/src/insert/row_validator.rs
@@ -211,39 +211,64 @@ impl<'a> RowValidator<'a> {
         pk_values: &Option<Vec<vibesql_types::SqlValue>>,
     ) -> Result<(), ExecutorError> {
         if let Some(ref new_pk_values) = pk_values {
+            // Effective per-key-part collation (key-part COLLATE → column
+            // collation → BINARY). A non-BINARY collation forces a
+            // collation-aware comparison because the primary-key hash index is
+            // keyed on exact `SqlValue` bytes and would miss collated
+            // duplicates — e.g. NOCASE 'a' vs 'A' (issue #5881).
+            let collations = self.schema.primary_key_effective_collations().unwrap_or_default();
+            let collated = super::constraints::has_non_binary_collation(&collations);
+
             // Check for duplicates within the batch
-            if self.batch_pk_values.contains(new_pk_values) {
-                let pk_col_names: Vec<String> = self.schema.primary_key.as_ref().unwrap().clone();
-                // SQLite uses "UNIQUE constraint failed" for PRIMARY KEY violations
-                let qualified_cols: Vec<String> =
-                    pk_col_names.iter().map(|col| format!("{}.{}", self.table_name, col)).collect();
-                // SQLite-compatible: output the message as-is without prefix
-                return Err(ExecutorError::SqliteCompatError(format!(
-                    "UNIQUE constraint failed: {}",
-                    qualified_cols.join(", ")
-                )));
+            let dup_in_batch = if collated {
+                self.batch_pk_values.iter().any(|b| {
+                    super::constraints::key_eq_with_collations(new_pk_values, b, &collations)
+                })
+            } else {
+                self.batch_pk_values.contains(new_pk_values)
+            };
+            if dup_in_batch {
+                return Err(super::constraints::primary_key_violation(
+                    self.schema,
+                    self.table_name,
+                ));
             }
 
-            // Check for duplicates in existing table data using index
+            // Check for duplicates in existing table data.
             let table = self
                 .db
                 .get_table(self.table_name)
                 .ok_or_else(|| ExecutorError::TableNotFound(self.table_name.to_string()))?;
 
-            if let Some(pk_index) = table.primary_key_index() {
-                if pk_index.contains_key(new_pk_values) {
-                    let pk_col_names: Vec<String> =
-                        self.schema.primary_key.as_ref().unwrap().clone();
-                    // SQLite uses "UNIQUE constraint failed" for PRIMARY KEY violations
-                    let qualified_cols: Vec<String> = pk_col_names
+            if collated {
+                // Collation-aware scan: the hash index cannot surface collated
+                // duplicates, so compare every row with the key-part collation.
+                let pk_indices = self.schema.get_primary_key_indices().unwrap_or_default();
+                for existing_row in table.scan() {
+                    let existing_pk_values: Vec<vibesql_types::SqlValue> = pk_indices
                         .iter()
-                        .map(|col| format!("{}.{}", self.table_name, col))
+                        .filter_map(|&idx| existing_row.get(idx).cloned())
                         .collect();
-                    // SQLite-compatible: output the message as-is without prefix
-                    return Err(ExecutorError::SqliteCompatError(format!(
-                        "UNIQUE constraint failed: {}",
-                        qualified_cols.join(", ")
-                    )));
+                    if existing_pk_values.contains(&vibesql_types::SqlValue::Null) {
+                        continue;
+                    }
+                    if super::constraints::key_eq_with_collations(
+                        new_pk_values,
+                        &existing_pk_values,
+                        &collations,
+                    ) {
+                        return Err(super::constraints::primary_key_violation(
+                            self.schema,
+                            self.table_name,
+                        ));
+                    }
+                }
+            } else if let Some(pk_index) = table.primary_key_index() {
+                if pk_index.contains_key(new_pk_values) {
+                    return Err(super::constraints::primary_key_violation(
+                        self.schema,
+                        self.table_name,
+                    ));
                 }
             }
         }
@@ -265,46 +290,48 @@ impl<'a> RowValidator<'a> {
                 continue;
             };
 
+            // Effective per-key-part collation (key-part COLLATE → column
+            // collation → BINARY). A non-BINARY collation forces a
+            // collation-aware comparison because the unique hash index is keyed
+            // on exact `SqlValue` bytes (issue #5881).
+            let collations = self.schema.unique_constraint_effective_collations(constraint_idx);
+            let collated = super::constraints::has_non_binary_collation(&collations);
+
             // Check for duplicates within the batch
-            if self.batch_unique_values[constraint_idx].contains(new_unique_values) {
-                let unique_col_names: Vec<String> =
-                    self.schema.unique_constraints[constraint_idx].clone();
-                // Format: "UNIQUE constraint failed: table.col1, table.col2" (SQLite-compatible)
-                let qualified_cols: Vec<String> = unique_col_names
-                    .iter()
-                    .map(|col| format!("{}.{}", self.table_name, col))
-                    .collect();
-                // SQLite-compatible: output the message as-is without prefix
-                return Err(ExecutorError::SqliteCompatError(format!(
-                    "UNIQUE constraint failed: {}",
-                    qualified_cols.join(", ")
-                )));
+            let dup_in_batch = if collated {
+                self.batch_unique_values[constraint_idx].iter().any(|b| {
+                    super::constraints::key_eq_with_collations(new_unique_values, b, &collations)
+                })
+            } else {
+                self.batch_unique_values[constraint_idx].contains(new_unique_values)
+            };
+            if dup_in_batch {
+                return Err(super::constraints::unique_constraint_violation(
+                    self.schema,
+                    self.table_name,
+                    constraint_idx,
+                ));
             }
 
-            // Check for duplicates in existing table data using index
+            // Check for duplicates in existing table data.
             let table = self
                 .db
                 .get_table(self.table_name)
                 .ok_or_else(|| ExecutorError::TableNotFound(self.table_name.to_string()))?;
 
-            if constraint_idx < table.unique_indexes().len() {
+            // BINARY fast path uses the hash index; a non-BINARY collation (or a
+            // missing index) falls through to a collation-aware scan.
+            if !collated && constraint_idx < table.unique_indexes().len() {
                 let unique_index = &table.unique_indexes()[constraint_idx];
                 if unique_index.contains_key(new_unique_values) {
-                    let unique_col_names: Vec<String> =
-                        self.schema.unique_constraints[constraint_idx].clone();
-                    // Format: "UNIQUE constraint failed: table.col1, table.col2" (SQLite-compatible)
-                    let qualified_cols: Vec<String> = unique_col_names
-                        .iter()
-                        .map(|col| format!("{}.{}", self.table_name, col))
-                        .collect();
-                    // SQLite-compatible: output the message as-is without prefix
-                    return Err(ExecutorError::SqliteCompatError(format!(
-                        "UNIQUE constraint failed: {}",
-                        qualified_cols.join(", ")
-                    )));
+                    return Err(super::constraints::unique_constraint_violation(
+                        self.schema,
+                        self.table_name,
+                        constraint_idx,
+                    ));
                 }
             } else {
-                // Fallback to table scan if index not available
+                // Scan (collation-aware when `collated`, exact otherwise).
                 let unique_indices = &unique_constraint_indices[constraint_idx];
                 for existing_row in table.scan() {
                     let existing_unique_values: Vec<vibesql_types::SqlValue> = unique_indices
@@ -317,19 +344,21 @@ impl<'a> RowValidator<'a> {
                         continue;
                     }
 
-                    if new_unique_values == &existing_unique_values {
-                        let unique_col_names: Vec<String> =
-                            self.schema.unique_constraints[constraint_idx].clone();
-                        // Format: "UNIQUE constraint failed: table.col1, table.col2" (SQLite-compatible)
-                        let qualified_cols: Vec<String> = unique_col_names
-                            .iter()
-                            .map(|col| format!("{}.{}", self.table_name, col))
-                            .collect();
-                        // SQLite-compatible: output the message as-is without prefix
-                        return Err(ExecutorError::SqliteCompatError(format!(
-                            "UNIQUE constraint failed: {}",
-                            qualified_cols.join(", ")
-                        )));
+                    let is_dup = if collated {
+                        super::constraints::key_eq_with_collations(
+                            new_unique_values,
+                            &existing_unique_values,
+                            &collations,
+                        )
+                    } else {
+                        *new_unique_values == existing_unique_values
+                    };
+                    if is_dup {
+                        return Err(super::constraints::unique_constraint_violation(
+                            self.schema,
+                            self.table_name,
+                            constraint_idx,
+                        ));
                     }
                 }
             }

--- a/crates/vibesql-executor/tests/pk_unique_collation_enforcement_tests.rs
+++ b/crates/vibesql-executor/tests/pk_unique_collation_enforcement_tests.rs
@@ -1,0 +1,203 @@
+//! INSERT uniqueness enforcement honors per-key-part COLLATE in PRIMARY KEY /
+//! UNIQUE key lists (issue #5881).
+//!
+//! Before this fix, `PRIMARY KEY(a COLLATE nocase)` (and the `UNIQUE(a COLLATE
+//! nocase)` table-constraint variant) parsed the COLLATE token but never applied
+//! it when detecting duplicate keys on INSERT: a case-variant duplicate was
+//! wrongly accepted. These tests pin the SQLite-compatible behavior: the
+//! collation declared on the key part (falling back to the column's declared
+//! collation, then BINARY) is honored when checking uniqueness.
+
+use vibesql_executor::{CreateTableExecutor, InsertExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Run a CREATE TABLE followed by INSERTs. Returns the result of the LAST
+/// statement so callers can assert success/failure of the final INSERT.
+fn run(sql: &str) -> Result<usize, vibesql_executor::ExecutorError> {
+    let mut db = Database::new();
+    let mut last: Result<usize, vibesql_executor::ExecutorError> = Ok(0);
+    for stmt_sql in sql.split(';') {
+        let trimmed = stmt_sql.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let stmt = Parser::parse_sql(trimmed).expect("parse");
+        last = match stmt {
+            vibesql_ast::Statement::CreateTable(c) => {
+                CreateTableExecutor::execute(&c, &mut db).expect("CREATE TABLE");
+                Ok(0)
+            }
+            vibesql_ast::Statement::Insert(i) => InsertExecutor::execute(&mut db, &i),
+            other => panic!("unexpected statement: {other:?}"),
+        };
+    }
+    last
+}
+
+/// Count rows physically present in `table` after a run.
+fn row_count(sql: &str, table: &str) -> usize {
+    let mut db = Database::new();
+    for stmt_sql in sql.split(';') {
+        let trimmed = stmt_sql.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let stmt = Parser::parse_sql(trimmed).expect("parse");
+        match stmt {
+            vibesql_ast::Statement::CreateTable(c) => {
+                CreateTableExecutor::execute(&c, &mut db).expect("CREATE TABLE");
+            }
+            vibesql_ast::Statement::Insert(i) => {
+                // Ignore INSERT errors so we can count how many rows survived.
+                let _ = InsertExecutor::execute(&mut db, &i);
+            }
+            other => panic!("unexpected statement: {other:?}"),
+        }
+    }
+    db.get_table(table).expect("table").scan().len()
+}
+
+fn is_unique_violation(result: &Result<usize, vibesql_executor::ExecutorError>) -> bool {
+    matches!(result, Err(e) if e.to_string().contains("UNIQUE constraint failed"))
+}
+
+#[test]
+fn nocase_pk_rejects_case_variant_duplicate() {
+    // The exact reproducer from issue #5881.
+    let result = run("CREATE TABLE t(a, b, PRIMARY KEY(a COLLATE nocase)) WITHOUT ROWID;
+         INSERT INTO t VALUES('a', 1);
+         INSERT INTO t VALUES('A', 2)");
+    assert!(is_unique_violation(&result), "expected UNIQUE violation, got {result:?}");
+    assert_eq!(
+        row_count(
+            "CREATE TABLE t(a, b, PRIMARY KEY(a COLLATE nocase)) WITHOUT ROWID;
+             INSERT INTO t VALUES('a', 1);
+             INSERT INTO t VALUES('A', 2)",
+            "t",
+        ),
+        1,
+        "only the first row should survive"
+    );
+}
+
+#[test]
+fn nocase_unique_constraint_rejects_case_variant_duplicate() {
+    let result = run("CREATE TABLE t(a, b, UNIQUE(a COLLATE nocase));
+         INSERT INTO t VALUES('hello', 1);
+         INSERT INTO t VALUES('HELLO', 2)");
+    assert!(is_unique_violation(&result), "expected UNIQUE violation, got {result:?}");
+}
+
+#[test]
+fn binary_pk_still_allows_case_variants() {
+    // Default (BINARY) PK: 'a' and 'A' are distinct — both insert.
+    let result = run("CREATE TABLE t(a, b, PRIMARY KEY(a)) WITHOUT ROWID;
+         INSERT INTO t VALUES('a', 1);
+         INSERT INTO t VALUES('A', 2)");
+    assert!(result.is_ok(), "BINARY PK must accept case variants, got {result:?}");
+    assert_eq!(
+        row_count(
+            "CREATE TABLE t(a, b, PRIMARY KEY(a)) WITHOUT ROWID;
+             INSERT INTO t VALUES('a', 1);
+             INSERT INTO t VALUES('A', 2)",
+            "t",
+        ),
+        2,
+    );
+}
+
+#[test]
+fn nocase_pk_allows_genuinely_distinct_values() {
+    let result = run("CREATE TABLE t(a, b, PRIMARY KEY(a COLLATE nocase)) WITHOUT ROWID;
+         INSERT INTO t VALUES('abc', 1);
+         INSERT INTO t VALUES('xyz', 2)");
+    assert!(result.is_ok(), "distinct values must insert, got {result:?}");
+}
+
+#[test]
+fn nocase_pk_rejects_case_variant_within_a_single_batch() {
+    // Both rows arrive in one multi-row VALUES list — the batch dedup path must
+    // also honor the collation.
+    let result = run("CREATE TABLE t(a, b, PRIMARY KEY(a COLLATE nocase)) WITHOUT ROWID;
+         INSERT INTO t VALUES('a', 1), ('A', 2)");
+    assert!(is_unique_violation(&result), "expected batch UNIQUE violation, got {result:?}");
+}
+
+#[test]
+fn rtrim_unique_treats_trailing_space_variants_as_equal() {
+    let result = run("CREATE TABLE t(a, UNIQUE(a COLLATE rtrim));
+         INSERT INTO t VALUES('x');
+         INSERT INTO t VALUES('x   ')");
+    assert!(is_unique_violation(&result), "RTRIM should collide 'x'/'x   ', got {result:?}");
+}
+
+#[test]
+fn key_part_collation_falls_back_to_column_declared_collation() {
+    // No explicit key-part COLLATE, but the column itself is declared NOCASE:
+    // the effective PK collation must fall back to the column's collation.
+    let result = run("CREATE TABLE t(a TEXT COLLATE nocase, b, PRIMARY KEY(a)) WITHOUT ROWID;
+         INSERT INTO t VALUES('a', 1);
+         INSERT INTO t VALUES('A', 2)");
+    assert!(is_unique_violation(&result), "expected fallback to column NOCASE, got {result:?}");
+}
+
+#[test]
+fn composite_pk_with_one_nocase_part() {
+    // ('a',1) and ('A',1) collide (nocase on a, binary on b).
+    let collide = run("CREATE TABLE t(a, b, PRIMARY KEY(a COLLATE nocase, b)) WITHOUT ROWID;
+         INSERT INTO t VALUES('a', 1);
+         INSERT INTO t VALUES('A', 1)");
+    assert!(is_unique_violation(&collide), "composite ('A',1) must collide, got {collide:?}");
+
+    // ('a',1) and ('A',2) do NOT collide — the binary second part differs.
+    let distinct = run("CREATE TABLE t(a, b, PRIMARY KEY(a COLLATE nocase, b)) WITHOUT ROWID;
+         INSERT INTO t VALUES('a', 1);
+         INSERT INTO t VALUES('A', 2)");
+    assert!(distinct.is_ok(), "composite ('A',2) must be distinct, got {distinct:?}");
+}
+
+#[test]
+fn nocase_pk_reports_qualified_column_in_error() {
+    let result = run("CREATE TABLE t(a, b, PRIMARY KEY(a COLLATE nocase)) WITHOUT ROWID;
+         INSERT INTO t VALUES('a', 1);
+         INSERT INTO t VALUES('A', 2)");
+    let msg = result.expect_err("should fail").to_string();
+    assert!(msg.contains("UNIQUE constraint failed: t.a"), "unexpected message: {msg}");
+}
+
+#[test]
+fn nocase_unique_allows_distinct_and_preserves_binary_numeric_keys() {
+    // Sanity: a non-text key under a nocase-declared constraint is compared by
+    // exact equality (collation only affects text), so distinct integers insert.
+    let mut db = Database::new();
+    for stmt_sql in [
+        "CREATE TABLE t(a, UNIQUE(a COLLATE nocase))",
+        "INSERT INTO t VALUES(1)",
+        "INSERT INTO t VALUES(2)",
+    ] {
+        let stmt = Parser::parse_sql(stmt_sql).expect("parse");
+        match stmt {
+            vibesql_ast::Statement::CreateTable(c) => {
+                CreateTableExecutor::execute(&c, &mut db).expect("CREATE TABLE");
+            }
+            vibesql_ast::Statement::Insert(i) => {
+                InsertExecutor::execute(&mut db, &i).expect("INSERT");
+            }
+            _ => unreachable!(),
+        }
+    }
+    let rows = db.get_table("t").expect("table").scan();
+    assert_eq!(rows.len(), 2);
+    // Confirm both integer values are present.
+    let mut vals: Vec<i64> = rows
+        .iter()
+        .filter_map(|r| match r.values.first() {
+            Some(SqlValue::Integer(i)) => Some(*i),
+            _ => None,
+        })
+        .collect();
+    vals.sort_unstable();
+    assert_eq!(vals, vec![1, 2]);
+}

--- a/crates/vibesql-storage/src/persistence/binary/constraints.rs
+++ b/crates/vibesql-storage/src/persistence/binary/constraints.rs
@@ -213,13 +213,40 @@ pub(crate) fn rehydrate_constraints_from_sql_source(
         }
     }
 
+    // ---- PRIMARY KEY key-part collations (issue #5881) ----
+    // The explicit per-key-part COLLATE (`PRIMARY KEY(a COLLATE nocase)`) is not
+    // a serialized binary field, so before this rehydration a reloaded WITHOUT
+    // ROWID / composite PK forgot its collation and INSERT uniqueness silently
+    // reverted to BINARY (a case-variant duplicate would wrongly be accepted).
+    // Rederive it from the re-parsed source, aligned with `primary_key`. A
+    // column-level PK (no table-level key-part COLLATE) leaves every entry
+    // `None`, which falls back to the column's declared collation at enforcement.
+    if let Some(pk_cols) = schema.primary_key.clone() {
+        let table_level_key_parts = create.table_constraints.iter().find_map(|tc| {
+            if let vibesql_ast::TableConstraintKind::PrimaryKey { columns, .. } = &tc.kind {
+                Some(
+                    columns
+                        .iter()
+                        .map(|c| match c {
+                            vibesql_ast::IndexColumn::Column { collation, .. } => collation.clone(),
+                            vibesql_ast::IndexColumn::Expression { .. } => None,
+                        })
+                        .collect::<Vec<_>>(),
+                )
+            } else {
+                None
+            }
+        });
+        schema.primary_key_collations =
+            Some(table_level_key_parts.unwrap_or_else(|| vec![None; pk_cols.len()]));
+    }
+
     // ---- CHECK constraints (column-level first, then table-level) ----
     // Matches ConstraintValidator::process_constraints ordering and naming.
     let mut check_constraints: Vec<(String, vibesql_ast::Expression)> = Vec::new();
     for col_def in &create.columns {
         for constraint in &col_def.constraints {
-            if let vibesql_ast::ColumnConstraintKind::Check { expr, source_text } =
-                &constraint.kind
+            if let vibesql_ast::ColumnConstraintKind::Check { expr, source_text } = &constraint.kind
             {
                 use vibesql_ast::pretty_print::ToSql;
                 // Prefer the explicit name, then the verbatim CHECK source
@@ -410,11 +437,8 @@ mod tests {
     fn rehydrated_check_name_preserves_source_spacing() {
         // Both spaced and unspaced CHECK forms round-trip verbatim through
         // rehydration, matching SQLite's violation-message text byte-for-byte.
-        let mut spaced = schema_with_source(
-            "t",
-            vec![col("d")],
-            "CREATE TABLE t(d INTEGER, CHECK (d > 0))",
-        );
+        let mut spaced =
+            schema_with_source("t", vec![col("d")], "CREATE TABLE t(d INTEGER, CHECK (d > 0))");
         rehydrate_constraints_from_sql_source(&mut spaced, &HashMap::new()).unwrap();
         assert_eq!(spaced.check_constraints[0].0, "d > 0");
 
@@ -584,11 +608,36 @@ mod tests {
 
     #[test]
     fn non_strict_table_stays_non_strict_on_rehydrate() {
-        let mut schema =
-            schema_with_source("t", vec![col("a")], "CREATE TABLE t(a INTEGER)");
+        let mut schema = schema_with_source("t", vec![col("a")], "CREATE TABLE t(a INTEGER)");
         rehydrate_constraints_from_sql_source(&mut schema, &HashMap::new()).unwrap();
         assert!(!schema.strict);
         assert!(schema.strict_types.is_empty());
+    }
+
+    #[test]
+    fn rehydrates_primary_key_key_part_collation() {
+        // The explicit `PRIMARY KEY(a COLLATE nocase)` key-part collation is not
+        // a serialized binary field; it must be rederived from `sql_source` so
+        // INSERT uniqueness keeps honoring it after a reload (issue #5881).
+        let mut schema = schema_with_source(
+            "t",
+            vec![col("a"), col("b")],
+            "CREATE TABLE t(a, b, PRIMARY KEY(a COLLATE nocase)) WITHOUT ROWID",
+        );
+        schema.primary_key = Some(vec!["a".to_string()]);
+        rehydrate_constraints_from_sql_source(&mut schema, &HashMap::new()).unwrap();
+        assert_eq!(schema.primary_key_collations, Some(vec![Some("nocase".to_string())]));
+    }
+
+    #[test]
+    fn rehydrates_column_level_pk_with_no_key_part_collation() {
+        // A column-level PK carries no key-part COLLATE, so every entry is None
+        // (enforcement falls back to the column's declared collation).
+        let mut schema =
+            schema_with_source("t", vec![col("id")], "CREATE TABLE t(id INTEGER PRIMARY KEY)");
+        schema.primary_key = Some(vec!["id".to_string()]);
+        rehydrate_constraints_from_sql_source(&mut schema, &HashMap::new()).unwrap();
+        assert_eq!(schema.primary_key_collations, Some(vec![None]));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`PRIMARY KEY(a COLLATE nocase)` and the `UNIQUE(a COLLATE nocase)` table-constraint variant parsed the per-key-part `COLLATE` token but never applied it when detecting duplicate keys on INSERT, so a case-variant duplicate was wrongly accepted. This PR wires the parsed key-part collation into INSERT uniqueness enforcement so declared collations (NOCASE, RTRIM) are honored.

The foundational AST carrier (`IndexColumn::Column { collation }`) already landed via #5921; the parser already populates it for table-level PK/UNIQUE lists. This PR adds the missing enforcement layer.

## Before / after (exact reproducer)

```sql
CREATE TABLE t(a, b, PRIMARY KEY(a COLLATE nocase)) WITHOUT ROWID;
INSERT INTO t VALUES('a', 1);
INSERT INTO t VALUES('A', 2);
SELECT COUNT(*) FROM t;
```

| | Before | After (matches sqlite3 3.51.0) |
|---|---|---|
| 2nd INSERT | wrongly accepted | `UNIQUE constraint failed: t.a` |
| `COUNT(*)` | `2` | `1` |

Same fix applies to `UNIQUE(a COLLATE nocase)` (2nd INSERT now fails `UNIQUE constraint failed: t2.a`).

## Collation fallback order

Each key part resolves its effective collation in SQLite order: **explicit key-part `COLLATE` → the column's declared collation → BINARY** (case-sensitive default). A non-text value under any collation still compares by exact equality (collation only affects text).

## Changes

- **`vibesql-catalog` `TableSchema`**: added non-persisted `primary_key_collations` / `unique_constraint_collations` (parallel to `primary_key` / `unique_constraints`), plus `primary_key_effective_collations()` / `unique_constraint_effective_collations()` resolvers implementing the fallback order. Not serialized (same pattern as `strict_types`); `remove_column` clears them to avoid stale misalignment.
- **`ConstraintValidator`**: collects the key-part `COLLATE` from each `IndexColumn` (table-level PK/UNIQUE) and sets it on the schema at CREATE TABLE time. Column-level PK/UNIQUE contribute `None` (fall back to the column's collation).
- **INSERT enforcement** (`insert/row_validator.rs` Phases 2 & 3, and the `enforce_primary_key_constraint` / `enforce_unique_constraints` free functions used by REPLACE/bulk paths): when any key part resolves to a non-BINARY collation, bypass the raw `SqlValue`-keyed hash index (which cannot surface collated duplicates — `'a'`/`'A'` hash to different buckets) and use a collation-aware scan. The BINARY hash fast path is unchanged, so the common case keeps O(1) probes. Batch (multi-row VALUES) dedup is also collation-aware.
- **Binary catalog load**: rederive PK key-part collations from the re-parsed `sql_source` during constraint rehydration, so enforcement survives a `\save`/reload (verified manually).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| nocase PK WITHOUT ROWID rejects case-variant dup | ✅ | Repro fails with `UNIQUE constraint failed: t.a`, `COUNT(*)=1` |
| `UNIQUE(a COLLATE nocase)` rejects case-variant dup | ✅ | 2nd INSERT fails `UNIQUE constraint failed: t2.a` |
| BINARY default still case-sensitive | ✅ | `PRIMARY KEY(a)` accepts `'a'` and `'A'` (COUNT=2) |
| genuinely-distinct value still inserts | ✅ | distinct + composite-key tests |
| Rust tests added | ✅ | 10 integration + 5 unit + 2 rehydration tests |
| No regressions | ✅ | See Test Plan |

## Test Plan

- New `pk_unique_collation_enforcement_tests.rs` (10 tests): nocase PK/UNIQUE reject, BINARY allows case variants, distinct values insert, single-batch dedup, RTRIM, column-collation fallback, composite PK, error message, numeric-key sanity.
- New `constraint_validator` unit tests (5) and `binary/constraints` rehydration tests (2).
- Full suites pass with no regressions: `vibesql-executor` lib (3506), `vibesql-storage` lib (803), `vibesql-catalog` (58), plus `conflict_resolution`, `constraint_rehydration_reload`, `upsert_do_update_constraint`, `comparison_collation`, `in_list_collation`, `foreign_key_collation_action` integration suites.
- Manual: exact reproducers above against `./target/release/vibesql`, plus `\save`/reload round-trip (PK enforcement survives reload).

## Out of scope / notes

- UPSERT conflict-target matching (`on_conflict_update.rs`) was #5921 and is untouched here. `INSERT ... ON CONFLICT(a) DO UPDATE` on a WITHOUT ROWID nocase PK currently still inserts a second row rather than matching the conflict; that path is unchanged by this PR and is a separate, pre-existing gap.
- Table-level `UNIQUE` collation is not restored on binary reload because `unique_constraints` itself is not persisted (post-reload UNIQUE is enforced via the persisted index path). PK key-part collation is rehydrated. Fully collation-aware reload of the named unique-index path can be a follow-up.

Closes #5881