### PR TITLE
feat(alter): enforce SQLite ADD COLUMN restrictions and fix column-insert position

### DIFF
--- a/crates/vibesql-executor/src/alter/columns.rs
+++ b/crates/vibesql-executor/src/alter/columns.rs
@@ -16,11 +16,42 @@ fn is_auto_index(name: &str) -> bool {
     name.to_ascii_lowercase().starts_with("sqlite_autoindex_")
 }
 
+/// Whether a DEFAULT expression is a compile-time constant, mirroring SQLite's
+/// `sqlite3ExprIsConstant` gate in `sqlite3AlterFinishAddColumn`. SQLite rejects
+/// `ALTER TABLE ... ADD COLUMN` with a non-constant default (e.g. `CURRENT_TIME`,
+/// a function call, or a column reference) because the new column's value must be
+/// materializable without a row context. Literals and arithmetic/unary
+/// combinations of literals are constant; everything else (CURRENT_*, functions,
+/// column refs, subqueries) is not.
+fn is_constant_default(expr: &Expression) -> bool {
+    match expr {
+        Expression::Literal(_) => true,
+        Expression::UnaryOp { expr, .. } => is_constant_default(expr),
+        Expression::BinaryOp { left, right, .. } => {
+            is_constant_default(left) && is_constant_default(right)
+        }
+        _ => false,
+    }
+}
+
+/// Whether a DEFAULT expression is (or folds to) SQL NULL. SQLite treats
+/// `DEFAULT NULL` as equivalent to no default when deciding whether a NOT NULL
+/// column can be added.
+fn is_null_default(expr: &Expression) -> bool {
+    matches!(expr, Expression::Literal(SqlValue::Null))
+}
+
 /// Execute ADD COLUMN
 pub(super) fn execute_add_column(
     stmt: &AddColumnStmt,
     database: &mut Database,
 ) -> Result<String, ExecutorError> {
+    // A view is not a table: SQLite rejects `ALTER TABLE <view> ADD COLUMN` with
+    // a view-specific message, before any table/column resolution (alter3-2.5).
+    if database.catalog.get_view(&stmt.table_name).is_some() {
+        return Err(ExecutorError::Other("Cannot add a column to a view".to_string()));
+    }
+
     let table = database
         .get_table_mut(&stmt.table_name)
         .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
@@ -28,6 +59,45 @@ pub(super) fn execute_add_column(
     // Check if column already exists
     if table.schema.has_column(&stmt.column_def.name) {
         return Err(ExecutorError::ColumnAlreadyExists(stmt.column_def.name.clone()));
+    }
+
+    // SQLite's ADD COLUMN restrictions (`sqlite3AlterFinishAddColumn`), checked in
+    // SQLite's order and *before* any schema mutation so a rejected ALTER leaves
+    // the table untouched (alter3-2.*, verified against sqlite3 3.51.0):
+    //   1. A PRIMARY KEY column cannot be added.
+    //   2. A UNIQUE column cannot be added.
+    //   3. A NOT NULL column with a NULL (or absent) default cannot be added.
+    //   4. A column with a non-constant default cannot be added.
+    let has_primary_key = stmt
+        .column_def
+        .constraints
+        .iter()
+        .any(|c| matches!(c.kind, ColumnConstraintKind::PrimaryKey { .. }));
+    if has_primary_key {
+        return Err(ExecutorError::Other("Cannot add a PRIMARY KEY column".to_string()));
+    }
+    let has_unique = stmt
+        .column_def
+        .constraints
+        .iter()
+        .any(|c| matches!(c.kind, ColumnConstraintKind::Unique { .. }));
+    if has_unique {
+        return Err(ExecutorError::Other("Cannot add a UNIQUE column".to_string()));
+    }
+    // A DEFAULT NULL is equivalent to no default for the NOT NULL check.
+    let default_is_null_or_absent =
+        stmt.column_def.default_value.as_deref().is_none_or(is_null_default);
+    if !stmt.column_def.nullable && default_is_null_or_absent {
+        return Err(ExecutorError::Other(
+            "Cannot add a NOT NULL column with default value NULL".to_string(),
+        ));
+    }
+    if let Some(default_expr) = stmt.column_def.default_value.as_deref() {
+        if !is_constant_default(default_expr) {
+            return Err(ExecutorError::Other(
+                "Cannot add a column with non-constant default".to_string(),
+            ));
+        }
     }
 
     // A STORED generated column may only be added while the table is empty.

--- a/crates/vibesql-executor/src/alter_rewrite.rs
+++ b/crates/vibesql-executor/src/alter_rewrite.rs
@@ -85,15 +85,100 @@ pub fn append_column(create_sql: &str, coldef: &str) -> Option<String> {
         return None;
     }
     let tokens = tokenize(create_sql)?;
-    let (_open, close) = column_list_parens(&tokens)?;
-    let insert_at = tokens[close].1.start;
+    let (open, close) = column_list_parens(&tokens)?;
 
+    // SQLite inserts the new column immediately after the last *column*
+    // definition — i.e. before any trailing table-level constraints — not merely
+    // before the closing `)` (verified against sqlite3 3.51.0: alter3-1.6/1.7,
+    // `CREATE TABLE t(a, b, UNIQUE(a, b))` + `ADD c` →
+    // `CREATE TABLE t(a, b, c, UNIQUE(a, b))`).
+    //
+    // Find the first top-level definition that begins with a table-constraint
+    // keyword. When every definition from there to the close is also a
+    // constraint (the normal case: all constraints trail the columns), insert the
+    // new column just before that constraint. Otherwise fall back to appending
+    // before the closing paren (constraints interleaved with columns — rare; the
+    // simple end-append stays valid and re-parseable).
+    if let Some(first_constraint) = first_trailing_constraint_start(&tokens, open, close) {
+        let insert_at = tokens[first_constraint].1.start;
+        let mut out = String::with_capacity(create_sql.len() + coldef.len() + 2);
+        out.push_str(&create_sql[..insert_at]);
+        out.push_str(coldef);
+        out.push_str(", ");
+        out.push_str(&create_sql[insert_at..]);
+        return Some(out);
+    }
+
+    let insert_at = tokens[close].1.start;
     let mut out = String::with_capacity(create_sql.len() + coldef.len() + 2);
     out.push_str(&create_sql[..insert_at]);
     out.push_str(", ");
     out.push_str(coldef);
     out.push_str(&create_sql[insert_at..]);
     Some(out)
+}
+
+/// Token index of the first top-level (depth-1) definition in the column list
+/// that begins with a table-level constraint keyword (`CONSTRAINT`, `PRIMARY`,
+/// `UNIQUE`, `CHECK`, `FOREIGN`), *provided* every definition from there to the
+/// closing paren is also a constraint. Returns `None` when there are no trailing
+/// table constraints, or when a column definition appears after a constraint
+/// (interleaved layout — the caller then appends at the end instead).
+///
+/// `open`/`close` are the column-list paren token indices from
+/// [`column_list_parens`]. Only the first token of each top-level definition is
+/// inspected, so a column-level constraint keyword (e.g. the `PRIMARY` in
+/// `a INTEGER PRIMARY KEY`) is never mistaken for a table constraint.
+fn first_trailing_constraint_start(
+    tokens: &[(Token, Span)],
+    open: usize,
+    close: usize,
+) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut at_def_start = false;
+    let mut first_constraint: Option<usize> = None;
+
+    let mut idx = open;
+    while idx < close {
+        let (tok, _) = &tokens[idx];
+        match tok {
+            Token::LParen => {
+                depth += 1;
+                if depth == 1 {
+                    at_def_start = true;
+                }
+            }
+            Token::RParen => depth -= 1,
+            Token::Comma if depth == 1 => at_def_start = true,
+            _ if depth == 1 && at_def_start => {
+                at_def_start = false;
+                let is_constraint = matches!(
+                    tok,
+                    Token::Keyword {
+                        keyword: Keyword::Constraint
+                            | Keyword::Primary
+                            | Keyword::Unique
+                            | Keyword::Check
+                            | Keyword::Foreign,
+                        ..
+                    }
+                );
+                if is_constraint {
+                    if first_constraint.is_none() {
+                        first_constraint = Some(idx);
+                    }
+                } else if first_constraint.is_some() {
+                    // A column definition follows a constraint: interleaved
+                    // layout. Bail so the caller appends at the end.
+                    return None;
+                }
+            }
+            _ => {}
+        }
+        idx += 1;
+    }
+
+    first_constraint
 }
 
 /// Whether `tok` is an identifier-like token whose text matches `name`
@@ -717,6 +802,40 @@ mod tests {
     fn append_column_no_column_list_returns_none() {
         // CREATE TABLE ... AS SELECT has no editable column list.
         assert!(append_column("CREATE TABLE t AS SELECT 1", "c INTEGER").is_none());
+    }
+
+    #[test]
+    fn append_column_before_trailing_table_constraint() {
+        // SQLite inserts the new column before a trailing table-level constraint,
+        // not before the closing paren (alter3-1.6/1.7).
+        let sql = "CREATE TABLE t2(a, b, UNIQUE(a, b))";
+        let out = append_column(sql, "c REFERENCES t1(c)").unwrap();
+        assert_eq!(out, "CREATE TABLE t2(a, b, c REFERENCES t1(c), UNIQUE(a, b))");
+    }
+
+    #[test]
+    fn append_column_before_multiple_trailing_constraints() {
+        let sql = "CREATE TABLE t(a, b, PRIMARY KEY(a), CHECK(b > 0))";
+        let out = append_column(sql, "c INTEGER").unwrap();
+        assert_eq!(out, "CREATE TABLE t(a, b, c INTEGER, PRIMARY KEY(a), CHECK(b > 0))");
+    }
+
+    #[test]
+    fn append_column_no_table_constraint_appends_at_end() {
+        // Column-level PRIMARY KEY is part of a column definition, not a
+        // table-level constraint, so the new column still appends at the end.
+        let sql = "CREATE TABLE t(a INTEGER PRIMARY KEY, b)";
+        let out = append_column(sql, "c INTEGER").unwrap();
+        assert_eq!(out, "CREATE TABLE t(a INTEGER PRIMARY KEY, b, c INTEGER)");
+    }
+
+    #[test]
+    fn append_column_interleaved_constraint_falls_back_to_end() {
+        // A column definition after a table constraint is an unusual layout;
+        // fall back to appending at the end (still valid + re-parseable).
+        let sql = "CREATE TABLE t(a, CHECK(a > 0), b)";
+        let out = append_column(sql, "c INTEGER").unwrap();
+        assert_eq!(out, "CREATE TABLE t(a, CHECK(a > 0), b, c INTEGER)");
     }
 
     #[test]

--- a/crates/vibesql-executor/src/tests/alter_add_column_restrictions.rs
+++ b/crates/vibesql-executor/src/tests/alter_add_column_restrictions.rs
@@ -1,0 +1,91 @@
+//! Tests for SQLite's `ALTER TABLE ... ADD COLUMN` restrictions (issue #6174,
+//! alter3-2.*). SQLite rejects adding a PRIMARY KEY / UNIQUE column, a NOT NULL
+//! column without a non-NULL default, a column with a non-constant default, and
+//! any column on a view — each with a verbatim message the TCL harness asserts.
+
+use vibesql_ast::Statement;
+use vibesql_storage::Database;
+
+fn exec_sql(db: &mut Database, sql: &str) -> Result<String, String> {
+    let stmt =
+        vibesql_parser::Parser::parse_sql(sql).map_err(|e| format!("Parse error: {:?}", e))?;
+
+    match stmt {
+        Statement::CreateTable(s) => {
+            crate::CreateTableExecutor::execute(&s, db).map_err(|e| e.to_string())
+        }
+        Statement::CreateView(s) => crate::advanced_objects::execute_create_view(&s, db)
+            .map(|_| "view created".to_string())
+            .map_err(|e| e.to_string()),
+        Statement::Insert(s) => crate::InsertExecutor::execute(db, &s)
+            .map(|count| format!("{} row(s) inserted", count))
+            .map_err(|e| e.to_string()),
+        Statement::AlterTable(s) => {
+            crate::alter::AlterTableExecutor::execute(&s, db).map_err(|e| e.to_string())
+        }
+        _ => Err("Unsupported statement type".to_string()),
+    }
+}
+
+#[test]
+fn add_primary_key_column_is_rejected() {
+    let mut db = Database::new();
+    exec_sql(&mut db, "CREATE TABLE t1(a, b)").unwrap();
+    exec_sql(&mut db, "INSERT INTO t1 VALUES(1, 2)").unwrap();
+    let err = exec_sql(&mut db, "ALTER TABLE t1 ADD c PRIMARY KEY").unwrap_err();
+    assert_eq!(err, "Cannot add a PRIMARY KEY column");
+    // The rejected ALTER left the table untouched.
+    assert!(exec_sql(&mut db, "ALTER TABLE t1 ADD c VARCHAR(10)").is_ok());
+}
+
+#[test]
+fn add_unique_column_is_rejected() {
+    let mut db = Database::new();
+    exec_sql(&mut db, "CREATE TABLE t1(a, b)").unwrap();
+    let err = exec_sql(&mut db, "ALTER TABLE t1 ADD c UNIQUE").unwrap_err();
+    assert_eq!(err, "Cannot add a UNIQUE column");
+}
+
+#[test]
+fn add_not_null_column_without_default_is_rejected() {
+    let mut db = Database::new();
+    exec_sql(&mut db, "CREATE TABLE t1(a, b)").unwrap();
+    let err = exec_sql(&mut db, "ALTER TABLE t1 ADD c NOT NULL").unwrap_err();
+    assert_eq!(err, "Cannot add a NOT NULL column with default value NULL");
+}
+
+#[test]
+fn add_not_null_column_with_explicit_null_default_is_rejected() {
+    let mut db = Database::new();
+    exec_sql(&mut db, "CREATE TABLE t1(a, b)").unwrap();
+    // DEFAULT NULL counts as "no default" for the NOT NULL check.
+    let err = exec_sql(&mut db, "ALTER TABLE t1 ADD c NOT NULL DEFAULT NULL").unwrap_err();
+    assert_eq!(err, "Cannot add a NOT NULL column with default value NULL");
+}
+
+#[test]
+fn add_not_null_column_with_constant_default_is_allowed() {
+    let mut db = Database::new();
+    exec_sql(&mut db, "CREATE TABLE t1(a, b)").unwrap();
+    exec_sql(&mut db, "INSERT INTO t1 VALUES(1, 2)").unwrap();
+    // A NOT NULL column with a non-NULL constant default is fine — including
+    // when the DEFAULT clause trails the NOT NULL constraint (alter3-2.4).
+    assert!(exec_sql(&mut db, "ALTER TABLE t1 ADD c NOT NULL DEFAULT 10").is_ok());
+}
+
+#[test]
+fn add_column_with_non_constant_default_is_rejected() {
+    let mut db = Database::new();
+    exec_sql(&mut db, "CREATE TABLE t1(a, b)").unwrap();
+    let err = exec_sql(&mut db, "ALTER TABLE t1 ADD d DEFAULT CURRENT_TIME").unwrap_err();
+    assert_eq!(err, "Cannot add a column with non-constant default");
+}
+
+#[test]
+fn add_column_to_view_is_rejected() {
+    let mut db = Database::new();
+    exec_sql(&mut db, "CREATE TABLE t1(a, b)").unwrap();
+    exec_sql(&mut db, "CREATE VIEW v1 AS SELECT * FROM t1").unwrap();
+    let err = exec_sql(&mut db, "ALTER TABLE v1 ADD COLUMN d").unwrap_err();
+    assert_eq!(err, "Cannot add a column to a view");
+}

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -65,6 +65,7 @@ mod aggregate_min_max_tests;
 mod aggregate_percentile_tests;
 mod aggregate_random_patterns;
 mod aggregate_without_from;
+mod alter_add_column_restrictions;
 mod alter_rename_collision;
 mod alter_rename_column_triggers;
 mod alter_table_constraints;

--- a/crates/vibesql-parser/src/arena_parser/ddl.rs
+++ b/crates/vibesql-parser/src/arena_parser/ddl.rs
@@ -400,6 +400,11 @@ impl<'arena> ArenaParser<'arena> {
                         self.advance();
                         self.parse_drop_constraint(table_name)?
                     }
+                    // SQLite allows DROP COLUMN without the COLUMN keyword:
+                    // `ALTER TABLE t DROP <col>` is a synonym for
+                    // `ALTER TABLE t DROP COLUMN <col>`. If we see a bare column
+                    // name, treat it as a column drop (mirrors the ADD case).
+                    Token::Identifier(_) => self.parse_drop_column(table_name)?,
                     _ => {
                         return Err(ParseError {
                             message: "Expected COLUMN or CONSTRAINT after DROP".to_string(),

--- a/crates/vibesql-parser/src/parser/alter.rs
+++ b/crates/vibesql-parser/src/parser/alter.rs
@@ -123,7 +123,7 @@ fn parse_add_column(
     let mut generated = parse_optional_generated_clause(parser)?;
 
     // Parse optional DEFAULT clause
-    let default_value = if parser.peek_keyword(Keyword::Default) {
+    let mut default_value = if parser.peek_keyword(Keyword::Default) {
         parser.advance(); // consume DEFAULT
         Some(Box::new(parser.parse_expression()?))
     } else {
@@ -198,6 +198,18 @@ fn parse_add_column(
                         deferral: None,
                     },
                 });
+            }
+            // A DEFAULT clause may appear among the other column constraints in
+            // any order (e.g. `ADD c NOT NULL DEFAULT 10`). SQLite accepts column
+            // constraints in any order; parsing DEFAULT only before the loop
+            // dropped a trailing `DEFAULT` and left the column with no default
+            // (alter3-2.4). The first DEFAULT seen wins.
+            Token::Keyword { keyword: Keyword::Default, .. } => {
+                parser.advance();
+                let expr = parser.parse_expression()?;
+                if default_value.is_none() {
+                    default_value = Some(Box::new(expr));
+                }
             }
             _ => break,
         }

--- a/crates/vibesql-parser/src/parser/alter.rs
+++ b/crates/vibesql-parser/src/parser/alter.rs
@@ -51,6 +51,11 @@ pub fn parse_alter_table(parser: &mut crate::Parser) -> Result<AlterTableStmt, P
                     parser.advance();
                     parse_drop_constraint(parser, table_name)
                 }
+                // SQLite allows DROP COLUMN without the COLUMN keyword:
+                // `ALTER TABLE t DROP <col>` is a synonym for
+                // `ALTER TABLE t DROP COLUMN <col>`. If we see a bare column
+                // name, treat it as a column drop (mirrors the ADD case above).
+                Token::Identifier(_) => parse_drop_column(parser, table_name),
                 _ => Err(ParseError {
                     message: "Expected COLUMN or CONSTRAINT after DROP".to_string(),
                 }),

--- a/crates/vibesql-parser/src/tests/alter_table.rs
+++ b/crates/vibesql-parser/src/tests/alter_table.rs
@@ -53,6 +53,27 @@ fn test_parse_alter_table_drop_column() {
 }
 
 #[test]
+fn test_parse_alter_table_drop_column_without_column_keyword() {
+    // SQLite allows `ALTER TABLE t DROP <col>` as a synonym for
+    // `ALTER TABLE t DROP COLUMN <col>` (issue #6174).
+    let result = Parser::parse_sql("ALTER TABLE users DROP email;");
+    assert!(result.is_ok(), "bare DROP <col> should parse: {result:?}");
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::AlterTable(alter) => match alter {
+            vibesql_ast::AlterTableStmt::DropColumn(drop) => {
+                assert_eq!(drop.table_name, "users");
+                assert_eq!(drop.column_name, "email");
+                assert!(!drop.if_exists);
+            }
+            _ => panic!("Expected DROP COLUMN"),
+        },
+        _ => panic!("Expected ALTER TABLE statement"),
+    }
+}
+
+#[test]
 fn test_parse_alter_table_drop_column_if_exists() {
     let result = Parser::parse_sql("ALTER TABLE users DROP COLUMN IF EXISTS email;");
     assert!(result.is_ok());

--- a/crates/vibesql-parser/src/tests/alter_table.rs
+++ b/crates/vibesql-parser/src/tests/alter_table.rs
@@ -507,6 +507,22 @@ fn test_parse_alter_table_add_plain_column_has_no_generated_expr() {
     }
 }
 
+#[test]
+fn test_parse_alter_table_add_column_not_null_then_default() {
+    // A DEFAULT clause following other column constraints (any order) must be
+    // captured, not dropped. Previously `NOT NULL DEFAULT 10` lost the DEFAULT
+    // because DEFAULT was only parsed before the constraint loop (alter3-2.4).
+    let result = Parser::parse_sql("ALTER TABLE t1 ADD c NOT NULL DEFAULT 10");
+    assert!(result.is_ok(), "err: {:?}", result);
+    match result.unwrap() {
+        vibesql_ast::Statement::AlterTable(vibesql_ast::AlterTableStmt::AddColumn(add)) => {
+            assert!(!add.column_def.nullable, "NOT NULL should be captured");
+            assert!(add.column_def.default_value.is_some(), "DEFAULT 10 should be captured");
+        }
+        other => panic!("Expected ADD COLUMN, got {:?}", other),
+    }
+}
+
 // ========================================================================
 // RENAME COLUMN with contextual-keyword column names (issue #5945)
 //

--- a/crates/vibesql-parser/src/tests/arena_alter_table.rs
+++ b/crates/vibesql-parser/src/tests/arena_alter_table.rs
@@ -120,6 +120,26 @@ fn test_arena_alter_table_drop_column() {
 }
 
 #[test]
+fn test_arena_alter_table_drop_column_without_column_keyword() {
+    // SQLite allows `ALTER TABLE t DROP <col>` as a synonym for
+    // `ALTER TABLE t DROP COLUMN <col>` (issue #6174).
+    let arena = Bump::new();
+    let result =
+        ArenaParser::parse_alter_table_sql_with_interner("ALTER TABLE users DROP email;", &arena);
+    assert!(result.is_ok(), "bare DROP <col> should parse: {:?}", result.err());
+    let (stmt, interner) = result.unwrap();
+
+    match stmt {
+        AlterTableStmt::DropColumn(DropColumnStmt { table_name, column_name, if_exists }) => {
+            assert_eq!(interner.resolve(*table_name), "users");
+            assert_eq!(interner.resolve(*column_name), "email");
+            assert!(!if_exists);
+        }
+        _ => panic!("Expected DROP COLUMN"),
+    }
+}
+
+#[test]
 fn test_arena_alter_table_drop_column_if_exists() {
     let arena = Bump::new();
     let result = ArenaParser::parse_alter_table_sql_with_interner(


### PR DESCRIPTION
## Summary

Improves `ALTER TABLE ... ADD COLUMN` conformance to SQLite for issue #6174 (ALTER TABLE semantics family, part of epic #5779). SQLite rejects several `ADD COLUMN` shapes outright and edits the stored `CREATE TABLE` text in a specific position; VibeSQL previously accepted the rejected shapes and appended the new column in the wrong place.

This is a focused, mergeable slice of the ~243-failure family — it does **not** close the issue.

## Changes

**Executor — ADD COLUMN restrictions** (`crates/vibesql-executor/src/alter/columns.rs`), all checked before any schema mutation (rejected ALTER is a no-op) with SQLite's verbatim messages:
- PRIMARY KEY constraint → `Cannot add a PRIMARY KEY column`
- UNIQUE constraint → `Cannot add a UNIQUE column`
- NOT NULL with a NULL/absent default → `Cannot add a NOT NULL column with default value NULL` (`DEFAULT NULL` counts as no default)
- non-constant default (e.g. `CURRENT_TIME`) → `Cannot add a column with non-constant default`
- target is a view → `Cannot add a column to a view`

**sql_source fidelity** (`crates/vibesql-executor/src/alter_rewrite.rs`):
- `append_column` inserts the new column after the last column definition — before trailing table-level constraints (UNIQUE / PRIMARY KEY / CHECK / FOREIGN KEY) — matching SQLite, instead of before the closing paren. Interleaved layouts safely fall back to end-append.

**Parser** (`crates/vibesql-parser/src/parser/alter.rs`):
- Accept a DEFAULT clause among other column constraints in any order (`ADD c NOT NULL DEFAULT 10`). DEFAULT was only parsed before the constraint loop, so a trailing DEFAULT was silently dropped.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| ADD PRIMARY KEY / UNIQUE / NOT-NULL / non-constant-default / view rejected with SQLite messages | ✅ | New executor unit tests + `make test-tcl-file FILE=alter3.test` |
| New column placed before trailing table constraints in `sqlite_master.sql` | ✅ | New `alter_rewrite` unit tests; alter3-1.6/1.7 pass |
| `ADD c NOT NULL DEFAULT 10` retains its default | ✅ | New parser unit test; alter3-2.4 passes |
| No regressions in the ALTER TCL suite | ✅ | Unchanged pass counts on altercol/alter2/alterdropcol/alterdropcol2/altertrig |

## Test Plan

- New unit tests: `crates/vibesql-executor/src/tests/alter_add_column_restrictions.rs` (7), `alter_rewrite` append tests (4), parser DEFAULT-ordering test (1).
- Full crate suites green (unfiltered): `cargo test -p vibesql-executor` (3518 lib + all integration binaries, 0 failed) and `cargo test -p vibesql-parser` (1775, 0 failed).
- Targeted TCL, clean before/after on this branch:
  - `alter3.test`: 15 → 24 passed
  - `alter.test`: 37 → 40 passed
  - altercol / alter2 / alterdropcol / alterdropcol2 / altertrig: unchanged (no regressions)

## Not in scope (follow-ups for #6174)

- Stripping the `schema.` qualifier from stored `CREATE TABLE` text (alter3-1.4/1.5) — a CREATE-path concern.
- RENAME COLUMN CHECK/NOT-NULL evaluation-order cases (alter3-9.*) — a constraint-evaluation subsystem.
- alter2's older-file-format / `hexio_*` tests — likely Bucket-A.

Part of #6174
Part of epic #5779