### PR TITLE
fix(executor): compound non-recursive seeds in recursive CTEs (Part of #6189)

### DIFF
--- a/crates/vibesql-executor/src/select/cte.rs
+++ b/crates/vibesql-executor/src/select/cte.rs
@@ -1309,6 +1309,142 @@ fn collect_select_list_columns(
     Some(names)
 }
 
+/// The seed/recursive partition of a recursive CTE body produced by
+/// [`split_recursive_compound`].
+struct RecursiveSplit {
+    /// The non-recursive seed, possibly itself a compound of leading terms.
+    base_query: vibesql_ast::SelectStmt,
+    /// The recursive term(s), executed against the working table each iteration.
+    recursive_query: vibesql_ast::SelectStmt,
+    /// `true` for UNION (deduplicate recursive rows), `false` for UNION ALL.
+    dedup_rows: bool,
+}
+
+/// Copy a compound term into a standalone `SelectStmt`.
+///
+/// Drops the set-operation link (the term is lifted out of its chain) and the
+/// compound-level ORDER BY/LIMIT/OFFSET (queue directives handled by the caller,
+/// not per-term clauses). All other clauses — including a leading term's own
+/// WITH clause — are preserved.
+fn strip_compound_term(stmt: &vibesql_ast::SelectStmt) -> vibesql_ast::SelectStmt {
+    vibesql_ast::SelectStmt {
+        with_clause: stmt.with_clause.clone(),
+        distinct: stmt.distinct,
+        select_list: stmt.select_list.clone(),
+        into_table: stmt.into_table.clone(),
+        into_variables: stmt.into_variables.clone(),
+        from: stmt.from.clone(),
+        where_clause: stmt.where_clause.clone(),
+        group_by: stmt.group_by.clone(),
+        having: stmt.having.clone(),
+        window_definitions: stmt.window_definitions.clone(),
+        order_by: None,
+        limit: None,
+        offset: None,
+        set_operation: None,
+        values: stmt.values.clone(),
+    }
+}
+
+/// Reassemble a right-leaning compound `SelectStmt` from a slice of standalone
+/// terms and the operators connecting each term to the next.
+///
+/// `connectors[i]` joins `terms[i]` to `terms[i + 1]`, so
+/// `connectors.len() == terms.len() - 1`. With a single term the term is
+/// returned verbatim.
+fn rebuild_compound(
+    terms: &[vibesql_ast::SelectStmt],
+    connectors: &[(vibesql_ast::SetOperator, bool)],
+) -> vibesql_ast::SelectStmt {
+    debug_assert_eq!(terms.len(), connectors.len() + 1);
+    let mut acc = terms[terms.len() - 1].clone();
+    for i in (0..connectors.len()).rev() {
+        let (op, all) = connectors[i].clone();
+        let mut term = terms[i].clone();
+        term.set_operation =
+            Some(vibesql_ast::SetOperation { op, all, right: Box::new(acc) });
+        acc = term;
+    }
+    acc
+}
+
+/// Partition a recursive CTE body into a non-recursive seed and its recursive
+/// term(s).
+///
+/// The body is a compound chain `T0 op0 T1 op1 T2 …`. The seed is the maximal
+/// leading run of terms that do NOT reference the CTE; the recursive part is
+/// every term from the first self-referencing term onward. Seed terms keep their
+/// own operators (any of UNION / UNION ALL / INTERSECT / EXCEPT — with5.test 113
+/// `… INTERSECT …`, 114/131 `… UNION ALL …`).
+///
+/// The operators joining the seed to the first recursive term and the recursive
+/// terms to one another must all be UNION or UNION ALL and identical:
+/// INTERSECT/EXCEPT there is rejected, and a UNION/UNION ALL mismatch is the
+/// SQLite "circular reference" case (with5.test 120/121). The shared boundary
+/// operator decides whether recursive rows are deduplicated (UNION) or kept
+/// (UNION ALL).
+fn split_recursive_compound(
+    cte: &vibesql_ast::CommonTableExpr,
+) -> Result<RecursiveSplit, ExecutorError> {
+    // Flatten the right-leaning set-operation chain into standalone terms plus
+    // the (operator, all) connecting each term to the next.
+    let mut terms: Vec<vibesql_ast::SelectStmt> = Vec::new();
+    let mut connectors: Vec<(vibesql_ast::SetOperator, bool)> = Vec::new();
+    let mut node = &cte.query;
+    loop {
+        terms.push(strip_compound_term(node));
+        match &node.set_operation {
+            Some(set_op) => {
+                connectors.push((set_op.op.clone(), set_op.all));
+                node = &set_op.right;
+            }
+            None => break,
+        }
+    }
+
+    // The recursive part starts at the first term referencing the CTE. A
+    // self-reference in the leading (base) term is circular, not recursion
+    // (with1.test 17.3); so is a body that references itself nowhere in a term
+    // we can split on.
+    let split_idx = match terms.iter().position(|t| stmt_references_table(t, &cte.name)) {
+        Some(0) | None => {
+            return Err(ExecutorError::SqliteCompatError(format!(
+                "circular reference: {}",
+                cte.name
+            )));
+        }
+        Some(idx) => idx,
+    };
+
+    // Operators joining the seed to the recursive part (connectors[split_idx-1])
+    // and the recursive terms to one another (connectors[split_idx..]).
+    let recursive_connectors = &connectors[split_idx - 1..];
+    for (op, _) in recursive_connectors {
+        if *op != vibesql_ast::SetOperator::Union {
+            return Err(ExecutorError::UnsupportedFeature(format!(
+                "Recursive CTE '{}' must use UNION or UNION ALL (not INTERSECT or EXCEPT)",
+                cte.name
+            )));
+        }
+    }
+    // Every recursive connector must agree on UNION vs UNION ALL; SQLite reports
+    // a mix as a circular reference (with5.test 120/121).
+    let boundary = recursive_connectors[0].clone();
+    if recursive_connectors.iter().any(|c| *c != boundary) {
+        return Err(ExecutorError::SqliteCompatError(format!(
+            "circular reference: {}",
+            cte.name
+        )));
+    }
+    // UNION (all == false) deduplicates; UNION ALL (all == true) keeps rows.
+    let dedup_rows = !boundary.1;
+
+    let base_query = rebuild_compound(&terms[..split_idx], &connectors[..split_idx - 1]);
+    let recursive_query = rebuild_compound(&terms[split_idx..], &connectors[split_idx..]);
+
+    Ok(RecursiveSplit { base_query, recursive_query, dedup_rows })
+}
+
 /// Execute a recursive CTE using iterative evaluation.
 ///
 /// Recursive CTEs in SQL:1999/SQLite are defined with UNION or UNION ALL:
@@ -1354,58 +1490,26 @@ where
 {
     use crate::limits::MAX_RECURSIVE_CTE_ITERATIONS;
 
-    // Validate that recursive CTE uses UNION ALL
-    let set_op = cte.query.set_operation.as_ref().ok_or_else(|| {
-        ExecutorError::UnsupportedFeature(format!(
-            "Recursive CTE '{}' must use UNION ALL",
-            cte.name
-        ))
-    })?;
-
-    if set_op.op != vibesql_ast::SetOperator::Union {
-        return Err(ExecutorError::UnsupportedFeature(format!(
-            "Recursive CTE '{}' must use UNION or UNION ALL (not INTERSECT or EXCEPT)",
-            cte.name
-        )));
-    }
-
-    // Extract base and recursive terms
-    // Base term: the main SELECT (before UNION [ALL])
-    // Recursive term: the right side of UNION [ALL]
-
-    // ORDER BY / LIMIT / OFFSET written after the `UNION ALL` bind to the
-    // *compound* query (the parser stores them on `cte.query`, not on the base
-    // or recursive terms). For a recursive CTE these are queue directives — the
+    // ORDER BY / LIMIT / OFFSET written after the compound bind to the *whole*
+    // recursive CTE (the parser stores them on `cte.query`, not on the base or
+    // recursive terms). For a recursive CTE these are queue directives — the
     // ORDER BY controls the priority-queue traversal, and LIMIT/OFFSET cap and
     // window the total result — so they must NOT be applied to the base term or
-    // re-applied on each recursive iteration. We interpret them here and strip
-    // them from the base term.
+    // re-applied on each recursive iteration. We interpret them here and keep
+    // them off the individual terms.
     let recursive_order_by = cte.query.order_by.clone();
 
-    // Create base-only query without the UNION ALL set operation
-    // This prevents the base term from trying to reference the CTE before it exists
-    let base_query = vibesql_ast::SelectStmt {
-        with_clause: cte.query.with_clause.clone(),
-        distinct: cte.query.distinct,
-        select_list: cte.query.select_list.clone(),
-        into_table: cte.query.into_table.clone(),
-        into_variables: cte.query.into_variables.clone(),
-        from: cte.query.from.clone(),
-        where_clause: cte.query.where_clause.clone(),
-        group_by: cte.query.group_by.clone(),
-        having: cte.query.having.clone(),
-        window_definitions: cte.query.window_definitions.clone(),
-        // Compound-level ORDER BY/LIMIT/OFFSET do not apply to the base term.
-        order_by: None,
-        limit: None,
-        offset: None,
-        set_operation: None, // Remove UNION ALL for base term execution
-        values: cte.query.values.clone(),
-    };
-
-    // The recursive term drives per-iteration expansion; execute it as written
-    // (it already carries no compound-level ORDER BY/LIMIT/OFFSET).
-    let recursive_query = &set_op.right;
+    // Split the (possibly compound) CTE body into a non-recursive seed and the
+    // recursive term(s). The seed may itself be a compound of several leading
+    // terms combined with any set operator — `VALUES(..) INTERSECT VALUES(..)`
+    // (with5.test 113), `VALUES(..) UNION ALL VALUES(..)` (114/131) — and there
+    // may be more than one recursive term. `split_recursive_compound` performs
+    // the seed/recursive partition and validates the recursive connectors.
+    let RecursiveSplit { base_query, recursive_query, dedup_rows } =
+        split_recursive_compound(cte)?;
+    // The recursive term(s) drive per-iteration expansion; execute as written
+    // (they carry no compound-level ORDER BY/LIMIT/OFFSET).
+    let recursive_query = &recursive_query;
 
     // SQLite compatibility: window functions are not allowed in the recursive
     // part of a recursive CTE (window1.test 15.0). SQLite reports the exact
@@ -1422,9 +1526,13 @@ where
     //   - the sole reference is buried in a subquery (no direct FROM ref)
     //     -> "circular reference: <name>" (7.4:
     //     `... FROM tree WHERE p IN (SELECT id FROM t)`);
-    //   - more than one reference — a FROM ref plus a subquery ref, or the
-    //     name twice in FROM -> "multiple recursive references: <name>" (7.5:
+    //   - the name appears more than once in the FROM clause
+    //     -> "multiple references to recursive table: <name>" (with2.test 1.16:
+    //     `... FROM t4, main.t4, t4 ...`);
+    //   - a single FROM ref plus a subquery ref
+    //     -> "multiple recursive references: <name>" (7.5:
     //     `... FROM tree, t WHERE p=id AND p IN (SELECT id FROM t)`).
+    // SQLite distinguishes these two verbatim (confirmed against sqlite3 3.51).
     // Only this leading recursive term is inspected; a compound recursive term
     // (`... UNION R1 UNION R2`, with5.test 110-112) keeps its sibling terms in
     // its own set-operation chain, which the counters deliberately do not walk,
@@ -1436,7 +1544,13 @@ where
             .as_ref()
             .map_or(0, |from| count_from_table_occurrences(from, self_name));
         let indirect = recursive_term_has_indirect_ref(recursive_query, self_name);
-        if from_refs > 1 || (from_refs >= 1 && indirect) {
+        if from_refs > 1 {
+            return Err(ExecutorError::SqliteCompatError(format!(
+                "multiple references to recursive table: {}",
+                self_name
+            )));
+        }
+        if from_refs >= 1 && indirect {
             return Err(ExecutorError::SqliteCompatError(format!(
                 "multiple recursive references: {}",
                 self_name
@@ -1495,7 +1609,7 @@ where
 
     // Track seen rows for UNION (deduplication)
     // For UNION ALL, we skip tracking to preserve all rows
-    let mut seen_rows: Option<HashSet<vibesql_storage::RowValues>> = if !set_op.all {
+    let mut seen_rows: Option<HashSet<vibesql_storage::RowValues>> = if dedup_rows {
         let mut seen = HashSet::with_capacity(base_rows.len());
         // For plain UNION, SQLite also deduplicates the base term itself, not
         // just recursive-term rows (issue #5838, item 7; with1.test 26.2).
@@ -1511,7 +1625,7 @@ where
     // alias/column name). `None` means "no priority ordering" (FIFO). An
     // unresolvable term is a name-resolution error (with1.test 10.7.1).
     let order_indices = match &recursive_order_by {
-        Some(items) => Some(resolve_recursive_order_indices(items, &set_op.right, &base_query)?),
+        Some(items) => Some(resolve_recursive_order_indices(items, recursive_query, &base_query)?),
         None => None,
     };
 
@@ -1863,13 +1977,21 @@ fn is_cte_self_referential(cte: &vibesql_ast::CommonTableExpr) -> bool {
     // UNION or UNION ALL" error rather than a generic "table not found". A
     // `WITH RECURSIVE` CTE with no set operation (issue #5838, item 3) is not
     // self-referential and runs as an ordinary CTE.
-    let set_op = match &cte.query.set_operation {
-        Some(op) => op,
-        None => return false,
-    };
-
-    // Check if the recursive term references this CTE
-    stmt_references_table(&set_op.right, &cte.name)
+    // Walk every non-leading term in the compound chain. The recursive
+    // self-reference may live in a term after a multi-term non-recursive seed —
+    // `VALUES(..) INTERSECT VALUES(..) UNION SELECT .. FROM cte` (with5.test
+    // 113/114/131) — so checking only the immediate right of the first set
+    // operation would misclassify those bodies as non-recursive. Each term is
+    // inspected without descending its own set-operation link (that is the next
+    // node in the walk), so sibling terms are counted exactly once.
+    let mut node = &cte.query;
+    while let Some(set_op) = &node.set_operation {
+        if stmt_references_table(&set_op.right, &cte.name) {
+            return true;
+        }
+        node = &set_op.right;
+    }
+    false
 }
 
 /// Count how many times `name` appears as a direct base table in a FROM clause,

--- a/crates/vibesql-executor/src/tests/recursive_cte_tests.rs
+++ b/crates/vibesql-executor/src/tests/recursive_cte_tests.rs
@@ -934,3 +934,144 @@ fn test_unreferenced_cte_not_validated() {
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].values[0], vibesql_types::SqlValue::Integer(10));
 }
+
+/// A recursive CTE whose non-recursive seed is itself a compound of several
+/// leading terms (combined with any set operator) must partition into that
+/// full seed plus the recursive term(s) — not misfire as a circular reference
+/// (issue #6189, with5.test 113/114/131).
+#[test]
+fn test_recursive_cte_compound_seed() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE link(aa INT, bb INT)").unwrap();
+    execute_sql(
+        &mut db,
+        "INSERT INTO link(aa,bb) VALUES \
+         (1,3),(5,3),(7,1),(7,9),(9,9),(5,11),(11,7),(2,4),(4,6),(8,6)",
+    )
+    .unwrap();
+
+    let ints = |rows: &[vibesql_storage::Row]| -> Vec<i64> {
+        rows.iter()
+            .map(|r| match &r.values[0] {
+                vibesql_types::SqlValue::Integer(i) => *i,
+                other => panic!("expected integer, got {:?}", other),
+            })
+            .collect()
+    };
+
+    // with5.test 113: `VALUES(1),(200),(300),(400) INTERSECT VALUES(1)` seed,
+    // then two recursive UNION terms. The seed reduces to {1}.
+    let rows = execute_sql(
+        &mut db,
+        "WITH RECURSIVE closure(x) AS ( \
+            VALUES(1),(200),(300),(400) \
+            INTERSECT \
+            VALUES(1) \
+            UNION \
+            SELECT bb FROM closure, link WHERE link.aa=closure.x \
+            UNION \
+            SELECT aa FROM link, closure WHERE link.bb=closure.x \
+         ) SELECT x FROM closure ORDER BY x",
+    )
+    .unwrap();
+    assert_eq!(ints(&rows), vec![1, 3, 5, 7, 9, 11]);
+
+    // with5.test 114: `VALUES(1),(200),(300),(400) UNION ALL VALUES(2)` seed
+    // keeps every seed row, then two recursive UNION terms.
+    let rows = execute_sql(
+        &mut db,
+        "WITH RECURSIVE closure(x) AS ( \
+            VALUES(1),(200),(300),(400) \
+            UNION ALL \
+            VALUES(2) \
+            UNION \
+            SELECT bb FROM closure, link WHERE link.aa=closure.x \
+            UNION \
+            SELECT aa FROM link, closure WHERE link.bb=closure.x \
+         ) SELECT x FROM closure ORDER BY x",
+    )
+    .unwrap();
+    assert_eq!(ints(&rows), vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 200, 300, 400]);
+
+    // with5.test 131: compound `SELECT..UNION ALL SELECT..` seed with an ordered
+    // LIMIT over the whole recursion.
+    let rows = execute_sql(
+        &mut db,
+        "WITH RECURSIVE closure(x) AS ( \
+            SELECT 1 AS x \
+            UNION ALL \
+            SELECT 2 \
+            UNION \
+            SELECT aa FROM link JOIN closure ON bb=x \
+            UNION \
+            SELECT bb FROM link JOIN closure ON aa=x \
+            ORDER BY x LIMIT 4 \
+         ) SELECT * FROM closure",
+    )
+    .unwrap();
+    assert_eq!(ints(&rows), vec![1, 2, 3, 4]);
+}
+
+/// When a recursive CTE mixes UNION and UNION ALL across its recursive
+/// connectors, SQLite reports a circular reference (issue #6189, with5.test
+/// 120/121). A uniform-operator compound seed must NOT trip this.
+#[test]
+fn test_recursive_cte_mixed_recursive_operators_circular() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE link(aa INT, bb INT)").unwrap();
+    execute_sql(&mut db, "INSERT INTO link(aa,bb) VALUES (1,3),(5,3),(7,1)").unwrap();
+
+    // with5.test 120: seed→R1 is UNION ALL but R1→R2 is UNION (mixed).
+    let err = execute_sql(
+        &mut db,
+        "WITH RECURSIVE closure(x) AS ( \
+            VALUES(1),(200) \
+            UNION ALL \
+            VALUES(2) \
+            UNION ALL \
+            SELECT bb FROM closure, link WHERE link.aa=closure.x \
+            UNION \
+            SELECT aa FROM link, closure WHERE link.bb=closure.x \
+         ) SELECT x FROM closure ORDER BY x",
+    )
+    .unwrap_err();
+    assert_eq!(err.to_string(), "circular reference: closure");
+
+    // with5.test 121: seed→R1 is UNION but R1→R2 is UNION ALL (mixed).
+    let err = execute_sql(
+        &mut db,
+        "WITH RECURSIVE closure(x) AS ( \
+            VALUES(1),(200) \
+            UNION ALL \
+            VALUES(2) \
+            UNION \
+            SELECT bb FROM closure, link WHERE link.aa=closure.x \
+            UNION ALL \
+            SELECT aa FROM link, closure WHERE link.bb=closure.x \
+         ) SELECT x FROM closure ORDER BY x",
+    )
+    .unwrap_err();
+    assert_eq!(err.to_string(), "circular reference: closure");
+}
+
+/// SQLite distinguishes "multiple references to recursive table" (the name
+/// appears more than once in FROM) from "multiple recursive references" (a
+/// single FROM ref plus a subquery ref) (issue #6189, with2.test 1.16 vs
+/// with1.test 7.5).
+#[test]
+fn test_recursive_cte_multiple_from_references_message() {
+    let mut db = vibesql_storage::Database::new();
+    execute_sql(&mut db, "CREATE TABLE main_t4(x)").unwrap();
+
+    // with2.test 1.16: three FROM references to the recursive table.
+    let err = execute_sql(
+        &mut db,
+        "WITH t4(x) AS ( \
+            VALUES(4) \
+            UNION ALL \
+            SELECT x+1 FROM t4, t4, t4 WHERE x<10 \
+         ) SELECT * FROM t4",
+    )
+    .unwrap_err();
+    assert_eq!(err.to_string(), "multiple references to recursive table: t4");
+}


### PR DESCRIPTION
## Summary

Partial increment on the CTE / WITH conformance issue. Fixes the genuine **engine** bugs in the `with*.test` failure tail; the remaining failures are documented residuals rooted outside the CTE engine (TCL harness procs, parser wording, non-CTE UNION/collation/VALUES defects).

Fresh per-file counts were re-measured on current `main` (the issue's stated 25/18/4/1/5 predates earlier merged PRs #6212/#6217/#6226/#6243). Baseline used here is the fresh measurement.

## Before / after per-file failure counts

| File | Before | After | Notes |
| --- | --- | --- | --- |
| with1.test | 15 | 15 | all residual (see below) |
| with2.test | 7 | **6** | 1.16 fixed |
| with3.test | 1 | 1 | residual (error ordering) |
| with4.test | 1 | 1 | residual (params-in-views) |
| with5.test | 3 | **0** | 113/114/131 fixed |

Net: 27 -> 23 failures; 4 in-scope CTE-engine failures eliminated.

## Root-cause clusters -> code change

- **Compound non-recursive seed misfires as "circular reference"** (with5.test 113/114/131). `is_cte_self_referential` and the seed/recursive split only looked at the *second* term of the compound chain, so a multi-term seed (`VALUES(..) INTERSECT VALUES(..)`, `VALUES(..) UNION ALL VALUES(..)`) left the real self-reference in a later term unseen and the body fell through to the non-recursive "circular reference" branch. Fix: new `split_recursive_compound` flattens the whole chain, partitions at the first self-reference (seed = leading non-recursive terms combined via their own operators; recursive = the rest), and validates the recursive connectors — INTERSECT/EXCEPT rejected, and a UNION vs UNION ALL mismatch reproduces SQLite's "circular reference" (keeps with5.test 120/121 passing). `is_cte_self_referential` now walks every non-leading term. `crates/vibesql-executor/src/select/cte.rs`.
- **Recursive-reference-shape error wording** (with2.test 1.16 vs with1.test 7.5). SQLite uses two verbatim messages: `multiple references to recursive table` when the name appears more than once in FROM, vs `multiple recursive references` for a FROM ref plus a subquery ref (confirmed against sqlite3 3.51). The code collapsed both into the latter. Fix: split the condition. `crates/vibesql-executor/src/select/cte.rs`.

## Documented residuals (out of scope for this issue)

- **with1 10.2-10.6, 10.8.1-3 (8)** — driven by the TCL harness proc `insert_into_tree` (`db one` / `db last_insert_rowid` / `parentid IS $var`), not the engine. The recursive-ORDER-BY queries return correct results when run directly against the engine. Harness/shim is explicitly out of scope.
- **with1 10.8.4.3** — collation resolution in a compound `UNION ALL ... ORDER BY` (non-CTE UNION/collation defect).
- **with1 3.6 / with2 3.6 / with1 26.0 / with2 6.6 / with2 4.1** — parser error-message wording gaps (non-CTE parser).
- **with1 16.1 / 22.1 / with2 4.7** — missing restriction / limit checks (recursive aggregate, too-many-FROM-terms, too-many-columns).
- **with2 10.1** — VALUES row type error (VALUES defect, explicitly out of scope per the issue).
- **with1 13.3, 24.1, with2 5.2 / 7.5 / 12.1 / 2.1, with3 1.0** — CTE column-count / no-such-table / error-ordering wording mismatches needing deeper investigation; deferred.
- **with4 130** — `parameters are not allowed in views` validation (non-CTE view/parameter check).

## Test plan

- `make test-tcl-file FILE=with5.test`: 13/13 pass (was 10/13).
- `make test-tcl-file FILE=with2.test`: 62/68 (was 61/68).
- with1/with3/with4: unchanged (no regressions).
- `cargo test -p vibesql-executor recursive_cte`: 39 pass (added 3 regression tests for compound seed, mixed-operator circular, and the multiple-FROM-references message).
- `cargo test -p vibesql-executor` (with_insert_cte / with_update_from_cte / cte / full lib): all green (3596 lib tests).

Part of #6189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)