### PR TITLE
conformance(tcl): AUTOINCREMENT via real sqlite_sequence table + rowid32 capability

### DIFF
--- a/crates/vibesql-catalog/src/table.rs
+++ b/crates/vibesql-catalog/src/table.rs
@@ -106,6 +106,22 @@ pub struct TableSchema {
     /// STRICT tables enforce rigid per-column datatypes on INSERT/UPDATE. See
     /// <https://sqlite.org/stricttables.html>.
     pub strict: bool,
+    /// If true, this table's INTEGER PRIMARY KEY (rowid alias) column was
+    /// declared with the AUTOINCREMENT keyword (SQLite compatibility, issue
+    /// #6173). Only ever set together with `rowid_alias_column` — SQLite
+    /// requires AUTOINCREMENT to be used on a single-column INTEGER PRIMARY
+    /// KEY, never on a WITHOUT ROWID table. When set, the engine tracks a
+    /// monotonically-increasing high-water-mark for this table's rowid in
+    /// the real `sqlite_sequence` table (created lazily the first time any
+    /// AUTOINCREMENT table exists), guaranteeing a NULL-inserted rowid is
+    /// always larger than any rowid the table has EVER held — even across a
+    /// full `DELETE FROM` and a process restart — unlike a plain (non-
+    /// AUTOINCREMENT) INTEGER PRIMARY KEY, which may reuse rowids after the
+    /// table becomes empty. Not serialized in the binary catalog — like
+    /// `rowid_alias_column`/`strict`, it is rederived from `sql_source` on
+    /// load, so no format bump is needed. See
+    /// <https://sqlite.org/autoinc.html>.
+    pub is_autoincrement: bool,
     /// Per-column STRICT storage-type classification, parallel to `columns`.
     /// Empty when the table is not STRICT. When non-empty, `strict_types[i]` is
     /// the declared strict type of `columns[i]` (validated at CREATE time to be
@@ -170,6 +186,7 @@ impl TableSchema {
             is_view: false,
             sql_source: None,
             strict: false,
+            is_autoincrement: false,
             strict_types: Vec::new(),
             primary_key_collations: None,
             unique_constraint_collations: Vec::new(),
@@ -208,6 +225,7 @@ impl TableSchema {
             is_view: false,
             sql_source: None,
             strict: false,
+            is_autoincrement: false,
             strict_types: Vec::new(),
             primary_key_collations: None,
             unique_constraint_collations: Vec::new(),
@@ -236,6 +254,7 @@ impl TableSchema {
             is_view: false,
             sql_source: None,
             strict: false,
+            is_autoincrement: false,
             strict_types: Vec::new(),
             primary_key_collations: None,
             unique_constraint_collations: Vec::new(),
@@ -264,6 +283,7 @@ impl TableSchema {
             is_view: false,
             sql_source: None,
             strict: false,
+            is_autoincrement: false,
             strict_types: Vec::new(),
             primary_key_collations: None,
             unique_constraint_collations: Vec::new(),
@@ -293,6 +313,7 @@ impl TableSchema {
             is_view: false,
             sql_source: None,
             strict: false,
+            is_autoincrement: false,
             strict_types: Vec::new(),
             primary_key_collations: None,
             unique_constraint_collations: Vec::new(),
@@ -324,6 +345,7 @@ impl TableSchema {
             is_view: false,
             sql_source: None,
             strict: false,
+            is_autoincrement: false,
             strict_types: Vec::new(),
             primary_key_collations: None,
             unique_constraint_collations: Vec::new(),
@@ -352,6 +374,7 @@ impl TableSchema {
             is_view: false,
             sql_source: None,
             strict: false,
+            is_autoincrement: false,
             strict_types: Vec::new(),
             primary_key_collations: None,
             unique_constraint_collations: Vec::new(),

--- a/crates/vibesql-executor/src/autoincrement.rs
+++ b/crates/vibesql-executor/src/autoincrement.rs
@@ -1,0 +1,314 @@
+//! AUTOINCREMENT bookkeeping via a real `sqlite_sequence` table (issue #6173).
+//!
+//! SQLite's `AUTOINCREMENT` keyword (only legal on a single-column `INTEGER
+//! PRIMARY KEY`, i.e. the rowid alias) guarantees a NULL-inserted rowid is
+//! always larger than any rowid the table has EVER held — even across a full
+//! `DELETE FROM <table>` and a process restart. A plain (non-AUTOINCREMENT)
+//! `INTEGER PRIMARY KEY` has no such guarantee: once every row is deleted, the
+//! next NULL insert reuses rowid 1.
+//!
+//! SQLite implements this by lazily creating a real table, `sqlite_sequence
+//! (name, seq)`, the first time any `AUTOINCREMENT` table is created, and
+//! maintaining one row per AUTOINCREMENT table: `seq` is the high-water mark
+//! (the largest rowid the table has ever held, explicit or auto-generated).
+//! VibeSQL mirrors this design exactly — `sqlite_sequence` is a genuine
+//! catalog table (not a virtual/computed one), so ordinary `SELECT` / `UPDATE`
+//! / `DELETE` against it flow through the normal executor pipeline for free,
+//! and its row data persists via the same WAL/snapshot machinery as any user
+//! table. Only the lazy creation, the per-INSERT bookkeeping, and the
+//! DROP-TABLE cleanup are special-cased here.
+//!
+//! Reference: <https://sqlite.org/autoinc.html>
+
+use vibesql_catalog::{ColumnSchema, TableIdentifier, TableSchema};
+use vibesql_storage::{Database, Row};
+use vibesql_types::{DataType, SqlValue};
+
+use crate::errors::ExecutorError;
+
+/// The reserved system table name (SQLite's own spelling, always lowercase).
+pub const SQLITE_SEQUENCE_TABLE: &str = "sqlite_sequence";
+
+/// Whether `name` refers to the `sqlite_sequence` system table (case-insensitive,
+/// matching SQLite's identifier folding).
+pub fn is_sqlite_sequence_table(name: &str) -> bool {
+    name.eq_ignore_ascii_case(SQLITE_SEQUENCE_TABLE)
+}
+
+/// Schema for the lazily-created `sqlite_sequence` table.
+///
+/// SQLite declares both columns with no type at all (`CREATE TABLE
+/// sqlite_sequence(name,seq)`), which gives them BLOB/NONE affinity — no
+/// coercion is applied to inserted/updated values (verified against sqlite3
+/// 3.51.0: `UPDATE sqlite_sequence SET seq='a-string'` stores the literal
+/// string, not an error or a coerced 0). VibeSQL's `DataType::BinaryLargeObject`
+/// is exactly this "no affinity" passthrough type (used for any column
+/// declared without a type, e.g. `CREATE TABLE t(a)` — see
+/// `vibesql-parser/src/parser/create/table.rs`), so it round-trips arbitrary
+/// values through a normal `UPDATE sqlite_sequence` unchanged.
+fn sqlite_sequence_table_schema() -> TableSchema {
+    let mut schema = TableSchema::new(
+        SQLITE_SEQUENCE_TABLE.to_string(),
+        vec![
+            ColumnSchema::new("name".to_string(), DataType::BinaryLargeObject, true),
+            ColumnSchema::new("seq".to_string(), DataType::BinaryLargeObject, true),
+        ],
+    );
+    schema.set_sql_source(format!("CREATE TABLE {}(name,seq)", SQLITE_SEQUENCE_TABLE));
+    schema
+}
+
+/// Lazily create the `sqlite_sequence` table in the CURRENT schema if it does
+/// not already exist. Safe to call unconditionally — a no-op when the table
+/// is already present (e.g. a second `CREATE TABLE ... AUTOINCREMENT` in the
+/// same schema, or a table reloaded from a snapshot that already created it).
+///
+/// Uses [`Database::create_table_with_identifier`] directly, bypassing the
+/// user-facing `sqlite_`-prefix reservation guard (`is_reserved_object_name`)
+/// that would otherwise reject this name — this is engine-internal DDL, not
+/// user-issued. Because that low-level API emits its own WAL `CreateTable` op
+/// and inserts into both the catalog and storage, the table persists exactly
+/// like any user table (issue #6173's core design point).
+pub fn ensure_sqlite_sequence_table(database: &mut Database) -> Result<(), ExecutorError> {
+    if database.catalog.get_table(SQLITE_SEQUENCE_TABLE).is_some() {
+        return Ok(());
+    }
+    database
+        .create_table_with_identifier(
+            sqlite_sequence_table_schema(),
+            TableIdentifier::new(SQLITE_SEQUENCE_TABLE, false),
+        )
+        .map_err(|e| ExecutorError::StorageError(e.to_string()))
+}
+
+/// SQLite's effective "read `seq` as an integer" semantics for the fallback
+/// path used when computing the next AUTOINCREMENT rowid: a valid integer (or
+/// an integer-valued real) parses as itself; NULL, a non-numeric TEXT value,
+/// or a value that doesn't fit in `i64` (verified against sqlite3 3.51.0:
+/// `UPDATE sqlite_sequence SET seq='-12345678901234567890'` — 20 digits,
+/// outside `i64` range — behaves exactly like an unparseable value) all
+/// return `None`, signaling "ignore me, fall back to the table's actual max
+/// rowid" to the caller.
+fn parse_seq_value(value: &SqlValue) -> Option<i64> {
+    match value {
+        SqlValue::Integer(v) | SqlValue::Bigint(v) => Some(*v),
+        SqlValue::Smallint(v) => Some(*v as i64),
+        SqlValue::Unsigned(v) => i64::try_from(*v).ok(),
+        SqlValue::Real(f) | SqlValue::Double(f) | SqlValue::Numeric(f) => {
+            if f.fract() == 0.0 && *f >= i64::MIN as f64 && *f <= i64::MAX as f64 {
+                Some(*f as i64)
+            } else {
+                None
+            }
+        }
+        SqlValue::Varchar(s) | SqlValue::Character(s) => s.trim().parse::<i64>().ok(),
+        _ => None,
+    }
+}
+
+/// Look up the `sqlite_sequence` row for `table_display_name` (exact,
+/// case-sensitive match on `name` — SQLite compares with the default BINARY
+/// collation). Returns `Some(parsed_seq)` when a row exists (`parsed_seq` is
+/// `None` when the stored value is NULL/non-numeric/out-of-range — see
+/// [`parse_seq_value`]), or `None` when no row exists for this table yet.
+fn lookup_sequence_row(database: &Database, table_display_name: &str) -> Option<Option<i64>> {
+    let table = database.get_table(SQLITE_SEQUENCE_TABLE)?;
+    table.scan_live().find_map(|(_, row)| match row.values.first() {
+        Some(SqlValue::Varchar(s)) if s.as_str() == table_display_name => {
+            Some(row.values.get(1).and_then(parse_seq_value))
+        }
+        _ => None,
+    })
+}
+
+/// The `sqlite_sequence.seq` high-water mark for `table_display_name`, or
+/// `None` when no row exists yet, or the stored value is NULL/non-numeric/
+/// out-of-range (see [`parse_seq_value`]) — either way, "nothing to combine
+/// with the table's own max rowid".
+///
+/// Used both by [`compute_next_autoincrement_rowid`] (the INTEGER PRIMARY KEY
+/// -named-column NULL-fill path in `insert/defaults.rs`) and by the
+/// `rowid`/`_rowid_`/`oid` pseudo-column auto-allocation path in
+/// `insert/execution.rs` — both paths auto-generate the SAME logical value
+/// (the IPK column value IS the rowid) and must agree, or the row's *stored*
+/// column value and its *tracked* high-water mark (`Table::max_rowid_signed`,
+/// which future allocations read from) silently diverge.
+pub fn sequence_high_water_mark(database: &Database, table_display_name: &str) -> Option<i64> {
+    lookup_sequence_row(database, table_display_name).and_then(|v| v)
+}
+
+/// Compute the rowid a NULL/omitted INTEGER PRIMARY KEY insert into an
+/// AUTOINCREMENT table must receive.
+///
+/// SQLite semantics (verified against sqlite3 3.51.0, autoinc.test): the new
+/// rowid is `max(table's actual current max rowid, sqlite_sequence.seq) + 1`
+/// — NOT simply `sqlite_sequence.seq + 1`. This is what makes a manually
+/// lowered `UPDATE sqlite_sequence SET seq=5` a no-op when the table's real
+/// max rowid is already higher, while a manually RAISED value (`seq=1234`
+/// when the table's max is 124) IS honored. An invalid stored `seq` (NULL, a
+/// non-numeric string, or one that doesn't fit `i64`) is ignored — the
+/// computation falls back to the table's actual max rowid alone.
+pub fn compute_next_autoincrement_rowid(
+    database: &Database,
+    storage_table_name: &str,
+    table_display_name: &str,
+) -> Result<i64, ExecutorError> {
+    let table_max = database.get_table(storage_table_name).and_then(|t| t.max_rowid_signed());
+    let seq_val = sequence_high_water_mark(database, table_display_name);
+    let combined = match (table_max, seq_val) {
+        (Some(a), Some(b)) => a.max(b),
+        (Some(a), None) => a,
+        (None, Some(b)) => b,
+        (None, None) => 0,
+    };
+    combined
+        .checked_add(1)
+        .ok_or_else(|| ExecutorError::SqliteCompatError("database or disk is full".to_string()))
+}
+
+/// Bump (or lazily create) the `sqlite_sequence` entry for `table_display_name`
+/// after a successfully-completed INSERT statement against an AUTOINCREMENT
+/// table.
+///
+/// `min_value` is the highest rowid this statement considered assigning to a
+/// row of the target table — explicit or auto-generated, and INCLUDING rows
+/// later discarded by `OR IGNORE` / `ON CONFLICT DO NOTHING` (SQLite still
+/// bumps the sequence for those, verified against sqlite3 3.51.0), or `0` when
+/// the statement processed no candidate rows at all (e.g. an `INSERT ...
+/// SELECT` whose SELECT yields zero rows still creates a `(table, 0)`
+/// sqlite_sequence row on its first successful run — sqlite3 3.51.0,
+/// autoinc-9.1). A statement that fails outright (no `OR IGNORE`/`ON CONFLICT`
+/// rescue) never reaches this call, so its bookkeeping never happens —
+/// matching SQLite's whole-statement rollback.
+///
+/// The stored value is always `max(existing stored value, min_value)` — a
+/// smaller explicit/auto rowid never lowers the tracked high-water mark.
+pub fn bump_sequence_after_insert(
+    database: &mut Database,
+    table_display_name: &str,
+    min_value: i64,
+) -> Result<(), ExecutorError> {
+    ensure_sqlite_sequence_table(database)?;
+
+    let existing = lookup_sequence_row(database, table_display_name);
+    let existing_valid = existing.and_then(|v| v);
+    let new_val = existing_valid.unwrap_or(i64::MIN).max(min_value);
+    let row_exists = existing.is_some();
+
+    if row_exists {
+        let name = table_display_name.to_string();
+        database
+            .update_row_matching(
+                SQLITE_SEQUENCE_TABLE,
+                move |row| matches!(row.values.first(), Some(SqlValue::Varchar(s)) if s.as_str() == name),
+                vec![("seq", SqlValue::Integer(new_val))],
+            )
+            .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+    } else {
+        database
+            .insert_row(
+                SQLITE_SEQUENCE_TABLE,
+                Row::new(vec![
+                    SqlValue::Varchar(arcstr::ArcStr::from(table_display_name)),
+                    SqlValue::Integer(new_val),
+                ]),
+            )
+            .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+    }
+    Ok(())
+}
+
+/// Remove the `sqlite_sequence` entry for a dropped AUTOINCREMENT table
+/// (SQLite: `DROP TABLE` on an AUTOINCREMENT table removes its
+/// `sqlite_sequence` row, but the `sqlite_sequence` table itself stays
+/// behind). A no-op if `sqlite_sequence` doesn't exist (or has no row for this
+/// table) — dropping a table before its first successful INSERT is normal.
+pub fn remove_sequence_entry(
+    database: &mut Database,
+    table_display_name: &str,
+) -> Result<(), ExecutorError> {
+    if database.get_table(SQLITE_SEQUENCE_TABLE).is_none() {
+        return Ok(());
+    }
+    let name = table_display_name.to_string();
+    database
+        .delete_row_matching(SQLITE_SEQUENCE_TABLE, move |row| {
+            matches!(row.values.first(), Some(SqlValue::Varchar(s)) if s.as_str() == name)
+        })
+        .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_sqlite_sequence_table() {
+        assert!(is_sqlite_sequence_table("sqlite_sequence"));
+        assert!(is_sqlite_sequence_table("SQLITE_SEQUENCE"));
+        assert!(is_sqlite_sequence_table("Sqlite_Sequence"));
+        assert!(!is_sqlite_sequence_table("sqlite_master"));
+        assert!(!is_sqlite_sequence_table("t1"));
+    }
+
+    #[test]
+    fn test_parse_seq_value() {
+        assert_eq!(parse_seq_value(&SqlValue::Integer(1234)), Some(1234));
+        assert_eq!(parse_seq_value(&SqlValue::Null), None);
+        assert_eq!(
+            parse_seq_value(&SqlValue::Varchar(arcstr::ArcStr::from("a-string"))),
+            None
+        );
+        assert_eq!(
+            parse_seq_value(&SqlValue::Varchar(arcstr::ArcStr::from(
+                "-12345678901234567890"
+            ))),
+            None
+        );
+        assert_eq!(
+            parse_seq_value(&SqlValue::Varchar(arcstr::ArcStr::from("42"))),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn test_ensure_sqlite_sequence_table_idempotent() {
+        let mut db = Database::new();
+        assert!(db.catalog.get_table(SQLITE_SEQUENCE_TABLE).is_none());
+        ensure_sqlite_sequence_table(&mut db).unwrap();
+        assert!(db.catalog.get_table(SQLITE_SEQUENCE_TABLE).is_some());
+        // Calling again must not error (idempotent).
+        ensure_sqlite_sequence_table(&mut db).unwrap();
+    }
+
+    #[test]
+    fn test_bump_sequence_creates_and_upserts() {
+        let mut db = Database::new();
+        bump_sequence_after_insert(&mut db, "t1", 12).unwrap();
+        assert_eq!(lookup_sequence_row(&db, "t1"), Some(Some(12)));
+
+        // A smaller explicit value never lowers the tracked max.
+        bump_sequence_after_insert(&mut db, "t1", 1).unwrap();
+        assert_eq!(lookup_sequence_row(&db, "t1"), Some(Some(12)));
+
+        // A larger value raises it.
+        bump_sequence_after_insert(&mut db, "t1", 123).unwrap();
+        assert_eq!(lookup_sequence_row(&db, "t1"), Some(Some(123)));
+
+        // A second table is tracked independently.
+        bump_sequence_after_insert(&mut db, "t2", 1).unwrap();
+        assert_eq!(lookup_sequence_row(&db, "t2"), Some(Some(1)));
+        assert_eq!(lookup_sequence_row(&db, "t1"), Some(Some(123)));
+    }
+
+    #[test]
+    fn test_remove_sequence_entry() {
+        let mut db = Database::new();
+        bump_sequence_after_insert(&mut db, "t1", 5).unwrap();
+        bump_sequence_after_insert(&mut db, "t2", 7).unwrap();
+        remove_sequence_entry(&mut db, "t1").unwrap();
+        assert_eq!(lookup_sequence_row(&db, "t1"), None);
+        assert_eq!(lookup_sequence_row(&db, "t2"), Some(Some(7)));
+    }
+}

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -309,18 +309,15 @@ impl CreateTableExecutor {
             .columns
             .iter()
             .map(|col_def| {
-                // For AUTO_INCREMENT columns, set default to NEXT VALUE FOR sequence
-                let default_value = if col_def
-                    .constraints
-                    .iter()
-                    .any(|c| matches!(c.kind, vibesql_ast::ColumnConstraintKind::AutoIncrement))
-                {
-                    // Create sequence name: {table_name}_{column_name}_seq
-                    let sequence_name = format!("{}_{}_seq", table_name, col_def.name);
-                    Some(vibesql_ast::Expression::NextValue { sequence_name })
-                } else {
-                    col_def.default_value.as_ref().map(|expr| (**expr).clone())
-                };
+                // AUTO_INCREMENT/AUTOINCREMENT columns get no synthetic default
+                // expression: NULL-fill for the INTEGER PRIMARY KEY (rowid
+                // alias) column is handled by the dedicated
+                // `apply_default_values_with_batch_context` IPK path, which
+                // consults the real `sqlite_sequence` table for AUTOINCREMENT
+                // tables (issue #6173) — this runs BEFORE the generic
+                // default-value pass ever inspects this column, so a
+                // default_value here would be unreachable dead code.
+                let default_value = col_def.default_value.as_ref().map(|expr| (**expr).clone());
 
                 // Extract column-level collation from constraints
                 let collation = col_def.constraints.iter().find_map(|c| {
@@ -398,6 +395,16 @@ impl CreateTableExecutor {
             ));
         }
 
+        // AUTOINCREMENT is meaningless on a WITHOUT ROWID table (there is no
+        // rowid to auto-generate) — SQLite rejects it at CREATE time (issue
+        // #6173, tableopts-1.1b). Checked before rowid-alias detection since a
+        // WITHOUT ROWID table never gets a `rowid_alias_column` regardless.
+        if stmt.without_rowid && !auto_increment_columns.is_empty() {
+            return Err(ExecutorError::SqliteCompatError(
+                "AUTOINCREMENT not allowed on WITHOUT ROWID tables".to_string(),
+            ));
+        }
+
         // Detect INTEGER PRIMARY KEY for SQLite rowid aliasing (Issue #4536)
         // In SQLite, a single-column PRIMARY KEY with exactly "INTEGER" type is an alias for rowid.
         // The column's value IS the rowid, and SELECT rowid returns this column's value.
@@ -412,6 +419,24 @@ impl CreateTableExecutor {
                     }
                 }
             }
+        }
+
+        // AUTOINCREMENT requires the column to be *the* single-column INTEGER
+        // PRIMARY KEY / rowid alias (SQLite: "AUTOINCREMENT is only allowed on
+        // an INTEGER PRIMARY KEY", issue #6173, autoinc-7.2). This also
+        // rejects AUTOINCREMENT on a composite PRIMARY KEY or on a PK column
+        // whose type isn't exactly INTEGER (e.g. `x TEXT PRIMARY KEY
+        // AUTOINCREMENT`), since neither becomes the rowid alias above.
+        if let Some(auto_inc_col) = auto_increment_columns.first() {
+            let is_rowid_alias = table_schema
+                .rowid_alias_column
+                .is_some_and(|idx| table_schema.columns[idx].name == *auto_inc_col);
+            if !is_rowid_alias {
+                return Err(ExecutorError::SqliteCompatError(
+                    "AUTOINCREMENT is only allowed on an INTEGER PRIMARY KEY".to_string(),
+                ));
+            }
+            table_schema.is_autoincrement = true;
         }
 
         // Check for STORAGE table option and apply storage format
@@ -633,27 +658,6 @@ impl CreateTableExecutor {
                 .map_err(|e| ExecutorError::StorageError(format!("Schema error: {:?}", e)))?;
         }
 
-        // Create internal sequences for AUTO_INCREMENT columns
-        for auto_inc_col in &auto_increment_columns {
-            let sequence_name = format!("{}_{}_seq", table_name, auto_inc_col);
-            database
-                .catalog
-                .create_sequence(
-                    sequence_name.clone(),
-                    Some(1), // start_with: 1
-                    1,       // increment_by: 1
-                    Some(1), // min_value: 1
-                    None,    // max_value: unlimited
-                    false,   // cycle: false
-                )
-                .map_err(|e| {
-                    ExecutorError::StorageError(format!(
-                        "Failed to create sequence for AUTO_INCREMENT: {:?}",
-                        e
-                    ))
-                })?;
-        }
-
         // Create table using Database API with TableIdentifier (handles both catalog and storage)
         // Note: identifier was created at the start of this function with proper quoted semantics
         let result = database
@@ -665,6 +669,16 @@ impl CreateTableExecutor {
 
         // Auto-create indexes for PRIMARY KEY and UNIQUE constraints
         Self::create_implicit_indexes(database, &table_name, &table_schema)?;
+
+        // Lazily create the real `sqlite_sequence` table (issue #6173) the
+        // first time an AUTOINCREMENT table exists in this schema. Runs AFTER
+        // the table itself is created so `sqlite_master`/`sqlite_sequence`
+        // list in creation order (`t1` then `sqlite_sequence`, matching
+        // sqlite3 3.51.0 autoinc-1.2) — `sqlite_sequence` gets no row for
+        // this table yet; that happens lazily on the table's first INSERT.
+        if table_schema.is_autoincrement {
+            crate::autoincrement::ensure_sqlite_sequence_table(database)?;
+        }
 
         // Restore original schema if we switched
         if needs_schema_switch {

--- a/crates/vibesql-executor/src/drop_table.rs
+++ b/crates/vibesql-executor/src/drop_table.rs
@@ -69,6 +69,15 @@ impl DropTableExecutor {
             ));
         }
 
+        // `sqlite_sequence` (AUTOINCREMENT bookkeeping, issue #6173) may never
+        // be dropped either, matching sqlite3 3.51.0 (autoinc-1.5): `table
+        // sqlite_sequence may not be dropped`.
+        if crate::autoincrement::is_sqlite_sequence_table(&stmt.table_name) {
+            return Err(ExecutorError::SqliteCompatError(
+                "table sqlite_sequence may not be dropped".to_string(),
+            ));
+        }
+
         // Check if table exists
         let table_exists = database.catalog.table_exists(&stmt.table_name);
 
@@ -84,6 +93,18 @@ impl DropTableExecutor {
 
         // Check DROP privilege on the table
         PrivilegeChecker::check_drop(database, &stmt.table_name)?;
+
+        // Remember whether this is an AUTOINCREMENT table (and its declared-
+        // case display name) before it's removed from the catalog, so its
+        // `sqlite_sequence` row can be cleaned up after the drop succeeds.
+        // SQLite: dropping an AUTOINCREMENT table removes its entry from
+        // `sqlite_sequence`, but `sqlite_sequence` itself stays behind
+        // (autoinc-3.2/3.3/3.4, issue #6173).
+        let autoincrement_display_name = database
+            .catalog
+            .get_table(&stmt.table_name)
+            .filter(|schema| schema.is_autoincrement)
+            .map(|schema| schema.name.clone());
 
         // Drop all indexes associated with this table first
         let dropped_indexes = database.catalog.drop_table_indexes(&stmt.table_name);
@@ -119,6 +140,10 @@ impl DropTableExecutor {
         database
             .drop_table(&stmt.table_name)
             .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
+
+        if let Some(display_name) = autoincrement_display_name {
+            crate::autoincrement::remove_sequence_entry(database, &display_name)?;
+        }
 
         // Return success message
         match (index_count, trigger_count) {

--- a/crates/vibesql-executor/src/index_ddl/validation.rs
+++ b/crates/vibesql-executor/src/index_ddl/validation.rs
@@ -68,6 +68,16 @@ pub fn validate_create_index(
         });
     }
 
+    // `sqlite_sequence` (AUTOINCREMENT bookkeeping, issue #6173) may not be
+    // indexed either, matching sqlite3 3.51.0 (autoinc-1.3.1): `table
+    // sqlite_sequence may not be indexed`.
+    if crate::autoincrement::is_sqlite_sequence_table(&table_name) {
+        return Err(ExecutorError::SqliteSystemTableReadOnly {
+            table_name: table_name.clone(),
+            operation: "indexed".to_string(),
+        });
+    }
+
     // Reject user attempts to create an index with a reserved name. Like
     // CREATE TABLE, SQLite forbids the `sqlite_` prefix for user objects and
     // errors `object name reserved for internal use: <name>` (sqlite3 3.51.0,

--- a/crates/vibesql-executor/src/insert/bulk_transfer.rs
+++ b/crates/vibesql-executor/src/insert/bulk_transfer.rs
@@ -49,6 +49,16 @@ pub fn try_bulk_transfer(
         return Ok(None); // Fall back to normal path
     }
 
+    // AUTOINCREMENT tables (issue #6173) need their `sqlite_sequence`
+    // high-water mark bumped as part of the INSERT statement (matching
+    // sqlite3's "xfer optimization" — the `sqlite_sequence` write-back still
+    // happens even when the row data itself is bulk-copied). Rather than
+    // duplicating that bookkeeping here, fall back to the normal per-row path
+    // (`execute_insert_internal`), which already has it (autoinc-10.1).
+    if dest_schema.is_autoincrement {
+        return Ok(None);
+    }
+
     // Phase 3: Execute optimized transfer
     execute_bulk_transfer(db, dest_table, &source_table, &dest_schema, &compat_result)
 }

--- a/crates/vibesql-executor/src/insert/defaults.rs
+++ b/crates/vibesql-executor/src/insert/defaults.rs
@@ -368,8 +368,20 @@ pub fn apply_default_values_with_batch_context(
     // This must happen before regular default value processing
     if let Some(ipk_idx) = schema.get_integer_primary_key_index() {
         if row_values[ipk_idx] == vibesql_types::SqlValue::Null {
-            // Auto-generate: max(existing_pk, batch_max) + 1, or 1 if table is empty
-            let table_max = compute_next_integer_pk_value(database, storage_table_name)?;
+            // Auto-generate: max(existing_pk, batch_max) + 1, or 1 if table is empty.
+            // AUTOINCREMENT tables (issue #6173) additionally consult the real
+            // `sqlite_sequence` high-water mark, so a NULL insert is always
+            // larger than any rowid the table has EVER held — even across a
+            // full DELETE that reset the table's own live max back to empty.
+            let table_max = if schema.is_autoincrement {
+                crate::autoincrement::compute_next_autoincrement_rowid(
+                    database,
+                    storage_table_name,
+                    &schema.name,
+                )?
+            } else {
+                compute_next_integer_pk_value(database, storage_table_name)?
+            };
             // The next value should be max of (table_max, batch_max_ipk + 1)
             let next_val = match batch_max_ipk {
                 Some(batch_max) => table_max.max(batch_max + 1),

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -632,6 +632,27 @@ fn execute_insert_internal(
     let table_max_rowid: Option<i64> =
         db.get_table(&storage_table_name).and_then(|t| t.max_rowid_signed());
 
+    // AUTOINCREMENT tables (issue #6173) fold in the `sqlite_sequence`
+    // high-water mark here too. This path (the `rowid`/`_rowid_`/`oid`
+    // pseudo-column *and* the INTEGER PRIMARY KEY-named-column auto-rowid
+    // computation below) and `apply_default_values_with_batch_context`'s IPK
+    // NULL-fill (`insert/defaults.rs`) both auto-generate the SAME logical
+    // value — the IPK column value IS the rowid — and must start from the
+    // same baseline, or the row's stored column value and its *tracked*
+    // high-water mark (what future allocations in this table read from) would
+    // silently diverge.
+    let table_max_rowid: Option<i64> = if schema.is_autoincrement {
+        let seq = crate::autoincrement::sequence_high_water_mark(db, &schema.name);
+        match (table_max_rowid, seq) {
+            (Some(a), Some(b)) => Some(a.max(b)),
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            (None, None) => None,
+        }
+    } else {
+        table_max_rowid
+    };
+
     // Track maximum signed rowid seen so far (updated as we process each row)
     let mut batch_max_rowid: Option<i64> = table_max_rowid;
 
@@ -1691,6 +1712,29 @@ fn execute_insert_internal(
             }
         }
         return Err(assertion_error);
+    }
+
+    // AUTOINCREMENT bookkeeping (issue #6173): on ANY successfully-completed
+    // INSERT statement against an AUTOINCREMENT table, bump (or lazily
+    // create) its `sqlite_sequence` entry to `max(existing, batch_max_ipk)`.
+    // `batch_max_ipk` already reflects the highest rowid this statement
+    // considered for the target table — explicit or auto-generated, and
+    // including rows later discarded by `OR IGNORE`/`ON CONFLICT DO NOTHING`
+    // (sqlite3 still bumps the sequence for those) — since it is updated
+    // unconditionally in the per-row loop above, before any conflict
+    // resolution. `unwrap_or(0)` covers a statement that considered zero rows
+    // (e.g. `INSERT ... SELECT` whose SELECT is empty): sqlite3 still creates
+    // a `(table, 0)` row on such a statement's first successful run
+    // (autoinc-9.1). Placed after every fallible step in this function
+    // (including the assertion-rollback path above), so a statement that
+    // ultimately errors out never reaches it — matching sqlite3's
+    // whole-statement rollback of the bookkeeping too.
+    if schema.is_autoincrement {
+        crate::autoincrement::bump_sequence_after_insert(
+            db,
+            &schema.name,
+            batch_max_ipk.unwrap_or(0),
+        )?;
     }
 
     // Project the RETURNING clause against the rows actually inserted/updated

--- a/crates/vibesql-executor/src/lib.rs
+++ b/crates/vibesql-executor/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod advanced_objects;
 mod alter;
+pub mod autoincrement;
 mod alter_rewrite;
 pub mod arena;
 pub mod cache;

--- a/crates/vibesql-executor/src/tests/auto_increment_tests.rs
+++ b/crates/vibesql-executor/src/tests/auto_increment_tests.rs
@@ -32,7 +32,8 @@ fn test_auto_increment_basic_inserts() {
                 default_value: None,
                 comment: None,
                 generated_expr: None,
-                is_exact_integer_type: false,
+                // INTEGER PRIMARY KEY AUTOINCREMENT is a genuine rowid-alias column.
+                is_exact_integer_type: true,
                 type_source: None,
             },
             ColumnDef {
@@ -186,7 +187,8 @@ fn test_last_insert_rowid_basic() {
                 default_value: None,
                 comment: None,
                 generated_expr: None,
-                is_exact_integer_type: false,
+                // INTEGER PRIMARY KEY AUTOINCREMENT is a genuine rowid-alias column.
+                is_exact_integer_type: true,
                 type_source: None,
             },
             ColumnDef {
@@ -285,7 +287,8 @@ fn test_last_insert_rowid_multi_row_insert() {
                 default_value: None,
                 comment: None,
                 generated_expr: None,
-                is_exact_integer_type: false,
+                // INTEGER PRIMARY KEY AUTOINCREMENT is a genuine rowid-alias column.
+                is_exact_integer_type: true,
                 type_source: None,
             },
             ColumnDef {
@@ -452,7 +455,8 @@ fn test_last_insert_rowid_via_select() {
                 default_value: None,
                 comment: None,
                 generated_expr: None,
-                is_exact_integer_type: false,
+                // INTEGER PRIMARY KEY AUTOINCREMENT is a genuine rowid-alias column.
+                is_exact_integer_type: true,
                 type_source: None,
             },
             ColumnDef {

--- a/crates/vibesql-executor/src/tests/truncate_table_tests.rs
+++ b/crates/vibesql-executor/src/tests/truncate_table_tests.rs
@@ -398,7 +398,8 @@ fn test_truncate_resets_auto_increment() {
                 default_value: None,
                 comment: None,
                 generated_expr: None,
-                is_exact_integer_type: false,
+                // INTEGER PRIMARY KEY AUTOINCREMENT is a genuine rowid-alias column.
+                is_exact_integer_type: true,
                 type_source: None,
             },
             ColumnDef {
@@ -516,7 +517,8 @@ fn test_truncate_resets_auto_increment_multiple_inserts() {
                 default_value: None,
                 comment: None,
                 generated_expr: None,
-                is_exact_integer_type: false,
+                // INTEGER PRIMARY KEY AUTOINCREMENT is a genuine rowid-alias column.
+                is_exact_integer_type: true,
                 type_source: None,
             },
             ColumnDef {

--- a/crates/vibesql-executor/src/truncate/core.rs
+++ b/crates/vibesql-executor/src/truncate/core.rs
@@ -30,6 +30,19 @@ pub fn reset_auto_increment_sequences(
         }
     }
 
+    // Capture the real-AUTOINCREMENT display name (issue #6173): an INTEGER
+    // PRIMARY KEY AUTOINCREMENT table tracks its high-water mark in the real
+    // `sqlite_sequence` table rather than a synthetic `NextValue` sequence, so
+    // it never appears in `sequence_names` above. TRUNCATE resets the counter
+    // to 1, mirrored by removing the `sqlite_sequence` row for this table (an
+    // empty table with no `seq` row makes the next NULL insert restart at 1);
+    // `bump_sequence_after_insert` lazily recreates the row on the next insert.
+    let autoincrement_display_name = if table_schema.is_autoincrement {
+        Some(table_schema.name.clone())
+    } else {
+        None
+    };
+
     // Now reset the sequences
     for sequence_name in sequence_names {
         if let Ok(sequence) = database.catalog.get_sequence_mut(&sequence_name) {
@@ -38,6 +51,11 @@ pub fn reset_auto_increment_sequences(
         }
         // Note: If sequence doesn't exist, we silently continue.
         // This shouldn't happen in normal operation but makes the function more robust.
+    }
+
+    // Reset the real `sqlite_sequence` high-water mark for AUTOINCREMENT tables.
+    if let Some(display_name) = autoincrement_display_name {
+        crate::autoincrement::remove_sequence_entry(database, &display_name)?;
     }
 
     Ok(())

--- a/crates/vibesql-storage/src/database/table_api.rs
+++ b/crates/vibesql-storage/src/database/table_api.rs
@@ -737,6 +737,110 @@ impl Database {
         Ok(true)
     }
 
+    /// Update the first LIVE row matching `predicate`, without requiring a
+    /// primary key (direct API, no SQL parsing).
+    ///
+    /// Unlike [`Database::update_row_by_pk`], this does not consult a PK index
+    /// — it scans live rows and updates the first match by content, via the
+    /// same `predicate` used to find it. Returns `Ok(false)` when no row
+    /// matches. This is intended for small internal system tables that have
+    /// no declared PRIMARY KEY, no user indexes, and no triggers — currently
+    /// only `sqlite_sequence` (AUTOINCREMENT bookkeeping, issue #6173) —
+    /// where the caller already guarantees at most one live row can match.
+    pub fn update_row_matching<F>(
+        &mut self,
+        table_name: &str,
+        mut predicate: F,
+        column_updates: Vec<(&str, vibesql_types::SqlValue)>,
+    ) -> Result<bool, StorageError>
+    where
+        F: FnMut(&Row) -> bool,
+    {
+        let (row_index, old_row, schema, resolved_name) = {
+            let table = self
+                .get_table(table_name)
+                .ok_or_else(|| StorageError::TableNotFound(table_name.to_string()))?;
+            let Some((row_index, row)) = table.scan_live().find(|(_, row)| predicate(row)) else {
+                return Ok(false);
+            };
+            let old_row = row.clone();
+            let schema = table.schema.clone();
+            let resolved_name = schema.name.clone();
+            (row_index, old_row, schema, resolved_name)
+        };
+
+        let mut new_row = old_row.clone();
+        let mut changed_columns = std::collections::HashSet::new();
+        for (col_name, new_value) in &column_updates {
+            let col_index =
+                schema.get_column_index(col_name).ok_or_else(|| StorageError::ColumnNotFound {
+                    column_name: col_name.to_string(),
+                    table_name: resolved_name.clone(),
+                })?;
+            new_row.set(col_index, new_value.clone())?;
+            changed_columns.insert(col_index);
+        }
+
+        let txn_id = self.transaction_id();
+        crate::mvcc::stamp_xmin_for_write(&mut new_row, txn_id);
+        new_row.xmax = None;
+
+        let table_mut = self.get_table_mut(table_name).unwrap();
+        table_mut.update_row_selective(row_index, new_row.clone(), &changed_columns)?;
+
+        if !self.is_temp_table(&resolved_name) {
+            self.emit_wal_op(WalOp::Update {
+                table_id: self.table_name_to_id(&resolved_name),
+                table_name: resolved_name.clone(),
+                row_id: row_index as u64,
+                old_values: old_row.values.to_vec(),
+                new_values: new_row.values.to_vec(),
+            });
+        }
+
+        self.columnar_cache.invalidate(&resolved_name);
+
+        Ok(true)
+    }
+
+    /// Delete the first LIVE row matching `predicate`, without requiring a
+    /// primary key (direct API, no SQL parsing).
+    ///
+    /// Same restriction and intended use as [`Database::update_row_matching`]:
+    /// internal system tables with no PK/indexes/triggers to maintain
+    /// (currently only `sqlite_sequence`). Returns `Ok(false)` when no row
+    /// matches.
+    pub fn delete_row_matching<F>(
+        &mut self,
+        table_name: &str,
+        predicate: F,
+    ) -> Result<bool, StorageError>
+    where
+        F: FnMut(&Row) -> bool + Clone,
+    {
+        let (row_index, old_values, resolved_name) = {
+            let table = self
+                .get_table(table_name)
+                .ok_or_else(|| StorageError::TableNotFound(table_name.to_string()))?;
+            let mut p = predicate.clone();
+            let Some((row_index, row)) = table.scan_live().find(|(_, row)| p(row)) else {
+                return Ok(false);
+            };
+            (row_index, row.values.to_vec(), table.schema.name.clone())
+        };
+
+        if !self.is_temp_table(&resolved_name) {
+            self.emit_wal_delete(&resolved_name, row_index as u64, old_values);
+        }
+
+        let table_mut = self.get_table_mut(table_name).unwrap();
+        table_mut.delete_where(predicate);
+
+        self.columnar_cache.invalidate(&resolved_name);
+
+        Ok(true)
+    }
+
     /// List all table names
     pub fn list_tables(&self) -> Vec<String> {
         self.catalog.list_tables()

--- a/crates/vibesql-storage/src/persistence/binary/constraints.rs
+++ b/crates/vibesql-storage/src/persistence/binary/constraints.rs
@@ -213,6 +213,28 @@ pub(crate) fn rehydrate_constraints_from_sql_source(
         }
     }
 
+    // ---- AUTOINCREMENT flag (issue #6173) ----
+    // `TableSchema::is_autoincrement` is not a serialized binary field either
+    // (same rationale as `rowid_alias_column`/`strict` above): rederive it
+    // from the re-parsed source so a process restart doesn't silently forget
+    // an AUTOINCREMENT column and start reusing rowids after a full DELETE.
+    // Mirrors `create_table.rs`'s validation: only column-level AUTOINCREMENT
+    // is checked here (the table-level `PRIMARY KEY(x AUTOINCREMENT)` spelling
+    // is not yet accepted by the parser), and only takes effect when the
+    // column ended up as the rowid alias above.
+    if let Some(col_idx) = schema.rowid_alias_column {
+        let col_name = &schema.columns[col_idx].name;
+        let is_autoincrement = create.columns.iter().any(|col_def| {
+            col_def.name.eq_ignore_ascii_case(col_name)
+                && col_def.constraints.iter().any(|c| {
+                    matches!(c.kind, vibesql_ast::ColumnConstraintKind::AutoIncrement)
+                })
+        });
+        if is_autoincrement {
+            schema.is_autoincrement = true;
+        }
+    }
+
     // ---- PRIMARY KEY key-part collations (issue #5881) ----
     // The explicit per-key-part COLLATE (`PRIMARY KEY(a COLLATE nocase)`) is not
     // a serialized binary field, so before this rehydration a reloaded WITHOUT

--- a/crates/vibesql-storage/src/table/mod.rs
+++ b/crates/vibesql-storage/src/table/mod.rs
@@ -298,17 +298,40 @@ impl Table {
         }
     }
 
-    /// Track a row's effective *signed* rowid for allocation (issue #5835).
+    /// Track a row's effective *signed* rowid for allocation (issue #5835,
+    /// extended by issue #6173).
     ///
-    /// `row_id` is the explicit rowid bit pattern if the row carries one;
-    /// `position` is the physical index the row occupies, from which an
-    /// implicit rowid (`position + 1`) is derived otherwise.
+    /// For a table with an INTEGER PRIMARY KEY rowid alias
+    /// (`schema.rowid_alias_column`), the alias COLUMN'S value IS the rowid —
+    /// `row.row_id` is deliberately left unset for such rows (see the INSERT
+    /// executor's "Skip INTEGER PRIMARY KEY (rowid alias) tables" comment),
+    /// so falling back to `row.row_id`/physical position here would silently
+    /// under-track the true max whenever the alias column's value diverges
+    /// from insertion order — e.g. an `INSERT INTO t(b) VALUES(...)` that
+    /// omits the named IPK column, following an earlier row whose IPK value
+    /// was itself non-sequential (an explicit large value, a gap left by
+    /// DELETE, or — the case that surfaced this — a BEFORE/AFTER INSERT
+    /// trigger recursively inserting extra rows into the same table). Without
+    /// this, a later NULL/omitted-IPK insert could recompute the SAME "next"
+    /// value twice and collide with a row already written (autoinc-3928).
+    ///
+    /// For any other table, `row_id` is the explicit rowid bit pattern if the
+    /// row carries one; `position` is the physical index the row occupies,
+    /// from which an implicit rowid (`position + 1`) is derived otherwise.
     #[inline]
-    fn track_effective_rowid(&mut self, row_id: Option<u64>, position: usize) {
-        let effective: i64 = match row_id {
+    fn track_effective_rowid(&mut self, row: &Row, position: usize) {
+        let alias_value = self
+            .schema
+            .rowid_alias_column
+            .and_then(|idx| row.values.get(idx))
+            .and_then(|v| if let SqlValue::Integer(i) = v { Some(*i) } else { None });
+        let effective: i64 = match alias_value {
+            Some(v) => v,
             // SQLite rowids are signed; reinterpret the stored bit pattern.
-            Some(rid) => rid as i64,
-            None => position as i64 + 1,
+            None => match row.row_id {
+                Some(rid) => rid as i64,
+                None => position as i64 + 1,
+            },
         };
         self.max_assigned_rowid =
             Some(self.max_assigned_rowid.map_or(effective, |m| m.max(effective)));
@@ -339,7 +362,7 @@ impl Table {
 
         // Track the largest effective rowid ever assigned (issue #5835) so
         // future implicit-rowid allocation never collides with it.
-        self.track_effective_rowid(normalized_row.row_id, self.rows.len());
+        self.track_effective_rowid(&normalized_row, self.rows.len());
 
         // Add row to table (always stored for indexing and potential row access)
         let row_index = self.rows.len();
@@ -453,7 +476,7 @@ impl Table {
         // Phase 3: Insert all rows into storage
         for row in normalized_rows {
             // Track the largest effective rowid ever assigned (issue #5835).
-            self.track_effective_rowid(row.row_id, self.rows.len());
+            self.track_effective_rowid(&row, self.rows.len());
             self.rows.push(row);
             self.deleted.push(false);
         }
@@ -1024,12 +1047,17 @@ impl Table {
         let normalizer = RowNormalizer::new(&self.schema);
         let normalized_row = normalizer.normalize_and_validate(row)?;
 
-        // Track the largest explicit rowid ever assigned (issue #5835).
-        // Only explicit rowids are tracked here: an UPDATE replaces a row in
-        // place, so a `None` row_id cannot introduce a new effective rowid
-        // beyond what its insert already tracked.
-        if let Some(rid) = normalized_row.row_id {
-            self.track_effective_rowid(Some(rid), index);
+        // Track the largest explicit rowid ever assigned (issue #5835), or
+        // (issue #6173) the largest INTEGER PRIMARY KEY alias value: an
+        // UPDATE replaces a row in place, so a row with neither an explicit
+        // `row_id` NOR a rowid-alias column cannot introduce a new effective
+        // rowid beyond what its insert already tracked — but `UPDATE t SET
+        // <ipk_col>=<bigger value>` on a rowid-alias table changes the
+        // row's *effective* rowid without ever touching `row_id`, and that
+        // new high-water mark must still be tracked (same reasoning as
+        // `track_effective_rowid`'s doc comment on the INSERT paths).
+        if normalized_row.row_id.is_some() || self.schema.rowid_alias_column.is_some() {
+            self.track_effective_rowid(&normalized_row, index);
         }
 
         // Get old row for index updates (clone to avoid borrow issues)

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -6774,7 +6774,14 @@ proc check_single_capability {cap} {
     # than skipped (e.g. e_expr-27.4.7..9/28.1.3..4/30.1.5..8, #6172).
     # Marking it unsupported routes `ifcapable {utf16}` guards to their
     # skip/else branch, matching a real SQLITE_OMIT_UTF16 build.
-    set unsupported_caps {wal vacuum_incr autovacuum stat4 stat3 tclvar vtab rtree fts3 fts4 fts5 fts3_unicode conflict hiddencolumns progress allow_rowid_in_view crashtest utf16}
+    # `rowid32` (the SQLITE_32BIT_ROWID compile-time option) is OFF in a normal
+    # SQLite build and in VibeSQL: rowids/INTEGER PRIMARY KEY values are signed
+    # 64-bit. Marking it unsupported routes `ifcapable {rowid32}` blocks to their
+    # skip/else branch and `ifcapable {!rowid32}` blocks to their run branch,
+    # matching a 64-bit-rowid build. Without this, autoinc-6.1 took the 32-bit
+    # branch (INSERT 2147483647) and autoinc-6.2's follow-on NULL insert did not
+    # overflow i64, so the expected "database or disk is full" never fired (#6173).
+    set unsupported_caps {wal vacuum_incr autovacuum stat4 stat3 tclvar vtab rtree fts3 fts4 fts5 fts3_unicode conflict hiddencolumns progress allow_rowid_in_view crashtest utf16 rowid32}
 
     # Handle negated capability (e.g., !autovacuum)
     set negate 0


### PR DESCRIPTION
## Summary

Implements SQLite `AUTOINCREMENT` semantics backed by a genuine, lazily-created `sqlite_sequence(name, seq)` catalog table (per <https://sqlite.org/autoinc.html>), replacing the previous synthetic per-column `NEXT VALUE FOR {table}_{col}_seq` default that never enforced AUTOINCREMENT's core guarantee: a NULL-inserted rowid is always larger than any rowid the table has *ever* held — even across a full `DELETE FROM` and a process restart.

This is one slice of the CREATE TABLE / schema-definition family (issue #6173). It targets the **AUTOINCREMENT / `sqlite_sequence`** sub-feature.

## Changes

**New module** `crates/vibesql-executor/src/autoincrement.rs`
- Lazy `sqlite_sequence` creation (a real catalog table — ordinary SELECT/UPDATE/DELETE and WAL/snapshot persistence work for free)
- High-water-mark lookup + SQLite-compatible `seq` parsing (NULL / non-numeric / out-of-`i64` all fall back to the table's actual max rowid)
- Next-rowid computation `max(table_max, seq) + 1`, with `i64` overflow → `database or disk is full`
- Per-INSERT bump and DROP-TABLE row cleanup
- 5 unit tests

**Wiring**
- `create_table.rs`: set `is_autoincrement`; reject `AUTOINCREMENT` on WITHOUT ROWID tables and on any non-`INTEGER PRIMARY KEY` column; remove the old synthetic sequence; lazily create `sqlite_sequence`
- `insert/defaults.rs`, `insert/execution.rs`, `insert/bulk_transfer.rs`: fold the `sqlite_sequence` high-water mark into rowid allocation; bump the sequence after every successful statement (including `OR IGNORE` / `ON CONFLICT DO NOTHING` candidates and empty `INSERT...SELECT`); bulk-transfer falls back to the per-row path for AUTOINCREMENT tables
- `drop_table.rs`, `index_ddl/validation.rs`: `sqlite_sequence` may not be dropped or indexed; dropping an AUTOINCREMENT table removes only its row
- storage `table/mod.rs`: track a row's effective rowid from the INTEGER PRIMARY KEY alias **column value** (not physical position), fixing under-tracking when the alias value diverges from insertion order (e.g. explicit large values, DELETE gaps, trigger-recursive inserts); add PK-less `update_row_matching` / `delete_row_matching` helpers used only by the system table
- catalog `table.rs` + `persistence/binary/constraints.rs`: add `is_autoincrement`, rederived from `sql_source` on reload (no binary format bump, same pattern as `rowid_alias_column` / `strict`)

**Test shim** `scripts/tester_vibesql.tcl`
- Mark `rowid32` unsupported (VibeSQL uses signed 64-bit rowids), routing `autoinc-6.1`/`6.2` to the 64-bit branch so the overflow error fires

## Acceptance Criteria Verification

Per-file `make test-tcl-file` before → after (this slice's target file):

| File | Before (baseline) | After |
|------|------:|------:|
| autoinc.test | 61 failed | **17 failed** (57/87 pass, 13 skipped) |

The other listed files in #6173 were already substantially cleared by earlier merged slices of this family and are unaffected/held by this PR: `strict1.test` 0 failed (100%), `check.test` 9 failed, `gencol1.test` 11 failed, `e_createtable.test` 150 failed, `tableopts.test` blanket-skipped in the shim (its lone marker is an unrelated file-scope `db2 close` cascade).

The 17 remaining `autoinc.test` failures are **out of scope** for this slice and left for follow-ups:
- `autoinc-4.*` (10) — per-schema `temp.sqlite_sequence` / ATTACH `aux.sqlite_sequence` (each attached database needs its own `sqlite_sequence`)
- `autoinc-3928.*` (6) — trigger-recursive-insert ordering / nested-statement sequence bookkeeping
- `autoinc-7.1` (1) — table-level `PRIMARY KEY(x AUTOINCREMENT)` spelling (needs parser support)

## Test Plan

- `cargo build -p vibesql-executor` / `cargo build --release -p vibesql` — clean
- `cargo test -p vibesql-executor --lib autoincrement` — 5 passed
- `cargo test -p vibesql-storage --lib rowid` — 11 passed (guards the `track_effective_rowid` change against IPK regressions)
- `make test-tcl-file FILE=autoinc.test` — 57 passed / 17 failed / 13 skipped

Part of #6173