### PR TITLE
feat(storage): make columnar_cache_budget=0 truly disable the representation cache

### DIFF
--- a/crates/vibesql-storage/src/columnar_cache.rs
+++ b/crates/vibesql-storage/src/columnar_cache.rs
@@ -187,9 +187,20 @@ impl ColumnarCache {
     /// # Returns
     /// The Arc-wrapped columnar table (for immediate use)
     pub fn insert(&self, table_name: &str, columnar: ColumnarTable) -> Arc<ColumnarTable> {
-        let key = normalize_cache_key(table_name);
-        let size_bytes = columnar.size_in_bytes();
         let data = Arc::new(columnar);
+
+        // #6199 Phase 0: a zero budget disables the representation cache. Never
+        // hold a resident copy — return the Arc for immediate use without
+        // caching (no `put`, no eviction, no conversion accounting). Combined
+        // with the `get_columnar` short-circuit in `database/cache.rs`, this
+        // keeps a disabled cache truly inert: `CacheStats` stays all-zero and
+        // `memory_usage()` stays 0.
+        if self.max_memory == 0 {
+            return data;
+        }
+
+        let key = normalize_cache_key(table_name);
+        let size_bytes = data.size_in_bytes();
 
         #[cfg(not(target_arch = "wasm32"))]
         {

--- a/crates/vibesql-storage/src/database/cache.rs
+++ b/crates/vibesql-storage/src/database/cache.rs
@@ -45,6 +45,18 @@ impl Database {
             }
         }
 
+        // #6199 Phase 0: a configured `columnar_cache_budget` of 0 disables the
+        // representation cache entirely. For row-oriented tables there is then
+        // no cached columnar form, so every consumer of `get_columnar` (the
+        // SIMD scan filter, analytical columnar execution, and columnar joins)
+        // receives `None` and falls back to the row path — matching
+        // `VIBESQL_DISABLE_COLUMNAR=1` parity. Native columnar tables are
+        // handled above and are unaffected (their data is table-resident, not
+        // cache-managed).
+        if self.columnar_cache.max_memory() == 0 {
+            return Ok(None);
+        }
+
         // Check cache first (for row-oriented tables)
         if let Some(cached) = self.columnar_cache.get(table_name) {
             return Ok(Some(cached));
@@ -369,5 +381,90 @@ mod tests {
         assert_eq!(stats1.conversions, 1);
         assert_eq!(stats2.conversions, 1, "Second pre-warm should not cause additional conversion");
         assert_eq!(stats2.hits, stats1.hits + 1, "Second pre-warm should result in cache hit");
+    }
+
+    // ========================================================================
+    // #6199 Phase 0 — user-configurable columnar cache budget behavior
+    // ========================================================================
+
+    /// A `columnar_cache_budget` of 0 disables the representation cache: for a
+    /// row-oriented table, `get_columnar` returns `None` so every consumer
+    /// falls back to the row path, and the cache never becomes resident
+    /// (`CacheStats` stays all-zero, `memory_usage()` stays 0). The row data is
+    /// still fully available via the row path — parity with the enabled cache.
+    #[test]
+    fn test_columnar_cache_budget_zero_disables_and_forces_row_path() {
+        let mut config = crate::DatabaseConfig::server_default();
+        config.columnar_cache_budget = 0;
+        let mut db = Database::with_config(config);
+
+        db.create_table(create_test_table_schema("t")).unwrap();
+        for row in create_test_rows(100) {
+            db.insert_row("t", row).unwrap();
+        }
+
+        // The representation cache is disabled: a row-oriented table yields no
+        // columnar form, so consumers take the row path.
+        assert_eq!(db.columnar_cache_budget(), 0, "budget should be reported as 0 (disabled)");
+        assert!(
+            db.get_columnar("t").unwrap().is_none(),
+            "disabled cache must return None for a row-oriented table (row path)"
+        );
+
+        // Repeated access must never make the cache resident or accrue stats.
+        let _ = db.get_columnar("t").unwrap();
+        let stats = db.columnar_cache_stats();
+        assert_eq!(stats.conversions, 0, "disabled cache must perform no conversions");
+        assert_eq!(stats.hits, 0, "disabled cache must record no hits");
+        assert_eq!(stats.evictions, 0, "disabled cache must record no evictions");
+        assert_eq!(db.columnar_cache_memory_usage(), 0, "disabled cache must stay at 0 bytes");
+
+        // Parity: the same rows are still fully available via the row path.
+        let rows = db.get_table("t").expect("table exists").scan_live_vec();
+        assert_eq!(rows.len(), 100, "row path must expose all rows when cache is disabled");
+
+        // Contrast: an enabled cache DOES produce a columnar form for the same
+        // data, proving the knob (not some unrelated condition) gates behavior.
+        let mut enabled = Database::with_config(crate::DatabaseConfig::server_default());
+        enabled.create_table(create_test_table_schema("t")).unwrap();
+        for row in create_test_rows(100) {
+            enabled.insert_row("t", row).unwrap();
+        }
+        assert!(
+            enabled.get_columnar("t").unwrap().is_some(),
+            "an enabled cache must produce a columnar representation"
+        );
+        assert!(
+            enabled.columnar_cache_stats().conversions > 0,
+            "an enabled cache must record at least one conversion"
+        );
+    }
+
+    /// A small non-zero budget forces LRU eviction once cached tables exceed the
+    /// budget: `CacheStats.evictions` must be > 0 after populating several
+    /// tables through `get_columnar`.
+    #[test]
+    fn test_small_columnar_cache_budget_forces_eviction() {
+        // Tiny budget so a second resident table evicts the first.
+        let mut config = crate::DatabaseConfig::server_default();
+        config.columnar_cache_budget = 512; // bytes
+        let mut db = Database::with_config(config);
+
+        for name in ["t1", "t2", "t3"] {
+            db.create_table(create_test_table_schema(name)).unwrap();
+            for row in create_test_rows(100) {
+                db.insert_row(name, row).unwrap();
+            }
+            // Populate the cache for this table (convert + insert).
+            let cached = db.get_columnar(name).unwrap();
+            assert!(cached.is_some(), "enabled (non-zero) cache should produce columnar data");
+        }
+
+        let stats = db.columnar_cache_stats();
+        assert!(
+            stats.evictions > 0,
+            "a small budget must force at least one eviction (got {})",
+            stats.evictions
+        );
     }
 }


### PR DESCRIPTION
## Summary

Phase 0 of #6199 (adaptive columnar representation cache) is the user-facing
cache-budget knob. The `[database] columnar_cache_budget` config key, its
human-size parsing, and the CLI plumbing already shipped in #6201 — but a
configured value of `"0"` only *nominally* disabled the cache. `Database::get_columnar`
never consulted the budget, and `ColumnarCache::insert` still stored a single
entry (thrashing on every scan), so a 0-byte budget still took the columnar
SIMD path rather than the row path the docs promised.

This PR makes the disable real and adds the path-assertion behavior tests the
Phase 0 acceptance requires.

## Changes

- **`Database::get_columnar`** (`crates/vibesql-storage/src/database/cache.rs`):
  when the cache budget is 0, return `Ok(None)` for row-oriented tables. Every
  consumer (SIMD scan filter in `select/scan/table.rs`, analytical columnar
  execution, columnar joins) already treats `None` as "columnar unavailable" and
  falls back to the row path — matching `VIBESQL_DISABLE_COLUMNAR=1` parity.
  Native `STORAGE COLUMNAR` tables are handled earlier and are unaffected.
- **`ColumnarCache::insert`** (`crates/vibesql-storage/src/columnar_cache.rs`):
  a 0 budget is inert — return the Arc without caching (no put, no eviction, no
  conversion accounting), so `CacheStats` stays all-zero and `memory_usage()`
  stays 0.
- **Tests** (`database/cache.rs`): two path-assertion tests (wall-clock timings
  are untrustworthy on this machine, per the issue).

No doc change: `.vibesqlrc.example` and `CLAUDE.md` already document
`columnar_cache_budget` (default `"256MB"`, `"0"` = row path) alongside `wal`,
from #6201 — this PR makes that documented behavior real.

## Acceptance Criteria Verification (Phase 0)

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Config key + human sizes + `"0"` disable parse | ✅ | `config::tests::test_columnar_cache_budget_*` (from #6201) still green |
| Budget plumbed into the `DatabaseConfig` the CLI constructs | ✅ | `main.rs:280` + `executor/mod.rs` `set_columnar_cache_budget`; `executor::tests::test_columnar_cache_budget_applied_on_open` |
| `budget = "0"` disables cache — all scans take the row path | ✅ | `test_columnar_cache_budget_zero_disables_and_forces_row_path`: `get_columnar` returns `None`, 0 conversions/hits/evictions, 0 bytes resident, row path exposes all rows; enabled cache produces columnar form for the same data |
| Small non-zero budget forces eviction (`CacheStats.evictions > 0`) | ✅ | `test_small_columnar_cache_budget_forces_eviction` |
| Documented alongside `wal` | ✅ | `.vibesqlrc.example` + `CLAUDE.md` (present since #6201; now accurate) |
| `cargo build --release` clean | ✅ | Finished release profile in ~1m49s |

## Test Plan

```
cargo test -p vibesql-storage --lib database::cache::tests   # 10 passed
cargo test -p vibesql-storage --lib columnar_cache::tests    # 8 passed
cargo test -p vibesql-cli --bins columnar_cache_budget       # 7 passed
cargo build --release                                        # clean
```

## Scope

This is **Phase 0 only**. Phases 1-3 of #6199 remain as separate increments:
Phase 1 (per-table access-pattern signals — partly landed in #6203), Phase 2
(adaptive dispatch + hotness-aware eviction replacing the `500`-row constant and
pure LRU), and Phase 3 (incremental columnar maintenance across writes).

Part of #6199