### PR TITLE
fix(insert): in-batch UNIQUE tracking for index-backed uniqueness + rehydrate unique_constraints on reload

### DIFF
--- a/crates/vibesql-executor/src/insert/constraints.rs
+++ b/crates/vibesql-executor/src/insert/constraints.rs
@@ -326,13 +326,136 @@ pub fn enforce_check_constraints(
     Ok(())
 }
 
+/// Per-statement working set of unique-index keys already claimed by earlier
+/// rows of the same multi-row INSERT (issue #6346).
+///
+/// The stored index bodies only reflect rows that have been physically
+/// inserted, but the multi-row INSERT path validates every row BEFORE
+/// inserting any — so without this set, two colliding rows in one VALUES list
+/// both pass the index-backed uniqueness checks and are both written. Keys
+/// are stored in the same canonical form the index bodies use
+/// (`normalize_for_comparison`, matching `IndexData::get`), so numeric
+/// variants like 1 and 1.0 collide exactly as they would against stored data.
+#[derive(Debug, Default)]
+pub struct BatchUniqueIndexKeys {
+    /// index name -> normalized non-NULL keys claimed by earlier batch rows
+    keys: std::collections::HashMap<
+        String,
+        std::collections::HashSet<Vec<vibesql_types::SqlValue>>,
+    >,
+}
+
+impl BatchUniqueIndexKeys {
+    /// True when an earlier row of this statement already claimed `key`
+    /// (raw, un-normalized values) under `index_name`.
+    pub fn contains(&self, index_name: &str, key: &[vibesql_types::SqlValue]) -> bool {
+        self.keys
+            .get(index_name)
+            .is_some_and(|set| set.contains(&normalize_index_key(key)))
+    }
+
+    /// Record `key` (raw, un-normalized values) as claimed under `index_name`.
+    pub fn insert(&mut self, index_name: &str, key: &[vibesql_types::SqlValue]) {
+        self.keys.entry(index_name.to_string()).or_default().insert(normalize_index_key(key));
+    }
+}
+
+/// Normalize an index key the way the stored index bodies do (see
+/// `IndexData::get` / index insertion), so in-batch comparisons agree with
+/// existing-data comparisons.
+fn normalize_index_key(key: &[vibesql_types::SqlValue]) -> Vec<vibesql_types::SqlValue> {
+    key.iter().map(vibesql_storage::database::indexes::normalize_for_comparison).collect()
+}
+
+/// Record every unique-index key the (already validated) `row_values` will
+/// occupy into `batch_index_keys`, so later rows of the same statement can be
+/// checked against it (issue #6346).
+///
+/// Mirrors the key construction in [`enforce_unique_indexes`]: partial-index
+/// predicates are evaluated leniently (a row outside the predicate never
+/// enters the index), expression components are evaluated with failures
+/// treated as NULL (matching expression-index maintenance), and keys
+/// containing NULL are skipped (multiple NULLs never conflict).
+pub fn record_unique_index_keys(
+    db: &vibesql_storage::Database,
+    schema: &vibesql_catalog::TableSchema,
+    table_name: &str,
+    row_values: &[vibesql_types::SqlValue],
+    batch_index_keys: &mut BatchUniqueIndexKeys,
+) {
+    let indexes_for_table = db.list_indexes_for_table(table_name);
+    if indexes_for_table.is_empty() {
+        return;
+    }
+
+    let candidate_row = vibesql_storage::Row::new(row_values.to_vec());
+    let evaluator = crate::evaluator::ExpressionEvaluator::new(schema)
+        .with_schema_context(crate::evaluator::SchemaExprContext::Index);
+
+    for index_name in indexes_for_table {
+        let Some(index_metadata) = db.get_index(&index_name) else {
+            continue;
+        };
+        if !index_metadata.unique {
+            continue;
+        }
+
+        // Partial index: a row that doesn't satisfy the predicate never
+        // enters the index, so it claims no key. Lenient on eval errors
+        // (row treated as not-in-index) — the enforcement pass that ran
+        // before this already propagated any hard errors.
+        if let Some(predicate) = index_metadata.where_clause.as_deref() {
+            let satisfied = evaluator
+                .eval(predicate, &candidate_row)
+                .map(|v| crate::partial_index_maintenance::is_predicate_truthy(&v))
+                .unwrap_or(false);
+            if !satisfied {
+                continue;
+            }
+        }
+
+        // Build the key: plain columns read from the row, expression
+        // components are evaluated (failures become NULL, matching
+        // expression-index maintenance).
+        let mut key_values = Vec::with_capacity(index_metadata.columns.len());
+        for index_col in &index_metadata.columns {
+            if let Some(name) = index_col.column_name() {
+                match schema.get_column_index(name) {
+                    Some(col_idx) => key_values.push(row_values[col_idx].clone()),
+                    None => key_values.push(vibesql_types::SqlValue::Null),
+                }
+            } else if let Some(expr) = index_col.get_expression() {
+                key_values.push(
+                    evaluator.eval(expr, &candidate_row).unwrap_or(vibesql_types::SqlValue::Null),
+                );
+            } else {
+                key_values.push(vibesql_types::SqlValue::Null);
+            }
+        }
+
+        // NULL keys never conflict (multiple NULLs are allowed).
+        if key_values.contains(&vibesql_types::SqlValue::Null) {
+            continue;
+        }
+
+        batch_index_keys.insert(&index_name, &key_values);
+    }
+}
+
 /// Enforce UNIQUE constraint for user-defined indexes (CREATE UNIQUE INDEX)
 /// Returns Ok if all unique index constraints are satisfied
+///
+/// `batch_index_keys` carries the keys already claimed by earlier rows of the
+/// same multi-row INSERT statement (issue #6346): the stored index bodies
+/// cannot see rows that are validated but not yet inserted, so in-batch
+/// duplicates must be caught against this working set. Single-row callers
+/// pass an empty default.
 pub fn enforce_unique_indexes(
     db: &vibesql_storage::Database,
     schema: &vibesql_catalog::TableSchema,
     table_name: &str,
     row_values: &[vibesql_types::SqlValue],
+    batch_index_keys: &BatchUniqueIndexKeys,
 ) -> Result<(), ExecutorError> {
     // Get all indexes for this table
     let indexes_for_table = db.list_indexes_for_table(table_name);
@@ -381,6 +504,7 @@ pub fn enforce_unique_indexes(
                     row_values,
                     table,
                     &snapshot,
+                    batch_index_keys,
                 )?;
                 continue;
             }
@@ -408,6 +532,22 @@ pub fn enforce_unique_indexes(
             // (NULL != NULL in SQL, so multiple NULLs are allowed)
             if key_values.contains(&vibesql_types::SqlValue::Null) {
                 continue;
+            }
+
+            // In-batch duplicate: an earlier row of this same statement
+            // already claimed this key (issue #6346). The stored index body
+            // cannot catch this because no batch row is inserted yet.
+            if batch_index_keys.contains(&index_name, &key_values) {
+                let columns_str = index_metadata
+                    .columns
+                    .iter()
+                    .map(|col| format!("{}.{}", table_name, col.expect_column_name()))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return Err(ExecutorError::SqliteCompatError(format!(
+                    "UNIQUE constraint failed: {}",
+                    columns_str
+                )));
             }
 
             // Check if this key already exists in the index
@@ -460,6 +600,7 @@ fn enforce_unique_expression_index(
     row_values: &[vibesql_types::SqlValue],
     table: Option<&vibesql_storage::Table>,
     snapshot: &vibesql_storage::TxnSnapshot,
+    batch_index_keys: &BatchUniqueIndexKeys,
 ) -> Result<(), ExecutorError> {
     let Some(table) = table else {
         return Ok(());
@@ -477,6 +618,15 @@ fn enforce_unique_expression_index(
     else {
         return Ok(());
     };
+
+    // In-batch duplicate: an earlier row of this same statement already
+    // claimed this expression key (issue #6346).
+    if batch_index_keys.contains(&index_metadata.index_name, &new_key) {
+        return Err(ExecutorError::SqliteCompatError(format!(
+            "UNIQUE constraint failed: index '{}'",
+            index_metadata.index_name
+        )));
+    }
 
     for (_idx, existing_row) in table.scan_visible(snapshot) {
         // Partial expression indexes: rows outside the predicate are not in

--- a/crates/vibesql-executor/src/insert/execution.rs
+++ b/crates/vibesql-executor/src/insert/execution.rs
@@ -552,6 +552,13 @@ fn execute_insert_internal(
        // (fkey1-5.1: `INSERT INTO t VALUES (1,NULL),(2,1),(3,2)` where t.parent
        // references t.x — row N must find its parent among rows 0..N-1).
     let mut batch_full_rows: Vec<Vec<vibesql_types::SqlValue>> = Vec::new();
+    // Track unique-INDEX keys claimed by earlier rows of this statement
+    // (issue #6346). Schema-level UNIQUE constraints are covered by
+    // `unique_constraint_values` above, but uniqueness enforced solely
+    // through unique index metadata (CREATE UNIQUE INDEX, or the implicit
+    // autoindex of a reloaded UNIQUE column whose schema-level constraint
+    // was lost) checks index bodies that cannot see not-yet-inserted rows.
+    let mut batch_index_keys = super::constraints::BatchUniqueIndexKeys::default();
 
     // Check if IGNORE conflict clause is set - if so, skip rows with constraint violations
     // Also treat a single-clause ON CONFLICT ... DO NOTHING as equivalent to
@@ -952,6 +959,7 @@ fn execute_insert_internal(
             &primary_key_values,
             &unique_constraint_values,
             &batch_full_rows,
+            &batch_index_keys,
             skip_duplicate_checks,
         );
 
@@ -981,6 +989,7 @@ fn execute_insert_internal(
                     &full_row_values,
                     &primary_key_values,
                     &unique_constraint_values,
+                    &batch_index_keys,
                 )
             };
             if would_violate {
@@ -1033,6 +1042,17 @@ fn execute_insert_internal(
         // Track row for self-referential FK lookups by later rows in the
         // same batch (see fkey1-5.1 note above).
         batch_full_rows.push(full_row_values.clone());
+
+        // Claim this row's unique-INDEX keys so later rows of the same
+        // statement conflict against it (issue #6346); mirrors the
+        // `unique_constraint_values` tracking above for schema-level UNIQUE.
+        super::constraints::record_unique_index_keys(
+            db,
+            &schema,
+            &storage_table_name,
+            &full_row_values,
+            &mut batch_index_keys,
+        );
 
         // Compute the value this row would contribute to last_insert_rowid()
         // *if it is actually inserted*. We commit it to `last_generated_id` only
@@ -1914,7 +1934,15 @@ fn resolve_replace_conflicts_for_row(
         &[], // No batch values to check against
     )?;
 
-    super::constraints::enforce_unique_indexes(db, schema, table_name, full_row_values)?;
+    // Single-row re-validation against existing data only: no in-batch
+    // working set applies here (empty default).
+    super::constraints::enforce_unique_indexes(
+        db,
+        schema,
+        table_name,
+        full_row_values,
+        &super::constraints::BatchUniqueIndexKeys::default(),
+    )?;
 
     // Re-validate the new row's OWN foreign keys too (fkey1-5.2/5.4): the
     // conflict-clearing delete above may have run a CASCADE / SET NULL /
@@ -1948,6 +1976,7 @@ fn check_would_violate_constraints(
     row_values: &[vibesql_types::SqlValue],
     batch_pk_values: &[Vec<vibesql_types::SqlValue>],
     batch_unique_values: &[Vec<Vec<vibesql_types::SqlValue>>],
+    batch_index_keys: &super::constraints::BatchUniqueIndexKeys,
 ) -> bool {
     // Check NOT NULL constraints
     for (col_idx, col) in schema.columns.iter().enumerate() {
@@ -2055,6 +2084,13 @@ fn check_would_violate_constraints(
                 // Skip if any value is NULL
                 if key_values.contains(&vibesql_types::SqlValue::Null) {
                     continue;
+                }
+
+                // In-batch duplicate: an earlier row of this same statement
+                // already claimed this key (issue #6346) — OR IGNORE must
+                // skip the row, not insert a duplicate.
+                if batch_index_keys.contains(&index_name, &key_values) {
+                    return true;
                 }
 
                 // Check if key exists in index

--- a/crates/vibesql-executor/src/insert/row_validator.rs
+++ b/crates/vibesql-executor/src/insert/row_validator.rs
@@ -33,11 +33,18 @@ pub struct RowValidator<'a> {
     /// `INSERT INTO t11 VALUES (1, NULL), (2, 1), (3, 2);` where t11.parent
     /// references t11.x — row (2, 1) must see the just-validated (1, NULL)).
     batch_full_rows: &'a [Vec<vibesql_types::SqlValue>],
+    /// Unique-index keys already claimed by earlier rows of this multi-row
+    /// INSERT (issue #6346). The stored index bodies cannot see rows that are
+    /// validated but not yet inserted, so index-backed uniqueness (CREATE
+    /// UNIQUE INDEX / the implicit autoindex of a reloaded UNIQUE column)
+    /// needs this working set to catch intra-statement duplicates.
+    batch_index_keys: &'a super::constraints::BatchUniqueIndexKeys,
     /// Skip PK/UNIQUE duplicate checks (for REPLACE conflict clause)
     skip_duplicate_checks: bool,
 }
 
 impl<'a> RowValidator<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         db: &'a vibesql_storage::Database,
         schema: &'a vibesql_catalog::TableSchema,
@@ -45,6 +52,7 @@ impl<'a> RowValidator<'a> {
         batch_pk_values: &'a [Vec<vibesql_types::SqlValue>],
         batch_unique_values: &'a [Vec<Vec<vibesql_types::SqlValue>>],
         batch_full_rows: &'a [Vec<vibesql_types::SqlValue>],
+        batch_index_keys: &'a super::constraints::BatchUniqueIndexKeys,
         skip_duplicate_checks: bool,
     ) -> Self {
         Self {
@@ -54,6 +62,7 @@ impl<'a> RowValidator<'a> {
             batch_pk_values,
             batch_unique_values,
             batch_full_rows,
+            batch_index_keys,
             skip_duplicate_checks,
         }
     }
@@ -419,6 +428,7 @@ impl<'a> RowValidator<'a> {
             self.schema,
             self.table_name,
             row_values,
+            self.batch_index_keys,
         )
     }
 

--- a/crates/vibesql-executor/tests/insert_batch_unique_index_tests.rs
+++ b/crates/vibesql-executor/tests/insert_batch_unique_index_tests.rs
@@ -1,0 +1,301 @@
+//! Regression tests for issue #6346: intra-statement (in-batch) UNIQUE
+//! duplicate detection for uniqueness enforced through unique INDEX metadata.
+//!
+//! Multi-row INSERT validates every row before inserting any, so the stored
+//! index bodies cannot see earlier rows of the same statement. Before the
+//! fix, uniqueness backed solely by unique-index metadata (a user-defined
+//! `CREATE UNIQUE INDEX`, or the implicit `sqlite_autoindex_*` of a UNIQUE
+//! column on a reopened/WAL-recovered table whose schema-level
+//! `unique_constraints` were lost on reload) had no in-batch tracking:
+//! `INSERT ... VALUES(1),(1)` silently wrote both rows, and
+//! `INSERT OR IGNORE` inserted two rows instead of one.
+//!
+//! Also covers the reopen path itself: `TableSchema::unique_constraints` is
+//! now rehydrated from the persisted `sql_source` on binary reload.
+
+use vibesql_ast::Statement;
+use vibesql_executor::{
+    CreateIndexExecutor, CreateTableExecutor, InsertExecutor, SelectExecutor,
+};
+use vibesql_parser::Parser;
+use vibesql_storage::Database;
+
+/// Create a table preserving the verbatim source text (issue #5619), the way
+/// the CLI/load paths capture it. `sql_source` is what the reload path
+/// re-parses, so reopen tests must go through this entry point.
+fn create_table(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse CREATE TABLE");
+    let Statement::CreateTable(create) = stmt else {
+        panic!("expected CREATE TABLE");
+    };
+    CreateTableExecutor::execute_with_source(&create, db, Some(sql)).expect("CREATE TABLE");
+}
+
+fn create_index(db: &mut Database, sql: &str) {
+    let stmt = Parser::parse_sql(sql).expect("parse CREATE INDEX");
+    let Statement::CreateIndex(create) = stmt else {
+        panic!("expected CREATE INDEX");
+    };
+    CreateIndexExecutor::execute(&create, db).expect("CREATE INDEX");
+}
+
+/// Execute an INSERT, returning Ok(()) or the error's Display text.
+fn insert(db: &mut Database, sql: &str) -> Result<(), String> {
+    let stmt = Parser::parse_sql(sql).map_err(|e| format!("parse error: {e:?}"))?;
+    let Statement::Insert(s) = stmt else {
+        panic!("expected INSERT");
+    };
+    InsertExecutor::execute(db, &s).map(|_| ()).map_err(|e| e.to_string())
+}
+
+/// COUNT(*) helper.
+fn count(db: &Database, table: &str) -> i64 {
+    let sql = format!("SELECT COUNT(*) FROM {table}");
+    let stmt = Parser::parse_sql(&sql).expect("parse SELECT");
+    let Statement::Select(select) = stmt else {
+        panic!("expected SELECT");
+    };
+    let result = SelectExecutor::new(db).execute_with_columns(&select).expect("SELECT");
+    match &result.rows[0].values[0] {
+        vibesql_types::SqlValue::Integer(n) => *n,
+        vibesql_types::SqlValue::Bigint(n) => *n,
+        other => panic!("unexpected COUNT value: {other:?}"),
+    }
+}
+
+/// Save to a binary `.vbsql` file and reload — the cross-process reopen path
+/// from the issue's repro.
+fn reopen_binary(db: &Database, tag: &str) -> Database {
+    let path =
+        std::env::temp_dir().join(format!("vibesql_6346_{tag}_{}.vbsql", std::process::id()));
+    db.save_binary(&path).expect("save_binary");
+    let reloaded = Database::load_binary(&path).expect("load_binary");
+    std::fs::remove_file(&path).ok();
+    reloaded
+}
+
+fn assert_unique_violation(err: &str) {
+    assert!(
+        err.contains("UNIQUE constraint failed"),
+        "expected UNIQUE violation wording, got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fresh process + CREATE UNIQUE INDEX (no reopen needed — the same hole)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fresh_unique_index_multi_row_insert_aborts() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t(c)");
+    create_index(&mut db, "CREATE UNIQUE INDEX i ON t(c)");
+
+    // Default ABORT: the whole statement rolls back, nothing persisted.
+    let err = insert(&mut db, "INSERT INTO t VALUES(1),(1)")
+        .expect_err("in-batch duplicate must fail");
+    assert_unique_violation(&err);
+    assert_eq!(count(&db, "t"), 0, "ABORT must persist no rows");
+}
+
+#[test]
+fn fresh_unique_index_or_fail_keeps_first_row() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t(c)");
+    create_index(&mut db, "CREATE UNIQUE INDEX i ON t(c)");
+
+    // OR FAIL: stop at the offending row but keep the rows before it.
+    let err = insert(&mut db, "INSERT OR FAIL INTO t VALUES(1),(1)")
+        .expect_err("in-batch duplicate must fail");
+    assert_unique_violation(&err);
+    assert_eq!(count(&db, "t"), 1, "OR FAIL keeps the first row only");
+}
+
+#[test]
+fn fresh_unique_index_or_ignore_inserts_exactly_one() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t(c)");
+    create_index(&mut db, "CREATE UNIQUE INDEX i ON t(c)");
+
+    // OR IGNORE: the second row is skipped, not an error.
+    insert(&mut db, "INSERT OR IGNORE INTO t VALUES(1),(1)").expect("OR IGNORE never errors");
+    assert_eq!(count(&db, "t"), 1, "OR IGNORE inserts exactly one row");
+}
+
+#[test]
+fn fresh_unique_index_numeric_variants_collide() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t(c)");
+    create_index(&mut db, "CREATE UNIQUE INDEX i ON t(c)");
+
+    // 1 and 1.0 are equal for uniqueness (index keys are normalized), so the
+    // in-batch working set must normalize the same way.
+    let err = insert(&mut db, "INSERT INTO t VALUES(1),(1.0)")
+        .expect_err("1 and 1.0 must collide on a unique index");
+    assert_unique_violation(&err);
+    assert_eq!(count(&db, "t"), 0);
+}
+
+#[test]
+fn fresh_unique_index_multiple_nulls_allowed() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t(c)");
+    create_index(&mut db, "CREATE UNIQUE INDEX i ON t(c)");
+
+    insert(&mut db, "INSERT INTO t VALUES(NULL),(NULL)")
+        .expect("multiple NULLs never conflict on a unique index");
+    assert_eq!(count(&db, "t"), 2);
+}
+
+#[test]
+fn fresh_composite_unique_index_in_batch() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t(a, b)");
+    create_index(&mut db, "CREATE UNIQUE INDEX i ON t(a, b)");
+
+    // Distinct composite keys pass...
+    insert(&mut db, "INSERT INTO t VALUES(1,2),(1,3)").expect("distinct composite keys");
+    assert_eq!(count(&db, "t"), 2);
+
+    // ...identical composite keys in one statement fail.
+    let err = insert(&mut db, "INSERT INTO t VALUES(4,5),(4,5)")
+        .expect_err("identical composite keys must fail");
+    assert_unique_violation(&err);
+    assert_eq!(count(&db, "t"), 2);
+}
+
+#[test]
+fn fresh_partial_unique_index_in_batch() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t(c)");
+    create_index(&mut db, "CREATE UNIQUE INDEX i ON t(c) WHERE c > 0");
+
+    // Rows outside the predicate never enter the index: duplicates allowed.
+    insert(&mut db, "INSERT INTO t VALUES(-1),(-1)")
+        .expect("rows outside the partial predicate never conflict");
+    assert_eq!(count(&db, "t"), 2);
+
+    // Rows inside the predicate conflict in-batch.
+    let err = insert(&mut db, "INSERT INTO t VALUES(5),(5)")
+        .expect_err("in-predicate duplicate must fail");
+    assert_unique_violation(&err);
+    assert_eq!(count(&db, "t"), 2);
+}
+
+#[test]
+fn fresh_unique_expression_index_in_batch() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t(a, b)");
+    create_index(&mut db, "CREATE UNIQUE INDEX i ON t(a+b)");
+
+    // (1,2) and (0,3) both evaluate a+b = 3 — must collide in one statement.
+    let err = insert(&mut db, "INSERT INTO t VALUES(1,2),(0,3)")
+        .expect_err("equal expression keys must fail in-batch");
+    assert!(
+        err.contains("UNIQUE constraint failed: index 'i'"),
+        "expected expression-index violation wording, got: {err}"
+    );
+    assert_eq!(count(&db, "t"), 0);
+
+    // Distinct expression keys pass.
+    insert(&mut db, "INSERT INTO t VALUES(1,2),(1,3)").expect("distinct expression keys");
+    assert_eq!(count(&db, "t"), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Reopened (binary save/load) table with a UNIQUE column — the filed repro
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reopened_schema_rehydrates_unique_constraints() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t(c UNIQUE)");
+    assert_eq!(
+        db.catalog.get_table("t").expect("t").unique_constraints,
+        vec![vec!["c".to_string()]],
+        "precondition: fresh schema carries the UNIQUE constraint"
+    );
+
+    let db2 = reopen_binary(&db, "rehydrate");
+    assert_eq!(
+        db2.catalog.get_table("t").expect("t").unique_constraints,
+        vec![vec!["c".to_string()]],
+        "unique_constraints must be rehydrated from sql_source on reload"
+    );
+}
+
+#[test]
+fn reopened_unique_column_or_fail_keeps_first_row() {
+    // The exact repro from issue #6346.
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t(c UNIQUE)");
+    let mut db2 = reopen_binary(&db, "or_fail");
+
+    let err = insert(&mut db2, "INSERT OR FAIL INTO t VALUES(1),(1)")
+        .expect_err("in-batch duplicate must fail after reopen");
+    assert_unique_violation(&err);
+    assert_eq!(count(&db2, "t"), 1, "OR FAIL keeps the first row only");
+}
+
+#[test]
+fn reopened_unique_column_plain_insert_aborts() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t(c UNIQUE)");
+    let mut db2 = reopen_binary(&db, "abort");
+
+    let err = insert(&mut db2, "INSERT INTO t VALUES(1),(1)")
+        .expect_err("in-batch duplicate must fail after reopen");
+    assert_unique_violation(&err);
+    assert_eq!(count(&db2, "t"), 0, "default ABORT persists no rows");
+}
+
+#[test]
+fn reopened_unique_column_or_ignore_inserts_exactly_one() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t(c UNIQUE)");
+    let mut db2 = reopen_binary(&db, "or_ignore");
+
+    insert(&mut db2, "INSERT OR IGNORE INTO t VALUES(1),(1)").expect("OR IGNORE never errors");
+    assert_eq!(count(&db2, "t"), 1, "OR IGNORE inserts exactly one row");
+}
+
+#[test]
+fn reopened_unique_column_cross_statement_detection_unchanged() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t(c UNIQUE)");
+    let mut db2 = reopen_binary(&db, "cross_stmt");
+
+    insert(&mut db2, "INSERT INTO t VALUES(1)").expect("first insert");
+    let err = insert(&mut db2, "INSERT INTO t VALUES(1)")
+        .expect_err("cross-statement duplicate must still fail");
+    assert_unique_violation(&err);
+    assert_eq!(count(&db2, "t"), 1);
+}
+
+#[test]
+fn reopened_unique_index_multi_row_insert_aborts() {
+    // Fresh-process CREATE UNIQUE INDEX, then reopen: the user-defined index
+    // metadata is serialized, and the in-batch working set must cover it too.
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t(c)");
+    create_index(&mut db, "CREATE UNIQUE INDEX i ON t(c)");
+    let mut db2 = reopen_binary(&db, "user_index");
+
+    let err = insert(&mut db2, "INSERT INTO t VALUES(1),(1)")
+        .expect_err("in-batch duplicate must fail after reopen");
+    assert_unique_violation(&err);
+    assert_eq!(count(&db2, "t"), 0);
+}
+
+#[test]
+fn reopened_table_level_unique_composite_in_batch() {
+    let mut db = Database::new();
+    create_table(&mut db, "CREATE TABLE t(a, b, UNIQUE(a, b))");
+    let mut db2 = reopen_binary(&db, "composite");
+
+    insert(&mut db2, "INSERT INTO t VALUES(1,2),(1,3)").expect("distinct composite keys");
+    let err = insert(&mut db2, "INSERT INTO t VALUES(4,5),(4,5)")
+        .expect_err("identical composite keys must fail after reopen");
+    assert_unique_violation(&err);
+    assert_eq!(count(&db2, "t"), 2);
+}

--- a/crates/vibesql-storage/src/database/indexes/index_manager.rs
+++ b/crates/vibesql-storage/src/database/indexes/index_manager.rs
@@ -442,6 +442,54 @@ impl IndexManager {
         table_schema: &vibesql_catalog::TableSchema,
         row: &Row,
     ) -> Result<(), StorageError> {
+        self.check_unique_constraints_for_insert_impl(table_name, table_schema, row, None)
+    }
+
+    /// Batch variant of [`check_unique_constraints_for_insert`]: validates
+    /// every row against the stored index bodies AND against the keys claimed
+    /// by earlier rows of the same batch (issue #6346). Without the in-batch
+    /// tracking, two colliding rows in one batch both pass the pre-insert
+    /// check (the index body is only rebuilt after the bulk append) and both
+    /// get written, silently corrupting UNIQUE-indexed data.
+    ///
+    /// This is defense-in-depth: the executor performs the same in-batch
+    /// tracking during validation (where OR IGNORE semantics require skipping
+    /// rather than erroring), so a violation here indicates a caller that
+    /// bypassed executor validation.
+    pub fn check_unique_constraints_for_insert_batch(
+        &self,
+        table_name: &str,
+        table_schema: &vibesql_catalog::TableSchema,
+        rows: &[Row],
+    ) -> Result<(), StorageError> {
+        let mut seen: std::collections::HashMap<
+            &str,
+            std::collections::HashSet<Vec<SqlValue>>,
+        > = std::collections::HashMap::new();
+        for row in rows {
+            self.check_unique_constraints_for_insert_impl(
+                table_name,
+                table_schema,
+                row,
+                Some(&mut seen),
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Shared implementation. When `batch_seen` is provided, each validated
+    /// row's keys are recorded into it and later rows are checked against it
+    /// (in-batch duplicate detection); `None` preserves the single-row
+    /// behavior exactly.
+    fn check_unique_constraints_for_insert_impl<'k>(
+        &'k self,
+        table_name: &str,
+        table_schema: &vibesql_catalog::TableSchema,
+        row: &Row,
+        mut batch_seen: Option<
+            &mut std::collections::HashMap<&'k str, std::collections::HashSet<Vec<SqlValue>>>,
+        >,
+    ) -> Result<(), StorageError> {
         for (index_name, metadata) in &self.indexes {
             if metadata.table_name == table_name && metadata.unique && !metadata.is_partial() {
                 // Skip expression indexes: storage cannot evaluate expressions
@@ -486,6 +534,23 @@ impl IndexManager {
                             .collect::<Vec<_>>()
                             .join(", ");
 
+                        // In-batch duplicate: an earlier row of this same
+                        // batch already claimed this key (issue #6346). The
+                        // stored index body cannot catch it because the batch
+                        // is appended (and indexes rebuilt) only after this
+                        // pre-check passes for every row.
+                        if let Some(seen) = batch_seen.as_deref_mut() {
+                            if seen
+                                .get(index_name.as_str())
+                                .is_some_and(|keys| keys.contains(&key_values))
+                            {
+                                return Err(StorageError::UniqueConstraintViolation(format!(
+                                    "UNIQUE constraint failed: {}",
+                                    columns_str
+                                )));
+                            }
+                        }
+
                         match index_data {
                             IndexData::InMemory { data, .. } => {
                                 if data.contains_key(&key_values) {
@@ -516,6 +581,12 @@ impl IndexManager {
                                 // HNSW indexes don't support unique constraints
                                 // Vector indexes are for similarity search, not uniqueness
                             }
+                        }
+
+                        // Row passed: claim its key so later rows of the same
+                        // batch conflict against it (issue #6346).
+                        if let Some(seen) = batch_seen.as_deref_mut() {
+                            seen.entry(index_name.as_str()).or_default().insert(key_values);
                         }
                     }
                 }

--- a/crates/vibesql-storage/src/database/indexes/mod.rs
+++ b/crates/vibesql-storage/src/database/indexes/mod.rs
@@ -38,3 +38,8 @@ pub use index_manager::IndexManager;
 pub use index_metadata::{IndexData, IndexMetadata};
 pub use ivfflat::IVFFlatIndex;
 pub use streaming::OwnedStreamingRangeScan;
+// Key normalization used when storing/looking up index keys. Exported so the
+// executor's in-batch unique-index duplicate tracking (issue #6346) can build
+// keys with the exact same canonical form the stored index bodies use
+// (Integer 1 and Real 1.0 must collide, matching `IndexData::get`).
+pub use value_normalization::{normalize_cow, normalize_for_comparison};

--- a/crates/vibesql-storage/src/database/operations.rs
+++ b/crates/vibesql-storage/src/database/operations.rs
@@ -304,11 +304,17 @@ impl Operations {
         let table_schema = catalog.get_table(table_name);
 
         // Check user-defined unique indexes BEFORE inserting any rows
-        // This is separate from the table-level constraint checks in Table::insert_batch
+        // This is separate from the table-level constraint checks in Table::insert_batch.
+        // The batch variant also tracks keys claimed by earlier rows of this
+        // same batch (issue #6346): the index bodies are only rebuilt after
+        // the bulk append, so without in-batch tracking two colliding rows
+        // in one batch would both pass and both be written.
         if let Some(schema) = table_schema {
-            for row in &rows {
-                self.index_manager.check_unique_constraints_for_insert(table_name, schema, row)?;
-            }
+            self.index_manager.check_unique_constraints_for_insert_batch(
+                table_name,
+                schema,
+                &rows,
+            )?;
         }
 
         // Record start index for return value

--- a/crates/vibesql-storage/src/persistence/binary/constraints.rs
+++ b/crates/vibesql-storage/src/persistence/binary/constraints.rs
@@ -263,6 +263,63 @@ pub(crate) fn rehydrate_constraints_from_sql_source(
             Some(table_level_key_parts.unwrap_or_else(|| vec![None; pk_cols.len()]));
     }
 
+    // ---- UNIQUE constraints (column-level first, then table-level) ----
+    // Neither `TableSchema::unique_constraints` nor
+    // `unique_constraint_collations` is a serialized binary field, so before
+    // this rehydration a reloaded table silently forgot every schema-level
+    // UNIQUE constraint (issue #6346): the executor's in-batch duplicate
+    // working set for multi-row INSERT went empty, `Table`'s per-constraint
+    // hash maps were never built, and collation-aware UNIQUE enforcement
+    // (`UNIQUE(a COLLATE nocase)`, issue #5881) was lost. Cross-statement
+    // duplicates were still caught only because the implicit
+    // `sqlite_autoindex_*` metadata IS serialized.
+    //
+    // Ordering must match `ConstraintValidator::process_constraints` exactly
+    // (column-level UNIQUE in column order, then table-level UNIQUE in
+    // declaration order): the positions align with the implicit autoindex
+    // ordinals from `create_implicit_indexes` and with `Table`'s positional
+    // unique-index maps.
+    let mut unique_constraints: Vec<Vec<String>> = Vec::new();
+    let mut unique_constraint_collations: Vec<Vec<Option<String>>> = Vec::new();
+    for col_def in &create.columns {
+        for constraint in &col_def.constraints {
+            if matches!(constraint.kind, vibesql_ast::ColumnConstraintKind::Unique { .. }) {
+                unique_constraints.push(vec![col_def.name.clone()]);
+                // Column-level UNIQUE carries no key-part COLLATE; enforcement
+                // falls back to the column's declared collation.
+                unique_constraint_collations.push(vec![None]);
+            }
+        }
+    }
+    for table_constraint in &create.table_constraints {
+        if let vibesql_ast::TableConstraintKind::Unique { columns, .. } = &table_constraint.kind {
+            let mut names: Vec<String> = Vec::with_capacity(columns.len());
+            let mut collations: Vec<Option<String>> = Vec::with_capacity(columns.len());
+            for part in columns {
+                match part {
+                    vibesql_ast::IndexColumn::Column { column_name, collation, .. } => {
+                        names.push(column_name.clone());
+                        collations.push(collation.clone());
+                    }
+                    vibesql_ast::IndexColumn::Expression { .. } => {
+                        // The CREATE TABLE path rejects expression key parts in
+                        // table-level UNIQUE, so an accepted source can't
+                        // contain one. Never silently drop a constraint.
+                        return Err(StorageError::NotImplemented(format!(
+                            "Persisted sql_source for table '{}' contains an expression key \
+                             part in a table-level UNIQUE constraint",
+                            schema.name
+                        )));
+                    }
+                }
+            }
+            unique_constraints.push(names);
+            unique_constraint_collations.push(collations);
+        }
+    }
+    schema.unique_constraints = unique_constraints;
+    schema.unique_constraint_collations = unique_constraint_collations;
+
     // ---- CHECK constraints (column-level first, then table-level) ----
     // Matches ConstraintValidator::process_constraints ordering and naming.
     let mut check_constraints: Vec<(String, vibesql_ast::Expression)> = Vec::new();
@@ -660,6 +717,52 @@ mod tests {
         schema.primary_key = Some(vec!["id".to_string()]);
         rehydrate_constraints_from_sql_source(&mut schema, &HashMap::new()).unwrap();
         assert_eq!(schema.primary_key_collations, Some(vec![None]));
+    }
+
+    #[test]
+    fn rehydrates_column_level_unique_constraints() {
+        // `TableSchema::unique_constraints` is not a serialized binary field;
+        // it must be rederived from `sql_source` so intra-statement duplicate
+        // detection (and Table's per-constraint hash maps) survive a reload
+        // (issue #6346).
+        let mut schema =
+            schema_with_source("t", vec![col("a"), col("b")], "CREATE TABLE t(a UNIQUE, b)");
+        assert!(schema.unique_constraints.is_empty(), "precondition: not yet rehydrated");
+        rehydrate_constraints_from_sql_source(&mut schema, &HashMap::new()).unwrap();
+
+        assert_eq!(schema.unique_constraints, vec![vec!["a".to_string()]]);
+        assert_eq!(schema.unique_constraint_collations, vec![vec![None]]);
+    }
+
+    #[test]
+    fn rehydrates_table_level_unique_with_ordering_and_collation() {
+        // Column-level UNIQUE constraints come first (column order), then
+        // table-level ones (declaration order) — the positions must align
+        // with the implicit autoindex ordinals and Table's positional
+        // unique-index maps. Explicit key-part COLLATE survives (issue #5881).
+        let mut schema = schema_with_source(
+            "t",
+            vec![col("a"), col("b"), col("c")],
+            "CREATE TABLE t(a UNIQUE, b, c, UNIQUE(b COLLATE nocase, c))",
+        );
+        rehydrate_constraints_from_sql_source(&mut schema, &HashMap::new()).unwrap();
+
+        assert_eq!(
+            schema.unique_constraints,
+            vec![vec!["a".to_string()], vec!["b".to_string(), "c".to_string()]]
+        );
+        assert_eq!(
+            schema.unique_constraint_collations,
+            vec![vec![None], vec![Some("nocase".to_string()), None]]
+        );
+    }
+
+    #[test]
+    fn table_without_unique_constraints_rehydrates_empty() {
+        let mut schema = schema_with_source("t", vec![col("a")], "CREATE TABLE t(a INTEGER)");
+        rehydrate_constraints_from_sql_source(&mut schema, &HashMap::new()).unwrap();
+        assert!(schema.unique_constraints.is_empty());
+        assert!(schema.unique_constraint_collations.is_empty());
     }
 
     #[test]

--- a/crates/vibesql-storage/src/wal/recovery.rs
+++ b/crates/vibesql-storage/src/wal/recovery.rs
@@ -2313,13 +2313,15 @@ mod tests {
                     ColumnSchema::new("id".to_string(), DataType::Integer, false),
                     ColumnSchema::new("y".to_string(), DataType::Integer, true),
                     ColumnSchema::new("z".to_string(), DataType::Integer, true),
+                    ColumnSchema::new("w".to_string(), DataType::Integer, true),
                 ],
                 vec!["id".to_string()],
             );
             child.set_sql_source(
                 "CREATE TABLE c(id INTEGER PRIMARY KEY, \
                  y INTEGER REFERENCES p(x) ON DELETE CASCADE, \
-                 z INTEGER CHECK(z > 0))"
+                 z INTEGER CHECK(z > 0), \
+                 w INTEGER UNIQUE)"
                     .to_string(),
             );
             db.create_table(child).unwrap();
@@ -2331,6 +2333,7 @@ mod tests {
                     SqlValue::Integer(10),
                     SqlValue::Integer(1),
                     SqlValue::Integer(5),
+                    SqlValue::Integer(7),
                 ]),
             )
             .unwrap();
@@ -2357,6 +2360,15 @@ mod tests {
         // source spacing (`CHECK(z > 0)` → `z > 0`, SQLite-compatible).
         assert_eq!(child.check_constraints.len(), 1, "CHECK must be rehydrated");
         assert_eq!(child.check_constraints[0].0, "z > 0");
+
+        // UNIQUE constraint survives (issue #6346): without it, the
+        // executor's intra-statement duplicate detection went empty after
+        // replay and multi-row INSERTs could write colliding rows.
+        assert_eq!(
+            child.unique_constraints,
+            vec![vec!["w".to_string()]],
+            "UNIQUE must be rehydrated"
+        );
 
         // FK survives with its action and resolved parent columns (the
         // parent's CreateTable precedes the child's in the WAL).


### PR DESCRIPTION
Closes #6346

## Problem

A single multi-row `INSERT ... VALUES(1),(1)` with an intra-statement UNIQUE collision silently inserted **both** rows whenever uniqueness was enforced solely through unique **index metadata**:

- a reopened (WAL/checkpoint-recovered) table with a `UNIQUE` column — the filed repro — because `TableSchema::unique_constraints` was never serialized nor rehydrated, emptying the executor's in-batch working set; only the serialized `sqlite_autoindex_*` metadata remained, and index-backed checks had no in-batch tracking
- a **fresh process** with `CREATE UNIQUE INDEX` (no reopen needed — same hole)
- `INSERT OR IGNORE ... VALUES(1),(1)` inserted 2 rows instead of 1 in both scenarios

Root cause per the curator's analysis: multi-row INSERT validates all rows before inserting any, so the stored index bodies cannot see earlier rows of the same statement, and neither `enforce_unique_indexes` nor `check_would_violate_constraints` tracked in-batch keys.

## Fix

**Part A (executor, the core fix)** — a per-statement `BatchUniqueIndexKeys` working set threaded through the validation loop, mirroring the existing `unique_constraint_values` pattern:
- `enforce_unique_indexes` checks it before the stored index body (plain, composite, **partial**, and **expression** unique indexes all covered) with SQLite-compatible violation messages
- `check_would_violate_constraints` consults it, so `OR IGNORE` **skips** the duplicate row (this is why the fix is executor-side — a storage-only error would break IGNORE semantics)
- keys are normalized with the same `normalize_for_comparison` canonical form the index bodies use (1 vs 1.0 collide; NULL keys never conflict), addressing the curator's normalization caveat
- belt-and-braces hardening: storage's `insert_rows_batch` pre-insert unique check now also tracks keys claimed by earlier rows of the same batch (`check_unique_constraints_for_insert_batch`)

**Part B (storage, schema fidelity)** — `rehydrate_constraints_from_sql_source` now rebuilds `unique_constraints` + `unique_constraint_collations` from the persisted `sql_source` (column-level UNIQUE in column order, then table-level UNIQUE in declaration order — exactly matching `ConstraintValidator::process_constraints`, so positions stay aligned with the implicit autoindex ordinals and `Table`'s positional unique-index maps). Covers both the binary checkpoint load path and WAL `CreateTable` replay (shared rehydration). Also revives collation-aware UNIQUE enforcement (`UNIQUE(a COLLATE nocase)`) after reopen. No format bump needed.

## Acceptance criteria (all verified)

- [x] Reopened table: `INSERT OR FAIL INTO t VALUES(1),(1)` errors `UNIQUE constraint failed: t.c`, only the first row persisted; plain `INSERT` (ABORT) errors with 0 rows
- [x] Fresh process: `CREATE UNIQUE INDEX` + `INSERT INTO t VALUES(1),(1)` errors identically
- [x] `INSERT OR IGNORE INTO t VALUES(1),(1)` inserts exactly 1 row (no error) in both scenarios
- [x] Cross-statement duplicate detection unchanged
- [x] TCL `fkey7-4.4`/`4.5` now **pass** (verified: main-branch binary fails 7 tests in fkey7.test including 4.4/4.5; this branch fails only the 5 pre-existing, unrelated ones — `fkey7-filescope-err.1`, `1.2`–`1.5`)

## Testing

- New integration suite `crates/vibesql-executor/tests/insert_batch_unique_index_tests.rs` (15 tests): fresh + reopened scenarios, ABORT/OR FAIL/OR IGNORE semantics, composite keys, numeric variants (1 vs 1.0), multiple NULLs, partial unique index, expression unique index, cross-statement regression, schema rehydration assertion
- Extended `persistence/binary/constraints.rs` rehydration unit tests (column-level, table-level ordering + key-part COLLATE, empty case)
- Extended WAL replay test `test_create_table_replay_restores_pk_constraints_and_rowid_alias` with a UNIQUE column
- Full `vibesql-executor` suite: 5996 passed, 0 failed; full `vibesql-storage` lib suite: 848 passed, 0 failed
- Workspace `cargo check` with CI feature set (`--no-default-features --features parallel,spatial`) clean
- Manual CLI verification of the issue's exact two-process repros (OR FAIL keeps 1 row + errors; OR IGNORE keeps 1 row silently; fresh-process unique index aborts with 0 rows; cross-statement still errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)