### PR TITLE
conformance(tcl): revalidate dependent objects on ALTER TABLE RENAME COLUMN (Part of #6174)

### DIFF
--- a/crates/vibesql-executor/src/alter/columns.rs
+++ b/crates/vibesql-executor/src/alter/columns.rs
@@ -528,27 +528,48 @@ pub(super) fn execute_rename_column(
     stmt: &RenameColumnStmt,
     database: &mut Database,
 ) -> Result<String, ExecutorError> {
+    // Resolve the table + column and check for a name conflict with an
+    // immutable borrow so the whole-schema precheck below can also borrow the
+    // database immutably. The mutable borrow for the actual rename is taken
+    // afterwards (once these checks and the precheck have passed).
+    let col_index = {
+        let table = database
+            .get_table(&stmt.table_name)
+            .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
+
+        // The old column must exist.
+        let col_index = table.schema.get_column_index(&stmt.old_column_name).ok_or_else(|| {
+            ExecutorError::ColumnNotFound {
+                column_name: stmt.old_column_name.clone(),
+                table_name: stmt.table_name.clone(),
+                searched_tables: vec![stmt.table_name.clone()],
+                available_columns: table.schema.columns.iter().map(|c| c.name.clone()).collect(),
+            }
+        })?;
+
+        // Renaming to an existing (different) column name is a conflict. Allow a
+        // case-only rename of the same column.
+        if !stmt.new_column_name.eq_ignore_ascii_case(&stmt.old_column_name)
+            && table.schema.has_column(&stmt.new_column_name)
+        {
+            return Err(ExecutorError::ColumnAlreadyExists(stmt.new_column_name.clone()));
+        }
+
+        col_index
+    };
+
+    // Whole-schema dependent-object re-validation, matching SQLite's schema
+    // re-parse on ALTER TABLE RENAME COLUMN (the same check DROP COLUMN runs):
+    // a view or trigger that is *already* broken — e.g. a trigger body that
+    // inserts into a table that was never created, or a view that references a
+    // column that does not exist — aborts the ALTER with
+    // `error in <type> <name>: <inner error>`, leaving the schema untouched.
+    // Runs before any mutation so a failed RENAME COLUMN is atomic.
+    super::drop_column_checks::precheck_schema_objects(database)?;
+
     let table = database
         .get_table_mut(&stmt.table_name)
         .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
-
-    // The old column must exist.
-    let col_index = table.schema.get_column_index(&stmt.old_column_name).ok_or_else(|| {
-        ExecutorError::ColumnNotFound {
-            column_name: stmt.old_column_name.clone(),
-            table_name: stmt.table_name.clone(),
-            searched_tables: vec![stmt.table_name.clone()],
-            available_columns: table.schema.columns.iter().map(|c| c.name.clone()).collect(),
-        }
-    })?;
-
-    // Renaming to an existing (different) column name is a conflict. Allow a
-    // case-only rename of the same column.
-    if !stmt.new_column_name.eq_ignore_ascii_case(&stmt.old_column_name)
-        && table.schema.has_column(&stmt.new_column_name)
-    {
-        return Err(ExecutorError::ColumnAlreadyExists(stmt.new_column_name.clone()));
-    }
 
     // Rename in the schema (keeps the column-index cache consistent).
     table.schema_mut().rename_column(col_index, &stmt.new_column_name)?;

--- a/crates/vibesql-executor/src/alter/drop_column_checks.rs
+++ b/crates/vibesql-executor/src/alter/drop_column_checks.rs
@@ -24,8 +24,8 @@
 
 use vibesql_ast::{
     visitor::{walk_expression, walk_statement, ExpressionVisitor, StatementVisitor, VisitResult},
-    ColumnConstraintKind, ColumnIdentifier, Expression, FromClause, PseudoTable, SelectItem,
-    Statement, TableConstraintKind, TriggerAction,
+    ColumnConstraintKind, ColumnIdentifier, CommonTableExpr, Expression, FromClause, InsertSource,
+    PseudoTable, SelectItem, SelectStmt, Statement, TableConstraintKind, TriggerAction,
 };
 use vibesql_catalog::{TableSchema, TriggerDefinition, ViewDefinition};
 use vibesql_storage::Database;
@@ -97,10 +97,10 @@ fn check_schema_objects(
 
     for name in database.catalog.list_triggers() {
         if let Some(trigger) = database.catalog.get_trigger(&name) {
-            if let Some(missing) = find_missing_pseudo_in_trigger(trigger, &sim) {
+            if let Some(inner) = find_trigger_resolution_error(trigger, &sim) {
                 return Err(ExecutorError::Other(format!(
-                    "error in trigger {}{}: no such column: {}",
-                    trigger.name, suffix, missing
+                    "error in trigger {}{}: {}",
+                    trigger.name, suffix, inner
                 )));
             }
         }
@@ -170,11 +170,28 @@ struct FromSource {
     columns: Vec<String>,
 }
 
+/// Re-parse a verbatim `CREATE VIEW ... AS <select>` definition and return the
+/// defining `SELECT`. `None` when the text does not parse to a `CREATE VIEW`.
+fn reparse_view_query(sql_definition: &str) -> Option<SelectStmt> {
+    match vibesql_parser::Parser::parse_sql(sql_definition).ok()? {
+        Statement::CreateView(create) => Some(*create.query),
+        _ => None,
+    }
+}
+
 /// First column reference in `view`'s defining query that does not resolve
 /// against the (possibly simulated) schema, in SQL text order — or `None`
 /// when the view is valid or too complex to validate statically.
 fn find_missing_column_in_view(view: &ViewDefinition, sim: &DropSimulation) -> Option<String> {
-    let query = &view.query;
+    // Resolve against the view's verbatim `CREATE VIEW` text — the same text
+    // SQLite itself re-parses — rather than the stored `query` AST. The AST can
+    // drift from the definition across a persistence round-trip (e.g. a quoted
+    // multi-word column such as `"big c"` currently reloads as `big`), and
+    // judging a view by a drifted AST would report a column missing that the
+    // definition in fact names. Fall back to the stored AST when the verbatim
+    // text is absent or does not re-parse to a `CREATE VIEW`.
+    let reparsed = view.sql_definition.as_deref().and_then(reparse_view_query);
+    let query = reparsed.as_ref().unwrap_or(&view.query);
 
     // Constructs that introduce additional name scopes are skipped wholesale:
     // resolving them faithfully would duplicate the planner, and a false
@@ -401,12 +418,48 @@ fn check_column_ref(col: &ColumnIdentifier, scope: &ViewScope) -> Option<String>
 // Trigger validation
 // ============================================================================
 
+/// First resolution error in `trigger`, returned as the inner message SQLite
+/// appends after `error in trigger <name>[ <suffix>]: ` — either
+/// `no such table: main.<t>` (a body statement references a table that does
+/// not exist) or `no such column: <new|old>.<c>` (a `NEW.`/`OLD.` reference
+/// names a column absent from the target table). `None` when the trigger is
+/// valid or cannot be judged.
+///
+/// SQLite re-parses and re-resolves every dependent trigger on ALTER TABLE
+/// RENAME/DROP; a trigger that was *already* broken (e.g. its body inserts
+/// into a table that was never created) aborts the ALTER. Missing-table
+/// resolution is checked first because SQLite reports it before descending
+/// into NEW/OLD column resolution.
+fn find_trigger_resolution_error(
+    trigger: &TriggerDefinition,
+    sim: &DropSimulation,
+) -> Option<String> {
+    // Parse the body once; an unparseable body cannot be judged, so skip it.
+    let TriggerAction::RawSql(sql) = &trigger.triggered_action;
+    let statements = crate::trigger_execution::TriggerFirer::parse_trigger_sql(sql).ok()?;
+
+    // 1) A body statement that reads from / writes to a non-existent table
+    //    aborts the ALTER, matching SQLite's schema re-parse
+    //    (`error in trigger <name>: no such table: main.<t>`).
+    if let Some(missing) = find_missing_table_in_statements(&statements, sim.db) {
+        return Some(format!("no such table: {}", missing));
+    }
+
+    // 2) A NEW./OLD. reference to a column absent from the target table.
+    if let Some(pseudo) = find_missing_pseudo_in_trigger(trigger, &statements, sim) {
+        return Some(format!("no such column: {}", pseudo));
+    }
+
+    None
+}
+
 /// First `NEW.<col>` / `OLD.<col>` reference in `trigger` (WHEN condition
-/// first, then the body statements in order) that does not name a column of
-/// the trigger's target table — formatted as `new.<col>` / `old.<col>` for the
-/// error message. `None` when the trigger is valid or cannot be judged.
+/// first, then the pre-parsed body `statements` in order) that does not name a
+/// column of the trigger's target table — formatted as `new.<col>` /
+/// `old.<col>`. `None` when the trigger is valid or cannot be judged.
 fn find_missing_pseudo_in_trigger(
     trigger: &TriggerDefinition,
+    statements: &[Statement],
     sim: &DropSimulation,
 ) -> Option<String> {
     // NEW/OLD resolve against the trigger's target table (or view for
@@ -418,15 +471,8 @@ fn find_missing_pseudo_in_trigger(
     if let Some(when) = &trigger.when_condition {
         collect_pseudo_refs_in_expr(when, &mut refs);
     }
-    let TriggerAction::RawSql(sql) = &trigger.triggered_action;
-    match crate::trigger_execution::TriggerFirer::parse_trigger_sql(sql) {
-        Ok(statements) => {
-            for stmt in &statements {
-                collect_pseudo_refs_in_statement(stmt, &mut refs);
-            }
-        }
-        // Unparseable body: cannot judge, skip.
-        Err(_) => return None,
+    for stmt in statements {
+        collect_pseudo_refs_in_statement(stmt, &mut refs);
     }
 
     for (pseudo, column) in refs {
@@ -442,6 +488,129 @@ fn find_missing_pseudo_in_trigger(
         }
     }
     None
+}
+
+// ============================================================================
+// Missing-table resolution in trigger bodies
+// ============================================================================
+
+/// First base-table reference in `statements` (INSERT/UPDATE/DELETE targets and
+/// FROM-clause tables, in SQL text order) that resolves to neither a table nor a
+/// view — named the way SQLite's `no such table:` message spells it (an
+/// unqualified name is reported as `main.<name>`). CTE names in scope are
+/// excluded (they are not base tables), and the check is skipped (returns
+/// `None`) for anything it cannot judge — conservative in the direction that
+/// never blocks an ALTER SQLite allows.
+fn find_missing_table_in_statements(statements: &[Statement], db: &Database) -> Option<String> {
+    let mut refs: Vec<String> = Vec::new();
+    let mut cte_names: Vec<String> = Vec::new();
+    for stmt in statements {
+        collect_table_refs_in_statement(stmt, &mut refs, &mut cte_names);
+    }
+
+    for name in refs {
+        let bare = name.rsplit('.').next().unwrap_or(&name);
+        // A WITH-clause name is not a base table.
+        if cte_names.iter().any(|c| c.eq_ignore_ascii_case(bare)) {
+            continue;
+        }
+        // Resolve as written (handles `schema.table`, temp shadowing, and the
+        // implicit main schema) and, failing that, by its bare name.
+        if db.catalog.get_table(&name).is_some()
+            || db.catalog.get_view(&name).is_some()
+            || db.catalog.get_table(bare).is_some()
+            || db.catalog.get_view(bare).is_some()
+        {
+            continue;
+        }
+        return Some(if name.contains('.') { name } else { format!("main.{}", name) });
+    }
+    None
+}
+
+/// Accumulate base-table references and CTE names from one trigger-body
+/// statement. Only INSERT/UPDATE/DELETE targets and FROM-clause tables are
+/// collected; subqueries nested inside expressions are intentionally not
+/// descended into (a false negative is safe, a false positive is not).
+fn collect_table_refs_in_statement(
+    stmt: &Statement,
+    refs: &mut Vec<String>,
+    cte_names: &mut Vec<String>,
+) {
+    match stmt {
+        Statement::Insert(insert) => {
+            collect_cte_names(&insert.with_clause, refs, cte_names);
+            let target = match &insert.schema_name {
+                Some(schema) => format!("{}.{}", schema, insert.table_name),
+                None => insert.table_name.clone(),
+            };
+            refs.push(target);
+            if let InsertSource::Select(select) = &insert.source {
+                collect_table_refs_in_select(select, refs, cte_names);
+            }
+        }
+        Statement::Update(update) => {
+            refs.push(update.table_name.clone());
+            if let Some(from) = &update.from_clause {
+                for source in from {
+                    collect_table_refs_in_from(source, refs, cte_names);
+                }
+            }
+        }
+        Statement::Delete(delete) => {
+            refs.push(delete.table_name.clone());
+        }
+        Statement::Select(select) => collect_table_refs_in_select(select, refs, cte_names),
+        _ => {}
+    }
+}
+
+/// Accumulate references from a SELECT: its CTE names, its FROM tables, and
+/// (recursively) any set-operation right-hand side.
+fn collect_table_refs_in_select(
+    select: &SelectStmt,
+    refs: &mut Vec<String>,
+    cte_names: &mut Vec<String>,
+) {
+    collect_cte_names(&select.with_clause, refs, cte_names);
+    if let Some(from) = &select.from {
+        collect_table_refs_in_from(from, refs, cte_names);
+    }
+    if let Some(set_op) = &select.set_operation {
+        collect_table_refs_in_select(&set_op.right, refs, cte_names);
+    }
+}
+
+/// Record the names defined by a WITH clause and descend into each CTE body.
+fn collect_cte_names(
+    with_clause: &Option<Vec<CommonTableExpr>>,
+    refs: &mut Vec<String>,
+    cte_names: &mut Vec<String>,
+) {
+    if let Some(ctes) = with_clause {
+        for cte in ctes {
+            cte_names.push(cte.name.clone());
+            collect_table_refs_in_select(&cte.query, refs, cte_names);
+        }
+    }
+}
+
+/// Accumulate base-table names from a FROM tree (recursing joins; skipping
+/// subqueries, VALUES, and table-valued functions).
+fn collect_table_refs_in_from(
+    from: &FromClause,
+    refs: &mut Vec<String>,
+    cte_names: &mut Vec<String>,
+) {
+    match from {
+        FromClause::Table { name, .. } => refs.push(name.clone()),
+        FromClause::Join { left, right, .. } => {
+            collect_table_refs_in_from(left, refs, cte_names);
+            collect_table_refs_in_from(right, refs, cte_names);
+        }
+        FromClause::Subquery { query, .. } => collect_table_refs_in_select(query, refs, cte_names),
+        FromClause::Values { .. } | FromClause::TableFunction { .. } => {}
+    }
 }
 
 /// Visitor collecting every `NEW.x` / `OLD.x` reference in encounter order.

--- a/crates/vibesql-executor/tests/alter_rename_column_revalidation_tests.rs
+++ b/crates/vibesql-executor/tests/alter_rename_column_revalidation_tests.rs
@@ -1,0 +1,139 @@
+//! Part of #6174: `ALTER TABLE ... RENAME COLUMN` re-validates the whole schema
+//! before mutating anything — the same dependent-object re-parse SQLite runs
+//! (and that `DROP COLUMN` already performed). A view or trigger that is
+//! *already* broken (references a column or a table that does not resolve)
+//! aborts the RENAME with SQLite's verbatim `error in <type> <name>: <inner>`
+//! message, leaving the schema untouched.
+//!
+//! Verified against sqlite3 3.51.0 / `altercol.test` sections 13, 17, and 23:
+//!   * trigger body reading a non-existent table  -> `error in trigger tr1: no such table: main.nosuchtable`
+//!   * trigger body inserting into a missing table -> `error in trigger u7t: no such table: main.u8`
+//!   * view selecting a non-existent column        -> `error in view t2: no such column: xyz`
+
+use vibesql_executor::{AlterTableExecutor, CreateTableExecutor, TriggerExecutor, ViewExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+fn create_table(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse CREATE TABLE");
+    let vibesql_ast::Statement::CreateTable(create) = stmt else {
+        panic!("expected CREATE TABLE");
+    };
+    CreateTableExecutor::execute_with_source(&create, db, Some(sql)).expect("CREATE TABLE");
+}
+
+fn create_view(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse CREATE VIEW");
+    let vibesql_ast::Statement::CreateView(view) = stmt else {
+        panic!("expected CREATE VIEW");
+    };
+    ViewExecutor::execute_create_view(&view, db).expect("CREATE VIEW");
+}
+
+fn create_trigger(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse CREATE TRIGGER");
+    let vibesql_ast::Statement::CreateTrigger(trigger) = stmt else {
+        panic!("expected CREATE TRIGGER");
+    };
+    TriggerExecutor::create_trigger(db, &trigger).expect("CREATE TRIGGER");
+}
+
+fn try_alter(db: &mut Database, sql: &str) -> Result<String, String> {
+    let stmt = Parser::parse_sql(sql).expect("parse ALTER");
+    let vibesql_ast::Statement::AlterTable(a) = stmt else {
+        panic!("expected ALTER TABLE");
+    };
+    AlterTableExecutor::execute_with_source(&a, db, Some(sql)).map_err(|e| e.to_string())
+}
+
+fn rename_column_err(db: &mut Database, sql: &str) -> String {
+    try_alter(db, sql).expect_err(&format!("expected RENAME COLUMN to fail: {sql}"))
+}
+
+/// altercol.test 13.1.2: a trigger whose body reads from a table that does not
+/// exist aborts the RENAME. No "after rename" suffix — the trigger was broken
+/// before the rename — and the missing table is qualified `main.<name>`.
+#[test]
+fn rename_rejected_when_trigger_reads_missing_table() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE x1(i INTEGER, t TEXT UNIQUE)");
+    create_trigger(
+        &mut db,
+        "CREATE TRIGGER tr1 AFTER INSERT ON x1 BEGIN SELECT * FROM nosuchtable; END",
+    );
+    assert_eq!(
+        rename_column_err(&mut db, "ALTER TABLE x1 RENAME COLUMN t TO ttt"),
+        "error in trigger tr1: no such table: main.nosuchtable"
+    );
+    // The failed ALTER must leave x1 untouched.
+    assert!(db.get_table("x1").unwrap().schema.has_column("t"));
+    assert!(!db.get_table("x1").unwrap().schema.has_column("ttt"));
+}
+
+/// altercol.test 17.1: a trigger whose body inserts into a table that does not
+/// exist aborts the RENAME with the same `no such table: main.<name>` message.
+#[test]
+fn rename_rejected_when_trigger_inserts_into_missing_table() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE u7(x, y, z)");
+    create_trigger(
+        &mut db,
+        "CREATE TRIGGER u7t AFTER INSERT ON u7 BEGIN \
+         INSERT INTO u8 VALUES(new.x, new.y, new.z); END",
+    );
+    assert_eq!(
+        rename_column_err(&mut db, "ALTER TABLE u7 RENAME COLUMN x TO xxx"),
+        "error in trigger u7t: no such table: main.u8"
+    );
+    assert!(db.get_table("u7").unwrap().schema.has_column("x"));
+}
+
+/// altercol.test 23.1: a view whose SELECT names a column that does not resolve
+/// aborts the RENAME with `error in view <name>: no such column: <col>`.
+#[test]
+fn rename_rejected_when_view_selects_missing_column() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t1(a INT, b REAL, c TEXT, d BLOB, e ANY)");
+    create_view(&mut db, "CREATE VIEW t2 AS SELECT a+10, b*5.0, xyz FROM t1");
+    assert_eq!(
+        rename_column_err(&mut db, "ALTER TABLE t1 RENAME COLUMN e TO eeee"),
+        "error in view t2: no such column: xyz"
+    );
+    // The failed ALTER must leave t1 untouched.
+    assert!(db.get_table("t1").unwrap().schema.has_column("e"));
+    assert!(!db.get_table("t1").unwrap().schema.has_column("eeee"));
+}
+
+/// A rename whose only dependent objects are well-formed still succeeds: the
+/// re-validation must not false-positive. The trigger reads from and writes to
+/// tables that exist, and the view selects real columns.
+#[test]
+fn rename_succeeds_when_dependents_are_valid() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t1(a, b, c)");
+    create_table(&mut db, "CREATE TABLE log(id)");
+    create_view(&mut db, "CREATE VIEW v1 AS SELECT a, b FROM t1");
+    create_trigger(
+        &mut db,
+        "CREATE TRIGGER tr AFTER INSERT ON t1 BEGIN INSERT INTO log VALUES(new.a); END",
+    );
+    try_alter(&mut db, "ALTER TABLE t1 RENAME COLUMN c TO cc").expect("rename should succeed");
+    assert!(db.get_table("t1").unwrap().schema.has_column("cc"));
+    assert!(!db.get_table("t1").unwrap().schema.has_column("c"));
+}
+
+/// A CTE name referenced in a trigger body is not a base table and must not be
+/// mistaken for a missing table: the rename still succeeds.
+#[test]
+fn rename_succeeds_when_trigger_body_uses_cte() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t1(a, b, c)");
+    create_table(&mut db, "CREATE TABLE dst(v)");
+    create_trigger(
+        &mut db,
+        "CREATE TRIGGER tr AFTER INSERT ON t1 BEGIN \
+         INSERT INTO dst WITH cte AS (SELECT new.a AS v) SELECT v FROM cte; END",
+    );
+    try_alter(&mut db, "ALTER TABLE t1 RENAME COLUMN c TO cc").expect("rename should succeed");
+    assert!(db.get_table("t1").unwrap().schema.has_column("cc"));
+}


### PR DESCRIPTION
## Summary

Part of #6174 (ALTER TABLE semantics family). This is the 7th incremental slice.

SQLite re-parses and re-resolves the whole schema when a column is renamed: a view or trigger that is *already* broken — one that references a column or a table that does not resolve — aborts the `ALTER TABLE ... RENAME COLUMN` with `error in <type> <name>: <inner>`, leaving the schema untouched. VibeSQL already did exactly this for `DROP COLUMN` (`precheck_schema_objects`) but **not** for `RENAME COLUMN`, which silently succeeded even against a broken dependent object.

## What changed

- **Wire dependent-object re-validation into `execute_rename_column`.** The table/column resolution and name-conflict checks are moved onto an immutable borrow so the whole-schema precheck can run, then the mutable borrow is taken for the actual rename. A failed `RENAME COLUMN` is now atomic (schema left untouched).
- **Detect missing-table references in trigger bodies.** The shared trigger validator now flags a body statement that reads from / writes to a table that does not exist (INSERT/UPDATE/DELETE targets and FROM-clause tables), reporting SQLite's `no such table: main.<t>`. CTE names in scope are excluded, and anything not statically judgeable is skipped — conservative in the direction that never blocks an ALTER SQLite allows.
- **Resolve views against their verbatim `sql_definition` text** (the same text SQLite re-parses) instead of the reconstructed `query` AST. The AST can drift across a persistence round-trip — a quoted multi-word column such as `"big c"` currently reloads as `big` — so judging a view by the drifted AST reported a column missing that its definition in fact names. This fixes a false positive (which would otherwise have regressed altercol 16.2.2) and is strictly more faithful to SQLite.

## Conformance impact

Measured against the canonical sqlite3 3.51.0 TCL suite. **No regressions** in `alter.test`, `altertab.test`, `altertab3.test`, `alterdropcol.test`, or `alterdropcol2.test`.

| file | before (failed) | after (failed) | fixed |
|------|-----------------|----------------|-------|
| altercol.test | 42 | 36 | 8.4.5, 13.1.2, 23.1, 23.2, 23.11, 23.13 |
| alter.test | 49 | 48 | 13.3 |
| alter3.test | 18 | 17 | (cascade) |

Net: **8 tests fixed, 0 regressions.**

## Tests

- New: `crates/vibesql-executor/tests/alter_rename_column_revalidation_tests.rs` (5 cases: trigger reads missing table, trigger inserts into missing table, view selects missing column, valid dependents still succeed, CTE name not mistaken for a table).
- Full `cargo test -p vibesql-executor` passes (192 test binaries).

Part of #6174