### PR TITLE
fix(pragma): echo verbatim declared type and DEFAULT text in table_info

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -128,6 +128,86 @@ fn sqlite_declared_type(
     }
 }
 
+/// Strip a single surrounding pair of SQL identifier delimiters from a declared
+/// type name, so `PRAGMA table_info` echoes it the way SQLite does.
+///
+/// SQLite records the declared type verbatim but without the delimiters that
+/// quote it: `CREATE TABLE t(b [TYPE_Y], c "TYPE_Z")` reports the types
+/// `TYPE_Y` and `TYPE_Z` (pragma-6.2). A non-delimited type such as
+/// `VARCHAR(45, 65)` is returned unchanged, parentheses and all. Only a matching
+/// outer pair of `[...]`, `"..."`, or `` `...` `` is removed; an unmatched or
+/// absent delimiter leaves the text untouched.
+fn strip_type_delimiters(type_source: &str) -> String {
+    let t = type_source.trim();
+    let bytes = t.as_bytes();
+    if bytes.len() >= 2 {
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        let matched = (first == b'[' && last == b']')
+            || (first == b'"' && last == b'"')
+            || (first == b'`' && last == b'`');
+        if matched {
+            return t[1..t.len() - 1].to_string();
+        }
+    }
+    t.to_string()
+}
+
+/// Apply SQLite's case normalization to a (delimiter-stripped) declared type
+/// name for `PRAGMA table_info`.
+///
+/// SQLite echoes declared types verbatim (preserving case and any argument
+/// list) with one exception: when the whole type name matches — case
+/// insensitively — one of the five canonical storage-class names `INTEGER`,
+/// `INT`, `TEXT`, `BLOB`, or `REAL`, it is reported upper-cased. So `text`
+/// becomes `TEXT` and `integer` becomes `INTEGER`, but `numeric`, `varchar`,
+/// `double`, `int(11)`, and `bigint` are all left exactly as written (verified
+/// against sqlite3 3.x). Anything not in the set is returned unchanged.
+fn canonicalize_sqlite_decltype(stripped_type: &str) -> String {
+    const CANONICAL: [&str; 5] = ["INTEGER", "INT", "TEXT", "BLOB", "REAL"];
+    for name in CANONICAL {
+        if stripped_type.eq_ignore_ascii_case(name) {
+            return name.to_string();
+        }
+    }
+    stripped_type.to_string()
+}
+
+/// Strip a single balanced outer parenthesis pair from a DEFAULT expression's
+/// verbatim source, matching SQLite's `dflt_value` normalization.
+///
+/// SQLite reports `CREATE TABLE t(b DEFAULT (5+3))` as the default `5+3`
+/// (pragma-6.2.2) — one layer of the outer parentheses that wrap the whole
+/// expression is removed. Text that is not wholly wrapped in a single balanced
+/// pair (e.g. `(1)+(2)` or `-1`) is returned unchanged.
+fn strip_outer_parens(default_source: &str) -> String {
+    let s = default_source.trim();
+    let bytes = s.as_bytes();
+    if bytes.first() != Some(&b'(') || bytes.last() != Some(&b')') {
+        return s.to_string();
+    }
+    // Confirm the leading '(' closes at the trailing ')', not earlier — so
+    // `(1)+(2)` (whose first '(' closes mid-string) is left untouched.
+    let mut depth = 0usize;
+    for (i, &b) in bytes.iter().enumerate() {
+        match b {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    // The opening paren's match: strip only if it is the final byte.
+                    if i == bytes.len() - 1 {
+                        return s[1..s.len() - 1].trim().to_string();
+                    }
+                    return s.to_string();
+                }
+            }
+            _ => {}
+        }
+    }
+    s.to_string()
+}
+
 /// Format SqlValue for output in SQLite-compatible format
 /// - Booleans are displayed as 0/1 instead of FALSE/TRUE
 /// - Other values use their standard Display format
@@ -2088,14 +2168,31 @@ impl SqlExecutor {
         // a CREATE ... AS SELECT with no explicit column list, or a re-parse
         // failure) means we fall back to the catalog-derived behavior below,
         // unchanged. `pk_source_positions` is likewise a best-effort override.
+        //   * The `type` column echoes the *declared* type text verbatim, as
+        //     written in the CREATE TABLE statement (only the surrounding
+        //     delimiters of a bracketed/quoted type name are stripped). The
+        //     catalog's affinity-only `data_type` is lossy — it renders
+        //     `VARCHAR(45, 65)` as `VARCHAR(45)` — so we prefer the re-parsed
+        //     `type_source`. `decl_type` holds the delimiter-stripped verbatim
+        //     text; `None` marks a typeless column (empty type).
+        //   * The `dflt_value` column echoes the *verbatim* DEFAULT expression
+        //     source (e.g. `X'abcdef'`, `'abcde'`, `-1`, `CURRENT_TIME`) rather
+        //     than a lossy `ToSql` re-render that uppercases blob hex and drops
+        //     operator spacing. A single balanced outer parenthesis pair is
+        //     stripped (`DEFAULT (5+3)` -> `5+3`), matching SQLite.
         let mut decl_facts: std::collections::HashMap<String, (bool, bool)> =
+            std::collections::HashMap::new();
+        let mut decl_types: std::collections::HashMap<String, Option<String>> =
+            std::collections::HashMap::new();
+        let mut default_sources: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
         let mut pk_source_positions: Option<std::collections::HashMap<String, usize>> = None;
         if let Some(src) = schema.sql_source.as_deref() {
-            if let Ok(vibesql_ast::Statement::CreateTable(create)) =
-                vibesql_parser::Parser::parse_sql(src)
+            if let Ok((vibesql_ast::Statement::CreateTable(create), dflt_srcs)) =
+                vibesql_parser::Parser::parse_sql_with_default_sources(src)
             {
                 if create.as_query.is_none() {
+                    default_sources = dflt_srcs;
                     for col in &create.columns {
                         let is_typeless = col.type_source.is_none();
                         let explicit_not_null = col.constraints.iter().any(|c| {
@@ -2107,6 +2204,13 @@ impl SqlExecutor {
                         });
                         decl_facts
                             .insert(col.name.to_lowercase(), (is_typeless, explicit_not_null));
+                        // Delimiter-stripped verbatim declared-type text; `None`
+                        // for a typeless column (reports empty type in SQLite).
+                        let decl_type = col
+                            .type_source
+                            .as_deref()
+                            .map(|ts| canonicalize_sqlite_decltype(&strip_type_delimiters(ts)));
+                        decl_types.insert(col.name.to_lowercase(), decl_type);
                     }
 
                     // Derive raw pk ordinals from a table-level PRIMARY KEY
@@ -2157,14 +2261,24 @@ impl SqlExecutor {
         for (cid, column) in schema.columns.iter().enumerate() {
             let decl = decl_facts.get(&column.name.to_lowercase());
 
-            // Type column: SQLite reports the declared type as supplied in the
-            // CREATE TABLE statement. A typeless column reports the empty
-            // string; otherwise we map our DataType back to the canonical
-            // SQLite-flavor name (we don't preserve the verbatim text).
-            let type_str = if matches!(decl, Some((true, _))) {
-                String::new()
-            } else {
-                sqlite_declared_type(&column.data_type, column.is_exact_integer_type)
+            // Type column: SQLite reports the declared type verbatim, exactly as
+            // supplied in the CREATE TABLE statement (delimiters aside). Prefer
+            // the re-parsed `type_source` (delimiter-stripped) so declarations
+            // the catalog's affinity mapping cannot round-trip — e.g.
+            // `VARCHAR(45, 65)` — echo faithfully. A typeless column reports the
+            // empty string. Fall back to the canonical affinity name only when
+            // no source declaration is available (programmatic table, reload
+            // without `sql_source`, or a re-parse failure).
+            let type_str = match decl_types.get(&column.name.to_lowercase()) {
+                Some(Some(decl_type)) => decl_type.clone(),
+                Some(None) => String::new(),
+                None => {
+                    if matches!(decl, Some((true, _))) {
+                        String::new()
+                    } else {
+                        sqlite_declared_type(&column.data_type, column.is_exact_integer_type)
+                    }
+                }
             };
 
             // notnull: 1 only for an *explicit* NOT NULL clause. An INTEGER
@@ -2188,11 +2302,21 @@ impl SqlExecutor {
                 }
             };
 
-            // dflt_value: render the default expression as SQL text, or NULL.
-            let dflt_value: Option<String> = column.default_value.as_ref().map(|e| {
-                use vibesql_ast::pretty_print::ToSql;
-                e.to_sql()
-            });
+            // dflt_value: echo the verbatim DEFAULT source text (SQLite does),
+            // falling back to a `ToSql` re-render only when the verbatim source
+            // is unavailable (programmatic table or reload without `sql_source`).
+            // The verbatim text preserves original spelling that `ToSql` loses:
+            // blob-literal hex casing (`X'abcdef'`, not `x'ABCDEF'`), quoted
+            // string delimiters, and operator spacing.
+            let dflt_value: Option<String> = default_sources
+                .get(&column.name.to_lowercase())
+                .map(|s| strip_outer_parens(s))
+                .or_else(|| {
+                    column.default_value.as_ref().map(|e| {
+                        use vibesql_ast::pretty_print::ToSql;
+                        e.to_sql()
+                    })
+                });
 
             // pk: 1-based position within the primary key, or 0 if not PK.
             let pk = pk_positions.get(&column.name.to_lowercase()).copied().unwrap_or(0);

--- a/crates/vibesql-cli/src/executor/tests.rs
+++ b/crates/vibesql-cli/src/executor/tests.rs
@@ -661,6 +661,71 @@ fn test_pragma_integrity_check_with_table_argument() {
 }
 
 #[test]
+fn test_pragma_table_info_verbatim_type_and_default() {
+    // PRAGMA table_info echoes the declared type verbatim (only bracket/quote
+    // delimiters stripped) and the verbatim DEFAULT source text, matching
+    // SQLite (pragma-6.7). Columns: cid, name, type, notnull, dflt_value, pk.
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor
+        .execute(
+            "CREATE TABLE test_table(\
+                one INT NOT NULL DEFAULT -1, \
+                two text, \
+                three VARCHAR(45, 65) DEFAULT 'abcde', \
+                four REAL DEFAULT X'abcdef', \
+                five DEFAULT CURRENT_TIME)",
+        )
+        .unwrap();
+    let result = executor.execute("PRAGMA table_info(test_table)").unwrap();
+    let expect: Vec<(&str, &str, &str, Option<&str>)> = vec![
+        ("one", "INT", "1", Some("-1")),
+        // `text` (lowercase) canonicalizes to `TEXT`; a column with no DEFAULT
+        // reports NULL.
+        ("two", "TEXT", "0", None),
+        // Two-argument VARCHAR the affinity mapping cannot round-trip is echoed
+        // verbatim, and the string default keeps its quotes.
+        ("three", "VARCHAR(45, 65)", "0", Some("'abcde'")),
+        // Blob-literal default preserves SQLite's `X'..'` spelling (not the
+        // ToSql `x'ABCDEF'` re-render).
+        ("four", "REAL", "0", Some("X'abcdef'")),
+        // Typeless column reports an empty type; CURRENT_TIME default verbatim.
+        ("five", "", "0", Some("CURRENT_TIME")),
+    ];
+    assert_eq!(result.row_count, expect.len());
+    for (i, (name, ty, notnull, dflt)) in expect.into_iter().enumerate() {
+        assert_eq!(result.rows[i][1].as_deref(), Some(name), "name row {i}");
+        assert_eq!(result.rows[i][2].as_deref(), Some(ty), "type row {i}");
+        assert_eq!(result.rows[i][3].as_deref(), Some(notnull), "notnull row {i}");
+        assert_eq!(result.rows[i][4].as_deref(), dflt, "dflt_value row {i}");
+    }
+}
+
+#[test]
+fn test_pragma_table_info_strips_type_delimiters() {
+    // Bracketed / double-quoted type names report the inner name only
+    // (pragma-6.2): `[TYPE_Y]` -> `TYPE_Y`, `"TYPE_Z"` -> `TYPE_Z`. A plain
+    // user type is echoed unchanged.
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor
+        .execute("CREATE TABLE t2(a TYPE_X, b [TYPE_Y], c \"TYPE_Z\")")
+        .unwrap();
+    let result = executor.execute("PRAGMA table_info(t2)").unwrap();
+    assert_eq!(result.rows[0][2].as_deref(), Some("TYPE_X"));
+    assert_eq!(result.rows[1][2].as_deref(), Some("TYPE_Y"));
+    assert_eq!(result.rows[2][2].as_deref(), Some("TYPE_Z"));
+}
+
+#[test]
+fn test_pragma_table_info_default_strips_outer_parens() {
+    // A parenthesized DEFAULT expression reports without its single outer paren
+    // pair, matching SQLite (`DEFAULT (5+3)` -> `5+3`, pragma-6.2.2).
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor.execute("CREATE TABLE t9(b DEFAULT (5+3))").unwrap();
+    let result = executor.execute("PRAGMA table_info(t9)").unwrap();
+    assert_eq!(result.rows[0][4].as_deref(), Some("5+3"));
+}
+
+#[test]
 fn test_pragma_database_list_memory_no_temp() {
     // An in-memory session with no temp objects reports exactly one row:
     // seq=0, name=main, file="" — matching sqlite3 3.51.0, which omits the

--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -373,12 +373,17 @@ impl Parser {
             Vec<vibesql_ast::ColumnConstraint>,
             Option<Box<vibesql_ast::Expression>>,
             Option<Box<vibesql_ast::Expression>>,
+            Option<String>,
         ),
         ParseError,
     > {
         let mut constraints = Vec::new();
         let mut default_value: Option<Box<vibesql_ast::Expression>> = None;
         let mut generated_expr: Option<Box<vibesql_ast::Expression>> = None;
+        // Verbatim source text of an interleaved DEFAULT expression, captured so
+        // PRAGMA table_info can echo the original spelling (#6175). See
+        // `Parser::parse_sql_with_default_sources`.
+        let mut default_source: Option<String> = None;
 
         loop {
             // Check for optional CONSTRAINT keyword
@@ -413,12 +418,14 @@ impl Parser {
                         });
                     }
                     self.advance(); // consume DEFAULT
+                    let default_start = self.current_position();
                     let expr = self.parse_expression()?;
                     if default_value.is_some() {
                         return Err(ParseError {
                             message: "Multiple DEFAULT clauses for the same column".to_string(),
                         });
                     }
+                    default_source = self.source_between(default_start, self.current_position());
                     default_value = Some(Box::new(expr));
                 }
                 Token::Keyword { keyword: Keyword::Null, .. } => {
@@ -641,7 +648,7 @@ impl Parser {
             }
         }
 
-        Ok((constraints, default_value, generated_expr))
+        Ok((constraints, default_value, generated_expr, default_source))
     }
 
     /// Absorb trailing, body-less `CONSTRAINT <name>` clauses that SQLite accepts

--- a/crates/vibesql-parser/src/parser/create/table.rs
+++ b/crates/vibesql-parser/src/parser/create/table.rs
@@ -196,9 +196,17 @@ impl Parser {
             // SQLite also allows DEFAULT to appear interleaved with column constraints
             // (e.g. `idx UNIQUE DEFAULT NULL`), so `parse_column_constraints` below may
             // also consume a DEFAULT clause and return it via its second tuple element.
+            // Verbatim source text of the DEFAULT expression, captured so
+            // PRAGMA table_info can echo the original spelling (#6175). A DEFAULT
+            // may appear here (before constraints) or interleaved with them
+            // (captured as `mid_default_source` below).
+            let mut default_source: Option<String> = None;
             let mut default_value = if self.peek_keyword(Keyword::Default) {
                 self.advance(); // consume DEFAULT
-                Some(Box::new(self.parse_expression()?))
+                let default_start = self.current_position();
+                let expr = self.parse_expression()?;
+                default_source = self.source_between(default_start, self.current_position());
+                Some(Box::new(expr))
             } else {
                 None
             };
@@ -225,7 +233,8 @@ impl Parser {
             // Parse column constraints (which may include NOT NULL, an
             // interleaved DEFAULT, and — in any order — a generated-column
             // `[GENERATED ALWAYS] AS (expr)` clause).
-            let (constraints, mid_default, mid_generated) = self.parse_column_constraints()?;
+            let (constraints, mid_default, mid_generated, mid_default_source) =
+                self.parse_column_constraints()?;
             if let Some(d) = mid_default {
                 if default_value.is_some() {
                     return Err(ParseError {
@@ -233,6 +242,7 @@ impl Parser {
                     });
                 }
                 default_value = Some(d);
+                default_source = mid_default_source;
             }
             if let Some(g) = mid_generated {
                 if generated_expr.is_some() {
@@ -260,6 +270,14 @@ impl Parser {
             let nullable = !constraints
                 .iter()
                 .any(|c| matches!(&c.kind, vibesql_ast::ColumnConstraintKind::NotNull));
+
+            // Record the verbatim DEFAULT source for PRAGMA table_info (#6175),
+            // keyed by lowercase column name. Only recorded when both a default
+            // and its captured source text are present (source capture requires
+            // the parser to have been built with source/span info).
+            if let Some(src) = default_source {
+                self.column_default_sources.push((name.to_lowercase(), src));
+            }
 
             columns.push(vibesql_ast::ColumnDef {
                 name,

--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -71,6 +71,14 @@ pub struct Parser {
     /// `RAISE()` inside a trigger body and reject it everywhere else,
     /// matching sqlite3 (`RAISE() may only be used within a trigger-program`).
     in_trigger_body: bool,
+    /// Verbatim source text of each CREATE TABLE column's `DEFAULT` expression,
+    /// as `(lowercase column name, source text)` pairs in declaration order.
+    /// Populated only when the parser was built with source/span info
+    /// ([`Parser::new_with_source`]). `PRAGMA table_info` reads this (via
+    /// [`Parser::parse_sql_with_default_sources`]) to echo the original default
+    /// spelling — e.g. `X'abcdef'`, `'abcde'`, `-1` — rather than a lossy
+    /// `ToSql` re-render (which uppercases blob hex and drops operator spacing).
+    column_default_sources: Vec<(String, String)>,
 }
 
 impl Parser {
@@ -87,6 +95,7 @@ impl Parser {
             in_trigger_body: false,
             source: String::new(),
             spans: Vec::new(),
+            column_default_sources: Vec::new(),
         }
     }
 
@@ -96,7 +105,15 @@ impl Parser {
     /// with its original quoting), which SQLite preserves in some error
     /// messages.
     pub fn new_with_source(tokens: Vec<Token>, spans: Vec<Span>, source: String) -> Self {
-        Parser { tokens, position: 0, placeholder_count: 0, in_trigger_body: false, source, spans }
+        Parser {
+            tokens,
+            position: 0,
+            placeholder_count: 0,
+            in_trigger_body: false,
+            source,
+            spans,
+            column_default_sources: Vec::new(),
+        }
     }
 
     /// Current token index (cursor position within the token stream).
@@ -201,6 +218,32 @@ impl Parser {
 
         let mut parser = Parser::new_with_source(tokens, spans, input.to_string());
         parser.parse_statement()
+    }
+
+    /// Parse SQL and, for a `CREATE TABLE`, also return the verbatim source text
+    /// of each column's `DEFAULT` expression, keyed by lowercase column name.
+    ///
+    /// `PRAGMA table_info` uses this so the `dflt_value` column echoes the
+    /// original default spelling (e.g. `X'abcdef'`, `'abcde'`, `-1`,
+    /// `CURRENT_TIME`) exactly as written in the CREATE TABLE statement, which
+    /// SQLite does. A plain `expr.to_sql()` re-render is lossy here: it
+    /// uppercases blob-literal hex (`x'ABCDEF'`) and normalizes operator
+    /// spacing. The map is empty for non-`CREATE TABLE` input or columns without
+    /// a DEFAULT.
+    pub fn parse_sql_with_default_sources(
+        input: &str,
+    ) -> Result<(vibesql_ast::Statement, std::collections::HashMap<String, String>), ParseError>
+    {
+        let mut lexer = Lexer::new(input);
+        let tokens_with_spans = lexer
+            .tokenize_with_spans()
+            .map_err(|e| ParseError { message: format!("Lexer error: {}", e) })?;
+        let (tokens, spans): (Vec<Token>, Vec<Span>) = tokens_with_spans.into_iter().unzip();
+
+        let mut parser = Parser::new_with_source(tokens, spans, input.to_string());
+        let stmt = parser.parse_statement()?;
+        let map = parser.column_default_sources.iter().cloned().collect();
+        Ok((stmt, map))
     }
 
     /// Parse a single SQL statement that originates from a `CREATE TRIGGER`


### PR DESCRIPTION
## Summary

`PRAGMA table_info` now reports each column's declared **type** and **DEFAULT value** using the verbatim source text from the `CREATE TABLE` statement, matching SQLite. This clears the schema-introspection case `pragma-6.7` and is a partial increment of the PRAGMA family (#6175).

Previously VibeSQL re-rendered the type from its affinity-only catalog `DataType` (lossy: `VARCHAR(45, 65)` collapsed to `VARCHAR(45)`) and the default via `ToSql` (lossy: blob hex uppercased to `x'ABCDEF'`, operator spacing dropped).

## Changes

- **Verbatim declared type** (`crates/vibesql-cli/src/executor/mod.rs`): `table_info` prefers the re-parsed `type_source`, stripping only a surrounding `[...]` / `"..."` / `` `...` `` delimiter pair. The five canonical storage-class names `INTEGER`, `INT`, `TEXT`, `BLOB`, `REAL` are upper-cased (as SQLite does); every other spelling keeps its original case. Falls back to the affinity name when no source is available (programmatic table / reload without `sql_source`).
- **Verbatim DEFAULT text**: `table_info` echoes the original default expression source; a single balanced outer paren pair is stripped (`DEFAULT (5+3)` → `5+3`).
- **Parser side-channel** (`crates/vibesql-parser/src/parser/...`): new `Parser::parse_sql_with_default_sources` returns per-column verbatim DEFAULT source alongside the AST. Captured at both DEFAULT parse sites (leading and interleaved-with-constraints). This avoids adding a field to `ColumnDef` (which is constructed at 150+ sites).
- Unit tests for verbatim type/default, delimiter stripping, and outer-paren stripping.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Introspection PRAGMA `table_info` matches SQLite (pragma-6.7) | ✅ | `pragma.test` 76 → 77 passing (pragma-6.7 flips); exactly one test flips, zero regressions in-file |
| No pragma reclassified as Bucket-A | ✅ | Pure introspection fix; no journaling/pager PRAGMA touched |
| No regressions in other `table_info` consumers | ✅ | Baseline vs. build: `e_createtable.test` 331/150 unchanged, `default.test` 2/0 unchanged, `intpkey.test` 84/0 unchanged, `colname.test` **62 → 64** (verbatim type also fixes 2 there) |

## Test Plan

- `make test-tcl-file FILE=pragma.test`: **76 → 77** passing (pragma-6.7).
- Baseline comparison (origin/main binary vs. this branch) on the highest-volume `table_info` files: no regressions; `colname.test` +2.
- `cargo test -p vibesql-cli --bin vibesql`: 171 passed (incl. 3 new table_info tests).
- `cargo test -p vibesql-parser`: 1821 + 8 passed.

## Remaining PRAGMA family work (not in this increment)

Still open under #6175: `user_version`/`schema_version`/`application_id` (need DB-header value persistence across the shim's per-process model), temp-vs-main `table_info` shadowing (pragma-6.6.3/6.6.4), and the empty-vs-NULL shim rendering (pragma-6.2.2). Genuinely pager/journal-internal PRAGMAs (`cache_size`, `synchronous`, `freelist_count`, `page_size`, proxy locking) remain flagged Bucket-A for #6154.

Part of #6175