### PR TITLE
conformance(tcl): add delete_file harness proc (Part of #6175)

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -8053,6 +8053,25 @@ proc forcedelete {args} {
     }
 }
 
+proc delete_file {args} {
+    # SQLite test utility: delete one or more files. In the canonical harness
+    # this is a pure-Tcl proc in tester.tcl (the non-`-force` sibling of
+    # `forcedelete`, via `do_delete_file false`), NOT a C testfixture command —
+    # so adding it here is straightforward parity with the real harness, not a
+    # stub for an unreachable engine primitive. The shim previously omitted it,
+    # so each file-scope `delete_file` call (pragma.test / pragma2.test remove
+    # stale database files between test sections) aborted at file scope and was
+    # recorded as a synthetic `filescope-err` failure (#6175).
+    #
+    # Delegate to forcedelete: VibeSQL correctness requires the same WAL /
+    # checkpoint / lock sibling cleanup (otherwise the next open of the same
+    # path replays the old WAL and the "deleted" database resurrects), plus the
+    # same "test.db" -> per-run temp-file mapping. The force-vs-non-force
+    # distinction is immaterial for the plain database files these tests target
+    # (mirrors copy_file / forcecopy both routing through copy_db_with_wal).
+    forcedelete {*}$args
+}
+
 proc copy_file {from to} {
     # SQLite test utility: copy a database file (used by malloc/recovery
     # tests to snapshot and restore db state). The shim's per-statement


### PR DESCRIPTION
## Summary

The TCL test shim (`scripts/tester_vibesql.tcl`) was missing the `delete_file` proc. Unlike the C-API testfixture commands the shim legitimately cannot provide, `delete_file` is defined in SQLite's *canonical* harness (`test/tester.tcl`) as a **pure-Tcl proc** — the non-`-force` sibling of `forcedelete` (both dispatch to `do_delete_file`). The shim already had `forcedelete` but not `delete_file`, so every file-scope `delete_file` call aborted at file scope and was recorded as a synthetic `filescope-err` failure.

`pragma.test` and `pragma2.test` call `delete_file` at file scope to remove stale database files between test sections. Adding the proc removes those synthetic markers and lets one real test see a clean database.

This is a harness-completeness fix (restoring parity with the canonical `tester.tcl`), not forcing anything green — the remaining `filescope-err` causes are genuine out-of-scope gaps and are left untouched.

## Changes

- `scripts/tester_vibesql.tcl`: add `proc delete_file` (delegates to `forcedelete` so VibeSQL's WAL / checkpoint / lock sibling cleanup and the `test.db` -> per-run-temp-file mapping still apply — otherwise the next open replays the old WAL and the "deleted" database resurrects). Force-vs-non-force is immaterial for the plain database files these tests target, mirroring how `copy_file`/`forcecopy` both route through `copy_db_with_wal`.

No Rust/engine changes.

## Acceptance Criteria Verification

The issue asks for introspection/config PRAGMAs to pass, and for genuinely out-of-scope PRAGMAs to be documented rather than forced green. This increment:

- Eliminates 6 synthetic `filescope-err` failures caused by a missing harness proc (a shim gap, not an engine gap).
- Flips one real assertion (`pragma-3.30`) green legitimately: it does `delete_file test.db; sqlite3 db test.db; ...; PRAGMA integrity_check` expecting a clean `{}`. Previously the stale db (index-corrupted by the earlier `hexio_write` `pragma-3.*` tests) survived and `integrity_check` flagged it; now a fresh db is created and `integrity_check` correctly returns clean — matching SQLite.
- Leaves the genuinely out-of-scope remainder documented below (no reclassification of any introspection PRAGMA).

## Test Plan

Per-file before/after (`make test-tcl-file FILE=...`), zero regressions:

| File | Before (failed) | After (failed) | Delta |
|------|----------------:|---------------:|-------|
| pragma.test  | 61 | 58 | -3 (2 markers + `pragma-3.30` green) |
| pragma2.test | 15 | 11 | -4 (4 markers) |
| pragma3.test | 13 | 13 | 0 (ATTACH/data_version, no `delete_file`) |
| pragma4.test | 15 | 15 | 0 (ATTACH/C-API, no `delete_file`) |
| pragma6.test | 1  | 1  | 0 |

Regression spot-check of other `delete_file` users (only 20 files use it; none Priority-1 core SQL):

| File | Before (failed) | After (failed) |
|------|----------------:|---------------:|
| savepoint.test | 56 | 55 |
| misc7.test | 18 | 18 |
| tkt35xx.test | 1 | 0 |

All unchanged or improved. Verified the full pragma.test real-failure set diff: exactly `pragma-3.30` flipped to pass, zero newly-failing.

## Out of scope (left for future increments / other tracks)

Remaining `pragma-family` `filescope-err` markers are genuine gaps, not `delete_file`:
- `hexio_write` / `database_never_corrupt` — B-tree corruption harness (VibeSQL has no page layer to corrupt; same precedent as `e_reindex-1.*`).
- `get_pwd` / `sqlite3_prepare_v2` — C-API testfixture commands (no SQL surface).
- `test_set_config_pagecache` / `test_restore_config_pagecache` — pager-internal pagecache config (Bucket-A).
- `ATTACH`-dependent cases (pragma4 `aux.sqlite_master`, pragma.test `t2`) — ATTACH is unsupported (large feature, out of this family's scope).

Non-`filescope-err` remainders across the family are unchanged and remain triaged out-of-scope per the issue's prior increments: `page_count`/`max_page_count` (pragma-14), `lock_status` (pragma-7.3), proxy locking (pragma-16), `freelist_count`/`cache_spill` (pragma2), `integrity_check`-after-corruption (pragma-3.*, 21/22), cross-connection `data_version` (pragma3), and `sqlite_master` creation-order (`pragma-23.1`, tracked in #6315).

Part of #6175. Part of epic #5779.