### PR TITLE
conformance(tcl): fix WINDOW-clause AST round-trip + ANY-column NUMERIC affinity (Part of #6191)

### DIFF
--- a/crates/vibesql-ast/src/pretty_print.rs
+++ b/crates/vibesql-ast/src/pretty_print.rs
@@ -933,6 +933,19 @@ impl ToSql for SelectStmt {
             if let Some(having) = &self.having {
                 result.push_str(&format!(" HAVING {}", having.to_sql()));
             }
+
+            // WINDOW clause (named window definitions, e.g. `WINDOW w AS (...)`).
+            // Dropping this on a persistence round-trip silently orphans every
+            // `OVER <name>` reference in the view body, surfacing as "no such
+            // window: <name>" the next time the view is loaded from storage
+            // (window1.test 8.1.2 / #6191).
+            if let Some(window_defs) = &self.window_definitions {
+                let defs_sql: Vec<String> = window_defs
+                    .iter()
+                    .map(|d| format!("{} AS ({})", format_identifier(&d.name), d.spec.to_sql()))
+                    .collect();
+                result.push_str(&format!(" WINDOW {}", defs_sql.join(", ")));
+            }
         }
 
         // Set operation (UNION, INTERSECT, EXCEPT) must be rendered BEFORE
@@ -1231,7 +1244,7 @@ impl ToSql for MixedGroupingItem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ColumnIdentifier, FunctionIdentifier};
+    use crate::{select::WindowDefinition, ColumnIdentifier, FunctionIdentifier};
 
     #[test]
     fn test_binary_operators() {
@@ -1613,5 +1626,71 @@ mod tests {
             },
         };
         assert_eq!(expr.to_sql(), "ROW_NUMBER() OVER (PARTITION BY dept ORDER BY salary DESC)");
+    }
+
+    /// A `SELECT ... WINDOW w AS (...)` statement must round-trip its named
+    /// window definitions through `to_sql()`. Views are persisted by
+    /// re-rendering their defining `SelectStmt` to SQL text and re-parsing it
+    /// on load; dropping `window_definitions` here silently orphaned every
+    /// `OVER <name>` reference in the view body, surfacing as "no such
+    /// window: <name>" the first time the view was reloaded from storage
+    /// (window1.test 8.1.2, #6191).
+    #[test]
+    fn test_select_with_window_clause_round_trips() {
+        let stmt = SelectStmt {
+            with_clause: None,
+            distinct: false,
+            select_list: vec![SelectItem::Expression {
+                expr: Expression::WindowFunction {
+                    function: WindowFunctionSpec::Aggregate {
+                        name: FunctionIdentifier::new("sum"),
+                        args: vec![Expression::ColumnRef(ColumnIdentifier::simple("b", false))],
+                        filter: None,
+                    },
+                    over: WindowSpec {
+                        base_window_name: Some("win".to_string()),
+                        partition_by: None,
+                        order_by: None,
+                        frame: None,
+                    },
+                },
+                alias: None,
+                source_text: None,
+            }],
+            into_table: None,
+            into_variables: None,
+            from: Some(FromClause::Table {
+                index_hint: None,
+                name: "t3".to_string(),
+                alias: None,
+                column_aliases: None,
+                quoted: false,
+            }),
+            where_clause: None,
+            group_by: None,
+            having: None,
+            window_definitions: Some(vec![WindowDefinition {
+                name: "win".to_string(),
+                spec: WindowSpec {
+                    base_window_name: None,
+                    partition_by: None,
+                    order_by: Some(vec![OrderByItem {
+                        expr: Expression::ColumnRef(ColumnIdentifier::simple("c", false)),
+                        direction: OrderDirection::Asc,
+                        nulls_order: None,
+                    }]),
+                    frame: None,
+                },
+            }]),
+            order_by: None,
+            limit: None,
+            offset: None,
+            set_operation: None,
+            values: None,
+        };
+        assert_eq!(
+            stmt.to_sql(),
+            "SELECT SUM(b) OVER (win) FROM t3 WINDOW win AS (ORDER BY c ASC)"
+        );
     }
 }

--- a/crates/vibesql-executor/src/insert/validation.rs
+++ b/crates/vibesql-executor/src/insert/validation.rs
@@ -651,15 +651,53 @@ pub fn coerce_value(
                     // NUMERIC affinity: try integer first, then real, else keep as text
                     // This is SQLite's behavior for types like NUM, NUMBER, etc.
                     match &value {
-                        // Numeric types pass through
+                        // Integer-storage-class types pass through unchanged.
                         SqlValue::Integer(_)
                         | SqlValue::Bigint(_)
                         | SqlValue::Smallint(_)
-                        | SqlValue::Numeric(_)
-                        | SqlValue::Double(_)
-                        | SqlValue::Real(_)
-                        | SqlValue::Float(_)
                         | SqlValue::Unsigned(_) => Ok(value),
+                        // Floating-point types: NUMERIC affinity losslessly converts a
+                        // whole-number REAL to INTEGER storage class (e.g. 6.0 -> 6), same
+                        // as SQLite. Without this, a column with an unrecognized declared
+                        // type (e.g. `ANY`, which defaults to NUMERIC affinity per the
+                        // SQLite algorithm) keeps 6.0 as REAL, so quote()/typeof() diverge
+                        // from SQLite (window1.test 29.2, #6191).
+                        SqlValue::Numeric(f) => {
+                            if f.fract() == 0.0 && *f >= i64::MIN as f64 && *f <= i64::MAX as f64 {
+                                Ok(SqlValue::Integer(*f as i64))
+                            } else {
+                                Ok(value)
+                            }
+                        }
+                        SqlValue::Double(f) => {
+                            if f.fract() == 0.0 && *f >= i64::MIN as f64 && *f <= i64::MAX as f64 {
+                                Ok(SqlValue::Integer(*f as i64))
+                            } else {
+                                Ok(value)
+                            }
+                        }
+                        SqlValue::Real(f) => {
+                            let f64_val = *f as f64;
+                            if f64_val.fract() == 0.0
+                                && f64_val >= i64::MIN as f64
+                                && f64_val <= i64::MAX as f64
+                            {
+                                Ok(SqlValue::Integer(f64_val as i64))
+                            } else {
+                                Ok(value)
+                            }
+                        }
+                        SqlValue::Float(f) => {
+                            let f64_val = *f as f64;
+                            if f64_val.fract() == 0.0
+                                && f64_val >= i64::MIN as f64
+                                && f64_val <= i64::MAX as f64
+                            {
+                                Ok(SqlValue::Integer(f64_val as i64))
+                            } else {
+                                Ok(value)
+                            }
+                        }
                         // Text: try to convert to number
                         SqlValue::Varchar(s) | SqlValue::Character(s) => {
                             let trimmed = s.trim();
@@ -843,5 +881,55 @@ mod boolean_affinity_tests {
             coerce_to_bool_col(SqlValue::Varchar(arcstr::ArcStr::from("abc"))),
             SqlValue::Varchar(arcstr::ArcStr::from("abc"))
         );
+    }
+}
+
+#[cfg(test)]
+mod user_defined_numeric_affinity_tests {
+    use vibesql_types::{DataType, SqlValue};
+
+    use super::coerce_value;
+
+    fn coerce_to_any_col(value: SqlValue) -> SqlValue {
+        coerce_value(value, &DataType::UserDefined { type_name: "ANY".to_string() })
+            .expect("coercion into an unrecognized/ANY-declared column should succeed")
+    }
+
+    /// A column declared with an unrecognized type name (e.g. `ANY`) gets
+    /// NUMERIC affinity per SQLite's column-affinity algorithm (no INT/CHAR/
+    /// CLOB/TEXT/BLOB/REAL/FLOA/DOUB substring match -> falls to rule 5,
+    /// NUMERIC). NUMERIC affinity losslessly converts a whole-number REAL to
+    /// INTEGER storage class on insert, matching `typeof()`/`quote()` on real
+    /// SQLite (verified against sqlite3 3.51.0: `CREATE TABLE t1(d ANY);
+    /// INSERT INTO t1 VALUES(6.0); SELECT typeof(d)` -> `integer`).
+    /// Previously only text values went through this conversion; already-
+    /// numeric REAL/DOUBLE/NUMERIC/FLOAT values passed through unchanged,
+    /// which broke window1.test 29.2's `quote(d)`/RANGE-frame comparisons
+    /// (#6191).
+    #[test]
+    fn whole_real_becomes_integer() {
+        assert_eq!(coerce_to_any_col(SqlValue::Real(6.0)), SqlValue::Integer(6));
+        assert_eq!(coerce_to_any_col(SqlValue::Double(9.0)), SqlValue::Integer(9));
+        assert_eq!(coerce_to_any_col(SqlValue::Numeric(1.0)), SqlValue::Integer(1));
+        assert_eq!(coerce_to_any_col(SqlValue::Float(-42.0)), SqlValue::Integer(-42));
+    }
+
+    /// Fractional reals are NOT coerced to integer and keep their original
+    /// floating-point storage class.
+    #[test]
+    fn fractional_real_stays_real() {
+        assert_eq!(coerce_to_any_col(SqlValue::Real(2.5)), SqlValue::Real(2.5));
+        assert_eq!(coerce_to_any_col(SqlValue::Double(8.25)), SqlValue::Double(8.25));
+        assert_eq!(coerce_to_any_col(SqlValue::Numeric(6.5)), SqlValue::Numeric(6.5));
+    }
+
+    /// Non-numeric text and other storage classes pass through unchanged.
+    #[test]
+    fn non_numeric_text_unchanged() {
+        assert_eq!(
+            coerce_to_any_col(SqlValue::Varchar(arcstr::ArcStr::from("xyz"))),
+            SqlValue::Varchar(arcstr::ArcStr::from("xyz"))
+        );
+        assert_eq!(coerce_to_any_col(SqlValue::Integer(6)), SqlValue::Integer(6));
     }
 }

--- a/crates/vibesql-parser/src/parser/create/types.rs
+++ b/crates/vibesql-parser/src/parser/create/types.rs
@@ -703,9 +703,16 @@ impl Parser {
                 Ok((vibesql_types::DataType::BinaryLargeObject, false))
             }
             "CLOB" => Ok((vibesql_types::DataType::CharacterLargeObject, false)),
-            // SQLite ANY type - represents any type, stored with BLOB affinity (no type affinity)
-            // This allows expressions like CAST(x AS ANY) to return the original type
-            "ANY" => Ok((vibesql_types::DataType::BinaryLargeObject, false)),
+            // SQLite ANY type: intentionally NOT special-cased to BLOB/no-affinity here.
+            // A plain (non-STRICT) column declared ANY does not match the INT/CHAR/
+            // CLOB/TEXT/BLOB/REAL/FLOA/DOUB substring rules, so per SQLite's column
+            // affinity algorithm (https://www.sqlite.org/datatype3.html#affinity) it
+            // falls through to rule 5 and gets NUMERIC affinity — e.g. inserting the
+            // REAL literal 6.0 into an ANY column stores it as INTEGER 6, matching
+            // `typeof()`/`quote()` on real SQLite (verified against sqlite3 3.51.0;
+            // window1.test 29.2, #6191). STRICT-table `ANY` columns (no affinity at
+            // all) are validated separately via `StrictType::Any` in
+            // vibesql-executor/src/strict.rs and are unaffected by this fallthrough.
             _ => {
                 // SQLite compatibility: Accept ANY string as a type name.
                 // SQLite uses type affinity rules to determine storage, but accepts


### PR DESCRIPTION
## Summary

Part of #6191 (window-function frame + aggregate FILTER-clause semantics). Seven prior PRs (#6215, #6227, #6244, #6261, #6267, #6270, #6271) already landed partial increments against this issue. This increment triages the remaining state with a fresh release build and fixes two more real engine gaps found in `window1.test`.

## Fixes

1. **`SelectStmt::to_sql()` dropped the `WINDOW` clause on AST round-trip** (`crates/vibesql-ast/src/pretty_print.rs`). Views are persisted by re-rendering their defining `SelectStmt` to SQL text (`view.query.to_sql()`) and re-parsing that text on load. `window_definitions` (the `WINDOW w AS (...)` clause) was never emitted, so a view using a named window silently lost it on every reload — `SELECT * FROM v2` (where `v2` uses `OVER win` + `WINDOW win AS (...)`) failed with `no such window: win` the moment the database was reopened. Fixed by rendering `WINDOW <name> AS (<spec>), ...` after `HAVING` and before the set-operation/`ORDER BY` tail, matching the parser's grammar position. (`window1.test` 8.1.2)

2. **NUMERIC affinity didn't collapse whole-number REALs to INTEGER for `UserDefined`-typed columns** (`crates/vibesql-executor/src/insert/validation.rs`). A column declared with an unrecognized type name (e.g. `ANY`) gets NUMERIC affinity per SQLite's column-affinity algorithm (no `INT`/`CHAR`/`CLOB`/`TEXT`/`BLOB`/`REAL`/`FLOA`/`DOUB` substring match → falls to rule 5). NUMERIC affinity should losslessly convert a whole-number REAL to INTEGER storage class on insert (`6.0` → `6`), matching `typeof()`/`quote()` on real SQLite (verified against `sqlite3 3.51.0`). The NUMERIC branch only applied this conversion to *text* values that parsed as numbers; already-numeric `Real`/`Double`/`Numeric`/`Float` values passed straight through unchanged. This broke `quote(d)` output and RANGE-frame boundary comparisons in a window query ordering by an `ANY`-declared column (`window1.test` 29.2). Also removed the incorrect `"ANY" => BinaryLargeObject` (no-affinity) special-case in the classic parser's column-type resolver (`crates/vibesql-parser/src/parser/create/types.rs`) so `ANY`-declared *columns* fall through to the standard `UserDefined` NUMERIC-affinity path — `CAST(x AS ANY)` expression parsing (a separate code path in `arena_parser`) is untouched and keeps its pre-existing (unrelated, pre-existing) no-affinity behavior.

## Before/after (fresh release build, per-file via `./scripts/tcltest test <file>`)

| File | Before | After | Notes |
| --- | --- | --- | --- |
| `window1.test` | 6 failed (8.1.2, 29.2, 52.2, 52.3, 52.4, 67.1) | **4 failed** (52.2, 52.3, 52.4, 67.1) | Fixed 8.1.2 and 29.2 |
| `window5.test` | whole-file Bucket-A skip | unchanged | Routed in a prior increment |
| `window6.test` | 0 failed / 3 skipped (`db func`/`db collate` UDF straddlers) | unchanged | Routed in a prior increment |
| `filter1.test` | 1 failed (6.3) | unchanged | See "Residual gaps" below |
| `filter2.test` | 0 failed | unchanged | 100% |
| `windowfault.test` | whole-file Bucket-A skip | unchanged | Routed in a prior increment |

## Residual real (non-Bucket-A) gaps — left for a future increment

These are genuine engine gaps, not harness limitations, but each is a deep, low-value SQLite-implementation-specific edge case unrelated to frame-boundary or FILTER-truthiness math:

- **`window1.test` 52.2/52.3/52.4**: with multiple *distinct* window specs and no statement-level `ORDER BY`, SQLite's actual output row order follows an undocumented internal choice among the window sorts (empirically: the *first* distinct spec's order for this query, not the last). Our current heuristic (`crates/vibesql-executor/src/select/window/mod.rs`) intentionally mirrors "last window's sort order" per a documented prior fix (issue #5291, `window9.test` 1.4); naively flipping to "first" risks regressing that test. Needs a real study of SQLite's window-pass ordering algorithm, not a heuristic swap.
- **`window1.test` 67.1**: a `catchsql` test expecting `no such table: v1` from a subquery nested inside a window's `ORDER BY`, itself nested inside a compound-`SELECT`'s outer `ORDER BY`. Our engine currently raises a different (also-valid-sounding but SQLite-incompatible) error instead of resolving the nested table reference. Requires deeper nested-subquery name-resolution work through window `ORDER BY` expressions inside compound-query `ORDER BY`.
- **`filter1.test` 6.3**: `SELECT (SELECT COUNT(a) FROM t2) FROM t1` expects SQLite's aggregate-scope-promotion behavior — when an aggregate's arguments reference *only* outer-query columns (none from the subquery's own FROM), SQLite associates the aggregate with the *outer* query, turning the whole outer SELECT into an implicit aggregate query (result: `{2}`, i.e. `COUNT(t1.a)` over all of `t1`). This is architecturally distinct from frame/FILTER work — it requires aggregate-scope resolution during subquery binding, not window or FILTER evaluation.

## Test plan

- [x] `make test-tcl-file FILE=window1.test` / `window5.test` / `window6.test` / `filter1.test` / `filter2.test` / `windowfault.test` on a fresh release build (see before/after table above)
- [x] Regression test added: `crates/vibesql-ast/src/pretty_print.rs` `test_select_with_window_clause_round_trips` (WINDOW clause round-trips through `to_sql()`)
- [x] Regression tests added: `crates/vibesql-executor/src/insert/validation.rs` `user_defined_numeric_affinity_tests` (whole-number REAL → INTEGER under NUMERIC affinity; fractional REAL unchanged; non-numeric text unchanged)
- [x] `cargo test -p vibesql-executor window` — 190 test-result blocks, 0 failed
- [x] `cargo test -p vibesql-executor -p vibesql-ast -p vibesql-parser -p vibesql-catalog` — 203 test-result blocks, 0 failed
- [x] Spot-checked `affinity2.test`, `affinity3.test`, `types.test`, `types2.test`, `types3.test` (affinity-sensitive TCL files) before/after — no new failures; all pre-existing residual failures are unrelated harness limitations (`db func`/custom-UDF, `tcl_variable_type` shim gaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)