### PR TITLE
fix(parser,executor): MATCH/REGEXP operators, LIKE/GLOB numeric coercion, printf %e, CAST affinity gaps

### DIFF
--- a/crates/vibesql-executor/src/evaluator/arena.rs
+++ b/crates/vibesql-executor/src/evaluator/arena.rs
@@ -1056,13 +1056,17 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
             SqlValue::Varchar(s) | SqlValue::Character(s) => s.clone(),
             SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            SqlValue::Smallint(i) => arcstr::ArcStr::from(i.to_string()),
+            SqlValue::Unsigned(u) => arcstr::ArcStr::from(u.to_string()),
             // Render floats through the SqlValue Display impl (SQLite %!.15g
             // scientific rendering), not raw f64/f32 `to_string()` (fixed-point).
             // Display already matches SQLite 3.51; this keeps stored/CTE REAL
             // values consistent with inline literals for LIKE/GLOB (fixes atof-3.1).
-            f @ (SqlValue::Float(_) | SqlValue::Double(_) | SqlValue::Real(_)) => {
-                arcstr::ArcStr::from(f.to_string())
-            }
+            f @ (SqlValue::Float(_)
+            | SqlValue::Double(_)
+            | SqlValue::Real(_)
+            | SqlValue::Numeric(_)) => arcstr::ArcStr::from(f.to_string()),
+            SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             SqlValue::Blob(b) => arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned()),
             _ => {
                 return Err(ExecutorError::TypeError(format!(
@@ -1077,13 +1081,18 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
             SqlValue::Varchar(s) | SqlValue::Character(s) => s.clone(),
             SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            SqlValue::Smallint(i) => arcstr::ArcStr::from(i.to_string()),
+            SqlValue::Unsigned(u) => arcstr::ArcStr::from(u.to_string()),
             // Render floats through the SqlValue Display impl (SQLite %!.15g
             // scientific rendering), not raw f64/f32 `to_string()` (fixed-point).
             // Display already matches SQLite 3.51; this keeps stored/CTE REAL
             // values consistent with inline literals for LIKE/GLOB (fixes atof-3.1).
-            f @ (SqlValue::Float(_) | SqlValue::Double(_) | SqlValue::Real(_)) => {
-                arcstr::ArcStr::from(f.to_string())
-            }
+            f @ (SqlValue::Float(_)
+            | SqlValue::Double(_)
+            | SqlValue::Real(_)
+            | SqlValue::Numeric(_)) => arcstr::ArcStr::from(f.to_string()),
+            SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
+            SqlValue::Blob(b) => arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned()),
             _ => {
                 return Err(ExecutorError::TypeError(format!(
                     "LIKE requires string operands, got {:?} and {:?}",
@@ -1109,13 +1118,17 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
             SqlValue::Varchar(s) | SqlValue::Character(s) => s.clone(),
             SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            SqlValue::Smallint(i) => arcstr::ArcStr::from(i.to_string()),
+            SqlValue::Unsigned(u) => arcstr::ArcStr::from(u.to_string()),
             // Render floats through the SqlValue Display impl (SQLite %!.15g
             // scientific rendering), not raw f64/f32 `to_string()` (fixed-point).
             // Display already matches SQLite 3.51; this keeps stored/CTE REAL
             // values consistent with inline literals for LIKE/GLOB (fixes atof-3.1).
-            f @ (SqlValue::Float(_) | SqlValue::Double(_) | SqlValue::Real(_)) => {
-                arcstr::ArcStr::from(f.to_string())
-            }
+            f @ (SqlValue::Float(_)
+            | SqlValue::Double(_)
+            | SqlValue::Real(_)
+            | SqlValue::Numeric(_)) => arcstr::ArcStr::from(f.to_string()),
+            SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             SqlValue::Blob(b) => arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned()),
             _ => {
                 return Err(ExecutorError::TypeError(format!(
@@ -1130,13 +1143,18 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
             SqlValue::Varchar(s) | SqlValue::Character(s) => s.clone(),
             SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            SqlValue::Smallint(i) => arcstr::ArcStr::from(i.to_string()),
+            SqlValue::Unsigned(u) => arcstr::ArcStr::from(u.to_string()),
             // Render floats through the SqlValue Display impl (SQLite %!.15g
             // scientific rendering), not raw f64/f32 `to_string()` (fixed-point).
             // Display already matches SQLite 3.51; this keeps stored/CTE REAL
             // values consistent with inline literals for LIKE/GLOB (fixes atof-3.1).
-            f @ (SqlValue::Float(_) | SqlValue::Double(_) | SqlValue::Real(_)) => {
-                arcstr::ArcStr::from(f.to_string())
-            }
+            f @ (SqlValue::Float(_)
+            | SqlValue::Double(_)
+            | SqlValue::Real(_)
+            | SqlValue::Numeric(_)) => arcstr::ArcStr::from(f.to_string()),
+            SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
+            SqlValue::Blob(b) => arcstr::ArcStr::from(String::from_utf8_lossy(b).into_owned()),
             _ => {
                 return Err(ExecutorError::TypeError(format!(
                     "GLOB requires string operands, got {:?} and {:?}",

--- a/crates/vibesql-executor/src/evaluator/casting.rs
+++ b/crates/vibesql-executor/src/evaluator/casting.rs
@@ -173,6 +173,104 @@ pub(crate) fn string_to_number(s: &str) -> (i64, f64, bool) {
     }
 }
 
+/// SQLite `NUMERIC`-affinity conversion of a text value: decide INTEGER vs REAL
+/// exactly as SQLite does when casting text to NUMERIC (or applying NUMERIC
+/// affinity). Non-numeric text yields INTEGER 0.
+///
+/// Rules (SQLite datatype3 / e_expr-32 evidence):
+/// * Integer-form text (no '.' and no exponent) that fits in a signed 64-bit
+///   integer -> INTEGER; integer-form text describing a value outside the i64
+///   range -> REAL (R-50300-26941: "text input that describes a value outside
+///   the range of a 64-bit signed integer yields a REAL result").
+/// * Float-form text (has a '.' and/or an exponent) -> REAL, unless the value
+///   round-trips losslessly through a ~51-bit signed integer, in which case the
+///   result is INTEGER (R-47045-23194: no fractional part and -2^51 <= v < 2^51).
+///
+/// This differs from the naive "integral && fits i64 -> INTEGER" rule in two
+/// SQLite-significant ways: an integer literal that overflows i64 is REAL (not a
+/// clamped i64::MAX/MIN), and a float-form value whose magnitude exceeds 2^51
+/// stays REAL even though it has no fractional part.
+pub(crate) fn text_to_numeric(s: &str) -> vibesql_types::SqlValue {
+    use vibesql_types::SqlValue;
+    // 2^51 — the window inside which every integer is exactly representable as an
+    // f64 and thus round-trips losslessly (matches SQLite's sqlite3RealSameAsInt).
+    const LOSSLESS_INT_LIMIT: f64 = 2_251_799_813_685_248.0;
+
+    let trimmed = s.trim_start();
+    if trimmed.is_empty() {
+        return SqlValue::Integer(0);
+    }
+
+    // Keep the sign separate so we can parse the magnitude and still recognise
+    // i64::MIN, whose magnitude (9223372036854775808) does not itself fit in i64.
+    let (negative, rest) = match trimmed.chars().next() {
+        Some('-') => (true, &trimmed[1..]),
+        Some('+') => (false, &trimmed[1..]),
+        _ => (false, trimmed),
+    };
+
+    // Scan the numeric prefix, tracking whether it is float-form ('.'/exponent).
+    let chars: Vec<char> = rest.chars().collect();
+    let len = chars.len();
+    let mut has_decimal = false;
+    let mut has_exponent = false;
+    let mut end_idx = 0;
+    while end_idx < len {
+        let c = chars[end_idx];
+        if c.is_ascii_digit() {
+            end_idx += 1;
+        } else if c == '.' && !has_decimal && !has_exponent {
+            has_decimal = true;
+            end_idx += 1;
+        } else if (c == 'e' || c == 'E') && !has_exponent && end_idx > 0 {
+            // Only accept the exponent if a valid exponent digit follows the
+            // optional sign; otherwise the 'e' terminates the numeric prefix.
+            let mut j = end_idx + 1;
+            if j < len && (chars[j] == '+' || chars[j] == '-') {
+                j += 1;
+            }
+            if j < len && chars[j].is_ascii_digit() {
+                has_exponent = true;
+                end_idx = j;
+                while end_idx < len && chars[end_idx].is_ascii_digit() {
+                    end_idx += 1;
+                }
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    if end_idx == 0 {
+        return SqlValue::Integer(0);
+    }
+
+    let magnitude: String = chars[..end_idx].iter().collect();
+    let float_form = has_decimal || has_exponent;
+
+    if !float_form {
+        // Integer-form text: INTEGER when it fits in i64, else REAL.
+        let signed = if negative { format!("-{magnitude}") } else { magnitude.clone() };
+        if let Ok(n) = signed.parse::<i64>() {
+            return SqlValue::Integer(n);
+        }
+        let f = magnitude.parse::<f64>().unwrap_or(0.0);
+        return SqlValue::Numeric(if negative { -f } else { f });
+    }
+
+    // Float-form text: REAL, narrowed to INTEGER only when it round-trips
+    // losslessly through a ~51-bit signed integer.
+    let m = magnitude.parse::<f64>().unwrap_or(0.0);
+    let f = if negative { -m } else { m };
+    if f.fract() == 0.0 && f >= -LOSSLESS_INT_LIMIT && f < LOSSLESS_INT_LIMIT {
+        SqlValue::Integer(f as i64)
+    } else {
+        SqlValue::Numeric(f)
+    }
+}
+
 /// SQLite-compatible string-to-integer coercion for CAST to INTEGER
 ///
 /// According to SQLite documentation (R-24225-46995):
@@ -420,28 +518,10 @@ pub(crate) fn cast_value(
                 // String/blob: convert to most appropriate type
                 // SQLite NUMERIC affinity: use INTEGER if value is exact integer
                 // '1.0' -> 1 (integer), '1.5' -> 1.5 (real)
-                SqlValue::Varchar(s) | SqlValue::Character(s) => {
-                    let (int_val, float_val, _) = string_to_number(s);
-                    if float_val.fract() == 0.0
-                        && float_val >= i64::MIN as f64
-                        && float_val <= i64::MAX as f64
-                    {
-                        Ok(SqlValue::Integer(int_val))
-                    } else {
-                        Ok(SqlValue::Numeric(float_val))
-                    }
-                }
+                SqlValue::Varchar(s) | SqlValue::Character(s) => Ok(text_to_numeric(s)),
                 SqlValue::Blob(bytes) => {
                     let text = std::str::from_utf8(bytes).unwrap_or("");
-                    let (int_val, float_val, _) = string_to_number(text);
-                    if float_val.fract() == 0.0
-                        && float_val >= i64::MIN as f64
-                        && float_val <= i64::MAX as f64
-                    {
-                        Ok(SqlValue::Integer(int_val))
-                    } else {
-                        Ok(SqlValue::Numeric(float_val))
-                    }
+                    Ok(text_to_numeric(text))
                 }
                 _ => Ok(SqlValue::Integer(0)), // SQLite: Default to 0 for unknown types
             }
@@ -721,26 +801,25 @@ pub(crate) fn cast_value(
             vibesql_types::TypeAffinity::None => cast_value(value, &BinaryLargeObject, sql_mode),
             vibesql_types::TypeAffinity::Real => cast_value(value, &DoublePrecision, sql_mode),
             vibesql_types::TypeAffinity::Numeric => {
-                // SQLite NUMERIC cast: text converts to INTEGER when the value
-                // is integral and representable losslessly, otherwise REAL;
-                // non-numeric text converts to 0.
-                let numeric_from_text = |s: &str| -> vibesql_types::SqlValue {
-                    let (i, f, is_float) = string_to_number(s);
-                    if is_float {
-                        if f == f.trunc() && f >= i64::MIN as f64 && f <= i64::MAX as f64 {
-                            SqlValue::Integer(f as i64)
-                        } else {
-                            SqlValue::Double(f)
-                        }
-                    } else {
-                        SqlValue::Integer(i)
-                    }
+                // SQLite NUMERIC cast: text converts to INTEGER when the value is
+                // integral and losslessly representable, otherwise REAL; values
+                // outside the i64 range become REAL and non-numeric text is 0.
+                // text_to_numeric's REAL branch tags its result as `Numeric`;
+                // this call site's established convention (predating this
+                // shared helper) is `Double` for the CAST-to-unknown-typename
+                // NUMERIC-affinity path, so re-tag here rather than changing
+                // text_to_numeric's variant and disturbing its other caller.
+                let retag_double = |v: SqlValue| match v {
+                    SqlValue::Numeric(f) => SqlValue::Double(f),
+                    other => other,
                 };
                 match value {
-                    SqlValue::Varchar(s) | SqlValue::Character(s) => Ok(numeric_from_text(s)),
+                    SqlValue::Varchar(s) | SqlValue::Character(s) => {
+                        Ok(retag_double(text_to_numeric(s)))
+                    }
                     SqlValue::Blob(bytes) => {
                         let text = std::str::from_utf8(bytes).unwrap_or("");
-                        Ok(numeric_from_text(text))
+                        Ok(retag_double(text_to_numeric(text)))
                     }
                     SqlValue::Boolean(b) => Ok(SqlValue::Integer(if *b { 1 } else { 0 })),
                     // Values that already have a numeric storage class keep it

--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -238,12 +238,15 @@ impl CombinedExpressionEvaluator<'_> {
             // SQLite coerces numeric types to strings for LIKE comparison
             vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Smallint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Unsigned(u) => arcstr::ArcStr::from(u.to_string()),
             // Render floats through the SqlValue Display impl (SQLite %!.15g
             // scientific rendering), not raw f64/f32 `to_string()` (fixed-point).
             // Keeps stored/CTE REAL values consistent for LIKE/GLOB (fixes atof-3.1).
             f @ (vibesql_types::SqlValue::Float(_)
             | vibesql_types::SqlValue::Double(_)
-            | vibesql_types::SqlValue::Real(_)) => arcstr::ArcStr::from(f.to_string()),
+            | vibesql_types::SqlValue::Real(_)
+            | vibesql_types::SqlValue::Numeric(_)) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
             vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for LIKE comparison
@@ -267,12 +270,15 @@ impl CombinedExpressionEvaluator<'_> {
             // SQLite coerces numeric types to strings for LIKE comparison
             vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Smallint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Unsigned(u) => arcstr::ArcStr::from(u.to_string()),
             // Render floats through the SqlValue Display impl (SQLite %!.15g
             // scientific rendering), not raw f64/f32 `to_string()` (fixed-point).
             // Keeps stored/CTE REAL values consistent for LIKE/GLOB (fixes atof-3.1).
             f @ (vibesql_types::SqlValue::Float(_)
             | vibesql_types::SqlValue::Double(_)
-            | vibesql_types::SqlValue::Real(_)) => arcstr::ArcStr::from(f.to_string()),
+            | vibesql_types::SqlValue::Real(_)
+            | vibesql_types::SqlValue::Numeric(_)) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
             vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for the LIKE pattern too:
@@ -365,12 +371,15 @@ impl CombinedExpressionEvaluator<'_> {
             // SQLite coerces numeric types to strings for GLOB comparison
             vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Smallint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Unsigned(u) => arcstr::ArcStr::from(u.to_string()),
             // Render floats through the SqlValue Display impl (SQLite %!.15g
             // scientific rendering), not raw f64/f32 `to_string()` (fixed-point).
             // Keeps stored/CTE REAL values consistent for LIKE/GLOB (fixes atof-3.1).
             f @ (vibesql_types::SqlValue::Float(_)
             | vibesql_types::SqlValue::Double(_)
-            | vibesql_types::SqlValue::Real(_)) => arcstr::ArcStr::from(f.to_string()),
+            | vibesql_types::SqlValue::Real(_)
+            | vibesql_types::SqlValue::Numeric(_)) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
             vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for GLOB comparison
@@ -394,12 +403,15 @@ impl CombinedExpressionEvaluator<'_> {
             // SQLite coerces numeric types to strings for GLOB comparison
             vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Smallint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Unsigned(u) => arcstr::ArcStr::from(u.to_string()),
             // Render floats through the SqlValue Display impl (SQLite %!.15g
             // scientific rendering), not raw f64/f32 `to_string()` (fixed-point).
             // Keeps stored/CTE REAL values consistent for LIKE/GLOB (fixes atof-3.1).
             f @ (vibesql_types::SqlValue::Float(_)
             | vibesql_types::SqlValue::Double(_)
-            | vibesql_types::SqlValue::Real(_)) => arcstr::ArcStr::from(f.to_string()),
+            | vibesql_types::SqlValue::Real(_)
+            | vibesql_types::SqlValue::Numeric(_)) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
             vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for the GLOB pattern too

--- a/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/predicates.rs
@@ -520,6 +520,8 @@ impl ExpressionEvaluator<'_> {
             // SQLite coerces numeric types to strings for LIKE comparison
             vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Smallint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Unsigned(u) => arcstr::ArcStr::from(u.to_string()),
             // Render floats through the SqlValue Display impl, not raw f64/f32
             // `to_string()`. Rust's `f64::to_string` emits fixed-point text
             // ("18446744073709550000") while SQLite coerces REAL to its %!.15g
@@ -527,7 +529,8 @@ impl ExpressionEvaluator<'_> {
             // already matches SQLite 3.51 (fixes atof-3.1's GLOB comparison).
             f @ (vibesql_types::SqlValue::Float(_)
             | vibesql_types::SqlValue::Double(_)
-            | vibesql_types::SqlValue::Real(_)) => arcstr::ArcStr::from(f.to_string()),
+            | vibesql_types::SqlValue::Real(_)
+            | vibesql_types::SqlValue::Numeric(_)) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
             vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for LIKE comparison
@@ -551,6 +554,8 @@ impl ExpressionEvaluator<'_> {
             // SQLite coerces numeric types to strings for LIKE comparison
             vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Smallint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Unsigned(u) => arcstr::ArcStr::from(u.to_string()),
             // Render floats through the SqlValue Display impl, not raw f64/f32
             // `to_string()`. Rust's `f64::to_string` emits fixed-point text
             // ("18446744073709550000") while SQLite coerces REAL to its %!.15g
@@ -558,7 +563,8 @@ impl ExpressionEvaluator<'_> {
             // already matches SQLite 3.51 (fixes atof-3.1's GLOB comparison).
             f @ (vibesql_types::SqlValue::Float(_)
             | vibesql_types::SqlValue::Double(_)
-            | vibesql_types::SqlValue::Real(_)) => arcstr::ArcStr::from(f.to_string()),
+            | vibesql_types::SqlValue::Real(_)
+            | vibesql_types::SqlValue::Numeric(_)) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
             vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for the LIKE pattern too:
@@ -648,6 +654,8 @@ impl ExpressionEvaluator<'_> {
             // SQLite coerces numeric types to strings for GLOB comparison
             vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Smallint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Unsigned(u) => arcstr::ArcStr::from(u.to_string()),
             // Render floats through the SqlValue Display impl, not raw f64/f32
             // `to_string()`. Rust's `f64::to_string` emits fixed-point text
             // ("18446744073709550000") while SQLite coerces REAL to its %!.15g
@@ -655,7 +663,8 @@ impl ExpressionEvaluator<'_> {
             // already matches SQLite 3.51 (fixes atof-3.1's GLOB comparison).
             f @ (vibesql_types::SqlValue::Float(_)
             | vibesql_types::SqlValue::Double(_)
-            | vibesql_types::SqlValue::Real(_)) => arcstr::ArcStr::from(f.to_string()),
+            | vibesql_types::SqlValue::Real(_)
+            | vibesql_types::SqlValue::Numeric(_)) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
             vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for GLOB comparison
@@ -679,6 +688,8 @@ impl ExpressionEvaluator<'_> {
             // SQLite coerces numeric types to strings for GLOB comparison
             vibesql_types::SqlValue::Integer(i) => arcstr::ArcStr::from(i.to_string()),
             vibesql_types::SqlValue::Bigint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Smallint(i) => arcstr::ArcStr::from(i.to_string()),
+            vibesql_types::SqlValue::Unsigned(u) => arcstr::ArcStr::from(u.to_string()),
             // Render floats through the SqlValue Display impl, not raw f64/f32
             // `to_string()`. Rust's `f64::to_string` emits fixed-point text
             // ("18446744073709550000") while SQLite coerces REAL to its %!.15g
@@ -686,7 +697,8 @@ impl ExpressionEvaluator<'_> {
             // already matches SQLite 3.51 (fixes atof-3.1's GLOB comparison).
             f @ (vibesql_types::SqlValue::Float(_)
             | vibesql_types::SqlValue::Double(_)
-            | vibesql_types::SqlValue::Real(_)) => arcstr::ArcStr::from(f.to_string()),
+            | vibesql_types::SqlValue::Real(_)
+            | vibesql_types::SqlValue::Numeric(_)) => arcstr::ArcStr::from(f.to_string()),
             // SQLite has no boolean type: EXISTS/IN results behave as integers 0/1
             vibesql_types::SqlValue::Boolean(b) => arcstr::ArcStr::from(if *b { "1" } else { "0" }),
             // SQLite treats blob bytes as raw text for the GLOB pattern too

--- a/crates/vibesql-executor/src/evaluator/functions/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/mod.rs
@@ -175,6 +175,14 @@ pub(super) fn eval_scalar_function(
         "INTREAL" => sqlite_compat::intreal(args),
         "GLOB" => sqlite_compat::glob(args),
         "LIKE" => sqlite_compat::like(args),
+        // Default `match()` application-defined function backing the `X MATCH Y`
+        // operator (parsed as `match(Y, X)`). SQLite ships a genuine default
+        // implementation that always raises "unable to use function MATCH in
+        // the requested context" (R-42037-37826); there is deliberately no
+        // "REGEXP" case here — SQLite has no default `regexp()`, so `X REGEXP Y`
+        // (parsed as `regexp(Y, X)`) falls through to the generic "no such
+        // function: REGEXP" error below, matching SQLite exactly.
+        "MATCH" => sqlite_compat::match_default(args),
 
         // JSON functions (SQLite JSON1 extension)
         //

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/mod.rs
@@ -43,6 +43,7 @@ pub(super) use math_funcs::{likely, random, unlikely};
 // Re-export pattern functions
 pub(super) use pattern_funcs::glob;
 pub(super) use pattern_funcs::like;
+pub(super) use pattern_funcs::match_default;
 // Re-export string functions
 pub(super) use string_funcs::char_func;
 pub(super) use string_funcs::{concat_ws, printf, unicode, unistr};

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/pattern_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/pattern_funcs.rs
@@ -52,10 +52,9 @@ pub(crate) fn like(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         // Floats coerce through the SqlValue Display impl (%!.15g), not the raw
         // f64/f32 `to_string()`. SQLite compares against the %!.15g rendering, so
         // `2.0 LIKE '2.0'` is true and `1e300 LIKE '1.0e+300'` is true.
-        SqlValue::Real(_)
-        | SqlValue::Double(_)
-        | SqlValue::Numeric(_)
-        | SqlValue::Float(_) => Cow::Owned(args[1].to_string()),
+        SqlValue::Real(_) | SqlValue::Double(_) | SqlValue::Numeric(_) | SqlValue::Float(_) => {
+            Cow::Owned(args[1].to_string())
+        }
         SqlValue::Boolean(b) => Cow::Owned(if *b { "1".to_string() } else { "0".to_string() }),
         other => Cow::Owned(other.to_string()),
     };
@@ -132,10 +131,9 @@ pub(crate) fn glob(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         SqlValue::Unsigned(u) => Cow::Owned(u.to_string()),
         // Floats coerce through the SqlValue Display impl (%!.15g), not the raw
         // f64/f32 `to_string()`, matching SQLite's GLOB coercion.
-        SqlValue::Real(_)
-        | SqlValue::Double(_)
-        | SqlValue::Numeric(_)
-        | SqlValue::Float(_) => Cow::Owned(args[1].to_string()),
+        SqlValue::Real(_) | SqlValue::Double(_) | SqlValue::Numeric(_) | SqlValue::Float(_) => {
+            Cow::Owned(args[1].to_string())
+        }
         SqlValue::Boolean(b) => Cow::Owned(if *b { "1".to_string() } else { "0".to_string() }),
         other => Cow::Owned(other.to_string()),
     };
@@ -143,6 +141,25 @@ pub(crate) fn glob(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
     // Use the pattern matching function from pattern.rs
     let matched = crate::evaluator::pattern::glob_match(&text, pattern);
     Ok(SqlValue::Integer(if matched { 1 } else { 0 }))
+}
+
+/// match(pattern, string) - the default `match()` application-defined function
+/// that backs the `X MATCH Y` infix operator (parsed as `match(Y, X)`).
+///
+/// SQLite ships a genuine default implementation of `match()` (R-42037-37826):
+/// unlike `regexp()` (which simply doesn't exist unless an extension registers
+/// it), `match()` is always present and its default behavior is to raise this
+/// exact error — it is only useful once an extension (e.g. FTS3/4/5) or a
+/// user-registered function overrides it with real matching logic. VibeSQL has
+/// no virtual-table MATCH override mechanism, so this default is always what
+/// callers get, matching SQLite's out-of-the-box behavior.
+pub(crate) fn match_default(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
+    if args.len() != 2 {
+        return Err(ExecutorError::WrongNumberOfArguments { function_name: "match".to_string() });
+    }
+    Err(ExecutorError::SqliteCompatError(
+        "unable to use function MATCH in the requested context".to_string(),
+    ))
 }
 
 #[cfg(test)]

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/string_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/string_funcs.rs
@@ -378,7 +378,15 @@ fn format_float_with_spec(val: &SqlValue, spec: &FormatSpec) -> String {
     format!("{:.prec$}", f, prec = precision)
 }
 
-fn format_scientific_with_spec(val: &SqlValue, uppercase: bool, _spec: &FormatSpec) -> String {
+/// `%e`/`%E` scientific-notation formatting, matching C's `printf("%e", ...)`:
+/// `[-]d.dddddde±dd` — exactly one digit before the decimal point, `precision`
+/// digits after it (default 6 when no precision is given), and an exponent
+/// with an explicit sign and a minimum of two digits. Rust's `{:e}` Display
+/// (used previously) instead emits Rust-style notation with no default
+/// precision and no exponent sign/padding (e.g. "1.234567891e6" instead of
+/// "1.234568e+06"), so it cannot be used directly — this builds the C form
+/// from Rust's precision-aware `{:.N e}` mantissa/exponent split.
+fn format_scientific_with_spec(val: &SqlValue, uppercase: bool, spec: &FormatSpec) -> String {
     let f = match val {
         SqlValue::Null => return "(null)".to_string(),
         SqlValue::Integer(i) => *i as f64,
@@ -391,11 +399,37 @@ fn format_scientific_with_spec(val: &SqlValue, uppercase: bool, _spec: &FormatSp
         _ => 0.0,
     };
 
-    if uppercase {
-        format!("{:E}", f)
-    } else {
-        format!("{:e}", f)
+    if f.is_nan() {
+        return if uppercase { "NAN".to_string() } else { "nan".to_string() };
     }
+    if f.is_infinite() {
+        let sign = if f < 0.0 { "-" } else { "" };
+        return format!("{}{}", sign, if uppercase { "INF" } else { "inf" });
+    }
+
+    let precision = spec.precision.unwrap_or(6);
+    let negative = f.is_sign_negative() && f != 0.0;
+
+    // Rust's `{:.N e}` on the absolute value already normalizes to exactly one
+    // non-zero digit before the point (d.ddddde<exp>, no sign, no exponent
+    // padding) — split that apart and re-render the exponent in C form.
+    let formatted = format!("{:.prec$e}", f.abs(), prec = precision);
+    let (mantissa, exp_str) = formatted.split_once('e').unwrap_or((formatted.as_str(), "0"));
+    let exp: i32 = exp_str.parse().unwrap_or(0);
+    let exp_sign = if exp < 0 { '-' } else { '+' };
+
+    let sign = if negative {
+        "-"
+    } else if spec.show_sign {
+        "+"
+    } else if spec.space_sign {
+        " "
+    } else {
+        ""
+    };
+
+    let e_char = if uppercase { 'E' } else { 'e' };
+    format!("{}{}{}{}{:02}", sign, mantissa, e_char, exp_sign, exp.abs())
 }
 
 fn format_string_with_spec(val: &SqlValue, spec: &FormatSpec) -> String {

--- a/crates/vibesql-executor/src/evaluator/operators/string.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/string.rs
@@ -30,11 +30,17 @@ impl StringOps {
             // Boolean - SQLite treats as integer 0/1
             Boolean(b) => if *b { "1" } else { "0" }.to_string(),
 
-            // Float types - use Rust's default formatting which is SQLite-compatible
-            Numeric(n) => format_float(*n),
-            Float(f) => format_float(*f as f64),
-            Real(r) => format_float(*r as f64),
-            Double(d) => format_float(*d),
+            // Float types - delegate to SqlValue's canonical Display impl
+            // (vibesql-types sql_value::display::format_f64/format_f32), which
+            // already implements SQLite's %!.15g rendering including scientific
+            // notation for |n| >= 1e15 or very small magnitudes. This used to be
+            // a second, independent formatter (`format_float` below) that only
+            // used scientific notation via Rust's bare `to_string()` fallback —
+            // which does NOT match SQLite's %!.15g scientific form — and never
+            // triggered for values like 9223372036854775808.0 that are exactly
+            // representable as an f64 "whole number" but far too large to print
+            // in fixed-point (e_expr-32.2.8: `CAST(x AS NUMERIC)||''`).
+            Numeric(_) | Float(_) | Real(_) | Double(_) => value.to_string(),
 
             // Temporal types
             Date(d) => d.to_string(),
@@ -72,30 +78,6 @@ impl StringOps {
         let left_str = Self::to_concat_string(left);
         let right_str = Self::to_concat_string(right);
         Ok(SqlValue::Varchar(arcstr::ArcStr::from(format!("{}{}", left_str, right_str))))
-    }
-}
-
-/// Format a float value for concatenation (SQLite-compatible).
-///
-/// Uses minimal representation: integers show without decimals,
-/// floats show their natural decimal representation.
-#[inline]
-fn format_float(n: f64) -> String {
-    if n.is_nan() {
-        "NaN".to_string()
-    } else if n.is_infinite() {
-        if n > 0.0 {
-            "Infinity".to_string()
-        } else {
-            "-Infinity".to_string()
-        }
-    } else if n.fract() == 0.0 && n.abs() < 1e15 {
-        // Whole number - format without decimals but add .0 for floats
-        // SQLite shows "10.0" for float 10.0, not "10"
-        format!("{}.0", n as i64)
-    } else {
-        // Fractional or very large - use default formatting
-        n.to_string()
     }
 }
 

--- a/crates/vibesql-parser/src/arena_parser/expression.rs
+++ b/crates/vibesql-parser/src/arena_parser/expression.rs
@@ -1639,7 +1639,13 @@ impl<'arena> ArenaParser<'arena> {
 
     /// Parse data type (simplified).
     pub(crate) fn parse_data_type(&mut self) -> Result<vibesql_types::DataType, ParseError> {
-        // Get type name as uppercase string
+        // Get type name as uppercase string (for matching known type names below),
+        // while also keeping the original-case spelling for the UserDefined
+        // fallback (unknown type names, e.g. CAST(x AS banana)/CAST(x AS shobblob_x)).
+        let original_name = match self.peek() {
+            Token::Identifier(type_name) => Some(type_name.clone()),
+            _ => None,
+        };
         let type_upper = match self.peek() {
             Token::Identifier(type_name) => type_name.to_uppercase(),
             Token::Keyword { keyword: Keyword::Date, .. } => "DATE".to_string(),
@@ -1753,8 +1759,18 @@ impl<'arena> ArenaParser<'arena> {
                 Ok(vibesql_types::DataType::Character { length })
             }
             _ => {
-                // Unknown type - default to varchar
-                Ok(vibesql_types::DataType::Varchar { max_length: None })
+                // Unknown type name (e.g. CAST(x AS banana), CAST(x AS shobblob_x)):
+                // SQLite accepts any type name and derives affinity from it via
+                // substring rules (INT/CHAR-CLOB-TEXT/BLOB/REAL-FLOA-DOUB, else
+                // NUMERIC) — see DataType::sqlite_affinity(). This used to
+                // default to `Varchar` (TEXT affinity unconditionally), which
+                // silently made CAST(x AS <unrecognized-name>) a no-op for text
+                // values instead of applying the declared name's real affinity
+                // (e_expr-27.3.2/27.3.3: `CAST('def' AS shobblob_x)` must yield
+                // BLOB, not TEXT, because the name contains "BLOB").
+                Ok(vibesql_types::DataType::UserDefined {
+                    type_name: original_name.unwrap_or(type_upper),
+                })
             }
         }
     }

--- a/crates/vibesql-parser/src/keywords.rs
+++ b/crates/vibesql-parser/src/keywords.rs
@@ -60,6 +60,7 @@ pub enum Keyword {
     Symmetric,
     Like,
     Glob,
+    Regexp,
     Escape,
     Exists,
     If,
@@ -624,6 +625,7 @@ impl Keyword {
                 | Keyword::Level
                 | Keyword::Like
                 | Keyword::Match
+                | Keyword::Regexp
                 | Keyword::Materialized
                 | Keyword::No
                 | Keyword::Nulls
@@ -722,6 +724,7 @@ impl fmt::Display for Keyword {
             Keyword::Symmetric => "SYMMETRIC",
             Keyword::Like => "LIKE",
             Keyword::Glob => "GLOB",
+            Keyword::Regexp => "REGEXP",
             Keyword::Escape => "ESCAPE",
             Keyword::Exists => "EXISTS",
             Keyword::If => "IF",

--- a/crates/vibesql-parser/src/lexer/keywords.rs
+++ b/crates/vibesql-parser/src/lexer/keywords.rs
@@ -63,6 +63,7 @@ static KEYWORDS: phf::Map<&'static str, Keyword> = phf_map! {
     "SYMMETRIC" => Keyword::Symmetric,
     "LIKE" => Keyword::Like,
     "GLOB" => Keyword::Glob,
+    "REGEXP" => Keyword::Regexp,
     "ESCAPE" => Keyword::Escape,
     "EXISTS" => Keyword::Exists,
     "IF" => Keyword::If,

--- a/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
+++ b/crates/vibesql-parser/src/parser/expressions/functions/mod.rs
@@ -42,6 +42,7 @@ impl Parser {
             | Token::Keyword { keyword: Keyword::Glob, .. }
             | Token::Keyword { keyword: Keyword::Like, .. }
             | Token::Keyword { keyword: Keyword::Match, .. }
+            | Token::Keyword { keyword: Keyword::Regexp, .. }
             | Token::Keyword { keyword: Keyword::Date, .. }
             | Token::Keyword { keyword: Keyword::Time, .. }
             | Token::Keyword { keyword: Keyword::If, .. } => {
@@ -58,6 +59,7 @@ impl Parser {
                     Token::Keyword { keyword: Keyword::Glob, .. } => "glob",
                     Token::Keyword { keyword: Keyword::Like, .. } => "like",
                     Token::Keyword { keyword: Keyword::Match, .. } => "match",
+                    Token::Keyword { keyword: Keyword::Regexp, .. } => "regexp",
                     Token::Keyword { keyword: Keyword::Date, .. } => "date",
                     Token::Keyword { keyword: Keyword::Time, .. } => "time",
                     Token::Keyword { keyword: Keyword::If, .. } => "if",
@@ -82,12 +84,12 @@ impl Parser {
         };
 
         self.advance(); // consume '('
-        // JSONB aggregate accept-and-convert: `jsonb_group_array` /
-        // `jsonb_group_object` are text-mode aliases of their `json_group_*`
-        // counterparts (VibeSQL does not implement binary JSONB — see #5786).
-        // Normalize them to the canonical `json_group_*` name here so every
-        // downstream aggregate site (detection, evaluation, window) recognizes
-        // them without duplicating the alias in each match.
+                        // JSONB aggregate accept-and-convert: `jsonb_group_array` /
+                        // `jsonb_group_object` are text-mode aliases of their `json_group_*`
+                        // counterparts (VibeSQL does not implement binary JSONB — see #5786).
+                        // Normalize them to the canonical `json_group_*` name here so every
+                        // downstream aggregate site (detection, evaluation, window) recognizes
+                        // them without duplicating the alias in each match.
         let first = match function_name.to_uppercase().as_str() {
             "JSONB_GROUP_ARRAY" => "json_group_array".to_string(),
             "JSONB_GROUP_OBJECT" => "json_group_object".to_string(),

--- a/crates/vibesql-parser/src/parser/expressions/operators.rs
+++ b/crates/vibesql-parser/src/parser/expressions/operators.rs
@@ -369,6 +369,27 @@ impl Parser {
     /// list/subquery or a table name), so a tighter-binding operator that follows an
     /// IN node takes the whole IN expression as its left operand:
     /// `1 IN (SELECT 1) + 1` parses as `(1 IN (SELECT 1)) + 1`.
+    /// Build the function-call AST for the `MATCH` / `REGEXP` infix operators.
+    ///
+    /// Per SQLite docs (R-37916-47407, R-33693-50180) `X MATCH Y` and
+    /// `X REGEXP Y` are pure syntactic sugar for the application-defined
+    /// function calls `match(Y, X)` / `regexp(Y, X)` — note the swapped
+    /// argument order (pattern first, expr second). Unlike LIKE/GLOB there is
+    /// no ESCAPE clause for either operator. `fn_name` is used verbatim as the
+    /// function's *display* name (SQLite reports "no such function: REGEXP",
+    /// preserving the operator's case, when no such function is registered).
+    fn build_match_regexp_call(
+        fn_name: &str,
+        expr: vibesql_ast::Expression,
+        pattern: vibesql_ast::Expression,
+    ) -> vibesql_ast::Expression {
+        vibesql_ast::Expression::Function {
+            name: vibesql_ast::FunctionIdentifier::new(fn_name),
+            args: vec![pattern, expr],
+            character_unit: None,
+        }
+    }
+
     pub(super) fn parse_comparison_expression(
         &mut self,
     ) -> Result<vibesql_ast::Expression, ParseError> {
@@ -556,6 +577,27 @@ impl Parser {
                         pattern: Box::new(pattern),
                         negated: true,
                         escape,
+                    };
+                    continue;
+                } else if self.peek_keyword(Keyword::Match) {
+                    // It's NOT MATCH. Per SQLite (R-37916-47407): "X MATCH Y" is
+                    // syntactic sugar for the application-defined function call
+                    // "match(Y, X)" (argument order swapped), no ESCAPE clause.
+                    self.consume_keyword(Keyword::Match)?;
+                    let pattern = self.parse_relational_expression()?;
+                    left = vibesql_ast::Expression::UnaryOp {
+                        op: vibesql_ast::UnaryOperator::Not,
+                        expr: Box::new(Self::build_match_regexp_call("MATCH", left, pattern)),
+                    };
+                    continue;
+                } else if self.peek_keyword(Keyword::Regexp) {
+                    // It's NOT REGEXP. Per SQLite (R-33693-50180): "X REGEXP Y" is
+                    // syntactic sugar for the function call "regexp(Y, X)".
+                    self.consume_keyword(Keyword::Regexp)?;
+                    let pattern = self.parse_relational_expression()?;
+                    left = vibesql_ast::Expression::UnaryOp {
+                        op: vibesql_ast::UnaryOperator::Not,
+                        expr: Box::new(Self::build_match_regexp_call("REGEXP", left, pattern)),
                     };
                     continue;
                 } else if self.peek_keyword(Keyword::Null) {
@@ -799,6 +841,20 @@ impl Parser {
                     negated: false,
                     escape,
                 };
+                continue;
+            } else if self.peek_keyword(Keyword::Match) {
+                // It's MATCH (not negated). Per SQLite (R-37916-47407): "X MATCH Y"
+                // is syntactic sugar for the function call "match(Y, X)".
+                self.consume_keyword(Keyword::Match)?;
+                let pattern = self.parse_relational_expression()?;
+                left = Self::build_match_regexp_call("MATCH", left, pattern);
+                continue;
+            } else if self.peek_keyword(Keyword::Regexp) {
+                // It's REGEXP (not negated). Per SQLite (R-33693-50180): "X REGEXP Y"
+                // is syntactic sugar for the function call "regexp(Y, X)".
+                self.consume_keyword(Keyword::Regexp)?;
+                let pattern = self.parse_relational_expression()?;
+                left = Self::build_match_regexp_call("REGEXP", left, pattern);
                 continue;
             }
 


### PR DESCRIPTION
## Summary

Partial increment on the largest in-scope conformance family (#6172, Part of epic #5779: expression / type-affinity / literal semantics). Starts with the `e_expr.test` file-scope setup failure the issue calls out first, then fixes several real expression-evaluation bugs found while chasing it down.

- **Parser**: `MATCH` and `REGEXP` are now recognized as SQL infix comparison operators (with `NOT` variants), translated to their documented function-call sugar per SQLite docs: `X MATCH Y` → `match(Y, X)` (R-37916-47407), `X REGEXP Y` → `regexp(Y, X)` (R-33693-50180). Previously **neither operator was recognized at all** — `SELECT 'abc' MATCH 'def'` was a hard parse error (`near "MATCH": syntax error`) anywhere in the grammar, not just in `e_expr.test`.
- **Executor**: implemented SQLite's default `match()` builtin, which always raises `"unable to use function MATCH in the requested context"` unless overridden by an extension (R-42037-37826). `regexp()` deliberately has no default implementation, so `X REGEXP Y` now correctly falls through to the existing `"no such function: REGEXP"` error path.
- **Executor**: fixed a `Type mismatch` bug in the infix `LIKE`/`GLOB` evaluators — three separate duplicated implementations (`arena.rs`, `expressions/predicates.rs`, `combined/predicates.rs`) coerced `Integer`/`Bigint`/`Float`/`Double`/`Real` operands to text but were missing `Numeric`/`Smallint`/`Unsigned`, so e.g. `'abc' GLOB 123.4` errored instead of comparing against the text `"123.4"`. This single gap was silently swallowing an entire `e_expr.test` cascade — a `foreach op $oplist { foreach {n1 rhs} $literals { foreach {n2 lhs} $literals { ... typeof($lhs $op $rhs) ... } } }` loop that aborted uncaught on the first `GLOB`/text-vs-numeric pair, losing ~163 assertions to a single `filescope-err` marker.
- **Executor**: fixed `printf('%e'/'%E', ...)` to produce real C-style scientific notation (`1.234568e+06`, precision-aware, signed 2-digit exponent) instead of delegating to Rust's bare `{:e}` Display formatter, which ignores precision entirely and renders the wrong exponent form (`1.234567891e6`).
- **Executor**: fixed `||` string concatenation's float-to-text conversion to delegate to `SqlValue`'s canonical Display impl (SQLite's `%!.15g` rendering, including scientific notation for `|n| >= 1e15`) instead of a second, independent, buggy formatter that always used fixed-point notation for large float values (e.g. `9223372036854775808.0 || ''` produced `"9223372036854776000"` instead of `"9.22337203685478e+18"`).
- **Parser (arena parser)**: fixed the `CAST`/column type-name fallback for unrecognized type names (e.g. `CAST(x AS banana)`, `CAST(x AS shobblob_x)`) — it was unconditionally defaulting to `Varchar` (TEXT affinity), silently making such casts a no-op for text values, instead of producing `DataType::UserDefined` so SQLite's substring-based affinity rules (`INT`→INTEGER, `CHAR`/`CLOB`/`TEXT`→TEXT, `BLOB`→NONE, `REAL`/`FLOA`/`DOUB`→REAL, else NUMERIC) actually apply. This only affected the CLI/prepared-statement fast path (the arena parser); the classic parser already had this correct, which is why the corresponding unit tests didn't catch it.

## Changes

- `crates/vibesql-parser/src/keywords.rs`, `crates/vibesql-parser/src/lexer/keywords.rs`: add `Keyword::Regexp` (non-reserved / SQLite fallback-identifier set, matching `LIKE`/`GLOB`/`MATCH`).
- `crates/vibesql-parser/src/parser/expressions/operators.rs`: parse `MATCH`/`REGEXP` (and `NOT MATCH`/`NOT REGEXP`) at the same precedence tier as `LIKE`/`GLOB`, translating to function-call sugar via a new `build_match_regexp_call` helper.
- `crates/vibesql-parser/src/parser/expressions/functions/mod.rs`: allow `REGEXP` as a function name too (`SELECT regexp(...)`), matching the existing `GLOB`/`LIKE`/`MATCH` allowance.
- `crates/vibesql-parser/src/arena_parser/expression.rs`: `parse_data_type`'s unknown-type-name fallback now produces `UserDefined { type_name }` (preserving original case) instead of `Varchar`.
- `crates/vibesql-executor/src/evaluator/functions/sqlite_compat/pattern_funcs.rs`, `mod.rs`, `functions/mod.rs`: new `match_default()` builtin.
- `crates/vibesql-executor/src/evaluator/{arena.rs,expressions/predicates.rs,combined/predicates.rs}`: add missing `Numeric`/`Smallint`/`Unsigned` (and, in `arena.rs`, missing `Boolean`) arms to the `LIKE`/`GLOB` text-coercion match blocks.
- `crates/vibesql-executor/src/evaluator/functions/sqlite_compat/string_funcs.rs`: rewrite `format_scientific_with_spec` (`%e`/`%E`) to build proper C-style output from Rust's precision-aware `{:.N e}` mantissa/exponent split.
- `crates/vibesql-executor/src/evaluator/operators/string.rs`: `to_concat_string`'s float arms now delegate to `SqlValue::to_string()` instead of a duplicated, buggy `format_float` (removed).
- `crates/vibesql-executor/src/evaluator/casting.rs`: (pre-existing work-in-progress from this worktree, verified/fixed and included) a shared `text_to_numeric` helper implementing SQLite's exact NUMERIC-affinity text→INTEGER/REAL rules (including the >i64::MAX/lossless-51-bit-round-trip edge cases), replacing two near-duplicate ad hoc implementations. Fixed a regression it introduced against an existing test (`test_cast_to_unknown_typename_numeric_affinity` expects `Double`, not `Numeric`, for the CAST-to-unknown-typename NUMERIC path) by re-tagging at that one call site rather than changing the shared helper's variant.

## Acceptance Criteria Verification

- `make test-tcl-file FILE=e_expr.test`: **307 → 301 failed** (out of 4924 → 5087 total tests; the total count itself grew by 163 because unblocking the `typeof()` cascade loop revealed 163 previously-invisible assertions, all now passing). Combined with the 5 individually-fixed tests (`e_expr-27.3.2/3`, `e_expr-32.1.8/9`, `e_expr-32.2.8`), that's **+168 net passing assertions** in this one file.
- Remaining 46 `filescope-err` markers in `e_expr.test` are all confirmed genuinely out-of-scope for a SQL-CLI-only harness, not left uninvestigated:
  - 30 markers: `sqlite3_prepare_v2`/`sqlite3_bind_*`/`sqlite3_step` C-API bound-parameter introspection (`parameter_test` proc) — same class as the already-documented `nan.test`/`types3.test` C-API-bound satellites.
  - 10 markers: `ATTACH 'test.db2' AS dbname` — VibeSQL has no multi-database/ATTACH support; already a documented, established out-of-scope gap (`scripts/tester_vibesql.tcl` has an existing auto-skip regex for `do_execsql_test`-wrapped ATTACH usage, but this file's raw `execsql {ATTACH ...}` at file scope isn't a `do_execsql_test`, so it cascades instead of cleanly skipping — the underlying limitation is the same).
  - Registration of `db func`/`db collate` is a no-op in the TCL shim (no bridge from VibeSQL's subprocess-per-query CLI model back into TCL callbacks), so the file's own `matchfunc`/`regexfunc` overrides (meant to make `MATCH`/`REGEXP` behave like `==` for its precedence-evidence loop) never take effect; the loop hits VibeSQL's new, SQLite-correct default `match()` error instead. This is an inherent harness limitation, not something fixable short of a UDF-callback bridge (a much larger, separate effort).
- `e_expr-23.1.x` (`CASE`-comparison collation semantics), `e_expr-30.1.x`/`28.1.x`/`33.1.x` (UTF-16LE/BE `PRAGMA encoding` dependent CAST/BLOB tests — VibeSQL is UTF-8 only), and `e_expr-11.1.x` (`?NNN` max-variable-number bounds-checking error text) were investigated but intentionally left for a follow-up builder — real gaps, but each is either a separate large feature (multi-encoding text storage) or needs more careful comparison-affinity semantics work than fits a bounded increment.
- Satellite files from the issue's table were spot-checked but are **unchanged** by this PR (confirmed already out of scope, not overlooked): `nan.test` and `types3.test` are 100%/95% built around `sqlite3_prepare`/`sqlite3_bind_double`/Tcl-dual-representation C-API introspection with no SQL-text equivalent. `like3.test`/`unhex.test` failures are UTF-16-encoding-dependent. `quote.test` has a real, separate gap (`"no such column: X" - should this be a string literal in single-quotes?"` hint text SQLite appends to ambiguous double-quoted-identifier errors) that would require threading original-quoting info through dozens of `"no such column"` call sites — flagged for a follow-up, not attempted here to keep this PR's blast radius bounded.
- `cargo test -p vibesql-parser -p vibesql-executor --release --lib`: 1821 + 3627 passed, 0 failed (2 pre-existing ignored).
- `cargo build --workspace --release`: clean.

## Test Plan

- [x] `cargo build --workspace --release` — clean build, no new warnings introduced beyond pre-existing baseline.
- [x] `cargo test -p vibesql-parser --release` — 1821 lib + 8 doctests, all pass.
- [x] `cargo test -p vibesql-executor --release --lib` — 3627 pass, 0 fail (2 pre-existing ignored) — includes the regression I introduced and then fixed against inherited `text_to_numeric` work (`test_cast_to_unknown_typename_numeric_affinity`).
- [x] `make test-tcl-file FILE=e_expr.test` — 301 failed / 5087 total (was 307 / 4924 pre-PR on this branch, 315/~4924 per the issue's original certified baseline).
- [x] Manual CLI verification of every specific fix (`SELECT 'abc' MATCH 'def'`, `SELECT regexp('abc','def')`, `SELECT 'abc' GLOB 123.4`, `SELECT printf('%.5e', ...)`, `SELECT CAST(... AS NUMERIC) || ''`, `SELECT typeof(CAST('def' AS shobblob_x))`, etc.) against SQLite's documented expected output.
- [x] Spot-checked `nan.test`, `istrue.test`, `like3.test`, `quote.test`, `regexp1.test`, `regexp2.test`, `literal.test`, `literal2.test`, `numcast.test`, `existsexpr.test`, `affinity2.test`, `affinity3.test`, `hexlit.test`, `unhex.test`, `types.test`, `types3.test` — no regressions, `literal.test`/`literal2.test` already at 100% from prior work (#6236).

## Remaining work for a follow-up builder

- `e_expr-23.1.x`: `CASE`-comparison collation/affinity semantics (bare-literal-vs-literal comparisons using fundamental storage-class ordering instead of implicit text coercion — e.g. `CASE 55 WHEN '55' THEN 'A' ELSE 'B' END` should be `'B'`, not `'A'`). Connects directly to `affinity2.test`/`affinity3.test`/`types.test` in the issue's satellite list.
- `quote.test`: SQLite's `"no such column: X" - should this be a string literal in single-quotes?"` hint text for ambiguous double-quoted identifiers.
- UTF-16LE/BE `PRAGMA encoding` support (affects `e_expr-28.1.x`/`30.1.x`/`33.1.x`, `like3.test`, `unhex.test`, `numcast.test`) — a genuinely large feature (multi-encoding text/BLOB storage), likely deserving its own issue rather than folding into this family.
- A TCL-shim UDF-callback bridge for `db func`/`db function` registration would unblock the remaining `e_expr.test` precedence-evidence loop and several other files, but is a separate, large harness project (VibeSQL's CLI is subprocess-per-query, with no channel back into the TCL interpreter).

Part of #6172. Part of epic #5779.