### PR TITLE
fix(fkey): parent-key UPDATE cascade + super-fast-path FK bypass

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -1601,7 +1601,14 @@ impl SqlExecutor {
                     })
                 }
                 "FOREIGN_KEYS" => {
-                    self.db.set_foreign_keys_enabled(bool_value);
+                    // EVIDENCE-OF R-46649-58537: it is not possible to enable
+                    // or disable foreign key constraints in the middle of a
+                    // multi-statement transaction (when not in autocommit
+                    // mode). Attempting to do so does not return an error —
+                    // it simply has no effect (e_fkey-6.1..6.3).
+                    if !self.db.in_transaction() {
+                        self.db.set_foreign_keys_enabled(bool_value);
+                    }
                     Ok(QueryResult {
                         rows: Vec::new(),
                         columns: Vec::new(),

--- a/crates/vibesql-executor/src/foreign_key_check.rs
+++ b/crates/vibesql-executor/src/foreign_key_check.rs
@@ -109,22 +109,43 @@ fn parent_has_matching_key(db: &Database, parent: &TableSchema, parent_indices: 
     //    WHERE clause) are excluded — SQLite's `sqlite3FkLocateIndex` only
     //    accepts indexes that cover every parent row. Expression indexes can
     //    never back an FK either.
+    //
+    //    EVIDENCE-OF R-00376-39212: the UNIQUE index must use the collation
+    //    sequences specified in the CREATE TABLE statement for the parent
+    //    table — an index column with an *explicit* `COLLATE` clause that
+    //    differs from the underlying column's own declared collation (its
+    //    `CREATE TABLE`-time collation, defaulting to BINARY) cannot back an
+    //    FK (e_fkey-18.5).
     for index in db.catalog.get_table_indexes(&parent.name) {
         if !index.is_unique || index.has_expression_columns() || index.is_partial() {
             continue;
         }
         let mut index_col_indices: Vec<usize> = Vec::with_capacity(index.columns.len());
         let mut all_resolved = true;
+        let mut collation_mismatch = false;
         for col in &index.columns {
             match col.column_name().and_then(|n| parent.get_column_index(n)) {
-                Some(idx) => index_col_indices.push(idx),
+                Some(idx) => {
+                    if let Some(explicit) = col.explicit_collation() {
+                        let declared = parent
+                            .columns
+                            .get(idx)
+                            .and_then(|c| c.collation.as_deref())
+                            .unwrap_or("BINARY");
+                        if !explicit.eq_ignore_ascii_case(declared) {
+                            collation_mismatch = true;
+                            break;
+                        }
+                    }
+                    index_col_indices.push(idx)
+                }
                 None => {
                     all_resolved = false;
                     break;
                 }
             }
         }
-        if !all_resolved {
+        if !all_resolved || collation_mismatch {
             continue;
         }
         if column_set_eq(&index_col_indices, parent_indices) {
@@ -135,6 +156,54 @@ fn parent_has_matching_key(db: &Database, parent: &TableSchema, parent_indices: 
     // 4. Fallback: a single-column FK against a column that is itself
     //    declared with column-level UNIQUE is represented in
     //    `unique_constraints`, so the match succeeds at step 2 above.
+    false
+}
+
+/// True when `changed_columns` overlaps any column that could plausibly back
+/// an FK parent key on `table_name`: the PRIMARY KEY, any UNIQUE constraint,
+/// or any non-partial, non-expression UNIQUE INDEX.
+///
+/// Used to decide whether an UPDATE needs to run the (relatively expensive)
+/// child-reference scan ([`crate::update::foreign_keys::ForeignKeyValidator::check_no_child_references`]).
+/// Historically that scan only fired when the update touched the table's
+/// PRIMARY KEY, silently skipping cascade/RESTRICT/NO ACTION enforcement for
+/// any FK whose parent key is a UNIQUE constraint/index instead (e_fkey-18.*,
+/// fkey2-genfkey.2/3 — `t3` references `t1(b, c)` where `t1`'s actual PK is
+/// `a`). This helper is intentionally permissive (any candidate key, not
+/// "the exact key some FK targets") — the per-FK old/new-value comparison
+/// inside `check_no_child_references` does the precise work; this is only a
+/// cheap up-front filter to avoid scanning every UPDATE unconditionally.
+pub fn changed_columns_touch_any_key(
+    db: &Database,
+    table: &TableSchema,
+    changed_columns: &[usize],
+) -> bool {
+    if changed_columns.is_empty() {
+        return false;
+    }
+    if let Some(pk_indices) = table.get_primary_key_indices() {
+        if pk_indices.iter().any(|i| changed_columns.contains(i)) {
+            return true;
+        }
+    }
+    for unique_idx_set in table.get_unique_constraint_indices() {
+        if unique_idx_set.iter().any(|i| changed_columns.contains(i)) {
+            return true;
+        }
+    }
+    for index in db.catalog.get_table_indexes(&table.name) {
+        if !index.is_unique || index.has_expression_columns() {
+            continue;
+        }
+        let touches = index.columns.iter().any(|col| {
+            col.column_name()
+                .and_then(|n| table.get_column_index(n))
+                .is_some_and(|idx| changed_columns.contains(&idx))
+        });
+        if touches {
+            return true;
+        }
+    }
     false
 }
 

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -946,13 +946,30 @@ pub(super) fn execute_internal(
         database.queue_deferred_fk_violation(v);
     }
 
-    // Step 7: Handle CASCADE updates for primary key changes (before triggers)
-    // This must happen after validation but before applying parent updates
-    for u in &updates {
-        if u.updates_pk {
-            ForeignKeyValidator::check_no_child_references(
-                database, table_name, &u.old_row, &u.new_row,
-            )?;
+    // Step 7: Handle CASCADE updates for parent-key changes (before triggers).
+    // This must happen after validation but before applying parent updates.
+    //
+    // Not just `u.updates_pk`: a child table's FK can target a UNIQUE
+    // constraint/index on this table instead of its PRIMARY KEY (e_fkey-18.*,
+    // fkey2-genfkey.2/3). Gating solely on the PK silently skipped every
+    // cascade/RESTRICT/NO ACTION check for such FKs whenever the UPDATE left
+    // the PK untouched. `changed_columns_touch_any_key` is a cheap superset
+    // filter (any candidate key, not "the exact key some FK targets"); the
+    // precise per-FK old/new comparison happens inside
+    // `check_no_child_references` itself.
+    if !updates.is_empty() {
+        for u in &updates {
+            let touches_key = u.updates_pk
+                || crate::foreign_key_check::changed_columns_touch_any_key(
+                    database,
+                    schema,
+                    &u.changed_columns.iter().copied().collect::<Vec<_>>(),
+                );
+            if touches_key {
+                ForeignKeyValidator::check_no_child_references(
+                    database, table_name, &u.old_row, &u.new_row,
+                )?;
+            }
         }
     }
 
@@ -2379,9 +2396,18 @@ fn execute_update_from(
         validate_unique_relocation(&updates, schema, table_for_check, database, table_name)?;
     }
 
-    // Handle CASCADE updates for primary key changes
+    // Handle CASCADE updates for parent-key changes. Not just `u.updates_pk`
+    // — see the rationale at the equivalent gate in `execute_internal`
+    // (Step 7): a child FK can target a UNIQUE constraint/index on this
+    // table rather than its PRIMARY KEY.
     for u in &updates {
-        if u.updates_pk {
+        let touches_key = u.updates_pk
+            || crate::foreign_key_check::changed_columns_touch_any_key(
+                database,
+                schema,
+                &u.changed_columns.iter().copied().collect::<Vec<_>>(),
+            );
+        if touches_key {
             ForeignKeyValidator::check_no_child_references(
                 database, table_name, &u.old_row, &u.new_row,
             )?;

--- a/crates/vibesql-executor/src/update/fast_path.rs
+++ b/crates/vibesql-executor/src/update/fast_path.rs
@@ -343,6 +343,22 @@ fn try_super_fast_path(
             return Ok(None); // Unique constraint needs validation
         }
 
+        // Check column is not a FOREIGN KEY child-side column. This in-place
+        // path writes the new value directly without running
+        // `ForeignKeyValidator::collect_constraints_with_old`, so an FK
+        // column update landing here silently skipped referential-integrity
+        // enforcement whenever the column was not *also* independently
+        // indexed/unique/PK (fkey3-3.6.5: `UPDATE t SET parent_id=1000
+        // WHERE id=2` on a self-referential composite-key FK reached this
+        // path — `parent_id` alone carries no index — and wrote the
+        // dangling value with zero FK validation). Any assignment touching
+        // an FK column must fall back to the row-materializing path where
+        // the check actually runs.
+        let is_fk_col = schema.foreign_keys.iter().any(|fk| fk.column_indices.contains(&col_index));
+        if is_fk_col {
+            return Ok(None); // FK column update needs full validation
+        }
+
         // Apply type affinity coercion (SQLite compatibility)
         let column = &schema.columns[col_index];
         let coerced_value = coerce_value(new_value, &column.data_type)?;

--- a/crates/vibesql-executor/src/update/foreign_keys.rs
+++ b/crates/vibesql-executor/src/update/foreign_keys.rs
@@ -205,39 +205,24 @@ impl ForeignKeyValidator {
             return Ok(());
         }
 
-        let parent_schema = db
+        let _parent_schema = db
             .catalog
             .get_table(parent_table_name)
             .ok_or_else(|| ExecutorError::TableNotFound(parent_table_name.to_string()))?;
 
-        // This check is only meaningful if the parent table has a primary key.
-        let pk_indices = match parent_schema.get_primary_key_indices() {
-            Some(indices) => indices,
-            None => return Ok(()),
-        };
-
-        let old_parent_key_values: Vec<vibesql_types::SqlValue> =
-            pk_indices.iter().map(|&idx| parent_row.values[idx].clone()).collect();
-
-        let new_parent_key_values: Vec<vibesql_types::SqlValue> =
-            pk_indices.iter().map(|&idx| new_parent_row.values[idx].clone()).collect();
-
-        // SQLite fires no referential action and raises no violation when an
-        // UPDATE does not actually change the parent key. Re-assigning a
-        // parent-key column to the value it already holds (e.g.
-        // `UPDATE t1 SET a = 1` when `a` is already 1, or `UPDATE t1 SET a = a`)
-        // leaves every existing child reference valid, so there is nothing to
-        // cascade, set-null/default, or restrict. Without this early-out the
-        // NO ACTION / RESTRICT paths below see child rows still matching the
-        // (unchanged) old key and raise a spurious "cannot update a parent
-        // row" violation (fkey2-1.*.13: `UPDATE t1 SET a = 1` /
-        // `UPDATE t7 SET b = 1` expect success). Plain equality is a
-        // conservative test: when the stored representations differ (e.g.
-        // 1 vs 1.0) we fall through to the full affinity-aware check below,
-        // preserving prior behaviour.
-        if old_parent_key_values == new_parent_key_values {
-            return Ok(());
-        }
+        // NOTE: the parent-key values that matter here are *per-FK*, not a
+        // single table-wide value. A parent table can be referenced by one
+        // FK on its PRIMARY KEY and another FK on a completely different
+        // UNIQUE constraint/index (e_fkey-18.1..18.9, fkey2-genfkey.2/3 —
+        // `t3` references `t1(b, c)` where `t1`'s actual PK is `a`). Hard-
+        // coding the table's PRIMARY KEY here (as earlier code did) computed
+        // the wrong "did the key change?" answer for any FK targeting a
+        // non-PK key: an UPDATE that changed only `b`/`c` left the PK-based
+        // old/new values equal, so the whole function early-out'ed and
+        // silently skipped every cascade/RESTRICT/NO ACTION check for that
+        // FK. Each FK's parent-side old/new values are now computed inside
+        // the loop below via `resolved_parent_indices_for_fk`, mirroring the
+        // resolution INSERT/DELETE already use (`foreign_key_check.rs`).
 
         // Optimization: Check if any table in the database has foreign keys at all
         // If not, skip the expensive scan of all tables
@@ -293,6 +278,43 @@ impl ForeignKeyValidator {
             for (fk_idx, fk) in child_schema.foreign_keys.iter().enumerate() {
                 // Use case-insensitive comparison for SQL identifier matching
                 if !fk.parent_table.eq_ignore_ascii_case(parent_table_name) {
+                    continue;
+                }
+
+                // Resolve THIS FK's own parent-side column indices — not the
+                // parent table's PRIMARY KEY, which may be a different
+                // column set entirely when the FK targets a UNIQUE
+                // constraint/index instead (e_fkey-18.*, fkey2-genfkey.2/3).
+                let fk_parent_indices =
+                    crate::foreign_key_check::resolved_parent_indices_for_fk(db, fk);
+                let old_parent_key_values: Vec<vibesql_types::SqlValue> =
+                    fk_parent_indices.iter().map(|&idx| parent_row.values[idx].clone()).collect();
+                let new_parent_key_values: Vec<vibesql_types::SqlValue> = fk_parent_indices
+                    .iter()
+                    .map(|&idx| new_parent_row.values[idx].clone())
+                    .collect();
+
+                // SQLite fires no referential action and raises no violation
+                // when an UPDATE does not actually change the parent key
+                // that THIS FK targets. Re-assigning a parent-key column to
+                // the value it already holds (e.g. `UPDATE t1 SET a = 1`
+                // when `a` is already 1, or `UPDATE t1 SET a = a`) leaves
+                // this FK's existing child references valid, so there is
+                // nothing to cascade, set-null/default, or restrict for it.
+                // Without this early-out the NO ACTION / RESTRICT paths
+                // below would see child rows still matching the (unchanged)
+                // old key and raise a spurious "cannot update a parent row"
+                // violation (fkey2-1.*.13: `UPDATE t1 SET a = 1` /
+                // `UPDATE t7 SET b = 1` expect success). Plain equality is a
+                // conservative test: when the stored representations differ
+                // (e.g. 1 vs 1.0) we fall through to the full affinity-aware
+                // check below, preserving prior behaviour. This check must
+                // be per-FK (not per-table) so an UPDATE that changes column
+                // `x` (part of one FK's parent key) but not column `y` (part
+                // of a different FK's parent key on the same table) still
+                // fires the `x`-keyed FK's action while correctly skipping
+                // the `y`-keyed FK's.
+                if old_parent_key_values == new_parent_key_values {
                     continue;
                 }
 

--- a/crates/vibesql-executor/tests/foreign_key_fast_path_and_unique_parent_tests.rs
+++ b/crates/vibesql-executor/tests/foreign_key_fast_path_and_unique_parent_tests.rs
@@ -1,0 +1,165 @@
+//! Regression tests for two silent "wrong answer" FK-enforcement bugs fixed
+//! under issue #6170. Both are the kind of correctness regression that is easy
+//! to reintroduce via an unrelated refactor, so they are pinned here in the
+//! path that gates every PR (`cargo test -p vibesql-executor`), independent of
+//! the (dispatch-only) TCL conformance job.
+//!
+//! Bug #1 — single-row UPDATE super-fast path bypassed FK validation.
+//!   `try_super_fast_path` (in-place column writes, no row cloning) checked
+//!   that an assigned column was not the PK / not UNIQUE / not independently
+//!   indexed, but never checked whether it was a FOREIGN KEY *child-side*
+//!   column. `UPDATE child SET fk_col=<literal> WHERE pk=<literal>` therefore
+//!   silently skipped referential-integrity enforcement whenever `fk_col`
+//!   carried no index of its own — a dangling reference was written and the
+//!   UPDATE returned success. These tests deliberately shape the UPDATE to hit
+//!   that path (`WHERE <ipk> = <literal>` → single row, `fk_col` unindexed).
+//!
+//! Bug #2 — UPDATE-triggered cascade checked the wrong parent key.
+//!   `ForeignKeyValidator::check_no_child_references` hardcoded the parent
+//!   table's PRIMARY KEY as "the key that changed". An FK whose parent key is a
+//!   UNIQUE constraint/index rather than the PK was silently skipped by every
+//!   CASCADE/SET NULL/SET DEFAULT/RESTRICT/NO ACTION check whenever the PK was
+//!   left untouched. These tests change only the UNIQUE parent key and assert
+//!   the configured referential action actually fires.
+
+use vibesql_ast::Statement;
+use vibesql_executor::{CreateTableExecutor, InsertExecutor, UpdateExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn run(db: &mut Database, sql: &str) -> Result<String, String> {
+    let stmt = Parser::parse_sql(sql).map_err(|e| format!("parse error: {:?}", e))?;
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).map(|_| String::new()).map_err(|e| e.to_string())
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).map(|_| String::new()).map_err(|e| e.to_string())
+        }
+        Statement::Update(s) => {
+            UpdateExecutor::execute(&s, db).map(|_| String::new()).map_err(|e| e.to_string())
+        }
+        other => Err(format!("unsupported statement type in test helper: {:?}", other)),
+    }
+}
+
+/// All rows of a table as raw value vectors, in physical scan order.
+fn rows(db: &Database, table: &str) -> Vec<Vec<SqlValue>> {
+    let t = db.get_table(table).expect("table not found");
+    t.scan().iter().map(|r| r.values.to_vec()).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Bug #1: single-row super-fast-path FK bypass.
+// ---------------------------------------------------------------------------
+
+/// `UPDATE child SET fk_col=<literal> WHERE id=<literal>` where `fk_col` has no
+/// index of its own and points at a non-existent parent row must be rejected —
+/// not silently applied by the in-place fast path.
+#[test]
+fn fast_path_update_of_fk_column_to_missing_parent_is_rejected() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    // `id INTEGER PRIMARY KEY` gives a rowid so `WHERE id = 1` resolves a single
+    // row (the trigger for the super-fast path). `fk_col` is a plain FK column
+    // with no UNIQUE/PK/index of its own — exactly the shape that used to slip
+    // past FK validation on the in-place path.
+    run(&mut db, "CREATE TABLE parent(a INTEGER PRIMARY KEY, b)").unwrap();
+    run(&mut db, "CREATE TABLE child(id INTEGER PRIMARY KEY, fk_col REFERENCES parent(a), payload)")
+        .unwrap();
+    run(&mut db, "INSERT INTO parent VALUES(1, 10)").unwrap();
+    run(&mut db, "INSERT INTO child VALUES(1, 1, 100)").unwrap();
+
+    // 999 has no matching parent row: this must raise an FK violation.
+    let res = run(&mut db, "UPDATE child SET fk_col = 999 WHERE id = 1");
+    assert!(
+        res.is_err(),
+        "single-row fast-path UPDATE of an FK column to a missing parent must be rejected, got {res:?}"
+    );
+
+    // And it must not have been silently applied: the row still references 1.
+    let child = rows(&db, "child");
+    assert_eq!(child.len(), 1, "child row count changed unexpectedly");
+    assert_eq!(
+        child[0][1],
+        SqlValue::Integer(1),
+        "FK column was silently mutated to a dangling value despite the violation: {child:?}"
+    );
+}
+
+/// Companion guard: the same fast-path UPDATE to a *valid* parent key must
+/// still succeed (the fix must not over-reject legitimate FK-column updates).
+#[test]
+fn fast_path_update_of_fk_column_to_existing_parent_succeeds() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    run(&mut db, "CREATE TABLE parent(a INTEGER PRIMARY KEY, b)").unwrap();
+    run(&mut db, "CREATE TABLE child(id INTEGER PRIMARY KEY, fk_col REFERENCES parent(a), payload)")
+        .unwrap();
+    run(&mut db, "INSERT INTO parent VALUES(1, 10)").unwrap();
+    run(&mut db, "INSERT INTO parent VALUES(2, 20)").unwrap();
+    run(&mut db, "INSERT INTO child VALUES(1, 1, 100)").unwrap();
+
+    run(&mut db, "UPDATE child SET fk_col = 2 WHERE id = 1")
+        .unwrap_or_else(|e| panic!("valid FK-column update via fast path must succeed: {e}"));
+
+    let child = rows(&db, "child");
+    assert_eq!(child[0][1], SqlValue::Integer(2), "valid FK update did not apply: {child:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Bug #2: UPDATE-triggered cascade against a UNIQUE (non-PK) parent key.
+// ---------------------------------------------------------------------------
+
+/// Child FK references a UNIQUE column (not the PK) with ON UPDATE CASCADE.
+/// Changing only that UNIQUE parent key must cascade into the child — before
+/// the fix, the parent check keyed off the (untouched) PRIMARY KEY and silently
+/// skipped the cascade, leaving the child pointing at the old value.
+#[test]
+fn update_of_unique_parent_key_cascades_to_child() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    run(&mut db, "CREATE TABLE parent(id INTEGER PRIMARY KEY, u UNIQUE)").unwrap();
+    run(&mut db, "CREATE TABLE child(x REFERENCES parent(u) ON UPDATE CASCADE, y)").unwrap();
+    run(&mut db, "INSERT INTO parent VALUES(1, 100)").unwrap();
+    run(&mut db, "INSERT INTO child VALUES(100, 5)").unwrap();
+
+    // Change only the UNIQUE parent key; the PK (id) is untouched.
+    run(&mut db, "UPDATE parent SET u = 200 WHERE id = 1")
+        .unwrap_or_else(|e| panic!("cascading UNIQUE-parent-key update must succeed: {e}"));
+
+    let child = rows(&db, "child");
+    assert_eq!(
+        child[0][0],
+        SqlValue::Integer(200),
+        "ON UPDATE CASCADE against a UNIQUE parent key did not fire — child left dangling: {child:?}"
+    );
+}
+
+/// Same schema shape but with the default RESTRICT action: changing the UNIQUE
+/// parent key while a child still references the old value must be rejected —
+/// before the fix this referential check was silently skipped and the update
+/// wrongly succeeded, orphaning the child.
+#[test]
+fn update_of_unique_parent_key_with_referencing_child_is_restricted() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    run(&mut db, "CREATE TABLE parent(id INTEGER PRIMARY KEY, u UNIQUE)").unwrap();
+    // No ON UPDATE action → NO ACTION / RESTRICT-style enforcement.
+    run(&mut db, "CREATE TABLE child(x REFERENCES parent(u), y)").unwrap();
+    run(&mut db, "INSERT INTO parent VALUES(1, 100)").unwrap();
+    run(&mut db, "INSERT INTO child VALUES(100, 5)").unwrap();
+
+    let res = run(&mut db, "UPDATE parent SET u = 200 WHERE id = 1");
+    assert!(
+        res.is_err(),
+        "changing a UNIQUE parent key still referenced by a child must raise an FK violation, got {res:?}"
+    );
+
+    // The child must remain untouched and still reference the (unchanged) key.
+    let parent = rows(&db, "parent");
+    assert_eq!(parent[0][1], SqlValue::Integer(100), "parent key changed despite restriction: {parent:?}");
+    let child = rows(&db, "child");
+    assert_eq!(child[0][0], SqlValue::Integer(100), "child reference changed unexpectedly: {child:?}");
+}


### PR DESCRIPTION
## Summary

Continues the FK-enforcement family (#6170, Part of epic #5779). Found and fixed three real correctness bugs by triaging the certified fkey2/e_fkey failures against SQLite's evidence-based test suite:

1. **UPDATE-triggered cascade/RESTRICT/NO ACTION checked the wrong key.** `ForeignKeyValidator::check_no_child_references` (the UPDATE-side parent check) hardcoded the parent table's PRIMARY KEY as "the key that changed" — both for the old/new-value comparison that decides whether *anything* needs checking, and for extracting per-FK key values. Any FK whose parent key is a UNIQUE constraint/index instead of the PK (a valid, common schema — e_fkey-18.1..18.9, fkey2-genfkey.2/3) was silently skipped by every cascade/SET NULL/SET DEFAULT/RESTRICT/NO ACTION check whenever the UPDATE left the PK untouched. Fixed by resolving each FK's own parent-side columns (mirroring the resolution INSERT/DELETE already use) *inside* the per-FK loop instead of once via the table's PK.

2. **The single-row UPDATE "super-fast path" silently bypassed FK validation for non-indexed FK columns.** `try_super_fast_path` (in-place column writes, no row cloning) checked that an assigned column was not the PK, not a declared UNIQUE constraint, and not independently indexed — but never checked whether the column was a FOREIGN KEY *child-side* column. `UPDATE t SET fk_col = <literal> WHERE pk = <literal>` silently skipped FK validation entirely whenever `fk_col` carried no index of its own. Reproduced with fkey3-3.6.5's self-referential composite-key FK, but this is general — a minimal non-self-referential single-column-FK repro shows the same bypass. Fixed by routing any assignment to an FK column to the row-materializing path where `ForeignKeyValidator::collect_constraints_with_old` actually runs.

3. **`PRAGMA foreign_keys = ON/OFF` ignored autocommit state.** SQLite silently no-ops this PRAGMA mid-transaction (EVIDENCE-OF R-46649-58537, e_fkey-6.1..6.3); fixed by gating the write on `!db.in_transaction()`.

4. **`detect_fk_mismatch`'s UNIQUE-INDEX candidate check ignored collation.** EVIDENCE-OF R-00376-39212: a UNIQUE index backing an FK's parent key must use the *same* collation as the column's own `CREATE TABLE`-time declaration — an index with an explicit, disagreeing `COLLATE` clause (e_fkey-18.5) doesn't qualify as a valid parent key. Fixed by comparing the index column's explicit collation (when present) against the column's declared collation.

## Verified failure counts

Native-TCL harness, this machine (not the certified AWS baseline — see #6154/#6175 for why absolute numbers differ across machines; only deltas are meaningful here):

| File | Session-start | After this PR | Certified baseline (#6170) |
|---|---:|---:|---:|
| fkey2.test | 110 | **104** | 179 |
| e_fkey.test | 134 | **124** | 148 |
| fkey3.test | 1 | **0** (clean) | 5 |
| fkey1.test | 4 | **2** | 4 |
| fkey4.test | 2 | 2 (unchanged) | 2 |
| fkey7.test | 7 | 7 (unchanged) | 7 |
| **Total** | 262 | **239** | 345 |

All prior FK unit/integration tests pass (`cargo test --release -p vibesql-executor` — full suite, 3647 lib tests + all `foreign_key_*`/`alter_rename_fk_rebind_tests` integration tests, 0 failures). `cargo clippy` shows no new warnings on the touched files.

## Remaining gaps (not silently reclassified — documented here)

- **fkey2-1.4.\* (dense block, ~17 tests):** `PRAGMA count_changes` inside an explicit `BEGIN...COMMIT` that spans multiple TCL `execsql` calls. The TCL shim batches statements between a cross-process BEGIN and COMMIT and replays them at flush time, discarding the per-statement `changes()` count for statements *inside* the transaction. Verified via direct CLI that the engine itself reports the correct `changes()` value — this is a shim/harness limitation, not a wrong SQL answer. Would need a shim-side fix to `trial_check_in_transaction`/`flush_batch` in `scripts/tester_vibesql.tcl`; left open given the complexity/risk of touching that load-bearing harness code this late in a long session.
- **e_fkey-20.2/4/5/6 (32 tests) and similar "foreign key mismatch" tests:** SQLite raises `foreign key mismatch` at *statement-prepare* time, independent of whether any row is actually affected. VibeSQL's FK validation is row-driven (only runs when the per-row update/delete loop executes), so a 0-row UPDATE/DELETE against a schema with a broken FK definition currently returns success instead of erroring. This is a real, structural gap (statement-level vs. row-level validation) requiring its own design — not attempted here.
- **fkey4/fkey7's remaining failures are C-API-only** (`db trace`, `db auth` authorizer callback, `sqlite3_prepare_v2`/`sqlite3_bind_zeroblob`, `incrblob`/`stat4` capability gates) — unreachable from the SQL CLI harness. Bucket-A candidates per #6154; not reclassified in this PR, just noted.
- **fkey1's 1 remaining non-C-API failure** (`CREATE TABLE sqlite_stat1 ... WITHOUT ROWID` under `PRAGMA writable_schema=ON`) is a niche SQLite-internals corruption-testing regression case; low value, left open.

`without_rowid3.test` (tracked under the WITHOUT ROWID family issue) shares fkey2's test body verbatim per #6170's own note. Not re-verified in this increment due to shared-machine time constraints during this session, but the parent-key/super-fast-path fixes here should reduce its failure count too — flagged for cross-check by that family's next increment.

## Test plan

- [x] `cargo build --release` — clean build
- [x] `cargo test --release -p vibesql-executor` — full suite, 0 failures (3647 lib tests + all FK-specific integration test files)
- [x] `cargo clippy --release -p vibesql-executor -p vibesql-cli --no-deps` — no new warnings on touched files
- [x] `make test-tcl-file FILE=fkey2.test` / `FILE=e_fkey.test` / `FILE=fkey1.test` / `FILE=fkey3.test` / `FILE=fkey4.test` / `FILE=fkey7.test` — measured before/after via a private scratch results DB (shared machine, concurrent builders — used an isolated `--results-db` to avoid lock contention with parallel TCL runs)
- [x] Manual CLI repros for each of the 4 bugs, confirmed fixed post-build

Part of epic #5779. Uses **"Part of #6170"** (not "Closes") — this is a genuine partial increment: fkey3.test is now clean, but fkey2/e_fkey/fkey1/fkey4/fkey7 still have real remaining failures (harness limitations + one structural gap + C-API-only tests), so the family issue stays open per this repo's partial-increment PR convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)