### PR TITLE
perf(tcl): persist detail rows in one transactional process, not per-batch

### DIFF
--- a/scripts/tcl_runner.py
+++ b/scripts/tcl_runner.py
@@ -766,6 +766,15 @@ def insert_detail_rows(
     Detail rows carry the AUTOINCREMENT `id` PK, so many rows may share one
     `run_id` via plain INSERTs — this is what makes incremental per-batch
     appends work without a PK conflict.
+
+    Persist strategy (issue #6149): all rows for this call are inserted by a
+    SINGLE `vibesql` process inside ONE transaction, so the CLI's expensive
+    full-DB checkpoint happens exactly ONCE (at COMMIT / process exit) rather
+    than once per 200-row batch. The previous implementation spawned a fresh
+    `vibesql <db> -c ...` process per batch, which re-checkpointed the entire
+    growing results DB every batch — O(rows^2) checkpoint work that ran for
+    hours and torned every rebaseline. A malformed value falls back to a
+    granular per-batch/per-row retry that still counts failures exactly.
     """
     # Helper to escape SQL string literals. Returns the full SQL literal
     # including surrounding quotes (or NULL for empty values).
@@ -808,15 +817,23 @@ def insert_detail_rows(
         "execution_time_ms, line_number"
     )
 
-    def insert_batch(rows: list[TestResult]) -> bool:
-        """Insert a batch of rows in one statement. Returns True on success."""
-        if not rows:
-            return True
+    # Rows-per-INSERT: bound each statement's size to keep the multi-row VALUES
+    # list manageable while still amortizing per-statement overhead.
+    BATCH_SIZE = 200
+
+    def batch_insert_sql(rows: list[TestResult]) -> str:
+        """Build one multi-row INSERT statement for `rows`."""
         values = ",\n".join(row_values(r) for r in rows)
-        insert_sql = f"INSERT INTO tcl_test_results ({columns}) VALUES\n{values};"
+        return f"INSERT INTO tcl_test_results ({columns}) VALUES\n{values};"
+
+    def run_command(sql: str) -> bool:
+        """Run a single statement in its own process. Returns True on success.
+
+        Used only by the rare per-row failure-isolation fallback below.
+        """
         try:
             subprocess.run(
-                [vibesql_path, db_path, "-c", insert_sql],
+                [vibesql_path, db_path, "-c", sql],
                 capture_output=True,
                 check=True,
             )
@@ -824,29 +841,90 @@ def insert_detail_rows(
         except subprocess.CalledProcessError:
             return False
 
+    def run_txn_script(insert_statements: list[str]) -> bool:
+        """Execute many INSERTs in ONE vibesql process wrapped in a single
+        transaction. Returns True on a clean exit (every insert succeeded).
+
+        This is the O(n^2) -> O(n) fix (issue #6149). Spawning a fresh
+        `vibesql <db> -c ...` process per 200-row batch made the CLI reload and
+        re-checkpoint the ENTIRE growing results DB on every batch's clean exit,
+        so a full run's persist did checkpoint work proportional to rows^2 and
+        ran for hours at 100% CPU (torning every rebaseline). The CLI's script
+        executor suppresses its per-modification-statement auto-save while a
+        transaction is open and checkpoints exactly ONCE at COMMIT, so feeding
+        all batches to a single process inside one BEGIN/COMMIT collapses the
+        whole persist to a single full-DB checkpoint at process exit.
+        """
+        if not insert_statements:
+            return True
+        script = "BEGIN;\n" + "\n".join(insert_statements) + "\nCOMMIT;\n"
+        try:
+            proc = subprocess.run(
+                [vibesql_path, db_path, "--stdin"],
+                input=script,
+                capture_output=True,
+                text=True,
+            )
+            return proc.returncode == 0
+        except OSError:
+            return False
+
+    def delete_this_calls_rows() -> None:
+        """Remove any rows THIS call may have already landed, scoped to this
+        call's files under `run_id`.
+
+        A batched transaction that hits a malformed value is NOT atomic in the
+        VibeSQL CLI: the script executor continues past the failed statement
+        while the transaction is open and still COMMITs the survivors. Before
+        the granular retry re-inserts everything we must therefore clear the
+        partial writes, or good rows would be double-inserted. The delete is
+        scoped to `file_path IN (this call's files)` so it never touches earlier
+        file-batches persisted under the same shared `run_id` (the #6136
+        incremental durability model persists each file exactly once).
+        """
+        distinct_files = sorted({r.file_path for r in results if r.file_path})
+        if not distinct_files:
+            return
+        in_list = ", ".join(sql_literal(f, 500) for f in distinct_files)
+        run_command(
+            f"DELETE FROM tcl_test_results "
+            f"WHERE run_id = {run_id} AND file_path IN ({in_list});"
+        )
+
     total_rows = len(results)
     inserted = 0
     failed_inserts = 0
     failure_samples: list[str] = []
 
-    # Insert in batches for speed. If a batch fails (e.g. one malformed value),
-    # fall back to per-row inserts so we lose at most the genuinely-bad rows and
-    # can count/report exactly how many failed instead of silently dropping the
-    # entire batch.
-    BATCH_SIZE = 200
-    for start in range(0, total_rows, BATCH_SIZE):
-        batch = results[start:start + BATCH_SIZE]
-        if insert_batch(batch):
-            inserted += len(batch)
-            continue
-        # Batch failed: retry each row individually.
-        for r in batch:
-            if insert_batch([r]):
-                inserted += 1
-            else:
-                failed_inserts += 1
-                if len(failure_samples) < 5:
-                    failure_samples.append(f"{r.file_path}::{r.test_name}")
+    # Partition into bounded multi-row INSERT statements once; both the fast
+    # single-transaction path and the granular fallback reuse the same batches.
+    batches = [
+        results[start:start + BATCH_SIZE]
+        for start in range(0, total_rows, BATCH_SIZE)
+    ]
+
+    # Fast path: ALL batches in ONE process inside ONE transaction -> ONE
+    # checkpoint at COMMIT. This is the common case (rows are well-formed).
+    if batches and run_txn_script([batch_insert_sql(b) for b in batches]):
+        inserted = total_rows
+    elif batches:
+        # Slow path (rare): a malformed value aborted the batched transaction,
+        # possibly leaving partial writes. Clean this call's rows, then retry
+        # per batch and finally per row so we lose at most the genuinely-bad
+        # rows and can count/report exactly how many failed.
+        delete_this_calls_rows()
+        for batch in batches:
+            if run_txn_script([batch_insert_sql(batch)]):
+                inserted += len(batch)
+                continue
+            # Batch failed: retry each row individually.
+            for r in batch:
+                if run_command(batch_insert_sql([r])):
+                    inserted += 1
+                else:
+                    failed_inserts += 1
+                    if len(failure_samples) < 5:
+                        failure_samples.append(f"{r.file_path}::{r.test_name}")
 
     if total_rows > 0:
         fail_pct = 100.0 * failed_inserts / total_rows


### PR DESCRIPTION
## Summary

`insert_detail_rows` in `scripts/tcl_runner.py` persisted per-test detail rows by spawning a **fresh `vibesql <db> -c "INSERT ..."` process per 200-row batch**. The `vibesql` CLI reloads and re-checkpoints the **entire growing results DB** on every clean exit, so a full 1174-file run (~360k rows ≈ ~1,800 batches) did checkpoint work proportional to **rows²** — running for hours at 100% CPU and torning every rebaseline (the summary `tcl_test_runs` and detail `tcl_test_results` tables never reconciled because the persist never finished before interruption).

This makes the persist **O(n²) → O(n)**: all batches are fed to a **single** `vibesql` process inside **one `BEGIN`/`COMMIT` transaction**. The CLI's script executor suppresses its per-modification-statement auto-save while a transaction is open and checkpoints **exactly once at COMMIT**, so the whole persist costs one full-DB checkpoint instead of one per batch.

## Changes

- `scripts/tcl_runner.py` — `insert_detail_rows`:
  - **Fast path:** partition rows into 200-row multi-row `VALUES` INSERTs (bounds statement size, unchanged) and run them all in **one** `vibesql <db> --stdin` process wrapped in a single `BEGIN; ... COMMIT;`. Clean exit ⇒ all rows inserted, **one checkpoint**.
  - **Fallback (rare):** on a non-zero exit (a value the engine rejects), delete this call's rows — **scoped to this call's `file_path`s** so earlier file-batches under the same shared `run_id` (the #6136 incremental model) survive — then retry per batch and finally per row so at most genuinely-bad rows are lost and `failed_inserts` is counted exactly. A partially-committed failed transaction can leave survivors, so the scoped delete prevents double-insertion.
  - `sql_literal` / `row_values` / `columns` / AUTOINCREMENT `id` handling / the >5% → non-zero-exit reporting block are **unchanged**.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Persist is O(n), one checkpoint per call, not per 200-row batch | ✅ | Single process, single transaction, single COMMIT checkpoint |
| Wall-clock scales linearly (10k vs 50k ≈ 5x, not ~25x) | ✅ | NEW: 0.14s → 0.70s = **5.0x** for 5x rows (linear); OLD: 1.10s → 19.0s = **17x** (quadratic) |
| Row count equals rows persisted; summary/detail reconcile | ✅ | Native e2e (select1+where): 495 detail rows; summary_scored=356 == detail_scored=356 |
| Per-batch failure fallback preserved (individual retry, count, >5% exit) | ✅ | Fallback test: 450 good + 1 colliding row → 449 inserted, 1 failed (0.2%), no double-insert, other file's rows untouched |
| `run_id` / AUTOINCREMENT `id` / `sql_literal` / `row_values` unchanged | ✅ | Those blocks left byte-for-byte as-is |
| #6136 incremental durability preserved (one run_id, per-file-batch persist) | ✅ | Each `insert_detail_rows` call = one process = one checkpoint; scoped delete never touches earlier batches |

## Test Plan

`cargo build --release` (green), then against fresh results DBs:

**Benchmark (OLD process-per-batch vs NEW single-process):**
```
=== N = 10000 ===  OLD 1.10s ckpt=2 rows=10000 | NEW 0.14s ckpt=2 rows=10000  (7.9x)
=== N = 50000 ===  OLD 19.01s ckpt=2 rows=50000 | NEW 0.70s ckpt=2 rows=50000 (27.1x)
scaling (NEW): 10000 -> 50000: rows x5.0, NEW time x5.0 (linear)
```
OLD is quadratic (17x time for 5x rows); NEW is linear (5x for 5x). Checkpoint **files** read 2 for both only because the CLI's archive is retention-pruned — the O(n²) cost is the checkpoint *write work per process exit* (250 writes OLD vs 1 write NEW), which the wall-clock captures definitively.

**Fallback correctness:** 450 good rows + 1 row colliding with a pre-seeded `UNIQUE(test_name)` row in a different file → 449 inserted, 1 counted failed, 449 distinct (no double-insert), the other file's row left intact, report `449/450 inserted ... 1 failed (0.2%)`.

**End-to-end (native tclsh):** `tcl_runner.py --native-tcl select1.test where.test` → 495 detail rows inserted, checkpoints constant at 2, `make test-tcl-status` reads 495 tests / 356 passed / 2 files; summary and detail reconcile.

**Regression:** existing `scripts/test_tcl_parser.py` — 4/4 pass (shared persist function used by both native and static paths).

Note: I confirmed the CLI's per-`-c`/per-statement auto-save is a full-DB checkpoint, and that the runner-side single-transaction fix is sufficient — no CLI change was needed. A future CLI flag to suppress per-exit checkpointing could help other callers, but is out of scope here.

Closes #6149