### PR TITLE
fix(executor): drive RIGHT JOIN nested loop from the left table

### DIFF
--- a/crates/vibesql-executor/src/select/join/nested_loop/mod.rs
+++ b/crates/vibesql-executor/src/select/join/nested_loop/mod.rs
@@ -235,54 +235,109 @@ pub(in crate::select::join) fn nested_loop_right_outer_join(
     outer_row: Option<&vibesql_storage::Row>,
     outer_schema: Option<&CombinedSchema>,
 ) -> Result<FromResult, ExecutorError> {
-    // Note: Memory check removed - delegates to LEFT OUTER JOIN which also doesn't check.
+    // Note: No memory check here (matches the LEFT/FULL OUTER nested-loop paths).
+    //
+    // Row ordering (issue #6190): SQLite drives a RIGHT JOIN from the *left*
+    // table in the nested loop (the same order a LEFT/INNER join uses) and only
+    // appends the unmatched right rows at the end. Implementing RIGHT JOIN by
+    // swapping the sides into a LEFT JOIN reversed that order (right-driven),
+    // which produced correct *sets* but SQLite-incompatible row *order*
+    // (values.test 8.1.3/8.1.4). We therefore iterate left-outer / right-inner
+    // directly and track which right rows matched, mirroring FULL OUTER's two
+    // passes but emitting NULL-extended rows only for the right side.
 
-    // RIGHT OUTER JOIN = LEFT OUTER JOIN with sides swapped
-    // Then we need to reorder columns to put left first, right second
+    // Total left column count (handles nested joins with multiple tables).
+    let left_column_count = left.schema.total_columns;
 
-    // Save original schemas before swapping - we need these to build the correct output schema
-    let left_schema = left.schema.clone();
-    let right_schema = right.schema.clone();
+    // Extract table names for ROWID tracking (issue #4370).
+    let left_table_names = left.schema.table_names();
+    let right_table_names = right.schema.table_names();
 
-    // Get the right column count (handles nested joins with multiple tables)
-    let right_col_count = right_schema.total_columns;
+    // Combine schemas using merge to preserve all tables from nested joins.
+    let combined_schema = CombinedSchema::merge(left.schema.clone(), right.schema.clone());
 
-    // Do LEFT OUTER JOIN with swapped sides
-    // Issue #4994: Pass outer context through
-    let swapped_result = nested_loop_left_outer_join(
-        right,
-        left,
-        condition,
-        database,
-        timeout_ctx,
-        outer_row,
-        outer_schema,
-    )?;
+    // Issue #4994: Create evaluator with outer context if available.
+    let evaluator = match (outer_row, outer_schema) {
+        (Some(outer_row), Some(outer_schema)) => {
+            CombinedExpressionEvaluator::with_database_and_outer_context(
+                &combined_schema,
+                database,
+                outer_row,
+                outer_schema,
+            )
+        }
+        _ => CombinedExpressionEvaluator::with_database(&combined_schema, database),
+    };
 
-    // Now we need to reorder the columns in the result
-    // The swapped result has right columns first, then left columns
-    // We need to reverse this to left first, then right
+    // Use as_slice() for zero-cost access without triggering row materialization.
+    let left_slice = left.as_slice();
+    let right_slice = right.as_slice();
 
-    // Reorder rows: move left columns (currently at positions right_col_count..) to front
-    // Use as_slice() for zero-cost access
-    let reordered_rows: Vec<vibesql_storage::Row> = swapped_result
-        .as_slice()
-        .iter()
-        .map(|row| {
-            let mut new_values = Vec::new();
-            // Add left columns (currently at end)
-            new_values.extend_from_slice(&row.values[right_col_count..]);
-            // Add right columns (currently at start)
-            new_values.extend_from_slice(&row.values[0..right_col_count]);
-            vibesql_storage::Row::new(new_values)
-        })
-        .collect();
+    let mut result_rows = Vec::new();
+    let mut right_matched = vec![false; right_slice.len()];
+    let mut iterations = 0;
 
-    // Build the correct schema: left columns first, then right columns
-    // The swapped_result.schema has [right, left] order, so we need to merge correctly
-    let correct_schema = CombinedSchema::merge(left_schema, right_schema);
+    // First pass: drive from the left (preserves SQLite's left-to-right order).
+    for left_row in left_slice {
+        for (right_idx, right_row) in right_slice.iter().enumerate() {
+            // Check timeout periodically.
+            iterations += 1;
+            if iterations % CHECK_INTERVAL == 0 {
+                timeout_ctx.check()?;
+            }
 
-    Ok(FromResult::from_rows(correct_schema, reordered_rows))
+            // Combine rows preserving ROWIDs for multi-table queries (issue #4370).
+            let combined_row = vibesql_storage::Row::combine_for_join(
+                left_row,
+                right_row,
+                &left_table_names,
+                &right_table_names,
+            );
+
+            // Clear CSE cache before evaluating join condition for this row
+            // combination to prevent stale cached column values from previous rows.
+            evaluator.clear_cse_cache();
+
+            let matches = if let Some(cond) = condition {
+                eval_join_condition_to_bool(evaluator.eval(cond, &combined_row)?)?
+            } else {
+                true // No condition = every pairing matches (cross product)
+            };
+
+            if matches {
+                result_rows.push(combined_row);
+                right_matched[right_idx] = true;
+            }
+        }
+    }
+
+    // Second pass: append unmatched right rows with NULLs for the left columns,
+    // preserving right-side ROWIDs (issue #4370).
+    for (right_idx, right_row) in right_slice.iter().enumerate() {
+        if !right_matched[right_idx] {
+            let mut combined_values =
+                Vec::with_capacity(left_column_count + right_row.values.len());
+            combined_values.extend(vec![vibesql_types::SqlValue::Null; left_column_count]);
+            combined_values.extend_from_slice(&right_row.values);
+
+            let mut row_ids = std::collections::HashMap::new();
+            if let Some(ref right_row_ids) = right_row.row_ids {
+                row_ids.extend(right_row_ids.iter().map(|(k, v)| (k.clone(), *v)));
+            } else if let Some(row_id) = right_row.row_id {
+                if let Some(table_name) = right_table_names.first() {
+                    row_ids.insert(table_name.to_lowercase(), row_id);
+                }
+            }
+
+            if row_ids.is_empty() {
+                result_rows.push(vibesql_storage::Row::new(combined_values));
+            } else {
+                result_rows.push(vibesql_storage::Row::with_row_ids(combined_values, row_ids));
+            }
+        }
+    }
+
+    Ok(FromResult::from_rows(combined_schema, result_rows))
 }
 
 /// Nested loop FULL OUTER JOIN implementation

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -118,6 +118,7 @@ mod query_timeout_tests;
 mod raise_trigger_tests;
 mod recursive_cte_tests;
 mod replace_fk_enforcement;
+mod right_join_order;
 mod rowid_tests;
 mod scalar_subquery_basic_tests;
 mod scalar_subquery_caching_tests;

--- a/crates/vibesql-executor/src/tests/right_join_order.rs
+++ b/crates/vibesql-executor/src/tests/right_join_order.rs
@@ -1,0 +1,96 @@
+//! Regression tests for issue #6190: RIGHT JOIN row ordering.
+//!
+//! VibeSQL previously implemented `RIGHT OUTER JOIN` by swapping the operands
+//! into a `LEFT OUTER JOIN` and reversing the output columns. That produced the
+//! correct result *set* but a right-driven row *order*, which disagreed with
+//! SQLite (values.test 8.1.3 / 8.1.4). SQLite drives a RIGHT JOIN from the left
+//! table in the nested loop — matched rows come out in left-to-right order and
+//! the unmatched right rows are appended at the end. These tests pin that order.
+
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+use crate::select::SelectExecutor;
+use crate::{CreateTableExecutor, InsertExecutor};
+
+fn exec(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse {sql:?}: {e:?}"));
+    match stmt {
+        vibesql_ast::Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).unwrap();
+        }
+        vibesql_ast::Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).unwrap();
+        }
+        other => panic!("unexpected statement type for exec(): {other:?}"),
+    }
+}
+
+fn query(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse {sql:?}: {e:?}"));
+    let vibesql_ast::Statement::Select(select_stmt) = stmt else {
+        panic!("expected SELECT statement: {sql:?}");
+    };
+    let executor = SelectExecutor::new(db);
+    executor
+        .execute(&select_stmt)
+        .unwrap_or_else(|e| panic!("execute {sql:?}: {e:?}"))
+        .into_iter()
+        .map(|r| r.values.to_vec())
+        .collect()
+}
+
+fn i(n: i64) -> SqlValue {
+    SqlValue::Integer(n)
+}
+
+/// RIGHT JOIN with no ON clause is a cross product. SQLite emits it in
+/// left-outer / right-inner order (values.test 8.1.3).
+#[test]
+fn right_join_no_condition_is_left_driven_order() {
+    let mut db = Database::new();
+    db.catalog.set_case_sensitive_identifiers(false);
+    exec(&mut db, "CREATE TABLE t1(x)");
+    exec(&mut db, "INSERT INTO t1 VALUES(10), (20)");
+
+    let rows = query(&db, "SELECT * FROM t1 RIGHT JOIN ( VALUES(1, 2), (3, 4) )");
+
+    // Expected order: each left row (10, then 20) paired with every right row
+    // in order — NOT right-driven (which would interleave differently).
+    assert_eq!(
+        rows,
+        vec![
+            vec![i(10), i(1), i(2)],
+            vec![i(10), i(3), i(4)],
+            vec![i(20), i(1), i(2)],
+            vec![i(20), i(3), i(4)],
+        ]
+    );
+}
+
+/// RIGHT JOIN with an ON clause: matched rows first (in left order), then the
+/// unmatched right rows appended with NULL left columns (values.test 8.1.4).
+#[test]
+fn right_join_with_condition_appends_unmatched_right_last() {
+    let mut db = Database::new();
+    db.catalog.set_case_sensitive_identifiers(false);
+    exec(&mut db, "CREATE TABLE t1(x)");
+    exec(&mut db, "INSERT INTO t1 VALUES(10), (20), (123)");
+
+    let rows = query(
+        &db,
+        "SELECT * FROM t1 RIGHT JOIN ( VALUES(1, 2), (3, 4), (123, 99) ) ON (column1 = x)",
+    );
+
+    // 123 is the only left value with a matching right column1 -> matched row
+    // comes first; the two unmatched right rows are appended with NULL x.
+    assert_eq!(
+        rows,
+        vec![
+            vec![i(123), i(123), i(99)],
+            vec![SqlValue::Null, i(1), i(2)],
+            vec![SqlValue::Null, i(3), i(4)],
+        ]
+    );
+}

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -6254,6 +6254,17 @@ proc do_select_tests {prefix args} {
 
 }
 
+# explain_i (from SQLite's tester.tcl): a purely diagnostic helper that dumps
+# the EXPLAIN VDBE bytecode listing for a statement so a human can eyeball it.
+# It makes no assertions and has no bearing on conformance pass/fail. VibeSQL
+# does not emit SQLite VDBE bytecode, so we define it as a no-op that swallows
+# its arguments. Without this, file-scope calls (e.g. values.test line 24)
+# raise `invalid command name "explain_i"` and produce a spurious
+# file-scope-error marker. (Issue #6190.)
+proc explain_i {sql {db db}} {
+    # Intentionally a no-op: diagnostic bytecode dump, not a test assertion.
+}
+
 proc do_eqp_test {name sql expected} {
     # EXPLAIN QUERY PLAN test
     # Runs the query with EXPLAIN QUERY PLAN and matches against expected pattern


### PR DESCRIPTION
## Summary

Fixes the remaining genuine engine failures in SQLite's `values.test` conformance file. On current `main` the file had **7 failures**; this PR takes it to **0** (110/110 passing, 2 skipped).

Two root causes:

1. **RIGHT JOIN row ordering (8.1.3 / 8.1.4).** `nested_loop_right_outer_join` implemented RIGHT OUTER JOIN by swapping the operands into a LEFT OUTER JOIN and reversing the output columns. That produced the correct result *set* but a right-driven row *order*, which disagrees with SQLite. SQLite drives a RIGHT JOIN from the left table in the nested loop: matched rows come out in left-to-right order and the unmatched right rows are appended at the end. Rewrote the function to iterate left-outer / right-inner directly, tracking which right rows matched (mirroring FULL OUTER's two-pass structure but null-extending only the right side). ROWIDs are preserved for both matched pairings and appended unmatched-right rows. RIGHT OUTER joins have no hash-join fast path, so this nested-loop function is the only affected path.

2. **`explain_i` file-scope error.** `explain_i` is a SQLite `tester.tcl` diagnostic helper that dumps the EXPLAIN VDBE bytecode listing for humans; it asserts nothing. VibeSQL emits no VDBE bytecode and the shim never defined it, so the file-scope call at `values.test` line 24 raised `invalid command name "explain_i"` and produced a spurious file-scope-error marker. Defined it as a no-op in the shim (also removes the same marker from 6 other files: bestindex8, bestindexB, indexA, scanstatus2, selectF, update2).

## Changes

- `crates/vibesql-executor/src/select/join/nested_loop/mod.rs` — rewrite `nested_loop_right_outer_join` to be left-driven (matched rows in left order, unmatched right rows appended), preserving ROWIDs.
- `scripts/tester_vibesql.tcl` — add a no-op `explain_i` proc.
- `crates/vibesql-executor/src/tests/right_join_order.rs` (new) + `tests/mod.rs` — regression tests pinning RIGHT JOIN row order for the no-condition (cross) and ON-condition cases.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `values.test` < 33 failures; target 0 real | ✅ | Fresh `--release` build: 7 → 0 failures (110 passed, 2 skipped) |
| filescope-err cascade marker resolved | ✅ | Resolved by defining no-op `explain_i`; marker gone |
| `do_catchsql_test` rows pass with verbatim errors | ✅ | No term-count/malformed-VALUES failures remained on current main |
| No regression in Rust VALUES/join tests | ✅ | `cargo test -p vibesql-executor` 3593+ passed, 0 failed; `-p vibesql-parser` green |
| No new failures in other TCL files on shared paths | ✅ | join.test (7 pre-existing DDL-cascade fails, none RIGHT-JOIN), join2/join5/selectF/indexA/update2 unchanged; explain_i change only removes markers |

## Test Plan

- `cargo build --release`
- `make test-tcl-file FILE=values.test` → 0 failures
- `cargo test -p vibesql-executor -p vibesql-parser` → green (incl. 2 new `right_join_order` tests)
- Spot-checked join.test / join2.test / join5.test / selectF.test / indexA.test / update2.test for regressions — none introduced

Closes #6190