### PR TITLE
fix(evaluator): COLLATE into IS/BETWEEN + BLOB equality in IS DISTINCT (part of #6172)

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -74,8 +74,17 @@ impl CombinedExpressionEvaluator<'_> {
 
         let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
 
-        // Get effective collation: explicit COLLATE or column-level collation
-        let collation = self.get_expression_collation(expr);
+        // Get effective collation for the BETWEEN comparisons (datatype3 §7.1).
+        // `x BETWEEN y AND z` is `x >= y AND x <= z`, so an explicit `COLLATE`
+        // operator on the tested expression OR on either bound propagates to the
+        // comparison. Prefer the tested expression's collation (explicit or its
+        // column's declared collation); otherwise fall back to an explicit
+        // COLLATE on a bound, so `'bbb' BETWEEN 'AAA' AND 'CCC' COLLATE nocase`
+        // compares under NOCASE (e_expr-9.22).
+        let collation = self.get_expression_collation(expr).or_else(|| {
+            crate::evaluator::collation::explicit_collation_of(low)
+                .or_else(|| crate::evaluator::collation::explicit_collation_of(high))
+        });
 
         let expr_val = self.eval(expr, row)?;
         let low_val = self.eval(low, row)?;
@@ -891,6 +900,20 @@ impl CombinedExpressionEvaluator<'_> {
 
         let left_val = self.eval(left, row)?;
         let right_val = self.eval(right, row)?;
+
+        // `IS` / `IS NOT` compare like `=` / `<>` but NULL-safe, so they honour
+        // the datatype3 §7.1 comparison collation and SQLite affinity, mirroring
+        // the `=` and row-value-element paths. In particular an explicit
+        // `COLLATE` operator on either operand propagates to the comparison
+        // (`'abcd' IS 'ABCD' COLLATE nocase` compares under NOCASE; e_expr-9.14).
+        let collation = self.comparison_collation(left, right);
+        let (left_val, right_val) = crate::evaluator::row_value::apply_collation_to_pair(
+            left_val,
+            right_val,
+            collation.as_deref(),
+        );
+        let (left_val, right_val) =
+            self.apply_affinity_for_comparison(left, left_val, right, right_val);
 
         // Use values_are_distinct for SQLite-compatible comparison
         // This handles Boolean/Integer comparison (SQLite treats 0 as FALSE, non-zero as TRUE)

--- a/crates/vibesql-executor/src/evaluator/core.rs
+++ b/crates/vibesql-executor/src/evaluator/core.rs
@@ -117,6 +117,12 @@ pub(crate) fn values_are_equal(
         (Character(a), Varchar(b)) | (Varchar(a), Character(b)) => a == b,
         (Boolean(a), Boolean(b)) => a == b,
 
+        // BLOB values compare byte-for-byte. Without this arm two identical
+        // blobs fell through to the `_ => false` catch-all, so `X'ABCDEF' IS
+        // X'ABCDEF'` wrongly reported "distinct" (e_expr-8.2.10.10.1 /
+        // 8.2.11.11.1 / 8.2.12.12.1) even though `X'ABCDEF' = X'ABCDEF'` is 1.
+        (Blob(a), Blob(b)) => a == b,
+
         // SQLite compatibility: Boolean/Integer comparisons.
         //
         // SQLite has no separate boolean storage class — TRUE is stored as the
@@ -237,5 +243,37 @@ pub(crate) fn values_are_distinct(
         // Both non-NULL - compare for inequality
         // Reuse the values_are_equal logic but invert it
         _ => !values_are_equal(left, right),
+    }
+}
+
+#[cfg(test)]
+mod blob_equality_tests {
+    use super::{values_are_distinct, values_are_equal};
+    use vibesql_types::SqlValue;
+
+    // Regression for e_expr-8.2.10.10.1 / 8.2.11.11.1 / 8.2.12.12.1: identical
+    // BLOB values must compare equal (and NOT distinct), matching `=`.
+    #[test]
+    fn identical_blobs_are_equal_and_not_distinct() {
+        let a = SqlValue::Blob(vec![0xAB, 0xCD, 0xEF]);
+        let b = SqlValue::Blob(vec![0xAB, 0xCD, 0xEF]);
+        assert!(values_are_equal(&a, &b));
+        assert!(!values_are_distinct(&a, &b));
+    }
+
+    #[test]
+    fn empty_blobs_are_equal_and_not_distinct() {
+        let a = SqlValue::Blob(vec![]);
+        let b = SqlValue::Blob(vec![]);
+        assert!(values_are_equal(&a, &b));
+        assert!(!values_are_distinct(&a, &b));
+    }
+
+    #[test]
+    fn differing_blobs_are_distinct() {
+        let a = SqlValue::Blob(vec![0xAB]);
+        let b = SqlValue::Blob(vec![0xCD]);
+        assert!(!values_are_equal(&a, &b));
+        assert!(values_are_distinct(&a, &b));
     }
 }

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -973,6 +973,20 @@ impl ExpressionEvaluator<'_> {
 
                 let left_val = self.eval(left, row)?;
                 let right_val = self.eval(right, row)?;
+                // `IS` / `IS NOT` compare like `=` / `<>` but NULL-safe, so they
+                // must honour the datatype3 §7.1 comparison collation and SQLite
+                // affinity, mirroring the `=` and row-value-element paths. In
+                // particular an explicit `COLLATE` operator on either operand
+                // propagates to the comparison, so `'abcd' IS 'ABCD' COLLATE
+                // nocase` compares under NOCASE (e_expr-9.14 / e_expr-9.20).
+                let collation = self.comparison_collation(left, right);
+                let (left_val, right_val) = crate::evaluator::row_value::apply_collation_to_pair(
+                    left_val,
+                    right_val,
+                    collation.as_deref(),
+                );
+                let (left_val, right_val) =
+                    self.apply_affinity_for_comparison(left, left_val, right, right_val);
                 let is_distinct = super::super::core::values_are_distinct(&left_val, &right_val);
                 let result = if *negated { !is_distinct } else { is_distinct };
                 Ok(SqlValue::Boolean(result))

--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -77,8 +77,17 @@ impl ExpressionEvaluator<'_> {
 
         let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
 
-        // Get effective collation: explicit COLLATE or column-level collation
-        let collation = self.get_expression_collation(expr);
+        // Get effective collation for the BETWEEN comparisons (datatype3 §7.1).
+        // `x BETWEEN y AND z` is `x >= y AND x <= z`, so an explicit `COLLATE`
+        // operator on the tested expression OR on either bound propagates to the
+        // comparison. Prefer the tested expression's collation (explicit or its
+        // column's declared collation); otherwise fall back to an explicit
+        // COLLATE on a bound, so `'bbb' BETWEEN 'AAA' AND 'CCC' COLLATE nocase`
+        // compares under NOCASE (e_expr-9.22).
+        let collation = self.get_expression_collation(expr).or_else(|| {
+            crate::evaluator::collation::explicit_collation_of(low)
+                .or_else(|| crate::evaluator::collation::explicit_collation_of(high))
+        });
 
         let expr_val = self.eval(expr, row)?;
         let low_val = self.eval(low, row)?;


### PR DESCRIPTION
## Summary

Part of the expression / type-affinity / literal conformance family (**#6172**, epic #5779). This is a **partial but solid increment** — it lands three genuine, well-justified expression-semantics fixes and documents why the bulk of the family's remaining failures are test-harness infrastructure gaps rather than engine bugs.

**Net result:** `e_expr.test` 315 → 309 failures (**6 certified rows cleared**), zero regressions, all **3514** executor unit tests pass, `cargo build --release` clean.

## Fixes (each verified against SQLite's `e_expr` evidence suite)

1. **`IS` / `IS NOT` collation + affinity.** These operators compare like `=` / `<>` but NULL-safe, so they must honour the datatype3 §7.1 comparison collation and SQLite affinity. The scalar path called `values_are_distinct` on raw values, ignoring an explicit `COLLATE`. Now mirrors the `=` / row-value-element paths. Fixes `'abcd' IS 'ABCD' COLLATE nocase` → 1 (**e_expr-9.14**, **e_expr-9.20**). Applied in both the single-table and combined evaluators.

2. **`BETWEEN` COLLATE on bounds.** `x BETWEEN y AND z` is `x >= y AND x <= z`, so an explicit `COLLATE` on a bound propagates to the comparison. Previously only the tested expression's collation was consulted. Fixes `'bbb' BETWEEN 'AAA' AND 'CCC' COLLATE nocase` → 1 (**e_expr-9.22**). Both evaluators. (The `IN (…)` path is deliberately left unchanged — per datatype3 §7.2 it uses only the LHS collation.)

3. **BLOB equality in `IS DISTINCT FROM`.** `values_are_equal` had no `(Blob, Blob)` arm, so identical blobs fell through to the catch-all and reported "distinct": `X'ABCDEF' IS X'ABCDEF'` wrongly returned 0 even though `X'ABCDEF' = X'ABCDEF'` returned 1 (**e_expr-8.2.10.10.1 / 8.2.11.11.1 / 8.2.12.12.1**). Also corrects BLOB dedup in simple `CASE` / `DISTINCT`. Adds regression unit tests.

## Why the rest of this family is not addressed here

I surveyed all satellites. The dominant failure sources are **test-harness infrastructure gaps, not expression-semantics bugs**, and are out of scope for an evaluator change:

| Cluster | Count | Root cause (not an engine semantics bug) |
|---|---|---|
| `nan.test` (0% pass), `istrue-600.*` | ~35 + 12 | Need `sqlite3_prepare` / `sqlite3_bind_double` / `sqlite3_step` C-test APIs to inject raw IEEE **NaN/Inf** doubles — values not expressible as SQL literals |
| `e_expr-12.3.*` | ~90 | Blocked by lack of **`ATTACH DATABASE`** (`CREATE TABLE dbname.tblname` fails, cascading the whole syntax-diagram block) |
| `types3.test` | 17 | Blocked by `tcl_variable_type` C-test command |
| `like3` / `numcast` utf16, `e_expr-27.4.*` | ~24 | **UTF-16 encoding** blobs — VibeSQL is UTF-8 |
| `e_expr` filescope-errs | 46 | 31 × `sqlite3_prepare_v2`, 9 × `db` command, plus `MATCH`/`ATTACH` parse — harness/C-API, not evaluator |
| `quote` / `literal` / `hexlit` | ~40 | Error-**message wording** differences (e.g. SQLite's "hex literal too big" hint) — both sides already error (rc=1) |

Genuinely-fixable-but-deferred (documented for follow-up issues): `reverse` test-collation registration (`e_expr-9.1/9.3/9.5/9.7`), integer-overflow→REAL affinity (`e_expr-32.1.*`), modulo `%` integer-truncation semantics (`e_expr-6.5`, has cross-SQL-mode implications), UNION/USING join-affinity (`affinity3-210/250`).

## Testing
- `e_expr.test`: 315 → 309 failures; the 6 cleared rows are exactly 8.2.10.10.1, 8.2.11.11.1, 8.2.12.12.1, 9.14, 9.20, 9.22 (diffed before/after — zero new failures).
- Regression sweep clean: `between`, `in4`, `where`, `select1`, `rowvalue`, `in2`, `join2`, `distinct2` (its 2 failures are a pre-existing `table t1 already exists` setup cascade, unrelated).
- `cargo test --release -p vibesql-executor --lib`: 3514 passed, 0 failed.

Part of #6172

🤖 Generated with [Claude Code](https://claude.com/claude-code)