### PR TITLE
fix(tcl): treat file-scope early return as clean exit, not an incomplete marker

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -7425,8 +7425,21 @@ proc run_test_file {filename} {
     # with $::varname (explicit global namespace). Using 'eval' inside this proc
     # would make those variables local to run_test_file, not global.
     # 'uplevel #0' ensures the test file runs in the global scope.
-    if {[catch {uplevel #0 $content} err]} {
-        # A top-level (non-do_test) statement threw and aborted file
+    # Distinguish a genuine mid-file abort (a real TCL_ERROR) from a clean
+    # file-scope `return` (#6151). `catch` reports the propagated return code:
+    #   1 == TCL_ERROR  -> a top-level statement threw and truncated the file.
+    #   2 == TCL_RETURN -> the file executed a bare `return` at file scope,
+    #                      a standard SQLite-test idiom to self-disable a file
+    #                      (e.g. alias.test's `return` after a comment) or to
+    #                      bail after a guard. This is a CLEAN early-exit, not a
+    #                      crash: err is empty and no errorInfo stack exists.
+    #   0 == TCL_OK      -> normal completion (does not enter the block).
+    # Previously EVERY non-zero code (including a clean TCL_RETURN) fell into
+    # the "aborted mid-file" path and wrote a false 'incomplete' marker, so
+    # ~128 self-disabling files were mis-counted as failed worker deaths.
+    set eval_code [catch {uplevel #0 $content} err eval_opts]
+    if {$eval_code == 1} {
+        # TCL_ERROR: a top-level (non-do_test) statement threw and aborted file
         # evaluation — typically a bare `execsql`/`db eval` setup statement
         # that hit a genuine VibeSQL gap, or cross-connection state the shim's
         # per-statement process model cannot preserve (e.g. TEMP objects from
@@ -7446,6 +7459,25 @@ proc run_test_file {filename} {
         # as the file's complete result. The row keeps the tests that DID run
         # (they are already emitted) and marks the file compromised in the DB.
         emit_test_detail incomplete "ABORTED_MID_FILE: $err"
+        set ::file_marker_emitted 1
+    } elseif {$eval_code == 2} {
+        # TCL_RETURN: clean file-scope early-return. Do NOT emit an 'incomplete'
+        # marker. Any tests that DID run before the return are already tallied
+        # (their detail rows were emitted incrementally); if none ran, finish_test
+        # synthesizes a clean 'skipped' row (the capability-self-skip path) so the
+        # file is recorded as a completed 0-test file rather than a worker death.
+        if {$::nTest > 0} {
+            puts "File-scope early return after $::nTest test(s) — file completed cleanly."
+        } else {
+            puts "File-scope early return (self-disabled) — 0 tests, clean early-exit."
+        }
+    } elseif {$eval_code != 0} {
+        # Any other non-zero, non-OK code (TCL_BREAK/TCL_CONTINUE at file scope,
+        # or a custom return code) is not a legitimate completion path. Treat it
+        # conservatively as a genuine abort so real problems are never masked.
+        puts "Setup error (file evaluation aborted mid-file, code $eval_code): $err"
+        puts "Error info: [expr {[info exists ::errorInfo] ? $::errorInfo : {(none)}}]"
+        emit_test_detail incomplete "ABORTED_MID_FILE (code $eval_code): $err"
         set ::file_marker_emitted 1
     }
 


### PR DESCRIPTION
## Summary

On a full native-TCL run, 277/1174 files emit a single `incomplete` marker ("worker died") instead of real per-test rows (#6151). This splits into two causes; this PR fixes **Cause A** (~128 files: a legitimate file-scope `return` mis-classified as a crash) and explicitly leaves **Cause B** (~141 files: genuine mid-file engine crashes) for follow-up.

### Root cause (Cause A)

The shim (`scripts/tester_vibesql.tcl`) evaluated each test file with `uplevel #0 $content` inside a bare `if {[catch ...]}`, which fires on **any** non-zero TCL return code. A file-scope `return` — a standard SQLite-test idiom for self-disabling a file (e.g. `alias.test`) or bailing after a platform/capability guard (e.g. `bigfile.test`'s `if {$tcl_platform(os)=="Darwin"} return`) — propagates as **TCL_RETURN (catch code 2)**, not an error, yet was routed into the "aborted mid-file" path and written as a false `incomplete` marker (counted as a failure).

## Changes

`scripts/tester_vibesql.tcl` — inspect the *propagated catch return code* instead of "any non-zero":

- **code 1 (TCL_ERROR)** — genuine mid-file abort → emit `incomplete` marker (unchanged; Cause B real crashes stay reported, **not masked**).
- **code 2 (TCL_RETURN)** — clean file-scope `return` → **no marker**. Tests that ran before the return are already tallied incrementally; if none ran, `finish_test` synthesizes a clean `skipped` row (the existing capability-self-skip path), so the file is recorded as a completed 0-test file.
- **other non-zero codes** (TCL_BREAK/CONTINUE/custom) — treated conservatively as genuine aborts, so real problems are never silently swallowed.

No change was needed in `scripts/tcl_runner.py`: the shim now prints the normal `finish_test` summary trailer and exits 0 for clean early-returns, exactly like the pre-existing whole-file-skip path the runner already handles.

Cause B (genuine worker deaths, e.g. `autoinc.test` → `invalid command name "sqlite3_db_config_lookaside"`, `attach.test` → mid-file crash after 29 tests) is intentionally **left for per-file engine triage** — no worker-resilience change was made, because the remaining deaths are subprocess-level crashes that the existing per-statement catch cannot recover cheaply.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `cargo build --release` succeeds | ✅ | Built clean (exit 0) |
| `alias.test` → clean completion, no incomplete marker | ✅ | Before: "Setup error… / worker died". After: "File-scope early return (self-disabled) — 0 tests, clean early-exit"; Skipped: 1, no incomplete marker |
| 2-3 more early-return files complete cleanly | ✅ | `bigfile.test`, `bigfile2.test`, `bigmmap.test` (self-disable via `if {os=="Darwin"} return`) now report clean skipped instead of incomplete |
| Cause B not masked | ✅ | `attach.test` still "Files incomplete: 1 (worker died)"; `autoinc.test` still incomplete (`invalid command name "sqlite3_db_config_lookaside"` — a real TCL_ERROR) |
| Normal files unchanged | ✅ | `select1.test` 188/188 passed; `where.test` runs all 307 tests, no worker death |
| `scripts/test_tcl_parser.py` + script tests, no regression | ✅ | `test_tcl_parser.py` 4/4 pass; `test_process_test_results.py` 21/21 pass. `test_generate_punchlist.py` fails identically on clean main (pre-existing Python-binding issue: `TableNotFound`/`save_sql_dump`), unrelated to this TCL-only change |
| Bonus: batch shows incomplete-count drop + detail/summary reconcile | ✅ | `big*.test` batch (new run_id=5): 64/64 detail rows inserted; big* files went **3 incomplete → 0 incomplete** (3 → clean skipped) vs old run_id=4, with real passes unchanged at 60 |

## Test Plan

```
./scripts/tcltest test alias.test     # clean early-exit, 0 tests, no incomplete marker
./scripts/tcltest test attach.test    # STILL incomplete (Cause B, not masked)
./scripts/tcltest test select1.test   # 188/188 unchanged
./scripts/tcltest run --pattern "big*.test"   # 0 incomplete markers, 64/64 rows reconcile
python3 scripts/test_tcl_parser.py    # 4/4 pass
```

Before/after (big* files, run 4 = old shim vs run 5 = fixed shim):

| run_id | incomplete_rows | skipped_rows | passed_rows |
|--------|-----------------|--------------|-------------|
| 4 (before) | 3 | 1 | 60 |
| 5 (after)  | 0 | 4 | 60 |

Part of epic #5779. Cause B (~141 genuine mid-file worker deaths) left for follow-up per-file engine triage.

Closes #6151

🤖 Generated with [Claude Code](https://claude.com/claude-code)