### PR TITLE
fix(order-by): validate positional ORDER BY range on empty results and fix ordinal suffixes

### DIFF
--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -501,6 +501,25 @@ fn levenshtein_distance(s1: &str, s2: &str) -> usize {
     prev_row[len2]
 }
 
+/// Format a 1-based position as an English ordinal ("1st", "2nd", "3rd",
+/// "4th", ..., "11th", "21st", "22nd", "23rd", ...).
+///
+/// This matches SQLite's `%r` ordinal formatting used in ORDER BY / GROUP BY
+/// range error messages. The prior implementation special-cased only 1/2/3 and
+/// suffixed everything else with "th", which produced wrong forms like "21th"
+/// and "22nd" → "22th" for positions >= 21 (tkt2822-7.21 / 7.22).
+fn format_ordinal(n: usize) -> String {
+    let suffix = match (n % 100, n % 10) {
+        // 11th, 12th, 13th are irregular regardless of the last digit.
+        (11..=13, _) => "th",
+        (_, 1) => "st",
+        (_, 2) => "nd",
+        (_, 3) => "rd",
+        _ => "th",
+    };
+    format!("{}{}", n, suffix)
+}
+
 impl std::fmt::Display for ExecutorError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use vibesql_l10n::vibe_msg;
@@ -1309,12 +1328,7 @@ impl std::fmt::Display for ExecutorError {
                 select_list_len,
             } => {
                 // SQLite-compatible error format: "1st ORDER BY term out of range - should be between 1 and N"
-                let ordinal = match term_position {
-                    1 => "1st".to_string(),
-                    2 => "2nd".to_string(),
-                    3 => "3rd".to_string(),
-                    n => format!("{}th", n),
-                };
+                let ordinal = format_ordinal(*term_position);
                 if *select_list_len == 0 {
                     write!(f, "{} ORDER BY term out of range - should be between 1 and 1", ordinal)
                 } else {
@@ -1331,12 +1345,7 @@ impl std::fmt::Display for ExecutorError {
                 select_list_len,
             } => {
                 // SQLite-compatible error format: "1st GROUP BY term out of range - should be between 1 and N"
-                let ordinal = match term_position {
-                    1 => "1st".to_string(),
-                    2 => "2nd".to_string(),
-                    3 => "3rd".to_string(),
-                    n => format!("{}th", n),
-                };
+                let ordinal = format_ordinal(*term_position);
                 if *select_list_len == 0 {
                     write!(f, "{} GROUP BY term out of range - should be between 1 and 1", ordinal)
                 } else {
@@ -1349,12 +1358,7 @@ impl std::fmt::Display for ExecutorError {
             }
             ExecutorError::OrderByTermNotInResultSet { term_position } => {
                 // SQLite-compatible error format: "1st ORDER BY term does not match any column in the result set"
-                let ordinal = match term_position {
-                    1 => "1st".to_string(),
-                    2 => "2nd".to_string(),
-                    3 => "3rd".to_string(),
-                    n => format!("{}th", n),
-                };
+                let ordinal = format_ordinal(*term_position);
                 write!(f, "{} ORDER BY term does not match any column in the result set", ordinal)
             }
             ExecutorError::InvalidLimitOffset { clause, value, reason } => {
@@ -1694,7 +1698,49 @@ impl From<vibesql_catalog::CatalogError> for ExecutorError {
 
 #[cfg(test)]
 mod tests {
-    use super::ExecutorError;
+    use super::{format_ordinal, ExecutorError};
+
+    #[test]
+    fn format_ordinal_matches_sqlite_percent_r() {
+        // Regular last-digit cases.
+        assert_eq!(format_ordinal(1), "1st");
+        assert_eq!(format_ordinal(2), "2nd");
+        assert_eq!(format_ordinal(3), "3rd");
+        assert_eq!(format_ordinal(4), "4th");
+        assert_eq!(format_ordinal(9), "9th");
+        assert_eq!(format_ordinal(10), "10th");
+        // The irregular teens always take "th".
+        assert_eq!(format_ordinal(11), "11th");
+        assert_eq!(format_ordinal(12), "12th");
+        assert_eq!(format_ordinal(13), "13th");
+        // Twenties: last digit governs again (regression for tkt2822-7.21/7.22,
+        // which previously rendered as "21th" / "22th").
+        assert_eq!(format_ordinal(20), "20th");
+        assert_eq!(format_ordinal(21), "21st");
+        assert_eq!(format_ordinal(22), "22nd");
+        assert_eq!(format_ordinal(23), "23rd");
+        assert_eq!(format_ordinal(24), "24th");
+        // Higher irregular teens (111..=113) still take "th".
+        assert_eq!(format_ordinal(111), "111th");
+        assert_eq!(format_ordinal(112), "112th");
+        assert_eq!(format_ordinal(121), "121st");
+    }
+
+    #[test]
+    fn order_by_out_of_range_uses_correct_ordinal() {
+        let err = ExecutorError::OrderByOutOfRange {
+            term_position: 21,
+            column_number: 0,
+            select_list_len: 25,
+        };
+        assert_eq!(err.to_string(), "21st ORDER BY term out of range - should be between 1 and 25");
+        let err = ExecutorError::OrderByOutOfRange {
+            term_position: 22,
+            column_number: 0,
+            select_list_len: 25,
+        };
+        assert_eq!(err.to_string(), "22nd ORDER BY term out of range - should be between 1 and 25");
+    }
 
     #[test]
     fn with_main_schema_qualifier_prefixes_bare_table_name() {

--- a/crates/vibesql-executor/src/select/order/mod.rs
+++ b/crates/vibesql-executor/src/select/order/mod.rs
@@ -58,6 +58,21 @@ pub(super) fn apply_order_by(
     // Get schema for proper wildcard expansion when counting columns (#4413)
     let schema = evaluator.schema();
 
+    // Resolve (and thereby validate) every ORDER BY term ONCE, up front and
+    // independent of the row count. Resolution is row-independent, so doing it
+    // here is behaviourally identical to resolving per-row — but it guarantees
+    // that positional out-of-range errors (e.g. `ORDER BY 0` / `ORDER BY 26`)
+    // are raised even when the result set is empty. Previously resolution lived
+    // inside the per-row loop, so an empty result set skipped validation
+    // entirely and silently accepted an invalid positional term (tkt2822).
+    let resolved_terms: Vec<std::borrow::Cow<'_, vibesql_ast::Expression>> = order_by
+        .iter()
+        .enumerate()
+        .map(|(term_index, order_item)| {
+            resolve_order_by_alias(&order_item.expr, select_list, term_index, Some(schema))
+        })
+        .collect::<Result<_, _>>()?;
+
     // Evaluate ORDER BY expressions for each row
     for (row, sort_keys) in &mut rows {
         // Clear CSE cache before evaluating this row's ORDER BY expressions
@@ -65,12 +80,8 @@ pub(super) fn apply_order_by(
         evaluator.clear_cse_cache();
 
         let mut keys = Vec::new();
-        for (term_index, order_item) in order_by.iter().enumerate() {
-            // Check if ORDER BY expression is a SELECT list alias or matches an aliased column
+        for (order_item, expr_to_eval) in order_by.iter().zip(resolved_terms.iter()) {
             // Evaluator handles window functions via window_mapping if present
-            // Pass schema for proper wildcard expansion in column count validation
-            let expr_to_eval =
-                resolve_order_by_alias(&order_item.expr, select_list, term_index, Some(schema))?;
             let key_value = evaluator.eval(expr_to_eval.as_ref(), row)?;
             // Get collation for this ORDER BY expression (explicit or inherited from column)
             let collation = evaluator.get_expression_collation(expr_to_eval.as_ref());


### PR DESCRIPTION
## Summary

Bounded triage-and-fix increment for the `tkt*` regression-ticket tail (#6194). This is a heterogeneous tracking issue (~172 certified failures across 52 files, each a different SQLite bug ticket). I ran the top tkt files fresh, triaged them, and landed the one cluster that converges cleanly with zero regressions: the `tkt2822.test` ORDER BY positional/ordinal failures.

Two related engine bugs are fixed:

1. **Positional ORDER BY range validation was skipped on empty result sets.** In `apply_order_by`, resolution/validation of ORDER BY terms ran *inside the per-row loop*, so a query returning zero rows never validated the term. `SELECT * FROM t ORDER BY 0` (or `ORDER BY 26`) on an empty table silently succeeded instead of erroring. Fixed by resolving+validating each term once, up front, independent of row count. Resolution is row-independent, so this is behaviourally identical for non-empty results (and slightly cheaper — one resolution per term instead of one per term per row).

2. **Ordinal suffixes were wrong for positions ≥ 21.** The ORDER BY / GROUP BY range error messages special-cased only 1/2/3 and suffixed everything else with `th`, producing `21th`/`22th` instead of SQLite's `21st`/`22nd`. A shared `format_ordinal` helper now applies standard English ordinal rules (including the 11–13 teens exception) across all three error formatters.

## Changes

- `crates/vibesql-executor/src/select/order/mod.rs`: resolve/validate ORDER BY terms once before the per-row loop so out-of-range positional errors fire even with zero rows.
- `crates/vibesql-executor/src/errors.rs`: add `format_ordinal` helper; use it in the `OrderByOutOfRange`, `GroupByOutOfRange`, and `OrderByTermNotInResultSet` formatters. Add unit tests for the ordinal helper and the corrected `21st`/`22nd` error strings.

## Impact on #6194

**tkt2822.test: 17 → 3 failures (20/38 → 34/38 passing).** All 14 `tkt2822-7.x` failures (positional out-of-range on the empty `t7` table + `%r` ordinal formatting) are fixed.

Remaining tkt2822 failures (3, distinct root causes, left for follow-up):
- `tkt2822-5.5` — `ORDER BY +b` should force expression evaluation (rule 3), not alias matching (rule 2). Separate ORDER BY resolution semantics.
- `tkt2822-6.5 / 6.6` — qualified column names (`t6b.x`) in a compound-query ORDER BY are not resolved to a result column. Maps to compound-query ORDER BY resolution (nearest family: #6189–#6193 set/compound work).

## Triage of the other top tkt files (out of scope for a bounded engine fix — recorded for the tracking issue)

- **tkt-78e04e52ea.test** (8 fail): filescope cascade — the parser rejects empty-string quoted identifiers (`CREATE TABLE ""("" ...)`) with `near """": syntax error`. Single parser root cause (empty quoted identifier), plus some sub-tests also depend on `EXPLAIN QUERY PLAN` output-format matching. Parser-scope, not this diff.
- **tkt3718.test** (10 fail): relies on TCL-registered SQL functions (`db func f1`) with reentrant `db eval` + nested statement-transaction rollback — a shim capability limitation, not a bounded engine fix.
- **tkt2854.test** (9 fail) and **tkt3793.test** (5 fail): shared-cache locking / busy-handler semantics (`sqlite3_enable_shared_cache`, `BEGIN EXCLUSIVE`, URI `cache=shared`, `database schema is locked`). VibeSQL does not implement shared-cache; out of scope.

## Test Plan

- `cargo build --release` — clean.
- `cargo test --release -p vibesql-executor` — 5776 passed, 0 failed (incl. new ordinal unit tests).
- `make test-tcl-file FILE=tkt2822.test` — 34/38 pass (was 20/38).
- Regression sweep on ORDER BY / compound-heavy files: `orderby1.test` 0 failures, `select1.test` 0 failures, `selectA.test` 0 failures.
- Direct checks: `ORDER BY 0` / `ORDER BY 26` on empty tables now error; ordinal error strings render `21st` / `22nd`.

Part of #6194