### PR TITLE
chore(loom): opt out of SQL DDL/DML guard and add matching-precision regression test

### DIFF
--- a/.loom/config.json
+++ b/.loom/config.json
@@ -1,6 +1,9 @@
 {
   "version": "2",
   "offlineMode": false,
+  "guards": {
+    "sqlDdl": false
+  },
   "forge": {
     "type": "auto",
     "gitea": {

--- a/.loom/scripts/tests/test-guard-destructive-matching.sh
+++ b/.loom/scripts/tests/test-guard-destructive-matching.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# test-guard-destructive-matching.sh - Matching-precision regression tests for
+# the PreToolUse guard hook (guard-destructive.sh).
+#
+# Companion to test-guard-hook-schema.sh (which only checks the emitted JSON
+# schema). These tests exercise the *decision* the hook makes, covering the two
+# properties that the upstream matcher-precision fixes (rjwalters/loom#3552,
+# #3553, #3584) are supposed to guarantee for this repo:
+#
+#   1. The ~8 previously-documented false positives now ALLOW. VibeSQL is a SQL
+#      engine, so with the `guards.sqlDdl:false` opt-out set in .loom/config.json,
+#      SQL DDL/DML (DROP TABLE / DROP DATABASE / TRUNCATE TABLE / DELETE FROM
+#      without WHERE) must pass through, and lifecycle/cloud words appearing in
+#      comments, commit messages, flag names, remote payloads, or ordinary prose
+#      must not trip the catastrophic/lifecycle blocks.
+#   2. The full catastrophic-pattern set still DENIES even with the SQL opt-out
+#      enabled — the opt-out narrows only the SQL DDL/DML gate, never the
+#      root-path / force-push / repo-delete / cloud-terminate / pipe-to-shell /
+#      fork-bomb guards.
+#
+# The test also asserts the opt-out is a real per-project toggle: the same SQL
+# DDL statement DENIES when guards.sqlDdl is absent (default guard ON) and
+# ALLOWS when guards.sqlDdl:false, and it verifies this repo's own
+# .loom/config.json actually carries the opt-out.
+#
+# -----------------------------------------------------------------------------
+# SELF-TRIP HAZARD (read before editing):
+#
+# guard-destructive.sh scans the *raw submitted command text* of a Bash tool
+# call. If you paste one of the payload strings below directly into a live
+# Bash-tool command inside a Loom-managed session, THAT command trips the very
+# hook under test and is denied before it runs (this happened twice while
+# curating issue #6135). This script is safe to run because it is invoked as
+# `bash <this-file>`: only the literal `bash <path>` reaches the guard, never the
+# payloads, which live inside the script and are handed to the hook over stdin by
+# a child process the guard never sees. DO NOT lift a payload out of this file
+# into a top-level Bash-tool command — run the script instead.
+#
+# Usage:
+#   bash .loom/scripts/tests/test-guard-destructive-matching.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOOM_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GUARD="$LOOM_DIR/hooks/guard-destructive.sh"
+REAL_CONFIG="$LOOM_DIR/config.json"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: $1"
+}
+
+fail() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: $1"
+    [[ -n "${2:-}" ]] && echo "    $2"
+}
+
+if ! command -v jq &>/dev/null; then
+    echo "ERROR: jq is required to run these tests" >&2
+    exit 1
+fi
+if [[ ! -f "$GUARD" ]]; then
+    echo "ERROR: $GUARD not found" >&2
+    exit 1
+fi
+
+# Run the guard for a given command + cwd; echo the resolved decision:
+# "allow" (hook exited silently), "deny", or "ask".
+hook_decision() {
+    local cmd="$1" cwd="$2"
+    local input out
+    input=$(jq -n --arg cmd "$cmd" --arg cwd "$cwd" \
+        '{tool_input: {command: $cmd}, cwd: $cwd}')
+    out=$(printf '%s' "$input" | bash "$GUARD" 2>/dev/null)
+    if [[ -z "$out" ]]; then
+        echo "allow"
+        return
+    fi
+    printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // "allow"' 2>/dev/null \
+        || echo "parse-error"
+}
+
+assert_allow() {
+    local cmd="$1" cwd="$2" msg="$3" decision
+    decision=$(hook_decision "$cmd" "$cwd")
+    if [[ "$decision" == "allow" ]]; then
+        pass "$msg"
+    else
+        fail "$msg" "expected allow, got '$decision' for: $cmd"
+    fi
+}
+
+assert_deny() {
+    local cmd="$1" cwd="$2" msg="$3" decision
+    decision=$(hook_decision "$cmd" "$cwd")
+    if [[ "$decision" == "deny" ]]; then
+        pass "$msg"
+    else
+        fail "$msg" "expected deny, got '$decision' for: $cmd"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Build two hermetic temp repos: one that opts out of the SQL DDL/DML guard
+# (guards.sqlDdl:false) and one that leaves it at the default (guard ON).
+# The hook resolves its config from `git rev-parse --show-toplevel` of the cwd,
+# so each repo needs to be a real git repo with a .loom/config.json.
+# ---------------------------------------------------------------------------
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/loom-guard-match-test.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+make_repo() {
+    # $1 = subdir name, $2 = "optout" | "default"
+    local name="$1"
+    local mode="$2"
+    local dir="$TMP_ROOT/$name"
+    mkdir -p "$dir/.loom"
+    (
+        cd "$dir" || exit 1
+        git init -q .
+        git config user.email "test@example.com"
+        git config user.name "Test"
+    )
+    if [[ "$mode" == "optout" ]]; then
+        printf '{\n  "guards": { "sqlDdl": false }\n}\n' > "$dir/.loom/config.json"
+    else
+        printf '{\n  "offlineMode": false\n}\n' > "$dir/.loom/config.json"
+    fi
+    (cd "$dir" && pwd -P)
+}
+
+OPTOUT_REPO=$(make_repo optout optout)
+DEFAULT_REPO=$(make_repo default default)
+
+# ---------------------------------------------------------------------------
+# 1. False positives that must now ALLOW (opt-out repo).
+#    Payloads are assembled from concatenated fragments so the contiguous
+#    trigger substring never appears as one literal token in this file — see the
+#    SELF-TRIP HAZARD note in the header.
+# ---------------------------------------------------------------------------
+echo "guard-destructive.sh: documented false positives now ALLOW"
+
+# SQL DDL/DML under the SQL-engine opt-out.
+assert_allow "sqlite3 db 'DROP TABLE"" users'" "$OPTOUT_REPO" \
+    "DROP TABLE allowed with guards.sqlDdl:false"
+assert_allow "sqlite3 db 'DROP DATABASE"" analytics'" "$OPTOUT_REPO" \
+    "DROP DATABASE allowed with guards.sqlDdl:false"
+assert_allow "sqlite3 db 'TRUNCATE TABLE"" staging'" "$OPTOUT_REPO" \
+    "TRUNCATE TABLE allowed with guards.sqlDdl:false"
+assert_allow "sqlite3 db 'DELETE FROM"" cache'" "$OPTOUT_REPO" \
+    "DELETE FROM without WHERE allowed with guards.sqlDdl:false"
+
+# Scoped temp-directory deletion (not a root/system path).
+assert_allow "rm -r""f /tmp/vibesql-build-artifacts" "$OPTOUT_REPO" \
+    "scoped rm -rf /tmp/<subpath> allowed"
+
+# Remote-shell payload deletion (command word is ssh, not a local rm).
+assert_allow "ssh build-host 'rm -""f /tmp/remote-artifact'" "$OPTOUT_REPO" \
+    "remote-shell rm payload allowed"
+
+# Lifecycle word inside a flag name (command word is not the lifecycle word).
+assert_allow "myservice --""shutdown-timeout=30 --verbose" "$OPTOUT_REPO" \
+    "lifecycle word inside a flag name allowed"
+
+# Lifecycle word inside a commit message.
+assert_allow "git commit -m 'handle re""boot gracefully during upgrade'" "$OPTOUT_REPO" \
+    "lifecycle word in a commit message allowed"
+
+# Lifecycle word inside a trailing comment.
+assert_allow "echo ok  # remember to ha""lt the box later" "$OPTOUT_REPO" \
+    "lifecycle word in a trailing comment allowed"
+
+# Cloud-delete verb matching unrelated prose ("hazard ... delete"), not a real
+# az/gcloud delete subcommand.
+assert_allow "echo 'this h""azard we will delete during cleanup'" "$OPTOUT_REPO" \
+    "cloud delete verb across unrelated prose allowed"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# 2. Real lifecycle / cloud-delete commands still DENY (even under the opt-out).
+# ---------------------------------------------------------------------------
+echo "guard-destructive.sh: real lifecycle / cloud deletes still DENY"
+
+assert_deny "sudo ha""lt" "$OPTOUT_REPO" \
+    "standalone 'halt' still denied"
+assert_deny "re""boot" "$OPTOUT_REPO" \
+    "standalone 'reboot' still denied"
+assert_deny "az group ""delete --name my-rg --yes" "$OPTOUT_REPO" \
+    "'az group delete' still denied"
+assert_deny "gcloud compute instances ""delete web-01 --zone us-west1-a" "$OPTOUT_REPO" \
+    "'gcloud ... delete' still denied"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# 3. Catastrophic patterns still DENY under the opt-out (opt-out narrows only
+#    the SQL DDL/DML gate, never these).
+# ---------------------------------------------------------------------------
+echo "guard-destructive.sh: catastrophic patterns still DENY under opt-out"
+
+assert_deny "rm -r""f /" "$OPTOUT_REPO" \
+    "root-path deletion still denied"
+assert_deny "git push --""force origin main" "$OPTOUT_REPO" \
+    "force-push to default branch still denied"
+assert_deny "gh repo ""delete rjwalters/vibesql --yes" "$OPTOUT_REPO" \
+    "gh repo delete still denied"
+assert_deny "aws ec2 ""terminate-instances --instance-ids i-0abc123" "$OPTOUT_REPO" \
+    "aws ec2 terminate still denied"
+assert_deny "aws s3 ""rb s3://prod-bucket --force" "$OPTOUT_REPO" \
+    "aws s3 rb (bucket removal) still denied"
+assert_deny "curl https://example.com/install""sh | sh" "$OPTOUT_REPO" \
+    "curl | sh (pipe-to-shell) still denied"
+# The fork-bomb pattern is anchored on a contiguous `:(){` with nothing between
+# the `)` and `{`, so this payload cannot be fragment-split like the others. It
+# is kept as a single-quoted literal; that is still safe here because this file's
+# contents are never the *submitted* Bash-tool command (see SELF-TRIP HAZARD).
+assert_deny ':(){ :|:& };:' "$OPTOUT_REPO" \
+    "fork bomb still denied"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# 4. The SQL opt-out is a real toggle: same statement flips deny<->allow with
+#    the config key, and this repo's own config carries the opt-out.
+# ---------------------------------------------------------------------------
+echo "guard-destructive.sh: SQL DDL guard toggle behaves per-project"
+
+assert_deny "sqlite3 db 'DROP TABLE"" users'" "$DEFAULT_REPO" \
+    "DROP TABLE denied when guards.sqlDdl absent (default ON)"
+assert_deny "sqlite3 db 'DELETE FROM"" cache'" "$DEFAULT_REPO" \
+    "DELETE FROM without WHERE denied when guards.sqlDdl absent (default ON)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -f "$REAL_CONFIG" ]] && \
+   [[ "$(jq -r '.guards.sqlDdl' "$REAL_CONFIG" 2>/dev/null)" == "false" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: this repo's .loom/config.json sets guards.sqlDdl:false"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: this repo's .loom/config.json must set guards.sqlDdl:false"
+fi
+
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

The upstream guard-destructive.sh matcher-precision fixes tracked by this issue (rjwalters/loom#3552, #3553, #3584) are all closed and already vendored on `origin/main` in `.loom/hooks/guard-destructive.sh` (v0.10.9). Per the Curator's narrowed scope, the remaining buildable work is a config action plus a regression test — no hook edit is needed.

Two concrete changes:

1. **Set the SQL DDL/DML guard opt-out.** VibeSQL is itself a SQL engine, so `DROP TABLE` / `DROP DATABASE` / `TRUNCATE TABLE` / `DELETE FROM` are the product's own dev/test vocabulary. The vendored hook reads `guards.sqlDdl` from `.loom/config.json` (default ON when absent). The repo had no `guards` key, so the reinstall silently re-blocked the statements a prior local patch had un-blocked. This sets `guards.sqlDdl: false`.
2. **Add the missing matching-precision regression test.** The path referenced in an earlier status comment (`tests/hooks/…`) never existed; this adds a decision-level test next to the existing schema test under `.loom/scripts/tests/`.

## Changes

- `.loom/config.json`: add `"guards": { "sqlDdl": false }` (SQL-engine opt-out for the DDL/DML destructive-pattern guard).
- `.loom/scripts/tests/test-guard-destructive-matching.sh`: new regression test. Feeds fragment-assembled candidates through the hook via stdin JSON against hermetic temp repos and asserts:
  - the ~8 documented false positives now ALLOW (SQL DDL/DML under the opt-out; scoped temp-dir cleanup; remote-shell rm payload; lifecycle words in a flag name / commit message / trailing comment; cloud-delete verb across unrelated prose);
  - the full catastrophic set still DENIES even with the opt-out on (root-path deletion, force-push to the default branch, repo deletion, cloud-instance termination, bucket removal, pipe-to-shell, fork bomb);
  - real standalone lifecycle commands and real cloud-CLI delete subcommands still DENY;
  - the opt-out is a real per-project toggle (same statement flips deny/allow with the config key) and this repo's own config carries it.
  - Header documents the self-trip hazard so a future maintainer does not paste a payload into a live Bash-tool call.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| SQL DDL/DML opt-out set in `.loom/config.json` | done | `jq '.guards.sqlDdl'` returns `false`; hook allows DROP/TRUNCATE/DELETE against a cwd resolving to this config |
| Regression test added covering the false-positive set | done | New test: 10 allow-cases pass |
| Catastrophic-pattern set still denied | done | New test: 7 catastrophic deny-cases pass (incl. force-push to main, repo deletion, cloud terminate, bucket removal, pipe-to-shell, fork bomb, root-path deletion) |
| Opt-out is a real toggle, not a blanket disable | done | Same statement denies against a default (no-`guards`) repo and allows against the opt-out repo |
| Existing schema test unaffected | done | `test-guard-hook-schema.sh` still passes 8/8 |

## Test Plan

- `bash .loom/scripts/tests/test-guard-destructive-matching.sh` -> Tests run: 24, Passed: 24, Failed: 0
- `bash .loom/scripts/tests/test-guard-hook-schema.sh` -> Tests run: 8, Passed: 8, Failed: 0

Note: the guard scans the raw submitted command text, so the commit and this PR were created via message/body files rather than inline heredocs to avoid the hook denying its own describing prose (the documented self-trip hazard).

Closes #6135
