### PR TITLE
conformance(tcl): TRUE/FALSE identifiers + constant exprs in DEFAULT (Part of #6172)

### DIFF
--- a/crates/vibesql-executor/src/alter/validation.rs
+++ b/crates/vibesql-executor/src/alter/validation.rs
@@ -82,43 +82,18 @@ pub(super) fn expression_references_column(expr: &Expression, column: &str) -> b
     }
 }
 
-/// Evaluate a simple default expression (literals and basic expressions)
-/// For more complex expressions, this would need full evaluation context
+/// Evaluate a simple default expression (literals and constant expressions).
+///
+/// This is the DEFAULT materializer for `ALTER TABLE ... ADD COLUMN ... DEFAULT
+/// <expr>`. It delegates to the canonical `evaluate_default_expression` so that
+/// ALTER and CREATE/INSERT share one set of SQLite-accurate DEFAULT semantics —
+/// unary +/- (including string-to-number coercion, `DEFAULT -'0xFF'` → 0),
+/// logical/bitwise NOT, and constant scalar functions — rather than the weaker
+/// literals-and-negation-only subset this used to reimplement (literal.test
+/// 1.9/1.13, which exercise `+0x7FFFFFFFFFFFFFFF` and `-'0xFF'` as ALTER
+/// defaults).
 pub(super) fn evaluate_simple_default(expr: &Expression) -> Result<SqlValue, ExecutorError> {
-    match expr {
-        Expression::Literal(val) => Ok(val.clone()),
-        Expression::UnaryOp { op, expr } => {
-            let val = evaluate_simple_default(expr)?;
-            match op {
-                vibesql_ast::UnaryOperator::Not => match val {
-                    SqlValue::Boolean(b) => Ok(SqlValue::Boolean(!b)),
-                    SqlValue::Null => Ok(SqlValue::Null),
-                    _ => Err(ExecutorError::TypeMismatch {
-                        left: val,
-                        op: "NOT".to_string(),
-                        right: SqlValue::Null,
-                    }),
-                },
-                vibesql_ast::UnaryOperator::Minus => match val {
-                    SqlValue::Integer(i) => Ok(SqlValue::Integer(-i)),
-                    SqlValue::Numeric(d) => Ok(SqlValue::Numeric(-d)),
-                    SqlValue::Null => Ok(SqlValue::Null),
-                    _ => Err(ExecutorError::TypeMismatch {
-                        left: val,
-                        op: "-".to_string(),
-                        right: SqlValue::Null,
-                    }),
-                },
-                _ => Err(ExecutorError::UnsupportedExpression(format!(
-                    "Unsupported unary operator in default: {:?}",
-                    op
-                ))),
-            }
-        }
-        _ => Err(ExecutorError::UnsupportedExpression(
-            "Complex expressions in DEFAULT not yet supported. Use simple literals.".to_string(),
-        )),
-    }
+    crate::insert::defaults::evaluate_default_expression(expr)
 }
 
 /// Check if type conversion is safe (widening conversions only)

--- a/crates/vibesql-executor/src/insert/defaults.rs
+++ b/crates/vibesql-executor/src/insert/defaults.rs
@@ -118,42 +118,17 @@ pub fn evaluate_default_expression(
 ) -> Result<vibesql_types::SqlValue, ExecutorError> {
     match expr {
         vibesql_ast::Expression::Literal(lit) => Ok(lit.clone()),
-        // Support unary plus/minus for DEFAULT expressions like "default +4.32" or "default -5"
+        // Unary operators over a materialized constant are all valid in DEFAULT
+        // expressions: unary +/- (`DEFAULT +4.32`, `DEFAULT -5`), logical NOT
+        // (istrue.test istrue-510: `DEFAULT(not true)` → 0), and bitwise NOT.
+        // The inner value is already a constant, so reuse the shared,
+        // SQLite-accurate unary evaluator rather than duplicating its
+        // truthiness / string-to-number / integer-coercion rules here. This is
+        // what makes `DEFAULT +0x7FFFFFFFFFFFFFFF` and `DEFAULT -'0xFF'` (→ 0)
+        // materialize with the same semantics as `SELECT` (literal.test 1.9/1.13).
         vibesql_ast::Expression::UnaryOp { op, expr } => {
             let inner = evaluate_default_expression(expr)?;
-            match op {
-                vibesql_ast::UnaryOperator::Plus => Ok(inner), // +x = x
-                vibesql_ast::UnaryOperator::Minus => {
-                    // Negate the value
-                    match inner {
-                        vibesql_types::SqlValue::Integer(i) => {
-                            Ok(vibesql_types::SqlValue::Integer(-i))
-                        }
-                        vibesql_types::SqlValue::Bigint(i) => {
-                            Ok(vibesql_types::SqlValue::Bigint(-i))
-                        }
-                        vibesql_types::SqlValue::Smallint(i) => {
-                            Ok(vibesql_types::SqlValue::Smallint(-i))
-                        }
-                        vibesql_types::SqlValue::Float(f) => Ok(vibesql_types::SqlValue::Float(-f)),
-                        vibesql_types::SqlValue::Real(f) => Ok(vibesql_types::SqlValue::Real(-f)),
-                        vibesql_types::SqlValue::Double(f) => {
-                            Ok(vibesql_types::SqlValue::Double(-f))
-                        }
-                        vibesql_types::SqlValue::Numeric(f) => {
-                            Ok(vibesql_types::SqlValue::Numeric(-f))
-                        }
-                        _ => Err(ExecutorError::UnsupportedExpression(format!(
-                            "Cannot apply unary minus to {:?}",
-                            inner
-                        ))),
-                    }
-                }
-                _ => Err(ExecutorError::UnsupportedExpression(format!(
-                    "Unary operator {:?} not supported in DEFAULT expressions",
-                    op
-                ))),
-            }
+            crate::evaluator::eval_unary_op(op, &inner)
         }
         vibesql_ast::Expression::NextValue { sequence_name } => {
             // NEXT VALUE FOR sequence - this should have been handled at a higher level
@@ -526,6 +501,52 @@ mod tests {
         };
         let err = evaluate_default_expression(&expr).expect_err("unknown function should error");
         assert_eq!(err.to_string(), "unknown function: definitely_not_a_function()");
+    }
+
+    fn unary(op: vibesql_ast::UnaryOperator, inner: Expression) -> Expression {
+        Expression::UnaryOp { op, expr: Box::new(inner) }
+    }
+
+    #[test]
+    fn logical_not_evaluates_in_default() {
+        // istrue.test istrue-510: BOOLEAN DEFAULT(not true) -> 0,
+        // DEFAULT(not false) -> 1.
+        let not_true =
+            unary(vibesql_ast::UnaryOperator::Not, Expression::Literal(SqlValue::Boolean(true)));
+        assert_eq!(
+            evaluate_default_expression(&not_true).expect("not true should evaluate"),
+            SqlValue::Boolean(false)
+        );
+        let not_false =
+            unary(vibesql_ast::UnaryOperator::Not, Expression::Literal(SqlValue::Boolean(false)));
+        assert_eq!(
+            evaluate_default_expression(&not_false).expect("not false should evaluate"),
+            SqlValue::Boolean(true)
+        );
+    }
+
+    #[test]
+    fn unary_minus_on_text_coerces_to_number_in_default() {
+        // literal.test 1.13: DEFAULT -'0xFF' materializes integer 0 (SQLite
+        // coerces the leading-numeric prefix of '0xFF' -> 0, then negates).
+        let expr = unary(
+            vibesql_ast::UnaryOperator::Minus,
+            Expression::Literal(SqlValue::Varchar(arcstr::ArcStr::from("0xFF"))),
+        );
+        assert_eq!(
+            evaluate_default_expression(&expr).expect("-'0xFF' should evaluate"),
+            SqlValue::Integer(0)
+        );
+    }
+
+    #[test]
+    fn unary_plus_is_identity_on_integer_in_default() {
+        // literal.test 1.9: DEFAULT +<int> keeps the integer value.
+        let expr = unary(vibesql_ast::UnaryOperator::Plus, int_lit(i64::MAX));
+        assert_eq!(
+            evaluate_default_expression(&expr).expect("+MAX should evaluate"),
+            SqlValue::Integer(i64::MAX)
+        );
     }
 }
 

--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -554,6 +554,12 @@ impl Keyword {
                     | Keyword::CurrentDate
                     | Keyword::CurrentTime
                     | Keyword::CurrentTimestamp
+                    // TRUE/FALSE are boolean literals only in expression
+                    // position; in table-name position no literal can occur, so
+                    // SQLite accepts them as plain table names
+                    // (istrue.test istrue-850/851: `SELECT ... FROM false`).
+                    | Keyword::True
+                    | Keyword::False
             )
     }
 

--- a/crates/vibesql-parser/src/parser/expressions/identifiers.rs
+++ b/crates/vibesql-parser/src/parser/expressions/identifiers.rs
@@ -30,6 +30,21 @@ impl Parser {
                 self.advance();
                 (name, true)
             }
+            // SQLite compatibility: TRUE/FALSE are boolean literals in ordinary
+            // primary position but plain identifiers when they qualify a dotted
+            // name (istrue.test istrue-800/830/850: `false.false` is the column
+            // `false` of table `false`). `parse_literal` only defers here when a
+            // `.` actually follows, so a bare TRUE/FALSE still parses as a
+            // literal; this arm handles just the qualified-reference case.
+            // (These two words are excluded from `can_be_identifier_in_expression`
+            // precisely to keep bare literals working, so they need their own arm.)
+            Token::Keyword { keyword: kw @ (Keyword::True | Keyword::False), .. }
+                if matches!(self.peek_next(), Token::Symbol('.')) =>
+            {
+                let name = format!("{}", kw).to_lowercase();
+                self.advance();
+                (name, false)
+            }
             Token::Keyword { keyword: kw, .. } if kw.can_be_identifier_in_expression() => {
                 // SQLite compatibility: in expression / primary position, a keyword that
                 // is not a reserved operator, clause-structure word, or special primary

--- a/crates/vibesql-parser/src/parser/expressions/literals.rs
+++ b/crates/vibesql-parser/src/parser/expressions/literals.rs
@@ -43,10 +43,22 @@ impl Parser {
                 Ok(Some(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Blob(blob_val))))
             }
             Token::Keyword { keyword: Keyword::True, .. } => {
+                // SQLite compatibility: TRUE/FALSE are not reserved words. When
+                // immediately followed by `.` they are the qualifier of a dotted
+                // name, not a boolean literal (istrue.test istrue-800/830/850:
+                // `SELECT 9 IN (false.false)` must parse as a column reference and
+                // fail with "no such column", not a syntax error). Defer to
+                // `parse_identifier_expression`, which builds the ColumnRef.
+                if matches!(self.peek_next(), Token::Symbol('.')) {
+                    return Ok(None);
+                }
                 self.advance();
                 Ok(Some(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(true))))
             }
             Token::Keyword { keyword: Keyword::False, .. } => {
+                if matches!(self.peek_next(), Token::Symbol('.')) {
+                    return Ok(None);
+                }
                 self.advance();
                 Ok(Some(vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(false))))
             }

--- a/crates/vibesql-parser/src/tests/literals.rs
+++ b/crates/vibesql-parser/src/tests/literals.rs
@@ -653,3 +653,65 @@ fn test_parse_date_time_as_bare_identifiers() {
     let result = crate::arena_parser::parse_select_to_owned("SELECT date, time FROM t");
     assert!(result.is_ok(), "arena: bare date/time should parse as column refs: {:?}", result);
 }
+
+// ========================================================================
+// TRUE / FALSE: boolean literals vs. non-reserved identifiers (istrue.test)
+// ========================================================================
+
+#[test]
+fn test_bare_true_false_remain_boolean_literals() {
+    // Regression guard: in ordinary primary position TRUE/FALSE stay boolean
+    // literals; the qualified-name special-case below must not disturb this.
+    let stmt = Parser::parse_sql("SELECT true, false;").expect("bare true/false should parse");
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            let is_bool = |item: &vibesql_ast::SelectItem, want: bool| match item {
+                vibesql_ast::SelectItem::Expression { expr, .. } => matches!(
+                    expr,
+                    vibesql_ast::Expression::Literal(vibesql_types::SqlValue::Boolean(b))
+                        if *b == want
+                ),
+                _ => false,
+            };
+            assert!(is_bool(&select.select_list[0], true), "first item should be TRUE literal");
+            assert!(is_bool(&select.select_list[1], false), "second item should be FALSE literal");
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+#[test]
+fn test_false_dot_false_parses_as_qualified_column_ref() {
+    // istrue.test istrue-800/830/850: TRUE/FALSE are not reserved, so `false.false`
+    // is the column `false` of table `false`, not a syntax error on the boolean
+    // literal. It must parse as a qualified ColumnRef (later resolved / rejected as
+    // "no such column").
+    let stmt = Parser::parse_sql("SELECT false.false;").expect("false.false should parse");
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match &select.select_list[0] {
+            vibesql_ast::SelectItem::Expression { expr, .. } => match expr {
+                vibesql_ast::Expression::ColumnRef(col) => {
+                    assert_eq!(col.table_canonical().as_deref(), Some("false"));
+                    assert_eq!(col.column_canonical(), "false");
+                }
+                other => panic!("Expected qualified ColumnRef, got {:?}", other),
+            },
+            _ => panic!("Expected expression"),
+        },
+        _ => panic!("Expected SELECT statement"),
+    }
+}
+
+#[test]
+fn test_true_false_usable_as_table_name() {
+    // istrue.test istrue-850/851: `SELECT ... FROM false` — TRUE/FALSE are plain
+    // table names in table position (no boolean literal can occur there).
+    assert!(
+        Parser::parse_sql("SELECT 1 FROM false;").is_ok(),
+        "FROM false should parse as a table reference"
+    );
+    assert!(
+        Parser::parse_sql("SELECT 1 FROM true;").is_ok(),
+        "FROM true should parse as a table reference"
+    );
+}


### PR DESCRIPTION
## Summary

A coherent, low-risk increment of the ~497-failure **expression / type-affinity / literal semantics** family (#6172). Fixes two related SQL-semantics gaps and unifies a duplicated DEFAULT evaluator.

### 1. TRUE / FALSE are not reserved words (SQLite)
They are boolean literals only in ordinary primary position; as a dotted-name qualifier or in table-name position they are plain identifiers.

- **parser** (`parse_literal`): defer `TRUE`/`FALSE` to identifier parsing when a `.` follows (mirrors the existing single-quoted-string qualifier rule), so `false.false` parses as column `false` of table `false` — later resolved / rejected as `no such column` — instead of a `near "."` / `near "false"` **syntax error**.
- **parser** (`parse_identifier_expression`): dedicated `TRUE`/`FALSE` arm for the qualified case (they are deliberately excluded from `can_be_identifier_in_expression` to keep bare literals working, so they need their own arm).
- **parser** (`can_be_identifier_in_table_position`): accept `TRUE`/`FALSE` as table names (`SELECT ... FROM false`).
- Bare `SELECT true, false` still yields boolean literals — regression-guarded by a unit test.

### 2. Constant expressions in DEFAULT
DEFAULT now materializes the full set of unary operators over a constant operand with SQLite-accurate semantics by delegating to the shared `eval_unary_op`:
- logical NOT (`DEFAULT(not true)` → 0, `DEFAULT(not false)` → 1)
- bitwise NOT
- unary +/- including string→number coercion (`DEFAULT -'0xFF'` → integer 0)

The redundant ALTER-path evaluator (`evaluate_simple_default`, which reimplemented a weaker literals+partial-negation subset and errored on `Plus`/`BitwiseNot`/text operands) now delegates to the single canonical `evaluate_default_expression`, so CREATE/INSERT and `ALTER TABLE ADD COLUMN` share one behavior.

## Root cause
- `TRUE`/`FALSE` were eagerly consumed as boolean literals in `parse_literal` before the identifier path could treat them as a dotted-name qualifier, and were excluded from the table-name identifier set.
- Two separate, weaker DEFAULT evaluators only special-cased unary `Minus` (numeric) and errored on everything else.

## Before / after (`make test-tcl-file`)
| File | Before | After |
|------|-------:|------:|
| istrue.test | 21 failed | **14 failed** (7 fixed) |
| literal.test | 3 failed | **0 failed** (100%) |

Fixed tests: `istrue-510/800/830/840/841/850/851`, `literal-1.9.2/1.13.2/1.13.3`.

Remaining istrue failures are **out of scope** for the engine: `istrue-600.*` depend on the `sqlite3_bind_double` NaN-binding C-API harness command, `istrue-810` needs ORDER-BY-by-column-name resolution, `istrue-820` is an error-message-format nicety.

## No regressions
- `select1.test` and `keyword1.test` remain 100%; `expr`/`join2`/`cast` unaffected.
- The parser/table-position/DEFAULT changes are strictly additive — they convert former parse/eval **errors** into successes; they cannot turn a previously-passing parse into a failure.
- Full `vibesql-parser` (1791+8) and `vibesql-executor` unit suites green; new unit tests added for both fixes.

## Scope
Partial increment — the e_expr file-scope `MATCH` gap and the remaining satellites (nan/like3/types3/quote, largely harness-command-bound) are left for follow-up.

Part of #6172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)