### PR TITLE
fix(fkey): enforce NO ACTION foreign keys on REPLACE conflict deletes

### DIFF
--- a/crates/vibesql-executor/src/insert/replace.rs
+++ b/crates/vibesql-executor/src/insert/replace.rs
@@ -158,6 +158,29 @@ pub fn handle_replace_conflicts(
         return Ok(());
     }
 
+    // SQLite performs foreign-key processing when a row is REPLACEd: the
+    // implicit DELETE of each conflicting row must not orphan the child rows
+    // that referenced it (fkey2-13.*, without_rowid3). Previously the
+    // conflict-clearing delete removed the parent row silently, so a REPLACE
+    // that broke a NO ACTION foreign key succeeded where SQLite raises
+    // "FOREIGN KEY constraint failed".
+    //
+    // For a NO ACTION foreign key, SQLite performs this check at statement end
+    // — AFTER the REPLACE re-inserts its new row. Because a foreign key's
+    // parent columns are always a key (PRIMARY KEY / UNIQUE), at most one
+    // parent row can carry a given key value, so a child orphaned by the
+    // conflict-delete is repaired precisely when the re-inserted row restores
+    // that same parent-key value (fkey2-13.1.3/4). We evaluate that repair
+    // here using `row_values` (the row about to be inserted) rather than
+    // erroring eagerly on the delete.
+    //
+    // CASCADE / SET NULL / SET DEFAULT / RESTRICT actions on a REPLACE-delete
+    // are a separate, pre-existing gap and are intentionally left unchanged
+    // here; this focused fix enforces only the default NO ACTION behaviour.
+    if db.foreign_keys_enabled() {
+        enforce_replace_no_action_fks(db, table_name, &rows_to_delete, row_values)?;
+    }
+
     // Check if any DELETE triggers exist for this table.
     //
     // SQLite rule (lang_conflict.html): "When the REPLACE conflict resolution
@@ -388,6 +411,126 @@ pub fn handle_replace_conflicts(
     // reached when `fire_delete_triggers` is false (no DELETE triggers, or
     // `recursive_triggers` is OFF). The trigger-firing case is fully handled by
     // the interleaved per-row path above, which returns before reaching here.
+
+    Ok(())
+}
+
+/// Enforce NO ACTION foreign keys against a REPLACE's conflict-clearing delete.
+///
+/// When a REPLACE deletes a conflicting parent row, any child row that
+/// referenced that parent's key would be orphaned. For a NO ACTION foreign key
+/// SQLite checks this at *statement end*, after the REPLACE re-inserts its new
+/// row: the orphan is repaired if the new row restores the same parent-key
+/// value (fkey2-13.1.3/4). Because a foreign key's parent columns are always a
+/// key (PRIMARY KEY / UNIQUE), at most one parent row can carry a given key
+/// value, so "some surviving parent still provides the key" reduces to "the
+/// re-inserted row provides the key".
+///
+/// Returns `Err(ConstraintViolation)` when a conflict row's key is dropped by
+/// the REPLACE (not restored by `new_row_values`) while a child still
+/// references it. Only the default NO ACTION on-delete behaviour is enforced;
+/// CASCADE / SET NULL / SET DEFAULT / RESTRICT on a REPLACE-delete are a
+/// separate pre-existing gap.
+fn enforce_replace_no_action_fks(
+    db: &vibesql_storage::Database,
+    parent_table: &str,
+    rows_to_delete: &[(usize, vibesql_storage::Row)],
+    new_row_values: &[vibesql_types::SqlValue],
+) -> Result<(), ExecutorError> {
+    use vibesql_types::SqlValue;
+
+    for child_table_name in db.catalog.list_tables() {
+        let child_schema = match db.catalog.get_table(&child_table_name) {
+            Some(s) => s,
+            None => continue,
+        };
+        if child_schema.foreign_keys.is_empty() {
+            continue;
+        }
+
+        for fk in child_schema.foreign_keys.iter() {
+            // Only foreign keys that reference the table being REPLACEd, and
+            // only the default NO ACTION on-delete action.
+            if !fk.parent_table.eq_ignore_ascii_case(parent_table) {
+                continue;
+            }
+            if !matches!(fk.on_delete, vibesql_catalog::ReferentialAction::NoAction) {
+                continue;
+            }
+
+            let parent_indices = crate::foreign_key_check::resolved_parent_indices_for_fk(db, fk);
+            if parent_indices.is_empty()
+                || parent_indices.iter().any(|&idx| idx >= new_row_values.len())
+            {
+                continue;
+            }
+            let parent_collations = crate::foreign_key_check::parent_collations_for_fk(db, fk);
+
+            // Parent-key values the re-inserted row will provide.
+            let new_key: Vec<SqlValue> =
+                parent_indices.iter().map(|&idx| new_row_values[idx].clone()).collect();
+
+            for (_, del_row) in rows_to_delete {
+                if parent_indices.iter().any(|&idx| idx >= del_row.values.len()) {
+                    continue;
+                }
+                let deleted_key: Vec<SqlValue> =
+                    parent_indices.iter().map(|&idx| del_row.values[idx].clone()).collect();
+
+                // NULL parent-key values never match a child reference.
+                if deleted_key.iter().any(|v| matches!(v, SqlValue::Null)) {
+                    continue;
+                }
+
+                // If the re-inserted row restores this exact key, no child that
+                // referenced the deleted row can be orphaned.
+                let restored = deleted_key.iter().zip(&new_key).enumerate().all(|(i, (dk, nk))| {
+                    crate::foreign_key_check::fk_values_equal(
+                        dk,
+                        nk,
+                        parent_collations.get(i).and_then(|c| c.as_deref()),
+                    )
+                });
+                if restored {
+                    continue;
+                }
+
+                // The key is being dropped: any child row that references it is
+                // now orphaned. Scan the child table (visibility-aware) for such
+                // a reference.
+                let snapshot = crate::mvcc::read_snapshot(db);
+                let child_table = match db.get_table(&child_table_name) {
+                    Some(t) => t,
+                    None => continue,
+                };
+                let orphaned = child_table.scan_visible(&snapshot).any(|(_, child_row)| {
+                    let child_fk_values: Vec<SqlValue> = fk
+                        .column_indices
+                        .iter()
+                        .map(|&idx| child_row.values[idx].clone())
+                        .collect();
+                    if child_fk_values.iter().any(|v| matches!(v, SqlValue::Null)) {
+                        return false;
+                    }
+                    child_fk_values.iter().zip(&deleted_key).enumerate().all(|(i, (cv, pv))| {
+                        crate::foreign_key_check::fk_values_equal(
+                            cv,
+                            pv,
+                            parent_collations.get(i).and_then(|c| c.as_deref()),
+                        )
+                    })
+                });
+
+                if orphaned {
+                    return Err(ExecutorError::ConstraintViolation(format!(
+                        "FOREIGN KEY constraint violation: cannot delete or update a parent row when a foreign key constraint exists. The conflict occurred in table '{}', constraint '{}'.",
+                        child_table_name,
+                        fk.name.as_deref().unwrap_or(""),
+                    )));
+                }
+            }
+        }
+    }
 
     Ok(())
 }

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -114,6 +114,7 @@ mod quantified_comparison_tests;
 mod query_timeout_tests;
 mod raise_trigger_tests;
 mod recursive_cte_tests;
+mod replace_fk_enforcement;
 mod rowid_tests;
 mod scalar_subquery_basic_tests;
 mod scalar_subquery_caching_tests;

--- a/crates/vibesql-executor/src/tests/replace_fk_enforcement.rs
+++ b/crates/vibesql-executor/src/tests/replace_fk_enforcement.rs
@@ -1,0 +1,142 @@
+//! Tests that REPLACE performs foreign-key processing on the rows it deletes
+//! to clear a PRIMARY KEY / UNIQUE conflict (fkey2-13.*, issue #6170).
+//!
+//! When a REPLACE deletes a conflicting parent row, any child row that
+//! referenced that parent's key would be orphaned. For a NO ACTION foreign
+//! key SQLite checks this at statement end — after the REPLACE re-inserts its
+//! new row — so an orphan is repaired when the re-inserted row restores the
+//! same parent-key value. These tests lock in that behaviour (verified against
+//! the SQLite fkey2.test expectations).
+
+use vibesql_ast::Statement;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Parse and execute a single DDL/DML statement.
+fn exec(db: &mut Database, sql: &str) -> Result<String, String> {
+    let stmt =
+        vibesql_parser::Parser::parse_sql(sql).map_err(|e| format!("Parse error: {:?}", e))?;
+    match stmt {
+        Statement::CreateTable(s) => {
+            crate::CreateTableExecutor::execute(&s, db).map_err(|e| e.to_string())
+        }
+        Statement::Insert(s) => crate::InsertExecutor::execute(db, &s)
+            .map(|count| format!("{} row(s) inserted", count))
+            .map_err(|e| e.to_string()),
+        other => Err(format!("Unsupported statement type: {:?}", other)),
+    }
+}
+
+/// Run a SELECT and return every value of every row flattened in row order.
+fn query_all(db: &Database, sql: &str) -> Vec<SqlValue> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).expect("parse select");
+    let select = match stmt {
+        Statement::Select(s) => s,
+        other => panic!("expected SELECT, got {:?}", other),
+    };
+    let result = crate::SelectExecutor::new(db).execute_with_columns(&select).expect("run select");
+    result.rows.iter().flat_map(|r| r.values.clone()).collect()
+}
+
+/// pp(a UNIQUE, b, c, PRIMARY KEY(b, c)); cc(d, e, f UNIQUE, FK(d,e) -> pp).
+fn setup(db: &mut Database) {
+    db.set_foreign_keys_enabled(true);
+    exec(db, "CREATE TABLE pp(a UNIQUE, b, c, PRIMARY KEY(b, c))").unwrap();
+    exec(db, "CREATE TABLE cc(d, e, f UNIQUE, FOREIGN KEY(d, e) REFERENCES pp)").unwrap();
+    exec(db, "INSERT INTO pp VALUES(1, 2, 3)").unwrap();
+    exec(db, "INSERT INTO cc VALUES(2, 3, 1)").unwrap();
+}
+
+#[test]
+fn replace_dropping_referenced_key_raises_fk_error() {
+    // fkey2-13.1.1: REPLACE INTO pp VALUES(1, 4, 5) conflicts on UNIQUE(a=1),
+    // so the parent row (b=2,c=3) is deleted. The new row provides (b=4,c=5),
+    // which does NOT restore the key cc references (2,3) -> orphan -> error.
+    let mut db = Database::new();
+    setup(&mut db);
+
+    let err = exec(&mut db, "REPLACE INTO pp VALUES(1, 4, 5)").unwrap_err();
+    assert!(
+        err.contains("FOREIGN KEY") || err.to_lowercase().contains("foreign key"),
+        "expected a foreign-key violation, got: {err}"
+    );
+
+    // The failed REPLACE must leave both tables untouched.
+    assert_eq!(
+        query_all(&db, "SELECT a, b, c FROM pp"),
+        vec![SqlValue::Integer(1), SqlValue::Integer(2), SqlValue::Integer(3)],
+    );
+    assert_eq!(
+        query_all(&db, "SELECT d, e, f FROM cc"),
+        vec![SqlValue::Integer(2), SqlValue::Integer(3), SqlValue::Integer(1)],
+    );
+}
+
+#[test]
+fn replace_restoring_referenced_key_succeeds() {
+    // fkey2-13.1.3 variant: REPLACE the parent row on its PRIMARY KEY(b, c)
+    // with a new row that carries the SAME (b, c) = (2, 3). The child's
+    // reference is repaired by the re-inserted row, so the REPLACE succeeds.
+    let mut db = Database::new();
+    setup(&mut db);
+
+    // Conflicts on PK(b, c) = (2, 3); new row keeps (b, c) = (2, 3) but
+    // changes a from 1 to 9. cc(2, 3) still finds a parent afterwards.
+    exec(&mut db, "REPLACE INTO pp VALUES(9, 2, 3)").expect("REPLACE should succeed");
+
+    assert_eq!(
+        query_all(&db, "SELECT a, b, c FROM pp"),
+        vec![SqlValue::Integer(9), SqlValue::Integer(2), SqlValue::Integer(3)],
+    );
+    assert_eq!(
+        query_all(&db, "SELECT d, e, f FROM cc"),
+        vec![SqlValue::Integer(2), SqlValue::Integer(3), SqlValue::Integer(1)],
+    );
+}
+
+#[test]
+fn replace_without_children_referencing_deleted_key_succeeds() {
+    // A REPLACE that deletes a parent row no child references must still work.
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    exec(&mut db, "CREATE TABLE pp(a UNIQUE, b, c, PRIMARY KEY(b, c))").unwrap();
+    exec(&mut db, "CREATE TABLE cc(d, e, f UNIQUE, FOREIGN KEY(d, e) REFERENCES pp)").unwrap();
+    exec(&mut db, "INSERT INTO pp VALUES(1, 2, 3)").unwrap();
+    exec(&mut db, "INSERT INTO pp VALUES(7, 8, 9)").unwrap();
+    // Only (2,3) is referenced; deleting (8,9) via REPLACE is fine.
+    exec(&mut db, "INSERT INTO cc VALUES(2, 3, 1)").unwrap();
+
+    exec(&mut db, "REPLACE INTO pp VALUES(7, 10, 11)").expect("REPLACE should succeed");
+
+    // (8,9) replaced by (10,11); the referenced (2,3) is untouched.
+    assert_eq!(
+        query_all(&db, "SELECT a, b, c FROM pp ORDER BY a"),
+        vec![
+            SqlValue::Integer(1),
+            SqlValue::Integer(2),
+            SqlValue::Integer(3),
+            SqlValue::Integer(7),
+            SqlValue::Integer(10),
+            SqlValue::Integer(11),
+        ],
+    );
+}
+
+#[test]
+fn replace_ignored_when_foreign_keys_disabled() {
+    // With PRAGMA foreign_keys = off, the REPLACE-delete is not FK-checked.
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(false);
+    exec(&mut db, "CREATE TABLE pp(a UNIQUE, b, c, PRIMARY KEY(b, c))").unwrap();
+    exec(&mut db, "CREATE TABLE cc(d, e, f UNIQUE, FOREIGN KEY(d, e) REFERENCES pp)").unwrap();
+    exec(&mut db, "INSERT INTO pp VALUES(1, 2, 3)").unwrap();
+    exec(&mut db, "INSERT INTO cc VALUES(2, 3, 1)").unwrap();
+
+    // Would orphan cc(2,3) but FK enforcement is off -> succeeds.
+    exec(&mut db, "REPLACE INTO pp VALUES(1, 4, 5)").expect("REPLACE should succeed with FK off");
+
+    assert_eq!(
+        query_all(&db, "SELECT a, b, c FROM pp"),
+        vec![SqlValue::Integer(1), SqlValue::Integer(4), SqlValue::Integer(5)],
+    );
+}


### PR DESCRIPTION
## Summary

REPLACE cleared a PRIMARY KEY / UNIQUE conflict by deleting the conflicting parent row with **no foreign-key processing**. A REPLACE that orphaned a child row therefore succeeded silently, where SQLite raises `FOREIGN KEY constraint failed` (fkey2-13.1.*). This PR makes REPLACE enforce the default NO ACTION foreign-key behaviour on the rows its conflict-resolution deletes.

This is a focused increment of the large FK family in #6170 (the ON DELETE/UPDATE action matrix, deferred constraints, PRAGMA edge cases remain).

## Changes

- `crates/vibesql-executor/src/insert/replace.rs`: `handle_replace_conflicts` now calls a new `enforce_replace_no_action_fks` helper after identifying the conflict rows to delete.
  - For every NO ACTION foreign key that references the table being REPLACEd, it checks whether the conflict-delete would orphan a child row.
  - Because a foreign key's parent columns are always a key (PRIMARY KEY / UNIQUE), at most one parent row carries a given key value, so an orphan is repaired **precisely when the re-inserted row restores that same parent-key value**. The helper evaluates this against the row about to be inserted (`row_values`) rather than erroring eagerly on the delete — matching SQLite's end-of-statement NO ACTION semantics.
- `crates/vibesql-executor/src/tests/replace_fk_enforcement.rs` (new): 4 regression tests (orphan raises, key-restoring REPLACE succeeds, unreferenced-key REPLACE succeeds, FK-off bypass).
- `crates/vibesql-executor/src/tests/mod.rs`: register the new test module.

CASCADE / SET NULL / SET DEFAULT / RESTRICT on a REPLACE-delete are a separate pre-existing gap and are intentionally untouched here.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| REPLACE that orphans a NO ACTION child raises FK error (fkey2-13.1.1.*) | ✅ | `make test-tcl-file FILE=fkey2.test` — 13.1.1.1–.4 now pass |
| REPLACE that restores the referenced key succeeds (fkey2-13.1.3/4) | ✅ | Same run — 13.1.3, 13.1.4 now pass |
| No regressions in fkey2 | ✅ | Failing-set diff: exactly 6 newly passing, 0 newly failing (165 → 159) |
| No regressions in without_rowid3 / fkey1/3/4/7 | ✅ | without_rowid3 85.2%; fkey1/3/4/7 unchanged (no REPLACE paths) |
| Build clean | ✅ | `cargo build --release` and `cargo clippy -p vibesql-executor` — no new warnings |

## Test Plan

- `cargo test --release -p vibesql-executor --lib` → 3515 passed, 0 failed.
- `cargo test --release -p vibesql-executor replace_fk_enforcement` → 4 passed.
- `make test-tcl-file FILE=fkey2.test` → 159 failures (was 165); the 6 fixed are exactly fkey2-13.1.1.1–.4, 13.1.3, 13.1.4. Remaining 13.1.2.* go through the rowid-reservation delete path (separate follow-up).

Part of #6170