### PR TITLE
fix(tcl): accept WAL-mode results DB in tcl_triage.py

### DIFF
--- a/scripts/tcl_triage.py
+++ b/scripts/tcl_triage.py
@@ -167,6 +167,36 @@ def default_vibesql_bin() -> str:
     return os.path.join(repo_root, "target", "release", "vibesql")
 
 
+def results_db_reachable(db_path: str) -> bool:
+    """Return True if ``db_path`` is an openable VibeSQL results database.
+
+    A plain ``os.path.exists`` check is wrong for the common case: in WAL mode
+    (the CLI default) there is *no* ``<name>.vbsql`` snapshot file at all — the
+    database is recovered from the extension-stripped siblings
+    ``<name>-checkpoints/`` (``*.vchk``) plus ``<name>.wal``. Both the certified
+    bench-runner DB and every local results DB are stored this way, so the file
+    check alone rejects databases the ``vibesql`` binary opens fine.
+
+    Consider the DB reachable if any of these hold:
+      - the ``db_path`` file itself exists (snapshot / legacy SQL-dump mode), or
+      - a ``<stem>-checkpoints/`` directory exists with at least one ``*.vchk``
+        (WAL mode, where ``<stem>`` is ``db_path`` minus a trailing ``.vbsql``), or
+      - a ``<stem>.wal`` write-ahead log exists.
+
+    The genuinely-absent case (no file, no checkpoints, no WAL) returns False so
+    the caller still fails loudly and never fabricates data.
+    """
+    if os.path.exists(db_path):
+        return True
+    stem = db_path[: -len(".vbsql")] if db_path.endswith(".vbsql") else db_path
+    checkpoints_dir = stem + "-checkpoints"
+    if os.path.isdir(checkpoints_dir) and any(
+        name.endswith(".vchk") for name in os.listdir(checkpoints_dir)
+    ):
+        return True
+    return os.path.exists(stem + ".wal")
+
+
 def _extract_json_array(raw: str) -> str | None:
     """Extract the JSON array from vibesql output.
 
@@ -629,12 +659,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    if not os.path.exists(args.db):
+    if not results_db_reachable(args.db):
         sys.stderr.write(
             "ERROR: results DB not found:\n"
             f"  {args.db}\n\n"
             "This tool does NOT fabricate data. To triage TCL failures you need a\n"
-            "populated results DB. Options:\n"
+            "populated results DB (a `.vbsql` snapshot, or its WAL-mode siblings:\n"
+            "a `-checkpoints/` directory with a `*.vchk`, or a `.wal` file).\n"
+            "Options:\n"
             "  - Local, NON-CERTIFIED: run `make test-tcl` (or `make test-tcl-all`)\n"
             "    then re-run this tool.\n"
             "  - CERTIFIED: obtain the AWS bench-runner DB (tag\n"

--- a/scripts/test_tcl_triage.py
+++ b/scripts/test_tcl_triage.py
@@ -24,6 +24,7 @@ from tcl_triage import (  # noqa: E402
     CERTIFIED_TAG_PATTERN,
     cluster_errors,
     normalize_error_message,
+    results_db_reachable,
     _extract_json_array,
 )
 
@@ -159,6 +160,57 @@ class TestJsonExtraction(unittest.TestCase):
         extracted = _extract_json_array(raw)
         self.assertIsNotNone(extracted)
         self.assertTrue(extracted.endswith("]"))
+
+
+class TestResultsDbReachable(unittest.TestCase):
+    """A WAL-mode results DB (checkpoints + wal, no .vbsql snapshot file) must
+    be recognized as reachable; a genuinely-absent DB must not."""
+
+    def setUp(self):
+        import tempfile
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.dir = self._tmp.name
+        self.db = os.path.join(self.dir, "tcl_test_results.vbsql")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_absent_db_is_unreachable(self):
+        # No file, no checkpoints, no wal.
+        self.assertFalse(results_db_reachable(self.db))
+
+    def test_snapshot_file_is_reachable(self):
+        with open(self.db, "w", encoding="utf-8") as fh:
+            fh.write("-- VibeSQL Database dump\n")
+        self.assertTrue(results_db_reachable(self.db))
+
+    def test_wal_mode_checkpoints_is_reachable(self):
+        # Extension-stripped sibling dir with a .vchk, no .vbsql file.
+        ckpt = os.path.join(self.dir, "tcl_test_results-checkpoints")
+        os.mkdir(ckpt)
+        with open(os.path.join(ckpt, "checkpoint_53.vchk"), "wb") as fh:
+            fh.write(b"VCHK\x02\x00\x00\x00")
+        self.assertFalse(os.path.exists(self.db))  # precondition: no snapshot
+        self.assertTrue(results_db_reachable(self.db))
+
+    def test_empty_checkpoints_dir_without_vchk_is_unreachable(self):
+        os.mkdir(os.path.join(self.dir, "tcl_test_results-checkpoints"))
+        self.assertFalse(results_db_reachable(self.db))
+
+    def test_wal_sibling_is_reachable(self):
+        with open(os.path.join(self.dir, "tcl_test_results.wal"), "wb") as fh:
+            fh.write(b"\x00" * 32)
+        self.assertTrue(results_db_reachable(self.db))
+
+    def test_non_vbsql_path_uses_path_as_stem(self):
+        # A bare basename (no .vbsql extension) recovers from <path>-checkpoints/.
+        bare = os.path.join(self.dir, "tcl_test_results")
+        ckpt = os.path.join(self.dir, "tcl_test_results-checkpoints")
+        os.mkdir(ckpt)
+        with open(os.path.join(ckpt, "checkpoint_1.vchk"), "wb") as fh:
+            fh.write(b"VCHK")
+        self.assertTrue(results_db_reachable(bare))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`scripts/tcl_triage.py` gated on `os.path.exists('tcl_test_results.vbsql')`, but in WAL mode (the CLI default, and how the certified bench-runner DB and every local results DB is stored) **there is no `.vbsql` snapshot file** — the database is recovered from the extension-stripped siblings `tcl_test_results-checkpoints/` (`*.vchk`) + `tcl_test_results.wal`. The `vibesql` binary opens the path fine via checkpoint recovery; only the Python file-check failed, printing "results DB not found" and exiting 2.

Because #6163 shipped the tool but deferred the actual certified run, this path was never exercised — the tool could never run against a real WAL-mode DB, blocking #6166 (decompose the certified 7,106 failures).

## Fix

Add `results_db_reachable(db_path)`: treat the DB as present if
- the `.vbsql` file exists (snapshot / legacy SQL-dump mode), **or**
- a `<stem>-checkpoints/` dir holds ≥1 `*.vchk` (WAL mode; `<stem>` strips a trailing `.vbsql`), **or**
- a `<stem>.wal` file exists.

The genuinely-absent case (no file, no checkpoints, no WAL) still errors loudly and exits non-zero — no fabricated data.

## Verification

- **End-to-end against the real certified DB** (now locally reachable): the tool produces a **CERTIFIED** triage report (`run_id=1`, 804,434 rows, 7,106 failures). Before this fix it exited 2 with "results DB not found".
- `python3 scripts/test_tcl_triage.py` → **23 tests pass**, incl. 6 new `TestResultsDbReachable` cases: absent-DB unreachable, snapshot-file reachable, WAL-checkpoints reachable, empty-checkpoints-dir unreachable, wal-sibling reachable, bare-basename stem.
- `ruff check` clean; `py_compile` clean.

## Acceptance criteria
- [x] `tcl_triage.py` runs against a WAL-mode DB with no `.vbsql` snapshot file (checkpoints + wal only).
- [x] Genuinely-missing case still errors loudly and exits non-zero.
- [x] Tests in `scripts/test_tcl_triage.py` cover WAL-mode-present and fully-absent cases.

## Note for #6166 (not addressed here)
Running the fixed tool surfaced two **data** findings independent of this fix: (1) a 1-row detail-vs-summary reconciliation gap (7123 vs 7124), and (2) all 7,106 failures collapse into a single `_(no error message)_` family — the certified run did not capture `error_message` for failed rows, so automated root-cause clustering isn't possible from this data; per-file decomposition is. Surfaced separately on #6166.

Closes #6168
Part of epic #5779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)