### PR TITLE
fix(alter): rewrite trigger WHEN clause and NEW/OLD refs on RENAME COLUMN

### DIFF
--- a/crates/vibesql-ast/src/rename.rs
+++ b/crates/vibesql-ast/src/rename.rs
@@ -162,10 +162,21 @@ fn rename_walk(expr: &mut Expression, old: &str, new: &str, changed: &mut bool) 
                 rename_walk(msg, old, new, changed);
             }
         }
+        // A `NEW.<col>` / `OLD.<col>` pseudo-variable inside a trigger's WHEN
+        // condition references the trigger's subject table. When that table's
+        // column is renamed, the pseudo-variable's column must be rewritten too
+        // (index expressions never contain pseudo-variables, so this arm is
+        // inert for the index-metadata caller).
+        Expression::PseudoVariable { column, .. } => {
+            if column.eq_ignore_ascii_case(old) {
+                *column = new.to_string();
+                *changed = true;
+            }
+        }
         // Leaf / out-of-scope forms: literals, placeholders, wildcard,
-        // current date/time, DEFAULT, sequence refs, pseudo/session variables,
+        // current date/time, DEFAULT, sequence refs, session variables,
         // subqueries, EXISTS, and window functions carry no rewritable
-        // column reference for index metadata.
+        // column reference here.
         _ => {}
     }
 }
@@ -249,5 +260,36 @@ mod tests {
             }
             _ => unreachable!(),
         }
+    }
+
+    #[test]
+    fn renames_new_old_pseudo_variable_column() {
+        // `NEW.b < 0` — the pseudo-variable's column must be rewritten so a
+        // trigger WHEN condition tracks a RENAME COLUMN of its subject table.
+        let mut expr = Expression::BinaryOp {
+            op: BinaryOperator::LessThan,
+            left: Box::new(Expression::PseudoVariable {
+                pseudo_table: crate::expression::PseudoTable::New,
+                column: "B".to_string(),
+            }),
+            right: Box::new(Expression::Literal(SqlValue::Integer(0))),
+        };
+        assert!(rename_column_in_expression(&mut expr, "b", "d"));
+        match &expr {
+            Expression::BinaryOp { left, .. } => match left.as_ref() {
+                Expression::PseudoVariable { column, .. } => assert_eq!(column, "d"),
+                other => panic!("expected pseudo-variable, got {other:?}"),
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn leaves_unrelated_pseudo_variable_column_untouched() {
+        let mut expr = Expression::PseudoVariable {
+            pseudo_table: crate::expression::PseudoTable::Old,
+            column: "c".to_string(),
+        };
+        assert!(!rename_column_in_expression(&mut expr, "b", "d"));
     }
 }

--- a/crates/vibesql-executor/src/alter/table_options.rs
+++ b/crates/vibesql-executor/src/alter/table_options.rs
@@ -276,6 +276,12 @@ pub(super) fn rewrite_triggers_for_column_rename(
         let body_text = match &existing.triggered_action {
             TriggerAction::RawSql(sql) => sql.clone(),
         };
+        // The `NEW`/`OLD` pseudo-tables always alias the trigger's own subject
+        // table, so `new.<col>` / `old.<col>` references resolve to the renamed
+        // table only when this trigger fires on the renamed table. Gate the
+        // new/old rewrite on that (SQLite rewrites the WHEN clause and body
+        // `new.old_col` references for such triggers, e.g. altercol-3.x).
+        let subject_is_renamed = existing.table_name.eq_ignore_ascii_case(table);
         // An ambiguous unqualified reference to the renamed column aborts the
         // ALTER (SQLite: "error in trigger <name>: ambiguous column name: <col>").
         // Map the resolver error to that message, using `Other` so the verbatim
@@ -292,6 +298,7 @@ pub(super) fn rewrite_triggers_for_column_rename(
             old_column,
             new_column,
             &table_has_column,
+            subject_is_renamed,
         )
         .map_err(ambiguity_error)?;
         let new_sql_definition = existing
@@ -304,15 +311,37 @@ pub(super) fn rewrite_triggers_for_column_rename(
                     old_column,
                     new_column,
                     &table_has_column,
+                    subject_is_renamed,
                 )
             })
             .transpose()
             .map_err(ambiguity_error)?;
 
+        // The runtime WHEN condition is stored as a separate AST (evaluated per
+        // row, not re-parsed from the trigger text), so it must be rewritten in
+        // its own right. A WHEN clause can only reference the subject table's
+        // columns via `NEW`/`OLD`, so rewriting is unambiguous when the trigger
+        // fires on the renamed table (altercol-3.3).
+        let new_when_condition = if subject_is_renamed {
+            existing.when_condition.as_ref().map(|expr| {
+                let mut rewritten = expr.clone();
+                let changed = vibesql_ast::rename::rename_column_in_expression(
+                    &mut rewritten,
+                    old_column,
+                    new_column,
+                );
+                (rewritten, changed)
+            })
+        } else {
+            None
+        };
+
         let body_changed = new_body != body_text;
         let sql_def_changed = new_sql_definition.as_deref() != existing.sql_definition.as_deref();
+        let when_changed =
+            new_when_condition.as_ref().map(|(_, changed)| *changed).unwrap_or(false);
 
-        if !body_changed && !sql_def_changed {
+        if !body_changed && !sql_def_changed && !when_changed {
             continue;
         }
 
@@ -322,6 +351,11 @@ pub(super) fn rewrite_triggers_for_column_rename(
         }
         if sql_def_changed {
             updated.sql_definition = new_sql_definition;
+        }
+        if when_changed {
+            if let Some((rewritten, _)) = new_when_condition {
+                updated.when_condition = Some(rewritten);
+            }
         }
         pending_updates.push(updated);
     }
@@ -470,6 +504,8 @@ pub(super) fn rewrite_views_for_column_rename(
             old_column,
             new_column,
             &table_has_column,
+            // A view has no NEW/OLD pseudo-tables.
+            false,
         )
         .map_err(|col| {
             ExecutorError::Other(format!("error in view {}: ambiguous column name: {}", name, col))

--- a/crates/vibesql-executor/src/tests/alter_rename_column_triggers.rs
+++ b/crates/vibesql-executor/src/tests/alter_rename_column_triggers.rs
@@ -206,6 +206,76 @@ fn rename_column_ambiguous_in_trigger_aborts_and_leaves_schema_unchanged() {
 }
 
 #[test]
+fn rename_column_rewrites_new_old_refs_in_when_clause_and_body() {
+    // altercol.test 3.x: a trigger on the renamed table references the renamed
+    // column via the NEW/OLD pseudo-tables in both its WHEN clause and body.
+    // SQLite rewrites those references (the pseudo-tables alias the subject
+    // table). Prior to the fix, `WHEN new.y<0` and `SET x=new.y` were left
+    // stale, so the stored `CREATE TRIGGER` text and the runtime WHEN condition
+    // both still referenced the old column.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t4(x, y, z)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TRIGGER ttt AFTER INSERT ON t4 WHEN new.y<0 BEGIN \
+         UPDATE t4 SET x=new.y WHERE old.y IS NULL; END",
+    )
+    .unwrap();
+
+    exec(&mut db, "ALTER TABLE t4 RENAME y TO abc").unwrap();
+
+    // Stored verbatim CREATE TRIGGER: WHEN clause and NEW/OLD body refs rewritten.
+    let sql = trigger_sql(&db, "ttt");
+    assert!(sql.contains("WHEN new.abc<0"), "WHEN clause not rewritten: {sql}");
+    assert!(sql.contains("x=new.abc"), "NEW body ref not rewritten: {sql}");
+    assert!(sql.contains("old.abc IS NULL"), "OLD body ref not rewritten: {sql}");
+    assert!(!sql.contains(".y"), "stale reference to old column remains: {sql}");
+
+    // Runtime WHEN condition AST (evaluated per row, not re-parsed from text) is
+    // rewritten so the trigger fires without a "no such column: new.y" error.
+    use vibesql_ast::pretty_print::ToSql;
+    let when_sql = db
+        .catalog
+        .get_trigger("ttt")
+        .expect("trigger exists")
+        .when_condition
+        .as_ref()
+        .expect("WHEN condition preserved")
+        .to_sql();
+    assert!(
+        when_sql.to_ascii_lowercase().contains("abc"),
+        "runtime WHEN not rewritten: {when_sql}"
+    );
+    assert!(
+        !when_sql.to_ascii_lowercase().contains("new.y"),
+        "runtime WHEN still references old column: {when_sql}"
+    );
+}
+
+#[test]
+fn rename_column_leaves_new_old_refs_untouched_for_trigger_on_other_table() {
+    // A trigger whose subject table is NOT the renamed table has NEW/OLD
+    // pseudo-tables aliasing a different table, so a `new.<name>` reference must
+    // not be rewritten even if the name collides with the renamed column.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a, b)").unwrap();
+    exec(&mut db, "CREATE TABLE t2(a, c)").unwrap();
+    // Trigger fires on t2; NEW.a here is t2.a, unrelated to t1.a being renamed.
+    exec(
+        &mut db,
+        "CREATE TRIGGER g AFTER INSERT ON t2 WHEN new.a<0 BEGIN \
+         INSERT INTO t1 VALUES(new.a, new.c); END",
+    )
+    .unwrap();
+
+    exec(&mut db, "ALTER TABLE t1 RENAME a TO renamed").unwrap();
+
+    let sql = trigger_sql(&db, "g");
+    assert!(sql.contains("WHEN new.a<0"), "NEW.a on unrelated trigger must be untouched: {sql}");
+    assert!(sql.contains("new.a, new.c"), "unrelated NEW refs must be untouched: {sql}");
+}
+
+#[test]
 fn rename_column_unambiguous_still_succeeds_with_other_table_sharing_name() {
     // Guard against over-eager aborting: a qualified `t3.e` is unambiguous even
     // though t4 also owns `e`, so the ALTER must still succeed.

--- a/crates/vibesql-executor/src/trigger_rename.rs
+++ b/crates/vibesql-executor/src/trigger_rename.rs
@@ -215,12 +215,20 @@ fn is_table_position(
 /// in that case with `error in trigger <name>: ambiguous column name: <col>`
 /// and leaves the schema unchanged; the caller is responsible for surfacing
 /// that error and not committing the rename.
+///
+/// When `new_old_refer_to_renamed_table` is true, a `new.<col>` / `old.<col>`
+/// qualified reference is treated as belonging to the renamed table. This is
+/// correct only when the trigger's own subject table *is* the renamed table
+/// (the `NEW`/`OLD` pseudo-tables always alias the trigger's subject table), so
+/// the caller must gate it on that. Views and triggers on other tables pass
+/// `false` and leave `new.`/`old.` references untouched.
 pub fn rewrite_column_refs_in_trigger_sql(
     sql: &str,
     renamed_table: &str,
     old_column: &str,
     new_column: &str,
     table_has_column: &dyn Fn(&str, &str) -> bool,
+    new_old_refer_to_renamed_table: bool,
 ) -> Result<String, String> {
     let tokens = match Lexer::new(sql).tokenize_with_spans() {
         Ok(t) => t,
@@ -246,13 +254,17 @@ pub fn rewrite_column_refs_in_trigger_sql(
             let qual_idx = significant[pos - 2];
             if matches!(tokens[dot_idx].0, Token::Symbol('.')) {
                 if let Token::Identifier(qualifier) = &tokens[qual_idx].0 {
+                    let is_new_old_ref = new_old_refer_to_renamed_table
+                        && (qualifier.eq_ignore_ascii_case("new")
+                            || qualifier.eq_ignore_ascii_case("old"));
                     if name.eq_ignore_ascii_case(old_column)
-                        && qualifier_is_renamed_table(
-                            qualifier,
-                            renamed_table,
-                            paren_scope_at(&tokens, &significant, pos),
-                            &scopes,
-                        )
+                        && (is_new_old_ref
+                            || qualifier_is_renamed_table(
+                                qualifier,
+                                renamed_table,
+                                paren_scope_at(&tokens, &significant, pos),
+                                &scopes,
+                            ))
                     {
                         edits.push(tokens[idx].1);
                     }
@@ -559,12 +571,12 @@ mod tests {
     }
 
     fn rewrite_col(sql: &str, table: &str, old: &str, new: &str) -> String {
-        rewrite_column_refs_in_trigger_sql(sql, table, old, new, &altertrig_schema)
+        rewrite_column_refs_in_trigger_sql(sql, table, old, new, &altertrig_schema, true)
             .expect("rewrite should not be ambiguous in this fixture")
     }
 
     fn rewrite_col_result(sql: &str, table: &str, old: &str, new: &str) -> Result<String, String> {
-        rewrite_column_refs_in_trigger_sql(sql, table, old, new, &altertrig_schema)
+        rewrite_column_refs_in_trigger_sql(sql, table, old, new, &altertrig_schema, true)
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Part of the ALTER TABLE semantics family (**Part of #6174**). This lands one coherent slice: **RENAME COLUMN propagation into trigger `WHEN` clauses and `NEW`/`OLD` references** (altercol.test section 3).

`ALTER TABLE t RENAME COLUMN old TO new` already rewrites column references in a trigger's body and in dependent views/indexes/FKs, but it missed two spots when the trigger fires *on the renamed table*:

1. **Stored `CREATE TRIGGER` text** — a `WHEN new.old<0` clause (and `NEW.old` / `OLD.old` references anywhere in the text) was left stale, because the token-level rewriter did not recognize `NEW`/`OLD` as aliases of the renamed (subject) table.
2. **Runtime `when_condition` AST** — the WHEN condition is stored as a separate expression tree (evaluated per row, not re-parsed from the trigger text), so it kept resolving the old column and firing the trigger failed with `no such column: new.old`.

## Changes

- `trigger_rename.rs`: `rewrite_column_refs_in_trigger_sql` gains a `new_old_refer_to_renamed_table` flag; when set, `new.<col>` / `old.<col>` qualified references are treated as the renamed table.
- `alter/table_options.rs`: `rewrite_triggers_for_column_rename` computes `subject_is_renamed` (trigger's `table_name` == renamed table) and (a) passes it to the text rewriter for both the body and the verbatim `sql_definition`, and (b) rewrites the runtime `when_condition` AST. Views pass `false` (no `NEW`/`OLD`).
- `vibesql-ast/rename.rs`: `rename_column_in_expression` now also rewrites the `Expression::PseudoVariable { column, .. }` node (`NEW`/`OLD` column), which is inert for the existing index-metadata caller.
- Gating on the subject table prevents over-rewriting: a trigger on *another* table whose `NEW.<name>` happens to collide with the renamed column is left untouched (covered by a new test).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| RENAME COLUMN rewrites trigger `WHEN` clause (stored SQL) | ✅ | `make test-tcl-file FILE=altercol.test` — section 3.4 passes; new unit test `rename_column_rewrites_new_old_refs_in_when_clause_and_body` |
| RENAME COLUMN fixes runtime WHEN so trigger fires | ✅ | altercol-3.3 passes; unit test asserts rewritten `when_condition` AST |
| `NEW`/`OLD` body refs rewritten on subject-table rename | ✅ | Unit test asserts `x=new.abc` / `old.abc` in stored text |
| No over-rewrite of `NEW`/`OLD` on triggers for other tables | ✅ | New unit test `rename_column_leaves_new_old_refs_untouched_for_trigger_on_other_table` |
| No regressions | ✅ | `cargo test -p vibesql-executor -p vibesql-ast` all pass; `altertrig.test` stays 36/36 |

## Test Plan

- `altercol.test`: **168 → 177 passing** (+9); `altertrig.test`: **36/36** (unchanged).
- Added 4 unit tests (2 in `vibesql-ast/rename.rs`, 2 in the executor trigger-rename suite).
- Full `vibesql-executor` + `vibesql-ast` unit suites pass with no failures.

Note: `alter3.test` is a pre-existing flaky file (28–30 passing across runs, driven by `hexio_*` harness commands and cascading state); it is unaffected by this change, which is scoped to RENAME COLUMN trigger propagation.

Part of #6174