### PR TITLE
feat(pragma): add introspection PRAGMAs data_version, collation_list, index_info/xinfo/list

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -1226,6 +1226,44 @@ impl SqlExecutor {
             "DATABASE_LIST" => {
                 return self.execute_pragma_database_list();
             }
+            "INDEX_LIST" => {
+                return self.execute_pragma_index_list(stmt);
+            }
+            "INDEX_INFO" => {
+                return self.execute_pragma_index_info(stmt, false);
+            }
+            "INDEX_XINFO" => {
+                return self.execute_pragma_index_info(stmt, true);
+            }
+            "COLLATION_LIST" => {
+                return self.execute_pragma_collation_list();
+            }
+            "DATA_VERSION" => {
+                // SQLite `PRAGMA data_version` returns an integer that a given
+                // connection observes changing only when *another* connection
+                // commits to the database file; commits made on the same
+                // connection never change it (R-47505-58569), and writing to
+                // the pragma is a no-op that still reports the current value.
+                //
+                // The VibeSQL TCL conformance shim runs each SQL batch as a
+                // fresh connection to the file, so every read legitimately sees
+                // the initial value 1 — which is exactly SQLite's behaviour for
+                // a connection that has observed no external commit. The
+                // multi-connection cases in pragma3 (a persistent `db2` seeing
+                // the counter advance to 2, 3, ...) cannot be emulated across
+                // the shim's ephemeral processes; those are a shim limitation,
+                // not an engine gap, and are left failing rather than forced.
+                //
+                // Handled here (before the set/query split) so both the query
+                // form and the read-only-write form `= N` report 1.
+                return Ok(QueryResult {
+                    columns: vec!["data_version".to_string()],
+                    rows: vec![vec![Some("1".to_string())]],
+                    row_count: 1,
+                    execution_time_ms: None,
+                    message: None,
+                });
+            }
             "INTEGRITY_CHECK" | "QUICK_CHECK" => {
                 // SQLite compatibility: `PRAGMA integrity_check` and the
                 // table-scoped form `PRAGMA integrity_check('t1')` both report
@@ -1973,6 +2011,237 @@ impl SqlExecutor {
                 Some(notnull.to_string()),
                 dflt_value,
                 Some(pk.to_string()),
+            ]);
+        }
+
+        let row_count = rows.len();
+        Ok(QueryResult { columns, rows, row_count, execution_time_ms: None, message: None })
+    }
+
+    /// PRAGMA collation_list - SQLite-compatible
+    ///
+    /// Returns one row (`seq`, `name`) per registered collating sequence. VibeSQL
+    /// ships the three built-in collations SQLite always registers — BINARY,
+    /// NOCASE and RTRIM — listed most-recently-registered first (BINARY is
+    /// registered first internally, so it sorts last), matching SQLite's
+    /// `pragma-11.1` fixture `{seq 0 name RTRIM seq 1 name NOCASE seq 2 name
+    /// BINARY}`. User-defined collations registered through the C API
+    /// (`db collate ...`) cannot be added through the CLI, so they are not
+    /// reported.
+    fn execute_pragma_collation_list(&self) -> anyhow::Result<QueryResult> {
+        let columns = vec!["seq".to_string(), "name".to_string()];
+        let names = ["RTRIM", "NOCASE", "BINARY"];
+        let rows: Vec<Vec<Option<String>>> = names
+            .iter()
+            .enumerate()
+            .map(|(seq, name)| vec![Some(seq.to_string()), Some((*name).to_string())])
+            .collect();
+        let row_count = rows.len();
+        Ok(QueryResult { columns, rows, row_count, execution_time_ms: None, message: None })
+    }
+
+    /// PRAGMA index_list(table-name) - SQLite-compatible
+    ///
+    /// Returns one row per index on the named table with:
+    ///   seq (index number), name, unique (0/1), origin, partial (0/1).
+    ///
+    /// `origin` is `c` for an index created by CREATE INDEX, `u` for the implicit
+    /// index backing a UNIQUE constraint, and `pk` for the implicit index backing
+    /// a (non-rowid) PRIMARY KEY. Implicit indexes are named `sqlite_autoindex_*`
+    /// and are materialized in the catalog, so they are reported here. Indexes are
+    /// listed newest-first (matching SQLite, which walks its per-table index list
+    /// in reverse creation order).
+    fn execute_pragma_index_list(
+        &self,
+        stmt: &vibesql_ast::PragmaStmt,
+    ) -> anyhow::Result<QueryResult> {
+        let columns = vec![
+            "seq".to_string(),
+            "name".to_string(),
+            "unique".to_string(),
+            "origin".to_string(),
+            "partial".to_string(),
+        ];
+
+        let empty = QueryResult {
+            columns: columns.clone(),
+            rows: Vec::new(),
+            row_count: 0,
+            execution_time_ms: None,
+            message: None,
+        };
+
+        let table_name = match &stmt.value {
+            Some(vibesql_ast::PragmaValue::Identifier(name)) => name.clone(),
+            Some(vibesql_ast::PragmaValue::String(name)) => name.clone(),
+            // No table argument supplied - SQLite returns no rows.
+            _ => return Ok(empty),
+        };
+
+        // Schema-qualified handling: VibeSQL carries a single schema, so a
+        // qualifier other than the current schema / `main` yields no rows.
+        let current_schema = self.db.catalog.get_current_schema().to_string();
+        if let Some(ref schema) = stmt.database {
+            let is_current =
+                schema.eq_ignore_ascii_case(&current_schema) || schema.eq_ignore_ascii_case("main");
+            if !is_current {
+                return Ok(empty);
+            }
+        }
+
+        // Unknown table -> no rows (SQLite is silent for index_list on a missing
+        // table).
+        let table = match self.db.catalog.get_table(&table_name) {
+            Some(t) => t,
+            None => return Ok(empty),
+        };
+
+        // Primary-key column set, used to distinguish a `pk`-origin autoindex
+        // from a `u`-origin (UNIQUE) autoindex.
+        let pk_cols: Option<Vec<String>> =
+            table.primary_key.as_ref().map(|cols| cols.iter().map(|c| c.to_lowercase()).collect());
+
+        // SQLite lists indexes in reverse creation order (newest first); the
+        // catalog stores them oldest-first, so reverse for parity.
+        let mut indexes = self.db.catalog.get_table_indexes(&table_name);
+        indexes.reverse();
+
+        let mut rows: Vec<Vec<Option<String>>> = Vec::with_capacity(indexes.len());
+        for (seq, index) in indexes.iter().enumerate() {
+            let unique = if index.is_unique { 1 } else { 0 };
+            let partial = if index.where_clause.is_some() { 1 } else { 0 };
+
+            let origin = if index.name.to_lowercase().starts_with("sqlite_autoindex_") {
+                // Implicit index: classify as pk vs u by comparing its key
+                // columns to the table's declared PRIMARY KEY.
+                let index_cols: Vec<String> = index
+                    .columns
+                    .iter()
+                    .filter_map(|c| c.column_name().map(|n| n.to_lowercase()))
+                    .collect();
+                match &pk_cols {
+                    Some(pk) if !pk.is_empty() && *pk == index_cols => "pk",
+                    _ => "u",
+                }
+            } else {
+                "c"
+            };
+
+            rows.push(vec![
+                Some(seq.to_string()),
+                Some(index.name.clone()),
+                Some(unique.to_string()),
+                Some(origin.to_string()),
+                Some(partial.to_string()),
+            ]);
+        }
+
+        let row_count = rows.len();
+        Ok(QueryResult { columns, rows, row_count, execution_time_ms: None, message: None })
+    }
+
+    /// PRAGMA index_info(index-name) / index_xinfo(index-name) - SQLite-compatible
+    ///
+    /// `index_info` returns one row per key column of the named index:
+    ///   seqno (rank within the index, 0-based), cid (rank of the column within
+    ///   the table, or -1 for a rowid/expression), name (column name, NULL for a
+    ///   rowid or expression column).
+    ///
+    /// `index_xinfo` (when `extended` is true) adds three columns —
+    ///   desc (1 if DESC), coll (collation name), key (1 for a key column, 0 for
+    ///   an auxiliary column) — and additionally lists the auxiliary columns that
+    ///   SQLite appends to every index on a rowid table: a trailing rowid entry
+    ///   (cid -1, name NULL, key 0).
+    fn execute_pragma_index_info(
+        &self,
+        stmt: &vibesql_ast::PragmaStmt,
+        extended: bool,
+    ) -> anyhow::Result<QueryResult> {
+        let columns = if extended {
+            vec![
+                "seqno".to_string(),
+                "cid".to_string(),
+                "name".to_string(),
+                "desc".to_string(),
+                "coll".to_string(),
+                "key".to_string(),
+            ]
+        } else {
+            vec!["seqno".to_string(), "cid".to_string(), "name".to_string()]
+        };
+
+        let empty = QueryResult {
+            columns: columns.clone(),
+            rows: Vec::new(),
+            row_count: 0,
+            execution_time_ms: None,
+            message: None,
+        };
+
+        let index_name = match &stmt.value {
+            Some(vibesql_ast::PragmaValue::Identifier(name)) => name.clone(),
+            Some(vibesql_ast::PragmaValue::String(name)) => name.clone(),
+            // No index argument supplied - SQLite returns no rows.
+            _ => return Ok(empty),
+        };
+
+        // Unknown index -> no rows (SQLite is silent for index_info on a missing
+        // index).
+        let index = match self.db.catalog.find_index_by_name(&index_name) {
+            Some(i) => i,
+            None => return Ok(empty),
+        };
+
+        // Resolve the backing table so key columns can be mapped to their table
+        // column position (cid).
+        let table = self.db.catalog.get_table(&index.table_name);
+
+        let mut rows: Vec<Vec<Option<String>>> = Vec::new();
+        for (seqno, column) in index.columns.iter().enumerate() {
+            let (cid, name): (i64, Option<String>) = match column.column_name() {
+                Some(col_name) => {
+                    let cid = table
+                        .and_then(|t| t.get_column_index(col_name))
+                        .map(|i| i as i64)
+                        .unwrap_or(-1);
+                    (cid, Some(col_name.to_string()))
+                }
+                // Expression column: SQLite reports cid -1 and a NULL name.
+                None => (-1, None),
+            };
+
+            if extended {
+                let desc = if matches!(column.order(), vibesql_catalog::SortOrder::Descending) {
+                    1
+                } else {
+                    0
+                };
+                rows.push(vec![
+                    Some(seqno.to_string()),
+                    Some(cid.to_string()),
+                    name,
+                    Some(desc.to_string()),
+                    Some("BINARY".to_string()),
+                    Some("1".to_string()),
+                ]);
+            } else {
+                rows.push(vec![Some(seqno.to_string()), Some(cid.to_string()), name]);
+            }
+        }
+
+        // index_xinfo lists the auxiliary columns appended to make the index a
+        // covering key. For an ordinary rowid table this is the trailing rowid
+        // (cid -1, name NULL, key 0). index_info omits auxiliary columns
+        // (R-23114-21695).
+        if extended {
+            let seqno = index.columns.len();
+            rows.push(vec![
+                Some(seqno.to_string()),
+                Some("-1".to_string()),
+                None,
+                Some("0".to_string()),
+                Some("BINARY".to_string()),
+                Some("0".to_string()),
             ]);
         }
 

--- a/crates/vibesql-cli/src/executor/tests.rs
+++ b/crates/vibesql-cli/src/executor/tests.rs
@@ -688,3 +688,140 @@ fn test_pragma_database_list_persistent_objects_no_temp_row() {
     assert_eq!(result.row_count, 1, "persistent objects only -> just main");
     assert_eq!(result.rows[0][1].as_deref(), Some("main"));
 }
+
+#[test]
+fn test_pragma_data_version_returns_one() {
+    // PRAGMA data_version reports 1 for a connection that has observed no
+    // external commit (SQLite's initial value). The read-only-write form
+    // `= N` is a no-op that still reports the current value.
+    let mut executor = SqlExecutor::new(None).unwrap();
+    let result = executor.execute("PRAGMA data_version").unwrap();
+    assert_eq!(result.row_count, 1);
+    assert_eq!(result.columns, vec!["data_version".to_string()]);
+    assert_eq!(result.rows[0][0].as_deref(), Some("1"));
+
+    // Read-only-write form still reports 1.
+    let result = executor.execute("PRAGMA data_version = 1234").unwrap();
+    assert_eq!(result.row_count, 1);
+    assert_eq!(result.rows[0][0].as_deref(), Some("1"));
+
+    // Schema-qualified form is accepted and ignored.
+    let result = executor.execute("PRAGMA main.data_version").unwrap();
+    assert_eq!(result.rows[0][0].as_deref(), Some("1"));
+}
+
+#[test]
+fn test_pragma_collation_list_builtins() {
+    // PRAGMA collation_list reports the three built-in collating sequences,
+    // most-recently-registered first: RTRIM, NOCASE, BINARY.
+    let mut executor = SqlExecutor::new(None).unwrap();
+    let result = executor.execute("PRAGMA collation_list").unwrap();
+    assert_eq!(result.columns, vec!["seq".to_string(), "name".to_string()]);
+    assert_eq!(result.row_count, 3);
+    assert_eq!(result.rows[0][0].as_deref(), Some("0"));
+    assert_eq!(result.rows[0][1].as_deref(), Some("RTRIM"));
+    assert_eq!(result.rows[1][1].as_deref(), Some("NOCASE"));
+    assert_eq!(result.rows[2][1].as_deref(), Some("BINARY"));
+}
+
+#[test]
+fn test_pragma_index_info_reports_key_columns() {
+    // PRAGMA index_info(idx) returns one row per key column: seqno, cid (table
+    // column rank), name. The `= idx` form is accepted the same as `(idx)`.
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor.execute("CREATE TABLE t3(a, b, c)").unwrap();
+    executor.execute("CREATE INDEX t3i2 ON t3(b, a)").unwrap();
+
+    let result = executor.execute("PRAGMA index_info(t3i2)").unwrap();
+    assert_eq!(result.columns, vec!["seqno".to_string(), "cid".to_string(), "name".to_string()]);
+    assert_eq!(result.row_count, 2);
+    // b is table column 1, a is table column 0.
+    assert_eq!(result.rows[0], vec![Some("0".into()), Some("1".into()), Some("b".into())]);
+    assert_eq!(result.rows[1], vec![Some("1".into()), Some("0".into()), Some("a".into())]);
+
+    // `= idx` form.
+    let result = executor.execute("PRAGMA index_info = t3i2").unwrap();
+    assert_eq!(result.row_count, 2);
+
+    // Unknown index -> empty result (no error).
+    let result = executor.execute("PRAGMA index_info(nope)").unwrap();
+    assert_eq!(result.row_count, 0);
+}
+
+#[test]
+fn test_pragma_index_xinfo_appends_rowid_aux_column() {
+    // PRAGMA index_xinfo(idx) adds desc/coll/key columns and appends the
+    // auxiliary rowid entry (cid -1, name NULL, key 0) that index_info omits.
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor.execute("CREATE TABLE t3(a, b)").unwrap();
+    executor.execute("CREATE INDEX t3i1 ON t3(a, b)").unwrap();
+
+    let result = executor.execute("PRAGMA index_xinfo(t3i1)").unwrap();
+    assert_eq!(
+        result.columns,
+        vec![
+            "seqno".to_string(),
+            "cid".to_string(),
+            "name".to_string(),
+            "desc".to_string(),
+            "coll".to_string(),
+            "key".to_string()
+        ]
+    );
+    assert_eq!(result.row_count, 3);
+    // Two key columns, then the auxiliary rowid column.
+    assert_eq!(result.rows[0][5].as_deref(), Some("1"), "a is a key column");
+    assert_eq!(result.rows[1][5].as_deref(), Some("1"), "b is a key column");
+    assert_eq!(result.rows[2][1].as_deref(), Some("-1"), "aux rowid cid = -1");
+    assert_eq!(result.rows[2][2], None, "aux rowid name is NULL");
+    assert_eq!(result.rows[2][5].as_deref(), Some("0"), "aux column key = 0");
+}
+
+#[test]
+fn test_pragma_index_list_origins() {
+    // PRAGMA index_list(table) reports seq, name, unique, origin, partial. An
+    // explicit CREATE INDEX has origin 'c'; a UNIQUE-constraint autoindex has
+    // origin 'u'; a PRIMARY KEY autoindex has origin 'pk'.
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor.execute("CREATE TABLE t3(a, b UNIQUE)").unwrap();
+    executor.execute("CREATE INDEX t3i1 ON t3(a, b)").unwrap();
+
+    let result = executor.execute("PRAGMA index_list(t3)").unwrap();
+    assert_eq!(
+        result.columns,
+        vec![
+            "seq".to_string(),
+            "name".to_string(),
+            "unique".to_string(),
+            "origin".to_string(),
+            "partial".to_string()
+        ]
+    );
+    // Newest-first ordering: the explicit index appears before the autoindex.
+    let names: Vec<Option<&str>> = result.rows.iter().map(|r| r[1].as_deref()).collect();
+    assert!(names.contains(&Some("t3i1")));
+    assert!(names.contains(&Some("sqlite_autoindex_t3_1")));
+    for row in &result.rows {
+        match row[1].as_deref() {
+            Some("t3i1") => {
+                assert_eq!(row[2].as_deref(), Some("0"), "explicit index not unique");
+                assert_eq!(row[3].as_deref(), Some("c"), "explicit -> origin c");
+            }
+            Some("sqlite_autoindex_t3_1") => {
+                assert_eq!(row[2].as_deref(), Some("1"), "UNIQUE autoindex is unique");
+                assert_eq!(row[3].as_deref(), Some("u"), "UNIQUE -> origin u");
+            }
+            other => panic!("unexpected index {other:?}"),
+        }
+    }
+
+    // PRIMARY KEY autoindex -> origin pk.
+    executor.execute("CREATE TABLE tp(a, b, PRIMARY KEY(a, b))").unwrap();
+    let result = executor.execute("PRAGMA index_list(tp)").unwrap();
+    assert_eq!(result.row_count, 1);
+    assert_eq!(result.rows[0][3].as_deref(), Some("pk"));
+
+    // Unknown table -> empty result (no error).
+    let result = executor.execute("PRAGMA index_list(nope)").unwrap();
+    assert_eq!(result.row_count, 0);
+}

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -2411,7 +2411,7 @@ proc execsql {sql {db ""}} {
                 }
                 continue  ;# Check for more statements
             }
-            if {[regexp -nocase {^PRAGMA\s+(?:\w+\.)?(full_column_names|short_column_names|case_sensitive_like|reverse_unordered_selects|integrity_check|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|table_info)} [string trim $sql]]} {
+            if {[regexp -nocase {^PRAGMA\s+(?:\w+\.)?(full_column_names|short_column_names|case_sensitive_like|reverse_unordered_selects|integrity_check|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|table_info|data_version|collation_list|index_list|index_xinfo|index_info)} [string trim $sql]]} {
                 # This PRAGMA is supported (with =value) - stop stripping
                 break
             } else {
@@ -3161,7 +3161,7 @@ proc execsql2 {sql {db ""}} {
     set sql_upper [string toupper [string trim $sql]]
     if {[string match "PRAGMA*" $sql_upper]} {
         # Allow supported PRAGMAs through
-        if {[regexp -nocase {^PRAGMA\s+(?:database\.)?(full_column_names|short_column_names|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys)} $sql]} {
+        if {[regexp -nocase {^PRAGMA\s+(?:database\.)?(full_column_names|short_column_names|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|data_version|collation_list|index_list|index_xinfo|index_info)} [string trim $sql]]} {
             # Pass through to VibeSQL - these are supported
         } else {
             return {}  ;# Skip unsupported PRAGMA statements


### PR DESCRIPTION
## Summary

Implements five previously-unimplemented SQLite **introspection** PRAGMAs in the CLI executor (all formerly returned an empty result), plus the TCL-shim allow-list wiring needed for them to be exercised by the conformance suite. This is **partial** progress on the PRAGMA family (#6175): it targets the in-scope introspection PRAGMAs and deliberately leaves the genuinely pager/journal-internal and persistence-dependent ones for follow-ups per the issue's triage rule.

## Changes

**Engine (`crates/vibesql-cli/src/executor/mod.rs`)** — new handlers, dispatched before the set/query split so both `(arg)` and `= arg` forms work:
- `PRAGMA data_version` → reports `1` (the initial value for a connection that has observed no external commit); the read-only-write form `= N` reports the current value, matching SQLite.
- `PRAGMA collation_list` → the three built-in collating sequences `RTRIM, NOCASE, BINARY` (most-recently-registered first).
- `PRAGMA index_info(idx)` → one row per key column: `seqno, cid, name` (cid is the table column rank; -1 for a rowid/expression column).
- `PRAGMA index_xinfo(idx)` → adds `desc, coll, key` and the trailing auxiliary rowid entry (`cid -1, name NULL, key 0`) that `index_info` omits.
- `PRAGMA index_list(table)` → one row per index: `seq, name, unique, origin, partial`; `origin` classified `c`/`u`/`pk` from `sqlite_autoindex_*` naming + PRIMARY KEY column comparison; newest-first ordering to match SQLite.

**TCL shim (`scripts/tester_vibesql.tcl`)** — the shim strips any PRAGMA not on an allow-list before handing SQL to vibesql, so these engine PRAGMAs were invisible to the suite:
- Added the five names to **both** allow-lists (`execsql` and `execsql2`).
- Fixed `execsql2` to apply the `^PRAGMA` anchor test to `[string trim $sql]` (it previously tested the untrimmed string, so a `{ pragma ... }` block carrying a leading space from the TCL braces was wrongly stripped — this is why `collation_list` returned empty even after allow-listing).

**Tests** — 5 executor unit tests (`crates/vibesql-cli/src/executor/tests.rs`).

## Deliberately out of scope (per triage rule — not forced green)

| PRAGMA / case | Why deferred |
|---|---|
| `cache_size`, `synchronous`, `page_count`, `freelist_count`, `cache_spill` (pragma2) | genuine pager/journal internals → Bucket-A / #6154 |
| `user_version`, `schema_version` (pragma-8) | require DB-header **persistence** across reconnect (survives `db close`/reopen) |
| `table_info` type = `{}` vs `BLOB` for typeless columns (pragma-6.2.2/6.8, pragma4-4.1.2/5.0) | needs a new `ColumnSchema` field to distinguish "no declared type" from `BLOB` (600+ construction sites) |
| multi-connection `data_version` = 2,3,… (pragma3-140+) and ATTACH/`aux` cases | the shim runs each batch as a fresh process — cross-connection counter advance can't be emulated |
| `capture_pragma`-based `index_list`/`index_info` tests (pragma-6.4/6.5.1/6.5.1b/6.7/7.1.1) | blocked by the shim's textual `$var` substitution vs SQLite's parameter binding — a generic shim limitation, not PRAGMA correctness |

The engine implementations are verified correct via the CLI and unit tests; the `capture_pragma` tests would pass once the shim gains real parameter binding.

## Acceptance Criteria Verification

| Criterion (from #6175) | Status | Verification |
|---|---|---|
| In-scope introspection PRAGMAs implemented (index_info/xinfo/list, collation_list, data_version) | ✅ | 5 new executor handlers + 5 unit tests (`cargo test -p vibesql-cli --bin vibesql executor::tests::test_pragma_*`) |
| Introspection PRAGMAs pass under `make test-tcl-file` | ✅ (partial) | pragma3 `0→11`, pragma.test `35→38` passing; remaining failures are the deferred cases above |
| Pager/journal internals NOT forced green; documented as Bucket-A | ✅ | Left untouched; table above routes them to #6154 |
| No silent reclassification of an introspection PRAGMA | ✅ | No skip-policy edits; only real engine implementations + shim allow-list wiring |

## Test Plan

- `cargo test --release -p vibesql-cli --bin vibesql -- executor::tests::` → 60 passed, 0 failed (5 new).
- `make test-tcl-file FILE=<f>` before → after (passed):
  - pragma.test 35 → **38**
  - pragma3.test 0 → **11**
  - pragma2.test 1 → 1, pragma4.test 2 → 2, pragma6.test 2 → 2 (unchanged; deferred cases)
- No true regression: diffing pragma.test failing-test names before/after shows the only newly-failing tests (6.4/6.5.1/6.5.1b) were **not passing** in baseline — they are `capture_pragma` cases now *reached* (previously short-circuited) that fail on the shim's parameter-binding limitation.
- `cargo clippy -p vibesql-cli` clean for new code (one pre-existing warning in untouched `sqlite_io.rs`).

Note: the full TCL suite was not run (shared machine); reviewer/auditor may wish to spot-check that the shim allow-list additions don't surface expected-empty regressions elsewhere.

Part of #6175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)