### PR TITLE
fix(autoinc): route sqlite_sequence bookkeeping to the table's own database

### DIFF
--- a/crates/vibesql-executor/src/autoincrement.rs
+++ b/crates/vibesql-executor/src/autoincrement.rs
@@ -58,10 +58,42 @@ fn sqlite_sequence_table_schema() -> TableSchema {
     schema
 }
 
-/// Lazily create the `sqlite_sequence` table in the CURRENT schema if it does
-/// not already exist. Safe to call unconditionally — a no-op when the table
-/// is already present (e.g. a second `CREATE TABLE ... AUTOINCREMENT` in the
-/// same schema, or a table reloaded from a snapshot that already created it).
+/// Resolve the schema that owns `target_table`'s AUTOINCREMENT bookkeeping,
+/// following SQLite's temp-shadows-main name resolution so it agrees with the
+/// schema the INSERT/DROP itself targeted. Falls back to the current schema
+/// when the table can't be resolved (e.g. engine-internal unit tests that
+/// track a `sqlite_sequence` row without a backing user table).
+fn sequence_owner_schema(database: &Database, target_table: &str) -> String {
+    database
+        .catalog
+        .resolve_table_schema_name(target_table)
+        .unwrap_or_else(|| database.catalog.get_current_schema().to_string())
+}
+
+/// The schema-qualified physical name of the `sqlite_sequence` table that owns
+/// `target_table`'s bookkeeping (e.g. `main.sqlite_sequence` or
+/// `temp_7.sqlite_sequence`).
+///
+/// Each database — `main` plus every session's temp schema — keeps its OWN
+/// `sqlite_sequence` table, exactly like SQLite (autoinc-4.x). Resolving the
+/// owning schema here (rather than using the bare, unqualified name, which
+/// resolves temp-shadows-main) is what keeps a main table's high-water mark in
+/// `main.sqlite_sequence` and a temp table's in `temp.sqlite_sequence` — the
+/// two never cross-contaminate even when both exist at once (issue #6173).
+fn sequence_table_name(database: &Database, target_table: &str) -> String {
+    format!("{}.{}", sequence_owner_schema(database, target_table), SQLITE_SEQUENCE_TABLE)
+}
+
+/// Lazily create the `sqlite_sequence` table in the schema that owns
+/// `target_table` if it does not already exist there. Safe to call
+/// unconditionally — a no-op when the table is already present (e.g. a second
+/// `CREATE TABLE ... AUTOINCREMENT` in the same schema, or a table reloaded
+/// from a snapshot that already created it).
+///
+/// The table is created in `target_table`'s owning schema (main vs. a temp
+/// schema), NOT the current schema, so a `CREATE TEMP TABLE ... AUTOINCREMENT`
+/// issued while the current schema is `main` still gets its `sqlite_sequence`
+/// in the temp schema (autoinc-4.x).
 ///
 /// Uses [`Database::create_table_with_identifier`] directly, bypassing the
 /// user-facing `sqlite_`-prefix reservation guard (`is_reserved_object_name`)
@@ -69,14 +101,19 @@ fn sqlite_sequence_table_schema() -> TableSchema {
 /// user-issued. Because that low-level API emits its own WAL `CreateTable` op
 /// and inserts into both the catalog and storage, the table persists exactly
 /// like any user table (issue #6173's core design point).
-pub fn ensure_sqlite_sequence_table(database: &mut Database) -> Result<(), ExecutorError> {
-    if database.catalog.get_table(SQLITE_SEQUENCE_TABLE).is_some() {
+pub fn ensure_sqlite_sequence_table(
+    database: &mut Database,
+    target_table: &str,
+) -> Result<(), ExecutorError> {
+    let owning_schema = sequence_owner_schema(database, target_table);
+    let qualified = format!("{}.{}", owning_schema, SQLITE_SEQUENCE_TABLE);
+    if database.get_table(&qualified).is_some() {
         return Ok(());
     }
     database
         .create_table_with_identifier(
             sqlite_sequence_table_schema(),
-            TableIdentifier::new(SQLITE_SEQUENCE_TABLE, false),
+            TableIdentifier::qualified(&owning_schema, false, SQLITE_SEQUENCE_TABLE, false),
         )
         .map_err(|e| ExecutorError::StorageError(e.to_string()))
 }
@@ -111,8 +148,12 @@ fn parse_seq_value(value: &SqlValue) -> Option<i64> {
 /// collation). Returns `Some(parsed_seq)` when a row exists (`parsed_seq` is
 /// `None` when the stored value is NULL/non-numeric/out-of-range — see
 /// [`parse_seq_value`]), or `None` when no row exists for this table yet.
-fn lookup_sequence_row(database: &Database, table_display_name: &str) -> Option<Option<i64>> {
-    let table = database.get_table(SQLITE_SEQUENCE_TABLE)?;
+fn lookup_sequence_row(
+    database: &Database,
+    seq_table: &str,
+    table_display_name: &str,
+) -> Option<Option<i64>> {
+    let table = database.get_table(seq_table)?;
     table.scan_live().find_map(|(_, row)| match row.values.first() {
         Some(SqlValue::Varchar(s)) if s.as_str() == table_display_name => {
             Some(row.values.get(1).and_then(parse_seq_value))
@@ -134,7 +175,8 @@ fn lookup_sequence_row(database: &Database, table_display_name: &str) -> Option<
 /// column value and its *tracked* high-water mark (`Table::max_rowid_signed`,
 /// which future allocations read from) silently diverge.
 pub fn sequence_high_water_mark(database: &Database, table_display_name: &str) -> Option<i64> {
-    lookup_sequence_row(database, table_display_name).and_then(|v| v)
+    let seq_table = sequence_table_name(database, table_display_name);
+    lookup_sequence_row(database, &seq_table, table_display_name).and_then(|v| v)
 }
 
 /// Compute the rowid a NULL/omitted INTEGER PRIMARY KEY insert into an
@@ -188,9 +230,13 @@ pub fn bump_sequence_after_insert(
     table_display_name: &str,
     min_value: i64,
 ) -> Result<(), ExecutorError> {
-    ensure_sqlite_sequence_table(database)?;
+    ensure_sqlite_sequence_table(database, table_display_name)?;
 
-    let existing = lookup_sequence_row(database, table_display_name);
+    // Target the `sqlite_sequence` in the SAME database as the table being
+    // inserted into, so a main table's counter never lands in
+    // `temp.sqlite_sequence` and vice-versa (autoinc-4.x, issue #6173).
+    let seq_table = sequence_table_name(database, table_display_name);
+    let existing = lookup_sequence_row(database, &seq_table, table_display_name);
     let existing_valid = existing.and_then(|v| v);
     let new_val = existing_valid.unwrap_or(i64::MIN).max(min_value);
     let row_exists = existing.is_some();
@@ -199,7 +245,7 @@ pub fn bump_sequence_after_insert(
         let name = table_display_name.to_string();
         database
             .update_row_matching(
-                SQLITE_SEQUENCE_TABLE,
+                &seq_table,
                 move |row| matches!(row.values.first(), Some(SqlValue::Varchar(s)) if s.as_str() == name),
                 vec![("seq", SqlValue::Integer(new_val))],
             )
@@ -207,7 +253,7 @@ pub fn bump_sequence_after_insert(
     } else {
         database
             .insert_row(
-                SQLITE_SEQUENCE_TABLE,
+                &seq_table,
                 Row::new(vec![
                     SqlValue::Varchar(arcstr::ArcStr::from(table_display_name)),
                     SqlValue::Integer(new_val),
@@ -218,21 +264,30 @@ pub fn bump_sequence_after_insert(
     Ok(())
 }
 
-/// Remove the `sqlite_sequence` entry for a dropped AUTOINCREMENT table
-/// (SQLite: `DROP TABLE` on an AUTOINCREMENT table removes its
+/// Remove the `sqlite_sequence` entry for a dropped or truncated AUTOINCREMENT
+/// table (SQLite: `DROP TABLE` on an AUTOINCREMENT table removes its
 /// `sqlite_sequence` row, but the `sqlite_sequence` table itself stays
-/// behind). A no-op if `sqlite_sequence` doesn't exist (or has no row for this
-/// table) — dropping a table before its first successful INSERT is normal.
+/// behind). A no-op if the owning schema's `sqlite_sequence` doesn't exist (or
+/// has no row for this table) — dropping a table before its first successful
+/// INSERT is normal.
+///
+/// `owning_schema` is the schema (`main` or a `temp_*` schema) that held the
+/// table, so the row is removed from the correct database's `sqlite_sequence`
+/// (autoinc-4.x). It MUST be captured by the caller BEFORE the table is dropped
+/// from the catalog, since it can no longer be resolved from the table name
+/// afterwards.
 pub fn remove_sequence_entry(
     database: &mut Database,
     table_display_name: &str,
+    owning_schema: &str,
 ) -> Result<(), ExecutorError> {
-    if database.get_table(SQLITE_SEQUENCE_TABLE).is_none() {
+    let seq_table = format!("{}.{}", owning_schema, SQLITE_SEQUENCE_TABLE);
+    if database.get_table(&seq_table).is_none() {
         return Ok(());
     }
     let name = table_display_name.to_string();
     database
-        .delete_row_matching(SQLITE_SEQUENCE_TABLE, move |row| {
+        .delete_row_matching(&seq_table, move |row| {
             matches!(row.values.first(), Some(SqlValue::Varchar(s)) if s.as_str() == name)
         })
         .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
@@ -272,34 +327,41 @@ mod tests {
         );
     }
 
+    /// Helper: read a `sqlite_sequence` row for `name`, resolving the owning
+    /// schema exactly as the production paths do.
+    fn lookup(db: &Database, name: &str) -> Option<Option<i64>> {
+        let seq_table = sequence_table_name(db, name);
+        lookup_sequence_row(db, &seq_table, name)
+    }
+
     #[test]
     fn test_ensure_sqlite_sequence_table_idempotent() {
         let mut db = Database::new();
         assert!(db.catalog.get_table(SQLITE_SEQUENCE_TABLE).is_none());
-        ensure_sqlite_sequence_table(&mut db).unwrap();
+        ensure_sqlite_sequence_table(&mut db, "t1").unwrap();
         assert!(db.catalog.get_table(SQLITE_SEQUENCE_TABLE).is_some());
         // Calling again must not error (idempotent).
-        ensure_sqlite_sequence_table(&mut db).unwrap();
+        ensure_sqlite_sequence_table(&mut db, "t1").unwrap();
     }
 
     #[test]
     fn test_bump_sequence_creates_and_upserts() {
         let mut db = Database::new();
         bump_sequence_after_insert(&mut db, "t1", 12).unwrap();
-        assert_eq!(lookup_sequence_row(&db, "t1"), Some(Some(12)));
+        assert_eq!(lookup(&db, "t1"), Some(Some(12)));
 
         // A smaller explicit value never lowers the tracked max.
         bump_sequence_after_insert(&mut db, "t1", 1).unwrap();
-        assert_eq!(lookup_sequence_row(&db, "t1"), Some(Some(12)));
+        assert_eq!(lookup(&db, "t1"), Some(Some(12)));
 
         // A larger value raises it.
         bump_sequence_after_insert(&mut db, "t1", 123).unwrap();
-        assert_eq!(lookup_sequence_row(&db, "t1"), Some(Some(123)));
+        assert_eq!(lookup(&db, "t1"), Some(Some(123)));
 
         // A second table is tracked independently.
         bump_sequence_after_insert(&mut db, "t2", 1).unwrap();
-        assert_eq!(lookup_sequence_row(&db, "t2"), Some(Some(1)));
-        assert_eq!(lookup_sequence_row(&db, "t1"), Some(Some(123)));
+        assert_eq!(lookup(&db, "t2"), Some(Some(1)));
+        assert_eq!(lookup(&db, "t1"), Some(Some(123)));
     }
 
     #[test]
@@ -307,8 +369,9 @@ mod tests {
         let mut db = Database::new();
         bump_sequence_after_insert(&mut db, "t1", 5).unwrap();
         bump_sequence_after_insert(&mut db, "t2", 7).unwrap();
-        remove_sequence_entry(&mut db, "t1").unwrap();
-        assert_eq!(lookup_sequence_row(&db, "t1"), None);
-        assert_eq!(lookup_sequence_row(&db, "t2"), Some(Some(7)));
+        // Fresh in-memory tables with no backing user table resolve to `main`.
+        remove_sequence_entry(&mut db, "t1", "main").unwrap();
+        assert_eq!(lookup(&db, "t1"), None);
+        assert_eq!(lookup(&db, "t2"), Some(Some(7)));
     }
 }

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -722,7 +722,12 @@ impl CreateTableExecutor {
         // sqlite3 3.51.0 autoinc-1.2) — `sqlite_sequence` gets no row for
         // this table yet; that happens lazily on the table's first INSERT.
         if table_schema.is_autoincrement {
-            crate::autoincrement::ensure_sqlite_sequence_table(database)?;
+            // The current schema was switched to the target schema above (for a
+            // TEMP table it is this session's temp schema), so resolving the
+            // just-created table's owning schema yields the right database —
+            // its `sqlite_sequence` is created there, not always in `main`
+            // (autoinc-4.x, issue #6173).
+            crate::autoincrement::ensure_sqlite_sequence_table(database, &table_name)?;
         }
 
         // Restore original schema if we switched

--- a/crates/vibesql-executor/src/drop_table.rs
+++ b/crates/vibesql-executor/src/drop_table.rs
@@ -112,11 +112,24 @@ impl DropTableExecutor {
         // SQLite: dropping an AUTOINCREMENT table removes its entry from
         // `sqlite_sequence`, but `sqlite_sequence` itself stays behind
         // (autoinc-3.2/3.3/3.4, issue #6173).
-        let autoincrement_display_name = database
+        // Capture the AUTOINCREMENT display name AND the schema that owns the
+        // table (`main` or a `temp_*` schema) while it still exists in the
+        // catalog. The owning schema selects the correct database's
+        // `sqlite_sequence` for the post-drop row cleanup — resolving it after
+        // the drop would fail (the table is gone) and wrongly fall back to the
+        // current schema (autoinc-4.x, issue #6173).
+        let autoincrement_cleanup = database
             .catalog
             .get_table(&stmt.table_name)
             .filter(|schema| schema.is_autoincrement)
-            .map(|schema| schema.name.clone());
+            .map(|schema| schema.name.clone())
+            .map(|display_name| {
+                let owning_schema = database
+                    .catalog
+                    .resolve_table_schema_name(&stmt.table_name)
+                    .unwrap_or_else(|| database.catalog.get_current_schema().to_string());
+                (display_name, owning_schema)
+            });
 
         // Drop all indexes associated with this table first
         let dropped_indexes = database.catalog.drop_table_indexes(&stmt.table_name);
@@ -153,8 +166,8 @@ impl DropTableExecutor {
             .drop_table(&stmt.table_name)
             .map_err(|e| ExecutorError::StorageError(e.to_string()))?;
 
-        if let Some(display_name) = autoincrement_display_name {
-            crate::autoincrement::remove_sequence_entry(database, &display_name)?;
+        if let Some((display_name, owning_schema)) = autoincrement_cleanup {
+            crate::autoincrement::remove_sequence_entry(database, &display_name, &owning_schema)?;
         }
 
         // Return success message

--- a/crates/vibesql-executor/src/truncate/core.rs
+++ b/crates/vibesql-executor/src/truncate/core.rs
@@ -37,7 +37,7 @@ pub fn reset_auto_increment_sequences(
     // to 1, mirrored by removing the `sqlite_sequence` row for this table (an
     // empty table with no `seq` row makes the next NULL insert restart at 1);
     // `bump_sequence_after_insert` lazily recreates the row on the next insert.
-    let autoincrement_display_name = if table_schema.is_autoincrement {
+    let autoincrement_cleanup = if table_schema.is_autoincrement {
         Some(table_schema.name.clone())
     } else {
         None
@@ -54,8 +54,15 @@ pub fn reset_auto_increment_sequences(
     }
 
     // Reset the real `sqlite_sequence` high-water mark for AUTOINCREMENT tables.
-    if let Some(display_name) = autoincrement_display_name {
-        crate::autoincrement::remove_sequence_entry(database, &display_name)?;
+    // The table still exists here (TRUNCATE clears rows, it does not drop it),
+    // so its owning schema — selecting the correct database's `sqlite_sequence`
+    // — resolves directly (autoinc-4.x, issue #6173).
+    if let Some(display_name) = autoincrement_cleanup {
+        let owning_schema = database
+            .catalog
+            .resolve_table_schema_name(table_name)
+            .unwrap_or_else(|| database.catalog.get_current_schema().to_string());
+        crate::autoincrement::remove_sequence_entry(database, &display_name, &owning_schema)?;
     }
 
     Ok(())

--- a/crates/vibesql-executor/tests/autoincrement_temp_sequence_tests.rs
+++ b/crates/vibesql-executor/tests/autoincrement_temp_sequence_tests.rs
@@ -1,0 +1,160 @@
+//! Integration tests for per-database `sqlite_sequence` AUTOINCREMENT
+//! bookkeeping (issue #6173).
+//!
+//! SQLite keeps a SEPARATE `sqlite_sequence` table in every database — `main`
+//! plus each connection's `temp` schema. A main table's high-water mark lives
+//! in `main.sqlite_sequence`; a TEMP table's lives in `temp.sqlite_sequence`.
+//! The two never cross-contaminate, even when a main and a temp AUTOINCREMENT
+//! table coexist (autoinc-4.x).
+//!
+//! Before the fix, the bookkeeping resolved the unqualified name
+//! `sqlite_sequence`, which follows SQLite's temp-shadows-main lookup — so once
+//! any temp AUTOINCREMENT table existed, EVERY table's counter (main tables
+//! included) landed in `temp.sqlite_sequence`, leaving `main.sqlite_sequence`
+//! wrongly empty. These tests pin the corrected, schema-qualified routing.
+//!
+//! NOTE: SQLite's canonical `autoinc.test` section 4 exercises exactly this
+//! behavior, but the multi-process VibeSQL TCL shim demotes `CREATE TEMP TABLE`
+//! to a persistent main-schema table (there is no long-lived connection to hold
+//! a session-scoped temp table across the shim's per-statement CLI processes),
+//! so it cannot observe the main-vs-temp `sqlite_sequence` split. These
+//! in-process engine tests verify the behavior directly instead.
+
+use vibesql_executor::{CreateTableExecutor, DropTableExecutor, InsertExecutor, SelectExecutor};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+use vibesql_types::SqlValue;
+
+fn exec_create_table(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse CREATE TABLE");
+    match stmt {
+        vibesql_ast::Statement::CreateTable(s) => {
+            CreateTableExecutor::execute(&s, db).expect("CREATE TABLE")
+        }
+        other => panic!("expected CREATE TABLE, got {other:?}"),
+    };
+}
+
+fn exec_insert(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse INSERT");
+    match stmt {
+        vibesql_ast::Statement::Insert(s) => {
+            InsertExecutor::execute(db, &s).expect("INSERT");
+        }
+        other => panic!("expected INSERT, got {other:?}"),
+    }
+}
+
+fn exec_drop_table(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse DROP TABLE");
+    match stmt {
+        vibesql_ast::Statement::DropTable(s) => {
+            DropTableExecutor::execute(&s, db).expect("DROP TABLE")
+        }
+        other => panic!("expected DROP TABLE, got {other:?}"),
+    };
+}
+
+/// Read `(name, seq)` pairs from the `sqlite_sequence` table in `schema`
+/// (`"main"` or `"temp"`), sorted by name. Returns an empty vec when the table
+/// has no rows.
+fn sequence_rows(db: &Database, schema: &str) -> Vec<(String, i64)> {
+    let sql = format!("SELECT name, seq FROM {schema}.sqlite_sequence ORDER BY name");
+    let stmt = Parser::parse_sql(&sql).expect("parse SELECT sqlite_sequence");
+    let rows = match stmt {
+        vibesql_ast::Statement::Select(s) => {
+            SelectExecutor::new(db).execute_with_columns(&s).expect("SELECT sqlite_sequence").rows
+        }
+        other => panic!("expected SELECT, got {other:?}"),
+    };
+    rows.iter()
+        .map(|r| {
+            let name = match &r.values[0] {
+                SqlValue::Varchar(s) => s.to_string(),
+                other => panic!("expected text name, got {other:?}"),
+            };
+            let seq = match &r.values[1] {
+                SqlValue::Integer(v) | SqlValue::Bigint(v) => *v,
+                SqlValue::Smallint(v) => *v as i64,
+                other => panic!("expected integer seq, got {other:?}"),
+            };
+            (name, seq)
+        })
+        .collect()
+}
+
+/// A main AUTOINCREMENT table's counter stays in `main.sqlite_sequence` and a
+/// coexisting TEMP AUTOINCREMENT table's counter stays in
+/// `temp.sqlite_sequence` — neither leaks into the other (autoinc-4.4/4.5).
+#[test]
+fn main_and_temp_autoincrement_sequences_are_isolated() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y)");
+    exec_create_table(&mut db, "CREATE TEMP TABLE t3(a INTEGER PRIMARY KEY AUTOINCREMENT, b)");
+
+    exec_insert(&mut db, "INSERT INTO t1 VALUES(10, 1)");
+    exec_insert(&mut db, "INSERT INTO t3 VALUES(20, 2)");
+    // NULL rowids auto-allocate to 11 / 21, advancing each high-water mark.
+    exec_insert(&mut db, "INSERT INTO t1 VALUES(NULL, 3)");
+    exec_insert(&mut db, "INSERT INTO t3 VALUES(NULL, 4)");
+
+    assert_eq!(
+        sequence_rows(&db, "main"),
+        vec![("t1".to_string(), 11)],
+        "main.sqlite_sequence must hold ONLY the main table's high-water mark"
+    );
+    assert_eq!(
+        sequence_rows(&db, "temp"),
+        vec![("t3".to_string(), 21)],
+        "temp.sqlite_sequence must hold ONLY the temp table's high-water mark"
+    );
+}
+
+/// Dropping the TEMP table removes only its `temp.sqlite_sequence` row; the main
+/// table's `main.sqlite_sequence` row is untouched (autoinc-4.8).
+#[test]
+fn dropping_temp_table_leaves_main_sequence_intact() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y)");
+    exec_create_table(&mut db, "CREATE TEMP TABLE t3(a INTEGER PRIMARY KEY AUTOINCREMENT, b)");
+    exec_insert(&mut db, "INSERT INTO t1 VALUES(10, 1)");
+    exec_insert(&mut db, "INSERT INTO t3 VALUES(20, 2)");
+
+    exec_drop_table(&mut db, "DROP TABLE t3");
+
+    assert_eq!(
+        sequence_rows(&db, "temp"),
+        Vec::<(String, i64)>::new(),
+        "dropping the temp table must clear its temp.sqlite_sequence row"
+    );
+    assert_eq!(
+        sequence_rows(&db, "main"),
+        vec![("t1".to_string(), 10)],
+        "the main table's sqlite_sequence row must survive the temp DROP"
+    );
+}
+
+/// Dropping the main table removes only its `main.sqlite_sequence` row while the
+/// temp table's `temp.sqlite_sequence` row is untouched — the inverse of the
+/// case above, and the one the pre-fix temp-shadowing got wrong (autoinc-4.9).
+#[test]
+fn dropping_main_table_leaves_temp_sequence_intact() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y)");
+    exec_create_table(&mut db, "CREATE TEMP TABLE t3(a INTEGER PRIMARY KEY AUTOINCREMENT, b)");
+    exec_insert(&mut db, "INSERT INTO t1 VALUES(10, 1)");
+    exec_insert(&mut db, "INSERT INTO t3 VALUES(20, 2)");
+
+    exec_drop_table(&mut db, "DROP TABLE t1");
+
+    assert_eq!(
+        sequence_rows(&db, "main"),
+        Vec::<(String, i64)>::new(),
+        "dropping the main table must clear its main.sqlite_sequence row"
+    );
+    assert_eq!(
+        sequence_rows(&db, "temp"),
+        vec![("t3".to_string(), 20)],
+        "the temp table's sqlite_sequence row must survive the main DROP"
+    );
+}


### PR DESCRIPTION
## Summary

AUTOINCREMENT high-water-mark bookkeeping resolved the **unqualified** name `sqlite_sequence`, which follows SQLite's temp-shadows-main name lookup. As soon as any TEMP `AUTOINCREMENT` table existed in a session, *every* table's counter — main tables included — landed in `temp.sqlite_sequence`, leaving `main.sqlite_sequence` wrongly empty. Symmetrically, dropping/truncating a main table tried to clean the temp copy (and vice-versa).

SQLite keeps a **separate** `sqlite_sequence` table in every database (`main` plus each connection's `temp` schema); a main table's counter lives in `main.sqlite_sequence` and a temp table's in `temp.sqlite_sequence`, and they never cross-contaminate (autoinc-4.x).

Reproduced directly against the built CLI before the fix:

```
CREATE TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y);
CREATE TEMP TABLE t3(a INTEGER PRIMARY KEY AUTOINCREMENT, b);
INSERT INTO t1 VALUES(10,1); INSERT INTO t3 VALUES(20,2);
SELECT * FROM main.sqlite_sequence;   -- WAS: 0 rows (wrong)   NOW: t1|10
SELECT * FROM temp.sqlite_sequence;   -- WAS: t1|10, t3|20     NOW: t3|20
```

## Changes

- `autoincrement.rs`: added `sequence_owner_schema` / `sequence_table_name` helpers that resolve the target table's owning schema (via `Catalog::resolve_table_schema_name`, same temp-shadows-main order the INSERT/DROP used) and build the schema-qualified `sqlite_sequence` physical name. `lookup`, lazy creation (`ensure_sqlite_sequence_table`), the per-INSERT `bump_sequence_after_insert`, and `remove_sequence_entry` now operate on that specific table instead of the unqualified (temp-shadowed) name. `ensure` creates the table in the owning schema (temp vs. main), not the current schema.
- `create_table.rs`: pass the just-created table name so its `sqlite_sequence` is ensured in the correct schema.
- `drop_table.rs`: capture the owning schema **before** the table leaves the catalog (it can no longer be resolved afterwards) and pass it to `remove_sequence_entry`.
- `truncate/core.rs`: resolve and pass the owning schema for the sequence-row reset.
- New integration test `autoincrement_temp_sequence_tests.rs`: proves main/temp sequence isolation across INSERT and across dropping either table.

Non-temp workloads are unchanged: with no temp shadow, a bare name already resolved to `main`, so `main.sqlite_sequence` is still the exact same physical table.

## Acceptance Criteria Verification

- [x] Main-table AUTOINCREMENT counter stays in `main.sqlite_sequence`; temp-table counter stays in `temp.sqlite_sequence` (verified via new integration test + direct CLI).
- [x] Dropping the temp table clears only its `temp.sqlite_sequence` row; the main row survives (and vice-versa).
- [x] `cargo build --release` is green; the 3 new integration tests pass (`test result: ok. 3 passed`).
- [x] No regression to the non-temp path (identical physical table).

## Test Plan

- `cargo test --release -p vibesql-executor --test autoincrement_temp_sequence_tests` — 3 passed.
- Direct CLI reproduction (main/temp split correct after the fix, DROP cleans the right database).

## Note on `autoinc.test` section 4

SQLite's canonical `autoinc.test` section 4 targets exactly this behavior, but the multi-process VibeSQL TCL shim **demotes** `CREATE TEMP TABLE` to a persistent `main`-schema table (there is no long-lived connection to hold a session-scoped temp table across the shim's per-statement CLI processes), so it cannot observe the main-vs-temp `sqlite_sequence` split (`temp.sqlite_sequence` never exists under the shim). The behavior is therefore verified by the in-process engine tests rather than by the TCL harness; `autoinc.test`'s passing count is unchanged.

Part of #6173