### PR TITLE
fix(dml): reject LIMIT/ORDER BY in trigger-body UPDATE/DELETE and accept integral-REAL LIMIT

### DIFF
--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -1182,6 +1182,28 @@ impl DeleteExecutor {
                 // Any negative OFFSET is treated as 0 (SQLite semantics, #5747).
                 SqlValue::Integer(n) if n < 0 => 0,
                 SqlValue::Bigint(n) if n < 0 => 0,
+                // SQLite applies integer affinity to OFFSET, but only a REAL
+                // that converts *losslessly* to an integer is accepted (e.g.
+                // `LIMIT 2+2, 16/4` supplies OFFSET `2+2`=4 and LIMIT `16/4`
+                // which evaluates to REAL 4.0 -> 4). A negative integral real
+                // clamps to 0, matching the integer branch. A non-integral real
+                // (e.g. 1.2) falls through to the error arm (e_delete-3.1).
+                SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f)
+                    if f.is_finite() && f.fract() == 0.0 =>
+                {
+                    if f >= 0.0 {
+                        f as usize
+                    } else {
+                        0
+                    }
+                }
+                SqlValue::Float(f) if f.is_finite() && f.fract() == 0.0 => {
+                    if f >= 0.0 {
+                        f as usize
+                    } else {
+                        0
+                    }
+                }
                 SqlValue::Null => 0, // NULL offset treated as 0
                 _ => {
                     return Err(ExecutorError::TypeError(
@@ -1202,6 +1224,27 @@ impl DeleteExecutor {
                 // Any negative LIMIT means "no limit" (SQLite semantics, #5747).
                 SqlValue::Integer(n) if n < 0 => None,
                 SqlValue::Bigint(n) if n < 0 => None,
+                // Integer affinity: a REAL LIMIT that converts losslessly to an
+                // integer is accepted (`16/4` -> 4.0 -> LIMIT 4); a negative
+                // integral real means "no limit", matching the integer branch.
+                // A non-integral real (e.g. 1.2) falls through to the error arm
+                // (e_delete-3.1 comma-form LIMIT).
+                SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f)
+                    if f.is_finite() && f.fract() == 0.0 =>
+                {
+                    if f >= 0.0 {
+                        Some(f as usize)
+                    } else {
+                        None
+                    }
+                }
+                SqlValue::Float(f) if f.is_finite() && f.fract() == 0.0 => {
+                    if f >= 0.0 {
+                        Some(f as usize)
+                    } else {
+                        None
+                    }
+                }
                 SqlValue::Null => None, // NULL limit treated as no limit
                 _ => {
                     return Err(ExecutorError::TypeError(

--- a/crates/vibesql-executor/src/delete/tests/limit.rs
+++ b/crates/vibesql-executor/src/delete/tests/limit.rs
@@ -145,3 +145,53 @@ fn delete_without_limit_deletes_all_matching() {
     assert_eq!(delete(&mut db, "DELETE FROM t WHERE b = 10"), 5);
     assert_eq!(row_count(&mut db), 0);
 }
+
+/// A LIMIT expression that evaluates to an *integral* REAL (e.g. `16/4` -> 4.0,
+/// since `/` on integers yields a REAL) is accepted with SQLite integer
+/// affinity: it caps the delete at 4 rows. Guards the comma-form LIMIT in
+/// e_delete-3.1 / e_update-3.0 that previously errored "LIMIT value must be a
+/// non-negative integer".
+#[test]
+fn delete_limit_integral_real_expression_is_accepted() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+
+    // `16/4` -> REAL 4.0 -> LIMIT 4 (of 5 rows), leaving exactly 1.
+    assert_eq!(delete(&mut db, "DELETE FROM t LIMIT 16/4"), 4);
+    assert_eq!(row_count(&mut db), 1);
+}
+
+/// The comma form `LIMIT offset, count` with integral-REAL operands
+/// (`LIMIT 2+2, 16/4` = OFFSET 4, LIMIT 4) skips the first 4 ordered rows and
+/// then deletes up to 4 more — here only 1 remains after the offset.
+#[test]
+fn delete_limit_comma_form_integral_real_operands() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+
+    // 5 rows ordered a=1..5; OFFSET 4 skips a=1..4, LIMIT 4 deletes a=5 only.
+    assert_eq!(delete(&mut db, "DELETE FROM t ORDER BY a LIMIT 2+2, 16/4"), 1);
+    let remaining: Vec<i64> =
+        select(&mut db, "SELECT a FROM t ORDER BY a").iter().map(|r| int(&r.values[0])).collect();
+    assert_eq!(remaining, vec![1, 2, 3, 4]);
+}
+
+/// A non-integral REAL LIMIT (e.g. `9/4` -> 2.25) cannot be converted
+/// losslessly to an integer, so it remains an error (SQLite raises a datatype
+/// mismatch here). We assert it does NOT silently truncate to 2.
+#[test]
+fn delete_limit_non_integral_real_is_rejected() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+
+    let stmt = match Parser::parse_sql("DELETE FROM t LIMIT 9/4").expect("parse") {
+        Statement::Delete(s) => s,
+        other => panic!("expected DELETE, got {:?}", other),
+    };
+    assert!(
+        DeleteExecutor::execute(&stmt, &mut db).is_err(),
+        "non-integral REAL LIMIT must be rejected, not truncated"
+    );
+    // No rows were removed by the failed statement.
+    assert_eq!(row_count(&mut db), 5);
+}

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -2489,6 +2489,27 @@ fn apply_order_by_and_limit(
             // Any negative OFFSET is treated as 0 (SQLite semantics, #5747).
             SqlValue::Integer(n) if n < 0 => 0,
             SqlValue::Bigint(n) if n < 0 => 0,
+            // SQLite applies integer affinity to OFFSET, but only a REAL that
+            // converts *losslessly* to an integer is accepted (e.g. `16/4`
+            // evaluates to REAL 4.0 -> 4). A negative integral real clamps to 0,
+            // matching the integer branch; a non-integral real (e.g. 1.2) falls
+            // through to the error arm (e_update-3.x).
+            SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f)
+                if f.is_finite() && f.fract() == 0.0 =>
+            {
+                if f >= 0.0 {
+                    f as usize
+                } else {
+                    0
+                }
+            }
+            SqlValue::Float(f) if f.is_finite() && f.fract() == 0.0 => {
+                if f >= 0.0 {
+                    f as usize
+                } else {
+                    0
+                }
+            }
             SqlValue::Null => 0, // NULL offset treated as 0
             _ => {
                 return Err(ExecutorError::TypeError(
@@ -2509,6 +2530,27 @@ fn apply_order_by_and_limit(
             // Any negative LIMIT means "no limit" (SQLite semantics, #5747).
             SqlValue::Integer(n) if n < 0 => None,
             SqlValue::Bigint(n) if n < 0 => None,
+            // Integer affinity: a REAL LIMIT that converts losslessly to an
+            // integer is accepted (`16/4` -> 4.0 -> LIMIT 4); a negative
+            // integral real means "no limit", matching the integer branch. A
+            // non-integral real (e.g. 1.2) falls through to the error arm
+            // (e_update-3.x comma-form LIMIT).
+            SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f)
+                if f.is_finite() && f.fract() == 0.0 =>
+            {
+                if f >= 0.0 {
+                    Some(f as usize)
+                } else {
+                    None
+                }
+            }
+            SqlValue::Float(f) if f.is_finite() && f.fract() == 0.0 => {
+                if f >= 0.0 {
+                    Some(f as usize)
+                } else {
+                    None
+                }
+            }
             SqlValue::Null => None, // NULL limit treated as no limit
             _ => {
                 return Err(ExecutorError::TypeError(

--- a/crates/vibesql-executor/src/update/tests/limit.rs
+++ b/crates/vibesql-executor/src/update/tests/limit.rs
@@ -181,3 +181,53 @@ fn update_without_limit_updates_all() {
     assert_eq!(update(&mut db, "UPDATE t SET b = 99 WHERE b = 10"), 5);
     assert_eq!(count_b(&mut db, 99), 5);
 }
+
+/// A LIMIT expression that evaluates to an *integral* REAL (`16/4` -> 4.0, since
+/// integer `/` yields a REAL) is accepted with SQLite integer affinity: it caps
+/// the update at 4 rows. Guards the comma-form LIMIT in e_update-3.0 /
+/// e_delete-3.1 that previously errored "LIMIT value must be a non-negative
+/// integer".
+#[test]
+fn update_limit_integral_real_expression_is_accepted() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+
+    // `16/4` -> REAL 4.0 -> LIMIT 4 of 5 rows.
+    assert_eq!(update(&mut db, "UPDATE t SET b = 99 LIMIT 16/4"), 4);
+    assert_eq!(count_b(&mut db, 99), 4);
+    assert_eq!(count_b(&mut db, 10), 1);
+}
+
+/// The comma form `LIMIT offset, count` with integral-REAL operands
+/// (`LIMIT 2+2, 16/4` = OFFSET 4, LIMIT 4) skips the first 4 ordered rows and
+/// then updates up to 4 more — here only row a=5 remains after the offset.
+#[test]
+fn update_limit_comma_form_integral_real_operands() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+
+    assert_eq!(update(&mut db, "UPDATE t SET b = 99 ORDER BY a LIMIT 2+2, 16/4"), 1);
+    let rows = select(&mut db, "SELECT a, b FROM t ORDER BY a");
+    let got: Vec<(i64, i64)> =
+        rows.iter().map(|r| (int(&r.values[0]), int(&r.values[1]))).collect();
+    assert_eq!(got, vec![(1, 10), (2, 10), (3, 10), (4, 10), (5, 99)]);
+}
+
+/// A non-integral REAL LIMIT (`9/4` -> 2.25) cannot be converted losslessly to
+/// an integer, so it remains an error rather than silently truncating to 2.
+#[test]
+fn update_limit_non_integral_real_is_rejected() {
+    let mut db = vibesql_storage::Database::new();
+    seed(&mut db);
+
+    let stmt = match Parser::parse_sql("UPDATE t SET b = 99 LIMIT 9/4").expect("parse") {
+        Statement::Update(s) => s,
+        other => panic!("expected UPDATE, got {:?}", other),
+    };
+    assert!(
+        UpdateExecutor::execute(&stmt, &mut db).is_err(),
+        "non-integral REAL LIMIT must be rejected, not truncated"
+    );
+    // The failed statement updated nothing.
+    assert_eq!(count_b(&mut db, 10), 5);
+}

--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -36,6 +36,28 @@ fn index_hint_rejection_message(hint: &vibesql_ast::IndexHint) -> String {
     }
 }
 
+/// SQLite rejects an `ORDER BY` or `LIMIT` clause on an UPDATE/DELETE statement
+/// inside a trigger body as a plain grammar syntax error — the trigger-program
+/// grammar simply has no ORDER BY / LIMIT productions for its DML statements,
+/// and this holds "regardless of the compilation options used to build SQLite"
+/// (R-57359-59558 for UPDATE, R-64942-06615 for DELETE; e_update-2.5 /
+/// e_delete-2.5). The offending token reported is `ORDER` when an ORDER BY is
+/// present and otherwise `LIMIT` (an OFFSET can only follow a LIMIT, so a bare
+/// OFFSET never occurs). Top-level UPDATE/DELETE ... LIMIT keeps working because
+/// this check only runs on trigger-body statements.
+fn trigger_body_limit_order_rejection(
+    order_by_present: bool,
+    limit_present: bool,
+) -> Option<ParseError> {
+    if order_by_present {
+        Some(ParseError { message: "near \"ORDER\": syntax error".to_string() })
+    } else if limit_present {
+        Some(ParseError { message: "near \"LIMIT\": syntax error".to_string() })
+    } else {
+        None
+    }
+}
+
 impl Parser {
     /// Parse CREATE TRIGGER statement
     ///
@@ -448,6 +470,12 @@ impl Parser {
                 if let Some(hint) = &update.index_hint {
                     return Err(ParseError { message: index_hint_rejection_message(hint) });
                 }
+                if let Some(e) = trigger_body_limit_order_rejection(
+                    update.order_by.is_some(),
+                    update.limit.is_some(),
+                ) {
+                    return Err(e);
+                }
             }
             Statement::Delete(delete) => {
                 if Self::dml_target_is_schema_qualified(&delete.table_name, delete.quoted) {
@@ -455,6 +483,12 @@ impl Parser {
                 }
                 if let Some(hint) = &delete.index_hint {
                     return Err(ParseError { message: index_hint_rejection_message(hint) });
+                }
+                if let Some(e) = trigger_body_limit_order_rejection(
+                    delete.order_by.is_some(),
+                    delete.limit.is_some(),
+                ) {
+                    return Err(e);
                 }
             }
             _ => {}

--- a/crates/vibesql-parser/src/tests/trigger.rs
+++ b/crates/vibesql-parser/src/tests/trigger.rs
@@ -1153,6 +1153,63 @@ fn test_create_trigger_rejects_not_indexed_in_delete_body() {
     );
 }
 
+// A trigger-body UPDATE/DELETE may not carry an ORDER BY / LIMIT clause. SQLite
+// rejects it as a plain grammar syntax error (`near "LIMIT"` / `near "ORDER"`),
+// "regardless of the compilation options used to build SQLite" (e_update-2.5 /
+// e_delete-2.5). Top-level UPDATE/DELETE ... LIMIT keeps working.
+const TRIGGER_LIMIT_SYNTAX_ERR: &str = "near \"LIMIT\": syntax error";
+const TRIGGER_ORDER_SYNTAX_ERR: &str = "near \"ORDER\": syntax error";
+
+#[test]
+fn test_create_trigger_rejects_limit_in_update_body() {
+    // e_update-2.5.1
+    assert_trigger_rejected_with(
+        "CREATE TRIGGER tr1 AFTER INSERT ON tA BEGIN \
+         UPDATE t16 SET a=a+1 LIMIT 10; END;",
+        TRIGGER_LIMIT_SYNTAX_ERR,
+    );
+}
+
+#[test]
+fn test_create_trigger_rejects_order_by_in_update_body() {
+    // e_update-2.5.2 — ORDER BY is the offending token even when a LIMIT follows.
+    assert_trigger_rejected_with(
+        "CREATE TRIGGER tr1 AFTER INSERT ON tA BEGIN \
+         UPDATE t16 SET a=a+1 ORDER BY a LIMIT 10; END;",
+        TRIGGER_ORDER_SYNTAX_ERR,
+    );
+}
+
+#[test]
+fn test_create_trigger_rejects_limit_offset_in_update_body() {
+    // e_update-2.5.4
+    assert_trigger_rejected_with(
+        "CREATE TRIGGER tr1 AFTER INSERT ON tA BEGIN \
+         UPDATE t16 SET a=a+1 LIMIT 10 OFFSET 2; END;",
+        TRIGGER_LIMIT_SYNTAX_ERR,
+    );
+}
+
+#[test]
+fn test_create_trigger_rejects_limit_in_delete_body() {
+    // e_delete-2.5.1
+    assert_trigger_rejected_with(
+        "CREATE TRIGGER tr3 AFTER INSERT ON t8 BEGIN \
+         DELETE FROM t8 LIMIT 10; END;",
+        TRIGGER_LIMIT_SYNTAX_ERR,
+    );
+}
+
+#[test]
+fn test_create_trigger_rejects_order_by_in_delete_body() {
+    // e_delete-2.5.2
+    assert_trigger_rejected_with(
+        "CREATE TRIGGER tr3 AFTER INSERT ON t8 BEGIN \
+         DELETE FROM t8 ORDER BY a LIMIT 5; END;",
+        TRIGGER_ORDER_SYNTAX_ERR,
+    );
+}
+
 #[test]
 fn test_create_trigger_accepts_unqualified_body_dml() {
     // Negative control: an ordinary unqualified body DML with no index hint is


### PR DESCRIPTION
## Summary

Two SQLite-conformance fixes surfaced by the INSERT/UPDATE/DELETE
documentation-evidence tests (`e_update.test` / `e_delete.test`), building on the
shim ATTACH-cascade fix already merged in #6214. This is an **incremental** part
of #6193 (see "Remaining / out of scope" below) — it does not close the issue.

## Changes

1. **Trigger-body `ORDER BY` / `LIMIT` rejection** (`e_update-2.5`, `e_delete-2.5`).
   SQLite's trigger-program grammar has no `ORDER BY`/`LIMIT` productions, so a
   body `UPDATE`/`DELETE` carrying one is a plain syntax error "regardless of the
   compilation options used to build SQLite" (R-57359-59558 / R-64942-06615).
   VibeSQL supports top-level `UPDATE/DELETE ... LIMIT` unconditionally, so it
   silently accepted them inside a trigger body. `validate_trigger_body_statement`
   now rejects a body `UPDATE`/`DELETE` whose `order_by`/`limit` is set, reporting
   the offending token exactly as SQLite does — `near "ORDER"` when an `ORDER BY`
   is present, otherwise `near "LIMIT"`. Only trigger-body statements are checked,
   so **top-level `UPDATE/DELETE ... LIMIT` keeps working**.

2. **Integral-REAL `LIMIT`/`OFFSET` affinity** (`e_update-3.0`, `e_delete-3.1` comma form).
   Integer division yields a REAL in VibeSQL (`16/4` → `4.0`), so a `LIMIT`/`OFFSET`
   expression such as `LIMIT 2+2, 16/4` evaluated to a REAL and hit the executor's
   `LIMIT value must be a non-negative integer` error. SQLite applies integer
   affinity to `LIMIT`/`OFFSET`, accepting any value that converts *losslessly* to
   an integer. The DELETE and UPDATE evaluators now accept an **integral** REAL
   (`fract() == 0`) and truncate it; a **non-integral** REAL (e.g. `1.2`) still
   errors rather than silently truncating, and the NULL/Text/Blob paths are
   unchanged.

New unit tests: parser trigger-body `LIMIT`/`ORDER BY` rejection (UPDATE + DELETE)
and executor integral-REAL / comma-form `LIMIT` acceptance + non-integral-REAL
rejection.

## Acceptance Criteria Verification

| Criterion (from #6193) | Status | Verification |
|---|---|---|
| e_update setup cascade broken | ✅ (via #6214) | Fresh run: e_update 66–68% pass, main-db sections run |
| e_delete in-scope gaps fixed or documented | ✅ | 2.5.1 / 2.5.2 fixed; 2.2.1.1 (schema-qualified trigger name) + filescope TEXT-LIMIT documented below |
| e_insert measurable reduction | ⚠️ prior (#6214) | Unchanged here; remaining 23 are autocommit C-API probes + REPLACE partial semantics (out of scope) |
| aux.* / §2.x isolated as ATTACH-blocked | ✅ | Left skipped/failing, not attempted |
| No regression in raw per-test pass rate | ✅ | e_delete 46→48, e_update 111→115, e_insert 180 (no new marker rows) |

## Test Plan

- Fresh `cargo build --release`, then `make test-tcl-file FILE=<f>.test` on each of the three files:
  - **e_delete**: 46 → **48** passed (fixed 2.5.1, 2.5.2)
  - **e_update**: 111 → **115** passed (fixed 2.5.1–2.5.4)
  - **e_insert**: 180 (unchanged)
- `cargo test -p vibesql-parser --lib` → 1790 passed, 0 failed
- `cargo test -p vibesql-executor --lib` → 3565 passed, 0 failed
- `trigger1.test` unaffected — no `near "LIMIT"/"ORDER"` regressions introduced.

## Remaining / out of scope (documented, not attempted here)

- **sqlite3_get_autocommit `.3` probes** — deliberately unstubbed per shim policy; the `e_*-*.3` autocommit assertions fail honestly (C-API, out of scope).
- **aux.* / cross-schema / attached-trigger cases** — ATTACH-blocked (VibeSQL has no ATTACH); Bucket-A straddlers, left failing.
- **OR FAIL / OR IGNORE partial-update row semantics** (`e_update-1.8.*.2`) — SQLite keeps rows modified before a mid-statement conflict; VibeSQL rolls the whole statement back. Deep executor change, deferred.
- **e_update §3.x `-query` divergence** — the engine result is verified correct in isolation (`UPDATE t7 SET s=q LIMIT 5` → `1 2 3 4 5 X X X X X`); the failures are an accumulated test-harness state interaction, not an engine gap.
- **Full LIMIT/OFFSET text/NULL/blob integer affinity + `datatype mismatch` message** (`e_delete-3.2/3.3/3.5`) — needs `'4'`→4 / `'1.0'`→1 text coercion and NULL→error semantics with SQLite's exact message; larger follow-up.
- **e_delete-2.2.1.1** — schema-qualified `CREATE TRIGGER main.tr1` parsing (`near "."`), entangled with cross-schema resolution.

Part of #6193
Part of #5779