### PR TITLE
conformance(tcl): SQLite numeric-affinity LIMIT/OFFSET + rowid-order delete/update (Part of #6193)

### DIFF
--- a/crates/vibesql-executor/src/delete/executor.rs
+++ b/crates/vibesql-executor/src/delete/executor.rs
@@ -1176,40 +1176,15 @@ impl DeleteExecutor {
             // Evaluate the offset expression without a row context
             // (it should be a constant or simple expression)
             let empty_row = vibesql_storage::Row::new(vec![]);
-            match evaluator.eval(offset_expr, &empty_row)? {
-                SqlValue::Integer(n) if n >= 0 => n as usize,
-                SqlValue::Bigint(n) if n >= 0 => n as usize,
-                // Any negative OFFSET is treated as 0 (SQLite semantics, #5747).
-                SqlValue::Integer(n) if n < 0 => 0,
-                SqlValue::Bigint(n) if n < 0 => 0,
-                // SQLite applies integer affinity to OFFSET, but only a REAL
-                // that converts *losslessly* to an integer is accepted (e.g.
-                // `LIMIT 2+2, 16/4` supplies OFFSET `2+2`=4 and LIMIT `16/4`
-                // which evaluates to REAL 4.0 -> 4). A negative integral real
-                // clamps to 0, matching the integer branch. A non-integral real
-                // (e.g. 1.2) falls through to the error arm (e_delete-3.1).
-                SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f)
-                    if f.is_finite() && f.fract() == 0.0 =>
-                {
-                    if f >= 0.0 {
-                        f as usize
-                    } else {
-                        0
-                    }
-                }
-                SqlValue::Float(f) if f.is_finite() && f.fract() == 0.0 => {
-                    if f >= 0.0 {
-                        f as usize
-                    } else {
-                        0
-                    }
-                }
-                SqlValue::Null => 0, // NULL offset treated as 0
-                _ => {
-                    return Err(ExecutorError::TypeError(
-                        "OFFSET value must be a non-negative integer".to_string(),
-                    ))
-                }
+            let value = evaluator.eval(offset_expr, &empty_row)?;
+            // SQLite numeric-affinity coercion shared with SELECT and UPDATE
+            // (#6193): INTEGER as-is, a losslessly-integral REAL or numeric
+            // TEXT ('4' -> 4, '1.0' -> 1) accepted, NULL/BLOB/non-numeric TEXT/
+            // non-integral REAL raise `datatype mismatch`. A negative OFFSET is
+            // then treated as 0 (SQLite semantics, #5747).
+            match crate::select::coerce_limit_offset_to_i64(value)? {
+                n if n < 0 => 0,
+                n => n as usize,
             }
         } else {
             0
@@ -1218,39 +1193,13 @@ impl DeleteExecutor {
         // Evaluate LIMIT expression if present
         let limit_val = if let Some(ref limit_expr) = limit {
             let empty_row = vibesql_storage::Row::new(vec![]);
-            match evaluator.eval(limit_expr, &empty_row)? {
-                SqlValue::Integer(n) if n >= 0 => Some(n as usize),
-                SqlValue::Bigint(n) if n >= 0 => Some(n as usize),
-                // Any negative LIMIT means "no limit" (SQLite semantics, #5747).
-                SqlValue::Integer(n) if n < 0 => None,
-                SqlValue::Bigint(n) if n < 0 => None,
-                // Integer affinity: a REAL LIMIT that converts losslessly to an
-                // integer is accepted (`16/4` -> 4.0 -> LIMIT 4); a negative
-                // integral real means "no limit", matching the integer branch.
-                // A non-integral real (e.g. 1.2) falls through to the error arm
-                // (e_delete-3.1 comma-form LIMIT).
-                SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f)
-                    if f.is_finite() && f.fract() == 0.0 =>
-                {
-                    if f >= 0.0 {
-                        Some(f as usize)
-                    } else {
-                        None
-                    }
-                }
-                SqlValue::Float(f) if f.is_finite() && f.fract() == 0.0 => {
-                    if f >= 0.0 {
-                        Some(f as usize)
-                    } else {
-                        None
-                    }
-                }
-                SqlValue::Null => None, // NULL limit treated as no limit
-                _ => {
-                    return Err(ExecutorError::TypeError(
-                        "LIMIT value must be a non-negative integer".to_string(),
-                    ))
-                }
+            let value = evaluator.eval(limit_expr, &empty_row)?;
+            // Same numeric-affinity coercion as OFFSET above (#6193). A negative
+            // LIMIT means "no limit" (SQLite semantics, #5747); a non-coercible
+            // value (NULL, BLOB, 'abc', 1.2) raises `datatype mismatch`.
+            match crate::select::coerce_limit_offset_to_i64(value)? {
+                n if n < 0 => None,
+                n => Some(n as usize),
             }
         } else {
             None
@@ -1269,6 +1218,12 @@ impl DeleteExecutor {
         if let Some(limit) = limit_val {
             rows_and_indices.truncate(limit);
         }
+
+        // ORDER BY only determines *which* rows fall within the LIMIT; the rows
+        // are then always deleted in rowid (physical-index) order, so AFTER
+        // DELETE triggers fire in rowid order regardless of the ORDER BY
+        // direction (SQLite lang_delete.html R-07548-13422; e_delete-3.10).
+        rows_and_indices.sort_by_key(|(index, _)| *index);
 
         Ok(())
     }

--- a/crates/vibesql-executor/src/select/helpers.rs
+++ b/crates/vibesql-executor/src/select/helpers.rs
@@ -141,7 +141,11 @@ fn evaluate_limit_offset_expr_raw(
 ///   `'2abc'`, `'2.5'` error. Note this is deliberately NOT the leading-prefix parse used for
 ///   truthiness — SQLite raises "datatype mismatch" for partial parses here
 /// - NULL, BLOB and everything else error with SQLite's exact wording `datatype mismatch` (#5804)
-pub(in crate::select) fn coerce_limit_offset_to_i64(
+///
+/// Also shared with the DELETE/UPDATE executors' LIMIT/OFFSET handling
+/// (`SQLITE_ENABLE_UPDATE_DELETE_LIMIT` evidence tests e_delete-3.x /
+/// e_update-3.x; #6193) so all three statement types apply identical affinity.
+pub(crate) fn coerce_limit_offset_to_i64(
     value: vibesql_types::SqlValue,
 ) -> Result<i64, crate::ExecutorError> {
     use vibesql_types::SqlValue;

--- a/crates/vibesql-executor/src/select/mod.rs
+++ b/crates/vibesql-executor/src/select/mod.rs
@@ -22,6 +22,8 @@ mod vectorized;
 pub(crate) mod view_reference_guard;
 pub(crate) mod window;
 
+pub(crate) use helpers::coerce_limit_offset_to_i64;
+
 pub use cte::CteResult;
 pub use executor::validation::{
     find_window_function_in_expression, validate_predicate_subquery_arity,

--- a/crates/vibesql-executor/src/tests/delete_returning.rs
+++ b/crates/vibesql-executor/src/tests/delete_returning.rs
@@ -134,13 +134,18 @@ fn test_delete_returning_order_by_limit() {
     execute_sql(&mut db, "CREATE TABLE t1(a INT)");
     execute_sql(&mut db, "INSERT INTO t1 VALUES (3), (1), (4), (2)");
 
-    // SQLite extension: DELETE ... ORDER BY ... LIMIT n deletes exactly
-    // the n rows selected by the sort; RETURNING reflects those rows.
+    // SQLite extension: DELETE ... ORDER BY ... LIMIT n deletes exactly the n
+    // rows selected by the sort. The ORDER BY only picks *which* rows fall
+    // within the LIMIT; the rows are then deleted — and RETURNING emitted — in
+    // rowid order, not ORDER BY order (SQLite lang_delete.html R-07548-13422;
+    // conformance test e_delete-3.10). Values (3),(1),(4),(2) occupy rowids
+    // 1..4, so `ORDER BY a DESC LIMIT 2` selects a=4 (rowid 3) and a=3 (rowid
+    // 1); emitted in rowid order that is [3, 4].
     let (count, returning) =
         execute_delete_returning(&mut db, "DELETE FROM t1 ORDER BY a DESC LIMIT 2 RETURNING a");
     assert_eq!(count, 2);
     let returning = returning.expect("RETURNING clause should produce a result");
-    assert_eq!(int_rows(&returning), vec![vec![4], vec![3]]);
+    assert_eq!(int_rows(&returning), vec![vec![3], vec![4]]);
 
     let remaining = execute_sql(&mut db, "SELECT a FROM t1");
     assert_eq!(remaining.len(), 2);

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -2483,39 +2483,15 @@ fn apply_order_by_and_limit(
     // Evaluate OFFSET expression if present
     let offset_val = if let Some(ref offset_expr) = offset {
         let empty_row = Row::new(vec![]);
-        match evaluator.eval(offset_expr, &empty_row)? {
-            SqlValue::Integer(n) if n >= 0 => n as usize,
-            SqlValue::Bigint(n) if n >= 0 => n as usize,
-            // Any negative OFFSET is treated as 0 (SQLite semantics, #5747).
-            SqlValue::Integer(n) if n < 0 => 0,
-            SqlValue::Bigint(n) if n < 0 => 0,
-            // SQLite applies integer affinity to OFFSET, but only a REAL that
-            // converts *losslessly* to an integer is accepted (e.g. `16/4`
-            // evaluates to REAL 4.0 -> 4). A negative integral real clamps to 0,
-            // matching the integer branch; a non-integral real (e.g. 1.2) falls
-            // through to the error arm (e_update-3.x).
-            SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f)
-                if f.is_finite() && f.fract() == 0.0 =>
-            {
-                if f >= 0.0 {
-                    f as usize
-                } else {
-                    0
-                }
-            }
-            SqlValue::Float(f) if f.is_finite() && f.fract() == 0.0 => {
-                if f >= 0.0 {
-                    f as usize
-                } else {
-                    0
-                }
-            }
-            SqlValue::Null => 0, // NULL offset treated as 0
-            _ => {
-                return Err(ExecutorError::TypeError(
-                    "OFFSET value must be a non-negative integer".to_string(),
-                ))
-            }
+        let value = evaluator.eval(offset_expr, &empty_row)?;
+        // SQLite numeric-affinity coercion shared with SELECT and DELETE
+        // (#6193): INTEGER as-is, a losslessly-integral REAL or numeric TEXT
+        // ('4' -> 4, '1.0' -> 1) accepted, NULL/BLOB/non-numeric TEXT/
+        // non-integral REAL raise `datatype mismatch`. A negative OFFSET is
+        // then treated as 0 (SQLite semantics, #5747).
+        match crate::select::coerce_limit_offset_to_i64(value)? {
+            n if n < 0 => 0,
+            n => n as usize,
         }
     } else {
         0
@@ -2524,39 +2500,13 @@ fn apply_order_by_and_limit(
     // Evaluate LIMIT expression if present
     let limit_val = if let Some(ref limit_expr) = limit {
         let empty_row = Row::new(vec![]);
-        match evaluator.eval(limit_expr, &empty_row)? {
-            SqlValue::Integer(n) if n >= 0 => Some(n as usize),
-            SqlValue::Bigint(n) if n >= 0 => Some(n as usize),
-            // Any negative LIMIT means "no limit" (SQLite semantics, #5747).
-            SqlValue::Integer(n) if n < 0 => None,
-            SqlValue::Bigint(n) if n < 0 => None,
-            // Integer affinity: a REAL LIMIT that converts losslessly to an
-            // integer is accepted (`16/4` -> 4.0 -> LIMIT 4); a negative
-            // integral real means "no limit", matching the integer branch. A
-            // non-integral real (e.g. 1.2) falls through to the error arm
-            // (e_update-3.x comma-form LIMIT).
-            SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f)
-                if f.is_finite() && f.fract() == 0.0 =>
-            {
-                if f >= 0.0 {
-                    Some(f as usize)
-                } else {
-                    None
-                }
-            }
-            SqlValue::Float(f) if f.is_finite() && f.fract() == 0.0 => {
-                if f >= 0.0 {
-                    Some(f as usize)
-                } else {
-                    None
-                }
-            }
-            SqlValue::Null => None, // NULL limit treated as no limit
-            _ => {
-                return Err(ExecutorError::TypeError(
-                    "LIMIT value must be a non-negative integer".to_string(),
-                ))
-            }
+        let value = evaluator.eval(limit_expr, &empty_row)?;
+        // Same numeric-affinity coercion as OFFSET above (#6193). A negative
+        // LIMIT means "no limit" (SQLite semantics, #5747); a non-coercible
+        // value (NULL, BLOB, 'abc', 1.2) raises `datatype mismatch`.
+        match crate::select::coerce_limit_offset_to_i64(value)? {
+            n if n < 0 => None,
+            n => Some(n as usize),
         }
     } else {
         None
@@ -2575,6 +2525,12 @@ fn apply_order_by_and_limit(
     if let Some(limit) = limit_val {
         rows_and_indices.truncate(limit);
     }
+
+    // ORDER BY only determines *which* rows fall within the LIMIT; the rows are
+    // then always modified in rowid (physical-index) order, so BEFORE/AFTER
+    // UPDATE triggers fire in rowid order regardless of the ORDER BY direction
+    // (SQLite lang_update.html R-10927-26133; e_update-3.5).
+    rows_and_indices.sort_by_key(|(index, _)| *index);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Part of #6193 (INSERT/UPDATE/DELETE documentation-evidence family). This increment lands the **e_delete track** by fixing two genuine engine gaps in the `SQLITE_ENABLE_UPDATE_DELETE_LIMIT` DELETE/UPDATE LIMIT/ORDER BY/OFFSET extension. The e_update ATTACH setup-cascade break already landed separately in #6214, so that premise of the issue is resolved; this PR addresses the in-scope DELETE/UPDATE-LIMIT engine behavior the cascade break exposed.

## What was wrong

1. **Numeric affinity on LIMIT/OFFSET.** A string LIMIT/OFFSET like `'4'` or `'1.0'` was rejected with `LIMIT value must be a non-negative integer` instead of being losslessly coerced (`'4'`→4, `'1.0'`→1, SQLite R-02661-56399). In the e_delete `-query` harness path each DELETE runs via `execsql` directly, so that error aborted the whole `do_delete_tests` block **at file scope**, masking the entire section-3 LIMIT matrix.
2. **Row-application order under ORDER BY.** ORDER BY only selects *which* rows fall within the LIMIT; rows are then deleted/updated in **rowid order**, so triggers fire in rowid order regardless of ORDER BY direction (R-07548-13422 / R-10927-26133). VibeSQL applied them in ORDER BY order.

## Fix

- DELETE and UPDATE LIMIT/OFFSET now route through the same `coerce_limit_offset_to_i64` helper SELECT already uses (widened `pub(in crate::select)` → `pub(crate)` and re-exported). All three statement types now apply identical numeric affinity and raise SQLite's exact `datatype mismatch` wording for non-coercible values (NULL, BLOB, `'abc'`, `1.2`) — this also fixes the `e_delete-3.3` / `e_delete-3.5` `-error {datatype mismatch}` matrix. The two duplicated ~40-line inline match blocks collapse to a shared call each.
- After LIMIT truncation, the selected rows are re-sorted by physical (rowid) index before applying, so trigger firing / RETURNING order is rowid order.
- `delete_returning` ORDER-BY-LIMIT unit test updated to the SQLite-correct rowid order (RETURNING follows deletion order).

## Before / after (fresh `cargo build --release`, per-file)

| File | Before (passed/failed/skipped) | After | Raw pass rate |
| --- | --- | --- | --- |
| **e_delete.test** | 48 / 2 / 9 (46 tests masked by file-scope abort) | **95 / 1 / 9** | 96.0% → **99.0%** |
| e_insert.test | 180 / 23 / 0 | 180 / 23 / 0 (unchanged) | 88.7% |
| e_update.test | 115 / 46 / 7 | 115 / 46 / 7 (unchanged) | 71.4% |

e_delete goes from 48 → 95 passing: the section-3 LIMIT matrix that the file-scope abort had hidden now executes, and the numeric-affinity + rowid-order fixes clear it.

## ATTACH-blocked / out-of-scope, isolated (not attempted)

- **e_delete-2.2.1.1** (lone remaining e_delete failure): schema-qualified `CREATE TRIGGER main.tr1` inside the ATTACH cross-schema trigger section → left as an ATTACH-blocked Bucket-A straddler.
- **e_insert** remaining 23: per-batch process-model limits — `last_insert_rowid()` across separate `execsql` processes (1.3.x), BEGIN-spanning transactions + missing `sqlite3_get_autocommit` harness command (4.1.x), and one trigger-body `DEFAULT VALUES` parser gap (5.2.1). No engine change here.
- **e_update** sections 1.8 / 2.x / 3.x: transaction-spanning OR-conflict matrix + `sqlite3_get_autocommit`, and ATTACH temp-trigger residue from section 2 cascading into section 3. Out of scope per the issue's ATTACH guidance.

## Tests / no regressions

- `cargo test -p vibesql-executor` — 3591 lib tests pass (delete_returning expectation updated).
- No TCL regressions in LIMIT-exercising files: `delete`, `delete2`, `delete4`, `update`, `wherelimit` (100%), `wherelimit2`, `limit` (100%) — all 0 failures.
- Clean `cargo build --release`; clippy shows only pre-existing warnings outside the changed regions.

## Coordination note

This PR **does not touch `scripts/tester_vibesql.tcl`** — all changes are in `crates/vibesql-executor/`. There is therefore **no overlap** with sibling PR #6232 (REINDEX strip near line 2463 of the shim).

Part of #6193

🤖 Generated with [Claude Code](https://claude.com/claude-code)