### PR TITLE
fix(fkey): self-referential FOREIGN KEY enforcement on UPDATE/DELETE (#6170)

### DIFF
--- a/crates/vibesql-executor/src/delete/integrity.rs
+++ b/crates/vibesql-executor/src/delete/integrity.rs
@@ -122,8 +122,19 @@ pub fn check_no_child_references(
             // `scan_visible(&snapshot)` so the MVCC visibility filter
             // applies. With MVCC OFF, this reduces to `scan_live` and
             // behavior is unchanged.
+            // Self-referential exclusion: when the child table *is* the
+            // parent table, the row being deleted is its own child. Deleting
+            // a row that references itself (e.g. `DELETE FROM self` where the
+            // sole row is `(17, 17)` with `b REFERENCES self(a)`) is legal in
+            // SQLite — the self-reference disappears together with the row, so
+            // it must not count as a blocking child reference (fkey2-16.1.*).
+            // Identify that row by full equality to the row being deleted.
+            let self_ref_table = table_name.eq_ignore_ascii_case(parent_table_name);
             let child_table = db.get_table(&table_name).unwrap();
             let has_references = child_table.scan_visible(&snapshot).any(|(_, child_row)| {
+                if self_ref_table && child_row.values.as_slice() == parent_row.values.as_slice() {
+                    return false;
+                }
                 let child_fk_values: Vec<SqlValue> =
                     fk.column_indices.iter().map(|&idx| child_row.values[idx].clone()).collect();
 

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -475,10 +475,11 @@ pub(super) fn execute_internal(
 
             // Validate foreign key constraints
             if !schema.foreign_keys.is_empty() {
-                match ForeignKeyValidator::collect_constraints(
+                match ForeignKeyValidator::collect_constraints_with_old(
                     database,
                     table_name,
                     &new_row.values,
+                    Some(&row.values),
                 ) {
                     Ok(deferred) => pending_deferred_violations.extend(deferred),
                     Err(_) => continue, // Skip this row
@@ -503,10 +504,11 @@ pub(super) fn execute_internal(
 
             // Validate foreign key constraints
             if !schema.foreign_keys.is_empty() {
-                let deferred = ForeignKeyValidator::collect_constraints(
+                let deferred = ForeignKeyValidator::collect_constraints_with_old(
                     database,
                     table_name,
                     &new_row.values,
+                    Some(&row.values),
                 )?;
                 pending_deferred_violations.extend(deferred);
             }
@@ -531,10 +533,11 @@ pub(super) fn execute_internal(
 
             // Enforce FOREIGN KEY constraints (child table)
             if !schema.foreign_keys.is_empty() {
-                let deferred = ForeignKeyValidator::collect_constraints(
+                let deferred = ForeignKeyValidator::collect_constraints_with_old(
                     database,
                     table_name,
                     &new_row.values,
+                    Some(&row.values),
                 )?;
                 pending_deferred_violations.extend(deferred);
             }
@@ -1895,10 +1898,11 @@ fn execute_update_from(
             // Validate foreign key constraints (only retain deferred violations
             // for kept rows — FK collection is per-row, so an Err means we skip).
             if !schema.foreign_keys.is_empty() {
-                match ForeignKeyValidator::collect_constraints(
+                match ForeignKeyValidator::collect_constraints_with_old(
                     database,
                     table_name,
                     &u.new_row.values,
+                    Some(&u.old_row.values),
                 ) {
                     Ok(deferred) => pending_deferred_violations.extend(deferred),
                     Err(_) => continue,
@@ -1951,10 +1955,11 @@ fn execute_update_from(
 
                 // Foreign key constraints still apply.
                 if !schema.foreign_keys.is_empty() {
-                    let deferred = ForeignKeyValidator::collect_constraints(
+                    let deferred = ForeignKeyValidator::collect_constraints_with_old(
                         database,
                         table_name,
                         &u.new_row.values,
+                        Some(&u.old_row.values),
                     )?;
                     pending_deferred_violations.extend(deferred);
                 }
@@ -2139,10 +2144,11 @@ fn execute_update_from(
 
             // Validate foreign key constraints
             if !schema.foreign_keys.is_empty() {
-                let deferred = ForeignKeyValidator::collect_constraints(
+                let deferred = ForeignKeyValidator::collect_constraints_with_old(
                     database,
                     table_name,
                     &u.new_row.values,
+                    Some(&u.old_row.values),
                 )?;
                 pending_deferred_violations.extend(deferred);
             }

--- a/crates/vibesql-executor/src/update/foreign_keys.rs
+++ b/crates/vibesql-executor/src/update/foreign_keys.rs
@@ -21,10 +21,38 @@ impl ForeignKeyValidator {
     /// immediate `Err`. The caller must push the returned violations
     /// onto the transaction queue once any immutable borrow of
     /// `database` is released.
-    pub fn collect_constraints(
+    ///
+    /// The `old_row_values` parameter carries the pre-update (`OLD`) row so
+    /// that self-referential foreign keys are checked against the row's
+    /// *post-update* state.
+    ///
+    /// SQLite evaluates a self-referential FK against the table as it will
+    /// look after the UPDATE is applied: the row being updated contributes
+    /// its NEW parent-key (not its OLD one). Two corrections follow from
+    /// this, both of which the plain (`old_row_values = None`) path gets
+    /// wrong for a self-referential constraint:
+    ///
+    /// 1. **Self-rescue** — an UPDATE that sets a row's own parent-key equal
+    ///    to its FK value (e.g. `UPDATE self SET a=14, b=14` on a
+    ///    `b REFERENCES self(a)` table) satisfies the constraint via the
+    ///    row itself. Without the OLD row we still scan for the new parent
+    ///    key, which does not yet exist in the stored (pre-update) table,
+    ///    and raise a spurious violation (fkey2-16.1.*.6 false positive).
+    ///
+    /// 2. **Old-row exclusion** — an UPDATE that moves a row's parent-key
+    ///    away (e.g. `UPDATE self SET a=15` where the row was `(14, 14)`)
+    ///    must *not* be rescued by its own stale OLD parent-key still sitting
+    ///    in the table during the scan; that OLD row is about to be
+    ///    overwritten. Excluding it exposes the real violation
+    ///    (fkey2-16.1.*.4 false negative).
+    ///
+    /// Non-self-referential FKs are unaffected: the parent table is a
+    /// different table, so neither the self-rescue nor the exclusion applies.
+    pub fn collect_constraints_with_old(
         db: &Database,
         table_name: &str,
         row_values: &[vibesql_types::SqlValue],
+        old_row_values: Option<&[vibesql_types::SqlValue]>,
     ) -> Result<Vec<DeferredFkViolation>, ExecutorError> {
         let mut deferred: Vec<DeferredFkViolation> = Vec::new();
 
@@ -68,6 +96,52 @@ impl ForeignKeyValidator {
             let parent_collations = crate::foreign_key_check::parent_collations_for_fk(db, fk);
             let parent_indices = crate::foreign_key_check::resolved_parent_indices_for_fk(db, fk);
 
+            // Self-referential FKs are evaluated against the post-update row
+            // (see the doc comment). Only relevant when the parent table is
+            // this very table.
+            let self_ref = fk.parent_table.eq_ignore_ascii_case(table_name);
+
+            // Correction 1 (self-rescue): if the NEW row's own parent-key
+            // equals its FK value, the row satisfies its own constraint.
+            if self_ref
+                && parent_indices.iter().zip(&fk_values).enumerate().all(
+                    |(i, (&parent_idx, fk_val))| match row_values.get(parent_idx) {
+                        Some(parent_val) => crate::foreign_key_check::fk_values_equal(
+                            fk_val,
+                            parent_val,
+                            parent_collations.get(i).and_then(|c| c.as_deref()),
+                        ),
+                        None => false,
+                    },
+                )
+            {
+                continue;
+            }
+
+            // Correction 2 (old-row exclusion): for a self-referential FK,
+            // skip the pre-update version of the row being changed — it is
+            // about to be overwritten and must not satisfy the new FK value.
+            let excluded_old: Option<&[vibesql_types::SqlValue]> =
+                if self_ref { old_row_values } else { None };
+            let is_excluded = |parent_row: &[vibesql_types::SqlValue]| -> bool {
+                excluded_old.map(|old| parent_row == old).unwrap_or(false)
+            };
+            let row_satisfies = |parent_row: &vibesql_storage::Row| -> bool {
+                if is_excluded(&parent_row.values) {
+                    return false;
+                }
+                parent_indices.iter().zip(&fk_values).enumerate().all(
+                    |(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
+                        Some(parent_val) => crate::foreign_key_check::fk_values_equal(
+                            fk_val,
+                            parent_val,
+                            parent_collations.get(i).and_then(|c| c.as_deref()),
+                        ),
+                        None => false,
+                    },
+                )
+            };
+
             // Phase 1d follow-up (#5205): the parent-existence check on
             // the UPDATE path must honor MVCC visibility for the same
             // reason as INSERT — an uncommitted concurrent INSERT on the
@@ -78,34 +152,12 @@ impl ForeignKeyValidator {
             let key_exists = {
                 #[cfg(feature = "mvcc_enabled")]
                 {
-                    parent_table.scan_visible(&snapshot).any(|(_, parent_row)| {
-                        parent_indices.iter().zip(&fk_values).enumerate().all(
-                            |(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
-                                Some(parent_val) => crate::foreign_key_check::fk_values_equal(
-                                    fk_val,
-                                    parent_val,
-                                    parent_collations.get(i).and_then(|c| c.as_deref()),
-                                ),
-                                None => false,
-                            },
-                        )
-                    })
+                    parent_table.scan_visible(&snapshot).any(|(_, parent_row)| row_satisfies(parent_row))
                 }
                 #[cfg(not(feature = "mvcc_enabled"))]
                 {
                     let _ = &snapshot;
-                    parent_table.scan().iter().any(|parent_row| {
-                        parent_indices.iter().zip(&fk_values).enumerate().all(
-                            |(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
-                                Some(parent_val) => crate::foreign_key_check::fk_values_equal(
-                                    fk_val,
-                                    parent_val,
-                                    parent_collations.get(i).and_then(|c| c.as_deref()),
-                                ),
-                                None => false,
-                            },
-                        )
-                    })
+                    parent_table.scan().iter().any(row_satisfies)
                 }
             };
 
@@ -242,7 +294,24 @@ impl ForeignKeyValidator {
                 // walking every physical row via `scan().iter()`.
                 let snapshot = crate::mvcc::read_snapshot(db);
                 let child_table = db.get_table(&table_name).unwrap();
+
+                // Self-referential exclusion: when the child table *is* the
+                // parent table, the row being updated is its own child. That
+                // row is updated in place by this same statement, and its
+                // post-update FK value is validated separately by
+                // `collect_constraints_with_old` (the child-side check). It
+                // must therefore not count as an orphaned child of its own
+                // parent-key change — otherwise `UPDATE self SET a=14, b=14`
+                // (which moves both the parent key and the self-reference in
+                // lock-step) would wrongly trip "cannot update a parent row"
+                // (fkey2-16.1.*). Identify that row by full equality to the
+                // OLD row still present in the pre-update scan.
+                let self_ref_table = table_name.eq_ignore_ascii_case(parent_table_name);
+                let excluded_self_row: &[vibesql_types::SqlValue] = &parent_row.values;
                 let matches_fk = |child_row: &vibesql_storage::Row| -> bool {
+                    if self_ref_table && child_row.values.as_slice() == excluded_self_row {
+                        return false;
+                    }
                     let child_fk_values: Vec<vibesql_types::SqlValue> = fk
                         .column_indices
                         .iter()

--- a/crates/vibesql-executor/tests/foreign_key_self_referential_tests.rs
+++ b/crates/vibesql-executor/tests/foreign_key_self_referential_tests.rs
@@ -1,0 +1,117 @@
+//! Tests for self-referential FOREIGN KEY enforcement on UPDATE / DELETE
+//! (issue #6170, mirroring SQLite's `fkey2-16.*` matrix).
+//!
+//! A self-referential FK is evaluated against the table's *post-mutation*
+//! state: the row being changed contributes its NEW key, and a row that is
+//! being deleted takes its own self-reference with it. Three behaviours
+//! follow, all previously wrong:
+//!
+//! 1. `UPDATE self SET a=?, b=?` that moves both the parent key and the
+//!    self-reference in lock-step must succeed (self-rescue).
+//! 2. `UPDATE self SET a=?` (or `SET b=?`) that breaks the self-reference
+//!    must fail — the stale OLD key still sitting in the table must not
+//!    rescue it (old-row exclusion).
+//! 3. `DELETE FROM self` of a row that references itself must succeed.
+
+use vibesql_ast::Statement;
+use vibesql_executor::{
+    CreateTableExecutor, DeleteExecutor, InsertExecutor, UpdateExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+fn run(db: &mut Database, sql: &str) -> Result<String, String> {
+    let stmt = Parser::parse_sql(sql).map_err(|e| format!("parse error: {:?}", e))?;
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).map(|_| String::new()).map_err(|e| e.to_string())
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).map(|_| String::new()).map_err(|e| e.to_string())
+        }
+        Statement::Update(s) => {
+            UpdateExecutor::execute(&s, db).map(|_| String::new()).map_err(|e| e.to_string())
+        }
+        Statement::Delete(s) => {
+            DeleteExecutor::execute(&s, db).map(|_| String::new()).map_err(|e| e.to_string())
+        }
+        other => Err(format!("unsupported statement type in test helper: {:?}", other)),
+    }
+}
+
+/// Build a fresh FK-enabled database holding a single self-referential
+/// table `self(a, b REFERENCES self(a))` created from `schema`.
+fn setup(schema: &str) -> Database {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    run(&mut db, schema).unwrap();
+    run(&mut db, "INSERT INTO self VALUES(13, 13)").unwrap();
+    db
+}
+
+/// Each of SQLite's three fkey2-16 schema variants must behave identically.
+fn schemas() -> Vec<&'static str> {
+    vec![
+        "CREATE TABLE self(a INTEGER PRIMARY KEY, b REFERENCES self(a))",
+        "CREATE TABLE self(a PRIMARY KEY, b REFERENCES self(a))",
+        "CREATE TABLE self(a UNIQUE, b INTEGER PRIMARY KEY REFERENCES self(a))",
+    ]
+}
+
+#[test]
+fn self_ref_update_both_columns_in_lockstep_succeeds() {
+    for schema in schemas() {
+        let mut db = setup(schema);
+        // Moves the parent key (a) and the self-reference (b) together.
+        run(&mut db, "UPDATE self SET a = 14, b = 14")
+            .unwrap_or_else(|e| panic!("[{schema}] first lock-step update failed: {e}"));
+        run(&mut db, "UPDATE self SET a = 17, b = 17")
+            .unwrap_or_else(|e| panic!("[{schema}] second lock-step update failed: {e}"));
+    }
+}
+
+#[test]
+fn self_ref_update_parent_key_only_fails() {
+    for schema in schemas() {
+        let mut db = setup(schema);
+        run(&mut db, "UPDATE self SET a = 14, b = 14").unwrap();
+        // Moving `a` alone orphans the row's own self-reference (b still 14).
+        let res = run(&mut db, "UPDATE self SET a = 15");
+        assert!(res.is_err(), "[{schema}] moving parent key alone must violate FK, got {res:?}");
+    }
+}
+
+#[test]
+fn self_ref_update_child_key_only_fails() {
+    for schema in schemas() {
+        let mut db = setup(schema);
+        run(&mut db, "UPDATE self SET a = 14, b = 14").unwrap();
+        // Moving `b` alone points the self-reference at a non-existent key.
+        let res = run(&mut db, "UPDATE self SET b = 15");
+        assert!(res.is_err(), "[{schema}] moving child key alone must violate FK, got {res:?}");
+    }
+}
+
+#[test]
+fn self_ref_delete_of_self_referencing_row_succeeds() {
+    for schema in schemas() {
+        let mut db = setup(schema);
+        run(&mut db, "UPDATE self SET a = 17, b = 17").unwrap();
+        // The row references itself; deleting it removes the reference too.
+        run(&mut db, "DELETE FROM self")
+            .unwrap_or_else(|e| panic!("[{schema}] delete of self-referencing row failed: {e}"));
+    }
+}
+
+#[test]
+fn self_ref_insert_without_matching_key_still_fails() {
+    // Guard against over-relaxing: an INSERT whose FK value matches neither
+    // an existing row nor its own key must still be rejected.
+    for schema in schemas() {
+        let mut db = Database::new();
+        db.set_foreign_keys_enabled(true);
+        run(&mut db, schema).unwrap();
+        let res = run(&mut db, "INSERT INTO self VALUES(20, 21)");
+        assert!(res.is_err(), "[{schema}] INSERT with unmatched self-FK must fail, got {res:?}");
+    }
+}


### PR DESCRIPTION
## Summary

Implements **self-referential FOREIGN KEY enforcement** on the UPDATE and DELETE paths, matching SQLite's `fkey2-16.*` matrix. A self-referential FK (parent table == child table) must be evaluated against the table's *post-mutation* state: the row being changed contributes its NEW key, and a row being deleted takes its own self-reference with it.

This is a coherent increment of the broader FK-enforcement family (issue #6170, ~346 certified failures). It targets the self-referential sub-family that was wholesale-wrong; the remaining FK gaps are documented below for follow-up.

## FK sub-features covered

- **UPDATE self-rescue** — `UPDATE self SET a=14, b=14` (moves parent key and self-reference in lock-step) now satisfies the constraint via the row itself instead of raising a spurious `FOREIGN KEY constraint failed`.
- **UPDATE old-row exclusion** — the pre-update version of the row being changed no longer rescues a broken self-reference during the parent-existence scan (it is about to be overwritten), so `UPDATE self SET a=15` alone now correctly fails.
- **UPDATE parent-side exclusion** — the row being updated is not treated as an orphaned child of its own parent-key change (the "cannot update a parent row" path).
- **DELETE self-reference** — deleting a row that references itself succeeds; the self-reference disappears together with the row (`fkey2-16.1.*`).

Implementation renames `ForeignKeyValidator::collect_constraints` → `collect_constraints_with_old`, threading the OLD row through all UPDATE call sites so self-referential checks see post-update state. **Non-self-referential FKs are unaffected** — the parent table is a different table, so neither the self-rescue nor the exclusion logic applies.

## Before/after failure counts (clean local runs, same machine)

| File | Before | After | Δ |
|------|-------:|------:|---:|
| `fkey2.test`  | 180 | 171 | **-9** |
| `e_fkey.test` | 150 | 150 | 0 (no regression) |

Measured by stashing the change, rebuilding pristine `main`, running the file, then re-running with the change on the same host (avoids the cross-machine skew vs the certified baseline, which reads fkey2=180 / e_fkey=149).

## Test coverage added

`crates/vibesql-executor/tests/foreign_key_self_referential_tests.rs` — 5 tests, each exercised across all three SQLite `fkey2-16` schema variants:
- lock-step update of both columns succeeds
- update of parent key alone fails
- update of child key alone fails
- delete of a self-referencing row succeeds
- INSERT with an unmatched self-FK still fails (over-relaxation guard)

Full `cargo test -p vibesql-executor` passes (3506 tests, 0 failures) — no regression.

## Remaining follow-up scope (NOT in this PR)

The FK family is large; this PR intentionally lands only the self-referential increment. Still failing on `fkey2`/`e_fkey`:
- ON DELETE / ON UPDATE **CASCADE / SET NULL / SET DEFAULT / RESTRICT / NO ACTION** action matrix (the dense `fkey2-1.4.*` block)
- **Deferred constraints** (`DEFERRABLE INITIALLY DEFERRED`) checkpointing at COMMIT (`e_fkey-15.*`)
- `PRAGMA foreign_keys` gating edge cases (`e_fkey-6.*`)
- Smaller files `fkey1/3/4/7`

Per the issue's note, `without_rowid3.test` re-runs `fkey2`'s body on WITHOUT ROWID tables; the remaining action-matrix work here will also move that family and should be cross-checked.

Part of #6170 (self-referential FK increment only; family stays open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)