### PR TITLE
docs(tcl): add skip-honesty policy + Bucket-B audit enforcement

### DIFF
--- a/docs/reference/tcl-skip-policy.md
+++ b/docs/reference/tcl-skip-policy.md
@@ -1,0 +1,317 @@
+# TCL Skip-Honesty Policy
+
+**Status:** canonical. Part of epic #5779. Delivers the static (source-only)
+half of issue #6154.
+
+An honest claim of "N% SQLite compatibility" is meaningless without a
+**defensible skip policy**: a documented taxonomy in which every whole-file and
+partial skip falls into exactly one bucket, with the "we skip because we fail"
+bucket driven to **zero**. Until every skip carries a category-level rationale a
+skeptical outside observer would accept, we cannot honestly say what "100%" is a
+percentage *of*.
+
+This document is the canonical taxonomy. It enumerates the Bucket-A categories
+with rationale, records the Bucket-B worklist, and states the standing rule that
+**no new skip may be added without declaring its bucket**.
+
+---
+
+## The two-bucket rule
+
+Every skip must be exactly one of:
+
+**Bucket A — Out-of-scope by design (HONEST to exclude).** The test exercises
+functionality VibeSQL deliberately does not implement, and never will as an
+in-scope SQL engine, OR it depends on a test-harness surface (C-API,
+TCL-registered helper, internal counter) that is unreachable from the SQL CLI. A
+skeptic reading the rationale agrees it is not a SQL-conformance gap.
+
+**Bucket B — Skipped because we fail / can't yet (DISHONEST to exclude).** Any
+skip that hides a real, in-scope SQL feature we do not yet support correctly.
+These must be **un-skipped** and either fixed or left visibly failing (counted in
+the denominator). This bucket must reach **zero** for an honest 100%.
+
+The tell for a Bucket-B smell is rationale language like *"behavior differs"*,
+*"handling differs"*, *"features differ"*, *"not implemented"*, or *"not fully
+supported"* attached to an **in-scope SQL surface** (collation, type affinity,
+subqueries, ROWID, UNIQUE, ALTER TABLE, name resolution, window functions).
+Contrast with a defensible Bucket-A rationale, which names a specific
+out-of-scope subsystem (a C-API entry point, a VFS/pager internal, an unshipped
+extension, or a harness-only function).
+
+---
+
+## Scope of this document (read this first)
+
+The issue title speaks of "all 174,982 skipped test **rows**". That row count is
+a property of the **certified full run** (tag `aws-c7i.8xlarge-32c-final`,
+run_id under #6144) whose results DB lives only on the AWS bench runner — it is
+**not** available in this working tree. The certified run tells you the *volume*
+each skip declaration suppresses (how many numbered test-row instances a given
+glob matched); it does **not** change the *category* of any declaration.
+
+This document therefore classifies the **static skip declarations** that are
+fully in-tree in `scripts/tester_vibesql.tcl`, which is everything the category
+decision actually depends on:
+
+| Array | Count | What it declares |
+|-------|-------|------------------|
+| `vibesql_skip_files` | 60 | whole-file skips (basename → reason) |
+| `vibesql_partial_skip_files` | 1 | documented partial-skip record (`atof1`) |
+| `vibesql_skip_tests` | 1,528 | individually-named test skips |
+| `vibesql_skip_patterns` | 56 | glob-pattern skip rules |
+
+**Deferred to operator data (deliverable 5 of #6154):** the reconciled
+excluded-row denominator "by category" and any `ifcapable`-guarded self-skip that
+produced `skipped` rows only at runtime require the certified bench-runner DB.
+Those are explicitly out of scope for the static classification and are tracked
+as a follow-up. See "Deferred work" at the end. The fuzz-corpus smoke-skips named
+in the issue body (`fuzz-oss1` / `fuzzer1` / `dbfuzz001`) are **not** present as
+static declarations in `scripts/tester_vibesql.tcl`; if they suppressed rows in
+the certified run they did so via runtime `ifcapable` guards, which fall under
+the deferred half.
+
+---
+
+## Bucket A categories (defensible out-of-scope)
+
+Every whole-file skip (all 60) and 13 of the 56 pattern skips are Bucket A. They
+group into the following categories. The rationale is stated **per category** so
+the audit is a short list of principles, not 116 ad-hoc notes.
+
+### A1. C-API / statement-handle surface
+
+Tests assert `sqlite3_*` C-API behavior (prepare / step / column metadata /
+bind / value-pointer / autocommit / error codes) that is unreachable from the SQL
+CLI. `execsql` blocks in these files are setup only; there is no
+`do_execsql_test` SQL-reachable coverage.
+
+- Whole-file: `capi2`, `capi3`, `capi3b`, `capi3c`, `capi3d`, `capi3e`,
+  `tkt2409`, `colmeta`, `tableapi`, `bind`, `ptrchng`, `delete_db`,
+  `intarray`, `snapshot`, `shared6`, `symlink`, `quota-glob`, `varint`.
+- Rationale: no SQL surface. VibeSQL is driven through SQL text; the C library
+  API is not a conformance target.
+
+### A2. VFS / pager internals
+
+Tests exercise the rollback-journal pager, page layout, byte-exact file format,
+file locking, or deliberately corrupted page images — none of which exist in
+VibeSQL, which uses its own WAL and has no B-tree page layer.
+
+- Whole-file: `jrnlmode`, `jrnlmode3`, `pagesize`, `filefmt`, `corruptL`,
+  `lock`, `lock5`, `sort2` (multi-threaded-sorter PMA config via
+  `sqlite3_config`), `strict2` (writable_schema rootpage aliasing).
+- Pattern: `e_wal-` ("WAL mode not implemented" — VibeSQL ships its own WAL;
+  SQLite's WAL-pragma pager semantics are not applicable).
+
+### A3. Unshipped extensions / virtual tables
+
+Tests require an extension or virtual-table module VibeSQL does not ship (FTS3/4,
+R-tree, RBU, session, `wholenumber` vtab, `ieee754`, trusted-schema).
+
+- Whole-file: `fts3`, `rtree`, `rbu`, `session`, `index6`, `index7` (wholenumber
+  vtab data population), `orderby7` (FTS3 join), `ieee754`, `trustschema1`.
+- Note: the permutation dispatchers below (A6) also recurse into these.
+
+### A4. Incremental blob I/O
+
+Tests use `incrblob` — SQLite's incremental blob streaming C API, no SQL surface.
+
+- Whole-file: `incrblob`, `incrblob2`, `incrblob3`, `incrblob4`,
+  `incrblob_err`, `incrblobfault`.
+
+### A5. Harness-only functions & TCL helpers
+
+Tests depend on a function or variable that exists only as a TCL test helper
+(`db func` / `db function` / `db collate` registration) or a SQLite test
+extension, with no SQL-CLI-reachable equivalent.
+
+- Whole-file: `intreal`, `func4` (`tointeger`/`toreal` from the `totype` test
+  extension), `trigger6` (`counter()` TCL helper), `update2` (`repeat()`
+  registered via `db func repeat [list string repeat]` — harness-provided, not a
+  SQLite built-in).
+- Pattern: `select9-2.*.3`, `select9-2.*.6` (custom `reverse` collation via
+  `db collate`, not bridgeable to the CLI subprocess), `temptable-`,
+  `temptable2-` (require cross-test session state the process-per-batch shim
+  cannot hold), `date-6.` (localtime DST needs the `SQLITE_TESTCTRL_LOCALTIME_FAULT`
+  harness override), `date4-` (compares against libc `strftime`; shim stubs it via
+  `clock format`).
+
+### A6. Permutation / suite dispatchers
+
+`all` / `full` / `quick` / `veryquick` / `extraquick` / `rbu` / `session` are
+`permutations.test` dispatchers that re-source the nonexistent `$testdir/tester.tcl`
+(the shim ships `tester_vibesql.tcl`) and would double-run content files the
+per-file runner already executes individually. A file-level skip yields one clean
+`skipped` row instead of an `incomplete` marker.
+
+- Whole-file: `all`, `full`, `quick`, `veryquick`, `extraquick`, `rbu`,
+  `session`.
+
+### A7. Internal optimizer / VDBE counters
+
+Tests assert internal opcode counters, transfer-optimization counts, or STAT4
+histogram-driven plan choices — query *results* are correct, but the counters
+have no VibeSQL equivalent.
+
+- Whole-file: `insert4`, `insert5` (xfer-opt counters), `whereJ` (STAT4),
+  `where8` (`sqlite_search_count` step counts), `malloc4` (OOM fault injection),
+  `manydb` (~116 concurrent connections; shim is process-per-batch).
+- Pattern: `indexexpr3-` (asserts `EXPLAIN` COVERING INDEX output), `fordelete-`
+  (btree `FORDELETE` VDBE flag), `fkey_malloc-`, `windowfault-` (fault
+  injection).
+
+### A8. Built-in-test fuzzers
+
+Gated by `ifcapable builtin_test`; drive a C-level fuzzer for an internal
+structure with no SQL surface.
+
+- Whole-file: `bitvec` (`sqlite3BitvecBuiltinTest`; ~750k assertions,
+  internals-only — #6140/#6143).
+
+### A9. Documented intentional engine divergence
+
+VibeSQL's Rust string pipeline enforces valid UTF-8 by construction, so
+byte-preserving invalid-UTF-8 behavior is a *deliberate* design divergence, not a
+conformance gap it intends to close. Reasonable skeptic accepts "we are UTF-8
+strict by construction."
+
+- Whole-file: `badutf`, `badutf2`.
+- Pattern: `utf16align-` (UTF-16 alignment/encoding internals; VibeSQL is UTF-8).
+- Borderline flag: this is the one Bucket-A category whose members are *failing*
+  rather than *unreachable*. It stays Bucket A only because the divergence is
+  documented and intentional. Any new member must justify why the divergence is a
+  design choice and not an unfixed bug.
+
+### A10. Error-message-format divergence
+
+Result set / behavior is correct; only the exact error **text** differs from
+SQLite's. Not a conformance gap for a differently-worded but semantically
+equivalent error.
+
+- Pattern: `subselect-1.2` ("row value misused" vs "sub-select returns N
+  columns").
+- (Many named `vibesql_skip_tests` entries also fall here — see below.)
+
+---
+
+## Bucket B worklist (dishonest skips — must reach zero)
+
+These skip declarations hide **in-scope SQL** behind blanket "differs" / "not
+implemented" rationales. Per the two-bucket rule they are Bucket B: each must be
+**un-skipped** and either fixed or left visibly `failed`. This PR **classifies**
+them; the actual un-skip + fix-or-fail-visibly is **Phase 2** (see "Deferred
+work") because verifying that an un-skip fails *cleanly* (without regressing
+passing tests in the same file, and without a monster-file row explosion
+dominating the raw pass rate) requires a full-suite run on the quiet bench runner.
+
+### B — curator-flagged pattern entries (all confirmed Bucket B)
+
+Each was scrutinized for a defensible Bucket-A rationale; none survives, because
+each names an **in-scope SQL surface**:
+
+| Pattern(s) | Rationale as written | Why it is Bucket B |
+|-----------|----------------------|--------------------|
+| `collate1-` … `collateA-` (8) | "Collation behavior differs" | Built-in `BINARY`/`NOCASE`/`RTRIM` collation is core SQL. Custom-collation *sub*-cases are already separately Bucket A (the `db collate` detector), so the blanket file glob over-skips real coverage. |
+| `types-`, `types2-` | "Type handling differs" | Type affinity is core SQL. |
+| `subquery-` | "Subquery handling differs" | Subqueries are core SQL. |
+| `without_rowid1/2/5/6-` | "WITHOUT ROWID tables not fully supported" | WITHOUT ROWID is a real SQLite feature; "not fully" + the fact that `without_rowid3/4` are *not* skipped is direct evidence of a partial engine gap. |
+| `autoindex3/4/5-` | "Automatic indexing not implemented" | Automatic (transient) indexing. Result-only cases must still pass; plan-assertion cases are Bucket A **only if** verified to assert `EXPLAIN`/`sqlite_search_count`. Blanket skip is not defensible; `autoindex1/2` are not skipped. |
+| `unique2-` | "UNIQUE constraint handling differs" | UNIQUE constraints are core SQL. |
+| `rowid-` | "ROWID behavior differs" | ROWID semantics are core SQLite conformance. |
+| `resolver01-` | "Name resolution handling differs" | Name/scope resolution is core SQL. |
+| `misc3-`, `misc4-` | "Miscellaneous tests - various features differ" | Vague-by-construction; indefensible as out-of-scope. |
+| `aggnested-` | "Nested aggregate functions not fully supported" | Nested/correlated aggregates are core SQL. |
+
+### B — additional pattern entries flagged by this audit (not in the curator list)
+
+Honesty requires reporting the Bucket-B smells the curator did not pre-list:
+
+| Pattern(s) | Rationale as written | Disposition |
+|-----------|----------------------|-------------|
+| `printf2-` | "format() function behavior differs" | `format()`/`printf()` is a SQL function → Bucket B. |
+| `e_totalchanges-` | "total_changes() not implemented" | `total_changes()` is SQL-reachable → Bucket B (engine gap). |
+| `altertab2-`, `altertab3-`, `alterlegacy-` | "ALTER TABLE features differ / legacy" | ALTER TABLE is core SQL → Bucket B. |
+| `window1-66.`, `window2-66.`, `window1-69.` | "json_group_array/object / total() as window function not implemented" | Window-function coverage of real aggregates → Bucket B (engine gap). |
+| `orderby8-1.` | "ORDER BY with many columns - stress test" | ORDER BY is core SQL; "stress test" is not an out-of-scope rationale → Bucket B (verify). |
+| `orderbyA-` | "ORDER BY optimization differs" | Bucket B **unless** verified to assert only the query plan (then A7). |
+| `boundary1-` … `boundary4-` | "Boundary condition tests - stress test" | Integer-boundary affinity/comparison is core SQL → Bucket B (verify). |
+| `like2-` | "LIKE operator test - setup cascade failures" | Cascade from an upstream failure → fix the upstream cause, do not blanket-skip. |
+| `tableopts-` | "Table options differ" | Bucket B (verify which options). |
+| `randexpr-` | "Random expression stress test" | Machine-generated expression fuzzer. Needs a **documented decision** (same shape as the fuzz-corpus question): either run for a certified number, or justify as a no-incremental-signal corpus. Until decided, treat as Bucket B. |
+| `sidedelete-` | "'sequence' conflicts with VibeSQL parser keyword" | VibeSQL reserves a keyword SQLite does not. Parser divergence → Bucket B (de-reserve, or document as an intentional divergence with a real rationale — "differs" alone is not one). |
+
+### B — named-test array (`vibesql_skip_tests`, 1,528 entries)
+
+The named-test array is dominated by Bucket-A categories (harness/TCL-helper,
+extension/vtab, internal/EXPLAIN/VDBE, error-message-format, and
+test-infra-cascade). A residual subset carries the same "differs" / "not
+supported" / "not implemented" Bucket-B smell attached to in-scope SQL. Per-entry
+adjudication of 1,528 rows is Phase-2 per-file work (the same fix-or-unskip
+verification loop as the patterns) and is **not** attempted in this static pass;
+the standing-rule check below flags the smell so the residual cannot grow
+silently.
+
+---
+
+## Landmines (do not regress)
+
+- **`atof1` partial skip (#6065).** The ~39,998 dynamically-named
+  `atof1-1.$i.1/.2` loop tests call `real2hex()`/`hex2real()` — harness-only
+  functions (Bucket A, category A5). But the ~7 non-loop `atof1-2.x`/`atof-3.x`
+  tests are legitimate `do_execsql_test` coverage and **must keep running**.
+  `atof1-2.10/2.20/2.30` (UTF-16be `substr`) and `atof-3.1` (large-literal REAL
+  precision) are REAL open engine bugs tracked in #6065 — they must keep
+  reporting `failed`, **never** be reclassified as skipped. This is why `atof1`
+  is a `vibesql_partial_skip_files` record and **not** a whole-file skip.
+- **`fuzz.test` real failures (#6070–#6073).** The residual `fuzz.test` failures
+  are tracked by OPEN ISSUES, not by skip entries — they keep running and
+  reporting `failed`. No `vibesql_skip_tests` entry may be added for them.
+- **`bitvec` (#6140/#6143)** and the **permutation dispatchers** (`all`/`quick`/
+  `full`/…) are confirmed Bucket A (categories A8 and A6).
+
+---
+
+## Standing rule: no undeclared skip
+
+**No new whole-file or pattern skip may be added to
+`scripts/tester_vibesql.tcl` without declaring its bucket.**
+
+- A Bucket-A skip must name one of the categories above (A1–A10) in its rationale
+  string, or add a new category to this document with a principled rationale.
+- A Bucket-B skip is not permitted as a *permanent* entry. If a temporary skip is
+  unavoidable, it must be recorded here in the Bucket-B worklist with a tracking
+  issue and the intent to un-skip.
+
+This is enforced (not merely documented) by
+`scripts/verify_skips.py --audit-buckets`, which scans every pattern/whole-file
+rationale for Bucket-B smell phrases and fails if it finds one that is not on the
+acknowledged Bucket-B worklist above (and is not on a declared Bucket-A
+override). A future contributor adding a "behavior differs" skip must therefore
+either declare it Bucket A with a category or add it to the worklist — the check
+will not let it pass silently. Run it locally and in review:
+
+```bash
+scripts/verify_skips.py --audit-buckets
+```
+
+---
+
+## Deferred work (operator data required — deliverable 5)
+
+These parts of #6154 depend on the certified bench-runner DB and are **not**
+delivered by the static classification:
+
+1. **Reconciled excluded-row denominator by category.** Attribute the certified
+   run's 174,982 skipped rows to the categories above and publish the count, so
+   the "100% of in-scope tests" claim has a defensible base. Requires the
+   `~/.vibesql/test_results/tcl_test_results.vbsql` DB on the AWS bench runner.
+2. **`ifcapable`-guarded runtime self-skips.** Enumerate skips that only appear at
+   runtime (including the `fuzz-oss1`/`fuzzer1`/`dbfuzz001` smoke-skips) and
+   classify them.
+3. **Drive Bucket B to zero.** Un-skip each Bucket-B pattern (and the named-test
+   residual), fix the gap or leave it visibly `failed`, and confirm on a quiet
+   full-suite run that no previously-passing test in the same file regresses.
+4. **Wire the by-category excluded count into `make test-tcl-status`.**
+
+Tracked under #6154 (this PR is `Part of #6154`, not `Closes`).

--- a/scripts/verify_skips.py
+++ b/scripts/verify_skips.py
@@ -24,6 +24,59 @@ REPO_ROOT = Path(__file__).parent.parent
 SHIM_FILE = REPO_ROOT / "scripts" / "tester_vibesql.tcl"
 TCL_TEST_DIR = REPO_ROOT / "docs" / "reference" / "sqlite" / "test"
 
+# ---------------------------------------------------------------------------
+# Skip-honesty audit (issue #6154 / epic #5779)
+#
+# See docs/reference/tcl-skip-policy.md for the two-bucket taxonomy. The audit
+# below is the structural enforcement of the standing rule "no new skip may be
+# added without declaring its bucket": it scans every whole-file / pattern skip
+# rationale for Bucket-B smell phrases (in-scope-SQL "differs"/"not implemented"
+# language) and fails if it finds one that is neither on the acknowledged
+# Bucket-B worklist nor declared as a Bucket-A category override.
+# ---------------------------------------------------------------------------
+
+# Rationale substrings that mark a skip as hiding an in-scope SQL gap.
+BUCKET_B_SMELL_PHRASES = (
+    "behavior differs",
+    "handling differs",
+    "features differ",
+    "feature differs",
+    "not fully supported",
+    "not implemented",
+    "optimization differs",
+    "options differ",
+)
+
+# Pattern/file keys already adjudicated Bucket B in the #6154 static pass. They
+# are expected to carry smell phrases; the policy doc records the Phase-2
+# fix-or-unskip worklist for each. Keyed by the exact array key in the shim.
+ACK_BUCKET_B = {
+    # curator-flagged
+    "collate1-", "collate2-", "collate3-", "collate4-", "collate5-",
+    "collate7-", "collate8-", "collate9-", "collateA-",
+    "types-", "types2-", "subquery-",
+    "without_rowid1-", "without_rowid2-", "without_rowid5-", "without_rowid6-",
+    "autoindex3-", "autoindex4-", "autoindex5-",
+    "unique2-", "rowid-", "resolver01-", "misc3-", "misc4-", "aggnested-",
+    # additional entries flagged by this audit
+    "printf2-", "e_totalchanges-",
+    "altertab2-", "altertab3-", "alterlegacy-",
+    "window1-66.", "window2-66.", "window1-69.",
+    "orderby8-1.", "orderbyA-",
+    "boundary1-", "boundary2-", "boundary3-", "boundary4-",
+    "like2-", "tableopts-", "randexpr-", "sidedelete-",
+}
+
+# Pattern/file keys whose rationale contains a smell phrase but which are
+# defensibly Bucket A (the phrase describes an out-of-scope subsystem, not an
+# in-scope SQL gap). Keep this list short and principled — each maps to a
+# category in docs/reference/tcl-skip-policy.md.
+ACK_BUCKET_A_OVERRIDE = {
+    "e_wal-",        # A2: VibeSQL ships its own WAL; SQLite WAL-pragma pager semantics N/A
+    "indexexpr3-",   # A7: asserts EXPLAIN COVERING INDEX output, not results
+    "utf16align-",   # A9: UTF-16 encoding internals; VibeSQL is UTF-8 by construction
+}
+
 
 def parse_skip_list(shim_content: str) -> dict:
     """Extract skip entries from the shim file."""
@@ -130,6 +183,91 @@ def parse_whole_file_skips(shim_content: str) -> dict:
             files[m.group(1)] = m.group(2).replace('\\"', '"')
 
     return files
+
+
+def parse_skip_patterns(shim_content: str) -> dict:
+    """Extract glob-pattern skip entries from the shim file.
+
+    These are the ``vibesql_skip_patterns`` list entries, each a TCL brace-quoted
+    ``{pattern "reason"}``. The pattern is a glob prefix (e.g. ``collate1-``) and
+    the reason is a double-quoted rationale string. Returns ``{pattern: reason}``.
+    """
+    patterns = {}
+
+    match = re.search(
+        r'variable vibesql_skip_patterns \{(.*?)\n\}',
+        shim_content,
+        re.DOTALL,
+    )
+    if not match:
+        return patterns
+
+    # Each entry is {<pattern> "<reason>"} on its own line. The pattern token has
+    # no whitespace; the reason is a double-quoted string.
+    for m in re.finditer(r'\{(\S+)\s+"((?:[^"\\]|\\.)*)"\}', match.group(1)):
+        patterns[m.group(1)] = m.group(2).replace('\\"', '"')
+
+    return patterns
+
+
+def audit_buckets(shim_content: str) -> int:
+    """Enforce the skip-honesty standing rule (issue #6154).
+
+    Scans every whole-file and pattern skip rationale for Bucket-B smell phrases.
+    Any smell-bearing entry that is neither on the acknowledged Bucket-B worklist
+    nor a declared Bucket-A override is an *undeclared* skip and fails the check.
+
+    Returns 0 when clean, 1 when an undeclared Bucket-B smell is found. See
+    docs/reference/tcl-skip-policy.md for the taxonomy this enforces.
+    """
+    patterns = parse_skip_patterns(shim_content)
+    files = parse_whole_file_skips(shim_content)
+
+    def smells(reason: str):
+        rl = reason.lower()
+        return [p for p in BUCKET_B_SMELL_PHRASES if p in rl]
+
+    acknowledged_b = []
+    undeclared = []
+
+    for kind, entries in (("pattern", patterns), ("whole-file", files)):
+        for key, reason in sorted(entries.items()):
+            hits = smells(reason)
+            if not hits:
+                continue
+            if key in ACK_BUCKET_A_OVERRIDE:
+                continue  # declared Bucket A despite the phrase
+            if key in ACK_BUCKET_B:
+                acknowledged_b.append((kind, key, hits))
+            else:
+                undeclared.append((kind, key, hits, reason))
+
+    print("=" * 60)
+    print("SKIP-HONESTY BUCKET AUDIT (issue #6154)")
+    print("=" * 60)
+    print(f"Patterns scanned:    {len(patterns)}")
+    print(f"Whole-file scanned:  {len(files)}")
+    print(f"Bucket-A overrides:  {len(ACK_BUCKET_A_OVERRIDE)}")
+    print(f"Acknowledged Bucket-B (worklist): {len(acknowledged_b)}")
+
+    if acknowledged_b:
+        print("\nAcknowledged Bucket-B skips (Phase-2 fix-or-unskip worklist):")
+        for kind, key, hits in acknowledged_b:
+            print(f"  [{kind}] {key}  ({', '.join(hits)})")
+
+    if undeclared:
+        print("\nERROR: undeclared Bucket-B smell — must declare a bucket")
+        print("(add a Bucket-A category rationale in tcl-skip-policy.md, or add")
+        print(" the key to the Bucket-B worklist in verify_skips.py):")
+        for kind, key, hits, reason in undeclared:
+            print(f"  [{kind}] {key}  ({', '.join(hits)})")
+            print(f"      reason: {reason[:100]}")
+        print(f"\nFAIL: {len(undeclared)} undeclared skip(s).")
+        return 1
+
+    print("\nOK: every smell-bearing skip is declared (Bucket A override or "
+          "Bucket-B worklist).")
+    return 0
 
 
 def find_stale_whole_file_skips(file_skips: dict) -> list:
@@ -307,11 +445,17 @@ def main():
     parser.add_argument("--test", help="Check only this specific test")
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
     parser.add_argument("--list-categories", action="store_true", help="List skip categories and counts")
+    parser.add_argument("--audit-buckets", action="store_true",
+                        help="Enforce the skip-honesty standing rule (issue #6154): "
+                             "fail if any skip carries an undeclared Bucket-B smell")
     args = parser.parse_args()
 
     # Read the shim file
     with open(SHIM_FILE, 'r') as f:
         shim_content = f.read()
+
+    if args.audit_buckets:
+        return audit_buckets(shim_content)
 
     # Parse skip list
     skips = parse_skip_list(shim_content)


### PR DESCRIPTION
## Summary

Delivers the **locally-buildable subset** of the skip-honesty audit (#6154):
the static classification of every in-tree skip declaration in
`scripts/tester_vibesql.tcl` plus a committed policy doc and a structural
enforcement check. This is an honest, deliberate scope-down: the full
174,982-row enumeration and the reconciled excluded-row denominator depend on
the certified run's results DB on the AWS bench runner, which is **not**
available in a local worktree. Those parts (deliverable 5, runtime `ifcapable`
self-skips, `make` wiring, and the Phase-2 drive-Bucket-B-to-zero) are documented
as deferred. This PR delivers deliverables 1, 2, 4 and the classification half of
3 from source alone.

## Changes

- **`docs/reference/tcl-skip-policy.md`** (new): the canonical two-bucket
  taxonomy.
  - All **60** `vibesql_skip_files` whole-file skips classified Bucket A, grouped
    into 10 auditable categories (A1 C-API, A2 VFS/pager, A3 extensions, A4
    incrblob, A5 harness-only functions/helpers, A6 permutation dispatchers, A7
    internal counters, A8 builtin_test fuzzers, A9 documented UTF-8 divergence,
    A10 error-message-format).
  - All **56** `vibesql_skip_patterns` classified: **13 Bucket A**, **43 Bucket
    B**. Every one of the ~15 curator-flagged candidates (collate1–A, types/types2,
    subquery, without_rowid1/2/5/6, autoindex3–5, unique2, rowid, resolver01,
    misc3/4, aggnested) is confirmed Bucket B with a per-entry reason, plus
    additional smells this audit found (printf2, e_totalchanges, altertab2/3,
    alterlegacy, window1/2-66, window1-69, orderby8/A, boundary1–4, like2,
    tableopts, randexpr, sidedelete).
  - `atof1` landmine (#6065) preserved and documented: loop tests Bucket A
    (harness-only `real2hex`/`hex2real`); the ~7 non-loop tests stay running and
    reporting `failed` as real bugs — never reclassified as skipped.
  - Standing rule: no new skip may be added without declaring its bucket.
- **`scripts/verify_skips.py`**: new `--audit-buckets` mode that structurally
  enforces the standing rule — it scans every whole-file/pattern rationale for
  Bucket-B smell phrases and exits non-zero on any that is not on the
  acknowledged worklist or a declared Bucket-A override. This is mechanism, not
  just documentation.

## Acceptance Criteria Verification

| Criterion (from #6154) | Status | Verification |
|---|---|---|
| Every skip classified Bucket A/B, grouped by category | ✅ (static) | All 60 whole-file + 56 pattern skips classified in the doc; named-test array (1,528) grouped at category level with the Bucket-B-smell residual flagged for Phase-2 per-file review |
| Bucket B is empty | ⏸ deferred | Classified as a Phase-2 fix-or-unskip worklist; un-skipping safely needs a quiet full-suite bench-runner run to confirm clean failure without regressions |
| `atof1` real-bug partials still run & report `failed` | ✅ | No shim change; documented as a landmine; `vibesql_partial_skip_files` record left intact |
| Committed skip-policy doc enumerating Bucket-A categories | ✅ | `docs/reference/tcl-skip-policy.md` |
| `make test-tcl-status` states excluded count by category | ⏸ deferred | Requires the certified bench-runner DB (deliverable 5) |

## Test Plan

- `python3 scripts/verify_skips.py --audit-buckets` → exit 0, prints the 34
  smell-bearing acknowledged Bucket-B entries and the 3 Bucket-A overrides.
- Negative test: injecting an undeclared `{newfeature- "... behavior differs"}`
  pattern makes the audit exit 1 with a clear "must declare a bucket" error —
  confirming the enforcement is real.
- `python3 -m py_compile scripts/verify_skips.py` and existing
  `--list-categories` still work (no regression to prior behavior).

## Deferred (operator data required)

Reconciled excluded-row denominator by category, the 174,982-row attribution,
runtime `ifcapable` self-skips (incl. `fuzz-oss1`/`fuzzer1`/`dbfuzz001`, which are
**not** static declarations in the shim), driving Bucket B to zero, and wiring the
by-category count into `make test-tcl-status`. Left open intentionally.

Part of #6154. Part of epic #5779.