### PR TITLE
feat(storage): adaptive columnar dispatch + hotness-aware eviction

### DIFF
--- a/crates/vibesql-executor/src/select/scan/table.rs
+++ b/crates/vibesql-executor/src/select/scan/table.rs
@@ -43,8 +43,13 @@ use crate::{
     },
 };
 
-/// Minimum row count to benefit from SIMD columnar filtering
-/// Below this threshold, row-by-row filtering is faster due to conversion overhead
+/// Minimum row count to benefit from SIMD columnar filtering on a *native*
+/// `STORAGE COLUMNAR` table, whose typed columns are already resident (no
+/// conversion cost). Below this the row-by-row path wins.
+///
+/// #6199 Phase 2: this constant now gates only the native-columnar SIMD path.
+/// The row-oriented representation-cache path is gated by the adaptive,
+/// signal-driven `Database::should_use_columnar` instead of this bare row count.
 const SIMD_COLUMNAR_THRESHOLD: usize = 500;
 
 /// Apply SQL:1999 E051-09 column aliases to a table schema
@@ -904,11 +909,10 @@ pub(crate) fn execute_table_scan(
                 let all_rows = table.scan();
                 // sqlite_search_count: Track rows examined during table scan
                 database.increment_search_count(all_rows.len() as u64);
-                // Phase 1 of #6199: record this analytical (columnar-eligible)
-                // scan and its projected column width (measurement only — no
-                // behavior change). `schema.total_columns` is the scan's output
-                // column count.
-                database.record_scan(table_name, schema.total_columns as u64);
+                // #6199: record this analytical (columnar-eligible) scan. The
+                // recorded scan/point-lookup/write mix drives the Phase 2
+                // adaptive dispatch decision below (`should_use_columnar`).
+                database.record_scan(table_name);
 
                 if crate::profiling::is_scan_debug_enabled() {
                     eprintln!(
@@ -980,7 +984,15 @@ pub(crate) fn execute_table_scan(
                 // post-SIMD filter so that rows tombstoned by concurrent
                 // writers or written by uncommitted/future txns are not
                 // surfaced through the columnar fast path.
-                if all_rows.len() >= SIMD_COLUMNAR_THRESHOLD {
+                // #6199 Phase 2: adaptive, signal-driven dispatch replaces the
+                // former bare `all_rows.len() >= SIMD_COLUMNAR_THRESHOLD` gate.
+                // `should_use_columnar` keeps hot analytical tables on the
+                // columnar (representation-cache) path while leaving small,
+                // point-lookup-dominated, or write-thrashed tables on the row
+                // path (so they are never converted/cached). The scan was
+                // already recorded above via `record_scan`, so the decision
+                // reflects the current access pattern.
+                if database.should_use_columnar(table_name, all_rows.len()) {
                     if let Ok(mut filtered_rows) = filter_with_cached_columnar(
                         database,
                         table,

--- a/crates/vibesql-executor/tests/columnar_adaptive_dispatch_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_adaptive_dispatch_tests.rs
@@ -1,0 +1,120 @@
+//! Path-assertion + parity tests for #6199 Phase 2: adaptive columnar dispatch.
+//!
+//! The former dispatch gate for the row-table representation cache was a bare
+//! `all_rows.len() >= SIMD_COLUMNAR_THRESHOLD` row count. Phase 2 replaces it
+//! with `Database::should_use_columnar`, a purely *structural* decision driven
+//! by the per-table access signal (scan / point-lookup / write mix) — never by
+//! wall-clock timing (the benchmark machine is always loaded).
+//!
+//! These end-to-end tests drive the real executor scan path and assert on
+//! `columnar_cache_stats().conversions` (a structural stat, not a timer):
+//!   - a hot, scan-dominated large table takes the columnar path and is
+//!     converted + cached,
+//!   - a large table whose access is dominated by point lookups is NOT
+//!     converted (it stays on the row path),
+//!   - result parity: the adaptive columnar path returns byte-identical rows to
+//!     the row path forced by disabling the representation cache
+//!     (`columnar_cache_budget = 0`, the documented `VIBESQL_DISABLE_COLUMNAR=1`
+//!     parity lever for the representation cache).
+//!
+//! No wall-clock assertions anywhere.
+
+mod common;
+use common::{execute_sql, run_select};
+use vibesql_storage::{Database, DatabaseConfig};
+use vibesql_types::SqlValue;
+
+/// Rows to exceed the `MIN_COLUMNAR_ROWS` (500) floor comfortably.
+const N: i64 = 600;
+
+/// Create `table(id INTEGER PRIMARY KEY, v INTEGER)` with `N` rows; `v` cycles
+/// 0..100 so a `WHERE v >= k` predicate is columnar-foldable and selective.
+fn setup_big(db: &mut Database, table: &str) {
+    execute_sql(db, &format!("CREATE TABLE {table} (id INTEGER PRIMARY KEY, v INTEGER)"));
+    let mut ins = String::new();
+    for i in 0..N {
+        ins.push_str(&format!("INSERT INTO {table} VALUES ({i}, {});", i % 100));
+    }
+    execute_sql(db, &ins);
+}
+
+#[test]
+fn hot_analytical_table_takes_columnar_path() {
+    let mut db = Database::new();
+    setup_big(&mut db, "hot");
+    // Ignore the writes from bulk-loading; measure only the analytical scan.
+    db.reset_access_signals();
+
+    let before = db.columnar_cache_stats().conversions;
+    let rows = run_select(&db, "SELECT id FROM hot WHERE v >= 0 ORDER BY id");
+    assert_eq!(rows.len(), N as usize, "all rows satisfy v >= 0");
+    let after = db.columnar_cache_stats().conversions;
+
+    assert!(
+        after > before,
+        "a hot, scan-first large table must take the columnar path (convert + cache); \
+         conversions before={before} after={after}"
+    );
+}
+
+#[test]
+fn point_lookup_dominated_table_is_never_converted() {
+    let mut db = Database::new();
+    setup_big(&mut db, "cold");
+    db.reset_access_signals();
+
+    // Overwhelm the access signal with point lookups so the table is judged
+    // non-analytical: scans * SCAN_DOMINANCE_FACTOR will stay far below the
+    // point-lookup count even after the scan below records one scan.
+    for k in 0..1000 {
+        db.get_row_by_pk("cold", &SqlValue::Integer(k % N)).unwrap();
+    }
+
+    let before = db.columnar_cache_stats().conversions;
+    let rows = run_select(&db, "SELECT id FROM cold WHERE v >= 0 ORDER BY id");
+    assert_eq!(rows.len(), N as usize, "row path returns the same rows");
+    let after = db.columnar_cache_stats().conversions;
+
+    assert_eq!(
+        after, before,
+        "a point-lookup-dominated table must NOT be converted/cached (stays on the row path); \
+         conversions before={before} after={after}"
+    );
+}
+
+#[test]
+fn adaptive_columnar_result_parity_with_row_path() {
+    const QUERY: &str = "SELECT id, v FROM t WHERE v >= 37 ORDER BY id";
+
+    // Columnar path: fresh scan on a large table takes the adaptive columnar
+    // dispatch (default budget).
+    let mut columnar_db = Database::new();
+    setup_big(&mut columnar_db, "t");
+    columnar_db.reset_access_signals();
+    let conv_before = columnar_db.columnar_cache_stats().conversions;
+    let columnar_rows = run_select(&columnar_db, QUERY);
+    assert!(
+        columnar_db.columnar_cache_stats().conversions > conv_before,
+        "parity setup sanity: the columnar path must actually be taken"
+    );
+
+    // Row path: disable the representation cache (budget 0). `get_columnar`
+    // returns None, so the cached-columnar filter fails and the scan falls
+    // through to row-by-row filtering — the documented parity lever.
+    let mut cfg = DatabaseConfig::server_default();
+    cfg.columnar_cache_budget = 0;
+    let mut row_db = Database::with_config(cfg);
+    setup_big(&mut row_db, "t");
+    let row_rows = run_select(&row_db, QUERY);
+
+    assert_eq!(
+        columnar_rows, row_rows,
+        "adaptive columnar dispatch must return byte-identical rows to the row path"
+    );
+    // Guard: the row-path database must never have converted anything.
+    assert_eq!(
+        row_db.columnar_cache_stats().conversions,
+        0,
+        "budget=0 must fully disable the representation cache (no conversions)"
+    );
+}

--- a/crates/vibesql-executor/tests/table_access_signal_tests.rs
+++ b/crates/vibesql-executor/tests/table_access_signal_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! These verify the end-to-end plumbing of the measurement-only access signal
 //! through the real executor + storage paths:
-//!   - analytical scans increment `scan_count` and record projection width,
+//!   - analytical scans increment `scan_count`,
 //!   - point lookups increment `point_lookup_count`,
 //!   - writes increment `write_count` (including for a native-columnar table,
 //!     proving the increment fires before the `is_native_columnar` early-return),
@@ -75,13 +75,6 @@ fn test_scan_count_matches_number_of_analytical_scans() {
 
     let sig = db.table_access_signal("items").expect("items should have a signal");
     assert_eq!(sig.scan_count, n, "scan_count should equal number of analytical scans");
-    // Projection width is the scan's output column count (all 3 columns of items).
-    assert_eq!(sig.projection_width_n, n, "one width recorded per scan");
-    assert_eq!(
-        sig.avg_projection_width(),
-        Some(3.0),
-        "avg projection width = items column count (id, name, price)"
-    );
     // Scans must not be miscounted as writes/lookups.
     assert_eq!(sig.point_lookup_count, 0);
     assert_eq!(sig.write_count, 0);
@@ -193,6 +186,22 @@ fn test_two_tables_independent_and_case_insensitive() {
 
     // Case-insensitive accessor lookup.
     assert_eq!(db.table_access_signal("ITEMS"), db.table_access_signal("items"));
+}
+
+#[test]
+fn test_point_lookup_on_missing_table_creates_no_signal() {
+    // #6199 Phase 2 carry-forward: a point lookup on a non-existent table must
+    // return an error WITHOUT creating an empty signal entry (record_point_lookup
+    // now fires after the table-existence check).
+    let db = Database::new();
+
+    let result = db.get_row_by_pk("ghost", &SqlValue::Integer(1));
+    assert!(result.is_err(), "lookup on a non-existent table should error");
+    assert_eq!(
+        db.table_access_signal("ghost"),
+        None,
+        "a lookup on a missing table must not create a signal entry"
+    );
 }
 
 #[test]

--- a/crates/vibesql-storage/src/columnar_cache.rs
+++ b/crates/vibesql-storage/src/columnar_cache.rs
@@ -71,6 +71,15 @@ struct CacheEntry {
     data: Arc<ColumnarTable>,
     /// Size in bytes (cached to avoid recomputation)
     size_bytes: usize,
+    /// #6199 Phase 2: structural "hotness" of this table (higher = more
+    /// analytically hot). Computed from the per-table access signal by
+    /// `database::columnar_hotness` and refreshed on insert / access. Under
+    /// memory pressure the *coldest* resident entry is evicted first, so hot
+    /// analytical tables stay resident. `0` (the default supplied by the legacy
+    /// two-argument [`ColumnarCache::insert`]) makes eviction fall back to pure
+    /// LRU tie-breaking, preserving the historical behavior for callers that do
+    /// not supply a hotness.
+    hotness: u64,
 }
 
 /// LRU cache for columnar table representations
@@ -112,6 +121,56 @@ pub struct ColumnarCache {
     current_memory: RwLock<usize>,
     /// Cache statistics
     stats: RwLock<CacheStats>,
+}
+
+/// Evict the coldest resident entries until `size_bytes` fits within
+/// `max_memory`, or until only entries strictly hotter than `incoming_hotness`
+/// remain (#6199 Phase 2, hotness-aware eviction).
+///
+/// Victim selection is by lowest `hotness`, tie-broken toward the LRU end:
+/// `LruCache::iter` yields most- to least-recently-used, and the `<=`
+/// comparison lets a later (more-LRU) entry win a hotness tie. A resident entry
+/// strictly hotter than the incoming table's `incoming_hotness` is protected —
+/// eviction stops rather than displace hotter analytical data for a colder
+/// newcomer. The caller then admits the newcomer even if that leaves the cache
+/// over budget; the next insert reclaims it (bounded to budget + one entry).
+///
+/// Operates on already-acquired lock targets so it is shared between the native
+/// and wasm code paths.
+fn evict_coldest_to_fit(
+    cache: &mut lru::LruCache<String, CacheEntry>,
+    current_memory: &mut usize,
+    stats: &mut CacheStats,
+    size_bytes: usize,
+    max_memory: usize,
+    incoming_hotness: u64,
+) {
+    while *current_memory + size_bytes > max_memory {
+        // Find the coldest resident entry (tie-break toward LRU).
+        let mut victim_key: Option<String> = None;
+        let mut victim_hotness = u64::MAX;
+        for (k, entry) in cache.iter() {
+            if entry.hotness <= victim_hotness {
+                victim_hotness = entry.hotness;
+                victim_key = Some(k.clone());
+            }
+        }
+
+        match victim_key {
+            // Protect residents strictly hotter than the incoming table.
+            Some(_) if victim_hotness > incoming_hotness => break,
+            Some(key) => {
+                if let Some(evicted) = cache.pop(&key) {
+                    *current_memory = current_memory.saturating_sub(evicted.size_bytes);
+                    stats.evictions += 1;
+                } else {
+                    break;
+                }
+            }
+            // Cache empty — nothing left to evict.
+            None => break,
+        }
+    }
 }
 
 impl ColumnarCache {
@@ -173,20 +232,48 @@ impl ColumnarCache {
         }
     }
 
-    /// Insert or update a columnar table in the cache
+    /// Insert or update a columnar table in the cache (hotness-agnostic).
     ///
-    /// If the table is already cached, the existing entry is updated.
-    /// If inserting would exceed the memory budget, least recently used
-    /// entries are evicted until there's sufficient space.
+    /// Equivalent to [`ColumnarCache::insert_with_hotness`] with a hotness of
+    /// `0`, which makes eviction fall back to pure LRU tie-breaking. Retained
+    /// for callers (and tests) that have no access-pattern signal to supply;
+    /// the adaptive [`crate::database::Database::get_columnar`] path uses
+    /// `insert_with_hotness` so that hot analytical tables are protected under
+    /// memory pressure.
+    ///
+    /// # Returns
+    /// The Arc-wrapped columnar table (for immediate use)
+    pub fn insert(&self, table_name: &str, columnar: ColumnarTable) -> Arc<ColumnarTable> {
+        self.insert_with_hotness(table_name, columnar, 0)
+    }
+
+    /// Insert or update a columnar table in the cache with a structural
+    /// **hotness** (#6199 Phase 2).
+    ///
+    /// If the table is already cached, the existing entry is replaced. If
+    /// inserting would exceed the memory budget, the *coldest* resident entries
+    /// are evicted first (hotness-aware eviction, not pure LRU) until there is
+    /// room — but a resident entry strictly hotter than `hotness` is never
+    /// displaced by this colder newcomer. When only hotter residents remain the
+    /// incoming entry is still admitted (possibly over budget); the over-budget
+    /// condition self-corrects on the next insert (bounded to budget + one
+    /// entry), matching the historical "always admit" behavior.
+    ///
     /// Table names are normalized for case-insensitive matching.
     ///
     /// # Arguments
     /// * `table_name` - Name of the table
     /// * `columnar` - The columnar table data to cache
+    /// * `hotness` - Structural hotness from `database::columnar_hotness`
     ///
     /// # Returns
     /// The Arc-wrapped columnar table (for immediate use)
-    pub fn insert(&self, table_name: &str, columnar: ColumnarTable) -> Arc<ColumnarTable> {
+    pub fn insert_with_hotness(
+        &self,
+        table_name: &str,
+        columnar: ColumnarTable,
+        hotness: u64,
+    ) -> Arc<ColumnarTable> {
         let data = Arc::new(columnar);
 
         // #6199 Phase 0: a zero budget disables the representation cache. Never
@@ -213,19 +300,17 @@ impl ColumnarCache {
                 *current_memory = current_memory.saturating_sub(old_entry.size_bytes);
             }
 
-            // Evict until we have space (or cache is empty)
-            while *current_memory + size_bytes > self.max_memory {
-                if let Some((_, evicted)) = cache.pop_lru() {
-                    *current_memory = current_memory.saturating_sub(evicted.size_bytes);
-                    stats.evictions += 1;
-                } else {
-                    // Cache is empty, can't evict more
-                    break;
-                }
-            }
+            evict_coldest_to_fit(
+                &mut cache,
+                &mut current_memory,
+                &mut stats,
+                size_bytes,
+                self.max_memory,
+                hotness,
+            );
 
             // Insert new entry
-            let entry = CacheEntry { data: Arc::clone(&data), size_bytes };
+            let entry = CacheEntry { data: Arc::clone(&data), size_bytes, hotness };
             cache.put(key, entry);
             *current_memory += size_bytes;
             stats.conversions += 1;
@@ -242,25 +327,46 @@ impl ColumnarCache {
                 *current_memory = current_memory.saturating_sub(old_entry.size_bytes);
             }
 
-            // Evict until we have space (or cache is empty)
-            while *current_memory + size_bytes > self.max_memory {
-                if let Some((_, evicted)) = cache.pop_lru() {
-                    *current_memory = current_memory.saturating_sub(evicted.size_bytes);
-                    stats.evictions += 1;
-                } else {
-                    // Cache is empty, can't evict more
-                    break;
-                }
-            }
+            evict_coldest_to_fit(
+                &mut cache,
+                &mut current_memory,
+                &mut stats,
+                size_bytes,
+                self.max_memory,
+                hotness,
+            );
 
             // Insert new entry
-            let entry = CacheEntry { data: Arc::clone(&data), size_bytes };
+            let entry = CacheEntry { data: Arc::clone(&data), size_bytes, hotness };
             cache.put(key, entry);
             *current_memory += size_bytes;
             stats.conversions += 1;
         }
 
         data
+    }
+
+    /// Refresh the stored hotness of a cached table without disturbing its LRU
+    /// recency or the memory accounting (#6199 Phase 2). No-op if the table is
+    /// not resident. Called on cache hits so a table's eviction priority tracks
+    /// its evolving access pattern rather than the hotness captured at insert.
+    pub fn update_hotness(&self, table_name: &str, hotness: u64) {
+        let key = normalize_cache_key(table_name);
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let mut cache = self.cache.write();
+            if let Some(entry) = cache.peek_mut(&key) {
+                entry.hotness = hotness;
+            }
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            let mut cache = self.cache.write().unwrap();
+            if let Some(entry) = cache.peek_mut(&key) {
+                entry.hotness = hotness;
+            }
+        }
     }
 
     /// Invalidate a cached table entry

--- a/crates/vibesql-storage/src/database/access_signal.rs
+++ b/crates/vibesql-storage/src/database/access_signal.rs
@@ -3,9 +3,16 @@
 // ============================================================================
 //
 // A cheap, always-on per-table usage counter used to make the columnar
-// representation cache adaptive in a later phase (#6199, Phase 2). This module
-// only *observes* how each table is used; it changes no dispatch, promotion, or
-// eviction behavior. Phase 2 is the sole consumer.
+// representation cache adaptive. Phase 1 (#6199) added the counters as
+// measurement only; Phase 2 (`columnar_policy.rs`) is the sole consumer,
+// converting the scan / point-lookup / write mix into dispatch and hotness-
+// eviction decisions.
+//
+// #6199 Phase 2 note: a `projection_width` counter recorded here in Phase 1 was
+// removed. The scan hook only had the table's full arity (a per-table constant)
+// to record, not the real SELECT projection list, so the "average projection
+// width" it produced carried no projection information and no adaptive decision
+// consumed it. It was dropped rather than left as a misleading dead signal.
 //
 // The read/scan path operates on `&Database` (a shared immutable ref) and scans
 // tables `&self`, so the signal must use interior mutability — it must never be
@@ -52,11 +59,6 @@ pub(super) struct TableAccessSignal {
     pub(super) scan_count: AtomicU64,
     /// Primary-key / point lookups of the table.
     pub(super) point_lookup_count: AtomicU64,
-    /// Running sum of projected column counts across recorded scans.
-    pub(super) projection_width_sum: AtomicU64,
-    /// Number of scans that contributed to `projection_width_sum`, so the
-    /// average projection width can be derived.
-    pub(super) projection_width_n: AtomicU64,
     /// Writes (INSERT/UPDATE/DELETE/TRUNCATE/ALTER) routed through the DML
     /// invalidation funnel.
     pub(super) write_count: AtomicU64,
@@ -72,24 +74,8 @@ pub struct AccessSignalSnapshot {
     pub scan_count: u64,
     /// Primary-key / point lookups of the table.
     pub point_lookup_count: u64,
-    /// Running sum of projected column counts across recorded scans.
-    pub projection_width_sum: u64,
-    /// Number of scans that contributed to `projection_width_sum`.
-    pub projection_width_n: u64,
     /// Writes routed through the DML invalidation funnel.
     pub write_count: u64,
-}
-
-impl AccessSignalSnapshot {
-    /// Average projected column width across recorded scans, or `None` when no
-    /// scan has recorded a width yet.
-    pub fn avg_projection_width(&self) -> Option<f64> {
-        if self.projection_width_n == 0 {
-            None
-        } else {
-            Some(self.projection_width_sum as f64 / self.projection_width_n as f64)
-        }
-    }
 }
 
 // ----------------------------------------------------------------------------
@@ -155,13 +141,17 @@ impl Database {
         });
     }
 
-    /// Record one analytical scan of `table_name` with the given projected
-    /// column width (the scan's output column count).
-    pub fn record_scan(&self, table_name: &str, projection_width: u64) {
+    /// Record one analytical scan of `table_name`.
+    ///
+    /// #6199 Phase 2: the former `projection_width` parameter was dropped. The
+    /// scan hook only had access to the table's full arity (a per-table
+    /// constant), not the real SELECT projection list, so the recorded
+    /// "projection width" carried no projection information and was never
+    /// consumed by the adaptive policy. Rather than record a misleading
+    /// constant, the field was removed (see the module docs).
+    pub fn record_scan(&self, table_name: &str) {
         self.with_access_signal(table_name, |sig| {
             sig.scan_count.fetch_add(1, Ordering::Relaxed);
-            sig.projection_width_sum.fetch_add(projection_width, Ordering::Relaxed);
-            sig.projection_width_n.fetch_add(1, Ordering::Relaxed);
         });
     }
 
@@ -187,8 +177,6 @@ impl Database {
             map.get(&key).map(|sig| AccessSignalSnapshot {
                 scan_count: sig.scan_count.load(Ordering::Relaxed),
                 point_lookup_count: sig.point_lookup_count.load(Ordering::Relaxed),
-                projection_width_sum: sig.projection_width_sum.load(Ordering::Relaxed),
-                projection_width_n: sig.projection_width_n.load(Ordering::Relaxed),
                 write_count: sig.write_count.load(Ordering::Relaxed),
             })
         })
@@ -205,19 +193,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_scan_count_and_projection_width() {
+    fn test_scan_count() {
         let db = Database::new();
 
-        // Record N scans of table "T" with projection widths 2, 4, 6.
-        db.record_scan("T", 2);
-        db.record_scan("T", 4);
-        db.record_scan("T", 6);
+        // Record N scans of table "T".
+        db.record_scan("T");
+        db.record_scan("T");
+        db.record_scan("T");
 
         let sig = db.table_access_signal("T").expect("signal should exist after scans");
         assert_eq!(sig.scan_count, 3, "scan_count should equal number of scans");
-        assert_eq!(sig.projection_width_n, 3);
-        assert_eq!(sig.projection_width_sum, 12);
-        assert_eq!(sig.avg_projection_width(), Some(4.0), "avg width = mean of recorded widths");
         assert_eq!(sig.point_lookup_count, 0);
         assert_eq!(sig.write_count, 0);
     }
@@ -247,20 +232,11 @@ mod tests {
     }
 
     #[test]
-    fn test_avg_projection_width_none_when_no_scans() {
-        let db = Database::new();
-        db.record_point_lookup("t");
-
-        let sig = db.table_access_signal("t").expect("signal should exist");
-        assert_eq!(sig.avg_projection_width(), None, "no scans yet => no avg width");
-    }
-
-    #[test]
     fn test_tables_are_independent() {
         let db = Database::new();
 
-        db.record_scan("a", 3);
-        db.record_scan("a", 3);
+        db.record_scan("a");
+        db.record_scan("a");
         db.record_point_lookup("b");
 
         let a = db.table_access_signal("a").expect("a exists");
@@ -277,8 +253,8 @@ mod tests {
         let db = Database::new();
 
         // Mixed casing must all land on the same entry.
-        db.record_scan("Users", 2);
-        db.record_scan("users", 2);
+        db.record_scan("Users");
+        db.record_scan("users");
         db.record_point_lookup("USERS");
 
         let via_lower = db.table_access_signal("users").expect("exists");
@@ -298,7 +274,7 @@ mod tests {
     fn test_reset_access_signals() {
         let db = Database::new();
 
-        db.record_scan("t", 4);
+        db.record_scan("t");
         db.record_point_lookup("t");
         db.record_write("t");
         assert!(db.table_access_signal("t").is_some());
@@ -310,7 +286,7 @@ mod tests {
     #[test]
     fn test_clone_resets_signals() {
         let db = Database::new();
-        db.record_scan("t", 4);
+        db.record_scan("t");
 
         let cloned = db.clone();
         assert_eq!(

--- a/crates/vibesql-storage/src/database/cache.rs
+++ b/crates/vibesql-storage/src/database/cache.rs
@@ -57,8 +57,18 @@ impl Database {
             return Ok(None);
         }
 
+        // #6199 Phase 2: structural hotness for this table, used to protect hot
+        // analytical tables from eviction by colder newcomers. Derived from the
+        // per-table access signal (never wall-clock).
+        let hotness =
+            super::columnar_policy::columnar_hotness(self.table_access_signal(table_name));
+
         // Check cache first (for row-oriented tables)
         if let Some(cached) = self.columnar_cache.get(table_name) {
+            // Refresh the resident entry's eviction priority so it tracks the
+            // table's evolving access pattern rather than the hotness captured
+            // at first insert.
+            self.columnar_cache.update_hotness(table_name, hotness);
             return Ok(Some(cached));
         }
 
@@ -71,9 +81,27 @@ impl Database {
         // Convert to columnar format
         let columnar = table.scan_columnar()?;
 
-        // Insert into cache and return
-        let cached = self.columnar_cache.insert(table_name, columnar);
+        // Insert into cache (hotness-aware eviction) and return
+        let cached = self.columnar_cache.insert_with_hotness(table_name, columnar, hotness);
         Ok(Some(cached))
+    }
+
+    /// Structural (non-timing) decision — should a row-oriented table of
+    /// `row_count` rows use its columnar representation for an analytical scan?
+    ///
+    /// #6199 Phase 2: this replaces the executor's former hardcoded
+    /// `SIMD_COLUMNAR_THRESHOLD = 500` row-count-only gate. The decision is
+    /// driven purely by structural signals — the row count and the per-table
+    /// access-pattern signal (scan / point-lookup / write mix) — never by
+    /// wall-clock timing. Point-lookup-dominated and write-thrashed tables stay
+    /// on the row path even when large; hot analytical tables convert. See
+    /// [`crate::database::should_use_columnar`] for the exact policy.
+    ///
+    /// Native `STORAGE COLUMNAR` tables are authoritative and are handled by
+    /// their own always-resident path; this gate governs only the transparent
+    /// row-table representation cache.
+    pub fn should_use_columnar(&self, table_name: &str, row_count: usize) -> bool {
+        super::columnar_policy::should_use_columnar(row_count, self.table_access_signal(table_name))
     }
 
     /// Invalidate columnar cache entry for a table
@@ -437,6 +465,83 @@ mod tests {
         assert!(
             enabled.columnar_cache_stats().conversions > 0,
             "an enabled cache must record at least one conversion"
+        );
+    }
+
+    // ========================================================================
+    // #6199 Phase 2 — adaptive dispatch + hotness-aware eviction
+    // ========================================================================
+
+    /// Warm `count` identical 100-row tables through `get_columnar` on a fresh
+    /// generous-budget database and return the cached size of one table, so a
+    /// test can pick a budget that holds exactly one table.
+    fn one_table_cached_size() -> usize {
+        let mut db = Database::new(); // default (256MB) budget — nothing evicts
+        db.create_table(create_test_table_schema("probe")).unwrap();
+        for row in create_test_rows(100) {
+            db.insert_row("probe", row).unwrap();
+        }
+        db.get_columnar("probe").unwrap();
+        let sz = db.columnar_cache_memory_usage();
+        assert!(sz > 0, "probe table should occupy non-zero cache memory");
+        sz
+    }
+
+    /// Hotness-aware eviction (structural, never wall-clock): an analytically
+    /// hot table stays resident under cache pressure while a colder,
+    /// point-lookup-dominated newcomer is admitted without displacing it.
+    ///
+    /// With pure LRU (the pre-Phase-2 behavior) the newcomer would evict the
+    /// least-recently-used entry — the hot table — and the subsequent access to
+    /// the hot table would re-convert it. Here the hot table must instead be a
+    /// cache hit with no re-conversion, proving eviction is ordered by hotness.
+    #[test]
+    fn test_hot_analytical_table_survives_cache_pressure() {
+        // Budget holds exactly one table, so admitting a second forces the
+        // eviction path to run (and, here, to protect the hotter resident).
+        let mut config = crate::DatabaseConfig::server_default();
+        config.columnar_cache_budget = one_table_cached_size();
+        let mut db = Database::with_config(config);
+
+        for name in ["hot", "cold"] {
+            db.create_table(create_test_table_schema(name)).unwrap();
+            for row in create_test_rows(100) {
+                db.insert_row(name, row).unwrap();
+            }
+        }
+
+        // Structural access signal: `hot` is scan-dominated, `cold` is
+        // point-lookup-dominated. (Recorded directly — the executor records the
+        // same counters end-to-end; here we drive them to isolate the policy.)
+        for _ in 0..50 {
+            db.record_scan("hot");
+        }
+        for _ in 0..50 {
+            db.record_point_lookup("cold");
+        }
+
+        // Warm `hot` into the cache (one conversion, now resident).
+        db.get_columnar("hot").unwrap();
+
+        // Admit the cold newcomer. It is colder than the resident hot table, so
+        // hotness-aware eviction must NOT displace `hot` (it is admitted
+        // over-budget instead). This converts `cold`.
+        db.get_columnar("cold").unwrap();
+
+        // `hot` must still be resident: accessing it is a cache hit with no
+        // re-conversion. Under pure LRU it would have been evicted by the cold
+        // insert and re-converted here.
+        let before = db.columnar_cache_stats();
+        db.get_columnar("hot").unwrap();
+        let after = db.columnar_cache_stats();
+        assert_eq!(
+            after.conversions, before.conversions,
+            "hot analytical table must stay resident (no re-conversion) under cache pressure"
+        );
+        assert_eq!(
+            after.hits,
+            before.hits + 1,
+            "accessing the still-resident hot table must be a cache hit"
         );
     }
 

--- a/crates/vibesql-storage/src/database/columnar_policy.rs
+++ b/crates/vibesql-storage/src/database/columnar_policy.rs
@@ -1,0 +1,180 @@
+// ============================================================================
+// Adaptive Columnar Policy (Phase 2 of #6199)
+// ============================================================================
+//
+// This module is the *consumer* of the Phase 1 per-table access-pattern signal
+// (`access_signal.rs`). It converts structural observations — row count plus the
+// scan / point-lookup / write mix — into two decisions:
+//
+//   1. **Dispatch** (`should_use_columnar`): should a row-oriented table use its
+//      columnar representation for an analytical scan, or stay on the row path?
+//      This replaces the old hardcoded `SIMD_COLUMNAR_THRESHOLD = 500`
+//      row-count-only gate in the executor.
+//
+//   2. **Hotness** (`columnar_hotness`): a single scalar ordering cached tables
+//      by how analytically-hot they are, used by `ColumnarCache` to evict the
+//      *coldest* resident table under memory pressure instead of the merely
+//      least-recently-used one. Hot analytical tables therefore stay resident
+//      while colder tables are reclaimed first.
+//
+// ## Hard constraint: structural signals only, never wall-clock
+//
+// Per #6199, the benchmark machine is always loaded so measured latency is
+// untrustworthy. Every decision here is derived from *counts* (rows, scans,
+// point lookups, writes) — a heuristic cost model, not a measured one. This
+// keeps the policy deterministic and path-assertion-testable.
+
+use super::access_signal::AccessSignalSnapshot;
+
+/// Minimum row count below which columnar conversion is never worth it,
+/// regardless of how analytically the table is accessed. Below this the
+/// row-by-row path wins because the row→columnar conversion overhead dominates
+/// the SIMD scan savings. This preserves the semantics of the executor's
+/// former `SIMD_COLUMNAR_THRESHOLD = 500` constant for the row-oriented path.
+pub const MIN_COLUMNAR_ROWS: usize = 500;
+
+/// How many competing structural accesses (point lookups + writes) a single
+/// analytical scan "earns" before the table is judged non-analytical and kept
+/// on the row path. With a factor of 4 a table stays columnar-eligible as long
+/// as scans are at least ~20% of its competing point-lookup/write traffic.
+///
+/// This is deliberately lenient: a freshly-scanned large table (scans ≥ 1, no
+/// competing traffic yet) is columnar-eligible, matching the pre-Phase-2
+/// behavior where any large table took the columnar path on first scan. Only
+/// tables whose access is *dominated* by point lookups or writes are demoted.
+pub const SCAN_DOMINANCE_FACTOR: u64 = 4;
+
+/// Structural decision: should a row-oriented table of `row_count` rows use its
+/// columnar representation for an analytical scan?
+///
+/// Driven purely by structural signals (never wall-clock):
+///
+/// - Tables below [`MIN_COLUMNAR_ROWS`] always take the row path.
+/// - A large table with no recorded access history yet defaults to columnar
+///   (legacy behavior: a large table converted on its first analytical scan).
+/// - A large table with history is columnar-eligible unless its access is
+///   *dominated* by point lookups and/or writes — i.e. unless
+///   `scan_count * SCAN_DOMINANCE_FACTOR < point_lookups + writes`. Point-lookup
+///   -dominated and write-thrashed tables therefore stay on the row path and are
+///   never converted/cached.
+///
+/// Native `STORAGE COLUMNAR` tables are authoritative and are handled by their
+/// own always-resident path; this function is only consulted for the transparent
+/// row-table representation cache.
+pub fn should_use_columnar(row_count: usize, signal: Option<AccessSignalSnapshot>) -> bool {
+    if row_count < MIN_COLUMNAR_ROWS {
+        return false;
+    }
+    match signal {
+        // Large table, no access history yet → default to columnar.
+        None => true,
+        Some(sig) => {
+            let scans = sig.scan_count;
+            let competing = sig.point_lookup_count.saturating_add(sig.write_count);
+            // Analytical/hot iff scans account for a meaningful share of the
+            // structural accesses. Otherwise (point-lookup-dominated or
+            // write-thrashed) keep the row path.
+            scans.saturating_mul(SCAN_DOMINANCE_FACTOR) >= competing
+        }
+    }
+}
+
+/// Structural "hotness" of a cached table: higher means more analytically hot
+/// and therefore more worth keeping resident under memory pressure.
+///
+/// Defined as the net analytical pressure — scans discounted by competing
+/// point-lookup and write traffic — saturating at 0. A table scanned many times
+/// with little competing traffic is hot; a table with lots of competing traffic
+/// (even if occasionally scanned) is cold and is reclaimed first. This is the
+/// ordering key for [`crate::columnar_cache::ColumnarCache`]'s hotness-aware
+/// eviction; it never uses wall-clock time.
+pub fn columnar_hotness(signal: Option<AccessSignalSnapshot>) -> u64 {
+    match signal {
+        None => 0,
+        Some(sig) => {
+            let competing = sig.point_lookup_count.saturating_add(sig.write_count);
+            sig.scan_count.saturating_sub(competing)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn signal(scans: u64, lookups: u64, writes: u64) -> AccessSignalSnapshot {
+        AccessSignalSnapshot { scan_count: scans, point_lookup_count: lookups, write_count: writes }
+    }
+
+    #[test]
+    fn small_table_never_columnar() {
+        // Below the floor, no access pattern makes columnar worthwhile.
+        assert!(!should_use_columnar(0, None));
+        assert!(!should_use_columnar(MIN_COLUMNAR_ROWS - 1, None));
+        assert!(!should_use_columnar(MIN_COLUMNAR_ROWS - 1, Some(signal(1_000_000, 0, 0))));
+    }
+
+    #[test]
+    fn large_table_no_history_defaults_to_columnar() {
+        assert!(should_use_columnar(MIN_COLUMNAR_ROWS, None));
+        assert!(should_use_columnar(10_000, None));
+    }
+
+    #[test]
+    fn freshly_scanned_large_table_is_columnar() {
+        // scans=1, no competing traffic: the first analytical scan converts.
+        assert!(should_use_columnar(10_000, Some(signal(1, 0, 0))));
+    }
+
+    #[test]
+    fn hot_analytical_table_is_columnar() {
+        // Many scans, little competing traffic.
+        assert!(should_use_columnar(10_000, Some(signal(1000, 5, 2))));
+    }
+
+    #[test]
+    fn point_lookup_dominated_table_stays_row_path() {
+        // Occasional scan, overwhelmingly point lookups → not columnar.
+        assert!(!should_use_columnar(10_000, Some(signal(1, 1000, 0))));
+    }
+
+    #[test]
+    fn write_thrashed_table_stays_row_path() {
+        // Occasional scan, overwhelmingly writes → not columnar.
+        assert!(!should_use_columnar(10_000, Some(signal(2, 0, 1000))));
+    }
+
+    #[test]
+    fn boundary_of_dominance_factor() {
+        // scans * 4 == competing → still eligible (>=).
+        assert!(should_use_columnar(10_000, Some(signal(10, 40, 0))));
+        // one more competing access tips it over into row-path.
+        assert!(!should_use_columnar(10_000, Some(signal(10, 41, 0))));
+    }
+
+    #[test]
+    fn hotness_orders_hot_above_cold() {
+        let hot = columnar_hotness(Some(signal(1000, 0, 0)));
+        let warm = columnar_hotness(Some(signal(100, 0, 0)));
+        let cold = columnar_hotness(Some(signal(5, 0, 0)));
+        assert!(hot > warm, "more scans => hotter ({hot} vs {warm})");
+        assert!(warm > cold, "more scans => hotter ({warm} vs {cold})");
+    }
+
+    #[test]
+    fn hotness_discounts_competing_traffic() {
+        // Same scan count, but the one with competing traffic is colder.
+        let clean = columnar_hotness(Some(signal(100, 0, 0)));
+        let contended = columnar_hotness(Some(signal(100, 60, 30)));
+        assert!(clean > contended, "competing traffic lowers hotness");
+        assert_eq!(clean, 100);
+        assert_eq!(contended, 10); // 100 - (60 + 30)
+    }
+
+    #[test]
+    fn hotness_saturates_at_zero() {
+        // Competing traffic dwarfs scans → floor at 0 (never underflows).
+        assert_eq!(columnar_hotness(Some(signal(1, 100, 100))), 0);
+        assert_eq!(columnar_hotness(None), 0);
+    }
+}

--- a/crates/vibesql-storage/src/database/mod.rs
+++ b/crates/vibesql-storage/src/database/mod.rs
@@ -5,6 +5,7 @@
 mod access_signal;
 mod cache;
 mod change_events_api;
+mod columnar_policy;
 mod config;
 mod constructors;
 mod core;
@@ -27,6 +28,9 @@ pub mod transactions;
 mod tests;
 
 pub use access_signal::AccessSignalSnapshot;
+pub use columnar_policy::{
+    columnar_hotness, should_use_columnar, MIN_COLUMNAR_ROWS, SCAN_DOMINANCE_FACTOR,
+};
 pub use core::{Database, ExportedSpatialIndexMetadata as SpatialIndexMetadata};
 // The WAL recovery path (`wal::recovery`) shares the CreateTable schema-blob
 // layout with the emit path here; its tests round-trip through the real

--- a/crates/vibesql-storage/src/database/point_lookup.rs
+++ b/crates/vibesql-storage/src/database/point_lookup.rs
@@ -45,12 +45,14 @@ impl Database {
         table_name: &str,
         pk_value: &vibesql_types::SqlValue,
     ) -> Result<Option<&Row>, StorageError> {
-        // Phase 1 of #6199: record the point lookup (measurement only).
-        self.record_point_lookup(table_name);
-
         let table = self
             .get_table(table_name)
             .ok_or_else(|| StorageError::TableNotFound(table_name.to_string()))?;
+
+        // #6199: record the point lookup (measurement only), AFTER the
+        // table-existence check so a lookup on a non-existent table does not
+        // create an empty signal entry (Phase 2 carry-forward tidy).
+        self.record_point_lookup(table_name);
 
         let pk_index = table.primary_key_index().ok_or_else(|| {
             StorageError::Other(format!("Table '{}' has no primary key", table_name))
@@ -88,12 +90,14 @@ impl Database {
         pk_value: &vibesql_types::SqlValue,
         column_index: usize,
     ) -> Result<Option<&vibesql_types::SqlValue>, StorageError> {
-        // Phase 1 of #6199: record the point lookup (measurement only).
-        self.record_point_lookup(table_name);
-
         let table = self
             .get_table(table_name)
             .ok_or_else(|| StorageError::TableNotFound(table_name.to_string()))?;
+
+        // #6199: record the point lookup (measurement only), AFTER the
+        // table-existence check so a lookup on a non-existent table does not
+        // create an empty signal entry (Phase 2 carry-forward tidy).
+        self.record_point_lookup(table_name);
 
         // Validate column index
         if column_index >= table.schema.columns.len() {
@@ -136,12 +140,14 @@ impl Database {
         table_name: &str,
         pk_values: &[vibesql_types::SqlValue],
     ) -> Result<Option<&Row>, StorageError> {
-        // Phase 1 of #6199: record the point lookup (measurement only).
-        self.record_point_lookup(table_name);
-
         let table = self
             .get_table(table_name)
             .ok_or_else(|| StorageError::TableNotFound(table_name.to_string()))?;
+
+        // #6199: record the point lookup (measurement only), AFTER the
+        // table-existence check so a lookup on a non-existent table does not
+        // create an empty signal entry (Phase 2 carry-forward tidy).
+        self.record_point_lookup(table_name);
 
         let pk_index = table.primary_key_index().ok_or_else(|| {
             StorageError::Other(format!("Table '{}' has no primary key", table_name))


### PR DESCRIPTION
## Summary

Phase 2 of #6199 (adaptive columnar representation cache): replace the hardcoded, row-count-only columnar dispatch and the pure-LRU eviction with a **structural, signal-driven policy** — the first consumer of the Phase 1 per-table access signal. Hot analytical tables promote and stay resident under cache pressure; write-thrashed or point-lookup-dominated tables never bother converting.

Every decision is derived from **counts only** (rows, scans, point lookups, writes) — never measured latency/wall-clock (this machine's timings are untrustworthy).

## Changes

- **New `database::columnar_policy` module** (the Phase 1 signal's first consumer):
  - `should_use_columnar(row_count, signal)` — dispatch. Tables below `MIN_COLUMNAR_ROWS` (500) always take the row path; a large table with no history defaults to columnar (legacy first-scan behavior); a large table is demoted to the row path only when its access is *dominated* by point lookups/writes (`scans * SCAN_DOMINANCE_FACTOR < point_lookups + writes`).
  - `columnar_hotness(signal)` — a scalar (net analytical pressure = scans discounted by competing traffic, saturating at 0) that orders resident tables for eviction.
- **Executor scan path** (`select/scan/table.rs`) now dispatches the row-table representation-cache path via `Database::should_use_columnar` instead of the bare `all_rows.len() >= SIMD_COLUMNAR_THRESHOLD`. The constant is retained **only** for the native-columnar SIMD path (always-resident typed columns).
- **`ColumnarCache`** gains `insert_with_hotness` + hotness-aware eviction (`evict_coldest_to_fit`, which evicts the coldest resident and never displaces a resident strictly hotter than the newcomer) and `update_hotness` on cache hits. Legacy `insert` maps to hotness `0` (pure-LRU tie-break) for callers with no signal.
- **`Database::get_columnar`** derives hotness from the access signal, protects hot residents under memory pressure, and refreshes a resident's hotness on hit.

### Phase 1 carry-forward items (both mandated by the Phase 1 merge comment)

1. **Dead `projection_width` signal dropped.** The scan hook only had the table's constant arity (`schema.total_columns`) to record, so `avg_projection_width()` carried no projection information and no adaptive decision consumed it. Removed the field/method and the `record_scan` parameter rather than leave a misleading dead signal (option b).
2. **`record_point_lookup` reordered.** Now fires *after* the table-existence check in all three point-lookup methods, so a lookup on a non-existent table no longer creates an empty signal entry.

Preserves Phase 0 semantics: `columnar_cache_budget = 0` still fully disables the cache. Phase 3 (incremental maintenance across writes / `invalidate()`) is intentionally untouched.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Structural signals only, never wall-clock | ✅ | Policy consumes only `scan/point_lookup/write` counts + row count; no timers anywhere |
| Hot analytical table stays on columnar path under cache pressure | ✅ | `test_hot_analytical_table_survives_cache_pressure` (storage): budget holds one table; the hot resident survives a colder newcomer's admission — accessing it is a cache hit with no re-conversion (pure LRU would have evicted+reconverted it) |
| Point-lookup-dominated table is not converted | ✅ | `point_lookup_dominated_table_is_never_converted` (executor, end-to-end): 1000 point lookups then an analytical scan → `conversions` delta is 0 (row path taken) |
| Hot large table converts on the columnar path | ✅ | `hot_analytical_table_takes_columnar_path` (executor): fresh analytical scan → `conversions` increments |
| Result parity vs disabled cache (row path) | ✅ | `adaptive_columnar_result_parity_with_row_path`: adaptive columnar path returns byte-identical rows to the row path forced by `columnar_cache_budget = 0` (the documented `VIBESQL_DISABLE_COLUMNAR=1` parity lever for the representation cache) |
| Phase 0 budget=0 still disables cache | ✅ | Existing `test_columnar_cache_budget_zero_disables_and_forces_row_path` still green |
| Carry-forward 1: no adaptive decision on the constant | ✅ | `projection_width` field + `record_scan` param removed; policy unit tests use only scan/lookup/write |
| Carry-forward 2: no signal entry for missing-table lookup | ✅ | `test_point_lookup_on_missing_table_creates_no_signal` (executor) |

## Test Plan

- `cargo test -p vibesql-storage --lib` — **826 passed, 0 failed** (includes new `columnar_policy` unit tests, hotness-eviction test, updated `access_signal` tests).
- `cargo test -p vibesql-executor` — **712 passed, 0 failed** across 60 test binaries (includes new `columnar_adaptive_dispatch_tests` and updated `table_access_signal_tests`).
- `cargo clippy` / `cargo fmt --check` on both crates: no new warnings or formatting diffs in touched files (pre-existing warnings/format diffs in untouched files left as-is per scope discipline).

Part of #6199