### PR TITLE
conformance(tcl): CREATE TABLE NOT NULL ON CONFLICT parsing + generated-column deps + REPLACE default substitution

### DIFF
--- a/crates/vibesql-executor/src/insert/defaults.rs
+++ b/crates/vibesql-executor/src/insert/defaults.rs
@@ -550,6 +550,44 @@ mod tests {
     }
 }
 
+/// Substitute the column DEFAULT value for a NOT NULL violation under the
+/// statement-level `REPLACE` conflict-resolution algorithm (`INSERT OR
+/// REPLACE` / `REPLACE INTO`).
+///
+/// Per <https://www.sqlite.org/lang_conflict.html>: "the REPLACE conflict
+/// resolution algorithm replaces the NULL value with the default value for
+/// that column, or if the column has no default value, then the ABORT
+/// algorithm is used." This is a distinct rule from REPLACE's usual
+/// duplicate-row-deletion behavior for PRIMARY KEY/UNIQUE — it fires even
+/// though a NOT NULL violation has no conflicting row to delete.
+///
+/// Must run after ordinary default-value application (so already-defaulted
+/// columns are a no-op here) but before generated-column evaluation, since a
+/// generated column may itself be declared NOT NULL by deriving from a
+/// stored column this substitution just fixed up (gencol1-7.11/7.20/7.30).
+/// A column with no default is left NULL, so the normal NOT NULL check
+/// downstream still raises the ABORT-equivalent error (gencol1's own
+/// fallback semantics).
+pub fn apply_replace_not_null_defaults(
+    schema: &vibesql_catalog::TableSchema,
+    row_values: &mut [vibesql_types::SqlValue],
+) -> Result<(), ExecutorError> {
+    for (col_idx, col) in schema.columns.iter().enumerate() {
+        if col.nullable || col.generated_expr.is_some() {
+            continue;
+        }
+        if row_values[col_idx] != vibesql_types::SqlValue::Null {
+            continue;
+        }
+        if let Some(default_expr) = &col.default_value {
+            let default_value = evaluate_default_expression(default_expr)?;
+            let coerced_value = super::validation::coerce_value(default_value, &col.data_type)?;
+            row_values[col_idx] = coerced_value;
+        }
+    }
+    Ok(())
+}
+
 /// Apply generated/computed column values
 /// Generated columns are defined with AS(expression) syntax and computed on INSERT/UPDATE
 pub fn apply_generated_columns(
@@ -560,13 +598,32 @@ pub fn apply_generated_columns(
     // Create a temporary row to evaluate generated expressions.
     // GeneratedColumn context: non-deterministic date/time uses (e.g.
     // `z AS (date())`) are rejected at evaluation time (SQLite, date2-140).
-    let temp_row = vibesql_storage::Row::new(row_values.to_vec());
+    let mut temp_row = vibesql_storage::Row::new(row_values.to_vec());
     let evaluator = crate::ExpressionEvaluator::new(schema)
         .with_schema_context(crate::evaluator::SchemaExprContext::GeneratedColumn);
 
-    for (col_idx, col) in schema.columns.iter().enumerate() {
-        // If column has a generated expression, compute and apply it
-        if let Some(generated_expr) = &col.generated_expr {
+    // Generated columns may reference other generated columns (e.g. a VIRTUAL
+    // column computed from a STORED column, strict1-7.1: `a INT AS (b*2)
+    // VIRTUAL, b INT AS (c*2) STORED`). A single pass in column-definition
+    // order only sees up-to-date values for *earlier*-indexed generated
+    // columns, so a forward reference (like `a` -> `b` above) would evaluate
+    // against `b`'s stale placeholder value. Iterate to a fixed point,
+    // re-evaluating and folding each freshly computed value back into
+    // `temp_row` so later (and earlier, on subsequent passes) columns see it.
+    // Bounded by the number of generated columns, which is also the longest
+    // possible acyclic dependency chain; SQLite rejects circular generated
+    // column definitions at CREATE TABLE time, so this always converges.
+    let generated_indices: Vec<usize> = schema
+        .columns
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, col)| col.generated_expr.as_ref().map(|_| idx))
+        .collect();
+
+    for _pass in 0..generated_indices.len().max(1) {
+        for &col_idx in &generated_indices {
+            let col = &schema.columns[col_idx];
+            let generated_expr = col.generated_expr.as_ref().expect("filtered above");
             let generated_value = evaluator.eval(generated_expr, &temp_row)?;
             // STRICT tables (issue #6173) apply SQLite's rigid strict-datatype
             // rules to the *computed* value of a generated column, exactly as
@@ -578,7 +635,8 @@ pub fn apply_generated_columns(
             } else {
                 super::validation::coerce_value(generated_value, &col.data_type)?
             };
-            row_values[col_idx] = coerced_value;
+            row_values[col_idx] = coerced_value.clone();
+            temp_row.values[col_idx] = coerced_value;
         }
     }
     Ok(())

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -864,6 +864,16 @@ fn execute_insert_internal(
             &assigned_columns,
         )?;
 
+        // INSERT OR REPLACE / REPLACE INTO: a NOT NULL column still holding
+        // NULL after ordinary default-value application (i.e. NULL was
+        // explicitly supplied, or the column was omitted and has no
+        // default-triggered value yet) gets the column's DEFAULT value
+        // substituted, per SQLite's REPLACE conflict-resolution rule for
+        // NOT NULL (gencol1-7.1x/7.2x/7.3x/7.4x/7.5x).
+        if matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Replace)) {
+            super::defaults::apply_replace_not_null_defaults(&schema, &mut full_row_values)?;
+        }
+
         // Apply generated/computed column values (AS(expression) syntax)
         super::defaults::apply_generated_columns(&schema, &mut full_row_values, db)?;
 

--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -442,10 +442,16 @@ impl Parser {
                     } else {
                         self.advance(); // consume NOT
                         self.expect_keyword(Keyword::Null)?;
-                        constraints.push(vibesql_ast::ColumnConstraint {
-                            name,
-                            kind: vibesql_ast::ColumnConstraintKind::NotNull,
-                        });
+                        // Parse optional ON CONFLICT clause (SQLite extension):
+                        // `col NOT NULL ON CONFLICT ROLLBACK|ABORT|FAIL|IGNORE|REPLACE`.
+                        let on_conflict = self.parse_constraint_conflict_clause()?;
+                        let kind = match on_conflict {
+                            Some(_) => vibesql_ast::ColumnConstraintKind::NotNullWithConflict {
+                                on_conflict,
+                            },
+                            None => vibesql_ast::ColumnConstraintKind::NotNull,
+                        };
+                        constraints.push(vibesql_ast::ColumnConstraint { name, kind });
                     }
                 }
                 Token::Keyword { keyword: Keyword::Deferrable, .. } => {

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -367,23 +367,49 @@ proc translate_error_to_sqlite {vibesql_error} {
     # - "child process exited abnormally"
     # We need to extract just the actual error message
 
-    # First, try to extract just the error line
+    # First, try to extract just the error line. A VibeSQL error message can
+    # itself span multiple lines (e.g. a CHECK constraint failure echoes the
+    # constraint's verbatim, possibly multi-line, source text: "CHECK
+    # constraint failed: x+y==11\n    OR x*y==12\n..." — check-4.6/4.9). Once
+    # the initial "Error executing statement N:" / "Error:" line is found,
+    # keep folding in subsequent RAW lines that are still part of the same
+    # message: stop at the next recognized error line, the CLI's
+    # "=== Script Execution Summary ===" trailer, EOF, or a line carrying the
+    # raw-mode row-framing control bytes (0x1e/0x1f) — which can only be
+    # genuine row output from a later statement, never engine error text.
     set error_msg ""
-    foreach line [split $vibesql_error "\n"] {
-        set line [string trim $line]
+    set lines [split $vibesql_error "\n"]
+    set nlines [llength $lines]
+    for {set li 0} {$li < $nlines} {incr li} {
+        set raw_line [lindex $lines $li]
+        set line [string trim $raw_line]
+        set msg ""
+        set matched 0
         # Look for "Error executing statement N: <message>"
         if {[regexp {^Error executing statement \d+: (.+)$} $line -> msg]} {
-            set error_msg $msg
-            break
+            set matched 1
+        } elseif {[regexp {^Error: (.+)$} $line -> msg]} {
+            # Also handle plain "Error: <message>"
+            set matched 1
+        } elseif {[string match "Error *" $line]} {
+            # Handle error lines that start with "Error" but have different format
+            set msg $line
+            set matched 1
         }
-        # Also handle plain "Error: <message>"
-        if {[regexp {^Error: (.+)$} $line -> msg]} {
+        if {$matched} {
             set error_msg $msg
-            break
-        }
-        # Handle error lines that start with "Error" but have different format
-        if {[string match "Error *" $line]} {
-            set error_msg $line
+            for {set lj [expr {$li + 1}]} {$lj < $nlines} {incr lj} {
+                set cont_raw [lindex $lines $lj]
+                set cont [string trim $cont_raw]
+                if {$cont eq ""} { break }
+                if {[string match "Error*" $cont]} { break }
+                if {[string match "=== Script Execution Summary ===*" $cont]} { break }
+                if {[string first "\x1e" $cont_raw] >= 0
+                        || [string first "\x1f" $cont_raw] >= 0} {
+                    break
+                }
+                append error_msg "\n" $cont
+            }
             break
         }
     }


### PR DESCRIPTION
## Summary

Part of #6173 — a targeted slice of the CREATE TABLE / schema-definition
conformance issue, found by chasing `strict1.test`, `gencol1.test`,
`check.test`, and `e_createtable.test` failures.

- **Parser**: `col NOT NULL ON CONFLICT <clause>` (a column-level conflict
  clause on a `NOT NULL` constraint) was a hard parse error ("near ON: syntax
  error"). `vibesql_ast::ColumnConstraintKind::NotNullWithConflict` and its
  downstream constraint-validator handling already existed — the parser
  simply never produced it. Now parses via the existing
  `parse_constraint_conflict_clause` helper (fixes e_createtable-4.19.0 and
  related "near ON" failures).

- **Generated columns**: `apply_generated_columns` evaluated every generated
  column against a single upfront snapshot row, so a `VIRTUAL` column
  computed from another (`STORED`) generated column saw that dependency's
  stale placeholder instead of its freshly computed value
  (`a INT AS (b*2) VIRTUAL, b INT AS (c*2) STORED` produced `a=NULL` instead
  of `a=4`). Now iterates to a fixed point, folding each computed value back
  into the working row before the next pass — bounded by the number of
  generated columns (SQLite forbids circular generated-column definitions,
  so this always converges). Fixes strict1-7.1 (`strict1.test` now 100%) and
  the equivalent `gencol1.test` dependency-chain cases.

- **INSERT OR REPLACE / REPLACE INTO NOT NULL substitution**: per
  https://www.sqlite.org/lang_conflict.html, `REPLACE` resolves a `NOT NULL`
  violation by substituting the column's `DEFAULT` value (falling back to
  the normal ABORT error only when the column has no default), rather than
  deleting/replacing a row. This was unimplemented — `REPLACE INTO` with an
  explicit `NULL` for a `NOT NULL DEFAULT` column always errored. Added
  `apply_replace_not_null_defaults`, run after ordinary default-value
  application and before generated-column evaluation (so a generated column
  derived from the fixed-up value computes correctly). Fixes
  gencol1-7.1x/7.2x/7.3x/7.4x/7.5x (10 tests).

- **Test shim** (`scripts/tester_vibesql.tcl`): `translate_error_to_sqlite`
  only captured the *first line* of a VibeSQL error, so a CHECK constraint
  failure whose source text spans multiple lines (SQLite echoes the
  verbatim, possibly multi-line, CHECK expression in its error message) was
  truncated and failed the `do_catchsql_test` comparison. Now folds in
  subsequent plain-text lines belonging to the same error until the next
  recognized error line, the CLI's summary trailer, EOF, or a line carrying
  raw-mode row-framing bytes (which can only be genuine row output from a
  later statement). Fixes check-4.6 and check-4.9.

## Measurements (single-file `make test-tcl-file` runs)

| File | Before | After |
|---|---|---|
| strict1.test | 48/49 | 49/49 (100%) |
| gencol1.test | 57/87 | 67/87 (77.0%) |
| check.test | 80/92 | 83/92 (90.2%) |
| e_createtable.test | 300/528 (56.8%) | 331/528 (62.7%) |

Remaining failures in these files are separate, larger features out of
scope for this slice: `PRAGMA ignore_check_constraints`, CHECK constraints
referencing not-yet-defined UDFs, full per-column/table `ON CONFLICT`
resolution enforcement for UNIQUE/PRIMARY KEY/NOT NULL beyond default ABORT
and the statement-level REPLACE substitution added here, and
AUTOINCREMENT/`sqlite_sequence` bookkeeping — tracked by the parent issue
#6173 for follow-up slices. A large block of `e_createtable-5.3.x`/`5.7.x`–
`5.11.x` failures traces to a separate test-shim transaction-batching
interaction (an open transaction spanning `drop_all_tables` + hundreds of
downstream statements) rather than an engine bug; flagged in #6173 as a
follow-up rather than fixed here given its scope/regression risk.

## Test plan

- [x] `cargo test --release -p vibesql-parser --lib` (1817 passed)
- [x] `cargo test --release -p vibesql-executor --lib` (3619 passed)
- [x] `make test-tcl-file FILE=strict1.test` — 49/49
- [x] `make test-tcl-file FILE=gencol1.test` — 67/87
- [x] `make test-tcl-file FILE=check.test` — 83/92
- [x] `make test-tcl-file FILE=e_createtable.test` — 331/528
- [x] Regression check: `trigger1.test` and `fkey1.test` pass/fail counts
      identical before/after the shim change (stash-diffed)
- [x] `cargo fmt` / `cargo clippy` clean on touched files

Part of #6173.