### PR TITLE
fix(pragma,catalog): user_version/application_id cookies + index_xinfo collation/expr cid

### DIFF
--- a/crates/vibesql-catalog/src/index.rs
+++ b/crates/vibesql-catalog/src/index.rs
@@ -91,6 +91,13 @@ pub enum IndexedColumn {
         /// When present, only the first N characters/bytes of the column value are indexed
         /// Example: UNIQUE (email(50)) indexes only first 50 characters
         prefix_length: Option<u64>,
+        /// Explicit `COLLATE <name>` on this index-column, if the `CREATE
+        /// INDEX` statement specified one (e.g. `CREATE INDEX i ON
+        /// t(d COLLATE nocase)`). `None` means the index column uses its
+        /// underlying table column's declared collation (defaulting further
+        /// to `BINARY`). Reported verbatim (case-preserving, matching
+        /// SQLite) by `PRAGMA index_xinfo`'s `coll` column — see issue #6175.
+        collation: Option<String>,
     },
     /// Expression index (functional index)
     /// Example: CREATE INDEX idx ON t(lower(name)) or CREATE INDEX idx ON t(a + b)
@@ -105,7 +112,7 @@ pub enum IndexedColumn {
 impl IndexedColumn {
     /// Create a new simple column index
     pub fn new_column(column_name: String, order: SortOrder) -> Self {
-        IndexedColumn::Column { column_name, order, prefix_length: None }
+        IndexedColumn::Column { column_name, order, prefix_length: None, collation: None }
     }
 
     /// Create a new column index with prefix length
@@ -114,7 +121,21 @@ impl IndexedColumn {
         order: SortOrder,
         prefix_length: u64,
     ) -> Self {
-        IndexedColumn::Column { column_name, order, prefix_length: Some(prefix_length) }
+        IndexedColumn::Column {
+            column_name,
+            order,
+            prefix_length: Some(prefix_length),
+            collation: None,
+        }
+    }
+
+    /// Attach an explicit `COLLATE <name>` to this index column (builder-style
+    /// chaining). A no-op on an `Expression` column. See issue #6175.
+    pub fn with_collation(mut self, collation: Option<String>) -> Self {
+        if let IndexedColumn::Column { collation: c, .. } = &mut self {
+            *c = collation;
+        }
+        self
     }
 
     /// Create a new expression index
@@ -142,6 +163,16 @@ impl IndexedColumn {
     pub fn prefix_length(&self) -> Option<u64> {
         match self {
             IndexedColumn::Column { prefix_length, .. } => *prefix_length,
+            IndexedColumn::Expression { .. } => None,
+        }
+    }
+
+    /// Get the explicit `COLLATE` name, if this index column declared one.
+    /// `None` for an `Expression` column, or a `Column` with no explicit
+    /// `COLLATE` clause (see issue #6175).
+    pub fn explicit_collation(&self) -> Option<&str> {
+        match self {
+            IndexedColumn::Column { collation, .. } => collation.as_deref(),
             IndexedColumn::Expression { .. } => None,
         }
     }

--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -74,6 +74,19 @@ pub struct SqlExecutor {
     /// current `cache_size`.
     cache_spill_enabled: bool,
     cache_spill_explicit_size: Option<i64>,
+    /// PRAGMA user_version session setting (SQLite-compatible, default 0).
+    /// SQLite persists this as a raw signed 32-bit cookie in the database
+    /// file header, available for application use; VibeSQL has no such
+    /// on-disk cookie storage yet, so this is session-only and resets to 0
+    /// on every reconnect (the TCL shim replays the last-set value across
+    /// its per-batch CLI processes so it survives a `db close` / reopen
+    /// against the same file within one logical connection — see
+    /// `tester_vibesql.tcl`'s `pragma_user_version_cookie`, issue #6175).
+    user_version: i64,
+    /// PRAGMA application_id session setting (SQLite-compatible, default 0).
+    /// Same persistence model as `user_version` above (a raw signed 32-bit
+    /// header cookie in real SQLite; session-only + shim-replayed here).
+    application_id: i64,
     /// Active WAL persistence state, present only when the opt-in
     /// `[database] wal = true` flag is set AND a file-backed database is in use.
     /// When `Some`, `save_database` checkpoints + truncates the WAL instead of
@@ -501,6 +514,8 @@ impl SqlExecutor {
                     default_cache_size_cookie: 0,
                     cache_spill_enabled: true,
                     cache_spill_explicit_size: None,
+                    user_version: 0,
+                    application_id: 0,
                     wal_state: Some(wal_state),
                     db_path: Some(db_path.clone()),
                     _db_lock: db_lock,
@@ -549,6 +564,8 @@ impl SqlExecutor {
             default_cache_size_cookie: 0,
             cache_spill_enabled: true,
             cache_spill_explicit_size: None,
+            user_version: 0,
+            application_id: 0,
             wal_state: None,
             db_path,
             _db_lock: db_lock,
@@ -1715,6 +1732,39 @@ impl SqlExecutor {
                         message: None,
                     })
                 }
+                "USER_VERSION" => {
+                    // SQLite-compatible PRAGMA user_version set (pragma.test
+                    // pragma-8.2.*, #6175). Accepts both `= N` and the
+                    // function-style `(N)` syntax (both parse to the same
+                    // `stmt.value`). A non-integral argument is a silent no-op,
+                    // matching SQLite's `getSafetyLevel`-style tolerance for
+                    // unparsable pragma arguments.
+                    if let Some(n) = pragma_value_to_i64(value) {
+                        self.user_version = n;
+                    }
+                    Ok(QueryResult {
+                        rows: Vec::new(),
+                        columns: Vec::new(),
+                        row_count: 0,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
+                "APPLICATION_ID" => {
+                    // SQLite-compatible PRAGMA application_id set (pragma.test
+                    // pragma-8.3.2, #6175). Same argument handling as
+                    // user_version above.
+                    if let Some(n) = pragma_value_to_i64(value) {
+                        self.application_id = n;
+                    }
+                    Ok(QueryResult {
+                        rows: Vec::new(),
+                        columns: Vec::new(),
+                        row_count: 0,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
                 _ => {
                     // Unknown pragma - silently ignore for SQLite compatibility
                     Ok(QueryResult {
@@ -1947,6 +1997,28 @@ impl SqlExecutor {
                     Ok(QueryResult {
                         columns: vec!["cache_spill".to_string()],
                         rows: vec![vec![Some(value.to_string())]],
+                        row_count: 1,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
+                "USER_VERSION" => {
+                    // SQLite-compatible PRAGMA user_version read (pragma.test
+                    // pragma-8.2.*, #6175). Default 0.
+                    Ok(QueryResult {
+                        columns: vec!["user_version".to_string()],
+                        rows: vec![vec![Some(self.user_version.to_string())]],
+                        row_count: 1,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
+                "APPLICATION_ID" => {
+                    // SQLite-compatible PRAGMA application_id read (pragma.test
+                    // pragma-8.3.*, #6175). Default 0.
+                    Ok(QueryResult {
+                        columns: vec!["application_id".to_string()],
+                        rows: vec![vec![Some(self.application_id.to_string())]],
                         row_count: 1,
                         execution_time_ms: None,
                         message: None,
@@ -2745,8 +2817,10 @@ impl SqlExecutor {
                         .unwrap_or(-1);
                     (cid, Some(col_name.to_string()))
                 }
-                // Expression column: SQLite reports cid -1 and a NULL name.
-                None => (-1, None),
+                // Expression column: SQLite reports cid -2 (not -1, which is
+                // reserved for a rowid reference) and a NULL name (pragma.test
+                // 23.2e, #6175).
+                None => (-2, None),
             };
 
             if extended {
@@ -2755,12 +2829,28 @@ impl SqlExecutor {
                 } else {
                     0
                 };
+                // Collation echoed by `coll`: an explicit `COLLATE` on this
+                // index-column wins; otherwise fall back to the underlying
+                // table column's declared collation; otherwise BINARY
+                // (SQLite's implicit default). Matches pragma.test 23.2d/2e
+                // (#6175).
+                let coll = column
+                    .explicit_collation()
+                    .map(|s| s.to_string())
+                    .or_else(|| {
+                        column.column_name().and_then(|col_name| {
+                            table
+                                .and_then(|t| t.get_column(col_name))
+                                .and_then(|c| c.collation.clone())
+                        })
+                    })
+                    .unwrap_or_else(|| "BINARY".to_string());
                 rows.push(vec![
                     Some(seqno.to_string()),
                     Some(cid.to_string()),
                     name,
                     Some(desc.to_string()),
-                    Some("BINARY".to_string()),
+                    Some(coll),
                     Some("1".to_string()),
                 ]);
             } else {

--- a/crates/vibesql-cli/src/executor/tests.rs
+++ b/crates/vibesql-cli/src/executor/tests.rs
@@ -1157,3 +1157,58 @@ fn test_pragma_cache_spill_default_and_toggle() {
     let result = executor.execute("PRAGMA cache_spill").unwrap();
     assert_eq!(result.rows, vec![vec![Some("0".to_string())]]);
 }
+
+#[test]
+fn test_pragma_user_version_default_set_and_negative() {
+    let mut executor = SqlExecutor::new(None).unwrap();
+
+    // Default is 0 (pragma.test pragma-8.2.1, #6175).
+    let result = executor.execute("PRAGMA user_version").unwrap();
+    assert_eq!(result.rows, vec![vec![Some("0".to_string())]]);
+
+    // `= N` form.
+    executor.execute("PRAGMA user_version = 2").unwrap();
+    let result = executor.execute("PRAGMA user_version").unwrap();
+    assert_eq!(result.rows, vec![vec![Some("2".to_string())]]);
+
+    // Negative values round-trip (pragma-8.2.14/8.2.15).
+    executor.execute("PRAGMA user_version = -450").unwrap();
+    let result = executor.execute("PRAGMA user_version").unwrap();
+    assert_eq!(result.rows, vec![vec![Some("-450".to_string())]]);
+}
+
+#[test]
+fn test_pragma_application_id_default_and_function_style_set() {
+    let mut executor = SqlExecutor::new(None).unwrap();
+
+    // Default is 0 (pragma.test pragma-8.3.1, #6175).
+    let result = executor.execute("PRAGMA application_id").unwrap();
+    assert_eq!(result.rows, vec![vec![Some("0".to_string())]]);
+
+    // Function-style `(N)` argument (pragma-8.3.2: `PRAGMA Application_ID(12345)`).
+    executor.execute("PRAGMA application_id(12345)").unwrap();
+    let result = executor.execute("PRAGMA application_id").unwrap();
+    assert_eq!(result.rows, vec![vec![Some("12345".to_string())]]);
+}
+
+#[test]
+fn test_pragma_index_xinfo_expression_column_cid_and_explicit_collation() {
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor.execute("CREATE TABLE t1(a INTEGER PRIMARY KEY, b, c, d)").unwrap();
+    executor.execute("CREATE INDEX i2x ON t1(d COLLATE nocase, c DESC)").unwrap();
+    executor.execute("CREATE INDEX i3 ON t1(d, b+c, c)").unwrap();
+
+    // Explicit COLLATE on an index column is echoed verbatim, not hardcoded
+    // BINARY (pragma.test 23.2d, #6175).
+    let result = executor.execute("PRAGMA index_xinfo(i2x)").unwrap();
+    // Columns: seqno, cid, name, desc, coll, key
+    assert_eq!(result.rows[0][4], Some("nocase".to_string()));
+    // The second (non-collated) key column still defaults to BINARY.
+    assert_eq!(result.rows[1][4], Some("BINARY".to_string()));
+
+    // An expression index column reports cid -2 (not -1, which is reserved
+    // for a rowid reference) (pragma.test 23.2e, #6175).
+    let result = executor.execute("PRAGMA index_xinfo(i3)").unwrap();
+    assert_eq!(result.rows[1][1], Some("-2".to_string()));
+    assert_eq!(result.rows[1][2], None);
+}

--- a/crates/vibesql-executor/src/index_ddl/btree_index.rs
+++ b/crates/vibesql-executor/src/index_ddl/btree_index.rs
@@ -210,11 +210,13 @@ fn convert_to_catalog_columns(columns: &[IndexColumn]) -> Vec<vibesql_catalog::I
                     order,
                     prefix_len,
                 )
+                .with_collation(col.collation().map(|c| c.to_string()))
             } else {
                 vibesql_catalog::IndexedColumn::new_column(
                     col.column_name().unwrap().to_string(),
                     order,
                 )
+                .with_collation(col.collation().map(|c| c.to_string()))
             }
         })
         .collect()

--- a/crates/vibesql-executor/src/sqlite_schema.rs
+++ b/crates/vibesql-executor/src/sqlite_schema.rs
@@ -1029,6 +1029,7 @@ mod tests {
                     column_name: "first_name".to_string(),
                     order: SortOrder::Descending,
                     prefix_length: None,
+                    collation: None,
                 },
             ],
             false, // not unique

--- a/crates/vibesql-storage/src/persistence/binary/catalog.rs
+++ b/crates/vibesql-storage/src/persistence/binary/catalog.rs
@@ -1068,15 +1068,19 @@ fn convert_ast_columns_to_catalog(
                 vibesql_ast::IndexColumn::Expression { expr, .. } => {
                     vibesql_catalog::IndexedColumn::new_expression((**expr).clone(), order)
                 }
-                vibesql_ast::IndexColumn::Column { column_name, prefix_length, .. } => {
+                vibesql_ast::IndexColumn::Column {
+                    column_name, prefix_length, collation, ..
+                } => {
                     if let Some(prefix) = prefix_length {
                         vibesql_catalog::IndexedColumn::new_column_with_prefix(
                             column_name.clone(),
                             order,
                             *prefix,
                         )
+                        .with_collation(collation.clone())
                     } else {
                         vibesql_catalog::IndexedColumn::new_column(column_name.clone(), order)
+                            .with_collation(collation.clone())
                     }
                 }
             }

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -247,6 +247,8 @@ set ::pragma_encoding ""                 ;# "" = default (UTF-8); otherwise the 
 set ::pragma_synchronous_raw ""          ;# "" = default (FULL); otherwise the last raw text set via PRAGMA synchronous=... (#6175)
 set ::pragma_cache_size_raw ""           ;# "" = default (-2000); otherwise the last raw text set via PRAGMA cache_size=... (#6175)
 array set ::pragma_default_cache_size_cookie {} ;# db-file-path -> last raw text set via PRAGMA default_cache_size=... (persists across reconnect to the SAME file, like SQLite's header cookie; #6175)
+array set ::pragma_user_version_cookie {}   ;# db-file-path -> last raw text set via PRAGMA user_version=... (persists across reconnect to the SAME file, like SQLite's header cookie; #6175)
+array set ::pragma_application_id_cookie {} ;# db-file-path -> last raw text set via PRAGMA application_id=... (persists across reconnect to the SAME file, like SQLite's header cookie; #6175)
 
 # DQS (Double-Quoted Strings) mode tracking
 # When enabled, double-quoted strings are treated as string literals instead of identifiers
@@ -1642,6 +1644,16 @@ proc build_pragma_prefix {} {
     if {$::pragma_synchronous_raw ne ""} {
         append prefix "PRAGMA synchronous=$::pragma_synchronous_raw;\n"
     }
+    # Replay PRAGMA user_version / application_id so a value set in an earlier
+    # batch is still visible to a later, freshly-spawned CLI process on the
+    # SAME logical connection AND survives a `db close` / reopen against the
+    # same file (both are real SQLite file-header cookies; #6175).
+    if {[info exists ::pragma_user_version_cookie($::db_file)]} {
+        append prefix "PRAGMA user_version=$::pragma_user_version_cookie($::db_file);\n"
+    }
+    if {[info exists ::pragma_application_id_cookie($::db_file)]} {
+        append prefix "PRAGMA application_id=$::pragma_application_id_cookie($::db_file);\n"
+    }
     # Replay real TEMP tables (#5591) so connection-scoped temp objects exist in
     # this fresh CLI process. Skip names whose CREATE TEMP TABLE is already in the
     # current batch (avoids a redundant create). IF NOT EXISTS keeps replay safe.
@@ -1836,6 +1848,22 @@ proc track_pragma_setting {sql} {
     set matches [regexp -all -inline -nocase {PRAGMA\s+(?:\w+\.)?default_cache_size\s*=\s*(-?\d+)} $sql]
     foreach {match value} $matches {
         set ::pragma_default_cache_size_cookie($::db_file) $value
+        set found 1
+    }
+
+    # Look for user_version / application_id settings (find all occurrences,
+    # use last one). Real SQLite file-header cookies (#6175): both `= N` and
+    # the function-style `(N)` syntax are accepted, mirroring the CLI parser.
+    # Tracked per-file (like default_cache_size above) so they survive a
+    # `db close` / reopen against the SAME file.
+    set matches [regexp -all -inline -nocase {PRAGMA\s+(?:\w+\.)?user_version\s*[=(]\s*(-?\d+)\s*[)]?} $sql]
+    foreach {match value} $matches {
+        set ::pragma_user_version_cookie($::db_file) $value
+        set found 1
+    }
+    set matches [regexp -all -inline -nocase {PRAGMA\s+(?:\w+\.)?application_id\s*[=(]\s*(-?\d+)\s*[)]?} $sql]
+    foreach {match value} $matches {
+        set ::pragma_application_id_cookie($::db_file) $value
         set found 1
     }
 
@@ -2805,7 +2833,7 @@ proc execsql {sql {db ""}} {
                 }
                 continue  ;# Check for more statements
             }
-            if {[regexp -nocase {^PRAGMA\s+(?:\w+\.)?(full_column_names|short_column_names|case_sensitive_like|reverse_unordered_selects|integrity_check|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|recursive_triggers|table_info|data_version|collation_list|index_list|index_xinfo|index_info|auto_vacuum|temp_store|encoding|synchronous|cache_size|default_cache_size|cache_spill)} [string trim $sql]]} {
+            if {[regexp -nocase {^PRAGMA\s+(?:\w+\.)?(full_column_names|short_column_names|case_sensitive_like|reverse_unordered_selects|integrity_check|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|recursive_triggers|table_info|data_version|collation_list|index_list|index_xinfo|index_info|auto_vacuum|temp_store|encoding|synchronous|cache_size|default_cache_size|cache_spill|user_version|application_id)} [string trim $sql]]} {
                 # This PRAGMA is supported (with =value) - stop stripping
                 break
             } else {
@@ -3615,7 +3643,7 @@ proc execsql2 {sql {db ""}} {
     set sql_upper [string toupper [string trim $sql]]
     if {[string match "PRAGMA*" $sql_upper]} {
         # Allow supported PRAGMAs through
-        if {[regexp -nocase {^PRAGMA\s+(?:database\.)?(full_column_names|short_column_names|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|recursive_triggers|data_version|collation_list|index_list|index_xinfo|index_info)} [string trim $sql]]} {
+        if {[regexp -nocase {^PRAGMA\s+(?:database\.)?(full_column_names|short_column_names|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|recursive_triggers|data_version|collation_list|index_list|index_xinfo|index_info|user_version|application_id)} [string trim $sql]]} {
             # Pass through to VibeSQL - these are supported
         } else {
             return {}  ;# Skip unsupported PRAGMA statements
@@ -7406,10 +7434,13 @@ proc sqlite3 {db args} {
         # orphaned siblings that would still be replayed on open.
         forcedelete $new_file
         lappend ::opened_dbs $new_file
-        # A genuinely fresh file has no `default_cache_size` header cookie
-        # (SQLite: cookie 0 = never set). Clear any stale tracked value from a
-        # PAST test that happened to reuse this same path (#6175).
+        # A genuinely fresh file has no `default_cache_size` / `user_version` /
+        # `application_id` header cookie (SQLite: cookie 0 = never set). Clear
+        # any stale tracked value from a PAST test that happened to reuse this
+        # same path (#6175).
         unset -nocomplain ::pragma_default_cache_size_cookie($new_file)
+        unset -nocomplain ::pragma_user_version_cookie($new_file)
+        unset -nocomplain ::pragma_application_id_cookie($new_file)
     }
 
     set ::db_file $new_file
@@ -7835,9 +7866,12 @@ proc reset_db {} {
     set ::pragma_synchronous_raw ""  ;# reset_db: synchronous resets to default FULL (#6175)
     set ::pragma_cache_size_raw ""   ;# reset_db: cache_size resets to default -2000 (#6175)
     # reset_db wipes the database file (via delete_db_with_wal above), so any
-    # tracked default_cache_size cookie for this path is stale — a fresh file
-    # has no header cookie, matching the "first open" clear in `proc sqlite3`.
+    # tracked default_cache_size/user_version/application_id cookie for this
+    # path is stale — a fresh file has no header cookie, matching the "first
+    # open" clear in `proc sqlite3`.
     unset -nocomplain ::pragma_default_cache_size_cookie($::db_file)
+    unset -nocomplain ::pragma_user_version_cookie($::db_file)
+    unset -nocomplain ::pragma_application_id_cookie($::db_file)
     set ::last_insert_rowid 0  ;# Connection closed: last_insert_rowid resets (#5843)
     # Drop all temp view/trigger replay state — reset_db wipes the database, so
     # replaying stale temp-object DDL into the fresh db would resurrect objects


### PR DESCRIPTION
## Summary

Fifth slice of the PRAGMA-support family issue #6175 (epic #5779). Implements `PRAGMA user_version` / `PRAGMA application_id` as SQLite-compatible session cookies, and fixes two `PRAGMA index_xinfo` bugs (collation echo, expression-column cid).

## Changes

### Engine (`crates/vibesql-cli/src/executor/mod.rs`)
- `PRAGMA user_version` (get/set): session-scoped signed integer, default 0. Accepts both `= N` and function-style `(N)` syntax; negative values round-trip (pragma-8.2.14/8.2.15, which already passed by coincidence and now pass for the right reason).
- `PRAGMA application_id` (get/set): same shape as `user_version` (pragma-8.3.1/8.3.2, including SQLite's `PRAGMA Application_ID(12345)` function-call form).
- 3 new unit tests in `crates/vibesql-cli/src/executor/tests.rs`.

### Catalog (`crates/vibesql-catalog/src/index.rs`)
- Added a `collation: Option<String>` field to `IndexedColumn::Column`, with a `with_collation` builder and `explicit_collation()` getter. The AST-level `IndexColumn::Column.collation` (an explicit `COLLATE` on an index column, e.g. `CREATE INDEX i ON t(d COLLATE nocase)`) was already parsed and already round-tripped through the binary snapshot format (v15+, issue #5921) — but it was silently dropped when converting the parsed AST into the catalog's in-memory `IndexedColumn` for both the live CREATE INDEX path (`vibesql-executor/src/index_ddl/btree_index.rs`) and the binary-snapshot reload path (`vibesql-storage/src/persistence/binary/catalog.rs`). Both conversion sites now propagate it. No format change — the bytes were already on disk, just never read into the in-memory catalog after `CREATE INDEX` or reload.

### PRAGMA index_xinfo (`crates/vibesql-cli/src/executor/mod.rs`)
- `coll`: was hardcoded to `"BINARY"` for every column. Now resolves the index column's explicit `COLLATE`, falling back to the underlying table column's declared collation, falling back to `BINARY` — matching SQLite (pragma.test 23.2d).
- `cid` for an expression-index column (e.g. `CREATE INDEX i3 ON t(d, b+c, c)`): was `-1` (the value reserved for a rowid reference), now `-2` per SQLite's documented `index_xinfo` semantics (pragma.test 23.2e).

### TCL shim (`scripts/tester_vibesql.tcl`)
- Added `user_version|application_id` to both PRAGMA allow-list regexes in `execsql`/`execsql2` (previously these PRAGMAs were silently stripped before reaching the CLI — same root cause class as PR #6298's `synchronous`/`cache_size` fix).
- Added per-db-file cookie tracking (`::pragma_user_version_cookie`, `::pragma_application_id_cookie`) mirroring the existing `default_cache_size` pattern: the last-set value is replayed as a `PRAGMA ...=...;` prefix in every fresh per-batch CLI process, and persists across a `db close` / reopen against the same file (both are real SQLite file-header cookies). Cleared on genuinely-fresh-file open and in `reset_db`.

## Results

| File | Before | After |
|---|---|---|
| `pragma.test` | 106/225 passing | **114/225 passing** (zero regressions; fixes pragma-8.2.1, 8.2.3.1, 8.2.3.2, 8.2.4.2, 8.3.1, 8.3.2, 23.2d, 23.2e) |
| `pragma2.test` | 3/30 | unchanged (unrelated — pager internals) |
| `pragma3.test` | 11/24 | unchanged (unrelated — multi-connection) |
| `pragma4.test` | 7/27 | unchanged (unrelated — ATTACH/EXPLAIN) |
| `pragma6.test` | 2/3 | unchanged (unrelated — `decode_hexdb` test helper) |

Reproduced live before starting (per builder instructions). Baseline `pragma.test` run showed 106 passing/83 failing/36 skipped on the current main tip (`b7f3ea835`, PR #6298 merged), matching that PR's reported end-state.

Also spot-checked `index.test` and `collate1.test` for regressions from the `IndexedColumn`/`index_xinfo` change: `index.test` has one pre-existing unrelated failure (`index-23.1`, `datatype mismatch`) confirmed present on both the pre-change and post-change binary; `collate1.test` all-skipped (unrelated to this change), no regressions.

## Bucket-A / deferred (unchanged from PR #6298's triage — no new routing needed)

`pragma-8.2.4.1`/`8.2.4.3` (need `schema_version` auto-increment-on-DDL, a materially larger slice — deferred to a future increment), pager-internal PRAGMAs (`cache_size`/`synchronous`/`page_count`/`freelist_count`/`lock_status` etc.), and multi-connection/ATTACH/C-API cases remain routed as documented in the issue's prior comments.

## Test plan

- `cargo build --release` — clean.
- `cargo test --release -p vibesql-catalog -p vibesql-cli -p vibesql-executor -p vibesql-storage` — 210 test-result blocks, all green (0 failed), including 3 new `user_version`/`application_id`/`index_xinfo` unit tests.
- `cargo clippy --release -p vibesql-catalog -p vibesql-cli -p vibesql-executor -p vibesql-storage` (lib targets) — 0 errors, no new warnings in changed code (pre-existing warnings/`--all-targets` `approx_constant` errors in unrelated test files confirmed present on `origin/main`, same precedent as PR #6298).
- `make test-tcl-file FILE=pragma.test` / `pragma2.test` / `pragma3.test` / `pragma4.test` / `pragma6.test` — results tabulated above.
- Regression spot-check: `index.test`, `collate1.test` (exercise `IndexedColumn`/collation code paths) — no new failures.

Part of #6175.