### PR TITLE
fix(tcl): surface count_changes row for mid-transaction DML in TCL shim

### DIFF
--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -231,6 +231,14 @@ set ::txn_trial_db ""
 # every flush and whenever a fresh transaction opens.
 set ::txn_had_tolerated_error 0
 
+# Set by trial_check_in_transaction's success path when `PRAGMA
+# count_changes=ON` is active and the statement being trial-checked is a DML
+# statement: the affected-row count SQLite would report for THAT statement's
+# execution, even though the shim defers its real execution to the eventual
+# COMMIT/ROLLBACK flush. `{}` (no row) otherwise. See trial_check_in_transaction
+# and its caller in execsql's `$::in_transaction` branch (Part of #6170).
+set ::txn_dml_count_result {}
+
 # PRAGMA state tracking - persists across process invocations
 # These are prepended to every SQL execution to maintain consistent state
 set ::pragma_full_column_names 0   ;# Default: OFF
@@ -2310,7 +2318,11 @@ proc trial_check_in_transaction {new_sql} {
     # eventual COMMIT/ROLLBACK (the normal flush_batch path).
     #
     # Returns: a TCL error (via `error ...`) if the trial reports an error,
-    # otherwise returns silently.
+    # otherwise returns silently. On success, also sets
+    # $::txn_dml_count_result (see below) so the caller can surface a
+    # SQLite-accurate `PRAGMA count_changes=ON` row for THIS statement even
+    # though its real execution is deferred to the eventual COMMIT/ROLLBACK
+    # flush.
     #
     # PERFORMANCE GUARD: re-executing the whole accumulated batch on every
     # statement is O(n^2) over the transaction length. For large transactions
@@ -2321,6 +2333,11 @@ proc trial_check_in_transaction {new_sql} {
     # statement (O(n) total). Before #5820 above-cap statements were not
     # checked at all, silently auto-passing ~9,900 fuzz.test statements. See
     # $::trial_check_max_batch and trial_check_incremental for the rationale.
+    #
+    # Reset up front so a stale value from a previous call can never leak
+    # into this statement's result (including the large-batch early return
+    # below, which does not compute a count_changes row at all).
+    set ::txn_dml_count_result {}
     if {[llength $::sql_batch] >= $::trial_check_max_batch} {
         trial_check_incremental $new_sql
         return
@@ -2442,6 +2459,32 @@ proc trial_check_in_transaction {new_sql} {
         set ::txn_survived_trial_error \
             [regexp {(?m)^Transaction rolled back} $result]
         error [translate_error_to_sqlite $new_err]
+    }
+
+    # Success: the trial (batch + $new_sql + ROLLBACK) ran cleanly. When
+    # `PRAGMA count_changes=ON` is active, real SQLite returns a one-row
+    # result carrying the affected-row count from THIS statement's own
+    # execution — even mid-transaction, since SQLite executes statement by
+    # statement over one persistent connection. The shim's per-batch process
+    # model instead defers $new_sql's real execution to the eventual
+    # COMMIT/ROLLBACK flush, so without this the caller can only report `{}`
+    # for a mid-transaction DML statement (fkey2-1.4.* expects `{0 1}`, e.g.
+    # a bare `INSERT`/`UPDATE`/`DELETE` result of "1 row changed").
+    #
+    # `build_pragma_prefix` already replayed `PRAGMA count_changes=N;` into
+    # this trial's prefix (see the call above), so the CLI emitted its own
+    # native count_changes row for every DML statement in the trial,
+    # including $new_sql — which is the LAST statement before the trailing
+    # ROLLBACK (batch order is preserved, and ROLLBACK itself never emits a
+    # data row). `parse_result` flattens every emitted row across the whole
+    # trial script into one list in execution order, so the new statement's
+    # own count is simply the tail of that list.
+    if {$::pragma_count_changes != 0
+            && [is_dml_statement [string toupper [string trim $new_sql]]]} {
+        set trial_parsed [parse_result $result]
+        if {[llength $trial_parsed] > 0} {
+            set ::txn_dml_count_result [list [lindex $trial_parsed end]]
+        }
     }
 }
 
@@ -3241,6 +3284,7 @@ proc execsql {sql {db ""}} {
         # RAISE(ROLLBACK) closes the transaction, so we drop the statement and
         # end the batched transaction (its prior statements were undone too).
         set ::txn_survived_trial_error 0
+        set ::txn_dml_count_result {}
         if {[catch {trial_check_in_transaction $sql} trial_err]} {
             if {$::txn_survived_trial_error} {
                 set ::txn_had_tolerated_error 1
@@ -3254,7 +3298,11 @@ proc execsql {sql {db ""}} {
             error $trial_err
         }
         lappend ::sql_batch $sql
-        return {}
+        # PRAGMA count_changes=ON: surface the affected-row count computed by
+        # trial_check_in_transaction's success path (see its doc comment)
+        # instead of the empty result SQLite's real per-statement execution
+        # would never produce for a DML statement.
+        return $::txn_dml_count_result
     }
 
     # Direct execution for non-transaction SQL


### PR DESCRIPTION
## Summary

Fixes a TCL-harness gap (not an engine bug) that was masquerading as 17 FK-conformance failures in the `fkey2.test` dense referential-action matrix.

`scripts/tester_vibesql.tcl` runs each `execsql`/`catchsql` call as a fresh CLI process against a persistent DB file. Since a transaction can't stay open across process boundaries, the shim batches every statement from `BEGIN` to `COMMIT`/`ROLLBACK` into one deferred flush, and a statement submitted while `$::in_transaction` is true previously always returned `{}` at the point it was submitted — real SQLite, by contrast, executes statement-by-statement over one persistent connection and returns each statement's own result immediately, even mid-transaction.

This is invisible for ordinary DML (no return value expected), but `PRAGMA count_changes=ON` makes every successful INSERT/UPDATE/DELETE return a one-row result with the affected-row count — and the shim had no way to produce that count for a statement whose real execution is deferred to the next flush. `fkey2-1.4.*` re-runs `fkey2-1.3.*`'s exact statements (which pass) wrapped in an explicit `BEGIN`/`COMMIT` per test, expecting `{0 1}` (status 0, one row changed) but getting `{0 {}}`.

## Changes

- `trial_check_in_transaction` (which already replays the accumulated batch + the new statement + a trailing `ROLLBACK` against a throwaway DB copy purely for error-detection) now also captures the count-changes row from that same trial run on its success path, storing it in a new global `::txn_dml_count_result`. Because `build_pragma_prefix` already replays `PRAGMA count_changes=N;` into the trial's prefix, and the new statement is the last DML statement in trial order (before the non-emitting trailing `ROLLBACK`), its own count is simply the last row of `parse_result`'s flattened output.
- `execsql`'s `$::in_transaction` branch now returns `$::txn_dml_count_result` instead of unconditionally returning `{}`.
- `::txn_dml_count_result` is reset to `{}` at the top of every `trial_check_in_transaction` call (including the large-batch/incremental early-return path) so a stale value can never leak into an unrelated statement's result.

No engine/Rust code changed — this is entirely a TCL test-harness fix (`scripts/tester_vibesql.tcl`).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| `fkey2.test` failures reduced | ✅ | 97 → 80 failed (all 17 `fkey2-1.4.*` now pass); `make test-tcl-file FILE=fkey2.test` |
| No regression in `e_fkey.test` | ✅ | `e_fkey.test` does not use `PRAGMA count_changes` (`grep -c count_changes` = 0); ~76 failures unchanged (run compromised by machine-load timeout at 1200s, unrelated to this change) |
| No regression in small FK files | ✅ | `fkey1.test` (2 failed), `fkey3.test` (0 failed, 100%), `fkey4.test` (2 failed), `fkey7.test` (7 failed) — none use `count_changes`, counts unaffected by this change |
| `without_rowid3.test` (shares fkey2's body) also improves | ✅ | 69 failed post-fix (down from a pre-fix run with the equivalent `without_rowid3-1.4.*` block failing); no `without_rowid3-1.4.*` failures remain |
| No regression in other `count_changes`-using files | ✅ | `pragma.test` (53 failed before AND after — `git stash` A/B compared), `delete.test` (0 failed), `update.test` (0 failed), `conflict.test`/`conflict2.test` (0 failed, both skip-only), `upsert1.test` (1 failed before AND after — pre-existing, unrelated `NOT NULL constraint` issue, confirmed via `git stash` A/B) |

## Test Plan

```
make test-tcl-file FILE=fkey2.test           # 1083→1100 passed, 97→80 failed
make test-tcl-file FILE=without_rowid3.test  # equivalent 1.4.* block now passes, 69 failed (no 1.4.* left)
./scripts/tcltest test e_fkey.test            # unaffected (no count_changes usage)
./scripts/tcltest test fkey1.test / fkey3.test / fkey4.test / fkey7.test   # unaffected
./scripts/tcltest test pragma.test / delete.test / update.test / conflict.test / conflict2.test / upsert1.test  # A/B via git stash: no regressions
```

## Remaining work on #6170

This is one increment of a large family issue (13 prior PRs already landed against it). Remaining known failure clusters after this PR:
- `fkey2.test`: 80 failures remain — SAVEPOINT/deferred-FK edge cases (`fkey2-2.*`), ALTER/DROP TABLE (`fkey2-14.*`), and others.
- `e_fkey.test`: ~76 failures remain (this run was compromised by a 1200s harness timeout under machine load; a clean re-run on a quiet machine is needed for an exact count) — deferred-constraint semantics (`e_fkey-15.*`), `PRAGMA foreign_keys` edge cases (`e_fkey-6.*`).
- `fkey1.test` (2), `fkey4.test` (2), `fkey7.test` (7) failures remain, unrelated to this change.

`fkey3.test` is now fully passing (100%).

Part of #6170