### PR TITLE
fix(parser): accept USING clause on comma-joins (SQLite compat)

### DIFF
--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -28,12 +28,24 @@ impl Parser {
                     self.advance(); // Consume comma
                     let right = self.parse_table_reference()?;
 
-                    // Check for legacy ON clause after comma-join
-                    // SQLite allows: FROM t1, t2 ON t1.a=t2.b (treated as INNER JOIN)
+                    // Check for a legacy ON or USING clause after a comma-join.
+                    // SQLite treats "," exactly like CROSS/INNER JOIN, so the
+                    // ON/USING filtering clauses are legal after it and turn the
+                    // cartesian product into an inner join:
+                    //   FROM t1, t2 ON t1.a=t2.b
+                    //   FROM t1, t2 USING (a)
+                    // (e_select-0.1.2 / 1.4 / 1.5 / 1.6 / 1.7 comma variants).
                     if self.peek_keyword(Keyword::On) {
                         self.consume_keyword(Keyword::On)?;
                         let condition = self.parse_expression()?;
                         (vibesql_ast::JoinType::Inner, right, Some(condition), None, false)
+                    } else if self.peek_keyword(Keyword::Using) {
+                        self.consume_keyword(Keyword::Using)?;
+                        self.expect_token(Token::LParen)?;
+                        let columns =
+                            self.parse_comma_separated_list(|p| p.parse_column_name())?;
+                        self.expect_token(Token::RParen)?;
+                        (vibesql_ast::JoinType::Inner, right, None, Some(columns), false)
                     } else {
                         (vibesql_ast::JoinType::Cross, right, None, None, false)
                     }

--- a/crates/vibesql-parser/src/tests/joins.rs
+++ b/crates/vibesql-parser/src/tests/joins.rs
@@ -557,6 +557,61 @@ fn test_parse_comma_without_on_still_cross_join() {
 }
 
 #[test]
+fn test_parse_legacy_comma_join_using(/* issue #6192 */) {
+    // SQLite treats "," exactly like CROSS/INNER JOIN, so a USING clause is
+    // legal after a comma-join and turns the cartesian product into an inner
+    // join. Previously the parser accepted `FROM t1, t2 ON ...` but rejected
+    // `FROM t1, t2 USING (...)` with a spurious `near "USING": syntax error`
+    // (e_select-0.1.2 / 1.4 / 1.5 / 1.6 / 1.7 comma variants).
+    let result = Parser::parse_sql("SELECT * FROM t1, t2 USING (a);");
+    assert!(result.is_ok(), "Parse failed: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match select.from.as_ref().unwrap() {
+            vibesql_ast::FromClause::Join {
+                join_type,
+                condition,
+                using_columns,
+                natural,
+                ..
+            } => {
+                // Comma-join with USING behaves like INNER JOIN ... USING.
+                assert_eq!(*join_type, vibesql_ast::JoinType::Inner);
+                assert!(!*natural);
+                assert!(condition.is_none(), "USING join carries no ON condition");
+                let cols = using_columns.as_ref().expect("Expected USING columns");
+                assert_eq!(cols.len(), 1);
+                assert_eq!(cols[0], "a");
+            }
+            _ => panic!("Expected JOIN"),
+        },
+        _ => panic!("Expected SELECT"),
+    }
+}
+
+#[test]
+fn test_parse_legacy_comma_join_using_multiple_columns(/* issue #6192 */) {
+    let result = Parser::parse_sql("SELECT * FROM t3, t4 USING (a, c);");
+    assert!(result.is_ok(), "Parse failed: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match select.from.as_ref().unwrap() {
+            vibesql_ast::FromClause::Join { join_type, using_columns, .. } => {
+                assert_eq!(*join_type, vibesql_ast::JoinType::Inner);
+                let cols = using_columns.as_ref().expect("Expected USING columns");
+                assert_eq!(cols.len(), 2);
+                assert_eq!(cols[0], "a");
+                assert_eq!(cols[1], "c");
+            }
+            _ => panic!("Expected JOIN"),
+        },
+        _ => panic!("Expected SELECT"),
+    }
+}
+
+#[test]
 fn test_parse_join_using_contextual_keyword_column(/* issue #5945 */) {
     // Contextual keywords (`m`, `key`, `level`) must be accepted as unquoted
     // column names in a JOIN ... USING (...) list, matching SQLite.


### PR DESCRIPTION
## Summary

SQLite treats a comma (`,`) in a FROM clause exactly like `CROSS`/`INNER JOIN`, so an ON **or** USING filtering clause is legal after it and turns the cartesian product into an inner join. VibeSQL's parser already accepted the legacy `FROM t1, t2 ON ...` form but rejected `FROM t1, t2 USING (...)` with a spurious `near "USING": syntax error`.

This is the single largest coherent cluster in the `e_select` documentation-evidence family (issue #6192): the comma variants of `e_select-0.1.2 / 1.4 / 1.5 / 1.6 / 1.7`, all of which drive `%JOIN%` expanding to `,`.

## Changes

- `crates/vibesql-parser/src/parser/select/from_clause.rs`: added a `USING` branch to the comma-join arm of `parse_from_clause`, mirroring the existing `ON` branch — consume the parenthesized column list and build an `INNER` join carrying `using_columns`. The executor then applies the normal USING semantics (column coalescing, equi-filter, and the SQLite `cannot join using column X - column not present in both tables` error when a named column is absent).
- `crates/vibesql-parser/src/tests/joins.rs`: added `test_parse_legacy_comma_join_using` and `test_parse_legacy_comma_join_using_multiple_columns` pinning the new behavior independent of the TCL harness.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Triage `e_select.test` on a fresh build, cluster failures by root cause | ✅ | Fresh build: 71 real failures; clustered by construct via `./scripts/tcltest test e_select.test` expected/got diffs. Largest cluster = comma-join + USING (18 tests) |
| `e_select2.test` re-measured; C-API / Bucket-A split off | ✅ | `e_select2.test` is **entirely** C-API (`sqlite3_prepare_v2` file-scope error) → Bucket-A out of scope, not SELECT-semantics gaps. The 6 `sqlite3_prepare` straddlers in `e_select.test` are the `filescope-err` markers, also Bucket-A |
| Genuine SELECT-semantics wrong-answers fixed at root cause, not test special-casing | ✅ | Root-cause parser fix in `parse_from_clause`; no test-specific branching |
| `e_select.test` real-failure count materially reduced; no Priority-1/2 regressions | ✅ | e_select.test: 71 → 53 failed (88.6% → 91.5%). `join`/`join2`/`select1`/`select4` TCL files show no new failures; their residual failures are pre-existing (table-setup, EQP plan mismatch) and unrelated to USING |
| Each cluster covered by a Rust unit test | ✅ | Two new parser unit tests added; full `vibesql-parser` suite green (1777 passed) |

## Test Plan

- `make test-tcl-file FILE=e_select.test`: 621 tests, 53 failed (was 71) — all 18 comma+USING failures cleared, zero new failures.
- `cargo test --release -p vibesql-parser`: 1777 passed, 0 failed (includes 2 new tests).
- Regression spot-check: `join.test` (7 pre-existing failures, all `table already exists` / `no such table` / EQP), `join2.test`/`select1.test`/`select4.test` clean.
- Manual: `SELECT count(*) FROM t1, t2 USING(a)` → 3; `SELECT * FROM t1, t3 USING (b)` → `cannot join using column b - column not present in both tables` (exact SQLite wording).
- `cargo build --release` clean.

## Scope note

This is a deliberate partial, zero-regression increment of the ~70-failure `e_select` family. The remaining 53 failures span separate clusters (result-ordering/collation stability, DISTINCT+ORDER BY term matching, GROUP BY/HAVING edge cases, compound-SELECT collation, aggregate error wording) that are best addressed as their own root-cause fixes.

Part of #6192