### PR TITLE
conformance(tcl): strip DB qualifier from stored CREATE TABLE + DROP COLUMN FK/generated checks (Part of #6174)

### DIFF
--- a/crates/vibesql-executor/src/alter/drop_column_checks.rs
+++ b/crates/vibesql-executor/src/alter/drop_column_checks.rs
@@ -51,17 +51,17 @@ pub(super) fn postcheck_schema_objects(
     table_name: &str,
     column: &str,
 ) -> Result<(), ExecutorError> {
-    // Table-level CHECK constraints (and column-level CHECKs owned by *other*
-    // columns) on the altered table must still resolve after the drop. The
-    // in-memory `check_constraints` list has no column/table origin, so the
-    // origin is recovered from the verbatim CREATE TABLE text (`sql_source`),
-    // exactly the text SQLite itself re-parses. A CHECK attached to the
+    // Constraints and generated-column expressions on the altered table itself
+    // must still resolve after the drop. The in-memory schema does not track a
+    // constraint's column/table origin, so the origin is recovered from the
+    // verbatim CREATE TABLE text (`sql_source`), exactly the text SQLite itself
+    // re-parses. A constraint or generated expression that belongs to the
     // dropped column is removed together with the column and is exempt.
     if let Some(table) = database.get_table(table_name) {
-        if let Some(missing) = check_constraint_missing_column(&table.schema, column) {
+        if let Some(inner) = table_self_reference_error(&table.schema, column) {
             return Err(ExecutorError::Other(format!(
-                "error in table {} after drop column: no such column: {}",
-                table_name, missing
+                "error in table {} after drop column: {}",
+                table_name, inner
             )));
         }
     }
@@ -640,38 +640,59 @@ fn collect_pseudo_refs_in_statement(stmt: &Statement, refs: &mut Vec<(PseudoTabl
 }
 
 // ============================================================================
-// Table-level CHECK validation (origin recovered from the CREATE TABLE text)
+// Table self-reference validation (origin recovered from the CREATE TABLE text)
 // ============================================================================
 
-/// Display name of the first reference to `dropped` inside a CHECK constraint
-/// that would *survive* the drop: a table-level CHECK, or a column-level CHECK
-/// attached to a column other than the dropped one. A CHECK attached to the
-/// dropped column itself is removed with the column (SQLite semantics,
-/// alterdropcol.test 3.2) and never reported.
+/// Full inner error text for the first surviving part of the altered table's
+/// own definition that references `dropped` — a table-level CHECK / FOREIGN KEY,
+/// a column-level CHECK on another column, or another column's generated
+/// expression. Definitions attached to the dropped column itself are removed
+/// with the column (SQLite semantics, alterdropcol.test 3.2) and never reported.
 ///
-/// Column-vs-table origin is not tracked in `TableSchema::check_constraints`,
-/// so it is recovered by re-parsing the verbatim `CREATE TABLE` text — the
-/// same text SQLite's own re-parse reads. Without `sql_source` (schema built
+/// The returned string is SQLite's inner wording (`no such column: <c>`, or
+/// `unknown column "<c>" in foreign key definition`); the caller prefixes it
+/// with `error in table <name> after drop column: `.
+///
+/// Column-vs-table origin is not tracked on the in-memory schema, so it is
+/// recovered by re-parsing the verbatim `CREATE TABLE` text — the same text
+/// SQLite's own re-parse reads. Without `sql_source` (schema built
 /// programmatically) the origin is unknown and the legacy behavior (silently
-/// dropping CHECKs that reference the column) is kept.
-fn check_constraint_missing_column(schema: &TableSchema, dropped: &str) -> Option<String> {
+/// dropping definitions that reference the column) is kept.
+fn table_self_reference_error(schema: &TableSchema, dropped: &str) -> Option<String> {
     let source = schema.sql_source.as_deref()?;
     let stmt = vibesql_parser::Parser::parse_sql(source).ok()?;
     let Statement::CreateTable(create) = stmt else {
         return None;
     };
 
-    // Table-level CHECK constraints always survive the drop.
+    // Table-level constraints always survive the drop, so any reference to the
+    // dropped column from one of them breaks the re-parsed schema.
     for constraint in &create.table_constraints {
-        if let TableConstraintKind::Check { expr, .. } = &constraint.kind {
-            if let Some(display) = find_column_ref_display(expr, dropped) {
-                return Some(display);
+        match &constraint.kind {
+            TableConstraintKind::Check { expr, .. } => {
+                if let Some(display) = find_column_ref_display(expr, dropped) {
+                    return Some(format!("no such column: {}", display));
+                }
             }
+            // A FOREIGN KEY whose local column list names the dropped column is
+            // reported with SQLite's dedicated FK wording rather than the generic
+            // "no such column" text (alterdropcol2 2.6.1). Matched on the bare
+            // local-column list — the referenced-parent columns belong to the
+            // other table and are untouched here.
+            TableConstraintKind::ForeignKey { columns, .. } => {
+                if let Some(display) = columns.iter().find(|c| c.eq_ignore_ascii_case(dropped)) {
+                    return Some(format!(
+                        "unknown column \"{}\" in foreign key definition",
+                        display
+                    ));
+                }
+            }
+            _ => {}
         }
     }
 
-    // Column-level CHECKs on *other* columns also survive; only the dropped
-    // column's own CHECKs vanish with it.
+    // Column-level constraints/expressions on *other* columns also survive; only
+    // the dropped column's own definitions vanish with it.
     for column in &create.columns {
         if column.name.eq_ignore_ascii_case(dropped) {
             continue;
@@ -679,8 +700,16 @@ fn check_constraint_missing_column(schema: &TableSchema, dropped: &str) -> Optio
         for constraint in &column.constraints {
             if let ColumnConstraintKind::Check { expr, .. } = &constraint.kind {
                 if let Some(display) = find_column_ref_display(expr, dropped) {
-                    return Some(display);
+                    return Some(format!("no such column: {}", display));
                 }
+            }
+        }
+        // A generated column (`x AS (<expr>)` / `... STORED`) that references the
+        // dropped column leaves a dangling reference after the drop
+        // (alterdropcol2 2.7.1/2.7.2).
+        if let Some(gen_expr) = &column.generated_expr {
+            if let Some(display) = find_column_ref_display(gen_expr, dropped) {
+                return Some(format!("no such column: {}", display));
             }
         }
     }

--- a/crates/vibesql-executor/src/alter_rewrite.rs
+++ b/crates/vibesql-executor/src/alter_rewrite.rs
@@ -251,6 +251,33 @@ fn table_name_index(tokens: &[(Token, Span)]) -> Option<usize> {
     Some(i)
 }
 
+/// Remove the `<schema>.` database qualifier from the table name in a verbatim
+/// `CREATE TABLE` statement. SQLite never stores the database qualifier in
+/// `sqlite_master.sql`: `CREATE TABLE main.t1(a, b)` is stored (and later
+/// rewritten by ALTER TABLE) as `CREATE TABLE t1(a, b)`. Everything else in the
+/// statement — whitespace, quoting, the column list — is preserved byte-for-byte.
+///
+/// Returns `None` when the statement carries no schema qualifier (or cannot be
+/// tokenized), so the caller keeps the original text unchanged. Verified against
+/// sqlite3 3.51.0 (alter3-1.4/1.5).
+pub fn strip_schema_qualifier(create_sql: &str) -> Option<String> {
+    let tokens = tokenize(create_sql)?;
+    let name_idx = table_name_index(&tokens)?;
+    // A qualifier is present only when the token immediately before the resolved
+    // table-name token is the `.` separator (its predecessor being the schema
+    // identifier). Without one, `table_name_index` lands directly on the bare
+    // name and there is nothing to strip.
+    if name_idx < 2 || !matches!(tokens.get(name_idx - 1), Some((Token::Symbol('.'), _))) {
+        return None;
+    }
+    let schema_start = tokens[name_idx - 2].1.start;
+    let name_start = tokens[name_idx].1.start;
+    let mut out = String::with_capacity(create_sql.len());
+    out.push_str(&create_sql[..schema_start]);
+    out.push_str(&create_sql[name_start..]);
+    Some(out)
+}
+
 /// Rewrite every `REFERENCES <old_parent>` clause in the verbatim `CREATE TABLE`
 /// text of a *child* table to `REFERENCES "<new_parent>"`, matching SQLite's
 /// `sqlite_rename_parent` (invoked when the referenced parent table is renamed
@@ -802,6 +829,29 @@ mod tests {
     fn append_column_no_column_list_returns_none() {
         // CREATE TABLE ... AS SELECT has no editable column list.
         assert!(append_column("CREATE TABLE t AS SELECT 1", "c INTEGER").is_none());
+    }
+
+    #[test]
+    fn strip_schema_qualifier_removes_database_prefix() {
+        // SQLite never stores the database qualifier (alter3-1.4/1.5).
+        assert_eq!(
+            strip_schema_qualifier("CREATE TABLE main.t1(a, b)").as_deref(),
+            Some("CREATE TABLE t1(a, b)")
+        );
+    }
+
+    #[test]
+    fn strip_schema_qualifier_preserves_surrounding_text() {
+        // Only the `<schema>.` run is removed; column list and spacing are kept.
+        assert_eq!(
+            strip_schema_qualifier("CREATE TABLE  main.\"My Tbl\" (x INT)").as_deref(),
+            Some("CREATE TABLE  \"My Tbl\" (x INT)")
+        );
+    }
+
+    #[test]
+    fn strip_schema_qualifier_none_when_unqualified() {
+        assert!(strip_schema_qualifier("CREATE TABLE t1(a, b)").is_none());
     }
 
     #[test]

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -375,8 +375,16 @@ impl CreateTableExecutor {
         // Preserve the verbatim original CREATE TABLE text for sqlite_master.sql
         // (SQLite stores it byte-for-byte; see issue #5619). The trailing
         // semicolon is stripped by set_sql_source to match SQLite.
+        //
+        // One deviation from byte-for-byte: SQLite never records the database
+        // qualifier, so `CREATE TABLE main.t1(a, b)` is stored as
+        // `CREATE TABLE t1(a, b)` (alter3-1.4/1.5). Strip any `<schema>.` prefix
+        // from the table name before recording the source.
         if let Some(src) = sql_source {
-            table_schema.set_sql_source(src);
+            match crate::alter_rewrite::strip_schema_qualifier(src) {
+                Some(stripped) => table_schema.set_sql_source(&stripped),
+                None => table_schema.set_sql_source(src),
+            }
         }
 
         // Apply WITHOUT ROWID flag from AST (SQLite compatibility)


### PR DESCRIPTION
## Summary

Part of #6174 (ALTER TABLE semantics family). Three SQLite-faithful fixes verified against sqlite3 3.51.0, each targeting a distinct, self-contained gap so there is no regression risk to the existing (passing) ALTER paths.

### 1. CREATE TABLE never stores the database qualifier (alter3-1.4/1.5)
SQLite records `CREATE TABLE main.t1(a, b)` in `sqlite_master.sql` as `CREATE TABLE t1(a, b)` — the `<schema>.` qualifier is stripped. VibeSQL kept it verbatim, so a subsequent `ALTER TABLE t1 ADD c` produced `CREATE TABLE main.t1(a, b, c)` instead of `CREATE TABLE t1(a, b, c)`.

New `alter_rewrite::strip_schema_qualifier` removes only the `<schema>.` token run (token-based, quoting/whitespace preserved) and is applied before recording `sql_source`. It reuses the existing schema-qualifier-aware `table_name_index`; a non-qualified statement returns `None` (no-op).

### 2. DROP COLUMN post-check: foreign-key and generated-column self-references
The post-drop schema re-parse now also rejects a column still referenced by the altered table's own definition:

- Table-level `FOREIGN KEY (<c>) REFERENCES ...` local-column list → SQLite's dedicated `unknown column "<c>" in foreign key definition` wording (alterdropcol2-2.6.1).
- Another column's generated expression (`x AS (<expr>)` / `... STORED`) → `no such column: <c>` (alterdropcol2-2.7.1/2.7.2).

The existing table-level CHECK reparse (`check_constraint_missing_column`) is generalized into `table_self_reference_error`, which returns the full inner error text; the caller prefixes the shared `error in table <name> after drop column: ` framing.

## Test results
- `alterdropcol2.test`: 18 → 21 passed (2.6.1, 2.7.1, 2.7.2 fixed)
- `alter3.test`: 35 → 37 passed (1.4, 1.5 fixed)
- No regressions: `altercol.test` (187), `alter.test` (54), `alterdropcol.test` (96) unchanged.
- Executor unit tests green (alter 112, create_table 56, sqlite_schema 23); new `strip_schema_qualifier` unit tests added.

Direct verification:
```
CREATE TABLE main.t1(a, b); ALTER TABLE t1 ADD c;
  -> CREATE TABLE t1(a, b, c)
CREATE TABLE c1(u, v, FOREIGN KEY (v) REFERENCES p1(y)); ALTER TABLE c1 DROP v;
  -> error in table c1 after drop column: unknown column "v" in foreign key definition
CREATE TABLE c1(u, v, w AS (u+v)); ALTER TABLE c1 DROP v;
  -> error in table c1 after drop column: no such column: v
```

## Scope note
Remaining failures in the listed files are out-of-scope Bucket-A (hexio file-format bytes in alter2/alter3, `sqlite_rename_quotefix` internal function in alterqf, the authorizer callback in alterauth, ATTACH-dependent cases) or require verbatim CREATE INDEX preservation / trigger-body revalidation tracked separately under the family issue.

Part of #6174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)