### PR TITLE
fix(trigger): UPDATE rowid affinity, quoted-identifier trigger bodies, NULL-rowid sentinel + shim fidelity (Part of #6176)

### DIFF
--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -73,7 +73,7 @@ pub fn execute_insert_with_trigger_context(
 
 /// Result of applying SQLite rowid (INTEGER) affinity to a value supplied for
 /// the rowid / INTEGER PRIMARY KEY position on INSERT.
-enum RowidAffinity {
+pub(crate) enum RowidAffinity {
     /// The value coerced to a concrete integer rowid.
     Value(i64),
     /// The value was NULL (or DEFAULT) — auto-assign the next rowid.
@@ -96,7 +96,9 @@ enum RowidAffinity {
 /// (`INSERT INTO t(rowid) VALUES(-42.0)` stores rowid -42; triggerC-4.1.4), so
 /// no positivity restriction is applied — only the affinity coercion and the
 /// lossless-integer check.
-fn coerce_rowid_affinity(value: &vibesql_types::SqlValue) -> Result<RowidAffinity, ExecutorError> {
+pub(crate) fn coerce_rowid_affinity(
+    value: &vibesql_types::SqlValue,
+) -> Result<RowidAffinity, ExecutorError> {
     use vibesql_types::SqlValue;
 
     let datatype_mismatch =
@@ -514,11 +516,13 @@ fn execute_insert_internal(
 
     // For multi-row INSERT, validate all rows first, then insert all
     // This ensures atomicity: all rows succeed or all fail (unless IGNORE is used)
-    // Each entry is (row values, explicit rowid, ipk_auto_assigned,
-    // candidate_last_id). The `ipk_auto_assigned` flag records whether the row's
-    // INTEGER PRIMARY KEY (rowid alias) value was auto-allocated rather than
-    // supplied by the INSERT; it is used to present `NEW.<ipk>` as the
-    // unwritten-rowid sentinel (-1) to BEFORE INSERT triggers.
+    // Each entry is (row values, explicit rowid, rowid_auto_assigned,
+    // candidate_last_id). The `rowid_auto_assigned` flag records whether the
+    // row's rowid — the INTEGER PRIMARY KEY (rowid alias) value, or an explicit
+    // `rowid` pseudo-column supplied as NULL/DEFAULT (triggerC-4.1.5) — was
+    // auto-allocated rather than supplied by the INSERT; it is used to present
+    // `NEW.<ipk>` / `NEW.rowid` as the unwritten-rowid sentinel (-1) to BEFORE
+    // INSERT triggers.
     //
     // `candidate_last_id` is the value this row would contribute to
     // last_insert_rowid() *if it is actually inserted* — the row's INTEGER
@@ -624,6 +628,14 @@ fn execute_insert_internal(
 
         // Extract rowid value if present (SQLite compatibility)
         // For NULL rowids, auto-assign using batch_max_rowid + 1
+        //
+        // Track whether the supplied rowid value was NULL/DEFAULT and therefore
+        // auto-assigned: SQLite does not allocate the real rowid until the row
+        // is written, so a BEFORE INSERT trigger must observe the
+        // unwritten-rowid sentinel (-1) for `INSERT INTO t(rowid,...)
+        // VALUES(NULL, ...)` exactly as it does when the rowid column is
+        // omitted (triggerC-4.1.5).
+        let mut rowid_was_auto = false;
         let explicit_rowid = if let Some(rowid_pos) = rowid_position {
             // Get the rowid expression
             let rowid_expr = &value_exprs[rowid_pos];
@@ -649,6 +661,7 @@ fn execute_insert_internal(
                         Ok(i as u64)
                     }
                     RowidAffinity::Auto => {
+                        rowid_was_auto = true;
                         // sqlite3 parity (issue #5894): max rowid + 1, but when the
                         // running max is already i64::MAX, delegate to the storage
                         // allocator's random-probe / SQLITE_FULL fallback instead of
@@ -971,7 +984,7 @@ fn execute_insert_internal(
         validated_rows.push((
             full_row_values,
             explicit_rowid,
-            ipk_auto_assigned,
+            ipk_auto_assigned || rowid_was_auto,
             candidate_last_id,
         ));
     }
@@ -1213,9 +1226,13 @@ fn execute_insert_internal(
         }
     } else {
         // Slow path: Insert rows one by one (needed for triggers, special clauses)
-        for (mut full_row_values, mut explicit_rowid, ipk_auto_assigned, candidate_last_id) in
+        for (mut full_row_values, mut explicit_rowid, rowid_auto_assigned, candidate_last_id) in
             validated_rows
         {
+            // Set when a REPLACE conflict resolution fixes this row's rowid
+            // before triggers fire; the BEFORE INSERT trigger then observes
+            // the fixed rowid rather than the unwritten-rowid sentinel.
+            let mut replace_fixed_rowid = false;
             // Check if ON DUPLICATE KEY UPDATE is specified
             if let Some(ref assignments) = stmt.on_duplicate_key_update {
                 // Try to update an existing row if there's a conflict
@@ -1300,6 +1317,7 @@ fn execute_insert_internal(
                                     &full_row_values,
                                     explicit_rowid,
                                 )?);
+                                replace_fixed_rowid = true;
                             }
                             Some(vibesql_ast::ConflictClause::Ignore) => continue,
                             _ => return Err(ExecutorError::ConstraintViolation(message)),
@@ -1315,6 +1333,7 @@ fn execute_insert_internal(
                     &full_row_values,
                     explicit_rowid,
                 )?);
+                replace_fixed_rowid = true;
             }
 
             // Fire BEFORE INSERT triggers only if triggers exist.
@@ -1328,8 +1347,11 @@ fn execute_insert_internal(
             // but the trigger must observe the sentinel — except when the rowid
             // was supplied explicitly (then the supplied value is visible as-is),
             // or when a REPLACE reservation has fixed the rowid before triggers
-            // (`explicit_rowid` is then `Some`). insert3-2.1/2.2, triggerC-4.1.2.
-            let row_to_insert = if ipk_auto_assigned && explicit_rowid.is_none() {
+            // (`replace_fixed_rowid`). `rowid_auto_assigned` covers both the
+            // omitted-IPK/NULL-IPK case and an explicit `rowid` pseudo-column
+            // supplied as NULL/DEFAULT (triggerC-4.1.5). insert3-2.1/2.2,
+            // triggerC-4.1.2.
+            let row_to_insert = if rowid_auto_assigned && !replace_fixed_rowid {
                 let mut trigger_values = full_row_values.clone();
                 if let Some(idx) = ipk_col_idx {
                     trigger_values[idx] = vibesql_types::SqlValue::Integer(-1);

--- a/crates/vibesql-executor/src/insert/mod.rs
+++ b/crates/vibesql-executor/src/insert/mod.rs
@@ -12,6 +12,7 @@ pub mod validation;
 use crate::errors::ExecutorError;
 
 pub use execution::InsertOutcome;
+pub(crate) use execution::{coerce_rowid_affinity, RowidAffinity};
 
 /// Executor for INSERT statements
 pub struct InsertExecutor;

--- a/crates/vibesql-executor/src/update/fast_path.rs
+++ b/crates/vibesql-executor/src/update/fast_path.rs
@@ -160,6 +160,14 @@ pub(super) fn try_fast_path_update(
             }
         })?;
 
+        // Assigning the INTEGER PRIMARY KEY (rowid alias) column relocates the
+        // rowid and applies rowid affinity (`datatype mismatch` on non-integer
+        // values, trigger1-15.1) — fall back to the normal path, same as a
+        // `SET rowid = ...` assignment above.
+        if schema.rowid_alias_column == Some(col_index) {
+            return Ok(None);
+        }
+
         let new_value = match &assignment.value {
             vibesql_ast::Expression::Default => {
                 let column = &schema.columns[col_index];

--- a/crates/vibesql-executor/src/update/tests/mod.rs
+++ b/crates/vibesql-executor/src/update/tests/mod.rs
@@ -1,5 +1,6 @@
 //! Tests for UPDATE statement execution.
 
 mod limit;
+mod rowid_affinity;
 mod set_rowid;
 mod trigger_phase_value;

--- a/crates/vibesql-executor/src/update/tests/rowid_affinity.rs
+++ b/crates/vibesql-executor/src/update/tests/rowid_affinity.rs
@@ -1,0 +1,134 @@
+//! Rowid (INTEGER) affinity on `UPDATE` assignments to the rowid — either the
+//! INTEGER PRIMARY KEY alias column or the virtual `rowid` pseudo-column
+//! (trigger1-15.1, issue #6176).
+//!
+//! sqlite3 3.51.0 semantics (verified against the reference binary):
+//!   - a TEXT/REAL value that is losslessly an integer is coerced
+//!     (`SET a='5'` stores 5; `SET a=7.0` stores 7);
+//!   - anything else — non-numeric TEXT, BLOB, fractional REAL, and (unlike
+//!     INSERT, where it means auto-assign) NULL — raises `datatype mismatch`.
+
+use vibesql_ast::Statement;
+use vibesql_parser::Parser;
+use vibesql_types::SqlValue;
+
+use crate::*;
+
+/// Execute a non-query statement (CREATE/INSERT/CREATE TRIGGER).
+fn ddl(db: &mut vibesql_storage::Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse {:?}: {:?}", sql, e));
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT");
+        }
+        Statement::CreateTrigger(s) => {
+            crate::advanced_objects::execute_create_trigger(&s, db).expect("CREATE TRIGGER");
+        }
+        other => panic!("unsupported ddl: {:?}", other),
+    }
+}
+
+/// Run an UPDATE, returning the executor result (so affinity errors are observable).
+fn update(db: &mut vibesql_storage::Database, sql: &str) -> Result<usize, crate::ExecutorError> {
+    match Parser::parse_sql(sql).expect("parse update") {
+        Statement::Update(s) => UpdateExecutor::execute(&s, db),
+        other => panic!("expected UPDATE, got {:?}", other),
+    }
+}
+
+/// Run a SELECT and return the single column of the single row.
+fn select_one(db: &mut vibesql_storage::Database, sql: &str) -> SqlValue {
+    match Parser::parse_sql(sql).expect("parse select") {
+        Statement::Select(s) => {
+            let rows = SelectExecutor::new(db).execute(&s).expect("SELECT");
+            assert_eq!(rows.len(), 1, "expected one row from {sql}");
+            rows[0].values[0].clone()
+        }
+        other => panic!("expected SELECT, got {:?}", other),
+    }
+}
+
+fn assert_datatype_mismatch(result: Result<usize, crate::ExecutorError>, context: &str) {
+    let err = result.expect_err(context);
+    assert!(
+        err.to_string().contains("datatype mismatch"),
+        "{context}: expected datatype mismatch, got: {err}"
+    );
+}
+
+fn ipk_db() -> vibesql_storage::Database {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE tA(a INTEGER PRIMARY KEY, b, c)");
+    ddl(&mut db, "INSERT INTO tA VALUES(1, 2, 3)");
+    db
+}
+
+/// trigger1-15.1: `UPDATE tA SET a='abc'` on an INTEGER PRIMARY KEY column is
+/// `datatype mismatch`, including when a BEFORE UPDATE trigger exists (the
+/// trigger must not mask the affinity check).
+#[test]
+fn update_ipk_to_nonnumeric_text_errors() {
+    let mut db = ipk_db();
+    ddl(&mut db, "CREATE TRIGGER tA_trigger BEFORE UPDATE ON tA BEGIN SELECT 1; END");
+    assert_datatype_mismatch(update(&mut db, "UPDATE tA SET a = 'abc'"), "SET a='abc'");
+    // Row unchanged.
+    assert_eq!(select_one(&mut db, "SELECT a FROM tA"), SqlValue::Integer(1));
+}
+
+/// NULL is valid on INSERT (auto-assign) but a `datatype mismatch` on UPDATE.
+#[test]
+fn update_ipk_to_null_errors() {
+    let mut db = ipk_db();
+    assert_datatype_mismatch(update(&mut db, "UPDATE tA SET a = NULL"), "SET a=NULL");
+}
+
+/// Fractional REAL cannot be a rowid.
+#[test]
+fn update_ipk_to_fractional_real_errors() {
+    let mut db = ipk_db();
+    assert_datatype_mismatch(update(&mut db, "UPDATE tA SET a = 7.5"), "SET a=7.5");
+}
+
+/// Lossless TEXT / REAL integers coerce (SQLite INTEGER affinity).
+#[test]
+fn update_ipk_lossless_coercions() {
+    let mut db = ipk_db();
+    assert_eq!(update(&mut db, "UPDATE tA SET a = '5'").unwrap(), 1);
+    assert_eq!(select_one(&mut db, "SELECT a FROM tA"), SqlValue::Integer(5));
+
+    assert_eq!(update(&mut db, "UPDATE tA SET a = 7.0").unwrap(), 1);
+    assert_eq!(select_one(&mut db, "SELECT a FROM tA"), SqlValue::Integer(7));
+}
+
+/// `SET rowid = ...` routed through the rowid keyword on an IPK table applies
+/// the same affinity rules.
+#[test]
+fn update_rowid_keyword_on_ipk_table() {
+    let mut db = ipk_db();
+    assert_datatype_mismatch(update(&mut db, "UPDATE tA SET rowid = 'abc'"), "SET rowid='abc'");
+    assert_eq!(update(&mut db, "UPDATE tA SET rowid = '9'").unwrap(), 1);
+    assert_eq!(select_one(&mut db, "SELECT a FROM tA"), SqlValue::Integer(9));
+}
+
+/// Virtual-rowid tables (no INTEGER PRIMARY KEY): same rules for
+/// `SET rowid = ...`, including the NULL rejection.
+#[test]
+fn update_virtual_rowid_affinity() {
+    let mut db = vibesql_storage::Database::new();
+    ddl(&mut db, "CREATE TABLE tB(a, b)");
+    ddl(&mut db, "INSERT INTO tB VALUES(1, 2)");
+
+    assert_datatype_mismatch(update(&mut db, "UPDATE tB SET rowid = 'abc'"), "SET rowid='abc'");
+    assert_datatype_mismatch(update(&mut db, "UPDATE tB SET rowid = NULL"), "SET rowid=NULL");
+    assert_datatype_mismatch(update(&mut db, "UPDATE tB SET rowid = 2.5"), "SET rowid=2.5");
+
+    // Lossless TEXT integer relocates the row.
+    assert_eq!(update(&mut db, "UPDATE tB SET rowid = '42'").unwrap(), 1);
+    match select_one(&mut db, "SELECT rowid FROM tB") {
+        SqlValue::Integer(i) | SqlValue::Bigint(i) => assert_eq!(i, 42),
+        other => panic!("expected integer rowid, got {other:?}"),
+    }
+}

--- a/crates/vibesql-executor/src/update/value_updater.rs
+++ b/crates/vibesql-executor/src/update/value_updater.rs
@@ -5,8 +5,30 @@ use std::collections::HashSet;
 use vibesql_ast::Assignment;
 
 use crate::{
-    errors::ExecutorError, evaluator::ExpressionEvaluator, insert::validation::coerce_value,
+    errors::ExecutorError,
+    evaluator::ExpressionEvaluator,
+    insert::validation::coerce_value,
+    insert::{coerce_rowid_affinity, RowidAffinity},
 };
+
+/// Apply SQLite's rowid (INTEGER) affinity to a value assigned to the rowid —
+/// either the INTEGER PRIMARY KEY alias column or the virtual `rowid`
+/// pseudo-column — by an UPDATE statement.
+///
+/// Shares the INSERT-path coercion rules (`coerce_rowid_affinity`): integers
+/// pass through, lossless-integer TEXT/REAL values are coerced, everything
+/// else raises `datatype mismatch`. Unlike INSERT, where NULL means
+/// "auto-assign the next rowid", sqlite3 3.51.0 rejects `UPDATE t SET
+/// rowid=NULL` (and `SET <ipk>=NULL`) with `datatype mismatch`
+/// (trigger1-15.1).
+fn coerce_update_rowid_value(value: &vibesql_types::SqlValue) -> Result<i64, ExecutorError> {
+    match coerce_rowid_affinity(value)? {
+        RowidAffinity::Value(i) => Ok(i),
+        RowidAffinity::Auto => {
+            Err(ExecutorError::SqliteCompatError("datatype mismatch".to_string()))
+        }
+    }
+}
 
 /// Applies assignment expressions to rows
 pub struct ValueUpdater<'a> {
@@ -99,27 +121,24 @@ impl<'a> ValueUpdater<'a> {
                 // If the table has an INTEGER PRIMARY KEY (rowid alias), update that column
                 // Otherwise, update the row's internal row_id field
                 if let Some(ipk_col_idx) = self.schema.rowid_alias_column {
-                    // The INTEGER PRIMARY KEY column IS the rowid - update it
+                    // The INTEGER PRIMARY KEY column IS the rowid - update it.
+                    // Apply SQLite's rowid (INTEGER) affinity: lossless TEXT/REAL
+                    // integers coerce; anything else — including NULL, which is
+                    // valid on INSERT (auto-assign) but not on UPDATE — raises
+                    // `datatype mismatch` (trigger1-15.1, sqlite3 3.51.0).
                     let new_value = self.evaluator.eval(&assignment.value, original_row)?;
+                    let coerced = coerce_update_rowid_value(&new_value)?;
                     new_row
-                        .set(ipk_col_idx, new_value)
+                        .set(ipk_col_idx, vibesql_types::SqlValue::Integer(coerced))
                         .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
                     changed_columns.insert(ipk_col_idx);
                 } else {
-                    // No INTEGER PRIMARY KEY - update the virtual rowid
-                    // Evaluate the new rowid value
+                    // No INTEGER PRIMARY KEY - update the virtual rowid.
+                    // Same rowid affinity rules as the alias path: sqlite3 raises
+                    // `datatype mismatch` for NULL / BLOB / non-numeric TEXT /
+                    // fractional REAL, and coerces lossless TEXT/REAL integers.
                     let new_value = self.evaluator.eval(&assignment.value, original_row)?;
-                    // Convert to u64 for row_id
-                    let new_rowid = match new_value {
-                        vibesql_types::SqlValue::Integer(i) => i as u64,
-                        vibesql_types::SqlValue::Bigint(i) => i as u64,
-                        other => {
-                            return Err(ExecutorError::UnsupportedExpression(format!(
-                                "ROWID must be an integer, got {:?}",
-                                other
-                            )));
-                        }
-                    };
+                    let new_rowid = coerce_update_rowid_value(&new_value)? as u64;
                     new_row.row_id = Some(new_rowid);
                     // Note: We don't add anything to changed_columns since row_id
                     // is not a real column. The storage layer will use the updated row_id.
@@ -166,8 +185,15 @@ impl<'a> ValueUpdater<'a> {
             // e.g., UPDATE t SET r='5' on a REAL column stores 5.0, not '5'.
             // STRICT tables (issue #5837) apply the rigid strict-datatype rules
             // instead, matching the INSERT strict gate.
+            //
+            // The INTEGER PRIMARY KEY rowid-alias column applies SQLite's rowid
+            // affinity instead: the stored value must be a (losslessly coerced)
+            // integer, and anything else — including NULL, which INSERT would
+            // auto-assign — raises `datatype mismatch` (trigger1-15.1).
             let column = &self.schema.columns[col_index];
-            let coerced_value = if let Some(st) = self.schema.strict_type_of(col_index) {
+            let coerced_value = if self.schema.rowid_alias_column == Some(col_index) {
+                vibesql_types::SqlValue::Integer(coerce_update_rowid_value(&new_value)?)
+            } else if let Some(st) = self.schema.strict_type_of(col_index) {
                 crate::strict::enforce_strict_type(new_value, st, &self.schema.name, &column.name)?
             } else {
                 coerce_value(new_value, &column.data_type)?

--- a/crates/vibesql-executor/tests/insert_rowid_affinity_tests.rs
+++ b/crates/vibesql-executor/tests/insert_rowid_affinity_tests.rs
@@ -176,3 +176,63 @@ fn trigger_observes_coerced_rowid_for_negative_real() {
     // sqlite3 3.51.0: new.rowid = -42 (integer), new.b = -42 (integer).
     assert_eq!(rows[0][0], SqlValue::Varchar("-42 integer -42 integer".into()));
 }
+
+/// triggerC-4.1.5 (issue #6176): `INSERT INTO t(rowid, ...) VALUES(NULL, ...)`
+/// auto-assigns the rowid, so a BEFORE INSERT trigger must observe the
+/// unwritten-rowid sentinel (-1) — exactly as it does when the rowid column is
+/// omitted — while an AFTER INSERT trigger observes the real assigned rowid.
+#[test]
+fn before_trigger_sees_sentinel_for_explicit_null_rowid() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE log(t TEXT)").unwrap();
+    exec(&mut db, "CREATE TABLE t4(a TEXT)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER t4bi BEFORE INSERT ON t4 BEGIN \
+         INSERT INTO log VALUES('before ' || new.rowid || ' ' || typeof(new.rowid)); \
+         END",
+    )
+    .unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER t4ai AFTER INSERT ON t4 BEGIN \
+         INSERT INTO log VALUES('after ' || new.rowid || ' ' || typeof(new.rowid)); \
+         END",
+    )
+    .unwrap();
+
+    exec(&mut db, "INSERT INTO t4(rowid, a) VALUES(NULL, 'x')").unwrap();
+
+    let rows = query(&db, "SELECT t FROM log ORDER BY rowid");
+    assert_eq!(rows.len(), 2);
+    // sqlite3 3.51.0: BEFORE sees -1 (sentinel), AFTER sees the assigned rowid 1.
+    assert_eq!(rows[0][0], SqlValue::Varchar("before -1 integer".into()));
+    assert_eq!(rows[1][0], SqlValue::Varchar("after 1 integer".into()));
+
+    // The stored row carries the real assigned rowid.
+    let (rowid, ty) = rowid_and_type(&db, "t4");
+    assert_eq!(rowid, 1);
+    assert_eq!(ty, SqlValue::Varchar("integer".into()));
+}
+
+/// An EXPLICIT (non-NULL) rowid remains visible as-is to BEFORE INSERT
+/// triggers — the sentinel only applies to auto-assigned rowids.
+#[test]
+fn before_trigger_sees_explicit_rowid_value() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE log(t TEXT)").unwrap();
+    exec(&mut db, "CREATE TABLE t4(a TEXT)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER t4bi BEFORE INSERT ON t4 BEGIN \
+         INSERT INTO log VALUES('before ' || new.rowid); \
+         END",
+    )
+    .unwrap();
+
+    exec(&mut db, "INSERT INTO t4(rowid, a) VALUES(45, 'x')").unwrap();
+
+    let rows = query(&db, "SELECT t FROM log");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], SqlValue::Varchar("before 45".into()));
+}

--- a/crates/vibesql-parser/src/tests/lexer/identifiers.rs
+++ b/crates/vibesql-parser/src/tests/lexer/identifiers.rs
@@ -501,3 +501,28 @@ fn test_tokenize_backtick_vs_doublequote_identifiers() {
 }
 
 // ============================================================================
+
+// ============================================================================
+// to_sql round-trip for delimited identifiers with embedded quotes
+// (triggerC-15.2, issue #6176)
+// ============================================================================
+
+/// `"""x2"""` lexes to the identifier `"x2"`, and `to_sql()` must re-emit it
+/// with the embedded quotes doubled (`"""x2"""`), not the unlexable `""x2""`.
+/// Trigger bodies are stored as reconstructed token text and re-parsed at fire
+/// time, so a non-round-tripping to_sql broke any trigger touching such a
+/// table (triggerC-15.2.1).
+#[test]
+fn test_delimited_identifier_with_embedded_quotes_roundtrips_through_to_sql() {
+    let mut lexer = Lexer::new("SELECT * FROM \"\"\"x2\"\"\"");
+    let tokens = lexer.tokenize().unwrap();
+    let ident = &tokens[3];
+    assert_eq!(*ident, Token::DelimitedIdentifier("\"x2\"".to_string()));
+
+    // Re-emit as SQL and lex again: must produce the same identifier.
+    let sql = ident.to_sql();
+    assert_eq!(sql, "\"\"\"x2\"\"\"");
+    let mut relexer = Lexer::new(&sql);
+    let retokens = relexer.tokenize().unwrap();
+    assert_eq!(retokens[0], Token::DelimitedIdentifier("\"x2\"".to_string()));
+}

--- a/crates/vibesql-parser/src/token.rs
+++ b/crates/vibesql-parser/src/token.rs
@@ -107,7 +107,12 @@ impl Token {
         match self {
             Token::Keyword { keyword, .. } => keyword.to_string(),
             Token::Identifier(id) => id.clone(),
-            Token::DelimitedIdentifier(id) => format!("\"{}\"", id),
+            // Escape embedded double quotes by doubling them (SQL-standard),
+            // so an identifier like `"x2"` round-trips as `"""x2"""` instead of
+            // the unlexable `""x2""` (triggerC-15.2). This matters because
+            // trigger bodies are stored as reconstructed token text and
+            // re-parsed at fire time.
+            Token::DelimitedIdentifier(id) => format!("\"{}\"", id.replace('"', "\"\"")),
             Token::Number(n) => n.clone(),
             Token::String(s) => format!("'{}'", s.replace('\'', "''")),
             Token::BlobLiteral(bytes) => {

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -2497,7 +2497,7 @@ proc execsql {sql {db ""}} {
                 }
                 continue  ;# Check for more statements
             }
-            if {[regexp -nocase {^PRAGMA\s+(?:\w+\.)?(full_column_names|short_column_names|case_sensitive_like|reverse_unordered_selects|integrity_check|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|table_info|data_version|collation_list|index_list|index_xinfo|index_info|auto_vacuum|temp_store)} [string trim $sql]]} {
+            if {[regexp -nocase {^PRAGMA\s+(?:\w+\.)?(full_column_names|short_column_names|case_sensitive_like|reverse_unordered_selects|integrity_check|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|recursive_triggers|table_info|data_version|collation_list|index_list|index_xinfo|index_info|auto_vacuum|temp_store)} [string trim $sql]]} {
                 # This PRAGMA is supported (with =value) - stop stripping
                 break
             } else {
@@ -3241,7 +3241,7 @@ proc execsql2 {sql {db ""}} {
     set sql_upper [string toupper [string trim $sql]]
     if {[string match "PRAGMA*" $sql_upper]} {
         # Allow supported PRAGMAs through
-        if {[regexp -nocase {^PRAGMA\s+(?:database\.)?(full_column_names|short_column_names|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|data_version|collation_list|index_list|index_xinfo|index_info)} [string trim $sql]]} {
+        if {[regexp -nocase {^PRAGMA\s+(?:database\.)?(full_column_names|short_column_names|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|recursive_triggers|data_version|collation_list|index_list|index_xinfo|index_info)} [string trim $sql]]} {
             # Pass through to VibeSQL - these are supported
         } else {
             return {}  ;# Skip unsupported PRAGMA statements
@@ -7003,6 +7003,9 @@ proc sqlite3 {db args} {
     set ::pragma_reverse_unordered_selects 0
     set ::pragma_foreign_keys 0
     set ::pragma_defer_foreign_keys 0
+    # recursive_triggers is per-connection in SQLite (OFF by default); a fresh
+    # open must not inherit the previous connection's setting (#5909).
+    set ::pragma_recursive_triggers 0
     set ::dqs_dml_mode 0  ;# Reset DQS mode for new database
     set ::last_insert_rowid 0  ;# Fresh connection: last_insert_rowid() is 0 (#5843)
 
@@ -7370,6 +7373,8 @@ proc reset_db {} {
     set ::pragma_reverse_unordered_selects 0
     set ::pragma_foreign_keys 0
     set ::pragma_defer_foreign_keys 0
+    # recursive_triggers is per-connection in SQLite (OFF by default; #5909).
+    set ::pragma_recursive_triggers 0
     set ::last_insert_rowid 0  ;# Connection closed: last_insert_rowid resets (#5843)
     # Drop all temp view/trigger replay state — reset_db wipes the database, so
     # replaying stale temp-object DDL into the fresh db would resurrect objects
@@ -7402,6 +7407,14 @@ proc forcedelete {args} {
     # `file rootname test.db-journal` is "test", whose siblings belong to
     # the still-live test.db).
     foreach f $args {
+        # The shim maps "test.db" to a unique per-run temp file (see the
+        # `sqlite3` proc), so `forcedelete test.db` must delete THAT file —
+        # deleting the literal ./test.db is a no-op and the "deleted" database
+        # silently survives into the next open (triggerC-12.1 saw a stale
+        # `table t1 already exists`). Apply the same mapping here.
+        if {[file tail $f] eq "test.db" && [info exists ::db_file] && $::db_file ne ""} {
+            set f $::db_file
+        }
         catch {file delete -force $f}
         if {[string match "*-journal" $f] || [string match "*-wal" $f] \
                 || [string match "*-shm" $f] || [string match "*-checkpoints" $f]} {


### PR DESCRIPTION
## Summary

A partial increment on the trigger / DROP TRIGGER / DROP VIEW conformance family (**Part of #6176**, epic #5779). Four engine fixes plus two TCL-shim fidelity fixes, all surfaced by the `trigger1` / `triggerC` acceptance files:

### Engine

1. **UPDATE rowid affinity** (`trigger1-15.1`). `UPDATE t SET <ipk> = 'abc'` (and `SET rowid = ...` on both IPK-alias and virtual-rowid tables) now applies SQLite's rowid INTEGER affinity: lossless TEXT/REAL integers coerce (`'5'` → 5, `7.0` → 7); non-numeric TEXT, BLOB, fractional REAL, and NULL raise `datatype mismatch` (NULL auto-assigns on INSERT but is rejected on UPDATE — verified against sqlite3 3.51.0). The single-row UPDATE fast path falls back to the normal path for rowid-alias assignments.
   - `crates/vibesql-executor/src/update/value_updater.rs`, `update/fast_path.rs`
2. **Quoted-identifier trigger bodies** (`triggerC-15.2.1/15.2.3`). `Token::to_sql()` now doubles embedded quotes in delimited identifiers. Trigger bodies are stored as reconstructed token text and re-parsed at fire time, so a body referencing a table named `"x2"` previously round-tripped as the unlexable `""x2""` and failed with `Lexer error: near """"`.
   - `crates/vibesql-parser/src/token.rs`
3. **Unwritten-rowid sentinel for explicit NULL rowid** (`triggerC-4.1.5`). `INSERT INTO t(rowid, ...) VALUES(NULL, ...)` now presents `NEW.rowid = -1` to BEFORE INSERT triggers, matching the omitted-rowid path; AFTER triggers and the stored row still see the real assigned rowid. REPLACE-fixed rowids remain visible as-is.
   - `crates/vibesql-executor/src/insert/execution.rs`

### TCL shim (faithful emulation, no test-forcing)

4. **`PRAGMA recursive_triggers` pass-through** (`triggerC-6.1/6.2/6.3`). The query form was being stripped (returning `{}`); it now passes through to the engine, which already answers it. The tracked value also resets on new connections / `reset_db`, matching SQLite's per-connection default (OFF).
5. **`forcedelete test.db` mapping** (`triggerC-12.1/12.2`). The shim maps `test.db` to a per-run temp file on open, but `forcedelete` deleted the literal path — so a "deleted" database silently survived into the next open (`table t1 already exists`). It now applies the same mapping.

## Before / after (failures per acceptance file)

| File | Before | After |
|------|-------:|------:|
| `triggerC.test` | 102 passed / 15 failed | **112 passed / 7 failed** |
| `trigger1.test` | 43 passed / 27 failed | **44 passed / 26 failed** |
| `e_droptrigger.test` | 0 passed / 59 failed | unchanged (see below) |
| `e_dropview.test` | 8 passed / 25 failed | unchanged (see below) |

Fixed: `triggerC-4.1.5`, `-6.1..6.3`, `-12.1`, `-12.2`, `-15.2.1`, `-15.2.3`, `trigger1-15.1`.

## No regressions

- TCL: `triggerB` 202/0, `trigger2` 69/2, `trigger7` 1/2, `triggerE` 23/2, `triggerG` 6/2, `temptrigger` 15/4, `trigger3` 17/0, `trigger4` 23/0, `trigger5` 1/0, `insert` 52/1, `insert3` 14/2, `update` 128/0, `delete` 49/0, `view` 24/0 (93 skipped), `select1` 188/0 — every count identical to a main-workspace baseline run.
- cargo: `vibesql-executor` 5876 passed / 0 failed, `vibesql-parser` 1810 passed / 0 failed — includes 9 new unit tests (`update/tests/rowid_affinity.rs`, two BEFORE-trigger sentinel tests in `insert_rowid_affinity_tests.rs`, one lexer `to_sql` round-trip test).
- `cargo fmt --check` clean; clippy warnings are pre-existing in untouched files.

## Remaining scope of #6176 (why this is partial)

- **`e_droptrigger.test` (59)** — every assertion either compares `list_all_triggers` output that embeds `aux.tr1/tr2/tr3` entries (requires `ATTACH`, #6193) or observes trigger firing through a `db func r` TCL callback (`SELECT r('temp.tr1')`), which the multi-process shim cannot bridge (C-API UDF harness gap, #5720).
- **`e_dropview.test` (25)** — same shape: `list_all_views` expected values embed `aux.v1/v2/v3`, and the file-scope setup proc opens with `ATTACH 'test.db2' AS aux`. The main-schema-only subset that could run also depends on schema-qualified `main.sqlite_master` (not yet resolvable) plus temp/main same-name `t1` coexistence under the shim's temp-table demotion.
- **`trigger1` residue (26)** — temp-table demotion artifacts (sections 1.8/3.x/4.x/6.x/8.x expect real session-scoped TEMP objects invisible to `sqlite_master` and to main-schema triggers) plus `trigger1-22.10` (temp vs main trigger name namespaces — needs per-schema trigger keying in the catalog).
- **`triggerC` residue (7)** — 5.1.7/5.2.7 (OR REPLACE conflict-deletion should fire each BEFORE DELETE trigger interleaved with its delete), 7.5-7.9 ("undefined behaviour" physical row-order after a BEFORE trigger mutates the target row), 16.1 (ORDER BY-term validation must precede the parser's RAISE-misuse rejection).

Part of #6176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)