### PR TITLE
fix(strict): enforce strict datatype rules on generated column values

### DIFF
--- a/crates/vibesql-executor/src/constraint_validator.rs
+++ b/crates/vibesql-executor/src/constraint_validator.rs
@@ -6,13 +6,65 @@
 #![allow(clippy::new_without_default)]
 
 use vibesql_ast::{
-    pretty_print::ToSql, ColumnConstraintKind, ColumnDef, Expression, TableConstraint,
-    TableConstraintKind,
+    pretty_print::ToSql,
+    visitor::{walk_expression, ExpressionVisitor, VisitResult},
+    ColumnConstraintKind, ColumnDef, Expression, TableConstraint, TableConstraintKind,
 };
 use vibesql_catalog::{ColumnSchema, TableSchema};
 use vibesql_types::DataType;
 
 use crate::errors::ExecutorError;
+
+/// Visitor that flags any bind parameter (`?`, `?NNN`, or `:name`) reached
+/// while walking an expression. SQLite prohibits parameters inside CHECK
+/// constraints because the constraint is evaluated at every INSERT/UPDATE with
+/// no bind context (see check-5.1 / check-5.2).
+struct ParameterFinder {
+    found: bool,
+}
+
+impl ExpressionVisitor for ParameterFinder {
+    fn visit_placeholder(&mut self, _index: usize) -> VisitResult {
+        self.found = true;
+        VisitResult::Stop
+    }
+
+    fn visit_numbered_placeholder(&mut self, _number: usize) -> VisitResult {
+        self.found = true;
+        VisitResult::Stop
+    }
+
+    fn visit_named_placeholder(&mut self, _name: &str) -> VisitResult {
+        self.found = true;
+        VisitResult::Stop
+    }
+}
+
+/// True if `expr` contains any bind parameter. Used to reject
+/// `CHECK( x < :abc )` / `CHECK( x < ? )` at CREATE TABLE time.
+fn expression_has_parameter(expr: &Expression) -> bool {
+    let mut finder = ParameterFinder { found: false };
+    walk_expression(&mut finder, expr);
+    finder.found
+}
+
+/// Validate that a CHECK constraint expression uses only forms SQLite permits.
+/// Subqueries and bind parameters are rejected at CREATE TABLE time with the
+/// exact SQLite messages so an invalid definition never creates a half-formed
+/// table (check-3.1, check-5.1, check-5.2).
+fn validate_check_expression(expr: &Expression) -> Result<(), ExecutorError> {
+    if crate::dml_returning::expression_has_subquery(expr) {
+        return Err(ExecutorError::SqliteCompatError(
+            "subqueries prohibited in CHECK constraints".to_string(),
+        ));
+    }
+    if expression_has_parameter(expr) {
+        return Err(ExecutorError::SqliteCompatError(
+            "parameters prohibited in CHECK constraints".to_string(),
+        ));
+    }
+    Ok(())
+}
 
 /// Result of processing constraints
 pub struct ConstraintResult {
@@ -179,6 +231,11 @@ impl ConstraintValidator {
                         result.unique_constraint_collations.push(vec![None]);
                     }
                     ColumnConstraintKind::Check { expr, source_text } => {
+                        // SQLite rejects subqueries and bind parameters inside
+                        // CHECK constraints at CREATE TABLE time (check-3.1,
+                        // check-5.1). Enforce the same prohibition so an invalid
+                        // definition never leaves a half-formed table behind.
+                        validate_check_expression(expr)?;
                         // Use explicit name if provided; otherwise use the
                         // verbatim CHECK source text (SQLite echoes the
                         // original operator spacing in the violation message),
@@ -264,6 +321,10 @@ impl ConstraintValidator {
                     result.unique_constraint_collations.push(key_part_collations(columns));
                 }
                 TableConstraintKind::Check { expr, source_text } => {
+                    // SQLite rejects subqueries and bind parameters inside CHECK
+                    // constraints at CREATE TABLE time (check-3.1, check-5.1).
+                    // Enforce the same prohibition for table-level CHECKs too.
+                    validate_check_expression(expr)?;
                     // Use explicit name if provided; otherwise the verbatim
                     // CHECK source text, falling back to the re-rendered
                     // expression only when no source span was captured.
@@ -557,6 +618,49 @@ mod tests {
         // Programmatic AST carries no source span, so the name falls back to
         // the re-rendered expression text.
         assert_eq!(result.check_constraints[0].0, check_expr.to_sql());
+    }
+
+    /// Assert that a parsed `CREATE TABLE` is rejected by constraint processing
+    /// with `expected` as the exact error message.
+    fn assert_create_table_rejected(sql: &str, expected: &str) {
+        let stmt = vibesql_parser::Parser::parse_sql(sql).expect("parse");
+        let create = match stmt {
+            vibesql_ast::Statement::CreateTable(c) => c,
+            other => panic!("expected CREATE TABLE, got {:?}", other),
+        };
+        let res = ConstraintValidator::process_constraints(
+            &create.table_name,
+            &create.columns,
+            &create.table_constraints,
+        );
+        match res {
+            Ok(_) => panic!("expected rejection of `{}`", sql),
+            Err(e) => assert_eq!(e.to_string(), expected),
+        }
+    }
+
+    #[test]
+    fn test_check_constraint_rejects_parameter() {
+        // A bind parameter inside a CHECK is rejected at CREATE TABLE time with
+        // SQLite's exact message (check-5.1 / check-5.2).
+        assert_create_table_rejected(
+            "CREATE TABLE t5(x, y, CHECK( x*y < :abc ))",
+            "parameters prohibited in CHECK constraints",
+        );
+        assert_create_table_rejected(
+            "CREATE TABLE t5(x, y, CHECK( x*y < ? ))",
+            "parameters prohibited in CHECK constraints",
+        );
+    }
+
+    #[test]
+    fn test_check_constraint_rejects_subquery() {
+        // A subquery inside a CHECK is rejected at CREATE TABLE time with
+        // SQLite's exact message (check-3.1).
+        assert_create_table_rejected(
+            "CREATE TABLE t3(x, y, z, CHECK( x < (SELECT min(x) FROM t1) ))",
+            "subqueries prohibited in CHECK constraints",
+        );
     }
 
     #[test]

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -157,8 +157,20 @@ impl CreateTableExecutor {
             // Schema-qualified table name - use qualified identifier
             // Note: We use stmt.quoted for both parts since the parser combined them
             // In a future iteration, CREATE TABLE could also store schema/table quoted status separately
-            let id = TableIdentifier::qualified(schema_part, stmt.quoted, table_part, stmt.quoted);
-            (schema_part.to_string(), table_part.to_string(), id)
+            if schema_part.eq_ignore_ascii_case(vibesql_catalog::TEMP_SCHEMA) {
+                // SQLite compatibility: the "temp" schema qualifier maps to this
+                // session's temp schema, so `CREATE TABLE temp.t(...)` creates a
+                // temporary table exactly like `CREATE TEMP TABLE t(...)`. Without
+                // this mapping the raw "temp" schema name is looked up verbatim and
+                // fails with SchemaNotFound("temp").
+                let temp_schema = database.catalog.temp_schema_name();
+                let id = TableIdentifier::qualified(temp_schema, false, table_part, stmt.quoted);
+                (temp_schema.to_string(), table_part.to_string(), id)
+            } else {
+                let id =
+                    TableIdentifier::qualified(schema_part, stmt.quoted, table_part, stmt.quoted);
+                (schema_part.to_string(), table_part.to_string(), id)
+            }
         } else {
             // Simple table name - use current schema
             let id = TableIdentifier::new(&stmt.table_name, stmt.quoted);

--- a/crates/vibesql-executor/src/dml_returning.rs
+++ b/crates/vibesql-executor/src/dml_returning.rs
@@ -195,7 +195,7 @@ pub(crate) fn returning_has_subquery(items: &[SelectItem]) -> bool {
 
 /// Recursively test whether an expression contains any subquery form
 /// (scalar subquery, IN (SELECT), EXISTS, or a quantified comparison).
-fn expression_has_subquery(expr: &Expression) -> bool {
+pub(crate) fn expression_has_subquery(expr: &Expression) -> bool {
     use Expression::*;
     match expr {
         ScalarSubquery(_) | Exists { .. } => true,

--- a/crates/vibesql-executor/src/insert/defaults.rs
+++ b/crates/vibesql-executor/src/insert/defaults.rs
@@ -547,7 +547,16 @@ pub fn apply_generated_columns(
         // If column has a generated expression, compute and apply it
         if let Some(generated_expr) = &col.generated_expr {
             let generated_value = evaluator.eval(generated_expr, &temp_row)?;
-            let coerced_value = super::validation::coerce_value(generated_value, &col.data_type)?;
+            // STRICT tables (issue #6173) apply SQLite's rigid strict-datatype
+            // rules to the *computed* value of a generated column, exactly as
+            // they do for directly-supplied column values — erroring with
+            // `cannot store <T> value in <T> column ...` when the generated
+            // result does not match the column's strict type (strict1-9.x).
+            let coerced_value = if let Some(st) = schema.strict_type_of(col_idx) {
+                crate::strict::enforce_strict_type(generated_value, st, &schema.name, &col.name)?
+            } else {
+                super::validation::coerce_value(generated_value, &col.data_type)?
+            };
             row_values[col_idx] = coerced_value;
         }
     }

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -1732,8 +1732,13 @@ fn apply_generated_columns_for_update(
         if let Some(generated_expr) = &col.generated_expr {
             // Evaluate the generated expression against the current row
             let generated_value = evaluator.eval(generated_expr, row)?;
-            let coerced_value =
-                crate::insert::validation::coerce_value(generated_value, &col.data_type)?;
+            // STRICT tables (issue #6173) enforce the rigid strict-datatype
+            // rules on the recomputed generated value, matching the INSERT path.
+            let coerced_value = if let Some(st) = schema.strict_type_of(col_idx) {
+                crate::strict::enforce_strict_type(generated_value, st, &schema.name, &col.name)?
+            } else {
+                crate::insert::validation::coerce_value(generated_value, &col.data_type)?
+            };
 
             // Check if the value actually changed
             let old_value = row.get(col_idx);

--- a/crates/vibesql-executor/tests/strict_generated_column_tests.rs
+++ b/crates/vibesql-executor/tests/strict_generated_column_tests.rs
@@ -1,0 +1,114 @@
+//! End-to-end regression tests for issue #6173: STRICT tables must enforce
+//! their rigid datatype rules on the *computed* value of a generated column
+//! (STORED or VIRTUAL), not only on directly-supplied column values.
+//!
+//! Before the fix, a generated column whose expression evaluated to a value of
+//! the wrong storage class was silently coerced by ordinary affinity rules, so
+//! INSERTs that SQLite rejects with `cannot store <T> value in <T> column
+//! <tbl>.<col>` succeeded. Mirrors SQLite's `strict1-9.x` tests.
+
+use vibesql_ast::Statement;
+use vibesql_executor::{CreateTableExecutor, InsertExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+fn create_with_source(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse CREATE");
+    let Statement::CreateTable(create) = stmt else {
+        panic!("expected CREATE TABLE");
+    };
+    CreateTableExecutor::execute_with_source(&create, db, Some(sql)).expect("CREATE TABLE");
+}
+
+/// Execute an INSERT, returning Ok(()) or the error's Display text.
+fn insert(db: &mut Database, sql: &str) -> Result<(), String> {
+    let stmt = Parser::parse_sql(sql).map_err(|e| format!("parse error: {e:?}"))?;
+    let Statement::Insert(s) = stmt else {
+        panic!("expected INSERT");
+    };
+    InsertExecutor::execute(db, &s).map(|_| ()).map_err(|e| e.to_string())
+}
+
+/// STORED generated columns whose expression yields a value of the wrong
+/// storage class are rejected in a STRICT table (SQLite strict1-9.2.x).
+#[test]
+fn strict_stored_generated_column_type_mismatch_rejected() {
+    let mut db = Database::new();
+    create_with_source(
+        &mut db,
+        "CREATE TABLE gc (
+            k INTEGER PRIMARY KEY,
+            c1 REAL AS(if(k=13,'x', k=14,x'34', 0.0))   STORED,
+            c2 INT  AS(if(k=21,1.5, k=23,'x', 0))       STORED,
+            c4 BLOB AS(if(k=42,2, x'00'))               STORED
+        ) STRICT;",
+    );
+
+    // Valid computed values succeed.
+    insert(&mut db, "INSERT INTO gc(k) VALUES(1)").expect("baseline insert should succeed");
+
+    // TEXT computed into a REAL column.
+    assert_eq!(
+        insert(&mut db, "INSERT INTO gc(k) VALUES(13)"),
+        Err("cannot store TEXT value in REAL column gc.c1".to_string())
+    );
+    // BLOB computed into a REAL column.
+    assert_eq!(
+        insert(&mut db, "INSERT INTO gc(k) VALUES(14)"),
+        Err("cannot store BLOB value in REAL column gc.c1".to_string())
+    );
+    // Non-lossless REAL computed into an INT column.
+    assert_eq!(
+        insert(&mut db, "INSERT INTO gc(k) VALUES(21)"),
+        Err("cannot store REAL value in INT column gc.c2".to_string())
+    );
+    // TEXT computed into an INT column.
+    assert_eq!(
+        insert(&mut db, "INSERT INTO gc(k) VALUES(23)"),
+        Err("cannot store TEXT value in INT column gc.c2".to_string())
+    );
+    // INT computed into a BLOB column.
+    assert_eq!(
+        insert(&mut db, "INSERT INTO gc(k) VALUES(42)"),
+        Err("cannot store INT value in BLOB column gc.c4".to_string())
+    );
+}
+
+/// VIRTUAL generated columns get the same enforcement (SQLite strict1-9.4.x).
+#[test]
+fn strict_virtual_generated_column_type_mismatch_rejected() {
+    let mut db = Database::new();
+    create_with_source(
+        &mut db,
+        "CREATE TABLE gc (
+            k INTEGER PRIMARY KEY,
+            c3 TEXT AS(if(k=34,x'34', 'x'))   VIRTUAL
+        ) STRICT;",
+    );
+
+    insert(&mut db, "INSERT INTO gc(k) VALUES(1)").expect("baseline insert should succeed");
+
+    // BLOB computed into a TEXT column is the only rejected case for TEXT.
+    assert_eq!(
+        insert(&mut db, "INSERT INTO gc(k) VALUES(34)"),
+        Err("cannot store BLOB value in TEXT column gc.c3".to_string())
+    );
+}
+
+/// A non-STRICT table applies ordinary affinity coercion to generated columns
+/// and never raises the strict `cannot store` error — the fix must not leak
+/// strict enforcement into ordinary tables.
+#[test]
+fn non_strict_generated_column_uses_affinity() {
+    let mut db = Database::new();
+    create_with_source(
+        &mut db,
+        "CREATE TABLE t (
+            k INTEGER PRIMARY KEY,
+            g REAL AS('x') STORED
+        );",
+    );
+    // 'x' is not numeric; affinity leaves it as-is rather than erroring.
+    insert(&mut db, "INSERT INTO t(k) VALUES(1)")
+        .expect("non-strict generated column must not raise a strict error");
+}


### PR DESCRIPTION
## Summary

Two coherent SQLite-conformance sub-features of #6173 (STRICT / CREATE TABLE
semantics, epic #5779), each landed as its own commit.

### 1. STRICT datatype enforcement on generated-column values

STRICT tables enforce SQLite's rigid datatype rules on directly-supplied
column values, but **not** on the computed value of a generated (STORED or
VIRTUAL) column. When a generated column's expression evaluated to a value of
the wrong storage class, VibeSQL silently applied ordinary affinity coercion,
so INSERT/UPDATE statements that SQLite rejects with
`cannot store <T> value in <T> column <tbl>.<col>` succeeded instead.

- `insert/defaults.rs::apply_generated_columns` — when the table is STRICT,
  route the computed generated value through `strict::enforce_strict_type`
  (which already implements the exact SQLite conversion rules) instead of the
  default affinity `coerce_value`.
- `update/executor.rs::apply_generated_columns_for_update` — same enforcement
  on the recomputed generated value, so UPDATEs that alter a generated column's
  dependencies are held to the same rule.
- New integration test `tests/strict_generated_column_tests.rs` covering
  STORED rejection, VIRTUAL rejection, valid-value acceptance, and the
  non-STRICT affinity path (guards against leaking strict enforcement into
  ordinary tables).

The existing `enforce_strict_type` helper already encodes the per-type rules
(TEXT accepts INT/REAL and rejects only BLOB; INT accepts lossless REAL/TEXT;
etc.), so no new type logic was needed — only wiring the generated-column path
into the same gate as supplied values.

### 2. temp.-qualified CREATE TABLE + CHECK subquery/parameter rejection

- `create_table.rs` — `CREATE TABLE temp.t(...)` previously failed with
  `SchemaNotFound("temp")` because the schema-qualified CREATE path looked up
  the literal `temp` schema instead of resolving it to the session temp schema
  the read path already understood. It now routes to the session temp schema
  exactly like `CREATE TEMP TABLE t(...)`, clearing the file-scope setup error
  that cascaded through e_createtable.test.
- `constraint_validator.rs` — CHECK constraints containing a subquery or a bind
  parameter are now rejected at CREATE TABLE time with SQLite's exact messages
  (`subqueries prohibited in CHECK constraints` /
  `parameters prohibited in CHECK constraints`) so an invalid definition never
  leaves a half-formed table behind (check-3.1, check-5.1, check-5.2). Adds a
  `ParameterFinder` expression visitor and reuses `expression_has_subquery`
  (now `pub(crate)` in `dml_returning.rs`), with new unit tests.

## Results

| Area | Result |
|------|--------|
| strict1.test | 48/49 pass (was 30/49); +18 fixed. Sole remaining failure strict1-7.1 is an unrelated gencol-references-gencol evaluation-order bug, out of scope |
| check.test | 67 → 71 passing |
| e_createtable.test | temp. file-scope setup error eliminated (+ de-cascade) |
| Regressions | gencol1 (57/30), table (61/10) unchanged before/after |
| Unit + integration | `cargo test -p vibesql-executor --lib` 3520 passed; new strict suite 3 passed; new CHECK unit tests pass |

## Test Plan

```
make test-tcl-file FILE=strict1.test    # 48/49 (was 30/49)
make test-tcl-file FILE=check.test      # 71 passing
cargo test --release -p vibesql-executor --test strict_generated_column_tests
cargo test --release -p vibesql-executor --lib   # 3520 passed
```

## Scope note

This PR lands two coherent sub-features of #6173. The remaining sub-features
listed in the issue (AUTOINCREMENT/`sqlite_sequence`, CHECK column-reference
validation, generated-column evaluation order) remain open and are better
addressed as separate focused PRs.

Part of #6173.
