### PR TITLE
feat(parser): accept ALTER TABLE DROP <col> without the COLUMN keyword

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/ddl.rs
+++ b/crates/vibesql-parser/src/arena_parser/ddl.rs
@@ -400,6 +400,11 @@ impl<'arena> ArenaParser<'arena> {
                         self.advance();
                         self.parse_drop_constraint(table_name)?
                     }
+                    // SQLite allows DROP COLUMN without the COLUMN keyword:
+                    // `ALTER TABLE t DROP <col>` is a synonym for
+                    // `ALTER TABLE t DROP COLUMN <col>`. If we see a bare column
+                    // name, treat it as a column drop (mirrors the ADD case).
+                    Token::Identifier(_) => self.parse_drop_column(table_name)?,
                     _ => {
                         return Err(ParseError {
                             message: "Expected COLUMN or CONSTRAINT after DROP".to_string(),

--- a/crates/vibesql-parser/src/parser/alter.rs
+++ b/crates/vibesql-parser/src/parser/alter.rs
@@ -51,6 +51,11 @@ pub fn parse_alter_table(parser: &mut crate::Parser) -> Result<AlterTableStmt, P
                     parser.advance();
                     parse_drop_constraint(parser, table_name)
                 }
+                // SQLite allows DROP COLUMN without the COLUMN keyword:
+                // `ALTER TABLE t DROP <col>` is a synonym for
+                // `ALTER TABLE t DROP COLUMN <col>`. If we see a bare column
+                // name, treat it as a column drop (mirrors the ADD case above).
+                Token::Identifier(_) => parse_drop_column(parser, table_name),
                 _ => Err(ParseError {
                     message: "Expected COLUMN or CONSTRAINT after DROP".to_string(),
                 }),

--- a/crates/vibesql-parser/src/tests/alter_table.rs
+++ b/crates/vibesql-parser/src/tests/alter_table.rs
@@ -53,6 +53,27 @@ fn test_parse_alter_table_drop_column() {
 }
 
 #[test]
+fn test_parse_alter_table_drop_column_without_column_keyword() {
+    // SQLite allows `ALTER TABLE t DROP <col>` as a synonym for
+    // `ALTER TABLE t DROP COLUMN <col>` (issue #6174).
+    let result = Parser::parse_sql("ALTER TABLE users DROP email;");
+    assert!(result.is_ok(), "bare DROP <col> should parse: {result:?}");
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::AlterTable(alter) => match alter {
+            vibesql_ast::AlterTableStmt::DropColumn(drop) => {
+                assert_eq!(drop.table_name, "users");
+                assert_eq!(drop.column_name, "email");
+                assert!(!drop.if_exists);
+            }
+            _ => panic!("Expected DROP COLUMN"),
+        },
+        _ => panic!("Expected ALTER TABLE statement"),
+    }
+}
+
+#[test]
 fn test_parse_alter_table_drop_column_if_exists() {
     let result = Parser::parse_sql("ALTER TABLE users DROP COLUMN IF EXISTS email;");
     assert!(result.is_ok());

--- a/crates/vibesql-parser/src/tests/arena_alter_table.rs
+++ b/crates/vibesql-parser/src/tests/arena_alter_table.rs
@@ -120,6 +120,26 @@ fn test_arena_alter_table_drop_column() {
 }
 
 #[test]
+fn test_arena_alter_table_drop_column_without_column_keyword() {
+    // SQLite allows `ALTER TABLE t DROP <col>` as a synonym for
+    // `ALTER TABLE t DROP COLUMN <col>` (issue #6174).
+    let arena = Bump::new();
+    let result =
+        ArenaParser::parse_alter_table_sql_with_interner("ALTER TABLE users DROP email;", &arena);
+    assert!(result.is_ok(), "bare DROP <col> should parse: {:?}", result.err());
+    let (stmt, interner) = result.unwrap();
+
+    match stmt {
+        AlterTableStmt::DropColumn(DropColumnStmt { table_name, column_name, if_exists }) => {
+            assert_eq!(interner.resolve(*table_name), "users");
+            assert_eq!(interner.resolve(*column_name), "email");
+            assert!(!if_exists);
+        }
+        _ => panic!("Expected DROP COLUMN"),
+    }
+}
+
+#[test]
 fn test_arena_alter_table_drop_column_if_exists() {
     let arena = Bump::new();
     let result = ArenaParser::parse_alter_table_sql_with_interner(


### PR DESCRIPTION
## Summary

SQLite treats `ALTER TABLE t DROP <col>` as a synonym for `ALTER TABLE t DROP COLUMN <col>`. Both VibeSQL ALTER-TABLE parsers (the legacy recursive-descent parser and the arena parser) required an explicit `COLUMN` or `CONSTRAINT` keyword after `DROP`, raising `Expected COLUMN or CONSTRAINT after DROP` for the bare shorthand. This is a small, coherent slice of the large ALTER TABLE conformance family (#6174).

## Changes

- `crates/vibesql-parser/src/parser/alter.rs` and `crates/vibesql-parser/src/arena_parser/ddl.rs`: after `DROP`, route a bare column-name identifier to `parse_drop_column`, mirroring the existing ADD-COLUMN handling that already accepts `ALTER TABLE t ADD <col>` without the `COLUMN` keyword. The `CONSTRAINT` keyword (VibeSQL's `DROP CONSTRAINT` extension) is still matched first, so only bare identifiers take the implicit-`DROP COLUMN` path — explicit `DROP COLUMN` / `DROP CONSTRAINT` are unchanged.
- Added parser unit tests for the shorthand in both the legacy and arena test suites.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Bare `DROP <col>` parses as DROP COLUMN | ✅ | New unit tests (legacy + arena) pass; `alterdropcol2.test` 15 → 5 failures |
| No regression in existing ALTER files | ✅ | `altercol` 51, `alter` 52, `alter3` 34, `alterqf` 12 — all unchanged before/after |
| No unit-test regressions | ✅ | `cargo test -p vibesql-parser` (1775 + 8 pass), `cargo test -p vibesql-executor --lib` (3518 pass) |
| Release build clean | ✅ | `cargo build --release` finished with no warnings/errors |

## Test Plan

- `cargo test -p vibesql-parser` — 1775 + 8 pass, 0 fail (includes 2 new tests).
- `cargo test -p vibesql-executor --lib` — 3518 pass, 0 fail.
- `make test-tcl-file FILE=alterdropcol2.test` — 15 → 5 failures (10 fixed by this parser change: 1.1, 1.2.1, 1.2.2, 2.4.1, 2.5.1, 2.8.1, 2.8.2, 2.8.3, 3.2.1, 3.2.2).
- Re-ran `altercol`/`alter`/`alter3`/`alterqf`: failure counts unchanged (zero regressions).

## Remaining ALTER TABLE follow-ups (out of scope here)

The ~243-failure family (#6174) remains largely open. Notable remaining sub-features, for follow-up increments:
- `sqlite_rename_quotefix()` internal SQL function (`alterqf.test` 1.1–1.11) — requires column-resolution-aware DQS quote normalization.
- String-literal-as-identifier in DDL (e.g. `CREATE TABLE 'one two'(...)`, `DROP COLUMN 'z 1'`, `RENAME ... TO 'four'`) — `alterdropcol2` filescope, `altercol` 22/23.
- DROP COLUMN dependency error-message parity (FK / generated-column / UNIQUE references: `alterdropcol2` 2.2.2, 2.6.1, 2.7.x).
- RENAME COLUMN/TABLE propagation edge cases in views/triggers/CHECK exprs (`altercol` various).
- `alter2.test`/`alter3.test` are largely SQLite file-format internals (`hexio_*`, direct `sqlite_master` UPDATE) — candidate Bucket-A; `altercorrupt`/`altermalloc*` corruption/OOM likely route to #6154.

Part of #6174