### PR TITLE
fix(autoinc): route sqlite_sequence bookkeeping via an explicit owning_schema param

### DIFF
--- a/crates/vibesql-executor/src/autoincrement.rs
+++ b/crates/vibesql-executor/src/autoincrement.rs
@@ -58,42 +58,33 @@ fn sqlite_sequence_table_schema() -> TableSchema {
     schema
 }
 
-/// Resolve the schema that owns `target_table`'s AUTOINCREMENT bookkeeping,
-/// following SQLite's temp-shadows-main name resolution so it agrees with the
-/// schema the INSERT/DROP itself targeted. Falls back to the current schema
-/// when the table can't be resolved (e.g. engine-internal unit tests that
-/// track a `sqlite_sequence` row without a backing user table).
-fn sequence_owner_schema(database: &Database, target_table: &str) -> String {
-    database
-        .catalog
-        .resolve_table_schema_name(target_table)
-        .unwrap_or_else(|| database.catalog.get_current_schema().to_string())
-}
-
-/// The schema-qualified physical name of the `sqlite_sequence` table that owns
-/// `target_table`'s bookkeeping (e.g. `main.sqlite_sequence` or
-/// `temp_7.sqlite_sequence`).
+/// The schema-qualified physical name of the `sqlite_sequence` table living in
+/// `owning_schema` (e.g. `main.sqlite_sequence` or `temp_7.sqlite_sequence`).
 ///
 /// Each database — `main` plus every session's temp schema — keeps its OWN
-/// `sqlite_sequence` table, exactly like SQLite (autoinc-4.x). Resolving the
-/// owning schema here (rather than using the bare, unqualified name, which
-/// resolves temp-shadows-main) is what keeps a main table's high-water mark in
-/// `main.sqlite_sequence` and a temp table's in `temp.sqlite_sequence` — the
-/// two never cross-contaminate even when both exist at once (issue #6173).
-fn sequence_table_name(database: &Database, target_table: &str) -> String {
-    format!("{}.{}", sequence_owner_schema(database, target_table), SQLITE_SEQUENCE_TABLE)
+/// `sqlite_sequence` table, exactly like SQLite (autoinc-4.x). The owning
+/// schema is supplied EXPLICITLY by the caller (resolved from the original,
+/// possibly-qualified statement text) rather than re-derived here from the
+/// bare table name: a bare-name re-resolution re-applies temp-shadows-main and
+/// therefore misroutes an explicitly-qualified `INSERT INTO main.t1` to
+/// `temp.sqlite_sequence` whenever a same-named table exists in the temp
+/// schema (issue #6350). This mirrors [`remove_sequence_entry`]'s API shape,
+/// which `drop_table.rs`/`truncate` already use correctly.
+fn sequence_table_in(owning_schema: &str) -> String {
+    format!("{}.{}", owning_schema, SQLITE_SEQUENCE_TABLE)
 }
 
-/// Lazily create the `sqlite_sequence` table in the schema that owns
-/// `target_table` if it does not already exist there. Safe to call
-/// unconditionally — a no-op when the table is already present (e.g. a second
-/// `CREATE TABLE ... AUTOINCREMENT` in the same schema, or a table reloaded
-/// from a snapshot that already created it).
+/// Lazily create the `sqlite_sequence` table in `owning_schema` if it does not
+/// already exist there. Safe to call unconditionally — a no-op when the table
+/// is already present (e.g. a second `CREATE TABLE ... AUTOINCREMENT` in the
+/// same schema, or a table reloaded from a snapshot that already created it).
 ///
-/// The table is created in `target_table`'s owning schema (main vs. a temp
-/// schema), NOT the current schema, so a `CREATE TEMP TABLE ... AUTOINCREMENT`
-/// issued while the current schema is `main` still gets its `sqlite_sequence`
-/// in the temp schema (autoinc-4.x).
+/// `owning_schema` is the schema (`main` or a `temp_*` schema) that owns the
+/// AUTOINCREMENT table, resolved by the caller from the original (possibly
+/// schema-qualified) statement — NOT re-derived from the bare table name here
+/// (issue #6350; see [`sequence_table_in`]). A `CREATE TEMP TABLE ...
+/// AUTOINCREMENT` issued while the current schema is `main` thus still gets
+/// its `sqlite_sequence` in the temp schema (autoinc-4.x).
 ///
 /// Uses [`Database::create_table_with_identifier`] directly, bypassing the
 /// user-facing `sqlite_`-prefix reservation guard (`is_reserved_object_name`)
@@ -103,17 +94,16 @@ fn sequence_table_name(database: &Database, target_table: &str) -> String {
 /// like any user table (issue #6173's core design point).
 pub fn ensure_sqlite_sequence_table(
     database: &mut Database,
-    target_table: &str,
+    owning_schema: &str,
 ) -> Result<(), ExecutorError> {
-    let owning_schema = sequence_owner_schema(database, target_table);
-    let qualified = format!("{}.{}", owning_schema, SQLITE_SEQUENCE_TABLE);
+    let qualified = sequence_table_in(owning_schema);
     if database.get_table(&qualified).is_some() {
         return Ok(());
     }
     database
         .create_table_with_identifier(
             sqlite_sequence_table_schema(),
-            TableIdentifier::qualified(&owning_schema, false, SQLITE_SEQUENCE_TABLE, false),
+            TableIdentifier::qualified(owning_schema, false, SQLITE_SEQUENCE_TABLE, false),
         )
         .map_err(|e| ExecutorError::StorageError(e.to_string()))
 }
@@ -167,6 +157,10 @@ fn lookup_sequence_row(
 /// out-of-range (see [`parse_seq_value`]) — either way, "nothing to combine
 /// with the table's own max rowid".
 ///
+/// `owning_schema` is the schema the statement's target table actually
+/// resolved to (honoring any explicit `main.`/`temp.` qualifier — issue
+/// #6350; see [`sequence_table_in`]).
+///
 /// Used both by [`compute_next_autoincrement_rowid`] (the INTEGER PRIMARY KEY
 /// -named-column NULL-fill path in `insert/defaults.rs`) and by the
 /// `rowid`/`_rowid_`/`oid` pseudo-column auto-allocation path in
@@ -174,8 +168,12 @@ fn lookup_sequence_row(
 /// (the IPK column value IS the rowid) and must agree, or the row's *stored*
 /// column value and its *tracked* high-water mark (`Table::max_rowid_signed`,
 /// which future allocations read from) silently diverge.
-pub fn sequence_high_water_mark(database: &Database, table_display_name: &str) -> Option<i64> {
-    let seq_table = sequence_table_name(database, table_display_name);
+pub fn sequence_high_water_mark(
+    database: &Database,
+    table_display_name: &str,
+    owning_schema: &str,
+) -> Option<i64> {
+    let seq_table = sequence_table_in(owning_schema);
     lookup_sequence_row(database, &seq_table, table_display_name).and_then(|v| v)
 }
 
@@ -190,13 +188,18 @@ pub fn sequence_high_water_mark(database: &Database, table_display_name: &str) -
 /// when the table's max is 124) IS honored. An invalid stored `seq` (NULL, a
 /// non-numeric string, or one that doesn't fit `i64`) is ignored — the
 /// computation falls back to the table's actual max rowid alone.
+///
+/// `owning_schema` is the schema the statement's target table actually
+/// resolved to (honoring any explicit `main.`/`temp.` qualifier — issue
+/// #6350; see [`sequence_table_in`]).
 pub fn compute_next_autoincrement_rowid(
     database: &Database,
     storage_table_name: &str,
     table_display_name: &str,
+    owning_schema: &str,
 ) -> Result<i64, ExecutorError> {
     let table_max = database.get_table(storage_table_name).and_then(|t| t.max_rowid_signed());
-    let seq_val = sequence_high_water_mark(database, table_display_name);
+    let seq_val = sequence_high_water_mark(database, table_display_name, owning_schema);
     let combined = match (table_max, seq_val) {
         (Some(a), Some(b)) => a.max(b),
         (Some(a), None) => a,
@@ -225,17 +228,22 @@ pub fn compute_next_autoincrement_rowid(
 ///
 /// The stored value is always `max(existing stored value, min_value)` — a
 /// smaller explicit/auto rowid never lowers the tracked high-water mark.
+///
+/// `owning_schema` is the schema the statement's target table actually
+/// resolved to (honoring any explicit `main.`/`temp.` qualifier — issue
+/// #6350; see [`sequence_table_in`]).
 pub fn bump_sequence_after_insert(
     database: &mut Database,
     table_display_name: &str,
+    owning_schema: &str,
     min_value: i64,
 ) -> Result<(), ExecutorError> {
-    ensure_sqlite_sequence_table(database, table_display_name)?;
+    ensure_sqlite_sequence_table(database, owning_schema)?;
 
     // Target the `sqlite_sequence` in the SAME database as the table being
     // inserted into, so a main table's counter never lands in
-    // `temp.sqlite_sequence` and vice-versa (autoinc-4.x, issue #6173).
-    let seq_table = sequence_table_name(database, table_display_name);
+    // `temp.sqlite_sequence` and vice-versa (autoinc-4.x, issues #6173/#6350).
+    let seq_table = sequence_table_in(owning_schema);
     let existing = lookup_sequence_row(database, &seq_table, table_display_name);
     let existing_valid = existing.and_then(|v| v);
     let new_val = existing_valid.unwrap_or(i64::MIN).max(min_value);
@@ -281,7 +289,7 @@ pub fn remove_sequence_entry(
     table_display_name: &str,
     owning_schema: &str,
 ) -> Result<(), ExecutorError> {
-    let seq_table = format!("{}.{}", owning_schema, SQLITE_SEQUENCE_TABLE);
+    let seq_table = sequence_table_in(owning_schema);
     if database.get_table(&seq_table).is_none() {
         return Ok(());
     }
@@ -327,10 +335,10 @@ mod tests {
         );
     }
 
-    /// Helper: read a `sqlite_sequence` row for `name`, resolving the owning
-    /// schema exactly as the production paths do.
-    fn lookup(db: &Database, name: &str) -> Option<Option<i64>> {
-        let seq_table = sequence_table_name(db, name);
+    /// Helper: read a `sqlite_sequence` row for `name` from `owning_schema`'s
+    /// `sqlite_sequence` table, exactly as the production paths do.
+    fn lookup_in(db: &Database, owning_schema: &str, name: &str) -> Option<Option<i64>> {
+        let seq_table = sequence_table_in(owning_schema);
         lookup_sequence_row(db, &seq_table, name)
     }
 
@@ -338,40 +346,59 @@ mod tests {
     fn test_ensure_sqlite_sequence_table_idempotent() {
         let mut db = Database::new();
         assert!(db.catalog.get_table(SQLITE_SEQUENCE_TABLE).is_none());
-        ensure_sqlite_sequence_table(&mut db, "t1").unwrap();
+        ensure_sqlite_sequence_table(&mut db, "main").unwrap();
         assert!(db.catalog.get_table(SQLITE_SEQUENCE_TABLE).is_some());
         // Calling again must not error (idempotent).
-        ensure_sqlite_sequence_table(&mut db, "t1").unwrap();
+        ensure_sqlite_sequence_table(&mut db, "main").unwrap();
     }
 
     #[test]
     fn test_bump_sequence_creates_and_upserts() {
         let mut db = Database::new();
-        bump_sequence_after_insert(&mut db, "t1", 12).unwrap();
-        assert_eq!(lookup(&db, "t1"), Some(Some(12)));
+        bump_sequence_after_insert(&mut db, "t1", "main", 12).unwrap();
+        assert_eq!(lookup_in(&db, "main", "t1"), Some(Some(12)));
 
         // A smaller explicit value never lowers the tracked max.
-        bump_sequence_after_insert(&mut db, "t1", 1).unwrap();
-        assert_eq!(lookup(&db, "t1"), Some(Some(12)));
+        bump_sequence_after_insert(&mut db, "t1", "main", 1).unwrap();
+        assert_eq!(lookup_in(&db, "main", "t1"), Some(Some(12)));
 
         // A larger value raises it.
-        bump_sequence_after_insert(&mut db, "t1", 123).unwrap();
-        assert_eq!(lookup(&db, "t1"), Some(Some(123)));
+        bump_sequence_after_insert(&mut db, "t1", "main", 123).unwrap();
+        assert_eq!(lookup_in(&db, "main", "t1"), Some(Some(123)));
 
         // A second table is tracked independently.
-        bump_sequence_after_insert(&mut db, "t2", 1).unwrap();
-        assert_eq!(lookup(&db, "t2"), Some(Some(1)));
-        assert_eq!(lookup(&db, "t1"), Some(Some(123)));
+        bump_sequence_after_insert(&mut db, "t2", "main", 1).unwrap();
+        assert_eq!(lookup_in(&db, "main", "t2"), Some(Some(1)));
+        assert_eq!(lookup_in(&db, "main", "t1"), Some(Some(123)));
     }
 
     #[test]
     fn test_remove_sequence_entry() {
         let mut db = Database::new();
-        bump_sequence_after_insert(&mut db, "t1", 5).unwrap();
-        bump_sequence_after_insert(&mut db, "t2", 7).unwrap();
-        // Fresh in-memory tables with no backing user table resolve to `main`.
+        bump_sequence_after_insert(&mut db, "t1", "main", 5).unwrap();
+        bump_sequence_after_insert(&mut db, "t2", "main", 7).unwrap();
         remove_sequence_entry(&mut db, "t1", "main").unwrap();
-        assert_eq!(lookup(&db, "t1"), None);
-        assert_eq!(lookup(&db, "t2"), Some(Some(7)));
+        assert_eq!(lookup_in(&db, "main", "t1"), None);
+        assert_eq!(lookup_in(&db, "main", "t2"), Some(Some(7)));
+    }
+
+    #[test]
+    fn test_bump_sequence_routes_to_explicit_owning_schema() {
+        // Same display name tracked independently per owning schema — the
+        // explicit `owning_schema` parameter, not any bare-name re-resolution,
+        // decides which `sqlite_sequence` receives the bookkeeping (#6350).
+        let mut db = Database::new();
+        // The session temp schema is created eagerly at connection open.
+        let temp_schema = db.catalog.temp_schema_name().to_string();
+
+        bump_sequence_after_insert(&mut db, "t1", "main", 10).unwrap();
+        bump_sequence_after_insert(&mut db, "t1", &temp_schema, 20).unwrap();
+
+        assert_eq!(lookup_in(&db, "main", "t1"), Some(Some(10)));
+        assert_eq!(lookup_in(&db, &temp_schema, "t1"), Some(Some(20)));
+
+        // Reads are schema-scoped too.
+        assert_eq!(sequence_high_water_mark(&db, "t1", "main"), Some(10));
+        assert_eq!(sequence_high_water_mark(&db, "t1", &temp_schema), Some(20));
     }
 }

--- a/crates/vibesql-executor/src/create_table.rs
+++ b/crates/vibesql-executor/src/create_table.rs
@@ -739,12 +739,14 @@ impl CreateTableExecutor {
         // sqlite3 3.51.0 autoinc-1.2) — `sqlite_sequence` gets no row for
         // this table yet; that happens lazily on the table's first INSERT.
         if table_schema.is_autoincrement {
-            // The current schema was switched to the target schema above (for a
-            // TEMP table it is this session's temp schema), so resolving the
-            // just-created table's owning schema yields the right database —
-            // its `sqlite_sequence` is created there, not always in `main`
-            // (autoinc-4.x, issue #6173).
-            crate::autoincrement::ensure_sqlite_sequence_table(database, &table_name)?;
+            // Pass the schema this CREATE TABLE explicitly targeted (for a
+            // TEMP table it is this session's temp schema) rather than
+            // re-resolving from the bare table name — a bare-name lookup
+            // re-applies temp-shadows-main and could pick the wrong database
+            // when a same-named table exists in the other schema
+            // (autoinc-4.x, issues #6173/#6350). The `sqlite_sequence` table
+            // is created there, not always in `main`.
+            crate::autoincrement::ensure_sqlite_sequence_table(database, &schema_name)?;
         }
 
         // Restore original schema if we switched

--- a/crates/vibesql-executor/src/insert/defaults.rs
+++ b/crates/vibesql-executor/src/insert/defaults.rs
@@ -328,6 +328,13 @@ pub fn apply_default_values_with_table_name(
     database: &mut vibesql_storage::Database,
     storage_table_name: &str,
 ) -> Result<Option<i64>, ExecutorError> {
+    // Resolve the owning schema from the (possibly-qualified) storage table
+    // name, falling back to the current schema — this wrapper has no
+    // statement-level resolution to reuse (issue #6350).
+    let owning_schema = database
+        .catalog
+        .resolve_table_schema_name(storage_table_name)
+        .unwrap_or_else(|| database.catalog.get_current_schema().to_string());
     // No column was explicitly assigned by the caller, so every NULL slot is an
     // omitted column that should receive its default.
     apply_default_values_with_batch_context(
@@ -335,6 +342,7 @@ pub fn apply_default_values_with_table_name(
         row_values,
         database,
         storage_table_name,
+        &owning_schema,
         None,
         &std::collections::HashSet::new(),
     )
@@ -352,13 +360,20 @@ pub fn apply_default_values_with_table_name(
 /// can fire, rather than being silently swapped for the column default (#5893). Columns
 /// omitted from the INSERT are absent from this set and still receive their default.
 ///
+/// `owning_schema` is the schema the INSERT's target table actually resolved
+/// to (honoring an explicit `main.`/`temp.` qualifier), used to scope the
+/// AUTOINCREMENT `sqlite_sequence` lookup to the correct database's table
+/// (issue #6350).
+///
 /// Returns the first auto-generated sequence value (for LAST_INSERT_ROWID support),
 /// or None if no sequence values were generated.
+#[allow(clippy::too_many_arguments)]
 pub fn apply_default_values_with_batch_context(
     schema: &vibesql_catalog::TableSchema,
     row_values: &mut [vibesql_types::SqlValue],
     database: &mut vibesql_storage::Database,
     storage_table_name: &str,
+    owning_schema: &str,
     batch_max_ipk: Option<i64>,
     explicitly_assigned: &std::collections::HashSet<usize>,
 ) -> Result<Option<i64>, ExecutorError> {
@@ -378,6 +393,7 @@ pub fn apply_default_values_with_batch_context(
                     database,
                     storage_table_name,
                     &schema.name,
+                    owning_schema,
                 )?
             } else {
                 compute_next_integer_pk_value(database, storage_table_name)?

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -340,6 +340,16 @@ fn execute_insert_internal(
     // which case firing falls back to the legacy schema-unaware match.
     let dml_schema: Option<String> = db.catalog.resolve_table_schema_name(&full_table_name);
 
+    // AUTOINCREMENT bookkeeping (issues #6173/#6350) must target the schema
+    // this INSERT actually resolved to — honoring an explicit `main.`/`temp.`
+    // qualifier — so a qualified `INSERT INTO main.t1` never reads or bumps
+    // `temp.sqlite_sequence` when a same-named table exists in the temp
+    // schema. `dml_schema` already carries exactly that resolution (temp
+    // shadows main only for unqualified names); fall back to the current
+    // schema when unresolvable, mirroring the drop/truncate paths.
+    let autoinc_owner_schema: String =
+        dml_schema.clone().unwrap_or_else(|| db.catalog.get_current_schema().to_string());
+
     // Validate INSERT trigger body statements at prepare time (mirrors the
     // DELETE path). SQLite resolves a trigger's body when the firing INSERT is
     // prepared, so a body with an unresolvable column reference (triggerB-2.1's
@@ -651,7 +661,8 @@ fn execute_insert_internal(
     // high-water mark (what future allocations in this table read from) would
     // silently diverge.
     let table_max_rowid: Option<i64> = if schema.is_autoincrement {
-        let seq = crate::autoincrement::sequence_high_water_mark(db, &schema.name);
+        let seq =
+            crate::autoincrement::sequence_high_water_mark(db, &schema.name, &autoinc_owner_schema);
         match (table_max_rowid, seq) {
             (Some(a), Some(b)) => Some(a.max(b)),
             (Some(a), None) => Some(a),
@@ -904,6 +915,7 @@ fn execute_insert_internal(
             &mut full_row_values,
             db,
             &storage_table_name,
+            &autoinc_owner_schema,
             batch_max_ipk,
             &assigned_columns,
         )?;
@@ -1467,6 +1479,7 @@ fn execute_insert_internal(
                         db,
                         &storage_table_name,
                         &schema.name,
+                        &autoinc_owner_schema,
                     )?
                 } else {
                     db.get_table(&storage_table_name)
@@ -1781,6 +1794,7 @@ fn execute_insert_internal(
         crate::autoincrement::bump_sequence_after_insert(
             db,
             &schema.name,
+            &autoinc_owner_schema,
             batch_max_ipk.unwrap_or(0),
         )?;
     }

--- a/crates/vibesql-executor/tests/autoincrement_temp_sequence_tests.rs
+++ b/crates/vibesql-executor/tests/autoincrement_temp_sequence_tests.rs
@@ -20,7 +20,9 @@
 //! so it cannot observe the main-vs-temp `sqlite_sequence` split. These
 //! in-process engine tests verify the behavior directly instead.
 
-use vibesql_executor::{CreateTableExecutor, DropTableExecutor, InsertExecutor, SelectExecutor};
+use vibesql_executor::{
+    CreateTableExecutor, DropTableExecutor, InsertExecutor, SelectExecutor, TriggerExecutor,
+};
 use vibesql_parser::Parser;
 use vibesql_storage::Database;
 use vibesql_types::SqlValue;
@@ -156,5 +158,188 @@ fn dropping_main_table_leaves_temp_sequence_intact() {
         sequence_rows(&db, "temp"),
         vec![("t3".to_string(), 20)],
         "the temp table's sqlite_sequence row must survive the main DROP"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Same-name collision: a table named `t1` in BOTH main and temp (issue #6350).
+// An explicitly-qualified INSERT must route its sqlite_sequence bookkeeping to
+// the qualified schema, not re-resolve the bare name via temp-shadows-main.
+// ---------------------------------------------------------------------------
+
+/// Helper: read the `x` (INTEGER PRIMARY KEY) column of `schema.t1`, sorted.
+fn t1_rowids(db: &Database, schema: &str) -> Vec<i64> {
+    let sql = format!("SELECT x FROM {schema}.t1 ORDER BY x");
+    let stmt = Parser::parse_sql(&sql).expect("parse SELECT t1");
+    let rows = match stmt {
+        vibesql_ast::Statement::Select(s) => {
+            SelectExecutor::new(db).execute_with_columns(&s).expect("SELECT t1").rows
+        }
+        other => panic!("expected SELECT, got {other:?}"),
+    };
+    rows.iter()
+        .map(|r| match &r.values[0] {
+            SqlValue::Integer(v) | SqlValue::Bigint(v) => *v,
+            other => panic!("expected integer rowid, got {other:?}"),
+        })
+        .collect()
+}
+
+/// The issue #6350 repro: with same-named AUTOINCREMENT tables in main and
+/// temp, `INSERT INTO main.t1` bumps `main.sqlite_sequence` and
+/// `INSERT INTO temp.t1` bumps `temp.sqlite_sequence` — the main insert's
+/// high-water mark is never absorbed into (or overwritten by) the temp one.
+#[test]
+fn qualified_inserts_with_same_named_tables_route_to_own_schema() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y)");
+    exec_create_table(&mut db, "CREATE TEMP TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y)");
+
+    exec_insert(&mut db, "INSERT INTO main.t1 VALUES(10, 1)");
+    exec_insert(&mut db, "INSERT INTO temp.t1 VALUES(20, 2)");
+
+    assert_eq!(
+        sequence_rows(&db, "main"),
+        vec![("t1".to_string(), 10)],
+        "main.sqlite_sequence must hold the qualified main insert's high-water mark"
+    );
+    assert_eq!(
+        sequence_rows(&db, "temp"),
+        vec![("t1".to_string(), 20)],
+        "temp.sqlite_sequence must hold ONLY the qualified temp insert's high-water mark"
+    );
+}
+
+/// The READ path: a NULL-IPK insert into `main.t1` must consult
+/// `main.sqlite_sequence`, not the same-named temp table's (higher) counter —
+/// and vice versa (issue #6350).
+#[test]
+fn qualified_null_ipk_insert_reads_own_schema_counter() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y)");
+    exec_create_table(&mut db, "CREATE TEMP TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y)");
+    exec_insert(&mut db, "INSERT INTO main.t1 VALUES(10, 1)");
+    exec_insert(&mut db, "INSERT INTO temp.t1 VALUES(100, 2)");
+
+    // Must allocate 11 (main's counter + 1), NOT 101 (temp's counter + 1).
+    exec_insert(&mut db, "INSERT INTO main.t1 VALUES(NULL, 3)");
+    assert_eq!(
+        t1_rowids(&db, "main"),
+        vec![10, 11],
+        "NULL IPK into main.t1 must continue main's own sequence, not temp's"
+    );
+
+    // And the temp side continues from its own counter.
+    exec_insert(&mut db, "INSERT INTO temp.t1 VALUES(NULL, 4)");
+    assert_eq!(t1_rowids(&db, "temp"), vec![100, 101]);
+
+    assert_eq!(sequence_rows(&db, "main"), vec![("t1".to_string(), 11)]);
+    assert_eq!(sequence_rows(&db, "temp"), vec![("t1".to_string(), 101)]);
+}
+
+/// Unqualified INSERT behavior is unchanged: with both tables present,
+/// temp still shadows main for a bare `t1`, so the bookkeeping lands in
+/// `temp.sqlite_sequence` (SQLite name-resolution order).
+#[test]
+fn unqualified_insert_still_temp_shadows_main() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y)");
+    exec_create_table(&mut db, "CREATE TEMP TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y)");
+
+    exec_insert(&mut db, "INSERT INTO t1 VALUES(30, 1)");
+
+    assert_eq!(
+        sequence_rows(&db, "main"),
+        Vec::<(String, i64)>::new(),
+        "an unqualified insert resolves to the temp table; main's sequence stays empty"
+    );
+    assert_eq!(sequence_rows(&db, "temp"), vec![("t1".to_string(), 30)]);
+    assert_eq!(t1_rowids(&db, "temp"), vec![30]);
+    assert_eq!(t1_rowids(&db, "main"), Vec::<i64>::new());
+}
+
+/// A qualified `INSERT ... SELECT` whose source is empty still creates the
+/// `(t1, 0)` sqlite_sequence row (autoinc-9.1) — in the QUALIFIED schema, not
+/// the temp-shadowed one (issue #6350).
+#[test]
+fn qualified_empty_insert_select_creates_zero_row_in_own_schema() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y)");
+    exec_create_table(&mut db, "CREATE TEMP TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y)");
+    exec_create_table(&mut db, "CREATE TABLE src(x INTEGER, y)");
+
+    exec_insert(&mut db, "INSERT INTO main.t1 SELECT * FROM src");
+
+    assert_eq!(
+        sequence_rows(&db, "main"),
+        vec![("t1".to_string(), 0)],
+        "the (t1, 0) row for an empty qualified INSERT ... SELECT belongs to main"
+    );
+    assert_eq!(
+        sequence_rows(&db, "temp"),
+        Vec::<(String, i64)>::new(),
+        "temp.sqlite_sequence must not absorb main.t1's bookkeeping"
+    );
+}
+
+/// The post-BEFORE-trigger rowid recompute (`execution.rs`) must also consult
+/// the qualified schema's counter: a NULL-IPK insert into `main.t1` whose
+/// BEFORE INSERT trigger fires still allocates from main's sequence, not the
+/// same-named temp table's higher counter (issue #6350).
+#[test]
+fn before_insert_trigger_recompute_uses_qualified_schema_counter() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y)");
+    exec_create_table(&mut db, "CREATE TABLE log(n INTEGER)");
+    // Bind the trigger to main.t1 BEFORE the same-named temp table exists.
+    let trigger_sql = "CREATE TRIGGER t1_before BEFORE INSERT ON t1 \
+                       BEGIN INSERT INTO log VALUES(1); END";
+    let stmt = Parser::parse_sql(trigger_sql).expect("parse CREATE TRIGGER");
+    match stmt {
+        vibesql_ast::Statement::CreateTrigger(s) => {
+            TriggerExecutor::create_trigger_with_sql(&mut db, &s, Some(trigger_sql))
+                .expect("CREATE TRIGGER");
+        }
+        other => panic!("expected CREATE TRIGGER, got {other:?}"),
+    }
+    exec_create_table(&mut db, "CREATE TEMP TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y)");
+
+    exec_insert(&mut db, "INSERT INTO main.t1 VALUES(10, 1)");
+    exec_insert(&mut db, "INSERT INTO temp.t1 VALUES(100, 2)");
+
+    // The trigger forces the post-trigger recompute path; the recomputed
+    // rowid must be 11 (main's counter + 1), NOT 101 (temp's counter + 1).
+    exec_insert(&mut db, "INSERT INTO main.t1 VALUES(NULL, 3)");
+
+    assert_eq!(
+        t1_rowids(&db, "main"),
+        vec![10, 11],
+        "post-trigger recompute must continue main's own sequence, not temp's"
+    );
+    assert_eq!(sequence_rows(&db, "main"), vec![("t1".to_string(), 11)]);
+    assert_eq!(sequence_rows(&db, "temp"), vec![("t1".to_string(), 100)]);
+}
+
+/// Regression pin for the already-correct DROP path: `DROP TABLE main.t1`
+/// removes only main's sequence row; the same-named temp table's row survives.
+#[test]
+fn dropping_qualified_main_table_leaves_same_named_temp_sequence() {
+    let mut db = Database::new();
+    exec_create_table(&mut db, "CREATE TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y)");
+    exec_create_table(&mut db, "CREATE TEMP TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y)");
+    exec_insert(&mut db, "INSERT INTO main.t1 VALUES(10, 1)");
+    exec_insert(&mut db, "INSERT INTO temp.t1 VALUES(20, 2)");
+
+    exec_drop_table(&mut db, "DROP TABLE main.t1");
+
+    assert_eq!(
+        sequence_rows(&db, "main"),
+        Vec::<(String, i64)>::new(),
+        "dropping main.t1 must clear only main's sequence row"
+    );
+    assert_eq!(
+        sequence_rows(&db, "temp"),
+        vec![("t1".to_string(), 20)],
+        "the same-named temp table's sequence row must survive DROP TABLE main.t1"
     );
 }


### PR DESCRIPTION
## Summary

Fixes the residual `sqlite_sequence` schema-routing gap found during Judge review of #6348: when a table of the same name exists in both `main` and the session's `temp` schema (both AUTOINCREMENT), an explicitly-qualified `INSERT INTO main.t1` misrouted its bookkeeping (both the high-water-mark **read** and the post-insert **bump**) to `temp.sqlite_sequence`, silently losing main's counter.

Root cause: the four public autoincrement entry points re-resolved the **bare** table display name via `Catalog::resolve_table_schema_name`, which re-applies temp-shadows-main and discards the statement's explicit qualifier. The fix adopts the API shape `remove_sequence_entry` already uses (and that drop/truncate call correctly): an explicit `owning_schema: &str` parameter, supplied by the caller from the statement-level resolution.

## Changes

- `crates/vibesql-executor/src/autoincrement.rs` — added `owning_schema` to `ensure_sqlite_sequence_table`, `sequence_high_water_mark`, `compute_next_autoincrement_rowid`, `bump_sequence_after_insert`; deleted the internal bare-name re-resolution (`sequence_owner_schema`/`sequence_table_name`, replaced by the pure formatter `sequence_table_in`); updated in-file unit tests and added a schema-routing unit test.
- `crates/vibesql-executor/src/insert/execution.rs` — derives `autoinc_owner_schema` once from the already-computed `dml_schema` (resolved from the possibly-qualified statement name; falls back to the current schema) and threads it to all three call sites: batch rowid baseline read, post-BEFORE-trigger rowid recompute, end-of-statement bump.
- `crates/vibesql-executor/src/insert/defaults.rs` — `apply_default_values_with_batch_context` accepts and forwards `owning_schema` for the INTEGER PRIMARY KEY NULL-fill path; the legacy `apply_default_values_with_table_name` wrapper resolves it from its (possibly-qualified) storage table name.
- `crates/vibesql-executor/src/create_table.rs` — passes the schema the CREATE TABLE explicitly targeted to `ensure_sqlite_sequence_table` instead of re-deriving from the bare table name.
- `crates/vibesql-executor/tests/autoincrement_temp_sequence_tests.rs` — six new same-name-collision integration tests.

## Acceptance Criteria Verification

- [x] Issue repro yields SQLite-correct state (`main.sqlite_sequence` → `t1|10`, `temp.sqlite_sequence` → `t1|20`) — verified via `qualified_inserts_with_same_named_tables_route_to_own_schema` AND manually against the CLI (output below).
- [x] Qualified INSERT routes both the sequence **read** (NULL/omitted IPK next-rowid computation) and the **write** (post-insert bump) to the qualified schema — `qualified_null_ipk_insert_reads_own_schema_counter` (main allocates 11, not 101, while temp's counter sits at 100) and `before_insert_trigger_recompute_uses_qualified_schema_counter` (the `execution.rs` post-trigger recompute path).
- [x] Unqualified INSERT behavior unchanged (temp still shadows main) — `unqualified_insert_still_temp_shadows_main`, plus all pre-existing tests in `autoincrement_temp_sequence_tests.rs` and `autoincrement_trigger_rowid_tests.rs` pass.
- [x] `create_table.rs` passes its already-known target schema to `ensure_sqlite_sequence_table`.
- [x] Out of scope respected: the reverse-creation-order CREATE TABLE existence-check bug is untouched (tests use the currently-reachable main-then-temp order).

## Test Plan

- [x] `cargo test -p vibesql-executor` — full suite passes (exit 0, zero failures).
- [x] New integration tests (9 total in `autoincrement_temp_sequence_tests.rs`, 6 new) all pass, including the empty qualified `INSERT ... SELECT` creating the `(t1, 0)` row in the correct schema (autoinc-9.1) and the qualified `DROP TABLE main.t1` regression pin.
- [x] Manual CLI verification of the issue's repro:

```
INSERT INTO main.t1 VALUES(10,1);
INSERT INTO temp.t1 VALUES(20,2);
SELECT * FROM main.sqlite_sequence;   -- t1|10  (was: 0 rows)
SELECT * FROM temp.sqlite_sequence;   -- t1|20  (was: t1|20 after absorbing/overwriting main's bump)
DROP TABLE main.t1;
SELECT * FROM temp.sqlite_sequence;   -- t1|20  (unchanged — drop path regression-free)
```

- [x] `cargo check` / `cargo clippy` clean for the changed files (remaining clippy warnings in touched files pre-date this change).

Closes #6350

🤖 Generated with [Claude Code](https://claude.com/claude-code)