### PR TITLE
conformance(tcl): PRAGMA auto_vacuum + temp_store (Part of #6175)

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -20,6 +20,16 @@ pub struct SqlExecutor {
     /// When ON, INSERT/UPDATE/DELETE statements return a one-row, one-column
     /// result containing the change count.
     count_changes: bool,
+    /// PRAGMA auto_vacuum session setting (SQLite-compatible, default 0=NONE).
+    /// VibeSQL does not implement pager auto-vacuum, but it parses, normalizes
+    /// and echoes the setting exactly like SQLite so introspection round-trips
+    /// (pragma.test pragma-17). Canonical codes: 0=NONE, 1=FULL, 2=INCREMENTAL.
+    auto_vacuum: i64,
+    /// PRAGMA temp_store session setting (SQLite-compatible, default 0=DEFAULT).
+    /// Parsed/normalized/echoed like SQLite (pragma.test pragma-18); VibeSQL
+    /// demotes TEMP tables to persistent so the value is advisory only.
+    /// Canonical codes: 0=DEFAULT, 1=FILE, 2=MEMORY.
+    temp_store: i64,
     /// Active WAL persistence state, present only when the opt-in
     /// `[database] wal = true` flag is set AND a file-backed database is in use.
     /// When `Some`, `save_database` checkpoints + truncates the WAL instead of
@@ -359,6 +369,8 @@ impl SqlExecutor {
                     db,
                     timing_enabled: false,
                     count_changes: false,
+                    auto_vacuum: 0,
+                    temp_store: 0,
                     wal_state: Some(wal_state),
                     db_path: Some(db_path.clone()),
                     _db_lock: db_lock,
@@ -399,6 +411,8 @@ impl SqlExecutor {
             db,
             timing_enabled: false,
             count_changes: false,
+            auto_vacuum: 0,
+            temp_store: 0,
             wal_state: None,
             db_path,
             _db_lock: db_lock,
@@ -1434,6 +1448,37 @@ impl SqlExecutor {
                         message: None,
                     })
                 }
+                "AUTO_VACUUM" => {
+                    // SQLite-compatible PRAGMA auto_vacuum set (pragma.test
+                    // pragma-17). VibeSQL has no pager auto-vacuum, but it
+                    // parses/normalizes/echoes the setting so a set-then-read
+                    // round-trip matches SQLite. Symbolic (none/full/incremental)
+                    // and numeric spellings are both accepted; out-of-range or
+                    // negative integers normalize to 0 (NONE), matching SQLite.
+                    self.auto_vacuum = normalize_auto_vacuum(value);
+                    Ok(QueryResult {
+                        rows: Vec::new(),
+                        columns: Vec::new(),
+                        row_count: 0,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
+                "TEMP_STORE" => {
+                    // SQLite-compatible PRAGMA temp_store set (pragma.test
+                    // pragma-18). Parsed/normalized/echoed like SQLite; the
+                    // value is advisory (VibeSQL demotes TEMP tables to
+                    // persistent). Symbolic (file/memory) and numeric spellings
+                    // accepted; out-of-range/negative integers -> 0 (DEFAULT).
+                    self.temp_store = normalize_temp_store(value);
+                    Ok(QueryResult {
+                        rows: Vec::new(),
+                        columns: Vec::new(),
+                        row_count: 0,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
                 _ => {
                     // Unknown pragma - silently ignore for SQLite compatibility
                     Ok(QueryResult {
@@ -1573,6 +1618,30 @@ impl SqlExecutor {
                     Ok(QueryResult {
                         columns: vec!["deferred_fk_count".to_string()],
                         rows: vec![vec![Some(count.to_string())]],
+                        row_count: 1,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
+                "AUTO_VACUUM" => {
+                    // SQLite-compatible PRAGMA auto_vacuum read (pragma.test
+                    // pragma-17). Reports the normalized session setting
+                    // (0=NONE, 1=FULL, 2=INCREMENTAL); default 0.
+                    Ok(QueryResult {
+                        columns: vec!["auto_vacuum".to_string()],
+                        rows: vec![vec![Some(self.auto_vacuum.to_string())]],
+                        row_count: 1,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
+                "TEMP_STORE" => {
+                    // SQLite-compatible PRAGMA temp_store read (pragma.test
+                    // pragma-18). Reports the normalized session setting
+                    // (0=DEFAULT, 1=FILE, 2=MEMORY); default 0.
+                    Ok(QueryResult {
+                        columns: vec!["temp_store".to_string()],
+                        rows: vec![vec![Some(self.temp_store.to_string())]],
                         row_count: 1,
                         execution_time_ms: None,
                         message: None,
@@ -2403,6 +2472,59 @@ fn pragma_value_to_i64(value: &vibesql_ast::PragmaValue) -> Option<i64> {
         }
         vibesql_ast::PragmaValue::String(s) => s.trim().parse::<i64>().ok(),
         vibesql_ast::PragmaValue::Identifier(_) => None,
+    }
+}
+
+/// Extract the raw textual spelling of a PRAGMA value, regardless of how the
+/// parser classified it (bare identifier, string literal, or number). Used by
+/// the enum-style config PRAGMAs (`auto_vacuum`, `temp_store`) that accept both
+/// symbolic (`full`, `memory`) and numeric (`1`, `2`) spellings.
+fn pragma_value_text(value: &vibesql_ast::PragmaValue) -> &str {
+    match value {
+        vibesql_ast::PragmaValue::Identifier(s)
+        | vibesql_ast::PragmaValue::String(s)
+        | vibesql_ast::PragmaValue::Number(s)
+        | vibesql_ast::PragmaValue::SignedNumber(s) => s.as_str(),
+    }
+}
+
+/// Normalize a `PRAGMA auto_vacuum = <value>` argument to its canonical integer
+/// code, matching SQLite's parse rules (pragma.test pragma-17):
+///   `none` / `0` / any other integer (incl. negative or out-of-range) -> 0
+///   `full` / `1`        -> 1
+///   `incremental` / `2` -> 2
+/// Symbolic names are case-insensitive.
+fn normalize_auto_vacuum(value: &vibesql_ast::PragmaValue) -> i64 {
+    let text = pragma_value_text(value);
+    match text.to_ascii_uppercase().as_str() {
+        "NONE" => 0,
+        "FULL" => 1,
+        "INCREMENTAL" => 2,
+        _ => match text.trim().parse::<i64>() {
+            Ok(1) => 1,
+            Ok(2) => 2,
+            _ => 0,
+        },
+    }
+}
+
+/// Normalize a `PRAGMA temp_store = <value>` argument to its canonical integer
+/// code, matching SQLite's parse rules (pragma.test pragma-18):
+///   `default` / `0` / any other integer (incl. negative or out-of-range) -> 0
+///   `file` / `1`   -> 1
+///   `memory` / `2` -> 2
+/// Symbolic names are case-insensitive.
+fn normalize_temp_store(value: &vibesql_ast::PragmaValue) -> i64 {
+    let text = pragma_value_text(value);
+    match text.to_ascii_uppercase().as_str() {
+        "DEFAULT" => 0,
+        "FILE" => 1,
+        "MEMORY" => 2,
+        _ => match text.trim().parse::<i64>() {
+            Ok(1) => 1,
+            Ok(2) => 2,
+            _ => 0,
+        },
     }
 }
 

--- a/crates/vibesql-cli/src/executor/tests.rs
+++ b/crates/vibesql-cli/src/executor/tests.rs
@@ -920,3 +920,80 @@ fn test_pragma_index_list_origins() {
     let result = executor.execute("PRAGMA index_list(nope)").unwrap();
     assert_eq!(result.row_count, 0);
 }
+
+// ============================================================================
+// PRAGMA auto_vacuum / temp_store parse-normalize-echo tests (issue #6175,
+// pragma.test pragma-17 / pragma-18). VibeSQL has no pager auto-vacuum and
+// demotes TEMP tables to persistent, but it parses/normalizes/echoes both
+// settings exactly like SQLite so introspection round-trips.
+// ============================================================================
+
+#[test]
+fn test_pragma_auto_vacuum_default_and_normalization() {
+    let mut executor = SqlExecutor::new(None).unwrap();
+
+    // Default is 0 (NONE).
+    let result = executor.execute("PRAGMA auto_vacuum").unwrap();
+    assert_eq!(result.columns, vec!["auto_vacuum".to_string()]);
+    assert_eq!(result.rows, vec![vec![Some("0".to_string())]]);
+
+    // Numeric + symbolic spellings normalize to the canonical code, and the
+    // value round-trips through a subsequent read. (setting, expected-echo)
+    for (set, want) in [
+        ("0", "0"),
+        ("1", "1"),
+        ("2", "2"),
+        ("3", "0"),            // out-of-range -> NONE
+        ("-1", "0"),           // negative -> NONE
+        ("1234", "0"),
+        ("-1234", "0"),
+        ("none", "0"),
+        ("NONE", "0"),
+        ("NoNe", "0"),
+        ("full", "1"),
+        ("FULL", "1"),
+        ("incremental", "2"),
+        ("INCREMENTAL", "2"),
+    ] {
+        executor.execute(&format!("PRAGMA auto_vacuum={set}")).unwrap();
+        let result = executor.execute("PRAGMA auto_vacuum").unwrap();
+        assert_eq!(
+            result.rows,
+            vec![vec![Some(want.to_string())]],
+            "auto_vacuum={set} should echo {want}"
+        );
+    }
+}
+
+#[test]
+fn test_pragma_temp_store_default_and_normalization() {
+    let mut executor = SqlExecutor::new(None).unwrap();
+
+    // Default is 0 (DEFAULT).
+    let result = executor.execute("PRAGMA temp_store").unwrap();
+    assert_eq!(result.columns, vec!["temp_store".to_string()]);
+    assert_eq!(result.rows, vec![vec![Some("0".to_string())]]);
+
+    for (set, want) in [
+        ("0", "0"),
+        ("1", "1"),
+        ("2", "2"),
+        ("3", "0"),   // out-of-range -> DEFAULT
+        ("-1", "0"),  // negative -> DEFAULT
+        ("file", "1"),
+        ("FILE", "1"),
+        ("fIlE", "1"),
+        ("memory", "2"),
+        ("MEMORY", "2"),
+        ("MeMoRy", "2"),
+        ("default", "0"),
+    ] {
+        executor.execute(&format!("PRAGMA temp_store={set}")).unwrap();
+        let result = executor.execute("PRAGMA temp_store").unwrap();
+        assert_eq!(
+            result.rows,
+            vec![vec![Some(want.to_string())]],
+            "temp_store={set} should echo {want}"
+        );
+    }
+}

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -2492,7 +2492,7 @@ proc execsql {sql {db ""}} {
                 }
                 continue  ;# Check for more statements
             }
-            if {[regexp -nocase {^PRAGMA\s+(?:\w+\.)?(full_column_names|short_column_names|case_sensitive_like|reverse_unordered_selects|integrity_check|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|table_info|data_version|collation_list|index_list|index_xinfo|index_info)} [string trim $sql]]} {
+            if {[regexp -nocase {^PRAGMA\s+(?:\w+\.)?(full_column_names|short_column_names|case_sensitive_like|reverse_unordered_selects|integrity_check|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|table_info|data_version|collation_list|index_list|index_xinfo|index_info|auto_vacuum|temp_store)} [string trim $sql]]} {
                 # This PRAGMA is supported (with =value) - stop stripping
                 break
             } else {


### PR DESCRIPTION
## Summary

Partial increment of the PRAGMA-support family issue #6175. Implements the highest-value self-contained slice available in `pragma.test`: the `auto_vacuum` (pragma-17) and `temp_store` (pragma-18) config PRAGMAs, which are pure parse-normalize-echo surfaces (all `:memory:`, set+read in one batch — no persistence required).

## What changed

- **`crates/vibesql-cli/src/executor/mod.rs`** — added SQLite-compatible `PRAGMA auto_vacuum` and `PRAGMA temp_store` handling (SET stores the normalized code on the session; query echoes it). Two normalizer helpers implement SQLite's documented parse rules:
  - `auto_vacuum`: `none`/`0`/negatives/out-of-range → 0, `full`/`1` → 1, `incremental`/`2` → 2 (symbolic case-insensitive)
  - `temp_store`: `default`/`0`/negatives/out-of-range → 0, `file`/`1` → 1, `memory`/`2` → 2 (symbolic case-insensitive)

  VibeSQL has no pager auto-vacuum and demotes TEMP tables to persistent, so these settings are advisory only — but they now round-trip exactly like SQLite so introspection matches. This is real SQLite parse semantics, not a forced-green stub.

- **`scripts/tester_vibesql.tcl`** — the shim previously stripped `auto_vacuum`/`temp_store` as "unsupported" (dropping both the set and the read → empty output). Added them to the supported-PRAGMA allowlist now that the engine genuinely handles them. SET forms remain a no-op for every other test file, matching prior behavior; only reads change, and only to match SQLite.

- **`crates/vibesql-cli/src/executor/tests.rs`** — added unit tests covering the full normalization matrix (default, numeric, out-of-range, negative, and every symbolic spelling) for both PRAGMAs.

## Before / after (`pragma.test`)

| | failing tests |
|---|---:|
| before | 140 |
| after | 113 |

All 25 `pragma-17.*` / `pragma-18.*` cases now pass. The single new `pragma-filescope-err` marker is the testfixture-only TCL command `database_never_corrupt` that the shim does not provide; it surfaces only because execution now progresses further into the file after the earlier fixes — an environment artifact, not a functional regression.

## Testing

- `cargo build --release` — clean
- `cargo test --release -p vibesql-cli --bins` — 168 passed, 0 failed (incl. 2 new)
- `make test-tcl-file FILE=pragma.test` — 140 → 113 failing, no functional regressions (diffed failing-test sets)
- pragma2/3/4/5/6 unchanged (they use only SET forms of these PRAGMAs)

## Scope

This is a **partial increment** — #6175 covers ~205 certified failures across pragma/pragma2/3/4/6. Remaining in-scope work (future PRs): `user_version`/`schema_version` persistence (pragma-8, needs DB-header persistence across the shim's per-process model), schema-qualified `temp`/`main` `table_info` shadowing (pragma-6.6), verbatim declared-type/default text in `table_info` (pragma-6.7), and `collation_list` user-collation ordering (pragma-11). Genuinely pager/journal-internal PRAGMAs remain candidates for Bucket-A (#6154).

Part of #6175
Part of epic #5779

🤖 Generated with [Claude Code](https://claude.com/claude-code)