### PR TITLE
conformance(tcl): OVER/WINDOW keywords as table aliases + AS-less select aliases (Part of #6191)

### DIFF
--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -1031,6 +1031,17 @@ impl Parser {
             None
         };
 
+        // Parse optional WINDOW clause (named window definitions).
+        // Mirrors `parse_select_statement_internal`; without this a WITH-prefixed
+        // query silently drops its named windows so `OVER win` fails to resolve
+        // ("no such window") — window6.test 10.0.
+        let window_definitions = if self.peek_keyword(Keyword::Window) {
+            self.consume_keyword(Keyword::Window)?;
+            Some(self.parse_window_definitions()?)
+        } else {
+            None
+        };
+
         // Parse set operations (UNION, INTERSECT, EXCEPT)
         let set_operation = if self.peek_keyword(Keyword::Union)
             || self.peek_keyword(Keyword::Intersect)
@@ -1176,7 +1187,7 @@ impl Parser {
             where_clause,
             group_by,
             having,
-            window_definitions: None, // Legacy path - WINDOW clause parsed separately
+            window_definitions,
             order_by,
             limit,
             offset,

--- a/crates/vibesql-parser/src/parser/select/from_clause.rs
+++ b/crates/vibesql-parser/src/parser/select/from_clause.rs
@@ -378,46 +378,7 @@ impl Parser {
 
                 // Check for optional alias
                 // Parse optional table alias - keywords allowed after AS (e.g., FROM t AS year)
-                let alias = if self.peek_keyword(Keyword::As) {
-                    self.consume_keyword(Keyword::As)?;
-                    Some(self.parse_alias_name()?)
-                } else if matches!(
-                    self.peek(),
-                    Token::Identifier(_) | Token::DelimitedIdentifier(_)
-                ) && !self.is_join_keyword()
-                    && !self.peek_index_hint()
-                {
-                    // Implicit alias (no AS keyword) - but not a JOIN keyword
-                    match self.peek() {
-                        Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
-                            let alias = id.clone();
-                            self.advance();
-                            Some(alias)
-                        }
-                        _ => None,
-                    }
-                } else if matches!(self.peek(), Token::Keyword { keyword: _, .. })
-                    && !self.is_join_keyword()
-                    && (!self.is_clause_keyword() || self.window_keyword_used_as_alias())
-                    && !self.peek_index_hint()
-                {
-                    // Allow non-reserved keywords as implicit aliases (e.g., FROM t m)
-                    // Keywords like M, YEAR, etc. can be used as aliases. WINDOW is
-                    // normally a clause keyword, but `FROM t4 window, t4` uses it as a
-                    // table alias (window6 4.1); `window_keyword_used_as_alias()`
-                    // permits that only when WINDOW does not begin a real
-                    // `WINDOW <name> AS (...)` clause.
-                    match self.peek() {
-                        Token::Keyword { keyword: kw, .. } => {
-                            let alias = kw.to_string();
-                            self.advance();
-                            Some(alias)
-                        }
-                        _ => None,
-                    }
-                } else {
-                    None
-                };
+                let alias = self.parse_optional_table_alias()?;
 
                 // Parse optional column aliases: AS alias (col1, col2, ...)
                 // SQL:1999 Feature E051-09
@@ -449,27 +410,10 @@ impl Parser {
             Token::Keyword { keyword: kw, .. } if kw.can_be_identifier_in_table_position() => {
                 let table = self.parse_table_ref()?;
 
-                // Check for optional alias
-                let alias = if self.peek_keyword(Keyword::As) {
-                    self.consume_keyword(Keyword::As)?;
-                    Some(self.parse_alias_name()?)
-                } else if matches!(
-                    self.peek(),
-                    Token::Identifier(_) | Token::DelimitedIdentifier(_)
-                ) && !self.is_join_keyword()
-                    && !self.peek_index_hint()
-                {
-                    match self.peek() {
-                        Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
-                            let alias = id.clone();
-                            self.advance();
-                            Some(alias)
-                        }
-                        _ => None,
-                    }
-                } else {
-                    None
-                };
+                // Check for optional alias. Uses the shared helper so a keyword
+                // may serve as the alias of a keyword table name too — e.g.
+                // `FROM over over` / `FROM window window` (window6 5.2/5.3/5.4).
+                let alias = self.parse_optional_table_alias()?;
 
                 let column_aliases =
                     if alias.is_some() { self.parse_column_alias_list()? } else { None };
@@ -665,6 +609,63 @@ impl Parser {
                 // implicit (AS-less) table alias.
                 | Token::Keyword { keyword: Keyword::Returning, .. }
         )
+    }
+
+    /// Parse an optional table alias in FROM position.
+    ///
+    /// Handles three forms, mirroring SQLite:
+    /// - `AS <name>` (explicit; keywords allowed after AS)
+    /// - `<identifier>` (implicit, no AS) — but not a JOIN keyword / index hint
+    /// - `<keyword>` used as an implicit alias (e.g. `FROM t m`, and the
+    ///   fallback-identifier keywords `FROM over over` / `FROM t4 window`),
+    ///   excluding JOIN keywords, clause keywords (unless `WINDOW` is being used
+    ///   as an alias rather than starting a real WINDOW clause), and index hints.
+    ///
+    /// Shared by both the identifier-table-name and keyword-table-name branches
+    /// so keyword aliases (`OVER`, `WINDOW`, ...) work after a keyword table name
+    /// too (window6 5.2/5.3/5.4: `FROM over over`, `FROM window window`).
+    pub(crate) fn parse_optional_table_alias(&mut self) -> Result<Option<String>, ParseError> {
+        let alias = if self.peek_keyword(Keyword::As) {
+            self.consume_keyword(Keyword::As)?;
+            Some(self.parse_alias_name()?)
+        } else if matches!(
+            self.peek(),
+            Token::Identifier(_) | Token::DelimitedIdentifier(_)
+        ) && !self.is_join_keyword()
+            && !self.peek_index_hint()
+        {
+            // Implicit alias (no AS keyword) - but not a JOIN keyword
+            match self.peek() {
+                Token::Identifier(id) | Token::DelimitedIdentifier(id) => {
+                    let alias = id.clone();
+                    self.advance();
+                    Some(alias)
+                }
+                _ => None,
+            }
+        } else if matches!(self.peek(), Token::Keyword { keyword: _, .. })
+            && !self.is_join_keyword()
+            && (!self.is_clause_keyword() || self.window_keyword_used_as_alias())
+            && !self.peek_index_hint()
+        {
+            // Allow non-reserved keywords as implicit aliases (e.g., FROM t m).
+            // Keywords like M, YEAR, etc. can be used as aliases. WINDOW is
+            // normally a clause keyword, but `FROM t4 window, t4` uses it as a
+            // table alias (window6 4.1); `window_keyword_used_as_alias()`
+            // permits that only when WINDOW does not begin a real
+            // `WINDOW <name> AS (...)` clause.
+            match self.peek() {
+                Token::Keyword { keyword: kw, .. } => {
+                    let alias = kw.to_string();
+                    self.advance();
+                    Some(alias)
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
+        Ok(alias)
     }
 
     /// Parse JOIN type (INNER JOIN, LEFT JOIN, NATURAL JOIN, etc.)

--- a/crates/vibesql-parser/src/parser/select/list.rs
+++ b/crates/vibesql-parser/src/parser/select/list.rs
@@ -141,13 +141,19 @@ impl Parser {
             // (window6 5.0). Clause/operator keywords (FROM, WHERE, ORDER, ...) are
             // not `can_be_identifier()` and so continue to terminate the item.
             //
-            // RETURNING and WINDOW are excluded even though they are fallback
-            // identifiers: each introduces a trailing clause that can directly
-            // follow the final select item (`INSERT ... SELECT 1 RETURNING a`,
-            // `SELECT 1 WINDOW w AS ()`), so grabbing them as an AS-less alias would
-            // swallow the clause (regression on insert-compound-returning, #5271).
+            // RETURNING is excluded even though it is a fallback identifier: it
+            // introduces a trailing clause that can directly follow the final
+            // select item (`INSERT ... SELECT 1 RETURNING a`), so grabbing it as
+            // an AS-less alias would swallow the clause (regression on
+            // insert-compound-returning, #5271).
+            //
+            // WINDOW is excluded only when it actually begins a real
+            // `WINDOW <name> AS (...)` clause (`SELECT 1 WINDOW w AS ()`); when it
+            // does not (`SELECT sum(window) OVER window window FROM ...`, window6
+            // 5.4), it is a valid AS-less alias like any other fallback identifier.
             if keyword.can_be_identifier()
-                && !matches!(keyword, Keyword::Returning | Keyword::Window)
+                && !matches!(keyword, Keyword::Returning)
+                && !(matches!(keyword, Keyword::Window) && self.peek_window_starts_clause())
             {
                 let alias = original.clone();
                 self.advance();

--- a/crates/vibesql-parser/src/tests/select/keyword_as_identifier.rs
+++ b/crates/vibesql-parser/src/tests/select/keyword_as_identifier.rs
@@ -239,3 +239,71 @@ fn test_reserved_keywords_in_operand_position_still_error() {
         assert!(Parser::parse_sql(sql).is_err(), "expected a syntax error for: {sql}");
     }
 }
+
+// --- window6.test keyword-as-identifier torture cases (Part of #6191) ---
+
+#[test]
+fn test_keyword_alias_after_keyword_table_name() {
+    // A fallback-identifier keyword may serve as the implicit alias of a keyword
+    // table name. Previously the keyword-table-name branch of the FROM parser only
+    // accepted an *identifier* alias, so `FROM over over` / `FROM window window`
+    // produced a syntax error (window6 5.2/5.3/5.4, 1.5.3).
+    for sql in [
+        "SELECT x FROM over over;",
+        "SELECT x FROM window window;",
+        // The keyword table name is aliased and then referenced qualified.
+        "SELECT filter.following FROM over filter;",
+    ] {
+        assert!(Parser::parse_sql(sql).is_ok(), "expected to parse: {sql}");
+    }
+}
+
+#[test]
+fn test_window6_5_2_over_torture() {
+    // window6 5.2/5.3: `over` used as column, OVER keyword, window name, AS-less
+    // column alias, table name, and table alias — all in one statement.
+    let sql = "SELECT sum(over) over over over \
+               FROM over over WINDOW over AS (ORDER BY over);";
+    assert!(Parser::parse_sql(sql).is_ok(), "window6 5.2 should parse: {sql}");
+}
+
+#[test]
+fn test_window6_5_4_window_torture() {
+    // window6 5.4: `window` used as column, OVER window name, AS-less column
+    // alias, table name, table alias, and to start the WINDOW clause. Requires
+    // both the keyword-table-alias fix and allowing WINDOW as an AS-less column
+    // alias when it does not begin a real `WINDOW <name> AS (...)` clause.
+    let sql = "SELECT sum(window) OVER window window \
+               FROM window window window window AS (ORDER BY window);";
+    assert!(Parser::parse_sql(sql).is_ok(), "window6 5.4 should parse: {sql}");
+}
+
+#[test]
+fn test_window_keyword_as_asless_select_alias() {
+    // `WINDOW` is a valid AS-less column alias when it does not start a real
+    // WINDOW clause (the token after it is not `<name> AS`).
+    assert!(
+        Parser::parse_sql("SELECT sum(x) OVER w window FROM t WINDOW w AS ();").is_ok(),
+        "WINDOW as an AS-less select alias should parse"
+    );
+}
+
+#[test]
+fn test_window_clause_still_not_swallowed_as_alias() {
+    // Regression guard: a real trailing `WINDOW <name> AS (...)` clause must NOT
+    // be grabbed as an AS-less alias of the final select item.
+    let stmt = Parser::parse_sql("SELECT sum(x) OVER w FROM t WINDOW w AS ();")
+        .expect("SELECT ... WINDOW w AS () should parse");
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            assert_eq!(select.select_list.len(), 1, "WINDOW clause must not become an alias");
+            match &select.select_list[0] {
+                vibesql_ast::SelectItem::Expression { alias, .. } => {
+                    assert!(alias.is_none(), "final item must have no alias, got {alias:?}");
+                }
+                other => panic!("expected expression select item, got {other:?}"),
+            }
+        }
+        _ => panic!("Expected SELECT statement"),
+    }
+}

--- a/crates/vibesql-parser/src/tests/window_functions.rs
+++ b/crates/vibesql-parser/src/tests/window_functions.rs
@@ -302,9 +302,7 @@ fn test_filter_on_non_aggregate_window_rejected() {
     }
 
     // FILTER on an *aggregate* window function stays valid.
-    assert!(
-        Parser::parse_sql("SELECT sum(x) FILTER (WHERE x>0) OVER (ORDER BY x) FROM t1").is_ok()
-    );
+    assert!(Parser::parse_sql("SELECT sum(x) FILTER (WHERE x>0) OVER (ORDER BY x) FROM t1").is_ok());
 }
 
 #[test]
@@ -661,6 +659,29 @@ fn test_real_window_clause_still_parses() {
         vibesql_ast::Statement::Select(select) => {
             let defs = select.window_definitions.expect("WINDOW clause must be captured");
             assert!(!defs.is_empty(), "WINDOW clause must define at least one window");
+        }
+        _ => panic!("expected a SELECT"),
+    }
+}
+
+// Regression (window6.test 10.0): a WITH-prefixed SELECT went through a
+// duplicated parser (`parse_select_statement_after_with`) that never parsed the
+// trailing WINDOW clause, so `window_definitions` was silently dropped and
+// `OVER w1` failed to resolve ("no such window: w1"). The WINDOW clause must be
+// captured on the CTE-prefixed path exactly as on the plain path.
+#[test]
+fn test_window_clause_parses_after_with_clause() {
+    let sql = "WITH t1(a, b) AS (VALUES(1, 2)) \
+               SELECT count() OVER w1 FROM t1 WINDOW w1 AS (ORDER BY a)";
+    let stmt = Parser::parse_sql(sql).expect("WITH + WINDOW clause should parse");
+    match stmt {
+        vibesql_ast::Statement::Select(select) => {
+            assert!(select.with_clause.is_some(), "CTE list must be attached");
+            let defs = select
+                .window_definitions
+                .expect("WINDOW clause must survive a leading WITH clause");
+            assert_eq!(defs.len(), 1, "exactly one named window expected");
+            assert_eq!(defs[0].name.to_lowercase(), "w1");
         }
         _ => panic!("expected a SELECT"),
     }


### PR DESCRIPTION
## Summary

Part of #6191 (window-function frame + aggregate FILTER clause semantics — a partial-increment family issue; this PR does **not** close it).

This slice closes the remaining `window6.test` failures, which are the fallback-identifier / keyword-as-identifier parser edge cases the family issue flagged as "reserved keyword used as identifier" gaps. `window6.test` uses `OVER`/`WINDOW` as column names, window names, table names, table aliases, and AS-less column aliases — all in one statement — to torture SQLite's fallback-identifier rules.

Two parser gaps remained:

1. **Keyword alias after a keyword table name.** The keyword-table-name branch of the FROM parser only accepted an *identifier* alias, so `FROM over over` / `FROM window window` / `FROM over filter` were syntax errors. The identifier-branch alias logic (already keyword-aware) is extracted into a shared `parse_optional_table_alias` helper and used by both branches. (`crates/vibesql-parser/src/parser/select/from_clause.rs`)

2. **`WINDOW` as an AS-less select alias.** The SELECT-list parser excluded `WINDOW` wholesale as an AS-less column alias, to avoid swallowing a trailing `WINDOW <name> AS (...)` clause. That is now relaxed: `WINDOW` is excluded only when it actually *begins* a real window clause (`peek_window_starts_clause`); otherwise it is a valid alias like any other fallback identifier. (`crates/vibesql-parser/src/parser/select/list.rs`)

## Before / after (fresh release build, per-file)

| File | Before | After | Notes |
| --- | --- | --- | --- |
| window6.test | 4 | **0** | 1.5.3, 5.2, 5.3, 5.4 now pass; 3 Bucket-A skips remain (`db func`/`db collate` #5720) |
| filter2.test | 0 | 0 | 100% |
| filter1.test | 1 | 1 | 6.3 unchanged (out of scope, see below) |
| window1.test | 6 | 6 | unchanged (out of scope, see below) |

window5.test / windowfault.test self-skip as whole-file Bucket-A straddlers (C-API / fault-injection), already routed in prior increments.

### Out-of-scope residuals (left visibly failing for a follow-up)
- **window1 8.1.2 / 52.2 / 52.3 / 52.4** — output *row-ordering* artifacts: all values are correct, but the queries have no outer `ORDER BY` and the test relies on SQLite's implementation-specific emission order.
- **window1 29.2** — NUMERIC affinity of an `ANY`-typed column (`6.0` should coerce to `6`); a type-affinity gap, not a window-frame bug.
- **window1 67.1** — error-message conformance for a compound SELECT with a window in `ORDER BY` referencing a missing table.
- **filter1 6.3** — aggregate binds to the outermost query providing its columns; a name-resolution/aggregate-binding semantic unrelated to window frames / FILTER.

## Tests
- Added 5 regression tests in `crates/vibesql-parser/src/tests/select/keyword_as_identifier.rs` (keyword alias after keyword table name; window6 5.2 and 5.4 full statements; `WINDOW` as an AS-less select alias; and a guard that a real trailing `WINDOW ... AS ()` clause is *not* grabbed as an alias).
- `cargo test -p vibesql-parser` — 1817 passed, 0 failed.
- `cargo test -p vibesql-executor window` — 160 passed, 0 failed (window1_quick_wins + window1_residuals green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)