### PR TITLE
fix(executor): allocate auto rowid after BEFORE INSERT trigger (Part of #6173)

### DIFF
--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -1289,7 +1289,7 @@ fn execute_insert_internal(
         }
     } else {
         // Slow path: Insert rows one by one (needed for triggers, special clauses)
-        for (mut full_row_values, mut explicit_rowid, rowid_auto_assigned, candidate_last_id) in
+        for (mut full_row_values, mut explicit_rowid, rowid_auto_assigned, mut candidate_last_id) in
             validated_rows
         {
             // Set when a REPLACE conflict resolution fixes this row's rowid
@@ -1439,6 +1439,45 @@ fn execute_insert_internal(
                 )? == crate::trigger_execution::TriggerOutcome::SkipRow
                 {
                     continue;
+                }
+            }
+
+            // SQLite allocates the real rowid for an auto-assigned INTEGER
+            // PRIMARY KEY (or `rowid` pseudo-column) only AFTER the BEFORE
+            // INSERT trigger has run. A BEFORE INSERT trigger body may itself
+            // insert rows into this same table — directly, or via recursive
+            // triggers — advancing the table's max rowid and, for AUTOINCREMENT,
+            // the `sqlite_sequence` high-water mark. The pre-trigger value fixed
+            // in the validation loop above would then collide with a rowid the
+            // trigger just consumed, producing duplicate rowids (autoinc-3928,
+            // recursive trigger inserts into an AUTOINCREMENT table). Recompute
+            // the auto-assigned rowid here against the now-current table state.
+            if has_insert_triggers && rowid_auto_assigned && !replace_fixed_rowid {
+                let recomputed = if schema.is_autoincrement {
+                    crate::autoincrement::compute_next_autoincrement_rowid(
+                        db,
+                        &storage_table_name,
+                        &schema.name,
+                    )?
+                } else {
+                    db.get_table(&storage_table_name)
+                        .map(|t| t.allocate_rowid())
+                        .unwrap_or(Ok(1))
+                        .map_err(|e| ExecutorError::StorageError(e.to_string()))?
+                };
+                if let Some(idx) = ipk_col_idx {
+                    full_row_values[idx] = vibesql_types::SqlValue::Integer(recomputed);
+                    // last_insert_rowid() and the end-of-statement sequence bump
+                    // must both observe the recomputed (post-trigger) rowid, not
+                    // the stale value assigned before the trigger ran.
+                    candidate_last_id = Some(recomputed);
+                    batch_max_ipk =
+                        Some(batch_max_ipk.map_or(recomputed, |m| m.max(recomputed)));
+                } else {
+                    // `rowid` pseudo-column table (no INTEGER PRIMARY KEY): the
+                    // auto rowid is carried in `explicit_rowid`, which flows into
+                    // the stored row and last_insert_rowid() below.
+                    explicit_rowid = Some(recomputed as u64);
                 }
             }
 

--- a/crates/vibesql-executor/tests/autoincrement_trigger_rowid_tests.rs
+++ b/crates/vibesql-executor/tests/autoincrement_trigger_rowid_tests.rs
@@ -1,0 +1,141 @@
+//! Regression tests: an auto-assigned INTEGER PRIMARY KEY must be allocated
+//! AFTER any BEFORE INSERT trigger has run (issue #6173, autoinc-3928).
+//!
+//! SQLite does not allocate the real rowid for a NULL/omitted INTEGER PRIMARY
+//! KEY until the row is physically written — which happens *after* the BEFORE
+//! INSERT trigger fires. A BEFORE INSERT trigger body may itself insert rows
+//! into the same table (directly, or via recursive triggers), advancing the
+//! table's max rowid and, for AUTOINCREMENT, the `sqlite_sequence` high-water
+//! mark. If the outer row's rowid were fixed *before* the trigger ran it would
+//! collide with a rowid the trigger just consumed, producing duplicate rowids.
+//!
+//! Every expectation below was verified against sqlite3 3.51.0 (autoinc.test
+//! section 3928, run under the default `recursive_triggers = off`, which bounds
+//! the mutually-recursive BEFORE/AFTER cascade to 13 rows).
+
+use vibesql_executor::{CreateTableExecutor, InsertExecutor, SelectExecutor, TriggerExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn exec(db: &mut Database, sql: &str) {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e:?}"));
+    match stmt {
+        Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE failed");
+        }
+        Statement::CreateTrigger(s) => {
+            TriggerExecutor::create_trigger_with_sql(db, &s, Some(sql))
+                .expect("CREATE TRIGGER failed");
+        }
+        Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT failed");
+        }
+        other => panic!("unsupported statement in test helper: {other:?}"),
+    }
+}
+
+fn query(db: &Database, sql: &str) -> Vec<Vec<SqlValue>> {
+    use vibesql_ast::Statement;
+    let stmt = Parser::parse_sql(sql).expect("parse failed");
+    let Statement::Select(select) = stmt else {
+        panic!("expected SELECT");
+    };
+    SelectExecutor::new(db)
+        .execute(&select)
+        .expect("SELECT failed")
+        .into_iter()
+        .map(|row| row.values.to_vec())
+        .collect()
+}
+
+fn ints(rows: &[Vec<SqlValue>], col: usize) -> Vec<i64> {
+    rows.iter()
+        .map(|r| match &r[col] {
+            SqlValue::Integer(v) => *v,
+            other => panic!("expected integer, got {other:?}"),
+        })
+        .collect()
+}
+
+/// A BEFORE INSERT trigger that inserts into the same AUTOINCREMENT table must
+/// not cause the outer row to reuse a rowid the trigger already consumed.
+/// Every rowid in the table must be distinct.
+#[test]
+fn before_insert_trigger_into_same_autoincrement_table_yields_unique_rowids() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t(a INTEGER PRIMARY KEY AUTOINCREMENT, b)");
+    // recursive_triggers defaults to off (matching sqlite3); set explicitly.
+    db.set_recursive_triggers(false);
+    exec(
+        &mut db,
+        "CREATE TRIGGER t_before BEFORE INSERT ON t BEGIN \
+         INSERT INTO t(b) VALUES('before'); END",
+    );
+
+    exec(&mut db, "INSERT INTO t(b) VALUES('outer')");
+
+    let rows = query(&db, "SELECT a, b FROM t ORDER BY a");
+    let rowids = ints(&rows, 0);
+    let mut sorted = rowids.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(
+        sorted.len(),
+        rowids.len(),
+        "AUTOINCREMENT rowids must be unique even when a BEFORE INSERT trigger \
+         inserts into the same table; got {rowids:?}"
+    );
+
+    // The sqlite_sequence high-water mark must equal the true maximum rowid the
+    // table ever held (not the stale pre-trigger value).
+    let seq = query(&db, "SELECT seq FROM sqlite_sequence WHERE name='t'");
+    let max_rowid = *rowids.iter().max().unwrap();
+    assert_eq!(
+        ints(&seq, 0),
+        vec![max_rowid],
+        "sqlite_sequence.seq must track the true max rowid"
+    );
+}
+
+/// The exact autoinc-3928.1/.2 shape: mutually-recursive BEFORE and AFTER
+/// INSERT triggers on an AUTOINCREMENT table. sqlite3 3.51.0 produces 13 rows
+/// with rowids 1..13 and `sqlite_sequence.seq = 13`.
+#[test]
+fn autoinc_3928_before_and_after_triggers_produce_contiguous_unique_rowids() {
+    let mut db = Database::new();
+    db.set_recursive_triggers(false);
+    exec(&mut db, "CREATE TABLE t3928(a INTEGER PRIMARY KEY AUTOINCREMENT, b)");
+    exec(
+        &mut db,
+        "CREATE TRIGGER t3928r1 BEFORE INSERT ON t3928 BEGIN \
+         INSERT INTO t3928(b) VALUES('before1'); \
+         INSERT INTO t3928(b) VALUES('before2'); END",
+    );
+    exec(
+        &mut db,
+        "CREATE TRIGGER t3928r2 AFTER INSERT ON t3928 BEGIN \
+         INSERT INTO t3928(b) VALUES('after1'); \
+         INSERT INTO t3928(b) VALUES('after2'); END",
+    );
+
+    exec(&mut db, "INSERT INTO t3928(b) VALUES('test')");
+
+    let rows = query(&db, "SELECT a FROM t3928 ORDER BY a");
+    let rowids = ints(&rows, 0);
+    assert_eq!(
+        rowids,
+        (1..=13).collect::<Vec<_>>(),
+        "recursive BEFORE/AFTER trigger inserts into an AUTOINCREMENT table must \
+         produce contiguous, unique rowids 1..13 (autoinc-3928.1)"
+    );
+
+    let seq = query(&db, "SELECT seq FROM sqlite_sequence WHERE name='t3928'");
+    assert_eq!(
+        ints(&seq, 0),
+        vec![13],
+        "sqlite_sequence.seq must be 13 after the recursive trigger cascade \
+         (autoinc-3928.2)"
+    );
+}


### PR DESCRIPTION
## Slice of the CREATE TABLE / schema-definition family (#6173)

This is a **partial increment** of the family issue #6173 (certified failure bucket ~292 across `e_createtable`, `autoinc`, `gencol1`, `check`, `strict1`, `table`, `tableopts`). It targets the AUTOINCREMENT / `sqlite_sequence` bookkeeping slice — specifically the `autoinc-3928` block, which exercises triggers that INSERT into an AUTOINCREMENT table.

### Root cause

SQLite does not allocate the real rowid for a NULL/omitted `INTEGER PRIMARY KEY` until the row is physically written — which happens **after** the BEFORE INSERT trigger fires. VibeSQL fixed the auto-assigned rowid in the pre-trigger validation loop. A BEFORE INSERT trigger body that inserts rows into the same table (directly, or via recursive triggers) advances the table's max rowid, so the outer row was then stored with a **stale rowid that collides with one the trigger just consumed** — a duplicate-rowid data-integrity bug on an AUTOINCREMENT table. The end-of-statement `sqlite_sequence` high-water mark was likewise too low.

Before this fix, `autoinc-3928.1` produced duplicate `a` values (`1 before1`, `1 test`, ...) and `sqlite_sequence.seq` read 10 instead of 13.

### Fix

In the row-by-row slow path (`crates/vibesql-executor/src/insert/execution.rs`), recompute the auto-assigned rowid immediately after the BEFORE INSERT trigger runs, against the now-current table state:
- AUTOINCREMENT tables fold in the `sqlite_sequence` high-water mark via `compute_next_autoincrement_rowid`.
- Plain INTEGER PRIMARY KEY / `rowid` pseudo-column tables use `Table::allocate_rowid`.
- `last_insert_rowid()` and the end-of-statement `sqlite_sequence` bump both observe the recomputed value.

The recompute is gated on `has_insert_triggers` (only a BEFORE INSERT trigger can insert rows before the outer row is written), so non-trigger insert paths are untouched. When the trigger does not touch the table, the recompute yields the same value as before (no behavior change).

### Before / after

| File | Before | After |
|------|-------:|------:|
| autoinc.test | 16 failed | 10 failed |

Fixed: `autoinc-3928.1`, `.2`, `.3`, `.4`, `.5`, `.7` (6 tests). Remaining `autoinc` failures are out-of-scope for this slice: `autoinc-4.3..4.10` (require `temp.sqlite_sequence` / TEMP-database qualified names) and `autoinc-7.1` (parser support for table-level `PRIMARY KEY(x AUTOINCREMENT)`).

### Verification

- New Rust regression tests: `crates/vibesql-executor/tests/autoincrement_trigger_rowid_tests.rs` (unique rowids + `sqlite_sequence` high-water mark under recursive BEFORE/AFTER trigger cascades).
- `vibesql-executor` insert / trigger / autoinc unit + integration tests: all pass.
- No regression vs. the base commit on Priority-1 TCL `trigger1.test` (25 failed, unchanged) and `insert.test` (1 failed, unchanged); `insert2.test` 0 failed.
- No new clippy warnings introduced.

Part of #6173