### PR TITLE
conformance(tcl): parse table-level PRIMARY KEY(col AUTOINCREMENT) syntax

### DIFF
--- a/crates/vibesql-parser/src/parser/create/constraints.rs
+++ b/crates/vibesql-parser/src/parser/create/constraints.rs
@@ -745,6 +745,24 @@ impl Parser {
                     }
                 }
 
+                // SQLite's alternate AUTOINCREMENT syntax: the keyword may
+                // appear directly inside the PRIMARY KEY parentheses, after
+                // the column list, e.g. `PRIMARY KEY(x AUTOINCREMENT)`
+                // (autoinc-7.1, issue #6173) — equivalent to declaring `x
+                // INTEGER PRIMARY KEY AUTOINCREMENT` as a column constraint.
+                // Only meaningful for a single-column PK; record the column
+                // name so the CREATE TABLE column loop (table.rs) can fold it
+                // into that column's own constraint list. A multi-column PK
+                // followed by AUTOINCREMENT has no documented meaning in
+                // SQLite and no test exercises it, so the keyword is simply
+                // left unconsumed in that case (surfacing as a syntax error,
+                // same as before this change).
+                if columns.len() == 1 && self.peek_keyword(Keyword::AutoIncrement) {
+                    self.advance(); // consume AUTOINCREMENT
+                    if let Some(name) = columns[0].column_name() {
+                        self.pending_table_pk_autoincrement_column = Some(name.to_string());
+                    }
+                }
                 self.expect_token(Token::RParen)?;
                 // Validate no expressions in PRIMARY KEY constraint
                 validate_no_expressions_in_constraint(&columns)?;

--- a/crates/vibesql-parser/src/parser/create/table.rs
+++ b/crates/vibesql-parser/src/parser/create/table.rs
@@ -79,6 +79,13 @@ impl Parser {
         self.expect_token(Token::LParen)?;
         let mut columns = Vec::new();
         let mut table_constraints = Vec::new();
+        // Column name (as written) carrying an AUTOINCREMENT designation via
+        // the table-level `PRIMARY KEY(col AUTOINCREMENT)` syntax (issue
+        // #6173, autoinc-7.1). Applied to the matching column's constraint
+        // list once the full column/constraint list has been parsed (see
+        // below), so this works regardless of whether the PRIMARY KEY
+        // constraint textually precedes or follows its column's definition.
+        let mut table_pk_autoincrement_column: Option<String> = None;
 
         loop {
             // Check if this is a table-level constraint (including CONSTRAINT keyword)
@@ -90,6 +97,9 @@ impl Parser {
                 || self.peek_keyword(Keyword::Fulltext)
             {
                 table_constraints.push(self.parse_table_constraint()?);
+                if let Some(name) = self.pending_table_pk_autoincrement_column.take() {
+                    table_pk_autoincrement_column = Some(name);
+                }
                 // Absorb any trailing, body-less `CONSTRAINT <name>` clauses that
                 // SQLite accepts and ignores after a table constraint (#6173).
                 self.skip_trailing_constraint_names();
@@ -299,6 +309,25 @@ impl Parser {
         }
 
         self.expect_token(Token::RParen)?;
+
+        // Fold a table-level `PRIMARY KEY(col AUTOINCREMENT)` designation
+        // (issue #6173, autoinc-7.1) into the target column's own constraint
+        // list, so downstream stages (rowid-alias detection and AUTOINCREMENT
+        // validation in vibesql-executor) see the same AST shape as the
+        // equivalent column-constraint spelling `col INTEGER PRIMARY KEY
+        // AUTOINCREMENT`. Matched case-insensitively against the column's
+        // declared name (SQLite identifiers are case-insensitive).
+        if let Some(pk_col_name) = table_pk_autoincrement_column {
+            if let Some(col) = columns
+                .iter_mut()
+                .find(|c: &&mut vibesql_ast::ColumnDef| c.name.eq_ignore_ascii_case(&pk_col_name))
+            {
+                col.constraints.push(vibesql_ast::ColumnConstraint {
+                    name: None,
+                    kind: vibesql_ast::ColumnConstraintKind::AutoIncrement,
+                });
+            }
+        }
 
         // Parse optional table options (MySQL extensions)
         let table_options = self.parse_table_options()?;

--- a/crates/vibesql-parser/src/parser/mod.rs
+++ b/crates/vibesql-parser/src/parser/mod.rs
@@ -79,6 +79,22 @@ pub struct Parser {
     /// spelling — e.g. `X'abcdef'`, `'abcde'`, `-1` — rather than a lossy
     /// `ToSql` re-render (which uppercases blob hex and drops operator spacing).
     column_default_sources: Vec<(String, String)>,
+    /// Set by [`Parser::parse_table_constraint`] when it parses a table-level
+    /// `PRIMARY KEY (col-name [, ...] AUTOINCREMENT)` constraint whose column
+    /// list has exactly one column — SQLite's alternate syntax for declaring
+    /// AUTOINCREMENT "inside the parentheses on a separate PRIMARY KEY
+    /// designation" (autoinc-7.1), equivalent to `col-name INTEGER PRIMARY KEY
+    /// AUTOINCREMENT` as a column constraint. Consumed by the CREATE TABLE
+    /// column loop (issue #6173), which folds it into that column's
+    /// constraint list so the rest of the pipeline (rowid-alias detection,
+    /// AUTOINCREMENT validation in vibesql-executor) sees a single uniform
+    /// shape regardless of which syntax the user wrote. Cleared to `None`
+    /// after being read; left `None` when AUTOINCREMENT was absent or the
+    /// column list had more than one column (in which case the AUTOINCREMENT
+    /// keyword is simply not consumed here and parsing proceeds normally,
+    /// surfacing as a syntax error — a composite-key AUTOINCREMENT has no
+    /// documented meaning and no test exercises it).
+    pending_table_pk_autoincrement_column: Option<String>,
 }
 
 impl Parser {
@@ -96,6 +112,7 @@ impl Parser {
             source: String::new(),
             spans: Vec::new(),
             column_default_sources: Vec::new(),
+            pending_table_pk_autoincrement_column: None,
         }
     }
 
@@ -113,6 +130,7 @@ impl Parser {
             source,
             spans,
             column_default_sources: Vec::new(),
+            pending_table_pk_autoincrement_column: None,
         }
     }
 

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -5730,6 +5730,35 @@ array set vibesql_skip_tests {
     pragma-11.2 "Custom collation registration via 'db collate New_Collation blah...' — a TCL-registered collating sequence reachable only through the C-API sqlite3_create_collation surface (harness limitation #5720), same class as window6-3.0. PRAGMA collation_list itself is correct for every collation VibeSQL can actually register (pragma-11.1 passes); there is no SQL-level CREATE COLLATION surface to bridge the TCL-only registration. Not a PRAGMA introspection gap (#6175)."
 }
 
+# autoinc-4.2/4.3/4.5..4.10 (#6173): these test that TEMP-table AUTOINCREMENT
+# bookkeeping (temp.sqlite_sequence) stays separate from MAIN's
+# (main.sqlite_sequence). autoinc-4.2 (whose script literally references
+# `sqlite_temp_master`) is allow-listed through the blanket
+# uses_sqlite_internals check via vibesql_temp_master_ok (below) so it
+# actually RUNS instead of being skipped outright — its own
+# sqlite_master/sqlite_temp_master enumeration assertion still legitimately
+# reports FAILED (demotion means the "temp" table now shows up in the MAIN
+# enumeration), but running it means its CREATE TABLE/CREATE TEMP TABLE side
+# effects happen, so autoinc-4.4/4.4.1 (plain INSERT/SELECT, no temp-vs-main
+# introspection, and NOT themselves caught by this regex) correctly PASS
+# against the tables 4.2 created, rather than cascading "no such table".
+#
+# autoinc-4.3/4.5..4.10 are NOT caught by the `sqlite_temp_master` regex at
+# all — their scripts reference `temp.sqlite_sequence` directly, a distinct
+# string — so they run (never skipped) and correctly report FAILED with "no
+# such table: temp.sqlite_sequence". Root cause: strip_temp_table_keyword
+# demotes 'CREATE TEMP TABLE t3(...AUTOINCREMENT...)' to a plain persistent
+# 'CREATE TABLE t3' so the table survives this shim's
+# fresh-CLI-process-per-batch model (#5505/#5511/#5591); t3 therefore
+# physically lives in the MAIN schema, not a genuinely connection-scoped temp
+# schema, so 'temp.sqlite_sequence' never really exists. This is a shim
+# architecture limitation, not a VibeSQL AUTOINCREMENT engine gap: a direct
+# single-session repro (CREATE TABLE t1(...AUTOINCREMENT...); CREATE TEMP
+# TABLE t3(...AUTOINCREMENT...); SELECT ... FROM sqlite_master/sqlite_temp_master)
+# against the real vibesql CLI correctly produces separate main/temp
+# sqlite_sequence rows in creation order. Left running (and failing) rather
+# than force-skipped, per the "never turn a clean pass into a skip" rule.
+
 # -----------------------------------------------------------------------------
 # fuzz.test residual classification (#6041) — DO NOT SKIP-LIST THESE.
 #
@@ -5853,6 +5882,30 @@ array set vibesql_writable_schema_ok {
     alterdropcol-8.0 1
 }
 
+# Tests allowed through the blanket "uses sqlite_temp_master" skip in
+# uses_sqlite_internals (issue #6173).
+#
+# autoinc-4.2 is a SETUP block (`CREATE TABLE t1(...AUTOINCREMENT...);
+# CREATE TEMP TABLE t3(...AUTOINCREMENT...); SELECT ... FROM sqlite_master /
+# sqlite_temp_master`) — under this shim's TEMP-table demotion
+# (strip_temp_table_keyword) t3 becomes an ordinary persistent table, so its
+# own `sqlite_master`/`sqlite_temp_master` enumeration assertion no longer
+# matches real SQLite's temp/main split and 4.2 itself still reports FAILED
+# (not a forced pass — see uses_sqlite_internals's reason string for why this
+# is a harness limitation, not an engine gap). But 4.2's CREATE statements
+# are what matter for later tests: skipping the whole block outright (the
+# default behavior for anything matching this regex) would prevent t1/t3
+# from ever existing, cascading spurious "no such table" failures into
+# autoinc-4.4/4.4.1 (plain INSERT/SELECT, no temp-vs-main introspection —
+# they pass fine against the demoted tables). Allow-listing 4.2 lets its SQL
+# actually run so those side effects happen, same trade-off as the
+# ATTACH-setup rescue elsewhere in this file. Keyed by testprefix-qualified
+# test name.
+variable vibesql_temp_master_ok
+array set vibesql_temp_master_ok {
+    autoinc-4.2 1
+}
+
 # Check if a test should be skipped based on VibeSQL-specific exclusions
 # Returns a list: {should_skip reason} where should_skip is 0/1
 proc vibesql_should_skip {name} {
@@ -5904,7 +5957,13 @@ proc vibesql_should_skip {name} {
 # Check if a test script uses SQLite internal metrics that we don't implement.
 # These tests verify internal query execution behavior, not SQL correctness.
 # Returns a list: {uses_internals reason} where uses_internals is 0/1
-proc uses_sqlite_internals {script} {
+#
+# `name` is the raw test name (as do_test received it, i.e. without the
+# ::testprefix already joined on) — needed to allow-list specific tests by
+# their fully-qualified `<prefix>-<name>` form (see vibesql_temp_master_ok
+# below). Defaults to "" for callers that only care about the script-content
+# checks and have no meaningful test name to allow-list against.
+proc uses_sqlite_internals {script {name ""}} {
     # SQLite internal performance counters
     # These track VDBE operations that don't exist in VibeSQL's execution model
     #
@@ -6125,9 +6184,45 @@ proc uses_sqlite_internals {script} {
         return [list 1 "uses sqlite3_status() (SQLite C API)"]
     }
 
-    # SQLite internal catalog tables
+    # SQLite internal catalog tables.
+    #
+    # VibeSQL does implement `sqlite_temp_master` itself (an alias for
+    # temp.sqlite_master, same as sqlite_master for the main schema — see
+    # vibesql-executor/src/sqlite_schema.rs and friends), but this shim
+    # demotes every `CREATE TEMP TABLE` to a plain persistent `CREATE TABLE`
+    # (see strip_temp_table_keyword above) so it survives the shim's
+    # fresh-CLI-process-per-batch model. That demotion means a "temp" table
+    # physically lives in the MAIN schema, not a genuinely connection-scoped
+    # temp schema — so any test that inspects `sqlite_temp_master` (or
+    # `temp.sqlite_sequence`, or the exact `sql` text a temp object was
+    # registered under) to verify the temp/main *separation itself* is
+    # testing something this shim's architecture cannot represent, and is
+    # correctly left skipped here (issue #6173; do not narrow this check —
+    # widening it revealed a broad class of pre-existing, unrelated
+    # temp-vs-main-separation gaps across 15+ files, e.g. alter4.test, whose
+    # triage belongs to those files' own issues, not this one).
+    #
+    # A handful of specific tests merely use plain data operations (INSERT/
+    # SELECT, no temp-vs-main schema introspection) on a table that
+    # incidentally was declared TEMP elsewhere in the same script; those
+    # pass fine under demotion and are allow-listed by name below so the
+    # broad regex doesn't force a real pass into a spurious skip.
     if {[regexp {sqlite_temp_master} $script]} {
-        return [list 1 "uses sqlite_temp_master (SQLite internal catalog)"]
+        variable vibesql_temp_master_ok
+        # Test names may already be fully testprefix-qualified as written in
+        # the .test file (e.g. autoinc.test's `do_test autoinc-4.2 {...}`,
+        # where $name arrives as "autoinc-4.2") or may be bare and rely on
+        # ::testprefix for qualification (e.g. "4.1.3" -> "selectA-4.1.3").
+        # Check both forms, same two-step pattern as vibesql_should_skip
+        # above, so this doesn't silently double-prefix or fail to match.
+        set tm_ok [info exists vibesql_temp_master_ok($name)]
+        if {!$tm_ok && [info exists ::testprefix] && $::testprefix ne ""} {
+            set tm_prefixed_name "${::testprefix}-${name}"
+            set tm_ok [info exists vibesql_temp_master_ok($tm_prefixed_name)]
+        }
+        if {!$tm_ok} {
+            return [list 1 "uses sqlite_temp_master (SQLite internal catalog; temp-vs-main separation is untestable under this shim's TEMP-table demotion — #6173)"]
+        }
     }
 
     # C API statement handles - these depend on sqlite3_prepare
@@ -6421,7 +6516,7 @@ proc do_test {name script expected} {
 
     # Check if test uses SQLite internal metrics we don't implement
     # Do this BEFORE incrementing test count or printing test name
-    set internal_check [uses_sqlite_internals $script]
+    set internal_check [uses_sqlite_internals $script $name]
     if {[lindex $internal_check 0]} {
         # Setup-only blocks (no expected result to assert) that merely use an
         # OR REPLACE / OR IGNORE conflict clause must still RUN: VibeSQL now


### PR DESCRIPTION
## Summary

- Parses SQLite's alternate AUTOINCREMENT syntax `PRIMARY KEY(col AUTOINCREMENT)` inside a table-level constraint (previously a syntax error), equivalent to `col INTEGER PRIMARY KEY AUTOINCREMENT` as a column constraint.
- Refines the TCL shim's blanket `sqlite_temp_master` skip so `autoinc-4.2`'s setup statements still run (creating the tables later `autoinc-4.x` tests depend on) instead of being skipped outright, which was cascading spurious "no such table" failures into unrelated tests.

## Changes

- `crates/vibesql-parser/src/parser/mod.rs`: new `pending_table_pk_autoincrement_column` field on `Parser` to carry the AUTOINCREMENT designation from `parse_table_constraint` to the CREATE TABLE column loop.
- `crates/vibesql-parser/src/parser/create/constraints.rs`: `parse_table_constraint` recognizes `AUTOINCREMENT` after a single-column `PRIMARY KEY(...)` list and records the column name (a multi-column PK followed by AUTOINCREMENT has no documented SQLite meaning and remains a syntax error, unchanged).
- `crates/vibesql-parser/src/parser/create/table.rs`: folds the recorded AUTOINCREMENT designation into the matching column's own `constraints` list after the full column/constraint list has been parsed, so it works regardless of whether `PRIMARY KEY(...)` textually precedes or follows the column definition, and so downstream stages (rowid-alias detection, AUTOINCREMENT validation in `vibesql-executor`) see one uniform AST shape.
- `scripts/tester_vibesql.tcl`: `uses_sqlite_internals` now takes the test name and allow-lists `autoinc-4.2` (via a new `vibesql_temp_master_ok` array) through the `sqlite_temp_master` skip regex, since that test's own CREATE-TABLE side effects are needed by later tests even though its own temp/main-separation assertion still correctly fails under this shim's TEMP-table demotion.

## Acceptance Criteria Verification

Issue #6173 is a large family issue (~292 certified failures across 7 files) that stays open across many partial-increment PRs — this PR lands one reasonably-scoped slice (the AUTOINCREMENT sub-feature within `autoinc.test`), not the whole family.

- `autoinc.test`: 67/75 passed (was worse before this change — the table-level `PRIMARY KEY(col AUTOINCREMENT)` syntax used by `autoinc-7.1` previously failed to parse at all). The remaining 8 failures (`autoinc-4.3`, `4.5`–`4.10`, and the introspection half of `4.2`) are a documented harness limitation: this shim demotes `CREATE TEMP TABLE` to a plain persistent `CREATE TABLE` to survive its fresh-CLI-process-per-batch model, so `temp.sqlite_sequence` never really exists under the shim even though a direct single-session repro against the real `vibesql` CLI produces correct separate main/temp `sqlite_sequence` rows.
- `cargo test -p vibesql-parser`: 1828/1828 passed, 0 failed.
- No new `cargo fmt` or `cargo clippy` findings in the touched files (verified via `git diff --unified=0` line ranges against the fmt/clippy diff output — all existing warnings are in files/lines this PR does not touch).

## Test Plan

- [x] `cargo build --release --bin vibesql`
- [x] `cargo test -p vibesql-parser` (1828 passed, 0 failed)
- [x] `make test-tcl-file FILE=autoinc.test` (67/75 passed; remaining failures documented as harness limitation, not engine gap)
- [x] `cargo fmt --check -p vibesql-parser` / `cargo clippy -p vibesql-parser --lib` — no new findings in touched files

Part of #6173