### PR TITLE
conformance(tcl): enforce CHECK on UPDATE fast path + validate CHECK column refs at CREATE (Part of #6173)

### DIFF
--- a/crates/vibesql-executor/src/constraint_validator.rs
+++ b/crates/vibesql-executor/src/constraint_validator.rs
@@ -48,6 +48,79 @@ fn expression_has_parameter(expr: &Expression) -> bool {
     finder.found
 }
 
+/// Visitor that flags the first column reference in a CHECK constraint that
+/// cannot be resolved against the table being created. SQLite resolves CHECK
+/// constraint column names against the new table only: an unqualified name
+/// must be a column of the table (or a rowid alias), and a `table.column`
+/// qualifier must name the table being created. A three-part `schema.table.col`
+/// reference has its database qualifier silently ignored (check-8.1), so only
+/// the table and column parts are validated.
+struct CheckColumnResolver<'a> {
+    /// Canonical (lower-cased) name of the table being created.
+    table_canonical: &'a str,
+    /// Canonical (lower-cased) column names of the table being created.
+    columns: &'a std::collections::HashSet<String>,
+    /// Display form of the first unresolved reference, if any.
+    unresolved: Option<String>,
+}
+
+impl ExpressionVisitor for CheckColumnResolver<'_> {
+    fn pre_visit_expression(&mut self, expr: &Expression) -> VisitResult {
+        if let Expression::ColumnRef(col_id) = expr {
+            // A table qualifier must name the table being created; the schema
+            // (database) qualifier, if present, is ignored per SQLite.
+            if let Some(table) = col_id.table_canonical() {
+                if !table.eq_ignore_ascii_case(self.table_canonical) {
+                    self.unresolved = Some(col_id.display().to_string());
+                    return VisitResult::Stop;
+                }
+            }
+
+            let col = col_id.column_canonical();
+            // rowid and its aliases are always valid inside a CHECK constraint
+            // (e.g. `CHECK(c > rowid*2)`, check-9.1).
+            let is_rowid_alias = col.eq_ignore_ascii_case("rowid")
+                || col == "_rowid_"
+                || col.eq_ignore_ascii_case("oid");
+            if !is_rowid_alias && !self.columns.contains(col) {
+                self.unresolved = Some(col_id.display().to_string());
+                return VisitResult::Stop;
+            }
+        }
+        VisitResult::Continue
+    }
+}
+
+/// Validate that every column referenced by a table's CHECK constraints exists
+/// on the table being created. SQLite performs this resolution at CREATE TABLE
+/// time and rejects the statement — leaving no table behind — when a CHECK
+/// names an unknown column (check-3.3) or a foreign table (check-3.5). This
+/// mirrors that behavior so an invalid definition never creates a table.
+pub fn validate_check_constraint_columns(
+    table_name: &str,
+    columns: &[ColumnSchema],
+    check_constraints: &[(String, Expression)],
+) -> Result<(), ExecutorError> {
+    if check_constraints.is_empty() {
+        return Ok(());
+    }
+    let column_set: std::collections::HashSet<String> =
+        columns.iter().map(|c| c.name.to_ascii_lowercase()).collect();
+    let table_canonical = table_name.to_ascii_lowercase();
+    for (_name, expr) in check_constraints {
+        let mut resolver = CheckColumnResolver {
+            table_canonical: &table_canonical,
+            columns: &column_set,
+            unresolved: None,
+        };
+        walk_expression(&mut resolver, expr);
+        if let Some(column_ref) = resolver.unresolved {
+            return Err(ExecutorError::NoSuchColumn { column_ref });
+        }
+    }
+    Ok(())
+}
+
 /// Validate that a CHECK constraint expression uses only forms SQLite permits.
 /// Subqueries and bind parameters are rejected at CREATE TABLE time with the
 /// exact SQLite messages so an invalid definition never creates a half-formed
@@ -423,6 +496,92 @@ mod tests {
             is_exact_integer_type: false,
             type_source: None,
         }
+    }
+
+    fn col(name: &str) -> ColumnSchema {
+        ColumnSchema::new(name.to_string(), DataType::Integer, true)
+    }
+
+    fn col_ref(name: &str) -> Expression {
+        Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(name, false))
+    }
+
+    fn qualified_col_ref(table: &str, column: &str) -> Expression {
+        Expression::ColumnRef(vibesql_ast::ColumnIdentifier::qualified(table, false, column, false))
+    }
+
+    fn lt(left: Expression, right: Expression) -> Expression {
+        Expression::BinaryOp {
+            left: Box::new(left),
+            op: vibesql_ast::BinaryOperator::LessThan,
+            right: Box::new(right),
+        }
+    }
+
+    #[test]
+    fn test_check_columns_unknown_column_rejected() {
+        // check-3.3: CHECK(q < x) where `q` is not a column -> "no such column: q".
+        let cols = vec![col("x"), col("y"), col("z")];
+        let checks = vec![(String::new(), lt(col_ref("q"), col_ref("x")))];
+        let err = validate_check_constraint_columns("t3", &cols, &checks).unwrap_err();
+        match err {
+            ExecutorError::NoSuchColumn { column_ref } => assert_eq!(column_ref, "q"),
+            other => panic!("expected NoSuchColumn, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_check_columns_foreign_table_qualifier_rejected() {
+        // check-3.5: CHECK(t2.x < x) references a different table -> "no such column: t2.x".
+        let cols = vec![col("x"), col("y"), col("z")];
+        let checks = vec![(String::new(), lt(qualified_col_ref("t2", "x"), col_ref("x")))];
+        let err = validate_check_constraint_columns("t3", &cols, &checks).unwrap_err();
+        match err {
+            ExecutorError::NoSuchColumn { column_ref } => assert_eq!(column_ref, "t2.x"),
+            other => panic!("expected NoSuchColumn, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_check_columns_self_table_qualifier_accepted() {
+        // check-3.7: CHECK(t3.x < 25) qualifies with the table being created -> ok.
+        let cols = vec![col("x"), col("y"), col("z")];
+        let checks = vec![(
+            String::new(),
+            lt(
+                qualified_col_ref("t3", "x"),
+                Expression::Literal(vibesql_types::SqlValue::Integer(25)),
+            ),
+        )];
+        assert!(validate_check_constraint_columns("t3", &cols, &checks).is_ok());
+    }
+
+    #[test]
+    fn test_check_columns_rowid_alias_accepted() {
+        // check-9.1: CHECK(c > rowid*2) — rowid is a valid pseudo-column.
+        let cols = vec![col("a"), col("c")];
+        let checks = vec![(
+            String::new(),
+            Expression::BinaryOp {
+                left: Box::new(col_ref("c")),
+                op: vibesql_ast::BinaryOperator::GreaterThan,
+                right: Box::new(col_ref("rowid")),
+            },
+        )];
+        assert!(validate_check_constraint_columns("t1", &cols, &checks).is_ok());
+    }
+
+    #[test]
+    fn test_check_columns_database_qualifier_ignored() {
+        // check-8.1: three-part `schema.table.column` — the (possibly bogus)
+        // database qualifier is ignored; only table+column are validated.
+        let cols = vec![col("b")];
+        let ref_bogus_schema =
+            Expression::ColumnRef(vibesql_ast::ColumnIdentifier::fully_qualified(
+                "xyzzy", false, "t811", false, "b", false,
+            ));
+        let checks = vec![(String::new(), lt(ref_bogus_schema, col_ref("b")))];
+        assert!(validate_check_constraint_columns("t811", &cols, &checks).is_ok());
     }
 
     #[test]

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -379,6 +379,18 @@ impl CreateTableExecutor {
         // Apply constraint results to schema (sets PK, unique, and check constraints)
         ConstraintValidator::apply_to_schema(&mut table_schema, &constraint_result);
 
+        // Resolve CHECK constraint column references against the new table.
+        // SQLite rejects a CREATE TABLE whose CHECK names an unknown column
+        // (check-3.3 `CHECK(q<x)`) or a foreign table (check-3.5 `CHECK(t2.x<x)`)
+        // before any table is created, so validate here — after the columns and
+        // check constraints are known but before the table is inserted into the
+        // catalog.
+        crate::constraint_validator::validate_check_constraint_columns(
+            &table_schema.name,
+            &table_schema.columns,
+            &table_schema.check_constraints,
+        )?;
+
         // WITHOUT ROWID tables must have a PRIMARY KEY (SQLite requirement, Issue #4953)
         if stmt.without_rowid && table_schema.primary_key.is_none() {
             return Err(ExecutorError::ConstraintViolation(

--- a/crates/vibesql-executor/src/update/constraints.rs
+++ b/crates/vibesql-executor/src/update/constraints.rs
@@ -330,8 +330,15 @@ impl<'a> ConstraintValidator<'a> {
         Ok(())
     }
 
-    /// Validate CHECK constraints
-    fn validate_check_constraints(
+    /// Validate CHECK constraints against a fully-materialized updated row.
+    ///
+    /// `new_row` must contain every column of the table (typically the original
+    /// row with the SET assignments applied), because a CHECK expression may
+    /// reference columns that the UPDATE did not touch — e.g. `CHECK(b > a)`
+    /// with only `b` in the SET list. Callers that mutate columns in place
+    /// without materializing the full row (the super-fast UPDATE path) must not
+    /// use this method; they should fall back to the row-materializing path.
+    pub(super) fn validate_check_constraints(
         &self,
         new_row: &vibesql_storage::Row,
     ) -> Result<(), ExecutorError> {

--- a/crates/vibesql-executor/src/update/fast_path.rs
+++ b/crates/vibesql-executor/src/update/fast_path.rs
@@ -197,6 +197,16 @@ pub(super) fn try_fast_path_update(
         }
     }
 
+    // Enforce CHECK constraints against the fully-materialized new row. The
+    // fast path previously validated NOT NULL only, silently bypassing CHECK
+    // for single-row PK-equality UPDATEs (check.test 9.2/9.3). `new_row` is a
+    // full clone of the old row with the assignments applied, so a CHECK that
+    // references untouched columns or the rowid evaluates correctly here.
+    if !schema.check_constraints.is_empty() {
+        super::constraints::ConstraintValidator::new(schema)
+            .validate_check_constraints(&new_row)?;
+    }
+
     // Check PK uniqueness if updating PK columns
     let pk_indices = schema.get_primary_key_indices();
     if let Some(ref pk_idx) = pk_indices {
@@ -272,6 +282,17 @@ fn try_super_fast_path(
 ) -> Result<Option<usize>, ExecutorError> {
     // Use canonical table name from schema for all storage operations
     let table_name = &schema.name;
+
+    // CHECK constraints may reference columns the UPDATE does not touch (e.g.
+    // `CHECK(b > a)` with only `b` assigned) or the rowid, so they can only be
+    // evaluated against a fully-materialized row. The super-fast path mutates
+    // columns in place without building such a row, so defer any table carrying
+    // CHECK constraints to the row-materializing fast/normal path where the
+    // check is actually enforced (regression: single-row PK UPDATEs silently
+    // bypassed CHECK — see check.test 9.2/9.3).
+    if !schema.check_constraints.is_empty() {
+        return Ok(None);
+    }
 
     // Collect all literal updates that can be done in-place
     let mut inplace_updates: Vec<(usize, SqlValue)> = Vec::new();

--- a/crates/vibesql-executor/tests/update_constraint_tests/check_constraints.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/check_constraints.rs
@@ -1,12 +1,22 @@
-use vibesql_ast::{Assignment, Expression, UpdateStmt};
+use vibesql_ast::{Assignment, BinaryOperator, Expression, UpdateStmt, WhereClause};
 use vibesql_executor::{ExecutorError, UpdateExecutor};
 use vibesql_storage::{Database, Row};
 use vibesql_types::SqlValue;
 
 use super::constraint_test_utils::{
     create_employees_table_with_check_bonus, create_products_table_with_check_price,
-    create_products_table_with_nullable_price,
+    create_products_table_with_nullable_price, create_products_table_with_pk_and_check_price,
 };
+
+/// Build `WHERE id = <val>` — a simple single-column PK equality that routes
+/// the UPDATE through the fast path in `update::fast_path`.
+fn where_id_eq(val: i64) -> WhereClause {
+    WhereClause::Condition(Expression::BinaryOp {
+        left: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple("id", false))),
+        op: BinaryOperator::Equal,
+        right: Box::new(Expression::Literal(SqlValue::Integer(val))),
+    })
+}
 
 #[test]
 fn test_update_check_constraint_passes() {
@@ -181,4 +191,88 @@ fn test_update_check_constraint_with_expression() {
         }
         other => panic!("Expected SqliteCompatError, got {:?}", other),
     }
+}
+
+/// Regression: a single-row `WHERE id = ?` UPDATE on a table with a PRIMARY KEY
+/// takes the fast path (`update::fast_path`). That path previously validated
+/// NOT NULL only and silently bypassed CHECK constraints, so an invalid value
+/// was written without error (check.test 9.2/9.3). The CHECK must now fire.
+#[test]
+fn test_update_check_constraint_violation_via_pk_fast_path() {
+    let mut db = Database::new();
+    create_products_table_with_pk_and_check_price(&mut db);
+
+    db.insert_row("products", Row::new(vec![SqlValue::Integer(1), SqlValue::Integer(50)])).unwrap();
+
+    // Update the row selected by its primary key to a value that violates the
+    // `price >= 0` CHECK. This must be rejected, not silently applied.
+    let stmt = UpdateStmt {
+        index_hint: None,
+        with_clause: None,
+        from_clause: None,
+        quoted: false,
+        alias: None,
+        table_name: "products".to_string(),
+        assignments: vec![Assignment {
+            column: "price".to_string(),
+            columns: Vec::new(),
+            value: Expression::Literal(SqlValue::Integer(-5)),
+        }],
+        where_clause: Some(where_id_eq(1)),
+        order_by: None,
+        limit: None,
+        offset: None,
+        conflict_clause: None,
+        returning: None,
+    };
+
+    let result = UpdateExecutor::execute(&stmt, &mut db);
+    assert!(result.is_err(), "CHECK must be enforced on the PK fast path");
+    match result.unwrap_err() {
+        ExecutorError::SqliteCompatError(msg) => {
+            assert!(msg.contains("CHECK constraint failed"), "unexpected message: {msg}");
+            assert!(msg.contains("price_positive"), "unexpected message: {msg}");
+        }
+        other => panic!("Expected SqliteCompatError, got {:?}", other),
+    }
+
+    // The invalid write must not have landed: the row still holds 50.
+    let rows = db.get_table("products").unwrap().scan();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].values[1], SqlValue::Integer(50));
+}
+
+/// A valid single-row `WHERE id = ?` UPDATE through the PK fast path must still
+/// succeed (CHECK enforcement must not reject legal values).
+#[test]
+fn test_update_check_constraint_passes_via_pk_fast_path() {
+    let mut db = Database::new();
+    create_products_table_with_pk_and_check_price(&mut db);
+
+    db.insert_row("products", Row::new(vec![SqlValue::Integer(1), SqlValue::Integer(50)])).unwrap();
+
+    let stmt = UpdateStmt {
+        index_hint: None,
+        with_clause: None,
+        from_clause: None,
+        quoted: false,
+        alias: None,
+        table_name: "products".to_string(),
+        assignments: vec![Assignment {
+            column: "price".to_string(),
+            columns: Vec::new(),
+            value: Expression::Literal(SqlValue::Integer(100)),
+        }],
+        where_clause: Some(where_id_eq(1)),
+        order_by: None,
+        limit: None,
+        offset: None,
+        conflict_clause: None,
+        returning: None,
+    };
+
+    let count = UpdateExecutor::execute(&stmt, &mut db).unwrap();
+    assert_eq!(count, 1);
+    let rows = db.get_table("products").unwrap().scan();
+    assert_eq!(rows[0].values[1], SqlValue::Integer(100));
 }

--- a/crates/vibesql-executor/tests/update_constraint_tests/constraint_test_utils.rs
+++ b/crates/vibesql-executor/tests/update_constraint_tests/constraint_test_utils.rs
@@ -82,6 +82,35 @@ pub fn create_products_table_with_check_price(db: &mut Database) {
     db.create_table(schema).unwrap();
 }
 
+/// Helper to create a products table with a PRIMARY KEY *and* a `price >= 0`
+/// CHECK constraint. A primary key routes single-row `WHERE id = ?` UPDATEs
+/// through the fast path, which historically validated NOT NULL only and
+/// silently bypassed CHECK (regression guarded by
+/// `test_update_check_constraint_violation_via_pk_fast_path`).
+pub fn create_products_table_with_pk_and_check_price(db: &mut Database) {
+    let schema = TableSchema::with_all_constraint_types(
+        "products".to_string(),
+        vec![
+            ColumnSchema::new("id".to_string(), DataType::Integer, false),
+            ColumnSchema::new("price".to_string(), DataType::Integer, false),
+        ],
+        Some(vec!["id".to_string()]),
+        Vec::new(),
+        vec![(
+            "price_positive".to_string(),
+            Expression::BinaryOp {
+                left: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::simple(
+                    "price", false,
+                ))),
+                op: BinaryOperator::GreaterThanOrEqual,
+                right: Box::new(Expression::Literal(SqlValue::Integer(0))),
+            },
+        )],
+        Vec::new(),
+    );
+    db.create_table(schema).unwrap();
+}
+
 /// Helper to create a products table with nullable price and check constraint
 pub fn create_products_table_with_nullable_price(db: &mut Database) {
     let schema = TableSchema::with_all_constraint_types(


### PR DESCRIPTION
## Summary

A **partial increment** of the CREATE TABLE / schema-definition family issue #6173, focused on one coherent sub-feature: **CHECK constraints**. Two real SQL-correctness gaps in `check.test` are fixed (both are silent-wrong-behavior bugs, not cosmetics).

### 1. CHECK silently bypassed on the single-row UPDATE fast path (check.test 9.2, 9.3)

A `WHERE <pk> = ?` UPDATE on a table with a PRIMARY KEY was routed through `update::fast_path`, which validated **NOT NULL only** and never evaluated CHECK constraints. An invalid value was written with no error:

```sql
CREATE TABLE t(a INTEGER PRIMARY KEY, b, CHECK(b < 5));
INSERT INTO t VALUES(1, 2);
UPDATE t SET b = 9 WHERE a = 1;   -- before: silently succeeded; after: CHECK constraint failed: b<5
```

Fix:
- The super-fast in-place path now defers any table carrying CHECK constraints to the row-materializing path (it mutates columns in place and cannot cheaply materialize a full row for a CHECK that references untouched columns).
- The main fast path evaluates CHECK against the fully-materialized `new_row`, which correctly resolves CHECKs referencing untouched columns or the rowid (`CHECK(b>a)`, `CHECK(c>rowid*2)`). It reuses `validate_check_constraints` from `update::constraints`.

### 2. CHECK column references not validated at CREATE TABLE (check.test 3.3-3.9)

`CREATE TABLE t3(x, y, z, CHECK(q<x))` was accepted even though `q` is not a column. SQLite rejects it (`no such column: q`) and creates no table; VibeSQL's acceptance then cascaded (`t3` existed, so the next `CREATE TABLE t3` failed with "already exists", etc.). Column refs in each CHECK are now resolved against the new table before it is inserted into the catalog:

- unqualified name must be a column (or a rowid alias) — else `no such column: q`
- `table.column` qualifier must name the table being created — `t2.x` -> `no such column: t2.x`, `t3.x` (self) -> ok
- three-part `schema.table.column` has its database qualifier silently ignored (check-8.1)

## Before / after

`check.test`: **21 -> 12 failures** (9 fixed: the 3.3-3.9 block and 9.2/9.3). *(This run's baseline was 21; the issue's certified baseline was 29 — strict1/other CHECK work has landed since.)*

Remaining `check.test` failures are out of scope for this sub-feature (different mechanisms): verbatim multi-line CHECK message text (4.6/4.9), `PRAGMA ignore_check_constraints` / `integrity_check` (4.8/4.8.1), UDF + multi-connection `db2` (7.x), and a file-reopen reset issue (10.1).

## No regressions

- `update.test`, `insert.test`, `index.test`, `tableopts.test`: their remaining single failures are pre-existing and unrelated (multi-connection `db2`, UNIQUE-message text `t0.rowid` vs `t0.c0`, datatype mismatch).
- `table.test` is unaffected — it declares no CHECK constraints, and both fixes are gated on `check_constraints` being present. (Under the loaded local machine `table.test` does not finish a native run; it is not exercised by this change.)

## Tests

- New unit tests for `validate_check_constraint_columns`: unknown column, foreign-table qualifier, self-table qualifier, rowid alias, db-qualifier ignored.
- New PK-fast-path integration tests: violation rejected (invalid write does not land) + valid update still applies.
- Full executor suite green: **3571 lib tests pass**, update_constraint integration suite 14/14.

## Scope

This is a partial increment — **Part of #6173** (the family issue stays open; AUTOINCREMENT, generated columns, STRICT, and the e_createtable evidence suite remain).