### PR TITLE
conformance(tcl): validate ADD COLUMN CHECK / generated-NOT NULL against existing rows (Part of #6174)

### DIFF
--- a/crates/vibesql-executor/src/alter/columns.rs
+++ b/crates/vibesql-executor/src/alter/columns.rs
@@ -85,9 +85,17 @@ pub(super) fn execute_add_column(
         return Err(ExecutorError::Other("Cannot add a UNIQUE column".to_string()));
     }
     // A DEFAULT NULL is equivalent to no default for the NOT NULL check.
+    // Generated columns are exempt: their value comes from the generation
+    // expression (not a default), so SQLite permits `ADD COLUMN x AS (expr)
+    // NOT NULL` and instead validates the computed value of every existing row
+    // against the NOT NULL constraint (alter3-9.5..9.7). That per-row check runs
+    // after the backfill below.
     let default_is_null_or_absent =
         stmt.column_def.default_value.as_deref().is_none_or(is_null_default);
-    if !stmt.column_def.nullable && default_is_null_or_absent {
+    if !stmt.column_def.nullable
+        && default_is_null_or_absent
+        && stmt.column_def.generated_expr.is_none()
+    {
         return Err(ExecutorError::Other(
             "Cannot add a NOT NULL column with default value NULL".to_string(),
         ));
@@ -190,6 +198,75 @@ pub(super) fn execute_add_column(
 
         for row in table.rows_mut() {
             row.add_value(default_value.clone());
+        }
+    }
+
+    // SQLite validates the constraints declared on an added column against the
+    // *existing* table contents and aborts the whole ALTER (leaving the table
+    // untouched) if any current row would violate them (alter3-9.*). We check
+    // the added column's:
+    //   - column-level CHECK constraints, and
+    //   - NOT NULL, but only for a generated column (a non-generated column is
+    //     already guaranteed non-NULL by the constant-default rule enforced
+    //     above; a generated column's value is computed per row and may be NULL).
+    // Rows are scanned in order and CHECK is evaluated before NOT NULL within a
+    // row, matching sqlite3 3.51.0 (alter3-9.6 reports the CHECK failure even
+    // though a later row would also fail NOT NULL).
+    let added_check_exprs: Vec<Expression> = stmt
+        .column_def
+        .constraints
+        .iter()
+        .filter_map(|c| match &c.kind {
+            ColumnConstraintKind::Check { expr, .. } => Some((**expr).clone()),
+            _ => None,
+        })
+        .collect();
+    let needs_not_null_check =
+        !stmt.column_def.nullable && stmt.column_def.generated_expr.is_some();
+
+    if !added_check_exprs.is_empty() || needs_not_null_check {
+        let schema_snapshot = table.schema.clone();
+        let new_col_index = schema_snapshot.columns.len() - 1;
+        let evaluator = crate::ExpressionEvaluator::new(&schema_snapshot)
+            .with_schema_context(crate::evaluator::SchemaExprContext::CheckConstraint);
+
+        let mut violation: Option<ExecutorError> = None;
+        for row in table.rows_mut() {
+            for expr in &added_check_exprs {
+                if evaluator.eval(expr, row)? == SqlValue::Boolean(false) {
+                    // SQLite emits the bare message (no constraint name) for the
+                    // ADD COLUMN existing-row validation path.
+                    violation = Some(ExecutorError::SqliteCompatError(
+                        "CHECK constraint failed".to_string(),
+                    ));
+                    break;
+                }
+            }
+            if violation.is_some() {
+                break;
+            }
+            if needs_not_null_check
+                && matches!(row.values.get(new_col_index), Some(SqlValue::Null))
+            {
+                violation = Some(ExecutorError::SqliteCompatError(
+                    "NOT NULL constraint failed".to_string(),
+                ));
+                break;
+            }
+        }
+
+        if let Some(err) = violation {
+            // Roll back the schema + row mutations so the rejected ALTER leaves
+            // the table exactly as it was (SQLite is atomic here).
+            for row in table.rows_mut() {
+                let _ = row.remove_value(new_col_index);
+            }
+            let _ = table.schema_mut().remove_column(new_col_index);
+            if added_strict_type.is_some() {
+                table.schema_mut().strict_types.pop();
+            }
+            database.invalidate_columnar_cache(&stmt.table_name);
+            return Err(err);
         }
     }
 

--- a/crates/vibesql-executor/src/tests/alter_add_column_restrictions.rs
+++ b/crates/vibesql-executor/src/tests/alter_add_column_restrictions.rs
@@ -89,3 +89,63 @@ fn add_column_to_view_is_rejected() {
     let err = exec_sql(&mut db, "ALTER TABLE v1 ADD COLUMN d").unwrap_err();
     assert_eq!(err, "Cannot add a column to a view");
 }
+
+#[test]
+fn add_column_check_violated_by_existing_row_is_rejected() {
+    // alter3-9.2: `ADD COLUMN c CHECK(a!=1)` must abort because an existing row
+    // has a=1. SQLite reports the bare "CHECK constraint failed" for this path.
+    let mut db = Database::new();
+    exec_sql(&mut db, "CREATE TABLE t1(a, b)").unwrap();
+    exec_sql(&mut db, "INSERT INTO t1 VALUES(1, 2), ('null!', NULL), (3, 4)").unwrap();
+    let err = exec_sql(&mut db, "ALTER TABLE t1 ADD COLUMN c CHECK(a!=1)").unwrap_err();
+    assert_eq!(err, "CHECK constraint failed");
+}
+
+#[test]
+fn add_column_check_rollback_leaves_table_untouched() {
+    // A rejected ADD COLUMN CHECK must be atomic: the column is not left behind,
+    // so a subsequent non-violating ADD of the same column name succeeds
+    // (alter3-9.2..9.4 depend on this rollback).
+    let mut db = Database::new();
+    exec_sql(&mut db, "CREATE TABLE t1(a, b)").unwrap();
+    exec_sql(&mut db, "INSERT INTO t1 VALUES(1, 2), ('null!', NULL), (3, 4)").unwrap();
+    let _ = exec_sql(&mut db, "ALTER TABLE t1 ADD COLUMN c CHECK(a!=1)").unwrap_err();
+    // No row has a=2, so this CHECK holds for every existing row.
+    assert!(exec_sql(&mut db, "ALTER TABLE t1 ADD COLUMN c CHECK(a!=2)").is_ok());
+}
+
+#[test]
+fn add_column_check_satisfied_by_all_rows_is_allowed() {
+    // alter3-9.4: `ADD COLUMN c CHECK(a!=2)` succeeds because no existing row
+    // has a=2.
+    let mut db = Database::new();
+    exec_sql(&mut db, "CREATE TABLE t1(a, b)").unwrap();
+    exec_sql(&mut db, "INSERT INTO t1 VALUES(1, 2), ('null!', NULL), (3, 4)").unwrap();
+    assert!(exec_sql(&mut db, "ALTER TABLE t1 ADD COLUMN c CHECK(a!=2)").is_ok());
+}
+
+#[test]
+fn add_generated_not_null_column_null_value_is_rejected() {
+    // alter3-9.5: a generated NOT NULL column is permitted (no static NULL-default
+    // rejection), but its computed value is validated per existing row. Row
+    // ('null!', NULL) yields b+1 = NULL, violating NOT NULL.
+    let mut db = Database::new();
+    exec_sql(&mut db, "CREATE TABLE t1(a, b)").unwrap();
+    exec_sql(&mut db, "INSERT INTO t1 VALUES(1, 2), ('null!', NULL), (3, 4)").unwrap();
+    let err = exec_sql(&mut db, "ALTER TABLE t1 ADD COLUMN d AS (b+1) NOT NULL").unwrap_err();
+    assert_eq!(err, "NOT NULL constraint failed");
+}
+
+#[test]
+fn add_generated_not_null_check_reports_check_first() {
+    // alter3-9.6: with both a CHECK and NOT NULL on a generated column, the first
+    // existing row (a=1) fails CHECK(a!=1); SQLite reports CHECK even though a
+    // later row would also fail NOT NULL. CHECK is evaluated before NOT NULL
+    // within a row and rows are scanned in order.
+    let mut db = Database::new();
+    exec_sql(&mut db, "CREATE TABLE t1(a, b)").unwrap();
+    exec_sql(&mut db, "INSERT INTO t1 VALUES(1, 2), ('null!', NULL), (3, 4)").unwrap();
+    let err = exec_sql(&mut db, "ALTER TABLE t1 ADD COLUMN d AS (b+1) NOT NULL CHECK(a!=1)")
+        .unwrap_err();
+    assert_eq!(err, "CHECK constraint failed");
+}

--- a/crates/vibesql-parser/src/parser/alter.rs
+++ b/crates/vibesql-parser/src/parser/alter.rs
@@ -199,6 +199,25 @@ fn parse_add_column(
                     },
                 });
             }
+            // A column-level CHECK constraint on the added column. Without this
+            // arm the loop broke at CHECK and the `CHECK(<expr>)` tokens were
+            // silently discarded, so the constraint was neither stored nor
+            // validated against existing rows (alter3-9.*). Mirror the CREATE
+            // TABLE column-constraint parser (create/constraints.rs), preserving
+            // the verbatim expression text for SQLite-compatible messages.
+            Token::Keyword { keyword: Keyword::Check, .. } => {
+                parser.advance(); // consume CHECK
+                let lparen_pos = parser.current_position();
+                parser.expect_token(Token::LParen)?;
+                let expr = parser.parse_expression()?;
+                let rparen_pos = parser.current_position();
+                parser.expect_token(Token::RParen)?;
+                let source_text = parser.source_inside_delimiters(lparen_pos, rparen_pos);
+                constraints.push(ColumnConstraint {
+                    name: None,
+                    kind: ColumnConstraintKind::Check { expr: Box::new(expr), source_text },
+                });
+            }
             // A DEFAULT clause may appear among the other column constraints in
             // any order (e.g. `ADD c NOT NULL DEFAULT 10`). SQLite accepts column
             // constraints in any order; parsing DEFAULT only before the loop

--- a/crates/vibesql-parser/src/tests/alter_table.rs
+++ b/crates/vibesql-parser/src/tests/alter_table.rs
@@ -573,3 +573,19 @@ fn test_parse_rename_column_rejects_reserved_keyword() {
     let result = Parser::parse_sql("ALTER TABLE t1 RENAME COLUMN select TO n");
     assert!(result.is_err(), "reserved keyword `select` must be rejected as a column name");
 }
+
+#[test]
+fn test_parse_add_column_with_check_constraint() {
+    // A column-level CHECK on an added column must be captured in the parsed
+    // constraints (previously the CHECK tokens were silently dropped).
+    let stmt = Parser::parse_sql("ALTER TABLE t1 ADD COLUMN c CHECK(a!=1)").unwrap();
+    match stmt {
+        vibesql_ast::Statement::AlterTable(vibesql_ast::AlterTableStmt::AddColumn(add)) => {
+            let has_check = add.column_def.constraints.iter().any(|c| {
+                matches!(c.kind, vibesql_ast::ColumnConstraintKind::Check { .. })
+            });
+            assert!(has_check, "ADD COLUMN CHECK constraint should be parsed");
+        }
+        _ => panic!("Expected ALTER TABLE ADD COLUMN statement"),
+    }
+}


### PR DESCRIPTION
## Summary

Part of the ALTER TABLE semantics family (#6174). This lands one coherent slice: **ADD COLUMN constraint validation against existing rows** (alter3 section 9).

SQLite validates the constraints declared on `ALTER TABLE ... ADD COLUMN` against the *existing* table contents and aborts the whole ALTER (leaving the table untouched) if any current row would violate them. VibeSQL did neither.

## Root causes fixed

1. **Parser** (`crates/vibesql-parser/src/parser/alter.rs`): the ADD COLUMN constraint loop had no `CHECK` arm, so `ADD COLUMN c CHECK(<expr>)` broke out of the loop and the CHECK tokens were silently discarded — the constraint was neither stored nor enforced. Added a CHECK arm mirroring the CREATE TABLE column-constraint parser (`create/constraints.rs`), preserving the verbatim expression text.

2. **Executor** (`crates/vibesql-executor/src/alter/columns.rs`):
   - A **generated** column is now exempt from the static "Cannot add a NOT NULL column with default value NULL" rejection — SQLite permits `ADD COLUMN x AS (expr) NOT NULL` and validates the computed value per row instead.
   - After the backfill, the added column's CHECK constraints and (for a generated column) NOT NULL are validated against every existing row **in order**; CHECK is evaluated before NOT NULL within a row (matching sqlite3 3.51.0: alter3-9.6 reports the CHECK failure even though a later row would also fail NOT NULL). On any violation, the schema + row mutations are **rolled back** so the rejected ALTER is atomic.

## Before / after

`make test-tcl-file FILE=alter3.test`:

| | passed | failed |
|---|--:|--:|
| before | 24 | 25 |
| after  | 28 | 21 |

+4 tests: **alter3-9.2, 9.3, 9.4, 9.6**. alter3-9.5 and 9.7 continue to pass.

The remaining section-9 failures (9.11-9.14) depend on TEMP tables + ATTACH connection visibility in the TCL harness (VibeSQL reports `no such table: t0`), unrelated to ADD COLUMN semantics — left visibly failing, not skipped. No regressions in the other alter files, `check.test`, `altertab.test`, or `conflict.test`.

## Tests

- Parser: `test_parse_add_column_with_check_constraint`
- Executor: 5 new tests in `alter_add_column_restrictions.rs` covering CHECK violation, atomic rollback, CHECK-satisfied success, generated NOT NULL per-row validation, and CHECK-before-NOT NULL ordering.
- Full `vibesql-parser` + `vibesql-executor` suites pass.

## Coordination

**No changes to `crates/vibesql-executor/src/trigger_rename.rs`** — no overlap with the sibling #6176 (triggers/DROP) wave.

Part of #6174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)