### PR TITLE
feat(trigger): reject qualified DML targets and index hints in trigger bodies

### DIFF
--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -9,6 +9,33 @@ use crate::{keywords::Keyword, lexer::Lexer, token::Token};
 /// rejects any variable reference at create time (see triggerE.test).
 const TRIGGER_CANNOT_USE_VARIABLES: &str = "trigger cannot use variables";
 
+/// SQLite's verbatim error when a trigger-body INSERT/UPDATE/DELETE targets a
+/// schema-qualified table name (e.g. `INSERT INTO main.t VALUES(...)` inside a
+/// trigger body). The trigger grammar never allowed a qualifier on the DML
+/// target; SQLite rejects it at create time with this message rather than a
+/// bare "syntax error" (ticket #3947, trigger1-16.1..16.3).
+const TRIGGER_QUALIFIED_TABLE: &str =
+    "qualified table names are not allowed on INSERT, UPDATE, and DELETE statements within triggers";
+
+/// SQLite's verbatim error when a trigger-body UPDATE/DELETE carries a
+/// `NOT INDEXED` clause (trigger1-16.4/16.6).
+const TRIGGER_NOT_INDEXED: &str =
+    "the NOT INDEXED clause is not allowed on UPDATE or DELETE statements within triggers";
+
+/// SQLite's verbatim error when a trigger-body UPDATE/DELETE carries an
+/// `INDEXED BY <index>` clause (trigger1-16.5/16.7).
+const TRIGGER_INDEXED_BY: &str =
+    "the INDEXED BY clause is not allowed on UPDATE or DELETE statements within triggers";
+
+/// Pick the verbatim SQLite rejection message for an index hint on a
+/// trigger-body UPDATE/DELETE (`NOT INDEXED` vs `INDEXED BY <index>`).
+fn index_hint_rejection_message(hint: &vibesql_ast::IndexHint) -> String {
+    match hint {
+        vibesql_ast::IndexHint::NotIndexed => TRIGGER_NOT_INDEXED.to_string(),
+        vibesql_ast::IndexHint::IndexedBy(_) => TRIGGER_INDEXED_BY.to_string(),
+    }
+}
+
 impl Parser {
     /// Parse CREATE TRIGGER statement
     ///
@@ -373,20 +400,77 @@ impl Parser {
             // `RAISE()` is admitted (SQLite only permits RAISE() within a
             // trigger-program; `parse_sql` rejects it at parse time, but a
             // trigger body legitimately contains it).
-            if let Err(e) = Self::parse_sql_in_trigger_body(&stmt_with_terminator) {
-                if Self::is_create_time_rejection(&e) {
-                    // Propagate verbatim so the message (e.g.
-                    // `unsupported use of NULLS FIRST`) matches the
-                    // direct-statement form and SQLite.
-                    return Err(e);
+            match Self::parse_sql_in_trigger_body(&stmt_with_terminator) {
+                Ok(stmt) => Self::validate_trigger_body_statement(&stmt)?,
+                Err(e) => {
+                    if Self::is_create_time_rejection(&e) {
+                        // Propagate verbatim so the message (e.g.
+                        // `unsupported use of NULLS FIRST`) matches the
+                        // direct-statement form and SQLite.
+                        return Err(e);
+                    }
+                    // Otherwise tolerate: a construct VibeSQL does not yet
+                    // parse. Preserve the prior behavior (stored raw, re-parsed
+                    // at fire time) so we don't reject bodies SQLite accepts.
                 }
-                // Otherwise tolerate: a construct VibeSQL does not yet
-                // parse. Preserve the prior behavior (stored raw, re-parsed
-                // at fire time) so we don't reject bodies SQLite accepts.
             }
         }
 
         Ok(())
+    }
+
+    /// Reject the create-time-invalid constructs SQLite disallows on a
+    /// trigger-body INSERT/UPDATE/DELETE statement (ticket #3947, trigger1-16.x):
+    ///
+    /// 1. A schema-qualified DML target (`INSERT INTO main.t ...`,
+    ///    `UPDATE main.t ...`, `DELETE FROM main.t ...`). The trigger grammar
+    ///    never permitted a schema qualifier on the DML target — the whole
+    ///    trigger program runs in the schema of the trigger's own table — so
+    ///    SQLite rejects it with a full message rather than a bare syntax error.
+    /// 2. An `INDEXED BY <index>` / `NOT INDEXED` clause on a body UPDATE/DELETE,
+    ///    which SQLite likewise forbids inside a trigger program.
+    ///
+    /// Only runs on statements VibeSQL parsed successfully, so bodies using
+    /// constructs VibeSQL cannot yet parse are still tolerated as before.
+    fn validate_trigger_body_statement(stmt: &vibesql_ast::Statement) -> Result<(), ParseError> {
+        use vibesql_ast::Statement;
+        match stmt {
+            Statement::Insert(insert) => {
+                // INSERT keeps the schema qualifier in a dedicated field.
+                if insert.schema_name.is_some() {
+                    return Err(ParseError { message: TRIGGER_QUALIFIED_TABLE.to_string() });
+                }
+            }
+            Statement::Update(update) => {
+                if Self::dml_target_is_schema_qualified(&update.table_name, update.quoted) {
+                    return Err(ParseError { message: TRIGGER_QUALIFIED_TABLE.to_string() });
+                }
+                if let Some(hint) = &update.index_hint {
+                    return Err(ParseError { message: index_hint_rejection_message(hint) });
+                }
+            }
+            Statement::Delete(delete) => {
+                if Self::dml_target_is_schema_qualified(&delete.table_name, delete.quoted) {
+                    return Err(ParseError { message: TRIGGER_QUALIFIED_TABLE.to_string() });
+                }
+                if let Some(hint) = &delete.index_hint {
+                    return Err(ParseError { message: index_hint_rejection_message(hint) });
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// Is an UPDATE/DELETE target name schema-qualified (`schema.table`)?
+    ///
+    /// UPDATE/DELETE flatten the qualifier into `table_name` as `schema.table`
+    /// (see [`vibesql_ast::TableRef::full_name`]). A dot only signals a schema
+    /// qualifier for an *unquoted* name — a quoted identifier may legitimately
+    /// contain a dot (`"weird.name"`) and is not a schema reference — so the
+    /// quoted form is deliberately left alone to avoid false positives.
+    fn dml_target_is_schema_qualified(table_name: &str, quoted: bool) -> bool {
+        !quoted && table_name.contains('.')
     }
 
     /// Is this body-statement parse error one that SQLite also rejects at

--- a/crates/vibesql-parser/src/tests/trigger.rs
+++ b/crates/vibesql-parser/src/tests/trigger.rs
@@ -1074,6 +1074,95 @@ fn test_create_trigger_accepts_raise() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Trigger-body DML restrictions (ticket #3947, trigger1-16.1..16.7). A
+// trigger-body INSERT/UPDATE/DELETE may not target a schema-qualified table
+// name, and a body UPDATE/DELETE may not carry an INDEXED BY / NOT INDEXED
+// clause. SQLite rejects each at CREATE TRIGGER time with a full message.
+// ---------------------------------------------------------------------------
+
+const TRIGGER_QUALIFIED_TABLE_ERR: &str =
+    "qualified table names are not allowed on INSERT, UPDATE, and DELETE statements within triggers";
+const TRIGGER_NOT_INDEXED_ERR: &str =
+    "the NOT INDEXED clause is not allowed on UPDATE or DELETE statements within triggers";
+const TRIGGER_INDEXED_BY_ERR: &str =
+    "the INDEXED BY clause is not allowed on UPDATE or DELETE statements within triggers";
+
+fn assert_trigger_rejected_with(sql: &str, expected: &str) {
+    let err = Parser::parse_sql(sql).expect_err(&format!("expected rejection for: {sql}"));
+    assert_eq!(err.message, expected, "wrong message for: {sql}\n  got: {}", err.message);
+}
+
+#[test]
+fn test_create_trigger_rejects_qualified_insert_target() {
+    // trigger1-16.1
+    assert_trigger_rejected_with(
+        "CREATE TRIGGER t16err1 AFTER INSERT ON tA BEGIN \
+         INSERT INTO main.t16 VALUES(1,2,3); END;",
+        TRIGGER_QUALIFIED_TABLE_ERR,
+    );
+}
+
+#[test]
+fn test_create_trigger_rejects_qualified_update_target() {
+    // trigger1-16.2
+    assert_trigger_rejected_with(
+        "CREATE TRIGGER t16err2 AFTER INSERT ON tA BEGIN \
+         UPDATE main.t16 SET a=a+1; END;",
+        TRIGGER_QUALIFIED_TABLE_ERR,
+    );
+}
+
+#[test]
+fn test_create_trigger_rejects_qualified_delete_target() {
+    // trigger1-16.3
+    assert_trigger_rejected_with(
+        "CREATE TRIGGER t16err3 AFTER INSERT ON tA BEGIN \
+         DELETE FROM main.t16; END;",
+        TRIGGER_QUALIFIED_TABLE_ERR,
+    );
+}
+
+#[test]
+fn test_create_trigger_rejects_not_indexed_in_body() {
+    // trigger1-16.4
+    assert_trigger_rejected_with(
+        "CREATE TRIGGER t16err4 AFTER INSERT ON tA BEGIN \
+         UPDATE t16 NOT INDEXED SET b=b+1; END;",
+        TRIGGER_NOT_INDEXED_ERR,
+    );
+}
+
+#[test]
+fn test_create_trigger_rejects_indexed_by_in_body() {
+    // trigger1-16.5
+    assert_trigger_rejected_with(
+        "CREATE TRIGGER t16err5 AFTER INSERT ON tA BEGIN \
+         UPDATE t16 INDEXED BY t16a SET b=b+1 WHERE a=1; END;",
+        TRIGGER_INDEXED_BY_ERR,
+    );
+}
+
+#[test]
+fn test_create_trigger_rejects_not_indexed_in_delete_body() {
+    // trigger1-16.6
+    assert_trigger_rejected_with(
+        "CREATE TRIGGER t16err6 AFTER INSERT ON tA BEGIN \
+         DELETE FROM t16 NOT INDEXED WHERE a=1; END;",
+        TRIGGER_NOT_INDEXED_ERR,
+    );
+}
+
+#[test]
+fn test_create_trigger_accepts_unqualified_body_dml() {
+    // Negative control: an ordinary unqualified body DML with no index hint is
+    // still accepted.
+    assert_trigger_accepted(
+        "CREATE TRIGGER tr1 AFTER INSERT ON tA BEGIN \
+         INSERT INTO t16 VALUES(1,2,3); UPDATE t16 SET b=b+1; DELETE FROM t16 WHERE a=1; END;",
+    );
+}
+
 // --- name_source: preserve the verbatim trigger-name spelling (issue #5527) ---
 //
 // SQLite echoes the trigger name *exactly as written* (including its quoting

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -730,6 +730,20 @@ proc translate_error_to_sqlite {vibesql_error} {
     if {[regexp -nocase {^Parse error: (trigger cannot use variables)$} $error_msg -> parse_msg]} {
         return $parse_msg
     }
+    # RAISE() used outside a trigger program (trigger1-11.1, triggerC-16.2) —
+    # SQLite returns this semantic message verbatim, not wrapped as a syntax error.
+    if {[regexp -nocase {^Parse error: (RAISE\(\) may only be used within a trigger-program)$} $error_msg -> parse_msg]} {
+        return $parse_msg
+    }
+    # Trigger-body DML restrictions (ticket #3947, trigger1-16.1..16.7) — a
+    # schema-qualified DML target, or an INDEXED BY / NOT INDEXED clause on a
+    # body UPDATE/DELETE. SQLite returns each of these verbatim, not wrapped.
+    if {[regexp -nocase {^Parse error: (qualified table names are not allowed on INSERT, UPDATE, and DELETE statements within triggers)$} $error_msg -> parse_msg]} {
+        return $parse_msg
+    }
+    if {[regexp -nocase {^Parse error: (the (?:NOT INDEXED|INDEXED BY) clause is not allowed on UPDATE or DELETE statements within triggers)$} $error_msg -> parse_msg]} {
+        return $parse_msg
+    }
     # Fallback for other parse errors (e.g., descriptive messages like "Expected identifier")
     if {[regexp -nocase {^Parse error: (.+)$} $error_msg -> parse_msg]} {
         return "near \"$parse_msg\": syntax error"


### PR DESCRIPTION
## Summary

Partial increment toward #6176 (trigger and DROP TRIGGER / DROP VIEW semantics). This PR fixes the cleanly engine-attributable trigger-body validation failures in `trigger1.test` and `triggerC.test`. It adds SQLite's create-time restrictions on what a `CREATE TRIGGER` body may contain (ticket #3947), plus the matching TCL-shim error passthroughs so the semantic messages are surfaced verbatim.

## Changes

- **`crates/vibesql-parser/src/parser/trigger.rs`** — `validate_trigger_body` now inspects each successfully-parsed body statement and rejects:
  - a schema-qualified INSERT/UPDATE/DELETE target (`INSERT INTO main.t ...` inside a trigger body) with `qualified table names are not allowed on INSERT, UPDATE, and DELETE statements within triggers`;
  - an `INDEXED BY <idx>` / `NOT INDEXED` clause on a body UPDATE/DELETE with the corresponding verbatim SQLite message.
  The checks only run on statements VibeSQL parses successfully, so bodies using constructs VibeSQL cannot yet parse remain tolerated (stored raw, re-parsed at fire time) exactly as before — no behavior change for those.
- **`scripts/tester_vibesql.tcl`** — added `translate_error_to_sqlite` passthroughs so the three new semantic messages, plus the pre-existing `RAISE() may only be used within a trigger-program` parse error, are returned verbatim instead of being wrapped by the catch-all as `near "...": syntax error`.
- **`crates/vibesql-parser/src/tests/trigger.rs`** — 7 new unit tests covering each rejection (qualified INSERT/UPDATE/DELETE, NOT INDEXED on UPDATE and DELETE, INDEXED BY) plus a negative control that ordinary unqualified body DML is still accepted.

## Acceptance Criteria Verification

The issue's acceptance is "the four files pass, or remaining failures are documented-behavior-justified." This PR is a **partial increment** — it fixes the trigger-body-validation subset and documents the remaining failures' root causes below.

| File | Before | After | Notes |
|------|-------:|------:|-------|
| trigger1.test | 35 failed | 27 failed | Fixes 16.1–16.7 (trigger-body DML restrictions) and 11.1 (RAISE outside trigger). |
| triggerC.test | 18 failed | 17 failed | Fixes 16.2 (RAISE outside trigger). |
| e_droptrigger.test | 59 failed | 59 failed | **All 59 blocked on `ATTACH DATABASE`** (`near "ATTACH": syntax error`), a separate large multi-database feature (Priority-3). Out of scope here. |
| e_dropview.test | 25 failed | 25 failed | Mostly blocked on `ATTACH` (aux database) and the missing `do_select_tests` shim proc; a subset also needs schema-qualified `main.sqlite_master`. Out of scope here. |

Remaining trigger1/triggerC failures are pre-existing and orthogonal to trigger-body validation: TEMP-object emulation artifacts (the shim rewrites TEMP tables to regular tables, so `temp_table`/`temp_trig` appear in `sqlite_master`), trigger firing-order/row-visibility differences, `UNIQUE constraint failed` message formatting, INTEGER-PK datatype-mismatch enforcement, and hex-literal parsing.

## Test Plan

- `cargo test -p vibesql-parser` — 1770 + 8 pass, including the 7 new trigger-body-validation tests.
- `cargo test -p vibesql-executor trigger` — all trigger unit tests pass (no regressions).
- `make test-tcl-file FILE=trigger1.test` — 35 → 27 failing.
- `make test-tcl-file FILE=triggerC.test` — 18 → 17 failing.
- Spot-checked `trigger2/7/B/E/G` and `temptrigger`: remaining failures are pre-existing and unrelated (no false-positive "qualified table names" rejections of valid triggers).
- Direct-binary verification of all four new error messages.

Part of #6176