### PR TITLE
fix(tcl): quote-aware variable substitution; unset TCL vars bind NULL

### DIFF
--- a/scripts/test_tcl_shim_substitution.tcl
+++ b/scripts/test_tcl_shim_substitution.tcl
@@ -1,0 +1,234 @@
+#!/usr/bin/env tclsh
+#-----------------------------------------------------------------------------
+# Unit tests for substitute_tcl_vars in scripts/tester_vibesql.tcl (#6307)
+#
+# Verifies SQLite-tclsqlite-compatible parameter substitution semantics:
+#   - Unset TCL variables bind SQL NULL (not left as literal text), and later
+#     references in the same statement are still substituted — for all four
+#     reference forms ($::var, $arr(elem), $var/${var}, :var).
+#   - The scan is quote-aware: $word / :word inside single-quoted literals,
+#     double-quoted identifiers, [bracketed] identifiers, and SQL comments
+#     pass through verbatim (even when a TCL variable of that name IS set).
+#   - Substituted text is never rescanned (no double substitution).
+#
+# Run with: tclsh scripts/test_tcl_shim_substitution.tcl
+# (Requires Tcl 8.5/8.6 — same as the shim itself. On macOS: /usr/bin/tclsh)
+#-----------------------------------------------------------------------------
+
+set _shim_dir [file dirname [file normalize [info script]]]
+source [file join $_shim_dir tester_vibesql.tcl]
+
+set ::_subst_pass 0
+set ::_subst_fail 0
+
+proc check {name actual expected} {
+    if {$actual eq $expected} {
+        incr ::_subst_pass
+        puts "ok - $name"
+    } else {
+        incr ::_subst_fail
+        puts "FAIL - $name"
+        puts "    expected: $expected"
+        puts "    actual:   $actual"
+    }
+}
+
+#-----------------------------------------------------------------------------
+# 1. Unset-var -> NULL, order-independent, later vars still substituted
+#    (the core #6307 defect, exercised from a proc scope like real tests)
+#-----------------------------------------------------------------------------
+proc test_unset_binds_null {} {
+    set set_var 42
+    unset -nocomplain missing_6307
+    check "unset-first: later var still substituted" \
+        [substitute_tcl_vars {INSERT INTO t VALUES($missing_6307, $set_var)}] \
+        {INSERT INTO t VALUES(NULL, 42)}
+    check "unset-last: still binds NULL" \
+        [substitute_tcl_vars {INSERT INTO t VALUES($set_var, $missing_6307)}] \
+        {INSERT INTO t VALUES(42, NULL)}
+    check "unset-only reference binds NULL" \
+        [substitute_tcl_vars {SELECT * FROM t WHERE a IS $missing_6307}] \
+        {SELECT * FROM t WHERE a IS NULL}
+}
+test_unset_binds_null
+
+#-----------------------------------------------------------------------------
+# 2. :var named placeholders — same NULL/continue semantics
+#-----------------------------------------------------------------------------
+proc test_colon_form {} {
+    set x 7
+    unset -nocomplain missing_6307
+    check ":var unset -> NULL, later :var still substituted" \
+        [substitute_tcl_vars {SELECT * FROM t WHERE a IS :missing_6307 AND b = :x}] \
+        {SELECT * FROM t WHERE a IS NULL AND b = 7}
+}
+test_colon_form
+
+#-----------------------------------------------------------------------------
+# 3. $::var global references
+#-----------------------------------------------------------------------------
+set ::gset_6307 11
+unset -nocomplain ::gmissing_6307
+proc test_global_form {} {
+    check "\$::var unset -> NULL, later \$::var still substituted" \
+        [substitute_tcl_vars {SELECT $::gmissing_6307, $::gset_6307}] \
+        {SELECT NULL, 11}
+}
+test_global_form
+
+#-----------------------------------------------------------------------------
+# 4. $arr(elem) array-element references
+#-----------------------------------------------------------------------------
+proc test_array_form {} {
+    array set a6307 {seq 3 name pk}
+    check "\$arr(elem) unset element -> NULL, later elements still substituted" \
+        [substitute_tcl_vars {INSERT INTO out VALUES($a6307(nope), $a6307(seq), $a6307(name))}] \
+        {INSERT INTO out VALUES(NULL, 3, 'pk')}
+}
+test_array_form
+
+#-----------------------------------------------------------------------------
+# 5. ${var} braced form
+#-----------------------------------------------------------------------------
+proc test_braced_form {} {
+    set braced_6307 5
+    unset -nocomplain bmissing_6307
+    check "\${var} set and unset" \
+        [substitute_tcl_vars {SELECT ${bmissing_6307}, ${braced_6307}}] \
+        {SELECT NULL, 5}
+}
+test_braced_form
+
+#-----------------------------------------------------------------------------
+# 6. Quote-awareness: single-quoted literals are never touched — even when a
+#    TCL variable of the embedded name IS set (correctness must come from
+#    literal-skipping, not from the old break-on-unset accident).
+#-----------------------------------------------------------------------------
+proc test_quote_awareness {} {
+    set memory "SHOULD_NOT_APPEAR"
+    set x 7
+    set dollar "SHOULD_NOT_APPEAR"
+    check "ATTACH ':memory:' unchanged (var 'memory' set)" \
+        [substitute_tcl_vars {ATTACH ':memory:' AS aux}] \
+        {ATTACH ':memory:' AS aux}
+    check "colon token inside literal unchanged" \
+        [substitute_tcl_vars {SELECT 'a:b'}] \
+        {SELECT 'a:b'}
+    check "\$ token inside literal unchanged (var set)" \
+        [substitute_tcl_vars {SELECT 'price $x'}] \
+        {SELECT 'price $x'}
+    check "\$ token inside literal unchanged (var 'dollar' set)" \
+        [substitute_tcl_vars {SELECT 'has $dollar'}] \
+        {SELECT 'has $dollar'}
+    check "'' escape stays inside the literal span" \
+        [substitute_tcl_vars {SELECT 'it''s $x here', $x}] \
+        {SELECT 'it''s $x here', 7}
+    check "substitution still happens around literals" \
+        [substitute_tcl_vars {SELECT 'a:b', $x, ':not_a_param', :x}] \
+        {SELECT 'a:b', 7, ':not_a_param', 7}
+}
+test_quote_awareness
+
+#-----------------------------------------------------------------------------
+# 7. Other token spans real SQLite's tokenizer would never bind inside
+#-----------------------------------------------------------------------------
+proc test_other_spans {} {
+    set x 7
+    check "double-quoted identifier unchanged" \
+        [substitute_tcl_vars {SELECT "a$x" FROM t}] \
+        {SELECT "a$x" FROM t}
+    check "bracketed identifier unchanged" \
+        [substitute_tcl_vars {SELECT [a$x] FROM t}] \
+        {SELECT [a$x] FROM t}
+    check "line comment unchanged, next line still substituted" \
+        [substitute_tcl_vars "SELECT 1 -- uses \$x\n, \$x"] \
+        "SELECT 1 -- uses \$x\n, 7"
+    check "block comment unchanged" \
+        [substitute_tcl_vars {SELECT /* $x */ $x}] \
+        {SELECT /* $x */ 7}
+}
+test_other_spans
+
+#-----------------------------------------------------------------------------
+# 8. Non-references: digit-leading $5, 12:34, lone $ / ::
+#-----------------------------------------------------------------------------
+proc test_non_references {} {
+    check "digit-leading \$5 untouched" \
+        [substitute_tcl_vars {SELECT a $5 FROM t}] \
+        {SELECT a $5 FROM t}
+    check "12:34 untouched (digit after colon)" \
+        [substitute_tcl_vars {SELECT 12:34}] \
+        {SELECT 12:34}
+    check "trailing lone \$ untouched" \
+        [substitute_tcl_vars {SELECT a FROM t WHERE b = 1 $}] \
+        {SELECT a FROM t WHERE b = 1 $}
+}
+test_non_references
+
+#-----------------------------------------------------------------------------
+# 9. No double substitution: a substituted value whose CONTENTS contain $word
+#    or :word text must not be rescanned.
+#-----------------------------------------------------------------------------
+proc test_no_double_substitution {} {
+    set inner 99
+    set holds_dollar {$inner}
+    set holds_colon {:inner}
+    check "value containing \$word not re-substituted" \
+        [substitute_tcl_vars {SELECT $holds_dollar}] \
+        {SELECT '$inner'}
+    check "value containing :word not re-substituted" \
+        [substitute_tcl_vars {SELECT $holds_colon}] \
+        {SELECT ':inner'}
+}
+test_no_double_substitution
+
+#-----------------------------------------------------------------------------
+# 10. Value formatting + scope resolution sanity (pre-existing behavior kept)
+#-----------------------------------------------------------------------------
+set ::scope_6307 global_val
+proc test_formatting_and_scope {} {
+    set s "it's"
+    set e ""
+    set n NULL
+    set f 1.5
+    check "string value quoted with '' escaping" \
+        [substitute_tcl_vars {INSERT INTO t VALUES($s)}] \
+        {INSERT INTO t VALUES('it''s')}
+    check "empty string value -> ''" \
+        [substitute_tcl_vars {INSERT INTO t VALUES($e)}] \
+        {INSERT INTO t VALUES('')}
+    check "NULL keyword value stays unquoted" \
+        [substitute_tcl_vars {INSERT INTO t VALUES($n)}] \
+        {INSERT INTO t VALUES(NULL)}
+    check "float passes through" \
+        [substitute_tcl_vars {INSERT INTO t VALUES($f)}] \
+        {INSERT INTO t VALUES(1.5)}
+    # Innermost scope shadows the global of the same name
+    set scope_6307 local_val
+    check "innermost scope wins over global" \
+        [substitute_tcl_vars {SELECT $scope_6307}] \
+        {SELECT 'local_val'}
+}
+test_formatting_and_scope
+
+# Nested procs: variable defined two frames up is still found (stack walk)
+proc outer_6307 {} {
+    set from_outer 8
+    inner_6307
+}
+proc inner_6307 {} {
+    check "variable from an outer (non-immediate) frame is found" \
+        [substitute_tcl_vars {SELECT $from_outer}] \
+        {SELECT 8}
+}
+outer_6307
+
+#-----------------------------------------------------------------------------
+# Summary
+#-----------------------------------------------------------------------------
+puts ""
+puts "substitution tests: $::_subst_pass passed, $::_subst_fail failed"
+if {$::_subst_fail > 0} {
+    exit 1
+}
+exit 0

--- a/scripts/tester_vibesql.tcl
+++ b/scripts/tester_vibesql.tcl
@@ -1252,20 +1252,54 @@ proc forget_temp_dependents_on {name_key} {
 # Core SQL execution
 #-----------------------------------------------------------------------------
 
+# Resolve a TCL variable (scalar name or "arr(elem)" element) for SQL
+# substitution, searching the user call stack from INNERMOST scope outward and
+# falling back to the global scope. `caller_abs` is the ABSOLUTE stack level of
+# substitute_tcl_vars's caller (so this helper's own extra stack frame does not
+# shift the search). Returns a two-element list: {found value}.
+#
+# The innermost-to-outermost order matches how TCL normally resolves variables.
+# This ensures loop variables like $i in "for {set i 1} {$i<10} {incr i}" are
+# found in the loop's scope, not a stale global value from a previous loop.
+proc resolve_subst_var {varname caller_abs} {
+    # Absolute level caller_abs is the immediate caller of substitute_tcl_vars;
+    # walk inward-to-outward down to level 1, then try global (#0) last.
+    for {set abs $caller_abs} {$abs >= 1} {incr abs -1} {
+        if {[catch {set value [uplevel "#$abs" [list set $varname]]}] == 0} {
+            return [list 1 $value]
+        }
+    }
+    if {[catch {set value [uplevel #0 [list set $varname]]}] == 0} {
+        return [list 1 $value]
+    }
+    return [list 0 ""]
+}
+
 # SQL-aware TCL variable substitution
 # This emulates SQLite's parameter binding where $var in SQL refers to TCL variables.
 # Unlike simple `uplevel 1 subst`, this:
-# 1. Walks the call stack from OUTERMOST level inward to find user-defined variables
+# 1. Walks the call stack from INNERMOST level outward to find user-defined variables
 # 2. Properly quotes string values for SQL (adds single quotes, escapes internal quotes)
-# 3. Handles both $var and ${var} syntax
+# 3. Handles $var, ${var}, $::var, $arr(elem), and :var syntax
 #
 # This is critical for braced SQL strings like {INSERT INTO t VALUES($x, $msg)}
 # where TCL doesn't perform substitution and we must do it manually with proper SQL quoting.
 #
-# The search order is INNERMOST to OUTERMOST (caller's scope first), which matches
-# how TCL normally resolves variables. This ensures loop variables like $i in
-# "for {set i 1} {$i<10} {incr i}" are found in the loop's scope, not a stale
-# global value from a previous loop.
+# Semantics (#6307, matching SQLite's tclsqlite binding):
+# - The scan is a single left-to-right, index-based pass. Substituted text is
+#   never rescanned, so a value whose *contents* contain "$word" is not
+#   double-substituted.
+# - The scan is QUOTE-AWARE, emulating SQLite's SQL tokenizer: $word / :word
+#   inside single-quoted string literals (with '' escapes), double-quoted
+#   identifiers (with "" escapes), [bracketed] identifiers, -- line comments,
+#   and /* block */ comments are NOT parameter references and pass through
+#   verbatim (e.g. ATTACH ':memory:' AS aux is never touched).
+# - A reference whose TCL variable is unset in every enclosing scope binds SQL
+#   NULL (the documented sqlite3 tcl behavior behind the pervasive
+#   `unset -nocomplain x; ... db eval {... IS $x ...}` test idiom), and
+#   scanning CONTINUES so later references in the same statement still
+#   substitute. (Previously each pattern's loop `break`-ed on the first unset
+#   reference, leaving it AND every later reference as literal text.)
 proc substitute_tcl_vars {sql} {
     # Quick check: if no $ or : variables, return immediately
     # Match both $var, ${var}, $::var, and :var patterns
@@ -1273,211 +1307,137 @@ proc substitute_tcl_vars {sql} {
         return $sql
     }
 
-    # Get the maximum stack depth to search
-    set max_level [info level]
+    # Absolute stack level of our caller, for the scope walk in resolve_subst_var
+    set caller_abs [expr {[info level] - 1}]
 
-    # Find all variable references: $var, ${var}, $::var, and :var patterns
-    # We'll process each one individually for proper SQL quoting
-    set result $sql
+    set result ""
+    set len [string length $sql]
+    set i 0
+    while {$i < $len} {
+        set ch [string index $sql $i]
 
-    # First handle $::varname patterns (explicit global namespace references)
-    # These must be processed BEFORE regular $var patterns to avoid partial matches
-    # Pattern matches: $::varname where varname starts with letter/underscore
-    set global_var_pattern {\$::([a-zA-Z_][a-zA-Z0-9_]*)}
-
-    set prev_result ""
-    while {$result ne $prev_result} {
-        set prev_result $result
-
-        # Find the first $::variable reference
-        if {![regexp $global_var_pattern $result match varname]} {
-            break
+        # ---- Quoted spans: copy verbatim (no substitution inside) ----
+        # 'string literal' with '' escapes, and "quoted identifier" with ""
+        # escapes. Real SQLite's tokenizer consumes these as single tokens, so
+        # a $word or :word inside them is never a bindable parameter.
+        if {$ch eq "'" || $ch eq "\""} {
+            set quote $ch
+            append result $quote
+            incr i
+            while {$i < $len} {
+                set c [string index $sql $i]
+                append result $c
+                incr i
+                if {$c eq $quote} {
+                    if {$i < $len && [string index $sql $i] eq $quote} {
+                        # Doubled quote is an escape — still inside the span
+                        append result $quote
+                        incr i
+                    } else {
+                        break
+                    }
+                }
+            }
+            continue
         }
 
-        # Look up the variable in global scope ONLY (that's what :: means)
-        set found 0
-        set value ""
-
-        if {[catch {set value [uplevel #0 [list set $varname]]}] == 0} {
-            set found 1
-        }
-
-        if {!$found} {
-            # Variable not found in global scope - leave it as-is (will cause error)
-            break
-        }
-
-        # Format the value as a SQL literal
-        set sql_value [format_sql_value $value]
-
-        # Replace the first occurrence of this variable reference
-        set result [string replace $result \
-            [string first $match $result] \
-            [expr {[string first $match $result] + [string length $match] - 1}] \
-            $sql_value]
-    }
-
-    # Handle TCL array-element references: $arr(elem)
-    #
-    # SQLite's TCL binding treats `$arr(elem)` as a single bound parameter whose
-    # value is the array element arr(elem) in the caller's scope. This is the
-    # idiom used by capture_pragma (pragma.test / index7.test), which iterates a
-    # PRAGMA with `db eval $sql x { ... }` (populating x(colname)) and then
-    # builds `INSERT INTO out VALUES($x(seq),$x(name),...)`. Without resolving the
-    # array element here we would forward the literal `$x(seq)` to VibeSQL, whose
-    # parser rejects it ("near \"(\": syntax error").
-    #
-    # This pass runs BEFORE the plain $var pass: otherwise the plain pattern would
-    # match the `$x` prefix, fail to read the array as a scalar, and leave the
-    # dangling `(seq)` behind. The element name is a bare identifier (optionally
-    # `*`, the column-name list key that db-eval sets).
-    set array_var_pattern {\$([a-zA-Z_][a-zA-Z0-9_]*)\(([a-zA-Z_*][a-zA-Z0-9_]*)\)}
-
-    set prev_result ""
-    while {$result ne $prev_result} {
-        set prev_result $result
-
-        # Find the first array-element reference
-        if {![regexp $array_var_pattern $result match arrname elemname]} {
-            break
-        }
-
-        # Resolve the array element, searching innermost scope outward, then
-        # global (mirroring the plain $var resolution order below).
-        set found 0
-        set value ""
-        for {set level 1} {$level <= $max_level} {incr level} {
-            if {[catch {set value [uplevel $level [list set "${arrname}($elemname)"]]}] == 0} {
-                set found 1
+        # ---- [bracketed identifier]: copy verbatim ----
+        if {$ch eq "\["} {
+            set close [string first "\]" $sql $i]
+            if {$close < 0} {
+                append result [string range $sql $i end]
                 break
             }
-        }
-        if {!$found} {
-            if {[catch {set value [uplevel #0 [list set "${arrname}($elemname)"]]}] == 0} {
-                set found 1
-            }
+            append result [string range $sql $i $close]
+            set i [expr {$close + 1}]
+            continue
         }
 
-        if {!$found} {
-            # Not found - leave as-is (will surface as a SQL error) and stop to
-            # avoid an infinite loop on this match.
-            break
-        }
-
-        set sql_value [format_sql_value $value]
-        set result [string replace $result \
-            [string first $match $result] \
-            [expr {[string first $match $result] + [string length $match] - 1}] \
-            $sql_value]
-    }
-
-    # Now handle regular $var patterns
-    # Pattern to match TCL variable references in SQL
-    # Matches: $varname or ${varname}
-    # Note: We need to be careful not to match things like $1 (positional params)
-    set var_pattern {\$(\{[a-zA-Z_][a-zA-Z0-9_]*\}|[a-zA-Z_][a-zA-Z0-9_]*)}
-
-    # Keep substituting until no more matches or no progress
-    set prev_result ""
-    while {$result ne $prev_result} {
-        set prev_result $result
-
-        # Find the first variable reference
-        if {![regexp $var_pattern $result match varname]} {
-            break
-        }
-
-        # Strip braces if present: ${foo} -> foo
-        if {[string index $varname 0] eq "\{"} {
-            set varname [string range $varname 1 end-1]
-        }
-
-        # Try to get the variable value - search from INNERMOST level outward
-        # This ensures loop variables are found in their defining scope, not
-        # stale global values from previous loop iterations.
-        # Search order: level 1 (direct caller) -> level 2 -> ... -> max_level -> global
-        set found 0
-        set value ""
-
-        # Search from innermost (level 1) to outermost (max_level)
-        # Level 1 is the immediate caller of this proc
-        for {set level 1} {$level <= $max_level} {incr level} {
-            if {[catch {set value [uplevel $level [list set $varname]]}] == 0} {
-                set found 1
+        # ---- -- line comment: copy verbatim through end of line ----
+        if {$ch eq "-" && [string index $sql [expr {$i + 1}]] eq "-"} {
+            set nl [string first "\n" $sql $i]
+            if {$nl < 0} {
+                append result [string range $sql $i end]
                 break
             }
+            append result [string range $sql $i $nl]
+            set i [expr {$nl + 1}]
+            continue
         }
 
-        # If not found in call stack, try global scope as last resort
-        if {!$found} {
-            if {[catch {set value [uplevel #0 [list set $varname]]}] == 0} {
-                set found 1
-            }
-        }
-
-        if {!$found} {
-            # Variable not found - leave it as-is (will cause SQL error, but that's expected)
-            # Just skip this match to avoid infinite loop
-            break
-        }
-
-        # Format the value as a SQL literal
-        set sql_value [format_sql_value $value]
-
-        # Replace the first occurrence of this variable reference
-        # Use string map with the exact match to be safe
-        set result [string replace $result \
-            [string first $match $result] \
-            [expr {[string first $match $result] + [string length $match] - 1}] \
-            $sql_value]
-    }
-
-    # Now handle :varname patterns (SQLite named placeholder syntax)
-    # Pattern matches: :varname where varname starts with letter/underscore
-    set colon_pattern {:([a-zA-Z_][a-zA-Z0-9_]*)}
-
-    # Keep substituting until no more matches or no progress
-    set prev_result ""
-    while {$result ne $prev_result} {
-        set prev_result $result
-
-        # Find the first :variable reference
-        if {![regexp $colon_pattern $result match varname]} {
-            break
-        }
-
-        # Try to get the variable value - search from INNERMOST level outward
-        set found 0
-        set value ""
-
-        # Search from innermost (level 1) to outermost (max_level)
-        for {set level 1} {$level <= $max_level} {incr level} {
-            if {[catch {set value [uplevel $level [list set $varname]]}] == 0} {
-                set found 1
+        # ---- /* block comment */: copy verbatim ----
+        if {$ch eq "/" && [string index $sql [expr {$i + 1}]] eq "*"} {
+            set close [string first "*/" $sql [expr {$i + 2}]]
+            if {$close < 0} {
+                append result [string range $sql $i end]
                 break
             }
+            append result [string range $sql $i [expr {$close + 1}]]
+            set i [expr {$close + 2}]
+            continue
         }
 
-        # If not found in call stack, try global scope as last resort
-        if {!$found} {
-            if {[catch {set value [uplevel #0 [list set $varname]]}] == 0} {
-                set found 1
+        # ---- $-form references ----
+        # Precedence (same as the old per-pattern pass order):
+        #   $::var  before  $arr(elem)  before  ${var}/$var
+        # $arr(elem) must be tried before plain $var: otherwise the plain
+        # pattern would match the `$arr` prefix, fail to read the array as a
+        # scalar, and leave the dangling `(elem)` behind. This is the idiom
+        # used by capture_pragma (pragma.test / index7.test). The element name
+        # is a bare identifier (optionally `*`, the column-name list key that
+        # db-eval sets). Digit-leading forms like $5 are NOT references.
+        if {$ch eq "\$"} {
+            set tail [string range $sql $i end]
+            if {[regexp {^\$::([a-zA-Z_][a-zA-Z0-9_]*)} $tail match varname]} {
+                # Explicit global namespace reference: global scope ONLY
+                set found 0
+                set value ""
+                if {[catch {set value [uplevel #0 [list set $varname]]}] == 0} {
+                    set found 1
+                }
+            } elseif {[regexp {^\$([a-zA-Z_][a-zA-Z0-9_]*)\(([a-zA-Z_*][a-zA-Z0-9_]*)\)} $tail match arrname elemname]} {
+                lassign [resolve_subst_var "${arrname}($elemname)" $caller_abs] found value
+            } elseif {[regexp {^\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}} $tail match varname]} {
+                lassign [resolve_subst_var $varname $caller_abs] found value
+            } elseif {[regexp {^\$([a-zA-Z_][a-zA-Z0-9_]*)} $tail match varname]} {
+                lassign [resolve_subst_var $varname $caller_abs] found value
+            } else {
+                # Not a variable reference (e.g. $5, lone $) — literal
+                append result $ch
+                incr i
+                continue
             }
+            if {$found} {
+                append result [format_sql_value $value]
+            } else {
+                # Unset TCL variable binds SQL NULL (sqlite3 tcl semantics);
+                # keep scanning so later references still substitute.
+                append result "NULL"
+            }
+            incr i [string length $match]
+            continue
         }
 
-        if {!$found} {
-            # Variable not found - leave it as-is (will cause SQL error, but that's expected)
-            break
+        # ---- :varname named-placeholder references ----
+        if {$ch eq ":"} {
+            if {[regexp {^:([a-zA-Z_][a-zA-Z0-9_]*)} [string range $sql $i end] match varname]} {
+                lassign [resolve_subst_var $varname $caller_abs] found value
+                if {$found} {
+                    append result [format_sql_value $value]
+                } else {
+                    append result "NULL"
+                }
+                incr i [string length $match]
+            } else {
+                # e.g. 12:34 or :: — not a reference
+                append result $ch
+                incr i
+            }
+            continue
         }
 
-        # Format the value as a SQL literal
-        set sql_value [format_sql_value $value]
-
-        # Replace the first occurrence of this variable reference
-        set result [string replace $result \
-            [string first $match $result] \
-            [expr {[string first $match $result] + [string length $match] - 1}] \
-            $sql_value]
+        append result $ch
+        incr i
     }
 
     return $result
@@ -9887,17 +9847,22 @@ proc run_test_file {filename} {
     finish_test
 }
 
-# Parse command line
-if {$argc > 0} {
-    set test_file [lindex $argv 0]
-    if {[lsearch $argv "--verbose"] >= 0 || [lsearch $argv "-v"] >= 0} {
-        set ::verbose 1
+# Parse command line — guarded so unit-test scripts can `source` this shim
+# (e.g. scripts/test_tcl_shim_substitution.tcl) without triggering the
+# auto-run / usage-exit tail (#6307). When run directly via
+# `tclsh tester_vibesql.tcl ...`, [info script] and $::argv0 are the same file.
+if {[file normalize [info script]] eq [file normalize $::argv0]} {
+    if {$argc > 0} {
+        set test_file [lindex $argv 0]
+        if {[lsearch $argv "--verbose"] >= 0 || [lsearch $argv "-v"] >= 0} {
+            set ::verbose 1
+        }
+        if {[lsearch $argv "--emit-detail"] >= 0} {
+            set ::emit_detail 1
+        }
+        run_test_file $test_file
+    } else {
+        puts "Usage: tclsh tester_vibesql.tcl <test_file.test> \[--verbose\]"
+        exit 1
     }
-    if {[lsearch $argv "--emit-detail"] >= 0} {
-        set ::emit_detail 1
-    }
-    run_test_file $test_file
-} else {
-    puts "Usage: tclsh tester_vibesql.tcl <test_file.test> \[--verbose\]"
-    exit 1
 }


### PR DESCRIPTION
## Summary

Rewrites `substitute_tcl_vars` in `scripts/tester_vibesql.tcl` from four restart-from-start regexp loops into a single left-to-right, index-based, **quote-aware** scan, per the curator's spec in #6307. An unset TCL variable reference now binds SQL `NULL` (matching real SQLite's tclsqlite semantics behind the pervasive `unset -nocomplain x; db eval {... $x ... $y ...}` test idiom), and later references in the same statement are still substituted — previously each loop `break`-ed on the first unset reference, leaving it **and** all later references as literal text.

## Changes

- **`scripts/tester_vibesql.tcl`**
  - `substitute_tcl_vars`: single index-based pass replacing the four per-pattern `while` loops. Precedence preserved: `$::var` → `$arr(elem)` → `${var}`/`$var` → `:var`. Digit-leading non-references (`$5`, `12:34`) still excluded.
  - **Quote-aware scanning** (the curator's critical hazard): single-quoted literals (with `''` escapes), double-quoted identifiers (with `""` escapes), `[bracketed]` identifiers, and `--` / `/* */` comments are copied verbatim — emulating SQLite's tokenizer, which never binds parameters inside those tokens. `ATTACH ':memory:'` and `$`/`:` tokens inside quoted literals now survive **by construction**, not by the removed break-on-unset accident.
  - Unset references (all four forms) substitute `NULL` and scanning continues.
  - Substituted text is never rescanned — fixes the latent double-substitution bug (a value whose contents contain `$word` was re-substituted by the old restart-from-start loops).
  - Scope resolution unchanged: innermost-to-outermost stack walk then global (`$::var` global-only), factored into `resolve_subst_var` using **absolute** stack levels so the helper's extra frame doesn't shift the search.
  - Auto-run tail guarded with `[file normalize [info script]] eq [file normalize $::argv0]` so unit scripts can `source` the shim (direct `tclsh tester_vibesql.tcl ...` invocation, incl. `tcl_runner.py`'s, is unchanged; usage/exit-1 with no args still works).
- **`scripts/test_tcl_shim_substitution.tcl`** (new): 28 tclsh assertions — run via `tclsh scripts/test_tcl_shim_substitution.tcl` (Tcl 8.5/8.6, e.g. `/usr/bin/tclsh` on macOS). Not wired into the Make target because the PATH `tclsh` on dev machines may be 9.x, which the shim itself doesn't support (`package require Tcl 8.5`).

## Acceptance Criteria Verification

- [x] **Unset refs bind NULL, later refs still substituted, all four forms** — unit tests cover `$var`, `${var}`, `$::var`, `$arr(elem)`, `:var` each with an unset ref followed/preceded by set refs.
- [x] **Order-independent** — `($missing, $set_var)` → `(NULL, 42)` and `($set_var, $missing)` → `(42, NULL)` (both asserted).
- [x] **Quote-aware** — `ATTACH ':memory:' AS aux` unchanged **with a TCL variable `memory` set**; `'a:b'`, `'price $x'`, `'has $dollar'` unchanged with those vars set; `''` escapes keep the scanner inside the span.
- [x] **No double substitution** — value containing `$inner` / `:inner` text is not re-substituted (asserted).
- [x] **No regression** — before/after comparison with the same engine binary on 8 representative files (see Test Plan): identical pass/fail counts everywhere; `with1.test` improved 101 → 106.
- [x] **with1.test 10.x outcome reported on #6189** — `10.2`–`10.6` newly pass; `10.8.1`–`10.8.3` now produce correctly-populated rows but fail on genuine engine row-ordering (`ORDER BY` with `COLLATE nocase` in the recursive CTE: expected `/a /B /c ...`, got `/B /a /c ...`). Comment posted on #6189.

## Test Plan

- [x] `tclsh scripts/test_tcl_shim_substitution.tcl` (Tcl 8.5): **28 passed, 0 failed**.
- [x] Targeted: `with1.test` — baseline (pre-fix shim @ HEAD) 101 passed / 12 failed → fixed shim **106 passed / 7 failed**; newly passing: `10.2 10.3 10.4 10.5 10.6`.
- [x] Regression sweep (same `vibesql` binary, `/usr/bin/tclsh` 8.5, pre-fix vs fixed shim run back-to-back per file — identical counts):

  | file | baseline pass/fail | fixed pass/fail |
  |---|---|---|
  | select1 | 188 / 0 | 188 / 0 |
  | insert | 52 / 1 | 52 / 1 |
  | where | 168 / 0 | 168 / 0 |
  | update | 128 / 0 | 128 / 0 |
  | index | 69 / 1 | 69 / 1 |
  | pragma (exercises `$arr(elem)`) | 142 / 50 | 142 / 50 |
  | attach (exercises `':memory:'`) | 23 / 34 | 23 / 34 |
  | with2 | 63 / 5 | 63 / 5 |

- [x] Shim direct invocation still works: no-arg run prints usage and exits 1; test-file run executes normally.
- [x] Blast radius (curator-requested corpus grep): **103** of 1,174 vendored `docs/reference/sqlite/test/*.test` files use `unset -nocomplain`; **98** of those also run `db eval`/`execsql` and were exposed to silent statement corruption.

## Scope

Single-file harness fix + one new unit-test script; no engine (Rust) changes; no `tcl_runner.py`/`tcltest` changes. The residual `with1.test` failures are engine-side and stay with #6189.

Closes #6307

🤖 Generated with [Claude Code](https://claude.com/claude-code)