### PR TITLE
feat(scan): WITHOUT ROWID tables scan in PRIMARY KEY order (#6171)

### DIFF
--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -240,6 +240,72 @@ fn sort_rows_by_integer_primary_key(rows: &mut Vec<vibesql_storage::Row>, ipk_co
     });
 }
 
+/// Sort rows by a WITHOUT ROWID table's PRIMARY KEY tuple (Issue #6171).
+///
+/// For a `WITHOUT ROWID` table the PRIMARY KEY *is* the table's clustering
+/// btree, so a full table scan with no explicit `ORDER BY` returns rows in
+/// ascending PRIMARY KEY order — not insertion order (which is what an ordinary
+/// rowid table would yield). Each key part is compared with its effective
+/// collating sequence (explicit key-part `COLLATE`, else the column's declared
+/// collation, else BINARY), matching SQLite's btree ordering.
+///
+/// `pk_indices` are the PK column positions in key order (from
+/// [`get_primary_key_indices`](vibesql_catalog::TableSchema::get_primary_key_indices));
+/// `pk_collations` is the parallel effective-collation vector (from
+/// [`primary_key_effective_collations`](vibesql_catalog::TableSchema::primary_key_effective_collations)).
+/// PK columns are `NOT NULL`, so NULL handling here is only a defensive fallback.
+fn sort_rows_by_without_rowid_pk(
+    rows: &mut [vibesql_storage::Row],
+    pk_indices: &[usize],
+    pk_collations: &[Option<String>],
+) {
+    use std::cmp::Ordering;
+
+    use crate::select::grouping::compare_sql_values_with_collation;
+
+    rows.sort_by(|a, b| {
+        for (part, &col_idx) in pk_indices.iter().enumerate() {
+            let ord = match (a.get(col_idx), b.get(col_idx)) {
+                (Some(av), Some(bv)) => {
+                    let collation = pk_collations.get(part).and_then(|c| c.as_deref());
+                    compare_sql_values_with_collation(av, bv, collation)
+                }
+                (None, None) => Ordering::Equal,
+                (None, Some(_)) => Ordering::Less,
+                (Some(_), None) => Ordering::Greater,
+            };
+            if ord != Ordering::Equal {
+                return ord;
+            }
+        }
+        Ordering::Equal
+    });
+}
+
+/// Apply SQLite's implicit full-scan row ordering when the query has no
+/// `ORDER BY` (Issues #4926, #6171).
+///
+/// SQLite returns table-scan rows in physical btree order:
+/// - INTEGER PRIMARY KEY (rowid-alias) tables → ascending rowid order (#4926).
+/// - `WITHOUT ROWID` tables → ascending PRIMARY KEY order, since the PK is the
+///   table btree (#6171).
+///
+/// Ordinary rowid tables keep physical/insertion order and are left untouched.
+/// The caller is responsible for only invoking this when `order_by.is_none()`.
+fn apply_implicit_scan_order(
+    rows: &mut Vec<vibesql_storage::Row>,
+    schema: &vibesql_catalog::TableSchema,
+) {
+    if let Some(ipk_col_idx) = schema.rowid_alias_column {
+        sort_rows_by_integer_primary_key(rows, ipk_col_idx);
+    } else if schema.without_rowid {
+        if let Some(pk_indices) = schema.get_primary_key_indices() {
+            let collations = schema.primary_key_effective_collations().unwrap_or_default();
+            sort_rows_by_without_rowid_pk(rows, &pk_indices, &collations);
+        }
+    }
+}
+
 /// Execute a table scan with SQL:1999 identifier semantics
 ///
 /// This is the new entry point that properly handles case-sensitivity based on
@@ -748,11 +814,9 @@ pub(crate) fn execute_table_scan(
             let mut live_rows = table.scan_visible_vec(&snapshot);
             // sqlite_search_count: Track rows examined during table scan
             database.increment_search_count(live_rows.len() as u64);
-            // Issue #4926: SQLite returns INTEGER PRIMARY KEY tables in rowid order
+            // Issue #4926 / #6171: implicit rowid- or PK-order scan
             if order_by.is_none() {
-                if let Some(ipk_col_idx) = table.schema.rowid_alias_column {
-                    sort_rows_by_integer_primary_key(&mut live_rows, ipk_col_idx);
-                }
+                apply_implicit_scan_order(&mut live_rows, &table.schema);
             }
             use crate::select::from_iterator::FromIterator;
             return Ok(super::FromResult::from_iterator(
@@ -893,11 +957,9 @@ pub(crate) fn execute_table_scan(
                     if let Ok(mut filtered_rows) =
                         filter_with_simd_columnar(table, &column_predicates)
                     {
-                        // Issue #4926: SQLite returns INTEGER PRIMARY KEY tables in rowid order
+                        // Issue #4926 / #6171: implicit rowid- or PK-order scan
                         if order_by.is_none() {
-                            if let Some(ipk_col_idx) = table.schema.rowid_alias_column {
-                                sort_rows_by_integer_primary_key(&mut filtered_rows, ipk_col_idx);
-                            }
+                            apply_implicit_scan_order(&mut filtered_rows, &table.schema);
                         }
                         // Mark WHERE as already filtered to avoid double-evaluation
                         return Ok(super::FromResult::from_rows_where_filtered(
@@ -927,11 +989,9 @@ pub(crate) fn execute_table_scan(
                         &column_predicates,
                         &snapshot,
                     ) {
-                        // Issue #4926: SQLite returns INTEGER PRIMARY KEY tables in rowid order
+                        // Issue #4926 / #6171: implicit rowid- or PK-order scan
                         if order_by.is_none() {
-                            if let Some(ipk_col_idx) = table.schema.rowid_alias_column {
-                                sort_rows_by_integer_primary_key(&mut filtered_rows, ipk_col_idx);
-                            }
+                            apply_implicit_scan_order(&mut filtered_rows, &table.schema);
                         }
                         // Mark WHERE as already filtered to avoid double-evaluation
                         return Ok(super::FromResult::from_rows_where_filtered(
@@ -968,11 +1028,9 @@ pub(crate) fn execute_table_scan(
                         })
                     })
                     .collect();
-                // Issue #4926: SQLite returns INTEGER PRIMARY KEY tables in rowid order
+                // Issue #4926 / #6171: implicit rowid- or PK-order scan
                 if order_by.is_none() {
-                    if let Some(ipk_col_idx) = table.schema.rowid_alias_column {
-                        sort_rows_by_integer_primary_key(&mut filtered_rows, ipk_col_idx);
-                    }
+                    apply_implicit_scan_order(&mut filtered_rows, &table.schema);
                 }
                 // Mark WHERE as already filtered to avoid double-evaluation
                 return Ok(super::FromResult::from_rows_where_filtered(
@@ -1009,11 +1067,9 @@ pub(crate) fn execute_table_scan(
                 None,
                 Some(cte_results), // CTE context for IN subqueries referencing CTEs
             )?;
-            // Issue #4926: SQLite returns INTEGER PRIMARY KEY tables in rowid order
+            // Issue #4926 / #6171: implicit rowid- or PK-order scan
             if order_by.is_none() {
-                if let Some(ipk_col_idx) = table.schema.rowid_alias_column {
-                    sort_rows_by_integer_primary_key(&mut filtered_rows, ipk_col_idx);
-                }
+                apply_implicit_scan_order(&mut filtered_rows, &table.schema);
             }
             // Mark WHERE as already filtered to avoid double-evaluation
             return Ok(super::FromResult::from_rows_where_filtered(schema, filtered_rows, None));
@@ -1028,12 +1084,12 @@ pub(crate) fn execute_table_scan(
     // sqlite_search_count: Track rows examined during table scan
     database.increment_search_count(live_rows.len() as u64);
 
-    // Issue #4926: SQLite returns INTEGER PRIMARY KEY tables in rowid order
-    // when no explicit ORDER BY is specified. Apply implicit sorting here.
+    // Issue #4926 / #6171: SQLite returns table-scan rows in physical btree
+    // order when no explicit ORDER BY is specified — ascending rowid order for
+    // INTEGER PRIMARY KEY tables, ascending PRIMARY KEY order for WITHOUT ROWID
+    // tables. Apply that implicit ordering here.
     if order_by.is_none() {
-        if let Some(ipk_col_idx) = table.schema.rowid_alias_column {
-            sort_rows_by_integer_primary_key(&mut live_rows, ipk_col_idx);
-        }
+        apply_implicit_scan_order(&mut live_rows, &table.schema);
     }
 
     #[cfg(feature = "parallel")]

--- a/crates/vibesql-executor/tests/without_rowid_pk_order_tests.rs
+++ b/crates/vibesql-executor/tests/without_rowid_pk_order_tests.rs
@@ -1,0 +1,172 @@
+//! Tests for WITHOUT ROWID implicit PRIMARY KEY row ordering (Issue #6171)
+//!
+//! For a `WITHOUT ROWID` table the PRIMARY KEY *is* the table's clustering
+//! btree, so SQLite returns rows from a full table scan in ascending PRIMARY
+//! KEY order when no `ORDER BY` is specified — not insertion order (which is
+//! what an ordinary rowid table yields). Composite keys sort lexicographically
+//! by key part, and text key parts honor their effective collating sequence.
+//!
+//! This mirrors the INTEGER PRIMARY KEY ordering guarantee (Issue #4926) tested
+//! in `integer_primary_key_order_tests.rs`.
+
+use vibesql_executor::{CreateTableExecutor, InsertExecutor, SelectExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn create_table(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::CreateTable(create) = stmt {
+        CreateTableExecutor::execute(&create, db).unwrap();
+    } else {
+        panic!("Expected CREATE TABLE statement");
+    }
+}
+
+fn insert(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Insert(insert_stmt) = stmt {
+        InsertExecutor::execute(db, &insert_stmt).unwrap();
+    } else {
+        panic!("Expected INSERT statement");
+    }
+}
+
+fn execute_query(db: &Database, sql: &str) -> Vec<vibesql_storage::Row> {
+    let stmt = Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor.execute(&select_stmt).unwrap()
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+fn int_col(rows: &[vibesql_storage::Row], col: usize) -> Vec<i64> {
+    rows.iter()
+        .map(|row| match row.get(col).unwrap() {
+            SqlValue::Integer(v) => *v,
+            SqlValue::Bigint(v) => *v,
+            other => panic!("Expected integer, got {other:?}"),
+        })
+        .collect()
+}
+
+fn text_col(rows: &[vibesql_storage::Row], col: usize) -> Vec<String> {
+    rows.iter()
+        .map(|row| match row.get(col).unwrap() {
+            SqlValue::Varchar(s) | SqlValue::Character(s) => s.to_string(),
+            other => panic!("Expected text, got {other:?}"),
+        })
+        .collect()
+}
+
+#[test]
+fn test_single_column_pk_scan_is_pk_ordered() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t (a INTEGER PRIMARY KEY, b) WITHOUT ROWID");
+
+    // Insert out of PK order.
+    insert(&mut db, "INSERT INTO t VALUES (5, 'five')");
+    insert(&mut db, "INSERT INTO t VALUES (1, 'one')");
+    insert(&mut db, "INSERT INTO t VALUES (3, 'three')");
+    insert(&mut db, "INSERT INTO t VALUES (2, 'two')");
+
+    let rows = execute_query(&db, "SELECT a FROM t");
+    assert_eq!(
+        int_col(&rows, 0),
+        vec![1, 2, 3, 5],
+        "WITHOUT ROWID scan must return rows in ascending PRIMARY KEY order"
+    );
+}
+
+#[test]
+fn test_composite_pk_scan_is_lexicographically_ordered() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t (a, b, c, PRIMARY KEY(c, a, b)) WITHOUT ROWID");
+
+    // Matches the without_rowid4-4.2 recursive-trigger scenario: rows inserted
+    // as (1,2,4) then (1,2,3); PK is (c,a,b) so the scan must yield (1,2,3)
+    // before (1,2,4).
+    insert(&mut db, "INSERT INTO t VALUES (1, 2, 4)");
+    insert(&mut db, "INSERT INTO t VALUES (1, 2, 3)");
+
+    let rows = execute_query(&db, "SELECT a, b, c FROM t");
+    let c_values = int_col(&rows, 2);
+    assert_eq!(c_values, vec![3, 4], "composite PK ordered by (c, a, b): c=3 row precedes c=4 row");
+}
+
+#[test]
+fn test_composite_pk_multi_part_tiebreak() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t (a, b, PRIMARY KEY(a, b)) WITHOUT ROWID");
+
+    insert(&mut db, "INSERT INTO t VALUES (2, 1)");
+    insert(&mut db, "INSERT INTO t VALUES (1, 2)");
+    insert(&mut db, "INSERT INTO t VALUES (1, 1)");
+    insert(&mut db, "INSERT INTO t VALUES (2, 0)");
+
+    let rows = execute_query(&db, "SELECT a, b FROM t");
+    let pairs: Vec<(i64, i64)> = int_col(&rows, 0).into_iter().zip(int_col(&rows, 1)).collect();
+    assert_eq!(
+        pairs,
+        vec![(1, 1), (1, 2), (2, 0), (2, 1)],
+        "second key part breaks ties within equal first key part"
+    );
+}
+
+#[test]
+fn test_pk_scan_with_where_is_pk_ordered() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t (a INTEGER PRIMARY KEY, b) WITHOUT ROWID");
+
+    insert(&mut db, "INSERT INTO t VALUES (5, 'five')");
+    insert(&mut db, "INSERT INTO t VALUES (1, 'one')");
+    insert(&mut db, "INSERT INTO t VALUES (3, 'three')");
+    insert(&mut db, "INSERT INTO t VALUES (2, 'two')");
+
+    let rows = execute_query(&db, "SELECT a FROM t WHERE a >= 2");
+    assert_eq!(
+        int_col(&rows, 0),
+        vec![2, 3, 5],
+        "filtered WITHOUT ROWID scan must still be PK-ordered"
+    );
+}
+
+#[test]
+fn test_explicit_order_by_overrides_implicit_pk_order() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t (a INTEGER PRIMARY KEY, b) WITHOUT ROWID");
+
+    insert(&mut db, "INSERT INTO t VALUES (1, 'one')");
+    insert(&mut db, "INSERT INTO t VALUES (2, 'two')");
+    insert(&mut db, "INSERT INTO t VALUES (3, 'three')");
+
+    let rows = execute_query(&db, "SELECT a FROM t ORDER BY a DESC");
+    assert_eq!(
+        int_col(&rows, 0),
+        vec![3, 2, 1],
+        "explicit ORDER BY DESC overrides the implicit PK order"
+    );
+}
+
+#[test]
+fn test_text_pk_scan_respects_nocase_collation() {
+    let mut db = Database::new();
+    // Key-part COLLATE nocase: ordering must be case-insensitive.
+    create_table(
+        &mut db,
+        "CREATE TABLE t (a TEXT, b, PRIMARY KEY(a COLLATE nocase)) WITHOUT ROWID",
+    );
+
+    insert(&mut db, "INSERT INTO t VALUES ('banana', 1)");
+    insert(&mut db, "INSERT INTO t VALUES ('Apple', 2)");
+    insert(&mut db, "INSERT INTO t VALUES ('cherry', 3)");
+
+    let rows = execute_query(&db, "SELECT a FROM t");
+    assert_eq!(
+        text_col(&rows, 0),
+        vec!["Apple".to_string(), "banana".to_string(), "cherry".to_string()],
+        "NOCASE PK collation orders 'Apple' before 'banana' case-insensitively"
+    );
+}


### PR DESCRIPTION
Closes #6171

## Summary

For a `WITHOUT ROWID` table the PRIMARY KEY *is* the table's clustering btree, so SQLite returns full-table-scan rows in ascending PRIMARY KEY order when no `ORDER BY` is present — not insertion order. VibeSQL already had substantial WITHOUT ROWID plumbing (the `without_rowid` schema flag, the internal PK unique index `_withoutrowidinternalpk_*`, DDL acceptance, binary/WAL persistence), but full-table scans still returned rows in physical/insertion order, producing wrong ordering for WITHOUT ROWID queries with no ORDER BY.

This PR closes that genuine storage-semantics gap.

## What changed

- Extended the existing implicit-scan-order hook (Issue #4926, which sorts INTEGER PRIMARY KEY rowid-alias tables by rowid) with a WITHOUT ROWID branch that sorts by the full PRIMARY KEY tuple.
- Each key part is compared with its **effective collating sequence** (explicit key-part `COLLATE`, else the column's declared collation, else BINARY) via the existing `primary_key_effective_collations()` + `compare_sql_values_with_collation()`.
- Introduced `apply_implicit_scan_order(rows, schema)` which replaces the six duplicated rowid-alias sort call sites across the scan return paths (correlated, SIMD-columnar, cached-columnar, direct-row-filter, generic-predicate, and no-WHERE full scan).

The change is **strictly gated on `schema.without_rowid`** — the rowid-alias branch is unchanged, so ordinary rowid tables and INTEGER PRIMARY KEY tables behave exactly as before. No non-WITHOUT-ROWID query path can be affected.

## Tests

New `crates/vibesql-executor/tests/without_rowid_pk_order_tests.rs` (6 tests): single-column PK, composite PK lexicographic order, multi-part tiebreak, WHERE-filtered scan still PK-ordered, explicit ORDER BY overrides implicit order, and NOCASE key-part collation ordering. All pass.

## Conformance impact

- `without_rowid4.test`: **62 → 63 passing** (`without_rowid4-4.2`, the recursive-trigger PK-order scan, now passes).
- `without_rowid7.test` / `without_rowid3.test`: no change from this PR (see below).

## Scope notes / remaining failures (intentionally out of scope)

Per the issue's guidance, this PR targets the **genuine WITHOUT ROWID storage layer**, not FK enforcement:

- **`without_rowid3.test`** is `fkey2.test`'s body re-run on WITHOUT ROWID tables (154/172 failing names match `fkey2` verbatim). Its residual failures are **FK-enforcement dependent** and will clear once **#6170** (FK enforcement, being built in parallel) merges. This PR branched from main before #6170 and deliberately does not re-implement FK enforcement. Current state: 84.8% passing (1006/1186).
- **`without_rowid7-3.x`** failures are **custom collation-sequence** registration (`db collate mysort ...`) and `sqlite3_extended_errcode` C-API shim gaps — not WITHOUT ROWID storage. Out of scope.
- **`without_rowid7-2.2a / 2.3a`** exercise `PRAGMA index_info` / `index_xinfo` *by table name* against a WITHOUT ROWID table's implicit PK index — a PRAGMA-reporting feature, distinct from the storage/iteration semantics fixed here. Left for a follow-up.
- **`without_rowid4-3.2`** is a regular (rowid) table trigger `WHEN (SELECT ...)` subquery-firing bug — unrelated to WITHOUT ROWID.
- **`without_rowid4-filescope-err.1`** is a pre-existing file-scope `save_database` persistence error present in the baseline before this change; it is not reproducible via WITHOUT ROWID constructs in isolation and is orthogonal to scan ordering.

## Verification

- `cargo build --release` clean.
- New test suite + related suites (`integer_primary_key_order_tests`, `without_rowid_autoindex_numbering_tests`, `update_or_replace_without_rowid_delete_trigger_tests`) all green.
- `select1.test` 100%; no clippy warnings introduced by the new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)