### PR TITLE
conformance(tcl): deferred-FK COMMIT survival, REPLACE cascade actions, ALTER ADD COLUMN REFERENCES check

### DIFF
--- a/crates/vibesql-executor/src/alter/columns.rs
+++ b/crates/vibesql-executor/src/alter/columns.rs
@@ -107,6 +107,22 @@ pub(super) fn execute_add_column(
             ));
         }
     }
+    // A REFERENCES column cannot carry a non-NULL default (SQLite's
+    // `sqlite3AlterFinishAddColumn`, fkey2-14.1.4/1.5, e_fkey-61.1.1): the
+    // added column's default would need to satisfy the FK constraint for
+    // every existing row without an FK existence check ever running, which
+    // SQLite refuses to do. `DEFAULT NULL` (or no default) is fine because
+    // NULL never participates in FK matching.
+    let has_references = stmt
+        .column_def
+        .constraints
+        .iter()
+        .any(|c| matches!(c.kind, ColumnConstraintKind::References { .. }));
+    if has_references && !default_is_null_or_absent {
+        return Err(ExecutorError::Other(
+            "Cannot add a REFERENCES column with non-NULL default value".to_string(),
+        ));
+    }
 
     // A STORED generated column may only be added while the table is empty.
     // sqlite3 3.51.0 rejects `ADD COLUMN ... GENERATED ALWAYS AS (expr) STORED`

--- a/crates/vibesql-executor/src/delete/integrity.rs
+++ b/crates/vibesql-executor/src/delete/integrity.rs
@@ -315,7 +315,7 @@ fn queue_orphaned_children(
 
 /// Delete child rows that reference a deleted parent row (CASCADE action)
 #[allow(clippy::too_many_arguments)]
-fn cascade_delete(
+pub(crate) fn cascade_delete(
     db: &mut vibesql_storage::Database,
     child_table_name: &str,
     fk: &vibesql_catalog::ForeignKeyConstraint,
@@ -460,7 +460,7 @@ fn cascade_delete(
 
 /// Set child FK columns to NULL (SET NULL action)
 #[allow(clippy::too_many_arguments)]
-fn set_null(
+pub(crate) fn set_null(
     db: &mut vibesql_storage::Database,
     child_table_name: &str,
     fk: &vibesql_catalog::ForeignKeyConstraint,
@@ -526,7 +526,7 @@ fn set_null(
 
 /// Set child FK columns to their default values (SET DEFAULT action)
 #[allow(clippy::too_many_arguments)]
-fn set_default(
+pub(crate) fn set_default(
     db: &mut vibesql_storage::Database,
     child_table_name: &str,
     fk: &vibesql_catalog::ForeignKeyConstraint,

--- a/crates/vibesql-executor/src/foreign_key_check.rs
+++ b/crates/vibesql-executor/src/foreign_key_check.rs
@@ -316,7 +316,10 @@ pub(crate) fn check_fk_row_existence(
     // have returned before reaching this helper).
     let parent_table = db
         .get_table(&fk.parent_table)
-        .ok_or_else(|| crate::errors::ExecutorError::TableNotFound(fk.parent_table.clone()))?;
+        .ok_or_else(|| {
+            crate::errors::ExecutorError::TableNotFound(fk.parent_table.clone())
+                .with_main_schema_qualifier()
+        })?;
 
     let parent_collations = parent_collations_for_fk(db, fk);
     let parent_indices = resolved_parent_indices_for_fk(db, fk);

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -1814,6 +1814,21 @@ fn resolve_replace_conflicts_for_row(
 
     super::constraints::enforce_unique_indexes(db, schema, table_name, full_row_values)?;
 
+    // Re-validate the new row's OWN foreign keys too (fkey1-5.2/5.4): the
+    // conflict-clearing delete above may have run a CASCADE / SET NULL /
+    // SET DEFAULT action (`enforce_replace_fk_actions`, inside
+    // `handle_replace_conflicts`) that removed the very parent row this new
+    // row is about to reference — e.g. a self-referential `ON DELETE
+    // CASCADE` where replacing row 2 cascades away row 3, and the new row
+    // being inserted for key 2 itself references key 3. The row's FK
+    // existence was already checked once by `RowValidator::validate_foreign_keys`
+    // before REPLACE conflict resolution ran (against the pre-cascade
+    // state), so it must be checked again now against the post-cascade
+    // state. `validate_foreign_key_constraints` is a no-op when
+    // `PRAGMA foreign_keys` is off and only re-does the read-only
+    // existence/deferred-queue work — it does not re-run PK/UNIQUE checks.
+    super::foreign_keys::validate_foreign_key_constraints(db, table_name, full_row_values)?;
+
     // Release the reservation now that all delete triggers have fired.
     // The REPLACE INSERT uses the returned rowid as its explicit rowid, so it
     // will not fail on its own reservation.

--- a/crates/vibesql-executor/src/insert/replace.rs
+++ b/crates/vibesql-executor/src/insert/replace.rs
@@ -159,26 +159,31 @@ pub fn handle_replace_conflicts(
     }
 
     // SQLite performs foreign-key processing when a row is REPLACEd: the
-    // implicit DELETE of each conflicting row must not orphan the child rows
-    // that referenced it (fkey2-13.*, without_rowid3). Previously the
-    // conflict-clearing delete removed the parent row silently, so a REPLACE
-    // that broke a NO ACTION foreign key succeeded where SQLite raises
-    // "FOREIGN KEY constraint failed".
+    // implicit DELETE of each conflicting row must not silently orphan the
+    // child rows that referenced it (fkey2-13.*, fkey1-5.2/5.4,
+    // without_rowid3). Previously the conflict-clearing delete removed the
+    // parent row without any FK processing at all.
     //
-    // For a NO ACTION foreign key, SQLite performs this check at statement end
-    // — AFTER the REPLACE re-inserts its new row. Because a foreign key's
+    // NO ACTION / RESTRICT: SQLite performs this check at statement end —
+    // AFTER the REPLACE re-inserts its new row. Because a foreign key's
     // parent columns are always a key (PRIMARY KEY / UNIQUE), at most one
     // parent row can carry a given key value, so a child orphaned by the
     // conflict-delete is repaired precisely when the re-inserted row restores
     // that same parent-key value (fkey2-13.1.3/4). We evaluate that repair
     // here using `row_values` (the row about to be inserted) rather than
-    // erroring eagerly on the delete.
+    // erroring eagerly on the delete. REPLACE's conflict-delete is always
+    // immediate (never deferred), so RESTRICT collapses to the same check as
+    // NO ACTION here.
     //
-    // CASCADE / SET NULL / SET DEFAULT / RESTRICT actions on a REPLACE-delete
-    // are a separate, pre-existing gap and are intentionally left unchanged
-    // here; this focused fix enforces only the default NO ACTION behaviour.
+    // CASCADE / SET NULL / SET DEFAULT: the conflict-delete must run the
+    // same referential action a plain DELETE of the conflicting row would
+    // (fkey1-5.2/5.4: `INSERT OR REPLACE` deleting a self-referential
+    // `ON DELETE CASCADE` parent must cascade to its children — and if that
+    // cascade orphans the row the REPLACE is about to re-insert, the whole
+    // statement fails with "FOREIGN KEY constraint failed"). Reuses the same
+    // action handlers the DELETE executor uses (`delete::integrity`).
     if db.foreign_keys_enabled() {
-        enforce_replace_no_action_fks(db, table_name, &rows_to_delete, row_values)?;
+        enforce_replace_fk_actions(db, table_name, &rows_to_delete, row_values)?;
     }
 
     // Check if any DELETE triggers exist for this table.
@@ -415,30 +420,43 @@ pub fn handle_replace_conflicts(
     Ok(())
 }
 
-/// Enforce NO ACTION foreign keys against a REPLACE's conflict-clearing delete.
+/// Enforce foreign keys against a REPLACE's conflict-clearing delete.
 ///
 /// When a REPLACE deletes a conflicting parent row, any child row that
-/// referenced that parent's key would be orphaned. For a NO ACTION foreign key
-/// SQLite checks this at *statement end*, after the REPLACE re-inserts its new
-/// row: the orphan is repaired if the new row restores the same parent-key
-/// value (fkey2-13.1.3/4). Because a foreign key's parent columns are always a
-/// key (PRIMARY KEY / UNIQUE), at most one parent row can carry a given key
-/// value, so "some surviving parent still provides the key" reduces to "the
-/// re-inserted row provides the key".
+/// referenced that parent's key is affected exactly as it would be by a
+/// plain `DELETE` of that row:
 ///
-/// Returns `Err(ConstraintViolation)` when a conflict row's key is dropped by
-/// the REPLACE (not restored by `new_row_values`) while a child still
-/// references it. Only the default NO ACTION on-delete behaviour is enforced;
-/// CASCADE / SET NULL / SET DEFAULT / RESTRICT on a REPLACE-delete are a
-/// separate pre-existing gap.
-fn enforce_replace_no_action_fks(
-    db: &vibesql_storage::Database,
+/// - **NO ACTION / RESTRICT**: SQLite checks this at *statement end*, after
+///   the REPLACE re-inserts its new row: the orphan is repaired if the new
+///   row restores the same parent-key value (fkey2-13.1.3/4). Because a
+///   foreign key's parent columns are always a key (PRIMARY KEY / UNIQUE),
+///   at most one parent row can carry a given key value, so "some surviving
+///   parent still provides the key" reduces to "the re-inserted row
+///   provides the key". REPLACE's conflict-delete is always immediate
+///   (never deferred), so RESTRICT collapses to the same check as NO
+///   ACTION here.
+/// - **CASCADE / SET NULL / SET DEFAULT**: the action actually runs against
+///   the child rows (reusing `delete::integrity`'s DELETE-side handlers),
+///   exactly as a plain `DELETE FROM <parent_table> WHERE ...` would
+///   (fkey1-5.2/5.4). If that action itself orphans the row the REPLACE is
+///   about to re-insert (e.g. a self-referential CASCADE that removes the
+///   very parent key the new row needs), the statement still fails.
+///
+/// Returns `Err(ConstraintViolation)` on any of the above.
+fn enforce_replace_fk_actions(
+    db: &mut vibesql_storage::Database,
     parent_table: &str,
     rows_to_delete: &[(usize, vibesql_storage::Row)],
     new_row_values: &[vibesql_types::SqlValue],
 ) -> Result<(), ExecutorError> {
+    use vibesql_catalog::ReferentialAction;
     use vibesql_types::SqlValue;
 
+    // Collect (child_table, fk, fk_idx, action) pairs up front so the
+    // action-performing loop below does not hold a borrow of `db.catalog`
+    // while mutating tables.
+    let mut matching_fks: Vec<(String, vibesql_catalog::ForeignKeyConstraint, usize)> =
+        Vec::new();
     for child_table_name in db.catalog.list_tables() {
         let child_schema = match db.catalog.get_table(&child_table_name) {
             Some(s) => s,
@@ -447,86 +465,127 @@ fn enforce_replace_no_action_fks(
         if child_schema.foreign_keys.is_empty() {
             continue;
         }
-
-        for fk in child_schema.foreign_keys.iter() {
-            // Only foreign keys that reference the table being REPLACEd, and
-            // only the default NO ACTION on-delete action.
+        for (fk_idx, fk) in child_schema.foreign_keys.iter().enumerate() {
             if !fk.parent_table.eq_ignore_ascii_case(parent_table) {
                 continue;
             }
-            if !matches!(fk.on_delete, vibesql_catalog::ReferentialAction::NoAction) {
+            matching_fks.push((child_table_name.clone(), fk.clone(), fk_idx));
+        }
+    }
+
+    let in_txn = db.in_transaction();
+    let session_defer = db.defer_foreign_keys();
+
+    for (child_table_name, fk, fk_idx) in &matching_fks {
+        let parent_indices = crate::foreign_key_check::resolved_parent_indices_for_fk(db, fk);
+        if parent_indices.is_empty()
+            || parent_indices.iter().any(|&idx| idx >= new_row_values.len())
+        {
+            continue;
+        }
+        let parent_collations = crate::foreign_key_check::parent_collations_for_fk(db, fk);
+
+        // Parent-key values the re-inserted row will provide (only relevant
+        // to the NO ACTION / RESTRICT repair check below).
+        let new_key: Vec<SqlValue> =
+            parent_indices.iter().map(|&idx| new_row_values[idx].clone()).collect();
+
+        for (_, del_row) in rows_to_delete {
+            if parent_indices.iter().any(|&idx| idx >= del_row.values.len()) {
+                continue;
+            }
+            let deleted_key: Vec<SqlValue> =
+                parent_indices.iter().map(|&idx| del_row.values[idx].clone()).collect();
+
+            // NULL parent-key values never match a child reference.
+            if deleted_key.iter().any(|v| matches!(v, SqlValue::Null)) {
                 continue;
             }
 
-            let parent_indices = crate::foreign_key_check::resolved_parent_indices_for_fk(db, fk);
-            if parent_indices.is_empty()
-                || parent_indices.iter().any(|&idx| idx >= new_row_values.len())
-            {
-                continue;
-            }
-            let parent_collations = crate::foreign_key_check::parent_collations_for_fk(db, fk);
-
-            // Parent-key values the re-inserted row will provide.
-            let new_key: Vec<SqlValue> =
-                parent_indices.iter().map(|&idx| new_row_values[idx].clone()).collect();
-
-            for (_, del_row) in rows_to_delete {
-                if parent_indices.iter().any(|&idx| idx >= del_row.values.len()) {
-                    continue;
-                }
-                let deleted_key: Vec<SqlValue> =
-                    parent_indices.iter().map(|&idx| del_row.values[idx].clone()).collect();
-
-                // NULL parent-key values never match a child reference.
-                if deleted_key.iter().any(|v| matches!(v, SqlValue::Null)) {
-                    continue;
-                }
-
-                // If the re-inserted row restores this exact key, no child that
-                // referenced the deleted row can be orphaned.
-                let restored = deleted_key.iter().zip(&new_key).enumerate().all(|(i, (dk, nk))| {
-                    crate::foreign_key_check::fk_values_equal(
-                        dk,
-                        nk,
-                        parent_collations.get(i).and_then(|c| c.as_deref()),
-                    )
-                });
-                if restored {
-                    continue;
-                }
-
-                // The key is being dropped: any child row that references it is
-                // now orphaned. Scan the child table (visibility-aware) for such
-                // a reference.
-                let snapshot = crate::mvcc::read_snapshot(db);
-                let child_table = match db.get_table(&child_table_name) {
-                    Some(t) => t,
-                    None => continue,
-                };
-                let orphaned = child_table.scan_visible(&snapshot).any(|(_, child_row)| {
-                    let child_fk_values: Vec<SqlValue> = fk
-                        .column_indices
-                        .iter()
-                        .map(|&idx| child_row.values[idx].clone())
-                        .collect();
-                    if child_fk_values.iter().any(|v| matches!(v, SqlValue::Null)) {
-                        return false;
-                    }
-                    child_fk_values.iter().zip(&deleted_key).enumerate().all(|(i, (cv, pv))| {
-                        crate::foreign_key_check::fk_values_equal(
-                            cv,
-                            pv,
-                            parent_collations.get(i).and_then(|c| c.as_deref()),
-                        )
-                    })
-                });
-
-                if orphaned {
-                    return Err(ExecutorError::ConstraintViolation(format!(
-                        "FOREIGN KEY constraint violation: cannot delete or update a parent row when a foreign key constraint exists. The conflict occurred in table '{}', constraint '{}'.",
+            match fk.on_delete {
+                ReferentialAction::Cascade => {
+                    crate::delete::integrity::cascade_delete(
+                        db,
                         child_table_name,
-                        fk.name.as_deref().unwrap_or(""),
-                    )));
+                        fk,
+                        *fk_idx,
+                        &deleted_key,
+                        in_txn,
+                        session_defer,
+                    )?;
+                }
+                ReferentialAction::SetNull => {
+                    crate::delete::integrity::set_null(
+                        db,
+                        child_table_name,
+                        fk,
+                        *fk_idx,
+                        &deleted_key,
+                        in_txn,
+                        session_defer,
+                    )?;
+                }
+                ReferentialAction::SetDefault => {
+                    crate::delete::integrity::set_default(
+                        db,
+                        child_table_name,
+                        fk,
+                        *fk_idx,
+                        &deleted_key,
+                        in_txn,
+                        session_defer,
+                    )?;
+                }
+                ReferentialAction::NoAction | ReferentialAction::Restrict => {
+                    // If the re-inserted row restores this exact key, no
+                    // child that referenced the deleted row can be orphaned.
+                    let restored =
+                        deleted_key.iter().zip(&new_key).enumerate().all(|(i, (dk, nk))| {
+                            crate::foreign_key_check::fk_values_equal(
+                                dk,
+                                nk,
+                                parent_collations.get(i).and_then(|c| c.as_deref()),
+                            )
+                        });
+                    if restored {
+                        continue;
+                    }
+
+                    // The key is being dropped: any child row that
+                    // references it is now orphaned. Scan the child table
+                    // (visibility-aware) for such a reference.
+                    let snapshot = crate::mvcc::read_snapshot(db);
+                    let child_table = match db.get_table(child_table_name) {
+                        Some(t) => t,
+                        None => continue,
+                    };
+                    let orphaned = child_table.scan_visible(&snapshot).any(|(_, child_row)| {
+                        let child_fk_values: Vec<SqlValue> = fk
+                            .column_indices
+                            .iter()
+                            .map(|&idx| child_row.values[idx].clone())
+                            .collect();
+                        if child_fk_values.iter().any(|v| matches!(v, SqlValue::Null)) {
+                            return false;
+                        }
+                        child_fk_values.iter().zip(&deleted_key).enumerate().all(
+                            |(i, (cv, pv))| {
+                                crate::foreign_key_check::fk_values_equal(
+                                    cv,
+                                    pv,
+                                    parent_collations.get(i).and_then(|c| c.as_deref()),
+                                )
+                            },
+                        )
+                    });
+
+                    if orphaned {
+                        return Err(ExecutorError::ConstraintViolation(format!(
+                            "FOREIGN KEY constraint violation: cannot delete or update a parent row when a foreign key constraint exists. The conflict occurred in table '{}', constraint '{}'.",
+                            child_table_name,
+                            fk.name.as_deref().unwrap_or(""),
+                        )));
+                    }
                 }
             }
         }

--- a/crates/vibesql-executor/src/tests/savepoint_implicit_transaction.rs
+++ b/crates/vibesql-executor/src/tests/savepoint_implicit_transaction.rs
@@ -113,8 +113,13 @@ fn rollback_to_implicit_savepoint_keeps_transaction_open() {
 
 #[test]
 fn release_runs_deferred_fk_check_and_can_fail() {
-    // fkey2-2.40: a deferred FK violation queued under an implicit-savepoint
-    // transaction must surface when the outermost RELEASE commits.
+    // fkey2-2.40/2.41: a deferred FK violation queued under an
+    // implicit-savepoint transaction must surface when the outermost
+    // RELEASE attempts to commit. Per EVIDENCE-OF R-37736-42616, a COMMIT
+    // (or RELEASE of a transaction savepoint) that fails this way leaves
+    // the transaction — and the savepoint itself — open, exactly as before:
+    // later statements can resolve the violation and release the *same*
+    // savepoint successfully.
     let mut db = Database::new();
     db.set_foreign_keys_enabled(true);
     exec_sql(
@@ -127,11 +132,24 @@ fn release_runs_deferred_fk_check_and_can_fail() {
     exec_sql(&mut db, "SAVEPOINT outer").unwrap();
     // References a non-existent parent (3) — deferred, so it does not fail now.
     exec_sql(&mut db, "INSERT INTO node VALUES(2, 3)").unwrap();
-    // RELEASE commits, which runs the deferred check and fails.
+    // RELEASE attempts to commit, which runs the deferred check and fails.
     let err = exec_sql(&mut db, "RELEASE outer").unwrap_err();
     assert!(err.contains("FOREIGN KEY constraint failed"), "unexpected error: {err}");
-    // The failed commit rolled the transaction back to autocommit.
+    // The transaction remains open — the failed RELEASE did NOT roll back.
+    assert!(db.in_transaction());
+    assert_eq!(db.savepoint_depth(), 1);
+
+    // A subsequent COMMIT attempt also fails (violation still unresolved).
+    let err2 = exec_sql(&mut db, "COMMIT").unwrap_err();
+    assert!(err2.contains("FOREIGN KEY constraint failed"), "unexpected error: {err2}");
+    assert!(db.in_transaction());
+
+    // Resolve the violation by inserting the missing parent row, then the
+    // SAME "outer" savepoint releases (and commits) successfully.
+    exec_sql(&mut db, "INSERT INTO node VALUES(3, 1)").unwrap();
+    exec_sql(&mut db, "RELEASE outer").unwrap();
     assert!(!db.in_transaction());
+    assert_eq!(row_count(&db, "node"), 3);
 }
 
 #[test]

--- a/crates/vibesql-executor/src/transaction.rs
+++ b/crates/vibesql-executor/src/transaction.rs
@@ -62,13 +62,34 @@ pub struct CommitExecutor;
 impl CommitExecutor {
     /// Execute a COMMIT statement.
     ///
-    /// Phase C2 of #5085: drains the transaction's deferred FK
-    /// violation queue and re-checks each entry against the current
-    /// parent state. If any deferred violation still holds, the COMMIT
-    /// fails and the transaction is rolled back, matching SQLite
-    /// semantics ("FOREIGN KEY constraint failed" raised at COMMIT).
+    /// Phase C2 of #5085: re-checks the transaction's deferred FK
+    /// violation queue against the current parent state. If any deferred
+    /// violation still holds, the COMMIT fails.
+    ///
+    /// EVIDENCE-OF R-37736-42616 (e_fkey-38.3/38.4, fkey2-2.40/2.41): when a
+    /// COMMIT (or the RELEASE of a transaction SAVEPOINT that empties the
+    /// savepoint stack) fails because of an outstanding deferred FK
+    /// violation, the transaction — and any nested savepoints — remain
+    /// open exactly as before. The caller can fix the violation with more
+    /// statements and retry COMMIT, or explicitly ROLLBACK. So the queue
+    /// must only be peeked (read-only) here; nothing may be drained or
+    /// rolled back unless the commit is actually going to succeed.
     pub fn execute(_stmt: &CommitStmt, db: &mut Database) -> Result<String, ExecutorError> {
-        // Drain and re-validate deferred FK violations before commit.
+        Self::check_deferred_fk_only(db)?;
+        Self::finalize(db)?;
+        Ok("Transaction committed".to_string())
+    }
+
+    /// Phase 1: read-only pre-check. Returns `Err` (without mutating any
+    /// transaction state) when an outstanding deferred FK violation would
+    /// still fail; returns `Ok(())` when the commit is safe to finalize.
+    ///
+    /// Split out so [`ReleaseSavepointExecutor`] can run this check BEFORE
+    /// popping the savepoint that would trigger the auto-commit — a failing
+    /// check must leave the named savepoint (and the transaction) untouched.
+    fn check_deferred_fk_only(db: &Database) -> Result<(), ExecutorError> {
+        // Peek (read-only) at deferred FK violations before mutating any
+        // transaction state.
         //
         // Phase 1d of #5136 — FK deferred-replay coordination:
         // Capture a fresh **commit-time** snapshot for the re-validation
@@ -81,25 +102,25 @@ impl CommitExecutor {
         // treats every transaction id allocated so far as committed,
         // making the committing transaction's own writes (stamped with
         // `xmin = current_txn_id`) pass `visible_to`.
-        let pending = db.take_deferred_fk_violations();
         let commit_snapshot = db.capture_commit_time_snapshot();
+        let pending: Vec<_> = db.deferred_fk_violations().to_vec();
         if let Some(err_msg) = check_deferred_fk_violations(db, &pending, &commit_snapshot) {
-            // Deferred violation still holds at COMMIT — abort the
-            // commit and roll back. SQLite raises "FOREIGN KEY
-            // constraint failed" here; auto-rollback follows the same
-            // convention as Bucket D (#5087, merged 17f23988).
-            //
-            // We ignore the rollback's own error: if rollback also
-            // fails, the original FK error is the more useful one.
-            let _ = db.rollback_transaction();
+            // Deferred violation still holds at COMMIT: fail without
+            // touching the transaction or its queue (see doc comment above).
             return Err(ExecutorError::ConstraintViolation(err_msg));
         }
+        Ok(())
+    }
 
+    /// Phase 2: drain the (now-confirmed-clean) deferred FK queue and
+    /// actually commit. Callers must have already called
+    /// [`Self::check_deferred_fk_only`] successfully.
+    fn finalize(db: &mut Database) -> Result<(), ExecutorError> {
+        let _ = db.take_deferred_fk_violations();
         db.commit_transaction().map_err(|e| {
             ExecutorError::StorageError(format!("Failed to commit transaction: {}", e))
         })?;
-
-        Ok("Transaction committed".to_string())
+        Ok(())
     }
 }
 
@@ -205,14 +226,21 @@ fn check_deferred_fk_violations(
         let parent_indices = resolved_parent_indices_for_fk(db, fk);
 
         // Phase 1d: scan visible parent rows (commit-time snapshot).
-        // Under MVCC OFF this is equivalent to scanning all rows
-        // (matches previous behavior of `parent_table.scan().iter()`,
-        // which did not filter the deletion bitmap; we keep the
-        // pre-existing wider semantics by also looking at non-bitmap-
-        // deleted rows — the `scan_visible` iterator filters the
-        // bitmap, but pre-Phase-1d the parent scan included deleted
-        // rows too, so to preserve OFF-state semantics exactly we
-        // continue to use `scan()` when MVCC is off).
+        //
+        // fkey2-2.15c: a deferred violation must stay a violation when the
+        // parent row that triggered it is still gone at COMMIT time. The
+        // previous OFF-state implementation deliberately scanned via
+        // `scan()`, which does NOT filter VibeSQL's bitmap-tombstone
+        // deletes — so a parent row deleted earlier in the very same
+        // transaction (as `DELETE FROM node WHERE nodeid=2` does here)
+        // still physically exists in backing storage and was wrongly
+        // treated as "the parent still exists", silently clearing the
+        // violation and letting COMMIT succeed. Use `scan_live()` (bitmap-
+        // filtered) instead — matching both the child-side check just
+        // above and `live_deferred_fk_violation_count`'s parent-side scan,
+        // which already uses `scan_live()`. Under MVCC ON, `scan_visible`
+        // additionally honors the commit-time snapshot for cross-
+        // transaction visibility.
         let key_exists = {
             #[cfg(feature = "mvcc_enabled")]
             {
@@ -232,7 +260,7 @@ fn check_deferred_fk_violations(
             #[cfg(not(feature = "mvcc_enabled"))]
             {
                 let _ = snapshot;
-                parent_table.scan().iter().any(|parent_row| {
+                parent_table.scan_live().any(|(_, parent_row)| {
                     parent_indices.iter().zip(&snapshot_fk_values).enumerate().all(
                         |(i, (&parent_idx, fk_val))| match parent_row.get(parent_idx) {
                             Some(parent_val) => fk_values_equal(
@@ -468,18 +496,37 @@ impl ReleaseSavepointExecutor {
     /// "FOREIGN KEY constraint failed" exactly as SQLite does (fkey2-2.40).
     /// For a transaction opened by an explicit `BEGIN`, `RELEASE` of the last
     /// savepoint leaves the transaction open until an explicit `COMMIT`.
+    ///
+    /// EVIDENCE-OF R-37736-42616: when this auto-commit fails because of an
+    /// outstanding deferred FK violation, the named savepoint (and every
+    /// nested savepoint) must remain exactly as they were — the RELEASE
+    /// itself must not take effect. So the deferred-FK check runs BEFORE
+    /// popping the savepoint stack (fkey2-2.40/2.41: `RELEASE outer` fails,
+    /// then later statements resolve the violation and the *same* `outer`
+    /// savepoint is released successfully).
     pub fn execute(
         stmt: &ReleaseSavepointStmt,
         db: &mut Database,
     ) -> Result<String, ExecutorError> {
+        let will_finalize =
+            db.is_implicit_savepoint_txn() && db.is_outermost_savepoint(&stmt.name);
+
+        if will_finalize {
+            // Read-only pre-check: does NOT mutate the savepoint stack or
+            // the deferred FK queue. On failure this returns without ever
+            // calling `release_savepoint`, so the savepoint survives.
+            CommitExecutor::check_deferred_fk_only(db)?;
+        }
+
         db.release_savepoint(stmt.name.clone()).map_err(|e| {
             ExecutorError::StorageError(format!("Failed to release savepoint: {}", e))
         })?;
 
-        // If this RELEASE emptied the savepoint stack of an implicitly-opened
-        // transaction, commit it (SQLite autocommit-on-outermost-release).
-        if db.is_implicit_savepoint_txn() && db.savepoint_depth() == 0 {
-            CommitExecutor::execute(&CommitStmt, db)?;
+        // The pre-check above already confirmed no outstanding deferred
+        // violation, so this can only fail on the (unexpected) storage-level
+        // commit itself — not on a deferred FK re-check.
+        if will_finalize {
+            CommitExecutor::finalize(db)?;
         }
 
         Ok(format!("Savepoint '{}' released", stmt.name))

--- a/crates/vibesql-executor/tests/foreign_key_deferred_tests.rs
+++ b/crates/vibesql-executor/tests/foreign_key_deferred_tests.rs
@@ -87,10 +87,26 @@ fn deferred_child_insert_without_parent_fails_at_commit() {
     let err = run(&mut db, "COMMIT").expect_err("COMMIT must fail when FK still violated");
     assert!(err.contains("FOREIGN KEY"), "expected FK error message, got: {}", err);
 
-    // Auto-rollback: child row must NOT be present in the committed state.
-    assert!(!db.in_transaction(), "transaction must be auto-rolled back after failed COMMIT");
+    // Per EVIDENCE-OF R-37736-42616, a COMMIT that fails on an outstanding
+    // deferred FK violation does NOT force-roll-back the transaction — the
+    // transaction stays OPEN so the caller can fix the violation and retry
+    // (or explicitly ROLLBACK). The child row remains present in that still-
+    // open transaction.
+    assert!(db.in_transaction(), "transaction must remain open after failed COMMIT");
     let c = db.get_table("c").expect("table c");
-    assert_eq!(c.scan().len(), 0, "child row must be rolled back");
+    assert_eq!(
+        c.scan_live().count(),
+        1,
+        "child row remains present in the still-open transaction"
+    );
+
+    // Resolve the violation by inserting the missing parent, then retry the
+    // COMMIT — it must now succeed and persist the child row.
+    run(&mut db, "INSERT INTO p VALUES (99)").unwrap();
+    run(&mut db, "COMMIT").expect("COMMIT must succeed once the violation is resolved");
+    assert!(!db.in_transaction(), "transaction closes after the successful retry COMMIT");
+    let c = db.get_table("c").expect("table c");
+    assert_eq!(c.scan_live().count(), 1, "child row is committed");
 }
 
 #[test]
@@ -180,9 +196,11 @@ fn pragma_defer_foreign_keys_defers_non_deferrable_fk() {
     run(&mut db, "INSERT INTO c VALUES (1, 99)").unwrap();
     assert_eq!(db.deferred_fk_violations().len(), 1);
 
-    // COMMIT fails, transaction auto-rolls back.
+    // COMMIT fails on the unresolved violation but, per EVIDENCE-OF
+    // R-37736-42616, leaves the transaction OPEN (no force-rollback).
     let err = run(&mut db, "COMMIT").expect_err("COMMIT must fail with unresolved violation");
     assert!(err.contains("FOREIGN KEY"));
+    assert!(db.in_transaction(), "failed COMMIT must not roll the transaction back");
 }
 
 #[test]

--- a/crates/vibesql-storage/src/database/transaction_api.rs
+++ b/crates/vibesql-storage/src/database/transaction_api.rs
@@ -382,6 +382,13 @@ impl Database {
         self.lifecycle.transaction_manager().savepoint_depth()
     }
 
+    /// True when `name` is the outermost live savepoint (releasing it would
+    /// empty the stack). See
+    /// [`TransactionManager::is_outermost_savepoint`] for the rationale.
+    pub fn is_outermost_savepoint(&self, name: &str) -> bool {
+        self.lifecycle.transaction_manager().is_outermost_savepoint(name)
+    }
+
     // ========================================================================
     // Implicit statement-level savepoint (#5417 — RAISE(ABORT) scope)
     // ========================================================================

--- a/crates/vibesql-storage/src/database/transactions.rs
+++ b/crates/vibesql-storage/src/database/transactions.rs
@@ -702,6 +702,23 @@ impl TransactionManager {
         }
     }
 
+    /// True when `name` is the outermost (bottom-of-stack) live savepoint —
+    /// i.e. releasing it would empty the savepoint stack entirely (matches
+    /// [`Self::release_savepoint`]'s `truncate(savepoint_idx)` semantics: a
+    /// release at index 0 leaves zero savepoints). Read-only: does not
+    /// mutate the stack. Used to decide, *before* actually releasing, whether
+    /// this RELEASE would auto-commit an implicitly-opened transaction, so
+    /// the caller can run the deferred-FK pre-check first (EVIDENCE-OF
+    /// R-37736-42616: a failing commit must leave the savepoint untouched).
+    pub fn is_outermost_savepoint(&self, name: &str) -> bool {
+        match &self.transaction_state {
+            TransactionState::Active { savepoints, .. } => {
+                savepoints.first().map(|sp| sp.name == name).unwrap_or(false)
+            }
+            TransactionState::None => false,
+        }
+    }
+
     /// Rollback to a named savepoint - returns the changes that need to be undone
     pub fn rollback_to_savepoint(
         &mut self,

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -2193,6 +2193,87 @@ proc trial_check_in_transaction {new_sql} {
     }
 }
 
+proc trial_check_closing_transaction {sql} {
+    # Trial-run the about-to-be-flushed batch (the existing $::sql_batch
+    # plus this closing $sql, e.g. "COMMIT" or a stack-emptying "RELEASE")
+    # with an appended ROLLBACK against a throwaway copy of the DB — the
+    # same technique trial_check_in_transaction uses for mid-transaction
+    # statements. Determines, WITHOUT mutating any real shim/DB state,
+    # whether this close succeeds, fails and closes the transaction, or
+    # fails while the transaction survives.
+    #
+    # EVIDENCE-OF R-37736-42616: "If a COMMIT statement (or the RELEASE of
+    # a transaction SAVEPOINT) fails because the database is currently in a
+    # state that violates a deferred foreign key constraint ... the nested
+    # savepoints remain open." Because each execsql runs in a FRESH process
+    # and nothing is persisted until a flush actually succeeds, the shim
+    # must know this BEFORE clearing $::sql_batch / $::in_transaction, or
+    # the batched statements are lost and the transaction is wrongly
+    # treated as closed (fkey2-2.40/2.41, e_fkey-38.3/38.4).
+    #
+    # Sets $::txn_close_survived_trial_error to 1 when the trial's error
+    # left the appended ROLLBACK something to undo (the close failed but
+    # the transaction survives), 0 otherwise (the close's error genuinely
+    # ended the transaction, e.g. RAISE(ROLLBACK)). Raises a TCL error
+    # (translated to SQLite wording) when the trial reports an error;
+    # returns silently on success.
+    set batch_stmts {}
+    foreach stmt $::sql_batch {
+        set s [string trimright $stmt]
+        set s [string trimright $s ";"]
+        lappend batch_stmts $s
+    }
+    set new_clean [string trimright $sql]
+    set new_clean [string trimright $new_clean ";"]
+    set trial_stmts $batch_stmts
+    lappend trial_stmts $new_clean
+    lappend trial_stmts "ROLLBACK"
+
+    set combined [join $trial_stmts ";\n"]
+    set pragma_prefix [build_pragma_prefix]
+    set combined "${pragma_prefix}${combined}"
+
+    set tmpfile "/tmp/vibesql_closetrial_[pid]_[clock microseconds].sql"
+    set f [open $tmpfile w]
+    puts $f $combined
+    close $f
+
+    if {$::db_file eq ""} {
+        catch {exec $::vibesql_path < $tmpfile 2>@1} result
+    } else {
+        set trial_db "/tmp/vibesql_closetrialdb_[pid]_[clock microseconds].vbsql"
+        copy_db_with_wal $::db_file $trial_db
+        catch {exec $::vibesql_path $trial_db < $tmpfile 2>@1} result
+        delete_db_with_wal $trial_db
+    }
+    file delete -force $tmpfile
+
+    set ::txn_close_survived_trial_error 0
+    if {[regexp {(?m)^Error executing statement|^Error:} $result]} {
+        set err_line [select_error_line_for_stmt $result 1]
+        if {$err_line eq ""} {
+            foreach line [split $result "\n"] {
+                set line [string trim $line]
+                if {[regexp {^Error: } $line]} {
+                    if {[is_script_failed_summary $line]} {
+                        continue
+                    }
+                    set err_line $line
+                    break
+                }
+            }
+        }
+        if {$err_line eq ""} {
+            # No attributable error line found — defensively treat as
+            # success rather than raising an unattributable failure.
+            return
+        }
+        set ::txn_close_survived_trial_error \
+            [regexp {(?m)^Transaction rolled back} $result]
+        error [translate_error_to_sqlite $err_line]
+    }
+}
+
 proc is_readonly_query {sql} {
     # True when $sql is a pure read-only query whose rows must be returned even
     # while a batched transaction is open: a top-level SELECT or VALUES, or a
@@ -2798,6 +2879,11 @@ proc execsql {sql {db ""}} {
                 return {}
             }
         }
+        # Snapshot the batch as it stood BEFORE this closing statement, in
+        # case the close fails-but-survives (see below) and it needs
+        # restoring. Cheap: just a list copy, no extra CLI invocation.
+        set pre_close_batch $::sql_batch
+
         lappend ::sql_batch $sql
         set ::in_transaction 0
         # Did this transaction already surface an aborting error (RAISE(ABORT) /
@@ -2809,8 +2895,42 @@ proc execsql {sql {db ""}} {
         set tolerate_err $::txn_had_tolerated_error
         set ::txn_had_tolerated_error 0
         if {[catch {flush_batch $tolerate_err} result]} {
+            set translated_err [translate_error_to_sqlite $result]
+            #
+            # Deferred-FK "close fails but transaction survives" recovery
+            # (EVIDENCE-OF R-37736-42616, fkey2-2.40/2.41, e_fkey-38.3/38.4):
+            # a COMMIT (or a RELEASE that empties the savepoint stack) can
+            # fail on an outstanding deferred FK violation WITHOUT closing
+            # the transaction. The real flush above already tried and
+            # failed (and — critically — did NOT persist anything, since
+            # per-statement WAL entries for an uncommitted transaction are
+            # discarded on the next open/replay), so it is safe to re-derive
+            # "did it survive?" from a throwaway trial replay of the exact
+            # same (pre-close-statement) batch, run only on this rarer
+            # failure path so the common (successful-close) path pays no
+            # extra CLI invocation at all. Gated on $::pragma_foreign_keys:
+            # files that never enable FK enforcement can never hit this.
+            if {$::pragma_foreign_keys != 0 && !$tolerate_err} {
+                set ::sql_batch $pre_close_batch
+                if {[catch {trial_check_closing_transaction $sql} trial_err]} {
+                    if {$::txn_close_survived_trial_error} {
+                        # Leave $::sql_batch (restored above) / re-open
+                        # $::in_transaction — the failing closer is
+                        # deliberately NOT appended to the batch — so later
+                        # statements (including a retried close) replay
+                        # correctly from scratch at the next flush.
+                        set ::in_transaction 1
+                        error $trial_err
+                    }
+                }
+                # Trial says the close genuinely ends the transaction (or
+                # unexpectedly succeeded) — restore the batch to empty /
+                # in_transaction to 0 as the real flush attempt already set,
+                # and fall through to raise the real flush's own error.
+                set ::sql_batch {}
+            }
             # Translate error to SQLite format before re-raising
-            error [translate_error_to_sqlite $result]
+            error $translated_err
         }
         set parsed [parse_result $result $tolerate_err]
         # When the statement that closes this batched transaction is ONLY a


### PR DESCRIPTION
## Summary

Substantial progress on FK enforcement semantics (Part of #6170). Fixes several distinct, verified root-cause bugs across deferred-FK COMMIT handling, REPLACE's conflict-delete referential-action dispatch, and a missing ALTER TABLE ADD COLUMN validation — plus the TCL harness change required to keep the shim's transaction-batching state in sync with the corrected engine behavior.

This PR does **not** fully clear the family (fkey2/e_fkey/fkey3/fkey4/fkey7 still have real remaining failures). It uses `Part of #6170`, not `Closes`.

## Changes

1. **`crates/vibesql-executor/src/transaction.rs`** — A `COMMIT` (or a `RELEASE` that empties the savepoint stack) that fails on an outstanding deferred FK violation no longer rolls the transaction back. Per EVIDENCE-OF R-37736-42616, the transaction — and any nested savepoints — must remain open so the caller can fix the violation and retry, or explicitly `ROLLBACK` (fkey2-2.39-2.70, e_fkey-38.*). `CommitExecutor` is split into a read-only pre-check phase and a finalize phase so `ReleaseSavepointExecutor` can verify success **before** popping the savepoint that would trigger the auto-commit — a failing check must leave the savepoint untouched.

2. **`crates/vibesql-executor/src/transaction.rs`** — The deferred-FK COMMIT-time re-check's parent-side scan used `Table::scan()` (raw, includes bitmap-tombstoned rows) instead of `scan_live()`, so a parent row deleted earlier in the *same* transaction was wrongly treated as "still exists," silently clearing a real violation (fkey2-2.15c, and everything downstream of it in the fkey2-2.* sequence).

3. **`crates/vibesql-executor/src/insert/replace.rs`, `delete/integrity.rs`** — `INSERT OR REPLACE`'s conflict-clearing DELETE now runs the full referential-action dispatch (CASCADE / SET NULL / SET DEFAULT), reusing the DELETE executor's existing action handlers (now `pub(crate)`), instead of only checking NO ACTION/RESTRICT (fkey1-5.2/5.4, fkey2-13.*).

4. **`crates/vibesql-executor/src/insert/execution.rs`** — After a REPLACE's conflict-delete runs (which can CASCADE away a row the new row itself is about to reference — e.g. a self-referential `ON DELETE CASCADE`), re-validate the new row's own FK existence. It was previously validated once, *before* conflict resolution ran, against pre-cascade state.

5. **`crates/vibesql-executor/src/foreign_key_check.rs`** — An INSERT whose FK references a nonexistent table now reports the SQLite-compatible `main.`-qualified name (`no such table: main.X`) instead of the bare name.

6. **`crates/vibesql-executor/src/alter/columns.rs`** — `ALTER TABLE ... ADD COLUMN ... REFERENCES ...` with a non-NULL `DEFAULT` is now rejected with `Cannot add a REFERENCES column with non-NULL default value`, matching sqlite3's `sqlite3AlterFinishAddColumn` (fkey2-14.1.4/1.5).

7. **`scripts/tester_vibesql.tcl`** — The harness batches each transaction into one process invocation and previously treated *any* `COMMIT`/`RELEASE` failure as unconditionally closing the transaction (clearing its own `sql_batch`/`in_transaction` tracking), which now races with fix #1's corrected engine behavior. Added a recovery path that determines "did the close fail-but-survive?" — but **only on the (rare) failure path**, via a throwaway-copy trial replay, so the common successful-close path pays zero extra CLI-invocation cost. Gated on `PRAGMA foreign_keys` so files that never enable FK enforcement never pay it either.

## Acceptance Criteria Verification

The issue's stated acceptance is full clearance of `fkey2.test`/`e_fkey.test`, or every remaining failure justified against SQLite documented behavior / routed to #6154. This PR does not reach full clearance — see honest counts and remaining-gap breakdown below.

- [x] `make test-tcl-file FILE=fkey2.test` — improved, not clean (129 still failing)
- [x] `make test-tcl-file FILE=e_fkey.test` — improved, not clean (148 still failing)
- [x] No regressions in `cargo test -p vibesql-executor --lib` (3627 passed, was 3619 — 0 failed)
- [x] Root-cause fixes verified against SQLite's own `EVIDENCE-OF` doc comments in `e_fkey.test`, not just made the assertion pass

## Test Plan / Measured Results

Run against this repo's TCL harness on this machine (not the certified AWS baseline — numbers are directly comparable only to each other, before vs. after, in this session):

| File | Before | After | Notes |
|---|---:|---:|---|
| `fkey1.test` | 4 failed | **2 failed** | fixed 5.2/5.4 (REPLACE+CASCADE) |
| `fkey2.test` | 150 failed¹ | **129 failed** | |
| `fkey3.test` | 3 failed | 3 failed | unchanged — see gaps below |
| `fkey4.test` | 2 failed | 2 failed | unchanged — harness API gap |
| `fkey7.test` | 7 failed | 7 failed | unchanged — not investigated this pass |
| `e_fkey.test` | 153 failed | **148 failed** | |

¹ `fkey2.test`'s certified baseline in the issue was 179+1(synthetic); two prior merged PRs (#6178, #6237) already brought this repo's fkey2.test down to 150 before this session started. This PR's own contribution is 150 → 129.

```
cargo test --release -p vibesql-executor --lib
test result: ok. 3627 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out
```

## What's still failing / honest scope note

This is a large family (~346 certified failures across 6 files) and this PR makes substantial, verified progress rather than full clearance:

- **#6278 (new issue, filed from this investigation)**: `ROLLBACK TO SAVEPOINT` does not undo `DELETE`/`UPDATE` — only `INSERT` is tracked for savepoint-scoped undo (`Database::record_change` is only ever called from the two `insert_row`/`insert_rows_batch` call sites). This is a real, pre-existing, **non-FK-specific** engine gap (affects any `SAVEPOINT ... DELETE/UPDATE ... ROLLBACK TO` sequence, likely also `savepoint.test`/`trans.test`), discovered while chasing `fkey2-2.26`/`.27` and the cascade of failures downstream of it in the fkey2-2.* sequence. A correct fix is a cross-cutting change (either retrofit `record_change` at every DELETE/UPDATE/cascade/REPLACE call site with bitmap-tombstone-aware undo, or give named `SAVEPOINT` the same wholesale-clone strategy `BEGIN`/full-`ROLLBACK` already use) — too large/risky to bundle into this focused PR.
- `fkey3-1.3`/`1.5`: `DROP TABLE` does not check for FK references from other tables before dropping (SQLite raises `FOREIGN KEY constraint failed`) — a real gap, not addressed this pass.
- `fkey4`/`fkey7` remaining failures are TCL harness API-coverage gaps (`db trace`, prepared-statement handles like `::STMT1`) rather than SQL-semantics bugs.
- The bulk of `fkey2`'s remaining ~129 failures span several distinct, smaller root causes not investigated individually in this pass: a `count_changes`+`BEGIN`/`COMMIT` harness limitation (the shim can't report per-statement row counts for DML batched inside a transaction), `ALTER`/`DROP TABLE` FK-metadata rename edge cases (`sqlite_rename_table` internal test-control function, unimplemented in the harness), RESTRICT-action gaps, and assorted `genfkey`/ticket-regression edge cases.

`Part of #6170` — the family stays open for the remaining work above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>