### PR TITLE
conformance(tcl): SQLite error wording for RENAME COLUMN on view / missing column (Part of #6174)

### DIFF
--- a/crates/vibesql-executor/src/alter/columns.rs
+++ b/crates/vibesql-executor/src/alter/columns.rs
@@ -548,6 +548,17 @@ pub(super) fn execute_rename_column(
     stmt: &RenameColumnStmt,
     database: &mut Database,
 ) -> Result<String, ExecutorError> {
+    // Renaming a column of a VIEW is rejected with a dedicated message
+    // (`cannot rename columns of view "<name>"`), matching SQLite. Checked
+    // before the table lookup so a view does not fall through to the generic
+    // `no such table` path (altercol-12.2.2/12.2.3).
+    if let Some(view) = database.catalog.get_view(&stmt.table_name) {
+        return Err(ExecutorError::Other(format!(
+            "cannot rename columns of view \"{}\"",
+            view.name
+        )));
+    }
+
     // Resolve the table + column and check for a name conflict with an
     // immutable borrow so the whole-schema precheck below can also borrow the
     // database immutably. The mutable borrow for the actual rename is taken
@@ -557,14 +568,11 @@ pub(super) fn execute_rename_column(
             .get_table(&stmt.table_name)
             .ok_or_else(|| ExecutorError::TableNotFound(stmt.table_name.clone()))?;
 
-        // The old column must exist.
+        // The old column must exist. SQLite reports the SQL-standard
+        // `no such column: "<col>"` here (altercol-12.4.2), the same wording
+        // the DROP COLUMN path uses.
         let col_index = table.schema.get_column_index(&stmt.old_column_name).ok_or_else(|| {
-            ExecutorError::ColumnNotFound {
-                column_name: stmt.old_column_name.clone(),
-                table_name: stmt.table_name.clone(),
-                searched_tables: vec![stmt.table_name.clone()],
-                available_columns: table.schema.columns.iter().map(|c| c.name.clone()).collect(),
-            }
+            ExecutorError::Other(format!("no such column: \"{}\"", stmt.old_column_name))
         })?;
 
         // Renaming to an existing (different) column name is a conflict. Allow a

--- a/crates/vibesql-executor/src/tests/alter_rename_column_triggers.rs
+++ b/crates/vibesql-executor/src/tests/alter_rename_column_triggers.rs
@@ -155,7 +155,10 @@ fn rename_column_missing_column_errors() {
     setup(&mut db);
 
     let err = exec(&mut db, "ALTER TABLE t2 RENAME nosuch TO x").unwrap_err();
-    assert!(matches!(err, ExecutorError::ColumnNotFound { .. }), "got: {err:?}");
+    assert!(
+        matches!(&err, ExecutorError::Other(m) if m == "no such column: \"nosuch\""),
+        "got: {err:?}"
+    );
 }
 
 #[test]

--- a/crates/vibesql-executor/tests/alter_rename_column_revalidation_tests.rs
+++ b/crates/vibesql-executor/tests/alter_rename_column_revalidation_tests.rs
@@ -122,6 +122,37 @@ fn rename_succeeds_when_dependents_are_valid() {
     assert!(!db.get_table("t1").unwrap().schema.has_column("c"));
 }
 
+/// altercol.test 12.2.2 / 12.2.3: renaming a column of a VIEW is rejected with
+/// SQLite's dedicated `cannot rename columns of view "<name>"` message rather
+/// than falling through to the generic `no such table` path.
+#[test]
+fn rename_column_of_view_is_rejected() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t1(a, b)");
+    create_view(&mut db, "CREATE VIEW v1 AS SELECT * FROM t1");
+    assert_eq!(
+        rename_column_err(&mut db, "ALTER TABLE v1 RENAME a TO z"),
+        "cannot rename columns of view \"v1\""
+    );
+    // The base table is untouched.
+    assert!(db.get_table("t1").unwrap().schema.has_column("a"));
+}
+
+/// altercol.test 12.4.2: renaming a column that does not exist reports SQLite's
+/// `no such column: "<col>"` (quoted), matching the DROP COLUMN wording.
+#[test]
+fn rename_missing_column_reports_no_such_column() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t2(x, y, z)");
+    assert_eq!(
+        rename_column_err(&mut db, "ALTER TABLE t2 RENAME COLUMN a TO b"),
+        "no such column: \"a\""
+    );
+    // The table's columns are unchanged.
+    assert!(db.get_table("t2").unwrap().schema.has_column("x"));
+    assert!(!db.get_table("t2").unwrap().schema.has_column("b"));
+}
+
 /// A CTE name referenced in a trigger body is not a base table and must not be
 /// mistaken for a missing table: the rename still succeeds.
 #[test]


### PR DESCRIPTION
## Summary

Partial increment of the ALTER TABLE conformance issue. Fixes two RENAME COLUMN error-message gaps where VibeSQL emitted its own wording instead of SQLite's, causing `do_catchsql_test` mismatches in `altercol.test`.

- **Renaming a column of a VIEW** now fails up front with `cannot rename columns of view "<name>"`. Previously the view name was not found in the table catalog, so it fell through to a generic `no such table` message (altercol-12.2.2, 12.2.3).
- **Renaming a column that does not exist** now reports the SQL-standard `no such column: "<col>"` (quoted) — the same wording the DROP COLUMN path already uses — instead of VibeSQL's verbose `Column 'a' not found (searched tables: ...)` form (altercol-12.4.2).

Both checks run before any schema mutation, so a failed RENAME COLUMN remains atomic.

## Changes

- `crates/vibesql-executor/src/alter/columns.rs`: in `execute_rename_column`, reject a view target early with the dedicated message, and emit `no such column: "<col>"` when the old column is absent.
- `crates/vibesql-executor/tests/alter_rename_column_revalidation_tests.rs`: two new unit tests (`rename_column_of_view_is_rejected`, `rename_missing_column_reports_no_such_column`) asserting the exact SQLite wording and schema-untouched atomicity.

## Acceptance Criteria Verification

- `altercol.test`: **36 failed -> 33 failed** (182 -> 185 passed). The three newly-passing tests are 12.2.2, 12.2.3, 12.4.2.
- No regressions in adjacent files: `alter.test` unchanged (43 passed / 46 failed); `alter3.test`/`alter2.test` are ADD-COLUMN file-format tests that do not use RENAME COLUMN (grep confirmed) and are unaffected by this change.
- `no such table` path for a genuinely missing table is preserved (checked view first, then table).

## Test Plan

- `cargo test -p vibesql-executor --test alter_rename_column_revalidation_tests` — 7 passed.
- `make test-tcl-file FILE=altercol.test` — before/after counts above.
- `cargo build --release` green.

## What's left for the next pass (still open under #6174)

- `altercol.test` remaining ~33: multi-connection (`-db db2`) persistence, ANALYZE/`sqlite_stat1` alterability (6.1/12.1.x), deep trigger-body plain-column resolution during RENAME COLUMN revalidation (13.2.x — risky static resolver, deferred), `writable_schema` manipulation (13.1.x/23.x), ambiguous-column-in-view after rename (16.1.1), and exotic identifier quoting (22.x/23.0).
- `alter.test` ~46: mostly `trigfunc` TCL-callback (shim) limitations, reserved-keyword-as-identifier parsing (3.2.x, e.g. `CREATE TABLE t(a, ON, c)` should be a syntax error), and multi-connection tests.
- `alter2.test`/`alter3.test`: ADD COLUMN on-disk file-format tests using `hexio_write`/`writable_schema` — largely a separate format concern.

Part of #6174