### PR TITLE
fix(storage): downgrade opendal to 0.57 (0.58.0 yanked) and restore Operator::finish

### DIFF
--- a/crates/vibesql-storage/Cargo.toml
+++ b/crates/vibesql-storage/Cargo.toml
@@ -58,7 +58,7 @@ smallvec = { version = "1.13", features = ["serde"] }
 arcstr = "1.2"
 ryu = "1.0"  # Fast float-to-string conversion with proper formatting
 tokio = { version = "1", features = ["rt", "sync"], optional = true }
-opendal = { version = "0.58", optional = true }
+opendal = { version = "0.57", optional = true }
 
 # Use parking_lot for native builds, std::sync for WASM
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/vibesql-storage/src/blob/service.rs
+++ b/crates/vibesql-storage/src/blob/service.rs
@@ -76,7 +76,7 @@ impl BlobStorageService {
 
         let builder = services::Fs::default().root(root);
 
-        Operator::new(builder).map_err(|e| {
+        Operator::new(builder).map(|b| b.finish()).map_err(|e| {
             StorageError::Other(format!("Failed to create filesystem operator: {}", e))
         })
     }
@@ -114,6 +114,7 @@ impl BlobStorageService {
         }
 
         Operator::new(builder)
+            .map(|b| b.finish())
             .map_err(|e| StorageError::Other(format!("Failed to create S3 operator: {}", e)))
     }
 
@@ -140,6 +141,7 @@ impl BlobStorageService {
         }
 
         Operator::new(builder)
+            .map(|b| b.finish())
             .map_err(|e| StorageError::Other(format!("Failed to create GCS operator: {}", e)))
     }
 
@@ -170,6 +172,7 @@ impl BlobStorageService {
         }
 
         Operator::new(builder)
+            .map(|b| b.finish())
             .map_err(|e| StorageError::Other(format!("Failed to create Azure operator: {}", e)))
     }
 
@@ -179,6 +182,7 @@ impl BlobStorageService {
         let builder = services::Memory::default();
 
         Operator::new(builder)
+            .map(|b| b.finish())
             .map_err(|e| StorageError::Other(format!("Failed to create memory operator: {}", e)))
     }
 


### PR DESCRIPTION
## Summary

`opendal = "0.58"` (crates/vibesql-storage/Cargo.toml:61) can no longer be resolved: **0.58.0 has been yanked from crates.io and no other 0.58.x exists**, so `^0.58` is unsatisfiable. Because `Cargo.lock` is gitignored (`.gitignore:5`), every fresh clone / Loom worktree does a fresh resolve that fails with:

```
error: failed to select a version for the requirement `opendal = "^0.58"`
  version 0.58.0 is yanked
```

`opendal` is optional/feature-gated, but cargo resolves optional deps regardless of feature selection, so this broke the default `--bin vibesql` build and the `test`, `storage-features-check`, and `wasm-check` CI jobs at the resolution step (it was blocking PR #6197).

The latest non-yanked release is **0.57.0**. This pins to `0.57` and re-adds the `.finish()` call on each `OperatorBuilder`: in 0.57 `Operator::new(builder)` returns an `OperatorBuilder<impl Access>` that must be `.finish()`ed, whereas the earlier 0.58 bump (issue #6081) had removed that step. CI already documents this exact API delta in a comment on the `storage-features-check` job.

## Changes

- `crates/vibesql-storage/Cargo.toml`: `opendal` requirement `0.58` -> `0.57`.
- `crates/vibesql-storage/src/blob/service.rs`: re-add `.map(|b| b.finish())` to all five operator constructors (fs, s3, gcs, azure, memory) to convert `OperatorBuilder` -> `Operator` under the 0.57 API.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Fresh resolve succeeds (no yanked-version error) | ✅ | Deleted the gitignored `Cargo.lock`, ran `cargo generate-lockfile` -> exit 0, resolves `opendal v0.57.0` |
| Default binary builds | ✅ | `cargo build --release --bin vibesql` -> Finished (exit 0) |
| Storage feature matrix compiles | ✅ | `cargo check -p vibesql-storage --features storage-all` (the exact `storage-features-check` CI command) -> exit 0 |
| Blob backend works at runtime | ✅ | `cargo test -p vibesql-storage --features opendal,storage-memory` -> 13 passed, incl. `test_memory_backend_store_and_get` exercising the new `.finish()` path |
| wasm-check unblocked | ✅ | `cargo check -p vibesql-wasm-bindings --lib --target wasm32-unknown-unknown` now proceeds past dependency resolution; `opendal` is confirmed absent from the wasm tree (`cargo tree`), so the yank was the sole wasm blocker |

## Test Plan

Ran a genuinely fresh resolve (lockfile deleted first, not copied):

```
$ rm -f Cargo.lock && cargo generate-lockfile   # exit 0
$ grep -A2 'name = "opendal"' Cargo.lock
name = "opendal"
version = "0.57.0"
$ cargo build --release --bin vibesql            # Finished (exit 0)
$ cargo check -p vibesql-storage --features storage-all   # exit 0
$ cargo test -p vibesql-storage --features opendal,storage-memory  # 13 passed
```

`cargo fmt -p vibesql-storage --check` and `cargo clippy -p vibesql-storage --features storage-all` produce no new findings from this change.

## Note on fix option 2 (committing Cargo.lock)

The issue's second option — committing `Cargo.lock` (or having `worktree.sh` seed it) so a future yank cannot silently break fresh worktrees — is a policy decision for the operator and is intentionally **not** done here. This PR does not commit the lockfile (it remains gitignored); it only restores a satisfiable dependency requirement so fresh resolves succeed today. If reproducible-build hardening is desired, that should be a separate, deliberate change.

Closes #6196