### PR TITLE
conformance(tcl): window functions inside INSERT VALUES rows (Part of #6190)

### DIFF
--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -135,6 +135,90 @@ fn coerce_rowid_affinity(value: &vibesql_types::SqlValue) -> Result<RowidAffinit
 }
 
 /// Internal implementation of INSERT execution
+/// Pre-evaluate VALUES rows that contain window functions into literal rows.
+///
+/// SQLite treats a `VALUES` row containing a window function as its own
+/// single-row `SELECT` coroutine, so a row such as `(7, row_number() OVER ())`
+/// evaluates to `(7, 1)` (`row_number()` over a single constant row is 1).
+/// The plain per-row expression evaluator used by the INSERT path rejects
+/// window functions with "misuse of window function", so any window-bearing
+/// row is instead executed here as a FROM-less `SELECT <expr>, ...` (the same
+/// window-aware path standalone `VALUES` already uses, issue #5036) and
+/// replaced with the resulting literal values. Rows without window functions
+/// are passed through unchanged, so the common case is a cheap scan with no
+/// allocation of new expression vectors (issue #6190).
+fn materialize_window_values_rows(
+    db: &vibesql_storage::Database,
+    rows: Vec<Vec<vibesql_ast::Expression>>,
+    cte_results: Option<
+        &std::collections::HashMap<String, crate::select::cte::CteResult>,
+    >,
+) -> Result<Vec<Vec<vibesql_ast::Expression>>, ExecutorError> {
+    // Fast path: no window function anywhere -> return the rows untouched.
+    if !rows.iter().any(|row| {
+        row.iter().any(crate::select::window::expression_has_window_function)
+    }) {
+        return Ok(rows);
+    }
+
+    let mut out = Vec::with_capacity(rows.len());
+    for row in rows {
+        let has_window =
+            row.iter().any(crate::select::window::expression_has_window_function);
+        if !has_window {
+            out.push(row);
+            continue;
+        }
+
+        // Build `SELECT <expr1>, <expr2>, ...` with no FROM clause and execute
+        // it through the window-aware SELECT path. A FROM-less SELECT evaluates
+        // over a single synthetic row, matching SQLite's per-row coroutine
+        // semantics for a window function inside a VALUES row.
+        let select_list: Vec<vibesql_ast::SelectItem> = row
+            .iter()
+            .enumerate()
+            .map(|(i, expr)| vibesql_ast::SelectItem::Expression {
+                expr: expr.clone(),
+                alias: Some(format!("column{}", i + 1)),
+                source_text: None,
+            })
+            .collect();
+        let temp_stmt = vibesql_ast::SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list,
+            into_table: None,
+            into_variables: None,
+            from: None,
+            where_clause: None,
+            group_by: None,
+            having: None,
+            window_definitions: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            set_operation: None,
+            values: None,
+        };
+        let executor = match cte_results {
+            Some(ctes) => crate::SelectExecutor::new_with_cte(db, ctes),
+            None => crate::SelectExecutor::new(db),
+        };
+        let result = executor.execute_with_columns(&temp_stmt)?;
+        // A FROM-less SELECT of one VALUES row produces exactly one output row.
+        let literal_row = result
+            .rows
+            .into_iter()
+            .next()
+            .map(|r| {
+                r.values.into_iter().map(vibesql_ast::Expression::Literal).collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        out.push(literal_row);
+    }
+    Ok(out)
+}
+
 fn execute_insert_internal(
     db: &mut vibesql_storage::Database,
     stmt: &vibesql_ast::InsertStmt,
@@ -297,8 +381,17 @@ fn execute_insert_internal(
     // Get the rows to insert based on the source
     let rows_to_insert = match &stmt.source {
         vibesql_ast::InsertSource::Values(values) => {
-            // For VALUES, we already have the rows as expressions
-            values.clone()
+            // For VALUES, we already have the rows as expressions. A VALUES
+            // row may contain a window function, e.g.
+            // `INSERT INTO t VALUES(7, row_number() OVER ())`. SQLite treats
+            // each such row as its own single-row SELECT coroutine, so
+            // `row_number() OVER ()` evaluates to 1. The plain per-row
+            // expression evaluator rejects window functions with
+            // "misuse of window function", so pre-evaluate any window-bearing
+            // rows through the window-aware FROM-less SELECT path and
+            // substitute the resulting literals (issue #6190, values.test
+            // sections 3 and 16).
+            materialize_window_values_rows(db, values.clone(), cte_results.as_ref())?
         }
         vibesql_ast::InsertSource::DefaultValues => {
             // For DEFAULT VALUES, insert a single row with DEFAULT for all columns

--- a/crates/vibesql-executor/tests/insert_window_values_tests.rs
+++ b/crates/vibesql-executor/tests/insert_window_values_tests.rs
@@ -1,0 +1,139 @@
+//! Regression tests for issue #6190 — window functions inside INSERT VALUES rows.
+//!
+//! SQLite treats a `VALUES` row that contains a window function as its own
+//! single-row `SELECT` coroutine, so `(7, row_number() OVER ())` evaluates to
+//! `(7, 1)` (`row_number()` over a single constant row is 1). VibeSQL used to
+//! reject such an INSERT with "misuse of window function row_number()" because
+//! the INSERT path evaluated each VALUES expression with the plain scalar
+//! evaluator. These cases mirror `docs/reference/sqlite/test/values.test`
+//! sections 3 and 16; all expected values were verified against SQLite.
+
+use vibesql_executor::SelectExecutor;
+use vibesql_types::SqlValue;
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).unwrap();
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            vibesql_executor::InsertExecutor::execute(db, &insert)
+                .unwrap_or_else(|e| panic!("INSERT failed: {} -- {:?}", sql, e));
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+fn query(db: &vibesql_storage::Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Parse failed: {} -- {:?}", sql, e));
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor
+            .execute(&select_stmt)
+            .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e))
+            .into_iter()
+            .map(|row| row.values.to_vec())
+            .collect()
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+fn int(n: i64) -> SqlValue {
+    SqlValue::Integer(n)
+}
+
+/// values.test 3.1.1 / 3.1.2 — a single window row in the middle of the VALUES
+/// list. `row_number() OVER ()` over its own one-row coroutine is 1.
+#[test]
+fn test_insert_values_single_window_row() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE y1(x, y)");
+    run_stmt(&mut db, "INSERT INTO y1 VALUES(1, 2), (3, 4), (row_number() OVER (), 5)");
+
+    let rows = query(&db, "SELECT * FROM y1");
+    assert_eq!(rows, vec![
+        vec![int(1), int(2)],
+        vec![int(3), int(4)],
+        vec![int(1), int(5)],
+    ]);
+}
+
+/// values.test 3.2.1 — two separate window rows. Each is its own single-row
+/// coroutine, so both `row_number() OVER ()` values are 1 (they do not
+/// accumulate across rows).
+#[test]
+fn test_insert_values_two_window_rows_each_reset() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE y1(x, y)");
+    run_stmt(
+        &mut db,
+        "INSERT INTO y1 VALUES(1, 2), (3, 4), (row_number() OVER (), 6), (row_number() OVER (), 7)",
+    );
+
+    let rows = query(&db, "SELECT * FROM y1");
+    assert_eq!(rows, vec![
+        vec![int(1), int(2)],
+        vec![int(3), int(4)],
+        vec![int(1), int(6)],
+        vec![int(1), int(7)],
+    ]);
+}
+
+/// values.test 16.2 — a window row surrounded by plain rows on both sides.
+#[test]
+fn test_insert_values_window_row_between_plain_rows() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t1(a, b)");
+    run_stmt(
+        &mut db,
+        "INSERT INTO t1 VALUES(1,2),(3,4),(5,6),(7,row_number()OVER()),\
+         (9,10), (11,12), (13,14), (15,16)",
+    );
+
+    let rows = query(&db, "SELECT * FROM t1 ORDER BY a, b");
+    assert_eq!(rows, vec![
+        vec![int(1), int(2)],
+        vec![int(3), int(4)],
+        vec![int(5), int(6)],
+        vec![int(7), int(1)],
+        vec![int(9), int(10)],
+        vec![int(11), int(12)],
+        vec![int(13), int(14)],
+        vec![int(15), int(16)],
+    ]);
+}
+
+/// values.test 16.4 — the leading row carries the window function.
+#[test]
+fn test_insert_values_leading_window_row() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t1(a, b)");
+    run_stmt(&mut db, "INSERT INTO t1 VALUES(1,row_number()OVER()),(2,3), (4,5), (6,7)");
+
+    let rows = query(&db, "SELECT * FROM t1 ORDER BY a, b");
+    assert_eq!(rows, vec![
+        vec![int(1), int(1)],
+        vec![int(2), int(3)],
+        vec![int(4), int(5)],
+        vec![int(6), int(7)],
+    ]);
+}
+
+/// A plain INSERT VALUES with no window function must be entirely unaffected by
+/// the window pre-evaluation fast path (regression guard for the common case).
+#[test]
+fn test_insert_values_no_window_unchanged() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t1(a, b)");
+    run_stmt(&mut db, "INSERT INTO t1 VALUES(1,2),(3,4),(5,6)");
+
+    let rows = query(&db, "SELECT * FROM t1");
+    assert_eq!(rows, vec![
+        vec![int(1), int(2)],
+        vec![int(3), int(4)],
+        vec![int(5), int(6)],
+    ]);
+}


### PR DESCRIPTION
## Summary

Fixes the **window-functions-inside-VALUES-rows** cluster of `values.test` (issue #6190, a partial increment — the family issue stays open).

SQLite treats a `VALUES` row containing a window function as its own single-row `SELECT` coroutine, so `(7, row_number() OVER ())` evaluates to `(7, 1)` (`row_number()` over a single constant row is 1). VibeSQL's INSERT path evaluated each VALUES expression with the plain scalar evaluator, which rejected window functions with `misuse of window function row_number()` — failing `values.test` sections 3 and 16.

The standalone-`VALUES` SELECT path already handled this per-row (issue #5036). This PR reuses the same idea for the INSERT `VALUES` source: a new `materialize_window_values_rows` helper pre-evaluates any window-bearing row via a FROM-less `SELECT <expr>, ...` (window-aware, single constant input row) and substitutes the resulting literals. Rows without window functions take a cheap no-op fast path, so the common INSERT case is unchanged.

## Root cause

`execute_insert_internal` took `InsertSource::Values(values) => values.clone()` and later evaluated each expression scalar-wise. A `WindowFunction` expression has no meaning in that evaluator, producing the misuse error. The fix routes only window-bearing rows through the existing window machinery.

## Before / after (`make test-tcl-file FILE=values.test`, fresh `--release` build)

| | Failures |
| --- | --- |
| Before (fresh main) | 14 |
| After | **7** |

Fully resolved (window-in-VALUES cluster): `3.1.1`, `3.1.2`, `3.2.1`, `16.2`, `16.4`, `16.6`.

> Note: the certified baseline in the issue was 33; a fresh main build already sat at 14 (intervening parser/executor work). This increment takes it from 14 → 7.

### Remaining 7 — out of scope for this VALUES increment (documented, not regressions)

- **`8.1.3.x` / `8.1.4.x` (6 tests)** — `RIGHT JOIN` nested-loop **row ordering**. This reproduces with plain tables and no `VALUES` at all (`t1 RIGHT JOIN t2` puts the right table in the slowest loop), so it belongs to a general RIGHT JOIN row-order fix, not `values.test`. Touching the join executor here would risk regressions across every RIGHT JOIN query.
- **`values-filescope-err.1` (1)** — the `explain_i` command is undefined in the TCL shim (harness-only). Out of scope: this increment must not touch the harness/shim.

## Tests

- New `crates/vibesql-executor/tests/insert_window_values_tests.rs` — 5 SQLite-verified regression cases (single window row, two window rows each resetting to 1, window row between plain rows, leading window row, plain no-window guard).
- `cargo test -p vibesql-executor --lib` — 3590 passed, 0 failed.
- Existing regression guards green: `with_values_tests` (19), `insert_multi_row_tests` (7), `insert_basic_tests` (9), `insert_select_tests` (4), `with_insert_cte_tests` (14).
- Parser `values` tests: 39 passed.
- Cross-file TCL spot check: `insert.test`, `insert2.test`, `window1.test` — the only failures (`insert-16.1` UNIQUE-message wording, `window1` 10.8 framing) are pre-existing and unrelated to window-in-VALUES INSERT.

## Files touched

- `crates/vibesql-executor/src/insert/execution.rs` — new `materialize_window_values_rows` helper + wire-up at the `InsertSource::Values` site.
- `crates/vibesql-executor/tests/insert_window_values_tests.rs` — new regression tests.

No parser files were changed (relevant for overlap with the sibling CTE builder).

Part of #6190. Part of epic #5779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)