### PR TITLE
fix(tcl-shim): rescue ATTACH-setup cascades and port delete_all_data for DML evidence tests

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -5768,6 +5768,67 @@ proc reconcile_skipped_txn_state {script} {
     }
 }
 
+# Split a multi-statement SQL string into individual statements at top-level
+# `;` boundaries. CREATE TRIGGER ... END bodies are masked (via
+# mask_trigger_bodies) so their internal `;`/BEGIN/END do not split a trigger
+# into fragments. Returns a list of statement strings (trailing `;` removed,
+# empty statements dropped). Index math is aligned because mask_trigger_bodies
+# preserves length. This is a pragmatic splitter for shim setup blocks; it does
+# not track `;` inside quoted string literals, which those blocks do not use.
+proc split_sql_statements {sql} {
+    set masked [mask_trigger_bodies $sql]
+    set stmts {}
+    set start 0
+    set len [string length $masked]
+    for {set i 0} {$i < $len} {incr i} {
+        if {[string index $masked $i] eq ";"} {
+            set stmt [string range $sql $start [expr {$i - 1}]]
+            if {[string trim $stmt] ne ""} { lappend stmts $stmt }
+            set start [expr {$i + 1}]
+        }
+    }
+    set tail [string range $sql $start end]
+    if {[string trim $tail] ne ""} { lappend stmts $tail }
+    return $stmts
+}
+
+# Remove ATTACH/DETACH statements and any statement that references an
+# attached-database schema (aux, aux1, aux2, ...) from a multi-statement SQL
+# block, returning the remaining (main-database) statements re-joined with `;`.
+#
+# VibeSQL has no ATTACH DATABASE support (#6193). SQLite evidence files such as
+# e_update.test open their file-scope setup with
+#   ATTACH 'test.db2' AS aux; CREATE TABLE t1(...); ...; CREATE TABLE aux.t1(...)
+# When the whole block is skipped because it contains ATTACH, none of the MAIN
+# tables get created and every later main-database test cascades to failure.
+# Stripping only the ATTACH/DETACH and aux.*-schema statements lets the
+# main-database statements run so those tests execute for real. Genuine
+# cross-database assertions still reference aux.* and are skipped by
+# uses_sqlite_internals, so this never forces an ATTACH-dependent test green.
+proc strip_attached_db_statements {sql} {
+    set kept {}
+    foreach stmt [split_sql_statements $sql] {
+        set t [string trim $stmt]
+        if {[regexp -nocase {^ATTACH\y} $t]} { continue }
+        if {[regexp -nocase {^DETACH\y} $t]} { continue }
+        if {[regexp -nocase {\maux\d*\.} $t]} { continue }
+        lappend kept $stmt
+    }
+    return [join $kept ";\n"]
+}
+
+# Canonical tester.tcl helper (docs/reference/sqlite/test/tester.tcl ~line 1159)
+# that empties every user table. Evidence files such as e_insert.test call it at
+# file scope between test sections to reset row state; without it the call is an
+# `invalid command name "delete_all_data"` file-scope error and, worse, rows
+# accumulate across sections so later assertions read every prior section's rows
+# (#6193). Ported verbatim so behavior matches upstream.
+proc delete_all_data {} {
+    db eval {SELECT tbl_name AS t FROM sqlite_master WHERE type = 'table'} {
+        db eval "DELETE FROM '[string map {' ''} $t]'"
+    }
+}
+
 proc do_test {name script expected} {
     # Run a test and compare result to expected
 
@@ -5811,6 +5872,63 @@ proc do_test {name script expected} {
             if {[info exists vibesql_writable_schema_ok($ws_name)]} {
                 set is_writable_schema_ok 1
             }
+        }
+        # ATTACH-setup rescue (#6193): a SETUP block (empty expected) whose only
+        # unsupported feature is ATTACH / an attached-database schema should
+        # still create its MAIN-database objects. VibeSQL has no ATTACH, but
+        # skipping the whole block aborts main-table creation and cascades
+        # every later main-database test to failure (e_update-0.0 is the
+        # canonical case: ATTACH is its first statement, so t1..t6 never get
+        # created and the file reads ~4.5% pass). Strip only the ATTACH/DETACH
+        # and aux.*-schema statements and run the remaining main-database
+        # statements. Genuine ATTACH-dependent ASSERTIONS carry a non-empty
+        # expected result (so they are not setup blocks) and/or reference aux.*
+        # directly, so they remain skipped and still fail/omit visibly — this
+        # never forces a cross-database test green.
+        #
+        # Zero-regression rule: the rescued main-db remainder is run under
+        # `catch`. If it still errors (e.g. it uses another unsupported feature
+        # such as a `main.`-qualified DROP TRIGGER), we FALL BACK to skipping
+        # the block exactly as before. A rescued block can therefore only
+        # improve a skip into a pass, never turn a clean skip into a failure.
+        #
+        # Only the FIRST ATTACH-region block is rescued — i.e. while
+        # ::attach_skipped is still unset. This restricts the rescue to a
+        # file's FOUNDATIONAL setup (e_update-0.0, e_delete-2.0), where ATTACH
+        # is incidental to creating the main tables the whole file uses. A
+        # mid-file self-contained ATTACH scenario (e.g. trigger1's
+        # `ifcapable attach` section 10, whose own aux cleanup is skipped) is
+        # reached only AFTER an earlier aux/ATTACH test has set ::attach_skipped,
+        # so it is NOT rescued — preventing its main-side objects from leaking
+        # into and corrupting the downstream tests that follow it.
+        if {![info exists ::attach_skipped] || !$::attach_skipped} {
+        if {([string match "*ATTACH DATABASE*" $reason]
+                || [string match "*DETACH DATABASE*" $reason]
+                || [string match "*attached database schema*" $reason])
+                && [string trim $expected] eq ""
+                && [lindex $script 0] eq "execsql"} {
+            set stripped [strip_attached_db_statements [lindex $script 1]]
+            if {[string trim $stripped] ne ""} {
+                set rescued_script [lreplace $script 1 1 $stripped]
+                incr ::nTest
+                set rescue_rc [catch {uplevel 1 $rescued_script} rescue_result]
+                if {$rescue_rc == 0
+                        && [normalize_result $rescue_result] eq [normalize_result $expected]} {
+                    incr ::nPass
+                    emit_test_detail passed $name
+                    if {$::verbose} { puts "  $name... ok (attach-setup rescue)" }
+                } else {
+                    # The main-db remainder errored or produced unexpected
+                    # output; this block was ATTACH-blocked anyway, so fall back
+                    # to skipping it rather than turning a clean skip into a
+                    # failure (zero-regression rule).
+                    incr ::nTest -1
+                    reconcile_skipped_txn_state $script
+                    omit_test $name $reason
+                }
+                return
+            }
+        }
         }
         if {!$is_conflict_setup && !$is_writable_schema_ok} {
             reconcile_skipped_txn_state $script


### PR DESCRIPTION
## Summary

The SQLite INSERT/UPDATE/DELETE documentation-evidence files (`e_insert.test`,
`e_update.test`, `e_delete.test`) failed wholesale against VibeSQL not because of
real DML bugs but because of two **file-scope setup cascades** in the TCL test
shim (`scripts/tester_vibesql.tcl`). VibeSQL has no `ATTACH DATABASE` support, so
genuinely cross-database (`aux.*`) tests stay out of scope — but a large in-scope
subset was blocked purely by these cascades. This PR breaks both, TCL-shim-only,
with **zero regressions** across every affected file.

## Changes

- **ATTACH-setup rescue in `do_test`.** A file's foundational setup opens with an
  `ATTACH` plus a mix of main-database and `aux.*` statements (e.g. `e_update-0.0`:
  `ATTACH 'test.db2' AS aux; CREATE TABLE t1(...); ...; CREATE TABLE aux.t1(...)`).
  Because the block contained `ATTACH`, the shim skipped the **whole** block, so the
  main tables (`t1..t7`) were never created and every later main-db test cascaded to
  failure (e_update read 4.5%). `do_test` now strips only the `ATTACH`/`DETACH` and
  `aux.*`-schema statements and runs the remaining main-database statements.
- **New helpers** `split_sql_statements` (trigger-body-aware, via `mask_trigger_bodies`)
  and `strip_attached_db_statements`.
- **Ported `delete_all_data`** verbatim from canonical `tester.tcl`. `e_insert.test`
  calls it between sections to reset row state; the shim never defined it, so each
  call was an `invalid command name` file-scope error **and** rows accumulated across
  sections, making later assertions read every prior section's rows.

### Zero-regression guards on the rescue
- Only empty-expected `execsql` **setup** blocks are eligible — genuine cross-database
  ASSERTIONS keep failing/omitting visibly (never forced green).
- The stripped remainder runs under `catch` and **falls back to the original skip** on
  any error or output mismatch, so a rescued block can only turn skip→pass, never
  skip→fail.
- Only the **first** ATTACH-region block is rescued (while `::attach_skipped` is unset),
  restricting it to a file's foundational setup. A mid-file self-contained ATTACH
  scenario whose own `aux` cleanup is skipped (e.g. `trigger1`'s `ifcapable attach`
  section 10) is reached only after the flag is set, so it is **not** rescued and cannot
  leak main-side objects into later tests.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Each file run on fresh `--release` build and triaged | ✅ | `make test-tcl-file` for all three on a fresh `cargo build --release` |
| e_update setup cascade broken (main tables create; `e_update-0` matrix no longer cascade-failing) | ✅ | e_update 7→111 passed (4.5%→66.1%); the `e_update-0` 48-case matrix now passes |
| e_delete 4 in-scope failures addressed or documented | ✅ | e_delete 44→46 passed; remaining 4 are `main.`-qualified DROP TRIGGER parse gap + UPDATE/DELETE...LIMIT (distinct engine gaps) |
| e_insert measurable reduction in ~49 failures | ✅ | e_insert 162→180 passed (76.8%→88.7%); `delete_all_data` cleared the accumulation cascade + 7 filescope errors |
| `aux.*` / §2.x cross-schema tests isolated as ATTACH-blocked, not attempted | ✅ | They reference `aux.` directly and remain skipped by `uses_sqlite_internals`; ATTACH not implemented |
| No regression in raw per-test pass rate for the three files | ✅ | Per-test pass-list diffs (stash vs branch) show no baseline passer lost in any file |

## Test Plan

Ran the 13 files whose foundational setup matches the rescued pattern (detected by
scanning for empty-expected `do_execsql_test` blocks containing `ATTACH`/`aux.`), each
with the baseline shim (git-stashed) vs this branch:

| File | Baseline pass/fail | This PR pass/fail |
|------|--------------------|-------------------|
| e_update | 7 / 51 | **111 / 50** |
| e_delete | 44 / 4 | **46 / 4** |
| e_insert | 162 / 49 | **180 / 23** |
| trigger1 | 43 / 27 | 43 / 27 (unchanged) |
| pragma2 | 1 / 17 | 1 / 17 (unchanged) |
| alter3, e_createtable, e_dropview, e_reindex, e_vacuum, with4, crashM, swarmvtab* | — | all unchanged vs baseline |

`trigger1` and `pragma2` were transient regressions from an earlier, unguarded
version of the rescue; the "first ATTACH-region only" guard removed them. No Rust
changes — TCL shim only.

## Scope / remaining failures (out of scope for this increment)

Remaining failures are genuine out-of-scope items, not counted against the real DML
gap: `aux.*` / §2.x cross-database tests (ATTACH-blocked, correctly skipped),
`sqlite3_get_autocommit` C-API probes (deliberately unstubbed per shim policy), and
distinct engine gaps (`OR FAIL` partial-update semantics, `UPDATE`/`DELETE ... LIMIT`,
`oid`/`last_insert_rowid()`). These warrant separate follow-up issues.

Part of #6193
Part of #5779