### PR TITLE
ci(packages): add packages job — build, test, lint the pnpm workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,32 @@ jobs:
         working-directory: web-demo
 
   # ============================================================================
+  # Build, test, and lint the npm packages in packages/* (root pnpm workspace).
+  # The root `pnpm install --frozen-lockfile` also guards against root-workspace
+  # manifest/lockfile drift — the sibling gap to #5251's web-demo guard.
+  # Before this job, breaking npm bumps got green checkmarks. See issue #6386.
+  # ============================================================================
+  packages:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - name: Verify root workspace lockfile is in sync
+        run: pnpm install --frozen-lockfile
+
+      - name: Build all packages
+        run: pnpm -r build
+
+      - name: Test all packages
+        run: pnpm -r test
+
+      - name: Lint vibesql-client-ts
+        run: pnpm -C packages/vibesql-client-ts lint
+
+  # ============================================================================
   # Fast CI for branches/PRs - optimized for speed
   # ============================================================================
   test:

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "nistmemsql",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@11.22.0",
   "description": "SQL Conformance Testing Database - pnpm helper scripts for Cargo commands",
   "scripts": {
     "check:all": "cargo fmt -- --check && cargo clippy --all-targets --all-features -- -D warnings && cargo test --all && cargo build --all",

--- a/packages/vibesql-drizzle/package.json
+++ b/packages/vibesql-drizzle/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "vitest",
+    "test": "vitest run",
     "test:watch": "vitest --watch",
     "lint": "eslint src --ext .ts,.tsx",
     "type-check": "tsc --noEmit"


### PR DESCRIPTION
## Summary

Adds the CI job #6386 asked for, now that #6390 unblocked it: a `packages` job in `ci.yml` that runs at the repo root:

- `pnpm install --frozen-lockfile` — guards **root** manifest/lockfile drift, the sibling gap to #5251's web-demo-only guard (the #6384 near-miss)
- `pnpm -r build` — previously impossible while `packages/vibesql-client` was broken; green as of #6390
- `pnpm -r test` — 142 tests (vibesql-client-ts) + 34 (vibesql-drizzle)
- `pnpm -C packages/vibesql-client-ts lint`

## Supporting changes

- Root `package.json` gains `"packageManager": "pnpm@11.22.0"` so `pnpm/action-setup` resolves the version without an explicit input.
- `vibesql-drizzle`'s test script becomes `vitest run` (bare `vitest` only exited because vitest detects CI/non-TTY; now explicit).

`vibesql-drizzle`'s lint script is deliberately not wired in — it declares eslint but never installs it, so it fails everywhere. Filed as #6391.

## Verification

All four job steps run green locally in sequence: frozen-lockfile install, recursive build, recursive test (142 + 34 passing), client-ts lint.

Closes #6386

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XT9PWnyJ6nzD8UnxA8JKh3