### PR TITLE
fix(fkey): enforce UNIQUE-INDEX-backed FK parent keys in UPDATE fast path

### DIFF
--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -488,6 +488,29 @@ impl CreateTableExecutor {
                 deferral,
             } = &constraint.kind
             {
+                // A table-level FOREIGN KEY(...) clause's child and parent column
+                // lists must be the same length when a parent column list is given
+                // at all (an omitted parent list defaults to the parent's PRIMARY
+                // KEY and is checked elsewhere). SQLite rejects a mismatch at CREATE
+                // TABLE time (table.test table-10.9/table-10.10, issue #6173):
+                //   FOREIGN KEY(b,c) REFERENCES t4(x)     -- 2 vs 1
+                //   FOREIGN KEY(b,c) REFERENCES t4(x,y,z) -- 2 vs 3
+                //
+                // This count check runs BEFORE resolving the child column names
+                // to indices: SQLite reports the column-count mismatch even when
+                // one of the child columns does not exist in this table (e_fkey-
+                // 54.B: `FOREIGN KEY(c,b) REFERENCES t2(d)` on a table with no
+                // column `c` still reports the count mismatch, not "unknown
+                // column c"). Only when the parent column list is entirely
+                // omitted (no count to compare against) does the unknown-child-
+                // column check below get to run first (e_fkey-54.A).
+                if !references_columns.is_empty() && references_columns.len() != fk_columns.len() {
+                    return Err(ExecutorError::SqliteCompatError(
+                        "number of columns in foreign key does not match the number of columns in the referenced table"
+                            .to_string(),
+                    ));
+                }
+
                 // Resolve column indices for FK columns. SQLite reports a
                 // dedicated "unknown column ... in foreign key definition"
                 // message here (distinct from the generic "no such column"
@@ -504,20 +527,6 @@ impl CreateTableExecutor {
                         })
                     })
                     .collect::<Result<Vec<_>, _>>()?;
-
-                // A table-level FOREIGN KEY(...) clause's child and parent column
-                // lists must be the same length when a parent column list is given
-                // at all (an omitted parent list defaults to the parent's PRIMARY
-                // KEY and is checked elsewhere). SQLite rejects a mismatch at CREATE
-                // TABLE time (table.test table-10.9/table-10.10, issue #6173):
-                //   FOREIGN KEY(b,c) REFERENCES t4(x)     -- 2 vs 1
-                //   FOREIGN KEY(b,c) REFERENCES t4(x,y,z) -- 2 vs 3
-                if !references_columns.is_empty() && references_columns.len() != fk_columns.len() {
-                    return Err(ExecutorError::SqliteCompatError(
-                        "number of columns in foreign key does not match the number of columns in the referenced table"
-                            .to_string(),
-                    ));
-                }
 
                 // Lookup parent table to get parent column indices
                 // If the parent table doesn't exist yet, use placeholder indices.

--- a/crates/vibesql-executor/src/update/fast_path.rs
+++ b/crates/vibesql-executor/src/update/fast_path.rs
@@ -129,6 +129,46 @@ pub(super) fn try_fast_path_update(
         }
     }
 
+    // The PK-only check above misses a real referential-integrity hazard:
+    // another table's FOREIGN KEY can target THIS table's parent key on a
+    // column set that is NOT this table's own PRIMARY KEY -- e.g.
+    // `FOREIGN KEY(x,y) REFERENCES tce71(a,b)` where tce71's actual PRIMARY
+    // KEY is only `a` and the composite parent key `(a,b)` is backed by a
+    // separate UNIQUE INDEX or table-level UNIQUE constraint (fkey2-
+    // ce7c13.1.2/1.3/1.5/1.6). Without this check, `UPDATE tce71 SET b=201`
+    // touches no PK column, `updates_pk` is false, and the fast path applied
+    // the write directly with ZERO foreign-key enforcement -- silently
+    // orphaning `tce72`'s reference. Fall back to the normal path whenever
+    // an assigned column is part of any OTHER table's FK parent key that
+    // references this table, using the same lazy parent-index resolution
+    // the normal path already relies on (`resolved_parent_indices_for_fk`)
+    // so a FK declared before its parent table existed still resolves
+    // correctly here.
+    {
+        let assigned_indices: HashSet<usize> =
+            stmt.assignments.iter().filter_map(|a| schema.get_column_index(&a.column)).collect();
+        let touches_incoming_fk_parent_key = !assigned_indices.is_empty()
+            && database.catalog.list_tables().iter().any(|other_table_name| {
+                database
+                    .catalog
+                    .get_table(other_table_name)
+                    .map(|other_schema| {
+                        other_schema.foreign_keys.iter().any(|fk| {
+                            fk.parent_table.eq_ignore_ascii_case(table_name)
+                                && crate::foreign_key_check::resolved_parent_indices_for_fk(
+                                    database, fk,
+                                )
+                                .iter()
+                                .any(|idx| assigned_indices.contains(idx))
+                        })
+                    })
+                    .unwrap_or(false)
+            });
+        if touches_incoming_fk_parent_key {
+            return Ok(None); // Use normal path for FK enforcement
+        }
+    }
+
     // Re-borrow table to get the old row
     let table = database
         .get_table(table_name)

--- a/crates/vibesql-executor/tests/foreign_key_fast_path_and_unique_parent_tests.rs
+++ b/crates/vibesql-executor/tests/foreign_key_fast_path_and_unique_parent_tests.rs
@@ -23,7 +23,7 @@
 //!   the configured referential action actually fires.
 
 use vibesql_ast::Statement;
-use vibesql_executor::{CreateTableExecutor, InsertExecutor, UpdateExecutor};
+use vibesql_executor::{CreateIndexExecutor, CreateTableExecutor, InsertExecutor, UpdateExecutor};
 use vibesql_parser::Parser;
 use vibesql_storage::Database;
 use vibesql_types::SqlValue;
@@ -33,6 +33,9 @@ fn run(db: &mut Database, sql: &str) -> Result<String, String> {
     match stmt {
         Statement::CreateTable(s) => {
             CreateTableExecutor::execute(&s, db).map(|_| String::new()).map_err(|e| e.to_string())
+        }
+        Statement::CreateIndex(s) => {
+            CreateIndexExecutor::execute(&s, db).map(|_| String::new()).map_err(|e| e.to_string())
         }
         Statement::Insert(s) => {
             InsertExecutor::execute(db, &s).map(|_| String::new()).map_err(|e| e.to_string())
@@ -66,8 +69,11 @@ fn fast_path_update_of_fk_column_to_missing_parent_is_rejected() {
     // with no UNIQUE/PK/index of its own — exactly the shape that used to slip
     // past FK validation on the in-place path.
     run(&mut db, "CREATE TABLE parent(a INTEGER PRIMARY KEY, b)").unwrap();
-    run(&mut db, "CREATE TABLE child(id INTEGER PRIMARY KEY, fk_col REFERENCES parent(a), payload)")
-        .unwrap();
+    run(
+        &mut db,
+        "CREATE TABLE child(id INTEGER PRIMARY KEY, fk_col REFERENCES parent(a), payload)",
+    )
+    .unwrap();
     run(&mut db, "INSERT INTO parent VALUES(1, 10)").unwrap();
     run(&mut db, "INSERT INTO child VALUES(1, 1, 100)").unwrap();
 
@@ -95,8 +101,11 @@ fn fast_path_update_of_fk_column_to_existing_parent_succeeds() {
     let mut db = Database::new();
     db.set_foreign_keys_enabled(true);
     run(&mut db, "CREATE TABLE parent(a INTEGER PRIMARY KEY, b)").unwrap();
-    run(&mut db, "CREATE TABLE child(id INTEGER PRIMARY KEY, fk_col REFERENCES parent(a), payload)")
-        .unwrap();
+    run(
+        &mut db,
+        "CREATE TABLE child(id INTEGER PRIMARY KEY, fk_col REFERENCES parent(a), payload)",
+    )
+    .unwrap();
     run(&mut db, "INSERT INTO parent VALUES(1, 10)").unwrap();
     run(&mut db, "INSERT INTO parent VALUES(2, 20)").unwrap();
     run(&mut db, "INSERT INTO child VALUES(1, 1, 100)").unwrap();
@@ -159,7 +168,150 @@ fn update_of_unique_parent_key_with_referencing_child_is_restricted() {
 
     // The child must remain untouched and still reference the (unchanged) key.
     let parent = rows(&db, "parent");
-    assert_eq!(parent[0][1], SqlValue::Integer(100), "parent key changed despite restriction: {parent:?}");
+    assert_eq!(
+        parent[0][1],
+        SqlValue::Integer(100),
+        "parent key changed despite restriction: {parent:?}"
+    );
     let child = rows(&db, "child");
-    assert_eq!(child[0][0], SqlValue::Integer(100), "child reference changed unexpectedly: {child:?}");
+    assert_eq!(
+        child[0][0],
+        SqlValue::Integer(100),
+        "child reference changed unexpectedly: {child:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bug #3 (#6170): single-row UPDATE fast path bypassed FK enforcement on a
+// parent key backed by a plain CREATE UNIQUE INDEX (not the table's own PK and
+// not a column/table-level UNIQUE constraint).
+// ---------------------------------------------------------------------------
+//
+// The fast path decided whether an incoming FK needed re-validation by checking
+// only whether the UPDATE touched the table's own PRIMARY KEY columns. A FK from
+// another table can target a *non-PK* composite parent key backed by a separate
+// `CREATE UNIQUE INDEX` — which, unlike a column/table-level `UNIQUE`, never
+// populates `schema.unique_constraints`, so the pre-existing "skip fast path if
+// table has unique constraints" guard did not catch it either. `UPDATE parent
+// SET b=201 WHERE a=1` therefore touched no PK column, the fast path applied the
+// write directly with ZERO FK enforcement, and the child row was silently
+// orphaned (fkey2-ce7c13.1.2/1.3/1.5/1.6). The fix falls back to the normal path
+// whenever an assigned column is part of any other table's FK parent key that
+// references this table.
+
+/// Composite parent key `(a,b)` backed by `CREATE UNIQUE INDEX` (the table's PK
+/// is only `a`). A child FK references `(a,b)`. `UPDATE parent SET b=<new>` via
+/// the single-row fast path, while a child still references the old `(a,b)`,
+/// must be rejected — not silently applied with the child left dangling.
+#[test]
+fn fast_path_update_of_unique_index_backed_parent_key_is_enforced() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    // Parent PK is only `a`; the composite parent key `(a,b)` is materialized
+    // solely by a plain CREATE UNIQUE INDEX — the exact shape that never lands
+    // in `schema.unique_constraints`.
+    run(&mut db, "CREATE TABLE tce71(a INTEGER PRIMARY KEY, b INTEGER)").unwrap();
+    run(&mut db, "CREATE UNIQUE INDEX tce71_ab ON tce71(a, b)").unwrap();
+    run(&mut db, "CREATE TABLE tce72(x, y, FOREIGN KEY(x, y) REFERENCES tce71(a, b))").unwrap();
+    run(&mut db, "INSERT INTO tce71 VALUES(1, 100)").unwrap();
+    run(&mut db, "INSERT INTO tce72 VALUES(1, 100)").unwrap();
+
+    // `WHERE a = 1` resolves a single row (fast-path trigger); `b` is not the PK
+    // and carries no UNIQUE constraint of its own. Changing it orphans tce72's
+    // (1,100) reference, so this must raise an FK violation.
+    let res = run(&mut db, "UPDATE tce71 SET b = 201 WHERE a = 1");
+    assert!(
+        res.is_err(),
+        "single-row fast-path UPDATE of a UNIQUE-INDEX-backed FK parent key with a referencing child must be rejected, got {res:?}"
+    );
+
+    // And it must not have been silently applied: the parent key is unchanged.
+    let parent = rows(&db, "tce71");
+    assert_eq!(parent.len(), 1, "parent row count changed unexpectedly");
+    assert_eq!(
+        parent[0][1],
+        SqlValue::Integer(100),
+        "UNIQUE-INDEX-backed parent key was silently mutated despite a referencing child: {parent:?}"
+    );
+}
+
+/// Companion guard: the same fast-path UPDATE of the UNIQUE-INDEX-backed parent
+/// key must still succeed when no child references the old value (the fallback
+/// to the normal path must not over-reject a legitimate update).
+#[test]
+fn fast_path_update_of_unique_index_backed_parent_key_without_child_ref_succeeds() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    run(&mut db, "CREATE TABLE tce71(a INTEGER PRIMARY KEY, b INTEGER)").unwrap();
+    run(&mut db, "CREATE UNIQUE INDEX tce71_ab ON tce71(a, b)").unwrap();
+    run(&mut db, "CREATE TABLE tce72(x, y, FOREIGN KEY(x, y) REFERENCES tce71(a, b))").unwrap();
+    run(&mut db, "INSERT INTO tce71 VALUES(1, 100)").unwrap();
+    // No child row references (1,100), so changing b is free.
+    run(&mut db, "UPDATE tce71 SET b = 201 WHERE a = 1").unwrap_or_else(|e| {
+        panic!("unreferenced UNIQUE-INDEX-backed parent-key update must succeed: {e}")
+    });
+
+    let parent = rows(&db, "tce71");
+    assert_eq!(
+        parent[0][1],
+        SqlValue::Integer(201),
+        "valid parent-key update did not apply: {parent:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bug #4 (#6170): CREATE TABLE FK validation reported the wrong error when a
+// column-count mismatch and an unknown child column coincided.
+// ---------------------------------------------------------------------------
+//
+// `FOREIGN KEY(...)` validation resolved child column names to indices (raising
+// "unknown column ... in foreign key definition") *before* checking whether the
+// child/parent column counts even matched. SQLite reports the count-mismatch
+// error first when an explicit parent column list is given, regardless of
+// whether a child column also happens to be unknown (e_fkey-54.B). The fix runs
+// the count check before the unknown-column resolution.
+
+/// `FOREIGN KEY(c, b) REFERENCES t2(d)` on a table with no column `c`: the child
+/// list has 2 columns, the parent list has 1 — SQLite reports the count mismatch
+/// even though `c` is also unknown. We must surface the count-mismatch message,
+/// not "unknown column c".
+#[test]
+fn create_table_fk_count_mismatch_reported_before_unknown_child_column() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    run(&mut db, "CREATE TABLE t2(d INTEGER PRIMARY KEY, e)").unwrap();
+
+    // Child column `c` does not exist AND the (2 vs 1) column counts mismatch.
+    let res = run(&mut db, "CREATE TABLE t1(a, b, FOREIGN KEY(c, b) REFERENCES t2(d))");
+    let err = res.expect_err("mismatched-count FK with an unknown child column must be rejected");
+    assert!(
+        err.contains("number of columns in foreign key does not match"),
+        "expected the column-count-mismatch message to win over the unknown-column message, got: {err}"
+    );
+    assert!(
+        !err.contains("unknown column"),
+        "unknown-column message leaked ahead of the count-mismatch check: {err}"
+    );
+}
+
+/// Control: when the counts DO match but a child column is genuinely unknown,
+/// the unknown-column message is still the one reported (the reorder must not
+/// swallow the unknown-column path when there is no count mismatch to report).
+#[test]
+fn create_table_fk_unknown_child_column_reported_when_counts_match() {
+    let mut db = Database::new();
+    db.set_foreign_keys_enabled(true);
+    run(&mut db, "CREATE TABLE t2(d INTEGER PRIMARY KEY)").unwrap();
+
+    // Counts match (1 vs 1) but child column `c` does not exist.
+    let res = run(&mut db, "CREATE TABLE t1(a, b, FOREIGN KEY(c) REFERENCES t2(d))");
+    let err = res.expect_err("FK referencing an unknown child column must be rejected");
+    assert!(
+        !err.contains("number of columns in foreign key"),
+        "count-mismatch message wrongly reported when counts actually match: {err}"
+    );
+    assert!(
+        err.contains("unknown column"),
+        "expected the unknown-column message when counts match but the child column is unknown, got: {err}"
+    );
 }

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -2488,7 +2488,7 @@ proc trial_check_in_transaction {new_sql} {
     }
 }
 
-proc trial_check_closing_transaction {sql} {
+proc trial_check_closing_transaction {sql {min_index 1} {base_db ""}} {
     # Trial-run the about-to-be-flushed batch (the existing $::sql_batch
     # plus this closing $sql, e.g. "COMMIT" or a stack-emptying "RELEASE")
     # with an appended ROLLBACK against a throwaway copy of the DB — the
@@ -2506,12 +2506,40 @@ proc trial_check_closing_transaction {sql} {
     # the batched statements are lost and the transaction is wrongly
     # treated as closed (fkey2-2.40/2.41, e_fkey-38.3/38.4).
     #
+    # $min_index (default 1, preserving the original callers' behavior) is
+    # the CLI statement index at/after which an error is attributed to
+    # *this* closing statement rather than to some earlier, already-known
+    # failure replayed from $::sql_batch. A caller whose batch already
+    # contains an earlier tolerated failure (#5478's "close fails but
+    # transaction survives" recovery, extended to the tolerate_err=1 case —
+    # zzfk-62.6/e_fkey-62.6) must pass the closer's own CLI statement index
+    # so the first (lower-index) re-fired error is skipped and only a
+    # genuinely NEW error at/after the closer is attributed here — mirroring
+    # trial_check_in_transaction's new_stmt_index.
+    #
     # Sets $::txn_close_survived_trial_error to 1 when the trial's error
     # left the appended ROLLBACK something to undo (the close failed but
     # the transaction survives), 0 otherwise (the close's error genuinely
     # ended the transaction, e.g. RAISE(ROLLBACK)). Raises a TCL error
-    # (translated to SQLite wording) when the trial reports an error;
-    # returns silently on success.
+    # (translated to SQLite wording) when the trial reports an error at/after
+    # $min_index; returns silently otherwise (including when only an
+    # earlier, lower-index error re-fired).
+    #
+    # $base_db (default "" — copy from the live $::db_file, the original
+    # behavior) lets a caller supply a PRE-flush snapshot to replay against
+    # instead. This matters for a caller invoked AFTER the real (mutating)
+    # flush_batch already ran once: that real flush executes $::sql_batch
+    # against the live $::db_file, and any pre-BEGIN autocommit DDL in the
+    # batch (e.g. `CREATE TABLE p(...); ...; BEGIN;` bundled into one
+    # execsql block — the common e_fkey/fkey2 pattern) is *already
+    # persisted* there regardless of whether the later transaction's close
+    # ultimately failed (matches real SQLite: autocommit DDL commits
+    # immediately, independent of a later BEGIN/COMMIT). Copying the
+    # (already-mutated) live db and then replaying that same pre-BEGIN DDL
+    # a second time spuriously fails with "table already exists" at an
+    # index BEFORE the closer, which masks the real question this trial
+    # exists to answer (zzfk-62.7/e_fkey-62.7). Supplying the PRE-flush
+    # snapshot avoids the double-application.
     set batch_stmts {}
     foreach stmt $::sql_batch {
         set s [string trimright $stmt]
@@ -2533,11 +2561,12 @@ proc trial_check_closing_transaction {sql} {
     puts $f $combined
     close $f
 
-    if {$::db_file eq ""} {
+    set source_db [expr {$base_db ne "" ? $base_db : $::db_file}]
+    if {$source_db eq ""} {
         catch {exec $::vibesql_path < $tmpfile 2>@1} result
     } else {
         set trial_db "/tmp/vibesql_closetrialdb_[pid]_[clock microseconds].vbsql"
-        copy_db_with_wal $::db_file $trial_db
+        copy_db_with_wal $source_db $trial_db
         catch {exec $::vibesql_path $trial_db < $tmpfile 2>@1} result
         delete_db_with_wal $trial_db
     }
@@ -2545,8 +2574,8 @@ proc trial_check_closing_transaction {sql} {
 
     set ::txn_close_survived_trial_error 0
     if {[regexp {(?m)^Error executing statement|^Error:} $result]} {
-        set err_line [select_error_line_for_stmt $result 1]
-        if {$err_line eq ""} {
+        set err_line [select_error_line_for_stmt $result $min_index]
+        if {$err_line eq "" && $min_index <= 1} {
             foreach line [split $result "\n"] {
                 set line [string trim $line]
                 if {[regexp {^Error: } $line]} {
@@ -2559,8 +2588,12 @@ proc trial_check_closing_transaction {sql} {
             }
         }
         if {$err_line eq ""} {
-            # No attributable error line found — defensively treat as
-            # success rather than raising an unattributable failure.
+            # No attributable error at/after $min_index — either a
+            # defensive "treat as success" (the classic min_index=1 case
+            # with truly no error line at all) or, for a caller-supplied
+            # min_index > 1, only an earlier, already-known error re-fired
+            # and the closer itself introduced nothing new. Either way
+            # there is nothing new to report here.
             return
         }
         set ::txn_close_survived_trial_error \
@@ -3203,6 +3236,26 @@ proc execsql {sql {db ""}} {
         # transaction ends with this flush.
         set tolerate_err $::txn_had_tolerated_error
         set ::txn_had_tolerated_error 0
+        # Snapshot the database exactly as it stands BEFORE this flush, so a
+        # deferred-FK "close fails but transaction survives" recovery trial
+        # (below) can replay $pre_close_batch from the same starting point the
+        # real flush used — not from the POST-flush database. The real flush
+        # runs the whole batch (including any pre-BEGIN autocommit DDL, e.g.
+        # `CREATE TABLE p(...); ...; BEGIN;` bundled into one execsql block —
+        # the common e_fkey/fkey2 pattern) against the live $::db_file, and
+        # that DDL is already persisted there regardless of whether the
+        # transaction's close ultimately fails (matches real SQLite: autocommit
+        # DDL commits immediately, independent of a later BEGIN/COMMIT).
+        # Replaying $pre_close_batch a second time against that already-mutated
+        # database would spuriously re-fail on "table already exists" (#6170,
+        # zzfk-62.7/e_fkey-62.7). Gated on $::pragma_foreign_keys (only FK
+        # enforcement can trigger this recovery at all) and $::db_file ne ""
+        # (nothing to snapshot for a pure in-memory run).
+        set pre_flush_snapshot ""
+        if {$::pragma_foreign_keys != 0 && $::db_file ne ""} {
+            set pre_flush_snapshot "/tmp/vibesql_preflush_[pid]_[clock microseconds].vbsql"
+            copy_db_with_wal $::db_file $pre_flush_snapshot
+        }
         if {[catch {flush_batch $tolerate_err} result]} {
             set translated_err [translate_error_to_sqlite $result]
             #
@@ -3211,17 +3264,19 @@ proc execsql {sql {db ""}} {
             # a COMMIT (or a RELEASE that empties the savepoint stack) can
             # fail on an outstanding deferred FK violation WITHOUT closing
             # the transaction. The real flush above already tried and
-            # failed (and — critically — did NOT persist anything, since
+            # failed (and — critically — did NOT persist anything beyond
+            # what the pre-flush snapshot above already captured, since
             # per-statement WAL entries for an uncommitted transaction are
             # discarded on the next open/replay), so it is safe to re-derive
             # "did it survive?" from a throwaway trial replay of the exact
-            # same (pre-close-statement) batch, run only on this rarer
-            # failure path so the common (successful-close) path pays no
-            # extra CLI invocation at all. Gated on $::pragma_foreign_keys:
-            # files that never enable FK enforcement can never hit this.
+            # same (pre-close-statement) batch — starting from the pre-flush
+            # snapshot — run only on this rarer failure path so the common
+            # (successful-close) path pays no extra CLI invocation at all.
+            # Gated on $::pragma_foreign_keys: files that never enable FK
+            # enforcement can never hit this.
             if {$::pragma_foreign_keys != 0 && !$tolerate_err} {
                 set ::sql_batch $pre_close_batch
-                if {[catch {trial_check_closing_transaction $sql} trial_err]} {
+                if {[catch {trial_check_closing_transaction $sql 1 $pre_flush_snapshot} trial_err]} {
                     if {$::txn_close_survived_trial_error} {
                         # Leave $::sql_batch (restored above) / re-open
                         # $::in_transaction — the failing closer is
@@ -3238,8 +3293,79 @@ proc execsql {sql {db ""}} {
                 # and fall through to raise the real flush's own error.
                 set ::sql_batch {}
             }
+            if {$pre_flush_snapshot ne ""} {
+                delete_db_with_wal $pre_flush_snapshot
+            }
             # Translate error to SQLite format before re-raising
             error $translated_err
+        }
+        # The recovery trial below only ever runs when $tolerate_err is set
+        # (an earlier statement in this transaction already surfaced an
+        # attributed error); when it's not set, the snapshot taken above is
+        # never consulted, so free it now rather than leaking a throwaway
+        # database + WAL siblings on every ordinary (non-recovery) close.
+        if {!$tolerate_err && $pre_flush_snapshot ne ""} {
+            delete_db_with_wal $pre_flush_snapshot
+            set pre_flush_snapshot ""
+        }
+        # Even when $tolerate_err suppressed flush_batch's exit-code check (an
+        # earlier statement in this transaction already surfaced an attributed
+        # error, #5478), the CLOSING statement itself can introduce a
+        # genuinely NEW error that has never been surfaced to any test — e.g.
+        # a deferred FK violation caught only at COMMIT, after an earlier
+        # immediate-FK statement in the same transaction already failed and
+        # was tolerated (zzfk-62.6 / e_fkey-62.6). parse_result's
+        # tolerate_attributed_error skip is position-blind: it swallows EVERY
+        # "Error" line in the flush output, not just the one already
+        # attributed to an earlier test, so the COMMIT's own new failure was
+        # silently dropped instead of surfacing at this test. Detect it by
+        # locating the CLI statement index at which the closing statement
+        # itself begins (after the pragma prefix and everything already
+        # batched before this close) and checking for an error at/after that
+        # index — mirroring trial_check_in_transaction's new_stmt_index math.
+        if {$tolerate_err} {
+            set pre_close_stmts {}
+            foreach stmt $pre_close_batch {
+                set s [string trimright $stmt]
+                set s [string trimright $s ";"]
+                lappend pre_close_stmts $s
+            }
+            set close_prefix [build_pragma_prefix]
+            if {[llength $pre_close_stmts] > 0} {
+                append close_prefix [join $pre_close_stmts ";\n"] ";\n"
+            }
+            set close_stmt_index [expr {[count_cli_statements $close_prefix] + 1}]
+            set new_err [select_error_line_for_stmt $result $close_stmt_index]
+            if {$new_err ne ""} {
+                set translated_err [translate_error_to_sqlite $new_err]
+                # Same deferred-FK "close fails but transaction survives"
+                # recovery as the untolerated-error branch above: re-derive
+                # whether the transaction survives from a throwaway trial
+                # replay of the pre-close batch — starting from the
+                # pre-flush snapshot, not the post-flush database.
+                if {$::pragma_foreign_keys != 0} {
+                    set ::sql_batch $pre_close_batch
+                    if {[catch {trial_check_closing_transaction $sql $close_stmt_index $pre_flush_snapshot} trial_err]} {
+                        if {$::txn_close_survived_trial_error} {
+                            # The pre-close batch still carries the earlier
+                            # already-attributed failing statement, so the
+                            # NEXT flush of this (still-open) transaction
+                            # must keep tolerating its re-fired error too.
+                            set ::in_transaction 1
+                            set ::txn_had_tolerated_error 1
+                            error $trial_err
+                        }
+                    }
+                    set ::sql_batch {}
+                }
+                if {$pre_flush_snapshot ne ""} {
+                    delete_db_with_wal $pre_flush_snapshot
+                }
+                error $translated_err
+            }
+            if {$pre_flush_snapshot ne ""} {
+                delete_db_with_wal $pre_flush_snapshot
+            }
         }
         set parsed [parse_result $result $tolerate_err]
         # When the statement that closes this batched transaction is ONLY a

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -3284,6 +3284,13 @@ proc execsql {sql {db ""}} {
                         # statements (including a retried close) replay
                         # correctly from scratch at the next flush.
                         set ::in_transaction 1
+                        # `error` unwinds straight out of execsql, past the
+                        # cleanup a few lines below, so free the pre-flush
+                        # snapshot here or it leaks on this survival path
+                        # (the common deferred-FK fkey2/e_fkey/zzfk case).
+                        if {$pre_flush_snapshot ne ""} {
+                            delete_db_with_wal $pre_flush_snapshot
+                        }
                         error $trial_err
                     }
                 }
@@ -3353,6 +3360,13 @@ proc execsql {sql {db ""}} {
                             # must keep tolerating its re-fired error too.
                             set ::in_transaction 1
                             set ::txn_had_tolerated_error 1
+                            # `error` unwinds straight out of execsql, past the
+                            # cleanup a few lines below, so free the pre-flush
+                            # snapshot here or it leaks on this survival path
+                            # (the common deferred-FK fkey2/e_fkey/zzfk case).
+                            if {$pre_flush_snapshot ne ""} {
+                                delete_db_with_wal $pre_flush_snapshot
+                            }
                             error $trial_err
                         }
                     }


### PR DESCRIPTION
## Summary

Part of the FK-enforcement family issue #6170 (fkey2/e_fkey/fkey1/fkey3/fkey4/fkey7). This increment fixes three distinct, verified bugs uncovered while chasing specific certified failures — one real engine gap, one CREATE TABLE validation-order bug, and one TCL-shim transaction-recovery bug that was silently masking real engine errors.

## Changes

1. **`update/fast_path.rs`** — the single-row UPDATE fast path decided whether an incoming foreign key needed re-validation by checking only whether the statement updates the *table's own PRIMARY KEY* columns. A FK from another table can target this table's parent key on a **non-PK** column set backed by a separate `UNIQUE INDEX` or table-level `UNIQUE` constraint (e.g. `FOREIGN KEY(x,y) REFERENCES tce71(a,b)` where `tce71`'s actual PK is only `a`). `UPDATE tce71 SET b=201` touched no PK column, so the fast path applied the write directly with **zero FK enforcement**, silently orphaning the child row (`fkey2-ce7c13.1.2/1.3/1.5/1.6`). Now falls back to the normal path whenever an assigned column is part of any *other* table's FK parent key referencing this table, using the same lazy parent-index resolution (`resolved_parent_indices_for_fk`) the normal path already relies on.

2. **`create_table.rs`** — `CREATE TABLE ... FOREIGN KEY(...)` validation resolved the child column names to indices (raising "unknown column ... in foreign key definition") *before* checking whether the child/parent column counts even matched. SQLite reports the count-mismatch error first when an explicit parent column list is given, regardless of whether a child column also happens to be unknown (`e_fkey-54.B`). Reordered the checks to match.

3. **`scripts/tester_vibesql.tcl`** (TCL conformance shim) — two related bugs in the shim's transaction-close recovery logic:
   - When a transaction close (COMMIT/RELEASE) fails on a **new** deferred-FK violation *after* an earlier statement in the same transaction already had a tolerated/attributed error, the shim's blanket "tolerate re-fired errors" logic swallowed the new error too instead of surfacing it (`zzfk-62.6`/`e_fkey-62.6`, `fkey2-12.1.6`, `fkey2-ce7c13.*`). Errors are now attributed by CLI statement position so only a genuinely new error at/after the closer is surfaced.
   - The recovery trial that determines "did the transaction survive this failed close" replayed the pre-close batch (including any pre-BEGIN autocommit DDL bundled into the same execsql block, the common e_fkey/fkey2 pattern) against a copy of the database **taken after** the real flush had already applied that same DDL — causing a spurious "table already exists" error that masked the real answer (`zzfk-62.7`/`e_fkey-62.7`, `fkey2-12.1.7`). The database is now snapshotted *before* the real flush and that pre-flush snapshot is used for the recovery trial.

A separate, unrelated bug was discovered during this investigation and filed independently rather than fixed here (out of scope for FK enforcement — it reproduces with a plain `UNIQUE` column and no FK at all): **#6346** — multi-row `INSERT ... VALUES (a),(b)` skips its intra-statement UNIQUE check on a table loaded from a reopened/WAL-recovered database.

## Acceptance Criteria Verification

Issue #6170 asks for `fkey2.test`/`e_fkey.test` to fully pass, or for every remaining failure to be justified/routed. This PR is a **partial increment** (the issue explicitly expects multiple increments and has 10+ prior merged partial-increment PRs) — it does not clear every remaining failure, but every failure it does clear is verified below, and no regressions were introduced.

| Criterion | Status | Verification |
|---|---|---|
| `fkey2.test` improves, no regressions | ✅ | 80 failed / 1100 passed → **71 failed / 1109 passed** (92.0%). Full before/after failure-list diff confirms the only removed items are `fkey2-2.68`, `2.69c`, `2.70`, `12.1.6`, `12.1.7`, `ce7c13.1.2/1.3/1.5/1.6` (9 fixed) — no new failures appear. |
| `e_fkey.test` improves, no regressions | ✅ | 830 failed(76)/passed(919 salvaged scope) → **843 passed / 64 failed** (within the same ~919-row salvaged scope; file exceeds the 1200s harness timeout on this loaded machine both before and after, per `CLAUDE.md`'s quiet-machine caveat). Confirmed absent from the failing list: `e_fkey-54.B.off`, `54.B.on`, `62.6`, `62.7`. |
| `fkey1.test`/`fkey3.test`/`fkey4.test`/`fkey7.test` unaffected or improved | ✅ | `fkey3.test` stays 100% (31/31). `fkey1.test` (21/26), `fkey4.test` (2/8), `fkey7.test` (8/16) are **unchanged** — their remaining failures are unrelated harness/engine gaps (`sqlite3_prepare_v2`/`db auth` C-API emulation, reserved `sqlite_stat1` name, and the newly-filed #6346) outside this increment's scope. |
| No regressions in shared TCL-shim transaction machinery | ✅ | `savepoint.test` (25/87) and `trans.test` (62/135) produce **byte-identical** pass/fail counts with the shim change stashed out vs. applied (isolated A/B test against the same rebuilt binary). |
| Rust unit tests pass | ✅ | All existing FK/UPDATE test suites pass: `foreign_key_tests`, `foreign_key_deferred_tests`, `foreign_key_deferred_phase_c3_tests`, `foreign_key_self_referential_tests`, `foreign_key_set_default_tests`, `foreign_key_composite_child_order_tests`, `foreign_key_cascade_cache_tests`, `foreign_key_fast_path_and_unique_parent_tests`, `foreign_key_parent_unchanged_key_tests`, `foreign_key_collation_action_tests`, `update_basic_tests`, `update_constraint_tests`, `update_onepass_tests`, `update_delete_pk_affinity_tests`, `update_deferred_uniqueness_tests`, `update_default_tests`, `update_cross_update_unique_message_tests` — 0 failures across all of them. |
| `cargo check` / `cargo +nightly fmt --check` clean on changed lines | ✅ | `cargo check -p vibesql-executor` passes. `cargo +nightly fmt --check` on the touched files shows only pre-existing, unrelated drift (confirmed via `git diff` that those lines are not part of this PR's diff); the new code in `fast_path.rs` is formatted per rustfmt. |

## Test Plan

```bash
make test-tcl-file FILE=fkey2.test    # 71 failed / 1109 passed (was 80/1100)
make test-tcl-file FILE=e_fkey.test   # 64 failed / 843 passed within salvaged scope (was 76/830)
make test-tcl-file FILE=fkey1.test    # unchanged: 2 failed / 21 passed
make test-tcl-file FILE=fkey3.test    # unchanged: 0 failed / 31 passed
make test-tcl-file FILE=fkey4.test    # unchanged: 2 failed / 2 passed
make test-tcl-file FILE=fkey7.test    # unchanged: 7 failed / 8 passed
make test-tcl-file FILE=savepoint.test  # unchanged: 54 failed / 25 passed (isolated shim-only A/B)
make test-tcl-file FILE=trans.test      # unchanged: 72 failed / 62 passed (isolated shim-only A/B)

cargo test -p vibesql-executor --release \
  --test foreign_key_tests --test foreign_key_deferred_tests \
  --test foreign_key_self_referential_tests --test foreign_key_set_default_tests \
  --test foreign_key_deferred_phase_c3_tests --test foreign_key_composite_child_order_tests \
  --test foreign_key_cascade_cache_tests --test foreign_key_fast_path_and_unique_parent_tests \
  --test foreign_key_parent_unchanged_key_tests --test foreign_key_collation_action_tests \
  --test update_basic_tests --test update_constraint_tests --test update_onepass_tests \
  --test update_delete_pk_affinity_tests --test update_deferred_uniqueness_tests \
  --test update_default_tests --test update_cross_update_unique_message_tests
# all passing, 0 failures
```

Part of #6170