### PR TITLE
fix(fkey): DROP TABLE performs SQLite's implicit FK-enforcing DELETE

### DIFF
--- a/crates/vibesql-executor/src/delete/integrity.rs
+++ b/crates/vibesql-executor/src/delete/integrity.rs
@@ -26,6 +26,86 @@ pub fn check_no_child_references(
     parent_table_name: &str,
     parent_row: &vibesql_storage::Row,
 ) -> Result<(), ExecutorError> {
+    check_child_references_impl(db, parent_table_name, parent_row, false)
+}
+
+/// Emulate SQLite's implicit `DELETE FROM <table>` that a `DROP TABLE`
+/// performs when foreign keys are enabled (`sqlite3FkDropTable`).
+///
+/// EVIDENCE-OF R-14208-23986 / R-11078-03945: the implicit DELETE removes
+/// all rows and *may invoke foreign key actions or constraint violations*,
+/// but does **not** fire SQL triggers on the dropped table. We therefore run
+/// the child-reference enforcement (RESTRICT / NO ACTION raise, CASCADE /
+/// SET NULL / SET DEFAULT actions) for every live parent row, but never fire
+/// the parent's own DELETE triggers (this path bypasses the DELETE executor).
+///
+/// Foreign keys where the child table *is* the table being dropped are
+/// skipped: a self-referential FK is always satisfied once the entire table
+/// (all parent and child rows) disappears together, so it can never block the
+/// drop (mirrors SQLite's statement-scoped counter reaching zero after the
+/// whole-table delete). Only FKs from *other* tables can be violated.
+///
+/// EVIDENCE-OF R-57242-37005: any "foreign key mismatch" that would be
+/// reported by an equivalent explicit DELETE is ignored here — an FK whose
+/// parent-side key columns do not resolve to a valid parent key is skipped
+/// rather than raised (handled by `check_child_references_impl` skipping
+/// unresolved parent indices).
+pub fn check_drop_table_references(
+    db: &mut vibesql_storage::Database,
+    table_name: &str,
+) -> Result<(), ExecutorError> {
+    // Skip FK enforcement when PRAGMA foreign_keys is OFF (default). The
+    // special DROP-TABLE behavior only applies when foreign keys are enabled
+    // (EVIDENCE-OF R-54142-41346).
+    if !db.foreign_keys_enabled() {
+        return Ok(());
+    }
+
+    // Fast exit: only tables *other* than the one being dropped can hold an FK
+    // that this drop could violate. A self-referential FK never blocks a drop.
+    let has_incoming_fks = db.catalog.list_tables().iter().any(|t| {
+        !t.eq_ignore_ascii_case(table_name)
+            && db
+                .catalog
+                .get_table(t)
+                .map(|schema| {
+                    schema
+                        .foreign_keys
+                        .iter()
+                        .any(|fk| fk.parent_table.eq_ignore_ascii_case(table_name))
+                })
+                .unwrap_or(false)
+    });
+    if !has_incoming_fks {
+        return Ok(());
+    }
+
+    // Snapshot every live parent row before mutating any child table, so the
+    // set of rows the implicit DELETE removes is fixed up front (a CASCADE
+    // into another table must not perturb this iteration).
+    let snapshot = crate::mvcc::read_snapshot(db);
+    let parent_rows: Vec<vibesql_storage::Row> = match db.get_table(table_name) {
+        Some(t) => t.scan_visible(&snapshot).map(|(_, r)| r.clone()).collect(),
+        None => return Ok(()),
+    };
+
+    for parent_row in &parent_rows {
+        check_child_references_impl(db, table_name, parent_row, true)?;
+    }
+
+    Ok(())
+}
+
+/// Shared implementation behind [`check_no_child_references`] and
+/// [`check_drop_table_references`]. When `exclude_self_table` is true, foreign
+/// keys whose child table is `parent_table_name` are skipped (the DROP TABLE
+/// self-reference case above); otherwise all child tables are considered.
+fn check_child_references_impl(
+    db: &mut vibesql_storage::Database,
+    parent_table_name: &str,
+    parent_row: &vibesql_storage::Row,
+    exclude_self_table: bool,
+) -> Result<(), ExecutorError> {
     // Skip FK enforcement when PRAGMA foreign_keys is OFF (default)
     if !db.foreign_keys_enabled() {
         return Ok(());
@@ -86,6 +166,13 @@ pub fn check_no_child_references(
     )> = Vec::new();
 
     for table_name in db.catalog.list_tables() {
+        // DROP TABLE's implicit DELETE skips self-referential FKs: once the
+        // whole table is removed both sides of the reference disappear, so it
+        // can never be violated (see `check_drop_table_references`).
+        if exclude_self_table && table_name.eq_ignore_ascii_case(parent_table_name) {
+            continue;
+        }
+
         let child_schema = db.catalog.get_table(&table_name).unwrap();
 
         if child_schema.foreign_keys.is_empty() {

--- a/crates/vibesql-executor/src/drop_table.rs
+++ b/crates/vibesql-executor/src/drop_table.rs
@@ -85,6 +85,18 @@ impl DropTableExecutor {
         // Check DROP privilege on the table
         PrivilegeChecker::check_drop(database, &stmt.table_name)?;
 
+        // Emulate SQLite's implicit `DELETE FROM <table>` before the drop when
+        // foreign keys are enabled (EVIDENCE-OF R-14208-23986 / R-11078-03945).
+        // This enforces referential actions (CASCADE / SET NULL / SET DEFAULT)
+        // on child tables and raises an immediate FOREIGN KEY constraint
+        // violation — leaving the table in place (R-32768-47925) — when a
+        // referencing row would be orphaned. Deferred violations are queued for
+        // the COMMIT-time re-check (R-05903-08460). Runs BEFORE any catalog
+        // mutation so an immediate failure aborts the whole DROP with the table
+        // still present. `foreign key mismatch` errors are ignored here, exactly
+        // as SQLite ignores them for the implicit DELETE (R-57242-37005).
+        crate::delete::integrity::check_drop_table_references(database, &stmt.table_name)?;
+
         // Drop all indexes associated with this table first
         let dropped_indexes = database.catalog.drop_table_indexes(&stmt.table_name);
         let index_count = dropped_indexes.len();

--- a/crates/vibesql-executor/src/tests/fk_cascade_triggers.rs
+++ b/crates/vibesql-executor/src/tests/fk_cascade_triggers.rs
@@ -31,6 +31,9 @@ fn exec(db: &mut Database, sql: &str) -> Result<String, String> {
         Statement::Update(s) => crate::update::UpdateExecutor::execute(&s, db)
             .map(|count| format!("{} row(s) updated", count))
             .map_err(|e| e.to_string()),
+        Statement::DropTable(s) => {
+            crate::DropTableExecutor::execute(&s, db).map_err(|e| e.to_string())
+        }
         other => Err(format!("Unsupported statement type: {:?}", other)),
     }
 }
@@ -942,4 +945,101 @@ fn on_delete_set_default_revalidates_default_against_parent() {
     // and the parent row was not deleted.
     assert_eq!(query_col(&db, "SELECT a FROM t1"), vec![SqlValue::Integer(2)]);
     assert_eq!(query_col(&db, "SELECT d FROM t2"), vec![SqlValue::Integer(2)]);
+}
+
+// ---------------------------------------------------------------------------
+// DROP TABLE performs SQLite's implicit FK-enforcing DELETE FROM (fkey3-1.3/1.5,
+// e_fkey-57/58/61.3). EVIDENCE-OF R-14208-23986 / R-11078-03945: the implicit
+// DELETE removes all rows and may invoke FK actions or constraint violations.
+// ---------------------------------------------------------------------------
+
+/// DROP TABLE of a parent still referenced (immediate NO ACTION) by a child
+/// row raises FOREIGN KEY constraint failed and leaves the table in place
+/// (EVIDENCE-OF R-32768-47925; fkey3-1.3).
+#[test]
+fn drop_table_referenced_parent_raises_and_keeps_table() {
+    let mut db = fresh_db();
+    exec(&mut db, "CREATE TABLE t1(x INTEGER PRIMARY KEY)").unwrap();
+    exec(&mut db, "INSERT INTO t1 VALUES(100), (101)").unwrap();
+    exec(&mut db, "CREATE TABLE t2(y INTEGER REFERENCES t1(x))").unwrap();
+    exec(&mut db, "INSERT INTO t2 VALUES(100), (101)").unwrap();
+
+    let err = exec(&mut db, "DROP TABLE t1").unwrap_err();
+    assert!(err.contains("FOREIGN KEY constraint"), "got: {err}");
+    // Table t1 must still exist and retain its rows.
+    assert!(db.catalog.table_exists("t1"));
+    assert_eq!(
+        query_col(&db, "SELECT x FROM t1 ORDER BY x"),
+        vec![SqlValue::Integer(100), SqlValue::Integer(101)]
+    );
+
+    // After dropping the child, the parent drops cleanly (fkey3-1.4/1.5).
+    exec(&mut db, "DROP TABLE t2").unwrap();
+    exec(&mut db, "DROP TABLE t1").unwrap();
+    assert!(!db.catalog.table_exists("t1"));
+}
+
+/// DROP TABLE of a parent with an ON DELETE CASCADE child empties the child
+/// via the implicit DELETE, then drops the parent (e_fkey-57.4).
+#[test]
+fn drop_table_cascades_into_child() {
+    let mut db = fresh_db();
+    exec(&mut db, "CREATE TABLE p(a, b, PRIMARY KEY(a, b))").unwrap();
+    exec(&mut db, "CREATE TABLE c3(c, d, FOREIGN KEY(c, d) REFERENCES p ON DELETE CASCADE)")
+        .unwrap();
+    exec(&mut db, "INSERT INTO p VALUES(1, 2)").unwrap();
+    exec(&mut db, "INSERT INTO c3 VALUES(1, 2)").unwrap();
+
+    exec(&mut db, "DROP TABLE p").unwrap();
+    assert!(!db.catalog.table_exists("p"));
+    // The cascade emptied the child.
+    assert_eq!(query_col(&db, "SELECT count(*) FROM c3"), vec![SqlValue::Integer(0)]);
+}
+
+/// DROP TABLE of a parent with an ON DELETE SET NULL child nulls the child's
+/// FK columns via the implicit DELETE, then drops the parent (e_fkey-61.3.1).
+#[test]
+fn drop_table_set_null_on_child() {
+    let mut db = fresh_db();
+    exec(&mut db, "CREATE TABLE p(a UNIQUE)").unwrap();
+    exec(&mut db, "CREATE TABLE c(b REFERENCES p(a) ON DELETE SET NULL)").unwrap();
+    exec(&mut db, "INSERT INTO p VALUES('x')").unwrap();
+    exec(&mut db, "INSERT INTO c VALUES('x')").unwrap();
+
+    exec(&mut db, "DROP TABLE p").unwrap();
+    assert!(!db.catalog.table_exists("p"));
+    // The child's FK column was set to NULL by the SET NULL action.
+    assert_eq!(query_col(&db, "SELECT b FROM c"), vec![SqlValue::Null]);
+}
+
+/// A self-referential FK never blocks a DROP TABLE: once the whole table is
+/// removed both sides of every self-reference disappear together, so the
+/// implicit DELETE can never leave an orphan (fkey3-3.* families rely on this).
+#[test]
+fn drop_table_self_referential_fk_does_not_block() {
+    let mut db = fresh_db();
+    exec(
+        &mut db,
+        "CREATE TABLE t3(a, b, c, d, UNIQUE(a, b), FOREIGN KEY(c, d) REFERENCES t3(a, b))",
+    )
+    .unwrap();
+    exec(&mut db, "INSERT INTO t3 VALUES(1, 2, 1, 2)").unwrap();
+
+    exec(&mut db, "DROP TABLE t3").unwrap();
+    assert!(!db.catalog.table_exists("t3"));
+}
+
+/// The special DROP-TABLE FK behavior only applies when foreign keys are
+/// enabled: with PRAGMA foreign_keys OFF a referenced parent drops freely
+/// (EVIDENCE-OF R-54142-41346).
+#[test]
+fn drop_table_referenced_parent_allowed_when_fk_disabled() {
+    let mut db = Database::new(); // foreign keys default OFF
+    exec(&mut db, "CREATE TABLE t1(x INTEGER PRIMARY KEY)").unwrap();
+    exec(&mut db, "INSERT INTO t1 VALUES(100)").unwrap();
+    exec(&mut db, "CREATE TABLE t2(y INTEGER REFERENCES t1(x))").unwrap();
+    exec(&mut db, "INSERT INTO t2 VALUES(100)").unwrap();
+
+    exec(&mut db, "DROP TABLE t1").unwrap();
+    assert!(!db.catalog.table_exists("t1"));
 }

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -8254,6 +8254,17 @@ proc drop_all_tables {} {
     if {$::db_file eq ""} {
         return
     }
+    # Mirror the canonical SQLite tester.tcl `drop_all_tables`, which disables
+    # foreign-key enforcement while dropping (and restores it afterward) so
+    # tables drop regardless of their referential-dependency order. A DROP
+    # TABLE now performs SQLite's implicit FK-enforcing DELETE FROM when
+    # `PRAGMA foreign_keys` is ON, so without this a table still referenced by
+    # another would refuse to drop and leak into the next test section
+    # (e.g. fkey2-1.2.0 "table t1 already exists"). `::pragma_foreign_keys` is
+    # the shim's tracked session state that seeds every batch's PRAGMA
+    # preamble, so toggling it here is what actually reaches the engine.
+    set saved_fk $::pragma_foreign_keys
+    set ::pragma_foreign_keys 0
     # Get list of tables
     set tables [execsql {SELECT name FROM sqlite_master WHERE type='table'}]
     # In case sqlite_master doesn't work, try an alternative approach
@@ -8267,6 +8278,7 @@ proc drop_all_tables {} {
             catch {execsql "DROP TABLE IF EXISTS $table"}
         }
     }
+    set ::pragma_foreign_keys $saved_fk
     return
 }
 


### PR DESCRIPTION
## Summary

Incremental progress on foreign-key enforcement semantics (**Part of #6170**, not `Closes`). This PR implements SQLite's DROP TABLE implicit-DELETE FK behavior — a coherent, previously-uncovered slice of the family (the `e_fkey` SECTION-5 DROP TABLE evidence tests and `fkey3-1.3/1.5`). It does **not** fully clear the family; fkey2/e_fkey/fkey1/fkey7 still have real remaining failures.

When `PRAGMA foreign_keys` is ON, SQLite's `DROP TABLE` performs an implicit `DELETE FROM` the table before removing it (`sqlite3FkDropTable`). That implicit delete enforces referential actions on child tables and can fail the DROP with a `FOREIGN KEY constraint failed`, leaving the table in place. VibeSQL previously dropped the table unconditionally, ignoring FK references entirely.

## Changes

**Engine (`crates/vibesql-executor`):**

1. **`delete/integrity.rs`** — new `check_drop_table_references`, which runs the existing child-reference enforcement (RESTRICT / NO ACTION raise, CASCADE / SET NULL / SET DEFAULT actions) for every live parent row of the dropped table. `check_no_child_references` is refactored onto a shared `check_child_references_impl` with an `exclude_self_table` flag:
   - A **self-referential FK never blocks a drop** — both sides of the reference vanish with the table, mirroring SQLite's statement-scoped violation counter reaching zero after a whole-table delete.
   - An FK whose parent-side key columns don't resolve to a valid parent key is **skipped**, so `foreign key mismatch` is ignored exactly as SQLite ignores it for the implicit DELETE (EVIDENCE-OF R-57242-37005).
2. **`drop_table.rs`** — call `check_drop_table_references` **before any catalog mutation**, so an immediate violation aborts the DROP with the table still present (EVIDENCE-OF R-32768-47925). Triggers on the dropped table are intentionally **not** fired (R-11078-03945).

**Harness (`scripts/tester_vibesql.tcl`):**

3. **`drop_all_tables`** now disables foreign-key enforcement while dropping (and restores it after), mirroring the canonical SQLite `tester.tcl`. Without this the shim's reset helper — which previously relied on the engine's non-conformant unconditional DROP — would refuse to drop a still-referenced table and leak it into the next test section (e.g. `fkey2-1.2.0` "table t1 already exists"). It toggles the shim's tracked `::pragma_foreign_keys` session state that seeds every batch's PRAGMA preamble.

## Acceptance Criteria Verification

The issue's stated acceptance is full clearance of `fkey2.test`/`e_fkey.test`. This PR is a partial increment and does not reach full clearance — honest counts below.

- [x] `fkey3.test`: 3 → **1** failed (fkey3-1.3 and 1.5 now pass)
- [x] `fkey2.test`: 117 → **115** failed (section-14 DROP TABLE FK; no regression)
- [x] `e_fkey.test`: 138 → **130** failed (e_fkey-57/58/59/61.3 DROP TABLE evidence tests now pass)
- [x] `fkey1.test` (2) / `fkey7.test` (7) unchanged — no regressions
- [x] `cargo test -p vibesql-executor --lib`: **3634 passed, 0 failed** (+5 new tests)
- [x] Behavior verified against SQLite's own `EVIDENCE-OF` doc comments (R-14208-23986, R-11078-03945, R-32768-47925, R-05903-08460, R-57242-37005, R-54142-41346), not just made the assertion pass.

## Test Plan / Measured Results

Measured on this repo's TCL harness (same machine, before vs. after — not the certified AWS baseline):

| File | Before | After |
|---|---:|---:|
| `fkey3.test` | 3 | **1** |
| `fkey2.test` | 117 | **115** |
| `e_fkey.test` | 138 | **130** |
| `fkey1.test` | 2 | 2 |
| `fkey7.test` | 7 | 7 |

```
cargo test --release -p vibesql-executor --lib
test result: ok. 3634 passed; 0 failed; 2 ignored
```

New Rust unit tests in `crates/vibesql-executor/src/tests/fk_cascade_triggers.rs`:
- `drop_table_referenced_parent_raises_and_keeps_table` — immediate NO ACTION raise + table survives (fkey3-1.3), then drop child → drop parent OK (1.4/1.5).
- `drop_table_cascades_into_child` — ON DELETE CASCADE empties child (e_fkey-57.4).
- `drop_table_set_null_on_child` — ON DELETE SET NULL nulls child FK cols (e_fkey-61.3.1).
- `drop_table_self_referential_fk_does_not_block` — self-referential FK never blocks a drop.
- `drop_table_referenced_parent_allowed_when_fk_disabled` — special behavior only applies with FK ON (R-54142-41346).

## What's still failing / honest scope note

This is a large family and this PR is one reviewable increment. Remaining, not addressed here:
- `e_fkey-60.2/60.4/60.5`: the **DELETE** path does not raise `foreign key mismatch` (an FK to a non-unique/non-existent parent key) — separate root cause from DROP TABLE; DROP correctly ignores these per R-57242-37005.
- `e_fkey-61.1.2/61.2.2`: `ALTER TABLE ADD COLUMN ... REFERENCES` restriction not gated on the `foreign_keys` pragma, and `ALTER TABLE RENAME` + `legacy_alter_table` — both in the ALTER area, unrelated to DROP.
- `fkey3-3.6.5`: composite self-referential FK on UPDATE — a distinct root cause.
- The bulk of `fkey2`/`e_fkey` remaining failures span the referential-action matrix, deferred-constraint/savepoint gaps (#6278), and harness API-coverage limits noted in prior increments (#6279, #6283).

`Part of #6170` — the family stays open for the remaining work above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>