### PR TITLE
fix(catalog,executor): scope trigger catalog keying per schema

### DIFF
--- a/crates/vibesql-catalog/src/store/advanced/triggers.rs
+++ b/crates/vibesql-catalog/src/store/advanced/triggers.rs
@@ -2,40 +2,122 @@
 
 use crate::{errors::CatalogError, trigger::TriggerDefinition};
 
+/// Compute the schema-scoped storage key for a trigger.
+///
+/// SQLite scopes trigger names *per schema*, exactly like tables: `main.tr` and
+/// `temp.tr` are two distinct triggers that may coexist. The catalog therefore
+/// keys triggers by `(schema, name)` rather than by bare `name`, so a `main`
+/// trigger and a `temp`/`aux` trigger sharing a name no longer collide
+/// (e_update-2.3.1 / e_delete-2.3.2).
+///
+/// The schema component is normalized case-insensitively, with `None` and
+/// `main` collapsing to the default (`main`) schema. The name component
+/// preserves the (already parser-normalized) identifier spelling so this keeps
+/// the previous exact-name collision semantics *within* a schema. A control
+/// character separates the two parts so a schema/name that happens to contain a
+/// `.` cannot forge a different key.
+fn trigger_storage_key(schema: Option<&str>, name: &str) -> String {
+    let schema = schema
+        .map(|s| s.to_ascii_lowercase())
+        .unwrap_or_else(|| crate::DEFAULT_SCHEMA.to_string());
+    format!("{schema}\u{1f}{name}")
+}
+
 impl super::super::Catalog {
     // ============================================================================
     // Trigger Management Methods
     // ============================================================================
 
-    /// Create a TRIGGER
+    /// Create a TRIGGER.
+    ///
+    /// The collision check is scoped to the trigger's own schema (see
+    /// [`trigger_storage_key`]): creating `temp.tr1` when a `main.tr1` already
+    /// exists succeeds, matching SQLite's per-schema trigger namespace.
     pub fn create_trigger(&mut self, trigger: TriggerDefinition) -> Result<(), CatalogError> {
-        let name = trigger.name.clone();
-        if self.triggers.contains_key(&name) {
-            return Err(CatalogError::TriggerAlreadyExists(name));
+        let key = trigger_storage_key(trigger.schema.as_deref(), &trigger.name);
+        if self.triggers.contains_key(&key) {
+            return Err(CatalogError::TriggerAlreadyExists(trigger.name));
         }
-        self.triggers.insert(name, trigger);
+        self.triggers.insert(key, trigger);
         Ok(())
     }
 
-    /// Get a TRIGGER definition by name
+    /// Get a TRIGGER definition by (unqualified) name.
+    ///
+    /// Triggers are stored per schema, so an unqualified name can match more than
+    /// one entry. This resolves them in SQLite's unqualified search order —
+    /// `temp` first, then `main`, then any other (attached) schema — returning
+    /// the first match. Callers that know the schema should prefer
+    /// [`Catalog::get_trigger_in_schema`].
     pub fn get_trigger(&self, name: &str) -> Option<&TriggerDefinition> {
-        self.triggers.get(name)
+        if let Some(trigger) = self.triggers.get(&trigger_storage_key(Some("temp"), name)) {
+            return Some(trigger);
+        }
+        if let Some(trigger) = self.triggers.get(&trigger_storage_key(None, name)) {
+            return Some(trigger);
+        }
+        self.triggers.values().find(|t| t.name == name)
+    }
+
+    /// Get a TRIGGER definition scoped to a specific schema.
+    ///
+    /// `schema` is the logical schema label a trigger carries
+    /// ([`TriggerDefinition::schema`]): `None`/`Some("main")` for the main schema,
+    /// `Some("temp")` for the temp schema, or an attached schema name. This never
+    /// falls through to another schema, so `main.tr` and `temp.tr` are
+    /// distinguishable.
+    pub fn get_trigger_in_schema(
+        &self,
+        name: &str,
+        schema: Option<&str>,
+    ) -> Option<&TriggerDefinition> {
+        self.triggers.get(&trigger_storage_key(schema, name))
+    }
+
+    /// Returns true if a trigger of `name` exists in the given schema.
+    ///
+    /// Used by the executor's `CREATE TRIGGER` path to enforce SQLite's
+    /// per-schema "trigger already exists" rule without colliding across schemas.
+    pub fn trigger_exists_in_schema(&self, name: &str, schema: Option<&str>) -> bool {
+        self.triggers.contains_key(&trigger_storage_key(schema, name))
+    }
+
+    /// Iterate over every trigger definition in the catalog, regardless of
+    /// schema. Preferred over `list_triggers()` + `get_trigger()` by callers
+    /// (e.g. persistence) that must see *every* trigger unambiguously, since a
+    /// name-only `get_trigger` can only return one of several same-named triggers
+    /// living in different schemas.
+    pub fn iter_triggers(&self) -> impl Iterator<Item = &TriggerDefinition> {
+        self.triggers.values()
     }
 
     /// Update a TRIGGER (for ALTER TRIGGER operations)
     pub fn update_trigger(&mut self, trigger: TriggerDefinition) -> Result<(), CatalogError> {
-        let name = trigger.name.clone();
-        if !self.triggers.contains_key(&name) {
-            return Err(CatalogError::TriggerNotFound(name));
+        let key = trigger_storage_key(trigger.schema.as_deref(), &trigger.name);
+        if !self.triggers.contains_key(&key) {
+            return Err(CatalogError::TriggerNotFound(trigger.name));
         }
-        self.triggers.insert(name, trigger);
+        self.triggers.insert(key, trigger);
         Ok(())
     }
 
-    /// Drop a TRIGGER
+    /// Drop a TRIGGER by (unqualified) name.
+    ///
+    /// Resolves the target in SQLite's unqualified search order (`temp`, then
+    /// `main`, then any other schema) and removes the first match.
     pub fn drop_trigger(&mut self, name: &str) -> Result<(), CatalogError> {
+        let key = if self.triggers.contains_key(&trigger_storage_key(Some("temp"), name)) {
+            trigger_storage_key(Some("temp"), name)
+        } else if self.triggers.contains_key(&trigger_storage_key(None, name)) {
+            trigger_storage_key(None, name)
+        } else {
+            match self.triggers.iter().find(|(_, t)| t.name == name) {
+                Some((k, _)) => k.clone(),
+                None => return Err(CatalogError::TriggerNotFound(name.to_string())),
+            }
+        };
         self.triggers
-            .remove(name)
+            .remove(&key)
             .map(|_| ())
             .ok_or_else(|| CatalogError::TriggerNotFound(name.to_string()))
     }
@@ -183,10 +265,10 @@ impl super::super::Catalog {
                 (table_name.to_string(), resolved_schema)
             };
 
-        let triggers_to_remove: Vec<String> = self
+        let keys_to_remove: Vec<String> = self
             .triggers
-            .values()
-            .filter(|trigger| {
+            .iter()
+            .filter(|(_, trigger)| {
                 // Only triggers defined ON the dropped table (case-insensitive,
                 // SQLite-compatible).
                 if !trigger.table_name.eq_ignore_ascii_case(&bare_table_name) {
@@ -205,12 +287,12 @@ impl super::super::Catalog {
                     None => true,
                 }
             })
-            .map(|trigger| trigger.name.clone())
+            .map(|(key, _)| key.clone())
             .collect();
 
-        triggers_to_remove
+        keys_to_remove
             .into_iter()
-            .filter_map(|name| self.triggers.remove(&name).map(|_| name))
+            .filter_map(|key| self.triggers.remove(&key).map(|trigger| trigger.name))
             .collect()
     }
 
@@ -248,10 +330,10 @@ impl super::super::Catalog {
         // stores views by bare name).
         let bare_view_name = view_name.rsplit_once('.').map_or(view_name, |(_, n)| n);
 
-        let triggers_to_remove: Vec<String> = self
+        let keys_to_remove: Vec<String> = self
             .triggers
-            .values()
-            .filter(|trigger| {
+            .iter()
+            .filter(|(_, trigger)| {
                 // Only INSTEAD OF triggers defined ON the dropped view
                 // (case-insensitive, SQLite-compatible). INSTEAD OF is the only
                 // timing valid on a view, but checking it keeps this strictly
@@ -263,18 +345,23 @@ impl super::super::Catalog {
                     // main trigger <-> main view).
                     && trigger.is_temp() == view_is_temp
             })
-            .map(|trigger| trigger.name.clone())
+            .map(|(key, _)| key.clone())
             .collect();
 
-        triggers_to_remove
+        keys_to_remove
             .into_iter()
-            .filter_map(|name| self.triggers.remove(&name).map(|_| name))
+            .filter_map(|key| self.triggers.remove(&key).map(|trigger| trigger.name))
             .collect()
     }
 
-    /// List all trigger names
+    /// List all trigger names.
+    ///
+    /// Returns the trigger identifiers (not the internal schema-scoped storage
+    /// keys). With per-schema keying a name may appear more than once (same name
+    /// in `main` and `temp`); callers that need to disambiguate should use
+    /// [`Catalog::iter_triggers`] or [`Catalog::get_trigger_in_schema`].
     pub fn list_triggers(&self) -> Vec<String> {
-        self.triggers.keys().cloned().collect()
+        self.triggers.values().map(|t| t.name.clone()).collect()
     }
 
     /// Cheap O(1) check: does the catalog hold *any* trigger at all?
@@ -308,7 +395,8 @@ mod tests {
     use vibesql_types::DataType;
 
     use crate::{
-        column::ColumnSchema, store::Catalog, table::TableSchema, trigger::TriggerDefinition,
+        column::ColumnSchema, errors::CatalogError, store::Catalog, table::TableSchema,
+        trigger::TriggerDefinition,
     };
 
     fn sample_trigger(name: &str, table: &str) -> TriggerDefinition {
@@ -356,6 +444,63 @@ mod tests {
         catalog.drop_trigger("t1").unwrap();
         catalog.drop_trigger("t2").unwrap();
         assert!(!catalog.has_any_triggers());
+    }
+
+    /// A `main` trigger and a `temp` trigger sharing a name coexist without a
+    /// spurious "already exists" collision — triggers are keyed per schema
+    /// (e_update-2.3.1 / e_delete-2.3.2).
+    #[test]
+    fn triggers_are_scoped_per_schema() {
+        let mut catalog = Catalog::new();
+        catalog.set_case_sensitive_identifiers(false);
+
+        // main.tr1 first, then temp.tr1 — no collision across schemas.
+        catalog
+            .create_trigger(sample_trigger("tr1", "t").with_schema(Some("main".to_string())))
+            .unwrap();
+        catalog
+            .create_trigger(sample_trigger("tr1", "t").with_schema(Some("temp".to_string())))
+            .unwrap();
+
+        // Both are retrievable by their own schema.
+        assert!(catalog.get_trigger_in_schema("tr1", Some("main")).is_some());
+        assert!(catalog.get_trigger_in_schema("tr1", Some("temp")).is_some());
+        assert!(catalog.trigger_exists_in_schema("tr1", Some("temp")));
+
+        // A same-schema duplicate still collides.
+        assert!(matches!(
+            catalog.create_trigger(sample_trigger("tr1", "t").with_schema(Some("main".to_string()))),
+            Err(CatalogError::TriggerAlreadyExists(_))
+        ));
+
+        // None (default) and Some("main") address the same schema slot.
+        assert!(catalog.trigger_exists_in_schema("tr1", None));
+
+        // Unqualified DROP resolves temp-first (SQLite search order): drops
+        // temp.tr1, leaving main.tr1.
+        catalog.drop_trigger("tr1").unwrap();
+        assert!(catalog.get_trigger_in_schema("tr1", Some("temp")).is_none());
+        assert!(catalog.get_trigger_in_schema("tr1", Some("main")).is_some());
+        catalog.drop_trigger("tr1").unwrap();
+        assert!(!catalog.has_any_triggers());
+    }
+
+    /// A default-schema trigger (`schema = None`) is addressable as `main` and
+    /// does not collide with a `temp` namesake — the `None`/`main` collapse.
+    #[test]
+    fn default_schema_trigger_collapses_to_main() {
+        let mut catalog = Catalog::new();
+        catalog.set_case_sensitive_identifiers(false);
+
+        catalog.create_trigger(sample_trigger("tr", "t")).unwrap(); // schema None
+        catalog
+            .create_trigger(sample_trigger("tr", "t").with_schema(Some("temp".to_string())))
+            .unwrap();
+
+        // list/iter see both entries.
+        assert_eq!(catalog.iter_triggers().count(), 2);
+        // A None-schema create now collides (same slot as the first).
+        assert!(catalog.create_trigger(sample_trigger("tr", "t")).is_err());
     }
 
     fn names_in_schema(

--- a/crates/vibesql-catalog/src/store/tables.rs
+++ b/crates/vibesql-catalog/src/store/tables.rs
@@ -410,10 +410,13 @@ impl super::Catalog {
         // dropped Note: We need to normalize trigger table_name for comparison in
         // case-insensitive mode
         let case_sensitive = self.case_sensitive_identifiers;
-        let trigger_names: Vec<String> = self
+        // Collect the schema-scoped storage keys (not the bare trigger names):
+        // triggers are keyed per schema, so a bare name no longer identifies a
+        // single map entry.
+        let trigger_keys: Vec<String> = self
             .triggers
-            .values()
-            .filter(|trigger| {
+            .iter()
+            .filter(|(_, trigger)| {
                 let trigger_table = if case_sensitive {
                     trigger.table_name.clone()
                 } else {
@@ -421,11 +424,11 @@ impl super::Catalog {
                 };
                 trigger_table == normalized_table
             })
-            .map(|trigger| trigger.name.clone())
+            .map(|(key, _)| key.clone())
             .collect();
 
-        for trigger_name in trigger_names {
-            self.triggers.remove(&trigger_name);
+        for trigger_key in trigger_keys {
+            self.triggers.remove(&trigger_key);
         }
 
         let schema = self

--- a/crates/vibesql-executor/src/alter/drop_column_checks.rs
+++ b/crates/vibesql-executor/src/alter/drop_column_checks.rs
@@ -95,14 +95,16 @@ fn check_schema_objects(
         }
     }
 
-    for name in database.catalog.list_triggers() {
-        if let Some(trigger) = database.catalog.get_trigger(&name) {
-            if let Some(inner) = find_trigger_resolution_error(trigger, &sim) {
-                return Err(ExecutorError::Other(format!(
-                    "error in trigger {}{}: {}",
-                    trigger.name, suffix, inner
-                )));
-            }
+    // Iterate trigger definitions directly rather than via `list_triggers()` +
+    // `get_trigger()`: triggers are keyed per schema, so a name-only `get_trigger`
+    // resolves temp-first and would skip a `main` trigger that shares a name with
+    // a `temp` trigger (issue #6296).
+    for trigger in database.catalog.iter_triggers() {
+        if let Some(inner) = find_trigger_resolution_error(trigger, &sim) {
+            return Err(ExecutorError::Other(format!(
+                "error in trigger {}{}: {}",
+                trigger.name, suffix, inner
+            )));
         }
     }
 

--- a/crates/vibesql-executor/src/alter/table_options.rs
+++ b/crates/vibesql-executor/src/alter/table_options.rs
@@ -173,12 +173,13 @@ fn rebind_child_foreign_keys(database: &mut Database, old_name: &str, new_name: 
 /// - `sql_definition` (the verbatim `CREATE TRIGGER` text shown in
 ///   `sqlite_master`/`sqlite_schema`).
 fn rewrite_triggers_for_rename(database: &mut Database, old_name: &str, new_name: &str) {
-    let trigger_names = database.catalog.list_triggers();
-    for name in trigger_names {
-        let Some(existing) = database.catalog.get_trigger(&name) else {
-            continue;
-        };
-
+    // Snapshot trigger definitions up front. Triggers are keyed per schema, so a
+    // name-only `get_trigger` resolves temp-first and would rewrite a `temp`
+    // trigger twice while leaving its `main` namesake untouched (issue #6296).
+    // Cloning also frees the immutable catalog borrow so `update_trigger` can
+    // mutate below.
+    let existing_triggers: Vec<_> = database.catalog.iter_triggers().cloned().collect();
+    for existing in existing_triggers {
         // Does this trigger reference the renamed table anywhere?
         let on_target_match = existing.table_name.eq_ignore_ascii_case(old_name);
         let body_text = match &existing.triggered_action {
@@ -266,12 +267,13 @@ pub(super) fn rewrite_triggers_for_column_rename(
     // in any trigger aborts the whole ALTER *before* any catalog mutation. This
     // mirrors SQLite, which leaves the schema entirely unchanged on a genuine
     // ambiguity rather than partially rewriting earlier triggers.
-    let trigger_names = database.catalog.list_triggers();
+    // Snapshot trigger definitions up front. Triggers are keyed per schema, so a
+    // name-only `get_trigger` resolves temp-first and would rewrite a `temp`
+    // trigger twice while leaving its `main` namesake untouched (issue #6296).
+    let existing_triggers: Vec<_> = database.catalog.iter_triggers().cloned().collect();
     let mut pending_updates = Vec::new();
-    for name in trigger_names {
-        let Some(existing) = database.catalog.get_trigger(&name) else {
-            continue;
-        };
+    for existing in existing_triggers {
+        let name = existing.name.clone();
 
         let body_text = match &existing.triggered_action {
             TriggerAction::RawSql(sql) => sql.clone(),

--- a/crates/vibesql-executor/src/sqlite_schema.rs
+++ b/crates/vibesql-executor/src/sqlite_schema.rs
@@ -195,15 +195,17 @@ pub fn execute_sqlite_schema_query(
     }
 
     // Add triggers. Temp triggers are tagged with the `temp` schema (#5532)
-    // and surface only via sqlite_temp_master, so skip them here.
-    for trigger_name in catalog.list_triggers() {
-        if let Some(trigger) = catalog.get_trigger(&trigger_name) {
-            if trigger.is_temp() {
-                continue;
-            }
-            let sql = generate_create_trigger_sql(trigger);
-            rows.push(schema_row("trigger", &trigger.name, &trigger.table_name, sql));
+    // and surface only via sqlite_temp_master, so skip them here. Iterate trigger
+    // definitions directly rather than via `list_triggers()` + `get_trigger()`:
+    // triggers are keyed per schema, so a name-only `get_trigger` resolves
+    // temp-first and would drop a `main` trigger that shares a name with a `temp`
+    // trigger (issue #6296).
+    for trigger in catalog.iter_triggers() {
+        if trigger.is_temp() {
+            continue;
         }
+        let sql = generate_create_trigger_sql(trigger);
+        rows.push(schema_row("trigger", &trigger.name, &trigger.table_name, sql));
     }
 
     Ok(SelectResult { columns: column_names, rows })
@@ -395,16 +397,17 @@ pub fn execute_sqlite_temp_schema_query(
         }
     }
 
-    // Add temp triggers. Triggers are also stored flat; filter on the `temp`
-    // schema tag from CREATE TEMP TRIGGER (#5532).
-    for trigger_name in catalog.list_triggers() {
-        if let Some(trigger) = catalog.get_trigger(&trigger_name) {
-            if !trigger.is_temp() {
-                continue;
-            }
-            let sql = generate_create_trigger_sql(trigger);
-            rows.push(schema_row("trigger", &trigger.name, &trigger.table_name, sql));
+    // Add temp triggers. Filter on the `temp` schema tag from CREATE TEMP
+    // TRIGGER (#5532). Iterate trigger definitions directly rather than via
+    // `list_triggers()` + `get_trigger()`: triggers are keyed per schema, and a
+    // name-only `get_trigger` resolves temp-first, so a `temp` trigger sharing a
+    // name with a `main` trigger would be emitted twice (issue #6296).
+    for trigger in catalog.iter_triggers() {
+        if !trigger.is_temp() {
+            continue;
         }
+        let sql = generate_create_trigger_sql(trigger);
+        rows.push(schema_row("trigger", &trigger.name, &trigger.table_name, sql));
     }
 
     Ok(SelectResult { columns: column_names, rows })
@@ -877,6 +880,81 @@ mod tests {
         assert!(
             !temp_names.contains(&"main_tr".to_string()),
             "temp_master must exclude main trigger"
+        );
+    }
+
+    #[test]
+    fn test_same_name_main_and_temp_triggers_each_appear_once_in_schema_views() {
+        // #6296 regression: a `main` trigger and a `temp` trigger sharing a name
+        // must each surface exactly once in their own schema view. The old
+        // `list_triggers()` + `get_trigger()` enumeration returned duplicate bare
+        // names and resolved every one temp-first, so the main trigger vanished
+        // from sqlite_master and the temp trigger was listed twice in
+        // sqlite_temp_master. Iterating `iter_triggers()` keys each definition by
+        // schema so both are distinguishable.
+        use vibesql_ast::{TriggerAction, TriggerEvent, TriggerGranularity, TriggerTiming};
+        use vibesql_catalog::TriggerDefinition;
+
+        let mut catalog = Catalog::new();
+
+        // Two base tables (one main, one conceptually the temp target); the
+        // trigger definitions only need a table name to reference.
+        let t = TableSchema::new(
+            "t".to_string(),
+            vec![ColumnSchema::new("a".to_string(), DataType::Integer, true)],
+        );
+        catalog.create_table(t).unwrap();
+        let t2 = TableSchema::new(
+            "t2".to_string(),
+            vec![ColumnSchema::new("b".to_string(), DataType::Integer, true)],
+        );
+        catalog.create_table(t2).unwrap();
+
+        // A `main` trigger and a `temp` trigger that share the bare name `tr`.
+        let mk_trigger = |name: &str, table: &str| {
+            TriggerDefinition::new(
+                name.to_string(),
+                TriggerTiming::After,
+                TriggerEvent::Insert,
+                table.to_string(),
+                TriggerGranularity::Row,
+                None,
+                TriggerAction::RawSql("SELECT 1".to_string()),
+            )
+        };
+        catalog.create_trigger(mk_trigger("tr", "t")).unwrap();
+        catalog
+            .create_trigger(mk_trigger("tr", "t2").with_schema(Some("temp".to_string())))
+            .unwrap();
+
+        let trigger_names = |result: &SelectResult| -> Vec<String> {
+            result
+                .rows
+                .iter()
+                .filter(|r| matches!(&r.values[0], SqlValue::Varchar(s) if s == "trigger"))
+                .map(|r| match &r.values[1] {
+                    SqlValue::Varchar(s) => s.to_string(),
+                    _ => String::new(),
+                })
+                .collect()
+        };
+
+        // sqlite_master: the main `tr` appears exactly once; no temp namesake.
+        let master = execute_sqlite_schema_query(&catalog).unwrap();
+        let master_triggers = trigger_names(&master);
+        assert_eq!(
+            master_triggers,
+            vec!["tr".to_string()],
+            "sqlite_master must list the main trigger `tr` exactly once (not 0 rows)"
+        );
+
+        // sqlite_temp_master: the temp `tr` appears exactly once (not twice).
+        let temp_master = execute_sqlite_temp_schema_query(&catalog).unwrap();
+        let temp_triggers = trigger_names(&temp_master);
+        assert_eq!(
+            temp_triggers,
+            vec!["tr".to_string()],
+            "sqlite_temp_master must list the temp trigger `tr` exactly once (not twice)"
         );
     }
 

--- a/crates/vibesql-executor/src/trigger_ddl.rs
+++ b/crates/vibesql-executor/src/trigger_ddl.rs
@@ -38,11 +38,36 @@ impl TriggerExecutor {
         stmt: &CreateTriggerStmt,
         original_sql: Option<&str>,
     ) -> Result<String, ExecutorError> {
+        // SQLite scopes trigger names *per schema* (like tables), so the
+        // "already exists" check must be scoped to the schema the new trigger
+        // will live in — not global. `CREATE TRIGGER temp.tr1` must succeed even
+        // when a `main.tr1` exists (e_update-2.3.1 / e_delete-2.3.2). The target
+        // schema is the explicit `schema.`/`TEMP` qualifier when present; with no
+        // qualifier it follows the target table (a temp-table target promotes the
+        // trigger to the temp schema, trigger1-1.8). `resolve_table_schema_name`
+        // is side-effect free, so computing this before target validation is safe.
+        let check_schema: Option<String> = match &stmt.schema {
+            Some(schema) => Some(schema.clone()),
+            None => {
+                let target_in_temp_schema = db
+                    .catalog
+                    .resolve_table_schema_name(&stmt.table_name)
+                    .as_deref()
+                    .is_some_and(vibesql_catalog::Catalog::is_temp_schema);
+                if target_in_temp_schema {
+                    Some("temp".to_string())
+                } else {
+                    None
+                }
+            }
+        };
+
         // `CREATE TRIGGER IF NOT EXISTS <name>` is a no-op success when a
-        // trigger with that name already exists (SQLite semantics, trigger1-1.2.0).
-        // SQLite resolves the existing-trigger check before validating the target
-        // object, so an already-present trigger short-circuits here.
-        if db.catalog.get_trigger(&stmt.trigger_name).is_some() {
+        // trigger with that name already exists *in the target schema* (SQLite
+        // semantics, trigger1-1.2.0). SQLite resolves the existing-trigger check
+        // before validating the target object, so an already-present trigger
+        // short-circuits here.
+        if db.catalog.trigger_exists_in_schema(&stmt.trigger_name, check_schema.as_deref()) {
             if stmt.if_not_exists {
                 return Ok(format!("Trigger '{}' already exists", stmt.trigger_name));
             }

--- a/crates/vibesql-storage/src/persistence/binary/catalog.rs
+++ b/crates/vibesql-storage/src/persistence/binary/catalog.rs
@@ -307,16 +307,16 @@ pub fn write_catalog<W: Write>(writer: &mut W, db: &Database) -> Result<(), Stor
     // reappears in the next session's catalog (issue #5940, Cluster A). The
     // count and the write loop iterate the same filtered list so they stay in
     // lockstep.
-    let trigger_names: Vec<String> = db
-        .catalog
-        .list_triggers()
-        .into_iter()
-        .filter(|name| db.catalog.get_trigger(name).is_some_and(|t| !t.is_temp()))
-        .collect();
-    write_u32(writer, trigger_names.len() as u32)?;
+    // Iterate trigger definitions directly. Triggers are keyed per schema, so a
+    // name-only `get_trigger` could return the temp namesake of a main trigger;
+    // collecting definitions keeps every non-temp trigger and keeps the count in
+    // lockstep with the write loop below.
+    let triggers: Vec<&vibesql_catalog::TriggerDefinition> =
+        db.catalog.iter_triggers().filter(|t| !t.is_temp()).collect();
+    write_u32(writer, triggers.len() as u32)?;
 
-    for trigger_name in trigger_names {
-        if let Some(trigger) = db.catalog.get_trigger(&trigger_name) {
+    for trigger in triggers {
+        {
             write_string(writer, &trigger.name)?;
             write_string(writer, &trigger.table_name)?;
 

--- a/crates/vibesql-storage/src/persistence/save.rs
+++ b/crates/vibesql-storage/src/persistence/save.rs
@@ -547,29 +547,30 @@ impl Database {
         // garbage that would fail to parse on reload.
         writeln!(writer, "-- Triggers")
             .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
-        for trigger_name in self.catalog.list_triggers() {
-            if let Some(trigger_def) = self.catalog.get_trigger(&trigger_name) {
-                // Skip temp triggers (`CREATE TEMP TRIGGER`): they are
-                // session-scoped and must not survive into the next session via
-                // the SQL dump (issue #5940, Cluster A).
-                if trigger_def.is_temp() {
-                    continue;
+        // Iterate trigger definitions directly. Triggers are keyed per schema, so
+        // a name-only `get_trigger` could return the temp namesake of a main
+        // trigger; iterating definitions keeps every non-temp trigger visible.
+        for trigger_def in self.catalog.iter_triggers() {
+            // Skip temp triggers (`CREATE TEMP TRIGGER`): they are
+            // session-scoped and must not survive into the next session via
+            // the SQL dump (issue #5940, Cluster A).
+            if trigger_def.is_temp() {
+                continue;
+            }
+            match trigger_def.sql_definition.as_ref() {
+                Some(sql) => {
+                    let sql = sql.trim_end_matches(';').trim();
+                    writeln!(writer, "{};", sql).map_err(|e| {
+                        StorageError::NotImplemented(format!("Write error: {}", e))
+                    })?;
                 }
-                match trigger_def.sql_definition.as_ref() {
-                    Some(sql) => {
-                        let sql = sql.trim_end_matches(';').trim();
-                        writeln!(writer, "{};", sql).map_err(|e| {
-                            StorageError::NotImplemented(format!("Write error: {}", e))
-                        })?;
-                    }
-                    None => {
-                        writeln!(
-                            writer,
-                            "-- Skipped trigger '{}' (no preserved SQL text)",
-                            trigger_def.name
-                        )
-                        .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
-                    }
+                None => {
+                    writeln!(
+                        writer,
+                        "-- Skipped trigger '{}' (no preserved SQL text)",
+                        trigger_def.name
+                    )
+                    .map_err(|e| StorageError::NotImplemented(format!("Write error: {}", e)))?;
                 }
             }
         }


### PR DESCRIPTION
## Summary

VibeSQL's trigger catalog stored triggers in a single **name-keyed** map, so a `main` trigger and a `temp`/`aux` trigger sharing a name collided with a spurious `trigger <name> already exists`. SQLite scopes trigger names **per schema**, exactly like tables. This PR schema-scopes the trigger catalog so same-named triggers in different schemas coexist, and scopes the `CREATE TRIGGER` existence check to the target schema.

The companion half of #6296 — a non-TEMP trigger's body resolving unqualified table names in its own schema (`e_update-2.2.1`) — was already implemented in #6293 (`suppress_temp_shadowing`); the engine already errors `no such table: main.<t>` correctly (verified directly against the CLI). That case stays red **only** under the TCL harness because the shim demotes `CREATE TEMP TABLE` to a main-schema table (documented harness artifact, red on baseline too), not because of an engine bug.

Closes #6296

## Changes

- **`vibesql-catalog`**: trigger storage keyed by `(schema, name)` via a schema-scoped storage key (`None`/`main` collapse to the default schema, case-insensitive schema, name spelling preserved). `main.tr` and `temp.tr` are now distinct entries.
  - `create_trigger` collision detection is per-schema.
  - New `get_trigger_in_schema` / `trigger_exists_in_schema` for precise lookups; `get_trigger` / `drop_trigger` resolve an unqualified name in SQLite's temp→main→attached search order.
  - New `iter_triggers` for callers that must see every trigger unambiguously.
  - `drop_table_triggers` / `drop_view_triggers` / the drop-table cascade remove by storage key (not bare name).
- **`vibesql-executor`**: `CREATE TRIGGER` checks existence in the **target** schema (explicit `schema.`/`TEMP` qualifier, else the target table's schema), so `CREATE TRIGGER temp.tr1` no longer collides with a leftover `main.tr1`.
- **`vibesql-storage`**: SQL-dump and binary-checkpoint persistence iterate trigger definitions directly (`iter_triggers`) instead of a name-only `list_triggers` + `get_trigger` round-trip that could return a temp namesake and drop a same-named main trigger.

## Acceptance Criteria

- [x] `e_update-2.3.1` / `e_delete-2.3.2`: a `main` trigger and a `temp`/`aux` trigger share a name without a spurious "already exists" collision — both now pass.
- [x] `e_update-2.2.1` engine behavior: a main trigger's unqualified body table reference resolves only in `main`; the missing-table case raises `no such table: main.<name>` (verified directly; remains masked under the harness by the shim's TEMP-table demotion, same as baseline and as documented in #6293).
- [x] No regression in `trigger1` / `triggerA` / `triggerD` / `temptrigger` (all unchanged or improved).
- [x] `e_delete.test` reaches 100% of runnable tests (0 failures); `e_update.test` net of the shim-blocked/ATTACH-blocked cases.

## Test Plan — TCL before/after (same machine, same harness)

| File | Baseline (pass/fail) | This PR (pass/fail) | Delta |
|------|----------------------|---------------------|-------|
| `e_delete.test` | 96 / 1 | 96 / **0** | `e_delete-2.3.2` fixed |
| `e_update.test` | 147 / 14 | **148** / 13 | `e_update-2.3.1` fixed |
| `trigger1.test` | 44 / 26 | **45** / 25 | +1 |
| `temptrigger.test` | 15 / 4 | 15 / 4 | unchanged |
| `triggerD.test` | 10 / 0 | 10 / 0 | unchanged |
| `triggerA.test` | 17 / 0 | 17 / 0 | unchanged |

Remaining `e_update.test` failures are the pre-existing `1.8.x` UPDATE-OR-conflict/transaction tests (unrelated to triggers) and `2.2.1` (shim TEMP-demotion artifact) — all red on baseline.

### Unit tests
- `cargo test -p vibesql-catalog --lib` — 60 passed (incl. 2 new: `triggers_are_scoped_per_schema`, `default_schema_trigger_collapses_to_main`)
- `cargo test -p vibesql-storage --lib` — 844 passed
- `cargo test -p vibesql-executor --lib` — 3642 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)