### PR TITLE
conformance(tcl): reject ON as unquoted identifier; ALTER TABLE system-table/view wording (Part of #6174)

### DIFF
--- a/crates/vibesql-executor/src/alter/columns.rs
+++ b/crates/vibesql-executor/src/alter/columns.rs
@@ -318,10 +318,10 @@ pub(super) fn execute_drop_column(
         )));
     }
 
-    // The schema table itself may not be altered.
-    if super::validation::is_sqlite_schema_table(table_name) {
-        return Err(ExecutorError::Other("table sqlite_master may not be altered".to_string()));
-    }
+    // (The schema/statistics-table guard — `table <name> may not be altered` —
+    // is now checked centrally in `alter::mod::execute_with_source` before
+    // dispatch, uniformly across every ALTER sub-command; see that check for
+    // rationale. Unreachable here.)
 
     // Resolve the table. A missing table keeps `TableNotFound`, which the
     // harness normalizes to SQLite's `no such table: <name>`.

--- a/crates/vibesql-executor/src/alter/mod.rs
+++ b/crates/vibesql-executor/src/alter/mod.rs
@@ -72,6 +72,29 @@ impl AlterTableExecutor {
             AlterTableStmt::ModifyColumn(s) => &s.table_name,
             AlterTableStmt::ChangeColumn(s) => &s.table_name,
         };
+
+        // SQLite refuses to ALTER any of its own schema/statistics tables
+        // (`sqlite_master`/`sqlite_schema`, and `sqlite_stat1..4`) with a single
+        // uniform message across *every* ALTER TABLE sub-command — RENAME TO,
+        // RENAME COLUMN, ADD COLUMN, DROP COLUMN, ADD/DROP CONSTRAINT, ALTER
+        // COLUMN — `table <name> may not be altered`, echoing the canonical
+        // lowercase name regardless of how the statement spelled it (e.g.
+        // `ALTER TABLE SqLiTe_master ...` still reports `sqlite_master`, not
+        // `SqLiTe_master`). These names are never real catalog entries, so
+        // without this upfront check every sub-command falls through to a
+        // generic (and wrong) `no such table` instead (alter-2.4, alter-15.*,
+        // altercol-6.1/12.1.2, alterdropcol.test). Checked before the privilege
+        // check and before dispatch, so it applies uniformly and atomically —
+        // no sub-command-specific handler needs its own copy of this guard.
+        if validation::is_sqlite_schema_table(table_name)
+            || crate::sqlite_stat::is_sqlite_stat_table(table_name)
+        {
+            return Err(ExecutorError::Other(format!(
+                "table {} may not be altered",
+                table_name.to_ascii_lowercase()
+            )));
+        }
+
         PrivilegeChecker::check_alter(database, table_name)?;
 
         let result = match stmt {

--- a/crates/vibesql-executor/src/alter/mod.rs
+++ b/crates/vibesql-executor/src/alter/mod.rs
@@ -77,21 +77,33 @@ impl AlterTableExecutor {
         // (`sqlite_master`/`sqlite_schema`, and `sqlite_stat1..4`) with a single
         // uniform message across *every* ALTER TABLE sub-command — RENAME TO,
         // RENAME COLUMN, ADD COLUMN, DROP COLUMN, ADD/DROP CONSTRAINT, ALTER
-        // COLUMN — `table <name> may not be altered`, echoing the canonical
-        // lowercase name regardless of how the statement spelled it (e.g.
-        // `ALTER TABLE SqLiTe_master ...` still reports `sqlite_master`, not
-        // `SqLiTe_master`). These names are never real catalog entries, so
-        // without this upfront check every sub-command falls through to a
-        // generic (and wrong) `no such table` instead (alter-2.4, alter-15.*,
-        // altercol-6.1/12.1.2, alterdropcol.test). Checked before the privilege
-        // check and before dispatch, so it applies uniformly and atomically —
-        // no sub-command-specific handler needs its own copy of this guard.
-        if validation::is_sqlite_schema_table(table_name)
-            || crate::sqlite_stat::is_sqlite_stat_table(table_name)
-        {
+        // COLUMN — `table <name> may not be altered`. The schema table is a
+        // special case: SQLite canonicalizes it to `sqlite_master` regardless of
+        // which alias (`sqlite_schema`, temp variants) or case the statement used
+        // (verified against sqlite3 3.51.0 — `ALTER TABLE sqlite_schema ...` and
+        // `ALTER TABLE SqLiTe_master ...` both report `sqlite_master`). The
+        // statistics tables instead echo the name exactly as spelled. These
+        // names are never real catalog entries, so without this upfront check
+        // every sub-command falls through to a generic (and wrong) `no such
+        // table` instead (alter-2.4, alter-15.*, altercol-6.1/12.1.2,
+        // alterdropcol.test). Checked before the privilege check and before
+        // dispatch, so it applies uniformly and atomically — no sub-command-
+        // specific handler needs its own copy of this guard.
+        if validation::is_sqlite_schema_table(table_name) {
+            // The schema table always reports the canonical `sqlite_master` name,
+            // regardless of which alias (`sqlite_master`/`sqlite_schema`, temp
+            // variants) or case the statement used — SQLite canonicalizes this
+            // specific message (verified against sqlite3 3.51.0).
+            return Err(ExecutorError::Other(
+                "table sqlite_master may not be altered".to_string(),
+            ));
+        }
+        if crate::sqlite_stat::is_sqlite_stat_table(table_name) {
+            // The statistics tables (`sqlite_stat1..4`) echo the actual name as
+            // spelled in the statement.
             return Err(ExecutorError::Other(format!(
                 "table {} may not be altered",
-                table_name.to_ascii_lowercase()
+                table_name
             )));
         }
 

--- a/crates/vibesql-executor/src/alter/table_options.rs
+++ b/crates/vibesql-executor/src/alter/table_options.rs
@@ -13,6 +13,16 @@ pub(super) fn execute_rename_table(
     stmt: &RenameTableStmt,
     database: &mut Database,
 ) -> Result<String, ExecutorError> {
+    // A view is not a table: SQLite rejects `ALTER TABLE <view> RENAME TO ...`
+    // with a view-specific message (`view <name> may not be altered`), before
+    // any table-name resolution — otherwise it falls through to the generic
+    // (and wrong) `no such table` (alter-12.2). Uses the view's stored name for
+    // case-preserving output, matching how RENAME COLUMN's equivalent check
+    // (below in `columns::execute_rename_column`) reports it.
+    if let Some(view) = database.catalog.get_view(&stmt.table_name) {
+        return Err(ExecutorError::Other(format!("view {} may not be altered", view.name)));
+    }
+
     // Reject renaming a table to a reserved `sqlite_`-prefixed name. SQLite
     // reserves that prefix for its own schema objects and errors
     // `object name reserved for internal use: <name>` (sqlite3 3.51.0,

--- a/crates/vibesql-executor/src/tests/alter_system_table_restrictions.rs
+++ b/crates/vibesql-executor/src/tests/alter_system_table_restrictions.rs
@@ -1,0 +1,91 @@
+//! Tests that `ALTER TABLE` refuses to touch SQLite's own schema/statistics
+//! tables (`sqlite_master`/`sqlite_schema`, `sqlite_stat1..4`) and views, with
+//! SQLite's exact error wording, for every ALTER sub-command (#6174).
+//!
+//! sqlite3 3.51.0 reports a single uniform message across every ALTER
+//! sub-command for its own system tables:
+//!
+//! ```text
+//! sqlite> ALTER TABLE sqlite_master RENAME TO x;
+//! Error: table sqlite_master may not be altered
+//! sqlite> ALTER TABLE sqlite_stat1 ADD COLUMN x;
+//! Error: table sqlite_stat1 may not be altered
+//! ```
+//!
+//! and a view-specific message for `RENAME TO`:
+//!
+//! ```text
+//! sqlite> CREATE VIEW v1 AS SELECT 1;
+//! sqlite> ALTER TABLE v1 RENAME TO v2;
+//! Error: view v1 may not be altered
+//! ```
+//!
+//! Before this fix these all fell through to the generic (and wrong)
+//! `no such table: <name>`, because none of `sqlite_master` / `sqlite_stat1` /
+//! a view are real catalog table entries (alter-2.4, alter-12.2, alter-15.*,
+//! altercol-6.1/12.1.2).
+
+use vibesql_ast::Statement;
+use vibesql_storage::Database;
+
+use crate::errors::ExecutorError;
+
+fn exec(db: &mut Database, sql: &str) -> Result<String, ExecutorError> {
+    let stmt = vibesql_parser::Parser::parse_sql(sql).expect("parse");
+    match stmt {
+        Statement::CreateTable(s) => crate::CreateTableExecutor::execute(&s, db),
+        Statement::CreateView(s) => {
+            crate::advanced_objects::execute_create_view(&s, db).map(|_| String::new())
+        }
+        Statement::AlterTable(s) => crate::alter::AlterTableExecutor::execute(&s, db),
+        other => panic!("unexpected statement: {:?}", other),
+    }
+}
+
+#[test]
+fn rename_sqlite_master_is_rejected_case_insensitively() {
+    let mut db = Database::new();
+    let err = exec(&mut db, "ALTER TABLE SqLiTe_master RENAME TO master").unwrap_err();
+    assert_eq!(err.to_string(), "table sqlite_master may not be altered");
+}
+
+#[test]
+fn add_column_to_sqlite_master_is_rejected() {
+    let mut db = Database::new();
+    let err = exec(&mut db, "ALTER TABLE sqlite_master ADD COLUMN x").unwrap_err();
+    assert_eq!(err.to_string(), "table sqlite_master may not be altered");
+}
+
+#[test]
+fn rename_sqlite_stat1_is_rejected() {
+    let mut db = Database::new();
+    let err = exec(&mut db, "ALTER TABLE sqlite_stat1 RENAME TO xyz").unwrap_err();
+    assert_eq!(err.to_string(), "table sqlite_stat1 may not be altered");
+}
+
+#[test]
+fn add_column_to_sqlite_stat1_is_rejected() {
+    let mut db = Database::new();
+    let err = exec(&mut db, "ALTER TABLE sqlite_stat1 ADD COLUMN xyz").unwrap_err();
+    assert_eq!(err.to_string(), "table sqlite_stat1 may not be altered");
+}
+
+#[test]
+fn rename_column_of_sqlite_stat1_is_rejected() {
+    let mut db = Database::new();
+    let err = exec(&mut db, "ALTER TABLE sqlite_stat1 RENAME tbl TO thetable").unwrap_err();
+    assert_eq!(err.to_string(), "table sqlite_stat1 may not be altered");
+}
+
+#[test]
+fn rename_view_is_rejected_with_view_specific_message() {
+    let mut db = Database::new();
+    exec(&mut db, "CREATE TABLE t1(a, b)").unwrap();
+    exec(&mut db, "CREATE VIEW v1 AS SELECT * FROM t1").unwrap();
+
+    let err = exec(&mut db, "ALTER TABLE v1 RENAME TO v2").unwrap_err();
+    assert_eq!(err.to_string(), "view v1 may not be altered");
+
+    // The failed rename must leave the view and its name untouched.
+    assert!(db.catalog.get_view("v1").is_some());
+}

--- a/crates/vibesql-executor/src/tests/mod.rs
+++ b/crates/vibesql-executor/src/tests/mod.rs
@@ -69,6 +69,7 @@ mod aggregate_without_from;
 mod alter_add_column_restrictions;
 mod alter_rename_collision;
 mod alter_rename_column_triggers;
+mod alter_system_table_restrictions;
 mod alter_table_constraints;
 mod auto_increment_tests;
 mod between_predicates;

--- a/crates/vibesql-parser/src/parser/create/table.rs
+++ b/crates/vibesql-parser/src/parser/create/table.rs
@@ -111,12 +111,28 @@ impl Parser {
                 // SQLite compatibility: at the start of a column definition, a keyword
                 // can only be a column name. Table-level constraint keywords (CONSTRAINT,
                 // PRIMARY, FOREIGN, UNIQUE, CHECK, FULLTEXT) are already consumed above,
-                // so any remaining keyword here is an unquoted column name. SQLite reserves
-                // very few words and accepts the rest as identifiers in this position,
-                // including DESC, ASC, KEY, BEGIN, END (see table.test table-7.x).
+                // so any remaining keyword here is an unquoted column name candidate.
+                // SQLite reserves very few words and accepts the rest as identifiers in
+                // this position, including DESC, ASC, KEY, BEGIN, END (see table.test
+                // table-7.x) — but truly reserved words (ON, SELECT, WHERE, ...) are NOT
+                // valid column names, matching SQLite's `nm` grammar production (which
+                // only demotes its `%fallback ID` keyword set to identifiers here).
+                // Without this guard `CREATE TABLE t10(a, ON, c)` silently created a
+                // column literally named `on` instead of raising SQLite's `near "ON":
+                // syntax error` (alter.test alter-3.2.6).
+                //
+                // Uses `can_be_identifier_in_table_position()` rather than the narrower
+                // `can_be_identifier() || is_sqlite_fallback_keyword()` pair: VibeSQL has
+                // its own extra keywords (e.g. `Pad`) that are not part of SQLite's real
+                // reserved/fallback vocabulary at all, and a stricter allow-list rejected
+                // them as column names (regression: `CREATE TABLE parent(pad INTEGER, ...)`
+                // in constraint_rehydration_reload_tests.rs). The table-position predicate
+                // is a denylist of the genuinely-reserved SQL keywords (mirroring
+                // `parse_table_ref`'s use of the same predicate below), so any keyword
+                // outside that denylist — including VibeSQL-only ones — stays accepted.
                 //
                 // SQL:1999: normalize to lowercase when used as an unquoted identifier.
-                Token::Keyword { keyword: kw, .. } => {
+                Token::Keyword { keyword: kw, .. } if kw.can_be_identifier_in_table_position() => {
                     let col_name = format!("{}", kw).to_lowercase();
                     self.advance();
                     col_name
@@ -130,6 +146,12 @@ impl Parser {
                     let c = col.clone();
                     self.advance();
                     c
+                }
+                // A genuinely reserved keyword here (ON, SELECT, WHERE, ...) is a
+                // syntax error, matching SQLite's `near "<TOKEN>": syntax error`
+                // wording rather than a generic "Expected column name" message.
+                Token::Keyword { .. } => {
+                    return Err(ParseError { message: self.peek().syntax_error() })
                 }
                 _ => return Err(ParseError { message: "Expected column name".to_string() }),
             };

--- a/crates/vibesql-parser/src/parser/helpers.rs
+++ b/crates/vibesql-parser/src/parser/helpers.rs
@@ -296,6 +296,16 @@ impl Parser {
     ///
     /// For schema-qualified names, the schema and table parts are stored separately
     /// with their individual quoted flags preserved.
+    ///
+    /// An unquoted keyword is only accepted as a name component when
+    /// `can_be_identifier_in_table_position()` allows it — the same predicate the
+    /// FROM-clause parser already gates on. Genuinely reserved words (`ON`,
+    /// `SELECT`, `WHERE`, ...) must stay rejected here too: this helper backs
+    /// `INSERT INTO`, `DROP TABLE`, `UPDATE`, `DELETE FROM`, and the `ON <table>`
+    /// target of `CREATE TRIGGER`, none of which previously guarded the keyword
+    /// case at all, so e.g. `CREATE TRIGGER t ... ON ON ...` silently created a
+    /// trigger on a table named `on` instead of raising SQLite's `near "ON":
+    /// syntax error` (alter.test alter-3.2.8).
     pub(super) fn parse_table_ref(&mut self) -> Result<vibesql_ast::TableRef, ParseError> {
         // Parse first identifier and track if it was quoted
         // SQLite compatibility: single-quoted strings can be used as identifiers
@@ -317,12 +327,12 @@ impl Parser {
                 self.advance();
                 (identifier, true) // Treat as quoted for case preservation
             }
-            Token::Keyword { keyword, .. } => {
+            Token::Keyword { keyword, .. } if keyword.can_be_identifier_in_table_position() => {
                 let identifier = keyword.to_string();
                 self.advance();
                 (identifier, false) // Keywords are treated as unquoted
             }
-            _ => return Err(ParseError { message: "Expected identifier".to_string() }),
+            _ => return Err(ParseError { message: self.peek().syntax_error() }),
         };
 
         // Check if there's a dot followed by another identifier
@@ -345,14 +355,12 @@ impl Parser {
                     self.advance();
                     (identifier, true)
                 }
-                Token::Keyword { keyword, .. } => {
+                Token::Keyword { keyword, .. } if keyword.can_be_identifier_in_table_position() => {
                     let identifier = keyword.to_string();
                     self.advance();
                     (identifier, false)
                 }
-                _ => {
-                    return Err(ParseError { message: "Expected identifier after '.'".to_string() })
-                }
+                _ => return Err(ParseError { message: self.peek().syntax_error() }),
             };
             // For qualified names, store schema and table parts separately
             // This preserves the individual quoted status for proper case handling

--- a/crates/vibesql-parser/src/tests/alter_table.rs
+++ b/crates/vibesql-parser/src/tests/alter_table.rs
@@ -589,3 +589,72 @@ fn test_parse_add_column_with_check_constraint() {
         _ => panic!("Expected ALTER TABLE ADD COLUMN statement"),
     }
 }
+
+// ========================================================================
+// `ON` must stay reserved as an unquoted identifier (alter.test alter-3.2.*,
+// part of #6174).
+// ========================================================================
+//
+// SQLite's grammar never demotes `ON` to a plain identifier (it is absent
+// from parse.y's `%fallback ID` list), so it cannot be used unquoted as a
+// database/table/column name anywhere. `CREATE TRIGGER ... ON ON ...` and
+// `CREATE TABLE t(a, ON, c)` must both raise a syntax error rather than
+// silently accepting `on` as a name.
+
+#[test]
+fn test_create_table_rejects_on_as_column_name() {
+    // alter.test alter-3.2.6: `CREATE TABLE t10(a, ON, c);` -> syntax error.
+    let result = Parser::parse_sql("CREATE TABLE t10(a, ON, c);");
+    assert!(result.is_err(), "unquoted ON must be rejected as a column name: {:?}", result);
+}
+
+#[test]
+fn test_create_table_accepts_quoted_on_as_column_name() {
+    // alter.test alter-3.2.7: quoting escapes the reservation.
+    let result = Parser::parse_sql("CREATE TABLE t10(a, 'ON', c);");
+    assert!(result.is_ok(), "quoted 'ON' should parse as a column name: {:?}", result.err());
+}
+
+#[test]
+fn test_create_trigger_rejects_on_as_table_name() {
+    // alter.test alter-3.2.8: the trigger's own `ON <table>` target cannot be
+    // the unquoted keyword `ON` itself.
+    let result = Parser::parse_sql("CREATE TRIGGER trig4 AFTER INSERT ON ON BEGIN SELECT 1; END;");
+    assert!(
+        result.is_err(),
+        "unquoted ON must be rejected as a trigger's table name: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_insert_into_rejects_on_as_table_name() {
+    let result = Parser::parse_sql("INSERT INTO ON VALUES(1);");
+    assert!(result.is_err(), "unquoted ON must be rejected as an INSERT INTO table name");
+}
+
+#[test]
+fn test_drop_table_rejects_on_as_table_name() {
+    let result = Parser::parse_sql("DROP TABLE ON;");
+    assert!(result.is_err(), "unquoted ON must be rejected as a DROP TABLE table name");
+}
+
+#[test]
+fn test_fallback_keywords_still_accepted_as_table_and_trigger_targets() {
+    // Regression guard: the reservation is specific to genuinely-reserved
+    // words. SQLite's %fallback ID keywords (e.g. `savepoint`, `view`) must
+    // remain usable unquoted as table names in these same positions.
+    assert!(
+        Parser::parse_sql("CREATE TRIGGER trig4 AFTER INSERT ON savepoint BEGIN SELECT 1; END;")
+            .is_ok(),
+        "fallback keyword `savepoint` should still parse as a trigger's table name"
+    );
+    assert!(
+        Parser::parse_sql("INSERT INTO savepoint VALUES(1);").is_ok(),
+        "fallback keyword `savepoint` should still parse as an INSERT INTO table name"
+    );
+    assert!(
+        Parser::parse_sql("DROP TABLE savepoint;").is_ok(),
+        "fallback keyword `savepoint` should still parse as a DROP TABLE table name"
+    );
+}


### PR DESCRIPTION
## Summary

Two independent, well-scoped ALTER-TABLE-family conformance fixes, both targeting certified failures tracked by #6174 (`alter.test`, `altercol.test`, `alter3.test`).

**1. Parser — `ON` must stay reserved as an unquoted identifier**

SQLite never demotes the keyword `ON` to a plain identifier (it's absent from `parse.y`'s `%fallback ID` list), so `CREATE TABLE t(a, ON, c)`, `CREATE TRIGGER t ... ON ON ...`, `INSERT INTO ON ...`, and `DROP TABLE ON` must all raise `near "ON": syntax error` instead of silently accepting `on` as a name. `parse_table_ref` (backing `INSERT INTO`, `DROP TABLE`, `UPDATE`, `DELETE FROM`, `CREATE TRIGGER ... ON <table>`) and the `CREATE TABLE` column-name parser now gate unquoted-keyword acceptance on `can_be_identifier_in_table_position()` — the same predicate the FROM-clause parser already used — so VibeSQL's own extra keywords stay accepted while genuinely-reserved SQLite keywords are rejected (alter-3.2.6/3.2.8).

**2. Executor — ALTER TABLE on system tables / views**

ALTER TABLE now uniformly rejects operating on SQLite's own schema/statistics tables (`sqlite_master`/`sqlite_schema`, `sqlite_stat1..4`) with `table <name> may not be altered` across *every* ALTER sub-command (RENAME TO, RENAME COLUMN, ADD COLUMN, DROP COLUMN, ...) — checked centrally before dispatch instead of ad hoc per-handler. Previously only DROP COLUMN had this guard (and always hardcoded "sqlite_master", which was wrong for `sqlite_stat1`); every other sub-command fell through to a misleading `no such table: sqlite_master` (alter-2.4, alter-15.*, altercol-6.1/12.1.2). RENAME TABLE also gained a view-specific `view <name> may not be altered` guard, matching the wording ADD/DROP/RENAME COLUMN already use for views (alter-12.2).

## Test plan

- [x] `cargo test -p vibesql-parser --lib` — 1834 passed
- [x] `cargo test -p vibesql-ast --lib` — 91 passed
- [x] `cargo test -p vibesql-executor --lib alter` — 109 passed (103 pre-existing + 6 new, covering system-table/view "may not be altered" wording across RENAME TO/RENAME COLUMN/ADD COLUMN)
- [x] `cargo test -p vibesql-executor --lib` (full suite) — 3646/3647 passed; the one failure (`test_parallel_nested_loop_large_dataset`, a 300s query-timeout perf test unrelated to ALTER TABLE) is machine-load flakiness from concurrent builds on this box, not a regression from this change
- [x] `make test-tcl-file FILE=alter.test` — 41 -> 35 failures (6 fixed: alter-2.4, alter-12.2, alter-15.1.1, alter-15.1.2, alter-15.2.1, alter-15.2.2)
- [x] `make test-tcl-file FILE=altercol.test` — 2 fixed (6.1, 12.1.2)
- [x] `make test-tcl-file FILE=alter3.test` — 1 fixed
- [x] Regression sweep across the rest of the ALTER family — no regressions: `alter2.test`, `alter4.test`, `alterdropcol.test`, `alterdropcol2.test`, `altertab.test`, `altertrig.test` (100%), `alterqf.test`, `alterauth.test`

Part of #6174