### PR TITLE
fix(executor): CHECK constraints cast result to NUMERIC before zero-test (Part of #6173)

### DIFF
--- a/crates/vibesql-executor/src/evaluator/operators/logical.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/logical.rs
@@ -68,6 +68,23 @@ pub fn is_truthy(value: &SqlValue) -> bool {
     }
 }
 
+/// Determine whether a CHECK-constraint result value constitutes a violation.
+///
+/// SQLite evaluates each CHECK expression and casts the result to a NUMERIC
+/// value "in the same way as a CAST expression". A constraint violation occurs
+/// only when the result is zero (integer value 0 or real value 0.0). If the
+/// result is NULL, or any other non-zero value, it is *not* a violation
+/// (EVIDENCE-OF: R-55435-14303, R-34109-39108).
+///
+/// This means non-numeric text such as `'abc'` casts to 0 and therefore
+/// violates, while `'1abc'` casts to 1 and passes. Relying on `is_truthy`
+/// gives exactly SQLite's leading-numeric coercion; NULL is handled here as a
+/// pass because `is_truthy(Null)` is `false` (row-selection semantics) whereas
+/// a CHECK treats NULL as satisfied.
+pub fn check_constraint_violated(value: &SqlValue) -> bool {
+    !matches!(value, SqlValue::Null) && !is_truthy(value)
+}
+
 fn parse_leading_numeric(s: &str) -> f64 {
     let s = s.trim_start();
     if s.is_empty() {
@@ -238,6 +255,28 @@ impl LogicalOps {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_check_constraint_violated() {
+        use arcstr::ArcStr;
+        // NULL passes (not a violation)
+        assert!(!check_constraint_violated(&SqlValue::Null));
+        // Boolean false / zero numerics violate
+        assert!(check_constraint_violated(&SqlValue::Boolean(false)));
+        assert!(check_constraint_violated(&SqlValue::Integer(0)));
+        assert!(check_constraint_violated(&SqlValue::Real(0.0)));
+        // Non-zero numerics pass
+        assert!(!check_constraint_violated(&SqlValue::Boolean(true)));
+        assert!(!check_constraint_violated(&SqlValue::Integer(1)));
+        assert!(!check_constraint_violated(&SqlValue::Integer(-4)));
+        assert!(!check_constraint_violated(&SqlValue::Real(0.5)));
+        // Text casts to leading NUMERIC: 'abc1' → 0 (violation), '1abc' → 1 (pass)
+        assert!(check_constraint_violated(&SqlValue::Varchar(ArcStr::from("abc1"))));
+        assert!(check_constraint_violated(&SqlValue::Varchar(ArcStr::from(""))));
+        assert!(check_constraint_violated(&SqlValue::Varchar(ArcStr::from("0"))));
+        assert!(!check_constraint_violated(&SqlValue::Varchar(ArcStr::from("1abc"))));
+        assert!(!check_constraint_violated(&SqlValue::Varchar(ArcStr::from("42"))));
+    }
 
     #[test]
     fn test_and_operator() {

--- a/crates/vibesql-executor/src/evaluator/operators/mod.rs
+++ b/crates/vibesql-executor/src/evaluator/operators/mod.rs
@@ -20,7 +20,7 @@ use string::StringOps;
 use vector::VectorOps;
 
 // Re-export truthiness helpers for use in CASE evaluation and row selection
-pub use logical::{is_truthy, is_truthy_string};
+pub use logical::{check_constraint_violated, is_truthy, is_truthy_string};
 use vibesql_types::SqlValue;
 
 use crate::errors::ExecutorError;

--- a/crates/vibesql-executor/src/insert/constraints.rs
+++ b/crates/vibesql-executor/src/insert/constraints.rs
@@ -310,9 +310,10 @@ pub fn enforce_check_constraints(
             // Evaluate the CHECK expression against the row
             let result = evaluator.eval(check_expr, &row)?;
 
-            // CHECK constraint passes if result is TRUE or NULL (UNKNOWN)
-            // CHECK constraint fails if result is FALSE
-            if result == vibesql_types::SqlValue::Boolean(false) {
+            // CHECK passes if the result is NULL or casts to a non-zero
+            // NUMERIC; it fails when the result casts to zero (integer 0 /
+            // real 0.0), which includes non-numeric text like 'abc' → 0.
+            if crate::evaluator::operators::check_constraint_violated(&result) {
                 // SQLite-compatible error format: "CHECK constraint failed: <name_or_expr>"
                 return Err(ExecutorError::SqliteCompatError(format!(
                     "CHECK constraint failed: {}",

--- a/crates/vibesql-executor/src/insert/row_validator.rs
+++ b/crates/vibesql-executor/src/insert/row_validator.rs
@@ -383,8 +383,10 @@ impl<'a> RowValidator<'a> {
             for (constraint_name, check_expr) in &self.schema.check_constraints {
                 let result = evaluator.eval(check_expr, &row)?;
 
-                // CHECK constraint fails if result is FALSE
-                if result == vibesql_types::SqlValue::Boolean(false) {
+                // CHECK passes if the result is NULL or casts to a non-zero
+                // NUMERIC; it fails when the result casts to zero (integer 0 /
+                // real 0.0), which includes non-numeric text like 'abc' → 0.
+                if crate::evaluator::operators::check_constraint_violated(&result) {
                     // SQLite-compatible error format: "CHECK constraint failed: <name_or_expr>"
                     return Err(ExecutorError::SqliteCompatError(format!(
                         "CHECK constraint failed: {}",

--- a/crates/vibesql-executor/src/update/constraints.rs
+++ b/crates/vibesql-executor/src/update/constraints.rs
@@ -352,9 +352,10 @@ impl<'a> ConstraintValidator<'a> {
                 // Evaluate the CHECK expression against the updated row
                 let result = evaluator.eval(check_expr, new_row)?;
 
-                // CHECK constraint passes if result is TRUE or NULL (UNKNOWN)
-                // CHECK constraint fails if result is FALSE
-                if result == vibesql_types::SqlValue::Boolean(false) {
+                // CHECK passes if the result is NULL or casts to a non-zero
+                // NUMERIC; it fails when the result casts to zero (integer 0 /
+                // real 0.0), which includes non-numeric text like 'abc' → 0.
+                if crate::evaluator::operators::check_constraint_violated(&result) {
                     // SQLite-compatible error format: "CHECK constraint failed: <name_or_expr>"
                     return Err(ExecutorError::SqliteCompatError(format!(
                         "CHECK constraint failed: {}",

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -1207,9 +1207,10 @@ fn validate_non_uniqueness_constraints(
         for (constraint_name, check_expr) in &schema.check_constraints {
             let result = evaluator.eval(check_expr, new_row)?;
 
-            // CHECK constraint passes if result is TRUE or NULL (UNKNOWN)
-            // CHECK constraint fails if result is FALSE
-            if result == SqlValue::Boolean(false) {
+            // CHECK passes if the result is NULL or casts to a non-zero
+            // NUMERIC; it fails when the result casts to zero (integer 0 /
+            // real 0.0), which includes non-numeric text like 'abc' → 0.
+            if crate::evaluator::operators::check_constraint_violated(&result) {
                 // SQLite-compatible error format: "CHECK constraint failed: <name_or_expr>"
                 return Err(ExecutorError::SqliteCompatError(format!(
                     "CHECK constraint failed: {}",


### PR DESCRIPTION
## Summary

Part of #6173 (CREATE TABLE / schema-definition semantics family — this is the 9th partial increment).

SQLite evaluates each CHECK expression and **casts the result to a NUMERIC value** "in the same way as a CAST expression". A constraint violation occurs only when the result is zero (integer `0` or real `0.0`); NULL and any other non-zero value pass. Non-numeric text such as `'abc'` casts to `0` and therefore violates, while `'1abc'` casts to `1` and passes (EVIDENCE-OF R-55435-14303, R-34109-39108).

The executor previously flagged a violation only when the CHECK result was exactly `Boolean(false)`. A CHECK that produces text — e.g. `CHECK(a||b)` — let rows through even when `a||b` evaluated to a non-numeric string like `'abc1'` (which SQLite casts to `0` → violation).

## Changes

- New shared helper `check_constraint_violated()` in `evaluator/operators/logical.rs`, next to `is_truthy()`. It reuses SQLite's existing leading-numeric coercion: a value violates when it is non-NULL and casts to a zero NUMERIC.
- Wired into all four CHECK enforcement sites so INSERT and UPDATE (fast paths and row-validator/constraint paths) behave identically:
  - `insert/constraints.rs`
  - `insert/row_validator.rs`
  - `update/executor.rs`
  - `update/constraints.rs`
- Added a unit test for the helper.

## Test results

`make test-tcl-file FILE=e_createtable.test`: **150 → 144 failures** — the `e_createtable-4.11` `a||b` cluster (2a/2b/3a/3b/4a/4b) now passes. The complementary `4.12` non-violation cases (text `'abc'`, NULL) continue to pass.

No regressions: `check.test` (9), `gencol1.test` (11), `tableopts.test` (1 harness-only) unchanged; executor CHECK unit/integration tests green.

The remaining `e_createtable`/`check.test` failures are separate sub-features (ATTACH `auxa`/`auxb` qualified names, `sqlite3_prepare_v2` harness commands, custom SQL function registration, DEFAULT-expression parsing) left for future increments in this family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)