### PR TITLE
fix(parser): parse WINDOW clause on WITH-prefixed SELECT statements

### DIFF
--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -1031,6 +1031,17 @@ impl Parser {
             None
         };
 
+        // Parse optional WINDOW clause (named window definitions).
+        // Mirrors `parse_select_statement_internal`; without this a WITH-prefixed
+        // query silently drops its named windows so `OVER win` fails to resolve
+        // ("no such window") — window6.test 10.0.
+        let window_definitions = if self.peek_keyword(Keyword::Window) {
+            self.consume_keyword(Keyword::Window)?;
+            Some(self.parse_window_definitions()?)
+        } else {
+            None
+        };
+
         // Parse set operations (UNION, INTERSECT, EXCEPT)
         let set_operation = if self.peek_keyword(Keyword::Union)
             || self.peek_keyword(Keyword::Intersect)
@@ -1176,7 +1187,7 @@ impl Parser {
             where_clause,
             group_by,
             having,
-            window_definitions: None, // Legacy path - WINDOW clause parsed separately
+            window_definitions,
             order_by,
             limit,
             offset,

--- a/crates/vibesql-parser/src/tests/window_functions.rs
+++ b/crates/vibesql-parser/src/tests/window_functions.rs
@@ -302,9 +302,7 @@ fn test_filter_on_non_aggregate_window_rejected() {
     }
 
     // FILTER on an *aggregate* window function stays valid.
-    assert!(
-        Parser::parse_sql("SELECT sum(x) FILTER (WHERE x>0) OVER (ORDER BY x) FROM t1").is_ok()
-    );
+    assert!(Parser::parse_sql("SELECT sum(x) FILTER (WHERE x>0) OVER (ORDER BY x) FROM t1").is_ok());
 }
 
 #[test]
@@ -661,6 +659,29 @@ fn test_real_window_clause_still_parses() {
         vibesql_ast::Statement::Select(select) => {
             let defs = select.window_definitions.expect("WINDOW clause must be captured");
             assert!(!defs.is_empty(), "WINDOW clause must define at least one window");
+        }
+        _ => panic!("expected a SELECT"),
+    }
+}
+
+// Regression (window6.test 10.0): a WITH-prefixed SELECT went through a
+// duplicated parser (`parse_select_statement_after_with`) that never parsed the
+// trailing WINDOW clause, so `window_definitions` was silently dropped and
+// `OVER w1` failed to resolve ("no such window: w1"). The WINDOW clause must be
+// captured on the CTE-prefixed path exactly as on the plain path.
+#[test]
+fn test_window_clause_parses_after_with_clause() {
+    let sql = "WITH t1(a, b) AS (VALUES(1, 2)) \
+               SELECT count() OVER w1 FROM t1 WINDOW w1 AS (ORDER BY a)";
+    let stmt = Parser::parse_sql(sql).expect("WITH + WINDOW clause should parse");
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            assert!(select.with_clause.is_some(), "CTE list must be attached");
+            let defs = select
+                .window_definitions
+                .expect("WINDOW clause must survive a leading WITH clause");
+            assert_eq!(defs.len(), 1, "exactly one named window expected");
+            assert_eq!(defs[0].name.to_lowercase(), "w1");
         }
         _ => panic!("expected a SELECT"),
     }


### PR DESCRIPTION
## Summary

A `SELECT` preceded by a `WITH` clause is parsed by a *duplicated* code path (`parse_select_statement_after_with` in `crates/vibesql-parser/src/parser/mod.rs`) that never parsed the named-`WINDOW` clause — it hardcoded `window_definitions: None`. As a result, any query of the form:

```sql
WITH t1(a,b) AS (VALUES(1,2))
SELECT count() OVER w1 FROM t1 WINDOW w1 AS (ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING);
```

silently dropped its named windows and failed at execution with `no such window: w1` (window6.test 10.0). The plain (non-CTE) path parses `WINDOW` correctly; only the WITH-prefixed path was affected.

Root cause was confirmed by instrumenting `execute()` and `collect_window_functions`: `window_definitions` arrived as `None` at the very entry of execution whenever a WITH clause was present, i.e. the loss was at parse time, in the duplicated parser.

## Changes

- `crates/vibesql-parser/src/parser/mod.rs`: parse the optional `WINDOW` clause in `parse_select_statement_after_with` (between HAVING and set operations), mirroring `parse_select_statement_internal`, and thread it into the returned `SelectStmt` instead of hardcoding `None`.
- `crates/vibesql-parser/src/tests/window_functions.rs`: add `test_window_clause_parses_after_with_clause` asserting the WINDOW clause survives a leading WITH clause.

This is a mechanism fix (the clause is now actually parsed), not a documentation change; it repairs every `WITH ... SELECT ... WINDOW w AS (...)` query, aggregate or non-aggregate, framed or not.

## Before/After (fresh release build, `./scripts/tcltest test`)

| File | Before | After | Note |
| --- | --- | --- | --- |
| window6.test | 5 failed (62 passed) | **4 failed (63 passed)** | 10.0 fixed (`count() FILTER(...) OVER w1` over a CTE) |
| filter1.test | 1 failed | 1 failed | 6.3 = aggregate-outer-binding (deep name resolution), out of scope |
| filter2.test | 0 failed | 0 failed | 100% |
| window1.test | 6 failed | 6 failed | float `quote()` formatting / error-message / multi-named-window row-ordering — all outside window-frame/FILTER scope |

Net certified-failure reduction this slice: **-1** (window6 10.0), via a root-cause parser fix that generalizes to all CTE-prefixed named-window queries.

### Remaining window6 failures (out of scope, deferred)

The 4 remaining window6 failures (1.5.3, 5.2, 5.3, 5.4) are all the **reserved-keyword-as-identifier** parser class — e.g. 1.5.3 expands to `SELECT sum(filter.following) OVER current FROM over filter WINDOW current AS (ORDER BY preceding)`, using `over`/`window`/`filter`/`following`/`preceding`/`current` simultaneously as table/column/window/alias identifiers. Prior increments explicitly deferred this as high grammar-regression risk; not touched here.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `filter2.test` at 100% | ✅ | 16 passed, 0 failed on fresh build |
| `filter1.test` residual explained | ✅ | Only 6.3 (aggregate-outer-binding, out of scope) remains |
| window5/6 real (non-straddler) frame failures fixed | ✅ | window6 10.0 fixed; remaining 4 are keyword-as-identifier straddlers; window5 whole-file already Bucket-A skipped |
| windowfault straddlers skipped | ✅ | window5 & windowfault run as skipped (Bucket-A), unchanged |
| Before/after from fresh build reported | ✅ | Table above (fresh `cargo build --release` binary) |
| No regression in Rust window/aggregate unit tests | ✅ | `cargo test -p vibesql-executor window` green; `cargo test -p vibesql-parser` 1811+ green incl. new test |

## Test Plan

- `cargo build --release --bin vibesql` (fresh binary; stale binary voids TCL results).
- New parser regression test: `cargo test -p vibesql-parser window_clause_parses_after_with_clause` — passes.
- `cargo test -p vibesql-parser` (1811 + 8 tests) and `cargo test -p vibesql-executor window` — green.
- Manual: `WITH t1(a,b) AS (VALUES(1,2)) SELECT count() FILTER (where b<>5) OVER w1 FROM t1 WINDOW w1 AS (ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING);` now returns `1` instead of erroring.
- Regression sweep on related files (no change vs. baseline): window2/3/7/8 100%; window4 7.3/7.5 pre-existing; with1 failures pre-existing (with1.test has zero WINDOW usages).

Part of #6191