### PR TITLE
feat(storage): per-table access-pattern signal plumbing (Phase 1 of #6199)

### DIFF
--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -840,6 +840,11 @@ pub(crate) fn execute_table_scan(
                 let all_rows = table.scan();
                 // sqlite_search_count: Track rows examined during table scan
                 database.increment_search_count(all_rows.len() as u64);
+                // Phase 1 of #6199: record this analytical (columnar-eligible)
+                // scan and its projected column width (measurement only — no
+                // behavior change). `schema.total_columns` is the scan's output
+                // column count.
+                database.record_scan(table_name, schema.total_columns as u64);
 
                 if crate::profiling::is_scan_debug_enabled() {
                     eprintln!(

--- a/crates/vibesql-executor/tests/table_access_signal_tests.rs
+++ b/crates/vibesql-executor/tests/table_access_signal_tests.rs
@@ -1,0 +1,226 @@
+//! Integration tests for the per-table access-pattern signal (Phase 1 of #6199).
+//!
+//! These verify the end-to-end plumbing of the measurement-only access signal
+//! through the real executor + storage paths:
+//!   - analytical scans increment `scan_count` and record projection width,
+//!   - point lookups increment `point_lookup_count`,
+//!   - writes increment `write_count` (including for a native-columnar table,
+//!     proving the increment fires before the `is_native_columnar` early-return),
+//!   - two tables' signals stay independent and table names are case-insensitive,
+//!   - the signal is observation-only (columnar-vs-row path is unchanged).
+//!
+//! All assertions are deterministic / counter-based — never wall-clock.
+
+use vibesql_catalog::{ColumnSchema, StorageFormat, TableSchema};
+use vibesql_executor::{CreateTableExecutor, InsertExecutor, SelectExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::{DataType, SqlValue};
+
+/// Execute one or more non-SELECT SQL statements separated by ';'.
+fn execute_sql(db: &mut Database, sql: &str) {
+    for sql_stmt in sql.split(';') {
+        let trimmed = sql_stmt.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
+        match stmt {
+            vibesql_ast::Statement::CreateTable(s) => {
+                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+            }
+            vibesql_ast::Statement::Insert(s) => {
+                InsertExecutor::execute(db, &s).expect("INSERT failed");
+            }
+            other => panic!("Unsupported statement type: {:?}", other),
+        }
+    }
+}
+
+/// Execute a SELECT (driving the real scan path) and return the row count.
+fn run_select(db: &Database, sql: &str) -> usize {
+    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
+    let select_stmt = match stmt {
+        vibesql_ast::Statement::Select(s) => s,
+        other => panic!("Expected SELECT statement, got {:?}", other),
+    };
+    let executor = SelectExecutor::new(db);
+    executor.execute(&select_stmt).expect("SELECT execution failed").len()
+}
+
+fn setup_items(db: &mut Database) {
+    execute_sql(
+        db,
+        "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, price INTEGER);
+         INSERT INTO items VALUES (1, 'a', 10);
+         INSERT INTO items VALUES (2, 'b', 20);
+         INSERT INTO items VALUES (3, 'c', 30)",
+    );
+}
+
+#[test]
+fn test_scan_count_matches_number_of_analytical_scans() {
+    let mut db = Database::new();
+    setup_items(&mut db);
+
+    // Ignore the writes from setup; measure only the scans below.
+    db.reset_access_signals();
+
+    // Run N analytical scans that go through the columnar-eligible scan path
+    // (a full-coverage columnar predicate on a non-PK column).
+    let n = 4;
+    for _ in 0..n {
+        run_select(&db, "SELECT id FROM items WHERE price >= 0");
+    }
+
+    let sig = db.table_access_signal("items").expect("items should have a signal");
+    assert_eq!(sig.scan_count, n, "scan_count should equal number of analytical scans");
+    // Projection width is the scan's output column count (all 3 columns of items).
+    assert_eq!(sig.projection_width_n, n, "one width recorded per scan");
+    assert_eq!(
+        sig.avg_projection_width(),
+        Some(3.0),
+        "avg projection width = items column count (id, name, price)"
+    );
+    // Scans must not be miscounted as writes/lookups.
+    assert_eq!(sig.point_lookup_count, 0);
+    assert_eq!(sig.write_count, 0);
+}
+
+#[test]
+fn test_point_lookup_count_matches_number_of_lookups() {
+    let mut db = Database::new();
+    setup_items(&mut db);
+    db.reset_access_signals();
+
+    let m = 5;
+    for _ in 0..m {
+        let row = db.get_row_by_pk("items", &SqlValue::Integer(1)).unwrap();
+        assert!(row.is_some());
+    }
+
+    let sig = db.table_access_signal("items").expect("signal exists");
+    assert_eq!(sig.point_lookup_count, m, "point_lookup_count should equal number of lookups");
+    assert_eq!(sig.scan_count, 0);
+}
+
+#[test]
+fn test_write_count_on_row_table() {
+    let mut db = Database::new();
+    setup_items(&mut db);
+    db.reset_access_signals();
+
+    // One INSERT, one UPDATE, one DELETE = three writes through the DML funnel.
+    execute_sql(&mut db, "INSERT INTO items VALUES (4, 'd', 40)");
+
+    let update = Parser::parse_sql("UPDATE items SET price = 99 WHERE id = 1").unwrap();
+    if let vibesql_ast::Statement::Update(s) = update {
+        vibesql_executor::UpdateExecutor::execute(&s, &mut db).expect("UPDATE failed");
+    } else {
+        panic!("expected UPDATE");
+    }
+
+    let delete = Parser::parse_sql("DELETE FROM items WHERE id = 2").unwrap();
+    if let vibesql_ast::Statement::Delete(s) = delete {
+        vibesql_executor::DeleteExecutor::execute(&s, &mut db).expect("DELETE failed");
+    } else {
+        panic!("expected DELETE");
+    }
+
+    let sig = db.table_access_signal("items").expect("signal exists");
+    assert_eq!(sig.write_count, 3, "one write recorded per INSERT/UPDATE/DELETE");
+}
+
+#[test]
+fn test_write_count_on_native_columnar_table() {
+    // Proves record_write fires BEFORE the is_native_columnar early-return in
+    // invalidate_columnar_cache: a native-columnar table must still be counted.
+    let mut db = Database::new();
+
+    let mut schema = TableSchema::with_primary_key(
+        "cols".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, false),
+            ColumnSchema::new("v".to_string(), DataType::Integer, true),
+        ],
+        vec!["id".to_string()],
+    );
+    schema.set_storage_format(StorageFormat::Columnar);
+    db.create_table(schema).unwrap();
+    assert!(
+        db.get_table("cols").unwrap().is_native_columnar(),
+        "table should be native-columnar for this test to be meaningful"
+    );
+
+    db.reset_access_signals();
+
+    execute_sql(&mut db, "INSERT INTO cols VALUES (1, 100)");
+    execute_sql(&mut db, "INSERT INTO cols VALUES (2, 200)");
+
+    let sig = db.table_access_signal("cols").expect("signal exists for columnar table");
+    assert_eq!(
+        sig.write_count, 2,
+        "writes to a native-columnar table must still be counted (increment precedes early-return)"
+    );
+}
+
+#[test]
+fn test_two_tables_independent_and_case_insensitive() {
+    let mut db = Database::new();
+    setup_items(&mut db);
+    execute_sql(
+        &mut db,
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, total INTEGER);
+         INSERT INTO orders VALUES (1, 500)",
+    );
+    db.reset_access_signals();
+
+    // Mixed workload over two tables, using varied casing for `items`.
+    run_select(&db, "SELECT id FROM items WHERE price >= 0");
+    run_select(&db, "SELECT id FROM ITEMS WHERE price >= 0");
+    db.get_row_by_pk("orders", &SqlValue::Integer(1)).unwrap();
+
+    let items = db.table_access_signal("items").expect("items signal");
+    let orders = db.table_access_signal("orders").expect("orders signal");
+
+    // Case-insensitive: both `items` and `ITEMS` scans land on one entry.
+    assert_eq!(items.scan_count, 2, "both casings map to the same signal entry");
+    assert_eq!(items.point_lookup_count, 0);
+
+    // No cross-contamination between tables.
+    assert_eq!(orders.point_lookup_count, 1);
+    assert_eq!(orders.scan_count, 0);
+
+    // Case-insensitive accessor lookup.
+    assert_eq!(db.table_access_signal("ITEMS"), db.table_access_signal("items"));
+}
+
+#[test]
+fn test_unknown_table_and_reset() {
+    let mut db = Database::new();
+    setup_items(&mut db);
+
+    assert_eq!(db.table_access_signal("does_not_exist"), None, "unknown table => None");
+
+    db.get_row_by_pk("items", &SqlValue::Integer(1)).unwrap();
+    assert!(db.table_access_signal("items").is_some());
+
+    db.reset_access_signals();
+    assert_eq!(db.table_access_signal("items"), None, "reset zeroes/clears all counters");
+}
+
+#[test]
+fn test_scan_result_unchanged_by_signal() {
+    // Regression: the signal is observation-only — query results are identical
+    // to what they'd be without it. (Counters cannot alter the columnar-vs-row
+    // path.) We assert the scan returns the expected rows while also recording.
+    let mut db = Database::new();
+    setup_items(&mut db);
+    db.reset_access_signals();
+
+    let count = run_select(&db, "SELECT id FROM items WHERE price >= 20");
+    assert_eq!(count, 2, "WHERE price >= 20 matches rows 2 and 3");
+
+    let sig = db.table_access_signal("items").expect("signal exists");
+    assert_eq!(sig.scan_count, 1, "the observed scan was recorded");
+}

--- a/crates/vibesql-storage/src/database/access_signal.rs
+++ b/crates/vibesql-storage/src/database/access_signal.rs
@@ -1,0 +1,322 @@
+// ============================================================================
+// Per-Table Access-Pattern Signal (Phase 1 — measurement only)
+// ============================================================================
+//
+// A cheap, always-on per-table usage counter used to make the columnar
+// representation cache adaptive in a later phase (#6199, Phase 2). This module
+// only *observes* how each table is used; it changes no dispatch, promotion, or
+// eviction behavior. Phase 2 is the sole consumer.
+//
+// The read/scan path operates on `&Database` (a shared immutable ref) and scans
+// tables `&self`, so the signal must use interior mutability — it must never be
+// threaded through `&mut`. It follows the existing `Database.search_count:
+// AtomicU64` precedent (mutated through `&self` with `Ordering::Relaxed`) and,
+// like `search_count`, is in-memory only: it resets on open and is never
+// persisted to disk.
+//
+// Home: `Database.table_access_signals`, an interior-mutable
+// `RwLock<HashMap<String, TableAccessSignal>>` keyed by the uppercased table
+// name (mirroring `normalize_cache_key` in `columnar_cache.rs`). Native builds
+// use `parking_lot::RwLock`; wasm uses `std::sync::RwLock`, matching the
+// `columnar_cache.rs` cfg split.
+
+use std::{
+    collections::HashMap,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+#[cfg(not(target_arch = "wasm32"))]
+use parking_lot::RwLock;
+#[cfg(target_arch = "wasm32")]
+use std::sync::RwLock;
+
+use super::core::Database;
+
+/// Normalize a table name into an access-signal map key (case-insensitive).
+///
+/// Mirrors `normalize_cache_key` in `columnar_cache.rs` so a table maps to the
+/// same signal entry regardless of the casing used at each call site.
+#[inline]
+pub(super) fn normalize_signal_key(table_name: &str) -> String {
+    table_name.to_uppercase()
+}
+
+/// Interior-mutable per-table access counters.
+///
+/// Every field is an `AtomicU64` mutated through a shared `&` with
+/// `Ordering::Relaxed` — the counters are advisory statistics, so relaxed
+/// ordering (no cross-counter synchronization) is sufficient and cheapest.
+#[derive(Debug, Default)]
+pub(super) struct TableAccessSignal {
+    /// Analytical scans of the table (the columnar-eligible full-scan path).
+    pub(super) scan_count: AtomicU64,
+    /// Primary-key / point lookups of the table.
+    pub(super) point_lookup_count: AtomicU64,
+    /// Running sum of projected column counts across recorded scans.
+    pub(super) projection_width_sum: AtomicU64,
+    /// Number of scans that contributed to `projection_width_sum`, so the
+    /// average projection width can be derived.
+    pub(super) projection_width_n: AtomicU64,
+    /// Writes (INSERT/UPDATE/DELETE/TRUNCATE/ALTER) routed through the DML
+    /// invalidation funnel.
+    pub(super) write_count: AtomicU64,
+}
+
+/// Plain `Copy` snapshot of a [`TableAccessSignal`].
+///
+/// Returned by [`Database::table_access_signal`] so callers observe a stable,
+/// atomically-loaded view without touching the internal atomics.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct AccessSignalSnapshot {
+    /// Analytical scans of the table.
+    pub scan_count: u64,
+    /// Primary-key / point lookups of the table.
+    pub point_lookup_count: u64,
+    /// Running sum of projected column counts across recorded scans.
+    pub projection_width_sum: u64,
+    /// Number of scans that contributed to `projection_width_sum`.
+    pub projection_width_n: u64,
+    /// Writes routed through the DML invalidation funnel.
+    pub write_count: u64,
+}
+
+impl AccessSignalSnapshot {
+    /// Average projected column width across recorded scans, or `None` when no
+    /// scan has recorded a width yet.
+    pub fn avg_projection_width(&self) -> Option<f64> {
+        if self.projection_width_n == 0 {
+            None
+        } else {
+            Some(self.projection_width_sum as f64 / self.projection_width_n as f64)
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// RwLock API shim: `parking_lot::RwLock` returns guards directly while
+// `std::sync::RwLock` returns `Result`. Isolate that difference here so the
+// recording/accessor logic below stays platform-agnostic.
+// ----------------------------------------------------------------------------
+
+type SignalMap = HashMap<String, TableAccessSignal>;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[inline]
+fn with_read<R>(lock: &RwLock<SignalMap>, f: impl FnOnce(&SignalMap) -> R) -> R {
+    f(&lock.read())
+}
+
+#[cfg(target_arch = "wasm32")]
+#[inline]
+fn with_read<R>(lock: &RwLock<SignalMap>, f: impl FnOnce(&SignalMap) -> R) -> R {
+    f(&lock.read().expect("access-signal lock poisoned"))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[inline]
+fn with_write<R>(lock: &RwLock<SignalMap>, f: impl FnOnce(&mut SignalMap) -> R) -> R {
+    f(&mut lock.write())
+}
+
+#[cfg(target_arch = "wasm32")]
+#[inline]
+fn with_write<R>(lock: &RwLock<SignalMap>, f: impl FnOnce(&mut SignalMap) -> R) -> R {
+    f(&mut lock.write().expect("access-signal lock poisoned"))
+}
+
+impl Database {
+    /// Apply `f` to the signal for `table_name`, creating a zeroed entry on
+    /// first touch.
+    ///
+    /// Fast path: a shared read lock is enough because the counters are atomics
+    /// mutated through `&`. Only inserting a brand-new entry needs the write
+    /// lock, so steady-state recording never contends on it.
+    fn with_access_signal(&self, table_name: &str, f: impl Fn(&TableAccessSignal)) {
+        let key = normalize_signal_key(table_name);
+
+        // Fast path: entry already exists — record under a shared read lock.
+        let existed = with_read(&self.table_access_signals, |map| match map.get(&key) {
+            Some(sig) => {
+                f(sig);
+                true
+            }
+            None => false,
+        });
+        if existed {
+            return;
+        }
+
+        // Slow path: create the entry under a write lock, then record. Another
+        // thread may have inserted it first; `entry(..).or_default()` handles
+        // that race without clobbering existing counts.
+        with_write(&self.table_access_signals, |map| {
+            let sig = map.entry(key).or_default();
+            f(sig);
+        });
+    }
+
+    /// Record one analytical scan of `table_name` with the given projected
+    /// column width (the scan's output column count).
+    pub fn record_scan(&self, table_name: &str, projection_width: u64) {
+        self.with_access_signal(table_name, |sig| {
+            sig.scan_count.fetch_add(1, Ordering::Relaxed);
+            sig.projection_width_sum.fetch_add(projection_width, Ordering::Relaxed);
+            sig.projection_width_n.fetch_add(1, Ordering::Relaxed);
+        });
+    }
+
+    /// Record one primary-key / point lookup of `table_name`.
+    pub(crate) fn record_point_lookup(&self, table_name: &str) {
+        self.with_access_signal(table_name, |sig| {
+            sig.point_lookup_count.fetch_add(1, Ordering::Relaxed);
+        });
+    }
+
+    /// Record one write (INSERT/UPDATE/DELETE/TRUNCATE/ALTER) to `table_name`.
+    pub(crate) fn record_write(&self, table_name: &str) {
+        self.with_access_signal(table_name, |sig| {
+            sig.write_count.fetch_add(1, Ordering::Relaxed);
+        });
+    }
+
+    /// Snapshot the access signal for `table_name`, or `None` if the table has
+    /// never been touched. Mirrors `columnar_cache_stats()` in shape.
+    pub fn table_access_signal(&self, table_name: &str) -> Option<AccessSignalSnapshot> {
+        let key = normalize_signal_key(table_name);
+        with_read(&self.table_access_signals, |map| {
+            map.get(&key).map(|sig| AccessSignalSnapshot {
+                scan_count: sig.scan_count.load(Ordering::Relaxed),
+                point_lookup_count: sig.point_lookup_count.load(Ordering::Relaxed),
+                projection_width_sum: sig.projection_width_sum.load(Ordering::Relaxed),
+                projection_width_n: sig.projection_width_n.load(Ordering::Relaxed),
+                write_count: sig.write_count.load(Ordering::Relaxed),
+            })
+        })
+    }
+
+    /// Reset all per-table access signals, clearing every entry.
+    pub fn reset_access_signals(&self) {
+        with_write(&self.table_access_signals, |map| map.clear());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scan_count_and_projection_width() {
+        let db = Database::new();
+
+        // Record N scans of table "T" with projection widths 2, 4, 6.
+        db.record_scan("T", 2);
+        db.record_scan("T", 4);
+        db.record_scan("T", 6);
+
+        let sig = db.table_access_signal("T").expect("signal should exist after scans");
+        assert_eq!(sig.scan_count, 3, "scan_count should equal number of scans");
+        assert_eq!(sig.projection_width_n, 3);
+        assert_eq!(sig.projection_width_sum, 12);
+        assert_eq!(sig.avg_projection_width(), Some(4.0), "avg width = mean of recorded widths");
+        assert_eq!(sig.point_lookup_count, 0);
+        assert_eq!(sig.write_count, 0);
+    }
+
+    #[test]
+    fn test_point_lookup_count() {
+        let db = Database::new();
+
+        for _ in 0..5 {
+            db.record_point_lookup("orders");
+        }
+
+        let sig = db.table_access_signal("orders").expect("signal should exist");
+        assert_eq!(sig.point_lookup_count, 5, "point_lookup_count should equal number of lookups");
+        assert_eq!(sig.scan_count, 0);
+    }
+
+    #[test]
+    fn test_write_count() {
+        let db = Database::new();
+
+        db.record_write("t");
+        db.record_write("t");
+
+        let sig = db.table_access_signal("t").expect("signal should exist");
+        assert_eq!(sig.write_count, 2);
+    }
+
+    #[test]
+    fn test_avg_projection_width_none_when_no_scans() {
+        let db = Database::new();
+        db.record_point_lookup("t");
+
+        let sig = db.table_access_signal("t").expect("signal should exist");
+        assert_eq!(sig.avg_projection_width(), None, "no scans yet => no avg width");
+    }
+
+    #[test]
+    fn test_tables_are_independent() {
+        let db = Database::new();
+
+        db.record_scan("a", 3);
+        db.record_scan("a", 3);
+        db.record_point_lookup("b");
+
+        let a = db.table_access_signal("a").expect("a exists");
+        let b = db.table_access_signal("b").expect("b exists");
+
+        assert_eq!(a.scan_count, 2);
+        assert_eq!(a.point_lookup_count, 0);
+        assert_eq!(b.scan_count, 0);
+        assert_eq!(b.point_lookup_count, 1);
+    }
+
+    #[test]
+    fn test_case_insensitive_key() {
+        let db = Database::new();
+
+        // Mixed casing must all land on the same entry.
+        db.record_scan("Users", 2);
+        db.record_scan("users", 2);
+        db.record_point_lookup("USERS");
+
+        let via_lower = db.table_access_signal("users").expect("exists");
+        let via_upper = db.table_access_signal("USERS").expect("exists");
+        assert_eq!(via_lower, via_upper, "casing should not create distinct entries");
+        assert_eq!(via_lower.scan_count, 2);
+        assert_eq!(via_lower.point_lookup_count, 1);
+    }
+
+    #[test]
+    fn test_unknown_table_is_none() {
+        let db = Database::new();
+        assert_eq!(db.table_access_signal("never_touched"), None);
+    }
+
+    #[test]
+    fn test_reset_access_signals() {
+        let db = Database::new();
+
+        db.record_scan("t", 4);
+        db.record_point_lookup("t");
+        db.record_write("t");
+        assert!(db.table_access_signal("t").is_some());
+
+        db.reset_access_signals();
+        assert_eq!(db.table_access_signal("t"), None, "reset clears all entries");
+    }
+
+    #[test]
+    fn test_clone_resets_signals() {
+        let db = Database::new();
+        db.record_scan("t", 4);
+
+        let cloned = db.clone();
+        assert_eq!(
+            cloned.table_access_signal("t"),
+            None,
+            "cloned database starts with empty access signals (like search_count)"
+        );
+    }
+}

--- a/crates/vibesql-storage/src/database/cache.rs
+++ b/crates/vibesql-storage/src/database/cache.rs
@@ -72,6 +72,12 @@ impl Database {
     /// For native columnar tables, this is a no-op since the columnar data
     /// is maintained incrementally by the Table itself during DML operations.
     pub fn invalidate_columnar_cache(&self, table_name: &str) {
+        // Phase 1 of #6199: this is the universal DML funnel (every
+        // INSERT/UPDATE/DELETE/TRUNCATE/ALTER routes through it), so record the
+        // write here — BEFORE the native-columnar early return below — so
+        // native-columnar tables are counted too.
+        self.record_write(table_name);
+
         // For native columnar tables, skip invalidation -- they maintain
         // their own columnar data incrementally during INSERT/UPDATE/DELETE
         if let Some(table) = self.get_table(table_name) {

--- a/crates/vibesql-storage/src/database/constructors.rs
+++ b/crates/vibesql-storage/src/database/constructors.rs
@@ -10,6 +10,11 @@ use std::{
     sync::{atomic::AtomicU64, Arc},
 };
 
+#[cfg(not(target_arch = "wasm32"))]
+use parking_lot::RwLock;
+#[cfg(target_arch = "wasm32")]
+use std::sync::RwLock;
+
 use super::{
     config::{DatabaseConfig, DEFAULT_COLUMNAR_CACHE_BUDGET},
     core::Database,
@@ -42,6 +47,8 @@ impl Clone for Database {
             total_changes_count: 0,
             // Clone resets search_count - each database instance tracks independently
             search_count: AtomicU64::new(0),
+            // Clone resets access signals - each database instance tracks independently
+            table_access_signals: RwLock::new(HashMap::new()),
             // Clone does not inherit persistence engine - cloned databases are independent
             persistence_engine: None,
             // Preserve table ID counter for consistency
@@ -72,6 +79,7 @@ impl Database {
             last_changes_count: 0,
             total_changes_count: 0,
             search_count: AtomicU64::new(0),
+            table_access_signals: RwLock::new(HashMap::new()),
             persistence_engine: None,
             next_table_id: 1,
             reserved_rowids: HashMap::new(),

--- a/crates/vibesql-storage/src/database/core.rs
+++ b/crates/vibesql-storage/src/database/core.rs
@@ -19,8 +19,16 @@ use std::sync::atomic::{AtomicU64, Ordering};
 #[allow(unused_imports)]
 use std::sync::Arc;
 
+#[cfg(not(target_arch = "wasm32"))]
+use parking_lot::RwLock;
+#[cfg(target_arch = "wasm32")]
+use std::sync::RwLock;
+
 pub use super::operations::SpatialIndexMetadata as ExportedSpatialIndexMetadata;
-use super::{lifecycle::Lifecycle, metadata::Metadata, operations::Operations};
+use super::{
+    access_signal::TableAccessSignal, lifecycle::Lifecycle, metadata::Metadata,
+    operations::Operations,
+};
 use crate::{
     change_events::ChangeEventSender, columnar_cache::ColumnarCache, wal::PersistenceEngine,
     QueryBufferPool, Table,
@@ -77,6 +85,13 @@ pub struct Database {
     /// Tracks the number of rows examined during query execution
     /// Used by SQLite TCL tests to verify query optimization behavior
     pub(super) search_count: AtomicU64,
+    /// Per-table access-pattern signal (Phase 1 of #6199 — measurement only).
+    ///
+    /// Interior-mutable, keyed by uppercased table name, mutated through `&self`
+    /// like `search_count`. In-memory only: reset on open, never persisted.
+    /// Phase 2 will consume this to make the columnar cache adaptive; nothing
+    /// reads it yet besides accessors/tests.
+    pub(super) table_access_signals: RwLock<HashMap<String, TableAccessSignal>>,
     /// Optional persistence engine for WAL-based async persistence
     /// Enables durable storage when enabled
     pub(super) persistence_engine: Option<PersistenceEngine>,

--- a/crates/vibesql-storage/src/database/mod.rs
+++ b/crates/vibesql-storage/src/database/mod.rs
@@ -2,6 +2,7 @@
 // Database Module
 // ============================================================================
 
+mod access_signal;
 mod cache;
 mod change_events_api;
 mod config;
@@ -25,6 +26,7 @@ pub mod transactions;
 #[cfg(test)]
 mod tests;
 
+pub use access_signal::AccessSignalSnapshot;
 pub use core::{Database, ExportedSpatialIndexMetadata as SpatialIndexMetadata};
 // The WAL recovery path (`wal::recovery`) shares the CreateTable schema-blob
 // layout with the emit path here; its tests round-trip through the real

--- a/crates/vibesql-storage/src/database/point_lookup.rs
+++ b/crates/vibesql-storage/src/database/point_lookup.rs
@@ -45,6 +45,9 @@ impl Database {
         table_name: &str,
         pk_value: &vibesql_types::SqlValue,
     ) -> Result<Option<&Row>, StorageError> {
+        // Phase 1 of #6199: record the point lookup (measurement only).
+        self.record_point_lookup(table_name);
+
         let table = self
             .get_table(table_name)
             .ok_or_else(|| StorageError::TableNotFound(table_name.to_string()))?;
@@ -85,6 +88,9 @@ impl Database {
         pk_value: &vibesql_types::SqlValue,
         column_index: usize,
     ) -> Result<Option<&vibesql_types::SqlValue>, StorageError> {
+        // Phase 1 of #6199: record the point lookup (measurement only).
+        self.record_point_lookup(table_name);
+
         let table = self
             .get_table(table_name)
             .ok_or_else(|| StorageError::TableNotFound(table_name.to_string()))?;
@@ -130,6 +136,9 @@ impl Database {
         table_name: &str,
         pk_values: &[vibesql_types::SqlValue],
     ) -> Result<Option<&Row>, StorageError> {
+        // Phase 1 of #6199: record the point lookup (measurement only).
+        self.record_point_lookup(table_name);
+
         let table = self
             .get_table(table_name)
             .ok_or_else(|| StorageError::TableNotFound(table_name.to_string()))?;

--- a/crates/vibesql-storage/src/lib.rs
+++ b/crates/vibesql-storage/src/lib.rs
@@ -44,10 +44,10 @@ pub use change_events::{
 pub use columnar::{ColumnData, ColumnarTable};
 pub use columnar_cache::{CacheStats, ColumnarCache};
 pub use database::{
-    print_delete_profile_summary, reset_delete_profile_stats, Database, DatabaseConfig,
-    DeferredFkViolation, DeferredFkViolationKind, DeleteProfileStats, IndexData, IndexManager,
-    IndexMetadata, OwnedStreamingRangeScan, SpatialIndexMetadata, SpillPolicy, TransactionState,
-    DELETE_PROFILE_STATS,
+    print_delete_profile_summary, reset_delete_profile_stats, AccessSignalSnapshot, Database,
+    DatabaseConfig, DeferredFkViolation, DeferredFkViolationKind, DeleteProfileStats, IndexData,
+    IndexManager, IndexMetadata, OwnedStreamingRangeScan, SpatialIndexMetadata, SpillPolicy,
+    TransactionState, DELETE_PROFILE_STATS,
 };
 pub use error::{StorageError, StorageResult};
 pub use index::{extract_mbr_from_sql_value, SpatialIndex, SpatialIndexEntry};


### PR DESCRIPTION
Closes #6202. Part of #6199 (adaptive columnar representation cache), **Phase 1: per-table access-pattern signal plumbing**. Phase 0 (#6200) shipped in #6201.

## What this does

Adds a cheap, always-on **per-table access signal** so a later phase can make the columnar cache adaptive. This PR is **measurement only** — it changes no dispatch, promotion, or eviction behavior, and nothing consumes the signal yet besides accessors/tests (expected per the issue's scope guard).

## Design (follows the `search_count` precedent)

The read/scan path uses `&Database` (shared immutable ref) and scans tables `&self`, so the signal uses **interior mutability** — no `&mut` threading. It mirrors the existing `Database.search_count: AtomicU64` mutated through `&self` with `Ordering::Relaxed`.

- New `TableAccessSignal` struct: five `AtomicU64` counters (`scan_count`, `point_lookup_count`, `projection_width_sum`, `projection_width_n`, `write_count`).
- New interior-mutable field `Database.table_access_signals: RwLock<HashMap<String, TableAccessSignal>>` (`parking_lot` on native / `std` on wasm, matching the `columnar_cache.rs` cfg split), keyed by uppercased table name like `normalize_cache_key`. Reset on clone alongside `search_count`.
- In-memory only: resets on open, never persisted.
- A tiny cfg'd `with_read`/`with_write` shim isolates the parking_lot-vs-std RwLock API difference so the recording logic stays platform-agnostic. Zero `unsafe`.

## Four hook points (one-line increments through `&self`)

1. **Analytical scan + projection width** — `select/scan/table.rs`, next to the existing `increment_search_count` call in the columnar-eligible scan path. Projection width = `schema.total_columns` (scan output column count).
2. **Point lookups** — `get_row_by_pk`, `get_column_by_pk`, `get_row_by_composite_pk` in `point_lookup.rs`.
3. **Writes** — `invalidate_columnar_cache` (the universal DML funnel), recorded **before** the `is_native_columnar` early-return so native-columnar tables are counted too.
4. **Accessors** — `table_access_signal(&self) -> Option<AccessSignalSnapshot>` (plain `Copy` snapshot, with `avg_projection_width()`), plus `reset_access_signals(&self)`.

## Tests (deterministic / counter-based — never wall-clock)

- **9 storage unit tests** (`database/access_signal.rs`): scan/lookup/write counts, avg projection width, `None` when no scans, table independence, case-insensitive keys, unknown table `None`, reset, clone-resets.
- **7 executor integration tests** (`tests/table_access_signal_tests.rs`, mirrors `insert_columnar_cache_tests.rs`): N analytical scans => `scan_count == N` with correct avg width; M point lookups => `point_lookup_count == M`; one write per INSERT/UPDATE/DELETE; **write counted for a native-columnar table** (proves increment precedes the early-return); two-table independence + case-insensitive names; unknown-table `None` + reset; observation-only regression check.

## Verification

Run in the worktree:
- `cargo build -p vibesql-storage -p vibesql-executor` — clean.
- `cargo test -p vibesql-storage` — 814 passed, 0 failed (+9 new `access_signal` unit tests).
- `cargo test -p vibesql-executor --test table_access_signal_tests` — 7 passed, 0 failed.
- `cargo test -p vibesql-executor --test insert_columnar_cache_tests` — 4 passed (no regression).
- `cargo clippy -p vibesql-storage -p vibesql-executor` — no new warnings from the added code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)