### PR TITLE
fix(storage): persist verbatim CREATE TRIGGER text across checkpoints

### DIFF
--- a/crates/vibesql-catalog/src/trigger.rs
+++ b/crates/vibesql-catalog/src/trigger.rs
@@ -99,6 +99,17 @@ impl TriggerDefinition {
         self
     }
 
+    /// Set the verbatim `CREATE TRIGGER` text (builder-style).
+    ///
+    /// This is the original statement text preserved so `sqlite_master.sql`
+    /// renders SQLite's exact form (original spacing/quoting, no injected
+    /// `BEFORE`/`FOR EACH ROW`). `None` leaves it unset, in which case the
+    /// renderer reconstructs the statement from the parsed fields.
+    pub fn with_sql_definition(mut self, sql_definition: Option<String>) -> Self {
+        self.sql_definition = sql_definition;
+        self
+    }
+
     /// Returns true if this trigger lives in the temp schema.
     pub fn is_temp(&self) -> bool {
         self.schema

--- a/crates/vibesql-storage/src/persistence/binary/catalog.rs
+++ b/crates/vibesql-storage/src/persistence/binary/catalog.rs
@@ -400,6 +400,23 @@ pub fn write_catalog<W: Write>(writer: &mut W, db: &Database) -> Result<(), Stor
                     write_bool(writer, false)?;
                 }
             }
+
+            // Write the trigger's verbatim `CREATE TRIGGER` text (v16+, issue
+            // #6174). Written last in the per-trigger record so v15-and-earlier
+            // readers, which stop after the schema field, are unaffected; the
+            // read path gates on `version >= 16`. Encoded as a present-flag bool
+            // + optional string, mirroring the view `sql_definition` field.
+            // Without it, a reloaded trigger loses its verbatim text and
+            // `sqlite_master.sql` renders an AST-reconstructed form.
+            match &trigger.sql_definition {
+                Some(def) => {
+                    write_bool(writer, true)?;
+                    write_string(writer, def)?;
+                }
+                None => {
+                    write_bool(writer, false)?;
+                }
+            }
         }
     }
 
@@ -976,6 +993,21 @@ pub fn read_catalog_v<R: Read>(reader: &mut R, version: u8) -> Result<Database, 
             None
         };
 
+        // Read the trigger's verbatim `CREATE TRIGGER` text (v16+, issue #6174).
+        // v15-and-earlier files do not include this field; absence is treated as
+        // `None`, so the renderer falls back to AST reconstruction (prior
+        // behavior). Written as present-flag bool + optional string.
+        let sql_definition = if version >= 16 {
+            let has_sql_def = read_bool(reader)?;
+            if has_sql_def {
+                Some(read_string(reader)?)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         // Create trigger definition
         let trigger = vibesql_catalog::TriggerDefinition::new(
             name,
@@ -986,7 +1018,8 @@ pub fn read_catalog_v<R: Read>(reader: &mut R, version: u8) -> Result<Database, 
             when_condition,
             triggered_action,
         )
-        .with_schema(schema);
+        .with_schema(schema)
+        .with_sql_definition(sql_definition);
 
         // Add to catalog
         db.catalog.create_trigger(trigger).map_err(|e| {
@@ -2003,6 +2036,91 @@ mod tests {
             reloaded.catalog.get_trigger("tr_temp").is_none(),
             "temp trigger must NOT survive a checkpoint round-trip"
         );
+    }
+
+    /// Issue #6174: a trigger's verbatim `CREATE TRIGGER` text
+    /// (`sql_definition`) must round-trip through the binary catalog (v16). Before
+    /// the fix, `write_catalog` never wrote the field, so every reloaded trigger
+    /// had `sql_definition = None` and `sqlite_master.sql` rendered an
+    /// AST-reconstructed form (injected `BEFORE`/`FOR EACH ROW`, normalized
+    /// spacing) after a checkpoint (altercol.test 9.x).
+    #[test]
+    fn test_binary_catalog_trigger_sql_definition_round_trips() {
+        let mut db = Database::new();
+
+        // A trigger whose verbatim text differs from any AST reconstruction
+        // (multi-line body, an odd unnamed-looking header, no `FOR EACH ROW`).
+        let verbatim =
+            "CREATE TRIGGER AFTER INSERT ON t1 BEGIN\n        SELECT _x_ FROM t1;\n      END";
+        let with_sql = vibesql_catalog::TriggerDefinition::new(
+            "AFTER".to_string(),
+            vibesql_ast::TriggerTiming::Before,
+            vibesql_ast::TriggerEvent::Insert,
+            "t1".to_string(),
+            vibesql_ast::TriggerGranularity::Row,
+            None,
+            vibesql_ast::TriggerAction::RawSql("BEGIN SELECT _x_ FROM t1; END".to_string()),
+        )
+        .with_sql_definition(Some(verbatim.to_string()));
+        db.catalog.create_trigger(with_sql).unwrap();
+
+        // A trigger with no preserved text: must round-trip as `None`.
+        let no_sql = vibesql_catalog::TriggerDefinition::new(
+            "tr_plain".to_string(),
+            vibesql_ast::TriggerTiming::After,
+            vibesql_ast::TriggerEvent::Insert,
+            "t1".to_string(),
+            vibesql_ast::TriggerGranularity::Row,
+            None,
+            vibesql_ast::TriggerAction::RawSql("SELECT 1".to_string()),
+        );
+        db.catalog.create_trigger(no_sql).unwrap();
+
+        let mut buf = Vec::new();
+        write_catalog(&mut buf, &db).unwrap();
+        let reloaded = read_catalog_v(&mut &buf[..], VERSION).unwrap();
+
+        let tr = reloaded.catalog.get_trigger("AFTER").expect("trigger must survive");
+        assert_eq!(
+            tr.sql_definition.as_deref(),
+            Some(verbatim),
+            "verbatim CREATE TRIGGER text must round-trip byte-for-byte (v16)"
+        );
+
+        let tr = reloaded.catalog.get_trigger("tr_plain").expect("trigger must survive");
+        assert_eq!(
+            tr.sql_definition, None,
+            "a trigger with no preserved text must round-trip as None"
+        );
+    }
+
+    /// Issue #6174: a v15 file has no per-trigger `sql_definition` field, so the
+    /// v16 reader must default it to `None` rather than mis-parsing the following
+    /// bytes. A v15 record ends right after the schema field, so reading it back
+    /// at version 15 must succeed and leave `sql_definition = None`.
+    #[test]
+    fn test_v15_trigger_loads_sql_definition_as_none() {
+        let mut db = Database::new();
+        let tr = vibesql_catalog::TriggerDefinition::new(
+            "tr".to_string(),
+            vibesql_ast::TriggerTiming::After,
+            vibesql_ast::TriggerEvent::Insert,
+            "t".to_string(),
+            vibesql_ast::TriggerGranularity::Row,
+            None,
+            vibesql_ast::TriggerAction::RawSql("SELECT 1".to_string()),
+        )
+        .with_sql_definition(Some("CREATE TRIGGER tr AFTER INSERT ON t ...".to_string()));
+        db.catalog.create_trigger(tr).unwrap();
+
+        let mut buf = Vec::new();
+        write_catalog(&mut buf, &db).unwrap();
+
+        // Reading the same bytes at version 15 must stop before the trailing
+        // sql_definition present-flag and default the field to None.
+        let reloaded = read_catalog_v(&mut &buf[..], 15).unwrap();
+        let tr = reloaded.catalog.get_trigger("tr").expect("trigger must survive");
+        assert_eq!(tr.sql_definition, None, "a v15 reader must default sql_definition to None");
     }
 
     /// Issue #5940, Cluster A: a v13 file has no per-trigger schema field, so the

--- a/crates/vibesql-storage/src/persistence/binary/format.rs
+++ b/crates/vibesql-storage/src/persistence/binary/format.rs
@@ -91,7 +91,17 @@ pub const MAGIC: &[u8; 5] = b"VBSQL";
 ///        stopped matching after a checkpoint (upsert4 2.x.2.1). v14 and earlier
 ///        files remain readable: the read path is gated on `version >= 15` and
 ///        treats absence as `collation = None` (prior behavior). Issue #5921.
-pub const VERSION: u8 = 15;
+/// - v16: Added `TriggerDefinition::sql_definition` persistence per trigger (one
+///        present-flag bool + optional string, appended after the trigger's
+///        schema field). Without it, every reloaded trigger lost its verbatim
+///        `CREATE TRIGGER` text and `sqlite_master.sql` fell back to an
+///        AST-reconstructed form (injected `BEFORE`/`FOR EACH ROW`, normalized
+///        spacing), so a trigger's `sql` column changed after a checkpoint
+///        (altercol.test 9.x). Mirrors the view `sql_definition` field. v15 and
+///        earlier files remain readable: the read path is gated on
+///        `version >= 16` and treats absence as `sql_definition = None` (prior
+///        AST-reconstruction behavior). Issue #6174.
+pub const VERSION: u8 = 16;
 
 /// Type tags for binary serialization
 #[repr(u8)]


### PR DESCRIPTION
## Summary

Part of the ALTER TABLE conformance family (#6174). This PR fixes a schema-persistence bug that was the single largest source of ALTER-related trigger failures: after a checkpoint reload, a trigger's `sqlite_master.sql` was rendered from an AST reconstruction instead of the verbatim `CREATE TRIGGER` text SQLite preserves.

### Root cause

`TriggerDefinition` already carries a `sql_definition` field (the original statement text), and `generate_create_trigger_sql` already prefers it — so freshly created triggers rendered correctly. But the **binary catalog serializer never wrote that field**. On checkpoint reload every trigger came back with `sql_definition = None`, and the AST-reconstruction fallback produces a malformed, normalized form, e.g.:

```
CREATE TRIGGER AFTER BEFORE INSERT ON t1 FOR EACH ROWBEGIN SELECT _x_ FROM t1 ; END
```

instead of the exact text SQLite stores. This broke `SELECT sql FROM sqlite_master` for triggers across a reopen, and by extension the `altercol.test` / `altertrig.test` RENAME COLUMN propagation checks that compare stored trigger text (the tests reopen the DB, i.e. `db close; sqlite3 db test.db`).

## Changes

- **`format.rs`**: bump binary format version 15 -> 16, with a version-history entry documenting the new field and the backward-compat gating.
- **`binary/catalog.rs`**: write per-trigger `sql_definition` (present-flag bool + optional string) last in the trigger record; read it back gated on `version >= 16`, defaulting to `None` for older files (prior AST-reconstruction behavior). Mirrors the existing view `sql_definition` persistence.
- **`trigger.rs`**: add a `TriggerDefinition::with_sql_definition` builder.
- **Tests**: `test_binary_catalog_trigger_sql_definition_round_trips` (verbatim text survives a v16 round-trip; a text-less trigger stays `None`) and `test_v15_trigger_loads_sql_definition_as_none` (older-file backward compat).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| ALTER files improve or fail visibly (never skipped) | Yes | altercol.test 65->51, altertrig.test 10->0 via `make test-tcl-file` |
| No regressions in storage/catalog | Yes | `cargo test -p vibesql-storage -p vibesql-catalog` all pass (800 storage tests incl. 2 new) |
| Backward compatibility with older DB files | Yes | v15 read path defaults `sql_definition` to `None`; unit test covers it |

## Test Plan

Clean before/after on this branch (stash + rebuild for the baseline), `make test-tcl-file`:

- **altercol.test: 65 -> 51 failures** (-14)
- **altertrig.test: 10 -> 0 failures** (-10)
- alter.test (already 1 on current main; the issue's baseline of 52 predates recent main fixes) and alter3.test (33) unchanged — their remaining failures are not trigger-persistence related.

Unit tests: `cargo test --release -p vibesql-storage -p vibesql-catalog` — all pass.

## Remaining work in the #6174 family (not addressed here)

This is a partial fix. The following remain and are better handled as separate, focused changes:
- **Index expression re-parenthesization** on RENAME COLUMN (`altercol-1.12.4`: `t1(d+d+d+d, c)` renders as `t1((d+d+d+d), c)`) — index SQL is AST-reconstructed and wraps expressions in parens.
- **Multi-connection tests** (`altercol-2.1..2.3` use a second `sqlite3 db2 test.db` handle) — a shim/connection limitation, not core ALTER semantics.
- **`altercorrupt` / `altermalloc*`** — corruption/OOM oriented; likely belong to the Bucket-A skip-policy process (#6154) rather than a semantics fix. Not touched here.
- alter2.test / alterdropcol2.test DROP COLUMN clusters — unaffected by this change (verified unchanged), tracked under the same family.

Part of #6174