### PR TITLE
fix(executor): materialize VALUES leaves in comma joins and correlate VALUES scalar subqueries

### DIFF
--- a/crates/vibesql-executor/src/evaluator/combined/subqueries/correlation.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/subqueries/correlation.rs
@@ -223,6 +223,26 @@ fn collect_correlation_refs(
         }
     }
 
+    // Check a top-level VALUES form (`(VALUES(x),(x))` as a scalar subquery).
+    // These rows are stored in `subquery.values`, not in a FROM clause, so
+    // without this check a correlated VALUES scalar subquery is treated as
+    // uncorrelated, cached once, and returns the same value for every outer
+    // row (e.g. `SELECT (VALUES(x),(x)) FROM t1` yielding 1,1 instead of 1,2).
+    // (values.test §6.1)
+    if let Some(rows) = &subquery.values {
+        for row in rows {
+            for expr in row {
+                collect_correlation_refs_from_expr(
+                    expr,
+                    outer_schema,
+                    subquery_tables,
+                    database,
+                    refs,
+                );
+            }
+        }
+    }
+
     // FIX for issue #4994: Check FROM clause for derived tables that reference outer columns
     // This is critical for queries like:
     //   SELECT x+1 FROM (SELECT f/d AS x FROM t2 JOIN t3 ON d*a=f)

--- a/crates/vibesql-executor/src/select/scan/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/mod.rs
@@ -110,7 +110,14 @@ where
         //
         // 2-table joins benefit from choosing optimal build/probe sides when one
         // table has highly selective predicates.
-        if reorder::should_apply_join_reordering(table_count) && reorder::all_joins_are_cross(from)
+        if reorder::should_apply_join_reordering(table_count)
+            && reorder::all_joins_are_cross(from)
+            // A comma/CROSS-join whose leaf is an inline `(VALUES ...)` cannot be
+            // materialized by the reorder path (TableRef has no row-list variant),
+            // which would raise a spurious "Table '_values_' not found". Fall
+            // through to the standard left-deep path, which handles VALUES leaves
+            // correctly. (values.test §6, §8)
+            && !reorder::from_contains_values(from)
         {
             // Apply join reordering optimization
             return reorder::execute_with_join_reordering(

--- a/crates/vibesql-executor/src/select/scan/reorder/mod.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/mod.rs
@@ -17,4 +17,6 @@ mod utils;
 
 // Re-export public API
 pub(crate) use optimizer::{execute_with_join_reordering, execute_with_semi_join_reordering};
-pub(crate) use utils::{all_joins_are_cross, count_tables_in_from, should_apply_join_reordering};
+pub(crate) use utils::{
+    all_joins_are_cross, count_tables_in_from, from_contains_values, should_apply_join_reordering,
+};

--- a/crates/vibesql-executor/src/select/scan/reorder/utils.rs
+++ b/crates/vibesql-executor/src/select/scan/reorder/utils.rs
@@ -104,6 +104,29 @@ pub(crate) fn count_tables_in_from(from: &FromClause) -> usize {
     }
 }
 
+/// Check whether a FROM tree contains a `VALUES` table constructor leaf.
+///
+/// The join-reordering path materializes each leaf via `TableRef`, which only
+/// carries a name/subquery — it has no representation for an inline `VALUES`
+/// row list. A comma/CROSS-join whose right side is `(VALUES ...)` therefore
+/// resolves the synthetic `_values_` alias as a missing table and errors out
+/// ("Table '_values_' not found"). Reordering a tiny inline `VALUES` clause has
+/// no meaningful benefit anyway, so we suppress reordering when one is present
+/// and let the standard left-deep join path (which materializes `VALUES`
+/// correctly via `execute_from_clause`) handle it. Mirrors the lateral-TVF
+/// suppression in `execute_from_clause`. (values.test §6, §8)
+pub(crate) fn from_contains_values(from: &FromClause) -> bool {
+    match from {
+        FromClause::Values { .. } => true,
+        FromClause::Table { .. }
+        | FromClause::Subquery { .. }
+        | FromClause::TableFunction { .. } => false,
+        FromClause::Join { left, right, .. } => {
+            from_contains_values(left) || from_contains_values(right)
+        }
+    }
+}
+
 /// Check if all joins in the tree are CROSS joins (comma-list syntax)
 ///
 /// Join reordering changes column ordering, so we only apply it to implicit CROSS joins

--- a/crates/vibesql-executor/tests/with_values_tests.rs
+++ b/crates/vibesql-executor/tests/with_values_tests.rs
@@ -266,6 +266,43 @@ fn test_values_left_arm_compound_order_by() {
     );
 }
 
+/// A comma/CROSS-join whose right leaf is an inline `(VALUES ...)` table must
+/// materialize the VALUES rows rather than resolving the synthetic `_values_`
+/// alias as a missing table (values.test 6.1: `SELECT * FROM t1, (VALUES...)`).
+/// Comma-list joins go through the join-reordering path, which had no
+/// representation for an inline VALUES leaf and raised "Table '_values_' not
+/// found"; reordering is now suppressed when a VALUES leaf is present.
+#[test]
+fn test_comma_join_with_values_table() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t1(x)");
+    run_stmt(&mut db, "INSERT INTO t1 VALUES('x'),('y')");
+    let expected = vec![
+        vec![SqlValue::Varchar(arcstr::ArcStr::from("x")), SqlValue::Integer(1)],
+        vec![SqlValue::Varchar(arcstr::ArcStr::from("x")), SqlValue::Integer(2)],
+        vec![SqlValue::Varchar(arcstr::ArcStr::from("y")), SqlValue::Integer(1)],
+        vec![SqlValue::Varchar(arcstr::ArcStr::from("y")), SqlValue::Integer(2)],
+    ];
+    // Bare comma-list syntax.
+    assert_eq!(query(&db, "SELECT * FROM t1, (VALUES(1),(2))"), expected);
+    // Explicit CROSS JOIN with an alias goes down the same reorder path.
+    assert_eq!(query(&db, "SELECT * FROM t1 CROSS JOIN (VALUES(1),(2)) AS v"), expected);
+}
+
+/// A correlated scalar subquery whose body is a top-level `VALUES` form
+/// (`SELECT (VALUES(x),(x)) FROM t1`) must be re-evaluated per outer row.
+/// Correlation detection previously ignored `SelectStmt.values`, so the
+/// subquery was treated as uncorrelated and cached — yielding 1,1 instead of
+/// 1,2 (values.test 6.1).
+#[test]
+fn test_correlated_scalar_values_subquery() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t1(x)");
+    run_stmt(&mut db, "INSERT INTO t1 VALUES(1),(2)");
+    let rows = query(&db, "SELECT ( VALUES( x ), ( x ) ) FROM t1");
+    assert_eq!(rows, vec![vec![SqlValue::Integer(1)], vec![SqlValue::Integer(2)]]);
+}
+
 /// `CREATE TABLE ... AS SELECT * FROM (VALUES ...)` names the derived columns
 /// `column1`, `column2`, ... rather than erroring (values.test 17.1 / 17.2).
 #[test]


### PR DESCRIPTION
## Summary

Fixes two independent `VALUES`-clause correctness bugs surfaced by SQLite's `values.test`, part of the certified failure tail (#6177) under epic #5779. Both are general engine correctness bugs (not test-specific), each with a clear root cause and a regression test.

`values.test`: **93 → 97 passed** (16 → 14 failures) on a fresh `--release` build.

## Changes

- **Comma/CROSS-join with an inline `VALUES` leaf** (`SELECT * FROM t1, (VALUES(1),(2))`): comma-list joins route through the join-reordering path, which materializes each leaf via a `TableRef` that has **no representation for an inline `VALUES` row list**. The synthetic `_values_` alias (or a user alias) was then resolved as a missing table — `Table '_values_' not found`. Fix: suppress reordering when a `VALUES` leaf is present (new `reorder::from_contains_values`), so the query falls through to the standard left-deep path, which materializes `VALUES` correctly via `execute_from_clause`. This mirrors the existing lateral-TVF reordering suppression. Reordering a tiny inline table constructor has no meaningful benefit, so nothing is lost.

- **Correlated scalar subquery with a top-level `VALUES` body** (`SELECT (VALUES(x),(x)) FROM t1`): correlation detection scanned the subquery's `WHERE`, `SELECT` list, `HAVING`, `GROUP BY`, `FROM`, and set-ops — but never `SelectStmt.values`, where a bare-`VALUES` subquery stores its rows. The subquery was misclassified as uncorrelated, cached once, and returned the first outer row's value for every row (`1,1` instead of `1,2`). Fix: scan the top-level `VALUES` rows for correlation refs.

- **Regression tests** added to `crates/vibesql-executor/tests/with_values_tests.rs` for both constructs (comma + aliased CROSS join; correlated scalar VALUES subquery).

## Acceptance Criteria Verification

| Criterion (issue #6190) | Status | Verification |
|---|---|---|
| `values.test` reports strictly fewer than 33 failures | ✅ | 14 failures (was 16 on current main; the certified baseline of 33 predates recent VALUES work) |
| Target 0 real failures; residual documented | ⚠️ Partial | 2 fixed here; 12 remaining across two distinct larger sub-features — documented below. Landing a coherent slice per issue guidance ("Part of #6190") |
| `do_catchsql_test` verbatim error messages | n/a | No error-message failures remain in the fixed clusters |
| No regression in Rust unit/integration tests for VALUES | ✅ | Full `cargo test -p vibesql-executor -p vibesql-parser` green (1781 + all integration + doc tests, 0 failed) |
| No new failures in shared code paths | ✅ | Full crate suites green; reorder suppression only *widens* the correct left-deep path |

## Remaining `values.test` failures (out of scope for this slice — follow-ups)

The other 12 failures fall into two distinct, larger sub-features, each meriting its own focused change (higher regression surface, not "smallest surface first"):

1. **Window functions inside a `VALUES` row** (`3.1.1/3.1.2/3.2.1`, `16.2/16.4/16.6` — 6 tests + the `filescope-err` cascade). `INSERT ... VALUES(row_number() OVER (), 5)` errors with `misuse of window function`. SQLite evaluates each such row as a single-row co-routine subquery (`row_number() OVER ()` = 1). This requires window-in-VALUES-row support through both the VALUES-scan and INSERT-VALUES paths.
2. **RIGHT JOIN row ordering with a `VALUES` derived table** (`8.1.3.*`, `8.1.4.*` — 6 tests). The join now produces the **correct rows with correct content**, but the **row order** differs from SQLite (SQLite emits RIGHT JOIN rows left-table-driven / matched-first). This is entangled with general RIGHT/FULL join ordering semantics and carries cross-suite regression risk, so it belongs in a dedicated change with a full join-suite run.

## Test Plan

- `cargo build --release && make test-tcl-file FILE=values.test` → 97/113 passed (was 93).
- `cargo test -p vibesql-executor -p vibesql-parser` → all green, 0 failed (unit + integration + doc tests), including `with_values_tests`, `select_values`, and `values_statement`.
- New tests `test_comma_join_with_values_table` and `test_correlated_scalar_values_subquery` pass.
- `cargo clippy -p vibesql-executor` → no new warnings in changed files.

Part of #6190
Part of epic #5779