### PR TITLE
fix(tcl): capture per-test failure detail on the native-TCL path

### DIFF
--- a/scripts/tcl_runner.py
+++ b/scripts/tcl_runner.py
@@ -1003,21 +1003,36 @@ def _parse_shim_output(output: str, test_file: str) -> tuple[int, int, int, list
     saw_summary = False
 
     for line in output.split('\n'):
-        # Machine-readable per-test detail line
+        # Machine-readable per-test detail line. Two shapes are emitted by the
+        # shim (tester_vibesql.tcl):
+        #   "##TCLTEST## <status>\t<name>"                       pass/skip
+        #   "##TCLTEST## <status>\t<name>\t<expected>\t<actual>" failure detail
+        # The 4-field form carries the do_test comparison text for failed tests
+        # so native-TCL runs record non-empty error_message/actual_output/
+        # expected_output instead of empty diagnostics (#6179). The 2-field form
+        # is still accepted for pass/skip rows (and for backward compatibility).
         if line.startswith(TCL_DETAIL_PREFIX):
             payload = line[len(TCL_DETAIL_PREFIX):]
-            if '\t' in payload:
-                status, test_name = payload.split('\t', 1)
-            else:
-                status, test_name = payload, ""
-            status = status.strip()
-            test_name = test_name.strip()
+            fields = payload.split('\t')
+            status = fields[0].strip()
+            test_name = fields[1].strip() if len(fields) > 1 else ""
+            expected = fields[2].strip() if len(fields) > 2 else ""
+            actual = fields[3].strip() if len(fields) > 3 else ""
+            # Route the failure diagnostic into error_message for triage
+            # clustering: prefer the actual/divergent text (VibeSQL engine
+            # errors surface there), falling back to the expected text.
+            error_message = None
+            if status == "failed":
+                error_message = actual or expected or None
             per_test_results.append(TestResult(
                 test_name=test_name,
                 file_path=test_file,
                 test_type="native-tcl",
                 status=status,
                 sql="",
+                expected_output=expected or None,
+                actual_output=actual or None,
+                error_message=error_message,
             ))
             continue
 

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -115,15 +115,38 @@ if {[info exists ::env(TCLTEST_CIRCUIT_BREAKER_MAX_ROWS)] &&
     set ::cb_row_ceiling $::env(TCLTEST_CIRCUIT_BREAKER_MAX_ROWS)
 }
 
+# Collapse a detail string (expected/actual result text) to a single tab-free,
+# newline-free, length-bounded field so it can ride on one "##TCLTEST##" line
+# without breaking the tab-delimited / line-oriented parsing in tcl_runner.py.
+proc detail_sanitize {s} {
+    # Tabs are the field separator and newlines are the record separator on the
+    # detail stream, so both must be squashed to spaces before the value is
+    # embedded. Collapse any run of whitespace to a single space and trim.
+    regsub -all {[\t\r\n]+} $s { } s
+    regsub -all { +} $s { } s
+    set s [string trim $s]
+    # Bound the length so a pathological multi-KB result/error doesn't bloat the
+    # stream; the Python side truncates again to the column width (#6179).
+    if {[string length $s] > 800} {
+        set s "[string range $s 0 799]…"
+    }
+    return $s
+}
+
 # Emit a structured per-test detail line consumed by tcl_runner.py.
 #
-# Format: "##TCLTEST## <status>\t<name>"
+# Format: "##TCLTEST## <status>\t<name>"                      (pass/skip)
+#     or: "##TCLTEST## <status>\t<name>\t<expected>\t<actual>" (failure detail)
 #   - status is one of: passed, failed, skipped
 #   - name is the test name (test names never contain tabs or newlines)
+#   - expected/actual carry the do_test comparison text for failed tests so the
+#     runner can populate error_message/actual_output/expected_output instead of
+#     recording every failure with empty diagnostics (#6179). Both are
+#     sanitized to stay on a single tab-delimited line.
 #
 # The sentinel prefix lets the Python runner distinguish these lines from the
 # human-readable output, so the same stream serves both humans and the parser.
-proc emit_test_detail {status name} {
+proc emit_test_detail {status name {expected ""} {actual ""}} {
     # Any passing test breaks a consecutive-identical-unsupported-command
     # failure streak (circuit-breaker, #6158). Done here — the single chokepoint
     # every passed row flows through (do_test and its do_execsql_test/
@@ -135,7 +158,11 @@ proc emit_test_detail {status name} {
         set ::cb_last_cmd ""
     }
     if {$::emit_detail} {
-        puts "##TCLTEST## $status\t$name"
+        if {$expected eq "" && $actual eq ""} {
+            puts "##TCLTEST## $status\t$name"
+        } else {
+            puts "##TCLTEST## $status\t$name\t[detail_sanitize $expected]\t[detail_sanitize $actual]"
+        }
     }
 }
 
@@ -5629,10 +5656,12 @@ proc do_test {name script expected} {
             omit_test $name "cascading from skipped WINDOW test"
             return
         }
-        # Script error - always print failures
+        # Script error - always print failures. The caught error text is the
+        # actual diagnostic; there is no expected value to compare against
+        # (#6179).
         incr ::nFail
         lappend ::failList $name
-        emit_test_detail failed $name
+        emit_test_detail failed $name "" "error: $result"
         puts "  $name... FAILED (error: $result)"
         # Circuit-breaker (#6158): feed this failure in. If it is the Nth
         # consecutive IDENTICAL unimplemented-command failure (a degenerate
@@ -5660,7 +5689,7 @@ proc do_test {name script expected} {
         } else {
             incr ::nFail
             lappend ::failList $name
-            emit_test_detail failed $name
+            emit_test_detail failed $name "pattern: $expected" $result
             puts "  $name... FAILED"
             puts "    Expected pattern: $expected"
             puts "    Got:              $result"
@@ -5697,7 +5726,7 @@ proc do_test {name script expected} {
         } else {
             incr ::nFail
             lappend ::failList $name
-            emit_test_detail failed $name
+            emit_test_detail failed $name $expected $result
             puts "  $name... FAILED"
             puts "    Expected: $expected"
             puts "    Got:      $result"
@@ -6352,7 +6381,7 @@ proc integrity_check {name} {
     }
     incr ::nFail
     lappend ::failList $name
-    emit_test_detail failed $name
+    emit_test_detail failed $name "ok" "integrity check: $result"
     # Always print failures
     puts "  $name... FAILED (integrity check: $result)"
 }
@@ -7620,7 +7649,7 @@ proc record_contained_error {seq err} {
     incr ::nTest
     incr ::nFail
     lappend ::failList $name
-    emit_test_detail failed $name
+    emit_test_detail failed $name "" "contained file-scope error: $err"
     puts "  $name... FAILED (contained file-scope error: $err)"
 }
 


### PR DESCRIPTION
## Summary

Native-TCL mode (the default runner path, and what produced the certified run) recorded every `status='failed'` row with an **empty** `error_message`, `actual_output`, and `expected_output`. The shim's machine-readable per-test detail line only carried `<status>\t<name>`, so the actual-vs-expected diff the shim already computes to decide pass/fail was discarded at the source. This collapsed all failures into a single `(no error message)` triage family, defeating `scripts/tcl_triage.py`'s root-cause clustering.

This routes the shim's per-test comparison text into the `TestResult` on the native-TCL path, the way the static-parsing path already does.

## Changes

- **`scripts/tester_vibesql.tcl`**
  - Added `detail_sanitize` to collapse tabs/newlines and length-bound a detail field so it rides safely on one `##TCLTEST##` line.
  - Extended `emit_test_detail` to take optional `expected`/`actual` text and emit a 4-field line `<status>\t<name>\t<expected>\t<actual>` for failures. Pass/skip rows keep the 2-field form (backward compatible).
  - The three `do_test` failure paths (script error, regex-pattern mismatch, value mismatch), `integrity_check`, and `record_contained_error` now pass their comparison/error text.
- **`scripts/tcl_runner.py`**
  - `_parse_shim_output` parses the extra fields and populates `expected_output`/`actual_output`/`error_message` on the native-TCL `TestResult`. `error_message` prefers the actual/divergent text (where VibeSQL engine errors surface), falling back to the expected text.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| A native-TCL run records non-empty `error_message` (or `actual_output`+`expected_output`) for failed tests | ✅ | End-to-end run of `e_expr.test`: 315/315 failed rows carry a non-empty `error_message` (0 empty). Synthetic run confirms value-mismatch rows carry `expected_output`/`actual_output` too. |
| `tcl_triage.py` clusters failures into >1 root-cause family | ✅ | `cluster_errors` over the real `e_expr.test` failures yields **39** families (e.g. `error: no such function: var`, `contained file-scope error: invalid command name "?"`, `near "?": syntax error`) instead of one empty bucket. |
| No regression to pass/skip counts or detail-vs-summary reconciliation | ✅ | `e_expr.test`: summary 4602/315/7 matches detail table; 4924/4924 detail rows inserted. `select1.test` reconciles 188/0/0. Pass/skip rows still emit the 2-field line and parse unchanged. |

## Test Plan

Targeted native-TCL runs (not the full suite) against a fresh temp results DB:
- `select1.test` — 188 passed, reconciles 188/0/0 (regression guard for pass/skip parsing).
- `e_expr.test` — 4602 passed / 315 failed / 7 skipped; all 315 failures carry non-empty `error_message`; `tcl_triage.cluster_errors` produces 39 families.
- Synthetic failing file — verified 4-field emission (`999`/`1` value mismatch; `error: no such column: ...` script error) flows into the DB columns.

Closes #6179