### PR TITLE
fix(executor,parser): schema-qualified sqlite_master + qualified trigger-name validation (Part of #6176)

### DIFF
--- a/crates/vibesql-executor/src/sqlite_schema.rs
+++ b/crates/vibesql-executor/src/sqlite_schema.rs
@@ -23,10 +23,19 @@ use vibesql_types::{DataType, SqlValue};
 
 use crate::{errors::ExecutorError, select::SelectResult};
 
-/// Check if a table reference is sqlite_master or sqlite_schema
+/// Check if a table reference is sqlite_master or sqlite_schema.
+///
+/// The `main.`-qualified forms (`main.sqlite_master` / `main.sqlite_schema`) name
+/// the same schema table — SQLite lets the schema table be referenced with an
+/// explicit `main.` database qualifier, and the evidence suites do so heavily
+/// (e.g. `list_all_views` in e_dropview.test queries `main.sqlite_master`). They
+/// resolve identically to the unqualified names here (#6176).
 pub fn is_sqlite_schema_table(table_name: &str) -> bool {
     let normalized = table_name.to_lowercase();
-    matches!(normalized.as_str(), "sqlite_master" | "sqlite_schema")
+    matches!(
+        normalized.as_str(),
+        "sqlite_master" | "sqlite_schema" | "main.sqlite_master" | "main.sqlite_schema"
+    )
 }
 
 /// Check whether an object name is reserved for internal use.
@@ -58,7 +67,19 @@ pub fn is_reserved_object_name(name: &str) -> bool {
 /// are the temp-schema counterpart to `sqlite_master`. See issue #5513.
 pub fn is_sqlite_temp_schema_table(table_name: &str) -> bool {
     let normalized = table_name.to_lowercase();
-    matches!(normalized.as_str(), "sqlite_temp_master" | "sqlite_temp_schema")
+    matches!(
+        normalized.as_str(),
+        // The `temp.`-qualified forms name the temp schema's schema table, which
+        // in SQLite is the temp-schema counterpart of sqlite_master (i.e.
+        // sqlite_temp_master). e_dropview.test's `list_all_views` reads
+        // `temp.sqlite_master` for the temp database (#6176).
+        "sqlite_temp_master"
+            | "sqlite_temp_schema"
+            | "temp.sqlite_master"
+            | "temp.sqlite_schema"
+            | "temp.sqlite_temp_master"
+            | "temp.sqlite_temp_schema"
+    )
 }
 
 /// Get the schema for sqlite_master/sqlite_schema
@@ -709,11 +730,17 @@ mod tests {
         assert!(is_sqlite_schema_table("SQLITE_MASTER"));
         assert!(is_sqlite_schema_table("SQLITE_SCHEMA"));
         assert!(is_sqlite_schema_table("Sqlite_Master"));
+        // #6176: main-qualified forms name the same schema table.
+        assert!(is_sqlite_schema_table("main.sqlite_master"));
+        assert!(is_sqlite_schema_table("main.sqlite_schema"));
+        assert!(is_sqlite_schema_table("MAIN.SQLITE_MASTER"));
         assert!(!is_sqlite_schema_table("users"));
         assert!(!is_sqlite_schema_table("sqlite_stat1"));
         assert!(!is_sqlite_schema_table("information_schema.tables"));
         // sqlite_temp_master is a distinct view, not sqlite_master.
         assert!(!is_sqlite_schema_table("sqlite_temp_master"));
+        // temp-qualified master belongs to the temp schema, not main.
+        assert!(!is_sqlite_schema_table("temp.sqlite_master"));
     }
 
     #[test]
@@ -722,7 +749,12 @@ mod tests {
         assert!(is_sqlite_temp_schema_table("sqlite_temp_schema"));
         assert!(is_sqlite_temp_schema_table("SQLITE_TEMP_MASTER"));
         assert!(is_sqlite_temp_schema_table("Sqlite_Temp_Schema"));
+        // #6176: temp-qualified master/schema name the temp schema table.
+        assert!(is_sqlite_temp_schema_table("temp.sqlite_master"));
+        assert!(is_sqlite_temp_schema_table("temp.sqlite_schema"));
+        assert!(is_sqlite_temp_schema_table("TEMP.SQLITE_MASTER"));
         assert!(!is_sqlite_temp_schema_table("sqlite_master"));
+        assert!(!is_sqlite_temp_schema_table("main.sqlite_master"));
         assert!(!is_sqlite_temp_schema_table("users"));
     }
 

--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -115,6 +115,19 @@ impl Parser {
         // (`schema . name` consumes three tokens; `name` consumes one.)
         let name_token_pos = self.current_position().saturating_sub(1).max(name_start_pos);
         let name_source = self.token_source_at(name_token_pos).map(str::to_string);
+        // For a `schema.name` reference the schema token sits two tokens before
+        // the name token (`schema`, `.`, `name`). Capture its verbatim source so
+        // an "unknown database" error echoes the spelling as written — SQLite
+        // preserves the original case (`temporary`, not the normalized keyword
+        // spelling `TEMPORARY`) in this message.
+        let schema_source = if name_ref.schema_name.is_some() {
+            name_token_pos
+                .checked_sub(2)
+                .and_then(|pos| self.token_source_at(pos))
+                .map(str::to_string)
+        } else {
+            None
+        };
 
         // Resolve the trigger's schema. An explicit `schema.` prefix wins; if
         // absent, the `TEMP`/`TEMPORARY` modifier implies the `temp` schema.
@@ -132,13 +145,18 @@ impl Parser {
                 // VibeSQL exposes only the `main` and `temp` schemas (no ATTACH),
                 // so a trigger name qualified with any other database is an
                 // "unknown database <name>" prepare-time error, matching SQLite
-                // (trigger7-1.2). `temporary` is accepted as an alias of `temp`.
+                // (trigger7-1.2). `TEMPORARY` is only a keyword synonym for `TEMP`
+                // in `CREATE TEMPORARY TRIGGER` syntax — it is not a valid
+                // `schema.object` qualifier, so `temporary.r1` is an unknown
+                // database exactly like any other unrecognized name.
                 if !schema_name.eq_ignore_ascii_case("main")
                     && !schema_name.eq_ignore_ascii_case("temp")
-                    && !schema_name.eq_ignore_ascii_case("temporary")
                 {
+                    // Echo the verbatim source spelling (case preserved) rather
+                    // than the normalized identifier, matching SQLite.
+                    let reported = schema_source.as_deref().unwrap_or(&schema_name);
                     return Err(ParseError {
-                        message: format!("unknown database {}", schema_name),
+                        message: format!("unknown database {}", reported),
                     });
                 }
                 Some(schema_name)

--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -123,11 +123,22 @@ impl Parser {
         let schema = match (is_temp, name_ref.schema_name) {
             (_, Some(schema_name)) => {
                 if is_temp && !schema_name.eq_ignore_ascii_case("temp") {
+                    // SQLite emits this exact message (no name suffix) for
+                    // `CREATE TEMP TRIGGER main.r1 ...` (trigger7-1.1).
                     return Err(ParseError {
-                        message: format!(
-                            "temporary trigger may not have qualified name: \"{}.{}\"",
-                            schema_name, trigger_name
-                        ),
+                        message: "temporary trigger may not have qualified name".to_string(),
+                    });
+                }
+                // VibeSQL exposes only the `main` and `temp` schemas (no ATTACH),
+                // so a trigger name qualified with any other database is an
+                // "unknown database <name>" prepare-time error, matching SQLite
+                // (trigger7-1.2). `temporary` is accepted as an alias of `temp`.
+                if !schema_name.eq_ignore_ascii_case("main")
+                    && !schema_name.eq_ignore_ascii_case("temp")
+                    && !schema_name.eq_ignore_ascii_case("temporary")
+                {
+                    return Err(ParseError {
+                        message: format!("unknown database {}", schema_name),
                     });
                 }
                 Some(schema_name)

--- a/crates/vibesql-parser/src/tests/trigger.rs
+++ b/crates/vibesql-parser/src/tests/trigger.rs
@@ -676,6 +676,20 @@ fn test_create_temp_trigger_with_non_temp_schema_rejected() {
 }
 
 #[test]
+fn test_create_trigger_temporary_qualifier_is_unknown_database() {
+    // `TEMPORARY` is only a keyword synonym for `TEMP` in
+    // `CREATE TEMPORARY TRIGGER` syntax — it is NOT a valid `schema.object`
+    // qualifier. Real sqlite3 (3.51.0) rejects `CREATE TRIGGER temporary.r1 ...`
+    // with `unknown database temporary`, exactly as it rejects any other
+    // unrecognized qualifier. It must not be accepted as an alias of `temp`.
+    let err = Parser::parse_sql(
+        "CREATE TRIGGER temporary.r1 AFTER INSERT ON t1 BEGIN SELECT 1; END;",
+    )
+    .expect_err("CREATE TRIGGER temporary.r1 must be rejected as unknown database");
+    assert_eq!(err.message, "unknown database temporary", "got: {}", err.message);
+}
+
+#[test]
 fn test_create_temp_table_and_view_still_parse() {
     // Regression checks: the CREATE TEMP dispatch must keep routing TABLE and
     // VIEW correctly after learning about TRIGGER.

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -805,6 +805,15 @@ proc translate_error_to_sqlite {vibesql_error} {
     if {[regexp -nocase {^Parse error: (RAISE\(\) may only be used within a trigger-program)$} $error_msg -> parse_msg]} {
         return $parse_msg
     }
+    # A TEMP trigger given a non-temp qualified name (trigger7-1.1), and a trigger
+    # name qualified with a database VibeSQL does not know (trigger7-1.2). SQLite
+    # returns both semantic messages verbatim, not wrapped as a syntax error.
+    if {[regexp -nocase {^Parse error: (temporary trigger may not have qualified name)$} $error_msg -> parse_msg]} {
+        return $parse_msg
+    }
+    if {[regexp {^Parse error: (unknown database .+)$} $error_msg -> parse_msg]} {
+        return $parse_msg
+    }
     # Trigger-body DML restrictions (ticket #3947, trigger1-16.1..16.7) — a
     # schema-qualified DML target, or an INDEXED BY / NOT INDEXED clause on a
     # body UPDATE/DELETE. SQLite returns each of these verbatim, not wrapped.


### PR DESCRIPTION
## Summary

Part of the trigger / DROP-TRIGGER / DROP-VIEW conformance family (#6176). Three engine/conformance fixes:

1. **Schema-qualified `sqlite_master`** — `main.sqlite_master` / `main.sqlite_schema` and `temp.sqlite_master` / `temp.sqlite_schema` now resolve. SQLite lets the schema table be referenced with an explicit database qualifier, and the evidence suites rely on it (e_dropview.test's `list_all_views` reads `$name.sqlite_master` for each row of `PRAGMA database_list`). Previously any qualified reference errored `Table 'main.sqlite_master' not found`. `is_sqlite_schema_table` now also matches the `main.`-qualified forms (identical resolution everywhere — SELECT scans and the write/ALTER guards), and `is_sqlite_temp_schema_table` matches the `temp.`-qualified forms (routed to the temp-schema introspection path).

2. **`CREATE TEMP TRIGGER main.r1 ...`** now errors with SQLite's exact message `temporary trigger may not have qualified name` (previously carried a `: "main.r1"` suffix SQLite doesn't emit, so the conformance shim re-wrapped it as a generic `near "...": syntax error`). trigger7-1.1.

3. **Unknown database qualifier on a trigger name** — `CREATE TRIGGER not_a_db.r1 ...` now errors `unknown database not_a_db` at parse time. VibeSQL exposes only the `main` and `temp` schemas (no ATTACH), so any other qualifier is an unknown database, matching SQLite's prepare-time rejection instead of silently creating the trigger. trigger7-1.2.

The conformance shim's `translate_error_to_sqlite` gains verbatim-passthrough entries for both new semantic messages (established whitelist pattern).

## Test impact
- `trigger7.test`: 1 → 3 passing (**0 failures**, was 2)
- `e_dropview.test`: 8 → **15 passing** (main/temp-qualified `sqlite_master` recovered 7)
- No regressions: `trigger2` (100%), `trigger3` (100%), `triggerB` (100%), `triggerE` (23/2 unchanged), `view` (100%)
- Unit tests: executor `sqlite_schema` (22) and parser `trigger` (110) pass, including new qualified-form assertions

## Known remaining gaps (out of scope here)
These files remain dominated by failures outside trigger semantics, left for follow-up:
- **`e_droptrigger.test` (59) and most of `e_dropview.test`** — gated on `ATTACH DATABASE`, which VibeSQL does not implement (Priority 3, per CLAUDE.md). Not fixable without multi-database ATTACH.
- **`trigger1.test` (26)** — TEMP-object visibility across the shim's multi-process model (TEMP tables are demoted to persistent, so temp triggers/tables leak into `sqlite_master`). The engine behavior is correct in isolation (verified directly); these are documented TCL-shim artifacts noted in #6293.
- **`triggerC.test` (7)** — documented "undefined behaviour" rowid-mutation scan ordering (7.x), UPDATE-OR-REPLACE multi-delete conflict count ordering (5.1.7/5.2.7), and RAISE-vs-ORDER-BY error precedence (16.1). Each is a deep, high-blast-radius change in conflict resolution / storage ordering / parse precedence.
- **`triggerG` (hex-literal materialization deferral)** and **`triggerE` (writable_schema + unbindable-parameter triggers)** belong to other families.

Part of #6176

🤖 Generated with [Claude Code](https://claude.com/claude-code)