### PR TITLE
fix(window): partitioned window's sort order wins multi-window output order

### DIFF
--- a/crates/vibesql-executor/src/select/window/evaluation.rs
+++ b/crates/vibesql-executor/src/select/window/evaluation.rs
@@ -86,6 +86,11 @@ pub(super) struct WindowEvaluationResult {
     /// Row indices in partition order (if PARTITION BY is present)
     /// This maps: partition_order_index -> original_row_index
     pub partition_order: Option<Vec<usize>>,
+    /// Whether this window has a non-empty PARTITION BY clause. Used by the
+    /// multi-window driver to decide which window's sort order determines the
+    /// final (no statement-level ORDER BY) output order: a partitioned window
+    /// takes precedence over a plain ORDER-BY-only window (window1.test 52.2-52.4).
+    pub has_partition_by: bool,
 }
 
 /// Evaluate a single window function over all rows
@@ -329,7 +334,7 @@ pub(super) fn evaluate_single_window_function(
     results_with_indices.sort_by_key(|(idx, _)| *idx);
     let values = results_with_indices.into_iter().map(|(_, result)| result).collect();
 
-    Ok(WindowEvaluationResult { values, partition_order })
+    Ok(WindowEvaluationResult { values, partition_order, has_partition_by })
 }
 
 /// Sequential evaluation of window function partitions

--- a/crates/vibesql-executor/src/select/window/mod.rs
+++ b/crates/vibesql-executor/src/select/window/mod.rs
@@ -83,27 +83,47 @@ pub(super) fn evaluate_window_functions(
     // Track the column index where window function results start
     let base_column_count = if rows.is_empty() { 0 } else { rows[0].values.len() };
 
-    // Track row reordering from the last window function with PARTITION BY/ORDER BY.
+    // Track row reordering that determines the final (no statement-level ORDER BY)
+    // output order.
     //
     // SQLite rewrites multi-window queries into nested sorting passes; when there
     // is no statement-level ORDER BY, rows are left in the order produced by the
-    // *last* window's sort pass. We mirror that by overwriting the captured order
-    // for each window function that has one (issue #5291, window9.test 1.4).
+    // final relevant sort pass. Empirically that pass is the last *partitioned*
+    // window when one exists, and otherwise the last plain ORDER-BY-only window:
+    //
+    //   - window9.test 1.4: `dense_rank() OVER (ORDER BY name)` followed by
+    //     `dense_rank() OVER (PARTITION BY name ORDER BY color)` — output is in the
+    //     partitioned window's order (issue #5291).
+    //   - window1.test 52.2-52.4: several windows over `PARTITION BY <const> ORDER BY a`
+    //     followed by a trailing `count(a) OVER (ORDER BY b)` — output is in the
+    //     partitioned window's `a` order, NOT the trailing ORDER-BY-b window's order.
+    //
+    // So a partitioned window's order takes precedence: once we have captured a
+    // partitioned window's order, a later ORDER-BY-only window must not override it.
+    // Among partitioned windows the last one wins; when no window is partitioned we
+    // fall back to the last ORDER-BY-only window (previous behavior).
     //
     // Known limitation: each pass's order is computed from the *original* input
     // order, whereas SQLite's chained passes stable-sort over the previous pass's
-    // output. These differ only when the last window's (PARTITION BY, ORDER BY)
+    // output. These differ only when the winning window's (PARTITION BY, ORDER BY)
     // keys have ties. If a future test demands exact tie behavior, reorder `rows`
     // (plus previously computed window columns) sequentially after each pass.
     let mut row_reordering: Option<Vec<usize>> = None;
+    let mut reordering_is_partitioned = false;
 
     for (idx, win_func) in window_functions.iter().enumerate() {
         let result = evaluation::evaluate_single_window_function(&rows, win_func, evaluator)?;
+        let has_partition_by = result.has_partition_by;
         window_results.push(result.values);
 
-        // Capture row reordering from the last window function that has one
+        // Capture row reordering, preferring partitioned windows over ORDER-BY-only ones.
         if result.partition_order.is_some() {
-            row_reordering = result.partition_order;
+            if has_partition_by {
+                row_reordering = result.partition_order;
+                reordering_is_partitioned = true;
+            } else if !reordering_is_partitioned {
+                row_reordering = result.partition_order;
+            }
         }
 
         // Build mapping: WindowFunctionKey -> column index

--- a/crates/vibesql-executor/src/tests/window1_residuals.rs
+++ b/crates/vibesql-executor/src/tests/window1_residuals.rs
@@ -211,3 +211,65 @@ fn test_non_correlated_aggregate_in_union_arm_not_flagged() {
         execute_sql(&mut db, "SELECT a FROM t0 WHERE (a,1)=(SELECT 2,2 UNION SELECT sum(5),1)");
     assert!(rows.is_ok(), "non-correlated aggregate in UNION arm must not be flagged: {rows:?}");
 }
+
+// ------------------------------------------------------------------------
+// 52.2-52.4 — multi-window output order: a partitioned window's sort order
+// takes precedence over a trailing ORDER-BY-only window when there is no
+// statement-level ORDER BY (window1.test 52.2-52.4).
+//
+// Previously the final output order was captured from the textually-last
+// window that had any ORDER BY (here `count(a) OVER (ORDER BY b)`), so rows
+// came out in `b` order. SQLite leaves the rows in the partitioned window's
+// (`win2 = PARTITION BY 6 ORDER BY a`) `a` order instead.
+// ------------------------------------------------------------------------
+
+fn first_column_ints(db: &mut vibesql_storage::Database, sql: &str) -> Vec<i64> {
+    execute_sql(db, sql)
+        .unwrap()
+        .iter()
+        .map(|r| match &r.values[0] {
+            SqlValue::Integer(n) => *n,
+            other => panic!("expected integer first column, got {other:?}"),
+        })
+        .collect()
+}
+
+fn setup_w52(db: &mut vibesql_storage::Database) {
+    execute_sql(db, "CREATE TABLE t1(a, b, c)").unwrap();
+    execute_sql(db, "INSERT INTO t1 VALUES('AA','bb',356)").unwrap();
+    execute_sql(db, "INSERT INTO t1 VALUES('CC','aa',158)").unwrap();
+    execute_sql(db, "INSERT INTO t1 VALUES('BB','aa',399)").unwrap();
+    execute_sql(db, "INSERT INTO t1 VALUES('FF','bb',938)").unwrap();
+}
+
+#[test]
+fn test_multi_window_partitioned_order_wins_over_trailing_orderby() {
+    let mut db = vibesql_storage::Database::new();
+    setup_w52(&mut db);
+    // window1.test 52.2: `count() OVER win1` is a running count over ORDER BY a,
+    // so a-sorted output must read 1,2,3,4 (AA,BB,CC,FF) — NOT b-sorted order.
+    let counts = first_column_ints(
+        &mut db,
+        "SELECT count() OVER win1, sum(c) OVER win2, first_value(c) OVER win2, \
+                count(a) OVER (ORDER BY b) \
+         FROM t1 \
+         WINDOW win1 AS (ORDER BY a), \
+                win2 AS (PARTITION BY 6 ORDER BY a \
+                         RANGE BETWEEN 5 PRECEDING AND 0 PRECEDING)",
+    );
+    assert_eq!(counts, vec![1, 2, 3, 4], "output must be in win2's `a` order");
+}
+
+#[test]
+fn test_multi_window_orderby_only_falls_back_to_last() {
+    // Regression guard for window9.test 1.4: when NO window is partitioned, the
+    // last ORDER-BY-only window still determines output order. Here both windows
+    // share ORDER BY a, so the running count reads 1,2,3,4.
+    let mut db = vibesql_storage::Database::new();
+    setup_w52(&mut db);
+    let counts = first_column_ints(
+        &mut db,
+        "SELECT count() OVER (ORDER BY a), count(a) OVER (ORDER BY a) FROM t1",
+    );
+    assert_eq!(counts, vec![1, 2, 3, 4]);
+}


### PR DESCRIPTION
## Summary

Partial increment of the window-frame / aggregate-FILTER conformance family (#6191). Fixes the multi-window final-output-ordering gap behind `window1.test` 52.2-52.4: when a query has several window functions and **no statement-level ORDER BY**, VibeSQL was leaving rows in the wrong window's sort order.

**Root cause.** `select/window/mod.rs` captured the row reordering from the *textually-last* window that had any ORDER BY. In `window1.test` 52.2-52.4 the trailing `count(a) OVER (ORDER BY b)` therefore forced `b` order, even though an earlier `win2 = PARTITION BY 6 ORDER BY a` window was present. SQLite leaves the rows in the **partitioned** window's `a` order. (The window function *values* were already computed correctly — only the emitted row order was wrong.)

**Fix.** Thread a `has_partition_by` flag out of `evaluate_single_window_function` and, in the multi-window driver, prefer the last *partitioned* window's order; fall back to the last ORDER-BY-only window only when no window is partitioned. That fallback preserves the previously-fixed `window9.test` 1.4 (issue #5291), whose output is correctly the last (and only) partitioned window's order.

## Changes

- `crates/vibesql-executor/src/select/window/evaluation.rs` — add `has_partition_by` to `WindowEvaluationResult`.
- `crates/vibesql-executor/src/select/window/mod.rs` — prefer the last partitioned window's order for final output; keep last-ORDER-BY fallback when none is partitioned. Documented against both anchor tests.
- `crates/vibesql-executor/src/tests/window1_residuals.rs` — two regression tests (partitioned-wins path + ORDER-BY-only fallback path).

## Fresh-build before/after (per file, this build — NOT certified run_id=1)

| File | Before | After | Notes |
| --- | --- | --- | --- |
| window1.test | 4 fail (52.2, 52.3, 52.4, 67.1) | **1 fail (67.1)** | fixed 52.2/52.3/52.4 |
| filter1.test | 1 fail (6.3) | 1 fail (6.3) | unchanged (see below) |
| filter2.test | 0 | 0 | 100% |
| window6.test | 0 (3 Bucket-A skips) | 0 | unchanged |
| window5.test | whole-file Bucket-A skip | same | C-API `sqlite3_create_window_function` |
| windowfault.test | whole-file Bucket-A skip | same | tvfs fault-injection |

No regressions across the rest of the window corpus on this build: window2/3/7/8/9 = 100%, window9.test 1.4 still green. window4.test has 2 pre-existing failures (7.3, 7.5) that are unrelated `lead(y, N, default)` default-argument gaps (7.3 is single-window; 7.5 uses one shared window spec) — untouched by this ordering change and out of scope for #6191.

## Straddlers / remaining (for the next increment)

- **window1 67.1** (`do_catchsql`): `ORDER BY (SELECT nth_value(a,2) OVER w1 WINDOW w1 AS (ORDER BY ((SELECT 1 FROM v1))))` — SQLite reports `no such table: v1`; VibeSQL masks it with `1st ORDER BY term does not match any column in the result set`. This is an **error-check ordering** issue in compound-query ORDER BY resolution (`select/executor/set_operations.rs`), not a frame/FILTER gap: the nested subquery's table references must be name-resolved before the ORDER-BY-column-match fallback. Left for a follow-up (must not regress 67.2, where `t2` exists and the column-match error is the correct one).
- **filter1 6.3**: `SELECT (SELECT COUNT(a) FROM t2) FROM t1` → SQLite hoists the aggregate to the outermost query that provides column `a` (result `2`); VibeSQL returns `1`. This is a deep aggregate-outer-scope binding semantic (previously deferred in #6244), unrelated to window frames / FILTER.
- **Bucket-A (#6154)**, unchanged from prior increments: window5 (whole file, C-API), windowfault (whole file, tvfs fault injection), window6 2.0/3.0/3.1 (`db func`/`db collate` custom UDF/collation).

## Acceptance Criteria Verification

| Criterion (issue #6191) | Status | Verification |
|---|---|---|
| window5/window6 real window-frame failures fixed; straddlers routed to Bucket-A | ✅ (this slice) | window1 52.2-52.4 multi-window ordering fixed; Bucket-A routing unchanged/verified |
| No regression in Rust window/aggregate unit tests | ✅ | `cargo test -p vibesql-executor --lib window` → 162 passed |
| Net certified-failure reduction reported from a fresh build (per-file) | ✅ | window1 4→1 on this build (table above) |
| filter1/2, window1 residuals individually explained if not fixed | ✅ | 67.1 + filter1 6.3 explained above |

## Test Plan

- `cargo build --release` (fresh) — green.
- `cargo test -p vibesql-executor --lib window` — 162 passed, incl. 2 new `window1_residuals` tests.
- `cargo test -p vibesql-executor --lib multi_window` — 2 passed.
- `cargo fmt`/`clippy` clean on the three changed files.
- TCL: `./scripts/tcltest test window1.test` → 320/1 (was 317/4); window2/3/4/6/7/8/9 re-run for regressions (none introduced).

Part of #6191