### PR TITLE
fix(window): frame-bound ordering, DISTINCT-window rejection, and FILTER handling for count()/bare-column

### DIFF
--- a/crates/vibesql-executor/src/evaluator/window/frames.rs
+++ b/crates/vibesql-executor/src/evaluator/window/frames.rs
@@ -34,6 +34,32 @@ pub fn validate_frame(frame_spec: &Option<WindowFrame>) -> Result<(), String> {
         validate_frame_bound(end_bound, false)?;
     }
 
+    // Validate the relative ordering of the start and end bounds.
+    //
+    // SQLite (window.c) rejects frames whose boundaries cannot describe a
+    // non-degenerate window with "unsupported frame specification". The
+    // offending combinations (where an omitted end bound defaults to CURRENT
+    // ROW) are:
+    //   * start = CURRENT ROW,          end = <expr> PRECEDING
+    //   * start = <expr> FOLLOWING,     end = <expr> PRECEDING
+    //   * start = <expr> FOLLOWING,     end = CURRENT ROW
+    // (UNBOUNDED PRECEDING as an end bound and UNBOUNDED FOLLOWING as a start
+    // bound are already rejected at parse time, so they cannot reach here.)
+    let start_is_current = matches!(frame.start, FrameBound::CurrentRow);
+    let start_is_following = matches!(frame.start, FrameBound::Following(_));
+    let (end_is_preceding, end_is_current) = match &frame.end {
+        Some(FrameBound::Preceding(_)) => (true, false),
+        Some(FrameBound::CurrentRow) => (false, true),
+        // An omitted end bound defaults to CURRENT ROW.
+        None => (false, true),
+        _ => (false, false),
+    };
+    if (start_is_current && end_is_preceding)
+        || (start_is_following && (end_is_preceding || end_is_current))
+    {
+        return Err("unsupported frame specification".to_string());
+    }
+
     Ok(())
 }
 

--- a/crates/vibesql-executor/src/evaluator/window/tests/frames.rs
+++ b/crates/vibesql-executor/src/evaluator/window/tests/frames.rs
@@ -215,3 +215,74 @@ fn test_range_frame_text_keys_collate_nocase() {
         assert_eq!(frame, i..i + 1, "frame for row {} should be its own peer group", i);
     }
 }
+
+/// Build an `N PRECEDING` bound from an integer literal.
+fn preceding(n: i64) -> FrameBound {
+    FrameBound::Preceding(Box::new(Expression::Literal(SqlValue::Integer(n))))
+}
+
+/// Build an `N FOLLOWING` bound from an integer literal.
+fn following(n: i64) -> FrameBound {
+    FrameBound::Following(Box::new(Expression::Literal(SqlValue::Integer(n))))
+}
+
+fn frame(unit: FrameUnit, start: FrameBound, end: Option<FrameBound>) -> Option<WindowFrame> {
+    Some(WindowFrame { unit, start, end, exclude: None })
+}
+
+// window6.test 9.7.1: `ROWS BETWEEN CURRENT ROW AND 4 PRECEDING` — a CURRENT
+// ROW start paired with an <expr> PRECEDING end is rejected by SQLite as an
+// "unsupported frame specification".
+#[test]
+fn test_validate_frame_current_to_preceding_rejected() {
+    let spec = frame(FrameUnit::Rows, FrameBound::CurrentRow, Some(preceding(4)));
+    assert_eq!(validate_frame(&spec), Err("unsupported frame specification".to_string()));
+}
+
+// window6.test 9.7.2: a single `ROWS 4 FOLLOWING` bound (end defaults to CURRENT
+// ROW) starts at <expr> FOLLOWING, which SQLite rejects.
+#[test]
+fn test_validate_frame_single_following_rejected() {
+    let spec = frame(FrameUnit::Rows, following(4), None);
+    assert_eq!(validate_frame(&spec), Err("unsupported frame specification".to_string()));
+}
+
+// window6.test 9.7.3: `ROWS BETWEEN 4 FOLLOWING AND CURRENT ROW`.
+#[test]
+fn test_validate_frame_following_to_current_rejected() {
+    let spec = frame(FrameUnit::Rows, following(4), Some(FrameBound::CurrentRow));
+    assert_eq!(validate_frame(&spec), Err("unsupported frame specification".to_string()));
+}
+
+// window6.test 9.7.4: `ROWS BETWEEN 4 FOLLOWING AND 2 PRECEDING`.
+#[test]
+fn test_validate_frame_following_to_preceding_rejected() {
+    let spec = frame(FrameUnit::Rows, following(4), Some(preceding(2)));
+    assert_eq!(validate_frame(&spec), Err("unsupported frame specification".to_string()));
+}
+
+// Valid frames whose bounds are correctly ordered must NOT be rejected by the
+// new ordering check. These mirror frames exercised by window1/window5/window6.
+#[test]
+fn test_validate_frame_valid_specs_accepted() {
+    // BETWEEN 1 PRECEDING AND 1 FOLLOWING
+    assert!(validate_frame(&frame(FrameUnit::Rows, preceding(1), Some(following(1)))).is_ok());
+    // BETWEEN 2 FOLLOWING AND 3 FOLLOWING (window6-5.5)
+    assert!(validate_frame(&frame(FrameUnit::Rows, following(2), Some(following(3)))).is_ok());
+    // BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+    assert!(validate_frame(&frame(
+        FrameUnit::Range,
+        FrameBound::UnboundedPreceding,
+        Some(FrameBound::UnboundedFollowing),
+    ))
+    .is_ok());
+    // BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING (window1-10.5)
+    assert!(validate_frame(&frame(
+        FrameUnit::Rows,
+        FrameBound::CurrentRow,
+        Some(FrameBound::UnboundedFollowing),
+    ))
+    .is_ok());
+    // Single CURRENT ROW bound
+    assert!(validate_frame(&frame(FrameUnit::Rows, FrameBound::CurrentRow, None)).is_ok());
+}

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/aggregate_function.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/aggregate_function.rs
@@ -234,6 +234,45 @@ fn extract_collations(order_items: &[vibesql_ast::OrderByItem]) -> Vec<Option<St
         .collect()
 }
 
+/// Return the display name of the first aggregate function nested anywhere
+/// within `expr`, or `None` if there is none.
+///
+/// Used to detect an aggregate illegally nested inside another aggregate's
+/// FILTER clause (SQLite: "misuse of aggregate function X()"). Window functions
+/// are intentionally *not* matched here — they are diagnosed elsewhere with
+/// their own "misuse of window function" wording.
+fn first_nested_aggregate_name(expr: &vibesql_ast::Expression) -> Option<String> {
+    use vibesql_ast::Expression;
+    match expr {
+        Expression::AggregateFunction { name, .. } => Some(name.display().to_string()),
+        Expression::Function { args, .. } => args.iter().find_map(first_nested_aggregate_name),
+        Expression::BinaryOp { left, right, .. } => {
+            first_nested_aggregate_name(left).or_else(|| first_nested_aggregate_name(right))
+        }
+        Expression::UnaryOp { expr, .. } => first_nested_aggregate_name(expr),
+        Expression::Case { operand, when_clauses, else_result, .. } => operand
+            .as_ref()
+            .and_then(|e| first_nested_aggregate_name(e))
+            .or_else(|| {
+                when_clauses.iter().find_map(|clause| {
+                    clause
+                        .conditions
+                        .iter()
+                        .find_map(first_nested_aggregate_name)
+                        .or_else(|| first_nested_aggregate_name(&clause.result))
+                })
+            })
+            .or_else(|| else_result.as_ref().and_then(|e| first_nested_aggregate_name(e))),
+        Expression::InList { expr, values, .. } => first_nested_aggregate_name(expr)
+            .or_else(|| values.iter().find_map(first_nested_aggregate_name)),
+        Expression::Between { expr, low, high, .. } => first_nested_aggregate_name(expr)
+            .or_else(|| first_nested_aggregate_name(low))
+            .or_else(|| first_nested_aggregate_name(high)),
+        Expression::Collate { expr, .. } => first_nested_aggregate_name(expr),
+        _ => None,
+    }
+}
+
 /// Validate aggregate function argument count
 /// Returns error with SQLite-compatible message if validation fails
 /// `name` is the FunctionIdentifier which provides both canonical (lowercase) and display forms
@@ -361,6 +400,18 @@ pub(super) fn evaluate(
         }
     };
 
+    // An aggregate function may not appear inside another aggregate's FILTER
+    // clause. SQLite reports this verbatim as "misuse of aggregate function
+    // X()" (filter1-2.3) — note this is the "function" spelling, distinct from
+    // the "misuse of aggregate: X()" context error used for a stray aggregate
+    // in e.g. ORDER BY. A window function nested in the FILTER is diagnosed
+    // separately by the evaluator ("misuse of window function X()").
+    if let Some(filter_expr) = filter {
+        if let Some(inner_name) = first_nested_aggregate_name(filter_expr) {
+            return Err(ExecutorError::MisuseOfAggregate { function_name: inner_name });
+        }
+    }
+
     // Validate argument count first
     validate_aggregate_args(name, args)?;
 
@@ -388,8 +439,13 @@ pub(super) fn evaluate(
     }
 
     // Special handling for COUNT(*)
-    if name.to_uppercase() == "COUNT" && args.len() == 1 {
-        let is_count_star = matches!(args[0], vibesql_ast::Expression::Wildcard)
+    //
+    // A bare `count()` with no arguments is equivalent to `count(*)` in SQLite,
+    // so it takes this same path (it must still be honored when it carries a
+    // FILTER clause, which routes through the row-oriented evaluator here).
+    if name.to_uppercase() == "COUNT" && args.len() <= 1 {
+        let is_count_star = args.is_empty()
+            || matches!(args[0], vibesql_ast::Expression::Wildcard)
             || matches!(
                 &args[0],
                 vibesql_ast::Expression::ColumnRef(col_id) if col_id.schema_canonical().is_none() && col_id.table_canonical().is_none() && col_id.column_canonical() == "*"

--- a/crates/vibesql-executor/src/select/executor/builder.rs
+++ b/crates/vibesql-executor/src/select/executor/builder.rs
@@ -577,7 +577,8 @@ impl<'a> SelectExecutor<'a> {
         // Scan SELECT list for MAX or MIN aggregates on a column
         for item in select_list {
             if let vibesql_ast::SelectItem::Expression { expr, .. } = item {
-                if let vibesql_ast::Expression::AggregateFunction { name, args, .. } = expr {
+                if let vibesql_ast::Expression::AggregateFunction { name, args, filter, .. } = expr
+                {
                     let name_upper = name.to_uppercase();
 
                     // We only care about MAX/MIN aggregates on columns
@@ -587,6 +588,22 @@ impl<'a> SelectExecutor<'a> {
                         let mut best_val: Option<SqlValue> = None;
 
                         for (idx, row) in group_rows.iter().enumerate() {
+                            evaluator.clear_cse_cache();
+
+                            // Honor the aggregate's FILTER (WHERE ...) clause: a
+                            // row excluded by the filter cannot determine the
+                            // MIN/MAX, so it cannot be the representative row for
+                            // bare column references. When the filter excludes
+                            // every row, no representative is found and the caller
+                            // falls back to the first row of the group — matching
+                            // SQLite (filter1-3.3 / 3.5).
+                            if let Some(filter_expr) = filter {
+                                match evaluator.eval(filter_expr, row) {
+                                    Ok(fv) if self.is_truthy(&fv).unwrap_or(false) => {}
+                                    _ => continue,
+                                }
+                            }
+
                             if let Ok(val) = evaluator.eval(&args[0], row) {
                                 // Skip NULL values
                                 if matches!(val, SqlValue::Null) {

--- a/crates/vibesql-executor/tests/filter_clause_semantics_tests.rs
+++ b/crates/vibesql-executor/tests/filter_clause_semantics_tests.rs
@@ -1,0 +1,114 @@
+//! Regression tests for aggregate `FILTER (WHERE ...)` clause semantics.
+//!
+//! Covers the filter1.test edge cases fixed under issue #6191:
+//! - a bare `count()` (zero-arg, == `count(*)`) still honors a FILTER clause
+//!   (filter1-8.0);
+//! - a bare column reference with GROUP BY follows the row that produced the
+//!   *filtered* MIN/MAX — and falls back to the first row of the group when the
+//!   FILTER excludes every row (filter1-3.3 / 3.5);
+//! - an aggregate nested inside another aggregate's FILTER is rejected with
+//!   SQLite's "misuse of aggregate function X()" wording (filter1-2.3).
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+fn int(n: i64) -> SqlValue {
+    SqlValue::Integer(n)
+}
+
+fn text(s: &str) -> SqlValue {
+    SqlValue::Varchar(arcstr::ArcStr::from(s))
+}
+
+/// Execute one DDL/DML statement against `db`.
+fn exec(db: &mut vibesql_storage::Database, sql: &str) {
+    match vibesql_parser::Parser::parse_sql(sql).unwrap() {
+        vibesql_ast::Statement::CreateTable(ct) => {
+            vibesql_executor::CreateTableExecutor::execute(&ct, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(ins) => {
+            vibesql_executor::InsertExecutor::execute(db, &ins).unwrap();
+        }
+        other => panic!("unexpected statement for `{sql}`: {other:?}"),
+    }
+}
+
+/// Run a SELECT and return its rows as nested value vectors.
+fn query(db: &vibesql_storage::Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let executor = SelectExecutor::new(db);
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select) = stmt {
+        let result = executor.execute_with_columns(&select).unwrap();
+        result.rows.into_iter().map(|r| r.values.to_vec()).collect()
+    } else {
+        panic!("expected SELECT for `{sql}`");
+    }
+}
+
+// filter1-8.0: a bare `count()` with a FILTER counts only the matching rows.
+#[test]
+fn test_bare_count_with_filter() {
+    let mut db = vibesql_storage::Database::new();
+    exec(&mut db, "CREATE TABLE t(a, b)");
+    exec(&mut db, "INSERT INTO t(a, b) VALUES (1, NULL), (2, 3), (4, NULL)");
+
+    // count() == count(*), so with no FILTER it counts every row.
+    assert_eq!(query(&db, "SELECT count() FROM t"), vec![vec![int(3)]]);
+    // With a FILTER only the two NULL-b rows qualify.
+    assert_eq!(query(&db, "SELECT count() FILTER (WHERE b IS NULL) FROM t"), vec![vec![int(2)]]);
+}
+
+// filter1-3.3: `max(b) FILTER (WHERE c='x')` matches no rows in either group,
+// so the bare column `c` falls back to the *first* row of each group (3 and 6),
+// not the last.
+#[test]
+fn test_bare_column_falls_back_to_first_row_when_filter_empty() {
+    let mut db = vibesql_storage::Database::new();
+    exec(&mut db, "CREATE TABLE t2(a, b, c)");
+    exec(&mut db, "INSERT INTO t2(a, b, c) VALUES (1, 2, 3), (1, 3, 4), (2, 5, 6), (2, 7, 8)");
+
+    let rows = query(&db, "SELECT a, c, max(b) FILTER (WHERE c='x') FROM t2 GROUP BY a");
+    assert_eq!(
+        rows,
+        vec![vec![int(1), int(3), SqlValue::Null], vec![int(2), int(6), SqlValue::Null],]
+    );
+}
+
+// filter1-3.5: the bare column follows the row producing the *filtered* max.
+// Group a=1 has c='x' rows, so max(b) FILTER picks b=5 from the ('x') row and
+// the bare c reports 'x'. Group a=2 has no c='x' row, so it falls back to the
+// first row (c=6) with a NULL max.
+#[test]
+fn test_bare_column_follows_filtered_max_row() {
+    let mut db = vibesql_storage::Database::new();
+    exec(&mut db, "CREATE TABLE t2(a, b, c)");
+    exec(
+        &mut db,
+        "INSERT INTO t2(a, b, c) VALUES (1, 5, 'x'), (1, 2, 3), (1, 4, 'x'), (2, 5, 6), (2, 7, 8)",
+    );
+
+    let rows = query(&db, "SELECT a, c, max(b) FILTER (WHERE c='x') FROM t2 GROUP BY a");
+    assert_eq!(rows, vec![vec![int(1), text("x"), int(5)], vec![int(2), int(6), SqlValue::Null],]);
+}
+
+// filter1-2.3: an aggregate nested inside another aggregate's FILTER is a misuse
+// reported as "misuse of aggregate function count()".
+#[test]
+fn test_aggregate_nested_in_filter_is_misuse() {
+    let mut db = vibesql_storage::Database::new();
+    exec(&mut db, "CREATE TABLE t1(a)");
+    exec(&mut db, "INSERT INTO t1(a) VALUES (1), (2), (3)");
+
+    let executor = SelectExecutor::new(&db);
+    let stmt =
+        vibesql_parser::Parser::parse_sql("SELECT sum(a) FILTER (WHERE 1 - count(a)) FROM t1")
+            .unwrap();
+    let vibesql_ast::Statement::Select(select) = stmt else {
+        panic!("expected SELECT");
+    };
+    let err = executor.execute_with_columns(&select).expect_err("nested aggregate must error");
+    assert!(
+        err.to_string().contains("misuse of aggregate function count()"),
+        "unexpected error: {err}"
+    );
+}

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -450,6 +450,15 @@ impl Parser {
         if matches!(self.peek(), Token::Keyword { keyword: Keyword::Over, .. }) {
             self.advance(); // consume OVER
 
+            // DISTINCT is not permitted on any window function. SQLite reports
+            // this verbatim (window6-9.3): `count(DISTINCT x) OVER (...)` ->
+            // "DISTINCT is not supported for window functions".
+            if distinct {
+                return Err(ParseError {
+                    message: "DISTINCT is not supported for window functions".to_string(),
+                });
+            }
+
             // Validate argument count for window functions
             self.validate_window_function_args(&function_name_upper, args.len(), &first)?;
 

--- a/crates/vibesql-parser/src/parser/expressions/functions/window.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/window.rs
@@ -266,6 +266,28 @@ impl Parser {
     }
 
     /// Parse frame clause (ROWS/RANGE/GROUPS BETWEEN ... AND ... [EXCLUDE ...])
+    /// Reject UNBOUNDED FOLLOWING used as a frame *start* bound.
+    ///
+    /// SQLite's grammar (`frame_bound_s`) does not allow UNBOUNDED FOLLOWING at
+    /// the start of a frame; it reports `near "FOLLOWING": syntax error`.
+    fn reject_unbounded_start(bound: &vibesql_ast::FrameBound) -> Result<(), ParseError> {
+        if matches!(bound, vibesql_ast::FrameBound::UnboundedFollowing) {
+            return Err(ParseError { message: "near \"FOLLOWING\": syntax error".to_string() });
+        }
+        Ok(())
+    }
+
+    /// Reject UNBOUNDED PRECEDING used as a frame *end* bound.
+    ///
+    /// SQLite's grammar (`frame_bound_e`) does not allow UNBOUNDED PRECEDING at
+    /// the end of a frame; it reports `near "PRECEDING": syntax error`.
+    fn reject_unbounded_end(bound: &vibesql_ast::FrameBound) -> Result<(), ParseError> {
+        if matches!(bound, vibesql_ast::FrameBound::UnboundedPreceding) {
+            return Err(ParseError { message: "near \"PRECEDING\": syntax error".to_string() });
+        }
+        Ok(())
+    }
+
     pub(super) fn parse_frame_clause(&mut self) -> Result<vibesql_ast::WindowFrame, ParseError> {
         // Parse frame unit (ROWS, RANGE, or GROUPS)
         let unit = match self.peek() {
@@ -297,15 +319,25 @@ impl Parser {
                 self.advance(); // consume BETWEEN
 
                 let start = self.parse_frame_bound()?;
+                // A start bound may not be UNBOUNDED FOLLOWING (SQLite grammar:
+                // frame_bound_s excludes UNBOUNDED FOLLOWING). SQLite reports a
+                // syntax error at the FOLLOWING token.
+                Self::reject_unbounded_start(&start)?;
 
                 self.expect_keyword(Keyword::And)?;
 
                 let end = self.parse_frame_bound()?;
+                // An end bound may not be UNBOUNDED PRECEDING (SQLite grammar:
+                // frame_bound_e excludes UNBOUNDED PRECEDING). SQLite reports a
+                // syntax error at the PRECEDING token.
+                Self::reject_unbounded_end(&end)?;
 
                 (start, Some(end))
             } else {
-                // Single bound (defaults to CURRENT ROW as end)
+                // Single bound (defaults to CURRENT ROW as end). A single start
+                // bound is subject to the same restriction as a BETWEEN start.
                 let start = self.parse_frame_bound()?;
+                Self::reject_unbounded_start(&start)?;
 
                 (start, None)
             };

--- a/crates/vibesql-parser/src/tests/window_functions.rs
+++ b/crates/vibesql-parser/src/tests/window_functions.rs
@@ -503,3 +503,52 @@ fn test_window_function_argument_count_validation() {
     let sql = "SELECT lag(x, 1, 0) OVER () FROM t";
     assert!(Parser::parse_sql(sql).is_ok(), "lag(x, 1, 0) should work");
 }
+
+// window6.test 9.4/9.5: UNBOUNDED FOLLOWING may not be used as a frame *start*
+// bound. SQLite reports `near "FOLLOWING": syntax error`.
+#[test]
+fn test_frame_start_unbounded_following_rejected() {
+    for sql in [
+        "SELECT count() OVER (ORDER BY x RANGE UNBOUNDED FOLLOWING) FROM c",
+        "SELECT count() OVER (ORDER BY x RANGE BETWEEN UNBOUNDED FOLLOWING AND UNBOUNDED FOLLOWING) FROM c",
+    ] {
+        let err = Parser::parse_sql(sql).expect_err("UNBOUNDED FOLLOWING start must error");
+        assert!(
+            err.message.contains("near \"FOLLOWING\": syntax error"),
+            "unexpected error for {sql:?}: {err:?}"
+        );
+    }
+}
+
+// window6.test 9.6: UNBOUNDED PRECEDING may not be used as a frame *end* bound.
+// SQLite reports `near "PRECEDING": syntax error`.
+#[test]
+fn test_frame_end_unbounded_preceding_rejected() {
+    let sql =
+        "SELECT count() OVER (ORDER BY x RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED PRECEDING) FROM c";
+    let err = Parser::parse_sql(sql).expect_err("UNBOUNDED PRECEDING end must error");
+    assert!(err.message.contains("near \"PRECEDING\": syntax error"), "unexpected error: {err:?}");
+}
+
+// A full-partition frame `BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING`
+// must still parse — the bound restrictions only reject the reversed forms.
+#[test]
+fn test_frame_unbounded_preceding_to_following_ok() {
+    let sql =
+        "SELECT sum(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM c";
+    assert!(
+        Parser::parse_sql(sql).is_ok(),
+        "UNBOUNDED PRECEDING..UNBOUNDED FOLLOWING should parse"
+    );
+}
+
+// window6.test 9.3: DISTINCT is not permitted on a window aggregate.
+#[test]
+fn test_distinct_window_aggregate_rejected() {
+    let sql = "SELECT count(DISTINCT x) OVER (ORDER BY x) FROM c";
+    let err = Parser::parse_sql(sql).expect_err("DISTINCT window aggregate must error");
+    assert!(
+        err.message.contains("DISTINCT is not supported for window functions"),
+        "unexpected error: {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Second wave on epic #5779's window-frame / aggregate-`FILTER` conformance tail (#6191, follow-up to merged PR #6215). The parsing/evaluation machinery already exists end-to-end; these are edge-case **semantic-correctness** gaps. All counts below are from a **fresh release build** running the SQLite `.test` corpus, not certified `run_id=1`.

## Triage clusters (fresh build)

| Cluster | Tests | Disposition |
|---|---|---|
| Frame-spec ordering validation | window6 9.7.1–9.7.4 | **Fixed** — `unsupported frame specification` |
| Frame-bound grammar (UNBOUNDED start/end) | window6 9.4, 9.5, 9.6 | **Fixed** — `near "FOLLOWING"/"PRECEDING": syntax error` |
| Bare `count()` (zero-arg) + FILTER | filter1 8.0 | **Fixed** |
| Bare column follows *filtered* MIN/MAX | filter1 3.3, 3.5 | **Fixed** |
| Aggregate nested in FILTER (misuse wording) | filter1 2.3 | **Fixed** |
| DISTINCT on a window function | window6 9.3 | **Behavior fixed** (now rejected); exact message blocked by harness (see below) |
| Correlated subquery / aggregate migration | filter1 6.3, window1 10.8 | Residual (deep, deferred) |
| `window`/`over` as table identifiers | window6 4.1, 5.0 | Residual (parser keyword-identifier, deferred) |
| Custom UDF/collation + fault-injection | window5 (whole file), windowfault (whole file), window6 2.0/3.0/3.1 + filescope-err | **Bucket-A → #6154** |

## Per-file before → after (fresh build)

| File | Before | After | Notes |
|---|---|---|---|
| filter1.test | 5 | **1** | only 6.3 (aggregate-migrates-to-outer) remains |
| filter2.test | 0 | **0** | 100% (fixed in prior wave) |
| window6.test | 14 | **7** | fixed 9.4/9.5/9.6/9.7.1–4; remainder are straddlers + 4.1/5.0/9.3 |
| window1.test | 1 | **1** | 10.8 (correlated window FILTER) |
| window5.test | 9 | 9 | **entirely Bucket-A** (`sqlite3_create_window_function`) |
| windowfault.test | 4 | 4 | **entirely Bucket-A** (OOM `do_faultsim_test`) |

Net: **11 conformance tests flipped green**, plus window6-9.3 behavior corrected.

## Straddlers routed to Bucket-A #6154 (NOT engine work)

- **window5.test (all 9)** — the whole file exercises `sqlite3_create_window_function()` (TCL-registered `median`/`win`/`sumint`). The single file-scope setup (custom window-function registration) is a harness-only C-API surface (#5720); the `filescope-err.1..4` markers cascade from it.
- **windowfault.test (all 4)** — `do_faultsim_test` with `oom-*` fault injection + `faultsim_save_and_close`; harness scaffolding, not a SQL gap.
- **window6 2.0 / 3.0 / 3.1 + window6-filescope-err.1** — `db func window winproc` (custom UDF) and `db collate window wincmp` (custom collation).

## Residuals kept visible (real, but out of this wave's scope)

- **filter1-6.3**: `SELECT (SELECT COUNT(a) FROM t2) FROM t1` where the inner aggregate references only outer columns must migrate to the outer query (single-row `2`). Deep correlated-aggregate name-resolution; deferred.
- **window1-10.8**: a window aggregate whose `FILTER` references a correlated outer column is not re-evaluated per outer row. Correlated-subquery caching; deferred.
- **window6-4.1 / 5.0**: `window` / `over` used as table names/aliases — parser keyword-as-identifier ambiguity; deferred to avoid broad parser risk.
- **window6-9.3**: the engine now correctly **rejects** `count(DISTINCT x) OVER (...)`, but the exact SQLite message `DISTINCT is not supported for window functions` is emitted as a parse error, which the TCL shim wraps as `near "...": syntax error`. Matching it verbatim needs a shim allowlist entry (a #6154-adjacent harness change) — deliberately not touched here per scope.

## Changes

- `crates/vibesql-parser/.../functions/window.rs` — reject UNBOUNDED FOLLOWING (start) / UNBOUNDED PRECEDING (end) frame bounds.
- `crates/vibesql-parser/.../functions/mod.rs` — reject DISTINCT on window functions.
- `crates/vibesql-executor/.../window/frames.rs` — `validate_frame` bound-ordering check.
- `crates/vibesql-executor/.../aggregation/evaluation/aggregate_function.rs` — zero-arg `count()` == `count(*)`; nested-aggregate-in-FILTER misuse.
- `crates/vibesql-executor/.../executor/builder.rs` — `find_representative_row_index` honors the aggregate FILTER.

## Test Plan

- New/extended Rust regression tests: `window/tests/frames.rs` (validate_frame ordering), `parser/tests/window_functions.rs` (frame-bound + DISTINCT-window), and a new `tests/filter_clause_semantics_tests.rs` (count()+FILTER, bare-column follows filtered max, nested-aggregate misuse).
- **Full unfiltered suites green**: `cargo test -p vibesql-parser` (1785 lib) and `cargo test -p vibesql-executor` (3557 lib + all integration binaries), 0 failures.
- Per-file TCL counts above captured on a fresh `cargo build --release`.

## Acceptance Criteria

| Criterion | Status | Verification |
|---|---|---|
| filter2 100%; filter1 residuals explained | ✅ | filter2 0 fails; filter1 only 6.3 (explained residual) |
| window1 residual explained | ✅ | 10.8 explained (correlated window FILTER) |
| window5/6 real frame gaps fixed; straddlers → #6154 | ✅ | window6 9.4–9.7 fixed; window5 + db-func/collate routed to #6154 |
| windowfault confirmed Bucket-A | ✅ | OOM `do_faultsim_test` scaffolding |
| Before/after from fresh build | ✅ | table above |
| No regression in window/aggregate unit tests | ✅ | full crate suites green |

Part of #6191