### PR TITLE
conformance(tcl): view DEFAULT VALUES via INSTEAD OF trigger + table-qualified cross-update UNIQUE message (Part of #6176)

### DIFF
--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -1945,8 +1945,18 @@ fn execute_insert_on_view(
             let mut row_values = vec![vibesql_types::SqlValue::Null; view_schema.columns.len()];
 
             for (expr, (col_idx, _col)) in value_exprs.iter().zip(target_columns.iter()) {
-                // Evaluate expression - for INSERT, these are typically literals
-                let value = evaluator.eval(expr, &dummy_row)?;
+                // A view column has no column-level DEFAULT, so a `DEFAULT`
+                // placeholder (from `INSERT INTO view DEFAULT VALUES`, or an
+                // explicit `DEFAULT` in a VALUES row) resolves to NULL — the
+                // INSTEAD OF trigger then sees NEW.<col> = NULL. This mirrors
+                // sqlite3 3.51.0 (triggerC-11.4). Evaluating the placeholder
+                // directly would raise "DEFAULT keyword is only valid in
+                // INSERT VALUES and UPDATE SET clauses".
+                let value = if matches!(expr, vibesql_ast::Expression::Default) {
+                    vibesql_types::SqlValue::Null
+                } else {
+                    evaluator.eval(expr, &dummy_row)?
+                };
                 row_values[*col_idx] = value;
             }
 

--- a/crates/vibesql-executor/src/update/index_sync.rs
+++ b/crates/vibesql-executor/src/update/index_sync.rs
@@ -278,6 +278,16 @@ pub(super) fn detect_surviving_replace_conflict(
     Ok(())
 }
 
+/// Format a constraint's columns as sqlite3's `table.col1, table.col2` list for
+/// a "UNIQUE constraint failed" message (e.g. `t1.a` or `t1.c, t1.d`).
+fn qualify_constraint_columns(table_name: &str, columns: &[String]) -> String {
+    columns
+        .iter()
+        .map(|col| format!("{}.{}", table_name, col))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// Validate that multiple updates in the same batch don't produce conflicting
 /// PK or UNIQUE constraint values. This ensures SQL's deferred constraint semantics
 /// where all rows must satisfy constraints after the entire UPDATE completes.
@@ -305,9 +315,12 @@ pub(super) fn validate_cross_update_uniqueness(
 
             if !seen_pks.insert(pk_values.clone()) {
                 let pk_col_names: Vec<String> = schema.primary_key.as_ref().unwrap().clone();
+                // sqlite3 3.51.0 reports "UNIQUE constraint failed: t1.a"
+                // (each column qualified by the table name), with no
+                // parenthetical suffix. See triggerC-1.15.
                 return Err(ExecutorError::ConstraintViolation(format!(
-                    "UNIQUE constraint failed: {} (multiple rows would have same key)",
-                    pk_col_names.join(", ")
+                    "UNIQUE constraint failed: {}",
+                    qualify_constraint_columns(&schema.name, &pk_col_names)
                 )));
             }
         }
@@ -332,8 +345,8 @@ pub(super) fn validate_cross_update_uniqueness(
                 let unique_col_names: Vec<String> =
                     schema.unique_constraints[constraint_idx].clone();
                 return Err(ExecutorError::ConstraintViolation(format!(
-                    "UNIQUE constraint failed: {} (multiple rows would have same key)",
-                    unique_col_names.join(", ")
+                    "UNIQUE constraint failed: {}",
+                    qualify_constraint_columns(&schema.name, &unique_col_names)
                 )));
             }
         }

--- a/crates/vibesql-executor/tests/insert_view_default_values_tests.rs
+++ b/crates/vibesql-executor/tests/insert_view_default_values_tests.rs
@@ -1,0 +1,82 @@
+//! `INSERT INTO <view> DEFAULT VALUES` with an INSTEAD OF INSERT trigger.
+//!
+//! A view column has no column-level DEFAULT, so a `DEFAULT` placeholder — from
+//! `INSERT INTO view DEFAULT VALUES`, or an explicit `DEFAULT` in a VALUES row —
+//! resolves to NULL, and the INSTEAD OF trigger sees `NEW.<col> = NULL`. This
+//! matches sqlite3 3.51.0 (triggerC-11.4). Before the fix the placeholder was
+//! evaluated directly, raising "DEFAULT keyword is only valid in INSERT VALUES
+//! and UPDATE SET clauses". Part of #6176.
+
+use vibesql_executor::{
+    CreateTableExecutor, InsertExecutor, SelectExecutor, TriggerExecutor, ViewExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn exec(db: &mut Database, sql: &str) {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e:?}"));
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+        }
+        Statement::CreateView(s) => {
+            ViewExecutor::execute_create_view(&s, db).expect("CREATE VIEW failed");
+        }
+        Statement::CreateTrigger(s) => {
+            TriggerExecutor::create_trigger_with_sql(db, &s, Some(sql))
+                .expect("CREATE TRIGGER failed");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT failed");
+        }
+        other => panic!("unsupported statement in test helper: {other:?}"),
+    }
+}
+
+/// Reads `log` as `(a, b)` pairs preserving insertion order.
+fn read_log(db: &Database) -> Vec<(SqlValue, SqlValue)> {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql("SELECT a, b FROM log;").expect("parse SELECT");
+    let Statement::Select(select) = stmt else { panic!("expected SELECT") };
+    let rows = SelectExecutor::new(db).execute(&select).expect("SELECT failed");
+    rows.iter().map(|r| (r.values[0].clone(), r.values[1].clone())).collect()
+}
+
+fn setup(db: &mut Database) {
+    exec(db, "CREATE TABLE log(a, b)");
+    exec(db, "CREATE TABLE t2(a, b)");
+    exec(db, "CREATE VIEW v2 AS SELECT * FROM t2");
+    exec(
+        db,
+        "CREATE TRIGGER tv2 INSTEAD OF INSERT ON v2 \
+         BEGIN INSERT INTO log VALUES(new.a, new.b); END",
+    );
+}
+
+/// triggerC-11.4: `INSERT INTO v2 DEFAULT VALUES` fires the INSTEAD OF trigger
+/// with all NEW columns NULL (a view has no column defaults).
+#[test]
+fn insert_default_values_on_view_fires_trigger_with_nulls() {
+    let mut db = Database::new();
+    setup(&mut db);
+
+    exec(&mut db, "INSERT INTO v2 DEFAULT VALUES");
+
+    let log = read_log(&db);
+    assert_eq!(log, vec![(SqlValue::Null, SqlValue::Null)]);
+}
+
+/// An explicit `DEFAULT` in a VALUES row on a view likewise resolves to NULL,
+/// while non-DEFAULT positions keep their literal value.
+#[test]
+fn explicit_default_in_values_on_view_resolves_to_null() {
+    let mut db = Database::new();
+    setup(&mut db);
+
+    exec(&mut db, "INSERT INTO v2 VALUES(DEFAULT, 5)");
+
+    let log = read_log(&db);
+    assert_eq!(log, vec![(SqlValue::Null, SqlValue::Integer(5))]);
+}

--- a/crates/vibesql-executor/tests/update_cross_update_unique_message_tests.rs
+++ b/crates/vibesql-executor/tests/update_cross_update_unique_message_tests.rs
@@ -1,0 +1,82 @@
+//! Cross-update UNIQUE/PK conflict error-message format.
+//!
+//! When a single UPDATE would land multiple rows on the same PRIMARY KEY or
+//! UNIQUE value, sqlite3 3.51.0 reports `UNIQUE constraint failed: t1.a` — each
+//! offending column qualified by its table name, with no parenthetical suffix.
+//! Before the fix VibeSQL emitted `UNIQUE constraint failed: a (multiple rows
+//! would have same key)`, which failed triggerC-1.15. Part of #6176.
+
+use vibesql_executor::{CreateTableExecutor, ExecutorError, InsertExecutor, UpdateExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+fn exec(db: &mut Database, sql: &str) {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e:?}"));
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT failed");
+        }
+        other => panic!("unsupported statement in test helper: {other:?}"),
+    }
+}
+
+fn run_update_err(db: &mut Database, sql: &str) -> ExecutorError {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).expect("parse UPDATE");
+    let Statement::Update(update) = stmt else { panic!("expected UPDATE") };
+    UpdateExecutor::execute(&update, db).expect_err("expected constraint violation")
+}
+
+/// triggerC-1.15: collapsing every row onto one INTEGER PRIMARY KEY value names
+/// the column as `t1.a`.
+#[test]
+fn cross_update_primary_key_collision_message_is_table_qualified() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b UNIQUE, c, d, e)");
+    exec(&mut db, "INSERT INTO t1 VALUES(1,2,3,4,5)");
+    exec(&mut db, "INSERT INTO t1 VALUES(6,7,8,9,10)");
+    exec(&mut db, "INSERT INTO t1 VALUES(11,12,13,14,15)");
+
+    match run_update_err(&mut db, "UPDATE t1 SET a=100") {
+        ExecutorError::ConstraintViolation(msg) => {
+            assert_eq!(msg, "UNIQUE constraint failed: t1.a", "got: {msg}");
+        }
+        other => panic!("expected ConstraintViolation, got {other:?}"),
+    }
+}
+
+/// A UNIQUE (non-PK) collision names the column as `t1.b`.
+#[test]
+fn cross_update_unique_collision_message_is_table_qualified() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b UNIQUE)");
+    exec(&mut db, "INSERT INTO t1 VALUES(1,2)");
+    exec(&mut db, "INSERT INTO t1 VALUES(6,7)");
+
+    match run_update_err(&mut db, "UPDATE t1 SET b=50") {
+        ExecutorError::ConstraintViolation(msg) => {
+            assert_eq!(msg, "UNIQUE constraint failed: t1.b", "got: {msg}");
+        }
+        other => panic!("expected ConstraintViolation, got {other:?}"),
+    }
+}
+
+/// A composite PRIMARY KEY qualifies every column: `t3.c, t3.d`.
+#[test]
+fn cross_update_composite_key_collision_message_qualifies_each_column() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t3(c, d, PRIMARY KEY(c, d))");
+    exec(&mut db, "INSERT INTO t3 VALUES(1, 2)");
+    exec(&mut db, "INSERT INTO t3 VALUES(3, 4)");
+
+    match run_update_err(&mut db, "UPDATE t3 SET c=9, d=9") {
+        ExecutorError::ConstraintViolation(msg) => {
+            assert_eq!(msg, "UNIQUE constraint failed: t3.c, t3.d", "got: {msg}");
+        }
+        other => panic!("expected ConstraintViolation, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

A partial increment on the trigger / DROP semantics family (**Part of #6176**). Two on-theme, single-process trigger-semantics fixes surfaced by the `triggerC` evidence suite:

1. **`INSERT INTO <view> DEFAULT VALUES` with an INSTEAD OF trigger.** A view column has no column-level default, so a `DEFAULT` placeholder (from `DEFAULT VALUES`, or an explicit `DEFAULT` in a VALUES row on a view) now resolves to `NULL`, and the INSTEAD OF INSERT trigger sees `NEW.<col> = NULL` — matching sqlite3 3.51.0 (`triggerC-11.4`). Previously the placeholder was evaluated directly, raising `DEFAULT keyword is only valid in INSERT VALUES and UPDATE SET clauses`.
   - `crates/vibesql-executor/src/insert/execution.rs` (`execute_insert_on_view`).

2. **Cross-update PK/UNIQUE collision message format.** A single UPDATE that would land multiple rows on one PRIMARY KEY / UNIQUE value now reports `UNIQUE constraint failed: t1.a` (each column qualified by table name, no parenthetical suffix), matching sqlite3 3.51.0 (`triggerC-1.15`). Previously emitted `UNIQUE constraint failed: a (multiple rows would have same key)`.
   - `crates/vibesql-executor/src/update/index_sync.rs` (`validate_cross_update_uniqueness`, new `qualify_constraint_columns` helper).

## Before / after (files touched)

| File | Before | After |
|------|-------:|------:|
| `triggerC.test` | 102 passed / 17 failed | **104 passed / 15 failed** |

Fixed: `triggerC-11.4`, `triggerC-1.15`. No new failures.

## No regressions

- Executor unit suite: all green (added `insert_view_default_values_tests`, `update_cross_update_unique_message_tests` — 5 new tests, all pass).
- `update.test` 128/0, `triggerB.test` 202/0, `trigger2/7/E/G`, `temptrigger` unchanged (pre-existing failures unrelated to these changes).

## Scope notes

- **Did not touch `crates/vibesql-executor/src/trigger_rename.rs`** — avoids overlap with the #6174 ALTER TABLE wave.
- The bulk of #6176 stays open by design: `e_droptrigger.test` (59) and `e_dropview.test` (25) are blocked by `ATTACH` + persistent-temp semantics that the multi-process TCL shim cannot provide; the `trigger1.test` temp failures are shim TEMP-table demotion artifacts; the remaining `triggerC` failures are "undefined behaviour" BEFORE-trigger ordering and PRAGMA-state-tracking cases. Left for follow-up increments.

Part of #6176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)