### PR TITLE
conformance(tcl): persist last_insert_rowid() across read-path processes (Part of #6193)

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -2809,7 +2809,23 @@ proc execsql {sql {db ""}} {
             set raw_sql ".mode raw\n${pragma_prefix}${trimmed_sql};\nSELECT changes();"
         }
     } else {
-        set raw_sql ".mode raw\n${pragma_prefix}$sql"
+        # Read-only (non-DML) block. Because each execsql runs in a FRESH
+        # process, a SELECT that references last_insert_rowid() would evaluate it
+        # to 0 instead of the value tracked across process invocations
+        # (::last_insert_rowid, #5843). The shim already tracks that value from
+        # the INSERT that ran in a previous process, so substitute it here as an
+        # integer literal. Only do this for pure read blocks (no INSERT/REPLACE/
+        # UPDATE/DELETE keyword) so a block that itself mutates rows still gets
+        # the engine's in-process value. (Part of #6193 — e_insert last_insert_rowid
+        # evidence tests such as e_insert-1.3.*b.)
+        set read_sql $sql
+        if {![regexp {(^|[^A-Z_])(INSERT|REPLACE|UPDATE|DELETE)([^A-Z_]|$)} $sql_upper]} {
+            if {[regexp -nocase {last_insert_rowid\s*\(\s*\)} $read_sql]} {
+                regsub -all -nocase {last_insert_rowid\s*\(\s*\)} \
+                    $read_sql $::last_insert_rowid read_sql
+            }
+        }
+        set raw_sql ".mode raw\n${pragma_prefix}$read_sql"
     }
 
     # Use exec_preserve_newlines to avoid TCL's exec stripping trailing newlines.


### PR DESCRIPTION
## Summary

Part of #6193 (INSERT/UPDATE/DELETE documentation-evidence). This is a **partial increment** focused on a clean, safe shim fix; the remaining failures are documented as distinct engine/shim gaps below.

Re-measured fresh baselines on current `main` (the issue body's counts were stale — the ATTACH file-scope cascade in `e_update` is already broken by prior work, so `e_update` reads 75%, not 4.5%):

| File | Before | After |
| --- | --- | --- |
| e_insert.test | 187 / 203 (16 fail) | **190 / 203 (13 fail)** |
| e_delete.test | 95 / 105 (1 fail) | 95 / 105 (unchanged) |
| e_update.test | 126 / 168 (35 fail) | 126 / 168 (unchanged) |

## What changed

`scripts/tester_vibesql.tcl` — read-path `last_insert_rowid()` persistence.

`e_insert` verifies inserts with `SELECT * FROM a2 WHERE oid=last_insert_rowid()` in a **separate `execsql` call** from the INSERT. Because each `execsql` runs in a fresh `vibesql` process, `last_insert_rowid()` inside a read-only query evaluated to `0` (the fresh-process default) instead of the value the shim already tracks across processes in `::last_insert_rowid` (#5843), so those reads returned no rows. The fix substitutes the tracked value as an integer literal for **pure read blocks only** (no INSERT/REPLACE/UPDATE/DELETE keyword); a block that itself mutates rows still gets the engine's in-process value.

Fixes `e_insert-1.3.1b` / `1.3.2b` / `1.3.3b`.

## Acceptance criteria coverage

- [x] All three files run on a fresh `--release` build; fresh per-file baselines recorded above.
- [x] **e_update setup cascade**: already broken on current `main` (main-db tables create; the 48-case `e_update-0` matrix passes). Re-measured, no longer 4.5%.
- [x] No regression in the three files vs the fresh baseline (e_delete/e_update identical; e_insert improved).
- [ ] **e_delete (1 remaining)** — `e_delete-2.2.1.1` documented as a gap (see below), not fixed.
- [ ] **e_insert (13 remaining)** — reduced by 3; remainder documented (transaction emulation), not fixed.
- [x] The `aux.*` / §2.x cross-schema e_update cases remain ATTACH-blocked Bucket-A straddlers, not attempted.

## What remains for #6193 (documented distinct gaps, not attempted here)

1. **Batched-transaction emulation (shim)** — the dominant remaining cluster. Both `e_insert-4.1.*` (13) and `e_update-1.8.6+ / §2 / §3` (~28) stem from a test doing `BEGIN` mid-file. The shim batches statements and returns `{}` for any statement submitted inside the open transaction, so the `.2` `SELECT ...` checks return empty and `sqlite3_get_autocommit` (the `.3` checks) reads wrong. The transaction never closes because the CLI **stops at the first statement error** during batch replay (no continue-on-error mode), so a tolerated constraint error early in the batch prevents the closing `OR ROLLBACK` from ever executing — cascading empties through `e_update` §2 and §3 (all of which are plain `UPDATE ... LIMIT/ORDER BY`, which the engine supports and which pass in isolation). Fixing this is a substantial shim (or CLI continue-on-error) change, out of scope for this increment.
2. **`UPDATE OR FAIL` partial-update semantics (engine)** — `e_update-1.8.3/1.8.4/1.8.5`. VibeSQL rolls the whole statement back on conflict (like `OR ABORT`) instead of preserving rows modified before the conflict. The update executor uses a two-phase collect-then-deferred-uniqueness model (needed for `UPDATE p SET a=a-1`, #5137); correct `OR FAIL` needs a row-by-row apply path — a risky divergence for a few tests before the §1.8.6 cascade.
3. **Cross-schema trigger error qualification** — `e_delete-2.2.1.1`. `CREATE TRIGGER ... ON main.t7` (schema-qualified table in the ON clause) is a parse error (`near "."`), and even once parsed, SQLite reports `no such table: main.t9` (schema-qualified from the trigger's body), which VibeSQL would not qualify — ATTACH/cross-schema-adjacent.

## Test plan

- `make test-tcl-file FILE=e_insert.test` / `FILE=e_delete.test` / `FILE=e_update.test` on a fresh `cargo build --release` (counts above).
- Regression: `autoinc.test` (heavy `last_insert_rowid()` user) is identical at 4/87 with and without the change; the substitution only affects read blocks that reference `last_insert_rowid()`, where the tracked value is strictly more correct than the fresh-process `0`.
- No Rust changes (shim-only), so no executor unit tests apply; conformance is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)