### PR TITLE
fix(fkey): cascade constraint re-validation, unknown-column-in-FK message, ALTER ADD COLUMN check order

### DIFF
--- a/crates/vibesql-executor/src/alter/columns.rs
+++ b/crates/vibesql-executor/src/alter/columns.rs
@@ -100,19 +100,17 @@ pub(super) fn execute_add_column(
             "Cannot add a NOT NULL column with default value NULL".to_string(),
         ));
     }
-    if let Some(default_expr) = stmt.column_def.default_value.as_deref() {
-        if !is_constant_default(default_expr) {
-            return Err(ExecutorError::Other(
-                "Cannot add a column with non-constant default".to_string(),
-            ));
-        }
-    }
     // A REFERENCES column cannot carry a non-NULL default (SQLite's
     // `sqlite3AlterFinishAddColumn`, fkey2-14.1.4/1.5, e_fkey-61.1.1): the
     // added column's default would need to satisfy the FK constraint for
     // every existing row without an FK existence check ever running, which
     // SQLite refuses to do. `DEFAULT NULL` (or no default) is fine because
-    // NULL never participates in FK matching.
+    // NULL never participates in FK matching. This check runs *before* the
+    // non-constant-default check below: SQLite's own restriction ordering
+    // reports the REFERENCES-specific message even when the default is also
+    // non-constant (e.g. `f REFERENCES t1 DEFAULT CURRENT_TIME`,
+    // fkey2-14.1.5) -- both restrictions apply, but SQLite surfaces this one
+    // first.
     let has_references = stmt
         .column_def
         .constraints
@@ -122,6 +120,13 @@ pub(super) fn execute_add_column(
         return Err(ExecutorError::Other(
             "Cannot add a REFERENCES column with non-NULL default value".to_string(),
         ));
+    }
+    if let Some(default_expr) = stmt.column_def.default_value.as_deref() {
+        if !is_constant_default(default_expr) {
+            return Err(ExecutorError::Other(
+                "Cannot add a column with non-constant default".to_string(),
+            ));
+        }
     }
 
     // A STORED generated column may only be added while the table is empty.
@@ -261,8 +266,7 @@ pub(super) fn execute_add_column(
             if violation.is_some() {
                 break;
             }
-            if needs_not_null_check
-                && matches!(row.values.get(new_col_index), Some(SqlValue::Null))
+            if needs_not_null_check && matches!(row.values.get(new_col_index), Some(SqlValue::Null))
             {
                 violation = Some(ExecutorError::SqliteCompatError(
                     "NOT NULL constraint failed".to_string(),

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -432,20 +432,18 @@ impl CreateTableExecutor {
                 deferral,
             } = &constraint.kind
             {
-                // Resolve column indices for FK columns
+                // Resolve column indices for FK columns. SQLite reports a
+                // dedicated "unknown column ... in foreign key definition"
+                // message here (distinct from the generic "no such column"
+                // used elsewhere) -- e.g. `FOREIGN KEY(rowid) REFERENCES t1(a)`
+                // on a table with no column literally named `rowid`
+                // (fkey2-10.2.1).
                 let column_indices: Vec<usize> = fk_columns
                     .iter()
                     .map(|col_name| {
                         table_schema.get_column_index(col_name).ok_or_else(|| {
-                            ExecutorError::ColumnNotFound {
+                            ExecutorError::UnknownColumnInForeignKeyDefinition {
                                 column_name: col_name.to_string(),
-                                table_name: table_name.clone(),
-                                searched_tables: vec![table_name.clone()],
-                                available_columns: table_schema
-                                    .columns
-                                    .iter()
-                                    .map(|c| c.name.clone())
-                                    .collect(),
                             }
                         })
                     })

--- a/crates/vibesql-executor/src/delete/integrity.rs
+++ b/crates/vibesql-executor/src/delete/integrity.rs
@@ -698,6 +698,33 @@ fn apply_cascade_child_updates(
             }
         }
 
+        // A cascading SET NULL/SET DEFAULT rewrite is itself an UPDATE on the
+        // child table and must satisfy the child's own NOT NULL/CHECK
+        // constraints, exactly like a user-issued UPDATE would (mirrors the
+        // equivalent check on the UPDATE-cascade path in
+        // update/foreign_keys.rs, fkey2-3.1.*).
+        let child_schema_for_check = db.catalog.get_table(child_table_name).unwrap().clone();
+        crate::update::constraints::ConstraintValidator::new(&child_schema_for_check)
+            .validate_row_skip_uniqueness(child_table_name, &new_row)?;
+
+        // SET DEFAULT in particular can rewrite the FK column(s) to a default
+        // value that is not itself a valid parent key -- re-validate the
+        // rewritten row's own foreign keys exactly as a user-issued UPDATE
+        // would (mirrors the equivalent check on the UPDATE-cascade path in
+        // update/foreign_keys.rs, fkey2-9.1.5).
+        if !child_schema_for_check.foreign_keys.is_empty() {
+            let deferred =
+                crate::update::foreign_keys::ForeignKeyValidator::collect_constraints_with_old(
+                    db,
+                    child_table_name,
+                    &new_row.values,
+                    Some(&old_row.values),
+                )?;
+            for violation in deferred {
+                db.queue_deferred_fk_violation(violation);
+            }
+        }
+
         let child_table_mut = db.get_table_mut(child_table_name).unwrap();
         child_table_mut
             .update_row(idx, new_row.clone())

--- a/crates/vibesql-executor/src/errors.rs
+++ b/crates/vibesql-executor/src/errors.rs
@@ -210,6 +210,13 @@ pub enum ExecutorError {
     MultiplePrimaryKeys {
         table_name: String,
     },
+    /// A `FOREIGN KEY(...)` column list names a column that does not exist on
+    /// the child table (SQLite-compatible error, distinct from the generic
+    /// `no such column` wording used elsewhere). Format:
+    /// `unknown column "<name>" in foreign key definition`
+    UnknownColumnInForeignKeyDefinition {
+        column_name: String,
+    },
     CannotDropColumn(String),
     ConstraintNotFound {
         constraint_name: String,
@@ -885,6 +892,12 @@ impl std::fmt::Display for ExecutorError {
             ExecutorError::ForeignKeyMismatch { child, parent } => {
                 // SQLite-compatible error format from fkey.c::sqlite3FkLocateIndex.
                 write!(f, "foreign key mismatch - \"{}\" referencing \"{}\"", child, parent)
+            }
+            ExecutorError::UnknownColumnInForeignKeyDefinition { column_name } => {
+                // SQLite-compatible error format from build.c::sqlite3AddCheckConstraint
+                // / resolveFkReferences (fkey2-10.2.1). Hardcoded (not localized)
+                // to stay byte-identical to SQLite, matching ForeignKeyMismatch.
+                write!(f, "unknown column \"{}\" in foreign key definition", column_name)
             }
             ExecutorError::MultiplePrimaryKeys { table_name } => {
                 // SQLite-compatible error format from build.c (misc1-7.1/7.2,

--- a/crates/vibesql-executor/src/tests/fk_cascade_triggers.rs
+++ b/crates/vibesql-executor/src/tests/fk_cascade_triggers.rs
@@ -879,3 +879,67 @@ fn cascade_orphan_in_explicit_txn_preserves_earlier_statements() {
     crate::CommitExecutor::execute(&vibesql_ast::CommitStmt, &mut db).expect("COMMIT ok");
     assert_eq!(query_col(&db, "SELECT id FROM log"), vec![SqlValue::Integer(100)]);
 }
+
+/// fkey2-3.1.3 (#6170): a multi-level `ON UPDATE CASCADE` chain (`ab` ->
+/// `cd` -> `ef`) that lands on a value forbidden by the grandchild's own
+/// CHECK constraint must abort the whole outer UPDATE — the cascade rewrite
+/// is itself an UPDATE on `ef` and must satisfy `ef`'s own constraints, not
+/// silently write the row anyway. Also verifies the multi-level propagation
+/// itself: `cd`'s cascaded PK change must further cascade to `ef`.
+#[test]
+fn multi_level_cascade_update_checks_grandchild_constraints() {
+    let mut db = fresh_db();
+    exec(&mut db, "CREATE TABLE ab(a PRIMARY KEY, b)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE cd(c PRIMARY KEY REFERENCES ab ON UPDATE CASCADE ON DELETE CASCADE, d)",
+    )
+    .unwrap();
+    exec(&mut db, "CREATE TABLE ef(e REFERENCES cd ON UPDATE CASCADE, f, CHECK (e!=5))").unwrap();
+    exec(&mut db, "INSERT INTO ab VALUES(1, 'b')").unwrap();
+    exec(&mut db, "INSERT INTO cd VALUES(1, 'd')").unwrap();
+    exec(&mut db, "INSERT INTO ef VALUES(1, 'e')").unwrap();
+
+    // Cascading ab.a: 1->5 propagates to cd.c (1->5), which must further
+    // cascade to ef.e (1->5) -- but ef has CHECK(e!=5), so the whole UPDATE
+    // must fail and leave every table unchanged.
+    let err = exec(&mut db, "UPDATE ab SET a = 5").unwrap_err();
+    assert!(err.contains("CHECK constraint failed"), "got: {err}");
+    assert_eq!(query_col(&db, "SELECT a FROM ab"), vec![SqlValue::Integer(1)]);
+    assert_eq!(query_col(&db, "SELECT c FROM cd"), vec![SqlValue::Integer(1)]);
+    assert_eq!(query_col(&db, "SELECT e FROM ef"), vec![SqlValue::Integer(1)]);
+
+    // A value that clears the grandchild's CHECK constraint cascades cleanly
+    // through both levels.
+    exec(&mut db, "UPDATE ab SET a = 2").unwrap();
+    assert_eq!(query_col(&db, "SELECT a FROM ab"), vec![SqlValue::Integer(2)]);
+    assert_eq!(query_col(&db, "SELECT c FROM cd"), vec![SqlValue::Integer(2)]);
+    assert_eq!(query_col(&db, "SELECT e FROM ef"), vec![SqlValue::Integer(2)]);
+}
+
+/// fkey2-9.1.5 (#6170): `ON DELETE SET DEFAULT` must re-validate that the
+/// column's default value is itself a valid parent key. If the default no
+/// longer resolves to an existing parent row, the whole DELETE must fail
+/// with a FOREIGN KEY violation instead of silently writing an orphaned
+/// default value into the child row.
+#[test]
+fn on_delete_set_default_revalidates_default_against_parent() {
+    let mut db = fresh_db();
+    exec(&mut db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b)").unwrap();
+    exec(
+        &mut db,
+        "CREATE TABLE t2(c INTEGER PRIMARY KEY, d INTEGER DEFAULT 1 REFERENCES t1 ON DELETE SET DEFAULT)",
+    )
+    .unwrap();
+    // Deliberately do NOT insert a row with a=1, so the default (1) does not
+    // resolve to any parent row once t1's only row (a=2) is deleted.
+    exec(&mut db, "INSERT INTO t1 VALUES(2, 'two')").unwrap();
+    exec(&mut db, "INSERT INTO t2 VALUES(1, 2)").unwrap();
+
+    let err = exec(&mut db, "DELETE FROM t1").unwrap_err();
+    assert!(err.contains("FOREIGN KEY constraint"), "got: {err}");
+    // Nothing was mutated: the child row keeps its original (valid) value
+    // and the parent row was not deleted.
+    assert_eq!(query_col(&db, "SELECT a FROM t1"), vec![SqlValue::Integer(2)]);
+    assert_eq!(query_col(&db, "SELECT d FROM t2"), vec![SqlValue::Integer(2)]);
+}

--- a/crates/vibesql-executor/src/update/foreign_keys.rs
+++ b/crates/vibesql-executor/src/update/foreign_keys.rs
@@ -152,7 +152,9 @@ impl ForeignKeyValidator {
             let key_exists = {
                 #[cfg(feature = "mvcc_enabled")]
                 {
-                    parent_table.scan_visible(&snapshot).any(|(_, parent_row)| row_satisfies(parent_row))
+                    parent_table
+                        .scan_visible(&snapshot)
+                        .any(|(_, parent_row)| row_satisfies(parent_row))
                 }
                 #[cfg(not(feature = "mvcc_enabled"))]
                 {
@@ -619,6 +621,54 @@ impl ForeignKeyValidator {
                         continue;
                     }
                 }
+
+                // A cascading UPDATE/SET NULL/SET DEFAULT is itself an UPDATE
+                // on the child table and must satisfy the child's own NOT
+                // NULL/CHECK constraints, exactly like a user-issued UPDATE
+                // would. Without this, a CASCADE chain that lands on a value
+                // forbidden by the child's CHECK constraint silently wrote the
+                // row anyway instead of aborting the whole outer statement
+                // (fkey2-3.1.3: `ab` -ON UPDATE CASCADE-> `cd` -ON UPDATE
+                // CASCADE-> `ef` landing on `e=5` must trip `CHECK(e!=5)`).
+                let child_schema_for_check = db.catalog.get_table(&table_name).unwrap().clone();
+                crate::update::constraints::ConstraintValidator::new(&child_schema_for_check)
+                    .validate_row_skip_uniqueness(&table_name, &new_row)?;
+
+                // SET DEFAULT in particular can rewrite the FK column(s) to a
+                // default value that is not itself a valid parent key (e.g.
+                // the default references a parent row that no longer
+                // exists) -- re-validate the rewritten row's own foreign keys
+                // exactly as a user-issued UPDATE would (mirrors the
+                // DELETE-side ON DELETE SET DEFAULT check, fkey2-9.1.5).
+                //
+                // This must NOT run for CASCADE: the cascaded value is the
+                // parent's brand-new key, which this very function applies to
+                // the parent's own row *after* this child-cascade loop
+                // returns (Step 7 runs before the parent row is written) --
+                // re-checking existence here would spuriously fail against
+                // the not-yet-written parent key. SET NULL is unaffected
+                // either way since NULL always short-circuits the FK check.
+                if matches!(fk.on_update, vibesql_catalog::ReferentialAction::SetDefault)
+                    && !child_schema_for_check.foreign_keys.is_empty()
+                {
+                    let deferred = Self::collect_constraints_with_old(
+                        db,
+                        &table_name,
+                        &new_row.values,
+                        Some(&old_row.values),
+                    )?;
+                    for violation in deferred {
+                        db.queue_deferred_fk_violation(violation);
+                    }
+                }
+
+                // Multi-level cascade: if this rewrite changed the child's own
+                // primary key (e.g. the FK column doubles as the child's PK),
+                // recursively propagate to grandchildren that reference *this*
+                // table before the row is written, mirroring the DELETE-side
+                // cascade's recursive `check_no_child_references` call for
+                // multi-level chains (fkey2-3.1.*).
+                Self::check_no_child_references(db, &table_name, &old_row, &new_row)?;
 
                 let child_table = db.get_table_mut(&table_name).unwrap();
                 child_table

--- a/crates/vibesql-executor/src/update/mod.rs
+++ b/crates/vibesql-executor/src/update/mod.rs
@@ -26,7 +26,7 @@
 pub(crate) mod constraints;
 mod executor;
 mod fast_path;
-mod foreign_keys;
+pub(crate) mod foreign_keys;
 mod from_clause;
 mod index_sync;
 mod row_selector;
@@ -150,8 +150,7 @@ impl UpdateExecutor {
             may_fire,
             stmt.conflict_clause,
             |database| {
-                executor::execute_internal(stmt, database, None, None, None)
-                    .map(|(count, _)| count)
+                executor::execute_internal(stmt, database, None, None, None).map(|(count, _)| count)
             },
         )
     }

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -677,6 +677,17 @@ proc translate_error_to_sqlite {vibesql_error} {
         return $error_msg
     }
 
+    # ALTER TABLE ADD COLUMN restrictions (sqlite3AlterFinishAddColumn): these
+    # are SQLite's own verbatim wordings and must pass through unchanged.
+    # Both "...NOT NULL column with default value NULL" and "...REFERENCES
+    # column with non-NULL default value" contain the substring "NULL", so
+    # without this early pass-through they fall into the generic
+    # `cannot.*NULL` -> "NOT NULL constraint failed" fallback below and lose
+    # their real wording (fkey2-14.1.4/1.5, e_fkey-61.1.1, alter3-2.4).
+    if {[regexp -nocase {^Cannot add a (NOT NULL column with default value NULL|REFERENCES column with non-NULL default value)$} $error_msg]} {
+        return $error_msg
+    }
+
     # Constraint violations - VibeSQL now outputs SQLite-compatible format directly
     # Format: "UNIQUE constraint failed: table.column" or "UNIQUE constraint failed: table.col1, table.col2"
     if {[regexp -nocase {UNIQUE constraint failed: (.+)$} $error_msg -> col_spec]} {


### PR DESCRIPTION
## Summary

Further progress on foreign-key enforcement semantics (Part of #6170). This PR does **not** fully clear the family (fkey2/e_fkey/fkey3/fkey4/fkey7 still have real remaining failures). Uses `Part of #6170`, not `Closes`.

Root-cause fixes to the engine (not test relaxation):

1. **`crates/vibesql-executor/src/update/foreign_keys.rs`, `crates/vibesql-executor/src/delete/integrity.rs`** — FK referential actions (`ON UPDATE`/`ON DELETE` `CASCADE`/`SET NULL`/`SET DEFAULT`) wrote the rewritten child row directly via `Table::update_row`, bypassing NOT NULL/CHECK constraint validation entirely. A cascading UPDATE is itself an UPDATE on the child table and must satisfy the child's own constraints (fkey2-3.1.3: a `CASCADE` chain landing on a `CHECK`-forbidden value now aborts the whole outer statement instead of silently writing it anyway).

2. **`crates/vibesql-executor/src/update/foreign_keys.rs`** — Multi-level `ON UPDATE CASCADE` didn't propagate past the first level: the UPDATE-side `check_no_child_references` never recursed into grandchildren the way the DELETE-side cascade already did. Now recurses when a cascade changes the child's own primary key (e.g. `ab` -CASCADE-> `cd` -CASCADE-> `ef`).

3. **`update/foreign_keys.rs`, `delete/integrity.rs`** — `ON DELETE`/`ON UPDATE SET DEFAULT` never re-validated that the default value is itself a valid parent key (fkey2-9.1.5: deleting the last matching parent row while the default no longer resolves to any parent row now correctly raises `FOREIGN KEY constraint failed` instead of writing an orphan). Deliberately scoped to `SET DEFAULT` only — re-validating `CASCADE`'s own FK against the not-yet-written parent row produces false positives, since this check runs *before* the parent row's own UPDATE is applied (verified: an earlier version of this fix regressed `fkey2-3.1.3`/`fkey2-genfkey.2.3` with spurious `FOREIGN KEY constraint failed` until scoped correctly).

4. **`crates/vibesql-executor/src/create_table.rs`, `errors.rs`** — `FOREIGN KEY(rowid)` referencing a table with no column literally named `rowid` now reports SQLite's dedicated `unknown column "rowid" in foreign key definition` instead of the generic `no such column` wording (fkey2-10.2.1).

5. **`crates/vibesql-executor/src/alter/columns.rs`** — `ALTER TABLE ADD COLUMN ... REFERENCES ... DEFAULT <non-constant>` now checks the REFERENCES-with-non-null-default restriction *before* the non-constant-default restriction, matching SQLite's own check ordering (fkey2-14.1.5): both restrictions apply, but SQLite's message surfaces the REFERENCES-specific one first.

6. **`scripts/tester_vibesql.tcl`** — Harness fix: `translate_error_to_sqlite`'s generic `cannot.*NULL` → `"NOT NULL constraint failed"` fallback was clobbering the two ALTER TABLE ADD COLUMN verbatim SQLite messages that happen to contain the substring "NULL" (`Cannot add a NOT NULL column with default value NULL` / `Cannot add a REFERENCES column with non-NULL default value`), silently losing the engine's already-correct output (fkey2-14.1.4/1.5, e_fkey-61.1.1, alter3-2.4).

## Test Plan / Measured Results

Measured this session against this repo's TCL harness (same machine, before vs. after — not the certified AWS baseline):

| File | Before | After |
|---|---:|---:|
| `fkey2.test` | 129 failed | **117 failed** |
| `e_fkey.test` | 148 failed | **138 failed** |
| `fkey1.test` | 2 failed | 2 failed (unchanged) |
| `fkey3.test` | 3 failed | 3 failed (unchanged) |
| `fkey4.test` | 2 failed | 2 failed (unchanged) |
| `fkey7.test` | 7 failed | 7 failed (unchanged) |

```
cargo test --release -p vibesql-executor --lib
test result: ok. 3629 passed; 0 failed; 2 ignored (was 3627 before; +2 new regression tests)
```

Also spot-checked for regressions in files sharing the touched code paths: `delete.test` (0 failed), `update.test` (0 failed), `alter.test`/`alter3.test`/`alter4.test` (failures present but all pre-existing/unrelated — verified none touch the REFERENCES/NOT NULL ALTER message path I changed), `without_rowid3.test` (no crash, 106/1186 failed — fkey2 shares this file's test bodies).

New Rust unit tests added to `crates/vibesql-executor/src/tests/fk_cascade_triggers.rs`:
- `multi_level_cascade_update_checks_grandchild_constraints` — locks in fixes #1/#2 above.
- `on_delete_set_default_revalidates_default_against_parent` — locks in fix #3 above.

## What's still failing / honest scope note

This is a large family and this PR makes real, verified progress rather than full clearance. Remaining gaps, not fixed this pass:

- **A larger real gap**: `ON UPDATE CASCADE`/`RESTRICT`/etc. on the parent side only fire when the UPDATE changes the parent's `PRIMARY KEY`, not when it changes a `UNIQUE`-based parent key a child FK actually references (`fkey2-genfkey.2.5`/`2.6`/`3.5`: `FOREIGN KEY(h,i) REFERENCES t1(b,c)` where `(b,c)` is a `UNIQUE` constraint, not `t1`'s PK). This spans `update/executor.rs`, `update/fast_path.rs`, and `update/from_clause.rs`'s `updates_pk` computation — a bigger, more invasive fix better suited to a focused follow-up.
- `SAVEPOINT`/`ROLLBACK TO` not undoing `DELETE`/`UPDATE` (tracked separately as #6278) underlies most of the `fkey2-2.*` deferred-FK/savepoint block (~20 remaining failures there).
- `fkey2-15.1.*` depend on `sqlite_search_count`/`sqlite_found_count`, internal B-tree step counters VibeSQL doesn't expose — same class of harness limitation as the existing `#5842`/`#5844` precedent (`select2`/`minmax3`).
- `fkey2-14.1aux.*`/`14.2aux.*` require `ATTACH DATABASE` (confirmed unsupported: `near "ATTACH": syntax error`); `fkey2-14.2tmp.*` involve `TEMP TABLE` + `RENAME` interaction bugs not investigated this pass.
- REPLACE-driven FK re-check row duplication (`fkey2-13.1.2.2`/`2.4`) and the `count_changes`-in-explicit-transaction harness gap (`fkey2-1.4.*`/`17.*`) flagged in the prior PR (#6279) are still open.

`Part of #6170` — the family stays open for the remaining work above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>