### PR TITLE
docs(tcl): define canonical SQLite-compatibility % metric and wire it into status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,8 @@ LIMIT 10;
 
 > **Which number do I quote?** For "how does VibeSQL compare to the epic baseline / to a previous run" use the **raw** headline (unchanged inclusion rules). For "how broad is our SQL coverage, ignoring monster-file domination" use the **file-weighted** mean and the clean/dirty file counts. Never quote the file-weighted number against 72.3% — they are different denominators.
 
+> **Canonical "SQLite compatibility %" claim.** The raw headline above **is** the canonical "SQLite compatibility %" metric — its exact denominator (in-scope tests = all tests minus the out-of-scope Bucket-A skips), the honest claim sentence with its scope/exclusions clause, its relationship to epic #5779's 72.3% baseline, and its frozen inclusion rules are defined in **[docs/reference/tcl-compatibility-metric.md](docs/reference/tcl-compatibility-metric.md)**. The out-of-scope exclusion taxonomy lives in **[docs/reference/tcl-skip-policy.md](docs/reference/tcl-skip-policy.md)**. `make test-tcl-status` prints this metric (raw headline + honest claim sentence + Bucket-A category breakdown) via `cmd_status()` in `scripts/tcltest`. The raw-row inclusion rules here, in that doc, and in `cmd_status()` are the same frozen rules and must never drift apart.
+
 > **Source-of-truth note:** `make test-tcl-status` reads the `tcl_test_runs` summary table for the headline numbers. Any per-file or per-test analysis must query the `tcl_test_results` detail table using the queries above. The two reconcile because every run (native-TCL and static) now writes both. If a detail-row insert fails, `tcl_runner.py` logs it to stderr, counts it, and exits non-zero when more than 5% of inserts fail — so silent divergence between the tables cannot recur unnoticed.
 
 ### Exporting Results

--- a/docs/reference/tcl-compatibility-metric.md
+++ b/docs/reference/tcl-compatibility-metric.md
@@ -248,5 +248,3 @@ here so the definitions stay in sync.
   raw-vs-file-weighted guidance, and results-table schema.
 - `scripts/tcltest` `cmd_status()` — the wiring that prints this metric.
 - `scripts/verify_skips.py --list-categories` — the live Bucket-A category counts.
-</content>
-</invoke>

--- a/docs/reference/tcl-compatibility-metric.md
+++ b/docs/reference/tcl-compatibility-metric.md
@@ -1,0 +1,252 @@
+# The Canonical "SQLite Compatibility %" Metric
+
+**Status:** canonical. Part of epic #5779. Defines issue #6156.
+
+This document defines, precisely and once, what VibeSQL means when it claims a
+**"SQLite compatibility percentage."** It fixes the exact numerator and
+denominator, names the honest claim sentence (with its scope/exclusions clause),
+and freezes the inclusion rules so the number is comparable across runs.
+
+> **What this document is and is not.** This defines *what* the compatibility %
+> means and wires the headline into `make test-tcl-status`. It does **not**
+> assert that the number *is* 100%. Reaching an actual 100% depends on (a)
+> certified full-suite results from the quiet bench runner and (b) driving the
+> Bucket-B skip worklist to zero and triaging the remaining failures — both
+> tracked elsewhere (#6154 deliverable 5, #6155, the epic). The metric is the
+> honest ruler; the reading against that ruler is separate work.
+
+---
+
+## 1. The denominator: "in-scope, SQL-reachable SQLite tests"
+
+The compatibility % is a percentage **of a defined universe**. That universe is:
+
+> Every SQLite TCL test **except** those excluded by a **Bucket-A** skip
+> declaration in [`tcl-skip-policy.md`](./tcl-skip-policy.md).
+
+Concretely:
+
+```
+in_scope_tests  =  all_tests  −  bucket_A_excluded_tests
+```
+
+- **`all_tests`** — every numbered test row the SQLite TCL suite would emit.
+- **`bucket_A_excluded_tests`** — tests suppressed by a **Bucket A** skip:
+  out-of-scope *by design*. These exercise functionality VibeSQL deliberately
+  does not implement (the C API, VFS/pager internals, unshipped extensions,
+  incremental-blob I/O, harness-only TCL helpers, internal VDBE/optimizer
+  counters, built-in-test fuzzers, and the documented UTF-8-strict divergence).
+  The full taxonomy — categories A1–A10, every whole-file and pattern skip that
+  qualifies — lives in [`tcl-skip-policy.md`](./tcl-skip-policy.md) and is **not**
+  re-enumerated here. That document is the single source of truth for what is
+  out of scope; this document only *points at it* to define the denominator.
+
+**Critically, Bucket-A exclusions are the *only* legitimate exclusions.**
+A **Bucket-B** skip (a real, in-scope SQL feature hidden behind a "behavior
+differs" / "not implemented" rationale) is **dishonest to exclude** and stays in
+the denominator: it counts against the compatibility % until it is fixed or left
+visibly failing. Driving Bucket B to zero is what makes an honest 100% possible;
+excluding Bucket-B tests would inflate the number by hiding real gaps. See the
+two-bucket rule in [`tcl-skip-policy.md`](./tcl-skip-policy.md).
+
+### How the denominator maps onto the results database
+
+In `~/.vibesql/test_results/tcl_test_results.vbsql`, each Bucket-A exclusion
+surfaces at runtime as a `status='skipped'` row (the shim declares it via
+`vibesql_skip_files` / `vibesql_skip_patterns` / `vibesql_skip_tests`). Every
+in-scope test that actually ran surfaces as `passed`, `failed`, or a
+non-completion marker (`timeout`/`incomplete`/`error`). Therefore:
+
+```
+in_scope_scored  =  passed + failed + timeout + incomplete + error   (skipped excluded)
+excluded         =  skipped
+```
+
+This is exactly the denominator of the **canonical pass-rate query** already
+frozen in `CLAUDE.md` (§ "Results Tables and the Canonical Pass-Rate Query") —
+`skipped` rows are excluded, marker rows count as failures. The compatibility %
+does **not** invent a new query; it *is* that query, re-labeled as the headline
+compatibility claim.
+
+> **Local vs. certified denominator (honesty note).** In a local worktree the
+> `skipped`-row count reflects whatever ran on this machine, and some Bucket-A
+> exclusions only appear at runtime via `ifcapable` guards rather than as static
+> declarations. The fully reconciled **excluded-row count by category** against
+> the certified 174,982-skip run (tag `aws-c7i.8xlarge-32c-final`) requires the
+> bench-runner DB and is **deferred to #6154 deliverable 5**. What is buildable
+> and honest *today* is the definition above plus the per-run numbers; the
+> by-category certified reconciliation is explicitly out of scope for #6156.
+
+---
+
+## 2. The headline metric: raw-row pass rate (and why)
+
+Two defensible weightings exist. We fix **one** as THE headline and keep the
+other as a supplementary lens, consistent with `CLAUDE.md`'s existing
+"Raw headline vs. file-weighted metrics" guidance.
+
+### THE headline: raw per-test-row pass rate
+
+```
+compatibility_%  =  100 × passed / (passed + failed + timeout + incomplete + error)
+```
+
+summed across every in-scope test row in the run (`skipped` excluded). **This is
+the canonical "SQLite compatibility %".**
+
+Why raw-row is the headline:
+
+1. **It is the epic-comparable number.** Epic #5779's baseline — "Raw pass rate:
+   72.3% — 116,719 passed / 44,624 failed" — is itself a raw per-row ratio with
+   these same inclusion rules. Only a raw-to-raw comparison is valid (see § 4).
+   Making anything else the headline would silently break comparability.
+2. **It answers "if you run an in-scope SQLite test at random, how likely is
+   VibeSQL to pass it?"** — the question an outside engineer actually means by
+   "compatibility."
+3. **It cannot be gamed by file granularity.** Splitting or merging test files
+   does not move a raw-row number; it *does* move a file-averaged number.
+
+### The supplementary lens: file-weighted mean
+
+The raw ratio has one honest hazard: it is dominated by whichever files emit the
+most rows. A few "monster" files (`fuzz.test` ~25k rows, `func.test` ~14.7k) that
+VibeSQL fails wholesale can drag the raw headline into single digits even while
+normal SQL files pass 90–99%. To keep that visible **without** changing the
+headline, `make test-tcl-status` also reports the file-weighted **mean per-file
+pass rate** and **clean vs. dirty file counts** (already computed in
+`cmd_status()`; issue #6137). These are reported *alongside*, never in place of,
+the raw headline, and are **not** comparable to the epic's 72.3% (different
+denominator). Per `CLAUDE.md`: use the **raw** number for cross-run / vs-epic
+comparison; use the **file-weighted** number for "how broad is coverage, ignoring
+monster-file domination." **Never quote the file-weighted number against 72.3%.**
+
+---
+
+## 3. The honest claim sentence
+
+A bare percentage is not an honest claim. The claim **must** name what it
+excludes. The canonical sentence (numbers filled from the live run, never
+hardcoded):
+
+> **VibeSQL passes `{passed}`/`{scored}` (`{rate}%`) of the `{N}` in-scope
+> SQLite TCL tests (`{K}` files); it deliberately does not implement SQLite's C
+> API, VFS/pager internals, or unshipped extensions, so `{P}` out-of-scope tests
+> are excluded (enumerated by category in
+> [`tcl-skip-policy.md`](./tcl-skip-policy.md)).**
+
+where, for the reported run:
+
+| Placeholder | Meaning | Source |
+|-------------|---------|--------|
+| `{passed}`  | in-scope tests that passed | `SUM(status='passed')` |
+| `{scored}` = `{N}` | in-scope tests scored (denominator) | `SUM(status IN passed,failed,timeout,incomplete,error)` |
+| `{rate}`    | `100 × passed / scored`, 1 dp | derived |
+| `{K}`       | files that produced detail rows | `COUNT(DISTINCT file_path)` |
+| `{P}`       | out-of-scope tests excluded | `SUM(status='skipped')` |
+
+The acceptance bar for this sentence: **would a skeptical outside engineer accept
+it as honest?** It passes that bar only because it (a) states the denominator,
+(b) names the excluded *categories* rather than hiding them behind a bare
+percentage, and (c) links to the per-category enumeration. A percentage without
+the exclusions clause is **not** an approved claim.
+
+`make test-tcl-status` prints this sentence, filled from the live run, as its
+compatibility headline (see § 5).
+
+---
+
+## 4. Relationship to epic #5779's 72.3% baseline
+
+Epic #5779 recorded a baseline "Raw pass rate: **72.3%** — 116,719 passed /
+44,624 failed" across **728 files**. The compatibility % defined here uses the
+**same weighting and the same inclusion rules** as that baseline (raw per-row,
+`skipped` excluded, marker rows as failures), so the two are directly
+comparable — *that is the whole point of fixing raw-row as the headline.*
+
+The current headline number will nonetheless usually **differ** from 72.3%, and
+that difference is **not** a "72 → 100" delta to be claimed. It differs because:
+
+1. **Different file/skip universe.** The 728-file baseline predates the
+   skip-honesty audit ([`tcl-skip-policy.md`](./tcl-skip-policy.md)). The
+   in-scope denominator moves as Bucket-A/Bucket-B classification changes which
+   tests are excluded vs. counted. A run over a different universe is a different
+   denominator.
+2. **Monster-file domination.** The raw number swings sharply with whether the
+   high-row files (`fuzz.test`, `func.test`, …) ran and how they fared, because
+   they contribute tens of thousands of rows each.
+3. **Marker rows.** A run with any `timeout`/`incomplete`/`error` markers reads
+   *worse* (markers count as failures) and is **not** comparable to a clean-run
+   baseline — it must be re-run on a quiet machine before comparison.
+
+**Honest-claim rule:** do not present a headline computed over one universe as a
+delta against 72.3% computed over another. Quote the current number *with its run
+universe* (files-with-results, marker count), and only compare raw-to-raw over
+the same inclusion rules. There is no legitimate "we went from 72.3% to 100%"
+narrative unless both numbers are raw-row ratios over the same in-scope universe
+on clean runs.
+
+---
+
+## 5. Wiring: what `make test-tcl-status` prints
+
+`make test-tcl-status` → `./scripts/tcltest status` → `cmd_status()`. The
+compatibility headline is printed as a dedicated **"SQLite compatibility metric"**
+block that:
+
+1. Prints the raw-row compatibility % (numerator/denominator from the canonical
+   query in § 2) as the headline.
+2. Prints the **honest claim sentence** from § 3, with `{passed}/{scored}`,
+   `{rate}`, `{K}`, and `{P}` filled from the live run.
+3. Prints the **excluded out-of-scope categories** — the static Bucket-A skip
+   category counts from `scripts/verify_skips.py --list-categories` — so the
+   exclusions clause is backed by a visible breakdown, not just a link.
+4. Links to [`tcl-skip-policy.md`](./tcl-skip-policy.md) (the exclusion taxonomy)
+   and to this document (the metric definition).
+
+The pre-existing **file-weighted** supplementary metrics (§ 2) and the run-universe
+reconciliation are unchanged and still printed alongside. If no results database
+exists yet, the block degrades gracefully (it prints the definition and the
+static category breakdown; the live numbers are simply absent).
+
+> The per-category **excluded-row count for the certified run** is **not** printed
+> by the local tool — that reconciliation needs the bench-runner DB and is
+> deferred to **#6154 deliverable 5**. Locally, the tool shows the static
+> Bucket-A category declarations (the *shape* of the exclusions) plus this run's
+> own `skipped` count (the `{P}` in the claim sentence).
+
+---
+
+## 6. Frozen inclusion rules (do not change silently)
+
+For the compatibility % to stay comparable across runs and against the epic, its
+inclusion rules are **frozen**. Changing any of them silently breaks every
+historical comparison:
+
+1. **Weighting:** raw per-test-row (not file-weighted).
+2. **Numerator:** `status = 'passed'`.
+3. **Denominator:** `status IN ('passed','failed','timeout','incomplete','error')`.
+4. **`skipped` rows are excluded** from the denominator (they are the Bucket-A
+   out-of-scope exclusions).
+5. **Marker rows** (`timeout`/`incomplete`/`error`) **count as failures**, so a
+   compromised run reads *worse*, never silently smaller.
+6. **Scope of exclusions:** only **Bucket-A** skips may reduce the denominator.
+   Bucket-B skips stay in (counted against the rate) until fixed or reclassified
+   in [`tcl-skip-policy.md`](./tcl-skip-policy.md).
+
+These rules are identical to the canonical pass-rate query frozen in `CLAUDE.md`.
+If that query changes, this document and `cmd_status()` must change with it — the
+three must never drift. `CLAUDE.md`'s "Which number do I quote?" guidance links
+here so the definitions stay in sync.
+
+---
+
+## Related documents
+
+- [`tcl-skip-policy.md`](./tcl-skip-policy.md) — the exclusion taxonomy
+  (Bucket A vs. Bucket B; defines what leaves the denominator).
+- `CLAUDE.md` § "SQLite TCL Test Suite" — the canonical pass-rate SQL, the
+  raw-vs-file-weighted guidance, and results-table schema.
+- `scripts/tcltest` `cmd_status()` — the wiring that prints this metric.
+- `scripts/verify_skips.py --list-categories` — the live Bucket-A category counts.
+</content>
+</invoke>

--- a/scripts/tcltest
+++ b/scripts/tcltest
@@ -607,6 +607,89 @@ EOF
     echo "Results database: $RESULTS_DB"
 }
 
+# Print the canonical "SQLite compatibility %" headline + honest claim sentence
+# (issue #6156).
+#
+# This is the HEADLINE compatibility metric: the raw per-test-row pass rate over
+# the in-scope universe (skipped rows excluded, marker rows counted as failures),
+# reframed as an honest claim that names its denominator and its out-of-scope
+# exclusions. It reuses the same canonical pass-rate inclusion rules frozen in
+# CLAUDE.md and defined in docs/reference/tcl-compatibility-metric.md — it does
+# NOT invent a new query. The excluded out-of-scope categories are the static
+# Bucket-A skip declarations enumerated in docs/reference/tcl-skip-policy.md and
+# surfaced live by scripts/verify_skips.py --list-categories.
+#
+# Degrades gracefully with no results DB / no detail rows: the definition and the
+# static category breakdown still print; the live numbers are simply absent.
+#
+# Arg: $1 = run_id (may be empty or "0" when no detail rows exist yet).
+print_compatibility_metric() {
+    local run_id="$1"
+
+    echo ""
+    echo "=== SQLite compatibility % (canonical headline — see docs/reference/tcl-compatibility-metric.md) ==="
+
+    if [ -n "$run_id" ] && [ "$run_id" != "0" ]; then
+        # Raw per-row numbers over the in-scope universe. Denominator excludes
+        # 'skipped' (the Bucket-A out-of-scope exclusions) and counts marker rows
+        # (timeout/incomplete/error) as failures — identical inclusion rules to
+        # CLAUDE.md's canonical pass-rate query.
+        local passed scored excluded files rate
+        passed="$("$VIBESQL_BIN" "$RESULTS_DB" --format raw -c "
+            SELECT COALESCE(SUM(CASE WHEN status = 'passed' THEN 1 ELSE 0 END), 0)
+            FROM tcl_test_results WHERE run_id = $run_id
+        " 2>/dev/null | tr -cd '0-9')" || passed=""
+        scored="$("$VIBESQL_BIN" "$RESULTS_DB" --format raw -c "
+            SELECT COALESCE(SUM(CASE WHEN status IN ('passed','failed','timeout','incomplete','error') THEN 1 ELSE 0 END), 0)
+            FROM tcl_test_results WHERE run_id = $run_id
+        " 2>/dev/null | tr -cd '0-9')" || scored=""
+        excluded="$("$VIBESQL_BIN" "$RESULTS_DB" --format raw -c "
+            SELECT COALESCE(SUM(CASE WHEN status = 'skipped' THEN 1 ELSE 0 END), 0)
+            FROM tcl_test_results WHERE run_id = $run_id
+        " 2>/dev/null | tr -cd '0-9')" || excluded=""
+        files="$("$VIBESQL_BIN" "$RESULTS_DB" --format raw -c "
+            SELECT COUNT(DISTINCT file_path) FROM tcl_test_results WHERE run_id = $run_id
+        " 2>/dev/null | tr -cd '0-9')" || files=""
+
+        if [ -n "$scored" ] && [ "$scored" -gt 0 ] 2>/dev/null; then
+            # 1-dp rate via integer math (avoid depending on awk/bc availability).
+            # tenths = 10 × percentage; split into integer + fractional digit.
+            # Pad to >=2 digits so sub-1% rates render as "0.x", not ".x".
+            local tenths
+            tenths=$(( (passed * 1000 + scored / 2) / scored ))
+            [ "${#tenths}" -lt 2 ] && tenths="0$tenths"
+            rate="${tenths%?}.${tenths: -1}"
+            echo ""
+            echo "  VibeSQL passes ${passed}/${scored} (${rate}%) of the ${scored} in-scope SQLite TCL"
+            echo "  tests (${files} files); it deliberately does not implement SQLite's C API,"
+            echo "  VFS/pager internals, or unshipped extensions, so ${excluded} out-of-scope tests"
+            echo "  are excluded (enumerated by category in docs/reference/tcl-skip-policy.md)."
+        else
+            print_warning "No scored in-scope rows in run $run_id — compatibility % unavailable (run: ./scripts/tcltest run)."
+        fi
+    else
+        print_warning "No test runs with detail rows yet — compatibility % unavailable (run: ./scripts/tcltest run)."
+    fi
+
+    # Excluded out-of-scope categories (static Bucket-A skip declarations). This
+    # backs the exclusions clause with a visible breakdown rather than a bare
+    # link. It is the STATIC declaration taxonomy from tester_vibesql.tcl, not a
+    # certified per-run row count — the reconciled by-category excluded-row count
+    # against the certified 174,982-skip run is deferred to #6154 deliverable 5.
+    if [ -f "$REPO_ROOT/scripts/verify_skips.py" ]; then
+        echo ""
+        echo "  Out-of-scope exclusions (static Bucket-A skip declarations; full taxonomy"
+        echo "  in docs/reference/tcl-skip-policy.md):"
+        # Show only the category summary counts, not the full per-file
+        # enumeration (that lives in tcl-skip-policy.md) — keeps `status` concise.
+        python3 "$REPO_ROOT/scripts/verify_skips.py" --list-categories 2>/dev/null \
+            | sed -n '/^Skip categories:/,$p' \
+            | grep -v '^[[:space:]]*- ' \
+            | sed 's/^/    /' \
+            || print_warning "  (could not read skip categories from verify_skips.py)"
+    fi
+}
+
 # Status command: quick summary
 cmd_status() {
     check_vibesql
@@ -648,6 +731,15 @@ cmd_status() {
     run_id="$("$VIBESQL_BIN" "$RESULTS_DB" --format raw -c "
         SELECT COALESCE((SELECT MAX(run_id) FROM tcl_test_results), 0)
     " 2>/dev/null | tr -cd '0-9')" || run_id=""
+
+    # Canonical "SQLite compatibility %" headline (issue #6156). This reframes
+    # the existing raw per-row pass rate as THE compatibility claim, backed by an
+    # honest scope/exclusions clause. Definition + frozen inclusion rules live in
+    # docs/reference/tcl-compatibility-metric.md; the exclusion taxonomy lives in
+    # docs/reference/tcl-skip-policy.md. No new headline SQL is invented here — the
+    # denominator is the same canonical query frozen in CLAUDE.md (skipped rows
+    # excluded, marker rows count as failures).
+    print_compatibility_metric "$run_id"
 
     if [ -n "$run_id" ] && [ "$run_id" != "0" ]; then
         echo ""


### PR DESCRIPTION
## Summary

Defines the canonical **"SQLite compatibility %"** metric and wires the headline into `make test-tcl-status`. This is a definition + wiring task: it fixes *what* the compatibility % means and prints it honestly. It does **not** assert the number is 100% — reaching an actual 100% depends on certified bench-runner data and driving the Bucket-B skip worklist to zero (tracked in #6154 deliverable 5, #6155, and the epic), which is explicitly out of scope here.

## Changes

- **New `docs/reference/tcl-compatibility-metric.md`** — the canonical metric definition:
  - **Denominator**: in-scope tests = all tests minus out-of-scope **Bucket-A** skips, pointing at (not re-enumerating) `docs/reference/tcl-skip-policy.md`. Bucket-B skips stay in the denominator (dishonest to exclude).
  - **Headline choice**: raw per-test-row pass rate is THE headline (epic-#5779-comparable, ungameable by file granularity); file-weighted mean stays the supplementary lens, consistent with CLAUDE.md's existing raw-vs-file-weighted guidance.
  - **Honest claim sentence** with an explicit scope/exclusions clause and a placeholder table (numbers filled from the live run, never hardcoded).
  - **Relationship to epic #5779's 72.3% baseline** — same inclusion rules so it is comparable, but why the current number differs (different universe, monster-file domination, marker rows); no false "72 -> 100" delta.
  - **Frozen inclusion rules** so the number stays comparable across runs.
- **`scripts/tcltest`** — new `print_compatibility_metric()` called from `cmd_status()` prints the raw-row compatibility % headline, the filled-in honest claim sentence, and the Bucket-A out-of-scope category breakdown from `verify_skips.py --list-categories`. Reuses the existing canonical pass-rate inclusion rules (no new headline SQL); degrades gracefully with no results DB. Existing file-weighted supplementary metrics and run-universe reconciliation are untouched.
- **`CLAUDE.md`** — cross-links the new doc from the "Which number do I quote?" guidance so the doc, the tool, and the canonical query cannot drift.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Metric doc defines exact denominator tied to Bucket-A in-scope set | ✅ | § 1 defines `in_scope = all − bucket_A_excluded`, links skip-policy doc |
| Headline raw-vs-file-weighted chosen + justified; other kept supplementary | ✅ | § 2 picks raw-row, keeps file-weighted as supplementary lens |
| Honest claim sentence with scope/exclusions clause | ✅ | § 3 template + placeholder table; printed live by `cmd_status()` |
| Relationship to #5779's 72.3% baseline; no false delta | ✅ | § 4 documents same rules but why it differs; honest-claim rule |
| Frozen inclusion rules for cross-run comparability | ✅ | § 6 enumerates the 6 frozen rules |
| Headline wired into `make test-tcl-status` with category breakdown | ✅ | `print_compatibility_metric()`; verified output below |
| Existing supplementary file-weighted metrics kept | ✅ | untouched in `cmd_status()` |
| CLAUDE.md guidance updated to reference (not duplicate) the doc | ✅ | cross-link added to "Which number do I quote?" |

## Test Plan

Ran `./scripts/tcltest status` against the local results DB (verified it does not crash, exits 0, and labels/format are correct):

```
=== SQLite compatibility % (canonical headline — see docs/reference/tcl-compatibility-metric.md) ===

  VibeSQL passes 60/60 (100.0%) of the 60 in-scope SQLite TCL
  tests (5 files); it deliberately does not implement SQLite's C API,
  VFS/pager internals, or unshipped extensions, so 4 out-of-scope tests
  are excluded (enumerated by category in docs/reference/tcl-skip-policy.md).

  Out-of-scope exclusions (static Bucket-A skip declarations; full taxonomy
  in docs/reference/tcl-skip-policy.md):
    Skip categories:
      OTHER: 1042 tests
      SQLITE_API: 204 tests
      ...
      WHOLE_FILE: 60 files (documented whole-file skips)
```

(The local DB numbers are whatever partial data exists locally; the point verified is the labeling/format/no-crash. Certified numbers come from the bench runner.)

- `bash -n scripts/tcltest` passes; script exits 0.
- Rate-formatting integer math checked for edge cases (72.3%, sub-1% -> 0.5%, 100.0%, 0.0%).
- Category breakdown trimmed to summary counts (full per-file taxonomy stays in the skip-policy doc).

Closes #6156