### PR TITLE
conformance(tcl): honor a subquery's own WITH clause across nested CTE scopes (Part of #6189)

### DIFF
--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/exists.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/exists.rs
@@ -55,6 +55,15 @@ pub(super) fn try_convert_exists_to_join(
     subquery: &SelectStmt,
     negated: bool,
 ) -> Option<(FromClause, Option<Expression>)> {
+    // A subquery with its own CTEs resolves its FROM names against those CTEs, not
+    // catalog base tables. The rewrite below reads `subquery.from` as a real table
+    // and would synthesize a join against a non-existent table while dropping the
+    // subquery's WITH clause. Bail so the caller falls back to row-by-row EXISTS
+    // evaluation, whose `.execute()` path materializes the WITH clause correctly.
+    if subquery.with_clause.is_some() {
+        return None;
+    }
+
     // For EXISTS, we need to extract the correlation predicate from the WHERE clause
     // and use it as the join condition
 

--- a/crates/vibesql-executor/src/optimizer/subquery_to_join/in_clause.rs
+++ b/crates/vibesql-executor/src/optimizer/subquery_to_join/in_clause.rs
@@ -274,6 +274,19 @@ pub(super) fn try_convert_in_to_join(
     database: &Database,
     with_clause: Option<&[CommonTableExpr]>,
 ) -> Option<InToJoinResult> {
+    // A subquery that declares its own CTEs — `x IN (WITH c AS (...) SELECT ... FROM c)`
+    // — resolves the names in its FROM clause against those CTEs, not against catalog
+    // base tables. The IN→SEMI/ANTI-join rewrite below reads `subquery.from` as if it
+    // named a real table and synthesizes a join against it, producing a bogus
+    // "no such table" for the CTE name (with2.test 7.5:
+    // `... WHERE y IN (WITH ss(x) AS (VALUES(7) UNION ALL SELECT x+7 FROM ss ...) SELECT x FROM ss)`).
+    // The subquery's WITH clause is also silently dropped by the rewrite. Bail so the
+    // caller falls back to row-by-row `eval_in_subquery`, whose `.execute()` path
+    // materializes the subquery's own WITH clause correctly.
+    if subquery.with_clause.is_some() {
+        return None;
+    }
+
     // Must have exactly one column in SELECT list
     if subquery.select_list.len() != 1 {
         return None;

--- a/crates/vibesql-executor/src/select/cte.rs
+++ b/crates/vibesql-executor/src/select/cte.rs
@@ -47,9 +47,15 @@ where
 /// main statement is never evaluated, so errors inside its body are never
 /// reported (with2.test 11.x/12.1). This entry point mirrors that behavior for
 /// paths that execute a statement's WITH clause (issue #5838).
+///
+/// `outer_ctes` seeds the enclosing CTE scope so a local CTE body may reference
+/// a CTE from an outer query — needed when this statement is a subquery of an
+/// outer query that also has CTEs (with3.test 2.1). Pass an empty map for a
+/// top-level statement. Local names shadow outer names.
 pub fn execute_ctes_for_stmt<F>(
     ctes: &[vibesql_ast::CommonTableExpr],
     root: &vibesql_ast::SelectStmt,
+    outer_ctes: &HashMap<String, CteResult>,
     database: &vibesql_storage::Database,
     executor: F,
 ) -> Result<HashMap<String, CteResult>, ExecutorError>
@@ -59,7 +65,7 @@ where
         &HashMap<String, CteResult>,
     ) -> Result<Vec<vibesql_storage::Row>, ExecutorError>,
 {
-    execute_ctes_with_memory_check(ctes, Some(root), database, executor, |_| Ok(()))
+    execute_ctes_with_outer(ctes, Some(root), outer_ctes, database, executor, |_| Ok(()))
 }
 
 /// SQLite evaluates a recursive CTE lazily against the queue that feeds the
@@ -158,6 +164,34 @@ where
     ) -> Result<Vec<vibesql_storage::Row>, ExecutorError>,
     M: Fn(usize) -> Result<(), ExecutorError>,
 {
+    execute_ctes_with_outer(ctes, root, &HashMap::new(), database, executor, memory_check)
+}
+
+/// Like [`execute_ctes_with_memory_check`], but with an explicit `outer_ctes`
+/// scope seeded from an enclosing query.
+///
+/// When a statement that carries its own `WITH` clause is itself a subquery of
+/// an outer query that also has CTEs (`WITH x AS (...) SELECT ... FROM (WITH y
+/// AS (SELECT * FROM x) SELECT ...)`), the inner CTE bodies must be able to see
+/// the outer CTEs (with3.test 2.1). The top-level entry previously seeded the
+/// outer scope with an empty map, so a local CTE body referencing an outer CTE
+/// failed with a spurious "no such table". Threading `outer_ctes` through fixes
+/// that; local names still shadow outer names.
+pub(super) fn execute_ctes_with_outer<F, M>(
+    ctes: &[vibesql_ast::CommonTableExpr],
+    root: Option<&vibesql_ast::SelectStmt>,
+    outer_ctes: &HashMap<String, CteResult>,
+    database: &vibesql_storage::Database,
+    executor: F,
+    memory_check: M,
+) -> Result<HashMap<String, CteResult>, ExecutorError>
+where
+    F: Fn(
+        &vibesql_ast::SelectStmt,
+        &HashMap<String, CteResult>,
+    ) -> Result<Vec<vibesql_storage::Row>, ExecutorError>,
+    M: Fn(usize) -> Result<(), ExecutorError>,
+{
     // If the root statement reads a directly-referenced recursive CTE under a
     // LIMIT, thread that limit inward so lazy recursion can terminate early
     // (with1.test 5.1, 5.4). Only top-level CTEs of the root statement are
@@ -168,7 +202,7 @@ where
     execute_cte_list(
         ctes,
         root,
-        &HashMap::new(),
+        outer_ctes,
         &mut in_progress,
         false,
         outer_row_hint,

--- a/crates/vibesql-executor/src/select/executor/execute.rs
+++ b/crates/vibesql-executor/src/select/executor/execute.rs
@@ -30,7 +30,7 @@ use crate::{
         PipelineInput,
     },
     select::{
-        cte::{execute_ctes_for_stmt, execute_ctes_with_memory_check, CteResult},
+        cte::{execute_ctes_for_stmt, execute_ctes_with_outer, CteResult},
         helpers::apply_limit_offset,
         join::FromResult,
         SelectResult,
@@ -365,9 +365,19 @@ impl SelectExecutor<'_> {
             // This query has its own CTEs - execute them with memory tracking.
             // The statement is passed as reachability root so unreferenced CTEs
             // are skipped (SQLite lazy expansion, issue #5838).
-            execute_ctes_with_memory_check(
+            //
+            // Seed the outer scope with any enclosing CTEs so a local CTE body
+            // may reference an outer CTE — e.g. an inner subquery that declares
+            // its own WITH but reads a CTE from the enclosing query
+            // (with3.test 2.1: `WITH x1 AS (...) SELECT * FROM (WITH x2 AS
+            // (SELECT * FROM x1) SELECT ... FROM x1, x2)`). Local names still
+            // shadow outer names.
+            let empty = HashMap::new();
+            let outer_ctes = self.cte_context.unwrap_or(&empty);
+            execute_ctes_with_outer(
                 with_clause,
                 Some(&optimized_stmt),
+                outer_ctes,
                 self.database,
                 |query, cte_ctx| self.execute_with_ctes(query, cte_ctx),
                 |size| self.track_memory_allocation(size),
@@ -611,9 +621,18 @@ impl SelectExecutor<'_> {
         // joins and NATURAL/USING deduplication). We do not return the rows.
         let from_result = if let Some(from_clause) = &stmt.from {
             let mut cte_results = if let Some(with_clause) = &stmt.with_clause {
-                execute_ctes_for_stmt(with_clause, stmt, self.database, |query, cte_ctx| {
-                    self.execute_with_ctes(query, cte_ctx)
-                })?
+                // Seed the outer CTE scope so a local CTE body can reference an
+                // enclosing query's CTE (with3.test 2.1): a derived-table
+                // subquery that declares its own WITH but reads an outer CTE.
+                let empty = HashMap::new();
+                let outer_ctes = self.cte_context.unwrap_or(&empty);
+                execute_ctes_for_stmt(
+                    with_clause,
+                    stmt,
+                    outer_ctes,
+                    self.database,
+                    |query, cte_ctx| self.execute_with_ctes(query, cte_ctx),
+                )?
             } else {
                 HashMap::new()
             };
@@ -699,9 +718,18 @@ impl SelectExecutor<'_> {
         // First, get the FROM result to access the schema
         let from_result = if let Some(from_clause) = &stmt.from {
             let mut cte_results = if let Some(with_clause) = &stmt.with_clause {
-                execute_ctes_for_stmt(with_clause, stmt, self.database, |query, cte_ctx| {
-                    self.execute_with_ctes(query, cte_ctx)
-                })?
+                // Seed the outer CTE scope so a local CTE body can reference an
+                // enclosing query's CTE (with3.test 2.1): a derived-table
+                // subquery that declares its own WITH but reads an outer CTE.
+                let empty = HashMap::new();
+                let outer_ctes = self.cte_context.unwrap_or(&empty);
+                execute_ctes_for_stmt(
+                    with_clause,
+                    stmt,
+                    outer_ctes,
+                    self.database,
+                    |query, cte_ctx| self.execute_with_ctes(query, cte_ctx),
+                )?
             } else {
                 HashMap::new()
             };
@@ -802,9 +830,18 @@ impl SelectExecutor<'_> {
         // Execute the FROM clause to get combined schema
         let from_result = if let Some(from_clause) = &stmt.from {
             let mut cte_results = if let Some(with_clause) = &stmt.with_clause {
-                execute_ctes_for_stmt(with_clause, stmt, self.database, |query, cte_ctx| {
-                    self.execute_with_ctes(query, cte_ctx)
-                })?
+                // Seed the outer CTE scope so a local CTE body can reference an
+                // enclosing query's CTE (with3.test 2.1): a derived-table
+                // subquery that declares its own WITH but reads an outer CTE.
+                let empty = HashMap::new();
+                let outer_ctes = self.cte_context.unwrap_or(&empty);
+                execute_ctes_for_stmt(
+                    with_clause,
+                    stmt,
+                    outer_ctes,
+                    self.database,
+                    |query, cte_ctx| self.execute_with_ctes(query, cte_ctx),
+                )?
             } else {
                 HashMap::new()
             };

--- a/crates/vibesql-executor/tests/cte_subquery_scope_tests.rs
+++ b/crates/vibesql-executor/tests/cte_subquery_scope_tests.rs
@@ -1,0 +1,165 @@
+//! Regression tests for CTE scoping in nested subqueries (issue #6189).
+//!
+//! Two distinct CTE-scoping gaps surfaced by the SQLite `with*.test`
+//! conformance fixtures, both fixed together because they share a root cause —
+//! a nested query's CTE scope being computed without the enclosing scope:
+//!
+//! 1. A `WITH` clause declared *inside* an `IN` / `EXISTS` subquery was dropped
+//!    by the IN/EXISTS→semi/anti-join optimizer, which treated the subquery's
+//!    CTE name as a real base table and produced a bogus "no such table"
+//!    (with2.test 7.5:
+//!    `... WHERE y IN (WITH ss(x) AS (VALUES(7) UNION ALL SELECT x+7 FROM ss WHERE x<49) SELECT x FROM ss)`).
+//!    The fix bails the transform when the subquery carries its own `WITH`,
+//!    falling back to row-by-row evaluation which materializes it correctly.
+//!
+//! 2. A subquery that declares its own `WITH` could not reference a CTE from the
+//!    enclosing query, because the inner CTE scope was seeded with an empty
+//!    outer scope (with3.test 2.1:
+//!    `WITH x1(a) AS (VALUES(100)) INSERT INTO t1(x) SELECT * FROM (WITH x2(y) AS (SELECT * FROM x1) SELECT y+a FROM x1, x2)`).
+//!    The fix threads the enclosing CTE scope into the inner WITH execution;
+//!    local names still shadow outer names.
+//!
+//! All expected values below were verified against sqlite3.
+
+use vibesql_executor::{InsertExecutor, SelectExecutor};
+use vibesql_types::SqlValue;
+
+fn run_stmt(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Parse failed: {} -- {:?}", sql, e));
+    match stmt {
+        vibesql_ast::Statement::CreateTable(create_table) => {
+            vibesql_executor::CreateTableExecutor::execute(&create_table, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(insert) => {
+            InsertExecutor::execute(db, &insert)
+                .unwrap_or_else(|e| panic!("Insert failed: {} -- {:?}", sql, e));
+        }
+        other => panic!("Unsupported statement in test setup: {:?}", other),
+    }
+}
+
+fn query(db: &vibesql_storage::Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql)
+        .unwrap_or_else(|e| panic!("Parse failed: {} -- {:?}", sql, e));
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor
+            .execute(&select_stmt)
+            .unwrap_or_else(|e| panic!("Query failed: {} -- {:?}", sql, e))
+            .into_iter()
+            .map(|row| row.values.to_vec())
+            .collect()
+    } else {
+        panic!("Expected SELECT statement: {}", sql);
+    }
+}
+
+/// with2.test 7.5: a recursive CTE declared inside an `IN` subquery.
+/// sqlite3 returns the rows of t6 whose y is a multiple of 7 present in the CTE.
+#[test]
+fn test_recursive_cte_in_in_subquery() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t6(y)");
+    run_stmt(&mut db, "INSERT INTO t6 VALUES(14),(28),(42),(15)");
+    let rows = query(
+        &db,
+        "SELECT y FROM t6 WHERE y IN ( \
+           WITH ss(x) AS ( VALUES(7) UNION ALL SELECT x+7 FROM ss WHERE x<49 ) \
+           SELECT x FROM ss \
+         ) ORDER BY y",
+    );
+    assert_eq!(
+        rows,
+        vec![
+            vec![SqlValue::Integer(14)],
+            vec![SqlValue::Integer(28)],
+            vec![SqlValue::Integer(42)],
+        ]
+    );
+}
+
+/// A non-recursive `WITH` inside an `IN` subquery (simpler variant of the same
+/// optimizer bug: the CTE name must not be read as a base table).
+#[test]
+fn test_non_recursive_cte_in_in_subquery() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t6(y)");
+    run_stmt(&mut db, "INSERT INTO t6 VALUES(14),(28),(42),(15)");
+    let rows = query(
+        &db,
+        "SELECT y FROM t6 WHERE y IN ( \
+           WITH ss(x) AS (VALUES(14),(28)) SELECT x FROM ss \
+         ) ORDER BY y",
+    );
+    assert_eq!(rows, vec![vec![SqlValue::Integer(14)], vec![SqlValue::Integer(28)]]);
+}
+
+/// A `WITH` inside an `EXISTS` subquery — the EXISTS→semi-join transform must
+/// likewise bail so the subquery's WITH clause is honored.
+#[test]
+fn test_cte_in_exists_subquery() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t6(y)");
+    run_stmt(&mut db, "INSERT INTO t6 VALUES(14),(28)");
+    let rows = query(
+        &db,
+        "SELECT y FROM t6 WHERE EXISTS ( \
+           WITH ss(x) AS (VALUES(14)) SELECT x FROM ss WHERE x = t6.y \
+         )",
+    );
+    assert_eq!(rows, vec![vec![SqlValue::Integer(14)]]);
+}
+
+/// A normal `IN` subquery (no inner WITH) must still work — guards against the
+/// bail-out being over-broad and disabling the semi-join transform everywhere.
+#[test]
+fn test_plain_in_subquery_still_works() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t6(y)");
+    run_stmt(&mut db, "INSERT INTO t6 VALUES(1),(2),(3),(4)");
+    run_stmt(&mut db, "CREATE TABLE t7(z)");
+    run_stmt(&mut db, "INSERT INTO t7 VALUES(2),(4)");
+    let rows = query(&db, "SELECT y FROM t6 WHERE y IN (SELECT z FROM t7) ORDER BY y");
+    assert_eq!(rows, vec![vec![SqlValue::Integer(2)], vec![SqlValue::Integer(4)]]);
+}
+
+/// with3.test 2.1: a derived-table subquery that declares its own `WITH x2`
+/// still references the enclosing `WITH x1`. sqlite3: 200.
+#[test]
+fn test_nested_with_references_outer_cte_in_derived_table() {
+    let mut db = vibesql_storage::Database::new();
+    run_stmt(&mut db, "CREATE TABLE t1(x)");
+    run_stmt(
+        &mut db,
+        "WITH x1(a) AS (VALUES(100)) \
+         INSERT INTO t1(x) \
+           SELECT * FROM (WITH x2(y) AS (SELECT * FROM x1) SELECT y+a FROM x1, x2)",
+    );
+    assert_eq!(query(&db, "SELECT x FROM t1"), vec![vec![SqlValue::Integer(200)]]);
+}
+
+/// Plain-SELECT form of the same outer-CTE-into-nested-WITH scoping fix.
+#[test]
+fn test_nested_with_references_outer_cte_plain_select() {
+    let db = vibesql_storage::Database::new();
+    let rows = query(
+        &db,
+        "WITH x1(a) AS (VALUES(100)) \
+         SELECT * FROM (WITH x2(y) AS (SELECT a FROM x1) SELECT y FROM x2)",
+    );
+    assert_eq!(rows, vec![vec![SqlValue::Integer(100)]]);
+}
+
+/// A nested `WITH` name shadows a same-named outer CTE (local precedence must be
+/// preserved even though the outer scope is now visible).
+#[test]
+fn test_nested_with_shadows_outer_cte() {
+    let db = vibesql_storage::Database::new();
+    let rows = query(
+        &db,
+        "WITH c(a) AS (VALUES(1)) \
+         SELECT * FROM (WITH c(a) AS (VALUES(99)) SELECT a FROM c)",
+    );
+    assert_eq!(rows, vec![vec![SqlValue::Integer(99)]]);
+}


### PR DESCRIPTION
## Summary

Fixes two related CTE-scoping gaps surfaced by the SQLite `with*.test` conformance fixtures, both stemming from a nested query's CTE scope being computed **without its enclosing scope**. Part of the CTE/WITH family issue #6189.

## Root-cause clusters (from triage of a fresh run)

The fresh build reproduced 29 in-scope failures across the five files (already below the certified 53 — earlier work fixed the rest). Triage grouped them into distinct clusters; this PR lands the two that share a single scoping root cause:

**Cluster 1 — WITH clause inside an IN/EXISTS subquery dropped by the semi-join optimizer.**
`... WHERE y IN (WITH ss(x) AS (VALUES(7) UNION ALL SELECT x+7 FROM ss WHERE x<49) SELECT x FROM ss)` (with2.test 7.5). The `IN`/`EXISTS` → semi/anti-join transform read the subquery's FROM name (`ss`, a CTE) as a real base table and synthesized a join against it → bogus `no such table: ss`. **Fix:** `try_convert_in_to_join` / `try_convert_exists_to_join` bail when the subquery carries its own `with_clause`, falling back to row-by-row evaluation whose `.execute()` path materializes the WITH clause correctly.

**Cluster 2 — a subquery's own WITH could not see an enclosing query's CTE.**
`WITH x1(a) AS (VALUES(100)) INSERT INTO t1(x) SELECT * FROM (WITH x2(y) AS (SELECT * FROM x1) SELECT y+a FROM x1, x2)` (with3.test 2.1) → `Table 'x1' not found`. The top-level CTE entry point seeded the outer scope with an **empty map**, so a local CTE body referencing an outer CTE failed. The nested-WITH-body infrastructure already threaded an `outer_ctes` scope — only the top-level seed was missing. **Fix:** thread `self.cte_context` into WITH execution via a new `execute_ctes_with_outer` entry (and an added `outer_ctes` param to `execute_ctes_for_stmt`); local names still shadow outer names.

## Before / after (fresh build, run-3 baseline → after)

| File | Before | After | Note |
| --- | --- | --- | --- |
| with2.test | 8 | **7** | 7.5 fixed |
| with3.test | 2 | **1** | 2.1 fixed |
| with1.test | 15 | 15 | unchanged (see remaining) |
| with4.test | 1 | 1 | unchanged |
| with5.test | 3 | 3 | unchanged |

Net: 2 in-scope TCL tests fixed by a single coherent scoping fix (the fix is a general class fix, broader than these 2 fixtures).

## Remaining (documented for the sibling family issue #6189)

- **with1 10.2–10.8.3** (8) — driven by the `insert_into_tree`/`scan_tree` TCL procs (harness `db one`/`db eval $var`/`last_insert_rowid` binding), **not** engine CTE gaps. Out of scope (harness/shim).
- **with5 113/114/131** (3) — compound *non-recursive seed* feeding multiple recursive UNION terms (`VALUES(...) INTERSECT/UNION ALL VALUES(...) UNION <rec> UNION <rec>`); the recursion split treats only the first term as base and mis-flags the rest as a "circular reference". Larger change to the core recursive split — left for a follow-up.
- **with1 3.6 / with2 6.6** — parser gaps (`Expected CTE name`, trailing `;`).
- **with3 1.0** — error-name ordering nuance (`no such table: m` vs `t0`).
- Assorted single wrong-answer/`SELECT table.*`-without-FROM/placeholder cases.

## Tests

- New `crates/vibesql-executor/tests/cte_subquery_scope_tests.rs` (7 cases): recursive + non-recursive WITH in `IN`, WITH in `EXISTS`, **plain-IN non-regression** (guard not over-broad), outer-CTE-into-nested-WITH for both INSERT and plain SELECT, and local-shadows-outer precedence.
- Full `vibesql-executor` suite green; `subquery_to_join` unit tests green.
- No TCL regressions: `in2.test` 1999/1999, `subquery2.test` 100% still pass (normal IN subqueries still transform to semi-joins).

## Files touched

- `crates/vibesql-executor/src/optimizer/subquery_to_join/in_clause.rs` — IN guard
- `crates/vibesql-executor/src/optimizer/subquery_to_join/exists.rs` — EXISTS guard
- `crates/vibesql-executor/src/select/cte.rs` — new `execute_ctes_with_outer`; `execute_ctes_for_stmt` gains `outer_ctes`
- `crates/vibesql-executor/src/select/executor/execute.rs` — seed outer CTE scope at the 4 WITH-execution call sites
- `crates/vibesql-executor/tests/cte_subquery_scope_tests.rs` — new regression tests

No parser/AST files changed. No harness/shim changes.

Part of #6189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)