### PR TITLE
fix(cte): detect circular CTE references and match SQLite arity error wording

### DIFF
--- a/crates/vibesql-executor/src/select/cte.rs
+++ b/crates/vibesql-executor/src/select/cte.rs
@@ -232,7 +232,37 @@ where
     let mut states = vec![CteState::Pending; ctes.len()];
     let mut local = HashMap::new();
 
-    for idx in 0..ctes.len() {
+    // Process order: CTEs the root statement references directly come first
+    // (in declaration order among them), then the rest. SQLite resolves CTEs
+    // lazily from the query that reads them, so a circular reference is named
+    // by the member closest to that query — starting resolution from the
+    // root's direct references makes the reported name match (with1.test 3.1,
+    // with2.test 3.4). When no root is provided (DML paths), this reduces to
+    // plain declaration order.
+    let process_order: Vec<usize> = {
+        let mut root_refs = HashSet::new();
+        if let Some(stmt) = root {
+            collect_stmt_table_refs(stmt, &HashSet::new(), true, false, &mut root_refs);
+        }
+        let (mut first, mut rest): (Vec<usize>, Vec<usize>) = (Vec::new(), Vec::new());
+        for (idx, cte) in ctes.iter().enumerate() {
+            if root_refs.contains(&cte.name.to_ascii_lowercase()) {
+                first.push(idx);
+            } else {
+                rest.push(idx);
+            }
+        }
+        first.into_iter().chain(rest).collect()
+    };
+
+    // When a root statement is provided, `needed[]` has pruned this list to only
+    // the CTEs the statement (transitively) references, so any CTE that reaches
+    // execute_cte_at is genuinely referenced. DML paths pass no root and execute
+    // every CTE eagerly, where an unreferenced CTE must NOT be validated
+    // (SQLite never evaluates it — with1.test 1.2/1.4).
+    let stmt_scoped = root.is_some();
+
+    for idx in process_order {
         if needed[idx] && states[idx] == CteState::Pending {
             let hint =
                 if hinted_cte.as_deref().is_some_and(|h| ctes[idx].name.eq_ignore_ascii_case(h)) {
@@ -248,6 +278,7 @@ where
                 outer_ctes,
                 in_progress,
                 nested,
+                stmt_scoped,
                 hint,
                 database,
                 executor,
@@ -270,6 +301,7 @@ fn execute_cte_at<F, M>(
     outer_ctes: &HashMap<String, CteResult>,
     in_progress: &mut Vec<String>,
     nested: bool,
+    stmt_scoped: bool,
     outer_row_hint: Option<usize>,
     database: &vibesql_storage::Database,
     executor: &F,
@@ -307,29 +339,43 @@ where
     // A WITH clause brings all its member names into scope at once (SQLite), so
     // a body may reference a sibling declared later in the list — at the top
     // level (with1.test 2.5) as well as in nested lists (with2.test 1.11).
-    // Materialize referenced siblings first; a chain that loops back to a CTE
-    // still InFlight is reported as a circular reference by execute_cte_at.
+    // Materialize referenced siblings first; a chain that loops back to a
+    // sibling still InFlight is a mutual circular reference (with2.test
+    // 3.2/3.3/3.4). SQLite names such a cycle by the referenced InFlight member,
+    // which — because the list is processed starting from the CTEs the root
+    // query reads directly (see execute_cte_list) — is the entry CTE closest to
+    // the triggering query (with1.test 3.1, with2.test 3.4).
     for sib_idx in 0..ctes.len() {
-        if sib_idx != idx
-            && states[sib_idx] == CteState::Pending
-            && body_refs.contains(&ctes[sib_idx].name.to_ascii_lowercase())
-        {
-            execute_cte_at(
-                sib_idx,
-                ctes,
-                states,
-                local,
-                outer_ctes,
-                in_progress,
-                nested,
-                // A sibling materialized on demand is not the CTE the outer
-                // statement reads directly, so the outer LIMIT hint never
-                // applies to it.
-                None,
-                database,
-                executor,
-                memory_check,
-            )?;
+        if sib_idx == idx || !body_refs.contains(&ctes[sib_idx].name.to_ascii_lowercase()) {
+            continue;
+        }
+        match states[sib_idx] {
+            CteState::Pending => {
+                execute_cte_at(
+                    sib_idx,
+                    ctes,
+                    states,
+                    local,
+                    outer_ctes,
+                    in_progress,
+                    nested,
+                    stmt_scoped,
+                    // A sibling materialized on demand is not the CTE the outer
+                    // statement reads directly, so the outer LIMIT hint never
+                    // applies to it.
+                    None,
+                    database,
+                    executor,
+                    memory_check,
+                )?;
+            }
+            CteState::InFlight => {
+                return Err(ExecutorError::SqliteCompatError(format!(
+                    "circular reference: {}",
+                    ctes[sib_idx].name
+                )));
+            }
+            CteState::Done => {}
         }
     }
 
@@ -386,6 +432,15 @@ where
                 cte.name
             )));
         }
+    } else if !shadowed_by_inner && body_refs.contains(&name_lower) {
+        // A non-recursive CTE whose body references its own name is circular:
+        // the name is in scope within the body (shadowing any real table), but a
+        // non-UNION self-reference cannot be materialized. SQLite reports
+        // "circular reference: <name>" (with2.test 3.1, e.g.
+        // `WITH i(x,y) AS (VALUES(1,(SELECT x FROM i)))`). Names redefined by
+        // the body's own nested WITH (shadowed_by_inner) are excluded — those
+        // resolve to the inner definition, not a self-reference.
+        return Err(ExecutorError::SqliteCompatError(format!("circular reference: {}", cte.name)));
     }
 
     // Build the visible CTE context for this body: enclosing scopes first,
@@ -393,6 +448,36 @@ where
     let mut visible = outer_ctes.clone();
     for (name, result) in local.iter() {
         visible.insert(name.clone(), result.clone());
+    }
+
+    // When a CTE declares an explicit column list, SQLite validates its arity
+    // against the CTE body's (leftmost/base term) output columns up front —
+    // before evaluating the body or checking UNION-term consistency. A mismatch
+    // is reported as `table <name> has <n> values for <m> columns`
+    // (with1.test 5.6.1-5.6.4/5.6.7, with3.test 6.0/6.1). This static check
+    // fires even when the body would produce no rows (with1.test 5.6.3) and
+    // takes precedence over the "same number of result columns" UNION check
+    // (with1.test 5.6.4/5.6.7). Wildcards are resolved against the visible CTE
+    // context and catalog; if the base arity cannot be determined statically we
+    // defer to the row-based check in derive_cte_schema.
+    //
+    // Only stmt-scoped lists (where `needed[]` proved this CTE is referenced)
+    // are validated: SQLite never evaluates an unreferenced CTE, so a
+    // `WITH x(a) AS (SELECT * FROM two_col_table) INSERT ...` where `x` is
+    // unused must not raise an arity error (with1.test 1.2/1.4).
+    if stmt_scoped {
+        if let Some(declared) = &cte.columns {
+            if let Some(base_cols) = collect_select_list_columns(&cte.query, database, &visible) {
+                if base_cols.len() != declared.len() {
+                    return Err(ExecutorError::SqliteCompatError(format!(
+                        "table {} has {} values for {} columns",
+                        cte.name,
+                        base_cols.len(),
+                        declared.len()
+                    )));
+                }
+            }
+        }
     }
 
     // Execute the body with this CTE's name marked in-progress so nested WITH
@@ -709,10 +794,15 @@ pub(super) fn derive_cte_schema(
         // Get data types from first row (if available)
         if let Some(first_row) = rows.first() {
             if first_row.values.len() != column_names.len() {
-                return Err(ExecutorError::UnsupportedFeature(format!(
-                    "CTE column count mismatch: specified {} columns but query returned {}",
-                    column_names.len(),
-                    first_row.values.len()
+                // SQLite's wording: `table <name> has <values> values for
+                // <columns> columns` (with1.test 5.6.x, with3.test 6.0/6.1).
+                // Reached only when the static pre-check in execute_cte_at could
+                // not resolve the base arity (e.g. an exotic FROM source).
+                return Err(ExecutorError::SqliteCompatError(format!(
+                    "table {} has {} values for {} columns",
+                    cte.name,
+                    first_row.values.len(),
+                    column_names.len()
                 )));
             }
 
@@ -1260,7 +1350,10 @@ where
         (count_stmt_columns(&base_query), count_stmt_columns(recursive_query))
     {
         if base_count != recursive_count {
-            return Err(ExecutorError::UnsupportedFeature(
+            // SQLite reports this verbatim (no "Unsupported feature:" prefix)
+            // for a recursive CTE whose terms disagree in arity
+            // (with1.test 5.6.6).
+            return Err(ExecutorError::SqliteCompatError(
                 "SELECTs to the left and right of UNION ALL do not have the same number of result columns".to_string()
             ));
         }

--- a/crates/vibesql-executor/src/tests/recursive_cte_tests.rs
+++ b/crates/vibesql-executor/src/tests/recursive_cte_tests.rs
@@ -740,3 +740,110 @@ fn test_recursive_cte_order_by_matches_select_alias() {
     .unwrap();
     assert_eq!(ints(&by_recursive), vec![1, 2, 3, 4, 5]);
 }
+
+/// Circular-reference detection and SQLite-compatible error messages.
+///
+/// Mirrors with2.test 3.1-3.4 and with1.test 3.1: mutual and self circular
+/// references between CTEs must report `circular reference: <name>`, naming the
+/// CTE closest to the query that reads the cycle (issue #6189).
+#[test]
+fn test_cte_circular_reference_errors() {
+    let mut db = vibesql_storage::Database::new();
+
+    // Self-reference in a non-recursive body (with2.test 3.1).
+    let err =
+        execute_sql(&mut db, "WITH i(x, y) AS ( VALUES(1, (SELECT x FROM i)) ) SELECT * FROM i")
+            .unwrap_err();
+    assert_eq!(err.to_string(), "circular reference: i", "self-ref non-recursive CTE");
+
+    // Mutual cycle i -> j -> k -> i, queried via i (with2.test 3.2).
+    let err = execute_sql(
+        &mut db,
+        "WITH i(x) AS ( SELECT * FROM j ), \
+              j(x) AS ( SELECT * FROM k ), \
+              k(x) AS ( SELECT * FROM i ) \
+         SELECT * FROM i",
+    )
+    .unwrap_err();
+    assert_eq!(err.to_string(), "circular reference: i", "3-CTE cycle named by entry i");
+
+    // Same two-CTE cycle read from j must be named by j (with2.test 3.4): the
+    // reported name follows the query's entry point, not declaration order.
+    let err = execute_sql(
+        &mut db,
+        "WITH i(x) AS ( SELECT * FROM (SELECT * FROM j) ), \
+              j(x) AS ( SELECT * FROM (SELECT * FROM i) ) \
+         SELECT * FROM j",
+    )
+    .unwrap_err();
+    assert_eq!(err.to_string(), "circular reference: j", "cycle named by query entry j");
+
+    // Cycle whose members are declared in the reverse of reference order is
+    // still named by the entry the root reads (with1.test 3.1).
+    let err = execute_sql(
+        &mut db,
+        "WITH tmp2(x) AS ( SELECT * FROM tmp1 ), \
+              tmp1(a) AS ( SELECT * FROM tmp2 ) \
+         SELECT * FROM tmp1",
+    )
+    .unwrap_err();
+    assert_eq!(err.to_string(), "circular reference: tmp1", "cycle named by root entry tmp1");
+}
+
+/// CTE arity validation uses SQLite's `table X has N values for M columns`
+/// wording and fires before the UNION-consistency check (issue #6189,
+/// with1.test 5.6.x, with3.test 6.0/6.1).
+#[test]
+fn test_cte_column_count_mismatch_messages() {
+    let mut db = vibesql_storage::Database::new();
+
+    // Declared columns exceed base-term values (with1.test 5.6.1).
+    let err = execute_sql(&mut db, "WITH i(x, y) AS ( VALUES(1) ) SELECT * FROM i").unwrap_err();
+    assert_eq!(err.to_string(), "table i has 1 values for 2 columns");
+
+    // Base term produces more values than declared (with1.test 5.6.2).
+    let err = execute_sql(&mut db, "WITH i(x) AS ( VALUES(1,2) ) SELECT * FROM i").unwrap_err();
+    assert_eq!(err.to_string(), "table i has 2 values for 1 columns");
+
+    // Arity check precedes the UNION-term consistency check (with1.test 5.6.4).
+    let err =
+        execute_sql(&mut db, "WITH i(x) AS ( SELECT 1, 2 UNION ALL SELECT 1 ) SELECT * FROM i")
+            .unwrap_err();
+    assert_eq!(err.to_string(), "table i has 2 values for 1 columns");
+
+    // Empty-body case is still validated statically (with1.test 5.6.3).
+    execute_sql(&mut db, "CREATE TABLE t5(a, b)").unwrap();
+    let err =
+        execute_sql(&mut db, "WITH i(x) AS ( SELECT * FROM t5 ) SELECT * FROM i").unwrap_err();
+    assert_eq!(err.to_string(), "table i has 2 values for 1 columns");
+
+    // Recursive term arity mismatch keeps SQLite's verbatim wording with no
+    // "Unsupported feature:" prefix (with1.test 5.6.6).
+    let err = execute_sql(
+        &mut db,
+        "WITH i(x) AS ( SELECT 1 UNION ALL SELECT x+1, x*2 FROM i ) SELECT * FROM i",
+    )
+    .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "SELECTs to the left and right of UNION ALL do not have the same number of result columns"
+    );
+}
+
+/// An unreferenced CTE with a column-count mismatch is never evaluated, so it
+/// raises no error even in DML statements (issue #6189, with1.test 1.2/1.4).
+#[test]
+fn test_unreferenced_cte_not_validated() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(x INTEGER, y INTEGER)").unwrap();
+
+    // `x(a)` declares one column over a two-column table but is never read by
+    // the INSERT: no arity error.
+    execute_sql(&mut db, "WITH x(a) AS ( SELECT * FROM t1 ) INSERT INTO t1 VALUES(1, 2)")
+        .expect("unreferenced CTE must not be validated");
+
+    // Likewise as a no-op SELECT that does not reference the CTE.
+    let rows = execute_sql(&mut db, "WITH x(a) AS ( SELECT * FROM t1 ) SELECT 10").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Integer(10));
+}


### PR DESCRIPTION
## Summary

Two self-contained clusters of SQLite-compatibility gaps in Common Table Expression handling, both localized to `crates/vibesql-executor/src/select/cte.rs`. Root-cause clustering was done with `make test-tcl-file` + manual reproduction against the release binary. Drives the certified `with*.test` failure family from **53 to 38** (15 fixed) with **zero regressions**.

Partial increment on the ~53-failure family — see "Residual failures" below for why it does not fully close.

## Root-cause clusters addressed

**Cluster A — circular-reference detection & naming** (with2.test 3.1-3.4, with1.test 3.1)
VibeSQL reported `no such table: X` where SQLite reports `circular reference: X`.
- A body reference to a sibling CTE that is still *InFlight* is now a circular reference (mutual cycles `i -> j -> k -> i`).
- A non-recursive CTE whose body references its own name is circular (e.g. `WITH i(x,y) AS (VALUES(1,(SELECT x FROM i)))`).
- CTE processing is seeded from the root statement's *direct* references, so a cycle is named by the member closest to the triggering query — matching SQLite regardless of declaration order (with2.test 3.4 names `j`, with1.test 3.1 names `tmp1`).

**Cluster B — CTE column-count / arity error messages** (with1.test 5.6.1-5.6.4/5.6.6/5.6.7, with3.test 6.0/6.1)
- A declared column list is validated against the base-term output arity up front, emitting SQLite's `table X has N values for M columns` and taking precedence over the UNION-consistency check. Fires even when the body produces no rows (with1.test 5.6.3, static wildcard resolution).
- The recursive-term arity-mismatch error drops its `Unsupported feature:` prefix to match SQLite verbatim (with1.test 5.6.6).
- The static arity check runs **only** for statement-scoped (referenced) CTEs, so an unreferenced CTE is never validated — SQLite never evaluates it (with1.test 1.2/1.4, an initial regression that this guard fixes).

## Changes

- `crates/vibesql-executor/src/select/cte.rs`:
  - `execute_cte_list`: seed processing order from the root's direct references (`stmt_scoped` flag threaded to `execute_cte_at`).
  - `execute_cte_at`: sibling-InFlight -> circular error; non-recursive self-reference -> circular error; static base-arity vs declared-column check (referenced CTEs only).
  - `derive_cte_schema`: fallback arity error reworded to SQLite's form.
  - `execute_recursive_cte`: UNION arity-mismatch error changed to `SqliteCompatError` (no prefix).
- `crates/vibesql-executor/src/tests/recursive_cte_tests.rs`: 3 new regression tests covering circular references, arity messages, and the unreferenced-CTE guard.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| with1 improves from 25 | ✅ | 25 -> 18 (fixed 3.1, 5.6.1/5.6.2/5.6.3/5.6.4/5.6.6/5.6.7) |
| with2/3/5 in-scope failures reduced | ✅ | with2 18->14, with3 4->2, with5 5->3 |
| No regression in passing `with*.test` cases | ✅ | Every file's failure count dropped or held; with1 1.2/1.4 (initially regressed) guarded and passing |
| Root-cause clusters summarized | ✅ | Clusters A/B above, each mapped to code changes |
| Existing Rust CTE suites pass | ✅ | `recursive_cte_tests` 23->26, `with_insert_cte_tests` 12, `with_update_from_cte_tests` 7 all green; full `-p vibesql-executor` suite green |

## Residual failures (out of scope for this increment)

- **with1 10.2-10.6, 10.8.x** — caused by the `insert_into_tree` TCL proc's handling of an unset `parentid` bind variable (harness/shim binding, not the CTE engine; the CTE queries themselves return correct results when run directly). Out of scope per the issue's "do not touch the harness/shim".
- **with5 113/114/120/121/131**, **with2 5.7/5.8/7.x/12.1** — multi-term compound recursive CTEs (mixed UNION/UNION ALL, multiple recursive references) and schema-qualified CTE names; a distinct engine cluster.
- **with1 3.6/26.0, with2 4.1/6.6, with3 1.0/2.1** — parser/syntax-error-message and non-CTE resolution differences.
- **with3 EQP entries** — pre-existing EXPLAIN QUERY PLAN pattern mismatches, not counted failures.

## Test Plan

- `cargo build --release` clean; `cargo clippy -p vibesql-executor` adds no new warnings.
- `make test-tcl-file FILE=with{1,2,3,4,5}.test` before/after: 53 -> 38 failures.
- `cargo test --release -p vibesql-executor` (incl. `recursive_cte_tests`, `with_insert_cte_tests`, `with_update_from_cte_tests`) all green.

Part of #6189

🤖 Generated with [Claude Code](https://claude.com/claude-code)