### PR TITLE
fix(parser): accept WINDOW/OVER/FILTER as fallback identifiers

### DIFF
--- a/crates/vibesql-parser/src/parser/create/types.rs
+++ b/crates/vibesql-parser/src/parser/create/types.rs
@@ -67,6 +67,15 @@ impl Parser {
             // through to the UserDefined catch-all below and is stored by
             // affinity (#5804).
             Token::Keyword { keyword: Keyword::Type, .. } => "type".to_string(),
+            // The window-function contextual keywords WINDOW, OVER, and FILTER are
+            // fallback identifiers in SQLite and are legal type names (window6.test
+            // iteration 5: `CREATE TABLE over(following, preceding window)` uses
+            // `window` as a column type). They are not in the general SQLite
+            // fallback set above, so each needs its own arm; all three fall through
+            // to the UserDefined affinity catch-all below.
+            Token::Keyword { keyword: Keyword::Window, .. } => "window".to_string(),
+            Token::Keyword { keyword: Keyword::Over, .. } => "over".to_string(),
+            Token::Keyword { keyword: Keyword::Filter, .. } => "filter".to_string(),
             _ => return Err(ParseError { message: "Expected data type".to_string() }),
         };
         self.advance();

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -435,7 +435,14 @@ impl Parser {
 
         // Parse optional FILTER clause (SQL:2003)
         // Syntax: aggregate(...) FILTER (WHERE condition) [OVER (...)]
-        let filter = if matches!(self.peek(), Token::Keyword { keyword: Keyword::Filter, .. }) {
+        //
+        // FILTER is a fallback identifier in SQLite: `SELECT sum(x) filter FROM t`
+        // uses `filter` as the output column alias (window6 1.5.4). A genuine FILTER
+        // clause is always `FILTER (`, so only consume it when a `(` follows;
+        // otherwise leave FILTER for the SELECT-list alias parser.
+        let filter = if matches!(self.peek(), Token::Keyword { keyword: Keyword::Filter, .. })
+            && matches!(self.peek_next(), Token::LParen)
+        {
             self.advance(); // consume FILTER
             self.expect_token(Token::LParen)?;
             self.expect_keyword(Keyword::Where)?;
@@ -446,8 +453,18 @@ impl Parser {
             None
         };
 
-        // Check for OVER clause (window function)
-        if matches!(self.peek(), Token::Keyword { keyword: Keyword::Over, .. }) {
+        // Check for OVER clause (window function).
+        //
+        // OVER is a fallback identifier in SQLite: `SELECT sum(x) over FROM over`
+        // uses `over` as the output column alias, not as a window clause (window6
+        // 5.0). A genuine OVER clause is only present when the token after OVER can
+        // begin a window specification — `(` or a window-name (identifier, or a
+        // keyword usable as an identifier such as `over`/`window`). If it cannot
+        // (e.g. the next token is FROM/WHERE/`,`), OVER is being used as an alias,
+        // so we do not consume it here and let the SELECT-list alias parser take it.
+        if matches!(self.peek(), Token::Keyword { keyword: Keyword::Over, .. })
+            && self.over_starts_window_spec()
+        {
             self.advance(); // consume OVER
 
             // DISTINCT is not permitted on any window function. SQLite reports

--- a/crates/vibesql-parser/src/parser/expressions/functions/window.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/window.rs
@@ -91,6 +91,20 @@ impl Parser {
         }
     }
 
+    /// Returns true when the token immediately after `OVER` can begin a window
+    /// specification: a `(` for an inline spec, or a window-name reference. A
+    /// window name may be a plain identifier or a keyword that is usable as an
+    /// identifier (SQLite fallback), e.g. `OVER over` / `OVER window` (window6
+    /// 5.1-5.4). When this returns false, `OVER` is being used as a fallback
+    /// identifier (a column alias), not a window clause.
+    pub(super) fn over_starts_window_spec(&self) -> bool {
+        match self.peek_next() {
+            Token::LParen | Token::Identifier(_) | Token::DelimitedIdentifier(_) => true,
+            Token::Keyword { keyword, .. } => keyword.can_be_identifier(),
+            _ => false,
+        }
+    }
+
     /// Parse window specification (OVER clause contents)
     ///
     /// Supports:
@@ -105,6 +119,18 @@ impl Parser {
         match self.peek() {
             Token::Identifier(name) => {
                 let base_name = name.clone();
+                self.advance();
+                return Ok(vibesql_ast::WindowSpec {
+                    base_window_name: Some(base_name),
+                    partition_by: None,
+                    order_by: None,
+                    frame: None,
+                });
+            }
+            // A window-name reference may also be a keyword used as a fallback
+            // identifier, e.g. `OVER over` / `OVER window` (window6 5.1-5.4).
+            Token::Keyword { keyword, original, .. } if keyword.can_be_identifier() => {
+                let base_name = original.clone();
                 self.advance();
                 return Ok(vibesql_ast::WindowSpec {
                     base_window_name: Some(base_name),

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -398,11 +398,15 @@ impl Parser {
                     }
                 } else if matches!(self.peek(), Token::Keyword { keyword: _, .. })
                     && !self.is_join_keyword()
-                    && !self.is_clause_keyword()
+                    && (!self.is_clause_keyword() || self.window_keyword_used_as_alias())
                     && !self.peek_index_hint()
                 {
                     // Allow non-reserved keywords as implicit aliases (e.g., FROM t m)
-                    // Keywords like M, YEAR, etc. can be used as aliases
+                    // Keywords like M, YEAR, etc. can be used as aliases. WINDOW is
+                    // normally a clause keyword, but `FROM t4 window, t4` uses it as a
+                    // table alias (window6 4.1); `window_keyword_used_as_alias()`
+                    // permits that only when WINDOW does not begin a real
+                    // `WINDOW <name> AS (...)` clause.
                     match self.peek() {
                         Token::Keyword { keyword: kw, .. } => {
                             let alias = kw.to_string();
@@ -612,6 +616,30 @@ impl Parser {
                 | Token::Keyword { keyword: Keyword::Natural, .. }
                 | Token::Keyword { keyword: Keyword::Outer, .. }
         )
+    }
+
+    /// Returns true when the current `WINDOW` keyword begins a real WINDOW clause,
+    /// i.e. it is followed by `<name> AS`. SQLite treats `WINDOW` as a fallback
+    /// identifier otherwise: `SELECT * FROM t4 window, t4` uses `window` as the
+    /// table alias of `t4` (window6 4.1), not as the start of a WINDOW clause.
+    pub(crate) fn peek_window_starts_clause(&self) -> bool {
+        if !matches!(self.peek(), Token::Keyword { keyword: Keyword::Window, .. }) {
+            return false;
+        }
+        let name_follows = matches!(
+            self.peek_next(),
+            Token::Identifier(_) | Token::DelimitedIdentifier(_) | Token::Keyword { .. }
+        );
+        name_follows
+            && matches!(self.peek_at_offset(2), Token::Keyword { keyword: Keyword::As, .. })
+    }
+
+    /// Returns true when the current token is `WINDOW` used as an identifier (table
+    /// alias) rather than as the start of a WINDOW clause. See
+    /// `peek_window_starts_clause` for the disambiguation rule.
+    pub(crate) fn window_keyword_used_as_alias(&self) -> bool {
+        matches!(self.peek(), Token::Keyword { keyword: Keyword::Window, .. })
+            && !self.peek_window_starts_clause()
     }
 
     /// Check if current token is a clause keyword that cannot be used as implicit alias

--- a/crates/vibesql-parser/src/parser/select/list.rs
+++ b/crates/vibesql-parser/src/parser/select/list.rs
@@ -135,6 +135,26 @@ impl Parser {
                 }
                 _ => None,
             }
+        } else if let Token::Keyword { keyword, original, .. } = self.peek() {
+            // A keyword usable as a fallback identifier is a valid AS-less alias,
+            // e.g. `SELECT sum(x) over FROM over` aliases the aggregate as `over`
+            // (window6 5.0). Clause/operator keywords (FROM, WHERE, ORDER, ...) are
+            // not `can_be_identifier()` and so continue to terminate the item.
+            //
+            // RETURNING and WINDOW are excluded even though they are fallback
+            // identifiers: each introduces a trailing clause that can directly
+            // follow the final select item (`INSERT ... SELECT 1 RETURNING a`,
+            // `SELECT 1 WINDOW w AS ()`), so grabbing them as an AS-less alias would
+            // swallow the clause (regression on insert-compound-returning, #5271).
+            if keyword.can_be_identifier()
+                && !matches!(keyword, Keyword::Returning | Keyword::Window)
+            {
+                let alias = original.clone();
+                self.advance();
+                Some(alias)
+            } else {
+                None
+            }
         } else {
             None
         };

--- a/crates/vibesql-parser/src/tests/window_functions.rs
+++ b/crates/vibesql-parser/src/tests/window_functions.rs
@@ -552,3 +552,112 @@ fn test_distinct_window_aggregate_rejected() {
         "unexpected error: {err:?}"
     );
 }
+
+// -----------------------------------------------------------------------------
+// window6.test: WINDOW / OVER / FILTER are fallback identifiers (keyword1-style).
+// These regression tests cover the reserved-keyword-as-identifier gaps fixed for
+// issue #6191 (window6 filescope-err.1 / 4.1 / 5.0 / 5.1 / 1.5.4) without
+// regressing the genuine WINDOW / OVER / FILTER clauses.
+// -----------------------------------------------------------------------------
+
+// window6 iteration 5 file-scope setup: `window`/`over`/`filter` are legal
+// column type names (`CREATE TABLE over(following, preceding window)`).
+#[test]
+fn test_window_over_filter_as_type_names() {
+    for ty in ["window", "over", "filter"] {
+        let sql = format!("CREATE TABLE t(a, b {ty})");
+        assert!(Parser::parse_sql(&sql).is_ok(), "`{ty}` should be a legal type name");
+    }
+}
+
+// window6 5.0: `SELECT sum(x) over FROM over` — OVER is a column alias (not a
+// window clause) because it is not followed by `(` or a window name.
+#[test]
+fn test_over_used_as_column_alias() {
+    let sql = "SELECT sum(x) over FROM over";
+    let stmt = Parser::parse_sql(sql).expect("OVER-as-alias should parse");
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match &select.select_list[0] {
+            vibesql_ast::SelectItem::Expression { expr, alias, .. } => {
+                assert!(
+                    matches!(expr, vibesql_ast::Expression::AggregateFunction { .. }),
+                    "expected a plain aggregate, not a window function"
+                );
+                assert_eq!(alias.as_deref(), Some("over"));
+            }
+            _ => panic!("expected an expression select item"),
+        },
+        _ => panic!("expected a SELECT"),
+    }
+}
+
+// window6 1.5.4: `SELECT sum(x) filter FROM t` — FILTER is a column alias because
+// it is not followed by `(`.
+#[test]
+fn test_filter_used_as_column_alias() {
+    let sql = "SELECT sum(x) filter FROM t";
+    let stmt = Parser::parse_sql(sql).expect("FILTER-as-alias should parse");
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match &select.select_list[0] {
+            vibesql_ast::SelectItem::Expression { expr, alias, .. } => {
+                assert!(matches!(
+                    expr,
+                    vibesql_ast::Expression::AggregateFunction { filter: None, .. }
+                ));
+                assert_eq!(alias.as_deref(), Some("filter"));
+            }
+            _ => panic!("expected an expression select item"),
+        },
+        _ => panic!("expected a SELECT"),
+    }
+}
+
+// window6 5.1: `OVER over` references a named window whose name is the keyword
+// `over`; the genuine WINDOW clause defines it.
+#[test]
+fn test_over_keyword_window_name() {
+    let sql = "SELECT sum(x) over over FROM over WINDOW over AS ()";
+    assert!(Parser::parse_sql(sql).is_ok(), "keyword window name after OVER should parse");
+}
+
+// window6 4.1: `SELECT * FROM t4 window, t4` — WINDOW is a table alias, not the
+// start of a WINDOW clause (which would be `WINDOW <name> AS (...)`).
+#[test]
+fn test_window_used_as_table_alias() {
+    let sql = "SELECT * FROM t4 window, t4";
+    assert!(Parser::parse_sql(sql).is_ok(), "WINDOW-as-table-alias should parse");
+}
+
+// Guard: a genuine trailing WINDOW clause is still recognized (not swallowed as
+// an alias) when it is a real `WINDOW <name> AS (...)`.
+#[test]
+fn test_real_window_clause_still_parses() {
+    let sql = "SELECT sum(x) OVER w FROM t1 WINDOW w AS (ORDER BY y)";
+    let stmt = Parser::parse_sql(sql).expect("real WINDOW clause should parse");
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            let defs = select.window_definitions.expect("WINDOW clause must be captured");
+            assert!(!defs.is_empty(), "WINDOW clause must define at least one window");
+        }
+        _ => panic!("expected a SELECT"),
+    }
+}
+
+// Guard: a genuine FILTER clause is still recognized when followed by `(`.
+#[test]
+fn test_real_filter_clause_still_parses() {
+    let sql = "SELECT sum(x) FILTER (WHERE x > 0) FROM t";
+    let stmt = Parser::parse_sql(sql).expect("real FILTER clause should parse");
+    match stmt {
+        vibesql_ast::Statement::Select(select) => match &select.select_list[0] {
+            vibesql_ast::SelectItem::Expression { expr, .. } => {
+                assert!(matches!(
+                    expr,
+                    vibesql_ast::Expression::AggregateFunction { filter: Some(_), .. }
+                ));
+            }
+            _ => panic!("expected an expression select item"),
+        },
+        _ => panic!("expected a SELECT"),
+    }
+}


### PR DESCRIPTION
## Summary

Resolves the window6.test reserved-keyword-as-identifier tail of #6191. SQLite
treats `WINDOW`, `OVER`, and `FILTER` as fallback identifiers — usable as type
names, table/column aliases, and window names whenever they cannot begin their
respective clause. VibeSQL's parser reserved them unconditionally, which failed
`window6.test` filescope-err.1 / 4.1 / 5.0 (and, once the file-scope setup was
unblocked, the newly-reachable 1.5.4). All are pure-parser gaps; the window
frame/FILTER engine and the Bucket-A straddler routing were already delivered by
the earlier increment (PR #6244).

## Changes

- **`create/types.rs`** — accept `window`/`over`/`filter` as affinity-only column
  type names (`CREATE TABLE over(following, preceding window)`, window6 iter-5).
- **`expressions/functions/mod.rs`** — only consume `OVER` as a window clause when
  the next token can begin a window spec (`(` or a window-name); otherwise `OVER`
  is an AS-less column alias (window6 5.0). Same gate for `FILTER`: a real clause
  is always `FILTER (`, else `filter` is a column alias (window6 1.5.4).
- **`expressions/functions/window.rs`** — `over_starts_window_spec()` lookahead
  helper; `parse_window_spec` accepts a fallback-keyword window name (`OVER over`,
  window6 5.1).
- **`select/from_clause.rs`** — allow `WINDOW` as a table alias when it does not
  begin a real `WINDOW <name> AS (...)` clause (window6 4.1), via
  `peek_window_starts_clause()` / `window_keyword_used_as_alias()`.
- **`select/list.rs`** — AS-less select-list aliases accept `can_be_identifier()`
  keywords, excluding `RETURNING`/`WINDOW` (each can introduce a trailing clause
  after the final item; preserves #5271).
- **`tests/window_functions.rs`** — 7 parser regression tests (one per fixed case
  plus guards that genuine `WINDOW`/`FILTER` clauses still parse).

## Acceptance Criteria Verification

Per-file before/after from a **fresh release build** (`./scripts/tcltest test`):

| File | Before | After | Notes |
| --- | --- | --- | --- |
| window6.test | 3 failed | **0 failed** | filescope-err.1, 4.1, 5.0 fixed (70 tests reachable now vs 63; 1.5.4 unmasked+fixed) |
| filter1.test | 1 failed | 1 failed | residual **6.3** only — see below |
| filter2.test | 0 | 0 | 100% |
| window1.test | 0 | 0 | 100% of in-scope |
| window5.test | Bucket-A | Bucket-A | whole-file C-API skip (PR #6244) |
| windowfault.test | Bucket-A | Bucket-A | whole-file fault-injection skip (PR #6244) |

**Residual (out of scope for this issue's window-frame/FILTER focus):**
`filter1.test 6.3` — `SELECT (SELECT COUNT(a) FROM t2) FROM t1` where `a` is an
outer column. SQLite binds the aggregate to the outermost query that provides its
columns (result `{2}`, a single row). This is a name-resolution / aggregate-binding
semantic unrelated to window frames or FILTER truthiness; it was flagged as deferred
in the prior increment and needs a separate targeted fix. Left visibly failing.

## Test Plan

- `cargo test -p vibesql-parser --lib` — **1808 passed, 0 failed** (7 new).
- `cargo test -p vibesql-executor --lib` — **3593 passed, 0 failed**.
- No-regression audit: stashed changes and rebuilt baseline; `join` (7), `tkt2822`
  (3), `aggnested` (1) failures are **identical** pre/post (pre-existing, not
  regressions). `keyword1.test` (the keyword-as-identifier torture file) stays
  **100%**; select1-6, window1-4, filter2 clean.
- A stale-binary hazard was avoided: every TCL count above is from a fresh
  `cargo build --release` in this worktree.

Part of #6191