### PR TITLE
docs(crates): add READMEs for vibesql-consensus, vibesql-l10n, vibesql-bench-common

### DIFF
--- a/crates/vibesql-bench-common/README.md
+++ b/crates/vibesql-bench-common/README.md
@@ -1,0 +1,56 @@
+# vibesql-bench-common
+
+Shared benchmark infrastructure for VibeSQL benchmarks.
+
+## Overview
+
+This crate provides the common benchmark code used by the `vibesql-executor` and `vibesql-server` benchmark suites: portable data generators, schema definitions, and timing/statistics infrastructure for industry-standard database benchmarks.
+
+It is primarily internal plumbing for the VibeSQL workspace's benchmark harness, published to crates.io for dependency-graph completeness. External users are welcome to reuse the generators, but the API tracks the needs of VibeSQL's own benchmarks.
+
+## Features
+
+- **TPC-C**: OLTP transaction processing benchmark (data generators and types)
+- **TPC-H**: Decision support (OLAP) benchmark
+- **Sysbench**: MySQL-compatible micro-benchmarks
+- **Harness**: timing and statistics infrastructure shared across suites
+
+### Cargo features
+
+Engine-specific schema loading is behind optional feature flags (all off by default, so the core generators stay dependency-light):
+
+- `vibesql` — VibeSQL schema loading (pulls in `vibesql-types`, `vibesql-ast`, `vibesql-catalog`, `vibesql-storage`)
+- `sqlite` — comparison-engine schema loading via `rusqlite`
+- `duckdb` — comparison-engine schema loading via `duckdb`
+- `mysql` — comparison-engine schema loading via `mysql`
+
+## Usage
+
+Add this to your `Cargo.toml` (typically as a dev-dependency):
+
+```toml
+[dev-dependencies]
+vibesql-bench-common = "0.2"
+```
+
+From the VibeSQL repository, the benchmark suites built on this crate run via:
+
+```bash
+make benchmark-tpch       # TPC-H decision support (22 queries)
+make benchmark-tpcc       # TPC-C OLTP transactions
+make benchmark-sysbench   # Sysbench micro-benchmarks
+```
+
+## Documentation
+
+- [API Documentation](https://docs.rs/vibesql-bench-common)
+- [Main VibeSQL Repository](https://github.com/rjwalters/vibesql)
+
+## License
+
+This project is licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE))
+- MIT License ([LICENSE-MIT](../../LICENSE-MIT))
+
+at your option.

--- a/crates/vibesql-consensus/README.md
+++ b/crates/vibesql-consensus/README.md
@@ -1,0 +1,52 @@
+# vibesql-consensus
+
+Consensus adapter layer for VibeSQL WAN replication.
+
+## Overview
+
+This crate is the stable seam between VibeSQL and the consensus engine that drives replication. Per [ADR-0004](../../docs/decisions/0004-consensus-library.md), VibeSQL runs `openraft` as a **single Raft group replicating the whole database** (the rqlite/dqlite/Turso model), but consumers of this crate depend only on the engine-agnostic `ConsensusBackend` trait — never on `openraft` types directly — so the consensus engine stays swappable.
+
+## Features
+
+- **`ConsensusBackend` trait**: engine-agnostic adapter (propose / read_committed / snapshot / role)
+- **`SingleNodeBackend`**: in-memory loopback implementation that commits every proposal immediately, for dev and unit tests
+- **`OpenraftBackend`**: the real engine — proposals flow through openraft's append → commit → apply pipeline, with optional on-disk durability (fsynced WAL-style log and vote records, torn-write tolerant recovery)
+- **TCP transport**: length-prefixed frames on a dedicated consensus port, with static membership via `cluster.toml`
+- **Durable snapshots**: CRC-framed, atomically-written snapshot files; recovery restores snapshot first, then replays the log
+- **Replicated state machine**: applies committed transactions from the Raft log to a real VibeSQL database
+
+All backend configurations pass the same behavioral conformance suite, so code written against the trait behaves identically on any of them.
+
+### Cargo features
+
+- `mvcc_enabled` — forwards the MVCC toggle to the storage/executor stack; enables commit-timestamp stamping (`xmin` = Raft log index) and the vacuum-horizon interlock
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+vibesql-consensus = "0.2"
+```
+
+Spin up a local multi-node test cluster from the VibeSQL repository:
+
+```bash
+make test-cluster
+```
+
+## Documentation
+
+- [API Documentation](https://docs.rs/vibesql-consensus)
+- [ADR-0004: Consensus Library Selection](../../docs/decisions/0004-consensus-library.md)
+- [Main VibeSQL Repository](https://github.com/rjwalters/vibesql)
+
+## License
+
+This project is licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE))
+- MIT License ([LICENSE-MIT](../../LICENSE-MIT))
+
+at your option.

--- a/crates/vibesql-l10n/README.md
+++ b/crates/vibesql-l10n/README.md
@@ -1,0 +1,54 @@
+# vibesql-l10n
+
+Localization support for VibeSQL using [Project Fluent](https://projectfluent.org/).
+
+## Overview
+
+This crate provides internationalization (i18n) and localization (l10n) support for the VibeSQL CLI and related tools. Translation catalogs are authored in Fluent (`.ftl`) files, embedded into the binary at compile time, and resolved at runtime with system locale detection and English fallback.
+
+## Features
+
+- **Fluent message catalogs**: translations authored in `.ftl` files and embedded via `rust-embed`
+- **Locale detection**: detects the system locale from the environment, with explicit override support
+- **Simple API**: `init()`, `format()`, and the `vibe_msg!` macro for messages with arguments
+- **Translation tooling**: `check-ftl` and `check-translations` binaries validate catalog syntax and cross-locale coverage
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+vibesql-l10n = "0.2"
+```
+
+Basic example:
+
+```rust
+use vibesql_l10n::{init, format, vibe_msg};
+
+// Initialize with system locale detection...
+init(None).unwrap();
+// ...or specify a locale explicitly
+init(Some("es")).unwrap();
+
+// Format a simple message
+let banner = format("cli-banner", None);
+
+// Format a message with arguments using the macro
+let rows = vibe_msg!("rows-with-time", count = 42, time = "0.123");
+```
+
+## Documentation
+
+- [API Documentation](https://docs.rs/vibesql-l10n)
+- [Main VibeSQL Repository](https://github.com/rjwalters/vibesql)
+
+## License
+
+This project is licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE))
+- MIT License ([LICENSE-MIT](../../LICENSE-MIT))
+
+at your option.


### PR DESCRIPTION
## Summary

Implements the curator-recommended **Option A** for #6322: write a `README.md` for each of the three publishable crates that shipped without one. All three are already live on crates.io at 0.2.0 with blank readme panels, so `publish = false` was not a viable alternative (and is mechanically impossible for `vibesql-l10n`, a regular dependency of four published crates).

- `crates/vibesql-consensus/README.md` — Raft replication adapter layer; sourced from the crate's module docs and ADR-0004. Documents the `ConsensusBackend` trait, backends, TCP transport, durable snapshots, and the `mvcc_enabled` feature.
- `crates/vibesql-l10n/README.md` — Project Fluent localization; documents `init`/`format`/`vibe_msg!` and the `check-ftl`/`check-translations` validation binaries.
- `crates/vibesql-bench-common/README.md` — shared benchmark infrastructure; includes the honest "internal plumbing published for dependency-graph completeness" framing and documents the `vibesql`/`sqlite`/`duckdb`/`mysql` feature flags.

All three follow the sibling template (`crates/vibesql-ast/README.md`): title, one-line summary, Overview, Features, Usage, Documentation, License.

**No `Cargo.toml` changes**: no sibling crate sets an explicit `readme` key — Cargo auto-detects `README.md` in the package root (verified below). `crates/README.md`'s publishing order is unchanged, per the curator's acceptance criteria (it only needed edits if a crate flipped to `publish = false`).

## Test plan

- [x] `cargo package --list -p <crate>` shows `README.md` included for all three crates (auto-detection confirmed, no `readme` key needed)
- [x] `cargo publish --dry-run -p vibesql-l10n` succeeds (compiles and packages cleanly; consensus/bench-common can't fully dry-run locally due to unpublished-at-this-version path deps, which is expected — `cargo package --list` is the right local check for those per the curator)
- [x] Relative license links (`../../LICENSE-APACHE`, `../../LICENSE-MIT`) and docs.rs/repo links match the sibling READMEs
- [x] Markdown-only change; no code touched

Closes #6322

🤖 Generated with [Claude Code](https://claude.com/claude-code)