### PR TITLE
fix(pragma,storage): schema-qualified table_info + stop persisting shadowed TEMP tables

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -2148,25 +2148,22 @@ impl SqlExecutor {
             }
         };
 
-        // Schema-qualified pragma handling. Only "main" or the current schema
-        // refer to the available schema; anything else returns an empty result
-        // (SQLite returns no rows for a missing table in table_info, no error).
-        let current_schema = self.db.catalog.get_current_schema().to_string();
-        if let Some(ref schema) = stmt.database {
-            let is_current =
-                schema.eq_ignore_ascii_case(&current_schema) || schema.eq_ignore_ascii_case("main");
-            if !is_current {
-                return Ok(QueryResult {
-                    columns,
-                    rows: Vec::new(),
-                    row_count: 0,
-                    execution_time_ms: None,
-                    message: None,
-                });
-            }
-        }
-
-        let schema = match self.db.catalog.get_table(&table_name) {
+        // Schema-qualified table resolution. A bare `PRAGMA table_info(t)` follows
+        // SQLite's shadowing rule — a TEMP table hides a main-schema table of the
+        // same name — via the catalog's temp-first `get_table`. A schema-qualified
+        // form instead pins the lookup to that schema: `PRAGMA temp.table_info(t)`
+        // reads the TEMP table and `PRAGMA main.table_info(t)` reads the
+        // main-schema table even when a TEMP table of the same name shadows it
+        // (ticket #3320; pragma-6.6.3 / pragma-6.6.4). Routing the qualifier
+        // straight through `get_table` (which resolves `temp` to this session's
+        // temp schema and `main` to the default schema) yields the correct table
+        // for each; an unknown schema resolves to nothing and produces an empty
+        // result — SQLite reports no rows, not an error, for a missing table.
+        let lookup = match &stmt.database {
+            Some(db) => format!("{}.{}", db, table_name),
+            None => table_name.clone(),
+        };
+        let schema = match self.db.catalog.get_table(&lookup) {
             Some(s) => s,
             None => {
                 // SQLite returns empty result for table_info on a missing table.

--- a/crates/vibesql-storage/src/persistence/binary/catalog.rs
+++ b/crates/vibesql-storage/src/persistence/binary/catalog.rs
@@ -62,8 +62,17 @@ pub fn write_catalog<W: Write>(writer: &mut W, db: &Database) -> Result<(), Stor
     let table_names = db.catalog.list_tables();
     write_u32(writer, table_names.len() as u32)?;
 
+    // `list_tables()` returns only the current (main) schema's tables, but the
+    // bare-name `db.get_table` applies SQLite temp-shadowing — a same-named TEMP
+    // table wins. Persisting through the bare lookup therefore serialized an
+    // ephemeral TEMP table's schema under the main table's name, clobbering the
+    // real main-schema table in the checkpoint (pragma-6.6.4; a TEMP table must
+    // never be persisted). Qualify the lookup with the current schema so the
+    // main-schema table is always the one written.
+    let current_schema = db.catalog.get_current_schema().to_string();
     for table_name in &table_names {
-        if let Some(table) = db.get_table(table_name) {
+        let qualified_name = format!("{}.{}", current_schema, table_name);
+        if let Some(table) = db.get_table(&qualified_name) {
             write_string(writer, table_name)?;
 
             // Write column count

--- a/crates/vibesql-storage/src/persistence/binary/data.rs
+++ b/crates/vibesql-storage/src/persistence/binary/data.rs
@@ -79,8 +79,14 @@ fn read_row_version_prefix<R: Read>(
 pub fn write_data<W: Write>(writer: &mut W, db: &Database) -> Result<(), StorageError> {
     let table_names = db.catalog.list_tables();
 
+    // Qualify with the current schema so temp-shadowing does not substitute an
+    // ephemeral TEMP table's rows for the same-named main-schema table's rows
+    // (mirrors the schema-write fix for pragma-6.6.4; a TEMP table is never
+    // persisted). `list_tables()` yields only current-schema names.
+    let current_schema = db.catalog.get_current_schema().to_string();
     for table_name in table_names {
-        if let Some(table) = db.get_table(&table_name) {
+        let qualified_name = format!("{}.{}", current_schema, table_name);
+        if let Some(table) = db.get_table(&qualified_name) {
             // Write table name
             write_string(writer, &table_name)?;
 

--- a/crates/vibesql-storage/src/persistence/tests/binary_persistence.rs
+++ b/crates/vibesql-storage/src/persistence/tests/binary_persistence.rs
@@ -128,6 +128,62 @@ fn test_binary_file_roundtrip_preserves_verbatim_sql_source() {
     std::fs::remove_file(path).ok();
 }
 
+/// Regression (pragma-6.6.4): a session-scoped TEMP table must never be
+/// persisted, and in particular a TEMP table that shadows a same-named
+/// main-schema table must not clobber the main table in the binary snapshot
+/// (the format used by the WAL checkpoint). Before the fix, `write_catalog` and
+/// `write_data` enumerated the current schema's table names but fetched each
+/// through the temp-first `get_table`, so a shadowing TEMP table's schema and
+/// rows were serialized under the main table's name — silently corrupting the
+/// persisted main table on the next checkpoint.
+#[test]
+fn test_temp_table_does_not_clobber_shadowed_main_table_on_save() {
+    let mut db = Database::new();
+
+    // Main-schema table `trial(col_main)` with one row (insert before the temp
+    // table exists so the unqualified insert lands in the main table).
+    let main_schema = TableSchema::new(
+        "trial".to_string(),
+        vec![ColumnSchema::new("col_main".to_string(), DataType::Integer, true)],
+    );
+    db.create_table_with_identifier(main_schema, TableIdentifier::new("trial", false)).unwrap();
+    db.get_table_mut("trial").unwrap().insert(crate::Row::new(vec![SqlValue::Integer(1)])).unwrap();
+
+    // Same-named TEMP table `trial(col_temp)` in this session's temp schema.
+    let temp_schema_name = db.catalog.temp_schema_name().to_string();
+    let temp_schema = TableSchema::new(
+        "trial".to_string(),
+        vec![ColumnSchema::new("col_temp".to_string(), DataType::Integer, true)],
+    );
+    db.create_table_with_identifier(
+        temp_schema,
+        TableIdentifier::qualified(&temp_schema_name, false, "trial", false),
+    )
+    .unwrap();
+
+    // Precondition: the unqualified lookup now sees the TEMP table (shadowing).
+    assert_eq!(
+        db.get_table("trial").unwrap().schema.columns[0].name,
+        "col_temp",
+        "precondition: temp table shadows main for unqualified lookup"
+    );
+
+    let path = "/tmp/test_temp_shadow_no_clobber_roundtrip.vbsql";
+    db.save_binary(path).unwrap();
+    let loaded = Database::load_binary(path).unwrap();
+
+    // The persisted `trial` must be the MAIN table (col_main) with its row; the
+    // TEMP table must not have survived the save/reload at all.
+    let table = loaded.get_table("trial").expect("main trial must survive the round-trip");
+    assert_eq!(
+        table.schema.columns[0].name, "col_main",
+        "persisted table must be the main-schema table, not the shadowing temp table"
+    );
+    assert_eq!(table.row_count(), 1, "main table's row must survive, not the temp table's rows");
+
+    std::fs::remove_file(path).ok();
+}
+
 /// Test that unquoted tables remain unquoted through roundtrip
 #[test]
 fn test_unquoted_table_identifier_roundtrip() {


### PR DESCRIPTION
## Summary

Partial increment for the PRAGMA family issue (#6175). Fixes the temp-vs-main
schema-qualified `PRAGMA table_info` shadowing slice (pragma-6.6.3 / pragma-6.6.4),
which turned out to also expose — and this PR fixes — a silent data-corruption
bug where a session-scoped TEMP table could clobber a same-named main table in
the persisted snapshot.

`pragma.test`: **77 -> 79 passing** (pragma-6.6.3 and pragma-6.6.4 now green).

## Changes

- **`crates/vibesql-cli/src/executor/mod.rs`** — `execute_pragma_table_info` now
  routes a schema qualifier (`PRAGMA temp.table_info(t)` / `PRAGMA main.table_info(t)`)
  straight through the catalog's `get_table`, which resolves `temp` to the
  session temp schema and `main` to the default schema. The old code treated
  `temp.` as a non-current schema (returned empty → 6.6.3 failed) and let `main.`
  fall through to the temp-shadowing bare lookup (returned the temp table → 6.6.4
  failed). An unknown schema still resolves to nothing → empty result (SQLite
  reports no rows, not an error, for a missing table). Ticket #3320.

- **`crates/vibesql-storage/src/persistence/binary/catalog.rs` + `data.rs`** —
  root cause of pragma-6.6.4: the binary snapshot writer (the format the WAL
  checkpoint uses) enumerated the current schema's table *names* but fetched each
  table through the temp-first `get_table`, so a TEMP table shadowing a same-named
  main table was serialized under the main table's name — corrupting the persisted
  main table on the next checkpoint. Both writers now qualify the lookup with the
  current schema, so a TEMP table is never persisted and never overwrites the
  main-schema table. (TEMP tables were already excluded from the WAL op log; only
  the checkpoint snapshot path had the leak.)

- **`crates/vibesql-storage/src/persistence/tests/binary_persistence.rs`** —
  regression test: a TEMP table shadowing a main table must not survive/clobber
  a `save_binary` → `load_binary` round-trip.

## Acceptance Criteria Verification

- `PRAGMA temp.table_info(trial)` → temp table columns (pragma-6.6.3 passes).
- `PRAGMA main.table_info(trial)` → main table columns even when a TEMP table
  shadows it (pragma-6.6.4 passes).
- A TEMP table is never written to the persisted `.vbsql` snapshot.

## Test Plan

- `make test-tcl-file FILE=pragma.test`: **77 -> 79** passing (6.6.3, 6.6.4).
- Regression files unchanged: `colname` 64, `default` 2/0, `intpkey` 84/0,
  `e_createtable` 337/144, `pragma2` 1/17, `pragma3` 11/13, `pragma4` 7/15.
- `where.test` 168/0, `select1.test` 188/0 (temp/persistence sanity) — clean.
- `cargo test -p vibesql-storage -p vibesql-cli`: all pass (new regression test
  included).

## Remaining in-scope slices for the next increment
- `user_version` / `schema_version` / `application_id` (pragma-8): need DB-header
  value persistence across the shim's per-process model (and schema_version's
  increment-on-DDL). Currently unimplemented — `PRAGMA user_version` returns
  nothing instead of `0`.
- raw-protocol empty-vs-NULL rendering in the shim (pragma-6.2.2).

## Bucket-A (route to #6154, do NOT force green)
Genuinely pager/journal-internal or corruption-harness PRAGMAs remain out of
scope: `cache_size`/`default_cache_size`/`synchronous` (pragma-1/5),
`page_size`/`page_count` (pragma-14), `freelist_count`/`cache_spill`/`lock_status`
(pragma2), proxy locking (pragma-16), the `integrity_check` B-tree corruption
harness (pragma-3.*, needs on-disk page corruption VibeSQL has no equivalent for),
and the C-API/`btree_from_db`/testvfs cases (pragma-9, pragma-19). pragma3
cross-connection `data_version` and pragma4 ATTACH/EXPLAIN cases are shim/C-API
limitations.

Part of #6175