### PR TITLE
fix(storage,executor): persist subquery-bearing trigger expressions + scope trigger-body name resolution to owning schema

### DIFF
--- a/crates/vibesql-catalog/src/store/mod.rs
+++ b/crates/vibesql-catalog/src/store/mod.rs
@@ -81,6 +81,14 @@ pub struct Catalog {
     /// When true, identifier lookups are case-sensitive (SQL standard).
     /// When false (default), identifier lookups are case-insensitive (MySQL compatible).
     pub(crate) case_sensitive_identifiers: bool,
+    /// When true, unqualified table-name resolution does NOT consult the session
+    /// temp schema — it resolves against the main schema only. This models
+    /// SQLite's rule that a trigger created in the `main` (or an attached)
+    /// database resolves the unqualified table names in its body against its own
+    /// database, ignoring temp tables (trigger1-3.2..3.5). It is toggled on only
+    /// for the duration of a non-temp trigger body's execution and restored
+    /// afterward. Default `false` (temp shadows main) everywhere else.
+    pub(crate) suppress_temp_shadowing: bool,
 }
 
 impl Catalog {
@@ -123,6 +131,9 @@ impl Catalog {
             // The parser preserves original case from SQL text. We use case-insensitive
             // mode so lookups work regardless of case in queries.
             case_sensitive_identifiers: false,
+            // Temp shadowing is active by default; only a non-temp trigger body
+            // suppresses it (see field docs).
+            suppress_temp_shadowing: false,
         };
 
         // Create the default schema (SQLite uses "main")
@@ -199,6 +210,24 @@ impl Catalog {
     /// Check if identifier lookups are case-sensitive
     pub fn is_case_sensitive_identifiers(&self) -> bool {
         self.case_sensitive_identifiers
+    }
+
+    /// Suppress (or restore) temp-schema shadowing for unqualified table lookups.
+    ///
+    /// When enabled, unqualified table-name resolution ignores the session temp
+    /// schema and resolves against the main schema only. Used to model SQLite's
+    /// rule that a non-temp trigger's body resolves unqualified names against the
+    /// trigger's own (main) database — a `main` trigger cannot see a TEMP table
+    /// of the same name (trigger1-3.2..3.5). Returns the previous value so the
+    /// caller can restore it (correct nesting of trigger bodies).
+    pub fn set_suppress_temp_shadowing(&mut self, suppress: bool) -> bool {
+        std::mem::replace(&mut self.suppress_temp_shadowing, suppress)
+    }
+
+    /// Whether temp-schema shadowing is currently suppressed for unqualified
+    /// table lookups (see [`Self::set_suppress_temp_shadowing`]).
+    pub fn is_temp_shadowing_suppressed(&self) -> bool {
+        self.suppress_temp_shadowing
     }
 
     /// Normalize an identifier for lookup (applies case folding if case-insensitive mode)

--- a/crates/vibesql-catalog/src/store/tables.rs
+++ b/crates/vibesql-catalog/src/store/tables.rs
@@ -214,10 +214,13 @@ impl super::Catalog {
             })
         } else {
             // For unqualified identifiers, check session-specific temp schema first (SQLite semantics)
-            // Temp tables shadow tables in the main schema
-            if let Some(temp_schema) = self.schemas.get(&self.temp_schema_name) {
-                if let Some(table) = temp_schema.get_table_by_identifier(identifier) {
-                    return Some(table);
+            // Temp tables shadow tables in the main schema — unless shadowing is
+            // suppressed for a non-temp trigger body (see `suppress_temp_shadowing`).
+            if !self.suppress_temp_shadowing {
+                if let Some(temp_schema) = self.schemas.get(&self.temp_schema_name) {
+                    if let Some(table) = temp_schema.get_table_by_identifier(identifier) {
+                        return Some(table);
+                    }
                 }
             }
 
@@ -244,15 +247,18 @@ impl super::Catalog {
             })
         } else {
             // Unqualified name: check session-specific temp schema first (SQLite semantics)
-            // Temp tables shadow tables in the main schema
+            // Temp tables shadow tables in the main schema — unless shadowing is
+            // suppressed for a non-temp trigger body (see `suppress_temp_shadowing`).
             let normalized_table = self.normalize_identifier(name);
 
             // First check session's temp schema
-            if let Some(temp_schema) = self.schemas.get(&self.temp_schema_name) {
-                if let Some(table) =
-                    temp_schema.get_table(&normalized_table, self.case_sensitive_identifiers)
-                {
-                    return Some(table);
+            if !self.suppress_temp_shadowing {
+                if let Some(temp_schema) = self.schemas.get(&self.temp_schema_name) {
+                    if let Some(table) =
+                        temp_schema.get_table(&normalized_table, self.case_sensitive_identifiers)
+                    {
+                        return Some(table);
+                    }
                 }
             }
 
@@ -499,13 +505,16 @@ impl super::Catalog {
 
         let normalized_table = self.normalize_identifier(name);
 
-        // Temp schema shadows main for unqualified names (SQLite semantics).
-        if let Some(temp_schema) = self.schemas.get(&self.temp_schema_name) {
-            if temp_schema
-                .get_table(&normalized_table, self.case_sensitive_identifiers)
-                .is_some()
-            {
-                return Some(self.temp_schema_name.clone());
+        // Temp schema shadows main for unqualified names (SQLite semantics) —
+        // unless shadowing is suppressed for a non-temp trigger body.
+        if !self.suppress_temp_shadowing {
+            if let Some(temp_schema) = self.schemas.get(&self.temp_schema_name) {
+                if temp_schema
+                    .get_table(&normalized_table, self.case_sensitive_identifiers)
+                    .is_some()
+                {
+                    return Some(self.temp_schema_name.clone());
+                }
             }
         }
 
@@ -543,10 +552,13 @@ impl super::Catalog {
             }
             false
         } else {
-            // For unqualified identifiers, check session's temp schema first (SQLite semantics)
-            if let Some(temp_schema) = self.schemas.get(&self.temp_schema_name) {
-                if temp_schema.table_exists_by_identifier(identifier) {
-                    return true;
+            // For unqualified identifiers, check session's temp schema first (SQLite
+            // semantics) — unless shadowing is suppressed for a non-temp trigger body.
+            if !self.suppress_temp_shadowing {
+                if let Some(temp_schema) = self.schemas.get(&self.temp_schema_name) {
+                    if temp_schema.table_exists_by_identifier(identifier) {
+                        return true;
+                    }
                 }
             }
 

--- a/crates/vibesql-executor/src/trigger_execution.rs
+++ b/crates/vibesql-executor/src/trigger_execution.rs
@@ -796,6 +796,17 @@ impl TriggerFirer {
         // the changes() the calling statement observes (e_changes-5.2/6.x/7.x).
         let saved_changes = db.last_changes_count();
 
+        // Scope unqualified table-name resolution in the body to the trigger's
+        // own schema. SQLite resolves the names in a non-temp trigger's body
+        // against the database the trigger belongs to, so a `main` trigger
+        // cannot see a TEMP table of the same name — an unqualified reference to
+        // a table that exists only in temp fails with `no such table: main.<t>`
+        // (trigger1-3.2..3.5). A TEMP trigger keeps normal resolution (temp
+        // shadows main). Nested trigger bodies restore the prior value, so a
+        // temp trigger fired from within a main trigger regains temp visibility.
+        let suppress_temp = !trigger.is_temp();
+        let prev_suppress = db.catalog.set_suppress_temp_shadowing(suppress_temp);
+
         // Execute each statement in the trigger body with trigger context.
         // A RAISE(IGNORE) inside any statement abandons the rest of this
         // trigger's action for the current row and asks the caller to skip the
@@ -810,7 +821,9 @@ impl TriggerFirer {
                 }
                 Err(e) => {
                     // Restore before propagating so a failed trigger body does
-                    // not corrupt the caller's changes() value.
+                    // not corrupt the caller's changes() value or leak the
+                    // temp-shadowing suppression to the caller.
+                    db.catalog.set_suppress_temp_shadowing(prev_suppress);
                     db.set_last_changes_count(saved_changes);
                     // A trigger body statement referencing a table that does not
                     // exist errors `no such table: main.<name>` when the trigger
@@ -819,15 +832,17 @@ impl TriggerFirer {
                     // schema and qualifies the "missing" report with it
                     // (R-28818-63526; e_delete-2.2.1.1 / e_update-2.2.1). A TEMP
                     // trigger's missing target is left unqualified instead
-                    // (R-31567-38587). This only affects the *message*; the
-                    // lookup itself still uses the connection's normal
-                    // temp-then-main search order.
-                    let e = if trigger.is_temp() { e } else { e.with_main_schema_qualifier() };
+                    // (R-31567-38587). With temp shadowing suppressed above, an
+                    // unqualified body reference to a table that exists only in
+                    // temp actually fails the lookup (not just the message),
+                    // matching SQLite (trigger1-3.2..3.5).
+                    let e = if suppress_temp { e.with_main_schema_qualifier() } else { e };
                     return Err(e);
                 }
             }
         }
 
+        db.catalog.set_suppress_temp_shadowing(prev_suppress);
         db.set_last_changes_count(saved_changes);
         Ok(outcome)
     }

--- a/crates/vibesql-executor/tests/trigger_body_schema_scope_tests.rs
+++ b/crates/vibesql-executor/tests/trigger_body_schema_scope_tests.rs
@@ -1,0 +1,146 @@
+//! Trigger-body name resolution is scoped to the trigger's own schema
+//! (trigger1-3.2..3.5, #6176).
+//!
+//! SQLite resolves the unqualified table names in a trigger's body against the
+//! database the trigger belongs to. A trigger created in the `main` schema
+//! therefore resolves an unqualified `t2` to `main.t2` only — it cannot see a
+//! `TEMP` table of the same name, and referencing one that exists only in temp
+//! fails with `no such table: main.t2`. A `TEMP` trigger keeps ordinary
+//! resolution (temp shadows main), so it *can* see the temp table.
+//!
+//! Expectations verified against sqlite3 3.51.0:
+//! ```text
+//! CREATE TABLE t1(a, b);
+//! CREATE TEMP TABLE t2(x, y);
+//! CREATE TRIGGER r1 AFTER INSERT ON t1 BEGIN INSERT INTO t2 VALUES(new.a,new.b); END;
+//! INSERT INTO t1 VALUES(1, 2);   -- Error: no such table: main.t2   (main trigger)
+//!
+//! -- but a TEMP trigger can see the temp table:
+//! CREATE TEMP TRIGGER r1 AFTER INSERT ON t1 BEGIN INSERT INTO t2 VALUES(new.a,new.b); END;
+//! INSERT INTO t1 VALUES(1, 2);   -- ok; temp.t2 now holds (1,2)
+//! ```
+
+use vibesql_executor::{CreateTableExecutor, InsertExecutor, SelectExecutor, TriggerExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn exec(db: &mut Database, sql: &str) {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e:?}"));
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+        }
+        Statement::CreateTrigger(s) => {
+            TriggerExecutor::create_trigger_with_sql(db, &s, Some(sql))
+                .expect("CREATE TRIGGER failed");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT failed");
+        }
+        other => panic!("unsupported statement in test helper: {other:?}"),
+    }
+}
+
+/// Run an INSERT and return the error message (expects it to fail).
+fn insert_err(db: &mut Database, sql: &str) -> String {
+    use vibesql_ast::Statement;
+    let Statement::Insert(s) = Parser::parse_sql(sql).expect("parse failed") else {
+        panic!("expected INSERT");
+    };
+    match InsertExecutor::execute(db, &s) {
+        Ok(_) => panic!("expected INSERT to fail, but it succeeded"),
+        Err(e) => e.to_string(),
+    }
+}
+
+/// Read the temp `t2` (x, y) rows as flat i64 pairs in insertion order.
+fn temp_t2(db: &Database) -> Vec<i64> {
+    use vibesql_ast::Statement;
+    let Statement::Select(select) = Parser::parse_sql("SELECT x, y FROM temp.t2;").expect("parse")
+    else {
+        panic!("expected SELECT");
+    };
+    let rows = SelectExecutor::new(db).execute(&select).expect("SELECT failed");
+    rows.iter()
+        .flat_map(|r| {
+            r.values.iter().map(|v| match v {
+                SqlValue::Integer(n) => *n,
+                other => panic!("expected integer, got {other:?}"),
+            })
+        })
+        .collect()
+}
+
+/// A `main`-schema trigger cannot resolve an unqualified body reference to a
+/// TEMP table of the same name; it reports `no such table: main.t2`
+/// (trigger1-3.2).
+#[test]
+fn main_trigger_body_cannot_see_temp_table() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a, b);");
+    exec(&mut db, "CREATE TEMP TABLE t2(x, y);");
+    exec(
+        &mut db,
+        "CREATE TRIGGER r1 AFTER INSERT ON t1 BEGIN INSERT INTO t2 VALUES(new.a, new.b); END;",
+    );
+
+    let msg = insert_err(&mut db, "INSERT INTO t1 VALUES(1, 2);");
+    assert!(
+        msg.contains("main.t2"),
+        "main trigger must report the unresolved table schema-qualified, got: {msg}"
+    );
+
+    // The failed trigger must not have polluted the temp table.
+    assert!(temp_t2(&db).is_empty(), "no row should have reached temp.t2");
+}
+
+/// A `TEMP`-schema trigger keeps ordinary resolution and *can* insert into the
+/// shadowing temp table (trigger1-3.6.2).
+#[test]
+fn temp_trigger_body_can_see_temp_table() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a, b);");
+    exec(&mut db, "CREATE TEMP TABLE t2(x, y);");
+    exec(
+        &mut db,
+        "CREATE TEMP TRIGGER r1 AFTER INSERT ON t1 \
+         BEGIN INSERT INTO t2 VALUES(new.a, new.b); END;",
+    );
+
+    exec(&mut db, "INSERT INTO t1 VALUES(1, 2);");
+    assert_eq!(temp_t2(&db), vec![1, 2], "temp trigger fills temp.t2 with (1,2)");
+}
+
+/// When only a `main` table of the referenced name exists, a `main` trigger
+/// resolves to it normally (the suppression only hides the temp schema).
+#[test]
+fn main_trigger_body_resolves_main_table_normally() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a, b);");
+    exec(&mut db, "CREATE TABLE t2(x, y);");
+    exec(
+        &mut db,
+        "CREATE TRIGGER r1 AFTER INSERT ON t1 BEGIN INSERT INTO t2 VALUES(new.a, new.b); END;",
+    );
+
+    exec(&mut db, "INSERT INTO t1 VALUES(5, 6);");
+
+    use vibesql_ast::Statement;
+    let Statement::Select(select) = Parser::parse_sql("SELECT x, y FROM main.t2;").expect("parse")
+    else {
+        panic!("expected SELECT");
+    };
+    let rows = SelectExecutor::new(&db).execute(&select).expect("SELECT failed");
+    let vals: Vec<i64> = rows
+        .iter()
+        .flat_map(|r| {
+            r.values.iter().map(|v| match v {
+                SqlValue::Integer(n) => *n,
+                other => panic!("expected integer, got {other:?}"),
+            })
+        })
+        .collect();
+    assert_eq!(vals, vec![5, 6], "main trigger fills main.t2 with (5,6)");
+}

--- a/crates/vibesql-storage/src/persistence/binary/expression/mod.rs
+++ b/crates/vibesql-storage/src/persistence/binary/expression/mod.rs
@@ -28,6 +28,7 @@ use types::{
     read_trim_position, read_truth_value, write_character_unit, write_fulltext_mode,
     write_interval_unit, write_pseudo_table, write_trim_position, write_truth_value,
 };
+use vibesql_ast::pretty_print::ToSql;
 use vibesql_ast::Expression;
 use window::{
     read_window_function_spec, read_window_spec, write_window_function_spec, write_window_spec,
@@ -259,15 +260,23 @@ pub fn write_expression<W: Write>(writer: &mut W, expr: &Expression) -> Result<(
                 write_expression(writer, else_expr)?;
             }
         }
+        // Subquery-bearing expressions (ScalarSubquery / IN (SELECT ...) /
+        // EXISTS / quantified comparison) wrap a full SELECT AST. Rather than
+        // serialize the entire nested SELECT in the binary format, we round-trip
+        // them through their canonical SQL text (`ToSql`) and re-parse on load —
+        // the same strategy used for expression- and partial-index predicates.
+        // This lets a trigger whose WHEN clause contains a scalar subquery (e.g.
+        // `WHEN (SELECT count(*) FROM t) = 0`, trigger2-3.2) persist and reload
+        // instead of aborting the checkpoint (#6176). These tags previously only
+        // ever errored on write, so no pre-existing on-disk file contains them —
+        // adding a working text encoding is backward-compatible (no version bump).
         Expression::ScalarSubquery(_) => {
-            return Err(StorageError::NotImplemented(
-                "ScalarSubquery serialization not yet implemented".to_string(),
-            ));
+            write_tag!(writer, ExprTag::ScalarSubquery);
+            write_string(writer, &expr.to_sql())?;
         }
         Expression::In { .. } => {
-            return Err(StorageError::NotImplemented(
-                "IN with subquery serialization not yet implemented".to_string(),
-            ));
+            write_tag!(writer, ExprTag::In);
+            write_string(writer, &expr.to_sql())?;
         }
         Expression::InList { expr, values, negated } => {
             write_tag!(writer, ExprTag::InList);
@@ -334,14 +343,12 @@ pub fn write_expression<W: Write>(writer: &mut W, expr: &Expression) -> Result<(
             }
         }
         Expression::Exists { .. } => {
-            return Err(StorageError::NotImplemented(
-                "EXISTS serialization not yet implemented".to_string(),
-            ));
+            write_tag!(writer, ExprTag::Exists);
+            write_string(writer, &expr.to_sql())?;
         }
         Expression::QuantifiedComparison { .. } => {
-            return Err(StorageError::NotImplemented(
-                "Quantified comparison serialization not yet implemented".to_string(),
-            ));
+            write_tag!(writer, ExprTag::QuantifiedComparison);
+            write_string(writer, &expr.to_sql())?;
         }
         Expression::CurrentDate => {
             write_tag!(writer, ExprTag::CurrentDate);
@@ -602,12 +609,11 @@ pub fn read_expression<R: Read>(reader: &mut R) -> Result<Expression, StorageErr
                 if has_else { Some(Box::new(read_expression(reader)?)) } else { None };
             Ok(Expression::Case { operand, when_clauses, else_result })
         }
-        ExprTag::ScalarSubquery => Err(StorageError::NotImplemented(
-            "ScalarSubquery deserialization not yet implemented".to_string(),
-        )),
-        ExprTag::In => Err(StorageError::NotImplemented(
-            "IN with subquery deserialization not yet implemented".to_string(),
-        )),
+        // Subquery-bearing expressions are stored as their canonical SQL text
+        // (see the write path) and reconstructed by re-parsing. The parser
+        // returns the exact variant (ScalarSubquery / In / Exists / quantified),
+        // so the tag is only used to route here.
+        ExprTag::ScalarSubquery | ExprTag::In => read_subquery_expr(reader),
         ExprTag::InList => {
             let expr = Box::new(read_expression(reader)?);
             let value_count = read_u32(reader)?;
@@ -664,12 +670,7 @@ pub fn read_expression<R: Read>(reader: &mut R) -> Result<Expression, StorageErr
             let escape = if has_escape { Some(Box::new(read_expression(reader)?)) } else { None };
             Ok(Expression::Glob { expr, pattern, negated, escape })
         }
-        ExprTag::Exists => Err(StorageError::NotImplemented(
-            "EXISTS deserialization not yet implemented".to_string(),
-        )),
-        ExprTag::QuantifiedComparison => Err(StorageError::NotImplemented(
-            "Quantified comparison deserialization not yet implemented".to_string(),
-        )),
+        ExprTag::Exists | ExprTag::QuantifiedComparison => read_subquery_expr(reader),
         ExprTag::CurrentDate => Ok(Expression::CurrentDate),
         ExprTag::CurrentTime => {
             let has_precision = read_bool(reader)?;
@@ -780,6 +781,24 @@ pub fn read_expression<R: Read>(reader: &mut R) -> Result<Expression, StorageErr
     }
 }
 
+/// Reconstruct a subquery-bearing expression from its canonical SQL text.
+///
+/// The write path (see [`write_expression`]) stores `ScalarSubquery`, `In`
+/// (with subquery), `Exists`, and `QuantifiedComparison` expressions as their
+/// `ToSql` text rather than serializing the full nested `SELECT` AST — the same
+/// round-trip-through-SQL strategy expression/partial indexes use. On load we
+/// read that text back and re-parse it with the main parser's expression
+/// grammar, which returns the exact original variant. The `ExprTag` is only
+/// used to route here; the parser determines the concrete variant.
+fn read_subquery_expr<R: Read>(reader: &mut R) -> Result<Expression, StorageError> {
+    let sql = read_string(reader)?;
+    vibesql_parser::Parser::parse_expression_sql(&sql).map_err(|e| {
+        StorageError::NotImplemented(format!(
+            "Failed to parse persisted subquery expression '{sql}': {e}"
+        ))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use vibesql_ast::{BinaryOperator, CaseWhen};
@@ -887,5 +906,56 @@ mod tests {
         let mut reader = &buf[..];
         let result = read_expression(&mut reader).unwrap();
         assert_eq!(result, expr);
+    }
+
+    /// Subquery-bearing expressions are persisted as canonical SQL text and
+    /// re-parsed on load (#6176). Previously these four variants (ScalarSubquery
+    /// / IN (SELECT) / EXISTS / quantified comparison) errored on write. We
+    /// assert the persisted form is a stable fixpoint: the first load may
+    /// normalize display casing via `ToSql`, but a second round-trip must
+    /// reproduce the loaded AST exactly and preserve the canonical SQL text.
+    fn assert_subquery_roundtrip(sql: &str) {
+        let expr = vibesql_parser::Parser::parse_expression_sql(sql)
+            .unwrap_or_else(|e| panic!("parse `{sql}` failed: {e}"));
+
+        let mut buf = Vec::new();
+        write_expression(&mut buf, &expr)
+            .unwrap_or_else(|e| panic!("write `{sql}` failed: {e}"));
+        let first = read_expression(&mut &buf[..])
+            .unwrap_or_else(|e| panic!("read `{sql}` failed: {e}"));
+
+        // Re-serializing the loaded AST and reading it back is a fixpoint.
+        let mut buf2 = Vec::new();
+        write_expression(&mut buf2, &first)
+            .unwrap_or_else(|e| panic!("re-write `{sql}` failed: {e}"));
+        let second = read_expression(&mut &buf2[..])
+            .unwrap_or_else(|e| panic!("re-read `{sql}` failed: {e}"));
+
+        assert_eq!(first, second, "persisted form is not a stable fixpoint for `{sql}`");
+        assert_eq!(
+            expr.to_sql(),
+            first.to_sql(),
+            "canonical SQL text not preserved across persistence for `{sql}`"
+        );
+    }
+
+    #[test]
+    fn test_scalar_subquery_roundtrip() {
+        assert_subquery_roundtrip("(SELECT count(*) FROM t) = 0");
+    }
+
+    #[test]
+    fn test_in_subquery_roundtrip() {
+        assert_subquery_roundtrip("x IN (SELECT a FROM t)");
+    }
+
+    #[test]
+    fn test_exists_roundtrip() {
+        assert_subquery_roundtrip("EXISTS (SELECT 1 FROM t WHERE t.a = x)");
+    }
+
+    #[test]
+    fn test_quantified_comparison_roundtrip() {
+        assert_subquery_roundtrip("x > ALL (SELECT a FROM t)");
     }
 }


### PR DESCRIPTION
## Summary

Two engine fixes toward the trigger / DROP TRIGGER / DROP VIEW semantics family (#6176). This is a **partial increment** — the family tracks ~152 certified failures across many files and remains open.

1. **Subquery-bearing expressions now persist.** `ScalarSubquery`, `IN (SELECT ...)`, `EXISTS`, and quantified comparisons previously returned `NotImplemented` on write, so checkpointing any schema containing one aborted. Most visibly, a trigger whose `WHEN` clause holds a scalar subquery (e.g. `WHEN (SELECT count(*) FROM t) = 0`, trigger2-3.2) was lost on reopen. They now round-trip through their canonical SQL text (`ToSql`) and re-parse on load — the same strategy used for expression- and partial-index predicates. These tags only ever errored on write, so no pre-existing on-disk file contains them: the new text encoding is backward-compatible (no format version bump).

2. **Non-temp trigger bodies resolve unqualified names against their own schema.** SQLite resolves the unqualified table names in a `main` trigger's body against the database the trigger belongs to, so a `main` trigger cannot see a `TEMP` table of the same name — an unqualified reference to a table that exists only in temp fails with `no such table: main.<t>` (trigger1-3.2..3.5). A `TEMP` trigger keeps ordinary resolution (temp shadows main); nested trigger bodies restore the prior value so a temp trigger fired from within a main trigger regains temp visibility. Implemented via a `suppress_temp_shadowing` toggle on `Catalog`, set only for the duration of a non-temp trigger body.

## Changes

- `crates/vibesql-storage/src/persistence/binary/expression/mod.rs` — write subquery-bearing variants as `ToSql` text; add `read_subquery_expr` to re-parse on load; 4 new round-trip unit tests.
- `crates/vibesql-catalog/src/store/mod.rs` — `suppress_temp_shadowing` field + `set_/is_temp_shadowing_suppressed` accessors.
- `crates/vibesql-catalog/src/store/tables.rs` — skip the temp schema in unqualified lookups when suppression is active.
- `crates/vibesql-executor/src/trigger_execution.rs` — toggle suppression around a non-temp trigger body (restored on both success and error paths).
- `crates/vibesql-executor/tests/trigger_body_schema_scope_tests.rs` — 3 new integration tests.

## Acceptance Criteria Verification

- `trigger2.test`: **70/70 (100%)** — subquery-WHEN trigger persistence fix.
- `triggerC.test`: 112/119 (94.1%, 7 remaining) — unchanged from prior increment #6262.
- `trigger1.test`: 26 remaining failures. The trigger1-3.2..3.5 cases target the schema-scope fix; the engine behavior is now correct and directly unit-tested, but these remain masked in the TCL harness by the shim's **TEMP-table demotion** (it rewrites `CREATE TEMP TABLE t2` to a persistent `main.t2`, so the main trigger finds it and the INSERT wrongly succeeds). This is a documented shim artifact called out in the issue's prior-increment notes, not an engine gap.
- Verified the subquery-WHEN trigger survives a real file-DB checkpoint + reopen round-trip via the CLI.

## Test Plan

- `cargo test -p vibesql-storage --lib persistence::binary::expression` — 11 passed (incl. 4 new subquery round-trips).
- `cargo test -p vibesql-executor --test trigger_body_schema_scope_tests` — 3 passed.
- Regression: `trigger_temp_schema_firing_tests` (6), `trigger_when_subquery_tests` (7), `drop_view_cascade_triggers_tests` (4), `changes_and_replace_trigger_semantics_tests` (8), `recursive_triggers_pragma_tests` (5) — all pass.
- TCL family regression: triggerB 100%, triggerA/triggerD 0 failures.
- `cargo clippy` on changed crates — no new warnings on changed files.

## Outstanding for follow-up PRs

The ~152-failure family remains open. Largest remaining buckets: `e_droptrigger.test` (~59, ATTACH #6193 + db-func TCL callbacks #5720), `e_dropview.test` (~25), `trigger1` shim TEMP-demotion artifacts + temp/main namespace (22.10), remaining `triggerC` (OR-REPLACE interleaving, BEFORE-trigger row-order UB, RAISE/ORDER-BY precedence).

Part of #6176.
