### PR TITLE
docs(release): re-home release policy to .repo/release-policy.md seams (Repo Skills v0.7.0)

### DIFF
--- a/.claude/commands/repo/audit.md
+++ b/.claude/commands/repo/audit.md
@@ -48,6 +48,14 @@ Run each of the following checks and compile results into a single report:
 - Local branches whose PRs are merged
 - Orphaned or stale worktrees
 
+### Out of scope: host posture (see [[host-optimize]])
+
+This is a repo-scoped audit. The **host** a machine presents to heavy build
+workloads — Gatekeeper scan churn, backup-agent interference, build-tree bloat,
+sudo/concurrency posture — is not checked here. For a build host, run
+[[host-optimize]] instead; unlike this read-only audit, that command applies its
+safe-tier fixes by default.
+
 ## Output Format
 
 Present findings as a table grouped by category:

--- a/.claude/commands/repo/branches.md
+++ b/.claude/commands/repo/branches.md
@@ -120,21 +120,77 @@ STALE WORKTREES (0):
 worktree is removed until it passes — irreversible removal of work that exists
 nowhere else is never acceptable, `--prune` or not.
 
+The check runs in two stages, plus one fixed rule about which way it fails.
+
+#### 5a. Ancestry — does the branch carry commits that exist nowhere else?
+
 For every branch about to be deleted, list commits that live *only* on that
 branch — not reachable from the default branch and not present on any remote:
 
 ```bash
-git log --oneline <branch> --not --remotes --not <default>
+git log --oneline <branch> --not <default> --remotes
 ```
 
-- **Empty** → the work is preserved elsewhere (merged or pushed); safe to delete.
-- **Non-empty** → those commits would be **permanently lost**. Do NOT auto-delete
-  even under `--prune`. Reclassify the branch as UNKNOWN, show the count and the
-  commit subjects, and require an explicit per-branch confirmation.
+- **Empty** → the branch carries no commits of its own; safe to delete.
+- **Non-empty** → this proves nothing yet. Go to 5b before concluding.
 
-(A merged PR whose remote branch was already deleted may show commits here after
-a squash-merge — that's the safe direction to err: surface it and let the user
-confirm the work is truly in the PR.)
+`--not` is a **toggle**, not a per-argument negation: it flips the sense of every
+ref that follows it, up to the next `--not`. Both exclusions must therefore sit
+after a **single** `--not`. Writing it as
+`<branch> --not --remotes --not <default>` flips the sense back to positive and
+folds all of `<default>`'s own commits into the output, so the exclusion silently
+stops working — the check then reports commits the branch never had, and returns
+empty only when unrelated refs happen to cover the tip. **Never add a second
+`--not`.** If `--remotes` is too broad for the repo, spell the exclusions out
+instead: `git log --oneline <branch> --not <default> origin/<default>`.
+
+#### 5b. Content — does `<default>` already contain this work?
+
+A non-empty 5a result does **not** mean the work would be lost. A squash-merge
+replays the branch's changes as one brand-new commit whose parent is
+`<default>`'s prior tip, so the branch's original commits never become ancestors
+of `<default>` and *always* appear in 5a — even when every line of the work is
+already merged. Decide with **content containment**, not SHA ancestry:
+
+```bash
+# Would merging the branch into <default> change anything at all?
+# `--write-tree` requires git >= 2.38; on older git this errors and you take the fallback below.
+[ "$(git merge-tree --write-tree <default> <branch>)" = "$(git rev-parse '<default>^{tree}')" ]
+```
+
+Equal trees → `<default>` already holds the branch's content → safe to delete.
+If `git merge-tree` is unsupported (git < 2.38) or reports a conflict, fall back
+to the exact-match form `git diff --quiet <default> <branch>`: exit 0 (identical
+trees) is also proof of containment, while a non-zero exit proves nothing either
+way. Failing both, ask the forge whether the branch's PR was merged:
+
+```bash
+gh pr list --head <branch> --state merged --json number --jq length
+```
+
+A count `>= 1` means the work landed through that PR; safe to delete.
+
+If none of these establish containment, the 5a commits would be **permanently
+lost**. Do NOT auto-delete even under `--prune`. Reclassify the branch as
+UNKNOWN, show the count and the commit subjects, and require an explicit
+per-branch confirmation.
+
+**Do NOT "simplify" 5b to `git branch --merged <default>`.** That lists only
+branches whose commits are literal ancestors of `<default>`, which is never true
+after a squash-merge — every squash-merged branch would be classified unsafe and
+`--prune` would silently stop pruning anything, defeating the feature with no
+error to notice. `--merged` answers "are these exact commits on `<default>`";
+pruning needs "does `<default>` already have this work". Different questions.
+
+#### 5c. Failure direction — ambiguity and errors always mean KEEP
+
+If any command in 5a or 5b exits non-zero unexpectedly, emits output that cannot
+be parsed, or cannot run at all — `gh` missing, unauthenticated, or rate-limited;
+no network; an unknown or ambiguous ref; `git merge-tree` unsupported — the
+branch is classified **UNKNOWN / KEEP**. **Never SAFE.** Ambiguity is never
+resolved in favour of deletion, and this holds under `--prune` exactly as it does
+without it. A branch wrongly kept costs one line of report noise; a branch
+wrongly deleted costs the work.
 
 For each worktree about to be removed, refuse if it has uncommitted changes —
 that work exists nowhere else:
@@ -151,7 +207,9 @@ Then delete the branches that passed the loss check:
 
 ```bash
 git branch -d <branch_name>           # -d (safe): refuses if not merged
-# escalate to -D only for a branch the loss check proved is pushed/merged
+# escalate to -D only for a branch the loss check proved is pushed, or whose
+# content 5b proved is already contained in <default> (the squash-merge case,
+# where -d refuses because the original SHAs are not ancestors of <default>)
 ```
 
 Report what was deleted, what was skipped for potential data loss, and what

--- a/.claude/commands/repo/handoff.md
+++ b/.claude/commands/repo/handoff.md
@@ -86,8 +86,14 @@ reset actually did — any earlier and it is speculative.
 2. A pointer in the agent's auto-memory index (`MEMORY.md` in the memory
    directory, when one exists): a single line —
    `- Handoff note at .claude/handoff.md — READ FIRST, then delete note + this line.`
-   The memory index is read automatically at session start; the pointer is
-   what makes the repo file reliably found rather than merely present.
+   The memory index is read automatically at session start, but it arrives as
+   passive background context, not an instruction — so the pointer is a
+   *best-effort backup*, not a guarantee the note is read (a live handoff has
+   been observed to slip past it). The mechanism that actively announces the
+   note is the `session-start-handoff.sh` **SessionStart hook** (installed by
+   Repo Skills), which surfaces the note as session context on startup and
+   resume — the full body inlined when the note is small, a header outline plus
+   an oversize warning when it is large.
 
 **What goes in — only what is not recoverable from the repo:**
 
@@ -127,7 +133,8 @@ to. End by printing an exact, copy-pasteable block for the human, e.g.:
 claude update
 #   3. Relaunch in this repo:
 cd <repo-root> && claude
-# The new session will find the handoff note via its memory index.
+# The SessionStart hook announces the handoff note to the new session
+# (the memory-index pointer is a best-effort backup).
 ```
 
 Then stop. The ritual is complete when the note is durable and the

--- a/.claude/commands/repo/help.md
+++ b/.claude/commands/repo/help.md
@@ -60,10 +60,12 @@ stashes, untracked files) always need an explicit opt-in.
 | /repo:handoff | Rolling the session (context full, CLI update) — preserve what only the session knows, then restart |
 | /repo:tidy  | Working tree cluttered with build artifacts and temp files |
 | /repo:remote | Need a cloud dev box (GCP/AWS) with this repo ready to go |
+| /repo:sudo | One-time machine setup — grant passwordless sudo (validated drop-in) so an agent over SSH isn't blocked on password prompts |
 | /repo:release | Cut a release — pre-flight, semver, CHANGELOG, version bump, tag, GitHub Release |
 
 ### Periodic maintenance
 | /repo:audit | Monthly sweep, or after a big refactor/import |
+| /repo:host-optimize | Prep/re-check a Mac (or Linux box) for heavy Loom/agent build use — Gatekeeper churn, backup-agent interference, build-tree bloat |
 | /repo:update-tools | Keep Loom/Anvil/Repo Skills installs current |
 
 ### Focused checks

--- a/.claude/commands/repo/host-optimize.md
+++ b/.claude/commands/repo/host-optimize.md
@@ -1,0 +1,370 @@
+---
+name: "host-optimize"
+description: "Audit and prepare a Mac (or Linux box) for heavy Loom/agent build use — Gatekeeper churn, backup-agent interference, build-tree bloat"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:host-optimize — Prepare a Build Host
+
+Audit the **host** a machine presents to heavy Loom/agent build workloads, then
+apply the safe fixes and gate the consequential ones. This is host preparation,
+not repo hygiene: nothing here is discoverable from inside a repo, and none of it
+is fixed by [[tidy]] or [[audit]]. It exists because a Mac Studio running six
+concurrent release-build worktrees melted down — load average 118, VNC unusable,
+a multi-hour remediation — and **every root cause was host configuration**:
+`syspolicyd` burning 14+ CPU-hours a day re-scanning `target/` trees on every
+Gatekeeper cache miss, a backup agent churning build dirs at 98% CPU, no
+passwordless sudo, an empty Developer Tools exemption list, and ~10 GB of dead
+worktree `target/` dirs the scanner kept re-walking.
+
+Follows the pack's **inventory → categorize by consequence → report → apply**
+shape (the same shape as [[tidy]] and [[branches]]). Audit checks are always
+report-only and safe. Fixes are split into three consequence tiers: **safe /
+default-on**, **confirm-first**, and **documented-but-manual** (printed only,
+never executed).
+
+**macOS-first, Linux-aware.** The Gatekeeper / SIP / Spotlight / Time Machine
+material is macOS-only and is gated behind a `uname` check. The portable subset
+— build-tree bloat, Loom concurrency vs core count, sudo posture, cache infra,
+remote access — still runs and reports on Linux.
+
+## Usage
+
+```
+/repo:host-optimize            # Audit, apply safe fixes, report; confirm-first items prompt
+/repo:host-optimize --ask      # Review every finding and confirm before applying anything
+/repo:host-optimize --audit    # Audit and report only — apply nothing (like /repo:audit)
+```
+
+(`--apply` is accepted as a synonym for the default, for muscle memory. On a
+non-macOS host the macOS-only checks are skipped with a one-line note and the
+portable subset runs unchanged.)
+
+## Hard constraints (read before implementing)
+
+1. **The two SIP-gated / global items — the ExecPolicy DB trim and
+   `spctl --global-disable` — are PRINT-ONLY. Never shell out to perform
+   either.** The ExecPolicy trim is SIP-gated (Recovery-mode only) and
+   `spctl --global-disable` disables Gatekeeper machine-wide; both are printed
+   as a recipe for a human to run deliberately. This is a hard constraint, not a
+   nice-to-have — it is the highest-consequence part of the command.
+2. **Never write to `/etc/sudoers.d/`.** The sudo-posture check only *detects*
+   whether a passwordless drop-in exists and *delegates* to `/repo:sudo` (issue #49)
+   or prints the manual `visudo`-validated recipe. It does not itself install a
+   sudoers drop-in.
+3. **Everything applied must have appeared in the report first**, and re-running
+   after a clean pass must report a no-op (idempotency) rather than re-applying
+   or erroring.
+
+## Steps
+
+### 1. Detect platform
+
+```bash
+OS="$(uname -s)"   # Darwin = macOS, Linux = Linux
+CORES="$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || nproc)"
+```
+
+Gate every macOS-only probe below behind `[ "$OS" = Darwin ]`. On Linux, print
+`Skipping macOS-only checks (syspolicyd, Gatekeeper, Time Machine, Spotlight) on
+$OS` and run only the portable subset (checks 4–8).
+
+### 2. Audit checks (report-only, always safe)
+
+Run each check and assign a severity consistent with [[audit]]'s scheme —
+**critical** (actively causing or about to cause harm), **warn** (should fix,
+not yet harmful), **info** (nice to fix). Report all findings in one table;
+never mutate anything in this phase.
+
+#### 2.1 syspolicyd health — macOS only
+
+The feedback loop that caused the incident. Each freshly built, ad-hoc-signed
+binary is a Gatekeeper cache miss (`errSecCSUnsigned`) that triggers a malware
+scan re-walking enormous `target/` trees, and the ExecPolicy DB bloats over time
+so every lookup gets slower.
+
+```bash
+# CPU time syspolicyd has burned vs system uptime (a high ratio = the loop is hot)
+ps -axo pid,comm,time | grep -E 'syspolicyd$'
+uptime
+# ExecPolicy DB size — 53 MB in the incident; anything into the tens of MB is a warn
+ls -lh /var/db/SystemPolicyConfiguration/ExecPolicy 2>/dev/null
+# Recent malware-scan churn in the log (bounded window so this stays cheap)
+log show --predicate 'process == "syspolicyd"' --last 30m --style compact 2>/dev/null \
+  | grep -ci 'malware' || true
+```
+
+- **critical**: syspolicyd CPU-time / uptime ratio is high **and** malware-scan
+  log churn is active — the loop is live.
+- **warn**: ExecPolicy DB in the tens of MB (lookups are slowing) with no active
+  churn yet.
+- **info**: DB small, ratio low.
+
+The remediation for a bloated DB is the SIP-gated trim — **printed only** in
+step 4, never run here.
+
+#### 2.2 Gatekeeper posture — macOS only
+
+```bash
+spctl --status                                   # assessments enabled/disabled
+spctl developer-mode --status 2>/dev/null || true
+# Developer Tools exemption list — empty list = every built binary is re-scanned
+sqlite3 /var/db/SystemPolicyConfiguration/ExecPolicy \
+  'select count(*) from developer_tools;' 2>/dev/null || echo 'unreadable'
+```
+
+- **warn**: Developer Tools list empty on a heavy build host (the exact
+  incident condition — every ad-hoc-signed binary is a fresh scan).
+- **info**: assessments enabled with a populated exemption list (normal, healthy).
+
+#### 2.3 Backup / indexing agents — macOS only
+
+Backup and indexing agents love churning build dirs (Backblaze ran a
+`-completesync` at ~98% CPU mid-build-storm during the incident).
+
+```bash
+# Backblaze present?
+ls /Library/Backblaze.bzpkg 2>/dev/null && echo 'backblaze present'
+pgrep -l bztransmit 2>/dev/null || true
+# Time Machine exclusions already covering build dirs?
+tmutil isexcluded ./target 2>/dev/null || true
+# Spotlight indexing status for this volume
+mdutil -s . 2>/dev/null || true
+```
+
+- **warn**: a backup/indexing agent is present and the repo's `target/` /
+  `.loom/worktrees/` dirs are **not** excluded — they will be re-walked.
+- **info**: agents present but build dirs already excluded.
+
+#### 2.4 sudo posture — portable
+
+Detect only; **never** write to `/etc/sudoers.d/`.
+
+```bash
+USER_NAME="$(id -un)"
+ls "/etc/sudoers.d/${USER_NAME}-nopasswd" 2>/dev/null && echo 'nopasswd drop-in present'
+sudo -n true 2>/dev/null && echo 'passwordless sudo works' || echo 'sudo requires a password'
+```
+
+- **warn**: no passwordless drop-in on an unattended agent build host — a remote
+  agent is blocked on every root-level fix.
+- **info**: drop-in present and `sudo -n` succeeds.
+
+Remediation is **delegated to `/repo:sudo` (#49)**, or the printed manual recipe —
+see step 5. Never installed here.
+
+#### 2.5 Build-tree bloat — portable
+
+The directory trees the scanner keeps re-walking. Dead worktree `target/` dirs
+are the safe-to-reclaim ones.
+
+```bash
+# target/ sizes across the repo and every loom worktree
+du -sh target 2>/dev/null || true
+for wt in .loom/worktrees/*/; do du -sh "$wt/target" 2>/dev/null || true; done
+# Dead worktrees whose branch/issue is gone but whose target/ lingers
+git worktree list --porcelain
+```
+
+- **warn**: multi-GB of `target/` under `.loom/worktrees/` belonging to worktrees
+  git no longer lists (dead artifacts), or a very large main `target/`.
+- **info**: only live-worktree build trees present.
+
+Cross-reference [[tidy]] for the in-repo clutter half; this check is specifically
+about the dead-worktree build artifacts the host scanner re-walks.
+
+#### 2.6 Cache infra — portable
+
+```bash
+command -v sccache >/dev/null && sccache --show-stats 2>/dev/null || echo 'sccache not installed'
+df -h . | tail -1     # disk headroom on the build volume
+```
+
+- **warn**: sccache absent (or installed but not wired into the build) on a
+  repeat-build host, or disk headroom under ~10%.
+- **info**: sccache working, ample headroom.
+
+#### 2.7 Concurrency sanity — portable
+
+```bash
+# Loom's configured worktree concurrency vs core count
+jq -r '.concurrency // .maxWorkers // "unset"' .loom/config.json 2>/dev/null || echo 'no .loom/config.json'
+echo "cores: $CORES"
+```
+
+- **critical**: configured concurrency far exceeds cores (the incident: six
+  concurrent release builds of a large Rust workspace drove load average to 118).
+- **info**: concurrency at or below a sane multiple of the core count.
+
+This check only *reports* the mismatch and suggests a value; it never edits
+`.loom/config.json` (that is a deliberate operator call).
+
+#### 2.8 Remote access — portable (with macOS specifics)
+
+A headless build box that sleeps mid-build, or has no remote path in, is a
+support problem waiting to happen.
+
+```bash
+# SSH reachable?
+[ "$OS" = Darwin ] && sudo systemsetup -getremotelogin 2>/dev/null || systemctl is-active ssh sshd 2>/dev/null || true
+if [ "$OS" = Darwin ]; then
+  # Screen Sharing enabled?
+  launchctl list 2>/dev/null | grep -qi screensharing && echo 'screen sharing on'
+  # Will it sleep a headless box mid-build?
+  pmset -g | grep -E 'sleep|disksleep'
+fi
+```
+
+- **warn**: no remote-access path enabled, or power settings will sleep the
+  machine (or its disk) during a long unattended build.
+- **info**: reachable and configured to stay awake.
+
+### 3. Report
+
+Group findings by check and severity, in one table (mirrors [[audit]]'s format),
+then list what the apply phase *will* do per tier before doing it.
+
+```
+## Host Optimize — <hostname> (Darwin, 20 cores)
+
+### Findings
+| Severity | Check            | Finding |
+|----------|------------------|---------|
+| critical | syspolicyd       | 14.2 CPU-hrs vs 26h uptime; malware-scan churn active |
+| critical | concurrency      | .loom concurrency 6 vs 20 cores of a large Rust WS — load 118 risk |
+| warn     | gatekeeper       | Developer Tools exemption list empty |
+| warn     | backup agents    | Backblaze present; target/ not excluded |
+| warn     | sudo posture     | no /etc/sudoers.d/<user>-nopasswd drop-in |
+| warn     | build-tree bloat | 9.7 GB target/ across 4 dead worktrees; 77 GB main target/ |
+| info     | cache infra      | sccache working; 41% disk free |
+| info     | remote access    | SSH on, Screen Sharing on, sleep disabled |
+
+### Will apply now (safe / default-on)
+- Remove target/ of 4 dead loom worktrees (frees ~9.7 GB)
+- tmutil addexclusion ./target and .loom/worktrees/*/target
+- Spotlight: drop .metadata_never_index into those dirs
+- Print Backblaze exclusion instructions (manual — GUI-gated)
+
+### Will prompt (confirm-first)
+- spctl developer-mode enable-terminal (+ GUI toggle you must flip)
+- sudo drop-in via /repo:sudo (delegated; not yet installed)
+
+### Printed only — never executed (documented-but-manual)
+- ExecPolicy DB trim (SIP-gated, Recovery-mode recipe)
+- spctl --global-disable trade-offs
+```
+
+Under `--audit`, stop here.
+
+### 4. Documented-but-manual — PRINT ONLY, NEVER EXECUTE
+
+These two items are printed as recipes for a human to run deliberately. The
+implementation **must not** contain a code path that executes either — verify by
+inspection.
+
+**ExecPolicy DB trim (SIP-gated, Recovery mode).** When the DB has bloated (2.1),
+print:
+
+```
+The ExecPolicy DB (/var/db/SystemPolicyConfiguration/ExecPolicy) is <size>.
+Trimming it is SIP-gated and cannot be done from a normal session. To reset it:
+  1. Reboot into Recovery (hold power on Apple silicon; Cmd-R on Intel).
+  2. From Recovery Terminal, disable SIP:  csrutil disable
+  3. Reboot, then from a normal session remove and let macOS rebuild the DB.
+  4. Reboot into Recovery again and re-enable SIP:  csrutil enable
+This is a deliberate, high-consequence procedure — do it during a maintenance
+window, not mid-build.
+```
+
+**`spctl --global-disable` (disables Gatekeeper machine-wide).** Print the
+trade-offs and the exact command, and require explicit human action:
+
+```
+spctl --global-disable turns off Gatekeeper assessment for the WHOLE machine.
+It eliminates the ad-hoc-signing scan storm but removes malware screening for
+every app on the host — a real security downgrade. If you accept that trade-off
+on a dedicated, physically-secured build box, run it yourself:
+  sudo spctl --global-disable
+Prefer the Developer Tools exemption (step 5) first — it fixes the build-scan
+churn without disabling Gatekeeper globally.
+```
+
+Never run either command from this skill.
+
+### 5. Apply — safe / default-on (no confirmation)
+
+Apply immediately (unless `--ask` or `--audit`), each reported as applied. All
+must be idempotent — re-running skips anything already done.
+
+- **Dead loom-worktree `target/` cleanup.** For each `target/` under
+  `.loom/worktrees/` whose worktree git no longer lists, `rm -rf` it (these are
+  regenerable build artifacts of a gone worktree; the [[tidy]] safety posture
+  applies — never touch a live worktree's tree). Re-report bytes freed.
+- **Time Machine exclusion** (macOS): `tmutil addexclusion` for `./target` and
+  each `.loom/worktrees/*/target`. `tmutil isexcluded` first so a second run is a
+  no-op.
+- **Spotlight exclusion** (macOS): drop a `.metadata_never_index` marker into
+  `target/` and the worktree build dirs (idempotent — skip if present); mention
+  `mdutil -i off <volume>` as the volume-wide alternative for a dedicated box.
+- **Backblaze exclusion instructions** (macOS): Backblaze's exclusions are
+  GUI-gated, so **print** the steps (Backblaze Settings → Exclusions → add the
+  repo `target/` and `.loom/worktrees/` paths) rather than editing its config.
+
+### 6. Apply — confirm-first (explicit prompt before acting)
+
+Each of these prompts for confirmation before doing anything (and under `--ask`
+so does everything in step 5):
+
+- **`spctl developer-mode enable-terminal`** (macOS): after confirmation, run it
+  to add the terminal's toolchain to the Developer Tools exemption — then **tell
+  the human** which GUI toggle to flip (System Settings → Privacy & Security →
+  Developer Tools → enable your terminal), because the pane is GUI-gated and the
+  CLI half alone is not always sufficient.
+- **sudo drop-in** (portable): **delegated to `/repo:sudo` (#49)** — never
+  reimplemented here. If `/repo:sudo` is installed, point the user at it (or its
+  `--sudo` flag). Until #49 ships, print the manual recipe and stop:
+
+  ```
+  To grant passwordless sudo for unattended agent work, run visudo and add a
+  validated drop-in (do NOT edit /etc/sudoers.d/ by hand without visudo -c):
+    sudo visudo -f /etc/sudoers.d/<user>-nopasswd
+    <user> ALL=(ALL) NOPASSWD: ALL
+  visudo validates syntax before saving — a malformed sudoers file can lock you
+  out. This skill will not write that file for you.
+  ```
+
+- **Pause / resume backup agents around a build storm** (macOS): after
+  confirmation, offer to pause Backblaze (`bztransmit` / the menu-bar control)
+  for the duration of a build and resume after — never silently, and always
+  reversible.
+
+### 7. Idempotency
+
+After applying, re-run the relevant probes so the report reflects the new state.
+A second back-to-back invocation must report a clean/no-op state (exclusions
+already present, dead targets already gone, drop-in already detected) and must
+not re-apply or error.
+
+## Safety Rules
+
+1. **PRINT-ONLY, NEVER EXECUTE** the ExecPolicy DB trim and
+   `spctl --global-disable`. No code path may run either — this is the load-bearing
+   constraint of the command.
+2. **Never write to `/etc/sudoers.d/`.** Detect and delegate to `/repo:sudo` (#49)
+   or print the `visudo` recipe; never install the drop-in from here.
+3. **Everything applied must appear in the report first** (step 3), and safe-tier
+   fixes are the only ones applied without confirmation.
+4. **Never delete a live worktree's `target/`** — only `target/` belonging to
+   worktrees git no longer lists. Regenerable build output only; never tracked
+   files, never `.git/`.
+5. **Confirm-first means confirm.** `spctl developer-mode enable-terminal`, the
+   sudo delegation, and backup-agent pause/resume all require an explicit prompt;
+   `--ask` extends confirmation to the safe tier too.
+6. **macOS-only checks skip cleanly on non-macOS** with a one-line note; the
+   portable subset (checks 4–8) still runs and reports.
+7. **Idempotent** — a second run on a prepared host reports a no-op, never
+   re-applies or errors.
+8. **Never edit `.loom/config.json`** — the concurrency check reports a mismatch
+   and suggests a value; changing it is a deliberate operator call.

--- a/.claude/commands/repo/release.md
+++ b/.claude/commands/repo/release.md
@@ -19,10 +19,66 @@ at release time, never hardcoded, so this works in any repo.
 /repo:release                  # Interactive release from the default branch
 ```
 
+## Phase 0 — Load project release policy
+
+Before Phase 1, load the repo's **release policy** if it has one. This is the
+single supported way for a project to inject its own procedural steps (gates,
+extra manifest edits, post-release deploys) at named phase boundaries without
+forking this command — see **Extension points — per-project release policy**
+below for the full seam contract and semantics. Projects migrating off Loom's
+removed `/loom:release` skill re-home their policy here.
+
+The policy lives in **one** file at the repo root: **`.repo/release-policy.md`**.
+Each seam is an H2 section headed `## seam: <name>`. Read it, then **validate the
+declared seam names and surface any that don't bind**, so a typo'd or orphaned
+seam fails loudly instead of silently doing nothing:
+
+```bash
+POLICY_FILE=".repo/release-policy.md"
+KNOWN_SEAMS="pre-flight pre-changelog-style pre-apply pre-push post-push pre-github-release post-summary"
+AUGMENT_ONLY="post-push post-summary"   # no default action → '(replace)' is meaningless
+if [ ! -f "$POLICY_FILE" ]; then
+  echo "(no $POLICY_FILE — running with the built-in phases only, no behavior change)"
+else
+  echo "Project release policy: $POLICY_FILE"
+  # Enumerate declared seams from '## seam: <name>' headers (dropping an optional
+  # '(replace)' suffix) and check each against the known set.
+  grep -E '^##[[:space:]]+seam:[[:space:]]*' "$POLICY_FILE" | while IFS= read -r header; do
+    name="$(printf '%s' "$header" | sed -E 's/^##[[:space:]]+seam:[[:space:]]*//; s/[[:space:]]*\(replace\)[[:space:]]*$//; s/[[:space:]]+$//')"
+    mode="augment"
+    printf '%s' "$header" | grep -Eq '\(replace\)[[:space:]]*$' && mode="replace"
+    case " $KNOWN_SEAMS " in
+      *" $name "*)
+        case " $AUGMENT_ONLY " in
+          *" $name "*)
+            if [ "$mode" = replace ]; then
+              echo "  WARNING: seam '$name' is augment-only — '(replace)' is meaningless here and will be ignored"
+            else
+              echo "  bound: $name (augment)"
+            fi ;;
+          *) echo "  bound: $name ($mode)" ;;
+        esac ;;
+      *)
+        echo "  WARNING: unknown seam '$name' — it matches no phase boundary and will NOT run. Fix the name (see the seam table) or remove the section." ;;
+    esac
+  done
+fi
+```
+
+If any `WARNING:` line prints, **stop and show it to the operator before Phase 1
+proceeds.** An unknown or misused seam is almost always a typo, or policy written
+against a seam this command doesn't expose — silently ignoring it is the exact
+failure this mechanism exists to prevent. Offer **[c]** continue anyway (the
+offending section simply won't run) or **[a]** abort to fix the policy. When the
+policy is clean, note which seams are bound and carry that into the phases below.
+
 ## Phase 1 — Pre-flight
 
 Confirm the repo is safe to cut from. The CI gate degrades gracefully when no
 workflows exist.
+
+> Seam `pre-flight` fires at the start of this phase — run any bound policy steps
+> before (augment) or in place of (replace) the checks below.
 
 ```bash
 # CI status, if CI exists at all
@@ -193,16 +249,65 @@ level and **ask the user to confirm or override.**
 
 ## Phase 4 — Draft the CHANGELOG
 
+> Seam `pre-changelog-style` fires before drafting — run any bound policy steps
+> to enforce a house changelog style (augment) or produce the entry itself
+> (replace).
+
 If `CHANGELOG.md` exists, study its format and draft a new entry matching it
 (header with today's date, a summary line, grouped changes, issue refs). If it's
 **absent**, offer to bootstrap a "Keep a Changelog" template. Present the draft
 and iterate until approved. Omit empty sections.
 
+### Fold an existing `## Unreleased` section into the draft
+
+A CHANGELOG may already carry a `## Unreleased` section — a convention where
+merged-but-unshipped changes accumulate under a placeholder heading at the top of
+the file (directly under the `# Changelog` title, above the newest version entry)
+until the next release names them. If one exists, this release **is** that
+version, so its entries must be folded into the new entry rather than left
+stranded below the freshly-inserted version heading. Do this **at draft time**,
+as part of matching the file's format above — not as a separate Phase 5 step:
+
+1. Check for an existing `^## Unreleased` heading in `CHANGELOG.md`. If none
+   exists, skip the rest of this sub-section entirely and behave exactly as
+   before — the fold path is strictly opt-in on the heading's presence and makes
+   **no** change to the draft-from-git-log path when absent.
+2. If present, capture its body — every line between that heading and the next
+   `^## ` heading (the newest existing version entry).
+3. Merge those captured items into the git-log-derived draft, **de-duplicating**
+   against items this release already derived from its git-log range. Entries in
+   this repo cite issue/PR numbers in their lead-ins (e.g. `(#38, PR #42)`,
+   `(#43)`), so a simple `grep -oE '#[0-9]+'` per bullet and a set-intersection
+   against the range's issue/PR references is a sufficient dedup key for v1 (fall
+   back to a fuzzy text match only for bullets that cite no number). Keep a
+   captured `## Unreleased` bullet only if none of its numbers already appear in
+   the git-log-derived draft.
+4. Produce **one** combined entry headed with the new version + today's date,
+   positioned **where `## Unreleased` was** — since that heading conventionally
+   sits at the very top, this is a rename-in-place (`## Unreleased` →
+   `## X.Y.Z (date)`), not an append elsewhere and no reordering. The
+   `## Unreleased` heading itself is removed as part of drafting.
+
+> Seam interaction: under a `pre-changelog-style (replace)` policy the default
+> draft heuristic — including this fold — is skipped per the seam's
+> "policy steps produce the entry; skip the default draft heuristic" semantics
+> (see the seam table below), so folding any `## Unreleased` section becomes the
+> policy's responsibility. Under `augment` (the default), the seam's steps run
+> first and then this fold runs, so there is no conflict.
+
 ## Phase 5 — Apply
+
+> Seam `pre-apply` fires before this phase — run any bound policy steps (e.g.
+> edit extra manifests) before (augment) or in place of (replace) the bump.
 
 Once approved:
 
-1. Insert the new entry into `CHANGELOG.md`.
+1. Insert the new entry into `CHANGELOG.md`. Phase 4 has already produced the
+   fully-merged entry (folding any `## Unreleased` section into it at draft
+   time), so this is a straight "write this string" — no fold/merge happens here.
+   The `pre-apply` seam therefore needs **no** change for the fold: it fires
+   before this insert, after drafting is complete, so it never observes an
+   un-folded entry regardless of how the string was assembled.
 2. **Show the version-bearing files** the tool will touch, then bump. Dispatch on
    the detected tool; each branch must produce a version commit **and** tag:
 
@@ -226,10 +331,27 @@ Once approved:
    commit/tag convention (check `git log` and `git tag`).
 3. **Verify**: re-read the version and confirm the tag exists
    (`git tag --sort=-v:refname | head -1`). For cargo, `cargo check --workspace`.
+   Also confirm the `## Unreleased` fold (Phase 4) actually landed: grep the
+   freshly-written `CHANGELOG.md` for any surviving `## Unreleased` heading and
+   **fail loudly** if one remains — a stray heading means the fold silently
+   didn't happen (e.g. both headings were left in place, or dedup dropped the
+   merge), which would strand this release's entries below the new version.
+
+   ```bash
+   if grep -Eq '^##[[:space:]]+Unreleased([[:space:]]|$)' CHANGELOG.md; then
+     echo "ERROR: a '## Unreleased' heading survived — Phase 4 fold did not complete" >&2
+     exit 1
+   fi
+   ```
 
 Show the result and get final confirmation.
 
 ## Phase 6 — Push & release
+
+Three seams fire in this phase: `pre-push` (before the push), `post-push`
+(immediately after it succeeds), and `pre-github-release` (before
+`gh release create`). Run any bound policy steps at each boundary — e.g. a
+`pre-github-release` gate that holds the Release until publish workflows finish.
 
 After an explicit yes:
 
@@ -259,11 +381,103 @@ CHANGELOG: 1 entry added
 Release:   GitHub Release created  (or: tag push only — no release workflow)
 ```
 
+> Seam `post-summary` fires after the summary — run any bound policy steps (e.g.
+> deploy a docs site, notify a channel).
+
+## Extension points — per-project release policy
+
+The phases above are fixed, but a project can inject its own procedural steps at
+**named phase boundaries** ("seams") without forking this command. This is what
+projects migrating off Loom's removed `/loom:release` skill use to re-home
+release policy — gates, extra manifest edits, post-release deploys.
+
+### Where policy lives
+
+**One** file, at the repo root: **`.repo/release-policy.md`**. There is a single
+supported lookup path by design — no per-user, per-branch, or fallback locations.
+Advisory *reminders* (e.g. "bump the protocol version when the API changes") still
+belong in the repo's CLAUDE.md, which this command already reads as context; the
+policy file is specifically for **procedural steps bound to a seam**.
+
+### Policy file format
+
+Each seam is an H2 section whose header is `## seam: <name>`, optionally suffixed
+with `(replace)`. The section body is the prose/steps the command runs at that
+boundary. Non-seam prose (a title, notes) is ignored — only `## seam:` headers
+bind.
+
+```markdown
+# Release policy — my-project
+
+## seam: pre-github-release
+
+Hold the GitHub Release until both publish workflows finish:
+- `gh run watch <npm-publish-run>` and `<crates-publish-run>` must both be green.
+
+## seam: post-summary
+
+Deploy the docs site: `gh workflow run deploy-site.yml`.
+
+## seam: pre-push (replace)
+
+Push via the release-bot identity instead of the default push:
+`git -c user.name="release-bot" push origin "$(git symbolic-ref --short HEAD)" --follow-tags`
+```
+
+### Seams and semantics
+
+Steps **augment** by default — they run *in addition to* the phase's built-in
+action, at the boundary. Appending `(replace)` to the header makes the policy
+steps stand in for the phase's default action instead. `(replace)` is only
+meaningful where the boundary has a default action to replace:
+
+| Seam | Fires | Augment (default) | `(replace)` |
+|------|-------|-------------------|-------------|
+| `pre-flight` | start of Phase 1 | run policy steps, then the standard pre-flight checks | policy steps become the pre-flight gate; skip the built-in CI/clean-tree checks |
+| `pre-changelog-style` | before Phase 4 drafts the entry | run policy steps (e.g. enforce a house changelog style), then draft — the default draft still folds any existing `## Unreleased` section into the new entry | policy steps produce the entry; skip the default draft heuristic — **including** the `## Unreleased` fold, so a `(replace)` policy owns folding any `## Unreleased` section itself or it will be left stranded |
+| `pre-apply` | before Phase 5 applies | run policy steps (e.g. edit extra manifests), then bump + commit + tag | policy steps perform the bump/commit/tag; skip the default apply dispatch |
+| `pre-push` | before the `git push` in Phase 6 | run policy steps (a final gate), then push | policy steps perform the push; skip the default `git push` |
+| `post-push` | immediately after the push succeeds | run policy steps | **augment-only** — no default action; a `(replace)` marker is ignored with a warning |
+| `pre-github-release` | before `gh release create` | run policy steps (e.g. wait for publish workflows), then create the Release | policy steps create the Release (or intentionally skip it); skip the default `gh release create` |
+| `post-summary` | after the Phase 7 summary | run policy steps (e.g. deploy a site) | **augment-only** — no default action; a `(replace)` marker is ignored with a warning |
+
+### Unknown seams are surfaced, never silently ignored
+
+Phase 0 enumerates every `## seam: <name>` in the policy file and checks each name
+against the table above. A header naming no known seam — a typo like
+`pre-changelog-styl`, or policy written against a seam this command doesn't expose
+— prints a `WARNING` shown to the operator **before Phase 1 proceeds**, rather
+than binding to nothing. Likewise, `(replace)` on an augment-only seam
+(`post-push`, `post-summary`) warns. This is the guarantee that migrated policy
+cannot silently stop firing.
+
+### Migrating from `/loom:release`
+
+Loom's removed `/loom:release` skill exposed five seams. **All five carry over
+under the same names**, so policy targeting them binds unchanged:
+
+| `/loom:release` seam | `/repo:release` seam | Change |
+|----------------------|----------------------|--------|
+| `pre-changelog-style` | `pre-changelog-style` | none (identity) |
+| `pre-push` | `pre-push` | none (identity) |
+| `post-push` | `post-push` | none (identity) |
+| `pre-github-release` | `pre-github-release` | none (identity) |
+| `post-summary` | `post-summary` | none (identity) |
+
+`/repo:release` adds two boundaries Loom didn't have — `pre-flight` and
+`pre-apply` — for gates that must run before the pre-flight checks or before the
+version bump. To migrate, move the policy text into `.repo/release-policy.md`
+under a `## seam: <name>` header for each old seam name. Nothing is dropped in the
+rename.
+
 ## Principles
 
 Cutting a release is irreversible and outward-facing, so unlike the safe-fix
 hygiene commands it stays **report first, act second** — nothing is committed,
 tagged, or pushed without a yes. **General by design** — the tool and the file
-set are discovered, never assumed. If the repo needs a release-time reminder
+set are discovered, never assumed. If the repo needs a release-time *reminder*
 (e.g. "bump the protocol version when the API changes"), keep it in the repo's
-own CLAUDE.md; this command reads that context at runtime.
+own CLAUDE.md; this command reads that context at runtime. Procedural policy that
+must *run* at a specific point — a gate, an extra manifest edit, a post-release
+deploy — goes in `.repo/release-policy.md` bound to a named seam instead (see
+**Extension points — per-project release policy** above).

--- a/.claude/commands/repo/remote.md
+++ b/.claude/commands/repo/remote.md
@@ -33,6 +33,29 @@ locally to drive the cloud CLI; they are **never** copied to the VM.
 First time in a repo? Run `/repo:remote --configure` to build the `.env` below,
 then `/repo:remote` to launch.
 
+The provisioning contract below is implemented **once**, as an executable
+script — `scripts/repo/repo-remote.sh`, installed to
+`.claude/skills/repo/scripts/repo-remote.sh`. The interactive flow here is a
+thin wrapper: it runs the wizard/cost-confirmation UX, and once you say yes it
+calls that script rather than re-issuing `aws`/`gcloud` calls from prose. The
+same script is the **headless entry point** a non-interactive caller (e.g.
+loom's `fleet add-worker`) invokes directly:
+
+```
+repo-remote up [aws|gcp]              # DRY RUN: print the resolved plan + estimated cost as JSON, create NOTHING
+repo-remote up --yes [--json]        # provision (or reuse) with no prompts; requires pre-supplied cost-relevant config
+repo-remote status [--json]          # list instances tagged repo-remote=<name>
+repo-remote down [--yes] [--delete]  # dry-run listing without --yes; stop (or --delete to terminate) with --yes
+```
+
+`--yes` **removes the prompt, not the consent.** A cost-relevant field missing
+from config — the provider, its credentials, or `REPO_REMOTE_INSTANCE_TYPE` —
+is a loud, non-zero-exit failure, never a silent default that could pick a
+billable size on its own. Plain `repo-remote up` (no `--yes`) is a dry run that
+prints the plan and estimated hourly cost and spends nothing, so a caller can
+implement a "plan shown before money is spent" check against the `--json`
+output (instance id, public IP, SSH alias, estimated hourly cost).
+
 ## Configuration — two layers
 
 Settings come from two files, loaded in order so the repo can override the
@@ -188,6 +211,15 @@ wants a repo-specific account/region.
 9. Offer to run `/repo:remote` right away.
 
 ## Steps
+
+Steps 1–4, plus `--status`/`--down`, describe the provisioning contract that
+`scripts/repo/repo-remote.sh` implements. The interactive flow **delegates** to
+that script: it performs the credential-hygiene checks and the wizard/cost
+confirmation here, then hands the resolved plan to `repo-remote up --yes`
+(passing the confirmed provider/instance-type through config) rather than
+issuing the `aws`/`gcloud` calls itself. This keeps a single implementation, so
+the headless path and the interactive path cannot drift. The cloud-CLI
+specifics below document *what the script does* and remain the reference for it.
 
 ### 1. Load and validate config
 
@@ -436,6 +468,10 @@ Claude Code cannot host an interactive SSH session itself, so hand it to the OS
   terminal
 
 Tell the user they can start `claude` in that session to continue on the remote.
+On a freshly provisioned box, `/repo:sudo` is the companion step that unblocks
+root-level remediation over SSH — a non-interactive SSH session can't answer a
+`sudo` password prompt, so an agent stalls on it until a validated
+passwordless-sudo drop-in is installed.
 
 ### 8. Report
 
@@ -444,6 +480,12 @@ hourly cost estimate, idle-shutdown window, the SSH alias, whether the ID was
 written back to `.env`, and the teardown command (`/repo:remote --down`).
 
 ## `--status` and `--down`
+
+Both delegate to the shared script (`repo-remote status` / `repo-remote down`),
+which resolves the same two config layers and only ever touches instances
+carrying this repo's `repo-remote` tag. `repo-remote down` without `--yes` is a
+dry run that lists exactly what would stop; `--yes` acts, and `--delete`
+terminates.
 
 - `--status`: list all instances labeled `repo-remote=<repo-name>` with state
   and uptime; estimate accumulated cost. Uses the resolved credentials (shared

--- a/.claude/commands/repo/sudo.md
+++ b/.claude/commands/repo/sudo.md
@@ -1,0 +1,275 @@
+---
+name: "sudo"
+description: "Opt-in passwordless sudo for a dev machine — install a visudo-validated /etc/sudoers.d drop-in (ALL or a scoped command list) so an agent over SSH isn't blocked on password prompts, always confirmed first"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:sudo — Passwordless-sudo setup for dev machines
+
+Install (or inspect, or remove) a `NOPASSWD:` **sudoers drop-in** for the
+current user on **this machine**, so an agent driving the box over SSH isn't
+stopped dead by a `sudo` password prompt it can't answer. A non-interactive SSH
+session has no TTY to type a password into, so every root-level remediation —
+`launchctl bootout`, killing a runaway root process, `spctl`, `renice` — stalls
+until a human runs the command by hand. This command installs the standard fix
+once, safely, so agent-driven remote sessions can finish end-to-end.
+
+This is **machine-global, consequential setup**: the drop-in grants anyone
+holding the user's SSH key effective root on this box. It is therefore in the
+same **always-confirm-first** class as `/repo:remote`, `/repo:followups`, and
+`/repo:update-tools` — it shows the **exact file contents** it will write and
+**never applies silently**, even without `--ask`. There is nothing to opt into;
+confirmation is the only mode. The reasonable trade this makes — passwordless
+root for personal dev machines on a private tailnet — is a deliberate operator
+choice, so the operator makes it explicitly every time a scope changes.
+
+> **Touch ID is the better answer for *local, interactive* use** — enabling
+> `pam_tid.so` in `/etc/pam.d/sudo` lets a Mac authorize `sudo` with a
+> fingerprint. But Touch ID does **not** work over SSH (there is no local
+> fingerprint reader on the remote end), which is exactly why a `NOPASSWD:`
+> drop-in is the right tool for **agent sessions** and this command exists.
+
+The **destructive-command guard still applies on top.** Passwordless sudo
+removes the *password* gate, not the guard's `ask`/`block` gates on risky
+commands (`rm -rf /`, force-push to `main`, cloud destruction, …). Granting
+passwordless root does not weaken any of those checks.
+
+## Usage
+
+```
+/repo:sudo                 # Guided: explain the grant, confirm, install an ALL-scoped drop-in
+/repo:sudo --scoped        # Confirm, then install a command-list-scoped drop-in
+                            #   (launchctl, pkill, spctl, renice, …) instead of ALL
+/repo:sudo --status        # Report whether a drop-in exists, its scope, and validity — writes nothing
+/repo:sudo --remove        # Confirm, then remove this command's drop-in file
+```
+
+## How it works
+
+The drop-in lives at a well-known, per-user path — **the file itself is the
+marker**:
+
+```
+/etc/sudoers.d/<user>-nopasswd
+```
+
+Both macOS and Linux read this directory automatically, so **no OS branching is
+needed**:
+
+- **macOS** — `/etc/sudoers` (a symlink target of `/private/etc/sudoers`)
+  ships `@includedir /private/etc/sudoers.d` by default, and `/etc/sudoers.d`
+  is `/private/etc/sudoers.d`.
+- **Linux** — nearly every distro ships `#includedir /etc/sudoers.d` in
+  `/etc/sudoers`.
+
+The candidate file is always syntax-checked **in isolation** with
+`sudo visudo -cf "$TMP"` *before* it is copied into `/etc/sudoers.d/` — a
+malformed drop-in never becomes live policy. After the validated file is
+installed, a full-chain `sudo visudo -c` (it validates `/etc/sudoers` **and**
+every file it includes) implicitly proves the include chain is active on either
+platform, so there is no need to detect the OS or hand-verify the directive.
+
+The written file always carries a **discoverability header** on its first line
+so `--status`, `--remove`, and any later host-posture audit (e.g.
+`/repo:host-optimize`) can find and attribute it without guessing from the
+filename:
+
+```
+# Installed by /repo:sudo (rjwalters/repo) — see .claude/commands/repo/sudo.md
+```
+
+Two scopes are supported:
+
+- **ALL** (default) — blanket passwordless root:
+
+  ```
+  <user> ALL=(ALL) NOPASSWD: ALL
+  ```
+
+- **Scoped** (`--scoped`) — passwordless only for a small allowlist of
+  service-management commands, so agents are unblocked on the operations that
+  actually stall over SSH without granting blanket root:
+
+  ```
+  <user> ALL=(ALL) NOPASSWD: /bin/launchctl, /usr/bin/pkill, /usr/sbin/spctl, /usr/bin/renice
+  ```
+
+  Anything outside that list still prompts for a password. Adjust the allowlist
+  to what the machine actually needs before confirming.
+
+## Steps
+
+### 1. Resolve the target and read current state
+
+Resolve the drop-in path and read what's already installed — every mode below
+starts here, and it is the whole of `--status`.
+
+```bash
+USER_NAME="$(id -un)"
+DROPIN="/etc/sudoers.d/${USER_NAME}-nopasswd"
+
+if [ -f "$DROPIN" ] || sudo test -f "$DROPIN" 2>/dev/null; then
+  CURRENT="$(sudo cat "$DROPIN" 2>/dev/null)"        # readable only as root (0440)
+else
+  CURRENT=""
+fi
+```
+
+Classify the installed scope from `$CURRENT`, ignoring the header/comment lines:
+
+- **absent** — no file.
+- **ALL** — the effective grant is `NOPASSWD: ALL`.
+- **scoped** — the effective grant is a `NOPASSWD:` command list.
+
+Determine the **requested** scope from the flags: `--scoped` → scoped list;
+otherwise → ALL. (`--status` and `--remove` don't request a scope.)
+
+### 2. `--status` — report only, write nothing
+
+Report and **stop** — this mode never writes, never prompts, and must not
+change the file's mtime:
+
+- Whether `$DROPIN` exists, and its scope (ALL vs. the scoped command list).
+- Whether it currently passes validation — run `sudo visudo -c` and report
+  pass/fail (this reads the config; it does not modify it).
+- Whether passwordless sudo is actually in effect right now:
+  `sudo -n true 2>/dev/null && echo 'passwordless sudo works' || echo 'sudo still requires a password'`.
+
+Then exit. Do not fall through to any write path.
+
+### 3. `--remove` — delete this command's drop-in (confirm first)
+
+Only ever remove **this command's own** file at `$DROPIN` (identified by the
+header from step 1) — never touch other files in `/etc/sudoers.d/`.
+
+1. If the file is absent, say so and stop (nothing to remove — idempotent).
+2. Show the file that will be deleted and its current contents, and get an
+   explicit **yes**.
+3. Remove it, then re-validate so the removal didn't break anything:
+
+   ```bash
+   sudo rm -f "$DROPIN"
+   sudo visudo -c
+   ```
+
+4. Confirm the effect: a subsequent `sudo` now prompts for a password again
+   (`sudo -n true` should fail). Report done.
+
+### 4. Idempotency check (install modes)
+
+Before writing anything, compare the **installed** scope (step 1) against the
+**requested** scope (step 2):
+
+- **Same scope already installed** → **no-op.** Report "already configured
+  (`<scope>`) at `$DROPIN`" and stop. Do not re-prompt and do not re-write —
+  re-running with the same scope must make no changes.
+- **Different scope installed** (e.g. `--scoped` requested but `ALL` is
+  installed, or vice-versa) → this is a real change of the grant. Say so
+  explicitly ("currently `ALL`; you asked for `scoped`"), and require
+  confirmation in step 5 before overwriting.
+- **Nothing installed** → proceed to step 5 as a fresh install.
+
+### 5. Confirm, then write / validate / roll back
+
+Always show the **exact file contents** (including the header line) that will be
+written, name the target path, and get an explicit **yes** before touching
+anything — even without `--ask`. Never write silently.
+
+Build the file in a temp location and **validate the candidate in isolation
+before it can go live** — only a syntactically valid file is ever copied into
+`/etc/sudoers.d/`. There is no separate "enable" step for a sudoers.d file: the
+`@includedir` / `#includedir` directive picks it up on the very next `sudo`
+parse, so a broken file that reaches the directory is *already* live policy —
+and because sudo fails closed on a syntax error, the rollback `sudo rm` could be
+denied by the very file it is trying to remove. Validating `$TMP` first makes
+that failure mode impossible; the post-install full-chain check is then only a
+belt-and-suspenders proof that the include wiring is sound:
+
+```bash
+USER_NAME="$(id -un)"
+DROPIN="/etc/sudoers.d/${USER_NAME}-nopasswd"
+TMP="$(mktemp)"
+
+# Header first (discoverability), then the grant line for the chosen scope:
+{
+  echo "# Installed by /repo:sudo (rjwalters/repo) — see .claude/commands/repo/sudo.md"
+  # Default (ALL):
+  echo "${USER_NAME} ALL=(ALL) NOPASSWD: ALL"
+  # --scoped instead:
+  # echo "${USER_NAME} ALL=(ALL) NOPASSWD: /bin/launchctl, /usr/bin/pkill, /usr/sbin/spctl, /usr/bin/renice"
+} > "$TMP"
+chmod 440 "$TMP"
+
+# Validate the candidate BEFORE it can affect live policy. visudo -cf checks a
+# single file's syntax without installing it, so a malformed drop-in never
+# becomes active and we never depend on a possibly-broken sudo to undo it.
+if ! sudo visudo -cf "$TMP"; then
+  rm -f "$TMP"
+  echo "candidate sudoers failed validation — nothing installed" >&2
+  exit 1
+fi
+
+# Only a validated file reaches /etc/sudoers.d/:
+sudo cp "$TMP" "$DROPIN"
+sudo chmod 440 "$DROPIN"
+rm -f "$TMP"
+
+# Belt-and-suspenders: full-chain re-check proves the include wiring too. If it
+# somehow fails, remove the drop-in and exit non-zero — never leave an
+# unvalidated or broken file in place. (This rollback is now reliable because
+# the file was already known-valid before it landed.)
+if ! sudo visudo -c; then
+  sudo rm -f "$DROPIN"
+  echo "post-install validation failed — removed ${DROPIN}, no change made" >&2
+  exit 1
+fi
+```
+
+The order is load-bearing: the candidate is syntax-checked with
+`visudo -cf "$TMP"` **before** the `cp`, so a malformed drop-in never becomes
+live policy and the rollback never has to fight a broken sudo. The post-install
+`visudo -c` is the final full-chain gate; if it fails for **any** reason the
+drop-in is deleted and the command exits non-zero — there is no path in which a
+failed-validation file survives, and no path in which an unvalidated file goes
+live even momentarily.
+
+### 6. Verify and report
+
+On success, prove the grant actually took and report a compact block:
+
+```bash
+sudo -n true 2>/dev/null && echo 'passwordless sudo now works' \
+                         || echo 'WARNING: drop-in written and validated but sudo -n still prompts'
+```
+
+Report: the path written, the scope (ALL vs. the scoped list, with the exact
+command list for the scoped case), that permissions are `0440`, that
+`visudo -c` passed, and the removal command (`/repo:sudo --remove`) for undoing
+it later.
+
+## Safety Rules
+
+1. **Always confirm before writing** — show the exact file contents (header +
+   grant line) and the target path, and act only on an explicit yes. There is
+   no silent/auto-apply mode; confirmation is the only mode.
+2. **Validate the candidate before it goes live, then roll back on failure** —
+   the candidate is built at `0440` in a temp file and syntax-checked in
+   isolation with `sudo visudo -cf "$TMP"` **before** it is copied into
+   `/etc/sudoers.d/`, so a malformed drop-in never becomes active policy (a
+   sudoers.d file is live the instant it lands, and sudo fails closed on a
+   syntax error — validating pre-install is what keeps the rollback reliable). A
+   post-install full-chain `sudo visudo -c` then re-checks the include wiring;
+   on any failure the file is removed and the command exits non-zero. A broken
+   sudoers file can lock the user out of root, so an unvalidated file is never
+   installed or left behind.
+3. **Idempotent** — re-running with the same scope detects the existing drop-in
+   and no-ops; only a scope *change* prompts to overwrite.
+4. **Only ever touch this command's own drop-in** at
+   `/etc/sudoers.d/<user>-nopasswd` (identified by its `Installed by /repo:sudo`
+   header) — never other files in `/etc/sudoers.d/`.
+5. **The destructive-command guard still applies** — passwordless sudo removes
+   the password gate, not the guard's `ask`/`block` gates on risky commands.
+6. **Prefer the smallest grant that unblocks the work** — offer `--scoped`
+   (launchctl / pkill / spctl / renice) when blanket `ALL` root isn't needed.

--- a/.claude/skills/repo/SKILL.md
+++ b/.claude/skills/repo/SKILL.md
@@ -14,7 +14,7 @@ each change; add `--ask` to review findings and confirm first. Anything
 irreversible — deleting a branch, worktree, stash, or untracked file — is never
 automatic: it takes an explicit opt-in and passes a permanent-loss check.
 Commands whose only action is consequential (`orphans`, `update-tools`,
-`followups`, `release`, `remote`) always confirm first by nature. The environment commands (`remote`) stand up
+`followups`, `release`, `remote`, `sudo`) always confirm first by nature. The environment commands (`remote`) stand up
 infrastructure only after showing exactly what they will create and what it
 costs.
 
@@ -26,9 +26,12 @@ costs.
 | [[all]] | The whole hygiene pass in order — audit, docs, tidy, update-tools, reset — safe fixes by default, destructive steps gated |
 | [[audit]] | Full sweep — runs all hygiene checks, produces a summary report |
 | [[reset]] | Back to baseline — review stale worktrees/branches/stashes, sync with remote, return to the default branch |
+| [[handoff]] | Roll the session safely — file follow-ups, reset, check for a CLI update, write a handoff note the next session reads first |
 | [[tidy]] | Tidy up — build artifacts, caches, temp files, empty dirs |
-| [[release]] | Cut a release — pre-flight, semver decision, CHANGELOG, version bump, tag, GitHub Release |
-| [[remote]] | Launch a cloud dev session (GCP or AWS) with this repo ready to go, then open SSH |
+| [[release]] | Cut a release — pre-flight, semver decision, CHANGELOG, version bump, tag, GitHub Release. Supports per-project release policy via named phase-boundary seams in `.repo/release-policy.md` |
+| [[host-optimize]] | Prepare a Mac (or Linux box) for heavy Loom/agent build use — audit Gatekeeper churn, backup-agent interference, build-tree bloat; apply safe fixes, gate consequential ones |
+| [[remote]] | Launch a cloud dev session (GCP or AWS) with this repo ready to go, then open SSH. Its provisioning contract is implemented once in `scripts/repo/repo-remote.sh` (installed to `.claude/skills/repo/scripts/`); the interactive flow delegates to that script, which also serves as a headless `repo-remote up --yes --json` entry point for non-interactive callers (e.g. loom's `fleet add-worker`) |
+| [[sudo]] | Opt-in passwordless-sudo setup for a dev machine — install a `visudo`-validated `/etc/sudoers.d` drop-in (blanket `ALL` or a scoped command list) so an agent over SSH isn't blocked on password prompts; always confirmed first, validated with rollback on failure |
 | [[update-tools]] | Check installed tool packages (Loom, Anvil, …) against their sources and offer updates |
 | [[followups]] | Capture follow-on work from this session and file it as issues — here or in upstream tool repos, always confirmed first |
 | [[branches]] | Branch & worktree hygiene — merged PRs, orphaned branches, stale worktrees |
@@ -45,6 +48,8 @@ costs.
 - When the working tree feels messy (`tidy`, `orphans`)
 - When `git branch` output has grown unmanageable (`branches`)
 - When local hardware isn't enough or you need a clean Linux box (`remote`)
+- Before turning a Mac into a heavy Loom/agent build host (`host-optimize`)
+- To unblock an agent driving a dev box over SSH from `sudo` password prompts (`sudo`)
 - Periodically, to keep installed tool packages current (`update-tools`)
 - Periodically (monthly) as general hygiene (`audit`)
 - Before a demo, handoff, or onboarding (clean up before they arrive)
@@ -132,3 +137,31 @@ or malformed config keeps the guard on; the opt-in toggles are the inverse.
 The full stable interface (input/output contract, exit semantics, every env
 name) is documented in the hook's own header — downstream tools (e.g. Loom's
 installer) gate on it via this repo's release version.
+
+## Handoff-note hook (SessionStart)
+
+The installer wires a second hook, `session-start-handoff.sh`, as two
+`SessionStart` entries — one matching `startup`, one matching `resume`. When
+[[handoff]] has left a note at `.claude/handoff.md`, the hook emits it as
+session context via `hookSpecificOutput.additionalContext`: the note's path,
+its age, a staleness warning once the note passes seven days, and the note
+itself. When the note is at or under a size cap (`MAX_BODY_BYTES`, 10 KB) the
+**full body is inlined**; above the cap it falls back to an outline built from
+the note's `#`/`##` headers plus an explicit oversize warning. Inlining the body
+is deliberate (issue #33): the load-bearing content lives in the body, and a
+headers-only summary conveys shape but nothing actionable.
+
+Behavioral contract:
+
+- **Read-only.** It never writes, deletes, or modifies the note. Absorbing the
+  note and deleting it is [[handoff]]'s own one-shot contract.
+- **Silent when there is nothing to say.** No note, or an unreadable one, means
+  no output and exit 0.
+- **Fails open.** Malformed stdin, a missing `cwd`, or any internal error exits
+  0 with no output. A hook fault must never block session start.
+- **Skips `/clear`.** `clear` is not a process relaunch, so re-emitting the
+  banner there would be noise.
+
+There are no configuration toggles — the hook's behavior is fixed. To disable
+it, remove its `SessionStart` entries from `.claude/settings.json` (or run
+`uninstall.sh`, which removes only the entries it owns).

--- a/.claude/skills/repo/hooks/guard-destructive.sh
+++ b/.claude/skills/repo/hooks/guard-destructive.sh
@@ -924,6 +924,90 @@ function qsplit(s,   out, n, i, c, j, qc, ci, inner, SQ, DQ) {
 }
 '
 
+# =============================================================================
+# MULTI-LINE QUOTE-AWARE SEGMENTATION (#71)
+#
+# The three segment parsers (parse_force_ops, lifecycle_or_cloud_reason,
+# extract_rm_targets) originally segmented per awk INPUT RECORD with
+# `$0 = qsplit($0); split($0, segs, "\n")`. Because awk's default RS="\n" splits
+# a multi-line command into separate records BEFORE the pattern block runs,
+# qsplit()'s quote-tracking state — scoped to a single call — reset at every
+# embedded newline. An interior line of an otherwise-inert multi-line quoted
+# DATA literal (echo/printf/--body) was therefore lexed as its own top-level
+# segment with no memory that it is still inside an open quote from a prior line,
+# so a quoted `git push --force origin main` false-`ask`ed (parse_force_ops) and
+# a quoted `halt` false-`deny`ed (lifecycle_or_cloud_reason). PR #69 fixed the
+# identical defect in extract_rm_targets() with a whole-buffer slurp-then-segment
+# lexer; this shared helper generalizes that lexer so all three parsers segment
+# ONCE over the full command and cannot drift (the same rationale the _QSPLIT_AWK
+# header gives for sharing qsplit()).
+#
+# `ml_segment(buf, segs)` fills the caller's `segs[]` out-array (AWK passes arrays
+# by reference) with one entry per top-level segment and returns the count. It
+# deliberately does NOT reuse qsplit()+split("\n"): qsplit() emits a `\n` for each
+# REAL separator while ALSO leaving a literal newline that lived inside an inert
+# quoted span untouched, so the two become indistinguishable to a downstream
+# `split(s, segs, "\n")`. Segmentation is therefore done inline here, so an inert
+# quoted span's embedded newlines never become segment boundaries.
+#
+# Segmentation contract (identical to qsplit()'s single-line behaviour, now
+# correctly carried ACROSS embedded newlines):
+#   - Separators `;` `&` (`&&`) `|` (`||`) OUTSIDE any quote split segments.
+#   - A raw newline OUTSIDE any quote ALSO splits — so a GENUINE multi-line
+#     command still yields a real later-line segment and still denies (safety
+#     floor preserved; matches the old per-record behaviour where each input line
+#     was its own record).
+#   - An INERT quoted span (no `$(` and no backtick) is copied VERBATIM, so its
+#     embedded newlines/separators stay literal and never manufacture a phantom
+#     segment out of quoted documentation prose (the false positive).
+#   - A quoted span carrying command substitution (`$(` or a backtick) keeps its
+#     separators ACTIVE (walked char-by-char, exactly like qsplit()), so a
+#     smuggled payload is never hidden behind an opening quote.
+#   - An unterminated quote copies the remainder verbatim (best-effort; never
+#     widens a deny into an allow).
+# =============================================================================
+_ML_QSPLIT_AWK='
+function ml_segment(buf, segs,   SQ, DQ, s, n, seg, segc, i, c, qc, ci, j, inner) {
+    SQ = sprintf("%c", 39)   # single quote
+    DQ = sprintf("%c", 34)   # double quote
+    split("", segs)          # clear the caller-supplied out-array
+    s = buf
+    n = length(s)
+    seg = ""
+    segc = 0
+    i = 1
+    while (i <= n) {
+        c = substr(s, i, 1)
+        if (c == DQ || c == SQ) {
+            qc = c
+            ci = 0
+            for (j = i + 1; j <= n; j++) if (substr(s, j, 1) == qc) { ci = j; break }
+            if (ci == 0) {
+                seg = seg substr(s, i)   # unterminated quote: copy rest verbatim
+                i = n + 1
+                continue
+            }
+            inner = substr(s, i + 1, ci - i - 1)
+            if (index(inner, "$(") == 0 && index(inner, "`") == 0) {
+                seg = seg substr(s, i, ci - i + 1)   # inert span: verbatim (newlines stay literal)
+                i = ci + 1
+                continue
+            }
+            seg = seg c   # command substitution present: keep separators ACTIVE
+            i++
+            continue
+        }
+        if (c == ";" || c == "&" || c == "|" || c == "\n") {
+            segs[++segc] = seg; seg = ""; i++; continue
+        }
+        seg = seg c
+        i++
+    }
+    segs[++segc] = seg
+    return segc
+}
+'
+
 # Parse force-op segments out of a command, emitting one TAB-separated
 # "<cpath>\t<target>" line per genuine git force-push / hard-reset. Portable awk
 # only (mirrors extract_rm_targets / lifecycle_or_cloud_reason segment parsing):
@@ -943,12 +1027,20 @@ function qsplit(s,   out, n, i, c, j, qc, ci, inner, SQ, DQ) {
 #   - reset --hard: always emitted with <target> = "@HEAD@".
 # The caller resolves "@HEAD@" to the checked-out branch and applies the mode.
 parse_force_ops() {
-    printf '%s' "$1" | awk "$_QSPLIT_AWK"'
-    BEGIN { SEP = sprintf("%c", 31) }  # US (unit separator) — non-whitespace so
-                                       # bash read does not trim an empty cpath.
-    {
-        $0 = qsplit($0)   # quote-aware segmentation (#3755)
-        n = split($0, segs, "\n")
+    printf '%s' "$1" | awk "$_ML_QSPLIT_AWK"'
+    BEGIN {
+        SEP = sprintf("%c", 31)  # US (unit separator) — non-whitespace so bash
+                                 # read does not trim an empty cpath.
+        buf = ""
+    }
+    # Slurp the whole (possibly multi-line) command, then segment ONCE with the
+    # shared quote-aware lexer (#71) so a multi-line quoted DATA literal whose
+    # interior line is a force-push phrase is no longer mis-read as a real
+    # segment (the pre-#71 per-record `qsplit()` reset quote state at each
+    # embedded newline).
+    { buf = buf (NR > 1 ? "\n" : "") $0 }
+    END {
+        n = ml_segment(buf, segs)
         for (i = 1; i <= n; i++) {
             seg = segs[i]
             sub(/^[ \t]+/, "", seg)
@@ -1089,6 +1181,142 @@ strip_literal_text() {
     }'
 }
 
+# Redact the quoted argument(s) of a non-executing "data sink" command word
+# (echo, printf) so a dangerous-looking string that appears ONLY as quoted DATA
+# handed to echo/printf no longer trips the raw ALWAYS_BLOCK_PATTERNS scan
+# (catastrophic tier) or the ASK_PATTERNS scan (ask tier) (#53). echo/printf
+# print their arguments verbatim; they never EXECUTE them, so a quoted argument
+# is inert text — exactly like a --body/-m value — yet strip_literal_text()'s
+# flag allowlist never covered it. This is the meta false-positive that blocked
+# a guard self-test (`echo '{"…":"<dangerous cmd>"}' | guard-destructive.sh`)
+# and blocked filing this very issue's heredoc body.
+#
+# Command-word anchored (mirrors fastpath_builtin_admits() and the segment
+# parsers): the quoted args are redacted ONLY for a simple command whose FIRST
+# token is exactly `echo` or `printf` (optionally behind a bare `sudo`/`env`
+# wrapper). A wrapper that actually EXECUTES its argument — `bash -c '<payload>'`,
+# `sh -c`, `eval`, `xargs` — is never a data sink and is never redacted here.
+#
+# Safety floor, identical to strip_literal_text()/qsplit():
+#   - A quoted span is redacted ONLY when it carries no command substitution /
+#     backtick opener (`$(` or a backtick), so a smuggled `echo "$(<payload>)"`
+#     keeps its payload intact and still hard-denies.
+#   - The `echo '<payload>' | sh` shape (data PIPED into a shell that WOULD
+#     execute it) is handled by the command_has_shell_segment() gate at the call
+#     site, which skips this redaction entirely whenever any pipeline segment's
+#     command word is a shell — so the raw scan still sees and blocks the payload.
+#
+# Single-pass quote-aware lexer. It deliberately does NOT reuse qsplit(), whose
+# `\n`-per-separator contract would conflate a real newline inside a multi-line
+# quoted span with a shell separator; here a multi-line span is redacted as one
+# inert unit (`.` never matches a newline, so each line stays SAME-LENGTH and the
+# surrounding byte offsets are preserved). Best-effort like strip_literal_text():
+# an unterminated quote copies the remainder verbatim (never redacts), and the
+# result feeds only the NARROWING scans, so the worst case is a raw substring
+# surviving (a false block) — never a catastrophic block being skipped.
+strip_datasink_literals() {
+    printf '%s' "$1" | awk '
+    BEGIN {
+        SQ = sprintf("%c", 39)   # single quote
+        DQ = sprintf("%c", 34)   # double quote
+        buf = ""
+    }
+    { buf = buf (NR > 1 ? "\n" : "") $0 }
+    END {
+        s = buf
+        n = length(s)
+        out = ""
+        i = 1
+        atcmd = 1     # at the start of a simple command (command-word position)
+        sink = 0      # inside an echo/printf data-sink command
+        while (i <= n) {
+            c = substr(s, i, 1)
+            # A shell separator resets to command-word position.
+            if (c == ";" || c == "&" || c == "|" || c == "\n") {
+                out = out c; i++; atcmd = 1; sink = 0; continue
+            }
+            # Leading whitespace is copied without leaving command-word position.
+            if (c == " " || c == "\t") { out = out c; i++; continue }
+            # Command-word position: read the first token and classify it.
+            if (atcmd) {
+                atcmd = 0
+                tok = ""
+                j = i
+                while (j <= n) {
+                    cc = substr(s, j, 1)
+                    if (cc == " " || cc == "\t" || cc == ";" || cc == "&" || cc == "|" || cc == "\n") break
+                    tok = tok cc
+                    j++
+                }
+                # A bare sudo/env wrapper: emit it and stay in command-word
+                # position so the NEXT token is classified as the command word.
+                if (tok == "sudo" || tok == "env") {
+                    out = out tok; i = j; atcmd = 1; continue
+                }
+                if (tok == "echo" || tok == "printf") { sink = 1 }
+                out = out tok; i = j; continue
+            }
+            # Mid-command: a quoted span is redacted only inside a data sink.
+            if (c == DQ || c == SQ) {
+                qc = c
+                ci = 0
+                for (j = i + 1; j <= n; j++) {
+                    if (substr(s, j, 1) == qc) { ci = j; break }
+                }
+                if (ci == 0) {
+                    # Unterminated quote: copy the rest verbatim, never redact.
+                    out = out substr(s, i); i = n + 1; continue
+                }
+                inner = substr(s, i + 1, ci - i - 1)
+                if (sink && index(inner, "$(") == 0 && index(inner, "`") == 0) {
+                    gsub(/./, "X", inner)   # . never matches \n: multi-line stays same-length
+                }
+                out = out qc inner qc; i = ci + 1; continue
+            }
+            out = out c; i++
+        }
+        printf "%s", out
+    }'
+}
+
+# Return 0 (success) if ANY quote-aware segment's command word is a shell binary
+# (sh/bash/dash/zsh/ksh/csh/tcsh/fish/pwsh, with or without a leading path).
+# GATES strip_datasink_literals(): when a shell could consume the command's data
+# (e.g. `echo '<payload>' | sh`), the data-sink redaction is skipped so the raw
+# catastrophic scan still sees — and blocks — the payload. Conservative by
+# construction: a shell ANYWHERE in the command disables the (narrowing)
+# redaction, so the worst case is a preserved false BLOCK, never a skipped one.
+# `guard-destructive.sh` (basename is not a bare shell word) is deliberately NOT
+# matched, so the guard's own `echo '<json>' | guard-destructive.sh` self-test
+# still redacts and no longer false-blocks (#53). Emits "yes"/"no".
+command_has_shell_segment() {
+    printf '%s' "$1" | awk "$_QSPLIT_AWK"'
+    { buf = buf (NR > 1 ? "\n" : "") $0 }
+    END {
+        found = 0
+        s = qsplit(buf)   # quote-aware segmentation (#3755); separators -> \n
+        n = split(s, segs, "\n")
+        for (i = 1; i <= n; i++) {
+            seg = segs[i]
+            sub(/^[ \t]+/, "", seg)
+            # Strip any run of leading VAR=val assignments, then a sudo/env wrapper,
+            # so the REAL command word is classified. The required trailing [ \t]+
+            # in the assignment pattern guarantees the loop makes progress.
+            while (match(seg, /^[A-Za-z_][A-Za-z0-9_]*=[^ \t]*[ \t]+/)) { seg = substr(seg, RLENGTH + 1) }
+            sub(/^sudo[ \t]+/, "", seg)
+            sub(/^env[ \t]+/, "", seg)
+            sub(/^[ \t]+/, "", seg)
+            m = split(seg, toks, /[ \t]+/)
+            if (m == 0) continue
+            w = toks[1]
+            sub(/.*\//, "", w)   # basename only
+            if (w == "sh" || w == "bash" || w == "dash" || w == "zsh" || \
+                w == "ksh" || w == "csh" || w == "tcsh" || w == "fish" || w == "pwsh") { found = 1 }
+        }
+        print (found ? "yes" : "no")
+    }'
+}
+
 # Helper: output a deny decision and exit
 #
 # Optional second arg is a short, STABLE rule tag (issue #3771) recorded as the
@@ -1171,6 +1399,18 @@ ALWAYS_BLOCK_PATTERNS=(
     # (root followed by a closing quote) still matches (#3553). The trailing
     # class matches anything that is not a path-continuation character (so `/`,
     # `/ `, `/*`, `/;`, `/'` all count as "root itself" but `/tmp` does not).
+    # NOTE (#72): these three patterns require `rm` to be immediately followed by
+    # whitespace, so a command-word substitution like `$(which rm) -rf /` (where
+    # `rm` is followed by `)`) does NOT match here. That shape is instead caught
+    # by the extract_rm_targets() -> rm-protected-path path below, whose deny
+    # covers root, $HOME, AND every top-level dir — a superset of these three.
+    # For that superset claim to actually hold for the substitution shape, the
+    # extract path must recognize the SAME home/root targets these literal
+    # patterns do: extract_rm_targets() strips a leading `env` (and VAR=val
+    # assignments) as well as `sudo`, and the protected-path loop expands a bare
+    # `~`/`$HOME` target before the check — so `env $(which rm) -rf /`,
+    # `$(which rm) -rf ~`, and `$(which rm) -rf $HOME` all deny just like their
+    # literal counterparts. No parallel regex is needed for the substitution case.
     'rm[[:space:]]+-[a-zA-Z]*[rf][a-zA-Z]*[[:space:]]+/([^[:alnum:]._~/-]|$)'
     'rm[[:space:]]+-[a-zA-Z]*[rf][a-zA-Z]*[[:space:]]+~([^[:alnum:]._~/-]|$)'
     'rm[[:space:]]+-[a-zA-Z]*[rf][a-zA-Z]*[[:space:]]+\$HOME([^[:alnum:]._~/-]|$)'
@@ -1239,6 +1479,19 @@ if [[ "$COMMAND" == *"--body"* || "$COMMAND" == *"--message"* || \
       "$COMMAND" == *"--comment"* || "$COMMAND" == *"-m"* ]]; then
     COMMAND_NO_LITERAL_TEXT=$(strip_literal_text "$COMMAND")
 fi
+# ALSO redact the quoted args of a data-sink command word (echo/printf), so a
+# dangerous string handed to echo/printf as inert DATA no longer trips the raw
+# scan (#53) — the meta false-positive that blocked guard self-tests and filing
+# this issue's heredoc body. Gated on echo/printf being present (off the hot
+# path otherwise) AND on NO shell segment existing: when data is piped into a
+# shell that would execute it (`echo '<payload>' | sh`), the redaction is skipped
+# so the raw scan still blocks the payload. `-c` wrappers (bash -c/sh -c) are
+# never data sinks, and `$(`/backtick spans are never redacted, so smuggling
+# still hard-denies.
+if [[ "$COMMAND" == *"echo"* || "$COMMAND" == *"printf"* ]] && \
+   [[ "$(command_has_shell_segment "$COMMAND")" == "no" ]]; then
+    COMMAND_NO_LITERAL_TEXT=$(strip_datasink_literals "$COMMAND_NO_LITERAL_TEXT")
+fi
 
 for pattern in "${ALWAYS_BLOCK_PATTERNS[@]}"; do
     if echo "$COMMAND_NO_LITERAL_TEXT" | grep -qiE "$pattern"; then
@@ -1286,6 +1539,15 @@ if [[ "$COMMAND_NO_COMMENT" == *"--body"* || "$COMMAND_NO_COMMENT" == *"--messag
       "$COMMAND_NO_COMMENT" == *"--comment"* || "$COMMAND_NO_COMMENT" == *"-m"* ]]; then
     COMMAND_ASK_SCAN=$(strip_literal_text "$COMMAND_NO_COMMENT")
 fi
+# Mirror the catastrophic tier's data-sink redaction (#53): an ask-phrase quoted
+# as inert echo/printf data (e.g. `echo 'run gh issue close 5 to clean up'`)
+# should not false-ask. Same shell-segment gate keeps `echo '<phrase>' | sh`
+# reaching the raw ask scan. Never feeds the catastrophic scan, so it can only
+# NARROW an ask, never miss a hard deny.
+if [[ "$COMMAND_NO_COMMENT" == *"echo"* || "$COMMAND_NO_COMMENT" == *"printf"* ]] && \
+   [[ "$(command_has_shell_segment "$COMMAND_NO_COMMENT")" == "no" ]]; then
+    COMMAND_ASK_SCAN=$(strip_datasink_literals "$COMMAND_ASK_SCAN")
+fi
 
 # =============================================================================
 # SYSTEM-LIFECYCLE + CLOUD-CLI DELETE (segment-parsed, command-word anchored)
@@ -1312,10 +1574,16 @@ fi
 lifecycle_or_cloud_reason() {
     # Emit a deny reason (one per line) for every segment whose command word is a
     # system-lifecycle command or an az/gcloud delete. Portable awk only.
-    printf '%s' "$1" | awk "$_QSPLIT_AWK"'
-    {
-        $0 = qsplit($0)   # quote-aware segmentation (#3755)
-        n = split($0, segs, "\n")
+    printf '%s' "$1" | awk "$_ML_QSPLIT_AWK"'
+    BEGIN { buf = "" }
+    # Slurp the whole (possibly multi-line) command, then segment ONCE with the
+    # shared quote-aware lexer (#71) so a multi-line quoted DATA literal whose
+    # interior line is a lifecycle/cloud word (e.g. `halt`) is no longer mis-read
+    # as a real segment (the pre-#71 per-record `qsplit()` reset quote state at
+    # each embedded newline, hard-denying inert quoted prose).
+    { buf = buf (NR > 1 ? "\n" : "") $0 }
+    END {
+        n = ml_segment(buf, segs)
         for (i = 1; i <= n; i++) {
             seg = segs[i]
             sub(/^[ \t]+/, "", seg)
@@ -1398,8 +1666,10 @@ fi
 #
 # Only *actual local* `rm` command words are inspected. `extract_rm_targets`
 # splits the command on ; | & && || and, for each simple-command segment whose
-# command word is `rm` (optionally sudo-prefixed) AND which carries a
-# recursive/force flag, emits the non-flag argument tokens. Consequences (#3553):
+# command word is `rm` (optionally sudo-prefixed) — OR a command-word
+# *substitution* `$(...)`/backtick in executable position (#72) — AND which
+# carries a recursive/force flag, emits the non-flag argument tokens.
+# Consequences (#3553):
 #   - A token from an earlier command in the same line (e.g. the `host-ip.txt`
 #     in `HOST=$(cat host-ip.txt); ssh $HOST rm -rf …`) is never mis-read as an
 #     rm target — only tokens of a real `rm` segment are considered.
@@ -1416,24 +1686,107 @@ fi
 
 extract_rm_targets() {
     # Emit one rm-target token per line for every local `rm -r/-f` invocation.
-    # Portable awk only (no GNU/BSD-specific escapes); replaces the shell
-    # separators with newlines, then inspects each simple command.
-    printf '%s' "$1" | awk "$_QSPLIT_AWK"'
-    {
-        $0 = qsplit($0)   # quote-aware segmentation (#3755)
-        n = split($0, segs, "\n")
-        for (i = 1; i <= n; i++) {
-            seg = segs[i]
+    # Portable awk only (no GNU/BSD-specific escapes).
+    #
+    # MULTI-LINE QUOTE AWARENESS (#60): slurp the whole (possibly multi-line)
+    # command into ONE buffer, then segment ONCE with a quote-aware walk — instead
+    # of the old per-awk-record `$0 = qsplit($0)`, whose quote-tracking reset at
+    # every input newline because awk's default RS split the command into separate
+    # records. That per-record form false-blocked a multi-line quoted DATA literal
+    # (echo/printf/--body) whose interior line merely BEGINS with `rm -rf /`: the
+    # interior line was scanned as its own top-level segment with no memory that it
+    # is still inside an open quote from a prior line, so its command word resolved
+    # to a real `rm` and its lone `/` token hit the protected-root deny. Mirrors
+    # the buffer-slurp the catastrophic/ask redactors (strip_datasink_literals /
+    # strip_literal_text) and command_has_shell_segment() already use.
+    #
+    # Segmentation is delegated to the shared ml_segment() lexer (#71,
+    # _ML_QSPLIT_AWK) rather than reusing qsplit()+split("\n"), because qsplit()
+    # emits a `\n` for each real separator while ALSO leaving a literal newline
+    # that lived inside an inert quoted span untouched — the two are then
+    # indistinguishable to a downstream `split(s, segs, "\n")`, which is exactly
+    # why the naive slurp-then-qsplit would still re-split the quoted `rm -rf /`
+    # line into its own segment. ml_segment() walks the buffer once so an inert
+    # quoted span's embedded newlines never become segment boundaries. PR #69
+    # introduced this lexer inline here; #71 extracted it into the shared helper
+    # so parse_force_ops()/lifecycle_or_cloud_reason() reuse the SAME algorithm
+    # instead of duplicating it (see the _ML_QSPLIT_AWK header for the full
+    # segmentation contract).
+    printf '%s' "$1" | awk "$_ML_QSPLIT_AWK"'
+    BEGIN { buf = "" }
+    { buf = buf (NR > 1 ? "\n" : "") $0 }
+    END {
+        segc = ml_segment(buf, segs)
+        for (si = 1; si <= segc; si++) {
+            seg = segs[si]
             sub(/^[ \t]+/, "", seg)
-            sub(/^sudo[ \t]+/, "", seg)
+            # Strip a leading run of VAR=val assignments and sudo/env wrappers
+            # (in any order/repetition) so the REAL command word — a literal `rm`
+            # OR a command-word substitution — is what we classify. `env` is
+            # stripped alongside `sudo` (#72): `env $(which rm) -rf /` and
+            # `env rm -rf /` must be seen as an rm command word, not shielded
+            # behind the wrapper. The required trailing [ \t]+ in each sub()
+            # guarantees the while loop makes progress and terminates.
+            while (sub(/^[A-Za-z_][A-Za-z0-9_]*=[^ \t]*[ \t]+/, "", seg) || \
+                   sub(/^sudo[ \t]+/, "", seg) || \
+                   sub(/^env[ \t]+/, "", seg)) { }
             sub(/^[ \t]+/, "", seg)
-            if (seg !~ /^rm([ \t]|$)/) continue
-            m = split(seg, toks, /[ \t]+/)
+            # Determine the argument tail and the token index to start scanning
+            # from. Two command-word shapes emit targets:
+            #   (a) a literal `rm` command word — scan from toks[2] (skip "rm").
+            #   (b) a command-word *substitution* — `$(...)` or a backtick pair —
+            #       in executable position (#72). The substitution result becomes
+            #       the command word at run time, so `$(which rm) -rf /` never
+            #       presents a literal `rm` token yet is exactly as dangerous. We
+            #       deliberately do NOT try to resolve what the substitution names
+            #       (`which rm`, `command -v rm`, an alias, a PATH-relative rm, … —
+            #       unbounded and trivially bypassable); we key on the SHAPE
+            #       (substitution in command-word position + a recursive/force
+            #       flag + a protected-path target) and let the downstream
+            #       protected-path check decide. A benign `$(which ls) -la /tmp`
+            #       carries no recursive/force flag, so it emits no target and
+            #       stays allowed — no blanket deny on command-word substitutions.
+            tail = ""
+            start = 0
+            if (seg ~ /^rm([ \t]|$)/) {
+                tail = seg
+                start = 2
+            } else if (substr(seg, 1, 2) == "$(") {
+                # Balanced-paren skip past the substitution so an internal space
+                # (e.g. `$(command -v rm)`) is NOT mis-split into a bogus
+                # flag/target token. Start depth at 1 for the opening `(`.
+                depth = 1
+                p = 3
+                L = length(seg)
+                while (p <= L && depth > 0) {
+                    ch = substr(seg, p, 1)
+                    if (ch == "(") depth++
+                    else if (ch == ")") depth--
+                    p++
+                }
+                if (depth != 0) continue   # unterminated: emit nothing (conservative)
+                tail = substr(seg, p)
+                sub(/^[ \t]+/, "", tail)
+                start = 1
+            } else if (substr(seg, 1, 1) == "`") {
+                # Backtick command word: skip to the closing backtick.
+                p = 2
+                L = length(seg)
+                while (p <= L && substr(seg, p, 1) != "`") p++
+                if (p > L) continue        # unterminated: emit nothing
+                p++                         # step past the closing backtick
+                tail = substr(seg, p)
+                sub(/^[ \t]+/, "", tail)
+                start = 1
+            } else {
+                continue
+            }
+            m = split(tail, toks, /[ \t]+/)
             has_rf = 0
-            for (j = 2; j <= m; j++)
+            for (j = start; j <= m; j++)
                 if (toks[j] ~ /^-/ && toks[j] ~ /[rRfF]/) has_rf = 1
             if (!has_rf) continue
-            for (j = 2; j <= m; j++) {
+            for (j = start; j <= m; j++) {
                 if (toks[j] == "") continue
                 if (toks[j] ~ /^-/) continue
                 print toks[j]
@@ -1481,8 +1834,14 @@ normalize_abs_path() {
 }
 
 # Cheap pre-check keeps awk off the hot path for the ~99% of commands that have
-# no recursive/force rm at all.
-if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
+# no recursive/force rm at all. The first alternative matches a literal `rm`
+# command word; the second admits a command-word *substitution* (#72) — a
+# closing `)` or backtick immediately followed by a recursive/force flag, as in
+# `$(which rm) -rf /` or `` `which rm` -rf / `` — so extract_rm_targets() is
+# invoked for that shape too. This gate is only an optimization: a false match
+# here is harmless because extract_rm_targets() emits a target only for a real
+# rm-flavored (substitution/rm command word + recursive-force flag) segment.
+if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]|[)`][[:space:]]+-[a-zA-Z]*[rf]'; then
     RM_TARGETS=$(extract_rm_targets "$COMMAND" | head -20)
 
     for target in $RM_TARGETS; do
@@ -1510,6 +1869,31 @@ if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
             *.pyc)
                 continue ;;
         esac
+
+        # Expand a leading `~` or `$HOME` token so home-directory targets are
+        # recognized the same way the literal-rm ALWAYS_BLOCK `$HOME`/`~`
+        # patterns handle them (#72). extract_rm_targets() emits the raw token,
+        # so a substitution-path target of `~` or `$HOME` (as in
+        # `$(which rm) -rf ~`) would otherwise be treated as a CWD-relative path
+        # and never flagged, an asymmetry vs. literal `rm -rf ~`/`rm -rf $HOME`.
+        # Only bare-home and home-subpath forms are expanded — this mirrors the
+        # literal floor exactly: bare `$HOME`/`~` deny (whole-home wipe) while a
+        # home *subpath* expands to a deeper path and stays allowed.
+        if [[ -n "$HOME" ]]; then
+            # The `~` in the case globs below is a LITERAL match against the
+            # emitted target token, not a path we want the shell to expand —
+            # SC2088 (tilde-does-not-expand-in-quotes) is exactly the intended
+            # behaviour here, so it is suppressed.
+            # shellcheck disable=SC2088
+            case "$target" in
+                '~')          target="$HOME" ;;
+                '~/'*)        target="$HOME/${target#\~/}" ;;
+                '$HOME')      target="$HOME" ;;
+                '$HOME/'*)    target="$HOME/${target#\$HOME/}" ;;
+                '${HOME}')    target="$HOME" ;;
+                '${HOME}/'*)  target="$HOME/${target#\$\{HOME\}/}" ;;
+            esac
+        fi
 
         # Resolve path to absolute (raw — normalization happens next).
         ABS_PATH=""

--- a/.claude/skills/repo/hooks/session-start-handoff.sh
+++ b/.claude/skills/repo/hooks/session-start-handoff.sh
@@ -54,9 +54,15 @@
 RECENT_HOURS=48
 STALE_HOURS=168
 
-# Max section headers rendered. The real-world note that motivated this was
-# 7.5 KB - far too much to inject on every launch - but its headers convey the
-# shape in a handful of lines.
+# Payload sizing (issue #33). When the note is small enough (<= MAX_BODY_BYTES)
+# it is cheap to inline verbatim on every launch, and the full body is what
+# carries the actionable content - a headers-only outline conveys shape but
+# nothing to act on. Above that cap we fall back to a headers-only outline
+# (capped at MAX_HEADERS) plus a loud oversize warning, bounding the pathological
+# case. The 10 KB cap comfortably covers the ~9 KB real-world note that motivated
+# the hook, and /repo:handoff's exclusion discipline is designed to keep notes
+# short, so the common case inlines.
+MAX_BODY_BYTES=10240
 MAX_HEADERS=9
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo ".")"
@@ -126,11 +132,6 @@ elif (( AGE_H < RECENT_HOURS ));  then AGE_LABEL="${AGE_H}h old"
 else                                   AGE_LABEL="$(( AGE_H / 24 ))d old"
 fi
 
-# Headers only - never the file body. `|| true` because grep exits 1 when the
-# note has no headers at all (a valid, non-error state) and head closing the
-# pipe early can surface as a non-zero status.
-HEADERS=$(grep -E '^#{1,2} ' "$NOTE" 2>/dev/null | head -n "$MAX_HEADERS" | sed 's/^#* *//' || true)
-
 CONTEXT="A /repo:handoff note is pending in this repository.
 
   Path: $NOTE
@@ -142,11 +143,41 @@ if (( AGE_H >= STALE_HOURS )); then
          every claim in it against the repo before acting on it."
 fi
 
-if [[ -n "$HEADERS" ]]; then
+# Payload policy (issue #33). Under the size cap, inline the full note body -
+# that is where the load-bearing, actionable content lives; a headers-only
+# outline conveys shape but nothing to act on, which was the observed failure.
+# Above the cap, fall back to that outline plus an explicit oversize warning so a
+# pathological note cannot bloat every launch. The read-in-full / one-shot
+# directive below is appended in BOTH branches.
+NOTE_BYTES=$(wc -c < "$NOTE" 2>/dev/null | tr -d '[:space:]') || NOTE_BYTES=""
+[[ "$NOTE_BYTES" =~ ^[0-9]+$ ]] || NOTE_BYTES=0
+
+if (( NOTE_BYTES <= MAX_BODY_BYTES )); then
+    # Full body inline. `|| BODY=""` keeps a read failure on the fail-open path.
+    BODY=$(cat "$NOTE" 2>/dev/null) || BODY=""
     CONTEXT="$CONTEXT
+
+The full note follows between the markers - read it now:
+
+----- BEGIN HANDOFF NOTE -----
+$BODY
+----- END HANDOFF NOTE -----"
+else
+    # Oversize fallback: headers only. `|| true` because grep exits 1 when the
+    # note has no headers at all (a valid, non-error state) and head closing the
+    # pipe early can surface as a non-zero status.
+    HEADERS=$(grep -E '^#{1,2} ' "$NOTE" 2>/dev/null | head -n "$MAX_HEADERS" | sed 's/^#* *//' || true)
+    CONTEXT="$CONTEXT
+  OVERSIZE: this note is ${NOTE_BYTES} bytes, above the ${MAX_BODY_BYTES}-byte
+            inline cap, so only its section headers are shown below. Open the
+            note and read it in full now - the actionable detail is in the body,
+            not these headers."
+    if [[ -n "$HEADERS" ]]; then
+        CONTEXT="$CONTEXT
 
 Sections:
 $(printf '%s\n' "$HEADERS" | sed 's/^/  - /')"
+    fi
 fi
 
 CONTEXT="$CONTEXT

--- a/.claude/skills/repo/install-metadata.json
+++ b/.claude/skills/repo/install-metadata.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.6.1",
-  "commit": "e0ee40b",
+  "version": "0.7.0",
+  "commit": "d0dbd37",
   "dev": false,
-  "commands": ["all","audit","branches","docs","followups","gitignore","handoff","help","links","orphans","readme","release","remote","reset","tidy","update-tools"]
+  "commands": ["all","audit","branches","docs","followups","gitignore","handoff","help","host-optimize","links","orphans","readme","release","remote","reset","sudo","tidy","update-tools"]
 }

--- a/.claude/skills/repo/scripts/repo-remote.sh
+++ b/.claude/skills/repo/scripts/repo-remote.sh
@@ -1,0 +1,747 @@
+#!/usr/bin/env bash
+# repo-remote.sh — headless, scriptable entry point for /repo:remote provisioning.
+#
+# This is the non-interactive implementation of the provisioning contract
+# documented (as prose) in commands/repo/remote.md. The interactive skill wraps
+# this script with its wizard / cost-confirmation UX and, once the human has
+# confirmed, calls `repo-remote up --yes`; a caller such as loom's
+# `fleet add-worker` invokes the same `up --yes --json` path directly. There is
+# ONE implementation of the contract so the two paths cannot drift (repo#52).
+#
+# The seam this produces, consumed by loom fleet orchestration: "a reachable
+# Ubuntu box, this repo's SSH alias written, instance id recorded" — emitted as
+# machine-readable JSON (instance id, public IP, SSH alias, estimated hourly
+# cost) so a caller can implement loom's "plan shown before money is spent" rule.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# STABLE INTERFACE (downstream tooling gates on this via the package version)
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Subcommands (both the `up`/`down`/`status` verbs and the remote.md-style
+# `--status`/`--down` flags are accepted, for parity with the prose command):
+#
+#   repo-remote up [--yes] [--json] [aws|gcp]     Provision (or reuse) an instance.
+#       Without --yes: a DRY-RUN plan (resolved spec + estimated cost) is emitted
+#       and NOTHING is created — this is the "plan shown before money spent" path.
+#       With --yes: the plan is executed. --yes removes the *prompt*, never the
+#       *consent requirement*: a cost-relevant field missing from config is a
+#       loud, non-zero-exit failure, never a silent default (repo#52 cost gate).
+#
+#   repo-remote status|--status [--json] [aws|gcp]   List instances this command
+#       created (tagged repo-remote=<name>) with state; no mutation.
+#
+#   repo-remote down|--down [--yes] [--delete] [--json] [aws|gcp]   Teardown.
+#       Without --yes: a DRY-RUN listing of exactly what would stop/terminate.
+#       With --yes: stop them; add --delete to terminate (disk goes with it).
+#
+# Config: two layers, shared first then repo (repo overrides), matching the
+# skill exactly:
+#   1. ${XDG_CONFIG_HOME:-$HOME/.config}/repo/remote.env   (shared cloud creds)
+#   2. <git-root>/.env                                     (per-repo machine)
+#
+# Cost gate (repo#52 — the highest-cost-of-being-wrong element): `up` (with or
+# without --yes) REQUIRES the provider, that provider's credentials, and
+# REPO_REMOTE_INSTANCE_TYPE to be present in config. Instance type is the
+# cost-relevant field and is NEVER defaulted here — that removes interactivity,
+# not consent. Non-cost-relevant fields (disk, idle window, image) do fall back
+# to built-in defaults, matching the prose command.
+#
+# Exit codes:
+#   0  success (including a dry-run plan)
+#   2  missing / invalid required config (the cost gate; loud failure)
+#   3  provider authentication failed
+#   4  cloud operation failed
+#   64 usage error
+#
+# Testability hooks (honored so the suite can exercise the full contract against
+# mocked cloud CLIs without touching real infrastructure or a real ~/.ssh):
+#   XDG_CONFIG_HOME            locates the shared remote.env (already standard)
+#   REPO_REMOTE_SSH_CONFIG     SSH config file to write the alias into
+#                              (default: ~/.ssh/config)
+#   PATH                       mock `aws`/`gcloud` are picked up from PATH
+#
+set -uo pipefail
+
+# ── output helpers ──────────────────────────────────────────────────────────
+_is_tty() { [[ -t 2 ]]; }
+log()  { printf '%s\n' "repo-remote: $*" >&2; }
+die()  { local code="$1"; shift; printf '%s\n' "repo-remote: ERROR: $*" >&2; exit "$code"; }
+
+JSON_OUT=false   # --json
+YES=false        # --yes
+DELETE=false     # --down --delete
+ACTION=""        # up | down | status
+PROVIDER_ARG=""  # aws | gcp (positional override)
+
+# ── JSON emission (no jq dependency for output; values are controlled) ──────
+# json_escape <string> -> a JSON string body (without surrounding quotes)
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\t'/\\t}"
+  s="${s//$'\r'/}"
+  printf '%s' "$s"
+}
+
+# ── config loading ──────────────────────────────────────────────────────────
+# Load the two env layers into the environment, shared first then repo (repo
+# wins because it is sourced last). Mirrors commands/repo/remote.md step 2.
+SHARED_ENV=""
+REPO_ENV=""
+GIT_ROOT=""
+
+resolve_paths() {
+  SHARED_ENV="${XDG_CONFIG_HOME:-$HOME/.config}/repo/remote.env"
+  GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  [[ -n "$GIT_ROOT" ]] && REPO_ENV="$GIT_ROOT/.env"
+}
+
+load_config() {
+  set -a
+  # shellcheck disable=SC1090
+  [[ -f "$SHARED_ENV" ]] && . "$SHARED_ENV"
+  # shellcheck disable=SC1090
+  [[ -n "$REPO_ENV" && -f "$REPO_ENV" ]] && . "$REPO_ENV"
+  set +a
+}
+
+# ── effective settings ──────────────────────────────────────────────────────
+PROVIDER=""
+NAME=""
+INSTANCE_TYPE=""
+INSTANCE_ID=""
+DISK_GB=""
+IMAGE=""
+GPU_ACCEL=""       # GCP accelerator string, e.g. nvidia-l4:1
+IDLE_MIN=""
+IS_GPU=false
+REGION=""
+COST_HOURLY=""
+COST_APPROX=false
+
+# GPU-family detection: infer a GPU host from the instance family so the caller
+# needn't set a separate flag (remote.md "GPU hosts").
+is_gpu_family() {  # <provider> <instance-type>
+  local p="$1" t="$2"
+  [[ -n "${GPU_ACCEL:-}" ]] && return 0
+  case "$p" in
+    aws) [[ "$t" =~ ^(g3|g4|g4dn|g5|g5g|g6|g6e|p2|p3|p4|p4d|p5)\. ]] && return 0 ;;
+    gcp) [[ "$t" =~ ^(g2|a2|a3)- ]] && return 0 ;;
+  esac
+  return 1
+}
+
+# Approximate on-demand USD/hour by instance type. Unknown types fall back to a
+# GPU/non-GPU heuristic flagged approximate — the JSON always carries a number
+# so a caller can implement a budget check, and never silently claims precision.
+estimate_cost() {  # sets COST_HOURLY, COST_APPROX
+  local t="$1"
+  COST_APPROX=false
+  case "$t" in
+    # AWS general purpose / compute
+    t3.medium)   COST_HOURLY=0.0416 ;;
+    t3.large)    COST_HOURLY=0.0832 ;;
+    t3.xlarge)   COST_HOURLY=0.1664 ;;
+    t3.2xlarge)  COST_HOURLY=0.3328 ;;
+    m5.large)    COST_HOURLY=0.096  ;;
+    m5.xlarge)   COST_HOURLY=0.192  ;;
+    m5.2xlarge)  COST_HOURLY=0.384  ;;
+    m5.4xlarge)  COST_HOURLY=0.768  ;;
+    m6i.xlarge)  COST_HOURLY=0.192  ;;
+    m6i.2xlarge) COST_HOURLY=0.384  ;;
+    c5.xlarge)   COST_HOURLY=0.17   ;;
+    c5.2xlarge)  COST_HOURLY=0.34   ;;
+    c5.4xlarge)  COST_HOURLY=0.68   ;;
+    # AWS GPU
+    g4dn.xlarge) COST_HOURLY=0.526  ;;
+    g5.xlarge)   COST_HOURLY=1.006  ;;
+    g5.2xlarge)  COST_HOURLY=1.212  ;;
+    g6.xlarge)   COST_HOURLY=0.8048 ;;
+    g6e.xlarge)  COST_HOURLY=1.861  ;;
+    g6e.2xlarge) COST_HOURLY=2.242  ;;
+    p4d.24xlarge) COST_HOURLY=32.77 ;;
+    # GCP predefined
+    e2-standard-2)  COST_HOURLY=0.067 ;;
+    e2-standard-4)  COST_HOURLY=0.134 ;;
+    e2-standard-8)  COST_HOURLY=0.268 ;;
+    n1-standard-4)  COST_HOURLY=0.19  ;;
+    n1-standard-8)  COST_HOURLY=0.38  ;;
+    g2-standard-4)  COST_HOURLY=0.71  ;;
+    g2-standard-8)  COST_HOURLY=0.85  ;;
+    a2-highgpu-1g)  COST_HOURLY=3.67  ;;
+    *)
+      COST_APPROX=true
+      if [[ "$IS_GPU" == true ]]; then COST_HOURLY=1.50; else COST_HOURLY=0.20; fi
+      ;;
+  esac
+  # A GCP accelerator adds to the machine price; fold in a rough per-card cost so
+  # the estimate for GPU-on-GCP is not silently the bare-machine price.
+  if [[ -n "${GPU_ACCEL:-}" && "$PROVIDER" == gcp ]]; then
+    COST_APPROX=true
+    COST_HOURLY="$(awk -v c="$COST_HOURLY" 'BEGIN{printf "%.4f", c + 0.70}')"
+  fi
+}
+
+resolve_settings() {
+  PROVIDER="${PROVIDER_ARG:-${REPO_REMOTE_PROVIDER:-}}"
+  # lower-case the provider
+  PROVIDER="$(printf '%s' "$PROVIDER" | tr '[:upper:]' '[:lower:]')"
+
+  NAME="$(basename "${GIT_ROOT:-$PWD}")"
+
+  INSTANCE_TYPE="${REPO_REMOTE_INSTANCE_TYPE:-}"
+  INSTANCE_ID="${REPO_REMOTE_INSTANCE_ID:-}"
+  GPU_ACCEL="${REPO_REMOTE_GPU:-}"
+  IMAGE="${REPO_REMOTE_IMAGE:-}"
+
+  # Non-cost-relevant fields DO fall back to defaults (matches the prose command).
+  DISK_GB="${REPO_REMOTE_DISK_GB:-50}"
+  IDLE_MIN="${REPO_REMOTE_IDLE_SHUTDOWN_MIN:-120}"
+
+  case "$PROVIDER" in
+    aws) REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}" ;;
+    gcp) REGION="${GCP_ZONE:-}" ;;
+  esac
+
+  if [[ -n "$INSTANCE_TYPE" ]] && is_gpu_family "$PROVIDER" "$INSTANCE_TYPE"; then
+    IS_GPU=true
+  fi
+  [[ -n "$INSTANCE_TYPE" ]] && estimate_cost "$INSTANCE_TYPE"
+}
+
+# ── the cost gate ───────────────────────────────────────────────────────────
+# Enforce that every field whose absence could cause an *unexpected* bill is
+# present in config. This is what makes `--yes` safe: it removes the interactive
+# prompt but not the requirement that the human pre-supplied the budget-relevant
+# choices. Missing config fails loudly (exit 2), never a silent default.
+require_cost_config() {
+  local missing=()
+
+  [[ -n "$PROVIDER" ]] || missing+=("REPO_REMOTE_PROVIDER (or an aws|gcp argument)")
+  case "$PROVIDER" in
+    aws)
+      [[ -n "${AWS_ACCESS_KEY_ID:-}" ]]     || missing+=("AWS_ACCESS_KEY_ID")
+      [[ -n "${AWS_SECRET_ACCESS_KEY:-}" ]] || missing+=("AWS_SECRET_ACCESS_KEY")
+      [[ -n "$REGION" ]]                    || missing+=("AWS_REGION")
+      ;;
+    gcp)
+      [[ -n "${GCP_PROJECT:-}" ]]                     || missing+=("GCP_PROJECT")
+      [[ -n "$REGION" ]]                              || missing+=("GCP_ZONE")
+      [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]  || missing+=("GOOGLE_APPLICATION_CREDENTIALS")
+      ;;
+    "") : ;;  # provider itself already reported above
+    *)  die 2 "unknown provider '$PROVIDER' (expected aws or gcp)" ;;
+  esac
+
+  # THE cost-relevant field. Never defaulted — an unpinned instance type is
+  # exactly how an unexpected bill happens.
+  [[ -n "$INSTANCE_TYPE" ]] || missing+=("REPO_REMOTE_INSTANCE_TYPE (required — no default, so a run never silently picks a billable size)")
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    local m
+    log "cannot proceed — required config is missing (no silent defaults for cost-relevant fields):"
+    for m in "${missing[@]}"; do log "  - $m"; done
+    log "set them in ${SHARED_ENV} (shared) or ${REPO_ENV:-<git-root>/.env} (per-repo), or run /repo:remote --configure."
+    exit 2
+  fi
+}
+
+# ── the idle-shutdown guard (cloud-init user-data) ──────────────────────────
+# A forgotten VM — GPU ones especially — must turn itself off. Emitted as a
+# cloud-init script that installs a cron watchdog running `shutdown -h` after
+# IDLE_MIN minutes with no active SSH session and low CPU.
+idle_guard_userdata() {
+  cat <<EOF
+#!/bin/bash
+# repo-remote idle-shutdown guard (idle window: ${IDLE_MIN} min)
+cat >/usr/local/bin/repo-remote-idle-check <<'GUARD'
+#!/bin/bash
+IDLE_MIN=${IDLE_MIN}
+STAMP=/var/run/repo-remote-idle.stamp
+if who | grep -q . || [ "\$(awk '{print (\$1 > 0.2)}' /proc/loadavg)" = "1" ]; then
+  date +%s > "\$STAMP"; exit 0
+fi
+[ -f "\$STAMP" ] || { date +%s > "\$STAMP"; exit 0; }
+NOW=\$(date +%s); LAST=\$(cat "\$STAMP")
+if [ \$(( (NOW - LAST) / 60 )) -ge "\$IDLE_MIN" ]; then
+  /sbin/shutdown -h now "repo-remote: idle for \${IDLE_MIN}m"
+fi
+GUARD
+chmod +x /usr/local/bin/repo-remote-idle-check
+echo "* * * * * root /usr/local/bin/repo-remote-idle-check" >/etc/cron.d/repo-remote-idle
+EOF
+}
+
+# ── AWS provider ────────────────────────────────────────────────────────────
+aws_authenticate() {
+  aws sts get-caller-identity >/dev/null 2>&1 \
+    || die 3 "AWS authentication failed with the resolved credentials (aws sts get-caller-identity). Not falling back to ambient/other credentials."
+}
+
+# Resolve the AMI into RESOLVED_AMI: an explicit override wins; a GPU host
+# defaults to the AWS Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu
+# 22.04); otherwise the latest Ubuntu 22.04 LTS. (remote.md "GPU hosts".)
+# Sets a global (rather than echoing) so a `die` here propagates to the whole
+# process instead of being swallowed by a `$(...)` subshell.
+RESOLVED_AMI=""
+aws_resolve_image() {
+  if [[ -n "$IMAGE" ]]; then RESOLVED_AMI="$IMAGE"; return 0; fi
+  local q name
+  if [[ "$IS_GPU" == true ]]; then
+    name='Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 22.04)*'
+    q="$(aws ec2 describe-images --owners amazon \
+      --filters "Name=name,Values=$name" \
+      --query 'sort_by(Images,&CreationDate)[-1].ImageId' --output text 2>/dev/null)"
+  else
+    name='ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*'
+    q="$(aws ec2 describe-images --owners 099720109477 \
+      --filters "Name=name,Values=$name" \
+      --query 'sort_by(Images,&CreationDate)[-1].ImageId' --output text 2>/dev/null)"
+  fi
+  [[ -n "$q" && "$q" != "None" ]] || die 4 "could not resolve an AMI for ${INSTANCE_TYPE} (GPU=${IS_GPU}). Set REPO_REMOTE_IMAGE to override."
+  RESOLVED_AMI="$q"
+}
+
+# Describe a single instance's state; echoes state name or "missing".
+aws_instance_state() {  # <instance-id>
+  local out
+  out="$(aws ec2 describe-instances --instance-ids "$1" \
+        --query 'Reservations[0].Instances[0].State.Name' --output text 2>/dev/null)" || { echo missing; return; }
+  [[ -n "$out" && "$out" != "None" ]] && echo "$out" || echo missing
+}
+
+# Find a running|stopped instance previously created for this repo (by tag).
+aws_find_tagged() {  # echoes "<id> <state>" or empty
+  aws ec2 describe-instances \
+    --filters "Name=tag:repo-remote,Values=${NAME}" \
+              "Name=instance-state-name,Values=running,stopped,stopping,pending" \
+    --query 'Reservations[].Instances[].[InstanceId,State.Name]' --output text 2>/dev/null \
+    | grep -v '^None' | head -n1
+}
+
+aws_public_ip() {  # <instance-id>
+  aws ec2 describe-instances --instance-ids "$1" \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' --output text 2>/dev/null
+}
+
+# Create a fresh instance into CREATED_ID (global, so a `die` propagates rather
+# than being swallowed by a command-substitution subshell). run-instances is
+# invoked EXACTLY ONCE — capturing stdout and stderr in one call — because a
+# retry-to-read-the-error would risk launching a second billable instance.
+CREATED_ID=""
+aws_create() {
+  local ami sg key udfile errfile iid rc err
+  aws_resolve_image; ami="$RESOLVED_AMI"
+  key="${REPO_REMOTE_SSH_KEY_NAME:-}"
+  sg="${REPO_REMOTE_SECURITY_GROUP:-}"
+
+  udfile="$(mktemp)"; idle_guard_userdata >"$udfile"
+  errfile="$(mktemp)"
+
+  local -a args=(ec2 run-instances
+    --image-id "$ami"
+    --instance-type "$INSTANCE_TYPE"
+    --block-device-mappings "DeviceName=/dev/sda1,Ebs={VolumeSize=${DISK_GB}}"
+    --tag-specifications "ResourceType=instance,Tags=[{Key=repo-remote,Value=${NAME}}]"
+    --user-data "file://${udfile}"
+    --query 'Instances[0].InstanceId' --output text)
+  [[ -n "$key" ]] && args+=(--key-name "$key")
+  [[ -n "$sg" ]]  && args+=(--security-group-ids "$sg")
+
+  iid="$(aws "${args[@]}" 2>"$errfile")"; rc=$?
+  err="$(cat "$errfile" 2>/dev/null)"
+  rm -f "$udfile" "$errfile"
+
+  if [[ $rc -ne 0 || -z "$iid" || "$iid" == "None" ]]; then
+    # Surface the quota-exceeded case with the exact remediation (remote.md).
+    if printf '%s' "$err" | grep -q 'VcpuLimitExceeded'; then
+      die 4 "AWS GPU vCPU quota is 0 by default (VcpuLimitExceeded). Request a limit >= this type's vCPUs at Service Quotas -> EC2 -> quota code L-DB2E81BA, then retry."
+    fi
+    die 4 "aws ec2 run-instances failed: ${err:-unknown error}"
+  fi
+  CREATED_ID="$iid"
+}
+
+aws_up() {
+  aws_authenticate
+  local iid="" state="" reused=false
+
+  if [[ -n "$INSTANCE_ID" ]]; then
+    state="$(aws_instance_state "$INSTANCE_ID")"
+    case "$state" in
+      running)          iid="$INSTANCE_ID"; reused=true ;;
+      stopped|stopping) aws ec2 start-instances --instance-ids "$INSTANCE_ID" >/dev/null 2>&1 \
+                          || die 4 "failed to start stopped instance $INSTANCE_ID"
+                        iid="$INSTANCE_ID"; reused=true ;;
+      missing)          log "pinned REPO_REMOTE_INSTANCE_ID=$INSTANCE_ID no longer exists; creating a fresh instance."
+                        INSTANCE_ID="" ;;
+      *)                iid="$INSTANCE_ID"; reused=true ;;
+    esac
+  fi
+
+  if [[ -z "$iid" ]]; then
+    local found; found="$(aws_find_tagged)"
+    if [[ -n "$found" ]]; then
+      iid="$(printf '%s' "$found" | awk '{print $1}')"
+      state="$(printf '%s' "$found" | awk '{print $2}')"
+      reused=true
+      if [[ "$state" == stopped || "$state" == stopping ]]; then
+        aws ec2 start-instances --instance-ids "$iid" >/dev/null 2>&1 \
+          || die 4 "failed to start reused instance $iid"
+      fi
+    fi
+  fi
+
+  if [[ -z "$iid" ]]; then
+    aws_create           # sets CREATED_ID or dies (main-shell context)
+    iid="$CREATED_ID"
+    reused=false
+  fi
+
+  aws ec2 wait instance-running --instance-ids "$iid" >/dev/null 2>&1 || true
+  local ip; ip="$(aws_public_ip "$iid")"
+  [[ "$ip" == "None" ]] && ip=""
+
+  writeback_instance_id "$iid"
+  local alias; alias="$(write_ssh_alias "$ip")"
+
+  emit_up_result "$iid" "$ip" "$alias" "$reused"
+}
+
+aws_status() {
+  aws_authenticate
+  local rows
+  rows="$(aws ec2 describe-instances \
+    --filters "Name=tag:repo-remote,Values=${NAME}" \
+    --query 'Reservations[].Instances[].[InstanceId,State.Name,InstanceType,PublicIpAddress,LaunchTime]' \
+    --output text 2>/dev/null | grep -v '^None' || true)"
+  emit_status_result "$rows"
+}
+
+aws_down() {
+  aws_authenticate
+  local ids
+  if [[ -n "$INSTANCE_ID" ]]; then
+    ids="$INSTANCE_ID"
+  else
+    ids="$(aws ec2 describe-instances \
+      --filters "Name=tag:repo-remote,Values=${NAME}" \
+                "Name=instance-state-name,Values=running,stopped,stopping,pending" \
+      --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null | grep -v '^None' || true)"
+  fi
+  ids="$(printf '%s' "$ids" | tr '\t' ' ' | xargs 2>/dev/null || true)"
+
+  if [[ -z "$ids" ]]; then
+    emit_down_result "" "noop"
+    return 0
+  fi
+
+  if [[ "$YES" != true ]]; then
+    emit_down_result "$ids" "dry-run"
+    return 0
+  fi
+
+  if [[ "$DELETE" == true ]]; then
+    # shellcheck disable=SC2086
+    aws ec2 terminate-instances --instance-ids $ids >/dev/null 2>&1 \
+      || die 4 "aws ec2 terminate-instances failed for: $ids"
+    emit_down_result "$ids" "terminated"
+  else
+    # shellcheck disable=SC2086
+    aws ec2 stop-instances --instance-ids $ids >/dev/null 2>&1 \
+      || die 4 "aws ec2 stop-instances failed for: $ids"
+    emit_down_result "$ids" "stopped"
+  fi
+}
+
+# ── GCP provider ────────────────────────────────────────────────────────────
+gcp_authenticate() {
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" >/dev/null 2>&1 \
+    || die 3 "GCP authentication failed (gcloud auth activate-service-account)."
+  gcloud config set project "${GCP_PROJECT}" >/dev/null 2>&1 || true
+}
+
+gcp_up() {
+  gcp_authenticate
+  local vm="repo-remote-${NAME}" ip="" reused=false state
+  state="$(gcloud compute instances describe "$vm" --zone "$REGION" \
+    --format='value(status)' 2>/dev/null || true)"
+  if [[ -n "$state" ]]; then
+    reused=true
+    if [[ "$state" != "RUNNING" ]]; then
+      gcloud compute instances start "$vm" --zone "$REGION" >/dev/null 2>&1 \
+        || die 4 "failed to start existing instance $vm"
+    fi
+  else
+    local -a args=(compute instances create "$vm"
+      --zone "$REGION"
+      --machine-type "$INSTANCE_TYPE"
+      --boot-disk-size "${DISK_GB}GB"
+      --labels "repo-remote=${NAME}"
+      --image-family "${IMAGE:-ubuntu-2204-lts}" --image-project "${REPO_REMOTE_IMAGE_PROJECT:-ubuntu-os-cloud}")
+    [[ -n "$GPU_ACCEL" ]] && args+=(--accelerator "type=${GPU_ACCEL%%:*},count=${GPU_ACCEL##*:}" --maintenance-policy TERMINATE)
+    local ud; ud="$(mktemp)"; idle_guard_userdata >"$ud"
+    args+=(--metadata-from-file "startup-script=${ud}")
+    gcloud "${args[@]}" >/dev/null 2>&1 || { rm -f "$ud"; die 4 "gcloud compute instances create failed for $vm"; }
+    rm -f "$ud"
+  fi
+  ip="$(gcloud compute instances describe "$vm" --zone "$REGION" \
+    --format='value(networkInterfaces[0].accessConfigs[0].natIP)' 2>/dev/null || true)"
+
+  writeback_instance_id "$vm"
+  local alias; alias="$(write_ssh_alias "$ip")"
+  emit_up_result "$vm" "$ip" "$alias" "$reused"
+}
+
+gcp_status() {
+  gcp_authenticate
+  local rows
+  rows="$(gcloud compute instances list \
+    --filter="labels.repo-remote=${NAME}" \
+    --format='value(name,status,machineType.basename(),networkInterfaces[0].accessConfigs[0].natIP,creationTimestamp)' 2>/dev/null || true)"
+  emit_status_result "$rows"
+}
+
+gcp_down() {
+  gcp_authenticate
+  local vm="repo-remote-${NAME}"
+  [[ -n "$INSTANCE_ID" ]] && vm="$INSTANCE_ID"
+  local exists
+  exists="$(gcloud compute instances describe "$vm" --zone "$REGION" --format='value(name)' 2>/dev/null || true)"
+  if [[ -z "$exists" ]]; then emit_down_result "" "noop"; return 0; fi
+  if [[ "$YES" != true ]]; then emit_down_result "$vm" "dry-run"; return 0; fi
+  if [[ "$DELETE" == true ]]; then
+    gcloud compute instances delete "$vm" --zone "$REGION" --quiet >/dev/null 2>&1 \
+      || die 4 "gcloud compute instances delete failed for $vm"
+    emit_down_result "$vm" "terminated"
+  else
+    gcloud compute instances stop "$vm" --zone "$REGION" --quiet >/dev/null 2>&1 \
+      || die 4 "gcloud compute instances stop failed for $vm"
+    emit_down_result "$vm" "stopped"
+  fi
+}
+
+# ── write-back + SSH alias ──────────────────────────────────────────────────
+# Write the new instance id back to the repo's .env (git root, never the shared
+# file — the handle is per-repo), updating in place or appending. remote.md §4.
+writeback_instance_id() {  # <instance-id>
+  local id="$1"
+  [[ -n "$REPO_ENV" ]] || return 0
+  if [[ -f "$REPO_ENV" ]] && grep -q '^REPO_REMOTE_INSTANCE_ID=' "$REPO_ENV"; then
+    local tmp; tmp="$(mktemp)"
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      if [[ "$line" == REPO_REMOTE_INSTANCE_ID=* ]]; then
+        printf 'REPO_REMOTE_INSTANCE_ID=%s\n' "$id"
+      else
+        printf '%s\n' "$line"
+      fi
+    done <"$REPO_ENV" >"$tmp"
+    mv "$tmp" "$REPO_ENV"
+  else
+    printf 'REPO_REMOTE_INSTANCE_ID=%s\n' "$id" >>"$REPO_ENV"
+  fi
+}
+
+# Write/refresh the one-word SSH alias so the connection is `ssh repo-remote-<name>`.
+# Honors REPO_REMOTE_SSH_CONFIG (default ~/.ssh/config) so tests never touch a
+# real config. Echoes the alias name.
+write_ssh_alias() {  # <ip>
+  local ip="$1" alias="repo-remote-${NAME}"
+  local cfg="${REPO_REMOTE_SSH_CONFIG:-$HOME/.ssh/config}"
+  local key="${REPO_REMOTE_SSH_KEY:-~/.ssh/id_ed25519}"
+  local user="${REPO_REMOTE_SSH_USER:-ubuntu}"
+  [[ -z "$ip" ]] && { printf '%s' "$alias"; return 0; }
+
+  mkdir -p "$(dirname "$cfg")" 2>/dev/null || true
+  local tmp; tmp="$(mktemp)"
+  # Strip any prior block for this alias, then append a fresh one.
+  if [[ -f "$cfg" ]]; then
+    awk -v a="Host $alias" '
+      $0 == a {skip=1; next}
+      skip && /^Host / {skip=0}
+      skip {next}
+      {print}
+    ' "$cfg" >"$tmp"
+  fi
+  {
+    [[ -s "$tmp" ]] && printf '\n'
+    printf 'Host %s\n' "$alias"
+    printf '    HostName %s\n' "$ip"
+    printf '    User %s\n' "$user"
+    printf '    IdentityFile %s\n' "$key"
+  } >>"$tmp"
+  mv "$tmp" "$cfg"
+  chmod 600 "$cfg" 2>/dev/null || true
+  printf '%s' "$alias"
+}
+
+# ── result emitters ─────────────────────────────────────────────────────────
+emit_plan() {  # dry-run plan (no cloud mutation)
+  if [[ "$JSON_OUT" == true ]]; then
+    printf '{'
+    printf '"action":"plan",'
+    printf '"dry_run":true,'
+    printf '"provider":"%s",' "$(json_escape "$PROVIDER")"
+    printf '"name":"%s",' "$(json_escape "$NAME")"
+    printf '"instance_type":"%s",' "$(json_escape "$INSTANCE_TYPE")"
+    printf '"region":"%s",' "$(json_escape "$REGION")"
+    printf '"disk_gb":%s,' "$DISK_GB"
+    printf '"gpu":%s,' "$IS_GPU"
+    printf '"idle_shutdown_min":%s,' "$IDLE_MIN"
+    printf '"ssh_alias":"repo-remote-%s",' "$(json_escape "$NAME")"
+    printf '"estimated_hourly_cost_usd":%s,' "$COST_HOURLY"
+    printf '"estimated_cost_approximate":%s' "$COST_APPROX"
+    printf '}\n'
+  else
+    log "PLAN (dry run — nothing created; pass --yes to provision):"
+    log "  provider:            $PROVIDER"
+    log "  instance type:       $INSTANCE_TYPE${IS_GPU:+ (GPU)}"
+    log "  region/zone:         $REGION"
+    log "  disk:                ${DISK_GB} GB"
+    log "  idle shutdown:       ${IDLE_MIN} min"
+    log "  est. hourly cost:    \$${COST_HOURLY}/hr$([[ "$COST_APPROX" == true ]] && echo ' (approximate)')"
+    log "  ssh alias:           repo-remote-${NAME}"
+  fi
+}
+
+emit_up_result() {  # <id> <ip> <alias> <reused>
+  local id="$1" ip="$2" alias="$3" reused="$4"
+  if [[ "$JSON_OUT" == true ]]; then
+    printf '{'
+    printf '"action":"up",'
+    printf '"provider":"%s",' "$(json_escape "$PROVIDER")"
+    printf '"name":"%s",' "$(json_escape "$NAME")"
+    printf '"instance_id":"%s",' "$(json_escape "$id")"
+    printf '"public_ip":"%s",' "$(json_escape "$ip")"
+    printf '"ssh_alias":"%s",' "$(json_escape "$alias")"
+    printf '"instance_type":"%s",' "$(json_escape "$INSTANCE_TYPE")"
+    printf '"region":"%s",' "$(json_escape "$REGION")"
+    printf '"gpu":%s,' "$IS_GPU"
+    printf '"idle_shutdown_min":%s,' "$IDLE_MIN"
+    printf '"reused":%s,' "$reused"
+    printf '"estimated_hourly_cost_usd":%s,' "$COST_HOURLY"
+    printf '"estimated_cost_approximate":%s' "$COST_APPROX"
+    printf '}\n'
+  else
+    log "$([[ "$reused" == true ]] && echo reused || echo created) instance $id (${INSTANCE_TYPE}) @ ${ip:-<no public ip>}"
+    log "  ssh alias:        $alias"
+    log "  est. hourly cost: \$${COST_HOURLY}/hr$([[ "$COST_APPROX" == true ]] && echo ' (approximate)')"
+    log "  teardown:         repo-remote down --yes   (or /repo:remote --down)"
+  fi
+}
+
+emit_status_result() {  # <rows: id state type ip launch, tab/space separated per line>
+  local rows="$1"
+  if [[ "$JSON_OUT" == true ]]; then
+    printf '{"action":"status","provider":"%s","name":"%s","instances":[' \
+      "$(json_escape "$PROVIDER")" "$(json_escape "$NAME")"
+    local first=true line id state type ip launch
+    while IFS= read -r line; do
+      [[ -z "$line" ]] && continue
+      id="$(printf '%s' "$line" | awk '{print $1}')"
+      state="$(printf '%s' "$line" | awk '{print $2}')"
+      type="$(printf '%s' "$line" | awk '{print $3}')"
+      ip="$(printf '%s' "$line" | awk '{print $4}')"
+      launch="$(printf '%s' "$line" | awk '{print $5}')"
+      [[ "$ip" == "None" ]] && ip=""
+      [[ "$first" == true ]] && first=false || printf ','
+      printf '{"instance_id":"%s","state":"%s","instance_type":"%s","public_ip":"%s","launch_time":"%s"}' \
+        "$(json_escape "$id")" "$(json_escape "$state")" "$(json_escape "$type")" "$(json_escape "$ip")" "$(json_escape "$launch")"
+    done <<<"$rows"
+    printf ']}\n'
+  else
+    if [[ -z "$rows" ]]; then
+      log "no instances tagged repo-remote=${NAME}"
+    else
+      log "instances tagged repo-remote=${NAME}:"
+      printf '%s\n' "$rows" >&2
+    fi
+  fi
+}
+
+emit_down_result() {  # <ids> <disposition: noop|dry-run|stopped|terminated>
+  local ids="$1" disp="$2"
+  if [[ "$JSON_OUT" == true ]]; then
+    printf '{"action":"down","provider":"%s","name":"%s","disposition":"%s","instances":[' \
+      "$(json_escape "$PROVIDER")" "$(json_escape "$NAME")" "$(json_escape "$disp")"
+    local first=true id
+    for id in $ids; do
+      [[ "$first" == true ]] && first=false || printf ','
+      printf '"%s"' "$(json_escape "$id")"
+    done
+    printf ']}\n'
+  else
+    case "$disp" in
+      noop)     log "no instances tagged repo-remote=${NAME} to stop" ;;
+      dry-run)  log "DRY RUN — would stop$([[ "$DELETE" == true ]] && echo /terminate): $ids (pass --yes to act)" ;;
+      stopped)  log "stopped: $ids" ;;
+      terminated) log "terminated (disks removed): $ids" ;;
+    esac
+  fi
+}
+
+# ── argument parsing ────────────────────────────────────────────────────────
+usage() {
+  sed -n '4,60p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      up|status|down) [[ -z "$ACTION" ]] && ACTION="$1" || die 64 "multiple actions given ($ACTION, $1)" ;;
+      --status)       ACTION="status" ;;
+      --down)         ACTION="down" ;;
+      --yes|-y)       YES=true ;;
+      --json)         JSON_OUT=true ;;
+      --delete)       DELETE=true ;;
+      aws|gcp)        PROVIDER_ARG="$1" ;;
+      -h|--help)      usage; exit 0 ;;
+      *)              die 64 "unknown argument: $1 (see --help)" ;;
+    esac
+    shift
+  done
+  [[ -n "$ACTION" ]] || die 64 "no action given (expected: up | status | down; see --help)"
+}
+
+# ── main ────────────────────────────────────────────────────────────────────
+main() {
+  parse_args "$@"
+  resolve_paths
+  load_config
+  resolve_settings
+
+  case "$ACTION" in
+    up)
+      require_cost_config
+      if [[ "$YES" != true ]]; then
+        emit_plan          # dry-run: the plan (with cost) is shown, nothing spent
+        exit 0
+      fi
+      case "$PROVIDER" in
+        aws) aws_up ;;
+        gcp) gcp_up ;;
+        *)   die 2 "unknown provider '$PROVIDER'" ;;
+      esac
+      ;;
+    status)
+      [[ -n "$PROVIDER" ]] || die 2 "REPO_REMOTE_PROVIDER (or an aws|gcp argument) is required for status"
+      case "$PROVIDER" in
+        aws) aws_status ;;
+        gcp) gcp_status ;;
+        *)   die 2 "unknown provider '$PROVIDER'" ;;
+      esac
+      ;;
+    down)
+      [[ -n "$PROVIDER" ]] || die 2 "REPO_REMOTE_PROVIDER (or an aws|gcp argument) is required for down"
+      case "$PROVIDER" in
+        aws) aws_down ;;
+        gcp) gcp_down ;;
+        *)   die 2 "unknown provider '$PROVIDER'" ;;
+      esac
+      ;;
+  esac
+}
+
+main "$@"

--- a/.loom/context/topics/release.md
+++ b/.loom/context/topics/release.md
@@ -1,23 +1,18 @@
 # VibeSQL Release Conventions
 
-Project-specific context injected by `methodology-inject.sh` whenever `/loom:release` is invoked. This **augments** `.claude/commands/loom/release.md` (the loom-default v0.10.4 skill); read both.
+Project-specific context injected by `methodology-inject.sh` whenever `/repo:release` (or release-cut phrasing) comes up. This **augments** `.claude/commands/repo/release.md` (Repo Skills `/repo:release`, Phases 0-7); read both.
 
-Procedural overrides target the named extension points the default skill exposes (see its "Operator extension points" section for the authoritative list of seams).
+This file carries only **advisory** reminders. The **procedural** half — steps that must run at a named phase boundary (CHANGELOG house style, irreversibility gate, publish-workflow polling, GitHub-Release gating, website follow-ups) — lives in `.repo/release-policy.md`, which `/repo:release` loads and validates at Phase 0 via its `## seam: <name>` sections.
 
 ## Advisory reminders (any phase)
 
 ### Pre-flight: four version-bearing files
 
-VibeSQL has four version-bearing file groups: `Cargo.toml` (workspace.package + member-crate internal `vibesql-*` pins), `pyproject.toml` (root), `crates/vibesql-python-bindings/pyproject.toml`, and `Cargo.lock`. `scripts/version.sh check` (invoked automatically by the default Phase 5 verify step) covers all of them. Drift surfaces as a non-zero exit and a `DRIFT: …` line per offending file — stop and resolve before bumping.
+VibeSQL has four version-bearing file groups: `Cargo.toml` (workspace.package + member-crate internal `vibesql-*` pins), `pyproject.toml` (root), `crates/vibesql-python-bindings/pyproject.toml`, and `Cargo.lock`. `scripts/version.sh check` (invoked by `/repo:release`'s Phase 2 drift gate) covers all of them. Drift surfaces as a non-zero exit and a `DRIFT: …` line per offending file — stop and resolve before bumping.
 
-### Pre-flight: CI gating policy
+CI gating policy (which workflows are release-blocking) is procedural and lives in `.repo/release-policy.md` under `## seam: pre-flight`.
 
-Not every workflow is release-blocking:
-
-- **Blocking** when failing on main: `ci-main.yml`, `ci-extended.yml` → fix first.
-- **NOT blocking** (note them, but ask the operator before letting them stop a release): `fuzz.yml`, `miri.yml`. Long runs and intermittent reds are normal.
-
-### Phase 2: commit-volume expectation
+### Phase 3: commit-volume expectation
 
 VibeSQL cycles are commit-heavy — the `[0.1.4]` entry triaged **878 commits**. Warn the operator upfront if `git log <last-tag>..HEAD --oneline | wc -l` exceeds 100. Group by scope for the CHANGELOG spine:
 
@@ -39,80 +34,15 @@ VibeSQL is **pre-1.0**, so MAJOR/MINOR semantics are looser. Treat `0.X.0` as "m
 
 **PATCH bump**: Bug fixes; performance improvements with no semantic change; internal refactors; docs/CLAUDE.md/README updates; dependency bumps; test additions; web demo updates.
 
-### Phase 5: scripts/version.sh implements the v0.10.4 contract
+### Phase 5: scripts/version.sh drives the bump
 
-`scripts/version.sh` exposes `show` / `list` / `check` / `bump <level> [--tag]` / `set <X.Y.Z> [--tag]` per the contract documented in the default skill's "scripts/version.sh interface" section. `bump`/`set` touch all four version-bearing files atomically (workspace.package + member-crate `vibesql-*` pins + both pyprojects + `cargo update -w` to refresh `Cargo.lock`), so Phase 5's auto-dispatch (`./scripts/version.sh bump <level> --tag`) drives the entire bump without operator intervention.
+`/repo:release` Phase 2 detects `scripts/version.sh` as the version tool (executable, first match wins), and Phase 5 dispatches `./scripts/version.sh bump <level> --tag`. The script exposes `show` / `list` / `check` / `bump <level> [--tag]` / `set <X.Y.Z> [--tag]`. `bump`/`set` touch all four version-bearing files atomically (workspace.package + member-crate `vibesql-*` pins + both pyprojects + `cargo update -w` to refresh `Cargo.lock`), so Phase 5's auto-dispatch drives the entire bump without operator intervention.
 
 **DO NOT bump** `crates/vibesql-sqllogictest/Cargo.toml` (pinned to upstream sqllogictest's `0.28.x`) or `web-demo/package.json` (independent version line). The bump script intentionally leaves them alone. If the operator wants either changed, that's a separate decision.
-
-## Procedural overrides at named seams
-
-### At extension point `pre-changelog-style`
-
-VibeSQL does NOT use Keep-a-Changelog's "Added/Changed/Fixed/Removed" grouping. Override Phase 4's default style with VibeSQL's themed-section convention:
-
-- `## [X.Y.Z] - YYYY-MM-DD` header with today's date.
-- **Theme paragraph** immediately after the header — 1-3 sentences naming the release theme and headline numbers ("N commits since X.Y.(Z-1)", pass-rate milestones, etc.).
-- **Top-level sections by THEME**, not by Added/Changed/Fixed: `### Performance`, `### SQL Compatibility`, `### MVCC`, `### Storage`, `### Parser`, `### Optimizer`, `### Bug Fixes`, `### Infrastructure`, `### Documentation`.
-- **Sub-sections** for major initiatives: `#### Phase N: <Name>`.
-- Reference issues/PRs with `(#NNNN)` format. Feature name in bold, then short description.
-- For a release with 100+ commits, expect a 100+-line entry. That's normal — read `head -200 CHANGELOG.md` to anchor on style (see `[0.1.4]`).
-
-### At extension point `pre-push`
-
-Before pushing the tag, prompt the operator literally with the irreversibility warning:
-
-> Pushing tag `v<X.Y.Z>` will trigger automatic publishes to **crates.io** (workspace crates) and **PyPI** (`vibesql` Python package). Both publishes are **irreversible** — crates.io and PyPI do not allow re-publishing the same version. Push? (y/N)
-
-Do NOT proceed without an explicit "yes".
-
-If branch protection on `main` blocks the direct push:
-1. Push the bump commit to a feature branch: `git push origin HEAD:chore/release-v<X.Y.Z>`
-2. Open a PR, get it merged.
-3. After merge, check out the new `main` HEAD and re-tag if the commit SHA changed (`git tag -d v<X.Y.Z>` then `git tag -a v<X.Y.Z>`).
-4. Push the tag from main: `git push origin v<X.Y.Z>`.
-
-### At extension point `post-push`
-
-After pushing the tag, TWO release workflows fire from `push: tags: ['v*']`:
-- `.github/workflows/release-crates.yml` → publishes workspace crates to crates.io
-- `.github/workflows/release-pypi.yml` → builds wheels (Linux/macOS/Windows) and publishes `vibesql` to PyPI
-
-Poll BOTH workflows for completion before continuing to `pre-github-release`:
-
-```bash
-gh run list --workflow release-crates.yml --limit 1 --json status,conclusion
-gh run list --workflow release-pypi.yml --limit 1 --json status,conclusion
-```
-
-Optional: `gh run watch <run-id>` for live progress. Time out after 30 minutes and ask the operator. If either workflow fails, stop and triage — do NOT proceed to GitHub Release creation on top of a partial publish.
-
-### At extension point `pre-github-release`
-
-Do NOT run `gh release create` until both workflows from `post-push` report `success`. Compose the release notes from the just-promoted CHANGELOG block:
-
-```bash
-NEW_VERSION=<X.Y.Z>
-notes=$(awk '/^## \['"$NEW_VERSION"'\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md)
-
-gh release create "v$NEW_VERSION" \
-  --title "v$NEW_VERSION" \
-  --notes "$notes"
-```
-
-The `release-crates.yml` workflow does NOT create the GitHub Release on its own (it only verifies the tag matches `Cargo.toml`'s version and publishes). The GitHub Release is the canonical human-facing announcement and is created here. No build artifacts are attached — both registry mirrors are the binary distribution.
-
-### At extension point `post-summary`
-
-Append these VibeSQL-specific follow-ups to the operator hand-off:
-
-- `make website` + commit the updated web-demo data so the live demo reflects the new release.
-- `wrangler deploy` from main to push the website (Cloudflare).
-- Open any tracking issue for follow-up cleanup found during CHANGELOG drafting.
 
 ## Important Notes (VibeSQL-specific)
 
 - **Four version-bearing files, propagation pattern**: only `[workspace.package]` in `Cargo.toml` carries the canonical Rust version; every member crate inherits via `version.workspace = true`. The exception is `crates/vibesql-sqllogictest/Cargo.toml`, which pins to upstream sqllogictest's `0.28.x` — do not touch it.
-- **`Cargo.lock` IS a version-bearing file, but it is gitignored**: every `vibesql-*` workspace crate has an entry in `Cargo.lock`, so `cargo update -w` is required after bumping `Cargo.toml` — it is not a no-op. However, `Cargo.lock` is gitignored in this repo (regenerated locally), so `commit_and_tag` does NOT stage or commit it; only the four tracked sources (`Cargo.toml`, member `vibesql-*` pins, both pyprojects) are committed atomically.
-- **Web demo and dashboard data are separate**: `make website` + `wrangler deploy` are NOT part of the release tag flow — they run after to refresh the public dashboard.
-- **Do not auto-publish to extra registries.** This skill only triggers what the existing workflows do. If the operator later adds a Homebrew formula, npm package, etc., that's a separate manual step.
+- **`Cargo.lock` IS a version-bearing file, and it IS tracked**: every `vibesql-*` workspace crate has an entry in `Cargo.lock`, so `cargo update -w` is required after bumping `Cargo.toml` — it is not a no-op. `Cargo.lock` is committed in this repo (this workspace ships binaries — see `.gitignore`), and `scripts/version.sh` stages and commits it atomically with the other version sources (`Cargo.toml`, member `vibesql-*` pins, both pyprojects) on the release commit.
+- **Web demo and dashboard data are separate**: `make website` + `wrangler deploy` are NOT part of the release tag flow — they run after to refresh the public dashboard (see `## seam: post-summary` in `.repo/release-policy.md`).
+- **Do not auto-publish to extra registries.** The release flow only triggers what the existing workflows do. If the operator later adds a Homebrew formula, npm package, etc., that's a separate manual step.

--- a/.repo/release-policy.md
+++ b/.repo/release-policy.md
@@ -1,0 +1,105 @@
+# Release policy — VibeSQL
+
+Procedural release steps bound to `/repo:release` seams. This file is loaded and
+validated by `/repo:release` **Phase 0** (see `.claude/commands/repo/release.md`,
+"Extension points — per-project release policy"). Every section below **augments**
+the corresponding phase's default action — nothing here replaces a built-in step.
+
+Advisory release context (version-bearing files, semver categories,
+`scripts/version.sh` notes) lives in `.loom/context/topics/release.md`, which is
+injected as conversation context; this file is only for steps that must *run* at
+a named phase boundary.
+
+## seam: pre-flight
+
+CI gating policy — not every workflow is release-blocking:
+
+- **Blocking** when failing on main: `ci-main.yml`, `ci-extended.yml` → fix first.
+- **NOT blocking** (note them, but ask the operator before letting them stop a
+  release): `fuzz.yml`, `miri.yml`. Long runs and intermittent reds are normal.
+
+## seam: pre-changelog-style
+
+VibeSQL does NOT use Keep-a-Changelog's "Added/Changed/Fixed/Removed" grouping.
+Draft the CHANGELOG entry in VibeSQL's themed-section convention instead:
+
+- `## [X.Y.Z] - YYYY-MM-DD` header with today's date.
+- **Theme paragraph** immediately after the header — 1-3 sentences naming the
+  release theme and headline numbers ("N commits since X.Y.(Z-1)", pass-rate
+  milestones, etc.).
+- **Top-level sections by THEME**, not by Added/Changed/Fixed: `### Performance`,
+  `### SQL Compatibility`, `### MVCC`, `### Storage`, `### Parser`,
+  `### Optimizer`, `### Bug Fixes`, `### Infrastructure`, `### Documentation`.
+- **Sub-sections** for major initiatives: `#### Phase N: <Name>`.
+- Reference issues/PRs with `(#NNNN)` format. Feature name in bold, then short
+  description.
+- For a release with 100+ commits, expect a 100+-line entry. That's normal —
+  read `head -200 CHANGELOG.md` to anchor on style (see `[0.1.4]`).
+
+## seam: pre-push
+
+Before pushing the tag, prompt the operator literally with the irreversibility
+warning:
+
+> Pushing tag `v<X.Y.Z>` will trigger automatic publishes to **crates.io**
+> (workspace crates) and **PyPI** (`vibesql` Python package). Both publishes are
+> **irreversible** — crates.io and PyPI do not allow re-publishing the same
+> version. Push? (y/N)
+
+Do NOT proceed without an explicit "yes".
+
+If branch protection on `main` blocks the direct push:
+
+1. Push the bump commit to a feature branch: `git push origin HEAD:chore/release-v<X.Y.Z>`
+2. Open a PR, get it merged.
+3. After merge, check out the new `main` HEAD and re-tag if the commit SHA
+   changed (`git tag -d v<X.Y.Z>` then `git tag -a v<X.Y.Z>`).
+4. Push the tag from main: `git push origin v<X.Y.Z>`.
+
+## seam: post-push
+
+After pushing the tag, TWO release workflows fire from `push: tags: ['v*']`:
+
+- `.github/workflows/release-crates.yml` → publishes workspace crates to crates.io
+- `.github/workflows/release-pypi.yml` → builds wheels (Linux/macOS/Windows) and
+  publishes `vibesql` to PyPI
+
+Poll BOTH workflows for completion before continuing to `pre-github-release`:
+
+```bash
+gh run list --workflow release-crates.yml --limit 1 --json status,conclusion
+gh run list --workflow release-pypi.yml --limit 1 --json status,conclusion
+```
+
+Optional: `gh run watch <run-id>` for live progress. Time out after 30 minutes
+and ask the operator. If either workflow fails, stop and triage — do NOT proceed
+to GitHub Release creation on top of a partial publish.
+
+## seam: pre-github-release
+
+Do NOT run `gh release create` until both workflows from `post-push` report
+`success`. Compose the release notes from the just-promoted CHANGELOG block:
+
+```bash
+NEW_VERSION=<X.Y.Z>
+notes=$(awk '/^## \['"$NEW_VERSION"'\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md)
+
+gh release create "v$NEW_VERSION" \
+  --title "v$NEW_VERSION" \
+  --notes "$notes"
+```
+
+The `release-crates.yml` workflow does NOT create the GitHub Release on its own
+(it only verifies the tag matches `Cargo.toml`'s version and publishes). The
+GitHub Release is the canonical human-facing announcement and is created here.
+No build artifacts are attached — both registry mirrors are the binary
+distribution.
+
+## seam: post-summary
+
+Append these VibeSQL-specific follow-ups to the operator hand-off:
+
+- `make website` + commit the updated web-demo data so the live demo reflects
+  the new release.
+- `wrangler deploy` from main to push the website (Cloudflare).
+- Open any tracking issue for follow-up cleanup found during CHANGELOG drafting.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,7 +261,7 @@ make analyze-tests        # SQLLogicTest conformance
 make analyze-benchmarks   # TPC-H, TPC-DS, TPC-C, Sysbench results
 
 <!-- BEGIN REPO-SKILLS -->
-This repository has [Repo Skills](https://github.com/rjwalters/repo) v0.6.1 installed —
+This repository has [Repo Skills](https://github.com/rjwalters/repo) v0.7.0 installed —
 general repository hygiene and environment commands invoked as `/repo:<command>`. Run
 `/repo:help` for the command list, or see `.claude/skills/repo/SKILL.md` for the full
 guide. Hygiene commands apply safe, reversible fixes by default and report each


### PR DESCRIPTION
Closes #6327

## Summary

PR #6321 migrated the release command from the removed `/loom:release` to Repo Skills `/repo:release`, but VibeSQL's project-specific release policy in `.loom/context/topics/release.md` still targeted the five extension-point seams of the removed skill — so the procedural half (publish-workflow gating, website follow-ups, etc.) silently bound to nothing.

Repo Skills v0.7.0 shipped the upstream seam mechanism (rjwalters/repo#43 → #68): `/repo:release` Phase 0 loads `.repo/release-policy.md`, validates every `## seam: <name>` header, and warns loudly on any seam that binds to no phase boundary. All five old `/loom:release` seam names carry over unchanged, so this is the re-target the issue author anticipated.

## Changes

- **Commit 1 (installer-managed, mechanical)**: upgrade Repo Skills v0.6.1 → v0.7.0 via the upstream `install.sh` at tag v0.7.0. `release.md` gains Phase 0 + the Extension points section; `SKILL.md`, hooks, the `CLAUDE.md` marker block, and metadata refresh; two new v0.7.0 commands (`host-optimize`, `sudo`) install.
- **New `.repo/release-policy.md`**: the five procedural overrides moved verbatim-modulo-formatting under `## seam:` headers — `pre-changelog-style` (themed CHANGELOG convention), `pre-push` (irreversibility prompt + branch-protection fallback), `post-push` (poll both publish workflows), `pre-github-release` (two-workflow gate before `gh release create`), `post-summary` (`make website` + `wrangler deploy`). The CI gating policy (blocking vs non-blocking workflows) moves under the new `pre-flight` seam.
- **`.loom/context/topics/release.md` slimmed to advisory-only**: header now describes augmenting `/repo:release` and points at the policy file; commit-volume expectation re-numbered from "Phase 2" to `/repo:release` Phase 3; `version.sh` section drops the "v0.10.4 contract" / "default skill's scripts/version.sh interface" references; stale "Cargo.lock is gitignored" bullet corrected (`Cargo.lock` IS tracked and committed with the release since PR #6321 / c94eba635).
- `.loom/context/topics/release.pattern` unchanged (already matches `/repo:release`; verified injection still fires).

## Verification

- **Phase 0 seam validation**: ran the exact validation block from the upgraded `release.md` against the new policy file — all six seams report `bound: <name> (augment)`, zero warnings.
- **Negative check**: temporarily appended `## seam: bogus-name` — the block emits `WARNING: unknown seam 'bogus-name' — it matches no phase boundary and will NOT run.`; removed afterward (verified file restored).
- **Injection still fires**: piped a `/repo:release` prompt through `.loom/hooks/methodology-inject.sh` — `[Topic: release]` context injected. (The bundled `test-methodology-inject.sh` requires the Loom source-repo layout (`defaults/hooks/`) and cannot run here.)
- **No stale references**: `grep -rn "loom:release\|v0.10.4\|extension point" .loom/context/topics/release.md` → empty.
- **Content preservation**: grepped all five overrides' key phrases (themed sections, irreversibility warning, both workflow names, `gh release create` gate, `make website` + `wrangler deploy`, 30-minute timeout) in the policy file — all present.
- **Upgrade sanity**: `release.md` contains Phase 0; `CLAUDE.md` marker block reads v0.7.0; `.claude/skills/repo/.install-local.json` is machine-local and confirmed gitignored (not committed).

## Test plan

- [x] Phase 0 validation: every declared seam bound, zero unknown-seam warnings
- [x] Negative bogus-seam check emits the WARNING
- [x] `methodology-inject.sh` still injects the release topic for `/repo:release`
- [x] No stale `/loom:release` / v0.10.4 / extension-point references in the topics file
- [x] All five procedural overrides preserved in `.repo/release-policy.md`
- [x] Automated tests: N/A (docs/config only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)