### PR TITLE
conformance(tcl): forcedelete WAL/checkpoint siblings on :memory: reopen in shim

### DIFF
--- a/crates/vibesql-executor/src/insert/defaults.rs
+++ b/crates/vibesql-executor/src/insert/defaults.rs
@@ -550,6 +550,44 @@ mod tests {
     }
 }
 
+/// Substitute the column DEFAULT value for a NOT NULL violation under the
+/// statement-level `REPLACE` conflict-resolution algorithm (`INSERT OR
+/// REPLACE` / `REPLACE INTO`).
+///
+/// Per <https://www.sqlite.org/lang_conflict.html>: "the REPLACE conflict
+/// resolution algorithm replaces the NULL value with the default value for
+/// that column, or if the column has no default value, then the ABORT
+/// algorithm is used." This is a distinct rule from REPLACE's usual
+/// duplicate-row-deletion behavior for PRIMARY KEY/UNIQUE — it fires even
+/// though a NOT NULL violation has no conflicting row to delete.
+///
+/// Must run after ordinary default-value application (so already-defaulted
+/// columns are a no-op here) but before generated-column evaluation, since a
+/// generated column may itself be declared NOT NULL by deriving from a
+/// stored column this substitution just fixed up (gencol1-7.11/7.20/7.30).
+/// A column with no default is left NULL, so the normal NOT NULL check
+/// downstream still raises the ABORT-equivalent error (gencol1's own
+/// fallback semantics).
+pub fn apply_replace_not_null_defaults(
+    schema: &vibesql_catalog::TableSchema,
+    row_values: &mut [vibesql_types::SqlValue],
+) -> Result<(), ExecutorError> {
+    for (col_idx, col) in schema.columns.iter().enumerate() {
+        if col.nullable || col.generated_expr.is_some() {
+            continue;
+        }
+        if row_values[col_idx] != vibesql_types::SqlValue::Null {
+            continue;
+        }
+        if let Some(default_expr) = &col.default_value {
+            let default_value = evaluate_default_expression(default_expr)?;
+            let coerced_value = super::validation::coerce_value(default_value, &col.data_type)?;
+            row_values[col_idx] = coerced_value;
+        }
+    }
+    Ok(())
+}
+
 /// Apply generated/computed column values
 /// Generated columns are defined with AS(expression) syntax and computed on INSERT/UPDATE
 pub fn apply_generated_columns(
@@ -560,13 +598,32 @@ pub fn apply_generated_columns(
     // Create a temporary row to evaluate generated expressions.
     // GeneratedColumn context: non-deterministic date/time uses (e.g.
     // `z AS (date())`) are rejected at evaluation time (SQLite, date2-140).
-    let temp_row = vibesql_storage::Row::new(row_values.to_vec());
+    let mut temp_row = vibesql_storage::Row::new(row_values.to_vec());
     let evaluator = crate::ExpressionEvaluator::new(schema)
         .with_schema_context(crate::evaluator::SchemaExprContext::GeneratedColumn);
 
-    for (col_idx, col) in schema.columns.iter().enumerate() {
-        // If column has a generated expression, compute and apply it
-        if let Some(generated_expr) = &col.generated_expr {
+    // Generated columns may reference other generated columns (e.g. a VIRTUAL
+    // column computed from a STORED column, strict1-7.1: `a INT AS (b*2)
+    // VIRTUAL, b INT AS (c*2) STORED`). A single pass in column-definition
+    // order only sees up-to-date values for *earlier*-indexed generated
+    // columns, so a forward reference (like `a` -> `b` above) would evaluate
+    // against `b`'s stale placeholder value. Iterate to a fixed point,
+    // re-evaluating and folding each freshly computed value back into
+    // `temp_row` so later (and earlier, on subsequent passes) columns see it.
+    // Bounded by the number of generated columns, which is also the longest
+    // possible acyclic dependency chain; SQLite rejects circular generated
+    // column definitions at CREATE TABLE time, so this always converges.
+    let generated_indices: Vec<usize> = schema
+        .columns
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, col)| col.generated_expr.as_ref().map(|_| idx))
+        .collect();
+
+    for _pass in 0..generated_indices.len().max(1) {
+        for &col_idx in &generated_indices {
+            let col = &schema.columns[col_idx];
+            let generated_expr = col.generated_expr.as_ref().expect("filtered above");
             let generated_value = evaluator.eval(generated_expr, &temp_row)?;
             // STRICT tables (issue #6173) apply SQLite's rigid strict-datatype
             // rules to the *computed* value of a generated column, exactly as
@@ -578,7 +635,8 @@ pub fn apply_generated_columns(
             } else {
                 super::validation::coerce_value(generated_value, &col.data_type)?
             };
-            row_values[col_idx] = coerced_value;
+            row_values[col_idx] = coerced_value.clone();
+            temp_row.values[col_idx] = coerced_value;
         }
     }
     Ok(())

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -864,6 +864,16 @@ fn execute_insert_internal(
             &assigned_columns,
         )?;
 
+        // INSERT OR REPLACE / REPLACE INTO: a NOT NULL column still holding
+        // NULL after ordinary default-value application (i.e. NULL was
+        // explicitly supplied, or the column was omitted and has no
+        // default-triggered value yet) gets the column's DEFAULT value
+        // substituted, per SQLite's REPLACE conflict-resolution rule for
+        // NOT NULL (gencol1-7.1x/7.2x/7.3x/7.4x/7.5x).
+        if matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Replace)) {
+            super::defaults::apply_replace_not_null_defaults(&schema, &mut full_row_values)?;
+        }
+
         // Apply generated/computed column values (AS(expression) syntax)
         super::defaults::apply_generated_columns(&schema, &mut full_row_values, db)?;
 

--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -442,10 +442,16 @@ impl Parser {
                     } else {
                         self.advance(); // consume NOT
                         self.expect_keyword(Keyword::Null)?;
-                        constraints.push(vibesql_ast::ColumnConstraint {
-                            name,
-                            kind: vibesql_ast::ColumnConstraintKind::NotNull,
-                        });
+                        // Parse optional ON CONFLICT clause (SQLite extension):
+                        // `col NOT NULL ON CONFLICT ROLLBACK|ABORT|FAIL|IGNORE|REPLACE`.
+                        let on_conflict = self.parse_constraint_conflict_clause()?;
+                        let kind = match on_conflict {
+                            Some(_) => vibesql_ast::ColumnConstraintKind::NotNullWithConflict {
+                                on_conflict,
+                            },
+                            None => vibesql_ast::ColumnConstraintKind::NotNull,
+                        };
+                        constraints.push(vibesql_ast::ColumnConstraint { name, kind });
                     }
                 }
                 Token::Keyword { keyword: Keyword::Deferrable, .. } => {

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -7097,12 +7097,20 @@ proc sqlite3 {db args} {
     # when multiple tests run in parallel.
     if {$filename eq ":memory:" || $filename eq ""} {
         # Use temp file instead of :memory: for persistence
-        # IMPORTANT: Each :memory: open should get a FRESH database, so we always delete
+        # IMPORTANT: Each :memory: open should get a FRESH database, so we always delete.
+        #
+        # Use forcedelete (NOT a bare `file delete`) so the VibeSQL durability
+        # siblings — <root>.wal / <root>-checkpoints/ / <root>.lock — are purged
+        # too. WAL is on by default for file-backed databases, so deleting only
+        # the main .vbsql snapshot leaves a stale WAL + checkpoint archive that
+        # the next open replays, resurrecting the "deleted" tables and producing
+        # spurious `table <name> already exists` errors on the fresh
+        # `sqlite3 db :memory:` (gencol1-12.10/13.10; same #5843 resurrection
+        # class as the forcedelete / test.db path, which the :memory: fast path
+        # had missed).
         set new_file [file normalize "/tmp/vibesql_test_[pid].vbsql"]
         # Always delete for :memory: - SQLite gives fresh empty database each time
-        if {[file exists $new_file]} {
-            catch {file delete -force $new_file}
-        }
+        forcedelete $new_file
     } elseif {$filename eq "test.db" || [file tail $filename] eq "test.db"} {
         # Map test.db to a unique temp file to prevent race conditions
         # Use current db_file if set (from run_test_file), otherwise create unique

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -367,23 +367,49 @@ proc translate_error_to_sqlite {vibesql_error} {
     # - "child process exited abnormally"
     # We need to extract just the actual error message
 
-    # First, try to extract just the error line
+    # First, try to extract just the error line. A VibeSQL error message can
+    # itself span multiple lines (e.g. a CHECK constraint failure echoes the
+    # constraint's verbatim, possibly multi-line, source text: "CHECK
+    # constraint failed: x+y==11\n    OR x*y==12\n..." — check-4.6/4.9). Once
+    # the initial "Error executing statement N:" / "Error:" line is found,
+    # keep folding in subsequent RAW lines that are still part of the same
+    # message: stop at the next recognized error line, the CLI's
+    # "=== Script Execution Summary ===" trailer, EOF, or a line carrying the
+    # raw-mode row-framing control bytes (0x1e/0x1f) — which can only be
+    # genuine row output from a later statement, never engine error text.
     set error_msg ""
-    foreach line [split $vibesql_error "\n"] {
-        set line [string trim $line]
+    set lines [split $vibesql_error "\n"]
+    set nlines [llength $lines]
+    for {set li 0} {$li < $nlines} {incr li} {
+        set raw_line [lindex $lines $li]
+        set line [string trim $raw_line]
+        set msg ""
+        set matched 0
         # Look for "Error executing statement N: <message>"
         if {[regexp {^Error executing statement \d+: (.+)$} $line -> msg]} {
-            set error_msg $msg
-            break
+            set matched 1
+        } elseif {[regexp {^Error: (.+)$} $line -> msg]} {
+            # Also handle plain "Error: <message>"
+            set matched 1
+        } elseif {[string match "Error *" $line]} {
+            # Handle error lines that start with "Error" but have different format
+            set msg $line
+            set matched 1
         }
-        # Also handle plain "Error: <message>"
-        if {[regexp {^Error: (.+)$} $line -> msg]} {
+        if {$matched} {
             set error_msg $msg
-            break
-        }
-        # Handle error lines that start with "Error" but have different format
-        if {[string match "Error *" $line]} {
-            set error_msg $line
+            for {set lj [expr {$li + 1}]} {$lj < $nlines} {incr lj} {
+                set cont_raw [lindex $lines $lj]
+                set cont [string trim $cont_raw]
+                if {$cont eq ""} { break }
+                if {[string match "Error*" $cont]} { break }
+                if {[string match "=== Script Execution Summary ===*" $cont]} { break }
+                if {[string first "\x1e" $cont_raw] >= 0
+                        || [string first "\x1f" $cont_raw] >= 0} {
+                    break
+                }
+                append error_msg "\n" $cont
+            }
             break
         }
     }


### PR DESCRIPTION
## Summary

Two commits in this branch move a set of CREATE TABLE / constraint-evaluation and TCL-shim conformance gaps forward. The first commit lands real engine changes across the parser and executor (plus a shim error-folding fix); the second commit fixes a shim database-reset bug that was masking a large number of `gencol1.test` assertions behind a spurious `table <name> already exists` cascade.

Because this is a squash merge, both commits collapse into this message — the per-commit attribution below records which change fixes which failures.

## Commit 1 — `49350d88a`: engine changes (parser + executor + shim error folding)

Four targeted fixes found via `strict1.test`, `gencol1.test`, `check.test`, and `e_createtable.test`:

- **Parser — column-level `NOT NULL ON CONFLICT <clause>`** (`crates/vibesql-parser/src/parser/create/constraints.rs`). `col NOT NULL ON CONFLICT REPLACE` (and the other conflict clauses on a NOT NULL constraint) was a hard parse error ("near ON: syntax error"). The AST already had `ColumnConstraintKind::NotNullWithConflict` and downstream constraint-validator handling; the parser just never produced it. Now parses via the existing `parse_constraint_conflict_clause` helper. Fixes `e_createtable-4.19.0` and related "near ON" failures.

- **Generated columns — fixed-point dependency evaluation** (`crates/vibesql-executor/src/insert/defaults.rs`). `apply_generated_columns` evaluated every generated column against a single upfront snapshot row, so a VIRTUAL column computed from another (STORED) generated column saw the dependency's stale placeholder instead of its freshly computed value (`a INT AS (b*2) VIRTUAL, b INT AS (c*2) STORED` produced `a=NULL` instead of `a=4`). Now iterates to a fixed point, folding each computed value back into the working row before the next pass, bounded by the number of generated columns (SQLite forbids circular generated-column definitions, so this always converges). Fixes `strict1-7.1` and the equivalent `gencol1.test` dependency-chain cases.

- **INSERT OR REPLACE / REPLACE INTO NOT NULL substitution** (`crates/vibesql-executor/src/insert/defaults.rs` + call site in `crates/vibesql-executor/src/insert/execution.rs`). Per https://www.sqlite.org/lang_conflict.html, REPLACE resolves a NOT NULL violation by substituting the column's DEFAULT value (falling back to ABORT only when the column has no default) rather than deleting/replacing a row. This was unimplemented — REPLACE INTO with an explicit NULL for a NOT NULL DEFAULT column always errored. Added `apply_replace_not_null_defaults`, run after ordinary default-value application and before generated-column evaluation (so a generated column derived from the fixed-up value computes correctly). Fixes `gencol1-7.1x/7.2x/7.3x/7.4x/7.5x` (10 tests).

- **Shim `translate_error_to_sqlite` multi-line error folding** (`scripts/tester_vibesql.tcl`). The helper only captured the first line of a VibeSQL error, so a CHECK constraint failure whose source text spans multiple lines (SQLite echoes the verbatim, possibly multi-line, CHECK expression) was truncated and failed the `do_catchsql_test` comparison. Now folds in subsequent plain-text lines belonging to the same error until the next recognized error line, the CLI summary trailer, EOF, or a line carrying raw-mode row-framing bytes. Fixes `check-4.6` and `check-4.9`.

**Commit 1 regression evidence** (single-file `make test-tcl-file` runs, verified before/after):
- `strict1.test`: 48/49 → **49/49** (100%)
- `gencol1.test`: 57/87 → **67/87** (77.0%)
- `check.test`: 80/92 → **83/92** (90.2%)
- `e_createtable.test`: 300/528 → **331/528** (56.8% → 62.7%)
- No regression: `trigger1.test` and `fkey1.test` identical pass/fail counts before/after.

## Commit 2 — `78a954c26`: `forcedelete` WAL/checkpoint siblings on `:memory:` reopen (shim)

The TCL shim maps `:memory:` databases to a per-run temp `.vbsql` file (each SQL batch runs in a fresh CLI process). On a `sqlite3 db :memory:` reopen it deleted only the main snapshot with a bare `file delete`, leaving the VibeSQL durability siblings (`<root>.wal`, `<root>-checkpoints/`, `<root>.lock`) behind. Because WAL is on by default for file-backed databases, the next open replayed the stale WAL/checkpoint and resurrected the "deleted" tables — so a fresh `:memory:` open incorrectly reported prior-scenario tables as already existing. This is the same `#5843` resurrection class the `forcedelete` / `test.db` paths already guard against; the `:memory:` fast path had simply missed it.

The fix (`scripts/tester_vibesql.tcl`) routes the `:memory:` reset through `forcedelete`, which purges the WAL/checkpoint/lock siblings so the reopened database is genuinely empty.

**Commit 2 regression evidence** — this reset fix unblocks the assertions that Commit 1's improvements had left cascade-aborted:
- `gencol1.test`: 67/87 passing (20 failed) → **141/152 passing (11 failed)**. ~65 previously cascade-aborted assertions now actually run. (The 57 → 67 step is Commit 1's engine work; the 67 → 141 step is this reset fix exposing and passing the previously-masked assertions.)
- No regression: `trigger1.test` (44/84), `view.test` (24/117 → 0 failed), `check.test` (83 passed), `strict1.test` (49/49) are byte-for-byte identical pre/post.

The remaining `gencol1` failures are genuine engine gaps **newly exposed** by the now-correct reset (they were previously masked because the resurrection bug aborted those loop iterations). Notably `gencol1-2.6.140/150` and `2.7.140/150` reveal a stale index on a generated column after `UPDATE` on `WITHOUT ROWID` tables (indexed `w` not recomputed); the rest are Bucket-A (`decode_hexdb` C-API helper). These are separate follow-ups, not regressions from this change.

## Scope notes / known out-of-scope gaps

- `apply_replace_not_null_defaults` (Commit 1) only fires on statement-level `INSERT OR REPLACE` / `REPLACE INTO`. A **column-level** `NOT NULL ON CONFLICT REPLACE` under a plain `INSERT` does **not** yet get default substitution — that path still ABORTs. This is a missing-feature gap, not a regression, and is left out of scope for this PR.
- Other remaining failures in the touched files are larger separate features (PRAGMA `ignore_check_constraints`, CHECK constraints referencing not-yet-defined UDFs, full per-column/table ON CONFLICT resolution enforcement for UNIQUE/PRIMARY KEY/NOT NULL beyond the default ABORT and the statement-level REPLACE substitution added here, AUTOINCREMENT / `sqlite_sequence` bookkeeping) tracked by the parent issue for a follow-up slice.

## Test Plan

- `make test-tcl-file FILE=gencol1.test` — improved as above.
- `make test-tcl-file FILE=strict1.test|check.test|e_createtable.test` — improved (Commit 1).
- `make test-tcl-file FILE=trigger1.test|view.test|fkey1.test` — no regression.
- Direct repro: creating a temp `.vbsql` (WAL on), deleting only the main file, then reopening resurrects the table; deleting siblings too yields an empty database.

Part of #6173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
