### PR TITLE
fix(pragma,storage): order-preserving index catalog + in-txn PRAGMA reads + debug capability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6433,6 +6433,7 @@ dependencies = [
  "bytes",
  "chrono",
  "criterion",
+ "indexmap",
  "instant",
  "js-sys",
  "log",

--- a/crates/vibesql-storage/Cargo.toml
+++ b/crates/vibesql-storage/Cargo.toml
@@ -51,6 +51,8 @@ rstar = "0.13"
 lru = "0.18"
 log = "0.4"
 rand = "0.10"  # For statistical sampling (Phase 5.2)
+indexmap = "2.7"  # Order-preserving index-name map so PRAGMA index_list / sqlite_master
+                   # report indexes in creation order across process boundaries (#6175)
 instant = { version = "0.1", features = ["wasm-bindgen"] }  # WASM-compatible time primitives
 # uuid is specified per-target below to add "js" feature for WASM
 bytes = "1.5"

--- a/crates/vibesql-storage/src/database/indexes/index_maintenance/create.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_maintenance/create.rs
@@ -848,7 +848,7 @@ impl IndexManager {
             .resolve_index_key(index_name)
             .ok_or_else(|| StorageError::IndexNotFound(index_name.to_string()))?;
 
-        if self.indexes.remove(&normalized).is_none() {
+        if self.indexes.shift_remove(&normalized).is_none() {
             return Err(StorageError::IndexNotFound(index_name.to_string()));
         }
         // Also remove the index data
@@ -902,7 +902,7 @@ impl IndexManager {
 
         // Drop each index
         for index_name in &indexes_to_drop {
-            self.indexes.remove(index_name);
+            self.indexes.shift_remove(index_name);
             self.index_data.remove(index_name);
             self.pending_expression_rebuilds.remove(index_name);
 

--- a/crates/vibesql-storage/src/database/indexes/index_manager.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_manager.rs
@@ -8,6 +8,7 @@ use std::{
     sync::Arc,
 };
 
+use indexmap::IndexMap;
 use vibesql_types::{DataType, SqlValue};
 
 use super::index_metadata::{
@@ -36,8 +37,16 @@ use crate::{
 /// (abundant memory) environments.
 #[derive(Clone)]
 pub struct IndexManager {
-    /// Index metadata storage (normalized_index_name -> metadata)
-    pub(super) indexes: HashMap<String, IndexMetadata>,
+    /// Index metadata storage (normalized_index_name -> metadata).
+    ///
+    /// Order-preserving (creation order, oldest first): `list_indexes()` feeds
+    /// the binary-snapshot writer, and `PRAGMA index_list` / `sqlite_master`
+    /// must report indexes in a stable, SQLite-compatible order across process
+    /// boundaries (a fresh CLI process reloading from the snapshot). A plain
+    /// `HashMap` iterates in a randomized, per-process order (Rust's default
+    /// SipHash seed), so a second connection against the same on-disk database
+    /// previously saw a scrambled index order (pragma.test 23.3, #6175).
+    pub(super) indexes: IndexMap<String, IndexMetadata>,
     /// Actual index data (normalized_index_name -> data)
     pub(super) index_data: HashMap<String, IndexData>,
     /// Resource budget configuration
@@ -80,7 +89,7 @@ impl IndexManager {
         let storage = Arc::new(MemoryStorage::new());
 
         IndexManager {
-            indexes: HashMap::new(),
+            indexes: IndexMap::new(),
             index_data: HashMap::new(),
             config: DatabaseConfig::default(),
             resource_tracker: ResourceTracker::new(),
@@ -98,7 +107,7 @@ impl IndexManager {
         let storage = Arc::new(MemoryStorage::new());
 
         IndexManager {
-            indexes: HashMap::new(),
+            indexes: IndexMap::new(),
             index_data: HashMap::new(),
             config,
             resource_tracker: ResourceTracker::new(),

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -2508,6 +2508,20 @@ proc is_readonly_query {sql} {
     if {[regexp {^WITH([^A-Z_]|$)} $u] && ![is_dml_statement $u]} {
         return 1
     }
+    # A single, bare `PRAGMA name;` (optionally schema-qualified) with NO
+    # argument at all is unambiguously a getter — SQLite's grammar requires an
+    # explicit `= value` or `(value)` to set anything, so a bare form can never
+    # have a side effect. Answering it via query_in_transaction (rather than
+    # silently deferring it into the batch and returning {}) matters because a
+    # config PRAGMA like `synchronous` is tracked/replayed by this shim
+    # independent of the DB's transactional state and must be readable even
+    # while a batched transaction is open (pragma.test pragma-5.2, #6175).
+    # Restricted to a single statement (no embedded `;`) and no trailing `=`/
+    # `(...)` so an actual setter (which always takes a value) is never
+    # misclassified as read-only.
+    if {[regexp {^PRAGMA\s+(?:[A-Z_][A-Z0-9_]*\.)?[A-Z_][A-Z0-9_]*\s*;?\s*$} $u]} {
+        return 1
+    }
     return 0
 }
 
@@ -5686,6 +5700,8 @@ array set vibesql_skip_tests {
     rowvalue9-1.6.2 "SQLite-implementation-defined join iteration order (row-value Stage 4, #6048, part of #5779). VibeSQL returns the correct value set (3 14 15 92, each twice) but in a different nested-loop join order than SQLite for this unordered EXISTS join (no ORDER BY). Pre-existing nested-loop ordering artifact documented in PR #6064; values match, only row order differs. Skipped rather than chased since the query has no ORDER BY and the result set is correct."
     window6-2.0 "Custom UDF registration via 'db func window winproc' — a TCL-registered scalar function reachable only through the C-API sqlite3_create_function surface (harness limitation #5720). The test calls window('hello world') and expects the registered proc's output; VibeSQL's SQL CLI cannot bridge the db-func registration, so the function is genuinely absent ('no such function: window'). Bucket-A straddler enumerated in #6191; not a window-frame engine gap."
     window6-3.0 "Custom collation registration via 'db collate window wincmp' — a TCL-registered collating sequence reachable only through the C-API sqlite3_create_collation surface (harness limitation #5720). The test creates a table with COLLATE window and ORDER BY x COLLATE window expecting the registered comparator; VibeSQL's SQL CLI cannot bridge the db-collate registration ('no such collation sequence: WINDOW'). Bucket-A straddler enumerated in #6191; not a window-frame engine gap."
+    pragma-10.3 "Cascades from pragma-10.1/10.2 (auto-skipped: they use the SQLite test function randstr(10,10) to populate/update t1); with t1 left empty, DELETE FROM t1 deletes 0 rows instead of the expected 1 under count_changes. Not a PRAGMA engine gap (#6175)."
+    pragma-11.2 "Custom collation registration via 'db collate New_Collation blah...' — a TCL-registered collating sequence reachable only through the C-API sqlite3_create_collation surface (harness limitation #5720), same class as window6-3.0. PRAGMA collation_list itself is correct for every collation VibeSQL can actually register (pragma-11.1 passes); there is no SQL-level CREATE COLLATION surface to bridge the TCL-only registration. Not a PRAGMA introspection gap (#6175)."
 }
 
 # -----------------------------------------------------------------------------
@@ -6976,7 +6992,20 @@ proc check_single_capability {cap} {
     # matching a 64-bit-rowid build. Without this, autoinc-6.1 took the 32-bit
     # branch (INSERT 2147483647) and autoinc-6.2's follow-on NULL insert did not
     # overflow i64, so the expected "database or disk is full" never fired (#6173).
-    set unsupported_caps {wal vacuum_incr autovacuum stat4 stat3 tclvar vtab rtree fts3 fts4 fts5 fts3_unicode conflict hiddencolumns progress allow_rowid_in_view crashtest utf16 rowid32}
+    # `debug` is the SQLITE_DEBUG compile-time option, which is OFF in a normal
+    # release build (and in VibeSQL, which has no VDBE to trace/list). Real
+    # SQLite gates debug-only introspection pragmas (`vdbe_listing`,
+    # `vdbe_trace`, `parser_trace` is separate/always-on) and debug-only test
+    # helpers behind `ifcapable debug`, so a non-debug build — matching
+    # VibeSQL — never runs them. Without this, `ifcapable debug { ... }`
+    # blocks were treated as capable and ran unconditionally: pragma.test's
+    # `PRAGMA vdbe_listing=YES; PRAGMA vdbe_listing;` (pragma-1.15/1.16) has no
+    # VDBE to report on and returned nothing instead of being skipped, and
+    # badutf2.test's `utf8_to_utf8` debug-only helper isn't implemented in this
+    # shim, so that block errored instead of skipping. Marking `debug`
+    # unsupported routes both to their skip branch, matching a real
+    # non-SQLITE_DEBUG build (#6175).
+    set unsupported_caps {wal vacuum_incr autovacuum stat4 stat3 tclvar vtab rtree fts3 fts4 fts5 fts3_unicode conflict hiddencolumns progress allow_rowid_in_view crashtest utf16 rowid32 debug}
 
     # Handle negated capability (e.g., !autovacuum)
     set negate 0


### PR DESCRIPTION
## Summary

Ninth increment of the PRAGMA-support family issue (#6175, epic #5779). Fixes a genuine cross-process index-ordering bug in the storage layer plus two TCL-shim gaps that were misclassifying/mishandling introspection PRAGMAs.

## Changes

### Storage (`crates/vibesql-storage/src/database/indexes/`)
- `IndexManager.indexes` was a plain `HashMap<String, IndexMetadata>`. `list_indexes()` (which feeds the binary-snapshot writer) therefore enumerated indexes in randomized, per-process hash order instead of creation order. A second CLI process reloading the same on-disk database (e.g. the TCL shim's `sqlite3 db2 test.db`) saw a scrambled `PRAGMA index_list` order that changed from run to run.
- Switched `indexes` to an order-preserving `indexmap::IndexMap` (already used on the catalog side for the same reason) and converted the two `.remove()` call sites to `.shift_remove()` so a drop doesn't disturb the remaining order.
- This is a general correctness fix for any multi-connection `index_list`/`index_info`/`sqlite_master` scenario, not just one test — it flips `pragma.test` 23.3.

### TCL shim (`scripts/tester_vibesql.tcl`)
- Added `debug` (the `SQLITE_DEBUG` compile-time option) to the unsupported-capability list. VibeSQL has no VDBE to list/trace, matching a normal non-debug SQLite build. `ifcapable debug { ... }` blocks were previously treated as capable and ran unconditionally, so `pragma.test`'s debug-only `vdbe_listing` pragma (1.15/1.16) returned nothing instead of being cleanly skipped (and `badutf2.test`'s debug-only `utf8_to_utf8` helper, which this shim doesn't implement, now skips instead of erroring).
- `is_readonly_query` now recognizes a bare `PRAGMA name;` (no `=`, no argument — unambiguously a getter under SQLite's grammar) as read-only, so it is answered immediately via `query_in_transaction` instead of being silently deferred into the batched-transaction queue and returning `{}`. Fixes `pragma-5.2` (`PRAGMA synchronous;` while a transaction opened by a prior statement is still open).
- Documented two out-of-scope cases in `vibesql_skip_tests`:
  - `pragma-10.3` cascades from `pragma-10.1`/`10.2` (auto-skipped: they use the SQLite test function `randstr()`), not a PRAGMA gap.
  - `pragma-11.2` requires `db collate` — a C-API-only TCL test hook (`sqlite3_create_collation`) with no SQL surface, same class as the existing `window6-3.0` entry. `PRAGMA collation_list` itself is correct for every collation VibeSQL can actually register (`pragma-11.1` passes).

## Acceptance Criteria Verification

- [x] Introspection/config PRAGMAs made to pass where the gap was genuinely in VibeSQL's / the shim's control (index ordering, debug-capability triage, in-transaction PRAGMA reads).
- [x] Pager/journal-internal PRAGMAs are **not** touched and remain routed to #6154 — see triage below. No introspection PRAGMA was silently reclassified as internal to dodge work.

### Triage of remaining `pragma.test` failures (all pre-existing, unchanged by this PR)
**Bucket-A (pager/journal-internal, route to #6154):** `cache_size`/`synchronous` edge cases (pragma-5.2 fixed here; pragma-15.3 cross-reload edge case remains), `page_size`/`page_count` (pragma-14.\*), `lock_status` (pragma-7.3), proxy locking (pragma-16.\*).
**C-API-only test hooks (out of CLI scope):** `btree_from_db` (pragma-9.\*), `get_pwd`, testvfs (pragma-19.\*), `database_never_corrupt`.
**Page-level corruption harness (no page layer to corrupt, same class as prior A2 precedent):** pragma-3.\*, 21.1, 22.2, 22.4.2 (all depend on `hexio_write`/`delete_file`, which this shim doesn't implement).
**ATTACH-dependent:** several `pragma-2.\*`/`4.\*`/`8.1.x` cases (unimplemented ATTACH).

### Two new findings documented for future increments (not fixed here — broader blast radius than this increment warrants)
- `pragma-23.1`: `sqlite_master` interleaves tables and indexes by object *type* instead of true chronological creation order across all object kinds (would need a global DDL sequence counter threaded through the catalog and persistence layer).
- `pragma-23.4`: the shim's `normalize_result` silently drops empty-string TCL list elements before a `/regex/`-pattern comparison, breaking any expected pattern that embeds a literal `{}` placeholder. This is a general harness bug (not PRAGMA-specific) with a wide blast radius (used by every regex-pattern `do_test`), so fixing it is deferred to a dedicated follow-up rather than bundled here.

## Test Plan

- `make test-tcl-file FILE=pragma.test`: 120/189 (65 failed) -> 122/187 passing (63 failed); the 2-test delta in the denominator is `pragma-1.15`/`1.16` now correctly skipping instead of failing.
- `make test-tcl-file FILE=pragma2.test` / `pragma3.test` / `pragma4.test` / `pragma6.test`: unchanged from the prior increment (3/17, 11/24, 7/22, 2/3 respectively) — no regressions.
- `cargo test --release -p vibesql-storage`: 839+16+13+15 tests, all green (unit, integration, doctest).
- `cargo test --release -p vibesql-cli -p vibesql-executor -p vibesql-catalog`: full suites green, 0 failures.
- Targeted regression spot-checks (index-heavy / multi-file scenarios likely to interact with the `IndexManager` ordering change): `index.test` (69/70, the 1 failure — `index-23.1`, a `TYPEOF`-expression-index/REINDEX test unrelated to PRAGMA or ordering — confirmed pre-existing via a stashed before/after comparison), `index2.test` (7/7), `index3.test` (1/1), `index4.test` (9/9), `select1.test` (188/188), `join.test` (177/178, 1 pre-existing unrelated skip).
- `cargo check -p vibesql-storage`, `cargo clippy -p vibesql-storage --lib`: no new warnings introduced (diffed against the pre-existing warning set).

Part of #6175 (epic #5779) — the family issue tracks ~205 certified failures across `pragma.test`/`pragma2-4.test`/`pragma6.test`; this increment resolves a targeted slice and documents/routes the rest per established Bucket-A triage. Not closing the family issue.