### PR TITLE
fix(agg): honor aggregate FILTER clause and coerce nth_value second arg

### DIFF
--- a/crates/vibesql-executor/src/select/columnar/aggregate/expression/mod.rs
+++ b/crates/vibesql-executor/src/select/columnar/aggregate/expression/mod.rs
@@ -79,9 +79,23 @@ pub fn extract_aggregates(
 
     for expr in exprs.iter() {
         match expr {
-            Expression::AggregateFunction { name, distinct, args, .. } => {
+            Expression::AggregateFunction { name, distinct, args, filter, .. } => {
                 // DISTINCT not supported for columnar optimization
                 if *distinct {
+                    return None;
+                }
+
+                // FILTER (WHERE ...) on an aggregate is not represented by
+                // AggregateSpec, so lowering here would silently drop it (e.g.
+                // `sum(a) FILTER (WHERE a<5)` would aggregate over every row).
+                // Bail out to the row-oriented path. (#6191)
+                //
+                // An aggregate ORDER BY (e.g. `count(ORDER BY a)`) is
+                // order-independent for every columnar-supported op
+                // (SUM/COUNT/AVG/MIN/MAX/VARIANCE/STDDEV), so it is safely
+                // ignored here — order-sensitive aggregates like group_concat
+                // are not in the supported-op set and already bail below.
+                if filter.is_some() {
                     return None;
                 }
 

--- a/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/detection.rs
@@ -1106,9 +1106,22 @@ impl SelectExecutor<'_> {
         let is_count_star = match &stmt.select_list[0] {
             vibesql_ast::SelectItem::Expression { expr, .. } => {
                 match expr {
-                    vibesql_ast::Expression::AggregateFunction { name, distinct, args, .. } => {
-                        // Must be COUNT, not DISTINCT, with single wildcard argument
-                        if name.to_uppercase() != "COUNT" || *distinct || args.len() != 1 {
+                    vibesql_ast::Expression::AggregateFunction {
+                        name,
+                        distinct,
+                        args,
+                        filter,
+                        ..
+                    } => {
+                        // Must be COUNT, not DISTINCT, with single wildcard argument.
+                        // A FILTER (WHERE ...) clause disqualifies the fast path: the
+                        // count must only include rows passing the filter, not the
+                        // whole table (issue #6191).
+                        if name.to_uppercase() != "COUNT"
+                            || *distinct
+                            || args.len() != 1
+                            || filter.is_some()
+                        {
                             return None;
                         }
                         matches!(args[0], vibesql_ast::Expression::Wildcard)

--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -1301,6 +1301,12 @@ impl SelectExecutor<'_> {
         let has_set_ops = stmt.set_operation.is_some();
         let has_window_funcs = self.has_window_functions(&stmt.select_list);
         let has_distinct_aggregates = self.has_distinct_aggregates(&stmt.select_list);
+        // Aggregates carrying a FILTER (WHERE ...) or ORDER BY clause are not
+        // handled by the columnar aggregate specs (they drop those clauses), so
+        // route them to the row-oriented path which applies FILTER/ORDER BY
+        // correctly. Without this, `sum(a) FILTER (WHERE a<5)` silently
+        // aggregates over every row (issue #6191).
+        let has_filtered_aggregates = self.has_filtered_aggregates(&stmt.select_list);
 
         // Issue #5104: implicit-outer-aggregate-collapse requires the
         // aggregation pipeline. The columnar pipelines do not support this
@@ -1339,15 +1345,17 @@ impl SelectExecutor<'_> {
             || has_window_funcs
             || has_set_ops
             || has_distinct_aggregates
+            || has_filtered_aggregates
         {
             log::debug!(
-                "{} pipeline doesn't support complex features (order_by={}, distinct={}, window={}, set_ops={}, distinct_agg={})",
+                "{} pipeline doesn't support complex features (order_by={}, distinct={}, window={}, set_ops={}, distinct_agg={}, filtered_agg={})",
                 strategy_name,
                 has_order_by,
                 has_distinct,
                 has_window_funcs,
                 has_set_ops,
-                has_distinct_aggregates
+                has_distinct_aggregates,
+                has_filtered_aggregates
             );
             return Ok(None);
         }
@@ -1556,6 +1564,54 @@ impl SelectExecutor<'_> {
                             || self.expr_has_distinct_aggregate(&case_when.result)
                     })
                     || else_result.as_ref().is_some_and(|e| self.expr_has_distinct_aggregate(e))
+            }
+            _ => false,
+        }
+    }
+
+    /// Check if the select list contains any aggregate carrying a FILTER
+    /// (WHERE ...) clause (e.g. `SUM(a) FILTER (WHERE a<5)`).
+    ///
+    /// The columnar aggregate paths lower each aggregate to an `AggregateSpec`
+    /// that captures only the operation and its source column/expression — a
+    /// FILTER clause is dropped. Such aggregates must therefore run through the
+    /// row-oriented aggregation path, which honors the filter. (#6191)
+    ///
+    /// An aggregate ORDER BY is intentionally NOT treated as complex here: it is
+    /// order-independent for the columnar-supported ops (SUM/COUNT/AVG/MIN/MAX/…)
+    /// and order-sensitive aggregates (group_concat) already bypass the columnar
+    /// path, so routing `count(ORDER BY a)` to the row path would only regress it.
+    fn has_filtered_aggregates(&self, select_list: &[vibesql_ast::SelectItem]) -> bool {
+        select_list.iter().any(|item| {
+            if let vibesql_ast::SelectItem::Expression { expr, .. } = item {
+                self.expr_has_filtered_aggregate(expr)
+            } else {
+                false
+            }
+        })
+    }
+
+    /// Recursively check if an expression contains an aggregate with a FILTER
+    /// clause.
+    #[allow(clippy::only_used_in_recursion)]
+    fn expr_has_filtered_aggregate(&self, expr: &vibesql_ast::Expression) -> bool {
+        match expr {
+            vibesql_ast::Expression::AggregateFunction { filter, .. } => filter.is_some(),
+            vibesql_ast::Expression::BinaryOp { left, right, .. } => {
+                self.expr_has_filtered_aggregate(left) || self.expr_has_filtered_aggregate(right)
+            }
+            vibesql_ast::Expression::UnaryOp { expr, .. } => self.expr_has_filtered_aggregate(expr),
+            vibesql_ast::Expression::Cast { expr, .. } => self.expr_has_filtered_aggregate(expr),
+            vibesql_ast::Expression::Function { args, .. } => {
+                args.iter().any(|arg| self.expr_has_filtered_aggregate(arg))
+            }
+            vibesql_ast::Expression::Case { operand, when_clauses, else_result } => {
+                operand.as_ref().is_some_and(|e| self.expr_has_filtered_aggregate(e))
+                    || when_clauses.iter().any(|case_when| {
+                        case_when.conditions.iter().any(|c| self.expr_has_filtered_aggregate(c))
+                            || self.expr_has_filtered_aggregate(&case_when.result)
+                    })
+                    || else_result.as_ref().is_some_and(|e| self.expr_has_filtered_aggregate(e))
             }
             _ => false,
         }

--- a/crates/vibesql-executor/src/select/window/evaluation.rs
+++ b/crates/vibesql-executor/src/select/window/evaluation.rs
@@ -28,6 +28,57 @@ use crate::{
 #[cfg(feature = "parallel")]
 use crate::select::parallel::ParallelConfig;
 
+/// Coerce a value to a positive integer using SQLite's numeric-affinity rules
+/// for `nth_value(expr, N)`.
+///
+/// SQLite applies numeric affinity to the second argument and accepts it only
+/// when the coerced value is an integer >= 1. Integral floats and numeric
+/// strings coerce (`2.0`, `'2'`, `'2.0'` -> 2); non-integral values, non-numeric
+/// or partially-numeric strings, NULL, and values < 1 are rejected
+/// (`8.5`, `'4ab'`, NULL, `0`, `-1`). Returns `None` for any rejected value.
+fn nth_value_positive_index(value: &SqlValue) -> Option<i64> {
+    // Convert an integral f64 to a positive i64, rejecting non-integral or
+    // out-of-range values.
+    fn integral_positive(f: f64) -> Option<i64> {
+        if f.is_finite() && f.fract() == 0.0 && f >= 1.0 && f <= i64::MAX as f64 {
+            Some(f as i64)
+        } else {
+            None
+        }
+    }
+
+    let n = match value {
+        SqlValue::Integer(n) => *n,
+        SqlValue::Smallint(n) => *n as i64,
+        SqlValue::Bigint(n) => *n,
+        SqlValue::Unsigned(n) => *n as i64,
+        SqlValue::Real(f) => return integral_positive(*f),
+        SqlValue::Float(f) => return integral_positive(*f as f64),
+        SqlValue::Double(f) => return integral_positive(*f),
+        SqlValue::Numeric(f) => return integral_positive(*f),
+        SqlValue::Varchar(s) | SqlValue::Character(s) => {
+            // Numeric affinity requires the *entire* trimmed string to parse as
+            // a number (unlike CAST's leading-prefix parse): '2' and '2.0' pass,
+            // '4ab' does not.
+            let t = s.trim();
+            if let Ok(i) = t.parse::<i64>() {
+                i
+            } else if let Ok(f) = t.parse::<f64>() {
+                return integral_positive(f);
+            } else {
+                return None;
+            }
+        }
+        _ => return None,
+    };
+
+    if n >= 1 {
+        Some(n)
+    } else {
+        None
+    }
+}
+
 /// Result from evaluating a window function, including optional row reordering
 pub(super) struct WindowEvaluationResult {
     /// Window function values in partition order
@@ -633,21 +684,19 @@ fn evaluate_window_function_for_partition(
                 let n_value = evaluator
                     .eval(&args[1], &partition.rows[row_idx])
                     .map_err(|e| ExecutorError::UnsupportedExpression(format!("{:?}", e)))?;
-                let n = match n_value {
-                    SqlValue::Integer(n) => n,
-                    _ => {
-                        return Err(ExecutorError::UnsupportedExpression(
-                            "NTH_VALUE second argument must be an integer".to_string(),
+                // SQLite applies numeric affinity to nth_value's second argument
+                // and requires the result to be a positive integer: '2', 2.0 and
+                // '2.0' coerce to 2, but 8.5, '4ab', NULL, 0 and -1 all raise
+                // "second argument to nth_value must be a positive integer"
+                // (window6.test 10.1.x / 10.2.x).
+                let n = match nth_value_positive_index(&n_value) {
+                    Some(n) => n,
+                    None => {
+                        return Err(ExecutorError::SqliteCompatError(
+                            "second argument to nth_value must be a positive integer".to_string(),
                         ))
                     }
                 };
-
-                if n < 1 {
-                    return Err(ExecutorError::UnsupportedExpression(format!(
-                        "NTH_VALUE n must be a positive integer, got {}",
-                        n
-                    )));
-                }
 
                 let nth_zero_based = (n - 1) as usize;
                 let frame_result = calculate_frame_with_exclusion(

--- a/crates/vibesql-executor/src/tests/aggregate_filter_clause_tests.rs
+++ b/crates/vibesql-executor/src/tests/aggregate_filter_clause_tests.rs
@@ -1,0 +1,167 @@
+//! Regression tests for the aggregate `FILTER (WHERE ...)` clause and
+//! `nth_value` second-argument coercion (#6191).
+//!
+//! The columnar aggregate paths lower each aggregate to an `AggregateSpec` that
+//! captures only the operation and its source column — a `FILTER` clause used
+//! to be silently dropped, so an implicit single-group aggregate like
+//! `sum(a) FILTER (WHERE a<5)` aggregated over every row. These tests pin the
+//! row-oriented fallback so the filter is honored regardless of GROUP BY.
+
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+use super::super::*;
+
+/// Helper to execute a SQL statement, returning the result rows.
+fn execute_sql(db: &mut Database, sql: &str) -> Result<Vec<vibesql_storage::Row>, String> {
+    let stmt = Parser::parse_sql(sql).map_err(|e| format!("Parse error: {:?}", e))?;
+
+    match stmt {
+        vibesql_ast::Statement::Select(select_stmt) => {
+            let executor = SelectExecutor::new(db);
+            executor.execute(&select_stmt).map_err(|e| format!("Execution error: {:?}", e))
+        }
+        vibesql_ast::Statement::CreateTable(create_stmt) => {
+            CreateTableExecutor::execute(&create_stmt, db)
+                .map_err(|e| format!("Execution error: {:?}", e))?;
+            Ok(vec![])
+        }
+        vibesql_ast::Statement::Insert(insert_stmt) => {
+            InsertExecutor::execute(db, &insert_stmt)
+                .map_err(|e| format!("Execution error: {:?}", e))?;
+            Ok(vec![])
+        }
+        _ => Err("Unsupported statement type".to_string()),
+    }
+}
+
+fn setup_t1(db: &mut Database) {
+    execute_sql(db, "CREATE TABLE t1(a)").unwrap();
+    for v in 1..=9 {
+        execute_sql(db, &format!("INSERT INTO t1 VALUES({v})")).unwrap();
+    }
+}
+
+/// `sum(a) FILTER (WHERE a<5)` over the implicit single group must sum only the
+/// matching rows (1+2+3+4 = 10), NOT the whole table (45). This is the core
+/// #6191 regression — the columnar fast path used to drop the FILTER.
+#[test]
+fn test_sum_filter_no_group_by() {
+    let mut db = Database::new();
+    setup_t1(&mut db);
+
+    let rows = execute_sql(&mut db, "SELECT sum(a) FILTER (WHERE a<5) FROM t1").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values[0], SqlValue::Integer(10));
+}
+
+/// A FILTER that no row satisfies must yield NULL for sum (empty aggregate),
+/// not 0 and not the unfiltered total.
+#[test]
+fn test_sum_filter_empty_is_null() {
+    let mut db = Database::new();
+    setup_t1(&mut db);
+
+    let rows = execute_sql(&mut db, "SELECT sum(a) FILTER (WHERE a>100) FROM t1").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values[0], SqlValue::Null);
+}
+
+/// `count(*) FILTER (WHERE a!=5)` must not take the simple-COUNT(*) fast path
+/// (which ignores the filter and returns the full row count of 9); it must
+/// count only the 8 rows that pass the filter.
+#[test]
+fn test_count_star_filter_no_group_by() {
+    let mut db = Database::new();
+    setup_t1(&mut db);
+
+    let rows = execute_sql(&mut db, "SELECT count(*) FILTER (WHERE a!=5) FROM t1").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values[0], SqlValue::Integer(8));
+}
+
+/// A plain `count(*)` with no FILTER must still use the fast path and return
+/// the full row count (guards against over-broadening the fast-path opt-out).
+#[test]
+fn test_count_star_without_filter_still_counts_all() {
+    let mut db = Database::new();
+    setup_t1(&mut db);
+
+    let rows = execute_sql(&mut db, "SELECT count(*) FROM t1").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values[0], SqlValue::Integer(9));
+}
+
+/// FILTER must still work alongside GROUP BY (this path already worked; kept as
+/// a guard so the row-oriented fix doesn't regress the grouped case).
+#[test]
+fn test_min_filter_with_group_by() {
+    let mut db = Database::new();
+    setup_t1(&mut db);
+
+    let rows =
+        execute_sql(&mut db, "SELECT min(a) FILTER (WHERE a>3) FROM t1 GROUP BY (a%2) ORDER BY 1")
+            .unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].values[0], SqlValue::Integer(4));
+    assert_eq!(rows[1].values[0], SqlValue::Integer(5));
+}
+
+/// `count(ORDER BY a)` (aggregate ORDER BY, no arguments) is order-independent
+/// for count and must keep returning the total row count — a guard against the
+/// FILTER fix accidentally routing order-only aggregates to a path that rejects
+/// them.
+#[test]
+fn test_count_with_order_by_no_args() {
+    let mut db = Database::new();
+    setup_t1(&mut db);
+
+    let rows = execute_sql(&mut db, "SELECT count(ORDER BY a) FROM t1").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values[0], SqlValue::Integer(9));
+}
+
+fn setup_nth(db: &mut Database) {
+    execute_sql(db, "CREATE TABLE tv(a, b)").unwrap();
+    execute_sql(db, "INSERT INTO tv VALUES(1, 2)").unwrap();
+    execute_sql(db, "INSERT INTO tv VALUES(2, 3)").unwrap();
+    execute_sql(db, "INSERT INTO tv VALUES(3, 4)").unwrap();
+}
+
+/// `nth_value` accepts a second argument that coerces to a positive integer via
+/// SQLite's numeric affinity: '2', 2.0 and '2.0' all mean N=2, yielding
+/// {NULL, 3, 3} over the running frame.
+#[test]
+fn test_nth_value_coercible_second_argument() {
+    for arg in ["'2'", "2.0", "'2.0'"] {
+        let mut db = Database::new();
+        setup_nth(&mut db);
+
+        let rows =
+            execute_sql(&mut db, &format!("SELECT nth_value(b, {arg}) OVER (ORDER BY a) FROM tv"))
+                .unwrap_or_else(|e| panic!("nth_value(b, {arg}) should succeed, got: {e}"));
+        assert_eq!(rows.len(), 3, "arg={arg}");
+        assert_eq!(rows[0].values[0], SqlValue::Null, "arg={arg}");
+        assert_eq!(rows[1].values[0], SqlValue::Integer(3), "arg={arg}");
+        assert_eq!(rows[2].values[0], SqlValue::Integer(3), "arg={arg}");
+    }
+}
+
+/// Invalid `nth_value` second arguments (0, -1, non-integral float, non-numeric
+/// or NULL) must all raise SQLite's exact error message.
+#[test]
+fn test_nth_value_invalid_second_argument() {
+    for arg in ["0", "-1", "8.5", "'4ab'", "NULL"] {
+        let mut db = Database::new();
+        setup_nth(&mut db);
+
+        let err =
+            execute_sql(&mut db, &format!("SELECT nth_value(b, {arg}) OVER (ORDER BY a) FROM tv"))
+                .expect_err(&format!("nth_value(b, {arg}) should error"));
+        assert!(
+            err.contains("second argument to nth_value must be a positive integer"),
+            "arg={arg} produced unexpected error: {err}"
+        );
+    }
+}

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -59,6 +59,7 @@ mod aggregate_caching;
 mod aggregate_count_sum_avg_tests;
 mod aggregate_distinct;
 mod aggregate_edge_case_tests;
+mod aggregate_filter_clause_tests;
 mod aggregate_group_by_tests;
 mod aggregate_having_tests;
 mod aggregate_min_max_tests;


### PR DESCRIPTION
## Summary

Window-function/aggregate `FILTER`-clause triage pass for #6191 (part of epic #5779). The core bug: the columnar aggregate paths lowered every aggregate to an `AggregateSpec` that captured only the op + source column, **silently dropping any `FILTER (WHERE ...)` clause**. An implicit single-group aggregate like `sum(a) FILTER (WHERE a<5)` therefore aggregated over *every* row (returning 45 instead of 10), even though the same aggregate under `GROUP BY` worked correctly. A second cluster: `nth_value`'s second argument was not coerced (SQLite numeric affinity) and used non-SQLite error wording.

## Changes

- **Aggregate FILTER routing** — aggregates carrying a `FILTER` clause now run through the row-oriented path, which honors the filter:
  - `execute_via_pipeline`: new `has_filtered_aggregates` guard (mirrors the existing DISTINCT-aggregate guard) → falls back to row-oriented.
  - `extract_aggregates`: bails to `None` when a `FILTER` is present (covers the native-columnar path). An aggregate `ORDER BY` is intentionally left on the columnar path (order-independent for every supported op), so `count(ORDER BY a)` does not regress.
  - `is_simple_count_star`: rejects the simple-`COUNT(*)` fast path when the `COUNT` carries a `FILTER`, so `count(*) FILTER (WHERE ...)` counts only matching rows.
- **nth_value second argument** — coerce via SQLite numeric affinity (`'2'`, `2.0`, `'2.0'` → 2) and raise the exact message `second argument to nth_value must be a positive integer` for `0`, `-1`, `8.5`, `'4ab'`, `NULL`.
- **Regression tests** — new `aggregate_filter_clause_tests.rs` (8 tests) covering FILTER over the implicit group, empty-FILTER NULL, `count(*)` FILTER vs plain fast path, FILTER + GROUP BY, `count(ORDER BY a)`, and nth_value coercion/errors.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `filter1`/`filter2` pass at 100% or residuals explained | Partial | filter2 **4→0 (100%)**; filter1 **14→5** — residuals are out-of-scope (see below) |
| `window1` passes at 100% | ✗ | Unchanged at 1 residual (10.8) — pre-existing, unrelated to FILTER/frame; out of scope |
| `window5`/`window6` real frame failures fixed; straddlers routed to Bucket-A | Partial | window6 **22→14** (nth_value cluster fixed); window5 is entirely `sqlite3_create_window_function` (Bucket-A #6154) |
| `windowfault` markers confirmed Bucket-A | ✓ | All 4 are `filescope-err` fault-injection scaffolding (Bucket-A #6154) |
| Net certified-failure reduction reported from a fresh build | ✓ | See table below |
| No regression in Rust window/aggregate unit tests | ✓ | `cargo test -p vibesql-executor --lib` → 3531 passed, 0 failed |

## Net certified-failure reduction (fresh release build, per-file)

| File | Before | After | Notes |
| --- | --- | --- | --- |
| filter1 | 14 | 5 | fixed 9 (non-grouped FILTER) |
| filter2 | 4 | 0 | fixed 4 |
| window6 | 22 | 14 | fixed 8 (nth_value 10.1.x + 10.2.x) |
| window1 | 1 | 1 | pre-existing, out of scope |
| window5 | 9 | 9 | **Bucket-A**: `sqlite3_create_window_function` (median/win/sumint custom UDF/window) |
| windowfault | 4 | 4 | **Bucket-A**: `filescope-err` fault-injection |

**21 real failures fixed, zero regressions.**

### Residuals not fixed here (out of scope for this increment)

- **filter1 2.3** — error wording (`misuse of aggregate function count()` vs our colon variant) for an aggregate inside a FILTER.
- **filter1 3.3 / 3.5** — bare-column representative-row semantics when a `MAX ... FILTER` yields NULL.
- **filter1 6.3** — `#5104` implicit-outer-aggregate-collapse (no FILTER involved).
- **filter1 8.0** — zero-arg `count()` + COUNTOFVIEW over a view.
- **window6 2.0 / 3.0 / 3.1 / filescope-err.1** — `db func winproc` / `db collate wincmp` custom-UDF/collation straddlers → Bucket-A #6154.
- **window6 4.1 / 5.0** — `over`/`window` keyword-as-identifier parser edge cases.
- **window6 9.3–9.7** — error-strictness gaps (reject DISTINCT-in-window, `RANGE UNBOUNDED FOLLOWING` syntax error, invalid frame spec). These need parser-grammar changes (`WindowFunctionSpec::Aggregate` has no `distinct` field) — a distinct sub-area deferred to keep this a zero-regression increment.

## Test Plan

- `make test-tcl-file FILE={filter1,filter2,window1,window5,window6,windowfault}.test` on a fresh `cargo build --release`.
- Regression sweep: window1–9, aggorderby, select5, countofview, aggnested — no new failures (`aggorderby` back to 100% after correcting the `count(ORDER BY a)` path).
- `cargo test -p vibesql-executor --release --lib` → 3531 passed / 0 failed; `cargo clippy` clean on changed files.

Part of #6191