### PR TITLE
fix(executor): SQLite-compatible unknown-database error + PRAGMA ignore_check_constraints

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -1521,6 +1521,7 @@ impl SqlExecutor {
                 // VibeSQL never finds corruption in a healthy table, so every
                 // valid target still resolves to "ok"; we only add the missing
                 // no-such-table validation for the name-argument form.
+                let mut target_table: Option<String> = None;
                 if let Some(name) = match &stmt.value {
                     Some(vibesql_ast::PragmaValue::Identifier(name)) => Some(name.clone()),
                     Some(vibesql_ast::PragmaValue::String(name)) => Some(name.clone()),
@@ -1544,12 +1545,60 @@ impl SqlExecutor {
                         if self.db.catalog.get_table(&lookup).is_none() {
                             anyhow::bail!("no such table: {}", name);
                         }
+                        target_table = Some(name);
                     }
                 }
+
+                // SQLite compatibility (Part of #6173, check.test check-4.8/
+                // 4.8.1): `PRAGMA integrity_check` validates every row against
+                // its table's CHECK constraints and reports one
+                // "CHECK constraint failed in <table>" diagnostic per row that
+                // violates any constraint, UNLESS `ignore_check_constraints`
+                // is ON (in which case CHECK validation is skipped here too,
+                // mirroring SQLite's coupling of the two settings — the same
+                // pragma that disables CHECK enforcement on DML also disables
+                // it during integrity_check).
+                let mut diagnostics: Vec<String> = Vec::new();
+                if !self.db.ignore_check_constraints() {
+                    let tables_to_check: Vec<String> = match &target_table {
+                        Some(name) => vec![name.clone()],
+                        None => self.db.catalog.list_tables(),
+                    };
+                    let current_schema = self.db.catalog.get_current_schema().to_string();
+                    for tbl_name in &tables_to_check {
+                        let schema = match self.db.catalog.get_table(tbl_name) {
+                            Some(schema) if !schema.check_constraints.is_empty() => schema,
+                            _ => continue,
+                        };
+                        let qualified_name = format!("{}.{}", current_schema, tbl_name);
+                        let rows: Vec<_> = if let Some(table) = self.db.tables.get(&qualified_name)
+                        {
+                            table.scan_live().map(|(_, row)| row.clone()).collect()
+                        } else if let Some(table) = self.db.tables.get(tbl_name.as_str()) {
+                            table.scan_live().map(|(_, row)| row.clone()).collect()
+                        } else {
+                            continue;
+                        };
+                        for row in &rows {
+                            if vibesql_executor::enforce_check_constraints(schema, &row.values)
+                                .is_err()
+                            {
+                                diagnostics
+                                    .push(format!("CHECK constraint failed in {}", tbl_name));
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                if diagnostics.is_empty() {
+                    diagnostics.push("ok".to_string());
+                }
+                let row_count = diagnostics.len();
                 return Ok(QueryResult {
                     columns: vec![pragma_name.to_lowercase()],
-                    rows: vec![vec![Some("ok".to_string())]],
-                    row_count: 1,
+                    rows: diagnostics.into_iter().map(|d| vec![Some(d)]).collect(),
+                    row_count,
                     execution_time_ms: None,
                     message: None,
                 });
@@ -1689,6 +1738,22 @@ impl SqlExecutor {
                     // at COMMIT/ROLLBACK. Runtime semantic change (deferring
                     // FK violations until COMMIT) ships in Phase C2.
                     self.db.set_defer_foreign_keys(bool_value);
+                    Ok(QueryResult {
+                        rows: Vec::new(),
+                        columns: Vec::new(),
+                        row_count: 0,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
+                "IGNORE_CHECK_CONSTRAINTS" => {
+                    // SQLite-compatible PRAGMA ignore_check_constraints
+                    // (Part of #6173, check.test check-4.8/4.8.1): when ON,
+                    // CHECK constraints are not enforced by INSERT/UPDATE, and
+                    // `PRAGMA integrity_check` also skips CHECK validation
+                    // (matching SQLite's coupling of the two). Session-scoped,
+                    // default OFF.
+                    self.db.set_ignore_check_constraints(bool_value);
                     Ok(QueryResult {
                         rows: Vec::new(),
                         columns: Vec::new(),
@@ -2039,6 +2104,18 @@ impl SqlExecutor {
                     let value = if self.db.defer_foreign_keys() { "1" } else { "0" };
                     Ok(QueryResult {
                         columns: vec!["defer_foreign_keys".to_string()],
+                        rows: vec![vec![Some(value.to_string())]],
+                        row_count: 1,
+                        execution_time_ms: None,
+                        message: None,
+                    })
+                }
+                "IGNORE_CHECK_CONSTRAINTS" => {
+                    // SQLite-compatible PRAGMA ignore_check_constraints read
+                    // (Part of #6173). Defaults to 0 (OFF).
+                    let value = if self.db.ignore_check_constraints() { "1" } else { "0" };
+                    Ok(QueryResult {
+                        columns: vec!["ignore_check_constraints".to_string()],
                         rows: vec![vec![Some(value.to_string())]],
                         row_count: 1,
                         execution_time_ms: None,

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -177,13 +177,14 @@ impl CreateTableExecutor {
             (database.catalog.get_current_schema().to_string(), stmt.table_name.clone(), id)
         };
 
-        // Check CREATE privilege on the schema
-        PrivilegeChecker::check_create(database, &schema_name)?;
-
         // The reserved-name and duplicate-column guards are USER-facing
         // conformance checks (issue #5614). They are skipped on the trusted
         // load/replay path so the engine's own persisted dump always reloads —
-        // see `execute_for_load`.
+        // see `execute_for_load`. SQLite checks these BEFORE resolving the
+        // database qualifier (e_createtable-1.1.1.3/1.1.1.4:
+        // `CREATE TABLE auxa."sqlite__"(x, y)` reports the reserved-name error
+        // even though `auxa` is never attached), so this block runs ahead of
+        // the "unknown database" check below.
         if !trusted {
             // Reject user attempts to create a table with a reserved name. SQLite
             // reserves the `sqlite_` prefix for its own schema objects and errors
@@ -214,6 +215,24 @@ impl CreateTableExecutor {
                 }
             }
         }
+
+        // SQLite compatibility: a database-qualifier that has not been
+        // ATTACHed (or otherwise does not exist) fails with "unknown database
+        // <name>" (e.g. `CREATE TABLE george.t1(x)` when `george` was never
+        // attached) rather than the internal catalog error text. This mirrors
+        // sqlite3's wording for qualified DDL against an unknown database
+        // (e_createtable-1.2.1.x). ATTACH itself is not supported by VibeSQL
+        // (single-file engine), so any non-main/non-temp qualifier the user
+        // supplies reaches this path.
+        if !database.catalog.schema_exists(&schema_name) {
+            return Err(ExecutorError::SqliteCompatError(format!(
+                "unknown database {}",
+                schema_name
+            )));
+        }
+
+        // Check CREATE privilege on the schema
+        PrivilegeChecker::check_create(database, &schema_name)?;
 
         // Handle CREATE TABLE AS SELECT syntax
         if let Some(query) = &stmt.as_query {

--- a/crates/vibesql-executor/src/delete/integrity.rs
+++ b/crates/vibesql-executor/src/delete/integrity.rs
@@ -792,6 +792,7 @@ fn apply_cascade_child_updates(
         // update/foreign_keys.rs, fkey2-3.1.*).
         let child_schema_for_check = db.catalog.get_table(child_table_name).unwrap().clone();
         crate::update::constraints::ConstraintValidator::new(&child_schema_for_check)
+            .with_check_constraints_ignored(db.ignore_check_constraints())
             .validate_row_skip_uniqueness(child_table_name, &new_row)?;
 
         // SET DEFAULT in particular can rewrite the FK column(s) to a default

--- a/crates/vibesql-executor/src/insert/bulk_transfer.rs
+++ b/crates/vibesql-executor/src/insert/bulk_transfer.rs
@@ -251,8 +251,10 @@ fn execute_bulk_transfer(
             )?;
         }
 
-        // CHECK constraints (if dest has them)
-        if compat_result.validate_check {
+        // CHECK constraints (if dest has them). SQLite compatibility (Part of
+        // #6173, check.test check-4.8): `PRAGMA ignore_check_constraints=ON`
+        // disables CHECK enforcement on INSERT/UPDATE entirely.
+        if compat_result.validate_check && !db.ignore_check_constraints() {
             super::constraints::enforce_check_constraints(dest_schema, &row_values)?;
         }
 

--- a/crates/vibesql-executor/src/insert/on_conflict_update.rs
+++ b/crates/vibesql-executor/src/insert/on_conflict_update.rs
@@ -682,6 +682,7 @@ fn validate_do_update_row(
 ) -> Result<(), ExecutorError> {
     // NOT NULL and CHECK — the per-row half of normal UPDATE validation.
     crate::update::constraints::ConstraintValidator::new(schema)
+        .with_check_constraints_ignored(db.ignore_check_constraints())
         .validate_row_skip_uniqueness(table_name, new_row)?;
 
     // PRIMARY KEY, UNIQUE constraints, and unique indexes (including

--- a/crates/vibesql-executor/src/insert/row_validator.rs
+++ b/crates/vibesql-executor/src/insert/row_validator.rs
@@ -376,6 +376,12 @@ impl<'a> RowValidator<'a> {
         &self,
         row_values: &[vibesql_types::SqlValue],
     ) -> Result<(), ExecutorError> {
+        // SQLite compatibility (Part of #6173, check.test check-4.8): `PRAGMA
+        // ignore_check_constraints=ON` disables CHECK enforcement on
+        // INSERT/UPDATE entirely.
+        if self.db.ignore_check_constraints() {
+            return Ok(());
+        }
         if !self.schema.check_constraints.is_empty() {
             let row = vibesql_storage::Row::new(row_values.to_vec());
             // CHECK context: non-deterministic date/time uses ('now', zero-arg

--- a/crates/vibesql-executor/src/lib.rs
+++ b/crates/vibesql-executor/src/lib.rs
@@ -95,6 +95,11 @@ pub use index_ddl::{
 // non-deterministic column DEFAULT at propose time with **exactly** the
 // semantics the apply-time executor would use when the DEFAULT fires.
 pub use insert::defaults::evaluate_default_expression;
+// `enforce_check_constraints` is re-exported so `PRAGMA integrity_check`
+// (vibesql-cli) can run the SAME CHECK-constraint evaluation the INSERT/UPDATE
+// paths use, gated by `ignore_check_constraints` (Part of #6173, check.test
+// check-4.8/4.8.1), without duplicating the CHECK evaluation logic.
+pub use insert::constraints::enforce_check_constraints;
 pub use insert::{InsertExecutor, InsertOutcome};
 pub use introspection::IntrospectionExecutor;
 pub use memory::QueryArena;

--- a/crates/vibesql-executor/src/update/constraints.rs
+++ b/crates/vibesql-executor/src/update/constraints.rs
@@ -5,12 +5,24 @@ use crate::{errors::ExecutorError, evaluator::ExpressionEvaluator};
 /// Validator for table constraints
 pub struct ConstraintValidator<'a> {
     schema: &'a vibesql_catalog::TableSchema,
+    /// SQLite compatibility (Part of #6173, check.test check-4.8): when true
+    /// (mirrors `PRAGMA ignore_check_constraints=ON`), CHECK constraints are
+    /// not enforced. Defaults to `false`; set via
+    /// [`Self::with_check_constraints_ignored`].
+    ignore_check_constraints: bool,
 }
 
 impl<'a> ConstraintValidator<'a> {
     /// Create a new constraint validator
     pub fn new(schema: &'a vibesql_catalog::TableSchema) -> Self {
-        Self { schema }
+        Self { schema, ignore_check_constraints: false }
+    }
+
+    /// Set whether CHECK constraints should be bypassed, mirroring
+    /// `PRAGMA ignore_check_constraints` (Part of #6173).
+    pub fn with_check_constraints_ignored(mut self, ignore: bool) -> Self {
+        self.ignore_check_constraints = ignore;
+        self
     }
 
     /// Validate all constraints for an updated row
@@ -342,6 +354,9 @@ impl<'a> ConstraintValidator<'a> {
         &self,
         new_row: &vibesql_storage::Row,
     ) -> Result<(), ExecutorError> {
+        if self.ignore_check_constraints {
+            return Ok(());
+        }
         if !self.schema.check_constraints.is_empty() {
             // CHECK context: non-deterministic date/time uses are rejected
             // at evaluation time (SQLite semantics).

--- a/crates/vibesql-executor/src/update/executor.rs
+++ b/crates/vibesql-executor/src/update/executor.rs
@@ -469,7 +469,8 @@ pub(super) fn execute_internal(
         // Validate all constraints (NOT NULL, PRIMARY KEY, UNIQUE, CHECK)
         // For IGNORE: catch constraint violations and skip the row
         // For REPLACE: we've already marked conflicts for deletion, so skip PK/UNIQUE validation
-        let constraint_validator = ConstraintValidator::new(schema);
+        let constraint_validator = ConstraintValidator::new(schema)
+            .with_check_constraints_ignored(database.ignore_check_constraints());
 
         if use_ignore {
             // Non-deterministic date/time uses in index expressions /
@@ -528,7 +529,12 @@ pub(super) fn execute_internal(
         } else if use_replace {
             // For REPLACE: validate NOT NULL and CHECK constraints, but skip PK/UNIQUE
             // since conflicting rows will be deleted
-            validate_non_uniqueness_constraints(schema, table_name, &new_row)?;
+            validate_non_uniqueness_constraints(
+                schema,
+                table_name,
+                &new_row,
+                database.ignore_check_constraints(),
+            )?;
 
             // Non-deterministic date/time uses in index expressions /
             // partial-index predicates abort the statement even under
@@ -1364,6 +1370,7 @@ fn validate_non_uniqueness_constraints(
     schema: &vibesql_catalog::TableSchema,
     table_name: &str,
     new_row: &Row,
+    ignore_check_constraints: bool,
 ) -> Result<(), ExecutorError> {
     // Check NOT NULL constraints
     for (col_idx, col) in schema.columns.iter().enumerate() {
@@ -1379,8 +1386,10 @@ fn validate_non_uniqueness_constraints(
         }
     }
 
-    // Check CHECK constraints
-    if !schema.check_constraints.is_empty() {
+    // Check CHECK constraints. SQLite compatibility (Part of #6173,
+    // check.test check-4.8): `PRAGMA ignore_check_constraints=ON` disables
+    // CHECK enforcement here too.
+    if !ignore_check_constraints && !schema.check_constraints.is_empty() {
         let evaluator = ExpressionEvaluator::new(schema);
 
         for (constraint_name, check_expr) in &schema.check_constraints {
@@ -2048,7 +2057,8 @@ fn execute_update_from(
     // Issue #5144: when `stmt.conflict_clause` is IGNORE or REPLACE, the per-row
     // skip / evict semantics replace the deferred-UNIQUE post-statement pass. The
     // logic mirrors the default UPDATE path at executor.rs:239-468.
-    let constraint_validator = ConstraintValidator::new(schema);
+    let constraint_validator = ConstraintValidator::new(schema)
+        .with_check_constraints_ignored(database.ignore_check_constraints());
 
     // Track rows to delete for REPLACE conflict resolution (before applying updates)
     let mut rows_to_delete_for_replace: Vec<usize> = Vec::new();
@@ -2151,7 +2161,12 @@ fn execute_update_from(
 
                 // NOT NULL + CHECK only (no PK/UNIQUE — those collisions get
                 // resolved by deletion).
-                validate_non_uniqueness_constraints(schema, table_name, &u.new_row)?;
+                validate_non_uniqueness_constraints(
+                    schema,
+                    table_name,
+                    &u.new_row,
+                    database.ignore_check_constraints(),
+                )?;
 
                 // Non-deterministic date/time uses in index expressions /
                 // partial-index predicates abort the statement even under

--- a/crates/vibesql-executor/src/update/fast_path.rs
+++ b/crates/vibesql-executor/src/update/fast_path.rs
@@ -212,6 +212,7 @@ pub(super) fn try_fast_path_update(
     // references untouched columns or the rowid evaluates correctly here.
     if !schema.check_constraints.is_empty() {
         super::constraints::ConstraintValidator::new(schema)
+            .with_check_constraints_ignored(database.ignore_check_constraints())
             .validate_check_constraints(&new_row)?;
     }
 

--- a/crates/vibesql-executor/src/update/foreign_keys.rs
+++ b/crates/vibesql-executor/src/update/foreign_keys.rs
@@ -657,6 +657,7 @@ impl ForeignKeyValidator {
                 // CASCADE-> `ef` landing on `e=5` must trip `CHECK(e!=5)`).
                 let child_schema_for_check = db.catalog.get_table(&table_name).unwrap().clone();
                 crate::update::constraints::ConstraintValidator::new(&child_schema_for_check)
+                    .with_check_constraints_ignored(db.ignore_check_constraints())
                     .validate_row_skip_uniqueness(&table_name, &new_row)?;
 
                 // SET DEFAULT in particular can rewrite the FK column(s) to a

--- a/crates/vibesql-storage/src/database/session.rs
+++ b/crates/vibesql-storage/src/database/session.rs
@@ -275,6 +275,29 @@ impl Database {
         );
     }
 
+    /// Get the ignore_check_constraints PRAGMA setting (SQLite compatibility).
+    ///
+    /// When ON, CHECK constraints are not enforced by INSERT/UPDATE (they are
+    /// silently skipped rather than raising "CHECK constraint failed"). This
+    /// is intended only for loading a schema/data set that is already known to
+    /// violate a CHECK constraint (e.g. to repair it afterwards) — SQLite's own
+    /// docs discourage general use. Defaults to OFF, matching SQLite (`check.test`
+    /// check-4.8/4.8.1).
+    pub fn ignore_check_constraints(&self) -> bool {
+        match self.get_session_variable("IGNORE_CHECK_CONSTRAINTS") {
+            Some(vibesql_types::SqlValue::Integer(n)) => *n != 0,
+            _ => false, // Default: OFF (SQLite compatibility)
+        }
+    }
+
+    /// Set the ignore_check_constraints PRAGMA setting (SQLite compatibility).
+    pub fn set_ignore_check_constraints(&mut self, value: bool) {
+        self.set_session_variable(
+            "IGNORE_CHECK_CONSTRAINTS",
+            vibesql_types::SqlValue::Integer(if value { 1 } else { 0 }),
+        );
+    }
+
     // ============================================================================
     // SQLite stat1 Storage (SQLite Compatibility)
     // ============================================================================

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -2945,7 +2945,7 @@ proc execsql {sql {db ""}} {
                 }
                 continue  ;# Check for more statements
             }
-            if {[regexp -nocase {^PRAGMA\s+(?:\w+\.)?(full_column_names|short_column_names|case_sensitive_like|reverse_unordered_selects|integrity_check|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|recursive_triggers|table_info|data_version|collation_list|index_list|index_xinfo|index_info|auto_vacuum|temp_store|encoding|synchronous|cache_size|default_cache_size|cache_spill|user_version|application_id|schema_version|lock_status|filename)} [string trim $sql]]} {
+            if {[regexp -nocase {^PRAGMA\s+(?:\w+\.)?(full_column_names|short_column_names|case_sensitive_like|reverse_unordered_selects|integrity_check|foreign_key_list|foreign_key_check|foreign_keys|defer_foreign_keys|recursive_triggers|ignore_check_constraints|table_info|data_version|collation_list|index_list|index_xinfo|index_info|auto_vacuum|temp_store|encoding|synchronous|cache_size|default_cache_size|cache_spill|user_version|application_id|schema_version|lock_status|filename)} [string trim $sql]]} {
                 # This PRAGMA is supported (with =value) - stop stripping
                 break
             } else {


### PR DESCRIPTION
## Summary

Partial increment on the CREATE TABLE / schema-definition semantics family (#6173). Fixes two contained, reproducible correctness gaps found while investigating `e_createtable.test` and `check.test`:

1. **Unknown-database error wording**: `CREATE TABLE george.t1(x)` (or any DDL against a database qualifier VibeSQL never attached — VibeSQL does not support `ATTACH`) raised an internal `Storage error: Schema error: SchemaNotFound("george")` instead of SQLite's `unknown database george`.
2. **`PRAGMA ignore_check_constraints`** was entirely unimplemented — the pragma parsed but had no effect, so `UPDATE ... ` under `ignore_check_constraints=ON` still raised `CHECK constraint failed` instead of bypassing enforcement, and `PRAGMA integrity_check` never actually validated CHECK constraints against live data (it unconditionally returned `ok`).

## Changes

- `crates/vibesql-executor/src/create_table.rs`: when the qualified schema/database in a `CREATE TABLE` statement doesn't exist, raise `unknown database <name>` (SQLite's exact wording) instead of the internal catalog error. Ordered *after* the reserved-name/duplicate-column guards to match SQLite's check precedence (`CREATE TABLE auxa."sqlite__"(x,y)` must still report the reserved-name error even though `auxa` was never attached).
- `crates/vibesql-storage/src/database/session.rs`: add `ignore_check_constraints()` / `set_ignore_check_constraints()` session-variable-backed PRAGMA state, following the existing `foreign_keys_enabled`/`recursive_triggers` pattern.
- `crates/vibesql-cli/src/executor/mod.rs`: wire the `IGNORE_CHECK_CONSTRAINTS` PRAGMA (get/set), and make `PRAGMA integrity_check` actually scan every row of every table against its CHECK constraints — reporting `CHECK constraint failed in <table>` per violating row — unless `ignore_check_constraints` is ON, matching SQLite's coupling of the two.
- `crates/vibesql-executor/src/insert/row_validator.rs`, `insert/bulk_transfer.rs`, `insert/on_conflict_update.rs`, `update/constraints.rs` (new `with_check_constraints_ignored` builder method), `update/executor.rs`, `update/fast_path.rs`, `update/foreign_keys.rs`, `delete/integrity.rs`: gate every CHECK-constraint enforcement call site (plain INSERT/UPDATE, REPLACE conflict resolution, upsert DO UPDATE, and FK cascade rewrites) behind `ignore_check_constraints`.
- `crates/vibesql-executor/src/lib.rs`: re-export `insert::constraints::enforce_check_constraints` so the CLI's `integrity_check` handler can reuse the exact same CHECK-evaluation logic the DML paths use, instead of duplicating it.
- `scripts/tester_vibesql.tcl`: add `ignore_check_constraints` to the shim's supported-pragma allowlist — it was previously being silently stripped from test SQL before reaching the CLI.

## Acceptance Criteria Verification

This is a **partial increment** of a large family issue (~292 certified failures across 7 files); the acceptance criterion is incremental progress with no regressions, not full closure.

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `check.test` improves, no regressions | ✅ | 92 tests: 83→85 passed (9→7 failed). The 2 newly-passing are `check-4.8`/`check-4.8.1` (the `ignore_check_constraints` + `integrity_check` scenario). Remaining 7 failures (`7.2`-`7.8`) require a TCL-registered custom SQL function (`db func myfunc`) unreachable from the SQL CLI — Bucket-A, unrelated to this fix. |
| `e_createtable.test` improves, no regressions | ✅ | 528 tests: 156→154 failed. `e_createtable-1.2.1.1`/`1.2.1.2` (the "unknown database" wording tests) now pass; verified via full before/after failing-test-ID diff that nothing else newly broke. |
| No regression in adjacent DDL/DML test files | ✅ | Re-ran `strict1.test` (49/49, unchanged), `tableopts.test` (10/10, unchanged), `gencol1.test` (170/174, unchanged), `autoinc.test` (67/87, unchanged — remaining failures are a documented TEMP-table harness limitation), `table.test` (unchanged: same 3 pre-existing failures + pre-existing table-15 harness timeout), `alter.test` (same failure set — the reworded lines are all pre-existing `ATTACH`-dependent failures, `ATTACH` being unsupported by VibeSQL). |
| Engine compiles clean | ✅ | `cargo check --workspace` and `cargo build --release --bin vibesql` both succeed with no new warnings. |
| Unit tests pass | ✅ | `cargo test -p vibesql-executor --lib`: 3646/3647 passed; the one failure (`test_parallel_nested_loop_large_dataset`, a 300s join-performance timeout) reproduces in isolation on this shared/loaded machine and is unrelated to this diff (no join code touched). `cargo test -p vibesql-storage --lib session`: 6/6 passed. |

## Test Plan

- [x] Manual repro: `CREATE TABLE george.t1(x,y);` → `unknown database george` (was `Storage error: Schema error: SchemaNotFound("george")`)
- [x] Manual repro: `PRAGMA ignore_check_constraints=ON; UPDATE t4 SET x=0,y=1;` bypasses CHECK; `PRAGMA integrity_check` then reports `ok` while ON and `CHECK constraint failed in t4` once turned OFF — matches `check.test` check-4.8/4.8.1 exactly.
- [x] `make test-tcl-file FILE=check.test` (85/92 passed, up from 83/92)
- [x] `make test-tcl-file FILE=e_createtable.test` (374/528 passed, up from 372/528; net 2 fixed, 0 regressed via full before/after diff)
- [x] `make test-tcl-file FILE=strict1.test`, `tableopts.test`, `gencol1.test`, `autoinc.test`, `table.test`, `alter.test` — no regressions
- [x] `cargo check --workspace`
- [x] `cargo build --release --bin vibesql`
- [x] `cargo test -p vibesql-executor --lib`, `cargo test -p vibesql-storage --lib session`

## What remains open in #6173

This is a partial increment — the family issue stays open. Remaining known gaps (not addressed here):
- `check.test` 7.2-7.8: TCL-registered custom SQL function, Bucket-A/out-of-scope.
- `e_createtable.test`: 154 failures remain, mostly `ATTACH`-dependent (VibeSQL doesn't support multi-database `ATTACH`) plus assorted syntax-error-wording and `sqlite3_prepare_v2`/C-API gaps.
- `autoinc.test`: 8 remaining failures are a documented TEMP-table harness limitation (shim demotes `CREATE TEMP TABLE` to persistent).
- `gencol1.test`: 4 remaining failures (`15.10`, `15.20`, `23.2`, `23.3`) not investigated in this PR.
- `table.test`: a pre-existing performance issue (`table-15`: 2000 `CREATE`/`DROP TABLE` statements inside one transaction) causes the harness's per-statement trial-check mechanism to time out at 1200s; this looks like real superlinear-scaling engine cost as schema size grows (verified independently of the harness — a single `vibesql` process creating N tables scales worse than linearly), not purely a harness artifact, but is out of scope for this PR and may warrant its own issue.

Part of #6173