### PR TITLE
fix(bench): TPC-DS isolated runner aborts after VibeSQL under set -e (only VibeSQL ever benchmarked)

### DIFF
--- a/scripts/bench-tpcds-isolated.sh
+++ b/scripts/bench-tpcds-isolated.sh
@@ -77,10 +77,10 @@ echo "--- Phase 1: VibeSQL-only ---" >> "$OUTPUT_FILE"
 if cargo bench --package vibesql-executor --bench ${BENCH_NAME} --features in-memory-indexes -- $CRITERION_ARGS 2>&1 | tee -a "$OUTPUT_FILE"; then
     strip_quarantine
     echo -e "${GREEN}✓ VibeSQL benchmark completed${NC}"
-    ((ENGINES_PASSED++))
+    ENGINES_PASSED=$((ENGINES_PASSED+1))
 else
     echo -e "${RED}✗ VibeSQL benchmark failed${NC}"
-    ((ENGINES_FAILED++))
+    ENGINES_FAILED=$((ENGINES_FAILED+1))
 fi
 echo "" >> "$OUTPUT_FILE"
 echo ""
@@ -93,10 +93,10 @@ echo "--- Phase 2: SQLite comparison ---" >> "$OUTPUT_FILE"
 if TPCDS_ENGINE=sqlite cargo bench --package vibesql-executor --bench ${BENCH_NAME} --features sqlite,in-memory-indexes -- $CRITERION_ARGS 2>&1 | tee -a "$OUTPUT_FILE"; then
     strip_quarantine
     echo -e "${GREEN}✓ SQLite comparison completed${NC}"
-    ((ENGINES_PASSED++))
+    ENGINES_PASSED=$((ENGINES_PASSED+1))
 else
     echo -e "${YELLOW}⚠ SQLite comparison failed (continuing)${NC}"
-    ((ENGINES_FAILED++))
+    ENGINES_FAILED=$((ENGINES_FAILED+1))
 fi
 echo "" >> "$OUTPUT_FILE"
 echo ""
@@ -111,10 +111,10 @@ echo "--- Phase 3: DuckDB comparison ---" >> "$OUTPUT_FILE"
 if TPCDS_ENGINE=duckdb cargo bench --package vibesql-executor --bench ${BENCH_NAME} --features sqlite,in-memory-indexes,duckdb -- $CRITERION_ARGS 2>&1 | tee -a "$OUTPUT_FILE"; then
     strip_quarantine
     echo -e "${GREEN}✓ DuckDB comparison completed${NC}"
-    ((ENGINES_PASSED++))
+    ENGINES_PASSED=$((ENGINES_PASSED+1))
 else
     echo -e "${YELLOW}⚠ DuckDB comparison failed (continuing)${NC}"
-    ((ENGINES_FAILED++))
+    ENGINES_FAILED=$((ENGINES_FAILED+1))
 fi
 echo "" >> "$OUTPUT_FILE"
 echo ""
@@ -129,10 +129,10 @@ if [ -n "$MYSQL_URL" ]; then
     if TPCDS_ENGINE=mysql cargo bench --package vibesql-executor --bench ${BENCH_NAME} --features sqlite,in-memory-indexes,mysql -- $CRITERION_ARGS 2>&1 | tee -a "$OUTPUT_FILE"; then
         strip_quarantine
         echo -e "${GREEN}✓ MySQL comparison completed${NC}"
-        ((ENGINES_PASSED++))
+        ENGINES_PASSED=$((ENGINES_PASSED+1))
     else
         echo -e "${YELLOW}⚠ MySQL comparison failed (continuing)${NC}"
-        ((ENGINES_FAILED++))
+        ENGINES_FAILED=$((ENGINES_FAILED+1))
     fi
     echo "" >> "$OUTPUT_FILE"
     echo ""


### PR DESCRIPTION
## Problem

`scripts/bench-tpcds-isolated.sh` runs under `set -e` (line 19) and tallies engine outcomes with `((ENGINES_PASSED++))` / `((ENGINES_FAILED++))`.

Bash's arithmetic command `(( ))` returns **exit status 1 whenever the expression evaluates to 0**, and a **post-increment evaluates to the *pre*-increment value**. So the very first `((ENGINES_PASSED++))` (0 → 1) evaluates to `0`, returns status 1, and `set -e` **aborts the script immediately after Phase 1 (VibeSQL)** — before Phase 2 (SQLite), Phase 3 (DuckDB), and Phase 4 (MySQL) ever run.

## Impact

`make benchmark-tpcds` and the `benchmark-all` matrix have been silently producing **VibeSQL-only** TPC-DS results. Confirmed 2026-07-21 on the AWS runner: every TPC-DS export read `V:99 S:0 D:0`, and the script exited RC=1 right after "✓ VibeSQL benchmark completed". This is why the website TPC-DS comparison lost its SQLite/DuckDB series.

## Fix

Replace the eight `((VAR++))` sites with `VAR=$((VAR+1))`, an assignment that always returns exit status 0, so `set -e` no longer aborts on the first increment.

## Verification (AWS c7i.8xlarge, this fix applied)

All four phases now run to completion (`RC=0`), and the export reads **`TPC-DS: 297 benchmarks (V:99 S:99 D:99)`** — full 3-engine coverage restored. The refreshed website data is in the companion PR (chore/web-bench-data-20260721).

🤖 Generated with [Claude Code](https://claude.com/claude-code)