### PR TITLE
fix(tcl,executor): per-statement DQS_DDL/DML gating + double-quoted "no such column" hint

### DIFF
--- a/crates/vibesql-executor/src/constraint_validator.rs
+++ b/crates/vibesql-executor/src/constraint_validator.rs
@@ -40,6 +40,28 @@ impl ExpressionVisitor for ParameterFinder {
     }
 }
 
+/// Builds the display text for a failed column-reference resolution,
+/// appending SQLite's own hint when the reference is an *unqualified*,
+/// quoted (double-quoted/backtick/bracket-delimited) identifier:
+/// `"X" - should this be a string literal in single-quotes?`.
+///
+/// SQLite emits this exact hint (R-... evidence in quote.test) because a
+/// delimited identifier that fails to resolve as a column may have been
+/// intended as a single-quoted string literal instead — e.g.
+/// `CHECK (c != "null")` with legacy double-quoted-string handling disabled
+/// (`SQLITE_DBCONFIG_DQS_DDL = 0`) raises `no such column: "null" - should
+/// this be a string literal in single-quotes?` rather than silently treating
+/// `"null"` as the string `'null'`. Only applied to unqualified references:
+/// a table-qualified miss (`t2.x` naming a foreign table) is a different
+/// failure class with no such hint in SQLite (check-3.5).
+fn quoted_column_display(col_id: &vibesql_ast::ColumnIdentifier) -> String {
+    if col_id.table_canonical().is_none() && col_id.is_column_quoted() {
+        format!("\"{}\" - should this be a string literal in single-quotes?", col_id.display())
+    } else {
+        col_id.display().to_string()
+    }
+}
+
 /// True if `expr` contains any bind parameter. Used to reject
 /// `CHECK( x < :abc )` / `CHECK( x < ? )` at CREATE TABLE time.
 fn expression_has_parameter(expr: &Expression) -> bool {
@@ -83,7 +105,7 @@ impl ExpressionVisitor for CheckColumnResolver<'_> {
                 || col == "_rowid_"
                 || col.eq_ignore_ascii_case("oid");
             if !is_rowid_alias && !self.columns.contains(col) {
-                self.unresolved = Some(col_id.display().to_string());
+                self.unresolved = Some(quoted_column_display(col_id));
                 return VisitResult::Stop;
             }
         }
@@ -629,6 +651,32 @@ mod tests {
         let err = validate_check_constraint_columns("t3", &cols, &checks).unwrap_err();
         match err {
             ExecutorError::NoSuchColumn { column_ref } => assert_eq!(column_ref, "q"),
+            other => panic!("expected NoSuchColumn, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_check_columns_quoted_unknown_column_gets_sqlite_hint() {
+        // quote-2.1.1: CHECK(c != "null") with "null" resolving to neither a
+        // column nor a rowid alias -> SQLite appends its "should this be a
+        // string literal" hint because the reference was double-quoted.
+        let cols = vec![col("a"), col("b"), col("c")];
+        let checks = vec![(
+            String::new(),
+            Expression::BinaryOp {
+                left: Box::new(col_ref("c")),
+                op: vibesql_ast::BinaryOperator::NotEqual,
+                right: Box::new(Expression::ColumnRef(vibesql_ast::ColumnIdentifier::quoted(
+                    "null",
+                ))),
+            },
+        )];
+        let err = validate_check_constraint_columns("xyz", &cols, &checks).unwrap_err();
+        match err {
+            ExecutorError::NoSuchColumn { column_ref } => assert_eq!(
+                column_ref,
+                "\"null\" - should this be a string literal in single-quotes?"
+            ),
             other => panic!("expected NoSuchColumn, got {other:?}"),
         }
     }

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -261,9 +261,16 @@ array set ::pragma_application_id_cookie {} ;# db-file-path -> last raw text set
 array set ::pragma_schema_version_cookie {} ;# db-file-path -> running schema_version cookie: last explicit set PLUS every DDL/VACUUM auto-increment seen since (persists across reconnect to the SAME file, like SQLite's header cookie; #6175)
 
 # DQS (Double-Quoted Strings) mode tracking
-# When enabled, double-quoted strings are treated as string literals instead of identifiers
-# This emulates SQLite's deprecated DQS_DML mode (SQLITE_DBCONFIG_DQS_DML)
+# When enabled, double-quoted strings are treated as string literals instead of identifiers.
+# SQLite exposes TWO independent legacy toggles that must be tracked separately:
+#   SQLITE_DBCONFIG_DQS_DDL - governs CREATE TABLE/INDEX/VIEW/TRIGGER (DDL) statements
+#   SQLITE_DBCONFIG_DQS_DML - governs SELECT/INSERT/UPDATE/DELETE (DML) statements
+# A single batch can legitimately set these to different values (quote.test sets
+# DDL=0/DML=1 in the same block), so conversion must be applied per-statement,
+# not as a single blanket pass over the whole SQL blob — see
+# apply_dqs_mode_conversion below (#6172).
 set ::dqs_dml_mode 0  ;# Default: OFF (double quotes are identifiers)
+set ::dqs_ddl_mode 0  ;# Default: OFF (double quotes are identifiers)
 
 # TEMP TABLE emulation — see strip_temp_table_keyword (below) for the rationale.
 # SQLite keeps a single connection open for the whole test file, so a TEMP table
@@ -1587,6 +1594,52 @@ proc convert_dqs_to_single_quotes {sql} {
     }
 
     return $result
+}
+
+# Apply DQS (Double-Quoted Strings) mode conversion on a PER-STATEMENT basis.
+#
+# SQLite exposes two independent legacy toggles - SQLITE_DBCONFIG_DQS_DDL
+# (governs CREATE TABLE/INDEX/VIEW/TRIGGER statements) and
+# SQLITE_DBCONFIG_DQS_DML (governs SELECT/INSERT/UPDATE/DELETE statements).
+# A single `db eval`/`execsql` batch can legitimately mix DDL and DML
+# statements with the two toggles set to DIFFERENT values (quote.test 2.x
+# sets DDL=0/DML=1 in the same block, then runs a CREATE TABLE ... CHECK
+# statement expecting the double-quoted string inside it to still be
+# resolved strictly as a column reference). A blanket "convert the whole SQL
+# blob if dqs_dml_mode" pass — the previous behavior — incorrectly applies
+# DML-mode conversion to DDL statements whenever DML mode happens to be on,
+# which silently turns an expected `no such column: "X"` parse-time failure
+# into a no-op success (#6172).
+#
+# Classifies each top-level statement (via split_sql_statements, which is
+# already trigger-body aware) as DDL (starts with CREATE/ALTER/DROP) or
+# non-DDL, and only converts a statement's double-quoted strings when the
+# toggle matching ITS OWN kind is enabled.
+proc apply_dqs_mode_conversion {sql} {
+    if {!$::dqs_ddl_mode && !$::dqs_dml_mode} {
+        # Fast path: neither toggle enabled (the overwhelming common case) -
+        # nothing to do, and no need to split/rejoin the SQL text at all.
+        return $sql
+    }
+    set out {}
+    foreach stmt [split_sql_statements $sql] {
+        set trimmed [string trimleft $stmt]
+        set is_ddl [regexp -nocase {^(CREATE|ALTER|DROP)\y} $trimmed]
+        if {$is_ddl} {
+            if {$::dqs_ddl_mode} {
+                lappend out [convert_dqs_to_single_quotes $stmt]
+            } else {
+                lappend out $stmt
+            }
+        } else {
+            if {$::dqs_dml_mode} {
+                lappend out [convert_dqs_to_single_quotes $stmt]
+            } else {
+                lappend out $stmt
+            }
+        }
+    }
+    return [join $out ";\n"]
 }
 
 # Build PRAGMA prefix to prepend to SQL for consistent session state
@@ -2952,11 +3005,9 @@ proc execsql {sql {db ""}} {
     # We use stack-walking substitution to find variables in outer scopes (for loops, etc.)
     set sql [substitute_tcl_vars $sql]
 
-    # Apply DQS (Double-Quoted Strings) mode conversion if enabled
-    # When DQS mode is on, double-quoted strings are treated as string literals
-    if {$::dqs_dml_mode} {
-        set sql [convert_dqs_to_single_quotes $sql]
-    }
+    # Apply DQS (Double-Quoted Strings) mode conversion if enabled, per-statement
+    # (DDL vs DML use independent toggles — see apply_dqs_mode_conversion, #6172)
+    set sql [apply_dqs_mode_conversion $sql]
 
     # Demote CREATE TEMP TABLE -> CREATE TABLE so temp tables persist across the
     # shim's per-batch process model (see strip_temp_table_keyword, #5512).
@@ -3744,10 +3795,9 @@ proc execsql_with_headers {sql {db ""}} {
     # We use stack-walking substitution to find variables in outer scopes (for loops, etc.)
     set sql [substitute_tcl_vars $sql]
 
-    # Apply DQS (Double-Quoted Strings) mode conversion if enabled
-    if {$::dqs_dml_mode} {
-        set sql [convert_dqs_to_single_quotes $sql]
-    }
+    # Apply DQS (Double-Quoted Strings) mode conversion if enabled, per-statement
+    # (DDL vs DML use independent toggles — see apply_dqs_mode_conversion, #6172)
+    set sql [apply_dqs_mode_conversion $sql]
 
     # Demote CREATE TEMP TABLE -> CREATE TABLE (see strip_temp_table_keyword, #5512).
     set sql [strip_temp_table_keyword $sql]
@@ -3793,10 +3843,9 @@ proc execsql2 {sql {db ""}} {
     # We use stack-walking substitution to find variables in outer scopes (for loops, etc.)
     set sql [substitute_tcl_vars $sql]
 
-    # Apply DQS (Double-Quoted Strings) mode conversion if enabled
-    if {$::dqs_dml_mode} {
-        set sql [convert_dqs_to_single_quotes $sql]
-    }
+    # Apply DQS (Double-Quoted Strings) mode conversion if enabled, per-statement
+    # (DDL vs DML use independent toggles — see apply_dqs_mode_conversion, #6172)
+    set sql [apply_dqs_mode_conversion $sql]
 
     # Demote CREATE TEMP TABLE -> CREATE TABLE (see strip_temp_table_keyword, #5512).
     set sql [strip_temp_table_keyword $sql]
@@ -8251,6 +8300,7 @@ proc sqlite3 {db args} {
         set ::pragma_synchronous_raw ""
         set ::pragma_cache_size_raw ""
         set ::dqs_dml_mode 0  ;# Reset DQS mode for new database
+        set ::dqs_ddl_mode 0  ;# Reset DQS mode for new database
         set ::last_insert_rowid 0  ;# Fresh connection: last_insert_rowid() is 0 (#5843)
     }
 
@@ -8865,19 +8915,26 @@ proc permutation {} {
 proc sqlite3_db_config {args} {
     # SQLite database configuration
     # This is used to set/get various database configuration options
-    # We specifically handle SQLITE_DBCONFIG_DQS_DML for double-quoted string mode
+    # We specifically handle SQLITE_DBCONFIG_DQS_DDL/DQS_DML for double-quoted
+    # string mode. These are independent toggles: DDL governs CREATE
+    # TABLE/INDEX/VIEW/TRIGGER statements, DML governs everything else
+    # (SELECT/INSERT/UPDATE/DELETE) — see apply_dqs_mode_conversion (#6172).
     #
-    # Usage: sqlite3_db_config db SQLITE_DBCONFIG_DQS_DML value
+    # Usage: sqlite3_db_config db SQLITE_DBCONFIG_DQS_DDL value
+    #        sqlite3_db_config db SQLITE_DBCONFIG_DQS_DML value
     # When value is 1: double-quoted strings are treated as string literals
     # When value is 0: double-quoted strings are treated as identifiers (default)
 
-    # Check if this is a DQS_DML configuration
     if {[llength $args] >= 3} {
         set config_name [lindex $args 1]
         set config_value [lindex $args 2]
 
         if {$config_name eq "SQLITE_DBCONFIG_DQS_DML"} {
             set ::dqs_dml_mode $config_value
+            return 0
+        }
+        if {$config_name eq "SQLITE_DBCONFIG_DQS_DDL"} {
+            set ::dqs_ddl_mode $config_value
             return 0
         }
     }


### PR DESCRIPTION
## Summary

- The TCL conformance shim only tracked `SQLITE_DBCONFIG_DQS_DML` and applied its double-quoted-string-to-single-quoted-string conversion as a single blanket pass over an entire SQL batch. `SQLITE_DBCONFIG_DQS_DDL` was silently ignored. A batch that sets `DDL=0` / `DML=1` (quote.test's canonical pattern) therefore wrongly applied DML-mode conversion to DDL statements too, turning an expected `no such column: "X"` CREATE TABLE/INDEX failure into a silent, incorrect success.
- Fixed by tracking `dqs_ddl_mode` and `dqs_dml_mode` as independent toggles and applying the conversion **per-statement** (classified DDL vs non-DDL via the existing trigger-body-aware `split_sql_statements` helper), matching real SQLite's per-statement-kind DQS semantics.
- Separately, the CHECK-constraint column resolver (`constraint_validator.rs`) now appends SQLite's `- should this be a string literal in single-quotes?` hint when an unresolved column reference is unqualified and quoted (double-quoted/backtick/bracket) — matching SQLite's own diagnostic for exactly this ambiguity (a delimited identifier that fails to resolve as a column may have been intended as a string literal).

## Changes

- `scripts/tester_vibesql.tcl`:
  - Added `::dqs_ddl_mode` alongside the existing `::dqs_dml_mode`, reset on new-database open.
  - `sqlite3_db_config` now handles `SQLITE_DBCONFIG_DQS_DDL` (previously ignored).
  - New `apply_dqs_mode_conversion` proc: splits a SQL batch into top-level statements, classifies each as DDL (`CREATE`/`ALTER`/`DROP`) or not, and only converts double-quoted strings in a statement when the toggle matching *that statement's own kind* is enabled.
  - The three former blanket-conversion call sites (`execsql`, `execsql_with_headers`, `execsql2`) now call `apply_dqs_mode_conversion` instead.
- `crates/vibesql-executor/src/constraint_validator.rs`:
  - New `quoted_column_display` helper: for an unqualified, quoted `ColumnIdentifier` that fails CHECK-constraint column resolution, returns `"X" - should this be a string literal in single-quotes?"` instead of the bare name.
  - `CheckColumnResolver` uses it when recording the unresolved column reference.
  - New unit test `test_check_columns_quoted_unknown_column_gets_sqlite_hint` locks in the new hint text; existing tests (`test_check_columns_unknown_column_rejected` unquoted, `test_check_columns_foreign_table_qualifier_rejected` qualified) confirm the hint is *not* added in those cases, matching SQLite (check-3.3/check-3.5 have no hint).

## Acceptance Criteria Verification

- `quote.test`: 15/29 → 17/29 passing. Fixed: `quote-2.1.1` (CHECK constraint column hint) and `quote-3.5` (DQS_DDL-gated CREATE INDEX expression argument, previously mis-converted). No new failures introduced.
- Remaining `quote.test` failures (`2.1.2`-`2.1.4`, `2.2`-`2.5`, `3.0`-`3.4`) are out of scope for this increment: `2.1.2`-`2.1.4`/`3.0`-`3.4` need the same SQLite hint threaded through the *CREATE INDEX* column-resolution error path (a different, currently non-SQLite-compatible `ColumnNotFound` message format used broadly across the executor — a larger, separate change) and `2.2`-`2.5`/`3.5`'s sibling test 3.5's setup depend on `PRAGMA writable_schema` bypassing schema validation entirely (an already-documented out-of-scope feature, same class as the `e_reindex` writable-schema harness).
- No regressions in satellite files that also exercise `SQLITE_DBCONFIG_DQS_DDL`/`DQS_DML`: `check.test` (85/92 passing, unchanged — sets DDL=DML so behavior-preserving), `alterqf.test` (2/14, pre-existing gaps unrelated to DQS, unchanged), `altercol.test` (187/218, pre-existing gaps unrelated to DQS, unchanged). `altermalloc3.test` is an existing whole-file skip (fault-injection harness), unaffected.
- `like3.test` (141/141), `istrue.test` (38/38), `literal.test` (96/96) already at 100% from prior increments; `nan.test`/`types3.test` remain whole-file capability skips (C-API-bound setup, no real failures); confirmed via fresh re-runs, not touched by this PR.
- `e_expr.test` (4903/5144, 234 real failures) was investigated in depth: the dominant residual cluster (~180 tests, section `e_expr-12.3.*`) cascades from a file-scope `ATTACH ... AS dbname; CREATE TABLE dbname.tblname(...)` that fails outright (VibeSQL has no multi-database ATTACH support) — genuinely out of scope for a single increment (tracked separately, same class as other ATTACH-dependent skips). The remaining clusters are TCL-registered custom-function/collation C-API bridging gaps (`db func`/`db collate`, inherent to the shim's process-per-batch architecture) or a `SQLITE_MAX_VARIABLE_NUMBER` cross-parameter-kind enforcement gap — noted for a future increment, not touched here.
- `regexp1.test`/`regexp2.test` were investigated as a candidate but found architecturally out of scope for this increment: `e_expr.test` explicitly asserts `regexp()` does **not** exist by default (`no such function: regexp`, evidence R-41650-20872) unless an extension is loaded at runtime, so a blanket built-in `regexp()`/`regexpi()` implementation would regress that test. Implementing it correctly needs session-scoped dynamic function registration keyed off `load_static_extension db regexp` — a larger feature, noted for a future increment.

## Test Plan

- `cargo check -p vibesql-executor` — clean.
- Rebuilt `./target/release/vibesql` and re-ran the affected TCL files against it directly (native-tcl mode):
  - `make test-tcl-file FILE=quote.test` — 17/29 (was 15/29).
  - `make test-tcl-file FILE=check.test` — 85/92 (unchanged, pre-existing custom-function gaps only).
  - `make test-tcl-file FILE=alterqf.test` — 2/14 (unchanged, pre-existing gaps only).
  - `make test-tcl-file FILE=altercol.test` — 187/218 (unchanged, pre-existing gaps only).
  - `make test-tcl-file FILE=altermalloc3.test` — unaffected whole-file skip.
- Added `crates/vibesql-executor/src/constraint_validator.rs::test_check_columns_quoted_unknown_column_gets_sqlite_hint` (unit-level regression coverage for the new hint text).

## Out of scope for this slice (for the next builder)

- `quote.test` `2.1.2`-`2.1.4`/`3.0`-`3.4`: thread the same SQLite hint through the CREATE INDEX / ALTER TABLE DROP COLUMN index-check column-resolution error paths (currently a different, non-SQLite-compatible message format).
- `quote.test` `2.2`-`2.5`/select7.test's DQS-hint test: depend on `PRAGMA writable_schema` bypassing schema validation — separate, larger feature.
- `e_expr.test`'s ~180-test `12.3.*` cluster: needs real multi-database `ATTACH` support — a mini-epic on its own.
- `e_expr.test`'s custom-function/collation clusters (`var`, `ceval`, `x`, `reverse` collation, etc.): TCL-registered UDF/collation C-API bridging, architecturally out of scope for the shim's process-per-batch model.
- `regexp1.test`/`regexp2.test`: session-scoped dynamic `regexp()`/`regexpi()` registration keyed off `load_static_extension`, to avoid regressing `e_expr.test`'s "no default regexp()" assertions.

Part of #6172