### PR TITLE
fix(executor): auto-name VALUES columns column1..N across CTE, compound ORDER BY, and CTAS

### DIFF
--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -904,6 +904,29 @@ impl CreateTableExecutor {
         for item in select_list {
             match item {
                 vibesql_ast::SelectItem::Wildcard { .. } => {
+                    // A `SELECT * FROM (VALUES ...)` source has no catalog table
+                    // to look up. SQLite names the resulting columns `column1`,
+                    // `column2`, ... (or the explicit `AS t(a,b)` aliases) and
+                    // gives them no declared type (BLOB/None affinity). Handle
+                    // this before the table-name path, which cannot resolve a
+                    // VALUES clause (values.test 17.1).
+                    if let Some(vibesql_ast::FromClause::Values { rows, column_aliases, .. }) = from
+                    {
+                        let aliases = column_aliases.as_deref().unwrap_or(&[]);
+                        let width = if !aliases.is_empty() {
+                            aliases.len()
+                        } else {
+                            rows.first().map(|r| r.len()).unwrap_or(0)
+                        };
+                        for i in 0..width {
+                            let name = aliases
+                                .get(i)
+                                .cloned()
+                                .unwrap_or_else(|| format!("column{}", i + 1));
+                            columns.push((name, TypeAffinity::None));
+                        }
+                        continue;
+                    }
                     // Expand wildcard using the FROM clause tables
                     let table_names = Self::get_table_names_from_from(from)?;
                     for table_name in table_names {

--- a/crates/vibesql-executor/src/select/cte.rs
+++ b/crates/vibesql-executor/src/select/cte.rs
@@ -743,6 +743,29 @@ pub(super) fn derive_cte_schema(
 
             Ok(cte_pseudo_schema(cte.name.clone(), columns))
         }
+    } else if cte.query.values.is_some() {
+        // A CTE whose body is a bare `VALUES (...)` clause has no select_list to
+        // infer names from. SQLite auto-names such columns `column1`, `column2`,
+        // ... so `WITH v AS (VALUES('a','b')) SELECT column1 FROM v` and
+        // `SELECT * FROM v` resolve (values.test 8.1.*). Derive the width from
+        // the materialized rows (falling back to the VALUES AST row width when
+        // the result set is empty).
+        let width = rows
+            .first()
+            .map(|r| r.values.len())
+            .or_else(|| cte.query.values.as_ref().and_then(|vr| vr.first()).map(|r| r.len()))
+            .unwrap_or(0);
+        let columns = (0..width)
+            .map(|i| {
+                let data_type = rows
+                    .first()
+                    .and_then(|first_row| first_row.values.get(i))
+                    .map(infer_type_from_value)
+                    .unwrap_or(vibesql_types::DataType::Varchar { max_length: Some(255) });
+                vibesql_catalog::ColumnSchema::new(format!("column{}", i + 1), data_type, true)
+            })
+            .collect();
+        Ok(cte_pseudo_schema(cte.name.clone(), columns))
     } else {
         // No explicit column names - infer from query SELECT list.
         // Wildcard items are statically expanded into the column names of the

--- a/crates/vibesql-executor/src/select/executor/set_operations.rs
+++ b/crates/vibesql-executor/src/select/executor/set_operations.rs
@@ -522,6 +522,20 @@ pub(super) fn collect_select_aliases(
 ) -> Vec<Option<String>> {
     let mut aliases = Vec::new();
 
+    // A VALUES clause (e.g. `VALUES(1,2),(3,4)`) carries no select_list; its
+    // columns are auto-named `column1`, `column2`, ... by SQLite. When such a
+    // clause is the left arm of a compound (`VALUES(...) UNION ALL SELECT ...`),
+    // ORDER BY resolution needs the correct column count/names from this branch
+    // (otherwise the branch reports zero columns and every ORDER BY term is
+    // rejected as out of range — see values.test 2.3 / 9.1).
+    if let Some(rows) = &stmt.values {
+        let width = rows.first().map(|r| r.len()).unwrap_or(0);
+        for i in 0..width {
+            aliases.push(Some(format!("column{}", i + 1)));
+        }
+        return aliases;
+    }
+
     // Pre-compute column names from FROM clause for wildcard expansion
     let from_columns = extract_column_names_from_from(database, stmt.from.as_ref());
     let mut from_col_idx = 0;

--- a/crates/vibesql-executor/tests/with_values_tests.rs
+++ b/crates/vibesql-executor/tests/with_values_tests.rs
@@ -205,3 +205,81 @@ fn test_from_values_subquery_sees_cte() {
         query(&db, "WITH c AS (SELECT 11) SELECT * FROM (VALUES((SELECT * FROM c))) AS v(x)");
     assert_eq!(rows, vec![vec![SqlValue::Integer(11)]]);
 }
+
+// ---------------------------------------------------------------------------
+// Regression tests for issue #6190 (values.test VALUES-clause semantics).
+// Expected values verified against SQLite's values.test.
+// ---------------------------------------------------------------------------
+
+/// A `WITH v AS (VALUES ...)` CTE with no explicit column list auto-names its
+/// columns `column1`, `column2`, ... (values.test 8.1.*). Previously the CTE
+/// materialized zero named columns, so `column1` did not resolve.
+#[test]
+fn test_with_values_cte_auto_column_names() {
+    let db = vibesql_storage::Database::new();
+    let rows = query(&db, "WITH v AS (VALUES('a','b'),('c','d')) SELECT column1 FROM v");
+    assert_eq!(
+        rows,
+        vec![
+            vec![SqlValue::Varchar(arcstr::ArcStr::from("a"))],
+            vec![SqlValue::Varchar(arcstr::ArcStr::from("c"))],
+        ]
+    );
+}
+
+/// `SELECT *` over such a CTE expands to the auto-named `column1`, `column2`.
+#[test]
+fn test_with_values_cte_star_expansion() {
+    let db = vibesql_storage::Database::new();
+    let rows = query(&db, "WITH v AS (VALUES('a','b'),('c','d')) SELECT * FROM v");
+    assert_eq!(
+        rows,
+        vec![
+            vec![
+                SqlValue::Varchar(arcstr::ArcStr::from("a")),
+                SqlValue::Varchar(arcstr::ArcStr::from("b"))
+            ],
+            vec![
+                SqlValue::Varchar(arcstr::ArcStr::from("c")),
+                SqlValue::Varchar(arcstr::ArcStr::from("d"))
+            ],
+        ]
+    );
+}
+
+/// A VALUES clause as the left arm of a compound with a trailing `ORDER BY <n>`
+/// must resolve the ordinal against the VALUES column count (values.test 9.1).
+/// Previously the VALUES branch reported zero columns, so `ORDER BY 1` was
+/// rejected as "1st ORDER BY term out of range".
+#[test]
+fn test_values_left_arm_compound_order_by() {
+    let db = vibesql_storage::Database::new();
+    let rows = query(&db, "VALUES(456),(123),(NULL) UNION ALL SELECT 122 ORDER BY 1");
+    assert_eq!(
+        rows,
+        vec![
+            vec![SqlValue::Null],
+            vec![SqlValue::Integer(122)],
+            vec![SqlValue::Integer(123)],
+            vec![SqlValue::Integer(456)],
+        ]
+    );
+}
+
+/// `CREATE TABLE ... AS SELECT * FROM (VALUES ...)` names the derived columns
+/// `column1`, `column2`, ... rather than erroring (values.test 17.1 / 17.2).
+#[test]
+fn test_ctas_from_values_star() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t1 AS SELECT * FROM (VALUES(1,2),(3,4 IN (1,2,3)))");
+    let rows = query(&db, "SELECT column1, column2 FROM t1");
+    // `4 IN (1,2,3)` is a boolean predicate, stored internally as Boolean(false)
+    // (rendered as 0 by the CLI, matching SQLite's values.test 17.2 output).
+    assert_eq!(
+        rows,
+        vec![
+            vec![SqlValue::Integer(1), SqlValue::Integer(2)],
+            vec![SqlValue::Integer(3), SqlValue::Boolean(false)],
+        ]
+    );
+}


### PR DESCRIPTION
## Summary

A bare `VALUES (...)` clause carries no `select_list`; SQLite auto-names its columns `column1`, `column2`, ... Three executor code paths ignored this and treated such a clause as producing **zero named columns**, causing 17 of the 33 `values.test` failures. This PR fixes all three, cutting `values.test` failures from **33 to 16** (73 -> 93 passing, 64.6% -> 82.3%).

This is a partial fix of the ~33-failure family — hence **Part of #6190**, not Closes.

## Changes

- **Compound ORDER BY** (`set_operations.rs::collect_select_aliases`): a `VALUES` clause used as the left arm of a compound contributed no aliases, so `VALUES(...) UNION ALL SELECT ... ORDER BY <n>` reported the branch as 0-column and rejected every ordinal with "1st ORDER BY term out of range - should be between 1 and 1". Now synthesizes `column1..N` from the VALUES row width. (fixes values.test 2.3, 9.1)
- **CTE schema** (`cte.rs::derive_cte_schema`): a `WITH v AS (VALUES ...)` body with no explicit column list materialized zero named columns, so `column1` and `SELECT *` did not resolve. Now names such columns `column1..N`. (fixes values.test 8.1.1.3, 8.1.2.3, and related WITH-form rows)
- **CTAS** (`create_table.rs::derive_ctas_columns`): `CREATE TABLE t AS SELECT * FROM (VALUES ...)` errored as an unsupported feature. Now expands the VALUES wildcard to `column1..N` (or the explicit `AS t(a,b)` aliases) with no declared type affinity, matching SQLite. This also unblocked the entire section-17/18 cascade (those tests failed only because their `t1` was never created). (fixes values.test 17.1, 17.2, 18.1–18.5)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `make test-tcl-file FILE=values.test` reports strictly fewer than 33 failures | Yes | 33 -> 16 failures (93/113 passing) on a fresh `--release` build |
| `filescope-err` cascade marker resolved or explained | Explained | Persists — it is a harness gap (`invalid command name "explain_i"`, a missing TCL shim proc), not an engine wrong-answer; out of scope for engine work |
| `do_catchsql_test` rows pass with SQLite-verbatim messages | Partial | The term-count `do_catchsql` rows (2.1.x) already passed; the RAISE `do_catchsql` rows (18.x) now pass via the CTAS-cascade fix |
| No regression in Rust unit/integration VALUES tests | Yes | `cargo test -p vibesql-executor` green (exit 0); new `with_values_tests` cases added |
| No new failures in other Priority-1/2 files on shared paths | Yes | `with1.test` unchanged vs certified baseline (88 pass / 25 fail), `select4.test` 100% |

## Remaining failures (out of scope for this PR — separate subsystems, tracked under #6190)

- **Window functions inside VALUES rows** (`row_number() OVER ()` — 3.1.x, 3.2.1, 16.2/4/6): requires the VALUES-as-coroutine transformation.
- **EXPLAIN QUERY PLAN tree formatting** for VALUES (`SCAN N-ROW VALUES CLAUSE` — 15.x, 16.3/5/7): EQP renderer subsystem.
- **RIGHT JOIN row ordering** with a VALUES source (8.1.3.x, 8.1.4.x): correctness rows differ only in iteration order; changing join order is high-regression-risk.
- **Scalar-subquery / comma-join VALUES** (6.1): `SELECT (VALUES(x),(x))` correlation and unaliased `_values_` in a comma join.
- **`explain_i` harness proc** (filescope-err.1): TCL shim gap, not an engine issue.

## Test Plan

- `cargo build --release` clean.
- `make test-tcl-file FILE=values.test`: 16 failures (down from 33), zero regressions among previously-passing rows.
- `cargo test -p vibesql-executor` green, including 4 new regression tests in `crates/vibesql-executor/tests/with_values_tests.rs` (CTE auto-column-names, `SELECT *` expansion, compound-ORDER-BY, CTAS-from-VALUES).
- Cross-file regression: `with1.test` (88/25, identical to certified run_id=1) and `select4.test` (100%).

Part of #6190

🤖 Generated with [Claude Code](https://claude.com/claude-code)