### PR TITLE
fix(cli,tcl): distinguish NULL from empty string in raw-format wire protocol

### DIFF
--- a/crates/vibesql-cli/src/formatter.rs
+++ b/crates/vibesql-cli/src/formatter.rs
@@ -10,8 +10,9 @@ pub enum OutputFormat {
     Csv,
     Markdown,
     Html,
-    /// Raw output format: space-separated values, one row per line.
-    /// NULL values are represented as empty strings.
+    /// Raw output format: values framed with ASCII 31/30 control bytes (see
+    /// `print_raw`). NULL values are represented by a dedicated sentinel byte,
+    /// distinct from an actual empty-string value.
     /// Compatible with SQLite TCL test harness expectations.
     Raw,
 }
@@ -198,7 +199,9 @@ impl ResultFormatter {
     /// Print results in raw format for SQLite TCL test compatibility.
     /// - ASCII 31 (Unit Separator, `\x1f`) between values within each row
     /// - ASCII 30 (Record Separator, `\x1e`) terminating each row
-    /// - NULL values output as empty strings
+    /// - NULL values output as the ASCII 1 (`\x01`) sentinel (see
+    ///   [`Self::NULL_SENTINEL`]); an actual empty-string value is emitted as
+    ///   literal empty text, distinct from NULL
     /// - No headers, no borders, no row count
     ///
     /// We use ASCII 31 between values (instead of pipe) because pipe can appear
@@ -216,6 +219,20 @@ impl ResultFormatter {
         print!("{}", Self::format_raw(result));
     }
 
+    /// ASCII 1 (Start of Heading). Emitted in place of a value to mean "this
+    /// column is actually NULL" — distinct from an actual empty-string value,
+    /// which is emitted as literal empty text. Chosen for the same reason as
+    /// the `\x1e`/`\x1f` framing bytes: a control character that cannot occur
+    /// in ordinary SQL text, so it is unambiguous on the wire (#6175).
+    ///
+    /// Without this sentinel, `None` (SQL NULL) and `Some("")` (an empty
+    /// string) both serialize to the same empty slot between separators, so a
+    /// consumer with a customized NULL representation (SQLite TCL's `db
+    /// nullvalue`) cannot tell them apart — e.g. `PRAGMA table_info` reporting
+    /// a NULL `dflt_value` (no DEFAULT clause) vs. an empty-string
+    /// `dflt_value` (`DEFAULT ''`).
+    const NULL_SENTINEL: &'static str = "\x01";
+
     /// Build the raw-format payload for `result` (see `print_raw`).
     ///
     /// Columns are joined with ASCII 31 (`\x1f`) and each row is terminated with
@@ -227,9 +244,10 @@ impl ResultFormatter {
             let values: Vec<&str> = row
                 .iter()
                 .map(|val| {
-                    // SQLite TCL tests expect NULL to be empty string
-                    // None represents actual NULL, Some("") is an empty string value
-                    val.as_ref().map(|s| s.as_str()).unwrap_or("")
+                    // None represents actual SQL NULL -> the NULL sentinel.
+                    // Some(s) is a real value (including an empty string,
+                    // which must round-trip as empty text, not NULL).
+                    val.as_ref().map(|s| s.as_str()).unwrap_or(Self::NULL_SENTINEL)
                 })
                 .collect();
             out.push_str(&values.join("\x1f"));
@@ -327,7 +345,8 @@ mod tests {
         };
 
         // Just verify it doesn't panic - output goes to stdout
-        // NULL values (None) should be converted to empty strings
+        // NULL values (None) should be converted to the NULL_SENTINEL byte,
+        // distinct from an actual empty-string value.
         formatter.print_raw(&result);
     }
 
@@ -346,7 +365,8 @@ mod tests {
             message: None,
         };
 
-        // NULL (None) should become empty, but "NULL" string (Some("NULL")) should stay "NULL"
+        // NULL (None) should become the sentinel, but "NULL" string
+        // (Some("NULL")) should stay "NULL"
         formatter.print_raw(&result);
     }
 
@@ -371,12 +391,9 @@ mod tests {
         // Rows are terminated with \x1e (Record Separator) and columns are
         // joined with \x1f (Unit Separator). Zero rows yields empty output.
         let result = create_test_result();
-        assert_eq!(
-            ResultFormatter::format_raw(&result),
-            "1\x1fAlice\x1e2\x1fBob\x1e"
-        );
+        assert_eq!(ResultFormatter::format_raw(&result), "1\x1fAlice\x1e2\x1fBob\x1e");
 
-        // NULL (None) renders as an empty string; a real "NULL" string stays.
+        // NULL (None) renders as the NULL_SENTINEL byte; a real "NULL" string stays.
         let nulls = QueryResult {
             columns: vec!["a".to_string(), "b".to_string()],
             rows: vec![vec![None, Some("NULL".to_string())]],
@@ -384,7 +401,18 @@ mod tests {
             execution_time_ms: None,
             message: None,
         };
-        assert_eq!(ResultFormatter::format_raw(&nulls), "\x1fNULL\x1e");
+        assert_eq!(ResultFormatter::format_raw(&nulls), "\x01\x1fNULL\x1e");
+
+        // An actual empty-string value (Some("")) is distinct from NULL: it
+        // renders as literal empty text, not the sentinel.
+        let empty_string_value = QueryResult {
+            columns: vec!["a".to_string(), "b".to_string()],
+            rows: vec![vec![Some(String::new()), None]],
+            row_count: 1,
+            execution_time_ms: None,
+            message: None,
+        };
+        assert_eq!(ResultFormatter::format_raw(&empty_string_value), "\x1f\x01\x1e");
 
         // Zero rows => empty string.
         let empty = QueryResult {

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3392,6 +3392,8 @@ proc parse_raw_result {output} {
     # Raw format framing (see crates/vibesql-cli/src/formatter.rs print_raw):
     #   - ASCII 31 (Unit Separator, \x1f) between values within a row
     #   - ASCII 30 (Record Separator, \x1e) terminating each row
+    #   - ASCII 1 (NULL_SENTINEL, \x01) in place of a value that is actually
+    #     SQL NULL, distinguishing it from an actual empty-string value (#6175)
     #
     # We deliberately split ROWS on \x1e rather than on a plain newline: a
     # single column VALUE may itself contain embedded newlines (e.g. the
@@ -3401,8 +3403,13 @@ proc parse_raw_result {output} {
     # are control characters that cannot appear in ordinary SQL values, so an
     # embedded newline is preserved verbatim inside its column.
     #
-    # NULL values are emitted as empty strings; the literal string 'NULL' stays
-    # as "NULL". This matches SQLite's TCL interface NULL representation.
+    # NULL values are emitted as the \x01 sentinel; the literal string 'NULL'
+    # stays as "NULL", and an actual empty-string value stays as "". This
+    # matters when a test customizes `db nullvalue` (e.g. pragma-6.2.2): before
+    # the sentinel, both NULL and "" collapsed to the same empty wire slot, so
+    # a customized nullvalue could not distinguish "no DEFAULT clause" (NULL)
+    # from "DEFAULT ''" (empty string).
+    set null_sentinel "\x01"
     set data {}
 
     # Special case: completely empty output means zero rows.
@@ -3411,13 +3418,14 @@ proc parse_raw_result {output} {
         return {}
     }
 
-    # Special case: a single record separator means one row whose single column
-    # is NULL (VibeSQL emits an empty value followed by \x1e). Check this BEFORE
-    # stripping the trailing separator.
+    # Special case: a single record separator means one row whose single
+    # column is an actual empty string (VibeSQL emits an empty value followed
+    # by \x1e; NULL would instead emit the sentinel followed by \x1e, which
+    # falls through to the general path below). Check this BEFORE stripping
+    # the trailing separator, since stripping would leave "" and Tcl's `split`
+    # of an empty string yields zero elements, losing the row.
     if {$output eq "\x1e"} {
-        # Return null_string if set, otherwise empty string
-        set null_rep [expr {[info exists ::null_string] && $::null_string ne "" ? $::null_string : ""}]
-        return [list $null_rep]
+        return [list ""]
     }
 
     # Strip exactly one trailing record separator if present.
@@ -3437,21 +3445,23 @@ proc parse_raw_result {output} {
             error [translate_error_to_sqlite $row]
         }
 
-        # Handle empty rows (represent a row whose single column is NULL).
-        # For a single-column query returning NULL, the row will be empty.
+        # Handle empty rows: for a single-column row, an actual empty-string
+        # value serializes as "" and Tcl's `split "" "\x1f"` yields zero
+        # elements (rather than one empty element), so it must be restored
+        # explicitly. A single-column NULL instead serializes as the sentinel
+        # alone, which splits to one element and falls through to the loop
+        # below — so this branch is only for the actual-empty-string case.
         if {$row eq ""} {
-            # Empty row = row with single NULL value
-            # Use null_string if set, otherwise empty string
-            set null_rep [expr {[info exists ::null_string] && $::null_string ne "" ? $::null_string : ""}]
-            lappend data $null_rep
+            lappend data ""
             continue
         }
 
         # Split by Unit Separator (ASCII 31) and add each value to the result.
-        # Empty values represent NULL - use null_string if set.
+        # The NULL sentinel represents SQL NULL - use null_string if set,
+        # otherwise empty string (SQLite TCL interface default).
         set null_rep [expr {[info exists ::null_string] && $::null_string ne "" ? $::null_string : ""}]
         foreach val [split $row "\x1f"] {
-            if {$val eq ""} {
+            if {$val eq $null_sentinel} {
                 lappend data $null_rep
             } else {
                 lappend data $val


### PR DESCRIPTION
## Summary

Partial increment of the PRAGMA-support family issue #6175. Fixes the CLI's `--format raw` wire protocol so a genuine SQL `NULL` is distinguishable from an actual empty-string value, and re-triages the rest of the family's currently-failing tests to confirm they are already correctly bucketed by prior increments.

## Changes

- `crates/vibesql-cli/src/formatter.rs`: `format_raw` now emits a dedicated `NULL_SENTINEL` byte (ASCII 1, `\x01`) for `None` (SQL NULL) instead of collapsing it to the same empty wire slot as `Some("")` (an actual empty string). Updated/added unit tests covering both cases.
- `scripts/tester_vibesql.tcl`: `parse_raw_result` decodes the sentinel back into the test's configured `null_string` (or `""` by default), and now correctly preserves an actual empty-string value as empty text instead of misreading it as NULL.

## Root cause

Before this fix, `None` (SQL NULL) and `Some("")` (an empty string) both serialized to the same empty slot between `\x1f`/`\x1e` framing bytes in `--format raw`. A test that customizes `db nullvalue` (e.g. `pragma-6.2.2`, which sets a distinct nullvalue token and expects a genuinely-NULL `PRAGMA table_info` `dflt_value` column to render as that token while an empty-string `DEFAULT ''` stays empty) could not tell the two apart. This exact gap was identified and explicitly deferred three times across earlier partial increments of #6175 (PRs #6209, #6221, #6284) as "too large/risky" because it touches the CLI's primary raw-format data channel used by the *entire* TCL suite (1,174 files). This PR implements the sentinel-byte fix that was previously deferred, with full before/after regression verification.

## Triage of the rest of the family (#6175)

Every other currently-failing test in `pragma.test` / `pragma2.test` / `pragma3.test` / `pragma4.test` / `pragma6.test` was individually re-inspected this session and confirmed to already be correctly bucketed by prior increments — no genuinely-fixable introspection/config PRAGMA gap was found:

- **Bucket-A (pager/journal/VFS internals, no VibeSQL equivalent):** `cache_size`/`default_cache_size`/`synchronous` (pragma-1/5), `page_size`/`page_count` (pragma-14), `freelist_count`/`cache_spill`/`lock_status` (pragma2), `lock_proxy_file` proxy locking (pragma-16), `PRAGMA error`/`PRAGMA filename` (pragma-19 — confirmed via `docs/reference/sqlite/src/test_vfs.c`, these are testvfs-only debug pragmas, not real `pragma.c` PRAGMAs).
- **B-tree corruption harness (no page layer, same precedent as `e_reindex-1.*`):** pragma-3.* (23 tests, `integrity_check` after `hexio_write` corruption), 21.1/22.2/22.4.2/23.1.
- **C-API-only test hooks:** pragma-filescope-err.* (`sqlite3_prepare_v2`), pragma-9.1.1/9.2.1/9.3.1 (`btree_from_db`), pragma-9.5 (`get_pwd`), pragma-8.1.3 (`sqlite3_db_config DEFENSIVE`), pragma4-2.100 (EXPLAIN-opcode simulation).
- **Multi-connection / ATTACH shim-architecture limit:** pragma3.test in full (13 tests, cross-connection `data_version` — the shim is process-per-batch), pragma4.test 4.1.x/4.2.x/4.3.x/4.4.x/4.6.x (13 tests, depend on a live `ATTACH aux` in a second connection — `ATTACH` is tracked separately in #6310), pragma-15.3 (`cache_size` is connection-local, unobservable across the shim's process boundary).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Introspection/config PRAGMAs pass under `make test-tcl-file` | ✅ | `pragma-6.2.2` (`PRAGMA table_info` NULL-vs-empty `dflt_value`) now passes |
| Genuinely pager/journal-internal PRAGMAs documented, not forced green | ✅ | Re-confirmed existing Bucket-A classification for every remaining failure (see triage above); none reclassified away from Bucket-B without cause |
| No silent reclassification of a real introspection PRAGMA | ✅ | Every remaining failure re-verified against its actual SQLite source (e.g. `PRAGMA filename` confirmed as a `test_vfs.c`-only debug PRAGMA, not `pragma.c`) before leaving it in its existing bucket |

## Test Plan

Before → after (fresh, this session):

| File | Failed before | Failed after |
|------|---------------:|-------------:|
| pragma.test | 62 | **61** (pragma-6.2.2 now passes) |
| pragma2.test | 15 | 15 (unchanged) |
| pragma3.test | 13 | 13 (unchanged) |
| pragma4.test | 15 | 15 (unchanged) |
| pragma6.test | 1 | 1 (unchanged) |

Zero regressions confirmed via stashed/unstashed before-after binary comparison across every file using `db nullvalue` customization (`e_createtable`, `e_expr`, `e_select`, `in`, `join7`/`9`/`A`/`B`/`C`/`E`/`F`/`H`, `types`, `tclsqlite`, `extension01`, `shell1`, `shell5`), plus the `colname`/`default`/`intpkey` canary files referenced by earlier #6175 increments — all identical to pre-patch baseline. `cargo test -p vibesql-cli` (179 tests), `cargo clippy -p vibesql-cli`, and `cargo check --workspace` all pass clean.

`joinD.test` (a 1170-test permutation file) showed a transient 17-test failure in one run of the patched binary, but **0 failures on an immediate rerun of the same binary**, and isolated re-execution of the exact failing setup+queries also passed — confirmed as pre-existing engine nondeterminism (likely hash-order tie-break in `ahash`-based hash joins for `ORDER BY coalesce(...)` ties), unrelated to this change and filed separately as #6317.

Part of #6175