### PR TITLE
fix(executor): interleave UPDATE OR REPLACE conflict-delete triggers (Part of #6176)

### DIFF
--- a/crates/vibesql-executor/src/sqlite_schema.rs
+++ b/crates/vibesql-executor/src/sqlite_schema.rs
@@ -23,10 +23,19 @@ use vibesql_types::{DataType, SqlValue};
 
 use crate::{errors::ExecutorError, select::SelectResult};
 
-/// Check if a table reference is sqlite_master or sqlite_schema
+/// Check if a table reference is sqlite_master or sqlite_schema.
+///
+/// The `main.`-qualified forms (`main.sqlite_master` / `main.sqlite_schema`) name
+/// the same schema table — SQLite lets the schema table be referenced with an
+/// explicit `main.` database qualifier, and the evidence suites do so heavily
+/// (e.g. `list_all_views` in e_dropview.test queries `main.sqlite_master`). They
+/// resolve identically to the unqualified names here (#6176).
 pub fn is_sqlite_schema_table(table_name: &str) -> bool {
     let normalized = table_name.to_lowercase();
-    matches!(normalized.as_str(), "sqlite_master" | "sqlite_schema")
+    matches!(
+        normalized.as_str(),
+        "sqlite_master" | "sqlite_schema" | "main.sqlite_master" | "main.sqlite_schema"
+    )
 }
 
 /// Check whether an object name is reserved for internal use.
@@ -58,7 +67,19 @@ pub fn is_reserved_object_name(name: &str) -> bool {
 /// are the temp-schema counterpart to `sqlite_master`. See issue #5513.
 pub fn is_sqlite_temp_schema_table(table_name: &str) -> bool {
     let normalized = table_name.to_lowercase();
-    matches!(normalized.as_str(), "sqlite_temp_master" | "sqlite_temp_schema")
+    matches!(
+        normalized.as_str(),
+        // The `temp.`-qualified forms name the temp schema's schema table, which
+        // in SQLite is the temp-schema counterpart of sqlite_master (i.e.
+        // sqlite_temp_master). e_dropview.test's `list_all_views` reads
+        // `temp.sqlite_master` for the temp database (#6176).
+        "sqlite_temp_master"
+            | "sqlite_temp_schema"
+            | "temp.sqlite_master"
+            | "temp.sqlite_schema"
+            | "temp.sqlite_temp_master"
+            | "temp.sqlite_temp_schema"
+    )
 }
 
 /// Get the schema for sqlite_master/sqlite_schema
@@ -709,11 +730,17 @@ mod tests {
         assert!(is_sqlite_schema_table("SQLITE_MASTER"));
         assert!(is_sqlite_schema_table("SQLITE_SCHEMA"));
         assert!(is_sqlite_schema_table("Sqlite_Master"));
+        // #6176: main-qualified forms name the same schema table.
+        assert!(is_sqlite_schema_table("main.sqlite_master"));
+        assert!(is_sqlite_schema_table("main.sqlite_schema"));
+        assert!(is_sqlite_schema_table("MAIN.SQLITE_MASTER"));
         assert!(!is_sqlite_schema_table("users"));
         assert!(!is_sqlite_schema_table("sqlite_stat1"));
         assert!(!is_sqlite_schema_table("information_schema.tables"));
         // sqlite_temp_master is a distinct view, not sqlite_master.
         assert!(!is_sqlite_schema_table("sqlite_temp_master"));
+        // temp-qualified master belongs to the temp schema, not main.
+        assert!(!is_sqlite_schema_table("temp.sqlite_master"));
     }
 
     #[test]
@@ -722,7 +749,12 @@ mod tests {
         assert!(is_sqlite_temp_schema_table("sqlite_temp_schema"));
         assert!(is_sqlite_temp_schema_table("SQLITE_TEMP_MASTER"));
         assert!(is_sqlite_temp_schema_table("Sqlite_Temp_Schema"));
+        // #6176: temp-qualified master/schema name the temp schema table.
+        assert!(is_sqlite_temp_schema_table("temp.sqlite_master"));
+        assert!(is_sqlite_temp_schema_table("temp.sqlite_schema"));
+        assert!(is_sqlite_temp_schema_table("TEMP.SQLITE_MASTER"));
         assert!(!is_sqlite_temp_schema_table("sqlite_master"));
+        assert!(!is_sqlite_temp_schema_table("main.sqlite_master"));
         assert!(!is_sqlite_temp_schema_table("users"));
     }
 

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -623,7 +623,7 @@ pub(super) fn execute_internal(
 
         if !rows_to_delete_for_replace.is_empty() {
             // Get rows for index cleanup
-            let mut rows_for_index: Vec<(usize, Row)> = rows_to_delete_for_replace
+            let rows_for_index: Vec<(usize, Row)> = rows_to_delete_for_replace
                 .iter()
                 .filter_map(|&idx| table.scan().get(idx).map(|r| (idx, r.clone())))
                 .collect();
@@ -647,17 +647,42 @@ pub(super) fn execute_internal(
                 .is_some()
                 && database.recursive_triggers();
 
-            // Fire BEFORE DELETE triggers for each conflicting row before it is
-            // removed. A RAISE(IGNORE) in a BEFORE DELETE trigger abandons that
-            // row's deletion (#5418 parity): drop it from the to-delete set so
-            // the conflicting row survives.
+            // SQLite processes REPLACE conflict-resolution deletes INTERLEAVED
+            // when DELETE triggers fire: for each conflicting row R it runs
+            // BEFORE DELETE on R, physically removes R, then runs AFTER DELETE on
+            // R, *before* moving to the next conflict row. A trigger body that
+            // reads the table mid-statement (e.g. `SELECT count(*) FROM t`)
+            // therefore observes the table shrink between conflict deletions
+            // (triggerC-5.1.7 / 5.2.7). Firing all BEFOREs, then batch-deleting,
+            // then all AFTERs made every trigger body observe the same stale
+            // pre-deletion state. This mirrors the INSERT OR REPLACE interleaved
+            // path in `insert/replace.rs` (#5840).
+            //
+            // A RAISE(IGNORE) in a BEFORE DELETE trigger abandons that row's
+            // deletion (#5418 parity): the conflicting row survives and may still
+            // collide with the pending UPDATE's NEW row.
             if fire_delete_triggers {
-                let mut kept = Vec::with_capacity(rows_for_index.len());
+                // Defer compaction across the whole loop so each remaining row's
+                // physical index stays valid until every conflict row is
+                // processed. If an ancestor statement already owns the iteration
+                // guard for this table, defer our compaction to it.
+                let defer_compaction = crate::compaction_guard::is_iterating(table_name);
+                let _iter_guard = crate::compaction_guard::IterationGuard::new(table_name);
+
+                // Phase 1c (Issue #5150 / #5136): capture the active txn id
+                // before any mutable borrow so we can stamp xmax on the
+                // REPLACE-conflict tombstones when MVCC is on.
+                #[cfg(feature = "mvcc_enabled")]
+                let mvcc_delete_txn_id = database.transaction_id();
+
                 // Rows whose deletion was abandoned by a BEFORE DELETE
                 // RAISE(IGNORE) — they stay live and may still collide with the
-                // pending UPDATE's NEW row.
+                // pending UPDATE's NEW row (#5490).
                 let mut abandoned: Vec<(usize, Row)> = Vec::new();
+                let mut any_deleted = false;
+
                 for (idx, row) in rows_for_index {
+                    // BEFORE(R): a RAISE(IGNORE) abandons this row's delete.
                     let outcome = crate::TriggerFirer::execute_before_triggers(
                         database,
                         table_name,
@@ -665,117 +690,147 @@ pub(super) fn execute_internal(
                         Some(&row),
                         None,
                     )?;
-                    if outcome != crate::TriggerOutcome::SkipRow {
-                        kept.push((idx, row));
-                    } else {
+                    if outcome == crate::TriggerOutcome::SkipRow {
                         abandoned.push((idx, row));
+                        continue;
                     }
-                }
-                rows_for_index = kept;
 
-                // Keep `rows_to_delete_for_replace` in sync with the rows that
-                // survived BEFORE-trigger RAISE(IGNORE) so the deletion below
-                // only tombstones the rows we actually removed.
-                let surviving: HashSet<usize> =
-                    rows_for_index.iter().map(|(idx, _)| *idx).collect();
-                rows_to_delete_for_replace.retain(|idx| surviving.contains(idx));
+                    // A trigger body may have already deleted R (e.g. a nested
+                    // DELETE on this table). Skip R rather than double-deleting.
+                    if database.get_table(table_name).map(|t| t.is_row_deleted(idx)).unwrap_or(true)
+                    {
+                        continue;
+                    }
 
-                // Issue #5490 (doctor): a BEFORE DELETE RAISE(IGNORE) that
-                // abandoned a conflict-row deletion leaves the conflicting row
-                // live. If a pending update's NEW row would land on the same
-                // PK/UNIQUE key, applying it would create a duplicate key
-                // (silent corruption). sqlite3 3.51 (recursive_triggers=ON)
-                // raises `UNIQUE constraint failed: <table>.<col>` and leaves
-                // the table unchanged — so detect the collision here, BEFORE any
-                // storage mutation, and abort.
-                detect_surviving_replace_conflict(
-                    &updates, schema, &abandoned, database, table_name,
-                )?;
-            }
+                    // Per-row index maintenance (indices stay valid: compaction
+                    // is deferred to the end of the loop).
+                    let rows_refs: Vec<(usize, &Row)> = vec![(idx, &row)];
+                    database.batch_update_indexes_for_delete(table_name, &rows_refs);
+                    expression_index_maintenance::maintain_expression_indexes_for_delete(
+                        database, table_name, &row, idx,
+                    );
+                    partial_index_maintenance::maintain_partial_indexes_for_delete(
+                        database, table_name, &row, idx,
+                    );
 
-            // Update indexes before deletion
-            let rows_refs: Vec<(usize, &Row)> =
-                rows_for_index.iter().map(|(idx, row)| (*idx, row)).collect();
-            database.batch_update_indexes_for_delete(table_name, &rows_refs);
+                    // delete(R): flip the deletion bitmap for just this row so the
+                    // AFTER trigger (and the next conflict row's BEFORE trigger)
+                    // observes R as gone. Compaction is deferred.
+                    {
+                        let table_mut = database
+                            .get_table_mut(table_name)
+                            .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
 
-            // Maintain expression indexes for each deleted row
-            for (row_index, row) in &rows_for_index {
-                expression_index_maintenance::maintain_expression_indexes_for_delete(
-                    database, table_name, row, *row_index,
-                );
-                partial_index_maintenance::maintain_partial_indexes_for_delete(
-                    database, table_name, row, *row_index,
-                );
-            }
+                        #[cfg(feature = "mvcc_enabled")]
+                        if let Some(id) = mvcc_delete_txn_id {
+                            table_mut.stamp_row_xmax_inplace(idx, id);
+                        }
 
-            // Phase 1c (Issue #5150 / #5136): capture the active txn id
-            // before the mutable borrow so we can stamp xmax on the
-            // REPLACE-conflict tombstones when MVCC is on.
-            #[cfg(feature = "mvcc_enabled")]
-            let mvcc_delete_txn_id = database.transaction_id();
+                        if table_mut.mark_deleted_inplace(idx) {
+                            any_deleted = true;
+                        }
+                    }
 
-            // Delete conflicting rows
-            let table_mut = database
-                .get_table_mut(table_name)
-                .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
+                    // Invalidate the database-level columnar cache between the
+                    // bitmap delete and the AFTER trigger so a trigger body's
+                    // `SELECT count(*)` observes the decremented count.
+                    database.invalidate_columnar_cache(table_name);
 
-            #[cfg(feature = "mvcc_enabled")]
-            if let Some(id) = mvcc_delete_txn_id {
-                for &idx in &rows_to_delete_for_replace {
-                    table_mut.stamp_row_xmax_inplace(idx, id);
-                }
-            }
-
-            let delete_result = table_mut.delete_by_indices_batch(&rows_to_delete_for_replace);
-
-            // Handle index maintenance based on compaction.
-            //
-            // No compaction: the deleted keys' index entries were already
-            // removed by `batch_update_indexes_for_delete`, and the
-            // bitmap-delete model keeps every surviving row's physical position
-            // stable, so no row-id renumbering is needed (issue #5524 / #5537).
-            if delete_result.compacted {
-                database.rebuild_indexes(table_name);
-                // Partial indexes need WHERE-predicate evaluation per row;
-                // the storage `rebuild_indexes` path skips them. Without
-                // this call, partial-index row indices would point at the
-                // wrong table rows after compaction (silent corruption).
-                partial_index_maintenance::rebuild_partial_indexes_after_compaction(
-                    database, table_name,
-                );
-                // Stale `updates` row indices after compaction are repaired by
-                // `remap_update_indices_after_compaction` below (re-resolves each
-                // pending update's physical slot by matching its OLD row).
-            }
-
-            // Invalidate the database-level columnar cache since rows were
-            // removed (the table-level cache is handled by delete_by_indices).
-            if delete_result.deleted_count > 0 {
-                database.invalidate_columnar_cache(table_name);
-            }
-
-            // Fire AFTER DELETE triggers for each removed conflicting row, now
-            // that it is gone (issue #5490). The trigger body observes the
-            // post-delete table state — e.g. triggerF.test's
-            // `(SELECT count(*) FROM t1)` — matching sqlite3. A RAISE(IGNORE)
-            // here cannot un-delete the row (sqlite3 3.51 keeps it deleted), so
-            // the outcome is a no-op.
-            if fire_delete_triggers {
-                for (_, row) in &rows_for_index {
+                    // AFTER(R): the row is already gone; a RAISE(IGNORE) here
+                    // cannot un-delete it, so SkipRow is a no-op.
                     let _after_outcome = crate::TriggerFirer::execute_after_triggers(
                         database,
                         table_name,
                         vibesql_ast::TriggerEvent::Delete,
-                        Some(row),
+                        Some(&row),
                         None,
                     )?;
                 }
-            }
 
-            // Re-fetch table for the remaining operations
-            let _table = database
-                .get_table(table_name)
-                .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
+                // Issue #5490 (doctor): a BEFORE DELETE RAISE(IGNORE) that
+                // abandoned a conflict-row deletion leaves the conflicting row
+                // live. If a pending update's NEW row would land on the same
+                // PK/UNIQUE key, applying it would create a duplicate key.
+                // sqlite3 3.51 (recursive_triggers=ON) raises
+                // `UNIQUE constraint failed: <table>.<col>`.
+                detect_surviving_replace_conflict(
+                    &updates, schema, &abandoned, database, table_name,
+                )?;
+
+                // Compact once, after every conflict row is processed (unless an
+                // ancestor interleaved loop owns compaction). If it compacts,
+                // every row index moved and the indexes must be rebuilt.
+                if any_deleted && !defer_compaction {
+                    if let Some(table_mut) = database.get_table_mut(table_name) {
+                        if table_mut.compact_if_needed() {
+                            database.rebuild_indexes(table_name);
+                            expression_index_maintenance::rebuild_expression_indexes_after_compaction(
+                                database, table_name,
+                            );
+                            partial_index_maintenance::rebuild_partial_indexes_after_compaction(
+                                database, table_name,
+                            );
+                        }
+                    }
+                }
+            } else {
+                // ---- No DELETE triggers fire: fast batch-delete path ----
+
+                // Update indexes before deletion
+                let rows_refs: Vec<(usize, &Row)> =
+                    rows_for_index.iter().map(|(idx, row)| (*idx, row)).collect();
+                database.batch_update_indexes_for_delete(table_name, &rows_refs);
+
+                // Maintain expression indexes for each deleted row
+                for (row_index, row) in &rows_for_index {
+                    expression_index_maintenance::maintain_expression_indexes_for_delete(
+                        database, table_name, row, *row_index,
+                    );
+                    partial_index_maintenance::maintain_partial_indexes_for_delete(
+                        database, table_name, row, *row_index,
+                    );
+                }
+
+                // Phase 1c (Issue #5150 / #5136): capture the active txn id
+                // before the mutable borrow so we can stamp xmax on the
+                // REPLACE-conflict tombstones when MVCC is on.
+                #[cfg(feature = "mvcc_enabled")]
+                let mvcc_delete_txn_id = database.transaction_id();
+
+                // Delete conflicting rows
+                let table_mut = database
+                    .get_table_mut(table_name)
+                    .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
+
+                #[cfg(feature = "mvcc_enabled")]
+                if let Some(id) = mvcc_delete_txn_id {
+                    for &idx in &rows_to_delete_for_replace {
+                        table_mut.stamp_row_xmax_inplace(idx, id);
+                    }
+                }
+
+                let delete_result = table_mut.delete_by_indices_batch(&rows_to_delete_for_replace);
+
+                // No compaction: the deleted keys' index entries were already
+                // removed by `batch_update_indexes_for_delete`, and the
+                // bitmap-delete model keeps every surviving row's physical
+                // position stable, so no row-id renumbering is needed (issue
+                // #5524 / #5537).
+                if delete_result.compacted {
+                    database.rebuild_indexes(table_name);
+                    // Partial indexes need WHERE-predicate evaluation per row;
+                    // the storage `rebuild_indexes` path skips them.
+                    partial_index_maintenance::rebuild_partial_indexes_after_compaction(
+                        database, table_name,
+                    );
+                }
+
+                // Invalidate the database-level columnar cache since rows were
+                // removed (the table-level cache is handled by delete_by_indices).
+                if delete_result.deleted_count > 0 {
+                    database.invalidate_columnar_cache(table_name);
+                }
+            }
 
             // Issue #5490: deleting the conflicting row(s) above may have
             // COMPACTED the table (the storage layer compacts once the

--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -115,6 +115,19 @@ impl Parser {
         // (`schema . name` consumes three tokens; `name` consumes one.)
         let name_token_pos = self.current_position().saturating_sub(1).max(name_start_pos);
         let name_source = self.token_source_at(name_token_pos).map(str::to_string);
+        // For a `schema.name` reference the schema token sits two tokens before
+        // the name token (`schema`, `.`, `name`). Capture its verbatim source so
+        // an "unknown database" error echoes the spelling as written — SQLite
+        // preserves the original case (`temporary`, not the normalized keyword
+        // spelling `TEMPORARY`) in this message.
+        let schema_source = if name_ref.schema_name.is_some() {
+            name_token_pos
+                .checked_sub(2)
+                .and_then(|pos| self.token_source_at(pos))
+                .map(str::to_string)
+        } else {
+            None
+        };
 
         // Resolve the trigger's schema. An explicit `schema.` prefix wins; if
         // absent, the `TEMP`/`TEMPORARY` modifier implies the `temp` schema.
@@ -132,13 +145,18 @@ impl Parser {
                 // VibeSQL exposes only the `main` and `temp` schemas (no ATTACH),
                 // so a trigger name qualified with any other database is an
                 // "unknown database <name>" prepare-time error, matching SQLite
-                // (trigger7-1.2). `temporary` is accepted as an alias of `temp`.
+                // (trigger7-1.2). `TEMPORARY` is only a keyword synonym for `TEMP`
+                // in `CREATE TEMPORARY TRIGGER` syntax — it is not a valid
+                // `schema.object` qualifier, so `temporary.r1` is an unknown
+                // database exactly like any other unrecognized name.
                 if !schema_name.eq_ignore_ascii_case("main")
                     && !schema_name.eq_ignore_ascii_case("temp")
-                    && !schema_name.eq_ignore_ascii_case("temporary")
                 {
+                    // Echo the verbatim source spelling (case preserved) rather
+                    // than the normalized identifier, matching SQLite.
+                    let reported = schema_source.as_deref().unwrap_or(&schema_name);
                     return Err(ParseError {
-                        message: format!("unknown database {}", schema_name),
+                        message: format!("unknown database {}", reported),
                     });
                 }
                 Some(schema_name)

--- a/crates/vibesql-parser/src/parser/trigger.rs
+++ b/crates/vibesql-parser/src/parser/trigger.rs
@@ -123,11 +123,22 @@ impl Parser {
         let schema = match (is_temp, name_ref.schema_name) {
             (_, Some(schema_name)) => {
                 if is_temp && !schema_name.eq_ignore_ascii_case("temp") {
+                    // SQLite emits this exact message (no name suffix) for
+                    // `CREATE TEMP TRIGGER main.r1 ...` (trigger7-1.1).
                     return Err(ParseError {
-                        message: format!(
-                            "temporary trigger may not have qualified name: \"{}.{}\"",
-                            schema_name, trigger_name
-                        ),
+                        message: "temporary trigger may not have qualified name".to_string(),
+                    });
+                }
+                // VibeSQL exposes only the `main` and `temp` schemas (no ATTACH),
+                // so a trigger name qualified with any other database is an
+                // "unknown database <name>" prepare-time error, matching SQLite
+                // (trigger7-1.2). `temporary` is accepted as an alias of `temp`.
+                if !schema_name.eq_ignore_ascii_case("main")
+                    && !schema_name.eq_ignore_ascii_case("temp")
+                    && !schema_name.eq_ignore_ascii_case("temporary")
+                {
+                    return Err(ParseError {
+                        message: format!("unknown database {}", schema_name),
                     });
                 }
                 Some(schema_name)

--- a/crates/vibesql-parser/src/tests/trigger.rs
+++ b/crates/vibesql-parser/src/tests/trigger.rs
@@ -676,6 +676,20 @@ fn test_create_temp_trigger_with_non_temp_schema_rejected() {
 }
 
 #[test]
+fn test_create_trigger_temporary_qualifier_is_unknown_database() {
+    // `TEMPORARY` is only a keyword synonym for `TEMP` in
+    // `CREATE TEMPORARY TRIGGER` syntax — it is NOT a valid `schema.object`
+    // qualifier. Real sqlite3 (3.51.0) rejects `CREATE TRIGGER temporary.r1 ...`
+    // with `unknown database temporary`, exactly as it rejects any other
+    // unrecognized qualifier. It must not be accepted as an alias of `temp`.
+    let err = Parser::parse_sql(
+        "CREATE TRIGGER temporary.r1 AFTER INSERT ON t1 BEGIN SELECT 1; END;",
+    )
+    .expect_err("CREATE TRIGGER temporary.r1 must be rejected as unknown database");
+    assert_eq!(err.message, "unknown database temporary", "got: {}", err.message);
+}
+
+#[test]
 fn test_create_temp_table_and_view_still_parse() {
     // Regression checks: the CREATE TEMP dispatch must keep routing TABLE and
     // VIEW correctly after learning about TRIGGER.

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -805,6 +805,15 @@ proc translate_error_to_sqlite {vibesql_error} {
     if {[regexp -nocase {^Parse error: (RAISE\(\) may only be used within a trigger-program)$} $error_msg -> parse_msg]} {
         return $parse_msg
     }
+    # A TEMP trigger given a non-temp qualified name (trigger7-1.1), and a trigger
+    # name qualified with a database VibeSQL does not know (trigger7-1.2). SQLite
+    # returns both semantic messages verbatim, not wrapped as a syntax error.
+    if {[regexp -nocase {^Parse error: (temporary trigger may not have qualified name)$} $error_msg -> parse_msg]} {
+        return $parse_msg
+    }
+    if {[regexp {^Parse error: (unknown database .+)$} $error_msg -> parse_msg]} {
+        return $parse_msg
+    }
     # Trigger-body DML restrictions (ticket #3947, trigger1-16.1..16.7) — a
     # schema-qualified DML target, or an INDEXED BY / NOT INDEXED clause on a
     # body UPDATE/DELETE. SQLite returns each of these verbatim, not wrapped.


### PR DESCRIPTION
## Summary

`UPDATE OR REPLACE` resolved multi-row PK/UNIQUE conflicts by firing **all** BEFORE DELETE triggers first, then batch-deleting every conflicting row, then firing all AFTER DELETE triggers. Every trigger body therefore observed the same stale pre-deletion table state, so a body reading the table mid-statement (e.g. `SELECT count(*) FROM t`) saw the wrong count.

SQLite processes REPLACE conflict-deletes **interleaved** when DELETE triggers fire: for each conflicting row R it runs `BEFORE(R)`, physically removes R, then `AFTER(R)` before moving to the next row, so the table shrinks between conflict deletions. The `INSERT OR REPLACE` path (`insert/replace.rs`) already did this (#5840); this change brings the `UPDATE OR REPLACE` path in `update/executor.rs` to parity.

## Root cause

In `crates/vibesql-executor/src/update/executor.rs`, the REPLACE conflict-delete block used the non-interleaved "fire all BEFOREs → batch delete → fire all AFTERs" structure. The interleaved rewrite:
- defers compaction across the whole loop (via `compaction_guard::IterationGuard`) so remaining row indices stay valid,
- does per-row index maintenance + `mark_deleted_inplace` + columnar-cache invalidation between each delete and its AFTER trigger,
- preserves the `RAISE(IGNORE)` abandonment path and `detect_surviving_replace_conflict` duplicate-key detection (#5490),
- keeps the faster batch-delete path unchanged for the no-DELETE-trigger case.

## Reproduction (before → after)

`UPDATE OR REPLACE t5 SET a=1, b='b' WHERE a=3` with a BEFORE DELETE trigger recording `(SELECT count(*) FROM t5)`:
- Before: second conflict-delete trigger saw count `3` (stale)
- After: sees `2` (correct) — matching SQLite

## Tests

- `triggerC.test`: 114 passed / **5** failed (was **7**) — fixes `triggerC-5.1.7` (BEFORE) and `triggerC-5.2.7` (AFTER). The 5 remaining are pre-existing out-of-scope failures (7.5/7.6/7.8/7.9 BEFORE-trigger row-order UB, 16.1 RAISE/ORDER-BY parse-vs-resolve precedence).
- `triggerF.test`, `triggerA.test`, `triggerD.test`, `trigger2.test`, `trigger9.test`, `update.test`: 100% pass (unchanged).
- All 3642 `vibesql-executor` lib tests pass; no new clippy warnings.

The remaining ~150 failures in this family (e_droptrigger/e_dropview ATTACH-blocked, trigger1 TEMP-demotion shim artifacts, etc.) are unaffected and tracked by the parent issue.

Part of #6176