### PR TITLE
fix(pragma): table_info empty type for typeless columns + notnull=0 for INTEGER PRIMARY KEY

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -2002,16 +2002,86 @@ impl SqlExecutor {
                 None => std::collections::HashMap::new(),
             };
 
+        // Recover per-column *declaration* facts that the catalog's affinity-only
+        // `data_type` / `nullable` fields cannot express, by re-parsing the
+        // verbatim CREATE TABLE text (`sql_source`). Two SQLite `table_info`
+        // quirks depend on the original declaration rather than the internal
+        // affinity/rowid state:
+        //
+        //   * The `type` column echoes the *declared* type text. A typeless
+        //     column (`CREATE TABLE t(a)`) reports an empty type in SQLite, but
+        //     VibeSQL folds it into BLOB affinity — so without this we'd wrongly
+        //     print "BLOB". `type_source == None` marks the typeless case.
+        //   * The `notnull` column reflects only an *explicit* NOT NULL clause.
+        //     An `INTEGER PRIMARY KEY` rowid alias is internally non-nullable
+        //     (VibeSQL sets `nullable = false`) yet SQLite reports `notnull = 0`
+        //     for it. Deriving notnull from the explicit NOT NULL constraint in
+        //     the source matches SQLite exactly.
+        //
+        // Keyed by lowercase column name. Absent (no sql_source, a CREATE ... AS
+        // SELECT with no explicit column list, or a re-parse failure) means we
+        // fall back to the catalog-derived behavior below, unchanged.
+        let decl_facts: std::collections::HashMap<String, (bool, bool)> = {
+            let mut map = std::collections::HashMap::new();
+            if let Some(src) = schema.sql_source.as_deref() {
+                if let Ok(vibesql_ast::Statement::CreateTable(create)) =
+                    vibesql_parser::Parser::parse_sql(src)
+                {
+                    if create.as_query.is_none() {
+                        for col in &create.columns {
+                            let is_typeless = col.type_source.is_none();
+                            let explicit_not_null = col.constraints.iter().any(|c| {
+                                matches!(
+                                    c.kind,
+                                    vibesql_ast::ColumnConstraintKind::NotNull
+                                        | vibesql_ast::ColumnConstraintKind::NotNullWithConflict { .. }
+                                )
+                            });
+                            map.insert(
+                                col.name.to_lowercase(),
+                                (is_typeless, explicit_not_null),
+                            );
+                        }
+                    }
+                }
+            }
+            map
+        };
+
         let mut rows: Vec<Vec<Option<String>>> = Vec::with_capacity(schema.columns.len());
         for (cid, column) in schema.columns.iter().enumerate() {
-            // Type column: SQLite reports the declared type as supplied in the
-            // CREATE TABLE statement. We don't preserve the verbatim text, so
-            // we map our DataType back to the canonical SQLite-flavor name.
-            let type_str = sqlite_declared_type(&column.data_type, column.is_exact_integer_type);
+            let decl = decl_facts.get(&column.name.to_lowercase());
 
-            // notnull: 1 if NOT NULL, else 0. SQLite implicitly marks INTEGER
-            // PRIMARY KEY rowid alias columns as NOT NULL.
-            let notnull = if !column.nullable { 1 } else { 0 };
+            // Type column: SQLite reports the declared type as supplied in the
+            // CREATE TABLE statement. A typeless column reports the empty
+            // string; otherwise we map our DataType back to the canonical
+            // SQLite-flavor name (we don't preserve the verbatim text).
+            let type_str = if matches!(decl, Some((true, _))) {
+                String::new()
+            } else {
+                sqlite_declared_type(&column.data_type, column.is_exact_integer_type)
+            };
+
+            // notnull: 1 only for an *explicit* NOT NULL clause. An INTEGER
+            // PRIMARY KEY rowid alias is internally non-nullable but SQLite
+            // still reports notnull=0. Prefer the re-parsed declaration; fall
+            // back to the catalog nullable flag when no source is available.
+            let notnull = match decl {
+                Some((_, explicit_not_null)) => {
+                    if *explicit_not_null {
+                        1
+                    } else {
+                        0
+                    }
+                }
+                None => {
+                    if !column.nullable {
+                        1
+                    } else {
+                        0
+                    }
+                }
+            };
 
             // dflt_value: render the default expression as SQL text, or NULL.
             let dflt_value: Option<String> = column.default_value.as_ref().map(|e| {

--- a/crates/vibesql-cli/src/executor/tests.rs
+++ b/crates/vibesql-cli/src/executor/tests.rs
@@ -756,6 +756,39 @@ fn test_pragma_collation_list_builtins() {
 }
 
 #[test]
+fn test_pragma_table_info_typeless_column_reports_empty_type() {
+    // A column declared without a datatype (`CREATE TABLE t(a)`) has BLOB
+    // affinity internally, but SQLite's table_info reports an *empty* declared
+    // type for it, not "BLOB". Regression guard for #6175 (pragma-6.2.2/6.2.3).
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor.execute("CREATE TABLE t(a, b TEXT, c)").unwrap();
+
+    let result = executor.execute("PRAGMA table_info(t)").unwrap();
+    assert_eq!(result.row_count, 3);
+    // type column is index 2.
+    assert_eq!(result.rows[0][2].as_deref(), Some(""), "typeless column a -> empty type");
+    assert_eq!(result.rows[1][2].as_deref(), Some("TEXT"), "typed column b keeps its type");
+    assert_eq!(result.rows[2][2].as_deref(), Some(""), "typeless column c -> empty type");
+}
+
+#[test]
+fn test_pragma_table_info_integer_primary_key_notnull_is_zero() {
+    // An INTEGER PRIMARY KEY rowid alias is internally non-nullable, but
+    // SQLite's table_info reports notnull=0 for it because there is no
+    // *explicit* NOT NULL clause. An explicit NOT NULL still reports 1.
+    // Regression guard for #6175 (pragma-6.2.3).
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor.execute("CREATE TABLE t(a, b INTEGER PRIMARY KEY, c TEXT NOT NULL)").unwrap();
+
+    let result = executor.execute("PRAGMA table_info(t)").unwrap();
+    assert_eq!(result.row_count, 3);
+    // Columns are cid, name, type, notnull, dflt_value, pk (notnull is index 3).
+    assert_eq!(result.rows[1][3].as_deref(), Some("0"), "INTEGER PRIMARY KEY notnull=0");
+    assert_eq!(result.rows[1][5].as_deref(), Some("1"), "INTEGER PRIMARY KEY pk=1");
+    assert_eq!(result.rows[2][3].as_deref(), Some("1"), "explicit NOT NULL notnull=1");
+}
+
+#[test]
 fn test_pragma_index_info_reports_key_columns() {
     // PRAGMA index_info(idx) returns one row per key column: seqno, cid (table
     // column rank), name. The `= idx` form is accepted the same as `(idx)`.


### PR DESCRIPTION
## Summary

Part of #6175 (PRAGMA support family, epic #5779). Lands the cleanest zero-regression increment of the **schema-introspection PRAGMA cluster**: two `PRAGMA table_info` correctness bugs that were the single most frequently recurring in-scope failure across `pragma.test` and `pragma4.test`.

Both bugs stem from `table_info` reading VibeSQL's internal affinity/rowid state instead of the original column *declaration*:

1. **Typeless columns printed `BLOB`.** A column declared without a datatype (`CREATE TABLE t(a)`) folds into BLOB affinity internally, so `table_info` printed `BLOB` for its type. SQLite reports an **empty** declared type.
2. **`INTEGER PRIMARY KEY` printed `notnull=1`.** The rowid alias is internally non-nullable (`nullable = false`), so `table_info` printed `notnull=1`. SQLite reports `notnull=0` because there is no *explicit* `NOT NULL` clause.

## Approach

`execute_pragma_table_info` now re-parses the persisted verbatim `sql_source` (the same rehydrate-from-source pattern the storage layer already uses for CHECK/FK constraints and the INTEGER-PK rowid alias) to recover:
- the typeless flag (`ColumnDef::type_source == None`) → empty type
- the explicit `NOT NULL` constraint → `notnull` value

When no source is available (programmatically-built tables, `CREATE ... AS SELECT`, or a re-parse failure) it **falls back to the previous catalog-derived behavior unchanged**. Typed columns are untouched — the change only affects the two quirks above. No new serialized fields, so **no binary format-version bump**.

## Verification

- `PRAGMA table_info` on `(a, b INTEGER PRIMARY KEY, c)` now reports empty types and `notnull=0` for the rowid alias; typed columns (`TEXT NOT NULL`, `INT`, `VARCHAR(50) DEFAULT 'x'`) are byte-identical to before.
- TCL: `pragma.test` 38→40 passed, `pragma4.test` 2→3 passed, **zero regressions** across `pragma.test`, `pragma2/3/4/6.test`. Newly green includes `pragma-6.2.3`.
- Full `vibesql-cli` unit suite green (162 + integration tests), plus two new focused regression tests.
- `cargo build --release` clean; no new clippy warnings in the edited files.

## Scope / remaining follow-ups (this is a partial increment)

The ~205-failure family is dominated by items **out of scope for this surgical introspection fix**:

- **Bucket-A (pager/journal internals) → route to #6154:** all of `pragma2.test` (`freelist_count`, `cache_spill`, `lock_status`), `pragma-1.*`/`pragma-5.*` (`synchronous`, `default_cache_size` file-header persistence), `pragma-14.*` (`page_count`/`max_page_count`), `pragma-16.*` (proxy locking). These reproduce SQLite's on-disk file format and pager semantics and should not be forced green.
- **Multi-connection / ATTACH / C-API (out of CLI scope):** `pragma3.test` cross-connection `data_version`; `pragma-8.*` `schema_version` with `SQLITE_SCHEMA` reload via `sqlite3_prepare`/`sqlite3_step`; `pragma4.test` 4.1.x/4.3.x/4.6.x which depend on `ATTACH` (VibeSQL: `near "ATTACH": syntax error`).
- **Raw-protocol NULL-vs-empty distinction:** `pragma-6.2.2` now returns the correct empty type, but the TCL shim's raw protocol cannot distinguish `""` from `NULL`, so a customized `db nullvalue` still renders it as the null token. Needs a shim/protocol change, tracked separately from introspection semantics.
- Remaining introspection gaps not in this increment: `PRAGMA table_info` composite-PK `pk` position dedup (`pragma-6.8`), temp-vs-main table resolution (`pragma-6.6.3/6.6.4`), `capture_pragma` dynamic-SQL path (`pragma-6.4/6.5.1/6.7`).

Part of #6175

🤖 Generated with [Claude Code](https://claude.com/claude-code)