### PR TITLE
fix(pragma,tcl): implement PRAGMA schema_version with DDL/VACUUM auto-increment

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -87,6 +87,14 @@ pub struct SqlExecutor {
     /// Same persistence model as `user_version` above (a raw signed 32-bit
     /// header cookie in real SQLite; session-only + shim-replayed here).
     application_id: i64,
+    /// PRAGMA schema_version session setting (SQLite-compatible, default 0).
+    /// Unlike `user_version`/`application_id`, SQLite auto-increments this
+    /// cookie every time the schema changes (CREATE/DROP/ALTER TABLE/INDEX/
+    /// VIEW/TRIGGER, and VACUUM) — see the explicit bump at each successful
+    /// DDL statement's dispatch site below (pragma.test pragma-8.1.*/8.2.4.*,
+    /// #6175). Same session-only + shim-replayed persistence model as
+    /// `user_version` (no on-disk cookie storage yet).
+    schema_version: i64,
     /// Active WAL persistence state, present only when the opt-in
     /// `[database] wal = true` flag is set AND a file-backed database is in use.
     /// When `Some`, `save_database` checkpoints + truncates the WAL instead of
@@ -516,6 +524,7 @@ impl SqlExecutor {
                     cache_spill_explicit_size: None,
                     user_version: 0,
                     application_id: 0,
+                    schema_version: 0,
                     wal_state: Some(wal_state),
                     db_path: Some(db_path.clone()),
                     _db_lock: db_lock,
@@ -566,6 +575,7 @@ impl SqlExecutor {
             cache_spill_explicit_size: None,
             user_version: 0,
             application_id: 0,
+            schema_version: 0,
             wal_state: None,
             db_path,
             _db_lock: db_lock,
@@ -582,6 +592,17 @@ impl SqlExecutor {
     /// Returns true if the current session is inside an active transaction.
     pub fn in_transaction(&self) -> bool {
         self.db.in_transaction()
+    }
+
+    /// Bump the session's `PRAGMA schema_version` cookie after a successful
+    /// schema-changing statement (CREATE/DROP/ALTER TABLE/INDEX/VIEW/TRIGGER,
+    /// or VACUUM) — mirrors SQLite's on-disk schema-cookie increment
+    /// (pragma.test pragma-8.1.5/8.1.6, #6175). Wrapping add: SQLite's cookie
+    /// is a 32-bit signed int that can in principle wrap; matching that is
+    /// simpler than special-casing overflow for a value no real test drives
+    /// anywhere near i64::MAX.
+    fn bump_schema_version(&mut self) {
+        self.schema_version = self.schema_version.wrapping_add(1);
     }
 
     pub fn execute(&mut self, sql: &str) -> anyhow::Result<QueryResult> {
@@ -640,6 +661,7 @@ impl SqlExecutor {
                 ) {
                     Ok(_) => {
                         result.row_count = 0; // DDL doesn't return rows
+                        self.bump_schema_version();
                     }
                     Err(e) => return Err(anyhow::anyhow!("{}", e)),
                 }
@@ -781,6 +803,7 @@ impl SqlExecutor {
                 ) {
                     Ok(_) => {
                         result.row_count = 0; // DDL doesn't return rows
+                        self.bump_schema_version();
                     }
                     Err(e) => return Err(anyhow::anyhow!("{}", e)),
                 }
@@ -792,6 +815,7 @@ impl SqlExecutor {
                 ) {
                     Ok(_) => {
                         result.row_count = 0; // DDL doesn't return rows
+                        self.bump_schema_version();
                     }
                     Err(e) => return Err(anyhow::anyhow!("{}", e)),
                 }
@@ -800,6 +824,7 @@ impl SqlExecutor {
                 match vibesql_executor::DropTableExecutor::execute(&drop_stmt, &mut self.db) {
                     Ok(_) => {
                         result.row_count = 0; // DDL doesn't return rows
+                        self.bump_schema_version();
                     }
                     Err(e) => return Err(anyhow::anyhow!("{}", e)),
                 }
@@ -823,6 +848,7 @@ impl SqlExecutor {
                 ) {
                     Ok(_) => {
                         result.row_count = 0; // DDL doesn't return rows
+                        self.bump_schema_version();
                     }
                     Err(e) => return Err(anyhow::anyhow!("{}", e)),
                 }
@@ -831,6 +857,7 @@ impl SqlExecutor {
                 match vibesql_executor::TriggerExecutor::alter_trigger(&mut self.db, &alter_stmt) {
                     Ok(_) => {
                         result.row_count = 0; // DDL doesn't return rows
+                        self.bump_schema_version();
                     }
                     Err(e) => return Err(anyhow::anyhow!("{}", e)),
                 }
@@ -839,6 +866,7 @@ impl SqlExecutor {
                 match vibesql_executor::TriggerExecutor::drop_trigger(&mut self.db, &drop_stmt) {
                     Ok(_) => {
                         result.row_count = 0; // DDL doesn't return rows
+                        self.bump_schema_version();
                     }
                     Err(e) => return Err(anyhow::anyhow!("{}", e)),
                 }
@@ -882,6 +910,9 @@ impl SqlExecutor {
                     Ok(_reclaimed) => {
                         result.message = Some("VACUUM completed".to_string());
                         result.row_count = 0; // VACUUM doesn't return rows
+                                              // SQLite bumps the schema-version cookie on VACUUM too
+                                              // (pragma.test pragma-8.2.4.2/8.2.4.3, #6175).
+                        self.bump_schema_version();
                     }
                     Err(e) => return Err(anyhow::anyhow!("{}", e)),
                 }
@@ -920,6 +951,7 @@ impl SqlExecutor {
                     Ok(msg) => {
                         result.message = Some(msg);
                         result.row_count = 0; // DDL doesn't return rows
+                        self.bump_schema_version();
                     }
                     Err(e) => return Err(anyhow::anyhow!("{}", e)),
                 }
@@ -929,6 +961,7 @@ impl SqlExecutor {
                     Ok(msg) => {
                         result.message = Some(msg);
                         result.row_count = 0; // DDL doesn't return rows
+                        self.bump_schema_version();
                     }
                     Err(e) => return Err(anyhow::anyhow!("{}", e)),
                 }
@@ -945,6 +978,7 @@ impl SqlExecutor {
                     Ok(msg) => {
                         result.message = Some(msg);
                         result.row_count = 0; // DDL doesn't return rows
+                        self.bump_schema_version();
                     }
                     Err(e) => return Err(anyhow::anyhow!("{}", e)),
                 }
@@ -1765,6 +1799,26 @@ impl SqlExecutor {
                         message: None,
                     })
                 }
+                "SCHEMA_VERSION" => {
+                    // SQLite-compatible PRAGMA schema_version set (pragma.test
+                    // pragma-8.1.1/8.1.4/8.1.8, #6175). Same argument handling
+                    // as user_version above. Note: real SQLite additionally
+                    // blocks this write when DEFENSIVE mode is enabled
+                    // (pragma-8.1.3) — VibeSQL has no DEFENSIVE mode (the
+                    // `sqlite3_db_config` C-API stub is a no-op), so that one
+                    // sub-case is a known, documented gap rather than
+                    // reclassified/masked.
+                    if let Some(n) = pragma_value_to_i64(value) {
+                        self.schema_version = n;
+                    }
+                    Ok(QueryResult {
+                        rows: Vec::new(),
+                        columns: Vec::new(),
+                        row_count: 0,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
                 _ => {
                     // Unknown pragma - silently ignore for SQLite compatibility
                     Ok(QueryResult {
@@ -2019,6 +2073,19 @@ impl SqlExecutor {
                     Ok(QueryResult {
                         columns: vec!["application_id".to_string()],
                         rows: vec![vec![Some(self.application_id.to_string())]],
+                        row_count: 1,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
+                "SCHEMA_VERSION" => {
+                    // SQLite-compatible PRAGMA schema_version read (pragma.test
+                    // pragma-8.1.*, #6175). Default 0; auto-incremented on
+                    // every successful DDL statement / VACUUM (see the bump
+                    // sites at each DDL statement's dispatch arm below).
+                    Ok(QueryResult {
+                        columns: vec!["schema_version".to_string()],
+                        rows: vec![vec![Some(self.schema_version.to_string())]],
                         row_count: 1,
                         execution_time_ms: None,
                         message: None,

--- a/crates/vibesql-cli/src/executor/tests.rs
+++ b/crates/vibesql-cli/src/executor/tests.rs
@@ -1192,6 +1192,37 @@ fn test_pragma_application_id_default_and_function_style_set() {
 }
 
 #[test]
+fn test_pragma_schema_version_default_set_and_ddl_autoincrement() {
+    let mut executor = SqlExecutor::new(None).unwrap();
+
+    // Default is 0.
+    let result = executor.execute("PRAGMA schema_version").unwrap();
+    assert_eq!(result.rows, vec![vec![Some("0".to_string())]]);
+
+    // Explicit `= N` set (pragma.test pragma-8.1.1/8.1.2).
+    executor.execute("PRAGMA schema_version = 105").unwrap();
+    let result = executor.execute("PRAGMA schema_version").unwrap();
+    assert_eq!(result.rows, vec![vec![Some("105".to_string())]]);
+
+    // A successful DDL statement bumps the cookie by 1 (pragma-8.1.5/8.1.6:
+    // schema_version 106 -> CREATE TABLE -> 107).
+    executor.execute("PRAGMA schema_version = 106").unwrap();
+    executor.execute("CREATE TABLE t4(a, b, c)").unwrap();
+    let result = executor.execute("PRAGMA schema_version").unwrap();
+    assert_eq!(result.rows, vec![vec![Some("107".to_string())]]);
+
+    // VACUUM also bumps the cookie (pragma-8.2.4.2/8.2.4.3: 108 -> VACUUM -> 109).
+    executor.execute("PRAGMA schema_version = 108").unwrap();
+    executor.execute("VACUUM").unwrap();
+    let result = executor.execute("PRAGMA schema_version").unwrap();
+    assert_eq!(result.rows, vec![vec![Some("109".to_string())]]);
+
+    // A plain read (no DDL) leaves the cookie unchanged.
+    let result = executor.execute("PRAGMA schema_version").unwrap();
+    assert_eq!(result.rows, vec![vec![Some("109".to_string())]]);
+}
+
+#[test]
 fn test_pragma_index_xinfo_expression_column_cid_and_explicit_collation() {
     let mut executor = SqlExecutor::new(None).unwrap();
     executor.execute("CREATE TABLE t1(a INTEGER PRIMARY KEY, b, c, d)").unwrap();

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -249,6 +249,7 @@ set ::pragma_cache_size_raw ""           ;# "" = default (-2000); otherwise the 
 array set ::pragma_default_cache_size_cookie {} ;# db-file-path -> last raw text set via PRAGMA default_cache_size=... (persists across reconnect to the SAME file, like SQLite's header cookie; #6175)
 array set ::pragma_user_version_cookie {}   ;# db-file-path -> last raw text set via PRAGMA user_version=... (persists across reconnect to the SAME file, like SQLite's header cookie; #6175)
 array set ::pragma_application_id_cookie {} ;# db-file-path -> last raw text set via PRAGMA application_id=... (persists across reconnect to the SAME file, like SQLite's header cookie; #6175)
+array set ::pragma_schema_version_cookie {} ;# db-file-path -> running schema_version cookie: last explicit set PLUS every DDL/VACUUM auto-increment seen since (persists across reconnect to the SAME file, like SQLite's header cookie; #6175)
 
 # DQS (Double-Quoted Strings) mode tracking
 # When enabled, double-quoted strings are treated as string literals instead of identifiers
@@ -1688,6 +1689,20 @@ proc build_pragma_prefix {} {
             append prefix "${ddl};\n"
         }
     }
+    # Replay PRAGMA schema_version so the running cookie (last explicit set
+    # plus every DDL/VACUUM auto-increment tracked since) is the starting
+    # point for this fresh CLI process, both across per-batch process
+    # boundaries on the SAME connection and across a `db close` / reopen
+    # against the same file (#6175). Placed LAST — after the TEMP table/view/
+    # trigger replay above — so those replayed CREATE statements (which the
+    # engine's schema_version bump cannot distinguish from "real" DDL, since
+    # the shim already demotes `CREATE TEMP TABLE` to plain `CREATE TABLE`
+    # before ever reaching VibeSQL) can never leak an extra +1 into this
+    # session's schema_version: this explicit assignment always has the
+    # final word before the test's own statement runs.
+    if {[info exists ::pragma_schema_version_cookie($::db_file)]} {
+        append prefix "PRAGMA schema_version=$::pragma_schema_version_cookie($::db_file);\n"
+    }
     return $prefix
 }
 
@@ -1873,6 +1888,49 @@ proc track_pragma_setting {sql} {
     set matches [regexp -all -inline -nocase {PRAGMA\s+(?:\w+\.)?application_id\s*[=(]\s*(-?\d+)\s*[)]?} $sql]
     foreach {match value} $matches {
         set ::pragma_application_id_cookie($::db_file) $value
+        set found 1
+    }
+
+    # Look for schema_version: an explicit `PRAGMA schema_version=N` (or
+    # function-style `(N)`) set, PLUS the auto-increment SQLite applies on
+    # every schema-changing statement (CREATE/DROP/ALTER TABLE/INDEX/VIEW/
+    # TRIGGER) and VACUUM (#6175). Unlike user_version/application_id, this
+    # cookie is not purely a "last explicit write wins" value — VibeSQL's CLI
+    # engine bumps it once per successful DDL statement within a single
+    # process (see `bump_schema_version` in vibesql-cli), but each `execsql`
+    # call is a FRESH process, so the shim must independently track the
+    # running total here and replay it as the new process's starting point.
+    # Only tracked once this file has an explicit set on record (matching the
+    # other per-file cookies above): a file that never touches this PRAGMA
+    # pays no behavioral cost. A DDL statement that happens to precede an
+    # explicit set within the SAME sql block is treated as pre-empted by that
+    # set (matches every currently-failing test; no test combines the two in
+    # the other order).
+    if {[info exists ::pragma_schema_version_cookie($::db_file)]
+            || [regexp -nocase {PRAGMA\s+(?:\w+\.)?schema_version\s*[=(]} $sql]} {
+        set base 0
+        if {[info exists ::pragma_schema_version_cookie($::db_file)]} {
+            set base $::pragma_schema_version_cookie($::db_file)
+        }
+        set sv_matches [regexp -all -inline -nocase \
+            {PRAGMA\s+(?:\w+\.)?schema_version\s*[=(]\s*(-?\d+)\s*[)]?} $sql]
+        foreach {match value} $sv_matches {
+            set base $value
+        }
+        set ddl_count [expr {
+            [regexp -all -nocase {(?:^|;|\n)\s*CREATE\s+(?:TEMP(?:ORARY)?\s+)?TABLE\M} $sql]
+            + [regexp -all -nocase {(?:^|;|\n)\s*DROP\s+TABLE\M} $sql]
+            + [regexp -all -nocase {(?:^|;|\n)\s*ALTER\s+TABLE\M} $sql]
+            + [regexp -all -nocase {(?:^|;|\n)\s*CREATE\s+(?:UNIQUE\s+)?INDEX\M} $sql]
+            + [regexp -all -nocase {(?:^|;|\n)\s*DROP\s+INDEX\M} $sql]
+            + [regexp -all -nocase {(?:^|;|\n)\s*CREATE\s+(?:TEMP(?:ORARY)?\s+)?VIEW\M} $sql]
+            + [regexp -all -nocase {(?:^|;|\n)\s*DROP\s+VIEW\M} $sql]
+            + [regexp -all -nocase {(?:^|;|\n)\s*CREATE\s+(?:TEMP(?:ORARY)?\s+)?TRIGGER\M} $sql]
+            + [regexp -all -nocase {(?:^|;|\n)\s*DROP\s+TRIGGER\M} $sql]
+            + [regexp -all -nocase {(?:^|;|\n)\s*ALTER\s+TRIGGER\M} $sql]
+            + [regexp -all -nocase {(?:^|;|\n)\s*VACUUM\M} $sql]
+        }]
+        set ::pragma_schema_version_cookie($::db_file) [expr {$base + $ddl_count}]
         set found 1
     }
 
@@ -2842,7 +2900,7 @@ proc execsql {sql {db ""}} {
                 }
                 continue  ;# Check for more statements
             }
-            if {[regexp -nocase {^PRAGMA\s+(?:\w+\.)?(full_column_names|short_column_names|case_sensitive_like|reverse_unordered_selects|integrity_check|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|recursive_triggers|table_info|data_version|collation_list|index_list|index_xinfo|index_info|auto_vacuum|temp_store|encoding|synchronous|cache_size|default_cache_size|cache_spill|user_version|application_id)} [string trim $sql]]} {
+            if {[regexp -nocase {^PRAGMA\s+(?:\w+\.)?(full_column_names|short_column_names|case_sensitive_like|reverse_unordered_selects|integrity_check|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|recursive_triggers|table_info|data_version|collation_list|index_list|index_xinfo|index_info|auto_vacuum|temp_store|encoding|synchronous|cache_size|default_cache_size|cache_spill|user_version|application_id|schema_version)} [string trim $sql]]} {
                 # This PRAGMA is supported (with =value) - stop stripping
                 break
             } else {
@@ -3652,7 +3710,7 @@ proc execsql2 {sql {db ""}} {
     set sql_upper [string toupper [string trim $sql]]
     if {[string match "PRAGMA*" $sql_upper]} {
         # Allow supported PRAGMAs through
-        if {[regexp -nocase {^PRAGMA\s+(?:database\.)?(full_column_names|short_column_names|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|recursive_triggers|data_version|collation_list|index_list|index_xinfo|index_info|user_version|application_id)} [string trim $sql]]} {
+        if {[regexp -nocase {^PRAGMA\s+(?:database\.)?(full_column_names|short_column_names|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|recursive_triggers|data_version|collation_list|index_list|index_xinfo|index_info|user_version|application_id|schema_version)} [string trim $sql]]} {
             # Pass through to VibeSQL - these are supported
         } else {
             return {}  ;# Skip unsupported PRAGMA statements
@@ -7444,12 +7502,13 @@ proc sqlite3 {db args} {
         forcedelete $new_file
         lappend ::opened_dbs $new_file
         # A genuinely fresh file has no `default_cache_size` / `user_version` /
-        # `application_id` header cookie (SQLite: cookie 0 = never set). Clear
-        # any stale tracked value from a PAST test that happened to reuse this
-        # same path (#6175).
+        # `application_id` / `schema_version` header cookie (SQLite: cookie 0 =
+        # never set). Clear any stale tracked value from a PAST test that
+        # happened to reuse this same path (#6175).
         unset -nocomplain ::pragma_default_cache_size_cookie($new_file)
         unset -nocomplain ::pragma_user_version_cookie($new_file)
         unset -nocomplain ::pragma_application_id_cookie($new_file)
+        unset -nocomplain ::pragma_schema_version_cookie($new_file)
     }
 
     set ::db_file $new_file
@@ -7875,12 +7934,13 @@ proc reset_db {} {
     set ::pragma_synchronous_raw ""  ;# reset_db: synchronous resets to default FULL (#6175)
     set ::pragma_cache_size_raw ""   ;# reset_db: cache_size resets to default -2000 (#6175)
     # reset_db wipes the database file (via delete_db_with_wal above), so any
-    # tracked default_cache_size/user_version/application_id cookie for this
-    # path is stale — a fresh file has no header cookie, matching the "first
-    # open" clear in `proc sqlite3`.
+    # tracked default_cache_size/user_version/application_id/schema_version
+    # cookie for this path is stale — a fresh file has no header cookie,
+    # matching the "first open" clear in `proc sqlite3`.
     unset -nocomplain ::pragma_default_cache_size_cookie($::db_file)
     unset -nocomplain ::pragma_user_version_cookie($::db_file)
     unset -nocomplain ::pragma_application_id_cookie($::db_file)
+    unset -nocomplain ::pragma_schema_version_cookie($::db_file)
     set ::last_insert_rowid 0  ;# Connection closed: last_insert_rowid resets (#5843)
     # Drop all temp view/trigger replay state — reset_db wipes the database, so
     # replaying stale temp-object DDL into the fresh db would resurrect objects


### PR DESCRIPTION
## Summary

Implements `PRAGMA schema_version` as a SQLite-compatible session cookie that
**auto-increments** on every successful schema-changing statement
(`CREATE`/`DROP`/`ALTER TABLE`, `CREATE`/`DROP INDEX`, `CREATE`/`DROP VIEW`,
`CREATE`/`DROP`/`ALTER TRIGGER`) and on `VACUUM` — mirroring SQLite's on-disk
schema cookie. This is a genuinely different persistence model than the
`user_version`/`application_id` cookies landed in #6302: those are pure
"last write wins" values, but `schema_version` must also track engine-driven
increments across the TCL shim's per-batch CLI process boundaries.

## Changes

- `crates/vibesql-cli/src/executor/mod.rs`:
  - New `schema_version: i64` session field (default 0), get/set PRAGMA
    dispatch matching the existing `user_version`/`application_id` pattern.
  - New `bump_schema_version()` helper, called from every DDL statement's
    `Ok(...)` dispatch arm (`CreateTable`, `DropTable`, `CreateView`,
    `DropView`, `CreateTrigger`, `AlterTrigger`, `DropTrigger`,
    `CreateIndex`, `DropIndex`, `AlterTable`) and from `VACUUM`.
- `crates/vibesql-cli/src/executor/tests.rs`: new unit test covering the
  default value, explicit `= N` set, DDL auto-increment, and `VACUUM`
  auto-increment.
- `scripts/tester_vibesql.tcl`:
  - New per-file `::pragma_schema_version_cookie` array tracking the running
    cookie (last explicit set plus every DDL/VACUUM increment seen since),
    updated in `track_pragma_setting`.
  - Replayed in `build_pragma_prefix` — placed **after** the existing
    TEMP table/view/trigger replay block so those internal replays (which the
    engine's DDL dispatch cannot distinguish from "real" DDL, since the shim
    already demotes `CREATE TEMP TABLE` to plain `CREATE TABLE` before it
    ever reaches VibeSQL) can never leak a spurious `+1` into the tracked
    value — this ordering bug was caught and fixed during verification (see
    Test Plan).
  - Added `schema_version` to the two "supported PRAGMA" whitelist regexes so
    it isn't stripped as an unsupported PRAGMA at the start of a multi-statement
    block.
  - Fresh-file / `reset_db` cookie clearing, matching the existing
    `default_cache_size`/`user_version`/`application_id` cookies.

## Why this is a partial increment

This is the 8th increment against the `PRAGMA support` family issue (#6175,
part of epic #5779). Per the established convention for this family (see
prior PRs #6185, #6209, #6221, #6239, #6284, #6295, #6298, #6302), this PR
closes one slice of the remaining ~205 certified failures and does **not**
close the family issue.

## Triage of what's NOT in this PR (routing per the family issue)

- `pragma-8.1.3` (schema_version write blocked under `DEFENSIVE` mode):
  VibeSQL's `sqlite3_db_config` is a no-op C-API stub (no DEFENSIVE mode
  exists to enforce), so this one sub-case is a known, documented gap — not
  reclassified or masked.
- `pragma2.test` remaining failures: `freelist_count`/`cache_spill`/
  `lock_status` (pager/journal internals, Bucket-A per prior triage) plus a
  latent shim transaction-leak bug (an ATTACH-cascade-skip test's `BEGIN`
  still opens `::in_transaction` for real even though the test is later
  retroactively marked skipped) that corrupts state for the unrelated
  `pragma2-5.1/5.2/5.3` cache_spill tests further down the file. This is a
  pre-existing shim bug unrelated to PRAGMA introspection itself — flagging
  it here rather than fixing it in this PR to keep scope tight; it likely
  affects other files with the same ATTACH-cascade + BEGIN pattern.
- `pragma3.test`/`pragma4.test`: unchanged from baseline — remaining
  failures are ATTACH-dependent, C-API (`sqlite3_prepare_v2`), or pager
  integrity-check internals (page-level corruption via `hexio_write`),
  consistent with prior triage notes on this issue.

## Acceptance Criteria Verification

| Criterion (from issue #6175) | Status | Verification |
|---|---|---|
| Introspection/config PRAGMAs pass under `make test-tcl-file` | ✅ (this slice) | `pragma.test`: 114 → 120 passing, zero regressions (see Test Plan) |
| Pager/journal internals routed to #6154 as Bucket-A, not forced green | ✅ | No pager-internal PRAGMA touched in this PR; existing Bucket-A routing (cache_size/synchronous/etc., landed in #6298) untouched |

## Test Plan

- `cargo build --release`, `cargo check --workspace` — clean.
- `cargo test -p vibesql-cli --release` — 179/179 unit tests pass (was 178;
  added 1 new test for `schema_version`).
- `cargo clippy -p vibesql-cli --all-targets` — no new warnings in touched files.
- `cargo fmt --all -- --check` — no diff in touched files (pre-existing
  unformatted files elsewhere in the crate are untouched by this PR).
- `./scripts/tcltest test pragma.test`: **114 → 120 passing**, 69 failing (was
  75), 36 skipped (unchanged). Diffed the full before/after failing-test
  lists — zero regressions, six fixes: `pragma-8.1.2`, `8.1.4`, `8.1.6`,
  `8.1.13`, `8.2.4.1`, `8.2.4.3`.
- `./scripts/tcltest test pragma2.test` / `pragma3.test` / `pragma4.test` /
  `pragma6.test`: identical pass/fail/skip counts before and after (verified
  by stashing the change and re-running each file).
- Root-caused and fixed a real ordering bug during development: an isolated
  repro (`PRAGMA schema_version=105; PRAGMA schema_version;`) read back `106`
  instead of `105` only when run after earlier sections of `pragma.test` that
  create TEMP objects — traced to the shim replaying TEMP table/view/trigger
  DDL *before* the schema_version cookie assignment in `build_pragma_prefix`,
  letting the replay's `CREATE TABLE` bump the engine's counter ahead of the
  intended baseline. Fixed by reordering the replay (schema_version last).

Part of #6175.