### PR TITLE
fix(parser): descriptive error for ON/USING with no preceding JOIN (tkt* triage pass)

### DIFF
--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -12,7 +12,24 @@ impl Parser {
         // Parse the first table reference
         let mut left = self.parse_table_reference()?;
 
-        // Check for USING without a preceding JOIN - SQLite error compatibility
+        // Check for a bare ON / USING with no preceding JOIN - SQLite error
+        // compatibility (tkt3935). A join constraint may only appear after a
+        // join operator (a JOIN keyword or a legacy comma-join), so when one
+        // directly follows the first table term SQLite emits a descriptive
+        // error rather than a bare token syntax error.
+        if self.peek_keyword(Keyword::On) {
+            // Consume "ON <expr>" first: SQLite parses the ON constraint before
+            // deciding what went wrong. If a USING clause then follows the ON
+            // expression (`... ON b USING(a)`), that trailing USING is a
+            // token-level syntax error (`near "USING": syntax error`); a bare
+            // `... ON b` instead reports the missing-JOIN diagnostic.
+            self.consume_keyword(Keyword::On)?;
+            let _ = self.parse_expression()?;
+            if self.peek_keyword(Keyword::Using) {
+                return Err(ParseError { message: self.peek().syntax_error() });
+            }
+            return Err(ParseError { message: "a JOIN clause is required before ON".to_string() });
+        }
         if self.peek_keyword(Keyword::Using) {
             return Err(ParseError {
                 message: "a JOIN clause is required before USING".to_string(),

--- a/crates/vibesql-parser/src/tests/joins.rs
+++ b/crates/vibesql-parser/src/tests/joins.rs
@@ -612,6 +612,34 @@ fn test_parse_legacy_comma_join_using_multiple_columns(/* issue #6192 */) {
 }
 
 #[test]
+fn test_bare_on_or_using_without_join_reports_descriptive_error(/* tkt3935 / issue #6194 */) {
+    // A join constraint (ON / USING) that directly follows the first FROM
+    // table term with no preceding join operator is a specific SQLite error,
+    // not a bare token syntax error.
+    //
+    // - `FROM t ON <expr>`            -> "a JOIN clause is required before ON"
+    // - `FROM t USING (...)`          -> "a JOIN clause is required before USING"
+    // - `FROM t ON <expr> USING (...)`-> token syntax error at the trailing USING
+    let cases = [
+        ("SELECT a FROM t1 AS t ON b;", "a JOIN clause is required before ON"),
+        ("SELECT a FROM (t1) AS t ON b;", "a JOIN clause is required before ON"),
+        ("SELECT a FROM (SELECT * FROM t1) AS t ON b;", "a JOIN clause is required before ON"),
+        ("SELECT a FROM t1 AS t USING(a);", "a JOIN clause is required before USING"),
+    ];
+    for (sql, expected) in cases {
+        let err = Parser::parse_sql(sql).expect_err(sql).message;
+        assert_eq!(err, expected, "for {sql}");
+    }
+
+    // `ON <expr> USING(...)`: the trailing USING is a token-level syntax error
+    // (SQLite: near "USING": syntax error), reported before the missing-JOIN
+    // diagnostic.
+    let err =
+        Parser::parse_sql("SELECT a FROM t1 AS t ON b USING(a);").expect_err("on+using").message;
+    assert_eq!(err, "near \"USING\": syntax error");
+}
+
+#[test]
 fn test_parse_join_using_contextual_keyword_column(/* issue #5945 */) {
     // Contextual keywords (`m`, `key`, `level`) must be accepted as unquoted
     // column names in a JOIN ... USING (...) list, matching SQLite.

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -701,6 +701,9 @@ proc translate_error_to_sqlite {vibesql_error} {
     if {[regexp -nocase {^Parse error: (a JOIN clause is required before USING)$} $error_msg -> parse_msg]} {
         return $parse_msg
     }
+    if {[regexp -nocase {^Parse error: (a JOIN clause is required before ON)$} $error_msg -> parse_msg]} {
+        return $parse_msg
+    }
     if {[regexp -nocase {^Parse error: (unknown join type: .+)$} $error_msg -> parse_msg]} {
         return $parse_msg
     }


### PR DESCRIPTION
## Summary

Per-ticket triage pass over the SQLite `tkt*` regression-ticket tail (#6194).
Ran the full `tkt*.test` universe (143 files) **fresh** against a clean
`cargo build --release` with the current per-test detail-capture binary
(run_id=4), replacing the stale certified run_id=1 counts, then clustered the
failures by root cause. Landed the one clean, well-contained, in-scope engine
fix surfaced by the triage and documented the remaining clusters.

**Fresh baseline (run_id=4): 152 failures across the tkt tail** (down from the
stale certified ~172/52-files — many certified failures were already fixed on
main, e.g. `tkt2822` 17 -> 3). This PR eliminates the entire "JOIN clause is
required" family (6 failures in `tkt3935.test`).

## Changes

- **`crates/vibesql-parser/src/parser/select/from_clause.rs`** — a bare `ON` /
  `USING` join constraint that directly follows the first FROM table term
  (no preceding JOIN operator or comma-join) now reports SQLite's descriptive
  diagnostic. The `USING`-without-JOIN case was already handled; this adds the
  parallel `ON` handling:
  - `FROM t ON <expr>`             -> `a JOIN clause is required before ON`
  - `FROM t ON <expr> USING (...)` -> `near "USING": syntax error` (trailing
    USING is a token-level error, reported before the missing-JOIN diagnostic)
- **`scripts/tester_vibesql.tcl`** — added a passthrough for the
  `a JOIN clause is required before ON` message (mirroring the existing USING
  passthrough) so the conformance shim delivers it unwrapped instead of
  re-wrapping it as `near "...": syntax error` via the generic fallback.
- **`crates/vibesql-parser/src/tests/joins.rs`** — unit test locking in all
  five error-message cases.

## Triage clustering (fresh run_id=4, top tkt files)

| File | Fresh fails | Root cause | Disposition |
| --- | --- | --- | --- |
| tkt3935 | 6 -> **0** | `ON`/`USING` w/o JOIN error message | **FIXED here** |
| tkt3718 | 10 | `db func` TCL-callback UDFs (f1/f2/sql) | Out of scope (C-API) |
| tkt2854 | 9 | `shared_cache` (`sqlite3_enable_shared_cache`) | Out of scope |
| tkt-78e04e52ea | 8 | empty quoted identifier `""` as table/column name | In scope, deferred (lexer/identifier blast radius) — orphan |
| tkt-9a8b09f8e6 | 6 | type affinity in comparisons (REAL/INT/TEXT) | Folds onto affinity family #6172 |
| tkt-d82e3f3721 | 6 | AUTOINCREMENT / `sqlite_sequence` table | Folds onto schema family #6173 |
| tkt-f777251dc7a | 6 | custom fns `force_rollback`/`ins` + `sqlite3_get_autocommit` | Out of scope (C-API) |
| tkt-fc62af4523 | 5 | IO-fault injection (`::sqlite_pending_byte`, `::chan`) | Out of scope (fault injection) |
| tkt3793 | 5 | `shared_cache` + `attach` | Out of scope |
| tkt2822 | 3 | compound (UNION ALL) ORDER BY by qualified column; ORDER BY alias in `+expr` | Folds onto ORDER BY resolver work |

**Cluster families (via `scripts/tcl_triage.py --run-id 4`), ranked:** the tail
is genuinely heterogeneous and dominated by out-of-scope Bucket-A classes —
custom TCL functions/commands registered via the C-API (`invalid command
name`, `no such function`, `update_hook`, custom collations `reverse`,
`hex_to_utf16*`), `shared_cache`, nested transactions
(`cannot start a transaction within a transaction`), and IO-fault injection.
The in-scope remainder is small and each cluster folds onto an existing #6177
family issue (type affinity #6172, schema/`sqlite_sequence` #6173, compound
ORDER BY resolution) rather than needing its own fix issue. The one genuine
orphan worth its own future issue is **empty quoted identifiers** (`tkt-78e04`,
8 tests) — deliberately deferred here because supporting `""` names touches
identifier handling broadly and is out of scope for a triage pass.

## Acceptance Criteria Verification

| Criterion (from issue) | Status | Verification |
|-----------|--------|--------------|
| Run top ~10 tkt files fresh with detail-capture binary | ✅ | Fresh `cargo build --release`; ran all 143 tkt files (run_id=4, 8290 rows, 0 insert failures) |
| Cluster failures by root cause | ✅ | `scripts/tcl_triage.py --run-id 4`; table above |
| Land tractable in-scope fixes that measurably improve pass rate | ✅ | tkt3935 6 -> 0 failures (parser + shim) |
| Fold clusters onto existing family issues / document orphans | ✅ | Table above; orphan = empty-identifier `tkt-78e04` |
| Do NOT attempt out-of-scope (ATTACH, C-API, Bucket-A) work | ✅ | Out-of-scope files documented, untouched |
| No regression in raw per-test pass rate for affected files | ✅ | 1776 parser unit tests pass; join/select/where spot-checks show only pre-existing failures; tkt3935 10/10 |

## Test Plan

- `cargo test -p vibesql-parser --release` — 1776 passed, 0 failed (includes the
  new `test_bare_on_or_using_without_join_reports_descriptive_error`).
- `./scripts/tcltest test tkt3935.test` — 10/10 pass (was 4/10).
- Spot-checked `join*/select*/where*` files: no new failures introduced
  (observed failures are pre-existing filescope/`table already exists`/EQP).

Closes #6194