### PR TITLE
fix(executor): CTE seed arity check for wildcard-without-FROM + reject aggregates in recursive term

### DIFF
--- a/crates/vibesql-executor/src/select/cte.rs
+++ b/crates/vibesql-executor/src/select/cte.rs
@@ -527,6 +527,63 @@ where
                         declared.len()
                     )));
                 }
+            } else if cte.query.from.is_none() {
+                // `collect_select_list_columns` only returns `None` when a
+                // wildcard item's column count could not be resolved, and the
+                // sole reason a wildcard is unresolvable with no FROM clause
+                // at all is that there is nothing to expand it against
+                // (`expand_wildcard_names` bails on `stmt.from.as_ref()?`).
+                //
+                // SQLite still validates the declared arity in this case: a
+                // `*`/`qualifier.*` term with no FROM clause contributes
+                // exactly ZERO columns to the nominal width (never "unknown"),
+                // while ordinary expressions each contribute one. If that
+                // nominal width mismatches the declared column list, the
+                // mismatch error fires *before* the query ever tries to
+                // execute the wildcard — taking priority over the "no tables
+                // specified" error that would otherwise surface once actual
+                // execution attempts to expand it (with1.test 13.3:
+                // `c(i,j) AS (SELECT 5,* UNION ALL ...)` — nominal width is 1
+                // (just `5`), declared is 2, so the mismatch error fires).
+                // When the nominal width happens to match the declared count
+                // (with1.test 13.2), no error is raised here and the real
+                // "no tables specified" error surfaces later during
+                // execution, exactly matching SQLite (confirmed against
+                // sqlite3 3.51). SQLite also never applies this mismatch
+                // check at all when the select list is *entirely* wildcards
+                // (nominal width 0, e.g. plain `SELECT *` — with1.test 13.1):
+                // it always reports "no tables specified" there regardless of
+                // the declared arity, so the `nominal_width > 0` guard below
+                // preserves that case.
+                let has_wildcard = cte.query.select_list.iter().any(|item| {
+                    matches!(
+                        item,
+                        vibesql_ast::SelectItem::Wildcard { .. }
+                            | vibesql_ast::SelectItem::QualifiedWildcard { .. }
+                    )
+                });
+                if has_wildcard {
+                    let nominal_width = cte
+                        .query
+                        .select_list
+                        .iter()
+                        .filter(|item| {
+                            !matches!(
+                                item,
+                                vibesql_ast::SelectItem::Wildcard { .. }
+                                    | vibesql_ast::SelectItem::QualifiedWildcard { .. }
+                            )
+                        })
+                        .count();
+                    if nominal_width > 0 && nominal_width != declared.len() {
+                        return Err(ExecutorError::SqliteCompatError(format!(
+                            "table {} has {} values for {} columns",
+                            cte.name,
+                            nominal_width,
+                            declared.len()
+                        )));
+                    }
+                }
             }
         }
     }
@@ -1517,6 +1574,25 @@ where
     if crate::select::window::has_window_functions(&recursive_query.select_list) {
         return Err(ExecutorError::SqliteCompatError(
             "cannot use window functions in recursive queries".to_string(),
+        ));
+    }
+
+    // SQLite compatibility: aggregate functions are not allowed in the
+    // recursive part of a recursive CTE (with1.test 16.1: `i(x) AS
+    // (VALUES(1) UNION SELECT count(*) FROM i)`). Each recursive step only
+    // ever sees the prior step's single working row, so an aggregate over
+    // "the recursive table" is meaningless — SQLite rejects it up front with
+    // "recursive aggregate queries not supported" rather than silently
+    // aggregating each single-row step.
+    if recursive_query.select_list.iter().any(|item| match item {
+        vibesql_ast::SelectItem::Expression { expr, .. } => {
+            crate::select::executor::validation::expression_contains_aggregate(expr)
+        }
+        vibesql_ast::SelectItem::Wildcard { .. }
+        | vibesql_ast::SelectItem::QualifiedWildcard { .. } => false,
+    }) {
+        return Err(ExecutorError::SqliteCompatError(
+            "recursive aggregate queries not supported".to_string(),
         ));
     }
 

--- a/crates/vibesql-executor/src/select/executor/validation/mod.rs
+++ b/crates/vibesql-executor/src/select/executor/validation/mod.rs
@@ -26,11 +26,11 @@ use std::collections::HashSet;
 
 // Re-export public validation functions
 pub use aggregates::{
-    check_aggregate_arg_count, find_aggregate_in_expression, find_window_function_in_expression,
-    validate_aggregate_arguments, validate_group_by_window_misuse,
-    validate_having_aliased_aggregates, validate_no_nested_aggregates,
-    validate_order_by_aliased_window_functions, validate_subquery_context_misuse,
-    validate_window_query_order_by_aggregates, SubqueryContext,
+    check_aggregate_arg_count, expression_contains_aggregate, find_aggregate_in_expression,
+    find_window_function_in_expression, validate_aggregate_arguments,
+    validate_group_by_window_misuse, validate_having_aliased_aggregates,
+    validate_no_nested_aggregates, validate_order_by_aliased_window_functions,
+    validate_subquery_context_misuse, validate_window_query_order_by_aggregates, SubqueryContext,
 };
 pub use collation_names::validate_collation_names;
 pub use column_refs::{extract_column_refs, validate_column_ref};

--- a/crates/vibesql-executor/src/tests/recursive_cte_tests.rs
+++ b/crates/vibesql-executor/src/tests/recursive_cte_tests.rs
@@ -1075,3 +1075,73 @@ fn test_recursive_cte_multiple_from_references_message() {
     .unwrap_err();
     assert_eq!(err.to_string(), "multiple references to recursive table: t4");
 }
+
+/// A CTE column-list arity mismatch must be detected even when the seed's
+/// select list contains a wildcard with no FROM clause to expand it against.
+/// SQLite treats such a wildcard as contributing exactly zero columns to the
+/// arity comparison (never "unknown"), so the mismatch error takes priority
+/// over the later "no tables specified" error that would otherwise fire once
+/// the query actually tries to execute the wildcard (issue #6189,
+/// with1.test 13.1/13.2/13.3, confirmed against sqlite3 3.51).
+#[test]
+fn test_cte_arity_check_with_unresolvable_wildcard_in_seed() {
+    let mut db = vibesql_storage::Database::new();
+
+    // Nominal width (1, from the literal `5`) mismatches the declared arity
+    // (2) -> the mismatch error fires before the wildcard is ever expanded.
+    let err = execute_sql(
+        &mut db,
+        "WITH RECURSIVE c(i,j) AS (SELECT 5,* UNION ALL SELECT i+1,11 FROM c WHERE i<10) \
+         SELECT i FROM c",
+    )
+    .unwrap_err();
+    assert_eq!(err.to_string(), "table c has 1 values for 2 columns");
+
+    // Nominal width (1) matches the declared arity (1) -> no mismatch is
+    // raised here, so the query falls through to the real "no tables
+    // specified" error when it tries to execute the wildcard.
+    let err = execute_sql(
+        &mut db,
+        "WITH RECURSIVE c(i) AS (SELECT 5,* UNION ALL SELECT i+1 FROM c WHERE i<10) \
+         SELECT i FROM c",
+    )
+    .unwrap_err();
+    assert_eq!(err.to_string(), "no tables specified");
+
+    // A select list that is *entirely* wildcards (nominal width 0) never
+    // triggers the mismatch check regardless of declared arity — SQLite
+    // always reports "no tables specified" in that case.
+    let err = execute_sql(
+        &mut db,
+        "WITH RECURSIVE c(i) AS (SELECT * UNION ALL SELECT i+1 FROM c WHERE i<10) \
+         SELECT i FROM c",
+    )
+    .unwrap_err();
+    assert_eq!(err.to_string(), "no tables specified");
+}
+
+/// SQLite rejects an aggregate function in the recursive term of a `WITH
+/// RECURSIVE` CTE with a dedicated error: each recursive step only ever sees
+/// the prior step's single working row, so aggregating "the recursive table"
+/// is meaningless (issue #6189, with1.test 16.1).
+#[test]
+fn test_recursive_cte_rejects_aggregate_in_recursive_term() {
+    let mut db = vibesql_storage::Database::new();
+
+    let err = execute_sql(
+        &mut db,
+        "WITH RECURSIVE i(x) AS (VALUES(1) UNION SELECT count(*) FROM i) SELECT * FROM i",
+    )
+    .unwrap_err();
+    assert_eq!(err.to_string(), "recursive aggregate queries not supported");
+
+    // The same aggregate in the *seed* (non-recursive) term is fine — only the
+    // recursive term is restricted.
+    let rows = execute_sql(
+        &mut db,
+        "WITH RECURSIVE i(x) AS (SELECT count(*) UNION ALL SELECT x+1 FROM i WHERE x<3) \
+         SELECT x FROM i",
+    )
+    .unwrap();
+    assert_eq!(rows.len(), 3);
+}


### PR DESCRIPTION
## Summary

Partial increment of the CTE / `WITH (RECURSIVE)` conformance family (#6189, part of epic #5779). Fixes two SQLite-compat validation gaps in `WITH`/`WITH RECURSIVE` surfaced by `with1.test`. Prior increments of this family landed via #6243, #6260, and #6294; this PR builds on them.

Because #6189 tracks the whole five-file `with*.test` family and residual clusters remain (see below), this PR uses `Part of #6189` rather than `Closes`.

## Changes

`crates/vibesql-executor/src/select/cte.rs`
- CTE seed arity check when the select list has a `*`/`qualifier.*` term and **no FROM clause** to expand it against. SQLite treats such an unresolvable wildcard as contributing exactly zero columns to the nominal width, so a declared-arity mismatch (`c(i,j) AS (SELECT 5,* ...)` — nominal width 1 vs declared 2) now raises `table c has N values for M columns` ahead of the later `no tables specified` execution error. A select list that is *entirely* wildcards (nominal width 0, plain `SELECT *`) keeps reporting `no tables specified`. Verified against sqlite3 3.51 (`with1.test` 13.1/13.2/13.3).
- Reject aggregate functions in the **recursive term** of a `WITH RECURSIVE` CTE up front with `recursive aggregate queries not supported` (`with1.test` 16.1: `i(x) AS (VALUES(1) UNION SELECT count(*) FROM i)`). The seed term is unaffected.

`crates/vibesql-executor/src/select/executor/validation/mod.rs`
- Re-export `expression_contains_aggregate` for the recursive-term check.

`crates/vibesql-executor/src/tests/recursive_cte_tests.rs`
- Rust regression cases mirroring both behaviors.

## Root-cause clusters addressed

This increment addresses two distinct clusters in `with1.test`:
1. **CTE column-name/arity resolution** — declared-arity validation must run even when a seed wildcard is unresolvable (no FROM). Landed in the non-recursive arity-check path in `cte.rs`.
2. **Recursive-term semantic restrictions** — aggregates are illegal in the recursive term. Landed in `execute_recursive_cte`.

Remaining `with*.test` residuals are separate clusters left for follow-up increments (per the issue's split-if-over-scope guidance): recursive `ORDER BY` controlling depth/breadth-first traversal + `COLLATE` in compound `ORDER BY` (`with1` 10.2–10.8.x), and a handful of error-message/edge cases (`with1` 22.1/24.1/26.0, `with2`×5, `with3`×1, `with4`×1).

## Acceptance Criteria Verification

Per-file TCL failure counts on a fresh `cargo build --release` (certified baseline → this PR):

| File | Certified | This PR |
| --- | --- | --- |
| with1.test | 25 | 12 |
| with2.test | 18 | 5 |
| with3.test | 4 | 1 |
| with4.test | 1 | 1 |
| with5.test | 5 | 0 |

- `with1.test` 13.1/13.2/13.3 and 16.1 (the tests this diff targets) now pass; no previously-passing `with*.test` case regresses.
- No new clippy warnings tied to these changes; `cargo fmt --check` clean.

## Test Plan

- `cargo test -p vibesql-executor --release recursive_cte` — 33 passed, incl. the two new cases `test_cte_arity_check_with_unresolvable_wildcard_in_seed` and `test_recursive_cte_rejects_aggregate_in_recursive_term`.
- `cargo test -p vibesql-executor --release --test with_insert_cte_tests --test with_update_from_cte_tests` — 14 + 7 passed.
- `make test-tcl-file FILE=with{1..5}.test` — counts in the table above.
- `cargo build --release` clean; `cargo fmt -p vibesql-executor --check` clean; `cargo clippy -p vibesql-executor` no new warnings.

Part of #6189

🤖 Generated with [Claude Code](https://claude.com/claude-code)