### PR TITLE
feat(cli): expose columnar cache budget as ~/.vibesqlrc [database] knob (#6200)

### DIFF
--- a/.vibesqlrc.example
+++ b/.vibesqlrc.example
@@ -53,6 +53,15 @@ auto_save = true
 # Default: 2
 # keep_checkpoints = 2
 
+# Memory budget for the columnar representation cache. The cache trades RAM for
+# analytical-query speed (row tables get a cached columnar copy so scans hit the
+# SIMD fast path). Accepts a human-readable size ("256MB", "512MB", "1GB", a bare
+# byte count) or "0" to disable the cache entirely (analytical queries take the
+# row path). Raise it to spend more RAM for speed; set "0" on a memory-constrained
+# machine.
+# Default: 256MB
+# columnar_cache_budget = "256MB"
+
 # ============================================================================
 # History Settings
 # ============================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,8 @@ The replicated state machine applies committed transactions from the Raft log. H
 
 The `vibesql` CLI keeps a Write-Ahead Log for file-backed databases so committed changes survive an unclean shutdown (crash, SIGKILL, power loss). WAL is **on by default**; set `[database] wal = false` in `~/.vibesqlrc` to opt out and use the snapshot-only path.
 
+The `~/.vibesqlrc` `[database]` section also exposes `columnar_cache_budget` (default `"256MB"`; accepts `"512MB"`, `"1GB"`, a bare byte count, or `"0"` to disable the columnar representation cache) to trade RAM for analytical-query speed.
+
 For a database file `mydata.vbsql`, WAL-active mode maintains two sibling files next to it:
 
 ```text

--- a/crates/vibesql-cli/src/config.rs
+++ b/crates/vibesql-cli/src/config.rs
@@ -82,6 +82,21 @@ pub struct DatabaseConfig {
     /// `1` so the newest checkpoint always survives.
     #[serde(default = "default_keep_checkpoints")]
     pub keep_checkpoints: usize,
+
+    /// Memory budget for the columnar representation cache (issue #6200).
+    ///
+    /// The columnar cache trades memory for analytical-query speed: row tables
+    /// get a transparently-cached columnar copy so scans hit the SIMD fast
+    /// path. Accepts a human-readable size string — `"256MB"`, `"512MB"`,
+    /// `"1GB"`, `"1MB"`, a plain byte count like `"268435456"`, or `"0"` to
+    /// disable the cache entirely (analytical queries take the row path).
+    ///
+    /// Defaults to `"256MB"` (matching
+    /// `vibesql_storage::database::DEFAULT_COLUMNAR_CACHE_BUDGET`). Parsed to
+    /// bytes via [`Config::get_columnar_cache_budget`]; a malformed value is a
+    /// clean error at open time, never a panic.
+    #[serde(default = "default_columnar_cache_budget")]
+    pub columnar_cache_budget: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -136,6 +151,48 @@ fn default_keep_checkpoints() -> usize {
     2
 }
 
+fn default_columnar_cache_budget() -> String {
+    // 256MB, matching vibesql_storage::database::DEFAULT_COLUMNAR_CACHE_BUDGET
+    // (256 * 1024 * 1024 bytes).
+    "256MB".to_string()
+}
+
+/// Parse a human-readable byte-size string into a byte count.
+///
+/// Accepts an optional `KB`/`MB`/`GB` suffix (case-insensitive, binary/1024
+/// based) or a bare byte count. `"0"` is honored as "disable". A malformed
+/// value returns a clear error rather than panicking (issue #6200).
+fn parse_byte_size(s: &str) -> anyhow::Result<usize> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("columnar_cache_budget is empty; expected a size like \"256MB\" or \"0\"");
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let (num_part, multiplier) = if let Some(n) = lower.strip_suffix("gb") {
+        (n, 1024usize * 1024 * 1024)
+    } else if let Some(n) = lower.strip_suffix("mb") {
+        (n, 1024usize * 1024)
+    } else if let Some(n) = lower.strip_suffix("kb") {
+        (n, 1024usize)
+    } else if let Some(n) = lower.strip_suffix('b') {
+        (n, 1usize)
+    } else {
+        (lower.as_str(), 1usize)
+    };
+
+    let value: usize = num_part.trim().parse().map_err(|_| {
+        anyhow::anyhow!(
+            "invalid columnar_cache_budget '{}': expected a byte count or a size like \"256MB\", \"512MB\", or \"0\"",
+            s
+        )
+    })?;
+
+    value.checked_mul(multiplier).ok_or_else(|| {
+        anyhow::anyhow!("columnar_cache_budget '{}' is too large (overflows usize bytes)", s)
+    })
+}
+
 impl Default for DisplayConfig {
     fn default() -> Self {
         DisplayConfig { format: default_format() }
@@ -151,6 +208,7 @@ impl Default for DatabaseConfig {
             wal: default_true(),
             lock_timeout_ms: default_lock_timeout_ms(),
             keep_checkpoints: default_keep_checkpoints(),
+            columnar_cache_budget: default_columnar_cache_budget(),
         }
     }
 }
@@ -208,6 +266,15 @@ impl Config {
             _ => None,
         }
     }
+
+    /// Parse the configured columnar cache budget into a byte count (#6200).
+    ///
+    /// Returns the number of bytes to allocate for the columnar representation
+    /// cache. `0` means the cache is disabled. A malformed `[database]
+    /// columnar_cache_budget` value yields a clear error, never a panic.
+    pub fn get_columnar_cache_budget(&self) -> anyhow::Result<usize> {
+        parse_byte_size(&self.database.columnar_cache_budget)
+    }
 }
 
 #[cfg(test)]
@@ -224,6 +291,63 @@ mod tests {
         assert_eq!(config.query.timeout_seconds, 0);
         // WAL is on by default (Phase 2, #5698): committed rows survive crashes.
         assert!(config.database.wal);
+        // Columnar cache budget defaults to 256MB (#6200).
+        assert_eq!(config.database.columnar_cache_budget, "256MB");
+    }
+
+    #[test]
+    fn test_columnar_cache_budget_defaults_when_unspecified() {
+        // Omitting the field must yield the 256MB default (unchanged behavior).
+        let toml_str = r#"
+[database]
+wal = true
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.database.columnar_cache_budget, "256MB");
+        assert_eq!(config.get_columnar_cache_budget().unwrap(), 256 * 1024 * 1024);
+        assert_eq!(Config::default().get_columnar_cache_budget().unwrap(), 256 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_columnar_cache_budget_disable_round_trips() {
+        // "0" must parse and round-trip to a 0-byte budget (cache disabled).
+        let toml_str = r#"
+[database]
+columnar_cache_budget = "0"
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.database.columnar_cache_budget, "0");
+        assert_eq!(config.get_columnar_cache_budget().unwrap(), 0);
+    }
+
+    #[test]
+    fn test_columnar_cache_budget_human_readable_sizes() {
+        // Human-readable suffixes are binary (1024-based) and case-insensitive;
+        // a bare number is a byte count.
+        let cases = [
+            ("512MB", 512 * 1024 * 1024),
+            ("1GB", 1024 * 1024 * 1024),
+            ("64mb", 64 * 1024 * 1024),
+            ("1MB", 1024 * 1024),
+            ("2048KB", 2048 * 1024),
+            ("268435456", 268435456), // bare byte count == 256MB
+        ];
+        for (input, expected) in cases {
+            let mut config = Config::default();
+            config.database.columnar_cache_budget = input.to_string();
+            assert_eq!(config.get_columnar_cache_budget().unwrap(), expected, "parsing {input}");
+        }
+    }
+
+    #[test]
+    fn test_columnar_cache_budget_malformed_errors_cleanly() {
+        // A malformed value must be a clean error, never a panic.
+        for bad in ["not-a-size", "12XB", "MB", ""] {
+            let mut config = Config::default();
+            config.database.columnar_cache_budget = bad.to_string();
+            let err = config.get_columnar_cache_budget();
+            assert!(err.is_err(), "expected error for {bad:?}");
+        }
     }
 
     #[test]

--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -214,6 +214,12 @@ pub struct DbOpenOptions {
     /// `<stem>-checkpoints/` directory does not grow unboundedly (issue #6023).
     /// Clamped to a minimum of 1 so the newest checkpoint always survives.
     pub keep_checkpoints: usize,
+    /// Memory budget (bytes) for the columnar representation cache
+    /// (`[database] columnar_cache_budget`, default 256MB). `0` disables the
+    /// cache so analytical queries take the row path. Applied to the `Database`
+    /// right after open, before any query runs — the cache populates lazily, so
+    /// setting the budget post-load discards nothing (issue #6200).
+    pub columnar_cache_budget: usize,
 }
 
 impl Default for DbOpenOptions {
@@ -223,6 +229,8 @@ impl Default for DbOpenOptions {
             recover_fallback: false,
             lock_timeout_ms: 5000,
             keep_checkpoints: 2,
+            // Matches vibesql_storage::database::DEFAULT_COLUMNAR_CACHE_BUDGET.
+            columnar_cache_budget: 256 * 1024 * 1024,
         }
     }
 }
@@ -342,6 +350,11 @@ impl SqlExecutor {
                         e
                     )
                 })?;
+                // Apply the configured columnar cache budget (issue #6200).
+                // Safe post-load: the cache populates lazily on the first
+                // analytical query, so no cached data is discarded here. `0`
+                // disables the cache entirely.
+                db.set_columnar_cache_budget(options.columnar_cache_budget);
                 return Ok(SqlExecutor {
                     db,
                     timing_enabled: false,
@@ -376,6 +389,11 @@ impl SqlExecutor {
         // (binary/JSON reload path). Harmless no-op when there are none. #5784.
         vibesql_executor::rebuild_pending_expression_indexes(&mut db)
             .map_err(|e| anyhow::anyhow!("Failed to rebuild expression indexes: {}", e))?;
+
+        // Apply the configured columnar cache budget (issue #6200). Applied
+        // before any query runs; the cache populates lazily so this discards
+        // nothing. `0` disables the cache (analytical queries take the row path).
+        db.set_columnar_cache_budget(options.columnar_cache_budget);
 
         Ok(SqlExecutor {
             db,

--- a/crates/vibesql-cli/src/executor/tests.rs
+++ b/crates/vibesql-cli/src/executor/tests.rs
@@ -1,4 +1,35 @@
-use super::{validation, SqlExecutor};
+use super::{validation, DbOpenOptions, SqlExecutor};
+
+#[test]
+fn test_columnar_cache_budget_applied_on_open() {
+    // A configured budget is applied to the Database on open (#6200).
+    let budget = 8 * 1024 * 1024; // 8MB
+    let executor = SqlExecutor::new_with_options(
+        None,
+        DbOpenOptions { columnar_cache_budget: budget, ..DbOpenOptions::default() },
+    )
+    .unwrap();
+    assert_eq!(executor.db.columnar_cache_budget(), budget);
+}
+
+#[test]
+fn test_columnar_cache_budget_zero_disables_cache() {
+    // `columnar_cache_budget = 0` disables the cache: the Database reports a
+    // 0-byte budget after open (#6200).
+    let executor = SqlExecutor::new_with_options(
+        None,
+        DbOpenOptions { columnar_cache_budget: 0, ..DbOpenOptions::default() },
+    )
+    .unwrap();
+    assert_eq!(executor.db.columnar_cache_budget(), 0);
+}
+
+#[test]
+fn test_columnar_cache_budget_default_is_256mb() {
+    // The default open options carry the 256MB budget through to the Database.
+    let executor = SqlExecutor::new(None).unwrap();
+    assert_eq!(executor.db.columnar_cache_budget(), 256 * 1024 * 1024);
+}
 
 #[test]
 fn test_list_schemas() {

--- a/crates/vibesql-cli/src/main.rs
+++ b/crates/vibesql-cli/src/main.rs
@@ -273,6 +273,11 @@ fn main() -> anyhow::Result<()> {
         // `<stem>-checkpoints/` directory does not grow unboundedly. Clamped to
         // a minimum of 1 downstream so the newest checkpoint always survives.
         keep_checkpoints: config.database.keep_checkpoints,
+        // Columnar representation cache budget (issue #6200): parsed from the
+        // human-readable `[database] columnar_cache_budget` (default 256MB;
+        // `0` disables the cache). A malformed value is a clean error here, not
+        // a panic.
+        columnar_cache_budget: config.get_columnar_cache_budget()?,
     };
 
     if let Some(cmd) = args.command {


### PR DESCRIPTION
Closes #6200

## Summary

Phase 0 of #6199, extracted as an independently shippable quick win. Exposes the columnar representation cache's memory budget as a user-configurable `~/.vibesqlrc` `[database] columnar_cache_budget` knob. The storage layer already had `Database::set_columnar_cache_budget()` and the `0 = disable` semantics — this is pure CLI plumbing following the `wal` / `keep_checkpoints` precedent.

## Changes

| File | LOC | What |
|------|-----|------|
| `crates/vibesql-cli/src/config.rs` | +124 | `columnar_cache_budget` String field (serde default `"256MB"`), `parse_byte_size` helper, `Config::get_columnar_cache_budget()` accessor, + 4 unit tests |
| `crates/vibesql-cli/src/executor/mod.rs` | +18 | `columnar_cache_budget` field on `DbOpenOptions`; `db.set_columnar_cache_budget()` applied on both WAL and snapshot open paths |
| `crates/vibesql-cli/src/executor/tests.rs` | +33 | 3 executor tests asserting the budget reaches the `Database` on open (incl. `0` = disabled, 256MB default) |
| `crates/vibesql-cli/src/main.rs` | +5 | thread `config.get_columnar_cache_budget()?` into `DbOpenOptions` |
| `.vibesqlrc.example` | +9 | document the knob (`0 = disable`, 256MB default) |
| `CLAUDE.md` | +2 | one-line mention next to `wal = false` |

Total ~190 LOC across 6 files.

## Behavior

- Accepts human-readable sizes (`"256MB"`, `"512MB"`, `"1GB"`, `"1MB"`, bare byte counts) or `"0"` to disable the cache (analytical queries take the row path).
- Absent field → 256MB default (unchanged behavior).
- Malformed value → clean error at open time, never a panic.
- Budget applied post-load on both open paths; the cache populates lazily so nothing is discarded.

## Scope guard

CLI plumbing + docs + tests only. No changes to eviction policy, SIMD dispatch threshold, or cache internals — those remain Phases 1–3 of #6199.

## Tests

`cargo build -p vibesql-cli` — succeeds.
`cargo test -p vibesql-cli --bins` — **162 passed, 0 failed** (7 new: 4 config + 3 executor).

The single pre-existing clippy warning (`unnecessary_filter_map` in unrelated index-column code) is untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)