### PR TITLE
fix(pragma): error on foreign_key_check for a missing table

### DIFF
--- a/crates/vibesql-cli/src/executor/mod.rs
+++ b/crates/vibesql-cli/src/executor/mod.rs
@@ -2479,6 +2479,26 @@ impl SqlExecutor {
             _ => None,
         };
 
+        // SQLite: `PRAGMA foreign_key_check(NAME)` on a table that does not
+        // exist raises "no such table: NAME" (pragma4-4.6.5, fkey5). This
+        // differs from `foreign_key_list` / `table_info`, which return an empty
+        // result for a missing table — so the check lives here, not in those.
+        // The schema tables (sqlite_master and its aliases) are always valid
+        // targets and never error. This mirrors the same no-such-table
+        // validation `integrity_check` performs for its name-argument form.
+        // (The schema-qualified `<other>.foreign_key_check(NAME)` form is
+        // already handled above, so any `stmt.database` reaching here is the
+        // current/main schema; the bare-name lookup matches the per-table
+        // resolution used in the scan loop below.)
+        if let Some(ref name) = table_name {
+            let lower = name.to_ascii_lowercase();
+            let is_schema_table =
+                matches!(lower.as_str(), "sqlite_master" | "sqlite_schema" | "sqlite_temp_schema");
+            if !is_schema_table && self.db.catalog.get_table(name).is_none() {
+                anyhow::bail!("no such table: {}", name);
+            }
+        }
+
         // Collect tables to check
         let tables_to_check: Vec<String> = if let Some(ref name) = table_name {
             vec![name.clone()]
@@ -2970,7 +2990,10 @@ impl SqlExecutor {
     /// in-memory database or the (always-empty-file) `temp` schema -- same
     /// path-resolution precedent as `execute_pragma_database_list`'s `main`
     /// row.
-    fn execute_pragma_filename(&self, stmt: &vibesql_ast::PragmaStmt) -> anyhow::Result<QueryResult> {
+    fn execute_pragma_filename(
+        &self,
+        stmt: &vibesql_ast::PragmaStmt,
+    ) -> anyhow::Result<QueryResult> {
         let schema = stmt.database.as_deref().unwrap_or("main").to_ascii_lowercase();
         let file = if schema == "temp" {
             String::new()

--- a/crates/vibesql-cli/src/executor/tests.rs
+++ b/crates/vibesql-cli/src/executor/tests.rs
@@ -698,6 +698,49 @@ fn test_pragma_integrity_check_argument_taxonomy() {
 }
 
 #[test]
+fn test_pragma_foreign_key_check_missing_table_errors() {
+    // SQLite: `PRAGMA foreign_key_check(NAME)` on a table that does not exist
+    // raises "no such table: NAME" (pragma4-4.6.5, fkey5). This differs from
+    // foreign_key_list / table_info, which return an empty result for a
+    // missing table.
+    let mut executor = SqlExecutor::new(None).unwrap();
+    executor.execute("CREATE TABLE t1(a)").unwrap();
+    executor.execute("CREATE UNIQUE INDEX i1 ON t1(a)").unwrap();
+    executor.execute("CREATE TABLE c1(a, b, c REFERENCES t1(a))").unwrap();
+    executor.execute("INSERT INTO c1 VALUES(1, 2, 3)").unwrap();
+
+    // Named argument that is not a table -> "no such table: NAME" (both the
+    // quoted-string and bare-identifier spellings).
+    let err = executor.execute("PRAGMA foreign_key_check('c2')").unwrap_err();
+    assert_eq!(err.to_string(), "no such table: c2");
+    let err = executor.execute("PRAGMA foreign_key_check(nope)").unwrap_err();
+    assert_eq!(err.to_string(), "no such table: nope");
+
+    // An existing table with a violated FK still reports the violation row
+    // (row 1 of c1 references t1(a)=3, which does not exist): table, rowid,
+    // parent, fkid.
+    let result = executor.execute("PRAGMA foreign_key_check('c1')").unwrap();
+    assert_eq!(result.row_count, 1);
+    assert_eq!(result.rows[0][0].as_deref(), Some("c1"));
+    assert_eq!(result.rows[0][1].as_deref(), Some("1"));
+    assert_eq!(result.rows[0][2].as_deref(), Some("t1"));
+    assert_eq!(result.rows[0][3].as_deref(), Some("0"));
+
+    // An existing table with no violations returns an empty result (no error).
+    executor.execute("CREATE TABLE t2(a)").unwrap();
+    let result = executor.execute("PRAGMA foreign_key_check('t2')").unwrap();
+    assert_eq!(result.row_count, 0);
+
+    // The whole-database form (no argument) never errors on a missing table.
+    let result = executor.execute("PRAGMA foreign_key_check").unwrap();
+    assert_eq!(result.rows[0][0].as_deref(), Some("c1"));
+
+    // Schema tables are always valid targets and never error.
+    let result = executor.execute("PRAGMA foreign_key_check('sqlite_master')").unwrap();
+    assert_eq!(result.row_count, 0);
+}
+
+#[test]
 fn test_pragma_table_info_verbatim_type_and_default() {
     // PRAGMA table_info echoes the declared type verbatim (only bracket/quote
     // delimiters stripped) and the verbatim DEFAULT source text, matching


### PR DESCRIPTION
## Summary

`PRAGMA foreign_key_check(NAME)` now raises `no such table: NAME` when the named table does not exist, matching SQLite. Previously VibeSQL silently returned an empty result for a missing named table.

This is a genuine introspection-PRAGMA semantics fix (not a fabricated/forced value): `foreign_key_check` errors on a missing table, which deliberately differs from `foreign_key_list` / `table_info` (both return an empty result for a missing table). The validation therefore lives only in `foreign_key_check`, mirroring the same no-such-table check `integrity_check` already performs for its name-argument form.

## Changes

- `crates/vibesql-cli/src/executor/mod.rs`: in `execute_pragma_foreign_key_check`, bail with `no such table: <name>` when a named-table argument does not resolve in the catalog. Schema tables (`sqlite_master` / `sqlite_schema` / `sqlite_temp_schema`) stay valid targets and never error; the whole-database (no-argument) form is unaffected. The schema-qualified `<other>.foreign_key_check(NAME)` form was already handled upstream.
- `crates/vibesql-cli/src/executor/tests.rs`: unit test covering the missing-table error (quoted + bare spellings), an existing-table violation still reporting its row, an existing-table-with-no-violations empty result, the no-argument whole-db form, and the `sqlite_master` no-error case.

## Effect on the PRAGMA family (pragma4.test)

| Test | Before | After | Why |
|------|--------|-------|-----|
| `4.6.5` (`pragma foreign_key_check('c2')` → `no such table: c2`) | FAIL (`0 {}`) | PASS | Correct SQLite error semantics |
| `4.6.1` / `4.6.2` / `4.6.4` | FAIL (silent empty) | SKIP | Now surface `no such table` for tables created inside the already-skipped ATTACH block `4.6.0`, so the shim's existing ATTACH-dependency cascade reclassifies them honestly instead of reporting raw failures |

Net for `pragma4.test`: Passed 7 → 8, Failed 13 → 9 (no test forced green; the three reclassified tests genuinely depend on ATTACH-created tables VibeSQL cannot build).

The remaining `pragma4` failures are ATTACH / multi-connection / `EXPLAIN PRAGMA` dependent; the bulk of `pragma.test` / `pragma2` / `pragma6` residual failures are genuinely pager/journal/file-format internal (integrity-check on corrupted on-disk B-trees via `hexio_write`, `page_count`, `freelist_count`, `cache_spill`, proxy locking, test-VFS `SQLITE_FCNTL_PRAGMA`) or cross-connection `data_version` — Bucket-A / architecturally separate from this introspection-PRAGMA fix and left for their respective tracks (#6154 etc.).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Introspection PRAGMA behaves per SQLite | ✅ | `foreign_key_check(missing)` errors `no such table: NAME`; existing-table violation/empty/whole-db/`sqlite_master` cases unchanged (unit test + manual CLI runs) |
| No introspection PRAGMA silently reclassified as internal | ✅ | The reclassified `4.6.x` tests are skipped because their **test data** requires ATTACH, not because `foreign_key_check` is internal — the pragma itself works and is exercised green by `fkey5.test` (54 passed / 0 failed) |
| No regressions | ✅ | `fkey5.test` 0 failed; `fkey1/fkey2/fkey7` remaining failures are pre-existing and unrelated (auth/trace commands, UNIQUE constraints, `sqlite_stat1`), none involving `foreign_key_check` missing-table errors |

## Test Plan

- `cargo test -p vibesql-cli --release --bin vibesql pragma` → 33 passed, 0 failed
- `cargo test -p vibesql-cli --release --bin vibesql foreign_key_check` → new test passes
- `make test-tcl-file FILE=pragma4.test` → Passed 7 → 8, Failed 13 → 9
- `make test-tcl-file FILE=fkey5.test` → 54 passed, 0 failed
- `cargo fmt --check` clean; `cargo clippy` on the CLI crate exits 0 (only pre-existing `vibesql-ast` warnings)

Part of #6175