### PR TITLE
conformance(tcl): window-chaining override validation + FILTER/frame edge cases (Part of #6191)

### DIFF
--- a/crates/vibesql-executor/src/evaluator/window/frames.rs
+++ b/crates/vibesql-executor/src/evaluator/window/frames.rs
@@ -145,6 +145,10 @@ fn evaluate_offset_expr(expr: &Expression) -> Result<Option<f64>, String> {
         Expression::Literal(SqlValue::Real(f)) => Ok(Some(*f)),
         Expression::Literal(SqlValue::Double(f)) => Ok(Some(*f)),
         Expression::Literal(SqlValue::Numeric(f)) => Ok(Some(*f)),
+        // SQLite coerces boolean literals to their numeric value (true -> 1,
+        // false -> 0) when used as a frame offset (window1 30.0:
+        // `RANGE BETWEEN 5.2 PRECEDING AND true PRECEDING`).
+        Expression::Literal(SqlValue::Boolean(b)) => Ok(Some(if *b { 1.0 } else { 0.0 })),
         Expression::Literal(SqlValue::Null) => {
             // NULL is treated as invalid (not a number)
             Ok(None)

--- a/crates/vibesql-executor/src/evaluator/window/tests/frames.rs
+++ b/crates/vibesql-executor/src/evaluator/window/tests/frames.rs
@@ -286,3 +286,17 @@ fn test_validate_frame_valid_specs_accepted() {
     // Single CURRENT ROW bound
     assert!(validate_frame(&frame(FrameUnit::Rows, FrameBound::CurrentRow, None)).is_ok());
 }
+
+// SQLite coerces boolean literals to their numeric value (`true` -> 1, `false`
+// -> 0) when they appear as a frame offset. Previously VibeSQL rejected a
+// boolean offset as "frame ending offset must be a non-negative integer"
+// (window1 30.0: `RANGE BETWEEN 5.2 PRECEDING AND true PRECEDING`).
+#[test]
+fn test_validate_frame_boolean_offset_accepted() {
+    let bool_bound =
+        |b: bool| FrameBound::Preceding(Box::new(Expression::Literal(SqlValue::Boolean(b))));
+    // BETWEEN 5 PRECEDING AND true PRECEDING (true -> 1, non-negative, accepted)
+    assert!(validate_frame(&frame(FrameUnit::Rows, preceding(5), Some(bool_bound(true)))).is_ok());
+    // BETWEEN 5 PRECEDING AND false PRECEDING (false -> 0, likewise valid)
+    assert!(validate_frame(&frame(FrameUnit::Rows, preceding(5), Some(bool_bound(false)))).is_ok());
+}

--- a/crates/vibesql-executor/src/select/executor/aggregation/window.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/window.rs
@@ -369,6 +369,41 @@ fn build_window_map(
     Ok(resolved_map)
 }
 
+/// Enforce the SQL:2011 restrictions on a window spec that references a base
+/// window by name. See the sibling implementation in
+/// `select::window::collection::validate_window_override` for the rationale;
+/// duplicated here because this GROUP BY window path resolves specs
+/// independently of the non-aggregate window path.
+fn validate_window_override(
+    base_name: &str,
+    spec: &WindowSpec,
+    base_spec: &WindowSpec,
+) -> Result<(), ExecutorError> {
+    if spec.partition_by.is_some() {
+        return Err(ExecutorError::Other(format!(
+            "cannot override PARTITION clause of window: {}",
+            base_name
+        )));
+    }
+    if spec.order_by.is_some() && base_spec.order_by.is_some() {
+        return Err(ExecutorError::Other(format!(
+            "cannot override ORDER BY clause of window: {}",
+            base_name
+        )));
+    }
+    // Only a chaining reference (one that adds a clause) may not target a framed
+    // base window; a bare `OVER win` uses the base as-is and is always legal.
+    let is_chaining =
+        spec.partition_by.is_some() || spec.order_by.is_some() || spec.frame.is_some();
+    if is_chaining && base_spec.frame.is_some() {
+        return Err(ExecutorError::Other(format!(
+            "cannot override frame specification of window: {}",
+            base_name
+        )));
+    }
+    Ok(())
+}
+
 /// Recursively resolve a window spec, handling inheritance chains
 fn resolve_window_spec_recursive(
     spec: &WindowSpec,
@@ -385,6 +420,8 @@ fn resolve_window_spec_recursive(
             } else {
                 return Err(ExecutorError::Other(format!("no such window: {}", base_name)));
             };
+
+            validate_window_override(base_name, spec, &base_spec)?;
 
             Ok(WindowSpec {
                 base_window_name: None,
@@ -407,6 +444,8 @@ fn resolve_window_spec(
             let base_spec = window_map
                 .get(&base_name.to_lowercase())
                 .ok_or_else(|| ExecutorError::Other(format!("no such window: {}", base_name)))?;
+
+            validate_window_override(base_name, spec, base_spec)?;
 
             Ok(WindowSpec {
                 base_window_name: None,

--- a/crates/vibesql-executor/src/select/window/collection.rs
+++ b/crates/vibesql-executor/src/select/window/collection.rs
@@ -29,6 +29,46 @@ fn build_window_map(
     Ok(resolved_map)
 }
 
+/// Enforce the SQL:2011 restrictions on a window spec that references a base
+/// window by name (`OVER (base ...)` or `WINDOW w AS (base ...)`).
+///
+/// Mirrors SQLite's `sqlite3WindowChain`: a referencing window may not add a
+/// `PARTITION BY` clause, may add an `ORDER BY` only if the base has none, and
+/// may not reference a base that itself carries an explicit frame
+/// specification. Checks are ordered PARTITION -> ORDER BY -> frame to match
+/// SQLite's diagnostic precedence.
+pub(super) fn validate_window_override(
+    base_name: &str,
+    spec: &WindowSpec,
+    base_spec: &WindowSpec,
+) -> Result<(), ExecutorError> {
+    if spec.partition_by.is_some() {
+        return Err(ExecutorError::Other(format!(
+            "cannot override PARTITION clause of window: {}",
+            base_name
+        )));
+    }
+    if spec.order_by.is_some() && base_spec.order_by.is_some() {
+        return Err(ExecutorError::Other(format!(
+            "cannot override ORDER BY clause of window: {}",
+            base_name
+        )));
+    }
+    // The frame restriction only applies to a *chaining* reference — one that
+    // adds a clause of its own (`OVER (win ORDER BY x)` / `WINDOW w2 AS (win
+    // ...)`). A bare direct reference (`OVER win`) uses the base window as-is,
+    // frame included, and is always legal (window1 7.4, 10.5, 10.6, 27.2).
+    let is_chaining =
+        spec.partition_by.is_some() || spec.order_by.is_some() || spec.frame.is_some();
+    if is_chaining && base_spec.frame.is_some() {
+        return Err(ExecutorError::Other(format!(
+            "cannot override frame specification of window: {}",
+            base_name
+        )));
+    }
+    Ok(())
+}
+
 /// Recursively resolve a window spec, handling inheritance chains
 fn resolve_window_spec_recursive(
     spec: &WindowSpec,
@@ -48,6 +88,8 @@ fn resolve_window_spec_recursive(
             } else {
                 return Err(ExecutorError::Other(format!("no such window: {}", base_name)));
             };
+
+            validate_window_override(base_name, spec, &base_spec)?;
 
             // Merge: inherit from base, override with any values from current spec
             Ok(WindowSpec {
@@ -72,6 +114,8 @@ fn resolve_window_spec(
             let base_spec = window_map
                 .get(&base_name.to_lowercase())
                 .ok_or_else(|| ExecutorError::Other(format!("no such window: {}", base_name)))?;
+
+            validate_window_override(base_name, spec, base_spec)?;
 
             // Merge: inherit from base, override with any values from current spec
             Ok(WindowSpec {
@@ -259,4 +303,90 @@ fn collect_from_expression(
         _ => {}
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use vibesql_ast::{
+        Expression, FrameBound, FrameUnit, OrderByItem, OrderDirection, WindowFrame,
+    };
+    use vibesql_types::SqlValue;
+
+    use super::*;
+
+    fn order_by() -> Option<Vec<OrderByItem>> {
+        Some(vec![OrderByItem {
+            expr: Expression::Literal(SqlValue::Integer(1)),
+            direction: OrderDirection::Asc,
+            nulls_order: None,
+        }])
+    }
+
+    fn framed() -> Option<WindowFrame> {
+        Some(WindowFrame {
+            unit: FrameUnit::Rows,
+            start: FrameBound::Preceding(Box::new(Expression::Literal(SqlValue::Integer(1)))),
+            end: Some(FrameBound::Following(Box::new(Expression::Literal(SqlValue::Integer(1))))),
+            exclude: None,
+        })
+    }
+
+    fn spec(
+        base: Option<&str>,
+        partition: Option<Vec<Expression>>,
+        order: Option<Vec<OrderByItem>>,
+        frame: Option<WindowFrame>,
+    ) -> WindowSpec {
+        WindowSpec {
+            base_window_name: base.map(str::to_string),
+            partition_by: partition,
+            order_by: order,
+            frame,
+        }
+    }
+
+    // window1 18.1.3 / 18.2.3: a window referencing a base may not add PARTITION BY.
+    #[test]
+    fn override_partition_rejected() {
+        let referencing = spec(Some("win1"), Some(vec![Expression::Literal(SqlValue::Integer(1))]), None, None);
+        let base = spec(None, None, None, None);
+        let err = validate_window_override("win1", &referencing, &base).unwrap_err();
+        assert_eq!(err.to_string(), "cannot override PARTITION clause of window: win1");
+    }
+
+    // window1 18.1.4 / 18.2.4: adding ORDER BY when the base already has one is rejected.
+    #[test]
+    fn override_order_by_rejected() {
+        let referencing = spec(Some("win1"), None, order_by(), None);
+        let base = spec(None, None, order_by(), None);
+        let err = validate_window_override("win1", &referencing, &base).unwrap_err();
+        assert_eq!(err.to_string(), "cannot override ORDER BY clause of window: win1");
+    }
+
+    // window1 18.1.1 / 18.2.1: chaining onto a base that carries an explicit frame is rejected.
+    #[test]
+    fn override_frame_rejected_for_chaining() {
+        let referencing = spec(Some("win1"), None, order_by(), None);
+        let base = spec(None, None, None, framed());
+        let err = validate_window_override("win1", &referencing, &base).unwrap_err();
+        assert_eq!(err.to_string(), "cannot override frame specification of window: win1");
+    }
+
+    // window1 7.4 / 10.5: a bare `OVER win` reference (adds no clause) uses the
+    // framed base as-is and must NOT trip the frame-override guard.
+    #[test]
+    fn bare_reference_to_framed_base_allowed() {
+        let referencing = spec(Some("win"), None, None, None);
+        let base = spec(None, None, order_by(), framed());
+        assert!(validate_window_override("win", &referencing, &base).is_ok());
+    }
+
+    // window1 18.3.x: adding ORDER BY to a base that has only PARTITION BY (no
+    // ORDER BY, no frame) is the canonical legal chaining case.
+    #[test]
+    fn adding_order_by_to_partition_only_base_allowed() {
+        let referencing = spec(Some("win1"), None, order_by(), None);
+        let base = spec(None, Some(vec![Expression::Literal(SqlValue::Integer(1))]), None, None);
+        assert!(validate_window_override("win1", &referencing, &base).is_ok());
+    }
 }

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -479,6 +479,18 @@ impl Parser {
             // Validate argument count for window functions
             self.validate_window_function_args(&function_name_upper, args.len(), &first)?;
 
+            // FILTER is only meaningful on *aggregate* window functions. The
+            // ranking (ROW_NUMBER, RANK, ...) and value (LAG, LEAD, NTH_VALUE,
+            // ...) window functions reject it. SQLite: `lag(x) FILTER (WHERE ..)
+            // OVER w` -> "FILTER clause may only be used with aggregate window
+            // functions" (window1 6.3).
+            if filter.is_some() && self.is_window_only_function(&function_name_upper) {
+                return Err(ParseError {
+                    message: "FILTER clause may only be used with aggregate window functions"
+                        .to_string(),
+                });
+            }
+
             // Parse window specification
             let window_spec = self.parse_window_spec()?;
 

--- a/crates/vibesql-parser/src/tests/window_functions.rs
+++ b/crates/vibesql-parser/src/tests/window_functions.rs
@@ -284,6 +284,29 @@ fn test_value_functions() {
     assert!(result.is_ok());
 }
 
+// window1 6.3: FILTER is only valid on aggregate window functions. A ranking or
+// value window function with a FILTER clause is a parse error, matching SQLite's
+// "FILTER clause may only be used with aggregate window functions".
+#[test]
+fn test_filter_on_non_aggregate_window_rejected() {
+    for sql in [
+        "SELECT lag(x) FILTER (WHERE (x%2)=0) OVER w FROM t1 WINDOW w AS (ORDER BY x)",
+        "SELECT row_number() FILTER (WHERE x>0) OVER (ORDER BY x) FROM t1",
+        "SELECT rank() FILTER (WHERE x>0) OVER (ORDER BY x) FROM t1",
+    ] {
+        let err = Parser::parse_sql(sql).expect_err(sql);
+        assert_eq!(
+            err.message, "FILTER clause may only be used with aggregate window functions",
+            "sql: {sql}"
+        );
+    }
+
+    // FILTER on an *aggregate* window function stays valid.
+    assert!(
+        Parser::parse_sql("SELECT sum(x) FILTER (WHERE x>0) OVER (ORDER BY x) FROM t1").is_ok()
+    );
+}
+
 #[test]
 fn test_complex_window_spec() {
     let sql = "SELECT RANK() OVER (PARTITION BY dept ORDER BY salary DESC ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM t";

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -564,6 +564,14 @@ proc translate_error_to_sqlite {vibesql_error} {
         return $parse_msg
     }
 
+    # FILTER on a ranking/value window function (window1-6.3) — SQLite returns
+    # this message verbatim, not wrapped in "near ...: syntax error". The
+    # optional `Parse error:` prefix is handled the same way as above (idempotent
+    # across execsql's/catchsql's double translation).
+    if {[regexp -nocase {^(?:Parse error: )?(FILTER clause may only be used with aggregate window functions)$} $error_msg -> parse_msg]} {
+        return $parse_msg
+    }
+
     # Legacy: Aggregate in ORDER BY context (for old error messages)
     if {[regexp -nocase {aggregate.*ORDER BY|ORDER BY.*aggregate} $error_msg]} {
         if {[regexp -nocase {(min|max|sum|avg|count)} $error_msg -> func_name]} {
@@ -5747,19 +5755,11 @@ proc uses_sqlite_internals {script} {
         return [list 1 "uses sqlite_exec() (SQLite internal)"]
     }
 
-    # Named WINDOW clause - SQL:2003 feature not yet supported in VibeSQL
-    # Pattern: WINDOW name AS (...) in SELECT statements
-    # Example: SELECT sum(x) OVER win FROM t WINDOW win AS (ORDER BY y)
-    if {[regexp -nocase {WINDOW\s+\w+\s+AS\s*\(} $script]} {
-        return [list 1 "uses named WINDOW clause (not yet supported)"]
-    }
-    # Also detect OVER <name> without parentheses (references a named window)
-    # Example: sum(x) OVER win
-    # But avoid false positives with OVER ( - the normal inline window spec
-    if {[regexp -nocase {OVER\s+[a-zA-Z_]\w*(?:\s|$|,|\))} $script] &&
-        ![regexp -nocase {OVER\s*\(} $script]} {
-        return [list 1 "uses named window reference (not yet supported)"]
-    }
+    # Note: the named WINDOW clause (WINDOW win AS (...)) and named window
+    # references (sum(x) OVER win, including window chaining WINDOW w2 AS (w1 ...))
+    # ARE supported by VibeSQL's parser + executor. The skips that previously
+    # matched these patterns were removed when the runtime support landed
+    # (#6191); do not re-add them.
 
     # Unsupported window functions
     # total() as window function - note: total() as aggregate IS supported


### PR DESCRIPTION
## Summary

`Part of #6191` (partial increment — leaves documented residuals for follow-up).

VibeSQL already supports named `WINDOW` clauses and named-window references end to end, but the TCL shim was still **skipping** every test that used them (two `uses_sqlite_internals` regexes). This PR removes those skips so the named-window conformance tests actually run, then fixes the real semantic gaps the un-hiding exposes.

### Engine/parser fixes

1. **Window-chaining override validation** (window1 18.1.1 / 18.1.3 / 18.1.4 / 18.2.1 / 18.2.3 / 18.2.4 — 6 tests). A window referencing a base window by name may not add a `PARTITION BY`, may add an `ORDER BY` only when the base has none, and may not chain onto a base that carries an explicit frame. Mirrors SQLite's `sqlite3WindowChain` diagnostic order (PARTITION → ORDER BY → frame). A bare `OVER win` reference (adds no clause) still uses a framed base as-is and is intentionally exempt from the frame guard (window1 7.4/10.5/10.6/27.2 confirm no false positives). Applied at both window-resolution sites (`select/window/collection.rs` non-aggregate path and `select/executor/aggregation/window.rs` GROUP BY path).

2. **FILTER on a non-aggregate window function** (window1 6.3). `lag(x) FILTER (WHERE ...) OVER w` now errors `FILTER clause may only be used with aggregate window functions` instead of silently dropping the FILTER; shim passes the message through verbatim.

3. **Boolean literal as a frame offset** (window1 30.0). `RANGE BETWEEN 5.2 PRECEDING AND true PRECEDING` now coerces `true`/`false` to 1/0 like SQLite, instead of rejecting it as `frame ending offset must be a non-negative integer`.

### Fresh-build per-file failure counts (`./scripts/tcltest test`, fresh `cargo build --release`)

Baseline is current `origin/main` (which **skips** the named-window tests); "after" is this branch (which **runs** them):

| File | Before (pass / fail / skip) | After (pass / fail / skip) |
| --- | --- | --- |
| filter1 | 34 / 1 / 0 | 34 / 1 / 0 |
| filter2 | 16 / 0 / 0 | 16 / 0 / 0 |
| window1 | 271 / 0 / 76 | **315 / 6 / 26** |
| window5 | 0 / 0 / 1 (Bucket-A) | 0 / 0 / 1 (Bucket-A) |
| window6 | 43 / 0 / 27 | **62 / 5 / 3** |
| windowfault | 0 / 0 / 1 (Bucket-A) | 0 / 0 / 1 (Bucket-A) |

Net for the named files: **+63 passing tests**, at the cost of un-hiding 11 real failures (8 of which were the targets fixed above — 18.x×6, 6.3, 30.0). window1 went 14 exposed → **6 residual**; window6 exposed 5.

### Corpus blast radius of the shim un-skip (verified by isolation)

The shim change is global, so I ran every non-window file that uses named windows and isolated the effect. Only two additional window-family files are affected, both net-positive:

- **windowB**: +17 passing, +1 newly-visible failure (4.2 — error-message format `ColumnNotFound{…}` vs `no such column`, not window-specific).
- **windowE**: +2 passing, +2 newly-visible failures (1.3 group_concat result; 2.1 `x_count` custom-UDF — a Bucket-A #5720 straddler).

Files with named windows that were unaffected / stayed green: window2/3/7/9 (100%), percentile (100%), windowerr (100%), altertab*. `with2` (6 fail) and `altertab3` (1 fail) were verified **identical with and without the shim change** (pre-existing, not named-window related).

### Documented residuals (left visibly failing — out of the frame/FILTER theme, for follow-up)

- **window1 52.2/52.3/52.4**: multi-window, no top-level ORDER BY — output **row order** differs (per-row window values are all correct). Known limitation #5291.
- **window1 29.2**: float formatting `6.0` vs `6` (numeric affinity of a VALUES-inserted integer), not a frame bug.
- **window1 8.1.2 / window6 10.0 / window8 8.4**: named-window definitions not preserved through a VIEW / CTE (`no such window`) — CTE/view plumbing, separate subsystem.
- **window1 67.1**: view error precedence (`no such table` vs ORDER-BY-term).
- **window6 1.5.3 / 5.2 / 5.3 / 5.4**: `OVER`/`WINDOW`/`FILTER` used as table names / aliases / columns — reserved-keyword-as-identifier parser edge cases (deferred to avoid broad grammar-regression risk).
- **windowB 4.2 / windowE 1.3 / windowE 2.1**: out-of-scope files; windowE 2.1 is a custom-UDF Bucket-A candidate.

### Tests

- New Rust regression tests: window-override rules (`select/window/collection.rs`), FILTER-on-non-aggregate parse error (`vibesql-parser`), boolean frame offset (`evaluator/window/tests/frames.rs`).
- `cargo test -p vibesql-executor --lib` — 3610 passed, 0 failed.
- `cargo test -p vibesql-parser --lib` — 1811 passed, 0 failed.
- `cargo test -p vibesql-executor window1` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)