### PR TITLE
fix(build): restore rand-0.10 RngExt imports and Assignment.columns in bench/test targets

### DIFF
--- a/crates/vibesql-bench-common/src/tpch/data.rs
+++ b/crates/vibesql-bench-common/src/tpch/data.rs
@@ -4,7 +4,7 @@
 //! It includes constants for reference data (nations, regions) and a data
 //! generator that produces deterministic pseudo-random data based on scale factor.
 
-use rand::{Rng, RngExt, SeedableRng};
+use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
 pub const NATIONS: &[(&str, usize)] = &[

--- a/crates/vibesql-executor/benches/tpcds/data.rs
+++ b/crates/vibesql-executor/benches/tpcds/data.rs
@@ -11,7 +11,7 @@
 //!   customer_demographics, household_demographics, income_band, store, catalog_page, web_page,
 //!   web_site, warehouse, ship_mode, reason, promotion, call_center
 
-use rand::{Rng, SeedableRng};
+use rand::{Rng, RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
 // Gender options

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/blob_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/blob_funcs.rs
@@ -7,7 +7,7 @@
 //! - RANDOMBLOB(n) - Create blob of n random bytes
 //! - QUOTE(x) - Return SQL literal representation
 
-use rand::{Rng, RngExt};
+use rand::RngExt;
 use vibesql_types::SqlValue;
 
 use crate::errors::ExecutorError;

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/math_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/math_funcs.rs
@@ -6,7 +6,7 @@
 //! - UNLIKELY(x) - Query planner hint (no-op)
 //! - LIKELIHOOD(x, p) - Query planner hint with probability (no-op)
 
-use rand::{Rng, RngExt};
+use rand::RngExt;
 use vibesql_types::SqlValue;
 
 use crate::errors::ExecutorError;

--- a/crates/vibesql-executor/src/evaluator/window/ranking.rs
+++ b/crates/vibesql-executor/src/evaluator/window/ranking.rs
@@ -8,10 +8,7 @@ use vibesql_ast::{Expression, OrderByItem};
 use vibesql_storage::Row;
 use vibesql_types::SqlValue;
 
-use super::{
-    partitioning::Partition,
-    sorting::{compare_values, compare_values_with_collation},
-};
+use super::{partitioning::Partition, sorting::compare_values_with_collation};
 
 /// Check if ORDER BY values differ between two rows, respecting collation
 fn order_values_differ<F>(

--- a/crates/vibesql-executor/src/select/scan/table_function.rs
+++ b/crates/vibesql-executor/src/select/scan/table_function.rs
@@ -156,16 +156,15 @@ pub(crate) fn execute_table_function(
     // `json_each(t.j).json == t.j` byte-for-byte (json101-5.5/5.6 compare with
     // `<>`). For a JSONB blob the text form of the decoded document is used; for
     // a non-text scalar its JSON scalar token is used.
-    let mut json_column_text: Option<String> = None;
-    let root = match &json_value {
+    let (root, json_column_text): (_, Option<String>) = match &json_value {
         SqlValue::Null => return Ok(super::FromResult::from_rows(schema, vec![])),
         SqlValue::Blob(bytes) => {
             let node = decode_jsonb_blob(bytes)
                 .ok_or_else(|| ExecutorError::SqliteCompatError("malformed JSON".to_string()))?;
             // JSONB blob: echo the decoded document as normalized JSON text
             // (the raw blob is not valid text to echo).
-            json_column_text = Some(json_node_to_json_text(&node));
-            node
+            let text = json_node_to_json_text(&node);
+            (node, Some(text))
         }
         other => {
             let json_str = match sqlvalue_as_json_text(other) {
@@ -175,8 +174,7 @@ pub(crate) fn execute_table_function(
             let node = parse_json_relaxed(&json_str)
                 .map_err(|_| ExecutorError::SqliteCompatError("malformed JSON".to_string()))?;
             // Echo the input text verbatim (preserves original whitespace).
-            json_column_text = Some(json_str);
-            node
+            (node, Some(json_str))
         }
     };
 

--- a/crates/vibesql-executor/tests/temporal_index_probe_tests.rs
+++ b/crates/vibesql-executor/tests/temporal_index_probe_tests.rs
@@ -185,7 +185,7 @@ fn expression_index_timestamp_one_sided_ranges_full_strings() {
 
 #[test]
 fn expression_index_timestamp_no_over_return_on_lower_bound() {
-    let mut db = timestamp_expression_db();
+    let db = timestamp_expression_db();
     // Over-return guard: rows strictly below the bound must NOT be returned.
     // Before the fix, lower-bounded probes returned every temporal key.
     let rows = select_ints(&db, "SELECT x FROM t1 WHERE datetime(b) >= '2017-07-10'").unwrap();

--- a/crates/vibesql-server/src/connection/auth.rs
+++ b/crates/vibesql-server/src/connection/auth.rs
@@ -75,7 +75,7 @@ pub async fn authenticate(
             debug!("Requesting MD5 password for user '{}'", user);
 
             // Generate random salt
-            use rand::{Rng, RngExt};
+            use rand::RngExt;
             let salt: [u8; 4] = rand::rng().random();
 
             send_md5_password_request(write_half, write_buf, &salt).await?;

--- a/crates/vibesql-sqllogictest/src/result_updater.rs
+++ b/crates/vibesql-sqllogictest/src/result_updater.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use rand::{Rng, RngExt};
+use rand::RngExt;
 
 use crate::{
     executor::Runner,

--- a/crates/vibesql-storage/src/wal/recovery.rs
+++ b/crates/vibesql-storage/src/wal/recovery.rs
@@ -1578,7 +1578,7 @@ mod tests {
             let file = std::fs::File::create(&wal_path).unwrap();
             let mut writer = WalWriter::create(file).unwrap();
             let mut lsn = 1u64;
-            let mut append = |writer: &mut WalWriter<std::fs::File>, op: WalOp, lsn: &mut u64| {
+            let append = |writer: &mut WalWriter<std::fs::File>, op: WalOp, lsn: &mut u64| {
                 writer.append(&WalEntry::new(*lsn, 0, op)).unwrap();
                 *lsn += 1;
             };

--- a/tests/storage/update_pk_performance.rs
+++ b/tests/storage/update_pk_performance.rs
@@ -56,6 +56,7 @@ fn test_update_with_pk_index_performance() {
             alias: None,
             assignments: vec![Assignment {
                 column: "value".to_string(),
+                columns: Vec::new(),
                 value: Expression::BinaryOp {
                     left: Box::new(Expression::ColumnRef(ColumnIdentifier::simple("value", false))),
                     op: BinaryOperator::Plus,


### PR DESCRIPTION
## Summary

`cargo build --release --all-targets` failed with **20 compile errors** (all in `vibesql-executor`) while the default `cargo build --release` passed — so CI's lib+bin build never caught it. The breakage came from the `rand` 0.10 bump: in rand 0.10 the number-generating methods (`random_range`, `random_bool`, `random`, `sample`) were moved onto the `RngExt` trait (`RngExt: Rng`). Call sites that only imported `Rng` lost those methods (`E0599`), and a bench also drifted from a changed AST struct (`E0063`).

**rand-0.10 trait-import idiom applied:** import `RngExt` (not `Rng`) at any call site that calls `random_range`/`random_bool`/`random`/`sample`, matching the already-migrated `vibesql-bench-common` code (`use rand::{Rng, RngExt, SeedableRng};`). Where `Rng` alone was imported but only `RngExt` methods were used, the unused `Rng` was dropped.

## Changes

- **benches/tpcds/data.rs** — add `RngExt` to the import so `random_range`/`random_bool`/`sample` on `ChaCha8Rng` resolve (fixes 19 E0599).
- **tests/storage/update_pk_performance.rs** — add the new `Assignment.columns` field (`columns: Vec::new()`) to the AST literal (fixes E0063).
- **result_updater.rs / blob_funcs.rs / math_funcs.rs / connection/auth.rs / tpch/data.rs** — drop now-unused `Rng` from imports that only use `RngExt`.
- **window/ranking.rs** — drop unused `compare_values` import.
- **select/scan/table_function.rs** — fold `json_column_text` into the `match` result tuple, removing the dead `None` initializer / `unused_assignments` warning.
- **wal/recovery.rs** — drop redundant `mut` on the `append` closure binding.
- **temporal_index_probe_tests.rs** — drop redundant `mut` on `db` (this warning only surfaced once the executor targets compiled past the bench again).

## Error/warning counts (before → after)

| Metric | Before | After |
|--------|--------|-------|
| `cargo build --release --all-targets` errors | 20 | **0** |
| `--all-targets` warnings (listed migration churn) | present | **0** |

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `cargo build --release --all-targets` zero errors | ✅ | Rebuilt: `EXIT=0`, 0 errors, 0 warnings |
| Executor benches build (`cargo bench --no-run -p vibesql-executor`) | ✅ | `BENCH_EXIT=0`, 0 errors |
| No new warnings; listed unused-import/mut/assignment warnings resolved | ✅ | `grep warning:` on the final `--all-targets` build is empty |
| Default `cargo build --release` remains green | ✅ | `DEFAULT_EXIT=0`, 0 errors |

## Test Plan

1. `cargo build --release --all-targets` → 0 errors, 0 warnings.
2. `cargo bench --no-run -p vibesql-executor` → compiles clean (tpcds/data.rs, update_pk_performance.rs).
3. `cargo build --release` → still green.

Only the touched files were formatted (`rustfmt <file>`), no repo-wide `cargo fmt`.

Closes #6147