### PR TITLE
fix(parser): SQLite-compatible syntax errors for malformed CTE clauses

### DIFF
--- a/crates/vibesql-parser/src/arena_parser/select.rs
+++ b/crates/vibesql-parser/src/arena_parser/select.rs
@@ -329,6 +329,14 @@ impl<'arena> ArenaParser<'arena> {
 
         // Parse optional column list
         let columns = if self.try_consume(&Token::LParen) {
+            // An empty column list `t()` is a syntax error in SQLite. Reject it
+            // here so the whole WITH statement falls back to the standard parser,
+            // which reports the SQLite-compatible `near ")": syntax error`
+            // (with2.test 4.1). Without this, an empty list is silently accepted
+            // and the mismatch only surfaces later as a column-count error.
+            if matches!(self.peek(), Token::RParen) {
+                return Err(ParseError { message: self.peek().syntax_error() });
+            }
             let mut cols = BumpVec::new_in(self.arena);
             while let Token::Identifier(col) = self.peek() {
                 let col = col.clone();

--- a/crates/vibesql-parser/src/parser/select/statement.rs
+++ b/crates/vibesql-parser/src/parser/select/statement.rs
@@ -493,16 +493,21 @@ impl Parser {
                 self.advance();
                 name
             }
-            _ => return Err(ParseError { message: "Expected CTE name (identifier)".to_string() }),
+            // SQLite reports the offending token as `near "<tok>": syntax error`
+            // (e.g. a trailing comma in the WITH list, `WITH a AS (...), SELECT ...`,
+            // yields `near "SELECT": syntax error`) rather than an internal
+            // "Expected CTE name" phrasing (with1.test 3.6).
+            _ => return Err(ParseError { message: self.peek().syntax_error() }),
         };
 
         // Parse optional column list: (col1, col2, ...)
         let columns = if matches!(self.peek(), Token::LParen) {
             self.advance(); // consume '('
 
-            // Check for empty column list
+            // An empty column list `t()` is a syntax error in SQLite, reported
+            // against the `)` token: `near ")": syntax error` (with2.test 4.1).
             if matches!(self.peek(), Token::RParen) {
-                return Err(ParseError { message: "CTE column list cannot be empty".to_string() });
+                return Err(ParseError { message: self.peek().syntax_error() });
             }
 
             // Parse comma-separated list of column identifiers

--- a/crates/vibesql-parser/src/tests/cte.rs
+++ b/crates/vibesql-parser/src/tests/cte.rs
@@ -393,3 +393,36 @@ fn test_parse_cte_named_level() {
     let result = Parser::parse_sql("WITH level AS (SELECT 1) SELECT * FROM level;");
     assert!(result.is_ok(), "CTE named `level` should parse: {:?}", result);
 }
+
+#[test]
+fn test_parse_cte_trailing_comma_reports_offending_token() {
+    // A trailing comma in the WITH list leaves the parser expecting another CTE
+    // name; SQLite reports the offending token, not an internal expectation
+    // string: `near "SELECT": syntax error` (with1.test 3.6).
+    let result = Parser::parse_sql("WITH tmp AS ( SELECT 1 ), SELECT * FROM tmp;");
+    assert!(result.is_err(), "trailing comma in WITH list should not parse");
+    let msg = result.unwrap_err().message;
+    assert_eq!(msg, "near \"SELECT\": syntax error", "Unexpected error message: {}", msg);
+}
+
+#[test]
+fn test_parse_cte_empty_column_list_is_syntax_error() {
+    // An empty CTE column list `t()` is a syntax error reported against the `)`
+    // token in SQLite: `near ")": syntax error` (with2.test 4.1).
+    let result = Parser::parse_sql("WITH x() AS ( SELECT 1,2,3 ) SELECT * FROM x;");
+    assert!(result.is_err(), "empty CTE column list should not parse");
+    let msg = result.unwrap_err().message;
+    assert_eq!(msg, "near \")\": syntax error", "Unexpected error message: {}", msg);
+}
+
+#[test]
+fn test_parse_cte_empty_column_list_via_arena_fallback() {
+    // The arena parser handles `WITH ...` first; it must reject an empty column
+    // list so the statement falls back to the standard parser and surfaces the
+    // SQLite-compatible `near ")": syntax error` rather than silently accepting a
+    // zero-column CTE (with2.test 4.1).
+    let result = crate::parse_with_arena_fallback("WITH x() AS ( SELECT 1,2,3 ) SELECT * FROM x;");
+    assert!(result.is_err(), "empty CTE column list should not parse via arena fallback");
+    let msg = result.unwrap_err().message;
+    assert_eq!(msg, "near \")\": syntax error", "Unexpected error message: {}", msg);
+}


### PR DESCRIPTION
## Summary

Incremental CTE-conformance fix for the `with*.test` family (#6189). Two CTE-clause parse errors emitted VibeSQL-internal phrasings instead of SQLite's canonical `near "TOKEN": syntax error` form. Both now match SQLite exactly.

This is the failure cluster **"CTE-clause parser produces non-SQLite error messages."** The remaining with1 `10.x`/`10.8.x` failures are harness-proc-driven (they depend on the `insert_into_tree`/`scan_tree` TCL procs' `db one`/`last_insert_rowid`; the underlying recursive-path SQL passes when run directly) and the `3.x`/`5.1`/`19.1b`/`24.1` failures are EQP/VDBE-opcode assertions — both out of scope per the issue and PR #6243's note.

## Changes

- `crates/vibesql-parser/src/parser/select/statement.rs` — the standard parser's `parse_cte` now reports the offending token via `Token::syntax_error()` for both a missing CTE name (trailing comma in the WITH list) and an empty column list, replacing the internal `"Expected CTE name (identifier)"` / `"CTE column list cannot be empty"` strings.
- `crates/vibesql-parser/src/arena_parser/select.rs` — the arena parser (which handles `WITH` first) now rejects an empty column list `t()` instead of silently accepting a zero-column CTE, so the statement falls back to the standard parser and surfaces the SQLite-compatible message. The standard parser is thus the single source of truth for the error text.
- `crates/vibesql-parser/src/tests/cte.rs` — three regression cases: trailing-comma → `near "SELECT": syntax error`, empty column list → `near ")": syntax error` (via both `Parser::parse_sql` and `parse_with_arena_fallback`).

## Root-cause cluster mapping

| TCL test | Before | After (SQLite) |
| --- | --- | --- |
| with1.test 3.6 | `Expected CTE name (identifier)` | `near "SELECT": syntax error` |
| with2.test 4.1 | `table x has 3 values for 0 columns` (semantic, late) | `near ")": syntax error` |

## Acceptance Criteria Verification

- with1.test: **15 → 14** in-scope failures (3.6 fixed).
- with2.test: **6 → 5** in-scope failures (4.1 fixed).
- with3/with4/with5.test: unchanged (1 / 1 / 0) — no regressions.
- No previously-passing `with*.test` case regresses; valid CTEs (`WITH x(a,b) AS ...`, recursive CTEs, no-column-list CTEs) still parse and execute.

## Test Plan

- [x] `make test-tcl-file FILE=with1.test` … `with5.test` on a fresh `cargo build --release` — counts above.
- [x] `cargo test -p vibesql-parser cte` — 114 passed (incl. 3 new cases).
- [x] `cargo test -p vibesql-parser --lib` — 1827 passed.
- [x] `cargo test -p vibesql-executor recursive_cte` — 39/1/2/2 passed.
- [x] `cargo test -p vibesql-executor with_insert_cte` — 2 passed; `with_update_from_cte` — 7 passed.
- [x] Manual: malformed CTEs report the SQLite message; valid CTEs unaffected.

Part of #6189
Part of epic #5779

🤖 Generated with [Claude Code](https://claude.com/claude-code)