### PR TITLE
fix(fkey): stop OR IGNORE from suppressing FOREIGN KEY violations

### DIFF
--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -1791,30 +1791,19 @@ fn check_would_violate_constraints(
         }
     }
 
-    // Check FOREIGN KEY constraints
-    for fk in &schema.foreign_keys {
-        let fk_values: Vec<vibesql_types::SqlValue> =
-            fk.column_indices.iter().map(|&idx| row_values[idx].clone()).collect();
-
-        // Skip if any FK value is NULL
-        if fk_values.iter().any(|v| v.is_null()) {
-            continue;
-        }
-
-        // Check if referenced key exists in parent table
-        if let Some(parent_table) = db.get_table(&fk.parent_table) {
-            let key_exists = parent_table.scan().iter().any(|parent_row| {
-                fk.parent_column_indices
-                    .iter()
-                    .zip(&fk_values)
-                    .all(|(&parent_idx, fk_val)| parent_row.get(parent_idx) == Some(fk_val))
-            });
-
-            if !key_exists {
-                return true;
-            }
-        }
-    }
+    // NOTE: FOREIGN KEY constraints are intentionally NOT checked here.
+    //
+    // This helper decides whether an OR IGNORE / untargeted DO NOTHING row
+    // should be silently skipped. Per SQLite, the ON CONFLICT algorithm applies
+    // only to NOT NULL, UNIQUE, PRIMARY KEY, and CHECK constraints — it does
+    // *not* apply to FOREIGN KEY constraints. An immediate FK violation must
+    // always raise "FOREIGN KEY constraint failed" (never be swallowed by
+    // OR IGNORE), and a deferred FK violation must be queued for COMMIT-time
+    // re-validation rather than dropping the row. Both are handled downstream
+    // by `RowValidator::validate_foreign_keys` (which also honors
+    // `PRAGMA foreign_keys` gating), so treating a missing parent key as an
+    // "ignorable conflict" here would both suppress real errors and misbehave
+    // when foreign keys are disabled (fkey2-20.2/20.3).
 
     false
 }

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -102,6 +102,7 @@ mod nested_with_tests;
 mod non_unique_disk_index_tests;
 mod not_operator_tests;
 mod operator_edge_cases;
+mod or_ignore_fk_enforcement;
 mod order_by_compaction_tests;
 mod order_by_index_optimization_tests;
 mod phase3_join_optimization;

--- a/crates/vibesql-executor/src/tests/or_ignore_fk_enforcement.rs
+++ b/crates/vibesql-executor/src/tests/or_ignore_fk_enforcement.rs
@@ -1,0 +1,113 @@
+//! Tests that the `OR IGNORE` conflict-resolution algorithm does NOT suppress
+//! FOREIGN KEY constraint enforcement (fkey2-20.2.*/20.3.*, issue #6170).
+//!
+//! Per SQLite, an ON CONFLICT clause (`OR IGNORE`, untargeted DO NOTHING, ...)
+//! applies only to NOT NULL / UNIQUE / PRIMARY KEY / CHECK constraints. It is
+//! explicitly documented to have **no effect on FOREIGN KEY constraints**: an
+//! immediate FK violation always raises "FOREIGN KEY constraint failed" and a
+//! DEFERRABLE one is still queued for COMMIT-time checking. Previously VibeSQL
+//! treated a missing parent key as an "ignorable conflict" and silently dropped
+//! the row (and did so even when `PRAGMA foreign_keys` was OFF, wrongly skipping
+//! a perfectly valid row). These tests lock in the corrected behaviour.
+
+use vibesql_ast::Statement;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+/// Parse and execute a single DDL/DML statement, returning a display string on
+/// success or the error message on failure.
+fn exec(db: &mut Database, sql: &str) -> Result<String, String> {
+    let stmt =
+        vibesql_parser::Parser::parse_sql(sql).map_err(|e| format!("Parse error: {:?}", e))?;
+    match stmt {
+        Statement::CreateTable(s) => {
+            crate::CreateTableExecutor::execute(&s, db).map_err(|e| e.to_string())
+        }
+        Statement::Insert(s) => crate::InsertExecutor::execute(db, &s)
+            .map(|count| format!("{} row(s) inserted", count))
+            .map_err(|e| e.to_string()),
+        Statement::Update(s) => crate::UpdateExecutor::execute(&s, db)
+            .map(|count| format!("{} row(s) updated", count))
+            .map_err(|e| e.to_string()),
+        other => Err(format!("Unsupported statement type: {:?}", other)),
+    }
+}
+
+/// Run a SELECT and return every value of every row flattened in row order.
+fn query_all(db: &Database, sql: &str) -> Vec<SqlValue> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).expect("parse select");
+    let select = match stmt {
+        Statement::Select(s) => s,
+        other => panic!("expected SELECT, got {:?}", other),
+    };
+    let result = crate::SelectExecutor::new(db).execute_with_columns(&select).expect("run select");
+    result.rows.iter().flat_map(|r| r.values.clone()).collect()
+}
+
+fn setup(db: &mut Database) {
+    exec(db, "CREATE TABLE pp(a PRIMARY KEY, b)").unwrap();
+    exec(db, "CREATE TABLE cc(c PRIMARY KEY, d REFERENCES pp)").unwrap();
+}
+
+#[test]
+fn insert_or_ignore_still_raises_immediate_fk_violation() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    setup(&mut db);
+
+    // Parent key 2 does not exist: OR IGNORE must NOT swallow the FK error.
+    let err = exec(&mut db, "INSERT OR IGNORE INTO cc VALUES(1, 2)").unwrap_err();
+    assert!(err.contains("FOREIGN KEY constraint"), "expected a FOREIGN KEY error, got: {err}");
+
+    // Nothing was inserted (statement aborted).
+    assert_eq!(query_all(&db, "SELECT count(*) FROM cc"), vec![SqlValue::Integer(0)]);
+}
+
+#[test]
+fn update_or_ignore_still_raises_immediate_fk_violation() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    setup(&mut db);
+
+    exec(&mut db, "INSERT INTO pp VALUES(2, 'two')").unwrap();
+    exec(&mut db, "INSERT INTO cc VALUES(1, 2)").unwrap();
+
+    // Repointing the child at a non-existent parent key must error even under
+    // OR IGNORE (fkey2-20.3.*).
+    let err = exec(&mut db, "UPDATE OR IGNORE cc SET d = 5").unwrap_err();
+    assert!(err.contains("FOREIGN KEY constraint"), "expected a FOREIGN KEY error, got: {err}");
+
+    // The row is unchanged (still points at parent key 2).
+    assert_eq!(query_all(&db, "SELECT d FROM cc WHERE c = 1"), vec![SqlValue::Integer(2)]);
+}
+
+#[test]
+fn insert_or_ignore_inserts_valid_row_when_foreign_keys_disabled() {
+    // With PRAGMA foreign_keys = OFF (the default), a missing parent key is not
+    // a violation at all, so OR IGNORE must insert the row rather than treating
+    // the absent parent as an ignorable conflict and silently dropping it.
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(false);
+    setup(&mut db);
+
+    exec(&mut db, "INSERT OR IGNORE INTO cc VALUES(1, 2)").unwrap();
+    assert_eq!(query_all(&db, "SELECT count(*) FROM cc"), vec![SqlValue::Integer(1)]);
+}
+
+#[test]
+fn insert_or_ignore_still_ignores_unique_conflicts() {
+    // Regression guard: OR IGNORE must keep suppressing genuine PRIMARY KEY /
+    // UNIQUE conflicts (the FK carve-out must not disable ordinary conflict
+    // resolution).
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    setup(&mut db);
+
+    exec(&mut db, "INSERT INTO pp VALUES(2, 'two')").unwrap();
+    exec(&mut db, "INSERT INTO cc VALUES(1, 2)").unwrap();
+    // Second row has the same PRIMARY KEY (c = 1) and a valid parent key: the
+    // PK conflict is silently ignored, leaving exactly one row.
+    exec(&mut db, "INSERT OR IGNORE INTO cc VALUES(1, 2)").unwrap();
+
+    assert_eq!(query_all(&db, "SELECT count(*) FROM cc"), vec![SqlValue::Integer(1)]);
+}

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -473,17 +473,23 @@ pub(super) fn execute_internal(
                 continue; // Skip this row
             }
 
-            // Validate foreign key constraints
+            // Validate foreign key constraints.
+            //
+            // Unlike NOT NULL / UNIQUE / PK / CHECK conflicts above, a FOREIGN
+            // KEY violation is NOT subject to the OR IGNORE conflict-resolution
+            // algorithm: SQLite always raises "FOREIGN KEY constraint failed"
+            // for an immediate violation and defers a DEFERRABLE one to COMMIT,
+            // regardless of OR IGNORE (fkey2-20.3). So propagate the immediate
+            // error instead of skipping the row; only genuinely deferred
+            // violations are queued.
             if !schema.foreign_keys.is_empty() {
-                match ForeignKeyValidator::collect_constraints_with_old(
+                let deferred = ForeignKeyValidator::collect_constraints_with_old(
                     database,
                     table_name,
                     &new_row.values,
                     Some(&row.values),
-                ) {
-                    Ok(deferred) => pending_deferred_violations.extend(deferred),
-                    Err(_) => continue, // Skip this row
-                }
+                )?;
+                pending_deferred_violations.extend(deferred);
             }
         } else if use_replace {
             // For REPLACE: validate NOT NULL and CHECK constraints, but skip PK/UNIQUE


### PR DESCRIPTION
## Summary

SQLite's ON CONFLICT algorithm (`OR IGNORE`, untargeted `DO NOTHING`) applies only to NOT NULL / UNIQUE / PRIMARY KEY / CHECK constraints and, per the SQLite docs, has **no effect on FOREIGN KEY constraints**. VibeSQL was treating a missing parent key as an "ignorable conflict" and silently dropping the row on both the INSERT and UPDATE `OR IGNORE` paths, so FK violations that SQLite reports as errors were swallowed.

This is a coherent, self-contained increment in the FK-enforcement family (#6170); the issue stays open for the rest of the family (deferred-FK transaction semantics, the referential-action matrix, `e_fkey` PRAGMA/deferred cases, etc.).

## Changes

- **INSERT** (`insert/execution.rs`): `check_would_violate_constraints` — the OR IGNORE / untargeted DO NOTHING "should this row be skipped?" test — included a FOREIGN KEY parent-key existence check. Removed it. It also ignored `PRAGMA foreign_keys` gating, so even with foreign keys **OFF** a perfectly valid row was wrongly dropped whenever its parent key happened to be absent. FK handling now flows through `RowValidator::validate_foreign_keys` downstream (immediate → error, deferred → queued, honors the PRAGMA).
- **UPDATE** (`update/executor.rs`): the OR IGNORE path caught the FK validator's error and `continue`d (silently skipping the row). It now propagates the immediate FK error and only queues genuinely deferred violations.
- Added `tests/or_ignore_fk_enforcement.rs` (4 regression tests).

Ordinary PK / UNIQUE / CHECK conflict resolution under OR IGNORE is unchanged (covered by a regression test).

## Acceptance Criteria Verification

This is a partial ("Part of") increment toward #6170, not full closure. Verified impact on the targeted files:

| Check | Status | Verification |
|-------|--------|--------------|
| `fkey2.test` reduced | ✅ | 159 → 155 failures (`make test-tcl-file FILE=fkey2.test`) |
| `fkey3.test` reduced | ✅ | 5 → 3 failures |
| No FK regressions | ✅ | fkey1 (4), fkey4 (2), fkey5 (0), fkey7 (7) unchanged |
| `e_fkey.test` no regression | ✅ | 148 unchanged — file uses no `OR`-clauses so cannot be affected |
| Immediate FK still raises under OR IGNORE | ✅ | New Rust tests + CLI repro |
| FK OFF: valid OR IGNORE row inserts | ✅ | New Rust test (was silently dropped before) |
| PK/UNIQUE OR IGNORE unchanged | ✅ | New regression test |
| Unit tests | ✅ | 3535 `vibesql-executor` tests pass |

## Test Plan

- `cargo test --release -p vibesql-executor` → 3535 passed
- `make test-tcl-file FILE=fkey2.test` → 155 failed (was 159)
- `make test-tcl-file FILE=fkey3.test` → 3 failed (was 5)
- Direct CLI reproduction confirms `INSERT/UPDATE OR IGNORE` now raise "FOREIGN KEY constraint failed" with FK on, and insert valid rows with FK off.

Part of #6170