### PR TITLE
fix(ddl): temp.-qualified CREATE TABLE + reject subquery/parameter CHECK constraints

### DIFF
--- a/crates/vibesql-executor/src/constraint_validator.rs
+++ b/crates/vibesql-executor/src/constraint_validator.rs
@@ -6,13 +6,65 @@
 #![allow(clippy::new_without_default)]
 
 use vibesql_ast::{
-    pretty_print::ToSql, ColumnConstraintKind, ColumnDef, Expression, TableConstraint,
-    TableConstraintKind,
+    pretty_print::ToSql,
+    visitor::{walk_expression, ExpressionVisitor, VisitResult},
+    ColumnConstraintKind, ColumnDef, Expression, TableConstraint, TableConstraintKind,
 };
 use vibesql_catalog::{ColumnSchema, TableSchema};
 use vibesql_types::DataType;
 
 use crate::errors::ExecutorError;
+
+/// Visitor that flags any bind parameter (`?`, `?NNN`, or `:name`) reached
+/// while walking an expression. SQLite prohibits parameters inside CHECK
+/// constraints because the constraint is evaluated at every INSERT/UPDATE with
+/// no bind context (see check-5.1 / check-5.2).
+struct ParameterFinder {
+    found: bool,
+}
+
+impl ExpressionVisitor for ParameterFinder {
+    fn visit_placeholder(&mut self, _index: usize) -> VisitResult {
+        self.found = true;
+        VisitResult::Stop
+    }
+
+    fn visit_numbered_placeholder(&mut self, _number: usize) -> VisitResult {
+        self.found = true;
+        VisitResult::Stop
+    }
+
+    fn visit_named_placeholder(&mut self, _name: &str) -> VisitResult {
+        self.found = true;
+        VisitResult::Stop
+    }
+}
+
+/// True if `expr` contains any bind parameter. Used to reject
+/// `CHECK( x < :abc )` / `CHECK( x < ? )` at CREATE TABLE time.
+fn expression_has_parameter(expr: &Expression) -> bool {
+    let mut finder = ParameterFinder { found: false };
+    walk_expression(&mut finder, expr);
+    finder.found
+}
+
+/// Validate that a CHECK constraint expression uses only forms SQLite permits.
+/// Subqueries and bind parameters are rejected at CREATE TABLE time with the
+/// exact SQLite messages so an invalid definition never creates a half-formed
+/// table (check-3.1, check-5.1, check-5.2).
+fn validate_check_expression(expr: &Expression) -> Result<(), ExecutorError> {
+    if crate::dml_returning::expression_has_subquery(expr) {
+        return Err(ExecutorError::SqliteCompatError(
+            "subqueries prohibited in CHECK constraints".to_string(),
+        ));
+    }
+    if expression_has_parameter(expr) {
+        return Err(ExecutorError::SqliteCompatError(
+            "parameters prohibited in CHECK constraints".to_string(),
+        ));
+    }
+    Ok(())
+}
 
 /// Result of processing constraints
 pub struct ConstraintResult {
@@ -179,6 +231,11 @@ impl ConstraintValidator {
                         result.unique_constraint_collations.push(vec![None]);
                     }
                     ColumnConstraintKind::Check { expr, source_text } => {
+                        // SQLite rejects subqueries and bind parameters inside
+                        // CHECK constraints at CREATE TABLE time (check-3.1,
+                        // check-5.1). Enforce the same prohibition so an invalid
+                        // definition never leaves a half-formed table behind.
+                        validate_check_expression(expr)?;
                         // Use explicit name if provided; otherwise use the
                         // verbatim CHECK source text (SQLite echoes the
                         // original operator spacing in the violation message),
@@ -264,6 +321,10 @@ impl ConstraintValidator {
                     result.unique_constraint_collations.push(key_part_collations(columns));
                 }
                 TableConstraintKind::Check { expr, source_text } => {
+                    // SQLite rejects subqueries and bind parameters inside CHECK
+                    // constraints at CREATE TABLE time (check-3.1, check-5.1).
+                    // Enforce the same prohibition for table-level CHECKs too.
+                    validate_check_expression(expr)?;
                     // Use explicit name if provided; otherwise the verbatim
                     // CHECK source text, falling back to the re-rendered
                     // expression only when no source span was captured.
@@ -557,6 +618,49 @@ mod tests {
         // Programmatic AST carries no source span, so the name falls back to
         // the re-rendered expression text.
         assert_eq!(result.check_constraints[0].0, check_expr.to_sql());
+    }
+
+    /// Assert that a parsed `CREATE TABLE` is rejected by constraint processing
+    /// with `expected` as the exact error message.
+    fn assert_create_table_rejected(sql: &str, expected: &str) {
+        let stmt = vibesql_parser::Parser::parse_sql(sql).expect("parse");
+        let create = match stmt {
+            vibesql_ast::Statement::CreateTable(c) => c,
+            other => panic!("expected CREATE TABLE, got {:?}", other),
+        };
+        let res = ConstraintValidator::process_constraints(
+            &create.table_name,
+            &create.columns,
+            &create.table_constraints,
+        );
+        match res {
+            Ok(_) => panic!("expected rejection of `{}`", sql),
+            Err(e) => assert_eq!(e.to_string(), expected),
+        }
+    }
+
+    #[test]
+    fn test_check_constraint_rejects_parameter() {
+        // A bind parameter inside a CHECK is rejected at CREATE TABLE time with
+        // SQLite's exact message (check-5.1 / check-5.2).
+        assert_create_table_rejected(
+            "CREATE TABLE t5(x, y, CHECK( x*y < :abc ))",
+            "parameters prohibited in CHECK constraints",
+        );
+        assert_create_table_rejected(
+            "CREATE TABLE t5(x, y, CHECK( x*y < ? ))",
+            "parameters prohibited in CHECK constraints",
+        );
+    }
+
+    #[test]
+    fn test_check_constraint_rejects_subquery() {
+        // A subquery inside a CHECK is rejected at CREATE TABLE time with
+        // SQLite's exact message (check-3.1).
+        assert_create_table_rejected(
+            "CREATE TABLE t3(x, y, z, CHECK( x < (SELECT min(x) FROM t1) ))",
+            "subqueries prohibited in CHECK constraints",
+        );
     }
 
     #[test]

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -157,8 +157,20 @@ impl CreateTableExecutor {
             // Schema-qualified table name - use qualified identifier
             // Note: We use stmt.quoted for both parts since the parser combined them
             // In a future iteration, CREATE TABLE could also store schema/table quoted status separately
-            let id = TableIdentifier::qualified(schema_part, stmt.quoted, table_part, stmt.quoted);
-            (schema_part.to_string(), table_part.to_string(), id)
+            if schema_part.eq_ignore_ascii_case(vibesql_catalog::TEMP_SCHEMA) {
+                // SQLite compatibility: the "temp" schema qualifier maps to this
+                // session's temp schema, so `CREATE TABLE temp.t(...)` creates a
+                // temporary table exactly like `CREATE TEMP TABLE t(...)`. Without
+                // this mapping the raw "temp" schema name is looked up verbatim and
+                // fails with SchemaNotFound("temp").
+                let temp_schema = database.catalog.temp_schema_name();
+                let id = TableIdentifier::qualified(temp_schema, false, table_part, stmt.quoted);
+                (temp_schema.to_string(), table_part.to_string(), id)
+            } else {
+                let id =
+                    TableIdentifier::qualified(schema_part, stmt.quoted, table_part, stmt.quoted);
+                (schema_part.to_string(), table_part.to_string(), id)
+            }
         } else {
             // Simple table name - use current schema
             let id = TableIdentifier::new(&stmt.table_name, stmt.quoted);

--- a/crates/vibesql-executor/src/dml_returning.rs
+++ b/crates/vibesql-executor/src/dml_returning.rs
@@ -195,7 +195,7 @@ pub(crate) fn returning_has_subquery(items: &[SelectItem]) -> bool {
 
 /// Recursively test whether an expression contains any subquery form
 /// (scalar subquery, IN (SELECT), EXISTS, or a quantified comparison).
-fn expression_has_subquery(expr: &Expression) -> bool {
+pub(crate) fn expression_has_subquery(expr: &Expression) -> bool {
     use Expression::*;
     match expr {
         ScalarSubquery(_) | Exists { .. } => true,


### PR DESCRIPTION
## Summary

Partial increment toward #6173 (CREATE TABLE / schema-definition semantics). Two low-blast-radius, zero-regression fixes:

1. **`temp.`-qualified CREATE TABLE** now resolves to the session temp schema. `CREATE TABLE temp.t(...)` previously failed with `SchemaNotFound("temp")` because the schema-qualified CREATE path looked up the literal `temp` schema name, while the read path already resolved `temp.` to the session's temp schema. This was the dominant file-scope setup error cascading through `e_createtable.test`.

2. **CHECK constraints with a subquery or bind parameter are rejected at CREATE TABLE time** with SQLite's exact messages, so an invalid definition never leaves a half-formed table behind (matches SQLite, which also rejects these):
   - `subqueries prohibited in CHECK constraints` (check-3.1)
   - `parameters prohibited in CHECK constraints` (check-5.1, check-5.2)

## Changes

- `create_table.rs`: schema-qualified CREATE detects a `temp`/`TEMP` qualifier and routes to `catalog.temp_schema_name()`, mirroring the `CREATE TEMP TABLE` branch.
- `constraint_validator.rs`: new `validate_check_expression` rejects subqueries (reusing `expression_has_subquery`) and bind parameters (new `ExpressionVisitor`-based `expression_has_parameter`) for both column-level and table-level CHECKs. Two new unit tests.
- `dml_returning.rs`: `expression_has_subquery` made `pub(crate)` for reuse.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Fix e_createtable file-scope setup failure (temp cascade) | ✅ | `temp.`-qualified CREATE now succeeds; the `SchemaNotFound("temp")` file-scope error is gone |
| CHECK sub-feature converges cleanly | ✅ | `check.test` 67 → 71 passing (25 → 21 failing) via check-3.1/3.2, check-5.1/5.2 |
| Zero regressions | ✅ | 3518 executor + catalog unit tests pass; changes only accept previously-erroring `temp.` and reject SQLite-invalid CHECK forms |

## Test Plan

- `cargo build --release` clean (full workspace).
- `cargo test -p vibesql-executor -p vibesql-catalog` — all pass, incl. 2 new CHECK-rejection tests.
- `make test-tcl-file FILE=check.test` — 71 passing (was 67).
- `make test-tcl-file FILE=e_createtable.test` — `temp.` file-scope error eliminated; passing count up.

## Remaining sub-features (follow-ups, NOT in this PR)

Deferred because each has a wide blast radius across all CREATE TABLE / DML and needs a full quiet-machine suite run to certify zero regressions:

- **AUTOINCREMENT / `sqlite_sequence`** (autoinc.test, 61 failures): VibeSQL uses internal `<table>_<col>_seq` sequences but does not expose the SQLite-visible `sqlite_sequence` table (`no such table: sqlite_sequence`). Requires a system-table shim.
- **CHECK column-existence validation** (check-3.3–3.9): reject CHECKs referencing unknown / foreign-table-qualified columns (`no such column: q`). Touches every CHECK-bearing CREATE TABLE.
- **Multiline CHECK source-text capture** (check-4.6, check-4.9): the violation message truncates a multiline CHECK to its first line.
- **Generated columns** (gencol1.test) and **STRICT typing** (strict1.test) residuals.

Part of #6173