### PR TITLE
test(scripts): guard pytest suite against stale/missing vibesql bindings

### DIFF
--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -27,6 +27,10 @@ on:
         description: 'Run SQLite TCL tests'
         type: boolean
         default: true
+      python_scripts:
+        description: 'Run scripts/ Python test suite (builds Python bindings)'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -248,11 +252,65 @@ jobs:
           fi
 
   # ============================================================================
+  # Python scripts test suite (scripts/test_*.py against the repo's own build)
+  # Builds the Python bindings wheel from this checkout, installs it, and runs
+  # pytest with VIBESQL_REQUIRE_BINDINGS=1 so the bindings tests must PASS —
+  # a skip (missing bindings) or a stale-wheel version mismatch fails the job.
+  # See issue #6323 and scripts/conftest.py.
+  # ============================================================================
+  python-scripts:
+    if: ${{ github.event.inputs.run_all == 'true' || github.event.inputs.python_scripts == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/free-disk-space
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache-key-suffix: ci-extended
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build and install Python bindings from this checkout
+        run: |
+          python3 -m pip install --upgrade pip maturin pytest
+          maturin build --release -m crates/vibesql-python-bindings/Cargo.toml
+          python3 -m pip install --force-reinstall "$(ls -t target/wheels/vibesql-*.whl | head -1)"
+
+      - name: Run scripts/ test suite (bindings required, skips forbidden)
+        env:
+          VIBESQL_REQUIRE_BINDINGS: "1"
+        run: |
+          python3 -m pytest -v -rs 2>&1 | tee pytest_scripts_output.txt
+
+      - name: Display Python scripts test results
+        if: always()
+        run: |
+          echo "## Python Scripts Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "scripts/test_*.py run against the bindings built from this checkout" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f pytest_scripts_output.txt ]; then
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            tail -20 pytest_scripts_output.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi
+
+  # ============================================================================
   # Summary job - reports overall status
   # ============================================================================
   summary:
     runs-on: ubuntu-latest
-    needs: [tpcds-validation, sqllogictest, pgsql-regress, tcl-tests]
+    needs: [tpcds-validation, sqllogictest, pgsql-regress, tcl-tests, python-scripts]
     if: always()
     steps:
       - name: Report summary
@@ -265,3 +323,4 @@ jobs:
           echo "| SQLLogicTest | ${{ needs.sqllogictest.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| PostgreSQL Regression | ${{ needs.pgsql-regress.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| SQLite TCL Tests | ${{ needs.tcl-tests.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Python Scripts | ${{ needs.python-scripts.result }} |" >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # VibeSQL Makefile
 # Convenience targets for common development tasks
 
-.PHONY: all all-bg logs status build build-all build-wasm build-python test test-unit test-workspace test-sqllogictest test-sqllogictest-halting test-tcl test-tcl-all test-tcl-file test-tcl-status test-cluster fuzz fuzz-parser fuzz-expr fuzz-type-convert fuzz-query fuzz-type-coercion fuzz-differential fuzz-list benchmark benchmark-quick benchmark-smoke benchmark-all benchmark-all-bg benchmark-logs benchmark-status benchmark-embedded-all benchmark-server-all benchmark-tpch benchmark-tpch-quick benchmark-tpch-profile benchmark-tpch-server benchmark-tpcc benchmark-tpcc-server benchmark-tpcds benchmark-sysbench benchmark-hnsw benchmark-sysbench-server benchmark-vibesql benchmark-sqlite benchmark-duckdb benchmark-cli benchmark-cli-prep benchmark-cli-quick fmt fmt-check clean help analyze-tests analyze-benchmarks analyze profile-tpch profile-tpcc profile-sysbench profile-select profile-query bench-storage bench-executor bench-types website mysql-start mysql-stop mysql-status strip-quarantine
+.PHONY: all all-bg logs status build build-all build-wasm build-python test test-unit test-workspace test-sqllogictest test-sqllogictest-halting test-tcl test-tcl-all test-tcl-file test-tcl-status test-cluster test-scripts fuzz fuzz-parser fuzz-expr fuzz-type-convert fuzz-query fuzz-type-coercion fuzz-differential fuzz-list benchmark benchmark-quick benchmark-smoke benchmark-all benchmark-all-bg benchmark-logs benchmark-status benchmark-embedded-all benchmark-server-all benchmark-tpch benchmark-tpch-quick benchmark-tpch-profile benchmark-tpch-server benchmark-tpcc benchmark-tpcc-server benchmark-tpcds benchmark-sysbench benchmark-hnsw benchmark-sysbench-server benchmark-vibesql benchmark-sqlite benchmark-duckdb benchmark-cli benchmark-cli-prep benchmark-cli-quick fmt fmt-check clean help analyze-tests analyze-benchmarks analyze profile-tpch profile-tpcc profile-sysbench profile-select profile-query bench-storage bench-executor bench-types website mysql-start mysql-stop mysql-status strip-quarantine
 
 # Default target: show help
 .DEFAULT_GOAL := help
@@ -110,6 +110,7 @@ help:
 	@echo "  make test-tcl-file FILE=X - Run specific TCL test file"
 	@echo "  make test-tcl-status    - Show TCL test status"
 	@echo "  make test-cluster       - Run 3-node TCP consensus cluster smoke tests"
+	@echo "  make test-scripts       - Build Python bindings, install them, run scripts/ pytest suite"
 	@echo ""
 	@echo "Fuzzing targets:"
 	@echo "  make fuzz               - Run all fuzz targets (5 min each)"
@@ -325,6 +326,18 @@ test-tcl-status:
 # partitioned followers). Exits nonzero on any failure.
 test-cluster:
 	cargo test --release -p vibesql-consensus --test tcp_cluster --test leader_reads --test follower_reads -- --nocapture
+
+# Run the scripts/ Python test suite against THIS checkout's bindings (#6323).
+# Builds the wheel via build-python, installs it into the active Python
+# environment, then runs pytest with VIBESQL_REQUIRE_BINDINGS=1 so missing
+# bindings FAIL instead of silently skipping. Installs into whatever `python3`
+# resolves to — activate a virtualenv first if your system Python is
+# externally managed (PEP 668). See scripts/README.md.
+test-scripts: build-python
+	@echo "Installing freshly built wheel into the active Python environment..."
+	python3 -m pip install --force-reinstall --quiet "$$(ls -t target/wheels/vibesql-*.whl | head -1)"
+	@echo "Running scripts/ test suite..."
+	VIBESQL_REQUIRE_BINDINGS=1 python3 -m pytest
 
 #
 # Fuzzing Targets

--- a/crates/vibesql-python-bindings/python/vibesql/__init__.py
+++ b/crates/vibesql-python-bindings/python/vibesql/__init__.py
@@ -30,7 +30,21 @@ apilevel = "2.0"
 threadsafety = 1
 paramstyle = "qmark"
 
-__version__ = "0.1.0"
+# Derive __version__ from the installed distribution metadata (populated by
+# maturin from pyproject.toml, which scripts/version.sh keeps in sync with the
+# workspace version). A hardcoded string here drifts silently across releases
+# and defeats staleness checks (issue #6323).
+try:
+    from importlib.metadata import PackageNotFoundError, version as _dist_version
+
+    try:
+        __version__ = _dist_version("vibesql")
+    except PackageNotFoundError:
+        # Imported from a source tree rather than an installed distribution.
+        __version__ = "0.0.0+unknown"
+    del _dist_version, PackageNotFoundError
+except ImportError:  # pragma: no cover - importlib.metadata requires Python 3.8+
+    __version__ = "0.0.0+unknown"
 __all__ = [
     # Module attributes
     "apilevel",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,70 @@
+# scripts/
+
+Helper scripts for testing, benchmarking, and result processing. This README
+covers only the **Python test suite** (`test_*.py`); the individual scripts are
+documented in their own headers.
+
+## The `test_*.py` suite
+
+Pytest collects these files (configured in the root `pyproject.toml` under
+`[tool.pytest.ini_options]`, added in #6321):
+
+| File | Covers | Needs `vibesql` bindings? |
+|------|--------|---------------------------|
+| `test_generate_punchlist.py` | Storing SQLLogicTest results in VibeSQL, SQL dump export/import | **Yes** |
+| `test_process_test_results.py` | Test-result processing helpers | No |
+| `test_tcl_parser.py` | Static TCL test-file parser | No |
+| `test_tcl_triage.py` | TCL failure triage helpers | No |
+
+> **Naming caveat:** `test_results_config.py` matches the `test_*.py` glob but
+> is a shared **config module** imported by other scripts, not a test file. It
+> is explicitly excluded from collection in `pyproject.toml` — keep it that way.
+
+> **Known bug:** two `test_generate_punchlist.py` tests are marked
+> `@unittest.expectedFailure` pending #6359 (the bindings' statement cache
+> replays the first execution's parameters for repeated parameterized SQL).
+> They will report *unexpected success* once #6359 is fixed — remove the
+> decorators then.
+
+### Running the suite
+
+The recommended entry point builds the Python bindings **from this checkout**,
+installs the wheel, and then runs pytest:
+
+```bash
+make test-scripts
+```
+
+Notes:
+
+- The wheel is installed into whatever `python3` resolves to. If your system
+  Python is externally managed (PEP 668, e.g. Homebrew), activate a
+  virtualenv first.
+- Alternative for an activated virtualenv:
+  `maturin develop --release -m crates/vibesql-python-bindings/Cargo.toml`,
+  then `pytest`.
+
+A plain `pytest` from the repo root also works, but only exercises the
+bindings-dependent tests if a **current** `vibesql` wheel is installed.
+
+### The bindings guard (`conftest.py`)
+
+`import vibesql` resolves to whatever wheel is installed — historically this
+silently tested a weeks-stale wheel, producing failures that looked like severe
+engine bugs (spurious `UNIQUE constraint failed`; issue #6323). `conftest.py`
+guards against both failure modes:
+
+- **Stale wheel** (installed bindings version — `vibesql.__version__` when
+  defined, else the distribution metadata — != workspace version in the root
+  `Cargo.toml`): the whole pytest session **aborts immediately**, naming the
+  stale module path and the rebuild command.
+- **No wheel installed**: the bindings-dependent tests **skip** with a message
+  naming the fix. Set `VIBESQL_REQUIRE_BINDINGS=1` (done automatically by
+  `make test-scripts` and CI) to turn that skip into a hard failure, so a green
+  run proves the bindings were actually exercised.
+
+The version check is a cheap tripwire, not proof of freshness — only rebuilding
+(`make test-scripts`) guarantees the repo build is under test.
+
+CI runs this suite in the `python-scripts` job of
+`.github/workflows/ci-extended.yml` with `VIBESQL_REQUIRE_BINDINGS=1`.

--- a/scripts/conftest.py
+++ b/scripts/conftest.py
@@ -1,0 +1,142 @@
+"""Pytest configuration for the scripts/ test suite.
+
+Guards the suite against testing the wrong `vibesql` Python bindings.
+
+`import vibesql` resolves to whatever wheel happens to be installed in the
+active Python environment — which may be weeks older than this checkout. A
+stale wheel produces failures that masquerade as severe engine bugs (e.g. a
+spurious "UNIQUE constraint failed" on plainly distinct primary keys, see
+issue #6323). This conftest makes both failure modes loud and actionable:
+
+1. **Stale wheel installed** — the whole pytest session aborts immediately,
+   naming the stale module path and the rebuild command. The misleading
+   engine-bug presentation is unreachable.
+2. **No wheel installed** — the bindings-dependent tests skip with a message
+   naming the fix. Set ``VIBESQL_REQUIRE_BINDINGS=1`` (done by
+   ``make test-scripts`` and CI) to turn that skip into a hard failure so a
+   green run proves the bindings were actually exercised.
+
+The freshness check compares the installed bindings' version — the module's
+``__version__`` when it defines one, else the ``vibesql`` distribution
+metadata (current maturin-built wheels ship a generated ``__init__`` stub
+with no ``__version__`` attribute) — against the workspace version in the
+root ``Cargo.toml``. This is a cheap tripwire, not proof of freshness — a
+wheel built from the same version but older code still passes it. Only
+rebuilding (``make test-scripts``) guarantees the repo build is under test.
+"""
+
+import os
+import re
+import sys
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _dist_version
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+REBUILD_HINT = (
+    "Rebuild and install this checkout's own bindings with:\n"
+    "  make test-scripts   # builds the wheel, installs it, then runs pytest\n"
+    "or manually:\n"
+    "  make build-python && python3 -m pip install --force-reinstall target/wheels/vibesql-*.whl\n"
+    "or, inside an activated virtualenv:\n"
+    "  maturin develop --release -m crates/vibesql-python-bindings/Cargo.toml"
+)
+
+
+class MissingBindingsError(Exception):
+    """`import vibesql` failed: no bindings installed in this environment."""
+
+
+class StaleBindingsError(Exception):
+    """The installed `vibesql` bindings do not match this checkout's version."""
+
+
+def workspace_version() -> str:
+    """Parse the workspace version from the root Cargo.toml.
+
+    ``[workspace.package] version`` in the root manifest is the repo's
+    version source of truth (see scripts/version.sh). Anchored on ^...$ so
+    dependency ``version = "..."`` lines never match.
+    """
+    cargo_toml = REPO_ROOT / "Cargo.toml"
+    match = re.search(
+        r'^version = "(\d+\.\d+\.\d+)"$', cargo_toml.read_text(), re.MULTILINE
+    )
+    if not match:
+        raise RuntimeError(f"could not parse workspace version from {cargo_toml}")
+    return match.group(1)
+
+
+def bindings_required() -> bool:
+    """True when skips-on-missing-bindings are forbidden (CI / make test-scripts)."""
+    return os.environ.get("VIBESQL_REQUIRE_BINDINGS", "") not in ("", "0")
+
+
+def installed_bindings_version(vibesql_module):
+    """Best-available version of the installed bindings, or None if unknowable.
+
+    Prefers the module's own ``__version__`` (catches wheels whose packaged
+    ``__init__.py`` carries a hardcoded stale string). Current maturin-built
+    wheels ship a generated ``__init__`` stub WITHOUT ``__version__``, so we
+    fall back to the ``vibesql`` distribution metadata, which maturin always
+    writes from pyproject.toml at build time.
+    """
+    module_version = getattr(vibesql_module, "__version__", None)
+    if module_version is not None:
+        return module_version
+    try:
+        return _dist_version("vibesql")
+    except PackageNotFoundError:
+        return None
+
+
+def load_vibesql():
+    """Import `vibesql`, verifying it matches this checkout's version.
+
+    Returns the imported module.
+
+    Raises:
+        MissingBindingsError: no bindings installed in this environment.
+        StaleBindingsError: installed bindings report a different version
+            than the workspace (or no version at all) — testing them would
+            produce misleading engine-bug failures, so callers must FAIL,
+            never skip.
+    """
+    try:
+        import vibesql
+    except ImportError as exc:
+        raise MissingBindingsError(
+            "vibesql Python bindings are not installed in this Python "
+            f"environment ({sys.executable}).\n{REBUILD_HINT}"
+        ) from exc
+
+    expected = workspace_version()
+    actual = installed_bindings_version(vibesql)
+    if actual != expected:
+        raise StaleBindingsError(
+            "Installed vibesql bindings are STALE: import resolved to "
+            f"{getattr(vibesql, '__file__', '<unknown>')} reporting version "
+            f"{actual!r}, but this checkout's workspace version is {expected!r}. "
+            "Testing a stale wheel produces misleading engine-bug failures "
+            "(e.g. spurious 'UNIQUE constraint failed' — issue #6323).\n"
+            f"{REBUILD_HINT}"
+        )
+    return vibesql
+
+
+def pytest_sessionstart(session):
+    """Abort the whole run immediately if a stale wheel is installed.
+
+    Absence is NOT an error here: bindings-independent tests should still run,
+    and the per-test guard (`load_vibesql` in the tests' setUp) skips — or
+    fails, under VIBESQL_REQUIRE_BINDINGS=1 — the tests that need bindings.
+    """
+    try:
+        load_vibesql()
+    except MissingBindingsError:
+        pass
+    except StaleBindingsError as exc:
+        pytest.exit(str(exc), returncode=1)

--- a/scripts/test_generate_punchlist.py
+++ b/scripts/test_generate_punchlist.py
@@ -11,6 +11,10 @@ import tempfile
 import os
 from pathlib import Path
 
+# Shared bindings guard (scripts/conftest.py). scripts/ is on sys.path both
+# under pytest (rootdir insertion) and when this file is run directly.
+from conftest import MissingBindingsError, bindings_required, load_vibesql
+
 
 class TestVibesqlPunchlist(unittest.TestCase):
     """Test VibeSQL integration for punchlist generation."""
@@ -18,10 +22,18 @@ class TestVibesqlPunchlist(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         try:
-            import vibesql
-            self.vibesql = vibesql
-        except ImportError:
-            self.skipTest("vibesql Python bindings not available")
+            # Verifies the installed bindings match this checkout's version.
+            # A STALE wheel raises StaleBindingsError, which intentionally
+            # propagates as a test FAILURE (never a skip) — testing a stale
+            # wheel yields misleading engine-bug failures (issue #6323).
+            self.vibesql = load_vibesql()
+        except MissingBindingsError:
+            if bindings_required():
+                raise  # VIBESQL_REQUIRE_BINDINGS=1: absence is a failure
+            self.skipTest(
+                "vibesql Python bindings not installed in this environment "
+                "(build them with `make test-scripts` or `make build-python`)"
+            )
 
         # Create temporary directory for test files
         self.test_dir = tempfile.mkdtemp()
@@ -42,9 +54,16 @@ class TestVibesqlPunchlist(unittest.TestCase):
         with open(self.schema_file, 'r') as f:
             schema_sql = f.read()
 
-        # Execute each CREATE TABLE statement
+        # Execute each CREATE TABLE statement. The schema file prefixes every
+        # statement with `--` comment banners, so comment-only lines must be
+        # stripped before the CREATE TABLE prefix check or every statement is
+        # silently filtered out.
         for statement in schema_sql.split(';'):
-            statement = statement.strip()
+            lines = [
+                line for line in statement.splitlines()
+                if not line.strip().startswith('--')
+            ]
+            statement = '\n'.join(lines).strip()
             if statement and statement.upper().startswith('CREATE TABLE'):
                 cursor.execute(statement)
 
@@ -60,6 +79,12 @@ class TestVibesqlPunchlist(unittest.TestCase):
 
         db.close()
 
+    # KNOWN BUG (#6359): the bindings' statement cache replays the FIRST
+    # execution's parameter values for repeated identical parameterized SQL,
+    # so the second insert spuriously fails with "UNIQUE constraint failed".
+    # When #6359 is fixed this test will report an UNEXPECTED SUCCESS —
+    # remove the decorator then.
+    @unittest.expectedFailure
     def test_insert_test_results(self):
         """Test inserting test file records."""
         db = self.vibesql.connect()
@@ -101,8 +126,14 @@ class TestVibesqlPunchlist(unittest.TestCase):
 
         db.close()
 
-    def test_export_sql_dump(self):
-        """Test exporting database as SQL dump."""
+    def test_save_database(self):
+        """Test persisting a database to disk with Database.save().
+
+        The bindings' former SQL-dump export (`save_sql_dump`) no longer
+        exists; `save(path)` writes a binary snapshot (preserves sequences
+        and column defaults). This test covers the export half of the
+        punchlist persistence round-trip.
+        """
         db = self.vibesql.connect()
         cursor = db.cursor()
 
@@ -121,27 +152,19 @@ class TestVibesqlPunchlist(unittest.TestCase):
             VALUES ('test.sql', 'index', 'PASS')
         """)
 
-        # Export SQL dump
-        dump_file = os.path.join(self.test_dir, 'test_dump.sql')
-        db.save_sql_dump(dump_file)
+        # Save binary snapshot
+        db_file = os.path.join(self.test_dir, 'test_db.vbsql')
+        db.save(db_file)
 
-        # Verify file exists
-        self.assertTrue(os.path.exists(dump_file))
-
-        # Verify file contains expected content
-        with open(dump_file, 'r') as f:
-            content = f.read()
-
-        self.assertIn('CREATE TABLE', content)
-        self.assertIn('INSERT INTO', content)
-        self.assertIn('test.sql', content)
-        self.assertIn('PASS', content)
+        # Verify file exists and is non-empty
+        self.assertTrue(os.path.exists(db_file))
+        self.assertGreater(os.path.getsize(db_file), 0)
 
         db.close()
 
-    def test_load_existing_dump(self):
-        """Test loading database from SQL dump."""
-        # Create and export database
+    def test_load_existing_database(self):
+        """Test loading a previously saved database with Database.load()."""
+        # Create and save database
         db1 = self.vibesql.connect()
         cursor1 = db1.cursor()
 
@@ -158,23 +181,13 @@ class TestVibesqlPunchlist(unittest.TestCase):
             INSERT INTO test_files (file_path, status) VALUES ('test2.sql', 'FAIL')
         """)
 
-        dump_file = os.path.join(self.test_dir, 'test_dump.sql')
-        db1.save_sql_dump(dump_file)
+        db_file = os.path.join(self.test_dir, 'test_db.vbsql')
+        db1.save(db_file)
         db1.close()
 
-        # Load into new database
-        db2 = self.vibesql.connect()
+        # Load into new database instance
+        db2 = self.vibesql.Database.load(db_file)
         cursor2 = db2.cursor()
-
-        with open(dump_file, 'r') as f:
-            for statement in f.read().split(';'):
-                statement = statement.strip()
-                if statement and not statement.startswith('--'):
-                    try:
-                        cursor2.execute(statement)
-                    except Exception as e:
-                        # Skip errors (e.g., empty statements, comments)
-                        pass
 
         # Verify data loaded
         cursor2.execute("SELECT COUNT(*) FROM test_files")
@@ -189,6 +202,11 @@ class TestVibesqlPunchlist(unittest.TestCase):
 
         db2.close()
 
+    # KNOWN BUG (#6359): repeated identical parameterized INSERTs replay the
+    # first execution's values (statement-cache bug), so this fails with a
+    # spurious "UNIQUE constraint failed". Remove the decorator when #6359 is
+    # fixed (this test will report an UNEXPECTED SUCCESS then).
+    @unittest.expectedFailure
     def test_summary_queries_match_old_format(self):
         """Test that SQL queries produce same stats as old JSON format."""
         db = self.vibesql.connect()


### PR DESCRIPTION
## Summary

`scripts/test_*.py` imported whatever `vibesql` wheel happened to be installed: a stale wheel produced failures masquerading as severe engine bugs (spurious `UNIQUE constraint failed`), and no wheel at all made the 5 bindings tests silently skip so a green run proved nothing. This PR ties the suite to the repo's own build with a loud, actionable guard, adds a `make test-scripts` target and a CI job, fixes the hardcoded `__version__` drift, and documents the suite in `scripts/README.md`.

Making the suite exercise the repo's real build immediately surfaced two pre-existing problems, filed as follow-ups rather than fixed here (scope discipline):
- **#6359** — real bindings bug: the statement cache replays the first execution's parameter values for repeated identical parameterized SQL. The two affected tests are marked `@unittest.expectedFailure` referencing #6359 (they will report *unexpected success* when it is fixed, forcing decorator removal).
- **#6360** — packaging gaps: `python/vibesql/__init__.py` is never shipped (maturin generates a stub), so wheels expose no package-level `__version__`; `Database.version()` hardcodes `"vibesql-py 0.1.0"`. Because of this, the conftest staleness check prefers `vibesql.__version__` when present but falls back to `importlib.metadata.version("vibesql")`, which is always written by maturin.

## Changes

- **`scripts/conftest.py` (new)**: session-level guard. Stale wheel (installed version != workspace version from root `Cargo.toml`) aborts the entire pytest session (exit 1) naming `vibesql.__file__`, both versions, and the rebuild commands — the misleading engine-bug presentation is unreachable. Missing bindings: bindings tests skip with the fix named, or hard-fail when `VIBESQL_REQUIRE_BINDINGS=1`.
- **`scripts/test_generate_punchlist.py`**: `setUp` routes through the shared guard (silent bare skip removed); modernized to the current bindings API — binary `save`/`Database.load` replace the removed `save_sql_dump`, and the schema test strips `--` comment lines so the CREATE TABLE statements are no longer all silently filtered out; 2 parameterized tests xfailed pending #6359.
- **`Makefile`**: `test-scripts` target — `build-python`, install the freshest wheel into the active environment, `VIBESQL_REQUIRE_BINDINGS=1 pytest`. Added to `.PHONY` and help text.
- **`.github/workflows/ci-extended.yml`**: new `python-scripts` job (own dispatch input, wired into the summary table) that builds/installs the bindings from the checkout and runs the suite with skips forbidden.
- **`crates/vibesql-python-bindings/python/vibesql/__init__.py`**: `__version__` derived from distribution metadata instead of the drifted hardcoded `"0.1.0"`.
- **`scripts/README.md` (new)**: minimal how-to-run doc — coverage table, `make test-scripts`, guard behavior, PEP 668 note, `test_results_config.py` naming caveat, known-bug note.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Python-side tests exercise the current build, not an arbitrary wheel | ✅ | `make test-scripts` builds + force-installs this checkout's wheel before pytest; conftest aborts on version mismatch. Verified end-to-end locally (see Test Plan) |
| Stale/absent wheel fails or skips with a message naming cause and fix, never a bare `UNIQUE constraint failed` | ✅ | Stale: session aborts (exit 1) with module path, versions, rebuild commands. Absent: 5 skips with rebuild hint, or 5 failures under `VIBESQL_REQUIRE_BINDINGS=1` |
| `scripts/test_*.py` collected by CI | ✅ | New `python-scripts` job in `ci-extended.yml` runs pytest with `VIBESQL_REQUIRE_BINDINGS=1` (skip-on-absent becomes fail) |
| Documented in `scripts/README.md` | ✅ | New file; covers running, prerequisites, guard semantics, naming caveat |
| `__version__` drift fixed | ✅ | Hardcode replaced with metadata derivation. Note: current wheels never ship this file at all (maturin stub) — filed as #6360; the guard therefore also checks distribution metadata, which reports `0.2.0` on a fresh build (verified) |
| Fresh build: all 5 `TestVibesqlPunchlist` tests execute (no skips) | ⚠️ Partial | All 5 execute; 3 pass, 2 are `expectedFailure` due to the **real** pre-existing bindings bug #6359 that this infrastructure surfaced. `make test-scripts` → `51 passed, 2 xfailed`, exit 0 |
| `pytest` still excludes `scripts/test_results_config.py` | ✅ | `pytest --collect-only -q` → 53 tests, config module absent |

## Test Plan

All run from the worktree with a Python 3.14 venv:

- Fresh build: `make test-scripts` (wheel built from this checkout, force-installed) → `51 passed, 2 xfailed`, exit 0; `importlib.metadata` reports `0.2.0` matching the workspace
- No wheel: `pytest -q` → `48 passed, 5 skipped`, each skip names the rebuild command
- No wheel + `VIBESQL_REQUIRE_BINDINGS=1`: `5 failed, 48 passed` (absence can no longer masquerade as green)
- Stale wheel (dummy `vibesql` with `__version__ = "0.1.0"` on `PYTHONPATH`): session aborts immediately, exit 1, message names the stale path, both versions, and the fix
- Direct execution `python3 scripts/test_generate_punchlist.py`: still works under plain unittest (skips without bindings; `OK (expected failures=2)` with fresh wheel)
- `python3 -m py_compile` on changed Python files; workflow YAML validated with `yaml.safe_load`; `make -n test-scripts` verified

Closes #6323