### PR TITLE
fix(executor): stop HAVING-only aggregates leaking into projection; reject aggregates in GROUP BY

### DIFF
--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -91,6 +91,10 @@ pub enum ExecutorError {
     MisuseOfAliasedWindowFunction {
         alias_name: String,
     },
+    /// Aggregate function used in a GROUP BY clause (SQLite-compatible error)
+    /// e.g., `SELECT max(a) FROM t GROUP BY max(b)`
+    /// Format: "aggregate functions are not allowed in the GROUP BY clause"
+    AggregateInGroupBy,
     /// Row value used in scalar context (SQLite-compatible error)
     /// e.g., HAVING (SELECT (a, b)) — a row value where a scalar is expected
     /// Format: "row value misused"
@@ -697,6 +701,10 @@ impl std::fmt::Display for ExecutorError {
             ExecutorError::MisuseOfAliasedWindowFunction { alias_name } => {
                 // SQLite-compatible error message format
                 write!(f, "misuse of aliased window function {}", alias_name)
+            }
+            ExecutorError::AggregateInGroupBy => {
+                // SQLite-compatible error message format (parse.c)
+                write!(f, "aggregate functions are not allowed in the GROUP BY clause")
             }
             ExecutorError::RowValueMisused => {
                 // SQLite-compatible error message format

--- a/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/mod.rs
@@ -229,6 +229,19 @@ impl SelectExecutor<'_> {
                         function_name: window_name,
                     });
                 }
+
+                // Aggregate functions are not allowed directly in a GROUP BY
+                // expression. SQLite rejects these at compile time with a fixed
+                // message rather than evaluating them (e_select-4.12, #6192),
+                // e.g. `SELECT max(a) FROM t GROUP BY max(b)` or
+                // `GROUP BY count(*)`. Check the expression as written; a bare
+                // positional/alias reference to an aggregate SELECT item is a
+                // legal grouping key, so only the direct form is rejected here.
+                if crate::select::executor::validation::find_aggregate_in_expression(group_expr)
+                    .is_some()
+                {
+                    return Err(crate::errors::ExecutorError::AggregateInGroupBy);
+                }
             }
         }
 

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/mod.rs
@@ -536,6 +536,11 @@ impl SelectExecutor<'_> {
         let has_unsupported_select_aggregates = select_aggregates.is_none();
         let mut aggregates = select_aggregates.unwrap_or_default();
 
+        // Number of aggregates that belong to the SELECT projection. Any
+        // aggregates appended below for HAVING-only predicates land *after*
+        // these and must be stripped from the output projection (Issue #6192).
+        let select_agg_count = aggregates.len();
+
         // Add aggregates from HAVING if not already present
         let mut has_unsupported_having_aggregates = false;
         if !having_aggregates.is_empty() {
@@ -722,7 +727,7 @@ impl SelectExecutor<'_> {
         #[cfg(feature = "profile-q6")]
         let exec_start = std::time::Instant::now();
 
-        let result = if has_group_by {
+        let mut result = if has_group_by {
             // GROUP BY path: Use hash-based grouping
             // Catch unsupported feature errors and fall back to row-oriented execution
             let group_by_result = match self.execute_columnar_group_by(
@@ -848,6 +853,23 @@ impl SelectExecutor<'_> {
         {
             let exec_time = exec_start.elapsed();
             eprintln!("[PROFILE-Q6] Native columnar execution: {:?}", exec_time);
+        }
+
+        // Strip HAVING-only aggregate columns from the output projection.
+        //
+        // Aggregates that appear *only* in a HAVING predicate (e.g.
+        // `SELECT up FROM t GROUP BY up HAVING sum(down) > 16`) are appended to
+        // `aggregates` above purely so the predicate can be evaluated. The
+        // grouped result layout is `[group_keys..., select_aggregates...,
+        // having_only_aggregates...]`, so those extra values are always the
+        // trailing columns. They must not leak into the result set (Issue
+        // #6192). The HAVING filter has already consumed them by this point.
+        let having_only_agg_count = aggregates.len().saturating_sub(select_agg_count);
+        if having_only_agg_count > 0 {
+            for row in &mut result {
+                let keep = row.values.len().saturating_sub(having_only_agg_count);
+                row.values.truncate(keep);
+            }
         }
 
         log::info!(

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -125,6 +125,7 @@ mod secondary_index_fast_path;
 mod select_basic_projection;
 mod select_derived_columns;
 mod select_distinct;
+mod select_having_projection;
 mod select_into_tests;
 mod select_joins;
 mod select_order_by;

--- a/crates/vibesql-executor/src/tests/select_having_projection.rs
+++ b/crates/vibesql-executor/src/tests/select_having_projection.rs
@@ -1,0 +1,144 @@
+//! SELECT documentation-evidence semantics for HAVING projection and
+//! GROUP BY validation (issue #6192, SQLite `e_select.test`).
+//!
+//! Two behaviors are pinned here independent of the TCL harness:
+//!
+//! 1. An aggregate that appears *only* in a HAVING predicate must not leak
+//!    into the result set as an extra column. The native columnar aggregation
+//!    path appended the HAVING-only aggregate to the row layout so the
+//!    predicate could be evaluated, but never stripped it from the output
+//!    projection (`e_select-4.13.1.*`).
+//!
+//! 2. An aggregate function used directly in a GROUP BY expression is a
+//!    compile-time error in SQLite with the fixed wording
+//!    "aggregate functions are not allowed in the GROUP BY clause"
+//!    (`e_select-4.12.*`), not the generic "misuse of aggregate" message.
+
+use vibesql_ast::Statement;
+use vibesql_parser::Parser;
+
+use super::super::*;
+
+/// Execute a DDL/DML statement, panicking on any error.
+fn exec_setup(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).unwrap();
+    match stmt {
+        Statement::CreateTable(create_stmt) => {
+            CreateTableExecutor::execute(&create_stmt, db).unwrap();
+        }
+        Statement::Insert(insert_stmt) => {
+            InsertExecutor::execute(db, &insert_stmt).unwrap();
+        }
+        other => panic!("unexpected setup statement: {other:?}"),
+    }
+}
+
+/// Run a SELECT and return the resulting rows.
+fn run_select(
+    db: &vibesql_storage::Database,
+    sql: &str,
+) -> Result<Vec<vibesql_storage::Row>, crate::ExecutorError> {
+    let stmt = Parser::parse_sql(sql).unwrap();
+    match stmt {
+        Statement::Select(select_stmt) => {
+            let executor = SelectExecutor::new(db);
+            executor.execute(&select_stmt)
+        }
+        other => panic!("expected SELECT, got {other:?}"),
+    }
+}
+
+fn c1_db() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    exec_setup(&mut db, "CREATE TABLE c1(up, down)");
+    for (up, down) in [("x", 1), ("x", 2), ("x", 4), ("x", 8), ("y", 16), ("y", 32)] {
+        exec_setup(&mut db, &format!("INSERT INTO c1 VALUES('{up}', {down})"));
+    }
+    db
+}
+
+/// e_select-4.13.1.1: a HAVING-only aggregate (`count(*)`) must not appear in
+/// the projected result — the query selects a single column `up`.
+#[test]
+fn having_only_count_star_does_not_leak_column() {
+    let db = c1_db();
+    let rows = run_select(&db, "SELECT up FROM c1 GROUP BY up HAVING count(*)>3").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values.len(), 1, "HAVING count(*) leaked into projection");
+    assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Varchar("x".into()));
+}
+
+/// e_select-4.13.1.2 / 4.13.1.3: a HAVING-only `sum()` aggregate must not leak.
+#[test]
+fn having_only_sum_does_not_leak_column() {
+    let db = c1_db();
+
+    let rows = run_select(&db, "SELECT up FROM c1 GROUP BY up HAVING sum(down)>16").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values.len(), 1, "HAVING sum(down) leaked into projection");
+    assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Varchar("y".into()));
+
+    let rows = run_select(&db, "SELECT up FROM c1 GROUP BY up HAVING sum(down)<16").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values.len(), 1, "HAVING sum(down) leaked into projection");
+    assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Varchar("x".into()));
+}
+
+/// A HAVING aggregate that is *also* selected must still appear exactly once.
+#[test]
+fn having_aggregate_also_in_select_is_not_double_counted() {
+    let db = c1_db();
+    let rows =
+        run_select(&db, "SELECT up, count(*) FROM c1 GROUP BY up HAVING count(*)>3").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values.len(), 2, "shared HAVING/SELECT aggregate changed column count");
+    assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Varchar("x".into()));
+}
+
+/// A non-aggregate HAVING predicate keeps the projection intact (control).
+#[test]
+fn non_aggregate_having_keeps_projection() {
+    let db = c1_db();
+    let rows = run_select(&db, "SELECT up FROM c1 GROUP BY up HAVING up='y'").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values.len(), 1);
+    assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Varchar("y".into()));
+}
+
+fn b3_db() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    exec_setup(&mut db, "CREATE TABLE b3(a COLLATE nocase, b COLLATE binary)");
+    for (a, b) in [("abc", "abc"), ("aBC", "aBC"), ("Def", "Def"), ("dEF", "dEF")] {
+        exec_setup(&mut db, &format!("INSERT INTO b3 VALUES('{a}', '{b}')"));
+    }
+    db
+}
+
+/// e_select-4.12.*: an aggregate function used directly in GROUP BY is a
+/// compile-time error with SQLite's exact wording.
+#[test]
+fn aggregate_in_group_by_is_rejected_with_sqlite_wording() {
+    let db = b3_db();
+
+    for sql in [
+        "SELECT * FROM b3 GROUP BY count(*)",
+        "SELECT max(a) FROM b3 GROUP BY max(b)",
+        "SELECT group_concat(a) FROM b3 GROUP BY a, max(b)",
+    ] {
+        let err = run_select(&db, sql).expect_err(sql);
+        assert_eq!(
+            err.to_string(),
+            "aggregate functions are not allowed in the GROUP BY clause",
+            "wrong error for: {sql}"
+        );
+    }
+}
+
+/// A non-aggregate expression in GROUP BY (including unary `+`) is still legal.
+#[test]
+fn non_aggregate_group_by_expression_is_allowed() {
+    let db = b3_db();
+    // `+a` is a unary-plus expression, not an aggregate — must not be rejected.
+    let rows = run_select(&db, "SELECT count(*) FROM b3 GROUP BY +a").unwrap();
+    assert!(!rows.is_empty(), "GROUP BY +a should be a legal grouping key");
+}

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -28,12 +28,24 @@ impl Parser {
                     self.advance(); // Consume comma
                     let right = self.parse_table_reference()?;
 
-                    // Check for legacy ON clause after comma-join
-                    // SQLite allows: FROM t1, t2 ON t1.a=t2.b (treated as INNER JOIN)
+                    // Check for a legacy ON or USING clause after a comma-join.
+                    // SQLite treats "," exactly like CROSS/INNER JOIN, so the
+                    // ON/USING filtering clauses are legal after it and turn the
+                    // cartesian product into an inner join:
+                    //   FROM t1, t2 ON t1.a=t2.b
+                    //   FROM t1, t2 USING (a)
+                    // (e_select-0.1.2 / 1.4 / 1.5 / 1.6 / 1.7 comma variants).
                     if self.peek_keyword(Keyword::On) {
                         self.consume_keyword(Keyword::On)?;
                         let condition = self.parse_expression()?;
                         (vibesql_ast::JoinType::Inner, right, Some(condition), None, false)
+                    } else if self.peek_keyword(Keyword::Using) {
+                        self.consume_keyword(Keyword::Using)?;
+                        self.expect_token(Token::LParen)?;
+                        let columns =
+                            self.parse_comma_separated_list(|p| p.parse_column_name())?;
+                        self.expect_token(Token::RParen)?;
+                        (vibesql_ast::JoinType::Inner, right, None, Some(columns), false)
                     } else {
                         (vibesql_ast::JoinType::Cross, right, None, None, false)
                     }

--- a/crates/vibesql-parser/src/tests/joins.rs
+++ b/crates/vibesql-parser/src/tests/joins.rs
@@ -557,6 +557,61 @@ fn test_parse_comma_without_on_still_cross_join() {
 }
 
 #[test]
+fn test_parse_legacy_comma_join_using(/* issue #6192 */) {
+    // SQLite treats "," exactly like CROSS/INNER JOIN, so a USING clause is
+    // legal after a comma-join and turns the cartesian product into an inner
+    // join. Previously the parser accepted `FROM t1, t2 ON ...` but rejected
+    // `FROM t1, t2 USING (...)` with a spurious `near "USING": syntax error`
+    // (e_select-0.1.2 / 1.4 / 1.5 / 1.6 / 1.7 comma variants).
+    let result = Parser::parse_sql("SELECT * FROM t1, t2 USING (a);");
+    assert!(result.is_ok(), "Parse failed: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match select.from.as_ref().unwrap() {
+            vibesql_ast::FromClause::Join {
+                join_type,
+                condition,
+                using_columns,
+                natural,
+                ..
+            } => {
+                // Comma-join with USING behaves like INNER JOIN ... USING.
+                assert_eq!(*join_type, vibesql_ast::JoinType::Inner);
+                assert!(!*natural);
+                assert!(condition.is_none(), "USING join carries no ON condition");
+                let cols = using_columns.as_ref().expect("Expected USING columns");
+                assert_eq!(cols.len(), 1);
+                assert_eq!(cols[0], "a");
+            }
+            _ => panic!("Expected JOIN"),
+        },
+        _ => panic!("Expected SELECT"),
+    }
+}
+
+#[test]
+fn test_parse_legacy_comma_join_using_multiple_columns(/* issue #6192 */) {
+    let result = Parser::parse_sql("SELECT * FROM t3, t4 USING (a, c);");
+    assert!(result.is_ok(), "Parse failed: {:?}", result.err());
+    let stmt = result.unwrap();
+
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match select.from.as_ref().unwrap() {
+            vibesql_ast::FromClause::Join { join_type, using_columns, .. } => {
+                assert_eq!(*join_type, vibesql_ast::JoinType::Inner);
+                let cols = using_columns.as_ref().expect("Expected USING columns");
+                assert_eq!(cols.len(), 2);
+                assert_eq!(cols[0], "a");
+                assert_eq!(cols[1], "c");
+            }
+            _ => panic!("Expected JOIN"),
+        },
+        _ => panic!("Expected SELECT"),
+    }
+}
+
+#[test]
 fn test_parse_join_using_contextual_keyword_column(/* issue #5945 */) {
     // Contextual keywords (`m`, `key`, `level`) must be accepted as unquoted
     // column names in a JOIN ... USING (...) list, matching SQLite.


### PR DESCRIPTION
## Summary

Fixes two in-scope SELECT documentation-evidence gaps surfaced by SQLite's `e_select.test` (issue #6192). On a fresh `cargo build --release`, `e_select.test` goes from **568 → 575 / 621 passing (91.5% → 92.6%)**, clearing **7 real SELECT-semantics failures** at their root cause with no regressions.

Both fixes are pinned by new Rust unit tests, independent of the submodule TCL harness.

## Changes

- **HAVING-only aggregate leak (`e_select-4.13.1.*`)** — The native columnar aggregation path (`columnar_execution/mod.rs`) appends an aggregate that appears *only* in a HAVING predicate (e.g. `SELECT up FROM t GROUP BY up HAVING sum(down)>16`) to the grouped row layout `[group_keys…, select_aggregates…, having_only_aggregates…]` so the predicate can be evaluated — but never stripped it from the output projection, so the aggregate value leaked as an extra result column. Now the SELECT-aggregate count is captured before HAVING aggregates are appended, and the trailing HAVING-only aggregate columns are truncated after the HAVING filter has consumed them. Fires only when HAVING introduces *new* aggregates, so non-HAVING and shared-aggregate queries are untouched.

- **Aggregate in GROUP BY (`e_select-4.12.*`)** — `GROUP BY max(b)` / `GROUP BY count(*)` was evaluated and reported the generic `misuse of aggregate: X()`. SQLite rejects this at compile time with fixed wording. Added `ExecutorError::AggregateInGroupBy` (`"aggregate functions are not allowed in the GROUP BY clause"`) and a check alongside the existing window-function rejection in the aggregation path. Only the directly-written form is rejected; bare positional/alias references to aggregate SELECT items remain legal grouping keys.

- **Tests** — New `crates/vibesql-executor/src/tests/select_having_projection.rs` (6 tests) covering: HAVING-only `count(*)`/`sum()` no longer leak, a shared HAVING/SELECT aggregate is not double-counted, non-aggregate HAVING keeps the projection, the three `e_select-4.12` forms are rejected with SQLite's wording, and `GROUP BY +a` remains legal.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Fresh build + `e_select.test` re-measured, failures clustered by root cause | ✅ | Fresh `cargo build --release`; `e_select.test` 568→575/621; failures triaged via `--verbose` expected-vs-actual into distinct clusters |
| `e_select2.test` re-measured; C-API / Bucket-A straddlers split off | ✅ | `e_select2.test`: its only 2 failures are `sqlite3_prepare_v2` file-scope markers (Bucket-A C-API) — no real SELECT-semantics failures. `e_select` `filescope-err.*` markers likewise C-API, left per skip policy |
| Genuine SELECT-semantics wrong-answers fixed at root cause in the executor | ✅ | HAVING projection truncation in the columnar path; aggregate-in-GROUP-BY validation in the aggregation path — no test special-casing |
| `e_select.test` real-failure count materially reduced; no Priority-1/2 regressions | ✅ | 7 failures cleared; `having.test` 0 fail, `distinct.test` 0 fail, `select1.test`/`select4.test` 100%; executor lib suite 3529 passed / 0 failed |
| Each fixed cluster covered by a Rust test independent of the TCL harness | ✅ | `select_having_projection.rs`, 6 tests, all passing |

## Deferred (documented as distinct engine gaps, not addressed here)

The remaining `e_select.test` failures are separate root causes, larger than this PR's scope:

- **Collation not applied in DISTINCT / GROUP BY / ORDER BY** (`4.11.2/4.11.4`, `5.3.2/5.4.*/5.6.*`, `7.10.3`, `8.9.*/8.11.*`) — `apply_distinct`, GROUP BY key building, and compound ORDER BY do not thread column/explicit `COLLATE` into their comparisons. A coherent collation-threading follow-up.
- **Cartesian-product / join iteration order** (`0.4.*`, `1.3.1`, `1.4.*`, `1-11.1a`) — nested-loop output ordering differs from SQLite's outer-first order.
- **`*` used outside a result list is a parse-time error** (`4.2.1.*`) — we emit `Unsupported expression: Wildcard` at eval time instead of `near "*": syntax error` at parse time.
- **HAVING arbitrary-row selection** (`4.13.1.4`), **compound-ORDER-BY term resolution** (`8.13.9`, `8.15.2`), and a few aggregate edge cases (`4.5.4/4.5.5`, `4.6.5/4.6.6`, `4.9.*`).
- **`sqlite3_prepare_v2` file-scope markers** (`e_select-filescope-err.*`, `e_select2-filescope-err.*`) — Bucket-A C-API, out of scope.

## Test Plan

- `cargo build --release` (fresh), `make test-tcl-file FILE=e_select.test` → 575/621 (was 568).
- `cargo test --release -p vibesql-executor --lib` → 3529 passed, 0 failed (incl. the 6 new tests).
- Regression TCL: `having.test`, `distinct.test`, `select1.test`, `select4.test`, `e_select2.test` — no new failures.

Closes #6192