### PR TITLE
conformance(tcl): REINDEX unknown object raises 'unable to identify the object to be reindexed' (reindex-1.9) (#6232)

### DIFF
--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -2,6 +2,10 @@
 pub enum ExecutorError {
     TableNotFound(String),
     TableAlreadyExists(String),
+    /// REINDEX names an object that is neither a table, an index, nor a
+    /// registered collating sequence. SQLite reports this with a fixed message
+    /// that carries no object name (matches `reindex-1.9`).
+    ReindexObjectUnknown,
     /// ALTER TABLE ... RENAME TO target collides with an existing table or
     /// index name. SQLite reports this with a distinct message that spans both
     /// the table and index namespaces.
@@ -530,6 +534,11 @@ impl std::fmt::Display for ExecutorError {
         match self {
             ExecutorError::TableNotFound(name) => {
                 write!(f, "{}", vibe_msg!("executor-table-not-found", name = name.as_str()))
+            }
+            ExecutorError::ReindexObjectUnknown => {
+                // SQLite-compatible, fixed wording (no object name), matching
+                // `reindex-1.9`'s `unable to identify the object to be reindexed`.
+                write!(f, "unable to identify the object to be reindexed")
             }
             ExecutorError::TableAlreadyExists(name) => {
                 write!(f, "{}", vibe_msg!("executor-table-already-exists", name = name.as_str()))

--- a/crates/vibesql-executor/src/index_ddl/reindex.rs
+++ b/crates/vibesql-executor/src/index_ddl/reindex.rs
@@ -9,6 +9,17 @@ use vibesql_storage::Database;
 
 use crate::errors::ExecutorError;
 
+/// Return `true` if `name` is one of the three built-in collating sequences
+/// VibeSQL implements (`BINARY`, `NOCASE`, `RTRIM`). Matching is
+/// case-insensitive, mirroring the canonical set used by SELECT-time collation
+/// validation. User-defined (C-API) collations are not reachable from the CLI,
+/// so only the built-ins are recognized here.
+fn is_builtin_collation(name: &str) -> bool {
+    name.eq_ignore_ascii_case("binary")
+        || name.eq_ignore_ascii_case("nocase")
+        || name.eq_ignore_ascii_case("rtrim")
+}
+
 /// Executor for REINDEX statements
 pub struct ReindexExecutor;
 
@@ -37,10 +48,32 @@ impl ReindexExecutor {
                 Ok("REINDEX completed successfully - all indexes are optimized".to_string())
             }
             Some(target) => {
-                // REINDEX with specific target (database, table, or index name)
-                // Validate that the target exists
+                // REINDEX with a specific target. SQLite resolves the name (in
+                // this order) against: a collating sequence, a table, or an
+                // index. If it matches none of those it raises
+                // `unable to identify the object to be reindexed`.
 
-                // First try as an index name
+                // A registered collating sequence. VibeSQL implements only the
+                // three SQLite built-ins (BINARY, NOCASE, RTRIM); matching is
+                // case-insensitive. `REINDEX nocase` / `REINDEX binary` succeed
+                // (e_reindex-0.1).
+                if is_builtin_collation(target) {
+                    return Ok(format!(
+                        "REINDEX completed successfully - collation '{}' is optimized",
+                        target
+                    ));
+                }
+
+                // A schema name (VibeSQL has only the implicit "main"/"temp"
+                // schemas). `REINDEX main` rebuilds every index in that schema.
+                if target.eq_ignore_ascii_case("main") || target.eq_ignore_ascii_case("temp") {
+                    return Ok(format!(
+                        "REINDEX completed successfully - schema '{}' is optimized",
+                        target
+                    ));
+                }
+
+                // An index name.
                 if database.index_exists(target) {
                     // It's an index - reindexing is not needed but we pretend to succeed
                     return Ok(format!(
@@ -49,7 +82,7 @@ impl ReindexExecutor {
                     ));
                 }
 
-                // Try as a table name
+                // A table name.
                 if database.get_table(target).is_some() {
                     // It's a table - reindex all its indexes
                     return Ok(format!(
@@ -58,8 +91,8 @@ impl ReindexExecutor {
                     ));
                 }
 
-                // Not found - error out
-                Err(ExecutorError::TableNotFound(target.clone()))
+                // Matches nothing - SQLite-compatible error (no object name).
+                Err(ExecutorError::ReindexObjectUnknown)
             }
         }
     }
@@ -196,10 +229,39 @@ mod tests {
     fn test_reindex_nonexistent_target() {
         let db = Database::new();
 
-        // Try to reindex non-existent object
+        // Try to reindex an object that is neither table, index, nor collation.
+        // SQLite raises `unable to identify the object to be reindexed`
+        // (reindex-1.9).
         let reindex_stmt = ReindexStmt { target: Some("nonexistent".to_string()) };
         let result = ReindexExecutor::execute(&reindex_stmt, &db);
-        assert!(result.is_err());
-        assert!(matches!(result, Err(ExecutorError::TableNotFound(_))));
+        assert!(matches!(result, Err(ExecutorError::ReindexObjectUnknown)));
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "unable to identify the object to be reindexed"
+        );
+    }
+
+    #[test]
+    fn test_reindex_builtin_collation() {
+        let db = Database::new();
+
+        // Built-in collation names are valid REINDEX targets and succeed even
+        // with no matching table/index (e_reindex-0.1: REINDEX nocase/binary).
+        for name in ["nocase", "NOCASE", "binary", "rtrim", "RTRIM"] {
+            let stmt = ReindexStmt { target: Some(name.to_string()) };
+            assert!(
+                ReindexExecutor::execute(&stmt, &db).is_ok(),
+                "REINDEX {name} should succeed"
+            );
+        }
+    }
+
+    #[test]
+    fn test_reindex_schema_name() {
+        let db = Database::new();
+
+        // A bare schema name reindexes that whole schema.
+        let stmt = ReindexStmt { target: Some("main".to_string()) };
+        assert!(ReindexExecutor::execute(&stmt, &db).is_ok());
     }
 }

--- a/crates/vibesql-parser/src/parser/index.rs
+++ b/crates/vibesql-parser/src/parser/index.rs
@@ -758,21 +758,34 @@ impl Parser {
 
     /// Parse REINDEX statement
     ///
-    /// Syntax:
-    ///   REINDEX [database_name | table_name | index_name]
+    /// Syntax (SQLite):
+    ///   REINDEX
+    ///   REINDEX collation-name
+    ///   REINDEX [schema-name '.'] (table-name | index-name)
     pub(super) fn parse_reindex_statement(
         &mut self,
     ) -> Result<vibesql_ast::ReindexStmt, ParseError> {
         // Expect REINDEX keyword
         self.expect_keyword(Keyword::Reindex)?;
 
-        // Check for optional target (database, table, or index name)
+        // Check for optional target (collation, table, or index name, optionally
+        // qualified by a schema name: `schema.object`).
         let target = if self.peek() == &Token::Semicolon || self.peek() == &Token::Eof {
-            // No target specified - reindex all
+            // No target specified - reindex everything
             None
         } else {
-            // Parse optional identifier (could be database, table, or index name)
-            Some(self.parse_identifier()?)
+            // Parse the (possibly schema-qualified) target. When a `schema.`
+            // qualifier is present we keep only the object name for resolution;
+            // VibeSQL has a single ("main") schema, so the qualifier is
+            // informational and validation happens against the object part.
+            let first = self.parse_identifier()?;
+            if self.peek() == &Token::Symbol('.') {
+                self.advance(); // consume the dot
+                let object = self.parse_identifier()?;
+                Some(object)
+            } else {
+                Some(first)
+            }
         };
 
         Ok(vibesql_ast::ReindexStmt { target })

--- a/crates/vibesql-parser/src/tests/index.rs
+++ b/crates/vibesql-parser/src/tests/index.rs
@@ -786,3 +786,40 @@ fn test_indexed_by_with_fallback_keyword_name() {
         }
     }
 }
+
+#[test]
+fn test_reindex_no_target() {
+    // Bare REINDEX rebuilds every index (no target).
+    let stmt = Parser::parse_sql("REINDEX").expect("parse REINDEX");
+    match stmt {
+        Statement::Reindex(r) => assert_eq!(r.target, None),
+        other => panic!("Expected Reindex, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_reindex_single_name() {
+    // REINDEX <name> — a table, index, or collation name.
+    let stmt = Parser::parse_sql("REINDEX t1").expect("parse REINDEX t1");
+    match stmt {
+        Statement::Reindex(r) => assert_eq!(r.target.as_deref(), Some("t1")),
+        other => panic!("Expected Reindex, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_reindex_schema_qualified() {
+    // REINDEX schema.object (#6232): the `main.` qualifier is accepted and the
+    // object name is retained for resolution.
+    let stmt = Parser::parse_sql("REINDEX main.t1").expect("parse REINDEX main.t1");
+    match stmt {
+        Statement::Reindex(r) => assert_eq!(r.target.as_deref(), Some("t1")),
+        other => panic!("Expected Reindex, got: {:?}", other),
+    }
+
+    let stmt = Parser::parse_sql("REINDEX main.i1").expect("parse REINDEX main.i1");
+    match stmt {
+        Statement::Reindex(r) => assert_eq!(r.target.as_deref(), Some("i1")),
+        other => panic!("Expected Reindex, got: {:?}", other),
+    }
+}

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -2532,19 +2532,13 @@ proc execsql {sql {db ""}} {
             }
         }
 
-        # Skip REINDEX statements
-        if {[string match "REINDEX*" $sql_upper]} {
-            if {[regexp -nocase {^REINDEX[^;]*;} [string trim $sql] match]} {
-                set rest [string range [string trim $sql] [string length $match] end]
-                set sql [string trim $rest]
-                if {$sql eq ""} {
-                    return {}
-                }
-                continue
-            } else {
-                return {}
-            }
-        }
+        # REINDEX is NOT stripped here (issue #6232). VibeSQL's engine handles
+        # REINDEX directly: it succeeds silently (raw format emits no DDL
+        # message) for a valid table/index/built-in-collation/schema target, and
+        # raises `unable to identify the object to be reindexed` for an
+        # unresolvable name (reindex-1.9). Stripping it to a no-op here masked
+        # that error and broke the catchsql assertion, so the statement is now
+        # passed through to the CLI unchanged.
 
         # No more statements to strip
         break


### PR DESCRIPTION
## Summary

`reindex-1.9` asserts that `REINDEX bogus` (a name that is neither a table, index, nor a registered collation) raises SQLite's `unable to identify the object to be reindexed`. VibeSQL did not, so the case failed. This PR makes the engine raise the SQLite-compatible error **and** routes the harness through the real engine path.

## Root cause (both confirmed)

1. **Shim masked it.** `scripts/tester_vibesql.tcl` stripped every *leading* `REINDEX ...;` statement to a `{}` no-op (in the `execsql` leading-statement strip loop), so `REINDEX bogus` never reached the CLI and `catchsql` received `{0 {}}` instead of `{1 {unable to identify the object to be reindexed}}`.
2. **Engine gap behind the mask.** `ReindexExecutor` *did* validate the target, but returned `TableNotFound` (translated to `no such table: bogus`, the wrong message), rejected built-in collation names (`REINDEX nocase`/`binary`), and could not parse a schema-qualified target (`REINDEX main.t1` — the parser read only `main`).

## Fix

- **Parser** (`crates/vibesql-parser/src/parser/index.rs`): `parse_reindex_statement` accepts an optional `schema.` qualifier and keeps the object name for resolution (VibeSQL has a single `main` schema).
- **Executor** (`crates/vibesql-executor/src/index_ddl/reindex.rs`): `REINDEX <name>` resolves against built-in collations (`BINARY`/`NOCASE`/`RTRIM`), the `main`/`temp` schema names, tables, then indexes. An unresolvable name yields the new `ExecutorError::ReindexObjectUnknown`, which renders SQLite's exact fixed message (no object name). Updated the stale unit test + added collation/schema tests.
- **Error** (`crates/vibesql-executor/src/errors.rs`): new `ReindexObjectUnknown` variant → `"unable to identify the object to be reindexed"`. The shim's `translate_error_to_sqlite` passes this through verbatim.
- **Shim** (`scripts/tester_vibesql.tcl`): removed the leading-`REINDEX` strip block so the statement reaches the CLI. Raw output format already suppresses DDL success messages, so valid targets still produce empty output; only the unknown-target case errors.

## Coordination note (overlap with #6193)

My only `scripts/tester_vibesql.tcl` edit is the **REINDEX strip removal inside `proc execsql`'s leading-statement strip loop** (was ~lines 2535–2547 on this branch, replaced with an explanatory comment; net around line 2535). This is a different region from the ATTACH-cascade / `do_execsql_test` area that #6193 (DML evidence) touches, so overlap should be clean — flagging for revalidation at merge.

## Before / after — `make test-tcl-file FILE=reindex.test`

| | reindex-1.9 | file result |
|---|---|---|
| before | failed | 15 passed / **1 failed** / 13 skipped |
| after | **passed** | **16 passed / 0 failed** / 13 skipped |

`e_reindex.test`: 8 passed / 0 failed (`REINDEX nocase`/`binary` still succeed). `reindex-1.1`–`1.8` and `reindex-4.*` unchanged (all `ok`); the custom-collation `reindex-2.*`/`reindex-3.*` sub-sections remain Bucket-A skips (#6195, untouched).

## Verification

- `make test-tcl-file FILE=reindex.test` → 16 passed / 0 failed / 13 skipped
- `make test-tcl-file FILE=e_reindex.test` → 8 passed / 0 failed
- `cargo test -p vibesql-executor --lib index_ddl::reindex` → 6 passed
- `cargo test -p vibesql-parser --lib tests::index::test_reindex` → 3 passed
- `cargo build --release` clean; `cargo clippy` no new warnings

Closes #6232