### PR TITLE
fix(executor,cli): UPDATE OR FAIL partial-apply + persist-on-error

### DIFF
--- a/crates/vibesql-cli/src/script.rs
+++ b/crates/vibesql-cli/src/script.rs
@@ -137,48 +137,7 @@ impl ScriptExecutor {
                 Ok(result) => {
                     self.formatter.print_result(&result);
                     success_count += 1;
-
-                    // Auto-save after modification statements if database path is provided.
-                    //
-                    // CRITICAL: Skip auto-save while a transaction is open. Persisting
-                    // uncommitted changes turns ROLLBACK into a no-op across CLI
-                    // invocations — the .vbsql dump captures the mid-transaction state
-                    // and the next process loads it as committed. This silently broke
-                    // deferred-FK semantics in the batched TCL shim path (every fkey6
-                    // test that ran ROLLBACK after an INSERT/UPDATE/DELETE was
-                    // observed to have lost data despite the rollback succeeding
-                    // in memory). The next save naturally happens at COMMIT or
-                    // ROLLBACK statement boundary, both of which match
-                    // `is_modification_statement` only if we add them — instead, we
-                    // also force a save when the transaction state transitions back
-                    // to "no active transaction" after this statement.
-                    if let Some(ref path) = self.database_path {
-                        let in_txn = self.executor.in_transaction();
-                        let should_save = is_modification_statement(stmt) && !in_txn;
-                        // Also save on the COMMIT/ROLLBACK boundary so the
-                        // post-commit (or post-rollback) state is durable.
-                        let upper = stmt.trim().to_uppercase();
-                        let is_txn_end = !in_txn
-                            && (upper.starts_with("COMMIT")
-                                || upper.starts_with("ROLLBACK")
-                                || upper.starts_with("END"));
-                        if should_save || is_txn_end {
-                            match self.executor.save_database(path) {
-                                Ok(()) => persist_failed = false,
-                                Err(e) => {
-                                    // Loud + fail-closed (issue #5832): the WAL
-                                    // is never truncated on a failed checkpoint,
-                                    // and the process must exit non-zero.
-                                    persist_failed = true;
-                                    crate::util::report_save_failure(
-                                        path,
-                                        self.executor.wal_active(),
-                                        &e,
-                                    );
-                                }
-                            }
-                        }
-                    }
+                    self.maybe_save_after_statement(stmt, &mut persist_failed);
                 }
                 Err(e) => {
                     eprintln!(
@@ -186,6 +145,25 @@ impl ScriptExecutor {
                         vibe_msg!("script-error", index = (idx + 1) as i64, error = e.to_string())
                     );
                     error_count += 1;
+
+                    // A top-level statement that returns an error can still have
+                    // legitimately applied (and kept) some changes in memory: an
+                    // `OR FAIL` conflict clause stops at the offending row but
+                    // keeps every row applied before it (R-28518-13457), and the
+                    // per-statement transaction-scope wrapper
+                    // (`raise_scope::run_top_level_dml_with_conflict_scope`) has
+                    // already decided, before returning here, whether to commit
+                    // that partial state or roll it back to the pre-statement
+                    // snapshot. Either way, the in-memory `Database` is now the
+                    // authoritative final state for this statement — persist it
+                    // exactly like a successful statement would, so a partial
+                    // `OR FAIL` apply survives across the process boundary
+                    // instead of being silently discarded when this process
+                    // exits without saving (issue #6193). For every other error
+                    // (full rollback already applied in-memory) this just
+                    // re-persists the unchanged prior state — a no-op.
+                    self.maybe_save_after_statement(stmt, &mut persist_failed);
+
                     // SQLite compatibility:
                     //   - Outside a transaction: stop on first error (issue #4731).
                     //     SQLite's TCL interface and CLI both stop execution on
@@ -225,6 +203,51 @@ impl ScriptExecutor {
             Err(anyhow::anyhow!("failed to persist database changes; see the ERROR output above"))
         } else {
             Ok(())
+        }
+    }
+
+    /// Auto-save after a modification statement, if a database path was
+    /// provided — called after BOTH a successful and a failed
+    /// `self.executor.execute(stmt)`, since the in-memory `Database` is the
+    /// authoritative final state either way (see the call sites for why an
+    /// erroring statement can still need this, e.g. `OR FAIL`).
+    ///
+    /// CRITICAL: Skip auto-save while a transaction is open. Persisting
+    /// uncommitted changes turns ROLLBACK into a no-op across CLI
+    /// invocations — the .vbsql dump captures the mid-transaction state
+    /// and the next process loads it as committed. This silently broke
+    /// deferred-FK semantics in the batched TCL shim path (every fkey6
+    /// test that ran ROLLBACK after an INSERT/UPDATE/DELETE was
+    /// observed to have lost data despite the rollback succeeding
+    /// in memory). The next save naturally happens at COMMIT or
+    /// ROLLBACK statement boundary, both of which match
+    /// `is_modification_statement` only if we add them — instead, we
+    /// also force a save when the transaction state transitions back
+    /// to "no active transaction" after this statement.
+    fn maybe_save_after_statement(&mut self, stmt: &str, persist_failed: &mut bool) {
+        let Some(path) = self.database_path.clone() else {
+            return;
+        };
+        let in_txn = self.executor.in_transaction();
+        let should_save = is_modification_statement(stmt) && !in_txn;
+        // Also save on the COMMIT/ROLLBACK boundary so the
+        // post-commit (or post-rollback) state is durable.
+        let upper = stmt.trim().to_uppercase();
+        let is_txn_end = !in_txn
+            && (upper.starts_with("COMMIT")
+                || upper.starts_with("ROLLBACK")
+                || upper.starts_with("END"));
+        if should_save || is_txn_end {
+            match self.executor.save_database(&path) {
+                Ok(()) => *persist_failed = false,
+                Err(e) => {
+                    // Loud + fail-closed (issue #5832): the WAL
+                    // is never truncated on a failed checkpoint,
+                    // and the process must exit non-zero.
+                    *persist_failed = true;
+                    crate::util::report_save_failure(&path, self.executor.wal_active(), &e);
+                }
+            }
         }
     }
 

--- a/crates/vibesql-executor/src/tests/or_fail_or_rollback_conflict_scope.rs
+++ b/crates/vibesql-executor/src/tests/or_fail_or_rollback_conflict_scope.rs
@@ -82,6 +82,79 @@ fn insert_or_fail_keeps_rows_applied_before_the_conflict() {
 }
 
 #[test]
+fn update_or_fail_surfaces_not_null_violation_on_a_later_row() {
+    // Doctor regression for #6193: `UPDATE OR FAIL` that hits a NOT NULL
+    // violation on a NON-first row must (a) keep the rows updated before it and
+    // (b) still surface the NOT NULL error — not silently report success.
+    //
+    // The bug: the collect loop stashed `fail_error = Some(NOT NULL...)` and
+    // broke, but the unconditional `fail_error = truncate_updates_for_or_fail(..)`
+    // that follows overwrote it back to `None` whenever the collected prefix had
+    // no PK/UNIQUE conflict among itself (the common case) — discarding the real
+    // error. Here row 1's update is applied, row 2 (b -> NULL) is the offending
+    // row, and there is no PK/UNIQUE conflict in the kept prefix.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(a INTEGER PRIMARY KEY, b INTEGER NOT NULL)").unwrap();
+    exec(&mut db, "INSERT INTO t VALUES(1,1),(2,2),(3,3)").unwrap();
+
+    let err = exec(
+        &mut db,
+        "UPDATE OR FAIL t SET b = CASE a WHEN 1 THEN 100 WHEN 2 THEN NULL ELSE 300 END",
+    )
+    .unwrap_err();
+    assert!(
+        err.contains("NOT NULL constraint failed"),
+        "expected a NOT NULL error, got: {err}"
+    );
+
+    // Row 1's update (b = 100) was applied before the offending row and is kept;
+    // rows 2 and 3 are untouched (the statement stopped at row 2).
+    assert_eq!(
+        query_all(&db, "SELECT a, b FROM t ORDER BY a"),
+        vec![
+            SqlValue::Integer(1),
+            SqlValue::Integer(100),
+            SqlValue::Integer(2),
+            SqlValue::Integer(2),
+            SqlValue::Integer(3),
+            SqlValue::Integer(3),
+        ]
+    );
+}
+
+#[test]
+fn update_or_fail_surfaces_not_null_violation_without_a_primary_key() {
+    // Same as above but with no PRIMARY KEY / UNIQUE key space at all, so
+    // `truncate_updates_for_or_fail` returns `None` via its empty-key-spaces
+    // early-out — the pre-existing NOT NULL error must survive that path too.
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t2(a INTEGER, b INTEGER NOT NULL)").unwrap();
+    exec(&mut db, "INSERT INTO t2 VALUES(1,1),(2,2),(3,3)").unwrap();
+
+    let err = exec(
+        &mut db,
+        "UPDATE OR FAIL t2 SET b = CASE a WHEN 1 THEN 100 WHEN 2 THEN NULL ELSE 300 END",
+    )
+    .unwrap_err();
+    assert!(
+        err.contains("NOT NULL constraint failed"),
+        "expected a NOT NULL error, got: {err}"
+    );
+
+    assert_eq!(
+        query_all(&db, "SELECT a, b FROM t2 ORDER BY a"),
+        vec![
+            SqlValue::Integer(1),
+            SqlValue::Integer(100),
+            SqlValue::Integer(2),
+            SqlValue::Integer(2),
+            SqlValue::Integer(3),
+            SqlValue::Integer(3),
+        ]
+    );
+}
+
+#[test]
 fn insert_default_abort_still_discards_the_whole_statement() {
     // Regression guard: without an OR clause (default ABORT), a multi-row
     // conflict must still roll back every row the statement applied,

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -618,13 +618,27 @@ pub(super) fn execute_internal(
             let table_for_check = database
                 .get_table(table_name)
                 .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
-            fail_error = index_sync::truncate_updates_for_or_fail(
+
+            // `fail_error` may already hold a NOT NULL / CHECK violation stashed
+            // by the collect loop when it `break`ed at the offending row (rows
+            // before it are kept in `updates`). `truncate_updates_for_or_fail`
+            // must still run — a PK/UNIQUE conflict among that already-collected
+            // prefix happens at an EARLIER row than the NOT NULL/CHECK stop and
+            // so takes precedence, cutting `updates` even shorter. But when it
+            // finds no such conflict it returns `None`, and that `None` must NOT
+            // clobber the pre-existing NOT NULL/CHECK error — otherwise the whole
+            // statement silently reports success (the #6193 doctor bug). So only
+            // let a Some(err) result replace `fail_error`; keep the original
+            // otherwise.
+            if let Some(err) = index_sync::truncate_updates_for_or_fail(
                 &mut updates,
                 schema,
                 table_for_check,
                 database,
                 table_name,
-            );
+            ) {
+                fail_error = Some(err);
+            }
 
             // Rowid relocation conflicts keep the existing all-or-nothing check
             // (a narrower, documented gap — not exercised by e_update.test): if

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -23,7 +23,7 @@ use super::{
     foreign_keys::ForeignKeyValidator,
     from_clause::{apply_update_from_matches, execute_update_from_join},
     index_sync::{
-        detect_surviving_replace_conflict, find_conflicting_rows_for_update,
+        self, detect_surviving_replace_conflict, find_conflicting_rows_for_update,
         resolve_cross_update_conflicts_for_replace, validate_cross_update_uniqueness,
         validate_post_statement_uniqueness, validate_rowid_relocation, validate_unique_relocation,
     },
@@ -365,6 +365,31 @@ pub(super) fn execute_internal(
     // Check conflict resolution clause
     let use_ignore = matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Ignore));
     let use_replace = matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Replace));
+    let use_fail = matches!(stmt.conflict_clause, Some(vibesql_ast::ConflictClause::Fail));
+
+    // `UPDATE OR FAIL` (SQLite conflict-resolution algorithm): a constraint
+    // violation stops the statement at the offending row, but — unlike the
+    // default ABORT — the rows already collected/applied before that row are
+    // KEPT rather than rolled back (e_update-1.8.3/1.8.9). This mirrors the
+    // already-correct `INSERT OR FAIL` behavior (#6275).
+    //
+    // The general UPDATE path defers PK/UNIQUE checking to a post-statement
+    // pass so permutation-style statements like `UPDATE p SET a = a - 1`
+    // succeed even with transient intermediate duplicates (#5137). That
+    // deferred, all-or-nothing model is incompatible with OR FAIL's
+    // keep-the-prefix semantics, so OR FAIL uses a separate, truncating
+    // uniqueness check (`truncate_updates_for_or_fail`) instead.
+    //
+    // Scoped to the simple, unambiguous case — no triggers (so there is no
+    // interleaved BEFORE/AFTER row-trigger mutation to reconcile with a
+    // truncated update list) and no foreign keys on this table (so there are
+    // no deferred-FK-violation entries that would need to be un-queued for a
+    // truncated-away row). Rowid relocation conflicts still use the existing
+    // all-or-nothing check below (a narrower, documented gap not exercised by
+    // e_update.test). OR FAIL statements outside this scope keep the existing
+    // (safe) all-or-nothing behavior, matching pre-#6193 semantics.
+    let use_fail_partial = use_fail && !has_triggers && schema.foreign_keys.is_empty();
+    let mut fail_error: Option<ExecutorError> = None;
 
     // Step 6: Build list of updates (two-phase execution for SQL semantics)
     // Each `PendingUpdate` carries: row_index, old_row, new_row, changed_columns, updates_pk.
@@ -518,6 +543,32 @@ pub(super) fn execute_internal(
                 )?;
                 pending_deferred_violations.extend(deferred);
             }
+        } else if use_fail_partial {
+            // OR FAIL (no triggers, no FKs on this table — see `use_fail_partial`
+            // above): stop collecting at the first NOT NULL / CHECK violation but
+            // KEEP the rows already collected, instead of propagating the error
+            // and discarding everything via `?`. PK/UNIQUE conflicts are handled
+            // afterward by `truncate_updates_for_or_fail`, which can also cut the
+            // list shorter than this loop does.
+            if let Err(e) = constraint_validator.validate_row_skip_uniqueness(table_name, &new_row)
+            {
+                fail_error = Some(e);
+                break;
+            }
+
+            // Non-deterministic date/time uses in index expressions / partial-
+            // index predicates are NOT a resolvable conflict — SQLite aborts the
+            // whole statement even under OR FAIL (mirrors OR IGNORE/OR REPLACE
+            // above, issue #5324).
+            crate::insert::constraints::enforce_index_expression_determinism(
+                database,
+                schema,
+                table_name,
+                &new_row.values,
+            )?;
+
+            // `use_fail_partial` guarantees `schema.foreign_keys.is_empty()`, so
+            // there is nothing to validate/queue here.
         } else {
             // Default: validate NOT NULL and CHECK per-row.
             // PRIMARY KEY / UNIQUE checks are deferred to a post-statement pass
@@ -558,49 +609,74 @@ pub(super) fn execute_internal(
         });
     }
 
-    // Cross-update uniqueness validation: check if multiple updates would produce
-    // the same PK or UNIQUE constraint values. This must be done after collecting
-    // all updates but before applying them to ensure SQL's two-phase semantics.
-    // Skip for REPLACE mode since conflicts will be resolved by deletion.
-    if !use_replace && !use_ignore && updates.len() > 1 {
-        validate_cross_update_uniqueness(&updates, schema)?;
-    }
+    if use_fail_partial {
+        // OR FAIL: replace the deferred, all-or-nothing PK/UNIQUE checks with an
+        // immediate, truncating check — a conflict on a later row keeps the
+        // earlier rows' changes (and the ones already collected up to it)
+        // instead of rolling back the whole statement (e_update-1.8.3/1.8.9).
+        if !updates.is_empty() {
+            let table_for_check = database
+                .get_table(table_name)
+                .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
+            fail_error = index_sync::truncate_updates_for_or_fail(
+                &mut updates,
+                schema,
+                table_for_check,
+                database,
+                table_name,
+            );
 
-    // Deferred uniqueness check (issue #5137): validate PK / UNIQUE / user-defined unique
-    // indexes against the post-statement table state. Rows that are themselves being
-    // updated to a different key are excluded from "existing" entries, allowing
-    // statements like `UPDATE p SET a = a - 1` to succeed even when intermediate
-    // states transiently duplicate keys.
-    //
-    // Skipped for IGNORE/REPLACE since those modes use per-row validation/resolution.
-    if !use_replace && !use_ignore && !updates.is_empty() {
-        // Re-borrow the table — `database` may have been mutated above for REPLACE,
-        // and we need an immutable read of the current PK/UNIQUE indexes.
-        let table_for_check = database
-            .get_table(table_name)
-            .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
-        validate_post_statement_uniqueness(
-            &updates,
-            schema,
-            table_for_check,
-            database,
-            table_name,
-        )?;
+            // Rowid relocation conflicts keep the existing all-or-nothing check
+            // (a narrower, documented gap — not exercised by e_update.test): if
+            // no PK/UNIQUE truncation already happened, a rowid-relocation
+            // conflict still aborts the whole statement rather than partially
+            // applying.
+            if fail_error.is_none() {
+                validate_rowid_relocation(&updates, schema, table_for_check)?;
+            }
+        }
+    } else if !use_replace && !use_ignore {
+        // Cross-update uniqueness validation: check if multiple updates would produce
+        // the same PK or UNIQUE constraint values. This must be done after collecting
+        // all updates but before applying them to ensure SQL's two-phase semantics.
+        if updates.len() > 1 {
+            validate_cross_update_uniqueness(&updates, schema)?;
+        }
 
-        // Explicit `UPDATE ... SET rowid = <expr>` on a virtual-rowid table
-        // (no INTEGER PRIMARY KEY): relocating onto a rowid another live row
-        // already occupies is `UNIQUE constraint failed: <table>.rowid` in
-        // sqlite3 (triggerC-7.x). IPK tables write the real PK column and are
-        // covered by the PK check above.
-        validate_rowid_relocation(&updates, schema, table_for_check)?;
+        // Deferred uniqueness check (issue #5137): validate PK / UNIQUE / user-defined unique
+        // indexes against the post-statement table state. Rows that are themselves being
+        // updated to a different key are excluded from "existing" entries, allowing
+        // statements like `UPDATE p SET a = a - 1` to succeed even when intermediate
+        // states transiently duplicate keys.
+        if !updates.is_empty() {
+            // Re-borrow the table — `database` may have been mutated above for REPLACE,
+            // and we need an immutable read of the current PK/UNIQUE indexes.
+            let table_for_check = database
+                .get_table(table_name)
+                .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
+            validate_post_statement_uniqueness(
+                &updates,
+                schema,
+                table_for_check,
+                database,
+                table_name,
+            )?;
 
-        // Regular (non-rowid) UNIQUE / PRIMARY KEY columns also get sqlite3's
-        // IMMEDIATE row-by-row intermediate-collision check (issue #5588): a
-        // single-statement swap / ascending-shift on a UNIQUE column errors even
-        // though its FINAL state is duplicate-free. The deferred validator above
-        // still permits #5137 descending-shift / negation cases that sqlite3
-        // accepts; this additive check only rejects what sqlite3 rejects.
-        validate_unique_relocation(&updates, schema, table_for_check, database, table_name)?;
+            // Explicit `UPDATE ... SET rowid = <expr>` on a virtual-rowid table
+            // (no INTEGER PRIMARY KEY): relocating onto a rowid another live row
+            // already occupies is `UNIQUE constraint failed: <table>.rowid` in
+            // sqlite3 (triggerC-7.x). IPK tables write the real PK column and are
+            // covered by the PK check above.
+            validate_rowid_relocation(&updates, schema, table_for_check)?;
+
+            // Regular (non-rowid) UNIQUE / PRIMARY KEY columns also get sqlite3's
+            // IMMEDIATE row-by-row intermediate-collision check (issue #5588): a
+            // single-statement swap / ascending-shift on a UNIQUE column errors even
+            // though its FINAL state is duplicate-free. The deferred validator above
+            // still permits #5137 descending-shift / negation cases that sqlite3
+            // accepts; this additive check only rejects what sqlite3 rejects.
+            validate_unique_relocation(&updates, schema, table_for_check, database, table_name)?;
+        }
     }
 
     // For REPLACE: handle cross-update conflicts by keeping only the last update
@@ -1135,6 +1211,14 @@ pub(super) fn execute_internal(
     } else {
         None
     };
+
+    // OR FAIL: the rows collected before the offending row (if any) have
+    // already been applied by the write path above, matching SQLite's "keep
+    // prior changes" semantics; surface the stashed violation now instead of
+    // reporting success (mirrors `INSERT OR FAIL`, #6275).
+    if let Some(e) = fail_error {
+        return Err(e);
+    }
 
     Ok((update_count, returning))
 }

--- a/crates/vibesql-executor/src/update/index_sync.rs
+++ b/crates/vibesql-executor/src/update/index_sync.rs
@@ -278,6 +278,174 @@ pub(super) fn detect_surviving_replace_conflict(
     Ok(())
 }
 
+/// For `UPDATE OR FAIL`: truncate `updates` to the longest prefix (in the
+/// given order) whose PRIMARY KEY / table-level UNIQUE / user-defined UNIQUE
+/// index values can all be applied without an immediate conflict, and return
+/// the constraint-violation error for the first row that could not be
+/// applied (if any).
+///
+/// Unlike [`validate_post_statement_uniqueness`] / [`validate_unique_relocation`]
+/// (which check the whole batch and either accept it all or reject it all),
+/// this implements sqlite3's real per-row, immediate (non-deferred) semantics
+/// for `OR FAIL`: rows are conceptually applied one at a time, each vacating
+/// its OLD key and occupying its NEW key, and the first row whose NEW key is
+/// still occupied at that moment stops the statement — but every row *before*
+/// it keeps its change (R-28518-13457's "OR FAIL" behavior, e_update-1.8.3 /
+/// e_update-1.8.9).
+///
+/// Assumes `updates` is already in the table's natural (ascending physical /
+/// rowid) scan order, matching how the caller collected it and how sqlite3
+/// itself visits rows for an UPDATE with no explicit ORDER BY.
+///
+/// The rowid / INTEGER PRIMARY KEY alias is intentionally NOT covered here —
+/// callers should still run [`validate_rowid_relocation`] (all-or-nothing)
+/// afterward for that narrower case, not exercised by `e_update.test`.
+pub(super) fn truncate_updates_for_or_fail(
+    updates: &mut Vec<PendingUpdate>,
+    schema: &TableSchema,
+    table: &Table,
+    database: &Database,
+    table_name: &str,
+) -> Option<ExecutorError> {
+    if updates.is_empty() {
+        return None;
+    }
+
+    // Key spaces to check, mirroring `validate_unique_relocation`: PRIMARY KEY
+    // (skipped when it is the rowid alias — that is `validate_rowid_relocation`'s
+    // job), table-level UNIQUE(...) constraints, and CREATE UNIQUE INDEX
+    // indexes with no expression columns. Each entry is (column indices,
+    // already-qualified conflict label for the error message).
+    let mut key_spaces: Vec<(Vec<usize>, String)> = Vec::new();
+
+    if schema.rowid_alias_column.is_none() {
+        if let (Some(pk_indices), Some(pk_cols)) =
+            (schema.get_primary_key_indices(), schema.primary_key.as_ref())
+        {
+            let label = pk_cols
+                .iter()
+                .map(|c| format!("{}.{}", schema.name, c))
+                .collect::<Vec<_>>()
+                .join(", ");
+            key_spaces.push((pk_indices, label));
+        }
+    }
+
+    let unique_constraint_indices = schema.get_unique_constraint_indices();
+    for (constraint_idx, unique_indices) in unique_constraint_indices.iter().enumerate() {
+        let label = schema.unique_constraints[constraint_idx]
+            .iter()
+            .map(|c| format!("{}.{}", schema.name, c))
+            .collect::<Vec<_>>()
+            .join(", ");
+        key_spaces.push((unique_indices.clone(), label));
+    }
+
+    for index_name in database.list_indexes_for_table(table_name) {
+        let index_metadata = match database.get_index(&index_name) {
+            Some(m) => m,
+            None => continue,
+        };
+        if !index_metadata.unique {
+            continue;
+        }
+        let mut col_idxs: Vec<usize> = Vec::with_capacity(index_metadata.columns.len());
+        let mut is_expression_index = false;
+        for ic in &index_metadata.columns {
+            if ic.get_expression().is_some() {
+                is_expression_index = true;
+                break;
+            }
+            match ic.column_name().and_then(|cn| schema.get_column_index(cn)) {
+                Some(ci) => col_idxs.push(ci),
+                None => {
+                    is_expression_index = true;
+                    break;
+                }
+            }
+        }
+        if is_expression_index {
+            continue;
+        }
+        let label = index_metadata
+            .columns
+            .iter()
+            .map(|col| format!("{}.{}", table_name, col.column_name().unwrap_or("?")))
+            .collect::<Vec<_>>()
+            .join(", ");
+        key_spaces.push((col_idxs, label));
+    }
+
+    if key_spaces.is_empty() {
+        return None;
+    }
+
+    // Seed each key space's "occupied" set from the current live table (the
+    // pre-statement baseline — nothing has been applied yet at this point).
+    let mut occupied: Vec<HashSet<Vec<SqlValue>>> = key_spaces
+        .iter()
+        .map(|(col_idxs, _)| {
+            table
+                .scan_live()
+                .map(|(_, row)| {
+                    col_idxs.iter().map(|&i| row.values[i].clone()).collect::<Vec<SqlValue>>()
+                })
+                .filter(|k: &Vec<SqlValue>| !k.contains(&SqlValue::Null))
+                .collect::<HashSet<_>>()
+        })
+        .collect();
+
+    let mut cut_at: Option<(usize, ExecutorError)> = None;
+    let key_of = |col_idxs: &[usize], row: &Row| -> Vec<SqlValue> {
+        col_idxs.iter().map(|&c| row.values[c].clone()).collect()
+    };
+
+    'rows: for (i, u) in updates.iter().enumerate() {
+        // Check every key space before committing any of them, so a row that
+        // conflicts in one key space isn't half-applied to the others.
+        for (ks_idx, (col_idxs, label)) in key_spaces.iter().enumerate() {
+            let new_key = key_of(col_idxs, &u.new_row);
+            let old_key = key_of(col_idxs, &u.old_row);
+            if new_key == old_key || new_key.contains(&SqlValue::Null) {
+                continue;
+            }
+            if occupied[ks_idx].contains(&new_key) {
+                cut_at = Some((
+                    i,
+                    ExecutorError::ConstraintViolation(format!(
+                        "UNIQUE constraint failed: {}",
+                        label
+                    )),
+                ));
+                break 'rows;
+            }
+        }
+
+        // No conflict: commit this row's vacate-then-occupy for every key
+        // space it actually changes.
+        for (ks_idx, (col_idxs, _)) in key_spaces.iter().enumerate() {
+            let new_key = key_of(col_idxs, &u.new_row);
+            let old_key = key_of(col_idxs, &u.old_row);
+            if new_key == old_key {
+                continue;
+            }
+            if !old_key.contains(&SqlValue::Null) {
+                occupied[ks_idx].remove(&old_key);
+            }
+            if !new_key.contains(&SqlValue::Null) {
+                occupied[ks_idx].insert(new_key);
+            }
+        }
+    }
+
+    if let Some((pos, err)) = cut_at {
+        updates.truncate(pos);
+        Some(err)
+    } else {
+        None
+    }
+}
+
 /// Format a constraint's columns as sqlite3's `table.col1, table.col2` list for
 /// a "UNIQUE constraint failed" message (e.g. `t1.a` or `t1.c, t1.d`).
 fn qualify_constraint_columns(table_name: &str, columns: &[String]) -> String {


### PR DESCRIPTION
## Summary

Final increment for the INSERT/UPDATE/DELETE documentation-evidence conformance family (#6193). Fixes the last tractable engine gap in `e_update.test`'s OR-conflict matrix: `UPDATE OR FAIL` did not implement SQLite's "keep the rows applied before the offending row" partial-apply semantics (R-28518-13457), rolling back the whole statement like `OR ABORT` instead. This one root cause cascaded 12 of e_update's 14 remaining failures.

## Root cause

UPDATE's executor uses a two-phase collect-then-apply model: validate every candidate row's constraints, defer PK/UNIQUE checks to a post-statement pass (so permutation statements like `UPDATE p SET a = a - 1` succeed despite transient intermediate duplicates, #5137), then apply all surviving rows in one batch. That deferred, all-or-nothing model works for the default (ABORT) case but is fundamentally incompatible with `OR FAIL`, which must stop at the *first* row that would conflict while keeping every row already applied before it — a genuinely different, row-by-row, immediate semantics.

## Changes

1. **`crates/vibesql-executor/src/update/index_sync.rs`** — new `truncate_updates_for_or_fail`: an immediate, row-by-row uniqueness check (vacate-then-occupy in scan order over PRIMARY KEY / table-level UNIQUE / user-defined UNIQUE indexes, seeded from the live table) that truncates the pending-updates list to the longest conflict-free prefix and returns the first violation — instead of the shared deferred all-or-nothing validator used by every other conflict clause.
2. **`crates/vibesql-executor/src/update/executor.rs`** — wires this in behind a new `use_fail_partial` flag: `OR FAIL`, no triggers on the table, no foreign keys on the table. This scoping avoids the harder problems of reconciling a truncated update list against interleaved BEFORE/AFTER trigger mutations, or un-queuing deferred-FK-violation entries for rows that got truncated away — both left on the existing (safe, all-or-nothing) path, unchanged. Within scope, the per-row NOT NULL/CHECK loop also stops at the first violation while keeping already-collected rows (mirroring `INSERT OR FAIL`, #6275), and the stashed error surfaces after the now-partial write path runs — reusing the existing physical-apply / trigger / RETURNING code unmodified.
3. **`crates/vibesql-cli/src/script.rs`** — a second, independent fix needed to make the above *observable* through the TCL harness's one-process-per-`execsql`-call model: the script executor only auto-saved the database after a **successful** statement, so an erroring `OR FAIL` statement's correctly-kept partial change was silently discarded when the process exited without saving. `maybe_save_after_statement` (extracted, shared helper) now runs after both `Ok` and `Err` outcomes — the in-memory `Database` is the authoritative final state either way, since the per-statement transaction-scope wrapper (`raise_scope::run_top_level_dml_with_conflict_scope`) has already decided, before returning, whether to commit that partial state or roll it back to the pre-statement snapshot. For every other error this is a no-op re-persist of unchanged data; it only changes behavior for `OR FAIL`'s partial keep.

## Acceptance criteria (from #6193)

- [x] All three files (`e_delete.test`, `e_insert.test`, `e_update.test`) run on a fresh `--release` build.
- [x] e_update setup cascade already broken by prior increments (#6214); reconfirmed still broken (main-db sections run).
- [x] **e_delete**: the 1 remaining failure (`e_delete-2.3.2`) is documented as a distinct engine gap — filed as #6296 (trigger catalog is keyed globally instead of per-schema).
- [x] **e_insert**: 100% (203/203), unchanged by this PR (already fixed by prior increments).
- [x] **e_update**: 147/168 (87.5%) -> **159/168 (94.6%)** — all 12 section-1.8 OR-FAIL cascade failures fixed. The 2 remaining (`e_update-2.2.1`, `e_update-2.3.1`) are the same distinct #6296 gap.
- [x] `aux.*` / §2.x cross-schema e_update cases remain ATTACH-blocked / Bucket-A, not attempted.
- [x] No regression in raw per-test pass rate for these three files.

## Before / after (fresh `cargo build --release`)

| File | Before | After |
| --- | --- | --- |
| `e_insert.test` | 203/203 (100%) | 203/203 (100%), unchanged |
| `e_update.test` | 147/168 (87.5%) | **159/168 (94.6%)** |
| `e_delete.test` | 96/105 (91.4%) | 96/105 (91.4%), unchanged |

## Remaining gap (not attempted here, filed as #6296)

`e_update-2.2.1`, `e_update-2.3.1`, `e_delete-2.3.2` share one root cause: VibeSQL's trigger catalog is keyed globally by name instead of per-schema (`main`/`temp`/`aux`), so (a) a main-schema trigger's unqualified body table reference can incorrectly fall through to a same-named TEMP table instead of erroring `no such table: main.<name>`, and (b) a `main` trigger and a `temp`/`aux` trigger can't share a name. Fixing this means schema-scoping the trigger catalog across ~89 call sites in `vibesql-catalog`/`vibesql-executor` — a larger, separate change, flagged in three prior PR reviews on this issue without a tracking issue until now.

## Test plan

- [x] `cargo test --release -p vibesql-executor --lib` — 3642 passed, 0 failed (includes 84 pre-existing `update::` tests, unaffected).
- [x] `make test-tcl-file FILE=e_insert.test` / `FILE=e_update.test` / `FILE=e_delete.test` — counts above.
- [x] Regression sweep (fresh `--release` build, before/after comparison where feasible): `insert.test` 52/1/17, `insert2.test` 16/0/11, `insert3.test` 16/0/2, `update.test` 128/0/10, `delete.test` 49/0/12, `trans3.test` 7/1/0, `savepoint.test` 25/56/7, `autoinc.test` 57/17/13, `trigger1.test` 44/26/14, `fkey1.test` 21/2/3 — all identical to pre-change numbers where a direct baseline was measured. `trans.test` was directly measured both ways (stashed vs applied) on a quiet machine: **56/78/1 both times** — confirming the CLI persist-on-error change is a true no-op outside the `OR FAIL` partial-keep case.
- [x] `cargo build --release` (full workspace) succeeds cleanly.

Closes #6193

🤖 Generated with [Claude Code](https://claude.com/claude-code)