### PR TITLE
fix(tcl): stale tableopts skip, generated-column recompute, NULL-key outer-join bug

### DIFF
--- a/crates/vibesql-cli/src/script.rs
+++ b/crates/vibesql-cli/src/script.rs
@@ -380,22 +380,33 @@ fn parse_statements(script: &str) -> Vec<String> {
     let mut statements = Vec::new();
     let mut current_statement = String::new();
     let mut in_string = false;
+    // Track SQLite delimited-identifier quoting so a `'` or `;` embedded in a
+    // quoted identifier's name doesn't get mistaken for a string-literal
+    // delimiter or statement terminator (issue #6173, table.test table-8.4:
+    // `SELECT count(*) AS [y'all] FROM t3` — without this, the splitter
+    // treated the `'` inside `[y'all]` as opening an unterminated string
+    // literal and silently swallowed every remaining statement in the script
+    // into it).
+    let mut in_double_quote = false;
+    let mut in_bracket = false;
     let mut in_multiline_comment = false;
     let mut begin_depth = 0; // Track BEGIN...END nesting for trigger bodies
-    // Track CASE...END nesting *within* a trigger body. A `CASE ... END`
-    // expression in a trigger action (e.g. `SELECT CASE WHEN ... THEN
-    // RAISE(IGNORE) END`) introduces an inner `END` that must NOT be counted
-    // as the trigger's terminating `END`. Without this, the splitter closes
-    // the `CREATE TRIGGER` at the CASE's `END`, slicing one statement into
-    // several malformed fragments (issue #5468). We only track CASE depth when
-    // already inside a trigger body (`begin_depth > 0`); top-level CASE
-    // expressions split correctly on their trailing `;` and need no tracking.
+                             // Track CASE...END nesting *within* a trigger body. A `CASE ... END`
+                             // expression in a trigger action (e.g. `SELECT CASE WHEN ... THEN
+                             // RAISE(IGNORE) END`) introduces an inner `END` that must NOT be counted
+                             // as the trigger's terminating `END`. Without this, the splitter closes
+                             // the `CREATE TRIGGER` at the CASE's `END`, slicing one statement into
+                             // several malformed fragments (issue #5468). We only track CASE depth when
+                             // already inside a trigger body (`begin_depth > 0`); top-level CASE
+                             // expressions split correctly on their trailing `;` and need no tracking.
     let mut case_depth = 0;
     let mut chars = script.chars().peekable();
 
     while let Some(ch) = chars.next() {
+        let in_quoted_ident = in_double_quote || in_bracket;
+
         // Handle multi-line comments
-        if !in_string && ch == '/' && chars.peek() == Some(&'*') {
+        if !in_string && !in_quoted_ident && ch == '/' && chars.peek() == Some(&'*') {
             chars.next(); // consume '*'
             in_multiline_comment = true;
             continue;
@@ -410,7 +421,7 @@ fn parse_statements(script: &str) -> Vec<String> {
         }
 
         // Handle single-line comments
-        if !in_string && ch == '-' && chars.peek() == Some(&'-') {
+        if !in_string && !in_quoted_ident && ch == '-' && chars.peek() == Some(&'-') {
             // Skip until end of line
             for c in chars.by_ref() {
                 if c == '\n' {
@@ -421,8 +432,38 @@ fn parse_statements(script: &str) -> Vec<String> {
             continue;
         }
 
+        // Handle double-quoted delimited identifiers (`"col name"`). SQLite
+        // doubles an embedded `"` to escape it, mirroring the single-quote
+        // string-literal escape below. Tracked separately from in_string so
+        // a `'` inside a double-quoted identifier is not mistaken for a
+        // string-literal delimiter.
+        if !in_string && !in_bracket && ch == '"' {
+            current_statement.push(ch);
+            if in_double_quote && chars.peek() == Some(&'"') {
+                chars.next(); // consume the second quote
+                current_statement.push('"');
+                continue;
+            }
+            in_double_quote = !in_double_quote;
+            continue;
+        }
+
+        // Handle SQLite bracket-quoted identifiers (`[col name]`). Bracket
+        // identifiers have no internal escape convention for `]`, so a
+        // matching close bracket always ends them.
+        if !in_string && !in_double_quote && ch == '[' && !in_bracket {
+            in_bracket = true;
+            current_statement.push(ch);
+            continue;
+        }
+        if in_bracket && ch == ']' {
+            in_bracket = false;
+            current_statement.push(ch);
+            continue;
+        }
+
         // Handle string literals
-        if ch == '\'' {
+        if ch == '\'' && !in_double_quote && !in_bracket {
             current_statement.push(ch);
             // Check for escaped quote ('' in SQL)
             if in_string && chars.peek() == Some(&'\'') {
@@ -435,7 +476,7 @@ fn parse_statements(script: &str) -> Vec<String> {
         }
 
         // Track BEGIN/END keywords for trigger body nesting (case-insensitive)
-        if !in_string && ch.is_ascii_alphabetic() {
+        if !in_string && !in_double_quote && !in_bracket && ch.is_ascii_alphabetic() {
             current_statement.push(ch);
             // Peek ahead to check for BEGIN or END keyword
             let rest: String = chars.clone().take_while(|c| c.is_ascii_alphabetic()).collect();
@@ -517,7 +558,7 @@ fn parse_statements(script: &str) -> Vec<String> {
         // Handle statement delimiter (semicolon)
         // Include the semicolon in the statement so the parser can see it.
         // But don't split if we're inside a BEGIN...END block (trigger body)
-        if !in_string && ch == ';' {
+        if !in_string && !in_double_quote && !in_bracket && ch == ';' {
             current_statement.push(ch); // Include the semicolon
             if begin_depth == 0 {
                 // Only split if we're not inside a BEGIN...END block.
@@ -535,7 +576,7 @@ fn parse_statements(script: &str) -> Vec<String> {
 
         // Handle newlines as delimiters for dot-commands (SQLite compatibility)
         // Dot-commands don't require semicolons - a newline ends them
-        if !in_string && ch == '\n' {
+        if !in_string && !in_double_quote && !in_bracket && ch == '\n' {
             let trimmed = current_statement.trim();
             if !trimmed.is_empty() && (trimmed.starts_with('.') || trimmed.starts_with('\\')) {
                 statements.push(trimmed.to_string());
@@ -641,6 +682,42 @@ mod tests {
         let stmts = parse_statements(script);
         assert_eq!(stmts.len(), 1);
         assert_eq!(stmts[0], "INSERT INTO test VALUES ('It''s a test');");
+    }
+
+    #[test]
+    fn test_parse_apostrophe_in_bracket_identifier_does_not_glue_statements() {
+        // SQLite bracket-quoted identifiers (`[...]`) can contain an
+        // apostrophe with no escaping convention (table.test table-8.4:
+        // `SELECT count(*) AS [y'all] FROM t3`). Without dedicated bracket
+        // tracking, the splitter mistook the `'` for a string-literal
+        // delimiter and glued every remaining statement into one unterminated
+        // "string" (issue #6173).
+        let script = "CREATE TABLE t5 AS SELECT count(*) AS [y'all] FROM t3; SELECT * FROM t5;";
+        let stmts = parse_statements(script);
+        assert_eq!(stmts.len(), 2);
+        assert_eq!(stmts[0], "CREATE TABLE t5 AS SELECT count(*) AS [y'all] FROM t3;");
+        assert_eq!(stmts[1], "SELECT * FROM t5;");
+    }
+
+    #[test]
+    fn test_parse_apostrophe_in_double_quoted_identifier_does_not_glue_statements() {
+        // Same hazard for a double-quoted identifier containing an
+        // apostrophe.
+        let script = "SELECT 1 AS \"y'all\"; SELECT 2;";
+        let stmts = parse_statements(script);
+        assert_eq!(stmts.len(), 2);
+        assert_eq!(stmts[0], "SELECT 1 AS \"y'all\";");
+        assert_eq!(stmts[1], "SELECT 2;");
+    }
+
+    #[test]
+    fn test_parse_escaped_double_quote_in_identifier() {
+        // Doubled `"` inside a double-quoted identifier is SQL's escape for
+        // an embedded literal `"`, mirroring the single-quote string escape.
+        let script = "SELECT 1 AS \"a\"\"b\";";
+        let stmts = parse_statements(script);
+        assert_eq!(stmts.len(), 1);
+        assert_eq!(stmts[0], "SELECT 1 AS \"a\"\"b\";");
     }
 
     #[test]

--- a/crates/vibesql-executor/src/constraint_validator.rs
+++ b/crates/vibesql-executor/src/constraint_validator.rs
@@ -121,6 +121,109 @@ pub fn validate_check_constraint_columns(
     Ok(())
 }
 
+/// Visitor that collects the (canonical, lower-cased) names of every column of
+/// `table_canonical` referenced by an expression. Used to build the
+/// generated-column dependency graph below; unlike [`CheckColumnResolver`] this
+/// does not stop early — every reference is needed to detect a cycle.
+struct GeneratedColumnDependencyCollector<'a> {
+    table_canonical: &'a str,
+    refs: Vec<String>,
+}
+
+impl ExpressionVisitor for GeneratedColumnDependencyCollector<'_> {
+    fn pre_visit_expression(&mut self, expr: &Expression) -> VisitResult {
+        if let Expression::ColumnRef(col_id) = expr {
+            if let Some(table) = col_id.table_canonical() {
+                if !table.eq_ignore_ascii_case(self.table_canonical) {
+                    return VisitResult::Continue;
+                }
+            }
+            self.refs.push(col_id.column_canonical().to_string());
+        }
+        VisitResult::Continue
+    }
+}
+
+/// Detect a circular dependency among a table's generated columns (`x AS
+/// (expr)` / `GENERATED ALWAYS AS (expr)`). SQLite rejects this with
+/// `generated column loop on "<col>"` — reported on the generated column whose
+/// own expression-resolution first re-encounters a column still being resolved
+/// higher up the same dependency chain (gencol1-8.20, issue #6173):
+///   `c1 AS(c0 + c2), c2 AS(c1)` — c1 depends on c2, c2 depends on c1.
+/// A single self-reference (`a AS(a)`) is also a (trivial) loop.
+///
+/// This walks the *static* dependency graph at CREATE TABLE time. SQLite's own
+/// cycle guard is a runtime "column busy" flag set while lazily resolving a
+/// generated column's value, but since only an actually-cyclic definition can
+/// ever trip it, detecting the same cycle statically and rejecting the CREATE
+/// up front is behavior-equivalent and — unlike the lazy guard — never leaves
+/// a broken table behind for INSERT/UPDATE to trip over one row at a time.
+pub fn validate_generated_column_cycles(
+    table_name: &str,
+    columns: &[ColumnSchema],
+) -> Result<(), ExecutorError> {
+    let table_canonical = table_name.to_ascii_lowercase();
+    let by_name: std::collections::HashMap<String, usize> =
+        columns.iter().enumerate().map(|(idx, c)| (c.name.to_ascii_lowercase(), idx)).collect();
+
+    // Dependencies of each generated column, restricted to OTHER generated
+    // columns of the same table (a reference to a plain stored column is a
+    // graph leaf and can never participate in a cycle).
+    let mut deps: Vec<Vec<usize>> = vec![Vec::new(); columns.len()];
+    for (idx, col) in columns.iter().enumerate() {
+        let Some(expr) = &col.generated_expr else { continue };
+        let mut collector = GeneratedColumnDependencyCollector {
+            table_canonical: &table_canonical,
+            refs: Vec::new(),
+        };
+        walk_expression(&mut collector, expr);
+        for r in collector.refs {
+            if let Some(&dep_idx) = by_name.get(&r) {
+                if columns[dep_idx].generated_expr.is_some() {
+                    deps[idx].push(dep_idx);
+                }
+            }
+        }
+    }
+
+    #[derive(Clone, Copy, PartialEq)]
+    enum State {
+        Unvisited,
+        Visiting,
+        Done,
+    }
+    let mut state = vec![State::Unvisited; columns.len()];
+
+    fn visit(
+        idx: usize,
+        deps: &[Vec<usize>],
+        state: &mut [State],
+        columns: &[ColumnSchema],
+    ) -> Result<(), ExecutorError> {
+        state[idx] = State::Visiting;
+        for &dep in &deps[idx] {
+            if state[dep] == State::Visiting {
+                return Err(ExecutorError::SqliteCompatError(format!(
+                    "generated column loop on \"{}\"",
+                    columns[idx].name
+                )));
+            }
+            if state[dep] == State::Unvisited {
+                visit(dep, deps, state, columns)?;
+            }
+        }
+        state[idx] = State::Done;
+        Ok(())
+    }
+
+    for idx in 0..columns.len() {
+        if columns[idx].generated_expr.is_some() && state[idx] == State::Unvisited {
+            visit(idx, &deps, &mut state, columns)?;
+        }
+    }
+    Ok(())
+}
+
 /// Validate that a CHECK constraint expression uses only forms SQLite permits.
 /// Subqueries and bind parameters are rejected at CREATE TABLE time with the
 /// exact SQLite messages so an invalid definition never creates a half-formed

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -388,11 +388,23 @@ impl CreateTableExecutor {
             &table_schema.check_constraints,
         )?;
 
-        // WITHOUT ROWID tables must have a PRIMARY KEY (SQLite requirement, Issue #4953)
+        // Reject a circular dependency among generated columns (gencol1-8.20,
+        // issue #6173): `c1 AS(c0+c2), c2 AS(c1)`. Checked here too, before the
+        // table is inserted into the catalog, so a cyclic definition never
+        // creates a half-formed table that later blows up one row at a time.
+        crate::constraint_validator::validate_generated_column_cycles(
+            &table_schema.name,
+            &table_schema.columns,
+        )?;
+
+        // WITHOUT ROWID tables must have a PRIMARY KEY (SQLite requirement, Issue #4953).
+        // SQLite's exact wording is "PRIMARY KEY missing on table <name>" (verbatim,
+        // no prefix) — tableopts.test tableopt-1.1 (issue #6173).
         if stmt.without_rowid && table_schema.primary_key.is_none() {
-            return Err(ExecutorError::ConstraintViolation(
-                "WITHOUT ROWID tables must have a PRIMARY KEY".to_string(),
-            ));
+            return Err(ExecutorError::SqliteCompatError(format!(
+                "PRIMARY KEY missing on table {}",
+                table_schema.name
+            )));
         }
 
         // AUTOINCREMENT is meaningless on a WITHOUT ROWID table (there is no
@@ -473,6 +485,20 @@ impl CreateTableExecutor {
                         })
                     })
                     .collect::<Result<Vec<_>, _>>()?;
+
+                // A table-level FOREIGN KEY(...) clause's child and parent column
+                // lists must be the same length when a parent column list is given
+                // at all (an omitted parent list defaults to the parent's PRIMARY
+                // KEY and is checked elsewhere). SQLite rejects a mismatch at CREATE
+                // TABLE time (table.test table-10.9/table-10.10, issue #6173):
+                //   FOREIGN KEY(b,c) REFERENCES t4(x)     -- 2 vs 1
+                //   FOREIGN KEY(b,c) REFERENCES t4(x,y,z) -- 2 vs 3
+                if !references_columns.is_empty() && references_columns.len() != fk_columns.len() {
+                    return Err(ExecutorError::SqliteCompatError(
+                        "number of columns in foreign key does not match the number of columns in the referenced table"
+                            .to_string(),
+                    ));
+                }
 
                 // Lookup parent table to get parent column indices
                 // If the parent table doesn't exist yet, use placeholder indices.

--- a/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/blob_funcs.rs
+++ b/crates/vibesql-executor/src/evaluator/functions/sqlite_compat/blob_funcs.rs
@@ -202,13 +202,14 @@ pub(crate) fn zeroblob(args: &[SqlValue]) -> Result<SqlValue, ExecutorError> {
         }
     };
 
-    // SQLite limits blob size, we'll use a reasonable limit
+    // SQLite limits blob size to SQLITE_MAX_LENGTH (default 1,000,000,000
+    // bytes) and reports an over-limit ZEROBLOB with the same message as any
+    // other over-limit string/blob construction: "string or blob too big"
+    // (SQLITE_TOOBIG), not a VibeSQL-specific diagnostic (table.test
+    // table-18.1, issue #6173).
     const MAX_BLOB_SIZE: usize = 1_000_000_000; // 1GB
     if n > MAX_BLOB_SIZE {
-        return Err(ExecutorError::UnsupportedFeature(format!(
-            "ZEROBLOB size {} exceeds maximum {}",
-            n, MAX_BLOB_SIZE
-        )));
+        return Err(ExecutorError::SqliteCompatError("string or blob too big".to_string()));
     }
 
     Ok(SqlValue::Blob(vec![0u8; n]))

--- a/crates/vibesql-executor/src/insert/validation.rs
+++ b/crates/vibesql-executor/src/insert/validation.rs
@@ -329,6 +329,61 @@ pub fn coerce_value(
             }
         }
 
+        // REAL/FLOAT/DOUBLE → Integer types (SQLite type affinity). Same
+        // whole-number-preserving rule as the Numeric→Integer arms above: a
+        // real value with no fractional part converts to an integer of the
+        // target width, otherwise it keeps its real type. Without these arms,
+        // any real-affinity source column (`x REAL`) feeding an INTEGER
+        // target — including a generated column's `AS (x)` recomputation,
+        // gencol1-23.1.* / -filescope-err.1, issue #6173 — hit the fallback
+        // "Type mismatch" error instead of applying affinity like every other
+        // real-typed variant already does.
+        (SqlValue::Real(f) | SqlValue::Double(f), DataType::Integer) => {
+            if f.fract() == 0.0 && *f >= i64::MIN as f64 && *f <= i64::MAX as f64 {
+                Ok(SqlValue::Integer(*f as i64))
+            } else {
+                Ok(value)
+            }
+        }
+        (SqlValue::Float(f), DataType::Integer) => {
+            let f64_val = *f as f64;
+            if f64_val.fract() == 0.0 && f64_val >= i64::MIN as f64 && f64_val <= i64::MAX as f64 {
+                Ok(SqlValue::Integer(f64_val as i64))
+            } else {
+                Ok(value)
+            }
+        }
+        (SqlValue::Real(f) | SqlValue::Double(f), DataType::Smallint) => {
+            if f.fract() == 0.0 && *f >= i16::MIN as f64 && *f <= i16::MAX as f64 {
+                Ok(SqlValue::Smallint(*f as i16))
+            } else {
+                Ok(value)
+            }
+        }
+        (SqlValue::Float(f), DataType::Smallint) => {
+            let f64_val = *f as f64;
+            if f64_val.fract() == 0.0 && f64_val >= i16::MIN as f64 && f64_val <= i16::MAX as f64 {
+                Ok(SqlValue::Smallint(f64_val as i16))
+            } else {
+                Ok(value)
+            }
+        }
+        (SqlValue::Real(f) | SqlValue::Double(f), DataType::Bigint) => {
+            if f.fract() == 0.0 && *f >= i64::MIN as f64 && *f <= i64::MAX as f64 {
+                Ok(SqlValue::Bigint(*f as i64))
+            } else {
+                Ok(value)
+            }
+        }
+        (SqlValue::Float(f), DataType::Bigint) => {
+            let f64_val = *f as f64;
+            if f64_val.fract() == 0.0 && f64_val >= i64::MIN as f64 && f64_val <= i64::MAX as f64 {
+                Ok(SqlValue::Bigint(f64_val as i64))
+            } else {
+                Ok(value)
+            }
+        }
+
         // VARCHAR/CHARACTER → Integer types (SQLite type affinity)
         // Try to convert text to integer, otherwise keep as text
         (SqlValue::Varchar(s) | SqlValue::Character(s), DataType::Integer) => {

--- a/crates/vibesql-executor/src/select/join/hash_join/columnar/probe.rs
+++ b/crates/vibesql-executor/src/select/join/hash_join/columnar/probe.rs
@@ -119,7 +119,10 @@ pub(crate) fn probe_columnar_left_outer(
     // in a separate phase produces a "matches-then-unmatched" ordering that
     // violates LEFT OUTER JOIN row order (issue #5696).
     match (left_key, right_key) {
-        (ColumnArray::Int64(left_values, left_nulls), ColumnArray::Int64(right_values, _)) => {
+        (
+            ColumnArray::Int64(left_values, left_nulls),
+            ColumnArray::Int64(right_values, right_nulls),
+        ) => {
             for (left_idx, &key) in left_values.iter().enumerate() {
                 // NULL keys never match in equi-joins, but the left row is still
                 // emitted NULL-padded on the right side.
@@ -130,6 +133,19 @@ pub(crate) fn probe_columnar_left_outer(
                     // BLOOM FILTER OPTIMIZATION: only probe when the key might be
                     // present on the build side.
                     for right_idx in hash_table.probe_i64(key, right_values) {
+                        // The hash table indexes ALL build-side rows, including
+                        // ones whose join-key column is NULL (stored as a
+                        // placeholder value, e.g. 0) — the same raw-value
+                        // equality gap that `probe_columnar`'s inner-join path
+                        // guards against below. Without this check, a NULL
+                        // build-side key whose placeholder happens to equal a
+                        // real probe key was reported as a match instead of
+                        // NULL-padded (gencol1-16.40, issue #6173: a generated
+                        // column's *real* value from the NULL row leaked into
+                        // an unmatched LEFT JOIN row instead of NULL).
+                        if is_null(right_nulls, right_idx as usize) {
+                            continue;
+                        }
                         left_indices.push(left_idx as u32);
                         right_indices.push(right_idx);
                         found_match = true;
@@ -142,7 +158,10 @@ pub(crate) fn probe_columnar_left_outer(
                 }
             }
         }
-        (ColumnArray::String(left_values, left_nulls), ColumnArray::String(right_values, _)) => {
+        (
+            ColumnArray::String(left_values, left_nulls),
+            ColumnArray::String(right_values, right_nulls),
+        ) => {
             for (left_idx, key) in left_values.iter().enumerate() {
                 let key_is_null = left_nulls.as_ref().map(|n| n[left_idx]).unwrap_or(false);
 
@@ -151,6 +170,11 @@ pub(crate) fn probe_columnar_left_outer(
                     // BLOOM FILTER OPTIMIZATION: only probe when the key might be
                     // present on the build side.
                     for right_idx in hash_table.probe_string(key, right_values) {
+                        // See the Int64 arm above: skip build-side rows whose
+                        // key is actually NULL (placeholder-value false match).
+                        if is_null(right_nulls, right_idx as usize) {
+                            continue;
+                        }
                         left_indices.push(left_idx as u32);
                         right_indices.push(right_idx);
                         found_match = true;
@@ -195,10 +219,13 @@ pub(crate) fn probe_columnar_right_outer(
     let mut right_matched = vec![false; right_row_count];
 
     match (right_key, left_key) {
-        (ColumnArray::Int64(right_values, right_nulls), ColumnArray::Int64(left_values, _)) => {
+        (
+            ColumnArray::Int64(right_values, right_nulls),
+            ColumnArray::Int64(left_values, left_nulls),
+        ) => {
             for (right_idx, &key) in right_values.iter().enumerate() {
-                let is_null = right_nulls.as_ref().map(|n| n[right_idx]).unwrap_or(false);
-                if is_null {
+                let right_key_is_null = right_nulls.as_ref().map(|n| n[right_idx]).unwrap_or(false);
+                if right_key_is_null {
                     continue;
                 }
 
@@ -209,6 +236,14 @@ pub(crate) fn probe_columnar_right_outer(
 
                 let mut found_match = false;
                 for left_idx in hash_table.probe_i64(key, left_values) {
+                    // Skip build-side (left) rows whose key column is actually
+                    // NULL: the hash table indexes every row's raw placeholder
+                    // value, so a NULL left key can otherwise false-match a
+                    // real right key equal to that placeholder (mirrors the
+                    // LEFT OUTER fix above, issue #6173).
+                    if is_null(left_nulls, left_idx as usize) {
+                        continue;
+                    }
                     left_indices.push(left_idx);
                     right_indices.push(right_idx as u32);
                     found_match = true;
@@ -218,10 +253,13 @@ pub(crate) fn probe_columnar_right_outer(
                 }
             }
         }
-        (ColumnArray::String(right_values, right_nulls), ColumnArray::String(left_values, _)) => {
+        (
+            ColumnArray::String(right_values, right_nulls),
+            ColumnArray::String(left_values, left_nulls),
+        ) => {
             for (right_idx, key) in right_values.iter().enumerate() {
-                let is_null = right_nulls.as_ref().map(|n| n[right_idx]).unwrap_or(false);
-                if is_null {
+                let right_key_is_null = right_nulls.as_ref().map(|n| n[right_idx]).unwrap_or(false);
+                if right_key_is_null {
                     continue;
                 }
 
@@ -232,6 +270,10 @@ pub(crate) fn probe_columnar_right_outer(
 
                 let mut found_match = false;
                 for left_idx in hash_table.probe_string(key, left_values) {
+                    // See the Int64 arm above.
+                    if is_null(left_nulls, left_idx as usize) {
+                        continue;
+                    }
                     left_indices.push(left_idx);
                     right_indices.push(right_idx as u32);
                     found_match = true;

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -1888,8 +1888,29 @@ fn apply_generated_columns_for_update(
     let evaluator = ExpressionEvaluator::new(schema)
         .with_schema_context(crate::evaluator::SchemaExprContext::GeneratedColumn);
 
-    for (col_idx, col) in schema.columns.iter().enumerate() {
-        if let Some(generated_expr) = &col.generated_expr {
+    // Generated columns may reference other generated columns (e.g. `w INT
+    // GENERATED ALWAYS AS (m*5), m INT AS (a*2) STORED` — gencol1-2.6/2.7,
+    // issue #6173). A single pass in column-definition order only sees an
+    // up-to-date value for generated columns *earlier* in declaration order:
+    // `w` (index 0) depends on `m` (index 1), so a single top-to-bottom pass
+    // would compute `w` from `m`'s stale pre-UPDATE value. Iterate to a fixed
+    // point exactly as the INSERT path does (`apply_generated_columns`),
+    // folding each freshly computed value back into the row so later (and
+    // earlier, on subsequent passes) generated columns see it. Bounded by the
+    // number of generated columns, the longest possible acyclic dependency
+    // chain; SQLite rejects circular generated-column definitions at CREATE
+    // TABLE time, so this always converges.
+    let generated_indices: Vec<usize> = schema
+        .columns
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, col)| col.generated_expr.as_ref().map(|_| idx))
+        .collect();
+
+    for _pass in 0..generated_indices.len().max(1) {
+        for &col_idx in &generated_indices {
+            let col = &schema.columns[col_idx];
+            let generated_expr = col.generated_expr.as_ref().expect("filtered above");
             // Evaluate the generated expression against the current row
             let generated_value = evaluator.eval(generated_expr, row)?;
             // STRICT tables (issue #6173) enforce the rigid strict-datatype

--- a/crates/vibesql-executor/tests/columnar_outer_join_null_key_tests.rs
+++ b/crates/vibesql-executor/tests/columnar_outer_join_null_key_tests.rs
@@ -1,0 +1,129 @@
+//! Regression tests for a NULL-key false-match bug in the columnar hash-join
+//! outer-join probe paths (issue #6173).
+//!
+//! `ColumnarHashTable::build_from_i64` (and friends) indexes every build-side
+//! row by its *raw* value, including rows whose join-key column is actually
+//! NULL — a NULL is stored as a placeholder value (0 for integers) alongside
+//! a separate null bitmap. The inner-join probe (`probe_columnar`) already
+//! guarded against this by skipping any hash-table hit whose build-side row is
+//! flagged NULL, but `probe_columnar_left_outer` and `probe_columnar_right_outer`
+//! were missing the same guard: a NULL build-side key whose placeholder value
+//! (0) happened to equal a real probe key was reported as a genuine match
+//! instead of NULL-padding the unmatched row — leaking that NULL row's *other*
+//! column values (e.g. a generated column's real computed value) into a join
+//! result row that SQL semantics say must be entirely NULL on that side.
+//!
+//! `gencol1-16.40` (SQLite's own generated-column test suite) is what
+//! surfaced this: `SELECT c0, c1, c2 FROM t0 LEFT JOIN t1 ON c0=c1` where
+//! `t1(c1, c2 AS (c1 ISNULL))` has a row `(NULL, 1)` — with the bug, an
+//! unmatched `t0` row (`c0=0`) spuriously read `c2=1` (from the NULL row)
+//! instead of `c2=NULL`. These tests reproduce the same false-match with
+//! plain (non-generated) columns to pin the root cause directly.
+
+use vibesql_executor::{CreateTableExecutor, InsertExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn execute_sql(db: &mut Database, sql: &str) {
+    for sql_stmt in sql.split(';') {
+        let trimmed = sql_stmt.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let stmt = Parser::parse_sql(trimmed).expect("Failed to parse SQL");
+        match stmt {
+            vibesql_ast::Statement::CreateTable(s) => {
+                CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+            }
+            vibesql_ast::Statement::Insert(s) => {
+                InsertExecutor::execute(db, &s).expect("INSERT failed");
+            }
+            other => panic!("Unsupported statement type: {:?}", other),
+        }
+    }
+}
+
+fn select_rows(db: &Database, sql: &str) -> Vec<vibesql_storage::Row> {
+    let stmt = Parser::parse_sql(sql).expect("Failed to parse SELECT");
+    if let vibesql_ast::Statement::Select(select_stmt) = stmt {
+        let executor = vibesql_executor::SelectExecutor::new(db);
+        executor.execute(&select_stmt).expect("SELECT failed")
+    } else {
+        panic!("Expected SELECT statement");
+    }
+}
+
+/// LEFT JOIN: a build-side (right) row whose join-key is NULL must never
+/// false-match a probe-side (left) row whose key equals the NULL row's
+/// placeholder storage value (0 for integers).
+#[test]
+fn left_outer_join_null_build_key_does_not_false_match_placeholder() {
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE t0(c0 INTEGER)");
+    execute_sql(&mut db, "CREATE TABLE t1(c1 INTEGER, tag INTEGER)");
+    execute_sql(&mut db, "INSERT INTO t0 VALUES(0)");
+    // Right side has a real key (1) and a NULL key, whose placeholder value
+    // (0) collides with the left row's actual key.
+    execute_sql(&mut db, "INSERT INTO t1 VALUES(1, 100)");
+    execute_sql(&mut db, "INSERT INTO t1 VALUES(NULL, 200)");
+
+    let rows = select_rows(&db, "SELECT c0, c1, tag FROM t0 LEFT JOIN t1 ON c0 = c1");
+    assert_eq!(rows.len(), 1, "left row must appear exactly once (no fan-out from a false match)");
+    assert_eq!(rows[0].values[0], SqlValue::Integer(0));
+    assert_eq!(rows[0].values[1], SqlValue::Null, "right join-key column must be NULL-padded");
+    assert_eq!(
+        rows[0].values[2],
+        SqlValue::Null,
+        "right non-key column must be NULL-padded too, not leaked from the NULL-keyed row"
+    );
+}
+
+/// RIGHT JOIN: symmetric case — a build-side (left) row whose join-key is
+/// NULL must never false-match a probe-side (right) row via the placeholder.
+#[test]
+fn right_outer_join_null_build_key_does_not_false_match_placeholder() {
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE t1(c1 INTEGER, tag INTEGER)");
+    execute_sql(&mut db, "CREATE TABLE t0(c0 INTEGER)");
+    execute_sql(&mut db, "INSERT INTO t1 VALUES(1, 100)");
+    execute_sql(&mut db, "INSERT INTO t1 VALUES(NULL, 200)");
+    execute_sql(&mut db, "INSERT INTO t0 VALUES(0)");
+
+    let rows = select_rows(&db, "SELECT c0, c1, tag FROM t1 RIGHT JOIN t0 ON c1 = c0");
+    assert_eq!(rows.len(), 1, "right row must appear exactly once (no fan-out from a false match)");
+    assert_eq!(
+        rows[0].values[0],
+        SqlValue::Integer(0),
+        "right table's own column is always present"
+    );
+    assert_eq!(rows[0].values[1], SqlValue::Null, "left join-key column must be NULL-padded");
+    assert_eq!(
+        rows[0].values[2],
+        SqlValue::Null,
+        "left non-key column must be NULL-padded too, not leaked from the NULL-keyed row"
+    );
+}
+
+/// Same LEFT JOIN scenario with a STRING join key (NULL placeholder is "").
+#[test]
+fn left_outer_join_null_build_key_does_not_false_match_empty_string_placeholder() {
+    let mut db = Database::new();
+    execute_sql(&mut db, "CREATE TABLE t0(c0 TEXT)");
+    execute_sql(&mut db, "CREATE TABLE t1(c1 TEXT, tag INTEGER)");
+    // Left key is empty string, which is the placeholder used for a NULL
+    // string build-side value.
+    execute_sql(&mut db, "INSERT INTO t0 VALUES('')");
+    execute_sql(&mut db, "INSERT INTO t1 VALUES('x', 100)");
+    execute_sql(&mut db, "INSERT INTO t1 VALUES(NULL, 200)");
+
+    let rows = select_rows(&db, "SELECT c0, c1, tag FROM t0 LEFT JOIN t1 ON c0 = c1");
+    assert_eq!(rows.len(), 1, "left row must appear exactly once (no fan-out from a false match)");
+    assert_eq!(rows[0].values[0], SqlValue::Varchar("".into()));
+    assert_eq!(rows[0].values[1], SqlValue::Null, "right join-key column must be NULL-padded");
+    assert_eq!(
+        rows[0].values[2],
+        SqlValue::Null,
+        "right non-key column must be NULL-padded too, not leaked from the NULL-keyed row"
+    );
+}

--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -368,6 +368,7 @@ impl Parser {
     #[allow(clippy::type_complexity)]
     pub(in crate::parser) fn parse_column_constraints(
         &mut self,
+        column_name: &str,
     ) -> Result<
         (
             Vec<vibesql_ast::ColumnConstraint>,
@@ -528,7 +529,32 @@ impl Parser {
                         let col_name = self.parse_column_name().map_err(|_| ParseError {
                             message: "Expected column name in REFERENCES".to_string(),
                         })?;
+                        // An inline column-constraint REFERENCES clause defines a
+                        // single-column foreign key, so the parent column list must
+                        // name exactly one column. SQLite still parses a longer list
+                        // grammatically but rejects it as a semantic error naming the
+                        // child column and parent table (table.test table-10.11):
+                        //   CREATE TABLE t6(a,b, c REFERENCES t4(x,y));
+                        //   -> "foreign key on c should reference only one column of table t4"
+                        // (issue #6173). Consume the rest of the list so the paren is
+                        // balanced before reporting the error.
+                        let mut extra = false;
+                        while matches!(self.peek(), Token::Comma) {
+                            self.advance();
+                            self.parse_column_name().map_err(|_| ParseError {
+                                message: "Expected column name in REFERENCES".to_string(),
+                            })?;
+                            extra = true;
+                        }
                         self.expect_token(Token::RParen)?;
+                        if extra {
+                            return Err(ParseError {
+                                message: format!(
+                                    "foreign key on {} should reference only one column of table {}",
+                                    column_name, table
+                                ),
+                            });
+                        }
                         Some(col_name)
                     } else {
                         None // Column not specified, defaults to PK

--- a/crates/vibesql-parser/src/parser/create/table.rs
+++ b/crates/vibesql-parser/src/parser/create/table.rs
@@ -234,7 +234,7 @@ impl Parser {
             // interleaved DEFAULT, and — in any order — a generated-column
             // `[GENERATED ALWAYS] AS (expr)` clause).
             let (constraints, mid_default, mid_generated, mid_default_source) =
-                self.parse_column_constraints()?;
+                self.parse_column_constraints(&name)?;
             if let Some(d) = mid_default {
                 if default_value.is_some() {
                     return Err(ParseError {
@@ -324,8 +324,16 @@ impl Parser {
                     self.advance(); // consume ROWID (SQLite WITHOUT ROWID tables)
                     without_rowid = true;
                 } else {
+                    // SQLite accepts an arbitrary identifier after WITHOUT and
+                    // rejects anything other than ROWID/OIDS with a dedicated
+                    // semantic message (not a generic syntax error):
+                    //   CREATE TABLE t1(a,b) WITHOUT unknown2;
+                    //   -> "unknown table option: unknown2"
+                    // (tableopts.test tableopt-1.2). Report the option's own
+                    // spelling rather than a token-position syntax error.
+                    let option_name = self.peek().to_sql();
                     return Err(ParseError {
-                        message: "Expected OIDS or ROWID after WITHOUT".to_string(),
+                        message: format!("unknown table option: {}", option_name),
                     });
                 }
             } else if self.peek_keyword(Keyword::Strict) {

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -829,6 +829,19 @@ proc translate_error_to_sqlite {vibesql_error} {
     if {[regexp -nocase {^Parse error: (the (?:NOT INDEXED|INDEXED BY) clause is not allowed on UPDATE or DELETE statements within triggers)$} $error_msg -> parse_msg]} {
         return $parse_msg
     }
+    # Unrecognized CREATE TABLE trailing option after WITHOUT (tableopts.test
+    # tableopt-1.2) — SQLite reports this as a semantic message, not a syntax
+    # error: "unknown table option: unknown2".
+    if {[regexp -nocase {^Parse error: (unknown table option: .+)$} $error_msg -> parse_msg]} {
+        return $parse_msg
+    }
+    # Inline column-constraint REFERENCES clause naming more than one parent
+    # column (table.test table-10.11) — SQLite parses the list grammatically
+    # and reports a semantic message, not a syntax error: "foreign key on c
+    # should reference only one column of table t4".
+    if {[regexp -nocase {^Parse error: (foreign key on .+ should reference only one column of table .+)$} $error_msg -> parse_msg]} {
+        return $parse_msg
+    }
     # Fallback for other parse errors (e.g., descriptive messages like "Expected identifier")
     if {[regexp -nocase {^Parse error: (.+)$} $error_msg -> parse_msg]} {
         return "near \"$parse_msg\": syntax error"
@@ -5808,7 +5821,6 @@ variable vibesql_skip_patterns {
     {utf16align- "UTF16 alignment test - encoding differs"}
     {subquery- "Subquery handling differs"}
     {resolver01- "Name resolution handling differs"}
-    {tableopts- "Table options differ"}
     {temptable- "Temp table tests require cross-test session state"}
     {temptable2- "Temp table tests require cross-test session state"}
     {fordelete- "Tests SQLite internal btree FORDELETE flag (VDBE-specific)"}


### PR DESCRIPTION
## Summary

Part of the `#6173` family (CREATE TABLE / schema-definition conformance). This increment clears a stale blanket test-harness skip that hid 10 passing tests, fixes several real CREATE TABLE / generated-column bugs, and — most importantly — fixes a root-cause NULL-key false-match bug in the columnar hash-join outer-join probe paths.

## Changes

**Harness fix (`scripts/tester_vibesql.tcl`)**
- Removed a stale blanket `{tableopts- "Table options differ"}` skip pattern. Because the shim's skip matcher also checks a `<file-basename>-<test-name>` fallback, this "tableopts-" prefix silently matched every test in `tableopts.test` (whose own test names are `tableopt-*`, no trailing "s") via `tableopts-tableopt-1.1`, etc. — a whole-file skip disguised as per-test skips. `tableopts.test`: 0/10 → 10/10.
- Added two verbatim-passthrough translations for new SQLite-compatible semantic error messages (see parser changes below), so they aren't mis-wrapped as generic `near "...": syntax error`.

**Parser (`crates/vibesql-parser`)**
- `CREATE TABLE ... WITHOUT <unknown>` now reports SQLite's `unknown table option: <name>` instead of a generic syntax error (`tableopt-1.2`).
- An inline column-constraint `REFERENCES tbl(a, b)` (more than one parent column) now reports SQLite's `foreign key on <col> should reference only one column of table <tbl>` (`table-10.11`).

**Executor / catalog (`crates/vibesql-executor`)**
- `WITHOUT ROWID` table missing a `PRIMARY KEY` now reports SQLite's exact `PRIMARY KEY missing on table <name>` (`tableopt-1.1`).
- Table-level `FOREIGN KEY(...) REFERENCES tbl(...)` now validates the child/parent column-count match, matching SQLite's `number of columns in foreign key does not match the number of columns in the referenced table` (`table-10.9`/`table-10.10`).
- `ZEROBLOB(n)` over the size limit now reports SQLite's `string or blob too big` instead of a VibeSQL-specific message (`table-18.1`).
- UPDATE's generated-column recompute now iterates to a fixed point (mirroring what the INSERT path already did), so a generated column that depends on *another* generated column (e.g. `w AS (m*5), m AS (a*2)`) sees the freshly-recomputed value instead of a stale one from earlier in declaration order (`gencol1-2.6.140`/`2.6.150`/`2.7.140`/`2.7.150`).
- Added generated-column cycle detection at `CREATE TABLE` time (`c1 AS(c0+c2), c2 AS(c1)` → `generated column loop on "c2"`, matching SQLite verbatim) (`gencol1-8.20`).
- Added `REAL`/`FLOAT`/`DOUBLE` → `INTEGER`/`SMALLINT`/`BIGINT` affinity-coercion arms (mirroring the existing `NUMERIC` arms) — a `REAL` source column feeding an `INTEGER`-typed generated column previously hit a hard "Type mismatch" error instead of applying SQLite's affinity rule (`gencol1-23.1.*`, and the file's single `filescope-err.1` cascade).

**Root-cause engine bug: columnar hash-join outer-join NULL keys (`crates/vibesql-executor/src/select/join/hash_join/columnar/`)**
- `ColumnarHashTable::build_from_i64`/etc. index build-side rows by their *raw* value, including rows whose join-key column is NULL (stored as a placeholder, e.g. `0` for integers, alongside a separate null bitmap). The inner-join probe (`probe_columnar`) already guarded against this by skipping any hash-table hit whose build-side row is flagged NULL — but `probe_columnar_left_outer` and `probe_columnar_right_outer` were missing the same guard. A NULL build-side key whose placeholder happened to equal a real probe key was reported as a genuine match instead of NULL-padding the row, leaking that NULL row's *other* column values into an unmatched-join result row.
- Surfaced by `gencol1-16.40`: `SELECT c0, c1, c2 FROM t0 LEFT JOIN t1 ON c0=c1` where `t1(c1, c2 AS (c1 ISNULL))` has a row `(NULL, 1)` — an unmatched `t0` row spuriously read `c2=1` (from the NULL row) instead of `c2=NULL`. This is a general LEFT/RIGHT OUTER JOIN correctness bug, not limited to generated columns — added `crates/vibesql-executor/tests/columnar_outer_join_null_key_tests.rs` with plain-column repros (int + string keys, both join directions) to pin the root cause independent of generated columns.

**CLI (`crates/vibesql-cli/src/script.rs`)**
- The script statement-splitter tracked single-quoted string literals but not double-quoted/bracket-quoted delimited identifiers, so an apostrophe inside `[y'all]` (a valid bracket-quoted identifier, `table.test table-8.4`) was mistaken for an unterminated string-literal delimiter — swallowing every remaining statement in the script into it. Added tracking for both delimited-identifier forms (including the `""` escape for embedded quotes) so quoting state is disambiguated correctly.

## Acceptance Criteria Verification

| File | Before | After | Verification |
|------|--------|-------|---------------|
| `tableopts.test` | 0/10 (100% shim-skipped) | 10/10 (100%) | `make test-tcl-file FILE=tableopts.test` |
| `table.test` | 74/82 (8 real failures) | 79/82 | `make test-tcl-file FILE=table.test` — remaining 3 documented below |
| `gencol1.test` | 117/152 (certified) → 141/152 (local re-check) | 170/174 | `make test-tcl-file FILE=gencol1.test` — remaining 4 documented below |
| `check.test` | 83/92 (from prior PR #6235) | 83/92 (unchanged, verified no regression) | `make test-tcl-file FILE=check.test` |
| `strict1.test` | 49/49 (100%, from prior work) | 49/49 (unchanged, verified no regression) | `make test-tcl-file FILE=strict1.test` |
| `crates/vibesql-executor` full suite | — | 195/195 test binaries green | `cargo test -p vibesql-executor --release` |
| `columnar_outer_join_null_key_tests.rs` (new) | — | 3/3 | `cargo test -p vibesql-executor --release --test columnar_outer_join_null_key_tests` |
| `crates/vibesql-cli` script-splitter tests | 23 (pre-existing) | 26 (3 new regression tests) | `cargo test -p vibesql-cli --bin vibesql script::` |
| Priority-1 spot-check (join/join2/select1/insert/update/where) | — | all green except one pre-existing, unrelated `insert-16.1` failure (verified present on unmodified `origin/main` tip build too) | individual `./scripts/tcltest test <file>` runs |

## Remaining documented gaps (not chased in this PR — Bucket-A / deep-VDBE-feature or acceptable per issue's own "documented behavior-justified" clause)

- `table.test` `table-8.7`/`table-8.8`: the shim's TEMP-table-demotion tradeoff (documented at length in `tester_vibesql.tcl`) keeps a demoted TEMP table visible across a `db close`/`sqlite3 db test.db` reconnect that real SQLite would drop it at — a harness-architecture limitation (process-per-batch shim vs. SQLite's one-connection-per-file model), not a VibeSQL engine bug.
- `table.test` `table-14.2`: SQLite VDBE-level "open cursor blocks DROP TABLE" locking semantics have no equivalent in VibeSQL's execution model.
- `gencol1.test` `15.10`/`15.20`: `db deserialize` / hex-encoded page-dump C-API tests (Bucket-A, no SQL-CLI-reachable surface).
- `gencol1.test` `23.2`/`23.3`: `INDEXED BY` covering-index-scan ordering + `EXPLAIN` VDBE-opcode introspection — not implemented.
- `check.test` `7.2`–`7.8`: `db func`/`db2 func` custom-UDF-per-connection harness tests (Bucket-A C-API class).
- `check.test` `4.8`/`4.8.1`: `PRAGMA ignore_check_constraints` not implemented.
- Also discovered but **not fixed here** (out of this issue's CREATE-TABLE-semantics scope): `autoinc.test`'s trigger-recursion tests (`autoinc-3928.*`) produce **duplicate AUTOINCREMENT primary-key values** under nested BEFORE/AFTER-trigger inserts — a genuine correctness bug, but in the trigger-execution engine rather than CREATE TABLE/AUTOINCREMENT bookkeeping itself. Filing a separate follow-up issue for this.

## Test Plan

- `cargo build --release` (full workspace) — clean
- `cargo test -p vibesql-executor --release` — 195/195 green (no regressions)
- `cargo test -p vibesql-cli --bin vibesql script::` — 26/26 green (3 new)
- `cargo clippy --release -p vibesql-cli -p vibesql-executor -p vibesql-parser` — no new warnings in touched files
- `rustfmt` applied to all touched files
- Per-file TCL verification table above
- Cross-checked `insert-16.1`'s pre-existing failure against an unmodified `origin/main` tip build to confirm it isn't a regression

Part of #6173.