### PR TITLE
fix(pragma): validate integrity_check/quick_check table-name argument (Part of #6175)

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -1490,7 +1490,46 @@ impl SqlExecutor {
                 // arrives as `stmt.value = Some(...)`, which would otherwise be
                 // misrouted to the SET branch and silently ignored (returning an
                 // empty result). Handle both forms here, before the set/query
-                // split, so any argument is accepted and "ok" is returned.
+                // split, so any argument is accepted.
+                //
+                // Argument taxonomy (SQLite):
+                //   PRAGMA integrity_check;            -- check whole database
+                //   PRAGMA integrity_check=N;          -- whole database, cap at N errors
+                //   PRAGMA integrity_check(N);         -- same, function form
+                //   PRAGMA integrity_check=NAME;       -- check only table/schema NAME
+                //   PRAGMA integrity_check='NAME';     -- quoted -> table NAME
+                // A numeric argument is an error-count *limit*; a string or bare
+                // identifier names a specific table to check and, if that name is
+                // not an existing table (nor one of the schema tables), SQLite
+                // errors with "no such table: NAME" (pragma-3.5.2 / pragma-3.6).
+                // VibeSQL never finds corruption in a healthy table, so every
+                // valid target still resolves to "ok"; we only add the missing
+                // no-such-table validation for the name-argument form.
+                if let Some(name) = match &stmt.value {
+                    Some(vibesql_ast::PragmaValue::Identifier(name)) => Some(name.clone()),
+                    Some(vibesql_ast::PragmaValue::String(name)) => Some(name.clone()),
+                    // Number / SignedNumber / None are the whole-database forms
+                    // (optionally with an error-count limit) — always "ok".
+                    _ => None,
+                } {
+                    // The schema tables (sqlite_master and its aliases) are always
+                    // valid integrity-check targets, even though they are not
+                    // ordinary user tables in the catalog (pragma-3.6c).
+                    let lower = name.to_ascii_lowercase();
+                    let is_schema_table = matches!(
+                        lower.as_str(),
+                        "sqlite_master" | "sqlite_schema" | "sqlite_temp_schema"
+                    );
+                    if !is_schema_table {
+                        let lookup = match &stmt.database {
+                            Some(db) => format!("{}.{}", db, name),
+                            None => name.clone(),
+                        };
+                        if self.db.catalog.get_table(&lookup).is_none() {
+                            anyhow::bail!("no such table: {}", name);
+                        }
+                    }
+                }
                 return Ok(QueryResult {
                     columns: vec![pragma_name.to_lowercase()],
                     rows: vec![vec![Some("ok".to_string())]],

--- a/crates/vibesql-cli/src/executor/tests.rs
+++ b/crates/vibesql-cli/src/executor/tests.rs
@@ -661,6 +661,43 @@ fn test_pragma_integrity_check_with_table_argument() {
 }
 
 #[test]
+fn test_pragma_integrity_check_argument_taxonomy() {
+    // SQLite distinguishes a numeric error-count *limit* from a table/schema
+    // *name* argument (pragma-3.5.2 / pragma-3.6):
+    //   PRAGMA integrity_check=4    -- limit 4 errors, whole db -> "ok"
+    //   PRAGMA integrity_check='4'  -- table named "4" -> "no such table: 4"
+    //   PRAGMA integrity_check=xyz  -- table named "xyz" -> "no such table: xyz"
+    // An existing table (or a schema table such as sqlite_schema) is a valid
+    // target and reports "ok".
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor.execute("CREATE TABLE t2(a INT)").unwrap();
+
+    // Numeric argument is an error-count limit, not a table name.
+    let result = executor.execute("PRAGMA integrity_check=4").unwrap();
+    assert_eq!(result.rows[0][0].as_deref(), Some("ok"));
+
+    // Existing table -> ok.
+    let result = executor.execute("PRAGMA integrity_check=t2").unwrap();
+    assert_eq!(result.rows[0][0].as_deref(), Some("ok"));
+
+    // Schema table is always a valid target.
+    let result = executor.execute("PRAGMA integrity_check=sqlite_schema").unwrap();
+    assert_eq!(result.rows[0][0].as_deref(), Some("ok"));
+
+    // Quoted string that is not a table -> "no such table: 4".
+    let err = executor.execute("PRAGMA integrity_check='4'").unwrap_err();
+    assert_eq!(err.to_string(), "no such table: 4");
+
+    // Bare identifier that is not a table -> "no such table: xyz".
+    let err = executor.execute("PRAGMA integrity_check=xyz").unwrap_err();
+    assert_eq!(err.to_string(), "no such table: xyz");
+
+    // quick_check shares the same argument handling.
+    let err = executor.execute("PRAGMA quick_check=nope").unwrap_err();
+    assert_eq!(err.to_string(), "no such table: nope");
+}
+
+#[test]
 fn test_pragma_table_info_verbatim_type_and_default() {
     // PRAGMA table_info echoes the declared type verbatim (only bracket/quote
     // delimiters stripped) and the verbatim DEFAULT source text, matching
@@ -706,9 +743,7 @@ fn test_pragma_table_info_strips_type_delimiters() {
     // (pragma-6.2): `[TYPE_Y]` -> `TYPE_Y`, `"TYPE_Z"` -> `TYPE_Z`. A plain
     // user type is echoed unchanged.
     let mut executor = SqlExecutor::new(None).unwrap();
-    executor
-        .execute("CREATE TABLE t2(a TYPE_X, b [TYPE_Y], c \"TYPE_Z\")")
-        .unwrap();
+    executor.execute("CREATE TABLE t2(a TYPE_X, b [TYPE_Y], c \"TYPE_Z\")").unwrap();
     let result = executor.execute("PRAGMA table_info(t2)").unwrap();
     assert_eq!(result.rows[0][2].as_deref(), Some("TYPE_X"));
     assert_eq!(result.rows[1][2].as_deref(), Some("TYPE_Y"));
@@ -1008,8 +1043,8 @@ fn test_pragma_auto_vacuum_default_and_normalization() {
         ("0", "0"),
         ("1", "1"),
         ("2", "2"),
-        ("3", "0"),            // out-of-range -> NONE
-        ("-1", "0"),           // negative -> NONE
+        ("3", "0"),  // out-of-range -> NONE
+        ("-1", "0"), // negative -> NONE
         ("1234", "0"),
         ("-1234", "0"),
         ("none", "0"),
@@ -1043,8 +1078,8 @@ fn test_pragma_temp_store_default_and_normalization() {
         ("0", "0"),
         ("1", "1"),
         ("2", "2"),
-        ("3", "0"),   // out-of-range -> DEFAULT
-        ("-1", "0"),  // negative -> DEFAULT
+        ("3", "0"),  // out-of-range -> DEFAULT
+        ("-1", "0"), // negative -> DEFAULT
         ("file", "1"),
         ("FILE", "1"),
         ("fIlE", "1"),


### PR DESCRIPTION
## Summary

Adds SQLite's missing **no-such-table validation** for the name-argument form of `PRAGMA integrity_check` / `PRAGMA quick_check`.

SQLite distinguishes a numeric error-count *limit* from a table/schema *name* argument:

| Statement | Meaning | Result |
|-----------|---------|--------|
| `PRAGMA integrity_check` | whole database | `ok` |
| `PRAGMA integrity_check=4` / `(4)` | whole db, cap at 4 errors | `ok` |
| `PRAGMA integrity_check=t2` | check existing table `t2` | `ok` |
| `PRAGMA integrity_check=sqlite_schema` | schema table | `ok` |
| `PRAGMA integrity_check='4'` | table named `4` (quoted) | `no such table: 4` |
| `PRAGMA integrity_check=xyz` | table named `xyz` | `no such table: xyz` |

Previously VibeSQL accepted *any* argument and always returned `ok`, silently ignoring an invalid target. The parser already models the distinction (`PragmaValue::Number` vs `String`/`Identifier`); this change acts on it in the CLI PRAGMA dispatch (`crates/vibesql-cli/src/executor/mod.rs`). VibeSQL never finds corruption in a healthy table, so every *valid* target still resolves to `ok` — this is purely the addition of the missing invalid-name error.

## Test results

`make test-tcl-file FILE=pragma.test`: **57 -> 54 failing**
- flips `pragma-3.5.2` (`integrity_check='4'`) and `pragma-3.6` (`integrity_check=xyz`) to passing
- `pragma-3.9b` (an ATTACH-qualified case) drops out of the failure set as a neutral side effect

**Zero regressions** across `pragma.test`, `pragma2.test`, `pragma3.test`, `pragma4.test`, `pragma6.test`. The name-argument form is rare in the wider corpus (`fts4check`, `strict2`, ...) and always targets a real table there, so those paths are unchanged. New unit test `test_pragma_integrity_check_argument_taxonomy` locks in the taxonomy; full `vibesql-cli` suite green.

## Triage of the remaining PRAGMA family (why this is a partial increment)

This issue has already landed ~15 increments; a fresh re-measure confirms the residual failures are all **out-of-scope or architectural-mismatch** categories, not further in-scope introspection gaps:

- **Testfixture-only harness commands** (harness gaps, not engine gaps): `hexio_write`, `btree_from_db`, `get_pwd`, `decode_hexdb`, `database_never_corrupt`, `sqlite3_prepare_v2`, `test_set_config_pagecache`/`test_restore_config_pagecache`, `testvfs` — the `*-filescope-err.*` markers and the `pragma-9.*`/`21.1`/pragma6-1.0 cases.
- **btree file-format corruption detection** (integrity_check `pragma-3.2`..`3.23`, `22.x`): built on `hexio_write` corrupting SQLite's on-disk btree; VibeSQL does not use that file format so the corruption is undetectable by construction.
- **ATTACH / multi-connection**: `pragma4` `4.1.x`..`4.6.x`, `pragma-14.6`, `pragma-15.3`, `23.1`.
- **`data_version` cross-connection change counter** (all of `pragma3.test`): requires per-connection own-vs-external write tracking that the shim's per-process model cannot emulate (deferred repeatedly by prior increments).
- **Pager/journal internals — route to #6154, not forced green**: `freelist_count` (pragma2 `1.x`/`3.2`), `cache_spill` numeric threshold semantics (pragma2 `5.x`), `page_count` (`pragma-14.x`), `lock_status` (`pragma-7.3`), proxy locking (`pragma-16.x`).
- **C-API config hooks**: `sqlite3_db_config DEFENSIVE` (`pragma-8.1.3`), `SQLITE_FCNTL_PRAGMA` via `testvfs` (`pragma-19.x`).
- **Interleaved `sqlite_master` creation order** (`23.1`): already filed as #6315.

No introspection PRAGMA has been silently reclassified; the pager/journal internals above remain flagged for #6154.

Part of #6175. Part of epic #5779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)