### PR TITLE
fix(trigger): place a trigger on a temp table in the temp schema

### DIFF
--- a/crates/vibesql-executor/src/trigger_ddl.rs
+++ b/crates/vibesql-executor/src/trigger_ddl.rs
@@ -138,10 +138,34 @@ impl TriggerExecutor {
             }
         }
 
+        // SQLite auto-assigns a trigger to the temp schema whenever its target
+        // table lives in the temp schema, even when the statement carries no
+        // `TEMP` keyword and no `temp.` qualifier (trigger1-1.8). Such a trigger
+        // must surface via `sqlite_temp_master` (and stay out of the main
+        // `sqlite_master`), mirroring `CREATE TEMP TRIGGER`. When the user gave
+        // an explicit schema we honor it verbatim; otherwise resolve the target
+        // table's schema and promote the trigger to `temp` if the table is temp.
+        let effective_schema = match &stmt.schema {
+            Some(schema) => Some(schema.clone()),
+            None => {
+                let target_in_temp_schema = db
+                    .catalog
+                    .resolve_table_schema_name(&stmt.table_name)
+                    .as_deref()
+                    .is_some_and(vibesql_catalog::Catalog::is_temp_schema);
+                if target_in_temp_schema {
+                    Some("temp".to_string())
+                } else {
+                    None
+                }
+            }
+        };
+
         // Create trigger definition from statement, preserving original SQL when available.
-        // The trigger's schema (from `CREATE TEMP TRIGGER` or an explicit
-        // `schema.` prefix) is threaded through so it binds to the correct
-        // table when a temp table shadows a main table of the same name.
+        // The trigger's schema (from `CREATE TEMP TRIGGER`, an explicit
+        // `schema.` prefix, or auto-promotion for a temp-table target above) is
+        // threaded through so it binds to the correct table when a temp table
+        // shadows a main table of the same name.
         let trigger = match original_sql {
             Some(sql) => TriggerDefinition::new_with_sql(
                 stmt.trigger_name.clone(),
@@ -163,7 +187,7 @@ impl TriggerExecutor {
                 stmt.triggered_action.clone(),
             ),
         }
-        .with_schema(stmt.schema.clone());
+        .with_schema(effective_schema);
 
         // Store in catalog
         db.catalog.create_trigger(trigger)?;

--- a/crates/vibesql-executor/tests/trigger_temp_schema_firing_tests.rs
+++ b/crates/vibesql-executor/tests/trigger_temp_schema_firing_tests.rs
@@ -47,6 +47,21 @@ fn exec(db: &mut Database, sql: &str) {
     }
 }
 
+/// Returns the first-column text values of an arbitrary introspection query
+/// (used to read trigger names from `sqlite_master` / `sqlite_temp_master`).
+fn names(db: &Database, sql: &str) -> Vec<String> {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).expect("parse failed");
+    let Statement::Select(select) = stmt else { panic!("expected SELECT") };
+    let rows = SelectExecutor::new(db).execute(&select).expect("SELECT failed");
+    rows.iter()
+        .map(|r| match &r.values[0] {
+            SqlValue::Varchar(s) | SqlValue::Character(s) => s.to_string(),
+            other => panic!("expected text, got {other:?}"),
+        })
+        .collect()
+}
+
 /// Returns the ordered `y` column of `t301` as i64s (insertion order).
 fn log_values(db: &Database) -> Vec<i64> {
     use vibesql_ast::Statement;
@@ -135,6 +150,68 @@ fn temp_trigger_on_main_only_table_fires() {
         log_values(&db),
         vec![7],
         "a temp trigger on a main-only table must bind to and fire for the main table"
+    );
+}
+
+/// A plain `CREATE TRIGGER` (no `TEMP` keyword, no `temp.` qualifier) whose
+/// target table lives in the temp schema is auto-promoted to the temp schema,
+/// exactly as SQLite does (trigger1-1.8). It must surface via
+/// `sqlite_temp_master`, stay out of the main `sqlite_master`, and still fire.
+#[test]
+fn plain_trigger_on_temp_table_is_promoted_to_temp_schema() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TEMP TABLE tt(x);");
+    exec(&mut db, "CREATE TABLE t301(y);");
+    // Note: no TEMP keyword and no schema qualifier on the trigger.
+    exec(
+        &mut db,
+        "CREATE TRIGGER trg AFTER INSERT ON tt \
+         BEGIN INSERT INTO t301 VALUES(new.x); END;",
+    );
+
+    // The trigger must NOT appear in the main schema introspection view...
+    assert!(
+        names(&db, "SELECT name FROM sqlite_master WHERE type='trigger';").is_empty(),
+        "a trigger on a temp table must not leak into main sqlite_master (trigger1-1.8)"
+    );
+    // ...and MUST appear in the temp-schema introspection view.
+    assert_eq!(
+        names(&db, "SELECT name FROM sqlite_temp_master WHERE type='trigger';"),
+        vec!["trg".to_string()],
+        "a trigger on a temp table must surface via sqlite_temp_master"
+    );
+
+    // It still fires for inserts into the temp table.
+    exec(&mut db, "INSERT INTO tt VALUES(5);");
+    assert_eq!(
+        log_values(&db),
+        vec![5],
+        "the auto-promoted temp trigger must still fire on its temp table"
+    );
+}
+
+/// An explicit schema qualifier is always honored verbatim: a `main.`-qualified
+/// trigger on a main-only table stays in the main schema and appears in
+/// `sqlite_master` (guards the promotion above from over-reaching).
+#[test]
+fn qualified_main_trigger_stays_in_main_schema() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE base(x);");
+    exec(&mut db, "CREATE TABLE t301(y);");
+    exec(
+        &mut db,
+        "CREATE TRIGGER main.r AFTER INSERT ON base \
+         BEGIN INSERT INTO t301 VALUES(new.x); END;",
+    );
+
+    assert_eq!(
+        names(&db, "SELECT name FROM sqlite_master WHERE type='trigger';"),
+        vec!["r".to_string()],
+        "a main-schema trigger on a main table must appear in sqlite_master"
+    );
+    assert!(
+        names(&db, "SELECT name FROM sqlite_temp_master WHERE type='trigger';").is_empty(),
+        "a main-schema trigger must not appear in sqlite_temp_master"
     );
 }
 


### PR DESCRIPTION
## Summary

A `CREATE TRIGGER` whose target table lives in the session temp schema is now
auto-assigned to the temp schema even when the statement carries no `TEMP`
keyword and no `temp.` qualifier — matching SQLite (`trigger1-1.8`: *"A trigger
created on a TEMP table is not inserted into sqlite_master"*). Such a trigger
now surfaces via `sqlite_temp_master` and no longer leaks into the main
`sqlite_master`. This is a focused, zero-regression increment of the trigger /
DROP TRIGGER / DROP VIEW family (#6176).

## Changes

- `crates/vibesql-executor/src/trigger_ddl.rs`: in `create_trigger_with_sql`,
  when the statement gives no explicit schema, resolve the target table's schema
  via `Catalog::resolve_table_schema_name` (temp shadows main for unqualified
  names) and promote the trigger to the `temp` schema if the table is temp.
  An explicit `schema.` qualifier is still honored verbatim.
- `crates/vibesql-executor/tests/trigger_temp_schema_firing_tests.rs`: adds two
  tests — (1) a plain trigger on a temp table is promoted to temp, is absent
  from `sqlite_master`, present in `sqlite_temp_master`, and still fires; (2) a
  `main.`-qualified trigger on a main table stays in `sqlite_master` (guards the
  promotion from over-reaching).

## Root cause

`CREATE TRIGGER temp_trig UPDATE ON temp_table ...` (no `TEMP` keyword) on a
temp table was stored in the main schema, so it appeared in `sqlite_master`.
Direct repro before/after:

```
CREATE TEMP TABLE temp_table(a);
CREATE TRIGGER temp_trig UPDATE ON temp_table BEGIN SELECT 1; END;
SELECT name FROM sqlite_master;        -- before: temp_trig  | after: (empty)
SELECT name FROM sqlite_temp_master;   -- before: (absent)   | after: temp_trig
```

## Scope / closing discipline

This is a **partial** increment of the ~152-failure family, so it uses
**`Part of #6176`** (not `Closes`). It deliberately targets the clean,
zero-regression trigger-schema-binding root cause and leaves the rest as
follow-ups.

### Why the TCL headline count for this family does not move here

The two evidence suites (`e_droptrigger` 59, `e_dropview` 25) are dominated by
`ATTACH`/aux-database and cross-schema semantics VibeSQL does not implement
(`near "ATTACH": syntax error`) — out of scope for a clean increment. The
`trigger1` temp cluster (`1.8`, `6.*`, `8.*`) is **masked by the TCL shim**,
which demotes an implicit TEMP table to a persistent main table (per-process
CLI model, `scripts/tester_vibesql.tcl` #5591), so at the engine boundary the
table is `main` and the trigger is (correctly, for that demoted world) a main
trigger. The engine fix here is nonetheless the SQLite-correct behavior and is
locked in by direct unit tests rather than the shim-masked TCL rows.

### Remaining sub-features (follow-ups)

- `ATTACH DATABASE` support to unblock `e_droptrigger` / `e_dropview` evidence suites.
- TCL-shim: replay implicit-TEMP triggers (trigger on a demoted temp table) so `trigger1-1.8/6.*/8.*` reflect the engine behavior.
- `triggerC` subtle firing/row-order cases (`4.1.5`, `5.1.7`, `7.5`) and the `UNIQUE constraint failed: <table>.<col>` message format.
- `triggerB` `no such column: old.<col>` qualifier preservation in trigger scope errors.

## Acceptance Criteria Verification

| Criterion (from #6176) | Status | Verification |
|---|---|---|
| Trigger on a TEMP table not inserted into `sqlite_master` (`trigger1-1.8`) | Done | Engine repro + new executor tests; absent from `sqlite_master`, present in `sqlite_temp_master` |
| Zero regressions across the trigger family | Done | `trigger1..9`, `triggerA..G`, `temptrigger` show no new failures; 3520 executor lib tests + temp/schema integration suites pass |
| `e_droptrigger` / `e_dropview` pass | Deferred | Blocked on `ATTACH` support (documented follow-up) |

## Test Plan

- `cargo test -p vibesql-executor --test trigger_temp_schema_firing_tests` — 6 passed.
- `cargo test -p vibesql-executor --lib` — 3520 passed, 0 failed.
- `cargo test -p vibesql-executor --test sqlite_temp_master_tests / sqlite_schema_tests / temp_view_dml_missing_table_unqualified_tests` — all pass.
- `make test-tcl-file FILE=trigger1.test / triggerC.test` and the full `trigger*`/`triggerA-G`/`temptrigger` family — no new failures introduced.
- `cargo build --release` — clean.

Part of #6176