### PR TITLE
fix(parser,executor): affinity-aware CASE/IS/NULLIF + ?NNN parameter-number bound (Part of #6172)

### DIFF
--- a/crates/vibesql-executor/src/evaluator/arena.rs
+++ b/crates/vibesql-executor/src/evaluator/arena.rs
@@ -547,7 +547,25 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
             ArenaExpression::IsDistinctFrom { left, right, negated } => {
                 let left_val = self.eval_with_depth(left, row)?;
                 let right_val = self.eval_with_depth(right, row)?;
-                let is_distinct = super::core::values_are_distinct(&left_val, &right_val);
+                // NULL-safe equality via the strict (no cross-type guessing)
+                // comparator, matching the arena evaluator's own affinity-less
+                // `=` operator (`eval_binary_op` below) rather than the
+                // permissive `values_are_distinct`/`values_are_equal` used for
+                // hash-join keys. Same bug class as e_expr-23.1.6, fixed for
+                // the core/combined evaluators below.
+                let is_distinct = match (&left_val, &right_val) {
+                    (SqlValue::Null, SqlValue::Null) => false,
+                    (SqlValue::Null, _) | (_, SqlValue::Null) => true,
+                    _ => !matches!(
+                        super::core::eval_binary_op_static(
+                            &left_val,
+                            &vibesql_ast::BinaryOperator::Equal,
+                            &right_val,
+                            self.sql_mode.clone(),
+                        )?,
+                        SqlValue::Boolean(true)
+                    ),
+                };
                 Ok(SqlValue::Boolean(if *negated { !is_distinct } else { is_distinct }))
             }
 
@@ -1002,7 +1020,20 @@ impl<'a, 'arena> ArenaExpressionEvaluator<'a, 'arena> {
             for when_clause in when_clauses.iter() {
                 for condition in when_clause.conditions.iter() {
                     let cond_val = self.eval_with_depth(condition, row)?;
-                    if super::core::values_are_equal(&op_val, &cond_val) {
+                    // Strict (no cross-type guessing) equality, matching the
+                    // arena evaluator's own affinity-less `=` operator rather
+                    // than the permissive `values_are_equal` used for
+                    // hash-join keys (e_expr-23.1.6: `CASE 55 WHEN '55' THEN
+                    // ...` must not match).
+                    if matches!(
+                        super::core::eval_binary_op_static(
+                            &op_val,
+                            &vibesql_ast::BinaryOperator::Equal,
+                            &cond_val,
+                            self.sql_mode.clone(),
+                        )?,
+                        SqlValue::Boolean(true)
+                    ) {
                         return self.eval_with_depth(&when_clause.result, row);
                     }
                 }

--- a/crates/vibesql-executor/src/evaluator/combined/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/eval.rs
@@ -511,6 +511,59 @@ impl CombinedExpressionEvaluator<'_> {
         (left_val, right_val)
     }
 
+    /// Compare two already-evaluated values for SQL equality: apply SQLite's
+    /// affinity-based coercion (via [`Self::apply_affinity_for_comparison`],
+    /// which only converts a TEXT/NUMERIC value when the *other* operand is a
+    /// real column with NUMERIC/INTEGER/REAL or TEXT affinity), then fall back
+    /// to a strict, storage-class-aware comparison with no further guessing.
+    ///
+    /// This is the correct semantics for CASE and `IS`/`IS NOT` (via
+    /// `Self::affinity_aware_is_distinct`) and NULLIF. It must NOT reuse the
+    /// permissive `values_are_equal` cross-type coercion used for hash-join key
+    /// comparisons — that helper unconditionally tries to parse TEXT as a
+    /// number regardless of affinity, which is wrong once affinity has already
+    /// been correctly resolved (or found not to apply). Two bare literals
+    /// (e.g. `55` and `'55'`) carry no affinity and must compare unequal by
+    /// storage class per SQLite datatype3 §4.2 (e_expr-23.1.6: `CASE 55 WHEN
+    /// '55' THEN 'A' ELSE 'B' END` -> 'B').
+    pub(crate) fn affinity_aware_equal(
+        &self,
+        left_expr: &vibesql_ast::Expression,
+        left_val: SqlValue,
+        right_expr: &vibesql_ast::Expression,
+        right_val: SqlValue,
+    ) -> Result<bool, ExecutorError> {
+        let (l, r) = self.apply_affinity_for_comparison(left_expr, left_val, right_expr, right_val);
+        let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
+        Ok(matches!(
+            ExpressionEvaluator::eval_binary_op_static(
+                &l,
+                &vibesql_ast::BinaryOperator::Equal,
+                &r,
+                sql_mode,
+            )?,
+            SqlValue::Boolean(true)
+        ))
+    }
+
+    /// NULL-safe counterpart of [`Self::affinity_aware_equal`] for `IS` /
+    /// `IS NOT` (IS NOT DISTINCT FROM / IS DISTINCT FROM): both-NULL is not
+    /// distinct, exactly one NULL is distinct, otherwise defers to the
+    /// affinity-aware equality check.
+    pub(crate) fn affinity_aware_is_distinct(
+        &self,
+        left_expr: &vibesql_ast::Expression,
+        left_val: SqlValue,
+        right_expr: &vibesql_ast::Expression,
+        right_val: SqlValue,
+    ) -> Result<bool, ExecutorError> {
+        match (&left_val, &right_val) {
+            (SqlValue::Null, SqlValue::Null) => Ok(false),
+            (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(true),
+            _ => Ok(!self.affinity_aware_equal(left_expr, left_val, right_expr, right_val)?),
+        }
+    }
+
     /// Apply SQLite type affinity rules for IN expression comparisons.
     ///
     /// IN expressions have different affinity rules than regular comparisons:

--- a/crates/vibesql-executor/src/evaluator/combined/predicates.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/predicates.rs
@@ -924,12 +924,9 @@ impl CombinedExpressionEvaluator<'_> {
             right_val,
             collation.as_deref(),
         );
-        let (left_val, right_val) =
-            self.apply_affinity_for_comparison(left, left_val, right, right_val);
-
-        // Use values_are_distinct for SQLite-compatible comparison
-        // This handles Boolean/Integer comparison (SQLite treats 0 as FALSE, non-zero as TRUE)
-        let is_distinct = super::super::core::values_are_distinct(&left_val, &right_val);
+        // Affinity-aware, NULL-safe equality (not the permissive
+        // `values_are_distinct`/`values_are_equal` used for hash-join keys).
+        let is_distinct = self.affinity_aware_is_distinct(left, left_val, right, right_val)?;
 
         // IS NOT DISTINCT FROM inverts the result
         let result = if negated { !is_distinct } else { is_distinct };

--- a/crates/vibesql-executor/src/evaluator/combined/special.rs
+++ b/crates/vibesql-executor/src/evaluator/combined/special.rs
@@ -1,9 +1,7 @@
 //! Special expression forms (CASE, CAST, Function calls)
 
 use super::super::{
-    casting::cast_value,
-    core::{CombinedExpressionEvaluator, ExpressionEvaluator},
-    functions::eval_scalar_function,
+    casting::cast_value, core::CombinedExpressionEvaluator, functions::eval_scalar_function,
 };
 use crate::errors::ExecutorError;
 
@@ -64,8 +62,16 @@ impl CombinedExpressionEvaluator<'_> {
                     for condition_expr in &when_clause.conditions {
                         let when_value = self.eval(condition_expr, row)?;
 
-                        // Compare operand to when_value using SQL equality semantics
-                        if ExpressionEvaluator::values_are_equal(&operand_value, &when_value) {
+                        // Affinity-aware equality (not the permissive
+                        // `values_are_equal` used for hash-join keys): a bare
+                        // literal operand carries no affinity, so `CASE 55
+                        // WHEN '55' THEN ...` must not match (e_expr-23.1.6).
+                        if self.affinity_aware_equal(
+                            operand_expr,
+                            operand_value.clone(),
+                            condition_expr,
+                            when_value,
+                        )? {
                             return self.eval(&when_clause.result, row);
                         }
                     }
@@ -171,8 +177,28 @@ impl CombinedExpressionEvaluator<'_> {
             return Ok(val1);
         }
 
-        // Check equality and return accordingly
-        if ExpressionEvaluator::values_are_equal(&val1, &val2) {
+        // NULLIF never applies column affinity, unlike `=`/CASE/IS: SQLite
+        // implements it as a plain scalar function (func.c `nullifFunc`) that
+        // compares the two already-evaluated `sqlite3_value`s directly via
+        // `sqlite3MemCompare` with no affinity conversion, even when an
+        // argument is a real affinity-carrying column reference. So a TEXT
+        // column holding '1' is NOT NULLIF-equal to the integer literal 1
+        // even though `x = 1` is TRUE for that same column (verified against
+        // SQLite: `CREATE TABLE t(x TEXT); INSERT INTO t VALUES(1); SELECT
+        // NULLIF(x, 1) FROM t` -> '1', not NULL). Use the strict (no
+        // cross-type guessing) comparator directly — not
+        // `affinity_aware_equal` (which is for `=`/CASE/IS) and not the
+        // permissive `values_are_equal` used for hash-join keys.
+        let sql_mode = self.database.map(|db| db.sql_mode()).unwrap_or_default();
+        if matches!(
+            super::super::core::ExpressionEvaluator::eval_binary_op_static(
+                &val1,
+                &vibesql_ast::BinaryOperator::Equal,
+                &val2,
+                sql_mode,
+            )?,
+            vibesql_types::SqlValue::Boolean(true)
+        ) {
             Ok(vibesql_types::SqlValue::Null)
         } else {
             Ok(val1)

--- a/crates/vibesql-executor/src/evaluator/expressions/eval.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/eval.rs
@@ -396,6 +396,53 @@ impl ExpressionEvaluator<'_> {
         (left_val, right_val)
     }
 
+    /// Compare two already-evaluated values for SQL equality: apply SQLite's
+    /// affinity-based coercion (via [`Self::apply_affinity_for_comparison`],
+    /// which only converts a TEXT/NUMERIC value when the *other* operand is a
+    /// real column with NUMERIC/INTEGER/REAL or TEXT affinity), then fall back
+    /// to a strict, storage-class-aware comparison with no further guessing.
+    ///
+    /// This is the correct semantics for CASE and `IS`/`IS NOT` (via
+    /// `Self::affinity_aware_is_distinct`) and NULLIF. It must NOT reuse the
+    /// permissive `values_are_equal` cross-type coercion used for hash-join key
+    /// comparisons — that helper unconditionally tries to parse TEXT as a
+    /// number regardless of affinity, which is wrong once affinity has already
+    /// been correctly resolved (or found not to apply). Two bare literals
+    /// (e.g. `55` and `'55'`) carry no affinity and must compare unequal by
+    /// storage class per SQLite datatype3 §4.2 (e_expr-23.1.6: `CASE 55 WHEN
+    /// '55' THEN 'A' ELSE 'B' END` -> 'B').
+    pub(super) fn affinity_aware_equal(
+        &self,
+        left_expr: &vibesql_ast::Expression,
+        left_val: SqlValue,
+        right_expr: &vibesql_ast::Expression,
+        right_val: SqlValue,
+    ) -> Result<bool, ExecutorError> {
+        let (l, r) = self.apply_affinity_for_comparison(left_expr, left_val, right_expr, right_val);
+        Ok(matches!(
+            self.eval_binary_op(&l, &vibesql_ast::BinaryOperator::Equal, &r)?,
+            SqlValue::Boolean(true)
+        ))
+    }
+
+    /// NULL-safe counterpart of [`Self::affinity_aware_equal`] for `IS` /
+    /// `IS NOT` (IS NOT DISTINCT FROM / IS DISTINCT FROM): both-NULL is not
+    /// distinct, exactly one NULL is distinct, otherwise defers to the
+    /// affinity-aware equality check.
+    pub(super) fn affinity_aware_is_distinct(
+        &self,
+        left_expr: &vibesql_ast::Expression,
+        left_val: SqlValue,
+        right_expr: &vibesql_ast::Expression,
+        right_val: SqlValue,
+    ) -> Result<bool, ExecutorError> {
+        match (&left_val, &right_val) {
+            (SqlValue::Null, SqlValue::Null) => Ok(false),
+            (SqlValue::Null, _) | (_, SqlValue::Null) => Ok(true),
+            _ => Ok(!self.affinity_aware_equal(left_expr, left_val, right_expr, right_val)?),
+        }
+    }
+
     /// Apply SQLite type affinity rules for IN expression comparisons.
     ///
     /// IN expressions have different affinity rules than regular comparisons:
@@ -985,9 +1032,8 @@ impl ExpressionEvaluator<'_> {
                     right_val,
                     collation.as_deref(),
                 );
-                let (left_val, right_val) =
-                    self.apply_affinity_for_comparison(left, left_val, right, right_val);
-                let is_distinct = super::super::core::values_are_distinct(&left_val, &right_val);
+                let is_distinct =
+                    self.affinity_aware_is_distinct(left, left_val, right, right_val)?;
                 let result = if *negated { !is_distinct } else { is_distinct };
                 Ok(SqlValue::Boolean(result))
             }

--- a/crates/vibesql-executor/src/evaluator/expressions/special.rs
+++ b/crates/vibesql-executor/src/evaluator/expressions/special.rs
@@ -59,10 +59,16 @@ impl ExpressionEvaluator<'_> {
                     for condition_expr in &when_clause.conditions {
                         let when_value = self.eval(condition_expr, row)?;
 
-                        if super::super::core::ExpressionEvaluator::values_are_equal(
-                            &operand_value,
-                            &when_value,
-                        ) {
+                        // Affinity-aware equality (not the permissive
+                        // `values_are_equal` used for hash-join keys): a bare
+                        // literal operand carries no affinity, so `CASE 55
+                        // WHEN '55' THEN ...` must not match (e_expr-23.1.6).
+                        if self.affinity_aware_equal(
+                            operand_expr,
+                            operand_value.clone(),
+                            condition_expr,
+                            when_value,
+                        )? {
                             return self.eval(&when_clause.result, row);
                         }
                     }
@@ -153,8 +159,22 @@ impl ExpressionEvaluator<'_> {
             return Ok(val1);
         }
 
-        // Check equality and return accordingly
-        if super::super::core::ExpressionEvaluator::values_are_equal(&val1, &val2) {
+        // NULLIF never applies column affinity, unlike `=`/CASE/IS: SQLite
+        // implements it as a plain scalar function (func.c `nullifFunc`) that
+        // compares the two already-evaluated `sqlite3_value`s directly via
+        // `sqlite3MemCompare` with no affinity conversion, even when an
+        // argument is a real affinity-carrying column reference. So a TEXT
+        // column holding '1' is NOT NULLIF-equal to the integer literal 1
+        // even though `x = 1` is TRUE for that same column (verified against
+        // SQLite: `CREATE TABLE t(x TEXT); INSERT INTO t VALUES(1); SELECT
+        // NULLIF(x, 1) FROM t` -> '1', not NULL). Use the strict (no
+        // cross-type guessing) comparator directly — not
+        // `affinity_aware_equal` (which is for `=`/CASE/IS) and not the
+        // permissive `values_are_equal` used for hash-join keys.
+        if matches!(
+            self.eval_binary_op(&val1, &vibesql_ast::BinaryOperator::Equal, &val2)?,
+            vibesql_types::SqlValue::Boolean(true)
+        ) {
             Ok(vibesql_types::SqlValue::Null)
         } else {
             Ok(val1)

--- a/crates/vibesql-executor/src/optimizer/expressions.rs
+++ b/crates/vibesql-executor/src/optimizer/expressions.rs
@@ -232,7 +232,26 @@ pub fn optimize_expression(
             if let (Expression::Literal(left_val), Expression::Literal(right_val)) =
                 (&left_opt, &right_opt)
             {
-                let is_distinct = ExpressionEvaluator::values_are_distinct(left_val, right_val);
+                // NULL-safe distinctness via the strict (no cross-type
+                // guessing) `=` comparator, not the permissive
+                // `values_are_distinct` used for hash-join keys. Folding two
+                // bare literals carries no affinity, so `55 IS NOT '55'` must
+                // fold to TRUE (distinct storage classes, e_expr-23.1.6),
+                // matching the runtime `IsDistinctFrom` evaluators.
+                let sql_mode = evaluator.database().map(|db| db.sql_mode()).unwrap_or_default();
+                let is_distinct = match (left_val, right_val) {
+                    (SqlValue::Null, SqlValue::Null) => false,
+                    (SqlValue::Null, _) | (_, SqlValue::Null) => true,
+                    _ => !matches!(
+                        ExpressionEvaluator::eval_binary_op_static(
+                            left_val,
+                            &BinaryOperator::Equal,
+                            right_val,
+                            sql_mode,
+                        )?,
+                        SqlValue::Boolean(true)
+                    ),
+                };
                 let result = if *negated { !is_distinct } else { is_distinct };
                 Ok(Expression::Literal(SqlValue::Boolean(result)))
             } else {

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/case.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/case.rs
@@ -3,7 +3,7 @@
 use super::super::super::builder::SelectExecutor;
 use crate::{
     errors::ExecutorError,
-    evaluator::{CombinedExpressionEvaluator, ExpressionEvaluator},
+    evaluator::CombinedExpressionEvaluator,
 };
 
 /// Evaluate CASE expression with potential aggregates in operand/conditions/results
@@ -42,8 +42,20 @@ pub(super) fn evaluate(
                         evaluator,
                     )?;
 
-                    // Use IS NOT DISTINCT FROM semantics (NULL = NULL is TRUE)
-                    if ExpressionEvaluator::values_are_equal(&operand_value, &when_value) {
+                    // Affinity-aware equality (not the permissive
+                    // `values_are_equal` used for hash-join keys): a bare
+                    // literal operand carries no affinity, so `CASE COUNT(*)
+                    // WHEN '2' THEN ...` must not match an INTEGER 2 against
+                    // TEXT '2' (e_expr-23.1.6, same fix as the main
+                    // evaluators). The operand/condition expressions are
+                    // threaded through here, so route through the shared
+                    // affinity-aware comparator on the combined evaluator.
+                    if evaluator.affinity_aware_equal(
+                        operand_expr,
+                        operand_value.clone(),
+                        condition_expr,
+                        when_value,
+                    )? {
                         // Evaluate result (may contain aggregates)
                         return executor.evaluate_with_aggregates(
                             &when_clause.result,

--- a/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/aggregation/evaluation/mod.rs
@@ -500,10 +500,22 @@ impl SelectExecutor<'_> {
                                     grouping_context,
                                 )?;
 
-                                if crate::evaluator::ExpressionEvaluator::values_are_equal(
-                                    &operand_value,
-                                    &when_value,
-                                ) {
+                                // Affinity-aware equality (not the permissive
+                                // `values_are_equal` used for hash-join keys):
+                                // a bare literal operand carries no affinity,
+                                // so `CASE COUNT(*) WHEN '2' THEN ...` must not
+                                // match INTEGER 2 against TEXT '2'
+                                // (e_expr-23.1.6, same fix as the main
+                                // evaluators). Route through the shared
+                                // affinity-aware comparator on the combined
+                                // evaluator; the operand/condition expressions
+                                // are threaded through here.
+                                if evaluator.affinity_aware_equal(
+                                    operand_expr,
+                                    operand_value.clone(),
+                                    condition_expr,
+                                    when_value,
+                                )? {
                                     return self.evaluate_with_aggregates_and_grouping(
                                         &when_clause.result,
                                         group_rows,
@@ -633,8 +645,14 @@ impl SelectExecutor<'_> {
                     evaluator,
                     grouping_context,
                 )?;
+                // Affinity-aware, NULL-safe distinctness (not the permissive
+                // `values_are_equal` used for hash-join keys), matching the
+                // main evaluators' `IsDistinctFrom` fix: `COUNT(*) IS NOT '2'`
+                // must treat INTEGER 2 as distinct from TEXT '2'
+                // (e_expr-23.1.6). The operand expressions are threaded
+                // through here, so route through the shared comparator.
                 let is_distinct =
-                    !crate::evaluator::ExpressionEvaluator::values_are_equal(&left_val, &right_val);
+                    evaluator.affinity_aware_is_distinct(left, left_val, right, right_val)?;
                 Ok(vibesql_types::SqlValue::Boolean(if *negated {
                     !is_distinct
                 } else {

--- a/crates/vibesql-executor/src/select/executor/columnar_execution/having.rs
+++ b/crates/vibesql-executor/src/select/executor/columnar_execution/having.rs
@@ -370,9 +370,23 @@ fn evaluate_expr_on_result_row(
                                 aggregates,
                                 schema,
                             )?;
-                            if crate::evaluator::ExpressionEvaluator::values_are_equal(
-                                &operand_val,
-                                &when_val,
+                            // Strict (no cross-type guessing) equality via the
+                            // same `eval_binary_op_static` `=` comparator this
+                            // file already uses for BinaryOp/IN/BETWEEN, not
+                            // the permissive `values_are_equal` used for
+                            // hash-join keys. A bare TEXT literal carries no
+                            // affinity here, so `HAVING CASE c WHEN '2' THEN
+                            // ...` must not match an INTEGER c=2 against TEXT
+                            // '2' (e_expr-23.1.6, same fix as the main
+                            // evaluators).
+                            if matches!(
+                                crate::evaluator::ExpressionEvaluator::eval_binary_op_static(
+                                    &operand_val,
+                                    &vibesql_ast::BinaryOperator::Equal,
+                                    &when_val,
+                                    SqlMode::default(),
+                                )?,
+                                SqlValue::Boolean(true)
                             ) {
                                 return evaluate_expr_on_result_row(
                                     &when_clause.result,

--- a/crates/vibesql-executor/tests/case_is_affinity_aggregate_paths_tests.rs
+++ b/crates/vibesql-executor/tests/case_is_affinity_aggregate_paths_tests.rs
@@ -1,0 +1,192 @@
+//! Affinity-aware CASE / IS DISTINCT FROM in the aggregate, ROLLUP, and
+//! columnar-HAVING evaluation paths.
+//!
+//! The main expression evaluators (`evaluator/expressions/*`,
+//! `evaluator/combined/*`, `evaluator/arena.rs`) were fixed so that CASE's
+//! simple form and scalar `IS`/`IS NOT` no longer guess numeric<->text
+//! equality without SQLite column affinity (datatype3 §4.2, e_expr-23.1.6:
+//! `CASE 55 WHEN '55' THEN 'A' ELSE 'B' END` -> 'B'; `55 IS '55'` -> 0).
+//!
+//! There are three *other* reachable evaluators that reimplement the same
+//! CASE / IS-DISTINCT-FROM logic and were initially missed:
+//!   1. aggregation/evaluation/case.rs      — CASE with an aggregate operand
+//!   2. aggregation/evaluation/mod.rs       — ROLLUP/CUBE/GROUPING SETS
+//!   3. columnar_execution/having.rs        — HAVING-clause CASE (columnar)
+//!
+//! These tests reproduce the pre-fix bug through each path and assert the
+//! affinity-aware (storage-class) semantics the main evaluators already have.
+
+use vibesql_executor::SelectExecutor;
+use vibesql_parser::Parser;
+use vibesql_storage::{Database, Row};
+use vibesql_types::SqlValue;
+
+fn setup_db() -> Database {
+    let mut db = Database::new();
+
+    let create = Parser::parse_sql("CREATE TABLE t (id INTEGER, x TEXT)").unwrap();
+    if let vibesql_ast::Statement::CreateTable(stmt) = create {
+        vibesql_executor::CreateTableExecutor::execute(&stmt, &mut db).unwrap();
+    }
+
+    // Two rows with x='55' (so COUNT(*) WHERE x='55' == 2) and one with x='99'.
+    for sql in [
+        "INSERT INTO t VALUES (1, '55')",
+        "INSERT INTO t VALUES (2, '55')",
+        "INSERT INTO t VALUES (3, '99')",
+    ] {
+        let stmt = Parser::parse_sql(sql).unwrap();
+        if let vibesql_ast::Statement::Insert(insert_stmt) = stmt {
+            vibesql_executor::InsertExecutor::execute(&mut db, &insert_stmt).unwrap();
+        }
+    }
+
+    db
+}
+
+fn execute_query(db: &Database, sql: &str) -> Vec<Row> {
+    let stmt = Parser::parse_sql(sql).unwrap();
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = SelectExecutor::new(db);
+        executor.execute(&select_stmt).unwrap()
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+fn text(val: &SqlValue) -> String {
+    match val {
+        SqlValue::Varchar(s) => s.to_string(),
+        other => panic!("Expected text, got {other:?}"),
+    }
+}
+
+fn int(val: &SqlValue) -> i64 {
+    match val {
+        SqlValue::Integer(i) => *i,
+        SqlValue::Bigint(i) => *i,
+        SqlValue::Smallint(i) => *i as i64,
+        SqlValue::Numeric(n) => *n as i64,
+        SqlValue::Double(d) => *d as i64,
+        SqlValue::Boolean(b) => *b as i64,
+        other => panic!("Expected integer, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Path 1: CASE with an aggregate operand (aggregation/evaluation/case.rs)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn case_over_aggregate_bare_text_literal_does_not_match_integer() {
+    let db = setup_db();
+
+    // COUNT(*) is INTEGER 2; '2' is a bare TEXT literal with no affinity, so
+    // per SQLite datatype3 §4.2 the branch must NOT match (SQLite: 'no-match').
+    let rows = execute_query(
+        &db,
+        "SELECT CASE COUNT(*) WHEN '2' THEN 'matched-2' ELSE 'no-match' END FROM t WHERE x='55'",
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(text(&rows[0].values[0]), "no-match");
+}
+
+#[test]
+fn case_over_aggregate_matching_integer_literal_still_matches() {
+    let db = setup_db();
+
+    // Control: integer-literal WHEN against integer COUNT(*) still matches.
+    let rows = execute_query(
+        &db,
+        "SELECT CASE COUNT(*) WHEN 2 THEN 'matched-2' ELSE 'no-match' END FROM t WHERE x='55'",
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(text(&rows[0].values[0]), "matched-2");
+}
+
+// ---------------------------------------------------------------------------
+// Path 2: ROLLUP/CUBE/GROUPING SETS (aggregation/evaluation/mod.rs)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rollup_case_over_aggregate_bare_text_literal_does_not_match() {
+    let db = setup_db();
+
+    // The x='55' group has COUNT(*)=2; the bare TEXT '2' must not match it.
+    let rows = execute_query(
+        &db,
+        "SELECT x, CASE COUNT(*) WHEN '2' THEN 'matched' ELSE 'no-match' END \
+         FROM t GROUP BY ROLLUP(x)",
+    );
+
+    for row in &rows {
+        // Every group (including the grand-total NULL group) must report
+        // 'no-match': no group's INTEGER count is affinity-equal to TEXT '2'.
+        assert_eq!(
+            text(&row.values[1]),
+            "no-match",
+            "row for x={:?} wrongly matched bare TEXT '2'",
+            row.values[0]
+        );
+    }
+}
+
+#[test]
+fn rollup_is_distinct_from_bare_text_literal_is_distinct_from_integer() {
+    let db = setup_db();
+
+    // `COUNT(*) IS NOT '2'` (IS DISTINCT FROM): INTEGER 2 is a different
+    // storage class than bare TEXT '2', so it IS distinct -> r = 1 (true)
+    // for the x='55' group (count 2), matching the main-evaluator fix.
+    let rows = execute_query(
+        &db,
+        "SELECT x, COUNT(*) AS c, (COUNT(*) IS NOT '2') AS r FROM t GROUP BY ROLLUP(x)",
+    );
+
+    let mut checked_count_two = false;
+    for row in &rows {
+        let c = int(&row.values[1]);
+        let r = int(&row.values[2]);
+        if c == 2 {
+            assert_eq!(r, 1, "INTEGER 2 must be IS-DISTINCT-FROM bare TEXT '2'");
+            checked_count_two = true;
+        }
+    }
+    assert!(checked_count_two, "expected a group with COUNT(*)=2");
+}
+
+// ---------------------------------------------------------------------------
+// Path 3: columnar HAVING CASE (columnar_execution/having.rs)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn having_case_bare_text_literal_does_not_match_integer_count() {
+    let db = setup_db();
+
+    // HAVING CASE c WHEN '2' THEN 1 ELSE 0 END: the x='55' group has c=2, but
+    // bare TEXT '2' must not match INTEGER 2, so the HAVING predicate is 0
+    // (false) for every group -> no rows survive.
+    let rows = execute_query(
+        &db,
+        "SELECT x, COUNT(*) c FROM t GROUP BY x HAVING CASE COUNT(*) WHEN '2' THEN 1 ELSE 0 END",
+    );
+    assert!(
+        rows.is_empty(),
+        "no group should survive HAVING (bare TEXT '2' must not match INTEGER 2), got {rows:?}"
+    );
+}
+
+#[test]
+fn having_case_matching_integer_literal_keeps_group() {
+    let db = setup_db();
+
+    // Control: integer-literal WHEN against integer count still matches, so
+    // the x='55' group (count 2) survives.
+    let rows = execute_query(
+        &db,
+        "SELECT x, COUNT(*) c FROM t GROUP BY x HAVING CASE COUNT(*) WHEN 2 THEN 1 ELSE 0 END",
+    );
+    assert_eq!(rows.len(), 1, "the count-2 group should survive HAVING");
+    assert_eq!(text(&rows[0].values[0]), "55");
+    assert_eq!(int(&rows[0].values[1]), 2);
+}

--- a/crates/vibesql-parser/src/lexer/mod.rs
+++ b/crates/vibesql-parser/src/lexer/mod.rs
@@ -519,8 +519,12 @@ impl<'a> Lexer<'a> {
     }
 
     /// Tokenize a SQLite-style numbered placeholder (?1, ?2, etc.).
-    /// 1-indexed like `$N`; `?0` is rejected (SQLite: "variable number must
-    /// be between ?1 and ?NNN"). Only called when a digit follows the `?`.
+    /// 1-indexed; the number NNN must be between 1 and
+    /// `SQLITE_MAX_VARIABLE_NUMBER` (SQLite's documented default, 999).
+    /// A `?0`, an over-limit `?1000`, or a value too large to represent all
+    /// raise SQLite's `variable number must be between ?1 and ?999` diagnostic
+    /// (emitted verbatim, not wrapped as a `near "…": syntax error`). Only
+    /// called when a digit follows the `?`.
     fn tokenize_question_numbered_placeholder(&mut self) -> Result<Token, LexerError> {
         self.advance(); // consume '?'
 
@@ -538,22 +542,27 @@ impl<'a> Lexer<'a> {
             }
         }
 
-        let index: usize = num_str.parse().map_err(|_| LexerError {
-            message: format!("Invalid numbered placeholder: ?{}", num_str),
-            position: start_pos,
-            near_token: Some(format!("?{}", num_str)),
-        })?;
+        // SQLite's default SQLITE_MAX_VARIABLE_NUMBER. The valid range for a
+        // `?NNN` parameter is 1..=MAX; anything outside it — including a value
+        // too large to parse — is the same "variable number must be between"
+        // error. Parse into u64 so an out-of-range literal is rejected with the
+        // proper diagnostic instead of panicking or wrapping on `usize`.
+        const MAX_VARIABLE_NUMBER: u64 = 999;
+        let out_of_range = || {
+            LexerError::preformatted(
+                format!("variable number must be between ?1 and ?{}", MAX_VARIABLE_NUMBER),
+                start_pos,
+            )
+        };
 
-        // SQLite requires ?1 or higher (no ?0)
-        if index == 0 {
-            return Err(LexerError {
-                message: "variable number must be between ?1 and ?NNN".to_string(),
-                position: start_pos,
-                near_token: Some(format!("?{}", num_str)),
-            });
+        match num_str.parse::<u64>() {
+            Ok(index) if index >= 1 && index <= MAX_VARIABLE_NUMBER => {
+                Ok(Token::NumberedPlaceholder(index as usize))
+            }
+            // 0, over the limit, or too large to parse: all report the same
+            // SQLite-compatible range error.
+            _ => Err(out_of_range()),
         }
-
-        Ok(Token::NumberedPlaceholder(index))
     }
 
     /// Tokenize a named placeholder (:name, :user_id, etc.).

--- a/crates/vibesql-parser/src/tests/lexer/identifiers.rs
+++ b/crates/vibesql-parser/src/tests/lexer/identifiers.rs
@@ -295,10 +295,39 @@ fn test_tokenize_question_numbered_placeholder_in_expression() {
 
 #[test]
 fn test_tokenize_question_zero_rejected() {
-    // SQLite rejects ?0: "variable number must be between ?1 and ?NNN"
+    // SQLite rejects ?0 with the verbatim diagnostic (not a `near "…": syntax
+    // error` wrapping): "variable number must be between ?1 and ?999".
     let mut lexer = Lexer::new("SELECT ?0");
     let err = lexer.tokenize().unwrap_err();
-    assert!(err.message.contains("?1"), "expected ?0 rejection message, got: {}", err.message);
+    assert_eq!(err.message, "variable number must be between ?1 and ?999");
+    // near_token must be unset so Display emits the message verbatim.
+    assert_eq!(err.to_string(), "variable number must be between ?1 and ?999");
+}
+
+#[test]
+fn test_tokenize_question_over_limit_rejected() {
+    // ?1000 exceeds SQLITE_MAX_VARIABLE_NUMBER (999) and is rejected with the
+    // same range diagnostic (SQLite e_expr-11.1.3).
+    let mut lexer = Lexer::new("SELECT ?1000");
+    let err = lexer.tokenize().unwrap_err();
+    assert_eq!(err.to_string(), "variable number must be between ?1 and ?999");
+}
+
+#[test]
+fn test_tokenize_question_max_allowed() {
+    // ?999 is exactly at the limit and must lex successfully.
+    let mut lexer = Lexer::new("SELECT ?999");
+    let tokens = lexer.tokenize().unwrap();
+    assert_eq!(tokens[1], Token::NumberedPlaceholder(999));
+}
+
+#[test]
+fn test_tokenize_question_overflow_rejected() {
+    // A parameter number too large to represent yields the same range error
+    // rather than panicking or wrapping (SQLite e_expr-11.1.5..13).
+    let mut lexer = Lexer::new("SELECT ?12345678903456789034567890234567890");
+    let err = lexer.tokenize().unwrap_err();
+    assert_eq!(err.to_string(), "variable number must be between ?1 and ?999");
 }
 
 #[test]

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -734,6 +734,12 @@ proc translate_error_to_sqlite {vibesql_error} {
     if {[regexp {^(?:Parse error: )?(hex literal too big: .+)$} $error_msg -> parse_msg]} {
         return $parse_msg
     }
+    # Out-of-range numbered parameter (`?0`, `?1000`, or a value too large to
+    # represent): SQLite reports `variable number must be between ?1 and ?NNN`
+    # verbatim, not wrapped as a `near "…": syntax error` (e_expr-11.1.2..13).
+    if {[regexp {^(?:Parse error: )?(variable number must be between \?1 and \?[0-9]+)$} $error_msg -> parse_msg]} {
+        return $parse_msg
+    }
     # Special case for "incomplete input" - return as-is (SQLite format)
     if {[regexp -nocase {^Parse error: incomplete input$} $error_msg]} {
         return "incomplete input"


### PR DESCRIPTION
Part of #6172 (expression / type-affinity / literal-semantics conformance family — Part of epic #5779). This is a **partial increment**; the family issue stays open.

## What this PR fixes

### 1. Affinity-aware CASE / scalar IS / NULLIF equality (commit c92db1099)
`values_are_equal` (used by simple `CASE` and scalar `IS`/`IS NOT`) unconditionally tried to parse a TEXT operand as a number whenever the other operand was numeric, regardless of SQLite column affinity. Real SQLite only coerces when a real NUMERIC/INTEGER/REAL or TEXT affinity column is involved (datatype3 S4.2); two bare literals or a BLOB/NONE column compare by storage class. This made `CASE 55 WHEN '55' THEN 'A' ELSE 'B' END` wrongly return `A` (SQLite: `B`) and `55 IS '55'` wrongly return true (SQLite: false).

- Adds `affinity_aware_equal`/`affinity_aware_is_distinct` (core + combined evaluators), applying `apply_affinity_for_comparison` before the strict, no-guessing comparator already used by plain `=`/`<>`, and routes CASE's simple form and scalar `IS`/`IS NOT` through them.
- `NULLIF` compares its two values with **no** affinity conversion at all (verified against SQLite: `NULLIF('1', 1)` on TEXT `'1'` returns `'1'`, not NULL) — routed through the strict comparator directly.
- Arena (prepared-statement) evaluator's CASE and IS/IS NOT use the same strict comparator.

Verified: `CASE 55 WHEN '55'…` → `B`, `55 IS '55'` → `0`, `NULLIF('1',1)` → `1`.

### 2. `?NNN` parameter-number bound (commit 47df9517c)
A `?NNN` numbered parameter must be within `1..=SQLITE_MAX_VARIABLE_NUMBER` (SQLite's documented default, 999). Previously VibeSQL accepted any `?NNN` up to `usize`, rejected only `?0`, and even `?0` surfaced `near "?0": syntax error` (the `LexerError` set `near_token`, so `Display` wrapped the intended message). Over-limit `?1000` was silently accepted; unparseably-large `?123…890` produced a token error.

- `tokenize_question_numbered_placeholder` now parses digits into `u64` and validates `1..=999`, returning SQLite's exact `variable number must be between ?1 and ?999` as a preformatted (verbatim) diagnostic for `?0`, over-limit, and too-large values alike.
- TCL shim `translate_error_to_sqlite` gets a verbatim passthrough for this diagnostic (its generic fallback otherwise re-wraps it as `near "…": syntax error`), mirroring the existing `hex literal too big` / NATURAL-join passthroughs.

Fixes e_expr-11.1.2 through e_expr-11.1.13 (12 tests). No test uses a `?NNN` above the limit (the only `?40960`/`?148848` occurrences are TCL `[expr ?:]` ternaries).

## Test results
- **e_expr.test: 277 → 265 failures** (4780 → 4792 passed, 94.6%).
- New lexer unit tests for `?0`, `?1000`, `?999`, overflow. Parser lib: 1824 pass. Executor lib: 3629 pass.
- No regressions: select1.test 100%, expr.test 0 failures.

## Remaining work on #6172 (for the next increment)
The bulk of e_expr's remaining 265 failures are **out of scope for expression semantics** and would need separate, larger features:
- **~171 (section 12.3)** blocked on **ATTACH DATABASE** (`ATTACH … AS dbname; CREATE TABLE dbname.tblname` — parser reports "ATTACH-blocked"; the whole file-scope setup fails so every `SELECT … FROM tblname` errors). Large cross-database feature.
- **~37 filescope-err** are C-API (`sqlite3_prepare_v2` ×31), `MATCH`-context, and a `tcl untested` array unset — not SQL-CLI reachable.
- **~40** need custom TCL-registered functions/collations (`var`, `ceval`, `reverse` collation, overridden `like`/`glob`) — not CLI reachable.

Satellite files surveyed (state after this PR):
- `literal.test` — **now 100%** (fixed by earlier increments).
- `nan.test` (35 fail) — entirely `sqlite3_bind_double`/`hexio_write` C-API to inject NaN/Inf (unrepresentable as SQL literals). Out of scope.
- `types3.test` (17) — entirely `tcl_variable_type` / custom type functions. Out of scope.
- `istrue.test` (13) — 8 are C-API NaN/Inf binding; `istrue-810` is a real name-resolution bug (`ORDER BY false` where `false` is a column name is treated as the boolean literal). Tractable next.
- `like3.test` (16) — EQP/optimizer + UTF-16 encoding (storage feature). Out of scope.
- `quote.test` (14) — SQLite's `no such column: "X" - should this be a string literal in single-quotes?` hint + `SQLITE_DBCONFIG_DQS_DDL` double-quote-in-DDL semantics. Tractable-but-nuanced next.
- `unhex.test` (3) — shim `$var` binds as bareword instead of TEXT parameter (shim-side). `numcast.test` (3) / `hexlit.test` (1) — UTF-16 encoding + hex-digit-count overflow, both narrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)