### PR TITLE
feat(parser): interleaved generated-column & ignored constraint-name clauses; shim do_select_tests

### DIFF
--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -365,14 +365,20 @@ impl Parser {
     /// with column constraints in any order (e.g., `idx UNIQUE DEFAULT NULL`), so
     /// callers should treat the returned default as additional output and merge it
     /// with any DEFAULT clause parsed before the constraint list.
+    #[allow(clippy::type_complexity)]
     pub(in crate::parser) fn parse_column_constraints(
         &mut self,
     ) -> Result<
-        (Vec<vibesql_ast::ColumnConstraint>, Option<Box<vibesql_ast::Expression>>),
+        (
+            Vec<vibesql_ast::ColumnConstraint>,
+            Option<Box<vibesql_ast::Expression>>,
+            Option<Box<vibesql_ast::Expression>>,
+        ),
         ParseError,
     > {
         let mut constraints = Vec::new();
         let mut default_value: Option<Box<vibesql_ast::Expression>> = None;
+        let mut generated_expr: Option<Box<vibesql_ast::Expression>> = None;
 
         loop {
             // Check for optional CONSTRAINT keyword
@@ -568,19 +574,93 @@ impl Parser {
                         kind: vibesql_ast::ColumnConstraintKind::Collate(collation_name),
                     });
                 }
-                _ => {
-                    // If we parsed a CONSTRAINT name but no constraint type, error
-                    if name.is_some() {
+                Token::Keyword { keyword: Keyword::Generated, .. } => {
+                    // Generated column constraint (full form):
+                    //   [CONSTRAINT name] GENERATED ALWAYS AS (expr) [STORED|VIRTUAL]
+                    // In SQLite the generated-column clause is itself a
+                    // column-constraint alternative, so it may appear interleaved
+                    // with UNIQUE / NOT NULL / etc. in any order (e.g.
+                    // `b UNIQUE AS(a)`, `b INT NOT NULL AS(a==0)`). Parsing it here
+                    // — rather than only at the fixed post-type position — lets
+                    // those orderings parse (#6173: gencol1 `near "AS"` failures).
+                    self.advance(); // consume GENERATED
+                    self.expect_keyword(Keyword::Always)?;
+                    self.expect_keyword(Keyword::As)?;
+                    self.expect_token(Token::LParen)?;
+                    let expr = self.parse_expression()?;
+                    self.expect_token(Token::RParen)?;
+                    if self.peek_keyword(Keyword::Stored) || self.peek_keyword(Keyword::Virtual) {
+                        self.advance();
+                    }
+                    if generated_expr.is_some() {
                         return Err(ParseError {
-                            message: "Expected constraint type after CONSTRAINT name".to_string(),
+                            message: "duplicate generated column clause".to_string(),
                         });
+                    }
+                    generated_expr = Some(Box::new(expr));
+                }
+                Token::Keyword { keyword: Keyword::As, .. } => {
+                    // Generated column constraint (short form):
+                    //   [CONSTRAINT name] AS (expr) [STORED|VIRTUAL]
+                    self.advance(); // consume AS
+                    self.expect_token(Token::LParen)?;
+                    let expr = self.parse_expression()?;
+                    self.expect_token(Token::RParen)?;
+                    if self.peek_keyword(Keyword::Stored) || self.peek_keyword(Keyword::Virtual) {
+                        self.advance();
+                    }
+                    if generated_expr.is_some() {
+                        return Err(ParseError {
+                            message: "duplicate generated column clause".to_string(),
+                        });
+                    }
+                    generated_expr = Some(Box::new(expr));
+                }
+                _ => {
+                    // A `CONSTRAINT name` clause with no constraint body following
+                    // it is accepted and ignored by SQLite for backwards
+                    // compatibility ("The CONSTRAINT name clause can follow a
+                    // constraint. Such a clause is ignored." — check.test 2.10).
+                    // This also covers back-to-back names such as
+                    // `CONSTRAINT x_one CONSTRAINT x_two CHECK(...)`, where only the
+                    // final name binds to the constraint body. We consumed the
+                    // CONSTRAINT + name tokens above, so continue the loop to pick
+                    // up whatever follows (another name, a real constraint, or the
+                    // column terminator) rather than erroring (#6173).
+                    if name.is_some() {
+                        continue;
                     }
                     break;
                 }
             }
         }
 
-        Ok((constraints, default_value))
+        Ok((constraints, default_value, generated_expr))
+    }
+
+    /// Absorb trailing, body-less `CONSTRAINT <name>` clauses that SQLite accepts
+    /// and ignores after a table-level constraint (e.g.
+    /// `CONSTRAINT u_one UNIQUE(x,y,z) CONSTRAINT u_two` — check.test 2.12). Only
+    /// a `CONSTRAINT <name>` immediately followed by a `,` or `)` terminator is
+    /// treated as such a trailing name; a `CONSTRAINT <name> <TYPE>` sequence is
+    /// left untouched so a genuine next constraint still parses.
+    pub(in crate::parser) fn skip_trailing_constraint_names(&mut self) {
+        while self.peek_keyword(Keyword::Constraint) {
+            let name_is_ident = matches!(
+                self.tokens.get(self.position + 1),
+                Some(Token::Identifier(_) | Token::DelimitedIdentifier(_) | Token::String(_))
+            );
+            let terminated = matches!(
+                self.tokens.get(self.position + 2),
+                Some(Token::Comma) | Some(Token::RParen)
+            );
+            if name_is_ident && terminated {
+                self.advance(); // consume CONSTRAINT
+                self.advance(); // consume the ignored name
+            } else {
+                break;
+            }
+        }
     }
 
     /// Parse table-level constraints (PRIMARY KEY, FOREIGN KEY, UNIQUE, CHECK)

--- a/crates/vibesql-parser/src/parser/create/table.rs
+++ b/crates/vibesql-parser/src/parser/create/table.rs
@@ -90,6 +90,9 @@ impl Parser {
                 || self.peek_keyword(Keyword::Fulltext)
             {
                 table_constraints.push(self.parse_table_constraint()?);
+                // Absorb any trailing, body-less `CONSTRAINT <name>` clauses that
+                // SQLite accepts and ignores after a table constraint (#6173).
+                self.skip_trailing_constraint_names();
                 if matches!(self.peek(), Token::Comma) {
                     self.advance();
                     continue;
@@ -219,8 +222,10 @@ impl Parser {
                 None
             };
 
-            // Parse column constraints (which may include NOT NULL and an interleaved DEFAULT)
-            let (constraints, mid_default) = self.parse_column_constraints()?;
+            // Parse column constraints (which may include NOT NULL, an
+            // interleaved DEFAULT, and — in any order — a generated-column
+            // `[GENERATED ALWAYS] AS (expr)` clause).
+            let (constraints, mid_default, mid_generated) = self.parse_column_constraints()?;
             if let Some(d) = mid_default {
                 if default_value.is_some() {
                     return Err(ParseError {
@@ -228,6 +233,14 @@ impl Parser {
                     });
                 }
                 default_value = Some(d);
+            }
+            if let Some(g) = mid_generated {
+                if generated_expr.is_some() {
+                    return Err(ParseError {
+                        message: "duplicate generated column clause".to_string(),
+                    });
+                }
+                generated_expr = Some(g);
             }
 
             // SQLite rejects a generated column that also declares DEFAULT with

--- a/crates/vibesql-parser/src/tests/create_table/constraints_column.rs
+++ b/crates/vibesql-parser/src/tests/create_table/constraints_column.rs
@@ -613,3 +613,62 @@ fn test_parse_column_standalone_deferrable() {
         assert!(result.is_ok(), "{sql} should parse: {:?}", result);
     }
 }
+
+// ========================================================================
+// Generated-column clause interleaved with other constraints (#6173)
+//
+// In SQLite the `[GENERATED ALWAYS] AS (expr) [STORED|VIRTUAL]` clause is a
+// column-constraint alternative, so it may appear in any order relative to
+// UNIQUE / NOT NULL / PRIMARY KEY. VibeSQL previously only accepted it at the
+// fixed post-type position, so `b UNIQUE AS(a)` failed with `near "AS"`.
+// ========================================================================
+
+#[test]
+fn test_parse_generated_column_after_constraint() {
+    for sql in [
+        "CREATE TABLE t(a INT, b UNIQUE AS (a))",
+        "CREATE TABLE t(a INT, b NOT NULL AS (a==0))",
+        "CREATE TABLE t(a INT, b INT UNIQUE AS (a))",
+        "CREATE TABLE t(a INT, b UNIQUE GENERATED ALWAYS AS (a))",
+        "CREATE TABLE t(a INT, b AS (a) STORED NOT NULL)",
+        "CREATE TABLE t(a INT, b UNIQUE AS (a) STORED)",
+    ] {
+        let result = Parser::parse_sql(sql);
+        assert!(result.is_ok(), "{sql} should parse: {:?}", result);
+        if let Ok(vibesql_ast::Statement::CreateTable(create)) = result {
+            assert!(
+                create.columns[1].generated_expr.is_some(),
+                "{sql}: column b should be recorded as a generated column"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_parse_duplicate_generated_clause_rejected() {
+    // Two generated clauses on the same column are a parse error.
+    let result = Parser::parse_sql("CREATE TABLE t(a INT, b AS (a) UNIQUE AS (a))");
+    assert!(result.is_err(), "Two generated clauses should be rejected");
+}
+
+// ========================================================================
+// Trailing / standalone `CONSTRAINT name` clauses are accepted and ignored
+// (#6173, check.test 2.10 / 2.12). SQLite documents: "The CONSTRAINT name
+// clause can follow a constraint. Such a clause is ignored. But the parser
+// must accept it for backwards compatibility."
+// ========================================================================
+
+#[test]
+fn test_parse_trailing_constraint_name_ignored() {
+    for sql in [
+        // Column-level trailing name
+        "CREATE TABLE t(x INTEGER CHECK(x<5) CONSTRAINT one, y TEXT PRIMARY KEY CONSTRAINT two)",
+        // Back-to-back names; only the last binds to the CHECK body
+        "CREATE TABLE t(x INTEGER CONSTRAINT a CONSTRAINT b CHECK(x>0) CONSTRAINT c CONSTRAINT d, y)",
+        // Table-level trailing name
+        "CREATE TABLE t(x, y, z, CONSTRAINT u_one UNIQUE(x,z) CONSTRAINT u_two)",
+    ] {
+        let result = Parser::parse_sql(sql);
+        assert!(result.is_ok(), "{sql} should parse: {:?}", result);
+    }
+}

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -5994,6 +5994,74 @@ proc do_catchsql_test {name sql expected} {
     do_test $name [list catchsql $sql] $expected
 }
 
+# Table-driven test helper ported faithfully from SQLite's canonical
+# tester.tcl (proc do_select_tests). Many evidence-suite files
+# (e_createtable.test, e_select.test, e_expr.test, ...) define thin wrappers
+# such as `do_createtable_tests` that forward to `do_select_tests`. Without
+# this proc every such wrapper aborts at file scope on
+# `invalid command name "do_select_tests"`, which the resilient file evaluator
+# records as a long run of `filescope-err` failures and skips the rest of the
+# file (#6173: 66 of e_createtable's 137 failures were this single missing
+# helper cascading). It dispatches each {name sql result} triple to the shim's
+# existing do_execsql_test / do_catchsql_test / do_test, so behavior matches
+# the upstream helper exactly, including 2-char switch abbreviations
+# (`-error` == `-errorformat`, `-query`, `-tclquery`, `-repair`, `-count`).
+proc do_select_tests {prefix args} {
+
+    set testlist [lindex $args end]
+    set switches [lrange $args 0 end-1]
+
+    set errfmt ""
+    set countonly 0
+    set tclquery ""
+    set repair ""
+
+    for {set i 0} {$i < [llength $switches]} {incr i} {
+        set s [lindex $switches $i]
+        set n [string length $s]
+        if {$n>=2 && [string equal -length $n $s "-query"]} {
+            set tclquery [list execsql [lindex $switches [incr i]]]
+        } elseif {$n>=2 && [string equal -length $n $s "-tclquery"]} {
+            set tclquery [lindex $switches [incr i]]
+        } elseif {$n>=2 && [string equal -length $n $s "-errorformat"]} {
+            set errfmt [lindex $switches [incr i]]
+        } elseif {$n>=2 && [string equal -length $n $s "-repair"]} {
+            set repair [lindex $switches [incr i]]
+        } elseif {$n>=2 && [string equal -length $n $s "-count"]} {
+            set countonly 1
+        } else {
+            error "unknown switch: $s"
+        }
+    }
+
+    if {$countonly && $errfmt!=""} {
+        error "Cannot use -count and -errorformat together"
+    }
+    set nTestlist [llength $testlist]
+    if {$nTestlist%3 || $nTestlist==0 } {
+        error "SELECT test list contains [llength $testlist] elements"
+    }
+
+    eval $repair
+    foreach {tn sql res} $testlist {
+        if {$tclquery != ""} {
+            execsql $sql
+            uplevel do_test ${prefix}.$tn [list $tclquery] [list [list {*}$res]]
+        } elseif {$countonly} {
+            set nRow 0
+            db eval $sql {incr nRow}
+            uplevel do_test ${prefix}.$tn [list [list set {} $nRow]] [list $res]
+        } elseif {$errfmt==""} {
+            uplevel do_execsql_test ${prefix}.${tn} [list $sql] [list [list {*}$res]]
+        } else {
+            set res [list 1 [string trim [format $errfmt {*}$res]]]
+            uplevel do_catchsql_test ${prefix}.${tn} [list $sql] [list $res]
+        }
+        eval $repair
+    }
+
+}
+
 proc do_eqp_test {name sql expected} {
     # EXPLAIN QUERY PLAN test
     # Runs the query with EXPLAIN QUERY PLAN and matches against expected pattern


### PR DESCRIPTION
## Summary

Partial progress on the CREATE TABLE / schema-definition family (#6173). This PR lands the contained, low-risk parser + test-harness wins that account for the largest single failure block (the e_createtable file-scope cascade) plus two focused parser gaps in the generated-column and CHECK sub-families. Deeper stateful sub-features are deferred to follow-ups (see below).

## Changes

- **TCL shim `do_select_tests`** (`scripts/tester_vibesql.tcl`): ported the canonical SQLite `tester.tcl` table-driven helper (including its 2-char switch abbreviations `-error`/`-query`/`-tclquery`/`-repair`/`-count`). Many evidence-suite files forward to it via thin wrappers (`do_createtable_tests`), so its absence aborted `e_createtable.test` at file scope with a 66-row `filescope-err` cascade. This was the KEY HINT in the issue.
- **Interleaved generated-column clause** (`create/constraints.rs`, `create/table.rs`): `[GENERATED ALWAYS] AS (expr) [STORED|VIRTUAL]` is a column-constraint alternative in SQLite and may appear in any order relative to `UNIQUE`/`NOT NULL`/etc. It is now parsed inside `parse_column_constraints` and merged back in the column parser, fixing `near "AS": syntax error` on `b UNIQUE AS(a)`, `b NOT NULL AS(a==0)`, etc.
- **Trailing / standalone `CONSTRAINT name` clauses** accepted and ignored at both column and table level (SQLite backwards-compat behavior; check.test 2.10/2.12), e.g. `y TEXT PRIMARY KEY CONSTRAINT two` and `UNIQUE(x,z) CONSTRAINT three`. New `skip_trailing_constraint_names` helper handles the table-level case; back-to-back names bind only the final name to the constraint body.
- **Parser unit tests** for all three parser behaviors.

## Impact on targeted TCL files

| File | Before | After |
|------|-------:|------:|
| e_createtable.test | 48 passed / 137 failed (226 scored) | 255 passed / 201 failed (524 scored) |
| check.test | 63 passed / 29 failed | 67 passed / 25 failed |
| gencol1.test | 53 passed / 34 failed | 57 passed / 30 failed |

(e_createtable's expanded scored count reflects the file-scope cascade being cleared so per-assertion tests now run; its residual failures are dominated by out-of-family gaps — ATTACH `auxa`/`auxb` databases, C-API `sqlite3_prepare_v2`, TEMP databases.)

## Deferred to follow-up sub-PRs (documented in commit)

- `sqlite_sequence` / AUTOINCREMENT bookkeeping (autoinc.test — a writable persistent system table + rowid allocation; the single biggest lever but a self-contained feature).
- `NOT NULL ON CONFLICT REPLACE` default substitution (gencol1-7.x — a general INSERT/conflict-resolution behavior, not gencol-specific).
- STRICT type-enforcement edge cases (strict1-9.x).

## Test Plan

- `cargo test -p vibesql-parser` — 1773 tests pass (incl. 3 new).
- `cargo test -p vibesql-executor` — all pass (no regressions).
- Re-ran targeted TCL files via `make test-tcl-file` / `scripts/tcltest`; numbers above.
- Did NOT run the full TCL suite (shared machine).

Part of #6173